### PR TITLE
Don't autoscroll the grid when click-selecting a visible thumbnail

### DIFF
--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -125,6 +125,30 @@ describe('MediaListComponent', () => {
     expect(component['pendingScrollToSelected']).toBe(true);
   });
 
+  // Regression: clicking a card in this grid selects an item that is, by
+  // definition, already on screen. Autoscrolling it into view is jarring and
+  // pointless, so a selection that originated from onMediaSelect must not queue
+  // an autoscroll — even in click mode.
+  it('does not queue an autoscroll for a selection driven by clicking a card', () => {
+    fixture.componentRef.setInput('focusMode', 'click');
+    TestBed.tick();
+    component.onMediaSelect(2);
+    component.ngOnChanges({ selectedId: new SimpleChange(null, 2, false) });
+    expect(component['pendingScrollToSelected']).toBe(false);
+  });
+
+  // A click on card 2 must not suppress a *later* off-screen selection (e.g. a
+  // vote auto-advance to card 5): only the clicked id is exempt from autoscroll.
+  it('still autoscrolls a subsequent selection from elsewhere after a click', () => {
+    fixture.componentRef.setInput('focusMode', 'click');
+    TestBed.tick();
+    component.onMediaSelect(2);
+    component.ngOnChanges({ selectedId: new SimpleChange(null, 2, false) });
+    expect(component['pendingScrollToSelected']).toBe(false);
+    component.ngOnChanges({ selectedId: new SimpleChange(2, 5, false) });
+    expect(component['pendingScrollToSelected']).toBe(true);
+  });
+
   // Regression: in hover mode the selection follows the cursor. Scrolling the
   // hovered item to the top shifts what's under the mouse, which re-selects and
   // scrolls again — an infinite autoscroll loop. Hover selection must not queue

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -93,6 +93,15 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   gridRowHeight = GRID_ROW_HEIGHT_FALLBACK;
 
   private pendingScrollToSelected = false;
+  /**
+   * The id most recently selected by clicking a card in *this* grid. Such an
+   * item is, by definition, already on screen (the user just clicked it), so we
+   * suppress the selection autoscroll for it — scrolling a visible thumbnail
+   * into view is jarring and pointless. Selections arriving from elsewhere
+   * (keyboard, vote auto-advance, stripe overview) leave this null and still
+   * autoscroll, since the target may be off-screen.
+   */
+  private clickSelectedId: number | null = null;
   private readonly destroy$ = new Subject<void>();
   /** The viewport instance whose ``scrolledIndexChange`` is currently subscribed. */
   private scrollSubscribedViewport?: CdkVirtualScrollViewport;
@@ -142,12 +151,18 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     // mode the selection follows the cursor, so scrolling the item to the top
     // would shift what's under the mouse, re-trigger selection, and scroll
     // again — an infinite autoscroll loop. Let the hovered item stay put.
-    if (
-      changes['selectedId'] &&
-      !changes['selectedId'].firstChange &&
-      this.focusMode() === 'click'
-    ) {
-      this.pendingScrollToSelected = true;
+    //
+    // And when the selection was driven by clicking a card in this grid, the
+    // item is already visible, so scrolling it into view is jarring and
+    // unnecessary — suppress the autoscroll for that id. Selections from
+    // elsewhere (keyboard, vote auto-advance, stripe overview) may target an
+    // off-screen item, so those still autoscroll.
+    if (changes['selectedId'] && !changes['selectedId'].firstChange) {
+      const clickedInThisGrid = changes['selectedId'].currentValue === this.clickSelectedId;
+      this.clickSelectedId = null;
+      if (this.focusMode() === 'click' && !clickedInThisGrid) {
+        this.pendingScrollToSelected = true;
+      }
     }
 
     // A wider/narrower goal width changes how many cards fit per grid row and
@@ -268,6 +283,10 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   }
 
   onMediaSelect(id: number): void {
+    // Remember that this selection came from a click on a visible card so the
+    // resulting ``selectedId`` change doesn't autoscroll an already-on-screen
+    // item into view (see ``ngOnChanges``).
+    this.clickSelectedId = id;
     this.mediaSelect.emit(id);
   }
 


### PR DESCRIPTION
## Problem

When you click-select a thumbnail in the media grid (e.g. the left-panel grid with click-select toggled on), the grid autoscrolls to bring that thumbnail to the top. But the thumbnail is already visible — that's how you clicked it — so the scroll is jarring and pointless.

## Fix

The grid's selection autoscroll (in `MediaListComponent`) fires on any `selectedId` input change in click mode. That's correct for selections arriving from elsewhere — keyboard navigation, vote auto-advance (`autoSelectNext`), the stripe overview — where the newly-selected item may be off-screen. But a selection the user drove by *clicking a card in this grid* targets an already-visible item.

This change tracks click-originated selections: `onMediaSelect` records the clicked id, and `ngOnChanges` suppresses the autoscroll when the incoming `selectedId` matches it. The flag is compared by id and reset on every selection change, so a click on card 2 never suppresses a later off-screen selection (e.g. auto-advancing to card 5 after a vote).

In click mode, `select` is only emitted from a real click on a visible card (`MediaItemComponent.onClick`), so this cleanly targets exactly the click-select case and leaves every other selection path scrolling as before.

## Tests

Two regressions added to `media-list.component.spec.ts`:
- A selection driven by clicking a card does not queue an autoscroll.
- A subsequent selection from elsewhere still autoscrolls after a click.

`./run-tests.sh frontend` passes (build OK, 1004 Vitest tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkpKArXuyhH1bBrBBsNXMG)_