### PR TITLE
Fix bin detail popup floor slipping below the region's south edge

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, ElementRef, HostListener, inject, input, OnChanges, OnDestroy, output, SimpleChanges, ViewChild } from '@angular/core';
+import { afterNextRender, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, ElementRef, HostListener, inject, Injector, input, OnChanges, OnDestroy, output, SimpleChanges, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { Subscription } from 'rxjs';
@@ -161,6 +161,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   private activeContext = inject(ActiveContextService);
   private settingsState = inject(SettingsStateService);
   private cdr = inject(ChangeDetectorRef);
+  private injector = inject(Injector);
 
   /** Member media ids of the bin the popup was summoned over. */
   readonly memberIds = input<number[]>([]);
@@ -219,6 +220,11 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   /** True only mid-drag (pointer down on the header, not yet released). */
   dragging = false;
   private dragStart = { x: 0, y: 0, left: 0, top: 0 };
+  /** Bounded re-measure counter for {@link nudgeOnScreen}: when a correction
+   *  actually moves the popup the pre-measurement clamp had under-modelled the
+   *  rendered size, so we re-measure on the next render until it settles (or the
+   *  cap is hit), rather than trusting a single post-render pass. */
+  private nudgeSettleAttempts = 0;
 
   /** Body height cap (px) for the current visible region; the body never grows
    *  past this, so a short region can't push the popup off the bottom edge. */
@@ -1081,7 +1087,23 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
     // what let the popup flash at the computed clamp and then jump to the
     // corrected spot.
     this.cdr.markForCheck();
-    requestAnimationFrame(() => this.nudgeOnScreen());
+    this.nudgeSettleAttempts = 0;
+    this.scheduleNudge();
+  }
+
+  /** Schedule the post-render corrective measurement ({@link nudgeOnScreen}).
+   *
+   *  Uses {@link afterNextRender} rather than a bare ``requestAnimationFrame``
+   *  so the panel is measured only *after* Angular's zoneless change detection
+   *  has written the freshly-clamped size (bound via {@link bodyOuterHeight} /
+   *  {@link maxWidthPx}) to the DOM. A raw rAF is not ordered against the
+   *  zoneless render, so it can fire *before* that write and measure a stale,
+   *  shorter panel — under-correcting the clamp and leaving the real (taller)
+   *  popup's floor below the region's bottom edge. That was the intermittent
+   *  "detail window pops up slightly out of frame" the first-click summon
+   *  surfaced. */
+  private scheduleNudge(): void {
+    afterNextRender(() => this.nudgeOnScreen(), { injector: this.injector });
   }
 
   /** Measure the rendered panel and slide it so its real rect sits inside the
@@ -1135,6 +1157,17 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
       }
     } else if (moved) {
       this.cdr.markForCheck();
+    }
+    // A correction that actually moved the popup means this pass measured a
+    // panel larger than the pre-measurement clamp modelled (e.g. the header or
+    // the view-controls settled a hair taller a frame after layout). Moving
+    // doesn't itself resize the panel, so a settled layout re-measures to the
+    // same spot and stops on the next pass; re-measuring (bounded) only keeps
+    // correcting while the size is still growing, so a late reflow can't strand
+    // the floor off-screen.
+    if (moved && this.nudgeSettleAttempts < 4) {
+      this.nudgeSettleAttempts++;
+      this.scheduleNudge();
     }
   }
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -14,10 +14,10 @@ import { settleZoneless } from '../../testing/settle-resource';
 
 /**
  * Drain several zoneless settle passes. The popup places itself across a chain
- * of `setTimeout(place)` → `requestAnimationFrame(nudge)` → `markForCheck`, and
- * the `setTimeout` is itself scheduled by the async CD tick that runs *after*
- * the first settle's own macrotask — so a single `settleZoneless` can return
- * before the reveal chain has run. A few passes flush it deterministically.
+ * of `setTimeout(place)` → `afterNextRender(nudge)` → `markForCheck`, and the
+ * `setTimeout` is itself scheduled by the async CD tick that runs *after* the
+ * first settle's own macrotask — so a single `settleZoneless` can return before
+ * the reveal chain has run. A few passes flush it deterministically.
  */
 async function settlePasses(fixture: ComponentFixture<unknown>, passes = 3): Promise<void> {
   for (let i = 0; i < passes; i++) await settleZoneless(fixture);
@@ -29,7 +29,7 @@ async function settlePasses(fixture: ComponentFixture<unknown>, passes = 3): Pro
  * The popup opens hidden and reveals itself only after its position has been
  * clamped on-screen and the rendered panel measured (see `place()` /
  * `nudgeOnScreen()`). Under zoneless change detection those steps run in a bare
- * `setTimeout` + `requestAnimationFrame`, with no change detection attached, so
+ * `setTimeout` + `afterNextRender`, with no change detection attached, so
  * the reveal must schedule its own `markForCheck()` or the `visibility` binding
  * silently goes stale — the popup would stay invisible, or (before the reveal
  * was moved past the measurement) flash at the un-corrected spot. This spec
@@ -125,6 +125,45 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     // read 5000px here.
     expect(parseFloat(panel.style.left)).toBeLessThan(400);
     expect(parseFloat(panel.style.top)).toBeLessThan(400);
+
+    fixture.destroy();
+  });
+
+  it('pulls a panel taller than the region up so its floor stays on-screen', async () => {
+    // The corrective measurement pass (nudgeOnScreen) keeps the *rendered* panel
+    // inside the region even when the computed clamp under-modelled its height —
+    // the "detail window pops up slightly out of frame" regression. jsdom reports
+    // 0-size rects, so stub the panel to report a height that overflows the 400px
+    // region and assert the popup is pulled up until its floor lands at
+    // regionBottom - EDGE_MARGIN (8), i.e. a top of 400 - 380 - 8 = 12.
+    const fixture = makeFixture();
+    fixture.componentRef.setInput('x', 50);
+    fixture.componentRef.setInput('y', 50);
+    await settlePasses(fixture);
+
+    const panel = fixture.nativeElement.querySelector('.bin-popup') as HTMLElement;
+    panel.getBoundingClientRect = () =>
+      ({
+        width: 100,
+        height: 380,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 380,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    // Re-place: a size-input change re-clamps and re-measures without
+    // re-anchoring to the cursor, so the stubbed oversize drives the correction.
+    fixture.componentRef.setInput('hoverThumbRadius', 40);
+    await settlePasses(fixture, 5);
+
+    const top = parseFloat(panel.style.top);
+    expect(top).toBe(12);
+    // The measured floor sits exactly at the region's bottom edge less the margin.
+    expect(top + 380).toBeLessThanOrEqual(400 - 8);
 
     fixture.destroy();
   });


### PR DESCRIPTION
## What & why

Right-clicking an image bin in VTSBrowse could open the detail popup slightly out of frame, with its floor below the visible region's bottom edge.

The popup's computed clamp (`clampInto`) is exact, but it depends on `headerH` measured at call time, and its safety-net correction (`nudgeOnScreen`) measured the rendered panel inside a **bare `requestAnimationFrame`**. Under zoneless change detection, that rAF is not ordered against Angular's render: it can fire *before* CD writes the freshly-clamped size to the DOM, so it measures a stale, shorter panel, under-corrects the clamp, and leaves the real (taller) popup's floor below the south edge.

This was latent for a while — the recent first-click right-click summon (`c65ca0c7`) made the popup open reliably on the first click, which is what re-surfaced it for image bins.

## Change

- Drive the corrective measurement with `afterNextRender` instead of a raw `requestAnimationFrame`, so the panel is always measured *after* the render that sized it.
- Re-measure (bounded to 4 passes) when a correction actually moves the popup, so a late reflow — e.g. the header or `vt-view-controls` settling a hair taller a frame after layout — can't strand the floor off-screen either. A settled layout re-measures to the same spot and stops on the next pass.

## Test

Added a zoneless regression test that stubs an oversized (380px) panel in the 400px region and asserts the popup is pulled up until its floor lands exactly at `regionBottom - EDGE_MARGIN` (top = 12). Full `./run-tests.sh frontend` gate passes (1003 Vitest tests, build, audit, lint/typecheck all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VX6ZKRGg8NPiYP4Md6YNtZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VX6ZKRGg8NPiYP4Md6YNtZ)_