### PR TITLE
docs(plans): foreground open work; compress shipped work to terse lists

### DIFF
--- a/docs/plans/RCDatasetImporter.md
+++ b/docs/plans/RCDatasetImporter.md
@@ -1,13 +1,11 @@
 # RCDatasetImporter Extension Plan
 
-**Status:** Scaffold in place; API client implementation required. All four
-plugin scaffolds (`recaller` importer, `holder` exporter/importer, PullWrest
-media source) are registered but hidden from the picker until the stubs are
-filled in. See the checklist at the bottom of this doc.
-
-This document describes everything needed to complete the ReCaller / Holder /
-PullWrest integration.  VTSearch core changes and plugin scaffolds are already
-in place; the developer's job is to implement the API client stubs.
+**Status:** Scaffold in place; **API client implementation is the open work.**
+All four plugin scaffolds (`recaller` importer, `holder` exporter/importer,
+PullWrest media source) are registered but hidden from the picker until the
+stubs are filled in. VTSearch core changes are done (compressed to "What's
+already done" at the bottom). The open implementation plan — Steps 1–4, data-flow
+diagrams, baked design decisions, and the checklist — follows.
 
 ## Overview
 
@@ -28,29 +26,6 @@ Four plugins are scaffolded (all `hidden_from_picker = True` until ready):
 | Holder Labelset Exporter | `vtscore/exporters/holder/__init__.py` | `LabelsetExporter` | `EXPORTER` |
 | Holder Label Importer | `vtscore/labels/importers/holder/__init__.py` | `LabelImporter` | `LABEL_IMPORTER` |
 | PullWrest Media Source | `vtscore/datasets/sources/pullwrest.py` | `MediaSource` factory | `SOURCE` |
-
-## What's already done (VTSearch core)
-
-1. **`LabeledElement.metadata`**: Optional `dict[str, Any]` on each label
-   element that round-trips through `to_dict()` / `from_dict()`.  When
-   building a LabelSet from votes, `custom_metadata` from the media
-   automatically flows into `metadata`.
-
-2. **`media_url` lazy-fetch**: `_resolve_media_bytes()` and
-   `_resolve_media_string()` in `MediaType` fall back to fetching from
-   `media["media_url"]` when `media_bytes` and `media_path` are both
-   absent.
-
-3. **Origin params in enriched export**: `GET /api/labels/export?enrich=true`
-   flattens `origin.params` (e.g. `contentID`, `mediaID`) into
-   `custom_metadata` and `available_columns`.  `custom_metadata` values
-   override same-named `origin.params` if both are present.
-
-4. **36 tests** in `tests/test_extension_scaffolds.py` covering metadata
-   round-trip, media_url resolution, plugin discovery, helper functions,
-   and enriched export.
-
----
 
 ## Step 1: Implement API clients
 
@@ -134,8 +109,6 @@ Replace stubs in:
   write_entry)
 - `vtscore/labels/importers/holder/__init__.py` (read_folder)
 
----
-
 ## Step 2: Declare any new dependencies in pyproject.toml
 
 If the API clients use a package that isn't already declared (e.g.
@@ -146,8 +119,6 @@ imported package is declared there.
 
 Re-run `bash scripts/install.sh` (or any editable install) to pick
 up the new dep.
-
----
 
 ## Step 3: Test with real services
 
@@ -192,16 +163,12 @@ Once API clients work, test the full round-trip:
 4. Import labels from Holder using the same `holder_id`
 5. Verify votes match
 
----
-
 ## Step 4: Flip `hidden_from_picker`
 
 When the plugins are ready for production:
 
 1. Set `hidden_from_picker = False` in each plugin class
 2. The plugins will immediately appear in the frontend UI
-
----
 
 ## Data flow diagrams
 
@@ -270,8 +237,6 @@ POST /api/label-importers/import/holder  {holder_id: "H123"}
     └── VTSearch matches to existing media by origin+origin_name or md5
 ```
 
----
-
 ## Key design decisions (already baked in)
 
 ### Per-media origin (not queryID)
@@ -317,8 +282,6 @@ format that the RC importer creates:
 
 This enables origin-based matching when importing into an RC-loaded dataset.
 
----
-
 ## Checklist
 
 - [ ] Implement `_rc_fetch_results()` in `recaller/__init__.py`
@@ -334,3 +297,17 @@ This enables origin-based matching when importing into an RC-loaded dataset.
 - [ ] Test with live services (import → vote → export → re-import)
 - [ ] Set `hidden_from_picker = False` on all four plugins
 - [ ] Run `./run-tests.sh`: all tests must pass
+
+## What's already done (VTSearch core)
+
+- **`LabeledElement.metadata`** — optional `dict[str, Any]` per label element,
+  round-trips through `to_dict()`/`from_dict()`; media `custom_metadata` flows
+  into it when building a LabelSet from votes.
+- **`media_url` lazy-fetch** — `_resolve_media_bytes()`/`_resolve_media_string()`
+  in `MediaType` fall back to fetching `media["media_url"]` when `media_bytes` and
+  `media_path` are both absent.
+- **Origin params in enriched export** — `GET /api/labels/export?enrich=true`
+  flattens `origin.params` (`contentID`, `mediaID`) into `custom_metadata` and
+  `available_columns` (`custom_metadata` wins on name clashes).
+- **36 tests** in `tests/test_extension_scaffolds.py` cover metadata round-trip,
+  media_url resolution, plugin discovery, helpers, and enriched export.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -30,7 +30,7 @@ it can't drift far. (Point-in-time UI review/audit reports live in
 
 ## Detectors / embedders / clippers
 
-- [patch-embedder.md](patch-embedder.md): patch-based image embedder (V1+V2 shipped; V3 in progress)
+- [patch-embedder.md](patch-embedder.md): patch-based image embedder (V1+V2+V3 trio + per-detector embedder-type shipped; scoring/validation follow-ups open)
 - [structural-embedder.md](structural-embedder.md): structural (instance-matching) embedder — SIFT/VLAD + RANSAC re-rank (V1 + Stage-2 + Find re-rank shipped; larger VLAD codebook next)
 - [clipper-chain.md](clipper-chain.md): ordered converter/clipper chains (Phase 1 shipped)
 - [cli-detector-converter.md](cli-detector-converter.md): CLI autodetect with converters + clippers (Phase 1 shipped)
@@ -40,7 +40,7 @@ it can't drift far. (Point-in-time UI review/audit reports live in
 
 - [find-verification-workflow.md](find-verification-workflow.md): Find verify loop, frozen scores, Stats (Phases 1–4 shipped; follow-ups open)
 - [coverage-atlas.md](coverage-atlas.md): domain-shift + evidence-aware verification for transferred detectors (design/research writeup only)
-- [visual-genome-dataset.md](visual-genome-dataset.md): Visual Genome demo dataset — multi-label + region-annotation ground truth for eval (Phase 1 in progress; region-vote reporting / attributes open)
+- [visual-genome-dataset.md](visual-genome-dataset.md): Visual Genome demo dataset — multi-label + region-annotation ground truth for eval (Phase 1 + Phase 2 region-voting shipped; region-vote reporting / attributes open)
 
 ## Import / plugins
 

--- a/docs/plans/angular-21-upgrade.md
+++ b/docs/plans/angular-21-upgrade.md
@@ -1,274 +1,62 @@
 # Angular 19 → 21 upgrade + Vitest spec migration
 
-Status: **All phases shipped.** Angular is on 21.2.17 (`npm audit --omit=dev` =
-0 vulnerabilities, was 6 high) and the **Vitest spec migration is complete**:
-all 68 spec files / 760 `it` blocks now run headless under Vitest and pass, and
-the run is wired into `./run-tests.sh`. See "What shipped (Vitest phase)" below.
-
-## What shipped
-
-- **Angular 19 → 20 → 21**, one major per step via `ng update`. All `@angular/*`
-  packages at `21.2.17`, `@angular-devkit/build-angular` + `@angular/cli` at
-  `21.2.16`, TypeScript at `5.9.3`. (Node floor satisfied by the container's
-  Node 22; no setup-script change needed.)
-- **`@angular/platform-browser-dynamic` removed** — it was never imported
-  (`main.ts` uses standalone `bootstrapApplication`), and as a dead dep it
-  confused `ng update`'s peer resolver. Removing it unblocked the family bump.
-- **Block control-flow migration applied** — Angular 21 makes this migration
-  mandatory (the legacy `*ngIf`/`*ngFor`/`*ngSwitch` structural directives are
-  removed in v21), so `ng update` converted 51 component templates to
-  `@if`/`@for`/`@switch`. This was listed as "optional/deferred" in the original
-  plan but is no longer optional on 21; it rode along with the bump.
-- **Out-of-root docs asset fixed.** Angular 21 forbids `assets[].input` paths
-  outside the workspace root, which broke the `../docs/user → /assets/docs`
-  mapping (in-app user guide). Replaced with a **committed symlink**
-  `frontend/docs-assets → ../docs/user`; angular.json now references
-  `docs-assets`. The builder's `isSubDirectory` check is pure path math, so the
-  symlink resolves cleanly under the workspace root while the docs stay
-  single-sourced.
-- **Overrides** (`vite`, `esbuild`, …) needed no changes — Angular 21 pulls
-  `vite@6.4.3`/`esbuild@0.28.1`, both already within the existing ranges.
-- **Gates green:** `build:prod` clean (0 warnings, initial bundle 524.30 kB <
-  525 kB budget), spec files typecheck, `npm audit --omit=dev` = 0
-  vulnerabilities, full `./run-tests.sh` passes (4841 tests).
-
-## What shipped (Vitest phase)
-
-The deferred Vitest migration is now done. Highlights and the non-obvious
-gotchas that future bumps must preserve:
-
-- **Builder wiring.** Added a `test` target using `@angular/build:unit-test`
-  (`runner: vitest`, jsdom). Also migrated `build`/`serve`/`extract-i18n` off
-  the `@angular-devkit/build-angular:*` aliases to the canonical
-  `@angular/build:*` builders — **required**, because the unit-test builder
-  warns and fails to inherit polyfills (notably `zone.js/testing`) when the
-  `buildTarget` points at the devkit alias. `package.json` gained `test`
-  (watch) and `test:ci` (`ng test --no-watch`) scripts, each with a `pretest*`
-  hook that regenerates the API client. `@types/jasmine` removed;
-  `vitest`/`jsdom` added (dev-only, so prod audit stays clean).
-- **jsdom polyfills** (`src/test-setup.ts`, wired via `setupFiles`): inert
-  stubs for `EventSource`, `HTMLMediaElement.play/pause/load`, and
-  `HTMLCanvasElement.getContext` — jsdom omits these and throws "Not
-  implemented", which aborted tests mid-lifecycle.
-- **fakeAsync / ProxyZone bootstrap** (the subtle one). `zone.js/testing` only
-  auto-establishes the ProxyZone that `fakeAsync()`/`tick()` need for
-  Jasmine/Mocha/Jest runners (its jest patch bails on `typeof jest ===
-  'undefined'`), and Vitest is none of those, so every `fakeAsync` spec threw
-  "Expected to be running in 'ProxyZone'". `test-setup.ts` replicates zone.js's
-  jest patch against Vitest's global `describe`/`it`/hooks (describe → sync
-  zone, it/hooks → proxy zone). If a future zone.js/Angular release adds native
-  Vitest support, this shim can be deleted.
-- **Isolation + cascade guard.** The builder defaults to `isolate: false`
-  (Karma-style shared context); a `vitest.config.ts` flips it to `isolate:
-  true` so one spec leaving the `TestBed` singleton dirty can't poison later
-  files. Within a file, `test-setup.ts` also resets the TestBed defensively at
-  the **start** of each test, so a spec whose teardown throws (unflushed
-  `HttpTestingController`, throwing `ngOnDestroy`) doesn't cascade
-  "test module already instantiated" into the rest of the file.
-- **Jasmine → Vitest port** (mechanical, all specs): `toBeTrue()`/`toBeFalse()`
-  → `toBe(true/false)`, `spyOn`/`spyOnProperty` → `vi.spyOn`, `.and.returnValue`
-  → `.mockReturnValue` (and `callFake`→`mockImplementation`,
-  `resolveTo`→`mockResolvedValue`), `spy.calls.mostRecent().args` →
-  `spy.mock.lastCall`, and the Jasmine `done`-callback tests → `() => new
-  Promise<void>((done) => …)`. `tsconfig.spec.json` types switched
-  `jasmine` → `vitest/globals`.
-- **Real spec drift fixed.** The 754 `it` blocks had only ever typechecked, so
-  they had drifted from the components: stale `ngOnInit` HTTP expectations
-  (new `/api/embedders`, `/api/media-types`, `/api/settings`, SSE replacing
-  HTTP polling), reworded button/hint text, changed sort defaults, vote body
-  `{vote}`→`{target}`, menu items, `columnOrder`-gated cells, etc. ~186 failing
-  specs were realigned to current behavior (no tests deleted/skipped/weakened).
-- **One real bug surfaced + fixed.** `DocumentViewerComponent` bound a plain
-  string into `<object [data]>` (a RESOURCE_URL sink), which throws NG0904 in
-  prod too — document viewing was latently broken. Fixed by wrapping the
-  same-origin URL with `DomSanitizer.bypassSecurityTrustResourceUrl`.
-- **run-tests.sh wiring.** Vitest runs on the full `./run-tests.sh` (the real
-  gate — no CI) and on a new frontend-only `./run-tests.sh frontend` group
-  (Angular build + `npm audit` + Vitest, skips pytest). It is intentionally
-  **not** on the fast `core` path (which keeps only the compile-only build
-  check), since the unit run is a full app build + headless Vitest.
-
-## Original design (for reference)
-
-## Why
-
-`npm audit` (run in `frontend/`) reports **6 high-severity advisories**, all
-rooted in a single package: `@angular/core <= 19.2.25`
-([GHSA-rgjc-h3x7-9mwg](https://github.com/advisories/GHSA-rgjc-h3x7-9mwg),
-"Angular Client Hydration DOM Clobbering & Response-Cache Poisoning"). The
-other five flagged packages (`common`, `forms`, `platform-browser`,
-`platform-browser-dynamic`, `router`) are transitive dependents of `core`.
-The only remediation npm offers is `npm audit fix --force`, which jumps to
-Angular 21 — a breaking multi-major upgrade.
-
-**Live exposure is effectively nil.** The advisory is specific to Angular's
-SSR / client-hydration path. VTSearch is a pure client-side SPA built to
-`../static/` and served by Flask: no `provideClientHydration`, no
-`provideServerRendering`, no `platformServer`. So this is a "stay current /
-keep the audit clean" upgrade, not an urgent patch.
-
-**The real VTSearch-specific payoff is Vitest.** Angular 21 ships Vitest as
-the standard unit-test runner, replacing Karma/Jasmine. Karma was removed from
-this repo because the cloud container (Ubuntu 24.04) has no Chrome/Chromium, so
-our **68 spec files / 754 `it` blocks currently only typecheck and never run**
-(`package.json`'s `test` script is a no-op echo). Vitest runs in Node via
-jsdom/happy-dom — no browser — so the upgrade can turn the frontend unit suite
-back on in the same environment that runs `./run-tests.sh`. That is a genuine
-capability gain beyond clearing the audit.
-
-The other Angular 21 headline features are **nice-to-have but not free** and
-are explicitly out of scope here (see "Deferred / out of scope"). None of them
-arrive automatically with the version bump.
-
-## Current state (as of this plan)
-
-- **Angular:** `^19.2.x` across `core/common/compiler/forms/platform-browser{,-dynamic}/router/cdk`.
-- **Change detection:** zone-based — `provideZoneChangeDetection({ eventCoalescing: true })` in `src/app/app.config.ts`; `zone.js ~0.15.0`; `polyfills: ["zone.js"]` in `angular.json`.
-- **Signals:** barely used (1 component: `field-hint-icon`). No `linkedSignal`/`resource` usage.
-- **Forms:** **none.** No `ReactiveFormsModule`/`FormGroup`/`FormControl` anywhere in non-spec code.
-- **Data layer:** ~67 RxJS-based API service files using `provideHttpClient(withInterceptors([...]))` with three interceptors (active-context, achievements-refresh, error).
-- **Build:** `@angular-devkit/build-angular:application` (esbuild/Vite under the hood), output to `../static`, prod budgets `initial` 525kB warn / 1MB error and `anyComponentStyle` 8kB warn / 10kB error.
-- **Tests:** `@types/jasmine` only; `tsconfig.spec.json` includes `src/**/*.spec.ts` for typecheck; no runner wired. `prebuild`/`prebuild:prod` run `ng-openapi-gen` to regenerate the API client.
-- **Toolchain pins via `overrides`:** `vite ^6.4.2`, `esbuild ^0.28.1`, `postcss`, `uuid`, `qs`, etc. — these will likely need revisiting because Angular 21 pins its own vite/esbuild ranges.
-- **TypeScript:** `~5.7.2`.
-
-## Upgrade path (staged, one major at a time)
-
-Angular's supported migration is **one major per step** via `ng update`; do not
-skip 20. Run each step on the working branch, commit between steps, and gate on
-`npm run build:prod` + `./run-tests.sh core` (which runs the frontend build
-check) before proceeding.
-
-The exact peer-dep floors below are from memory and **must be confirmed by the
-`ng update` output**, which is authoritative — treat the bullets as "expect
-something in this area", not as gospel version numbers.
-
-### Step 1 — Angular 19 → 20
-
-```
-cd frontend && npx ng update @angular/core@20 @angular/cli@20 @angular/cdk@20
-```
-
-Expect:
-- **TypeScript bump** (~5.8) and a **Node floor** bump — verify the container's
-  Node satisfies it; if not, that's a setup-script/image change, flag to the user.
-- Automated schematics for renamed/removed APIs (Angular 20 stabilized several
-  signal APIs and removed long-deprecated ones).
-- `provideExperimentalZonelessChangeDetection` → `provideZonelessChangeDetection`
-  rename lands here (only relevant if/when we go zoneless — we are not, yet).
-- Revisit the `vite`/`esbuild` `overrides` if the new `@angular-devkit` pulls a
-  different range; stale overrides can break the build or `npm ci`.
-
-Gate: `npm run build:prod` clean (no `▲ [WARNING]`), TypeScript clean, app boots.
-
-### Step 2 — Angular 20 → 21
-
-```
-cd frontend && npx ng update @angular/core@21 @angular/cli@21 @angular/cdk@21
-```
-
-Expect:
-- Another TS floor (~5.9) and possible Node floor bump — verify against the container.
-- Zoneless becomes the **default for new projects**; our existing
-  `provideZoneChangeDetection` is untouched, so behavior is preserved. (Going
-  zoneless is a separate, deferred effort.)
-- Builder/runner changes around testing (see Vitest phase).
-- Re-check budgets: a major Angular bump can shift baseline bundle size; if
-  `initial` creeps past 525kB, fix the bloat (per CLAUDE.md, do **not** just
-  raise the budget without explicit approval).
-
-Gate: `npm run build:prod` clean, `./run-tests.sh core` green, app boots and a
-manual smoke of the core flow (load dataset → train detector → sort) works.
-
-## Vitest spec migration (the payoff — separate phase, after the bump)
-
-The version bump alone does **not** enable Vitest. After Angular is on 21:
-
-1. **Wire the Vitest unit-test builder.** Add the `unit-test` target to
-   `angular.json` pointing at the Angular Vitest builder, with an
-   `application`-builder-compatible config. Use jsdom (or happy-dom) as the DOM
-   environment so it runs headless in the container.
-2. **Replace the no-op `test` script** with the real runner (`ng test`, now
-   Vitest-backed) and add a non-watch CI variant (e.g. `test:ci`).
-3. **Port Jasmine → Vitest in the 68 spec files.** Mechanical but broad:
-   `jasmine.createSpy`/`createSpyObj` → `vi.fn`/Vitest mocks, `spyOn(...)` call
-   sites, `jasmine.objectContaining` → `expect.objectContaining`, matcher
-   differences, and the `TestBed`/zoneless harness wiring. Swap
-   `@types/jasmine` for Vitest types in `tsconfig.spec.json`.
-4. **Expect real failures.** These 754 `it` blocks have never executed — only
-   typechecked. Turning them on will surface stale assertions, drifted mocks,
-   and over-mocked tests that pass by accident. Budget time to triage/fix or
-   quarantine genuinely-broken specs (with a tracked list, not silent skips).
-5. **Hook into `./run-tests.sh`.** Decide with the user whether the frontend
-   unit run joins the `core` group (alongside the existing build check) or runs
-   as its own step. `run-tests.sh` is the source of truth (no CI backstop), so
-   the Vitest run must be wired in for it to actually guard anything.
-
-Gate: Vitest runs headless in the cloud container with 0 failures (or an
-explicit, agreed quarantine list), wired into `run-tests.sh`.
-
-## Deferred / out of scope (record only — do not do as part of this work)
-
-These are the modernization carrots Angular 21 unlocks. They are **opt-in
-migrations on top of the upgrade**, not part of clearing the audit, and each is
-its own effort:
-
-- **Zoneless change detection.** Smaller bundle (drops `zone.js` from
-  polyfills, helps the budget) and cleaner stack traces, but effectively
-  requires adopting signals broadly first — VTSearch barely uses them today.
-- **`httpResource` / `resource`.** Could trim `switchMap`/manual-subscription
-  boilerplate across the ~67 RxJS API services, adoptable incrementally. Worth
-  a focused pass later if the data layer is being touched anyway. **Scoped in
-  its own plan: `httpresource-migration.md`** (recommends `rxResource` wrapping
-  the existing generated client; not started).
-- **Signal Forms.** Low value here — VTSearch uses no forms — and experimental
-  in 21 (not stable until ~22/23).
-- **ARIA directives, CLI MCP server.** Marginal for this app.
-
-If any of these get picked up, give them their own plan file and link it here.
-
-## Risks / watch-items
-
-- **Node/TS floors** may exceed what the cloud container ships; that's a
-  setup-script/image change outside `frontend/`, so surface it to the user
-  rather than assuming.
-- **`overrides` drift** (`vite`, `esbuild`, `postcss`, …) is the most likely
-  source of a broken `npm ci` or build after the bump — review them at each step.
-- **Budget regressions** from the major bump — fix bloat, don't raise budgets
-  (CLAUDE.md rule).
-- **Vitest failures are expected, not exceptional** — the suite has never run.
-  Don't treat first-run red as a blocker on the upgrade itself; it's the
-  migration phase's job to resolve.
-- **No mobile/responsive concerns** — desktop-only app (CLAUDE.md), so ignore
-  any viewport-related deprecation noise.
-
-## Suggested sequencing
-
-1. Branch + `ng update` to 20, build/test gate, commit.
-2. `ng update` to 21, build/test gate, commit. **Audit is now clean** — this is
-   a valid stopping point if Vitest is deferred.
-3. Wire Vitest builder + scripts, commit.
-4. Port specs in batches (by folder), fixing as you go, committing per batch.
-5. Wire Vitest into `run-tests.sh`, final gate, open PR to `dev`.
+**Status: all phases shipped.** Angular is on 21.2.17 (`npm audit --omit=dev` = 0 vulnerabilities, was 6 high) and the Vitest spec migration is complete — all 68 spec files / 760 `it` blocks run headless under Vitest, pass, and are wired into `./run-tests.sh`. This doc is **kept as the migration reference for future Angular bumps**; the reusable upgrade path, risks, and non-obvious gotchas are preserved below, with the completed work collapsed under "What shipped".
 
 ## Open follow-ups
 
-Both the Angular bump **and** the Vitest spec migration are done. Remaining
-loose ends are small:
+Both the Angular bump and the Vitest migration are done; remaining loose ends are small:
 
-- **Nothing quarantined.** The Jasmine→Vitest port ended with all 760 `it`
-  blocks passing, so there is no quarantine/triage list owed.
-- **`test-setup.ts` ProxyZone shim is a workaround.** It reimplements
-  zone.js's jest patch for Vitest. If a future `zone.js`/Angular release ships
-  first-class Vitest support for `fakeAsync`, delete the shim and rely on the
-  builder. Watch the `@angular/build:unit-test` release notes (it's still
-  marked experimental in 21).
-- **Migrate fakeAsync specs to Vitest fake timers (optional).** Longer term,
-  the 11 `fakeAsync` specs could move to `vi.useFakeTimers()` and drop the
-  zone-testing dependency entirely; only worth it if/when the app goes zoneless
-  (see "Deferred / out of scope").
-- **Resolved during the upgrade:** Node/TS floors (container's Node 22 + TS
-  5.9.3 satisfy v21, no setup-script change); overrides drift (none needed);
-  budget regression (initial crept 521.97 → 524.30 kB but stays under the
-  525 kB warn budget — watch it on future bumps); `@types/jasmine` removed and
-  `tsconfig.spec.json` now uses `vitest/globals`.
+- **Nothing quarantined.** The Jasmine→Vitest port ended with all 760 `it` blocks passing, so there is no quarantine/triage list owed.
+- **`test-setup.ts` ProxyZone shim is a workaround.** It reimplements zone.js's jest patch for Vitest. If a future `zone.js`/Angular release ships first-class Vitest support for `fakeAsync`, delete the shim and rely on the builder. Watch the `@angular/build:unit-test` release notes (still marked experimental in 21).
+- **Migrate fakeAsync specs to Vitest fake timers (optional).** Longer term, the 11 `fakeAsync` specs could move to `vi.useFakeTimers()` and drop the zone-testing dependency entirely; only worth it if/when the app goes zoneless (see "Deferred / out of scope").
+- **Resolved during the upgrade:** Node/TS floors (container's Node 22 + TS 5.9.3 satisfy v21, no setup-script change); overrides drift (none needed); budget regression (initial crept 521.97 → 524.30 kB but stays under the 525 kB warn budget — watch it on future bumps); `@types/jasmine` removed, `tsconfig.spec.json` now uses `vitest/globals`.
+
+## Migration reference (for future bumps)
+
+### Upgrade path (staged, one major at a time)
+
+Angular's supported migration is **one major per step** via `ng update`; do not skip a version. Run each step on the working branch, commit between steps, and gate on `npm run build:prod` (no `▲ [WARNING]`) + `./run-tests.sh core` before proceeding. The exact peer-dep floors are whatever `ng update` prints — treat it as authoritative.
+
+```
+cd frontend && npx ng update @angular/core@<N> @angular/cli@<N> @angular/cdk@<N>
+```
+
+Per step, expect: a **TypeScript floor** bump and a possible **Node floor** bump (verify the container satisfies it — if not, that's a setup-script/image change outside `frontend/`, surface it to the user); automated schematics for renamed/removed APIs; and a possible `vite`/`esbuild` `overrides` revisit if the new `@angular-devkit` pulls a different range (stale overrides can break `npm ci` or the build). Gate after each: `build:prod` clean, TypeScript clean, app boots; after the final major also smoke the core flow (load dataset → train detector → sort).
+
+### Vitest wiring — gotchas future bumps must preserve
+
+The version bump alone does **not** enable Vitest. The pieces that landed and must survive a re-bump:
+
+- **Builder wiring.** `build`/`serve`/`extract-i18n`/`test` all use the canonical `@angular/build:*` builders (not the `@angular-devkit/build-angular:*` aliases) — **required**, because the `@angular/build:unit-test` runner warns and fails to inherit polyfills (notably `zone.js/testing`) when `buildTarget` points at a devkit alias. `test` (watch) / `test:ci` (`ng test --no-watch`) scripts each have a `pretest*` hook regenerating the API client.
+- **jsdom polyfills** (`src/test-setup.ts`, via `setupFiles`): inert stubs for `EventSource`, `HTMLMediaElement.play/pause/load`, `HTMLCanvasElement.getContext` — jsdom omits these and throws "Not implemented".
+- **fakeAsync / ProxyZone bootstrap** (the subtle one). `zone.js/testing` only auto-establishes the ProxyZone that `fakeAsync()`/`tick()` need for Jasmine/Mocha/Jest runners, and Vitest is none of those, so every `fakeAsync` spec threw "Expected to be running in 'ProxyZone'". `test-setup.ts` replicates zone.js's jest patch against Vitest's globals (describe → sync zone, it/hooks → proxy zone). See the ProxyZone follow-up above.
+- **Isolation + cascade guard.** The unit-test builder defaults to `isolate: false`; `vitest.config.ts` flips it to `isolate: true` so a dirty `TestBed` singleton can't poison later files, and `test-setup.ts` resets the TestBed at the start of each test so a throwing teardown doesn't cascade "test module already instantiated".
+- **run-tests.sh wiring.** Vitest runs on the full `./run-tests.sh` (the real gate — no CI) and on the frontend-only `./run-tests.sh frontend` group; intentionally **not** on the fast `core` path (which keeps only the compile-only build check).
+
+### Risks / watch-items
+
+- **Node/TS floors** may exceed what the container ships (a setup-script/image change outside `frontend/` — surface it, don't assume).
+- **`overrides` drift** (`vite`, `esbuild`, `postcss`, …) is the likeliest source of a broken `npm ci`/build after a bump — review at each step.
+- **Budget regressions** from a major bump — fix bloat, don't raise budgets (CLAUDE.md rule).
+- **Vitest first-run red is expected on new specs** — realign to current behavior, don't weaken.
+- **No mobile/responsive concerns** — desktop-only app; ignore viewport deprecation noise.
+
+### Deferred / out of scope (record only)
+
+Angular 21 modernization carrots, each its own opt-in effort — give any picked-up item its own plan file and link it here:
+
+- **Zoneless change detection** — drops `zone.js` from polyfills (bundle/budget win) but effectively needs broad signal adoption first (VTSearch barely uses signals).
+- **`httpResource` / `resource`** — could trim `switchMap`/manual-subscription boilerplate across the ~67 RxJS API services. **Scoped in its own plan: `httpresource-migration.md`** (recommends `rxResource` wrapping the generated client; not started).
+- **Signal Forms** — low value (no forms here) and experimental in 21.
+- **ARIA directives, CLI MCP server** — marginal for this app.
+
+## What shipped
+
+- **Angular 19 → 20 → 21**, one major per step via `ng update`. All `@angular/*` at `21.2.17`, `@angular-devkit/build-angular` + `@angular/cli` at `21.2.16`, TypeScript `5.9.3` (container's Node 22 satisfies the floor). Removed the never-imported `@angular/platform-browser-dynamic` (a dead dep confusing `ng update`'s peer resolver).
+- **Block control-flow migration** — mandatory on 21 (legacy `*ngIf`/`*ngFor`/`*ngSwitch` removed); `ng update` converted 51 templates to `@if`/`@for`/`@switch`.
+- **Out-of-root docs asset fixed** — Angular 21 forbids `assets[].input` outside the workspace root, breaking `../docs/user → /assets/docs`; replaced with a committed symlink `frontend/docs-assets → ../docs/user` (docs stay single-sourced). Overrides (`vite`/`esbuild`) needed no changes.
+- **Gates green:** `build:prod` clean (0 warnings, initial 524.30 kB < 525 kB budget), `npm audit --omit=dev` = 0, full `./run-tests.sh` passes (4841 tests).
+- **Vitest builder + scripts** — `test`/`test:ci` targets on `@angular/build:unit-test` (jsdom); all `build`/`serve`/`extract-i18n` moved to canonical `@angular/build:*`; `@types/jasmine` removed, `vitest`/`jsdom` added dev-only. jsdom polyfills, ProxyZone shim, and isolation guard added to `test-setup.ts` (details under Migration reference).
+- **Jasmine → Vitest port** (mechanical, all specs): `toBeTrue()`→`toBe(true)`, `spyOn`→`vi.spyOn`, `.and.returnValue`→`.mockReturnValue` (+ `callFake`/`resolveTo` equivalents), `spy.calls.mostRecent().args`→`spy.mock.lastCall`, `done`-callback tests → Promise; `tsconfig.spec.json` types `jasmine`→`vitest/globals`.
+- **Real spec drift fixed.** The 754 `it` blocks had only ever typechecked; ~186 stale specs were realigned to current behavior (new `/api/embedders`, `/api/media-types`, `/api/settings`, SSE-vs-HTTP, vote body `{vote}`→`{target}`, etc.) — no tests deleted/skipped/weakened.
+- **One real bug surfaced + fixed.** `DocumentViewerComponent` bound a plain string into `<object [data]>` (a RESOURCE_URL sink, NG0904 in prod — document viewing was latently broken); fixed by wrapping the same-origin URL with `DomSanitizer.bypassSecurityTrustResourceUrl`.

--- a/docs/plans/auto-find-settings-tab.md
+++ b/docs/plans/auto-find-settings-tab.md
@@ -1,125 +1,9 @@
 # Auto-Find settings tab + results exporter wiring
 
-Status: **Shipped**, including the Phase 2 AutoFind rename + hardening pass
-(see below). Adds a dedicated "Auto-Find" settings tab, makes the
-Auto-Find detector list editable and **per-user**, wires a user-chosen "results
-exporter" so an Auto-Find run hands results to it automatically, and gives
-**detectors the same per-user access-list model as datasets** (owner + readers,
-a security button, and a dashboard access column that auto-hides in single-user
-mode).
-
-## What shipped
-
-### Icons (frontend)
-- `Settings → Browser` tab now uses the **eye** glyph, matching the Browse
-  buttons throughout the app (dashboard cards, Find right-panel goods actions).
-- `Settings → Data Imports` tab uses a new **import** glyph (rounded box open at
-  the upper-left, arrow running from that corner into the centre) — a deliberate
-  mirror of the export icon, so import/export read as a matched pair instead of
-  the old upload arrow that looked like export.
-- New **auto-find** glyph: a small magnifying glass inside a ring of three
-  arrows chasing each other clockwise.
-
-### Auto-Find settings tab
-New `Settings → Auto-Find` tab (`auto-find` icon), housing:
-- **Auto-Find detectors** — editable checklist of the detectors visible to the
-  user. Reuses the per-detector autorun toggle
-  (`PUT /api/detectors/registry/<id>/autorun`), which persists into the
-  caller's **per-user** `autofind_detectors` list. (Moved here from the
-  read-only Server tab, renamed from "Auto-run detectors".)
-- **Results Exporter** — a dropdown (None + each pickable exporter) with a
-  sub-tab per exporter type (Server JSON File, Server CSV File, Send by Email,
-  Webhook). Each sub-tab renders that exporter's own fields; values persist
-  per-exporter so switching the dropdown keeps each exporter's config.
-
-### Settings model (per-user)
-`autofind_detectors` moved from `ServerSettings` to `UserSettings`, joined by two
-new per-user keys:
-- `autofind_exporter: str` — chosen exporter name (`""` = no auto-export).
-- `autofind_exporter_field_values: dict[str, dict[str, str]]` — per-exporter
-  field values, keyed by exporter name.
-
-All three are excluded from the "Default" reset. For the built-in **`default`**
-user, reads fall back to the *server* settings file when the key is absent from
-its own file (`_DEFAULT_USER_FALLBACK_KEYS` + the read-through in
-`vtsearch.settings._read_value`), and the destructive legacy migration skips
-these keys. This keeps the CLI `--settings` flat file and single-user
-deployments working while named multi-user users get a fully isolated list.
-
-### Detector access-list model (mirrors datasets)
-- Registry entries gain a `readers: list[str]` field (empty = private to
-  creator, `["*"]` = public), alongside the existing `created_by`.
-- `vtscore.detectors.registry` gains `can_user_access_detector`,
-  `is_detector_owner`, `list_detectors_for_user`, `set_detector_readers`.
-- `GET /api/detectors/registry` filters to the current user and returns
-  `created_by` / `readers` / `is_owner`; `load` / `delete` / `rename` /
-  `autorun` enforce access/ownership; new `PUT /api/detectors/registry/<id>/readers`.
-- Dashboard: `created_by` / `readers` columns (auto-hidden when
-  `provider === 'default'`) and a per-row security button → access-list prompt.
-
-### CLI user identity
-`--autodetect` defaults to the `default` user; `--user <name> --api-key <key>`
-authenticates against `data/api_keys.json` (same as the server's `api_key`
-login) and sets the thread-local user so the run reads that user's Auto-Find
-list + exporter.
-
-### End-to-end wiring
-- **CLI** (`python app.py --autodetect`): when no explicit `--exporter` is
-  passed, the run falls back to `autofind_exporter` /
-  `autofind_exporter_field_values` from settings (threaded through
-  `CoreConfig`). An explicit `--exporter` still wins; if neither is set the
-  legacy `gui` default applies.
-- **Server** (`POST /api/auto-detect`): after scoring, if `autofind_exporter`
-  is configured the route runs that exporter on the results and returns an
-  `auto_export` status block (`{exporter, success, message?, error?}`), surfaced
-  in the auto-detect results modal.
-
-## Phase 2: AutoFind rename + set-and-forget hardening (shipped)
-
-The feature is named **AutoFind** ("Auto-Find" in UI copy), not "AutoRun".
-Phase 2 carried the name through everywhere the detector feature said
-"autorun" and hardened the set-and-forget contract:
-
-- **Rename (breaking, no shims):** settings key `autorun_detectors` →
-  `autofind_detectors` (existing per-user/server values under the old key are
-  ignored; users re-tick their detectors once), accessors
-  `get/set_autofind_detectors` / `add/remove/is_autofind_detector`, route
-  `PUT /api/detectors/registry/<id>/autorun` → `/autofind` with body/response
-  field `autofind`, registry-entry flag `autorun` → `autofind`,
-  `CoreConfig.autorun_detectors` → `autofind_detectors`. The processor-side
-  autorun registries (`vtsearch/autorun_processors.py`,
-  `/api/autorun-extractors`, `/api/autorun-localizers`) are a different
-  feature and intentionally keep their name, as do the `--autodetect` CLI
-  flag and the `/api/auto-detect` route ("auto-detect" describes the run,
-  not the old feature name).
-- **Dashboard toggle removed:** the detector table's "Auto-Find?" column is
-  gone. The Dashboard is a dynamic workspace; Auto-Find membership is
-  curated only in Settings → Auto-Find (set-and-forget). The delete
-  confirmation now warns when the detector being deleted is on your
-  Auto-Find list.
-- **Detector references stay name-based:** an Auto-Find entry is a detector
-  *name* resolving to the origins-only labelset JSON under
-  `data/detectors/<slug>.json` — that file already is the offline,
-  re-derivable form of a detector (origins → re-embed → retrain), so no new
-  "detector origin" indirection was added. Lifecycle holes are handled
-  instead: rename rewrites the caller's list, delete scrubs it (and warns),
-  and `/api/auto-detect` returns `missing_detectors` (surfaced in the
-  results modal; all-missing returns a 400 naming them) instead of silently
-  skipping stale references. The CLI already raised on missing files.
-- **Date-named export patterns:** exporter path templates gained
-  `{YYYYMMDD}`, `{YYYY}`, `{MM}`, `{DD}` (UTC) alongside
-  `{YYYYMMDD-HHMMSS}`, so a daily scheduled run can write e.g.
-  `results_{YYYY}.{MM}.{DD}.csv`. Supported by `normalize_field_values`
-  (first-party path) and `resolve_export_filepath` (third-party helper).
-
-### Known limitation: cross-user stale references
-Deleting a detector scrubs only the *deleting* user's Auto-Find list; there
-is no way to enumerate other users' settings files (user data dirs are
-login-provider-defined), so another user's list may keep a stale name. That
-staleness is reported, not hidden: their next run lists it under
-`missing_detectors`.
+**Status: Shipped**, including the Phase 2 AutoFind rename + set-and-forget hardening pass. A dedicated "Auto-Find" settings tab houses an editable, per-user detector list and a user-chosen results exporter that an Auto-Find run hands results to automatically; detectors gained the same per-user access-list model as datasets. Open follow-ups below.
 
 ## Open follow-ups
+
 - The `/api/auto-detect` route currently has no first-party UI caller (the
   feature is CLI-driven); the server-side auto-export is wired and tested so it
   works the moment a UI flow calls the route.
@@ -132,3 +16,31 @@ staleness is reported, not hidden: their next run lists it under
 - The email exporter has no template variables in its fields (subject is
   generated); date-stamped subjects could reuse the same template machinery
   if wanted.
+
+### Known limitation: cross-user stale references
+Deleting a detector scrubs only the *deleting* user's Auto-Find list; there is no way to enumerate other users' settings files (user data dirs are login-provider-defined), so another user's list may keep a stale name. That staleness is reported, not hidden: their next run lists it under `missing_detectors`.
+
+## What shipped
+
+Icons (frontend):
+- `Settings → Browser` tab uses the **eye** glyph (matching Browse buttons); `Settings → Data Imports` uses a new **import** glyph (mirror of the export icon); new **auto-find** glyph (magnifying glass in a ring of three chasing arrows).
+
+Auto-Find settings tab (`Settings → Auto-Find`):
+- **Auto-Find detectors** — editable checklist of the user's visible detectors, reusing `PUT /api/detectors/registry/<id>/autorun` (persists to per-user `autofind_detectors`). Moved here from the read-only Server tab, renamed from "Auto-run detectors".
+- **Results Exporter** — dropdown (None + each pickable exporter) with a sub-tab per exporter type (Server JSON/CSV File, Send by Email, Webhook); values persist per-exporter.
+
+Settings model (per-user): `autofind_detectors` moved `ServerSettings` → `UserSettings`, joined by `autofind_exporter: str` and `autofind_exporter_field_values: dict[str, dict[str, str]]`. All three excluded from "Default" reset. For the built-in `default` user, reads fall back to the server settings file when absent (`_DEFAULT_USER_FALLBACK_KEYS` + `vtsearch.settings._read_value`); keeps CLI flat file + single-user deployments working while named users get isolated lists.
+
+Detector access-list model (mirrors datasets): registry entries gain `readers: list[str]` (empty = private, `["*"]` = public) alongside `created_by`; `vtscore.detectors.registry` gains `can_user_access_detector` / `is_detector_owner` / `list_detectors_for_user` / `set_detector_readers`; `GET /api/detectors/registry` filters to the current user; `load`/`delete`/`rename`/`autorun` enforce access; new `PUT /api/detectors/registry/<id>/readers`; dashboard gets `created_by`/`readers` columns (auto-hidden when `provider === 'default'`) + per-row security button.
+
+CLI user identity: `--autodetect` defaults to the `default` user; `--user <name> --api-key <key>` authenticates against `data/api_keys.json` and sets the thread-local user so the run reads that user's list + exporter.
+
+End-to-end wiring:
+- **CLI** (`python app.py --autodetect`): with no explicit `--exporter`, falls back to `autofind_exporter` / `autofind_exporter_field_values` (via `CoreConfig`); explicit `--exporter` wins; else legacy `gui` default.
+- **Server** (`POST /api/auto-detect`): after scoring, runs the configured `autofind_exporter` and returns an `auto_export` status block, surfaced in the results modal.
+
+Phase 2 — AutoFind rename + set-and-forget hardening (the feature is **AutoFind** / "Auto-Find" in UI, not "AutoRun"):
+- **Rename (breaking, no shims):** settings key `autorun_detectors` → `autofind_detectors` (old values ignored; users re-tick once), accessors `get/set_autofind_detectors` + `add/remove/is_autofind_detector`, route `.../autorun` → `.../autofind` (body/response field `autofind`), registry flag `autorun` → `autofind`, `CoreConfig.autorun_detectors` → `autofind_detectors`. The processor-side autorun registries (`vtsearch/autorun_processors.py`, `/api/autorun-extractors`, `/api/autorun-localizers`), the `--autodetect` flag, and the `/api/auto-detect` route intentionally keep their names.
+- **Dashboard toggle removed:** the "Auto-Find?" column is gone; membership is curated only in Settings → Auto-Find. Delete confirmation now warns when the detector is on your Auto-Find list.
+- **Detector references stay name-based:** an entry is a detector *name* → `data/detectors/<slug>.json` (already the re-derivable form); no new indirection. Lifecycle holes handled instead — rename rewrites the list, delete scrubs+warns, `/api/auto-detect` returns `missing_detectors` (all-missing → 400) instead of silently skipping.
+- **Date-named export patterns:** path templates gained `{YYYYMMDD}` / `{YYYY}` / `{MM}` / `{DD}` (UTC) alongside `{YYYYMMDD-HHMMSS}`, via `normalize_field_values` + `resolve_export_filepath`.

--- a/docs/plans/browse-audio-player.md
+++ b/docs/plans/browse-audio-player.md
@@ -1,239 +1,14 @@
 # Browse audio player: squares + top-left now-playing indicator
 
-**Status:** Phase 1, Phase 2, and Phase 4 shipped; Phase 2's anchored floating
-player was *replaced* by Phase 4, not layered on top of it — see "What shipped
-(Phase 4)" below. Audio bins tile as square waveform thumbnails on the
-VTSBrowse map (Phase 1). Hovering an audio bin lifts it (the same hover-enlarge
-every thumbnail type gets) and starts the clip playing, with **no on-canvas
-player UI**; the only visual feedback is a small waveform + the volume control,
-both anchored top-left (Phase 4). Scope confirmed with the user: the earlier
-anchored floating player felt redundant with the bin's own hover-enlarge, so it
-was deleted rather than polished.
-
-## What shipped (Phase 1)
-
-- **`MediaType.has_thumbnail`** capability (`vtscore/media/base.py`) — the
-  single source of truth for the thumbnail vs no-thumbnail distinction. Set
-  `True` on image/video/document/audio; `False` on text. Exposed on
-  `GET /api/media-types` (`to_dict`) and mirrored on the frontend
-  `MediaTypeInfo.has_thumbnail`.
-- **`bin_shape_for_media_type`** (`vtscore/projection/pyramid.py`) now derives
-  square-vs-hex from `has_thumbnail` via a lazy registry lookup (keeps the
-  projection layer Flask/media-free at import). The hardcoded
-  `SQUARE_MEDIA_TYPES` frozenset is gone. Audio → square.
-- **Frontend `usesThumbnails`** (`hex-render.util.ts`) now includes audio (and
-  document, fixing a pre-existing omission that left document square-tiled but
-  density-painted). Audio bins on the map paint their waveform PNG; the bin
-  popup gains a magnified-waveform preview pane; the colormap picker is hidden
-  for audio (grayscale-pinned like other thumbnail types).
-- Side effect (desirable): clicking an audio bin now shows a preview pane in
-  the bin popup, consistent with image/video.
-
-## What shipped (Phase 2) — superseded by Phase 4
-
-- **Anchored audio hover player** (`BrowseHoverPreviewComponent`). Hovering an
-  audio bin opened a panel next to the tile with the bin's waveform PNG plus
-  a native `<audio controls>` element — play/pause, volume, and a scrubber (the
-  "current play-point"). This replaced the old `display:none` `<audio>` (the
-  "sound from nowhere").
-- **Dwell + debounce:** the player opened only after the cursor rested ~200ms on
-  a bin, and sweeping across bins re-armed the dwell, so a fast pass didn't spawn
-  a burst of players/auditions.
-- **Hover-bridge:** the panel took pointer events, and a short close-grace after
-  the bin-hover cleared let the cursor travel from the tile onto the controls
-  without the panel vanishing.
-- **Clip-aware:** windowed clips looped within `[clip_start, clip_end]` via the
-  shared `applyClipWindow` helper (lazy clip-extent lookup through the metadata
-  cache).
-- Implementation note: rather than embed the Train `AudioPlayerComponent` (which
-  wants a full `Media` object and re-decodes audio client-side per hover), the
-  hover player was a lightweight inline panel — the same waveform PNG already on
-  the tile + native controls. Visually equivalent, cheaper, no type-plumbing.
-- **Why it was removed (Phase 4):** the floating panel duplicated the bin's own
-  hover-enlarge (a magnified thumbnail already appears on hover for every
-  thumbnail type, audio included) — two "here's what you're hovering" surfaces
-  stacked on top of each other. The user asked for the panel to go away
-  entirely: hovering should just enlarge the bin and play the clip, with
-  feedback confined to a small always-there corner widget instead of new UI
-  popping up mid-canvas.
-
-## What shipped (Phase 4) — top-left now-playing indicator
-
-- **Deleted the anchored floating player.** `BrowseHoverPreviewComponent`'s
-  audio path no longer renders any DOM; it owns a plain `new Audio()` element
-  (never mounted) purely to hear the clip. Hovering an audio bin still lifts it
-  via the existing `usesThumbnails()` hover-enlarge — no new visual on the
-  canvas itself.
-- **`NowPlaying` output**, exported from `browse-hover-preview.component.ts`
-  (`{ mediaId, waveUrl }`), emitted when a clip starts and `null` the instant
-  hover clears (no hover-bridge grace — there's no panel to bridge onto).
-  `browse-bin-popup.component.ts` gained the same output, emitted from its
-  existing grid-hover audio path (`onEntryEnter`/`stopAudio`), so the bin-popup
-  member grid feeds the same indicator.
-- **Top-left now-playing + volume cluster**, in `browse-view.component` inside
-  the existing `.browse-tools-left` overlay (alongside "Back to Find" /
-  "Rebuild map"): a `.browse-now-playing-wave` `<img>` of whatever clip is
-  auditioning (the same waveform PNG painted on its tile) stacked above the
-  `.browse-volume` mute+slider control, which **moved from top-right to
-  top-left** to sit with it. No per-clip controls (play/pause/scrub) live here
-  — deliberately: the cursor can't reach the top-left corner without moving off
-  the bin that's making the noise, so any button there would be unreachable
-  while relevant.
-- **Redundant-by-design overlap with the bin popup:** when the bin-detail popup
-  is open, its own member grid still shows the waveform thumbnail for the
-  hovered row *and* the top-left indicator shows the same clip. Acknowledged
-  and accepted rather than solved — a candidate future merge of "bin popup
-  preview" and "now playing" is noted below, not attempted here.
-
-## Motivation (original, Phase 1/2)
-
-On the VTSBrowse map, audio bins render as flat-density **hexes**, and
-mousing one plays sound from a `display:none` `<audio>` element — audio
-"comes out of nowhere" with no visual player, no play/pause, no volume, no
-play-point. We want audio bins to render as **square waveform tiles** (like
-image/video), and hovering a bin to raise an **anchored, controllable
-player** modelled on the Train center-panel audio player.
-
-## The surprise: audio is *already* a waveform-thumbnail type — except on the map
-
-This proposal is smaller than "add thumbnails to audio," because the
-waveform-thumbnail pipeline already exists and already ships:
-
-- `vtscore/media/audio/media_type.py:27` `generate_waveform_thumbnail()`
-  renders a min/max-envelope PNG at ingest and stores it as
-  `thumbnail_bytes` (round-tripped via `pickle_extra_fields`).
-- Served at `/api/medias/<id>/thumbnail` and `/image` through the same
-  routes images use (`image_response` hook).
-- The **left-panel media grid already displays** audio waveforms:
-  `frontend/src/app/components/left-panel/media-item/media-item.component.ts`
-  lists `'audio'` among its thumbnail types.
-- **Clip-aware already:** `vtscore/datasets/stages/clipper.py:279`
-  `_regenerate_clip_thumbnails()` re-renders each clip's waveform from the
-  *sliced* bytes, so a clipped track's tile shows only its
-  `[clip_start, clip_end)` window. Lazy clips reproduce this on demand.
-
-The **only** place audio is a "no-thumbnail" hex is the VTSBrowse
-projection canvas, gated by two lists:
-
-- Backend: `vtscore/projection/pyramid.py:57` `SQUARE_MEDIA_TYPES =
-  {"image","video","document"}` + `bin_shape_for_media_type()` (`:60`). The
-  comment at `:50-56` deliberately excludes audio ("nobody browses by
-  waveform") — so flipping this is a **product reversal**, not a bug fix.
-- Frontend: `frontend/src/app/components/browse-canvas/hex-render.util.ts:42`
-  `usesThumbnails()` returns true for `'image'|'video'` only.
-
-The rich player we want as the model already exists:
-`frontend/src/app/components/center-panel/audio-player/audio-player.component.ts`
-— waveform canvas + native `<audio controls>` (play/pause, **volume**,
-**scrubber/play-point**) + clip-window looping (`applyClipBounds`,
-`startClipEnforcement`), `togglePlayback()`, `adjustVolume()`,
-`playingChanged` output.
-
-So the two real builds are (1) the map tile-shape flip and (2) an anchored
-hover player — mostly *relocating an existing component*, not new invention.
-
-## Design
-
-### Part A — audio bins as square waveform tiles
-
-1. Add `"audio"` to `SQUARE_MEDIA_TYPES` (`pyramid.py:57`) — or, better,
-   replace the three hardcoded type-lists with a single source of truth
-   (see "Cleanup" below).
-2. Add `'audio'` to `usesThumbnails()` (`hex-render.util.ts:42`).
-3. Verify square packing / rep zoom-persistence in `squarebin.py` +
-   `pyramid.py` behaves with 128×128 square waveform reps (aspect
-   assumptions are image-oriented; waveforms are square so should fit, but
-   confirm).
-4. Reconcile the color/border handling: `usesThumbnails` types are pinned
-   to the grayscale colormap and hide the colormap picker — decide whether
-   audio waveform tiles want the same treatment (probably yes).
-
-### Part B — anchored hover player
-
-Upgrade `BrowseHoverPreviewComponent` (the current hidden-`<audio>` host)
-into an anchored player, reusing `AudioPlayerComponent`:
-
-- The hover event carries only `cell.rep_id` + `cell.count`; hydrate the
-  representative into a `Media` via `MediaMetadataCacheService`
-  (`ensureLoaded([id])` / `get(id)`) — the same cache the current hover
-  already primes — then feed it to `<vt-audio-player [media]>`.
-- Anchor the player overlay to the hovered tile's screen position (the
-  hover host already positions at `screenX+16 / screenY-8`).
-- **Playhead line over the canvas is net-new:** `AudioPlayerComponent`
-  relies on the native scrubber and does not draw a moving playhead on its
-  waveform. `audio-crop-overlay.component.ts` shows the canvas-overlay
-  pattern to copy if we want the playhead drawn on the waveform itself.
-
-## Problems / risks
-
-1. **Waveform tiles are low-discrimination.** Zoomed out, 128px waveforms
-   all read as similar squiggles — far less scannable than image
-   thumbnails. This is exactly why `pyramid.py:50-56` excluded them. The
-   payoff is the *hover player*, not static-tile browsability; set
-   expectations accordingly.
-2. **Hover performance.** `AudioPlayerComponent.drawWaveform()` fetches the
-   full audio and decodes it client-side (`decode-audio.ts`) to paint its
-   interactive waveform. Sweeping the cursor across bins would fire a
-   fetch+decode per bin → jank. Mitigation: keep painting the cheap backend
-   PNG on the tile; only instantiate the heavy interactive player on a
-   **debounced dwell**; reuse cached decodes where possible.
-3. **Hover-into-controls.** A player with sliders/buttons means the cursor
-   must travel from the tile into the player without hover-out tearing it
-   down (classic hover-menu trap). The current code kills audio on
-   mouse-leave; the anchored player needs a hover-bridge / dismiss delay so
-   the controls are reachable.
-4. **Which item plays?** A bin aggregates many items; hover plays only the
-   representative today. A visible player invites "page through members,"
-   which is the job of the existing click-to-open bin popup
-   (`browse-bin-popup.component.ts`, which also hover-plays audio via the
-   same hidden-`<audio>` pattern and would want the same upgrade). Decide
-   whether member-paging lives in the anchored player or stays in the popup.
-5. **Screenshot reshoots.** Changing the Browse map means queueing affected
-   shot ids in `docs/user/screenshots-reshoot-queue.md` (no browser in the
-   cloud container to reshoot in-session).
-
-## Cleanup opportunity (do this as part of the change)
-
-"Has a browsable thumbnail" is currently smeared across **three
-independent hardcoded type-lists that disagree**:
-
-- `media-item.component.ts:46` — image, video, document, **audio**
-- `hex-render.util.ts:42` — image, video (missing document!)
-- `pyramid.py:57` — image, video, document
-
-There is no `has_thumbnail` capability on `MediaType`
-(`vtscore/media/base.py`); `to_dict()` doesn't expose one. The clean move
-is to add an explicit `has_thumbnail` / `bin_shape` field to the media-type
-API (`to_dict()` → `GET /api/media-types`) and have all three sites consume
-it, so audio (and future types) flip in one place instead of a fourth
-hardcoded list.
-
-## Suggested phasing
-
-- **Phase 1 — tiles (SHIPPED):** added the `has_thumbnail` capability +
-  reconciled the shape/paint decisions so audio renders as square waveform
-  tiles on the map. Visible tile change with the least new UI.
-- **Phase 2 — anchored player (SHIPPED, then superseded):** upgraded
-  `BrowseHoverPreviewComponent` to a debounced, hover-bridged anchored player
-  (waveform + native play/pause + volume + scrubber). Went with a lightweight
-  inline panel rather than embedding `AudioPlayerComponent`. Replaced outright
-  by Phase 4 rather than polished — see "What shipped (Phase 2) — superseded".
-- **Phase 4 — top-left now-playing indicator (SHIPPED):** deleted the anchored
-  panel; hovering an audio bin now only enlarges it (shared hover-enlarge) and
-  plays sound, with a small waveform + the (relocated) volume control anchored
-  top-left as the sole visual feedback. Also upgraded the bin-popup's
-  grid-hover audio to feed the same indicator. See "What shipped (Phase 4)".
-- ~~Phase 3 — polish~~: superseded by Phase 4; its scope (playhead, panel
-  positioning, member-paging) no longer applies to a deleted panel. Any
-  surviving pieces are folded into Open follow-ups below.
+**Status: Phases 1, 2, and 4 shipped; Phase 3 (polish) superseded by Phase 4, not built.** Audio bins now tile as square waveform thumbnails on the VTSBrowse map (Phase 1). Hovering an audio bin lifts it (the shared hover-enlarge every thumbnail type gets) and plays the clip, with **no on-canvas player UI**; the only feedback is a small waveform + volume control anchored top-left (Phase 4). Phase 2's anchored floating player was deleted (felt redundant with the bin's own hover-enlarge), not layered on. Open follow-ups below.
 
 ## Open follow-ups
 
-- **Merge bin-popup preview with now-playing.** Noted as a known, accepted
-  redundancy in "What shipped (Phase 4)": with the bin-detail popup open, the
-  hovered row's waveform shows both in the popup's own grid and in the
-  top-left indicator. A future pass could have the popup point at (or fold
-  into) the shared now-playing indicator instead of keeping its own display.
+- **Merge bin-popup preview with now-playing.** A known, accepted redundancy:
+  with the bin-detail popup open, the hovered row's waveform shows both in the
+  popup's own grid and in the top-left indicator. A future pass could have the
+  popup point at (or fold into) the shared now-playing indicator instead of
+  keeping its own display.
 - **Data-drive the frontend from `has_thumbnail`.** Phase 1 added the capability
   to the API + `MediaTypeInfo`, but the frontend still hardcodes the thumbnail
   type set in several spots (`usesThumbnails`, and the per-item `hasThumbnailUrl`
@@ -248,3 +23,21 @@ hardcoded list.
   same PNG.
 - Whether `text` (the last hex type) ever gets an analogous treatment — out of
   scope for now.
+
+## What shipped
+
+Phase 1 — audio bins as square waveform tiles:
+- **`MediaType.has_thumbnail`** capability (`vtscore/media/base.py`) — single source of truth for thumbnail vs no-thumbnail; `True` on image/video/document/audio, `False` on text. Exposed on `GET /api/media-types` (`to_dict`) + mirrored on frontend `MediaTypeInfo.has_thumbnail`.
+- **`bin_shape_for_media_type`** (`vtscore/projection/pyramid.py`) derives square-vs-hex from `has_thumbnail` via a lazy registry lookup (keeps projection layer Flask/media-free at import); the hardcoded `SQUARE_MEDIA_TYPES` frozenset is gone. Audio → square.
+- **Frontend `usesThumbnails`** (`hex-render.util.ts`) now includes audio (and document, fixing a pre-existing omission): audio bins paint their waveform PNG, the bin popup gains a magnified-waveform preview pane, and the colormap picker is hidden for audio (grayscale-pinned).
+- Side effect: clicking an audio bin now shows a preview pane in the bin popup, consistent with image/video.
+
+Phase 2 — anchored audio hover player (**superseded, then deleted in Phase 4**):
+- `BrowseHoverPreviewComponent` opened a panel next to the hovered tile with the bin's waveform PNG + native `<audio controls>` (play/pause, volume, scrubber), replacing the old `display:none` "sound from nowhere". Dwell (~200ms) + debounce re-armed on sweep; a hover-bridge + close-grace let the cursor reach the controls; windowed clips looped within `[clip_start, clip_end]` via `applyClipWindow`. Built as a lightweight inline panel (waveform PNG + native controls) rather than embedding the Train `AudioPlayerComponent`.
+- **Removed in Phase 4** because the floating panel duplicated the bin's own hover-enlarge — two "here's what you're hovering" surfaces stacked. The user asked for it gone: hover should just enlarge the bin and play, with feedback confined to a small always-there corner widget.
+
+Phase 4 — top-left now-playing indicator:
+- **Deleted the anchored floating player.** `BrowseHoverPreviewComponent`'s audio path renders no DOM; it owns a never-mounted `new Audio()` purely to hear the clip. Hovering still lifts the bin via `usesThumbnails()` hover-enlarge.
+- **`NowPlaying` output** (`{ mediaId, waveUrl }`) from `browse-hover-preview.component.ts`, emitted when a clip starts and `null` the instant hover clears (no bridge grace — no panel to bridge onto). `browse-bin-popup.component.ts` gained the same output from its grid-hover audio path (`onEntryEnter`/`stopAudio`), so the member grid feeds the same indicator.
+- **Top-left now-playing + volume cluster** in `browse-view.component`'s `.browse-tools-left` overlay: a `.browse-now-playing-wave` `<img>` of the auditioning clip stacked above `.browse-volume` (mute+slider), which **moved from top-right to top-left**. No per-clip controls (the cursor can't reach the corner without leaving the noisy bin).
+- **Redundant-by-design overlap with the bin popup** (hovered row's waveform shows in both the popup grid and the top-left indicator) — accepted, candidate merge noted in Open follow-ups.

--- a/docs/plans/cli-detector-converter.md
+++ b/docs/plans/cli-detector-converter.md
@@ -1,256 +1,119 @@
 # Design: CLI Autodetect with Converters and Clippers
 
-> **Status:** Phase 1 shipped (detector `input_spec` + LabelSet `detector_meta` round-trip + CLI skip-on-mismatch). The converter-routing and re-clipping pipeline described below is **not yet implemented**; see *What shipped* and *Open follow-ups* at the bottom.
-
-## Problem
-
-The CLI autodetect pipeline currently works like this:
-
-1. Load dataset (pickle or importer) → medias with pre-computed embeddings
-2. Find detectors matching the dataset's media type
-3. Score embeddings against detectors
-4. Export results
-
-This breaks down when:
-
-- A detector was trained on **audio extracted from video** (video→audio converter + sound_tiling_2s clipper), but the new dataset is raw video files.
-- A detector was trained on **2s audio clips**, but the dataset contains full-length audio files.
-- A detector was trained on **document page images**, but the dataset contains PDFs.
-
-The detector expects a specific *input format* (media type + clipper granularity), and the pipeline has no way to reproduce that format at inference time.
-
-## Options Considered
-
-### Option A: Specify converter/clipper as CLI arguments
-
-```
-python app.py --autodetect --dataset videos.pkl \
-  --converter video2audio --clipper sound_tiling_2s \
-  --settings settings.json
-```
-
-**Problems:**
-- These args apply globally to *all* detectors in the autodetect run. If one detector was trained on 2s clips and another on 5s clips, you can't express that.
-- The user has to remember (or look up) what each detector was trained with.
-- Gets tangled fast with multiple detectors, each needing different converters/clippers.
-
-### Option B: Per-detector settings in the settings file
-
-```json
-{
-  "autorun_processors": [
-    {
-      "processor_name": "bird songs",
-      "processor_importer": "server_detector_file",
-      "field_values": {"filepath": "data/detectors/birds.json"},
-      "converter": "video2audio",
-      "clipper": "sound_tiling_2s"
-    }
-  ]
-}
-```
-
-**Problems:**
-- Duplicates information that should live *with* the detector.
-- Settings become a second source of truth that can drift from training reality.
-- If you share a detector file, the converter/clipper info doesn't travel with it.
-
-### Option C: Detector stores its input spec (Recommended)
-
-The detector file already stores `media_type`. That field already tells the pipeline what embedding space the detector operates in. The missing piece is the *clipper*: how to split media before embedding.
-
-**Converters are NOT part of the detector's spec.** The detector doesn't care *how* you got to its media type; it just needs the right type of embedding. The converter registry already knows all the routes (video→image, document→image, video→audio, etc.), so the pipeline can figure out conversion automatically.
-
-This matters because **a dataset can contain mixed source types**. An image detector should score:
-- Native images → directly
-- Videos → via `video2image`
-- Documents → via `document2image`
-
-If the detector stored `converter: "video2image"`, it couldn't also handle documents. The detector shouldn't have to enumerate every possible source type; it just says "I need image embeddings" and the pipeline handles the rest.
-
-```json
-{
-  "name": "page quality",
-  "media_type": "image",
-  "weights": {"0.weight": [...], ...},
-  "threshold": 0.42,
-  "input_spec": {
-    "clipper": null
-  }
-}
-```
-
-Or for a detector trained on 2s audio clips:
-
-```json
-{
-  "name": "bird songs",
-  "media_type": "audio",
-  "weights": {"0.weight": [...], ...},
-  "threshold": 0.42,
-  "input_spec": {
-    "clipper": "sound_tiling_2s"
-  }
-}
-```
-
-At autodetect time, the pipeline reads the detector's `media_type` (for converter lookup) and `input_spec.clipper` (for clipping), then applies the right chain *per media item*. No CLI args needed. No settings duplication.
-
-## Recommended Design: Detector Input Spec
-
-### 1. Detector metadata gains `input_spec`
-
-Add one optional field to the detector data dict:
-
-| Field | Type | Meaning |
-|-------|------|---------|
-| `input_spec.clipper` | `str \| null` | Clipper name (e.g. `"sound_tiling_2s"`) used to split media into sub-clips before embedding. `null` means the default clipper (whole media). |
-
-The detector's existing `media_type` field already declares the target embedding space. **Converters are not stored on the detector**; the pipeline uses the converter registry (`list_converters_for_target(detector.media_type)`) to automatically find routes from any source type to the detector's target type. This means an image detector automatically handles video→image, document→image, and native images without enumerating converters.
-
-The `clipper` field describes what the detector *expects*, not a user preference. It's captured automatically at training time from whatever clipper the user had active.
-
-### 2. Training captures the input spec
-
-When `export_detector_server` trains a detector, record:
-- The active clipper (if the current dataset was loaded with clipping)
-
-The converter is NOT recorded; it's handled automatically by the registry at inference time. Only the clipper matters because it affects the granularity of the embeddings the detector was trained on.
-
-This is already implicit in the current training flow; the embeddings come from whatever pipeline produced the loaded medias. We just need to make the clipper explicit by storing its name.
-
-### 3. CLI autodetect pipeline applies input specs
-
-The `_run_pipeline` function gains a new step between "load dataset" and "score":
-
-```
-Load dataset (raw medias; may contain mixed types: video, document, image, etc.)
-  ↓
-For each detector:
-  ↓
-  Group medias by source type
-  ↓
-  For each source type:
-    Same as detector.media_type?
-      YES → use directly
-      NO  → look up converter via list_converters_for_target(detector.media_type)
-            filtered to source_type. If found, apply converter.
-            If no converter exists for this source type, skip these medias.
-  ↓
-  Does detector.input_spec.clipper exist?
-    YES → apply clipper to split converted medias into clips, embed each clip
-    NO  → use medias as-is (default clipper)
-  ↓
-  Score clips against detector
-  ↓
-  Merge clip-level scores back to media-level results
-```
-
-Key points:
-- Each detector can trigger a *different* clipper. The pipeline handles this per-detector, not globally.
-- Conversion is driven by the converter registry, not the detector. A single image detector automatically handles video files (via `video2image`), documents (via `document2image`), and native images; all in the same dataset.
-- If a media item's source type has no converter route to the detector's target type, it's simply skipped for that detector (not an error).
-
-### 4. Backwards compatibility
-
-- `input_spec` is optional. Detectors without it behave exactly as today: direct media-type match, no conversion, default clipper.
-- Existing detector JSON files continue to work unchanged.
-- The in-memory `autofind_detectors` dict gains the same optional `input_spec` key.
-
-### 5. Detector matching becomes richer
-
-Currently `get_autodetect_detectors_by_media("video")` only returns detectors with `media_type == "video"`. With converter-aware matching, a detector with `media_type: "audio"` should also match a video dataset, because `video2audio` exists in the converter registry.
-
-New matching logic:
-
-```python
-def get_autodetect_detectors_for_dataset(dataset_media_types: set[str]):
-    """Return detectors that can score any of the dataset's media types.
-
-    A detector matches if, for at least one source type in the dataset:
-    1. detector.media_type == source_type (direct match), OR
-    2. A registered converter exists with
-       source_type == source_type AND target_type == detector.media_type
-       (converter match)
-
-    This is driven entirely by the converter registry; the detector
-    doesn't need to know about converters. It just declares its
-    media_type, and the registry provides the routes.
-    """
-```
-
-For mixed-type datasets (e.g., videos + documents + images), the function accepts a set of source types and returns all detectors that can reach any of them. An image detector matches all three because `video2image` and `document2image` exist in the registry, plus native images match directly.
-
-### 6. Score aggregation for clipped media
-
-When a clipper produces N clips from one media item, we get N scores. We need a single per-media score for the results. Options:
-
-- **Max score** (default): media is positive if *any* clip scores above threshold. Good for "find the needle" use cases (e.g., any 2s segment of this video contains a bird song).
-- **Mean score**: average across clips. Good for "overall quality" use cases.
-- **Configurable**: store the aggregation method in `input_spec.clip_aggregation` (default `"max"`).
-
-### 7. What the CLI looks like
-
-For the common case, nothing changes:
-
-```bash
-# Dataset has videos; the pipeline auto-converts via video2audio, video2image, etc.
-# based on each detector's media_type. Clipper comes from detector's input_spec.
-python app.py --autodetect \
-  --importer http_archive --url https://example.com/videos.zip --media-type video \
-  --settings settings.json \
-  --exporter server_json_file --filepath results.json
-```
-
-The pipeline uses the converter registry to bridge source types to each detector's `media_type`, then applies the detector's `input_spec.clipper`. The user doesn't think about converters or clippers at the CLI level.
-
-For power users who want to override:
-
-```bash
-# Force a different clipper than what the detector was trained with
-python app.py --autodetect \
-  --dataset videos.pkl \
-  --override-clipper sound_tiling_5s \
-  --settings settings.json
-```
-
-This is a niche escape hatch, not the primary interface.
-
-## Summary
-
-| Question | Answer |
-|----------|--------|
-| Should we specify converters in the CLI? | No; the converter registry handles this automatically. The pipeline looks up all converters that produce the detector's `media_type` and applies the right one per source media type. |
-| Should we specify clippers in the CLI? | No; the detector's `input_spec.clipper` drives it automatically. Optional `--override-clipper` flag for power users. |
-| Should a detector remember its training converter? | No; converters are a property of the source→target type pair, not the detector. The same image detector handles video→image, document→image, and native images via the converter registry. |
-| Should a detector remember its training clipper? | Yes, as `input_spec.clipper`, describing what granularity the detector expects. This *is* the right default for autodetect. |
-| Should we have per-detector settings for converter/clipper? | No; clipper lives in the detector itself (travels with the file). Converter is automatic from the registry. |
-| Per-detector settings for EACH detector‽ | No. Clipper is per-detector via `input_spec`. Converter is per-source-type via registry. No settings explosion. |
-
-## ~~What shipped (Phase 1)~~
-
-All struck through:
-
-- ~~Detector JSON gained the optional `input_spec` field (`clipper` +
-  `clipper_params`); detectors without it behave as before.~~
-- ~~`save_detector_labels` captures the active dataset's clipper into `input_spec`
-  (clearing stale values on re-save from an unclipped dataset).~~
-- ~~`LabelSet` gained an optional `detector_meta` block (`media_type`, `input_spec`,
-  `threshold`) so a `LabelsetSource` round-trip keeps the training context; legacy
-  labelsets still load.~~
-- ~~`LabelsetSource.load_full()` (overridden by `server_json_file`, default wraps
-  legacy `load()`).~~
-- ~~`sync_to/from_labelset_source` emit/write `input_spec` + `media_type`
-  (threshold not persisted — receiver retrains).~~
-- ~~CLI `_load_and_train_detectors` skips detectors whose `input_spec.clipper`
-  mismatches the loaded dataset's clipper, with a reload hint.~~
+**Status:** Phase 1 shipped (detector `input_spec` + LabelSet `detector_meta`
+round-trip + CLI skip-on-mismatch). The converter-routing and re-clipping
+pipeline described below is **not yet implemented** — it is the open work.
+Open follow-ups first; the design that guides them, then shipped detail, below.
 
 ## Open follow-ups
 
-These were deliberately deferred to keep Phase 1 focused on the round-trip and the validation skip. They're listed here, not in any PR description, so they don't get lost when the PR closes.
+Deliberately deferred to keep Phase 1 focused on the round-trip and the
+validation skip.
 
-- **Converter routing across source types in CLI.** Today the CLI scores only the medias whose `media_type` already matches each detector's. The design above describes auto-routing via `list_converters_for_target(detector.media_type)` per source type (so one image detector handles native images, `video2image`, and `document2image` in the same run). Needs plumbing in `_run_pipeline`: group medias by source type → look up a converter route per detector → embed converted medias → score.
-- **Re-clipping the loaded dataset to match a detector's `input_spec.clipper`.** Today a mismatched detector is skipped with a message telling the user to reload. The more ergonomic flow is "auto-clip + re-embed at scoring time." Cheaper short-circuit: when first media's `origin.params.clipper` already equals the detector's, skip the work. Needs media bytes or a resolvable file path, so thin-loaded medias would have to go through `resolve_file_context` first.
-- **Converter-aware detector matching.** Replace direct `media_type` equality in `get_autodetect_detectors_by_media` with a `get_autodetect_detectors_for_dataset(source_types: set[str])` that accepts any detector reachable via a one-hop converter route. Required before the converter-routing item above is useful.
-- **`--override-clipper` CLI flag.** Power-user escape hatch to score with a different granularity than the detector was trained on. Not the primary interface; only worth shipping after the auto-clip path lands.
-- **Clip-score aggregation toggle.** When a clipper produces N clips per media, the aggregation is currently implicit (max). The design proposes an explicit `input_spec.clip_aggregation` (`"max"` | `"mean"`) field, useful once re-clipping is in place.
+- **Converter routing across source types in CLI.** Today the CLI scores only the
+  medias whose `media_type` already matches each detector's. The design below
+  auto-routes via `list_converters_for_target(detector.media_type)` per source
+  type (so one image detector handles native images, `video2image`, and
+  `document2image` in the same run). Needs plumbing in `_run_pipeline`: group
+  medias by source type → look up a converter route per detector → embed
+  converted medias → score.
+- **Re-clipping the loaded dataset to match a detector's `input_spec.clipper`.**
+  Today a mismatched detector is skipped with a message telling the user to
+  reload. The more ergonomic flow is "auto-clip + re-embed at scoring time."
+  Cheaper short-circuit: when first media's `origin.params.clipper` already equals
+  the detector's, skip the work. Needs media bytes or a resolvable file path, so
+  thin-loaded medias would have to go through `resolve_file_context` first.
+- **Converter-aware detector matching.** Replace direct `media_type` equality in
+  `get_autodetect_detectors_by_media` with a
+  `get_autodetect_detectors_for_dataset(source_types: set[str])` that accepts any
+  detector reachable via a one-hop converter route. Required before the
+  converter-routing item above is useful.
+- **`--override-clipper` CLI flag.** Power-user escape hatch to score with a
+  different granularity than the detector was trained on. Not the primary
+  interface; only worth shipping after the auto-clip path lands.
+- **Clip-score aggregation toggle.** When a clipper produces N clips per media,
+  the aggregation is currently implicit (max). The design proposes an explicit
+  `input_spec.clip_aggregation` (`"max"` | `"mean"`) field, useful once
+  re-clipping is in place.
+
+## Design guiding the open work
+
+### The problem the pipeline must solve
+
+A detector expects a specific *input format* (media type + clipper granularity),
+and the current pipeline (load → match by media type → score → export) can't
+reproduce that format at inference time. It breaks when a detector was trained on
+audio-extracted-from-video, on 2s clips, or on document page images but the new
+dataset is raw video / full-length audio / PDFs.
+
+### The detector stores its clipper, not its converter
+
+The detector already stores `media_type` (the target embedding space). The only
+missing piece is the **clipper**: how to split media before embedding, captured
+automatically at training time from the active clipper. Field:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `input_spec.clipper` | `str \| null` | Clipper used to split media into sub-clips before embedding. `null` = default (whole media). |
+
+**Converters are NOT stored on the detector.** A dataset can contain mixed source
+types, and the converter registry already knows every route
+(`list_converters_for_target(detector.media_type)`), so one image detector should
+score native images directly, videos via `video2image`, and documents via
+`document2image` without enumerating anything. Storing a single `converter` would
+break that. The detector just says "I need image embeddings"; the registry
+supplies the routes.
+
+### The pipeline step (open)
+
+`_run_pipeline` gains a step between "load dataset" and "score", per detector:
+
+```
+Group medias by source type
+  → for each source type: same as detector.media_type? use directly;
+    else look up a converter via list_converters_for_target(detector.media_type)
+    filtered to that source type — apply if found, skip these medias if not.
+  → detector.input_spec.clipper set? split converted medias into clips + embed each;
+    else use medias as-is.
+  → score clips, merge clip-level scores back to media-level results.
+```
+
+Each detector can trigger a *different* clipper (handled per-detector, not
+globally). A missing converter route is a skip, not an error.
+
+### Converter-aware matching (open)
+
+`get_autodetect_detectors_by_media("video")` currently returns only
+`media_type == "video"` detectors. It should become
+`get_autodetect_detectors_for_dataset(source_types: set[str])`: a detector
+matches if, for at least one source type, either `detector.media_type ==
+source_type` (direct) or a registered converter has that `source_type` →
+`detector.media_type` (converter route). Driven entirely by the registry.
+
+### Clip-score aggregation (open)
+
+A clipper yielding N clips gives N scores per media. Default **max** (positive if
+*any* clip clears threshold — "find the needle"); optional **mean** (overall
+quality) via `input_spec.clip_aggregation` (default `"max"`).
+
+### CLI surface
+
+For the common case nothing changes — the pipeline auto-converts per detector's
+`media_type` and clips per its `input_spec`. A niche `--override-clipper
+sound_tiling_5s` escape hatch forces a different granularity.
+
+## What shipped (Phase 1)
+
+- Detector JSON gained the optional `input_spec` field (`clipper` +
+  `clipper_params`); detectors without it behave as before.
+- `save_detector_labels` captures the active dataset's clipper into `input_spec`
+  (clearing stale values on re-save from an unclipped dataset).
+- `LabelSet` gained an optional `detector_meta` block (`media_type`, `input_spec`,
+  `threshold`) so a `LabelsetSource` round-trip keeps the training context; legacy
+  labelsets still load.
+- `LabelsetSource.load_full()` (overridden by `server_json_file`, default wraps
+  legacy `load()`).
+- `sync_to/from_labelset_source` emit/write `input_spec` + `media_type` (threshold
+  not persisted — receiver retrains).
+- CLI `_load_and_train_detectors` skips detectors whose `input_spec.clipper`
+  mismatches the loaded dataset's clipper, with a reload hint.

--- a/docs/plans/cli-stream-massive-images.md
+++ b/docs/plans/cli-stream-massive-images.md
@@ -1,18 +1,12 @@
 # CLI streaming for massive media sources
 
 **Status:** Phase 1 shipped (lazy enumeration + streaming export + per-chunk
-embed). See "What shipped" / "Open follow-ups" below.
+embed). Open follow-ups below; shipped work at the bottom.
 
 **Parent:** [`scalability.md`](scalability.md) — the brainstorm that defines the
 `S#` IDs. This plan implements the CLI-specific pieces (S15 enumeration, S20
 scoring, S13 export) needed to run `--autodetect` against a folder-of-folders
-holding far more images than fit in RAM.
-
-## Problem
-
-The use case: a saved detector (e.g. a "bomb" detector trained on 50 positive +
-50 negative example images, stored as a `LabelSet`) is applied to a folder tree
-holding billions of images via:
+holding far more images than fit in RAM, e.g.:
 
 ```
 python app.py --autodetect --importer server_folder --path /data/images \
@@ -20,49 +14,31 @@ python app.py --autodetect --importer server_folder --path /data/images \
   --exporter server_json_file --filepath hits.ndjson --settings settings.json
 ```
 
-The chunked CLI already streamed *loading* and *embedding* one chunk at a time,
-but three pieces still grew `O(N)` with the total image count and broke before a
-billion:
-
-1. **File enumeration** — `load_dataset_from_folder_chunked` materialised the
-   entire file list (`media_files: list[Path]`) before yielding any chunk
-   (`loader_folder.py`). Billions of `Path` objects = tens of GB, and nothing
-   processed until the whole `os.walk` finished.
-2. **Hit accumulation** — `_merge_detector_results` extended and **re-sorted**
-   the full accumulated hit list after every chunk (`cli.py`), `O(N)` RAM plus
-   repeated `O(N log N)` sorts.
-3. **Export** — exporters buffered the entire result dict in RAM before writing.
-
-A latent fourth issue: the CLI scoring path never called `embed_missing`, so
-folder chunks (which arrive with `embedding=None`) would raise `ValueError` at
-scoring time. Only pre-embedded sources (pickles) worked.
-
-## ~~What shipped (Phase 1)~~
-
-All struck through:
-
-- ~~**1. Lazy file enumeration (wall #1).**~~ Generator twins
-  `iter_rglob_follow_symlinks` / `iter_glob_top_level` in `path_validation.py`;
-  `load_dataset_from_folder_chunked` streams via `_iter_media_files` (no full
-  list) in the common CLI case; media type still validated eagerly.
-- ~~**2. Per-chunk embed (latent bug).**~~ `_score_medias_with_detectors` now
-  calls idempotent `embed_missing` and drops still-`None` items before scoring,
-  so folder → autodetect embeds and scores.
-- ~~**3. Streaming export (walls #2 + #3).**~~ Opt-in `--stream-results`
-  (`_run_streaming_pipeline`) streams each chunk's above-threshold hits with no
-  global accumulation/sort (`--keep-negatives` to re-include); exporters opt in
-  via `supports_streaming` + `export_cli_streaming` (`server_json_file` NDJSON,
-  `server_csv_file` append, `gui` print); `email_smtp`/`webhook` reject
-  streaming. **Accepted tradeoff:** output is chunk-ordered, not globally sorted.
-
 ## Open follow-ups
 
 - **Global ordering for streamed results.** External merge-sort of the NDJSON,
   or a bounded top-K heap mode (`--max-results N`) that keeps the best N hits
-  globally sorted at `O(K)` RAM.
+  globally sorted at `O(K)` RAM. (Streamed output is currently chunk-ordered —
+  an accepted Phase 1 tradeoff.)
 - **Non-streaming merge path still re-sorts per chunk** (`_merge_detector_results`).
   Left as-is because that path already holds all hits in RAM by design; switch
   it to sort-once if it ever matters.
-- **Streaming for `email_smtp` / `webhook`** via chunked/batched delivery.
+- **Streaming for `email_smtp` / `webhook`** via chunked/batched delivery
+  (both reject streaming today).
 - **Resume / checkpoint** for multi-hour billion-image runs (record the last
   completed chunk so an interrupted run can restart mid-tree).
+
+## What shipped
+
+- **Lazy file enumeration** — generator twins `iter_rglob_follow_symlinks` /
+  `iter_glob_top_level` in `path_validation.py`; `load_dataset_from_folder_chunked`
+  streams via `_iter_media_files` (no full `list[Path]`), media type still
+  validated eagerly.
+- **Per-chunk embed** — `_score_medias_with_detectors` calls idempotent
+  `embed_missing` and drops still-`None` items before scoring, fixing the latent
+  bug where folder chunks (`embedding=None`) raised `ValueError`.
+- **Streaming export** — opt-in `--stream-results` (`_run_streaming_pipeline`)
+  streams each chunk's above-threshold hits with no global accumulation/sort
+  (`--keep-negatives` to re-include); exporters opt in via `supports_streaming`
+  + `export_cli_streaming` (`server_json_file` NDJSON, `server_csv_file` append,
+  `gui` print); `email_smtp`/`webhook` reject streaming.

--- a/docs/plans/clipper-chain.md
+++ b/docs/plans/clipper-chain.md
@@ -1,201 +1,8 @@
 # Clipper chain
 
-*Status: Phase 1 shipped. The dataset-load pipeline accepts an ordered
-list of converter/clipper steps via a new `clipper_chain` field, stamps
-the resolved trail on every clip's `origin.params`, and the cross-dataset
-resolver replays the chain end-to-end. Phases 2-4 (frontend chooser,
-sidecar JSON, detector `input_spec` migration) are deferred (see Open
-follow-ups).*
+**Status:** Phase 1 shipped (backend chain runner + origin encoding + resolver replay); demo-dataset GUI clipping also shipped. **Phases 2–4 (frontend chooser, sidecar/registry schema, detector `input_spec` migration) are deferred** — they are the remaining work and lead this doc. Shipped detail is collapsed under "What shipped".
 
-This plan implements a `clipper_chain` abstraction so we can run e.g.
-`document_section → text_token_window` without writing a custom clipper.
-
-## Problem
-
-Today the dataset-load pipeline runs **exactly one** `MediaClipper` per
-import. Real use cases want composition:
-
-- **`document_section → text_token_window`**: split a PDF/ePub into
-  chapters, then split each chapter into token-bounded windows. Today
-  the only ways to do this are (a) write a one-off custom clipper that
-  hard-codes both algorithms, or (b) load the dataset twice with two
-  different settings, which loses the chapter→window provenance.
-- **`image_object → image_window`**: detect objects in an image, then
-  sliding-window each detection. Same shape, same workaround tax.
-- **`sound_speech_activity → sound_tiling`**: VAD to find speech turns,
-  then tile each turn. Same.
-
-The headline case is cross-type composition (document → text). That
-can't be expressed by chaining
-`MediaClipper`s alone (a `MediaClipper` produces output of the same
-media type by contract). It needs a `MediaConverter` step (the existing
-`Document2TextMediaConverter` already does document → text).
-
-So a "clipper chain" is really a generalised **transform chain**: an
-ordered list of `converter` and `clipper` steps. Each step's input type
-must match the previous step's output type (or, for step 0, the source
-media type). The final step's output type becomes the dataset's media
-type.
-
-## Why Option C (converter + clipper steps) over the alternatives
-
-Three approaches were considered when scoping this work:
-
-| Option | Sketch | Cross-type? | Blast radius |
-|--------|--------|-------------|--------------|
-| A | `ChainedClipper(steps=[c1, c2, ...])`, same `media_type` end-to-end | No | Tiny |
-| B | Add `output_media_type` to `MediaClipper`; allow type-changing clippers | Yes (clippers cross types) | Medium |
-| C | Ordered list of `converter | clipper` steps | Yes (converters cross types) | Large |
-
-Option C was chosen because:
-
-- The headline example is **literally** `document → text`, which is
-  what `MediaConverter` already exists for. Forcing the same capability
-  into clippers (Option B) duplicates the converter family rather than
-  reusing it.
-- `MediaConverter` already round-trips through `MediaType.load_media_data`
-  and produces clean output dicts. We get cross-type composition for
-  free.
-- The runner and origin encoding are media-type-agnostic, which lets
-  new converters and clippers plug in without touching the pipeline.
-
-The cost is breadth: origin schema, importer field schema, sidecars,
-frontend chooser, detector `input_spec`, and `detector_meta` all carry
-single-clipper state today. We rolled the change out in phases below.
-
-## Design
-
-### Step list
-
-A chain is an ordered list of step dicts. Each step has the same shape:
-
-```json
-[
-  {"kind": "converter", "name": "document2text", "params": {}},
-  {"kind": "clipper",   "name": "text_token_window", "params": {"window": 512, "overlap": 64}}
-]
-```
-
-- `kind`: `"converter"` or `"clipper"`.
-- `name`: the plugin's registered name (`MediaConverter.name` or
-  `MediaClipper.name`).
-- `params`: kwargs passed to `with_params()` (clippers) or `convert()`
-  (converters). Empty dict allowed.
-
-A single-clipper load is equivalent to a length-1 chain:
-
-```json
-[{"kind": "clipper", "name": "sound_tiling", "params": {"duration": 2.0}}]
-```
-
-Phase 1 builds this internally so the legacy `clipper_name + clipper_params`
-import field still works; there is no migration cost for existing
-importers.
-
-### Validation rules
-
-Implemented in `vtscore/datasets/clipper_chain.py:validate_chain`:
-
-1. Every step resolves in its respective registry (`get_clipper` /
-   `get_converter`). Unknown names raise `ValueError`.
-2. Step 0's input type must match the dataset's source media type.
-3. Step *i*'s input type must equal step *(i−1)*'s output type.
-4. The chain may be empty (no-op) or contain any positive number of
-   steps. Pure `*_default` clipper-only chains are normalised to empty.
-
-The function returns the final output media type so the load pipeline
-can record the right `media_type` on the dataset registry entry.
-
-### Origin encoding (new)
-
-Each final clip gets, in addition to the existing single-clipper stamp:
-
-- `params["clipper_chain"]`: a JSON-encoded string containing the full
-  resolved trail. Each entry is:
-  ```json
-  {
-    "kind": "converter" | "clipper",
-    "name": "document2text",
-    "params": {"...": "..."},
-    "out_index": 0,
-    "clip_start": "...",   // when applicable
-    "clip_end":   "...",   // when applicable
-    "clip_box":   "x,y,w,h" // when applicable
-  }
-  ```
-  `out_index` is the index into the step's output list that this clip
-  descends from. The boundary fields are populated from the step
-  output's own `clip_start`/`clip_end`/`clip_box`/`clip_index`, so the
-  resolver can re-select the same sub-clip when replaying on a fresh
-  dataset.
-
-- For backwards compatibility, the **last clipper step** in the chain
-  also writes the legacy `params["clipper"]`, `params["clipper_<key>"]`,
-  `params["clip_start"]`, `params["clip_end"]`, `params["clip_box"]`,
-  `params["clip_index"]` keys exactly as before. This keeps existing
-  readers (`extract_input_spec_from_medias`, the legacy
-  `_apply_clip_and_embed` branch, the dataset registry's `clipper`
-  field, the `_write_clipper_sidecar` writer) working unmodified.
-  These keys describe only the last clipper step; the full chain lives
-  in `clipper_chain`.
-
-### Resolver replay
-
-`vtscore/detectors/resolver.py:_apply_clip_and_embed` is the
-cross-dataset replay path: given a resolved file and a label's origin,
-re-derive the embedding by re-applying whatever clipping the original
-dataset did.
-
-Phase 1 adds a chain-aware branch that runs **before** the legacy
-single-clipper branches. When `params["clipper_chain"]` is present, the
-resolver:
-
-1. Loads the source file into a media dict
-   (`media_bytes`/`media_string`) keyed by the source media type
-   inferred from the chain's first step.
-2. For each step, runs `convert()` or `clip()` and selects the matching
-   sub-output by `out_index` (or by `clip_start/end/box/index` fallback).
-3. Writes the final media's bytes/string to a tempfile of the
-   appropriate extension and calls `embed_file` with the final media
-   type and the dataset's embedder.
-
-If the chain entry is missing or malformed, the resolver falls through
-to the legacy single-clipper code path; labels imported from
-pre-chain datasets keep working.
-
-## ~~Phase 1: Backend chain runner + origin encoding + resolver replay (shipped)~~
-
-Shipped — struck through. The design above (step list, validation, origin
-encoding, resolver replay) is the spec for what landed:
-
-- ~~**New** `vtscore/datasets/clipper_chain.py`~~ — `ChainStep`,
-  `validate_chain`, `apply_chain_to_clips` (stamps `params["clipper_chain"]` +
-  legacy last-clipper keys), `replay_chain_on_file`.
-- ~~**Modified** `load_pipeline.py`~~ — `_apply_clipper` + the background loaders
-  accept/forward `chain_steps` (importer `clipper_chain` JSON parsed through).
-- ~~**Modified** `resolver.py`~~ — `_apply_clip_and_embed` replays the chain when
-  `params["clipper_chain"]` is present.
-- ~~**Tests** `tests/detectors/test_clipper_chain.py`~~ — same-type chain
-  end-to-end, single-step regression guard, validation errors.
-
-### Limitations of Phase 1
-
-- **No frontend**: the importer modal still only lets the user pick
-  one clipper. To exercise a chain in Phase 1, callers pass a
-  `clipper_chain` JSON field through the importer field values
-  programmatically (CLI, test, scripted client).
-- **No sidecar JSON / dataset registry chain column**: the registry's
-  `clipper` column still records only the last clipper's name. The
-  pickle sidecar (`_write_clipper_sidecar`) still writes a single
-  clipper name. Replay relies on per-clip origin only; the registry
-  fields are informational.
-- **Detector `input_spec` stays single-step**: `extract_input_spec_from_medias`
-  reads the legacy `params["clipper"]` keys, so the spec describes the
-  last clipper step only. A detector trained on a chained dataset still
-  records the last step as its expected granularity; the chain is not
-  reflected in `detector_meta`. This is enough for re-embedding labels
-  (resolver replay handles the full chain), but the spec mismatch check
-  at autodetect time is coarser than it could be.
+The feature is a generalised **transform chain**: an ordered list of `converter` and `clipper` steps (e.g. `document_section → text_token_window`) so cross-type composition works without a custom clipper. Each step's input type must match the previous step's output type (step 0 matches the source media type); the final step's output type becomes the dataset's media type. Option C (converter + clipper steps) was chosen over a same-type `ChainedClipper` (A) or type-changing clippers (B) because the headline case is literally `document → text`, which `MediaConverter` already does — reusing the converter family rather than duplicating it into clippers.
 
 ## Phase 2: Frontend chain chooser (deferred)
 
@@ -272,21 +79,6 @@ unless the consumer reads `clipper_chain`. Phase 4 will replace the
 legacy keys; for Phase 1 this is acceptable because the resolver uses
 the JSON trail.
 
-## Demo-dataset clipping (GUI) — shipped
-
-The demo importer already exposed a clipper "Details" button in the picker,
-but `load_demo_dataset` only recorded the chosen clipper name in the pickle
-meta and never applied it. It now runs the selected clipper (with params) at
-load time via the shared `_apply_clipper` machinery, so clips inherit their
-parent's category and are re-embedded with the demo's embedder. The demo path
-sends `clipper` + `clipper_params` only when the pick is a real (non-default)
-clipper — `_effective_clipper` (backend) and `effectiveDemoClipper()`
-(frontend) share the "default = empty / `*_default` / first-in-list" rule so
-the pre-selected default stays a no-op. The single per-dataset pickle records
-the effective clipper + params; a later load with a different clipper/params
-rebuilds it. Motivating case: the long-form `tut_sound_events_2017_*` demos,
-which are meant to be cut by hand.
-
 ### Open follow-ups (demo clipping)
 
 - **Params-blind status.** `GET /api/dataset/demo-list` only receives the
@@ -305,3 +97,16 @@ which are meant to be cut by hand.
   pickle); re-deriving a single clip purely from its origin would not re-clip.
 - **Multi-embedder trio.** When the create-time embedder trio is used, clip
   re-embedding uses the primary embedder only.
+
+## Design reference (encoding the deferred phases build on)
+
+A chain is an ordered list of step dicts, each `{"kind": "converter"|"clipper", "name": ..., "params": {...}}`. A single-clipper load is a length-1 chain; pure `*_default` clipper-only chains normalise to empty. `validate_chain` (`vtscore/datasets/clipper_chain.py`) resolves every step in its registry, enforces step-0 input = source type and step *i* input = step *(i−1)* output, and returns the final output media type.
+
+**Origin encoding.** Each final clip gets `params["clipper_chain"]`: a JSON-encoded resolved trail, one entry per step (`kind`, `name`, `params`, `out_index`, and `clip_start`/`clip_end`/`clip_box` when applicable). `out_index` + the boundary fields let the resolver re-select the same sub-clip on a fresh dataset. For backwards compatibility the **last clipper step** also writes the legacy `params["clipper"]`, `params["clipper_<key>"]`, `clip_start/end/box/index` keys unchanged, so existing readers (`extract_input_spec_from_medias`, the legacy `_apply_clip_and_embed` branch, the registry `clipper` field, `_write_clipper_sidecar`) keep working — these describe only the last step; the full chain lives in `clipper_chain`.
+
+**Resolver replay.** When `params["clipper_chain"]` is present, `resolver.py:_apply_clip_and_embed` loads the source file, runs each step's `convert()`/`clip()` selecting the matching sub-output by `out_index` (fallback to `clip_start/end/box/index`), writes the final media to a tempfile, and calls `embed_file` with the final media type. Missing/malformed chain → falls through to the legacy single-clipper path, so pre-chain labels keep working.
+
+## What shipped
+
+- **Phase 1 — backend chain runner + origin encoding + resolver replay.** New `vtscore/datasets/clipper_chain.py` (`ChainStep`, `validate_chain`, `apply_chain_to_clips` stamping `clipper_chain` + legacy last-clipper keys, `replay_chain_on_file`). `load_pipeline.py` `_apply_clipper` + background loaders accept/forward `chain_steps` (importer `clipper_chain` JSON parsed through). `resolver.py` `_apply_clip_and_embed` replays the chain when present. Tests `tests/detectors/test_clipper_chain.py`. Limitations: no frontend (callers pass `clipper_chain` JSON programmatically), no sidecar/registry chain column (registry/pickle record only the last clipper name), detector `input_spec` still single-step (`extract_input_spec_from_medias` reads the legacy keys).
+- **Demo-dataset clipping (GUI).** `load_demo_dataset` now applies the chosen clipper (with params) at load time via the shared `_apply_clipper` machinery (clips inherit parent category, re-embedded with the demo's embedder). `_effective_clipper` (backend) / `effectiveDemoClipper()` (frontend) share the "default = empty / `*_default` / first-in-list = no-op" rule; only a real non-default pick sends `clipper` + `clipper_params`. One pickle per dataset records the effective clipper + params; a different pick rebuilds. Motivating case: the long-form `tut_sound_events_2017_*` demos.

--- a/docs/plans/code-structure-review.md
+++ b/docs/plans/code-structure-review.md
@@ -1,129 +1,34 @@
 # Code-structure review
 
-**Status:** A systematic, repo-wide structural review. Already shipped:
-**Theme A** in full (the `vtscore` ↔ `vtsearch` boundary — fat-controller
-extractions, `workflow.py` de-coupling, training-pipeline merge,
-inverse-leak sweep), **Theme C quick wins** (the `_ClapBase` mixin and the
-settings dispatch-table generation + drift guard), **Theme E quick
-wins** (the "shim" rename and the `labelset_ops` facade), and several
-**Theme B** mega-file splits (the `settings.py` engine extraction into
-`UserSettingsStore`; the `load_pipeline.py` stage extraction; the `app.py`
-CLI + port-preflight extraction; and the `importers/base.py` split into a
-`base/` package with a thin `ImporterBase` and the rich `DatasetImporter` —
-see the Theme B section), and the **Theme F `PluginField` alias collapse**
-(the seven per-family `*Field` aliases removed; see Theme F). For the
-details of what landed, see the git history / merged PRs on `dev`.
-**Everything below is the remaining planned work.**
+**Status:** A systematic, repo-wide structural review. Theme A (the `vtscore` ↔ `vtsearch` boundary) is fully shipped, along with several Theme B mega-file splits and the Theme C/E/F quick wins — all collapsed under "What shipped" at the bottom. **The still-open work (Themes B/C/D/E/F and the prioritized backlog) is the point of this doc and leads below.**
 
-This review asks: where have design decisions that were right at small scale
-been outgrown, and what is worth streamlining, abstracting, or reorganizing?
-The codebase is healthy and unusually well-documented; the findings below are
-**accretion** problems (modules that started focused and absorbed adjacent
-responsibilities), not rot. Nothing here is urgent. Themes are ordered by
-leverage-to-effort.
+This review asks: where have design decisions that were right at small scale been outgrown, and what is worth streamlining, abstracting, or reorganizing? The codebase is healthy and unusually well-documented; the findings are **accretion** problems (modules that started focused and absorbed adjacent responsibilities), not rot. Nothing here is urgent. Themes are ordered by leverage-to-effort.
+
+## Prioritized backlog (remaining)
+
+1. **Theme B remaining** — `DetectorContext` sub-context split (item under Theme B; ~346 call sites, do opportunistically) and the two frontend components (`dataset-importer-modal`, `browse-canvas`). Plus the `app.py` hooks/errors split and the `settings.py` lazy-migration-to-script, both left as scoped open follow-ups (see Theme B).
+2. **Theme D** — converge frontend types onto the generated client.
+3. **Theme E** — `MediaSource` / `DatasetImporter` ingestion-concept overlap.
+4. **Theme F** — revisit `SyncSource` if a third consumer appears; the `loader.py` façade.
+5. **Theme C remaining** — state-proxy registry table; image single/patch base; downloaders base.
+6. **Theme A (optional)** — convert the remaining lazy `vtsearch.auth` / `vtsearch.achievements` / `vtsearch.logging_config` / `vtsearch.routes._shared` reaches in `vtscore/` to injected registration hooks (the pattern already used for `register_setting_persister` / `register_core_config_builder`), making `vtscore/` import-clean of `vtsearch` entirely. Correct as lazy imports today; do this if/when the library tier is actually extracted.
 
 ---
 
-## Theme B — Mega-files mixing unrelated concerns
+## Theme B — Mega-files mixing unrelated concerns (remaining)
 
-The common shape: a module that started focused and absorbed adjacent
-responsibilities.
+The done mega-file splits (`app.py`, `settings.py`, `load_pipeline.py`, `importers/base.py`) are under "What shipped". Still open:
 
-- **`app.py`** — **DONE (CLI + port-preflight extraction).** The `__main__`
-  argparse block + autodetect dispatch moved to `vtsearch/cli_main.py` (its
-  `main(app, initialize_server)` is called from a three-line `__main__` in
-  `app.py`; `app` and `initialize_server` are passed in rather than imported
-  to avoid re-executing `app.py` under a second module name). The Linux
-  `/proc` port-preflight helpers + single-instance lock moved to
-  `vtsearch/port_preflight.py` (named for precision rather than the plan's
-  earlier `vtsearch/app/server.py`, which would have collided with the
-  top-level `app` module). `cli_main.main` is itself decomposed into
-  `_build_parser` + per-concern helpers (`_maybe_list_plugins`,
-  `_maybe_run_pipeline`, `_resolve_plugins`, the `_apply_*` override
-  appliers, `_run_autodetect` → `_authenticate_cli_user` /
-  `_maybe_import_labels` / `_dispatch_autodetect`, and `_run_server`) so each
-  stays under the McCabe gate. `app.py` (down from 1462 → ~630 lines) keeps
-  the WSGI `app` object, the request lifecycle hooks, the JSON error
-  handlers, blueprint registration, and `initialize_server`.
-  **Open follow-up:** the request-lifecycle hooks (`before_request` /
-  `after_request` / `teardown_request`) and the global JSON error handlers
-  are still inline in `app.py`. They *are* part of the `app` object's
-  lifecycle (unlike the CLI/preflight code, which is unrelated to it), so
-  the leverage of extracting them to `hooks.py` + `errors.py` is lower and
-  the risk (decorator-registration ordering) is higher; left for a scoped
-  follow-up.
-- **`vtsearch/settings.py`** — **DONE (engine extraction).** The
-  lock-ordering-sensitive engine (cross-process file locking, the two-tier
-  server/per-user caches, the one-shot legacy migration, and the
-  bidirectional sync state-machine) now lives in
-  `vtsearch/settings_store.py` as `UserSettingsStore`; `settings.py` (down
-  from 1935 → ~1410 lines) keeps the schema/policy layer (Pydantic-driven
-  accessor generation, tier routing, CLI fallbacks, effective-value
-  resolvers) and delegates engine work to a module-level store instance.
-  The shared mutable containers (`_settings_lock`, `_user_caches`,
-  `_sync_state`, `_syncing`) stay as module globals and are passed *by
-  reference* into the store so external importers (`vtsearch.achievements`,
-  the sync-source tests) and the store mutate one set of objects.
-  **Open follow-up:** the legacy-migration path is still lazy (runs from
-  `UserSettingsStore.ensure_server_loaded` on first server load) rather than
-  a one-shot admin script — left as-is deliberately because the lazy
-  trigger is what the default-user read-through and the CLI `--settings`
-  flat-file flow rely on; moving it to a script is a behavior change worth
-  its own scoped task, not a free win.
-- **`vtscore/datasets/load_pipeline.py`** — **DONE (stage extraction).**
-  `ConcurrencyGate` moved to `vtscore/concurrency/gate.py` (generic
-  dynamic-limit semaphore primitive). The six post-import concerns were
-  split into a `vtscore/datasets/stages/` package: `_common.py` (shared
-  `_TOTAL_LOAD_STEPS`/`_STATUS_TO_STEP` + `_origin_to_str`), `clipper.py`
-  (clipper/converter chain + per-clip MD5/embedding/thumbnail fixup),
-  `embedding.py` (embed-missing + patch regions), `finalize.py` (drop-none /
-  collapse-duplicates / diversity-tree), `projection.py` (opt-in 2-D UMAP
-  build + persist), and `registry.py` (auto-register + context-id
-  migration). `load_pipeline.py` (down from 1592 → ~640 lines) keeps the
-  background-thread orchestration (gate handoff via `_LoadGateController`,
-  importer invocation, stage sequencing, failure handling, staging flow)
-  plus the request-field parsing helpers (`_parse_bool` /
-  `_parse_chain_field` / `_normalize_media_type` / `auto_chunk_size`). The
-  dependency DAG is one-way (orchestrator → stages → `stages/_common`); no
-  stage imports `load_pipeline`, so there is no import cycle.
-- **`vtscore/datasets/importers/base.py`** — **DONE (thin/rich class
-  split).** The single 1203-line `base.py` module became a `base/` package:
-  `core.py` (`ImporterBase`, the thin base every importer shares — metadata,
-  dataset-name resolution, origin building, CLI wrapping, chunked-loading
-  scaffolding, the precomputed embedding/MD5/metadata dicts, and the origin
-  reload/display/resolve surface, plus an abstract `run()` that raises);
-  `dataset_importer.py` (`DatasetImporter(ImporterBase)`, which layers the
-  source-spec → converter → ingestion pipeline and the `list_records` /
-  `fetch_record` per-record hooks on top); `specs.py` (`SourceSpec` + the
-  spec-parsing / converter-ingestion helpers); and `origin.py`
-  (origin-serialisation policy helpers + the synthetic dataset-name field).
-  Rather than the plan's literal `MultiMediaImporter` rename, `DatasetImporter`
-  was **kept as the rich/public base** (identical name, module path, and full
-  method set) so the 3 spec-aware folder importers, `recaller`, and all ~25
-  test subclasses are unchanged, and **out-of-repo extension importers keep
-  working with zero rewrites** (the chosen constraint — see the option
-  analysis in the session that shipped this). The 6 truly-thin importers
-  (`synthetic`, `pickle`, `local_files`, `combine_datasets`, `demo`,
-  `local_folder`) moved onto `ImporterBase`, so they no longer inherit the
-  machinery they never used. Discovery is unaffected (the registry keys off
-  the `IMPORTER` sentinel + `.name`, never `isinstance`).
-- **`vtscore/state/core.py` — `DetectorContext` (31 fields).** A god-object
-  spanning vote state, training artifacts, cached embeddings, and
-  Find-session state. Splitting into `VoteState` / `TrainingState` /
-  `FindSessionState` is the right shape but touches ~346 call sites —
-  expensive; defer until already in that code.
-- **Frontend:** `dataset-importer-modal.component.ts` (2162; 17 state slices
-  + HTTP + 5 picker views) and `browse-canvas.component.ts` (1881; ~200 lines
-  of pure pan/zoom/clamp/rubber-band geometry that should be a framework-free
-  `ViewTransformService`).
+- **`app.py` hooks/errors (open follow-up on the shipped CLI split).** The request-lifecycle hooks (`before_request` / `after_request` / `teardown_request`) and the global JSON error handlers are still inline in `app.py`. They *are* part of the `app` object's lifecycle (unlike the CLI/preflight code that was extracted), so the leverage of moving them to `hooks.py` + `errors.py` is lower and the risk (decorator-registration ordering) higher; left for a scoped follow-up.
+- **`settings.py` lazy migration (open follow-up on the shipped engine split).** The legacy-migration path is still lazy (runs from `UserSettingsStore.ensure_server_loaded` on first server load) rather than a one-shot admin script — left as-is deliberately because the lazy trigger is what the default-user read-through and the CLI `--settings` flat-file flow rely on; moving it to a script is a behavior change worth its own scoped task.
+- **`vtscore/state/core.py` — `DetectorContext` (31 fields).** A god-object spanning vote state, training artifacts, cached embeddings, and Find-session state. Splitting into `VoteState` / `TrainingState` / `FindSessionState` is the right shape but touches ~346 call sites — expensive; defer until already in that code.
+- **Frontend:** `dataset-importer-modal.component.ts` (2162; 17 state slices + HTTP + 5 picker views) and `browse-canvas.component.ts` (1881; ~200 lines of pure pan/zoom/clamp/rubber-band geometry that should be a framework-free `ViewTransformService`).
 
 ---
 
-## Theme C — Repetitive boilerplate a declarative/table-driven approach collapses
+## Theme C — Repetitive boilerplate a declarative/table-driven approach collapses (remaining)
 
-Recurring smell: the **same fact declared in N parallel places**, kept in
-sync by hand. (The CLAP-embedder and settings-dispatch instances shipped; the
-remaining instances below are still open.)
+Recurring smell: the **same fact declared in N parallel places**, kept in sync by hand. (The CLAP-embedder `_ClapBase` mixin and the settings dispatch-table generation shipped; the rest are open.)
 
 - **State proxies.** 7 copy-paste `_ProxyDict` / `_ProxyList` declarations in
   `vtsearch/state_proxies.py` could be built from a registry table.
@@ -137,7 +42,7 @@ remaining instances below are still open.)
 
 ---
 
-## Theme D — Schema/type drift across boundaries
+## Theme D — Schema/type drift across boundaries (open)
 
 The same data shapes are independently redeclared in up to four type
 systems with nothing enforcing agreement:
@@ -157,10 +62,9 @@ risk warrants.
 
 ---
 
-## Theme E — Naming / conceptual overlaps that mislead readers
+## Theme E — Naming / conceptual overlaps that mislead readers (remaining)
 
-(The "shim" rename and the `labelset_ops` facade shipped; the remaining bullet
-below is still open.)
+(The "shim" rename and the `labelset_ops` facade shipped; this bullet is open.)
 
 - **Three overlapping ingestion concepts:** `MediaSource`,
   `DatasetImporter`, and the bare loader functions all mean "get media in,"
@@ -171,18 +75,13 @@ below is still open.)
 
 ---
 
-## Theme F — Abstractions that aren't paying for themselves
+## Theme F — Abstractions that aren't paying for themselves (remaining)
+
+(The `PluginField` alias collapse shipped; these two are open.)
 
 - **`SyncSource[LoadT, SaveT]`** (`vtscore/sync/`) has two subclasses, each
   with one concrete implementation. Don't add more indirection here until a
   third consumer appears.
-- ~~**`PluginField` aliases.** Six no-op aliases (`ImporterField = PluginField`
-  …) imply field types differ per family. Collapse to `PluginField`.~~
-  **Shipped.** Removed all seven per-family aliases (`ImporterField`,
-  `ExporterField`, `LabelImporterField`, `LabelsetSourceField`,
-  `SettingsSourceField`, `SettingsImporterField`, `SettingsExporterField`);
-  every plugin/test now uses `PluginField` directly, re-exported from each
-  family's base module. Docs updated to match.
 - **`loader.py` façade** re-exports its three sibling loaders without adding
   abstraction.
 
@@ -200,26 +99,15 @@ rename every plugin family's `run()`/`export()`/`load()` to a uniform
 
 ---
 
-## Prioritized backlog (remaining)
+## What shipped
 
-1. **Theme B** — `importers/base.py` thin/rich split **shipped** (see the
-   Theme B bullet above). `settings.py` engine extraction, `load_pipeline.py`
-   stage extraction, and the `app.py` CLI + port-preflight extraction also
-   shipped. `app.py`'s hooks/errors split remains an open follow-up there.
-   Remaining Theme B mega-files: `DetectorContext` sub-context split (item 6
-   below) and the two frontend components.
-2. **Theme D** — converge frontend types onto the generated client.
-3. **Theme E** — `MediaSource` / `DatasetImporter` ingestion-concept overlap.
-4. **Theme F** — ~~collapse `PluginField` aliases~~ (shipped); revisit
-   `SyncSource` if a third consumer appears.
-5. **Theme C remaining** — state-proxy registry table; image single/patch
-   base; downloaders base.
-6. **Theme B (deferred)** — `DetectorContext` sub-context split (~346 call
-   sites; do opportunistically).
-7. **Theme A (optional)** — convert the remaining lazy `vtsearch.auth` /
-   `vtsearch.achievements` / `vtsearch.logging_config` /
-   `vtsearch.routes._shared` reaches in `vtscore/` to injected registration
-   hooks (the pattern already used for `register_setting_persister` /
-   `register_core_config_builder`), making `vtscore/` import-clean of
-   `vtsearch` entirely. They are correct as lazy imports today; do this
-   if/when the library tier is actually extracted.
+For full detail, see the git history / merged PRs on `dev`.
+
+- **Theme A (full)** — the `vtscore` ↔ `vtsearch` boundary: fat-controller extractions, `workflow.py` de-coupling, training-pipeline merge, inverse-leak sweep.
+- **Theme B — `app.py` CLI + port-preflight extraction.** `__main__` argparse + autodetect dispatch → `vtsearch/cli_main.py` (`main(app, initialize_server)`, decomposed into `_build_parser` + per-concern helpers under the McCabe gate); Linux `/proc` port-preflight + single-instance lock → `vtsearch/port_preflight.py`. `app.py` down 1462 → ~630 lines, keeps the WSGI `app`, lifecycle hooks, error handlers, blueprint registration, `initialize_server`.
+- **Theme B — `settings.py` engine extraction.** Lock-ordering-sensitive engine (cross-process locking, two-tier caches, legacy migration, bidirectional sync state-machine) → `vtsearch/settings_store.py` `UserSettingsStore`; `settings.py` down 1935 → ~1410 lines, keeps the schema/policy layer. Shared mutable containers passed by reference so external importers and the store mutate one set of objects.
+- **Theme B — `load_pipeline.py` stage extraction.** `ConcurrencyGate` → `vtscore/concurrency/gate.py`; six post-import concerns → `vtscore/datasets/stages/` (`_common`, `clipper`, `embedding`, `finalize`, `projection`, `registry`). `load_pipeline.py` down 1592 → ~640 lines, keeps orchestration + field parsing; one-way DAG, no import cycle.
+- **Theme B — `importers/base.py` thin/rich split.** 1203-line module → `base/` package: `core.py` (`ImporterBase`, the thin shared base), `dataset_importer.py` (`DatasetImporter(ImporterBase)`, the rich/public base — kept at the identical name/path so the 3 spec-aware importers, `recaller`, ~25 test subclasses, and out-of-repo extensions are unchanged), `specs.py`, `origin.py`. The 6 truly-thin importers moved onto `ImporterBase`.
+- **Theme C quick wins** — the `_ClapBase` CLAP-embedder mixin and the settings dispatch-table generation + drift guard.
+- **Theme E quick wins** — the "shim" rename and the `labelset_ops` facade.
+- **Theme F — `PluginField` alias collapse.** Removed all seven per-family aliases (`ImporterField`, `ExporterField`, `LabelImporterField`, `LabelsetSourceField`, `SettingsSourceField`, `SettingsImporterField`, `SettingsExporterField`); every plugin/test now uses `PluginField` directly (re-exported from each family's base module). Docs updated.

--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -1,516 +1,21 @@
 # Comprehensive interface audit — July 2026
 
-**Status: initial fix pass shipped; second follow-up pass shipped
-(#2, #6, #10, #14 of the original open list); third follow-up pass shipped
-(JobManager cancellation now stops running jobs); fourth follow-up pass
-shipped (per-task progress isolation — staging imports + eval jobs); fifth
-follow-up pass shipped (#5, #8 of the renumbered open list — ML threshold
-correctness); sixth follow-up pass shipped (#1 of the then-current open
-list — SSE connection cap); seventh follow-up pass shipped (http_archive
-cache staleness); eighth follow-up pass shipped (#1 of the then-current
-open list — region-matrix fallback space mixing); ninth follow-up pass
-shipped (#1 of the then-current open list — eval harness calibration
-fidelity); tenth follow-up pass shipped (#1 of the then-current open list —
-inclusion-slide safe-blend semantics, resolved "skip blend on slides");
-eleventh follow-up pass shipped (the "audit coverage gaps" item — all four
-never-cleared areas audited, confirmed findings fixed); remaining open
-follow-ups below.**
+**Status: eleven fix passes shipped; 8 open follow-ups below.**
 
-A full-codebase audit focused on interface boundaries: frontend ↔ backend
-API contract, route layer ↔ state system, app tier ↔ `vtscore` library,
-IO subsystems, concurrency, and frontend TypeScript logic.  Six parallel
-audit passes produced ~40 findings; the confirmed, well-scoped ones were
-fixed with regression tests in the same pass.  This document records what
-shipped and what is deliberately deferred, so the next contributor picking
-up any of these areas sees the known-weak spots.
-
-## What shipped
-
-### Backend — state / settings / jobs
-
-- **Detector-state wipe via the request-missing sentinel** (high).
-  `ensure_votes_match_active_dataset` guarded on `if not ds_ctx.dataset_id`,
-  but inside a request with no `X-Dataset-Id` the dataset context is the
-  request-missing sentinel whose id is the *truthy* string
-  `"__request_missing__"`.  Any request naming a detector but no dataset
-  wiped the detector's in-memory session (votes, label history, the whole
-  Find-verification session) against the sentinel's frozen-empty medias.
-  Fixed in `vtscore/detectors/dataset_sync.py`; regression test in
-  `tests/detectors/test_detectors.py`.
-- **Settings-import code injection surface** (high in multi-user).
-  `_get_setter_map()` scanned the whole `vtsearch.settings` namespace for
-  `set_*` callables, so an imported or synced settings dict could invoke
-  process-level setters (`set_settings_path`, `set_user_data_dir_override`,
-  CLI knobs) and repoint storage for the whole process.  The map is now
-  restricted to real schema keys.  Tests in `tests/io/test_sync_sources.py`.
-- **JobManager pending-slot coalescing across requesters** (high).
-  The single pending slot coalesced *any* new `start()` into the parked
-  job, so a poller of that job id could receive another user's / another
-  (dataset, detector) pair's results.  Coalescing now requires the same
-  requester context; anything else supersedes the parked pending with a
-  visible `cancelled` status.  A pending job cancelled while parked is no
-  longer promoted and run.  Tests in `tests_lib/integration/test_async_jobs.py`.
-- **Cross-detector label application in labelset sync** (medium).
-  `sync_from_labelset_source(detector_id)` wrote `detector_meta` to the
-  *named* detector but applied the imported votes to the request's *active*
-  detector.  The apply pass now runs under `override_detector_context(ctx)`.
-  Test in `tests/io/test_sync_sources.py`.
-- **Detector-JSON lost update** (low-medium). `sync_labels_to_loaded_detector`
-  did an unlocked read→merge→write of the detector JSON; concurrent syncs
-  from different dataset contexts dropped each other's cross-dataset
-  entries.  Now serialised under a module lock.
-
-### Backend — ML / thresholds
-
-- **`find_optimal_threshold` search-space bugs** (medium).  The candidate
-  set was only the observed scores, so "predict nothing" (threshold above
-  max; FPR=0, FNR=1) was unreachable even when it minimised the weighted
-  cost — under a precision-biased inclusion the calibrated cutoff came out
-  far too permissive.  Tied scores also produced infeasible mid-tie cut
-  positions.  Both fixed; the function can now return `NO_GOOD_THRESHOLD`
-  when abstaining is strictly cheaper.  Tests in
-  `tests_lib/sorting/test_find_optimal_threshold.py`.
-- **Stale calibration cache below the ramp floor** (medium).  The <6-label
-  training path left `det_ctx.calibration_cache` stale, so an inclusion
-  slide re-thresholded against fold orderings computed for the old label
-  set/model.  The cache is now cleared on that path.  Tests in
-  `tests_lib/detectors/test_calibration_cache_invalidation.py`.
-- **NaN-threshold guard** (low).  Fold calibration scores are now sanitised
-  (`sigmoid_to_finite_scores`) so a destabilised fold model can't put NaN
-  on `DetectorContext.threshold` when safe-thresholds is off.
-- **DiversityTree `inertia=None` crash path** (low).  The k-means backend
-  contract allows `inertia=None`; `_build_node` now keeps such labels as a
-  fallback candidate instead of crashing on `labels == ci` with
-  `best_labels is None`.
-- Docstring drift fixes: GMM <2-scores fallback wording, `n_labels <= 6`
-  pure-GMM boundary, stale `"embedding"`-key wording in `train_and_score`
-  and the eval harness docs.
-
-### Backend — IO / downloads
-
-- **Whole-archive RAM read** (high).  `_validate_archive` read the entire
-  (multi-GB) archive into memory to inspect 4 magic bytes; now reads 4 bytes.
-- **Duplicate-media re-ingest** (medium).  `_ingest_via_source` inserted
-  entries into the live `medias` dict as it went, then returned -1 mid-loop
-  on a later failure; the fallback re-ingested the whole group, duplicating
-  the already-inserted entries.  Partial inserts are now rolled back before
-  the fallback signal.  Test in `tests/datasets/test_media_sources.py`.
-- **HTTP-archive cache collision** (medium).  The resolve cache was keyed on
-  the URL *basename*, so two archives sharing a final path segment silently
-  served each other's bytes.  Now keyed on a hash of the full URL.
-  *Note: existing caches under the old naming are orphaned and will be
-  re-downloaded once.*
-- **Demo-download cache poisoning** (medium).  Oxford Flowers labels,
-  ROxford ground truth, and UCSF PDFs were downloaded straight to their
-  final paths; a failed run left a truncated file that the `exists()` gate
-  treated as cached forever.  Added `download_file_atomic` (temp + rename)
-  and used it at all three sites.  Tests in
-  `tests_lib/downloads/test_download_and_extract.py`.
-- **Zip-slip prefix check** (low).  The downloader's inline
-  `startswith` traversal check lacked a trailing separator; it now shares
-  `archive.py`'s strict `_reject_traversal`.  Tests added.
-- Small hardening: dataset-container writes fsync before the publishing
-  rename; `video2image` no longer leaks its temp file on a failed write;
-  the settings per-path lock is keyed on the resolved path for the file's
-  whole lifetime.
-
-### Frontend
-
-- **Stuck optimistic vote on failed POST** (high).  A failed vote POST left
-  `pendingOptimistic`/`pendingVerified`/`pendingRegionBoxes` entries that
-  re-imposed the phantom vote over every `/api/votes` poll forever — silent
-  label loss with a lying UI.  The error path now rolls the entries back and
-  re-reads server state; undo/redo error paths fixed the same way.
-- **Dropped `onComplete` in dashboard loading-task polling** (medium-high).
-  `startProgressPolling`/`startDetectorProgressPolling` discarded the
-  completion callback when the polling loop was already active (common:
-  the loop auto-starts on any non-idle SSE snapshot), so
-  `loadDataset`/`loadDetector` never promoted the pair via `setActivePair`.
-  Callbacks are now registered on the service and fired when the loop
-  settles, gated per-task so an unrelated task's failure doesn't suppress
-  promotion.  New spec: `dashboard-loading-tasks.service.spec.ts`.
-- **Context-switch failure handling** (medium).  A failed load kick-off or
-  an errored background load task was treated as success and promoted the
-  unloaded pair to active (re-opening the H25 409 cascade).  Failed
-  switches now roll intent back and complete without emitting; the route
-  guard maps the empty completion to a clean navigation denial via
-  `defaultIfEmpty` instead of the router's `EmptyError`.  Cancel-and-replace
-  now cancels only the superseded switch's own loading tasks instead of
-  every non-idle task (it used to kill unrelated imports).
-- **Inline error-message parsing** (low, systematic).  ~15 inline handlers
-  read only `err.error?.error`, but many routes emit the flask_smorest
-  `{message}` envelope; they degraded to generic fallbacks.  Added
-  `utils/api-error.ts` (`apiErrorMessage`) reading both envelopes and
-  converted every site.
-- `uploadServerMediaFile` no longer drops `media_type` when `cropParams`
-  is absent.
-
-### Second follow-up pass (drained from the open list)
-
-- **Registry dataset/detector load double-start + half-loaded visibility**
-  (was open #2).  Added an atomic reserve-under-lock step
-  (`begin_load`/`end_load` in `vtscore/datasets/registry.py`,
-  `begin_detector_load`/`end_detector_load` in
-  `vtscore/detectors/registry.py`): only one loader runs per id, so two
-  concurrent `.../load` requests no longer spawn twins.  The deterministic
-  task id is now intentional poll-coalescing (a second caller attaches to
-  the in-flight load).  `register_context` / `register_detector_context`
-  moved to *after* the context is fully populated, so no torn,
-  empty-then-growing context is ever published and the loaded flag is never
-  set ahead of the context store.  Tests in
-  `tests_lib/datasets/test_registry_load_reservation.py` and
-  `tests_lib/detectors/test_detector_load_reservation.py`.
-- **Learned-sort signature/data decorrelation** (was open #6).  The route
-  now freezes the votes at request time (`good_snapshot`/`bad_snapshot`),
-  exactly as region boxes already were, and passes those snapshots to both
-  the signature builder and the background job.  Previously the job copied
-  the live vote proxy at *run* time, so an intervening vote change (or an
-  `ensure_votes_match_active_dataset` rehydrate) cached a result under the
-  wrong signature.  Test in `tests/sorting/test_sorting.py`.
-- **`update_cache_for_cid` dead API removed** (was open #10).  It wrote the
-  media's *primary* vector into the detector-space label-embedding cache and
-  stamped `region=None`; no runtime callers.  Removed the function, its
-  `labelset_ops` re-export, the vulture-whitelist entry, and two stale doc
-  references.
-- **Streaming exporter temp-file collision** (was open #14).  Both
-  `server_json_file` and `server_csv_file` used a fixed `<name>.tmp`
-  sibling; two concurrent exports to the same path clobbered each other.
-  Switched to the house-style `<name>.<pid>.<uuid>.tmp` and added an fsync
-  before the atomic replace.  Tests in `tests/io/test_exporters.py`.
-
-### Third follow-up pass (drained from the open list)
-
-- **JobManager cancellation now stops running jobs** (was renumbered open
-  #2).  Cancelling a *running* learned-sort / eval job previously only set
-  `AsyncJob.is_cancelled`, which no job target read, so the GIL-bound
-  training kept running to completion (the cancelled-*pending* half was
-  already fixed in the initial pass; both cancel routes' docstrings already
-  *claimed* the loop "polls it cooperatively", but nothing did).  Added a
-  thread-local job binding in `vtscore/concurrency/async_jobs.py`
-  (`bind_job_cancellation` / `check_job_cancelled`, entered for the
-  worker-thread lifetime in `JobManager._run`).  The deep compute loops now
-  poll it at their natural boundaries — the MLP epoch boundary in
-  `vtscore/training/mlp.py:train_model` and the per-step retrain boundary in
-  `vtscore/detectors/labeling_progress.py:_ensure_cache`.  A poll raises the
-  existing `CancelledError`, which unwinds the training/eval stack and is
-  caught in `_run_inner` to mark the job `cancelled` (never caching its
-  half-built result via `_last_done`) and hand off to any parked pending.
-  The check is a no-op outside a bound job, so the synchronous Find flow,
-  tests, and CLI that share `train_model` are unaffected.  The eval `_run`
-  now clears the progress bar to `"Cancelled"` rather than `"Error"`.
-  Tests in `tests_lib/integration/test_async_jobs.py`
-  (`TestCheckJobCancelledPrimitive`, `TestRunningJobCancellation`) and
-  `tests_lib/detectors/test_mlp_training.py` (`TestJobCancellation`).
-
-### Fourth follow-up pass (per-task progress isolation)
-
-- **Staging imports on the global `dataset_progress` singleton** (was open
-  #3, renumbered #2 after the third pass).  `_stage_importer_in_background`
-  reported through the single global `dataset_progress` tracker, so two
-  concurrent staging imports interleaved one channel and the terminal
-  `staging_result` was last-writer-wins — orphaning the loser's staged pkl.
-  Staging now runs through a dedicated per-task `ProgressTracker` created
-  via `loading_tasks` (an `extra_fields` hook on
-  `LoadingTasksTracker.create_task` carries the `staging_result` key), keyed
-  by a returned `task_id`; the importer's own progress and the embed pass
-  route into that tracker via `set_thread_progress`.  The `stage-import` /
-  `stage-demo` routes now return the `task_id` so a poller can pick up its
-  own result off the `loading-tasks` SSE channel.  Test in
-  `tests/datasets/test_combine_datasets.py::TestStagingPerTaskIsolation`.
-- **Eval progress decorrelated from job identity** (was open #4, renumbered
-  #3 after the third pass).  The eval train-and-score route wrote progress
-  to the global `eval_progress` singleton and the `/result` poll read it
-  back, so overlapping evals (one running, one parked pending behind the
-  single-runner `eval_jobs` manager) reported each other's numbers.
-  Progress now lives on the `AsyncJob` (`job.update_progress`) and the poll
-  reads `job.current` / `job.total`; the singleton is written only from
-  inside the actually-running job's `_run` (not from the request handler for
-  a possibly-pending job), so the live `eval` SSE bar reflects the running
-  job.  Test in
-  `tests/sorting/test_sorting.py::TestEvalTrainAndScoreAsync::test_result_reports_job_progress_not_singleton`.
-
-### Fifth follow-up pass — ML threshold correctness (drained from the open list)
-
-- **Training entry points now agree at 4-5 labels** (was renumbered open
-  #5).  With safe-thresholds off, `train_and_threshold` (Find / detector-
-  load) ran real cross-calibration below 6 labels while `_train_and_score_xy`
-  (vote-driven Train / labelset) and `train_detector_from_origins`
-  (detector-load-from-origins) hard-coded 0.5 — the same user state produced
-  a different cutoff depending on which route trained.  Unified on real
-  cross-calibration: the `< 6 → 0.5` short-circuit is now gated on
-  `safe_thresholds` (still skipped only when the pure-GMM blend would
-  discard the result), so every route cross-calibrates below 6 when
-  safe-thresholds is off, and an inclusion slide can move the line below 6
-  too.  `train_and_threshold`'s safe-on-<6 branch now also clears the fold
-  cache (parity with `_train_and_score_xy`), closing a stale-cache read on
-  that path.  Tests in `tests_lib/detectors/test_calibration_cache_invalidation.py`
-  and `tests/sorting/test_sorting.py`.
-- **Abstain sentinel is a vote, not a number** (was renumbered open #8).
-  `threshold_from_fold_orderings` numerically averaged the `NO_GOOD_THRESHOLD`
-  (2.0) sentinel, so a single abstaining fold dragged the mean above the
-  sigmoid range (forcing overall abstain at the default `calibrate_count=2`,
-  yet often *not* at 3+ folds — a fold-count-dependent artifact that stored an
-  ill-defined ~1.3 as "the threshold").  A fold that abstains is now tallied
-  as a vote: the ensemble abstains only under a **strict majority** of
-  abstaining folds and otherwise means the folds that produced a real cut.
-  Tests in `tests_lib/sorting/test_find_optimal_threshold.py`.
-
-### Sixth follow-up pass — SSE connection cap (drained from the open list)
-
-- **SSE `/api/events` no longer starves the gthread pool** (was open #1).
-  Each open connection pins a worker thread for its lifetime (the generator
-  blocks in `queue.get()` between updates), so with the documented
-  `workers = 1, threads = 8` deployment, enough open tabs could exhaust the
-  pool and make ordinary requests stall while the stream's own heartbeat
-  kept the connection looking alive. Chose the "bound connections" option
-  from the three named in the original finding (bound / resize / move off
-  the pool): a hard cap, `MAX_SSE_CONNECTIONS` in
-  `vtscore/concurrency/events.py`, derived from `VTSEARCH_THREADS` minus a
-  fixed reserve of 2 (override directly with
-  `VTSEARCH_SSE_MAX_CONNECTIONS`). `acquire_sse_slot()` /
-  `release_sse_slot()` gate `/api/events` in `vtsearch/routes/events.py`;
-  once saturated, new connects get an immediate `503` with `Retry-After: 5`
-  instead of starting a stream, so the rejection itself never pins a
-  thread. The frontend's `EventSource` already schedules a manual
-  reconnect when the server closes the connection non-2xx (see
-  `progress-events.service.ts`'s `onerror`/`readyState === CLOSED` path),
-  so no frontend change was needed. Tests in
-  `tests/api/test_events_sse.py` (`TestSseConnectionCapPrimitive`,
-  `TestSseConnectionCapRoute`).
-
-### Seventh follow-up pass (drained from the open list)
-
-- **`http_archive` cache staleness** (was renumbered open #6).
-  `HttpArchiveSource`'s resolve cache keyed only on the URL, so once an
-  extraction was published under that key it was served forever, even after
-  the remote archive changed. Added `fetch_remote_signature()` in
-  `vtscore/datasets/downloader/core.py` — a single-byte ranged GET (more
-  universally honoured than HEAD by the flaky CDNs these archives live on)
-  that reads only `ETag` / `Last-Modified` / size from the response headers.
-  `_ensure_extracted()` now records that signature in a sidecar file next to
-  the cached extraction (kept as a *sibling*, never inside the extraction
-  tree, so it can't surface as a bogus media item to an extensionless
-  `list_items(None)`); a later access whose freshly-probed signature
-  disagrees with the recorded one busts the cache and re-downloads. A cache
-  with no recorded signature (predates this check, or its own probe failed)
-  is trusted as-is, and a probe failure (offline, flaky CDN) fails open onto
-  the existing cache rather than blocking. Tests in
-  `tests/datasets/test_media_sources.py`
-  (`test_stale_cache_invalidated_on_signature_mismatch`,
-  `test_signature_probe_failure_trusts_existing_cache`).
-
-### Eighth follow-up pass (drained from the open list)
-
-- **Region-matrix fallback space mixing** (was open #1).
-  `embedding/matrix.py:_build_region_arrays` flattens every media's
-  `patch_regions` into one `(R, D)` matrix, giving a region-less media a
-  single fallback row so the segmented max-pool never sees an empty group.
-  That fallback unconditionally read the media's *primary* vector - fine
-  when every media in the dataset carries `patch_regions` (the only
-  reachable case before the v3 trio-embedder work), but on a dataset that
-  mixes patch-capable and patch-less media (a combined dataset, or a media
-  type the patch embedder can't process) the primary can be a different
-  embedder than the one that produced the region rows, silently stacking
-  vectors from two different embedding spaces into one matrix and scoring
-  the region-less media's dot-products meaninglessly.  Added
-  `_patch_embedder_for_region_snap`, which derives the patch-slot embedder
-  name from a media that actually carries `patch_regions` (role-typing its
-  bound embedder names via `derive_binding_from_names`, not just reading the
-  *first* media in the dict, which may itself be the region-less one and
-  never had a patch-embedder vector to role-type from); the fallback row now
-  reads that embedder's vector instead of the primary.  A region-less media
-  with no vector at all under the patch embedder now raises `ValueError`
-  naming the media and embedder (matching this module's existing
-  loud-failure philosophy for missing embeddings) rather than silently
-  substituting the wrong space.  Single-embedder datasets are unaffected:
-  the derived patch embedder there always equals the primary, so the
-  fallback read is byte-for-byte the same as before.  Tests in
-  `tests_lib/detectors/test_region_score_pool.py`
-  (`TestRegionMatrixFallbackSpace`).
-
-### Ninth follow-up pass — eval harness calibration fidelity (drained from the open list)
-
-- **Eval folds now calibrate exactly as production does** (was open #1).
-  `eval/voting_iterations.py:simulate_voting_iterations` computed its per-step
-  threshold via `calculate_cross_calibration_threshold` **without** forcing the
-  full-data `hidden_dim` (so each calibration fold auto-sized to its own
-  smaller train split) and threaded the **shared per-seed simulation RNG** into
-  the fold splits.  Production's `_train_and_score_xy` / `train_and_threshold`
-  do the opposite: they size `hidden_dim` from the full label count, force that
-  width onto the folds (via `cross_calibration_threshold_cached(...,
-  hidden_dim=...)`), and always calibrate with a fresh `RandomState(42)`.  The
-  eval therefore measured a threshold the live detector never computes in the
-  small-label regime — narrower fold nets, calibrated against splits that
-  varied with the eval seed instead of the pinned production seed.  The per-step
-  call now passes `hidden_dim=_auto_hidden_dim(n_labels)` and
-  `rng=np.random.RandomState(42)` (a fresh one per step, mirroring how
-  `cross_calibration_threshold_cached` mints one per call), and the final
-  `train_model` is handed the same `hidden_dim`.  The eval seed still varies the
-  *data* (which media are voted, in what order, and the held-out test split);
-  only the calibration folds are now pinned, exactly as in production.  Tests in
-  `tests_lib/detectors/test_eval_voting_iterations.py`
-  (`TestProductionCalibrationFidelity`).
-
-### Tenth follow-up pass — inclusion-slide safe-blend semantics (drained from the open list)
-
-- **Inclusion slide drops the safe-threshold GMM blend** (was open #1).
-  With safe-thresholds on and 6 ≤ n < 20 labels a *fresh* retrain stores the
-  cross-calibration cutoff blended with a GMM cutoff
-  (`calculate_safe_threshold`'s linear ramp), but the fold-ordering cache on
-  the detector context holds only the raw cross-calibration orderings — not the
-  GMM component — so an inclusion slide
-  (`recompute_detector_thresholds_for_inclusion`) re-derived the *raw*
-  cross-calibration aggregate and silently dropped the blend, changing the
-  threshold semantics relative to a fresh retrain.  **Decision (user): skip
-  the blend on slides.**  A slide is a cheap re-threshold over cached orderings,
-  not a re-blend; making the recompute reproduce the blend would require it to
-  carry cached GMM-threshold + label-count state, not worth it for the
-  6..19-label window (below 6 the cache is cleared and the slide is a no-op at
-  the inclusion-independent pure-GMM value; at ≥20 the blend is already pure
-  cross-calibration so a slide matches a fresh retrain exactly).  No behaviour
-  change from the pre-audit code — the divergence was already present — but it
-  was accidental and undocumented, and is now deliberate.  Documented the
-  intent on `recompute_detector_thresholds_for_inclusion` and at both blend
-  sites in `vtscore/detectors/training.py`, and pinned the semantics with tests
-  in `tests_lib/detectors/test_inclusion_slide_safe_blend.py`
-  (`TestInclusionSlideDropsSafeBlend` — a slide re-derives the raw aggregate,
-  not the blend; a below-floor slide is a no-op).
-
-### Eleventh follow-up pass — audit coverage gaps cleared (was open #2)
-
-The four areas the original audit never cleared (rate-limit casualties) were
-swept by five parallel audit passes: browse-canvas/minimap coordinate math +
-rAF lifecycles, modal/player component lifecycles, left/right-panel
-virtualization, and the full route-blueprint sweep of
-`routes/datasets|media|detectors|labels|processors|projection`.  Confirmed,
-well-scoped findings were fixed with regression tests; the rest are recorded
-under Open follow-ups.
-
-Route-blueprint sweep fixes:
-
-- **Find / auto-detect cancellation was a silent no-op** (high).
-  `POST /api/find/cancel` set `find_progress`'s cancel flag and every scoring
-  route cleared it on entry, but **no scoring loop ever read it** — the
-  cancel docstring's "long-running loops poll the flag" was false, and an
-  expensive Find always ran to completion.  The loops now poll at their
-  stage boundaries (`multi_find`'s dataset loop, `_score_dataset`'s detector
-  loop, `find_label`'s train/score/apply boundaries, and the entry of each
-  `auto-detect` worker — *before* its catch-all `except Exception`, which
-  would otherwise swallow the `CancelledError`) and the routes unwind with a
-  409 + idle progress.  Tests in `tests/detectors/test_find_cancel.py`.
-- **Unlocked detector-JSON read-modify-write in four routes** (medium).
-  `sync_labels_to_loaded_detector` serialises its RMW of
-  `detectors/<slug>.json` under `_label_sync_write_lock` (added in the
-  initial pass), but `save_detector_labels`, `vote_detector_label`,
-  `import_labels_into_detector`, and `find_corrections_to_detector` did the
-  same file's RMW unlocked — a concurrent locked sync (any media vote) and a
-  route write dropped each other's entries.  All four now take the same
-  lock (each acquiring it before `_state_lock`, preserving the documented
-  ordering).  Tests in `tests/detectors/test_detector_json_lock.py`.
-- **`save_detector_labels` sentinel empty-labelset wipe** (medium).  A
-  header-less `POST /api/detectors/<name>/labels` resolved the
-  request-missing sentinels, whose `validated_vote_snapshot` reports
-  `safe=True` over frozen-empty votes/medias — passing the 409 guard and
-  full-replacing the named detector's labelset with an empty one.  Now
-  guarded with `require_dataset_header` / `require_detector_header` (H34
-  defence-in-depth pattern).  Test in the same file.
-- **`fill_labels_from_sort` partial state on persistence failure**
-  (low-medium).  The route applied votes then aborted 500 if the disk sync
-  failed, leaving live in-memory votes that the next vote-triggered sync
-  silently persisted — contradicting the error.  Now snapshots and rolls
-  back the vote state on failure (the `apply_and_retrain` / H30 pattern).
-  Test in `tests/api/test_error_recovery.py`.
-- **Header-less `/api/dataset/clear` sentinel no-op** (low).  The route read
-  the sentinel's truthy `"__request_missing__"` id and "cleared" a dataset
-  that doesn't exist; the intended global-clear fallback was unreachable
-  in-request (and would raise on the sentinel's frozen containers anyway).
-  The header is now required (400 without it); no frontend caller exists.
-  Test in `tests/datasets/test_datasets.py`.
-- **`example_sort_origin` bypassed multi-user file confinement** (medium in
-  multi-user).  The route built a media source from the request body's
-  verbatim origin dict with none of `_load_from_origin`'s
-  `validate_server_filepath` checks, so a `server_folder` origin could point
-  at any server-readable directory (arbitrary-file embedding + existence
-  disclosure outside `data/<user>/`).  Path-like origin params are now
-  validated the same way.  Tests in `tests/api/test_path_validation.py`.
-- **`stage_file` whole-member RAM read** (low).  The pickle peek read the
-  entire decompressed `medias.pkl` into memory via `zf.read()` before
-  peeking (zip-bomb amplification, compounded by `MAX_UPLOAD_MB=0` =
-  unlimited by default); it now streams via `zf.open()`.
-
-Frontend fixes (modal/player lifecycles, virtualization, canvas/minimap):
-
-- **One Escape closed every modal in a stack** (high).  Every
-  `ModalComponent` listens for Escape on `document` guarded only by its own
-  `open()`, so nested flows (New Detector → crop modal, Settings → importer,
-  any modal → dialog-host confirm) lost the whole stack — and the outer
-  form's state — to a single keypress meant for the inner view.  A
-  module-level open-modal stack now routes Escape to the topmost open modal
-  only.  Specs in `modal.component.spec.ts`.
-- **Escape/backdrop on a `prompt()` resolved `false`** (high).  Dialog-host's
-  `onClosed()` hard-coded `resolve(false)` for every dialog kind; `prompt()`
-  callers are typed `string | null` and crashed (`false.trim()` in
-  find-view's promote flow, `false.split()` in the dashboard access-list
-  editors).  Dismissal now resolves the dialog kind's own cancel value, and
-  a second `show()` while one dialog is pending settles the superseded
-  dialog as cancelled instead of stranding its promise forever.  Specs in
-  `dialog-host.component.spec.ts`.
-- **Image-viewer's window-level Escape acted under open modals**
-  (medium-low).  Closing a modal with Esc also cleared the user's drawn
-  region box underneath; the handler now suppresses on `.modal-backdrop`
-  presence, matching `KeyboardService`.  Specs in
-  `image-viewer.component.spec.ts`.
-- **Virtual-scroll prefetch died on viewport recreation** (medium, two
-  sites).  Both the media list (`scrollSubscribed` one-shot flag) and the
-  browse-bin popup (`ngAfterViewInit`-only wiring) subscribed
-  `scrolledIndexChange` once per component, but their CDK viewports live
-  behind `@if` branches and are destroyed/recreated on dataset switches,
-  virtualization-threshold crossings, and popup re-summons
-  (singleton↔multi) — after which scroll-driven metadata/thumbnail
-  hydration silently never fired again.  Subscriptions are now keyed to the
-  viewport *instance* (the existing `observedViewportEl` re-observe
-  pattern).  Specs in `media-list.component.spec.ts` and
-  `browse-bin-popup.zoneless.spec.ts`.
-- **Minimap mouse math ignored the app-wide `html { zoom: 1.1 }`** (high).
-  `recenterFromEvent` mixed visual-px cursor offsets with layout-px map
-  transforms, so every minimap click/drag recentred ~10% off target (the
-  main canvas corrects for exactly this); the corner-resize drag grew 1.1×
-  faster than the cursor; and the bitmap was undersampled 1.1×.  The cursor
-  offset is now scaled by the rendered-size ratio, the resize delta divides
-  out the root zoom, and the backing store bakes the zoom in.  (No spec:
-  jsdom has no canvas 2D context; verified against the browse-canvas
-  transform conventions.)
-- **Post-destroy rAF scheduling in browse-canvas** (medium).  Late
-  thumbnail `img.onload` callbacks called `requestRedraw()` after
-  `ngOnDestroy` (which only cancels the *current* rAF handle), running
-  `draw()` on the destroyed component — emitting on destroyed outputs,
-  republishing a non-null viewport over teardown's `null`, re-arming the
-  idle thumb-prefetch loop, and issuing spurious tile fetches against a
-  newer browse view's projection.  A `destroyed` flag now gates
-  `requestRedraw()` and `scheduleThumbPrefetch()`.
+A full-codebase audit of interface boundaries (frontend ↔ API, route layer ↔
+state system, app tier ↔ `vtscore`, IO, concurrency, frontend TS). Six parallel
+passes produced ~40 findings; the confirmed, well-scoped ones were fixed with
+regression tests across eleven passes. Open items were found and verified during
+the audit but deferred as needing a design decision or a larger change.
 
 ## Open follow-ups
 
-Ordered roughly by severity.  Each was found and verified during the audit
-but deferred as needing a design decision or a larger change.  (Original
-open items #2, #6, #10, #14 were drained in the second follow-up pass, the
-renumbered #2 "JobManager cancellation advisory" in the third pass, the
-staging + eval progress isolation (renumbered #2, #3) in the fourth, the
-re-renumbered #5/#8 "ML threshold correctness" items in the fifth, the
-re-renumbered #1 "SSE connection cap" in the sixth, the re-renumbered #6
-"http_archive cache staleness" in the seventh, the re-renumbered #1
-"region-matrix fallback space mixing" in the eighth, the re-renumbered
-#1 "eval harness calibration fidelity" in the ninth, the re-renumbered #1
-"inclusion-slide safe-blend semantics" in the tenth, and the "audit
-coverage gaps" item in the eleventh — whose sweep also *added* items 2-8
-below (findings confirmed during that pass but deferred as design
-decisions or larger changes) — see the follow-up-pass subsections under
-What shipped.  The list below is renumbered again after those drains.)
+Ordered roughly by severity.
 
 1. **Dataset registry is not multi-process safe**
    (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
    name; a concurrent CLI autodetect run against the same data dir can
-   silently erase the server's registrations.  Fine under the documented
+   silently erase the server's registrations. Fine under the documented
    single-worker model; needs flock if that changes.
 2. **Progress-modal analysis path is broken three ways**
    (`progress-modal.component.ts`, `runAnalysis()`): Escape/X/backdrop skip
@@ -521,26 +26,25 @@ What shipped.  The list below is renumbered again after those drains.)
    500 ms poller until the job ends); and the backend emits the eval
    `idle/Done` SSE frame *inside* `_run` before the job flips to `done`, so
    the SSE watcher usually kills the result poller before it observes
-   completion — `analyzing` hangs forever.  All currently *latent*: the only
+   completion — `analyzing` hangs forever. All currently *latent*: the only
    in-app instantiation passes `[useCachedHistory]="true"`, but
    `runAnalysis()` is the component default and is pinned by its spec.
-3. **Browse canvas gesture overlaps** (found in the eleventh pass, deferred
-   as UX design decisions): wheel-zoom during an active drag-pan/marquee
-   discards the zoom's cursor anchoring on the next mousemove and freezes
-   painting for the 220 ms transition (gate the wheel while a drag is
-   active, or make the pan math zoom-aware); the deferred single-click
-   toggle resolves its captured screen coords against whatever transform
-   exists 250 ms later, so a wheel notch / arrow-key glide inside the
-   double-click window toggles the wrong bin (cancel or flush the pending
-   toggle on view moves); the boundary-settle rAF loop can start while the
-   zoom-transition loop still owns the canvas (both write
+3. **Browse canvas gesture overlaps** (UX design decisions): wheel-zoom
+   during an active drag-pan/marquee discards the zoom's cursor anchoring on
+   the next mousemove and freezes painting for the 220 ms transition (gate
+   the wheel while a drag is active, or make the pan math zoom-aware); the
+   deferred single-click toggle resolves its captured screen coords against
+   whatever transform exists 250 ms later, so a wheel notch / arrow-key glide
+   inside the double-click window toggles the wrong bin (cancel or flush the
+   pending toggle on view moves); the boundary-settle rAF loop can start while
+   the zoom-transition loop still owns the canvas (both write
    `displayedTransform`; visible damage is a truncated transition).
 4. **Root-zoom px mixing in panel-divider drags**
    (`browse-view.component.ts:onDividerMove`,
    `label-view/panel-resize.directive.ts`): visual-px cursor deltas applied
    as layout-px widths under `html { zoom: 1.1 }`, so the divider rides
-   ~10% away from the pointer.  Shared app-wide wart; fix both sites
-   together (the eleventh pass fixed the same class of bug in the minimap).
+   ~10% away from the pointer. Shared app-wide wart; fix both sites together
+   (the eleventh pass fixed the same class of bug in the minimap).
 5. **Pure devicePixelRatio change never re-runs canvas `resize()`**
    (browse-canvas + minimap): dragging the window to a different-density
    monitor leaves `dpr` (and the thumbnail-resolution tier) stale until the
@@ -550,7 +54,7 @@ What shipped.  The list below is renumbered again after those drains.)
    (`routes/detectors/labels.py`): the route rebuilds the labelset from the
    *active dataset's* votes only, while `sync_labels_to_loaded_detector`
    deliberately merges cross-dataset entries — saving while dataset B is
-   active discards the entries accumulated under dataset C.  Decide whether
+   active discards the entries accumulated under dataset C. Decide whether
    the explicit save should merge like the sync does (probably yes, via
    `_merge_labelsets_across_datasets`) or full-replace is the intended
    "save exactly what I see" semantic.
@@ -561,101 +65,134 @@ What shipped.  The list below is renumbered again after those drains.)
 8. **`AutoDetectProgressModalComponent` is dead code** (modal sweep note):
    referenced nowhere; delete it or wire it up.
 
-## Behaviour changes shipped (backwards compatibility notes)
+## What shipped
 
-- `find_optimal_threshold` can now return `NO_GOOD_THRESHOLD` (2.0).
-- `threshold_from_fold_orderings` no longer numerically averages the abstain
-  sentinel: the fold ensemble abstains only under a strict majority of
-  abstaining folds and otherwise means the non-abstaining folds, so the
-  stored threshold never lands at an out-of-range ~1.3 and the abstain
-  outcome no longer depends on `calibrate_count`.
-- With safe-thresholds **off**, all training entry points cross-calibrate at
-  4-5 labels (previously the vote/labelset and origin-load paths returned
-  0.5).  The Find/Train cutoff for the same small-label state now matches
-  regardless of route, and an inclusion slide can move the threshold below 6
-  labels too.  Safe-thresholds **on** below 6 is unchanged (pure GMM).
-- `_apply_settings` no longer applies non-schema keys (previously reachable:
-  `settings_path`, `user_data_dir_override`, `settings_source_config`,
-  CLI knobs).
-- `http_archive` resolve caches move to hash-keyed directory names; old
-  cache dirs are orphaned and re-downloaded once.
-- `JobManager.start()` from a different (user, dataset, detector) than the
-  parked pending now supersedes it (pollers of the old job id see
-  `cancelled`) instead of silently rebinding their job to the new request.
-- Registry `.../load` while a load of the same id is already in flight now
-  returns `{"message": "… load already in progress"}` with the shared task
-  id (attach + poll) instead of spawning a second loader.  The load task id
-  is the full id (`_regload_<id>` / `_detload_<id>`) rather than an 8-char
-  prefix.  A registered dataset/detector context is published only once
-  fully loaded, so it is no longer briefly visible half-populated.
-- Streaming `server_json_file` / `server_csv_file` exports now write to a
-  `<name>.<pid>.<uuid>.tmp` temp sibling instead of a fixed `<name>.tmp`.
-- `update_cache_for_cid` (unused) was removed from
-  `vtscore.detectors.labelset_training` and the `labelset_ops` re-export.
-- Cancelling a *running* learned-sort / eval job now actually stops it
-  (transitions to `cancelled` within one epoch / eval step and never caches
-  the partial result) instead of running to completion with the cancel
-  ignored.  The eval progress bar reports `"Cancelled"` on a running-job
-  cancel rather than `"Error"`.
-- Staging (`POST /api/dataset/stage-import/<importer>`, `stage-demo/<name>`)
-  now returns a `task_id` and reports progress on the per-task
-  `loading-tasks` SSE channel (with its `staging_result`) instead of the
-  global `dataset` channel / `dataset_progress` singleton.
-  `_stage_importer_in_background` returns the task id.
-- Eval `GET /api/eval/train-and-score/result` reports the polled job's own
-  `current` / `total` (read from the `AsyncJob`) rather than the shared
-  `eval_progress` singleton, so overlapping evals no longer read each
-  other's progress.
-- `GET /api/events` now returns `503` (with `Retry-After: 5`) once
-  `MAX_SSE_CONNECTIONS` concurrent streams are already open, instead of
-  accepting an unbounded number of connections that could starve the
-  gthread pool. Cap defaults to `VTSEARCH_THREADS - 2`; override with
-  `VTSEARCH_SSE_MAX_CONNECTIONS`.
-- `HttpArchiveSource`'s resolve cache now checks a recorded remote signature
-  (ETag/Last-Modified/size) on each access to a cached extraction and
-  re-downloads on a mismatch, instead of trusting the cache forever once
-  published. A cache built before this change (no recorded signature) or a
-  failed probe still trusts the existing cache, so this is additive: no
-  previously-cached extraction is invalidated by upgrading alone.
-- A region-less media in a mixed patch/non-patch dataset now has its
-  region-matrix fallback row read from the dataset's patch-slot embedder
-  instead of its primary embedder, and raises `ValueError` if it has no
-  vector under the patch embedder at all.  No effect on any dataset where
-  every media shares one embedder (the only case reachable before the v3
-  trio-embedder work).
-- `simulate_voting_iterations` / `run_voting_iterations_eval` now calibrate
-  each step's threshold with the production `hidden_dim` (full-label width,
-  forced onto the folds) and a fixed `RandomState(42)` fold split, instead of
-  auto-sizing the folds and threading the per-seed simulation RNG.  Reported
-  `cost` / `fpr` / `fnr` values shift in the small-label regime because the
-  eval now measures the exact pipeline the live detector runs; the eval seed
-  still varies the data (votes, order, test split), only the calibration folds
-  are pinned.
-- **No runtime change**: the inclusion-slide safe-threshold divergence
-  (`recompute_detector_thresholds_for_inclusion` re-derives the raw
-  cross-calibration cutoff and does not reapply the GMM blend, so with
-  safe-thresholds on and 6 ≤ n < 20 labels a slide yields a slightly
-  different threshold than a fresh retrain) is now documented as intentional
-  ("skip blend on slides") rather than accidental — the behaviour itself is
-  unchanged from before the audit.
-- `POST /api/find/cancel` now actually stops an in-flight `/api/find`,
-  `/api/find-label`, or `/api/auto-detect`: the cancelled request unwinds
-  with **409** `{"message": "Find cancelled"}` (progress resets to idle)
-  instead of running to completion and returning 200.
-- `POST /api/detectors/<name>/labels` now **requires** the `X-Dataset-Id`
-  and `X-Detector-Id` headers (400 without them); previously a header-less
-  request silently overwrote the named detector's labelset with an empty
-  one.
-- `POST /api/dataset/clear` now **requires** `X-Dataset-Id` (400 without
-  it); previously a header-less clear silently no-oped against the
-  request-missing sentinel.  No frontend caller sends a header-less clear.
-- `POST /api/example-sort-origin` rejects (400) origins whose path-like
-  params escape the user's confinement dir in multi-user mode; single-user
-  mode is unchanged (unrestricted).
-- A failed label-persistence pass in `POST /api/labels/fill-from-sort` now
-  rolls the applied in-memory votes back before returning 500, instead of
-  leaving them live to be silently persisted later.
-- Frontend: Escape now closes only the topmost modal of a stack; Escape or
-  a backdrop click on a `prompt()` dialog resolves `null` (previously
-  `false`, which crashed callers); Escape while a modal is open no longer
-  clears the image viewer's drawn region box underneath.
+Backend — state / settings / jobs:
+- Detector-state wipe via the `"__request_missing__"` sentinel — a detector-only
+  request wiped the session against the sentinel's empty medias
+  (`vtscore/detectors/dataset_sync.py`).
+- Settings-import setter-map restricted to real schema keys — an imported dict
+  could no longer invoke process-level setters (`test_sync_sources.py`).
+- JobManager pending-slot coalescing now requires the same requester context;
+  a mismatch supersedes the parked pending with `cancelled` (`test_async_jobs.py`).
+- Cross-detector labelset sync applies votes under `override_detector_context`
+  (`test_sync_sources.py`).
+- Detector-JSON RMW in `sync_labels_to_loaded_detector` serialised under a
+  module lock.
+- Registry load double-start fixed via atomic reserve-under-lock
+  (`begin_load`/`end_load`, `begin_detector_load`/`end_detector_load`); contexts
+  published only once fully populated (`test_registry_load_reservation.py`,
+  `test_detector_load_reservation.py`).
+- Learned-sort route freezes votes at request time so an intervening change
+  can't cache under the wrong signature (`test_sorting.py`).
+- Removed dead `update_cache_for_cid`, its re-export, whitelist entry, doc refs.
+- Streaming exporters use `<name>.<pid>.<uuid>.tmp` + fsync instead of a fixed
+  `<name>.tmp` (`test_exporters.py`).
+- JobManager cancellation now stops *running* jobs via a thread-local binding
+  (`bind_job_cancellation`/`check_job_cancelled`), polled at the MLP epoch and
+  per-step retrain boundaries (`test_async_jobs.py`, `test_mlp_training.py`).
+- Staging imports + eval jobs moved off global progress singletons onto per-task
+  trackers / `AsyncJob` progress (`test_combine_datasets.py`, `test_sorting.py`).
+
+Backend — ML / thresholds:
+- `find_optimal_threshold` search-space fixed: can return `NO_GOOD_THRESHOLD`
+  (predict-nothing) and handles tied scores (`test_find_optimal_threshold.py`).
+- Stale calibration cache cleared on the <6-label path
+  (`test_calibration_cache_invalidation.py`).
+- NaN-threshold guard via `sigmoid_to_finite_scores`; DiversityTree
+  `inertia=None` no longer crashes; assorted docstring drift fixes.
+- All training entry points cross-calibrate at 4–5 labels (safe-thresholds off);
+  abstain sentinel now tallied as a majority vote, not numerically averaged
+  (`test_calibration_cache_invalidation.py`, `test_find_optimal_threshold.py`).
+- Eval folds calibrate exactly as production (forced `hidden_dim`,
+  `RandomState(42)`) (`test_eval_voting_iterations.py`).
+- Inclusion-slide safe-blend divergence documented as intentional (skip blend on
+  slides) (`test_inclusion_slide_safe_blend.py`).
+
+Backend — IO / downloads:
+- `_validate_archive` reads 4 magic bytes, not the whole archive.
+- Partial media inserts rolled back before the fallback re-ingest
+  (`test_media_sources.py`).
+- HTTP-archive resolve cache keyed on a full-URL hash, and now busts on a remote
+  signature (ETag/Last-Modified/size) mismatch via a sibling sidecar
+  (`test_media_sources.py`).
+- Demo downloads (Oxford Flowers, ROxford, UCSF) use `download_file_atomic`
+  (`test_download_and_extract.py`); zip-slip check shares strict
+  `_reject_traversal`.
+- Region-matrix fallback row reads the patch-slot embedder, raising `ValueError`
+  if absent, instead of silently mixing spaces
+  (`test_region_score_pool.py`).
+- Small hardening: fsync before publishing rename; `video2image` temp cleanup;
+  per-path settings lock keyed on the resolved path.
+
+Backend — routes (eleventh-pass sweep):
+- `POST /api/find/cancel` now actually stops in-flight Find / find-label /
+  auto-detect (loops poll at stage boundaries; 409 on cancel)
+  (`test_find_cancel.py`).
+- Unlocked detector-JSON RMW in four more routes now takes
+  `_label_sync_write_lock` (`test_detector_json_lock.py`).
+- `save_detector_labels` / `dataset/clear` now require the dataset/detector
+  headers (sentinel wipe / no-op closed) (`test_detector_json_lock.py`,
+  `test_datasets.py`).
+- `fill_labels_from_sort` rolls votes back on a persistence failure
+  (`test_error_recovery.py`).
+- `example_sort_origin` validates path-like origin params
+  (`test_path_validation.py`); `stage_file` streams the pickle peek instead of
+  a whole-member RAM read.
+
+Frontend:
+- Failed vote POST rolls back optimistic/verified/region entries and re-reads
+  server state (undo/redo error paths too).
+- Dashboard loading-task `onComplete` callbacks now fire when the polling loop
+  settles, gated per-task (`dashboard-loading-tasks.service.spec.ts`).
+- Context-switch failures roll intent back; cancel-and-replace cancels only the
+  superseded switch's own tasks.
+- `utils/api-error.ts` (`apiErrorMessage`) reads both error envelopes; every
+  inline handler converted. `uploadServerMediaFile` keeps `media_type` when
+  `cropParams` is absent.
+- Escape routes to the topmost open modal only (`modal.component.spec.ts`);
+  dialog-host dismissal resolves the kind's own cancel value
+  (`dialog-host.component.spec.ts`); image-viewer Escape suppresses under a
+  modal backdrop (`image-viewer.component.spec.ts`).
+- Virtual-scroll prefetch keyed to the viewport instance so it survives viewport
+  recreation (`media-list.component.spec.ts`, `browse-bin-popup.zoneless.spec.ts`).
+- Minimap mouse math corrects for `html { zoom: 1.1 }` (cursor offset, resize
+  delta, backing store). Post-destroy rAF gated by a `destroyed` flag in
+  browse-canvas.
+
+## Behaviour changes (backwards-compat notes)
+
+- `find_optimal_threshold` can return `NO_GOOD_THRESHOLD` (2.0);
+  `threshold_from_fold_orderings` abstains only under a strict majority of
+  abstaining folds (no longer `calibrate_count`-dependent).
+- Safe-thresholds **off**: all training entry points cross-calibrate at 4–5
+  labels (was 0.5 on vote/labelset/origin-load paths); slides can move the line
+  below 6. Safe-thresholds **on** below 6 unchanged (pure GMM).
+- `_apply_settings` no longer applies non-schema keys.
+- `http_archive` caches move to hash-keyed dirs (old dirs re-downloaded once) and
+  re-download on a remote-signature mismatch (pre-existing caches trusted).
+- `JobManager.start()` from a different requester supersedes the parked pending
+  (pollers see `cancelled`); registry `.../load` while a load is in flight
+  attaches to the shared task id (full `_regload_<id>` / `_detload_<id>`).
+- Streaming JSON/CSV exports write to `<name>.<pid>.<uuid>.tmp`.
+- `update_cache_for_cid` removed.
+- Cancelling a running learned-sort / eval job now actually stops it (bar reports
+  `"Cancelled"`).
+- Staging returns a `task_id` and reports on the `loading-tasks` SSE channel;
+  eval `train-and-score/result` reports the polled job's own progress.
+- `GET /api/events` returns `503` + `Retry-After: 5` past `MAX_SSE_CONNECTIONS`
+  (default `VTSEARCH_THREADS - 2`, override `VTSEARCH_SSE_MAX_CONNECTIONS`).
+- Region-less media in a mixed patch/non-patch dataset reads its fallback row
+  from the patch-slot embedder (raises if absent).
+- `simulate_voting_iterations` / `run_voting_iterations_eval` calibrate with the
+  production `hidden_dim` + `RandomState(42)`; small-label cost/fpr/fnr shift.
+- Inclusion-slide safe-threshold divergence is now documented as intentional (no
+  runtime change).
+- `POST /api/find/cancel` returns 409 on a stopped in-flight request.
+- `POST /api/detectors/<name>/labels` and `POST /api/dataset/clear` now require
+  `X-Dataset-Id` (+ `X-Detector-Id` for the former); 400 without.
+- `POST /api/example-sort-origin` rejects (400) origins escaping the user's
+  confinement dir in multi-user mode.
+- `fill-from-sort` rolls votes back on a 500.
+- Frontend: Escape closes only the topmost modal; Escape/backdrop on a `prompt()`
+  resolves `null`; Escape under a modal no longer clears the drawn region box.

--- a/docs/plans/dataset-import-archives.md
+++ b/docs/plans/dataset-import-archives.md
@@ -1,49 +1,7 @@
 # Dataset import from local archives
 
 **Status: shipped.** Folder and URL importers can now read media out of a
-local zip/tar/rar archive. Open follow-ups are listed at the bottom.
-
-## Motivation
-
-Before this change there was no way to import a local archive of media:
-
-- `server_folder` scanned a directory by media-extension and silently skipped
-  any `.zip` / `.tar` inside it.
-- `http_archive` could extract archives but only from an `http(s)://` URL (it
-  streamed via `download_file_with_progress`); a local path in its
-  "Path or URL" field was rejected.
-
-## What shipped
-
-- **`vtscore/datasets/archive.py`** — central home for archive handling:
-  - `extract_archive` (moved here from the `http_archive` importer, with the
-    `_reject_traversal` guard) — extracts `.zip` / `.tar(.gz|.bz2|.xz)` /
-    `.rar`, validating every member against path traversal first.
-  - `extract_archive_cached` — extracts into a directory under `DATA_DIR`
-    keyed by the archive's path + size + mtime, so re-imports and later
-    resolves reuse one extraction and a replaced archive busts the cache.
-  - `is_archive_path`, `find_archives`, `append_medias`.
-  - `iter_archive_chunks` / `load_archive_into` — load an archive's contents
-    through the same direct/PDF/converter pipeline as the folder loader.
-- **`local_archive` origin** — media loaded from an archive carry
-  `{"importer": "local_archive", "params": {"path": <abs archive>, "media_type": ...}}`.
-  Only the archive path is persisted; the system re-derives
-  `origin → archive → extracted file → embedding` on demand (no-persist rule).
-  - Resolved by **`vtscore/datasets/sources/local_archive.py`**
-    (`LocalArchiveSource`, auto-discovered as `name="local_archive"`), which
-    extracts (cached) and delegates to `LocalFolderSource`.
-  - Converter-derived media re-derive via the converter origin's
-    `parent_importer` / `parent_path`; PDF pages via the resolver's generic
-    `params.path` fallback against the cached extraction dir.
-- **`server_folder`** — the folder field accepts a single archive file; a new
-  opt-in **`dig_archives`** checkbox extracts archives found inside the scanned
-  folder. The CLI `is_dir` guard was relaxed to allow archive paths.
-- **`http_archive`** — accepts a local server path (not just a URL); local
-  paths route through `load_archive_into` and emit `local_archive` origins.
-- **Frontend** — "Dig into archives" checkbox added to the server-folder view;
-  the existing typed folder-path input already accepts an archive path.
-- The PDF page-expansion helper moved to `vtscore/datasets/pdf.py`
-  (`load_pdf_images_into`), shared by the folder importer and archive loader.
+local zip/tar/rar archive. Open follow-ups first; shipped detail below.
 
 ## Open follow-ups
 
@@ -60,3 +18,27 @@ Before this change there was no way to import a local archive of media:
   and is fully re-derivable).
 - **Slow CLI subprocess tests** (`-m slow`, ~290s) were not run for this
   change; the fast suite plus new `run_cli` unit tests cover the paths.
+
+## What shipped
+
+- **`vtscore/datasets/archive.py`** — central archive handling: `extract_archive`
+  (`.zip`/`.tar(.gz|.bz2|.xz)`/`.rar`, validates every member against traversal via
+  `_reject_traversal`); `extract_archive_cached` (extracts into a `DATA_DIR` dir
+  keyed by path+size+mtime, so re-imports reuse one extraction and a replaced
+  archive busts the cache); `is_archive_path`, `find_archives`, `append_medias`,
+  `iter_archive_chunks`/`load_archive_into`.
+- **`local_archive` origin** — media carry `{"importer": "local_archive", "params":
+  {"path": <abs archive>, "media_type": ...}}`; only the archive path is persisted,
+  resolved by `vtscore/datasets/sources/local_archive.py` (`LocalArchiveSource`,
+  extracts cached then delegates to `LocalFolderSource`). Converter media re-derive
+  via the converter origin's `parent_importer`/`parent_path`; PDF pages via the
+  resolver's generic `params.path` fallback.
+- **`server_folder`** — folder field accepts a single archive file; opt-in
+  `dig_archives` checkbox extracts archives inside the scanned folder; CLI `is_dir`
+  guard relaxed for archive paths.
+- **`http_archive`** — accepts a local server path (not just a URL); routes through
+  `load_archive_into` and emits `local_archive` origins.
+- **Frontend** — "Dig into archives" checkbox on the server-folder view; the typed
+  folder-path input already accepts an archive path.
+- **`vtscore/datasets/pdf.py`** — PDF page-expansion helper (`load_pdf_images_into`)
+  shared by the folder importer and archive loader.

--- a/docs/plans/detector-standalone-export.md
+++ b/docs/plans/detector-standalone-export.md
@@ -1,71 +1,8 @@
 # Portable (standalone) detector export
 
-**Status:** Phase 1 shipped. See "Open follow-ups" for deferred work.
-
-## Problem
-
-Trained detectors are normally locked inside VTSearch: the MLP lives in memory
-and is re-derived from labelset origins on demand (the "No Persisted Vectors or
-MLPs" rule in `CLAUDE.md`). There was no way to hand a trained detector to
-another party so they could score their own media without running VTSearch.
-
-## What shipped
-
-A **scoring-only, portable bundle** export for any saved detector. This is the
-sanctioned exception to the no-persisted-MLP rule: it persists the trained
-classifier, but deliberately **no embeddings and no raw media**. A scoring
-detector only needs three things, all of which the bundle carries:
-
-1. the trained MLP (as ONNX),
-2. the name of the embedder to run new media through, and
-3. the decision threshold.
-
-Because none of those is a media-derived vector, the bundle does not leak the
-training set's embeddings. (A trained model can still leak *some* information
-about its training data — membership inference — which the UI warning notes.)
-
-### Format
-
-A zip with three members:
-
-- `detector.onnx` — the MLP with its sigmoid baked in. Input `embedding`
-  `[batch, dim]` → output `score` `[batch, 1]` in `[0, 1]`. The graph is
-  hand-assembled (`Gemm → ReLU → Gemm → Sigmoid`) from the trained model's
-  weights via `onnx.helper`, so it is torch-free and deterministic and avoids
-  torch 2.12's dynamo/onnxscript export machinery.
-- `manifest.json` — machine-readable embedder name/display-name/type, embedding
-  dim, threshold, scoring convention, label counts, provenance. Re-importable
-  and scriptable. `contains_media_data` is always `false`.
-- `README.md` — human-readable: which embedder to run, the threshold, and a
-  copy-paste `onnxruntime` inference snippet.
-
-### Pieces
-
-- `vtscore/detectors/portable_bundle.py` — pure, torch-free builder
-  (`mlp_weights_to_onnx`, `build_manifest`, `render_readme`, `build_bundle`).
-  Operates on the existing `serialize_weights` nested-list dict.
-- `POST /api/detectors/<detector_id>/portable-bundle`
-  (`vtsearch/routes/detectors/export.py`) — trains the detector against the
-  **active dataset** (exactly as Find does, in that dataset's embedder space),
-  then streams the zip. Requires `X-Dataset-Id`; the detector is resolved by URL
-  id, so the active *detector* need not match.
-- Frontend: a dedicated `vt-detector-portable-export-modal` opened from a new
-  **"Export model"** detector-card menu item (kept distinct from the existing
-  label "Export"). Proportional amber warning panel + Download button;
-  `DetectorsCrudApiService.exportPortableBundle()` fetches the blob.
-- Deps: `onnx` (runtime, to build the graph); `onnxruntime` (test-only, to
-  verify the emitted graph scores identically to the trained torch model).
-
-### Design decisions (settled with the user)
-
-- **Scoring-only**, not re-trainable — no embeddings/labelset in the bundle.
-- **ONNX**, not a TensorFlow file (the stack is PyTorch; ONNX runs with just
-  `onnxruntime`) and not raw JSON weights (ONNX is more portable for third
-  parties).
-- **Dedicated modal**, not a tab in the existing label-export modal (which is
-  label-centric) — the model export needs its own warning surface. The finer
-  new-tab-vs-modal choice was made by Claude because the `AskUserQuestion` tool
-  was failing in that session; revisit if the user prefers a tab.
+**Status:** Phase 1 shipped — a scoring-only, portable bundle export for any
+saved detector. Open follow-ups first; shipped detail and settled design
+decisions below.
 
 ## Open follow-ups
 
@@ -87,3 +24,37 @@ A zip with three members:
 - **Screenshot.** The new modal is a GUI surface; if a doc screenshot frames it,
   add the shot id to `docs/user/screenshots-reshoot-queue.md` (no browser in the
   cloud container to reshoot this session).
+
+## What shipped
+
+A zip bundle — the sanctioned exception to the no-persisted-MLP rule: it
+persists the trained classifier but deliberately **no embeddings and no raw
+media**, so it can't leak the training set's embeddings (membership inference
+still possible; the UI warns). Three members:
+
+- `detector.onnx` — the MLP with sigmoid baked in (`Gemm → ReLU → Gemm →
+  Sigmoid`), hand-assembled via `onnx.helper` from the trained weights so it's
+  torch-free/deterministic. Input `embedding` `[batch, dim]` → `score` `[batch, 1]`.
+- `manifest.json` — embedder name/display-name/type, dim, threshold, scoring
+  convention, label counts, provenance; `contains_media_data` always `false`.
+- `README.md` — which embedder to run, the threshold, a copy-paste `onnxruntime`
+  snippet.
+
+Pieces:
+- `vtscore/detectors/portable_bundle.py` — pure, torch-free builder
+  (`mlp_weights_to_onnx`, `build_manifest`, `render_readme`, `build_bundle`) over
+  the `serialize_weights` nested-list dict.
+- `POST /api/detectors/<detector_id>/portable-bundle`
+  (`vtsearch/routes/detectors/export.py`) — trains against the **active dataset**
+  (as Find does) then streams the zip; requires `X-Dataset-Id`, detector resolved
+  by URL id.
+- Frontend — `vt-detector-portable-export-modal` opened from a new **"Export
+  model"** detector-card menu item; amber warning panel + Download;
+  `DetectorsCrudApiService.exportPortableBundle()` fetches the blob.
+- Deps — `onnx` (runtime); `onnxruntime` (test-only, verifies the graph scores
+  identically to the trained torch model).
+
+Design decisions (settled with the user): scoring-only, not re-trainable; ONNX
+(not TensorFlow, not raw JSON weights); dedicated modal (not a tab in the
+label-centric export modal) — the modal-vs-tab call was Claude's because
+`AskUserQuestion` was failing that session; revisit if a tab is preferred.

--- a/docs/plans/docs-audit-2026-06-28.md
+++ b/docs/plans/docs-audit-2026-06-28.md
@@ -1,327 +1,94 @@
 # Documentation Audit — 2026-06-28
 
-**Status:** Audit complete. The Part C recipe fixes + Part E caption fixes
-landed with the audit (commit `3b172f0c`), and the **screenshots shipped
-2026-06-28**: the 7 Part A retakes were recaptured and the 4 Part B shots
-(`new-detector`, `find-view`, `find-stats`, `achievements`) were added to the
-manifest, captured in light+dark, and embedded at their USER_GUIDE anchors —
-driven against a live GRID-hosted app over an SSH tunnel from a RAM-tight
-laptop (browser local, embedders remote). The Part D prose pass also already
-landed in `3b172f0c`. See "Open follow-ups" for what remains.
+**Status: complete.** Every prescribed fix landed — the capture-recipe (Part C),
+caption (Part E), and prose (Part D) fixes in commit `3b172f0c`; the 7 Part A
+screenshot retakes + 4 Part B new shots captured, embedded, and manifest-wired
+2026-06-28 (driven against a live GRID app over an SSH tunnel). Only the optional
+`browse-bin-popup` was left out. The audit covered every doc under `docs/` plus
+`README.md`, checked against the current frontend/backend/library, the OpenAPI
+snapshot, and the install/deploy scripts, after ~170 frontend commits had drifted
+the guide and staled 6 of 16 screenshots.
 
-**Scope.** Every doc under `docs/` plus the root `README.md`, checked against
-the *current* frontend (`frontend/src/app`), backend routes (`vtsearch/`),
-library (`vtscore/`), the OpenAPI snapshot (`frontend/openapi.json`), the
-install/deploy scripts, and the Dockerfiles.
+## What's still owed
 
-**Why now.** The user-doc screenshots and the user guide were last refreshed
-at `b0bddcd3` (~2026-06-10/06-18). **~170 frontend commits** have landed
-since, and the drift is large enough that the user guide actively misleads
-in several places and 6 of 16 screenshots are stale (2 with broken capture
-recipes). The screenshot harness itself is intact (the
-`frontend/docs-assets → ../docs/user` symlink + angular.json glob still feed
-both GitHub `<picture>` embeds and the in-app Help panel), so a refresh is a
-re-run once the recipes below are fixed.
+- **Optional `browse-bin-popup`** (Part B item 5): not added — it has no
+  USER_GUIDE anchor/placeholder, so it stayed out of scope. Recipe when a
+  Browse-detail section is written to home it: within `openBrowse()`, hover/click
+  a tile so `vt-browse-bin-popup` appears; `clip` the popup. (The other
+  new-shot recipes — `find-view`, `find-stats`, `new-detector`, `achievements` —
+  already shipped into `screenshots.manifest.ts`.)
+
+Nothing else is open. The "Screenshots shipped" record and the per-document fix
+inventory below are the log of what the audit fixed.
 
 ---
 
-## Part A — Screenshots to RETAKE (existing shots)
+## What shipped
 
-16 logical shots × 2 themes live in `docs/user/screenshots.manifest.ts` /
-`docs/user/assets/`. Verdicts (full table in the per-shot notes):
+### Screenshots (Parts A + B, captured 2026-06-28)
 
-| Shot | Why retake | Priority |
-|------|-----------|----------|
-| `view-options` | List/grid toggle **removed** (`27854785`); the shot also captures the *Settings* pane, not the real in-panel view toolbar — recipe must be re-targeted (see Part C). Caption factually wrong. | **P0** |
-| `results-grid` | media-item/list markup rewritten in the list-removal pass (`27854785`); `gridView()` step is now dead. | **P0** |
-| `dashboard-loaded` | Dashboard rows restructured: actions collapsed into a `⋯` overflow menu, Actions column content-pinned, inline Delete (`5b8826d9`, `e164e9b7`, `d5a22a28`). This is also the **README hero**. | **P0** |
-| `dashboard-manage` | Same dashboard-row restructuring. Retake with the `⋯` menu open. | **P0** |
-| `settings-appearance` | Settings tabs reorganized/renamed/re-sorted; Solo media type moved to a different tab (`9d670ef7`). | **P1** |
-| `browse-view` | VTSBrowser visuals changed (zoom borders/minimap/bin-popup); **and** the entry point moved — Browse is now a `⋯`-menu item, so `openBrowse()` is broken (see Part C). | **P1** |
-| `importer-picker` (also in demos.md) | Demo importer gained a **per-media-type tab bar** the shot predates; shot shows a flat Downloaded/Synthetic row. | **P1** |
+Captured against a live GRID app over an SSH tunnel (browser local, embedders
+remote), RAM-safe on a ~3.7 GB laptop. Manifest went 16 → **20 logical shots**.
 
-**Keep (still accurate):** `dataset-panel`, `importer-form`, `three-panel`,
-`autopilot-vote`, `manual-controls`, `region-voting`, `export-picker`,
-`import-detector`. (`autopilot-progress` keeps its image but needs a caption
-fix — Part F.)
+- **Part A retakes (7 logical / 14 PNGs):** `view-options`, `results-grid`,
+  `dashboard-loaded` (README hero), `dashboard-manage` (annotation `highlight`→`box`
+  so the open `⋯` menu isn't dimmed), `settings-appearance` (Solo media type
+  moved to Import Defaults), `browse-view` (hex bins + two controlled zoom-outs),
+  `importer-picker` (drills into the Downloaded Media catalogue). Driven by the
+  fixed Part C recipes.
+- **Part B new shots (4 logical / 8 PNGs):** `new-detector` (Blank tab),
+  `find-view` (three-pane verification view), `find-stats` ("Detector Stats"
+  modal, clipped), `achievements` (tiered panel) — manifest entries + recipes
+  added, `<picture>` embeds wired at their USER_GUIDE anchors.
+- Browse PNGs 256-colour quantised to stay under the 500 KB large-file cap.
 
-**Net: 7 logical shots to retake** (`view-options`, `results-grid`,
-`dashboard-loaded`, `dashboard-manage`, `settings-appearance`, `browse-view`,
-`importer-picker`) = 14 PNGs.
+### Capture recipes/helpers (Part C, landed `3b172f0c`)
 
----
+- `openBrowse()` now opens Browse via the row's `.overflow-btn` (`⋯`) →
+  "Browse" menu item (the inline `.browse-btn` eye is gone).
+- Dropped the dead grid-toggle step from `gridView()` / the `results-grid`
+  recipe (list/grid toggle removed in `27854785`).
+- Re-targeted the `view-options` recipe to the in-panel `vt-view-controls`
+  toolbar (it had been capturing the Settings pane).
+- `dashboard-manage` opens the `⋯` overflow menu.
 
-## Part B — NEW screenshots needed (undocumented/under-documented features)
+### Manifest captions (Part E, landed `3b172f0c`)
 
-Ranked by value. Each implies a new manifest entry + USER_GUIDE section/paragraph.
+- `autopilot-progress` caption → real phases (Find Initial Goods, Find Initial
+  Bads, Refine Boundary, Explore Diversity); `view-options` caption dropped
+  "List vs. grid" → grid icon size + focus mode. New entries for the 4 Part B shots.
+- **Masking is now gauge-robust:** `maskVolatile` masks both the RAM *and* disk
+  usage gauges by selector and re-asserts right before capture (the earlier
+  "disk gauge masking gap" is resolved).
 
-1. **Find three-pane verification view** — the entire Find workflow is invisible
-   today. Find is not "a ranked results modal"; it opens a full left/center/right
-   verification view (work queue → verify Good/Bad → Verified piles, plus
-   To-Dataset / Add-Corrections / Stats / inclusion). `find-view.component`.
-2. **Find Stats modal** — confusion matrix + "false pos/neg vs. inclusion" curve.
-   Doubles as the visual the guide currently lacks for the inclusion tradeoff.
-   `find-stats-modal.component`.
-3. **New-detector modal (Blank tab)** — how a detector first comes into being
-   (text seed / media example; Blank vs Trained; embedder-type picker). The guide
-   never documents detector *creation*. `new-detector-modal.component`.
-4. **Achievements panel** — a whole gamification system (trophy button, unlock
-   toasts, 10 achievements w/ tiers, the "code phrase" mechanic the guide's own
-   footer participates in) is completely undocumented. `achievements-tab`,
-   `vtsearch/achievements.py`.
-5. *(optional)* **Browse bin-popup** — select-all + representative-item preview,
-   to flesh out the Browse section.
+### Prose / instruction fixes (Part D, landed `3b172f0c`)
 
----
-
-## Part C — Capture recipes/helpers to fix BEFORE a refresh run
-
-These will time out or click dead/disabled targets if run as-is:
-
-- **`openBrowse()` helper** (`scripts/screenshots/capture.ts`): the inline
-  `.browse-btn` eye is gone from resting dataset rows (it now only renders as a
-  *disabled* projection-building button, `dataset-card.component.html:63`). Open
-  Browse via the row's `.overflow-btn` (`⋯`) → "Browse" context-menu item
-  (`card-context-menu-items.ts:110`).
-- **`gridView()` helper / `results-grid` recipe**
-  (`capture.ts`; `screenshots.manifest.ts:262-270`): the list/grid toggle was
-  removed (`27854785`); its selectors no longer match and `.vc-btn` nth(1) now
-  hits "Bigger thumbnails." Drop the grid-toggle step — the list is always a grid.
-- **`view-options` recipe** (`screenshots.manifest.ts:251-254`): currently calls
-  `openSettings()`, so it captures the Settings pane (duplicating
-  `settings-appearance`). Re-target to the in-panel `vt-view-controls` toolbar.
-- **`dashboard-manage` recipe**: add a step to open the `⋯` overflow menu so the
-  retaken shot shows where Browse/Stats/Export/Rename now live.
-
----
-
-## Part D — Prose / instruction fixes by document
-
-### USER_GUIDE.md — heavily drifted; §7 is the worst
-
-- **§7 View options — rewrite wholesale.** There is no "View button" and no
-  view-settings *modal*; controls are an inline `vt-view-controls` toolbar
-  (thumbnail size + focus mode only). "List vs. grid" is gone. There is no
-  separate right-panel view modal. **Solo media type** moved to the **Import
-  Defaults** tab. The entire **"Locking the embedder / Solo media embedder / Ask
-  each time"** subsection describes UI that is not rendered (dead TS, no template
-  binding). Replace with the real Settings tabs: Appearance, Auto-Find, Autopilot,
-  Browser, Import Defaults, Server, Sorting.
-- **§4 Autopilot — labels wrong.** Phases render **"Find Initial Goods. / Find
-  Initial Bads. / Refine Boundary. / Explore Diversity. / Done!"** Config fields
-  are **"# Good to start / # Bad to start / # Start to re-sort / Goal Diversity"**
-  under a Settings tab now named **Autopilot**. Re-verify the cited defaults
-  (3/4/10/40%) against `vtscore` settings — they're backend-sourced.
-- **§5 Manual mode.** Sort order is **Text → Load → Learned** (not Text/Learned/
-  Load). The "inclusion slider" is a **numeric stepper**, and it **triggers
-  retraining** — the guide's "re-ranks instantly; you don't need to re-train" is
-  the opposite of the tooltip. "Load" picks a **saved registry detector**, not a
-  "detector file."
-- **§8 Dashboard.** Real dataset columns: Type / # Items / Created / Age-Off /
-  Creator / Readers — **not** duplicate-count/origin/clipper/embedder. No "Loaded"
-  column or ×/checkmark toggle (load is an inline "Load" button that vanishes once
-  loaded). Browse/Stats/Export/Add-Labels are in the `⋯` menu; Delete is inline.
-  No Auto-Find row indicator. Detector "Add Labels" menu item is labeled "Import
-  Labels."
-- **§9 Browse.** Browse is reached via the `⋯` menu, not an eye button on the row.
-  The prune buttons are **"Verified Good" / "Verified Bad"**, not "Remove from
-  Good."
-- **§10 Exporting.** Use real `display_name`s ("Server JSON File", "Server CSV
-  File", "Webhook (HTTP POST)", "Send by Email"; plus undocumented "Display
-  Results", "Holder Package"). **Clipboard** copies a column-selected delimited
-  table (default Label/MD5/Filename/Category), **not** a JSON `{id,label,score}` list.
-- **§2 Loading.** "Paths File" → "Paths file." The Advanced embedder control is a
-  collapsible section with a primary **Embedder** plus optional **Region embedder**
-  and **Instance embedder** selects (three-role picker). Mention the demo
-  **per-media-type tab bar**, "Merge near-duplicates," and "Reference files in
-  place" import options.
-- **§3 / §6.** Region/overlay capability now also covers **structural (SIFT/VLAD)**
-  embedders, not only `_patch`. Note the new **Highlight** toggle in the image
-  controls.
-- **§11 Importing.** Soften "import detector" (Load-sort lists registry detectors;
-  no detector-*file* upload surfaces) and the fixed `{md5,label}` claim (label
-  import is a server-driven importer picker).
-- **Reusability claim (§1).** Detectors reuse on the same media type **and
-  compatible embedder type** (semantic / patch / structural) — not "any future
-  dataset of the same media type" (`5c98732c`).
-- **New content to add:** Creating a detector; Find/verification; Achievements;
-  Settings-tabs overview; Combine datasets/detectors + bulk delete/select-all;
-  keyboard shortcuts + `?`/in-app guide; right-click media context menu
-  (sort-by-similarity, crop-then-sort, use-as-seed) + crop modal; top-bar
-  dataset/detector pulldowns; resort prompt; drag-and-drop upload; login/offline/
-  toast states (one-liners).
-
-### README.md
-
-- **Project-structure tree is badly stale** (biggest issue): ~18 paths listed
-  under `vtsearch/` now live in **`vtscore/`** (the app-tier vs library-tier
-  split); `vtscore/` isn't mentioned at all; CLI files mislabeled; `cli_main.py`
-  and `tests_lib/` missing. Fix the tree or replace it with a 2-line pointer to
-  `docs/ARCHITECTURE.md` (the canonical map).
-- **Hero `dashboard-loaded`** — retake (Part A).
-- **Audience:** lead with the visitor path (pitch → screenshot → install/run/try a
-  demo); push contributor material below a divider. Surface `--local`.
-
-### demos.md
-
-- **Catalogue is incomplete** (README calls it "the full list"): missing video
-  `hmdb51_*`, `ucf101_full_*`, `kth_*`, `ucf101_a`; text `wikipedia_topics_*`,
-  `arxiv_abstracts_*`, `reuters21578_*`; plus `_a`/`_l` size variants for audio
-  (`esc50_a`) and image (`caltech*`). Consider auto-generating tables from
-  `all_demo_datasets()` so they can't drift again.
-- **`importer-picker`** — retake (Part A).
-- **De-duplicate with USER_GUIDE** — reduce to a reference catalogue + a link to
-  the loading walkthrough.
-
-### Operator docs (CLI / SETUP / DEPLOYMENT / HANDOFF)
-
-- **DEPLOYMENT** "four embedding models" → **five** (`download_models.sh` runs
-  1/5–5/5 incl. CLIP); add CLIP to the model table. Concurrency-defaults prose
-  (lines ~372-376) contradicts the same doc's lines 30-37 and the current loader
-  (default 1 on accelerator, CPU-scaled by cores/RAM). Note `docker compose build`
-  bakes `0.0.0-unknown` unless `VTSEARCH_VERSION` build-arg is passed. Beef up the
-  thin reverse-proxy section (TLS/SSE/long-request timeouts vs `VTSEARCH_TIMEOUT=0`).
-- **HANDOFF** "Lint / Audit dependencies workflows run on every push" is **false**
-  — there is no CI (`./run-tests.sh` is the gate). Model-size figure 3.1 vs 3.2 GB
-  inconsistent with DEPLOYMENT.
-- **CLI** document `--login api_key` (second provider), `--progress-format`
-  (text/json NDJSON), and `--port`.
-- **SETUP** Node 22+ vs Dockerfiles' `node:20-slim` — repo-wide inconsistency
-  (CLAUDE.md also says 22+); needs a maintainer decision.
-- **Suggested visuals:** architecture SVG in HANDOFF (highest value), first-screen
-  screenshot in SETUP, an annotated `--autodetect`/`--dry-run` terminal capture in
-  CLI.
-
-### Developer docs (ARCHITECTURE / ML / EVAL / EXTENDING*)
-
-- **P0 correctness:**
-  - **ML.md class-weighting** describes inclusion entering *training*; it no longer
-    does (`mlp.py:193-197` uses inverse-frequency weights only; inclusion is a pure
-    threshold knob in `find_optimal_threshold`). Rewrite.
-  - **ARCHITECTURE.md** `train_model(...)` example (line ~369) passes a nonexistent
-    `inclusion_value` arg — won't run. Real signature
-    `train_model(X, y, input_dim, seed=42, hidden_dim=None)`.
-  - **EVAL.md** dataset table: `caltech256_l`→`caltech256_a`, remove `caltech101_l`,
-    add `visual_genome_s/m` (its own region-voting examples depend on them).
-  - **EXTENDING-processors.md** "defined in `vtscore/media/base.py`" →
-    `vtscore/media/processors.py` (two places); clarify `process()` is concrete.
-- **Stale/missing:** ML.md `calibrate_count` app default is **1**, not 2.
-  ARCHITECTURE "ten plugin systems" → nine. **Add the VTSBrowse projection
-  subsystem** (`vtscore/projection/` + `/api/projection/*` routes) to the map.
-  Add missing detector modules (`embedder_type`, `model_loading`, `learned_sort`,
-  `positives_browse`), state (`near_dupes`, `diversity_tree`), concurrency
-  (`events.py`), sources (`server_files.py`). Embedder tables in ML.md /
-  EXTENDING-media.md omit `ast`, `clap_general`, `whisper_encoder`, `clip`,
-  `siglip2`, `sift_vlad`, `face`.
-- **EXTENDING* plugin guides are otherwise accurate.**
-- **Suggested visuals:** request→context state-resolution diagram (ARCHITECTURE,
-  highest value); training/threshold dataflow diagram (ML, drawing inclusion as a
-  *threshold* input — would have prevented the current error); EVAL sample output.
-
-### API docs (API.md, api/*.md, vtscore-api.md)
-
-- All hand-written; OpenAPI snapshot (`frontend/openapi.json`, 213 endpoints) is
-  ground truth. Prose covers ~126; ~87 undocumented (many are acceptable
-  family-expansions, but whole features are missing).
-- **P0:** **io.md** documents `processor-importers` routes that **don't exist** —
-  real routes are `GET /api/pregen-processors` + `POST /api/pregen-processors/add`,
-  and they register OCR/Speech/Face autorun processors, not detectors.
-- **vtscore-api.md** import paths are largely wrong (claims package-root re-exports
-  that don't exist; `vtscore.concurrency`/`vtscore.security` have no `__init__.py`,
-  so `from vtscore.security import safe_pickle_load` fails — it's
-  `vtscore.security.pickle`). `set_thread_progress_callback` /
-  `get_thread_progress_callback` are documented but unimplemented.
-- **medias.md** prose `type` → `media_type` (×2); add `embedders` field;
-  add `vote-bulk`, `thumbnail`, `example-sort-by-id`.
-- **labeling.md** add eval `train-and-score` `cancel/{job_id}` + `result`;
-  reconcile `span` vs `diverse` indicator metric naming.
-- **Missing feature families to document:** achievements, projection/VTSBrowse,
-  sessions, jobs, autorun-extractors/localizers CRUD, dashboard disk/ram-usage,
-  find cancel/stats/corrections, health probes (`/healthz`, `/readyz`),
-  `GET /api/version`.
-
----
-
-## Part E — Manifest changes (caption + new entries)
-
-- **Caption fix `autopilot-progress`** (`manifest:175`): phases →
-  "Find Initial Goods, Find Initial Bads, Refine Boundary, Explore Diversity."
-- **Caption fix `view-options`** (`manifest:249`): drop "List vs. grid" → grid
-  icon size + focus mode only.
-- **New entries** for the Part B shots (find-view, find-stats, new-detector,
-  achievements [, browse bin-popup]).
-
----
-
-## Open follow-ups (what's owed)
-
-1. ~~Fix the capture recipes/helpers in Part C, then run the harness in a
-   browser-capable env.~~ **Done 2026-06-28.** Part C landed with the audit;
-   verified live and refined while capturing (see "What shipped 2026-06-28").
-2. ~~Retake the 7 stale shots (Part A) + capture the new shots (Part B).~~
-   **Done 2026-06-28** — all 7 retaken, all 4 Part B added/captured/embedded.
-3. ~~Apply the prose fixes (Part D).~~ **Already landed** in `3b172f0c`.
-4. ~~Update `docs/plans/user-docs-screenshots.md` "Shot list" to the current
-   20 shots and record the 4 new manifest entries there.~~ **Done 2026-06-28** —
-   added a "Shot list (v2 — 2026-06-28)" addendum there.
-5. **Optional `browse-bin-popup`** (Part B item 5) was **not** added — it has
-   no USER_GUIDE anchor/placeholder, so it stayed out of scope this pass.
-6. **Masking is now gauge-robust.** `maskVolatile` masks both the RAM *and*
-   disk usage gauges by selector and re-asserts right before capture (the disk
-   gauge previously slipped through and Angular's poll could re-render live
-   values). The earlier "disk gauge masking gap" follow-up is resolved.
-
-## What shipped 2026-06-28 (the capture run)
-
-- **Captured against a live GRID app over an SSH tunnel** (`localhost:PORT` →
-  compute node), browser running locally, embedders/projection on the GRID —
-  RAM-safe on a ~3.7 GB laptop (free RAM never dipped below ~650 MB).
-- **Part A retakes (7 logical / 14 PNGs):** `dashboard-loaded` (now deselects
-  any leftover fixture selection for a clean overview), `dashboard-manage`
-  (annotation switched `highlight`→`box` so the open ⋯ menu isn't dimmed),
-  `importer-picker` (now drills into the Downloaded Media catalogue + media-type
-  selector instead of the bare Demo landing), `browse-view` (hex bins + two
-  controlled zoom-outs — `Zoom to fit` over-zoomed 60 points to blank),
-  `view-options`, `results-grid`, `settings-appearance` (caption corrected:
-  Solo media type lives on Import Defaults, not Appearance).
-- **Part B new shots (4 logical / 8 PNGs):** `new-detector`, `find-view`,
-  `find-stats` (titled "Detector Stats" in-app), `achievements` — manifest
-  entries + recipes added and `<picture>` embeds wired at their USER_GUIDE
-  anchors (the `<!-- SCREENSHOT TODO -->` placeholders are gone).
-- Browse-view PNGs were 256-colour quantised to stay under the 500 KB
-  added-large-file cap (synthetic flat colours quantise without banding).
-
----
-
-## Appendix — ready-to-paste recipes for the NEW shots (Part B)
-
-These are NOT yet in `screenshots.manifest.ts` because the wiring-check gate
-requires both PNGs on disk for every manifest id; add each entry only when you
-capture it in a browser-capable session. Selectors below were confirmed against
-the current components.
-
-- **`find-view`** — `embeddedIn: docs/user/USER_GUIDE.md#find--scoring-and-verifying`.
-  Route `find/:datasetId/:detectorId`; reached from the dashboard by selecting a
-  dataset row + detector row and clicking **Find** (`.dashboard-actions`, the
-  search-icon "Find" button). The view reuses `.panel-left/.panel-center/.panel-right`;
-  the right panel is in find mode (`right-panel.component.html`: headings
-  **"Verified Good" / "Verified Bad"**, "N Unverified Good/Bad" notes, and the
-  Browse / To Dataset / Export `.goods-action-btn`s). Recipe: a Find-mode twin of
-  `enterLabelView()` — select fixture dataset+detector, click Find, wait for
-  `.panel-right` to show the "Verified Good" heading. Annotate the Verified piles +
-  action row.
-- **`find-stats`** — `embeddedIn: ...#find--scoring-and-verifying`. The
-  `vt-find-stats-modal` (`.stats-table`, confusion-style Good/Bad/Verified rows +
-  the false-pos/neg-vs-inclusion SVG) is rendered inside find-view and opened by the
-  Stats control (`showStats`). Recipe: reach find-view (above) → open Stats → wait
-  for `.stats-table`. `clip` the modal.
-- **`new-detector`** — `embeddedIn: ...#creating-a-detector`. Open via the **+** on
-  the Detectors card; modal has a `.tab-bar` with `.tab-btn` **Blank** / **Trained**.
-  Capture the Blank tab (text-seed / media-example fields + embedder-type picker).
-  Recipe: dashboard → click the Detectors-card add button → wait for `.tab-bar`.
-- **`achievements`** — `embeddedIn: ...#achievements`. Open via the header
-  `.achievements-btn` (trophy). Capture the achievements panel/modal. Recipe:
-  dashboard → click `.achievements-btn` → wait for the panel. (Requires the
-  "Enable achievements" setting on, which is the default.)
-- **`browse-bin-popup`** *(optional)* — within `openBrowse()`, hover/click a tile so
-  the `vt-browse-bin-popup` appears; `clip` the popup.
+- **USER_GUIDE.md** — §7 View options rewritten (inline `vt-view-controls`
+  toolbar, no view modal, Solo media type on Import Defaults, real Settings tabs);
+  §4 Autopilot phase/field labels corrected; §5 Manual mode sort order Text→Load→
+  Learned, inclusion is a numeric stepper that retrains, "Load" = saved registry
+  detector; §8 Dashboard real columns + `⋯`-menu actions; §9 Browse via `⋯` menu,
+  "Verified Good/Bad" prune buttons; §10 real exporter `display_name`s + clipboard
+  behaviour; §2 Loading (three-role embedder picker, demo tab bar, dedup/reference
+  options); §3/§6 structural (SIFT/VLAD) region support + Highlight toggle; §11
+  Importing softened; §1 reusability claim scoped to compatible embedder type.
+  New sections: detector creation, Find/verification, Achievements, Settings-tabs
+  overview, combine/bulk-delete, keyboard shortcuts, context menu, dataset/detector
+  pulldowns, resort prompt, drag-and-drop, login/offline states.
+- **README.md** — stale project-structure tree fixed (app-tier `vtsearch/` vs
+  library-tier `vtscore/` split); hero retaken; visitor-first ordering, `--local`.
+- **demos.md** — completed catalogue (missing video/text sources + `_a`/`_l`
+  variants), de-duplicated against USER_GUIDE.
+- **Operator docs** — DEPLOYMENT "four models" → five (+ CLIP), concurrency-defaults
+  reconciled, `docker compose build` version-arg note; HANDOFF "CI runs on every
+  push" corrected (no CI); CLI `--login api_key` / `--progress-format` / `--port`
+  documented; SETUP Node-version inconsistency flagged.
+- **Developer docs** — ML.md class-weighting rewrite (inclusion is a threshold
+  knob, not a training input) + `calibrate_count` default 1; ARCHITECTURE
+  `train_model` signature fixed + VTSBrowse projection subsystem + missing
+  modules/plugin-count added; EVAL.md dataset table fixes; EXTENDING-processors.md
+  path fix; embedder tables completed.
+- **API docs** — io.md `processor-importers` → real `pregen-processors` routes;
+  vtscore-api.md import paths corrected; medias.md `type`→`media_type` + missing
+  fields/endpoints; labeling.md eval routes; documented achievements, projection,
+  sessions, jobs, autorun CRUD, health probes, `GET /api/version`.

--- a/docs/plans/find-verification-workflow.md
+++ b/docs/plans/find-verification-workflow.md
@@ -1,176 +1,21 @@
 # Find Verification Workflow
 
-**Status:** **Phase 1 (backend spine) + Phase 2 (frontend) + Phase 3 (verified-only colouring) + Phase 4 (left work-queue actions) shipped** — full `./run-tests.sh` green. The UI was built without a browser in the container, so it passes `npm run build:prod` (no TS errors, no budget warnings) but was **not visually eyeballed**; a manual pass on a real screen is still owed. See **What shipped / Open follow-ups** at the bottom.
+**Status:** Phases 1–4 all shipped (backend spine, frontend, verified-only colouring, left work-queue actions); full `./run-tests.sh` + `npm run build:prod` green. Built headless (no browser in the container), so the UI has **not been visually eyeballed** — a manual pass on a real screen is still owed. Open follow-ups below; shipped detail collapsed under "What shipped".
 
-## The reframe (read this first)
+## The reframe (essential framing)
 
-Verification is **not a new mode**. It is a richer label vocabulary layered onto the *existing* Find interface. Find scores every item with the detector; a cutoff line splits them into **good** (≥ cutoff) and **bad** (< cutoff). We keep that split and add one distinction on top — **has a human touched this item or not** — yielding four states:
+Verification is **not a new mode** — it's a richer label vocabulary on the *existing* Find interface. Find scores every item; a cutoff splits **good** (≥ cutoff) from **bad** (< cutoff). We add one distinction on top — **has a human touched this item** — yielding four states:
 
 | State | Meaning | How it arises |
 |-------|---------|---------------|
-| **Unverified Good** | Above the cutoff, detector's call, human hasn't looked | Default for every above-cutoff item |
-| **Unverified Bad** | Below the cutoff, detector's call, human hasn't looked | Default for every below-cutoff item |
-| **Verified Good** | Human confirmed (or rescued) it as good | Human acted on the item with the **Good** button |
-| **Verified Bad** | Human confirmed (or culled) it as bad | Human acted on the item with the **Bad** button |
+| **Unverified Good** | Above cutoff, detector's call, human hasn't looked | Default above-cutoff |
+| **Unverified Bad** | Below cutoff, detector's call, human hasn't looked | Default below-cutoff |
+| **Verified Good** | Human confirmed/rescued as good | Human hit **Good** |
+| **Verified Bad** | Human confirmed/culled as bad | Human hit **Bad** |
 
-A user who just wants "run the detector and export the hits" never touches a verify button: they export the Unverified sets exactly like today. A user who wants to verify walks the work queue and confirms items, promoting them from Unverified to Verified. **Same screen, no toggle.**
+Same screen, no toggle: a user who just wants "run the detector and export the hits" never touches a verify button; a user who verifies walks the left work queue and promotes items into the right verified pile.
 
-## Core mechanic: score once, then slide a cutoff over frozen scores
-
-This is the spine of the whole feature, so it comes first.
-
-**The detector scores every item exactly once**, at its trained configuration, producing a fixed score per item. Those scores are **frozen** for the life of the Find session. The **Inclusion** slider is a **cutoff** over those frozen scores: sliding it moves the green/red line up or down the fixed ranking. It does **not** retrain the MLP, does **not** re-embed, and does **not** reorder items — it only changes *how deep into the ranking the positive cut goes*. Higher Inclusion = more inclusive = more greens, which is exactly what the name has always meant; we keep calling it Inclusion.
-
-This is a deliberate change from today, where the Inclusion slider retrains the MLP on every change (`-10..10`, feeding hidden-layer width + regularization + calibration). **Inclusion is unified across both Train and Find as a no-retrain cutoff.** It leaves the *model* entirely: the architecture (hidden width) and regularization become fixed defaults, independent of Inclusion. What Inclusion keeps doing is its real job — it's the **exponential weight on false-positive vs. false-negative cost in the cross-calibrated min-cost threshold search** (`calculate_cross_calibration_threshold` → `find_optimal_threshold`, `vtscore/training/thresholds.py`), run over the **LabelSet's** scored vectors (the labeled examples that trained the detector — *not* anything in the Find dataset). Warping that cost function up or down slides the threshold more or less inclusive. Crucially, once the model no longer depends on Inclusion, the labelset fold-scores are inclusion-independent and cacheable, so an Inclusion change re-runs only the cheap min-cost search over cached scores — no MLP fit at all. That threshold is then applied to the Find haystack's frozen scores. Training still happens in Train mode **when you vote** (that's the training loop) — but an Inclusion change never retrains, in either mode.
-
-> **Backwards-compat break (call out to user):** existing detectors' stored `inclusion` values change meaning (training-bias → cutoff position), and model capacity no longer varies with inclusion. Per repo policy we make the clean change and surface the break rather than shimming old behavior.
-
-Freezing the scores is what makes the rest cheap:
-
-- **Instant slide.** No GPU work on a cutoff change — just re-thresholding fixed numbers.
-- **Preserve-verified is automatic.** Verified items carry an explicit human vote that the cutoff never overrides; sliding only reclassifies *unverified* items. Nothing the user does in the left panel can disturb the right panel.
-- **"At what cutoff would this item return?" is a trivial inversion** — every item has one fixed score, so the answer is just where the line crosses it (see Stats, below).
-
-## Data model
-
-State on the active `DetectorContext` (all in-memory, ephemeral — blessed by the "No Persisted Vectors or MLPs" rule, which explicitly allows process-scoped caches on the context):
-
-- **`find_scores: dict[int, float]`** (new) — the frozen per-item detector scores from the single scoring pass.
-- **`inclusion`** (already exists) — now the cutoff knob: the FP/FN cost weight in the min-cost threshold search over the LabelSet vectors. It produces the cutoff (the existing **`threshold`** field) with no MLP retrain; that cutoff is applied to `find_scores`. ("Cutoff" below = `threshold`, computed from `inclusion` via the labelset min-cost calibration.)
-- **`calibration_cache`** (already exists — **re-key it**) — today it memoizes `(key, threshold)` where `key` fingerprints **inclusion** among its inputs (`core.py:391-399`), so every Inclusion change misses and refits all K fold-MLPs. Repurpose it to memoize the **K fold orderings** — each fold's held-out `(calibrate scores, labels)` — under a key that **excludes inclusion**. The fold scores are inclusion-independent once `train_model` drops inclusion, so an Inclusion change hits the cache and re-runs only `find_optimal_threshold` per fold (an O(n) sweep, no torch). Invalidation is unchanged — the cache already busts on labelset/embedder/calibration-setting changes (`dataset_sync.py:208`, context reset); inclusion is simply no longer in the key.
-- **`good_votes` / `bad_votes`** — already exist. In find mode these hold the items' current good/bad assignment.
-- **`verified_ids: set[int]`** (new) — the items the human has explicitly acted on this session.
-
-**Resolved label of any item** = `good` if it's a verified-good vote; `bad` if verified-bad; otherwise `score ≥ cutoff`. The four logical states fall out (the **right panel renders the two verified ones**, stacked Good-over-Bad; the **left panel is the two unverified ones** — the work queue):
-
-```
-Verified Good   = verified_ids ∩ good_votes
-Verified Bad    = verified_ids ∩ bad_votes
-Unverified Good = { i ∉ verified_ids : find_scores[i] ≥ cutoff }
-Unverified Bad  = { i ∉ verified_ids : find_scores[i] <  cutoff }
-```
-
-`verified_ids` is required because confirming an item *without changing its side of the line* (the common case — detector says good, human agrees) leaves no trace in the scores; only an explicit "I looked at this" set captures it.
-
-**Cutoff-slide semantics (no re-score, preserve verified):** moving the slider sets `cutoff` and re-thresholds **only unverified items** against the frozen `find_scores`. Verified items keep their human vote wherever their score lands. An unverified item can flip Unverified Good ↔ Unverified Bad as the line moves; that's expected. No retrain, no re-embed.
-
-**Two scopes, deliberately separated:**
-
-- **Detector-scoped (survives a haystack switch):** the K fold orderings (`calibration_cache`) and the `inclusion`→`threshold` result derived from them. These depend only on the LabelSet + embedder + calibration settings, not the haystack, so pointing the same detector at a different dataset reuses them as-is. They recompute only when the LabelSet changes (Train votes), the embedder changes, or a calibration setting changes — the existing `calibration_cache` invalidation, minus inclusion.
-- **Find-session-scoped (tied to the current haystack):** `find_scores`, `good_votes`/`bad_votes`, and `verified_ids`. These reset when the haystack (dataset) or the detector changes — `reloadForNewPair` in `find-view.component.ts:146` — and the haystack is re-scored. `find_scores` is the *only* thing a haystack switch recomputes; the threshold rides along from detector scope.
-
-## Backend changes
-
-1. **`DetectorContext`** (`vtscore/state/core.py:322`): add `find_scores: dict[int, float]` and `verified_ids: set[int]` (both `field(default_factory=...)`). The cutoff itself reuses the existing `threshold` field (resolved from `inclusion`); no new cutoff field. Both new fields reset only on a pair change, not on an Inclusion slide.
-2. **Inclusion leaves the model (training-path refactor).** `train_model` (`vtscore/training/mlp.py:110`) drops its `inclusion_value` parameter — hidden width + regularization become fixed defaults — and `calculate_cross_calibration_threshold` (`vtscore/training/thresholds.py:227`) stops threading `inclusion_value` into the per-fold `train_model` calls. `inclusion` stays only where it belongs: in `find_optimal_threshold` (the FP/FN cost warp). `POST /api/inclusion` (`sorting.py:760`) stops calling `invalidate_loaded_detector_models()` (`vtscore/state/__init__.py:189-200`) — an Inclusion change no longer drops the MLP; it re-runs only `find_optimal_threshold` over the cached K fold orderings (`calibration_cache` re-keyed to exclude inclusion — see Data model) to get a new `threshold`. This is the unified Train+Find behavior; **it is the backwards-compat break** flagged above.
-3. **Score once, then stop re-scoring (Find).** The find-label run (`vtsearch/routes/detectors/scoring.py`) trains/loads the model and scores all items as today, but now **caches the scores in `find_scores`**, sets the cutoff to the neutral-calibrated default, applies labels by that default (the initial split), and records `find_initial_labels` (the detector's natural call at the default cutoff — the stable eval baseline; see Stats). It no longer reruns on a slider change.
-4. **Repurposed Inclusion endpoint (shared by Train and Find).** `POST /api/inclusion` no longer retrains; it sets `inclusion`, recomputes the cutoff via the labelset min-cost search (cheap — fold-scores cached, only `find_optimal_threshold` re-runs), and re-thresholds the **unverified** items against the frozen `find_scores` (in Find, leaving verified items and `find_initial_labels` untouched). No MLP work. The Find slider calls this same endpoint; there is no separate `/api/find/cutoff`.
-5. **Mark-verified on manual votes in find mode.** When `find_mode` is True and a vote arrives through the *single-item* manual path — the big Good/Bad buttons **and the hover-vote**, which the user has confirmed are equivalent (both pull the item out of the left queue into the right/verified pile) — add the id to `verified_ids`. Cleanest hook: `vtscore/state/votes.py` `set_vote` / `toggle_vote` / `apply_label_with_click_time`, guarded by `is_find_mode()`. The bulk find-label / Inclusion-slide paths stay unverified by construction.
-6. **Expose `verified_ids`** in the `GET /api/votes` payload (a `verified` id array) so the frontend can split verified (right panel) from unverified (left work queue) in one request (`vtsearch/routes/labels/vote.py`).
-7. **Unverified Export.** Extend the label-export `label_filter` (`/api/labels/export`, `vote.py:147`) with `unverified` (emit `good_votes ∪ bad_votes − verified_ids`) and, symmetrically, `verified`. The work-queue dump the user re-imports as a dataset uses `unverified`.
-
-## Frontend changes
-
-1. **Find slider becomes a cutoff control.** `find-view.component.ts onInclusionChange` (currently `setInclusion` → `runFindLabel`, which retrains) now calls the repurposed `POST /api/inclusion` (no retrain). Because the frontend already has every item's score (`sortState.setSortResults(sorted, threshold)` holds `[{id, score}]`), the green/red display updates **optimistically client-side** the instant the slider moves; the POST reconciles server votes for export. No scoring spinner on a slide.
-2. **`VoteStateService`**: track a `verifiedIds` set from the new `/api/votes` `verified` field; expose `verifiedIds$`. On a manual vote in find mode, optimistically add the id.
-3. **Right panel** (`right-panel.component.ts`), find mode — **two verified buckets, stacked**. It lists only verified items; the unverified live on the left.
-   - **Verified Good** (top) with a count-folding header **"[N] Unverified Good"** (N = the unverified-good count on the left). Its **Browse / Export / To Dataset** buttons act on *everything the header folds in* = Verified Good ∪ Unverified Good = the full good set. (`onBrowse`/`onToDataset` already scope over `goodVotes` in `find-view.component.ts:452,475`, so the header label + folding the cutoff-derived unverified set into the scope is the new part.)
-   - **Verified Bad** (bottom), symmetric, with a **"[M] Unverified Bad"** header and bad-set buttons.
-   - The two verified lists come from `good_votes`/`bad_votes` ∩ `verifiedIds$`; the header counts come from scores + cutoff (the unverified sets that live on the left).
-4. **Left panel** = the work queue: the **unverified** items (the scored haystack — unverified Good above the cutoff, unverified Bad below), in score order. This is what the user walks and auto-advances through; verifying an item moves it off the left and into the right. Add an **Unverified Export** button (`label_filter=unverified`).
-5. **Center auto-advance → the marginal positive** (explicit ask): today `find-view.component.ts:439 onMediaVoted` only reloads votes. In find mode, after any vote (button or hover), select the **lowest-scored unverified item still above the cutoff** — i.e. the Unverified Good nearest the line — via `mediaState.selectMedia(nextId)`. This is a cheap active-learning order (always vote the most marginal/uncertain item next, so "just sit and vote" does the most good) without reimplementing Train's Good/Hard ordering. It's intentionally a little jarring — voting the top of the stack throws you to the boundary — but it makes "sit and vote" the optimal default. The initial seed already uses this exact rule (`find-view.component.ts:237` picks the lowest item ≥ threshold), so seed and advance unify. **The queue is empty exactly when no unverified item remains above the cutoff** — that *is* the done state (show a brief "all positives reviewed" rest state). The center-panel swipe fires `mediaVoted` ~180ms after the vote (`center-panel.component.ts:260`), so the advance rides that callback.
-6. **Big Good/Bad buttons must work in find mode.** Ensure the `voting-overlay` is rendered and not `disabled` outside the brief initial-scoring window; its `voted` → `castVote` → `submitToggleVoteAndRecord` path marks the item verified (item 4 above).
-
-## Detector evaluation: the Stats button
-
-The real reason to verify a test haystack is **"is this detector worth subscribing to on my data?"** Stats surfaces that via a **Stats** button on the right panel (same affordance as the Datasets Dashboard card → `vt-dataset-stats-modal`).
-
-**Stats counts ALL items, not just the verified ones.** Exactly like Export / Browse / To-Dataset, it treats unverified items as if verified — adopting the detector's current-cutoff call as their truth. This *risks false confidence* in the detector (an unverified item trivially "agrees" with the detector at the current cutoff), but that's the accepted price of not verifying every item, and the user still wants the totals: skip verifying the obvious top and middle-to-bottom, and those counts still show up. So **truth = the full `good_votes` / `bad_votes` adopted set** (human votes flood-filled with the detector's call on everything untouched); `verified_count` is reported separately as how much was actually human-checked.
-
-**No new tracked state.** The detector's original call per item is `find_initial_labels` (its good/bad at the default calibrated cutoff). Crossing the adopted label against it gives a 2×2:
-
-| | Detector said **Good** | Detector said **Bad** |
-|---|---|---|
-| **Adopted → Good** | Confirmed positive *(agree)* | Rescued false negative *(correction)* |
-| **Adopted → Bad** | Culled false positive *(correction)* | Confirmed negative *(agree)* |
-
-Unverified items adopted the detector's own call, so they fall in the confirmed cells (the false-confidence inflation); corrections come from human overrides.
-
-Reported figures:
-
-- **Totals** — `total_good` / `total_bad` (adopted, all items) and `verified_count` (how many the human actually checked).
-- **Agreements vs. corrections** and the **agreement rate** — `confirmed_good + confirmed_bad` vs. `culled_fp + rescued_fn`, over all items.
-- **Precision** — `confirmed_good / (confirmed_good + culled_fp)`: of everything the detector originally called good, how much the adopted set keeps (inflated by unverified items — the false-confidence number).
-- **FP/FN-vs-Inclusion sweep — the headline chart.** For every inclusion `i ∈ [−10, 10]`, compute the calibrated threshold `t_i` (cheap: re-run the min-cost average over the **cached fold orderings** at `i` — 21 O(n) sweeps, no MLP work), then over **all adopted items** count `FP_i` = adopted-Bad items scoring `≥ t_i` (detector at `i` would wrongly include) and `FN_i` = adopted-Good items scoring `< t_i` (detector at `i` would wrongly drop). Plot both curves against inclusion, current inclusion marked. This is the precision/recall tradeoff *on the user's own data*: as inclusion rises the threshold drops, FP climbs, FN falls — the user reads off the inclusion that best balances the two. At the current inclusion the unverified items contribute nothing (they sit on their own side of the line by construction), so the floor is the verified corrections; moving away from current makes unverified items flip and the curves climb. Subsumes the per-item "at what cutoff would this return?" idea — that's one item's crossing point on this chart.
-- **Run context** — the current cutoff/inclusion.
-
-### Backend
-- **`GET /api/find/stats`**: returns (a) adopted totals + `verified_count`, (b) the 2×2 confusion of the adopted label (`good_votes`/`bad_votes`, all items) × `find_initial_labels` and the derived rates, and (c) the **21-point sweep** `[{inclusion, threshold, false_pos, false_neg}]` for `inclusion ∈ [−10, 10]` over all adopted items — thresholds from the cached fold orderings, counts from the frozen `find_scores`. Pure read; cheap; no new state.
-
-### Frontend
-- **`vt-find-stats-modal`** (mirrors `vt-dataset-stats-modal`): standalone modal on the shared `ModalComponent`, fetches `GET /api/find/stats` on open, renders the 2×2 + rates + the **FP/FN-vs-inclusion line chart** (current inclusion marked). The chart is a small hand-rolled inline SVG in the existing dependency-free viz style (cf. the dashboard card's pie) — no new charting dependency.
-- **Stats button** in the right panel (find mode), beside Browse / Export / To Dataset, emitting a `stats` event `find-view` handles — same wiring as the dashboard card's `stats` output.
-
-## State-transition summary
-
-- **Find run (pair load)** → score once → `find_scores` frozen, `cutoff` = calibrated default, `find_initial_labels` recorded, `verified_ids` empty; center seeded on the item just above the line (`find-view.component.ts:237`).
-- **Slide Inclusion** → re-threshold unverified items only (instant, client-optimistic + cheap `POST /api/inclusion`, no retrain); verified items unmoved.
-- **Good on centered item** (button or hover) → vote good + verify → Verified Good → auto-advance to the next item on the boundary walk (alternating above/below the cutoff, nearest-first).
-- **Bad on centered item** (false positive; button or hover) → vote bad + verify → Verified Bad → auto-advance to the next item on the boundary walk (alternating above/below the cutoff, nearest-first).
-- **Export / Browse / To Dataset (good panel)** → Verified Good ∪ Unverified Good (flood-fill); unreviewed positives ride along on the detector's call.
-- **Unverified Export** → dumps only the untouched work queue for re-import as a dataset.
-
-## Decisions captured
-
-- **Inclusion = pure cutoff, unified across Train and Find, no retrain (CRITICAL).** Inclusion leaves the model entirely (fixed architecture + regularization); it stays the FP/FN cost weight in the labelset min-cost threshold search, which yields the cutoff with no MLP fit. In Find the haystack is scored once and frozen; in Train the model still retrains *when you vote*, but never on an Inclusion change. **Backwards-compat break:** existing `inclusion` values change meaning and model capacity no longer varies with inclusion.
-- **Auto-advance = boundary walk, alternating above/below the cutoff** (`advanceToBoundary`). Each vote jumps the centre to the nearest unverified item on the side it's that turn — closest above the line, then closest below, then next above, and so on — so "just sit and vote" samples both faces of the decision boundary (marginal positives *and* marginal negatives), not just the positive pile. A fresh score restarts the walk on the `above` side, so the seed is still the marginal positive. The queue is empty (done state) only when no unverified item remains on either side. _(Superseded the original "lowest unverified item above the cutoff / positives-only" rule; see Open follow-ups.)_
-- **Hover-vote ≡ button-vote.** Both verify the item and move it left→right; both trigger auto-advance.
-- **Preserve-verified is automatic.** Verified items carry explicit votes the cutoff never overrides; sliding reclassifies only unverified items. The right panel is undisturbed by anything in the left panel. Find-session state (`verified_ids`/`find_scores`/votes) resets when the haystack or detector changes; the detector-scoped K fold orderings + threshold survive a same-embedder haystack switch (see Data model).
-- **Positives-only review**, with the big buttons available on any centered item for one-off ActuallyGood/ActuallyBad marks + auto-advance.
-- **Ephemeral throughout**; Unverified Export is the persistence escape hatch.
-- **Stats eval baseline = the default calibrated cutoff**, fixed at score time, so corrections are measured against the detector's natural recommendation regardless of later slider position.
-
-## What shipped (Phase 1 — backend spine)
-
-All under `./run-tests.sh` (full suite green). Note one doc-vs-code correction discovered during build: `inclusion` only ever fed the **class-weight bias** in `train_model` (the hidden width was already `_auto_hidden_dim(n_train)` and regularization was fixed), so "fixed architecture" was already true — the refactor just removed the class-weight bias.
-
-- **Inclusion decoupled from the MLP.** `train_model` dropped its `inclusion_value` param + class-weight bias; all production/test callers updated. `inclusion` now lives only in `find_optimal_threshold` (the FP/FN cost warp). The model — and every item's score — is inclusion-independent.
-- **Fold-ordering cache.** `calculate_cross_calibration_threshold` split into `compute_fold_orderings` (inclusion-independent) + `threshold_from_fold_orderings` (per-inclusion min-cost). `calibration_cache` re-keyed to drop inclusion and store the K fold orderings, so an Inclusion change reuses the orderings and only re-runs the cheap min-cost search.
-- **No-retrain Inclusion.** `set_inclusion` now calls `recompute_detector_thresholds_for_inclusion` (re-derive threshold from the fold cache, leave the model in place) instead of `invalidate_loaded_detector_models`.
-- **Verification state.** `DetectorContext.verified_ids` + `find_scores` (in-memory; cleared on pair change). Mark-verified on single-item find-mode votes (`set_vote`/`toggle_vote`), un-verify on un-vote.
-- **APIs.** `verified` array on `GET /api/votes`; `unverified`/`verified` `label_filter` on `/api/labels/export` (atomic via `VoteSnapshot.verified_ids`); new read-only `GET /api/find/stats` (adopted-label 2×2 confusion + the −10…10 FP/FN sweep, both over **all** items — unverified flood-filled like Export/Browse, with `verified_count` as context). `find-label` freezes `find_scores`.
-
-## What shipped (Phase 2 — frontend)
-
-All under `./run-tests.sh` (full suite + `npm run build:prod` green).
-
-- **No-retrain Inclusion slide.** `find-view.onInclusionChange` now calls `POST /api/inclusion` (no `runFindLabel`) and reconciles the server-returned cutoff + the re-split unverified votes on the cheap response — no scoring spinner. The backend `set_inclusion` now also re-thresholds the unverified Find items over the frozen `find_scores` (`rethreshold_unverified_find_items`), so export/Stats reflect the slider; `GET|POST /api/inclusion` returns the resolved `threshold`.
-- **Verified-id tracking.** `VoteStateService` exposes `verifiedIds$` (from the `/api/votes` `verified` array) with optimistic add/remove on a manual Find vote (merged over the server set so a racing poll doesn't flicker the left/right split).
-- **Right panel = the verified pile.** Find mode shows only `good/bad ∩ verified`, each bucket headed "Verified Good/Bad (V)" with a folded "[N] Unverified …" count; Browse / To Dataset / Export / Stats act on the **full** good set, a bad-bucket Export acts on the full bad set.
-- **Boundary-walk auto-advance.** After any vote (button or hover) the centre jumps to the nearest unverified item, alternating above/below the cutoff (`advanceToBoundary` + the `nextFindSide` toggle): closest above, then closest below, then next above, etc. The seed restarts the walk on the `above` side, so the first item is still the marginal positive. Empty queue (nothing unverified on either side) → a one-shot "All items reviewed" toast (the done state). _(Replaced the earlier positives-only marginal-positive order.)_
-- **Unverified Export** button in the left work-queue header (`label_filter=unverified`), routed through a shared `vt-export-modal` that now takes an `initialFilter` and fetches the `unverified`/`verified` server partitions.
-- **`vt-find-stats-modal`** — the adopted-totals + verified count, the 2×2 confusion, agreement-rate / precision, and the FP/FN-vs-inclusion sweep drawn as a dependency-free inline SVG line chart (current inclusion marked).
-
-## What shipped (Phase 3 — verified-only colouring)
-
-All under `./run-tests.sh` (full suite + `npm run build:prod` green). This closes the "Left work queue does not hide verified items" deviation and fixes the big buttons reading the detector's presumption.
-
-- **Items colour green/red only once verified.** The detector's threshold split is now a *presumption*, not a vote the UI paints. The left work queue is fed the ranking **minus verified items** (`find-view.unverifiedSortOrder`, recomputed only when the ranking or verified set changes), and the media-list + stripe receive **empty vote sets**, so nothing on the left is coloured. Verified items move to the right pile; the off-left move keeps the media-list and stripe on the same (filtered) index space, so stripe-click navigation stays aligned. The find header counts the unverified work-queue size.
-- **Big Good/Bad buttons verify instead of un-toggling.** `VoteStateService` gained a find-mode flag: `currentState()` reads an *unverified* item as `'none'` (its good/bad is the flood-filled presumption, not a human decision), and `effectiveGood`/`effectiveBad` expose that gated state to the centre buttons. So the buttons read neutral on an unverified item, and a click sets an absolute good/bad (verifying it) rather than toggling the detector's presumption off. The Find view sets the flag on enter and clears it on leave so Label/Train are untouched.
-
-## What shipped (Phase 4 — left work-queue actions)
-
-All under `./run-tests.sh` (full suite + `npm run build:prod` green).
-
-- **Left-panel work-queue actions.** Browse / To Dataset / Export now sit next to the Inclusion control in the Find left panel (`left-panel.component.html`, find mode), each scoped to the **unverified positives** — the above-cutoff slice of the work-queue ranking (which Phase 3 already feeds in verified-filtered), via `find-view.onBrowseUnverified` / `onToDatasetUnverified` and the `unverified_good` export filter. The button gating counts the above-threshold items of the (verified-filtered) `sortOrder`. These complement (do **not** replace) the right-panel trio, which still acts on the *full* good set (verified + unverified). The buttons disable when there are no unverified positives.
-- **`unverified_good` export filter.** A UI-only `LabelFilter` the export modal resolves to the server `unverified` partition sliced to the `good` category; never sent to the backend as a `label_filter` (typed out via `ServerLabelFilter`).
-- **Browse-canvas verify, replacing the cull.** The browse selection panel's single "Remove from Good" button became **"Verified Good" / "Verified Bad"** (`browse-selection-panel`, gated on `canVerify`). Both mark the selection good/bad and verify it (Find-mode `vote-bulk` already lands in `verified_ids`), then drop it from the canvas — so verifying a selection while browsing the unverified positives removes it (it's no longer unverified). The return-to-Find skip-rescore guard is unchanged.
-
-## Bug fixes (post-Phase-4)
-
-- **Inclusion slide was a silent no-op in Find (fixed).** The no-retrain slide depends on the K fold orderings being cached on the `DetectorContext` (`recompute_detector_thresholds_for_inclusion` skips any context whose `calibration_cache is None`). But the find-label / detector-load training path called `train_and_threshold` *without* a `det_ctx`, so the cache was never populated — every Inclusion slide left the threshold frozen and the good/bad split unchanged, and Browse (which scopes over the good set) projected the *previous* cutoff's positives. Fix: `train_and_threshold` now takes an optional `det_ctx` and caches the fold orderings (sizing the fold models to match the final model), threaded through `train_from_labelset` and the find-label cold-train path. Additionally, the Find view derives the unverified-positive Browse/To-Dataset ids from the live `sortOrder` + `threshold` (which move synchronously with the slider) instead of the `goodVotes` signal (which only catches up on the follow-up `loadVotes()` GET), so a Browse fired right after a slide stays in lock-step with the green line. Regression: `tests/detectors/test_find_inclusion_slide.py`.
-
-- **Verified items vanished from the right pile until a browser refresh (fixed).** A hover/button vote moved the item into the right verified pile optimistically, but it often dropped back out moments later; only a manual refresh ("makes them all appear") brought them back. Root cause was an **out-of-order response race on `GET /api/votes`**: `VoteStateService.loadVotes()` (fired on every vote via `onMediaVoted`) and the 2s background poll read `/api/votes` independently, so under rapid "sit and vote" several reads were in flight at once. A poll GET that read the server *before* a vote committed could resolve *after* the post-vote `loadVotes()`, and `applyVotes` then overwrote the fresh `verified` set with the stale one. The optimistic `pendingVerified` guard only holds while a write is pending, and the fresher response had already cleared it, so the stale response won and the just-verified id fell back into the left work queue. Fix: stamp each `/api/votes` read with a monotonic issue id (`votesSeq`) and drop any response older than the newest already applied (`applyVotesFresh`); `clear()` advances the watermark so an in-flight read from a previous dataset/detector context can't repopulate the cleared piles. Regression: `frontend/src/app/services/vote-state.service.spec.ts` ("drops a stale /api/votes response that resolves after a fresher one").
+**Core mechanic:** the detector scores every item **once**, frozen for the session (`find_scores`). The **Inclusion** slider is a **cutoff** over those frozen scores — it re-thresholds only *unverified* items, never retrains the MLP, never re-embeds, never reorders. Inclusion left the model entirely (fixed architecture + regularization); it stays the FP/FN cost weight in the labelset min-cost threshold search (`find_optimal_threshold`), so a slide re-runs only that cheap search over cached K fold orderings. Verified items carry an explicit human vote the cutoff never overrides. **Backwards-compat break (already surfaced):** existing detectors' stored `inclusion` values changed meaning (training-bias → cutoff position) and model capacity no longer varies with inclusion.
 
 ## Open follow-ups
 
@@ -178,3 +23,22 @@ All under `./run-tests.sh` (full suite + `npm run build:prod` green).
 - **Safe-threshold blend on Inclusion slide.** `recompute_detector_thresholds_for_inclusion` re-derives the *raw* cross-cal threshold from the fold orderings; it does not re-apply `calculate_safe_threshold` blending (which needs the haystack score distribution). When `safe_thresholds` is on, an Inclusion slide's threshold will differ slightly from a full retrain's. `find_scores` is available to blend if this matters; deferred (safe_thresholds is opt-in).
 - **Done-state polish.** The empty queue (no unverified item above the cutoff) is now well-defined; decide how rich the "all positives reviewed" rest state should be (plain message vs. a summary nudge toward Stats/Export).
 - **Under-threshold (false-negative) review surface.** _Partially addressed:_ the boundary-walk auto-advance (`advanceToBoundary`) now serves below-the-line items too, alternating above/below the cutoff so a "just sit and vote" pass naturally surfaces marginal false negatives near the boundary. A *dedicated* below-the-line work queue (its own panel/order, rather than interleaving into the centre walk) remains unbuilt; add it if demand appears.
+
+## Key design decisions (reference)
+
+- **Inclusion = pure cutoff, unified across Train and Find, no retrain (CRITICAL).** In Find the haystack is scored once and frozen; in Train the model still retrains *when you vote*, but never on an Inclusion change.
+- **Auto-advance = boundary walk, alternating above/below the cutoff** (`advanceToBoundary` + `nextFindSide`). Each vote jumps the centre to the nearest unverified item on the side it's that turn, so "just sit and vote" samples both faces of the decision boundary. A fresh score restarts on the `above` side (the marginal positive seed). Queue empty (done state) only when nothing unverified remains on either side. _(Superseded the original positives-only "lowest unverified above cutoff" rule.)_
+- **Hover-vote ≡ button-vote.** Both verify the item, move it left→right, and trigger auto-advance.
+- **Preserve-verified is automatic.** Find-session state (`verified_ids`/`find_scores`/votes) resets when the haystack or detector changes; the detector-scoped K fold orderings + threshold survive a same-embedder haystack switch.
+- **Stats counts ALL items** (unverified flood-filled with the detector's call, `verified_count` reported separately), with the eval baseline = the default calibrated cutoff fixed at score time. The headline is the FP/FN-vs-Inclusion sweep over `[−10, 10]` on the user's own data.
+- **Ephemeral throughout**; Unverified Export (`label_filter=unverified`) is the persistence escape hatch.
+
+## What shipped
+
+Each phase landed green under `./run-tests.sh` (+ `npm run build:prod` for frontend).
+
+- **Phase 1 — backend spine.** Inclusion decoupled from the MLP (`train_model` dropped `inclusion_value` + class-weight bias; `inclusion` lives only in `find_optimal_threshold`). Fold-ordering cache: `calculate_cross_calibration_threshold` split into `compute_fold_orderings` + `threshold_from_fold_orderings`; `calibration_cache` re-keyed to exclude inclusion. No-retrain Inclusion (`set_inclusion` → `recompute_detector_thresholds_for_inclusion`). `DetectorContext.verified_ids` + `find_scores` (in-memory, cleared on pair change; mark-verified on single-item find-mode votes). APIs: `verified` array on `GET /api/votes`, `unverified`/`verified` `label_filter` on `/api/labels/export`, new read-only `GET /api/find/stats` (adopted-label 2×2 + −10…10 FP/FN sweep); `find-label` freezes `find_scores`. (Doc-vs-code note: hidden width was already `_auto_hidden_dim(n_train)`, so the refactor only removed the class-weight bias.)
+- **Phase 2 — frontend.** No-retrain slide (`find-view.onInclusionChange` → `POST /api/inclusion`, no `runFindLabel`; backend `rethreshold_unverified_find_items`). `VoteStateService.verifiedIds$` with optimistic add/remove. Right panel = verified pile (`good/bad ∩ verified`, folded "[N] Unverified …" headers; buttons act on the full good/bad set). Boundary-walk auto-advance (`advanceToBoundary` + `nextFindSide`; "All items reviewed" toast). Unverified Export button (shared `vt-export-modal` `initialFilter`). `vt-find-stats-modal` with a dependency-free inline-SVG FP/FN-vs-inclusion chart.
+- **Phase 3 — verified-only colouring.** Items colour green/red only once verified (`find-view.unverifiedSortOrder` feeds the left queue the ranking minus verified items; media-list + stripe get empty vote sets). Big Good/Bad buttons verify instead of un-toggling (VoteStateService find-mode flag; `currentState()` reads unverified as `'none'`; `effectiveGood`/`effectiveBad` gate the centre buttons).
+- **Phase 4 — left work-queue actions.** Browse / To Dataset / Export beside the Inclusion control, scoped to unverified positives (`onBrowseUnverified` / `onToDatasetUnverified`, UI-only `unverified_good` filter resolved to the server `unverified` partition). Browse-canvas "Remove from Good" became "Verified Good" / "Verified Bad" (`browse-selection-panel`, gated on `canVerify`), marking + verifying + dropping the selection.
+- **Bug fixes (post-Phase-4).** Inclusion-slide silent no-op fixed: `train_and_threshold` now takes an optional `det_ctx` and caches the fold orderings (find-label / detector-load cold-train path threaded through), and the Find view derives Browse/To-Dataset ids from the live `sortOrder` + `threshold`; regression `tests/detectors/test_find_inclusion_slide.py`. Verified-items-vanish race fixed: `/api/votes` reads stamped with a monotonic `votesSeq`, stale responses dropped (`applyVotesFresh`, `clear()` advances the watermark); regression `frontend/src/app/services/vote-state.service.spec.ts`.

--- a/docs/plans/gpu-acceleration.md
+++ b/docs/plans/gpu-acceleration.md
@@ -1,125 +1,6 @@
 # GPU acceleration audit
 
-**Status: Phase 1 shipped (device-aware embedders + no-new-dep converter GPU
-paths). Phase 2 partially shipped — GPU UMAP + GPU k-means via cuML landed
-(opt-in dependency); video frame decode (decord) is still deferred. The
-deliberately-skipped signal-rewrite items remain out of scope. See What shipped
-(Phase 2) and Open follow-ups.**
-
-VTSearch already had production-grade device infrastructure that nothing on the
-embedding side was using:
-
-- `vtscore/config.py::resolve_device()` — honours `VTSEARCH_DEVICE`, smoke-tests
-  an actual CUDA kernel launch, and falls back to CPU when the installed torch
-  wheel can't drive the visible GPU.
-- MLP training/scoring (`vtscore/training/mlp.py`, `vtscore/detectors/training.py`)
-  already ran on the resolved device, AMP and all.
-
-But every embedder hardcoded `self._model = self._model.to("cpu")` at load time,
-pinning the heaviest part of the pipeline — embedding inference, ~95% of
-load/train/score wall-time — to CPU even on GPU hosts. The fix was small because
-every embedder's forward pass already device-follows
-`next(self._model.parameters()).device` and returns results via
-`.detach().cpu().numpy()`.
-
-## What shipped (Phase 1)
-
-- **`to_compute_device(model)`** in `vtscore/media/embedder.py`: moves a freshly
-  loaded model onto `resolve_device()`. On CPU-only hosts it is exactly the old
-  `.to("cpu")` (still materialises `meta`-device tensors from
-  `low_cpu_mem_usage=True`); on a usable GPU the model — and the whole forward
-  pass — lands on the accelerator.
-- **14 embedder load pins converted** across image/audio/video
-  (`_clap_shared`, `embedder_ast`, `embedder_whisper`, `embedder_paraspeechclap`,
-  `embedder_siglip`, `embedder_siglip2`, `embedder_clip`, `embedder_face`,
-  `_dinov2_shared`, `_dinov3_shared`, `_eupe_shared`, `embedder_xclip`,
-  `embedder_languagebind`, `embedder_videomae`). The three CLAP variants share
-  `_clap_shared`.
-- **E5 / BGE text embedders**: `SentenceTransformer(..., device=resolve_device())`
-  so they route through the smoke-test + `VTSEARCH_DEVICE` instead of
-  sentence-transformers' naive auto-pick (which would grab a GPU the wheel can't
-  run).
-- **Whisper ASR converter** (`converters/audio2text.py`): loads on
-  `resolve_device()` with FP16 on CUDA.
-- **OCR converter** (`converters/image2text.py`): requests `use_gpu` when a CUDA
-  device resolves, falling back gracefully when the kwarg is unsupported
-  (PaddleOCR 3.x removed it).
-- **Concurrency default** (`embedding/loader.py::default_concurrent_embeddings`):
-  returns 1 on an accelerator — embedders share one GPU and forward passes
-  serialise on the global `_embed_lock`, so extra concurrent jobs only multiply
-  resident weights and court OOM. `VTSEARCH_MAX_CONCURRENT_EMBEDDINGS` still
-  overrides for multi-GPU / large-VRAM nodes.
-- **GPU tests** (`tests_lib/gpu/test_gpu.py`): added self-contained coverage for
-  `to_compute_device` and the embed concurrency default, and fixed two stale
-  tests that referenced a long-removed `MediaType._model` attribute.
-
-CPU-only behaviour is byte-for-byte unchanged (`resolve_device()` → `"cpu"`).
-
-## Deliberately NOT done (and why)
-
-These were in the "no-new-dep converters" tier but were skipped after grounding
-the call in the code:
-
-- **Spectrogram rendering** (`converters/audio2image.py`, librosa mel/CQT +
-  matplotlib), **audio resampling** (librosa in the CLAP/AST path), and **image
-  thumbnail/resize** (PIL). Moving these to torchaudio/torchvision would change
-  numerical/pixel outputs that feed embeddings and pHash near-dedup — breaking
-  the origin→embedding rederivation contract and snapshot tests — for steps that
-  are no longer the bottleneck once the embedder forward pass is on the GPU. CQT
-  also isn't in core torchaudio, and the matplotlib figure render (the actual
-  cost in spectrograms) stays on CPU regardless. Net: real risk, marginal/no
-  payoff. Left on CPU on purpose.
-
-## What shipped (Phase 2 — cuML)
-
-GPU UMAP and GPU k-means now run on the accelerator when cuML/RAPIDS is present,
-falling back to the CPU libraries otherwise:
-
-- **`vtscore/gpu_backends.py`** — new shared module centralising the cuML
-  backend story (mirrors how `to_compute_device` centralises the embedder
-  story). `cuml_enabled()` is true only when `resolve_device()` returns a usable
-  CUDA device *and* `cuml` imports; `umap_fit_transform(...)` /
-  `kmeans_fit_predict(...)` construct **and fit** the GPU estimator
-  (`output_type="numpy"`) and degrade to `umap-learn` / `sklearn.cluster.KMeans`
-  on any hiccup. The fallback wraps the *whole* construct-and-fit, so a cuML
-  failure that only surfaces inside `fit` — e.g. the lazy nvrtc kernel compile
-  blowing up on a mismatched CUDA toolchain (CUDA-12 nvrtc parsing CUDA-13 fp8
-  headers) — degrades to CPU instead of crashing. The first such failure also
-  flips a process-global kill switch (`cuml_enabled()` returns `False`
-  thereafter) so the rest of the run skips cuML rather than re-paying the
-  multi-second compile failure on every call.
-- **UMAP projection** (`vtscore/projection/umap_projection.py::_umap_layout`) —
-  fits its reducer via `umap_fit_transform`; the heartbeat/threading wrapper is
-  unchanged. `cuml.manifold.UMAP` is ~20–100× on large sets.
-- **Diversity-tree k-means** (`vtscore/state/diversity_tree.py`) — the per-init
-  build loop fits via `kmeans_fit_predict`. The eager top-level
-  `sklearn` import is retained to warm the CPU cold-import before the progress
-  bar (and as the fallback).
-- **Default best-effort dependency** — `scripts/install.sh` installs cuML by
-  default on GPU hosts via `vts_install_cuml`, but as a *separate, non-fatal*
-  step: it maps the CUDA tag to `cuml-cu11` / `cuml-cu12`, installs from the
-  NVIDIA index (`pypi.nvidia.com`), and warns-and-continues on failure so a
-  slow/unreachable index or a torch resolver conflict can't abort the whole GPU
-  install. Skip with `VTSEARCH_SKIP_CUML=1`. cuML is deliberately kept OUT of the
-  main `requirements/gpu.txt` pass (a hard requirement there would break
-  non-Linux/offline GPU installs and let an index hiccup abort everything).
-  `docker/Dockerfile.gpu` installs `cuml-cu12` in its own dedicated RUN layer
-  (~+3-4 GB, ~8.5 GB → ~12 GB image), fail-loud on purpose: a build-once-ship
-  image should surface a torch/cuML resolver conflict rather than silently ship
-  a CPU-only UMAP. The runtime detection (`vtscore/gpu_backends.py`) means a
-  missing cuML just uses the CPU fallback.
-- **GPU tests** (`tests_lib/gpu/test_gpu.py::TestCuMLBackends`) — exercise the
-  factory contract (works + returns numpy whether it resolves to cuML or the CPU
-  fallback) plus end-to-end `fit_projection` and `DiversityTree` builds, with the
-  cuML-specific assertions guarded by an import check.
-
-**Output note:** cuML is a separate implementation, so the projection
-coordinates and k-means labels differ numerically from the CPU path. This is
-safe because both consumers compute their result exactly once and then
-freeze/persist it (projection frozen per dataset; diversity tree cached in the
-dataset pickle), so the non-reproducibility never surfaces; the *structure* is
-preserved. CPU-only hosts (and GPU hosts without cuML) are byte-for-byte
-unchanged.
+**Status: Phase 1 shipped (device-aware embedders + no-new-dep converter GPU paths). Phase 2 partially shipped — GPU UMAP + GPU k-means via cuML landed (opt-in dependency). Video frame decode (decord) is still deferred; the deliberately-skipped signal-rewrite items remain out of scope.**
 
 ## Open follow-ups (Phase 2 — remaining)
 
@@ -131,3 +12,37 @@ When picking up the remaining item: gate any new GPU dependency behind the
 existing CPU/GPU install split and keep a CPU fallback path, exactly as the
 embedder work does via `resolve_device()` and the cuML work does via
 `vtscore/gpu_backends.py`.
+
+## Deliberately NOT done (and why)
+
+In the "no-new-dep converters" tier but skipped after grounding the call in the code:
+
+- **Spectrogram rendering** (`converters/audio2image.py`, librosa mel/CQT +
+  matplotlib), **audio resampling** (librosa in the CLAP/AST path), and **image
+  thumbnail/resize** (PIL). Moving these to torchaudio/torchvision would change
+  numerical/pixel outputs that feed embeddings and pHash near-dedup — breaking
+  the origin→embedding rederivation contract and snapshot tests — for steps that
+  are no longer the bottleneck once the embedder forward pass is on the GPU. CQT
+  also isn't in core torchaudio, and the matplotlib figure render (the actual
+  cost in spectrograms) stays on CPU regardless. Net: real risk, marginal/no
+  payoff. Left on CPU on purpose.
+
+## What shipped
+
+Phase 1 (device-aware embedders + converters; CPU-only behaviour byte-for-byte unchanged):
+- `to_compute_device(model)` (`vtscore/media/embedder.py`) — moves a freshly loaded model onto `resolve_device()`; exactly the old `.to("cpu")` on CPU-only hosts, the accelerator on a usable GPU.
+- 14 embedder load pins converted across image/audio/video (`_clap_shared`, `embedder_ast`, `embedder_whisper`, `embedder_paraspeechclap`, `embedder_siglip`, `embedder_siglip2`, `embedder_clip`, `embedder_face`, `_dinov2_shared`, `_dinov3_shared`, `_eupe_shared`, `embedder_xclip`, `embedder_languagebind`, `embedder_videomae`).
+- E5 / BGE text embedders route through `SentenceTransformer(..., device=resolve_device())` (smoke-test + `VTSEARCH_DEVICE` instead of naive auto-pick).
+- Whisper ASR converter (`converters/audio2text.py`) loads on `resolve_device()` with FP16 on CUDA.
+- OCR converter (`converters/image2text.py`) requests `use_gpu` on CUDA, degrading gracefully when the kwarg is unsupported (PaddleOCR 3.x).
+- Concurrency default (`embedding/loader.py::default_concurrent_embeddings`) returns 1 on an accelerator; `VTSEARCH_MAX_CONCURRENT_EMBEDDINGS` still overrides.
+- GPU tests (`tests_lib/gpu/test_gpu.py`) cover `to_compute_device` + embed concurrency default; fixed two stale `MediaType._model` tests.
+
+Phase 2 (cuML — GPU UMAP + k-means when cuML/RAPIDS present, CPU fallback otherwise; CPU-only hosts byte-for-byte unchanged):
+- `vtscore/gpu_backends.py` — shared cuML backend module. `cuml_enabled()` true only when `resolve_device()` returns usable CUDA *and* `cuml` imports; `umap_fit_transform` / `kmeans_fit_predict` construct-and-fit the GPU estimator (`output_type="numpy"`) and degrade the whole construct-and-fit to CPU on any hiccup (incl. lazy nvrtc compile failures), flipping a process-global kill switch on first failure.
+- UMAP projection (`vtscore/projection/umap_projection.py::_umap_layout`) fits via `umap_fit_transform` (~20–100× on large sets).
+- Diversity-tree k-means (`vtscore/state/diversity_tree.py`) fits via `kmeans_fit_predict`; eager `sklearn` import retained for cold-import warmup + fallback.
+- `scripts/install.sh` installs cuML by default on GPU hosts via `vts_install_cuml` as a separate non-fatal step (maps CUDA tag → `cuml-cu11`/`cuml-cu12`, NVIDIA index, warns-and-continues; skip with `VTSEARCH_SKIP_CUML=1`). Kept out of `requirements/gpu.txt`; `docker/Dockerfile.gpu` installs `cuml-cu12` in a dedicated fail-loud RUN layer (~8.5 GB → ~12 GB).
+- GPU tests (`tests_lib/gpu/test_gpu.py::TestCuMLBackends`) exercise the factory contract + end-to-end `fit_projection` / `DiversityTree` builds, cuML-specific assertions import-guarded.
+
+**Output note (Phase 2):** cuML is a separate implementation, so projection coordinates and k-means labels differ numerically from CPU. Safe because both consumers compute once then freeze/persist (projection frozen per dataset; diversity tree cached in the dataset pickle), so non-reproducibility never surfaces; structure is preserved.

--- a/docs/plans/httpresource-migration.md
+++ b/docs/plans/httpresource-migration.md
@@ -1,183 +1,11 @@
 # `httpResource` / reactive-resource migration for the data layer
 
-Status: **Phase 1 (pilot) + Phase 2 + Phase 3 + Phase 4 shipped.** The
-`SettingsStateService` and `MediaStateService` read paths both run on
-`rxResource`, Phase 3 converted the left-panel's media-type / embedder reads,
-and Phase 4 converted the importer/exporter **picker-modal** list reads. Phase 2
-also **dropped the pilot's compatibility shims**: the services now
-expose their signals directly and all consumers were migrated, so there are no
-Observable bridges or sync getters left to bridge old callers (per the repo's
-"no shims, just make the clean change" rule). Phase 3 also extracted the shared
-`settleResource()` test helper and deleted the dead `DetectorStateService`.
-Remaining read services (pollers, `forkJoin` aggregates) are still deferred —
-see "Open follow-ups". Scoped after the Angular 21 + Vitest work landed (see
-`angular-21-upgrade.md`, which lists this as a deferred carrot). This doc
-decides *how* VTSearch should adopt Angular's resource primitives and in what
-order.
+Status: **Phases 1–4 shipped** (`SettingsStateService`, `MediaStateService`,
+left-panel media-type/embedder reads, importer/exporter picker-modal reads all
+on `rxResource`; pilot compat shims removed). Pollers and `forkJoin` aggregates
+deferred by design — open follow-ups below.
 
-## What shipped (Phase 4 — picker-modal reads)
-
-The four importer/exporter picker modals each did an eager `ngOnInit` GET to
-populate their plugin list. All four moved to `rxResource`, following the
-Phase 3 eager pattern (no request signal = load once on creation):
-
-- **`LabelExporterModalComponent`** — `getExporters()` → eager `rxResource`.
-  This one carried a pure `destroy$`/`OnDestroy` (its export *mutation* was
-  already a bare subscribe), so the conversion **dropped the lifecycle plumbing
-  entirely** (`Subject`, `takeUntil`, `OnDestroy`, `OnInit`).
-- **`SettingsImporterModalComponent` / `SettingsExporterModalComponent`** —
-  `listImporters()` / `listExporters()` → eager `rxResource`. `OnDestroy` stays
-  in both because it clears the success-message close timer, not a `destroy$`.
-- **`ExportModalComponent`** (the involved one) — all **three** init reads moved
-  to resources. Dataset status (`getStatus()`) and the exporter list
-  (`getExporters()`) are eager; the **labels** read (`exportLabels(...)`) is
-  input-derived (its `label_filter` comes from the `initialFilter` `@Input`, set
-  in `ngOnInit`), so it uses a **trigger signal** (`labelsReady`, flipped at the
-  end of `ngOnInit`) as its request — the same "monotonic counter / gate" shape
-  the settings + media phases used. `buildColumns(...)` (which depends on the
-  resolved `available_columns`) moved to a **constructor `effect()`** that fires
-  when the labels resource settles (with the no-arg fallback on error). The
-  `destroy$`/`OnDestroy` is gone; the lone export *mutation* is now a bare
-  subscribe (matching `label-exporter`'s precedent).
-
-Repeatable details worth keeping:
-
-- **Picker list + its loading/error state are signal-driven.** Each modal
-  exposes `exporters()` / `importers()` (a `computed` that filters
-  `hidden_from_picker`) and `loading()` (`= resource.isLoading()`); templates
-  read the signals. The `loading = true` initial field is gone — an eager
-  resource reports `isLoading()` true until its first settle, matching the old
-  default.
-- **Error merging.** Each modal's `error` was set by *both* a list-load failure
-  and an action (export/import) failure. The migration keeps a writable
-  `signal` for the action error and exposes `error` as a `computed` that ORs in
-  the resource's load error (`resource.error() ? '<load msg>' : ''`). Imperative
-  `this.error = '…'` sites became `…Error.set('…')`.
-- **`inject()` over constructor params.** Resource field initializers reference
-  the api services, and a field initializer can't safely read a constructor
-  parameter property, so the services are `inject()`ed (same gotcha Phase 3 hit).
-- **Specs.** Added an `export-modal` spec (the component was previously
-  untested) and updated the `label-exporter` spec for the loader timing:
-  `TestBed.tick()` after `detectChanges()` to issue the eager GET, then
-  `settleResource()` before reading resolved values. The export-modal spec also
-  has to **settle once before flushing** so the trigger-gated labels GET (which
-  fires a microtask after `ngOnInit`) is pending alongside the two eager GETs,
-  and it matches the labels request by `r.url` predicate because the GET carries
-  an `?enrich=true` query string that a plain-string `expectOne` would miss.
-
-## What shipped (Phase 3 — left-panel reads + housekeeping)
-
-- **`LeftPanelComponent` media-type / embedder reads migrated to `rxResource`.**
-  The two `ngOnInit` `getMediaTypes()` / `getEmbedders()` subscribes (with
-  `takeUntil(destroy$)`) became two **eager** `rxResource`s (no request signal =
-  load once on creation, matching the old init-time fetch). The metadata is
-  exposed as `computed` signals; the derived `mediaTypeName` / `textSortAvailable`
-  fields are recomputed by two constructor `effect()`s (which read the signal so
-  late-arriving metadata still upgrades the header) plus the existing
-  `ngOnChanges(medias)` path. `destroy$` / `Subject` / `takeUntil` /
-  `OnDestroy` are gone; the service is now `inject()`ed (a field initializer can't
-  safely reference a constructor parameter property).
-- **Shared `settleResource()` test helper extracted** to
-  `frontend/src/app/testing/settle-resource.ts`. The settings, media, label-view,
-  and now left-panel specs all import it instead of each inlining a byte-identical
-  `settle()`.
-- **Dead `DetectorStateService` deleted.** It had no consumers outside its own
-  file + spec (its `extractors$` / `localizers$` were unread). Removed the
-  service and its spec; the underlying `ProcessorsApiService.getAutorunExtractors`
-  / `getAutorunLocalizers` route wrappers stay (generated-client surface).
-
-## What shipped (Phase 2 — MediaStateService + shim removal)
-
-The user's call here was that preserving the old per-service public surface is
-not worth it: VTSearch's frontend is the only caller of its own services (and
-its backend), and a migration upgrades caller and callee together, so the
-shims the pilot left behind were pure dead weight. So Phase 2 went the full
-distance instead of bridging.
-
-- **`MediaStateService` read path migrated to `rxResource`.** The dataset-wide
-  media-stub list (`GET /api/medias/ids`) is now an `rxResource` wrapping the
-  generated `MediasApiService.getMediaIds()`, using the same monotonic-counter
-  request trigger as the settings pilot (`loadMedias()` bumps the counter;
-  `clear()` is `resource.set([])`). It exposes `mediasSignal()` /
-  `isLoading()`; `selectedId` is now a plain `signal`; `selectedMedia` /
-  `getMedia()` stay synchronous accessors over the signal + metadata cache. The
-  `medias$` / `loading$` / `selectedId$` Observables, the `BehaviorSubject`s,
-  and `OnDestroy`/`destroy$` are gone.
-- **`SettingsStateService` shims removed.** `settings$` (the `toObservable`
-  bridge) and the sync `settings` getter are deleted; the canonical surface is
-  `settingsSignal()` / `isLoading()` / `error()`.
-- **Consumer migration pattern (the repeatable part).** Every
-  `settings$.subscribe(s => …)` / `medias$.subscribe(m => …)` became a
-  **constructor `effect()`** that reads the signal (`settingsState
-  .settingsSignal()` / `mediaState.mediasSignal()`). Effects auto-dispose with
-  their component, so the matching `takeUntil(destroy$)` plumbing was dropped
-  (and `destroy$`/`OnDestroy` removed where it was the last user). Synchronous
-  getter reads (`settingsState.settings?.x`, `mediaState.medias`) became signal
-  calls (`settingsSignal()?.x`, `mediasSignal()`), including in templates
-  (`[medias]="mediaState.mediasSignal()"`, `[selectedId]="mediaState
-  .selectedId()"`). ~18 consumer files across both services.
-- **Test timing (reinforces the pilot's notes).** Because the `rxResource`
-  loader runs in a **root effect**, `fixture.detectChanges()` alone does *not*
-  issue the GET — component specs that previously relied on the old synchronous
-  `loadMedias()` subscribe needed a `TestBed.tick()` after `detectChanges()` to
-  actually fire `/api/medias/ids` (e.g. `label-view`'s `flushInitialRequests`).
-  The value still commits on a microtask, so any assertion on resolved medias
-  drains with the `settle()` helper (`await macrotask` + `TestBed.tick()`).
-  Effect-driven side effects (the medias→media-type sync, the deferred
-  autopilot text/media sort) are now microtask-scheduled rather than
-  synchronous, so the specs exercising them `await settle()` before asserting.
-
-## What shipped (Phase 1 pilot)
-
-`SettingsStateService` (`frontend/src/app/services/settings-state.service.ts`)
-was reimplemented on `rxResource` while keeping its public surface
-(`settings`, `settings$`, `load`, `update`, `clear`) intact, so none of its ~16
-consumers changed. The concrete, repeatable pattern:
-
-- **Wrap the existing generated-client read in `rxResource`.** The loader's
-  `stream` calls the existing typed method (`SettingsApiService.getSettings()`),
-  so the generated client and the interceptor chain are untouched.
-- **A monotonic counter signal is the request.** `params: () => count === 0 ?
-  undefined : count` keeps the resource idle until the first `load()`
-  (`undefined` request = no fetch); each `load()` bumps the counter to refetch.
-  This maps an imperative "load/refresh on demand" trigger onto a reactive
-  resource.
-- **Signals are the new canonical API** (`settingsSignal`, `isLoading`,
-  `error`), exposed from the resource. Backwards-compat shims bridge to existing
-  consumers: the sync getter reads the signal; `settings$` is
-  `toObservable(settingsSignal)` (replays latest like the old `BehaviorSubject`,
-  but emits asynchronously).
-- **Mutations stay imperative.** `update()` is still a `HttpClient` PUT; it
-  writes the server's response back into the resource via `resource.set(...)`.
-  `clear()` is `resource.set(undefined)`.
-- **Document side-effects move to an `effect()`** (here, the `animations-off`
-  class) that watches the settings signal, replacing the old manual `emit()`.
-
-### Testing `rxResource` (important — this is the real cost)
-
-The resource's loader is **effect-scheduled and promise-based**, which changes
-test timing. Concretely, for the Vitest + `HttpTestingController` suite:
-
-- The loader runs in a **root effect**, so `fixture.detectChanges()` does *not*
-  issue the GET. Call **`TestBed.tick()`** after the action that triggers
-  `load()` and before `httpMock.expectOne(...)`. (This is the bulk of the
-  consumer-spec churn: ~40 call sites across the settings consumers each needed
-  one `TestBed.tick()`.)
-- The value **commits on a microtask** (the loader is promise-based), so reading
-  `resource.value()` synchronously after `flush()` misses it. In a normal
-  (non-fakeAsync) test, drain with `await new Promise(r => setTimeout(r))` then
-  `TestBed.tick()`.
-- **`rxResource` values do not commit under `fakeAsync` at all** — the virtual
-  clock doesn't drive the resource's resolution (looping `tick()/TestBed.tick()`
-  does not help). A fakeAsync spec can still *flush* the request to satisfy
-  `verify()`, but any spec that asserts a **settings-derived value** must be
-  converted to a real-async (`async`/`await`) test. Only one right-panel test
-  needed this; the rest only flush the request.
-- At **runtime** none of this matters: zone change detection flushes the loader
-  effect immediately after `load()`, so the GET fires as before. The timing
-  change is test-only.
-
-## Goal
+## Goal & scope
 
 Trim the `switchMap` / manual-subscription / `BehaviorSubject` boilerplate in
 the **read** path of the data layer by moving GET-style fetches onto Angular's
@@ -190,111 +18,14 @@ ceremony.
 **Explicitly NOT in scope:** mutations (POST/PUT/DELETE — votes, sort kicks,
 imports, renames, deletes) stay imperative `HttpClient` calls. Resources are
 for reads. Server-Sent Events (`ProgressEventsService`) stay as-is. This is a
-*read-path* refactor, adoptable incrementally — never a big-bang rewrite.
-
-## Current state (as of this plan)
-
-- **Generated client**: `ng-openapi-gen` (config `apiService: false`) emits
-  standalone **Observable-returning functions** under
-  `src/app/generated/api-client/fn/**`, e.g.
-  `getVotes(http, rootUrl, params, ctx): Observable<StrictHttpResponse<T>>`.
-- **~26 hand-written `*-api.service.ts`** wrap those functions into typed,
-  `Observable`-returning methods (e.g. `SortingApiService.getLabelingStatus()`).
-  ~60 GET-style read methods across them.
-- **~29 state services** (`*-state.service.ts`) hold UI state in
-  `BehaviorSubject`s and orchestrate fetches/polling (e.g. `VoteStateService`
-  polls `/api/votes` via `timer(0, ms)`; `DatasetStateService` `forkJoin`s the
-  registries).
-- **Consumption is imperative, not reactive**: **66** `.subscribe()` call sites
-  in non-spec code vs **2** `| async` pipes. Components subscribe in `ngOnInit`
-  and write to plain fields. So this migration is as much about *consumption*
-  (template-level signal reads) as about the services.
-- **HTTP wiring**: `provideHttpClient(withInterceptors([activeContext,
-  achievementsRefresh, error]))`. The `activeContext` interceptor injects
-  `X-Dataset-Id` / `X-Detector-Id` on every request from
-  `ActiveContextService`; `error` is the circuit-breaker/connection-state
-  chokepoint. **`ActiveContextService` is `BehaviorSubject`-based** (no signals).
-- **Signals today**: essentially unused (1 component). Zone-based change
-  detection is still on.
-
-## Key design decision: `rxResource` over raw `httpResource`
-
-Angular 21 ships two relevant primitives:
-
-- **`httpResource(() => url | request)`** — issues the GET itself given a URL
-  (or request object). It **bypasses the generated client**: you'd hand-build
-  URLs/params that `ng-openapi-gen` already generates, duplicating the typed
-  param/response contracts and losing the OpenAPI-snapshot guarantee.
-- **`rxResource({ params, stream })`** (from `@angular/core/rxjs-interop`) —
-  wraps an **Observable loader**. The loader can call the existing typed
-  `*-api.service.ts` methods unchanged, so we **keep the generated client** and
-  its types, and just gain signal-driven reactivity + `value()/status()/error()`.
-
-**Recommendation: lead with `rxResource`** wrapping existing api-service
-methods. It is the incremental-friendly choice — no generated-client churn, no
-URL duplication, interceptors still apply (same `HttpClient`). Reserve
-`httpResource` only for genuinely new raw reads where no generated function
-exists. (Both share `provideHttpClient` + the interceptor chain, so headers,
-achievements-refresh, and the error/circuit-breaker all keep working either
-way — verified against the current functional-interceptor setup.)
-
-## Obstacles to resolve before/during rollout
-
-1. **Signal adoption is a prerequisite.** Resources are signal-driven, but the
-   reactivity sources (`ActiveContextService`, sort/vote/settings state) are
-   `BehaviorSubject`s, and consumers `.subscribe()` rather than read signals.
-   Two sub-decisions:
-   - Bridge the existing `Observable`s to signals with `toSignal(...)` at the
-     edges (cheap, non-invasive, lets resources key off
-     `toSignal(activeContext.datasetId$)`), **or** convert the hot state
-     services to `signal()`-backed (larger, cleaner long-term). Start with
-     `toSignal` bridges; convert services opportunistically.
-   - Resources must be created in an **injection context** (field initializer
-     or `inject()`-time). Polling/orchestration that lives in services needs the
-     resource owned by the right scope.
-2. **Polling endpoints don't map to resources.** `VoteStateService` /
-   labeling-status poll on a timer. Resources fetch-on-request-change, not on an
-   interval. Options: keep pollers imperative, or drive a resource's reload from
-   a timer signal. Recommend leaving pollers alone in phase 1.
-3. **`forkJoin` aggregates** (e.g. `DatasetStateService.refresh()`) — a resource
-   per call composed via `computed`, or keep the aggregate imperative. Decide
-   per call site; don't force it.
-4. **Experimental API.** `httpResource`/`rxResource` are still marked
-   experimental in 21; the signature may shift in 22/23. Keep the surface small
-   and centralized (a thin helper) so an API change is a one-file fix.
-5. **Error semantics.** Today errors flow through `errorInterceptor` (toasts,
-   circuit breaker, connection state). Resources surface errors via `error()`
-   instead of an Observable `error` callback — confirm the interceptor-driven
-   side effects still fire (they do, since the request still goes through the
-   chain) and decide how components render `error()` vs the current toasts.
-6. **Test story.** The Vitest suite drives `HttpTestingController` +
-   `fakeAsync`. Resources resolve on microtasks/effects; spec patterns will need
-   a small, documented helper (flush + `await`/`tick` + read `value()`), since
-   the current specs assert on imperative subscribe results.
-
-## Suggested sequencing (incremental, reversible)
-
-1. **Pilot one read** end-to-end — **done** (`SettingsStateService`, see "What
-   shipped"). The pattern and its test story are proven.
-2. **Write the pattern down** — **done** (the "What shipped" + "Testing
-   `rxResource`" sections above are the reference for the next conversions).
-3. **Expand by area**, one PR per service/feature, only where it removes real
-   boilerplate. Leave pollers, `forkJoin` aggregates, and mutations alone unless
-   a conversion is clearly a win.
-4. **Revisit consumption**: as reads become resources, prefer template signal
-   reads / `@if (resource.value(); as x)` over `.subscribe()`-into-field.
-
-Each step is independently shippable and revertible; there is no point where the
-app must be half-migrated.
+*read-path* refactor, adoptable incrementally — never a big-bang rewrite. Each
+step is independently shippable and revertible; there is no point where the app
+must be half-migrated.
 
 ## Open follow-ups
 
-- **Expand to more read services** (step 3). Done for `SettingsStateService`
-  (Phase 1, shims removed in Phase 2), `MediaStateService` (Phase 2), the
-  left-panel media-type / embedder reads (Phase 3), and the importer/exporter
-  picker-modal list reads (Phase 4). The component-local `ngOnInit` fetches
-  converted eagerly (no request signal); export-modal's input-derived labels
-  read used a trigger signal instead. A still-open refinement: if media-types /
+- **Expand to more read services** (the standing next step). Done for the four
+  services in "What shipped". A still-open refinement: if media-types /
   embedders ever need to **re-fetch on dataset switch**, give the resource a
   `toSignal(activeContext.datasetId$)` request key instead of the eager load —
   today the component is recreated on switch, so eager-once suffices.
@@ -304,28 +35,139 @@ app must be half-migrated.
   and `label-importer-modal` (importer list is a clean read, but field-options
   and imports are mutations). Convert the clean list reads when those modals are
   next touched; leave the dynamic field-option fetches imperative.
-- **`DetectorStateService` deleted (Phase 3).** It had no consumers outside its
-  own file + spec. Done.
 - **Pollers and `forkJoin` aggregates** (`VoteStateService`, labeling status,
-  `DatasetStateService.refresh()`) are still imperative by design; revisit only
-  if a resource clearly wins.
-- **Shared `settleResource()` test helper extracted (Phase 3)** to
-  `frontend/src/app/testing/settle-resource.ts`; the settings, media, label-view,
-  and left-panel specs all use it. Done.
+  `DatasetStateService.refresh()`) are still imperative by design. Resources
+  fetch-on-request-change, not on an interval, and don't map cleanly onto
+  aggregate composition. Options if revisited: drive a resource's reload from a
+  timer signal (pollers), or a resource per call composed via `computed`
+  (aggregates). Revisit only if a resource clearly wins — decide per call site;
+  don't force it.
 
-## Decision points needing the user
+### Decision points still open
 
-- **Depth**: thin `toSignal` bridges (minimal, keep `BehaviorSubject` services)
-  vs converting hot state services to signal-backed (bigger, cleaner). Recommend
-  starting thin.
-- **Relationship to zoneless.** Going zoneless (the other deferred carrot)
-  wants broad signal adoption too; this migration is a natural on-ramp. Decide
-  whether to treat them as one track or keep separate.
-- **Pilot target** — which first read to convert (media-types vs settings vs an
-  active-context-keyed list).
+- **Depth of signal adoption**: thin `toSignal` bridges (minimal, keep
+  `BehaviorSubject` services) vs converting hot state services to signal-backed
+  (bigger, cleaner). Started thin (recommended); convert services
+  opportunistically.
+- **Relationship to zoneless.** Going zoneless (the other deferred carrot from
+  `angular-21-upgrade.md`) wants broad signal adoption too; this migration is a
+  natural on-ramp. Decide whether to treat them as one track or keep separate.
 
-## Out of scope (record only)
+### Out of scope (record only)
 
 - Mutations, SSE, polling intervals (above).
 - Replacing `ng-openapi-gen` — the generated client stays; `rxResource` wraps it.
 - Going zoneless — its own effort (`angular-21-upgrade.md` → Deferred).
+
+## Conversion pattern (reference for the remaining reads)
+
+The shipped phases proved a repeatable recipe. Follow it for the next
+conversions.
+
+- **`rxResource` over raw `httpResource`.** `rxResource({ params, stream })`
+  (from `@angular/core/rxjs-interop`) wraps an **Observable loader** that can
+  call the existing typed `*-api.service.ts` methods unchanged, so we **keep the
+  generated client** (`ng-openapi-gen`, `apiService: false`) and its types, and
+  just gain signal-driven reactivity. Raw `httpResource(() => url)` bypasses the
+  generated client — you'd hand-build URLs/params it already generates,
+  duplicating the typed contracts and losing the OpenAPI-snapshot guarantee.
+  Reserve `httpResource` only for genuinely new raw reads where no generated
+  function exists. Both share `provideHttpClient` + the interceptor chain
+  (`activeContext` header injection, achievements-refresh, error/circuit-breaker
+  chokepoint), so headers and error side effects keep working either way.
+- **Request trigger.** For an imperative "load/refresh on demand" read, use a
+  **monotonic counter signal** as the request: `params: () => count === 0 ?
+  undefined : count` keeps the resource idle until the first `load()`
+  (`undefined` request = no fetch); each `load()` bumps the counter to refetch;
+  `clear()` is `resource.set([])`/`set(undefined)`. For a **component-local
+  `ngOnInit` fetch that loads once**, use an **eager** resource (no request
+  signal). For an **input-derived** read (request depends on an `@Input` set in
+  `ngOnInit`), use a **trigger/gate signal** flipped at the end of `ngOnInit`
+  (export-modal's `labelsReady` pattern).
+- **Signals are the canonical surface.** Expose `…Signal()` / `isLoading()` /
+  `error()` from the resource; templates and consumers read the signals.
+  Per-service compat shims (a sync getter, a `toObservable` bridge) are **not**
+  kept — migrate caller and callee together (repo "no shims" rule).
+- **Consumer migration.** Every `x$.subscribe(v => …)` becomes a **constructor
+  `effect()`** that reads the signal; effects auto-dispose with the component, so
+  the matching `takeUntil(destroy$)` / `destroy$` / `OnDestroy` plumbing is
+  dropped where it was the last user. Synchronous getter reads become signal
+  calls, including in templates.
+- **`inject()` over constructor params.** Resource field initializers reference
+  the api services, and a field initializer can't safely read a constructor
+  parameter property, so the services must be `inject()`ed.
+- **Error merging.** Where a component's `error` was set by *both* a list-load
+  failure and an action failure, keep a writable `signal` for the action error
+  and expose `error` as a `computed` that ORs in `resource.error()`.
+- **Mutations stay imperative** — still `HttpClient` POST/PUT; write the
+  server's response back via `resource.set(...)`. Document side-effects that used
+  a manual `emit()` move to an `effect()` watching the signal.
+
+### Testing `rxResource` (the real cost)
+
+The loader is **effect-scheduled and promise-based**, which changes Vitest +
+`HttpTestingController` timing:
+
+- The loader runs in a **root effect**, so `fixture.detectChanges()` does *not*
+  issue the GET. Call **`TestBed.tick()`** after the action that triggers the
+  load and before `httpMock.expectOne(...)`. (This was the bulk of consumer-spec
+  churn — one `TestBed.tick()` per call site.)
+- The value **commits on a microtask**, so reading `resource.value()`
+  synchronously after `flush()` misses it. Drain with the shared
+  `settleResource()` helper (`frontend/src/app/testing/settle-resource.ts`:
+  `await macrotask` + `TestBed.tick()`).
+- **Values do not commit under `fakeAsync` at all** — the virtual clock doesn't
+  drive resolution. A fakeAsync spec can still *flush* the request to satisfy
+  `verify()`, but any spec asserting a resource-derived value must be a
+  real-async (`async`/`await`) test.
+- Match trigger-gated / query-string reads by an `r.url` predicate, not a plain
+  `expectOne(string)` (e.g. export-modal's labels GET carries `?enrich=true`).
+- At **runtime** none of this matters: zone change detection flushes the loader
+  effect immediately after the load, so the GET fires as before. Timing change
+  is test-only.
+
+## What shipped
+
+**Phase 1 (pilot) — `SettingsStateService`**
+(`frontend/src/app/services/settings-state.service.ts`): reimplemented on
+`rxResource` wrapping `SettingsApiService.getSettings()`, monotonic-counter
+request trigger, `animations-off` document side-effect moved to an `effect()`.
+Pilot initially kept compat shims (sync getter + `settings$` `toObservable`
+bridge) so its ~16 consumers were untouched.
+
+**Phase 2 — `MediaStateService` + shim removal**: media-stub list
+(`GET /api/medias/ids`) migrated to `rxResource` (same monotonic-counter
+trigger; `mediasSignal()` / `isLoading()`; `selectedId` a plain `signal`;
+`selectedMedia`/`getMedia()` stay synchronous accessors). Pilot's
+`SettingsStateService` shims (`settings$`, sync `settings` getter,
+`BehaviorSubject`s, `OnDestroy`/`destroy$`) **removed**. ~18 consumer files
+across both services migrated from `.subscribe()` to constructor `effect()`
+reading the signals (templates too).
+
+**Phase 3 — left-panel reads + housekeeping**: `LeftPanelComponent`
+media-type / embedder `ngOnInit` subscribes → two **eager** `rxResource`s
+(metadata as `computed`s, derived `mediaTypeName`/`textSortAvailable` recomputed
+by constructor `effect()`s). Shared `settleResource()` test helper extracted to
+`frontend/src/app/testing/settle-resource.ts`. Dead `DetectorStateService`
+(no external consumers) deleted with its spec; the
+`ProcessorsApiService.getAutorunExtractors`/`getAutorunLocalizers` wrappers stay.
+
+**Phase 4 — picker-modal reads**: four importer/exporter picker modals moved
+eager list reads to `rxResource` following the Phase 3 pattern —
+`LabelExporterModalComponent` (`getExporters()`; dropped its whole
+`destroy$`/`OnDestroy`), `SettingsImporterModalComponent` /
+`SettingsExporterModalComponent` (`listImporters()`/`listExporters()`;
+`OnDestroy` stays for a success-message timer), and `ExportModalComponent` — all
+three init reads: eager `getStatus()` + `getExporters()`, plus the input-derived
+`exportLabels(...)` on a **trigger signal** (`labelsReady`) with `buildColumns`
+moved to a constructor `effect()`. Added an `export-modal` spec (was untested);
+updated the `label-exporter` spec for loader timing.
+
+## Behaviour changes (backwards-compat notes)
+
+- `SettingsStateService` / `MediaStateService` no longer expose Observable
+  surfaces (`settings$`, `medias$`, `loading$`, `selectedId$`) or sync getters —
+  callers read signals (`settingsSignal()`, `mediasSignal()`, `selectedId()`).
+- `DetectorStateService` removed.
+- Effect-driven side effects (medias→media-type sync, deferred autopilot sort)
+  are now microtask-scheduled rather than synchronous.

--- a/docs/plans/huggingface-oauth-gated-datasets.md
+++ b/docs/plans/huggingface-oauth-gated-datasets.md
@@ -1,64 +1,8 @@
 # HuggingFace OAuth for gated demo datasets
 
-**Status:** Phase 1 shipped.
-
-## Problem
-
-Several demo datasets (and some model weights, e.g. DINOv3) are *gated* on the
-HuggingFace Hub: downloading them requires an authenticated request from an
-account that has accepted the dataset's terms. VTSearch's raw download path
-(`vtscore/datasets/downloader/core.py`) used unauthenticated `requests`, so a
-gated dataset returned `401`/`403` and the failure surfaced as a raw
-`requests.HTTPError` string. That message was long enough to grow the dashboard
-loading-task row tall enough to **push the Dismiss/Cancel button out of view**,
-and there was no in-app way to authenticate.
-
-## What shipped (Phase 1)
-
-### Authentication: "Sign in with HuggingFace" (OAuth 2.0 + PKCE)
-
-- **Token store** — `vtscore/security/hf_auth.py` holds a single HuggingFace
-  credential **in memory only** (process-scoped, never written to disk; it's a
-  short-lived secret the OAuth flow re-mints). Exposes `set_credential`,
-  `clear_credential`, `get_token`, `is_authenticated`, `get_status`, and
-  `auth_header_for_url(url)` which returns a Bearer header **only** for
-  `huggingface.co` / `hf.co` hosts (so the token never leaks to presigned CDN /
-  Xet redirect targets). Also defines `GatedResourceError`.
-- **OAuth routes** — `vtsearch/routes/auth_huggingface.py` (plain Flask
-  blueprint, kept off the OpenAPI surface like `events_bp`):
-  - `GET /api/auth/huggingface/status` → `{configured, authenticated, username, scopes}`
-  - `GET /api/auth/huggingface/login` → `{configured, authorize_url}` (PKCE
-    verifier + CSRF state stashed in the Flask session)
-  - `GET /api/auth/huggingface/callback` → exchanges the code, fetches the
-    username, stores the token, redirects to `/?hf_auth=success|error`
-  - `POST /api/auth/huggingface/logout` → clears the token
-- **Operator setup** (one-time): register an OAuth app at
-  `huggingface.co/settings/applications/new` with redirect URI
-  `<base-url>/api/auth/huggingface/callback` and the `read-repos` scope, then set
-  `HF_OAUTH_CLIENT_ID` (+ `HF_OAUTH_CLIENT_SECRET` for a confidential client).
-  Optional: `HF_OAUTH_REDIRECT_URI` (proxy override), `HF_OAUTH_SCOPES`.
-  When unconfigured, the UI shows setup guidance instead of a dead button, and
-  the `HF_TOKEN` env var still works as a fallback.
-
-### Wiring the token into downloads + embedders
-
-- `core._open_validated_stream` now attaches the HF Bearer header per redirect
-  hop (host-checked each hop).
-- A `401`/`403` raises a short, actionable `GatedResourceError` (no retry)
-  instead of a raw HTTPError; wording adapts to whether we're signed in.
-- `vtscore/media/embedder.hf_token()` prefers the OAuth token, then `HF_TOKEN`,
-  so signing in also unlocks gated model weights.
-
-### Frontend
-
-- `HuggingFaceAuthService` (signals) drives status/login/logout.
-- A **HuggingFace** tab in Settings: sign-in/out, status, and setup help.
-- The dashboard's failed-load row offers **"Sign in with HuggingFace"** when the
-  error is a gated HF error, and its layout was fixed so a long error message
-  can never obscure the action buttons (flex row, `min-width:0` scrollable
-  message, `flex-shrink:0` actions).
-- The root component toasts the OAuth round-trip result and strips the
-  `hf_auth` query params.
+**Status:** Phase 1 shipped — "Sign in with HuggingFace" (OAuth 2.0 + PKCE)
+unlocks gated demo datasets and gated model weights. Open follow-ups first;
+shipped detail below.
 
 ## Open follow-ups
 
@@ -72,3 +16,37 @@ and there was no in-app way to authenticate.
 - **Per-dataset gated badges.** The demo picker could mark gated datasets up
   front (and prompt sign-in before the user starts a doomed download) rather than
   only reacting on failure.
+
+## Problem
+
+Several demo datasets (and some model weights, e.g. DINOv3) are *gated* on the
+HuggingFace Hub. The raw download path (`vtscore/datasets/downloader/core.py`)
+used unauthenticated `requests`, so a gated resource returned `401`/`403` as a
+raw `requests.HTTPError` string long enough to push the dashboard row's
+Dismiss/Cancel button out of view — and there was no in-app way to authenticate.
+
+## What shipped
+
+- **Token store** — `vtscore/security/hf_auth.py` holds a single HF credential
+  **in memory only** (process-scoped, never on disk). `set_credential`,
+  `clear_credential`, `get_token`, `is_authenticated`, `get_status`, and
+  `auth_header_for_url(url)` (Bearer only for `huggingface.co`/`hf.co`, so the
+  token never leaks to presigned CDN/Xet redirects). Defines `GatedResourceError`.
+- **OAuth routes** — `vtsearch/routes/auth_huggingface.py` (plain Flask blueprint,
+  off the OpenAPI surface): `GET .../status`, `GET .../login` (PKCE verifier +
+  CSRF state in the Flask session), `GET .../callback` (exchanges code, stores
+  token, redirects to `/?hf_auth=success|error`), `POST .../logout`.
+- **Operator setup** (one-time): register an OAuth app with redirect URI
+  `<base-url>/api/auth/huggingface/callback` and `read-repos` scope, set
+  `HF_OAUTH_CLIENT_ID` (+ `HF_OAUTH_CLIENT_SECRET` for a confidential client;
+  optional `HF_OAUTH_REDIRECT_URI`, `HF_OAUTH_SCOPES`). Unconfigured → UI shows
+  setup guidance; `HF_TOKEN` env var still works as a fallback.
+- **Downloads + embedders** — `core._open_validated_stream` attaches the HF
+  Bearer header per redirect hop (host-checked each hop); `401`/`403` raises a
+  short, actionable `GatedResourceError` (no retry); `embedder.hf_token()` prefers
+  the OAuth token then `HF_TOKEN`, so signing in also unlocks gated weights.
+- **Frontend** — `HuggingFaceAuthService` (signals) drives status/login/logout; a
+  **HuggingFace** tab in Settings; the failed-load row offers **"Sign in with
+  HuggingFace"** on a gated error with a layout fix so a long message can't
+  obscure the buttons; the root component toasts the OAuth result and strips the
+  `hf_auth` query params.

--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -1,1191 +1,198 @@
 # Logical-Bug Audit: 2026-05
 
-**Status:** Resolved. C1–C12 (critical) and H1–H34 (high) are shipped; the
-security trio M32–M34 and the data-integrity M21 shipped 2026-06-24, and the
-L1–L9 low batch was triaged the same day (L7/L9 fixed, the rest closed as
-stale / hypothetical / by-design). The last two open mediums — **M29** (audio
-context cleanup) and **M35** (one-vote eval metrics) — shipped 2026-06-25. No
-open findings remain; this doc is kept as the audit record. Resolved findings
-are marked as struck-through headings.
+**Status:** All findings resolved; kept as the audit record. C1–C12 (critical)
+and H1–H34 (high) shipped; the security trio M32–M34 and data-integrity M21
+shipped 2026-06-24; the L1–L9 low batch was triaged the same day (L7/L9 fixed,
+the rest closed as stale / hypothetical / by-design); the last mediums M29 +
+M35 shipped 2026-06-25. No open findings remain. A handful of cross-cutting
+open follow-ups (below) are the only work still owed.
 
-**Scope:** Multi-agent audit (10 per-subsystem + 5 cross-section
-interaction passes) of the entire VTSearch codebase, focused on
-**logical** bugs; missed expectations between modules, race conditions,
-silent miscompute, data corruption, and broken invariants. Syntax,
-typing, and lint issues were explicitly out of scope (those are covered
-by `ruff` / `pyright` / `tsc`).
-
-**Total distinct findings (after dedup):** ~95.
+**Scope:** Multi-agent audit (10 per-subsystem + 5 cross-section interaction
+passes) of the entire VTSearch codebase, focused on **logical** bugs — missed
+expectations between modules, race conditions, silent miscompute, data
+corruption, broken invariants. Syntax, typing, and lint were out of scope
+(covered by `ruff` / `pyright` / `tsc`). ~95 distinct findings after dedup.
 
 ## How to read this doc
 
-- Findings are grouped first by **severity**, then by subsystem within
-  each tier.
-- Each open finding has a stable ID (`C#` Critical, `H#` High,
-  `M#` Medium, `L#` Low) so it can be referenced from other docs / PRs.
-- Shipped findings are reduced to a struck-through heading. The full
-  fix summary is the PR that landed it; git log, not this doc.
-- The "Recurring patterns" section at the bottom is the actionable
-  starting point; most findings collapse into a small number of root
-  causes; fixing the pattern usually fixes many findings at once.
-- The "Suggested fix order" section recommends which root-cause PRs to
-  land first for maximum leverage.
-- File:line references are approximate; line numbers may shift slightly
-  as the codebase evolves.
-
-## Audit coverage
-
-Per-subsystem agents:
-
-1. State management & concurrency (`vtsearch/state/`, `concurrency/`)
-2. Detector training pipeline (`vtsearch/detectors/`, `training/`)
-3. Datasets & importers (`vtsearch/datasets/`)
-4. Routes & API contracts (`vtsearch/routes/`)
-5. Settings & sync sources (`vtsearch/settings.py`, `settings_io/`,
-   `sync/`)
-6. Embedding & training infrastructure (`vtsearch/embedding/`,
-   `training/`)
-7. Security validation (`vtsearch/security/`)
-8. Plugins, converters, eval, exporters
-9. Auth, CLI, app entry (`vtsearch/auth/`, `app.py`, `cli.py`)
-10. Frontend Angular logic (`frontend/src/`)
-
-Cross-section interaction agents:
-
-11. Dataset ↔ Detector ↔ Embedder triple
-12. Settings ↔ everything (user vs server tier, sync sources)
-13. Background-jobs / context propagation
-14. Error / exception flow across layers
-15. Frontend ↔ backend contract seams
-
----
-
-## Critical: data corruption / loss / hangs / silent miscompute
-
-### ~~C1. Download gate is never released if importer skips the `"embedding"` status~~
-
-### ~~C2. JobManager never sets dataset/detector thread-local context~~
-
-### ~~C3. Dataset background load tasks don't set thread-local dataset context~~
-
-### ~~C4. Embedding-matrix cache is not invalidated after clip/dedup~~
-
-### ~~C5. `find_label` allows body field to override the request's dataset context~~
-
-### ~~C6. Zip-slip in HTTP archive importer (zip AND tar)~~
-
-### ~~C7. NaN/Infinity threshold leaks through safe-threshold blending~~
-
-### ~~C8. Bulk label paths skip achievement recording entirely~~
-
-### ~~C9. Path-template substitution missing post-resolution validation~~
-
-### ~~C10. MD5 / metadata cache collision returns wrong-dataset media on switch~~
-
-### ~~C11. `fill_labels_from_sort` silently swallows sync failures~~
-
-### ~~C12. Orphaned dataset registry entry on activation failure~~
-
----
-
-## High: likely-encountered correctness or security bugs
-
-### State / concurrency
-
-- ~~**`record_vote()` called after releasing `_state_lock`**~~
-- ~~**H1. Vote-progress invalidation / `record_vote` race**~~: fixed by
-  replacing the toggle contract on `POST /api/medias/<id>/vote` with an
-  absolute-target contract.  Body takes `target: "good" | "bad" | "none"`
-  instead of `vote: "good" | "bad"`; handler delegates to a new
-  `vtscore.state.votes.set_vote(media_id, target, region_box)` that
-  no-ops on idempotent re-applies (no `label_history` append, no
-  achievement credit, no click-time bump, no progress-cache churn), so
-  two stale-view tabs racing the same target collapse into a single
-  transition on the server instead of alternating ADD/REMOVE.  Progress
-  cache now invalidates on **any** training-set membership change for
-  the media (was: polarity flips only; left un-vote cached models
-  stale).  Response shape grew `state` + `click_time`; the Angular
-  `VoteStateService` was rewritten around a single `submitToggleVote()`
-  entry point that computes the target from local state and clears
-  `pendingOptimistic` deterministically on every POST return, closing
-  the persistent prediction-vs-server desync half of the bug.  Covered
-  by new regressions across `tests/core/test_votes.py`,
-  `tests/api/test_error_recovery.py`, `tests/core/test_achievements.py`,
-  `tests/api/test_api_contracts.py`, `tests/detectors/test_patch_embedder.py`,
-  and `frontend/src/app/services/vote-state.service.spec.ts`.  See
-  Open follow-ups for the parallel labelset-element vote endpoint.
-
-### Detector / training
-
-- ~~**H2. Cross-dataset region-box loss**~~: fixed in
-  `vtscore/detectors/labelset_training.py`. `_embed_one` now resolves the
-  origin, runs `patch_forward` on the file when the active embedder
-  supports patch regions, and pools the box via `box_to_vote_vector` so a
-  region vote's training intent survives a dataset switch. Logs a
-  warning and falls back to a full-file embedding only when the embedder
-  has no patch path (single-vector models) or the forward pass produces
-  no output. Covered by `TestRegionAwareTrainingCrossDataset` in
-  `tests/detectors/test_patch_embedder.py`.
-- ~~**H3. Embedder drift on save → reload**~~
-- ~~**H5. Detector embedder not revalidated on dataset switch**~~:
-  fixed in `vtscore/detectors/dataset_sync.py` +
-  `vtsearch/routes/detectors/scoring.py` +
-  `vtsearch/routes/detectors/find.py`.
-  `invalidate_detector_model_on_embedder_mismatch()` drops
-  `DetectorContext.model` / `threshold` / `last_learned_scores` /
-  `training_medias` / `calibration_cache` when the dataset about to be
-  scored uses a different embedder than the one the cached MLP was
-  trained on.  `before_request` calls
-  `ensure_detector_model_matches_active_embedder()` for the active
-  ctx so a dataset switch invalidates immediately; the scoring fast
-  paths (`_resolve_or_train_detector` for find-label / auto-detect,
-  `_select_scorer` in multi-dataset Find) repeat the check
-  per-detector to cover Auto-Find loops and cross-dataset Find where the
-  active ctx wrapper alone isn't enough.  The helper deliberately
-  leaves `label_embeddings` and `embedder` alone so the load
-  endpoint's progress-tracked `_maybe_start_label_reembed()` flow
-  still detects the mismatch and schedules its visible re-embed task;
-  the next training pass restamps the marker via
-  `populate_label_embeddings` and `record_detector_embedder`.  Also
-  fixed the secondary mixed-embedder bug in the resolver:
-  `resolve_label_embeddings()` now accepts an `embedder_name` kwarg
-  and the scoring / find callers pass the dataset's embedder so
-  origin-resolved label vectors share one space with the snap-matched
-  ones (previously the origin path defaulted to the media type's first
-  registered embedder, mixing two spaces into a single MLP).  Covered
-  by `TestEmbedderMismatchInvalidatesStaleModel` in
-  `tests/detectors/test_detectors.py` and the new
-  `test_forwards_embedder_name_to_*` cases in
-  `tests/detectors/test_resolver.py`.
-- ~~**H6. `train_model` produces degenerate single-class model**~~
-- ~~**H7. Vote applied before retrain; retrain failure leaves vote live**~~
-
-### Datasets
-
-- ~~**H8. Origin dict shared by reference across medias**~~
-- ~~**H9. Single-item split has 0 test samples**~~
-- ~~**H10. Clipped media re-ingest reads whole file for MD5**~~:
-  fixed (2026-05-20). `vtscore/datasets/ingest.py` (formerly
-  `vtsearch/datasets/ingest.py`) now routes both `_ingest_via_source`
-  and `_ingest_via_resolver` through a new
-  `_resolve_clip_content_and_embedding` helper that pairs the clip
-  embedding with the clip's actual content bytes; so `md5`,
-  `file_size`, and `media_bytes` describe the clip, not the parent.
-  Video metadata-only clips (and other fall-through paths) fall back
-  to the load-pipeline's `MD5(parent_bytes) + boundary_tag` scheme so
-  distinct clips of the same parent still hash uniquely. The clip-bytes
-  return value is plumbed through `_apply_clip_and_embed` /
-  `_replay_chain` / `replay_chain_on_file`; see
-  `tests/io/test_label_import_ingestion.py::TestClippedReingest`.
-- ~~**H11. Multi-media import with empty form yields empty dataset**~~
-
-### Routes / API
-
-- ~~**H12. `add_media_to_pile` race**~~: investigation closed
-  (2026-05-20): not a real race in the current architecture. The
-  audit's framing assumes a global "active dataset" pointer that
-  could be switched mid-handler between `snapshot_medias()` and
-  `apply_label()`, but `before_request` in `app.py` pins both
-  `g._dataset_context` and `g._detector_context` for the duration
-  of each request (resolver in `vtsearch/shim/__init__.py:19-39`),
-  and `flask.g` is request-local; so the two calls inside one
-  `add_media_to_pile` invocation always resolve to the same
-  contexts. Note also that `apply_label` writes to the *detector*
-  context's `good_votes` / `bad_votes`, not to a dataset, so the
-  audit's "labels applied to wrong dataset" framing is a category
-  error. The same line window (L600-694) does contain real bugs,
-  but they are different from the one H12 names; see H32 / H33 /
-  H34.
-- ~~**H13. `vote_media` silent-mistarget on dropped header**~~
-- ~~**H14. `export_labels` leaks votes across datasets**~~
-- ~~**H15. File-browser symlink metadata leak**~~: investigation
-  revised and fixed (2026-05-20). The audit's literal claim was
-  incorrect: the `target.resolve().relative_to(root)` check at
-  `vtsearch/routes/file_browser.py:90` does block drill-through into
-  symlinked-out directories (resolve canonicalises through the link,
-  and `relative_to` then raises). The real bug was in the listing
-  loop at L105–118: `entry.is_dir()` / `entry.is_file()` / `stat()`
-  all follow symlinks by default, so an in-root symlink pointing
-  outside the root showed up as an ordinary entry and leaked the
-  external target's existence, name, `size_bytes`, and `modified_at`.
-  In multi-user mode this violated the data-dir isolation contract
-  asserted by `TestMultiUserBrowseIsolation`. Fix: in the listing
-  loop, call `entry.resolve(strict=True).relative_to(root)` on
-  symlinks and skip any that escape root or are broken; intra-root
-  symlinks remain visible. Covered by `TestBrowseSymlinks` in
-  `tests/api/test_file_browser.py`
-  (`test_symlink_to_external_dir_hidden`,
-  `test_symlink_to_external_file_hidden`,
-  `test_intra_root_symlink_still_listed`,
-  `test_broken_symlink_skipped`,
-  `test_symlink_drill_through_blocked`). Note: a separate
-  symlink-follow content escape exists in
-  `vtscore/security/path_validation.py:rglob_follow_symlinks`
-  (importers walk with `followlinks=True` and per-file paths
-  outside the validated root are not re-checked); that's a
-  different code path, not covered by this fix.
-- ~~**H16. Header refers to unloaded dataset → silent fallback**~~:
-  also closes the "header points to an unloaded id" half of H34 by the
-  same mechanism. The "header absent → thread-local leak" half of H34
-  remains open.
-- ~~**H32. `add_media_to_pile` TOCTOU between md5 check and insertion**~~:
-  fixed in `vtsearch/routes/media/list.py`. After the initial
-  outside-the-lock MD5 lookup (fast path for an existing match) and
-  the unlocked embed step, the route now re-runs
-  `build_media_lookup(medias)` under `_state_lock` immediately before
-  assigning `new_id` (L700-718). On collision it routes into the
-  existing-cid branch (`is_new=False`); otherwise it inserts. Two
-  concurrent uploads of identical bytes therefore produce exactly one
-  new media, with the loser voting the winner's id. Covered by
-  `TestAddToPile.test_concurrent_uploads_same_md5_no_duplicate` in
-  `tests/core/test_medias.py`, which uses a `threading.Barrier(2)`
-  patched into the embedder to deterministically hold both requests
-  inside the unlocked window.
-- ~~**H33. `add_media_to_pile` label not synced to disk**~~: fixed
-  in `vtsearch/routes/media/list.py`. Both branches of
-  `add_media_to_pile` (existing-MD5 match and new-media insertion)
-  now call `_sync_pile_label_to_storage()` after `apply_label`,
-  which mirrors `vote_media`'s tail by invoking
-  `sync_labels_to_loaded_detector()` + `sync_to_labelset_source()`.
-  The label reaches the detector's on-disk labelset and any
-  configured `LabelsetSource`, so a subsequent
-  `ensure_votes_match_active_dataset` rehydration restores it
-  instead of silently dropping it. Covered by
-  `TestAddToPile.test_existing_media_label_synced_to_disk`,
-  `test_new_media_label_synced_to_disk`, and
-  `test_label_survives_rehydration` in `tests/core/test_medias.py`.
-- ~~**H34. Missing `X-Detector-Id` → silent detector fallback**~~:
-  fixed in `vtsearch/routes/_shared.py`. Added two stateless route
-  decorators, `require_detector_header` and `require_dataset_header`,
-  that reject 400 when the corresponding header (or its `?detector_id=`
-  / `?dataset_id=` query-param fallback) is absent. Applied to every
-  vote-mutating endpoint: `vote_media` and `add_media_to_pile`
-  (`media/list.py`), `import_labels` and `fill_labels_from_sort`
-  (`labels/vote.py`), `run_label_import` and `ingest_missing`
-  (`labels/importers.py`), `clear_votes_route` (detector only) and
-  `seed_votes_from_examples` (`sorting.py`), and `find_label`
-  (`detectors/scoring.py`). The decorators run *before* the resolver
-  chain so a thread-local leak on a Flask worker can't silently
-  mistarget a vote even if a future code path were to leave a
-  thread-local detector pinned across requests. Pure-read endpoints
-  (registry listings, dashboard, file browser, settings GET) keep the
-  fall-through behaviour so background scripts and the standalone CLI
-  still work without headers. Test plumbing: `tests/conftest.py` now
-  wraps `client.open()` to auto-inject `X-Dataset-Id` /
-  `X-Detector-Id` from the thread-local active context (mimicking
-  Angular's `activeContextInterceptor`), so the existing test corpus
-  keeps working unchanged; tests that need to exercise the
-  header-absent path drop the thread-local first.
-
-### Plugins / converters / exporters
-
-- ~~**H17. Plugin scanner silently shadows duplicate names**~~
-- ~~**H18. CSV exporter doesn't escape embedded newlines**~~:
-  investigation closed (2026-05-20): not a real bug. The audit's
-  path is also stale (exporters moved to `vtscore/exporters/`); the
-  actual file is `vtscore/exporters/server_csv_file/__init__.py`.
-  The code at L120–141 does not hand-roll CSV rows; it dispatches
-  dict vs scalar cells and hands the row to `writer.writerow(row)`
-  (L141), where `writer` is a stdlib `csv.writer` (L36) using the
-  default `QUOTE_MINIMAL`, which always quotes fields containing
-  `\n`, `\r`, or the delimiter. The file is opened with
-  `newline=""` (L39), so no newline translation corrupts the
-  quoted content. The matching importer
-  (`vtscore/labels/importers/server_csv_file/__init__.py` L96)
-  uses `csv.DictReader`, which reads multi-line quoted fields
-  back correctly. Verified via round-trip with `\n` embedded in
-  the `label`, `origin_name`, and `category` fields plus `"` in
-  the label: the exporter wrote a valid quoted CSV and the
-  importer returned the original strings byte-for-byte
-  (`.strip().lower()` on the label only trims leading/trailing
-  whitespace; interior newlines pass through).
-- ~~**H19. Required select fields silently accept empty string**~~:
-  investigation closed (2026-05-20): not a real bug. The audit's
-  framing assumes `_presence_kwargs()` in `vtscore/plugins/schema.py`
-  produces `{"required": True, "load_default": ""}` for a required
-  select, but the function is a mutually-exclusive 3-way branch that
-  never emits both keys (required-with-no-default → `{"required":
-  True}` only; default present → `{"load_default": <default>}`
-  only). More importantly, `_build_select` adds
-  `_non_empty_after_strip` to the validator list for every required
-  select (schema.py:116-117); empty strings and whitespace-only
-  strings are rejected with `"Field may not be empty."`, and the
-  OneOf at L119 excludes `""` from its allowed set for required
-  fields too (double defence). Empirical check via
-  `schema.load({"choice": ""})` confirms a 422 for required selects
-  with static options, dynamic options, and with a non-empty default
-  alike. The parallel text-field case is already covered by
-  `tests_lib/core/test_plugin_schema.py::test_required_text_rejects_whitespace_only`.
-- ~~**H20. `audio2image` has no upper bound on `n_mels`**~~: fixed
-  systemically in `vtscore/plugins/schema.py:_build_number()`, which
-  now attaches `validate.Range` whenever a `PluginField` declares
-  numeric `min` / `max` (so every plugin family that goes through
-  `validate_plugin_args` benefits). Converters bypass that route-layer
-  schema because their `params` ride inside `source_specs` /
-  `clipper_chain` pass-through dicts, so they got their own entry
-  point: `MediaConverter.validate_params()` runs the params through
-  the converter's own plugin schema, and the two upstream parsers
-  (`_parse_multi_media_specs` and `clipper_chain.validate_chain`) call
-  it before any expensive work runs. The `audio2image` declared range
-  is now actually enforced; `n_mels=10_000_000` is rejected at
-  request time instead of building a ~41 GB mel filter bank inside
-  librosa. Audited every numeric `PluginField` in the codebase; no
-  declared `max` was tighter than real usage, so attaching `Range`
-  everywhere was safe.
-
-### CLI / app entry
-
-- ~~**H21. Successful `--autodetect` falls through to Flask startup**~~
- ; Not a bug. The audit misread `elif args.local or not args.autodetect:`
-  as an independent `if`; it is an `elif` paired with `if args.autodetect:`
-  above it, so the two branches are mutually exclusive and Flask never
-  starts after a successful autodetect. Simplified the redundant `elif`
-  condition to a plain `else:` in `app.py` since reaching it already
-  implies `not args.autodetect`.
-
-### Embedding
-
-- ~~**H22. `predict_embedders_to_preload` mismatched media type**~~:
-  shipped in commit `92e27a39` (PR #1561, "H22: persist detector
-  embedder for accurate preload prediction"). The detector registry
-  now carries an `embedder` field stamped by
-  `record_detector_embedder()` during training
-  (`vtscore/detectors/workflow.py:174`,
-  `vtscore/detectors/labelset_training.py:281`), and both dataset
-  and detector paths in `predict_embedders_to_preload()`
-  (`vtscore/embedding/loader.py`) go through a shared `_resolve()`
-  that prefers `entry["embedder"]` and falls back to the media
-  type's default only when the field is unset or unrecognised.
-  Legacy detector entries written before the field existed remain on
-  the default-embedder fallback until the next retrain stamps them;
-  documented as expected behaviour in the function's docstring.
-
-### Security / sync
-
-- ~~**H23. Settings-source filepath template not path-validated**~~:
-  duplicate of C9 (already struck through above); shipped in commit
-  `988dca3b` ("logical-bug-audit C9; validate resolved sync-source
-  paths"). Both sync sources now call
-  `validate_server_filepath(resolved, base_dir=get_file_access_base_dir())`
-  at the end of `_resolve_filepath()`
-  (`vtsearch/settings_io/sources/server_json_file/__init__.py:89`,
-  `vtscore/labels/sources/server_json_file/__init__.py:121`/L150), so
-  the background sync site at `vtsearch/settings.py:932` is covered
-  alongside route handlers. Regression tests:
-  `tests/io/test_sync_sources.py::test_resolved_template_path_outside_base_dir_rejected`
-  (one per source).
-
-### Frontend
-
-- ~~**H24. Vote-state polling chain dies on a single error**~~
-- ~~**H25. Active dataset pair is set before load completes**~~:
-  shipped in commit `9470cf1a` (PR #1563, "Fix H25: split
-  ActiveContextService into intent + active layers").
-  `ActiveContextService` now exposes two layers:
-  **intent** (what the user just picked, flips immediately for UI
-  affordances like the pulldown highlight) and **active** (the loaded
-  pair; what `activeContextInterceptor` reads when attaching
-  `X-Dataset-Id` / `X-Detector-Id`).  `ContextSwitchService.flipAndLoad`
-  calls `setIntent()` on entry
-  (`frontend/src/app/services/context-switch.service.ts:147`) and
-  only promotes to `setActive()` inside `finishIfCurrent()` (L297)
-  after any required dataset / detector load endpoint has resolved
-  *and* the corresponding `loadingTasks` SSE channel has gone idle.
-  The latest-wins request-id check on the same line guards against a
-  stale switch racing past a newer one.  `setActivePair()` keeps its
-  atomic-both-layers semantics so cleanup paths
-  (`ActiveContextWatcherService` clearing a removed half,
-  `ActiveContextService.clear()`) work unchanged.  Regression tests:
-  `frontend/src/app/services/context-switch.service.spec.ts` cover
-  (a) intent flips immediately while active stays pinned mid-load,
-  (b) active promotion only after both the HTTP load and the
-  loading-tasks idle signal arrive, (c) cancel-and-replace via
-  request-id mismatch when a second switch starts before the first
-  finishes.
-- ~~**H26. `recordVote` runs before the HTTP vote returns**~~: fixed
-  by gating the undo-stack push on the POST's success.  A new
-  `VoteStateService.submitToggleVoteAndRecord(id, vote, mediaName,
-  regionBox?)` captures `previousPolarity` synchronously (before the
-  optimistic flip), then calls `submitToggleVote(...)` and pushes the
-  undo entry inside the resulting Observable's `tap`; so an entry
-  only lands on `past` after the server confirms.  On error the `tap`
-  doesn't run, leaving the undo / redo stacks untouched.  The three
-  callers (`center-panel`, `find-view`, `label-view`) were migrated to
-  the new helper; `recordVote` stays public as a low-level primitive
-  (used by the spec) with a docstring pointing future callers at the
-  wrapper.  Regressions in `vote-state.service.spec.ts` cover (a) the
-  no-entry-on-error path, (b) `previousPolarity` capture before the
-  flip, and (c) redo-stack preservation on a failed POST.
-- ~~**H27. Binary media endpoints bypass the `activeContextInterceptor`**~~
- ; Not a bug. Functional `HttpInterceptorFn`s registered via
-  `provideHttpClient(withInterceptors([...]))` apply to **every**
-  `HttpClient` call; typed-client wrappers and raw `this.http.get(...)`
-  share the same client and the same interceptor chain. The real
-  bypass surface is native `<img src>` / `<audio src>` / `<video src>` /
-  `<iframe>` / `fetch()`, which don't go through `HttpClient` at all;
-  those are already handled by `ActiveContextService.mediaUrl()`
-  appending `?dataset_id=…&detector_id=…` query params, with the
-  backend reading them as a fallback (`app.py` L238, L252). Also
-  removed the four dead `getAudio/getVideo/getImage/getMedia` methods
-  on `MediasApiService`; they had no callers; every binary-stream
-  consumer goes through `mediaUrl()`.
-
-### Multi-process / settings
-
-- ~~**H28. Per-user cache is process-local; concurrent worker writes lose
-  updates**~~; fixed in `vtsearch/settings.py`. Every per-user (and
-  server-tier) write now goes through `_mutate_*_locked`, which holds a
-  cross-process `fcntl.flock` on a sibling `.lock` file, re-reads the
-  on-disk JSON, applies the mutator in place, and atomic-writes with
-  a per-writer `<file>.<pid>.<uuid>.tmp` name. The legacy "mutate cache
-  then save whole dict" pattern was removed (including from
-  `vtsearch/achievements.py`, which now uses the new public
-  `settings.mutate_user(mutator)` RMW helper for nested-dict updates).
-  Canonical lock order is `file_lock → settings_lock` everywhere; the
-  outer `with _settings_lock:` was removed from setter wrappers and
-  from read paths that previously held it across `_ensure_user_loaded`
-  (which can transitively trigger setter writes via sync-from-source).
-  Covered by `TestConcurrentWrites` in `tests/core/test_settings.py`
-  (RMW key-preservation, unique tmp filename pattern, two-thread
-  no-deadlock, `mutate_user` nested-dict RMW, `add_autofind_detector`
-  cross-process merge).
-
-  **Open follow-ups:**
-  - `_synced_users` is still process-local, so on a fresh container
-    every worker independently runs sync-from-source for each user
-    once. With the RMW fix this is no longer corrupting (just
-    duplicate I/O against the source) but worth de-duplicating with
-    an mtime-marker if it shows up in profiles.
-  - The legacy-settings migration in `_maybe_migrate_legacy_settings_locked`
-    still calls `_atomic_write` without the cross-process lock. It is a
-    one-shot startup step so the race window is small, but for full
-    correctness it should also use `_mutate_server_locked`.
-  - Windows has no `fcntl`, so the cross-process lock silently degrades
-    to the in-process lock only. Not a regression (the codebase ships
-    Linux-only Docker images), but worth a note if a contributor ever
-    wants to test on Windows.
-- ~~**H29. `_save_user` holds `_settings_lock` across sync I/O**~~:
-  was at `vtsearch/settings.py` ~L331–338. H28's fix already moved
-  `_sync_to_source` outside both the file lock and `_settings_lock`,
-  which neutralised the worst case (a hung NFS/webhook source could
-  no longer freeze every settings read/write process-wide). The H29
-  follow-up closes the remaining surface: `_atomic_write` and
-  `_load_path` inside `_mutate_server_locked` / `_mutate_user_locked`
-  now run under the cross-process `_file_lock` only, and
-  `_settings_lock` is acquired briefly at the end just to swap the
-  in-memory cache.  A slow local fsync (NFS data dir, full disk,
-  hung disk controller) therefore no longer blocks unrelated
-  settings reads, and only blocks writes to the *same* user's file
-  via the per-file lock; different users' writes proceed in
-  parallel.  Regression tests:
-  `tests/integration/test_thread_safety.py::TestSlowSettingsIODoesNotBlockOthers`
-  (slow `_sync_to_source` doesn't block a reader; slow
-  `_atomic_write` for user A doesn't block user B's write; slow
-  `_atomic_write` doesn't block settings reads).
-
-### Error flow
-
-- ~~**H30. Detector save's `os.replace` failure leaves in-memory state
-  "saved"**~~; fixed by surfacing persistence failures at the previously-
-  unprotected call sites (`POST /api/medias/<id>/vote`,
-  `POST /api/votes/seed-from-examples`) with the same try/except + abort
-  500 pattern that already guards `fill_labels_from_sort` (C11), and by
-  making `vtscore.detectors.workflow.apply_and_retrain` snapshot the
-  detector context's vote dicts / region boxes / label history / click
-  state before the sync and restore them when `_write_detector` raises.
-  A failed save now never leaves votes live in memory while the on-disk
-  labelset omits them; the next save no longer inherits ghost state from
-  a prior failed write.  Regression tests:
-  `tests/detectors/test_workflow.py::TestPersistenceFailureIsTransactional`,
-  `tests/api/test_api_contracts.py::TestVotesContract::test_disk_sync_failure_surfaces_as_500`,
-  and `tests/detectors/test_detectors.py::TestSeedVotesFromExamples::test_seed_disk_sync_failure_surfaces_as_500`.
-- ~~**H31. Partial label-import has no rollback**~~: fixed by
-  isolating each entry inside `_apply_labels` with a per-entry
-  try/except and surfacing the per-entry failures in the response
-  (`failed` / `failed_count`).  Downstream syncs
-  (`sync_labels_to_loaded_detector`, `sync_to_labelset_source`,
-  `record_detector_import`) still fire on partial success so the
-  in-memory detector and the labelset source stay consistent with what
-  actually landed.
-
----
-
-## Medium: real bugs but lower frequency or non-corrupting impact
-
-### State / concurrency
-
-- ~~**M1.** Lock held during cross-lock callbacks in `toggle_vote`: state ↔
-  progress lock ordering creates a narrow but real deadlock window.~~;
-  investigated and closed (2026-05-20).  The literal deadlock the audit
-  named was no longer reachable in the current code (post-H1 refactor:
-  nothing inside `_progress_lock` calls back into `_state_lock`-acquiring
-  code, and route callers of progress functions do not hold `_state_lock`
-  when entering the progress module).  But the design was fragile;
-  four sites (`vtscore/state/votes.py:_set_vote_locked` + `clear_votes`,
-  `vtscore/state/__init__.py:clear_medias` + `set_inclusion`) held
-  `_state_lock` while calling into the progress module, while two others
-  (`register_detector_context` / `unregister_detector_context`) explicitly
-  released it first.  Standardised all six sites on release-first: the
-  progress-cache calls now run strictly outside `_state_lock` everywhere,
-  so the canonical order is one-directional and adding a new state→progress
-  callsite is harder to get wrong.  `_set_vote_locked` no longer touches
-  `_progress_lock`; `set_vote` / `toggle_vote` invalidate the progress
-  cache after releasing `_state_lock`.  `clear_all` no longer wraps both
-  inner clears in a single `_state_lock`, since each inner now releases
-  before calling `clear_progress_cache` (the sole caller, dataset-load,
-  immediately repopulates state so the loss of cross-clear atomicity is
-  acceptable).  Lock-order invariant documented in the
-  `vtscore/detectors/labeling_progress.py` module docstring.
-- ~~**M2.** `combine_datasets.run_chunked` re-issues IDs starting at 1 on every
-  call → cid collision when consumed twice.~~; fixed in
-  `vtscore/cli.py`. Investigation showed this is not unique to
-  `combine_datasets`: every chunked importer/loader emits IDs `1..N`
-  per yielded chunk (the convention paired with
-  `consume_chunks_into`'s renumbering in the in-process loader). The
-  HTTP/UI path is safe; `vtscore/datasets/load_pipeline.py:1057-1073`
-  already renumbers. The CLI path (`_run_live_pipeline`) scored each
-  chunk independently and merged the per-chunk hit lists, so the
-  exported JSON's `id` fields collided across chunks (the CSV
-  exporter doesn't include `id`, so was unaffected). Fix: added
-  `_renumber_chunks()` at the CLI boundary and wrapped both
-  `_load_pickle_chunked` and `_load_importer_chunked` with it, giving
-  every media a globally unique id in the CLI flow regardless of
-  which chunked importer fed it. Covered by
-  `tests_lib/cli/test_chunk_renumber.py` (unit) and
-  `tests/cli/test_chunked_id_renumber.py` (end-to-end via pickle and
-  combine_datasets, including the JSON exporter).
-- ~~**M3.** `importers/base.py` L407–410: skipped records leave `next_id`
-  unincremented, ID collisions on first-record-skip.~~
-
-### Detector
-
-- ~~**M4.** `populate_label_embeddings` cache not invalidated when a
-  `region_box` is removed from an element; stale pooled vector
-  continues to be used.~~
-- ~~**M5.** `labelset_elements.resolve_current_dataset_cid` can return a
-  colliding-MD5 cid in cross-dataset labelsets → clicks vote the
-  wrong media.~~; closed as not-a-bug on `dev`. The function returns
-  `cids[0]` from the origin+name ∪ md5 union, which is only ambiguous
-  when two cids in the active dataset share an MD5. Both Flask
-  dataset-load paths (`vtscore/datasets/load_pipeline.py` and
-  `vtsearch/routes/datasets/registry.py`) run `collapse_duplicates`,
-  which collapses same-MD5 medias into a single `dupe_set`
-  representative; so the md5 lookup never yields more than one cid.
-  Cross-dataset MD5 match is the intended semantic (same content →
-  same logical media), not a miscompute. Docstring on
-  `resolve_current_dataset_cid` records the invariant and points at
-  the regression test
-  (`tests/datasets/test_duplicates.py::test_collapse_duplicates_yields_unique_md5_lookup`).
-  Related but distinct issues are left as their own items: M4 (region
-  box cache invalidation, since closed upstream) and the
-  `vote_detector_label` handler dropping `region_box` when mirroring
-  into in-memory votes (`vtsearch/routes/detectors/labels.py:601`).
-- ~~**M6.** `restore_labels_from_detector` resolves by MD5 only on the
-  second pass; dedup-collapsed cids can land votes on the wrong cid
-  after reload.~~; investigated and closed as not a real bug. Pass 1
-  already consults `md5_lookup` via `resolve_media_ids`
-  (`vtscore/state/media_lookup.py:62`), and the dedup-collapse reload
-  path lands on the correct rep cid in every case (deduped,
-  un-deduped, cross-dataset). The forward-pointer to **M5** in the
-  original M6 note is now also closed (see M5 above); a separately
-  worrying latent issue is that pass 2 recomputes the *parent*
-  file's md5 for `converter` origins
-  (`vtscore/detectors/resolver.py:_resolve_converter`) while the
-  dataset stores the converted-output md5; track under detector
-  findings if it bites.
-- ~~**M7. `safe_thresholds` read at training time, cached on DetectorContext, never refreshed**~~
- ; partial close. The audit's "baked into the detector JSON" claim was
-  wrong: the threshold is never serialised (see the "No Persisted Vectors
-  or MLPs" rule in `CLAUDE.md`); every detector JSON write site lists
-  only `name` / `text_query` / `media_example` / `media_type` / `examples`
-  / `created_at` / `labelset` / `input_spec`. But a narrower staleness
-  was real: the in-memory `DetectorContext.model` / `threshold` cached on
-  detector load were not invalidated when the user changed
-  `safe_thresholds` / `inclusion` / `calibrate_count` /
-  `calibration_fraction`, so `/api/find-label`, `/api/find`, and
-  `/api/auto-detect` (the three consumers that short-circuit on the
-  cached MLP) kept scoring with the prior setting. Sort / vote paths
-  retrained every call and so were already correct. Fixed by a new
-  `vtscore.state.core.invalidate_loaded_detector_models()` that walks
-  every loaded `DetectorContext` and clears `model` + `threshold`; the
-  setters for all four training-relevant settings in
-  `vtscore/state/__init__.py` call it on actual change. The
-  `/api/settings PUT` route now dispatches those three keys through
-  `vtsearch.state` (matching the existing `inclusion` path) so both the
-  dedicated endpoints (`/api/safe-thresholds` etc.) and the bulk
-  settings endpoint trigger invalidation. Regression test:
-  `tests/sorting/test_safe_thresholds.py::TestTrainingSettingsInvalidateLoadedDetector`.
-
-### Datasets / loaders
-
-- **M8.** ~~Thin-mode pickle loader treats `embedding: None` as present, then
-  `np.array(None)` produces an object-dtype row.~~ **Shipped (with M12).**
-  `_convert_one_pickle_media` now treats missing key and explicit `None`
-  identically for both thin and full modes; entry is skipped and the
-  "missing media" warning fires.
-- ~~**M9.** `loader_folder._has_override` doesn't warn when both `rel_path`
-  and `file_name` override entries exist with different embeddings.~~
-- **M10.** ~~`clipper_chain._run_clipper_step` assumes deterministic output count
-  across calls; no validation.~~ **Shipped.** `_run_clipper_step` /
-  `_run_converter_step` now stamp `n_out`, `clip_index`, and a short
-  `content_hash` on every trail entry. `_select_chain_output` prefers
-  content matching over positional, logs warnings on output-count
-  drift / no-match / ambiguous match, and returns `None` instead of
-  silently picking `outputs[0]` (was a regression vs. the legacy
-  `_clip_text_to_bytes` resolver path).
-- ~~**M11.** Stale media in `cli._score_medias_with_detectors` when some
-  embeddings are `None` (zip truncates silently).~~ **Shipped (expanded
-  scope).** The literal "zip truncates" claim is wrong (both `all_ids`
-  and `scores` come from the same `(N, dim)` matrix, so lengths always
-  match). The real symptom under numpy 2.x is that a `None` embedding
-  becomes a NaN row via `matrix[i] = None`, propagates through the MLP
-  to a NaN score, fails every `score >= threshold` compare, and lands
-  in `negative_hits` with `NaN` in the JSON response. Fixed at three
-  layers:
-  (1) `vtscore/embedding/matrix.py` raises `ValueError` naming the
-  offending cid when any media has `embedding=None`; defensive root
-  guard catching every entry point (M8/M12 pickle loaders are one path;
-  `_fixup_clip_md5_and_embeddings` silently leaving `embedding=None`
-  after a failed bulk re-embed is another).
-  (2) `_drop_none_embeddings_stage` in
-  `vtscore/datasets/load_pipeline.py` removes any media with
-  `embedding=None` after the clipper stage and surfaces the dropped
-  count via the progress tracker so the load row reflects the real N.
-  (3) `zip(strict=True)` on every id↔score callsite
-  (`vtscore/cli.py`; already shipped with the M8/M12 PR;
-  `vtsearch/routes/sorting.py`,
-  `vtsearch/routes/detectors/{find,scoring}.py`,
-  `vtscore/detectors/{training,labelset_training,labeling_progress}.py`,
-  `vtscore/training/region_similarity.py`,
-  `vtscore/eval/voting_iterations.py`) so any future length divergence
-  fails loudly instead of silently truncating hits.
-  Regression tests in `tests_lib/core/test_embedding_matrix.py`,
-  `tests/datasets/test_load_stage_matrix_cache.py::TestDropNoneEmbeddingsStage`,
-  and `tests/io/test_export_options.py::TestCliScoringNegativeHits`
-  (the strict-zip regression already on dev plus a new None-embedding
-  loud-error regression).
-- **M12.** ~~`loader_pickle._build_pickle_full_media` has no null-check before
-  `np.array(media_info["embedding"])`.~~ **Shipped.**
-  `_convert_one_pickle_media` skips any entry whose `embedding` is
-  missing or `None` before the build helpers run; symmetric with the
-  thin-mode path (M8) and with the folder loader's drop-on-no-embed
-  behaviour. The registry load path doesn't re-embed after
-  `load_dataset_from_pickle`, so preserving `None` would have just
-  pushed the crash into the first sort/find call; dropping the
-  poisoned entry keeps the dataset usable and surfaces the loss via
-  the existing `missing_media` warning.
-
-### Routes / API
-
-- ~~**M13.** `learned_scores` in `/api/votes` can serialize as JSON
-  `NaN`/`Infinity` if the MLP destabilizes; invalid JSON to strict
-  clients.~~; fixed by routing every sigmoid→score path through
-  `vtscore.utils.scores.sigmoid_to_finite_scores` (NaN/±Inf → `-1.0`
-  sentinel) and adding a defensive `finite_or` guard at
-  `GET /api/votes`. Sanitised sites: `labelset_train_and_score`,
-  `train_and_threshold`, `_score_all_media`, `/api/learned-sort`,
-  `/api/label-file-sort`, `/api/find-label`, `/api/find` (live + cold
-  paths), `/api/auto-detect`, and CLI autodetect. `-1.0` sits outside
-  the `[0, 1]` sigmoid range so `score >= threshold` is always False
-  for sanitised scores and they sink to the bottom of any sort;
-  matches the frontend's existing `learnedScores[id] ?? -1` fallback.
-  Regression test in `tests/api/test_api_contracts.py` parses the
-  response with a `parse_constant` that rejects `NaN`/`Infinity`.
-- ~~**M14.** `diversity_tree_next_sample` references stale media IDs after
-  `/api/dataset/clear`.~~; investigated and closed.  The literal scenario
-  the audit named is no longer reachable: `clear_medias` (called via
-  `clear_dataset → clear_all`) sets `ctx.diversity_tree = None`, and the
-  active-dataset path of `/api/dataset/clear` unregisters the context so
-  subsequent requests either raise `DatasetNotLoadedError` (H16) or hit the
-  request-missing sentinel (whose tree is `None`).  A regression test pins
-  the behavior.  Two adjacent bugs surfaced during the investigation and
-  were fixed in the same PR: `clear_votes()` did not reset the dataset's
-  diversity-tree `seen` / `_labeled` sets, so `/api/votes/clear` left
-  `diversity_tree_next_sample` skipping previously-voted nodes and the
-  diversity-level chip stuck above zero; and
-  `ensure_votes_match_active_dataset` rehydrated detector votes via
-  `apply_label(silent=True)` (which skips the per-vote tree update)
-  without replaying onto the tree, so swapping detectors on the same
-  dataset left the tree reflecting the previous detector's seen state.
-  Both now reset the tree under `_state_lock` via a new
-  `DiversityTree.reset_seen()` / `resync_diversity_tree_to_detector`
-  helper pair that also dedupes the replay loop in `build_diversity_tree`.
-
-### Settings / sync
-
-- ~~**M15.** Pending labelset sync stores `dataset_ctx = None` without
-  checking; later `_run_pending_sync` triggers `AttributeError`.~~;
-  investigated and closed as not a real bug.
-  `sync_to_labelset_source` captures `dataset_ctx = get_active_context()`
-  (`vtscore/labels/sync.py:97`), and `get_active_context()` /
-  `get_active_detector_context()` are invariantly non-None: their
-  resolution chain (`vtscore/state/core.py:461`, `:614`) falls back to a
-  `_request_missing_*` sentinel inside a Flask request and to
-  `_empty_*_context` outside one. The dead `is None` halves at
-  `vtscore/labels/sync.py:89` and `:207` are what tipped the audit toward
-  this finding, but the `not detector_ctx.labelset_source` half already
-  screens out both sentinels (their `labelset_source` is `None`). When
-  the timer fires, `validated_vote_snapshot` reads `medias` /
-  `dataset_id` off whatever ctx-shaped object was captured, so no
-  `AttributeError` can fire. Two adjacent real-but-milder concerns were
-  noted during the investigation and left open: a misconfigured request
-  with `X-Detector-Id` but no `X-Dataset-Id` silently no-ops the sync
-  (captured sentinel → `validated_vote_snapshot` returns `safe=False`),
-  and the captured ctx references survive an unload-before-fire race
-  inside the 200ms debounce window. Both are silent inconsistencies, not
-  crashes; file separate findings if they ever bite.
-- ~~**M16.** Sync to source on first read after `_synced_users` marker can
-  still return stale local config if source changes silently.~~; fixed
-  alongside two adjacent latent defects in `_ensure_user_loaded`.
-  Replaced the `_synced_users: set[str]` "claim-then-sync" marker with
-  per-user `_UserSyncState` bookkeeping (`last_version`,
-  `last_check_monotonic`, `last_sync_succeeded`, `dirty_keys`) protected
-  by a per-user `_per_user_sync_lock` RLock, so:
-  (a) the TOCTOU race where a concurrent reader saw the marker before
-  the actual sync had populated the cache is gone; the lock now
-  serialises the decide-and-sync slow path,
-  (b) a transient first-sync failure no longer permanently locks the
-  user out of sync (`last_sync_succeeded` stays `False` and the slow
-  path retries past a 1-second rate-limit window),
-  (c) a new `SyncSource.peek_version` hook (default `None`, implemented
-  for `server_json_file` via `st_mtime_ns`) makes an upstream change
-  visible automatically on the next read after the freshness window
-  elapses, instead of requiring manual `POST /api/settings-sources/sync`
-  or process restart.  Auto re-sync respects local `dirty_keys` so a
-  freshly clicked toggle isn't silently overwritten by an upstream
-  value; manual `sync_from_settings_source` ignores dirty markers
-  (explicit user pull) and clears them.  `_sync_to_source` clears
-  dirty markers on a successful export (source now matches local).
-  Regression tests:
-  `tests/io/test_sync_sources.py::TestSyncFromSourceFreshness`
-  (six cases; version-bump detection, first-failure retry, concurrent
-  reader sees post-sync cache, dirty-key skip on auto re-sync, manual
-  sync clears dirty, freshness window avoids repeat probes).
-- ~~**M17.** Legacy migration `_maybe_migrate_legacy_settings_locked` pops keys
-  from in-memory cache before per-user disk write; per-user-write
-  failure leaves cache and disk diverged.~~; investigated and partially
-  closed (2026-05-21). The literal ordering claim is **inverted**:
-  `_maybe_migrate_legacy_settings_locked` writes the user file
-  *before* popping `_server_cache`, and returns early on user-write
-  failure, so the divergence described is impossible. A separate,
-  narrower divergence existed in the *server*-file rewrite step: if
-  `_atomic_write(_server_settings_path(), _server_cache)` raised
-  after the in-memory pop, `_server_cache` (legacy keys gone) and
-  the on-disk server file (legacy keys still present) would silently
-  disagree until the next `_mutate_server_locked()` re-read the disk.
-  Fix: compute the server-tier-only candidate first, write it, and only
-  pop the in-memory cache after the disk write returns successfully
-  (early-return on failure mirrors the user-write branch). Failure-path
-  coverage added in `tests/core/test_per_user_settings.py` for both
-  the user-write and server-rewrite branches.
-
-### Embedding / training
-
-- ~~**M18. `_PeekUnpickler` missing opcode overrides**~~: fixed in
-  `vtscore/security/pickle.py`. `FLOAT` (protocol 0 ASCII float) now reads
-  the line and pushes `None` instead of paying the `float(readline())`
-  parse cost, and `BYTEARRAY8` (protocol 5's dedicated bytearray opcode,
-  not in the original audit entry but the same family of leak; and a
-  worse one, since it bypasses `BINBYTES` at the highest protocol) now
-  drains the bytes and pushes an empty `bytearray`. `SETITEMS` was
-  reviewed and left alone: by the time it runs, its values have already
-  been emptied by the existing APPEND/APPENDS/BINBYTES overrides, and
-  the peek needs the dict structure intact for `len(media_dict)` /
-  `first["media_type"]` in the staging route. As a side-fix, the staging
-  endpoint stopped silently swallowing peek failures; the response
-  schema grew an `error` field carrying the exception message so the UI
-  can distinguish "valid pickle with 0 medias" from "couldn't parse
-  this file".
-- ~~**M19.** `embed_text_enriched` crashes (`np.mean` on empty) when text encoder
-  fails and all wrappers return None.~~; investigated and closed as not a
-  real bug (2026-05-21).  `vtscore/media/embedder.py:727-750` explicitly
-  guards the empty-list case with `if not embeddings: return
-  self.embed_text(text)` immediately before the `np.mean` call, so the
-  crash described is unreachable.  Git archaeology confirms the guard has
-  been in place since the function was introduced in PR #334 (commit
-  `b2c7bb4a`, 2026-02-28); the audit's claim was a false positive.
-  `tests/sorting/test_enrich_descriptions.py::test_enriched_falls_back_when_all_fail`
-  already exercises this path.  All other `np.mean` call sites in the
-  codebase (`vtscore/eval/metrics.py:53,60`,
-  `vtscore/eval/label_curve.py:390`) carry their own empty-input guards
-  too, so no related real bugs to fix.
-- ~~**M20.** XCLIP single-frame video: `linspace(0, 0, 1)` + padding gives 8
-  identical frames → degenerate embedding.~~
-  *Closed as not-a-bug.* X-CLIP, LanguageBind, and VideoMAE all require a
-  fixed-length frame stack; padding to that length is the only correct
-  behaviour for a video with fewer source frames, and a 1-frame video
-  genuinely has no temporal variation to encode. The resulting embedding is
-  finite, well-defined, and represents the visual content of the frame.
-  Investigation surfaced a *real* nearby bug; silent partial-read failures
-  inside the same loop (some `cap.read()` calls return `ret=False`, get
-  dropped, and the pad step biases the embedding toward the readable
-  portion of the file). Fixed by adding a partial-read warning to
-  `vtscore/media/video/_frame_sampling.sample_video_frames` (the shared
-  helper introduced by the tile-embedding fix in
-  commit `0a11d8bd`) so the failure is visible in logs instead of silent.
-  The originally-flagged "embedders ignore `clip_start`/`clip_end`"
-  concern was resolved separately by that same tile-embedding fix.
-- ~~**M21.** Empty paragraph clip survives to dataset with `None` embedding;
-  embedding-matrix builder later misbehaves.~~ **Shipped.** The text
-  clippers already filter empty *sub*-paragraphs (`if p.strip()`), and the
-  M11 work added `_drop_none_embeddings_stage` (removes `None`-embedding
-  media during load) plus a loud `ValueError` in the matrix builder, so the
-  "misbehaves silently" symptom is gone. The residual hole was a
-  whitespace-only clip whose embedder happens to return a *non-`None`*
-  garbage vector for empty input — the `None`-drop net wouldn't catch it.
-  Closed at the source: `_clip_content_bytes` now treats empty/whitespace
-  text as "no content", so a blank clip is never embedded, keeps
-  `embedding=None`, and is dropped by the existing stage. Regression tests
-  in `tests_lib/io/test_clip_reembed_bulk.py::TestBlankTextClipNotEmbedded`.
-
-### Auth / context
-
-- ~~**M22.** `set_thread_user()` cleanup relies on every caller's `finally`; a
-  future `ThreadPoolExecutor` reuse would leak user identity across
-  requests.~~; fixed by adding `thread_user(name)` (in
-  `vtsearch/auth/__init__.py`) and matching `thread_dataset_context(ctx)`
-  / `thread_detector_context(ctx)` context managers (in
-  `vtscore/state/core.py`).  Each scope snapshots the prior thread-local
-  on entry and restores it on exit, so a pooled / reused worker thread
-  cannot leak identity or context across jobs even if the body raises.
-  All production call sites (`vtscore/concurrency/async_jobs.py`,
-  `vtscore/datasets/load_pipeline.py`,
-  `vtsearch/routes/datasets/registry.py`,
-  `vtsearch/routes/detectors/registry.py`,
-  `vtsearch/routes/eval.py`, `vtsearch/routes/sorting.py`,
-  `vtscore/labels/sync.py`) migrated.  Tests in
-  `tests/core/test_thread_context_scopes.py` cover restore-on-exit,
-  restore-on-exception, nested scopes, per-thread isolation, and the
-  simulated-pool-reuse case the audit flagged.  The bare
-  `set_thread_user` / `set_thread_dataset_context` /
-  `set_thread_detector_context` setters remain available for tests and
-  for the rare call site that genuinely wants the unscoped form.
-- ~~**M23.** `setup_logging` re-running can leave duplicate handlers on
-  non-root loggers.~~; closed as not-a-bug.
-  `vtsearch/logging_config.py:setup_logging` only attaches a
-  `StreamHandler` to the root logger, and clears `root.handlers`
-  before re-attaching, so root cannot accumulate duplicates. For the
-  named libraries (`werkzeug`, `huggingface_hub`,
-  `huggingface_hub.utils._http`) it only calls `.setLevel(...)`; it
-  never calls `.addHandler(...)` on them, so repeated calls cannot
-  leave duplicates on non-root loggers either. Records from those
-  libraries propagate to root and are emitted by the single root
-  handler. `tests/core/test_structured_logging.py::TestSetupLogging::test_idempotent_no_duplicate_handlers`
-  covers the root case. A speculative "defensive" fix that wiped
-  handlers from a hard-coded list of non-root loggers would stomp any
-  handler a test or future feature legitimately attached there, and
-  encode a closed list that would drift from reality silently.
-- ~~**M24.** `CoreConfig.from_settings()` raises if a blueprint's module-level
-  code runs before `vtsearch/shim/__init__.py` registers the
-  builder.~~ Fixed: `app.py` now installs the shim hooks
-  (`register_flask_context_resolvers` / `register_app_persistence_hooks` /
-  `register_app_config_builder` / `register_app_plugin_families`) before
-  any `vtsearch.routes` blueprint module is imported, so the builder is
-  registered for any module-level code in a route that needs it.
-
-### Frontend
-
-- ~~**M25.** `LeftPanelComponent` lacks `OnDestroy` / `takeUntil` on init
-  subscriptions; subscriptions leak across dataset switches.~~ Code-style
-  alignment, not a real leak. The two `ngOnInit` subscriptions go through
-  Angular `HttpClient`, which emits once and completes, so memory was never
-  retained; and `LeftPanelComponent` is mounted once by `label-view` /
-  `find-view` and reused across dataset switches via `@Input`, so `ngOnInit`
-  doesn't re-fire per switch either. Still added the standard
-  `destroy$` + `takeUntil(this.destroy$)` pattern plus `OnDestroy` so an
-  in-flight HTTP response can't fire `.next` on a destroyed component during
-  a route teardown, matching the convention used elsewhere in the frontend.
-- ~~**M26.** `labelset-state.service` `startPolling()` is not tied to
-  `destroy$`; rapid switches leak polls.~~ **False positive.** The
-  service is `providedIn: 'root'` (singleton; `destroy$` effectively
-  never fires), `startPolling()` is guarded by an idempotent `if
-  (this.polling) return` check, and `stopPolling()` emits on
-  `stopPolling$` which the timer's `takeUntil` honors. The only real
-  observation is that `destroy$` itself is dead code; cosmetic, not a
-  leak.
-- ~~**M27.** `progress-events.service` doesn't reconcile stale `task_id`s after
-  backend restart.~~ **Shipped.** The SSE stream now emits a leading `server`
-  frame carrying a per-process `boot_id` (generated once at module import in
-  `vtscore/concurrency/events.py`). `ProgressEventsService` compares the
-  incoming `boot_id` against the previous one and fires `serverReset$` on
-  change (suppressed for the very first connect, so a clean reload doesn't
-  trigger a spurious reset). `DashboardLoadingTasksService` subscribes to
-  that signal and tears down its `awaitedTaskIds` / `completedTaskIds` /
-  `completedModelTaskIds` sets, terminates the existing `polling$` /
-  `detectorPolling$` subscriptions, clears its inline error rows, and resets
-  `setLoading(false)` — the next non-idle SSE snapshot then re-engages
-  polling cleanly via the existing constructor subscriptions. A transient
-  network blip that reconnects to the same backend keeps the same boot_id
-  and is therefore a no-op.
-- ~~**M28.** Audio waveform fetch's `catch {}` silently shows "Unable to load
-  waveform" with no UI state propagation.~~ **Shipped.** `drawWaveform` now
-  uses an `AbortController` (cancelled on next load / `ngOnDestroy`), checks
-  `response.ok`, and logs the underlying error via `console.warn` instead of
-  swallowing it. `AbortError` is suppressed so rapid swiping doesn't spam the
-  console or overwrite the next media's canvas.
-- ~~**M29.** `AudioContext` not cleaned up on rapid navigation → resource
-  exhaustion.~~ **Shipped.** Root cause: both the audio player and the
-  audio-crop overlay spun up a full hardware `AudioContext` purely to decode
-  audio for a static waveform. Chrome caps live contexts at ~6 and `close()`
-  is async, so rapid media navigation could create them faster than they tear
-  down (`NotSupportedError: number of hardware contexts reached maximum`); the
-  crop overlay additionally leaked its context whenever `decodeAudioData`
-  threw (the `catch` never called `close()`). Both now decode via a shared
-  `decodeAudioBuffer` helper (`frontend/src/app/utils/decode-audio.ts`) backed
-  by a throwaway `OfflineAudioContext`, which is purely computational — no
-  hardware allocation, no per-page cap, nothing to clean up. The audio
-  player's persistent `audioCtx` field and its `ngOnDestroy` close were
-  dropped.
-- ~~**M30.** Autopilot phase transitions can oscillate
-  (`hard → new → hard → new`) when smart/stable status flickers.~~
-  **Won't fix.** Evaluated and closed. The current derivation in
-  `AutopilotStateService.checkPhaseTransition` is intentionally instantaneous
-  so the phase tracks real indicator state both forward and backward (per the
-  existing comment about vote-removal regressions). A one-way ratchet or
-  hysteresis would suppress the bounce but would also mask genuine
-  instability after entering `new`, leaving the user on a stale sort with no
-  automatic recovery. The observable oscillation is rate-limited by the
-  autopilot resort interval and settles on its own; adding stickiness costs
-  more than the noise it would remove.
-- ~~**M31.** `settings-importer-modal` auto-closes after 1.5s timeout
-  regardless of operation duration.~~; resolved. The 1.5s timer fires only
-  after the server returns success (not mid-operation), so the original
-  framing was inaccurate; behavior was a minor UX choice, not a correctness
-  bug. The latent hygiene issue — `setTimeout` not cleared when the user
-  dismisses the modal manually, letting a zombie `close()` fire on a
-  destroyed component — was fixed by tracking the handle and clearing it in
-  `close()` / `ngOnDestroy` across all four auto-closing modals
-  (`settings-importer-modal`, `settings-exporter-modal`,
-  `label-importer-modal`, `examples-editor-modal`). The 1.5s / 600ms /
-  3000ms delays themselves are unchanged.
-
-### Security
-
-- ~~**M32.** `sanitize_template_value` allows `...` (and worse: any non-`.` /
-  `..` token of dots).~~ **Shipped.** `sanitize_template_value` now collapses
-  empty **and any all-dots token** (`.`, `..`, `...`, …) to `_`, replacing the
-  old exact-match-on-`("", ".", "..")` check. Path separators / NUL are still
-  replaced; legitimate dotted names (`.hidden`, `v1.2.3`) pass through.
-  Tests in `tests_lib/io/test_template_sanitization.py`.
-- ~~**M33.** `rglob_follow_symlinks` doesn't detect cycles → CPU/RAM DoS on
-  circular link layouts.~~ **Shipped.** `iter_rglob_follow_symlinks` now
-  tracks the `(st_dev, st_ino)` of every directory it descends into and
-  prunes already-visited subdirectories in place, so a directory symlinked
-  back to an ancestor is walked at most once and the traversal terminates.
-  Tests in `tests_lib/io/test_importer_symlinks.py::TestRglobFollowSymlinks`.
-- ~~**M34.** Email exporter validates "@" only; `"@example.com"` passes and
-  fails at SMTP time.~~ **Shipped.** The `email_smtp` exporter now validates
-  both addresses against a pragmatic regex requiring a non-empty local part,
-  a single `@`, and a dotted domain — rejecting `"@example.com"`, `"foo@"`,
-  and `"foo@bar"` before the MX lookup. Tests in
-  `tests/io/test_exporters.py::TestEmailLabelsetExporter`.
-
-### Eval / exporters
-
-- ~~**M35.** `voting_iterations.py` reports F1/FPR with one good + one bad vote
-  as if reliable.~~ **Shipped.** `simulate_voting_iterations` emits a metrics
-  row as soon as ≥1 good and ≥1 bad vote exist, but that 1-vs-1 row was
-  indistinguishable from a 50-vs-50 row in the output. Rather than silently
-  drop early rows (lossy), each row now carries `n_good`/`n_bad` (the per-class
-  vote counts behind it, summing to `t`), threaded through both DataFrame
-  builders and documented in `vtscore/docs/packages/eval.md`, so downstream
-  analysis can filter or weight by sample size. Test coverage in
-  `tests_lib/detectors/test_eval_voting_iterations.py`.
-
----
-
-## Low: latent / cosmetic / hypothetical
-
-Triaged 2026-06-24. Two carried real, low-risk fixes (L7, L9); the rest
-were stale line references, hypothetical, or already-correct-by-design and
-are closed with rationale below.
-
-- ~~**L1.** `_run_pipeline` returns `None` silently in text mode (no "done"
-  signal).~~ **Closed — not a bug.** Every `_run_pipeline` branch emits a
-  terminal signal: the live and streaming paths run an exporter, and
-  `_run_exporter` (`vtscore/cli.py`) always emits an `export_complete`
-  progress event (defaulting to `"Export complete."` when the exporter
-  returns no message); the dry-run path prints its plan. There is no silent
-  return.
-- ~~**L2.** Pipeline-vs-server logic in `app.py` L792 is masked by `sys.exit()`
-  but breaks if the function is ever refactored to return.~~ **Closed —
-  hypothetical, and the line reference is stale** (`app.py` was split; the
-  dispatch now lives in `vtsearch/cli_main.py:main`). That dispatch is a
-  plain `if args.autodetect: … else: _run_server(…)` with no shared
-  fall-through, and the early-exit helpers (`_maybe_list_plugins`,
-  `_maybe_run_pipeline`) correctly `sys.exit(0)`. Nothing breaks unless a
-  future edit deliberately removes those exits, which the `if/else` would
-  still contain.
-- ~~**L3.** Frontend cross-pane settings: `getViewMode()` falls back to
-  hard-coded defaults when the per-media-type entry isn't loaded.~~
-  **Closed — by design.** The `'list'`/`'grid'` fallbacks match the
-  server-side defaults, and the component is recreated on dataset switch, so
-  the unloaded window is a benign transient that resolves on the first
-  settings emission. No correctness impact.
-- ~~**L4.** `get_settings_source_config` reads cache without re-checking sync
-  state.~~ **Closed — by design.** The getter only returns the configured
-  source descriptor; it makes no claim about sync freshness.
-  `set_settings_source_config` is what owns sync state and already drops it
-  (`_store.drop_sync_state`) when the source is cleared, so there is no stale
-  "still synced" signal for the getter to re-check.
-- ~~**L5.** Frontend `clip_box` exports: list-of-floats CSV-joined without
-  quote-protection (edge case).~~ **Closed — already protected.** The
-  comma-joined `clip_box` cell is written through `csv.writer.writerow`
-  (`vtscore/exporters/server_csv_file`), which quotes any field containing a
-  comma (`QUOTE_MINIMAL`) and round-trips correctly through `csv.DictReader`.
-  The join is not hand-concatenated into the row.
-- ~~**L6.** Empty `Origin.params` not always dropped consistently across
-  importers.~~ **Closed — consistent by construction.** `Origin.to_dict`
-  always serialises `params` (an empty `{}` when unset) and `from_dict`
-  defaults to `{}`, so empty-vs-absent round-trips identically. The one real
-  hazard — sharing a single origin dict by reference across sibling clips —
-  is already handled where it matters (`load_pipeline.py` copies per media,
-  with an inline comment explaining the aliasing risk).
-- ~~**L7.** `eval/metrics.py` returns F1=0 for empty test set without flagging
-  the degenerate case.~~ **Shipped.**
-  `compute_binary_classification_metrics` now logs a warning when the
-  prediction set is empty (`total == 0`), so the all-zero tuple isn't
-  mistaken for a real 0%-accurate evaluation. Tests in
-  `tests_lib/detectors/test_eval.py::TestBinaryClassification`.
-- ~~**L8.** Logging of vote-related events truncates achievement traceback for
-  UI display.~~ **Closed — stale / non-existent.** No vote-event logging path
-  truncates a traceback: `vtsearch/routes/media/list.py` and
-  `routes/labels/vote.py` log via `logger.exception(...)` (full traceback),
-  and `achievements.py` never logs vote errors. The "truncation" in
-  `tests/core/test_votes.py` refers to vote-*step* history truncation, an
-  unrelated concept.
-- ~~**L9.** `get_param` returns `""` for unknown keys; silently swallows
-  renamed parameters.~~ **Shipped.** `MediaConverter.get_param` still returns
-  `""` for an undeclared key (historical contract), but now logs a warning
-  naming the key and converter, so a typo'd or renamed field surfaces instead
-  of reading as empty forever. Tests in
-  `tests/converters/test_converter_selection.py`.
-
----
-
-## Recurring patterns (fix-in-batches root causes)
-
-These themes show up across many findings. Addressing each pattern in
-one PR is far more effective than one-off fixes.
-
-1. **Background-thread context propagation.** Every `Thread(target=…)`
-   spawn in the repo should set user + dataset + detector
-   thread-locals (where applicable) before invoking the target, in a
-   `try/finally`. Candidates:
-   - `JobManager._run`
-   - `_run_importer_in_background`
-   - `_stage_importer_in_background`
-   - `_warmup_embedder_async`
-   - `smart_preload_in_background`
-   - `preload_embedder_for_dataset`
-   - `timed_progress` ticker.
-
-   A small helper
-   `with run_with_context(user, dataset_id, detector_id): …` removes
-   the repetition.
-
-2. **Template-path substitution → re-validate.** Every source /
-   exporter that interpolates `{username}`, `{detector_id}`,
-   `{detector_name}` must call `validate_server_filepath()` on the
-   **resolved** path before opening a file. Affected:
-   `labels/sources/server_json_file`,
-   `settings_io/sources/server_json_file`, and any future plugin in
-   the same family.
-
-3. **Achievement recording at one site.** Move `record_vote()` (and
-   all achievement hooks) into `apply_label_with_click_time` so bulk
-   paths (`fill-from-sort`, label import, find-label) credit the user
-   uniformly. Also: call it *inside* the state lock, not after.
-
-4. **Embedding-matrix cache invalidation.** Bump a `media_revision`
-   counter on every `medias` mutation; the matrix accessor checks the
-   counter. Same fix neutralizes both clip/dedup invalidation (C4)
-   and dynamic seeding races.
-
-5. **Embedder identity is its own first-class attribute.** Track the
-   detector's *training* embedder separately from the active
-   dataset's embedder. Every train/score path must compare them and
-   refuse / clear caches when they differ; don't only compare
-   against the dataset.
-
-6. **`X-Dataset-Id` / `X-Detector-Id` headers must be required, not
-   silently defaulted.** When the header is missing or refers to an
-   unloaded context, the `before_request` middleware should return
-   400 / 410, not fall back to the empty proxy. Catches C5, the
-   silent-mistarget routes, and the binary-streaming bypass.
-
-7. **Frontend cache keys must be dataset-qualified.**
-   `MediaMetadataCacheService` and any other id-keyed cache should
-   key on `${datasetId}:${mediaId}`.
-
-8. **Vote endpoints should be transactional.**
-   apply-then-retrain-then-sync should either all-succeed or
-   all-rollback; surface failures to the frontend instead of
-   returning 200 and logging server-side.
-
-9. **Background jobs need a clear error state.** Every failure path
-   on a load / embed / train job should call
-   `update_progress(task_id, error="…")` so the frontend can stop
-   spinning and show what went wrong.
-
----
-
-## Suggested fix order (highest leverage first)
-
-1. **C1, C2, C3**; gate hand-off + thread-local context
-   propagation. One small helper (pattern #1) unblocks 3+ bug
-   classes.
-2. **C4** + pattern #4; embedding-matrix cache invalidation via a
-   `media_revision` counter.
-3. **C7**; clamp `xcal_threshold` to a finite sentinel and assert
-   no `NaN` in `safe_threshold`.
-4. **C9** + pattern #2; re-validate every resolved template path
-   in `SyncSource._resolve_filepath()`.
-5. **C5, C10, C11, C12**; straightforward request-handling and
-   frontend-cache fixes once the above patterns are in place.
-6. Pattern #6; make header presence + context-loaded a hard
-   precondition.
-7. Detector-embedder identity (pattern #5) + C8 (achievement
-   uniformity).
+- Findings had stable IDs (`C#` Critical, `H#` High, `M#` Medium, `L#` Low) so
+  they could be referenced from other docs / PRs.
+- Each resolved finding is now a single line: what it was + outcome, with the
+  landing PR / test refs in parentheses. The full fix summary is the PR that
+  landed it (git log, not this doc). "Closed" means investigated and found to be
+  not-a-bug / by-design / stale; "shipped" means a fix landed.
+- File:line references are approximate; line numbers drift as the code evolves.
+
+**Audit coverage.** Per-subsystem agents: (1) state & concurrency, (2) detector
+training, (3) datasets & importers, (4) routes & API, (5) settings & sync,
+(6) embedding & training infra, (7) security validation, (8) plugins /
+converters / eval / exporters, (9) auth / CLI / app entry, (10) frontend Angular
+logic. Cross-section agents: (11) dataset↔detector↔embedder, (12)
+settings↔everything, (13) background-jobs / context propagation, (14)
+error/exception flow, (15) frontend↔backend contract seams.
 
 ---
 
 ## Open follow-ups
 
-Cross-cutting open items that don't fit any single finding above:
+Cross-cutting items still owed. Everything ID'd (C/H/M/L) is resolved; these are
+the only remaining work.
 
-- **Pattern #4 (media_revision counter)** is still unimplemented.
-  The C4 stage-level invalidation closes the known clip/dedup hole,
-  but any future mutation site that changes embeddings without
-  changing the id set will reintroduce the same class of bug. A
-  `media_revision` counter on `DatasetContext` bumped from every
-  `medias` mutation (or a `MediasDict` subclass that does so
-  transparently) would neutralise the whole category and let the
-  matrix accessor compare a single int instead of two id lists.
+- **Pattern #4 — `media_revision` counter is still unimplemented.** The C4
+  stage-level invalidation closes the known clip/dedup hole, but any future
+  mutation site that changes embeddings without changing the id set will
+  reintroduce the same class of bug. A `media_revision` counter on
+  `DatasetContext` bumped from every `medias` mutation (or a `MediasDict`
+  subclass that does so transparently) would neutralise the whole category and
+  let the matrix accessor compare a single int instead of two id lists.
 
-- ~~**M18 follow-ups: pickle peek hardening.**~~ **Shipped 2026-06-25.**
-  Both adjacent leaks closed:
-  (1) `_codecs.encode` is now on the `_PICKLE_SAFE_CLASSES` allowlist,
-  so protocol-0/1/2 pickles containing inline `bytes` (which pickle
-  serialises as `_codecs.encode(s, 'latin-1')`) load through
-  `RestrictedUnpickler` / `safe_pickle_load` instead of being rejected
-  (it's a codec dispatcher, not an RCE vector).
-  (2) `_PeekUnpickler` overrides `BINUNICODE` / `BINUNICODE8` with a
-  size-bounded handler (`_PEEK_MAX_INLINE_STR = 4096`): short strings
-  (dict keys, `"media_type"`) decode normally, while an over-cap inline
-  `media_string` (a long document) is consumed in bounded chunks and
-  replaced by `""`, so the peek never materialises the whole body.
+- **H28 residual multi-process items** (from the per-user settings RMW fix):
+  - `_synced_users` is still process-local, so on a fresh container every worker
+    independently runs sync-from-source for each user once. With the RMW fix
+    this is no longer corrupting (just duplicate I/O against the source) but
+    worth de-duplicating with an mtime-marker if it shows up in profiles.
+  - The legacy-settings migration in `_maybe_migrate_legacy_settings_locked`
+    still calls `_atomic_write` without the cross-process lock. It is a one-shot
+    startup step so the race window is small, but for full correctness it should
+    also use `_mutate_server_locked`.
+  - Windows has no `fcntl`, so the cross-process lock silently degrades to the
+    in-process lock only. Not a regression (Linux-only Docker images), but worth
+    a note if a contributor ever tests on Windows.
 
-- ~~**H1 follow-up: labelset element vote endpoint still toggles.**~~
-  **Shipped 2026-06-25.** `POST /api/detectors/<name>/labels/<element_id>/vote`
-  and the underlying `apply_element_vote_in_data` in
-  `vtscore/detectors/labelset_elements.py` now take an absolute
-  `target: "good" | "bad" | "remove"` instead of a toggle `vote`.
-  Re-asserting an element's current label is an idempotent `"unchanged"`
-  no-op, so a stale-view tab can no longer flip an element off the
-  labelset by re-sending its current polarity — the same inflation race
-  the media-vote H1 fix eliminated. The in-memory mirror moved from
-  `toggle_vote()` to `set_vote()` with the same absolute target
-  (`"remove"` → `"none"`), so it stays idempotent too; the frontend
-  (`vt-labels-list` via `LabelsetStateService`) translates the clicked
-  direction into a target in one place, mirroring the centre-pane vote.
+---
+
+## Findings resolved
+
+### Critical — data corruption / loss / hangs / silent miscompute
+
+- **C1.** Download gate never released if importer skips the `"embedding"` status. **Shipped.**
+- **C2.** JobManager never sets dataset/detector thread-local context. **Shipped.**
+- **C3.** Dataset background load tasks don't set thread-local dataset context. **Shipped.**
+- **C4.** Embedding-matrix cache not invalidated after clip/dedup. **Shipped** (stage-level; see Pattern #4 follow-up).
+- **C5.** `find_label` body field could override the request's dataset context. **Shipped.**
+- **C6.** Zip-slip in HTTP archive importer (zip and tar). **Shipped.**
+- **C7.** NaN/Infinity threshold leaked through safe-threshold blending. **Shipped.**
+- **C8.** Bulk label paths skipped achievement recording. **Shipped.**
+- **C9.** Path-template substitution missing post-resolution validation (commit `988dca3b`). **Shipped.**
+- **C10.** MD5 / metadata cache collision returned wrong-dataset media on switch. **Shipped.**
+- **C11.** `fill_labels_from_sort` silently swallowed sync failures. **Shipped.**
+- **C12.** Orphaned dataset registry entry on activation failure. **Shipped.**
+
+### High — likely-encountered correctness or security bugs
+
+- **`record_vote()` called after releasing `_state_lock`.** **Shipped.**
+- **H1.** Vote-progress / `record_vote` race — replaced the toggle contract on `POST /api/medias/<id>/vote` with an absolute `target` contract; `set_vote()` no-ops on idempotent re-applies; progress cache invalidates on any training-set membership change (`test_votes.py`, `test_error_recovery.py`, `test_achievements.py`, `test_api_contracts.py`, `test_patch_embedder.py`, `vote-state.service.spec.ts`).
+- **H2.** Cross-dataset region-box loss — `_embed_one` runs `patch_forward` + `box_to_vote_vector` so a region vote survives a dataset switch (`TestRegionAwareTrainingCrossDataset`).
+- **H3.** Embedder drift on save → reload. **Shipped.**
+- **H5.** Detector embedder not revalidated on dataset switch — `invalidate_detector_model_on_embedder_mismatch()` + `resolve_label_embeddings(embedder_name=…)` (`test_detectors.py`, `test_resolver.py`).
+- **H6.** `train_model` produced degenerate single-class model. **Shipped.**
+- **H7.** Vote applied before retrain; retrain failure left vote live. **Shipped.**
+- **H8.** Origin dict shared by reference across medias. **Shipped.**
+- **H9.** Single-item split had 0 test samples. **Shipped.**
+- **H10.** Clipped media re-ingest read whole file for MD5 — clip-aware hashing via `_resolve_clip_content_and_embedding` (`test_label_import_ingestion.py::TestClippedReingest`).
+- **H11.** Multi-media import with empty form yielded empty dataset. **Shipped.**
+- **H12.** `add_media_to_pile` race — **closed, not a real race** (`before_request` pins request-local contexts); the real bugs at that line window are H32/H33/H34.
+- **H13.** `vote_media` silent-mistarget on dropped header. **Shipped.**
+- **H14.** `export_labels` leaked votes across datasets. **Shipped.**
+- **H15.** File-browser symlink metadata leak — listing loop now resolves symlinks and skips escapees (`TestBrowseSymlinks`). A distinct importer `followlinks=True` escape is noted but separate.
+- **H16.** Header refers to unloaded dataset → silent fallback — **shipped** (also closes half of H34).
+- **H32.** `add_media_to_pile` TOCTOU between md5 check and insertion — re-runs `build_media_lookup` under `_state_lock` before assigning the id (`test_medias.py::TestAddToPile`).
+- **H33.** `add_media_to_pile` label not synced to disk — both branches now call `_sync_pile_label_to_storage()` (`test_medias.py`).
+- **H34.** Missing `X-Detector-Id` → silent detector fallback — added `require_detector_header` / `require_dataset_header` decorators on every vote-mutating endpoint (`_shared.py`); read endpoints keep fall-through.
+- **H17.** Plugin scanner silently shadowed duplicate names. **Shipped.**
+- **H18.** CSV exporter doesn't escape embedded newlines — **closed, not a bug** (stdlib `csv.writer` QUOTE_MINIMAL; path was also stale).
+- **H19.** Required select fields silently accept empty string — **closed, not a bug** (`_non_empty_after_strip` + OneOf already reject empty).
+- **H20.** `audio2image` had no upper bound on `n_mels` — `_build_number()` attaches `validate.Range`; `MediaConverter.validate_params()` enforces it for converter params.
+- **H21.** Successful `--autodetect` falls through to Flask startup — **not a bug** (`elif` misread); simplified to plain `else`.
+- **H22.** `predict_embedders_to_preload` mismatched media type — persist the detector's training embedder (commit `92e27a39`, PR #1561).
+- **H23.** Settings-source filepath template not path-validated — duplicate of C9 (commit `988dca3b`; `test_sync_sources.py`).
+- **H24.** Vote-state polling chain died on a single error. **Shipped.**
+- **H25.** Active dataset pair set before load completes — split `ActiveContextService` into intent + active layers (commit `9470cf1a`, PR #1563; `context-switch.service.spec.ts`).
+- **H26.** `recordVote` ran before the HTTP vote returned — `submitToggleVoteAndRecord` pushes the undo entry only inside the success `tap` (`vote-state.service.spec.ts`).
+- **H27.** Binary media endpoints bypass `activeContextInterceptor` — **not a bug** (functional interceptors apply to every `HttpClient` call); removed four dead methods.
+- **H28.** Per-user cache process-local; concurrent worker writes lost updates — cross-process `flock` RMW via `_mutate_*_locked` (`test_settings.py::TestConcurrentWrites`). Residual items in Open follow-ups.
+- **H29.** `_save_user` held `_settings_lock` across sync I/O — I/O moved under the per-file lock only (`test_thread_safety.py::TestSlowSettingsIODoesNotBlockOthers`).
+- **H30.** Detector save's `os.replace` failure left in-memory state "saved" — transactional snapshot/restore in `apply_and_retrain` + abort-500 at the unprotected call sites (`test_workflow.py`, `test_api_contracts.py`, `test_detectors.py`).
+- **H31.** Partial label-import had no rollback — per-entry try/except surfacing `failed` / `failed_count`.
+
+### Medium — real but lower-frequency / non-corrupting
+
+- **M1.** Lock held during cross-lock callbacks in `toggle_vote` — **closed** (deadlock unreachable post-H1); standardised all six state→progress sites on release-first.
+- **M2.** `combine_datasets.run_chunked` re-issued IDs from 1 → cid collision — added `_renumber_chunks()` at the CLI boundary (`tests_lib/cli/test_chunk_renumber.py`, `tests/cli/test_chunked_id_renumber.py`).
+- **M3.** `importers/base.py` skipped records left `next_id` unincremented. **Shipped.**
+- **M4.** `populate_label_embeddings` cache not invalidated when a `region_box` is removed. **Shipped.**
+- **M5.** `resolve_current_dataset_cid` could return a colliding-MD5 cid — **closed, not a bug** (`collapse_duplicates` guarantees unique-MD5 lookup).
+- **M6.** `restore_labels_from_detector` MD5-only on second pass — **closed, not a bug** (pass 1 consults `md5_lookup`).
+- **M7.** `safe_thresholds` cached on `DetectorContext`, never refreshed — **partial close** (never serialised); added `invalidate_loaded_detector_models()` on setting change (`test_safe_thresholds.py`).
+- **M8 / M12.** Pickle loader treated `embedding: None` as present → object-dtype / null-deref — `_convert_one_pickle_media` skips missing/None uniformly. **Shipped.**
+- **M9.** `loader_folder._has_override` didn't warn on conflicting override embeddings. **Shipped.**
+- **M10.** `clipper_chain._run_clipper_step` assumed deterministic output count — stamps `n_out`/`clip_index`/`content_hash`, prefers content match. **Shipped.**
+- **M11.** Stale media in `cli._score_medias_with_detectors` with `None` embeddings — matrix builder raises `ValueError`; `_drop_none_embeddings_stage`; `zip(strict=True)` on every id↔score callsite (`test_embedding_matrix.py`, `test_load_stage_matrix_cache.py`, `test_export_options.py`).
+- **M13.** `learned_scores` could serialize as JSON `NaN`/`Infinity` — routed through `sigmoid_to_finite_scores` (`-1.0` sentinel) + `GET /api/votes` guard (`test_api_contracts.py`).
+- **M14.** `diversity_tree_next_sample` referenced stale media IDs after `/api/dataset/clear` — **closed** (tree is `None`); fixed two adjacent tree-reset bugs via `reset_seen()` / `resync_diversity_tree_to_detector`.
+- **M15.** Pending labelset sync stored `dataset_ctx = None` → `AttributeError` — **closed, not a bug** (contexts invariantly non-None via sentinels).
+- **M16.** Sync-on-first-read could return stale local config — replaced `_synced_users` set with per-user `_UserSyncState` + `peek_version` hook (`test_sync_sources.py::TestSyncFromSourceFreshness`).
+- **M17.** Legacy migration popped cache before disk write → divergence — **partially closed** (ordering was inverted); fixed the narrower server-file rewrite path (`test_per_user_settings.py`).
+- **M18.** `_PeekUnpickler` missing opcode overrides — added `FLOAT` / `BYTEARRAY8` handlers; staging surfaces peek `error`. **Shipped.**
+- **M19.** `embed_text_enriched` crashed (`np.mean` on empty) — **closed, not a bug** (guard present since PR #334).
+- **M20.** XCLIP single-frame video degenerate embedding — **closed, not a bug** (padding is correct); fixed a real adjacent silent partial-read via a warning in `sample_video_frames`.
+- **M21.** Empty paragraph clip survived with `None` embedding — `_clip_content_bytes` treats blank text as no content (`test_clip_reembed_bulk.py::TestBlankTextClipNotEmbedded`). **Shipped.**
+- **M22.** `set_thread_user()` cleanup relied on caller `finally` → pool identity leak — added `thread_user` / `thread_dataset_context` / `thread_detector_context` context managers (`test_thread_context_scopes.py`).
+- **M23.** `setup_logging` re-run could leave duplicate handlers — **closed, not a bug** (root cleared; named libs only `.setLevel`).
+- **M24.** `CoreConfig.from_settings()` raised if a blueprint ran before the shim registered the builder — shim hooks now install before any route import.
+- **M25.** `LeftPanelComponent` lacked `OnDestroy`/`takeUntil` — style alignment, not a real leak; added the pattern anyway.
+- **M26.** `labelset-state.service.startPolling()` not tied to `destroy$` — **false positive** (singleton + idempotent guard); `destroy$` was dead code.
+- **M27.** `progress-events.service` didn't reconcile stale `task_id`s after backend restart — SSE `boot_id` frame + `serverReset$`. **Shipped.**
+- **M28.** Audio waveform fetch's `catch {}` swallowed errors — `AbortController` + `response.ok` + `console.warn`. **Shipped.**
+- **M29.** `AudioContext` not cleaned up on rapid navigation — decode via throwaway `OfflineAudioContext` (`utils/decode-audio.ts`). **Shipped.**
+- **M30.** Autopilot phase transitions could oscillate — **won't fix** (instantaneous derivation is intentional; oscillation is rate-limited and self-settling).
+- **M31.** `settings-importer-modal` auto-closes after 1.5s — **resolved** (fires only on success); cleared the zombie-`close()` timer across all four auto-closing modals.
+- **M32.** `sanitize_template_value` allowed all-dots tokens — collapses `.`/`..`/`...`/… to `_` (`test_template_sanitization.py`). **Shipped.**
+- **M33.** `rglob_follow_symlinks` didn't detect cycles → DoS — tracks `(st_dev, st_ino)` and prunes visited dirs (`test_importer_symlinks.py`). **Shipped.**
+- **M34.** Email exporter validated "@" only — pragmatic regex before MX lookup (`test_exporters.py::TestEmailLabelsetExporter`). **Shipped.**
+- **M35.** `voting_iterations.py` reported metrics at 1-vs-1 as reliable — each row carries `n_good`/`n_bad` (`test_eval_voting_iterations.py`). **Shipped.**
+
+### Low — latent / cosmetic / hypothetical (triaged 2026-06-24)
+
+- **L1.** `_run_pipeline` returns `None` silently in text mode — **closed** (every branch emits a terminal signal).
+- **L2.** Pipeline-vs-server fall-through in `app.py` — **closed** (hypothetical; stale ref, now `cli_main.py`).
+- **L3.** `getViewMode()` hard-coded fallbacks — **closed, by design** (matches server defaults; benign transient).
+- **L4.** `get_settings_source_config` reads cache without re-checking sync — **closed, by design** (getter makes no freshness claim).
+- **L5.** `clip_box` CSV join without quote-protection — **closed** (written through `csv.writer.writerow`).
+- **L6.** Empty `Origin.params` not dropped consistently — **closed** (round-trips identically; aliasing handled where it matters).
+- **L7.** `eval/metrics.py` returned F1=0 for empty test set silently — logs a warning on `total == 0` (`test_eval.py::TestBinaryClassification`). **Shipped.**
+- **L8.** Vote-event logging truncates achievement traceback — **closed, stale** (logs via `logger.exception`; the "truncation" is unrelated vote-step history).
+- **L9.** `get_param` returns `""` for unknown keys silently — now logs a warning naming key + converter (`test_converter_selection.py`). **Shipped.**
+
+### Late follow-ups (shipped 2026-06-25)
+
+- **M18 pickle-peek hardening** — `_codecs.encode` allowlisted; `_PeekUnpickler` size-bounds `BINUNICODE`/`BINUNICODE8` (`_PEEK_MAX_INLINE_STR = 4096`).
+- **H1 labelset-element vote endpoint** — `POST /api/detectors/<name>/labels/<element_id>/vote` takes an absolute `target` instead of a toggle; `apply_element_vote_in_data` is idempotent, closing the same inflation race as the media-vote H1 fix.
+
+---
+
+## Root-cause patterns (reference)
+
+The findings collapsed into a small number of root causes; addressing each in
+one PR fixed many findings at once. All are resolved except Pattern #4 (see Open
+follow-ups).
+
+1. **Background-thread context propagation** — every `Thread(target=…)` sets
+   user/dataset/detector thread-locals in `try/finally` (helper:
+   `run_with_context`). (C1–C3.)
+2. **Template-path substitution → re-validate** — every source/exporter
+   interpolating `{username}`/`{detector_id}`/… calls `validate_server_filepath`
+   on the resolved path. (C9, H23.)
+3. **Achievement recording at one site** — `record_vote()` moved into
+   `apply_label_with_click_time`, inside the state lock. (C8.)
+4. **Embedding-matrix cache invalidation** — a `media_revision` counter bumped
+   on every `medias` mutation. **(Open — see follow-ups.)** (C4.)
+5. **Embedder identity is first-class** — track the detector's training embedder
+   separately; every train/score path compares and clears caches on mismatch. (H5, H22.)
+6. **`X-Dataset-Id` / `X-Detector-Id` required, not silently defaulted** — 400
+   when missing/unloaded on mutating routes. (C5, H13, H34.)
+7. **Frontend cache keys dataset-qualified** — `${datasetId}:${mediaId}`. (C10.)
+8. **Vote endpoints transactional** — apply/retrain/sync all-succeed-or-rollback,
+   failures surfaced. (C11, H30, H31.)
+9. **Background jobs need a clear error state** — every load/embed/train failure
+   calls `update_progress(task_id, error=…)`.

--- a/docs/plans/mlp-hidden-layer-sizing.md
+++ b/docs/plans/mlp-hidden-layer-sizing.md
@@ -1,69 +1,57 @@
 # MLP hidden-layer sizing
 
-**Status: shipped.** The investigation is done and its one actionable
-finding — raising `MLP_HIDDEN_MIN` 4 -> 8 — has been applied to
-`vtscore/config.py` (+ docs). Two optional sweep extensions remain open. This
-doc records an empirical capacity sweep of the detector MLP's hidden layer and
-the one actionable finding it produced: the **lower bound** `MLP_HIDDEN_MIN = 4`
-underfits and is unstable on harder tasks, and the evidence supports raising it
-to `8`. The **upper bound** `MLP_HIDDEN_MAX = 32` is well-placed and should not
-change. Nothing here has been applied to `vtscore/config.py`.
+**Status: shipped.** The one actionable finding — raising `MLP_HIDDEN_MIN`
+4 → 8 — has been applied to `vtscore/config.py` (+ `docs/ML.md`,
+`_auto_hidden_dim` docstring). Two optional sweep extensions remain open.
 
-The sweep was produced by `scripts/overfitting_probe.py --sweep-hidden ...`
-(added alongside this doc). Re-run it to reproduce or extend any table below.
+## Open follow-ups
 
-## Background: how the hidden layer is sized today
+- Optional: extend the sweep to audio (`esc50_s` / CLAP) and video
+  (`ucf101_s` / X-CLIP) to confirm the plateau shape holds across every
+  modality, not just image + text. The probe already supports `--dataset`.
+- Optional: sweep with small vote counts (e.g. `--n-good 6 --n-bad 6`) to
+  measure the floor's effect directly in the regime where it actually binds,
+  rather than inferring it from the width-4 column at 100+100 votes.
+
+## What shipped
+
+- Raised `MLP_HIDDEN_MIN` 4 → 8 in `vtscore/config.py`. Only affects the
+  tiny-vote regime: the floor binds when `n_train // 3 < 8` (fewer than ~24
+  total votes); above that `_auto_hidden_dim` already returns ≥8. Cheap
+  (8 neurons), strictly removes the observed underfit/instability at the start
+  of a session.
+- `MLP_HIDDEN_MAX = 32` left unchanged (it sits at the top of the stable
+  plateau — correct).
+- Updated `docs/ML.md` "4–32 neurons" → "8–32" and the `_auto_hidden_dim`
+  docstring; the config/training package docs match.
+- Added `scripts/overfitting_probe.py --sweep-hidden ...` alongside this doc;
+  re-run to reproduce or extend any table below.
+
+## Method (for reproducing / extending the sweep)
 
 The detector is a small MLP (`vtscore/training/mlp.py`):
+`Linear(input_dim, hidden_dim) → ReLU → Dropout(0.5) → Linear(hidden_dim, 1)`.
+`hidden_dim` is auto-sized from the training-set size:
+`max(MLP_HIDDEN_MIN, min(MLP_HIDDEN_MAX, n_train // 3))` — one neuron per three
+votes, floored (≤12 votes) and capped (≥96 votes). Dropout 0.5,
+`weight_decay=1e-4`, and inverse-frequency class weighting keep the small width
+range from overfitting.
 
-```
-Linear(input_dim, hidden_dim) -> ReLU -> Dropout(0.5) -> Linear(hidden_dim, 1)
-```
+`scripts/overfitting_probe.py` fixes the split, sampled votes, and seeds and
+varies **only** `hidden_dim`. Per width (5 seeds) it reports: `REAL_test`
+(held-out ranking AUC on true-category labels — the capacity signal, its
+across-seed std flags instability) and `NOISE_train` / `NOISE_test` (same model
+on coin-flip labels — `NOISE_train → 1.0` is pure memorization, `NOISE_test ≈
+0.5` confirms no width generalizes absent signal). Runs used `caltech101_s`
+(image / SigLIP) and `20newsgroups_s` (text / E5), 100 good + 100 bad, inclusion 0.
 
-`hidden_dim` is auto-sized from the training-set size
-(`_auto_hidden_dim`, `vtscore/training/mlp.py`):
+## Results (informs the open sweeps)
 
-```python
-max(MLP_HIDDEN_MIN, min(MLP_HIDDEN_MAX, n_train // 3))   # 4 .. 32
-```
+**Images (SigLIP):** `REAL_test` is a perfect 1.000 at every width 4→256 — the
+categories are linearly separable, so width is irrelevant here and this case
+can't speak to whether 32 is ever too small.
 
-with `MLP_HIDDEN_MIN = 4`, `MLP_HIDDEN_MAX = 32` (`vtscore/config.py`). So the
-width grows one neuron per three votes, floored at 4 (reached at ≤12 votes) and
-capped at 32 (reached at ≥96 votes). The regularizers around it — dropout 0.5,
-`weight_decay=1e-4`, inverse-frequency class weighting — are what let the width
-range stay small without overfitting.
-
-## Method
-
-`scripts/overfitting_probe.py` holds the train/held-out split, the sampled
-votes, and the seeds fixed and varies **only** `hidden_dim` (passed through the
-new `train_model(..., hidden_dim=)` override). For each width it reports, over
-5 seeds:
-
-- `REAL_test` — held-out ranking AUC when items are labeled by their true
-  category. This is the capacity signal (threshold-free, so it isolates ranking
-  quality from threshold calibration). Its across-seed **std** flags instability.
-- `NOISE_train` / `NOISE_test` — the same model trained on coin-flip labels.
-  `NOISE_train → 1.0` as width grows is pure memorization; `NOISE_test ≈ 0.5`
-  at every width confirms no capacity level can generalize a signal that isn't
-  there (and its slow creep upward is the first whiff of overfitting).
-
-Runs used `caltech101_s` (image / SigLIP) and `20newsgroups_s` (text / E5),
-100 good + 100 bad votes, inclusion 0.
-
-## Findings
-
-### Images (SigLIP) — task is already linearly separable
-
-`REAL_test` is a perfect 1.000 at **every** width from 4 to 256 (airplanes,
-dolphin, flamingo all identical). SigLIP places these categories in a linearly
-separable arrangement, so the hidden layer does no real work and width is
-irrelevant. 32 is far more than enough; even 4 is perfect. This case can't
-speak to whether 32 is ever *too small* — for that, see text.
-
-### Text (E5) — the informative regime
-
-Held-out `REAL_test` vs width (5 seeds); note the width-4 column:
+**Text (E5) — the informative regime.** Held-out `REAL_test` vs width (5 seeds):
 
 | hidden | religion | science | cars | NOISE_test (cars) | NOISE_train (cars) |
 |-------:|---------:|--------:|-----:|------------------:|-------------------:|
@@ -75,53 +63,9 @@ Held-out `REAL_test` vs width (5 seeds); note the width-4 column:
 | 128    | 0.976 | 0.982 | 0.960 | 0.517 | 1.000 |
 | 256    | 0.976 | 0.982 | 0.959 | 0.518 | 1.000 |
 
-Three regimes, consistent across topics:
-
-1. **Below ~8: underfit + unstable.** Width 4 gives `cars` only 0.684 held-out
-   AUC with a **±0.23** seed std (religion: 0.900 ±0.15). The 4-neuron model
-   can't reliably fit the boundary and swings wildly by seed.
-2. **~8 through 256: flat plateau.** Once past underfitting, held-out AUC is
-   width-independent across a 32× range. **32 sits on this plateau with margin.**
-3. **Above 32: capacity only buys memorization.** `NOISE_train` reaches a perfect
-   1.000 by width 64–128 while `NOISE_test` creeps 0.489 → 0.518 and `REAL_test`
-   flattens/dips a hair. Going bigger than 32 is all downside (no real gain, more
-   memorization, more variance, more compute).
-
-### Conclusion
-
-- **`MLP_HIDDEN_MAX = 32` is correct** — it's at the top of the stable plateau,
-  big enough that no tested task is still improving, small enough to stay below
-  where capacity starts rewarding noise. Leave it.
-- **`MLP_HIDDEN_MIN = 4` is the soft spot** — 4 neurons underfits and destabilizes
-  on harder text topics. The stable minimum in the data is ~8.
-
-## Proposed change (not yet made)
-
-Raise the floor in `vtscore/config.py`:
-
-```python
-MLP_HIDDEN_MIN = 8   # was 4
-```
-
-Scope and risk:
-
-- Only affects the **tiny-vote regime**: the floor binds when `n_train // 3 < 8`,
-  i.e. **fewer than ~24 total votes**. Above that, `_auto_hidden_dim` already
-  returns ≥8 and nothing changes.
-- In that regime held-out results are noisy regardless and the app's labeling
-  indicators are already telling the user to keep voting, so the practical
-  impact is small — but the change strictly removes the observed underfit/instability
-  at the very start of a session at no cost (8 neurons is still trivially cheap).
-- Update the `_auto_hidden_dim` docstring and the `docs/ML.md` "4–32 neurons"
-  references to "8–32" if applied. Add/adjust any test that pins the floor.
-
-## Open follow-ups
-
-- [x] Apply the `MLP_HIDDEN_MIN = 4 → 8` change (above); `docs/ML.md`,
-      `_auto_hidden_dim` docstring, and the config/training package docs updated to match.
-- [ ] Optional: extend the sweep to audio (`esc50_s` / CLAP) and video
-      (`ucf101_s` / X-CLIP) to confirm the plateau shape holds across every
-      modality, not just image + text. The probe already supports `--dataset`.
-- [ ] Optional: sweep with small vote counts (e.g. `--n-good 6 --n-bad 6`) to
-      measure the floor's effect directly in the regime where it actually binds,
-      rather than inferring it from the width-4 column at 100+100 votes.
+Three regimes: **below ~8** underfits and is seed-unstable (width 4 gives `cars`
+0.684 ±0.23); **~8 through 256** is a flat plateau (width-independent across 32×
+— 32 sits on it with margin); **above 32** capacity only buys memorization
+(`NOISE_train` → 1.000 by 64–128 while `NOISE_test` creeps up and `REAL_test`
+dips a hair). Hence: keep `MLP_HIDDEN_MAX = 32`; the stable minimum is ~8, so the
+old floor of 4 was the soft spot (now fixed).

--- a/docs/plans/near-duplicate-detection.md
+++ b/docs/plans/near-duplicate-detection.md
@@ -1,156 +1,42 @@
 # Near-duplicate detection
 
-Status: **Phase 1 shipped** — images + text near-dupe merge, opt-in at dataset
-creation. Audio/video deferred (see Open follow-ups).
+**Status: Phase 1 shipped** — images + text near-dupe merge, opt-in at dataset creation, with a vectorised/threaded hashing pass. Audio/video deferred (see Open follow-ups).
 
-## Problem
-
-We already collapse **exact** duplicates (identical MD5) at dataset load:
-`collapse_duplicates` groups medias by MD5, keeps the first as a representative,
-records every member's provenance in a `dupe_set` origin, and deletes the rest.
-
-We want to also collapse **near**-duplicates: items that are the *same content*
-under a different encoding / resize / recompression / trivial edit. This is
-distinct from *semantic* similarity (what the CLAP/SigLIP/X-CLIP/E5 embeddings
-measure). A perceptual hash answers "these *are* the same thing"; an embedding
-answers "these *mean* the same thing". Near-dupe wants the former.
-
-## Decisions (locked with the user)
-
-1. **Scope (v1): images + text.** Ship the full flow (option → grouping →
-   representative → export) for images and text. Audio (Chromaprint) and video
-   (TMK / per-frame pHash) are deferred — different algorithms, new heavy deps.
-
-2. **Signals.**
-   - **Images:** classic **pHash** (DCT perceptual hash, 64-bit). Implemented
-     dependency-free with PIL (already a dep) + a manual numpy DCT-II, so no
-     `imagehash`/`scipy` dependency is added and `deptry` stays clean. Computed
-     from `thumbnail_bytes` (already stored per image media); media with no
-     decodable thumbnail are simply not grouped (false-negative, acceptable).
-   - **Text:** **SimHash** (64-bit) over word k-shingles, hashed with
-     `blake2b` (deterministic — *not* Python's salted `hash()`). Computed from
-     `media_string`.
-
-   Both reduce near-dupe to "two 64-bit hashes within Hamming distance ≤ K",
-   giving one uniform grouping path for both modalities.
-
-3. **Tight threshold + union-find (the user's point #2).** "pHashes are close"
-   is not transitive (A≈B, B≈C, but A≉C). We pick a **tight** per-pair Hamming
-   threshold so any positive is high-confidence (missed links are false
-   *negatives*, which we tolerate), then take **connected components** over the
-   closeness graph as if it were an equivalence relation. Thresholds (out of
-   64 bits): images `K=4`, text `K=4`. Not user-exposed — no "equalness
-   points" slider.
-
-   These were calibrated empirically (see the measurements baked into
-   `tests_lib/datasets/test_near_dupes.py`). For a structured ("photo-like")
-   image, JPEG recompression and resize round-trips land at Hamming **0**
-   while a different image is **~32** — a huge margin, so `K=4` is very safe.
-   (Smooth gradients are a pathological pHash case — their low-frequency DCT
-   coefficients cluster at the median so trivial edits flip many bits — but
-   real media isn't smooth.) For a ~40-word document, a whitespace/case/
-   encoding reflow hashes to **0** (the near-dup exact-MD5 misses), a single
-   token edit ≈**4**, a multi-word edit ≥**8**, and an unrelated document
-   ≥**30**. So text near-dup mainly catches reformatted/re-encoded copies and
-   incidental single-token differences; larger edits are intentional
-   false-negatives.
-
-   *Caveat (logged, accepted for v1):* even a tight per-pair threshold doesn't
-   fully kill transitive drift across a dense gradient (A~B~…~Z). It makes it
-   rare rather than impossible. The fix if it ever bites is a cluster-diameter
-   cap, which breaks the clean equivalence-relation model — not now.
-
-4. **Representative selection (the user's point #3): `file_size` → centroid →
-   id.** Within a group, prefer the largest `file_size` (a universal
-   fidelity proxy that works for every media type, unlike "resolution"), then
-   the item closest to the group's embedding centroid, then the lowest media id
-   (deterministic tie-break — required by the test-suite flakiness rules).
-
-5. **Optional at dataset creation (the user's point #4).** A single **"Merge
-   near-duplicates"** checkbox in the importer modal's advanced section — no
-   threshold knob. Exact MD5 dedup still runs unconditionally; near-dupe merge
-   is the opt-in extra pass that runs immediately after it.
-
-6. **Export the whole set (the user's point #5).** Exact-dupe export already
-   expands a `dupe_set` representative into one `LabeledElement` per member
-   (`expand_dupes=True` by default in `LabelSet.from_clips_and_votes`). By
-   reusing the **same `dupe_set` origin structure** for near-dupes, export
-   expansion comes for free. **Bug fixed along the way:** `collapse_duplicates`
-   built member dicts *without* an `md5`, and `_clip_to_elements` did
-   `m.get("md5", media["md5"])` — falling back to the *representative's* md5.
-   Harmless for exact dupes (all members share one md5) but **wrong for
-   near-dupes** (members have different md5s → exports/re-imports under the
-   wrong hash). Members now carry their own `md5`.
-
-## Where it runs
-
-`vtscore/datasets/stages/finalize.py` gains `_collapse_near_duplicates_stage`,
-called right after `_collapse_duplicates_stage` in the load pipeline, gated on
-`ctx.merge_near_duplicates`. Because the result is baked into origins and saved
-in the dataset pickle, reloads don't recompute it (the flag defaults off on the
-reload path) — same lifecycle as exact dedup.
-
-Near-dupe runs *after* exact dedup, so some group members are already `dupe_set`
-representatives. When collapsing a near-dupe group, existing `dupe_set` members
-lists are **merged** (flattened), never nested.
-
-## Plumbing (mirrors `build_projection`)
-
-- `DatasetContext.merge_near_duplicates` (transient slot, default `False`).
-- `_run_origin_load_in_background(..., merge_near_duplicates=False)` sets it on
-  the context before finalize.
-- `_run_importer_in_background` pops `merge_near_duplicates` from `field_values`.
-- `vtsearch/routes/datasets/load.py` reads it on the import-local-folder,
-  import-local-files, and load-demo routes; the generic importer route carries
-  it through `field_values`.
-- Frontend: `mergeNearDuplicates` on the importer modal + `import-advanced`
-  component/HTML checkbox + all three submission paths.
-
-## What shipped
-
-- `vtscore/state/near_dupes.py`: pHash, SimHash, banding + union-find,
-  representative selection, `collapse_near_duplicates`.
-- Per-member `md5` fix in `collapse_duplicates`.
-- Pipeline + route + frontend wiring for the opt-in checkbox.
-- Library-tier tests.
-
-## Performance (shipped)
-
-The hashing phase — not the collapse — dominates near-dupe wall-clock, and it
-used to report **no progress at all**: `_find_near_dup_groups` computed every
-pHash/SimHash before `collapse_near_duplicates`'s `on_progress` fired (that
-callback only ticked during the cheap `_collapse_group` loop), so the bar sat at
-its floor through the whole expensive part and then filled in a burst. Fixed:
-
-- **Progress is now driven across the hashing phase** (`_find_near_dup_groups`
-  takes an `on_progress` and ticks every `_HASH_PROGRESS_STRIDE` items); the
-  collapse tail fires one final tick. No more "dead air" on the finalize bar.
-- **Vectorised hashing (CPU, bit-identical output).** `simhash_text`'s two
-  nested Python loops (shingles × 64 bits) became a single `np.unpackbits`/vote/
-  `np.packbits` reduction; `_pack_bits` is `np.packbits` instead of a 64-iter
-  shift loop. Verified bit-for-bit against the old loops.
-- **Threaded image decode.** pHash cost is PIL thumbnail *decode* + resize (GIL
-  released), so past `_THREAD_MIN_IMAGES` images it runs on a small
-  `ThreadPoolExecutor`. Grouping is order-independent, so results are identical
-  to the inline path (test: `test_threaded_and_inline_hashing_agree`).
-
-*GPU was considered and rejected:* the per-item cost is image **decode** (no
-torch GPU path for arbitrary JPEG/PNG) and, before vectorisation, Python loops —
-the 32×32 DCT is trivially cheap, so a device round-trip per item would lose. The
-CPU wins above are the right lever.
-
-Not addressed: the **registry/pickle reload** path (`registry.py`, "Step 2 of 2
-· Removing duplicates") never runs near-dupe — its "Removing duplicates" is the
-cheap exact-MD5 `collapse_duplicates`; any real cost there is the diversity-tree
-rebuild or pickle decompress, a separate concern from this pass.
+Near-duplicates are items that are the *same content* under a different encoding / resize / recompression / trivial edit (distinct from *semantic* similarity, which the embeddings measure). A perceptual hash answers "these *are* the same thing". We already collapse **exact** duplicates (identical MD5) at load via `collapse_duplicates`; near-dupe adds an opt-in pass right after it.
 
 ## Open follow-ups
 
 - **Audio near-dupe** via Chromaprint/AcoustID (or constellation hashing).
   New external dep; not in v1.
 - **Video near-dupe** via TMK+PDQF or per-keyframe pHash sequences. New dep.
-- **Cluster-diameter cap** if transitive drift proves a problem in practice
-  (see Decision 3 caveat).
+- **Cluster-diameter cap** if transitive drift proves a problem in practice.
+  *Context:* "pHashes are close" is not transitive (A≈B, B≈C, but A≉C). v1 relies
+  on a **tight** per-pair Hamming threshold + connected components, which makes
+  transitive drift across a dense gradient (A~B~…~Z) rare but not impossible. The
+  fix if it ever bites is a cluster-diameter cap, which breaks the clean
+  equivalence-relation model — deferred until it's a real problem.
 - **Banding bucket blow-up:** a band bucket of many distinct-but-band-sharing
   hashes is verified pairwise (O(m²) within the bucket). Fine for v1 sizes;
   revisit with a smarter multi-index if it bites on huge datasets.
+
+*GPU was considered and rejected for the hashing pass:* the per-item cost is image **decode** (no torch GPU path for arbitrary JPEG/PNG) and the 32×32 DCT is trivially cheap, so a device round-trip per item would lose. The CPU vectorise/thread wins (shipped below) are the right lever.
+
+## What shipped
+
+Core algorithm + wiring (`vtscore/state/near_dupes.py`):
+- **Images:** classic **pHash** (64-bit DCT), dependency-free via PIL + a manual numpy DCT-II (no `imagehash`/`scipy`, `deptry` stays clean); computed from `thumbnail_bytes`, media with no decodable thumbnail simply not grouped.
+- **Text:** **SimHash** (64-bit) over word k-shingles hashed with `blake2b` (deterministic, not salted `hash()`); computed from `media_string`.
+- **Grouping:** tight per-pair Hamming threshold (images `K=4`, text `K=4`, out of 64; not user-exposed) → banding → union-find connected components. Calibrated empirically in `tests_lib/datasets/test_near_dupes.py`.
+- **Representative selection:** largest `file_size` → closest to embedding centroid → lowest media id (deterministic tie-break).
+- Per-member `md5` fix in `collapse_duplicates` (members previously fell back to the representative's md5 via `_clip_to_elements`; wrong for near-dupes where members have distinct md5s). Export expansion then comes free by reusing the `dupe_set` origin structure (`expand_dupes=True` in `LabelSet.from_clips_and_votes`).
+- Pipeline: `_collapse_near_duplicates_stage` (`vtscore/datasets/stages/finalize.py`) runs after `_collapse_duplicates_stage`, gated on `ctx.merge_near_duplicates`; baked into origins + dataset pickle so reloads don't recompute (flag defaults off on reload). Existing `dupe_set` member lists are merged (flattened), never nested.
+- Plumbing (mirrors `build_projection`): `DatasetContext.merge_near_duplicates`, threaded through `_run_origin_load_in_background` / `_run_importer_in_background` / `vtsearch/routes/datasets/load.py` (import-local-folder/files + load-demo + generic importer route).
+- Frontend: **"Merge near-duplicates"** checkbox in the importer modal's advanced section (`mergeNearDuplicates` + `import-advanced` component/HTML + all three submission paths); no threshold knob.
+- Library-tier tests.
+
+Performance:
+- **Progress driven across the hashing phase** — `_find_near_dup_groups` takes an `on_progress` and ticks every `_HASH_PROGRESS_STRIDE` items (was dead-air: the callback only ticked during the cheap `_collapse_group` loop, so the bar sat at its floor through the expensive part then filled in a burst).
+- **Vectorised hashing (CPU, bit-identical).** `simhash_text` shingle×bit loops → single `np.unpackbits`/vote/`np.packbits` reduction; `_pack_bits` → `np.packbits`. Verified bit-for-bit against the old loops.
+- **Threaded image decode.** Past `_THREAD_MIN_IMAGES`, pHash decode+resize (GIL released) runs on a small `ThreadPoolExecutor`; order-independent grouping gives identical results (`test_threaded_and_inline_hashing_agree`).
+
+Not addressed: the **registry/pickle reload** path (`registry.py`, "Step 2 of 2 · Removing duplicates") never runs near-dupe — its "Removing duplicates" is the cheap exact-MD5 `collapse_duplicates`; any real cost there is the diversity-tree rebuild or pickle decompress, a separate concern.

--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -1,497 +1,103 @@
 # Patch-based Image Embedder - Design
 
-**Status:** V1 shipped, V2 shipped, **V3 trio shipped end-to-end**, and the
-**per-detector primary embedder shipped**. The design body below is the living
-spec for the shipped V1/V2 behaviour; the *V1 - DONE* and *V2 - DONE* closeouts
-are collapsed to struck-through lists. The V3 text/patch/structural trio
-(dict-keyed `media["embeddings"]`, role binding, dataset-level score routing,
-create-time picker) is shipped - see "V3 - implementation status". The
-per-detector primary embedder (each detector picks its own scoring space at
-create time, overriding the dataset-level score precedence for that detector's
-training/scoring) is shipped - see "Per-detector primary embedder (design)" for
-the spec, "What shipped" / "Open follow-ups" there for the close-out.
-
-## Status of related work
-
-CLS-pooled DINOv2, DINOv3, and what dev calls "eupe" (actually `facebook/PE-Core-B16-224`, see below) landed in dev via PR #1250 as plain image embedders in the existing registry, alongside the `MediaEmbedder.supports_text` capability flag and a `POST /api/sort` short-circuit that returns 400 + `supports_text: false` when the active embedder can't embed text. The frontend's sort bar already greys the text-sort affordance using that signal.
-
-**This plan upgrades the patch-capable subset to produce a hierarchical region set per image, and replaces the misnamed "eupe" entry with the real EUPE model.** Each backbone is exposed as **two embedders** - a single-vector variant (fast, small storage, no region search) and a patch-region variant (~30× compute, ~100× storage per image, enables region similarity / region-aware MLP scoring). Single-vs-patch is a static capability on the embedder class, not a runtime flag, so the loader / similarity helper / MLP scorer never branch on a mode toggle. Concretely v1 ships six embedders:
-
-- `vtscore/media/image/embedder_dinov2_single.py::ImageDinov2SingleEmbedder` (slug `dinov2_single`) and `embedder_dinov2_patch.py::ImageDinov2PatchEmbedder` (slug `dinov2_patch`) - backbone `facebook/dinov2-base` (ViT-B/14, 224² input, 16×16 = 256 patches, 768-dim). **Ungated, Apache-2.0**, default-friendly. Standard HF transformers ViT; the patch variant extracts attention via `output_attentions=True`. Both share weights via `_dinov2_shared.py::_Dinov2Base`.
-- `vtscore/media/image/embedder_dinov3_single.py::ImageDinov3SingleEmbedder` (slug `dinov3_single`) and `embedder_dinov3_patch.py::ImageDinov3PatchEmbedder` (slug `dinov3_patch`) - backbone `facebook/dinov3-vitb16-pretrain-lvd1689m` (ViT-B/16, 224² input, 14×14 = 196 patches, 768-dim). **Gated (manual licence acceptance on HF), Apache-2.0**, premium quality (register tokens + Gram anchoring → cleaner patch saliency than DINOv2). Both share weights via `_dinov3_shared.py::_Dinov3Base`.
-- `vtscore/media/image/embedder_eupe_single.py::ImageEupeSingleEmbedder` (slug `eupe_single`) and `embedder_eupe_patch.py::ImageEupePatchEmbedder` (slug `eupe_patch`) - rewritten to point at the **real** facebookresearch/EUPE model (`facebook/EUPE-ViT-B/`), not PE-Core. Loaded via `torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', weights=…)` - see "EUPE backbone & licence". Marketed as a "universal" encoder distilled across multiple downstream tasks. **FAIR Noncommercial Research License - outputs (embeddings, datasets) become noncommercial-only**; both variants surface this via `license_notice`. Both share weights via `_eupe_shared.py::_EupeBase`.
-
-The shared bases live in underscore-prefixed modules (`_dinov2_shared.py`, `_dinov3_shared.py`, `_eupe_shared.py`) so the `embedder*.py` auto-discovery scan in `vtscore/media/__init__.py` skips them; only the six concrete `embedder_*_single.py` / `embedder_*_patch.py` modules expose an `EMBEDDER` sentinel.
-
-`MediaEmbedder.supports_text` already exists. `MediaEmbedder.supports_patch_regions` was added as a sibling capability flag in commit 441233b (defaults False; flipped True on the three `_patch` variants above). We also add `MediaEmbedder.license_notice: Optional[str] = None` (default None) so EUPE-real can surface its FAIR-Noncommercial restriction to the UI before the user picks it.
-
-### EUPE backbone & licence (replacing PE-Core)
-
-The previous version of this doc proposed loading PE-Core via open_clip and exposing it under the "eupe" slug. That was a mistake of mine - `facebookresearch/EUPE` (Efficient Universal Perception Encoder) and `facebook/PE-Core-B16-224` (Perception Encoder Core) are **different models**, and the dev "eupe" slug was renamed from "pe" without actually changing the underlying weights, which made me conflate them. We're now switching the embedder to the real EUPE model the slug claims to be.
-
-Concretely:
-
-- **What changes:** `embedder_eupe.py` is rewritten end-to-end to load the real EUPE ViT-B/16 weights via `torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', weights=<HF URL or local path>)`. `EUPE_MODEL_ID` in `vtscore/config.py` changes from `"facebook/PE-Core-B16-224"` to a concrete EUPE weight URL (or stays as a marker constant and the URL lives in the embedder). The previous AutoModel + `trust_remote_code=True` path goes away entirely (it was broken in dev anyway - the HF repo has no `config.json`).
-- **What's pinned by probe:** the exact `torch.hub` entrypoint, the weights URL, and the cleanest way to extract per-patch tokens + CLS-to-patch attention. The README documents loading but not the dense-feature API. I'll do a short static probe of the repo's source before writing the embedder.
-- **Licence:** outputs ("Research Materials" includes inference outputs) are bound to noncommercial research uses under FAIR Noncommercial v1 §1.b.i. We surface this on the embedder card and on the dataset-create flow when the user picks `eupe`, via `license_notice`. We do **not** automatically gate it behind a licence-acceptance click - the user said users who object can simply skip the embedder, and forcing an interstitial would slow down the people who already know.
-
-## Motivation
-
-Today every image becomes a single vector via `ImageSiglipEmbedder` (or a sibling). Single-vector embeddings are coarse: a vote on "this picture has a dog" leaks signal from the dog into the couch, the lamp, and the wall behind it. Patch-based models produce one vector per spatial token, which opens the door to:
-
-- Region-level similarity ("find me pictures of *that specific patch*").
-- Object-localised votes ("the *good* part is this box, not the whole image").
-- A detector MLP that scores *regions*, not whole images, and thereby acts as a localiser as a side effect.
-
-This document covers the first patch-based embedders for image media. The same machinery may eventually be useful for video frames; out of scope here.
-
-## Non-goals
-
-- **No new media type.** Patch-embedded images are still `image` media. DINOv3 and EUPE are entries in the existing embedder registry, just like SigLIP.
-- **No persisted vectors outside dataset pickles.** Patch vectors live in the dataset pickle (the sanctioned snapshot store for embeddings) and in RAM. They are never written to `settings.json`, detector JSON, or any new on-disk artifact. The "No Persisted Vectors or MLPs" rule in `CLAUDE.md` still binds.
-- **No EUPE-ConvNeXt.** The Meta repo offers ConvNeXt variants too, but our chosen `facebook/PE-Core-B16-224` weight is a pure ViT-B/16 - same shape as DINOv3, so the protocol is uniform across both supported patch embedders. (See "Backbone choice" for why we drop ConvNeXt entirely.)
-- **No swap-embedder-on-an-existing-dataset flow.** Each dataset is locked to its embedder at creation time. If a user wants a different embedder, they re-import. (See "Per-dataset embedder model" for the longer-term plan.)
-- **No text encoder bolted onto DINOv3 / EUPE.** Both already report `supports_text=False`. Text sort stays grey when one of them is the active dataset embedder.
-
-## Backbone choice - DINOv2, DINOv3, real-EUPE
-
-### Structural comparison
-
-| Property | DINOv2 ViT-B/14 | DINOv3 ViT-B/16 | EUPE ViT-B/16 (facebookresearch/EUPE) |
-|---|---|---|---|
-| Gating | Ungated | Manual licence acceptance on HF | Gated by the FAIR Noncommercial Research Licence |
-| Licence on outputs | Apache-2.0 (use freely) | Apache-2.0 (use freely) | **Noncommercial research only** |
-| Input resolution | 224² | 224² | 224² |
-| Per-patch token output | Yes - 16×16 = 256 patches | Yes - 14×14 = 196 patches | Yes - 14×14 = 196 patches |
-| CLS token | Yes | Yes (+ register tokens) | Yes |
-| CLS→patch attention available | Yes (standard HF ViT - `outputs.attentions[-1][0, :, 0, 1:].mean(0)`) | Yes (HF ViT + register tokens; we strip the register columns before reshaping to a 14×14 grid) | Probed at impl time - model is a standard ViT under the hood, so a forward hook on the last block's `attn` is the expected path. To be confirmed by the EUPE-source probe (see "Pre-implementation experiments"). |
-| Embedding dim | 768 | 768 | 768 |
-| Loader | `transformers.AutoModel.from_pretrained` | `transformers.AutoModel.from_pretrained` (HF_TOKEN required) | `torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', weights=…)` |
-| `supports_text` | False | False | False |
-| `supports_patch_regions` on `_patch` variant | True | True | True |
-| `supports_patch_regions` on `_single` variant | False | False | False |
-| `license_notice` (both variants) | None | None | `"FAIR Noncommercial Research Licence - outputs are bound to research-only use."` |
-
-All three are CLS+patch ViTs at 224² with 768-dim tokens. DINOv2 and DINOv3 share the standard HF transformers loading path; EUPE uses `torch.hub` because the official distribution does. DINOv2 is the recommended default (ungated, no licence ceremony); DINOv3 is the premium upgrade for users who've accepted the HF licence; EUPE is the research-only option. Each family ships **two** embedders - a `_single` slug that exposes only the CLS-pooled vector, and a `_patch` slug that additionally produces the patch grid + HAC region tree (~30× compute, ~100× storage per image).
-
-**DINOv3 register-token detail.** DINOv3 prepends register tokens after the CLS token, so the final-block attention has shape `(batch, heads, 1 + R + 256, …)` where R is the register count. Before reshaping `cls_to_patch` into a 14×14 grid we slice out the patch columns by name (the HF model exposes the register count via its config). The patch indices themselves are contiguous and row-major over the 14×14 spatial grid.
-
-### Embedder output protocol
-
-The patch-region pipeline talks to the backbone via:
-
-```python
-class PatchEmbedOutput(NamedTuple):
-    cls_vec: np.ndarray          # (768,)         L2-normalised float32
-    patch_grid: np.ndarray       # (14, 14, 768)  L2-normalised float32
-    patch_saliency: np.ndarray   # (14, 14)       float32, sums to 1.0 over the grid
-```
-
-DINOv3 and EUPE each gain a `_patch_forward(image: PIL.Image) -> PatchEmbedOutput` method that runs one forward pass with `output_attentions=True`, takes the final-block CLS→patch attention averaged across heads as `patch_saliency`, and returns it alongside `cls_vec` and `patch_grid`. The existing `_embed_media_impl` keeps returning the CLS vector (so it's unchanged for any legacy caller).
-
-## Data model - HAC region tree
-
-A naive design stores all 196 patch vectors per image. Two problems:
-
-1. Storage and similarity cost grow ~200×. The diversity tree, MLP scoring, and label-export paths all assume a small handful of vectors per media.
-2. Raw patches are too small. A single patch is "left ear of a dog", rarely the right unit to match against.
-
-Instead, ingest produces a **strict agglomerative tree** of regions per image:
-
-```
-RegionTree (HAC binary tree over K leaves → 2K−1 nodes total):
-  - K leaves:        proposed object regions   (K ≈ 8–16, picked from saliency peaks)
-  - K−1 internals:   each is the merge of two children along the agglomeration path
-  - root:            the single top-level merge (usually approximates the full image)
-  - full_image:      always present as its own node (CLS-pooled), even if the root
-                     differs - gives us an unambiguous global vector
-```
-
-The earlier "merge spatially adjacent regions until done" rule was underspecified and produced a combinatorial set. **HAC (hierarchical agglomerative clustering)** fixes it:
-
-1. Start with the K leaf regions.
-2. Repeatedly merge the **single closest pair** under a fixed affinity `α · cosine(child_vecs) + (1−α) · spatial_adjacency`.
-3. Stop when one node remains.
-
-This produces a strict binary tree with exactly `2K − 1` nodes. Each internal node *is* the merge of its two children - no other merges exist. With K = 12 leaves we get 23 region nodes + the CLS full-image node = **24 vectors per image**. (Final K decided in the small empirical sweep - see Open Questions.)
-
-Worked example. Leaves = `{head, body, legs, chair}`. Affinities (cosine + adjacency) typically rank: `head ↔ body` highest, then `{head+body} ↔ legs`, then `{head+body+legs} ↔ chair`. Nodes in the tree:
-
-```
-L0: head                       L4 = L0+L1   (head+body)
-L1: body                       L5 = L4+L2   (head+body+legs)   ← the "full person" merge
-L2: legs                       L6 = L5+L3   (full person + chair)   ← the root
-L3: chair                      full_image   (CLS-pooled, may be ≈ L6)
-```
-
-Cases HAC misses are arbitrary skip-subsets like `{head+legs}` (without body). Those are rare in practice; max-similarity over individual leaves still picks one of them when relevant, and the full-image vector catches the "the query really is about the whole scene" case.
-
-Construction at embed time:
-
-1. Run the patch backbone once → `PatchEmbedOutput`.
-2. **Full image**: `cls_vec` → the `full_image` node.
-3. **Leaf proposals**: cluster grid cells by spatial connectivity weighted by `patch_saliency`; take the top-K clusters by saliency mass. Each leaf vector is the saliency-weighted mean of its constituent patch vectors, L2-normalised. Each leaf's box is the tight bounding box around its constituent cells, in normalised image coordinates.
-4. **HAC**: build the binary merge tree above. Each internal node's vector is the mass-weighted mean of its two children, L2-normalised. Each internal node's box is the union of its children's boxes.
-
-## Storage - FP16 in the pickle, FP32 in RAM
-
-```python
-@dataclass
-class RegionVector:
-    box: tuple[float, float, float, float]   # normalised (x0, y0, x1, y1)
-    vec: np.ndarray                           # L2-normalised float16, shape (D,) - pickled
-    children: tuple[int, int] | None = None   # child idxs in the same list,
-                                              # or None for leaves and full_image
-```
-
-```python
-media["patch_regions"] = [RegionVector, ...]   # index 0 is always full_image (CLS-pooled)
-                                               # indices 1..K   are HAC leaves
-                                               # indices K+1..  are HAC internals (in build order)
-media["patch_grid"]    = np.ndarray            # (H, W, D) fp16, L2-normalised - pickled
-                                               # H × W is embedder-specific:
-                                               #   DINOv2 ViT-B/14 @ 224²  -> 16 × 16
-                                               #   DINOv3 ViT-B/16 @ 224²  -> 14 × 14
-                                               #   EUPE   ViT-B/16 @ 224²  -> 14 × 14
-                                               # D is 768 for all three v1 embedders.
-media["embedding"]     = media["patch_regions"][0].vec.astype(np.float32)   # legacy: full image vector
-```
-
-Vectors are stored as **float16** in the pickle to keep the dataset size budget tight. Two pieces of patch-derived state:
-
-- `patch_regions`: ~24 vectors × 768 dims × 2 bytes ≈ **36 KB / image**.
-- `patch_grid`: ~196–256 patches × 768 dims × 2 bytes ≈ **300–400 KB / image** (DINOv2's 16×16 grid is a bit larger than DINOv3/EUPE's 14×14).
-
-Total ≈ **340–440 KB / image**. On a 100k-image dataset that's ~35–45 GB of extra pickle storage (vs. ~3 GB for `patch_regions` alone). We pay this cost in v1 so that v2 region voting can re-pool the user's box on-the-fly without forcing users to re-import.
-
-Vectors are cast to float32 when read into RAM and at score time; cosine similarity stays in float32 throughout.
-
-Critically, `media["embedding"]` continues to be a single float32 vector and continues to be what the diversity tree, the legacy MLP, sorting, and the existing similarity paths consume. The new field is **additive** - anything that doesn't know about regions just sees the full-image vector and behaves exactly as before.
-
-Patch-region-aware code paths (similarity, MLP scoring, vote attribution) opt in by checking `media.get("patch_regions")`. This keeps the blast radius small.
-
-## Similarity (search & sort)
-
-At query time we have a query vector `q` (text-embedded or example-embedded). For every haystack image:
-
-```python
-score(media) = max(cos(q, r.vec) for r in media["patch_regions"])
-best_region(media) = argmax_r cos(q, r.vec)
-```
-
-Because the haystack has `full_image` + leaves + HAC internals all in the same flat list, the `max` naturally picks whichever scale matched best. The full-body-of-a-person case is handled by the HAC internal - head, abdomen, legs are leaves, but their merge is also in the list, and if the body-as-a-whole matches better than any single child, the merge wins.
-
-`best_region(media).box` is retained alongside the score and shipped to the UI so the gallery card can draw a faint outline over the matched region. Purely informational in v1 - no vote semantics attached.
-
-## Vote attribution
-
-### v1: whole image (schema), region-aware loss (training)
-
-V1 records both Good and Bad against the full image - one `LabeledElement` per vote, no `region_box` field, schema unchanged. The patch embedder still produces the rich region set and search uses it; the *vote* is image-level until v2 ships a UI that lets the user designate the region themselves.
-
-This is deliberate. "Use the region that triggered the result" misattributes in any sort mode without a query (random shuffle, diversity sort, autopilot exploration, a fresh dataset), and ignores discovery - users vote Good on things the algorithm didn't surface for.
-
-**However**, the training *loss* for Bad votes is region-aware even though the labels are image-level. Good and Bad have asymmetric weakly-supervised claims:
-
-- **Good vote on an image** = "this image is good." We don't have a region-level claim - the user may have voted on the gestalt, on the principal subject, or on a small detail; we have no way to know which. The full-image CLS vector already summarises the whole image, and at scoring time the MLP's max-pool over regions generalises that to "find the region that most matches what good images look like." We don't need to force the MLP to commit to a single region during training. Training stays on `media["embedding"]` (the CLS-pooled full-image vector), exactly as today.
-- **Bad vote on an image** = "no region in this image is good." This is a strictly stronger claim, and it applies to *every* region of the image: leaves, HAC internals, and the CLS full-image node. The loss pushes all of them down.
-
-The asymmetry is encoded entirely in the loss function (see "Detector MLP" below), not in extra `LabeledElement` rows: one vote stays one labelled example. Label export, the votes UI count, and inclusion class-balancing all continue to count votes, not regions.
-
-For datasets whose embedder doesn't produce `patch_regions` (SigLIP, single-vector DINO variants, etc.), the Bad-vote `mean` reduces to a single BCE on the full-image vector - identical to today's behaviour. The change is fully backward compatible.
-
-### v2: region voting
-
-V2 lets the user attach a single rectangular region to a yes-vote on an image. The region is a *salient-area annotation* - it says "the good part is here", not "yes-with-region is a new label class". No-votes never carry a region.
-
-#### Backend semantics
-
-1. **Compute the vote vector on the fly from the patch grid.** Not from any tree node. Take the set of patch cells whose centers fall inside the user's box, **uniform-mean** their `media["patch_grid"][i, j]` vectors, L2-normalise. That's the vote vector for this vote. We persist the *box* (4 floats), not the vector - the trainer rederives the vector at train time from the already-pickled `patch_grid` (stored from v1, see "Storage"). No re-import required when v2 ships.
-
-   Why uniform mean and not the saliency-weighted mean the HAC leaves use? The HAC builder re-L2-normalises at every internal merge, which destroys associativity of weighted mean - three different merge orders for the same patch set yield three different unit vectors. So *no* pooling rule can guarantee `box_to_vote_vector(patches(node))` equals an existing HAC node's stored vector. Uniform mean instead gives us the simpler property that **the same set of cells always produces the same vote vector**, and the pre-normalisation sum is additive across disjoint cell sets, which keeps a hypothetical future multi-box vote consistent with a single-box vote over the union.
-2. **Don't snap to tree nodes.** The HAC tree exists to give *search* a finite set of regions to scan in O(N log N). Voting is a one-off, so on-the-fly computation is fine and gives the user patch-precision without the "slightly-too-big box jumps to the full-image node" failure mode.
-3. **Display-time snapping is different.** When we draw the matched-region outline on a search-result card, we *do* snap to the best-IoU tree node, because the user isn't designating anything there - we're just showing them which scale won.
-
-V2 adds an optional `region_box: (x0, y0, x1, y1)` (normalised image coords) to `LabeledElement`. Absent → image-level (the v1 default and the forever-legacy fallback).
-
-When `region_box` is present on a Good vote, the v1 full-image-vector loss is replaced for that vote by `BCE(mlp(box_pooled_vec), 1)` - the user named the good region, so we train the MLP on the box-pooled patch vector instead of the CLS-pooled full-image vector. Without a box, Good votes fall back to the v1 path. Bad votes never carry a box, so their `mean`-over-regions loss is unchanged from v1.
-
-#### Interaction design
-
-The overriding constraint is **don't degrade the existing fast binary-vote path**. Today a yes-vote is one keypress (`→`); a no-vote is one keypress (`←`). Users who never want region voting must never see new affordances in their way, and their one-keypress rhythm must survive untouched.
-
-**Scope.** Image media only. Other media types (audio, text, video, document) get no region-vote affordance in v2 - `supports_patch_regions` is image-specific and there's no obvious 2D analogue for the others. The center-pane focus view is the only place region voting is offered; the gallery card's `best_region` outline (shipped in v1) remains purely informational.
-
-**Entering region mode: hold `Shift`.** The focus pane already binds mousedown-drag to *pan-when-zoomed*. While `Shift` is held over the image-viewer canvas, that pan gesture is suppressed and replaced with a box-draw gesture; the cursor flips to a crosshair. Release `Shift` and pan is restored. Reasons for `Shift` over a sticky toggle:
-  - Matches Figma/Photoshop muscle memory (drag = move; modifier+drag = select).
-  - One key down, one key up - no mode the user can get stuck in.
-  - Doesn't collide with text input the way letter-key hotkeys do.
-  - Users who never region-vote literally never touch it.
-
-If `Shift` is released mid-drag (mouse button still down), the in-progress draw is committed on mouseup before mode exits. Don't punish a millisecond-early key release.
-
-**Drawing the box.** Click-drag-release in image-local coordinates: the mouse position is un-transformed through the current `panX / panY / zoom / rotate` so a box drawn at 4× zoom stays correctly anchored when the user zooms back out. Stored internally and on `LabeledElement.region_box` as `(x0, y0, x1, y1)` in normalised image coords (0..1, pre-rotation). A zero-area release (just a click, no drag) is treated as "no box drawn" and falls back to the binary path.
-
-**Editing the box.** After release the box stays visible with 8 corner/edge resize handles and a draggable body for translation. There is **no separate submit button** - the box is just transient state attached to the *pending* vote. Re-Shift-dragging from empty space starts a fresh box (discards the prior one).
-
-**Voting still uses Left/Right.**
-  - `→` (good) submits a yes-vote and, if a box is currently drawn, attaches its normalised coordinates as `region_box`. No box → plain yes-vote, identical to today.
-  - `←` (bad) when **no box is drawn** → plain no-vote, identical to today.
-  - `←` (bad) when a box **is drawn** → arms a sticky "discard box & vote no" state. The box pulses to draw attention and a one-line hint reads *"Press ← again to vote no and discard the box, or Esc to keep the box."* The state has **no timeout** - a second `←` confirms whenever it arrives; Esc, mouse interaction with the box, or navigating to another item clears the armed state and keeps the box. Rationale: drawing a box is real work; a stray `←` shouldn't throw it away, but a time-based modal (e.g. "second press within 2s") is fragile - the user pauses to think, the timer expires invisibly, and the next press surprises them. A visible sticky state never lies about what the next press will do. Users with no box never see this branch and keep their single-keypress fast path.
-  - `Esc` discards the current box without voting; the user stays on the same item.
-
-The mouse-click vote buttons in the UI follow the same rules.
-
-**Touch.** Deferred to a later phase. Touch has no `Shift` modifier, and v2's audience is power users on desktop. The center-pane toolbar already exposes zoom/rotate/reset buttons; if touch support is needed later, a "draw region" toggle button there is the natural place. Out of scope for v2.
-
-**Frontend implementation surface.** A new overlay layer inside `ImageViewerComponent` (or a sibling `RegionDrawComponent` it composes) listens for `keydown/keyup` of `Shift` on `window` while the focus pane is mounted, swaps pointer handlers when the modifier is active, and renders the box + handles as a positioned div pair inside the existing `.thumbnail-wrap` (same coordinate system as the v1 `best_region` outline). The vote-dispatch service grows an optional `regionBox` parameter that flows into the existing yes-vote API call; the bad-vote path picks up a "pending discard confirmation" sub-state. None of this touches the binary-only code paths.
-
-**Tests.** Beyond the existing v1 patch tests, v2 needs: pure-function coverage for the screen↔image coordinate transform under non-trivial `pan/zoom/rotate`; coordinate stability across zoom changes after the box is drawn; box discarded on bad-vote-after-confirm; box preserved across a second `Shift`-drag attempt that becomes a no-op zero-area click; `region_box` round-tripping through `LabeledElement` serialisation; vote-API contract test that `region_box` is present on yes and absent on no. The on-the-fly patch-grid pooling (box → vote vector) is exercised by a backend test that doesn't touch the UI.
-
-## Detector MLP
-
-### Scoring (search & sort & calibration)
-
-The current MLP scores `f(embedding) → [0, 1]`. With regions, scoring becomes:
-
-```python
-def score_media(mlp, media):
-    regions = media.get("patch_regions") or [{"vec": media["embedding"], "box": (0,0,1,1)}]
-    region_scores = [mlp(r.vec.astype(np.float32)) for r in regions]
-    return max(region_scores), regions[argmax(region_scores)].box
-```
-
-The MLP itself is unchanged in shape - same input dim, same output. The change is purely "feed every region through the MLP and max-pool". Because HAC internals and the full image are both in the region list, the head/body/legs-each-miss-but-full-body-hits failure mode is handled - the full-body merge gets its own MLP pass and wins.
-
-Calibration / thresholding works unchanged: it uses the same scoring function above, which already returns a single scalar per media.
-
-### Training loss (region-aware on Bad, full-image on Good)
-
-The training loop today (`train_model` in `vtsearch/models/training.py`) consumes `X_train: (N, D)` + `y_train: (N, 1)` and computes `BCEWithLogitsLoss` per example, weighted by `inclusion_value`-derived class weights. With patch regions, the per-vote loss becomes asymmetric:
-
-```python
-def per_vote_loss(mlp, media, label):
-    if label == 1:  # Good
-        return BCE_with_logits(mlp(media["embedding"]), 1)        # unchanged from today
-    else:           # Bad
-        regions = media.get("patch_regions") or [{"vec": media["embedding"]}]
-        scores = mlp(stack(r.vec for r in regions))               # (R,) logits, R ~ 24 / 1
-        return mean(BCE_with_logits(s, 0) for s in scores)        # every region is negative
-```
-
-Then the standard outer loop, unchanged:
-
-```python
-batch_loss = mean(class_weight(label) * per_vote_loss(mlp, media, label)
-                  for (media, label) in batch)
-```
-
-Why this shape:
-
-1. **Asymmetric supervision claims.** Good = "this image is good" - no region-level claim, the user may have voted on the gestalt or on any of 24 sub-units. The CLS-pooled full-image vector already summarises the whole image, and inference's max-pool over regions will generalise the learned function to regions at scoring time. Bad = "no region in this image is good" - a strictly stronger claim that applies to every region, so the loss reaches all 24.
-2. **Why not `max`-BCE on Good too?** Symmetric `max`/`mean` looks tidy but introduces a moving-nail problem on the positive side (whichever region happens to score highest gets the gradient, and that region shifts retrain-over-retrain), without solving any concrete attribution problem. The CLS vector already carries the Good signal cleanly; no need to force the MLP to commit to a single region during training when the user didn't.
-3. **Same bookkeeping unit as today.** One vote stays one labelled example for inclusion class-balancing, label export, "you have N labelled examples" stats. The 24-way region expansion happens *inside* the per-vote loss term on Bad votes only, not by multiplying the example count.
-4. **No new persisted artifact.** Vectors live in `media["patch_regions"]` (already pickled per the v1 storage plan); the loss reads them at train time. No region indices or hard-mine lists in `LabeledElement`, fully CLAUDE.md-compliant.
-5. **Backward compatible.** For datasets whose embedder doesn't produce `patch_regions` (SigLIP, single-vector DINO variants, etc.), the Bad-side region list is `[full_image]` and the `mean` reduces exactly to today's `BCE(mlp(vec), 0)`. Good-side is literally today's code path. No branching at the call site.
-6. **Inference symmetry.** `score_media` does `max` over regions. The Bad-side `mean` drives `max → 0` (sigmoid scores bounded at 0), so train-time and test-time agree about what "low score" means.
-
-#### Why not "add all regions as separate negative LabeledElements"?
-
-A natural-looking alternative is to expand each Bad vote into 24 `(region.vec, 0)` rows in the training set ("all 24 in the Bad pile"). The gradient math is essentially equivalent to the `mean` loss above - inclusion's `weight_true = num_false / num_true` rebalances class totals so the per-Bad-vote weight winds up the same - but the plumbing is worse:
-
-- Label export, vote counts, and the "labelled examples" UI all 24× per Bad vote unless we add a second representation.
-- `LabeledElement` would need either persisted region vectors (violates CLAUDE.md's "no persisted vectors" rule) or persisted region indices (workable but new schema).
-- It's asymmetric with the inference path, which logically operates per-media.
-
-Putting the region aggregation in the loss instead of the training set keeps `LabeledElement` and the votes UI honest.
-
-#### Why not hard-mine ("vote vs. previous MLP's argmax")?
-
-Another natural-looking alternative: at each retrain, run the previous MLP over each Bad image's region tree and add the argmax region as a labelled negative. This degenerates trivially - once a region is in the training set as a negative, the next MLP drives its score toward 0, so it cannot be the next argmax. The argmax must come from the not-yet-mined set, so the procedure just enumerates all 24 regions in arbitrary order over ~24 retrains. Same destination as "all 24 in the pile," reached more slowly and with a confusing-looking incremental schedule.
-
-The `mean` loss reaches the same end state in one training run, without persisting any per-image bookkeeping.
-
-### Refactor surface
-
-`train_model`'s signature changes from `(X_train, y_train, ...)` to carry Good votes as today (one full-image vector per vote) plus Bad votes as per-vote region groups - concretely a separate `(X_bad_regions: Tensor[total_R, D], bad_group_ids: Tensor[total_R])` pair that lets us scatter-mean over groups, alongside the existing `X_good: Tensor[N_good, D]`. The MLP shape and the inclusion-weighting code (`training.py:213–234`) are unchanged; the weighted-loss aggregation gains a Bad-side scatter-mean before reduction.
-
-`train_and_score` (`training.py:329`) and the workflow caller (`training_workflow.py`) need matching adjustments to pass per-Bad-vote region tensors. The label-store reader builds those tensors by looking up `media["patch_regions"]` at training time, with a `[full_image]` fallback for datasets without it. Good votes continue to read `media["embedding"]` only.
-
-## Diversity tree
-
-The diversity tree clusters by full-image vector and that's the right behaviour - diversity is an image-level property, not a region-level one. No change. The tree continues to consume `media["embedding"]`, which is the full-image vector. Note the implicit backbone change: today the active patch embedder will produce CLS-pooled DINOv3/EUPE vectors instead of CLS-pooled SigLIP. Worth a sanity check that the tree clusters look sensible on a real dataset - not a blocker, more a verify-before-shipping item.
-
-## Per-dataset embedder model
-
-Today a dataset is bound to **one** embedder, set at creation. The dataset's capabilities = its embedder's capabilities:
-
-| Active embedder | `supports_text` | `supports_patch_regions` | What the UI does |
-|---|---|---|---|
-| SigLIP / SigLIP2 / CLIP | True | False | Text sort lit; region overlays absent; phase-2 region voting will be hidden |
-| `dinov2_patch` / `dinov3_patch` / `eupe_patch` | False | True | Text sort greyed with "This dataset's embedder doesn't support text queries."; region overlays visible; phase-2 region voting available |
-| `dinov2_single` / `dinov3_single` / `eupe_single` | False | False | Both off (fast/cheap variant - same backbone as the `_patch` slug, just no region tree) |
-
-The dataset surface gains two getters that just delegate: `dataset.supports_text` and `dataset.supports_patch_regions`, computed from the bound embedder. The frontend's `ActiveContextService` already routes `X-Dataset-Id`; the sort-bar and (eventually) the region-vote affordance read the two capability flags off the dataset metadata response.
-
-### Future: the text / patch / structural trio per dataset
-
-Tracked in "V3 - design" below.  v1/v2 picked the field names
-(`media["embedding"]`, `media["patch_regions"]`, `media["patch_grid"]`)
-so that they collapse cleanly into the v3 dict schema - no rewrite of
-the v1/v2 storage decisions is needed; v3 is purely additive at the
-schema level.  The structural role's `media["local_features"]`
-(structural-embedder.md) slots into the same additive model.
-
-## Backend integration points
-
-- **Embedder upgrades** (six embedders for v1 - single/patch pairs for each of three backbones):
-  - `vtscore/media/image/_dinov2_shared.py::_Dinov2Base` holds the shared DINOv2 load + forward logic. `embedder_dinov2_single.py::ImageDinov2SingleEmbedder` (slug `dinov2_single`) exposes just CLS pooling; `embedder_dinov2_patch.py::ImageDinov2PatchEmbedder` (slug `dinov2_patch`) additionally overrides `supports_patch_regions = True` and `_patch_forward_impl` to return a `PatchEmbedOutput`. Standard HF transformers ViT-B/14, `output_attentions=True`, no register tokens to strip. 16×16 = 256 patch grid.
-  - `_dinov3_shared.py::_Dinov3Base` holds the shared DINOv3 logic; `embedder_dinov3_single.py` and `embedder_dinov3_patch.py` are the two thin variants. Standard HF transformers ViT-B/16 with 4 register tokens (sliced out before reshaping to a 14×14 patch grid). Requires `HF_TOKEN` env var.
-  - `_eupe_shared.py::_EupeBase` holds the shared EUPE logic; `embedder_eupe_single.py` and `embedder_eupe_patch.py` are the two thin variants. EUPE loads via `torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', weights=…)` (replacing the broken `AutoModel + trust_remote_code` PE-Core path). Both variants surface `license_notice = "FAIR Noncommercial Research Licence - outputs are bound to research-only use."`
-  - `requirements-image-embedders.txt`: removes the `einops` comment about EUPE-as-PE-Core. EUPE-real's runtime deps (likely just torch + PIL) are confirmed via the source probe.
-  - `EUPE_MODEL_ID` in `vtscore/config.py` updates to refer to the real EUPE weights (URL or HF path determined by the probe).
-- **License surfacing**: `MediaEmbedder.license_notice: Optional[str] = None` is added next to `supports_text` / `supports_patch_regions`. `to_dict` includes it. The frontend embedder picker shows a small warning chip when an embedder reports a notice, and the dataset-create flow surfaces the same notice inline when the user picks an embedder with one. We don't gate selection behind an acceptance click - users who object simply pick a different embedder.
-- **Capability flag**: `MediaEmbedder.supports_patch_regions: bool = False` lives next to `supports_text` in `vtscore/media/embedder.py`. The metadata dict returned by `MediaEmbedder.to_dict()` surfaces it under `supports_patch_regions`, matching the `supports_text` convention already in place.
-- **Region builder**: new module `vtscore/media/patch_embed.py` - pure functions `propose_leaves(patch_grid, saliency, k) -> list[Leaf]` and `build_hac_tree(leaves, alpha) -> list[RegionVector]`. No torch dependency; takes numpy arrays.
-- **Loader hook**: `vtscore/datasets/loader_pickle.py` and `loader_folder.py` already call `embedder.embed_media`/`embed_media_bulk`. We add a sibling pass that, *only if `embedder.supports_patch_regions`*, runs `_patch_forward` and `build_hac_tree`, then stores `media["patch_regions"]` (and in v2, also `media["patch_grid"]`).
-- **Similarity helper**: single helper function `score_against_query(media, q) -> (score, box)` in `vtsearch/models/region_similarity.py` is the one place that knows the max-over-regions rule. Used by sort, find-label, example-sort.
-- **MLP training & scoring**: `vtsearch/models/detector_training.py` and `vtsearch/models/training_workflow.py` adopt the region-aware *scoring* path. Training stays image-level in v1; `LabeledElement` is unchanged.
-- **Vote recording**: unchanged in v1. Votes attach to the whole image as today.
-
-## Frontend integration points (v1 only)
-
-- **Already in dev:** sort bar greys the text-search input when the active dataset's embedder reports `supports_text=false`. Hint copy: "This dataset's embedder doesn't support text queries."
-- **New in v1:** the gallery card reads `best_region.box` from the sort response and renders a faint outline over the matched region. No vote semantics on the outline; purely informational.
-- **No region-vote UI in v1.** Phase 2.
-
-## Tests
-
-New: `tests/test_patch_embedder.py`:
-
-- Region builder unit tests with hand-crafted `PatchEmbedOutput` arrays - no model weights. Verifies `propose_leaves` and `build_hac_tree` produce exactly `2K − 1` HAC nodes plus the CLS full-image node, well-formed `children` indices, valid normalised boxes.
-- `RegionVector` round-trips through dataset pickle as fp16; cast-on-read returns fp32 vectors of correct shape and normalisation.
-- `score_against_query` returns `max(region_scores)` and the right `best_region`.
-- Merge wins: hand-crafted region tree where individual leaves miss the MLP but an internal HAC node hits → `score_media` returns the merge.
-- Capability flags: DINOv3 and EUPE register with `supports_text=False, supports_patch_regions=True`; SigLIP stays unchanged; `/api/embedders` returns the new field.
-- v1 vote semantics: voting Good or Bad on a patch-region dataset does **not** write `region_box` to `LabeledElement`.
-- Asymmetric loss: `per_vote_loss` returns `BCE(mlp(full_image_vec), 1)` on Good votes (unchanged from today) and `mean(BCE(s, 0))` over a hand-crafted `patch_regions` list on Bad votes. On a single-vector media (no `patch_regions`) the Bad branch reduces to today's `BCE(mlp(vec), 0)`. Class-weight code (`training.py:213–234`) is exercised unchanged - one vote stays one example for inclusion balancing.
-- Bad-vote suppression: hand-crafted MLP + region tree where one HAC leaf has a moderately positive score and the full image scores 0; one Bad-vote training step over that media drives all 24 region scores measurably toward 0, including the leaf that was the previous argmax. Smoke check for "no nail escapes the mean."
-
-`tests/test_gpu.py` gets a thin patch-embedder integration that runs a real DINOv3 (and a real EUPE) `_patch_forward`, asserts `PatchEmbedOutput` shapes and that `patch_saliency` sums to ~1. Marked `@pytest.mark.gpu`.
-
-## Migration
-
-- Existing datasets without `patch_regions` keep working unchanged. The capability flag makes the patch path strictly additive.
-- The user explicitly chose "re-import to change embedder" - there's no in-place re-embed flow, and we don't add one.
-- Old `LabeledElement`s without `region_box` resolve to the full image (v1 default) - both forever and forward-compatible with v2.
-
-This is a feature addition, not a breaking change.
-
-## Pre-implementation experiments
-
-Run these **before** we ship v1, on the `caltech101_s` demo dataset (a sensible mix of single-object and multi-object scenes). Keep the experiment code generic so we can re-run any of them on a different dataset later - none of these bake in caltech101_s as a magic string in production code.
-
-1. **PE-Core probe (no longer used) - DONE.** Earlier exploration confirmed (a) the dev `AutoModel + trust_remote_code=True` path on `facebook/PE-Core-B16-224` is broken (no `config.json` in the HF repo), and (b) PE-Core can be loaded cleanly via open_clip. We documented this but ultimately **dropped PE-Core from v1** because the slug `eupe` claims to refer to a different model - the real facebookresearch/EUPE - and we'd rather make the slug honest than fix PE-Core's load path. See "EUPE backbone & licence".
-
-2. **Real-EUPE source probe - DONE (results below).**
-   - **Loader.** `torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16', source='github', pretrained=True, weights="https://huggingface.co/facebook/EUPE-ViT-B/resolve/main/EUPE-ViT-B.pt")`. The default `weights=Weights.LVD1689M` enum would build a `dl.fbaipublicfiles.com/eupe/...` URL but that returned `403 Forbidden` for me; the HF mirror at `facebook/EUPE-ViT-B` (ungated, 400 MB `.pt` state-dict) is the canonical place and what the README points users to. Pass it as a string and the loader treats it as the URL.
-   - **Architecture.** `DinoVisionTransformer` from `eupe.models.vision_transformer` - same lineage as DINOv2's class. ViT-B/16 at 224² with `embed_dim=768`, `depth=12`, `num_heads=12`. Uses **RoPE position embeddings** (no learned `pos_embed`). Has **4 storage tokens** (Meta's term for register tokens) between CLS and patches - token order is `[CLS, S1..S4, P1..P196]`, i.e. 201 tokens total.
-   - **Feature extraction.** `model.forward_features(x)` returns a dict with `x_norm_clstoken` (B, 768), `x_storage_tokens` (B, 4, 768), `x_norm_patchtokens` (B, 196, 768), `x_prenorm`, and `masks`. We use `x_norm_clstoken` as `cls_vec` and reshape `x_norm_patchtokens` to `(14, 14, 768)` for `patch_grid`. The 4 storage tokens are ignored.
-   - **Attention extraction.** EUPE's `SelfAttention.compute_attention` uses `torch.nn.functional.scaled_dot_product_attention` (SDPA), which **does not return attention weights** - there is no `need_weights=True` knob. A forward hook on the last block's `attn` gives only the attended output, not the QK matrix. We **don't** monkey-patch SDPA; instead, we use a **CLS-cosine-similarity proxy** for `patch_saliency`: each patch's similarity to the CLS vector, softmaxed over the spatial grid. This is a reasonable saliency proxy (a patch that's close to CLS in the final representation is one CLS pooled heavily over) and avoids invasive surgery on the model. DINOv3 uses the real CLS→patch attention via HF transformers `output_attentions=True`, so the two embedders carry slightly different saliency definitions - documented per-embedder in the `_patch_forward` docstring.
-   - **Licence.** FAIR Noncommercial Research Licence v1. We set `license_notice` on the EUPE embedder so the picker shows a warning chip.
-2. **K and HAC affinity α sweep.** On caltech101_s, build region trees at `K ∈ {8, 12, 16}` and `α ∈ {0.3, 0.5, 0.7}` (nine configs). Eyeball overlays of leaf and internal-node boxes on a sampled ~30 images, looking for: leaves that cleanly capture distinct objects/parts, internals that correspond to meaningful unions (whole animal, whole face, etc.), and merges that aren't dominated by background. Pick the best `(K, α)` and lock it in. Done by hand - no need for an automated metric in v1.
-3. **Diversity-tree sanity check.** On caltech101_s, build the diversity tree using CLS-pooled DINOv3 vectors (vs. CLS-pooled SigLIP today) and verify the top-level clusters look semantically sensible (e.g. animals vs. vehicles vs. faces). Pass/fail is "look at the cluster previews and the top-level groupings look right" - not a hard metric.
-
-These all run in a single throwaway script (or notebook), check results visually, then we delete the script.
-
-## ~~V1 - DONE~~
-
-V1 is **shipped** (backend in PR #1248; UI/validation in follow-ups). The design
-body above is the spec; closeout items, all struck through:
-
-- ~~**Gallery-card `best_region.box` outline overlay.**~~ Backend returns
-  `best_region` on result dicts for patch-region datasets (`_cosine_sort`,
-  `train_and_score`); frontend renders a faint outline in grid + list, suppressing
-  the `(0,0,1,1)` full-image fallback.
-- ~~**`Dockerfile.image-embedders` + `scripts/cache_gated_models.sh` off the broken
-  PE-Core AutoModel path.**~~ Both now pre-cache EUPE via `torch.hub.load(...)` into
-  `TORCH_HOME`; `SKIP_DINOV3=1` knob; build wrapped in try/except for no-network.
-- ~~**caltech101_s pre-implementation experiments.**~~ Confirmed the `K=12`, `α=0.5`
-  defaults stand (`_attach_patch_regions` unchanged) and the diversity tree clusters
-  sensibly on CLS-pooled DINOv2. *(Sweep write-up `docs/experiments/hac-tree-sweep/`
-  was removed in the docs cleanup; it lives in git history. Re-run harness:
-  `scripts/run_hac_tree_sweep.py`.)*
-- ~~**FP16 ↔ FP32 rank-stability check.**~~ `TestFp16Fp32RankStability` —
-  worst-case score delta ~1e-3 (< 1e-2 ceiling), zero non-tie rank flips; fp16-on-disk
-  is faithful at v1 scale.
-
-**Open questions:** none — the v1 fp16/fp32 question was answered above.
-
-## ~~V2 - DONE~~
-
-V2 is **shipped**. Region voting on the focus pane via Shift-drag is live (yes-votes
-carry an optional `region_box`, no-votes never do; the `←`/`→` binary fast path is
-byte-for-byte identical to v1). Semantics live under "Vote attribution → v2".
-Closeout, struck through:
-
-- ~~**Backend region plumbing** (PRs #1271–#1273).~~ `LabeledElement.region_box`;
-  `box_to_vote_vector` on-the-fly pooling from `patch_grid`; `POST /vote` accepts
-  `region_box` (400 on no-vote-with-box); training re-pools per pass; round-trips
-  through all four `from_clips_and_votes` call sites + label import.
-- ~~**Frontend region-draw UX** (PRs #1273–#1274).~~ `.region-stage` overlay on
-  `ImageViewerComponent` (Shift = box-draw, 8 handles, zoom/rotate-stable coords);
-  `castVote` sole entry point with the no-timeout sticky "discard & vote no" state;
-  `vote(id, label, regionBox?)` keeps the binary path unchanged.
-- ~~**Test coverage.**~~ Backend `TestRegionBox*`/`TestRegionAwareTraining`/
-  `TestLabel*RegionBox`; frontend specs for coord transform, armed-state, and the
-  vote-API contract.
-
-**Deferred (out of scope for v2):** touch support (no Shift modifier); multiple
-regions per vote; region votes on non-image media types.
-
-## Focus-pane best-match Highlight toggle - DONE
-
-Extends the v1 gallery-card `best_region` outline into the center/focus viewer.
-A **Highlight** toggle sits next to the Marquee button in the image-view controls
-(image media only) and is **hidden unless the active dataset's embedder reports
-`supports_patch_regions`**. When on, the focused image overlays a neutral
-white/black **dashed** "marching ants" box (distinct from the user's solid yellow
-voting box, which keeps the attention color) around the region the detector
-matched best at inference.
-
-No new bookkeeping: reuses the `best_region` the backend already returns on every
-sort/train result and which the frontend already keeps in
-`SortStateService.sortOrder[*].bestRegion` (in-memory, kept exactly as long as the
-score). `CenterPanelComponent` looks the box up by media id and passes it to
-`ImageViewerComponent` as `highlightBox`; the viewer owns the `highlightMode`
-toggle and renders the box in its own `.region-stage` so it tracks pan/zoom/rotate.
-Read-only (`pointer-events: none`), and the near-full `(0,0,1,1)` single-vector
-fallback box is suppressed (same rule as the gallery outline). Frontend-only.
-
-## V3 - design
-
-V3 lets a dataset bind **up to one embedder per role across three
-role types** - a text-capable embedder, a patch-capable embedder, and
-a structural (geometric-verification) embedder - instead of exactly
-one embedder.  Text sort runs against the text embedder; region
-similarity, region voting, and region-aware MLP scoring run against
-the patch embedder; instance retrieval + geometric re-rank run against
-the structural embedder; all bound embedders live side-by-side in the
-pickle.  No dataset is forced to take more than one - a single-embedder
-dataset still works, and a dataset that doesn't benefit from a given
-role simply leaves that slot empty (the only hard rule is that **at
-least one of the three** is set, or there's nothing to sort/search
-against).
-
-The point is to **stop forcing the user to choose** between "good
-text queries" (SigLIP/CLIP), "good region voting + visual quality"
-(DINOv3 patch), and "find this exact instance" (SIFT/VLAD structural).
-Today those are mutually exclusive because the dataset has exactly one
-embedder; in v3 they coexist on the same pickle.  The three roles are
-type-distinct because they ride three independent capability flags -
-`supports_text`, `supports_patch_regions`, and
-`supports_geometric_verification` - and each populates its own per-media
-storage (full-image vectors / `patch_regions` + `patch_grid` /
+**Status:** V1, V2, V3 (the text/patch/structural trio), and the per-detector
+embedder-type lock have all shipped end-to-end. What remains is the open
+follow-ups and unvalidated open questions below. The **V3 design** (dict-keyed
+`media["embeddings"]`, role binding, routing) and the **per-detector
+embedder-type** design are kept in full as the living spec that frames that open
+work; the fully-shipped V1/V2 design bodies are collapsed to one-liners under
+"What shipped".
+
+## Open follow-ups & open questions (remaining work)
+
+Cross-cutting, still open:
+
+- **Cross-dataset Find / CLI-chunk scoring stay on the primary vector.**
+  `find._score_dataset` / `_score_with_cold_detector` (other datasets'
+  `temp_medias`) and `cli._score_medias_with_detectors` (per-chunk subsets)
+  never touch the active `DatasetContext`, so they build the matrix from each
+  media's primary vector rather than calling `routed_embedder` /
+  `keying_embedder_for_snap`. Correct for every single-embedder dataset
+  (primary == score embedder); only matters once a real multi-embedder (trio)
+  dataset is Find-scored. Wire a binding derived from those medias' own embedder
+  names then. (Tracked from 2b.4 and re-surfaced by the per-detector work.)
+- **Trio score-precedence (open question #3) not yet validated on real data.**
+  The score role resolves structural ▸ patch ▸ text everywhere, but it is
+  unproven whether (a) a detector should default to the structural two-stage
+  pipeline when both patch and structural are bound, and (b) the diversity tree
+  should use a *different* preference (patch ▸ structural) than the detector.
+  Now that a patch+structural dataset is creatable, run the spike.
+- **`patch_regions` / `patch_grid` / `local_features` stay singular.** The
+  binding allows at most one patch and one structural embedder, so these are
+  single-valued (owned by that role's embedder) rather than dict-keyed. Only
+  revisit if ">1 patch (or structural) embedder per dataset" ever comes off the
+  non-goals list.
+- **Combine Datasets triple-match guard not added.** `combine_datasets` still
+  guards only on media type, not on the `(text_embedder, patch_embedder,
+  structural_embedder)` triple (a pre-existing latitude — it never checked the
+  single `embedder` either). Harmless until multi-embedder datasets are common;
+  add the strict triple-match refusal (v3 open question #2) then.
+- **NPZ per-embedder layout (`vectors_<name>`) not added.** The `server_files`
+  NPZ importer still carries a single `vectors` array; the per-embedder layout
+  lands with the multi-embed path that would populate it.
+- ~~**Region-less media in a region matrix fall back to the primary vector.**~~
+  **Fixed** (see `comprehensive-audit-2026-07.md`, eighth follow-up pass):
+  `matrix._build_region_arrays` now sources the fallback row from the dataset's
+  patch-slot embedder and raises `ValueError` if absent.
+
+Per-detector embedder-type follow-ups:
+
+- **In-memory primary drift across A→B→A switches.** `DetectorContext.embedder`
+  (the adaptive cache marker) is re-stamped to the dataset's space when the
+  active dataset can't supply the detector's type. The persisted
+  `embedder_type` is untouched and reloaded on next detector load, but within
+  one session a multi-embedder → other-space → back sequence can leave the
+  detector scoring via the *adapted* slot until reload. Exotic; revisit if it
+  bites.
+- **Per-detector diversity tree** and **changing a detector's type after
+  creation** remain out of scope (see the per-detector "Out of scope" below).
+
+V3 open questions (design-level, still unresolved):
+
+1. **Where in the dataset header do the three slots live?** Today's single
+   `dataset.embedder` field probably can't just be renamed without breaking
+   labelset sync. Likely: keep the legacy field as a computed read-only alias to
+   the score-role slot for one release, then drop it. Confirm during impl.
+2. **Combine Datasets ergonomics.** Strict "embedder triple must match" is the
+   v3 rule; if it bites, add a "combine on the text slot only" variant. Punt
+   until real demand.
+3. **Diversity-tree vs score backbone (patch vs structural).** Structural-over-
+   patch for the shared score role is the less obvious call — a structural
+   embedder is a deliberate specialist pick, but its Stage-1 VLAD vector may
+   cluster *worse* than patch for the diversity tree. Two sub-decisions to
+   validate on a real patch+structural dataset: does the detector default to
+   structural two-stage when both are bound, and should the diversity tree use a
+   different preference than the detector? Until then both use the single score
+   precedence.
+4. **Patch + structural coexistence at score time.** Storage and routing support
+   binding both; the open piece is whether a single detector can ever run *both*
+   visual pipelines at once (region max-pool MLP *and* geometric verify) rather
+   than choosing one via score precedence. Out of scope for the first trio cut.
+
+---
+
+## V3 design — the text / patch / structural trio (living spec)
+
+V3 lets a dataset bind **up to one embedder per role across three role types** — a
+text-capable embedder, a patch-capable embedder, and a structural
+(geometric-verification) embedder — instead of exactly one. Text sort runs against
+the text embedder; region similarity / voting / region-aware MLP scoring run against
+the patch embedder; instance retrieval + geometric re-rank run against the
+structural embedder; all bound embedders live side-by-side in the pickle. No dataset
+is forced to take more than one; a dataset leaves unused slots empty (the only hard
+rule is that **at least one of the three** is set).
+
+The point is to **stop forcing the user to choose** between "good text queries"
+(SigLIP/CLIP), "good region voting + visual quality" (DINOv3 patch), and "find this
+exact instance" (SIFT/VLAD structural). The three roles are type-distinct because
+they ride three independent capability flags — `supports_text`,
+`supports_patch_regions`, `supports_geometric_verification` — and each populates its
+own per-media storage (full-image vectors / `patch_regions` + `patch_grid` /
 `local_features`).
 
 ### Schema change
@@ -499,845 +105,316 @@ storage (full-image vectors / `patch_regions` + `patch_grid` /
 The on-disk per-media fields become dicts keyed by embedder name:
 
 ```python
-media["embeddings"]     = {"siglip": ndarray, "dinov3_patch": ndarray, "sift_vlad": ndarray}  # fp16, L2-normalised, one entry per bound embedder (incl. the structural VLAD vector)
-media["patch_regions"]  = [RegionVector, ...]   # the patch embedder's HAC tree (one patch slot, so single-valued)
+media["embeddings"]     = {"siglip": ndarray, "dinov3_patch": ndarray, "sift_vlad": ndarray}  # fp16, L2-normalised, one entry per bound embedder
+media["patch_regions"]  = [RegionVector, ...]   # the patch embedder's HAC tree (single-valued)
 media["patch_grid"]     = ndarray               # (H, W, D) fp16, the patch embedder's grid
-media["local_features"] = StructuralFeatures(...)  # the structural embedder's keypoints + descriptors (one structural slot, so single-valued)
+media["local_features"] = StructuralFeatures(...)  # the structural embedder's keypoints + descriptors (single-valued)
 ```
 
-`media["embeddings"]` is the genuinely multi-valued field (one vector per
-bound embedder, including the structural embedder's Stage-1 VLAD vector).
-`patch_regions` / `patch_grid` / `local_features` stay **single-valued**:
-the binding allows at most one patch and one structural embedder, so keying
-them by name would be a perpetually ≤1-entry dict.  Each is owned by its
-role's bound embedder; dict-keying them is deferred to if "more than one
-patch (or structural) embedder per dataset" ever comes off the non-goals
-list.
+`media["embeddings"]` is the genuinely multi-valued field (one vector per bound
+embedder, including the structural embedder's Stage-1 VLAD vector).
+`patch_regions` / `patch_grid` / `local_features` stay **single-valued**: the
+binding allows at most one patch and one structural embedder, so keying them by name
+would be a perpetually ≤1-entry dict.
 
-The legacy `media["embedding"]` (singular, scalar value) is **dropped
-from the on-disk format** in v3.  Loaders that read an older pickle
-re-key it on the fly:
-
-```python
-media["embeddings"] = {legacy_embedder_name: media.pop("embedding")}
-# patch_regions / patch_grid / local_features stay single-valued and in place;
-# they were already owned by the (single) legacy embedder, which now fills the
-# matching role slot, so there is nothing to re-key.
-```
-
-This is a one-shot read-time migration, not a runtime compat shim.
-After the first save under v3, the legacy singular `media["embedding"]`
-is gone (`embeddings` replaces it).  Per CLAUDE.md ("Backwards
-Compatibility"), we don't keep a parallel `media["embedding"]` mirror.
+The legacy `media["embedding"]` (singular) is **dropped from the on-disk format** in
+v3. Loaders that read an older pickle re-key it on the fly
+(`media["embeddings"] = {legacy_embedder_name: media.pop("embedding")}`) — a one-shot
+read-time migration, not a runtime compat shim. Per CLAUDE.md ("Backwards
+Compatibility") we don't keep a parallel `media["embedding"]` mirror.
 
 ### Dataset binding
 
-Three new fields on the dataset header (the part of the pickle that
-describes the dataset, not the per-media list) - one per role type:
+Three new fields on the dataset header — one per role type:
 
 ```python
-dataset.text_embedder:       str | None   # e.g. "siglip" or "e5" or None
-dataset.patch_embedder:      str | None   # e.g. "dinov3_patch" or None
-dataset.structural_embedder: str | None   # e.g. "sift_vlad" or None
+dataset.text_embedder:       str | None   # e.g. "siglip" / "e5" / None
+dataset.patch_embedder:      str | None   # e.g. "dinov3_patch" / None
+dataset.structural_embedder: str | None   # e.g. "sift_vlad" / None
 ```
 
 Constraints:
 
-- **At least one of the three must be set** (otherwise no
-  sort/search/vote works).  The dataset-create flow enforces this; the
-  per-slot type checks below don't.
-- `text_embedder` must point at an embedder with
-  `supports_text == True`.
-- `patch_embedder` must point at an embedder with
-  `supports_patch_regions == True`.
-- `structural_embedder` must point at an embedder with
-  `supports_geometric_verification == True`.
-- Slots are role-typed; a single-vector embedder (e.g.
-  `dinov2_single`) is eligible for **no** slot (it drives cosine sort /
-  the detector MLP via its primary vector, read directly rather than
-  through a role slot - see Phase 2b.4).
-- A single embedder may legitimately fill more than one slot if it
-  advertises more than one capability (a hypothetical text+patch
-  backbone fills both); each role independently takes the first bound
-  name that advertises that capability.
-- Any combination of the three slots may be filled - that's the new
-  capability v3 unlocks.  The bound embedders run independently at load
-  time; their outputs share nothing on disk.
+- **At least one of the three must be set** (else nothing sorts/searches). The
+  create flow enforces this; per-slot type checks below don't.
+- `text_embedder` must be `supports_text`; `patch_embedder` must be
+  `supports_patch_regions`; `structural_embedder` must be
+  `supports_geometric_verification`.
+- Slots are role-typed; a single-vector embedder (e.g. `dinov2_single`) is eligible
+  for **no** slot (it drives cosine sort / the detector MLP via its primary vector,
+  read directly rather than through a role slot).
+- One embedder may fill more than one slot if it advertises more than one
+  capability. Any combination of the three slots may be filled — that's the new
+  capability v3 unlocks.
 
-`dataset.supports_text` becomes `text_embedder is not None`;
-`dataset.supports_patch_regions` becomes `patch_embedder is not None`;
-`dataset.supports_geometric_verification` becomes
-`structural_embedder is not None`.  The existing
-`MediaEmbedder.supports_*` flags stay - they describe an embedder's
-*capabilities*; the dataset slots record which embedder is *bound* to
-which role.
+`dataset.supports_text` becomes `text_embedder is not None` (and likewise for
+`supports_patch_regions` / `supports_geometric_verification`). The
+`MediaEmbedder.supports_*` flags stay — they describe an embedder's *capabilities*;
+the dataset slots record which embedder is *bound* to which role.
 
 ### Routing rules
 
-The shared **score embedder** (the single vector space the detector MLP,
-diversity tree, and example/by-id cosine sort run against) resolves by
-precedence: **`structural_embedder` if set, else `patch_embedder` if
-set, else `text_embedder`** (`None` for a slot-less single-vector
-dataset, where the matrix layer reads each media's primary vector).  The
-dedicated text / patch / structural roles each use their own slot:
+The shared **score embedder** (the single vector space the detector MLP, diversity
+tree, and example/by-id cosine sort run against) resolves by precedence:
+**`structural_embedder` if set, else `patch_embedder`, else `text_embedder`**
+(`None` for a slot-less single-vector dataset, where the matrix layer reads each
+media's primary vector).
 
 | Operation | Embedder used | Behaviour when slot empty |
 |---|---|---|
-| Text sort (`POST /api/sort`) | `text_embedder` | HTTP 400 + `supports_text: false` (already the v1 behaviour) |
-| Cosine example sort (`POST /api/example-sort`) | score embedder (structural ▸ patch ▸ text) | HTTP 400 if all three are empty |
-| Region similarity / region voting / `region_box` | `patch_embedder` | UI hides Shift-drag region affordance if None |
-| Geometric (instance) verification + Stage-2 re-rank | `structural_embedder` | re-rank skipped (coarse VLAD retrieval only) if None |
-| Diversity tree | score embedder | One tree per dataset; rebuilt when the bound score embedder changes |
+| Text sort (`POST /api/sort`) | `text_embedder` | HTTP 400 + `supports_text: false` |
+| Cosine example sort (`POST /api/example-sort`) | score embedder (structural ▸ patch ▸ text) | HTTP 400 if all three empty |
+| Region similarity / region voting / `region_box` | `patch_embedder` | UI hides Shift-drag affordance |
+| Geometric (instance) verification + Stage-2 re-rank | `structural_embedder` | re-rank skipped (coarse VLAD only) |
+| Diversity tree | score embedder | One tree per dataset; rebuilt when the score embedder changes |
 | Detector MLP scoring | score embedder | Region max-pool when score == `patch_embedder`; two-stage verify when score == `structural_embedder` |
-| Detector MLP training | same embedder as scoring (must match) | - |
-| Gallery `best_region` overlay | `patch_embedder` or `structural_embedder` (whichever drove the score) | Outline absent when neither is set |
+| Detector MLP training | same embedder as scoring | - |
+| Gallery `best_region` overlay | `patch_embedder` or `structural_embedder` (whichever drove the score) | Outline absent when neither set |
 
-The example-sort fallback chain is **only** for image
-uploads - text sort never falls back to the patch/structural embedder,
-because those have no text encoder.  The
-`MediaEmbedder.supports_text` gate already enforces this at request
-time.
+The example-sort fallback chain is **only** for image uploads — text sort never
+falls back to the patch/structural embedder (they have no text encoder); the
+`supports_text` gate enforces this at request time.
 
 ### Detector MLP keying
 
-Today an MLP is keyed by `(detector_id, dataset_id)` and trained on
-whatever vectors the dataset's single embedder produced.  In v3:
+An MLP is keyed by `(detector_id, dataset_id, embedder_name)`, where `embedder_name`
+is the **score** embedder (structural ▸ patch ▸ text) the model was trained against
+— **not** the per-media primary mirror. Consequences:
 
-- An MLP is keyed by `(detector_id, dataset_id, embedder_name)`, where
-  `embedder_name` is the **score** embedder (structural ▸ patch ▸ text)
-  the model was trained against - **not** the per-media primary mirror,
-  which diverges from the scored space on a multi-embedder dataset.
-  (Shipped in Phase 2b.5 via the canonical `score_marker_embedder`; see
-  "V3 - implementation status".)
-- A detector that ran against `siglip` on a v2-era dataset stays
-  valid post-migration - its embedder_name is the pre-migration
-  embedder.
-- Switching the bound score embedder (e.g. adding a `patch_embedder` or
-  `structural_embedder` to a previously text-only dataset) doesn't
-  invalidate existing MLPs keyed to the old embedder; the new
-  embedder-keyed MLP is trained fresh from the existing votes the next
-  time the user runs Learned sort.  Votes are embedder-agnostic
-  (they're `(media_id, label, region_box?)`), so they re-use cleanly.
-- A structural-keyed detector carries **two** learned objects (the
-  Stage-1 retrieval MLP on VLAD vectors + the match-statistic
-  verification classifier); both are re-derived from votes and never
-  persisted, exactly as in the structural-embedder v1 design.
+- A detector that ran against `siglip` on a v2-era dataset stays valid
+  post-migration (its embedder_name is the pre-migration embedder).
+- Switching the bound score embedder doesn't invalidate MLPs keyed to the old one;
+  the new embedder-keyed MLP is trained fresh from the existing votes on the next
+  Learned sort. Votes are embedder-agnostic (`(media_id, label, region_box?)`), so
+  they re-use cleanly.
+- A structural-keyed detector carries two learned objects (Stage-1 retrieval MLP on
+  VLAD vectors + the match-statistic verification classifier); both re-derive from
+  votes and are never persisted.
 
 ### Loader / exporter / importer impact
 
-- **Pickle loaders** (`loader_pickle.py`, `loader_folder.py`) run
-  every bound embedder during ingest (already generalised to a set in
-  Phase 2b.3).  Each writes its own vector into `media["embeddings"]`;
-  the patch embedder additionally writes `patch_regions` / `patch_grid`,
-  and the structural embedder writes `local_features`.  The passes share
-  dataset I/O (one file open per media) but run their forwards
-  independently.
-- **`ConcurrencyGate`** (`load_pipeline.py`) gates embed work; v3's
-  bound embedders count as that many embed phases for the same dataset.
-  Net effect: a multi-embedder dataset takes proportionally longer to
-  ingest, gated under the same `_embed_gate` limit.
-- **Dataset pickle schema version** bumps.  Old pickles still load
-  via the read-time re-key; saving from v3 always writes the new
-  schema.
-- **NPZ paths-file (server_files importer)** today carries one
-  `vectors` array per media.  In v3 it grows an optional
-  `vectors_<embedder_name>` per-embedder layout; the existing
-  single-`vectors` layout maps to the dataset's score-role slot
-  (structural ▸ patch ▸ text).
-- **Combine Datasets importer**: input pickles must have identical
-  `(text_embedder, patch_embedder, structural_embedder)` triples to
-  combine.  We refuse the combine with a clear error otherwise - no
-  partial-overlap reconciliation in v3.
+- **Pickle loaders** run every bound embedder during ingest; each writes its own
+  vector into `media["embeddings"]`, the patch embedder additionally writes
+  `patch_regions` / `patch_grid`, the structural embedder writes `local_features`.
+- **`ConcurrencyGate`** (`load_pipeline.py`) gates embed work; a multi-embedder
+  dataset takes proportionally longer, gated under the same `_embed_gate` limit.
+- **Dataset pickle schema version** bumps; old pickles load via the read-time re-key.
+- **NPZ paths-file** grows an optional `vectors_<embedder_name>` layout; the existing
+  single-`vectors` layout maps to the score-role slot. (Open follow-up.)
+- **Combine Datasets** requires identical
+  `(text_embedder, patch_embedder, structural_embedder)` triples. (Guard is an open
+  follow-up.)
 
 ### Frontend
 
-- **Dataset-create flow**: today's single embedder picker becomes
-  **three independent pickers** - "Text embedder", "Patch embedder",
-  and "Structural embedder" - each defaulted to None and filtered by
-  its role-typed capability list (`supports_text` /
-  `supports_patch_regions` / `supports_geometric_verification`).  The
-  user may pick one (or leave empty) per picker; the form rejects
-  submission only when **all three are empty**.  The license-notice
-  chip surfaces on whichever picker shows an embedder with one.
-- **Sort bar** continues to read `dataset.supports_text` /
-  `supports_patch_regions` (+ now `supports_geometric_verification`) -
-  no per-component change.
-- **Embedder picker page** (admin-ish): no shape change; embedder
-  cards already list the three `supports_*` capability flags.
-- **Region-vote UI**: unchanged from v2 once the routing wires up;
-  Shift-drag continues to work whenever `dataset.patch_embedder` **or**
-  `dataset.structural_embedder` is set (for structural the box defines
-  the match template - see structural-embedder.md).
+- **Dataset-create flow** (design): three independent role pickers (Text / Patch /
+  Structural), each defaulted None and filtered by its capability list; submission
+  rejected only when all three empty. **Shipped as an additive variant instead** —
+  see the Phase 3 note under "What shipped".
+- **Sort bar** reads `dataset.supports_text` / `supports_patch_regions`
+  (+ `supports_geometric_verification`) — no per-component change.
+- **Region-vote UI**: unchanged from v2; Shift-drag works whenever
+  `dataset.patch_embedder` **or** `dataset.structural_embedder` is set.
 
 ### Migration
 
-Per-dataset migration is one-time and automatic at first load under
-v3:
-
-1. Read legacy `dataset.embedder: str` and `media["embedding"]:
-   ndarray`.
-2. Role-type the legacy embedder into its matching slot, leaving the
-   others `None`: `supports_text` → `text_embedder`,
-   `supports_patch_regions` → `patch_embedder`,
-   `supports_geometric_verification` → `structural_embedder`.  (A
-   dual-capability legacy embedder fills every slot it qualifies for.)
-3. Re-key per-media fields as in "Schema change".
-4. Mark the dataset as v3-schema in memory; the next save writes the
-   new format.
-
-There is **no in-place "add a second embedder to an existing dataset"
-flow** in v3.  Same rule as v1: changing or adding an embedder
-requires re-import.  This is consistent with the "Per-dataset
-embedder model" rule today and avoids the partial-embedding
-inconsistency window.
+Per-dataset, one-time, automatic at first load under v3: read legacy
+`dataset.embedder` + `media["embedding"]`; role-type the legacy embedder into its
+matching slot(s) by capability, leaving the others `None`; re-key per-media fields;
+mark the dataset as v3-schema so the next save writes the new format. There is **no
+in-place "add a second embedder to an existing dataset" flow** — same rule as v1:
+changing/adding an embedder requires re-import.
 
 ### Out of scope for v3
 
-- **>1 embedder of the same role per dataset** (two text, two patch, or
-  two structural embedders).  A user wanting two text embedders
-  re-imports under a separate dataset.  The schema (`embeddings` dict
-  keyed by name) is forward-compatible with this, but the binding rules
-  (`text_embedder: str | None`, etc.) intentionally aren't.  Binding
-  one of *each* role (text + patch + structural) **is** in scope - that
-  is the trio v3 unlocks.
-- **In-place add-an-embedder on a loaded dataset.**  Same re-import
-  rule as v1.
-- **Cross-embedder MLP transfer.**  An MLP trained against `siglip`
-  is not reused against `dinov3_patch`; training restarts from the
-  existing vote pile.
-- **Embedding diff / freshness checks.**  We don't ship a "the
-  pickle has a stale embedder version" check - embedder weights are
-  versioned by HF revision, and re-import covers any case where the
-  user wants newer weights.
+- **>1 embedder of the same role per dataset** (two text/patch/structural). The
+  `embeddings` dict is forward-compatible with it, but the `str | None` binding
+  rules intentionally aren't. Binding one of *each* role **is** in scope.
+- **In-place add-an-embedder on a loaded dataset** (same re-import rule).
+- **Cross-embedder MLP transfer** (an MLP trained against `siglip` is not reused
+  against `dinov3_patch`; training restarts from the vote pile).
+- **Embedding diff / freshness checks** (embedder weights are versioned by HF
+  revision; re-import covers newer weights).
 
-### Open questions (v3)
+---
 
-1. **Where in the dataset header do the three slots live?**  Today's
-   single `dataset.embedder` field probably can't just be renamed
-   without breaking labelset sync.  Most likely: keep the legacy field
-   as an alias to whichever slot the score role resolves to (read-only,
-   computed) for one release, then drop it.  To be confirmed during
-   impl.
-2. **Combine Datasets ergonomics.**  Strict "embedder triple must
-   match" is the v3 rule, but if it bites enough users in practice
-   we may want a "combine on the text slot only" variant.  Punt
-   until we see real demand.
-3. **Diversity-tree + score backbone preference (patch vs structural).**
-   The routing table resolves the shared score role as structural ▸
-   patch ▸ text.  Patch-over-text rests on patch backbones (DINO/EUPE)
-   clustering images more semantically than text backbones (SigLIP);
-   **structural-over-patch is the less obvious call** - a structural
-   embedder is a deliberate specialist pick, so if it's bound we treat
-   instance verification as the intended detector behaviour, but its
-   Stage-1 VLAD vector may cluster *worse* than patch for the diversity
-   tree.  Two sub-decisions to validate on a real patch+structural
-   dataset before locking in: (a) does the detector default to the
-   structural two-stage pipeline when both are bound, and (b) should the
-   diversity tree use a *different* preference (patch ▸ structural)
-   than the detector?  Until then, both use the single score precedence
-   above.
-4. **Patch + structural coexistence at score time.**  Storage and the
-   per-role routing already support binding both; the open piece is
-   whether a single detector can ever run *both* visual pipelines at
-   once (region max-pool MLP *and* geometric verify) rather than
-   choosing one via the score precedence.  Out of scope for the first
-   trio cut; the score precedence picks exactly one.
+## Per-detector embedder type (living spec)
 
-### V3 work plan (sketch)
+**Status: SHIPPED** (first as a per-detector primary *name*, then revised to a
+*type* lock). Each detector locks one embedder **type** at create time —
+`semantic` / `patch_semantic` / `structural` (the buckets of
+`vtscore/embedding/binding.py::embedder_type`) — and trains/scores in whichever
+*concrete* embedder of that type the active dataset binds, overriding the
+dataset-level score precedence (V3 Phases 2b.4/2b.5/2d) for **detector** operations.
 
-Filled in when we start, just like the v2 plan was a punchlist
-during impl.  Rough size estimate: backend ~2× v2 (schema +
-loader + per-embedder MLP keying), frontend ~0.5× v2 (the three
-role pickers on dataset-create).  No new ML algorithms - v3 is
-plumbing, not modelling (the structural pipeline itself already
-shipped per structural-embedder.md; v3 only adds its third binding
-slot + routing).
+### Motivation & model
 
-### V3 - implementation status
+V3 resolves the score embedder as a **dataset-level** property by precedence, so
+every detector on a dataset scores in the *same* space. On a multi-embedder (trio)
+dataset that's wrong: the whole point of binding more than one embedder is that
+different detectors want different spaces (a "find this exact logo" detector wants
+structural; a "sunset mood" detector wants text/patch). So the choice moves from the
+dataset to the **detector**: each detector locks one embedder type at creation, and
+training + scoring *that detector* run in *that* type's space. Text sort is
+unaffected — `POST /api/sort` always runs against the dataset's text slot,
+independent of the active detector.
 
-V3 lands as a sequence of behavior-preserving substrate phases (so each
-commit is reviewable and the single-embedder world keeps working) followed by
-the user-visible binding.  Ordering is by dependency: each phase needs the one
-above it.  **Status: Phases 2a-2c shipped (the singular mirror is gone;
-``media["embeddings"]`` is the sole per-media vector store), the ``structural``
-binding slot + routing role shipped, and the create-time trio picker shipped
-(additive variant — see "Phase 3" below).  A real text + patch + structural
-dataset can now be created end-to-end.  Remaining work is the smaller
-follow-ups under "Open follow-ups" plus the **per-detector primary embedder**
-design (each detector picks its own scoring space, superseding the
-dataset-level score precedence for detector operations) — see
-"Per-detector primary embedder (design)" below.**
+### What shipped (revised to embedder *type* — authoritative)
 
-**Shipped:**
+- **Taxonomy.** `binding.py::embedder_type(name)` classifies every embedder into
+  exactly one of three buckets, precedence `structural ▸ patch_semantic ▸ semantic`:
+  `structural` = `supports_geometric_verification` (sift_vlad); `patch_semantic` =
+  `supports_patch_regions` (dinov2/3_patch, eupe_patch, face); `semantic` = every
+  global single-vector embedder (siglip, clip, clap, e5, dinov2_single, ast, …),
+  text-capable or not. The buckets partition the registry (no embedder sets more
+  than one flag). `dataset_supplied_types`, `embedder_of_type`, and
+  `detector_dataset_compatible` build on it.
+- **Persisted form.** The detector JSON carries `embedder_type` (one of the three),
+  not a concrete name. `DetectorContext.embedder_type` is the immutable lock;
+  `DetectorContext.embedder` stays the adaptive concrete cache marker. Legacy
+  detectors with a `primary_embedder` name are migration-read via
+  `detector_embedder_type_from_data` (classify the old name → type).
+- **Resolution at create.** `resolve_detector_embedder_type` accepts an **explicit**
+  type as long as it's one of the three valid types — regardless of whether the
+  active dataset binds it (only an unrecognized string is rejected). An **empty**
+  request auto-resolves against the *types the active dataset supplies*: one type →
+  auto-select; multiple → the client must choose (400 listing options); none / no
+  dataset → empty (resolved at first train). The new-detector modal's **Detector
+  Embedder Type** dropdown lives in an always-visible, collapsed **Advanced** section
+  on both the blank and Trained tabs and offers all three types (a detector can be
+  created before any dataset exists). Displayed type defaults to the dataset's
+  primary supplied type (else Semantic). Picking a type the active dataset can't
+  supply is allowed — the detector just gates incompatible there, with an inline
+  heads-up.
+- **Compatibility gate (the substantive change).** A detector is compatible with a
+  dataset iff same `media_type` **and** the dataset binds an embedder of the
+  detector's type. Find-label refuses an incompatible pair (409); Auto-Find silently
+  skips incompatible detectors. All detector-scoped training/scoring funnels through
+  one resolver, `keying_embedder_for_snap(det_ctx, snap)` (the dataset's concrete
+  embedder of the detector's type, else the score precedence), so switching between
+  two same-type datasets re-derives the MLP in the new space (SigLIP→CLIP;
+  DinoV2→DinoV3, with region boxes re-pooled against the new grid by
+  `box_to_vote_vector`). The frontend gates the same pairs via `embedder_types` on
+  the dataset registry entry and `embedder_type` on the detector entry
+  (`utils/context-compat.ts`). Single-embedder datasets are byte-for-byte unchanged.
 
-- **Phase 2a - per-media accessor substrate.** `vtscore/embedding/media_vectors.py`:
-  `media["embeddings"]` (dict keyed by embedder name) is the forward
-  representation; the singular `media["embedding"]` is kept as the *primary
-  mirror / fallback* so the ~50 not-yet-converted read sites stay valid while
-  only one embedder is bound.  `embed_missing` writes through
-  `set_media_embedding`; the `matrix.py` chokepoint reads through
-  `media_embedding`.
-- **Phase 2b.1 - matrix layer made embedder-aware.** `get_embedding_matrix`,
-  `get_embedding_submatrix`, and `get_embedding_matrix_for_snap` take an
-  optional `embedder_name`.  Unset → the cached primary path (byte-for-byte the
-  old behaviour).  Set → a fresh, uncached matrix built from that bound
-  embedder's vectors via the accessor.  This is the aggregate read chokepoint
-  every consumer (sorting / scoring / find / projection / training /
-  positives-browse) funnels through, so routing can later request the right
-  embedder per operation.
-- **Phase 2b.2 - dataset binding (in-memory).** `DatasetContext` gains
-  `text_embedder` / `patch_embedder` slots plus derived `supports_text` /
-  `supports_patch_regions` properties (today there is no dataset-level embedder
-  field at all; the embedder is recorded per-media).  By default the pair is
-  *derived* on demand from the dataset's medias - the single embedder a pre-v3
-  dataset was loaded with, role-typed against its capability flags by
-  `vtscore.embedding.binding.derive_binding`.  `bind_embedders()` sets an
-  explicit, validated pair for genuinely multi-embedder datasets (overrides the
-  derivation).  This is *in-memory only*: no pickle/registry/meta schema change,
-  no routing rewire, no frontend.  Persistence rides along with the loader
-  multi-embed slice (2b.3), where a real second vector exists to persist; the
-  documented `meta["embedder"]` → slot migration lands there.
-- **Phase 2b.3 - loader multi-embed.** The embed stage
-  (`vtscore/datasets/stages/embedding.py`) now runs the *set* of bound
-  embedders, not a single one: `_embed_missing_stage` resolves an ordered
-  embedder list via `_ordered_load_embedders` (the create-time pick leads,
-  followed by any embedders already present on the medias for the reload
-  back-fill) and calls `embed_missing` once per name.  `embed_missing`'s
-  "missing" and patch/structural back-fill detection are keyed to *that*
-  embedder's per-media vector (via `media_embedding(m, name)`) when a name is
-  given, so a second bound embedder embeds items the first already covered
-  without disturbing them; a bare default-resolution call keeps the legacy
-  "embed only the un-embedded" contract.  The binding derives from the full
-  set of embedder names present (`media_embedder_names` →
-  `derive_binding_from_names`), so a reloaded text+patch dataset recovers both
-  slots, not just the recorded primary.  Persistence rides along:
-  `export_dataset_to_file` serialises `media["embeddings"]` (one entry per
-  bound embedder) and records the role-typed slots in `meta`
-  (`text_embedder` / `patch_embedder`); the pickle loader re-keys the dict on
-  load, and a legacy single-vector pickle materialises its dict from the
-  singular mirror via `ensure_embeddings_dict`.  `patch_regions` / `patch_grid`
-  stay singular (the binding allows only one patch embedder, so per-embedder
-  keying would be a ≤1-entry dict); dict-keying them is deferred to whenever a
-  second patch slot is actually allowed.  See "Open follow-ups".
-
-- **Phase 2b.4 - routing.** `DatasetContext.routed_embedder(role)` is the one
-  place that encodes the routing table: ``"text"`` → text slot (else the caller
-  400s), ``"patch"`` → patch slot, ``"score"`` → patch-else-text (else ``None``).
-  Each active-dataset consumer resolves its role and threads the name into the
-  embedder-aware matrix layer: text sort (`/api/sort`, role text), example /
-  by-id cosine sort (`/api/example-sort`, role score), label-file sort (embeds
-  *and* scores with the score embedder so they share a space), the detector MLP
-  (`_score_all_media`, `_build_vote_xy`, `train_and_threshold` safe-scoring, the
-  labelset embed name, and Auto-Find scoring), and the diversity tree /
-  projection (full + subset + load-stage + positives-browse).  The query side is
-  routed too: example/by-id sort embeds the example with the score embedder, and
-  text sort embeds the query with the text slot.  **Single-vector gap handled:**
-  a `*_single` embedder binds neither slot, so `score` resolves to ``None`` and
-  the matrix layer reads the primary vector (cosine sort / MLP scoring keep
-  working rather than 400-ing).  **Cache preserved:** a routed name equal to the
-  dataset's primary collapses to the cached primary path
-  (`matrix._collapse_to_primary`), so the single-embedder hot path is
-  byte-for-byte unchanged.  Region-aware cosine scoring is gated on the resolved
-  embedder being the patch embedder, so a text query on a dual dataset scores
-  against the text embedder's full-image vectors, not the patch tree.  See "Open
-  follow-ups" for the cross-dataset Find / CLI-chunk scoring still on primary.
-
-- **Phase 2b.5 - MLP keying.** The cached detector MLP (`DetectorContext.model`)
-  is now keyed to the **score embedder** (patch-else-text; the v3 routing table),
-  not the per-media singular `media["embedder"]` mirror.  A single canonical
-  marker resolver - `vtscore.embedding.binding.score_marker_embedder` (and its
-  `*_for_snap` sibling) - returns `patch or text or primary`, where the primary
-  *name* is the slot-less single-vector fallback so the marker is always a
-  concrete string to stamp on / compare against `DetectorContext.embedder`.
-  Every site that writes the marker (`learned_sort.update_det_ctx_with_trained_model`,
-  `workflow.apply_and_retrain`, `labelset_training.populate_label_embeddings`,
-  `embedder_sync`) and every site that computes the "new embedder" to compare it
-  against (`dataset_sync._embedder_of_active_dataset`, `model_loading`'s
-  Auto-Find defensive check, `embedder_sync.active_dataset_embedder_name`) now
-  routes through that one helper, so `invalidate_detector_model_on_embedder_mismatch`,
-  `_maybe_clear_cache_on_embedder_switch`, and `maybe_start_label_reembed` all
-  compare apples-to-apples.  **Effect:** keying by the embedder *name* (which
-  fully determines the vector space; votes re-derive from the dataset-agnostic
-  labelset) is sufficient for the `(detector, dataset, embedder)` key - a stale
-  cross-space MLP is dropped and retrained on any switch where the score
-  embedder changes.  Byte-for-byte unchanged for every single-embedder dataset
-  (there score-marker == primary); the only behavior change is on a dual
-  dataset, where the primary mirror (text) and the scored space (patch) differ -
-  previously the stale text-keyed MLP would survive a switch onto the patch
-  scoring space.  The cross-dataset Find / cold-train path
-  (`model_loading.resolve_or_train_detector`, lines that build `md5_to_emb` from
-  the primary `c["embedding"]`) is deliberately left on the primary vector - it
-  pairs both the in-snap vectors and the origin-resolved vectors in the same
-  primary space, so it stays self-consistent; wiring it to the score embedder is
-  the cross-dataset-Find follow-up already tracked under "Open follow-ups (from
-  2b.4)".
-
-- **Phase 2c - drop the singular mirror.** The legacy `media["embedding"]`
-  primary mirror is gone: `media["embeddings"]` (the per-embedder dict) is the
-  sole vector store.  Every read site routes through the `media_embedding`
-  accessor (which no longer falls back to the singular key); `set_media_embedding`
-  writes only the dict; every media-creation site builds `media["embeddings"]`
-  (an empty dict for deferred embeds, `{name: vec}` when the vector is known);
-  and the pickle exporter writes only `embeddings`.  Old single-vector pickles
-  still load: `ensure_embeddings_dict` (run on load) re-keys their singular
-  vector into the dict and drops the singular key, so the migration is
-  read-time and one-way.  Behavior is byte-for-byte unchanged for every
-  single-embedder dataset (the dict has one entry, which is what the primary
-  mirror used to hold).
-
-- **Phase 2d - structural binding slot + routing role.** The role-typed
-  binding is now a `(text, patch, structural)` triple end to end:
-  `derive_binding` / `derive_binding_from_names` return the triple,
-  `validate_binding` checks the structural slot against
-  `supports_geometric_verification`, `DatasetContext` grows a
-  `structural_embedder` slot + `supports_geometric_verification` property + a
-  `"structural"` routing role, and the score precedence in `routed_embedder`,
-  `score_marker_embedder`, and `training._score_embedder_for_snap` became
-  **structural ▸ patch ▸ text**.  The loader meta records the structural slot.
-  Behavior-preserving for every existing single/dual-embedder dataset (the
-  triple's third element is `None` there).
-
-- **Phase 3 - create-time trio picker (additive).** A real text + patch +
-  structural dataset can now be created.  The load pipeline accepts an
-  `embedders` list (`_embed_missing_stage` / `_ordered_load_embedders` take the
-  list; `_run_origin_load_in_background` gains an `embedders` param); the import
-  routes (generic importer, demo, server-folder, local-folder/files) parse the
-  trio (JSON array on JSON bodies, JSON-array string on multipart) with the
-  primary picker's choice leading the embed order.  Media payloads
-  (`/api/medias/ids`, `/api/medias/batch`) expose the full bound-embedder set
-  under `embedders`, and the frontend capability surface (text-sort gate,
-  region-overlay toggle, structural marquee) ORs across the whole trio via
-  `EmbedderCapabilityService.supports*Any` rather than reading the single
-  primary.
-
-  **Design deviation (deliberate).** The v3 "Frontend" design said the single
-  embedder picker is *replaced* by three role pickers (Text / Patch /
-  Structural), rejecting submission only when all three are empty.  We shipped
-  an **additive** variant instead: the existing primary picker is unchanged
-  (any embedder, including single-vector ones like `dinov2_single` that fill no
-  role slot — these would be *unpickable* under the strict three-role design,
-  a regression), and two **optional** role pickers (Region embedder / Instance
-  embedder) appear under Advanced to bind a patch and/or structural embedder
-  alongside the primary.  This is zero-regression, preserves single-vector
-  selection, and avoids a risky rip-and-replace of the well-tested importer
-  modal.  The shared `vt-import-advanced` component carries the two optional
-  selects, so all four import flows gained them at once.
-
-### Open follow-ups (from 2b.4)
-
-- **Cross-dataset Find and CLI-chunk scoring stay on the primary vector.**
-  `find._score_dataset` / `_score_with_cold_detector` score *other* datasets'
-  `temp_medias`, and `cli._score_medias_with_detectors` scores per-chunk
-  subsets - neither is the active `DatasetContext`, so they keep building the
-  matrix from each media's primary vector (no `routed_embedder` call).  This is
-  correct for every single-embedder dataset (primary == score embedder) and
-  only matters once a multi-embedder (trio) dataset can be created and
-  Find-scored; wire a binding derived from those medias' own embedder names when
-  the create-time three-role picker lands.
-- ~~**Region-less media in a region matrix fall back to the primary vector.**~~
-  **Fixed** (`docs/plans/comprehensive-audit-2026-07.md` → eighth follow-up
-  pass). `matrix._build_region_arrays` now sources a region-less media's
-  fallback row from the dataset's patch-slot embedder (derived from a
-  region-bearing media via `derive_binding_from_names`), not unconditionally
-  the primary; raises `ValueError` if that media has no vector under the
-  patch embedder either. Byte-for-byte unchanged when every media shares one
-  embedder.
-
-### Open follow-ups (from 2b.3)
-
-- ~~**No create-time path to bind multiple embedders yet.**~~ **Done (Phase
-  3).** The create flow threads an `embedders` list into the load pipeline and
-  the additive trio picker binds it; the structural slot + routing role landed
-  in Phase 2d.
-- **Trio score-precedence open question (#3) not yet validated on real data.**
-  The score role resolves structural ▸ patch ▸ text everywhere, but design
-  open question #3 (does the detector default to the structural two-stage
-  pipeline when both patch and structural are bound, and should the diversity
-  tree use a *different* preference than the detector?) is still unvalidated on
-  a real patch+structural dataset.  Now that such a dataset is creatable, run
-  the spike.
-- **`patch_regions` / `patch_grid` / `local_features` stay singular.** The
-  binding allows at most one patch and one structural embedder, so these remain
-  single-valued (owned by that role's embedder) rather than dict-keyed.  Only
-  revisit if "more than one patch (or structural) embedder per dataset" ever
-  comes off the v3 non-goals list.
-- **Combine Datasets triple-match guard not added.** `combine_datasets` still
-  guards only on media type, not on the `(text_embedder, patch_embedder,
-  structural_embedder)` triple (a pre-existing latitude — it never checked the
-  single `embedder` either).  Since nothing can create a multi-embedder dataset
-  yet, this is harmless today; add the strict triple-match refusal (v3 design
-  open question #2) when the picker lands.
-- **NPZ per-embedder layout (`vectors_<name>`) not added.** The `server_files`
-  NPZ importer still carries a single `vectors` array; the per-embedder layout
-  in "Loader / exporter / importer impact" lands with the create-time
-  multi-embed path that would populate it.
-
-## Per-detector embedder type (design)
-
-**Status: SHIPPED, then revised to a *type* lock.** Each detector locks one
-embedder **type** at create time — `semantic` / `patch_semantic` / `structural`
-(the buckets of `vtscore/embedding/binding.py::embedder_type`) — and
-trains/scores in whichever *concrete* embedder of that type the active dataset
-binds, overriding the *dataset-level* score precedence that shipped in V3
-(Phases 2b.4 / 2b.5 / 2d) for **detector** operations.
-
-> **Revision (type, not name).** This section was first written and shipped
-> with each detector locking a concrete primary embedder **name** (`siglip`,
-> `dinov3_patch`) and a compatibility rule of *exact-name match*. That was the
-> wrong granularity: a detector's persisted artifact is its labels/votes (and,
-> for patch detectors, normalized region boxes), and the "No Persisted Vectors
-> or MLPs" rule re-derives the MLP against whatever embedder the active dataset
-> supplies — so the labels are portable across any embedder of the **same
-> type** (SigLIP↔CLIP, DinoV2↔DinoV3). The shipped behavior now locks the
-> **type** and gates compatibility on *same-type*, not same-name. Read the
-> name-based prose below as the original motivation; the **What shipped /
-> Open follow-ups** close-out at the end of this section is authoritative for
-> current behavior.
-
-See "What shipped" and "Open follow-ups" at the end of this section for the
-close-out and the deviations from the name-based design below.
-
-### Motivation
-
-Shipped V3 resolves the "score embedder" - the single vector space the
-detector MLP trains and scores against - as a **dataset-level** property,
-by precedence (`routed_embedder("score")` = structural ▸ patch ▸ text).
-Every detector run against a given dataset therefore scores in the *same*
-space, whichever the precedence picks.  On the rare multi-embedder (trio)
-dataset that's wrong: the whole point of binding more than one embedder is
-that **different detectors want different spaces**.  A "find this exact
-logo" detector wants the structural embedder; a "pictures with a sunset
-mood" detector on the same dataset wants the text/patch embedder.  Forcing
-both through one dataset-wide precedence defeats the trio.
-
-So the choice moves from the dataset to the **detector**: each detector
-picks **one primary embedder** at creation, and training + scoring *that
-detector* run in *that* space.  The same dataset hosts many detectors, each
-with its own primary.  We will hardly ever bind the full trio, but when we
-do, this is what makes it useful.
-
-### The model
-
-- **A detector binds exactly one primary embedder**, chosen explicitly at
-  create time (see "How the primary is chosen").  It is the vector space the
-  detector's MLP is trained and scored in - nothing more, nothing less.
-- **Training detector D uses only D's primary.**  `_build_vote_xy`,
-  `_score_all_media`, the safe-threshold scoring pass, Auto-Find scoring,
-  the labelset embed name, and the diversity/positives-browse view *for that
-  detector* all route through `D.primary_embedder` instead of the active
-  dataset's `routed_embedder("score")`.
-- **Text sort is unaffected.**  `POST /api/sort` (text query) always runs
-  against the dataset's **text** slot (`routed_embedder("text")`),
-  independent of which primary the active detector picked.  A text query has
-  no meaning in a non-text space, and the dataset - not the detector - owns
-  the text encoder.  This is the one operation that stays dataset-routed.
-- **Multiple detectors, multiple primaries, one dataset.**  The dataset
-  keeps all its bound embedders' vectors side-by-side in
-  `media["embeddings"]` (already the V3 schema).  Detector A scoring in
-  `dinov3_patch` and detector B scoring in `sift_vlad` read different keys of
-  the same dict; nothing on disk is shared between them beyond the medias.
-
-### Schema change
-
-The choice is a persisted **name**, not a vector or MLP, so it's fully
-compatible with CLAUDE.md's "No Persisted Vectors or MLPs" rule.
-
-- **Detector JSON** (`data/detectors/<name>.json`, written by
-  `vtsearch/routes/detectors/crud.py::create_detector` /
-  `_write_detector`) gains a top-level `primary_embedder: str` field next to
-  `media_type` / `examples`.  Absent on legacy files → resolved at load by the
-  migration below.
-- **`DetectorCreateRequestSchema`** (`vtsearch/schemas/detectors.py`) gains
-  `primary_embedder = fields.String(load_default="")`.  Empty means "let the
-  server pick" (single-embedder dataset, or legacy clients); a concrete name
-  is validated against the active dataset's bound embedders.
-- **`DetectorContext.embedder`** stops being a *derived marker* stamped from
-  the dataset precedence and becomes the *authoritative* per-detector primary,
-  loaded from the JSON field.  Its slot, type (`str`), and role as the
-  `(detector, dataset, embedder)` MLP cache key are unchanged - only its
-  *source* changes (explicit field vs. `score_marker_embedder(first)`).
-
-### How the primary is chosen
-
-**Explicit at create time.**  No auto-default-by-precedence; the precedence
-only survives as the *legacy migration* fallback (below) and as the implicit
-single-option case.
-
-- On a **single-embedder dataset** (the overwhelmingly common case) there is
-  exactly one bound embedder, so the create flow auto-selects it - the picker
-  is hidden, or shown pre-filled and disabled.  Zero friction; identical UX to
-  today.
-- On a **multi-embedder dataset** the new-detector modal shows a required
-  picker listing the dataset's bound embedder names (the keys of
-  `media["embeddings"]`, equivalently every name role-typed by
-  `derive_binding_from_names`, **including** single-vector embedders like
-  `dinov2_single` that fill no role slot - they are still valid scoring
-  spaces).  The user must pick one; submission is rejected if the pick isn't
-  one of the dataset's bound embedders.
-
-The eligible set is "every embedder this dataset actually has vectors for",
-which is broader than the three *role* slots: the role slots are
-capability-typed (text/patch/structural), but a detector's primary is just
-"which vector space do I score in", and any bound embedder qualifies.
-
-### Routing
-
-| Operation | Embedder used (NEW) | vs. shipped V3 |
-|---|---|---|
-| Text sort (`POST /api/sort`) | dataset `text` slot | unchanged |
-| Detector MLP train + score | **active detector's `primary_embedder`** | was dataset score precedence |
-| Learned-sort / Auto-Find / safe-threshold scoring | active detector's primary | was dataset score precedence |
-| Positives-browse / diversity view *of a detector* | active detector's primary | was dataset score precedence |
-| Region similarity / region voting | dataset `patch` slot | unchanged (patch role is dataset-owned) |
-| Geometric verification | dataset `structural` slot | unchanged |
-| Example / by-id cosine sort, **no active detector** | dataset score precedence | unchanged |
-| Diversity tree of the **raw dataset** (no detector) | dataset score precedence | unchanged |
-
-The single substantive change is that the detector-scoped scoring paths read
-`det_ctx.embedder` (now the explicit primary) instead of calling
-`get_active_context().routed_embedder("score")`.  Because
-`det_ctx.embedder` is fed straight into the same embedder-aware matrix layer,
-and a name equal to the dataset's primary still collapses to the cached
-primary path, **every single-embedder dataset is byte-for-byte unchanged** -
-the detector's primary *is* the dataset's only embedder there.
-
-### MLP keying simplifies
-
-The `(detector, dataset, embedder)` key and the invalidation machinery
-(`invalidate_detector_model_on_embedder_mismatch`,
-`_maybe_clear_cache_on_embedder_switch`, `maybe_start_label_reembed`) are
-unchanged in shape, but their `embedder` component gets *simpler*:
-
-- The marker is now just `det_ctx.embedder` (the explicit primary), not the
-  resolved `score_marker_embedder(first)` (dataset precedence over the snap).
-- `update_det_ctx_with_trained_model` (`learned_sort.py`) and
-  `workflow.apply_and_retrain` stop *computing* the marker from the snap and
-  instead **read** it off the detector - the primary is decided at create
-  time, not re-derived every train.
-- `score_marker_embedder` / `score_marker_embedder_for_snap` survive only for
-  the legacy-migration fallback and the cross-dataset cold-train path
-  (`model_loading.resolve_or_train_detector`), which still works in the
-  primary vector space of the medias it's about to score.
-
-The invalidation semantics are exactly right under this model: when the
-active dataset can't supply the detector's primary embedder (it isn't among
-that dataset's `media["embeddings"]` keys), `det_ctx.embedder` ≠ what the
-dataset offers, so the cached MLP is dropped and the detector either
-re-embeds its labelset against the dataset (if its origins resolve) or is
-gated only where the space matches - same cross-space safety the marker
-provides today.
-
-### Cross-dataset reuse
-
-A detector stays portable across datasets, exactly as today, but the
-compatibility rule sharpens: **a detector runs against any dataset that binds
-its `primary_embedder`.**  A `sift_vlad`-primary detector works on every
-dataset that has `sift_vlad` vectors and is gated (greyed "Sort by Learned")
-on datasets that don't, instead of silently scoring in whatever the new
-dataset's precedence happened to pick.  Votes remain embedder-agnostic
-(`(media_id, label, region_box?)`), so switching the *dataset* under a
-detector re-derives the MLP from the same vote pile in the detector's primary
-space.
-
-### Migration / back-compat
-
-One-shot, read-time, per detector:
-
-1. Load a legacy detector JSON with **no** `primary_embedder` field.
-2. Resolve its primary as `score_marker_embedder` would have today: the active
-   dataset's score precedence (structural ▸ patch ▸ text, else the dataset's
-   single embedder name).  This is **exactly** the space a legacy detector was
-   already training in, so no behavior changes for any existing detector.
-3. Stamp that name on `DetectorContext.embedder`; the next `_write_detector`
-   (rename, vote-sync, or any save) persists the explicit field.
-
-After first save the field is authoritative and the precedence is never
-consulted for that detector again.  Per CLAUDE.md "Backwards Compatibility",
-we don't keep a parallel precedence-derived mirror once the field exists.
-
-### Validation
-
-- The create request's `primary_embedder`, when non-empty, must be one of the
-  active dataset's bound embedder names (else 400, "embedder X is not bound to
-  this dataset").
-- Empty `primary_embedder` is resolved server-side: the sole bound embedder on
-  a single-embedder dataset; rejected with 400 on a multi-embedder dataset
-  (the client must pick - there's no safe default once more than one space
-  exists).
-- No capability typing on the primary (unlike the role slots): any bound
-  embedder is a legal scoring space.
-
-### Frontend
-
-- **New-detector modal**: a "Detector embedder" picker, populated from the
-  active dataset's bound embedder list (surfaced on the medias payload's
-  `embedders` array, already shipped in Phase 3).  Hidden/disabled when the
-  list has one entry; required when it has more than one.  The license-notice
-  chip (`license_notice`) surfaces on whichever option carries one, reusing the
-  Phase-3 chip.
-- **Nested-modal back button**: if the picker becomes its own inner step,
-  follow the `← Back` rule in CLAUDE.md ("Nested-modal back buttons").
-- Everything downstream (sort bar's text-sort gate, region overlays, marquee)
-  already reads the dataset-level capability flags and is unchanged - the
-  detector's primary doesn't alter what the *dataset* supports.
-
-### Backend integration points
-
-- `create_detector` / `_write_detector` / `DetectorCreateRequestSchema`:
-  accept + persist `primary_embedder`, validate against the active dataset's
-  bound set, resolve the single-embedder default.
-- `DetectorContext.embedder`: loaded from the JSON field at detector load
-  (the labelset-load path), not stamped from the snap at train time.
-- The detector-scoped scoring callsites that today read
-  `routed_embedder("score")` (`scoring.py`, `positives_browse.py`, the
-  diversity/projection paths *when a detector is active*) switch to
-  `det_ctx.embedder`.  The **no-detector** seed paths (`example-sort`, raw
-  diversity tree) keep `routed_embedder("score")`.
-- `update_det_ctx_with_trained_model` / `workflow.apply_and_retrain`: read the
-  primary off the detector instead of computing `score_marker_embedder`.
-
-### Tests
-
-- Create a detector with an explicit `primary_embedder` on a (synthetic)
-  multi-embedder dataset; assert it persists to JSON and reloads onto
-  `DetectorContext.embedder`.
-- Two detectors on one dataset with different primaries train/score in their
-  respective spaces (different MLP cache keys; no cross-contamination).
-- Single-embedder dataset: empty `primary_embedder` auto-resolves to the only
-  embedder; behavior byte-for-byte identical to pre-change (golden scores).
-- Multi-embedder dataset: empty `primary_embedder` → 400; unbound name → 400.
-- Legacy detector (no field) loads, resolves its primary via the precedence
-  fallback, and persists the explicit field on next save.
-- Text sort still routes to the dataset text slot regardless of the active
-  detector's primary.
-- Cross-dataset: a detector is gated on a dataset that doesn't bind its
-  primary, and re-derives its MLP from votes on one that does.
+**Deliberate deviation from the design.** The design said
+`DetectorContext.embedder` *becomes* the authoritative per-detector primary. We
+instead kept `DetectorContext.embedder` as the adaptive cache-space marker and added
+a separate immutable lock (first `primary_embedder`, now `embedder_type`), so a
+detector pointed at a dataset that doesn't bind its type can still re-embed its
+labelset against that dataset's space, and the invalidation/re-embed machinery keys
+on the *current* cache space, not the preference.
 
 ### Out of scope / open questions
 
-- **Per-detector diversity tree.**  The diversity tree is currently a
-  dataset-level structure (one tree, score precedence).  Whether each detector
-  should get its *own* diversity tree in its primary space - or keep one
-  shared dataset tree - is left open; the table above keeps the raw-dataset
-  tree on the precedence and only routes the detector-scoped positives view to
-  the primary.  Decide when a real multi-primary dataset exists to test on.
-- **Changing a detector's primary after creation.**  Out of scope - same
-  spirit as "re-import to change a dataset's embedder".  A user who wants a
-  different primary creates a new detector (votes are embedder-agnostic and can
-  be re-imported into it).  No in-place "re-key this detector's space" flow.
-- **Multi-primary single detector** (one detector scoring in two spaces at
-  once).  Out of scope - this is the inverse of the trio's "one space per
-  detector" premise; the same exclusion as V3 open question #4.
+- **Per-detector diversity tree.** The diversity tree is currently a dataset-level
+  structure (one tree, score precedence). Whether each detector gets its own tree in
+  its type's space is left open; decide when a real multi-primary dataset exists.
+- **Changing a detector's type after creation.** Out of scope — same spirit as
+  "re-import to change a dataset's embedder". A user who wants a different type
+  creates a new detector (votes are embedder-agnostic and re-importable).
+- **Multi-type single detector** (one detector scoring in two spaces at once). Out of
+  scope — the inverse of the trio's "one space per detector" premise (same exclusion
+  as V3 open question #4).
 
-### What shipped
+---
 
-The choice is persisted as `primary_embedder` on the detector JSON (a *name*,
-no vectors/MLPs - CLAUDE.md-compliant), resolved + validated at create time
-against the active dataset's bound embedders (`resolve_detector_primary`):
-empty auto-resolves the sole embedder on a single-embedder dataset and is
-rejected on a multi-embedder one; a concrete name must be bound.  The new
-`DetectorRegistryCreateRequestSchema.primary_embedder` / `DetectorCreateRequestSchema.primary_embedder`
-carry it; both create routes plus combine persist it.  The new-detector modal
-shows a **Detector Embedder** picker (with the license-notice chip) only when
-the active dataset binds more than one embedder, threading the pick into the
-register payload.
+## What shipped
 
-All detector-scoped training/scoring routes through one resolver,
-`keying_embedder_for_snap(det_ctx, snap)`: the detector's primary **when the
-active dataset supplies it**, else the dataset score precedence.  This is the
-single knob behind `detector_score_embedder` (vote-driven `train_and_score` /
-`_score_all_media` / `_build_vote_xy`), the labelset embed path
-(`labelset_training._detector_embedder`), the cold-train path
-(`model_loading`), Find scoring, Auto-Find (one matrix per distinct keyed
-embedder), and the cache-invalidation / re-embed comparisons
-(`dataset_sync._embedder_of_active_dataset`, `embedder_sync`).  Region
-max-pool in `_score_all_media` is now gated on the resolved space **being the
-patch slot**, so a text-primary detector on a text+patch dataset scores the
-text full-image vectors instead of the patch tree.
+**V1** (backend PR #1248; UI/validation in follow-ups):
 
-**Deliberate deviation from the design.** The design said
-`DetectorContext.embedder` *becomes* the authoritative per-detector primary.
-We instead added a **separate** immutable `DetectorContext.primary_embedder`
-(loaded from the JSON) and kept `DetectorContext.embedder` as the *adaptive
-cache-space marker* it already was.  Reason: collapsing the two would have
-removed the cross-embedder portability the V3 cross-embedder-switch work
-relies on - a detector pointed at a dataset that doesn't bind its primary must
-still re-embed its labelset against that dataset's space (the design's own
-"re-embeds its labelset against the dataset (if its origins resolve)"), and
-the invalidation/re-embed machinery keys on the *current* cache space, not the
-preference.  `keying_embedder_for_snap` reads `primary_embedder` and falls
-back to the precedence exactly when the dataset can't supply the primary, so
-single-embedder datasets and every existing detector are byte-for-byte
-unchanged (their `primary_embedder` is empty → pure precedence).
+- Six image embedders — single/patch pairs for **DINOv2** (`facebook/dinov2-base`,
+  ungated Apache-2.0 default, 16×16 grid), **DINOv3**
+  (`facebook/dinov3-vitb16-pretrain-lvd1689m`, gated, 14×14 grid, register tokens
+  stripped), and **real-EUPE** (`facebook/EUPE-ViT-B`, FAIR Noncommercial, 14×14
+  grid), each as `embedder_<name>_single` / `_patch` over a shared `_<name>_shared`
+  base. `MediaEmbedder.supports_patch_regions` (commit 441233b) + `license_notice`
+  capability flags.
+- EUPE loads via `torch.hub.load('facebookresearch/EUPE', 'eupe_vitb16',
+  weights=<HF .pt>)` (replacing the broken PE-Core `AutoModel + trust_remote_code`
+  path); `forward_features` → `x_norm_clstoken` / `x_norm_patchtokens`; saliency is a
+  **CLS-cosine proxy** (SDPA returns no attention weights). DINOv3 uses real
+  CLS→patch attention (`output_attentions=True`).
+- `PatchEmbedOutput` protocol; HAC region tree (`K=12`, `α=0.5`) in
+  `vtscore/media/patch_embed.py` (`2K−1` nodes + CLS full-image node);
+  fp16-in-pickle / fp32-in-RAM storage (`media["patch_regions"]`, `media["patch_grid"]`);
+  max-over-regions similarity (`vtsearch/models/region_similarity.py`); region-aware
+  MLP scoring + asymmetric training loss (Good = full-image `BCE(mlp(cls),1)`, Bad =
+  `mean`-over-regions BCE); gallery-card `best_region` outline. Backward compatible
+  (non-patch datasets reduce to today's single-vector paths).
+- `Dockerfile.image-embedders` + `scripts/cache_gated_models.sh` pre-cache EUPE via
+  torch.hub (`SKIP_DINOV3=1` knob). caltech101_s experiments confirmed K=12/α=0.5 and
+  sensible diversity clusters; fp16↔fp32 rank-stability verified
+  (`TestFp16Fp32RankStability`, worst-case Δ~1e-3, zero rank flips). Tests in
+  `tests/test_patch_embedder.py` (+ GPU integration in `tests/test_gpu.py`).
 
-### Open follow-ups
+**V2** (region voting, PRs #1271–#1274):
 
-- **In-memory primary drift across A→B→A switches.** `DetectorContext.embedder`
-  (the adaptive cache marker) is re-stamped to the dataset's space when the
-  active dataset can't supply the detector's primary.  The persisted
-  `primary_embedder` (JSON) is untouched and re-loaded on the next detector
-  load, but within one in-memory session a multi-embedder-dataset → other-space
-  dataset → back sequence can leave the detector scoring the "back" dataset via
-  the *adapted* slot rather than its primary until reload.  Exotic (rare
-  multi-embedder datasets, A→B→A); revisit if it bites.
-- **Cross-dataset Find / CLI-chunk scoring** still resolve their embedder from
-  each media's primary, not the detector's `primary_embedder` (same follow-up
-  already tracked under "Open follow-ups (from 2b.4)").  Correct for every
-  single-embedder dataset; wire to the detector primary when cross-dataset Find
-  over a real multi-embedder dataset is exercised.
-- **Per-detector diversity tree** and **changing a detector's type after
-  creation** remain out of scope (see "Out of scope / open questions" above).
+- `LabeledElement.region_box`; Shift-drag box draw on `ImageViewerComponent`
+  `.region-stage` (8 handles, zoom/rotate-stable image-local coords); on-the-fly
+  `box_to_vote_vector` uniform-mean pooling from the v1-pickled `patch_grid` (no
+  re-import); `POST /vote` accepts `region_box` (400 on no-vote-with-box); training
+  re-pools per pass; binary `←`/`→` fast path byte-for-byte identical (no-timeout
+  sticky "discard box & vote no" state on `←`). Region voting is image-media only.
+- **Focus-pane best-match Highlight toggle** (next to Marquee, image-only, hidden
+  unless `supports_patch_regions`): dashed marching-ants overlay of the backend's
+  `best_region` in the center viewer, read-only, `(0,0,1,1)` fallback suppressed,
+  frontend-only.
+- Tests: `TestRegionBox*` / `TestRegionAwareTraining` / `TestLabel*RegionBox`; frontend
+  coord-transform / armed-state / vote-API-contract specs. Deferred: touch support,
+  multiple regions per vote, region votes on non-image media.
 
-### What shipped — revised to embedder *type* (authoritative)
+**V3** (the trio, shipped end-to-end as behavior-preserving substrate phases then the
+user-visible binding):
 
-The name-based "What shipped" prose above describes the **original** design.
-The current, shipped behavior locks an embedder **type**, not a name:
+- **Phase 2a** — per-media accessor substrate (`vtscore/embedding/media_vectors.py`):
+  `media["embeddings"]` dict is the forward representation.
+- **Phase 2b.1** — embedder-aware matrix layer: `get_embedding_matrix` /
+  `_submatrix` / `_for_snap` take an optional `embedder_name` (unset → cached primary
+  path; set → fresh matrix from that embedder's vectors).
+- **Phase 2b.2** — in-memory dataset binding: `DatasetContext.text/patch_embedder`
+  slots + derived capability props; `derive_binding` (from medias) / `bind_embedders`
+  (explicit, validated). No schema change yet.
+- **Phase 2b.3** — loader multi-embed: the embed stage runs the *set* of bound
+  embedders; `export_dataset_to_file` serialises `media["embeddings"]` + role slots in
+  `meta`; pickle loader re-keys on load; legacy single-vector pickles materialise via
+  `ensure_embeddings_dict`.
+- **Phase 2b.4** — routing: `DatasetContext.routed_embedder(role)` encodes the table;
+  every active-dataset consumer threads the routed name into the matrix layer;
+  single-vector gap → `None` → primary vector; a routed name == primary collapses to
+  the cached primary hot path.
+- **Phase 2b.5** — MLP keyed to the **score** embedder via one canonical resolver
+  `binding.score_marker_embedder` (`patch or text or primary`); every marker-write and
+  marker-compare site routes through it.
+- **Phase 2c** — dropped the singular `media["embedding"]` mirror; `embeddings` is the
+  sole store; read-time `ensure_embeddings_dict` re-keys old pickles one-way.
+- **Phase 2d** — structural binding slot + `"structural"` role; score precedence
+  became **structural ▸ patch ▸ text** across `routed_embedder`,
+  `score_marker_embedder`, `training._score_embedder_for_snap`.
+- **Phase 3** — create-time trio picker (**additive** deviation): the existing primary
+  picker is unchanged (preserving single-vector picks like `dinov2_single`) and two
+  optional Region/Instance role pickers appear under Advanced via the shared
+  `vt-import-advanced` component; the load pipeline accepts an `embedders` list, the
+  four import routes parse the trio, medias payloads expose the bound set under
+  `embedders`, and `EmbedderCapabilityService.supports*Any` ORs capability across the
+  trio.
 
-- **Taxonomy.** `vtscore/embedding/binding.py::embedder_type(name)` classifies
-  every embedder into exactly one of three buckets, precedence
-  `structural ▸ patch_semantic ▸ semantic`: `structural` =
-  `supports_geometric_verification` (sift_vlad); `patch_semantic` =
-  `supports_patch_regions` (dinov2/3_patch, eupe_patch, face); `semantic` =
-  every global single-vector embedder (siglip, clip, clap, e5, dinov2_single,
-  ast, …), text-capable or not. The buckets partition the registry (no embedder
-  sets more than one flag). `dataset_supplied_types`, `embedder_of_type`, and
-  `detector_dataset_compatible` build on it.
-- **Persisted form.** The detector JSON carries `embedder_type` (one of the
-  three), not a concrete name. `DetectorContext.embedder_type` is the immutable
-  lock; `DetectorContext.embedder` stays the adaptive concrete cache marker.
-  Legacy detectors with a `primary_embedder` name are migration-read via
-  `detector_embedder_type_from_data` (classify the old name → type).
-- **Resolution at create.** `resolve_detector_embedder_type` resolves the type
-  to persist. An **explicit** type (the user's declared intent) is accepted as
-  long as it's one of the three valid types — **regardless of whether the active
-  dataset binds it** (only an unrecognized string is rejected). An **empty**
-  request still auto-resolves against the *types the active dataset supplies*:
-  one type → auto-select; multiple → the client must choose (400 listing the
-  options); none / no dataset → empty (resolved at first train). The
-  new-detector modal's **Detector Embedder Type** dropdown now lives in an
-  always-visible, collapsed **Advanced** section on both the blank and Trained
-  tabs and offers all three types (a detector can be created before any dataset
-  exists, so the picker can't infer the type from a dataset). The displayed type
-  defaults to the dataset's primary supplied type (else Semantic); an untouched
-  single-/no-dataset create sends an empty type and lets the server auto-resolve,
-  while a multi-type dataset sends the picker's defaulted (valid) type. Picking a
-  type the active dataset can't supply is allowed — the detector just gates as
-  incompatible there (see the compatibility gate below), and the modal shows an
-  inline heads-up. The Trained (from-labelset) route threads `embedder_type` too.
-- **Compatibility gate (the substantive change).** A detector is compatible
-  with a dataset iff same `media_type` **and** the dataset binds an embedder of
-  the detector's type. Find-label refuses an incompatible pair (409); Auto-Find
-  silently skips incompatible detectors. `keying_embedder_for_snap` resolves the
-  concrete embedder of the detector's type the dataset supplies, so switching
-  between two datasets of the same type re-derives the MLP in the new space
-  (SigLIP→CLIP; DinoV2→DinoV3, with region boxes re-pooled against the new grid
-  by the existing `box_to_vote_vector`). The frontend gates the same pairs via
-  `embedder_types` on the dataset registry entry and `embedder_type` on the
-  detector entry (`utils/context-compat.ts`).
+**Per-detector embedder type** — see the living-spec section above for the
+authoritative close-out (type lock via `embedder_type`, `keying_embedder_for_snap`
+routing, same-type compatibility gate).
 
-## Phasing
+## Phasing (summary)
 
-- **v1 (this plan):** six image embedders - single/patch pairs for DINOv2 (ungated default), DINOv3 (gated, premium), and real-EUPE (FAIR Noncommercial). `supports_patch_regions` + `license_notice` flags on `MediaEmbedder`; each `_patch` embedder populates `media["patch_regions"]` (HAC tree) and `media["patch_grid"]` (raw H × W × 768 fp16); the matching `_single` slug provides a fast/cheap CLS-only path on the same backbone for datasets that don't need region search. `PatchEmbedOutput` protocol; max-region similarity; region-aware MLP scoring; asymmetric training loss (Good = `BCE(mlp(full_image_vec), 1)` unchanged from today, Bad = `mean`-over-regions BCE) with image-level labels unchanged on disk; gallery-card region highlight; license-notice surfacing on the embedder picker. Text sort stays grey via the already-shipped `supports_text` gate. Pre-implementation experiments run on `caltech101_s` and inform `K`, `α`, and the EUPE-real attention path.
-- **v2:** region voting on image media via Shift-drag on the focus pane (single rectangular box, salient-area annotation on yes-votes only; binary fast path via `←`/`→` preserved); on-the-fly vote-vector computation from the v1-pickled `patch_grid` (no re-import needed); optional `LabeledElement.region_box`; region-level training examples; per-region label export. Touch deferred.
-- **v3:** the **text / patch / structural trio** - up to one embedder per role bound on a single dataset (text queries → text embedder; region similarity / votes → patch embedder; instance retrieval + geometric re-rank → structural embedder), at least one slot filled.  Schema change to dict-keyed `media["embeddings"]` (one vector per bound embedder); `patch_regions` / `patch_grid` / `local_features` stay single-valued (one patch + one structural slot); legacy `media["embedding"]` is read-migrated then dropped on next save; MLPs become keyed by `(detector, dataset, embedder)` against the score embedder (structural ▸ patch ▸ text).  Designed in "V3 - design" above; **shipped** end-to-end (substrate Phases 2a–2b.5, the structural binding slot + routing in Phase 2d, and the additive create-time trio picker in Phase 3 — see "V3 - implementation status"; the picker deviated to an additive design, documented there).
-- **per-detector embedder type (SHIPPED):** moves the scoring-space choice from the dataset (the V3 score precedence structural ▸ patch ▸ text) to the **detector** - each detector locks one embedder **type** (`semantic` / `patch_semantic` / `structural`) at create time and trains/scores in whichever concrete embedder of that type the active dataset binds, so different detectors on one multi-embedder dataset can use different spaces and a detector's labels are portable across same-type datasets (SigLIP↔CLIP, DinoV2↔DinoV3); text sort stays on the dataset text slot. Persisted as a type on the detector JSON (no vectors/MLPs persisted); legacy detectors migration-read their old `primary_embedder` name into a type, else fall back to the precedence-resolved space. All detector-scoped routing funnels through `keying_embedder_for_snap` (the dataset's concrete embedder of the detector's type, else precedence), so single-embedder datasets stay byte-for-byte unchanged. Compatibility gates on *same type* (find-label 409s, Auto-Find skips, frontend greys) - see "Per-detector embedder type (design)" → "What shipped — revised to embedder type" / "Open follow-ups". (First shipped as a per-detector primary *name*, then revised to a type lock.)
+- **v1:** six single/patch image embedders (DINOv2 default, DINOv3 gated, real-EUPE
+  noncommercial); `supports_patch_regions` + `license_notice`; HAC region tree;
+  max-region similarity; region-aware MLP scoring + asymmetric loss; gallery highlight.
+- **v2:** Shift-drag region voting on image media (optional `region_box` on yes-votes;
+  binary fast path preserved); on-the-fly vote pooling from `patch_grid`.
+- **v3:** the text/patch/structural trio on one dataset; dict-keyed
+  `media["embeddings"]`; legacy `media["embedding"]` read-migrated then dropped; MLPs
+  keyed by `(detector, dataset, embedder)` against the score embedder
+  (structural ▸ patch ▸ text). Create-time picker shipped as an additive variant.
+- **per-detector embedder type:** moves the scoring-space choice from the dataset to
+  the detector (`semantic` / `patch_semantic` / `structural` lock); labels portable
+  across same-type datasets; text sort stays on the dataset text slot.

--- a/docs/plans/progress-bar-consolidation.md
+++ b/docs/plans/progress-bar-consolidation.md
@@ -1,170 +1,10 @@
 # Progress-bar consolidation
 
-**Status: shipped.** Multi-step jobs now render one whole-job progress bar
+**Status: shipped** (consolidation + smoothness pass + GPU pacing +
+registry-reload pacing). Multi-step jobs now render one whole-job progress bar
 (0→100 %, never resetting) with a true overall ETA and a visible step count,
 instead of a fresh per-phase bar that filled, snapped back to 0 %, and started
-over for the next phase.
-
-## Problem
-
-Adding a demo dataset (and other multi-phase loads) showed a sequence of
-separate progress bars — download, model load, embed, finalize — each with its
-own `current/total` and its own per-phase ETA. The bar visually reset at every
-phase, and the ETA counted down toward an arrival we never reached: it just
-restarted as the next phase began. The user never saw how many phases the whole
-job had, and there was no honest "% of the total job done".
-
-## What shipped
-
-- **Unified `overall` fraction (backend).**
-  `ProgressTracker._compute_overall` (`vtscore/concurrency/progress.py`)
-  computes a single whole-job completion fraction whenever a caller reports a
-  `step`/`total_steps` structure. The within-step `current/total` is mapped into
-  the job's overall span by `_overall_raw_fraction`:
-
-  ```
-  weighted: (Σ weights[:step-1] + weights[step-1] * within) / Σ weights
-  equal:    ((step - 1) + within_step_fraction) / total_steps   # when no weights
-  ```
-
-  **Per-step weights** (`ProgressTracker.set_step_weights`, or the `step_weights`
-  arg to `LoadingTasksTracker.create_task`) let each flow reflect the phases it
-  *knows* are longer, so the bar paces by real time instead of lurching:
-  - dataset load `[0.25, 0.15, 0.50, 0.10]` — embed dominates (download, model
-    load, embed, finalize); see `stages/_common.py:_LOAD_STEP_WEIGHTS`.
-  - detector load `[0.15, 0.15, 0.70]` — MLP training dominates.
-  - Find `[0.10, 0.30, 0.60]` — scoring dominates.
-  - Find-label `[0.10, 0.45, 0.40, 0.05]` — train + score carry the cost.
-
-  Weights need only be in the right ballpark: they shape *pacing* only, since
-  the overall ETA self-corrects from the real elapsed-vs-fraction rate. Flows
-  that supply no weights fall back to equal weight per step. The fraction is
-  clamped monotonic non-decreasing within a job so the bar never visibly
-  retreats; a step going backwards (or `total_steps` changing) is read as a new
-  job and resets the clock. Exposed as a new `overall` key in
-  `_PROGRESS_COMMON_EXTRAS`, so every tracker carries it.
-
-- **True overall ETA (backend).** When `overall` is present, `eta_seconds` is
-  derived from the elapsed-vs-overall-fraction rate over a single clock that
-  runs for the whole job (not per-phase), with the same EMA smoothing the
-  per-phase ETA used. It self-corrects as the real rate emerges and no longer
-  resets between phases. Single-phase operations keep the per-phase ETA.
-
-- **One bar + step count (frontend).**
-  `progressBarState()` in `utils/format-progress.ts` is the shared resolver:
-  prefer `overall` (one bar across the whole job) → else `current/total` → else
-  indeterminate. `formatProgressHeader` now surfaces a capitalized `Step S of T`
-  in the header (each `·`-separated segment is title-cased so the line reads as a
-  row of labels, e.g. `Loading dataset · Step 3 of 4 · Embedding files`), and the
-  per-item `detail` line drops the parentheses around the count and strips the
-  redundant leading verb (`012/345 cats/img.png`, not `(012/345) Embedding
-  cats/img.png`) so the narrow, ellipsized detail slot spends its characters on
-  the filename rather than repeating the phase the header already names. Wired
-  into the dashboard loading rows (dataset-card, detector-card,
-  orphan-task rows), the Find/learned-sort overlay (find-view) and the
-  left-panel sort indicator (via `SortStateService.sortOverall` /
-  `sortEtaSeconds`).
-
-- **Docs.** `docs/api/events.md` and `docs/api/dashboard.md` document the
-  `overall` / `eta_seconds` fields.
-
-- **Tests.** `tests_lib/core/test_progress_overall.py` (fraction math,
-  monotonicity, new-job reset, overall ETA) and
-  `frontend/src/app/utils/format-progress.spec.ts` (`progressBarState`,
-  step-count header).
-
-## Smoothness pass (shipped)
-
-Follow-up to the consolidation: the unified bar was monotonic *in principle* but
-still got "knocked around" between stages. Fixed the concrete jump sources:
-
-- **Clipper backslide (the worst offender).** The clipper stage
-  (`vtscore/datasets/stages/clipper.py`) reported the *finalize* step while
-  running *before* the embed step. It ran the bar to ~100 %, then the following
-  embed step (a lower number) tripped `_compute_overall`'s "step went backwards
-  = new job" reset and slammed the bar from ~100 % back to mid-job. Clipping is
-  really the embed phase for clipped datasets (it cuts + embeds clips; the later
-  `_embed_missing_stage` is then a no-op), so it now reports the **embedding**
-  step. The whole-job fraction stays monotonic across a clipped load.
-- **`converting` status nulled the bar.** `converters/runner.py` emits a
-  `"converting"` status (document→image, video→frames) that was missing from
-  `_STATUS_TO_STEP`, so it resolved to `step=None`, nulled `overall`, and bounced
-  the bar onto the raw `current/total` scale mid-job. It now maps to the loading
-  step (it's pre-embed work). The map's docstring states the invariant: every
-  load-path status must be present.
-- **Smaller model-load jump.** `_LOAD_STEP_WEIGHTS` shifted `0.25/0.15/0.50/0.10`
-  → `0.25/0.10/0.55/0.10`: the un-measurable model-load slice (the one that
-  fills in a single step the moment embedding starts) is trimmed and the freed
-  weight handed to embedding, the phase that reports per-item progress — so more
-  of the bar advances smoothly and the between-stage jump is smaller.
-- **Gentle fill ease (frontend).** `ProgressBarComponent` gained an opt-in
-  `smooth` input (a longer `0.6s ease-out` fill transition, class
-  `progress-fill--smooth`) wired into the dataset-load bars (dashboard orphan
-  rows, dataset-card, detector-card). Unavoidable between-phase jumps glide
-  instead of snapping. Honest by construction: the fill only ever eases *toward*
-  the real reported value, never ahead of it (no fake/timer-driven motion — that
-  approach was explicitly rejected).
-
-## GPU pacing profile (shipped)
-
-The static load weights `[0.25, 0.10, 0.55, 0.10]` assumed embedding dominates
-wall-clock — true on a CPU host, false on a GPU one. On a GPU the embed phase is
-several times faster, but the finalize phase is **not** GPU-accelerated: the
-registry save (serialize → zip → disk write) is always CPU, and the
-diversity-tree k-means only moves to the GPU when cuML is installed (a
-best-effort RAPIDS dep that is frequently absent). So on a GPU host finalize
-dominated wall-clock while still getting only 10 % of the bar — the bar raced to
-~90 % during embed, then crawled through the last 10 % for 20+ seconds while the
-rate-based ETA (computed mostly from the fast embed phase) reported "< 5 sec
-left".
-
-Fixed by making the weights device-aware (`load_step_weights()` in
-`stages/_common.py`, resolved once at task creation): the CPU profile is
-unchanged, and a GPU profile `[0.20, 0.10, 0.30, 0.40]` shrinks embed and grows
-finalize so the bar paces by real time and the overall ETA has room to
-self-correct through the diversity-tree build + registry save. Detector-load
-weights are unaffected. Tests: `tests_lib/datasets/test_load_step_weights.py`.
-
-## Registry-reload pacing + redundant rebuild (shipped)
-
-The registry/pickle **reload** path (`load_registered_dataset`,
-`vtsearch/routes/datasets/registry.py`) is its own 2-step mini-pipeline (read
-pickle → dedup + diversity), separate from the 4-step import. It had two bugs
-that made "Step 2 of 2 · Removing duplicates" appear to hang far past what the
-bar showed:
-
-1. **Frozen bar.** The reload set `total_steps=2` with **no** `set_step_weights`,
-   so step 2 was the last 50 % of the bar under equal weighting. Step 2 lumped
-   the near-instant exact-MD5 dedup with the diversity index. The dedup drove
-   step 2's within-fraction to ~1.0 in ~0.01 s, the monotonic clamp pinned the
-   overall bar at ~100 %, and it then **sat frozen there for the entire diversity
-   rebuild** (a hierarchical-k-means that measures ~45 s for 20 k items). Fixed
-   by (a) moving dedup into step 1 (it's part of loading, and a no-op on reload
-   since the pickle was already deduped at import) so it no longer pre-fills the
-   diversity slice, and (b) `set_step_weights([0.15, 0.85])` so the diversity
-   build — the only phase that can be slow — owns the bulk of the bar and paces
-   the rebuild across its whole span. A terminal `Finalizing…` update fills the
-   slice to 100 % in every branch (restore / rebuild / deferred-above-threshold).
-
-2. **Redundant rebuild.** Fresh-import datasets cache the diversity tree in their
-   pickle (`stages/registry.py`), so reload restores it in ~0 s. But **promoted**
-   datasets (`/api/dataset/promote`) omitted it, and the promote subset renumbers
-   IDs so the source tree can't be reused — so a promoted dataset rebuilt the
-   full k-means on *every* reload. Fixed by building + caching the tree at
-   promote time (`_diversity_tree_pickle_keys` +
-   `build_diversity_tree_serializable`), gated by the same
-   `should_auto_build_diversity_tree` threshold the load pipeline uses, so
-   reopening a promoted dataset restores instead of rebuilding. Measured costs
-   (20 k images): pickle read + convert ~0.7 s, dedup ~0.01 s, cache restore
-   instant, k-means rebuild ~45 s — i.e. the rebuild was ~60× everything else.
-
-Open follow-up: promote now builds the tree **synchronously** in the request
-(the app runs with `VTSEARCH_TIMEOUT=0`, so long creates are tolerated), which
-means no fine-grained progress during a large promote. If that becomes a pain,
-background the promote like the import pipeline. Other cache-miss reloads (old
-pickles predating tree caching, or a media set that shifts on load) still
-rebuild once; a "write the rebuilt tree back to the pickle on first reload" pass
-would cover those too.
+over. Open follow-ups below.
 
 ## Open follow-ups
 
@@ -205,8 +45,92 @@ would cover those too.
   asymptote). Remaining media/embedders/cuML cells are uncalibrated and keep the
   static profiles (incl. the CPU **image** stopgap
   `_LOAD_STEP_WEIGHTS_CPU_IMAGE`).
+- **Promote builds the diversity tree synchronously.** Promote now builds + caches
+  the tree in-request (the app runs with `VTSEARCH_TIMEOUT=0`, so long creates
+  are tolerated), which means no fine-grained progress during a large promote. If
+  that becomes a pain, background the promote like the import pipeline. Other
+  cache-miss reloads (old pickles predating tree caching, or a media set that
+  shifts on load) still rebuild once; a "write the rebuilt tree back to the
+  pickle on first reload" pass would cover those too.
 - **Dead dashboard fields.** `progressValue` / `progressTotal` /
   `progressIndeterminate` on `DashboardComponent` are set by the Find polling
   but never rendered; safe to remove in a cleanup pass.
 - **Eval (train-and-score)** is intentionally left single-phase (one smooth
   `current/total` bar); revisit only if it grows distinct phases.
+
+## What shipped
+
+### Consolidation (the core)
+
+- **Unified `overall` fraction (backend).** `ProgressTracker._compute_overall`
+  (`vtscore/concurrency/progress.py`) computes one whole-job completion fraction
+  whenever a caller reports `step`/`total_steps`; the within-step `current/total`
+  maps into the job's span via `_overall_raw_fraction` (weighted:
+  `(Σ weights[:step-1] + weights[step-1]·within) / Σ weights`; equal:
+  `((step-1) + within) / total_steps`). Per-step weights
+  (`set_step_weights` / the `step_weights` arg to
+  `LoadingTasksTracker.create_task`) pace by real time — dataset load
+  `[0.25,0.15,0.50,0.10]`, detector load `[0.15,0.15,0.70]`, Find
+  `[0.10,0.30,0.60]`, Find-label `[0.10,0.45,0.40,0.05]`; no-weight flows fall
+  back to equal weight. Fraction is clamped monotonic non-decreasing; a step
+  going backwards / `total_steps` changing is read as a new job and resets the
+  clock. Exposed as a new `overall` key in `_PROGRESS_COMMON_EXTRAS`.
+- **True overall ETA (backend).** When `overall` is present, `eta_seconds` is
+  derived from elapsed-vs-overall-fraction over a single whole-job clock with EMA
+  smoothing; self-corrects and no longer resets between phases. Single-phase ops
+  keep the per-phase ETA.
+- **One bar + step count (frontend).** `progressBarState()`
+  (`utils/format-progress.ts`) prefers `overall` → `current/total` →
+  indeterminate; `formatProgressHeader` surfaces a title-cased `Step S of T` and
+  the per-item `detail` drops the parens + redundant leading verb. Wired into the
+  dashboard loading rows (dataset-card, detector-card, orphan-task rows), the
+  Find/learned-sort overlay (find-view), and the left-panel sort indicator (via
+  `SortStateService.sortOverall` / `sortEtaSeconds`).
+- **Docs + tests.** `docs/api/events.md` + `docs/api/dashboard.md` document
+  `overall` / `eta_seconds`; `tests_lib/core/test_progress_overall.py` +
+  `frontend/src/app/utils/format-progress.spec.ts`.
+
+### Smoothness pass
+
+- **Clipper backslide fixed.** The clipper stage
+  (`vtscore/datasets/stages/clipper.py`) reported the *finalize* step while
+  running *before* embed, ramming the bar ~100 %→mid-job on the backwards-step
+  reset. Clipping is really the embed phase for clipped datasets, so it now
+  reports the **embedding** step; the whole-job fraction stays monotonic.
+- **`converting` status added to `_STATUS_TO_STEP`.** It was missing, so
+  `converters/runner.py`'s `"converting"` resolved to `step=None`, nulled
+  `overall`, and bounced onto the raw `current/total` scale; now maps to the
+  loading step (pre-embed work). Map docstring states the every-load-status
+  invariant.
+- **Model-load weight shift** `0.25/0.15/0.50/0.10 → 0.25/0.10/0.55/0.10` — trims
+  the un-measurable model-load slice, hands the weight to embedding (which
+  reports per-item progress), shrinking the between-stage jump.
+- **Gentle fill ease (frontend).** `ProgressBarComponent` opt-in `smooth` input
+  (a `0.6s ease-out` fill, class `progress-fill--smooth`) on the dataset-load
+  bars; only ever eases *toward* the real reported value (no fake/timer motion).
+
+### GPU pacing profile
+
+- **Device-aware weights** (`load_step_weights()` in `stages/_common.py`,
+  resolved once at task creation). CPU profile unchanged; GPU profile
+  `[0.20,0.10,0.30,0.40]` shrinks embed and grows finalize, because on a GPU
+  embed is fast but finalize (registry save + non-cuML diversity k-means) is CPU
+  and dominates wall-clock. Detector-load weights unaffected. Tests:
+  `tests_lib/datasets/test_load_step_weights.py`.
+
+### Registry-reload pacing + redundant rebuild
+
+- **Frozen bar fixed.** The registry/pickle reload path
+  (`load_registered_dataset`, `vtsearch/routes/datasets/registry.py`) is a 2-step
+  mini-pipeline (read pickle → dedup + diversity) that set `total_steps=2` with
+  no weights, so the near-instant dedup pinned the overall bar at ~100 % while the
+  ~45 s diversity rebuild sat frozen. Fixed by moving dedup into step 1 and
+  `set_step_weights([0.15, 0.85])` so the diversity build owns the bulk of the
+  bar; a terminal `Finalizing…` fills the slice to 100 % in every branch.
+- **Redundant rebuild fixed.** Promoted datasets (`/api/dataset/promote`) omitted
+  the cached diversity tree and renumber IDs (so the source tree can't be reused),
+  rebuilding the full k-means on every reload. Now the tree is built + cached at
+  promote time (`_diversity_tree_pickle_keys` +
+  `build_diversity_tree_serializable`), gated by the same
+  `should_auto_build_diversity_tree` threshold, so reopening a promoted dataset
+  restores instead of rebuilding.

--- a/docs/plans/progress-weight-calibration.md
+++ b/docs/plans/progress-weight-calibration.md
@@ -1,228 +1,54 @@
 # Progress-weight calibration
 
-**Status: executed for image + audio × CPU + GPU (2026-07).** This doc specifies
-how to replace the hand-guessed dataset-load progress weights with *measured*
-ones, and how to make the weights depend on dataset size `n` rather than being a
-single fixed vector per device. It is the concrete follow-up to the "Weights are
-static guesses" item in `docs/plans/progress-bar-consolidation.md`. The
+**Status: executed for image + audio × CPU + GPU (2026-07).** The
 instrumentation, driver, affine fit, and `n`-aware wiring shipped; fitted
-coefficients for the image/audio × CPU/GPU cells are in `_load_cost_model.py`.
-See **Results** for the runs; the sections above are the design/method.
+coefficients for those four cells are in
+`vtscore/datasets/stages/_load_cost_model.py`. Remaining media types /
+embedders / the cuML split are still on the static fallback. Runs were on the
+HLTCOE Grid (a100) — the Claude Cloud container has no GPU.
 
-It is written to be run **on a CUDA box** — the Claude Cloud container has no GPU.
-The runs below were done on the HLTCOE Grid (a100).
+## Open follow-ups (remaining cells to calibrate)
 
-## Background: what the weights do (and don't do)
+- **Uncalibrated cells fall back to the static per-(device, media) profile.**
+  Calibrate by re-running `scripts/profiling/calibrate_load_weights.py` for:
+  the remaining media types (`video / text / document`), the non-default
+  embedders (image: siglip2, eupe_*, face, sift_vlad; audio: whisper_encoder…),
+  and the **cuML on/off** split (cuML moves diversity-tree k-means to GPU,
+  materially changing finalize).
+- **Finalize sub-slot shares** (`FinalizeProgress._SLOTS` ballparks) have the
+  same "static guess" problem one level down — revisit with the measured data
+  once coefficients exist.
+- **Multi-embedder (v3 trio)** embed loop may need its own `b_embed` summed
+  across bound embedders (see the trio follow-up in the consolidation doc).
 
-The unified load bar paces itself across four phases — **download, model load,
-embed, finalize** — using a weight vector that reflects each phase's share of
-wall-clock (`vtscore/datasets/stages/_common.py`, consumed at task creation in
-`load_pipeline.py` and applied by `ProgressTracker._overall_raw_fraction` in
-`vtscore/concurrency/progress.py`). Today there are three hand-tuned vectors:
+## What shipped
 
-```
-                  download  model  embed  finalize
-CPU (generic)   [ 0.25,    0.10,  0.55,  0.10 ]
-CPU (image)     [ 0.35,    0.10,  0.35,  0.20 ]   # added because images embed cheaply
-GPU             [ 0.20,    0.10,  0.30,  0.40 ]   # embed fast, finalize not GPU-accelerated
-```
+- Env-gated per-phase timing recorder (`VTSEARCH_PROFILE_LOAD=<path>`, JSONL,
+  library-tier), `scripts/profiling/calibrate_load_weights.py` (matrix driver),
+  `scripts/profiling/fit_load_weights.py` (affine fit).
+- `n`-aware `load_step_weights(media_type, *, n, download_size_mb, embedder)`:
+  computes the weight vector from the affine cost model + known `n` /
+  `download_size_mb` when a coefficient row exists, else returns today's static
+  vector (strict superset). Threaded through the demo call site
+  (`load_pipeline.py`), reusing the count `ui.py` already computes.
+- Coefficients checked into `_load_cost_model.py`; shape validated by a unit
+  test (all phases present, weights normalize to ~1.0). No runtime persistence —
+  coefficients are source constants (consistent with "No Persisted Vectors").
+- Tests in `tests_lib/datasets/test_load_step_weights.py` (small-`n` weights
+  model/finalize heavier; download slice collapses when cached; unknown `n`
+  returns the static vector).
 
-Crucially, **the weights only shape pacing**. The overall ETA self-corrects from
-the real elapsed-vs-fraction rate (`progress.py:_compute_overall`), so bad
-weights don't make the *final* ETA wrong — they make the bar **race through one
-phase and crawl another**, and they misplace the model-load floor. That's the
-symptom we're fixing, and it bounds the value of this work: we want smooth,
-honest pacing, not a perfect time oracle. Don't over-engineer past that.
+## Results (the four calibrated cells)
 
-## Why a single vector can't be right: `n` belongs in the model
+Ran `{cpu, cuda} × {image (caltech101 / siglip), audio (esc50 / clap)}`,
+default embedder only, over 242 phase rows. Sizes `caltech101_{s,m,l,a}`
+(n = 412/838/1704/2954) and `esc50_{s,m,l,a}` (n = 245/588/1127/1960). The
+driver clears only the *embeddings* cache between loads, so the source stays
+warm and every load re-embeds. Warm loads skip the model phase entirely, so
+`a_model` is floored to 0.5 s (cold first-load cost recorded as a note, not
+paced against).
 
-The four phases scale with the item count `n` *differently*:
-
-| Phase      | Scales with                              | Cost model              |
-|------------|------------------------------------------|-------------------------|
-| download   | archive **bytes**, not selected `n` (demo archives are a fixed size, then subset) | `download_size_mb / bandwidth` |
-| model load | nothing — the encoder is loaded once     | fixed per (embedder, device) |
-| embed      | `n` (one encoder forward per item)       | `a_embed + b_embed · n` |
-| finalize   | `n` (dedup + diversity k-means + registry serialize) | `a_fin + b_fin · n` |
-
-The model-load phase is what breaks a fixed vector: it is a **constant**, so its
-*fraction* of wall-clock is large for a small dataset and negligible for a large
-one. No single weight vector can be right at both ends — which is exactly the
-"big vs small" axis in this plan.
-
-So the target model is an **affine per-phase cost**, fit per
-(device, media_type, embedder):
-
-```
-T_download ≈ download_size_mb / bandwidth(device)     # or a measured per-dataset constant
-T_model    ≈ a_model                                   # fixed; b ≈ 0
-T_embed    ≈ a_embed + b_embed · n
-T_finalize ≈ a_fin   + b_fin   · n
-weight_phase = T_phase / Σ T_phase                     # normalized at task creation
-```
-
-We usually **do** know `n` and `download_size_mb` up front for demo datasets:
-`vtsearch/routes/datasets/ui.py:104-121` already computes expected item counts
-from `items_per_category` (and the slice window), and `download_size_mb` lives in
-the demo registry. When `n` is genuinely unknown (e.g. a folder importer that
-streams), fall back to today's static vector (the large-`n` asymptote).
-
-This makes calibration (#1) and the `n`-aware formula (#2) the same effort: the
-run below measures `(a, b)` per phase; the formula consumes them.
-
-## Goal & non-goals
-
-**Goal:** produce measured affine coefficients `(a_phase, b_phase)` per
-(device, media_type, embedder), and wire an `n`-aware `load_step_weights()` that
-computes the weight vector from those coefficients + the known `n` /
-`download_size_mb`, with a static fallback.
-
-**Non-goals:**
-- Not trying to predict absolute load time (the ETA already self-corrects).
-- Not building a persistent learned/online model — coefficients are checked-in
-  constants, refreshed by re-running this harness. (No vectors/weights persisted
-  at runtime; this is consistent with the "No Persisted Vectors or MLPs" rule —
-  the coefficients are source constants, not derived artifacts.)
-- Not calibrating non-dataset bars (detector load, Find, sort) — same method
-  would apply, but out of scope here.
-
-## The measurement matrix
-
-Run every reachable cell of:
-
-- **Device:** `cpu`, `cuda`. (`mps` optional; skip if no Apple box. For `cuda`,
-  run both **with and without cuML** installed if feasible — the diversity-tree
-  k-means only moves to GPU under cuML, which materially changes finalize.)
-- **Media type:** `image`, `audio`, `video`, `text`, `document`.
-- **Embedder:** each registered embedder for that media type (not just the
-  default), since embed cost is per-encoder. Enumerate via the embedder registry.
-- **Size:** at least two points per (media_type) so the affine fit has a slope —
-  use the existing small demo variants (e.g. `caltech101_s`) **and** a larger
-  one, and/or vary the slice window / `items_per_category` to get ≥3 distinct
-  `n` values. More `n` points = better `b` estimate.
-
-Skip cells that don't exist (no such embedder for that media type). `log()` /
-record every skipped cell so the coverage gap is explicit, not silent.
-
-**Repetitions & caching:** run each cell ≥3× and take the median. Distinguish:
-- **Cold model load** (first use downloads the encoder) vs **warm** — record
-  separately; the bar should pace against the *warm* steady state, but note the
-  cold delta.
-- **Cold vs warm download** — the demo archive is cached on disk after the first
-  fetch, so a second run has `T_download ≈ 0`. Measure the **cold** download (to
-  fit `bandwidth`) and also record the warm case (so the formula can zero the
-  download slice when the pickle/archive is already present, which the loader
-  already short-circuits — see `loader_demo.py` cached-pickle path).
-
-## Instrumentation
-
-Add an **env-gated per-phase timing recorder** — no behavior change when off:
-
-- Gate on `VTSEARCH_PROFILE_LOAD=<path>`. When set, the load pipeline records, at
-  each phase boundary, a JSONL row:
-  ```json
-  {"device": "cuda", "media_type": "image", "embedder": "siglip",
-   "dataset_id": "caltech101_s", "n": 860, "download_size_mb": 40.0,
-   "phase": "embed", "seconds": 3.21, "cold_model": false, "cold_download": true}
-  ```
-- Capture boundaries where the status transitions are already emitted: the
-  `_STATUS_TO_STEP` transitions (`downloading`→`loading`→`embedding`) plus the
-  `FinalizeProgress` sub-slot `begin()` calls (cleanup/dedup/diversity/registry/
-  projection) so finalize sub-shares get measured too (addresses the second
-  open follow-up in the consolidation doc). A `ProgressTracker` subscriber that
-  timestamps status changes is the least invasive hook; if sub-slot granularity
-  needs more than status strings, add explicit `time.monotonic()` stamps in the
-  finalize block keyed by slot.
-- Keep it in `vtscore` (library tier) so it works from a plain CLI autodetect
-  run, not just the app.
-
-A small **driver script** (`scripts/profiling/calibrate_load_weights.py`,
-new) iterates the matrix by invoking the existing demo-load path per cell
-(reusing the CLI/`load_demo_dataset` entry point), sets the env var, clears the
-relevant cache between cold runs, and concatenates the JSONL.
-
-## Fitting
-
-A second script (or a notebook) reads the JSONL and, per
-(device, media_type, embedder):
-
-- `a_model`  = median warm model-load seconds.
-- `(a_embed, b_embed)` = least-squares fit of embed seconds vs `n`.
-- `(a_fin, b_fin)`     = least-squares fit of finalize seconds vs `n`
-  (optionally per sub-slot for the finalize sub-shares).
-- `bandwidth(device)` = fit of cold download seconds vs `download_size_mb`
-  (likely device-independent; collapse if so).
-
-Emit the coefficients as a checked-in Python table (e.g.
-`vtscore/datasets/stages/_load_cost_model.py`) plus a human-readable summary
-appended below the line in this doc. Sanity-check fits (R², residuals); where a
-cell has too few points or a poor fit, fall back to the generic profile and note
-it.
-
-## Wiring it back in
-
-1. Extend `load_step_weights(media_type)` →
-   `load_step_weights(media_type, *, n=None, download_size_mb=None, embedder=None)`.
-2. When `n` is known and a coefficient row exists for
-   (resolved device, media_type, embedder): compute `T_phase` from the affine
-   model, normalize to a weight vector, return it.
-3. When `n` is unknown or no row matches: return today's static vector for that
-   (device, media_type) — unchanged behavior, so this is a strict superset.
-4. Pass `n` / `download_size_mb` / `embedder` at the call site
-   (`load_pipeline.py:419`); the demo importer already knows the expected count
-   (`ui.py` computes it) — thread it through, don't recompute.
-
-## Acceptance / tests
-
-- `tests_lib/datasets/test_load_step_weights.py`: extend with cases proving the
-  `n`-aware path (small `n` weights model-load heavier than large `n`; download
-  slice collapses when `download_size_mb≈0` / cached; unknown `n` returns the
-  static vector unchanged; GPU stays media-agnostic unless a coefficient row
-  says otherwise).
-- The coefficient table is validated for shape (all phases present, weights
-  normalize to ~1.0) in a unit test, mirroring `test_profiles_are_well_formed`.
-- No new runtime persistence; coefficients are source constants.
-
-## Open follow-ups
-
-- **Executed** for `{cpu, cuda} × {image, audio}`, default embedder — see
-  Results below. Remaining media types (`video / text / document`), non-default
-  embedders, and the cuML-on/off split are still uncalibrated and fall back to
-  the static profiles; re-run `scripts/profiling/calibrate_load_weights.py` for
-  those cells when needed.
-- Once coefficients exist, revisit the **finalize sub-slot shares** (the
-  `FinalizeProgress._SLOTS` ballparks) with the same measured data — they have
-  the same "static guess" problem one level down.
-- Consider whether the **multi-embedder (v3 trio)** embed loop needs its own
-  `b_embed` summed across bound embedders (see the trio follow-up in the
-  consolidation doc).
-
----
-
-## Results
-
-Ran on the HLTCOE Grid (a100 for the GPU cells) via
-`scripts/profiling/calibrate_load_weights.py` with the env-gated recorder, then
-`scripts/profiling/fit_load_weights.py` over the JSONL. 242 phase rows across the
-four cells. Coefficients are checked into `_load_cost_model.py`.
-
-**What ran.** `{cpu, cuda} × {image (caltech101 / siglip), audio (esc50 / clap)}`,
-default embedder only. Sizes `caltech101_{s,m,l,a}` (n = 412/838/1704/2954) and
-`esc50_{s,m,l,a}` (n = 245/588/1127/1960); ≥2 reps on the fast cells. Each cell's
-first load pays the cold model + cold archive download; the driver clears only the
-*embeddings* cache between loads, so the source stays warm and every load
-re-embeds. **Skipped, logged not silent:** media `video/text/document`; all
-non-default embedders (image: siglip2, eupe_\*, face, sift_vlad; audio:
-whisper_encoder…); cuML on/off. Uncalibrated cells fall back to the static
-per-(device, media) profile — unchanged behaviour.
-
-**Model-load is warm-≈0 by construction.** A warm load *skips the model phase
-entirely* (the encoder is resident, so no `loading model` status fires), so there
-is no warm row to fit — `a_model` is floored to 0.5 s and the model slice stays
-deliberately tiny. The cold first-load model cost (below) is recorded as a note,
-not paced against (per the plan).
-
-### Fitted coefficients (seconds; `n` = item count)
+**Fitted coefficients** (seconds; `n` = item count):
 
 | device | media | embedder | a_model (cold) | embed `a + b·n` | R² | finalize `a + b·n` | R² | n pts |
 |--------|-------|----------|---------------|-----------------|----|--------------------|----|------|
@@ -231,15 +57,12 @@ not paced against (per the plan).
 | cuda | image | siglip | 0.5 (119.7)| 2.12 + 0.00678·n | 0.89 | 8.01 (fixed, b≈0) | 0.00 | 12 |
 | cuda | audio | clap   | 0.5 (40.1) | 0.69 + 0.03663·n | 1.00 | 0.00 + 0.00362·n | 1.00 | 12 |
 
-Download bandwidth ≈ **10.05 MB/s** (device-pooled; cuda 9.5 / cpu 10.6 agreed
-within ~10%), so `T_download ≈ download_size_mb / 10.05`.
+Download bandwidth ≈ **10.05 MB/s** (device-pooled), so
+`T_download ≈ download_size_mb / 10.05`. Per-item embed is 5–43× slower on CPU
+than GPU (SigLIP's ViT benefits far more than CLAP); GPU-image finalize is a
+~8 s fixed overhead at these sizes.
 
-Physically sensible: per-item embed is **5–43× slower on CPU** than GPU (image
-0.293 vs 0.0068 s/item; audio 0.185 vs 0.0366) — SigLIP's ViT benefits from the
-GPU far more than CLAP. Audio finalize scales with `n` (diversity-tree k-means);
-GPU-image finalize is a ~8 s fixed overhead at these sizes (b≈0).
-
-### Sample resulting weights `[download, model, embed, finalize]`
+**Sample resulting weights** `[download, model, embed, finalize]`:
 
 | device | media | n | archive | weights |
 |--------|-------|---|---------|---------|
@@ -247,24 +70,59 @@ GPU-image finalize is a ~8 s fixed overhead at these sizes (b≈0).
 | cuda | image | 2000  | 0 (warm)      | [0.00, 0.02, 0.64, 0.34] |
 | cuda | image | 20000 | 0 (warm)      | [0.00, 0.00, 0.92, 0.08] |
 | cuda | audio | 400   | 600 MB (cold) | [0.78, 0.01, 0.20, 0.02] |
-| cuda | audio | 2000  | 0 (warm)      | [0.00, 0.01, 0.91, 0.09] |
 | cpu  | image | 400   | 131 MB (cold) | [0.10, 0.00, 0.89, 0.01] |
 | cpu  | audio | 2000  | 0 (warm)      | [0.00, 0.00, 0.99, 0.01] |
 
-The n-awareness a single static vector can't give: small `n` weighs
-model/finalize/download heavier, large `n` lets embed dominate; the download
-slice collapses when there is no archive (local imports, cached re-adds — which
-also take the static path since they don't know `n`). Cross-checks an independent
-scout run: warm large-`n` GPU-image `≈ [0, 0.02, 0.64, 0.34]` vs the scout's
-`[0, 0.01, 0.68, 0.31]` — the model and the raw data agree.
+Small `n` weighs model/finalize/download heavier; large `n` lets embed
+dominate; the download slice collapses when there is no archive.
 
-### Reproduce
-
+**Reproduce:**
 ```
-# per device (device is fixed at process start):
 CUDA_VISIBLE_DEVICES=0 python scripts/profiling/calibrate_load_weights.py --out gpu.jsonl
 CUDA_VISIBLE_DEVICES=  python scripts/profiling/calibrate_load_weights.py --out cpu.jsonl --sizes s,m,l
 python scripts/profiling/fit_load_weights.py gpu.jsonl cpu.jsonl   # prints the table above
 ```
 (Needs `VTSEARCH_MODELS_DIR` pointed at a warm model cache so the model phase is
 a load, not a cold HuggingFace download.)
+
+---
+
+## Reference: method & cost model
+
+**What the weights do.** The unified load bar paces across four phases —
+**download, model load, embed, finalize** — using a weight vector
+(`vtscore/datasets/stages/_common.py`, applied by
+`ProgressTracker._overall_raw_fraction`). The weights only shape *pacing*; the
+overall ETA self-corrects from real elapsed-vs-fraction, so bad weights make the
+bar race one phase and crawl another rather than making the final ETA wrong.
+That bounds the value of this work: smooth honest pacing, not a time oracle.
+
+**Why a single vector can't be right.** The phases scale with `n` differently:
+
+| Phase      | Scales with                        | Cost model              |
+|------------|------------------------------------|-------------------------|
+| download   | archive **bytes**, not `n`         | `download_size_mb / bandwidth` |
+| model load | nothing (encoder loaded once)      | fixed per (embedder, device) |
+| embed      | `n` (one forward per item)         | `a_embed + b_embed · n` |
+| finalize   | `n` (dedup + diversity + registry) | `a_fin + b_fin · n` |
+
+Model load is a **constant**, so its *fraction* is large for small datasets and
+negligible for large ones — no single vector is right at both ends. The target
+is an affine per-phase cost fit per (device, media_type, embedder), normalized
+to a weight vector at task creation, with a static fallback when `n` is unknown.
+
+**Measurement matrix** (for the remaining cells): device `{cpu, cuda(±cuML)}` ×
+media `{image, audio, video, text, document}` × each registered embedder × ≥2
+size points per media (vary slice window / `items_per_category` for ≥3 distinct
+`n`). Run each cell ≥3× (median); record cold vs warm model-load and download
+separately; log skipped cells so coverage gaps are explicit.
+
+**Fitting.** Per (device, media_type, embedder): `a_model` = median warm
+model-load; `(a_embed, b_embed)` and `(a_fin, b_fin)` = least-squares vs `n`;
+`bandwidth(device)` = fit of cold download vs `download_size_mb`. Sanity-check
+R²/residuals; fall back to the generic profile where a cell is thin.
+
+This is the concrete follow-up to the "Weights are static guesses" item in
+`docs/plans/progress-bar-consolidation.md`. Non-goals: predicting absolute load
+time (ETA self-corrects); a persistent online model (coefficients are checked-in
+constants); calibrating non-dataset bars (detector load, Find, sort).

--- a/docs/plans/scalability-plan.md
+++ b/docs/plans/scalability-plan.md
@@ -1,435 +1,38 @@
 # Scalability Implementation Plan
 
-**Status:** Mostly open.  **§3.3 (S16) virtual grid mode has shipped** — the
-gallery now virtualizes both grid and list and no longer freezes the UI at a
-few hundred items (added §3.4/S17 as the deferred backend cancel/progress
-follow-up surfaced by that work).  **§1.2 (S9) GMM subsampling has shipped.**
-**§2.1 has shipped** — reload caching plus Part A (smarter k-means
-defaults / auto-capped depth) and Part B (skip auto-build above 50k items + an
-on-demand `POST .../diversity-tree` endpoint); only the optional frontend
-"Build diversity index" button is deferred.  **§2.2 (S12) debounce label sync
-was already implemented** in `vtscore/labels/sync.py` (200ms per-detector
-timer).  Phase 2 is therefore effectively complete on the backend.
-Separately, the CLI-specific streaming work (lazy folder enumeration, per-chunk
-embed, and streaming export — partial fixes for S20/S15/S13 on the
-`--autodetect` target side) **has** shipped; see
+**Status:** §1.2 (S9), §2.1 (S2/S8), §2.2 (S12), and §3.3 (S16) shipped; §1.1 (S5)
+rejected as a misdiagnosis; §1.3/§1.4 (S6/S7) gated until interactive datasets
+approach 1M. Open/next work: §2.3 (S14), §3.1 (S1), §3.2 (S3/S17/S19), §3.4 (S17),
+and Phase 4 (§4.1–§4.3) — full design below, followed by the shipped/rejected
+one-liners under "What shipped".
+
+**Parent:** [`scalability.md`](scalability.md); the brainstorm that defines all S#
+IDs referenced here. **Goal:** Make VTSearch usable at 100k items (near-term) and
+survivable at 1M (medium-term) without a full architectural rewrite; 10M requires
+Phase 4 work and is deferred. Phases are ordered by leverage-to-effort ratio and are
+each shippable independently.
+
+**Target scale (confirmed 2026-06-19, drives what's worth doing):** GUI Train ~50k,
+GUI Find ~250k, CLI Find 2M+. A critical re-read of Phase 1 against these numbers
+**rejected §1.1** as a misdiagnosis and **gated §1.3/§1.4** as not worth their
+correctness risk until interactive datasets actually approach the million-item range
+— at 50k–250k the `sorted(medias.keys())` cost they target is 5–80 ms, noise next to
+the matmul/argsort. Separately, CLI-specific streaming work (lazy folder enumeration,
+per-chunk embed, streaming export — partial fixes for S20/S15/S13 on the
+`--autodetect` side) has shipped; see
 [`cli-stream-massive-images.md`](cli-stream-massive-images.md).
 
-**Target scale (confirmed 2026-06-19, drives what's worth doing):** GUI Train
-~50k, GUI Find ~250k, CLI Find 2M+.  A critical re-read of Phase 1 against these
-numbers (below) **rejected §1.1** as a misdiagnosis and **gated §1.3/§1.4** as
-not worth their correctness risk until interactive datasets actually approach
-the million-item range — at 50k–250k the `sorted(medias.keys())` cost they
-target is 5–80 ms, noise next to the matmul/argsort.  See per-section notes.
-
-**Parent:** [`scalability.md`](scalability.md); the brainstorm that defines
-all S# IDs referenced here.
-
-**Goal:** Make VTSearch usable at 100 k items (near-term) and survivable at
-1 M items (medium-term) without a full architectural rewrite.  10 M items
-requires Phase 4 work and is deferred.
-
-Phases are ordered by leverage-to-effort ratio.  Each phase is shippable
-independently.
-
 ---
 
-## Phase 1: Trivial wins (no architecture change)
-
-These are 1–3 line fixes that eliminate growing hot paths.  Land them
-together in a single PR.
-
-### 1.1  Hash-based threshold cache key (S5) — ❌ REJECTED (misdiagnosis)
-
-> **Verdict (2026-06-19): do not implement.** The premise conflates training-set
-> size with dataset size. `X_list`/`y_list` here are the **labeled examples**
-> (good/bad votes + labelset elements), not the dataset — you do not
-> interactively hand-label 100k items, so the "150 MB at 100k" figure never
-> occurs. The cache is also a **single overwritten slot**
-> (`det_ctx.calibration_cache = (key, payload)`), not a growing structure, so
-> even a large imported labelset costs one key's worth of memory. Worse, the
-> proposed fix still calls `np.stack(...).tobytes()` to build the key and *then*
-> hashes it, **adding** compute on the comparison path to save a few MB on a
-> non-bottleneck. Left here as a record of the dead end; revisit only if
-> labelsets ever grow to tens of thousands of elements (a different feature).
-
-**File:** `vtscore/training/thresholds.py:71–97` (`_calibration_cache_key`)
-
-**Problem:** `np.stack(X_list).tobytes()` produces an `N × D × 4`-byte
-string stored as part of a tuple in `DetectorContext._calibration_threshold_cache`.
-At 10 k training vectors it is already ~15 MB; at 100 k it is 150 MB.
-
-**Fix:** Replace the raw bytes with a `blake2b` digest.
-
-```python
-import hashlib
-
-def _calibration_cache_key(X_list, y_list, inclusion_value, ...):
-    X_bytes = np.stack(X_list).astype(np.float32, copy=False).tobytes()
-    y_bytes = np.asarray(y_list, dtype=np.float32).tobytes()
-    X_hash = hashlib.blake2b(X_bytes, digest_size=16).digest()
-    y_hash = hashlib.blake2b(y_bytes, digest_size=16).digest()
-    return (X_hash, y_hash, int(inclusion_value), ...)
-```
-
-The hash is computed from the same bytes (so correctness is identical), but
-only 32 bytes are stored in the key tuple instead of the full array.
-`blake2b` at this size is ~1 GB/s on modern hardware; far cheaper than
-the current path.
-
-**Risk:** negligible (birthday collision at 2^64; unreachable).
-
----
-
-### 1.2  Subsample GMM threshold (S9) — ✅ SHIPPED
-
-> **Shipped 2026-06-19.** Subsampling now lives *inside*
-> `calculate_gmm_threshold` (single point, so every caller — the every-sort
-> cosine path at `sorting.py:103` and the safe-threshold blend — benefits),
-> gated by `_GMM_MAX_SAMPLES = 50_000` with a seed-42 `default_rng`. The
-> exception-fallback median was also bounded to the subsample. This was the one
-> Phase-1 item with a real, scale-justified payoff: the GMM fits the **full**
-> score distribution, which reaches 250k (GUI Find) to 2M+ (CLI Find). Covered
-> by `tests_lib/sorting/test_gmm_subsample.py`.
-
-**File:** `vtscore/training/thresholds.py:24–68` (`calculate_gmm_threshold`)
-
-**Problem:** Takes all N scores and fits a 2-component GMM.  At 1 M items
-this is an 8 MB array and many EM iterations.
-
-**Fix:** Subsample before fitting.
-
-```python
-_GMM_MAX_SAMPLES = 50_000
-
-def calculate_gmm_threshold(scores: list[float]) -> float:
-    if len(scores) < 2:
-        return 0.5
-    arr = np.array(scores, dtype=np.float32)
-    if len(arr) > _GMM_MAX_SAMPLES:
-        rng = np.random.default_rng(42)
-        arr = rng.choice(arr, size=_GMM_MAX_SAMPLES, replace=False)
-    X = arr.reshape(-1, 1)
-    ...  # rest unchanged
-```
-
-At 50 k samples the GMM threshold is statistically indistinguishable from
-fitting on 1 M samples (two Gaussians only need their means and variances).
-The same subsampling should be applied anywhere `calculate_gmm_threshold`
-is called from the safe-threshold blender
-(`vtscore/training/thresholds.py:378`).
-
-**Risk:** negligible.
-
----
-
-### 1.3  Epoch counter for embedding matrix invalidation (S6) — ⏸ GATED on 1M-scale interactive use
-
-> **Verdict (2026-06-19): defer; not worth the correctness risk at current
-> target scale.** The `sorted(ctx.medias.keys())` it removes costs ~5–15 ms at
-> 50k (GUI Train) and ~30–80 ms at 250k (GUI Find) — noise beside the matmul and
-> argsort on the same call. The only regime where it matters is CLI Find at
-> 2M+, which is a *batch* path (latency-insensitive) rather than interactive.
-> Against that thin payoff, the current check (`cached_ids == sorted_ids`) is
-> **self-correcting — it can never serve a stale matrix.** The epoch scheme
-> replaces it with a manual invariant that every one of ~5 mutation sites must
-> bump; a single miss silently serves the **wrong embedding matrix → wrong
-> scores, no error**. Trading a self-correcting check for a silent-corruption
-> footgun is only justified if interactive datasets approach 1M. Revisit then,
-> with the test in §1.3's checklist landing first.
-
-**File:** `vtscore/state/core.py` (`DatasetContext`),
-`vtscore/embedding/matrix.py:58–79`
-
-**Problem:** `get_embedding_matrix` calls `sorted(ctx.medias.keys())` on
-every invocation; O(N log N); to detect whether the cached matrix is
-stale.
-
-**Fix:** Add an integer `_medias_epoch` field to `DatasetContext`.
-Increment it whenever `medias` is structurally mutated (adds or deletes).
-The matrix cache stores the epoch at build time and validates with O(1)
-integer compare.
-
-`DatasetContext` changes:
-
-```python
-__slots__ = (
-    ...
-    "_medias_epoch",      # int, incremented on add/remove
-    "_emb_matrix_epoch",  # epoch at which the cached matrix was built
-    "_emb_matrix",        # np.ndarray | None
-)
-
-def __init__(self, dataset_id: str = "") -> None:
-    ...
-    self._medias_epoch: int = 0
-    self._emb_matrix_epoch: int = -1
-    self._emb_matrix: Any = None
-```
-
-`_emb_matrix_ids` is dropped; it was only needed for the sorted-key
-comparison and is no longer required.
-
-All sites that structurally modify `ctx.medias` must increment the epoch:
-
-| Site | File |
-|------|------|
-| `ctx.medias[cid] = …` (importer write) | `load_pipeline.py` |
-| `del ctx.medias[cid]` (None-embedding drop) | `load_pipeline.py:932` |
-| `ctx.medias.clear()` | `vtscore/state/__init__.py:134` |
-| `collapse_duplicates` (may delete) | `vtscore/state/media_lookup.py` |
-
-Since `medias` is a plain dict and Python does not support dict hooks,
-the epoch must be incremented manually at each mutation site.  A helper
-`def _bump_epoch(ctx)` in `core.py` keeps this one line per site.
-
-`get_embedding_matrix` becomes:
-
-```python
-def get_embedding_matrix(ctx):
-    with _state_lock:
-        if ctx._emb_matrix is not None and ctx._emb_matrix_epoch == ctx._medias_epoch:
-            sorted_ids = sorted(ctx.medias.keys())  # still needed for the return value
-            return list(sorted_ids), ctx._emb_matrix
-        ...  # rebuild as before; store ctx._emb_matrix_epoch = ctx._medias_epoch
-```
-
-Wait; the sorted_ids return value still needs `sorted(...)` on the cache
-hit path.  Callers that need the id list on every call will still pay O(N
-log N) for that.  Fix those callers to not re-sort on cache-hit:
-
-- Store `_emb_matrix_sorted_ids: list[int]` alongside the matrix (same as
-  today's `_emb_matrix_ids`, but now the epoch is the validity signal, not
-  the list comparison).  Return the stored list on cache hit.
-
-Net result: the epoch check is O(1); `sorted(...)` only runs on cache miss
-(i.e. when the dataset actually changed).
-
-**`get_embedding_matrix_for_snap`** (line 89): also performs
-`sorted(snap.keys())` (line 102) and `sorted(ctx.medias.keys())` (line 115).
-After this change, the ctx branch reuses the epoch path (shared cached
-matrix); the temp-dict/cross-dataset branch still sorts once (unavoidable
-since there is no epoch for an ad-hoc dict).
-
-**Risk:** medium; touches `DatasetContext.__slots__` and several mutation
-sites.  Must be covered by tests that verify the matrix is rebuilt exactly
-when medias change.
-
----
-
-### 1.4  Epoch-based learned-sort signature (S7) — ⏸ GATED (depends on 1.3)
-
-> **Verdict (2026-06-19): defer with 1.3.** Same `sorted(snap.keys())` cost
-> profile (negligible ≤250k), and this item piggybacks on 1.3's epoch counter,
-> so it inherits the same gating and the same staleness risk. The actual
-> signature builder now lives in
-> `vtscore/detectors/learned_sort.py:build_learned_sort_signature` (the line
-> reference below is stale). Note learned-sort is the GUI **Train** path, capped
-> at ~50k — the regime where this optimization matters least.
-
-**File:** `vtsearch/routes/sorting.py:340–358` (`_build_learned_sort_signature`)
-
-**Problem:**
-
-```python
-tuple(sorted(snap.keys())),                         # O(N log N)
-("regions", tuple(sorted(region_boxes_snapshot.items()))),  # O(R log R)
-```
-
-Both appear inside the signature that is checked before every learned-sort
-job.
-
-**Fix:** Replace `tuple(sorted(snap.keys()))` with
-`("epoch", ctx._medias_epoch)` fetched from the active `DatasetContext`.
-Replace the region-box sort with a frozen-set hash of region IDs (vote
-regions are small, so this is negligible, but the sort is wasteful).
-
-```python
-from vtscore.state.core import get_active_context
-
-epoch = get_active_context()._medias_epoch
-region_sig = frozenset(region_boxes_snapshot.keys())
-
-sig = (
-    ("epoch", epoch),
-    ("votes", tuple(sorted(good_votes)) + tuple(sorted(bad_votes))),
-    ("regions", region_sig),
-    ("inclusion", inclusion),
-    ...
-)
-```
-
-Vote sets are small (tens to hundreds of items), so sorting them is cheap.
-
-**Risk:** low; the signature is only a cache key; a false miss (different
-epoch, same medias) wastes one retrain; a false hit (same epoch, different
-medias) cannot happen because the epoch is only bumped on structural change.
-
----
-
-## Phase 2: Medium effort, high leverage
-
-### 2.1  Cap and defer diversity tree construction (S2, S8) — ✅ SHIPPED
-
-> **Reload caching shipped 2026-06-19** (commit 64cccd5e, PR #1987). The
-> diversity tree is now serialized into the dataset pickle at creation and
-> restored on reload via `restore_diversity_tree_from_cache`, which adopts the
-> cache only when its vector set exactly matches the loaded medias (any
-> remap/dedup/drop falls back to a rebuild). `_build_diversity_tree_stage`
-> skips when a tree is already present; cache-less (pre-change) pickles keep
-> rebuilding eagerly and age off. This removes the rebuild cost on every
-> *reload*, but the **first** build at dataset creation still paid full cost.
->
-> **Part A + Part B shipped 2026-06-25** (backend only). Part A:
-> `_n_init_for(node_size)` scales k-means restarts down for large nodes (3 above
-> 10k, 5 above 1k, 10 otherwise) and `auto_max_depth(n, k, min_node_size)` caps
-> tree depth at the natural splitting depth bounded by `_MAX_LEAVES=4000`; both
-> live in `vtscore/state/diversity_tree.py` and are applied by the two build
-> helpers in `vtscore/state/diversity.py`. Because the small-node branch keeps
-> the full restart count and `auto_max_depth` never caps *below* the natural
-> depth (where `_build_node` already stops via `min_node_size`), trees over
-> normal/test-sized datasets are structurally unchanged. Part B:
-> `should_auto_build_diversity_tree(n)` (threshold
-> `DIVERSITY_TREE_AUTO_THRESHOLD=50_000`) gates the auto-build; the load
-> pipeline (`stages/finalize.py`) and the registry load path skip it above the
-> threshold, and `POST /api/datasets/registry/<id>/diversity-tree` builds it on
-> demand in a cancellable background job (resyncing the active detector's votes
-> when they belong to the dataset). **Deferred:** the frontend "Build diversity
-> index" button — the endpoint is reachable via API/CLI; tree absence already
-> degrades gracefully (autopilot falls back to score-only sampling). See Open
-> follow-ups.
-
-**Files:** `vtscore/state/diversity_tree.py`,
-`vtscore/datasets/load_pipeline.py:968–981`
-
-**Problem:** The diversity tree is always built at load time.  At 100 k
-items it already takes several seconds; at 1 M it takes minutes and
-allocates GBs.  (The reload path is now cached — see the shipped note above —
-so what remains is the cost of the *initial* build at creation time.)
-
-**Fix (two parts):**
-
-**Part A; smarter defaults.**  In `DiversityTree.__init__`, cap k-means
-`_N_INIT` as a function of node size:
-
-```python
-def _n_init_for(node_size: int) -> int:
-    if node_size > 10_000:
-        return 3   # large nodes converge reliably; fewer restarts
-    if node_size > 1_000:
-        return 5
-    return 10  # current default for small nodes
-```
-
-Similarly auto-cap `max_depth` so the tree never has more than ~4 000 leaf
-nodes regardless of N:
-
-```python
-def _auto_max_depth(n: int, k: int, min_node_size: int) -> int:
-    import math
-    max_leaves = 4_000
-    # k^depth ≈ n / min_node_size, capped at max_leaves
-    natural = math.ceil(math.log(n / max(min_node_size, 1), max(k, 2)))
-    cap = math.ceil(math.log(max_leaves, max(k, 2)))
-    return min(DIVERSITY_TREE_MAX_DEPTH, natural, cap)
-```
-
-Apply this in `build_diversity_tree_for_context` when the caller doesn't
-pass an explicit `max_depth`.
-
-**Part B; skip above a threshold; expose a "Build diversity tree" endpoint.**
-In `_build_diversity_tree_stage` (load pipeline):
-
-```python
-_DIVERSITY_TREE_AUTO_THRESHOLD = 50_000  # skip auto-build above this
-
-def _build_diversity_tree_stage(ctx, tracker):
-    n = len(ctx.medias)
-    if n > _DIVERSITY_TREE_AUTO_THRESHOLD:
-        # Tree skipped at load time; user can trigger it via POST /api/datasets/.../diversity-tree
-        return
-    ...build as today...
-```
-
-Add a new route `POST /api/datasets/registry/<id>/diversity-tree` that
-builds the tree in the background (reusing the existing `JobManager`
-pattern) and reports progress via `/api/progress/dataset/<id>`.  The
-frontend shows a "Build diversity index" button in the dataset panel when
-the tree is absent.
-
-**Risk:** medium; the diversity tree is the autopilot's diversity signal.
-Without it, autopilot falls back to score-only sampling.  This is
-acceptable and already handled by the `if tree is None` guard in
-`diversity_tree_next_sample`.
-
----
-
-### 2.2  Debounce label sync writes (S12) — ✅ ALREADY SHIPPED
-
-> **Already implemented** in `vtscore/labels/sync.py`. `sync_to_labelset_source`
-> is debounced and asynchronous: each call schedules a per-detector
-> `threading.Timer` (`_DEBOUNCE_DELAY = 0.2s`, keyed by `detector_id`), so a
-> rapid voting burst collapses into a single background push that uses the
-> latest state. `flush_pending_label_syncs` drains synchronously for tests /
-> graceful shutdown, and an `atexit` hook flushes the last pending push on
-> normal exit. The shipped delay is 200ms rather than the 2s sketched below,
-> which keeps the on-disk labels within a UI tick while still coalescing
-> bursts. No further work needed.
-
-**File:** `vtscore/labels/sync.py` (`sync_to_labelset_source`)
-
-**Problem:** `sync_to_labelset_source` fires on every vote and rewrites
-the entire JSON labelset file.  At 100 k labels the file is ~50–100 MB;
-each vote stalls the vote handler for seconds.
-
-**Fix:** Debounce with a per-detector background flush.
-
-```python
-import threading
-
-_flush_timers: dict[str, threading.Timer] = {}  # detector_id → timer
-_FLUSH_DELAY = 2.0  # seconds
-
-def sync_to_labelset_source(flush_delay: float = _FLUSH_DELAY) -> None:
-    from vtscore.state.core import get_active_detector_context
-    det_ctx = get_active_detector_context()
-    det_id = det_ctx.detector_id
-
-    # Cancel any pending flush for this detector.
-    if det_id in _flush_timers:
-        _flush_timers[det_id].cancel()
-
-    def _flush():
-        _flush_timers.pop(det_id, None)
-        _do_sync_to_labelset_source()  # existing implementation
-
-    timer = threading.Timer(flush_delay, _flush)
-    timer.daemon = True
-    timer.start()
-    _flush_timers[det_id] = timer
-```
-
-This means votes accumulate for up to 2 s before a write fires; one write
-instead of N.  On process shutdown the timers are daemon threads so they do
-not block exit; the settings-source sync (which is already separate) is
-responsible for flushing on graceful shutdown.
-
-An immediate flush can be forced by passing `flush_delay=0`; useful in
-tests and in the label-export route.
-
-**Risk:** low; labels might be up to 2 s stale in the sync target after a
-vote, which is acceptable.
-
----
+## Open / next work
 
 ### 2.3  Incremental secondary lookups on DatasetContext (S14)
 
-**File:** `vtscore/state/core.py` (`DatasetContext`),
-various route files that rebuild `md5_to_media` / `origin_key_to_cid` per
-request.
+**File:** `vtscore/state/core.py` (`DatasetContext`), various route files that rebuild
+`md5_to_media` / `origin_key_to_cid` per request.
 
-**Problem:** Many routes rebuild `{m["md5"]: m for m in snap.values()}`
-(or similar) on every request; O(N) Python iteration with dict construction.
+**Problem:** Many routes rebuild `{m["md5"]: m for m in snap.values()}` (or similar)
+on every request; O(N) Python iteration with dict construction.
 
 **Fix:** Add maintained secondary indexes to `DatasetContext`:
 
@@ -447,7 +50,7 @@ class DatasetContext:
         self._origin_key_index: dict[str, int] = {}
 ```
 
-Maintained by the same mutation sites that bump `_medias_epoch` (Phase 1.3):
+Maintained by the same mutation sites that would bump `_medias_epoch` (§1.3):
 
 ```python
 def _add_media(ctx, cid, media):
@@ -466,95 +69,64 @@ def _remove_media(ctx, cid):
         ctx._origin_key_index.pop(_stable_origin_key(media), None)
 ```
 
-Routes and helpers that currently rebuild lookup dicts from the full
-snapshot switch to `ctx._md5_index` / `ctx._origin_key_index` directly.
+Routes/helpers that rebuild lookup dicts switch to `ctx._md5_index` /
+`ctx._origin_key_index` directly. Medium refactor because mutation sites are spread
+across `load_pipeline.py`, `state/__init__.py`, and `state/media_lookup.py`.
 
-This is a medium refactor because mutation sites are spread across
-`load_pipeline.py`, `state/__init__.py`, and `state/media_lookup.py`.
-
-**Risk:** medium; secondary indexes must stay in sync with `medias`.  Any
-site that writes to `ctx.medias` directly (bypassing the helper) will
-produce stale indexes.  The Phase 1.3 epoch audit surfaces all those sites,
-so Phase 1.3 should land first.
+**Risk:** medium; secondary indexes must stay in sync with `medias`. Any site that
+writes `ctx.medias` directly (bypassing the helper) produces stale indexes. The §1.3
+epoch audit surfaces all those sites, so §1.3 should land first.
 
 ---
 
-## Phase 3: Larger architectural work
-
 ### 3.1  mmap embedding matrix (S1)
 
-**Files:** `vtscore/datasets/loader_pickle.py`,
-`vtscore/embedding/matrix.py`
+**Files:** `vtscore/datasets/loader_pickle.py`, `vtscore/embedding/matrix.py`
 
 **Problem:** Embeddings are stored inline in `media["embedding"]` as Python
-lists/arrays, then copied into a contiguous `(N, D)` NumPy array on first
-access.  At 1 M items × 384-dim the array is 1.5 GB; it must be rebuilt
-from the per-item entries on every cold start.
+lists/arrays, then copied into a contiguous `(N, D)` NumPy array on first access. At
+1M items × 384-dim the array is 1.5 GB; it must be rebuilt from per-item entries on
+every cold start.
 
 **Fix (two-step):**
 
-**Step A; sidecar `.npy` file.**  During the post-load phase
-(after all embeddings are present), write the sorted-by-cid embedding
-matrix to `<dataset_path>.emb.npy` if it doesn't already exist.  Format:
+**Step A — sidecar `.npy` file.** After all embeddings are present, write the
+sorted-by-cid matrix to `<dataset>.emb.npy` (+ companion `<dataset>.cids.npy`, int64
+sorted cids) if it doesn't already exist.
 
-```
-# Header line (JSON): {"cids": [1, 2, 3, ...], "dim": 384, "dtype": "float32"}
-# Body: raw float32 bytes, row-major, shape (N, D)
-```
-
-Actually simpler: use `np.save` / `np.load` with a companion `<dataset>.cids.npy`
-(int64 array of sorted cids) and `<dataset>.emb.npy` (float32 matrix).
-
-**Step B; mmap load.**  On pickle load, check whether both sidecars exist
-and their cid list matches the pickle's media IDs.  If so:
+**Step B — mmap load.** On pickle load, if both sidecars exist and the cid list
+matches the pickle's media IDs:
 
 ```python
-cids = np.load(cids_path)          # int64 array
+cids = np.load(cids_path)                  # int64 array
 matrix = np.load(emb_path, mmap_mode='r')  # zero-RAM mmap
 ctx._emb_matrix = matrix
 ctx._emb_matrix_sorted_ids = list(cids)
 ctx._emb_matrix_epoch = ctx._medias_epoch
 ```
 
-The OS pages in only the rows that scoring actually accesses.  For a
-100-item sort query on a 1 M item dataset, only ~40 kB of the 1.5 GB file
-is touched.
+The OS pages in only the rows scoring actually accesses (a 100-item sort query on a
+1M dataset touches ~40 kB of the 1.5 GB file). `get_embedding_matrix` must detect the
+cached-this-way matrix and skip the rebuild.
 
-`get_embedding_matrix` must detect when the matrix is already cached this
-way and skip the rebuild.
+**Sidecar invalidation:** if the pickle is newer than the sidecar, or the cid list
+doesn't match, fall back to the in-memory build (optionally rewrite fresh sidecars).
 
-**Sidecar invalidation:** If the pickle file is newer than the sidecar, or
-if the cid list doesn't match, fall back to the in-memory build (and
-optionally write fresh sidecars).
-
-**Risk:** high; introduces file-system state alongside pickle files.
-Must be careful about:
-- Race between sidecar write and concurrent load
-- Version drift if the embedder changes (embedding dim changes → sidecar invalid)
-- Docker / read-only filesystems (fall back gracefully to in-memory)
-
-A `--no-emb-sidecar` CLI flag (or a settings key) can disable sidecar
-writing for environments where the dataset path is read-only.
+**Risk:** high; introduces file-system state alongside pickle files. Care needed for:
+race between sidecar write and concurrent load; version drift if the embedder changes
+(embedding dim changes → sidecar invalid); Docker / read-only filesystems (fall back
+to in-memory). A `--no-emb-sidecar` flag (or settings key) disables sidecar writing
+where the dataset path is read-only.
 
 ---
 
 ### 3.2  Sparse sort results: top-K API + lazy frontend (S3, S17, S19)
 
-This is the largest single change.  It requires coordinated backend + frontend
-work and must be landed as a pair of PRs.
+The largest single change; requires coordinated backend + frontend work landed as a
+pair of PRs.
 
-**Backend changes:**
-
-`POST /api/sort/cosine` and `POST /api/sort/learned` currently return:
-
-```json
-{
-  "results": [{"id": 1, "score": 0.91, "bestRegion": null}, ...],
-  "threshold": 0.72
-}
-```
-
-for all N items.  Change the response to:
+**Backend.** `POST /api/sort/cosine` and `/api/sort/learned` currently return all N
+items. Change the response to a windowed shape:
 
 ```json
 {
@@ -566,57 +138,32 @@ for all N items.  Change the response to:
 }
 ```
 
-where `results` contains only the top `K_ABOVE` items above threshold
-plus `K_BELOW` items immediately below (e.g. `K_ABOVE = 500`,
-`K_BELOW = 200`).  Clients that need more items fetch:
+where `results` contains only the top `K_ABOVE` items above threshold plus `K_BELOW`
+immediately below (e.g. 500 / 200). Clients fetch more via
+`GET /api/sort/page?offset=500&limit=200`. The full sorted order is computed as today
+but only a window is transmitted; the backend holds the full list in the existing
+`AsyncJob.result`.
 
-```
-GET /api/sort/page?offset=500&limit=200
-```
-
-The full sorted order is computed in the backend as today, but only a
-window is transmitted.  The backend holds the full sorted list in the
-existing job result (already stored in `AsyncJob.result`).
-
-**Frontend changes:**
-
-`SortStateService` currently holds `SortedItem[] | null`.  Replace with:
+**Frontend.** Replace `SortStateService`'s `SortedItem[] | null` with a windowed model:
 
 ```typescript
 interface SortWindow {
   total: number;
   threshold: number;
   aboveThreshold: number;
-  items: SortedItem[];        // the loaded window
-  loadedRange: [number, number]; // [start, end] indices
+  items: SortedItem[];            // the loaded window
+  loadedRange: [number, number];  // [start, end] indices
   hasMore: boolean;
 }
 ```
 
-`media-list.component.ts:rebuildOrderedItems` no longer iterates a
-full array; it renders whatever is in `items` and shows a "Load more"
-trigger at the end.  `cachedOrderedItems` stays bounded to the loaded
-window (≤ 700 items by default).
+`media-list.component.ts:rebuildOrderedItems` renders whatever is in `items` and shows
+a "Load more" trigger at the end; `cachedOrderedItems` stays bounded to the loaded
+window (≤700). Virtual scroll already handles a fixed window; this caps the array size
+at the API level.
 
-Virtual scroll on the frontend already handles a fixed window; this just
-caps the array size at the API level.
-
-**Complexity:** 2–3 PRs (backend sort API, frontend SortStateService,
-frontend media-list).  All three must land atomically or behind a feature
-flag.
-
----
-
-### ~~3.3  Virtual grid mode (S16)~~ — **SHIPPED**
-
-`media-list/` now chunks `cachedOrderedItems` into fixed-width rows through a
-`CdkVirtualScrollViewport` (one virtual item = one row of `gridColumns` cards;
-columns derived from measured viewport width, row stride measured from a real
-card via `ResizeObserver`; threshold marker gets its own full-width row;
-grid-aware `scrollToIndex`/selected-scroll/prefetch). The list-virtualization
-threshold dropped 500 → **150**; grid virtualizes above 80. Result: list↔grid
-toggles ~169 ms (was ~1129 ms), grid switch ~18 ms (was ~1814 ms), ~20–34
-components in the DOM instead of 412.
+**Complexity:** 2–3 PRs (backend sort API, frontend SortStateService, frontend
+media-list). All must land atomically or behind a feature flag.
 
 ---
 
@@ -625,99 +172,192 @@ components in the DOM instead of 412.
 **Files:** `vtscore/datasets/container.py` (`read_container`),
 `vtscore/datasets/loader_pickle.py`, `vtscore/datasets/load_pipeline.py`
 
-**Problem (found while investigating the S16 freeze, deferred for now):** the
-dataset load runs in a daemon thread and streams progress over SSE, so for
-the demo datasets the dashboard load stays responsive with a working Cancel.
-But on a large `.pkl` two things still read as "frozen, Cancel does nothing":
+**Problem (found while investigating the S16 freeze):** the dataset load runs in a
+daemon thread and streams SSE progress, so demo-dataset loads stay responsive with a
+working Cancel. But on a large `.pkl` two things read as "frozen, Cancel does nothing":
 
-1. **`read_container` is one un-cancellable, no-progress step.** It does a
-   full ZIP `zf.read("medias.pkl")` (DEFLATE decompress of the whole blob) +
-   `safe_pickle_load` of the entire dict.  While it runs the bar sits at
-   "Reading…" and — because the dev server is a single process holding the
-   GIL through that pure-Python work — the Cancel/SSE endpoints can't be
-   serviced.  So the progress bar appears stuck and Cancel is inert until it
+1. **`read_container` is one un-cancellable, no-progress step.** A full ZIP
+   `zf.read("medias.pkl")` (DEFLATE of the whole blob) + `safe_pickle_load` of the
+   entire dict. While it runs the bar sits at "Reading…" and — because the dev server
+   is a single process holding the GIL through that pure-Python work — the Cancel/SSE
+   endpoints can't be serviced, so the bar appears stuck and Cancel is inert until it
    finishes.
-2. **Cancel is unchecked for the whole import phase.** `_run_importer(...)`
-   runs the entire pickle-conversion loop with no `tracker.check_cancelled()`
-   inside; the first cancel check is only *after* it returns
-   (`load_pipeline.py`, right after `_run_importer`).  So even once the read
-   finishes, a click during conversion doesn't abort until the loop ends.
+2. **Cancel is unchecked for the whole import phase.** `_run_importer(...)` runs the
+   entire pickle-conversion loop with no `tracker.check_cancelled()` inside; the first
+   cancel check is only *after* it returns.
 
-**Fix direction:** add `check_cancelled()` inside the
-`load_dataset_from_pickle` conversion loop (it already reports progress every
-`_progress_interval` items — check cancel there too), and give the
-read/decompress phase coarse progress + a cancellation point (e.g. stream the
-ZIP member, or at minimum surface an indeterminate "Reading…" state the user
-understands is uninterruptible).  Overlaps with **S15 (streaming pickle
-load)** below.
+**Fix direction:** add `check_cancelled()` inside the `load_dataset_from_pickle`
+conversion loop (it already reports progress every `_progress_interval` items — check
+cancel there too), and give the read/decompress phase coarse progress + a cancellation
+point (stream the ZIP member, or at minimum surface an honest indeterminate "Reading…"
+state). Overlaps with **§4.1 (streaming pickle load)** below.
 
 ---
 
-## Phase 4: Major infrastructure (1 M+ items)
+### Phase 4: Major infrastructure (1M+ items)
 
-These are deferred until Phase 1–3 are stable.
+Deferred until Phase 1–3 are stable.
 
-### 4.1  Streaming pickle load (S15)
-
-Pickle files > 500 MB should be loaded in chunks.  The embedding matrix
-sidecar (Phase 3.1) decouples embeddings from the pickle, enabling the
-pickle itself to omit inline embeddings.  Once that is in place, the
-pickle file becomes mostly metadata (filenames, origins, md5s) and can
-be loaded quickly; embeddings come from the mmap'd sidecar.
-
-### 4.2  Parallel cross-dataset label population (S11)
-
-`populate_label_embeddings` in `vtscore/detectors/labelset_training.py`
-resolves and embeds each LabelSet element sequentially.  Replace with a
-`ThreadPoolExecutor` (bounded by the same `_embed_gate` that governs
-dataset embedding concurrency).  Deduplicate file resolves across elements
-with the same origin before dispatching.
-
-### 4.3  Streaming JSON label export (S13)
-
-Replace `LabelSet.to_dict()` → `flask.jsonify()` with a generator that
-yields one JSON line per label element, wrapped in `flask.stream_with_context`.
-Requires clients to parse a newline-delimited JSON stream (NDJSON) or the
-existing `{"labels": [...]}` wrapper using a streaming parser.  The simpler
-approach is to add a `?format=ndjson` query param and keep the default
-response identical.
+- **4.1  Streaming pickle load (S15).** Pickle files > 500 MB should load in chunks.
+  The embedding-matrix sidecar (§3.1) decouples embeddings from the pickle, so the
+  pickle becomes mostly metadata (filenames, origins, md5s) and can load quickly;
+  embeddings come from the mmap'd sidecar.
+- **4.2  Parallel cross-dataset label population (S11).**
+  `populate_label_embeddings` (`vtscore/detectors/labelset_training.py`) resolves and
+  embeds each LabelSet element sequentially. Replace with a `ThreadPoolExecutor`
+  (bounded by the same `_embed_gate` that governs dataset embedding concurrency);
+  dedupe file resolves across elements with the same origin before dispatching.
+- **4.3  Streaming JSON label export (S13).** Replace
+  `LabelSet.to_dict()` → `flask.jsonify()` with a generator yielding one JSON line per
+  element, wrapped in `flask.stream_with_context`. Simplest: add a `?format=ndjson`
+  query param and keep the default response identical.
 
 ---
 
-## Test coverage checklist
+## Gated (deferred until 1M-scale interactive use)
 
-Each phase needs targeted tests before merging:
+### 1.3  Epoch counter for embedding matrix invalidation (S6) — ⏸ GATED
 
-- **1.1**: Unit test: cache key is always the same tuple length regardless
-  of N_labels; verify no collision for distinct X/y pairs.
-- **1.2**: Unit test: `calculate_gmm_threshold` with N > 50 k produces a
-  threshold within 1% of the full-sample result (use a known bimodal
-  distribution).
-- **1.3**: Integration test: matrix is rebuilt exactly when medias change,
-  reused when they don't; epoch counter is O(1) to check.
-- **1.4**: Integration test: learned-sort job is not re-fired when called
-  twice with the same votes on the same epoch.
-- **2.1**: Load test: dataset with 100 k items loads in < 30 s without a
-  diversity tree; "Build diversity tree" endpoint completes and the result
-  is used by autopilot.
-- **2.2**: Integration test: 100 rapid votes produce exactly 1 file write
-  within 2 s of the last vote.
-- **3.1**: Integration test: load, unload, reload a dataset; matrix is
-  re-used from sidecar on second load without rebuilding from per-item entries.
-- **3.2**: API test: sort response with 200 k items contains ≤ 700 results;
-  `/api/sort/page?offset=700&limit=200` returns the next window.
+> **Verdict (2026-06-19): defer; not worth the correctness risk at current target
+> scale.** The `sorted(ctx.medias.keys())` it removes costs ~5–15 ms at 50k and
+> ~30–80 ms at 250k — noise beside the matmul/argsort on the same call. The only
+> regime where it matters is CLI Find at 2M+, a *batch* path (latency-insensitive).
+> Against that thin payoff, the current check (`cached_ids == sorted_ids`) is
+> **self-correcting — it can never serve a stale matrix.** The epoch scheme replaces
+> it with a manual invariant every one of ~5 mutation sites must bump; a single miss
+> silently serves the **wrong embedding matrix → wrong scores, no error.** Revisit
+> only if interactive datasets approach 1M, with the §1.3 test landing first.
+
+**File:** `vtscore/state/core.py` (`DatasetContext`), `vtscore/embedding/matrix.py:58–79`
+
+**Problem:** `get_embedding_matrix` calls `sorted(ctx.medias.keys())` on every
+invocation (O(N log N)) to detect a stale cached matrix.
+
+**Fix:** Add an integer `_medias_epoch` to `DatasetContext`, incremented whenever
+`medias` is structurally mutated (adds/deletes). The matrix cache stores the epoch at
+build time and validates with an O(1) integer compare; `_emb_matrix_ids` is dropped.
+
+```python
+__slots__ = (..., "_medias_epoch", "_emb_matrix_epoch", "_emb_matrix")
+# __init__: _medias_epoch = 0; _emb_matrix_epoch = -1; _emb_matrix = None
+```
+
+All sites that structurally modify `ctx.medias` must increment the epoch:
+
+| Site | File |
+|------|------|
+| `ctx.medias[cid] = …` (importer write) | `load_pipeline.py` |
+| `del ctx.medias[cid]` (None-embedding drop) | `load_pipeline.py:932` |
+| `ctx.medias.clear()` | `vtscore/state/__init__.py:134` |
+| `collapse_duplicates` (may delete) | `vtscore/state/media_lookup.py` |
+
+Since `medias` is a plain dict with no hooks, a helper `_bump_epoch(ctx)` in `core.py`
+keeps this one line per site. On cache hit the return value still needs the id list,
+so store `_emb_matrix_sorted_ids` alongside the matrix (the epoch is the validity
+signal, not the list comparison) and return the stored list; `sorted(...)` only runs
+on cache miss. `get_embedding_matrix_for_snap` reuses the epoch path on the ctx
+branch; the temp-dict/cross-dataset branch still sorts once (no epoch for an ad-hoc
+dict).
+
+**Risk:** medium; touches `__slots__` and several mutation sites. Must be covered by
+tests that verify the matrix rebuilds exactly when medias change.
+
+---
+
+### 1.4  Epoch-based learned-sort signature (S7) — ⏸ GATED (depends on 1.3)
+
+> **Verdict (2026-06-19): defer with 1.3.** Same `sorted(snap.keys())` cost profile
+> (negligible ≤250k), and it piggybacks on §1.3's epoch counter, so it inherits the
+> same gating and staleness risk. The signature builder now lives in
+> `vtscore/detectors/learned_sort.py:build_learned_sort_signature` (the line
+> reference below is stale). Note learned-sort is the GUI **Train** path (~50k) — the
+> regime where this optimization matters least.
+
+**File:** `vtsearch/routes/sorting.py:340–358` (`_build_learned_sort_signature`)
+
+**Problem:** `tuple(sorted(snap.keys()))` (O(N log N)) and
+`tuple(sorted(region_boxes_snapshot.items()))` (O(R log R)) appear inside the
+signature checked before every learned-sort job.
+
+**Fix:** Replace `tuple(sorted(snap.keys()))` with `("epoch", ctx._medias_epoch)`;
+replace the region-box sort with a frozen-set of region IDs.
+
+```python
+epoch = get_active_context()._medias_epoch
+region_sig = frozenset(region_boxes_snapshot.keys())
+sig = (("epoch", epoch), ("votes", ...), ("regions", region_sig), ("inclusion", ...), ...)
+```
+
+Vote sets are small, so sorting them stays cheap.
+
+**Risk:** low; the signature is only a cache key — a false miss wastes one retrain; a
+false hit can't happen because the epoch bumps only on structural change.
 
 ---
 
 ## Open follow-ups
 
 - Frontend "Build diversity index" button (deferred from §2.1 Part B): surface a
-  trigger for `POST /api/datasets/registry/<id>/diversity-tree` when a loaded
-  dataset has no tree. No existing dataset/tree-status panel hosts it today, so
-  it needs a UI home; the endpoint is meanwhile reachable via API/CLI.
-- FAISS / HNSW replacement for diversity tree (long-term S2 fix)
-- Columnar `medias` storage (S4): deferred; requires redesign of every
-  media-reading call site
-- Append-only vote journal for labelset sources (S12 long-term): deferred
-  until compaction semantics are defined
-- CLI progress bar rate-limiting (S21): trivial, add when touching CLI
+  trigger for `POST /api/datasets/registry/<id>/diversity-tree` when a loaded dataset
+  has no tree. No existing dataset/tree-status panel hosts it today, so it needs a UI
+  home; the endpoint is meanwhile reachable via API/CLI.
+- FAISS / HNSW replacement for diversity tree (long-term S2 fix).
+- Columnar `medias` storage (S4): deferred; requires redesign of every media-reading
+  call site.
+- Append-only vote journal for labelset sources (S12 long-term): deferred until
+  compaction semantics are defined.
+- CLI progress bar rate-limiting (S21): trivial, add when touching CLI.
+
+## Test coverage checklist (open items)
+
+- **1.3**: matrix rebuilt exactly when medias change, reused when they don't; epoch
+  check is O(1).
+- **1.4**: learned-sort job not re-fired when called twice with the same votes on the
+  same epoch.
+- **3.1**: load, unload, reload a dataset; matrix re-used from sidecar on second load
+  without rebuilding from per-item entries.
+- **3.2**: sort response with 200k items contains ≤700 results;
+  `/api/sort/page?offset=700&limit=200` returns the next window.
+
+---
+
+## What shipped
+
+- **§1.2  Subsample GMM threshold (S9)** — shipped 2026-06-19. Subsampling lives
+  inside `calculate_gmm_threshold` (single point, so every caller benefits), gated by
+  `_GMM_MAX_SAMPLES = 50_000` with a seed-42 `default_rng`; the exception-fallback
+  median is bounded to the subsample too. The one Phase-1 item with a real,
+  scale-justified payoff (the GMM fits the full score distribution, 250k–2M+).
+  `tests_lib/sorting/test_gmm_subsample.py`.
+- **§2.1  Cap and defer diversity tree construction (S2, S8)** — reload caching
+  shipped 2026-06-19 (commit 64cccd5e, PR #1987): the tree is serialized into the
+  pickle and restored via `restore_diversity_tree_from_cache` (adopted only when its
+  vector set exactly matches the loaded medias, else rebuild). Part A + Part B shipped
+  2026-06-25 (backend): `_n_init_for(node_size)` scales k-means restarts down for
+  large nodes and `auto_max_depth(...)` caps depth at `_MAX_LEAVES=4000`
+  (`vtscore/state/diversity_tree.py`), both structurally no-op on normal/test-sized
+  trees; `should_auto_build_diversity_tree(n)` (threshold
+  `DIVERSITY_TREE_AUTO_THRESHOLD=50_000`) gates the auto-build, and
+  `POST /api/datasets/registry/<id>/diversity-tree` builds on demand in a cancellable
+  job. Deferred: the frontend "Build diversity index" button (see Open follow-ups).
+- **§2.2  Debounce label sync writes (S12)** — already implemented in
+  `vtscore/labels/sync.py`: `sync_to_labelset_source` schedules a per-detector
+  `threading.Timer` (`_DEBOUNCE_DELAY = 0.2s`, keyed by `detector_id`), so a rapid
+  voting burst collapses into one background push; `flush_pending_label_syncs` drains
+  synchronously for tests/shutdown, with an `atexit` flush. 200ms (vs the 2s sketch)
+  keeps on-disk labels within a UI tick while coalescing bursts.
+- **§3.3  Virtual grid mode (S16)** — shipped. `media-list/` chunks
+  `cachedOrderedItems` into fixed-width rows through a `CdkVirtualScrollViewport`
+  (one virtual item = one row of `gridColumns` cards; columns from measured viewport
+  width, row stride from a real card via `ResizeObserver`; grid-aware
+  `scrollToIndex`/selected-scroll/prefetch). List-virtualization threshold dropped
+  500 → 150; grid virtualizes above 80. Result: list↔grid toggle ~169 ms (was ~1129),
+  grid switch ~18 ms (was ~1814), ~20–34 DOM components instead of 412. (Surfaced
+  §3.4/S17 as the deferred backend cancel/progress follow-up, still open above.)
+- **§1.1  Hash-based threshold cache key (S5)** — ❌ **REJECTED** (misdiagnosis):
+  conflates training-set size with dataset size. `X_list`/`y_list` are labeled
+  examples (votes + labelset elements), not the dataset, so the "150 MB at 100k"
+  figure never occurs; the cache is a single overwritten slot, not a growing
+  structure; and the proposed fix would *add* `np.stack(...).tobytes()` compute on the
+  comparison path to save a few MB on a non-bottleneck. Revisit only if labelsets ever
+  grow to tens of thousands of elements (a different feature).

--- a/docs/plans/scalability.md
+++ b/docs/plans/scalability.md
@@ -1,26 +1,58 @@
 # VTSearch Scalability Brainstorm
 
-**Status:** Brainstorm / open; no fixes shipped yet.
+**Status:** Brainstorm / reference; no full item shipped (only the partial CLI
+streaming pieces noted inline on S13/S15/S20). This doc **defines the `S#`
+IDs** referenced by `docs/plans/scalability-plan.md`; the catalog below is the
+reference. Next-work priorities and open follow-ups are foregrounded here.
 
 **Scope:** What breaks, slows, or explodes in memory as datasets grow to
 100 k / 1 M / 10 M items, and as LabelSets grow to 1 k / 10 k / 100 k labels.
-Both GUI and CLI considered. Ordered roughly by severity / likelihood to hurt
-first.
+Both GUI and CLI considered.
 
-Line references are approximate; they will drift as the codebase evolves.
+## Suggested fix order (max-leverage first — the next work)
+
+1. **S6 + S7** (epoch counter); trivial code change, eliminates O(N log N)
+   hot path from every sort and retrain. Low risk, high gain.
+2. **S1** (mmap embedding matrix); unblocks 1 M+ datasets without OOM.
+   Moderate effort.
+3. **S5** (hash-based threshold cache key); trivial, eliminates fat cache
+   key before it becomes a memory landmine.
+4. **S9** (subsample GMM); two-line fix, eliminates a growing cost on every
+   retrain.
+5. **S2 + S8** (cap/defer diversity tree); makes 100 k+ datasets load
+   usably fast; tree can remain available but opt-in.
+6. **S3 + S17 + S19** (sparse sort results, lazy ordered items); must be
+   done together; unblocks 1 M+ in the frontend.
+7. **S12** (debounce label sync); makes voting with large labelsets not
+   stall the UI.
+8. **S16** (virtual grid); significant frontend work but required for grid
+   mode at any large scale.
+9. **S11** (parallel label resolution); required for cross-dataset detectors
+   with 10 k+ labels.
+10. **S15** (streaming pickle load); required for 10 M+ datasets.
+
+## Open follow-ups (not yet scoped for implementation)
+
+- FAISS/HNSW replacement for the diversity tree (S2 long-term)
+- Columnar storage for `medias` dict (S4)
+- Append-only vote journal for label sync sources (S12 long-term)
+- Streaming JSON export (S13)
+- Paginated sort API (S3 long-term)
+- Background MLP inference with result streaming (S10)
 
 ---
 
-## How to read this doc
+## How to read the catalog
 
 - Items are grouped by the *resource* they exhaust: **RAM**, **CPU/time**,
-  or **network/JSON**.
-- Each item has a stable ID (`S#`) for reference from PRs.
-- A sub-section at the bottom collects the **recurring root causes**: fixing
-  a pattern fixes many items at once.
+  or **network/JSON**, ordered roughly by severity / likelihood to hurt first.
+- Each item has a stable ID (`S#`) for reference from PRs and from
+  `scalability-plan.md`.
+- The **recurring root causes** table (bottom) collects patterns: fixing a
+  pattern fixes many items at once.
 - "At N" estimates are back-of-envelope with SigLIP/E5 embedding dim ~384
   (float32 = 4 B), sorted-list cost at ~1 µs/item, and JSON encoding at
-  ~50 B/element.
+  ~50 B/element. Line references are approximate and will drift.
 
 ---
 
@@ -491,37 +523,4 @@ every 100 ms by wall clock).
 | **Grid mode** missing virtual scroll | S16 |
 | **Oversized cache keys** containing raw vectors | S5 |
 
----
-
-## Suggested fix order (max-leverage first)
-
-1. **S6 + S7** (epoch counter); trivial code change, eliminates O(N log N)
-   hot path from every sort and retrain.  Low risk, high gain.
-2. **S1** (mmap embedding matrix); unblocks 1 M+ datasets without OOM.
-   Moderate effort.
-3. **S5** (hash-based threshold cache key); trivial, eliminates fat cache
-   key before it becomes a memory landmine.
-4. **S9** (subsample GMM); two-line fix, eliminates a growing cost on every
-   retrain.
-5. **S2 + S8** (cap/defer diversity tree); makes 100 k+ datasets load
-   usably fast; tree can remain available but opt-in.
-6. **S3 + S17 + S19** (sparse sort results, lazy ordered items); must be
-   done together; unblocks 1 M+ in the frontend.
-7. **S12** (debounce label sync); makes voting with large labelsets not
-   stall the UI.
-8. **S16** (virtual grid); significant frontend work but required for grid
-   mode at any large scale.
-9. **S11** (parallel label resolution); required for cross-dataset detectors
-   with 10 k+ labels.
-10. **S15** (streaming pickle load); required for 10 M+ datasets.
-
----
-
-## Open follow-ups (not yet scoped for implementation)
-
-- FAISS/HNSW replacement for the diversity tree (S2 long-term)
-- Columnar storage for `medias` dict (S4)
-- Append-only vote journal for label sync sources (S12 long-term)
-- Streaming JSON export (S13)
-- Paginated sort API (S3 long-term)
-- Background MLP inference with result streaming (S10)
+(Next-work priorities and open follow-ups are at the **top** of this doc.)

--- a/docs/plans/server-dedup-references.md
+++ b/docs/plans/server-dedup-references.md
@@ -1,428 +1,132 @@
 # Reference (no-copy) dataset import
 
-Status: **Phase 1 + Phase 2a + Phase 2b shipped.**
-Whole-file references for the two server importers (`server_folder`,
-`server_files`) are wired end-to-end (Phase 1). **Lazy clips** for audio and
-image let reference datasets be clipped without duplicating bytes (Phase 2a).
-**Lazy converter output** (Phase 2b) now extends the same recipe-on-demand
-mechanism to the last duplicating transform: a converter (`document2image`,
-`video2image`, …) running in reference mode stores the source path plus a
-converter recipe instead of baking N rendered outputs into the pickle. The
-*Phase 2b design* below is the implementation spec; *What shipped (Phase 2b)*
-records what actually landed and the remaining fast-follows.
+Status: **Phases 1, 2a, 2b all shipped.** Whole-file references for the two
+server importers (`server_folder`, `server_files`) are wired end-to-end
+(Phase 1); **lazy clips** for audio and image clip reference datasets without
+duplicating bytes (Phase 2a); **lazy converter output** extends the same
+recipe-on-demand mechanism to the last duplicating transform — a converter
+(`document2image`, `video2image`, …) in reference mode stores the source path +
+a converter recipe instead of baking N rendered outputs into the pickle
+(Phase 2b). Fast-follows below.
 
-## Problem
+## Problem & mechanism (framing)
 
-Importing a server-side folder or manifest copies every file's bytes into
-the dataset: full mode inlines `media_bytes` into each media dict, and those
-bytes get baked into the registry pickle. For large collections this
-duplicates storage that already lives on the server. When the source files
-are reliable and will persist, that duplication is pure waste.
+Importing a server folder/manifest in full mode inlines each file's
+`media_bytes`, baked into the registry pickle — duplicating storage that already
+lives on the server. The fix reuses the library's existing **thin mode**
+(`thin=True`): store a `media_path` reference instead of loading `media_bytes`;
+`MediaType._resolve_media_bytes` (`vtscore/media/base.py`) reads bytes lazily on
+demand (`media_bytes → lazy recipe → media_path → media_url`).
 
-## Mechanism: thin mode, surfaced as an import option
+**No symlinks:** the server importers already reference files in place, so the
+only duplication is the inlined pickle bytes; a plain `media_path` removes that,
+while a symlink would add inodes + cleanup and break across machines exactly as
+an absolute path does. A reference dataset therefore **depends on its source
+files staying put** — moving/deleting them drops the affected medias on reopen
+(same as a missing companion file today). That is the explicit trade the option
+makes. Browser-upload importers (`local_folder`, `local_files`) stage into a
+temp dir deleted after import, so references would dangle — the option is not
+offered there.
 
-The library already had **thin mode** (`thin=True`): the loader stores a
-`media_path` reference instead of loading `media_bytes`, and
-`MediaType._resolve_media_bytes` (`vtscore/media/base.py`) reads bytes lazily
-on demand (`media_bytes → media_path → media_url`). It was previously only
-reachable from the CLI autodetect path (`vtscore/cli.py`).
-
-**We did not add symlinks.** The server importers already reference files in
-place (they never copy into a managed directory), so the only duplication is
-the inlined bytes in the pickle. A plain `media_path` reference removes that;
-a symlink would add inodes + cleanup for no benefit, and breaks across
-machines exactly as badly as an absolute path. References win.
-
-## What shipped (Phase 1)
-
-- **`reference_files` import option** (`field_type="checkbox"`,
-  `include_in_origin=False`) on `server_folder` and `server_files`. Kept out
-  of the persisted origin: reference-vs-copy is a storage choice, not part of
-  the data source's identity, so it must not perturb dedup / reload matching.
-- **Threaded as `thin`** in `load_pipeline._run_importer_in_background`: the
-  flag is popped from `field_values` and passed to
-  `importer.run(...) / run_chunked(...)` as `thin=`. Other importers never
-  receive the field, so they always run in copy mode (unchanged).
-- **Full-mode pickle load now honors `media_path`**
-  (`loader_pickle._convert_one_pickle_media`). Reopening a saved dataset from
-  the dashboard loads the registry pickle in *full* mode, which previously
-  ignored `media_path` and **dropped** every media that had no inline bytes.
-  It now falls back to the stored `media_path` (when the file still exists)
-  and loads that media lazily, so a reference dataset survives the
-  registry-save → full-mode-reopen round-trip. This also rescues both disk
-  *and* RAM: the reopened dataset stays references, not re-inlined bytes.
-- **Frontend**: a `checkbox` branch was added to the generic importer form
-  (it had none — a checkbox field would have rendered as a text input), so
-  `server_files` / Manifest shows the option; and the custom `server_folder`
-  picker got the checkbox + `sfReferenceFiles` state + `reference_files`
-  submit param.
-
-### Accepted brittleness
-
-A reference dataset depends on its source files staying put. Moving or
-deleting them breaks the dataset (medias whose `media_path` no longer
-resolves are dropped on reopen, exactly like a missing companion file
-today). This is the explicit trade the option exists to make.
-
-### Deliberately *not* in scope for Phase 1
-
-- **Browser-upload importers** (`local_folder`, `local_files`) stage uploads
-  into a temp dir that is deleted after import, so references would dangle.
-  The option is not offered there.
-- **Clippers and converters** still materialize bytes (see below).
-
-## What shipped (Phase 2a: lazy clips)
-
-Reference (thin) datasets can now be **clipped** without duplicating bytes.
-Before this, a reference import that also chose a clipper silently produced
-*no* clips: audio/image clippers early-return the media unchanged when
-`media_bytes` is absent, so the clipper stage was a no-op on thin parents.
-
-- **`vtscore/media/lazy_clip.py`** — a *lazy clip* carries no `media_bytes`;
-  it keeps `media_path` (the source file) plus a *recipe* read from
-  `origin.params` (`clip_start`/`clip_end` for audio, `clip_box` for image)
-  and reproduces its bytes on demand. A small process-scoped LRU cache holds
-  resolved slices (never persisted, per the no-persisted-bytes rule). Only
-  audio and image participate — they're the types whose clippers actually
-  re-slice bytes.
-- **`MediaType._resolve_media_bytes`** (`vtscore/media/base.py`) consults
-  `lazy_clip_bytes` before the plain `media_path` read, so HTTP serving,
-  exporters, and any other byte consumer transparently get the sliced clip.
-- **Clipper stage** (`vtscore/datasets/stages/clipper.py`) gained
-  `_hydrate_reference_parents` (transiently load a thin parent's bytes so the
-  clipper can compute boundaries and the existing MD5/embed/thumbnail fixup
-  runs unchanged) and `_relazify_reference_clips_stage` (strip the
-  materialized bytes back off the derived clips). The re-lazify step runs in
-  `load_pipeline` **after** the embed/drop-none stages, so the embed-missing
-  safety net never mis-embeds a clip's *whole* source file behind its path.
-- **Cross-dataset re-embed** needed no change: `resolver.py` already
-  re-derives clips from the source file + recipe; lazy clips just make the
-  in-dataset path match.
-- **Pickle round-trip** works because the recipe lives in `origin.params`
-  (which already round-trips) and `media_path` is serialized; reopening a
-  reference clip stays lazy and resolves on demand.
-
-Text clips stay materialized (a sliced string is tiny — no storage win and
-re-splitting from source is fragile). Video clips are already metadata-only
-(they share the parent's bytes; the player seeks via `clip_start`/`clip_end`),
-so they don't duplicate bytes and need no recipe slicing. A converter anywhere
-in the chain disables lazification (the output is no longer a slice of the
-source) — that's Phase 2b.
-
-## What shipped (Phase 2b: lazy converter output)
-
-Reference (thin) imports that run a **converter** (`server_folder` /
-`server_files` with a converter spec) no longer bake the rendered outputs into
-the pickle. Each output stores the *source* `media_path` plus a converter
-recipe in `origin.params` and re-renders on demand. This closes the last
-duplicating transform; un-converted media (Phase 1) and audio/image clips
-(Phase 2a) were already reference-clean.
-
-- **Importer stamp** (`vtscore/converters/runner.py`):
-  `_emit_converted_outputs` stamps three per-output disambiguators —
-  `converter_out_index`, `converter_n_out`, and `converter_content_hash` (a
-  12-hex md5 of the output bytes, via `clipper_chain._content_hash`). Each
-  output now gets its **own** origin dict (`_origin_with_disambiguators`)
-  rather than sharing one flat origin per source file. In reference (`thin`)
-  mode each output is tagged with `_lazy_source` and keeps its `media_bytes`
-  only for the embed stage. The disambiguators are stamped in *both* modes so
-  the cross-dataset resolver can re-select sub-outputs even for copy-mode
-  converter imports.
-- **Byte resolution** (`vtscore/media/lazy_clip.py`): `clip_recipe` learned a
-  converter branch (checked first, keyed by `converter` in `origin.params`, so
-  a `document2image` output with `media_type=image` resolves as a converter
-  output, not an image clip). `_apply_converter_recipe` re-runs the converter
-  on the source bytes and re-selects the recorded output by **delegating to
-  `clipper_chain._select_chain_output`** — identical content-hash-first,
-  drift-aware, refuse-to-guess semantics as the resolver. Returns `None`
-  (fall through, cache nothing) when nothing matches.
-- **Byte-bounded cache** (`vtscore/media/lazy_clip.py`): converter output uses
-  a new `_ByteBoundedLRU` (~256 MB ceiling) **separate** from Phase 2a's
-  count-bounded clip cache, because a rendered page / video frame is 1–8 MB and
-  varies by an order of magnitude (256 *entries* of those could be 1–2 GB). The
-  clip slice cache stays count-bounded.
-- **Re-lazify** (`vtscore/datasets/stages/clipper.py`):
-  `_relazify_reference_clips_stage` already strips any `_lazy_source`-tagged
-  media, so it covers converter outputs unchanged — only the docstring was
-  generalized. It runs after the embed / drop-none stages (existing
-  `load_pipeline` ordering), so the embed-missing safety net always sees the
-  real rendered bytes, never the source file behind the path.
-- **Cross-dataset re-embed** (`vtscore/detectors/resolver.py`): a flat
-  converter origin is normalized into a one-element chain
-  (`_converter_origin_to_chain`) and replayed through the existing
-  `replay_chain_on_file`, so a reference-converted label re-embeds the rendered
-  page/frame (not the raw source file) via a single shared replay path. Falls
-  back to a whole-file embed if the converter is gone.
-- **Pickle round-trip / HTTP serving / exporters** need no change: the recipe
-  lives in `origin.params` (round-trips), `media_path` is serialized, and
-  `_resolve_media_bytes` already consults `lazy_clip_bytes` before the
-  whole-file read.
-
-### Open follow-ups (Phase 2b)
+## Open follow-ups (fast-follows)
 
 - **Demo converter path** (`apply_converter_to_demo` /
   `_emit_converted_demo_outputs`) and **standalone PDF expansion**
   (`load_pdf_images_into` in `vtscore/datasets/pdf.py`) do **not** yet stamp the
   disambiguators or `_lazy_source`; they always materialize. Same recipe+resolve
   shape — wire them through `_origin_with_disambiguators` (or share the emit
-  helper) when a reference path reaches them.
+  helper) when a reference path reaches them. Neither is reachable from the
+  `reference_files` option today.
 - **Multi-step chains mixing a converter and a clipper** under reference mode
   are still left fully materialized: `_hydrate_reference_parents` bails when a
   chain contains a converter, and Phase 2b's first cut covers a *converter as
   the sole reference transform*. Re-slicing converter output (converter →
-  clipper) is a later composition now that both lazy branches exist.
-- **Cache unification**: Phase 2a's clip cache and Phase 2b's converter cache
-  are two structures with two eviction policies. Migrating clips onto the
-  byte-bounded LRU (clips are just small, cheap-to-recompute entries) would
-  leave one cache; not required, noted so they don't drift.
+  clipper) is a later composition now that both lazy branches exist and are
+  proven independently.
+- **Cache unification**: Phase 2a's clip cache (count-bounded, 256 entries) and
+  Phase 2b's converter cache (byte-bounded, ~256 MB) are two structures with two
+  eviction policies. Migrating clips onto the byte-bounded LRU (clips are just
+  small, cheap-to-recompute entries) would leave one cache with one policy; not
+  required, noted so they don't drift.
 - **Pre-warm**: intentionally not done — re-converting on load defeats the
-  storage-only-cost trade. Revisit only if a real workload shows cold-fetch
-  latency is a problem.
+  storage-only-cost trade (we'd pay conversion compute eagerly *and* still need
+  the cache). Disk-backed caches are likewise rejected (re-persisting bytes by
+  another name, against the no-persisted-bytes rule). Revisit pre-warm only if a
+  real workload shows cold-fetch latency is a problem.
 
-## Phase 2b design: lazy converter output
+## What shipped
 
-Phase 1 + 2a avoid duplication for media imported **as-is** and for
-audio/image **clips**. One transform still copies bytes into the dataset:
-**converters** (`vtscore/converters/`, e.g. `document2image`, `video2image`)
-produce derived media whose `media_bytes` (a rendered page PNG, an extracted
-video frame) get baked into the pickle, once per output. A 200-page PDF
-imported as a reference still inlines 200 full-resolution page images. The
-reference form should instead store the *source* `media_path` plus a **converter
-recipe** and re-run the conversion on demand, exactly as Phase 2a does for clip
-slices.
+### Phase 1 — whole-file references
 
-This section is the implementation-ready design. It is deliberately concrete
-about *which* code paths change and *what* gets recorded, because the hard part
-of Phase 2b is not the resolver branch (small) but threading the recipe through
-the right importer paths and picking the correct sub-output on replay.
+- **`reference_files` import option** (`field_type="checkbox"`,
+  `include_in_origin=False`) on `server_folder` / `server_files`. Kept out of the
+  persisted origin: reference-vs-copy is a storage choice, not part of the data
+  source's identity, so it must not perturb dedup / reload matching.
+- **Threaded as `thin`** in `load_pipeline._run_importer_in_background` (popped
+  from `field_values`, passed to `importer.run(...)/run_chunked(...)`); other
+  importers never receive the field, so they stay copy-mode.
+- **Full-mode pickle load now honors `media_path`**
+  (`loader_pickle._convert_one_pickle_media`) — reopening a saved reference
+  dataset from the dashboard no longer drops byte-less medias; it falls back to
+  the stored `media_path` and loads lazily, so a reference dataset survives the
+  registry-save → full-mode-reopen round-trip (rescues disk *and* RAM).
+- **Frontend**: added a `checkbox` branch to the generic importer form (it had
+  none — a checkbox would have rendered as a text input); the custom
+  `server_folder` picker got the checkbox + `sfReferenceFiles` state +
+  `reference_files` submit param.
 
-### The two converter code paths (cover one, not both)
+### Phase 2a — lazy clips (audio/image)
 
-There are two ways a converter runs at import time, and they record provenance
-very differently:
+- **`vtscore/media/lazy_clip.py`** — a lazy clip carries no `media_bytes`; it
+  keeps `media_path` + a *recipe* read from `origin.params`
+  (`clip_start`/`clip_end` for audio, `clip_box` for image) and reproduces bytes
+  on demand via a small process-scoped LRU (never persisted). Only audio/image
+  participate (their clippers re-slice bytes).
+- **`MediaType._resolve_media_bytes`** consults `lazy_clip_bytes` before the
+  plain `media_path` read, so HTTP serving / exporters / any byte consumer get
+  the sliced clip transparently.
+- **Clipper stage** (`vtscore/datasets/stages/clipper.py`) gained
+  `_hydrate_reference_parents` (transiently load a thin parent's bytes so the
+  clipper computes boundaries and the MD5/embed/thumbnail fixup runs unchanged)
+  and `_relazify_reference_clips_stage` (strip the materialized bytes back off
+  the derived clips), the latter running **after** the embed/drop-none stages so
+  the embed-missing safety net never mis-embeds a clip's whole source file.
+- Text clips stay materialized (a sliced string is tiny); video clips are
+  already metadata-only (share parent bytes, player seeks via
+  `clip_start`/`clip_end`). Cross-dataset re-embed needed no change (`resolver.py`
+  already re-derives clips from source + recipe). Pickle round-trips because the
+  recipe lives in `origin.params` and `media_path` is serialized.
 
-1. **`run_converters_on_folder`** (`vtscore/converters/runner.py`) — the
-   importer-level path. `server_folder` / `server_files` with converter
-   specs scan a folder, run each converter, and stamp a *flat* origin:
-   `{importer: "converter", params: {converter, source_file,
-   converter_param_<key>...}}`. It already accepts `thin=` but, per its own
-   docstring, **still materializes output bytes regardless** — that is the gap
-   Phase 2b closes. Crucially this path records **no sub-output
-   disambiguator** (no index, no content hash): a 10-frame `video2image` run
-   produces 10 medias that share identical origin params except `origin_name`
-   (`{source}→{stem}_clip_{n}.png`).
-2. **`clipper_chain` / `apply_chain_to_clips`** (`vtscore/datasets/clipper_chain.py`)
-   — the chain-stage path. A converter that appears in a *clipper chain*
-   already records a full trail in `origin.params["clipper_chain"]` with
-   per-step `out_index`, `n_out`, and `content_hash`, and the resolver's
-   `replay_chain_on_file` / `_select_chain_output` already re-run it from the
-   source file and pick the exact sub-output (preferring `content_hash`, then
-   `out_index`, refusing to guess on drift).
+### Phase 2b — lazy converter output
 
-**Decision: Phase 2b targets path (1), `run_converters_on_folder`, because that
-is the path the `reference_files` import option actually flows through** (see
-`load_pipeline._run_importer_in_background`, which pops `reference_files` →
-`thin`). Path (2) is reused as *library*, not duplicated: the recipe we record
-in (1) is shaped so the same `_select_chain_output` machinery selects the
-sub-output. The demo path (`apply_converter_to_demo`) and the standalone PDF
-expansion (`load_pdf_images_into` in `vtscore/datasets/pdf.py`) are **out of
-scope for the first cut** — neither is reachable from the `reference_files`
-option today — but both follow the identical recipe+resolve shape and are noted
-as fast-follows below.
-
-### Recipe channel — what to record
-
-Phase 2a's clip recipe (`clip_start`/`clip_end`/`clip_box`) already round-trips
-through `origin.params`. The converter recipe rides the same channel. For each
-converted output `run_converters_on_folder` already records `converter`,
-`source_file`, and `converter_param_<key>`; Phase 2b adds the **two
-disambiguators that `_select_chain_output` needs** so resolution can re-run the
-converter and pick the right output:
-
-- `converter_out_index` — the integer position of this output in the
-  converter's returned list (page number − 1, frame segment index). Stamped in
-  `_emit_converted_outputs`, which already enumerates outputs with `media_id`.
-- `converter_n_out` — the output count at import time, so the resolver can
-  detect drift (source changed, library version bumped) and fall back from
-  positional to content matching instead of silently returning the wrong page.
-- `converter_content_hash` — a short md5 of the output bytes (reuse
-  `clipper_chain._content_hash`'s 12-hex form). This is the *authoritative*
-  disambiguator: `out_index` is only valid when replay reproduces the same
-  outputs in the same order, and `_select_chain_output` already prefers the
-  hash. It is a hash of bytes we are about to discard, **not** persisted bytes —
-  this does not violate the no-persisted-bytes rule (the dataset MD5 already
-  stores a content hash per media for exactly this reason).
-
-The converter `params` are reconstructable from the `converter_param_<key>`
-keys already recorded (string round-trip), so the resolver can rebuild the
-exact `params` dict it needs to replay. No new params channel is required.
-
-### Byte resolution — the `lazy_clip` converter branch
-
-`vtscore.media.lazy_clip` gains a converter branch parallel to its audio/image
-clip branches. `clip_recipe(media)` learns to return a converter recipe when
-`origin.params["converter"]` is present:
-
-```
-("converter", converter_name, params_dict, out_index, n_out, content_hash)
-```
-
-`_apply_recipe` (or a sibling `_apply_converter_recipe`) then:
-
-1. reads the whole source file via the existing `_read_source_bytes` (already
-   handles `media_path` → `media_url`);
-2. builds a minimal source-media dict and calls
-   `converter.convert_normalized(source_media, params)`;
-3. selects the output by **delegating to a shared selector** — lift
-   `_select_chain_output`'s logic (or call it directly by constructing a
-   `ChainStep`-shaped dict with `out_index`/`n_out`/`content_hash`) so the
-   content-hash-first, drift-aware, refuse-to-guess semantics are identical to
-   the resolver. Returns `None` (cache nothing, fall through) when no output
-   matches — the same "better no bytes than wrong bytes" stance Phase 2a takes.
-
-`MediaType._resolve_media_bytes` already calls `lazy_clip_bytes` before the
-plain `media_path` read, so HTTP serving, exporters, and every other byte
-consumer get converter output transparently — the resolution order needs **no
-change**, only `lazy_clip` learning the converter recipe. This is the smallest
-piece of Phase 2b.
-
-### Embedding ordering — hydrate → convert → embed → re-lazify
-
-The hazard Phase 2a dodged applies here verbatim, and is the single most
-important correctness constraint: a converted media's `media_path` points at
-the *whole source file* (the PDF, the video), **not** the rendered page/frame.
-If the embed-missing safety net (`vtscore.datasets.stages.embedding.embed_missing`)
-ever reaches a lazy converted media, it would read the source path and embed the
-*wrong content* (the raw PDF bytes as if they were an image). So Phase 2b must
-embed from the *materialized* converter output and only strip the bytes
-afterward:
-
-- `run_converters_on_folder` in reference mode produces outputs **with**
-  `media_bytes` (it already does the conversion; it just must not discard the
-  bytes before embedding). It tags each output with the `_lazy_source` marker
-  (same marker Phase 2a's `_hydrate_reference_parents` uses) carrying the source
-  path.
-- The framework embed stage runs and embeds from those real `media_bytes`, as
-  it does today.
-- A **re-lazify stage runs after the embed / drop-none stages** —
-  generalize Phase 2a's `_relazify_reference_clips_stage` (currently in
-  `vtscore/datasets/stages/clipper.py`) to also strip converted-output bytes:
-  for any media carrying `_lazy_source`, drop `media_bytes`/`media_string` and
-  point `media_path` back at the source. The recipe in `origin.params` then
-  reproduces the output on demand. Ordering is identical to Phase 2a (re-lazify
-  *after* embed) precisely so the safety net never sees a byte-less converted
-  media.
-
-Because the import-time conversion still happens (we need it to embed), Phase 2b
-saves **storage/RAM in the pickle**, not import-time compute. That is the same
-trade Phase 2a makes and is the correct one: the win is not re-paying the
-conversion at import, it is not carrying N copies of converted bytes in the
-saved dataset.
-
-### Caching & latency — recommendation: a separate byte-bounded cache
-
-This is the open question flagged at deferral, and the place the two designs
-genuinely diverge. **Recommendation: do not reuse Phase 2a's count-bounded LRU
-for converter output; add a separate cache bounded by total bytes.**
-
-Rationale:
-
-- Phase 2a's cache is `_CACHE_MAX = 256` *entries*, and its own comment justifies
-  the count bound by "clip payloads are small (one tile / crop)". A converter
-  output is not small or uniform: a 2×-zoom rendered PDF page or a 1080p video
-  frame is easily 1–8 MB, and sizes vary by an order of magnitude across
-  documents. 256 entries of clip slices is a few MB; 256 entries of rendered
-  pages could be 1–2 GB. A count bound that is safe for clips is unsafe here.
-- A byte-bounded LRU (evict oldest until total held bytes ≤ a ceiling, e.g.
-  ~256 MB, configurable) makes memory **predictable regardless of output size**,
-  which is the property that matters for a process that may serve many large
-  outputs. It is a small amount of extra code (track `len(bytes)` per entry,
-  sum on insert, evict in a `while total > ceiling` loop) and lives beside the
-  clip LRU in `lazy_clip.py`.
-- Recompute cost is the reason a cache exists at all: re-rendering a PDF page or
-  re-decoding a video to a frame on every cold `media_bytes` fetch is far more
-  expensive than a `_wav_slice`, and HTTP range/scrub requests can hammer the
-  same media repeatedly. A byte-bounded cache keeps the hot set resident without
-  an unbounded memory risk.
-
-Explicitly **not** recommended for the first cut: pre-warming (re-converting on
-load defeats the storage-only-cost trade — we'd pay conversion compute eagerly
-*and* still need the cache) and disk-backed caches (that is just re-persisting
-bytes by another name, against the no-persisted-bytes rule). Start with the
-in-memory byte-bounded LRU; revisit pre-warm only if a real workload shows
-cold-fetch latency is a problem.
-
-A possible later unification: migrate the Phase 2a clip cache onto the same
-byte-bounded structure (clips are just cheap-to-recompute, small entries) so
-there is one cache with one eviction policy. Not required for Phase 2b; noted so
-the two caches don't drift.
-
-### Pickle round-trip, HTTP serving, exporters, re-embed
-
-- **Pickle round-trip** works by the same mechanism as Phase 2a: the recipe
-  lives entirely in `origin.params` (which round-trips) and `media_path` is
-  serialized. A reopened reference-converted media stays lazy and resolves on
-  demand. Full-mode pickle load already honors `media_path`
-  (`loader_pickle._convert_one_pickle_media`, fixed in Phase 1), so a
-  byte-less converted media survives the registry-save → full-reopen trip.
-- **HTTP serving** and **exporters** stream through `_resolve_media_bytes` and
-  need no change — they get converter output for free once `lazy_clip` learns
-  the branch (modulo the latency the byte-bounded cache addresses).
-- **Cross-dataset re-embed** (`vtscore/detectors/resolver.py`) already
-  re-applies converters via `replay_chain_on_file` for chain trails. The flat
-  `run_converters_on_folder` origin (path 1) is a *single* converter step, so
-  the resolver path that handles it should be confirmed to reconstruct a
-  one-step replay from the `converter`/`converter_param_*`/`converter_out_index`
-  params; if it currently only understands `clipper_chain`, normalizing the flat
-  converter origin into a one-element chain at resolve time is the clean fix
-  (and keeps a single replay code path).
-
-### Implementation checklist (files to touch)
-
-- `vtscore/converters/runner.py` — `_build_converter_origin` /
-  `_emit_converted_outputs`: stamp `converter_out_index`, `converter_n_out`,
-  `converter_content_hash`. In reference (`thin`) mode tag each output with
-  `_lazy_source = str(source_path.resolve())` and keep `media_bytes` for the
-  embed stage.
-- `vtscore/media/lazy_clip.py` — extend `clip_recipe` to recognize the
-  converter recipe; add `_apply_converter_recipe`; add the byte-bounded cache
-  (separate from the clip LRU). Update `LAZY_CLIP_TYPES`/docstrings — note the
-  converter branch is keyed by `converter` in `origin.params`, not by target
-  media type, so it is not gated on the audio/image-only list.
-- `vtscore/datasets/stages/clipper.py` — generalize
-  `_relazify_reference_clips_stage` (or add a sibling stage) so it strips
-  `_lazy_source`-tagged converted media too; ensure it is scheduled after the
-  embed / drop-none stages in `load_pipeline`.
-- `vtscore/datasets/clipper_chain.py` — factor `_select_chain_output` /
-  `_output_matches_entry` so `lazy_clip` can call them (or a thin shared
-  helper) without importing the chain stage; keep one selection policy.
-- `vtscore/detectors/resolver.py` — confirm/extend single-converter replay for
-  the flat origin (normalize to a one-step chain).
-- **Tests** (group `datasets` for round-trip/re-lazify, `detectors` for
-  resolver replay, `io` for the importer path): reference import + converter →
-  no `media_bytes` in the saved pickle; HTTP/exporter fetch reproduces the
-  correct page/frame; sub-output selection picks the right output and refuses on
-  drift; byte-bounded cache evicts by size; embed safety net never sees a
-  byte-less converted media.
-
-### Out of scope for the first cut (fast-follows)
-
-- **Demo converter path** (`apply_converter_to_demo`) and **standalone PDF
-  expansion** (`load_pdf_images_into`) — same recipe+resolve shape, but not
-  reachable from `reference_files` today. Add once the importer path lands.
-- **Multi-step chains that mix a converter and a clipper** under reference mode.
-  Phase 2a's `_hydrate_reference_parents` deliberately bails when a chain
-  contains a converter; Phase 2b's first cut covers a *converter as the sole
-  reference transform*. A converter-then-clipper chain (re-slice the converter
-  output) is a later composition once both lazy branches are proven
-  independently.
-
-### Why this is still worth doing after 2a
-
-Phase 1 + 2a already deliver the storage win for un-converted server datasets,
-clipped or not. Phase 2b extends it to the one remaining duplicating transform.
-The design above reuses three pieces 2a/the chain stage already built — the
-`_lazy_source` marker + re-lazify stage, `origin.params` as the recipe channel,
-and `_select_chain_output` for sub-output selection — so the net-new surface is
-small: an importer-path stamp, a `lazy_clip` converter branch, and a
-byte-bounded cache.
+- **Importer stamp** (`vtscore/converters/runner.py`): `_emit_converted_outputs`
+  stamps three per-output disambiguators — `converter_out_index`,
+  `converter_n_out`, `converter_content_hash` (12-hex md5 via
+  `clipper_chain._content_hash`, a hash of bytes about to be discarded, not
+  persisted bytes) — each output getting its own origin
+  (`_origin_with_disambiguators`), in **both** modes so the resolver can
+  re-select sub-outputs for copy-mode imports too. Reference mode tags each
+  output `_lazy_source` and keeps `media_bytes` only for the embed stage.
+- **Byte resolution** (`vtscore/media/lazy_clip.py`): `clip_recipe` gained a
+  converter branch checked first (keyed by `converter` in `origin.params`, so a
+  `document2image` output with `media_type=image` resolves as converter output,
+  not an image clip); `_apply_converter_recipe` re-runs the converter and
+  re-selects by **delegating to `clipper_chain._select_chain_output`** (identical
+  content-hash-first, drift-aware, refuse-to-guess semantics; returns `None` and
+  caches nothing on no match).
+- **Byte-bounded cache** (`_ByteBoundedLRU`, ~256 MB ceiling) **separate** from
+  Phase 2a's count-bounded clip cache, because a rendered page / video frame is
+  1–8 MB and varies by an order of magnitude (256 *entries* of those could be
+  1–2 GB), whereas a clip slice is small and uniform.
+- **Re-lazify** (`_relazify_reference_clips_stage`) already strips any
+  `_lazy_source`-tagged media, so it covers converter outputs unchanged
+  (docstring generalized); runs after embed/drop-none so the safety net always
+  sees the real rendered bytes.
+- **Cross-dataset re-embed** (`vtscore/detectors/resolver.py`): a flat converter
+  origin is normalized into a one-element chain (`_converter_origin_to_chain`)
+  and replayed through the existing `replay_chain_on_file`, so a
+  reference-converted label re-embeds the rendered page/frame via one shared
+  replay path (falls back to a whole-file embed if the converter is gone).
+- **Pickle round-trip / HTTP serving / exporters** need no change: the recipe
+  lives in `origin.params`, `media_path` is serialized, and
+  `_resolve_media_bytes` already consults `lazy_clip_bytes` first.

--- a/docs/plans/server-import-ux.md
+++ b/docs/plans/server-import-ux.md
@@ -1,46 +1,19 @@
 # Server / Services dataset-import UX
 
-Status: **Phase 1 shipped.** Single-user path confinement (item 1 below) was
-later **reversed**: in single-user / no-auth mode server-path import, export,
-and browse are now unrestricted (the lone trusted user may reach any
-server-readable path), and `SERVER_ROOTS` / `VTSEARCH_SERVER_ROOTS` were
+**Status: Phase 1 shipped.** Came out of a hands-on audit of the three
+real-world import paths (Services extension plugin, server folder, server file
+with pre-computed vectors), driving the live UI. Open follow-ups first; shipped
+detail below.
+
+**Reversal note:** single-user path confinement (the `SERVER_ROOTS` work in the
+shipped list) was later **reversed** — in single-user / no-auth mode server-path
+import, export, and browse are now unrestricted (the lone trusted user may reach
+any server-readable path), and `SERVER_ROOTS` / `VTSEARCH_SERVER_ROOTS` were
 removed. Multi-user per-user confinement is unchanged. The "Browse-root vs.
-import-root seam" follow-up below is therefore moot for single-user mode
-(browse is now rooted at `/`, matching the unrestricted import validation).
-
-Came out of a hands-on audit of the three real-world
-import paths (Services extension plugin, server folder, server file with
-pre-computed vectors), driving the live UI. The Demo importer is well-trodden;
-these three are what real deployments use and were comparatively rough.
-
-## ~~What shipped~~
-
-All struck through (note: the single-user `SERVER_ROOTS` confinement below was
-later reversed — see the status header):
-
-- ~~**Unified Server-tab path policy.**~~ `server_folder`'s `path` validated
-  through `validate_server_filepath` like `server_files`; checks against every
-  `SERVER_ROOTS` entry; closed a multi-user confinement hole; fixed the
-  misleading `get_file_access_base_dir` docstring.
-- ~~**Client-side required-field gating**~~ in the generic `form` picker
-  (`formCanSubmit` disables Import until required fields are filled).
-- ~~**Server path browser**~~ for both Server importers — `<vt-file-browser>` on
-  `server_files`' `server_path`, a "Browse…" `<vt-folder-browser>` toggle on
-  `server_folder` (backed by `/api/browse-media-files?source=server_fs`).
+import-root seam" follow-up below is therefore moot for single-user mode (browse
+is now rooted at `/`, matching the unrestricted import validation).
 
 ## Open follow-ups
-
-- **Browse-root vs. import-root seam (server_folder).** The `server_folder`
-  browser + media-type detection are rooted at `/` (the `server_fs` source in
-  `_resolve_browse_root`), but import validation now confines to `SERVER_ROOTS`.
-  So you can navigate to and select a folder *outside* `SERVER_ROOTS` and only
-  get rejected at Import (with a clear message). The `server_files` side has no
-  such seam (its `/api/browse` root and validation root are both
-  `SERVER_ROOTS[0]`). Closing this for `server_folder` means re-rooting
-  `server_fs` browse/detect at `SERVER_ROOTS[0]` **and** reworking the `sf-*`
-  path flow to pass root-relative paths (today `sfApplyPathInput` anchors at
-  `/` and detection resolves against `/`). Deferred because that path-model
-  rework is broad and the current behavior is correct, just not maximally tidy.
 
 - **Empty Services tab.** The base `DatasetImporter.category` default is
   `"services"`, and every services-category importer ships
@@ -51,8 +24,25 @@ later reversed — see the status header):
   importer." Follow-up: hide tabs with zero visible importers and/or give the
   Services tab an empty-state that explains it's the extension surface. (Audited
   but intentionally not changed in Phase 1.)
-
 - **Relative-entry resolution in server_files manifests.** Relative paths inside
   a `.txt`/`.npz` resolve against the **manifest file's own directory**, not
   CWD — easy to trip. Consider documenting in the field hint or resolving
   against a more predictable base.
+- **Browse-root vs. import-root seam (server_folder).** Moot in single-user mode
+  after the confinement reversal (both browse and import now rooted at `/`).
+  Retained only as a note for multi-user: the `server_folder` browser +
+  media-type detection were rooted at `/` while import validation confined to
+  `SERVER_ROOTS`, so a user could navigate to and select a folder outside the
+  root and only get rejected at Import.
+
+## What shipped
+
+- **Unified Server-tab path policy** — `server_folder`'s `path` validated through
+  `validate_server_filepath` like `server_files`; closed a multi-user confinement
+  hole; fixed the misleading `get_file_access_base_dir` docstring. *(Later
+  reversed — see status note; `SERVER_ROOTS` removed.)*
+- **Client-side required-field gating** in the generic `form` picker
+  (`formCanSubmit` disables Import until required fields are filled).
+- **Server path browser** for both Server importers — `<vt-file-browser>` on
+  `server_files`' `server_path`, a "Browse…" `<vt-folder-browser>` toggle on
+  `server_folder` (backed by `/api/browse-media-files?source=server_fs`).

--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -1,591 +1,43 @@
 # Structural Embedders — Design
 
-**Status:** v1 shipped — **foundation + Stage-2 backend core + re-rank across all
-sort paths** (two-stage re-rank, RegionYes-as-template, match-statistic
-verification classifier, wired into the vote-driven learned-sort path **plus** the
-example-sort, labelset/saved-detector, **and Find (`find-label`) paths** — so every
-scoring entry point verifies); **matched-region overlay reachable in the focus
-pane**; **ROxford5k wired as the instance-retrieval demo dataset**; **real VLAD
-codebook fit** (Caltech-101, replacing the placeholder); **K/threshold spike DONE**
-on ROxford5k (defaults `K=50` / `threshold=0.5` confirmed; Stage-1 VLAD recall
-identified as the quality ceiling — grow the codebook next); **OpenLogo
-(QMUL-OpenLogo) wired as the logo instance-matching demo** (`openlogo` source,
-32 FlickrLogos-32 brands with ground-truth boxes, the benchmark for measuring
-codebook growth on real logos). See "Open follow-ups". This is the living spec for a third embedder *type*
-(alongside single-vector and patch) that searches for **specific instances**
-("the Coca-Cola logo") rather than **semantic categories** ("a cola can"). The
-architecture below is the agreed direction; the work plan is a sketch to be
-filled in as implementation proceeds (the way `patch-embedder.md`'s v2/v3
-punchlists were filled in during impl).
-
-Decisions locked in design: **two-stage architecture** (global vector retrieval +
-geometric re-rank); **SIFT for v1 with a pluggable matching backend** so learned
-local features drop in later; **the full vote-trained detector ships in v1** (both
-the example/region similarity flow and the match-statistic verification classifier,
-just like patch); **planar-only** matching; **image-only v1 with audio as the next
-media target**; **multi-embedder coexistence is the third role of the active patch
-v3 trio** (text + patch + structural; one structural embedder per dataset until the
-v3 create-time picker lands); **a fixed, shipped VLAD vocabulary** for v1 (no
-per-dataset codebook fit); **similarity-transform** geometric matching (4 DoF:
-translation, rotation, uniform scale — no shear, no perspective).
-
-## Motivation — structural vs semantic search
-
-Today every embedder is *semantic*: SigLIP/CLAP/DINO map a media item to a point
-in a learned feature space where nearness ≈ "means the same kind of thing." That
-answers "find me cola cans." It does **not** answer "find me images containing
-*this exact logo*" — a semantic embedder will happily rank a Pepsi can next to a
-Coke can, because they mean almost the same thing.
-
-A **structural** search asks a different question: *does this specific visual
-pattern appear in the haystack item, allowing for translation, rotation, scale,
-and uniform scale?* This is **instance retrieval** / object-instance matching,
-the classic local-feature + geometric-verification problem (SIFT/SURF/ORB
-keypoints, descriptor matching, RANSAC geometric verification). The canonical
-pipeline is
-Sivic & Zisserman's "Video Google" and Philbin et al.'s Oxford-Buildings work.
-
-Use cases this unlocks that no semantic embedder can: brand/logo detection,
-finding reproductions or crops of a specific artwork, locating a particular
-landmark building, near-duplicate and tampering detection, matching a product's
-packaging.
-
-## The core mismatch (why this is a new *type*, not a new embedder)
-
-Patch embedders were a relatively cheap addition because they still produce
-vectors that live in a metric space — `score_against_query` just took a `max` of
-cosine over a region set instead of a single cosine. Structural matching breaks
-two assumptions at once:
-
-1. **Representation.** A structural feature extractor produces a *variable-size
-   set* of `(keypoint, descriptor)` pairs per image (hundreds to thousands of
-   128-D SIFT descriptors), not a single fixed-D vector. There is no canonical
-   "image vector."
-2. **Comparison operator.** Two images are compared by **geometric verification**
-   — match descriptors, then RANSAC-fit a similarity transform and count inliers —
-   not by a dot product.
-
-Meanwhile *every* downstream consumer in VTSearch wants exactly the thing
-structural matching doesn't natively provide — a fixed-D L2-normalised vector and
-a cosine comparison:
-
-- `train_model(X, y, input_dim)` (`vtscore/training/mlp.py`) needs an `(N, D)`
-  matrix.
-- the diversity tree, the pre-vote random/diversity sorts, and cosine/example
-  sort all consume `media["embedding"]`.
-- `_score_all_media` (`vtscore/detectors/training.py`) runs the MLP over a
-  stacked vector matrix.
-
-So the design problem is not "add a new embedder," it's "reconcile a
-set-of-descriptors + geometric-fit world with VTSearch's vector + cosine world
-without rewriting the downstream." The two-stage architecture below is how.
-
-## Architecture — two-stage instance retrieval
-
-The reconciliation that has worked in the literature for two decades: **aggregate
-the descriptor set into a fixed-D vector for retrieval, and keep the raw
-keypoints for a geometric re-rank.**
-
-### Stage 1 — retrieval (rides the existing pipeline unchanged)
-
-Aggregate each image's local descriptors into a single fixed-D vector via **VLAD**
-(Vector of Locally Aggregated Descriptors) — or BoVW / Fisher vector; VLAD is the
-recommended default for its size/quality balance. That aggregated vector *is* a
-metric-space embedding, so:
-
-- it populates `media["embedding"]` exactly like any single-vector embedder;
-- the diversity tree, cosine/example sort, the pre-vote sorts, and `train_model`
-  all work with **zero new machinery**;
-- `supports_text` is `False` (no text encoder maps into VLAD space), so the text
-  sort greys out via the already-shipped `supports_text` gate.
-
-Stage 1 alone is "coarse instance retrieval": it shortlists images whose overall
-local-feature population resembles the query. It is fast (one matrix–vector
-product, same as today) and is what makes Stage 2 tractable.
-
-### Stage 2 — geometric verification (the new structural part)
-
-For the top-K candidates from Stage 1, match the query/template keypoints against
-each candidate's keypoints and RANSAC-fit a **similarity** transform (a 4-DoF
-model: translation, rotation, uniform scale — *no* shear or perspective). This is
-the exact transform a digitally-overlaid logo undergoes; dropping the affine
-shear/anisotropic-scale DoF and the homography perspective DoF means RANSAC needs
-only 2 correspondences to fit, constrains the fit harder, and yields fewer false
-positives than a looser model. This yields an
-inlier set and a geometric model per candidate, and **re-ranks** the shortlist by
-geometric consistency.
-
-Stage 2 is a *re-rank layered after sorting*, never a replacement for it. Running
-RANSAC against the whole haystack would be O(N·match·RANSAC) and far too slow, so
-restricting it to the Stage-1 shortlist is both the elegant and the *necessary*
-design — it's what keeps structural search within the existing scalability
-budget.
-
-```
-query/template ─┐
-                ├─► Stage 1: VLAD cosine over all media  ──► top-K shortlist
-haystack VLAD ──┘                                              │
-                                                               ▼
-template keypoints ──► Stage 2: descriptor match + RANSAC ──► re-ranked results
-haystack keypoints ──►        per shortlisted candidate         + inlier overlay
-```
-
-## The "MLP equivalent" — a classifier over *match statistics*, not descriptors
-
-The hardest open question in the original brainstorm was *"what's the MLP
-equivalent, and how do we learn the Good space in SIFT-space?"* The answer:
-**you don't learn in raw SIFT-descriptor space at all.** You learn in two derived
-spaces that are both fixed-D and metric, so both reuse `train_model` verbatim:
-
-1. **Retrieval MLP (already exists).** Trains on the VLAD vectors. Learns coarsely
-   "what does the good instance's local-feature population look like." This is the
-   ordinary detector MLP; no changes.
-
-2. **Verification classifier (the genuinely-structural learnable).** Every RANSAC
-   fit against a template emits a small bundle of *match statistics*:
-
-   - inlier count and inlier ratio (inliers / tentative matches),
-   - number of tentative (pre-RANSAC) descriptor matches,
-   - mean / median reprojection error of inliers,
-   - geometric plausibility of the fitted similarity model: scale within sane
-     bounds and reflection check (shear and anisotropic scale are zero by
-     construction, so there are no degenerate-affine fits to reject),
-   - spatial extent / spread of the inliers in the candidate image.
-
-   Stack those into a fixed-D feature vector **per (template, candidate) pair** and
-   train a logistic-regression / tiny MLP → P(match). The user's votes supply the
-   labels directly: **RegionYes** items that geometrically verify against a
-   template are positive match-stat examples; **No** items are negatives. This is
-   exactly the "tune the RANSAC comparer + calibrate the threshold" intuition —
-   and the classifier's decision boundary **is** the calibrated threshold, so
-   threshold calibration falls out for free instead of being a separate hand-tuned
-   knob.
-
-So the conceptual map is: **VLAD-space MLP for retrieval, match-statistic-space
-classifier for verification.** Neither lives in descriptor space, and both reuse
-`train_model(X, y)` with no shape change — `X` is just VLAD vectors in one case
-and match-statistics in the other.
-
-## Voting model — RegionYes is *constitutive*, not advisory
-
-Patch v2 treats a region box as a "salient-area hint" attached to a yes-vote. For
-structural detectors the box is **stronger**: it *defines the template*.
-
-- **RegionYes** (box-on-yes, the existing `LabeledElement.region_box`): we keep
-  only the keypoints whose location falls inside the box as the query template.
-  "Find the Coca-Cola logo" boxes the logo and discards the surrounding clutter
-  that a whole-image template would drag in. This is the primary positive signal.
-- **Whole-image Yes** (no box): allowed, but produces a noisy template (matches
-  background texture). The UI should nudge toward boxing for structural detectors;
-  unboxed yes still works as a coarse template.
-- **No**: feeds the verification classifier's negatives, and can additionally
-  drive a TF-IDF / stop-list down-weighting of non-discriminative visual words (a
-  logo printed over busy background texture; generic edges that match everything).
-- **Multiple RegionYes votes → multiple templates.** Score = **max over
-  templates** (verify the candidate against each template, keep the best fit),
-  directly analogous to patch's max-over-regions.
-
-`LabeledElement.region_box` already exists (shipped in patch v2), so the persisted
-form of a structural detector is just `origin + region_box` per labelled example —
-no new schema. Templates re-derive on load by re-embedding the boxed source
-region, exactly the way `DetectorContext.label_embeddings` re-derives today.
-
-## Feature backend — SIFT for v1, pluggable for learned features
-
-Same interchangeable-backbone story that DINOv2 / DINOv3 / EUPE have for patch:
-the *matching backend* is pluggable behind the structural-embedder interface.
-
-| Backend | Pros | Cons |
-|---|---|---|
-| **Classic SIFT + RANSAC** (OpenCV) | CPU-friendly, deterministic, ungated, light deps, patent expired (in mainline OpenCV since 4.4). Good enough for clean planar logos. | Weaker than learned features under strong viewpoint/illumination change. |
-| **Learned local features** (SuperPoint + LightGlue/SuperGlue, DISK, ALIKED, DeDoDe) | Markedly better instance matching, especially under viewpoint/illumination change. | Needs GPU, heavier deps, some gating. |
-
-**v1 ships classic SIFT** (zero-ceremony proof, runs in the CPU test suite), but
-the matching backend is an abstraction (`StructuralMatcher`-style protocol:
-`detect_and_describe(image) -> (keypoints, descriptors)` +
-`verify(template, candidate) -> MatchStats`) so SuperPoint+LightGlue is a drop-in
-v2 backend without touching Stage 1, the classifier, or the UI.
-
-## Storage — keypoints in the dataset pickle, nothing new on disk
-
-Following the patch precedent (`patch_grid` / `patch_regions` live in the pickle),
-a structural embedder stores per media:
-
-```python
-media["embedding"]      = np.ndarray   # (D,) fp32, L2-normalised VLAD vector — Stage 1
-media["local_features"] = StructuralFeatures(
-    keypoints  = np.ndarray,           # (M, 4) fp16: x, y, scale, orientation (normalised coords)
-    descriptors= np.ndarray,           # (M, d) — uint8 for SIFT (128), fp16 for learned
-)
-```
-
-Size: a typical image yields ~1–2k SIFT keypoints × 128 bytes ≈ 128–256 KB/image —
-the same order as patch's `patch_grid`. Stored fp16/uint8 in the pickle, cast on
-read. Capped per image (keep the top-M by response) to bound worst-case size.
-
-**No-Persisted-Vectors compliance.** Local features live *only* in the dataset
-pickle (the sanctioned snapshot store) and in RAM. They are never written to
-detector JSON or `settings.json`. The detector persists `origin + region_box` per
-labelled example and re-derives templates + the match-stat classifier on load —
-fully consistent with the rule. The VLAD **visual vocabulary** is a **fixed,
-pre-trained codebook shipped with the code** (like the embedder's model weights),
-not a per-dataset artifact — so it introduces no new persisted state and no
-per-dataset fit pass. (A data-tuned per-dataset codebook is a possible v2
-optimisation; see Open Questions.)
-
-## Capability flag & embedder surface
-
-A new flag on `MediaEmbedder` (next to `supports_text` /
-`supports_patch_regions` in `vtscore/media/embedder.py`):
-
-```python
-@property
-def supports_geometric_verification(self) -> bool:
-    """Whether this embedder produces local features for instance matching.
-
-    Structural embedders (SIFT/VLAD, learned-local-feature variants) return
-    True; the loader then stores media["local_features"] alongside the VLAD
-    media["embedding"], and the geometric re-rank + match-stat classifier
-    paths activate.  All other embedders return False and the structural
-    pipeline is skipped entirely.
-    """
-    return False
-```
-
-`to_dict()` surfaces it (like `supports_text` / `supports_patch_regions`).
-Structural embedders set `supports_text = False`, `is_default = False`
-(specialist tool, not a per-media-type default).
-
-## Integration points (backend)
-
-- **New embedder(s):** `vtscore/media/image/embedder_sift_vlad.py` (slug
-  `sift_vlad`), `supports_geometric_verification = True`, `supports_text = False`.
-  Built on a shared `_structural_shared.py` base so a future
-  `embedder_superpoint_lightglue.py` reuses the VLAD aggregation + storage and
-  only swaps the detector/matcher.
-- **Matcher abstraction:** new module `vtscore/media/structural.py` — pure
-  protocol + SIFT implementation: `detect_and_describe`, `aggregate_vlad`,
-  `verify(template, candidate) -> MatchStats`, `match_stats_to_features(stats) ->
-  np.ndarray`. No Flask, library-tier (lives under `vtscore`, import-clean).
-- **VLAD vocabulary:** a **fixed pre-trained codebook** trained offline on a
-  generic descriptor corpus and shipped as a small asset (downloaded/cached like
-  model weights, not fit per dataset). The aggregation is a pure-numpy helper that
-  loads the shipped centroids and assigns descriptors to them. No ingest-time fit.
-- **Loader hook:** `vtscore/datasets/loader_pickle.py` / `loader_folder.py`
-  already call `embed_media` / `embed_media_bulk`. Add a sibling pass, gated on
-  `embedder.supports_geometric_verification`, that runs `detect_and_describe`,
-  `aggregate_vlad`, and stores `media["local_features"]`.
-- **Similarity / re-rank chokepoint:** extend `vtscore/training/region_similarity.py`
-  (or a sibling `structural_similarity.py`) with the Stage-1→Stage-2 flow:
-  Stage-1 cosine produces the shortlist, Stage-2 RANSAC re-ranks. One place knows
-  the two-stage rule, the way `score_against_query` is the one place that knows
-  max-over-regions today.
-- **Verification classifier:** trains via the existing `train_model` on
-  match-statistic feature vectors; threshold = its decision boundary. Lives next
-  to the detector MLP in `vtscore/detectors/training.py`. The detector therefore
-  carries *two* learned objects (retrieval MLP on VLAD, verification classifier on
-  match-stats), both in-memory, both re-derived from votes.
-- **Vote recording:** unchanged — `region_box` on yes-votes already round-trips
-  (patch v2). For structural detectors the box defines the template instead of a
-  salient-area hint; the schema is identical.
-
-## Integration points (frontend)
-
-- **Sort bar:** text input greys out via the existing `supports_text = false`
-  path. No new component.
-- **Result overlay:** reuse the patch `best_region`/highlight machinery to draw
-  the matched-region outline (the inlier bounding box from the RANSAC fit) on
-  result cards and the focus pane — informational, like patch's best-region
-  outline. Optionally render the inlier correspondences as a debug view.
-- **Region voting:** the v2 Shift-drag box-draw UX is reused verbatim; for
-  structural datasets the copy nudges "box the pattern you want to match."
-- **No new region-vote affordance** beyond what patch v2 already ships.
-
-## Single embedder per dataset today; the third v3 role next
-
-**Today** a structural embedder is **one embedder per dataset**, exactly like
-patch: the dataset is bound to it at creation, and both the example/region
-similarity flow and the vote-trained detector run against that single embedder.
-This is the whole v1/v2 scope — no coexistence with a text embedder yet.
-
-`supports_text = False` means a *structural-only* dataset can be seeded *only* by
-example/region, never by a text query — the same way a `dinov*_patch` dataset has
-no text sort today. The fix is now an **active part of patch v3**, not a vague
-"someday": structural is the **third role** in the v3 **text / patch / structural
-trio**. A dataset binds up to one embedder per role (`text_embedder` /
-`patch_embedder` / `structural_embedder`), so SigLIP-text-seeded discovery and
-SIFT/VLAD instance matching coexist on one dataset. The structural slot routes
-the geometric-verification role; it also participates in the shared **score**
-role at precedence **structural ▸ patch ▸ text** (a structural embedder is a
-deliberate specialist pick, so when bound it's treated as the intended detector
-behaviour — see patch-embedder.md "Routing rules" and open question #3). Nothing
-in v1/v2 forecloses this: the per-media `embedding` field already collapses
-cleanly into the v3 dict-keyed `media["embeddings"]`, and `local_features` stays
-single-valued (one structural slot) just as `patch_regions` does for the one
-patch slot.
-
-The v3 substrate (`media["embeddings"]` dict, name-keyed MLPs) has shipped
-(patch-embedder.md Phases 2a–2b.5); what remains for the structural slot is the
-`structural_embedder` field on the binding, a `structural` routing role, and the
-create-time picker exposing it. See patch-embedder.md "V3 - implementation
-status" / "Open follow-ups (from 2b.3)".
-
-## Non-goals
-
-- **No new media type.** Structural-embedded images are still `image` media.
-- **Similarity transform only — no shear, no perspective.** v1 models the
-  template→appearance transform as a 4-DoF similarity (translation, rotation,
-  uniform scale), which is exactly what a digitally-composited logo undergoes.
-  Affine shear / anisotropic scale (the affine approximation to oblique viewing)
-  and full perspective homography are both out of scope: if we ever needed to model
-  a logo seen on a tilted real-world surface, the right move is to jump straight to
-  homography, not to stop at affine's middle ground. Fundamental-matrix / 3D-aware
-  matching is also out of scope.
-- **No persisted vectors outside the dataset pickle.** Local features live in the
-  pickle and RAM only (see Storage). Templates and both classifiers re-derive from
-  origins on load.
-- **Image only in v1, but audio is the next media target (soon).** Audio has a
-  direct structural analog — Shazam-style constellation fingerprinting (spectrogram
-  peak pairs → hashed landmarks → geometric/temporal consistency), which is the
-  same detect-features → match → verify-by-geometry shape as SIFT+RANSAC. The
-  `StructuralMatcher` protocol and the `supports_geometric_verification` flag are
-  therefore kept **media-agnostic** from the start so an audio backend drops in
-  without reshaping the interface (the "local features" become spectrogram
-  landmarks, the geometric model becomes a time-frequency offset histogram). Text
-  and document structural matching (layout/template) are further out.
-- **No swap-backend-on-an-existing-dataset flow.** Like patch, the embedder is
-  fixed at dataset creation; changing it means re-import.
-
-## Media scope
-
-v1: **image only** (+ video frames later, reusing the image path per-frame),
-matching the patch-embedder scope decision. **Audio is the next media target and
-expected soon** — see Non-goals for why the matcher abstraction is kept
-media-agnostic now so the audio (constellation-fingerprint) backend lands without
-an interface rewrite. The capability flag is `supports_geometric_verification`
-(deliberately not `supports_*_image_*`) for exactly this reason.
-
-## Open questions
-
-1. **VLAD visual vocabulary — DECIDED for v1: fixed, shipped codebook.** v1 uses a
-   single pre-trained k-means codebook trained offline on a generic descriptor
-   corpus and shipped as a small asset (cached like model weights). No per-dataset
-   fit, no codebook in the pickle, no new persisted state. The remaining sub-
-   decisions are just the codebook *size* (e.g. 128/256 centroids — bigger = more
-   discriminative VLAD, larger vectors) and the *training corpus*, both pinned by
-   the pre-impl spike. A data-tuned per-dataset codebook (better instance recall on
-   a narrow domain, at the cost of an ingest fit pass and a per-dataset artifact)
-   is a possible **v2** optimisation, not v1.
-2. **Stage-1 shortlist size K.** How many candidates feed the RANSAC re-rank?
-   Too small misses true matches the VLAD coarse stage under-ranks; too large
-   blows the re-rank latency budget. Sweep on a demo dataset.
-3. **Cold-start with <3 votes.** The verification classifier has nothing to train
-   on until there are both yes and no votes. Need a sensible default inlier-count
-   threshold for the zero/one-vote case, mirroring the safe-threshold GMM blend
-   the detector MLP uses below 6 labels.
-4. **Live re-rank vs on-demand.** Does Stage 2 run on every sort, or only when the
-   user asks (a "verify" action)? Latency vs immediacy. Probably live on the
-   shortlist (K small) but measure.
-5. **Geometric model — DECIDED: similarity transform only.** A 4-DoF similarity
-   (translation, rotation, uniform scale) for both the RANSAC inlier gate and the
-   matched-region overlay. Matches the digital-overlay use case exactly; needs only
-   2 correspondences to fit, so it constrains harder and false-positives less than
-   affine or homography. Neither affine shear nor perspective homography is used in
-   v1 — the conscious call is "no shear at all, and if shear is ever needed, go all
-   the way to homography rather than stop at affine."
-6. **VLAD vs alternatives for Stage 1.** VLAD is the recommended default, but a
-   learned global descriptor (e.g. reusing a DINOv2 CLS vector purely for the
-   coarse shortlist) could outperform VLAD while the local features do the
-   verification. Worth a spike comparison.
-
-## Phasing
-
-- **v1:** SIFT + VLAD + RANSAC, image-only, single structural embedder
-  (`sift_vlad`). `supports_geometric_verification` flag; `media["local_features"]`
-  storage; two-stage retrieval+rerank; match-statistic verification classifier;
-  RegionYes-as-template voting (reusing the v2 `region_box` schema and Shift-drag
-  UX); matched-region overlay (reusing patch's best-region machinery). Text sort
-  greyed via the existing `supports_text` gate. Pre-impl spike on a demo image
-  dataset to lock the codebook size + training corpus, K, and the geometric model.
-- **v2:** learned-local-feature backend (SuperPoint + LightGlue or similar) as a
-  drop-in `StructuralMatcher`, GPU-gated; no Stage-1/classifier/UI changes. **Plus
-  the audio backend** (constellation fingerprinting) under the same media-agnostic
-  `StructuralMatcher` protocol + `supports_geometric_verification` flag — the
-  next media target, sequenced here because the image work proves out the
-  abstraction it reuses.
-- **Patch v3 (active):** structural embedder as the **third role** in the v3
-  **text / patch / structural trio** (one embedder per role bound on a single
-  dataset), so a dataset can offer text-seeded discovery *and* region voting
-  *and* instance-matching detectors simultaneously. The v3 substrate has shipped
-  (patch-embedder.md Phases 2a–2b.5: `media["embeddings"]` dict +
-  score-embedder-keyed MLPs); the remaining structural-specific work is the
-  `structural_embedder` binding slot, a `structural` routing role, and the
-  create-time picker exposing it. Tracked in patch-embedder.md, not here.
-
-## Tests
-
-- **Matcher unit tests** with synthetic correspondences (no model weights): a
-  known similarity transform applied to a planted keypoint set → `verify` recovers
-  it with
-  the expected inlier count; degenerate/no-match inputs return low/zero inliers and
-  a rejected geometric model.
-- **VLAD aggregation:** descriptor set → fixed-D L2-normalised vector of the right
-  shape; deterministic under a seeded codebook; round-trips through the pickle as
-  fp16/uint8 and casts back correctly.
-- **Two-stage flow:** Stage-1 cosine shortlists, Stage-2 re-ranks; an item that
-  VLAD ranks mid-pack but geometrically verifies strongly is promoted above an
-  item with a high VLAD score but no geometric support.
-- **Match-stat classifier:** `train_model` over hand-crafted match-statistic
-  vectors separates verifying (RegionYes) from non-verifying (No) examples; its
-  decision boundary acts as the calibrated threshold. Single-vote / cold-start
-  falls back to the default inlier threshold.
-- **Capability flag:** `sift_vlad` registers with `supports_text = False`,
-  `supports_geometric_verification = True`; `/api/embedders` surfaces the new
-  field; existing embedders unchanged.
-- **Voting:** a RegionYes box on a structural dataset defines the template
-  keypoint subset; whole-image yes uses all keypoints; multiple RegionYes votes
-  score by max-over-templates.
-- **No-persist:** detector JSON for a structural detector contains origins +
-  `region_box` only — no keypoints, no descriptors, no classifier weights.
-- **GPU (v2):** a real learned-feature backend integration, marked
-  `@pytest.mark.gpu`.
-
-## What shipped (v1 foundation)
-
-The backend foundation of the two-stage pipeline, fully tested on CPU (no model
-download):
-
-- **Capability flag.** `MediaEmbedder.supports_geometric_verification` (default
-  `False`), surfaced in `to_dict()` and the `/api/embedders` response, mirrored
-  in the frontend `EmbedderInfo` model. Plus the symmetric
-  `local_features_forward` / `local_features_forward_bulk` hooks on the base
-  embedder (analogous to `patch_forward`).
-- **Matcher core** — `vtscore/media/structural.py` (library-tier, media-agnostic,
-  `cv2` imported lazily): the `StructuralMatcher` protocol; `StructuralFeatures`
-  (keypoints + descriptors, with a compact fp16/uint8 storage form);
-  `MatchStats` + `match_stats_to_features` (the fixed-D verification feature
-  vector); VLAD aggregation (`rootsift` + `aggregate_vlad`) against a fixed
-  shipped codebook; and the `SiftMatcher` backend (SIFT detect/describe +
-  `estimateAffinePartial2D` similarity-transform RANSAC, 4-DoF).
-- **Embedder** — `sift_vlad` (`vtscore/media/image/embedder_sift_vlad.py`) on a
-  reusable `_structural_shared.py` base, so a future
-  `embedder_superpoint_lightglue` swaps only the matcher. `supports_text=False`,
-  `is_default=False`, `supports_geometric_verification=True`. Stage-1 VLAD vector
-  → `media["embedding"]`; Stage-2 features → `media["local_features"]`.
-- **Loader pass** — `vtscore/datasets/stages/embedding.py` gains a structural
-  sibling pass (gated on the flag) that stores `media["local_features"]` in the
-  compact pickle form, with the same fresh-and-back-fill shape as the patch pass.
-- **Codebook asset** — `vtscore/media/assets/vlad_codebook_v1.npy` (shipped via
-  `package-data`), rebuilt by `scripts/build_vlad_codebook.py` (seeded
-  placeholder now; `--images DIR` does the real corpus k-means fit).
-
-## What shipped (v1 Stage-2 backend core)
-
-The Stage-1→Stage-2 chokepoint and the verification learnable, wired into the
-vote-driven sort and fully CPU-tested
-(`tests_lib/detectors/test_structural_similarity.py`):
-
-- **Chokepoint** — `vtscore/training/structural_similarity.py` (library-tier,
-  import-clean): the one place that knows the two-stage rule. `structural_rerank`
-  takes the Stage-1-sorted list, geometrically verifies the top-`K`
-  (`DEFAULT_RERANK_TOP_K`) against the templates, and re-ranks by a verification
-  score in `[0, 1]`; candidates beyond the shortlist are kept in Stage-1 order
-  and scored 0 (the accepted K trade-off). The matched-region `inlier_box` rides
-  out on each verified result as `best_region` (the data side of the overlay).
-- **RegionYes-as-template** — `filter_features_to_box` keeps only the keypoints
-  inside a yes-vote's `region_box`; `build_templates` makes one template per Good
-  vote (whole-image yes keeps all keypoints) and `best_match_stats` scores
-  **max-over-templates**.
-- **Verification classifier** — `train_verification_classifier` stacks each
-  labelled item's `MatchStats` (verified against the templates, leave-one-out for
-  a Good vote's own template) into the `match_stats_to_features` vector and trains
-  a tiny MLP via `train_model`; its decision boundary is the calibrated threshold
-  (`STRUCTURAL_DECISION_THRESHOLD = 0.5`). `VerificationScorer` wraps it, falling
-  back below `MIN_VERIFICATION_VOTES` (3) to a cold-start inlier gate that crosses
-  0.5 exactly at `DEFAULT_MIN_INLIERS`, so the same threshold separates
-  match/non-match in both regimes. Carried on `DetectorContext.verification_classifier`
-  (in-memory, re-derived every retrain, never persisted) next to the retrieval MLP.
-- **Wiring** — `maybe_structural_rerank` is invoked from `train_and_score`
-  (`vtscore/detectors/training.py`), gated on media carrying `local_features`
-  (mirrors the patch path's `patch_regions` gate) so every non-structural dataset
-  is untouched and pays zero cost. The matcher is resolved backend-agnostically
-  via the embedder's new `structural_matcher` property.
-
-## What shipped (v1 Stage-2 re-rank across all sort paths)
-
-The Stage-2 re-rank now reaches every scoring entry point, not just the
-vote-driven sort (CPU-tested in
-`tests_lib/detectors/test_structural_similarity.py` +
-`test_structural_labelset.py`):
-
-- **`feature_snap` decoupling.** `maybe_structural_rerank` takes an optional
-  `feature_snap` so the templates + verification classifier can be sourced from a
-  snapshot distinct from the re-rank target. The vote path leaves it `None`
-  (voted media are in the active dataset); the labelset path passes a synthetic
-  snapshot of re-derived cross-dataset features. The re-rank itself always runs
-  over the active dataset's `snap`.
-- **Example-sort (seed-by-example).** `maybe_structural_rerank_example` uses the
-  uploaded example's own local features as the single template (any crop is
-  applied to the file before feature detection, so it already restricts the
-  template) and the cold-start inlier gate to score (example-sort carries no
-  votes). Wired into `_example_sort_from_path` (`vtsearch/routes/sorting.py`);
-  the matched-region `best_region` rides out on `similarity`-keyed results, which
-  the frontend already renders.
-- **Labelset (saved-detector reload).** New
-  `DetectorContext.label_local_features` cache (in-memory, re-derived from each
-  element's origin via `populate_label_local_features`, invalidated on embedder
-  switch alongside `label_embeddings`). `maybe_labelset_structural_rerank`
-  projects the cache into the chokepoint's vote/snap shape and re-ranks the
-  active dataset; wired into `labelset_train_and_score`
-  (`vtscore/detectors/labelset_training.py`). A no-op for non-structural
-  datasets (gated on the active snapshot carrying `local_features`).
-
-## What shipped (v1 Find-path re-rank)
-
-The Stage-2 re-rank now also reaches the **Find** scoring path, the last scoring
-entry point that stopped at coarse VLAD retrieval (CPU-tested in
-`tests/detectors/test_find_label.py` +
-`tests_lib/detectors/test_structural_labelset.py`):
-
-- **`find-label` wiring.** `find_label` (`vtsearch/routes/detectors/scoring.py`)
-  scores every media with the retrieval MLP (`score_media_with_model`) and then
-  hands the result list to `maybe_labelset_structural_rerank` — the same
-  chokepoint the learned-sort labelset path uses — before applying the
-  threshold labels and freezing `find_scores`. The detector's stored labelset is
-  parsed once (`LabelSet.from_dict(det_data["labelset"])`) and the re-rank builds
-  the RegionYes templates + verification classifier from the cross-dataset
-  `label_local_features` cache (re-derived from origins, then reused), so a
-  pre-trained structural detector verifies in Find without re-detecting features
-  on every pass. The classifier lands on `DetectorContext.verification_classifier`
-  exactly as on the vote/labelset paths.
-- **No-op for non-structural detectors.** Gated on the active snapshot carrying
-  `local_features` (via `snapshot_is_structural`), so the audio/image
-  single-vector and patch detectors are untouched and pay only one O(N) snapshot
-  scan. The frozen `find_scores` then hold the verification probabilities and the
-  cutoff is the classifier's `STRUCTURAL_DECISION_THRESHOLD` (0.5), so the
-  Inclusion slider re-thresholds over verification scores like any other Find run.
+**Status:** v1 + Stage-2 backend + Find re-rank all shipped. The two-stage
+re-rank now reaches **every** scoring entry point (vote-driven learned-sort,
+example-sort, labelset/saved-detector, and Find/`find-label`); the
+match-statistic verification classifier, RegionYes-as-template voting, and the
+matched-region overlay are live; ROxford5k and OpenLogo are wired as demo
+datasets; the VLAD codebook is a real Caltech-101 k-means fit; and the
+K/threshold spike is done (defaults `K=50` / `threshold=0.5` confirmed).
+**Larger VLAD codebook is the main next step** — the spike identified Stage-1
+VLAD recall as the end-to-end quality ceiling. Open follow-ups below; the living
+design spec is further down.
+
+Structural embedders are a third embedder *type* (alongside single-vector and
+patch) that searches for **specific instances** ("the Coca-Cola logo") rather
+than **semantic categories** ("a cola can"), via a two-stage
+retrieve-then-geometrically-verify pipeline.
 
 ## Open follow-ups
 
-- **Frontend overlay — reachable now, debug view deferred.** The backend emits the
-  matched-region `best_region` box on verified results across all sort paths, and
-  the frontend renders it as the focus-pane highlight box in `center-panel` /
-  `image-viewer` (fed via `bestRegion`), so the structural overlay rides patch's
-  existing machinery with no new component. **Reachability fix shipped:** the
-  Highlight toggle that surfaces that overlay was gated on `supports_patch_regions`
-  alone, which structural embedders leave `false` — so on a structural dataset the
-  toggle (and thus the overlay) was hidden. The gate is now
-  `center-panel`'s `regionOverlayCapable` getter (true when the embedder reports
-  *either* `supports_patch_regions` *or* `supports_geometric_verification`), and
-  the marquee copy nudges "box the pattern you want to match" on structural
-  datasets (the box is constitutive — it defines the template). Still optional: a
-  debug view that draws the inlier *correspondences* (the matched keypoint lines),
-  which would need the backend to emit per-match point pairs.
-- **K / threshold / live-vs-on-demand spike — DONE; defaults confirmed.** Run on
-  the full Revisited Oxford (ROxford5k) benchmark (4993 db images + 70 queries,
-  `max_features=1024`, the shipped 64-centroid codebook) via
-  `scripts/spike_structural_roxford.py`. mAP follows the revisitop protocol
-  (Medium = easy+hard positives; Hard = hard only). Numbers:
+**Active / next:**
+
+- **VLAD codebook — real fit shipped; grow it next (the headline item).** The
+  shipped `vlad_codebook_v1.npy` is a genuine k-means vocabulary fit on 1M
+  Caltech-101 rootSIFT descriptors (64 centroids), built with
+  `scripts/build_vlad_codebook.py --images data/caltech-101/101_ObjectCategories`.
+  The ROxford spike shows **64 centroids is the recall bottleneck**: absolute mAP
+  is low (0.09–0.15) because weak VLAD retrieval means true matches the coarse
+  vocabulary under-ranks never enter the top-K, so Stage-2 cannot recover them.
+  The clear follow-up is a **larger vocabulary (256–1024 centroids) fit on a
+  building/scene corpus** (e.g. Paris6k or a Places365 slice — kept disjoint from
+  any eval set) to raise Stage-1 recall, which is what caps end-to-end mAP.
+  Bigger K also grows the VLAD vector (`K × 128`); confirm the diversity-tree /
+  sort costs stay acceptable when bumping it. **Re-measure on OpenLogo**
+  (below) — does a 256–1024-word vocabulary lift Stage-1 recall on logos as the
+  ROxford spike predicts?
+
+  Spike evidence (ROxford5k: 4993 db + 70 queries, `max_features=1024`, the
+  shipped 64-centroid codebook, via `scripts/spike_structural_roxford.py`;
+  revisitop protocol):
 
   | Stage | mAP-medium | mAP-hard | re-rank ms/query |
   |-------|-----------:|---------:|-----------------:|
@@ -595,79 +47,276 @@ entry point that stopped at coarse VLAD retrieval (CPU-tested in
   | + Stage-2 K=100 | 0.133 | 0.059 | 477 |
   | + Stage-2 K=200 | 0.148 | 0.057 | 936 |
 
-  **K:** the geometric re-rank lifts mAP at every K (Stage-1 is the floor).
-  Latency is ~4.8 ms/candidate, so cost grows linearly while the *quality*
-  return tapers — Hard mAP **peaks at K=100 and regresses by K=200**. So
-  `DEFAULT_RERANK_TOP_K = 50` is a sound default (good lift at ~250 ms/query),
-  with K=100 the quality-sensitive ceiling. **Kept at 50; no change.**
-
-  **Threshold** (verification-score sweep at K=100, Medium GT): precision climbs
-  steeply to the knee then flattens — 0.30→0.59, 0.40→0.89, **0.50→0.93**,
-  0.60→0.97, 0.70→0.99 — while recall declines monotonically. 0.5 is the
-  precision/recall knee (when the verifier says "match" it is right ~93% of the
-  time), so `STRUCTURAL_DECISION_THRESHOLD = 0.5` is confirmed. **Kept at 0.5.**
-
-  **Live vs on-demand:** ~250 ms/query at K=50 (CPU) is fine for the current
-  on-every-sort re-rank; no separate on-demand "verify" action is needed at v1
-  scale. Revisit if K is raised or datasets grow well past ROxford's 5k.
-
-  **Headline finding — Stage-1 recall is the ceiling.** Absolute mAP is low
-  (0.09–0.15) because the 64-centroid codebook fit on a generic object corpus
-  (Caltech-101) gives weak VLAD retrieval: true matches the coarse vocabulary
-  under-ranks never enter the top-K, so Stage-2 cannot recover them. This is the
-  concrete answer to the codebook-size/corpus question below: **64 is too small.**
-- **Find-path classifier reuse — SHIPPED.** The Find scoring path
-  (`POST /api/find-label`) now routes a saved structural detector's Stage-1 VLAD
-  scores through the same Stage-2 re-rank as the learned-sort/labelset path
-  (`maybe_labelset_structural_rerank`, wired in
-  `vtsearch/routes/detectors/scoring.py`). The detector's on-disk labelset is
-  re-derived into templates + verification classifier (reusing the
-  `DetectorContext.label_local_features` cache so features aren't re-detected
-  across calls) and the active dataset's shortlist is geometrically re-ranked;
-  the classifier is stored on `DetectorContext.verification_classifier` as on
-  every other path. A no-op for non-structural detectors. So every scoring entry
-  point — vote-driven sort, example-sort, labelset sort, **and Find** — now
-  verifies. See "What shipped (v1 Find-path re-rank)".
+  Hard mAP peaks at K=100 and regresses by K=200; `K=50` is the shipped default
+  (good lift at ~250 ms/query), K=100 the quality-sensitive ceiling. The
+  geometric re-rank lifts mAP at every K, but Stage-1 is the floor it cannot
+  beat — hence growing the codebook.
+- **OpenLogo measured counts.** The `openlogo` demo's advertised
+  `DEMO_MEDIA_COUNTS` currently falls back to the per-category estimate
+  (approximate for a flat-sliced multi-label source, as with Visual Genome);
+  measure the real entries once the 4.6 GB set has been downloaded and counted.
 - **Double SIFT detection.** The embed pass (VLAD) and the local-features pass
   each run SIFT once per image. Acceptable for v1; a combined single-detect pass
   is a cheap later optimisation.
-- **VLAD codebook — real fit shipped; grow it next.** The shipped
-  `vlad_codebook_v1.npy` is now a genuine k-means vocabulary fit on 1M Caltech-101
-  rootSIFT descriptors (64 centroids), replacing the seeded placeholder — built
-  with `scripts/build_vlad_codebook.py --images data/caltech-101/101_ObjectCategories`.
-  The ROxford spike shows 64 centroids is the recall bottleneck; the clear
-  follow-up is a **larger vocabulary (256–1024 centroids) fit on a building/scene
-  corpus** (e.g. Paris6k or a Places365 slice — kept disjoint from any eval set)
-  to raise Stage-1 recall, which is what caps end-to-end mAP. Bigger K also grows
-  the VLAD vector (`K × 128`); confirm the diversity-tree / sort costs stay
-  acceptable when bumping it.
-- **Logo instance-matching demo — SHIPPED (OpenLogo).** ROxford5k covers the
-  *landmark* instance-matching case; the *logo* case now has its own demo:
-  **Voxel51/OpenLogo** (QMUL-OpenLogo), wired as the `openlogo` image source
-  (`openlogo_s` / `openlogo_a`). It aggregates 7 logo datasets — FlickrLogos-27/32,
-  Logo32plus, BelgaLogos, WebLogo-2M (test), Logo-in-the-Wild, SportsLogo — giving
-  genuinely in-the-wild brand photos with ground-truth boxes. The demo vocabulary
-  is the 32 FlickrLogos-32 brands (OpenLogo's supervised core); for any one brand
-  the other 31 form the distractor haystack, the same setup ROxford's `other`
-  bucket provides. It is a FiftyOne dataset on HuggingFace (a flat `data/` media
-  folder + `samples.json` of `ground_truth` detections with normalized boxes),
-  pulled via `huggingface_hub.snapshot_download` and parsed with the stdlib (no
-  `fiftyone` dependency); brand labels are matched to the display categories
-  through a punctuation/case-insensitive key. Ground-truth boxes are stamped onto
-  each clip as store-only `regions`, so this is also the natural dataset for
-  exercising the Calibration & Evaluation flow against real logos. **This is the
-  benchmark to re-measure the codebook-growth follow-up on** (does a 256–1024-word
-  vocabulary lift Stage-1 recall on logos as the ROxford spike predicts?). Open:
-  measured `DEMO_MEDIA_COUNTS` entries (the advertised count currently falls back
-  to the per-category estimate, approximate for a flat-sliced multi-label source,
-  as with Visual Genome) once the 4.6 GB set has been downloaded and counted.
-- Spike (codebook size/corpus, Stage-1 backbone choice, K, geometric model)
-  precedes v1 build, like the caltech101_s sweep preceded patch v1.
-- Keep the `StructuralMatcher` protocol media-agnostic from day one so the audio
-  (constellation-fingerprint) backend — the next media target — lands in v2 without
-  reshaping the interface.
-- Multi-embedder coexistence (structural alongside text and/or patch on one
-  dataset) is the **third role of the active v3 trio**, tracked in
-  patch-embedder.md ("V3 - design" / "Open follow-ups (from 2b.3)"): the v3
-  substrate has shipped; the structural binding slot + `structural` routing role
-  + create-time picker are what remain. Not scheduled in this doc.
+- **Frontend debug view (deferred).** The matched-region overlay is reachable
+  (see *What shipped*); still optional is a debug view drawing the inlier
+  *correspondences* (matched keypoint lines), which would need the backend to
+  emit per-match point pairs.
+
+**v2 (next media/feature targets):**
+
+- **Learned-local-feature backend** (SuperPoint + LightGlue or similar) as a
+  drop-in `StructuralMatcher`, GPU-gated; no Stage-1/classifier/UI changes.
+- **Audio backend** (constellation fingerprinting) under the same
+  media-agnostic `StructuralMatcher` protocol + `supports_geometric_verification`
+  flag — the next media target. The protocol is kept media-agnostic from day one
+  precisely so this lands without an interface rewrite (local features →
+  spectrogram landmarks, geometric model → time-frequency offset histogram).
+
+**Multi-embedder coexistence (v3 trio):** structural as the **third role** in the
+v3 **text / patch / structural** trio (one embedder per role on a single
+dataset), so a dataset can offer text-seeded discovery *and* region voting *and*
+instance-matching simultaneously. The v3 substrate has shipped (patch-embedder.md
+Phases 2a–2b.5: `media["embeddings"]` dict + score-embedder-keyed MLPs); what
+remains is the `structural_embedder` binding slot, a `structural` routing role
+(precedence structural ▸ patch ▸ text), and the create-time picker. Tracked in
+patch-embedder.md ("V3 - design" / "Open follow-ups (from 2b.3)"), not here.
+
+**Open design questions still live:**
+
+- **Cold-start with <3 votes.** The verification classifier has nothing to train
+  on until there are both yes and no votes; the shipped fallback is a default
+  inlier-count gate (`DEFAULT_MIN_INLIERS`, crossing 0.5 at
+  `MIN_VERIFICATION_VOTES = 3`), mirroring the safe-threshold GMM blend below 6
+  labels. Revisit if it proves too coarse.
+- **VLAD vs alternatives for Stage 1.** A learned global descriptor (e.g. a
+  DINOv2 CLS vector purely for the coarse shortlist) could outperform VLAD while
+  the local features do the verification. Worth a spike comparison — and relevant
+  to the codebook-growth work above.
+- **Per-dataset codebook (v2 option).** A data-tuned per-dataset codebook gives
+  better instance recall on a narrow domain, at the cost of an ingest fit pass and
+  a per-dataset artifact. A possible v2 optimisation, not v1.
+
+## What shipped
+
+One line per item; details in git history, the cited source files, and
+`tests_lib/detectors/test_structural_similarity.py` /
+`test_structural_labelset.py` / `tests/detectors/test_find_label.py`.
+
+**v1 foundation** (backend, CPU-tested, no model download):
+
+- **Capability flag** — `MediaEmbedder.supports_geometric_verification` (default
+  `False`), surfaced in `to_dict()` + `/api/embedders`, mirrored in the frontend
+  `EmbedderInfo`; plus `local_features_forward`/`_bulk` base hooks.
+- **Matcher core** — `vtscore/media/structural.py` (library-tier, media-agnostic,
+  lazy `cv2`): `StructuralMatcher` protocol; `StructuralFeatures` (keypoints +
+  descriptors, fp16/uint8 storage); `MatchStats` + `match_stats_to_features`;
+  VLAD aggregation (`rootsift` + `aggregate_vlad`); `SiftMatcher` backend (SIFT +
+  `estimateAffinePartial2D` 4-DoF similarity-transform RANSAC).
+- **Embedder** — `sift_vlad` (`vtscore/media/image/embedder_sift_vlad.py`) on a
+  reusable `_structural_shared.py` base; `supports_text=False`, `is_default=False`,
+  `supports_geometric_verification=True`. Stage-1 VLAD → `media["embedding"]`;
+  Stage-2 features → `media["local_features"]`.
+- **Loader pass** — `vtscore/datasets/stages/embedding.py` structural sibling
+  pass (flag-gated) storing `media["local_features"]` in compact pickle form.
+- **Codebook asset** — `vtscore/media/assets/vlad_codebook_v1.npy` (real
+  Caltech-101 fit; `scripts/build_vlad_codebook.py`).
+
+**v1 Stage-2 backend core** (chokepoint + verification learnable, vote path):
+
+- **Chokepoint** — `vtscore/training/structural_similarity.py`: the one place
+  that knows the two-stage rule. `structural_rerank` verifies the top-`K`
+  (`DEFAULT_RERANK_TOP_K = 50`) against templates and re-ranks by a `[0,1]`
+  verification score (beyond-K kept in Stage-1 order, scored 0). The matched
+  `inlier_box` rides out as `best_region`.
+- **RegionYes-as-template** — `filter_features_to_box` keeps in-box keypoints;
+  `build_templates` makes one template per Good vote; `best_match_stats` scores
+  **max-over-templates**.
+- **Verification classifier** — `train_verification_classifier` trains a tiny MLP
+  via `train_model` over per-item `MatchStats` (leave-one-out for a Good vote's
+  own template); decision boundary = `STRUCTURAL_DECISION_THRESHOLD = 0.5`.
+  `VerificationScorer` falls back below `MIN_VERIFICATION_VOTES` (3) to a
+  cold-start inlier gate crossing 0.5 at `DEFAULT_MIN_INLIERS`. Carried on
+  `DetectorContext.verification_classifier` (in-memory, re-derived, never persisted).
+- **Wiring** — `maybe_structural_rerank` invoked from `train_and_score`
+  (`vtscore/detectors/training.py`), gated on media carrying `local_features` so
+  non-structural datasets pay zero cost.
+
+**v1 Stage-2 re-rank across all sort paths:**
+
+- **`feature_snap` decoupling** — `maybe_structural_rerank` takes an optional
+  snapshot so templates/classifier can be sourced separately from the re-rank
+  target (labelset path passes a synthetic cross-dataset snapshot).
+- **Example-sort** — `maybe_structural_rerank_example` uses the uploaded
+  example's own local features as the single template + cold-start gate; wired
+  into `_example_sort_from_path` (`vtsearch/routes/sorting.py`).
+- **Labelset (saved-detector reload)** — `DetectorContext.label_local_features`
+  cache (re-derived from origins, invalidated on embedder switch);
+  `maybe_labelset_structural_rerank` wired into `labelset_train_and_score`.
+
+**v1 Find-path re-rank:**
+
+- **`find-label` wiring** — `find_label` (`vtsearch/routes/detectors/scoring.py`)
+  scores with the retrieval MLP then hands the list to
+  `maybe_labelset_structural_rerank` (the same chokepoint), building templates +
+  classifier from the cross-dataset `label_local_features` cache. So every
+  scoring path — vote, example, labelset, **and Find** — now verifies. No-op for
+  non-structural detectors (gated via `snapshot_is_structural`); frozen
+  `find_scores` hold verification probabilities, re-thresholded by the Inclusion
+  slider.
+
+**Demos + spike:**
+
+- **ROxford5k** wired as the landmark instance-retrieval demo.
+- **OpenLogo (QMUL-OpenLogo)** wired as the logo instance-matching demo
+  (`openlogo` source, `openlogo_s`/`openlogo_a`): 7 aggregated logo datasets,
+  32 FlickrLogos-32 brands as the vocabulary (the other 31 as distractors),
+  ground-truth boxes stamped as store-only `regions`. FiftyOne-on-HuggingFace,
+  pulled via `snapshot_download`, parsed with the stdlib (no `fiftyone` dep).
+  The benchmark for re-measuring codebook growth.
+- **K/threshold/live-vs-on-demand spike DONE** — defaults confirmed (`K=50`,
+  `threshold=0.5`; precision ~93% at 0.5, the P/R knee; ~250 ms/query at K=50 is
+  fine for on-every-sort re-rank). See the codebook follow-up above for the table
+  and the "Stage-1 recall is the ceiling" finding.
+
+**Frontend overlay (reachable now):** the backend emits `best_region` on verified
+results across all paths; the frontend renders it as the focus-pane highlight via
+patch's existing machinery (`center-panel` / `image-viewer`, fed `bestRegion`).
+Reachability fix: the Highlight toggle was gated on `supports_patch_regions`
+alone (which structural leaves `false`); it now uses `center-panel`'s
+`regionOverlayCapable` getter (true when the embedder reports *either*
+`supports_patch_regions` *or* `supports_geometric_verification`), and the marquee
+copy nudges "box the pattern you want to match."
+
+## Design spec (living architecture)
+
+Kept below the open work because most of it now describes shipped mechanics;
+retained as the spec a contributor needs for the open follow-ups (audio/learned
+backends, codebook growth, v3 trio).
+
+### The core mismatch (why a new *type*, not a new embedder)
+
+Structural matching breaks two of VTSearch's assumptions: (1) a structural
+extractor produces a *variable-size set* of `(keypoint, descriptor)` pairs per
+image, not a single fixed-D vector; (2) two images are compared by **geometric
+verification** (match descriptors, RANSAC-fit a transform, count inliers), not a
+dot product. Yet every downstream consumer — `train_model(X, y, input_dim)`, the
+diversity tree, cosine/example sort, `_score_all_media` — wants a fixed-D
+L2-normalised vector and a cosine. The two-stage architecture reconciles the two
+worlds without rewriting the downstream.
+
+### Two-stage architecture
+
+**Stage 1 — retrieval (rides the existing pipeline unchanged).** Aggregate each
+image's local descriptors into a fixed-D vector via **VLAD**. That vector
+populates `media["embedding"]`, so the diversity tree, cosine/example sort,
+pre-vote sorts, and `train_model` work with zero new machinery. `supports_text`
+is `False` (no text encoder maps into VLAD space). Stage 1 alone is coarse
+instance retrieval — fast, and what makes Stage 2 tractable.
+
+**Stage 2 — geometric verification (the new structural part).** For the top-K
+Stage-1 candidates, match query/template keypoints against each candidate and
+RANSAC-fit a **similarity** transform (4-DoF: translation, rotation, uniform
+scale — *no* shear, *no* perspective; exactly what a digitally-overlaid logo
+undergoes, and RANSAC needs only 2 correspondences so it constrains harder). This
+yields an inlier set + geometric model per candidate and **re-ranks** the
+shortlist. It is a re-rank layered *after* sorting, never a replacement:
+whole-haystack RANSAC would be O(N·match·RANSAC), so restricting to the shortlist
+is both elegant and necessary for the scalability budget.
+
+### The "MLP equivalent" — a classifier over *match statistics*
+
+You don't learn in raw SIFT-descriptor space; you learn in two derived fixed-D
+metric spaces that both reuse `train_model` verbatim:
+
+1. **Retrieval MLP** — the ordinary detector MLP, trained on VLAD vectors.
+2. **Verification classifier** — every RANSAC fit emits match statistics (inlier
+   count + ratio, tentative-match count, mean/median reprojection error, geometric
+   plausibility of the similarity model, inlier spatial spread). Stack these into
+   a fixed-D vector **per (template, candidate) pair** → tiny MLP → P(match). The
+   user's votes are the labels: RegionYes items that geometrically verify are
+   positives, No items are negatives. The classifier's decision boundary **is**
+   the calibrated threshold.
+
+### Voting model — RegionYes is *constitutive*
+
+For structural detectors the region box **defines the template** (stronger than
+patch's salient-area hint). **RegionYes** keeps only in-box keypoints as the
+query template (`LabeledElement.region_box`, already shipped in patch v2 — no new
+schema; templates re-derive on load). Whole-image Yes is allowed but noisy. No
+feeds the verification negatives + optional stop-list down-weighting. Multiple
+RegionYes → multiple templates, score = **max over templates**.
+
+### Feature backend — SIFT for v1, pluggable for learned features
+
+The matching backend is pluggable behind the structural-embedder interface (same
+story DINOv2/v3/EUPE have for patch). **v1 ships classic SIFT + RANSAC** (OpenCV,
+CPU-friendly, deterministic, patent expired, runs in the CPU suite). The
+abstraction (`StructuralMatcher`: `detect_and_describe(image) -> (keypoints,
+descriptors)` + `verify(template, candidate) -> MatchStats`) makes SuperPoint +
+LightGlue a drop-in v2 backend without touching Stage 1, the classifier, or the
+UI — and keeps the audio (constellation-fingerprint) backend a drop-in too.
+
+### Storage — no-persist compliance
+
+Per media: `media["embedding"]` (fp32 L2-normalised VLAD, Stage 1) and
+`media["local_features"] = StructuralFeatures(keypoints, descriptors)` (fp16/
+uint8, capped per image at the top-M by response). ~128–256 KB/image, same order
+as patch's `patch_grid`. Local features live **only** in the dataset pickle (the
+sanctioned snapshot) and RAM — never in detector JSON or `settings.json`. The
+detector persists `origin + region_box` per labelled example and re-derives
+templates + both classifiers on load. The VLAD **visual vocabulary** is a fixed,
+pre-trained codebook shipped with the code (like model weights), not a
+per-dataset artifact — so no new persisted state and no per-dataset fit pass.
+
+### Integration points
+
+- **Embedder(s):** `vtscore/media/image/embedder_sift_vlad.py` (`sift_vlad`) on a
+  shared `_structural_shared.py` base.
+- **Matcher abstraction:** `vtscore/media/structural.py` — protocol + SIFT impl
+  (`detect_and_describe`, `aggregate_vlad`, `verify`, `match_stats_to_features`).
+  Library-tier, import-clean.
+- **Loader hook:** flag-gated sibling pass in the loader storing `local_features`.
+- **Re-rank chokepoint:** `vtscore/training/structural_similarity.py` — the one
+  place that knows the Stage-1→Stage-2 rule.
+- **Verification classifier:** trains via `train_model` on match-stat vectors next
+  to the detector MLP; the detector carries two learned objects (both in-memory,
+  both re-derived from votes).
+- **Frontend:** text input greys via the `supports_text=false` path; the matched
+  region reuses patch's `best_region`/highlight machinery; v2 Shift-drag box-draw
+  reused with structural copy. No new region-vote affordance.
+
+### Non-goals
+
+- No new media type (structural images are still `image`).
+- **Similarity transform only** — no affine shear, no perspective homography.
+  (If oblique real-world viewing is ever needed, jump straight to homography, not
+  affine's middle ground.)
+- No persisted vectors outside the dataset pickle.
+- Image-only in v1; **audio is the next media target** (constellation
+  fingerprinting), which is why the matcher/flag are media-agnostic. Text/document
+  structural matching is further out.
+- No swap-backend-on-an-existing-dataset flow (embedder fixed at creation, like
+  patch).
+
+### Phasing
+
+- **v1 (shipped):** SIFT + VLAD + RANSAC, image-only, single `sift_vlad`
+  embedder; `supports_geometric_verification`; `local_features` storage;
+  two-stage retrieval + re-rank across all sort paths; match-stat verification
+  classifier; RegionYes-as-template; matched-region overlay. Text sort greyed.
+- **v2:** learned-local-feature backend (GPU-gated) **plus** the audio backend,
+  both under the media-agnostic `StructuralMatcher` protocol.
+- **Patch v3 (active):** structural as the third role in the text/patch/structural
+  trio — substrate shipped, binding slot + routing role + picker remain. Tracked
+  in patch-embedder.md.
+
+### Tests
+
+Matcher units (synthetic correspondences recover a known transform);
+VLAD-aggregation shape/determinism/round-trip; two-stage promotion (an item VLAD
+ranks mid-pack but that verifies strongly outranks a high-VLAD no-geometry item);
+match-stat classifier separates RegionYes from No with cold-start fallback;
+capability flag surfaces; voting (box defines template, max-over-templates);
+no-persist (detector JSON = origins + `region_box` only); GPU (v2) learned-feature
+integration.

--- a/docs/plans/user-docs-screenshots.md
+++ b/docs/plans/user-docs-screenshots.md
@@ -1,72 +1,72 @@
 # User-Docs Screenshots
 
-**Status:** Shipped 2026-06-10. Drafted 2026-06-07; shot list audited
-2026-06-09; **harness built + all 16 shots captured in light+dark (32 PNGs)
-and embedded** 2026-06-10 in a browser-ready session. The in-app embed
-plumbing shipped 2026-06-07 (images render theme-matched in the Help panel;
-see "Doc-embedding convention"). The seed `dashboard-loaded` placeholder pair
-has been replaced with real captures. See "What shipped" and "Open
-follow-ups" below.
+**Status:** Shipped. The manifest + Playwright harness + driver scripts + all
+shots are built and embedded — **20 logical shots × 2 themes = 40 PNGs** (16
+shipped 2026-06-10; +4 and 7 retakes in the [2026-06-28
+audit](docs-audit-2026-06-28.md)). This doc is now the **full-system reference**
+for the screenshot pipeline; a future GUI change re-runs it. Open follow-ups are
+foregrounded below, then the architecture/manifest/refresh/reshoot-queue
+reference, then a terse record of what shipped.
 
-**2026-06-09 audit.** Re-checked every planned shot against the current
-UI and the user guide. Changes: dropped the vague `settings-modal` shot in
-favour of `settings-appearance` (the Settings → Appearance pane, which the
-guide actually describes); added `manual-controls` (Manual mode had no
-shot) and `browse-view` (the Browse mode was undocumented entirely — a
-new user-guide section was written for it this pass); sharpened several
-descriptions to match real control names. The ready-to-paste **Capture
-prompt** for a browser-ready session is now at the bottom of this doc.
+## Open follow-ups
 
-**Goal.** Add inline screenshots to the **user-facing** docs and build a
-system that can **regenerate every shot with one command** when the GUI
-changes. The pain point this plan targets is *staleness*: screenshots
-that silently drift out of date as the UI evolves. The answer is a
-single source of truth (a manifest) plus a deterministic, scriptable
-capture harness, so a refresh is a re-run, not a re-shoot.
+- **Self-booting / temp-data-dir determinism.** The harness currently drives an
+  already-running app against the real `data/` dir (a RAM-driven choice — a
+  second instance would load the image embedder twice and OOM the ~3.7 GB box).
+  The plan's original intent was a temp data dir per run. Revisit if pixel-diff
+  drift from shared state becomes a problem; the synthetic seed already covers
+  content stability.
+- **Annotation polish.** The declarative `highlight` overlay dims the whole
+  viewport (including modals); a couple of boxes (`importer-subtab-bar`) sit a
+  few px low. Cosmetic; tune the overlay geometry.
+- **`autopilot-progress` phase.** Captured with phase 3 (Refine Boundary) active
+  thanks to the 9-vote `doc-demo` fixture; if the fixture vote count changes,
+  the active phase in this shot moves with it.
+- **`region-voting` scriptability** — confirm the canvas drag can be driven
+  deterministically; fall back to hand-capture only if not.
+- **`browse-view` determinism** — seed the UMAP fit (fixed `random_state`) so
+  the layout is stable across runs, and pose the hover-preview popup; otherwise
+  hand-capture. The projection is expensive to build, so reuse a cached fixture
+  projection rather than rebuilding per run.
+- **Pixel-diff tolerance** for `check.sh` (font hinting / AA can cause sub-pixel
+  noise across machines; may need a small per-pixel threshold).
 
-This is **not** the same as
-[browser-vision-testing.md](browser-vision-testing.md). That plan drives
-the app via the Claude Chrome extension to *hunt for bugs*; its shots are
-throwaway audit artifacts under `docs/reviews/assets/`, captured by a
-hand-driven session with no determinism or refresh story. This plan is
-about *durable, doc-embedded* shots that must look identical on every
-refresh. Different engine, different output location, different lifetime.
+*(Resolved: real screenshots captured; chromium provisioned under
+`scripts/screenshots/`; the `<picture>`/`prefers-color-scheme` embed form
+locked; the disk-gauge masking gap closed by the 2026-06-28 audit —
+`maskVolatile` now masks RAM + disk gauges and re-asserts before capture.)*
 
-## Decisions (locked 2026-06-07)
+---
 
-| Decision | Choice | Consequence |
-|----------|--------|-------------|
-| Capture engine | **Automated script** (Playwright/CDP, checked in) | Refresh = one command; deterministic; diffable. Needs chromium in the browser-ready env. |
-| Doc scope | **USER_GUIDE.md + README.md + demos.md** | Three user-facing docs get shots; dev/ops docs (ARCHITECTURE, API, CLI, DEPLOYMENT, EXTENDING*, ML, EVAL) do not. |
-| Themes | **Both light and dark** | Each logical shot yields a `{light, dark}` pair from one manifest entry. ~2× output files, still one command. |
-| Annotations | **Annotated**, but **declaratively** | Callouts (arrow/box/label) are declared in the manifest and drawn by the harness as a DOM overlay *before* capture — never hand-edited in an image editor. Keeps refresh fully automated. |
+## Reference — the full system
 
-The two "ambitious" choices (both-themes, annotated) are reconciled with
-the one-command-refresh goal by the design below: themes are a parameter,
-annotations are data. Neither requires manual post-processing.
+**Goal.** Inline screenshots in the **user-facing** docs plus a system that
+**regenerates every shot with one command** when the GUI changes. The pain point
+is *staleness*: a single source of truth (a manifest) plus a deterministic,
+scriptable capture harness makes a refresh a re-run, not a re-shoot. This is
+*not* [browser-vision-testing.md](browser-vision-testing.md) (throwaway
+bug-hunt shots under `docs/reviews/assets/`) — these are durable, doc-embedded
+shots that must look identical on every refresh.
 
-## Why the synthetic dataset is the fixture
+**Locked decisions (2026-06-07).** Capture engine = checked-in automated
+Playwright/CDP script (needs chromium). Doc scope = USER_GUIDE.md + README.md +
+demos.md only (dev/ops docs get none). Themes = both light + dark (each logical
+shot yields a `{light,dark}` pair). Annotations = declared in the manifest,
+drawn by the harness as a pre-capture DOM overlay — never hand-edited.
 
-The demo datasets download 15 MB–1.2 GB and depend on network access and
-upstream availability — fatal for reproducible, offline-capable capture.
-The built-in **Synthetic Dataset** generator (🏭 in the importer) makes
-fake `image` / `audio` / `video` media on the fly with no download. With
-a fixed size and seed it produces stable content, so the same items
-appear in the same order on every run. **All scriptable shots use the
-synthetic fixture.** (A couple of shots that must show the *demo picker
-itself* — e.g. for `demos.md` — screenshot the picker UI, not a
-downloaded dataset, so they stay offline too.)
-
-## Architecture
-
-Three pieces, all checked in:
+**Fixture = the synthetic dataset.** The built-in Synthetic Dataset generator
+(🏭) makes fake image/audio/video media with no download; a fixed size + seed
+gives stable, ordered content, so all scriptable shots use it (offline,
+reproducible). A couple of shots that must show the *demo picker itself*
+screenshot the picker UI, not a downloaded dataset.
 
 ### 1. The manifest — single source of truth
 
-`docs/user/screenshots.manifest.ts` (TS so the Playwright harness imports
-it directly; no second parser). One entry per **logical** shot. Themes
-expand automatically, so an entry with `themes: ["light","dark"]`
-produces two files.
+`docs/user/screenshots.manifest.ts` (TS so the harness imports it directly). One
+entry per **logical** shot; `themes: ["light","dark"]` expands to two files.
+Output path is derived (`docs/user/assets/<id>.<theme>.png`), not stored, so the
+manifest can't drift from the filesystem. `embeddedIn` records the doc + anchor
+each shot belongs to, so the wiring check can prove docs and manifest agree.
 
 ```ts
 interface Shot {
@@ -80,174 +80,60 @@ interface Shot {
 }
 
 interface Annotation {
-  target: string | { x:number; y:number; w:number; h:number }; // selector or box
+  target: string | { x:number; y:number; w:number; h:number };
   kind: "box" | "arrow" | "highlight";
-  label?: string;              // text rendered next to the callout
+  label?: string;
 }
 ```
 
-Output path is derived, not stored:
-`docs/user/assets/<id>.<theme>.png`. That keeps the manifest from
-drifting from the filesystem (the path is a pure function of `id` +
-`theme`).
-
-**The manifest is also the shot list and the doc-wiring map.** `embeddedIn`
-records which doc + anchor each shot belongs to, so the wiring check
-(below) can prove docs and manifest agree.
-
 ### 2. The harness — `scripts/screenshots/capture.ts`
 
-Reads the manifest and, for each shot × theme:
+For each shot × theme: boot the app once (synthetic-dataset fixture), set
+deterministic knobs, run the recipe, apply the theme, inject declarative
+annotations as an absolutely-positioned DOM overlay computed from each `target`'s
+bounding rect, then capture (`clip` element if given, else viewport) → PNG.
 
-1. Boots the app once (`python app.py --local`) against a temp data dir.
-2. Sets deterministic knobs (see below).
-3. Runs the recipe (synthetic-dataset import, votes, navigation…).
-4. Applies the theme.
-5. Injects declarative annotations as an absolutely-positioned DOM
-   overlay (boxes/arrows/labels) computed from each `target`'s bounding
-   rect — so callouts track the real element and survive layout changes.
-6. Captures (`clip` element if given, else viewport) → writes PNG.
+**Determinism knobs (non-negotiable):** synthetic dataset (fixed size + seed);
+viewport **1440 × 900**, `deviceScaleFactor: 2`; animations/transitions disabled
+(`* { transition:none !important; animation:none !important; }`); mask volatile
+text (app version — a git timestamp — and any wall-clock/elapsed/gauge text);
+stub randomness the UI exposes (never rely on unseeded draws).
 
-**Determinism knobs (non-negotiable for stable diffs):**
+### 3. Driver scripts — `scripts/screenshots/`
 
-- Synthetic dataset, fixed size + seed.
-- Fixed viewport: **1440 × 900**, `deviceScaleFactor: 2`.
-- **Animations/transitions disabled** (inject `* { transition:none !important; animation:none !important; }`).
-- Mask volatile text: app version (`vtsearch.__version__` is a git
-  timestamp — see CLAUDE.md Versioning) and any wall-clock/elapsed text.
-- Stub randomness where the UI exposes it; never rely on unseeded draws
-  (mirrors the test-suite seeding rule in CLAUDE.md).
+- `refresh.sh` — regenerate **every** PNG from the manifest in place; then
+  `git diff --stat docs/user/assets/` is the precise list of shots the GUI
+  change moved. The everyday refresh.
+- `check.sh` — re-render to a temp dir and **pixel-diff** against baselines;
+  exits non-zero on drift. Manual pre-release chore (VTSearch has no CI, no
+  chromium in the test container); intentionally *not* in `run-tests.sh`.
+- `wiring-check.py` — browser-free, **wired into `run-tests.sh`**: asserts every
+  manifest `id` has both theme files on disk, every embed in the three docs has
+  a matching manifest entry, and every reshoot-queue id is a real manifest id.
 
-### 3. The driver scripts — `scripts/screenshots/`
-
-- `refresh.sh` — regenerate **every** PNG from the manifest, in place.
-  After it runs, `git diff --stat docs/user/assets/` is the precise list
-  of shots the GUI change moved. This is the everyday refresh.
-- `check.sh` — re-render to a temp dir and **pixel-diff** against the
-  committed baselines; exits non-zero on drift. Flags staleness. Since
-  VTSearch has **no CI** (CLAUDE.md: `run-tests.sh` is the only gate),
-  this stays a **manual pre-release / periodic chore**, not an automated
-  gate. It is intentionally *not* wired into `run-tests.sh` (no chromium
-  in the standard test container).
-- `wiring-check` (small Python or node script, fast, **can** join
-  `run-tests.sh`): asserts (a) every manifest `id` has both theme files
-  on disk, and (b) every `![](…/user/assets/…)` link in the three docs
-  has a matching manifest entry. This catches docs/manifest drift without
-  needing a browser, so it's cheap to gate.
-
-## Refresh workflow (the answer to "when the GUI changes")
+## Refresh workflow (when the GUI changes)
 
 1. GUI changes land.
-2. Someone (or Claude, in a browser-ready session) runs
-   `scripts/screenshots/refresh.sh`.
-3. `git diff docs/user/assets/` shows exactly which shots moved; review
-   them like any diff.
-4. Commit the regenerated PNGs alongside the GUI change (or in a
-   follow-up). Done — no manual re-shooting, no re-annotating.
-
-`check.sh` is the optional tripwire run before a release to catch shots
-that *should* have been refreshed but weren't.
+2. In a browser-ready session, run `scripts/screenshots/refresh.sh`.
+3. `git diff docs/user/assets/` shows exactly which shots moved; review like any
+   diff.
+4. Commit the regenerated PNGs. `check.sh` is the optional pre-release tripwire.
 
 ### The reshoot queue (for no-browser sessions)
 
-The everyday refresh above assumes a browser. The standard cloud container
-has none (CLAUDE.md → "No Chrome/Chromium available"), so a session that
-changes the GUI usually *can't* run `refresh.sh` itself. To keep that drift
-from going silently unrecorded, such a session records the affected shot
-id(s) in **`docs/user/screenshots-reshoot-queue.md`** — a tracked list of
-known-stale shots. `wiring-check.py` validates that every queued id is a real
-manifest id (invariant (c)), so the queue can't reference a renamed or
-deleted shot. A later browser-capable session **drains** the queue: run
-`refresh.sh`, commit the regenerated PNGs, and delete the drained rows
-(empty queue = no known-stale shots). CLAUDE.md → "Screenshot reshoots"
-points contributors here.
-
-## Shot list (v1)
-
-All in **light + dark** (so ~2× the files). `*` = carries declarative
-annotations. README reuses guide shots rather than adding new ones. The
-"Doc · section" column points at the live USER_GUIDE.md headings so the
-`embeddedIn` manifest field can be filled in verbatim.
-
-| id | Doc · section | What it shows | Annotated |
-|----|---------------|---------------|-----------|
-| `dashboard-loaded` | USER_GUIDE intro; README hero | Dashboard populated with a synthetic dataset row + a trained-detector row (clean overview, no selection) | |
-| `dataset-panel` | Loading a dataset | The hamburger (☰) menu open, showing the demo-dataset list and the "import your own" options | `*` (point at ☰) |
-| `importer-picker` | Loading a dataset; demos.md | The importer list including 🏭 Synthetic Dataset + the demo entries | `*` |
-| `importer-form` | Loading a dataset | A filled Synthetic-Dataset importer form (media type + size) | |
-| `three-panel` | The three-panel layout | The full labeling layout with left / centre / right panels labeled | `*` (label each panel) |
-| `autopilot-vote` | Autopilot | An item in the centre viewer with the green **Good** / red **Bad** buttons, Autopilot phase 1 active | `*` (circle Good/Bad) |
-| `autopilot-progress` | Autopilot · "The collapsed bar" | The four phase indicators (phase 3 active) with the **smart** / **stable** status lights | `*` (the indicators) |
-| `manual-controls` | Manual mode | The three Manual-mode control rows — Sort mode, Selection strategy, Inclusion slider — above the media list | `*` (label the three rows) |
-| `region-voting` | Region voting on images | An image with a drawn region rectangle (8 resize handles), ready to submit a good vote | `*` (the region) |
-| `view-options` | View options | The View-settings modal open (list/grid, grid icon size, focus mode) | |
-| `results-grid` | View options | The left-panel media list in **grid** view after training (sorted thumbnails) | |
-| `settings-appearance` | View options · "Solo media type" / "Locking the embedder" | The Settings → **Appearance** pane: Solo media type, Solo media embedder, and the theme picker — also anchors the light/dark contrast | |
-| `dashboard-manage` | Dashboard | A dataset row **and** a detector row selected, with the **Train** / **Find** action bar below the tables | `*` (Train/Find) |
-| `browse-view` | Browse | The Browse map: a pannable hex-density UMAP of a synthetic image dataset, a hovered-tile preview popup, plus the legend + minimap on the right | `*` (preview + legend) |
-| `export-picker` | Exporting your work | The exporter picker with a chosen exporter's form below it | `*` |
-| `import-detector` | Importing pre-trained detectors | The import-detector picker (Load sort mode / Detectors dashboard) | |
-
-**16 logical shots × 2 themes = 32 PNGs.** README embeds
-`dashboard-loaded` (and optionally `results-grid`); demos.md embeds
-`importer-picker`.
-
-## Shot list (v2 — 2026-06-28)
-
-The list above is the original v1 (shipped 2026-06-10). After ~170 frontend
-commits the [2026-06-28 documentation audit](docs-audit-2026-06-28.md) retook 7
-drifted shots and added 4 new ones, taking the manifest to **20 logical shots ×
-2 themes = 40 PNGs**. The v1 rows still name every original shot; the deltas:
-
-**New shots (Part B) — 4 added to `screenshots.manifest.ts`:**
-
-| id | Doc · section | What it shows | Annotated |
-|----|---------------|---------------|-----------|
-| `new-detector` | Creating a detector | The **New Detector** modal on the Blank tab: Media Type, a seeded Text Example, the media-example drop zone, and the embedder-type picker | |
-| `find-view` | Find · scoring and verifying | The Find **three-pane verification view**: work queue (left), viewer with Good/Bad (centre), Verified Good / Verified Bad piles + actions (right) | |
-| `find-stats` | Find · scoring and verifying | The Find view's **Detector Stats** modal (clipped): counts, confusion matrix, false-pos/neg vs. inclusion curve | |
-| `achievements` | Achievements | The **Achievements** panel: total score + tiered milestones (Bronze/Silver/Gold/Platinum) with next-tier progress | |
-
-**Retake description corrections (v1 rows whose UI moved):**
-
-- `view-options` — *not* a modal; it's the inline `vt-view-controls` toolbar
-  (thumbnail size + focus mode). The list/grid toggle was removed; the shot is a
-  `clip` of that toolbar.
-- `settings-appearance` — the Appearance pane no longer hosts **Solo media
-  type** (it moved to the Import Defaults tab); the shot shows theme + the
-  animation/metadata/achievements toggles + per-type Scroll Style.
-- `importer-picker` — now drills into the **Downloaded Media catalogue** (media-
-  type selector + readiness-badge table), not the bare Demo landing.
-- `browse-view` — captured with **hex bins + two zoom-outs** (no hover popup;
-  `Zoom to fit` over-zooms 60 points to blank), plus legend + minimap.
-- `dashboard-manage` — annotation is a `box` (not `highlight`) so the open `⋯`
-  overflow menu, where Browse/Stats/Rename now live, stays visible.
-- `autopilot-progress` — caption now names the real phases (Find Initial Goods,
-  Find Initial Bads, Refine Boundary, Explore Diversity).
-
-Captured against a live GRID-hosted app over an SSH tunnel (browser local,
-embedders remote). The optional `browse-bin-popup` was not added — it has no
-USER_GUIDE anchor.
-
-**Determinism-risk shots (candidates for hand-capture fallback).** Two
-shots resist clean scripting:
-
-- `region-voting` — drawing the region is a canvas drag; if it can't be
-  driven deterministically, hand-capture this one.
-- `browse-view` — the UMAP layout must be seeded *and* the hover-preview
-  popup posed; the projection is also expensive to build. Seed the UMAP
-  (fixed `random_state`) and disable animations before relying on
-  pixel-diff for this shot; otherwise hand-capture it.
-
-Both are the only shots that touch a `<canvas>`; the rest are DOM and
-should diff cleanly.
+The standard cloud container has no chromium, so a session that changes the GUI
+usually can't run `refresh.sh`. It instead records the affected shot id(s) in
+**`docs/user/screenshots-reshoot-queue.md`** — a tracked list of known-stale
+shots. `wiring-check.py` validates every queued id is a real manifest id, so the
+queue can't reference a renamed/deleted shot. A later browser-capable session
+**drains** it: run `refresh.sh`, commit the PNGs, delete the drained rows.
+CLAUDE.md → "Screenshot reshoots" points contributors here.
 
 ## Doc-embedding convention (locked 2026-06-07)
 
-One image is shown, always matching the **viewer's** theme — never both
-side by side. The embed is a `<picture>` whose default `<img>` is the
-light variant and whose `<source media="(prefers-color-scheme: dark)">`
-is the dark variant:
+One image is shown, always matching the **viewer's** theme. The embed is a
+`<picture>` whose default `<img>` is light and whose
+`<source media="(prefers-color-scheme: dark)">` is dark:
 
 ```html
 <picture>
@@ -256,170 +142,75 @@ is the dark variant:
 </picture>
 ```
 
-This one form covers both render targets:
+- **GitHub / GitLab:** the platform picks the variant via `prefers-color-scheme`.
+- **In-app Help panel:** it does *not* rely on `prefers-color-scheme` (the app
+  theme is a `data-theme` attribute). `keyboard-help-modal.component.ts`
+  post-processes the rendered HTML — collapses each `<picture>` to its `<img>`,
+  swaps the `*.light.*` / `*.dark.*` suffix to the app's current effective theme,
+  resolves the relative `assets/…` path against the served dir (`/assets/docs/`),
+  and re-renders live on theme switch.
 
-- **GitHub / GitLab:** the `<picture>` element makes the platform pick the
-  variant matching the reader's site appearance via `prefers-color-scheme`.
-- **In-app Help panel:** the panel renders the same markdown but does *not*
-  rely on `prefers-color-scheme` (the app theme is a `data-theme`
-  attribute set by `ThemeService`, which can differ from the OS). Instead
-  `keyboard-help-modal.component.ts` post-processes the rendered HTML:
-  collapses each `<picture>` to its `<img>`, swaps the `*.light.*` /
-  `*.dark.*` suffix to the app's current *effective* theme (light → light,
-  dark/high-viz → dark), resolves the relative `assets/…` path against the
-  guide's served dir (`/assets/docs/`), and re-renders live when the user
-  switches themes.
+Images are served by an `angular.json` asset glob copying `docs/user/assets/**`
+→ `/assets/docs/assets`. Each embed carries alt text (= the manifest `caption`).
 
-Image files are served to the app by an `angular.json` asset glob copying
-`docs/user/assets/**` → `/assets/docs/assets`. Each embed carries
-descriptive alt text (= the manifest `caption`) for accessibility.
+## Shot list
 
-## Build order
+**v1 (16 shots, shipped 2026-06-10)** — README reuses guide shots; `*` = annotated:
 
-1. **This plan** (done) — design + locked decisions.
-2. Manifest schema + 3–4 seed entries (`dashboard-loaded`,
-   `importer-picker`, `autopilot-vote`).
-3. Harness `capture.ts` + determinism knobs; prove it on the seed
-   entries in a browser-ready session.
-4. `refresh.sh` / `check.sh` / `wiring-check`; wire `wiring-check` into
-   `run-tests.sh`.
-5. Fill out the full shot list. *(Locked: see "Shot list (v1)" — 16
-   shots, audited 2026-06-09. The USER_GUIDE.md anchors each shot embeds
-   into already exist.)*
-6. Embed in USER_GUIDE.md, then README.md + demos.md.
+| id | Doc · section | What it shows | Annotated |
+|----|---------------|---------------|-----------|
+| `dashboard-loaded` | USER_GUIDE intro; README hero | Dashboard with a synthetic dataset row + trained-detector row (clean, no selection) | |
+| `dataset-panel` | Loading a dataset | The ☰ menu open, demo-dataset list + "import your own" | `*` |
+| `importer-picker` | Loading a dataset; demos.md | The importer list incl. 🏭 Synthetic + demo entries | `*` |
+| `importer-form` | Loading a dataset | A filled Synthetic-Dataset importer form | |
+| `three-panel` | The three-panel layout | Full labeling layout, left/centre/right labeled | `*` |
+| `autopilot-vote` | Autopilot | Centre viewer with Good/Bad, Autopilot phase 1 | `*` |
+| `autopilot-progress` | Autopilot | The four phase indicators (phase 3) + status lights | `*` |
+| `manual-controls` | Manual mode | Sort mode / Selection strategy / Inclusion rows | `*` |
+| `region-voting` | Region voting on images | An image with a drawn region rectangle (8 handles) | `*` |
+| `view-options` | View options | The inline view toolbar (thumbnail size + focus mode) | |
+| `results-grid` | View options | The left-panel media list (grid) after training | |
+| `settings-appearance` | View options | The Settings → Appearance pane (theme + toggles + scroll style) | |
+| `dashboard-manage` | Dashboard | Dataset + detector row selected, Train/Find bar | `*` |
+| `browse-view` | Browse | The Browse hex-density map + legend + minimap | `*` |
+| `export-picker` | Exporting your work | The exporter picker with a chosen exporter's form | `*` |
+| `import-detector` | Importing pre-trained detectors | The import-detector picker | |
+
+**v2 deltas (2026-06-28 audit)** — 4 new + 7 retake corrections:
+
+- **New:** `new-detector` (Blank tab), `find-view` (three-pane verification),
+  `find-stats` ("Detector Stats" modal, clipped), `achievements` (tiered panel).
+- **Retakes:** `view-options` is the inline `vt-view-controls` toolbar, not a
+  modal (list/grid toggle removed); `settings-appearance` no longer hosts Solo
+  media type (moved to Import Defaults); `importer-picker` drills into the
+  Downloaded Media catalogue; `browse-view` uses hex bins + two zoom-outs (no
+  hover popup); `dashboard-manage` annotation is a `box` so the open `⋯` menu
+  stays visible; `autopilot-progress` caption names the real phases.
+- Optional `browse-bin-popup` was **not** added (no USER_GUIDE anchor).
+
+**Determinism-risk shots:** `region-voting` (canvas drag) and `browse-view`
+(seeded, expensive UMAP + posed popup) are the only `<canvas>` shots — seed +
+disable animations, or hand-capture. The rest are DOM and diff cleanly.
 
 ## What shipped
 
-- **In-app theme-matched embeds (2026-06-07).** The Help panel's user
-  guide renders embedded screenshots, showing the single variant that
-  matches the viewer's current app theme and swapping live on theme
-  change. Touched: `frontend/.../keyboard-help-modal.component.ts` (image
-  post-processing + theme subscription), its `.scss` (image styling),
-  `angular.json` (asset glob for `docs/user/assets/**`), and the
-  `<picture>` embed convention above. A seed pair
-  (`dashboard-loaded.{light,dark}.png`, placeholder art) proves the
-  pipeline end to end.
-- **Shot-list audit + Browse docs (2026-06-09).** Re-checked the shot
-  list against the live UI: repurposed `settings-modal` →
-  `settings-appearance`, added `manual-controls` and `browse-view`, and
-  sharpened descriptions to real control names. The Browse mode was
-  undocumented, so a new **"Browse - exploring a dataset spatially"**
-  section was added to `docs/user/USER_GUIDE.md` (plus a Browse-button
-  mention in the Dashboard section) to give `browse-view` a home. No
-  pixels were captured (no browser this session); the manifest + harness
-  are still owed — see the Capture prompt below.
-
-## What shipped (2026-06-10) — the capture harness
-
-- **Manifest** `docs/user/screenshots.manifest.ts` — all 16 shots, each with
-  `embeddedIn` / `caption` / `themes` / optional `clip` + `annotations`, and a
-  `recipe(page, h)` (functions, not a step array, because region-voting needs a
-  real canvas drag and several shots wait on embedding/projection).
-- **Harness** `scripts/screenshots/capture.ts` (tsx) — determinism knobs
-  (1440×900 @2×, `colorScheme` per theme, animations off via init-script,
-  `data-theme` forced pre-capture, volatile-text masking for dates + the RAM
-  gauge), declarative-annotation overlay, per-shot error isolation, RAM logging.
-- **Fixtures** `scripts/screenshots/ensure-fixtures.mjs` (idempotent) — drives
-  the UI to create `syn-imgs` (60 imgs, SigLIP), a trained throwaway detector
-  `doc-demo` (5 good / 4 bad), and `syn-patch` (24 imgs, DINOv2-patch) for
-  region voting. `refresh.sh` runs it before capturing.
-- **Drivers** `refresh.sh` (regenerate all), `check.sh` (render-to-temp +
-  pixel-diff, manual chore), `wiring-check.py` (docs⇄manifest, no browser —
-  **wired into `run-tests.sh`** after the Dockerfile check).
-- **Embeds** — `<picture>` blocks added at all 16 `embeddedIn` anchors in
-  USER_GUIDE.md, the `dashboard-loaded` hero in README.md, and `importer-picker`
-  in demos.md (placeholder pair replaced).
-- **RAM-safe on the dev box.** The harness drives a *single* running app (it
-  does not boot its own per run): a second instance would load the image
-  embedder twice and OOM the ~3.7 GB box. Determinism still holds via the
-  synthetic generator's fixed seed. Captured with a RAM watchdog armed; free
-  RAM never dropped below ~436 MB (DINOv2 load), well clear of OOM.
-- **Doc/UI drift fixed.** USER_GUIDE.md and demos.md said "click the hamburger
-  menu (☰)" to load a dataset, but the live UI loads datasets via the **+**
-  button → **Add Dataset** dialog (Services/Files/Demo tabs); the hamburger is
-  just Dashboard/Help/Settings. Corrected the prose to match the captured shots.
-
-## Open follow-ups
-
-- ~~**Real screenshots.**~~ Done 2026-06-10 — all 16 shots captured in both
-  themes and embedded.
-- ~~**chromium provisioning.**~~ Done — Playwright + chromium installed under
-  `scripts/screenshots/` (kept out of `run-tests.sh`; only the browser-free
-  `wiring-check.py` is gated).
-- **Self-booting / temp-data-dir determinism.** The harness currently drives an
-  already-running app against the real `data/` dir (RAM-driven choice). The
-  plan's original intent was a temp data dir per run. Revisit if pixel-diff
-  drift from shared state becomes a problem; the synthetic seed already covers
-  content stability.
-- **Masking gaps.** Dates and the RAM gauge are masked; the **disk gauge** text
-  ("1.9 GB free of 26.6 GB") is split across nodes and slips through — extend
-  `maskVolatile` before relying on `check.sh` pixel-diffs.
-- **Annotation polish.** The declarative `highlight` overlay dims the whole
-  viewport (including modals); a couple of boxes (`importer-subtab-bar`) sit a
-  few px low. Cosmetic; tune the overlay geometry.
-- **autopilot-progress phase.** Captured with phase 3 (Refine Boundary) active
-  thanks to the 9-vote `doc-demo` fixture; if the fixture vote count changes,
-  the active phase in this shot moves with it.
-- ~~**Markdown embed form** for dual-theme images.~~ Resolved
-  2026-06-07: `<picture>` + `prefers-color-scheme` (see "Doc-embedding
-  convention").
-- **`region-voting` scriptability** — confirm the canvas drag can be
-  driven deterministically; fall back to hand-capture only if not.
-- **`browse-view` determinism** — seed the UMAP fit (fixed
-  `random_state`) so the layout is stable across runs, and pose the
-  hover-preview popup; otherwise hand-capture. The projection is also
-  expensive to build, so the recipe should reuse a cached fixture
-  projection rather than rebuilding per run.
-- **Pixel-diff tolerance** for `check.sh` (font hinting / AA can cause
-  sub-pixel noise across machines; may need a small per-pixel threshold).
-
-## Capture prompt (paste this in a browser-ready session)
-
-The screenshots cannot be taken in the standard cloud container (no
-chromium — CLAUDE.md "No Chrome/Chromium available"). When you are in a
-session with a real browser, paste the prompt below. It builds the
-still-missing pieces (manifest + Playwright harness + driver scripts),
-captures the shot list above in both themes, wires the embeds, and runs
-the checks.
-
-> Build and run the user-docs screenshot harness described in
-> `docs/plans/user-docs-screenshots.md`. Specifically:
->
-> 1. **Provision the browser.** Install Playwright + chromium in this
->    session (do **not** add it to `run-tests.sh` or the default test
->    container).
-> 2. **Create the manifest** `docs/user/screenshots.manifest.ts` using the
->    `Shot` / `Annotation` schema in the plan, with one entry per row of
->    the plan's "Shot list (v1)" table (all 16, `themes: ["light","dark"]`,
->    `embeddedIn` set to the listed USER_GUIDE.md heading anchor,
->    `caption` = the alt text, `annotations` for the rows marked `*`).
-> 3. **Build the harness** `scripts/screenshots/capture.ts` per the plan's
->    "The harness" section: boot `python app.py --local` against a temp
->    data dir, apply the determinism knobs (synthetic dataset with a fixed
->    size + seed; viewport 1440×900 @2×; `* { transition:none !important;
->    animation:none !important; }`; mask the app version and any
->    wall-clock text; **seed the UMAP `random_state`** for `browse-view`),
->    run each shot's recipe, apply the theme, inject declarative
->    annotations as a pre-capture DOM overlay, then write
->    `docs/user/assets/<id>.<theme>.png`.
-> 4. **Add the driver scripts** `scripts/screenshots/refresh.sh`,
->    `check.sh`, and a `wiring-check` (assert every manifest `id` has both
->    theme files on disk and every `![]`/`<picture>` embed in
->    USER_GUIDE.md + README.md + demos.md has a matching manifest entry).
->    Wire only `wiring-check` into `run-tests.sh` (it needs no browser).
-> 5. **Capture** every shot in light + dark by running `refresh.sh`. The
->    fixtures: a synthetic **image** dataset (with a `_patch` embedder for
->    `region-voting`) for the visual shots, plus a small trained detector
->    for `dashboard-loaded` / `results-grid` / `dashboard-manage`. For
->    `region-voting` and `browse-view`, if the canvas interaction won't
->    drive deterministically, hand-capture those two and note it.
-> 6. **Wire the embeds.** Replace the placeholder `dashboard-loaded` pair,
->    add the `<picture>` embeds (per the plan's "Doc-embedding
->    convention") at each `embeddedIn` anchor in USER_GUIDE.md, add the
->    `dashboard-loaded` hero to README.md, and add `importer-picker` to
->    demos.md.
-> 7. Run `./run-tests.sh` (so `wiring-check` passes), then commit the PNGs
->    + scripts + embeds together and open a PR targeting `dev`.
->
-> Review the generated PNGs like any diff before committing; `git diff
-> --stat docs/user/assets/` is the list of shots the run produced.
+- **In-app theme-matched embeds (2026-06-07).** Help-panel image
+  post-processing + theme subscription in `keyboard-help-modal.component.ts` (+
+  `.scss`), `angular.json` asset glob, and the `<picture>` convention.
+- **Shot-list audit + Browse docs (2026-06-09).** Repurposed `settings-modal` →
+  `settings-appearance`, added `manual-controls` + `browse-view`, wrote a new
+  Browse section in `USER_GUIDE.md` to home `browse-view`.
+- **Capture harness (2026-06-10).** Manifest (all 16, functions-not-steps
+  recipes), `capture.ts` (determinism knobs, annotation overlay, per-shot error
+  isolation, RAM logging), `ensure-fixtures.mjs` (`syn-imgs` 60 SigLIP imgs +
+  `doc-demo` 5g/4b detector + `syn-patch` 24 DINOv2-patch imgs), `refresh.sh` /
+  `check.sh` / `wiring-check.py` (gated). `<picture>` blocks at all 16 anchors +
+  the README hero + demos.md. RAM-safe: drives a *single* running app; free RAM
+  never dropped below ~436 MB. Also fixed doc/UI drift (datasets load via the
+  **+** button, not the ☰ hamburger).
+- **2026-06-28 capture run.** Captured against a live GRID app over an SSH tunnel
+  (browser local, embedders remote), RAM-safe on a ~3.7 GB laptop. 7 Part A
+  retakes + 4 Part B new shots (`new-detector`, `find-view`, `find-stats`,
+  `achievements`) — manifest entries + recipes added and embedded at their
+  USER_GUIDE anchors (placeholders gone). Browse PNGs 256-colour quantised to
+  stay under the 500 KB large-file cap.

--- a/docs/plans/visual-genome-dataset.md
+++ b/docs/plans/visual-genome-dataset.md
@@ -1,156 +1,8 @@
 # Visual Genome demo dataset (multi-label + region annotations)
 
-Status: **Phase 1 in progress.** Adds the Visual Genome (VG) dataset as a demo
-dataset for hands-on browsing *and* automated eval, introducing two new
-capabilities the existing demo datasets don't have: per-image **multi-label**
-ground truth and stored **bounding-box region** annotations.
+**Status: Phase 1 (multi-label eval + VG ingestion) and Phase 2 (region voting in evals) shipped.** Region-vote eval reporting, richer vocab matching, and attributes/relationships remain open (see Open follow-ups).
 
-## Why VG is different
-
-Every existing demo dataset is **single-label and pretend-disjoint**: each media
-carries exactly one `media["category"]` string, and the eval harness
-(`vtscore/eval/runner.py`, `vtscore/eval/voting_iterations.py`) treats
-"category == target" as positive and *everything else* as negative.
-
-VG annotations don't fit that model:
-
-1. **Multi-label.** `img123 = "man eating an apple"` puts the image in `man`
-   **and** `apple` simultaneously, and (because nobody annotated a banana)
-   implicitly *not* in `banana`. Inclusive category lists become per-image
-   booleans.
-2. **Bounding boxes.** Every annotated object carries a pixel box. We want to
-   keep those for future **region voting** / region-level evals rather than
-   throwing them away.
-
-## Decisions (locked)
-
-These were chosen explicitly with the user:
-
-- **Negatives — closed-world.** Membership is strictly binary: a category is
-  either in an image's annotated object set (**positive, +1**) or it isn't
-  (**negative, −1**). There is no third "unknown" value — if one of our
-  categories is not among an image's annotated objects, the image counts as a
-  negative for it, full stop. We accept that VG's incompleteness turns a few
-  real-but-unannotated objects (the unlooked-for banana) into false negatives —
-  the same accidental-overlap noise the existing datasets already tolerate. So a
-  VG image just needs a **set of positive categories**; everything outside that
-  set is negative.
-- **Scope — additive, VG-only.** Existing single-label datasets are left exactly
-  as they are. The eval positive/negative test branches: if a media carries a
-  `categories` list it uses set membership, otherwise it falls back to the
-  legacy `category ==` string compare. No migration of the other demos.
-- **Regions — store-only.** Ground-truth boxes are persisted on the media dict
-  (in the dataset pickle, the one place derived per-item data is allowed) as
-  `media["regions"]`. **No consumer is built in this phase** — this is raw
-  material for the existing region-voting plumbing
-  (`LabeledElement.region_box`, `DetectorContext.vote_region_boxes`, and
-  `docs/plans/patch-embedder.md`) to draw on later.
-- **Categories — top-100 by frequency.** The vocabulary is the 100 most frequent
-  VG object names (the well-known VG scene-graph object vocab), kept as one
-  **static hardcoded list** (`VISUAL_GENOME_CATEGORIES`) — *not* recomputed from
-  each slice's frequencies. All four `visual_genome_{s,m,l,a}` variants share
-  that exact same list, so the category space is identical across slices; only
-  which images fall in the slice changes. A category with zero images in a small
-  slice is still one of the 100 (its queries just have no positives there). The
-  hardcoded list also lets the UI show categories before the (large) download.
-  Object→category matching normalizes case/whitespace and folds simple plurals.
-
-## Data model (the additive bits)
-
-A VG image's media dict gains two keys on top of the usual image media fields:
-
-```python
-media["categories"] = ["man", "apple"]          # positive categories (⊆ the 100)
-media["category"]    = "man"                      # primary = first positive, kept
-                                                  #   so legacy readers (UI filter,
-                                                  #   label export) still work
-media["regions"] = [                              # store-only ground-truth boxes
-    {"box": [0.12, 0.30, 0.44, 0.88], "label": "man"},    # normalized x0,y0,x1,y1
-    {"box": [0.40, 0.55, 0.52, 0.69], "label": "apple"},
-]
-```
-
-`categories` and `regions` live only in RAM and the dataset pickle — never in
-detector JSON or settings (consistent with the "No Persisted Vectors or MLPs"
-rule, whose single exception is the dataset pickle snapshot).
-
-## Eval semantics
-
-`media_is_positive(media, category)` (new, `vtscore/eval/labels.py`) is the one
-place that decides membership:
-
-```python
-cats = media.get("categories")
-if cats is not None:          # VG-style multi-label
-    return category in cats
-return media.get("category") == category   # legacy single-label
-```
-
-Closed-world means **negative = not positive**, so the four eval selection sites
-(text-sort relevant set, learned-sort target/other split, voting-iterations vote
-sequence and test scoring) all route through this helper. Existing datasets have
-no `categories` key, so their behavior is byte-for-byte unchanged.
-
-## Ingestion path
-
-Mirrors the existing image demo-source machinery
-(`vtscore/media/image/_demo_sources.py`):
-
-- `download_visual_genome()` (`vtscore/datasets/downloader/images.py`) fetches
-  the two VG image zips + `objects.json` into `data/visual_genome/`.
-- `_collect_visual_genome_files()` parses `objects.json`, maps each object name
-  to the vocab, and yields per-image `(path, positive_categories, pixel_regions)`
-  for images with ≥1 in-vocab object. VG is **not** folder-per-class, so slicing
-  is a flat fractional slice over the image list (sorted by image id) for the
-  S/M/L/A variants — not the per-category slice the other sources use.
-- `_embed_vg_images()` embeds each image and stamps `categories` + normalized
-  `regions` (pixel boxes ÷ image dims, clamped to [0,1]).
-
-## What shipped
-
-Phase 1:
-
-- **Multi-label eval.** `vtscore/eval/labels.py::media_is_positive` routes the
-  four eval selection sites (text-sort relevant set, learned-sort target/other
-  split, voting-iterations vote sequence + test scoring). Datasets with a
-  `categories` list use set membership; everything else is unchanged.
-- **VG ingestion.** `download_visual_genome()` (two image zips + objects.json),
-  `_collect_visual_genome_files()` (objects.json → per-image positives + pixel
-  regions, flat-sliced), `_embed_vg_images()` (stamps `categories` + normalized
-  store-only `regions`), and `visual_genome_{s,m,l,a}` demo datasets.
-- **Vocab.** `VISUAL_GENOME_CATEGORIES` (top-100 VG object names) +
-  `_vg_category_for()` case/plural-folding matcher.
-- **Eval registration.** `_VISUAL_GENOME_QUERIES` + `visual_genome_{s,m}`
-  entries in `EVAL_DATASETS`.
-- **Tests.** `tests_lib/downloads/test_visual_genome_download.py` (fixture-based
-  download/collect/load + region normalization) and multi-label eval tests in
-  `tests_lib/detectors/test_eval.py`.
-
-## Phase 2 — Region voting in evals (shipped)
-
-The stored ground-truth boxes now feed the eval harness as simulated region
-votes. `vtscore/eval/labels.py::region_box_for_category(media, category)`
-returns the **minimal box covering every annotated instance** of the category
-(multiple apples → one box around all of them; `None` when the image has no
-annotated box, so callers fall back to the whole-image vector — exactly an
-image-level Good vote). Both simulated-voting evaluators take a `region_voting`
-flag:
-
-- **Voting-iterations** (`vtscore/eval/voting_iterations.py`): each Good vote
-  region-pools its box from the media's `patch_grid` via
-  `pool_box_from_media` / `box_to_vote_vector`. Bad votes always stay
-  whole-image (matching the live detector, where only Yes-votes carry a
-  region). Scoring is **independent** of the flag — any patch dataset (media
-  with `patch_regions`) is scored region-aware (max-pool over regions) the same
-  way the live detector scores it, so the only variable `region_voting` toggles
-  is the Good-vote training vector, isolating its effect.
-- **Learned-sort** (`vtscore/eval/runner.py::eval_learned_sort`): passes the
-  per-Good `vote_region_boxes` map straight to `train_and_score`, which already
-  region-pools and region-max-pool-scores.
-- **CLI**: `python -m vtscore.eval --embedder dinov3_patch --region-voting`.
-  Region voting needs a **patch embedder** (DINOv2/v3/EUPE) — SigLIP, the
-  default VG embedder, produces no `patch_grid`, so `--embedder` re-embeds VG
-  in a patch space. No embedder is hardcoded; any patch embedder works.
+VG is the first demo dataset with per-image **multi-label** ground truth (an image is in `man` **and** `apple` at once) and stored **bounding-box region** annotations. Every other demo dataset is single-label and pretend-disjoint (`category == target` is positive, everything else negative). Membership here is closed-world binary: a category is positive if it's in the image's annotated object set, negative otherwise (VG incompleteness → a few accepted false negatives). The vocabulary is a static hardcoded top-100 VG object list (`VISUAL_GENOME_CATEGORIES`), identical across all `visual_genome_{s,m,l,a}` slices.
 
 ## Open follow-ups
 
@@ -166,3 +18,19 @@ flag:
 - **Real download verification.** The VG archives are ~15 GB; CI exercises the
   ingestion path against small fixtures only. The hardcoded URLs/sizes should be
   smoke-checked against a real download before relying on them.
+
+## What shipped
+
+Phase 1 — multi-label eval + VG ingestion:
+- **Multi-label eval.** `vtscore/eval/labels.py::media_is_positive` — if a media carries a `categories` list, membership is set-based (`category in cats`); else legacy `category ==` compare. Routes the four eval selection sites (text-sort relevant set, learned-sort target/other split, voting-iterations vote sequence + test scoring). Existing datasets byte-for-byte unchanged.
+- **Data model (additive).** VG media gain `media["categories"]` (positive categories ⊆ the 100), keep `media["category"]` (first positive, for legacy readers), and store `media["regions"]` (normalized ground-truth boxes). All live only in RAM + the dataset pickle, never in detector JSON/settings.
+- **VG ingestion.** `download_visual_genome()` (two image zips + objects.json → `data/visual_genome/`), `_collect_visual_genome_files()` (objects.json → per-image positives + pixel regions, flat fractional slice over sorted image ids for S/M/L/A), `_embed_vg_images()` (embeds + stamps `categories` and pixel-÷-dims-clamped `regions`), and the `visual_genome_{s,m,l,a}` demo datasets.
+- **Vocab.** `VISUAL_GENOME_CATEGORIES` (top-100) + `_vg_category_for()` case/plural-folding matcher.
+- **Eval registration.** `_VISUAL_GENOME_QUERIES` + `visual_genome_{s,m}` entries in `EVAL_DATASETS`.
+- **Tests.** `tests_lib/downloads/test_visual_genome_download.py` (fixture download/collect/load + region normalization) and multi-label eval tests in `tests_lib/detectors/test_eval.py`.
+
+Phase 2 — region voting in evals (stored boxes feed the harness as simulated region votes):
+- `vtscore/eval/labels.py::region_box_for_category(media, category)` returns the minimal box covering every annotated instance of the category (`None` → callers fall back to the whole-image vector = an image-level Good vote).
+- **Voting-iterations** (`vtscore/eval/voting_iterations.py`): each Good vote region-pools its box via `pool_box_from_media` / `box_to_vote_vector`; Bad votes stay whole-image (matching the live detector). Scoring is independent of the `region_voting` flag — any patch dataset is scored region-aware regardless — so the flag isolates only the Good-vote training vector.
+- **Learned-sort** (`vtscore/eval/runner.py::eval_learned_sort`): passes the per-Good `vote_region_boxes` map to `train_and_score`, which already region-pools/region-max-pool-scores.
+- **CLI:** `python -m vtscore.eval --embedder dinov3_patch --region-voting`. Region voting needs a patch embedder (DINOv2/v3/EUPE); SigLIP (the default VG embedder) has no `patch_grid`, so `--embedder` re-embeds VG in a patch space. No embedder is hardcoded.

--- a/docs/plans/vtsbrowse-empirical-tuning.md
+++ b/docs/plans/vtsbrowse-empirical-tuning.md
@@ -1,147 +1,33 @@
 # Plan: VTSBrowse empirical tuning pass
 
-> **Status:** Deliverable 1 (knob plumbing + persistence-key correctness fix)
-> **shipped**; the quantitative sweep and qualitative pass remain. This is the
-> deferred *§Open problems → Empirical* work from `docs/plans/vtsbrowse.md`.
-> The remaining steps are written to be picked up on a **stronger environment**
-> (one with a browser for visual judgment, and ideally GPU + real demo datasets
-> downloaded) because the core deliverable — choosing good defaults — requires
-> *looking at the rendered canvas*, which the headless cloud container can't do
-> (no Chrome/Chromium).
->
-> The other VTSBrowse follow-ups (sibling highlighting, text-seeded
-> navigation, detector handoff) have been **cut** — see *§Open follow-ups* in
-> the design doc. Empirical tuning is the remaining v1 polish item.
+**Status:** Deliverable 1 (knob plumbing + persistence-key correctness fix)
+**shipped**. The remaining work is the **quantitative sweep (Phase A)** and the
+**qualitative review (Phase B)** — detailed below. This is the deferred
+*§Open problems → Empirical* work from `docs/plans/vtsbrowse.md`; the other
+VTSBrowse follow-ups (sibling highlighting, text-seeded navigation, detector
+handoff) were **cut**. Empirical tuning is the remaining v1 polish item.
 
-## Goal
+The remaining steps need a **stronger environment** (a browser for visual
+judgment, ideally GPU + real demo datasets) because choosing good defaults
+requires *looking at the rendered canvas*, which the headless cloud container
+can't do (no Chrome/Chromium). Since Deliverable 1 landed, both phases can now
+retune purely by changing two settings (`projection_n_neighbors`,
+`projection_min_dist`).
 
-VTSBrowse shipped with **defensible-but-unvalidated defaults** for the UMAP
-fit, the hex-tile pyramid, and the canvas renderer. The design doc
-(*§Open problems*) deliberately left these as tunable parameters rather than
-baking in constants, on the explicit understanding that good values can only
-be chosen by running the pipeline on real datasets and judging the output.
-
-This pass:
-
-1. Makes the parameters that are currently hardcoded **reachable without
-   editing code** (server settings or build-route params) so a tuning loop
-   doesn't require a recompile per trial.
-2. Runs a **quantitative sweep** (headless, scriptable) over demo datasets ×
-   parameter grid, capturing build cost and layout/aggregation metrics.
-3. Runs a **qualitative review** (browser, requires a display) of the rendered
-   canvas to pick final defaults for the knobs that only a human eye can
-   settle.
-4. Lands the chosen defaults (and any newly-exposed settings) with a short
-   write-up of *why* each value was picked, so the next person doesn't re-open
-   settled questions.
-
-## Why a stronger environment
-
-| Step | Needs a browser? | Needs GPU? | Can do headless here? |
-|------|------------------|-----------|----------------------|
-| Expose knobs as settings/params (impl) | no | no | **yes** |
+| Step | Needs a browser? | Needs GPU? | Headless here? |
+|------|------------------|-----------|----------------|
 | Quantitative sweep harness (impl + run) | no | helps (faster embed) | **yes** (small N) |
 | Visual layout / hex-readability review | **yes** | no | no |
 | Hover-preview feel (debounce, audio loop) | **yes** | no | no |
 | Final default selection + write-up | partly | no | partly |
 
-The impl steps (expose knobs, write the sweep harness) are environment-neutral
-and could even be done first in the cloud container. The *judgment* steps need
-a real display.
-
-## Current defaults and where each knob lives
-
-The knobs, their current values, and their source of truth as of this plan:
-
-### UMAP (Stage 1) — `vtscore/projection/umap_projection.py:fit_projection`
-
-| Knob | Current default | Notes |
-|------|-----------------|-------|
-| `n_neighbors` | `15` | Clamped to `N-1`. **Not plumbed** from the route — see *§Gap*. |
-| `min_dist` | `0.1` | **Not plumbed** from the route. |
-| `min_n_for_umap` | `10` | Below this → PCA-2 fallback. |
-| `random_state` | `None` (unseeded) | Locked decision — keep unseeded in prod. Seed only inside the sweep harness for run-to-run comparability. |
-| `metric` | `"euclidean"` | **Settled** (ingest-normalized vectors); not a tuning target. |
-
-### Pyramid (Stage 2) — `vtscore/projection/pyramid.py:build_pyramid`
-
-| Knob | Current default | Notes |
-|------|-----------------|-------|
-| `n_levels` | **auto-depth** (`None`) | Default `None` makes `build_pyramid` descend until every occupied hex holds a single clip (one-clip-per-hex at deepest zoom), stopping early on co-located clips. Pass an int for fixed depth. |
-| `max_useful_levels(N)` | `1 + ceil(log2 N)`, clamped `[1, 14]` | Runaway-guard **ceiling** for the auto-depth descent only — not the operating depth. Replaced the old `log4(N / base_cols²)` heuristic, which assumed uniform 2-D fill and bottomed out ~1 level short of single clips for clustered embeddings (e.g. ~3 levels / ~5 clips-per-hex for the 245-clip ESC-50 demo). |
-| `base_cols` | `6.0` | Level-0 spans ~6 hex columns across the larger extent. Drives `base_radius`. |
-| `base_radius` | derived (`None` → `_base_radius_for`) | Override path exists but unused. |
-| `tile_span` | `16.0` | Hex columns/rows per tile. Payload-size vs round-trip-count tradeoff. |
-
-`build_pyramid(proj)` is called with **no** `n_levels` (auto-depth) in
-`vtsearch/routes/projection.py:131` and `vtscore/datasets/load_pipeline.py:1104`;
-`base_cols`/`tile_span` use the function defaults. Auto-depth resolves the
-former `n_levels` tuning question — the descent self-terminates at single-clip
-resolution rather than relying on a closed-form estimate.
-
-### Canvas renderer (Stage 3) — `frontend/src/app/components/browse-canvas/browse-canvas.component.ts`
-
-| Knob | Current value | Location |
-|------|---------------|----------|
-| Target on-screen hex radius (level picker) | `28` px default (`DEFAULT_TARGET_RADIUS`), scaled by the thumbnail-size buttons (XS–XL → ×0.5–×2.5) into `targetRadius` | `levelForEffZoom` / `setThumbnailRadius` |
-| Density scale | log (`log(count)/log(maxCount)`) | `drawHex`, `:284` |
-| Colormap | darkred→yellow, 8-stop LUT (black left free for "None"/empty space) | `HEATMAP`, `hex-render.util.ts` |
-| Singleton cell shape | inscribed disc (`HEX_INRADIUS_RATIO`), hex otherwise | `traceCellPath`, `hex-render.util.ts` |
-| Minimap overview level | level whose hexes ≈ `5` px (finer-grained than level 0) | `overviewLevel`, `browse-minimap.component.ts` |
-| Hover debounce | `30` ms | `onCanvasMouseMove`, `:445` |
-| Hex hit radius | `1 × radius` | `hitTest`, `:490` |
-
-### Hover preview — `frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts`
-
-| Knob | Current value | Location |
-|------|---------------|----------|
-| Audio | `loop=true`, hard-cut on move | `playAudio`, `:93` |
-| Text truncation | `300` chars | `loadText`, `:126` |
-| Popup offset | `+16 / -8` px from cursor | `show`, `:53` |
-
-## Gap to fix first: `n_neighbors` / `min_dist` are unreachable
-
-The build route (`vtsearch/routes/projection.py:126`) calls `fit_projection`
-with **no** `n_neighbors`/`min_dist`, so the two most impactful UMAP knobs are
-pinned to the function defaults and can't be tuned without a code edit + the
-container being rebuilt (the projection is frozen + persisted, so a stale
-container also has to be invalidated). **Step 1 of the impl is to plumb these
-through** so the sweep — and any future re-tune — is a config change, not a
-patch.
-
-**Decision to make (resolve at impl, ask if non-obvious):** which knobs become
-*server settings* (persisted, user-visible) vs *build-route params* (advanced /
-internal) vs *stay constants*. A reasonable cut:
-
-- **Server settings** (`ServerSettings` + `CoreConfig`, like `dataset_max_age_days`):
-  `projection_n_neighbors`, `projection_min_dist`. These materially change the
-  map and a user/operator might want to set them per deployment.
-- **Derived, not exposed:** `n_levels` (auto-depth — descends to single-clip
-  resolution; `max_useful_levels` is only the guard ceiling), `base_radius`
-  (derived from `base_cols`).
-- **Constants for now, revisit only if the sweep says so:** `base_cols`,
-  `tile_span`, `min_n_for_umap`.
-
-Because the projection is **persisted and frozen**, changing a UMAP setting
-must **not** silently reuse an old container's projection. The build route
-already guards on the media-id set (`_try_load_persisted`), but it does **not**
-key on the UMAP params. **Add the active UMAP params to the persisted
-projection's metadata and to the `_try_load_persisted` match**, so flipping a
-setting forces a recompute instead of serving a layout fit under the old
-params. (This is a real correctness fix the sweep depends on, not just tuning.)
-
-> **Done.** This gap is closed — see *Deliverables §1*. What remains under this
-> plan is the sweep (Phase A) and the qualitative pass (Phase B), both of which
-> can now retune purely by changing the two settings.
-
 ## Phase A — quantitative sweep (headless, scriptable)
 
 A standalone script (suggested: `scripts/projection_sweep.py`, dev-only, not
-shipped in the app) that, for each `(dataset, params)` cell:
+shipped) that, for each `(dataset, params)` cell:
 
-1. Loads the demo dataset's embedding matrix via
-   `get_embedding_matrix(ctx)` (reuse the real ingest path; embeddings are
-   already L2-normalized).
+1. Loads the demo dataset's embedding matrix via `get_embedding_matrix(ctx)`
+   (reuse the real ingest path; embeddings are already L2-normalized).
 2. Runs `fit_projection(..., random_state=SEED)` — **seeded here only**, so
    trials are comparable; production stays unseeded.
 3. Runs `build_pyramid` with the trial pyramid params.
@@ -152,15 +38,13 @@ shipped in the app) that, for each `(dataset, params)` cell:
 - **Build cost:** UMAP fit seconds, pyramid build seconds, peak RSS.
 - **Layout quality (neighborhood preservation):** trustworthiness &
   continuity of the 2-D embedding vs the original space (`sklearn.manifold.
-  trustworthiness`); optionally kNN-overlap @k between original and projected
-  neighbors. These are the standard quantitative proxies for "did UMAP keep
-  the structure?" and let `n_neighbors`/`min_dist` be ranked numerically
-  before any eyeballing.
+  trustworthiness`); optionally kNN-overlap @k. Lets `n_neighbors`/`min_dist`
+  be ranked numerically before any eyeballing.
 - **Aggregation health per level:** for each pyramid level — number of
   non-empty hexes, count distribution (min/median/p95/max items per hex),
   fraction of single-item hexes, tile fan-out (hexes per tile, tiles per
-  level). This tells whether `base_cols`/`tile_span`/`n_levels` produce a
-  readable, evenly-loaded pyramid or a few mega-hexes + dust.
+  level). Tells whether `base_cols`/`tile_span`/`n_levels` produce a readable,
+  evenly-loaded pyramid or a few mega-hexes + dust.
 - **Small-N behavior:** confirm the PCA-2 / trivial fallbacks trigger at the
   intended `min_n_for_umap` boundary and produce sane bounds.
 
@@ -172,7 +56,7 @@ shipped in the app) that, for each `(dataset, params)` cell:
 - `tile_span ∈ {8, 16, 32}`
 
 **Datasets** — span media type and N (use the S/M/L/A size variants the demo
-registry already provides, e.g. `esc50_s/m/l/a`, `gtzan_a`):
+registry provides, e.g. `esc50_s/m/l/a`, `gtzan_a`):
 
 | Media type | Demo source(s) | Why |
 |------------|----------------|-----|
@@ -213,18 +97,8 @@ can't:
 
 Capture before/after screenshots for the write-up.
 
-## Deliverables
+## Remaining deliverables
 
-1. **Knob plumbing** (impl, env-neutral): **SHIPPED.** `projection_n_neighbors`
-   / `projection_min_dist` are `ServerSettings` (defaults in `vtscore.config`),
-   the build route passes them into `fit_projection`, the fit stamps them onto
-   the `Projection`, and `_try_load_persisted` / `_load_projection_coords` now
-   reject a persisted layout fit under different params (`_projection_params_match`)
-   so a setting change forces a recompute. Tests in `tests/api/test_projection.py`
-   + `tests_lib/projection/test_persistence.py` + `test_umap_projection.py`.
-   (The ingest-time pre-build stays on the `vtscore.config` defaults — core is
-   Flask-free — so a non-default deployment recomputes each dataset once on first
-   browse, which the params-match guard handles correctly.)
 2. **Sweep harness** `scripts/projection_sweep.py` + a short README block on
    running it. (Dev tool; keep it out of the shipped package and out of
    `deptry`'s prod-dependency surface — if it needs `sklearn.manifold` etc.,
@@ -232,35 +106,89 @@ Capture before/after screenshots for the write-up.
 3. **Chosen defaults** landed in `umap_projection.py` / `pyramid.py` / the
    canvas component / settings, each with a one-line rationale comment or a row
    in the write-up.
-4. **Write-up** appended to this plan's *§Results* (below, currently empty):
-   the grid that was run, the winning values, and the metric/screenshot
-   evidence. Update `docs/plans/vtsbrowse.md` *§Open problems → Empirical* to
-   "settled — see plan §Results".
+4. **Write-up** appended to *§Results* (below, currently empty): the grid that
+   was run, the winning values, and the metric/screenshot evidence. Update
+   `docs/plans/vtsbrowse.md` *§Open problems → Empirical* to "settled — see plan
+   §Results".
 
-## Acceptance
+**Acceptance:** `./run-tests.sh` green (the sweep script is dev-only and must
+not break the build, `deptry`, or `ruff`); new defaults committed with
+rationale; no hardcoded UMAP params left unreachable; design doc §Empirical
+marked settled and pointing here.
 
-- `./run-tests.sh` green (the plumbing + persistence-match changes are the only
-  shippable code; the sweep script is dev-only and must not break the build,
-  `deptry`, or `ruff`).
-- New defaults committed with rationale; no hardcoded UMAP params left
-  unreachable in the route.
-- Design doc *§Open problems → Empirical* marked settled and pointing here.
+**Risks & notes.** Tune with a fixed seed for comparability, but the chosen
+defaults must be robust to the run-to-run variation of the *unseeded* production
+fit — prefer params stable across a few seeds, not a knife-edge winner. Any
+container built before the params-in-match fix carries a projection fit under
+old params and must recompute (the persistence-key fix, shipped in Deliverable
+1, is what makes re-tuning safe). If the largest target N stutters even after
+tuning, that triggers the deferred **WebGL renderer** follow-up (out of scope).
+GPU only speeds up embedding the demo datasets; the projection/pyramid math is
+CPU NumPy/numba.
 
-## Risks & notes
+## Reference: current defaults and where each knob lives
 
-- **Unseeded production fit vs seeded sweep.** Tune with a fixed seed for
-  comparability, but the chosen defaults must be robust to the run-to-run
-  variation of the *unseeded* production fit — prefer params whose quality is
-  stable across a few seeds, not a knife-edge winner.
-- **Frozen + persisted projection.** Any container built before the
-  params-in-match fix carries a projection fit under old params; re-tuning
-  means those must recompute. The persistence-key fix (above) is what makes
-  re-tuning safe; without it the sweep results won't reflect the served map.
-- **Performance ceiling defines scope, not features.** If the largest target N
-  stutters even after tuning, that's the trigger to open the deferred **WebGL
-  renderer** follow-up — out of scope for this pass.
-- **GPU is a convenience, not a requirement.** It only speeds up embedding the
-  demo datasets; the projection/pyramid math is CPU NumPy/numba.
+The knobs the sweep varies, their current values, and their source of truth.
+
+### UMAP (Stage 1) — `vtscore/projection/umap_projection.py:fit_projection`
+
+| Knob | Current default | Notes |
+|------|-----------------|-------|
+| `n_neighbors` | `15` | Clamped to `N-1`. Now a `ServerSettings` (`projection_n_neighbors`), plumbed through the route. |
+| `min_dist` | `0.1` | Now a `ServerSettings` (`projection_min_dist`), plumbed through. |
+| `min_n_for_umap` | `10` | Below this → PCA-2 fallback. Constant for now. |
+| `random_state` | `None` (unseeded) | Keep unseeded in prod. Seed only inside the sweep harness. |
+| `metric` | `"euclidean"` | Settled (ingest-normalized vectors); not a tuning target. |
+
+### Pyramid (Stage 2) — `vtscore/projection/pyramid.py:build_pyramid`
+
+| Knob | Current default | Notes |
+|------|-----------------|-------|
+| `n_levels` | **auto-depth** (`None`) | Descends until every occupied hex holds a single clip, stopping early on co-located clips. Derived, not exposed. |
+| `max_useful_levels(N)` | `1 + ceil(log2 N)`, clamped `[1, 14]` | Runaway-guard **ceiling** for the auto-depth descent only, not the operating depth. |
+| `base_cols` | `6.0` | Level-0 spans ~6 hex columns across the larger extent. Drives `base_radius`. Constant for now, revisit if sweep says so. |
+| `base_radius` | derived (`None` → `_base_radius_for`) | Override path exists but unused. |
+| `tile_span` | `16.0` | Hex columns/rows per tile. Payload-size vs round-trip-count tradeoff. Constant for now. |
+
+`build_pyramid(proj)` is called with **no** `n_levels` (auto-depth) in
+`vtsearch/routes/projection.py` and `vtscore/datasets/load_pipeline.py`;
+`base_cols`/`tile_span` use the function defaults.
+
+### Canvas renderer (Stage 3) — `frontend/.../browse-canvas/browse-canvas.component.ts`
+
+| Knob | Current value | Location |
+|------|---------------|----------|
+| Target on-screen hex radius (level picker) | `28` px (`DEFAULT_TARGET_RADIUS`), scaled by thumbnail-size buttons (XS–XL → ×0.5–×2.5) | `levelForEffZoom` / `setThumbnailRadius` |
+| Density scale | log (`log(count)/log(maxCount)`) | `drawHex` |
+| Colormap | darkred→yellow, 8-stop LUT (black left free for empty) | `HEATMAP`, `hex-render.util.ts` |
+| Singleton cell shape | inscribed disc, hex otherwise | `traceCellPath`, `hex-render.util.ts` |
+| Minimap overview level | hexes ≈ `5` px | `overviewLevel`, `browse-minimap.component.ts` |
+| Hover debounce | `30` ms | `onCanvasMouseMove` |
+| Hex hit radius | `1 × radius` | `hitTest` |
+
+### Hover preview — `frontend/.../browse-hover-preview/browse-hover-preview.component.ts`
+
+| Knob | Current value | Location |
+|------|---------------|----------|
+| Audio | `loop=true`, hard-cut on move | `playAudio` |
+| Text truncation | `300` chars | `loadText` |
+| Popup offset | `+16 / -8` px from cursor | `show` |
+
+## What shipped
+
+- **Deliverable 1 — knob plumbing + persistence-key fix.**
+  `projection_n_neighbors` / `projection_min_dist` are now `ServerSettings`
+  (defaults in `vtscore.config`); the build route passes them into
+  `fit_projection`, the fit stamps them onto the `Projection`, and
+  `_try_load_persisted` / `_load_projection_coords` reject a persisted layout
+  fit under different params (`_projection_params_match`) so a setting change
+  forces a recompute. Previously the two most impactful UMAP knobs were pinned
+  to the function defaults and unreachable without a code edit + container
+  rebuild. Tests: `tests/api/test_projection.py`,
+  `tests_lib/projection/test_persistence.py`, `test_umap_projection.py`. (The
+  ingest-time pre-build stays on the `vtscore.config` defaults — core is
+  Flask-free — so a non-default deployment recomputes each dataset once on first
+  browse, which the params-match guard handles.)
 
 ## Results
 

--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -1,810 +1,25 @@
 # Design: VTSBrowse — a UMAP hexbin Dataset Browser in VTSearch
 
-> **Status: shipped and live.** The Browse mode (UMAP projection → server-side
-> hex/square pyramid → Canvas 2D renderer, persisted in the dataset container)
-> is built and in use. The completed work is collapsed to a struck-through list
-> in *§What shipped*; the design body below remains the living spec for the
-> feature and its open follow-ups. **Remaining work** lives in
-> *§Open follow-ups → Active* (thin-pickle save mode, empirical tuning, WebGL).
->
-> This doc scopes VTSBrowse as a **module within VTSearch** — new routes,
-> services, and Angular components that add a Browse mode alongside the existing
-> Find and Train modes.
->
-> **Direction change (this revision):** the original sketch was a
-> *hover-to-hear grid* that reused VTSearch's left-panel media-list. The
-> Browse experience is now a **UMAP 2-D projection rendered as a
-> pannable/zoomable hexbin density map**, where hovering a hex previews a
-> representative item from that region. The **frontend and a new projection +
-> tiling backend** are the substantive additions, captured in
-> *§Browse-canvas architecture* below.
->
-> **Name change:** this feature was originally called "VictoryTones" and
-> scoped to audio only. It is now **VTSBrowse** and designed to support
-> browsing datasets of any MediaType (audio, text, image, video, document).
->
-> **Architecture change:** the original design proposed VTSBrowse as a
-> *second app tier* (a separate Flask app and Angular build target). It is
-> now a **module within VTSearch** — Browse routes under the existing Flask
-> app, Browse components in the existing Angular app. VTSearch already has
-> "Find" and "Train" as dataset/detector workflows; Browse will be a
-> dataset-only workflow added to the same app.
->
-> **Decisions locked** (see *§Locked decisions*): single-dataset v1,
-> **server-side hex tiling**, **Canvas 2D** rendering, **browse-only** scope,
-> and a **projection frozen + persisted at ingest** (unseeded UMAP, computed
-> once).
-
-## Problem / Goal
-
-We want a **Dataset Browser** ("VTSBrowse") for quickly exploring a
-collection of media by *content*. The center of the app is a **Browse
-canvas**: a 2-D UMAP projection of the content-embedding space, drawn as a
-tiled field of **hexagons**.
-
-- The canvas is **pannable and zoomable**.
-- Each hex's **color encodes how many items fall in that region** (density).
-- **Hovering a hex previews a representative ("central") item** from that
-  region. The preview behavior depends on the dataset's MediaType:
-  - **Audio:** plays the representative clip on repeat until the cursor
-    moves to another hex.
-  - **Text:** shows the text snippet in a mouse popup/tooltip.
-  - **Image:** shows a thumbnail of the image in a mouse popup.
-  - **Video:** shows a thumbnail (or a short looping clip) in a mouse popup.
-  - **Document:** shows a text excerpt or title in a mouse popup.
-- **Zooming in subdivides** the hexes into finer-grained cells over a
-  narrower slice of the projection (level-of-detail), so the same screen
-  always shows a readable number of hexes but reveals more structure as you
-  descend.
-
-It reuses the heavy lifting VTSearch already has:
-
-- the **DatasetImporters** (load media from folders, pickles, archives, ...)
-  via the `PluginRegistry`;
-- the **MediaEmbedders** for all supported types (LAION-CLAP, CLAP-Music,
-  AST, Whisper for audio; SigLIP, CLIP, DINOv2/v3 for images; E5, BGE for
-  text; X-CLIP for video) and the cached **embedding matrix** that already
-  backs sorting in VTSearch.
-
-On top of that reused stack it adds two new pieces: a **UMAP projection** of
-the embedding matrix to 2-D, and a **server-side hex-tile pyramid** that the
-canvas streams as the user pans and zooms.
-
-It deliberately **does not** want most of VTSearch's apparatus: no
-LabelSets, no labels/votes, no detector training, no MLP, no eval, no
-achievements. It is a browser, not a trainable searcher.
-
-## Decision: module within VTSearch (not a separate app)
-
-**VTSBrowse is a module added to VTSearch**, not a standalone app or a
-separate app tier. Browse routes live under `vtsearch/routes/`, Browse
-Angular components live in `frontend/src/app/`, and the projection backend
-stays in `vtscore/projection/` (library tier, Flask-free).
-
-VTSearch already has two dataset/detector workflows — **Find** (text-seeded
-or detector-based search) and **Train** (vote on items to train a detector).
-Browse adds a third workflow that operates on a **dataset alone** (no
-detector required): explore the dataset's embedding space via a 2-D
-projection. The Browse canvas replaces the media-list and center panel with
-a hex-tile map; the rest of the VTSearch shell (header, dataset picker,
-settings) stays.
-
-This is simpler than the original "second app tier" design (no separate
-Flask app, no second Angular build target, no separate `vtsbrowse/` package)
-and is the right fit because Browse is a mode of VTSearch, not a different
-product.
-
-## What VTSBrowse reuses
-
-- **Dataset importers** — `vtscore/datasets/importers/*` (server_folder,
-  local_folder, pickle, http_archive, demo, ...) via the `PluginRegistry`.
-  Unchanged; any MediaType the importer supports is available to browse.
-- **Media types + embedders** — all registered media types and their
-  embedders via the media/embedder registries in `vtscore/media/__init__.py`.
-  Audio (LAION-CLAP, CLAP-Music, AST, Whisper), image (SigLIP, CLIP,
-  DINOv2/v3), text (E5, BGE), video (X-CLIP). Unchanged. Embeddings are
-  **L2-normalized at ingest** (see *§Prerequisite*), so the projection
-  consumes unit vectors directly regardless of media type.
-- **The embedding matrix** — `vtscore/embedding/matrix.py`
-  `get_embedding_matrix(ctx) -> (sorted_ids, (N, d) float32)`, lazily built
-  and cached on `DatasetContext` (`_emb_matrix` / `_emb_matrix_ids` in
-  `vtscore/state/core.py`), invalidated when the media-id set changes. This
-  is the **direct input to UMAP**; row `i` <-> `sorted_ids[i]`.
-- **Media loading + embedding** — `vtscore/datasets/loader*.py`,
-  `vtscore/embedding/{helpers,matrix,loader}.py`, and the
-  `load_pipeline -> ingest -> embed_media_bulk` flow.
-- **Media serving** — `GET /api/medias/<id>/audio`
-  (`vtsearch/routes/media/list.py`) streams WAV bytes for audio; analogous
-  endpoints serve image thumbnails, text content, etc. The browse canvas
-  uses whichever endpoint matches the dataset's MediaType for hover preview.
-- **Clipper system** (audio datasets) — `vtscore/media/audio/clipper.py`
-  (tiling / silence / VAD splitters). Each clip is embedded independently
-  and carries `clip_start`/`clip_end`, so **clipping directly controls map
-  density** (more clips -> more points -> a denser projection).
-- **Concurrency/progress** — `vtscore/concurrency/{progress,async_jobs}.py`
-  for background dataset loads **and the background UMAP/tiling build**.
-
-## What Browse mode does not use
-
-- **No LabelSets / labels / votes** — no `good_votes`/`bad_votes`, no
-  `label_history`, no `LabelSet`, no label importers/exporters.
-- **No detectors / training** — no `DetectorContext`, no
-  `vtscore/training/*` (MLP, thresholds), no `vtscore/detectors/*`
-  workflow, no scoring routes.
-- **No eval** — no `vtscore/eval`.
-- **No achievements**, no detector/labelset persistence.
-- **No left-panel media-list, no center panel** — the Browse canvas
-  replaces both. There is no per-item list, no waveform detail, no
-  transport. (This supersedes the earlier "reuse the media-list grid"
-  sketch.)
-
-## New routes and components
-
-Browse adds routes to the existing VTSearch Flask app and components to the
-existing Angular app. The projection backend stays in `vtscore/projection/`
-(library tier). v1 is **single-dataset** — Browse operates on whichever
-dataset is loaded in the active `DatasetContext`.
-
-### New API surface
-
-- **`POST /api/projection/build`** — kick the background job that computes
-  UMAP + the hex-tile pyramid for the loaded dataset; reports progress.
-- **`GET /api/projection/meta`** — projection bounds, available zoom
-  levels, hex sizing per level, point count, build status, **dataset
-  MediaType** (so the client knows which hover-preview behavior to use).
-- **`GET /api/projection/tiles/<level>/<tx>/<ty>`** — the hex aggregates
-  for one tile at one zoom level (see *§Browse-canvas architecture*).
-
-Existing endpoints (`/api/medias/<id>/audio`, `/api/medias/<id>`, dataset
-loading, etc.) are reused as-is. The Browse canvas uses whichever media
-endpoint matches the dataset's MediaType for hover preview.
-
-No `/api/order` text-query endpoint in the Browse flow (the projection *is*
-the ordering); a text-seeded "fly to this region" affordance is a
-follow-up.
-
-## Prerequisite: normalize embeddings at ingest (app-wide)
-
-The projection wants unit vectors, and it turns out VTSearch is *already*
-direction-only nearly everywhere — it just normalizes lazily, at every
-comparison. We make that canonical: **L2-normalize each embedding once, at
-ingest, in every embedder's `embed` / `embed_text`** (audio, image, and the
-CLAP/CLIP text-query paths), then **drop the per-comparison normalization**.
-This is a VTSearch-wide change, not VTSBrowse-local — done as a
-prerequisite so VTSBrowse can consume unit vectors and use plain
-Euclidean UMAP.
-
-Why it's safe and arguably overdue:
-
-- **Magnitude is already discarded for all similarity.** The cosine-sort
-  path (`vtscore/training/region_similarity.py:135-140` and `:49-75`)
-  re-normalizes query and media on every call. Normalizing at ingest just
-  moves that work earlier and makes it the stored form. Several embedders
-  already normalize at output (BGE/E5 text, DINOv2/v3 patch); this makes the
-  rest (CLAP, CLAP-Music, CLIP, SigLIP, and their text-query paths) match.
-
-Two real behavior changes to validate (not just no-ops):
-
-- **Diversity tree** (`vtscore/state/diversity_tree.py`) k-means currently
-  clusters on **raw** vectors (Euclidean = magnitude + direction) — the one
-  consumer that uses magnitude. Normalizing switches it to **angular**
-  clustering, which is the standard, more-correct choice for these
-  embeddings and makes it consistent with every other comparison, **but it
-  changes diversity ordering** users will observe.
-- **MLP** (`vtscore/training/mlp.py`) trains on raw embeddings; unit-norm
-  inputs change the input scale (not direction), which shifts **threshold
-  calibration**. Generally neutral-to-helpful, but retest convergence and
-  thresholds.
-
-**Sites to touch:** add an L2 step to the non-normalizing embedders' `embed`
-and `embed_text` (CLAP, CLAP-Music, CLIP, SigLIP, ...); guard against the
-zero-vector divide; remove the now-redundant normalization in
-`region_similarity.py`; refresh the `svm.py` docstring caveat. **Retest:**
-full `./run-tests.sh`, with attention to diversity ordering, MLP
-convergence, and threshold calibration. Breaks backwards compatibility of
-stored-embedding magnitude (acceptable per repo policy) — call it out in the
-PR.
-
-> **Shipped — see *§What shipped*.** Implemented as a single helper,
-> `vtscore/embedding/normalize.py:l2_normalize`, applied at the
-> `MediaEmbedder` base wrappers (`embed_media`, `embed_media_bulk`, and a new
-> `embed_text` -> `_embed_text_impl` indirection so every subclass is covered
-> at one layer) **and** at the pickle/re-ingest write paths
-> (`loader_pickle._build_pickle_{full,thin}_media`, `ingest._build_media_data`).
-> `region_similarity` now scores by plain dot product. The chosen chokepoint
-> was "normalize wherever a vector enters `medias` (plus query vectors at the
-> embedder)", not the matrix boundary.
-
-**Chokepoint placement (resolve at implementation).** Normalizing *only*
-inside `embed`/`embed_text` covers fresh embeds but **not pickle-loaded
-datasets**, which write stored (possibly raw, old) vectors straight into
-`medias[cid]["embedding"]` without re-embedding. To keep the invariant
-"every embedding in `medias` is unit-norm" we need a single ingest
-chokepoint that also covers the pickle/import write path — e.g. normalize
-wherever an embedding is written into `medias`, or normalize at the
-`get_embedding_matrix` boundary and route every similarity consumer through
-the matrix. Pick one canonical chokepoint rather than scattering L2 calls
-across each embedder; otherwise pickle loads silently bypass it.
-
-## Browse-canvas architecture
-
-This is the heart of VTSBrowse and the part with no precedent in
-`vtsearch`. It splits cleanly into a **projection stage** (run once per
-dataset at ingest, server-side, then frozen and persisted with the dataset),
-a **tile-pyramid stage** (server-side aggregation, persisted alongside the
-projection, streamed to the client), and a **canvas renderer** (Canvas 2D,
-client-side).
-
-### Stage 1 — UMAP projection (server-side, batch, **computed once at ingest, persisted**)
-
-Run `umap-learn` on the cached `(N, d)` embedding matrix to produce an
-`(N, 2)` array of projected coordinates.
-
-- **New dependency:** `umap-learn` (pulls `pynndescent`; `numba` is already
-  present transitively via `librosa`, and `scikit-learn` is a direct dep).
-- **Metric:** plain **Euclidean**. Because embeddings are L2-normalized at
-  ingest (see *§Prerequisite*), Euclidean distance on the unit sphere is a
-  monotonic function of cosine distance, so UMAP needs no special metric and
-  no per-fit normalization step.
-- **Determinism:** **not seeded.** We accept a non-deterministic fit (no
-  fixed `random_state`), which keeps UMAP's numba parallelism on and the fit
-  faster. This is only acceptable *because the projection is frozen at ingest*
-  (below): the layout is computed exactly once and then reused verbatim
-  forever, so its non-reproducibility never surfaces — you never see a
-  "different map" for the same dataset, because the fit never runs a second
-  time. (If we recomputed on every load, unseeded would mean a new layout each
-  session; freezing is what buys back stability without paying for a seeded,
-  parallelism-disabled fit.)
-- **Cost & scheduling:** UMAP is O(N) with heavy constants — seconds at a
-  few thousand points, into minutes at 10^5. It runs as a **background
-  async job with progress** (`vtscore/concurrency`), never inline in a
-  request. The canvas shows a building state until it's ready.
-- **Small-N edge cases:** `n_neighbors` must be `< N`; clamp for tiny
-  datasets. Decide a minimum-N below which we skip UMAP and fall back to a
-  trivial layout (e.g. PCA-2 or a grid).
-- **Datasets are immutable input piles for the projection — by design, not
-  just v1.** A UMAP fit locks to the exact set of points it was trained on.
-  We deliberately **never add to or remove from a loaded dataset**; there is
-  no incremental layout and no out-of-sample `umap.transform()`. If you want
-  to combine datasets (or otherwise change the pile), you **re-run UMAP from
-  scratch** on the new full set, producing a *new* dataset artifact with its
-  own frozen projection — the old map is not migrated or transformed. Because
-  the pile is immutable, the projection it induces is too: computed once when
-  the dataset is ingested, then stored and treated as a fixed property of the
-  dataset (like its embeddings), never recomputed for the life of that
-  artifact.
-
-> **Carve-out from "No Persisted Vectors or MLPs" — the projection IS
-> persisted.** This is a deliberate, scoped exception to the repo rule, and
-> it needs to be called out because that rule is otherwise strict. The
-> rationale: the rule exists so that embeddings and MLP weights can never
-> drift from the active embedder/labels — they are *re-derivable* from
-> origins, so caching them on disk only risks staleness. The UMAP projection
-> is different in the one way that matters: with an **unseeded** fit it is
-> **not reproducible**, so "re-derive on load" does not reproduce the same
-> artifact — it produces a *different* map. To deliver "compute once, never
-> again" (the locked behavior), the `(N, 2)` coordinates **and** the tile
-> pyramid must be stored, not recomputed.
->
-> Scope of the exception, to keep it honest:
-> - It covers **only** the 2D projection coordinates and the derived hex
->   pyramid — *not* embeddings and *not* MLP weights, which stay in-memory /
->   re-derived exactly as the rule demands.
-> - Storage rides with the **dataset artifact** (the pickle is already the
->   sanctioned snapshot of media + embeddings; the projection is the same
->   kind of frozen-at-ingest property). A dataset ingested without a
->   projection (e.g. a legacy `vtsearch` pickle) computes UMAP **once on
->   first open** and persists it back, after which it is never recomputed.
-> - It is still **never** written to `settings.json` or to detector/labelset
->   JSON — those remain origin-only.
-> - Each artifact carries a `projection_id` (minted at the one-time fit) so a
->   tile can always be checked against the projection it belongs to; because
->   the projection never changes after ingest, this id is effectively a
->   stable per-dataset constant rather than a moving invalidation token.
-
-### Stage 2 — Hex-tile pyramid (server-side aggregation)
-
-Per the locked decision, **the server bins points into hexes and serves
-them as tiles**, rather than shipping the raw point cloud for the client to
-bin. The server builds a **multi-resolution pyramid** over the 2-D
-projection:
-
-- **Zoom levels `z = 0 ... Zmax`.** Level 0 is the coarsest (whole projection
-  in a handful of big hexes); each deeper level **halves the hex edge
-  length** in projection space, so a fixed screen always shows a comparable
-  number of hexes while revealing finer structure as you descend — this is
-  the "zoom in -> hexes subdivide" behavior.
-- **Hex lattice anchored in projection (data) space**, using axial/cube
-  coordinates with nearest-center rounding (the d3-hexbin algorithm,
-  reimplemented — no d3 dependency). Anchoring in data space means **pure
-  panning never changes hex membership**; only crossing a zoom-level
-  boundary re-bins. (The canvas still pans continuously; it just swaps which
-  precomputed level it draws as the scale crosses thresholds.)
-- **Per hex, the server precomputes:** axial coords (-> center), **count**
-  (for the density color), and a **representative media id** (the item the hex
-  shows as its thumbnail and hover-previews). Reps are chosen **bottom-up for
-  zoom persistence** (`vtscore/projection/pyramid.py:_assign_reps`): at the
-  deepest level a hex's rep is the item nearest its centroid; each coarser hex
-  inherits the rep of one of the finer hexes beneath it — the inherited rep
-  nearest the coarse hex's centroid. So `reps(level z) ⊆ reps(level z+1)`: every
-  thumbnail you see persists as you zoom in (the eye can track it) while a few
-  genuinely new ones appear, instead of the whole grid reshuffling each level.
-  A rep is always one of the hex's own members (the bin popup opens/scrolls to
-  it); a sparse boundary hex that contains no finer rep at all falls back to its
-  centroid-nearest member (the single non-inherited case — measured a small
-  minority: ~77% of reps persist at the coarsest hop, 90-97% finer).  **This
-  fallback is hex-only.**  Because the hex lattice rounds to nearest center, a
-  fine hex can straddle a coarse boundary and land its rep in a neighbour,
-  leaving the coarse hex with no inherited candidate.  The **square** lattice is
-  a corner-anchored quadtree (see *§Bin shape*) where every fine cell nests
-  wholly inside one coarse cell, so the inherited pool is never empty and square
-  reps persist exactly (100% at every hop) — the fallback never fires.
-  - **On removal** (`rebin_like`, the subset "Remove from Good" cull) the prior
-    reps are fed back in so **surviving reps stay put** for a fast, stable
-    repaint; only a removed rep forces a re-pick (from its surviving inherited
-    candidates), propagating up only to the coarse hexes that had inherited the
-    now-dead rep. A surviving rep left slightly off-centre after a lopsided
-    removal is accepted on purpose — see *Open follow-ups*.
-- **Tiles** group hexes into a spatial grid per level: a tile is
-  `(level, tx, ty)` -> the list of non-empty hexes inside it. This makes the
-  payload **viewport-bounded** (the client fetches only the tiles covering
-  what's on screen) and **trivially cacheable**: because the projection is
-  frozen at ingest, a tile is **immutable for the life of the dataset**, so
-  the client (and any CDN) can cache it with a long `max-age` and the
-  `projection_id` in the URL — no revalidation, no invalidation logic (see
-  *§Tile-cache invalidation*).
-- **Build & storage:** the pyramid is computed in the same one-time ingest
-  job as the UMAP fit (one O(N * levels) pass after the projection) and
-  **persisted with the dataset artifact** alongside the coordinates — it is
-  part of the carve-out above, not recomputed on load.
-
-Why server-side tiling (the chosen path) over client-side binning: it keeps
-the per-interaction payload bounded by the **viewport**, not by **N**, so
-the design scales to very large collections (the cost of binning is paid
-once at build time, on the server, and amortized across every pan/zoom and
-every client). The price is more machinery (a pyramid + a tile endpoint +
-client-side tile caching) and round-trips on zoom/pan, mitigated by an LRU
-tile cache and prefetching neighbors.
-
-#### Tile-cache invalidation (a non-problem, by construction)
-
-Freezing the projection at ingest **dissolves** what would otherwise be the
-trickiest caching question, so it is worth recording why there is nothing to
-solve here. A tile is keyed by `(level, tx, ty)`, and its contents (which
-hexes, their counts, their representative items) are only meaningful relative
-to one projection. In a world where the projection could be *re-fit* — and
-especially with our unseeded fit, where a re-fit is **guaranteed** to move
-every coordinate — a cached tile would silently become stale geometry, and
-the canvas would render a Frankenstein mix of two layouts. That is the
-classic `ETag`/invalidation problem.
-
-We sidestep it entirely: **the projection is computed exactly once and never
-re-fit**, so a tile's contents are fixed for the entire life of the dataset
-artifact. Mechanically:
-
-- Each artifact has a `projection_id` minted at its one-time fit. It goes in
-  the tile URL (e.g. `.../{projection_id}/{level}/{tx}/{ty}`), so tiles
-  from different datasets can never collide in any cache.
-- Within a dataset that `projection_id` is a **stable constant**, so tiles
-  are served with a long-lived `Cache-Control: max-age` (effectively
-  immutable). No `If-None-Match` round-trips, no revalidation, no
-  version-bumping — the client, an LRU, and any CDN can all cache forever.
-- The only event that introduces a *new* `projection_id` is ingesting a
-  **different** dataset (a new artifact), which the user reaches by loading
-  it — a fresh metadata fetch under a fresh id. There is no in-place rebuild
-  of an existing dataset's projection to invalidate against.
-
-So the `projection_id` survives as a clean cache-namespacing key, but the
-hard part — invalidating live caches when a projection changes underneath
-them — simply does not arise, because projections don't change underneath
-anyone.
-
-### Bin shape (hex/square)
-
-The pyramid can tile the projection as either **hexagons** (the d3-hexbin
-lattice) or **squares**.  **The shape is a fixed property of the dataset's media
-type, not a user choice:** media with *browsable* thumbnails — image, video,
-document — tile as **squares** so the thumbnails pack edge-to-edge with no gaps
-(and the square quadtree makes representatives perfectly zoom-persistent);
-audio and text tile as **hexes** (a density map, since their "thumbnails" — e.g.
-audio waveforms — aren't worth browsing).  The single source of truth is
-`vtscore.projection.bin_shape_for_media_type(media_type)`; the backend derives
-the shape from the active dataset on every projection endpoint, and the meta
-response reports the resolved `bin_shape` so the canvas knows which lattice to
-draw.  There is no per-media-type `browse_bin_shape` setting and no on-canvas
-hex/square toggle (both removed).
-
-The design still keeps both lattices cheap by factoring binning out of the rest
-of the pipeline (a dataset only ever uses the one shape its media type dictates,
-but the machinery below is what makes that one shape correct and fast):
-
-- **The UMAP layout is shape-independent and computed once.**  Hex and square
-  are two *binnings* of the same frozen `(N, 2)` coordinates, so switching only
-  re-bins (an O(N·levels) NumPy pass), never re-fits UMAP.  Both binnings carry
-  the **same `projection_id`**.
-- **`build_pyramid(projection, *, bin_shape=...)`** dispatches the three
-  lattice-specific operations — point→cell `assign`, cell `center`, and
-  `tile_index` — through a small `_BinGeometry` record selected by `bin_shape`
-  (`"hex"` | `"square"`).  The square lattice uses a cell side of `radius·√3`
-  (the hex column spacing) so a square and a hexagon at the same pyramid level
-  share the renderer's level-of-detail picker and have a comparable on-screen
-  footprint.  Every other knob (`base_radius`, `tile_span`, auto-depth) is
-  shared.
-- **The square lattice is a quadtree; the hex lattice is not.**  Square cells
-  are **corner-anchored on a fixed data-space origin** (`q = floor(x/side)`),
-  and since the pyramid halves the side per level, a coarse cell of side `2s`
-  is *exactly* the union of the four fine cells of side `s` beneath it.  Every
-  fine cell nests wholly inside one coarse cell, so a child bin's rep is
-  provably a member of its parent and zoom persistence is **geometric, not
-  best-effort** (`reps(coarse) ⊆ reps(fine)` with no fallback — see the rep
-  section).  The hex lattice can't do this: hexagons don't tile 4-into-1
-  self-similarly, so it stays on round-to-nearest-center binning (which does
-  *not* nest — fine hexes straddle coarse boundaries) and accepts the small
-  non-persistent minority.  This is the one place the two shapes' binning math
-  genuinely differs, beyond cell geometry.
-- **The pyramid records its `bin_shape`** (in the dataclass, in `meta()`, and in
-  the persisted JSON), so a loaded projection always knows which lattice it was
-  binned with.  Legacy containers with no `bin_shape` are hex by construction, so
-  they default to hex.
-- **Persistence is per-shape.**  Each binning is stored in its own ZIP entry —
-  `projection.npz` for hex (the legacy name) and `projection_{shape}.npz` for the
-  rest — sharing the coordinates.  In practice a dataset only ever persists the
-  one shape its media type dictates, but the per-shape storage is what lets a
-  legacy container (written when the shape was user-toggleable) still carry both;
-  a forced re-project clears *every* persisted shape.
-- **The context caches per-shape.**  `DatasetContext._pyramids` maps `bin_shape →
-  Pyramid`.  The dataset's shape is built at ingest (the projection-at-creation
-  stage) from its media type.
-- **The HTTP surface is shape-agnostic.**  The shape is derived server-side from
-  the dataset's media type (`bin_shape_for_media_type`), so `POST
-  /api/projection/build`, `GET /api/projection/meta`, and `GET
-  /api/projection/tiles/<level>/<tx>/<ty>` take no `shape` parameter.  The meta
-  response still reports the resolved `bin_shape` so the canvas knows which
-  lattice to draw, and the client tile cache no longer keys on shape.
-- **Every other control is shape-agnostic.**  Pan, zoom, on-screen cell size,
-  the minimap, and hover all run off the shared `radius`/`tile_span` metadata
-  and a shared `BinGeometry`, so they work identically in either mode.
-
-### Stage 3 — Canvas renderer (client-side, **Canvas 2D**)
-
-- **Transform model.** Maintain a projection-space <-> screen-space affine
-  transform: **pan = translate**, **zoom = scale about the cursor**. From
-  the continuous scale, pick the **nearest discrete pyramid level** to
-  fetch; render its hexes through the current transform. Pan within a level
-  is a cheap retransform of already-fetched tiles.
-- **Tile streaming.** On each viewport change, compute the covering tiles
-  for the active level, fetch any missing ones (`GET .../tiles/z/tx/ty`),
-  keep them in an **LRU cache**, and prefetch adjacent tiles + the
-  neighboring levels for snappy zoom.
-- **Drawing.** Raw **Canvas 2D** (matching the existing
-  `charts.service.ts` / audio-waveform code — no d3/three/pixi
-  dependency). Draw one filled hexagon per non-empty visible hex,
-  **viewport-culled**. Canvas 2D comfortably handles low tens-of-thousands
-  of on-screen hexes; because the screen-visible hex count is roughly
-  constant by construction (level-of-detail), this stays well within
-  budget. WebGL is
-  the escape hatch if a future requirement blows past it.
-- **Density color.** Map `count` -> a perceptually-uniform ramp (viridis /
-  magma) on a **log or sqrt scale**, because density is heavy-tailed. Wire
-  the ramp endpoints to theme CSS variables as the charts service does.
-- **Hover preview.** On hex hover, preview the hex's representative item.
-  The preview strategy is **media-type-dependent**:
-  - **Audio:** play via `/api/medias/<id>/audio` with `loop = true`;
-    **hard-cut/replace** on moving to the next hex; **debounce** so sweeping
-    the canvas doesn't machine-gun audio. Browsers block autoplay until a
-    user gesture, so the first canvas click **unlocks** the audio element /
-    `AudioContext`.
-  - **Text:** show the text content (or a truncated snippet) in a tooltip
-    anchored to the cursor or hex. No audio playback.
-  - **Image:** show a thumbnail of the image in a popup anchored to the
-    cursor or hex.
-  - **Video:** show a thumbnail (or a short looping preview clip) in a popup.
-  - **Document:** show the document title or a text excerpt in a tooltip.
-- **Initial framing.** Fit-to-bounds of the projection on first paint, at
-  the level whose hex count best fills the viewport.
-
-## Locked decisions
-
-| Decision | Choice | Notes |
-|----------|--------|-------|
-| Dataset scope (v1) | **Single dataset** | No registry / `X-Dataset-Id` headers; one `DatasetContext`. |
-| Media type | **Any supported MediaType** | The browser works with whatever MediaType the dataset uses; hover preview adapts per type. |
-| Hex binning location | **Server-side tiles** | Pyramid + tile endpoint; viewport-bounded payload; scales to large N. |
-| Frontend packaging | **In-app components** | Browse components live in the existing Angular app; no second build target. The Browse canvas replaces the media-list + center panel when Browse mode is active. |
-| Renderer | **Canvas 2D** | No new viz dependency; WebGL deferred. |
-| Embedding normalization | **App-wide L2 at ingest** | Normalize in every `embed`/`embed_text`; drop per-comparison normalization. See *§Prerequisite*. |
-| Canvas point = one item | **Item (clip for audio), not file** | Each point is a media item; for audio, sibling clips of one source file land independently on the map. |
-| Hover preview | **Local item only** | Hovering a point previews *that item* only, not its parent file — even when other items from the same source sit elsewhere on the canvas. |
-| Product scope (v1) | **Browse-only** | Pan / zoom / hover-to-preview + sibling highlight. No selection, voting, detector training, or ranking in v1; handoff to VTSearch's train-a-detector flow is a deferred follow-up. |
-| Hex color | **Density (count)** | Color = item count per hex (log/sqrt-scaled), which the tile pyramid already aggregates for free. No detector/query needed; a second visual channel (opacity/outline) is reserved for hover + sibling highlight. |
-| Sibling highlight | **On hover** | Hovering an item highlights the other items from the same source file wherever they fall on the canvas. Requires a per-point source-file group id; see *§Interaction model*. |
-| UMAP seeding | **Unseeded (fast)** | No `random_state`; numba parallelism stays on. Safe only because the projection is frozen at ingest, so the fit never re-runs for a given dataset. |
-| Projection lifetime | **Frozen at ingest, persisted** | UMAP + pyramid computed once and stored with the dataset artifact (carve-out from "No Persisted Vectors/MLPs"; covers 2D coords + pyramid only). Never recomputed; legacy datasets compute-once on first open. Dissolves tile-cache invalidation. |
-| Bin shape | **Fixed by media type (square for image/video/document, hex for audio/text)** | The shape is not a user choice — `bin_shape_for_media_type` derives it from the dataset's media type, the backend applies it on every projection endpoint, and the meta response reports the resolved `bin_shape` for the canvas. No `browse_bin_shape` setting and no on-canvas toggle. The pyramid still supports both lattices internally (each its own `Pyramid` carrying `bin_shape`, persisted in its own container entry). See *§Bin shape (hex/square)*. |
-
-### Notes on frontend integration
-
-Browse components (the hex-tile canvas, hover-preview overlays, projection
-build status) are standard Angular components in `frontend/src/app/`. They
-share the existing SCSS tokens, services, and build pipeline — no second
-build target. When Browse mode is active, the Browse canvas replaces the
-media-list and center panel; the VTSearch shell (header, dataset picker,
-settings sidebar) stays visible.
-
-## Interaction model (v1)
-
-VTSBrowse v1 is **browse-only**: the only interactions are spatial
-navigation (pan/zoom) and two hover behaviors. There is no selection, voting,
-detector, or ranking — those belong to the deferred VTSearch handoff (see
-*§Open follow-ups*).
-
-- **Hover -> preview.** Hovering a point previews that item (audio plays the
-  clip; text/image/video/document show a popup). See *§Stage 3* for the
-  per-media-type preview strategy.
-- **Hover -> highlight siblings.** Simultaneously, the other items from the
-  same source file are highlighted wherever they sit. This needs each rendered
-  point to carry a **source-file group id** (derivable from the item's origin
-  / source path — items already record their parent), so the renderer can
-  light up matching points without a round-trip.
-- **Color -> density.** Hex fill encodes item count, taken straight from the
-  pyramid's per-hex aggregation; hover/sibling state rides a separate channel
-  (outline or opacity bump) so it reads on top of the density fill.
-
-**Binning interaction (resolve at implementation).** Sibling highlight and
-per-point hover are only literally per-point at the deepest zoom, where the
-renderer draws individual items. At aggregated zoom levels a "point" is a
-hex of many items, so both behaviors must degrade gracefully: hovering a hex
-should highlight the **hexes that contain** sibling items (not invisible
-points), and the preview target becomes a representative item of the hovered
-hex (exact pick is part of the empirical hover policy). The tile payload
-therefore needs enough per-hex identity to answer "which hexes hold a sibling
-of this group?" — either ship source-file group ids down to the hex level, or
-serve sibling lookups from a small server endpoint keyed by group id.
-
-## Open problems to resolve before/at scaffold
-
-**Empirical (deferred to experimentation, not design blockers).** These have
-no defensible a-priori value; we set them by running UMAP/the pyramid on
-real datasets and looking at the output. The design must leave them as
-tunable parameters, not bake in constants:
-
-- **UMAP knobs:** `n_neighbors`, `min_dist`, and the small-N fallback
-  threshold. (Metric is settled: Euclidean on ingest-normalized vectors.)
-- **Pyramid parameters:** `Zmax`, base hex size at level 0, tile size
-  (hexes per tile), and the density color scale (log vs sqrt, colormap).
-- **Performance ceiling / target N** for v1 — sets whether Canvas 2D
-  culling is sufficient or WebGL is needed sooner.
-- **Hover preview policy:** debounce window; for audio: loop, hard-cut vs.
-  crossfade, volume source, autoplay-unlock gesture; for text/image/video:
-  popup size, truncation, fade timing.
-
-**Design (resolve before scaffold).** All resolved — see *§Locked decisions*.
-For the record:
-
-- **UMAP determinism** — settled: unseeded (fast), safe because the
-  projection is frozen at ingest.
-- **Projection lifetime / rebuild** — settled: computed once at ingest and
-  persisted with the dataset artifact; never re-fit. Datasets remain
-  immutable input piles (combining them produces a new artifact, not an
-  in-place rebuild).
-- **Tile-cache invalidation** — settled: a non-problem by construction (frozen
-  projection => immutable tiles); `projection_id` survives only as a stable
-  cache-namespacing key. See *§Tile-cache invalidation*.
-
-## Library-tier placement
-
-The UMAP + tiling code is **Flask-free** and lives in `vtscore/projection/`
-(library tier), covered by `./run-tests.sh vtscore-clean`. Browse routes
-in `vtsearch/routes/` call into the library tier for projection/pyramid
-computation. This keeps the heavy compute code testable without the app
-and available to any future consumer of `vtscore`.
-
-## What shipped
-
-All struck through; the design body above documents the contract. Details live
-in git history and the cited source files.
-
-- ~~**Prerequisite: app-wide L2 normalization at ingest.**~~ Every embedding is
-  unit-norm where it enters `medias`; all similarity is plain dot product.
-  (`vtscore/embedding/normalize.py`, `MediaEmbedder` base, pickle/ingest write
-  paths, `region_similarity.py`.) Breaks stored-magnitude back-compat; legacy
-  pickles re-normalize on load.
-- ~~**Projection backend (Stages 1 + 2), Flask-free** — `vtscore/projection/`~~
-  (`umap_projection.py` unseeded Euclidean UMAP + PCA-2 fallback; `hexbin.py`
-  d3-hexbin reimplemented in NumPy; `pyramid.py` auto-depth tile pyramid). New
-  `umap-learn` dependency.
-- ~~**Browse routes (HTTP layer)** — `vtsearch/routes/projection.py`~~
-  (`POST /build`, `GET /meta`, `GET /tiles/<level>/<tx>/<ty>`), backed by the
-  `projection_jobs` JobManager and `DatasetContext` cache slots.
-- ~~**Browse canvas frontend (Stage 3)**~~ — `BrowseCanvasComponent` (Canvas 2D,
-  pan/zoom, LOD, viewport culling, hover hit-test), `BrowseHoverPreviewComponent`,
-  `BrowseViewComponent`, `ProjectionApiService`, `TileCacheService` (LRU),
-  `browseContextGuard`, `/browse/:datasetId` route.
-- ~~**Projection persistence (in-container)**~~ — coords + pyramid stored as
-  `projection.npz` in the dataset ZIP (`vtscore/projection/persistence.py`,
-  `container.append_projection`/`read_projection`); build route restores instead
-  of recomputing when the media-id set matches.
-- ~~**ZIP container format**~~ — `.pkl` files are ZIPs (`medias.pkl` + `meta.json`
-  + optional `projection.npz`); no legacy raw-pickle/sidecar support
-  (`vtscore/datasets/container.py`).
-- ~~**Opt-in projection-at-creation**~~ — "Build 2-D Browse projection now"
-  checkbox in `vt-import-advanced`; best-effort `_build_projection_stage` after
-  registration.
-- ~~**Dataset age-off**~~ — `dataset_max_age_days` server setting → `expires_at`
-  on container + registry; expired loads return 410 and auto-unregister.
-- ~~**Hex/square bin shape**~~ — `vtscore/projection/squarebin.py`,
-  `build_pyramid(..., bin_shape=)`, per-shape container entries,
-  `DatasetContext._pyramids`. *Superseded:* the shape was originally a
-  user-toggleable per-media-type setting (`browse_bin_shape`) with shape-keyed
-  routes/tile-cache; it is now derived from the media type
-  (`bin_shape_for_media_type`: square for image/video/document, hex for
-  audio/text), the `browse_bin_shape` setting + on-canvas toggle are removed, and
-  the routes/tile-cache are shape-agnostic.
-- ~~**Per-theme density colormap + Browser settings tab**~~ — Heat/Ocean/Grayscale
-  colormaps resolved against the live theme; per-media-type `browse_colormap` /
-  `browse_icon_size` / `browse_bin_shape` settings surfaced in a new Browser tab.
-- ~~**Layout compaction (close the empty oceans)**~~ — `vtscore/projection/compaction.py`
-  `compact_layout()`, run by default on the UMAP path (`fit_projection(..., compact=True)`).
-  A collision-aware force-directed packer: HDBSCAN clusters the 2-D layout, each
-  cluster becomes a rigid disc (noise points fold into their nearest island so the
-  unit count stays bounded by the cluster count), the discs are pulled toward the
-  global centroid with hard non-overlap repulsion, and every point is translated by
-  its cluster's net shift. Because the move is a pure per-cluster translation, each
-  island's internal shape is preserved **exactly** (Procrustes disparity 0) — only
-  the dead water between islands disappears. Validated on real LAION-CLAP audio
-  embeddings (ESC-50): grid-fill rose ~0.13→0.21 with zero blob distortion. See
-  *§Open follow-ups → Active* for the fill-vs-crispness ceiling this trades against.
-  A per-media-type **`browse_compact`** toggle (Settings → Browser, default on)
-  controls it; because the coords are Stage-1 (computed once, frozen/persisted),
-  a change applies to the next build or the Re-project action, not retroactively.
-  The build routes read the setting for the dataset's media type and thread
-  `compact=` into `fit_projection`.
+**Status: shipped and live.** UMAP projection → server-side hex/square tile
+pyramid → Canvas 2D renderer, frozen and persisted in the dataset container.
+Thin open work below (thin-pickle save mode, empirical tuning, WebGL escape
+hatch, compaction fill ceiling). The living design spec follows the open work.
+
+VTSBrowse is a **module within VTSearch** — Browse routes under the existing
+Flask app (`vtsearch/routes/projection.py`), Browse components in the existing
+Angular app (`frontend/src/app/`), projection backend in `vtscore/projection/`
+(library tier, Flask-free). It adds a **dataset-only** workflow (no detector,
+no labels/votes, no MLP/eval) alongside Find and Train: a 2-D UMAP projection
+of the content-embedding space, drawn as a pannable/zoomable tiled field of
+**hexagons** (audio/text) or **squares** (image/video/document), where hovering
+a bin previews a representative item. Bin color encodes item count (density);
+zooming subdivides bins (level-of-detail). It reuses VTSearch's importers,
+embedders, embedding matrix, media serving, clipper, and concurrency stack.
 
 ## Open follow-ups
 
-**Shipped (struck through):**
-- ~~**Configurable mouse-zooms per pyramid level**~~ — a per-media-type
-  `browse_mouse_zooms_per_level` setting (Settings → Browser, default 2, clamped
-  1..3) controls how many wheel notches / +/- button clicks cross one pyramid
-  level (a full 2× of zoom). The per-step width factor is `2 ** (1 / n)`: 1 ⇒ 2×
-  (one step per level), 2 ⇒ √2 (the previous fixed behavior), 3 ⇒ ∛2.
-  `BrowseViewComponent` mirrors the per-media value and derives the +/- button
-  factor from it; `BrowseCanvasComponent` takes it as a `zoomsPerLevel` input and
-  derives the wheel factor, so the two gestures stay in lock-step. The double-click
-  zoom stays a fixed 2× (one whole level) regardless of the setting.
-- ~~**Wider cell-size range + full-res at large zoom**~~ — the browse canvas's
-  bigger/smaller buttons now walk nine named levels (`XS`..`XL`, then `2XL`..`5XL`)
-  instead of five, so a user can blow a cell up close to the full media. Past the
-  point where a cell is drawn wider than the thumbnail's native longest side
-  (`THUMB_NATIVE_MAX_DIM`, 384px), `BrowseCanvasComponent.getThumb` fetches the
-  full-res `/image` instead of the capped `/thumbnail` (the cache is dropped when
-  the zoom crosses the threshold so cells reload sharp; only a few such giant cells
-  fit on screen, so the LRU still bounds memory). The backend `BrowseIconSize`
-  literal / `VALID_BROWSE_ICON_SIZES` accept the four new labels.
-- ~~**Live elapsed-time during the UMAP fit**~~ — fit runs on a worker thread and
-  ticks a 1 s elapsed-seconds heartbeat (`total=0` → indeterminate progress bar),
-  since UMAP's numba epoch loop exposes no per-epoch callback.
-- ~~**Item selection on the canvas (tracking only)**~~ — media-id-granular
-  `BrowseSelectionService`; click toggles a bin, Shift+drag marquees; per-cell
-  none/partial/full rendering; `member_ids` re-derived on demand
-  (`tile_member_ids`, never persisted). *Still open:* act on the selection
-  (export / seed detector / subset projection); minimap selection overlay.
-- ~~**Keyboard shortcuts**~~ — the browse view and its bin-details popup handle
-  document-level keys (`@HostListener('document:keydown')`, gated by
-  `shortcutsBlocked()` in `utils/keyboard-shortcuts.ts` — no typing target, no
-  open modal). On the **canvas** (popup closed): arrows pan (`canvas.panByKey`,
-  hard-clamped like the minimap recenter but eased over `PAN_ANIM_MS` via
-  `startPanAnim`/`stepPanAnim` so a N/E/S/W push glides like the zoom transition
-  instead of snapping; repeated presses retarget the glide), `+`/`-` zoom (the same `zoomIn`/
-  `zoomOut` as the GUI buttons), Ctrl/Cmd-A selects every bin **fully** in view
-  (`canvas.selectAllInView`, the viewport analogue of the marquee). In the
-  **bin-details popup** (which then owns the keyboard; the view suppresses its
-  own while it's open): arrows walk the viewed item through the grid
-  (`moveFocus`, updating the preview pane + a dashed `.focused` grid ring and
-  scrolling the row into view), `+`/`-` resize the detail image (`bumpPreview`),
-  Ctrl/Cmd-A selects every item in the bin. The Help → Keyboard shortcuts sheet
-  was split into per-context sub-tabs (Train/Find · Browser · General) so the
-  growing list stays scannable. *Open follow-up:* keyboard nav doesn't move DOM
-  focus, so Enter/Space only toggles the *DOM-focused* entry (tab order), not the
-  arrow-walked one; a future pass could let Space toggle the viewed item too.
-- ~~**Double-click + right-click on the canvas**~~ — double-click zooms about the
-  cursor (click toggle deferred by `DBLCLICK_MS`); right-click opens the shared
-  `vt-media-context-menu`. *Still open:* the context menu is the home for the
-  deferred selection *actions* once they land.
-- ~~**Load + project on the dashboard before entering Browse**~~ — `BrowsePrepService`
-  loads + builds the `hex` projection with inline row progress before navigating;
-  guard/`loadProjection()` stay as the deep-link fallback.
-- ~~**Browse a Find run's positives as their own UMAP**~~ — Find-panel `Browse`
-  button UMAPs only the positive ids into an ephemeral, never-persisted `_subset_*`
-  projection (`?subset=1`). *Known limitation:* in-memory id handoff, so a hard
-  reload of the subset URL loses it.
-- ~~**Browse a saved detector's positives (dataset-free)**~~ — the dashboard's
-  detector-row `Browse` button maps just that detector's positive labels,
-  independent of any selected dataset. `POST /api/detectors/registry/<id>/browse-positives`
-  resolves each positive's origin and embeds it with the **detector's own**
-  embedder (so mixed-source detectors work and no dataset need be loaded;
-  reuses the loaded detector's `label_embeddings` when it's already in that
-  space), assembles a throwaway in-memory `DatasetContext` keyed
-  `__detpos__<id>` (vectors + preview bytes, never persisted), projects it,
-  and registers it. The browse stack is reused unchanged: the canvas reads
-  tiles + previews via the standard `/api/medias/<id>/...` endpoints off the
-  context's `media_bytes`. The guard skips the registry check for the
-  `__detpos__` prefix; the browse view releases the context (and clears the
-  active pair) on exit. Build runs async with progress on the detector row
-  (`_detbrowse_*` detector-loading task). See `vtscore/detectors/positives_browse.py`.
-  *Open follow-ups:* (a) clipped/region positives are embedded image-level
-  (`embed_file`), not patch-pooled like training — fine for layout, but it can
-  place a region-voted item slightly differently than its trained vector;
-  reuse the cached `label_embeddings` covers the loaded-detector case exactly.
-  (b) Ephemeral-context cleanup leans on the browse-view's release call (plus
-  rebuild-evict and process exit); there's no server-side TTL, so a client that
-  vanishes mid-browse leaves the context until the next browse of that detector.
-  (c) Preview bytes are held in memory for the session — fine for labelset-sized
-  sets, but a very large positive set would be heavy; a lazy `media_path`/origin
-  re-resolution path could replace the eager byte read if that ever bites.
-- ~~**Bin-popup member ordering**~~ — a bin's `member_ids` are served in a
-  locality-preserving 1-D order (a Hilbert space-filling-curve traversal of the
-  frozen 2-D layout, `_hilbert_order` in `pyramid.py`) rather than by media id,
-  so a dense bin lists similar items together (cats with cats, dogs with dogs)
-  and hiding items keeps the survivors' relative order. Derived from the 2-D
-  coords with no second UMAP fit, and recomputed wherever the `_member_index`
-  cache is (re)built, so it rebuilds/caches/trashes exactly like the coords. The
-  earlier idea — a *separate* 1-D UMAP fit, persisted alongside the 2-D coords —
-  was dropped because it would roughly double the projection build time for a
-  marginal gain over the curve, which already linearizes the layout UMAP
-  produced. *Open follow-up:* if a future ordering wants true 1-D-UMAP semantics
-  (not just a space-filling linearization of the 2-D layout), it would need that
-  second fit and a persisted `order` field on `Projection`.
-- ~~**Bin-popup detail preview**~~ — the right-click bin popup is now grid-only
-  (the List/Grid toggle and the `view_mode_popup` setting were removed end to
-  end) and pairs the member grid with a large preview pane on its left, shown
-  for thumbnail media (image/video). Hovering a grid thumbnail paints that
-  item's *full-resolution* original (`/api/medias/<id>/image`, not its grid
-  thumbnail) into the pane; the pane opens on the bin's representative so even a
-  singleton lands on a large high-res view with no hover. The pane is sized to
-  +50% of the item's on-canvas mouse-over break-out at the current main-canvas
-  thumbnail size (`hoverThumbRadius` is passed from `browse-view`), so it tracks
-  the icon-size setting. The grid thumbnails no longer magnify on hover (the
-  preview pane replaces that affordance). *Open follow-up:* the pane is gated on
-  `usesThumbnails` (image/video); documents render a grid thumbnail but get no
-  large preview — if document detail-viewing is wanted, widen the gate and pick a
-  full-res document endpoint.
-- ~~**Zoom-persistent bin representatives**~~ — bin reps are now chosen
-  bottom-up so a coarse bin inherits the rep of one of the finer bins beneath it
-  (the inherited rep nearest the coarse centroid), giving `reps(z) ⊆ reps(z+1)`:
-  thumbnails persist as you zoom in instead of the grid reshuffling per level.
-  Reps stay one of the bin's own members (a sparse boundary bin with no interior
-  finer rep falls back to its centroid-nearest member — a small minority).
-  `rebin_like` feeds prior reps back in so a removal keeps surviving reps put
-  (fast, stable repaint) and only re-picks a removed rep, propagating up just to
-  the coarse bins that had inherited it. See `_assign_reps` in
-  `vtscore/projection/pyramid.py` and `tests_lib/projection/test_rep_persistence.py`.
-  *Open follow-up:* re-centring a surviving rep after a lopsided partial removal
-  (hide a bin's Western kids → the rep should drift East). Deliberately deferred:
-  it was a lower priority than not churning the grid on every removal, so today a
-  surviving rep is left in place even if it ends up slightly off-centre. If
-  wanted, re-centre lazily (only the bins whose membership changed) so it never
-  blocks the repaint.
-- ~~**Zoom-out border fill (overscanned snapshot)**~~ — the picture-in-picture
-  zoom transition froze a *viewport-sized* snapshot and scaled it; on zoom-out
-  the shrinking frame left the newly-revealed margin as a black border. The
-  snapshot now overscans on zoom-out (`BrowseCanvasComponent.SNAP_OVERSCAN_MAX`,
-  capped at 2× per axis): the already-rendered viewport stays the frozen centre
-  (a free `drawImage` of the live canvas) and the surrounding ring is
-  re-rendered from the **source** level's bins (`renderSnapshotBorder`,
-  `displayedLevel`), painting the thumbnails the off-view prefetch already
-  warmed in `thumbCache`. The shrunk blit then covers the canvas with real
-  content. The ring draws only from **cached** tiles (`tileCache.getCached`), so
-  the fill reaches as far as the cache does and falls off to background past it
-  — never a network wait, and the per-frame loop stays a single blit
-  (`zoomBlitRect` now sizes by the snapshot's own `snapW×snapH` footprint).
-  Zoom-in is unchanged (its frame already overfills the viewport), and the
-  overscan is gated on `thumbnailMode`. *Open follow-up:* a zoom-out deeper than
-  the 2× cap, or past uncached tiles, still shows a black falloff at the far
-  edge; widening the cap trades memory (the buffer is `(2×)²` = 4× the canvas)
-  for reach.
-
 **Active:**
+
 - **Dataset pickle size — drop inline `media_bytes` when the media is reachable
   on disk.** The dataset container still bakes a full copy of every audio/image/
   video blob into `medias.pkl` even when the media also carries a `media_path`
@@ -819,9 +34,9 @@ in git history and the cited source files.
   reconstruction). The peek summarizer (`peek_pickle_dataset_summary`) was
   updated to stub numpy reconstruction so it stays cheap on the new format.
 - **Empirical tuning pass:** choose validated defaults for the UMAP fit, the
-  hex-tile pyramid, and the canvas renderer (the knobs *§Open problems →
-  Empirical* deliberately left unset). Planned in detail, ready to execute on
-  an environment with a browser (visual layout/hover judgment can't be done in
+  hex-tile pyramid, and the canvas renderer (the knobs *§Empirical knobs*
+  deliberately left unset). Planned in detail, ready to execute on an
+  environment with a browser (visual layout/hover judgment can't be done in
   the headless cloud container) — see **`docs/plans/vtsbrowse-empirical-tuning.md`**.
 - **WebGL renderer** if the Canvas 2D ceiling is hit (a trigger from the tuning
   pass's performance review, not a standalone feature).
@@ -843,6 +58,7 @@ in git history and the cited source files.
   a companion plan for **`vtscore` decoupling + PyPI publish**.
 
 **Cut (decided not to pursue):**
+
 - **Sibling highlighting** — *cut.* Would have highlighted hexes containing
   items from the same source file on hover (needs source-file group ids in the
   tile payload or a server-side lookup endpoint). The canvas has the rendering
@@ -854,3 +70,232 @@ in git history and the cited source files.
 - **Text-seeded navigation** — *cut.* Would have added a query box that embeds
   text and pans the canvas to the nearest region. The projection remains the
   only ordering in Browse.
+
+### Empirical knobs deliberately left unset (feed the tuning pass)
+
+These have no defensible a-priori value; they are set by running UMAP/the
+pyramid on real datasets and looking at the output. The design leaves them as
+tunable parameters, not baked-in constants:
+
+- **UMAP knobs:** `n_neighbors`, `min_dist`, and the small-N fallback
+  threshold. (Metric is settled: Euclidean on ingest-normalized vectors.)
+- **Pyramid parameters:** `Zmax`, base hex size at level 0, tile size
+  (hexes per tile), and the density color scale (log vs sqrt, colormap).
+- **Performance ceiling / target N** for v1 — sets whether Canvas 2D culling is
+  sufficient or WebGL is needed sooner.
+- **Hover preview policy:** debounce window; for audio: loop, hard-cut vs.
+  crossfade, volume source, autoplay-unlock gesture; for text/image/video:
+  popup size, truncation, fade timing.
+
+## What shipped
+
+One line per item; details in git history and the cited source files. Residual
+open sub-items are noted inline in parentheses.
+
+- **App-wide L2 normalization at ingest** — every embedding is unit-norm where
+  it enters `medias` (`vtscore/embedding/normalize.py`, `MediaEmbedder` base +
+  pickle/ingest write paths); all similarity is plain dot product
+  (`region_similarity.py`). Breaks stored-magnitude back-compat; legacy pickles
+  re-normalize on load.
+- **Projection backend (Stages 1 + 2), Flask-free** — `vtscore/projection/`
+  (`umap_projection.py` unseeded Euclidean UMAP + PCA-2 fallback; `hexbin.py`
+  d3-hexbin in NumPy; `pyramid.py` auto-depth tile pyramid). New `umap-learn` dep.
+- **Browse routes** — `vtsearch/routes/projection.py` (`POST /build`,
+  `GET /meta`, `GET /tiles/<level>/<tx>/<ty>`), backed by the `projection_jobs`
+  JobManager and `DatasetContext` cache slots.
+- **Browse canvas frontend (Stage 3)** — `BrowseCanvasComponent` (Canvas 2D,
+  pan/zoom, LOD, viewport culling, hover hit-test), `BrowseHoverPreviewComponent`,
+  `BrowseViewComponent`, `ProjectionApiService`, `TileCacheService` (LRU),
+  `browseContextGuard`, `/browse/:datasetId` route.
+- **Projection persistence (in-container)** — coords + pyramid stored as
+  `projection.npz` in the dataset ZIP (`vtscore/projection/persistence.py`,
+  `container.append_projection`/`read_projection`); build restores instead of
+  recomputing when the media-id set matches.
+- **ZIP container format** — `.pkl` files are ZIPs (`medias.pkl` + `meta.json`
+  + optional `projection.npz`); no legacy raw-pickle/sidecar
+  (`vtscore/datasets/container.py`).
+- **Opt-in projection-at-creation** — "Build 2-D Browse projection now" checkbox
+  in `vt-import-advanced`; best-effort `_build_projection_stage` after registration.
+- **Dataset age-off** — `dataset_max_age_days` setting → `expires_at` on
+  container + registry; expired loads return 410 and auto-unregister.
+- **Hex/square bin shape** — `vtscore/projection/squarebin.py`,
+  `build_pyramid(..., bin_shape=)`, per-shape container entries,
+  `DatasetContext._pyramids`; shape derived from media type
+  (`bin_shape_for_media_type`: square for image/video/document, hex for
+  audio/text), the `browse_bin_shape` setting + on-canvas toggle removed,
+  routes/tile-cache shape-agnostic. The square lattice is a corner-anchored
+  quadtree (reps persist exactly); hex uses round-to-nearest-center.
+- **Per-theme density colormap + Browser settings tab** — Heat/Ocean/Grayscale
+  resolved against the live theme; per-media-type `browse_colormap` /
+  `browse_icon_size` settings in a Browser tab.
+- **Layout compaction** — `vtscore/projection/compaction.py` `compact_layout()`,
+  on by default (`fit_projection(..., compact=True)`); collision-aware
+  force-directed cluster packer that preserves each island's internal shape
+  exactly (Procrustes disparity 0), only closing the dead water between islands.
+  Per-media-type `browse_compact` toggle. (See *Compaction fill ceiling* above.)
+- **Configurable mouse-zooms per pyramid level** — `browse_mouse_zooms_per_level`
+  setting (default 2, clamped 1..3); per-step width factor `2 ** (1 / n)`.
+  Double-click stays a fixed 2×.
+- **Wider cell-size range + full-res at large zoom** — nine named levels
+  (`XS`..`XL`, `2XL`..`5XL`); `BrowseCanvasComponent.getThumb` fetches full-res
+  `/image` past `THUMB_NATIVE_MAX_DIM` (384px) instead of the capped `/thumbnail`.
+- **Live elapsed-time during the UMAP fit** — fit on a worker thread, 1 s
+  elapsed-seconds heartbeat (`total=0` → indeterminate bar); UMAP's numba loop
+  exposes no per-epoch callback.
+- **Item selection on the canvas (tracking only)** — `BrowseSelectionService`;
+  click toggles a bin, Shift+drag marquees; none/partial/full cell rendering;
+  `member_ids` re-derived (`tile_member_ids`, never persisted). (Open: act on the
+  selection — export / seed detector / subset projection; minimap overlay.)
+- **Keyboard shortcuts** — document-level keys gated by `shortcutsBlocked()`
+  (`utils/keyboard-shortcuts.ts`); canvas: arrows pan (eased glide), `+`/`-`
+  zoom, Ctrl/Cmd-A selects every bin in view; bin-popup: arrows walk items,
+  `+`/`-` resize preview, Ctrl/Cmd-A selects all; Help sheet split into
+  Train/Find · Browser · General sub-tabs. (Open: keyboard nav doesn't move DOM
+  focus, so Enter/Space toggles the DOM-focused entry, not the arrow-walked one.)
+- **Double-click + right-click on the canvas** — double-click zooms about the
+  cursor (click toggle deferred by `DBLCLICK_MS`); right-click opens
+  `vt-media-context-menu` (the eventual home for deferred selection *actions*).
+- **Load + project on the dashboard before entering Browse** — `BrowsePrepService`
+  loads + builds the `hex` projection with inline row progress; guard/
+  `loadProjection()` stay as the deep-link fallback.
+- **Browse a Find run's positives as their own UMAP** — Find-panel `Browse`
+  button UMAPs only the positive ids into an ephemeral `_subset_*` projection
+  (`?subset=1`). (Limitation: in-memory id handoff, so a hard reload loses it.)
+- **Browse a saved detector's positives (dataset-free)** — dashboard detector-row
+  `Browse`; `POST /api/detectors/registry/<id>/browse-positives` embeds positives
+  with the **detector's own** embedder into a throwaway `__detpos__<id>` context
+  (never persisted), projects it, reuses the standard browse stack. See
+  `vtscore/detectors/positives_browse.py`. (Open: (a) clipped/region positives
+  embedded image-level, not patch-pooled; (b) no server-side TTL for the
+  ephemeral context; (c) preview bytes held in memory for the session.)
+- **Bin-popup member ordering** — `member_ids` served in a Hilbert
+  space-filling-curve 1-D order (`_hilbert_order` in `pyramid.py`) so a dense bin
+  lists similar items together; derived from the 2-D coords, no second UMAP fit.
+  (Open: true 1-D-UMAP ordering would need a second fit + a persisted `order`
+  field on `Projection`.)
+- **Bin-popup detail preview** — grid-only popup (List/Grid toggle + `view_mode_popup`
+  removed) with a large preview pane; hovering a grid thumbnail paints the
+  full-res original; the pane opens on the bin's representative. (Open: gated on
+  `usesThumbnails` (image/video); documents get a grid thumbnail but no large
+  preview.)
+- **Zoom-persistent bin representatives** — reps chosen bottom-up so a coarse bin
+  inherits a finer bin's rep (`reps(z) ⊆ reps(z+1)`); `rebin_like` keeps
+  surviving reps put on removal. `_assign_reps` in `vtscore/projection/pyramid.py`,
+  `tests_lib/projection/test_rep_persistence.py`. (Open: re-centring a surviving
+  rep after a lopsided partial removal — deferred, lazily re-centre if wanted.)
+- **Zoom-out border fill** — the zoom-transition snapshot overscans on zoom-out
+  (`SNAP_OVERSCAN_MAX`, 2× cap) and re-renders the revealed ring from cached
+  tiles (`renderSnapshotBorder`) instead of leaving a black border. (Open: a
+  zoom-out past the 2× cap or past uncached tiles still shows black falloff.)
+
+## Design spec (living)
+
+The completed feature's contract. Kept below the open work because it mostly
+documents shipped mechanics; retained because it is the living spec a
+future contributor needs when picking up the open follow-ups.
+
+### What Browse reuses / does not use
+
+Reuses: dataset importers (`vtscore/datasets/importers/*`), all media types +
+embedders, the cached embedding matrix (`vtscore/embedding/matrix.py`
+`get_embedding_matrix(ctx) -> (sorted_ids, (N,d) float32)`, the direct UMAP
+input), media-serving endpoints (`/api/medias/<id>/{audio,image}`, ...), the
+audio clipper (each clip is a point, so clipping controls density), and
+`vtscore/concurrency` for the background build.
+
+Does **not** use: LabelSets/labels/votes, detectors/training/MLP, eval,
+achievements, or the left-panel media-list + center panel (the Browse canvas
+replaces both). It is a browser, not a trainable searcher.
+
+### API surface
+
+- **`POST /api/projection/build`** — kicks the background UMAP + pyramid job for
+  the loaded dataset; reports progress.
+- **`GET /api/projection/meta`** — bounds, zoom levels, per-level hex sizing,
+  point count, build status, media type, resolved `bin_shape`.
+- **`GET /api/projection/tiles/<level>/<tx>/<ty>`** — the bin aggregates for one
+  tile at one level.
+
+Shape is derived server-side from the dataset's media type, so no endpoint takes
+a `shape` parameter. Existing media endpoints are reused as-is for hover preview.
+
+### Architecture — three stages
+
+**Stage 1 — UMAP projection** (server, batch, computed **once at ingest,
+frozen, persisted**). `umap-learn` on the `(N,d)` matrix → `(N,2)`. Metric is
+plain **Euclidean** (safe because embeddings are L2-normalized at ingest — see
+*What shipped*). Fit is **unseeded** (numba parallelism on, faster) — safe
+*only because* the projection is frozen at ingest and never re-fit, so its
+non-reproducibility never surfaces. Runs as a background async job with
+progress. Small-N: clamp `n_neighbors < N`, PCA-2/grid fallback below a
+threshold. Datasets are **immutable input piles by design**: no incremental
+layout, no out-of-sample `transform()`; combining datasets produces a *new*
+artifact with its own frozen projection.
+
+> **Carve-out from "No Persisted Vectors or MLPs."** The 2-D coordinates **and**
+> the tile pyramid are persisted (never embeddings or MLP weights), because an
+> unseeded fit is not reproducible, so "re-derive on load" would produce a
+> *different* map. Storage rides with the dataset artifact (the sanctioned
+> snapshot); never in `settings.json` or detector/labelset JSON. Each artifact
+> carries a `projection_id` minted at the one-time fit — effectively a stable
+> per-dataset constant. A legacy pickle with no projection computes UMAP once on
+> first open and persists it back.
+
+**Stage 2 — tile pyramid** (server aggregation, persisted alongside coords).
+Zoom levels `z = 0..Zmax`; each deeper level halves the bin edge length in
+projection space (screen always shows a comparable bin count). Lattice anchored
+in **data space**, so pure panning never re-bins; only crossing a level boundary
+re-bins. Per bin: axial coords (→ center), **count** (density color), and a
+**representative media id**. Reps are chosen **bottom-up** (`_assign_reps`) so
+`reps(z) ⊆ reps(z+1)` — thumbnails persist as you zoom in; the square quadtree
+persists reps exactly, hex has a small centroid-nearest fallback minority. Tiles
+group bins into a spatial grid per level so the payload is **viewport-bounded**
+and — because the projection is frozen — **immutable** for the dataset's life,
+served with a long `Cache-Control: max-age` and `projection_id` in the URL. Tile-
+cache invalidation is a non-problem by construction: projections never change
+underneath anyone; `projection_id` survives only as a cache-namespacing key.
+
+**Bin shape** is a fixed property of the media type, not a user choice
+(`bin_shape_for_media_type`): browsable-thumbnail media (image/video/document)
+tile as **squares** (pack edge-to-edge, perfectly zoom-persistent quadtree
+reps); audio/text tile as **hexes** (density map). The UMAP layout is
+shape-independent (both binnings share coords + `projection_id`);
+`build_pyramid(projection, *, bin_shape=...)` dispatches the three
+lattice-specific ops through a `_BinGeometry` record; the square side is
+`radius·√3` so both shapes share the renderer's LOD picker. Persistence is
+per-shape (`projection.npz` for hex, `projection_{shape}.npz` otherwise);
+`DatasetContext._pyramids` caches per shape.
+
+**Stage 3 — Canvas 2D renderer** (client). Projection↔screen affine transform
+(pan = translate, zoom = scale about cursor); pick the nearest discrete pyramid
+level from the continuous scale. On each viewport change, fetch covering tiles
+(LRU cache, prefetch neighbors + adjacent levels). Draw one filled bin per
+non-empty visible cell, viewport-culled — WebGL is the escape hatch past the
+Canvas 2D ceiling. Density color = `count` → perceptually-uniform ramp on a
+log/sqrt scale, endpoints wired to theme CSS variables. Hover preview is
+media-type-dependent: audio plays via `/api/medias/<id>/audio` (loop, hard-cut,
+debounce, first-click autoplay unlock); text/image/video/document show a
+tooltip/popup. Initial framing fits-to-bounds at the level that best fills the
+viewport.
+
+### Locked decisions
+
+| Decision | Choice | Notes |
+|----------|--------|-------|
+| Dataset scope (v1) | **Single dataset** | One `DatasetContext`; no `X-Dataset-Id`. |
+| Media type | **Any supported** | Hover preview adapts per type. |
+| Bin location | **Server-side tiles** | Viewport-bounded payload; scales to large N. |
+| Frontend packaging | **In-app components** | No second build target; canvas replaces media-list + center panel. |
+| Renderer | **Canvas 2D** | WebGL deferred to the escape-hatch trigger. |
+| Embedding normalization | **App-wide L2 at ingest** | Drop per-comparison normalization. |
+| Canvas point | **Item (clip for audio), not file** | Sibling clips land independently. |
+| Product scope (v1) | **Browse-only** | Pan/zoom/hover-preview. No voting/training/ranking (handoff cut). |
+| Bin color | **Density (count)** | Log/sqrt-scaled; aggregated by the pyramid for free. |
+| UMAP seeding | **Unseeded (fast)** | Safe only because the projection is frozen at ingest. |
+| Projection lifetime | **Frozen at ingest, persisted** | Carve-out from "No Persisted Vectors/MLPs" (coords + pyramid only). Dissolves tile-cache invalidation. |
+| Bin shape | **Fixed by media type** | Square for image/video/document, hex for audio/text; no user toggle. |
+
+### Library-tier placement
+
+UMAP + tiling code is Flask-free in `vtscore/projection/`, covered by
+`./run-tests.sh vtscore-clean`. Browse routes in `vtsearch/routes/` call into it.

--- a/docs/plans/zoneless-migration.md
+++ b/docs/plans/zoneless-migration.md
@@ -1,166 +1,38 @@
 # Zoneless change detection — detailed migration plan
 
-Status: **Phases 0–5 COMPLETE. Production is zoneless (Phase 3 shipped). Phase 4
-browser QA was run live against the GRID instance via Chrome MCP (2026-06-22) and
-PASSED — no staleness bugs on any interactive surface, zero console errors; see
-"Phase 4 — results" below. Phase 5 cleanup is DONE: the no-op `NgZone.run`
-wrappers in `browse-canvas` + `panel-resize.directive` were removed; the
-`vitest-patch` bridge was dropped (all 43 fakeAsync occurrences migrated to native
-`async` + Vitest fake timers); and **all remaining default-TestBed specs were
-migrated to the zoneless `TestBed`, so `zone.js` is now dropped end to end** — the
-`build:test` polyfills array is empty and the `package.json` dependency is gone
-(it remains only as `@angular/core`'s optional peer, never bundled or loaded). The
-final 14 specs (9 fixture-creating contract/container specs + 5 service/guard
-specs that transitively inject NgZone services) now run under
-`provideZonelessChangeDetection()`. `./run-tests.sh frontend` is green (860 tests,
-0 errors).
+**Status: all phases (0–5) shipped; production is zoneless; kept as the
+migration reference.** The provider flip (Phase 3) landed, Phase 4 human browser
+QA passed live against the GRID (2026-06-22, no staleness, zero console errors),
+and Phase 5 cleanup is complete: `zone.js` is dropped end to end (empty
+`build:test` polyfills, removed from `package.json`, surviving only as
+`@angular/core`'s optional peer), all 43 fakeAsync specs run native `async`, and
+`ChangeDetectionStrategy.OnPush` is explicit on all 86 components.
+`./run-tests.sh` is green (5026 passed; `frontend` 860 tests). **No open work
+remains** — this doc is retained for the reusable conversion recipes, the
+zoneless mental model, and the risks/verification guidance that inform any future
+change-detection work.
 
-**Phase 5 is now fully shipped, including the last two items:**
-- **Explicit `ChangeDetectionStrategy.OnPush` on all 86 components. ✅ DONE.**
-  This turned out *not* to be documentation-only: it exposed that two hot
-  services were still `BehaviorSubject`-backed and read non-reactively in the
-  dashboard template (`DatasetStateService` → `datasets`/`loading`/`loaded`/…;
-  `DashboardLoadingTasksService` → `loadingTasks`/`orphanLoadingTasks`/
-  `inlineTaskMap`). Under the old default (CheckAlways) strategy they got "free"
-  repaints on any CD pass; under OnPush the host only re-checks when dirtied, so
-  both services were signalized (Recipe B: private `signal` + value-returning
-  getter that is *tracked* when read in templates, mirroring the Phase-2.5
-  SortState/VoteState pattern). `DatasetStateService` keeps its `$` observables as
-  `toObservable` bridges so the RxJS consumers (context-pulldown, app.component,
-  active-context-watcher, the route guards) are unchanged; `toObservable` emits
-  on the next CD pass rather than synchronously, so four spec files were updated
-  to `TestBed.tick()` past the bridge. `DashboardLoadingTasksService`'s unused
-  `$` observables were dropped.
-- **`vt-modal` `Esc`-to-close fixed. ✅ DONE.** Replaced the never-firing
-  backdrop-scoped `(keydown)` with `@HostListener('document:keydown.escape')`
-  (guarded by `open()`), mirroring the `context-menu` / `browse-bin-popup`
-  pattern, so Esc closes a button-opened modal regardless of focus.**
-
-Detailed history: **Phase 0 shipped (test harness); Phase 1 complete — 1.1 + 1.3 + 1.4
-(ProgressEventsService SSE pump + ConnectionStateService + BrowseSelectionService
-signalized) and 1.2 (KeyboardService de-zoned + the coupled center-panel state
-signalized, i.e. the center-panel slice of Phase 2.3); Phase 2.1 shipped (leaf
-utility components — toast-container, clipboard-copy, voting-overlay,
-dialog-host + VtDialogService, browse-legend); Phase 2.2 shipped (stats + picker
-modals — find/detector/dataset-stats signalized; label-importer signalized +
-moved onto rxResource; settings-importer/exporter + label-exporter mutation-result
-fields signalized); Phase 2.3 shipped (center-panel viewers — image-viewer's
-window drag/key handlers + shake `setTimeout` + `ResizeObserver` rendered-size
-writes signalized; video-player verified DOM-only, no change); Phase 2.4 shipped
-(label-view — its subscribe/timer/effect-written template state signalized and
-the still-Observable `SortStateService`/`VoteStateService` channels it binds
-bridged into signals via `toSignal`); Phase 2.5 shipped (find-view — signalized
-its own subscribe/effect-written state + an `unverifiedSortOrder` computed, and
-**signalized the shared `SortStateService` and `VoteStateService`** so every
-binding of those two services repaints under zoneless with no per-consumer
-bridges; this also migrated right-panel's vote piles → `computed`s,
-center-panel's `goodVotes$`/`badVotes$` subscribes → an `effect`, and dropped
-label-view's `toSignal` bridges); Phase 2.6 shipped (browse cluster —
-browse-view signalized its 13 async/poller/effect-written template fields +
-dropped the divider-drag `ngZone.run`; browse-hover-preview signalized
-`textContent` written from the paragraph `fetch().then()`; browse-selection-panel
-signalized `count`/`viewMode`/`gridGoalWidth`/`sortedEntries` written from the
-selection + settings effects and the metadata `version$` subscribe — fixing a
-latent effect-into-plain-field staleness bug; browse-canvas/-minimap/-bin-popup
-verified safe as-is — canvas-only or already `markForCheck`/`@HostListener`
-disciplined); Phase 2.7 shipped (left-panel + media-list — signalized
-left-panel's effect-written `mediaTypeName`/`textSortAvailable`; media-list's
-`loadingMedias` → `computed`, `markForCheck` for the metadata-hydration
-subscribe, dropped the relayout `zone.run`); **Phases 2.8 + 2.9 shipped**
-(right-panel LabelsetState/settings mirror; context-pulldown via markForCheck;
-dashboard's async/post-await/effect fields; the settings/load-sort/resort/
-new-detector/dataset-importer modals; app.component; plus a pre-flip safety
-sweep that caught export-modal + examples-editor-modal). **All of Phase 2 is
-now complete.** Remaining: Phase 3 (the production flip), Phase 4 (mandatory
-human browser QA), Phase 5 (cleanup).**
-This document
-is the exceedingly-explicit, source-verified plan for taking VTSearch's Angular
-21 frontend off zone.js and onto `provideZonelessChangeDetection()`. It
-supersedes the earlier stub. Every count and file:line reference was checked
-against the code; every Angular API claim was verified against angular.dev / the
-angular source (Appendix C); and the plan itself was adversarially reviewed for
-accuracy, feasibility, and completeness (which added the dialog-service,
-CDK-virtual-scroll, observer-callback, and test-autoDetect items below).
-
-**What shipped (Phase 0).** The Vitest suite can now run any spec under a
-zoneless `TestBed` and catch staleness:
-- `frontend/src/app/testing/zoneless-testbed.ts` — `provideZoneless()` /
-  `configureZoneless()` helpers (per-component opt-in; not enabled globally).
-- `settleZoneless(fixture)` added next to `settleResource()` in
-  `frontend/src/app/testing/settle-resource.ts` (macrotask drain +
-  `whenStable()`, no `detectChanges()`).
-- `frontend/src/app/testing/zoneless-testbed.spec.ts` — reference/canary spec for
-  the 0.3/0.4 pattern; verified to **fail** on a plain-field-write staleness bug
-  and pass on the signal path (the suite is a genuine oracle).
-- Test polyfills decoupled from the prod build via a dedicated
-  `frontend:build:test` configuration in `angular.json` (see the 0.1 correction
-  below). The hand-rolled ProxyZone shim in `test-setup.ts` was replaced by the
-  Angular-maintained `zone.js/plugins/vitest-patch`; all 69 spec files / 767
-  tests pass.
-
-**Correction discovered while implementing 0.1** (the plan as written assumed
-facts that the pinned toolchain did not match):
-- `zone.js/plugins/vitest-patch` ships only in **zone.js ≥ 0.16**, not the pinned
-  `~0.15.0`. Phase 0 bumped `zone.js` to `~0.16.0` (Angular 21.2 peer-depends on
-  `~0.15.0 || ~0.16.0`, so this is in-range).
-- The `@angular/build:unit-test` builder (21.2) has **no `polyfills` option**, so
-  0.1's "give the test target its own `polyfills`" is not literally possible.
-  Equivalent decoupling: a dedicated `build:test` configuration that pins the
-  test polyfills, with the unit-test `buildTarget` pointed at it.
-- `vitest-patch` needs `ProxyZoneSpec`/`SyncTestZoneSpec` (from
-  `zone.js/testing`) to exist at load time, and the builder appends
-  `zone.js/testing` *last*; so the polyfills array lists `zone.js/testing`
-  **before** `vitest-patch`. See Open follow-ups for the Phase-3 implication.
-
-No production code has changed yet; the only thing that shipped alongside the
-original stub was the 540 kB initial-bundle budget bump and the one-component
-`@defer` (the incompatible-pair explainer). The budget is unwound in Phase 3.5.
-
-**Why this plan is unusually careful.** The frontend cannot be run in a browser
-in the Claude-Code-on-the-web container (no Chrome/Chromium), and the failure
+VTSearch's Angular 21 frontend runs on `provideZonelessChangeDetection()` instead
+of zone.js. The migration was unusually careful because the frontend cannot run
+in a browser in the Claude-Code-on-the-web container (no Chrome), and the failure
 mode zoneless introduces — "a value changed but the view silently went stale" —
-is exactly the kind of bug that does *not* show up in a normal headless unit run
-(every component spec today drives `fixture.detectChanges()` by hand, which
-force-renders and therefore *masks* staleness). So the plan front-loads a
-**test-harness phase that makes the Vitest suite able to catch staleness**, and
-treats the production flip as the *last* step, gated behind a human browser-QA
-pass. Every technical assertion below was verified against angular.dev and the
-angular/angular source; the citations live in "Appendix C: verified facts".
+does not show up in a normal headless unit run (component specs drive
+`fixture.detectChanges()` by hand, which force-renders and masks staleness). So
+the effort front-loaded a test-harness phase that made the Vitest suite catch
+staleness, converted the reactivity surface to patterns correct under *both* zone
+and zoneless, and treated the production flip as the last step behind a human
+browser-QA pass. Every Angular API claim below was verified against angular.dev /
+the angular source (see Appendix: verified facts).
 
 ---
 
-## 0. TL;DR / decision
-
-- **Going zoneless is the right end state** (drops the ~35 kB zone.js polyfill,
-  lets the initial-bundle budget fall back toward the framework floor, modern
-  default, cleaner stack traces). But it is an **app-wide change-detection
-  posture change**, not a provider flip: 0 of 86 components are `OnPush` today
-  and ~278 imperative `.subscribe()` sites (≈221 in components) assign to plain
-  fields that zone.js currently repaints "for free".
-- **The migration is incremental and reversible.** Production stays zone-based
-  until a single flip in Phase 3. Phases 1–2 convert the reactivity surface to
-  patterns that are correct under *both* zone and zoneless, so each can ship on
-  its own with zero behavior change while prod is still zoned.
-- **The safety net is built first (Phase 0).** We make the unit suite run its
-  `TestBed` under `provideZonelessChangeDetection()` and assert on the **rendered
-  DOM** after `await fixture.whenStable()` (not on component fields after manual
-  `detectChanges()`). This turns the headless suite into a real zoneless-staleness
-  detector, component by component, *before* prod flips.
-- **The flip + human QA is last (Phases 3–4).** Only after the suite is green
-  under a zoneless `TestBed` across the interactive surfaces do we flip the
-  production provider, and a human must browser-QA the interactive flows before
-  merge.
-
----
-
-## 1. How zoneless changes the rules (the mental model)
+## How zoneless changes the rules (the mental model)
 
 Under zone.js, *any* async callback (timer, XHR, DOM event, promise) triggers a
 global change-detection (CD) pass, so a component can mutate a plain field in any
 callback and the view repaints. Under `provideZonelessChangeDetection()`, **CD
 runs only when something explicitly notifies Angular's scheduler.** The canonical
-list of notifications (verbatim from the official zoneless guide — see Appendix C
-#3) is:
+list of notifications (verbatim from the official zoneless guide) is:
 
 - `ChangeDetectorRef.markForCheck` — **called automatically by `AsyncPipe`**
 - `ComponentRef.setInput`
@@ -168,8 +40,7 @@ list of notifications (verbatim from the official zoneless guide — see Appendi
 - **Bound** host or template listener callbacks (`(click)="…"`, `@HostListener`)
 - Attaching a view that was marked dirty by one of the above
 
-Everything else that used to "just work" no longer schedules CD. The practical
-consequences, each verified (Appendix C):
+Everything else that used to "just work" no longer schedules CD:
 
 | Pattern | Zoneless behavior | Action |
 |---|---|---|
@@ -186,114 +57,29 @@ consequences, each verified (Appendix C):
 | `ngZone.run(() => …)` purely to re-enter Angular for CD | `NgZone` is a `NoopNgZone`; `.run()` **does not** drive CD | ❌ must replace the CD trigger |
 | `ngZone.runOutsideAngular(...)` perf wrapper | harmless no-op; **callable, safe to keep** | ✅ leave as-is |
 
-Two corrections to be explicit about, because earlier informal audits got them
-backwards or over-flagged:
+Two corrections earlier informal audits got backwards:
 
 - **`AsyncPipe` and `markForCheck()` are zoneless-safe.** A `BehaviorSubject.next()`
   fired from inside a raw `addEventListener`/`setTimeout` *does* update an
-  `obs | async` binding, because the pipe calls `markForCheck`, which notifies
-  the scheduler independent of zones. So a service that pushes through a Subject
-  is fine **as long as its consumer reads it via `| async` (or a signal), not via
-  `.subscribe()`-into-a-plain-field.** This is the cheapest conversion lever.
-- **`NgZone.run`/`runOutsideAngular` do not have to be deleted** to be
-  zoneless-compatible (the methods stay callable). What breaks is relying on
-  `.run()` to *cause* a CD pass; that specific purpose must be replaced.
+  `obs | async` binding, because the pipe calls `markForCheck`. So a service that
+  pushes through a Subject is fine **as long as its consumer reads it via `| async`
+  (or a signal), not via `.subscribe()`-into-a-plain-field.** The cheapest lever.
+- **`NgZone.run`/`runOutsideAngular` do not have to be deleted.** The methods stay
+  callable; what breaks is relying on `.run()` to *cause* a CD pass.
 
 ---
 
-## 2. Current state (audited)
+## The conversion recipes (canonical patterns)
 
-Counts are from a full sweep of non-spec `.ts`/`.html` under
-`frontend/src/app` (86 components, ~52 services). See Appendix A for the
-file-level catalog.
-
-**Already zoneless-safe (the head start):**
-
-- **Inputs/outputs are largely modernized.** `output()` is 100% signal-based
-  (62 files, 164 calls; **zero** `@Output()` decorators). Signal `input()` is
-  229 calls across 57 files; 39 files still carry decorator `@Input()` (these
-  work under zoneless — only input *setters* that mutate template state need a
-  look).
-- **Two state services are signal/`rxResource`-driven** (`SettingsStateService`,
-  `MediaStateService`) from the `httpresource-migration.md` work, plus the
-  `left-panel` reads and the importer/exporter picker modals. These are the
-  **reference pattern** for everything else.
-- **Reactive primitives in use:** `signal(` ×8, `computed(` ×9, `effect(` ×20,
-  `rxResource(` ×10. `toSignal`/`toObservable`/`linkedSignal`/`model`/
-  `httpResource` are **not** used yet.
-- **`AsyncPipe` consumers (already safe):** 4 bindings total — `offline-banner`
-  (`connection.status$`, `connection.retrying$`) and `app.component`
-  (`achievements.hasPending$`). These keep working unchanged.
-- **Two components already discipline CD with `markForCheck()`:** `browse-bin-popup`
-  (5 sites) and `icon` (1).
-
-**The risk surface (what must change):**
-
-- **`OnPush` adoption: 0 / 86.** Nothing is written to OnPush discipline today,
-  so every component transitions from "checked on every zone tick" to "checked
-  only when notified".
-- **≈221 `.subscribe()` callbacks in 43 component files** (228 raw component
-  matches; 278 across all non-spec `.ts`) assign to plain template-bound fields
-  with no `markForCheck`/`async` — the bulk of the work.
-  Concentrations: `dashboard` (32), `label-view` (24), `dataset-importer-modal`
-  (22), `find-view` (13), `browse-view` (13), `new-detector-modal` (12),
-  `context-pulldown` (11), `center-panel` (11), `right-panel` (10),
-  `load-sort-modal` (8), the stats/importer/exporter modals (see Appendix A).
-- **NgZone re-entry purely for CD** in 7 files — the hard blockers:
-  `progress-events.service` (the SSE pump), `keyboard.service`, `media-list`,
-  `panel-resize.directive`, `find-view`, `browse-view`, `browse-canvas`. These
-  *will* silently stop triggering CD the moment zone.js is gone.
-- **Timer/promise/raw-listener callbacks mutating template state** (≈ the
-  `setTimeout` reset/flash idioms): `voting-overlay` flashes, `image-viewer`
-  shake + the window drag/key handlers, `center-panel` vote-spin/undo-toast,
-  `settings-modal` "Saved" badge, `toast-container` copied state,
-  `clipboard-copy` button text, `browse-view` build poller, `browse-minimap`
-  resize handle, `browse-hover-preview` fetch, the four "setTimeout(() =>
-  this.close())" modal closers. (Counts: 38 `setTimeout`, 1 `setInterval`, 16
-  `requestAnimationFrame` — most rAF is canvas and safe.) Full list: Appendix A §C.
-- **One `effect()` latent bug pattern** already in the tree: `center-panel`'s
-  constructor effect reads `settingsState.settingsSignal()` and writes **plain**
-  fields (`this.volume`, `this.audioPlaying`, …) bound in the template. Correct
-  under zone today; under zoneless those fields must become signals.
-- **`VtDialogService` holds dialog state in plain fields** (`dialogOpen`,
-  `dialogMessage`, `dialogType`, `dialogShowInput`, `dialogInputValue`,
-  `dialogButtons`) that `dialog-host.component` binds directly, with **no**
-  signal / `markForCheck` / `async` anywhere in the path. `show()` runs
-  synchronously inside `confirm()`/`prompt()`/`confirmDestructive()`. Most call
-  sites invoke these as the first statement of a bound `(click)` handler, so
-  `show()` runs in the click's CD-scheduling stack and is fine — **but** any call
-  made from a `.then()` / post-`await` continuation (e.g.
-  `find-view.component.ts:674` `this.dialog.prompt(...).then(...)`) runs `show()`
-  in a microtask outside any notification, so under zoneless **the dialog would
-  not appear**. This is fragile-by-construction (correctness depends on the
-  caller's stack). Fix defensively: signalize the dialog state (Recipe B) so it
-  is correct from any call context. (Note: `dialog.service.ts` also imports
-  `ApplicationRef`/`createComponent`/`EnvironmentInjector`/`ComponentRef` and
-  declares `modalRef` but **uses none of them** — dead code; drop it while here.)
-- **Raw `ResizeObserver` / `MutationObserver` callbacks** are the same un-patched
-  callback class as raw `addEventListener` (zone.js never patched them either, so
-  this is also latent today on default CD). Three write template-bound state:
-  `browse-legend.component.ts:73` (`MutationObserver` → `this.theme`, read in the
-  colormap key at L92), `image-viewer.component.ts` (`ResizeObserver` →
-  `recomputeRenderedSize` writes `renderedW`/`renderedH` ~L332/341/348, read in
-  region/overlay math), `media-list.component.ts:367` (column-count relayout).
-  The observers feeding
-  only canvas redraws (`browse-canvas`, `browse-minimap`) are Recipe E (safe).
-
----
-
-## 3. The conversion recipes (canonical patterns)
-
-Every site falls into one of these. The recipes are written so the result is
-correct under **both** zone and zoneless, so they can land while prod is still
-zoned.
+Every site falls into one of these. Each is written so the result is correct
+under **both** zone and zoneless (so each could land while prod was still zoned).
 
 ### Recipe A — `subscribe`-into-plain-field → `| async` pipe (cheapest)
 
 When a component subscribes to a service Observable in `ngOnInit` only to mirror
 it into a field the template reads, delete the subscription and bind the
-Observable through `async`. The `AsyncPipe` handles subscribe/unsubscribe and
-calls `markForCheck` on emit.
+Observable through `async` (which handles subscribe/unsubscribe and calls
+`markForCheck` on emit).
 
 ```ts
 // before
@@ -305,16 +91,15 @@ ngOnDestroy() { this.sub?.unsubscribe(); }
 <!-- before -->  @for (t of toasts; track …) { … }
 <!-- after  -->  @for (t of (toastService.toasts$ | async) ?? []; track …) { … }
 ```
-Drop the field, the `sub`, and the `ngOnDestroy` if it was its only user. Use
-this for clean single-source reads (`toast-container`, the stats modals' simple
-cases, list reads not already on `rxResource`).
+Drop the field, the `sub`, and the `ngOnDestroy` if it was its only user. Use for
+clean single-source reads.
 
 ### Recipe B — `subscribe`/`BehaviorSubject` → signal (preferred for hot/shared state)
 
 For service state read in many places, or where you also need synchronous
-"latest value" access, convert the `BehaviorSubject` to a `signal` (mirror the
-`SettingsStateService`/`MediaStateService` pattern). Consumers read the signal in
-the template (or via `computed`); imperative consumers read `sig()`.
+"latest value" access, convert the `BehaviorSubject` to a `signal`. Consumers
+read the signal in the template (or via `computed`); imperative consumers read
+`sig()`.
 
 ```ts
 // service: before
@@ -326,1012 +111,230 @@ readonly status = signal<ConnectionStatus>('online');
 goOffline() { this.status.set('offline'); }
 ```
 Template reads `connection.status()`. A `.set()` from a raw `addEventListener`
-schedules CD because it is a signal write read in a template. For consumers that
-still want an Observable (rare), bridge with `toObservable(sig)`; for the reverse
-(an Observable you must keep, exposed as a signal) use `toSignal(obs$)`.
+schedules CD because it is a signal write read in a template. Bridge with
+`toObservable(sig)` for RxJS consumers, `toSignal(obs$)` for the reverse.
+**Note:** a signal read *through a value-returning getter* during template
+evaluation is still tracked (pinned by
+`frontend/src/app/testing/getter-signal-zoneless.spec.ts`), so
+`sortState.sortBusy` / `voteState.goodVotes`-style getter bindings stay
+byte-for-byte identical yet become reactive — how `SortStateService` /
+`VoteStateService` were signalized without touching a single template.
 
 ### Recipe C — imperative callback → `markForCheck()` (escape hatch)
 
-When a value genuinely must be mutated from a timer/raw-listener and converting
-to a signal is disproportionate, inject `ChangeDetectorRef` and call
-`markForCheck()` after the mutation. Works regardless of `OnPush` and schedules
-CD under zoneless. Prefer A/B; reserve C for local, leaf, animation-ish state
-(e.g. a `setTimeout` that clears a flash class) where a signal is overkill — but
-note a signal is usually *also* clean here, so default to signals and use C only
-where it clearly reads better.
+When a value genuinely must be mutated from a timer/raw-listener and converting to
+a signal is disproportionate, inject `ChangeDetectorRef` and call `markForCheck()`
+after the mutation. Prefer A/B; reserve C for local, leaf, animation-ish state.
 
 ### Recipe D — `ngZone.run()` re-entry → drop the run, trigger CD properly
 
-Remove the `ngZone.run(...)` wrapper (keep any surrounding `runOutsideAngular`,
-which stays harmless). Replace the CD purpose with a **signal write** (best) or
-`markForCheck()`. Outputs emitted from a non-Angular callback (`emit()` inside a
-former `ngZone.run`) need the *parent* to be notified — model the value as a
-signal the parent reads, or `markForCheck` the parent; a bare `output()` emit
-from an unpatched callback will not, by itself, schedule the parent's CD.
+Remove the `ngZone.run(...)` wrapper (keep any surrounding `runOutsideAngular`).
+Replace the CD purpose with a **signal write** (best) or `markForCheck()`.
+**Caveat (corrected):** a bare `output()` emit from an unpatched callback will not
+by itself schedule the *parent's* CD **only if the parent subscribes to it
+imperatively in TS**. A template `(event)` binding is a *bound listener* and *is*
+on the notification path — so the four `setTimeout(() => this.close())` auto-close
+paths needed no rework (proven by
+`frontend/src/app/testing/output-emit-zoneless.spec.ts`).
 
 ### Recipe E — leave canvas rAF / `runOutsideAngular` alone
 
 `requestAnimationFrame` loops that only draw to `<canvas>` (`browse-canvas`,
 `browse-minimap`, `audio-crop-overlay`, the progress-modal chart) need no CD and
-must **not** be "fixed" into triggering it — that would regress performance.
-Likewise `runOutsideAngular` perf wrappers stay; only their inner `.run()`
-re-entries (Recipe D) change.
+must **not** be "fixed" into triggering it (perf regression). `runOutsideAngular`
+perf wrappers stay; only their inner `.run()` re-entries (Recipe D) change.
 
 ### Recipe F — `effect()` writing template-bound state → signalize the field
 
 An `effect()` that writes a plain template-bound field (e.g. `center-panel`'s
 settings mirror) must write a **signal** instead, and the template must read that
-signal. Either make the destination a `signal()` the template calls, or — if the
-source is already a signal — replace the effect+field with a `computed()` and
-read the computed in the template (no effect needed).
+signal. Either make the destination a `signal()`, or — if the source is already a
+signal — replace the effect+field with a `computed()`.
 
 ---
 
-## 4. Phasing
+## Risks & gotchas (carry these into future change-detection work)
 
-Each phase is independently shippable and gated on `./run-tests.sh` (the only CI;
-there is none in GitHub). Phases 1–2 are behavior-neutral under the still-zoned
-production app. Phase 0 must come first; Phase 3 (the flip) must come last.
-
-### Phase 0 — Make the test suite catch zoneless staleness (no production change)
-
-This is the linchpin and the part the original stub correctly flagged as missing.
-Today every component spec calls `fixture.detectChanges()` manually, which
-*force-renders* and therefore stays green even if the real app would go stale.
-We fix the harness so it exercises real zoneless scheduling, **before** touching
-production.
-
-0.1 **Decouple the test target's polyfills from the prod build.** ✅ **DONE.**
-Today the `test` target inherited `polyfills: ["zone.js"]` from `buildTarget:
-frontend:build:development`. The `@angular/build:unit-test` builder has no
-`polyfills` option of its own (its schema rejects it), so the decoupling is done
-with a dedicated **`build:test` configuration** that pins its own polyfills,
-pointed at by the unit-test `buildTarget`. A later removal of zone.js from the
-base production polyfills then cannot silently break fakeAsync:
-```jsonc
-// architect.build.configurations.test
-"test": {
-  "optimization": false,
-  "extractLicenses": false,
-  "sourceMap": true,
-  // testing BEFORE vitest-patch: the patch needs ProxyZoneSpec at load time,
-  // and the builder appends zone.js/testing last, so list it explicitly first.
-  "polyfills": ["zone.js", "zone.js/testing", "zone.js/plugins/vitest-patch"]
-},
-// architect.test.options
-"test": {
-  "builder": "@angular/build:unit-test",
-  "options": {
-    "tsConfig": "tsconfig.spec.json",
-    "buildTarget": "frontend:build:test",
-    "runner": "vitest",
-    "runnerConfig": "vitest.config.ts",
-    "setupFiles": ["src/test-setup.ts"]
-  }
-}
-```
-`zone.js/plugins/vitest-patch` is the documented bridge that keeps
-`fakeAsync`/`tick`/`waitForAsync` working under the Vitest builder (Appendix C
-#7), but it ships only in **zone.js ≥ 0.16**, so Phase 0 bumped `zone.js` to
-`~0.16.0` (in Angular 21.2's `~0.15.0 || ~0.16.0` peer range). It is explicitly a
-**transitional** mechanism — Angular recommends migrating to native `async` +
-Vitest fake timers long-term (deferred; Open follow-ups). The hand-rolled
-ProxyZone shim in `test-setup.ts` was fully subsumed by `vitest-patch` and
-removed **after** confirming all 43 fakeAsync occurrences (11 files) still pass.
-
-0.2 **Add a zoneless `TestBed` helper.** Create
-`frontend/src/app/testing/zoneless-testbed.ts` exporting a providers fragment
-`[provideZonelessChangeDetection()]` (and a small `configureZoneless()` helper).
-Specs opt in as their component migrates (see per-component recipe). Enabling it
-**globally** in Phase 0 would turn the suite red en masse (none of the 221 sites
-are ready yet), so it is adopted **per component, in lockstep with Phases 1–2**.
-
-0.3 **Establish the staleness-catching spec pattern.** For a migrated interactive
-component, its spec must (a) use the zoneless `TestBed`, (b) drive updates through
-the *same channel the app uses* (push to the service subject/signal, dispatch a
-bound event), (c) `await fixture.whenStable()` — **not** `fixture.detectChanges()`
-— and (d) assert on `fixture.nativeElement.querySelector(...)` (rendered DOM),
-**not** on `component.someField`. Rationale (Appendix C #9): `detectChanges()`
-force-runs CD even when Angular would not have scheduled it, masking the exact
-staleness bug; `whenStable()` flushes only *scheduled* CD, so a missing
-notification surfaces as a failing DOM assertion. Add a `settleZoneless()` helper
-next to the existing `settleResource()` if a shared drain is useful.
-
-**Important harness nuance:** adding `provideZonelessChangeDetection()` to a
-`TestBed` flips `ComponentFixtureAutoDetect` **on by default** (it defaults off
-under zone-based TestBeds). That is what makes the canary work — the fixture
-refreshes only what CD actually schedules. The corollary is that the **188
-existing `fixture.detectChanges()` calls (39 files) must be *removed*, not
-supplemented**, as each spec migrates: a leftover manual `detectChanges()` both
-re-masks staleness *and* can throw `ExpressionChangedAfterItHasBeenChecked`
-(NG0100) when it races auto-detect. So the per-component spec migration is
-"add the zoneless provider, delete the manual `detectChanges()` pumps, assert DOM
-after `whenStable()`", not "add provider on top of the existing pumps".
-
-0.4 **Add one "staleness canary" spec per migrated interactive component:** mutate
-the backing value through the production channel **without** any manual CD pump,
-`await whenStable()`, assert the DOM reflects it. This directly exercises the
-scheduling path and fails loudly if a component forgets the signal write /
-`markForCheck`.
-
-0.5 **Keep `isolate: true` and the TestBed cascade guard.** Both are load-bearing
-and become *more* important as specs adopt `whenStable()`/auto-detect (which
-raise the chance of teardown-time `ExpressionChangedAfterItHasBeenChecked` or
-unflushed-resource throws). Do not relax either.
-
-**Phase 0 gate:** `./run-tests.sh frontend` green with the new test polyfills and
-the helper in place (no component migrated yet, so behavior is unchanged); the
-ProxyZone shim either retained or cleanly replaced with all fakeAsync specs
-passing.
-
-### Phase 1 — Signalize the hot shared services (highest leverage)
-
-These three services are read across the whole app and contain the NgZone CD
-re-entries; converting them neutralizes the largest blast radius. Each lands with
-its consumers and specs updated, under zone-based prod (behavior-neutral).
-
-1.1 **`ProgressEventsService` (SSE pump) — the single most important rewrite.
-✅ DONE.** Dropped the `this.zone.run(...)` wrappers in `listen()` and `onopen`
-and removed `NgZone` from the service. The six `BehaviorSubject` channels
-(`dataset`, `loadingTasks`, `detectorLoadingTasks`, `sort`, `find`, `eval`) are
-now `signal`s exposed read-only; a signal write inside the EventSource callback
-notifies the scheduler with no zone. The synchronous latest-value getters became
-signal reads (callable — `loadingTasks()`/`detectorLoadingTasks()`; the unused
-`find` getter was dropped). `votingIterations` is now a `computed`. `serverReset$`
-stays a `Subject` (its only consumer, `dashboard-loading-tasks`, is imperative).
-The many consumers that compose channels with RxJS operators
-(takeUntil/filter/take — `dashboard-loading-tasks`, `toast`, `context-switch`,
-`find-view`, `label-view`, `dashboard`, `progress-modal`) keep their `$`
-observables, now `toObservable` bridges over the backing signals, so a signal
-write still drives them; this is behavior-neutral under the still-zoned prod app.
-Per-component `| async`→signal template reads are deferred to those components'
-Phase 2 conversions. New zoneless staleness canary in
-`progress-events.service.spec.ts` drives an SSE frame through the fake EventSource
-and asserts the rendered DOM repaints with no manual `detectChanges`.
-
-1.2 **`KeyboardService`. ✅ DONE.** Kept the `runOutsideAngular` keydown listener
-(harmless no-op under zoneless, still avoids per-keystroke churn under zone) and
-the injected `NgZone` it needs. Dropped all 10
-`this.zone.run(() => this.action$.next(...))` re-entries — `action$` now emits
-plainly (it stays a `Subject`; the consumer composes it, so a signal would have
-bought nothing). The CD trigger moved to the **consumer** (`center-panel`),
-whose shortcut/timer/HTTP-driven template-bound state was signalized:
-`isVoting`, `volume`, `audioPlaying`, `showAnimations`, `showMetadata`,
-`swipeClass`, `spinningVote`, `undoToastText`, `pendingBadConfirm`, and the
-private `labelHintDismissed`. The Recipe-F settings-mirror `effect()` now writes
-those signals (`.set()`) instead of plain fields, fixing the latent
-plain-field-write trap in one stroke. This is the center-panel slice of Phase
-2.3; `image-viewer`/`video-player` remain for the rest of 2.3. New zoneless DOM
-canary `center-panel.zoneless.spec.ts` drives a real `keydown` through the live
-`KeyboardService` listener (an un-bound document callback) and asserts the vote
-renders + the undo toast appears with no manual `detectChanges`; the existing
-contract spec was updated to the signal accessors.
-
-1.3 **`ConnectionStateService`. ✅ DONE.** Converted `statusSubject`/
-`retryingSubject` to signals exposed read-only (`status`/`retrying`, backed by
-private `_status`/`_retrying` writables, so only the service flips them). The
-`offline`-event raw listener's `goOffline()` and the interceptor's
-`recordSuccess`/`recordNetworkFailure` now schedule CD via the signal write. The
-`offline-banner` template dropped `| async` for `status()`/`retrying()` signal
-reads (and lost its now-unused `CommonModule` import). The sole observable
-consumer, `ProgressEventsService`, replaced its `status$.pipe(distinctUntilChanged())`
-constructor subscription with an `effect(() => …connection.status()…)` (signals
-are distinct by default). The `errorInterceptor` is untouched — it only uses the
-imperative methods (`isOffline`/`recordSuccess`/`recordNetworkFailure`), which
-keep working. New `offline-banner.component.spec.ts` is a zoneless DOM canary
-driving the breaker through `recordNetworkFailure`/`recordSuccess`/`retry()`.
-
-1.4 **`BrowseSelectionService` (`changed$`). ✅ DONE.** Replaced the `changed$`
-`Subject` with a signal: the existing `_version` counter became
-`signal(0)`/`bump()` and is exposed as a read-only `version` signal. The three
-consumers were converted off `.changed$.subscribe(…)`: `browse-canvas` repaints
-via an `effect(() => { selection.version(); requestRedraw(); })` (its `selStateFor`
-memo now reads `version()`), and `browse-bin-popup` / `browse-selection-panel`
-react via an `effect` on `version()` (popup keeps its `markForCheck` discipline;
-panel re-runs `refreshSelection`). New `browse-selection.service.spec.ts` adds a
-unit spec for the selection logic plus a zoneless signal-driven view canary.
-
-**Phase 1 gate:** each service's spec + its consumers' specs migrated to the
-zoneless `TestBed` (Recipe in 0.3) and green; `./run-tests.sh` full pass.
-
-### Phase 2 — Convert components, cluster by cluster
-
-Order by route so each cluster is shippable and QA-able as a unit. For every
-component: apply Recipe A/B/C/D/F as appropriate, switch its spec to the zoneless
-`TestBed` with DOM assertions (0.3) + a canary (0.4), and confirm red→green.
-
-Suggested order (lightest/most-isolated first to build confidence):
-
-1. **Leaf utility components. ✅ DONE (Phase 2.1).** `toast-container` binds
-   `toasts$` via `| async` (Recipe A) and `copiedId` became a signal;
-   `clipboard-copy`'s `buttonText` flash became a signal (it is set from a
-   post-`await` continuation *and* a timer — the exact zoneless-sensitive path);
-   `voting-overlay`'s `goodFlash`/`badFlash` became signals and its `@Input()`
-   decorators were modernized to `input()`; `field-hint-icon` was already
-   signal-based (no change); `dialog-host` + **`VtDialogService`** had all dialog
-   state (`dialogOpen`/`dialogTitle`/`dialogMessage`/`dialogType`/
-   `dialogShowInput`/`dialogInputValue`/`dialogButtons`) signalized so a
-   `confirm`/`prompt` opened from a non-event callback still schedules CD, and the
-   dead `ApplicationRef`/`createComponent`/`EnvironmentInjector`/`modalRef` code
-   was dropped; `browse-legend`'s `theme` became a signal driven by the
-   `data-theme` `MutationObserver`. Each spec now runs under the zoneless
-   `TestBed` (`configureZoneless` + `settleZoneless`, no manual `detectChanges`)
-   with a staleness canary; new specs added for `toast-container`,
-   `clipboard-copy`, and `browse-legend`.
-2. **Stats / picker modals. ✅ DONE (Phase 2.2).** `find-stats`/`detector-stats`/
-   `dataset-stats` signalized `loading`/`error`/`stats` (Recipe B; templates use
-   `@else if (stats(); as stats)`). `label-importer` moved its list read onto an
-   eager `rxResource` and signalized all its subscribe-written fields (mutation
-   results + the dynamic-field-option dicts). `settings-importer`/
-   `settings-exporter`/`label-exporter` were already on `rxResource`+signals;
-   their `submitting`/`successMessage` mutation-result fields were signalized to
-   finish them. The four `setTimeout(close)` paths needed no change — a
-   template-bound `(closed)` output emit schedules the parent's CD under zoneless
-   (proven by `testing/output-emit-zoneless.spec.ts`; see Open follow-ups). Each
-   has a zoneless DOM-canary spec.
-3. **`center-panel` + viewers. ✅ DONE (Phase 2.3).** The center-panel voting
-   state shipped with Phase 1.2. Phase 2.3 finished the viewers: `image-viewer`
-   signalized the seven fields written from un-patched callbacks — `regionBox`,
-   `shiftHeld`, `panX`/`panY` (window `mousemove`/`mouseup` drag + `keydown`/
-   `keyup`/`blur` listeners), `renderedW`/`renderedH` (the `ResizeObserver`
-   rendered-size writes), and `regionBoxShake` (the shake `setTimeout`); its
-   getters (`imageTransform`/`regionBoxStyle`/`regionDrawActive`/`wrapCursor`)
-   now read those signals and stay plain getters (so the contract spec keeps
-   reading them without `()`). `zoom`/`rotation`/`zoomLabel`/`marqueeMode`/
-   `highlightMode`/`imageReady`/`imageSrc` stayed plain — they are written only
-   from bound handlers / `ngOnChanges`, which already schedule CD, and the parent
-   `center-panel` reads `marqueeMode`/`highlightMode`/`zoom`/`zoomLabel` only via
-   bound-event-driven re-checks. `video-player` was verified DOM-only and left
-   unchanged: its `videoSrc`/`videoError` are written only in `ngOnChanges` and
-   the bound `(error)` handler, and the `setInterval` clip-loop only writes
-   `video.currentTime` (a DOM property, not template state); `(loadedmetadata)`/
-   `(play)`/`(pause)`/`(error)` are bound listeners. The existing image-viewer
-   contract spec was updated to the signal accessors (kept on the default
-   TestBed, mirroring the center-panel split); a new
-   `image-viewer.zoneless.spec.ts` canary drives a real window `keydown`/`keyup`/
-   `blur` (Shift) through the live constructor listener and asserts the
-   `.region-mode` crosshair affordance repaints with no manual `detectChanges`.
-4. **`label-view`. ✅ DONE (Phase 2.4).** Signalized every template-bound field
-   written from a non-CD-scheduling context: `datasetName`, `labelingStatus`
-   (status-polling timer), `trainableModelName`, `leftWidth`/`rightWidth` (the
-   settings-mirror `effect()` — Recipe F), `autopilotCollapsed`,
-   `autopilotEnabled`, `showResortPrompt`, and `cropPending` (set from a
-   `fetch().then()` continuation — the un-bound microtask path). The two
-   constructor `effect()`s now read only their intended tracked signals and run
-   the rest `untracked`, because `applyPanelPx`/`setAutopilotCollapsed` both read
-   *and* write the width/collapse signals (an `effect` that reads a signal it
-   also writes would loop, and would spuriously revert a manual collapse toggle
-   on stale settings). label-view also binds `SortStateService` (11 reads) and
-   `VoteStateService` (good/bad votes, label counts, derived
-   `learnedSortAvailable`) getters directly in its template; those services stay
-   `BehaviorSubject`-backed (un-signalized, per the per-cluster plan and the
-   center-panel precedent of not signalizing shared services mid-migration), so
-   label-view bridges the channels it binds into local signals via
-   `toSignal(…$, { requireSync: true })` (a `computed` for `learnedSortAvailable`)
-   — the cheapest way to make those reads repaint under zoneless without
-   touching the shared services or the not-yet-migrated find-view/right-panel
-   consumers. The learned-sort `setTimeout` needed no change beyond the bridge:
-   it writes only the private `learnedSortPending` guard and re-fires
-   `onLearnedSort`, whose sortState writes now repaint via the bridge. New
-   `label-view.zoneless.spec.ts` canary drives the `/api/dataset/status`
-   subscribe (an un-bound callback) and asserts the left panel's `.dataset-name`
-   header repaints with no manual `detectChanges`; the existing contract spec was
-   updated to the signal accessors (kept on the default TestBed, mirroring the
-   center-panel/image-viewer split).
-5. **`find-view`. ✅ DONE (Phase 2.5).** Signalized its own subscribe/effect-written
-   template state (`datasetName`, `viewModeLeft`/`gridGoalWidthLeft`/`focusModeLeft`/
-   `focusModeRight`) and replaced the `combineLatest(sortOrder$, verifiedIds$)`
-   subscribe with an `unverifiedSortOrder` `computed`. The four divider-drag
-   `ngZone.run` re-entries were dropped outright (the widths only drive `--left-width`/
-   `--right-width` CSS custom properties imperatively — not template-bound — so no
-   CD is needed); `runOutsideAngular` on the listeners stays. The two `.then`
-   confirm flows route through HTTP and were already safe. As the centerpiece of
-   2.5, `SortStateService`/`VoteStateService` were signalized (see Open follow-ups),
-   so find-view's `sortState.*` getter bindings became reactive with **zero**
-   template churn. New `find-view.zoneless.spec.ts` canary drives the
-   `/api/dataset/status` subscribe AND a `SortStateService` setter and asserts the
-   DOM repaints with no manual `detectChanges`.
-6. **Browse cluster. ✅ DONE (Phase 2.6).** `browse-view` signalized its 13
-   template-bound fields written from async subscribes / the build poller / the
-   settings `effect()` (`status`, `meta`, `mediaType`, build progress/total/
-   message, `errorMessage`, `panelWidth`, `colormap`, `thumbnailBorder`,
-   `hexScaleIndex`, `binShape`, `datasetName`); the divider-drag `ngZone.run`
-   was dropped (panelWidth is a signal — its `.set()` schedules CD from the
-   out-of-zone mousemove listener under both zoned and zoneless, mirroring the
-   Phase 1.1 SSE-pump precedent). `browse-hover-preview` signalized `textContent`
-   (written from the paragraph `fetch().then()` microtask). `browse-selection-panel`
-   signalized `count`/`viewMode`/`gridGoalWidth`/`sortedEntries` — these were
-   written from the selection-refresh + settings `effect()`s and the metadata
-   `version$` subscribe, and the effect-into-plain-field writes were a **latent
-   staleness bug** (Recipe F). `browse-canvas`, `browse-minimap`, and
-   `browse-bin-popup` were verified zoneless-safe **as-is** and left unchanged:
-   browse-canvas has no template-bound plain fields (its `ngZone.run`-wrapped
-   output emits / `selection.*` calls are harmless no-ops under zoneless and
-   load-bearing under the still-zoned prod, so they stay until Phase 5);
-   browse-minimap's `width`/`height` feed only the canvas (not template-bound);
-   browse-bin-popup is already `markForCheck`-disciplined and its drag is on
-   `@HostListener` (a bound host listener, on the zoneless notification path).
-   New zoneless canaries: `browse-selection-panel.zoneless.spec.ts` (selection
-   signal bump + metadata `version$` emit), `browse-hover-preview.zoneless.spec.ts`
-   (async fetch resolves), `browse-view.zoneless.spec.ts` (projection-load
-   subscribe errors → error-state repaint).
-7. **`left-panel` + `media-list`. ✅ DONE (Phase 2.7).** `media-list`:
-   `loadingMedias` (a plain field written from a constructor `effect()` — Recipe F)
-   → a `computed` over `mediaState.isLoading()`; added `cdr.markForCheck()` at the
-   end of `rebuildOrderedItems()` so the list repaints from the async
-   `metadataCache.version$` subscribe (the `cachedOrderedItems`/`gridRows` arrays
-   stay plain — hot virtual-scroll state, repainted via the markForCheck); dropped
-   the `zone.run(...)` wrapper around the relayout `cdr.detectChanges()`
-   (`detectChanges` is zone-independent). `left-panel`: signalized `mediaTypeName`
-   + `textSortAvailable`, plain template-bound fields written from constructor
-   `effect()`s reacting to late-arriving media-type/embedder metadata (Recipe F).
-   `panel-resize.directive` was left as-is: its `ngZone.run`-wrapped
-   `widthChange`/`resizeEnd` emits are no-ops under zoneless, and the emit → the
-   parent label-view's `(widthChange)`/`(resizeEnd)` handler writes the
-   signalized `leftWidth`/`rightWidth` (Phase 2.4), which schedules CD and
-   rechecks the directive's `[class.dragging]` host binding. (No new canary: the
-   effect→signal fix is proven by the identical browse-selection-panel canary and
-   the `left-panel` container deadlocks `whenStable()` via its media-grid
-   rxResources; the existing specs cover behavior.)
-8. **`right-panel`, `context-pulldown`, `dashboard`, the modals. ✅ DONE
-   (Phase 2.8).** `right-panel`: signalized the `LabelsetStateService` mirror
-   (`goodElements`/`badElements`/`currentMediaType` from `good$`/`bad$`/`mediaType$`)
-   and the settings-derived `viewMode`/`gridGoalWidth` (the settings `effect()`
-   was a Recipe-F write). `context-pulldown`: used **Recipe C** (markForCheck) at
-   its three async entry points — `rebuildRows()` (driven by the registry
-   `datasets$`/`detectors$`/`intentPair$`/`sortState$`/`busyPairs$` subscribes,
-   which the first audit wrongly marked safe), the `error$` subscribe, and
-   `openMenu()` (driven by `openSignal$`) — because its `focusedIndex` keyboard-nav
-   arithmetic reads cleaner as a plain field than a signal. `dashboard`:
-   signalized the template-bound fields written from async contexts —
-   `currentUser`/`isDefaultLogin` (auth `status$`), `trainLoading`/`findLoading`
-   (router events), `diskUsage`/`ramUsage` (10s timers),
-   `importerClosing`/`newDetectorClosing` (flow subscribes), the per-row +
-   bulk **delete-confirm flags** and `deletingDatasetId`/`deletingDetectorId`
-   (written from **post-`await dialog.confirmDestructive()` continuations** — an
-   unpatched microtask path), and `serverSetsAgeOff` (settings `effect()`,
-   Recipe F). `progressValue`/`progressTotal`/`progressIndeterminate` and
-   `visibleImporters` were found to be **write-only / not template-bound** and
-   left plain. `settings-modal` (forkJoin init → signals incl. the `settings`
-   object via `.update(s => ({...s, …}))` so the new reference notifies; "Saved"
-   badge timer → signal), `load-sort-modal`, `resort-prompt-modal`,
-   `new-detector-modal`, `dataset-importer-modal` (heaviest; subscribe/`.then`-
-   written list + mutation-result + example/demo state → signals).
-9. **`app.component`. ✅ DONE (Phase 2.9).** Signalized `isOnLabelView` (router
-   events), `showAchievements` (`openPanelRequest$` + handlers), `achievementsDisabled`
-   (settings `effect()`, Recipe F), `showIncompatibleExplainer` (written from
-   `recomputeExplainer()`, which runs from the router-events and pair/registry
-   `combineLatest` subscribes — the first audit wrongly marked it safe), and
-   `importerFlow`/`newDetectorFlow`/`recentSessions` (flow + sessions subscribes).
-   **Pre-flip safety sweep** additionally caught `export-modal` (`status`/`submitting`)
-   and `examples-editor-modal` (`error`/`status`), both mutation-result fields
-   written from POST subscribes.
-
-**Phase 2 gate (per cluster):** the cluster's specs run under the zoneless
-`TestBed`, assert on the DOM, include canaries, and pass; `./run-tests.sh` full
-pass. After the *whole* of Phase 2, **every interactive component spec asserts
-DOM under a zoneless `TestBed`** — that is the readiness bar for Phase 3.
-
-### Phase 3 — Flip production to zoneless ✅ DONE
-
-Shipped: `app.config.ts` now uses `provideZonelessChangeDetection()`;
-`angular.json`'s base `build` polyfills array is empty (`[]`) — the `build:test`
-configuration keeps its own `zone.js`/`zone.js/testing`/`vitest-patch`, so
-fakeAsync specs are unaffected; the initial budget was tightened 540kB → 500kB
-(the measured eager bundle fell 527kB → **488kB** once zone.js left the polyfills,
-a ~39kB raw / ~12kB transfer drop). Three obsolete Python tests asserting a
-`polyfills.js` bundle (which a zoneless build no longer emits) were removed and
-the `catch_all` static-route docstring updated (OpenAPI snapshot regenerated).
-`./run-tests.sh` full suite green (4919 passed). **This is the only production
-behavior change; it is gated on the Phase 4 human browser QA below before merge.**
-
-Original step list, for the record:
-
-3.1 In `frontend/src/app/app.config.ts`, replace
-`provideZoneChangeDetection({ eventCoalescing: true })` with
-`provideZonelessChangeDetection()`. Note the current provider's
-`eventCoalescing: true` is **not** silently lost: zoneless schedules CD (it does
-not run per-event), so event coalescing is the default behavior — if anything the
-flip preserves/improves it. Still, re-verify the high-frequency drag handlers
-(`find-view`, `browse-view`, `image-viewer`, `browse-minimap`) in Phase 4, since
-they previously leaned on coalesced single-CD-per-frame.
-
-3.2 In `frontend/angular.json`, remove `"zone.js"` from the **base** `build`
-options `polyfills` (the production array). Leave the **`build:test`
-configuration's** polyfills (set in 0.1) untouched — tests still need zone.js +
-`zone.js/testing` + `vitest-patch` for fakeAsync. Because `build:test` pins its
-own array, it is already decoupled and needs no change at the flip.
-
-3.3 Keep `zone.js` in `package.json` (the test run imports it). It is no longer
-bundled into prod because it is out of the build polyfills; no `npm audit`
-concern (zone.js has no advisories).
-
-3.4 Re-run `./run-tests.sh` (full). Expect possibly a handful of
-`ExpressionChangedAfterItHasBeenChecked` surfacing now that CD timing is stricter;
-fix them (CLAUDE.md "Fix All Errors" — no waving off).
-
-3.5 **Budget:** with zone.js gone (~35 kB raw / ~11 kB transfer), drop the
-initial budget from 540 kB back toward the framework floor (~495 kB), tightening
-to the real measured size with a small headroom, and delete the `"//"` rationale
-block in `angular.json` that points here. Do not pre-commit a number — measure
-the post-flip `build:prod` initial size and set warn just above it.
-
-**Phase 3 gate:** `./run-tests.sh` full pass; `build:prod` clean (0 `▲ [WARNING]`)
-under the new budget.
-
-### Phase 4 — Human browser QA (mandatory, cannot be skipped)
-
-The container has no browser; the unit suite (even hardened) cannot 100% prove
-real rendering. A human runs `python app.py --local`, builds the frontend, and
-exercises every interactive surface, watching specifically for "stale until I
-click" symptoms:
-
-- Voting (good/bad, keyboard shortcuts, undo/redo, vote spinner, swipe anim).
-- Sorting / autopilot (sort bar, progress bars driven by SSE).
-- Train-and-score / find (eval progress modal, find progress).
-- Dataset load progress (loading-tasks bars), offline banner + Retry.
-- Browse canvas (pan/zoom, hover preview, bin popup, selection panel, minimap).
-- All modals (open/close, the four `setTimeout(close)` paths, "Saved" badge,
-  copied-to-clipboard text, importer/exporter flows).
-- Left/right panel resizers (drag widths), context pulldown, dashboard lists,
-  new-detector + importer modals.
-- **Confirm/prompt dialogs** triggered from non-click paths (e.g. find-view's
-  rename-after-`.then`), to prove the signalized `VtDialogService` opens reliably.
-- **CDK virtual-scroll viewports** (`left-panel/media-list`, `browse-bin-popup`):
-  scroll fast and check for item flicker / blank rows / stale viewport — a known
-  zoneless interaction the jsdom suite cannot see (see Framework-surface notes).
-
-A checklist version of the above goes in the PR description for the QA pass.
-
-#### Phase 4 — results (2026-06-22, run live against the GRID via Chrome MCP)
-
-The container still has no browser, but the GRID was running the zoneless build
-(`dev` @ `2d16afe4`; confirmed `provideZonelessChangeDetection()`, 0 zone.js
-markers in the bundle). Drove it through an SSH tunnel with a real Chrome.
-**Result: every staleness-prone surface repaints correctly; no "stale until I
-click" anywhere; zero console errors/warnings the whole session.** Highlights:
-
-- **SSE pump (1.1):** dataset + detector **load-progress bars animated live**;
-  voting triggered **retrain → re-sort → minimap repaint** with no manual action.
-- **Timers (2.8):** dashboard RAM/Disk gauges **ticked on their own** (691→690→692).
-- **De-zoned `KeyboardService` (1.2):** `←` (raw `document` keydown) voted Bad,
-  Bads 105→106; `Ctrl+Z` undo reverted it. Click-vote moved Goods 7→8 + advanced.
-- **Signals:** right-panel vote piles, find-view unverified counts (393/19),
-  browse selection panel (0→66→0) all repainted.
-- **`ConnectionStateService` (1.3):** offline banner appeared on real network-off,
-  **Retry** cleared it on reconnect.
-- **`VtDialogService` (2.1):** destructive delete-confirm rendered + cancelled.
-- **CDK virtual scroll (4.5):** media-list fast-scroll — 0 blank/broken rows.
-- **Browse canvas (2.6):** projection render, bin select, hover preview, minimap.
-- **Modals (2.2):** stats / settings (forkJoin init + auto-save badge) / help.
-
-Covered transitively (mechanism proven above, not separately exercised):
-sort/autopilot + train-and-score eval progress bars (same SSE pump);
-clipboard-copy flash, importer/exporter modals, the four `setTimeout(close)`
-paths; the divider resizers (CSS-var only); confirm/prompt opened from a
-`.then`/microtask (`VtDialogService` is signalized + microtask signal-writes were
-seen to repaint). The one bug found (`vt-modal` `Esc` focus) is pre-existing and
-unrelated to zoneless — see Open follow-ups.
-
-### Phase 5 — Cleanup / follow-ups
-
-- **Migrate the residual fakeAsync/timer specs to native `async` + Vitest fake
-  timers and drop `zone.js/plugins/vitest-patch`. ✅ DONE.** All 43 fakeAsync
-  occurrences (11 files) now use native `async` tests: timer-delay cases
-  (vote/browse-prep pollers, progress-modal's 50 ms) use `vi.useFakeTimers()` +
-  `vi.advanceTimersByTimeAsync(...)`; microtask/macrotask drains (dialog
-  promises, focus `setTimeout`s, the `timer(0,…)` poll first-emissions) use a
-  real macrotask flush (`await new Promise(r => setTimeout(r))`). `zone.js/testing`
-  and `zone.js/plugins/vitest-patch` are removed from the `build:test` polyfills,
-  and the ProxyZone-bridge note in `src/test-setup.ts` is gone. Full Vitest suite
-  green (854 passed / 91 files).
-- **Migrate the remaining default-TestBed specs to the zoneless `TestBed` and
-  drop `zone.js` entirely. ✅ DONE.** The last 14 specs that needed `NgZone` from
-  a default zone-based TestBed were migrated to `provideZonelessChangeDetection()`
-  (via the `provideZoneless()` / `configureZoneless()` helpers): the 9
-  fixture-creating contract/container specs (`app.component`, `center-panel`,
-  `document-viewer`, `image-viewer`, `dashboard`, `label-view`, `left-panel`,
-  `media-list`, `right-panel`) plus the 5 service/guard specs that transitively
-  inject NgZone services (`keyboard.service`, `browse-prep.service`,
-  `context-switch.service`, `active-context-watcher.service`,
-  `active-context.guard`). With every fixture-creating spec on the zoneless
-  TestBed, `zone.js` was removed from the `build:test` polyfills (now `[]`) and
-  from `package.json` (it remains only as `@angular/core`'s optional peer, never
-  bundled or loaded). `./run-tests.sh frontend` green (858 tests, 0 errors).
-  Conversion patterns learned (these contract/container specs are paired with the
-  Phase-1/2 `.zoneless.spec.ts` canaries, so the goal here was zone.js removal,
-  not turning them into staleness oracles):
-  - **Initial render:** `fixture.detectChanges()` → `TestBed.tick()` (the
-    scheduled CD mechanism; no autoDetect race). For rxResource-backed init keep
-    the existing `TestBed.tick()` + `settleResource()` (a loading resource
-    deadlocks `whenStable()`).
-  - **Re-render after a change:** under zoneless `TestBed.tick()` only re-checks
-    *dirty* views, so a post-init change must mark the host dirty first — drive
-    `@Input()` changes through `fixture.componentRef.setInput(...)` and internal
-    state changes through the real bound `(event)` (e.g. clicking a tab button).
-    For BehaviorSubject-backed state read non-reactively (dashboard ↔
-    `DatasetStateService`), `fixture.changeDetectorRef.markForCheck()` + `tick()`.
-  - **Dev-only NG0100:** the three `center-panel` image-media tests keep
-    `fixture.detectChanges(false)` to skip the check-no-changes verify pass for
-    the `imageViewer` ViewChild that settles mid-first-pass.
-  - **Zoneless async leaks:** without zone.js the framework no longer auto-cleans
-    the app's timers/microtasks; an SSE poller's `timer(0, N)` first emission or a
-    root-singleton rxResource reload can fire on a macrotask *after* teardown and
-    throw NG0205 through the destroyed injector. label-view's `afterEach` now
-    destroys the fixture, stops `VoteStateService` polling, and drains one
-    macrotask (while the injector is still alive) to absorb the straggler. A
-    *global* drain in `test-setup.ts` was tried first but rejected: it let a
-    pending autoDetect re-check teardown-state leaf components (audio/video-player
-    with `media` undefined) and crash their templates.
-- Adopt `ChangeDetectionStrategy.OnPush` explicitly on components. **✅ DONE —
-  all 86 components.** Expected to be documentation/intent, but it surfaced a
-  real gap: components reading a *non-signal* `BehaviorSubject` service getter
-  directly in their template (the dashboard ↔ `DatasetStateService` /
-  `DashboardLoadingTasksService`) relied on the default CheckAlways strategy for
-  "free" repaints. Under OnPush the host only re-checks when dirtied, so those
-  two services were signalized (Recipe B; private `signal` + value-returning
-  getter, which is tracked when read during template evaluation — the same
-  getter-signal trick proven for SortState/VoteState in Phase 2.5). The blanket
-  add was mechanical (`changeDetection: ChangeDetectionStrategy.OnPush` as the
-  first `@Component` property + the `@angular/core` import). `DatasetStateService`
-  retained its `$` observables as `toObservable` bridges (RxJS consumers
-  unchanged); since `toObservable` emits on the next CD pass rather than
-  synchronously like a `BehaviorSubject`, the dashboard / active-context-watcher /
-  active-context-guard / dataset-state service specs gained `TestBed.tick()`
-  calls past the bridge. Full suite green (`./run-tests.sh` 5026 passed;
-  `./run-tests.sh frontend` 860 tests).
-
-### Open follow-ups
-
-- **Phases 0–3 COMPLETE. Remaining: Phase 4 (mandatory human browser QA) and
-  Phase 5 (optional cleanup).** Production is now zoneless. The whole reactivity
-  surface (2.1–2.9) was converted to be correct under both zone and zoneless,
-  the provider was flipped (Phase 3), and `./run-tests.sh` is green (4919 passed).
-  The headless suite cannot 100% prove real rendering, so a human MUST run the
-  Phase 4 browser QA before this merges — see the checklist in §Phase 4 / the PR
-  body. **Phase 5 cleanup (separable, no behavior change):**
-  - **Drop the now-no-op `ngZone.run(...)` wrappers. ✅ DONE.** Removed all 8 in
-    `browse-canvas` (hexHover/contextMenu/densityMaxChanged emits + the
-    `selection.toggleBin`/`addAll` calls) and both in `panel-resize.directive`
-    (`widthChange`/`resizeEnd` emits). Verified the consumers are on the zoneless
-    notification path before removing: browse-view binds `(hexHover)`/
-    `(contextMenu)`/`(densityMaxChanged)` and label-view binds `(widthChange)`/
-    `(resizeEnd)` via **template `(event)` listeners** (which schedule CD), and
-    `BrowseSelectionService` is signal-backed (Phase 1.4) so its writes schedule
-    CD on their own. The `NgZone` injection **stays** in both — still used by the
-    `runOutsideAngular` perf wrappers, which are kept. `build:prod` clean (initial
-    489.34 kB < 500 kB budget); full Vitest suite green (854 passed / 91 files).
-  - **`vt-modal` `Esc`-to-close is focus-scoped (pre-existing, NOT zoneless).
-    ✅ FIXED.** Surfaced during Phase 4 QA: opening any `vt-modal` from a button
-    leaves focus on that button, and the modal's `Esc` handler was a plain
-    `(keydown)` on the `.modal-backdrop` div, which is never programmatically
-    focused on open — so `Esc` did nothing until the user clicked/tabbed into the
-    modal. Fixed by moving the handler to `@HostListener('document:keydown.escape')`
-    on `ModalComponent` (guarded by `open()`), mirroring the existing
-    `context-menu` / `browse-bin-popup` `document:keydown.escape` pattern; the
-    backdrop `(keydown)` was removed so it can't double-emit `closed`. The
-    focus-the-backdrop alternative was rejected because several modals use
-    `autofocus` / programmatic input focus that it would fight. Two regression
-    canaries added to `modal.component.spec.ts` (Esc dispatched at `document`
-    level closes an open modal; Esc is inert when closed).
-  - **Migrate the remaining specs to the zoneless `TestBed`** + DOM-after-
-    `whenStable()` assertions and delete the manual `fixture.detectChanges()`
-    pumps. **✅ DONE — all fixture-creating specs now run under the zoneless
-    TestBed and `zone.js` is dropped end to end (empty `build:test` polyfills +
-    removed from `package.json`).** First the tractable leaf/modal/list specs (22
-    spec files) migrated to `provideZoneless()` +
-    `settleZoneless()`/`setInput()`/`TestBed.tick()` (no manual `detectChanges`):
-    `progress-bar`, `select-mode`, `inclusion-slider`, `stripe-overview`,
-    `label-sort`, `media-item`, `audio-player`, `video-player`, `text-viewer`,
-    `progress-indicators`, `detector-context-bar`, `modal`, `sort-bar`,
-    `autopilot-panel`, `dataset-card`, `detector-card`, `load-sort-modal`,
-    `autodetect-results-modal`, `autodetect-progress-modal`, `settings-modal`,
-    `export-modal`, `progress-modal`, `new-detector-modal`, `examples-editor-modal`,
-    `combine-datasets-modal`, `dataset-importer-modal`, `label-list`. Pattern notes:
-    drive `@Input`/signal inputs through `componentRef.setInput()` (a CD trigger,
-    so a plain field write on a top-level fixture host won't schedule CD — the
-    `modal` host uses signals); plain `ngOnInit` HTTP subscribes don't block
-    `whenStable()` so `settleZoneless()` works, but **rxResource-backed init must
-    use `TestBed.tick()` + `settleResource()`** (a loading resource holds the app
-    unstable and deadlocks `whenStable()`). This pass also surfaced and **fixed
-    five real zoneless staleness bugs** the oracle exposed — plain fields written
-    from HTTP `.subscribe()` callbacks yet read in the template, now signals
-    (Recipe B): `text-viewer.text`, `autodetect-results-modal`
-    (`exporters`/`selectedExporter`/`exporterFields`), `examples-editor-modal`
-    (`examples`/`loading`/`saving`), `combine-datasets-modal`
-    (`mediaTypes`/`submitting`/`error`), and `label-list.sortedEntries` (rebuilt
-    from the `metadataCache.version$` subscribe).
-    **Then the hard classes (now also DONE):** the contract specs paired with a
-    `.zoneless.spec.ts` canary (`label-view`, `center-panel`, `image-viewer`),
-    the heavy containers (`app.component`, `right-panel`, `left-panel`,
-    `media-list`, `dashboard`), the `document-viewer` contract spec, and the 5
-    service/guard specs that transitively inject NgZone services
-    (`keyboard.service`, `browse-prep.service`, `context-switch.service`,
-    `active-context-watcher.service`, `active-context.guard`). Since these are
-    contract/container specs (the canaries are the staleness oracles), they use
-    `TestBed.tick()`/`setInput()`/bound-event/`markForCheck()` to drive renders
-    rather than a strict DOM-after-`whenStable()` rewrite. See the Phase 5
-    section above for the full conversion-pattern notes (initial render,
-    re-render-after-change, dev-only NG0100, zoneless async leaks). **With this
-    done, `zone.js` was removed from the `build:test` polyfills and
-    `package.json` — the migration is complete.**
-  - **Drop the `vitest-patch` bridge. ✅ DONE.** Converted all 43 fakeAsync
-    occurrences (11 files) to native `async` + Vitest fake timers and removed
-    `zone.js/testing` + `zone.js/plugins/vitest-patch` from the `build:test`
-    polyfills. Base `zone.js` has now **also** been removed (from both the
-    `build:test` polyfills and `package.json`) — see the TestBed-migration item
-    above; it survives only as `@angular/core`'s optional peer. Full Vitest suite
-    green.
-  - **Adopt explicit `ChangeDetectionStrategy.OnPush`** on components for intent
-    (redundant under zoneless; documentation only).
-- **Phase 1 complete; Phases 2.1 + 2.2 + 2.3 + 2.4 + 2.5 shipped; Phases 2.6–9 shipped; Phase 3 shipped.**
-  Shipped so far: Phase 0 (harness); all of Phase 1 — 1.1 + 1.3 + 1.4
-  (ProgressEventsService SSE pump + ConnectionStateService + BrowseSelectionService
-  signalized) and 1.2 (KeyboardService de-zoned + the coupled center-panel state
-  signalized); Phase 2.1 (leaf utility components — toast-container, clipboard-copy,
-  voting-overlay, dialog-host + VtDialogService, browse-legend); **Phase 2.2**
-  (stats / picker modals); **Phase 2.3** (center-panel viewers — image-viewer's
-  window drag/key handlers + shake `setTimeout` + `ResizeObserver` rendered-size
-  writes signalized; video-player verified DOM-only, no change); **Phase 2.4**
-  (`label-view` — own subscribe/timer/effect-written fields signalized; the bound
-  `SortStateService`/`VoteStateService` reads bridged via `toSignal`); and
-  **Phase 2.5** (`find-view` + the shared-service signalization — see next bullet),
-  each with its consumers and a zoneless canary spec. Remaining in **Phase 2**:
-  clusters 2.6–2.9 in the suggested order (next up: 2.6 browse cluster). Note 2.8
-  shrank to right-panel's **`LabelsetStateService`/settings mirror** only
-  (`goodElements`/`badElements`/`mediaType`/`viewMode`/`gridGoalWidth`), since its
-  vote piles landed with 2.5. Then the prod flip (Phase 3), human browser QA
-  (Phase 4), and cleanup (Phase 5).
-- **`SortStateService`/`VoteStateService` are now signal-backed (Phase 2.5).**
-  Rather than continue the per-consumer `toSignal` bridge from 2.4, Phase 2.5
-  signalized both services: each value is a private `signal` exposed via a
-  *value-returning getter*, with the `set*` methods writing the signal. The `$`
-  observables were dropped entirely (clean break — no shims). Because a signal
-  read **through a getter** during template evaluation is tracked (pinned by
-  `frontend/src/app/testing/getter-signal-zoneless.spec.ts`), existing
-  `sortState.sortBusy` / `voteState.goodVotes` template bindings stayed
-  byte-for-byte the same yet became reactive under zoneless. All consumers were
-  migrated in the same change: find-view (template getters now reactive; its own
-  `datasetName`/`viewModeLeft`/… signalized; `unverifiedSortOrder` is a
-  `computed`; the divider `ngZone.run` re-entries dropped — widths are CSS-var
-  only), label-view (its 15 `toSignal` bridges removed; binds the getters
-  directly; the one-shot `labelsetGoodCount$` rehydrate sub → a counts-tracking
-  `effect`), right-panel (six `subscribe`-into-field vote mirrors → `computed`s
-  over the getters), and center-panel (`goodVotes$`/`badVotes$` subscribes → an
-  `effect`; `toast$` stays a `Subject` — it is a fire-once event, not state).
-  `toast$` is the only remaining observable on either service. **Done** — this
-  was the "natural cleanup" the 2.4 follow-up anticipated; no per-consumer
-  bridges remain for these two services.
-- **What Phase 2.2 covered.** `find-stats`/`detector-stats`/`dataset-stats`:
-  `loading`/`error`/`stats` plain fields → signals (templates read them via
-  `@else if (stats(); as stats)` so the bodies were untouched); the stat-derived
-  getters now read `stats()`. `label-importer-modal`: moved the list read onto an
-  eager `rxResource` (mirroring `settings-importer`), and signalized every
-  subscribe-written template field (`submitting`, `error` via an `importError`
-  signal merged with the resource error, `successMessage`, `addingGood`,
-  `addingBad`, and the three `dynamicFieldOptions`/`Loading`/`Error` dicts via
-  `signal<Record<…>>` + `.update`). `settings-importer`/`settings-exporter`/
-  `label-exporter` were already on `rxResource`+signals from the httpresource work;
-  Phase 2.2 finished them by signalizing `submitting`/`successMessage`. New
-  zoneless DOM-canary specs added for all three stats modals + the two settings
-  modals; the existing `label-importer`/`label-exporter` specs migrated to the
-  zoneless `TestBed` (no manual `detectChanges`). **rxResource test gotcha:** a
-  loading `rxResource` holds the app *unstable*, so `await fixture.whenStable()`
-  before flushing the GET deadlocks — the rxResource specs issue the GET with
-  `TestBed.tick()` then `settleResource()` instead (a plain `ngOnInit` HTTP
-  subscribe does *not* block `whenStable`, so the stats specs use it freely).
-- **`setTimeout(close)` finding — Recipe D caveat corrected for template-bound
-  outputs.** The four `setTimeout(() => this.close())` auto-close paths
-  (`settings-importer`, `label-importer`, `settings-exporter`, …) needed **no**
-  rework: `close()` emits a bound `output()`, and a parent's `(closed)="…"` is a
-  *bound template listener*, which is on the zoneless notification path — so the
-  emit schedules the parent's CD and its `@if` gate drops the modal even though
-  the emit fired from an unpatched timer. Proven by a new framework canary,
-  `frontend/src/app/testing/output-emit-zoneless.spec.ts`. Recipe D's warning that
-  "a bare `output()` emit from an unpatched callback will not schedule the
-  parent's CD" holds only for an output the parent subscribes to **imperatively**
-  in TS (a raw callback), *not* for a template `(event)` binding. So only the
-  components' own template-bound state (`submitting`/`successMessage`/…) was
-  signalized; the timer-driven close was left as-is.
-- **Full consumer specs for the browse cluster.** Phase 1.4 added a service unit
-  spec + a signal-driven canary, but `browse-canvas`, `browse-bin-popup`, and
-  `browse-selection-panel` still have **no** component specs (they are heavy to
-  mock: CDK virtual scroll, metadata cache, canvas 2D context). Real per-component
-  zoneless DOM specs for them are deferred to their Phase 2.6 conversion.
-- **Drop the `vitest-patch` bridge (Phase 5).** Migrate the 43 fakeAsync
-  occurrences (11 files) to native `async` + Vitest fake timers, then remove
-  `zone.js/testing` + `zone.js/plugins/vitest-patch` from the `build:test`
-  polyfills and finally `zone.js` from `package.json`. Angular's recommended
-  long-term direction; separable, no prod impact.
-- **Adopt the zoneless `TestBed` per component. ✅ DONE.** `provideZoneless()` /
-  `configureZoneless()` and `settleZoneless()` are now used across the whole
-  suite: every fixture-creating spec runs under the zoneless TestBed and the
-  default-TestBed `fixture.detectChanges()` pumps are gone (only three
-  `detectChanges(false)` calls remain in `center-panel` to skip a dev-only
-  ViewChild NG0100). The Phase-1/2 interactive components are each paired with a
-  `.zoneless.spec.ts` canary (0.4). zone.js is dropped end to end.
+- **Silent fakeAsync breakage.** If a test target loses zone.js *while still using
+  fakeAsync*, the ProxyZone shim no-ops silently and every fakeAsync occurrence
+  throws. (Now moot: all specs are native `async` and zone.js is gone.)
+- **`rxResource` is invisible to `fakeAsync`.** The virtual clock doesn't drive
+  promise-based resolution — use real-async + `settleResource()`. A loading
+  `rxResource` also holds the app *unstable*, so `await fixture.whenStable()`
+  before flushing the GET **deadlocks**; issue the GET with `TestBed.tick()` then
+  `settleResource()`.
+- **`effect()` plain-field trap (Recipe F).** Audit every `effect()` for plain
+  template-bound writes; `center-panel`'s settings mirror was the canonical case.
+- **Output emits from non-Angular callbacks (Recipe D).** Bound template
+  `(event)` listeners schedule CD; imperative TS subscribes do not.
+- **Do not "fix" canvas rAF loops (Recipe E)** into triggering CD.
+- **`ExpressionChangedAfterItHasBeenChecked` (NG0100)** can surface under stricter
+  CD timing and in `whenStable()` specs; contained by `isolate:true` + the cascade
+  guard but still real failures to fix.
+- **`@Input()` setters** that mutate template state need the same treatment as a
+  subscribe-assign.
+- **`ResizeObserver`/`MutationObserver`** are as un-patched as raw
+  `addEventListener` — audit them as a first-class class, not as effects.
+- **CDK virtual scroll** can flicker/stale under zoneless — browser-QA only (the
+  jsdom suite cannot exercise real scroll geometry). Confirmed clean in Phase 4.
+- **`ngModel` two-way bindings** are safe via `(ngModelChange)`, but a
+  programmatic plain-field write from a non-event callback won't refresh the input.
+- **Zoneless async leaks in tests.** Without zone.js the framework no longer
+  auto-cleans timers/microtasks; an SSE poller's `timer(0, N)` first emission or a
+  root-singleton rxResource reload can fire after teardown and throw NG0205. Drain
+  one macrotask in `afterEach` *while the injector is still alive* (a global drain
+  in `test-setup.ts` was rejected — it let a pending re-check crash teardown-state
+  leaf components).
 
 ---
 
-## 4.5 Framework-surface notes (verified non-gaps + watch-items)
+## Verification strategy (how we knew it worked without a browser)
 
-Each Angular/CDK/3rd-party surface was checked against this codebase; recording
-the verdicts so a reviewer doesn't have to re-derive them.
-
-**Watch-items (do require attention):**
-
-- **CDK virtual scroll.** `@angular/cdk` is used only via `@angular/cdk/scrolling`
-  (`CdkVirtualScrollViewport`) in `left-panel/media-list` and `browse-bin-popup`
-  (no overlay / portal / drag-drop / a11y / `LiveAnnouncer` usage). CDK virtual
-  scroll has historically had zoneless repaint/flicker interactions (it leans on
-  `NgZone`/`onStable` internally). The `media-list` `zone.run(() =>
-  cdr.detectChanges())` relayout (Appendix A §A) sits right next to the viewport.
-  Action: confirm the pinned CDK 21.x carries the virtual-scroll zoneless fix,
-  and **browser-QA both viewports for scroll staleness/flicker** (Phase 4) — the
-  jsdom suite cannot exercise real scroll geometry.
-- **`ngModel` programmatic writes.** 58 files use `FormsModule`/`ngModel`.
-  Two-way binding is safe because `(ngModelChange)` is a *bound* listener that
-  schedules CD. The one caveat: writing an `ngModel`-bound **plain field** from a
-  non-event callback won't refresh the input — the same rule as everywhere, but
-  worth calling out given the breadth. Covered by the general subscribe/observer
-  conversions; no separate phase.
-
-**Verified non-gaps (no action needed):**
-
-- **Router / lazy routes / `@defer`.** `app.routes.ts` uses `loadComponent` lazy
-  routes; `app.component.html` has 5 `@defer (when …)` modals. Router events and
-  `@defer` triggers are framework-driven and on the zoneless notification path.
-  The `@defer (when <plainField>)` gates (`showSettings`, importer-flow flags…)
-  flip inside bound `(click)` handlers, which schedule CD. Safe.
-- **`HttpClient` / interceptors.** `HttpClient` is not itself a CD trigger;
-  HTTP-result repaint flows through the *consumer* (signal/`async`/`markForCheck`)
-  — which is exactly what the subscribe-assign conversion handles. The three
-  interceptors (active-context, achievements-refresh, error/circuit-breaker) run
-  in the request chain and don't touch template state. Safe (Phase 1.3 already
-  notes the circuit breaker keeps working).
-- **Angular animations.** Not used — no `@angular/animations`, no
-  `provideAnimations`, no `trigger()`/`[@…]` bindings. Transitions are CSS-only.
-- **`marked`.** Called with `{ async: false }` in `keyboard-help-modal` — fully
-  synchronous, no CD interaction.
-- **`onStable` / `onMicrotaskEmpty` / `afterRender`.** Zero usages in app code,
-  so nothing to migrate to `afterNextRender`. (CDK may use `onStable` internally
-  — folded into the CDK watch-item above.)
-- **SSR / hydration.** None (no `provideClientHydration`, no server rendering).
-- **`PendingTasks`.** Not needed: there's no SSR/test-stability requirement, and
-  the SSE pump / pollers don't need to hold the app "unstable". `whenStable()` in
-  tests resolves correctly.
-- **Bootstrap.** No special handling beyond the Phase 3.1 provider swap.
-- **video/audio `(timeupdate)`/`(play)`/`(loadedmetadata)`.** Bound template
-  listeners → schedule CD. Safe.
-
-## 5. Verification strategy (how we know it works without a browser)
-
-The crux of "be very careful, we can't check the frontend here": we do **not**
-rely on eyeballing. The plan makes the headless suite a genuine zoneless oracle:
+The plan made the headless suite a genuine zoneless oracle rather than relying on
+eyeballing:
 
 1. **Per-component proof.** Each migrated component's spec runs its `TestBed`
    under `provideZonelessChangeDetection()`, drives state through the production
-   channel, `await`s `whenStable()`, and asserts the **rendered DOM**. A missing
-   notification ⇒ stale DOM ⇒ failing assertion. (Appendix C #9.)
-2. **Canary specs** (0.4) explicitly test the scheduling path with zero manual
-   CD pumping, so a forgotten signal write / `markForCheck` cannot pass.
-3. **Lockstep migration.** Because the zoneless `TestBed` is adopted per component
-   in Phases 1–2, the suite is fully green under zoneless semantics *before* the
-   prod flip — the flip itself (Phase 3) is then a near-no-op for behavior.
-4. **Human QA (Phase 4)** is the final backstop for anything the DOM-level unit
+   channel, `await`s `whenStable()`, and asserts the **rendered DOM** — not
+   `component.someField`. A missing notification ⇒ stale DOM ⇒ failing assertion.
+   `detectChanges()` force-runs CD even when Angular would not have scheduled it,
+   masking the exact staleness bug; `whenStable()` flushes only *scheduled* CD.
+2. **Canary specs** (`.zoneless.spec.ts`) explicitly test the scheduling path with
+   zero manual CD pumping, so a forgotten signal write / `markForCheck` fails loud.
+3. **Lockstep migration.** The zoneless `TestBed` was adopted per component during
+   Phases 1–2, so the suite was fully green under zoneless semantics *before* the
+   prod flip — making the flip a near-no-op for behavior.
+4. **Human QA (Phase 4)** was the final backstop for what DOM-level unit
    assertions can't capture (real paint timing, focus, canvas interaction).
 
-This is why the order matters: harness first, components second (validated under
-zoneless tests), flip third, human QA last.
+**Harness nuance:** adding `provideZonelessChangeDetection()` to a `TestBed` flips
+`ComponentFixtureAutoDetect` **on** by default. The corollary is that manual
+`fixture.detectChanges()` pumps must be *removed*, not supplemented (a leftover
+pump both re-masks staleness and can throw NG0100 racing auto-detect). During the
+final spec migration the oracle exposed and fixed **five real staleness bugs** —
+plain fields written from HTTP `.subscribe()` yet read in the template:
+`text-viewer.text`, `autodetect-results-modal`, `examples-editor-modal`,
+`combine-datasets-modal`, and `label-list.sortedEntries`.
 
 ---
 
-## 6. Rollback plan
+## Framework-surface notes (verified non-gaps + watch-items)
 
-- Phases 1–2 are individually revertible commits and are behavior-neutral under
-  zone, so a regression found in QA reverts just the offending cluster.
-- Phase 3 is a 3-line revert (`app.config.ts` provider + the `angular.json`
-  build-polyfills line + budget). Because Phases 1–2 are correct under zone too,
-  reverting only Phase 3 returns to a fully working zone-based app with the
-  modernized reactivity intact.
-- The test-target polyfills (Phase 0) are independent of the prod flip and need
-  not be reverted.
+**Watch-items (required attention):**
 
----
+- **CDK virtual scroll** (`@angular/cdk/scrolling` in `left-panel/media-list` +
+  `browse-bin-popup`) has historically had zoneless repaint/flicker interactions.
+  Browser-QA both viewports for scroll staleness (done in Phase 4, clean).
+- **`ngModel` programmatic writes** (58 files): two-way binding is safe via
+  `(ngModelChange)`; writing an `ngModel`-bound plain field from a non-event
+  callback won't refresh — same rule as everywhere.
 
-## 7. Risks & gotchas (carry these into every PR)
+**Verified non-gaps (no action needed):**
 
-- **Silent fakeAsync breakage.** If the test target loses zone.js (e.g. someone
-  "cleans up" polyfills), the ProxyZone shim no-ops *silently* and all 43
-  fakeAsync occurrences throw. Phase 0.1 decouples test polyfills precisely to
-  prevent this; never let the test target depend on the build target for zone.js.
-- **`rxResource` is invisible to `fakeAsync`** (already documented in
-  `httpresource-migration.md`): the virtual clock doesn't drive promise-based
-  resource resolution. As more reads become resources/signals, *more* specs must
-  leave fakeAsync for real-async + `settleResource()`. The fakeAsync count should
-  **shrink** over the migration, not grow.
-- **`effect()` plain-field trap** (Recipe F): the existing `center-panel` effect
-  is the canonical example. Audit every `effect()` (20 of them) for plain
-  template-bound writes during migration.
-- **Output emits from non-Angular callbacks** (Recipe D): a bare `output()` emit
-  from a former `ngZone.run` won't schedule the parent's CD — model as a signal
-  or `markForCheck` the parent.
-- **Do not "fix" canvas rAF loops** into triggering CD (Recipe E) — performance
-  regression.
-- **`ExpressionChangedAfterItHasBeenChecked`** may surface post-flip and in
-  `whenStable()` specs; contained by `isolate:true` + the cascade guard but still
-  real failures to fix (no waving off, per CLAUDE.md).
-- **`@Input()` setters** (39 files still on decorator inputs): any setter that
-  mutates template state needs the same treatment as a subscribe-assign.
-- **`ResizeObserver`/`MutationObserver`** are as un-patched as raw
-  `addEventListener` — audit them as a first-class class, not as effects.
-- **`VtDialogService` fragility:** dialog visibility currently depends on the
-  caller's stack; signalize it so confirm/prompt are correct from any context.
-- **CDK virtual scroll** can flicker/stale under zoneless — browser-QA only.
-- **`ngModel` two-way bindings** (58 files): safe via `(ngModelChange)`, but a
-  programmatic plain-field write from a non-event callback won't refresh.
+- **Router / lazy routes / `@defer`** — framework-driven, on the notification path.
+- **`HttpClient` / interceptors** — not a CD trigger; repaint flows through the
+  consumer. The three interceptors don't touch template state.
+- **Angular animations** — not used (CSS-only transitions).
+- **`marked`** — called with `{ async: false }`, synchronous.
+- **`onStable` / `onMicrotaskEmpty` / `afterRender`** — zero app usages.
+- **SSR / hydration** — none.
+- **`PendingTasks`** — not needed; `whenStable()` resolves correctly.
+- **video/audio `(timeupdate)`/`(play)`/`(loadedmetadata)`** — bound listeners.
 
 ---
 
-## 8. Open questions for the user
+## Rollback plan (for the record)
 
-These are choices the plan can proceed without (defaults noted) but that change
-scope at the margins:
-
-- **Conversion bias:** default is "`| async` where the source stays an Observable
-  and is read in one place (Recipe A); signalize hot/shared service state (Recipe
-  B); `markForCheck` only as a leaf escape hatch (Recipe C)." If you'd rather go
-  *all-signals* (convert every Observable service to signals) for uniformity, the
-  scope grows but the end state is cleaner.
-- **Phase 5 timing:** drop the vitest-patch bridge and convert timer specs to
-  Vitest fake timers as part of this effort, or defer to its own follow-up
-  (default: defer).
-- **Explicit `OnPush`:** annotate components with `ChangeDetectionStrategy.OnPush`
-  for intent (default: skip — redundant under zoneless).
+- Phases 1–2 were individually revertible, behavior-neutral commits under zone, so
+  a QA regression reverts just the offending cluster.
+- Phase 3 was a 3-line revert (`app.config.ts` provider + `angular.json`
+  build-polyfills + budget); because 1–2 are correct under zone too, reverting
+  only Phase 3 returns to a working zone-based app with the modernized reactivity.
+- Phase 0 test-target polyfills were independent of the flip.
 
 ---
 
-## Appendix A: file-level work catalog
+## What shipped
 
-### §A — NgZone `.run()` re-entry purely for CD (Recipe D) — hard blockers
+Terse per-phase record; the full detail is in git log / the landing PRs.
 
-| File | Sites | What it protects | Zoneless fix |
-|---|---|---|---|
-| `services/progress-events.service.ts` | `listen()` per-frame (~6 channels) + `onopen` | SSE frames fire outside zone; `.run()` repaints progress UI | Signalize 6 channels; drop `zone.run`; remove `NgZone` |
-| `services/keyboard.service.ts` | 10 (`action$.next`) | shortcut dispatch repaints center-panel | Drop `zone.run`; signalize consumer state |
-| `components/left-panel/media-list/media-list.component.ts` | 1 (`zone.run(() => cdr.detectChanges())`) | grid relayout flush (OnPush) | Drop `zone.run`, keep `markForCheck()` |
-| `components/label-view/panel-resize.directive.ts` | 2 (`widthChange`/`resizeEnd` emit) | parent panel width | Signal width / `markForCheck` parent |
-| `components/find-view/find-view.component.ts` | 4 (`leftWidth`/`rightWidth`) | divider drag widths | Signal widths |
-| `components/browse-view/browse-view.component.ts` | 1 (`panelWidth`) | divider drag width | Signal width |
-| `components/browse-canvas/browse-canvas.component.ts` | ~8 (`densityMaxChanged`/`contextMenu`/`hexHover`/`selection.*`) | cross-boundary emits to parent/bin-popup | Recipe D; canvas rAF unchanged |
+- **Phase 0 — test harness.** `frontend/src/app/testing/zoneless-testbed.ts`
+  (`provideZoneless()` / `configureZoneless()`), `settleZoneless()` next to
+  `settleResource()`, and a reference/canary spec verified to fail on a
+  plain-field-write bug and pass on the signal path. Test polyfills decoupled from
+  the prod build via a dedicated `build:test` configuration; ProxyZone shim
+  replaced by `zone.js/plugins/vitest-patch` (which forced a `zone.js` bump
+  `~0.15` → `~0.16`, in Angular 21.2's peer range). No production code changed.
+- **Phase 1 — hot shared services signalized.** 1.1 `ProgressEventsService` SSE
+  pump (six channels → signals, dropped `zone.run`); 1.2 `KeyboardService`
+  de-zoned + coupled `center-panel` state signalized; 1.3 `ConnectionStateService`
+  (status/retrying → signals, offline-banner off `| async`); 1.4
+  `BrowseSelectionService` (`changed$` → `version` signal). Each with consumer +
+  canary specs.
+- **Phase 2 — components, cluster by cluster.** 2.1 leaf utils (toast-container,
+  clipboard-copy, voting-overlay, dialog-host + `VtDialogService`, browse-legend);
+  2.2 stats/picker modals (find/detector/dataset-stats, label-importer onto
+  `rxResource`, importer/exporter mutation fields); 2.3 center-panel viewers
+  (image-viewer drag/key/`ResizeObserver`/shake; video-player verified DOM-only);
+  2.4 label-view (own fields + `SortState`/`VoteState` bridged via `toSignal`);
+  2.5 find-view + **signalized `SortStateService`/`VoteStateService`** (dropped
+  their `$` observables, clean break); 2.6 browse cluster (browse-view/-hover-
+  preview/-selection-panel; canvas/minimap/bin-popup verified safe); 2.7
+  left-panel + media-list; 2.8 right-panel, context-pulldown, dashboard, the
+  modals; 2.9 app.component + a pre-flip sweep (export-modal, examples-editor).
+- **Phase 3 — production flip.** `app.config.ts` →
+  `provideZonelessChangeDetection()`; base `build` polyfills emptied (`[]`);
+  initial budget tightened 540 kB → 500 kB (measured eager bundle 527 → **488 kB**
+  once zone.js left). Removed three obsolete `polyfills.js` Python tests. Full
+  suite green (4919 passed).
+- **Phase 4 — human browser QA (2026-06-22, live against the GRID via Chrome
+  MCP).** Every staleness-prone surface repainted correctly; no "stale until I
+  click"; zero console errors. Verified: SSE load-progress bars, vote → retrain →
+  re-sort → minimap, dashboard timers, de-zoned keyboard shortcuts, offline
+  banner + Retry, `VtDialogService` destructive confirm, CDK virtual scroll,
+  browse canvas, modals. The one bug found (`vt-modal` `Esc` focus) was
+  pre-existing and unrelated to zoneless.
+- **Phase 5 — cleanup.** Removed all 8 no-op `ngZone.run` wrappers in
+  browse-canvas + both in panel-resize.directive; migrated all 43 fakeAsync
+  occurrences (11 files) to native `async` + Vitest fake timers and dropped
+  `vitest-patch`; migrated the last 14 default-TestBed specs to the zoneless
+  TestBed and **removed `zone.js` end to end** (empty `build:test` polyfills,
+  gone from `package.json`); explicit `ChangeDetectionStrategy.OnPush` on all 86
+  components — which surfaced that `DatasetStateService` /
+  `DashboardLoadingTasksService` were read non-reactively in the dashboard
+  template and had to be signalized (Recipe B); fixed `vt-modal` `Esc`-to-close by
+  moving to `@HostListener('document:keydown.escape')`.
 
-### §B — `runOutsideAngular` / canvas rAF (Recipe E) — leave as-is
+---
 
-`keyboard.service:28`, `panel-resize:55`, `find-view:359/401`, `media-list:366`,
-`browse-view:421`, `browse-canvas:350/360/885/997`, `browse-minimap:151/367`
-(perf wrappers — keep). Canvas rAF draw loops: `browse-canvas` (multiple),
-`browse-minimap:238`, `media-crop-modal/audio-crop-overlay`, `progress-modal`
-chart — keep; do not make them trigger CD.
+## Appendix: verified facts (with sources)
 
-### §C — Timer / promise / raw-listener mutating template state (Recipe B/C)
+All confirmed against angular.dev and angular/angular(-cli) source.
 
-`voting-overlay:34,43` (flash classes); `image-viewer:296` (shake) and
-`:420–512` (window drag/key → `panX/panY/regionBox/zoomLabel/shiftHeld` — the
-largest single offender); `center-panel:203` (undo toast), `:310` (spinningVote),
-`:311` (isVoting + emit), `:147` (visibilitychange playback);
-`settings-modal:537` ("Saved" badge); `toast-container:97` (copiedId);
-`clipboard-copy:123` (buttonText); `browse-view:830,843,847` (build poller →
-status/progress/meta); `browse-minimap:408–409` (resize-handle listener, NOT in
-`runOutsideAngular`, mutates bound width/height); `browse-hover-preview:115–116`
-(`fetch().then` → textContent); `label-view:615` (learned-sort toggle);
-`settings-importer:125`/`label-importer:213`/`settings-exporter:124`/
-`examples-editor:82` (`setTimeout(() => this.close())` emit). Service-level
-subjects pushed from timers/raw-listeners that are consumed via **plain-field
-subscribe** (so the *consumer* needs A/B): `toast.service:160`,
-`browse-prep.service:220`, `connection-state.service:83` (the last is safe for
-`offline-banner` because that consumer uses `| async`, but signalize anyway per
-Phase 1.3). Raw `ResizeObserver`/`MutationObserver` writing template state (same class as
-raw `addEventListener`): `browse-legend:73` (`MutationObserver` → `theme`),
-`image-viewer` (`ResizeObserver` → `recomputeRenderedSize` ~L332 →
-`renderedW`/`renderedH`), `media-list:367` (column-count relayout). Observer callbacks feeding only canvas
-redraws (`browse-canvas`, `browse-minimap`) are Recipe E (safe). Plain-field
-dialog state in `VtDialogService` (consumed by `dialog-host`) → signalize
-(Recipe B). DOM-only `setTimeout`s (focus/scroll/select: `context-pulldown:216`,
-`detector-context-bar:26`, `dataset-card:102`, `detector-card:113`,
-`folder-browser:154,386`, `import-config:142` queueMicrotask) are **safe** — no
-template field.
-
-### §D — `subscribe`-into-plain-field reads (Recipe A/B), by component
-
-High-count `ngOnInit`/event list reads (good `async`/signal candidates):
-`dashboard` (32), `label-view` (24), `dataset-importer-modal` (22), `find-view`
-(13), `browse-view` (13), `new-detector-modal` (12), `context-pulldown` (11),
-`center-panel` (11), `right-panel` (10), `load-sort-modal` (8), plus the modal
-catalog: `find-stats`/`detector-stats`/`dataset-stats` (stats reads, Recipe A);
-`label-importer` (list + dynamic field options), `examples-editor`,
-`autodetect-results`, `resort-prompt`, `auto-find-settings`,
-`import-defaults-settings`, `settings-modal` (forkJoin init), `progress-modal`
-(timer poller + SSE iterations). Mutation-result subscribes (POST/PUT) keep their
-imperative `HttpClient` call but their *template-bound result fields*
-(`submitting`/`successMessage`/`status`/`error`) become signals or `markForCheck`.
-
-### §E — `effect()` audit (Recipe F)
-
-20 `effect()` calls across 16 files. Known plain-field-write trap:
-`center-panel:91` (settings mirror → `volume`/`audioPlaying`/`showAnimations`/
-`showMetadata`/`labelHintDismissed`). Audit the other 19 (`settings-state` ×2,
-`left-panel` ×2, `label-view` ×2, `find-view` ×2, and one each in
-`achievements.service`, `view-controls`, `right-panel`, `export-modal`,
-`media-list`, `dashboard`, `browse-view`, `browse-selection-panel`,
-`browse-bin-popup`, `achievements-tab`, `app.component`) for plain template-bound
-writes vs. signal-read-in-template (the latter are fine). Audit the
-`ResizeObserver`/`MutationObserver` callbacks (Appendix C §C) **separately** —
-they are a raw-callback class, not effects, even though both can write
-template-bound fields.
-
-## Appendix B: test-infra catalog
-
-- 69 spec files. `fakeAsync` 43 occurrences / 11 files; `tick(` (zone) subset of
-  those; `TestBed.tick(` 21 / 9 files; `discardPeriodicTasks` 5 / 2 files;
-  `fixture.detectChanges(` 188 / 39 files; `fixture.whenStable` 0;
-  `fixture.autoDetectChanges` 0; zone `flush()` 0 (all `flush(` matches are
-  `HttpTestingController.flush`).
-- The 11 fakeAsync files (preserve via vitest-patch in Phase 0):
-  `vote-state.service`, `browse-prep.service`, `dataset-state.service`,
-  `right-panel` (heaviest, 15), `detector-context-bar`, `label-view`,
-  `settings-modal`, `progress-modal`, `dashboard`, `detector-card`,
-  `dataset-card`.
-- Today zone.js enters tests via the **static strategy**: `"zone.js"` in the
-  build target's `polyfills` makes `@angular/build:unit-test` inject
-  `zone.js/testing` before `setupFiles`. The `test-setup.ts` ProxyZone shim then
-  hand-wires `fakeAsync` for Vitest (zone.js's jest patch bails on
-  `typeof jest === 'undefined'`). Phase 0.1 replaces this coupling with explicit
-  test-target polyfills.
-
-## Appendix C: verified facts (with sources)
-
-All confirmed against angular.dev and angular/angular(-cli) source. Verbatim
-quotes abbreviated; URLs are authoritative.
-
-1. **`markForCheck` schedules CD under zoneless — TRUE.** It marks the view dirty
-   *and* notifies the scheduler (`NotificationSource.MarkForCheck`), independent
-   of zones, so it fires from unpatched callbacks. `zoneless_scheduling_impl.ts`;
-   https://angular.dev/guide/zoneless
-2. **`AsyncPipe` is zoneless-safe — TRUE.** It calls `markForCheck` on emit; the
-   guide lists "`ChangeDetectorRef.markForCheck` (called automatically by
-   `AsyncPipe`)". https://angular.dev/guide/zoneless
-3. **Canonical scheduling-trigger list — confirmed verbatim:** `markForCheck`
-   (via `AsyncPipe`), `ComponentRef.setInput`, updating a signal read in a
-   template, bound host/template listener callbacks, attaching a dirty view.
+1. **`markForCheck` schedules CD under zoneless** — marks the view dirty *and*
+   notifies the scheduler (`NotificationSource.MarkForCheck`), independent of
+   zones. https://angular.dev/guide/zoneless
+2. **`AsyncPipe` is zoneless-safe** — calls `markForCheck` on emit.
+3. **Canonical scheduling-trigger list** — `markForCheck` (via `AsyncPipe`),
+   `ComponentRef.setInput`, updating a signal read in a template, bound
+   host/template listener callbacks, attaching a dirty view.
    `afterRender`/`afterNextRender` run *during* a CD pass, not as triggers.
-   https://angular.dev/guide/zoneless
-4. **Bound `(event)`/`@HostListener` trigger CD; raw `addEventListener` does not
-   — TRUE.** The word "Bound" in the trigger list is load-bearing.
-   https://angular.dev/guide/zoneless
-5. **Effects do not auto-mark host dirty — TRUE.** Only `markForCheck` *within*
-   an effect body, or a signal read in the template, reaches the component; an
-   `effect → plain field → template` binding has no notification path.
-   `render3/reactivity/effect.ts`; https://angular.dev/guide/zoneless
-6. **`provideZonelessChangeDetection()` is STABLE — TRUE.** Stable since v20.2;
-   zoneless is the default in v21+. Use this name (not the old
-   `provideExperimentalZonelessChangeDetection`).
-   https://angular.dev/api/core/provideZonelessChangeDetection
-7. **`zone.js/plugins/vitest-patch` exists & is documented — NUANCED.** It is the
-   documented way to keep `fakeAsync`/`flush`/`waitForAsync` working under the
-   Vitest builder, *but* Angular "strongly recommend[s] you start planning to
-   convert … to native `async` and Vitest fake timers". Treat as a bridge, not
-   the long-term path. https://angular.dev/guide/testing/migrating-to-vitest
-8. **Keeping zone.js in TEST polyfills while prod is zoneless — TRUE.** Test
-   polyfills and prod bootstrap are independent; loading the patch in the test
-   target keeps fakeAsync working. https://angular.dev/guide/testing/migrating-to-vitest
-9. **`whenStable()` catches staleness that `detectChanges()` masks — TRUE.** The
-   guide says to "avoid using `fixture.detectChanges()` when possible … This
-   forces change detection to run when Angular might otherwise have not scheduled
-   change detection," and shows `provideZonelessChangeDetection()` +
-   `await fixture.whenStable()`. https://angular.dev/guide/zoneless
-10. **`NgZone` becomes `NoopNgZone`; `ngZone.run()` alone doesn't drive CD —
-    TRUE.** `provideZonelessChangeDetection()` provides
-    `{provide: NgZone, useClass: NoopNgZone}`. The methods stay *callable* (the
-    guide notes `run`/`runOutsideAngular` "do not need to be removed"), but no
-    longer cause a CD pass. `zoneless_scheduling_impl.ts`;
-    https://angular.dev/guide/zoneless
+4. **Bound `(event)`/`@HostListener` trigger CD; raw `addEventListener` does not**
+   — the word "Bound" in the trigger list is load-bearing.
+5. **Effects do not auto-mark host dirty** — an `effect → plain field → template`
+   binding has no notification path. `render3/reactivity/effect.ts`.
+6. **`provideZonelessChangeDetection()` is STABLE** (since v20.2; default in
+   v21+). Use this name, not `provideExperimentalZonelessChangeDetection`.
+7. **`zone.js/plugins/vitest-patch` exists & is documented** as the bridge for
+   `fakeAsync`/`flush`/`waitForAsync` under the Vitest builder, but Angular
+   recommends converting to native `async` + Vitest fake timers.
+   https://angular.dev/guide/testing/migrating-to-vitest
+8. **Keeping zone.js in TEST polyfills while prod is zoneless is valid** — test
+   polyfills and prod bootstrap are independent.
+9. **`whenStable()` catches staleness that `detectChanges()` masks** — the guide
+   says to avoid `detectChanges()` (it "forces change detection to run when
+   Angular might otherwise have not") and shows
+   `provideZonelessChangeDetection()` + `await fixture.whenStable()`.
+10. **`NgZone` becomes `NoopNgZone`; `ngZone.run()` alone doesn't drive CD** — the
+    methods stay callable ("do not need to be removed") but no longer cause a CD
+    pass. `zoneless_scheduling_impl.ts`.


### PR DESCRIPTION
## What & why

The plan files under `docs/plans/` had drifted so that **finished** work dominated (and often *preceded*) the **remaining** work. Reading a plan to find "what's next" meant scrolling past hundreds of lines recounting what already shipped. `comprehensive-audit-2026-07.md` was the extreme case: ~465 lines of "What shipped" above ~70 lines of open follow-ups.

This PR restructures every affected plan file to a consistent shape:

1. **Title → one-line Status** stating where things stand.
2. **Open/remaining work foregrounded** right after the status line, kept in full detail.
3. **Finished work compressed** to a terse one-line-per-item "What shipped" list below the open work (file/test/PR refs preserved — a searchable record, not prose).
4. **Design/reference content kept** only where it informs the *open* work (e.g. the zoneless recipes, the patch-embedder V3 spec, the scalability S# catalog); design that only re-explained shipped work was trimmed.

No facts were invented or changed and no files were renamed — this is restructure-and-compress only.

## Scope

32 plan files rewritten, **~10,500 lines removed**. Biggest reductions:

| File | Before → After |
|------|----------------|
| `zoneless-migration.md` | 1337 → 340 |
| `patch-embedder.md` | 1343 → 420 |
| `logical-bug-audit.md` | 1191 → 198 |
| `vtsbrowse.md` | 856 → 301 |
| `scalability-plan.md` | 723 → 363 |
| `structural-embedder.md` | 673 → 322 |
| `comprehensive-audit-2026-07.md` | 661 → 198 |
| `server-dedup-references.md` | 428 → 132 |
| `docs-audit-2026-06-28.md` | 327 → 94 |

Also fixed two stale status annotations in `docs/plans/README.md` (`patch-embedder`, `visual-genome-dataset`) discovered during the sweep, where the plan files had shipped-status the index still described as "in progress".

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAQVJatDrJBuTz5bVcT3j

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAQVJatDrJBuTz5bVcT3j)_