### PR TITLE
Cap MAX_UPLOAD_MB at 2 GiB by default instead of unlimited

### DIFF
--- a/app.py
+++ b/app.py
@@ -120,9 +120,10 @@ app = Flask(__name__)
 # deployments should always set the env var.
 app.secret_key = os.environ.get("VTSEARCH_SECRET_KEY", "vtsearch-dev-key-change-in-production")
 
-# Optional cap on request body size (uploads).  ``MAX_UPLOAD_MB == 0`` leaves
-# Flask's default of no limit in place; a positive value rejects oversized
-# requests with HTTP 413 before they consume disk.
+# Cap on request body size (uploads).  Defaults to 2 GiB (see
+# ``vtscore.config.MAX_UPLOAD_MB``); a positive value rejects oversized
+# requests with HTTP 413 before they consume disk.  ``MAX_UPLOAD_MB == 0``
+# (set via ``VTSEARCH_MAX_UPLOAD_MB=0``) leaves Flask's default of no limit.
 from vtscore.config import MAX_UPLOAD_MB as _MAX_UPLOAD_MB  # noqa: E402
 
 if _MAX_UPLOAD_MB > 0:

--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -1,7 +1,8 @@
 # Comprehensive interface audit — July 2026
 
 **Status: eleven fix passes shipped; follow-up #1 (registry multi-process
-safety) shipped; 7 open follow-ups below.**
+safety) shipped; item 6 (`MAX_UPLOAD_MB` default cap) fixed; 6 open follow-ups
+below.**
 
 A full-codebase audit of interface boundaries (frontend ↔ API, route layer ↔
 state system, app tier ↔ `vtscore`, IO, concurrency, frontend TS). Six parallel
@@ -54,10 +55,12 @@ Ordered roughly by severity.
    the explicit save should merge like the sync does (probably yes, via
    `_merge_labelsets_across_datasets`) or full-replace is the intended
    "save exactly what I see" semantic.
-6. **`MAX_UPLOAD_MB` defaults to 0 = unlimited** (`vtscore/config.py`):
-   staging uploads are unbounded by default; decide a sane default cap.
-   (The eleventh pass removed the *decompressed-copy* amplification in
-   `stage_file`, but the upload itself is still unbounded.)
+6. ~~**`MAX_UPLOAD_MB` defaults to 0 = unlimited** (`vtscore/config.py`):
+   staging uploads are unbounded by default; decide a sane default cap.~~
+   **Fixed:** default changed to `2048` (2 GiB) — generous enough for typical
+   media archives and dataset pickles, oversized requests get HTTP 413.
+   `VTSEARCH_MAX_UPLOAD_MB=0` still opts back into unlimited for genuinely
+   large-archive uploads.
 7. **`AutoDetectProgressModalComponent` is dead code** (modal sweep note):
    referenced nowhere; delete it or wire it up.
 

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -80,7 +80,7 @@ def resolve_device() -> str:
     """Resolve DEVICE='auto' to the concrete torch device string for this host."""
 
 MAX_UPLOAD_MB: int
-"""HTTP request size cap in MB; 0 = unlimited. Honours $VTSEARCH_MAX_UPLOAD_MB."""
+"""HTTP request size cap in MB; default 2048 (2 GiB), 0 = unlimited. Honours $VTSEARCH_MAX_UPLOAD_MB."""
 
 TRAIN_EPOCHS: int
 """Upper bound on MLP training epochs. Honours $VTSEARCH_TRAIN_EPOCHS; default 200."""

--- a/tests_lib/core/test_torch_config.py
+++ b/tests_lib/core/test_torch_config.py
@@ -64,6 +64,40 @@ def test_torch_threads_constant_clamps_to_one(monkeypatch):
     assert config.TORCH_THREADS == 1
 
 
+def test_max_upload_mb_default(monkeypatch):
+    """``MAX_UPLOAD_MB`` defaults to a bounded 2 GiB cap, not unlimited."""
+    monkeypatch.delenv("VTSEARCH_MAX_UPLOAD_MB", raising=False)
+    import vtscore.config as config
+
+    config = importlib.reload(config)
+    assert config.MAX_UPLOAD_MB == 2048
+
+
+def test_max_upload_mb_honours_env(monkeypatch):
+    monkeypatch.setenv("VTSEARCH_MAX_UPLOAD_MB", "512")
+    import vtscore.config as config
+
+    config = importlib.reload(config)
+    assert config.MAX_UPLOAD_MB == 512
+
+
+def test_max_upload_mb_zero_disables_cap(monkeypatch):
+    """``VTSEARCH_MAX_UPLOAD_MB=0`` opts back into Flask's unlimited body size."""
+    monkeypatch.setenv("VTSEARCH_MAX_UPLOAD_MB", "0")
+    import vtscore.config as config
+
+    config = importlib.reload(config)
+    assert config.MAX_UPLOAD_MB == 0
+
+
+def test_max_upload_mb_negative_clamps_to_zero(monkeypatch):
+    monkeypatch.setenv("VTSEARCH_MAX_UPLOAD_MB", "-5")
+    import vtscore.config as config
+
+    config = importlib.reload(config)
+    assert config.MAX_UPLOAD_MB == 0
+
+
 def test_ensure_torch_configured_applies_constant(monkeypatch):
     """``ensure_torch_configured`` passes ``TORCH_THREADS`` to torch."""
     import vtscore.media.torch_setup as torch_setup

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -163,12 +163,13 @@ def resolve_device() -> str:
 # :func:`vtscore.security.path_validation.get_file_access_base_dir`.
 
 # Maximum size (in megabytes) accepted for a single HTTP request body.  Wired
-# into Flask's ``MAX_CONTENT_LENGTH`` config in ``app.py``.  ``0`` (the
-# default) disables the cap, preserving Flask's out-of-the-box "no limit"
-# behaviour so existing large-archive uploads keep working.  Set
-# ``VTSEARCH_MAX_UPLOAD_MB`` to a positive integer to reject oversized
-# uploads with HTTP 413 before they consume disk.
-MAX_UPLOAD_MB = max(0, int(os.environ.get("VTSEARCH_MAX_UPLOAD_MB", "0")))
+# into Flask's ``MAX_CONTENT_LENGTH`` config in ``app.py``.  Defaults to
+# ``2048`` (2 GiB): generous enough for typical media archives and dataset
+# pickles while still rejecting pathological uploads with HTTP 413 before they
+# consume disk.  Set ``VTSEARCH_MAX_UPLOAD_MB`` to a different positive integer
+# to raise or lower the cap, or to ``0`` to disable it entirely (Flask's
+# out-of-the-box "no limit" behaviour) for genuinely large-archive uploads.
+MAX_UPLOAD_MB = max(0, int(os.environ.get("VTSEARCH_MAX_UPLOAD_MB", "2048")))
 
 # Training
 #

--- a/vtscore/docs/packages/config.md
+++ b/vtscore/docs/packages/config.md
@@ -145,7 +145,7 @@ when one is in scope). Tests rely on this: they override
 |--------------------------|---------|-------------------------------|------------------------------------------------------------------------------------------------------------------|
 | `TORCH_THREADS`          | `1`     | `VTSEARCH_TORCH_THREADS`      | Native thread count for OpenMP / MKL / `torch.set_num_threads`. Default 1 keeps RSS low in constrained envs.     |
 | `DEVICE`                 | `"auto"`| `VTSEARCH_DEVICE`             | Preferred compute device. `"auto"` resolves at call time; explicit `"cuda"`, `"cuda:0"`, `"cpu"`, `"mps"` are honoured, but a CUDA device the installed torch wheel can't actually run on falls back to `"cpu"`. |
-| `MAX_UPLOAD_MB`          | `0`     | `VTSEARCH_MAX_UPLOAD_MB`      | HTTP body cap in megabytes. `0` = unlimited (Flask's out-of-the-box behaviour).                                  |
+| `MAX_UPLOAD_MB`          | `2048`  | `VTSEARCH_MAX_UPLOAD_MB`      | HTTP body cap in megabytes (default 2 GiB). Oversized requests get HTTP 413. Set to `0` for unlimited (Flask's out-of-the-box behaviour). |
 | `TRAIN_EPOCHS`           | `200`   | `VTSEARCH_TRAIN_EPOCHS`       | Upper bound on MLP training epochs. `vtscore.training.mlp.train_model` may early-stop sooner.                    |
 | `TRAIN_PATIENCE`         | `10`    | `VTSEARCH_TRAIN_PATIENCE`     | Epochs the training loss must fail to improve before early-stop fires. `0` disables early-stop.                  |
 | `DEFAULT_CALIBRATE_COUNT`| `1`     | `VTSEARCH_CALIBRATE_COUNT`    | First-run default for `CoreConfig.calibrate_count`. Min 1.                                                       |
@@ -248,7 +248,7 @@ Every env var consulted by `vtscore.config`, in one place:
 | `VTSEARCH_MODELS_DIR`       | Override `MODELS_CACHE_DIR`. Independent of `VTSEARCH_DATA_DIR`.                                |
 | `VTSEARCH_TORCH_THREADS`    | Set `TORCH_THREADS` (and therefore OMP / MKL caps). Floor of 1.                                 |
 | `VTSEARCH_DEVICE`           | Set `DEVICE`. `"auto"` is the default; pin to `"cuda"`, `"cuda:0"`, `"cpu"`, or `"mps"`.        |
-| `VTSEARCH_MAX_UPLOAD_MB`    | Set `MAX_UPLOAD_MB`. `0` = unlimited.                                                           |
+| `VTSEARCH_MAX_UPLOAD_MB`    | Set `MAX_UPLOAD_MB` (default 2048 MB). `0` = unlimited.                                         |
 | `VTSEARCH_TRAIN_EPOCHS`     | Set `TRAIN_EPOCHS` (MLP training upper bound).                                                  |
 | `VTSEARCH_TRAIN_PATIENCE`   | Set `TRAIN_PATIENCE` (early-stop patience). `0` disables.                                       |
 | `VTSEARCH_CALIBRATE_COUNT`  | Set `DEFAULT_CALIBRATE_COUNT` (first-run default; later writes go to per-user settings).        |


### PR DESCRIPTION
## Summary

Resolves item 7 of `docs/plans/comprehensive-audit-2026-07.md`: `MAX_UPLOAD_MB` defaulted to `0` (unlimited), so staging uploads were unbounded by default and free to consume disk.

Changes the default to **2048 MB (2 GiB)** — generous enough for typical media archives and dataset pickles, while oversized requests now get rejected with HTTP 413 (via Flask's `MAX_CONTENT_LENGTH`) before they hit disk. Setting `VTSEARCH_MAX_UPLOAD_MB=0` still opts back into Flask's unlimited behaviour for genuinely large-archive uploads.

## Changes

- `vtscore/config.py` — default `VTSEARCH_MAX_UPLOAD_MB` from `0` → `2048`; updated the comment.
- `app.py` — updated the wiring comment (behaviour unchanged; still reads the constant).
- Docs — `vtscore/docs/packages/config.md` and `docs/vtscore-api.md` updated for the new default.
- `docs/plans/comprehensive-audit-2026-07.md` — marked follow-up 7 as fixed, updated open-count header.
- `tests_lib/core/test_torch_config.py` — added regression tests for the default (2048), env override, `0`-disables, and negative-clamps-to-zero.

## Testing

`./run-tests.sh core` — all 908 tests pass (ruff / codespell / deptry / frontend build gate first).

## Backwards compatibility

This is a behaviour change: deployments that previously accepted arbitrarily large uploads now cap at 2 GiB by default. Set `VTSEARCH_MAX_UPLOAD_MB=0` (or a higher value) to restore the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcJDBciHtDbREUFio3D5zs

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcJDBciHtDbREUFio3D5zs)_