### PR TITLE
Fix progress-modal analysis path (audit follow-up #2)

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -1,8 +1,8 @@
 # Comprehensive interface audit — July 2026
 
-**Status: eleven fix passes shipped; follow-up #1 (registry multi-process
-safety) shipped; item 6 (`MAX_UPLOAD_MB` default cap) fixed; 6 open follow-ups
-below.**
+**Status: eleven fix passes shipped; follow-ups #1 (registry multi-process
+safety) and #2 (progress-modal analysis path) shipped; `MAX_UPLOAD_MB` default
+cap fixed; 5 open follow-ups below.**
 
 A full-codebase audit of interface boundaries (frontend ↔ API, route layer ↔
 state system, app tier ↔ `vtscore`, IO, concurrency, frontend TS). Six parallel
@@ -14,19 +14,7 @@ the audit but deferred as needing a design decision or a larger change.
 
 Ordered roughly by severity.
 
-1. **Progress-modal analysis path is broken three ways**
-   (`progress-modal.component.ts`, `runAnalysis()`): Escape/X/backdrop skip
-   the eval-job cancel the in-body Cancel button performs; the
-   `trainAndScore` subscribe has no `takeUntil`, so a destroy while the POST
-   is in flight arms `pollEvalJob()` against an already-completed `destroy$`
-   (RxJS `takeUntil` never fires on a pre-completed notifier → orphan
-   500 ms poller until the job ends); and the backend emits the eval
-   `idle/Done` SSE frame *inside* `_run` before the job flips to `done`, so
-   the SSE watcher usually kills the result poller before it observes
-   completion — `analyzing` hangs forever. All currently *latent*: the only
-   in-app instantiation passes `[useCachedHistory]="true"`, but
-   `runAnalysis()` is the component default and is pinned by its spec.
-2. **Browse canvas gesture overlaps** (UX design decisions): wheel-zoom
+1. **Browse canvas gesture overlaps** (UX design decisions): wheel-zoom
    during an active drag-pan/marquee discards the zoom's cursor anchoring on
    the next mousemove and freezes painting for the 220 ms transition (gate
    the wheel while a drag is active, or make the pan math zoom-aware); the
@@ -36,18 +24,18 @@ Ordered roughly by severity.
    pending toggle on view moves); the boundary-settle rAF loop can start while
    the zoom-transition loop still owns the canvas (both write
    `displayedTransform`; visible damage is a truncated transition).
-3. **Root-zoom px mixing in panel-divider drags**
+2. **Root-zoom px mixing in panel-divider drags**
    (`browse-view.component.ts:onDividerMove`,
    `label-view/panel-resize.directive.ts`): visual-px cursor deltas applied
    as layout-px widths under `html { zoom: 1.1 }`, so the divider rides
    ~10% away from the pointer. Shared app-wide wart; fix both sites together
    (the eleventh pass fixed the same class of bug in the minimap).
-4. **Pure devicePixelRatio change never re-runs canvas `resize()`**
+3. **Pure devicePixelRatio change never re-runs canvas `resize()`**
    (browse-canvas + minimap): dragging the window to a different-density
    monitor leaves `dpr` (and the thumbnail-resolution tier) stale until the
    next CSS resize; rendering-quality only (hit-testing is CSS-px based).
    Needs a `matchMedia('(resolution: …)')` listener.
-5. **`save_detector_labels` full-replace drops cross-dataset labels**
+4. **`save_detector_labels` full-replace drops cross-dataset labels**
    (`routes/detectors/labels.py`): the route rebuilds the labelset from the
    *active dataset's* votes only, while `sync_labels_to_loaded_detector`
    deliberately merges cross-dataset entries — saving while dataset B is
@@ -55,13 +43,13 @@ Ordered roughly by severity.
    the explicit save should merge like the sync does (probably yes, via
    `_merge_labelsets_across_datasets`) or full-replace is the intended
    "save exactly what I see" semantic.
-6. ~~**`MAX_UPLOAD_MB` defaults to 0 = unlimited** (`vtscore/config.py`):
+5. ~~**`MAX_UPLOAD_MB` defaults to 0 = unlimited** (`vtscore/config.py`):
    staging uploads are unbounded by default; decide a sane default cap.~~
    **Fixed:** default changed to `2048` (2 GiB) — generous enough for typical
    media archives and dataset pickles, oversized requests get HTTP 413.
    `VTSEARCH_MAX_UPLOAD_MB=0` still opts back into unlimited for genuinely
    large-archive uploads.
-7. **`AutoDetectProgressModalComponent` is dead code** (modal sweep note):
+6. **`AutoDetectProgressModalComponent` is dead code** (modal sweep note):
    referenced nowhere; delete it or wire it up.
 
 ## What shipped
@@ -165,6 +153,14 @@ Frontend:
 - Minimap mouse math corrects for `html { zoom: 1.1 }` (cursor offset, resize
   delta, backing store). Post-destroy rAF gated by a `destroyed` flag in
   browse-canvas.
+- Progress-modal analysis path (was follow-up #2): the modal's `(closed)` now
+  routes Escape/X/backdrop through `onCancel()` so every dismissal cancels the
+  running eval job; the `trainAndScore` POST is guarded with
+  `takeUntil(destroy$)` (no orphan poller when destroyed mid-flight); and the
+  eval SSE progress watcher stops via a dedicated subject instead of
+  `destroy$.next()`, so the backend's early `idle/Done` frame no longer tears
+  down the result poller and hangs `analyzing`
+  (`progress-modal.component.spec.ts`).
 
 ## Behaviour changes (backwards-compat notes)
 

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
@@ -1,4 +1,4 @@
-<vt-modal [title]="title" [open]="true" (closed)="close()">
+<vt-modal [title]="title" [open]="true" (closed)="onCancel()">
   @if (analyzing) {
     <div class="analysis-loading">
       @if (useCachedHistory()) {

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -1,18 +1,31 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
+import { HttpRequest } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { Subject } from 'rxjs';
 import { ProgressModalComponent } from './progress-modal.component';
+import { ProgressEventsService } from '../../../services/progress-events.service';
+import { VotingIterationsResponse } from '../../../models/api.models';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
 
 describe('ProgressModalComponent', () => {
   let component: ProgressModalComponent;
   let fixture: ComponentFixture<ProgressModalComponent>;
   let httpMock: HttpTestingController;
+  // Controllable stand-in for the `eval` SSE channel so a test can push a
+  // "done" progress frame at will.
+  let votingIterations$: Subject<VotingIterationsResponse>;
 
   beforeEach(async () => {
+    votingIterations$ = new Subject<VotingIterationsResponse>();
     await TestBed.configureTestingModule({
       imports: [ProgressModalComponent],
-      providers: [...provideZoneless(), provideHttpClient(), provideHttpClientTesting()],
+      providers: [
+        ...provideZoneless(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ProgressEventsService, useValue: { votingIterations$ } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProgressModalComponent);
@@ -72,5 +85,102 @@ describe('ProgressModalComponent', () => {
     vi.spyOn(component.closed, 'emit');
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();
+  });
+
+  it('keeps polling for the result after the SSE reports done', async () => {
+    // Regression: the eval `idle/Done` frame lands while the job status
+    // endpoint may still say `running`. The progress watcher must not tear
+    // down the result poller, or `analyzing` hangs forever.
+    vi.useFakeTimers();
+    try {
+      component.metric = 'smart';
+      TestBed.tick();
+
+      // Job started, not a cache hit -> the component polls for the result.
+      httpMock.expectOne('/api/eval/train-and-score').flush({
+        job_id: 'j1',
+        status: 'running',
+        current: 0,
+        total: 5,
+      });
+      expect(component.analyzing).toBe(true);
+
+      // SSE says done *before* the result endpoint flips. This used to kill
+      // the poller; it must only stop the progress watcher now.
+      votingIterations$.next({ progress: 5, total: 5, done: true });
+
+      const isResult = (req: HttpRequest<unknown>) =>
+        req.url === '/api/eval/train-and-score/result';
+
+      // First poll still sees `running`.
+      await vi.advanceTimersByTimeAsync(200);
+      httpMock.expectOne(isResult).flush({ job_id: 'j1', status: 'running', current: 5, total: 5 });
+      expect(component.analyzing).toBe(true);
+
+      // Next poll observes completion and applies the data.
+      await vi.advanceTimersByTimeAsync(500);
+      httpMock.expectOne(isResult).flush({
+        job_id: 'j1',
+        status: 'done',
+        metric: 'smart',
+        error_cost: [{ num_labels: 5, error_cost: 0.5 }],
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.chartData.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels the in-flight eval job when dismissed via the modal', async () => {
+    // Regression: Escape / X / backdrop route through the modal's `(closed)`
+    // to `onCancel()`, so they must cancel the running job like the in-body
+    // Cancel button does — not silently orphan it.
+    vi.useFakeTimers();
+    try {
+      component.metric = 'stable';
+      TestBed.tick();
+
+      httpMock.expectOne('/api/eval/train-and-score').flush({
+        job_id: 'j2',
+        status: 'running',
+        current: 0,
+        total: 3,
+      });
+
+      vi.spyOn(component.closed, 'emit');
+      component.onCancel();
+
+      httpMock.expectOne('/api/eval/train-and-score/cancel/j2').flush({ ok: true });
+      expect(component.closed.emit).toHaveBeenCalled();
+      expect(component.analyzing).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not arm a poller when destroyed before the job envelope arrives', async () => {
+    // Regression: destroying the modal while the train POST is in flight must
+    // not leave a poller running against an already-completed `destroy$`.
+    vi.useFakeTimers();
+    try {
+      component.metric = 'diverse';
+      TestBed.tick();
+
+      const trainReq = httpMock.expectOne('/api/eval/train-and-score');
+      component.ngOnDestroy();
+      // The POST resolves after destroy; `takeUntil(destroy$)` drops it, so
+      // `pollEvalJob` never runs and no result poll is issued.
+      trainReq.flush({ job_id: 'j3', status: 'running', current: 0, total: 3 });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      httpMock.expectNone((req: HttpRequest<unknown>) =>
+        req.url === '/api/eval/train-and-score/result',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -171,9 +171,10 @@ describe('ProgressModalComponent', () => {
 
       const trainReq = httpMock.expectOne('/api/eval/train-and-score');
       component.ngOnDestroy();
-      // The POST resolves after destroy; `takeUntil(destroy$)` drops it, so
-      // `pollEvalJob` never runs and no result poll is issued.
-      trainReq.flush({ job_id: 'j3', status: 'running', current: 0, total: 3 });
+      // `takeUntil(destroy$)` unsubscribes from the in-flight POST, so the
+      // request is cancelled: its `next` never runs, `pollEvalJob` is never
+      // armed, and no result poll is issued.
+      expect(trainReq.cancelled).toBe(true);
 
       await vi.advanceTimersByTimeAsync(1000);
       httpMock.expectNone((req: HttpRequest<unknown>) =>

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -92,36 +92,51 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     this.analyzing = true;
     this.analysisProgress = 0;
 
-    // Progress comes from the `eval` SSE channel on /api/events.
+    // Progress comes from the `eval` SSE channel on /api/events. Use a
+    // dedicated notifier to stop watching once the bar reaches 100%: the
+    // backend emits the `idle/Done` eval frame *inside* `_run`, before the
+    // job flips to `done`, so this fires while the result poller is still
+    // polling. It must NOT tear down the poller — hence a separate subject
+    // rather than `this.destroy$.next()`, which would kill the poller too
+    // and leave `analyzing` hung forever.
+    const stopWatchingProgress$ = new Subject<void>();
     this.progressEvents.votingIterations$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this.destroy$), takeUntil(stopWatchingProgress$))
       .subscribe({
         next: (res) => {
           if (res.total > 0) {
             this.analysisProgress = Math.round((res.progress / res.total) * 100);
           }
           if (res.done) {
-            this.destroy$.next(); // stop watching
+            stopWatchingProgress$.next();
+            stopWatchingProgress$.complete();
           }
         },
       });
 
     // Request train-and-score; the new endpoint returns a job envelope.
-    this.sortingApi.trainAndScore(this.metric).subscribe({
-      next: (res) => {
-        if (res.status === 'done') {
-          this.applyEvalResult(res);
-        } else if (res.status === 'running') {
-          this.currentJobId = res.job_id;
-          this.pollEvalJob(res.job_id);
-        } else {
+    // `takeUntil(destroy$)` guards the case where the modal is dismissed
+    // while the POST is in flight: without it, a late `next` would arm
+    // `pollEvalJob()` against an already-completed `destroy$` (RxJS
+    // `takeUntil` never fires on a pre-completed notifier), leaking a poller.
+    this.sortingApi
+      .trainAndScore(this.metric)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          if (res.status === 'done') {
+            this.applyEvalResult(res);
+          } else if (res.status === 'running') {
+            this.currentJobId = res.job_id;
+            this.pollEvalJob(res.job_id);
+          } else {
+            this.analyzing = false;
+          }
+        },
+        error: () => {
           this.analyzing = false;
-        }
-      },
-      error: () => {
-        this.analyzing = false;
-      },
-    });
+        },
+      });
   }
 
   private pollEvalJob(jobId: string): void {
@@ -148,7 +163,14 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
       });
   }
 
-  /** Cancel the in-flight eval job and close the modal. */
+  /** Cancel the in-flight eval job (if any) and close the modal.
+   *
+   *  This is the single dismissal path for the modal: the in-body Cancel
+   *  button, and Escape / the X / a backdrop click (routed here from the
+   *  inner `vt-modal`'s `(closed)`) all land here, so every way of leaving
+   *  the modal stops the running eval job rather than orphaning it. Safe on
+   *  the cached-history path, where `currentJobId` is null and no cancel
+   *  request is sent. */
   onCancel(): void {
     const jobId = this.currentJobId;
     this.currentJobId = null;


### PR DESCRIPTION
Fixes the three latent bugs in `ProgressModalComponent.runAnalysis()` documented as follow-up #2 in `docs/plans/comprehensive-audit-2026-07.md`.

## The three bugs

1. **Dismissal skipped the eval-job cancel.** Escape / the X button / a backdrop click routed through the inner `vt-modal`'s `(closed)` to `close()`, which only emitted the modal's own `closed` output — it never cancelled the running eval job that the in-body Cancel button (`onCancel()`) does. Only the explicit Cancel button stopped the job.

2. **`trainAndScore` POST had no `takeUntil`.** Destroying the modal while the POST was in flight let a late `next` arm `pollEvalJob()` against an already-completed `destroy$`. RxJS `takeUntil` never fires on a pre-completed notifier, so the 500 ms result poller ran forever until the job ended.

3. **The SSE `idle/Done` frame tore down the result poller.** The backend emits the eval `idle/Done` progress frame *inside* `_run`, before the job status flips to `done`. The old `votingIterations$` handler called `this.destroy$.next()` on that frame ("stop watching"), which also unsubscribed the result poller — usually before it observed completion — leaving `analyzing` hung forever.

## The fixes

- Route the modal's `(closed)` to `onCancel()` so **every** dismissal path (Escape / X / backdrop / Cancel button) cancels the in-flight job. Safe on the cached-history path, where there is no job to cancel.
- Guard the `trainAndScore` subscribe with `takeUntil(this.destroy$)`; a destroy mid-flight now cancels the POST instead of arming an orphan poller.
- Stop the eval progress watcher via a dedicated `stopWatchingProgress$` subject instead of `destroy$.next()`, so the backend's early `idle/Done` frame no longer kills the result poller. The poller now runs to completion independently and applies the result.

## Tests

Adds three regression specs in `progress-modal.component.spec.ts`:
- the poller survives an SSE `done` frame and applies the result on a later poll;
- dismissing via the modal cancels the running eval job;
- destroying before the job envelope arrives cancels the POST and arms no poller.

Full frontend gate green: `./run-tests.sh frontend` → 1009 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vdcde9M5kuxC7PjcquRiZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vdcde9M5kuxC7PjcquRiZ7)_