### PR TITLE
Close the three H28 residual multi-process follow-ups

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -46,18 +46,27 @@ the only remaining work.
   subclass that does so transparently) would neutralise the whole category and
   let the matrix accessor compare a single int instead of two id lists.
 
-- **H28 residual multi-process items** (from the per-user settings RMW fix):
-  - `_synced_users` is still process-local, so on a fresh container every worker
-    independently runs sync-from-source for each user once. With the RMW fix
-    this is no longer corrupting (just duplicate I/O against the source) but
-    worth de-duplicating with an mtime-marker if it shows up in profiles.
-  - The legacy-settings migration in `_maybe_migrate_legacy_settings_locked`
-    still calls `_atomic_write` without the cross-process lock. It is a one-shot
-    startup step so the race window is small, but for full correctness it should
-    also use `_mutate_server_locked`.
-  - Windows has no `fcntl`, so the cross-process lock silently degrades to the
-    in-process lock only. Not a regression (Linux-only Docker images), but worth
-    a note if a contributor ever tests on Windows.
+- **H28 residual multi-process items** (from the per-user settings RMW fix) —
+  **all three resolved.**
+  - ~~Duplicate cross-worker sync-from-source I/O.~~ **Shipped.** A best-effort
+    per-user on-disk marker (`<user_settings.json>.syncmark`, written by
+    `_write_sync_marker`) records the source `peek_version` last applied. A
+    fresh worker whose first read finds the source unchanged at that version
+    adopts it and skips the duplicate `source.load()` — the values are already
+    on disk (`_adopt_sync_marker_if_current`; `test_sync_sources.py::TestSyncDedupMarker`).
+  - ~~Legacy-settings migration wrote without the cross-process lock.~~
+    **Shipped.** `ensure_server_loaded` now does its first load + one-shot
+    migration inside `_load_and_migrate_server` under the server `file_lock`,
+    and `_maybe_migrate_legacy_settings` takes the default user's `file_lock`
+    around its write — so both `_atomic_write` calls are cross-process safe.
+    The migration was hoisted out of `settings_lock` (callers invoke
+    `ensure_server_loaded` outside the lock) to keep the canonical
+    file→settings order (`test_per_user_settings.py::TestMigrationCrossProcessLock`).
+  - ~~Windows `fcntl` degradation was untested.~~ **Covered.** The fallback to
+    the in-process lock is now exercised by
+    `test_settings.py::TestFileLockWithoutFcntl`. Still Linux-only in
+    production; the fallback only matters for a Windows contributor running
+    multiple processes against one settings file (which they shouldn't).
 
 ---
 
@@ -110,7 +119,7 @@ the only remaining work.
 - **H25.** Active dataset pair set before load completes — split `ActiveContextService` into intent + active layers (commit `9470cf1a`, PR #1563; `context-switch.service.spec.ts`).
 - **H26.** `recordVote` ran before the HTTP vote returned — `submitToggleVoteAndRecord` pushes the undo entry only inside the success `tap` (`vote-state.service.spec.ts`).
 - **H27.** Binary media endpoints bypass `activeContextInterceptor` — **not a bug** (functional interceptors apply to every `HttpClient` call); removed four dead methods.
-- **H28.** Per-user cache process-local; concurrent worker writes lost updates — cross-process `flock` RMW via `_mutate_*_locked` (`test_settings.py::TestConcurrentWrites`). Residual items in Open follow-ups.
+- **H28.** Per-user cache process-local; concurrent worker writes lost updates — cross-process `flock` RMW via `_mutate_*_locked` (`test_settings.py::TestConcurrentWrites`). The three residual multi-process items (sync dedup marker, migration under the file lock, Windows fallback coverage) are now also resolved — see Open follow-ups.
 - **H29.** `_save_user` held `_settings_lock` across sync I/O — I/O moved under the per-file lock only (`test_thread_safety.py::TestSlowSettingsIODoesNotBlockOthers`).
 - **H30.** Detector save's `os.replace` failure left in-memory state "saved" — transactional snapshot/restore in `apply_and_retrain` + abort-500 at the unprotected call sites (`test_workflow.py`, `test_api_contracts.py`, `test_detectors.py`).
 - **H31.** Partial label-import had no rollback — per-entry try/except surfacing `failed` / `failed_count`.

--- a/tests/core/test_per_user_settings.py
+++ b/tests/core/test_per_user_settings.py
@@ -223,6 +223,107 @@ class TestLegacyMigration:
             settings_mod.reset()
 
 
+class TestMigrationCrossProcessLock:
+    """H28 residual follow-up: the one-shot legacy migration must run its two
+    ``_atomic_write`` calls under the cross-process ``file_lock`` (previously
+    it wrote bare), and must migrate exactly once even under concurrent first
+    loads."""
+
+    def _seed_legacy(self, tmp_path, monkeypatch):
+        legacy = {
+            "saved_datasets_dir": "/tmp/legacy",  # server tier
+            "volume": 0.33,  # user tier
+            "theme": "light",  # user tier
+        }
+        server_path = tmp_path / "settings.json"
+        server_path.write_text(json.dumps(legacy))
+        monkeypatch.setattr(settings_mod, "SETTINGS_PATH", server_path)
+        settings_mod.set_user_data_dir_override(tmp_path / "users")
+        settings_mod.reset()
+        return server_path
+
+    def test_migration_writes_under_file_lock(self, tmp_path, monkeypatch):
+        """Both the default-user write and the server rewrite happen inside a
+        ``file_lock`` for their target file."""
+        import contextlib
+        from pathlib import Path
+
+        server_path = self._seed_legacy(tmp_path, monkeypatch)
+
+        locked: list[str] = []
+        real_file_lock = settings_store_mod.file_lock
+
+        @contextlib.contextmanager
+        def recording_file_lock(path):
+            locked.append(Path(path).name)
+            with real_file_lock(path):
+                yield
+
+        monkeypatch.setattr(settings_store_mod, "file_lock", recording_file_lock)
+        try:
+            # Triggers ensure_server_loaded -> load+migrate.
+            assert settings_mod.get_volume() == 0.33
+            # Server file locked for the load+migrate; default user's file
+            # locked for the migration write.
+            assert "settings.json" in locked
+            assert "user_settings.json" in locked
+            # Migration still produced the correct split.
+            remaining = json.loads(server_path.read_text())
+            assert "volume" not in remaining
+            assert remaining["saved_datasets_dir"] == "/tmp/legacy"
+        finally:
+            settings_mod.set_user_data_dir_override(None)
+            settings_mod.reset()
+
+    def test_concurrent_first_load_migrates_once(self, tmp_path, monkeypatch):
+        """Four threads racing the first load must not double-migrate or
+        deadlock; the migration body runs exactly once."""
+        import threading
+
+        server_path = self._seed_legacy(tmp_path, monkeypatch)
+
+        calls = {"n": 0}
+        real = settings_store_mod.UserSettingsStore._maybe_migrate_legacy_settings
+
+        def counting(self, cache, path):
+            calls["n"] += 1
+            return real(self, cache, path)
+
+        monkeypatch.setattr(
+            settings_store_mod.UserSettingsStore, "_maybe_migrate_legacy_settings", counting
+        )
+        try:
+            barrier = threading.Barrier(4)
+            results: list[float] = []
+            errors: list[Exception] = []
+
+            def worker():
+                try:
+                    barrier.wait(timeout=5)
+                    results.append(settings_mod.get_volume())
+                except Exception as exc:  # pragma: no cover - surfaced below
+                    errors.append(exc)
+
+            threads = [threading.Thread(target=worker) for _ in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+            assert not errors, f"workers raised: {errors}"
+            for t in threads:
+                assert not t.is_alive(), "thread hung (likely deadlock)"
+            assert results == [0.33] * 4
+            # The first thread to win the server file lock migrates; the rest
+            # find the cache already published and skip the body entirely.
+            assert calls["n"] == 1
+            remaining = json.loads(server_path.read_text())
+            assert "volume" not in remaining
+        finally:
+            settings_mod.set_user_data_dir_override(None)
+            settings_mod.reset()
+
+
 class TestBackgroundThreadPropagation:
     def test_thread_local_user_routes_writes(self, isolated_settings):
         """A background thread's settings writes resolve to its thread-local user."""

--- a/tests/core/test_per_user_settings.py
+++ b/tests/core/test_per_user_settings.py
@@ -289,9 +289,7 @@ class TestMigrationCrossProcessLock:
             calls["n"] += 1
             return real(self, cache, path)
 
-        monkeypatch.setattr(
-            settings_store_mod.UserSettingsStore, "_maybe_migrate_legacy_settings", counting
-        )
+        monkeypatch.setattr(settings_store_mod.UserSettingsStore, "_maybe_migrate_legacy_settings", counting)
         try:
             barrier = threading.Barrier(4)
             results: list[float] = []

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -785,3 +785,65 @@ class TestConcurrentWrites:
         assert "sibling" in final["autofind_detectors"]
         assert "ours-pre" in final["autofind_detectors"]
         assert "ours-post" in final["autofind_detectors"]
+
+
+class TestFileLockWithoutFcntl:
+    """H28 residual follow-up: on a platform without ``fcntl`` (Windows) the
+    cross-process ``file_lock`` degrades to the in-process lock only.  That
+    fallback must still serialise same-path writers and not crash."""
+
+    def test_file_lock_serialises_in_process_without_fcntl(self, tmp_path, monkeypatch):
+        """Two threads can't hold the same path's ``file_lock`` at once even
+        when ``fcntl`` is unavailable (in-process lock still enforces it)."""
+        import threading
+
+        from vtsearch import settings_store as settings_store_mod
+
+        monkeypatch.setattr(settings_store_mod, "_fcntl", None)
+        path = tmp_path / "x.json"
+
+        a_inside = threading.Event()
+        a_may_release = threading.Event()
+        b_acquired = threading.Event()
+        errors: list[Exception] = []
+
+        def hold_a():
+            try:
+                with settings_store_mod.file_lock(path):
+                    a_inside.set()
+                    a_may_release.wait(timeout=5)
+            except Exception as exc:  # pragma: no cover - surfaced below
+                errors.append(exc)
+
+        def hold_b():
+            try:
+                a_inside.wait(timeout=5)
+                with settings_store_mod.file_lock(path):
+                    b_acquired.set()
+            except Exception as exc:  # pragma: no cover - surfaced below
+                errors.append(exc)
+
+        ta = threading.Thread(target=hold_a)
+        tb = threading.Thread(target=hold_b)
+        ta.start()
+        tb.start()
+
+        assert a_inside.wait(timeout=5)
+        # While A holds the lock, B must be blocked.
+        assert not b_acquired.wait(timeout=0.3), "B acquired the lock while A held it"
+        a_may_release.set()
+        assert b_acquired.wait(timeout=5), "B never acquired the lock after A released"
+
+        ta.join(timeout=5)
+        tb.join(timeout=5)
+        assert not errors, f"threads raised: {errors}"
+
+    def test_settings_write_round_trips_without_fcntl(self, isolated_settings, monkeypatch):
+        """A normal read-modify-write still works with ``fcntl`` unavailable."""
+        from vtsearch import settings_store as settings_store_mod
+
+        monkeypatch.setattr(settings_store_mod, "_fcntl", None)
+        settings_mod.set_volume(0.5)
+        settings_mod.set_inclusion(3)
+        assert settings_mod.get_volume() == pytest.approx(0.5)
+        assert settings_mod.get_inclusion() == 3

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -968,6 +968,115 @@ class TestSyncFromSourceFreshness:
         assert probes["n"] - baseline <= 1
 
 
+class TestSyncDedupMarker:
+    """H28 residual follow-up: a per-user on-disk marker records the source
+    version last applied, so a *fresh* worker whose first read finds the
+    source unchanged skips the duplicate ``source.load()`` (the values are
+    already on disk in the user file)."""
+
+    def _configure_and_pull(self, settings, tmp_path, source_file, value):
+        """Configure the source, then pull *value* into the local file.
+
+        Mirrors the freshness tests: ``set_settings_source_config`` pushes
+        local -> source, so we overwrite the source *after* configuring and
+        force a re-sync to pull the desired value back in."""
+        import os
+
+        config = {
+            "source_name": "server_json_file",
+            "field_values": {"filepath": str(source_file)},
+        }
+        settings.set_settings_source_config(config)
+        source_file.write_text(json.dumps({"volume": value}))
+        new_mtime = source_file.stat().st_mtime_ns + 10_000_000_000
+        os.utime(source_file, ns=(new_mtime, new_mtime))
+        settings._sync_state["default"].last_check_monotonic -= 5.0
+        assert settings.get_volume() == value
+
+    def test_fresh_worker_adopts_marker_and_skips_load(self, tmp_path, isolated_settings, monkeypatch):
+        from vtsearch import settings
+        from vtsearch import settings_store as settings_store_mod
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source_file = tmp_path / "remote.json"
+        self._configure_and_pull(settings, tmp_path, source_file, 0.66)
+
+        # The first worker's pull stamped the dedup marker.
+        marker_version = settings_store_mod._read_sync_marker(isolated_settings._user)
+        assert marker_version is not None
+
+        # Simulate a fresh worker: forget in-memory sync state + user cache so
+        # the next read reloads the user file from disk and hits the
+        # first-attempt branch.  The source is unchanged since the marker.
+        settings._sync_state.pop("default", None)
+        settings._user_caches.pop("default", None)
+
+        src = get_settings_source("server_json_file")
+        assert src is not None
+        loads = {"n": 0}
+        real_load = src.load
+
+        def counting_load(fv):
+            loads["n"] += 1
+            return real_load(fv)
+
+        monkeypatch.setattr(src, "load", counting_load)
+
+        # Value comes straight from the already-synced user file; no load.
+        assert settings.get_volume() == 0.66
+        assert loads["n"] == 0
+        state = settings._sync_state["default"]
+        assert state.last_sync_succeeded is True
+        assert state.last_version == marker_version
+
+    def test_stale_marker_falls_back_to_load(self, tmp_path, isolated_settings, monkeypatch):
+        """If the source changed since the marker, the fresh worker must NOT
+        adopt it - it does the full load and picks up the new value."""
+        import os
+
+        from vtsearch import settings
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source_file = tmp_path / "remote.json"
+        self._configure_and_pull(settings, tmp_path, source_file, 0.66)
+
+        # Source moves on after the marker was written.
+        source_file.write_text(json.dumps({"volume": 0.77}))
+        new_mtime = source_file.stat().st_mtime_ns + 20_000_000_000
+        os.utime(source_file, ns=(new_mtime, new_mtime))
+
+        settings._sync_state.pop("default", None)
+        settings._user_caches.pop("default", None)
+
+        src = get_settings_source("server_json_file")
+        assert src is not None
+        loads = {"n": 0}
+        real_load = src.load
+
+        def counting_load(fv):
+            loads["n"] += 1
+            return real_load(fv)
+
+        monkeypatch.setattr(src, "load", counting_load)
+
+        # Marker version != current source version -> full load -> new value.
+        assert settings.get_volume() == 0.77
+        assert loads["n"] >= 1
+
+    def test_clearing_source_removes_marker(self, tmp_path, isolated_settings):
+        from vtsearch import settings
+        from vtsearch import settings_store as settings_store_mod
+
+        source_file = tmp_path / "remote.json"
+        self._configure_and_pull(settings, tmp_path, source_file, 0.66)
+        marker_path = settings_store_mod._sync_marker_path(isolated_settings._user)
+        assert marker_path.exists()
+
+        # Clearing the source drops the now-defunct dedup marker.
+        settings.set_settings_source_config(None)
+        assert not marker_path.exists()
+
+
 # ---------------------------------------------------------------------------
 # DetectorContext.labelset_source field
 # ---------------------------------------------------------------------------

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -246,7 +246,7 @@ _SERVER_KEYS: frozenset[str] = frozenset(ServerSettings.model_fields.keys())
 #: still expect a value placed in ``settings.json`` to take effect. The
 #: read-through (see :func:`_read_value`) makes that work without the
 #: destructive legacy migration moving them out of the server file (see
-#: ``UserSettingsStore._maybe_migrate_legacy_settings_locked``, which skips
+#: ``UserSettingsStore._maybe_migrate_legacy_settings``, which skips
 #: these keys).
 _DEFAULT_USER_FALLBACK_KEYS: frozenset[str] = frozenset(
     {"autofind_detectors", "autofind_exporter", "autofind_exporter_field_values"}

--- a/vtsearch/settings_store.py
+++ b/vtsearch/settings_store.py
@@ -89,6 +89,62 @@ def _atomic_write(path: Path, data: dict[str, Any]) -> None:
         raise
 
 
+# ---------------------------------------------------------------------------
+# Cross-worker sync-dedup marker (H28 residual follow-up)
+#
+# On a fresh container every Gunicorn worker independently runs
+# sync-from-source once per user, duplicating the (potentially expensive)
+# ``source.load()`` read.  A worker that finishes its sync stamps a small
+# sibling marker next to the user's settings file recording the source
+# ``peek_version`` it applied.  A later worker whose first read finds the
+# source *unchanged* at that version skips its own load: the synced values
+# are already on disk in the user file (which it loaded into its cache),
+# so re-reading the source would be pure duplicate I/O.  The marker is a
+# best-effort optimisation only - any read/write/serialisation failure is
+# swallowed and the worker falls back to the full load.
+# ---------------------------------------------------------------------------
+
+
+def _sync_marker_path(user_path: Path) -> Path:
+    """Sibling marker recording the source version last applied to *user_path*."""
+    return user_path.with_name(user_path.name + ".syncmark")
+
+
+def _read_sync_marker(user_path: Path) -> Any:
+    """Return the source version token stashed in *user_path*'s sync marker.
+
+    Best-effort: returns ``None`` if the marker is absent, unreadable, or
+    malformed.  The token is whatever :meth:`SettingsSource.peek_version`
+    produced at the last successful sync (an ``st_mtime_ns`` int, an ETag
+    string, ...).
+    """
+    marker = _sync_marker_path(user_path)
+    try:
+        if not marker.exists():
+            return None
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if isinstance(data, dict):
+        return data.get("version")
+    return None
+
+
+def _write_sync_marker(user_path: Path, version: Any) -> None:
+    """Record *version* as the source version applied to *user_path*.
+
+    Best-effort: a ``None`` token (source can't cheaply report a version),
+    a non-JSON-serialisable token, or any write failure is swallowed - the
+    marker is a pure cross-worker dedup hint, never a correctness input.
+    """
+    if version is None:
+        return
+    try:
+        _atomic_write(_sync_marker_path(user_path), {"version": version})
+    except Exception:
+        pass
+
+
 # Per-path in-process locks. Used in two ways:
 # 1. As a fallback when ``fcntl`` is unavailable (Windows).
 # 2. Held in addition to the cross-process flock so that, within a single
@@ -263,12 +319,44 @@ class UserSettingsStore:
     # -- cache loaders ---------------------------------------------------
 
     def ensure_server_loaded(self) -> dict[str, Any]:
-        """Load the server-tier cache on first access and migrate legacy keys."""
+        """Load the server-tier cache on first access and migrate legacy keys.
+
+        The first load runs under the cross-process *server* file lock so the
+        one-shot legacy migration's ``_atomic_write`` calls are protected
+        against a sibling worker migrating the same files concurrently (H28
+        residual follow-up). The file lock is taken *before* ``settings_lock``
+        (the canonical file-lock -> settings-lock order), so this must never
+        be called while already holding ``settings_lock``: callers that need
+        the server tier loaded before touching a user cache (see
+        :meth:`ensure_user_loaded`) invoke it *outside* the lock.
+        """
         with self._lock:
-            if self._server_cache is None:
-                self._server_cache = _load_path(self._server_path())
-                self._maybe_migrate_legacy_settings_locked()
+            if self._server_cache is not None:
+                return self._server_cache
+        self._load_and_migrate_server()
+        with self._lock:
+            assert self._server_cache is not None
             return self._server_cache
+
+    def _load_and_migrate_server(self) -> None:
+        """Read the server settings file and run the one-shot legacy migration.
+
+        Runs under the cross-process server file lock. The freshly-read dict
+        is migrated *before* it is published to ``self._server_cache`` so no
+        concurrent reader ever observes the intermediate (pre-migration)
+        shape.
+        """
+        server_path = self._server_path()
+        with file_lock(server_path):
+            with self._lock:
+                if self._server_cache is not None:
+                    # A sibling thread completed the load while we waited
+                    # for the file lock.
+                    return
+            fresh = _load_path(server_path)
+            self._maybe_migrate_legacy_settings(fresh, server_path)
+            with self._lock:
+                self._server_cache = fresh
 
     def ensure_user_loaded(self, username: str) -> dict[str, Any]:
         """Load *username*'s per-user cache on first access and reconcile with the source.
@@ -286,17 +374,18 @@ class UserSettingsStore:
         sync, so a concurrent thread B saw the marker and returned the
         pre-sync local cache.
         """
+        # Ensure the server tier is loaded (and the one-shot legacy migration
+        # has run) *before* we take ``settings_lock``: ``ensure_server_loaded``
+        # acquires the server file lock, and taking a file lock while holding
+        # ``settings_lock`` would invert the canonical file -> settings order.
+        # The migration may populate ``_user_caches["default"]``; we pick that
+        # up below.
+        self.ensure_server_loaded()
         with self._lock:
             cache = self._user_caches.get(username)
             if cache is None:
-                # Make sure server tier is loaded (and legacy migration has run)
-                # before we materialise a fresh user cache, otherwise the legacy
-                # migration step might not see this user yet.
-                self.ensure_server_loaded()
-                cache = self._user_caches.get(username)
-                if cache is None:
-                    cache = _load_path(self._user_path(username))
-                    self._user_caches[username] = cache
+                cache = _load_path(self._user_path(username))
+                self._user_caches[username] = cache
             # Re-entrance guard: a setter inside ``_apply_settings`` re-enters
             # this function while the outer call holds the sync lock.  Skip
             # the sync path so we don't recurse or fire another peek probe.
@@ -350,7 +439,12 @@ class UserSettingsStore:
         if state is None or state.last_check_monotonic == 0.0:
             # No state, or state exists only because a setter populated it
             # via ``mark_user_keys_dirty`` before we'd ever talked to the
-            # source.  Either way: first sync attempt is due.
+            # source.  Either way: this process's first sync attempt is due -
+            # unless a sibling worker already synced this user's file at the
+            # source's current version, in which case adopt that (the values
+            # are already on disk) and skip the duplicate load.
+            if self._adopt_sync_marker_if_current(username, cache_cfg):
+                return False
             return True
 
         if not state.last_sync_succeeded:
@@ -390,6 +484,44 @@ class UserSettingsStore:
                     s.last_check_monotonic = now
             return False
 
+        return True
+
+    def _adopt_sync_marker_if_current(self, username: str, cache_cfg: dict[str, Any]) -> bool:
+        """Skip the first sync-from-source load if a sibling worker already did it.
+
+        Returns ``True`` (and stamps ``_sync_state`` as freshly synced) when
+        an on-disk marker records that *username*'s file was synced at the
+        source's *current* version - the values are already on disk, so
+        re-reading the source would be duplicate I/O (H28 residual
+        follow-up).  Returns ``False`` (caller does the full load) when there
+        is no marker, the source is unknown, it can't cheaply report a
+        version, or the versions differ.
+        """
+        marker_version = _read_sync_marker(self._user_path(username))
+        if marker_version is None:
+            return False
+
+        from vtsearch.settings_io.sources import get_settings_source
+
+        source = get_settings_source(cache_cfg["source_name"])
+        if source is None:
+            return False
+        field_values = cache_cfg.get("field_values", {})
+        try:
+            current_version = source.peek_version(field_values)
+        except Exception:
+            return False
+        if current_version is None or current_version != marker_version:
+            return False
+
+        # The user file already reflects the source at this version (a sibling
+        # worker applied it and stamped the marker).  Adopt it without a load.
+        with self._lock:
+            self._sync_state[username] = UserSyncState(
+                last_version=current_version,
+                last_check_monotonic=time.monotonic(),
+                last_sync_succeeded=True,
+            )
         return True
 
     def _run_sync_from_source(self, username: str) -> None:
@@ -458,22 +590,33 @@ class UserSettingsStore:
             # confirms the source matches local (which clears them) or a
             # manual POST sync clears them on purpose.
 
-    def _maybe_migrate_legacy_settings_locked(self) -> None:
+        # Stamp the cross-worker dedup marker so a sibling worker can skip
+        # its own first load while the source stays at this version.
+        _write_sync_marker(self._user_path(username), new_version)
+
+    def _maybe_migrate_legacy_settings(self, server_cache: dict[str, Any], server_path: Path) -> None:
         """Move per-user keys from a legacy ``data/settings.json`` into the
         default user's per-user file (one-shot, idempotent).
 
-        Called from :meth:`ensure_server_loaded` with the settings lock held.
+        Called from :meth:`_load_and_migrate_server` with the **server file
+        lock** held. Operates on *server_cache* - the freshly-read,
+        not-yet-published dict - in place, so the migrated shape is what gets
+        published to ``self._server_cache``. The default user's file write
+        takes that file's own cross-process ``file_lock`` (server-then-user
+        ordering; no other path acquires both, so no deadlock), giving both
+        ``_atomic_write`` calls full multi-process protection - previously
+        they wrote without any cross-process lock (H28 residual follow-up).
         """
-        if self._legacy_migrated:
-            return
-        self._legacy_migrated = True
-        assert self._server_cache is not None
+        with self._lock:
+            if self._legacy_migrated:
+                return
+            self._legacy_migrated = True
         # ``fallback_keys`` legitimately live in the server file (the
         # default user reads through to them), so they are NOT "orphaned per-user"
         # keys; leave them in place rather than moving them into the default user's
         # file (which would also rewrite a CLI ``--settings`` file under the user).
         legacy_user_entries = {
-            k: v for k, v in self._server_cache.items() if k not in self._server_keys and k not in self._fallback_keys
+            k: v for k, v in server_cache.items() if k not in self._server_keys and k not in self._fallback_keys
         }
         if not legacy_user_entries:
             return
@@ -483,39 +626,42 @@ class UserSettingsStore:
         # multi-user upgrades (admins can copy it into other users' files).
         default_user = "default"
         user_path = self._user_path(default_user)
-        if user_path.exists():
-            existing = _load_path(user_path)
-            # Existing per-user values win - never clobber a real user file.
-            merged: dict[str, Any] = {**legacy_user_entries, **existing}
-        else:
-            merged = dict(legacy_user_entries)
-        try:
-            _atomic_write(user_path, merged)
-        except Exception as exc:
-            logger.warning("Legacy settings migration to %s failed: %s", user_path, exc)
-            return
+        with file_lock(user_path):
+            if user_path.exists():
+                existing = _load_path(user_path)
+                # Existing per-user values win - never clobber a real user file.
+                merged: dict[str, Any] = {**legacy_user_entries, **existing}
+            else:
+                merged = dict(legacy_user_entries)
+            try:
+                _atomic_write(user_path, merged)
+            except Exception as exc:
+                logger.warning("Legacy settings migration to %s failed: %s", user_path, exc)
+                return
 
-        # Build the server-tier shape first; a failure here must not pop the
-        # in-memory cache, or server_cache and disk would silently diverge. Keep
-        # the default-user fallback keys in the server file (they are read through
-        # there, not migrated out).
-        new_server = {k: v for k, v in self._server_cache.items() if k in self._server_keys or k in self._fallback_keys}
-        try:
-            _atomic_write(self._server_path(), new_server)
-        except Exception as exc:
-            logger.warning("Failed to rewrite server settings after legacy migration: %s", exc)
-            return
-        for k in list(self._server_cache.keys()):
-            if k not in self._server_keys and k not in self._fallback_keys:
-                self._server_cache.pop(k, None)
+            # Build the server-tier shape first; a failure here must not mutate
+            # the fresh dict, or the published server_cache and disk would
+            # silently diverge. Keep the default-user fallback keys in the
+            # server file (they are read through there, not migrated out).
+            new_server = {k: v for k, v in server_cache.items() if k in self._server_keys or k in self._fallback_keys}
+            try:
+                _atomic_write(server_path, new_server)
+            except Exception as exc:
+                logger.warning("Failed to rewrite server settings after legacy migration: %s", exc)
+                return
 
-        # Refresh the default user's cache if it was already materialised
-        # (unlikely, since this runs from ensure_server_loaded, but safe).
-        self._user_caches[default_user] = _load_path(user_path)
+            # Mutate the not-yet-published dict in place to the migrated shape.
+            for k in list(server_cache.keys()):
+                if k not in self._server_keys and k not in self._fallback_keys:
+                    server_cache.pop(k, None)
+
+            # Refresh the default user's cache if it was already materialised.
+            with self._lock:
+                self._user_caches[default_user] = _load_path(user_path)
         logger.info(
             "Migrated %d legacy per-user setting(s) from %s into %s",
             len(legacy_user_entries),
-            self._server_path(),
+            server_path,
             user_path,
         )
 
@@ -632,6 +778,8 @@ class UserSettingsStore:
                 last_sync_succeeded=True,
                 dirty_keys=set(),
             )
+        # Local now matches source at this version - stamp the dedup marker.
+        _write_sync_marker(self._user_path(username), new_version)
 
     def sync_from_source_now(self, cfg: dict[str, Any], username: str) -> dict[str, Any] | None:
         """Pull settings from *cfg*'s source and apply them (explicit/manual).
@@ -686,6 +834,8 @@ class UserSettingsStore:
                 last_sync_succeeded=True,
                 dirty_keys=set(),
             )
+        # Local now matches source at this version - stamp the dedup marker.
+        _write_sync_marker(self._user_path(username), new_version)
 
         return imported
 
@@ -704,6 +854,10 @@ class UserSettingsStore:
         """Forget *username*'s sync bookkeeping (e.g. when the source is cleared)."""
         with self._lock:
             self._sync_state.pop(username, None)
+        # The dedup marker described a now-defunct source; drop it so a later
+        # re-configure can't consult a stale version. Best-effort.
+        with contextlib.suppress(OSError):
+            _sync_marker_path(self._user_path(username)).unlink(missing_ok=True)
 
     def reset(self) -> None:
         """Reset every in-memory cache and sync state (for testing).

--- a/vtsearch/settings_store.py
+++ b/vtsearch/settings_store.py
@@ -459,6 +459,18 @@ class UserSettingsStore:
             return False
 
         # Window elapsed - cheap probe to detect upstream changes.
+        return self._source_version_changed(username, cache_cfg, state.last_version, now)
+
+    def _source_version_changed(self, username: str, cache_cfg: dict[str, Any], last_version: Any, now: float) -> bool:
+        """Probe the source and report whether it changed since *last_version*.
+
+        Returns ``True`` only when the source reports a concrete version that
+        differs from ``last_version`` (a full re-sync is due).  On any no-sync
+        outcome (unknown source, transient peek failure, source can't cheaply
+        report a version, or the version is unchanged) it refreshes
+        ``last_check_monotonic`` so the probe stays rate-limited, and returns
+        ``False``.
+        """
         from vtsearch.settings_io.sources import get_settings_source
 
         source = get_settings_source(cache_cfg["source_name"])
@@ -470,13 +482,9 @@ class UserSettingsStore:
         except Exception:
             # Transient peek failure - back off until next window, keep
             # serving the local cache.
-            with self._lock:
-                s = self._sync_state.get(username)
-                if s is not None:
-                    s.last_check_monotonic = now
-            return False
+            current_version = last_version  # forces the "unchanged" branch below
 
-        if current_version is None or current_version == state.last_version:
+        if current_version is None or current_version == last_version:
             # Source can't cheaply check, or unchanged since last sync.
             with self._lock:
                 s = self._sync_state.get(username)


### PR DESCRIPTION
## Summary

H28's core fix (per-user settings RMW under a cross-process `flock`) already shipped. This closes the three residual multi-process items that the audit doc parked in `docs/plans/logical-bug-audit.md` § Open follow-ups.

**1. Cross-worker sync dedup (was: duplicate `source.load()` per worker).**
On a fresh container every Gunicorn worker independently ran sync-from-source once per user. A best-effort per-user marker (`<user_settings.json>.syncmark`, written by `_write_sync_marker` on every successful sync) now records the source `peek_version` last applied. A fresh worker whose first read finds the source unchanged at that version adopts it and skips the duplicate load — the values are already on disk in the user file it just loaded (`_adopt_sync_marker_if_current`). The marker is cleared when the source is cleared, and any read/write/serialisation failure falls back to a full load.

**2. Legacy migration now writes under the cross-process lock.**
`_maybe_migrate_legacy_settings` previously called `_atomic_write` on both the user and server files with no cross-process lock. `ensure_server_loaded` now performs its first load + one-shot migration inside `_load_and_migrate_server` under the server `file_lock`, and the migration takes the default user's `file_lock` around its write, so both writes are multi-process safe. To preserve the canonical **file-lock → settings-lock** order, the migration was hoisted out of `settings_lock`: callers (`ensure_user_loaded`) now invoke `ensure_server_loaded` outside the lock. The freshly-read dict is migrated before it is published to `server_cache`, so no reader observes an intermediate shape.

**3. Windows `fcntl` fallback is now covered by a test.**
Still Linux-only in production; the in-process-lock fallback is now exercised so a Windows contributor gets a green signal that same-path writers still serialise.

Also extracted `_source_version_changed` from `_needs_sync_from_source` to keep it under the complexity limit after the marker branch was added.

## Tests

- `tests/core/test_per_user_settings.py::TestMigrationCrossProcessLock` — migration writes under `file_lock`; concurrent first-load migrates exactly once with no deadlock.
- `tests/io/test_sync_sources.py::TestSyncDedupMarker` — fresh worker adopts a current marker and skips the load; a stale marker falls back to a full load; clearing the source removes the marker.
- `tests/core/test_settings.py::TestFileLockWithoutFcntl` — `file_lock` still serialises and round-trips writes with `fcntl` unavailable.

Full `./run-tests.sh` green (5508 passed, 1 skipped). No behavior changes to the settings schema or public API.

## Backwards compatibility

No breaking changes. The new `.syncmark` sibling files are created lazily and ignored if absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpvGZMG1TYjZebpb5huPt9)_