### PR TITLE
Implement media_revision counter for embedding-matrix cache invalidation (Pattern #4)

### DIFF
--- a/docs/plans/logical-bug-audit.md
+++ b/docs/plans/logical-bug-audit.md
@@ -38,13 +38,21 @@ error/exception flow, (15) frontend↔backend contract seams.
 Cross-cutting items still owed. Everything ID'd (C/H/M/L) is resolved; these are
 the only remaining work.
 
-- **Pattern #4 — `media_revision` counter is still unimplemented.** The C4
-  stage-level invalidation closes the known clip/dedup hole, but any future
-  mutation site that changes embeddings without changing the id set will
-  reintroduce the same class of bug. A `media_revision` counter on
-  `DatasetContext` bumped from every `medias` mutation (or a `MediasDict`
-  subclass that does so transparently) would neutralise the whole category and
-  let the matrix accessor compare a single int instead of two id lists.
+- **Pattern #4 — `media_revision` counter. Shipped (hybrid).**
+  `DatasetContext` now carries a monotonic `media_revision` counter, and
+  `DatasetContext.medias` is a `MediasDict` (dict subclass) that bumps it on
+  every *structural* mutation (add / remove / replace / clear / wholesale
+  reassignment). The embedding-matrix and region-matrix caches key their
+  validity on the counter (a single int) instead of comparing two sorted id
+  lists, so a mutation that changes vectors without changing the id set now
+  invalidates them. **Residual caveat by design:** a dict subclass cannot
+  observe an *in-place* rewrite of a value dict (`medias[cid]["embedding"] =
+  vec` during re-embed / clip), so those stages still call
+  `invalidate_embedding_matrix` (which bumps the counter) after the rewrite —
+  the counter makes that the single uniform "vectors changed" signal rather
+  than each site knowing which caches to clear. Any *future* in-place
+  vector-rewrite site must likewise call `bump_media_revision()`; structural
+  churn needs nothing. (`test_embedding_matrix.py::TestMediaRevisionCounter`.)
 
 - **H28 residual multi-process items** (from the per-user settings RMW fix):
   - `_synced_users` is still process-local, so on a fresh container every worker
@@ -174,8 +182,8 @@ the only remaining work.
 ## Root-cause patterns (reference)
 
 The findings collapsed into a small number of root causes; addressing each in
-one PR fixed many findings at once. All are resolved except Pattern #4 (see Open
-follow-ups).
+one PR fixed many findings at once. All are resolved (Pattern #4 shipped as a
+hybrid `media_revision` counter; see Open follow-ups for the by-design caveat).
 
 1. **Background-thread context propagation** — every `Thread(target=…)` sets
    user/dataset/detector thread-locals in `try/finally` (helper:
@@ -186,7 +194,10 @@ follow-ups).
 3. **Achievement recording at one site** — `record_vote()` moved into
    `apply_label_with_click_time`, inside the state lock. (C8.)
 4. **Embedding-matrix cache invalidation** — a `media_revision` counter bumped
-   on every `medias` mutation. **(Open — see follow-ups.)** (C4.)
+   on every `medias` mutation (structural bumps come free via `MediasDict`;
+   in-place vector rewrites bump through `invalidate_embedding_matrix`). The
+   matrix/region caches key on the counter, not id-list compares. **Shipped**
+   (hybrid; see the Pattern #4 follow-up note above for the by-design caveat). (C4.)
 5. **Embedder identity is first-class** — track the detector's training embedder
    separately; every train/score path compares and clears caches on mismatch. (H5, H22.)
 6. **`X-Dataset-Id` / `X-Detector-Id` required, not silently defaulted** — 400

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -823,8 +823,9 @@ inherently a web-app affordance.
 
 ```python
 class DatasetContext:
-    """Per-dataset state: medias dict, diversity tree, display name, cached embedding
-    matrix. Mutable, RLock-protected."""
+    """Per-dataset state: medias (a MediasDict that bumps media_revision on
+    mutation), diversity tree, display name, cached embedding matrix keyed on
+    media_revision. Mutable, RLock-protected."""
 
 class DetectorContext:
     """Per-detector state: votes, labelset, label_embeddings cache, click times,

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -313,3 +313,91 @@ class TestEmbeddingMatrixLockScoping:
         assert mat.shape == (4, 4)
         # Cache must not hold the stale [1,2,3,4] build now that medias changed.
         assert ctx._emb_matrix_ids != [1, 2, 3, 4]
+
+
+class TestMediaRevisionCounter:
+    """Root-cause Pattern #4: the matrix cache keys on ``media_revision``.
+
+    Structural mutations bump the counter transparently through
+    :class:`MediasDict`; an in-place vector rewrite (same id set, different
+    vectors) is invisible to a dict subclass and must be signalled by
+    ``invalidate_embedding_matrix`` / ``bump_media_revision`` — this is the
+    exact C4 miscompute the counter neutralises.
+    """
+
+    def _ctx(self) -> DatasetContext:
+        ctx = DatasetContext("test_media_revision")
+        for cid in (1, 2, 3):
+            ctx.medias[cid] = {
+                "id": cid,
+                "embedder": "e5",
+                "embeddings": {"e5": np.full(4, float(cid), dtype=np.float32)},
+            }
+        return ctx
+
+    def test_structural_mutations_bump_revision(self):
+        ctx = DatasetContext("test_bump_structural")
+        assert ctx.media_revision == 0
+        ctx.medias[1] = {"id": 1, "embedder": "e5", "embeddings": {"e5": np.ones(4, dtype=np.float32)}}
+        after_add = ctx.media_revision
+        assert after_add > 0
+        del ctx.medias[1]
+        assert ctx.media_revision > after_add
+
+    def test_wholesale_reassignment_bumps_revision(self):
+        ctx = DatasetContext("test_bump_reassign")
+        before = ctx.media_revision
+        ctx.medias = {1: {"id": 1, "embedder": "e5", "embeddings": {"e5": np.ones(4, dtype=np.float32)}}}
+        assert ctx.media_revision > before
+        # The assigned mapping is wrapped so it keeps bumping on later edits.
+        after_assign = ctx.media_revision
+        ctx.medias[2] = {"id": 2, "embedder": "e5", "embeddings": {"e5": np.full(4, 2.0, dtype=np.float32)}}
+        assert ctx.media_revision > after_assign
+
+    def test_no_bump_without_mutation(self):
+        ctx = self._ctx()
+        rev = ctx.media_revision
+        _ = ctx.medias[1]  # a read must not bump
+        _ = list(ctx.medias.keys())
+        assert ctx.media_revision == rev
+
+    def test_cache_reused_across_calls_at_same_revision(self):
+        ctx = self._ctx()
+        ids1, mat1 = get_embedding_matrix(ctx)
+        ids2, mat2 = get_embedding_matrix(ctx)
+        assert ids1 == ids2 == [1, 2, 3]
+        # Same underlying array object → served from cache, not rebuilt.
+        assert mat1 is mat2
+        assert ctx._emb_matrix_revision == ctx.media_revision
+
+    def test_inplace_vector_rewrite_needs_explicit_bump(self):
+        """A dict-subclass can't see ``medias[cid][...] = vec``; until the
+        counter is bumped the cache keeps serving the pre-rewrite matrix."""
+        ctx = self._ctx()
+        _, mat_before = get_embedding_matrix(ctx)
+        assert mat_before[0, 0] == 1.0
+
+        # Rewrite media 1's vector in place — no structural change, no bump.
+        ctx.medias[1]["embeddings"]["e5"] = np.full(4, 42.0, dtype=np.float32)
+        _, mat_stale = get_embedding_matrix(ctx)
+        assert mat_stale[0, 0] == 1.0  # still the cached pre-rewrite row
+
+        # The embed/clip stages signal the in-place change via this call.
+        invalidate_embedding_matrix(ctx)
+        _, mat_fresh = get_embedding_matrix(ctx)
+        assert mat_fresh[0, 0] == 42.0
+
+    def test_same_id_set_new_content_not_served_stale(self):
+        """Reassigning ``medias`` to a fresh dict with the *same ids* but new
+        vectors must invalidate the cache (the id-list key could not tell)."""
+        ctx = self._ctx()
+        _, mat_before = get_embedding_matrix(ctx)
+        assert mat_before[0, 0] == 1.0
+
+        ctx.medias = {
+            cid: {"id": cid, "embedder": "e5", "embeddings": {"e5": np.full(4, float(cid) + 100.0, dtype=np.float32)}}
+            for cid in (1, 2, 3)
+        }
+        ids, mat_after = get_embedding_matrix(ctx)
+        assert ids == [1, 2, 3]
+        assert mat_after[0, 0] == 101.0

--- a/vtscore/docs/packages/embedding.md
+++ b/vtscore/docs/packages/embedding.md
@@ -248,7 +248,8 @@ exist because parts of the legacy app reach into the backbone.
 For any sort or learned-sort over a loaded dataset, you need every
 media's embedding as a contiguous `(N, D) float32` array.
 `vtscore/embedding/matrix.py` keeps that array on `DatasetContext`
-and rebuilds it only when the set of loaded media IDs changes.
+and rebuilds it only when the context's `media_revision` counter
+changes (bumped on every `medias` mutation).
 
 ```python
 def get_embedding_matrix(ctx: DatasetContext) -> tuple[list[int], np.ndarray]: ...
@@ -260,16 +261,18 @@ def get_embedding_matrix_for_snap(snap: dict) -> tuple[list[int], np.ndarray]: .
 
 ### How the cache works
 
-`DatasetContext._emb_matrix` and `DatasetContext._emb_matrix_ids` are
-the cache. `get_embedding_matrix(ctx)` (`vtscore/embedding/matrix.py:29`):
+`DatasetContext._emb_matrix`, `DatasetContext._emb_matrix_ids`, and
+`DatasetContext._emb_matrix_revision` are the cache.
+`get_embedding_matrix(ctx)` (`vtscore/embedding/matrix.py:29`):
 
 1. Acquires `vtscore.state.core._state_lock`.
-2. Computes `sorted_ids = sorted(ctx.medias.keys())`.
-3. If `sorted_ids == ctx._emb_matrix_ids`, returns the cached
-   `(ids, matrix)` directly - no rebuild.
+2. Snapshots `revision = ctx.media_revision`.
+3. If `ctx._emb_matrix_revision == revision` (and the matrix is
+   present), returns the cached `(ids, matrix)` directly - no rebuild.
 4. Otherwise, allocates an `(N, D) float32` array, fills it row by
    row from `media_embedding(ctx.medias[cid])` (the per-embedder
-   `media["embeddings"]` dict), and stores it on the context.
+   `media["embeddings"]` dict), and stores it on the context along
+   with the revision it was built at.
 
 Convert to torch with `torch.from_numpy(matrix)` for a zero-copy
 view. The matrix is contiguous, so it's safe to slice without
@@ -285,10 +288,16 @@ ids, matrix = get_embedding_matrix(ctx)   # (N, D) float32
 invalidate_embedding_matrix(ctx)          # next call rebuilds
 ```
 
-Callers that mutate `ctx.medias` directly don't strictly need to
-invalidate - the next access detects the new key set and rebuilds -
-but explicit invalidation is cheaper than the implicit "did the key
-set change?" walk and removes the ambiguity.
+Callers that add / remove / replace entries in `ctx.medias` don't need
+to invalidate: `ctx.medias` is a `MediasDict` that bumps
+`media_revision` on every structural mutation, so the next access sees
+the new revision and rebuilds. The one case that *does* need an explicit
+call is an **in-place** rewrite of an existing media's vector
+(`ctx.medias[cid]["embeddings"][name] = vec` during re-embed / clip): a
+dict subclass can't observe a mutation to a value's internals, so those
+stages call `invalidate_embedding_matrix(ctx)` (which bumps the counter)
+afterwards. See root-cause Pattern #4 in
+`docs/plans/logical-bug-audit.md`.
 
 `get_embedding_matrix_for_snap(snap)` (`vtscore/embedding/matrix.py:70`)
 is for callers that hold a media-dict snapshot (typically from

--- a/vtscore/docs/packages/state.md
+++ b/vtscore/docs/packages/state.md
@@ -46,17 +46,23 @@ Per-dataset mutable state. One context per loaded dataset.
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `dataset_id` | `str` | Registration key |
-| `medias` | `dict[int, dict[str, Any]]` | `cid -> media dict` for every loaded item |
+| `medias` | `MediasDict` | `cid -> media dict` for every loaded item; a `dict` subclass that bumps `media_revision` on every structural mutation |
+| `media_revision` | `int` (read-only) | Monotonic counter advanced on every `medias` mutation; the matrix caches key on it |
 | `diversity_tree` | `DiversityTree \| None` | Hierarchical clustering of the embeddings (built lazily) |
 | `dataset_display_name` | `str \| None` | UI-overridable name |
 | `_emb_matrix_ids` | `list[int] \| None` | Sorted media-ID list the matrix corresponds to |
 | `_emb_matrix` | `np.ndarray \| None` | Cached `(N, D)` contiguous float32 embedding matrix |
+| `_emb_matrix_revision` | `int \| None` | The `media_revision` the cached matrix was built at (cache key) |
 
 The cached matrix is rebuilt lazily by
 `vtscore.embedding.matrix.get_embedding_matrix` and reused across
 cosine sort, MLP scoring, and diversity-tree construction so the library
-doesn't rebuild an `(N, D)` matrix per call. `clear_medias()` drops both
-the matrix and the diversity tree.
+doesn't rebuild an `(N, D)` matrix per call. Cache validity is a single
+`media_revision` compare, so a mutation that changes vectors without
+changing the id set still invalidates it (root-cause Pattern #4). An
+in-place vector rewrite must bump the counter via
+`invalidate_embedding_matrix` / `bump_media_revision`. `clear_medias()`
+drops both the matrix and the diversity tree.
 
 ### `DetectorContext`
 

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -123,8 +123,10 @@ def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None
         embedder_name = _collapse_to_primary(ctx.medias, embedder_name)
         if embedder_name is None:
             cached_matrix = ctx._emb_matrix
+            # A revision match guarantees the id set is unchanged, so the live
+            # sorted_ids equals the cached ids the matrix rows correspond to.
             if cached_matrix is not None and ctx._emb_matrix_revision == revision:
-                return list(ctx._emb_matrix_ids), cached_matrix
+                return list(sorted_ids), cached_matrix
 
         if not sorted_ids:
             if embedder_name is None:

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -8,10 +8,15 @@ media IDs changes, so we cache one contiguous ``(N, D)`` float32 array
 on the active dataset context and hand callers a ``torch.from_numpy``
 view (zero-copy) when they need a tensor.
 
-Cache invalidation is keyed on ``sorted(ctx.medias.keys())``: when that
-list differs from the cached one, the matrix is rebuilt.  Callers that
-mutate ``ctx.medias`` don't need to do anything - the next access will
-detect the new key set and rebuild.
+Cache invalidation is keyed on ``ctx.media_revision``: when the counter
+differs from the one the cached matrix was built at, the matrix is
+rebuilt.  Structural mutations of ``ctx.medias`` (add / remove / replace
+an entry) bump the counter automatically via
+:class:`~vtscore.state.core.MediasDict`, so callers don't need to do
+anything.  An *in-place* rewrite of an existing media's vector (re-embed /
+clip) is invisible to a dict subclass, so those stages call
+``invalidate_embedding_matrix`` (which bumps the counter) after the
+rewrite - see root-cause Pattern #4 in ``docs/plans/logical-bug-audit.md``.
 
 Any media whose ``embedding`` is ``None`` causes the builder to raise
 ``ValueError`` instead of silently filling the row with NaN - the bug
@@ -109,17 +114,23 @@ def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None
     # numpy stack and stall every other request's before_request state-sync.
     with _state_lock:
         sorted_ids = sorted(ctx.medias.keys())
+        # Snapshot the revision under the lock; the cache is valid iff it still
+        # matches after the unlocked build (phase 3). Keying on the counter
+        # rather than an id-list compare also catches an in-place vector
+        # rewrite that leaves the id set unchanged (root-cause Pattern #4).
+        revision = ctx.media_revision
         # A routed name equal to the primary collapses to the cached path.
         embedder_name = _collapse_to_primary(ctx.medias, embedder_name)
         if embedder_name is None:
             cached_matrix = ctx._emb_matrix
-            if cached_matrix is not None and ctx._emb_matrix_ids == sorted_ids:
-                return list(sorted_ids), cached_matrix
+            if cached_matrix is not None and ctx._emb_matrix_revision == revision:
+                return list(ctx._emb_matrix_ids), cached_matrix
 
         if not sorted_ids:
             if embedder_name is None:
                 ctx._emb_matrix_ids = []
                 ctx._emb_matrix = np.empty((0, 0), dtype=np.float32)
+                ctx._emb_matrix_revision = revision
                 return [], ctx._emb_matrix
             return [], np.empty((0, 0), dtype=np.float32)
 
@@ -130,14 +141,15 @@ def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None
     # Phase 2 (unlocked): the heavy contiguous (N, D) build.
     matrix = _stack_embeddings(sorted_ids, medias_snapshot, embedder_name)
 
-    # Phase 3 (locked): repopulate the primary cache, double-checking the id
-    # set still matches so a media mutation during the unlocked build cannot
-    # cache a stale matrix. The named path never touches the cache.
+    # Phase 3 (locked): repopulate the primary cache, double-checking the
+    # revision still matches so a media mutation during the unlocked build
+    # cannot cache a stale matrix. The named path never touches the cache.
     if embedder_name is None:
         with _state_lock:
-            if sorted(ctx.medias.keys()) == sorted_ids:
+            if ctx.media_revision == revision:
                 ctx._emb_matrix_ids = sorted_ids
                 ctx._emb_matrix = matrix
+                ctx._emb_matrix_revision = revision
     return list(sorted_ids), matrix
 
 
@@ -174,16 +186,23 @@ def invalidate_embedding_matrix(ctx: "DatasetContext") -> None:
 
     Clears both the per-media embedding matrix and the flattened
     per-region matrix (used by patch-region scoring), since both are keyed
-    on the media-id set and become stale together when the dataset's media
-    change.
+    on ``media_revision`` and become stale together when the dataset's media
+    change.  Also bumps ``media_revision`` so this stands in as the explicit
+    "vectors changed in place" signal at the embed / clip stages: an
+    in-place rewrite of existing media dicts is invisible to
+    :class:`~vtscore.state.core.MediasDict`, so those stages call this to
+    advance the counter (and free the cached arrays' RAM immediately).
     """
     with _state_lock:
         ctx._emb_matrix_ids = None
         ctx._emb_matrix = None
+        ctx._emb_matrix_revision = None
         ctx._region_matrix_ids = None
         ctx._region_matrix = None
+        ctx._region_matrix_revision = None
         ctx._region_media_index = None
         ctx._region_index_per_row = None
+        ctx.bump_media_revision()
 
 
 def _patch_embedder_for_region_snap(snap: dict[int, dict[str, Any]]) -> str | None:
@@ -288,9 +307,16 @@ def get_region_matrix_for_snap(
 
     ctx = get_active_context()
     with _state_lock:
+        # Snapshot the revision so a mutation during the unlocked build below
+        # can't cache a stale matrix. The id-list compare still guards against
+        # a *different* snap with a coincidentally equal cached id set; the
+        # revision compare additionally catches an in-place vector rewrite
+        # under the same id set (root-cause Pattern #4).
+        revision = ctx.media_revision
         if (
             ctx._region_matrix is not None
             and ctx._region_matrix_ids == sorted_ids
+            and ctx._region_matrix_revision == revision
             and ctx._region_media_index is not None
             and ctx._region_index_per_row is not None
         ):
@@ -304,14 +330,17 @@ def get_region_matrix_for_snap(
     region_matrix, media_index, region_index = _build_region_arrays(snap, sorted_ids)
 
     # Populate the cache only when *snap* matches the active dataset's medias
-    # (the common case: ``snap = snapshot_medias()``).  Subset / cross-dataset
-    # dicts are ephemeral and must not clobber the active cache.
+    # (the common case: ``snap = snapshot_medias()``) and no mutation landed
+    # during the build.  Subset / cross-dataset dicts are ephemeral and must
+    # not clobber the active cache.
     if sorted_ids == sorted(ctx.medias.keys()):
         with _state_lock:
-            ctx._region_matrix_ids = sorted_ids
-            ctx._region_matrix = region_matrix
-            ctx._region_media_index = media_index
-            ctx._region_index_per_row = region_index
+            if ctx.media_revision == revision:
+                ctx._region_matrix_ids = sorted_ids
+                ctx._region_matrix = region_matrix
+                ctx._region_matrix_revision = revision
+                ctx._region_media_index = media_index
+                ctx._region_index_per_row = region_index
     return list(sorted_ids), region_matrix, media_index, region_index
 
 
@@ -346,7 +375,12 @@ def get_embedding_matrix_for_snap(
         with _state_lock:
             cached_ids = ctx._emb_matrix_ids
             cached_matrix = ctx._emb_matrix
-        if cached_matrix is not None and cached_ids == sorted_ids:
+            cache_current = ctx._emb_matrix_revision == ctx.media_revision
+        # The id-list compare guards against a *different* snap whose ids
+        # happen to equal the cached set; the revision compare additionally
+        # rejects a cache stale from an in-place vector rewrite under the same
+        # id set (root-cause Pattern #4).
+        if cached_matrix is not None and cached_ids == sorted_ids and cache_current:
             return sorted_ids, cached_matrix
 
     # When *snap* matches the active dataset's medias (the common case:

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -18,6 +18,7 @@ from vtscore.state.core import _state_lock  # noqa: F401
 # Re-export context management functions ---------------------------------
 from vtscore.state.core import (  # noqa: F401
     DatasetContext,
+    MediasDict,
     clear_all_contexts,
     get_active_context,
     get_context,
@@ -151,11 +152,13 @@ def clear_medias() -> None:
 
     with _state_lock:
         ctx = _core.get_active_context()
-        ctx.medias.clear()
+        ctx.medias.clear()  # bumps media_revision via MediasDict
         ctx._emb_matrix_ids = None
         ctx._emb_matrix = None
+        ctx._emb_matrix_revision = None
         ctx._region_matrix_ids = None
         ctx._region_matrix = None
+        ctx._region_matrix_revision = None
         ctx._region_media_index = None
         ctx._region_index_per_row = None
         ctx._projection = None

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -258,6 +258,78 @@ def register_detector_context_resolver(fn: Callable[[], Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
+class MediasDict(dict):
+    """A ``dict`` of media items that bumps a revision counter on mutation.
+
+    Backs :attr:`DatasetContext.medias`.  The embedding-matrix and
+    region-matrix caches key their validity on ``ctx.media_revision``
+    (see :mod:`vtscore.embedding.matrix`); routing every add / remove /
+    replace through this subclass means those *structural* mutations bump
+    the revision automatically, so no call site has to remember to
+    invalidate the derived caches after changing which media are loaded.
+
+    Limitation (important): a ``dict`` subclass only observes changes to
+    the *key → value* mapping.  An in-place edit of a value dict - e.g.
+    ``medias[cid]["embedding"] = vec`` while re-embedding or clipping -
+    never calls ``__setitem__`` on this container, so it does **not** bump
+    the counter.  Code that rewrites a media's vector in place must bump it
+    itself via :meth:`DatasetContext.bump_media_revision`; the embed / clip
+    load stages do this through ``invalidate_embedding_matrix``.  This is
+    the ``media_revision`` follow-up (root-cause Pattern #4) recorded in
+    ``docs/plans/logical-bug-audit.md``.
+
+    Over-bumping (bumping when nothing actually changed) is always safe: it
+    only forces an unnecessary cache rebuild, never serves a stale one.
+    """
+
+    __slots__ = ("_on_mutate",)
+
+    def __init__(self, on_mutate: Callable[[], None], *args: Any, **kwargs: Any) -> None:
+        # dict's C-level constructor / update populate directly without
+        # calling our Python __setitem__, so seeding from *args* does not
+        # fire _on_mutate - the owner counts construction as one bump when it
+        # assigns the dict, not once per seeded item.
+        object.__setattr__(self, "_on_mutate", on_mutate)
+        super().__init__(*args, **kwargs)
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        super().__setitem__(key, value)
+        self._on_mutate()
+
+    def __delitem__(self, key: Any) -> None:
+        super().__delitem__(key)  # raises before the bump if key is absent
+        self._on_mutate()
+
+    def pop(self, *args: Any) -> Any:
+        n = len(self)
+        result = super().pop(*args)
+        if len(self) != n:
+            self._on_mutate()
+        return result
+
+    def popitem(self) -> Any:
+        result = super().popitem()  # raises on empty before the bump
+        self._on_mutate()
+        return result
+
+    def clear(self) -> None:
+        had_items = bool(self)
+        super().clear()
+        if had_items:
+            self._on_mutate()
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        super().update(*args, **kwargs)
+        self._on_mutate()
+
+    def setdefault(self, key: Any, default: Any = None) -> Any:
+        existed = key in self
+        result = super().setdefault(key, default)
+        if not existed:
+            self._on_mutate()
+        return result
+
+
 class DatasetContext:
     """All mutable state that belongs to a single loaded dataset.
 
@@ -268,16 +340,28 @@ class DatasetContext:
 
     __slots__ = (
         "dataset_id",
-        "medias",
+        # Backing store for the ``medias`` property (a :class:`MediasDict`)
+        # and the monotonic revision counter it bumps.  ``media_revision``
+        # advances on every structural mutation of the medias (and on every
+        # in-place vector rewrite that calls ``bump_media_revision``); the
+        # embedding / region matrix caches key their validity on it instead
+        # of comparing sorted id lists (root-cause Pattern #4, see
+        # ``docs/plans/logical-bug-audit.md``).
+        "_medias",
+        "_media_revision",
         "diversity_tree",
         "dataset_display_name",
-        # Cached contiguous (N, D) float32 embedding matrix and the sorted
-        # media-id list it corresponds to.  Built lazily on first access by
+        # Cached contiguous (N, D) float32 embedding matrix, the sorted
+        # media-id list it corresponds to, and the ``media_revision`` it was
+        # built at.  Built lazily on first access by
         # ``vtscore.embedding.matrix.get_embedding_matrix`` and reused
         # across cosine sort, MLP scoring, and diversity-tree construction so
-        # we don't rebuild a 10k-row matrix per call.
+        # we don't rebuild a 10k-row matrix per call.  Cache validity is the
+        # revision match; the id list is kept for the returned tuple / region
+        # snap-key match.
         "_emb_matrix_ids",
         "_emb_matrix",
+        "_emb_matrix_revision",
         # Cached *flattened region matrix* for patch-region (e.g. DINOv3)
         # datasets, mirroring ``_emb_matrix`` but expanded to one row per
         # (media, region) pair.  ``_region_matrix`` is the ``(R, D)`` float32
@@ -287,9 +371,11 @@ class DatasetContext:
         # Built lazily by ``vtscore.embedding.matrix.get_region_matrix_for_snap``
         # and reused across votes so online retraining never rebuilds the
         # multi-hundred-thousand-row matrix per vote.  Keyed, like
-        # ``_emb_matrix``, on the sorted media-id list in ``_region_matrix_ids``.
+        # ``_emb_matrix``, on the sorted media-id list in ``_region_matrix_ids``
+        # plus the ``media_revision`` it was built at (``_region_matrix_revision``).
         "_region_matrix_ids",
         "_region_matrix",
+        "_region_matrix_revision",
         "_region_media_index",
         "_region_index_per_row",
         # VTSBrowse: cached projection (frozen at ingest) + per-bin-shape
@@ -332,13 +418,20 @@ class DatasetContext:
 
     def __init__(self, dataset_id: str = "") -> None:
         self.dataset_id: str = dataset_id
-        self.medias: dict[int, dict[str, Any]] = {}
+        # ``_media_revision`` must exist before ``_medias`` so the MediasDict's
+        # mutate callback can safely bump it.  Assign the backing slot directly
+        # (not via the ``medias`` setter) so construction leaves the revision
+        # at 0 rather than counting itself as a mutation.
+        self._media_revision: int = 0
+        self._medias: MediasDict = MediasDict(self.bump_media_revision)
         self.diversity_tree: Any = None  # DiversityTree | None
         self.dataset_display_name: str | None = None
         self._emb_matrix_ids: list[int] | None = None
         self._emb_matrix: Any = None  # np.ndarray | None
+        self._emb_matrix_revision: int | None = None  # media_revision the matrix was built at
         self._region_matrix_ids: list[int] | None = None
         self._region_matrix: Any = None  # np.ndarray | None, shape (R, D)
+        self._region_matrix_revision: int | None = None  # media_revision the region matrix was built at
         self._region_media_index: Any = None  # np.ndarray | None, int64 (R,)
         self._region_index_per_row: Any = None  # np.ndarray | None, int64 (R,)
         self._projection: Any = None  # Projection | None
@@ -360,6 +453,50 @@ class DatasetContext:
         self._structural_embedder: str | None = None
         self._binding_explicit: bool = False
         self.merge_near_duplicates: bool = False
+
+    # ------------------------------------------------------------------
+    # Medias + revision counter (root-cause Pattern #4)
+    # ------------------------------------------------------------------
+
+    @property
+    def medias(self) -> MediasDict:
+        """The dataset's ``{id: media}`` map, as a revision-tracking dict.
+
+        Structural mutations (add / remove / replace an entry) bump
+        :attr:`media_revision` automatically via :class:`MediasDict`.
+        """
+        return self._medias
+
+    @medias.setter
+    def medias(self, value: dict[int, dict[str, Any]]) -> None:
+        # Wrap any assigned mapping in a fresh MediasDict bound to *this*
+        # context, then count the wholesale replacement as one mutation so a
+        # cached matrix built against the old contents is invalidated even
+        # when the new id set happens to match the old one.
+        self._medias = MediasDict(self.bump_media_revision, value)
+        self.bump_media_revision()
+
+    @property
+    def media_revision(self) -> int:
+        """Monotonic counter, advanced on every mutation of the medias.
+
+        The embedding-matrix and region-matrix caches compare this single
+        int instead of two sorted id lists, so a mutation that changes
+        vectors without changing the id set still invalidates them
+        (root-cause Pattern #4 in ``docs/plans/logical-bug-audit.md``).
+        """
+        return self._media_revision
+
+    def bump_media_revision(self) -> None:
+        """Advance :attr:`media_revision` by one.
+
+        Called automatically by :class:`MediasDict` on structural changes.
+        Call it directly after an *in-place* rewrite of a media's embedding
+        vector (which a dict subclass can't observe) so the derived matrix
+        caches rebuild; the embed / clip stages do so via
+        ``invalidate_embedding_matrix``.
+        """
+        self._media_revision += 1
 
     # ------------------------------------------------------------------
     # Role-typed embedder binding
@@ -698,13 +835,20 @@ class _RequestMissingDatasetContext(DatasetContext):
         # Use object.__setattr__ to bypass our own write guard while
         # initialising the slot values.
         object.__setattr__(self, "dataset_id", "__request_missing__")
-        object.__setattr__(self, "medias", _FrozenDict("dataset"))
+        # ``medias`` is a property on the base class; write its backing slot
+        # directly with a frozen dict so every mutation raises.  The revision
+        # counter is inert here (a frozen dict never mutates), but the slot
+        # must exist for the property / bump machinery not to AttributeError.
+        object.__setattr__(self, "_medias", _FrozenDict("dataset"))
+        object.__setattr__(self, "_media_revision", 0)
         object.__setattr__(self, "diversity_tree", None)
         object.__setattr__(self, "dataset_display_name", None)
         object.__setattr__(self, "_emb_matrix_ids", None)
         object.__setattr__(self, "_emb_matrix", None)
+        object.__setattr__(self, "_emb_matrix_revision", None)
         object.__setattr__(self, "_region_matrix_ids", None)
         object.__setattr__(self, "_region_matrix", None)
+        object.__setattr__(self, "_region_matrix_revision", None)
         object.__setattr__(self, "_region_media_index", None)
         object.__setattr__(self, "_region_index_per_row", None)
         object.__setattr__(self, "_text_embedder", None)


### PR DESCRIPTION
## What & why

Root-cause **Pattern #4** from `docs/plans/logical-bug-audit.md` — the last open item from the 2026-05 logical-bug audit. The embedding-matrix cache used to decide staleness by comparing `sorted(ctx.medias.keys())` — the *set of media IDs*. A mutation that changes **embeddings** while leaving the **id set** unchanged (the C4 miscompute class: in-place re-embed / clip) slipped past the id-list key and served stale vectors into cosine sort, MLP scoring, and the diversity tree. C4 was closed by scattering explicit `invalidate_embedding_matrix` calls at the *known* mutation sites; any future site reintroduced the bug.

## What changed

- **`DatasetContext.media_revision`** — a monotonic counter, and **`DatasetContext.medias` is now a `MediasDict`** (a `dict` subclass) that bumps the counter on every *structural* mutation (add / remove / replace / clear / wholesale reassignment). Structural churn now invalidates the caches with nothing to remember.
- **Matrix + region caches key on the counter** (`_emb_matrix_revision`, `_region_matrix_revision`) — a single int compare instead of two sorted id lists — so a same-id-set / changed-vectors mutation invalidates them.
- **`invalidate_embedding_matrix` bumps the counter** (and still frees the cached arrays' RAM). An *in-place* rewrite of a value dict (`medias[cid]["embeddings"][name] = vec`) is invisible to a dict subclass, so the embed / clip stages keep calling it — now as the single uniform "vectors changed" signal rather than each site knowing which caches to clear.

## By-design caveat

A dict subclass cannot observe an in-place edit of a value's internals, so a future in-place vector-rewrite site must still call `bump_media_revision()` (via `invalidate_embedding_matrix`). This is documented in the plan's Open follow-ups and the `MediasDict` docstring. The counter makes structural mutations automatic and unifies the invalidation signal; it does not (and can't) make in-place rewrites automatic.

## Tests

- New `TestMediaRevisionCounter` in `tests_lib/core/test_embedding_matrix.py`: structural bumps, wholesale reassignment re-wraps and keeps bumping, reads don't bump, cache reuse at the same revision, the in-place-rewrite-needs-explicit-bump path, and same-id-set/new-content invalidation.
- The existing phase-3 concurrent-mutation test now exercises the revision path.
- Full suite green: `ALL 5507 TESTS PASSED (1 skipped)`.

## Backwards compatibility

`DatasetContext.medias` is now a `MediasDict` rather than a plain `dict` (still `isinstance(..., dict)`); the app-tier `_ProxyDict` forwards mutations through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhzzjhThmgHEMobAe11eB3)_