### PR TITLE
fix(registry): make dataset/detector registries multi-process safe

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -1,6 +1,7 @@
 # Comprehensive interface audit — July 2026
 
-**Status: eleven fix passes shipped; 8 open follow-ups below.**
+**Status: eleven fix passes shipped; follow-up #1 (registry multi-process
+safety) shipped; 7 open follow-ups below.**
 
 A full-codebase audit of interface boundaries (frontend ↔ API, route layer ↔
 state system, app tier ↔ `vtscore`, IO, concurrency, frontend TS). Six parallel
@@ -12,12 +13,7 @@ the audit but deferred as needing a design decision or a larger change.
 
 Ordered roughly by severity.
 
-1. **Dataset registry is not multi-process safe**
-   (`vtscore/datasets/registry.py`): in-process lock plus a fixed `.tmp`
-   name; a concurrent CLI autodetect run against the same data dir can
-   silently erase the server's registrations. Fine under the documented
-   single-worker model; needs flock if that changes.
-2. **Progress-modal analysis path is broken three ways**
+1. **Progress-modal analysis path is broken three ways**
    (`progress-modal.component.ts`, `runAnalysis()`): Escape/X/backdrop skip
    the eval-job cancel the in-body Cancel button performs; the
    `trainAndScore` subscribe has no `takeUntil`, so a destroy while the POST
@@ -29,7 +25,7 @@ Ordered roughly by severity.
    completion — `analyzing` hangs forever. All currently *latent*: the only
    in-app instantiation passes `[useCachedHistory]="true"`, but
    `runAnalysis()` is the component default and is pinned by its spec.
-3. **Browse canvas gesture overlaps** (UX design decisions): wheel-zoom
+2. **Browse canvas gesture overlaps** (UX design decisions): wheel-zoom
    during an active drag-pan/marquee discards the zoom's cursor anchoring on
    the next mousemove and freezes painting for the 220 ms transition (gate
    the wheel while a drag is active, or make the pan math zoom-aware); the
@@ -39,18 +35,18 @@ Ordered roughly by severity.
    pending toggle on view moves); the boundary-settle rAF loop can start while
    the zoom-transition loop still owns the canvas (both write
    `displayedTransform`; visible damage is a truncated transition).
-4. **Root-zoom px mixing in panel-divider drags**
+3. **Root-zoom px mixing in panel-divider drags**
    (`browse-view.component.ts:onDividerMove`,
    `label-view/panel-resize.directive.ts`): visual-px cursor deltas applied
    as layout-px widths under `html { zoom: 1.1 }`, so the divider rides
    ~10% away from the pointer. Shared app-wide wart; fix both sites together
    (the eleventh pass fixed the same class of bug in the minimap).
-5. **Pure devicePixelRatio change never re-runs canvas `resize()`**
+4. **Pure devicePixelRatio change never re-runs canvas `resize()`**
    (browse-canvas + minimap): dragging the window to a different-density
    monitor leaves `dpr` (and the thumbnail-resolution tier) stale until the
    next CSS resize; rendering-quality only (hit-testing is CSS-px based).
    Needs a `matchMedia('(resolution: …)')` listener.
-6. **`save_detector_labels` full-replace drops cross-dataset labels**
+5. **`save_detector_labels` full-replace drops cross-dataset labels**
    (`routes/detectors/labels.py`): the route rebuilds the labelset from the
    *active dataset's* votes only, while `sync_labels_to_loaded_detector`
    deliberately merges cross-dataset entries — saving while dataset B is
@@ -58,16 +54,23 @@ Ordered roughly by severity.
    the explicit save should merge like the sync does (probably yes, via
    `_merge_labelsets_across_datasets`) or full-replace is the intended
    "save exactly what I see" semantic.
-7. **`MAX_UPLOAD_MB` defaults to 0 = unlimited** (`vtscore/config.py`):
+6. **`MAX_UPLOAD_MB` defaults to 0 = unlimited** (`vtscore/config.py`):
    staging uploads are unbounded by default; decide a sane default cap.
    (The eleventh pass removed the *decompressed-copy* amplification in
    `stage_file`, but the upload itself is still unbounded.)
-8. **`AutoDetectProgressModalComponent` is dead code** (modal sweep note):
+7. **`AutoDetectProgressModalComponent` is dead code** (modal sweep note):
    referenced nowhere; delete it or wire it up.
 
 ## What shipped
 
 Backend — state / settings / jobs:
+- Dataset + detector registries made multi-process safe (was open follow-up #1):
+  every mutation re-reads the manifest fresh under a cross-process `file_lock`
+  and writes it back via `atomic_write_json` (pid+uuid temp name), so a
+  concurrent CLI autodetect can no longer clobber the server's registrations. A
+  library-tier `file_lock` was added to `vtscore.io`
+  (`test_registry_multiprocess_safety.py` in both `tests_lib/datasets` and
+  `tests_lib/detectors`).
 - Detector-state wipe via the `"__request_missing__"` sentinel — a detector-only
   request wiped the session against the sentinel's empty medias
   (`vtscore/detectors/dataset_sync.py`).

--- a/tests_lib/datasets/test_registry_multiprocess_safety.py
+++ b/tests_lib/datasets/test_registry_multiprocess_safety.py
@@ -1,0 +1,100 @@
+"""Regression (audit follow-up #1): dataset registry multi-process safety.
+
+The old persistence layer wrote the manifest through a fixed ``.tmp`` name and
+mutated a process-local in-memory cache, then dumped that cache back to disk.
+A second process (e.g. a CLI ``--autodetect`` run against the same data dir)
+that registered a dataset would be silently erased the next time the server
+process wrote its stale cache back.
+
+The fix routes every mutation through :func:`vtscore.datasets.registry._read_modify_write`,
+which re-reads the manifest fresh from disk under a cross-process ``file_lock``
+before mutating and writing atomically (unique per-writer temp name).  A writer
+therefore merges into the current on-disk state instead of clobbering a
+sibling's commit.  These tests reproduce the clobber scenario by writing to the
+on-disk manifest directly to stand in for the sibling process's commit.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+
+from vtscore.datasets import registry
+
+
+def _read_disk_ids() -> set[str]:
+    return {e["id"] for e in json.loads(registry.REGISTRY_PATH.read_text(encoding="utf-8"))}
+
+
+def _commit_sibling_entry(entry_id: str, name: str = "sibling") -> None:
+    """Append an entry straight to the on-disk manifest.
+
+    Stands in for a separate process committing a registration while *this*
+    process holds a stale in-memory cache.
+    """
+    on_disk = json.loads(registry.REGISTRY_PATH.read_text(encoding="utf-8"))
+    on_disk.append({"id": entry_id, "name": name, "media_type": "audio", "pkl_path": f"{entry_id}.pkl"})
+    registry.REGISTRY_PATH.write_text(json.dumps(on_disk), encoding="utf-8")
+
+
+class TestRegistryMultiprocessSafety:
+    def test_register_merges_concurrent_sibling_write(self):
+        registry.reset_for_tests()
+        a = registry.register_dataset(name="A", media_type="audio", num_items=1, pkl_path="a.pkl")
+
+        # A sibling process commits its own registration to disk. This process's
+        # in-memory cache does not know about it.
+        _commit_sibling_entry("sibling-b")
+
+        # Registering here must NOT drop the sibling's entry.
+        c = registry.register_dataset(name="C", media_type="audio", num_items=1, pkl_path="c.pkl")
+
+        assert _read_disk_ids() == {a["id"], "sibling-b", c["id"]}
+
+    def test_unregister_preserves_concurrent_sibling_write(self):
+        registry.reset_for_tests()
+        a = registry.register_dataset(name="A", media_type="audio", num_items=1, pkl_path="a.pkl")
+        _commit_sibling_entry("sibling-b")
+
+        assert registry.unregister_dataset(a["id"]) is True
+
+        # Removing A must leave the sibling's B intact, not rewind to the stale
+        # cache (which never contained B).
+        assert _read_disk_ids() == {"sibling-b"}
+
+    def test_rename_preserves_concurrent_sibling_write(self):
+        registry.reset_for_tests()
+        a = registry.register_dataset(name="A", media_type="audio", num_items=1, pkl_path="a.pkl")
+        _commit_sibling_entry("sibling-b")
+
+        assert registry.rename_dataset(a["id"], "A-renamed") is True
+
+        assert _read_disk_ids() == {a["id"], "sibling-b"}
+
+    def test_temp_file_is_not_a_fixed_name(self):
+        # A fixed ``<name>.tmp`` lets two concurrent writers truncate each
+        # other's in-flight temp file. The atomic writer now embeds pid + uuid,
+        # so no fixed sibling temp file is left behind after a write.
+        registry.reset_for_tests()
+        registry.register_dataset(name="A", media_type="audio", num_items=1, pkl_path="a.pkl")
+        fixed_tmp = registry.REGISTRY_PATH.with_suffix(".tmp")
+        assert not fixed_tmp.exists()
+
+    def test_concurrent_registers_all_survive(self):
+        # Many threads registering at once must all land on disk; the flock plus
+        # fresh re-read serialises the read-modify-write so none clobber another.
+        registry.reset_for_tests()
+        n = 12
+        barrier = threading.Barrier(n)
+
+        def worker(i: int) -> None:
+            barrier.wait()
+            registry.register_dataset(name=f"D{i}", media_type="audio", num_items=1, pkl_path=f"d{i}.pkl")
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(_read_disk_ids()) == n

--- a/tests_lib/detectors/test_registry_multiprocess_safety.py
+++ b/tests_lib/detectors/test_registry_multiprocess_safety.py
@@ -1,0 +1,89 @@
+"""Regression (audit follow-up #1): detector registry multi-process safety.
+
+The detector registry mirrors the dataset registry and had the identical
+fixed-``.tmp`` + stale-cache clobber bug. Every mutation now routes through
+:func:`vtscore.detectors.registry._read_modify_write` (fresh re-read under a
+cross-process ``file_lock`` + atomic unique-temp write). See the dataset twin
+in ``tests_lib/datasets/test_registry_multiprocess_safety.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+
+from vtscore.detectors import registry
+
+
+def _read_disk_ids() -> set[str]:
+    return {e["id"] for e in json.loads(registry.REGISTRY_PATH.read_text(encoding="utf-8"))}
+
+
+def _commit_sibling_entry(entry_id: str, name: str = "sibling") -> None:
+    on_disk = json.loads(registry.REGISTRY_PATH.read_text(encoding="utf-8"))
+    on_disk.append({"id": entry_id, "name": name, "media_type": "audio", "created_by": "default"})
+    registry.REGISTRY_PATH.write_text(json.dumps(on_disk), encoding="utf-8")
+
+
+class TestDetectorRegistryMultiprocessSafety:
+    def test_register_merges_concurrent_sibling_write(self):
+        registry.reset_for_tests()
+        a = registry.register_detector(name="A", media_type="audio")
+        _commit_sibling_entry("sibling-b")
+
+        c = registry.register_detector(name="C", media_type="audio")
+
+        assert _read_disk_ids() == {a["id"], "sibling-b", c["id"]}
+
+    def test_unregister_preserves_concurrent_sibling_write(self):
+        registry.reset_for_tests()
+        a = registry.register_detector(name="A", media_type="audio")
+        _commit_sibling_entry("sibling-b")
+
+        assert registry.unregister_detector(a["id"]) is True
+
+        assert _read_disk_ids() == {"sibling-b"}
+
+    def test_record_embedder_merges_concurrent_sibling_write(self):
+        registry.reset_for_tests()
+        a = registry.register_detector(name="A", media_type="audio")
+        _commit_sibling_entry("sibling-b")
+
+        registry.record_detector_embedder(a["id"], "laion_clap")
+
+        ids = _read_disk_ids()
+        assert ids == {a["id"], "sibling-b"}
+
+    def test_record_embedder_unchanged_skips_write(self):
+        # The per-training-cycle fast path must not rewrite the manifest when the
+        # embedder is already stamped.
+        registry.reset_for_tests()
+        a = registry.register_detector(name="A", media_type="audio", embedder="laion_clap")
+        before = registry.REGISTRY_PATH.read_text(encoding="utf-8")
+
+        registry.record_detector_embedder(a["id"], "laion_clap")
+
+        assert registry.REGISTRY_PATH.read_text(encoding="utf-8") == before
+
+    def test_temp_file_is_not_a_fixed_name(self):
+        registry.reset_for_tests()
+        registry.register_detector(name="A", media_type="audio")
+        fixed_tmp = registry.REGISTRY_PATH.with_suffix(".tmp")
+        assert not fixed_tmp.exists()
+
+    def test_concurrent_registers_all_survive(self):
+        registry.reset_for_tests()
+        n = 12
+        barrier = threading.Barrier(n)
+
+        def worker(i: int) -> None:
+            barrier.wait()
+            registry.register_detector(name=f"D{i}", media_type="audio")
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(_read_disk_ids()) == n

--- a/vtscore/datasets/registry.py
+++ b/vtscore/datasets/registry.py
@@ -15,10 +15,12 @@ import json
 import logging
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from vtscore.config import DATA_DIR
+from vtscore.io import atomic_write_json, file_lock
 
 logger = logging.getLogger(__name__)
 
@@ -40,9 +42,16 @@ def get_saved_datasets_dir() -> Path:
 # Backward-compat alias - prefer :func:`get_saved_datasets_dir` for live value.
 SAVED_DATASETS_DIR = DATA_DIR / "saved_datasets"
 
+_T = TypeVar("_T")
+
+# Guards the process-local state below: the ``_entries`` cache and the
+# ``_loaded_ids`` / ``_loading_ids`` sets.  Cross-process durability of the
+# on-disk manifest is handled separately by :func:`_read_modify_write` under a
+# ``file_lock``; this lock only serialises threads within one process.
 _lock = threading.RLock()
 
-# In-memory cache - loaded once from disk, written back on every mutation.
+# In-memory cache - loaded once from disk, refreshed from disk on every
+# mutation (see :func:`_read_modify_write`).
 _entries: list[dict[str, Any]] | None = None
 
 # The set of dataset IDs that are currently loaded in memory.
@@ -74,16 +83,8 @@ def _load() -> list[dict[str, Any]]:
 
 
 def _save(entries: list[dict[str, Any]]) -> None:
-    """Write *entries* to disk atomically."""
-    import os
-
-    REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tmp = REGISTRY_PATH.with_suffix(".tmp")
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(entries, f, indent=2)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(str(tmp), str(REGISTRY_PATH))
+    """Write *entries* to disk atomically (per-writer unique temp name)."""
+    atomic_write_json(REGISTRY_PATH, entries)
 
 
 def _ensure_loaded() -> list[dict[str, Any]]:
@@ -92,6 +93,30 @@ def _ensure_loaded() -> list[dict[str, Any]]:
     if _entries is None:
         _entries = _load()
     return _entries
+
+
+def _read_modify_write(mutator: Callable[[list[dict[str, Any]]], _T]) -> _T:
+    """Run *mutator* over a fresh-from-disk registry under a cross-process lock.
+
+    Holding the ``file_lock`` while re-reading the manifest closes the
+    multi-process read-modify-write race: a concurrent process (e.g. a CLI
+    autodetect run against the same data dir) can't commit between our read and
+    write, so a mutation always merges into the *current* on-disk state instead
+    of clobbering entries a sibling registered.  ``_load`` is deliberately used
+    (not the possibly-stale ``_entries`` cache) so we start from disk truth.
+
+    *mutator* receives the fresh list, mutates it in place, and returns this
+    call's result.  The list is always persisted and swapped into the in-memory
+    cache, so the cache converges to disk truth on every mutation.
+    """
+    global _entries
+    with file_lock(REGISTRY_PATH):
+        entries = _load()
+        result = mutator(entries)
+        _save(entries)
+        with _lock:
+            _entries = entries
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -178,10 +203,7 @@ def register_dataset(
         "ingest_finished_at": now,
         "expires_at": expires_at,
     }
-    with _lock:
-        entries = _ensure_loaded()
-        entries.append(entry)
-        _save(entries)
+    _read_modify_write(lambda entries: entries.append(entry))
 
     # New entry expands the predicted-embedder set; warm anything new in the
     # background so a subsequent load is instant. Idempotent: already-loaded
@@ -201,42 +223,47 @@ def unregister_dataset(dataset_id: str) -> bool:
 
     Returns ``True`` if the dataset was found and removed.
     """
-    with _lock:
-        entries = _ensure_loaded()
+
+    def mutate(entries: list[dict[str, Any]]) -> bool:
         for i, entry in enumerate(entries):
             if entry["id"] == dataset_id:
                 pkl = Path(entry.get("pkl_path", ""))
                 if pkl.is_file():
                     pkl.unlink(missing_ok=True)
                 entries.pop(i)
-                _loaded_ids.discard(dataset_id)
-                _save(entries)
                 return True
-    return False
+        return False
+
+    removed = _read_modify_write(mutate)
+    with _lock:
+        _loaded_ids.discard(dataset_id)
+    return removed
 
 
 def rename_dataset(dataset_id: str, new_name: str) -> bool:
     """Rename a registered dataset. Returns ``True`` on success."""
-    with _lock:
-        entries = _ensure_loaded()
+
+    def mutate(entries: list[dict[str, Any]]) -> bool:
         for entry in entries:
             if entry["id"] == dataset_id:
                 entry["name"] = new_name
-                _save(entries)
                 return True
-    return False
+        return False
+
+    return _read_modify_write(mutate)
 
 
 def update_dataset(dataset_id: str, **fields: Any) -> bool:
     """Update arbitrary fields on a registered dataset."""
-    with _lock:
-        entries = _ensure_loaded()
+
+    def mutate(entries: list[dict[str, Any]]) -> bool:
         for entry in entries:
             if entry["id"] == dataset_id:
                 entry.update(fields)
-                _save(entries)
                 return True
-    return False
+        return False
+
+    return _read_modify_write(mutate)
 
 
 def get_loaded_ids() -> set[str]:
@@ -350,16 +377,17 @@ def set_readers(dataset_id: str, readers: list[str], requesting_user: str) -> tu
 
     Returns ``(success, error_message)``.
     """
-    with _lock:
-        entries = _ensure_loaded()
+
+    def mutate(entries: list[dict[str, Any]]) -> tuple[bool, str]:
         for entry in entries:
             if entry["id"] == dataset_id:
                 if entry.get("created_by", "default") != requesting_user:
                     return False, "Only the dataset creator can modify readers"
                 entry["readers"] = readers
-                _save(entries)
                 return True, ""
         return False, "Dataset not found"
+
+    return _read_modify_write(mutate)
 
 
 def reset_for_tests() -> None:

--- a/vtscore/detectors/registry.py
+++ b/vtscore/detectors/registry.py
@@ -19,14 +19,22 @@ import json
 import logging
 import threading
 import time
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from vtscore.config import DATA_DIR
+from vtscore.io import atomic_write_json, file_lock
 
 logger = logging.getLogger(__name__)
 
 REGISTRY_PATH = DATA_DIR / "detector_registry.json"
 
+_T = TypeVar("_T")
+
+# Guards the process-local state below: the ``_entries`` cache and the
+# ``_loaded_ids`` / ``_loading_ids`` sets.  Cross-process durability of the
+# on-disk manifest is handled by :func:`_read_modify_write` under a
+# ``file_lock``; this lock only serialises threads within one process.
 _lock = threading.RLock()
 
 _entries: list[dict[str, Any]] | None = None
@@ -58,15 +66,7 @@ def _load() -> list[dict[str, Any]]:
 
 
 def _save(entries: list[dict[str, Any]]) -> None:
-    import os
-
-    REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tmp = REGISTRY_PATH.with_suffix(".tmp")
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(entries, f, indent=2)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(str(tmp), str(REGISTRY_PATH))
+    atomic_write_json(REGISTRY_PATH, entries)
 
 
 def _ensure_loaded() -> list[dict[str, Any]]:
@@ -74,6 +74,26 @@ def _ensure_loaded() -> list[dict[str, Any]]:
     if _entries is None:
         _entries = _load()
     return _entries
+
+
+def _read_modify_write(mutator: Callable[[list[dict[str, Any]]], _T]) -> _T:
+    """Run *mutator* over a fresh-from-disk registry under a cross-process lock.
+
+    Mirrors :func:`vtscore.datasets.registry._read_modify_write`.  Holding the
+    ``file_lock`` while re-reading closes the multi-process read-modify-write
+    race so a mutation merges into the current on-disk state instead of
+    clobbering entries a sibling process committed since this process last read.
+    ``_load`` starts from disk truth (not the possibly-stale cache); the result
+    is always persisted and swapped into ``_entries``.
+    """
+    global _entries
+    with file_lock(REGISTRY_PATH):
+        entries = _load()
+        result = mutator(entries)
+        _save(entries)
+        with _lock:
+            _entries = entries
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -149,48 +169,50 @@ def register_detector(
         # ``["*"]`` = visible to everyone. See ``can_user_access_detector``.
         "readers": list(readers) if readers else [],
     }
-    with _lock:
-        entries = _ensure_loaded()
-        entries.append(entry)
-        _save(entries)
+    _read_modify_write(lambda entries: entries.append(entry))
     return entry
 
 
 def unregister_detector(detector_id: str) -> bool:
     """Remove a detector from the registry. Returns ``True`` if found."""
-    with _lock:
-        entries = _ensure_loaded()
+
+    def mutate(entries: list[dict[str, Any]]) -> bool:
         for i, entry in enumerate(entries):
             if entry["id"] == detector_id:
                 entries.pop(i)
-                _loaded_ids.discard(detector_id)
-                _save(entries)
                 return True
-    return False
+        return False
+
+    removed = _read_modify_write(mutate)
+    with _lock:
+        _loaded_ids.discard(detector_id)
+    return removed
 
 
 def rename_detector(detector_id: str, new_name: str) -> bool:
     """Rename a registered detector. Returns ``True`` on success."""
-    with _lock:
-        entries = _ensure_loaded()
+
+    def mutate(entries: list[dict[str, Any]]) -> bool:
         for entry in entries:
             if entry["id"] == detector_id:
                 entry["name"] = new_name
-                _save(entries)
                 return True
-    return False
+        return False
+
+    return _read_modify_write(mutate)
 
 
 def update_detector(detector_id: str, **fields: Any) -> bool:
     """Update arbitrary fields on a registered detector."""
-    with _lock:
-        entries = _ensure_loaded()
+
+    def mutate(entries: list[dict[str, Any]]) -> bool:
         for entry in entries:
             if entry["id"] == detector_id:
                 entry.update(fields)
-                _save(entries)
                 return True
-    return False
+        return False
+
+    return _read_modify_write(mutate)
 
 
 def record_detector_embedder(detector_id: str, embedder_name: str) -> None:
@@ -204,16 +226,23 @@ def record_detector_embedder(detector_id: str, embedder_name: str) -> None:
     """
     if not detector_id or not embedder_name:
         return
+    global _entries
     try:
-        with _lock:
-            entries = _ensure_loaded()
+        # Inline read-modify-write (not the shared helper) so an already-stamped
+        # embedder skips the disk write - this runs on every training cycle.
+        with file_lock(REGISTRY_PATH):
+            entries = _load()
+            changed = False
             for entry in entries:
                 if entry["id"] == detector_id:
-                    if entry.get("embedder") == embedder_name:
-                        return
-                    entry["embedder"] = embedder_name
-                    _save(entries)
-                    return
+                    if entry.get("embedder") != embedder_name:
+                        entry["embedder"] = embedder_name
+                        changed = True
+                    break
+            if changed:
+                _save(entries)
+            with _lock:
+                _entries = entries
     except Exception as exc:
         logger.warning("Failed to persist embedder for detector %s: %s", detector_id, exc)
 
@@ -283,16 +312,17 @@ def set_detector_readers(detector_id: str, readers: list[str], requesting_user: 
 
     Returns ``(success, error_message)``.
     """
-    with _lock:
-        entries = _ensure_loaded()
+
+    def mutate(entries: list[dict[str, Any]]) -> tuple[bool, str]:
         for entry in entries:
             if entry["id"] == detector_id:
                 if entry.get("created_by", "default") != requesting_user:
                     return False, "Only the detector creator can modify readers"
                 entry["readers"] = readers
-                _save(entries)
                 return True, ""
         return False, "Detector not found"
+
+    return _read_modify_write(mutate)
 
 
 def add_loaded_detector_id(detector_id: str) -> None:

--- a/vtscore/io.py
+++ b/vtscore/io.py
@@ -19,15 +19,27 @@ explicitly working around the helper.
 
 from __future__ import annotations
 
+import contextlib
 import json
+import logging
 import os
+import threading
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+
+try:
+    import fcntl as _fcntl  # POSIX-only; falls back to in-process locking on Windows.
+except ImportError:  # pragma: no cover - Windows
+    _fcntl = None
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "atomic_write_json",
     "atomic_write_text",
+    "file_lock",
     "read_server_json",
 ]
 
@@ -107,3 +119,82 @@ def atomic_write_json(path: Path | str, obj: Any, *, indent: int = 2) -> None:
     newline don't complain).
     """
     atomic_write_text(path, json.dumps(obj, indent=indent) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Cross-process file locking
+# ---------------------------------------------------------------------------
+#
+# Library-tier twin of ``vtsearch.settings_store.file_lock``.  It lives here
+# (not in the app tier) so library-tier stores - the dataset/detector
+# registries - can serialise their read-modify-write cycles across processes
+# without importing ``vtsearch`` (which would break the library-clean layering).
+#
+# Pair it with a fresh ``_load()`` inside the ``with file_lock(...)`` block and
+# an :func:`atomic_write_json` at the end: holding the flock while re-reading
+# means a writer always merges into the *current* on-disk state instead of
+# clobbering entries a sibling process committed since this process last read.
+
+# Per-path in-process locks, held in addition to the cross-process flock so
+# threads within one process serialise on the same path without repeatedly
+# re-entering the kernel (and as the sole guard when ``fcntl`` is unavailable).
+_path_locks: dict[str, threading.Lock] = {}
+_path_locks_guard = threading.Lock()
+
+
+def _path_lock_for(path: Path) -> threading.Lock:
+    # resolve() is non-strict (works for not-yet-created files), so the same
+    # target maps to one lock across its whole lifetime regardless of whether
+    # the file exists yet or is reached via a relative/symlinked path.
+    key = str(path.resolve())
+    with _path_locks_guard:
+        lock = _path_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _path_locks[key] = lock
+        return lock
+
+
+@contextlib.contextmanager
+def file_lock(path: Path | str) -> Iterator[None]:
+    """Acquire an exclusive cross-process lock for *path*.
+
+    The lock is taken on a sibling ``<path>.lock`` file rather than on the
+    data file itself, because atomic writes replace the data file's inode via
+    :func:`os.replace` - any fd held against the old inode would be useless.
+    The sibling lock file's inode is stable.
+
+    An in-process lock is always taken first (so threads in one process
+    serialise even on Windows), then the POSIX ``flock``.  ``flock`` releases
+    automatically when the process exits, so a crash never leaves a stale lock
+    behind.  On Windows (``fcntl`` unavailable) only the in-process lock is
+    used and cross-process protection degrades silently; VTSearch is deployed
+    on Linux, so this affects only the rare Windows-dev case.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    in_proc = _path_lock_for(p)
+    in_proc.acquire()
+    fd: int | None = None
+    fcntl_mod = _fcntl  # snapshot so the narrowed binding survives the yield
+    if fcntl_mod is not None:
+        lock_path = p.with_name(p.name + ".lock")
+        try:
+            fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+            fcntl_mod.flock(fd, fcntl_mod.LOCK_EX)
+        except OSError as exc:
+            logger.warning("Could not acquire file lock on %s: %s", lock_path, exc)
+            if fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                fd = None
+    try:
+        yield
+    finally:
+        if fd is not None and fcntl_mod is not None:
+            try:
+                fcntl_mod.flock(fd, fcntl_mod.LOCK_UN)
+            finally:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+        in_proc.release()


### PR DESCRIPTION
## What & why

Closes open follow-up #1 from `docs/plans/comprehensive-audit-2026-07.md`.

The dataset and detector registries persisted their JSON manifests through a **fixed `<name>.tmp`** name and mutated a **process-local in-memory cache**, then dumped that cache back to disk. Two failure modes under concurrent processes (e.g. a CLI `--autodetect` run sharing the same data dir with the server):

1. **Lost registrations.** A sibling process registers an entry to disk; this process, holding a stale cache, later writes its cache back and silently erases the sibling's entry.
2. **Torn temp files.** Two writers race on the same fixed `<name>.tmp`, truncating each other's in-flight file.

Fine under the documented single-worker model, but latent data loss the moment that changes — the audit flagged it as the top open item.

## What changed

- **`vtscore/io.py`** — added a library-tier `file_lock(path)` context manager: the cross-process, library-clean twin of `vtsearch.settings_store.file_lock` (sibling `<path>.lock` flock + in-process path lock, POSIX `flock` auto-releases on process exit, degrades to in-process-only on Windows). Placed here so the registries gain cross-process safety without importing the app tier (preserving the `vtscore` library-clean layering).
- **`vtscore/datasets/registry.py`** and **`vtscore/detectors/registry.py`** — every mutation now routes through a `_read_modify_write` helper that, under `file_lock`, re-reads the manifest **fresh from disk**, applies the mutation, and writes it back atomically via `atomic_write_json` (per-writer `pid.uuid.tmp` name). A writer merges into current on-disk state instead of clobbering a sibling's commit. `_save` now delegates to `atomic_write_json` (drops the hand-rolled fixed-`.tmp` writer). The in-process `RLock` is retained solely to guard the process-local cache and the loaded/loading id sets; `record_detector_embedder` keeps its "skip the write if the embedder is unchanged" fast path (it runs every training cycle) via an inline lock+re-read.

Both registries are documented mirrors of each other, so both got the identical fix.

## Tests

New regression suites (fail on the old fixed-`.tmp` + stale-cache code, pass now):
- `tests_lib/datasets/test_registry_multiprocess_safety.py`
- `tests_lib/detectors/test_registry_multiprocess_safety.py`

They reproduce the clobber by committing a "sibling" entry straight to the on-disk manifest, then assert register/unregister/rename/record-embedder all preserve it; plus a 12-thread concurrent-register test and a no-fixed-`.tmp` assertion.

Full `./run-tests.sh` passes (5512 passed), including the `vtscore-clean` library-import tier (confirms the new `fcntl` import in `vtscore.io` pulls in no app-tier module).

## Backwards-compat

No API change. Registry manifests are written to `<name>.<pid>.<uuid>.tmp` before the atomic rename (was `<name>.tmp`); a stale `<name>.tmp` left by a crashed old process is now ignored rather than reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hPg68AxDYCeKbXZpAYPLV

---
_Generated by [Claude Code](https://claude.ai/code/session_016hPg68AxDYCeKbXZpAYPLV)_