### PR TITLE
Light mode: move the neutral gray onto the panels so cards separate

### DIFF
--- a/docs/user/screenshots-reshoot-queue.md
+++ b/docs/user/screenshots-reshoot-queue.md
@@ -34,11 +34,41 @@ An empty table means "no known-stale shots" — the desired resting state.
 
 ## Queue
 
+Every shot below is captured in **both** themes (`themes: BOTH` in the
+manifest). The 2026-07-09 light-mode neutral-ramp change (see below) alters the
+**light** variant of *all* of them, so the whole shot set is listed here; a few
+rows also carry an earlier, unrelated staleness reason.
+
+**Light-mode neutral ramp (2026-07-09).** The light theme moved its gray off the
+mostly-hidden desk and onto the surfaces the user actually looks at: `--bg-panel`
+(all three layout columns) `#f1f3f8 → #e9ecf3`, `--bg-subtle` `#edeff4 → #e3e7f0`,
+`--bg-body` `#e4e7ef → #dbdfea`, `--bg-hover` `#dbe0ec → #d3d8e6`,
+`--bg-secondary-btn` `#dde1ec → #d8dce9` (cards/`--bg-surface` stay `#fff`). Every
+light-theme frame's panel/background tone shifts, so each `.light.png` is stale.
+This session had a browser but could not drain the queue: the repo pins
+Playwright 1.60 (Chromium build 1223) while the container ships build 1194, and
+the dev app server would not stay alive across the capture in this session's
+process model — both environment blockers, not recipe problems.
+
 | Shot id | Embedded in | Why it's stale | Flagged |
 |---------|-------------|----------------|---------|
-| `importer-picker` | `docs/user/USER_GUIDE.md#loading-a-dataset` | The shot's caption calls out "per-row readiness badges" (`.badge-ready`/`.badge-embedding`); the 2026-07-09 UI style review Phase 1 fix swapped their unreadable white text for a new `--badge-text-dark` token, changing the badge's rendered text color in both themes. | 2026-07-09 |
-| `dashboard-loaded` | USER_GUIDE.md#what-vtsearch-does | §2 contrast fix: dark-theme table row dividers (--border-subtle) now perceptible; dim sub-text (--text-dim) lightened | 2026-07-09 |
-| `dashboard-manage` | USER_GUIDE.md#dashboard--managing-datasets-and-detectors | §2 contrast fix: dark-theme table row dividers (--border-subtle) now perceptible; dim sub-text (--text-dim) lightened | 2026-07-09 |
-| `three-panel` | USER_GUIDE.md#the-three-panel-layout | (1) Panels now snap tight to their grid columns on load (not just on divider drag), so the left/right panel widths — and the centre boundary between them — shift from the old restored-width layout. (2) The collapsed "Metadata" toggle moved from a full-width divider row above the Good/Bad buttons to a docked strip below them (center-panel tray now sits under the voting overlay). | 2026-07-09 |
-| `results-grid` | USER_GUIDE.md#view-options | Left panel snaps tight to its grid columns on load, so the `.panel-left` clip is now narrower (no trailing gap past the last thumbnail column). | 2026-07-09 |
-| `autopilot-vote` | USER_GUIDE.md#autopilot--the-guided-workflow | The collapsed "Metadata" toggle now sits below the Good/Bad buttons rather than above them. | 2026-07-09 |
+| `importer-picker` | `docs/user/USER_GUIDE.md#loading-a-dataset` | The shot's caption calls out "per-row readiness badges" (`.badge-ready`/`.badge-embedding`); the 2026-07-09 UI style review Phase 1 fix swapped their unreadable white text for a new `--badge-text-dark` token, changing the badge's rendered text color in both themes. Also: 2026-07-09 light-mode neutral-ramp change (see note above) shifts the light variant's background tone. | 2026-07-09 |
+| `dashboard-loaded` | USER_GUIDE.md#what-vtsearch-does | §2 contrast fix: dark-theme table row dividers (--border-subtle) now perceptible; dim sub-text (--text-dim) lightened. Also: 2026-07-09 light-mode neutral-ramp change shifts the light variant's background tone. | 2026-07-09 |
+| `dashboard-manage` | USER_GUIDE.md#dashboard--managing-datasets-and-detectors | §2 contrast fix: dark-theme table row dividers (--border-subtle) now perceptible; dim sub-text (--text-dim) lightened. Also: 2026-07-09 light-mode neutral-ramp change shifts the light variant's background tone. | 2026-07-09 |
+| `three-panel` | USER_GUIDE.md#the-three-panel-layout | (1) Panels now snap tight to their grid columns on load (not just on divider drag), so the left/right panel widths — and the centre boundary between them — shift from the old restored-width layout. (2) The collapsed "Metadata" toggle moved from a full-width divider row above the Good/Bad buttons to a docked strip below them (center-panel tray now sits under the voting overlay). Also: 2026-07-09 light-mode neutral-ramp change shifts the light variant's panel tone. | 2026-07-09 |
+| `results-grid` | USER_GUIDE.md#view-options | Left panel snaps tight to its grid columns on load, so the `.panel-left` clip is now narrower (no trailing gap past the last thumbnail column). Also: 2026-07-09 light-mode neutral-ramp change shifts the light variant's panel tone. | 2026-07-09 |
+| `dataset-panel` | USER_GUIDE.md#loading-a-dataset | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts (see note above). | 2026-07-09 |
+| `importer-form` | USER_GUIDE.md#loading-a-dataset | 2026-07-09 light-mode neutral-ramp change: light variant's modal/background tone shifts. | 2026-07-09 |
+| `autopilot-vote` | USER_GUIDE.md#autopilot--the-guided-workflow | The collapsed "Metadata" toggle now sits below the Good/Bad buttons rather than above them. Also: 2026-07-09 light-mode neutral-ramp change shifts the light variant's panel tone. | 2026-07-09 |
+| `autopilot-progress` | USER_GUIDE.md#the-collapsed-bar | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
+| `manual-controls` | USER_GUIDE.md#manual-mode--for-power-users | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
+| `region-voting` | USER_GUIDE.md#region-voting-on-images | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
+| `view-options` | USER_GUIDE.md#view-options | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
+| `settings-appearance` | USER_GUIDE.md#solo-media-type--streamline-for-one-media-type | 2026-07-09 light-mode neutral-ramp change: light variant's modal/background tone shifts. | 2026-07-09 |
+| `browse-view` | USER_GUIDE.md#browse--exploring-a-dataset-spatially | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
+| `export-picker` | USER_GUIDE.md#exporting-your-work | 2026-07-09 light-mode neutral-ramp change: light variant's modal/background tone shifts. | 2026-07-09 |
+| `import-detector` | USER_GUIDE.md#importing-pre-trained-detectors | 2026-07-09 light-mode neutral-ramp change: light variant's modal/background tone shifts. | 2026-07-09 |
+| `new-detector` | USER_GUIDE.md#creating-a-detector | 2026-07-09 light-mode neutral-ramp change: light variant's modal/background tone shifts. | 2026-07-09 |
+| `find-view` | USER_GUIDE.md#find--scoring-and-verifying | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
+| `find-stats` | USER_GUIDE.md#find--scoring-and-verifying | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
+| `achievements` | USER_GUIDE.md#achievements | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -176,18 +176,24 @@
 }
 
 [data-theme="light"] {
-  // Neutral ramp. The desk (--bg-body) is a clearly-grayed slate so that white
-  // surfaces (cards, modals, dropdowns) and the lighter side panels read as
-  // *raised* against it - mirroring the dark theme, where --bg-surface sits a
-  // visible step above the near-black --bg-body. A near-white desk (the old
-  // #f0f2f5) made white cards blend into the background. Elevation order, low
-  // to high: hover < body < subtle < panel < surface.
-  --bg-body: #e4e7ef;
+  // Neutral ramp. Follows the industry "gray chrome, white cards" pattern
+  // (GitHub, Ant, Material): the panels the user actually looks at (--bg-panel,
+  // which paints all three layout columns) carry a clearly-gray tone, and white
+  // content surfaces (cards, modals, dropdowns) read as *raised* against them.
+  // An earlier ramp put the gray only on --bg-body (the desk), but the 3-panel
+  // layout covers the desk almost entirely, so the visible chrome was near-white
+  // (#f1f3f8) and cards barely separated from it - the whole thing read washed
+  // out despite the tokens measuring on the gray side of the industry range.
+  // Pulling the gray up onto --bg-panel (L 0.84, between Material's 0.86 and
+  // Tailwind slate-200's 0.80 - still comfortably standard, not darkened past
+  // it) restores the panel-vs-card separation. Elevation order, low to high:
+  // hover < body < subtle < panel < surface.
+  --bg-body: #dbdfea;
   --bg-surface: #ffffff;
-  --bg-panel: #f1f3f8;
-  --bg-hover: #dbe0ec;
-  --bg-subtle: #edeff4;
-  --bg-secondary-btn: #dde1ec;
+  --bg-panel: #e9ecf3;
+  --bg-hover: #d3d8e6;
+  --bg-subtle: #e3e7f0;
+  --bg-secondary-btn: #d8dce9;
   // Border ramp, faintest to strongest: subtle < border < secondary. (Unlike
   // dark, where "fainter" means darker/closer-to-bg, here fainter means
   // lighter/closer-to-the-white-surface the line sits on.)


### PR DESCRIPTION
## What prompted this

The light theme looked "washed out — very white, instead of gray." The ask was to *check* the backgrounds against industry standard, without artificially darkening anything.

## The check

I rendered VTSearch's light-mode neutral tokens beside five design systems (GitHub Primer, Ant Design, Tailwind Slate, Material 3, Atlassian), measuring WCAG relative luminance (L). The raw values were **not** whiter than standard — if anything, slightly grayer:

| Surface | VTSearch | L | vs. industry app-chrome grays |
|---|---|---|---|
| Desk (`--bg-body`) | `#e4e7ef` | 0.799 | grayest of everyone compared |
| Main panels (`--bg-panel`) | `#f1f3f8` | 0.896 | grayer than GitHub (0.936), Ant (0.913), Tailwind (0.908), Atlassian (0.937) |
| Cards (`--bg-surface`) | `#ffffff` | 1.000 | same white as everyone |

So the washed-out impression wasn't the values being too light — it was a **layout** effect:

1. The 3-panel layout (`300px | 1fr | 300px`) paints all three columns `--bg-panel`, so the genuinely-gray desk (`--bg-body`) is almost entirely occluded — its gray never does visual work. What the user actually stares at is the near-white panels.
2. Cards (`#fff`, L 1.000) sit on panels (L 0.896) — only a ~0.10 luminance step, so cards barely separate. That flatness is the washed-out feeling.

The industry pattern (GitHub, Ant, Material) is "**gray chrome, white cards**": the panels are the gray layer, content cards are white on top.

## The change

Move the gray off the hidden desk and onto the surfaces the user looks at, keeping cards pure white and staying inside the industry range (no darkening past standard):

| Token | Before | After |
|---|---|---|
| `--bg-panel` (all 3 columns) | `#f1f3f8` | `#e9ecf3` (L ~0.84) |
| `--bg-subtle` | `#edeff4` | `#e3e7f0` |
| `--bg-body` (desk) | `#e4e7ef` | `#dbdfea` |
| `--bg-hover` | `#dbe0ec` | `#d3d8e6` |
| `--bg-secondary-btn` | `#dde1ec` | `#d8dce9` |
| `--bg-surface` (cards) | `#ffffff` | `#ffffff` (unchanged) |

Elevation order (hover < body < subtle < panel < surface) is preserved. The `_variables.scss` comment is rewritten to explain the "gray chrome, white cards" rationale.

Only the light theme changes; dark and highviz are untouched.

## Screenshots

All 20 user-docs shots are captured in both themes, so every `.light.png` is now stale. I had a browser this session but couldn't drain the reshoot queue: the repo pins Playwright 1.60 (Chromium build 1223) while the container ships build 1194, and the dev app server wouldn't stay alive across the capture in this session's process model. So the affected shots are recorded in `docs/user/screenshots-reshoot-queue.md` for a properly-provisioned session to drain.

## Verification

`./run-tests.sh frontend` green (Angular `build:prod` with no budget warnings, `npm audit` clean, Vitest 1006 passed). `wiring-check.py` OK (20 shots, 20 reshoots queued). `codespell` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VudZCU7xthq82nbT3pCuUC)_