### PR TITLE
Ignore key auto-repeat for arrow-key votes

### DIFF
--- a/frontend/src/app/services/keyboard.service.spec.ts
+++ b/frontend/src/app/services/keyboard.service.spec.ts
@@ -67,6 +67,38 @@ describe('KeyboardService', () => {
     document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
   }));
 
+  it('should not emit vote on auto-repeat ArrowRight (held key)', () => {
+    service.start();
+    const actions: KeyboardAction[] = [];
+    service.action$.subscribe((a) => actions.push(a));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    // Subsequent events with repeat=true simulate the OS key-repeat while held.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', repeat: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', repeat: true }));
+    expect(actions.length).toBe(1);
+    expect(actions[0].direction).toBe('good');
+  });
+
+  it('should not emit vote on auto-repeat ArrowLeft (held key)', () => {
+    service.start();
+    const actions: KeyboardAction[] = [];
+    service.action$.subscribe((a) => actions.push(a));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', repeat: true }));
+    expect(actions.length).toBe(1);
+    expect(actions[0].direction).toBe('bad');
+  });
+
+  it('should still emit volume on auto-repeat ArrowUp (held key adjusts)', () => {
+    service.start();
+    const actions: KeyboardAction[] = [];
+    service.action$.subscribe((a) => actions.push(a));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', repeat: true }));
+    expect(actions.length).toBe(2);
+    expect(actions.every((a) => a.type === 'volume')).toBe(true);
+  });
+
   it('should not emit when modifier keys are held', () => {
     service.start();
     const actions: KeyboardAction[] = [];

--- a/frontend/src/app/services/keyboard.service.ts
+++ b/frontend/src/app/services/keyboard.service.ts
@@ -72,11 +72,17 @@ export class KeyboardService implements OnDestroy {
     switch (e.key) {
       case 'ArrowRight':
         e.preventDefault();
+        // Ignore OS key auto-repeat: holding the key would otherwise cast a
+        // vote per repeat event, rapidly (mis)tagging item after item until
+        // the user releases. Each vote must be a discrete key press. Volume/
+        // zoom/rotate below intentionally allow repeat (holding to adjust).
+        if (e.repeat) break;
         (document.activeElement as HTMLElement)?.blur();
         this.action$.next({ type: 'vote', direction: 'good' });
         break;
       case 'ArrowLeft':
         e.preventDefault();
+        if (e.repeat) break;
         (document.activeElement as HTMLElement)?.blur();
         this.action$.next({ type: 'vote', direction: 'bad' });
         break;

--- a/frontend/src/app/services/keyboard.service.ts
+++ b/frontend/src/app/services/keyboard.service.ts
@@ -73,9 +73,10 @@ export class KeyboardService implements OnDestroy {
       case 'ArrowRight':
         e.preventDefault();
         // Ignore OS key auto-repeat: holding the key would otherwise cast a
-        // vote per repeat event, rapidly (mis)tagging item after item until
-        // the user releases. Each vote must be a discrete key press. Volume/
-        // zoom/rotate below intentionally allow repeat (holding to adjust).
+        // vote per repeat event, rapidly tagging item after item (often the
+        // wrong ones) until the user releases. Each vote must be a discrete
+        // key press. Volume/zoom/rotate below intentionally allow repeat
+        // (holding the key to adjust continuously).
         if (e.repeat) break;
         (document.activeElement as HTMLElement)?.blur();
         this.action$.next({ type: 'vote', direction: 'good' });


### PR DESCRIPTION
## Problem

Fixes #2215. When tagging items good/bad with the arrow keys, holding a key down fired a vote on every OS key-repeat event. If the display lagged, this tagged the next item or two by mistake, and holding the key would rapidly tag item after item until release.

## Fix

In `KeyboardService.handleKeydown`, the `ArrowRight`/`ArrowLeft` (good/bad vote) cases now short-circuit when `KeyboardEvent.repeat` is set, so each vote requires a discrete key press. `e.preventDefault()` still runs on repeats to suppress page scrolling.

Volume (`ArrowUp`/`ArrowDown`), zoom, and rotate are deliberately left untouched — holding those keys to adjust continuously is the intended behavior.

## Tests

Added three unit tests in `keyboard.service.spec.ts`:
- Held `ArrowRight` (repeat events) emits exactly one `good` vote.
- Held `ArrowLeft` emits exactly one `bad` vote.
- Held `ArrowUp` still emits a volume action per repeat (regression guard that repeat suppression is scoped to votes).

Full `./run-tests.sh frontend` gate passes (build + audit + 1012 Vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrH38JL1mWe6d6hEMAdw8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrH38JL1mWe6d6hEMAdw8n)_