### PR TITLE
Show a success toast when an export completes

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ExportModalComponent } from './export-modal.component';
+import { ToastService } from '../../../services/toast.service';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
 import { settleResource } from '../../../testing/settle-resource';
 
@@ -99,6 +100,17 @@ describe('ExportModalComponent', () => {
     component.startExporter(mockExporters[0] as never);
     httpMock.expectOne('/api/exporters/export').flush({ success: true });
     expect(component.exported.emit).toHaveBeenCalled();
+  });
+
+  it('fires a success toast that outlives the closing modal', async () => {
+    await flushInit();
+    const toast = TestBed.inject(ToastService);
+    const successSpy = vi.spyOn(toast, 'success');
+    component.labelFilter = 'good'; // two matching labels in the fixture
+    component.startExporter(mockExporters[0] as never);
+    httpMock.expectOne('/api/exporters/export').flush({ success: true });
+    expect(successSpy).toHaveBeenCalledTimes(1);
+    expect(successSpy.mock.calls[0][0].message).toBe('Exported 2 labels to Server JSON');
   });
 
   it('emits closed on close', async () => {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -25,6 +25,7 @@ import { ExportersApiService } from '../../../services/exporters-api.service';
 import { LabelSessionService } from '../../../services/label-session.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import type { LabelFilter } from '../../../services/sorting-api.service';
+import { ToastService } from '../../../services/toast.service';
 import { ImporterField } from '../../../models/api.models';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 import type { LabeledElement } from '../../../generated/api-client/models/labeled-element';
@@ -68,6 +69,7 @@ export class ExportModalComponent implements OnInit {
   private readonly sortingApi = inject(SortingApiService);
   private readonly activeContext = inject(ActiveContextService);
   private readonly datasetState = inject(DatasetStateService);
+  private readonly toast = inject(ToastService);
 
   // Two eager reads (dataset status + exporter list) load on creation; the
   // labels read is input-derived, so it waits for `ngOnInit` to set
@@ -428,7 +430,8 @@ export class ExportModalComponent implements OnInit {
 
   exportLabelsWith(exporter: ExporterEntry, fieldValues: Record<string, string>): void {
     const exporterLabel = exporter.display_name || exporter.name;
-    this.status.set(`Exporting ${this.filteredLabels.length.toLocaleString()} labels to ${exporterLabel}…`);
+    const labelCount = this.filteredLabels.length;
+    this.status.set(`Exporting ${labelCount.toLocaleString()} labels to ${exporterLabel}…`);
     this.actionError.set('');
     this.submitting.set(true);
 
@@ -447,6 +450,14 @@ export class ExportModalComponent implements OnInit {
           this.status.set('Labels exported.');
           this.submitting.set(false);
           this.selectedExporter = null;
+          // The parent closes the modal on `exported`, so the inline status
+          // above is never seen. Fire a toast that outlives the modal so the
+          // user gets confirmation the export actually succeeded (issue #2217).
+          this.toast.success({
+            message: `Exported ${labelCount.toLocaleString()} label${labelCount === 1 ? '' : 's'} to ${exporterLabel}`,
+            detail: fieldValues['filepath'] ? `Destination: ${fieldValues['filepath']}` : undefined,
+            dedupKey: 'export-labels-success',
+          });
           this.exported.emit();
         },
         error: () => {

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { LabelExporterModalComponent } from './label-exporter-modal.component';
+import { ToastService } from '../../../services/toast.service';
 import { configureZoneless } from '../../../testing/zoneless-testbed';
 import { settleResource, settleZoneless } from '../../../testing/settle-resource';
 
@@ -80,6 +81,25 @@ describe('LabelExporterModalComponent', () => {
 
     expect(component.exportComplete.emit).toHaveBeenCalled();
     expect(component.closed.emit).toHaveBeenCalled();
+  });
+
+  it('fires a success toast so feedback survives the modal closing', async () => {
+    await flushInit();
+    const toast = TestBed.inject(ToastService);
+    const successSpy = vi.spyOn(toast, 'success');
+
+    component.selectExporter(mockExporters[1] as any);
+    httpMock.expectOne('/api/labels/export').flush({
+      labels: [
+        { md5: 'a', label: 'good' },
+        { md5: 'b', label: 'good' },
+        { md5: 'c', label: 'good' },
+      ],
+    });
+    httpMock.expectOne('/api/exporters/export').flush({ success: true });
+
+    expect(successSpy).toHaveBeenCalledTimes(1);
+    expect(successSpy.mock.calls[0][0].message).toBe('Exported 3 labels to server_json_file');
   });
 
   it('should render exporter cards', async () => {

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.ts
@@ -4,6 +4,7 @@ import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { ExportersApiService } from '../../../services/exporters-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
+import { ToastService } from '../../../services/toast.service';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 
 @Component({
@@ -22,6 +23,7 @@ export class LabelExporterModalComponent {
 
   private readonly exportersApi = inject(ExportersApiService);
   private readonly sortingApi = inject(SortingApiService);
+  private readonly toast = inject(ToastService);
 
   // Eager `rxResource`: loads the exporter list once on creation (no request
   // signal), wrapping the generated-client read so the interceptor chain still
@@ -48,8 +50,10 @@ export class LabelExporterModalComponent {
   }
 
   selectExporter(exporter: ExporterEntry): void {
+    const exporterLabel = exporter.display_name || exporter.name;
     this.sortingApi.exportLabels(this.goodsOnly).subscribe({
       next: (labelsData) => {
+        const labelCount = labelsData.labels?.length ?? 0;
         this.exportersApi
           .runExport({
             exporter_name: exporter.name,
@@ -57,6 +61,12 @@ export class LabelExporterModalComponent {
           })
           .subscribe({
             next: () => {
+              // Selecting an exporter closes the modal immediately, so a toast
+              // is the only durable confirmation the export succeeded (#2217).
+              this.toast.success({
+                message: `Exported ${labelCount.toLocaleString()} label${labelCount === 1 ? '' : 's'} to ${exporterLabel}`,
+                dedupKey: 'label-export-success',
+              });
               this.exportComplete.emit();
               this.closed.emit();
             },


### PR DESCRIPTION
## Problem

Fixes #2217. When the user runs an export, the only feedback was the export window closing. Both the main label **Export** modal (`vt-export-modal`) and the `vt-label-exporter-modal` emit their `exported` / `exportComplete` output on success, and the parent (`right-panel`, `find-view`) responds by flipping the modal off immediately. The export modal *did* set an inline `Labels exported.` status, but the modal was already gone by the time it rendered — so the user had no way to tell whether the export reached its destination without going and checking the endpoint themselves.

## Change

Fire a `ToastService.success` notification from the export success handlers. The toast outlives the modal and auto-dismisses after a few seconds, so the user gets durable, non-blocking confirmation naming the label count and the exporter it went to (e.g. *"Exported 2 labels to Server JSON"*). File exporters also surface the destination path as the toast detail.

- `export-modal.component.ts` — inject `ToastService`, emit a success toast in `exportLabelsWith`'s success branch before `exported.emit()`.
- `label-exporter-modal.component.ts` — same, in `selectExporter`'s nested success callback, using the fetched label count.

The `settings-exporter-modal` and `detector-portable-export-modal` already show durable inline feedback (a success message / a "done" state and they stay open), so they're left unchanged.

## Tests

Added a spec to each affected modal asserting the success toast fires with the expected message. Full frontend gate passes: production build, `npm audit --omit=dev` (0 vulnerabilities), and 1011 Vitest unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T873LUx2FBffS4t97qWoy

---
_Generated by [Claude Code](https://claude.ai/code/session_013T873LUx2FBffS4t97qWoy)_