### PR TITLE
fix(export): make export preview table columns resizable

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -49,11 +49,21 @@
       <p class="empty-state">No labeled items to export.</p>
     } @else {
       <div class="table-scroll">
-        <table class="export-table">
+        <table class="export-table" [class.table-fixed]="tableFixed">
           <thead>
             <tr>
               @for (col of enabledColumns; track col.key) {
-                <th [title]="col.label">{{ col.label }}</th>
+                <th
+                  [attr.data-col]="col.key"
+                  [title]="col.label"
+                  [style.width.px]="tableFixed ? colWidths[col.key] : null"
+                >
+                  <span
+                    class="col-resize-handle"
+                    (mousedown)="startColResize($event, col.key)"
+                    title="Drag to resize column"
+                  ></span>{{ col.label }}
+                </th>
               }
             </tr>
           </thead>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -80,6 +80,24 @@
   border-collapse: collapse;
   font-size: var(--font-sm);
 
+  // Once the user drags a divider the component freezes per-column pixel
+  // widths and flips to fixed layout; `max-content` sizes the table to the sum
+  // of those widths (so a widened column overflows and the `.table-scroll`
+  // container scrolls), while `min-width: 100%` keeps it filling the container
+  // when the columns are narrow.
+  &.table-fixed {
+    table-layout: fixed;
+    width: max-content;
+    min-width: 100%;
+
+    // Explicit per-column widths govern in fixed layout; drop the auto-layout
+    // 220px cap so a column can be dragged wider than that.
+    th,
+    td {
+      max-width: none;
+    }
+  }
+
   th,
   td {
     padding: var(--space-xs) var(--space-md);
@@ -99,6 +117,36 @@
     font-size: var(--font-xs);
     text-transform: uppercase;
     letter-spacing: 0.02em;
+
+    // Column resize handle, pinned inside the cell's right edge so the next
+    // sticky <th>'s stacking context can't paint over it (the reason the
+    // shared datagrid handle instead leaks left onto the following cell).
+    // The 2px indicator sits just inside the divider.
+    .col-resize-handle {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: 10px;
+      cursor: col-resize;
+      z-index: 2;
+
+      &::after {
+        content: '';
+        position: absolute;
+        top: 25%;
+        bottom: 25%;
+        right: 2px;
+        width: 2px;
+        background: var(--accent);
+        opacity: 0;
+        transition: opacity var(--transition-base);
+      }
+
+      &:hover::after {
+        opacity: 0.6;
+      }
+    }
   }
 
   tbody tr:hover {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -107,4 +107,68 @@ describe('ExportModalComponent', () => {
     component.close();
     expect(component.closed.emit).toHaveBeenCalled();
   });
+
+  describe('preview column resize', () => {
+    /** Build a detached preview-style table and return its parts. */
+    function makeTable(): { table: HTMLTableElement; th1: HTMLElement; handle: HTMLElement } {
+      const table = document.createElement('table');
+      const thead = document.createElement('thead');
+      const tr = document.createElement('tr');
+      const th1 = document.createElement('th');
+      th1.setAttribute('data-col', 'label');
+      const th2 = document.createElement('th');
+      th2.setAttribute('data-col', 'md5');
+      tr.append(th1, th2);
+      thead.append(tr);
+      table.append(thead);
+      const handle = document.createElement('span');
+      th1.append(handle);
+      document.body.append(table);
+      return { table, th1, handle };
+    }
+
+    function mousedownOn(handle: HTMLElement, clientX: number): MouseEvent {
+      const ev = new MouseEvent('mousedown', { clientX });
+      Object.defineProperty(ev, 'target', { value: handle });
+      return ev;
+    }
+
+    it('freezes every column width and enters fixed layout on first grab', async () => {
+      await flushInit();
+      const { table, handle } = makeTable();
+      component.startColResize(mousedownOn(handle, 100), 'label');
+      expect(component.tableFixed).toBe(true);
+      expect(component.colWidths).toHaveProperty('label');
+      expect(component.colWidths).toHaveProperty('md5');
+      expect(document.body.style.cursor).toBe('col-resize');
+      component.onColResizeEnd();
+      table.remove();
+    });
+
+    it('resizes the grabbed column by the drag delta, clamped to a minimum', async () => {
+      await flushInit();
+      const { table, handle } = makeTable();
+      component.startColResize(mousedownOn(handle, 100), 'label');
+      // offsetWidth is 0 under jsdom, so startWidth is 0; +80px drag → 80px.
+      component.onColResizeMove(new MouseEvent('mousemove', { clientX: 180 }));
+      expect(component.colWidths['label']).toBe(80);
+      // A tiny drag can't shrink the column below the 40px floor.
+      component.onColResizeMove(new MouseEvent('mousemove', { clientX: 110 }));
+      expect(component.colWidths['label']).toBe(40);
+      component.onColResizeEnd();
+      table.remove();
+    });
+
+    it('ignores pointer motion once the drag ends and clears the cursor', async () => {
+      await flushInit();
+      const { table, handle } = makeTable();
+      component.startColResize(mousedownOn(handle, 100), 'label');
+      component.onColResizeMove(new MouseEvent('mousemove', { clientX: 180 }));
+      component.onColResizeEnd();
+      expect(document.body.style.cursor).toBe('');
+      component.onColResizeMove(new MouseEvent('mousemove', { clientX: 400 }));
+      expect(component.colWidths['label']).toBe(80); // unchanged after end
+      table.remove();
+    });
+  });
 });

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   computed,
   effect,
+  HostListener,
   inject,
   input,
   OnInit,
@@ -224,6 +225,72 @@ export class ExportModalComponent implements OnInit {
 
   get enabledColumns(): ColumnDef[] {
     return this.columns.filter((c) => c.enabled);
+  }
+
+  // --- Preview column resize ---
+  //
+  // The preview table's columns default to auto layout (`width: 100%`, each
+  // column sized to its content up to a cap). Once the user grabs a divider we
+  // switch to a pixel model: freeze every column's current width, flip the
+  // table to `table-layout: fixed`, and let the grabbed column grow/shrink on
+  // its own. The `.table-scroll` container already scrolls horizontally, so a
+  // widened column reveals its full content instead of redistributing space
+  // away from its neighbours. Widths are per-process view state, not persisted
+  // (the preview is ephemeral).
+
+  private static readonly MIN_COL_PX = 40;
+
+  /** Pixel widths keyed by column key; populated on first resize. */
+  colWidths: Record<string, number> = {};
+
+  /** Once true, the table uses `table-layout: fixed` with explicit widths. */
+  tableFixed = false;
+
+  private colResize: { key: string; startX: number; startWidth: number } | null = null;
+
+  /** Begin dragging a column divider: freeze current widths, then track the
+   *  grabbed column so `onColResizeMove` can size it. */
+  startColResize(event: MouseEvent, key: string): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const th = (event.target as HTMLElement).closest('th');
+    const table = th?.closest('table');
+    if (!table) return;
+
+    if (!this.tableFixed) {
+      const ths = table.querySelectorAll('thead th') as NodeListOf<HTMLElement>;
+      ths.forEach((cell) => {
+        const cellKey = cell.getAttribute('data-col');
+        if (cellKey) this.colWidths[cellKey] = cell.offsetWidth;
+      });
+      this.tableFixed = true;
+    }
+
+    this.colResize = {
+      key,
+      startX: event.clientX,
+      startWidth: this.colWidths[key] ?? (th as HTMLElement).offsetWidth,
+    };
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }
+
+  @HostListener('document:mousemove', ['$event'])
+  onColResizeMove(event: MouseEvent): void {
+    if (!this.colResize) return;
+    const dx = event.clientX - this.colResize.startX;
+    this.colWidths[this.colResize.key] = Math.max(
+      ExportModalComponent.MIN_COL_PX,
+      this.colResize.startWidth + dx,
+    );
+  }
+
+  @HostListener('document:mouseup')
+  onColResizeEnd(): void {
+    if (!this.colResize) return;
+    this.colResize = null;
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
   }
 
   get filteredLabels(): LabeledElement[] {


### PR DESCRIPTION
## Summary

Fixes #2216. The export modal's data-preview table only ever auto-fit its columns — the widths shifted when you toggled columns on/off, but you couldn't drag a header to widen a column for readability. Long values (filenames, metadata) stayed clipped with no way to see more.

This adds drag-to-resize handles to the preview header cells.

## Behavior

- Each preview column header now carries a thin resize handle at its right edge (a faint accent line that appears on hover, `col-resize` cursor).
- On the first grab, the table freezes each column's current pixel width and switches to `table-layout: fixed`; the grabbed column then grows/shrinks on its own down to a 40px floor.
- Because the preview already lives in a horizontally-scrollable container, widening a column reveals its full content and scrolls rather than stealing space from neighbours — every column, including the last, is independently resizable.
- Column widths are ephemeral per-modal view state; nothing is persisted (consistent with the preview being a throwaway view).

## Implementation notes

The shared `ManagedColumns` datagrid controller (dashboard, pickers) was a poor fit here: it assumes a fixed column set, a trailing pinned column, and bundles sort + drag-reorder, none of which apply to a checkbox-driven preview with a dynamic, all-data column set. So the resize is a small self-contained addition to `ExportModalComponent` (three `@HostListener`-driven handlers plus a scoped handle style), mirroring the app's existing resize UX without the machinery that doesn't fit.

The handle is pinned inside the cell's right edge (rather than leaking left onto the next cell like the datagrid handle) so the neighbouring sticky `<th>`'s stacking context can't paint over it while keeping the last column resizable.

## Tests

- Added unit coverage for the resize lifecycle (freeze-on-grab, delta sizing with the min-width clamp, motion ignored after release).
- `./run-tests.sh frontend` passes: ruff/pyright/deptry/pip-audit clean, frontend build OK, 1012 Vitest tests pass.

No doc-screenshot reshoot is queued: the handle indicator is `opacity: 0` at rest, so the `export-picker` screenshot renders identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XydyApr8fZUt7bfipp2s81

---
_Generated by [Claude Code](https://claude.ai/code/session_01XydyApr8fZUt7bfipp2s81)_