### PR TITLE
Fix audio waveform thumbnails silently returning None for AAC/MP4 clips

### DIFF
--- a/tests_lib/core/test_audio.py
+++ b/tests_lib/core/test_audio.py
@@ -54,6 +54,31 @@ class TestGenerateWaveformThumbnail:
         assert result is not None
         assert result[:8] == b"\x89PNG\r\n\x1a\n"
 
+    def test_falls_back_to_tempfile_when_buffer_decode_fails(self, monkeypatch):
+        """AAC/M4A can't decode from a BytesIO (librosa only reaches ffmpeg via a
+        real path), so a buffer-decode failure must retry through a temp file
+        rather than silently returning None."""
+        import librosa
+        import numpy as np
+
+        calls = {"buffer": 0, "path": 0}
+
+        def fake_load(path, **kwargs):
+            if isinstance(path, io.BytesIO):
+                calls["buffer"] += 1
+                raise RuntimeError("libsndfile cannot parse AAC-in-MP4 from a buffer")
+            calls["path"] += 1
+            rng = np.random.default_rng(0)
+            return rng.standard_normal(4000).astype(np.float32), 44100
+
+        monkeypatch.setattr(librosa, "load", fake_load)
+
+        result = generate_waveform_thumbnail(b"fake aac bytes", filename="clip.m4a")
+        assert result is not None
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+        assert calls["buffer"] == 1  # tried the buffer first
+        assert calls["path"] == 1  # then fell back to the temp file
+
 
 class TestGenerateWav:
     def test_returns_valid_wav(self):

--- a/vtscore/datasets/stages/clipper.py
+++ b/vtscore/datasets/stages/clipper.py
@@ -248,7 +248,7 @@ def _thumb_for(clip: dict, media_type: str) -> bytes | None:
 
         wav = clip.get("media_bytes")
         if wav is not None:
-            return generate_waveform_thumbnail(wav)
+            return generate_waveform_thumbnail(wav, filename=clip.get("filename", ""))
         path = clip.get("media_path")
         if path:
             return generate_waveform_thumbnail_from_file(Path(path))

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -89,19 +89,22 @@ def _render_waveform(audio_data, *, size: int = _THUMB_SIZE) -> bytes | None:
     return buf.getvalue()
 
 
-def generate_waveform_thumbnail(audio_bytes: bytes, *, size: int = _THUMB_SIZE) -> bytes | None:
+def generate_waveform_thumbnail(
+    audio_bytes: bytes, *, filename: str = "", size: int = _THUMB_SIZE
+) -> bytes | None:
     """Render a waveform thumbnail as a PNG image from raw audio bytes.
 
-    Decodes the audio with librosa from an in-memory buffer, computes the
-    min/max amplitude envelope, and draws it onto a square PIL image.  Returns
-    PNG bytes, or ``None`` if the audio cannot be decoded.
+    Decodes the audio with librosa, computes the min/max amplitude envelope, and
+    draws it onto a square PIL image.  Returns PNG bytes, or ``None`` if the
+    audio cannot be decoded.
 
-    Note that ``soundfile``-backed containers (WAV/FLAC/OGG/MP3) decode straight
-    from the in-memory buffer, but codecs that fall back to ``audioread`` +
-    ffmpeg (AAC/M4A/MP4) can only be decoded from a real file path, so this
-    buffer-only path returns ``None`` for them.  Use
-    :func:`_decode_audio_file_bytes` (which spills to a temp file) when a member
-    may be an ffmpeg-only codec.
+    ``soundfile``-backed containers (WAV/FLAC/OGG/MP3) decode straight from the
+    in-memory buffer.  Codecs that fall back to ``audioread`` + ffmpeg
+    (AAC/M4A/MP4) can't be decoded from a ``BytesIO`` at all - librosa only
+    reaches the ffmpeg backend for a real filesystem path - so on a buffer-decode
+    failure this spills to a temp file via :func:`_decode_audio_file_bytes` and
+    retries.  *filename* (when known) lends its extension to that temp file so
+    ``audioread`` picks the right backend.
     """
     try:
         import librosa  # noqa: PLC0415
@@ -110,6 +113,8 @@ def generate_waveform_thumbnail(audio_bytes: bytes, *, size: int = _THUMB_SIZE) 
     try:
         audio_data, _sr = librosa.load(io.BytesIO(audio_bytes), sr=None, mono=True)
     except Exception:
+        audio_data, _sr = _decode_audio_file_bytes(audio_bytes, filename)
+    if audio_data is None:
         return None
     return _render_waveform(audio_data, size=size)
 
@@ -883,7 +888,7 @@ class AudioMediaType(MediaType):
             duration = len(audio_data) / sr
         except Exception:
             duration = 0.0
-        thumbnail = generate_waveform_thumbnail(media_bytes)
+        thumbnail = generate_waveform_thumbnail(media_bytes, filename=Path(file_path).name)
         return {"media_bytes": media_bytes, "duration": duration, "thumbnail_bytes": thumbnail}
 
     # ------------------------------------------------------------------

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -89,9 +89,7 @@ def _render_waveform(audio_data, *, size: int = _THUMB_SIZE) -> bytes | None:
     return buf.getvalue()
 
 
-def generate_waveform_thumbnail(
-    audio_bytes: bytes, *, filename: str = "", size: int = _THUMB_SIZE
-) -> bytes | None:
+def generate_waveform_thumbnail(audio_bytes: bytes, *, filename: str = "", size: int = _THUMB_SIZE) -> bytes | None:
     """Render a waveform thumbnail as a PNG image from raw audio bytes.
 
     Decodes the audio with librosa, computes the min/max amplitude envelope, and

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -961,7 +961,7 @@ def _embed_upload(embedder, file_bytes: bytes, original_filename: str):
     return embedding
 
 
-def _make_pile_thumbnail(media_type: str, file_bytes: bytes) -> bytes | None:
+def _make_pile_thumbnail(media_type: str, file_bytes: bytes, filename: str = "") -> bytes | None:
     """Precompute the grid/list thumbnail for an add-to-pile upload.
 
     Dispatches per media type (audio waveform, video frame, image downscale) so
@@ -971,7 +971,7 @@ def _make_pile_thumbnail(media_type: str, file_bytes: bytes) -> bytes | None:
     if media_type == "audio":
         from vtscore.media.audio.media_type import generate_waveform_thumbnail  # noqa: PLC0415
 
-        return generate_waveform_thumbnail(file_bytes)
+        return generate_waveform_thumbnail(file_bytes, filename=filename)
     if media_type == "video":
         from vtscore.media.video.media_type import generate_video_thumbnail  # noqa: PLC0415
 
@@ -1094,7 +1094,7 @@ def add_media_to_pile():
 
     # Precompute the grid/list thumbnail so the request path never decodes the
     # full-resolution upload on a cold tile fetch (matches the ingest path).
-    thumb = _make_pile_thumbnail(dataset_media_type, file_bytes)
+    thumb = _make_pile_thumbnail(dataset_media_type, file_bytes, original_filename)
 
     new_media: dict[str, Any] = {
         "media_type": dataset_media_type,


### PR DESCRIPTION
Fixes #2233.

## Problem

`generate_waveform_thumbnail()` decoded raw audio bytes only through an in-memory `io.BytesIO`. `soundfile`/libsndfile can't parse AAC-in-MP4/M4A containers, and librosa 0.11's `audioread`/ffmpeg fallback **only fires for a real filesystem path, never for a `BytesIO`** — so the fallback branch was dead code at this call site and the thumbnail silently came back `None` for those codecs (no error surfaced in the UI).

The sibling `generate_waveform_thumbnail_from_file()` and the archive-member window path had already been fixed to spill to a temp file, but the raw-bytes entry point had not. It's reached by:
- `AudioMediaType.load_media_data()` — folder/demo import of `.m4a` files (`.m4a` is a registered audio extension)
- the add-to-pile upload path (`_make_pile_thumbnail` in `routes/media/list.py`)
- the clipper (`_thumb_for` in `datasets/stages/clipper.py`)

## Fix

On a buffer-decode failure, `generate_waveform_thumbnail()` now falls back to the existing `_decode_audio_file_bytes()` temp-file decoder (which reaches ffmpeg), instead of giving up. The source filename is threaded through so the temp file keeps the right extension and `audioread` picks the correct backend. The fast in-memory path is preserved for `soundfile`-supported containers (WAV/FLAC/OGG/MP3) — the temp-file spill only happens when the buffer decode actually fails.

> Note: ffmpeg must be reachable on `$PATH` for the fallback to succeed for AAC/M4A; without it the decode still yields `None`, same as before.

## Tests

Added `test_falls_back_to_tempfile_when_buffer_decode_fails`, which stubs `librosa.load` to fail on a `BytesIO` and succeed on a path, asserting the thumbnail is produced and that the buffer path is tried first, then the temp file. Full `./run-tests.sh` suite passes (5537 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMwu3RGGcZdWP2wj2vhXRL

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMwu3RGGcZdWP2wj2vhXRL)_