### PR TITLE
Region-vote training on patch datasets: snap Good votes, flood Bad votes

### DIFF
--- a/docs/ML.md
+++ b/docs/ML.md
@@ -32,7 +32,7 @@ The model outputs raw logits (not probabilities) during training. This allows th
 
 ### Class Weighting
 
-Training uses **inverse-frequency weighting only** to balance classes (`mlp.py:193-197`). Inclusion does **not** enter training — the trained model, and therefore every item's score, is independent of inclusion. Inclusion is applied later as a pure threshold knob in `find_optimal_threshold` (see [Threshold Calibration](#threshold-calibration) below).
+Training balances classes by **inverse-frequency weighting** by default (`mlp.py`). The one exception is region flooding on patch datasets, where the caller supplies explicit per-bag `sample_weights` instead (see [Region-aware training](#region-aware-training-on-patch-region-datasets) below). Either way, inclusion does **not** enter training — the trained model, and therefore every item's score, is independent of inclusion. Inclusion is applied later as a pure threshold knob in `find_optimal_threshold` (see [Threshold Calibration](#threshold-calibration) below).
 
 - **Weights**: `weight_true = num_false / num_true`, `weight_false = 1.0`
 
@@ -115,11 +115,19 @@ The **document** media type has no embedding model of its own. Documents (PDF, D
 
 Embeddings are computed once when a dataset is loaded. The full-image vector lands in each clip's `"embeddings"` dict, keyed by embedder name (`numpy.ndarray` values; read it through the `media_embedding` accessor); patch embedders additionally populate `"patch_regions"` (list of `RegionVector`s, fp16-on-disk / fp32-in-RAM) and `"patch_grid"` (`H × W × D` ndarray, fp16). The MLP trains on these pre-computed vectors, so training is fast (typically < 1 second for 200 epochs on a few hundred labeled examples).
 
-### Region-aware training loss (patch-region datasets)
+### Region-aware training on patch-region datasets
 
-When the dataset's embedder produces `patch_regions`, the MLP's per-vote loss is asymmetric: Good votes train on the full-image vector (the user's "this image is good" claim doesn't single out a region); Bad votes apply `BCE(score, 0)` to *every* region in the image's HAC tree (the strictly stronger claim "no region in this image is good") and reduce by mean. At inference time `score_media` max-pools the MLP over regions, so train-time and test-time agree about what "low score" means. For datasets whose embedder doesn't produce regions, the Bad-side mean collapses to today's single-vector BCE (fully backward-compatible). See "Detector MLP: Training loss" in [`docs/plans/patch-embedder.md`](plans/patch-embedder.md) for the rationale.
+Inference max-pools the MLP over each image's `patch_regions` (an image scores by its **best** region — see `score_media`). Training is shaped to match that scorer, and it is deliberately asymmetric between Good and Bad votes — the multiple-instance-learning treatment of a max-pool bag:
 
-Yes-votes may additionally carry an optional `region_box` (4-float normalised rectangle) drawn by the user via Shift-drag on the focus pane. When set, the trainer pools the box's patch-grid cells on the fly (uniform mean, L2-normalise) and uses that vector instead of the full-image CLS vector for that Good example.
+- **Good vote** — a positive bag needs only *one* good region, and the user tells us which via an optional `region_box` (drawn by Shift-drag on the focus pane). The box is **snapped to the nearest `patch_regions` node** (max box-IoU, `snap_box_to_region`), so the positive is one of the exact candidates the max-pool will score — not a fresh uniform pool that matches no node. A Good vote with no box falls back to the full-image CLS node.
+- **Bad vote** — a negative bag asserts that *no* region is good, so a Bad vote **floods the image's CLS + HAC-leaf nodes** (the disjoint covering set; saliency-weighted internal nodes are dropped as redundant) as negatives. This trains every leaf down, so the max-pool can't surface a look-alike sub-region of a rejected image.
+
+Because flooding turns one Bad vote into many correlated leaf rows, class balance and calibration are **per-bag, not per-row**:
+
+- The final fit is `train_model(..., sample_weights=...)` where each Bad image's leaves share one image's worth of negative mass (`_per_bag_fit_weights`), so a rejected image counts once regardless of leaf count. Good votes weigh `n_bad_bags / n_good`, matching the default inverse-frequency balance but with the *bag* as the unit.
+- Cross-calibration (`compute_fold_orderings(groups=...)`) splits Train/Calibrate **by bag** (a Bad image's leaves never straddle the boundary), sizes fold counts over votes not rows, weights fold fits per-bag, and **max-pools each calibration group to one score** — so the threshold is placed on the per-image score scale the detector actually deploys. Hidden-layer width and the safe-threshold ramp likewise size on vote count.
+
+Flooding applies only where scoring is region-aware max-pool: the Learned-sort vote path (`train_and_score`) and the saved-detector labelset path (`labelset_train_and_score` / `train_from_labelset`). Paths that score each image by a single vector — Find cold-detector scoring, label-file sort — score image-level and are intentionally *not* flooded (flooding leaf negatives while scoring one image vector would be a train/score space mismatch). On any dataset whose embedder produces no regions, every bag holds one row and the whole path collapses byte-for-byte to the historical single-vector BCE — fully backward-compatible.
 
 ## Key Files
 

--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -280,8 +280,8 @@ independent of the active detector.
   one resolver, `keying_embedder_for_snap(det_ctx, snap)` (the dataset's concrete
   embedder of the detector's type, else the score precedence), so switching between
   two same-type datasets re-derives the MLP in the new space (SigLIP→CLIP;
-  DinoV2→DinoV3, with region boxes re-pooled against the new grid by
-  `box_to_vote_vector`). The frontend gates the same pairs via `embedder_types` on
+  DinoV2→DinoV3, with region boxes snapped to the new grid's nearest HAC node by
+  `snap_box_to_region`). The frontend gates the same pairs via `embedder_types` on
   the dataset registry entry and `embedder_type` on the detector entry
   (`utils/context-compat.ts`). Single-embedder datasets are byte-for-byte unchanged.
 

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -1958,3 +1958,152 @@ class TestRegionAwareTrainingCrossDataset:
         eid = stable_element_id(elem)
         np.testing.assert_array_equal(det_ctx.label_embeddings[eid], sentinel)
         assert patch_calls == []
+
+
+class TestBadVoteRegionFlooding:
+    """A Bad vote on a patch media floods the image's CLS + HAC-leaf negatives
+    (the disjoint covering set), so the max-pool can't surface any look-alike
+    sub-region of a rejected image.  Internals are dropped; legacy datasets
+    contribute one image-level negative, unchanged.
+    """
+
+    @staticmethod
+    def _patch_media(cid, d=8):
+        rng = np.random.default_rng(cid)
+
+        def _unit(v):
+            v = np.asarray(v, dtype=np.float32)
+            return v / (np.linalg.norm(v) + 1e-8)
+
+        cls = _unit(rng.standard_normal(d))
+        leaf1 = _unit(rng.standard_normal(d))
+        leaf2 = _unit(rng.standard_normal(d))
+        internal = _unit(leaf1 + leaf2)
+        regions = [
+            RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=cls, children=None),  # CLS
+            RegionVector(box=(0.0, 0.0, 0.5, 1.0), vec=leaf1, children=None),  # leaf
+            RegionVector(box=(0.5, 0.0, 1.0, 1.0), vec=leaf2, children=None),  # leaf
+            RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=internal, children=(1, 2)),  # internal
+        ]
+        return {
+            "id": cid,
+            "md5": f"md5-{cid:04x}",
+            "media_type": "image",
+            "embedder": "dinov3_patch",
+            "embeddings": {"dinov3_patch": cls},
+            "patch_regions": regions,
+        }, [cls, leaf1, leaf2]
+
+    def test_bad_negative_vecs_returns_cls_plus_leaves_not_internals(self):
+        from vtscore.detectors.training import bad_negative_vecs
+
+        media, expected_leaves = self._patch_media(1)
+        vecs = bad_negative_vecs(media, "dinov3_patch")
+        assert len(vecs) == 3  # CLS + 2 leaves, internal dropped
+        for got, exp in zip(vecs, expected_leaves):
+            np.testing.assert_array_equal(got, exp)
+
+    def test_bad_negative_vecs_legacy_media_single_image_vector(self):
+        from vtscore.detectors.training import bad_negative_vecs
+
+        vec = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        media = {"id": 1, "media_type": "image", "embedder": "siglip", "embeddings": {"siglip": vec}}
+        vecs = bad_negative_vecs(media, "siglip")
+        assert len(vecs) == 1
+        np.testing.assert_array_equal(vecs[0], vec)
+
+    def test_build_vote_xy_floods_bad_patch_vote_with_grouped_rows(self):
+        from vtscore.detectors.training import _build_vote_xy
+
+        good_media, _ = self._patch_media(1)
+        good_media["patch_grid"] = None  # good vote falls back to image-level (no box)
+        bad_media, _ = self._patch_media(2)
+        clips = {1: good_media, 2: bad_media}
+
+        X, y, groups = _build_vote_xy(clips, {1: None}, {2: None}, {}, "dinov3_patch")
+        # 1 good row + 3 flooded bad rows.
+        assert y == [1.0, 0.0, 0.0, 0.0]
+        assert groups == [("g", 1), ("b", 2), ("b", 2), ("b", 2)]
+        assert len(X) == 4
+
+    def test_per_bag_weights_balance_bag_not_rows(self):
+        from vtscore.training.thresholds import _per_bag_fit_weights
+
+        # 1 good vote, 1 bad bag flooded into 3 rows.
+        y = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        groups = [("g", 1), ("b", 2), ("b", 2), ("b", 2)]
+        w = _per_bag_fit_weights(y, groups)
+        # good weight = n_bad_bags / n_good = 1/1 = 1; each bad row = 1/3.
+        np.testing.assert_allclose(w, [1.0, 1 / 3, 1 / 3, 1 / 3], atol=1e-6)
+        # Total good mass == total bad mass (balanced at the bag level).
+        assert abs(w[y == 1].sum() - w[y == 0].sum()) < 1e-6
+
+    def test_flood_context_noop_when_every_bag_is_one_row(self):
+        from vtscore.detectors.training import _flood_context
+
+        X = [np.zeros(4, dtype=np.float32) for _ in range(3)]
+        y = [1.0, 0.0, 0.0]
+        groups = [("g", 1), ("b", 2), ("b", 3)]  # no multi-row bag
+        n_votes, cal_groups, sample_weights = _flood_context(X, y, groups)
+        assert n_votes == 3
+        assert cal_groups is None  # unflooded -> legacy row-wise path
+        assert sample_weights is None
+
+    def test_build_xy_from_labelset_floods_bad_from_neg_cache(self):
+        from vtscore.datasets.labelset import LabeledElement, LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.labelset_training import build_xy_from_labelset
+        from vtscore.state.core import DetectorContext
+
+        good = LabeledElement(md5="g", label="good")
+        bad = LabeledElement(md5="b", label="bad")
+        det = DetectorContext("d1")
+        gid, bid = stable_element_id(good), stable_element_id(bad)
+        det.label_embeddings[gid] = np.array([1, 0, 0, 0], dtype=np.float32)
+        det.label_embeddings[bid] = np.array([0, 1, 0, 0], dtype=np.float32)  # ignored when flooded
+        leaves = [np.array([0, 0, 1, 0], dtype=np.float32), np.array([0, 0, 0, 1], dtype=np.float32)]
+        det.label_negative_regions[bid] = leaves
+
+        X, y, groups = build_xy_from_labelset(det, LabelSet([good, bad]))
+        assert y == [1.0, 0.0, 0.0]
+        assert groups == [("g", gid), ("b", bid), ("b", bid)]
+        np.testing.assert_array_equal(X[1], leaves[0])
+        np.testing.assert_array_equal(X[2], leaves[1])
+
+
+class TestBagAwareCalibration:
+    """``compute_fold_orderings(groups=...)`` splits by bag and max-pools each
+    calibration group to one score - so a Bad bag's flooded leaves never
+    straddle the Train/Calibrate boundary and score as one image.
+    """
+
+    def test_grouped_calibration_keeps_bags_together_and_maxpools(self):
+        import torch.nn as nn
+
+        from vtscore.training.thresholds import compute_fold_orderings
+
+        rng = np.random.default_rng(0)
+        # 3 good votes (singletons) + 3 bad bags (3 rows each) = 6 bags, 12 rows.
+        X, y, groups = [], [], []
+        for g in range(3):
+            X.append(rng.standard_normal(4).astype(np.float32))
+            y.append(1.0)
+            groups.append(("g", g))
+        for b in range(3):
+            for _ in range(3):
+                X.append(rng.standard_normal(4).astype(np.float32))
+                y.append(0.0)
+                groups.append(("b", b))
+
+        orderings, fallback = compute_fold_orderings(
+            X, y, 4, rng=np.random.RandomState(42), calibrate_count=2, hidden_dim=8, groups=groups
+        )
+        assert fallback is None
+        assert len(orderings) == 2
+        for scores, labels in orderings:
+            # One score per calibration GROUP, not per row: a fold holding
+            # k cal groups yields exactly k scores/labels.
+            assert len(scores) == len(labels)
+            assert all(lbl in (0.0, 1.0) for lbl in labels)
+            # No fold has more entries than there are bags.
+            assert len(scores) <= 6

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -2078,8 +2078,6 @@ class TestBagAwareCalibration:
     """
 
     def test_grouped_calibration_keeps_bags_together_and_maxpools(self):
-        import torch.nn as nn
-
         from vtscore.training.thresholds import compute_fold_orderings
 
         rng = np.random.default_rng(0)

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -29,6 +29,7 @@ from vtscore.media.patch_embed import (
     eupe_features_to_patch_output,
     hf_vit_to_patch_output,
     propose_leaves,
+    snap_box_to_region,
     to_fp16,
 )
 from vtscore.training.region_similarity import (
@@ -1056,6 +1057,80 @@ class TestBoxToVoteVector:
         np.testing.assert_array_equal(tuple_v, list_v)
 
 
+class TestSnapBoxToRegion:
+    """``snap_box_to_region`` picks the region tree node whose box best matches
+    the user's drawn box (max IoU) and returns *that node's* vector - the exact
+    sub-image suggestion the MLP max-pools over at inference, rather than a
+    fresh pool that matches no node.
+    """
+
+    @staticmethod
+    def _region(box, axis, d=8):
+        """A RegionVector whose vec is the one-hot unit vector along *axis*."""
+        vec = np.zeros(d, dtype=np.float32)
+        vec[axis] = 1.0
+        return RegionVector(box=box, vec=vec)
+
+    def test_returns_exact_node_vector_not_a_fresh_pool(self):
+        regions = [
+            self._region((0.0, 0.0, 1.0, 1.0), axis=0),  # full-image / CLS
+            self._region((0.0, 0.0, 0.5, 0.5), axis=1),  # top-left
+            self._region((0.5, 0.5, 1.0, 1.0), axis=2),  # bottom-right
+        ]
+        # A box hugging the top-left region.
+        v = snap_box_to_region(regions, (0.02, 0.02, 0.48, 0.48))
+        np.testing.assert_array_equal(v, regions[1].vec)
+
+    def test_snaps_to_highest_iou_not_nearest_centroid(self):
+        # Two candidates share a centroid region but differ in extent; the
+        # tighter-overlapping box must win on IoU.
+        regions = [
+            self._region((0.0, 0.0, 1.0, 1.0), axis=0),  # full image
+            self._region((0.1, 0.1, 0.4, 0.4), axis=1),  # tight match
+        ]
+        v = snap_box_to_region(regions, (0.1, 0.1, 0.4, 0.4))
+        np.testing.assert_array_equal(v, regions[1].vec)
+
+    def test_whole_image_box_collapses_to_cls_node(self):
+        regions = [
+            self._region((0.0, 0.0, 1.0, 1.0), axis=0),  # full-image / CLS
+            self._region((0.0, 0.0, 0.3, 0.3), axis=1),
+        ]
+        v = snap_box_to_region(regions, (0.0, 0.0, 1.0, 1.0))
+        np.testing.assert_array_equal(v, regions[0].vec)
+
+    def test_returns_l2_normalised_float32(self):
+        # A float16-stored, slightly off-unit vector must come back unit-norm
+        # float32 (the pickle dtype can drift the norm on upcast).
+        vec = (np.array([3.0, 4.0], dtype=np.float32) / 5.0).astype(np.float16)
+        regions = [RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=vec)]
+        v = snap_box_to_region(regions, (0.1, 0.1, 0.9, 0.9))
+        assert v.dtype == np.float32
+        assert abs(float(np.linalg.norm(v)) - 1.0) < 1e-5
+
+    def test_degenerate_zero_area_box_falls_back_to_nearest_centroid(self):
+        regions = [
+            self._region((0.0, 0.0, 0.2, 0.2), axis=0),  # centroid (0.1, 0.1)
+            self._region((0.6, 0.6, 1.0, 1.0), axis=1),  # centroid (0.8, 0.8)
+        ]
+        # A zero-area "line" box near the second region's centroid: IoU is 0
+        # against everything, so centroid distance decides.
+        v = snap_box_to_region(regions, (0.75, 0.75, 0.75, 0.9))
+        np.testing.assert_array_equal(v, regions[1].vec)
+
+    def test_empty_regions_returns_none(self):
+        assert snap_box_to_region([], (0.0, 0.0, 1.0, 1.0)) is None
+
+    def test_swapped_corners_tolerated(self):
+        regions = [
+            self._region((0.0, 0.0, 1.0, 1.0), axis=0),
+            self._region((0.0, 0.0, 0.5, 0.5), axis=1),
+        ]
+        normal = snap_box_to_region(regions, (0.0, 0.0, 0.5, 0.5))
+        swapped = snap_box_to_region(regions, (0.5, 0.5, 0.0, 0.0))
+        np.testing.assert_array_equal(normal, swapped)
+
+
 # ---------------------------------------------------------------------------
 # v2: vote endpoint, label export, and region-aware training wiring
 # ---------------------------------------------------------------------------
@@ -1361,9 +1436,10 @@ class TestLabelImportRegionBox:
 
 
 class TestRegionAwareTraining:
-    """``train_and_score`` and ``populate_label_embeddings`` pool the
-    training vector on-the-fly from ``media["patch_grid"]`` when an element
-    carries a ``region_box``.  Patch-embedder v2 step 4.
+    """``train_and_score`` and ``populate_label_embeddings`` derive the
+    training vector on-the-fly when an element carries a ``region_box``:
+    snapping to the media's nearest ``patch_regions`` node when a region tree
+    is present, else pooling ``media["patch_grid"]``.  Patch-embedder v2 step 4.
     """
 
     def _media_with_patch_grid(self, grid_value: float, cid: int) -> dict:
@@ -1393,8 +1469,9 @@ class TestRegionAwareTraining:
         }
 
     def test_train_and_score_uses_box_pooled_vec_when_grid_present(self):
-        """A yes-vote with region_box on a media that has a patch_grid feeds
-        the MLP with the *pooled* vector, not the CLS embedding."""
+        """A yes-vote with region_box on a media that has a patch_grid but no
+        region tree falls back to the *pooled* grid vector, not the CLS
+        embedding."""
         from vtscore.media.patch_embed import box_to_vote_vector
         from vtscore.detectors.training import _training_vec_for_vote
 
@@ -1406,6 +1483,30 @@ class TestRegionAwareTraining:
         np.testing.assert_array_equal(vec, expected)
         # And the CLS vector is *not* what we got.
         assert not np.array_equal(vec, media_embedding(media))
+
+    def test_train_and_score_snaps_to_region_node_when_regions_present(self):
+        """When the media carries a ``patch_regions`` tree, a region vote trains
+        on the *snapped node's* vector (an inference-time candidate), not a
+        fresh grid pool that matches no node."""
+        from vtscore.media.patch_embed import box_to_vote_vector, snap_box_to_region
+        from vtscore.detectors.training import _training_vec_for_vote
+
+        media = self._media_with_patch_grid(0.99, cid=7)
+        # A distinct one-hot node vector so it can't coincide with any grid pool
+        # (whose non-zero support is the 16 grid axes 0..15).
+        node_vec = np.zeros(16, dtype=np.float32)
+        node_vec[15] = 1.0
+        media["patch_regions"] = [
+            RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=np.eye(16, dtype=np.float32)[0]),
+            RegionVector(box=(0.0, 0.0, 0.5, 0.5), vec=node_vec),
+        ]
+        box = (0.02, 0.02, 0.48, 0.48)  # hugs the second node's box
+
+        vec = _training_vec_for_vote(media, box)
+        np.testing.assert_array_equal(vec, snap_box_to_region(media["patch_regions"], box))
+        np.testing.assert_array_equal(vec, node_vec)
+        # It is *not* the grid pool the old path would have produced.
+        assert not np.array_equal(vec, box_to_vote_vector(media["patch_grid"], box))
 
     def test_train_and_score_falls_back_to_cls_without_patch_grid(self):
         """Legacy / single-vector datasets have no ``patch_grid``; even with

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -1105,6 +1105,7 @@ class TestSnapBoxToRegion:
         vec = (np.array([3.0, 4.0], dtype=np.float32) / 5.0).astype(np.float16)
         regions = [RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=vec)]
         v = snap_box_to_region(regions, (0.1, 0.1, 0.9, 0.9))
+        assert v is not None
         assert v.dtype == np.float32
         assert abs(float(np.linalg.norm(v)) - 1.0) < 1e-5
 

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -551,6 +551,7 @@ class TestGoodTrainingVec:
         media = _patch_media(1, positive=True, category="apple")
         vec = _good_training_vec(media, "apple", region_voting=True)
         expected = snap_box_to_region(media["patch_regions"], (0.0, 0.0, 2 / 3, 1.0))
+        assert expected is not None
         np.testing.assert_allclose(vec, expected)
         # The snapped vector is one of the tree's actual node vectors.
         assert any(np.allclose(vec, r.vec) for r in media["patch_regions"])

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -542,13 +542,18 @@ class TestGoodTrainingVec:
         vec = _good_training_vec(media, "apple", region_voting=False)
         np.testing.assert_allclose(vec, media_embedding(media))
 
-    def test_pools_box_when_region_voting_on(self):
-        from vtscore.media.patch_embed import box_to_vote_vector
+    def test_snaps_box_to_region_when_region_voting_on(self):
+        """With a ``patch_regions`` tree present, the simulated region vote
+        snaps the ground-truth box to its nearest region node (the same path
+        the live vote flow takes), not a fresh uniform grid pool."""
+        from vtscore.media.patch_embed import snap_box_to_region
 
         media = _patch_media(1, positive=True, category="apple")
         vec = _good_training_vec(media, "apple", region_voting=True)
-        expected = box_to_vote_vector(np.asarray(media["patch_grid"]), (0.0, 0.0, 2 / 3, 1.0))
+        expected = snap_box_to_region(media["patch_regions"], (0.0, 0.0, 2 / 3, 1.0))
         np.testing.assert_allclose(vec, expected)
+        # The snapped vector is one of the tree's actual node vectors.
+        assert any(np.allclose(vec, r.vec) for r in media["patch_regions"])
 
     def test_falls_back_without_patch_grid(self):
         from vtscore.embedding.media_vectors import media_embedding

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -64,28 +64,24 @@ def _detector_embedder(det_ctx, snap: dict[int, dict[str, Any]] | None) -> str:
     return keying_embedder_for_snap(det_ctx, snap)
 
 
-def _patch_pooled_from_file(
+def _region_tree_from_file(
     file_path: Path,
     *,
     media_type: str,
     embedder_name: str,
-    region_box: tuple[float, float, float, float],
-) -> np.ndarray | None:
-    """Run ``patch_forward`` on *file_path* and snap *region_box* to a node.
+):
+    """Rebuild a media's ``patch_regions`` tree from its file, or ``None``.
 
-    Mirrors the in-dataset region path (``pool_box_from_media`` →
-    :func:`snap_box_to_region`) for the cross-dataset case: resolve the origin
-    to a file, rebuild the region tree via :meth:`MediaEmbedder.patch_forward`
-    + :func:`build_region_tree` (same ``k``/``alpha`` defaults ingest uses),
-    and snap the user-drawn box to its nearest node - so a Good region-vote
-    trains on the exact sub-image suggestion the MLP will max-pool over on the
-    new dataset.  Returns ``None`` when the chosen embedder doesn't support
-    patch regions or the forward pass produces no output, so the caller can
-    fall back to an image-level embedding.
+    Resolves the embedder (the detector's, else the media type's default),
+    runs :meth:`MediaEmbedder.patch_forward`, and builds the region tree with
+    the same ``k``/``alpha`` defaults ingest uses.  Returns ``None`` when the
+    embedder doesn't support patch regions or the forward pass produces no
+    output.  Shared by the Good-vote snap path and the Bad-vote leaf-flood
+    path so both rebuild the identical tree cross-dataset.
     """
     from vtscore.media import embedders_for_type, get_embedder
     from vtscore.media.embedder import media_from_path
-    from vtscore.media.patch_embed import build_region_tree, snap_box_to_region
+    from vtscore.media.patch_embed import build_region_tree
 
     embedder = None
     if embedder_name:
@@ -113,7 +109,45 @@ def _patch_pooled_from_file(
         return None
     if output is None:
         return None
-    return snap_box_to_region(build_region_tree(output), region_box)
+    return build_region_tree(output)
+
+
+def _leaves_from_regions(regions) -> list[np.ndarray] | None:
+    """CLS + HAC-leaf vectors (``children is None``) from a ``patch_regions`` list.
+
+    The disjoint set a Bad vote floods as negatives - the full-image node plus
+    the leaves, dropping the redundant saliency-weighted internal pools.
+    Returns ``None`` for an empty/leafless list.
+    """
+    if not regions:
+        return None
+    leaves = [np.asarray(r.vec, dtype=np.float32) for r in regions if getattr(r, "children", None) is None]
+    return leaves or None
+
+
+def _patch_pooled_from_file(
+    file_path: Path,
+    *,
+    media_type: str,
+    embedder_name: str,
+    region_box: tuple[float, float, float, float],
+) -> np.ndarray | None:
+    """Run ``patch_forward`` on *file_path* and snap *region_box* to a node.
+
+    Mirrors the in-dataset region path (``pool_box_from_media`` →
+    :func:`snap_box_to_region`) for the cross-dataset case: rebuild the region
+    tree via :func:`_region_tree_from_file` and snap the user-drawn box to its
+    nearest node - so a Good region-vote trains on the exact sub-image
+    suggestion the MLP will max-pool over on the new dataset.  Returns ``None``
+    when the tree can't be built, so the caller can fall back to an image-level
+    embedding.
+    """
+    from vtscore.media.patch_embed import snap_box_to_region
+
+    regions = _region_tree_from_file(file_path, media_type=media_type, embedder_name=embedder_name)
+    if regions is None:
+        return None
+    return snap_box_to_region(regions, region_box)
 
 
 def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> np.ndarray | None:
@@ -186,6 +220,8 @@ def _maybe_clear_cache_on_embedder_switch(det_ctx, embedder_name: str) -> None:
     if det_ctx.embedder and embedder_name and det_ctx.embedder != embedder_name:
         det_ctx.label_embeddings.clear()
         det_ctx.label_embedding_regions.clear()
+        # Flooded leaf negatives live in the old embedder's space too.
+        det_ctx.label_negative_regions.clear()
         # Local features are descriptor sets in the old embedder's feature space;
         # a switch invalidates them too (a SIFT template can't verify against a
         # learned-feature candidate, nor vice versa).
@@ -233,6 +269,42 @@ def _resolve_uncached_embedding(
     return np.asarray(emb) if emb is not None else None
 
 
+def _resolve_negative_leaves(
+    elem: LabeledElement,
+    snap: dict[int, dict[str, Any]] | None,
+    *,
+    media_type: str,
+    embedder_name: str,
+) -> list[np.ndarray] | None:
+    """Leaf negatives (CLS + HAC leaves) for a Bad *elem* on a patch dataset.
+
+    In-dataset: read the resolved media's ``patch_regions`` leaves (no I/O).
+    Cross-dataset: rebuild the region tree from the origin file via
+    :func:`_region_tree_from_file` and take its leaves.  Returns ``None`` for
+    non-patch datasets/elements (and clipper-bearing origins, whose patch grid
+    we can't reconstruct) so the caller falls back to a single image-level
+    negative - i.e. no flooding, the pre-change behaviour.
+    """
+    from vtscore.detectors.labelset_elements import resolve_current_dataset_cid
+    from vtscore.detectors.resolver import resolve_file_context
+
+    if snap:
+        cid = resolve_current_dataset_cid(elem)
+        if cid is not None and cid in snap:
+            return _leaves_from_regions(snap[cid].get("patch_regions"))
+
+    origin = elem.origin or {}
+    params = origin.get("params", {}) if isinstance(origin, dict) else {}
+    if isinstance(params, dict) and params.get("clipper"):
+        return None
+
+    with resolve_file_context(elem.origin, elem.origin_name, elem.filename) as file_path:
+        if file_path is None:
+            return None
+        regions = _region_tree_from_file(file_path, media_type=media_type, embedder_name=embedder_name)
+    return _leaves_from_regions(regions)
+
+
 def populate_label_embeddings(
     det_ctx,
     labelset: LabelSet,
@@ -265,8 +337,20 @@ def populate_label_embeddings(
     total = len(labelset.elements)
     cached = 0
 
+    neg_cache: dict[str, list[np.ndarray]] = det_ctx.label_negative_regions
+
     for idx, elem in enumerate(labelset.elements):
         eid = stable_element_id(elem)
+        # Bad elements on a patch dataset flood their CLS + leaf negatives (the
+        # cross-dataset counterpart of ``bad_negative_vecs``); cache the leaf
+        # set once so re-sorts don't re-resolve.  A no-op on non-patch datasets
+        # (``_resolve_negative_leaves`` returns None), leaving the Bad element
+        # to contribute its single image-level vector below.
+        if elem.label == "bad" and eid not in neg_cache:
+            leaves = _resolve_negative_leaves(elem, snap, media_type=media_type, embedder_name=embedder_name)
+            if leaves is not None:
+                neg_cache[eid] = leaves
+
         # Cache hit only when the cached vector was built against the same
         # ``region_box`` the element currently carries.  Region-voted
         # elements (``region_box is not None``) always fall through so the
@@ -303,23 +387,44 @@ def populate_label_embeddings(
 def build_xy_from_labelset(
     det_ctx,
     labelset: LabelSet,
-) -> tuple[list[np.ndarray], list[float]]:
-    """Build ``(X_list, y_list)`` from the cached embeddings on *det_ctx*."""
+) -> tuple[list[np.ndarray], list[float], list]:
+    """Build ``(X_list, y_list, groups)`` from the cached embeddings on *det_ctx*.
+
+    A Good element contributes its single cached vector.  A Bad element on a
+    patch dataset contributes its flooded CLS + leaf negatives (cached in
+    ``label_negative_regions`` by :func:`populate_label_embeddings`); on a
+    legacy dataset it contributes its single image-level vector, as before.
+    ``groups`` carries one bag id per row - ``("g"/"b", element_id)`` - so the
+    trainer/calibrator balance and split by element (image), not by row.  When
+    nothing floods, every bag holds one row and the downstream path is
+    byte-for-byte the pre-flood behaviour.
+    """
     from vtscore.detectors.labelset_elements import stable_element_id
 
     cache: dict[str, np.ndarray] = det_ctx.label_embeddings
+    neg_cache: dict[str, list[np.ndarray]] = det_ctx.label_negative_regions
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
+    groups: list = []
     for elem in labelset.elements:
         if elem.label not in ("good", "bad"):
             continue
         eid = stable_element_id(elem)
+        if elem.label == "bad":
+            leaves = neg_cache.get(eid)
+            if leaves:
+                for vec in leaves:
+                    X_list.append(vec)
+                    y_list.append(0.0)
+                    groups.append(("b", eid))
+                continue
         emb = cache.get(eid)
         if emb is None:
             continue
         X_list.append(emb)
         y_list.append(1.0 if elem.label == "good" else 0.0)
-    return X_list, y_list
+        groups.append(("g" if elem.label == "good" else "b", eid))
+    return X_list, y_list, groups
 
 
 # ---------------------------------------------------------------------------
@@ -514,7 +619,7 @@ def train_from_labelset(
         snap=snap,
         on_progress=on_progress,
     )
-    X_list, y_list = build_xy_from_labelset(det_ctx, labelset)
+    X_list, y_list, groups = build_xy_from_labelset(det_ctx, labelset)
     if len(X_list) < 2:
         return False
     if not any(y == 1.0 for y in y_list) or not any(y == 0.0 for y in y_list):
@@ -527,7 +632,7 @@ def train_from_labelset(
     # Pass det_ctx so the fold orderings are cached for a no-retrain Inclusion
     # slide (otherwise the slide can't move the cutoff — see train_and_threshold).
     mlp, threshold = train_and_threshold(
-        X_list, y_list, snap=snap, embedder_name=det_ctx.embedder or None, det_ctx=det_ctx
+        X_list, y_list, snap=snap, embedder_name=det_ctx.embedder or None, det_ctx=det_ctx, groups=groups
     )
     det_ctx.model = mlp
     det_ctx.threshold = threshold
@@ -559,7 +664,7 @@ def labelset_train_and_score(
     from vtscore.detectors.training import _train_and_score_xy
 
     populate_label_embeddings(det_ctx, labelset, media_type=media_type, snap=clips_dict)
-    X_list, y_list = build_xy_from_labelset(det_ctx, labelset)
+    X_list, y_list, groups = build_xy_from_labelset(det_ctx, labelset)
     results, threshold, model = _train_and_score_xy(
         X_list,
         y_list,
@@ -569,6 +674,7 @@ def labelset_train_and_score(
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
         det_ctx=det_ctx,
+        groups=groups,
     )
 
     # Stage-2 structural re-rank for a saved structural detector reloaded

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -71,19 +71,21 @@ def _patch_pooled_from_file(
     embedder_name: str,
     region_box: tuple[float, float, float, float],
 ) -> np.ndarray | None:
-    """Run ``patch_forward`` on *file_path* and pool *region_box* into one vector.
+    """Run ``patch_forward`` on *file_path* and snap *region_box* to a node.
 
-    Mirrors the in-dataset region path (``_pool_box_from_media`` →
-    :func:`box_to_vote_vector`) for the cross-dataset case: resolve the
-    origin to a file, rebuild a patch grid via
-    :meth:`MediaEmbedder.patch_forward`, and pool the user-drawn box.
-    Returns ``None`` when the chosen embedder doesn't support patch
-    regions or the forward pass produces no output, so the caller can
+    Mirrors the in-dataset region path (``pool_box_from_media`` →
+    :func:`snap_box_to_region`) for the cross-dataset case: resolve the origin
+    to a file, rebuild the region tree via :meth:`MediaEmbedder.patch_forward`
+    + :func:`build_region_tree` (same ``k``/``alpha`` defaults ingest uses),
+    and snap the user-drawn box to its nearest node - so a Good region-vote
+    trains on the exact sub-image suggestion the MLP will max-pool over on the
+    new dataset.  Returns ``None`` when the chosen embedder doesn't support
+    patch regions or the forward pass produces no output, so the caller can
     fall back to an image-level embedding.
     """
     from vtscore.media import embedders_for_type, get_embedder
     from vtscore.media.embedder import media_from_path
-    from vtscore.media.patch_embed import box_to_vote_vector
+    from vtscore.media.patch_embed import build_region_tree, snap_box_to_region
 
     embedder = None
     if embedder_name:
@@ -111,7 +113,7 @@ def _patch_pooled_from_file(
         return None
     if output is None:
         return None
-    return box_to_vote_vector(np.asarray(output.patch_grid), region_box)
+    return snap_box_to_region(build_region_tree(output), region_box)
 
 
 def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> np.ndarray | None:
@@ -119,8 +121,9 @@ def _embed_one(elem: LabeledElement, *, media_type: str, embedder_name: str) -> 
 
     When *elem* carries a ``region_box`` and the active embedder supports
     patch regions, the resolved file is patch-forwarded and the box is
-    pooled via :func:`box_to_vote_vector` so the user's region-level
-    training intent survives a dataset switch.  Logs a warning and falls
+    snapped to its nearest region node via :func:`snap_box_to_region` so the
+    user's region-level training intent survives a dataset switch.  Logs a
+    warning and falls
     back to a full-file embedding when the patch path is unavailable -
     legacy single-vector embedders, an origin carrying a clipper we'd
     have to replay against an unknown patch grid, or a failed forward
@@ -199,11 +202,10 @@ def _resolve_uncached_embedding(
     """Produce a training vector for *elem*, not consulting the cache.
 
     Tries the in-dataset path first: when *elem* resolves to a cid in the
-    active *snap*, reuse the stored embedding (region-pooling from
-    ``patch_grid`` when the element has a ``region_box`` and a patch grid
-    is available).  Falls back to the cross-dataset path - resolve via the
-    importer and embed freshly.  Returns ``None`` when neither path
-    produces a vector.
+    active *snap*, reuse the stored embedding (snapping the ``region_box`` to
+    the media's nearest ``patch_regions`` node when the element carries one).
+    Falls back to the cross-dataset path - resolve via the importer and embed
+    freshly.  Returns ``None`` when neither path produces a vector.
     """
     from vtscore.detectors.labelset_elements import resolve_current_dataset_cid
     from vtscore.detectors.training import pool_box_from_media
@@ -220,9 +222,9 @@ def _resolve_uncached_embedding(
             if emb is not None:
                 return np.asarray(emb)
 
-    # Cross-dataset path: ``_embed_one`` rebuilds a patch grid on the
+    # Cross-dataset path: ``_embed_one`` rebuilds the region tree on the
     # resolved file when ``elem.region_box`` is set and the embedder
-    # supports patch regions, then pools via ``box_to_vote_vector`` so
+    # supports patch regions, then snaps via ``snap_box_to_region`` so
     # region votes survive a dataset switch.  When the patch path isn't
     # available (legacy single-vector embedder, clipper-bearing origin,
     # failed forward pass) it logs a warning and returns the image-level

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -283,41 +283,79 @@ def _training_vec_for_vote(
     return pooled if pooled is not None else media_embedding(media, embedder_name)
 
 
+def bad_negative_vecs(
+    media: dict[str, Any],
+    embedder_name: str | None = None,
+) -> list[np.ndarray]:
+    """Negative training vectors contributed by one Bad vote on *media*.
+
+    On **patch** media (carrying a ``patch_regions`` tree) a Bad vote floods
+    every region node with no children - the CLS full-image node plus the HAC
+    leaves, the disjoint set that tiles the image - as negatives.  This is the
+    multiple-instance-learning treatment of a rejected image: since inference
+    scores an image by its **best** region (max-pool), a Bad vote asserts that
+    *no* region of it should score high, so we train every leaf down.  Internal
+    HAC nodes (``children`` set) are saliency-weighted pools of those leaves and
+    are dropped as redundant (they inflate the negative count with correlated
+    duplicates without adding coverage).
+
+    Non-patch media contribute a single image-level vector, exactly as before,
+    so every legacy single-vector dataset is byte-for-byte unchanged.
+    """
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
+    regions = media.get("patch_regions")
+    if regions:
+        leaves = [np.asarray(r.vec, dtype=np.float32) for r in regions if r.children is None]
+        if leaves:
+            return leaves
+    return [media_embedding(media, embedder_name)]
+
+
 def _build_vote_xy(
     clips_dict: dict[int, dict[str, Any]],
     good_votes: dict[int, None],
     bad_votes: dict[int, None],
     region_boxes: dict[int, tuple[float, float, float, float]],
     embedder_name: str | None = None,
-) -> tuple[list[np.ndarray], list[float]]:
-    """Build ``(X_list, y_list)`` from filtered votes.
+) -> tuple[list[np.ndarray], list[float], list]:
+    """Build ``(X_list, y_list, groups)`` from filtered votes.
 
     Good votes that designated a region are region-pooled via
-    :func:`_training_vec_for_vote`; bad votes always use the image-level
-    embedding.  Returns the raw lists - the caller
-    (:func:`_train_and_score_xy`) enforces the ≥2-samples / ≥1-good /
-    ≥1-bad guard.
+    :func:`_training_vec_for_vote` (one row each).  Bad votes are expanded by
+    :func:`bad_negative_vecs`: one row per image-level vector on a legacy
+    dataset, or one row per region leaf on a patch dataset (region flooding).
+
+    ``groups`` carries one bag id per row - ``("g", cid)`` for a Good vote,
+    ``("b", cid)`` shared across all of a Bad vote's flooded leaf rows - so the
+    downstream trainer/calibrator can balance and split by **image**, not by
+    row.  On a legacy dataset every bag holds exactly one row, so ``groups`` is
+    1:1 with the rows and the whole path collapses to the pre-flood behaviour.
+    The caller (:func:`_train_and_score_xy`) enforces the ≥2-samples /
+    ≥1-good / ≥1-bad guard.
 
     *embedder_name* is the detector's primary embedder; when ``None`` the
     dataset score precedence for *clips_dict* is used (the pre-per-detector
     behaviour).  Either way the MLP trains in the same space
     :func:`_score_all_media` scores against.
     """
-    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
-
     if embedder_name is None:
         embedder_name = _score_embedder_for_snap(clips_dict)
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
+    groups: list = []
     for cid in good_votes:
         if cid in clips_dict:
             X_list.append(_training_vec_for_vote(clips_dict[cid], region_boxes.get(cid), embedder_name))
             y_list.append(1.0)
+            groups.append(("g", cid))
     for cid in bad_votes:
         if cid in clips_dict:
-            X_list.append(media_embedding(clips_dict[cid], embedder_name))
-            y_list.append(0.0)
-    return X_list, y_list
+            for vec in bad_negative_vecs(clips_dict[cid], embedder_name):
+                X_list.append(vec)
+                y_list.append(0.0)
+                groups.append(("b", cid))
+    return X_list, y_list, groups
 
 
 def _score_all_media(
@@ -484,6 +522,7 @@ def _train_and_score_xy(
     calibrate_count: int,
     calibration_fraction: float,
     det_ctx: Any,
+    groups: list | None = None,
 ) -> tuple[list[dict[str, Any]], float, nn.Sequential | None]:
     """Train an MLP on ``(X_list, y_list)`` and score every media in *clips_dict*.
 
@@ -493,15 +532,22 @@ def _train_and_score_xy(
     ``(X_list, y_list)``, so the guard → threshold → train → score → format
     tail lives here once.
 
-    ``hidden_dim`` is sized from the label count so the cross-calibration
-    fold models share the final model's architecture, making fold thresholds
-    directly comparable to final-model scores.  Returns ``([], 0.5, None)``
-    when the labels don't satisfy ≥2 samples AND ≥1 good AND ≥1 bad.
+    ``hidden_dim`` and the safe-threshold label count are sized from the
+    **vote** count (distinct *groups*) rather than the row count, so region
+    flooding - which turns one Bad vote into many leaf rows - doesn't inflate
+    the model width or shift the small-count threshold ramp.  When *groups*
+    reveals at least one multi-row bag (flooding actually happened), the
+    calibration split, fold fits, and final fit all run **bag-aware**
+    (grouped fold split, per-bag loss weights); otherwise every row is its own
+    bag and the path is byte-for-byte the pre-flood behaviour.  Returns
+    ``([], 0.5, None)`` when the labels don't satisfy ≥2 samples AND ≥1 good
+    AND ≥1 bad.
     """
     import torch  # noqa: PLC0415
 
     from vtscore.training.mlp import _auto_hidden_dim, train_model  # noqa: PLC0415
     from vtscore.training.thresholds import (  # noqa: PLC0415
+        _per_bag_fit_weights,
         calculate_safe_threshold,
         cross_calibration_threshold_cached,
     )
@@ -519,7 +565,19 @@ def _train_and_score_xy(
     X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
-    hidden_dim = _auto_hidden_dim(len(X_list))
+
+    # Flooding is "on" only when a bag holds more than one row; otherwise pass
+    # groups=None so the calibrator/trainer take their historical row-wise path
+    # unchanged.  n_votes counts bags (images), the unit for width + ramp.
+    n_votes = len(set(groups)) if groups is not None else len(X_list)
+    flooded = groups is not None and len(X_list) != n_votes
+    cal_groups = groups if flooded else None
+    sample_weights = (
+        torch.tensor(_per_bag_fit_weights(np.asarray(y_list, dtype=np.float32), groups), dtype=torch.float32)
+        if flooded
+        else None
+    )
+    hidden_dim = _auto_hidden_dim(n_votes)
 
     # Skip k-fold calibration *only* when safe-thresholds is on and the label
     # count is below the ``calculate_safe_threshold`` ramp floor: there the
@@ -530,7 +588,7 @@ def _train_and_score_xy(
     # keeps the vote/labelset path agreeing with the Find path
     # (:func:`train_and_threshold`), which has always cross-calibrated below 6
     # labels when safe-thresholds is off.
-    if safe_thresholds and len(X_list) < 6:
+    if safe_thresholds and n_votes < 6:
         threshold = 0.5
         # Drop any fold-ordering cache from a previous ≥6-label training:
         # this branch neither reads nor rewrites it, and a later inclusion
@@ -549,19 +607,23 @@ def _train_and_score_xy(
             calibration_fraction=calibration_fraction,
             hidden_dim=hidden_dim,
             det_ctx=det_ctx,
+            groups=cal_groups,
         )
 
-    # Training is image-level in v1 - the MLP only ever sees one vector
-    # per labelled media, mirroring the "vote on whole images" rule.
-    model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
+    # A Good vote trains on one region (the snapped box); a Bad vote trains on
+    # its whole leaf set (region flooding), per-bag weighted so a rejected
+    # image counts once.  On a legacy dataset ``sample_weights`` is None and
+    # this is the historical one-vector-per-media fit.
+    model = train_model(X, y, input_dim, hidden_dim=hidden_dim, sample_weights=sample_weights)
 
     all_ids, scores, best_region = _score_all_media(model, clips_dict, score_emb)
 
     if safe_thresholds:
         # Blend applies on this fresh retrain only; the cached fold orderings
         # are raw cross-cal, so an inclusion slide re-derives the unblended
-        # cutoff (see recompute_detector_thresholds_for_inclusion).
-        threshold = calculate_safe_threshold(threshold, scores, len(X_list))
+        # cutoff (see recompute_detector_thresholds_for_inclusion).  The label
+        # count is votes, not flooded rows, so the small-count ramp is unmoved.
+        threshold = calculate_safe_threshold(threshold, scores, n_votes)
 
     results = _format_results(all_ids, scores, best_region, clips_dict)
     return results, threshold, model
@@ -620,7 +682,7 @@ def train_and_score(
           training was not possible).
     """
     region_boxes = vote_region_boxes or {}
-    X_list, y_list = _build_vote_xy(
+    X_list, y_list, groups = _build_vote_xy(
         clips_dict, good_votes, bad_votes, region_boxes, detector_score_embedder(det_ctx, clips_dict)
     )
     results, threshold, model = _train_and_score_xy(
@@ -632,6 +694,7 @@ def train_and_score(
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
         det_ctx=det_ctx,
+        groups=groups,
     )
 
     # Stage-2 structural re-rank: a no-op for every non-structural dataset

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -230,15 +230,17 @@ def pool_box_from_media(
     media: dict[str, Any],
     region_box: tuple[float, float, float, float] | None,
 ) -> np.ndarray | None:
-    """Return the region-pooled training vector for *media*, or ``None``.
+    """Return the region training vector for *media*, or ``None``.
 
-    When *region_box* is set **and** *media* has a stored ``patch_grid``,
-    pool the box on-the-fly via
-    :func:`vtscore.media.patch_embed.box_to_vote_vector` and return it.
-    Otherwise return ``None`` so the caller can fall back to the media's
-    image-level ``embedding`` - the legacy training vector for image-level
-    votes, single-vector embedders, and patch datasets that haven't been
-    re-loaded under the v1 storage scheme.  Patch-embedder v2.
+    When *region_box* is set, snap it to the media's nearest ``patch_regions``
+    node via :func:`vtscore.media.patch_embed.snap_box_to_region` and return
+    that node's vector - i.e. train on the exact sub-image suggestion the MLP
+    max-pools over at inference, so the Good vote is a fair representative of
+    what the detector will actually score.  Falls back to a uniform pool of
+    the raw ``patch_grid`` (:func:`box_to_vote_vector`) only when the media
+    carries a grid but no region tree, and to ``None`` (the caller then uses
+    the image-level ``embedding``) for legacy single-vector embedders and
+    patch datasets that predate region storage.  Patch-embedder v2.
 
     Shared by the in-dataset vote path (:func:`_training_vec_for_vote`) and
     the cross-dataset labelset path
@@ -246,6 +248,15 @@ def pool_box_from_media(
     """
     if region_box is None:
         return None
+
+    regions = media.get("patch_regions")
+    if regions:
+        from vtscore.media.patch_embed import snap_box_to_region  # noqa: PLC0415
+
+        snapped = snap_box_to_region(regions, region_box)
+        if snapped is not None:
+            return snapped
+
     grid = media.get("patch_grid")
     if grid is None:
         return None

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -706,13 +706,13 @@ def train_and_score(
             20% Calibrate.
         vote_region_boxes: Optional ``media_id -> (x0, y0, x1, y1)`` map from
             yes-votes that designated a region.  When set and the source
-            media has a stored ``patch_grid``, the training vector for that
-            vote is pooled on-the-fly via
-            :func:`vtscore.media.patch_embed.box_to_vote_vector` instead
-            of using ``media["embeddings"]``.  Falls back to the full-image
-            vector when the media lacks a patch grid (legacy datasets,
-            single-vector embedders) or when the box is missing.  Patch-
-            embedder v2.
+            media carries a ``patch_regions`` tree, the box is snapped to its
+            nearest region node (:func:`vtscore.media.patch_embed.snap_box_to_region`)
+            and that node's vector trains the vote, instead of
+            ``media["embeddings"]``.  Falls back to a uniform patch-grid pool,
+            then to the full-image vector, when the media lacks a region tree /
+            patch grid (legacy datasets, single-vector embedders) or the box is
+            missing.  Patch-embedder v2.
 
     Returns:
         A tuple ``(results, threshold, model)`` where:

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -612,9 +612,12 @@ def _train_and_score_xy(
 
     # A Good vote trains on one region (the snapped box); a Bad vote trains on
     # its whole leaf set (region flooding), per-bag weighted so a rejected
-    # image counts once.  On a legacy dataset ``sample_weights`` is None and
-    # this is the historical one-vector-per-media fit.
-    model = train_model(X, y, input_dim, hidden_dim=hidden_dim, sample_weights=sample_weights)
+    # image counts once.  On a legacy dataset there are no per-bag weights, so
+    # the call stays identical to the historical one-vector-per-media fit.
+    if sample_weights is not None:
+        model = train_model(X, y, input_dim, hidden_dim=hidden_dim, sample_weights=sample_weights)
+    else:
+        model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
 
     all_ids, scores, best_region = _score_all_media(model, clips_dict, score_emb)
 

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -89,12 +89,50 @@ def validate_good_bad_split(y_list: list[float]) -> tuple[int, int]:
     return num_good, num_bad
 
 
+def _flood_context(
+    X_list: list,
+    y_list: list[float],
+    groups: list | None,
+) -> tuple[int, list | None, Any]:
+    """Resolve the bag-aware training context for a possibly-flooded label set.
+
+    Returns ``(n_votes, cal_groups, sample_weights)``:
+
+    * ``n_votes`` - the number of distinct bags (votes/images); the unit the
+      hidden-layer width and the safe-threshold ramp should size on, so region
+      flooding (many rows per Bad vote) doesn't inflate either.
+    * ``cal_groups`` - *groups* when flooding actually occurred (a bag holds
+      more than one row), else ``None`` so the calibrator takes its historical
+      row-wise path unchanged.
+    * ``sample_weights`` - per-bag loss weights when flooding occurred, else
+      ``None`` so :func:`~vtscore.training.mlp.train_model` computes its default
+      inverse-frequency weights.
+
+    Shared by :func:`train_and_threshold` and :func:`_train_and_score_xy` so the
+    vote, labelset, and Find paths flood identically.
+    """
+    import torch  # noqa: PLC0415
+
+    from vtscore.training.thresholds import _per_bag_fit_weights  # noqa: PLC0415
+
+    n_votes = len(set(groups)) if groups is not None else len(X_list)
+    flooded = groups is not None and len(X_list) != n_votes
+    cal_groups = groups if flooded else None
+    sample_weights = None
+    if flooded and groups is not None:
+        sample_weights = torch.tensor(
+            _per_bag_fit_weights(np.asarray(y_list, dtype=np.float32), groups), dtype=torch.float32
+        )
+    return n_votes, cal_groups, sample_weights
+
+
 def train_and_threshold(
     X_list: list,
     y_list: list[float],
     snap: dict | None = None,
     embedder_name: str | None = None,
     det_ctx: Any = None,
+    groups: list | None = None,
 ) -> tuple[Any, float]:
     """Train an MLP and compute a calibrated threshold.
 
@@ -150,17 +188,23 @@ def train_and_threshold(
     X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
-    # Size the hidden layer from the full label count (the same width
-    # train_model() picks by default), so when we cache the fold orderings
+
+    # Bag-aware setup (region flooding): size on votes not rows, split/weight
+    # per bag.  On a legacy label set every bag is one row, so this collapses
+    # to the historical behaviour.
+    n_votes, cal_groups, sample_weights = _flood_context(X_list, y_list, groups)
+
+    # Size the hidden layer from the vote count (the same width train_model()
+    # picks by default when unflooded), so when we cache the fold orderings
     # below their models match the final model — keeping the cached
     # re-thresholding consistent with this run's threshold.
-    hidden_dim = _auto_hidden_dim(len(X_list))
+    hidden_dim = _auto_hidden_dim(n_votes)
 
     safe = bool(get_safe_thresholds() and snap)
     # Below the safe-threshold ramp floor the cross-cal output is blended
     # away (pure GMM), so don't pay for the fold trainings.  Safe-thresholds
     # OFF falls through to real cross-calibration at every label count.
-    if safe and len(X_list) < 6:
+    if safe and n_votes < 6:
         threshold = NO_GOOD_THRESHOLD
         # This branch never recomputes the fold orderings, so drop any stale
         # cache from a previous ≥6-label training - otherwise a later
@@ -182,6 +226,7 @@ def train_and_threshold(
             calibration_fraction=get_calibration_fraction(),
             hidden_dim=hidden_dim,
             det_ctx=det_ctx,
+            groups=cal_groups,
         )
     else:
         threshold = calculate_cross_calibration_threshold(
@@ -191,9 +236,13 @@ def train_and_threshold(
             get_inclusion(),
             calibrate_count=get_calibrate_count(),
             calibration_fraction=get_calibration_fraction(),
+            groups=cal_groups,
         )
 
-    model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
+    if sample_weights is not None:
+        model = train_model(X, y, input_dim, hidden_dim=hidden_dim, sample_weights=sample_weights)
+    else:
+        model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
 
     if safe:
         from vtscore.embedding.matrix import get_embedding_matrix_for_snap
@@ -211,7 +260,7 @@ def train_and_threshold(
         # cache above stores the raw cross-cal orderings, so a later inclusion
         # slide re-derives the unblended cutoff (intentional - see
         # recompute_detector_thresholds_for_inclusion).
-        threshold = calculate_safe_threshold(threshold, all_scores, len(y_list))
+        threshold = calculate_safe_threshold(threshold, all_scores, n_votes)
 
     return model, threshold
 
@@ -547,7 +596,6 @@ def _train_and_score_xy(
 
     from vtscore.training.mlp import _auto_hidden_dim, train_model  # noqa: PLC0415
     from vtscore.training.thresholds import (  # noqa: PLC0415
-        _per_bag_fit_weights,
         calculate_safe_threshold,
         cross_calibration_threshold_cached,
     )
@@ -566,17 +614,9 @@ def _train_and_score_xy(
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
 
-    # Flooding is "on" only when a bag holds more than one row; otherwise pass
-    # groups=None so the calibrator/trainer take their historical row-wise path
-    # unchanged.  n_votes counts bags (images), the unit for width + ramp.
-    n_votes = len(set(groups)) if groups is not None else len(X_list)
-    flooded = groups is not None and len(X_list) != n_votes
-    cal_groups = groups if flooded else None
-    sample_weights: torch.Tensor | None = None
-    if flooded and groups is not None:
-        sample_weights = torch.tensor(
-            _per_bag_fit_weights(np.asarray(y_list, dtype=np.float32), groups), dtype=torch.float32
-        )
+    # Bag-aware setup (region flooding): size on votes not rows, split/weight
+    # per bag when a Bad vote flooded its leaf set; a no-op on legacy datasets.
+    n_votes, cal_groups, sample_weights = _flood_context(X_list, y_list, groups)
     hidden_dim = _auto_hidden_dim(n_votes)
 
     # Skip k-fold calibration *only* when safe-thresholds is on and the label

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -572,11 +572,11 @@ def _train_and_score_xy(
     n_votes = len(set(groups)) if groups is not None else len(X_list)
     flooded = groups is not None and len(X_list) != n_votes
     cal_groups = groups if flooded else None
-    sample_weights = (
-        torch.tensor(_per_bag_fit_weights(np.asarray(y_list, dtype=np.float32), groups), dtype=torch.float32)
-        if flooded
-        else None
-    )
+    sample_weights: torch.Tensor | None = None
+    if flooded and groups is not None:
+        sample_weights = torch.tensor(
+            _per_bag_fit_weights(np.asarray(y_list, dtype=np.float32), groups), dtype=torch.float32
+        )
     hidden_dim = _auto_hidden_dim(n_votes)
 
     # Skip k-fold calibration *only* when safe-thresholds is on and the label

--- a/vtscore/media/patch_embed.py
+++ b/vtscore/media/patch_embed.py
@@ -519,6 +519,12 @@ def box_to_vote_vector(
     specific HAC node's vector without replicating its exact merge chain.
     See ``docs/plans/patch-embedder.md`` ("v2 → Backend semantics §1").
 
+    Because of that mismatch, the live Good region-vote path no longer pools
+    here: it snaps the drawn box to an actual region node via
+    :func:`snap_box_to_region`, so training sees the exact vector inference
+    max-pools over.  This function remains the fallback for media that carry a
+    raw ``patch_grid`` but no region tree.
+
     Parameters
     ----------
     patch_grid : ndarray, shape (H, W, D)
@@ -572,6 +578,82 @@ def box_to_vote_vector(
     vecs = patch_grid[mask].astype(np.float32, copy=False)
     pooled = vecs.mean(axis=0)
     return _l2_normalize(pooled)
+
+
+def snap_box_to_region(
+    regions: list[RegionVector],
+    box: tuple[float, float, float, float],
+) -> Optional[np.ndarray]:
+    """Snap a user-drawn *box* to the region tree node it best matches.
+
+    Returns the L2-normalised (float32) vector of the ``patch_regions`` node
+    with the highest box IoU against *box* - i.e. the **exact sub-image
+    suggestion the MLP max-pools over at inference time**.  A Good region-vote
+    trained through this function contributes one of the very candidates the
+    detector will later score, rather than a fresh uniform pool
+    (:func:`box_to_vote_vector`) that lands *between* the HAC nodes and matches
+    none of them (the internals are saliency-weighted means renormalised at
+    every merge; see that function's note).
+
+    Matching is by box intersection-over-union - the same rectangular
+    footprint the gallery outlines and the user drew against.  When every IoU
+    is zero (a degenerate zero-area drawn box), fall back to the region whose
+    centroid is nearest the drawn box's centre.  The CLS full-image node (box
+    ``(0, 0, 1, 1)``) is always present and overlaps any in-bounds box, so a
+    tightly-drawn box snaps to the matching leaf/internal while a whole-image
+    box collapses to the CLS vector (an image-level Good vote).
+
+    Parameters
+    ----------
+    regions : list[RegionVector]
+        A media's ``patch_regions`` (CLS node + HAC leaves + HAC internals),
+        or a freshly built :func:`build_region_tree` for the cross-dataset
+        resolve path.  Vectors may be float16 (pickle dtype) or float32.
+    box : (x0, y0, x1, y1)
+        Normalised image coordinates in ``[0, 1]``; swapped corners tolerated.
+
+    Returns
+    -------
+    ndarray, shape (D,), float32, L2-normalised - or ``None`` when *regions*
+    is empty, so the caller can fall back to raw-grid pooling.
+    """
+    if not regions:
+        return None
+
+    x0, y0, x1, y1 = (float(v) for v in box)
+    dx0, dx1 = min(x0, x1), max(x0, x1)
+    dy0, dy1 = min(y0, y1), max(y0, y1)
+    d_area = max(0.0, dx1 - dx0) * max(0.0, dy1 - dy0)
+
+    best_idx = 0
+    best_iou = -1.0
+    for idx, r in enumerate(regions):
+        rx0, ry0, rx1, ry1 = r.box
+        inter_w = max(0.0, min(dx1, rx1) - max(dx0, rx0))
+        inter_h = max(0.0, min(dy1, ry1) - max(dy0, ry0))
+        inter = inter_w * inter_h
+        r_area = max(0.0, rx1 - rx0) * max(0.0, ry1 - ry0)
+        union = d_area + r_area - inter
+        iou = inter / union if union > 0.0 else 0.0
+        if iou > best_iou:
+            best_iou = iou
+            best_idx = idx
+
+    if best_iou <= 0.0:
+        # Degenerate drawn box (zero area - a line or point): IoU is 0 against
+        # everything, so fall back to the nearest region centroid.
+        dcx, dcy = 0.5 * (dx0 + dx1), 0.5 * (dy0 + dy1)
+        best_idx = min(
+            range(len(regions)),
+            key=lambda i: (
+                (0.5 * (regions[i].box[0] + regions[i].box[2]) - dcx) ** 2
+                + (0.5 * (regions[i].box[1] + regions[i].box[3]) - dcy) ** 2
+            ),
+        )
+
+    # Region vectors are stored L2-normalised, but re-normalise defensively:
+    # the float16 pickle dtype can drift the norm off 1.0 on upcast.
+    return _l2_normalize(np.asarray(regions[best_idx].vec, dtype=np.float32))
 
 
 def to_fp16(regions: list[RegionVector]) -> list[RegionVector]:

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -691,6 +691,13 @@ class DetectorContext:
         # downstream at template-build time.  In-memory only, never persisted.
         # See docs/plans/structural-embedder.md.
         "label_local_features",  # str → StructuralFeatures
+        # Region-flooded negatives for the labelset's Bad elements on patch
+        # datasets: str → list[np.ndarray], keyed by stable_element_id, holding
+        # the element's CLS + HAC-leaf vectors so a saved detector re-sorted
+        # cross-dataset floods the same leaf negatives the live vote path does.
+        # In-memory only, re-derived from origins, never persisted; cleared on
+        # embedder switch alongside ``label_embeddings``.
+        "label_negative_regions",
         "model",  # nn.Sequential | None (current trained MLP)
         # Structural (SIFT/VLAD) detectors carry a *second* learned object next
         # to the retrieval MLP: the match-statistic verification classifier
@@ -782,6 +789,7 @@ class DetectorContext:
         self.label_embeddings: dict[str, Any] = {}
         self.label_embedding_regions: dict[str, tuple[float, float, float, float] | None] = {}
         self.label_local_features: dict[str, Any] = {}
+        self.label_negative_regions: dict[str, list[Any]] = {}
         self.model: Any = None  # nn.Sequential | None
         # Match-statistic verification classifier for structural detectors;
         # None for non-structural detectors and until first trained.
@@ -1023,6 +1031,7 @@ class _RequestMissingDetectorContext(DetectorContext):
         object.__setattr__(self, "label_embeddings", _FrozenDict("detector"))
         object.__setattr__(self, "label_embedding_regions", _FrozenDict("detector"))
         object.__setattr__(self, "label_local_features", _FrozenDict("detector"))
+        object.__setattr__(self, "label_negative_regions", _FrozenDict("detector"))
         object.__setattr__(self, "model", None)
         object.__setattr__(self, "verification_classifier", None)
         object.__setattr__(self, "threshold", 0.5)

--- a/vtscore/training/mlp.py
+++ b/vtscore/training/mlp.py
@@ -207,10 +207,7 @@ def train_model(
     if sample_weights is not None:
         weights = sample_weights.reshape(-1).to(dtype=torch.float32, device=device)
         if weights.numel() != len(y_train):
-            raise ValueError(
-                f"sample_weights length {weights.numel()} does not match "
-                f"training-set size {len(y_train)}"
-            )
+            raise ValueError(f"sample_weights length {weights.numel()} does not match training-set size {len(y_train)}")
     else:
         # Balanced class weights - the single-class case was rejected above.
         weight_true = num_false / num_true

--- a/vtscore/training/mlp.py
+++ b/vtscore/training/mlp.py
@@ -115,6 +115,7 @@ def train_model(
     input_dim: int,
     seed: int = 42,
     hidden_dim: int | None = None,
+    sample_weights: torch.Tensor | None = None,
 ) -> nn.Sequential:
     """Train a small MLP classifier and return the trained model.
 
@@ -123,11 +124,17 @@ def train_model(
     provided via ``hidden_dim``.  Dropout is applied during training to
     reduce overfitting.
 
-    Trains using class-balanced binary cross-entropy loss with logits
-    (``BCEWithLogitsLoss``).  Inclusion does **not** enter training: it is a
-    pure threshold/cutoff knob applied later in :func:`find_optimal_threshold`,
-    so the trained model (and therefore every item's score) is independent of
-    inclusion.  See docs/plans/find-verification-workflow.md.
+    Trains using binary cross-entropy loss with logits (``BCEWithLogitsLoss``).
+    By default each sample is weighted by inverse class frequency (balanced
+    BCE).  When *sample_weights* is provided (one weight per row of
+    *X_train*), those weights are used verbatim instead - this is how the
+    region-flooding path expresses **per-bag** balancing: a Bad image's many
+    correlated region negatives share one image's worth of weight, so they
+    don't count as many independent negatives.  Inclusion does **not** enter
+    training: it is a pure threshold/cutoff knob applied later in
+    :func:`find_optimal_threshold`, so the trained model (and therefore every
+    item's score) is independent of inclusion.  See
+    docs/plans/find-verification-workflow.md.
 
     A local ``torch.Generator`` seeded with *seed* is used for model-weight
     initialisation, and ``torch.random.fork_rng`` isolates the global RNG
@@ -143,6 +150,10 @@ def train_model(
         hidden_dim: Number of neurons in the hidden layer.  When ``None``
             (default) the width is chosen automatically via
             :func:`_auto_hidden_dim` based on the training-set size.
+        sample_weights: Optional per-row loss weights of shape ``(N,)`` or
+            ``(N, 1)``.  When ``None`` (default) inverse-class-frequency
+            weights are computed internally.  When provided they replace the
+            frequency weights entirely (the caller owns class balance).
 
     Returns:
         A trained ``nn.Sequential`` model in eval mode.
@@ -188,13 +199,23 @@ def train_model(
 
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001, weight_decay=1e-4)
 
-    # Balanced class weights - the single-class case was rejected above.
-    # Inclusion is deliberately absent here (it's applied later as a pure
-    # threshold knob in find_optimal_threshold), so the model is inclusion-
-    # independent and its scores can be frozen across cutoff slides.
-    weight_true = num_false / num_true
-    weight_false = 1.0
-    weights = torch.where(y_train == 1, weight_true, weight_false).squeeze().to(device)
+    # Sample weights: caller-supplied (per-bag flooding balance) or the default
+    # inverse-class-frequency balance.  Inclusion is deliberately absent here
+    # (it's applied later as a pure threshold knob in find_optimal_threshold),
+    # so the model is inclusion-independent and its scores can be frozen across
+    # cutoff slides.
+    if sample_weights is not None:
+        weights = sample_weights.reshape(-1).to(dtype=torch.float32, device=device)
+        if weights.numel() != len(y_train):
+            raise ValueError(
+                f"sample_weights length {weights.numel()} does not match "
+                f"training-set size {len(y_train)}"
+            )
+    else:
+        # Balanced class weights - the single-class case was rejected above.
+        weight_true = num_false / num_true
+        weight_false = 1.0
+        weights = torch.where(y_train == 1, weight_true, weight_false).squeeze().to(device)
     loss_fn = nn.BCEWithLogitsLoss(reduction="none")
 
     # Fork the global RNG so the Dropout seed is isolated per call -

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -351,15 +351,14 @@ def _compute_fold_orderings_grouped(
     n_train_pos = _per_class_n_train(len(pos_groups))
     n_train_neg = _per_class_n_train(len(neg_groups))
 
-    pos_arr = np.array(pos_groups, dtype=object)
-    neg_arr = np.array(neg_groups, dtype=object)
-
+    # Index the plain group lists by position - group ids are tuples, and
+    # ``np.array(list_of_tuples)`` would build a 2-D array and mangle them.
     orderings: list[tuple[list[float], list[float]]] = []
     for _ in range(max(1, calibrate_count)):
-        pos_perm = _rng.permutation(len(pos_arr))
-        neg_perm = _rng.permutation(len(neg_arr))
-        train_groups = [pos_arr[i] for i in pos_perm[:n_train_pos]] + [neg_arr[i] for i in neg_perm[:n_train_neg]]
-        cal_groups = [pos_arr[i] for i in pos_perm[n_train_pos:]] + [neg_arr[i] for i in neg_perm[n_train_neg:]]
+        pos_perm = _rng.permutation(len(pos_groups))
+        neg_perm = _rng.permutation(len(neg_groups))
+        train_groups = [pos_groups[i] for i in pos_perm[:n_train_pos]] + [neg_groups[i] for i in neg_perm[:n_train_neg]]
+        cal_groups = [pos_groups[i] for i in pos_perm[n_train_pos:]] + [neg_groups[i] for i in neg_perm[n_train_neg:]]
 
         train_idx = [i for g in train_groups for i in rows_by_group[g]]
         X_train = torch.tensor(X_np[train_idx], dtype=torch.float32)

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -364,9 +364,7 @@ def _compute_fold_orderings_grouped(
         train_idx = [i for g in train_groups for i in rows_by_group[g]]
         X_train = torch.tensor(X_np[train_idx], dtype=torch.float32)
         y_train = torch.tensor(y_np[train_idx], dtype=torch.float32).unsqueeze(1)
-        fold_w = torch.tensor(
-            _per_bag_fit_weights(y_np[train_idx], [grp[i] for i in train_idx]), dtype=torch.float32
-        )
+        fold_w = torch.tensor(_per_bag_fit_weights(y_np[train_idx], [grp[i] for i in train_idx]), dtype=torch.float32)
         model = train_model(X_train, y_train, input_dim, hidden_dim=hidden_dim, sample_weights=fold_w)
 
         # Score every calibration row, then max-pool per group to one score.

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -93,6 +93,7 @@ def _calibration_cache_key(
     calibrate_count: int,
     calibration_fraction: float,
     hidden_dim: int,
+    groups: list | None = None,
 ) -> tuple:
     """Build a deterministic cache key for the calibration **fold orderings**.
 
@@ -107,12 +108,16 @@ def _calibration_cache_key(
     """
     X_bytes = np.stack(X_list).astype(np.float32, copy=False).tobytes()
     y_bytes = np.asarray(y_list, dtype=np.float32).tobytes()
+    # Bag membership changes the fold split and per-group max-pool, so a change
+    # in grouping must invalidate the cached orderings even when X/y are equal.
+    groups_key = tuple(str(g) for g in groups) if groups is not None else None
     return (
         X_bytes,
         y_bytes,
         int(calibrate_count),
         float(calibration_fraction),
         int(hidden_dim),
+        groups_key,
     )
 
 
@@ -126,6 +131,7 @@ def cross_calibration_threshold_cached(
     calibration_fraction: float,
     hidden_dim: int,
     det_ctx: Any = None,
+    groups: list | None = None,
 ) -> float:
     """Memoized wrapper around :func:`calculate_cross_calibration_threshold`.
 
@@ -143,7 +149,7 @@ def cross_calibration_threshold_cached(
     payload: tuple[list[tuple[list[float], list[float]]], float | None] | None = None
     key = None
     if det_ctx is not None:
-        key = _calibration_cache_key(X_list, y_list, calibrate_count, calibration_fraction, hidden_dim)
+        key = _calibration_cache_key(X_list, y_list, calibrate_count, calibration_fraction, hidden_dim, groups)
         cached = getattr(det_ctx, "calibration_cache", None)
         if cached is not None and cached[0] == key:
             payload = cached[1]
@@ -158,6 +164,7 @@ def cross_calibration_threshold_cached(
             calibrate_count=calibrate_count,
             calibration_fraction=calibration_fraction,
             hidden_dim=hidden_dim,
+            groups=groups,
         )
         if det_ctx is not None and key is not None:
             det_ctx.calibration_cache = (key, payload)
@@ -259,6 +266,126 @@ def find_optimal_threshold(
     return float(sorted_scores[best_idx])
 
 
+def _per_bag_fit_weights(
+    y_rows: np.ndarray,
+    group_rows: list,
+) -> np.ndarray:
+    """Per-row loss weights that balance Good votes against Bad **bags**.
+
+    Every Good row weighs ``n_bad_bags / n_good``; every Bad row weighs
+    ``1 / (rows in its bag)`` so each Bad image contributes exactly one image's
+    worth of negative mass regardless of how many region nodes it flooded in.
+    Total Good mass (``n_bad_bags``) equals total Bad mass (``n_bad_bags``), so
+    the classes are balanced at the same magnitude as :func:`train_model`'s
+    default inverse-frequency weights - only the *unit* changes from row to bag.
+    """
+    from collections import Counter  # noqa: PLC0415
+
+    n_good = sum(1 for lbl in y_rows if lbl == 1.0)
+    bad_groups = {g for g, lbl in zip(group_rows, y_rows, strict=True) if lbl == 0.0}
+    n_bad_bags = len(bad_groups)
+    bag_sizes = Counter(g for g, lbl in zip(group_rows, y_rows, strict=True) if lbl == 0.0)
+    good_w = (n_bad_bags / n_good) if n_good else 1.0
+    w = np.ones(len(y_rows), dtype=np.float32)
+    for i, (g, lbl) in enumerate(zip(group_rows, y_rows, strict=True)):
+        w[i] = good_w if lbl == 1.0 else (1.0 / bag_sizes[g])
+    return w
+
+
+def _compute_fold_orderings_grouped(
+    X_list: list[np.ndarray],
+    y_list: list[float],
+    input_dim: int,
+    groups: list,
+    rng: np.random.RandomState | None,
+    calibrate_count: int,
+    calibration_fraction: float,
+    hidden_dim: int | None,
+) -> tuple[list[tuple[list[float], list[float]]], float | None]:
+    """Bag-aware variant of :func:`compute_fold_orderings`.
+
+    Splits by *group* (a voted image) instead of by row so a Bad bag's flooded
+    region negatives never straddle the Train/Calibrate boundary, sizes the
+    split over votes not rows, weight-balances each fold fit per-bag, and
+    collapses every calibration group to a single max-pooled score (an image
+    scores by its best region, as at inference).
+    """
+    import torch  # noqa: PLC0415
+
+    from vtscore.training.mlp import train_model  # noqa: PLC0415
+    from vtscore.utils.scores import sigmoid_to_finite_scores  # noqa: PLC0415
+
+    _rng = rng if rng is not None else np.random
+    X_np = np.array(X_list)
+    y_np = np.array(y_list)
+    grp = list(groups)
+
+    # Rows per group, and each group's (single) label.
+    order_groups: list = []
+    rows_by_group: dict = {}
+    label_by_group: dict = {}
+    for i, g in enumerate(grp):
+        if g not in rows_by_group:
+            rows_by_group[g] = []
+            order_groups.append(g)
+            label_by_group[g] = y_np[i]
+        rows_by_group[g].append(i)
+
+    pos_groups = [g for g in order_groups if label_by_group[g] == 1.0]
+    neg_groups = [g for g in order_groups if label_by_group[g] == 0.0]
+    n = len(order_groups)
+    if n < 4:
+        return [], 0.5
+    if len(pos_groups) < 2 or len(neg_groups) < 2:
+        return [], 0.5
+
+    n_cal = max(1, round(n * calibration_fraction))
+    n_train = n - n_cal
+    if n_train < 2 or n_cal < 1:
+        return [], NO_GOOD_THRESHOLD
+
+    def _per_class_n_train(class_total: int) -> int:
+        target = round(class_total * n_train / n)
+        return max(1, min(class_total - 1, target))
+
+    n_train_pos = _per_class_n_train(len(pos_groups))
+    n_train_neg = _per_class_n_train(len(neg_groups))
+
+    pos_arr = np.array(pos_groups, dtype=object)
+    neg_arr = np.array(neg_groups, dtype=object)
+
+    orderings: list[tuple[list[float], list[float]]] = []
+    for _ in range(max(1, calibrate_count)):
+        pos_perm = _rng.permutation(len(pos_arr))
+        neg_perm = _rng.permutation(len(neg_arr))
+        train_groups = [pos_arr[i] for i in pos_perm[:n_train_pos]] + [neg_arr[i] for i in neg_perm[:n_train_neg]]
+        cal_groups = [pos_arr[i] for i in pos_perm[n_train_pos:]] + [neg_arr[i] for i in neg_perm[n_train_neg:]]
+
+        train_idx = [i for g in train_groups for i in rows_by_group[g]]
+        X_train = torch.tensor(X_np[train_idx], dtype=torch.float32)
+        y_train = torch.tensor(y_np[train_idx], dtype=torch.float32).unsqueeze(1)
+        fold_w = torch.tensor(
+            _per_bag_fit_weights(y_np[train_idx], [grp[i] for i in train_idx]), dtype=torch.float32
+        )
+        model = train_model(X_train, y_train, input_dim, hidden_dim=hidden_dim, sample_weights=fold_w)
+
+        # Score every calibration row, then max-pool per group to one score.
+        cal_idx = [i for g in cal_groups for i in rows_by_group[g]]
+        with torch.no_grad():
+            X_cal = torch.tensor(X_np[cal_idx], dtype=torch.float32).to(next(model.parameters()).device)
+            row_scores = sigmoid_to_finite_scores(model(X_cal))
+        pos_in_cal = {i: s for i, s in zip(cal_idx, row_scores, strict=True)}
+        group_scores: list[float] = []
+        group_labels: list[float] = []
+        for g in cal_groups:
+            rows = rows_by_group[g]
+            group_scores.append(max(pos_in_cal[i] for i in rows))
+            group_labels.append(float(label_by_group[g]))
+        orderings.append((group_scores, group_labels))
+
+    return orderings, None
+
+
 def compute_fold_orderings(
     X_list: list[np.ndarray],
     y_list: list[float],
@@ -267,6 +394,7 @@ def compute_fold_orderings(
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     hidden_dim: int | None = None,
+    groups: list | None = None,
 ) -> tuple[list[tuple[list[float], list[float]]], float | None]:
     """Train the K calibration folds and return their held-out orderings.
 
@@ -282,7 +410,27 @@ def compute_fold_orderings(
     orderings are empty and ``fallback`` is the sentinel threshold the public
     wrapper must return (mirrors :func:`calculate_cross_calibration_threshold`'s
     historical early-returns); otherwise ``fallback`` is ``None``.
+
+    *groups* activates the **bag-aware** path used when Bad votes are flooded
+    into their region nodes: rows sharing a ``groups`` id belong to one voted
+    image (a Bad bag's region negatives, or a single Good row) and
+    are kept together on one side of every Train/Calibrate split, split counts
+    are taken over *groups* (votes) not rows, fold fits are *weights*-balanced,
+    and each calibration group collapses to one max-pooled score - matching how
+    inference scores an image by its best region.  When *groups* is ``None``
+    (every non-flooded caller) the historical row-wise path runs unchanged.
     """
+    if groups is not None:
+        return _compute_fold_orderings_grouped(
+            X_list,
+            y_list,
+            input_dim,
+            groups,
+            rng=rng,
+            calibrate_count=calibrate_count,
+            calibration_fraction=calibration_fraction,
+            hidden_dim=hidden_dim,
+        )
     n = len(X_list)
     if n < 4:
         return [], 0.5
@@ -386,6 +534,7 @@ def calculate_cross_calibration_threshold(
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     hidden_dim: int | None = None,
+    groups: list | None = None,
 ) -> float:
     """Estimate a decision threshold using k-fold calibration.
 
@@ -448,6 +597,7 @@ def calculate_cross_calibration_threshold(
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
         hidden_dim=hidden_dim,
+        groups=groups,
     )
     if fallback is not None:
         return fallback


### PR DESCRIPTION
Two related changes to how region votes train a detector on patch-region datasets (DINOv2/DINOv3/EUPE), where inference **max-pools** the MLP over each image's `patch_regions` (an image scores by its best region).

## 1. Snap Good region-votes to the nearest HAC node

A Good vote on a drawn region now trains on the vector of the nearest `patch_regions` node (max box-IoU, `snap_box_to_region`) instead of a uniform pool of the raw patch grid. The old pool matched **no** actual candidate the MLP scores (HAC internals are saliency-weighted means, renormalised per merge); snapping makes the positive one of the exact sub-images the detector ranks against. Reuses stored region vectors — no embedder forward pass on the interactive path. Cross-dataset (saved detector, different dataset) rebuilds the tree and snaps.

## 2. Flood Bad votes with the image's leaf negatives (MIL)

A Bad vote is a false positive iff its *best* region scores high, so a Bad vote now asserts "no region here is good": it **floods the CLS + HAC-leaf nodes** (the disjoint covering set; redundant saliency-weighted internals dropped) as negatives, training every leaf down. Previously a Bad vote contributed a single image-level negative that left the leaf scores — the thing max-pool actually surfaces — unconstrained.

Because flooding turns one Bad vote into many correlated rows, class balance and threshold calibration are **per-bag, not per-row**:

- **Weighted fit** — `train_model` gained an optional `sample_weights`; each Bad image's leaves share one image's worth of negative mass (`_per_bag_fit_weights`), so a rejected image counts once regardless of leaf count.
- **Bag-aware calibration** — `compute_fold_orderings(groups=...)` splits Train/Calibrate by bag (a Bad image's leaves never straddle the boundary), sizes counts over votes not rows, weights fold fits per-bag, and **max-pools each calibration group to one score** so the threshold lands on the per-image scale the detector deploys. Hidden-layer width and the safe-threshold ramp size on vote count too.

### Scope: only where scoring max-pools

Flooding is wired into the **region-aware-scored** paths — the Learned-sort vote path (`train_and_score`) and the saved-detector labelset path (`labelset_train_and_score` / `train_from_labelset`). The **Find cold-detector** path and **label-file sort** score each image by a single vector (`get_embedding_matrix_for_snap`, not the region matrix), so they are intentionally *not* flooded — flooding leaf negatives while scoring one image vector would be a train/score space mismatch. On any embedder that produces no regions, every bag is one row and the whole path is byte-for-byte the historical single-vector BCE.

## Why (measured)

A synthetic MIL eval and an A/B of the **shipped** `train_and_score` (flooding on vs. monkeypatched off) on planted "distractor" negatives (a Bad image harboring a target-looking region):

| distractor cosine-to-target | image-level only (old) | flood (shipped) |
|---|---|---|
| 0.70 | `fpr_dist` 0.257 | **0.055** |
| 0.85 | `fpr_dist` 0.309 | **0.036** |

Distractor false-positives drop ~4–8×. As the look-alike approaches the target (0.85+), suppressing it also costs some recall (`fnr` rises) — the expected precision/recall trade in the near-identical regime; no method fully separates a Bad region that is essentially the target.

## Tests

- Snap: `TestSnapBoxToRegion` (exact-node selection, IoU-over-centroid, whole-image collapse, zero-area fallback, float32/unit-norm, empty tree, swapped corners) + `_training_vec_for_vote` snap-vs-grid.
- Flood: `TestBadVoteRegionFlooding` (`bad_negative_vecs` CLS+leaves-not-internals, legacy single-vector, `_build_vote_xy` grouped rows, `_per_bag_fit_weights` balance, `_flood_context` no-op, `build_xy_from_labelset` from neg-cache) + `TestBagAwareCalibration` (grouped split keeps bags together, one max-pooled score per cal group).
- The calibration test caught a real latent bug: `np.array(list_of_tuples, dtype=object)` mangled tuple group-ids into 2-D rows, which would have broken production flooding once a patch dataset accumulated ≥4 Bad bags.
- Full suite green: `ALL 5552 TESTS PASSED`.

## Backwards compatibility

Behaviour change, not a data/format break: votes still persist only `region_box`; region vectors are re-derived on demand; no persisted artifacts change. Existing detectors retrain from the same stored votes on the next Learned sort. Non-patch datasets are byte-for-byte unchanged.
