### PR TITLE
Promote py7zr to a hard dependency for the Clotho demo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ dependencies = [
     # MLP (vtscore.detectors.portable_bundle). Pure-Python protobuf builder; no
     # torch.onnx dependency (the graph is hand-assembled via onnx.helper).
     "onnx",
+    # Extract the Clotho audio demo, which ships as a single .7z archive on
+    # Zenodo (vtscore.datasets.downloader.core._extract_7z). Imported lazily so
+    # a missing install still surfaces an actionable error, but declared here so
+    # a plain `install.sh` covers the Clotho demo out of the box.
+    "py7zr",
 ]
 
 [project.optional-dependencies]
@@ -169,7 +174,6 @@ extend_exclude = [
 # users opt in by installing the extra package.
 DEP001 = [
     "paddleocr",
-    "py7zr",
     "rarfile",
     "whisper",
     "mediapipe",

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -548,11 +548,12 @@ def _move_tree_contents(src: Path, dst: Path) -> None:
 def _extract_7z(archive_path: Path, dest_dir: Path, dataset_name: str, on_progress: ProgressCallback) -> None:
     """Extract a ``.7z`` archive into *dest_dir* using ``py7zr``.
 
-    ``py7zr`` is an optional dependency (only the Clotho audio demo ships as
-    ``.7z``), so it is imported lazily and a missing install surfaces as a
-    short, actionable ``RuntimeError`` rather than an ``ImportError``.  Every
-    member name is validated against *dest_dir* before extraction to guard
-    against path traversal (the same protection the zip branch applies).
+    ``py7zr`` is a declared dependency (installed by ``install.sh``), but only
+    the Clotho audio demo ships as ``.7z``, so it is still imported lazily and a
+    missing install surfaces as a short, actionable ``RuntimeError`` rather than
+    an ``ImportError``.  Every member name is validated against *dest_dir* before
+    extraction to guard against path traversal (the same protection the zip
+    branch applies).
     """
     try:
         import py7zr  # noqa: PLC0415  # pyright: ignore[reportMissingImports]


### PR DESCRIPTION
## What & why

The Clotho audio demo ships as a single `.7z` archive on Zenodo, so extracting it needs `py7zr`. That dependency was originally left optional (lazily imported, with an actionable `RuntimeError` if missing). The consequence: a plain `bash scripts/install.sh` did **not** install `py7zr`, so anyone who ran install.sh and then picked the Clotho demo hit the error and had to `pip install py7zr` by hand.

`py7zr` is small (pure-Python plus a handful of prebuilt compiled wheels), and the demo is the reference dataset for natural-language text→audio (CLAP) retrieval, so the few MB added to every install is a fair trade for "just run install.sh and every demo works."

## Changes

- Declare `py7zr` in `[project.dependencies]` in `pyproject.toml`, so `install.sh` (via `requirements/base.txt` → project metadata) installs it out of the box.
- Drop `py7zr` from the `deptry` `DEP001` ignore list now that it's a declared dependency.
- Update the `_extract_7z` docstring to reflect that `py7zr` is now declared; the lazy import + friendly `RuntimeError` stay as a backstop.

## Testing

- `./run-tests.sh downloads` → 197 passed (includes the `test_missing_py7zr_raises_actionable_error` backstop test).
- `python -m deptry .` → no dependency issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzAw7GTEKJvfXwcgjMU4N4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzAw7GTEKJvfXwcgjMU4N4)_