### PR TITLE
Fix video2image spec validation rejecting blank seconds_per_frame

### DIFF
--- a/tests/converters/test_document_and_converters.py
+++ b/tests/converters/test_document_and_converters.py
@@ -461,6 +461,28 @@ class TestVideo2ImageMediaConverter:
         results = c.convert_normalized(media, {"n_clips": "4", "seconds_per_frame": ""})
         assert len(results) == 4
 
+    def test_source_spec_parser_accepts_blank_seconds_per_frame(self):
+        """Regression for #2245: the multi-media source-spec parser must not
+        reject a blank optional ``seconds_per_frame`` as "Not a valid number".
+
+        The frontend submits ``seconds_per_frame: ""`` when the user leaves
+        the field empty in favour of "Frames per video"; that empty string
+        must be scrubbed before marshmallow validation rather than reaching
+        the Float loader."""
+        from vtscore.datasets.importers.base.specs import _parse_multi_media_specs
+
+        raw = [
+            {
+                "source_type": "video",
+                "converter": "video2image",
+                "params": {"n_clips": "10", "seconds_per_frame": ""},
+            }
+        ]
+        # Must not raise; the blank field is treated as "unset".
+        specs = _parse_multi_media_specs(raw, output_type="image")
+        assert len(specs) == 1
+        assert specs[0].converter == "video2image"
+
 
 # ===========================================================================
 # Video2AudioMediaConverter tests

--- a/vtscore/datasets/importers/base/specs.py
+++ b/vtscore/datasets/importers/base/specs.py
@@ -107,8 +107,6 @@ def _validate_spec_converter(spec: SourceSpec, output_type: str, get_converter) 
     :class:`PluginField` schema, so declared ``min`` / ``max`` ranges
     are enforced before the params reach :meth:`MediaConverter.convert`.
     """
-    from marshmallow import ValidationError  # noqa: PLC0415
-
     if spec.converter is None:
         if spec.source_type != output_type:
             raise ValueError(
@@ -128,10 +126,14 @@ def _validate_spec_converter(spec: SourceSpec, output_type: str, get_converter) 
             f"Converter {spec.converter!r} produces "
             f"{converter.target_type!r}, but output media_type is {output_type!r}",
         )
-    try:
-        converter.validate_params(spec.params)
-    except ValidationError as exc:
-        raise ValueError(f"Invalid params for converter {spec.converter!r}: {exc.messages}") from exc
+    # Route through ``normalize_params`` (not ``validate_params``) so that
+    # empty-string values for optional/defaulted fields are scrubbed before
+    # marshmallow sees them - otherwise a blank optional ``number`` field
+    # (e.g. "Seconds per frame" left unset in favour of "Frames per video")
+    # reaches the Float loader as ``""`` and is rejected as "Not a valid
+    # number".  ``normalize_params`` already raises ``ValueError`` on a real
+    # validation failure, matching this call site's error contract.
+    converter.normalize_params(spec.params)
 
 
 PickerView = str  # one of: "form", "demo", "server_folder", "local"


### PR DESCRIPTION
## Problem

Creating an image dataset from video failed when the **Seconds per frame** field was left empty:

```
Invalid params for converter 'video2image': {'seconds_per_frame': ['Not a valid number.']}
```

The two frame-count knobs (`n_clips` / `seconds_per_frame`) are mutually exclusive — leaving `seconds_per_frame` blank is the normal way to use `n_clips`. The converter's own runtime path (`convert_normalized` → `normalize_params`) already scrubs empty-string values for optional/defaulted fields before marshmallow validation. But the **source-spec validation path** (`_validate_spec_converter` in `vtscore/datasets/importers/base/specs.py`) called `converter.validate_params(...)` directly, skipping that scrub. So a blank `seconds_per_frame` (`""`) reached marshmallow's `Float` loader and was rejected as "Not a valid number."

## Fix

Route the spec-time validation through `normalize_params` (which scrubs empty-string optional fields, then validates) instead of `validate_params`. `normalize_params` already raises `ValueError` on a real validation failure with the same message format, so the call site's error contract is unchanged.

## Test

Added a regression test to the source-spec parser (`test_source_spec_parser_accepts_blank_seconds_per_frame`) that submits `seconds_per_frame: ""` via `_parse_multi_media_specs` — mirroring the frontend payload — and asserts it parses without raising.

`./run-tests.sh converters` (184 passed) and `./run-tests.sh io` (820 passed) are green.

Fixes #2245


---
_Generated by [Claude Code](https://claude.ai/code/session_0149PrUUF7CuanFF6HKxLqje)_