### PR TITLE
Fix load-file crash: wrap pickle upload as save-able UploadedFile

### DIFF
--- a/tests/datasets/test_load_routes.py
+++ b/tests/datasets/test_load_routes.py
@@ -86,6 +86,54 @@ class TestLoadFile:
         assert resp.status_code == 400
         assert "No file selected" in resp.get_json()["message"]
 
+    def test_upload_is_wrapped_as_saveable_and_loads(self, client, monkeypatch):
+        """Regression: the upload must reach the pickle importer as a save-able
+        ``UploadedFile``, never a bare ``io.BytesIO``.
+
+        The route reads the upload into memory before the background thread
+        runs (the Flask ``FileStorage`` stream dies with the request).  Those
+        bytes must be wrapped in a ``BytesIOUploadedFile``: the pickle importer
+        persists the upload via ``file_obj.save(temp_path)``, and a raw
+        ``io.BytesIO`` has no ``.save``, so an unwrapped buffer crashed the
+        background load with ``'_io.BytesIO' object has no attribute 'save'``.
+        """
+        import vtsearch.routes.datasets.load as load_mod
+        from vtscore.plugins.uploads import UploadedFile, wrap_cli_file_fields
+
+        # A real, valid exported pickle of the fixture dataset.
+        pkl_bytes = client.get("/api/dataset/export").data
+        assert pkl_bytes
+
+        captured: dict = {}
+
+        def _capture(importer, field_values):
+            captured["importer"] = importer
+            captured["field_values"] = field_values
+            return "task-regression"
+
+        monkeypatch.setattr(load_mod, "_run_importer_in_background", _capture)
+
+        data = {"file": (io.BytesIO(pkl_bytes), "dataset.pkl")}
+        resp = client.post("/api/dataset/load-file", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 200
+
+        file_obj = captured["field_values"]["file"]
+        # The contract the pickle importer relies on: a save-able UploadedFile,
+        # not a bare io.BytesIO (which is what the bug handed it).
+        assert not isinstance(file_obj, io.BytesIO)
+        assert isinstance(file_obj, UploadedFile)
+        assert callable(getattr(file_obj, "save", None))
+        assert file_obj.filename == "dataset.pkl"
+
+        # End-to-end: run the importer exactly as the background runner does
+        # (normalize file fields, then run) and confirm it loads the dataset
+        # rather than raising the AttributeError the bug produced.
+        importer = captured["importer"]
+        normalized = wrap_cli_file_fields(importer.fields, dict(captured["field_values"]))
+        loaded: dict = {}
+        importer.run(normalized, loaded)
+        assert len(loaded) > 0
+
 
 # ---------------------------------------------------------------------------
 # POST /api/dataset/load-source

--- a/vtsearch/routes/datasets/load.py
+++ b/vtsearch/routes/datasets/load.py
@@ -412,15 +412,21 @@ def load_dataset_file():
     if not file.filename:
         abort(400, message="No file selected")
 
+    from vtscore.plugins.uploads import BytesIOUploadedFile  # noqa: PLC0415
+
     importer = get_importer("pickle")
     # Read file contents before passing to background thread, since the
     # Flask FileStorage stream is only valid during the request lifecycle.
-    file_bytes = io.BytesIO(file.read())
-    file_bytes.name = file.filename
+    # Wrap in BytesIOUploadedFile (not a raw io.BytesIO) so the value satisfies
+    # the UploadedFile protocol the importer relies on: a bare BytesIO has no
+    # ``.save()``, so the pickle importer's ``file_obj.save(temp_path)`` would
+    # raise ``'_io.BytesIO' object has no attribute 'save'`` in the background
+    # thread.
+    uploaded = BytesIOUploadedFile(file.read(), file.filename)
     task_id = _run_importer_in_background(
         importer,
         {
-            "file": file_bytes,
+            "file": uploaded,
             "build_projection": "true" if _form_flag(request.form.get("build_projection")) else "false",
         },
     )


### PR DESCRIPTION
## The bug

Every pickle upload via **`POST /api/dataset/load-file`** crashed the background import with:

```
'_io.BytesIO' object has no attribute 'save'
```

The route read the upload into a bare `io.BytesIO` and handed it to the background importer as `field_values["file"]`. But `PickleDatasetImporter.run()` persists the upload with `file_obj.save(temp_path)` — and a raw `io.BytesIO` has no `.save()`.

The normalization step in `_run_importer_in_background` (`wrap_cli_file_fields`) only wraps `str`/`Path` values into `CliUploadedFile`; a raw `BytesIO` is neither a `str`/`Path` nor a valid `UploadedFile`, so it passed straight through unwrapped to `run()`.

## The fix

Wrap the upload bytes in **`BytesIOUploadedFile`** in the route — the same `UploadedFile` adapter the multipart bytesio path (`validate_plugin_args(file_mode="bytesio")` → `_populate_file_fields`) already uses. It carries `.filename` / `.read()` / `.save()` / `.stream`, so the background thread can persist the file after the Flask request (and its `FileStorage` stream) has been torn down.

One-line behavioral change in `vtsearch/routes/datasets/load.py::load_dataset_file`; no API/shape change.

## Test

Adds a regression test in `tests/datasets/test_load_routes.py`. The prior `TestLoadFile` only covered the two 400 branches and explicitly *"does not exercise the background import thread"* — which is how this shipped. The new test:

- exports the fixture dataset to a real pickle, POSTs it to `/api/dataset/load-file`,
- asserts the importer receives a save-able `UploadedFile` (and **not** a bare `io.BytesIO`), and
- runs the pickle importer end-to-end and asserts the dataset actually loads.

On the old code the test fails at the `isinstance(..., io.BytesIO)` assertion and, end-to-end, reproduces the original `AttributeError`.

## Validation

Full gated `datasets` group: **831 passed, 2 skipped** (ruff / codespell / deptry / pip-audit / pyright all clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)