### PR TITLE
Re-run canvas resize on devicePixelRatio change (monitor-to-monitor drag)

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -14,11 +14,6 @@ Named, unordered — delete an item when it ships; never renumber (see the
 plan-file policy in `CLAUDE.md`). Roughly severity-ordered, but the name is
 the identifier, not the position.
 
-- **Pure devicePixelRatio change never re-runs canvas `resize()`**
-  (browse-canvas + minimap): dragging the window to a different-density
-  monitor leaves `dpr` (and the thumbnail-resolution tier) stale until the
-  next CSS resize; rendering-quality only (hit-testing is CSS-px based).
-  Needs a `matchMedia('(resolution: …)')` listener.
 - **`save_detector_labels` full-replace drops cross-dataset labels**
   (`routes/detectors/labels.py`): the route rebuilds the labelset from the
   *active dataset's* votes only, while `sync_labels_to_loaded_detector`

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -16,6 +16,7 @@ import {
 import { binGeometry, BinGeometry } from './bin-geometry';
 import { prefersReducedMotion } from '../../utils/reduced-motion';
 import { readRootZoom } from '../../utils/root-zoom';
+import { onDevicePixelRatioChange } from '../../utils/device-pixel-ratio';
 import type {
   HexCellPayload,
   ProjectionMeta,
@@ -419,6 +420,11 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private panAnimBg = '';
 
   private resizeObserver: ResizeObserver | null = null;
+  // Teardown for the devicePixelRatio-change listener. A pure density change
+  // (dragging to a different-density monitor) leaves the CSS box unchanged, so
+  // the ResizeObserver never fires; this re-runs `resize()` to refresh the
+  // backing store and the thumbnail-resolution tier.
+  private dprListenerTeardown: (() => void) | null = null;
   // Repaints when the document theme flips (explicit switch or an OS
   // dark/light change while on "system"), so the colormap and background
   // track the live theme without the parent having to feed it in.
@@ -514,6 +520,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     });
     this.resizeObserver.observe(this.canvasRef.nativeElement.parentElement!);
 
+    // A pure devicePixelRatio change (monitor-to-monitor drag, browser zoom, OS
+    // scaling) doesn't touch the element box, so the ResizeObserver stays quiet;
+    // re-run resize() to rebuild the backing store at the new density.
+    this.dprListenerTeardown = onDevicePixelRatioChange(() => {
+      this.ngZone.runOutsideAngular(() => this.resize());
+    });
+
     this.themeObserver = new MutationObserver(() => this.requestRedraw());
     this.themeObserver.observe(document.documentElement, {
       attributes: true,
@@ -590,6 +603,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.recenterSub?.unsubscribe();
     this.viewport.setViewport(null);
     this.resizeObserver?.disconnect();
+    this.dprListenerTeardown?.();
     this.themeObserver?.disconnect();
     if (this.rafId) cancelAnimationFrame(this.rafId);
     if (this.animRafId) cancelAnimationFrame(this.animRafId);

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -12,6 +12,7 @@ import {
 } from '../browse-canvas/hex-render.util';
 import { binGeometry } from '../browse-canvas/bin-geometry';
 import { readRootZoom } from '../../utils/root-zoom';
+import { onDevicePixelRatioChange } from '../../utils/device-pixel-ratio';
 import { IconComponent } from '../icon/icon.component';
 import type { HexCellPayload, ProjectionMeta } from '../../models/projection.models';
 
@@ -81,6 +82,11 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
 }>();
 
   private resizeObserver: ResizeObserver | null = null;
+  // Teardown for the devicePixelRatio-change listener. A pure density change
+  // (monitor-to-monitor drag) leaves the element box untouched, so neither the
+  // dock ResizeObserver nor the floating width/height inputs fire; this re-runs
+  // resizeCanvas() to rebuild the backing store at the new density.
+  private dprListenerTeardown: (() => void) | null = null;
 
   private ctx!: CanvasRenderingContext2D;
   private dpr = 1;
@@ -110,6 +116,15 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     this.ctx = this.canvasRef.nativeElement.getContext('2d')!;
     if (this.dock) this.startDockSizing();
     this.resizeCanvas();
+
+    // A pure devicePixelRatio change doesn't resize the element, so re-run the
+    // canvas sizing (and repaint) when the display density shifts.
+    this.ngZone.runOutsideAngular(() => {
+      this.dprListenerTeardown = onDevicePixelRatioChange(() => {
+        this.resizeCanvas();
+        this.requestRedraw();
+      });
+    });
 
     // Overview tiles arrive asynchronously; repaint as the cache fills. The
     // viewport box updates on every pan/zoom the main canvas publishes.
@@ -149,6 +164,7 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     this.viewportSub?.unsubscribe();
     this.themeObserver?.disconnect();
     this.resizeObserver?.disconnect();
+    this.dprListenerTeardown?.();
     if (this.rafId) cancelAnimationFrame(this.rafId);
     this.detachResizeListeners();
     this.detachNavListeners();

--- a/frontend/src/app/utils/device-pixel-ratio.spec.ts
+++ b/frontend/src/app/utils/device-pixel-ratio.spec.ts
@@ -1,0 +1,112 @@
+import { onDevicePixelRatioChange } from './device-pixel-ratio';
+
+interface StubMediaQueryList {
+  matches: boolean;
+  media: string;
+  onchange: ((e: MediaQueryListEvent) => void) | null;
+  addEventListener: (type: string, listener: (e: MediaQueryListEvent) => void) => void;
+  removeEventListener: (type: string, listener: (e: MediaQueryListEvent) => void) => void;
+  dispatchEvent: (event: Event) => boolean;
+  _listeners: Array<(e: MediaQueryListEvent) => void>;
+  _fire: () => void;
+}
+
+function makeStubMedia(media: string): StubMediaQueryList {
+  return {
+    matches: true,
+    media,
+    onchange: null,
+    _listeners: [],
+    addEventListener(_type, l) {
+      this._listeners.push(l);
+    },
+    removeEventListener(_type, l) {
+      this._listeners = this._listeners.filter((x) => x !== l);
+    },
+    dispatchEvent: () => false,
+    _fire() {
+      const ev = { matches: this.matches, media: this.media } as MediaQueryListEvent;
+      // Copy so a re-subscribe inside the handler doesn't mutate the list we're iterating.
+      [...this._listeners].forEach((l) => l(ev));
+    },
+  };
+}
+
+describe('onDevicePixelRatioChange', () => {
+  let originalMatchMedia: typeof window.matchMedia;
+  let originalDpr: number;
+  let stubs: StubMediaQueryList[];
+  let queries: string[];
+
+  function setDpr(value: number): void {
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value,
+    });
+  }
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    originalDpr = window.devicePixelRatio;
+    stubs = [];
+    queries = [];
+    setDpr(1);
+    (window as unknown as { matchMedia: (q: string) => MediaQueryList }).matchMedia = (q: string) => {
+      queries.push(q);
+      const stub = makeStubMedia(q);
+      stubs.push(stub);
+      return stub as unknown as MediaQueryList;
+    };
+  });
+
+  afterEach(() => {
+    (window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia = originalMatchMedia;
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: originalDpr,
+    });
+  });
+
+  it('pins the media query to the current devicePixelRatio', () => {
+    setDpr(2);
+    onDevicePixelRatioChange(() => {});
+    expect(queries).toEqual(['(resolution: 2dppx)']);
+  });
+
+  it('invokes the callback when the density changes', () => {
+    let count = 0;
+    onDevicePixelRatioChange(() => count++);
+    stubs[0]._fire();
+    expect(count).toBe(1);
+  });
+
+  it('re-subscribes at the new dpr so successive changes keep firing', () => {
+    let count = 0;
+    onDevicePixelRatioChange(() => count++);
+
+    // First density change: 1 -> 2. The handler re-pins to the new dpr.
+    setDpr(2);
+    stubs[0]._fire();
+    // Second change: 2 -> 3, delivered on the freshly-subscribed query.
+    setDpr(3);
+    stubs[stubs.length - 1]._fire();
+
+    expect(count).toBe(2);
+    expect(queries).toEqual(['(resolution: 1dppx)', '(resolution: 2dppx)', '(resolution: 3dppx)']);
+  });
+
+  it('stops firing after teardown', () => {
+    let count = 0;
+    const teardown = onDevicePixelRatioChange(() => count++);
+    teardown();
+    stubs[0]._fire();
+    expect(count).toBe(0);
+    expect(stubs[0]._listeners).toEqual([]);
+  });
+
+  it('returns a no-op teardown when matchMedia is unavailable', () => {
+    (window as unknown as { matchMedia: unknown }).matchMedia = undefined;
+    const teardown = onDevicePixelRatioChange(() => {});
+    expect(() => teardown()).not.toThrow();
+  });
+});

--- a/frontend/src/app/utils/device-pixel-ratio.ts
+++ b/frontend/src/app/utils/device-pixel-ratio.ts
@@ -1,0 +1,42 @@
+/**
+ * Subscribe to changes in `window.devicePixelRatio`. Invokes `onChange`
+ * whenever the display density changes — most commonly when the window is
+ * dragged onto a different-density monitor, but also on browser zoom or an OS
+ * scaling change. A `ResizeObserver` does *not* catch this on its own: dragging
+ * to a Retina display leaves the element's CSS box unchanged, so nothing fires
+ * and the canvas keeps rendering at the stale `dpr` (and stale thumbnail-
+ * resolution tier) until the next actual resize.
+ *
+ * There is no dedicated "dpr changed" event, so we lean on the standard
+ * `matchMedia('(resolution: Ndppx)')` trick: a query pinned to the *current*
+ * dpr matches now and stops matching the instant dpr moves, firing a `change`
+ * event. Because the query is pinned to one value it is one-shot, so the
+ * handler re-establishes a fresh listener at the new dpr each time before
+ * invoking the callback — keeping it live across any number of density changes.
+ *
+ * Returns a teardown that removes the active listener; a no-op where matchMedia
+ * is unavailable (SSR, jsdom tests).
+ */
+export function onDevicePixelRatioChange(onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {};
+  }
+  let mql: MediaQueryList | null = null;
+  const handler = () => {
+    // Re-pin to the new dpr first so a rapid second change (e.g. dragging
+    // across three monitors) is still observed, then notify the caller.
+    subscribe();
+    onChange();
+  };
+  const subscribe = () => {
+    if (mql) mql.removeEventListener('change', handler);
+    const dpr = window.devicePixelRatio || 1;
+    mql = window.matchMedia(`(resolution: ${dpr}dppx)`);
+    mql.addEventListener('change', handler);
+  };
+  subscribe();
+  return () => {
+    if (mql) mql.removeEventListener('change', handler);
+    mql = null;
+  };
+}


### PR DESCRIPTION
## What

Fixes open follow-up #3 from the July 2026 comprehensive audit: a **pure `devicePixelRatio` change never re-ran the browse canvas `resize()`** (nor the minimap `resizeCanvas()`).

Dragging the window onto a different-density monitor (or a browser-zoom / OS-scaling change) leaves the element's CSS box unchanged, so the `ResizeObserver` stays quiet. The canvas keeps rendering its backing store — and picking its thumbnail-resolution tier — at the **stale** `dpr` until the next real CSS resize, leaving the projection blurry or over-sharp.

## How

There is no dedicated "dpr changed" event, so this uses the standard `matchMedia('(resolution: Ndppx)')` trick: a query pinned to the *current* dpr matches now and stops matching the instant dpr moves, firing a `change` event. Because that query is one-shot (pinned to one value), the handler re-pins a fresh listener at the new density each time before invoking the callback, keeping it live across any number of monitor hops.

- New `frontend/src/app/utils/device-pixel-ratio.ts` — `onDevicePixelRatioChange(cb)`, returning a teardown; a no-op where `matchMedia` is unavailable (SSR/jsdom), matching the shape of the existing `reduced-motion.ts` helper.
- `browse-canvas.component.ts` — subscribes in `ngOnInit` (runs `resize()` outside Angular), tears down in `ngOnDestroy`.
- `browse-minimap.component.ts` — subscribes in `ngOnInit` (runs `resizeCanvas()` + repaint), tears down in `ngOnDestroy`. Covers both the docked (`ResizeObserver`) and floating (width/height input) sizing paths, neither of which fires on a pure density change.
- New `device-pixel-ratio.spec.ts` — covers pinning to the current dpr, firing on change, re-subscribing so successive changes keep firing, teardown, and the no-`matchMedia` fallback.

Rendering-quality only — hit-testing is CSS-px based and was already correct.

## Testing

`./run-tests.sh frontend` passes: lint, pyright, TypeScript build, and the full Vitest suite (1022 passed, including the new spec).

Removes the now-shipped item #3 from `docs/plans/comprehensive-audit-2026-07.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019v36MgEmUGPVbSyDGHqexr)_