### PR TITLE
Fix root-zoom px mixing in panel-divider drags

### DIFF
--- a/docs/plans/comprehensive-audit-2026-07.md
+++ b/docs/plans/comprehensive-audit-2026-07.md
@@ -1,6 +1,6 @@
 # Comprehensive interface audit — July 2026
 
-**Status:** 5 open follow-ups remain from the audit (below).
+**Status:** 4 open follow-ups remain from the audit (below).
 
 Background: a full-codebase audit of interface boundaries (frontend ↔ API, route
 layer ↔ state system, app tier ↔ `vtscore`, IO, concurrency, frontend TS)
@@ -22,13 +22,7 @@ Ordered roughly by severity.
    pending toggle on view moves); the boundary-settle rAF loop can start while
    the zoom-transition loop still owns the canvas (both write
    `displayedTransform`; visible damage is a truncated transition).
-2. **Root-zoom px mixing in panel-divider drags**
-   (`browse-view.component.ts:onDividerMove`,
-   `label-view/panel-resize.directive.ts`): visual-px cursor deltas applied
-   as layout-px widths under `html { zoom: 1.1 }`, so the divider rides
-   ~10% away from the pointer. Shared app-wide wart; fix both sites together
-   (the eleventh pass fixed the same class of bug in the minimap).
-3. **Pure devicePixelRatio change never re-runs canvas `resize()`**
+2. **Pure devicePixelRatio change never re-runs canvas `resize()`**
    (browse-canvas + minimap): dragging the window to a different-density
    monitor leaves `dpr` (and the thumbnail-resolution tier) stale until the
    next CSS resize; rendering-quality only (hit-testing is CSS-px based).

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -15,6 +15,7 @@ import {
 } from './hex-render.util';
 import { binGeometry, BinGeometry } from './bin-geometry';
 import { prefersReducedMotion } from '../../utils/reduced-motion';
+import { readRootZoom } from '../../utils/root-zoom';
 import type {
   HexCellPayload,
   ProjectionMeta,
@@ -631,7 +632,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // avoid the canvas being visually double-scaled (once by html{zoom:N}, once by
     // the explicit style override), which would shift hit-test coordinates off the
     // cursor by the zoom factor.
-    const rootZoom = parseFloat(getComputedStyle(document.documentElement).zoom) || 1;
+    const rootZoom = readRootZoom();
     canvas.style.width = `${this.width / rootZoom}px`;
     canvas.style.height = `${this.height / rootZoom}px`;
     this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -11,6 +11,7 @@ import {
   type CanvasTheme,
 } from '../browse-canvas/hex-render.util';
 import { binGeometry } from '../browse-canvas/bin-geometry';
+import { readRootZoom } from '../../utils/root-zoom';
 import { IconComponent } from '../icon/icon.component';
 import type { HexCellPayload, ProjectionMeta } from '../../models/projection.models';
 
@@ -184,7 +185,7 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     // the element zoom× larger on screen — bake the zoom into the backing
     // store (as the main canvas effectively does via its visual-px sizing)
     // so the bitmap isn't undersampled/blurry.
-    const rootZoom = parseFloat(getComputedStyle(document.documentElement).zoom) || 1;
+    const rootZoom = readRootZoom();
     const scale = this.dpr * rootZoom;
     const canvas = this.canvasRef.nativeElement;
     canvas.width = Math.round(this.width * scale);
@@ -488,7 +489,7 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     // clientX/Y deltas are visual px but width/height are layout px, so
     // divide out the app-wide root zoom or the panel grows faster than the
     // cursor moves.
-    const rootZoom = parseFloat(getComputedStyle(document.documentElement).zoom) || 1;
+    const rootZoom = readRootZoom();
     const dw = (this.resizeStartX - event.clientX) / rootZoom;
     const dh = (this.resizeStartY - event.clientY) / rootZoom;
     this.width = Math.round(

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -37,6 +37,7 @@ import {
 } from '../browse-canvas/hex-render.util';
 import type { ProjectionMeta } from '../../models/projection.models';
 import { snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
+import { readRootZoom } from '../../utils/root-zoom';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
@@ -570,7 +571,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   /** Largest the side panel can grow to while leaving the canvas its minimum. */
   private panelMax(): number {
-    const layoutWidth = this.content?.nativeElement.getBoundingClientRect().width ?? 0;
+    // `getBoundingClientRect()` is visual px (scaled by `html{zoom}`); the panel
+    // width it bounds is layout px, so divide the zoom out to compare like units.
+    const layoutWidth = (this.content?.nativeElement.getBoundingClientRect().width ?? 0) / readRootZoom();
     const fit = layoutWidth - BrowseViewComponent.DIVIDER_WIDTH - BrowseViewComponent.CANVAS_MIN;
     return Math.min(BrowseViewComponent.PANEL_MAX, Math.max(this.panelMin(), fit));
   }
@@ -590,6 +593,12 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     const root = this.content?.nativeElement;
     if (!root) return BrowseViewComponent.PANEL_FLOOR;
     const current = this.panelWidth();
+    // `getBoundingClientRect()` widths are visual px (scaled by `html{zoom}`),
+    // whereas `panelWidth`, `clientWidth`, and computed-style lengths are all
+    // layout px. Divide the zoom out of the rect reads below so every term in
+    // these floor sums is layout px — otherwise the floor drifts with the zoom
+    // (a phantom scrollbar of ~(zoom-1)×width, etc.).
+    const zoom = readRootZoom();
 
     let oneColumn = BrowseViewComponent.PANEL_FLOOR;
     const list = root.querySelector('.bsp-list') as HTMLElement | null;
@@ -597,7 +606,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       const goal = parseFloat(getComputedStyle(list).getPropertyValue('--grid-goal-width')) || 80;
       const style = getComputedStyle(list);
       const padH = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
-      const bounding = list.getBoundingClientRect().width;
+      const bounding = list.getBoundingClientRect().width / zoom;
       const scrollbar = Math.max(0, bounding - list.clientWidth);
       // Chrome between the panel edge and the grid element (0 today, but measured
       // so any future wrapper padding is accounted for automatically).
@@ -613,10 +622,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       if (toolbar) {
         const tstyle = getComputedStyle(toolbar);
         const tpad = parseFloat(tstyle.paddingLeft) + parseFloat(tstyle.paddingRight);
-        const panelChrome = Math.max(0, current - toolbar.getBoundingClientRect().width);
+        const panelChrome = Math.max(0, current - toolbar.getBoundingClientRect().width / zoom);
         toolbarChromeH = tpad + panelChrome;
       }
-      sortRow = Math.ceil(sort.getBoundingClientRect().width + toolbarChromeH) + 1;
+      sortRow = Math.ceil(sort.getBoundingClientRect().width / zoom + toolbarChromeH) + 1;
     }
 
     return Math.max(BrowseViewComponent.PANEL_FLOOR, oneColumn, sortRow);
@@ -637,10 +646,16 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private onPanelMouseMove(event: MouseEvent): void {
     if (!this.dragging || !this.content) return;
     const rect = this.content.nativeElement.getBoundingClientRect();
+    // `clientX` and `rect` are visual px (scaled by the app-wide `html{zoom}`),
+    // but `panelWidth` is applied as a layout-px CSS var that the zoom re-scales,
+    // and the clamp bounds (`DIVIDER_WIDTH`/`CANVAS_MIN`/`PANEL_MAX`/`dragMin`)
+    // are layout px — so convert the visual-px container width and pointer delta
+    // to layout px, or the divider rides ~(zoom-1) off the cursor.
+    const zoom = readRootZoom();
     // The panel is on the right, so its width grows as the cursor moves left.
-    const fit = rect.width - BrowseViewComponent.DIVIDER_WIDTH - BrowseViewComponent.CANVAS_MIN;
+    const fit = rect.width / zoom - BrowseViewComponent.DIVIDER_WIDTH - BrowseViewComponent.CANVAS_MIN;
     const max = Math.min(BrowseViewComponent.PANEL_MAX, Math.max(this.dragMin, fit));
-    const width = this.clamp(rect.right - event.clientX, this.dragMin, max);
+    const width = this.clamp((rect.right - event.clientX) / zoom, this.dragMin, max);
     // `panelWidth` is a signal read in the template's `--browse-panel-width`
     // binding, so the `.set()` schedules CD on its own — no `ngZone.run`.
     this.panelWidth.set(width);

--- a/frontend/src/app/components/label-view/panel-resize.directive.ts
+++ b/frontend/src/app/components/label-view/panel-resize.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, HostBinding, HostListener, NgZone, OnDestroy, inject, input, output } from '@angular/core';
+import { readRootZoom } from '../../utils/root-zoom';
 
 /**
  * Handles a vertical-divider drag for a flanking panel inside `vt-label-view`.
@@ -71,8 +72,16 @@ export class PanelResizeDirective implements OnDestroy {
   /** Translate a pointer position into a clamped width for this side. */
   private computeWidth(event: MouseEvent): number {
     const rect = this.layoutEl().getBoundingClientRect();
-    const raw = this.side() === 'left' ? event.clientX - rect.left : rect.right - event.clientX;
-    const max = rect.width - this.dividerTotal() - this.centerMin() - this.opposingWidth();
+    // `clientX` and `rect` are visual px (scaled by the app-wide `html{zoom}`),
+    // but the emitted width is applied as a layout-px CSS value that the zoom
+    // re-scales — divide the visual-px pointer delta and the container width by
+    // the zoom so the divider tracks the cursor instead of riding ~(zoom-1) off.
+    // The clamp bounds (`minWidth`/`centerMin`/`opposingWidth`/`dividerTotal`)
+    // are already layout px, so they need no conversion.
+    const zoom = readRootZoom();
+    const rawVisual = this.side() === 'left' ? event.clientX - rect.left : rect.right - event.clientX;
+    const raw = rawVisual / zoom;
+    const max = rect.width / zoom - this.dividerTotal() - this.centerMin() - this.opposingWidth();
     return Math.max(this.minWidth(), Math.min(max, raw));
   }
 

--- a/frontend/src/app/utils/root-zoom.spec.ts
+++ b/frontend/src/app/utils/root-zoom.spec.ts
@@ -1,0 +1,48 @@
+import { readRootZoom } from './root-zoom';
+
+describe('readRootZoom', () => {
+  let original: typeof window.getComputedStyle;
+
+  function stubZoom(value: string): void {
+    (window as unknown as { getComputedStyle: (el: Element) => CSSStyleDeclaration }).getComputedStyle =
+      (el: Element) => {
+        if (el === document.documentElement) {
+          return { zoom: value } as unknown as CSSStyleDeclaration;
+        }
+        return original(el);
+      };
+  }
+
+  beforeEach(() => {
+    original = window.getComputedStyle;
+  });
+
+  afterEach(() => {
+    (window as unknown as { getComputedStyle: typeof window.getComputedStyle }).getComputedStyle = original;
+  });
+
+  it('reads a fractional zoom factor off the root element', () => {
+    stubZoom('1.1');
+    expect(readRootZoom()).toBeCloseTo(1.1, 5);
+  });
+
+  it('reads an integer zoom factor', () => {
+    stubZoom('2');
+    expect(readRootZoom()).toBe(2);
+  });
+
+  it('falls back to 1 when the computed zoom is the default "normal"', () => {
+    stubZoom('normal');
+    expect(readRootZoom()).toBe(1);
+  });
+
+  it('falls back to 1 when the computed zoom is empty', () => {
+    stubZoom('');
+    expect(readRootZoom()).toBe(1);
+  });
+
+  it('falls back to 1 for a zero computed zoom that would divide-by-zero downstream', () => {
+    stubZoom('0');
+    expect(readRootZoom()).toBe(1);
+  });
+});

--- a/frontend/src/app/utils/root-zoom.ts
+++ b/frontend/src/app/utils/root-zoom.ts
@@ -1,0 +1,22 @@
+/**
+ * The app applies an interface-scale factor as `html { zoom: <n> }`, which
+ * renders the whole page `n×` larger on screen without changing any layout-px
+ * value in CSS. That split is the source of a recurring class of bug: pointer
+ * coordinates (`MouseEvent.clientX/Y`) and `getBoundingClientRect()` boxes come
+ * back in *visual* px (already multiplied by the zoom), while CSS widths, canvas
+ * backing-store sizes, and other layout dimensions are in *layout* px (the
+ * pre-zoom unit). Mixing the two makes a dragged divider or resize handle ride
+ * ~`(zoom-1)` away from the pointer.
+ *
+ * `readRootZoom()` is the single place that reads the current factor so callers
+ * can convert between the two spaces (divide a visual-px delta by it to get
+ * layout px; multiply a layout-px size by it to get the on-screen size). Falls
+ * back to 1 where the value is unset, unparseable, or the DOM is unavailable
+ * (SSR, jsdom tests).
+ */
+export function readRootZoom(): number {
+  if (typeof document === 'undefined' || typeof getComputedStyle !== 'function') {
+    return 1;
+  }
+  return parseFloat(getComputedStyle(document.documentElement).zoom) || 1;
+}


### PR DESCRIPTION
## What

Under the app-wide `html { zoom: N }` interface scale, `MouseEvent.clientX/Y` and `getBoundingClientRect()` return **visual** px (already multiplied by the zoom), while CSS widths are **layout** px (the pre-zoom unit). The panel-divider drags mixed the two: they took a visual-px pointer delta and emitted it directly as a layout-px CSS width, which the zoom then re-scaled — so under `zoom: 1.1` the divider rode ~10% away from the pointer.

This was follow-up #2 from `docs/plans/comprehensive-audit-2026-07.md` ("the eleventh pass fixed the same class of bug in the minimap").

## Changes

- **`label-view/panel-resize.directive.ts`** (`computeWidth`): divide the visual-px pointer delta and container width by the root zoom so the emitted layout-px width tracks the cursor.
- **`browse-view.component.ts`** (`onPanelMouseMove`): same conversion for the right-side divider drag. Also fixed the coupled `panelMax()` clamp and the `panelMin()` floor sums, which mixed visual-px `getBoundingClientRect()` widths with layout-px `clientWidth`/`panelWidth`/computed-style values (a phantom `~(zoom-1)×width` scrollbar term, etc.).
- **New `utils/root-zoom.ts`**: extracts the repeated inline `parseFloat(getComputedStyle(document.documentElement).zoom) || 1` into a single `readRootZoom()` helper (with SSR/jsdom guards), and routes the existing `browse-canvas` and `browse-minimap` call sites through it.
- Added `utils/root-zoom.spec.ts`.

## Testing

`./run-tests.sh frontend` — build OK, 1022 Vitest tests pass.

Note: the visual behavior under a non-1 zoom can't be exercised in this session (no Chromium in the cloud container); the fix mirrors the already-shipped minimap correction and is covered by the unit test for the shared helper.

Resolves audit follow-up #2 in `docs/plans/comprehensive-audit-2026-07.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)