### PR TITLE
Throttle demo download progress

### DIFF
--- a/docs/plans/efficiency-wins.md
+++ b/docs/plans/efficiency-wins.md
@@ -62,26 +62,6 @@ canvas renderer, LSH near-dup detection, async jobs with signature caches.
   **Files touched:** `vtscore/datasets/loader.py`, `vtscore/datasets/loader_demo.py`.
   Impact: high. Complexity: trivial.
 
-- **Throttled download progress** — the demo downloader calls `on_progress`
-  once per 8 KB chunk (`vtscore/datasets/downloader/core.py:404-408`). Each
-  call goes `update_progress` → `ProgressTracker.update`
-  (`vtscore/concurrency/progress.py`), which takes a lock, copies the data
-  dict, and synchronously pushes an SSE frame. A 5 GB download (Food-101,
-  UCF101, Visual Genome) makes ~650k such calls — real CPU plus an SSE flood
-  that can throttle the transfer itself.
-  **Fix:** bump `iter_content(chunk_size=...)` to `1 << 20` (1 MB), and gate
-  the `on_progress` call on elapsed time (emit at most every ~200 ms via a
-  `time.monotonic()` check; always emit the final 100% call after the loop).
-  The tar/zip extract loops in the same file already gate on `i % 100` — this
-  brings the download loop in line.
-  **Gotchas:** keep the resume-from-Range logic intact (`downloaded` starts
-  nonzero on resume); the throttle must compare against `time.monotonic()`,
-  not call count, so slow links still update. Tests: `./run-tests.sh downloads`
-  (the download tests mock `iter_content`; check none assert per-chunk
-  progress counts).
-  **Files touched:** `vtscore/datasets/downloader/core.py`.
-  Impact: medium-high on big demos. Complexity: trivial.
-
 - **Array-native score conversion** — `_score_all_media`
   (`vtscore/detectors/training.py:469`) does
   `np.asarray(sigmoid_to_finite_scores(model(X_all)), dtype=np.float64)`.

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -414,9 +414,7 @@ def download_file_with_progress(  # noqa: C901
                     now = time.monotonic()
                     if now - last_emit >= 0.2:
                         last_emit = now
-                        on_progress(
-                            "downloading", f"Downloading {dest_path.name}...", downloaded, total_size
-                        )
+                        on_progress("downloading", f"Downloading {dest_path.name}...", downloaded, total_size)
             on_progress("downloading", f"Downloading {dest_path.name}...", downloaded, total_size)
             return  # stream consumed cleanly
         except _RETRYABLE_EXCEPTIONS:

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -402,10 +402,22 @@ def download_file_with_progress(  # noqa: C901
                 total_size = _total_size_from_headers(response, downloaded, expected_size)
 
             mode = "ab" if downloaded else "wb"
+            # Emit progress at most every ~200 ms rather than once per chunk: a
+            # multi-GB download makes hundreds of thousands of chunk writes, and
+            # a per-chunk SSE push is real CPU that can throttle the transfer.
+            # Throttle on wall-clock (time.monotonic), not chunk count, so slow
+            # links still update; always emit a final 100% call after the loop.
+            last_emit = time.monotonic()
             with open(dest_path, mode) as f:
-                for chunk in response.iter_content(chunk_size=8192):
+                for chunk in response.iter_content(chunk_size=1 << 20):
                     downloaded += f.write(chunk)
-                    on_progress("downloading", f"Downloading {dest_path.name}...", downloaded, total_size)
+                    now = time.monotonic()
+                    if now - last_emit >= 0.2:
+                        last_emit = now
+                        on_progress(
+                            "downloading", f"Downloading {dest_path.name}...", downloaded, total_size
+                        )
+            on_progress("downloading", f"Downloading {dest_path.name}...", downloaded, total_size)
             return  # stream consumed cleanly
         except _RETRYABLE_EXCEPTIONS:
             if last_attempt:


### PR DESCRIPTION
## Summary

Fixes the **Throttled download progress** item from `docs/plans/efficiency-wins.md`.

The demo downloader (`download_file_with_progress`) called `on_progress` once per 8 KB chunk. Each call goes `update_progress` → `ProgressTracker.update`, which takes a lock, copies the data dict, and synchronously pushes an SSE frame. A multi-GB download (Food-101, UCF101, Visual Genome) makes hundreds of thousands of such calls — real CPU plus an SSE flood that can throttle the transfer itself.

## Changes

- Bump `iter_content(chunk_size=...)` from 8 KB to `1 << 20` (1 MB).
- Gate `on_progress` on wall-clock time via `time.monotonic()` — emit at most every ~200 ms instead of once per chunk. Throttling on elapsed time (not chunk count) means slow links still update.
- Always emit a final 100% progress call after the loop so completion is guaranteed to be reported even when the last interval was under 200 ms.

The resume-from-Range logic is untouched: `total_size` is still resolved before the loop, so every emit (including the final one) carries the true total; the resume-restart accounting is unchanged.

## Testing

- `./run-tests.sh downloads` — 197 passed. The resume tests exercise `iter_content` on small payloads that complete near-instantly; the post-loop final emit guarantees at least one progress call carrying the true total, so `test_resumes_after_connection_drop`'s "progress always reported the true total" assertion still holds.

Refs `docs/plans/efficiency-wins.md` (item pruned in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01899sB6xK5H9YZBCsShLpAm

---
_Generated by [Claude Code](https://claude.ai/code/session_01899sB6xK5H9YZBCsShLpAm)_