### PR TITLE
Array-native score conversion in _score_all_media

### DIFF
--- a/docs/plans/efficiency-wins.md
+++ b/docs/plans/efficiency-wins.md
@@ -41,34 +41,6 @@ canvas renderer, LSH near-dup detection, async jobs with signature caches.
 
 <!-- item-sep -->
 
-- **Array-native score conversion** — `_score_all_media`
-  (`vtscore/detectors/training.py:469`) does
-  `np.asarray(sigmoid_to_finite_scores(model(X_all)), dtype=np.float64)`.
-  `sigmoid_to_finite_scores` (`vtscore/utils/scores.py:34-58`) ends in
-  `.cpu().tolist()` — so every retrain materializes a Python list of R floats
-  (R = flattened (media, region) rows; large on patch datasets) and immediately
-  re-parses it into numpy. That's a pure-Python, GIL-holding O(R) pass in the
-  background training thread, which competes with request handlers (the
-  `_segmented_max_pool` docstring in the same file explains why GIL stalls
-  there matter).
-  **Fix:** add `sigmoid_to_finite_array(logits, *, default=...) -> np.ndarray`
-  next to the list version in `vtscore/utils/scores.py`: same
-  `torch.sigmoid(...).squeeze(-1)` + `torch.nan_to_num`, but ending in
-  `.cpu().numpy()` (then `.astype(np.float64, copy=False)` at the call site if
-  the downstream math wants float64 — check what `_segmented_max_pool` and the
-  threshold code actually need; float32 may be fine end-to-end, in which case
-  skip the upcast). Route `_score_all_media` through it. Leave the list version
-  for JSON-response call sites (grep `sigmoid_to_finite_scores` for the
-  others — the grouped-fold calibration in `thresholds.py:373` runs on small
-  splits and can keep the list form).
-  **Gotchas:** the returned array must be writable/owned if anything mutates it
-  (`.numpy()` on a CPU tensor shares memory with the tensor — if the tensor is
-  a temporary this is fine, but add `np.ascontiguousarray`/`.copy()` only if a
-  test proves mutation happens; don't copy blindly). Tests:
-  `./run-tests.sh detectors sorting`.
-  **Files touched:** `vtscore/utils/scores.py`, `vtscore/detectors/training.py`.
-  Impact: medium (large patch datasets). Complexity: trivial.
-
 ## Tier 2 — high impact, needs care
 
 <!-- item-sep -->

--- a/tests_lib/detectors/test_score_sanitization.py
+++ b/tests_lib/detectors/test_score_sanitization.py
@@ -22,6 +22,7 @@ import torch.nn as nn
 from vtscore.utils.scores import (
     NON_FINITE_SCORE_SENTINEL,
     finite_or,
+    sigmoid_to_finite_array,
     sigmoid_to_finite_scores,
 )
 
@@ -80,6 +81,55 @@ class TestSigmoidToFiniteScores:
         assert scores[0] == pytest.approx(0.5, abs=1e-3)
         assert scores[1] == NON_FINITE_SCORE_SENTINEL
         assert math.isfinite(scores[2])
+
+
+class TestSigmoidToFiniteArray:
+    """Array-native twin of the list helper; same sanitisation, ``np.ndarray``."""
+
+    def test_finite_logits_round_trip(self):
+        logits = torch.tensor([[-2.0], [0.0], [2.0]])
+        arr = sigmoid_to_finite_array(logits)
+        assert isinstance(arr, np.ndarray)
+        assert arr.shape == (3,)
+        assert arr == pytest.approx([0.1192, 0.5, 0.8808], abs=1e-3)
+        assert np.all(np.isfinite(arr))
+
+    def test_nan_logits_replaced_with_sentinel(self):
+        logits = torch.tensor([[float("nan")], [1.0], [float("nan")]])
+        arr = sigmoid_to_finite_array(logits)
+        assert arr[0] == NON_FINITE_SCORE_SENTINEL
+        assert arr[2] == NON_FINITE_SCORE_SENTINEL
+        assert arr[1] == pytest.approx(0.7311, abs=1e-3)
+        assert np.all(np.isfinite(arr))
+
+    def test_inf_logits_produce_finite_scores(self):
+        arr = sigmoid_to_finite_array(torch.tensor([[float("inf")], [float("-inf")]]))
+        assert np.all(np.isfinite(arr))
+
+    def test_custom_default(self):
+        arr = sigmoid_to_finite_array(torch.tensor([[float("nan")]]), default=0.5)
+        assert arr[0] == 0.5
+
+    def test_unsqueezed_input_handled(self):
+        arr = sigmoid_to_finite_array(torch.tensor([0.0, float("nan"), 2.0]))
+        assert arr[0] == pytest.approx(0.5, abs=1e-3)
+        assert arr[1] == NON_FINITE_SCORE_SENTINEL
+        assert np.all(np.isfinite(arr))
+
+    def test_matches_list_helper(self):
+        # The array and list helpers must agree element-for-element so the
+        # hot path swap is behaviour-preserving.
+        logits = torch.tensor([[-3.0], [float("nan")], [0.5], [float("inf")]])
+        arr = sigmoid_to_finite_array(logits)
+        lst = sigmoid_to_finite_scores(logits)
+        assert arr.tolist() == pytest.approx(lst)
+
+    def test_returned_array_is_writable(self):
+        # ``.numpy()`` can alias the source tensor; downstream max-pool never
+        # mutates, but the array must be safe to write if a caller ever does.
+        arr = sigmoid_to_finite_array(torch.tensor([[0.0], [1.0]]))
+        assert arr.flags.writeable
+        arr[0] = 42.0  # must not raise
 
 
 class _NaNProducingModel(nn.Module):

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from vtscore.utils.scores import sigmoid_to_finite_scores
+from vtscore.utils.scores import sigmoid_to_finite_array, sigmoid_to_finite_scores
 
 if TYPE_CHECKING:
     import torch.nn as nn
@@ -466,7 +466,7 @@ def _score_all_media(
         # leak non-finite floats into the JSON response. The downstream
         # segmented max-pool then incidentally drops sentinels in favour of
         # any real score (in ``[0, 1]``) for the same media.
-        flat_scores = np.asarray(sigmoid_to_finite_scores(model(X_all)), dtype=np.float64)
+        flat_scores = sigmoid_to_finite_array(model(X_all)).astype(np.float64, copy=False)
 
     scores, best_region = _segmented_max_pool(flat_scores, media_index_per_row, region_index_per_row, len(all_ids))
     return all_ids, scores, best_region

--- a/vtscore/utils/scores.py
+++ b/vtscore/utils/scores.py
@@ -26,6 +26,7 @@ import math
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import numpy as np
     import torch
 
 NON_FINITE_SCORE_SENTINEL: float = -1.0
@@ -56,6 +57,38 @@ def sigmoid_to_finite_scores(
     scores = torch.sigmoid(logits).squeeze(-1)
     scores = torch.nan_to_num(scores, nan=default, posinf=default, neginf=default)
     return scores.cpu().tolist()
+
+
+def sigmoid_to_finite_array(
+    logits: torch.Tensor,
+    *,
+    default: float = NON_FINITE_SCORE_SENTINEL,
+) -> np.ndarray:
+    """Apply sigmoid to *logits* and return a JSON-safe ``np.ndarray``.
+
+    Array-native twin of :func:`sigmoid_to_finite_scores`: same squeeze /
+    sigmoid / ``nan_to_num`` sanitisation, but ends in ``.cpu().numpy()``
+    instead of ``.tolist()``. Use this at sites whose output feeds straight
+    into numpy math (e.g. segmented max-pool) so the scores never make a
+    round-trip through a Python list, which is a pure-Python, GIL-holding
+    ``O(N)`` pass that matters in the background training thread.
+
+    Args:
+        logits: Raw MLP output, shape ``(N, 1)`` or ``(N,)``.
+        default: Sentinel substituted for ``NaN`` / ``+Inf`` / ``-Inf``.
+            Defaults to :data:`NON_FINITE_SCORE_SENTINEL`.
+
+    Returns:
+        A freshly-owned ``np.ndarray`` (the returned array does not alias any
+        live tensor), every element guaranteed ``math.isfinite``. Dtype
+        follows the input tensor (typically ``float32``); upcast at the call
+        site if the downstream math wants ``float64``.
+    """
+    import torch  # noqa: PLC0415
+
+    scores = torch.sigmoid(logits).squeeze(-1)
+    scores = torch.nan_to_num(scores, nan=default, posinf=default, neginf=default)
+    return scores.cpu().numpy()
 
 
 def finite_or(value: float, default: float = NON_FINITE_SCORE_SENTINEL) -> float:


### PR DESCRIPTION
## What & why

`_score_all_media` (`vtscore/detectors/training.py`) — on the hot vote→retrain
scoring path — did:

```python
flat_scores = np.asarray(sigmoid_to_finite_scores(model(X_all)), dtype=np.float64)
```

`sigmoid_to_finite_scores` ends in `.cpu().tolist()`, so every retrain
materialized a Python list of **R** floats (R = flattened `(media, region)`
rows, large on patch datasets) only to immediately re-parse it back into numpy.
That's a pure-Python, GIL-holding `O(R)` pass running in the **background
training thread**, which competes with the `gthread` request handlers serving
the next vote — exactly the kind of stall the neighboring `_segmented_max_pool`
docstring calls out.

## Change

- Add `sigmoid_to_finite_array(logits, *, default=...) -> np.ndarray` next to
  the list version in `vtscore/utils/scores.py`: identical
  `sigmoid` → `squeeze(-1)` → `nan_to_num` sanitisation, but ending in
  `.cpu().numpy()` instead of `.tolist()`. The returned array is freshly owned
  and writable.
- Route `_score_all_media` through it, upcasting once at the call site
  (`.astype(np.float64, copy=False)`) to keep the downstream `float64` behaviour
  byte-identical. The `.astype` from the `float32` tensor produces an owned copy,
  so there's no aliasing of any live tensor.
- Leave `sigmoid_to_finite_scores` in place for the JSON-response call sites and
  the small-split grouped-fold calibration in `thresholds.py`.

## Tests

- New `TestSigmoidToFiniteArray` in
  `tests_lib/detectors/test_score_sanitization.py` mirrors the list helper's
  invariants (finite round-trip, NaN/±Inf → sentinel, custom default,
  unsqueezed input), asserts element-for-element agreement with the list helper,
  and checks the returned array is writable.
- `./run-tests.sh detectors sorting` and the full `./run-tests.sh` suite pass
  (5573 passed).

Part of `docs/plans/efficiency-wins.md` (Tier 1); the shipped item is pruned
from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011zA16uEWRoN9KaKibA2Sbe)_