### PR TITLE
Virtualize the right-panel label piles above 80 items

### DIFF
--- a/docs/plans/efficiency-wins.md
+++ b/docs/plans/efficiency-wins.md
@@ -187,38 +187,6 @@ canvas renderer, LSH near-dup detection, async jobs with signature caches.
   `vtsearch/routes/media/list.py` (ETag), maybe a tiny peaks-cache service.
   Impact: high for audio-heavy voting. Complexity: medium.
 
-<!-- item-sep -->
-
-- **Virtualized label piles** — the right-panel Good/Bad piles render **every**
-  labeled item as DOM with a plain `@for`
-  (`frontend/src/app/components/right-panel/label-list/label-list.component.html:14`,
-  `labelset-list/labelset-list.component.html:6`), each row with an `<img>`.
-  Every vote and every 1.5 s labelset poll re-runs the loop over the full
-  pile. The left grid virtualizes above 80 items for exactly this reason
-  (`media-list.component.ts:20`, `GRID_VIRTUAL_THRESHOLD = 80`, with a comment
-  citing a ~1.8 s freeze).
-  **Fix:** wrap both lists in `cdk-virtual-scroll-viewport` +
-  `*cdkVirtualFor` above a threshold (copy the left grid's hybrid pattern:
-  plain `@for` under the threshold so small piles keep natural height).
-  While in there, fix the template-getter churn: `hasThumbnailUrl()` /
-  `thumbnailUrl()` / `placeholderIcon()` are called 3-4× per row per
-  change-detection cycle (`label-list.component.ts:148-184`, identical copies
-  in `labelset-list.component.ts:78-113` — including a
-  `region_box.map(v => v.toFixed(4)).join(',')` string build per call).
-  Precompute `thumbnailUrl`, `hasThumbnail`, `placeholderIcon` onto each entry
-  inside `buildSortedEntries()` / `buildSorted()` (where sorting already
-  happens) and bind the stored fields.
-  **Gotchas:** fixed `itemSize` is required by CDK — measure the current row
-  height (thumbnail rows vs text rows may differ; if heights vary use
-  `autosize` from `@angular/cdk-experimental` — no, don't add a dep: make row
-  height uniform instead, it's a simple list). Keep `track` on entry id.
-  Desktop-only per CLAUDE.md — no responsive concerns. Frontend gate:
-  `./run-tests.sh frontend`; watch the `anyComponentStyle` budget (shared
-  styles go in `_components.scss` if a component sheet grows).
-  **Files touched:** `label-list.component.{ts,html,scss}`,
-  `labelset-list.component.{ts,html,scss}`, possibly `right-panel.component.html`.
-  Impact: medium-high for large labelsets. Complexity: medium.
-
 ## Tier 3 — worthwhile, more design judgment needed
 
 <!-- item-sep -->

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -10,29 +10,12 @@
     </div>
     <ng-content select="[list-actions]"></ng-content>
   </div>
-  <div class="vote-list" [style.--grid-goal-width]="gridGoalWidth() + 'px'">
-    @for (entry of sortedEntries(); track trackById($index, entry)) {
-      <div
-        class="vote-entry"
-        [class.vote-entry-missing]="isMissing(entry.id)"
-        [attr.title]="isMissing(entry.id) ? entry.name + ' (not in the current dataset)' : null"
-        role="button"
-        tabindex="0"
-        [attr.aria-label]="(label === 'good' ? 'Good' : 'Bad') + ': ' + entry.name + (isMissing(entry.id) ? ' (not in current dataset)' : '')"
-        (click)="onEntryClick(entry.id)"
-        (contextmenu)="onEntryContextMenu($event, entry.id)"
-        (mouseenter)="onEntryMouseEnter(entry.id)"
-        (keydown)="onEntryKeydown($event, entry.id)"
-      >
-        @if (hasThumbnailUrl(entry.id)) {
-          <span class="vote-thumbnail-wrap">
-            <img class="vote-thumbnail" [src]="thumbnailUrl(entry.id)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(thumbnailUrl(entry.id))" />
-          </span>
-        } @else if (placeholderIcon(entry.id)) {
-          <span class="vote-placeholder">{{ placeholderIcon(entry.id) }}</span>
-        }
-        <span class="vote-name-grid">{{ entry.name }}</span>
-      </div>
-    }
-  </div>
+  <vt-vote-grid
+    [entries]="sortedEntries()"
+    [label]="label"
+    [gridGoalWidth]="gridGoalWidth()"
+    [focusMode]="focusMode()"
+    (entrySelected)="onEntrySelected($event)"
+    (entryVote)="onEntryVote($event)"
+  />
 </div>

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -5,6 +5,8 @@
   flex-direction: column;
 }
 
+// Cell/grid styles live in vote-grid.component.scss; this sheet only styles
+// the section chrome (heading chip, folded note, action cluster slot).
 .vote-section {
   flex: 1;
   min-height: 0;
@@ -56,103 +58,4 @@ h3 {
 
   &.good { color: var(--color-good); }
   &.bad  { color: var(--color-bad); }
-}
-
-.vote-list {
-  overflow-y: auto;
-  scrollbar-gutter: stable;
-  flex: 1;
-  min-height: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, var(--grid-goal-width, 80px));
-  gap: var(--space-xs);
-  align-content: start;
-  justify-content: end;
-}
-
-.vote-entry {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: var(--space-xs);
-  gap: var(--space-2xs);
-  border-radius: var(--radius-sm);
-  font-size: var(--font-sm);
-  cursor: pointer;
-  color: var(--text-vote);
-  line-height: 1.3;
-  // Query container so the name can hide itself at small icon sizes (below).
-  container-type: inline-size;
-  container-name: vote-cell;
-
-  &:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-    border-radius: var(--radius-sm);
-  }
-}
-
-.vote-entry-missing {
-  outline: 1px solid var(--missing-border);
-  outline-offset: -1px;
-  border-radius: var(--radius-sm);
-}
-
-.vote-thumbnail-wrap {
-  display: block;
-  width: 100%;
-  height: auto;
-  aspect-ratio: 1;
-  min-height: 0;
-  border-radius: var(--radius-sm);
-  flex-shrink: 0;
-  overflow: hidden;
-}
-
-.vote-thumbnail {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  border-radius: var(--radius-sm);
-  background: var(--bg-surface);
-  display: block;
-}
-
-.vote-placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  aspect-ratio: 1;
-  border-radius: var(--radius-sm);
-  background: var(--bg-surface);
-  color: var(--text-muted);
-  font-size: var(--font-3xl);
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.vote-name-grid {
-  font-size: var(--font-2xs);
-  color: var(--text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-  text-align: center;
-  line-height: 1.2;
-  flex-shrink: 0;
-}
-
-// At the two smallest icon sizes (XS/S, ~42px content-box) the name truncates to
-// a useless "a…", so hide it and let the grid pack tighter. M and up keep it.
-@container vote-cell (max-width: 60px) {
-  .vote-name-grid {
-    display: none;
-  }
 }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.spec.ts
@@ -123,62 +123,59 @@ describe('LabelListComponent', () => {
     });
   });
 
-  describe('view modes and thumbnails', () => {
+  describe('precomputed entry display fields', () => {
+    // Entries carry their thumbnail URL / fallback icon precomputed by
+    // buildSortedEntries() (the template binds stored fields; there are no
+    // per-change-detection getters anymore).
     beforeEach(async () => {
-      // setInput builds the media-id → media lookup map (in ngOnChanges) so
-      // thumbnailUrl()/hasThumbnailUrl() resolve.
-      await setInputs({ medias: sampleMedias });
+      await setInputs({ ids: [1, 2, 3], medias: sampleMedias });
     });
 
-    it('should have thumbnail URL for images', () => {
-      expect(component.hasThumbnailUrl(2)).toBe(true);
+    function entryById(id: number) {
+      const entry = component.sortedEntries().find((e) => e.id === id);
+      if (!entry) throw new Error(`no entry for id ${id}`);
+      return entry;
+    }
+
+    it('should precompute thumbnail URLs for audio/image/video', () => {
+      expect(entryById(1).thumbnailUrl).toBe('/api/medias/1/thumbnail');
+      expect(entryById(2).thumbnailUrl).toBe('/api/medias/2/thumbnail');
+      expect(entryById(3).thumbnailUrl).toBe('/api/medias/3/thumbnail');
     });
 
-    it('should have thumbnail URL for videos', () => {
-      expect(component.hasThumbnailUrl(3)).toBe(true);
+    it('should fold a region box into the thumbnail URL', async () => {
+      await setInputs({ regionBoxes: { '2': [0, 0.25, 0.5, 1] } });
+      expect(entryById(2).thumbnailUrl).toBe('/api/medias/2/thumbnail?region=0.0000,0.2500,0.5000,1.0000');
+      expect(entryById(1).thumbnailUrl).toBe('/api/medias/1/thumbnail');
     });
 
-    it('should have thumbnail URL for audio', () => {
-      expect(component.hasThumbnailUrl(1)).toBe(true);
+    it('should keep a media-type fallback icon for failed thumbnails', () => {
+      expect(entryById(1).fallbackIcon).toBe('♫');
+      expect(entryById(2).fallbackIcon).toBe('□');
     });
 
-    it('should generate correct thumbnail URLs', () => {
-      expect(component.thumbnailUrl(1)).toBe('/api/medias/1/thumbnail');
-      expect(component.thumbnailUrl(2)).toBe('/api/medias/2/thumbnail');
-      expect(component.thumbnailUrl(3)).toBe('/api/medias/3/thumbnail');
-    });
-
-    it('should not show placeholder icon for audio (has thumbnail)', () => {
-      expect(component.placeholderIcon(1)).toBeNull();
-    });
-
-    it('should not show placeholder icon for image (has thumbnail)', () => {
-      expect(component.placeholderIcon(2)).toBeNull();
+    it('should mark ids without a media as missing with no thumbnail or icon', async () => {
+      await setInputs({ ids: [999] });
+      const entry = component.sortedEntries()[0];
+      expect(entry.thumbnailUrl).toBe('');
+      expect(entry.fallbackIcon).toBeNull();
+      expect(entry.missing).toBe(true);
     });
   });
 
-  it('should emit mediaSelected on entry click', () => {
+  it('should emit mediaSelected with a numeric id on grid selection', () => {
     vi.spyOn(component.mediaSelected, 'emit');
-    component.onEntryClick(42);
+    component.onEntrySelected({ key: '42', name: 'x', thumbnailUrl: '', fallbackIcon: null, missing: false });
     expect(component.mediaSelected.emit).toHaveBeenCalledWith(42);
   });
 
-  it('should emit mediaSelected on Enter keydown', () => {
-    vi.spyOn(component.mediaSelected, 'emit');
-    component.onEntryKeydown(new KeyboardEvent('keydown', { key: 'Enter' }), 42);
-    expect(component.mediaSelected.emit).toHaveBeenCalledWith(42);
-  });
-
-  it('should emit mediaSelected on Space keydown', () => {
-    vi.spyOn(component.mediaSelected, 'emit');
-    component.onEntryKeydown(new KeyboardEvent('keydown', { key: ' ' }), 42);
-    expect(component.mediaSelected.emit).toHaveBeenCalledWith(42);
-  });
-
-  it('should not emit on other key', () => {
-    vi.spyOn(component.mediaSelected, 'emit');
-    component.onEntryKeydown(new KeyboardEvent('keydown', { key: 'a' }), 42);
-    expect(component.mediaSelected.emit).not.toHaveBeenCalled();
+  it('should forward grid votes with a numeric id', () => {
+    vi.spyOn(component.mediaVote, 'emit');
+    component.onEntryVote({
+      entry: { key: '42', name: 'x', thumbnailUrl: '', fallbackIcon: null, missing: false },
+      vote: 'good',
+    });
+    expect(component.mediaVote.emit).toHaveBeenCalledWith({ id: 42, vote: 'good' });
   });
 
   it('should use filename for entry name', async () => {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -6,10 +6,10 @@ import { Media } from '../../../models/api.models';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
+import { THUMBNAIL_MEDIA_TYPES, VoteGridComponent, VoteGridEntry } from '../vote-grid/vote-grid.component';
 
-export interface LabelEntry {
+export interface LabelEntry extends VoteGridEntry {
   id: number;
-  name: string;
   time: number;
   score: number;
   confidence: number;
@@ -19,7 +19,7 @@ export interface LabelEntry {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-label-list',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, VoteGridComponent],
   templateUrl: './label-list.component.html',
   styleUrl: './label-list.component.scss',
 })
@@ -111,7 +111,41 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
     if (score >= 0) {
       confidence = this.label === 'good' ? score : 1 - score;
     }
-    return { id, name, time, score, confidence };
+    return {
+      id,
+      key: String(id),
+      name,
+      time,
+      score,
+      confidence,
+      thumbnailUrl: this.buildThumbnailUrl(media, id),
+      fallbackIcon: this.buildFallbackIcon(media),
+      missing: !this.mediaMap.has(id),
+    };
+  }
+
+  private buildThumbnailUrl(media: Media | undefined, id: number): string {
+    if (!media || !THUMBNAIL_MEDIA_TYPES.has(media.media_type)) return '';
+    // Downscaled tile, not the full-resolution ``/image``: the labeled set can
+    // hold hundreds of items, and decoding every full-size bitmap at once
+    // exhausts browser memory.
+    let url = this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
+    // A region-voted item shows a thumbnail of just the voted crop. The box
+    // coordinates ride in the query string so a re-vote with a different box
+    // is a distinct URL (and cache entry) rather than a stale tile.
+    const box = this.regionBoxes()[String(id)];
+    if (box && box.length === 4) {
+      const sep = url.includes('?') ? '&' : '?';
+      url += `${sep}region=${box.map((v) => v.toFixed(4)).join(',')}`;
+    }
+    return url;
+  }
+
+  private buildFallbackIcon(media: Media | undefined): string | null {
+    if (!media) return null;
+    if (media.media_type === 'audio') return '♫';
+    if (media.media_type === 'text') return '¶';
+    return '□';
   }
 
   private sortEntries(entries: LabelEntry[]): LabelEntry[] {
@@ -143,79 +177,11 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
     return sorted;
   }
 
-  private thumbnailFailedUrls = new Set<string>();
-
-  hasThumbnailUrl(id: number): boolean {
-    const url = this.thumbnailUrl(id);
-    if (url && this.thumbnailFailedUrls.has(url)) return false;
-    const media = this.lookup(id);
-    return !!media && (media.media_type === 'image' || media.media_type === 'video' || media.media_type === 'document' || media.media_type === 'audio');
+  onEntrySelected(entry: VoteGridEntry): void {
+    this.mediaSelected.emit(Number(entry.key));
   }
 
-  thumbnailUrl(id: number): string {
-    const media = this.lookup(id);
-    if (!media) return '';
-    // Downscaled tile, not the full-resolution ``/image``: the labeled set can
-    // hold hundreds of items, and decoding every full-size bitmap at once
-    // exhausts browser memory.
-    let url = this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
-    // A region-voted item shows a thumbnail of just the voted crop. The box
-    // coordinates ride in the query string so a re-vote with a different box
-    // is a distinct URL (and cache entry) rather than a stale tile.
-    const box = this.regionBoxes()[String(id)];
-    if (box && box.length === 4) {
-      const sep = url.includes('?') ? '&' : '?';
-      url += `${sep}region=${box.map((v) => v.toFixed(4)).join(',')}`;
-    }
-    return url;
-  }
-
-  onThumbnailError(url: string): void {
-    if (url) this.thumbnailFailedUrls.add(url);
-  }
-
-  placeholderIcon(id: number): string | null {
-    if (this.hasThumbnailUrl(id)) return null;
-    const media = this.lookup(id);
-    if (!media) return null;
-    if (media.media_type === 'audio') return '\u266B';
-    if (media.media_type === 'text') return '\u00B6';
-    return '\u25A1';
-  }
-
-  isMissing(id: number): boolean {
-    return !this.mediaMap.has(id);
-  }
-
-  onEntryClick(id: number): void {
-    if (this.focusMode() === 'hover') {
-      this.mediaVote.emit({ id, vote: 'bad' });
-    } else {
-      this.mediaSelected.emit(id);
-    }
-  }
-
-  onEntryContextMenu(event: MouseEvent, id: number): void {
-    if (this.focusMode() === 'hover') {
-      event.preventDefault();
-      this.mediaVote.emit({ id, vote: 'good' });
-    }
-  }
-
-  onEntryMouseEnter(id: number): void {
-    if (this.focusMode() === 'hover') {
-      this.mediaSelected.emit(id);
-    }
-  }
-
-  onEntryKeydown(event: KeyboardEvent, id: number): void {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      this.mediaSelected.emit(id);
-    }
-  }
-
-  trackById(_index: number, entry: LabelEntry): number {
-    return entry.id;
+  onEntryVote(event: { entry: VoteGridEntry; vote: 'good' | 'bad' }): void {
+    this.mediaVote.emit({ id: Number(event.entry.key), vote: event.vote });
   }
 }

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
@@ -2,29 +2,12 @@
   <h3 [class]="label()" [title]="label() === 'good' ? 'Items you have marked as positive examples (' + elements().length + ')' : 'Items you have marked as negative examples (' + elements().length + ')'">
     {{ label() === 'good' ? 'Goods' : 'Bads' }} ({{ elements().length | number }})
   </h3>
-  <div class="vote-list" [style.--grid-goal-width]="gridGoalWidth() + 'px'">
-    @for (entry of sortedEntries; track trackById($index, entry)) {
-      <div
-        class="vote-entry"
-        [class.vote-entry-missing]="isMissing(entry)"
-        [attr.title]="isMissing(entry) ? entry.name + ' (not in the current dataset)' : null"
-        role="button"
-        tabindex="0"
-        [attr.aria-label]="(label() === 'good' ? 'Good' : 'Bad') + ': ' + entry.name + (isMissing(entry) ? ' (not in current dataset)' : '')"
-        (click)="onEntryClick(entry)"
-        (contextmenu)="onEntryContextMenu($event, entry)"
-        (mouseenter)="onEntryMouseEnter(entry)"
-        (keydown)="onEntryKeydown($event, entry)"
-      >
-        @if (hasThumbnailUrl(entry)) {
-          <span class="vote-thumbnail-wrap">
-            <img class="vote-thumbnail" [src]="thumbnailUrl(entry)" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(thumbnailUrl(entry))" />
-          </span>
-        } @else if (placeholderIcon(entry)) {
-          <span class="vote-placeholder">{{ placeholderIcon(entry) }}</span>
-        }
-        <span class="vote-name-grid">{{ entry.name }}</span>
-      </div>
-    }
-  </div>
+  <vt-vote-grid
+    [entries]="sortedEntries"
+    [label]="label()"
+    [gridGoalWidth]="gridGoalWidth()"
+    [focusMode]="focusMode()"
+    (entrySelected)="onEntrySelected($event)"
+    (entryVote)="onEntryVote($event)"
+  />
 </div>

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -3,8 +3,9 @@ import { CommonModule } from '@angular/common';
 import type { DetectorLabelView } from '../../../generated/api-client/models/detector-label-view';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
+import { THUMBNAIL_MEDIA_TYPES, VoteGridComponent, VoteGridEntry } from '../vote-grid/vote-grid.component';
 
-interface SortedElement extends DetectorLabelView {
+interface SortedElement extends DetectorLabelView, VoteGridEntry {
   confidence: number;
 }
 
@@ -12,7 +13,7 @@ interface SortedElement extends DetectorLabelView {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-labelset-list',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, VoteGridComponent],
   templateUrl: './labelset-list.component.html',
   styleUrls: ['../label-list/label-list.component.scss'],
 })
@@ -32,7 +33,6 @@ export class LabelsetListComponent implements OnChanges {
 }>();
 
   sortedEntries: SortedElement[] = [];
-  private thumbnailFailedUrls = new Set<string>();
 
   ngOnChanges(_changes: SimpleChanges): void {
     this.sortedEntries = this.buildSorted();
@@ -41,9 +41,28 @@ export class LabelsetListComponent implements OnChanges {
   private buildSorted(): SortedElement[] {
     const entries: SortedElement[] = this.elements().map((e) => ({
       ...e,
+      key: e.id,
       confidence: e.score >= 0 ? (this.label() === 'good' ? e.score : 1 - e.score) : -1,
+      thumbnailUrl: this.buildThumbnailUrl(e),
+      fallbackIcon: e.media_type === 'audio' ? '♫' : e.media_type === 'text' ? '¶' : '□',
+      missing: e.cid === null || e.cid === undefined,
     }));
     return this.sortEntries(entries);
+  }
+
+  private buildThumbnailUrl(entry: DetectorLabelView): string {
+    const modelName = this.modelName();
+    if (!modelName || !THUMBNAIL_MEDIA_TYPES.has(entry.media_type)) return '';
+    let url = this.detectorsCrudApi.labelThumbnailUrl(modelName, entry.id);
+    // The route crops to the element's stored region box server-side; fold the
+    // box into the URL so a re-vote with a different box busts the cached tile
+    // (the box coords aren't otherwise part of the URL).
+    const box = entry.region_box;
+    if (box && box.length === 4) {
+      const sep = url.includes('?') ? '&' : '?';
+      url += `${sep}region=${box.map((v) => v.toFixed(4)).join(',')}`;
+    }
+    return url;
   }
 
   private sortEntries(entries: SortedElement[]): SortedElement[] {
@@ -75,76 +94,11 @@ export class LabelsetListComponent implements OnChanges {
     return sorted;
   }
 
-  hasThumbnailUrl(entry: DetectorLabelView): boolean {
-    const url = this.thumbnailUrl(entry);
-    if (url && this.thumbnailFailedUrls.has(url)) return false;
-    return (
-      entry.media_type === 'image' ||
-      entry.media_type === 'video' ||
-      entry.media_type === 'document' ||
-      entry.media_type === 'audio'
-    );
+  onEntrySelected(entry: VoteGridEntry): void {
+    this.elementSelected.emit(entry as SortedElement);
   }
 
-  thumbnailUrl(entry: DetectorLabelView): string {
-    const modelName = this.modelName();
-    if (!modelName) return '';
-    let url = this.detectorsCrudApi.labelThumbnailUrl(modelName, entry.id);
-    // The route crops to the element's stored region box server-side; fold the
-    // box into the URL so a re-vote with a different box busts the cached tile
-    // (the box coords aren't otherwise part of the URL).
-    const box = entry.region_box;
-    if (box && box.length === 4) {
-      const sep = url.includes('?') ? '&' : '?';
-      url += `${sep}region=${box.map((v) => v.toFixed(4)).join(',')}`;
-    }
-    return url;
-  }
-
-  onThumbnailError(url: string): void {
-    if (url) this.thumbnailFailedUrls.add(url);
-  }
-
-  placeholderIcon(entry: DetectorLabelView): string | null {
-    if (this.hasThumbnailUrl(entry)) return null;
-    if (entry.media_type === 'audio') return '♫';
-    if (entry.media_type === 'text') return '¶';
-    return '□';
-  }
-
-  isMissing(entry: DetectorLabelView): boolean {
-    return entry.cid === null || entry.cid === undefined;
-  }
-
-  onEntryClick(entry: DetectorLabelView): void {
-    if (this.focusMode() === 'hover') {
-      this.elementVote.emit({ id: entry.id, vote: 'bad' });
-    } else {
-      this.elementSelected.emit(entry);
-    }
-  }
-
-  onEntryContextMenu(event: MouseEvent, entry: DetectorLabelView): void {
-    if (this.focusMode() === 'hover') {
-      event.preventDefault();
-      this.elementVote.emit({ id: entry.id, vote: 'good' });
-    }
-  }
-
-  onEntryMouseEnter(entry: DetectorLabelView): void {
-    if (this.focusMode() === 'hover') {
-      this.elementSelected.emit(entry);
-    }
-  }
-
-  onEntryKeydown(event: KeyboardEvent, entry: DetectorLabelView): void {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      this.elementSelected.emit(entry);
-    }
-  }
-
-  trackById(_index: number, entry: SortedElement): string {
-    return entry.id;
+  onEntryVote(event: { entry: VoteGridEntry; vote: 'good' | 'bad' }): void {
+    this.elementVote.emit({ id: event.entry.key, vote: event.vote });
   }
 }

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.html
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.html
@@ -1,0 +1,52 @@
+@if (useVirtual) {
+  <!-- Virtual scrolling for large piles: cells are chunked into rows so only
+       the visible rows are mounted, instead of every thumbnail at once. -->
+  <cdk-virtual-scroll-viewport
+    [itemSize]="rowHeight"
+    class="vote-list vote-list-virtual"
+    [style.--grid-goal-width]="gridGoalWidth() + 'px'"
+  >
+    <div
+      class="vote-grid-row"
+      *cdkVirtualFor="let row of rows; trackBy: trackByRow"
+      [style.height.px]="rowHeight"
+      [style.--grid-goal-width]="gridGoalWidth() + 'px'"
+      [style.grid-template-columns]="'repeat(' + columns + ', var(--grid-goal-width, 80px))'"
+    >
+      @for (entry of row; track entry.key) {
+        <ng-container [ngTemplateOutlet]="cell" [ngTemplateOutletContext]="{ $implicit: entry }" />
+      }
+    </div>
+  </cdk-virtual-scroll-viewport>
+} @else {
+  <!-- Plain DOM rendering for small piles (natural height, no measurement). -->
+  <div class="vote-list vote-list-plain" [style.--grid-goal-width]="gridGoalWidth() + 'px'">
+    @for (entry of entries(); track entry.key) {
+      <ng-container [ngTemplateOutlet]="cell" [ngTemplateOutletContext]="{ $implicit: entry }" />
+    }
+  </div>
+}
+
+<ng-template #cell let-entry>
+  <div
+    class="vote-entry"
+    [class.vote-entry-missing]="entry.missing"
+    [attr.title]="entry.missing ? entry.name + ' (not in the current dataset)' : null"
+    role="button"
+    tabindex="0"
+    [attr.aria-label]="(label() === 'good' ? 'Good' : 'Bad') + ': ' + entry.name + (entry.missing ? ' (not in current dataset)' : '')"
+    (click)="onEntryClick(entry)"
+    (contextmenu)="onEntryContextMenu($event, entry)"
+    (mouseenter)="onEntryMouseEnter(entry)"
+    (keydown)="onEntryKeydown($event, entry)"
+  >
+    @if (entry.thumbnailUrl && !thumbnailFailedUrls.has(entry.thumbnailUrl)) {
+      <span class="vote-thumbnail-wrap">
+        <img class="vote-thumbnail" [src]="entry.thumbnailUrl" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.thumbnailUrl)" />
+      </span>
+    } @else if (entry.fallbackIcon) {
+      <span class="vote-placeholder">{{ entry.fallbackIcon }}</span>
+    }
+    <span class="vote-name-grid">{{ entry.name }}</span>
+  </div>
+</ng-template>

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.scss
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.scss
@@ -1,0 +1,123 @@
+:host {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+// Shared scroll container for both render modes. `snapPanelWidthToGridColumns`
+// (grid-icon-size.ts) matches `.vote-list` and reads the inline
+// --grid-goal-width from it, so both the plain grid and the CDK viewport keep
+// this class and that style.
+.vote-list {
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  flex: 1;
+  min-height: 0;
+}
+
+.vote-list-plain {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, var(--grid-goal-width, 80px));
+  gap: var(--space-xs);
+  align-content: start;
+  justify-content: end;
+}
+
+// Virtualized pile: each CDK item is a single row of cells laid out with a
+// fixed column template, so only on-screen rows are mounted. Same gap and
+// right-alignment as the plain grid.
+.vote-grid-row {
+  display: grid;
+  gap: var(--space-xs);
+  align-content: start;
+  justify-content: end;
+  box-sizing: border-box;
+}
+
+.vote-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--space-xs);
+  gap: var(--space-2xs);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-sm);
+  cursor: pointer;
+  color: var(--text-vote);
+  line-height: 1.3;
+  // Query container so the name can hide itself at small icon sizes (below).
+  container-type: inline-size;
+  container-name: vote-cell;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+}
+
+.vote-entry-missing {
+  outline: 1px solid var(--missing-border);
+  outline-offset: -1px;
+  border-radius: var(--radius-sm);
+}
+
+.vote-thumbnail-wrap {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1;
+  min-height: 0;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.vote-thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  display: block;
+}
+
+.vote-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  font-size: var(--font-3xl);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.vote-name-grid {
+  font-size: var(--font-2xs);
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+  text-align: center;
+  line-height: 1.2;
+  flex-shrink: 0;
+}
+
+// At the two smallest icon sizes (XS/S, ~42px content-box) the name truncates to
+// a useless "a…", so hide it and let the grid pack tighter. M and up keep it.
+@container vote-cell (max-width: 60px) {
+  .vote-name-grid {
+    display: none;
+  }
+}

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.spec.ts
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.spec.ts
@@ -1,0 +1,146 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { VoteGridComponent, VoteGridEntry } from './vote-grid.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
+
+function makeEntries(n: number, overrides: Partial<VoteGridEntry> = {}): VoteGridEntry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    key: String(i + 1),
+    name: `item-${i + 1}`,
+    thumbnailUrl: '',
+    fallbackIcon: '□',
+    missing: false,
+    ...overrides,
+  }));
+}
+
+describe('VoteGridComponent', () => {
+  let component: VoteGridComponent;
+  let fixture: ComponentFixture<VoteGridComponent>;
+
+  async function setInputs(inputs: Record<string, unknown>): Promise<void> {
+    for (const [k, v] of Object.entries(inputs)) {
+      fixture.componentRef.setInput(k, v);
+    }
+    await settleZoneless(fixture);
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VoteGridComponent],
+      providers: [...provideZoneless()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(VoteGridComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', async () => {
+    await settleZoneless(fixture);
+    expect(component).toBeTruthy();
+  });
+
+  it('renders small piles as a plain grid (no CDK viewport)', async () => {
+    await setInputs({ entries: makeEntries(5) });
+    const el = fixture.nativeElement as HTMLElement;
+    expect(component.useVirtual).toBe(false);
+    expect(el.querySelector('cdk-virtual-scroll-viewport')).toBeNull();
+    expect(el.querySelector('.vote-list-plain')).toBeTruthy();
+    expect(el.querySelectorAll('.vote-entry').length).toBe(5);
+  });
+
+  it('switches to a CDK virtual-scroll viewport above the threshold', async () => {
+    await setInputs({ entries: makeEntries(100) });
+    const el = fixture.nativeElement as HTMLElement;
+    expect(component.useVirtual).toBe(true);
+    expect(el.querySelector('cdk-virtual-scroll-viewport')).toBeTruthy();
+    expect(el.querySelector('.vote-list-plain')).toBeNull();
+    // jsdom reports zero viewport width, so the column count stays 1 and each
+    // entry becomes its own virtualized row.
+    expect(component.rows.length).toBe(100);
+    expect(component.rows[0].length).toBe(1);
+  });
+
+  it('drops back to the plain grid when the pile shrinks', async () => {
+    await setInputs({ entries: makeEntries(100) });
+    await setInputs({ entries: makeEntries(3) });
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('cdk-virtual-scroll-viewport')).toBeNull();
+    expect(el.querySelectorAll('.vote-entry').length).toBe(3);
+  });
+
+  it('chunks entries into rows of the current column count', async () => {
+    await setInputs({ entries: makeEntries(100) });
+    component.columns = 3;
+    component['rebuildRows']();
+    expect(component.rows.length).toBe(Math.ceil(100 / 3));
+    expect(component.rows[0].map((e) => e.key)).toEqual(['1', '2', '3']);
+    expect(component.rows.at(-1)!.length).toBe(100 % 3 || 3);
+  });
+
+  describe('event routing', () => {
+    const entry: VoteGridEntry = { key: '7', name: 'x', thumbnailUrl: '', fallbackIcon: null, missing: false };
+
+    it('click selects in click mode', async () => {
+      await setInputs({ focusMode: 'click' });
+      vi.spyOn(component.entrySelected, 'emit');
+      component.onEntryClick(entry);
+      expect(component.entrySelected.emit).toHaveBeenCalledWith(entry);
+    });
+
+    it('click votes bad in hover mode', async () => {
+      await setInputs({ focusMode: 'hover' });
+      vi.spyOn(component.entryVote, 'emit');
+      component.onEntryClick(entry);
+      expect(component.entryVote.emit).toHaveBeenCalledWith({ entry, vote: 'bad' });
+    });
+
+    it('contextmenu votes good in hover mode', async () => {
+      await setInputs({ focusMode: 'hover' });
+      vi.spyOn(component.entryVote, 'emit');
+      const event = new MouseEvent('contextmenu', { cancelable: true });
+      component.onEntryContextMenu(event, entry);
+      expect(event.defaultPrevented).toBe(true);
+      expect(component.entryVote.emit).toHaveBeenCalledWith({ entry, vote: 'good' });
+    });
+
+    it('mouseenter selects in hover mode only', async () => {
+      vi.spyOn(component.entrySelected, 'emit');
+      await setInputs({ focusMode: 'click' });
+      component.onEntryMouseEnter(entry);
+      expect(component.entrySelected.emit).not.toHaveBeenCalled();
+      await setInputs({ focusMode: 'hover' });
+      component.onEntryMouseEnter(entry);
+      expect(component.entrySelected.emit).toHaveBeenCalledWith(entry);
+    });
+
+    it('Enter and Space select; other keys do not', () => {
+      vi.spyOn(component.entrySelected, 'emit');
+      component.onEntryKeydown(new KeyboardEvent('keydown', { key: 'a' }), entry);
+      expect(component.entrySelected.emit).not.toHaveBeenCalled();
+      component.onEntryKeydown(new KeyboardEvent('keydown', { key: 'Enter' }), entry);
+      component.onEntryKeydown(new KeyboardEvent('keydown', { key: ' ' }), entry);
+      expect(component.entrySelected.emit).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('falls back to the type icon when a thumbnail URL fails', async () => {
+    await setInputs({ entries: makeEntries(1, { thumbnailUrl: '/api/medias/1/thumbnail', fallbackIcon: '♫' }) });
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.vote-thumbnail')).toBeTruthy();
+    expect(el.querySelector('.vote-placeholder')).toBeNull();
+
+    component.onThumbnailError('/api/medias/1/thumbnail');
+    await settleZoneless(fixture);
+    expect(el.querySelector('.vote-thumbnail')).toBeNull();
+    expect(el.querySelector('.vote-placeholder')?.textContent).toContain('♫');
+  });
+
+  it('marks missing entries and labels them in the aria text', async () => {
+    await setInputs({ label: 'good', entries: makeEntries(1, { missing: true }) });
+    const el = fixture.nativeElement as HTMLElement;
+    const cell = el.querySelector('.vote-entry');
+    expect(cell?.classList.contains('vote-entry-missing')).toBe(true);
+    expect(cell?.getAttribute('aria-label')).toBe('Good: item-1 (not in current dataset)');
+  });
+});

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.ts
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.ts
@@ -1,0 +1,261 @@
+import {
+  AfterViewChecked,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  inject,
+  input,
+  NgZone,
+  OnChanges,
+  OnDestroy,
+  output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+
+/**
+ * One display-ready cell in a Good/Bad vote pile. Every field is precomputed
+ * by the parent when its inputs change (inside the existing sort pass), so
+ * change detection over a large pile binds stored values instead of
+ * re-deriving thumbnail URLs and icons per row per cycle.
+ */
+export interface VoteGridEntry {
+  /** Stable identity for `track` (stringified media id / labelset element id). */
+  key: string;
+  name: string;
+  /** Downscaled tile URL, or '' when the media type has no thumbnail. */
+  thumbnailUrl: string;
+  /** Icon shown when there is no thumbnail (or it failed to load); null renders the name only. */
+  fallbackIcon: string | null;
+  /** True when the item isn't present in the current dataset. */
+  missing: boolean;
+}
+
+/** Media types the thumbnail route can render a tile for. */
+export const THUMBNAIL_MEDIA_TYPES: ReadonlySet<string> = new Set([
+  'image',
+  'video',
+  'document',
+  'audio',
+]);
+
+/**
+ * Entry count above which the pile switches to CDK virtual scrolling.
+ * Mirrors the left grid's ``GRID_VIRTUAL_THRESHOLD`` and its rationale: a few
+ * hundred thumbnail rows re-rendered on every vote (and every labelset poll)
+ * froze the panel, so small piles stay plain DOM (natural height, exact
+ * layout) and larger ones mount only the visible rows.
+ */
+const PILE_VIRTUAL_THRESHOLD = 80;
+/** Horizontal/vertical gap between pile cells (px); mirrors ``--space-xs``. */
+const GRID_GAP_PX = 4;
+/** Fallback row stride before the first real cell is measured (px). */
+const ROW_HEIGHT_FALLBACK = 100;
+/**
+ * Smallest plausible measured row stride (px). A cell mid-relayout (its
+ * ``<img>`` still loading) can momentarily report a near-zero height;
+ * accepting that as the CDK ``itemSize`` would mount nearly every row at
+ * once and defeat virtualization. Heights below this floor are treated as
+ * "not yet laid out" and ignored until a real cell measures.
+ */
+const MIN_ROW_HEIGHT = 24;
+
+/**
+ * The grid of vote cells shared by the Good/Bad piles (`vt-label-list`) and
+ * the saved-labelset piles (`vt-labelset-list`). Renders precomputed
+ * ``VoteGridEntry`` rows and owns the plain-vs-virtualized switch, so both
+ * parents stay a thin "sort + enrich" layer.
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'vt-vote-grid',
+  standalone: true,
+  imports: [NgTemplateOutlet, ScrollingModule],
+  templateUrl: './vote-grid.component.html',
+  styleUrl: './vote-grid.component.scss',
+})
+export class VoteGridComponent implements OnChanges, AfterViewChecked, OnDestroy {
+  private cdr = inject(ChangeDetectorRef);
+  private zone = inject(NgZone);
+
+  readonly entries = input<VoteGridEntry[]>([]);
+  readonly label = input<'good' | 'bad'>('good');
+  readonly gridGoalWidth = input<number>(80);
+  readonly focusMode = input<'click' | 'hover'>('click');
+
+  readonly entrySelected = output<VoteGridEntry>();
+  readonly entryVote = output<{
+    entry: VoteGridEntry;
+    vote: 'good' | 'bad';
+}>();
+
+  @ViewChild(CdkVirtualScrollViewport) virtualViewport?: CdkVirtualScrollViewport;
+
+  /** ``entries`` chunked into rows of ``columns`` cells for virtual scrolling. */
+  rows: VoteGridEntry[][] = [];
+  /** Number of cells per virtualized row, derived from the viewport width. */
+  columns = 1;
+  /** Measured stride of one virtualized row (px); fed to CDK as ``itemSize``. */
+  rowHeight = ROW_HEIGHT_FALLBACK;
+
+  /** Thumbnail URLs that 404'd; their cells fall back to the type icon. */
+  readonly thumbnailFailedUrls = new Set<string>();
+
+  private resizeObserver?: ResizeObserver;
+  private observedViewportEl?: HTMLElement;
+  /** True once ``rowHeight`` has been measured from a real rendered cell. */
+  private rowHeightMeasured = false;
+
+  /** Whether the pile is large enough to render through the CDK viewport. */
+  get useVirtual(): boolean {
+    return this.entries().length > PILE_VIRTUAL_THRESHOLD;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // A wider/narrower goal width changes how many cells fit per row and the
+    // height of each cell, so recompute columns and re-measure the stride.
+    if (changes['gridGoalWidth'] && !changes['gridGoalWidth'].firstChange) {
+      this.rowHeightMeasured = false;
+      this.recomputeColumns();
+    }
+    if (changes['entries'] || changes['gridGoalWidth']) {
+      this.rebuildRows();
+    }
+  }
+
+  ngAfterViewChecked(): void {
+    // Keep the viewport measured while virtualizing: a ResizeObserver tracks
+    // width (→ column count) and the first rendered cell's height (→ CDK row
+    // stride). Tear it down when the pile shrinks back to plain DOM.
+    if (this.useVirtual && this.virtualViewport) {
+      this.setupViewport();
+    } else if (this.observedViewportEl) {
+      this.resizeObserver?.disconnect();
+      this.resizeObserver = undefined;
+      this.observedViewportEl = undefined;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
+  }
+
+  private rebuildRows(): void {
+    const cols = Math.max(1, this.columns);
+    const entries = this.entries();
+    const rows: VoteGridEntry[][] = [];
+    for (let i = 0; i < entries.length; i += cols) {
+      rows.push(entries.slice(i, i + cols));
+    }
+    this.rows = rows;
+  }
+
+  /**
+   * Recompute how many cells fit across the viewport. Returns ``true`` when
+   * the column count changed (so callers know to rebuild the rows).
+   */
+  private recomputeColumns(): boolean {
+    const el = this.virtualViewport?.elementRef.nativeElement;
+    if (!el) return false;
+    const inner = el.clientWidth;
+    if (inner <= 0) return false;
+    const cols = Math.max(1, Math.floor((inner + GRID_GAP_PX) / (this.gridGoalWidth() + GRID_GAP_PX)));
+    if (cols === this.columns) return false;
+    this.columns = cols;
+    return true;
+  }
+
+  /** Observe the viewport for width/height changes (runs outside Angular). */
+  private setupViewport(): void {
+    const vp = this.virtualViewport?.elementRef.nativeElement;
+    if (!vp || this.observedViewportEl === vp) {
+      // Already observing the right element. Re-measure only until the row
+      // height has been captured from a real cell, so the steady state doesn't
+      // force a reflow on every change-detection cycle.
+      if (!this.rowHeightMeasured) this.measureLayout();
+      return;
+    }
+    this.resizeObserver?.disconnect();
+    this.observedViewportEl = vp;
+    this.rowHeightMeasured = false;
+    this.zone.runOutsideAngular(() => {
+      this.resizeObserver = new ResizeObserver(() => this.measureLayout());
+      this.resizeObserver.observe(vp);
+    });
+    this.measureLayout();
+  }
+
+  /**
+   * Recompute the column count (from viewport width) and row stride (from a
+   * rendered cell), applying changes in a fresh CD tick. Guarded so it
+   * converges instead of looping: it only re-renders when something moved.
+   */
+  private measureLayout(): void {
+    let changed = this.recomputeColumns();
+    if (changed) this.rebuildRows();
+
+    const vp = this.virtualViewport?.elementRef.nativeElement;
+    const cell = vp?.querySelector('.vote-entry') as HTMLElement | null;
+    if (cell) {
+      const measured = Math.round(cell.getBoundingClientRect().height + GRID_GAP_PX);
+      // Only trust a measurement once the cell has actually laid out (see
+      // MIN_ROW_HEIGHT); leave ``rowHeightMeasured`` false so the next pass
+      // re-measures against a real cell.
+      if (measured >= MIN_ROW_HEIGHT) {
+        this.rowHeightMeasured = true;
+        if (Math.abs(measured - this.rowHeight) > 1) {
+          this.rowHeight = measured;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      // detectChanges() runs CD on this view synchronously and is
+      // zone-independent (this fires from the ResizeObserver callback and
+      // from ngAfterViewChecked).
+      this.cdr.detectChanges();
+    }
+  }
+
+  onThumbnailError(url: string): void {
+    if (url) {
+      this.thumbnailFailedUrls.add(url);
+      this.cdr.markForCheck();
+    }
+  }
+
+  onEntryClick(entry: VoteGridEntry): void {
+    if (this.focusMode() === 'hover') {
+      this.entryVote.emit({ entry, vote: 'bad' });
+    } else {
+      this.entrySelected.emit(entry);
+    }
+  }
+
+  onEntryContextMenu(event: MouseEvent, entry: VoteGridEntry): void {
+    if (this.focusMode() === 'hover') {
+      event.preventDefault();
+      this.entryVote.emit({ entry, vote: 'good' });
+    }
+  }
+
+  onEntryMouseEnter(entry: VoteGridEntry): void {
+    if (this.focusMode() === 'hover') {
+      this.entrySelected.emit(entry);
+    }
+  }
+
+  onEntryKeydown(event: KeyboardEvent, entry: VoteGridEntry): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.entrySelected.emit(entry);
+    }
+  }
+
+  trackByRow(index: number, _row: VoteGridEntry[]): number {
+    return index;
+  }
+}

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -62,6 +62,18 @@ class EventSourceMock {
 }
 (globalThis as unknown as { EventSource: unknown }).EventSource = EventSourceMock;
 
+// --- ResizeObserver ----------------------------------------------------------
+// The virtualized grids (media-list, vote-grid) observe their viewport to
+// derive column count and row stride. jsdom has no ResizeObserver — and no
+// layout engine, so a real one would never fire anyway. An inert stub lets
+// specs mount the virtualized branch.
+class ResizeObserverMock {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverMock;
+
 // --- HTMLMediaElement play/pause/load --------------------------------------
 // The audio/video players call these; jsdom throws "Not implemented".
 Object.defineProperties(HTMLMediaElement.prototype, {


### PR DESCRIPTION
Ships the **Virtualized label piles** item from `docs/plans/efficiency-wins.md` (Tier 2; item pruned from the plan here).

## Problem

The right-panel Good/Bad piles (`vt-label-list`) and saved-labelset piles (`vt-labelset-list`) rendered **every** labeled item as DOM with a plain `@for`, each row with an `<img>`. On top of that, the templates called `hasThumbnailUrl()` / `thumbnailUrl()` / `placeholderIcon()` 3–4× per row per change-detection cycle — including a `region_box.map(v => v.toFixed(4)).join(',')` string build per call — so every vote and every 1.5 s labelset poll re-walked the full pile. The left grid already virtualizes above 80 items for exactly this reason (`GRID_VIRTUAL_THRESHOLD`, ~1.8 s freeze).

## Change

- **New shared `vt-vote-grid` component** (`right-panel/vote-grid/`): renders the pile cells from precomputed display fields and owns the plain-vs-virtualized switch — plain `@for` at ≤80 entries so small piles keep natural height and identical layout, `cdk-virtual-scroll-viewport` + `*cdkVirtualFor` over row chunks above that. Column count and row stride are measured with the same viewport-`ResizeObserver` pattern as the left grid (cells are uniform squares + name line, so a fixed `itemSize` is accurate). The viewport keeps the `.vote-list` class and inline `--grid-goal-width` so `snapPanelWidthToGridColumns` keeps working in both modes.
- **`label-list` / `labelset-list` become thin sort+enrich layers**: `buildSortedEntries()` / `buildSorted()` now precompute `thumbnailUrl` (with the region-box query), `fallbackIcon`, and `missing` onto each entry once per input change, and the template binds the stored fields. The per-CD template getters, the duplicated cell markup, and the duplicated focus-mode event routing are gone.
- **Thumbnail-failure fallback** moved into `vt-vote-grid` (failed URLs fall back to the media-type icon, as before).
- **Test setup**: stubbed `ResizeObserver` in `frontend/src/test-setup.ts` (jsdom has none, and no layout engine to drive a real one) so specs can mount the virtualized branch.
- **Tests**: new `vote-grid.component.spec.ts` (threshold switch both directions, row chunking, click/hover/contextmenu/keyboard routing, thumbnail-error fallback, missing-entry aria); `label-list.component.spec.ts` updated to assert the precomputed entry fields (thumbnail URLs, region-box URL, fallback icons, missing flag) and the new grid→output forwarding.

Behavior notes: a labelset cell with an empty `modelName` now shows the type icon instead of an `<img src="">` (previously rendered a broken empty image); everything else is behavior-identical for piles ≤80 items.

## Testing

- `./run-tests.sh frontend` — build, audit, and Vitest green (1091 tests).
- `./run-tests.sh` — full suite: **ALL 5566 TESTS PASSED** (1 skipped).

No screenshot reshoots queued: no manifest shot frames a pile above the virtualization threshold, and sub-threshold rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8YgA8o6AHwQLf1x69bJxY

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8YgA8o6AHwQLf1x69bJxY)_