### PR TITLE
Make R-Y-G progress bar gradients continuous

### DIFF
--- a/frontend/src/app/components/progress-bar/progress-bar.component.html
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.html
@@ -10,5 +10,6 @@
     [class.indeterminate]="indeterminate"
     [class.progress-fill--smooth]="smooth"
     [style.width.%]="indeterminate ? 100 : percentage"
+    [style.background]="fillColor"
   ></div>
 </div>

--- a/frontend/src/app/components/progress-bar/progress-bar.component.scss
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.scss
@@ -8,9 +8,12 @@
 
 .progress-fill {
   height: 100%;
+  // Falls back to --accent only while indeterminate (no percentage to color
+  // by); otherwise the component's `fillColor` inline style (a red -> yellow
+  // -> green color-mix keyed off the percentage) overrides this.
   background: var(--accent);
   border-radius: var(--radius-sm);
-  transition: width var(--transition-slow) ease;
+  transition: width var(--transition-slow) ease, background-color var(--transition-slow) ease;
 
   // Multi-stage load bar: a longer, decelerating ease so the jumps between
   // phases (e.g. an un-measurable model-load slice filling in one step) glide

--- a/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
@@ -80,4 +80,49 @@ describe('ProgressBarComponent', () => {
     const fill = fixture.nativeElement.querySelector('.progress-fill');
     expect(fill.classList).toContain('progress-fill--smooth');
   });
+
+  describe('fillColor', () => {
+    it('should be reddest at 0%', () => {
+      component.value = 0;
+      component.max = 100;
+      expect(component.fillColor).toBe('color-mix(in srgb, var(--text-warning) 0%, var(--color-bad))');
+    });
+
+    it('should be yellowest at 50%', () => {
+      component.value = 50;
+      component.max = 100;
+      expect(component.fillColor).toBe('color-mix(in srgb, var(--text-warning) 100%, var(--color-bad))');
+    });
+
+    it('should be greenest at 100%', () => {
+      component.value = 100;
+      component.max = 100;
+      expect(component.fillColor).toBe('color-mix(in srgb, var(--color-good) 100%, var(--text-warning))');
+    });
+
+    it('should interpolate continuously between red and yellow below 50%', () => {
+      component.value = 25;
+      component.max = 100;
+      expect(component.fillColor).toBe('color-mix(in srgb, var(--text-warning) 50%, var(--color-bad))');
+    });
+
+    it('should interpolate continuously between yellow and green above 50%', () => {
+      component.value = 75;
+      component.max = 100;
+      expect(component.fillColor).toBe('color-mix(in srgb, var(--color-good) 50%, var(--text-warning))');
+    });
+
+    it('should be null while indeterminate', () => {
+      component.indeterminate = true;
+      expect(component.fillColor).toBeNull();
+    });
+
+    it('should apply the fill color as the background style', async () => {
+      fixture.componentRef.setInput('value', 75);
+      fixture.componentRef.setInput('max', 100);
+      await settleZoneless(fixture);
+      const fill = fixture.nativeElement.querySelector('.progress-fill') as HTMLElement;
+      expect(fill.style.background).toContain('color-mix');
+    });
+  });
 });

--- a/frontend/src/app/components/progress-bar/progress-bar.component.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.ts
@@ -26,4 +26,25 @@ export class ProgressBarComponent {
     if (this.max <= 0) return 0;
     return Math.min(100, (this.value / this.max) * 100);
   }
+
+  /**
+   * Continuous red -> yellow -> green fill color, matching the CMD progress
+   * bar gradient: reddest at 0%, yellowest at 50%, greenest at 100%. Built
+   * from the theme's `--color-bad` / `--text-warning` / `--color-good`
+   * variables via `color-mix` so it stays correct in every theme (light,
+   * dark, high-visibility) without hardcoding RGB values here.
+   *
+   * Returns `null` while indeterminate so the element falls back to the
+   * SCSS default (`--accent`); there is no percentage to color by.
+   */
+  get fillColor(): string | null {
+    if (this.indeterminate) return null;
+    const pct = this.percentage;
+    if (pct <= 50) {
+      const t = (pct / 50) * 100;
+      return `color-mix(in srgb, var(--text-warning) ${t}%, var(--color-bad))`;
+    }
+    const t = ((pct - 50) / 50) * 100;
+    return `color-mix(in srgb, var(--color-good) ${t}%, var(--text-warning))`;
+  }
 }

--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -12,6 +12,7 @@ Also tests ``load_pretrained_local_first`` which avoids network hangs by
 preferring locally cached model files.
 """
 
+import re
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -25,6 +26,7 @@ from vtscore.media.embedder import (
     timed_progress,
 )
 from vtscore.embedding.loader import (
+    _ANSI_RESET,
     _make_console_progress,
     initialize_models,
     predict_embedders_to_preload,
@@ -182,50 +184,72 @@ class TestMakeConsoleProgress:
         for seg in renders:
             assert seg.index("s)") > seg.index("%")
 
-    def test_bar_fill_is_colored_red_at_or_below_half(self, capsys):
-        """A bar at ≤50% colors its fill red (between the brackets only)."""
+    def test_bar_fill_uses_a_truecolor_gradient(self, capsys):
+        """The fill is colored with a 24-bit RGB escape, not a fixed 16-color code."""
         cb = _make_console_progress(lambda *a, **kw: None)
 
         cb("loading", "model.safetensors", 30, 100)
-        cb("loading", "model.safetensors", 50, 100)
 
         out = capsys.readouterr().out
-        # Every render's bracketed fill opens with the red code and resets
-        # before the closing bracket; the percentage stays uncolored.
-        for seg in (s for s in out.split("\r") if "[" in s):
-            assert "[\033[31m" in seg
-            assert "\033[0m]" in seg
+        assert "\033[38;2;" in out
 
-    def test_bar_fill_is_colored_yellow_past_half(self, capsys):
-        """A bar in (50%, 100%) colors its fill yellow."""
+    def test_bar_color_is_reddest_at_zero_percent(self):
+        from vtscore.embedding.loader import _bar_rgb, _RGB_RED
+
+        assert _bar_rgb(0) == _RGB_RED
+
+    def test_bar_color_is_yellowest_at_fifty_percent(self):
+        from vtscore.embedding.loader import _bar_rgb, _RGB_YELLOW
+
+        assert _bar_rgb(50) == _RGB_YELLOW
+
+    def test_bar_color_is_greenest_at_hundred_percent(self):
+        from vtscore.embedding.loader import _bar_rgb, _RGB_GREEN
+
+        assert _bar_rgb(100) == _RGB_GREEN
+
+    def test_bar_color_interpolates_continuously(self):
+        """Every percentage should get a distinct shade, not a three-step palette."""
+        from vtscore.embedding.loader import _bar_rgb
+
+        rgbs = [_bar_rgb(pct) for pct in range(0, 101, 5)]
+        # No two consecutive 5%-apart samples should be identical: proves the
+        # color is a continuous function of percentage rather than a step function.
+        assert len(set(rgbs)) == len(rgbs)
+
+    def test_only_filled_chars_are_colored_not_empty_dots(self, capsys):
+        """Only the '#' fill is colored; the '.' remainder stays default-colored."""
         cb = _make_console_progress(lambda *a, **kw: None)
 
-        cb("loading", "model.safetensors", 75, 100)
+        cb("loading", "model.safetensors", 30, 100)
 
         out = capsys.readouterr().out
-        assert "[\033[93m" in out
-        assert "\033[0m]" in out
+        bar_start = out.index("[")
+        bar_end = out.index("]", bar_start)
+        bar_content = out[bar_start + 1 : bar_end]
 
-    def test_bar_fill_is_colored_green_at_completion(self, capsys):
-        """A 100% bar colors its fill green."""
-        cb = _make_console_progress(lambda *a, **kw: None)
+        match = re.match(r"\033\[38;2;\d+;\d+;\d+m", bar_content)
+        assert match
+        rest = bar_content[match.end() :]
+        reset_idx = rest.index(_ANSI_RESET)
+        filled_part = rest[:reset_idx]
+        dots_part = rest[reset_idx + len(_ANSI_RESET) :]
 
-        cb("loading", "model.safetensors", 100, 100)
+        assert filled_part == "#" * 9  # 30% of 30 columns
+        assert dots_part == "." * 21
 
-        out = capsys.readouterr().out
-        assert "[\033[32m" in out
-        assert "\033[0m]" in out
+    def test_completed_bar_via_flush_is_greenest(self, capsys):
+        """The flush-finalized bar (snap to 100%) colors its fill the greenest shade."""
+        from vtscore.embedding.loader import _bar_color
 
-    def test_completed_bar_via_flush_is_green(self, capsys):
-        """The flush-finalized bar (snap to 100%) colors its fill green."""
         cb = _make_console_progress(lambda *a, **kw: None)
 
         cb("loading", "model.safetensors", 40, 100)
         cb.flush()
 
         out = capsys.readouterr().out
-        # The final overwrite is the full green bar at 100%.
-        assert "[\033[32m" + "#" * 30 + "\033[0m] 100%" in out
+        # The final overwrite is the full bar colored with the 100% (greenest) shade.
+        assert "[" + _bar_color(100) + "#" * 30 + _ANSI_RESET + "] 100%" in out
 
     def test_color_codes_do_not_shift_bar_alignment(self, capsys):
         """ANSI color codes live *inside* the brackets, so the open-bracket

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -27,26 +27,37 @@ _TIME_SUFFIX_RE = re.compile(r"\s*\(\d+s(?:,\s*\d+\s+modules)?\)$")
 #: bracket always lands in the same column and the bars stay aligned.
 _LABEL_WIDTH = 32
 
-#: ANSI colors for the bar fill *between* the brackets (the rest of the line
-#: keeps its default color).  Red while at or below the half-way mark, yellow
-#: past it, green only at completion.  ``_ANSI_RESET`` restores the default so
-#: the closing bracket and trailing percentage are uncolored.
-_ANSI_RED = "\033[31m"
-_ANSI_YELLOW = "\033[93m"  # bright yellow; the dim \033[33m renders olive/brown
-_ANSI_GREEN = "\033[32m"
+#: 24-bit ("truecolor") RGB endpoints for the bar-fill gradient, interpolated
+#: continuously by :func:`_bar_rgb`: reddest at 0%, yellowest at 50%, greenest
+#: at 100%.  Only the fill (the ``#`` characters already drawn) is colored;
+#: the ``.`` characters marking the not-yet-filled remainder keep the
+#: terminal's default text color, and so does the rest of the line.
+#: ``_ANSI_RESET`` restores the default color after the fill.
+_RGB_RED = (205, 0, 0)
+_RGB_YELLOW = (255, 215, 0)
+_RGB_GREEN = (0, 205, 0)
 _ANSI_RESET = "\033[0m"
 
 
-def _bar_color(pct: int) -> str:
-    """Return the ANSI color for a bar at *pct* percent (0-100).
+def _bar_rgb(pct: int) -> tuple[int, int, int]:
+    """Return the interpolated ``(r, g, b)`` fill color for a bar at *pct* (0-100).
 
-    Red for ``pct <= 50``, yellow for ``50 < pct < 100``, green at ``100``.
+    Linearly interpolates red -> yellow over ``[0, 50]`` and yellow -> green
+    over ``[50, 100]``, so every percentage gets a distinct shade rather than
+    snapping between three fixed colors.
     """
-    if pct >= 100:
-        return _ANSI_GREEN
-    if pct > 50:
-        return _ANSI_YELLOW
-    return _ANSI_RED
+    pct = max(0, min(100, pct))
+    if pct <= 50:
+        start, end, t = _RGB_RED, _RGB_YELLOW, pct / 50
+    else:
+        start, end, t = _RGB_YELLOW, _RGB_GREEN, (pct - 50) / 50
+    return tuple(round(start[i] + (end[i] - start[i]) * t) for i in range(3))  # type: ignore[return-value]
+
+
+def _bar_color(pct: int) -> str:
+    """Return the 24-bit ANSI foreground escape for a bar at *pct* percent (0-100)."""
+    r, g, b = _bar_rgb(pct)
+    return f"\033[38;2;{r};{g};{b}m"
 
 
 def _strip_time_suffix(msg: str) -> str:
@@ -351,7 +362,7 @@ def _make_console_progress(original_callback):
         """Overwrite the current progress line with a 100% bar."""
         if _last_base[0]:
             label = _fit_label(_last_base[0])
-            sys.stdout.write(f"\r    {label} [{_ANSI_GREEN}{_FULL_BAR}{_ANSI_RESET}] 100%\033[K")
+            sys.stdout.write(f"\r    {label} [{_bar_color(100)}{_FULL_BAR}{_ANSI_RESET}] 100%\033[K")
 
     def _flush() -> None:
         if _on_progress_line[0]:
@@ -374,9 +385,10 @@ def _make_console_progress(original_callback):
                 sys.stdout.write("\n")
             pct = min(100, current * 100 // total)
             filled = pct * 30 // 100
-            # Color only the fill between the brackets: red ≤50%, yellow >50%,
-            # green at 100%.  The rest of the line keeps its default color.
-            bar = f"{_bar_color(pct)}{'#' * filled}{'.' * (30 - filled)}{_ANSI_RESET}"
+            # Color only the '#' fill characters with the continuous R->Y->G
+            # gradient; reset before the '.' placeholders so the not-yet-filled
+            # remainder keeps the terminal's default text color.
+            bar = f"{_bar_color(pct)}{'#' * filled}{_ANSI_RESET}{'.' * (30 - filled)}"
             # Pad the base label to a fixed width so every bar starts at the
             # same column and the bars line up vertically.  The elapsed-time /
             # status suffix (e.g. "(3s, 247 modules)") goes *after* the


### PR DESCRIPTION
## Summary
- CMD progress bars (`vtscore/embedding/loader.py`) now interpolate a continuous 24-bit RGB gradient from red (0%) through yellow (50%) to green (100%), instead of snapping between three fixed 16-color states.
- Fixed the fill coloring to only color the `#` fill characters — the `.` placeholders for the not-yet-filled remainder now keep the terminal's default text color (previously the whole bracketed bar, including the empty dots, was colored).
- The GUI `vt-progress-bar` component gets the same treatment: a `color-mix` of the theme's `--color-bad` / `--text-warning` / `--color-good` variables, continuous by percentage, so it renders correctly across light/dark/high-visibility themes without hardcoding RGB values in the component.

## Test plan
- [x] `./run-tests.sh cli` — passes (197 tests)
- [x] `./run-tests.sh frontend` — passes (build, audit, 1098 Vitest tests)
- [x] `./run-tests.sh` (full suite) — passes (5576 tests)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Koq2Afg2awod5ArerbS5Gt)_