### PR TITLE
Drop redundant dataset name from VTSBrowser canvas; move item count to minimap

### DIFF
--- a/docs/user/screenshots-reshoot-queue.md
+++ b/docs/user/screenshots-reshoot-queue.md
@@ -65,7 +65,7 @@ process model — both environment blockers, not recipe problems.
 | `region-voting` | USER_GUIDE.md#region-voting-on-images | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
 | `view-options` | USER_GUIDE.md#view-options | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
 | `settings-appearance` | USER_GUIDE.md#solo-media-type--streamline-for-one-media-type | 2026-07-09 light-mode neutral-ramp change: light variant's modal/background tone shifts. | 2026-07-09 |
-| `browse-view` | USER_GUIDE.md#browse--exploring-a-dataset-spatially | 2026-07-09 light-mode neutral-ramp change: light variant's panel/background tone shifts. | 2026-07-09 |
+| `browse-view` | USER_GUIDE.md#browse--exploring-a-dataset-spatially | The bottom-left canvas overlay (redundant dataset name + item count) was removed, and the item count now renders as a floater pinned to the minimap's bottom-left. Both themes' frames change. Also: 2026-07-09 light-mode neutral-ramp change shifts the light variant's panel/background tone. | 2026-07-10 |
 | `export-picker` | USER_GUIDE.md#exporting-your-work | 2026-07-09 light-mode neutral-ramp change: light variant's modal/background tone shifts. | 2026-07-09 |
 | `import-detector` | USER_GUIDE.md#importing-pre-trained-detectors | 2026-07-09 light-mode neutral-ramp change: light variant's modal/background tone shifts. | 2026-07-09 |
 | `new-detector` | USER_GUIDE.md#creating-a-detector | 2026-07-09 light-mode neutral-ramp change: light variant's modal/background tone shifts. | 2026-07-09 |

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.html
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.html
@@ -1,4 +1,7 @@
 <canvas #canvas (mousedown)="onCanvasDown($event)"></canvas>
+@if (meta()?.point_count; as count) {
+  <span class="minimap-count">{{ count | number }} {{ countNoun() }}</span>
+}
 @if (!dock) {
   <button
     type="button"

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.scss
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.scss
@@ -36,6 +36,23 @@ canvas {
   cursor: crosshair;
 }
 
+// Item-count floater, pinned to the minimap's bottom-left. Non-interactive so a
+// click-drag over it still recenters the main view via the canvas underneath.
+.minimap-count {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  padding: 1px var(--space-xs);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  font-size: var(--font-xs);
+  line-height: normal;
+  color: var(--text-secondary);
+  pointer-events: none;
+  opacity: 0.85;
+}
+
 .minimap-close {
   position: absolute;
   top: 2px;

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -14,6 +14,7 @@ import { binGeometry } from '../browse-canvas/bin-geometry';
 import { readRootZoom } from '../../utils/root-zoom';
 import { onDevicePixelRatioChange } from '../../utils/device-pixel-ratio';
 import { IconComponent } from '../icon/icon.component';
+import { DecimalPipe } from '@angular/common';
 import type { HexCellPayload, ProjectionMeta } from '../../models/projection.models';
 
 /** Resize clamps; must mirror the backend ``browse_minimap_*`` setting ranges. */
@@ -38,7 +39,7 @@ export const MINIMAP_MAX_HEIGHT = 450;
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-minimap',
   standalone: true,
-  imports: [IconComponent],
+  imports: [IconComponent, DecimalPipe],
   templateUrl: './browse-minimap.component.html',
   styleUrl: './browse-minimap.component.scss',
 })
@@ -65,6 +66,11 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
   @Input() height = 150;
   /** Density colormap preset; mirrors the main canvas so the overview matches. */
   readonly colormap = input<BrowseColormapId>('auto');
+  /**
+   * Noun for the item-count floater ("items", or "positives" for a Find-subset
+   * browse). The count itself is read from ``meta.point_count``.
+   */
+  readonly countNoun = input('items');
   /**
    * Docked mode: the minimap fills its container (the browse side panel's
    * meta-row) and sizes its canvas to fit via a {@link ResizeObserver},

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -188,10 +188,6 @@
               </button>
             </div>
           </div>
-          <div class="browse-info">
-            <span class="browse-info-label">{{ datasetName() }}</span>
-            <span class="browse-info-count">{{ meta()?.point_count | number }} {{ countNoun }}</span>
-          </div>
         </div>
 
         <div
@@ -213,6 +209,7 @@
               <vt-browse-minimap
                 [meta]="meta()"
                 [colormap]="colormap()"
+                [countNoun]="countNoun"
                 [dock]="true"
               />
             </div>

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -98,28 +98,6 @@
   background: var(--bg-surface);
 }
 
-.browse-info {
-  position: absolute;
-  bottom: var(--space-md);
-  left: var(--space-md);
-  display: flex;
-  gap: var(--space-sm);
-  align-items: center;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  padding: var(--space-xs) var(--space-sm);
-  font-size: var(--font-xs);
-  color: var(--text-secondary);
-  pointer-events: none;
-  opacity: 0.85;
-}
-
-.browse-info-label {
-  font-weight: var(--weight-medium);
-  color: var(--text-primary);
-}
-
 // Ready-state layout: the canvas region, a draggable divider, and the docked
 // side panel. The panel width is driven by the ``--browse-panel-width`` custom
 // property the divider drag updates (persisted as ``browse_panel_width``).

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -125,7 +125,6 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   readonly buildProgress = signal(0);
   readonly buildTotal = signal(0);
   readonly buildMessage = signal('');
-  readonly datasetName = signal('');
 
   /**
    * Discrete thumbnail-size multipliers, one per named icon size (XS…XL),
@@ -329,7 +328,6 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       const handoff = this.browseSubset.take();
       if (handoff && handoff.ids.length > 0) {
         this.subsetIds = handoff.ids;
-        this.datasetName.set(handoff.label);
       } else {
         // No handoff (e.g. a hard reload): the ephemeral subset is gone.
         this.status.set('error');
@@ -346,7 +344,6 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (status) => {
-          if (!this.subset) this.datasetName.set(status.display_name || '');
           this.mediaType.set(status.media_type || '');
           this.applyBrowsePrefsForMediaType();
           this.statusResolved = true;

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -696,7 +696,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
    * scopes to the unverified positives instead ({@link onBrowseUnverified}).
    */
   onBrowse(): void {
-    this.browseIds(this.goodIds(), 'positives');
+    this.browseIds(this.goodIds());
   }
 
   /**
@@ -705,24 +705,19 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
    * longer unverified. Left-panel work-queue action.
    */
   onBrowseUnverified(): void {
-    this.browseIds(this.unverifiedGoodIds(), 'unverified positives');
+    this.browseIds(this.unverifiedGoodIds());
   }
 
   /**
    * Stash *ids* for the browse view and navigate to
-   * `/browse/:datasetId?subset=1`, where they're UMAP'd on their own. *suffix*
-   * names the subset in the browse header (e.g. "<detector> — positives").
+   * `/browse/:datasetId?subset=1`, where they're UMAP'd on their own.
    */
-  private browseIds(ids: number[], suffix: string): void {
+  private browseIds(ids: number[]): void {
     const datasetId = this.activeContext.datasetId;
     if (!datasetId || ids.length === 0) return;
-    const modelId = this.activeContext.modelId;
-    const detectorName =
-      this.datasetState.detectors.find((d) => d.id === modelId)?.name || 'Detector';
     this.browseSubset.set({
       datasetId,
       ids,
-      label: `${detectorName} — ${suffix}`,
     });
     this.router.navigate(['/browse', datasetId], { queryParams: { subset: 1 } });
   }

--- a/frontend/src/app/services/browse-subset.service.ts
+++ b/frontend/src/app/services/browse-subset.service.ts
@@ -6,8 +6,6 @@ export interface BrowseSubset {
   datasetId: string;
   /** Media ids to project (e.g. the positives of a Find run). */
   ids: number[];
-  /** Human label for the browse header, e.g. the detector name. */
-  label: string;
 }
 
 /**


### PR DESCRIPTION
## What & why

In VTSBrowser the bottom-left canvas overlay repeated the dataset name, which is already shown in the top blue bar — pure redundancy. This removes that overlay and relocates the total item count to where it reads more naturally: a small floater pinned to the minimap's bottom-left corner.

## Changes

- **`browse-view`**: removed the `.browse-info` overlay (dataset name + count) from the canvas and its now-dead SCSS. The write-only `datasetName` signal is gone.
- **`browse-minimap`**: added a `countNoun` input and a `.minimap-count` floater rendering `point_count` + noun (`items`, or `positives` for a Find-subset browse). It's `pointer-events: none` so click-drag-to-recenter still works over it.
- **`browse-subset` handoff**: the `label` field (only ever fed the removed header) and the `suffix` plumbing in `find-view`'s `browseIds` are dropped.
- **Reshoot queue**: `browse-view` shot flagged stale (no browser this session to reshoot).

## Testing

`./run-tests.sh frontend` passes — ruff/codespell/deptry/pyright/pip-audit clean, frontend `build:prod` OK, Vitest 1091 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpHRfdYDuM8UZsXQDQQoZe)_