### PR TITLE
Fix VTSBrowse Browse spinner hanging behind another projection job

### DIFF
--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -97,6 +97,57 @@ class TestProjectionMeta:
         assert body["method"] == "pca"
         assert isinstance(body["media_type"], str)
 
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_building_while_parked_behind_another_job(self, _mock_fit, client):
+        """A full build parked behind another projection job still reports
+        ``building``, not ``idle``.
+
+        The projection runner is a single app-wide slot shared across every
+        dataset's full build and every subset build. When another job holds the
+        runner, this dataset's build is parked in the pending slot. Meta must
+        look up this context's own tracked job (``ctx._full_job_id``) and report
+        its ``building`` status — *not* ask the runner for ``current()``, which
+        returns the unrelated job hogging the slot and made meta fall back to
+        ``idle``. That false ``idle`` made the frontend's poll loop re-issue
+        ``build()`` forever, hanging the Browse spinner until the blocking job
+        happened to free the runner (the reported "reload fixes it" bug).
+        """
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _blocker(job):
+            started.set()
+            release.wait(timeout=30)
+
+        # Occupy the single runner with an unrelated job (a different dataset id
+        # so the build we fire next can't coalesce into it).
+        projection_jobs.start(("blocker",), _blocker, dataset_id="__other__")
+        assert started.wait(timeout=5)
+
+        try:
+            # The runner is busy, so this build parks in the pending slot.
+            resp = client.post("/api/projection/build")
+            assert resp.status_code == 200
+            build_body = resp.get_json()
+            assert build_body["status"] == "building"
+
+            # Regression: meta must find the parked build and say "building".
+            meta = client.get("/api/projection/meta").get_json()
+            assert meta["status"] == "building"
+        finally:
+            release.set()
+
+        # Freeing the runner promotes the parked build; it then finishes.
+        build_job = projection_jobs.get(build_body["job_id"])
+        assert build_job is not None
+        assert build_job.done_event.wait(timeout=30)
+
+        meta = client.get("/api/projection/meta").get_json()
+        assert meta["status"] == "ready"
+        assert meta["point_count"] > 0
+
 
 class TestProjectionBuild:
     """``POST /api/projection/build`` background job lifecycle."""

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -382,8 +382,15 @@ class DatasetContext:
         # pyramids derived from it. The projection (UMAP coords) is shared
         # across bin shapes; ``_pyramids`` maps "hex"/"square" -> Pyramid so the
         # browse hex/square toggle can keep both binnings cached at once.
+        # ``_full_job_id`` tracks the in-flight background UMAP build for status
+        # polling — the projection runner is a single app-wide slot shared with
+        # every other dataset's full build and every subset build, so a poll
+        # must look up *this* dataset's own job by id rather than asking the
+        # runner what it happens to be running right now (which may be a
+        # different dataset's job while this one sits parked pending).
         "_projection",
         "_pyramids",
+        "_full_job_id",
         # VTSBrowse subset projection: an ephemeral UMAP fit over just a subset
         # of this dataset's media ids (e.g. the positives of a Find run),
         # computed on demand and never persisted.  Held alongside the full
@@ -436,6 +443,7 @@ class DatasetContext:
         self._region_index_per_row: Any = None  # np.ndarray | None, int64 (R,)
         self._projection: Any = None  # Projection | None
         self._pyramids: dict[str, Any] = {}  # bin_shape -> Pyramid
+        self._full_job_id: str | None = None  # in-flight full-dataset build job id
         self._subset_projection: Any = None  # Projection | None (ephemeral subset UMAP)
         self._subset_pyramids: dict[str, Any] = {}  # bin_shape -> Pyramid (subset)
         self._subset_ids: list[int] | None = None  # sorted ids the subset layout is fit on

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -271,6 +271,13 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, for
             ctx._pyramids[bin_shape] = pyr
             return {"status": "ready", "projection_id": pyr.projection_id}
 
+        # Already building this exact dataset + shape?  Reuse the in-flight job
+        # instead of queueing a duplicate fit behind it.
+        if ctx._full_job_id:
+            existing = projection_jobs.get(ctx._full_job_id)
+            if existing is not None and existing.signature == sig and existing.status in ("running", "pending"):
+                return {"status": "building", "job_id": existing.job_id}
+
     mat_copy = matrix.copy()
     ids_copy = list(sorted_ids)
     dataset_id = ctx.dataset_id
@@ -302,6 +309,7 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, for
             _persist_projection(dataset_id, proj, pyr)
 
     job = projection_jobs.start(sig, _run, dataset_id=ctx.dataset_id)
+    ctx._full_job_id = job.job_id
     return {"status": "building", "job_id": job.job_id}
 
 
@@ -565,22 +573,19 @@ def projection_meta():
         meta["content_version"] = 0  # full-dataset layouts are never edited in place
         return meta
 
-    job = projection_jobs.current()
-    # A subset build shares the single projection runner; don't report its
-    # progress as the full-dataset build's status.
-    if job is not None and job.job_id == ctx._subset_job_id:
-        job = None
-    if job is not None and job.dataset_id == ctx.dataset_id:
-        if job.status in ("running", "pending"):
-            return {
-                "status": "building",
-                "job_id": job.job_id,
-                "current": job.current,
-                "total": job.total,
-                "message": job.message,
-            }
-        if job.status == "error":
-            return {"status": "error", "error": job.error or "projection build failed"}
+    if ctx._full_job_id:
+        job = projection_jobs.get(ctx._full_job_id)
+        if job is not None:
+            if job.status in ("running", "pending"):
+                return {
+                    "status": "building",
+                    "job_id": job.job_id,
+                    "current": job.current,
+                    "total": job.total,
+                    "message": job.message,
+                }
+            if job.status == "error":
+                return {"status": "error", "error": job.error or "projection build failed"}
 
     return {"status": "idle"}
 


### PR DESCRIPTION
## The bug

From the Dashboard: load a new image demo dataset, click **Browse**. The progress bar spins, then nothing happens — no navigation into VTSBrowser. Clicking again repeats the same non-outcome. Only a page reload, followed by another click, actually lands you in the Browser.

## Root cause

The projection runner (`projection_jobs`) is a **single app-wide slot** — one job runs at a time, with a single coalescing "pending" slot. It's shared by every dataset's full-dataset build **and** every subset (Find-positives) build.

`GET /api/projection/meta` reported build status by asking the runner for `projection_jobs.current()` — the job it happens to be *executing right now*. But when another projection job already occupies the runner, this dataset's build gets parked in the *pending* slot, and `current()` returns the unrelated running job. Since that job's `dataset_id` doesn't match, `projection_meta()` fell through to `{"status": "idle"}` — reporting "nothing built" for a build that is actually queued and in flight.

The frontend (`browse-prep.service.ts`) treats `idle` as "kick off the build," so it re-issues `POST /api/projection/build`, which just re-parks the same pending job. That's an `idle` ⇄ `building` bounce that never progresses or completes until the *other* job finally frees the runner. Meanwhile the completed build persists the projection to the container — which is why a **reload** (a fresh request that finds the persisted layout instantly) makes Browse "just work."

The subset path never had this bug: it already tracks its own job id on the context (`ctx._subset_job_id`) and looks it up directly. The full-dataset path just never got the same treatment.

## The fix

Give the full-dataset build its own tracked job id, mirroring the subset pattern:

- **`DatasetContext._full_job_id`** (new slot) records the in-flight full-dataset build's job id.
- **`_start_umap_build`** stamps `ctx._full_job_id` on start, and reuses an already-in-flight job for the same signature instead of queueing a duplicate behind it (same guard the subset path already has).
- **`projection_meta`** looks up `ctx._full_job_id` directly and reports its `running`/`pending` status as `building`, instead of asking the runner for `current()`. This also lets the old subset-vs-full disambiguation (`job.job_id == ctx._subset_job_id`) go away, since each path now consults only its own tracked id.

## Tests

- New regression test `TestProjectionMeta::test_building_while_parked_behind_another_job`: occupies the runner with an unrelated gated job, fires a full build (which parks pending), and asserts `/api/projection/meta` reports `building` — not `idle`. Releases the runner and confirms the parked build promotes and finishes. This test fails against the pre-fix code (which returned `idle`).
- Full suite green: `ALL 5573 TESTS PASSED (1 skipped)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015by2PQYzTBat5mBqBkHBys)_