### PR TITLE
Test coverage: specs for all four HTTP interceptors

### DIFF
--- a/docs/plans/test-suite-improvements.md
+++ b/docs/plans/test-suite-improvements.md
@@ -96,8 +96,6 @@ Each item below is independent; pick any and delete it when it ships.
 
 <!-- item-sep -->
 
-- **HTTP interceptors (0 of 4 tested)** — `frontend/src/app/interceptors/`: `error.interceptor.ts` (197 lines, the global error-to-toast funnel for every API call), `active-context.interceptor.ts` (stamps `X-Dataset-Id`/`X-Detector-Id` — the backbone of the multi-context state model; a regression silently mistargets every mutation), `achievements-refresh` and `timezone`. These are pure functions over `HttpRequest`/`HttpHandler`, cheap to test with `HttpTestingController`, and currently the highest-risk untested frontend code.
-
 <!-- item-sep -->
 
 - **Browse-canvas subsystem** — `components/browse-canvas/browse-canvas.component.ts` (2,640 lines — largest file in the frontend) plus `browse-minimap.component.ts` (538) have no specs; only the extracted `view-transform.ts` util does. Full canvas rendering isn't unit-testable, but the extracted pure logic is: start by testing `hex-render.util.ts` (219) and `bin-geometry.ts` (143), and extract+test hit-testing/pan-zoom math from the component rather than testing the component wholesale.

--- a/frontend/src/app/interceptors/achievements-refresh.interceptor.spec.ts
+++ b/frontend/src/app/interceptors/achievements-refresh.interceptor.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+
+import { achievementsRefreshInterceptor } from './achievements-refresh.interceptor';
+import { AchievementsService } from '../services/achievements.service';
+
+/**
+ * The achievements-refresh interceptor nudges AchievementsService after any
+ * action endpoint that could unlock a tier. Pin the gate: POST + a watched
+ * path + a 2xx response, and nothing else.
+ */
+describe('achievementsRefreshInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let achievements: { refresh: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    achievements = { refresh: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([achievementsRefreshInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AchievementsService, useValue: achievements },
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  const watched = [
+    '/api/medias/xyz/vote',
+    '/api/detectors/mydet/labels/l1/vote',
+    '/api/find-label',
+    '/api/auto-detect',
+    '/api/label-importers/import/server_json_file',
+    '/api/datasets/registry/reg-1/load',
+  ];
+
+  for (const url of watched) {
+    it(`refreshes after a successful POST to ${url}`, () => {
+      http.post(url, {}).subscribe();
+      httpMock.expectOne(url).flush({ ok: true });
+      expect(achievements.refresh).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  it('does not refresh when a watched POST fails with a non-2xx status', () => {
+    http.post('/api/find-label', {}).subscribe({ error: () => {} });
+    httpMock
+      .expectOne('/api/find-label')
+      .flush({ error: 'boom' }, { status: 500, statusText: 'Server Error' });
+    expect(achievements.refresh).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-POST methods on a watched path', () => {
+    http.get('/api/medias/xyz/vote').subscribe();
+    httpMock.expectOne('/api/medias/xyz/vote').flush({});
+    expect(achievements.refresh).not.toHaveBeenCalled();
+  });
+
+  it('ignores POSTs to unwatched endpoints', () => {
+    http.post('/api/datasets', {}).subscribe();
+    httpMock.expectOne('/api/datasets').flush({});
+    expect(achievements.refresh).not.toHaveBeenCalled();
+  });
+
+  it('matches a watched path even with a query string', () => {
+    http.post('/api/auto-detect?dry=1', {}).subscribe();
+    httpMock.expectOne('/api/auto-detect?dry=1').flush({});
+    expect(achievements.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not match a superstring of a watched path', () => {
+    // The anchored regex must not fire for a longer, unrelated path.
+    http.post('/api/find-label/extra', {}).subscribe();
+    httpMock.expectOne('/api/find-label/extra').flush({});
+    expect(achievements.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/interceptors/active-context.interceptor.spec.ts
+++ b/frontend/src/app/interceptors/active-context.interceptor.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+
+import { activeContextInterceptor } from './active-context.interceptor';
+import { ActiveContextService } from '../services/active-context.service';
+
+/**
+ * The active-context interceptor stamps `X-Dataset-Id` / `X-Detector-Id` on
+ * every outgoing request — the backbone of the multi-context state model. A
+ * regression here silently mistargets every mutation, so pin the exact
+ * header behaviour: only add a header when its id is non-empty.
+ */
+describe('activeContextInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let ctx: ActiveContextService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([activeContextInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    ctx = TestBed.inject(ActiveContextService);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('adds no context headers when nothing is selected', () => {
+    http.get('/api/foo').subscribe();
+    const req = httpMock.expectOne('/api/foo');
+    expect(req.request.headers.has('X-Dataset-Id')).toBe(false);
+    expect(req.request.headers.has('X-Detector-Id')).toBe(false);
+    req.flush({});
+  });
+
+  it('stamps only X-Dataset-Id when a dataset but no detector is active', () => {
+    ctx.setActive('ds-1', '');
+    http.get('/api/foo').subscribe();
+    const req = httpMock.expectOne('/api/foo');
+    expect(req.request.headers.get('X-Dataset-Id')).toBe('ds-1');
+    expect(req.request.headers.has('X-Detector-Id')).toBe(false);
+    req.flush({});
+  });
+
+  it('stamps only X-Detector-Id when a detector but no dataset is active', () => {
+    ctx.setActive('', 'mdl-7');
+    http.get('/api/foo').subscribe();
+    const req = httpMock.expectOne('/api/foo');
+    expect(req.request.headers.has('X-Dataset-Id')).toBe(false);
+    expect(req.request.headers.get('X-Detector-Id')).toBe('mdl-7');
+    req.flush({});
+  });
+
+  it('stamps both headers when a dataset and detector are active', () => {
+    ctx.setActive('ds-1', 'mdl-7');
+    http.get('/api/foo').subscribe();
+    const req = httpMock.expectOne('/api/foo');
+    expect(req.request.headers.get('X-Dataset-Id')).toBe('ds-1');
+    expect(req.request.headers.get('X-Detector-Id')).toBe('mdl-7');
+    req.flush({});
+  });
+
+  it('preserves headers already on the request', () => {
+    ctx.setActive('ds-1', 'mdl-7');
+    http.get('/api/foo', { headers: { 'X-Custom': 'keep-me' } }).subscribe();
+    const req = httpMock.expectOne('/api/foo');
+    expect(req.request.headers.get('X-Custom')).toBe('keep-me');
+    expect(req.request.headers.get('X-Dataset-Id')).toBe('ds-1');
+    req.flush({});
+  });
+});

--- a/frontend/src/app/interceptors/error.interceptor.spec.ts
+++ b/frontend/src/app/interceptors/error.interceptor.spec.ts
@@ -1,0 +1,186 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import {
+  HttpClient,
+  HttpContext,
+  HttpErrorResponse,
+  provideHttpClient,
+  withInterceptors,
+} from '@angular/common/http';
+
+import { errorInterceptor, SKIP_ERROR_TOAST } from './error.interceptor';
+import { ActiveContextService } from '../services/active-context.service';
+import { CONNECTION_PROBE, ConnectionStateService } from '../services/connection-state.service';
+import { ToastService } from '../services/toast.service';
+
+/**
+ * The error interceptor is the global error-to-toast funnel and the
+ * connection circuit-breaker chokepoint. It carries the most logic of the
+ * four interceptors, so these tests exercise: error-body parsing, context
+ * enrichment, the SKIP_ERROR_TOAST opt-out, the silent status-0 path, and
+ * the offline breaker (suppression + probe passthrough).
+ */
+describe('errorInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let toast: { error: ReturnType<typeof vi.fn> };
+  let ctx: ActiveContextService;
+  let connection: ConnectionStateService;
+
+  beforeEach(() => {
+    toast = { error: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([errorInterceptor])),
+        provideHttpClientTesting(),
+        { provide: ToastService, useValue: toast },
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    ctx = TestBed.inject(ActiveContextService);
+    connection = TestBed.inject(ConnectionStateService);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  function tripOffline(): void {
+    connection.recordNetworkFailure();
+    connection.recordNetworkFailure();
+    connection.recordNetworkFailure();
+  }
+
+  it('pushes a structured error toast for a non-zero HTTP status', () => {
+    let caught: HttpErrorResponse | undefined;
+    http.get('/api/foo').subscribe({ error: (e: HttpErrorResponse) => (caught = e) });
+    httpMock
+      .expectOne('/api/foo')
+      .flush(
+        { error: 'Boom', detail: 'more detail', request_id: 'req-1' },
+        { status: 500, statusText: 'Server Error' },
+      );
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    const arg = toast.error.mock.calls[0][0];
+    expect(arg.message).toBe('Boom');
+    expect(arg.detail).toBe('more detail');
+    expect(arg.dedupKey).toBe('http:500:Boom');
+    expect(arg.errorContext.status).toBe(500);
+    expect(arg.errorContext.statusText).toBe('Server Error');
+    expect(arg.errorContext.method).toBe('GET');
+    expect(arg.errorContext.url).toBe('/api/foo');
+    expect(arg.errorContext.requestId).toBe('req-1');
+    // The failure still propagates to the caller unchanged.
+    expect(caught).toBeInstanceOf(HttpErrorResponse);
+    expect(caught?.status).toBe(500);
+  });
+
+  it('enriches the error context with the active dataset/detector ids', () => {
+    ctx.setActive('ds-9', 'mdl-3');
+    http.get('/api/foo').subscribe({ error: () => {} });
+    httpMock.expectOne('/api/foo').flush({ error: 'x' }, { status: 400, statusText: 'Bad Request' });
+
+    const arg = toast.error.mock.calls[0][0];
+    expect(arg.errorContext.datasetId).toBe('ds-9');
+    expect(arg.errorContext.detectorId).toBe('mdl-3');
+  });
+
+  it('falls back to the X-Request-Id header when the body has no request_id', () => {
+    http.get('/api/foo').subscribe({ error: () => {} });
+    httpMock
+      .expectOne('/api/foo')
+      .flush(
+        { error: 'x' },
+        { status: 500, statusText: 'err', headers: { 'X-Request-Id': 'hdr-1' } },
+      );
+
+    expect(toast.error.mock.calls[0][0].errorContext.requestId).toBe('hdr-1');
+  });
+
+  it('surfaces unknown top-level body fields under extra', () => {
+    http.get('/api/foo').subscribe({ error: () => {} });
+    httpMock
+      .expectOne('/api/foo')
+      .flush({ error: 'x', missing_fields: ['a', 'b'] }, { status: 422, statusText: 'err' });
+
+    expect(toast.error.mock.calls[0][0].errorContext.extra).toEqual({
+      missing_fields: ['a', 'b'],
+    });
+  });
+
+  it('captures a non-JSON string body as rawBody and uses a default message', () => {
+    http.get('/api/foo', { responseType: 'text' }).subscribe({ error: () => {} });
+    httpMock
+      .expectOne('/api/foo')
+      .flush('<html>503</html>', { status: 503, statusText: 'Service Unavailable' });
+
+    const arg = toast.error.mock.calls[0][0];
+    expect(arg.errorContext.rawBody).toBe('<html>503</html>');
+    expect(arg.message).toBe('Request failed (503 Service Unavailable).');
+  });
+
+  it('suppresses the toast when SKIP_ERROR_TOAST is set but still propagates the error', () => {
+    let caught: HttpErrorResponse | undefined;
+    http
+      .get('/api/foo', { context: new HttpContext().set(SKIP_ERROR_TOAST, true) })
+      .subscribe({ error: (e: HttpErrorResponse) => (caught = e) });
+    httpMock.expectOne('/api/foo').flush({ error: 'x' }, { status: 500, statusText: 'err' });
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(caught?.status).toBe(500);
+  });
+
+  it('stays silent on a network error (status 0) and never toasts', () => {
+    let caught: HttpErrorResponse | undefined;
+    http.get('/api/foo').subscribe({ error: (e: HttpErrorResponse) => (caught = e) });
+    httpMock.expectOne('/api/foo').error(new ProgressEvent('error'));
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(caught).toBeInstanceOf(HttpErrorResponse);
+    expect(caught?.status).toBe(0);
+  });
+
+  it('trips the connection breaker after repeated network failures', () => {
+    for (let i = 0; i < 3; i++) {
+      http.get('/api/foo').subscribe({ error: () => {} });
+      httpMock.expectOne('/api/foo').error(new ProgressEvent('error'));
+    }
+    expect(connection.isOffline).toBe(true);
+  });
+
+  it('records reachability on a successful response, resetting the failure tally', () => {
+    connection.recordNetworkFailure();
+    connection.recordNetworkFailure();
+
+    http.get('/api/foo').subscribe();
+    httpMock.expectOne('/api/foo').flush({ ok: true });
+
+    // The success reset the tally, so a single further failure must not trip.
+    http.get('/api/bar').subscribe({ error: () => {} });
+    httpMock.expectOne('/api/bar').error(new ProgressEvent('error'));
+    expect(connection.isOffline).toBe(false);
+  });
+
+  it('short-circuits non-probe requests while offline without hitting the wire', () => {
+    tripOffline();
+    expect(connection.isOffline).toBe(true);
+
+    let caught: HttpErrorResponse | undefined;
+    http.get('/api/foo').subscribe({ error: (e: HttpErrorResponse) => (caught = e) });
+
+    // The request must never reach the backend.
+    httpMock.expectNone('/api/foo');
+    expect(caught).toBeInstanceOf(HttpErrorResponse);
+    expect(caught?.status).toBe(0);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('lets the connection probe through the offline breaker', () => {
+    tripOffline();
+    http
+      .get('/healthz', { context: new HttpContext().set(CONNECTION_PROBE, true), responseType: 'text' })
+      .subscribe();
+    httpMock.expectOne('/healthz').flush('ok');
+    expect(connection.isOffline).toBe(false);
+  });
+});

--- a/frontend/src/app/interceptors/timezone.interceptor.spec.ts
+++ b/frontend/src/app/interceptors/timezone.interceptor.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+
+import { timezoneInterceptor } from './timezone.interceptor';
+
+/**
+ * The timezone interceptor carries the browser's local UTC offset to the
+ * backend so wall-clock achievement buckets reflect the user's clock. Pin
+ * that it stamps the offset on every request and leaves existing headers
+ * intact.
+ */
+describe('timezoneInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([timezoneInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    vi.restoreAllMocks();
+  });
+
+  it('stamps X-Timezone-Offset with the current browser offset', () => {
+    const expected = String(new Date().getTimezoneOffset());
+    http.get('/api/foo').subscribe();
+    const req = httpMock.expectOne('/api/foo');
+    expect(req.request.headers.get('X-Timezone-Offset')).toBe(expected);
+    req.flush({});
+  });
+
+  it('reflects the actual getTimezoneOffset value', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-330);
+    http.get('/api/foo').subscribe();
+    const req = httpMock.expectOne('/api/foo');
+    expect(req.request.headers.get('X-Timezone-Offset')).toBe('-330');
+    req.flush({});
+  });
+
+  it('preserves headers already on the request', () => {
+    http.get('/api/foo', { headers: { 'X-Custom': 'keep-me' } }).subscribe();
+    const req = httpMock.expectOne('/api/foo');
+    expect(req.request.headers.get('X-Custom')).toBe('keep-me');
+    expect(req.request.headers.has('X-Timezone-Offset')).toBe(true);
+    req.flush({});
+  });
+});


### PR DESCRIPTION
Closes the **HTTP interceptors (0 of 4 tested)** item from `docs/plans/test-suite-improvements.md` — the highest-risk untested frontend code.

## What landed

Adds a spec file for each interceptor in `frontend/src/app/interceptors/`, driving real requests through `provideHttpClient(withInterceptors([...]))` + `HttpTestingController`:

- **`error.interceptor.spec.ts`** — the global error-to-toast funnel and connection circuit-breaker chokepoint (most logic of the four). Covers: structured error-body parsing (`{error, detail, request_id}`), `X-Request-Id` header fallback, unknown fields surfaced under `extra`, non-JSON string body → `rawBody` + default message, dataset/detector context enrichment, the `SKIP_ERROR_TOAST` opt-out (suppresses toast, still propagates), the silent status-0 network path, breaker tripping after repeated failures, reachability reset on success, offline suppression without hitting the wire, and probe passthrough.
- **`active-context.interceptor.spec.ts`** — `X-Dataset-Id` / `X-Detector-Id` stamping: none/dataset-only/detector-only/both, plus preservation of existing headers.
- **`achievements-refresh.interceptor.spec.ts`** — the POST + watched-path + 2xx gate: parameterized over all six watched patterns, plus non-2xx / non-POST / unwatched / query-string / anchored-regex-superstring negatives.
- **`timezone.interceptor.spec.ts`** — `X-Timezone-Offset` stamping (real + spied offset) and existing-header preservation.

## Verification

`./run-tests.sh frontend` green: TypeScript build OK, `npm audit` clean, Vitest **1136 passed**.

The plan file's frontend item is deleted (sentinels left in place per the plan convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4Ccxae1i2EMZZnCyofrep)_