### PR TITLE
Test suite speedup: ship the Speed section of the test-suite-improvements plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ Tests are grouped by folder under `tests/` and `tests_lib/`. Each folder is a py
 ## Test Markers
 
 - **Default** (`./run-tests.sh` or `pytest tests/`): Runs fast CPU tests only (~35s). Excludes `gpu` and `slow` markers.
-- **`slow`**: CLI subprocess tests that spawn `python app.py --autodetect` (each ~16s, total ~290s). Run with `-m slow` or include with `-m 'not gpu'`.
+- **`slow`**: CLI subprocess tests that spawn `python app.py --autodetect` (2 tests in `tests/cli/test_cli_main_subprocess.py`, each ~16s). Run with `-m slow` or include with `-m 'not gpu'`.
 - **`gpu`**: CUDA-only tests. Run with `-m gpu`.
 - **All tests**: Use `-m ''` to run everything.
 

--- a/docs/plans/test-suite-improvements.md
+++ b/docs/plans/test-suite-improvements.md
@@ -1,50 +1,11 @@
-# Test Suite Improvements (speed + coverage)
+# Test Suite Improvements (coverage)
 
 Open work from a full evaluation of the test suite (2026-07). Baseline measurements that motivate the items below, taken on a 4-core cloud container, cold caches, `pytest tests/ tests_lib/ -q -n auto` with coverage enabled:
 
-- 5,614 Python tests, 197s wall. The worst individual tests are numba-JIT-bound UMAP fits (~50s each) and real-time backoff/ticker sleeps, not training or I/O.
 - Backend line coverage (vtsearch + vtscore combined): **83%**. Cold spots are concentrated in embedder wrappers (stubbed session-wide), `vtsearch/cli_main.py` (6% — only covered by the excluded `slow` subprocess tests), and a handful of network-facing/plugin modules.
 - Frontend: 115 spec files; ~68% of components and ~76% of services have specs; **0 of 4 HTTP interceptors** are tested.
 
 Each item below is independent; pick any and delete it when it ships.
-
-## Speed
-
-<!-- item-sep -->
-
-- **Fix the static-bundle ordering race under bare `pytest -n auto`** — With no pre-built `static/` bundle, 9 tests in `tests/api/test_dashboard.py` fail: the session-autouse fixture in `tests/core/test_frontend.py:39` runs `npm run build:prod` (~28s) only on whichever xdist worker collects that file, while dashboard tests on other workers read `static/` before it exists. (Under `./run-tests.sh` the bundle is built beforehand, so the gate passes — but `pytest tests/ tests_lib/ -m 'not gpu'` is a documented invocation in CLAUDE.md and currently red on a fresh clone.) Fix: hoist ensure-frontend-built into a shared session fixture guarded by a cross-worker file lock (build once, others wait), and make `test_dashboard.py` depend on it; that also prevents N concurrent 16s npm builds when several workers hit `test_frontend.py`.
-
-<!-- item-sep -->
-
-- **Stop paying numba JIT compilation for UMAP/librosa tests** — The two slowest tests, `tests_lib/projection/test_gpu_backends.py::test_umap_fit_transform_falls_back_when_cuml_fit_raises` (53s) and `tests_lib/projection/test_umap_projection.py::test_umap_fit_shape_and_metadata` (49s), run real `umap-learn` fits on tiny matrices (60×16); nearly all the time is numba JIT compiling UMAP's kernels, paid once per xdist worker per run. Options, in order of preference: (a) set `NUMBA_CACHE_DIR` to a persistent path in the test conftests so compiled kernels cache across runs and workers; (b) `NUMBA_DISABLE_JIT=1` for the test env (verify the librosa mel-spectrogram test, `tests/converters/test_audio2image_and_image2text.py::test_convert_mel_spectrogram` at 9.8s, stays tolerable interpreted); (c) mark the real-fit tests `slow` and keep a mocked-UMAP fast path. Expected saving: ~100s of worker CPU per cold run.
-
-<!-- item-sep -->
-
-- **Patch `time.sleep` in the HF backoff-failure test** — `tests_lib/cli/test_preload_progress.py::TestLoadPretrainedLocalFirst::test_network_fallback_error_propagates` (14s) exercises the retry loop in `vtscore/media/embedder.py` (`_HF_RETRY_BACKOFF_BASE` sleeps of 2+4+8s) with real sleeps. The sibling test at `tests_lib/cli/test_preload_progress.py:804` already does `@patch("vtscore.media.embedder.time.sleep")`; apply the same to this one. Saves 14s.
-
-<!-- item-sep -->
-
-- **Parameterize the `timed_progress` tick interval** — `timed_progress` in `vtscore/media/embedder.py` hardcodes `stop.wait(timeout=1.0)`, forcing 9 tests in `tests_lib/cli/test_preload_progress.py` (lines ~1037–1180) to sleep 1.5–2.5s each (~14.5s of pure sleeping). Add a `tick_interval: float = 1.0` parameter and pass ~0.05 in tests; replace the unconditional "verify ticker stopped" post-block sleeps with a wait of a couple of tick intervals.
-
-<!-- item-sep -->
-
-- **Stub or cache waveform thumbnails in the media fixtures** — `tests/fixtures/medias.py:89` (and the `tests_lib` twin) call `generate_waveform_thumbnail()` for each of the 20 generated WAVs at session start, which imports librosa/numba and decodes every file — in every xdist worker, every run. Either cache `thumbnail_bytes` in the existing per-worker `media_embedding_cache*.npz`, or stub `generate_waveform_thumbnail` the way `embed_audio_file` is stubbed. Also: the NPZ embedding cache stores conftest-faked vectors (saves nothing) and writes into the repo's `data/` dir — consider dropping it or pointing it at a temp dir while in there.
-
-<!-- item-sep -->
-
-- **Replace fixed race-window sleeps with "waiter parked" event hooks** — Negative-assertion sleeps that always pay full price and are inherently flaky: `tests/datasets/test_parallel_loading.py:669,729,733` (0.3–0.5s around the download gate), `tests/io/test_sync_sources.py:1819` (0.3s cancelled-timer probe), `tests_lib/detectors/test_new_embedders.py:1322` (0.1s lock race). Add a test-visible `threading.Event` set when a waiter blocks on the gate/timer so the tests become deterministic and near-instant.
-
-<!-- item-sep -->
-
-- **Trim the voting-iteration eval sweeps** — `tests_lib/detectors/test_eval_voting_iterations.py` makes 27 calls to `simulate_voting_iterations` / `run_voting_iterations_eval`, each training an MLP per voting step and calibrating per split; several tests take 1.3–5.5s. Where the assertion doesn't need the full sweep (shape/plumbing tests like `test_full_cross_product_shape`, `test_multiple_seeds`), pass minimal step counts / `calibrate_count` and smaller media pools. Same review applies to `tests/sorting/test_safe_thresholds.py` (4 tests at 1.8–3.6s) and the 500-epoch run at `tests/sorting/test_sorting.py:272` (could assert on a smaller epoch bound).
-
-<!-- item-sep -->
-
-- **Slim the combine-datasets pickle round-trips** — `tests/datasets/test_combine_datasets.py` has ~10 tests at ~2s each; `make_dataset_file` (`tests/helpers.py:55`) pickles the full 20-media snapshot including `media_bytes` (~3–4MB per write) even for tests that only assert on metadata/dedup/registry behavior. Use 2–3-media subsets (several tests already do) or strip `media_bytes` where the test doesn't read it back.
-
-<!-- item-sep -->
-
-- **Correct the stale `slow`-marker note in CLAUDE.md** — Only 2 subprocess CLI tests remain (`tests/cli/test_cli_main_subprocess.py`, ~16s each); CLAUDE.md still says "total ~290s". Update when touching CLAUDE.md for other reasons (or as part of the in-process CLI item below, which may remove them entirely).
 
 ## Coverage — backend
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -330,12 +330,17 @@ fi
 #   --no-header: skip the platform/plugin header noise
 #   -q:         quiet mode (dots instead of full test names)
 #   -n auto:    parallel execution via pytest-xdist (one worker per CPU)
+#   --dist loadgroup: like the default load scheduling, except tests marked
+#       @pytest.mark.xdist_group run together on one worker.  Used to pin all
+#       real-UMAP-fit tests to a single worker so the ~30s numba JIT compile
+#       of umap-learn's kernels is paid once per run, not once per worker
+#       (see tests_lib/projection/test_umap_projection.py).
 #
 # Both tests/ (app tier) and tests_lib/ (library tier) are passed in.
 # The two trees have independent conftests; pytest's auto-merge picks
 # the right autouse fixtures per test based on file location.
 if [[ -n "$MARKER_EXPR" ]]; then
-    python -m pytest tests/ tests_lib/ -q --tb=short --no-header -n auto -m "$MARKER_EXPR" "${COV_ARGS[@]}" "${EXTRA_ARGS[@]}"
+    python -m pytest tests/ tests_lib/ -q --tb=short --no-header -n auto --dist loadgroup -m "$MARKER_EXPR" "${COV_ARGS[@]}" "${EXTRA_ARGS[@]}"
 else
-    python -m pytest tests/ tests_lib/ -q --tb=short --no-header -n auto "${COV_ARGS[@]}" "${EXTRA_ARGS[@]}"
+    python -m pytest tests/ tests_lib/ -q --tb=short --no-header -n auto --dist loadgroup "${COV_ARGS[@]}" "${EXTRA_ARGS[@]}"
 fi

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -1,5 +1,7 @@
 """Tests for the VTSearch dashboard API endpoint."""
 
+import pytest
+
 import app as app_module  # noqa: F401  (triggers conftest side effects)
 from vtscore.datasets.registry import register_dataset
 from vtscore.detectors.registry import register_detector
@@ -127,6 +129,7 @@ class TestDashboardDiskUsage:
         assert data["used"] + data["free"] <= data["total"] + 1  # rounding tolerance
 
 
+@pytest.mark.usefixtures("angular_bundle")
 class TestDashboardHtmlPresent:
     """Test that the dashboard-related content is present in the Angular bundle."""
 
@@ -217,6 +220,7 @@ class TestGuessMediaEmbedder:
         task = next(t for t in tasks if t["task_id"] == "test_no_emb")
         assert "embedder" not in task
 
+    @pytest.mark.usefixtures("angular_bundle")
     def test_js_contains_embedder_guessing_logic(self, client):
         """The Angular bundle should include the embedder guessing code."""
         import glob as globmod
@@ -435,6 +439,7 @@ class TestDashboardSecurityIcon:
         assert "readers" in ds
         assert isinstance(ds["readers"], list)
 
+    @pytest.mark.usefixtures("angular_bundle")
     def test_security_icon_in_frontend_bundle(self, client):
         """The Angular bundle should contain the security icon shield path."""
         import glob as globmod
@@ -646,6 +651,7 @@ class TestAutofindCheckboxPersistence:
         assert "autofind_detectors" not in data
 
 
+@pytest.mark.usefixtures("angular_bundle")
 class TestDashboardColumnHeaders:
     """Verify the frontend JS contains the updated column headers."""
 
@@ -695,6 +701,7 @@ class TestFindButtonValidation:
         assert resp.status_code == 400
         assert "No datasets selected" in resp.get_json()["message"]
 
+    @pytest.mark.usefixtures("angular_bundle")
     def test_frontend_uses_resolved_model_count(self, client):
         """The Angular bundle should use resolvedSelectedModels for Find validation."""
         import glob as globmod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,17 @@ init_medias()
 # Save the test medias so we can replay them into each test's fresh context.
 _test_medias_snapshot = {k: dict(v) for k, v in medias.items()}
 
+# Freeze the startup heap (torch, Flask app, test medias — all of it lives for
+# the whole session anyway) so it is excluded from garbage-collection scans.
+# Production code sprinkles ``gc.collect()`` through the dataset-load pipeline
+# for memory hygiene on huge datasets; with the multi-hundred-MB startup heap
+# unfrozen, each of those calls costs ~0.3s of pure scan time in tests that
+# load several tiny datasets (combine, staging, promote).
+import gc
+
+gc.collect()
+gc.freeze()
+
 # Stop the module-level patch (init_medias is done); the per-test autouse
 # fixture below re-applies the patches for every test so that /api/sort and
 # other routes that call embed_text don't trigger CLAP loading either.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,6 +323,18 @@ def reset_state():
 
     _clear_query_cache()
 
+    # ``resolve_device`` is lru_cached for the life of the process.  A test
+    # that resolves it under mocked CUDA (e.g. tests_lib/core/
+    # test_torch_config.py, which shares the worker process) would otherwise
+    # leak a cached "cuda" into every later ``train_model`` on a CPU-only box.
+    # ``vtscore.embedding.loader`` binds the function at import, and the
+    # ``importlib.reload`` in those tests can leave it holding a *different*
+    # function object than the current module attribute — clear both.
+    import vtscore.embedding.loader as _emb_loader
+
+    config.resolve_device.cache_clear()
+    _emb_loader.resolve_device.cache_clear()
+
     _dataset_progress.reset_cancel()
     _find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _sort_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -149,6 +150,71 @@ _audio_emb = _embedders_for_type("audio")[0]
 # download real CLIP / X-CLIP / E5 / SigLIP weights.
 _ALL_EMBEDDERS = _all_embedders()
 _ALL_MEDIA_TYPES = _all_types()
+
+
+# ---------------------------------------------------------------------------
+# Angular bundle (static/) on demand, safe under pytest-xdist.
+#
+# `./run-tests.sh` builds the bundle before pytest starts, so this is a no-op
+# there.  Bare `pytest tests/ -n auto` invocations on a fresh clone need the
+# bundle built exactly once: without cross-worker coordination, the worker
+# that collects tests/core/test_frontend.py would build while workers running
+# tests/api/test_dashboard.py read static/ before it exists (and several
+# workers could kick off concurrent ~16s npm builds).  A cross-process flock
+# (vtscore.io.file_lock) elects one builder; the others block until the build
+# finishes, then see the bundle and return.
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_STATIC_DIR = _REPO_ROOT / "static"
+_FRONTEND_DIR = _REPO_ROOT / "frontend"
+
+
+def _angular_bundle_built() -> bool:
+    return (_STATIC_DIR / "index.html").exists() and (_STATIC_DIR / "main.js").exists()
+
+
+@pytest.fixture(scope="session")
+def angular_bundle() -> None:
+    """Ensure the Angular bundle exists in ``static/`` (build once per run).
+
+    Tests that serve the SPA shell or read bundle artefacts request this
+    fixture.  Skips (cached for the whole session) when the bundle is absent
+    and cannot be built here (no npm / node_modules / failing build).
+    """
+    import shutil
+    import subprocess
+
+    if _angular_bundle_built():
+        return
+    npm = shutil.which("npm")
+    if npm is None or not (_FRONTEND_DIR / "node_modules").exists():
+        pytest.skip(
+            "Angular bundle not built and cannot build it here "
+            f"(npm={'found' if npm else 'missing'}, "
+            f"node_modules={'present' if (_FRONTEND_DIR / 'node_modules').exists() else 'missing'}). "
+            "Run: cd frontend && npm install && npm run build:prod"
+        )
+
+    from vtscore.io import file_lock
+
+    # flock-based: releases automatically if the building process dies, so a
+    # crashed builder can't wedge the other workers.
+    with file_lock(config.DATA_DIR / "angular-bundle-build"):
+        if _angular_bundle_built():
+            return  # another xdist worker built it while we waited
+        try:
+            subprocess.run(  # noqa: S603  # npm resolved via shutil.which, args are constant
+                [npm, "run", "build:prod"],
+                cwd=_FRONTEND_DIR,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            pytest.skip(f"Angular build failed: {exc.stderr.strip() or exc.stdout.strip() or exc}")
+    if not _angular_bundle_built():
+        pytest.skip("Angular build completed but static/main.js or static/index.html still missing")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/test_frontend.py
+++ b/tests/core/test_frontend.py
@@ -10,68 +10,18 @@ Covers:
 
 from __future__ import annotations
 
-import shutil
-import subprocess
-from pathlib import Path
-
 import pytest
 
 # Tests below hit the Angular SPA shell or its bundle artefacts
 # (main.js / styles.css / index.html; the app is zoneless, so there is no
-# polyfills.js bundle), which only exist
-# after `npm run build:prod` has populated `static/`.  `./run-tests.sh`
-# builds the bundle as part of the core / full-suite path, so the
-# normal flow is already covered.  For plain `pytest` invocations the
-# session fixture below builds the bundle on demand (~16s, once per
-# session) so the tests run for real instead of being silently skipped.
-# Only if the build itself isn't possible (no npm, no node_modules, or
-# `npm run build:prod` fails) do we fall back to `pytest.skip` with a
-# clear reason.
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_STATIC_DIR = _REPO_ROOT / "static"
-_FRONTEND_DIR = _REPO_ROOT / "frontend"
-
-
-def _bundle_built() -> bool:
-    return (_STATIC_DIR / "index.html").exists() and (_STATIC_DIR / "main.js").exists()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _ensure_angular_bundle() -> None:
-    """Build the Angular bundle on demand if it isn't already on disk.
-
-    Runs once per session.  No-op when the bundle is already present
-    (the normal `./run-tests.sh` flow builds it before pytest starts).
-    """
-    if _bundle_built():
-        return
-    npm = shutil.which("npm")
-    if npm is None or not (_FRONTEND_DIR / "node_modules").exists():
-        pytest.skip(
-            "Angular bundle not built and cannot build it here "
-            f"(npm={'found' if npm else 'missing'}, "
-            f"node_modules={'present' if (_FRONTEND_DIR / 'node_modules').exists() else 'missing'}). "
-            "Run: cd frontend && npm install && npm run build:prod",
-            allow_module_level=True,
-        )
-    try:
-        subprocess.run(  # noqa: S603  # npm resolved via shutil.which, args are constant
-            [npm, "run", "build:prod"],
-            cwd=_FRONTEND_DIR,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        pytest.skip(
-            f"Angular build failed: {exc.stderr.strip() or exc.stdout.strip() or exc}",
-            allow_module_level=True,
-        )
-    if not _bundle_built():
-        pytest.skip(
-            "Angular build completed but static/main.js or static/index.html still missing",
-            allow_module_level=True,
-        )
+# polyfills.js bundle), which only exist after `npm run build:prod` has
+# populated `static/`.  `./run-tests.sh` builds the bundle as part of the
+# core / full-suite path, so the normal flow is already covered.  For plain
+# `pytest` invocations the shared session fixture `angular_bundle` (in
+# tests/conftest.py, guarded by a cross-worker file lock for `-n auto`)
+# builds the bundle on demand, or skips with a clear reason when the build
+# isn't possible (no npm, no node_modules, or `npm run build:prod` fails).
+pytestmark = pytest.mark.usefixtures("angular_bundle")
 
 
 class TestIndexRoute:

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -629,7 +629,13 @@ class TestStageDemoEndpoint:
         assert data["ok"] is True
 
 
+@pytest.mark.xdist_group("shared-staging-dir")
 class TestClearStagingEndpoint:
+    """DELETE /api/dataset/staging wipes the repo-shared ``data/staging/``
+    directory, so these tests must not run concurrently with tests on other
+    xdist workers that assert staged files exist on disk — grouped with
+    ``TestStagingPerTaskIsolation`` via ``--dist loadgroup``."""
+
     def test_clear_staging(self, client):
         """DELETE /api/dataset/staging returns ok."""
         resp = client.delete("/api/dataset/staging")
@@ -704,11 +710,15 @@ def _sync_thread_factory(store: list):
     return fake_thread
 
 
+@pytest.mark.xdist_group("shared-staging-dir")
 class TestStagingPerTaskIsolation:
     """Two concurrent staging imports must each publish their own
     ``staging_result`` on their own per-task tracker; the terminal result is
     no longer last-writer-wins on the global ``dataset_progress`` singleton
-    (which orphaned the loser's staged pkl)."""
+    (which orphaned the loser's staged pkl).
+
+    Grouped with ``TestClearStagingEndpoint``: the existence assertions below
+    read the repo-shared ``data/staging/`` dir, which that class wipes."""
 
     def test_concurrent_stagings_keep_distinct_results(self, isolated_settings):
         from pathlib import Path

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -611,7 +611,12 @@ class TestStageImportEndpoint:
         assert result["ok"] is True
 
 
+@pytest.mark.xdist_group("shared-demo-data-dir")
 class TestStageDemoEndpoint:
+    """Grouped with the demo-status tests in ``test_datasets.py``: staging a
+    demo reads the repo-shared ``data/embeddings/<demo>.pkl`` those tests
+    create and delete."""
+
     def test_rejects_invalid_name(self, client):
         resp = client.post("/api/dataset/stage-demo/nonexistent_xyz_demo")
         assert resp.status_code == 400

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -426,8 +426,15 @@ class TestStartupState:
         )
 
 
+@pytest.mark.xdist_group("shared-demo-data-dir")
 class TestDemoDatasetReadiness:
-    """Demo datasets report three-state status: ready / needs_embedding / needs_download."""
+    """Demo datasets report three-state status: ready / needs_embedding / needs_download.
+
+    These tests create/delete real files under the repo-shared
+    ``data/embeddings/`` and ``data/ESC-50-master/`` paths (several write the
+    *same* filename), so they are pinned to one xdist worker via
+    ``--dist loadgroup`` together with every other test touching those paths.
+    """
 
     def test_audio_pkl_without_esc50_shows_needs_download(self, client):
         """Audio pkl exists but ESC-50 audio dir is absent → needs_download (stale pkl)."""
@@ -620,8 +627,12 @@ class TestDemoDatasetReadiness:
             assert ds["status"] in ("ready", "needs_embedding", "needs_download")
 
 
+@pytest.mark.xdist_group("shared-demo-data-dir")
 class TestDemoDatasetEmbedderStatus:
-    """Demo dataset status respects which embedder produced the cached pkl."""
+    """Demo dataset status respects which embedder produced the cached pkl.
+
+    Grouped with ``TestDemoDatasetReadiness``: these tests write the same
+    repo-shared ``data/embeddings/<demo>.pkl`` files."""
 
     def test_ready_with_matching_embedder(self, client):
         """Container with matching embedder in meta → ready."""

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -658,15 +658,16 @@ class TestLoadingGates:
             # Wait for first load to actually start running.
             assert first_started.wait(timeout=10)
 
+            _download_gate.waiter_parked.clear()
             task2 = _run_origin_load_in_background(
                 second_load,
                 {"importer": "test2", "params": {}},
                 name="Second",
             )
 
-            # Second load should be waiting; give it a moment to start its
-            # thread and hit the gate wait.
-            time.sleep(0.3)
+            # Wait until the second load is actually parked on the gate
+            # (deterministic; no fixed race-window sleep).
+            assert _download_gate.waiter_parked.wait(timeout=10), "Second load never blocked on the download gate"
             assert not second_started.is_set(), "Second load should be queued, not running"
 
             # Check that the second task shows a "Waiting" message.
@@ -721,16 +722,22 @@ class TestLoadingGates:
             assert first_started.wait(timeout=10)
 
             # Start a second load; it will be queued on the download gate.
+            _download_gate.waiter_parked.clear()
             task2 = _run_origin_load_in_background(
                 lambda medias: None,
                 {"importer": "test2", "params": {}},
                 name="Second",
             )
-            time.sleep(0.3)
+            assert _download_gate.waiter_parked.wait(timeout=10), "Second load never blocked on the download gate"
 
-            # Cancel the queued task before it acquires the gate.
+            # Cancel the queued task before it acquires the gate, then wait
+            # for its worker thread to fully unwind (mark_finished runs in
+            # the task's outermost finally, after any gate release).
             loading_tasks.cancel_task(task2)
-            time.sleep(0.5)
+            deadline = time.time() + 10
+            while not loading_tasks.is_finished(task2) and time.time() < deadline:
+                time.sleep(0.05)
+            assert loading_tasks.is_finished(task2), "Cancelled task never finished"
 
             # The gate should still show exactly one holder (the first load).
             # If the cancel wrongly released, active would drop to 0.

--- a/tests/fixtures/medias.py
+++ b/tests/fixtures/medias.py
@@ -1,13 +1,11 @@
-"""Test media generation and embedding cache management."""
+"""Test media generation."""
 
 import hashlib
+import io
 import os
-
-import numpy as np
 
 from vtscore.media.audio.audio_generator import generate_wav
 from vtscore.config import DATA_DIR
-from vtscore.media.audio.media_type import generate_waveform_thumbnail
 
 NUM_MEDIAS = 20
 from vtscore.embedding import embed_audio_file
@@ -24,56 +22,41 @@ def _worker_suffix():
     return f".{worker}" if worker else ""
 
 
-def _embedding_cache_path():
-    """Path to the cached test-media embeddings file (worker-specific under xdist)."""
-    return DATA_DIR / f"media_embedding_cache{_worker_suffix()}.npz"
+def _fake_waveform_thumbnail() -> bytes:
+    """A tiny valid PNG standing in for a real waveform thumbnail.
 
+    The real ``generate_waveform_thumbnail()`` imports librosa (and its numba
+    stack) and decodes every generated WAV — seconds of startup per xdist
+    worker per run, spent on pixels no test inspects beyond "non-empty PNG
+    bytes".  A solid-colour PIL PNG satisfies every consumer; routes that
+    exercise real on-the-fly thumbnailing pop ``thumbnail_bytes`` first and
+    still hit the real code path.
+    """
+    from PIL import Image  # noqa: PLC0415
 
-def _embedding_cache_key():
-    """Deterministic key derived from media-generation parameters so the cache
-    auto-invalidates when NUM_MEDIAS, frequencies, or durations change."""
-    parts = []
-    for i in range(1, NUM_MEDIAS + 1):
-        freq = 200 + (i - 1) * 50
-        dur = round(1.0 + (i % 5) * 0.5, 1)
-        parts.append(f"{i}:{freq}:{dur}")
-    return hashlib.md5("|".join(parts).encode()).hexdigest()
+    buf = io.BytesIO()
+    Image.new("RGB", (80, 80), (32, 32, 32)).save(buf, format="PNG")
+    return buf.getvalue()
 
 
 def init_medias():
-    """Generate test medias with embeddings, using a cache for speed."""
+    """Generate test medias with (conftest-stubbed) embeddings.
+
+    ``embed_audio_file`` is patched with a deterministic fake by conftest
+    before this runs, so embedding is cheap; each WAV is still written to a
+    temp file because the fake derives its seed from the file's leading bytes
+    (distinct audio → distinct, worker-independent vectors).
+    """
     DATA_DIR.mkdir(exist_ok=True)
-    suffix = _worker_suffix()
-    temp_path = DATA_DIR / f"temp_embed{suffix}.wav"
-    cache_path = _embedding_cache_path()
-    cache_key = _embedding_cache_key()
+    temp_path = DATA_DIR / f"temp_embed{_worker_suffix()}.wav"
+    thumbnail = _fake_waveform_thumbnail()
 
-    # Try to load cached embeddings
-    cached_embeddings = {}
-    if cache_path.exists():
-        try:
-            data = np.load(cache_path, allow_pickle=False)
-            if "cache_key" in data and str(data["cache_key"]) == cache_key:
-                for i in range(1, NUM_MEDIAS + 1):
-                    k = f"emb_{i}"
-                    if k in data:
-                        cached_embeddings[i] = data[k]
-        except Exception:
-            pass
-
-    new_embeddings = {}
     for i in range(1, NUM_MEDIAS + 1):
         freq = 200 + (i - 1) * 50  # 200 Hz .. 1150 Hz
         duration = round(1.0 + (i % 5) * 0.5, 1)  # 1.0 – 3.0 s
         wav_bytes = generate_wav(freq, duration)
-
-        if i in cached_embeddings:
-            embedding = cached_embeddings[i]
-        else:
-            # Generate embedding by saving to temp file
-            temp_path.write_bytes(wav_bytes)
-            embedding = embed_audio_file(temp_path)
-            new_embeddings[i] = embedding
+        temp_path.write_bytes(wav_bytes)
+        embedding = embed_audio_file(temp_path)
 
         fname = f"test_media_{i}.wav"
         medias[i] = {
@@ -86,7 +69,7 @@ def init_medias():
             "md5": hashlib.md5(wav_bytes).hexdigest(),
             "embeddings": {"clap": embedding},
             "media_bytes": wav_bytes,
-            "thumbnail_bytes": generate_waveform_thumbnail(wav_bytes),
+            "thumbnail_bytes": thumbnail,
             "filename": fname,
             "category": "test",
             "origin": {"importer": "test", "params": {}},
@@ -96,10 +79,3 @@ def init_medias():
     # Clean up temp file
     if temp_path.exists():
         temp_path.unlink()
-
-    # Save cache if we computed any new embeddings (or cache didn't exist)
-    if new_embeddings or not cached_embeddings:
-        save_data = {"cache_key": np.array(cache_key)}
-        for i in range(1, NUM_MEDIAS + 1):
-            save_data[f"emb_{i}"] = medias[i]["embeddings"]["clap"]
-        np.savez(cache_path, **save_data)  # pyright: ignore[reportArgumentType]

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -1795,6 +1795,7 @@ class TestLabelsetSyncDebounce:
     def test_reset_drops_pending_without_writing(self, tmp_path):
         """reset_label_sync_for_tests cancels the timer instead of running it."""
         from vtscore.labels.sync import (
+            _run_pending_sync,
             reset_label_sync_for_tests,
             sync_to_labelset_source,
         )
@@ -1813,10 +1814,10 @@ class TestLabelsetSyncDebounce:
 
             reset_label_sync_for_tests()
 
-            # Give any (cancelled) timer a chance to fire.
-            import time
-
-            time.sleep(0.3)
+            # Simulate the worst-case race deterministically: a timer that
+            # already fired before cancel() landed runs its callback *after*
+            # the reset.  The pending entry is gone, so it must be a no-op.
+            _run_pending_sync(ctx.detector_id)
 
             assert not (tmp_path / "labels.json").exists()
         finally:

--- a/tests/sorting/test_safe_thresholds.py
+++ b/tests/sorting/test_safe_thresholds.py
@@ -350,18 +350,22 @@ class TestSafeThresholdsEval:
     def test_simulate_voting_iterations_accepts_safe_thresholds(self):
         from vtscore.eval.voting_iterations import simulate_voting_iterations
 
-        medias = self._make_clips()
+        # Plumbing test: a small pool + calibrate_count=1 keeps the per-step
+        # MLP-train/calibrate sweep cheap; the assertion is shape-only.
+        medias = self._make_clips(n=16)
         rows_off = simulate_voting_iterations(
             medias,
             "target",
             seed=42,
             safe_thresholds=False,
+            calibrate_count=1,
         )
         rows_on = simulate_voting_iterations(
             medias,
             "target",
             seed=42,
             safe_thresholds=True,
+            calibrate_count=1,
         )
         # Both should produce valid results
         assert len(rows_off) > 0
@@ -375,12 +379,13 @@ class TestSafeThresholdsEval:
     def test_run_voting_iterations_eval_accepts_safe_thresholds(self):
         from vtscore.eval.voting_iterations import run_voting_iterations_eval
 
-        medias = self._make_clips()
+        medias = self._make_clips(n=16)
         df = run_voting_iterations_eval(
             {"test": medias},
             seeds=[42],
             categories={"test": ["target"]},
             safe_thresholds=True,
+            calibrate_count=1,
         )
         assert len(df) > 0
         assert "cost" in df.columns
@@ -568,12 +573,15 @@ class TestCalibrationFractionEval:
     def test_simulate_voting_iterations_accepts_calibration_fraction(self):
         from vtscore.eval.voting_iterations import simulate_voting_iterations
 
-        medias = self._make_clips()
+        # Plumbing test: small pool + calibrate_count=1 (see the safe-
+        # thresholds twin above).
+        medias = self._make_clips(n=16)
         rows = simulate_voting_iterations(
             medias,
             "target",
             seed=42,
             calibration_fraction=0.3,
+            calibrate_count=1,
         )
         assert len(rows) > 0
         for row in rows:
@@ -582,12 +590,13 @@ class TestCalibrationFractionEval:
     def test_run_voting_iterations_eval_accepts_calibration_fraction(self):
         from vtscore.eval.voting_iterations import run_voting_iterations_eval
 
-        medias = self._make_clips()
+        medias = self._make_clips(n=16)
         df = run_voting_iterations_eval(
             {"test": medias},
             seeds=[42],
             categories={"test": ["target"]},
             calibration_fraction=0.2,
+            calibrate_count=1,
         )
         assert len(df) > 0
 

--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -787,7 +787,8 @@ class TestLoadPretrainedLocalFirst:
         except ImportError:
             pass
 
-    def test_network_fallback_error_propagates(self):
+    @patch("vtscore.media.embedder.time.sleep")
+    def test_network_fallback_error_propagates(self, mock_sleep):
         """If both local and network attempts fail, the network error propagates."""
 
         def fake_load(*args, **kwargs):
@@ -1025,23 +1026,28 @@ class TestTimedProgress:
 
     def test_elapsed_time_updates_during_slow_operation(self):
         """A slow block should produce elapsed-time suffixed messages."""
-        import time
+        import re
+        import threading
 
         calls = []
+        ticked = threading.Event()
 
         def cb(status, message, current, total):
             calls.append((status, message, current, total))
+            if "(" in message:
+                ticked.set()
 
-        with timed_progress(cb, "loading", "Importing torch…", 1, 2):
-            # Sleep long enough for at least one tick (~1s interval)
-            time.sleep(2.5)
+        with timed_progress(cb, "loading", "Importing torch…", 1, 2, tick_interval=0.05):
+            # Block until the ticker has fired at least once (deterministic,
+            # no fixed sleep).
+            assert ticked.wait(timeout=5)
 
         # Should have the initial message plus at least one timed update
         timed_calls = [c for c in calls if "(" in c[1]]
         assert len(timed_calls) >= 1
-        # Check format: "Importing torch… (1s)" / "(2s)"; possibly extended with
+        # Check format: "Importing torch… (Ns)"; possibly extended with
         # ", N modules" when sys.modules grew during the block.
-        assert any("(1s" in c[1] or "(2s" in c[1] for c in timed_calls)
+        assert any(re.search(r"\(\d+s", c[1]) for c in timed_calls)
         # All calls should preserve status, current, total
         for c in calls:
             assert c[0] == "loading"
@@ -1052,21 +1058,25 @@ class TestTimedProgress:
         """If sys.modules grows during the block, the ticker suffix should
         include the count so the user sees a concrete 'still working' signal."""
         import sys
-        import time
+        import threading
         import types
 
         calls = []
+        saw_modules = threading.Event()
 
         def cb(status, message, current, total):
             calls.append(message)
+            if "modules" in message:
+                saw_modules.set()
 
         fake_names = [f"_vtsearch_test_fake_mod_{i}" for i in range(5)]
         try:
-            with timed_progress(cb, "loading", "Importing thing…", 0, 0):
+            with timed_progress(cb, "loading", "Importing thing…", 0, 0, tick_interval=0.05):
                 # Simulate new modules being registered (cheaper than a real import).
                 for name in fake_names:
                     sys.modules[name] = types.ModuleType(name)
-                time.sleep(1.5)
+                # Block until a tick reported the module-count suffix.
+                assert saw_modules.wait(timeout=5)
         finally:
             for name in fake_names:
                 sys.modules.pop(name, None)
@@ -1077,18 +1087,24 @@ class TestTimedProgress:
 
     def test_ticker_stops_after_block_exits(self):
         """The background ticker thread should stop once the with block exits."""
+        import threading
         import time
 
         calls = []
+        ticked = threading.Event()
 
         def cb(status, message, current, total):
             calls.append(time.monotonic())
+            ticked.set()
 
-        with timed_progress(cb, "loading", "test", 0, 1):
-            time.sleep(1.5)
+        with timed_progress(cb, "loading", "test", 0, 1, tick_interval=0.05):
+            assert ticked.wait(timeout=5)
 
         count_during = len(calls)
-        time.sleep(1.5)
+        # The context manager joins the ticker thread on exit, so no further
+        # calls can arrive; a wait of a few tick intervals would catch a
+        # regression where the ticker outlives the block.
+        time.sleep(0.25)
         count_after = len(calls)
 
         # No new calls should arrive after the block exits
@@ -1096,34 +1112,44 @@ class TestTimedProgress:
 
     def test_exception_in_block_still_stops_ticker(self):
         """The ticker should be cleaned up even if the block raises."""
+        import threading
         import time
 
         calls = []
+        ticked = threading.Event()
 
         def cb(status, message, current, total):
             calls.append(message)
+            ticked.set()
 
         try:
-            with timed_progress(cb, "loading", "test", 0, 0):
-                time.sleep(1.5)
+            with timed_progress(cb, "loading", "test", 0, 0, tick_interval=0.05):
+                assert ticked.wait(timeout=5)
                 raise RuntimeError("boom")
         except RuntimeError:
             pass
 
         count_during = len(calls)
-        time.sleep(1.5)
+        # A few tick intervals is enough to catch a leaked ticker.
+        time.sleep(0.25)
         count_after = len(calls)
 
         assert count_after == count_during
 
     def test_works_with_console_progress_wrapper(self, capsys):
         """timed_progress should integrate with _make_console_progress."""
-        import time
+        import threading
 
-        cb = _make_console_progress(lambda *a, **kw: None)
+        ticked = threading.Event()
+        console = _make_console_progress(lambda *a, **kw: None)
 
-        with timed_progress(cb, "loading", "Importing torch…", 1, 2):
-            time.sleep(1.5)
+        def cb(status, message, current, total):
+            console(status, message, current, total)
+            if "(" in message:
+                ticked.set()
+
+        with timed_progress(cb, "loading", "Importing torch…", 1, 2, tick_interval=0.05):
+            assert ticked.wait(timeout=5)
 
         captured = capsys.readouterr()
         # Should see the initial message and at least one elapsed update
@@ -1134,20 +1160,24 @@ class TestTimedProgress:
         module-count delta, clamped one below the estimate so a running import
         can never report 100% (the snap to done is signalled externally)."""
         import sys
-        import time
+        import threading
         import types
 
         calls = []
+        bar_moved = threading.Event()
 
         def cb(status, message, current, total):
             calls.append((current, total))
+            if current > 0:
+                bar_moved.set()
 
         fake = [f"_vt_est_fake_mod_{i}" for i in range(5)]
         try:
-            with timed_progress(cb, "loading", "Importing thing…", est_modules=3):
+            with timed_progress(cb, "loading", "Importing thing…", est_modules=3, tick_interval=0.05):
                 for name in fake:
                     sys.modules[name] = types.ModuleType(name)
-                time.sleep(1.5)
+                # Block until a tick moved the bar off zero.
+                assert bar_moved.wait(timeout=5)
         finally:
             for name in fake:
                 sys.modules.pop(name, None)
@@ -1167,17 +1197,24 @@ class TestTimedProgress:
         never shows 100% (that only happens on completion, via the next phase
         message or cb.flush())."""
         import sys
-        import time
+        import threading
         import types
 
-        cb = _make_console_progress(lambda *a, **kw: None)
+        ticked = threading.Event()
+        console = _make_console_progress(lambda *a, **kw: None)
+
+        def cb(status, message, current, total):
+            console(status, message, current, total)
+            if current > 0:
+                ticked.set()
 
         fake = [f"_vt_est_con_mod_{i}" for i in range(8)]
         try:
-            with timed_progress(cb, "loading", "Importing thing…", est_modules=4):
+            with timed_progress(cb, "loading", "Importing thing…", est_modules=4, tick_interval=0.05):
                 for name in fake:
                     sys.modules[name] = types.ModuleType(name)
-                time.sleep(1.5)
+                # Block until a tick rendered the climbing bar.
+                assert ticked.wait(timeout=5)
         finally:
             for name in fake:
                 sys.modules.pop(name, None)

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -132,6 +132,17 @@ _test_medias_snapshot = {k: dict(v) for k, v in medias.items()}
 
 _patch_embed_audio.stop()
 
+# Freeze the startup heap (torch, registries, test medias — all of it lives
+# for the whole session anyway) so it is excluded from garbage-collection
+# scans.  Production code sprinkles ``gc.collect()`` through the dataset-load
+# pipeline for memory hygiene on huge datasets; with the multi-hundred-MB
+# startup heap unfrozen, each of those calls costs ~0.3s of pure scan time in
+# tests that load several tiny datasets.
+import gc  # noqa: E402
+
+gc.collect()
+gc.freeze()
+
 from vtscore.media import (  # noqa: E402
     all_embedders as _all_embedders,
     all_types as _all_types,

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -235,6 +235,19 @@ def reset_contexts(tmp_path, monkeypatch):
 
     _clear_query_cache()
 
+    # ``resolve_device`` is lru_cached for the life of the process.  A test
+    # that resolves it under mocked CUDA (e.g. test_torch_config.py) would
+    # otherwise leak a cached "cuda" into every later ``train_model`` on a
+    # CPU-only box.  ``vtscore.embedding.loader`` binds the function at
+    # import, and the ``importlib.reload`` in those tests can leave it
+    # holding a *different* function object than the current module
+    # attribute — clear both.
+    import vtscore.config as _config
+    import vtscore.embedding.loader as _emb_loader
+
+    _config.resolve_device.cache_clear()
+    _emb_loader.resolve_device.cache_clear()
+
     _dataset_progress.reset_cancel()
     _find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _sort_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -148,8 +148,13 @@ class TestMakeVoteSequence:
 
 
 class TestSimulateVotingIterations:
+    # Shape/plumbing tests use small media pools and ``calibrate_count=1``:
+    # each simulated voting step trains an MLP and calibrates per split, so a
+    # full-size sweep costs seconds for assertions that only look at row
+    # structure.  Behavioral tests (cost decrease, inclusion sensitivity)
+    # keep the full sweep they actually measure.
     def test_returns_rows(self):
-        medias = _make_separable_clips(n_per_cat=10)
+        medias = _make_separable_clips(n_per_cat=6)
         rows = simulate_voting_iterations(
             medias,
             target_category="alpha",
@@ -157,16 +162,18 @@ class TestSimulateVotingIterations:
             dataset_name="test_ds",
             inclusion=0,
             sim_fraction=0.5,
+            calibrate_count=1,
         )
         assert len(rows) > 0
 
     def test_row_schema(self):
-        medias = _make_separable_clips(n_per_cat=10)
+        medias = _make_separable_clips(n_per_cat=6)
         rows = simulate_voting_iterations(
             medias,
             target_category="alpha",
             seed=42,
             dataset_name="test_ds",
+            calibrate_count=1,
         )
         expected_keys = {
             "seed",
@@ -189,8 +196,8 @@ class TestSimulateVotingIterations:
         The first scored row reflects the 1-good + 1-bad minimum, and the
         counts never exceed the votes seen so far (t).
         """
-        medias = _make_separable_clips(n_per_cat=10)
-        rows = simulate_voting_iterations(medias, "alpha", seed=42)
+        medias = _make_separable_clips(n_per_cat=6)
+        rows = simulate_voting_iterations(medias, "alpha", seed=42, calibrate_count=1)
         assert rows  # at least one scored step
         first = rows[0]
         assert first["n_good"] >= 1
@@ -202,9 +209,9 @@ class TestSimulateVotingIterations:
             assert row["n_bad"] >= 1
 
     def test_seed_determinism(self):
-        medias = _make_separable_clips(n_per_cat=10)
-        rows1 = simulate_voting_iterations(medias, "alpha", seed=42)
-        rows2 = simulate_voting_iterations(medias, "alpha", seed=42)
+        medias = _make_separable_clips(n_per_cat=6)
+        rows1 = simulate_voting_iterations(medias, "alpha", seed=42, calibrate_count=1)
+        rows2 = simulate_voting_iterations(medias, "alpha", seed=42, calibrate_count=1)
         assert len(rows1) == len(rows2)
         for r1, r2 in zip(rows1, rows2):
             # Compare all fields except elapsed_seconds (wall-clock timing varies between runs)
@@ -214,8 +221,8 @@ class TestSimulateVotingIterations:
 
     def test_different_seeds_differ(self):
         medias = _make_separable_clips(n_per_cat=10)
-        rows1 = simulate_voting_iterations(medias, "alpha", seed=42)
-        rows2 = simulate_voting_iterations(medias, "alpha", seed=99)
+        rows1 = simulate_voting_iterations(medias, "alpha", seed=42, calibrate_count=1)
+        rows2 = simulate_voting_iterations(medias, "alpha", seed=99, calibrate_count=1)
         # Different seeds should produce different vote orderings / splits,
         # so the t-indexed costs should differ (not guaranteed for every row,
         # but at least the full sequence should differ).
@@ -224,8 +231,8 @@ class TestSimulateVotingIterations:
         assert costs1 != costs2
 
     def test_t_values_monotonically_increase(self):
-        medias = _make_separable_clips(n_per_cat=10)
-        rows = simulate_voting_iterations(medias, "alpha", seed=42)
+        medias = _make_separable_clips(n_per_cat=6)
+        rows = simulate_voting_iterations(medias, "alpha", seed=42, calibrate_count=1)
         t_vals = [r["t"] for r in rows]
         assert t_vals == sorted(t_vals)
         # t starts >=2 because we need at least 1 good + 1 bad
@@ -275,8 +282,8 @@ class TestSimulateVotingIterations:
 
     def test_elapsed_seconds_non_negative_and_increasing(self):
         """elapsed_seconds should be non-negative and non-decreasing over rows."""
-        medias = _make_separable_clips(n_per_cat=10)
-        rows = simulate_voting_iterations(medias, "alpha", seed=42)
+        medias = _make_separable_clips(n_per_cat=6)
+        rows = simulate_voting_iterations(medias, "alpha", seed=42, calibrate_count=1)
         times = [r["elapsed_seconds"] for r in rows]
         assert all(t >= 0.0 for t in times)
         for i in range(1, len(times)):
@@ -386,12 +393,15 @@ class TestProductionCalibrationFidelity:
 
 
 class TestRunVotingIterationsEval:
+    # Plumbing tests (columns, cross-product coverage): small pools and
+    # ``calibrate_count=1`` keep each seed×category sweep cheap.
     def test_returns_dataframe(self):
-        medias = _make_separable_clips(n_per_cat=10)
+        medias = _make_separable_clips(n_per_cat=6)
         df = run_voting_iterations_eval(
             dataset_clips={"ds1": medias},
             seeds=[42],
             categories={"ds1": ["alpha"]},
+            calibrate_count=1,
         )
         assert isinstance(df, pd.DataFrame)
         assert list(df.columns) == [
@@ -408,48 +418,53 @@ class TestRunVotingIterationsEval:
         ]
 
     def test_multiple_seeds(self):
-        medias = _make_separable_clips(n_per_cat=10)
+        medias = _make_separable_clips(n_per_cat=6)
         df = run_voting_iterations_eval(
             dataset_clips={"ds1": medias},
             seeds=[1, 2, 3],
             categories={"ds1": ["alpha"]},
+            calibrate_count=1,
         )
         assert set(df["seed"].unique()) == {1, 2, 3}
 
     def test_multiple_categories(self):
-        medias = _make_separable_clips(n_per_cat=10)
+        medias = _make_separable_clips(n_per_cat=6)
         df = run_voting_iterations_eval(
             dataset_clips={"ds1": medias},
             seeds=[42],
             categories={"ds1": ["alpha", "beta"]},
+            calibrate_count=1,
         )
         assert set(df["category"].unique()) == {"alpha", "beta"}
 
     def test_auto_categories(self):
         """When categories=None, all unique categories are used."""
-        medias = _make_three_category_clips(n_per_cat=10)
+        medias = _make_three_category_clips(n_per_cat=6)
         df = run_voting_iterations_eval(
             dataset_clips={"ds1": medias},
             seeds=[42],
+            calibrate_count=1,
         )
         assert set(df["category"].unique()) == {"alpha", "beta", "gamma"}
 
     def test_multiple_datasets(self):
-        clips1 = _make_separable_clips(n_per_cat=10, seed=0)
-        clips2 = _make_separable_clips(n_per_cat=10, seed=1)
+        clips1 = _make_separable_clips(n_per_cat=6, seed=0)
+        clips2 = _make_separable_clips(n_per_cat=6, seed=1)
         df = run_voting_iterations_eval(
             dataset_clips={"ds1": clips1, "ds2": clips2},
             seeds=[42],
             categories={"ds1": ["alpha"], "ds2": ["beta"]},
+            calibrate_count=1,
         )
         assert set(df["dataset"].unique()) == {"ds1", "ds2"}
 
     def test_cost_column_numeric(self):
-        medias = _make_separable_clips(n_per_cat=10)
+        medias = _make_separable_clips(n_per_cat=6)
         df = run_voting_iterations_eval(
             dataset_clips={"ds1": medias},
             seeds=[42],
             categories={"ds1": ["alpha"]},
+            calibrate_count=1,
         )
         assert df["cost"].dtype == np.float64
         assert df["fpr"].dtype == np.float64
@@ -457,11 +472,12 @@ class TestRunVotingIterationsEval:
 
     def test_full_cross_product_shape(self):
         """2 seeds x 1 dataset x 2 categories -> each combo produces rows."""
-        medias = _make_separable_clips(n_per_cat=10)
+        medias = _make_separable_clips(n_per_cat=6)
         df = run_voting_iterations_eval(
             dataset_clips={"ds1": medias},
             seeds=[1, 2],
             categories={"ds1": ["alpha", "beta"]},
+            calibrate_count=1,
         )
         combos = df.groupby(["seed", "dataset", "category"]).ngroups
         assert combos == 4  # 2 seeds x 1 dataset x 2 categories

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -1327,8 +1327,11 @@ class TestEmbedMediaLock:
             def __exit__(self, *exc):
                 self._lock.release()
 
+        from typing import cast
+
         original_lock = MediaEmbedder._embed_lock
-        MediaEmbedder._embed_lock = _SignalingLock()
+        # cast: duck-typed context-manager stand-in for the real Lock.
+        MediaEmbedder._embed_lock = cast(threading.Lock, _SignalingLock())
         try:
             t1.start()
             # Wait for t1 to be inside _embed_media_impl

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -1305,10 +1305,30 @@ class TestEmbedMediaLock:
         t1 = threading.Thread(target=call_embed, args=(0,))
         t2 = threading.Thread(target=call_embed, args=(1,))
 
-        # Save and replace the lock with a fresh one so we don't interfere
-        # with other tests (the class attr is shared).
+        # Save and replace the lock with a fresh one (wrapped so the test can
+        # observe acquire attempts) so we don't interfere with other tests
+        # (the class attr is shared).
+        second_acquire_attempted = threading.Event()
+        acquire_attempts = []
+
+        class _SignalingLock:
+            """Lock wrapper that signals when a second acquire is attempted."""
+
+            def __init__(self):
+                self._lock = threading.Lock()
+
+            def __enter__(self):
+                acquire_attempts.append(threading.current_thread().name)
+                if len(acquire_attempts) >= 2:
+                    second_acquire_attempted.set()
+                self._lock.acquire()
+                return self
+
+            def __exit__(self, *exc):
+                self._lock.release()
+
         original_lock = MediaEmbedder._embed_lock
-        MediaEmbedder._embed_lock = threading.Lock()
+        MediaEmbedder._embed_lock = _SignalingLock()
         try:
             t1.start()
             # Wait for t1 to be inside _embed_media_impl
@@ -1316,10 +1336,9 @@ class TestEmbedMediaLock:
             assert inside.is_set(), "t1 should be inside _embed_media_impl"
 
             t2.start()
-            # Give t2 a moment to hit the lock
-            import time
-
-            time.sleep(0.1)
+            # Wait until t2 has actually reached the lock acquisition
+            # (deterministic; no fixed race-window sleep).
+            assert second_acquire_attempted.wait(timeout=5), "t2 never attempted to acquire the embed lock"
             # t2 should be blocked on the lock; inside should still be set by t1 only
             assert not overlap_detected, "t2 entered _embed_media_impl while t1 was still inside"
 

--- a/tests_lib/fixtures/medias.py
+++ b/tests_lib/fixtures/medias.py
@@ -1,13 +1,11 @@
-"""Test media generation and embedding cache management."""
+"""Test media generation."""
 
 import hashlib
+import io
 import os
-
-import numpy as np
 
 from vtscore.media.audio.audio_generator import generate_wav
 from vtscore.config import DATA_DIR
-from vtscore.media.audio.media_type import generate_waveform_thumbnail
 
 NUM_MEDIAS = 20
 from vtscore.embedding import embed_audio_file
@@ -24,56 +22,41 @@ def _worker_suffix():
     return f".{worker}" if worker else ""
 
 
-def _embedding_cache_path():
-    """Path to the cached test-media embeddings file (worker-specific under xdist)."""
-    return DATA_DIR / f"media_embedding_cache{_worker_suffix()}.npz"
+def _fake_waveform_thumbnail() -> bytes:
+    """A tiny valid PNG standing in for a real waveform thumbnail.
 
+    The real ``generate_waveform_thumbnail()`` imports librosa (and its numba
+    stack) and decodes every generated WAV — seconds of startup per xdist
+    worker per run, spent on pixels no test inspects beyond "non-empty PNG
+    bytes".  A solid-colour PIL PNG satisfies every consumer; routes that
+    exercise real on-the-fly thumbnailing pop ``thumbnail_bytes`` first and
+    still hit the real code path.
+    """
+    from PIL import Image  # noqa: PLC0415
 
-def _embedding_cache_key():
-    """Deterministic key derived from media-generation parameters so the cache
-    auto-invalidates when NUM_MEDIAS, frequencies, or durations change."""
-    parts = []
-    for i in range(1, NUM_MEDIAS + 1):
-        freq = 200 + (i - 1) * 50
-        dur = round(1.0 + (i % 5) * 0.5, 1)
-        parts.append(f"{i}:{freq}:{dur}")
-    return hashlib.md5("|".join(parts).encode()).hexdigest()
+    buf = io.BytesIO()
+    Image.new("RGB", (80, 80), (32, 32, 32)).save(buf, format="PNG")
+    return buf.getvalue()
 
 
 def init_medias():
-    """Generate test medias with embeddings, using a cache for speed."""
+    """Generate test medias with (conftest-stubbed) embeddings.
+
+    ``embed_audio_file`` is patched with a deterministic fake by conftest
+    before this runs, so embedding is cheap; each WAV is still written to a
+    temp file because the fake derives its seed from the file's leading bytes
+    (distinct audio → distinct, worker-independent vectors).
+    """
     DATA_DIR.mkdir(exist_ok=True)
-    suffix = _worker_suffix()
-    temp_path = DATA_DIR / f"temp_embed{suffix}.wav"
-    cache_path = _embedding_cache_path()
-    cache_key = _embedding_cache_key()
+    temp_path = DATA_DIR / f"temp_embed{_worker_suffix()}.wav"
+    thumbnail = _fake_waveform_thumbnail()
 
-    # Try to load cached embeddings
-    cached_embeddings = {}
-    if cache_path.exists():
-        try:
-            data = np.load(cache_path, allow_pickle=False)
-            if "cache_key" in data and str(data["cache_key"]) == cache_key:
-                for i in range(1, NUM_MEDIAS + 1):
-                    k = f"emb_{i}"
-                    if k in data:
-                        cached_embeddings[i] = data[k]
-        except Exception:
-            pass
-
-    new_embeddings = {}
     for i in range(1, NUM_MEDIAS + 1):
         freq = 200 + (i - 1) * 50  # 200 Hz .. 1150 Hz
         duration = round(1.0 + (i % 5) * 0.5, 1)  # 1.0 – 3.0 s
         wav_bytes = generate_wav(freq, duration)
-
-        if i in cached_embeddings:
-            embedding = cached_embeddings[i]
-        else:
-            # Generate embedding by saving to temp file
-            temp_path.write_bytes(wav_bytes)
-            embedding = embed_audio_file(temp_path)
-            new_embeddings[i] = embedding
+        temp_path.write_bytes(wav_bytes)
+        embedding = embed_audio_file(temp_path)
 
         fname = f"test_media_{i}.wav"
         medias[i] = {
@@ -86,7 +69,7 @@ def init_medias():
             "md5": hashlib.md5(wav_bytes).hexdigest(),
             "embeddings": {"clap": embedding},
             "media_bytes": wav_bytes,
-            "thumbnail_bytes": generate_waveform_thumbnail(wav_bytes),
+            "thumbnail_bytes": thumbnail,
             "filename": fname,
             "category": "test",
             "origin": {"importer": "test", "params": {}},
@@ -96,10 +79,3 @@ def init_medias():
     # Clean up temp file
     if temp_path.exists():
         temp_path.unlink()
-
-    # Save cache if we computed any new embeddings (or cache didn't exist)
-    if new_embeddings or not cached_embeddings:
-        save_data = {"cache_key": np.array(cache_key)}
-        for i in range(1, NUM_MEDIAS + 1):
-            save_data[f"emb_{i}"] = medias[i]["embeddings"]["clap"]
-        np.savez(cache_path, **save_data)  # pyright: ignore[reportArgumentType]

--- a/tests_lib/projection/test_gpu_backends.py
+++ b/tests_lib/projection/test_gpu_backends.py
@@ -56,7 +56,10 @@ def _install_fake_broken_cuml(monkeypatch):
     monkeypatch.setattr(gb, "cuml_enabled", lambda: True)
 
 
+@pytest.mark.xdist_group("numba-umap-jit")
 def test_umap_fit_transform_falls_back_when_cuml_fit_raises(monkeypatch, caplog):
+    # Real umap-learn fit → shares the JIT-compile worker with
+    # test_umap_projection.py (see the pytestmark comment there).
     _install_fake_broken_cuml(monkeypatch)
     rng = np.random.default_rng(0)
     mat = rng.standard_normal((60, 16)).astype(np.float32)

--- a/tests_lib/projection/test_umap_projection.py
+++ b/tests_lib/projection/test_umap_projection.py
@@ -10,6 +10,14 @@ import pytest
 import vtscore.projection.umap_projection as up
 from vtscore.projection.umap_projection import Projection, fit_projection
 
+# Several tests below run *real* umap-learn fits (tiny matrices, but the first
+# fit numba-JIT-compiles UMAP's kernels: ~30s of one-off CPU per process, and
+# umap-learn's njit kernels are not disk-cacheable).  Pin this module — plus
+# the one real-fit test in test_gpu_backends.py — to a single xdist worker via
+# `--dist loadgroup` (see run-tests.sh) so the whole run pays the JIT cost
+# once instead of once per worker that happens to pick up a UMAP test.
+pytestmark = pytest.mark.xdist_group("numba-umap-jit")
+
 
 def _matrix(n: int, d: int, seed: int = 0) -> np.ndarray:
     rng = np.random.default_rng(seed)

--- a/vtscore/concurrency/gate.py
+++ b/vtscore/concurrency/gate.py
@@ -20,6 +20,12 @@ class ConcurrencyGate:
         self._get_limit = get_limit
         self._cv = threading.Condition()
         self._active = 0
+        #: Test-visible hook: set every time a blocking ``acquire()`` actually
+        #: parks because the gate is full.  Lets tests wait for "a waiter is
+        #: queued" deterministically instead of sleeping a fixed race window.
+        #: Tests clear it before triggering the contended acquire they care
+        #: about; production code never reads it.
+        self.waiter_parked = threading.Event()
 
     def _limit(self) -> int:
         return max(1, int(self._get_limit()))
@@ -34,6 +40,7 @@ class ConcurrencyGate:
 
             if timeout is None:
                 while self._active >= self._limit():
+                    self.waiter_parked.set()
                     self._cv.wait()
                 self._active += 1
                 return True
@@ -43,6 +50,7 @@ class ConcurrencyGate:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     return False
+                self.waiter_parked.set()
                 self._cv.wait(timeout=remaining)
             self._active += 1
             return True

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -471,6 +471,19 @@ class LoadingTasksTracker:
                 entry["finished_at"] = time.time()
         self._notify()
 
+    def is_finished(self, task_id: str) -> bool:
+        """Return ``True`` once :meth:`mark_finished` ran for *task_id*.
+
+        The task body calls ``mark_finished`` from its outermost ``finally``,
+        so a ``True`` here means the worker thread has fully unwound (gates
+        released, contexts restored).  Tests use this to wait for a
+        cancelled/finished task deterministically instead of sleeping.
+        ``False`` for unknown (never created or already removed) task ids.
+        """
+        with self._lock:
+            entry = self._tasks.get(task_id)
+        return bool(entry and entry.get("finished_at") is not None)
+
     def get_tracker(self, task_id: str) -> ProgressTracker | None:
         """Return the ProgressTracker for *task_id*, or ``None``."""
         with self._lock:

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -158,6 +158,7 @@ def timed_progress(
     current: int = 0,
     total: int = 0,
     est_modules: int | None = None,
+    tick_interval: float = 1.0,
 ) -> Any:
     """Show elapsed time in the progress message while a block executes.
 
@@ -185,6 +186,10 @@ def timed_progress(
     never claims a still-running import has finished.  Without *est_modules* the
     passed *current*/*total* are forwarded unchanged (e.g. a fixed step counter
     or an indeterminate ``0/0`` phase message).
+
+    *tick_interval* is the seconds between ticker updates.  Production call
+    sites keep the 1-second default; tests pass a small value so they can
+    observe ticks without real multi-second sleeps.
     """
     import sys  # noqa: PLC0415
 
@@ -206,7 +211,7 @@ def timed_progress(
 
     def _ticker() -> None:
         start = time.monotonic()
-        while not stop.wait(timeout=1.0):
+        while not stop.wait(timeout=tick_interval):
             elapsed = int(time.monotonic() - start)
             loaded = len(sys.modules) - baseline_modules
             suffix = f"({elapsed}s, {loaded} modules)" if loaded > 0 else f"({elapsed}s)"


### PR DESCRIPTION
Ships every item in the **Speed** section of `docs/plans/test-suite-improvements.md` (section pruned from the plan now that it's all landed), with determinism as a hard constraint: every removed sleep is replaced by an event/condition wait, not a shorter sleep.

**Measured on this 4-core container: full `pytest tests/ tests_lib/ -n auto` went from 108.6s wall with 9 failures (origin/dev, fresh clone) to 76.8s with everything green.** Three consecutive full runs pass; the threading-sensitive files were additionally run 3× standalone.

## Speed changes

- **Static-bundle race fixed** — the Angular-bundle-on-demand build moved from a `test_frontend.py` session-autouse fixture to a shared `angular_bundle` fixture in `tests/conftest.py`, guarded by a cross-process flock (`vtscore.io.file_lock`), so under `-n auto` one worker builds while the rest wait. The 9 bundle-reading dashboard tests now request the fixture explicitly. Verified for real: on a bundle-less tree all 101 dashboard+frontend tests pass under `-n 4` with a single npm build.
- **UMAP numba JIT paid once per run, not once per worker** — measurement showed the plan's preferred options don't work: umap-learn's njit kernels are not disk-cacheable (1 of 117 decorators has `cache=True`, so `NUMBA_CACHE_DIR` is a no-op for them) and `NUMBA_DISABLE_JIT=1` makes the projection group *slower* (57s vs 36s — interpreted fits cost more than one JIT compile). Instead, all real-UMAP-fit tests share an `xdist_group("numba-umap-jit")` and `run-tests.sh` now passes `--dist loadgroup`, confining the ~30s compile to one worker. The librosa mel test needs nothing: its kernels are `cache=True` and already disk-cache (10.3s → 6.0s on rerun).
- **`gc.freeze()` after conftest startup** (both tiers) — the dataset-load pipeline calls `gc.collect()` per loaded dataset, and each call was scanning the multi-hundred-MB torch/app startup heap (~0.3s). Freezing the startup heap halved `test_combine_datasets.py` (13.6s → 7.6s) and helps every dataset-load test. This is what the plan's "slim the combine pickle round-trips" item was actually seeing — the tests there already use 1–3-media inputs and `make_dataset_file` isn't involved.
- **HF backoff test** — `test_network_fallback_error_propagates` now patches `time.sleep` like its siblings (was 14s of real backoff).
- **`timed_progress` grew a `tick_interval` parameter** (default 1.0s unchanged in production); its tests pass 0.05s and wait on callback-driven `threading.Event`s instead of sleeping 1.5–2.5s each.
- **Media fixtures** — `generate_waveform_thumbnail()` (librosa + numba import + 20 WAV decodes per worker per run) replaced with a tiny PIL PNG; the NPZ embedding cache is deleted outright since it only ever stored conftest-faked vectors.
- **Eval sweep trims** — shape/plumbing tests in `test_eval_voting_iterations.py` and the "accepts param" tests in `test_safe_thresholds.py` use smaller pools and `calibrate_count=1`; the behavioral tests (cost decrease, inclusion sensitivity, calibration fidelity) keep their full sweeps. The 500-epoch run at `test_sorting.py` measured <0.3s here and was left alone.
- **CLAUDE.md** slow-marker note corrected (2 subprocess tests, not "~290s").

## Determinism / anti-flake changes

- **Race-window sleeps → event waits.** `ConcurrencyGate` gained a test-visible `waiter_parked` event (set whenever a blocking acquire actually parks) and `LoadingTasksTracker.is_finished()` exposes "the worker thread fully unwound". The parallel-loading tests wait on those instead of `sleep(0.3)`/`sleep(0.5)`; the embed-lock test uses a signaling lock wrapper instead of `sleep(0.1)`; the cancelled-label-sync test now drives the worst-case race directly (invokes the timer callback after reset) instead of sleeping and hoping.
- **Fixed a real test-isolation bug the reshuffle exposed:** `resolve_device()` is `lru_cache`d, and `test_torch_config.py` resolves it under mocked CUDA — the cached `"cuda"` then leaked into every later `train_model` on the same worker (`AssertionError: Torch not compiled with CUDA enabled`, 19 failures on first full run). Both conftests' reset fixtures now clear the cache on both binding sites (`vtscore.config` and `vtscore.embedding.loader`, which can diverge after the `importlib.reload` those tests do).
- **Fixed two cross-worker shared-directory races** (pre-existing, surfaced by the new scheduling): the clear-staging endpoint tests wipe the repo-shared `data/staging/` while `TestStagingPerTaskIsolation` asserts staged pkls exist, and the demo-status tests in `test_datasets.py` write the *same* `data/embeddings/<demo>.pkl` files concurrently. Both sets are now pinned to shared `xdist_group`s.

## Verification

- `./run-tests.sh` fully green (ruff, codespell, deptry, pip-audit, pyright, OpenAPI snapshot, frontend build + audit + Vitest, 5613 Python tests in 77.8s)
- `./run-tests.sh vtscore-clean` green (1964 tests)
- Full pytest green 3× in a row; `test_parallel_loading.py` + `test_sync_sources.py` green 3× standalone

Refs the deleted Speed section of `docs/plans/test-suite-improvements.md`; the Coverage sections are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEsq3ADpUh71X6uNMtujdZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEsq3ADpUh71X6uNMtujdZ)_