### PR TITLE
Parallel per-file build in folder loaders

### DIFF
--- a/docs/plans/efficiency-wins.md
+++ b/docs/plans/efficiency-wins.md
@@ -45,41 +45,6 @@ canvas renderer, LSH near-dup detection, async jobs with signature caches.
 
 <!-- item-sep -->
 
-- **Parallel folder ingest** — full-mode folder import processes files
-  strictly serially (`vtscore/datasets/loader_folder.py:454-470` inside
-  `_build_per_file_media`, driven by plain `for` loops in
-  `load_dataset_from_folder` ~line 567 and `load_dataset_from_folder_chunked`
-  ~line 699). Per file: disk read + `mt.load_media_data` (for images: PIL
-  decode + LANCZOS thumbnail + JPEG re-encode in `make_image_thumbnail`; for
-  audio: decode + waveform PNG). PIL decode/resize/encode release the GIL, so
-  this parallelizes near-linearly — and the codebase already proves the
-  pattern twice: `vtscore/state/near_dupes.py:300-313` (ThreadPoolExecutor,
-  with a comment saying exactly this) and
-  `vtscore/datasets/importers/recaller/__init__.py:254`
-  (`ThreadPoolExecutor(max_workers=16)`).
-  **Fix:** inside each chunk, submit `_build_per_file_media(...)` for the
-  chunk's files to a `ThreadPoolExecutor(max_workers=min(8, os.cpu_count() or 4))`,
-  then collect results **in submission order** (`executor.map`, or a list of
-  futures iterated in order — not `as_completed`) so media IDs and origin
-  ordering stay deterministic. Assign `media_id` before submission (it's an
-  input, not derived inside). Gate on a small-N threshold (e.g. skip the pool
-  under ~64 files, mirroring near_dupes' `_THREAD_MIN_IMAGES`) so tiny imports
-  don't pay pool startup. Progress: call `on_progress` from the collection
-  loop (main thread), not from workers, to keep ProgressTracker single-writer.
-  **Gotchas:** (1) cancellation — the serial loop's `check_cancelled()` calls
-  must survive: check in the collection loop each iteration, and on
-  `CancelledError` call `executor.shutdown(cancel_futures=True)`. (2) Memory —
-  a chunk's worth of `media_bytes` in flight is the same as today (the chunk
-  already bounds it); don't widen the pool beyond the chunk. (3) Exceptions in
-  a worker must propagate with the failing file's path in the message, same as
-  today. (4) `thin=True` mode does no decode — keep it on the serial path or
-  let it flow through (harmless either way).
-  **Files touched:** `vtscore/datasets/loader_folder.py` only.
-  Tests: `./run-tests.sh datasets io` — plus add one test asserting IDs/order
-  match the serial path on a fixture folder.
-  Impact: high (bulk image/audio import ≈ cores× faster on the decode phase).
-  Complexity: medium.
-
 <!-- item-sep -->
 
 - **Vectorized region cosine sort** — text/example sort on a patch dataset

--- a/tests_lib/io/test_parallel_folder_ingest.py
+++ b/tests_lib/io/test_parallel_folder_ingest.py
@@ -1,0 +1,137 @@
+"""Parallel per-file build in the folder loaders.
+
+The full-mode folder loaders decode/encode each file's media on a small thread
+pool (PIL/audio decode releases the GIL), but must produce results that are
+byte-for-byte identical to the old serial path: same media IDs, same order,
+same md5/filename/origin_name.  These tests pin that determinism, plus the
+cancellation and worker-exception contracts the pool must preserve.
+
+Library tier: no Flask / app modules.  A mock media type keeps the tests
+hermetic — md5 is computed from the file bytes independently of
+``load_media_data``, so ordering and hashing are exercised for real.
+"""
+
+from __future__ import annotations
+
+import unittest.mock as mock
+from contextlib import ExitStack
+from pathlib import Path
+
+import pytest
+
+import vtscore.datasets.loader_folder as lf
+from vtscore.concurrency.progress import CancelledError
+from vtscore.datasets.loader import load_dataset_from_folder, load_dataset_from_folder_chunked
+from helpers import make_wav_bytes as _make_wav_bytes
+
+# Comfortably above _PARALLEL_MIN_FILES (64) so the pool actually engages.
+_N_FILES = 130
+
+
+def _make_mock_audio_type():
+    mt = mock.MagicMock()
+    mt.type_id = "audio"
+    mt.file_extensions = ["*.wav"]
+    mt.load_media_data.return_value = {"duration": 1.0}
+    return mt
+
+
+def _patch_registry(mt) -> ExitStack:
+    stack = ExitStack()
+    stack.enter_context(mock.patch("vtscore.media.get_by_folder_name", return_value=mt))
+    return stack
+
+
+def _make_files(folder: Path, n: int) -> None:
+    """Write *n* distinct WAV files across two subdirs (exercises rel_path order)."""
+    (folder / "a").mkdir()
+    (folder / "b").mkdir()
+    for i in range(n):
+        sub = "a" if i % 2 == 0 else "b"
+        # Distinct frequency per file → distinct bytes → distinct md5.
+        (folder / sub / f"clip_{i:04d}.wav").write_bytes(_make_wav_bytes(frequency=100.0 + i))
+
+
+def _fingerprint(medias: dict[int, dict]) -> tuple[list[int], dict[int, tuple]]:
+    """Reduce a medias dict to the order-and-identity fields we assert on."""
+    order = list(medias.keys())
+    ident = {mid: (m["id"], m["md5"], m["filename"], m["origin_name"], m["file_size"]) for mid, m in medias.items()}
+    return order, ident
+
+
+class TestParallelMatchesSerial:
+    def test_monolithic_parallel_equals_serial(self, tmp_path, monkeypatch):
+        _make_files(tmp_path, _N_FILES)
+        mt = _make_mock_audio_type()
+
+        parallel: dict[int, dict] = {}
+        with _patch_registry(mt):
+            load_dataset_from_folder(tmp_path, "audio", parallel, on_progress=lambda *a: None)
+
+        # Force the serial path by lifting the pool threshold above the file count.
+        monkeypatch.setattr(lf, "_PARALLEL_MIN_FILES", 10**9)
+        serial: dict[int, dict] = {}
+        with _patch_registry(mt):
+            load_dataset_from_folder(tmp_path, "audio", serial, on_progress=lambda *a: None)
+
+        assert len(parallel) == _N_FILES
+        assert _fingerprint(parallel) == _fingerprint(serial)
+        # IDs are the contiguous 1..N the serial loader assigned.
+        assert list(parallel.keys()) == list(range(1, _N_FILES + 1))
+
+    def test_chunked_parallel_equals_serial(self, tmp_path, monkeypatch):
+        _make_files(tmp_path, _N_FILES)
+        mt = _make_mock_audio_type()
+
+        with _patch_registry(mt):
+            par_chunks = list(load_dataset_from_folder_chunked(tmp_path, "audio", chunk_size=70))
+
+        monkeypatch.setattr(lf, "_PARALLEL_MIN_FILES", 10**9)
+        with _patch_registry(mt):
+            ser_chunks = list(load_dataset_from_folder_chunked(tmp_path, "audio", chunk_size=70))
+
+        assert [len(c) for c in par_chunks] == [len(c) for c in ser_chunks] == [70, 60]
+        for pc, sc in zip(par_chunks, ser_chunks):
+            assert _fingerprint(pc) == _fingerprint(sc)
+            # Each chunk restarts IDs at 1.
+            assert list(pc.keys()) == list(range(1, len(pc) + 1))
+
+
+class TestCancellation:
+    def test_cancel_from_progress_stops_the_pool(self, tmp_path):
+        _make_files(tmp_path, _N_FILES)
+        mt = _make_mock_audio_type()
+
+        calls = {"n": 0}
+
+        def cancelling_progress(status, msg="", current=0, total=0):
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise CancelledError("user cancelled")
+
+        target: dict[int, dict] = {}
+        with _patch_registry(mt):
+            with pytest.raises(CancelledError):
+                load_dataset_from_folder(tmp_path, "audio", target, on_progress=cancelling_progress)
+
+
+class TestWorkerException:
+    def test_worker_error_surfaces_first_failing_file(self, tmp_path):
+        _make_files(tmp_path, _N_FILES)
+        mt = _make_mock_audio_type()
+
+        # Exactly one file fails to decode.  The collection loop consumes in
+        # submission order, so the failure surfaces at that file's position with
+        # its path in the message, even though later files may have already been
+        # decoded on other workers.
+        def boom(file_path, media_bytes=None):
+            if Path(file_path).name == "clip_0008.wav":
+                raise ValueError(f"decode failed for {Path(file_path).name}")
+            return {"duration": 1.0}
+
+        mt.load_media_data.side_effect = boom
+
+        target: dict[int, dict] = {}
+        with _patch_registry(mt):
+            with pytest.raises(ValueError, match="decode failed for clip_0008.wav"):
+                load_dataset_from_folder(tmp_path, "audio", target, on_progress=lambda *a: None)

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -19,7 +19,7 @@ import os
 from collections import defaultdict
 from contextlib import closing
 from pathlib import Path
-from typing import Any, Callable, Iterator, Optional
+from typing import Any, Callable, Generator, Iterator, Optional
 
 from vtscore.datasets.loader import (
     ProgressCallback,
@@ -520,7 +520,7 @@ def _build_media_in_order(
     build_one: Callable[[int, Path, str], dict[str, Any]],
     *,
     parallel: bool,
-) -> Iterator[tuple[int, Path, str, dict[str, Any]]]:
+) -> Generator[tuple[int, Path, str, dict[str, Any]], None, None]:
     """Yield ``(media_id, file_path, rel_path, media_data)`` for each spec, in submission order.
 
     The per-file work in *build_one* (disk read + PIL/audio decode + thumbnail

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 import gc
 import hashlib
 import logging
+import os
 from collections import defaultdict
+from contextlib import closing
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import Any, Callable, Iterator, Optional
 
 from vtscore.datasets.loader import (
     ProgressCallback,
@@ -475,6 +477,119 @@ def _build_per_file_media(
     return media_data
 
 
+# Mirror near_dupes._THREAD_MIN_IMAGES: a decode thread pool only pays off past
+# a handful of files, so tiny imports keep the serial path and skip pool startup.
+_PARALLEL_MIN_FILES = 64
+
+
+def _folder_ingest_workers() -> int:
+    """Worker count for the parallel per-file build (mirrors near_dupes/recaller)."""
+    return min(8, os.cpu_count() or 4)
+
+
+def _make_file_builder(
+    mt: Any,
+    content_vectors: dict[str, Any] | None,
+    content_md5s: dict[str, str] | None,
+    custom_metadata_map: dict[str, dict[str, Any]] | None,
+    thin: bool,
+    origin: dict[str, Any] | None,
+    content_embedder_name: str,
+) -> Callable[[int, Path, str], dict[str, Any]]:
+    """Bind the per-load parameters into a ``build_one(media_id, file_path, rel_path)`` closure."""
+
+    def build_one(media_id: int, file_path: Path, rel_path: str) -> dict[str, Any]:
+        return _build_per_file_media(
+            media_id=media_id,
+            file_path=file_path,
+            rel_path=rel_path,
+            mt=mt,
+            content_vectors=content_vectors,
+            content_md5s=content_md5s,
+            custom_metadata_map=custom_metadata_map,
+            thin=thin,
+            origin=origin,
+            content_embedder_name=content_embedder_name,
+        )
+
+    return build_one
+
+
+def _build_media_in_order(
+    build_specs: list[tuple[int, Path, str]],
+    build_one: Callable[[int, Path, str], dict[str, Any]],
+    *,
+    parallel: bool,
+) -> Iterator[tuple[int, Path, str, dict[str, Any]]]:
+    """Yield ``(media_id, file_path, rel_path, media_data)`` for each spec, in submission order.
+
+    The per-file work in *build_one* (disk read + PIL/audio decode + thumbnail
+    encode) is CPU-bound and releases the GIL, so past :data:`_PARALLEL_MIN_FILES`
+    it runs on a small thread pool.  Results are still yielded strictly in
+    submission order, so media IDs and origin ordering are byte-for-byte
+    identical to the serial path regardless of completion order.  Progress
+    reporting and cancellation are the caller's job and run on the consuming
+    (main) thread, keeping the ProgressTracker single-writer.
+
+    On any exception raised by a worker (surfaced by ``future.result()`` in
+    submission order, so the first failing file wins exactly as it would
+    serially) or by the consumer (e.g. ``CancelledError`` from a progress
+    callback), the generator's ``finally`` shuts the pool down with
+    ``cancel_futures=True`` so queued files stop immediately.  Wrap the
+    iteration in :func:`contextlib.closing` to guarantee that runs.
+    """
+    if not parallel or len(build_specs) < _PARALLEL_MIN_FILES:
+        for media_id, file_path, rel_path in build_specs:
+            yield media_id, file_path, rel_path, build_one(media_id, file_path, rel_path)
+        return
+
+    from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
+
+    executor = ThreadPoolExecutor(max_workers=_folder_ingest_workers())
+    try:
+        futures = [executor.submit(build_one, mid, fp, rp) for mid, fp, rp in build_specs]
+        for (media_id, file_path, rel_path), future in zip(build_specs, futures):
+            yield media_id, file_path, rel_path, future.result()
+    finally:
+        executor.shutdown(cancel_futures=True)
+
+
+def _build_folder_chunk(
+    specs_with_idx: list[tuple[int, int, Path, str]],
+    chunk_idx: int,
+    build_one: Callable[[int, Path, str], dict[str, Any]],
+    on_progress: ProgressCallback,
+    media_type: str,
+    total_files: int,
+    progress_interval: int,
+    thin: bool,
+) -> dict[int, dict[str, Any]]:
+    """Build one chunk's files (parallel within the chunk), preserving submission order.
+
+    *specs_with_idx* carries ``(global_idx, media_id, file_path, rel_path)`` per
+    file.  Progress reporting and cancellation run here on the generator (main)
+    thread; peak memory stays bounded by the chunk size exactly as the serial
+    contract did.  thin mode does no decode, so parallelism buys nothing there —
+    it stays on the serial path.
+    """
+    chunk_medias: dict[int, dict[str, Any]] = {}
+    specs = [(mid, fp, rp) for (_gi, mid, fp, rp) in specs_with_idx]
+    global_idxs = [gi for (gi, _mid, _fp, _rp) in specs_with_idx]
+    with closing(_build_media_in_order(specs, build_one, parallel=not thin)) as built:
+        for global_idx, (mid, _fp, rel_path, media_data) in zip(global_idxs, built):
+            if global_idx % progress_interval == 0 or (total_files and global_idx + 1 == total_files):
+                _emit_per_file_progress(
+                    on_progress,
+                    media_type,
+                    rel_path,
+                    global_idx + 1,
+                    total_files,
+                    chunk_label=f" (chunk {chunk_idx + 1})",
+                )
+            chunk_medias[mid] = media_data
+    return chunk_medias
+
+
 # ---------------------------------------------------------------------------
 # Public folder loaders
 # ---------------------------------------------------------------------------
@@ -560,43 +675,37 @@ def load_dataset_from_folder(
     )
 
     medias.clear()
-    media_id = 1
     _progress_interval = max(1, min(50, total_files // 50)) if total_files > 0 else 1
 
+    build_specs = [
+        (media_id, file_path, file_path.relative_to(folder_path).as_posix())
+        for media_id, file_path in enumerate(media_files, start=1)
+    ]
+    build_one = _make_file_builder(
+        mt, content_vectors, content_md5s, custom_metadata_map, thin, origin, content_embedder_name
+    )
+
+    loaded = 0
     try:
-        for i, file_path in enumerate(media_files):
-            rel_path = file_path.relative_to(folder_path).as_posix()
-
-            if i % _progress_interval == 0 or i + 1 == total_files:
-                _emit_per_file_progress(
-                    on_progress,
-                    media_type,
-                    rel_path,
-                    i + 1,
-                    total_files,
-                    chunk_label="",
-                )
-
-            built = _build_per_file_media(
-                media_id=media_id,
-                file_path=file_path,
-                rel_path=rel_path,
-                mt=mt,
-                content_vectors=content_vectors,
-                content_md5s=content_md5s,
-                custom_metadata_map=custom_metadata_map,
-                thin=thin,
-                origin=origin,
-                content_embedder_name=content_embedder_name,
-            )
-            medias[media_id] = built
-            media_id += 1
+        # thin mode does no decode, so parallelism buys nothing there — keep it serial.
+        with closing(_build_media_in_order(build_specs, build_one, parallel=not thin)) as built:
+            for i, (media_id, file_path, rel_path, media_data) in enumerate(built):
+                if i % _progress_interval == 0 or i + 1 == total_files:
+                    _emit_per_file_progress(
+                        on_progress,
+                        media_type,
+                        rel_path,
+                        i + 1,
+                        total_files,
+                        chunk_label="",
+                    )
+                medias[media_id] = media_data
+                loaded += 1
     except MemoryError:
         medias.clear()
         gc.collect()
         raise MemoryError(
-            f"Out of memory after loading {media_id - 1} of {total_files} files. "
-            "Try a smaller dataset or free up system RAM."
+            f"Out of memory after loading {loaded} of {total_files} files. Try a smaller dataset or free up system RAM."
         )
 
     on_progress("idle", f"Loaded {len(medias)} {media_type} medias from folder", 0, 0)
@@ -691,47 +800,35 @@ def load_dataset_from_folder_chunked(
     # when streaming (total unknown) fall back to a fixed file interval.
     _progress_interval = max(1, min(50, total_files // 50)) if total_files > 0 else 200
 
-    chunk_medias: dict[int, dict[str, Any]] = {}
     media_id = 1
     chunk_index = 0
     media_seen = 0
+    build_one = _make_file_builder(
+        mt, content_vectors, content_md5s, custom_metadata_map, thin, origin, content_embedder_name
+    )
 
+    # Accumulate a chunk's worth of file specs (cheap path ops) before building,
+    # so the build parallelises within the chunk without reading ahead — pulling
+    # one chunk still touches only that chunk's files (streaming laziness).
+    pending: list[tuple[int, int, Path, str]] = []
     for global_idx, file_path in enumerate(file_iter):
         rel_path = file_path.relative_to(folder_path).as_posix()
-
-        if global_idx % _progress_interval == 0 or (total_files and global_idx + 1 == total_files):
-            _emit_per_file_progress(
-                on_progress,
-                media_type,
-                rel_path,
-                global_idx + 1,
-                total_files,
-                chunk_label=f" (chunk {chunk_index + 1})",
-            )
-
-        chunk_medias[media_id] = _build_per_file_media(
-            media_id=media_id,
-            file_path=file_path,
-            rel_path=rel_path,
-            mt=mt,
-            content_vectors=content_vectors,
-            content_md5s=content_md5s,
-            custom_metadata_map=custom_metadata_map,
-            thin=thin,
-            origin=origin,
-            content_embedder_name=content_embedder_name,
-        )
+        pending.append((global_idx, media_id, file_path, rel_path))
         media_id += 1
         media_seen += 1
 
-        if len(chunk_medias) >= chunk_size:
-            yield chunk_medias
-            chunk_medias = {}
+        if len(pending) >= chunk_size:
+            yield _build_folder_chunk(
+                pending, chunk_index, build_one, on_progress, media_type, total_files, _progress_interval, thin
+            )
+            pending = []
             media_id = 1
             chunk_index += 1
 
-    if chunk_medias:
-        yield chunk_medias
+    if pending:
+        yield _build_folder_chunk(
+            pending, chunk_index, build_one, on_progress, media_type, total_files, _progress_interval, thin
+        )
 
     if media_seen == 0:
         # Matches the monolithic loader's empty-folder contract.  Raised after


### PR DESCRIPTION
## What

Full-mode folder import (`load_dataset_from_folder` and
`load_dataset_from_folder_chunked`) processed files strictly serially: per file
a disk read + `mt.load_media_data` (PIL decode + LANCZOS thumbnail + JPEG
re-encode for images; decode + waveform PNG for audio). That decode/encode work
releases the GIL, so it now runs on a small `ThreadPoolExecutor`, making bulk
image/audio import roughly cores× faster on the decode phase.

This is the **Parallel folder ingest** item from `docs/plans/efficiency-wins.md`.

## How

- New `_build_media_in_order(...)` helper builds each chunk's files on a
  `ThreadPoolExecutor(max_workers=min(8, os.cpu_count() or 4))` and **yields
  results in submission order** (futures iterated in order, not `as_completed`),
  so media IDs and origin ordering are byte-for-byte identical to the serial
  path regardless of completion order.
- `media_id` is assigned before submission (it's an input, not derived in the
  worker). Both loaders share a `build_one` closure via `_make_file_builder`.
- Gated below **64 files** (mirrors `near_dupes._THREAD_MIN_IMAGES`) so tiny
  imports don't pay pool startup, and **skipped for `thin=True`** (no decode).
- Progress reporting and cancellation stay on the consuming (main) thread,
  keeping the `ProgressTracker` single-writer. On a `CancelledError` from the
  progress callback or a worker exception, the generator's `finally` shuts the
  pool down with `cancel_futures=True` (guaranteed via `contextlib.closing`).
- Worker exceptions surface via `future.result()` in submission order, so the
  first failing file wins exactly as it would serially.
- The chunked loader still streams lazily: pulling one chunk touches only that
  chunk's files (specs accumulate before the parallel build).

Peak memory is unchanged — the build parallelises *within* a chunk, so
in-flight bytes stay bounded by the chunk size / worker count as before.

## Tests

- New `tests_lib/io/test_parallel_folder_ingest.py`: asserts the parallel path
  produces identical IDs/order/md5/filename/origin_name as the serial path
  (both monolithic and chunked, 130-file fixture), plus cancellation stops the
  pool and a single worker error surfaces its file path.
- `./run-tests.sh datasets io` green; full `./run-tests.sh` green (5630 passed).

Files touched: `vtscore/datasets/loader_folder.py` (+ new test, plan prune).

Refs efficiency-wins plan (Parallel folder ingest — now shipped and pruned).

---
_Generated by [Claude Code](https://claude.ai/code/session_011FgffjG8exjZ3nXo48Aamh)_