### PR TITLE
Toponymy integration: all three dependency workarounds tested on grid

### DIFF
--- a/docs/plans/vtsbrowse-toponymy.md
+++ b/docs/plans/vtsbrowse-toponymy.md
@@ -217,17 +217,55 @@ toggle. Add `RegionLabelPayload` to `models/projection.models.ts`.
 > **`docs/reports/2026-07-12-toponymy-audio-signposts.html`** and the reusable
 > framework at `scripts/experiments/toponymy_audio/`.
 
-1. **Adopt `toponymy` at all** — **RESOLVED: adopt the pipeline, but do NOT
-   `pip install` it into the app venv as-is.** The pipeline works (fine-layer
-   signs on ESC-50: ARI 0.87 / purity 0.97 / 91% name–category hit; ~3–5 min
-   end-to-end for 2k clips on one GPU). But toponymy 0.5.2 hard-pins
-   `transformers<5.0.0` (plus unconditional `datasets`, `dask`, `vectorizers`,
-   `apricot-select`), and a resolver dry-run downgrades the app's
-   transformers 5.12→4.57 and huggingface-hub 1.20→0.36. Path options, in
-   order: upstream a lazy/optional `transformers` import (it is only truly
-   needed by `HuggingFaceNamer`); vendor the core (clustering + keyphrases +
-   templates have no transformers dependency); sidecar venv. Re-check the pin
-   at implementation time.
+1. **Adopt `toponymy` at all** — **RESOLVED: adopt, installed with
+   `--no-deps` + explicitly declared real dependencies.** The pipeline works
+   (fine-layer signs on ESC-50: ARI 0.87 / purity 0.97 / 91% name–category
+   hit; ~3–5 min end-to-end for 2k clips on one GPU). A plain
+   `pip install toponymy` is still off the table — toponymy 0.5.2 pins
+   `transformers<5.0.0` and a resolver dry-run downgrades the app's
+   transformers 5.12→4.57 and huggingface-hub 1.20→0.36 — but all three
+   workarounds were **tested end-to-end on the grid (2026-07-12)** in a venv
+   mirroring the app (transformers 5.12.1, hf-hub 1.x), rerunning the full
+   ESC-50 fit from cached embeddings/texts:
+
+   - **Install `--no-deps` (recommended — tested, passes):** unmodified
+     toponymy 0.5.2 imports and runs the *entire* pipeline under
+     transformers 5.12.1 — including its own `HuggingFaceNamer` driving
+     Qwen2.5-7B through the transformers-5 pipeline API — with an identical
+     topic tree (70/34/13), identical names, and timing parity (fit 113 s vs
+     108 s on transformers 4.57). The `<5` pin (upstream rationale: a
+     sentence-transformers compat concern) is empirically unnecessary for our
+     usage. Static analysis agrees: `transformers` is only *used* inside the
+     already-guarded HuggingFaceNamer block, `tokenizers` is imported but
+     never used, and `datasets` is declared but **never imported anywhere**.
+     Integration recipe: pin `toponymy==0.5.2`, install with `--no-deps` in
+     `scripts/install.sh`, and declare its actually-used deps in
+     `pyproject.toml`: `fast_hdbscan`, `vectorizers`, `apricot-select`,
+     `tenacity`, `jinja2` (numpy/pandas/scikit-learn/scipy/numba/tqdm are
+     already VTSearch deps; `httpx` arrives via huggingface-hub 1.x;
+     `tokenizers` via transformers). Add a smoke test that imports toponymy
+     and fits a tiny corpus, since `--no-deps` bypasses resolver protection
+     for future toponymy versions; deptry will need `toponymy` in
+     dependencies plus the usual per-rule config.
+   - **Vendor the core (tested, passes — fallback):** a 5-line patch (drop
+     the vestigial top-level `import tokenizers` / `import transformers` in
+     `llm_wrappers.py`, wrap `import httpx` in try/except there and in
+     `embedding_wrappers.py`) makes the whole package import-clean; full fit
+     reproduces the baseline exactly. ~13k LOC to carry if upstream ever
+     hard-breaks.
+   - **Sidecar venv/process (tested, passes — last resort):** toponymy in its
+     own 752 MB venv (its own transformers 4.57.6, **no torch**), embeddings
+     and texts passed by file, keyphrase/topic-name embedding served by the
+     app's CLAP text branch over localhost HTTP — only **4 round-trips for
+     4,352 encoded strings** end-to-end; fit parity (180 s). Working demo:
+     `scripts/experiments/toponymy_audio/sidecar/`. Operationally heaviest
+     (second venv to build/ship, process lifecycle) — keep as escape hatch.
+
+   Upstream: `main` still pins `<5` and has *added* `litellm` as a hard dep
+   (trending heavier), and #150 deliberately made transformers a base dep —
+   so don't block on upstream; file an issue offering the transformers-5
+   runtime evidence and the unused `datasets`/`tokenizers` finding, and
+   re-check before implementation in case a fixed release lands.
 2. ~~`clusterable_vectors` source~~ **RESOLVED:** cluster on a **dedicated
    higher-D UMAP** (`n_components≈5`, `metric="cosine"`), not the 2-D browse
    layout. Confirmed empirically (26 s for 2k clips; multiresolution tree

--- a/scripts/experiments/toponymy_audio/run_toponymy.py
+++ b/scripts/experiments/toponymy_audio/run_toponymy.py
@@ -115,10 +115,14 @@ def make_hf_namer(model_id: str, stats: CallStats):
             stats.record("hf_sys", {"system": system_prompt, "user": user_prompt}, r)
             return r
 
+    import transformers
+
+    # transformers 5 renamed the pipeline dtype kwarg (torch_dtype -> dtype).
+    dtype_key = "dtype" if int(transformers.__version__.split(".")[0]) >= 5 else "torch_dtype"
     return CountingHFNamer(
         model=model_id,
         device_map="auto",
-        model_kwargs={"torch_dtype": torch.bfloat16},
+        model_kwargs={dtype_key: torch.bfloat16},
     )
 
 

--- a/scripts/experiments/toponymy_audio/sidecar/clap_server.py
+++ b/scripts/experiments/toponymy_audio/sidecar/clap_server.py
@@ -1,0 +1,47 @@
+"""Stand-in for the VTSearch app side of the sidecar architecture.
+
+Serves the active embedder's text branch over localhost HTTP (stdlib only):
+POST /encode {"texts": [...]} -> {"vectors": [[...], ...]}. In a real
+integration this would be an internal endpoint of the Flask app; here it
+runs in the transformers-5 venv to prove cross-venv text encoding works.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import common  # noqa: E402
+
+common.setup_env()
+
+from run_toponymy import ClapTextEncoder  # noqa: E402
+
+encoder = ClapTextEncoder(sys.argv[1] if len(sys.argv) > 1 else "clap")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != "/encode":
+            self.send_error(404)
+            return
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        vecs = encoder.encode(body["texts"])
+        payload = json.dumps({"vectors": vecs.tolist()}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *a):
+        pass
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 8763
+    print(f"clap text server ready on :{port}", flush=True)
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()

--- a/scripts/experiments/toponymy_audio/sidecar/sidecar_fit.py
+++ b/scripts/experiments/toponymy_audio/sidecar/sidecar_fit.py
@@ -1,0 +1,112 @@
+"""Sidecar half of the fallback architecture: toponymy in its OWN venv.
+
+Runs the full Toponymy fit in a venv where toponymy was installed normally
+(its own transformers 4.x pin, no torch), reading embeddings/texts from
+files and encoding keyphrase strings via the app's text branch over
+localhost HTTP (see clap_server.py). Proves the conflict can be fenced off
+entirely if the in-venv route is ever blocked.
+
+Usage::  sidecar_fit.py <dataset> <variant> [--server http://127.0.0.1:8763]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import common  # noqa: E402
+
+import numpy as np  # noqa: E402
+
+from run_toponymy import CallStats, make_keyphrase_namer  # noqa: E402
+
+
+class RemoteTextEncoder:
+    """TextEmbedderProtocol adapter that calls the app process over HTTP."""
+
+    def __init__(self, server: str):
+        self.server = server
+        self.calls = 0
+        self.texts_encoded = 0
+
+    def encode(self, texts, show_progress_bar=False, **kwargs):
+        import httpx  # a toponymy dependency, present in the sidecar venv
+
+        texts = [str(t) for t in texts]
+        resp = httpx.post(self.server + "/encode", json={"texts": texts}, timeout=600)
+        resp.raise_for_status()
+        vecs = resp.json()["vectors"]
+        self.calls += 1
+        self.texts_encoded += len(texts)
+        return np.asarray(vecs, dtype=np.float32)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dataset")
+    ap.add_argument("variant")
+    ap.add_argument("--server", default="http://127.0.0.1:8763")
+    args = ap.parse_args()
+
+    out = common.ds_dir(args.dataset)
+    emb = np.load(out / "embeddings_clap.npy").astype(np.float32)
+    texts = [str(t) for t in common.load_json(out / f"texts_{args.variant}.json")]
+    n = min(len(texts), len(emb))
+    emb, texts = emb[:n], texts[:n]
+
+    import transformers
+    import umap
+    import toponymy as topo_pkg
+    from toponymy import Toponymy
+    from toponymy.clustering import ToponymyClusterer
+
+    print(
+        f"sidecar venv: toponymy from {Path(topo_pkg.__file__).parents[1]}, "
+        f"transformers {transformers.__version__}, torch "
+        f"{'ABSENT' if 'torch' not in sys.modules and not _has('torch') else 'present'}"
+    )
+
+    timings: dict = {}
+    with common.timed("umap_5d", timings):
+        umap5 = umap.UMAP(n_components=5, metric="cosine", random_state=42).fit_transform(emb)
+
+    stats = CallStats()
+    encoder = RemoteTextEncoder(args.server)
+    model = Toponymy(
+        llm_wrapper=make_keyphrase_namer(stats),
+        text_embedding_model=encoder,
+        clusterer=ToponymyClusterer(min_clusters=4, verbose=True),
+        object_description="audio clips",
+        corpus_description=f"a collection of short audio clips ({args.dataset})",
+        verbose=True,
+    )
+    t0 = time.time()
+    with common.timed("toponymy_fit", timings):
+        model.fit(texts, emb, umap5.astype(np.float32))
+
+    layers = [{"layer": i, "n_topics": len(model.topic_names_[i])} for i in range(len(model.cluster_layers_))]
+    common.save_json(
+        out / f"sidecar_{args.variant}_keyphrase.json",
+        {
+            "layers": layers,
+            "topic_names_l1": list(model.topic_names_[1]) if len(layers) > 1 else [],
+            "timings_s": timings,
+            "rpc_calls": encoder.calls,
+            "rpc_texts": encoder.texts_encoded,
+            "namer_calls": stats.calls,
+            "wall_fit_s": round(time.time() - t0, 1),
+        },
+    )
+
+
+def _has(mod: str) -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec(mod) is not None
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #2287: investigates and **runtime-tests** the three integration paths for adding `toponymy` to VTSearch despite its `transformers<5` pin, in a grid venv mirroring the app (transformers 5.12.1, huggingface-hub 1.x), rerunning the full ESC-50 signpost fit from cached embeddings.

| workaround | result | notes |
|---|---|---|
| `pip install --no-deps` (**recommended**) | ✅ parity | Unmodified toponymy 0.5.2 runs the whole pipeline — including its own `HuggingFaceNamer` driving Qwen2.5-7B via the transformers-5 pipeline API — with identical topic tree (70/34/13), names, and timings (fit 113 s vs 108 s baseline). The pin is empirically unnecessary: `transformers` is only used in the already-guarded HF-namer block, `tokenizers` is imported but never used, `datasets` is declared but **never imported**. Real deps to declare: `fast_hdbscan`, `vectorizers`, `apricot-select`, `tenacity`, `jinja2` (rest already present; `httpx` comes with hf-hub 1.x). |
| vendored core | ✅ parity | 5-line patch (drop vestigial top-level transformers/tokenizers imports, make httpx optional) makes the package import-clean. Fallback if `--no-deps` ever feels fragile. |
| sidecar venv/process | ✅ parity | toponymy in its own 752 MB venv (own transformers 4.57.6, **no torch**); embeddings/texts by file; keyphrase/name encoding served by the app's CLAP text branch over localhost HTTP — 4 round-trips for 4,352 strings; fit 168 s. Working demo committed under `scripts/experiments/toponymy_audio/sidecar/`. Last resort. |

Upstream (checked): `main` still pins `<5` and added `litellm` as a hard dep; #150 there deliberately made transformers a base dep — so the plan says file an evidence-backed issue but don't block on it.

`docs/plans/vtsbrowse-toponymy.md` decision **Adopt toponymy** rewritten from "options, in order" to the tested verdict + concrete `--no-deps` integration recipe. Also makes the experiment framework's HF-namer dtype kwarg transformers-5-aware.

Refs docs/plans/vtsbrowse-toponymy.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)