### PR TITLE
Fix Enrico demo: GitHub-hosted labels CSV + tolerate flat .jpg layout

### DIFF
--- a/tests_lib/downloads/test_download_and_extract.py
+++ b/tests_lib/downloads/test_download_and_extract.py
@@ -199,6 +199,72 @@ class TestDownloadAndExtract:
 
         assert not download_called
 
+    def test_is_complete_overrides_check_path(self, tmp_path):
+        """When *is_complete* is given, an existing check_path does NOT skip.
+
+        Guards the partial-state trap: a bare (e.g. empty) check_path dir left
+        by a failed run must not masquerade as a finished download. The probe
+        decides completion by content, so the archive still downloads.
+        """
+        from vtscore.datasets import downloader as dl_module
+
+        zip_path = _make_zip(tmp_path, arcname="data_dir")
+        extract_to = tmp_path / "extracted"
+        # A bare leftover dir whose mere existence would satisfy a check_path gate.
+        check_path = extract_to / "partial"
+        check_path.mkdir(parents=True)
+
+        download_called = []
+
+        def fake_download(url, dest, size, cb):
+            download_called.append(True)
+            zip_path.rename(dest)
+
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "download_file_with_progress", fake_download),
+        ):
+            dl_module._download_and_extract(
+                url="http://example.com/test.zip",
+                archive_name="test.zip",
+                extract_to=extract_to,
+                check_path=check_path,
+                download_size_mb=1,
+                dataset_name="Test",
+                on_progress=lambda *a: None,
+                is_complete=lambda: (extract_to / "data_dir" / "file.txt").exists(),
+            )
+
+        assert download_called, "is_complete=False must not be short-circuited by check_path.exists()"
+        assert (extract_to / "data_dir" / "file.txt").read_text() == "hello"
+
+    def test_is_complete_true_skips_download(self, tmp_path):
+        """When *is_complete* returns True, nothing is downloaded."""
+        from vtscore.datasets import downloader as dl_module
+
+        download_called = []
+
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(
+                dl_module.core,
+                "download_file_with_progress",
+                lambda *a, **kw: download_called.append(True),
+            ),
+        ):
+            dl_module._download_and_extract(
+                url="http://example.com/test.zip",
+                archive_name="test.zip",
+                extract_to=tmp_path / "extracted",
+                check_path=tmp_path / "does_not_exist",
+                download_size_mb=1,
+                dataset_name="Test",
+                on_progress=lambda *a: None,
+                is_complete=lambda: True,
+            )
+
+        assert not download_called
+
     def test_unsupported_format_raises(self, tmp_path):
         """Raises ValueError for unsupported archive extensions."""
         from vtscore.datasets import downloader as dl_module

--- a/tests_lib/downloads/test_enrico_download.py
+++ b/tests_lib/downloads/test_enrico_download.py
@@ -2,8 +2,9 @@
 
 Enrico is VTSearch's born-digital *screenshot* image demo: ~1,460 Android UI
 screenshots (a curated Rico subset) each labeled with one of 20 "design topic"
-categories.  It ships as ``screenshots.zip`` (flat JPEGs named
-``<rico_screen_id>-screenshot.jpg``) plus a separate ``design_topics.csv``
+categories.  It ships as ``screenshots.zip`` (JPEGs keyed on the Rico screen
+id, unpacking as either flat ``<screen_id>.jpg`` or the older
+``<screen_id>-screenshot.jpg``) plus a separate ``design_topics.csv``
 (``screen_id,topic``) carrying the labels — both fetched by ``download_enrico``.
 """
 
@@ -18,7 +19,9 @@ class TestDownloadEnrico:
         """download_enrico extracts the screenshots zip and pulls design_topics.csv."""
         from vtscore.datasets import downloader as dl_module
 
-        def fake_extract(*, url, archive_name, extract_to, check_path, download_size_mb, dataset_name, on_progress):
+        def fake_extract(
+            *, url, archive_name, extract_to, check_path, download_size_mb, dataset_name, on_progress, is_complete=None
+        ):
             shots = Path(extract_to) / "screenshots"
             shots.mkdir(parents=True, exist_ok=True)
             (shots / "50245-screenshot.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
@@ -60,6 +63,63 @@ class TestDownloadEnrico:
         assert not file_called
         assert result == enrico
 
+    def test_flat_jpg_layout_counts_as_cached(self, tmp_path):
+        """The new flat ``<screen_id>.jpg`` layout is recognized as complete."""
+        from vtscore.datasets import downloader as dl_module
+
+        enrico = tmp_path / "enrico"
+        enrico.mkdir(parents=True)
+        (enrico / "50245.jpg").write_bytes(b"\xff\xd8")
+        (enrico / "design_topics.csv").write_text("screen_id,topic\n50245,login\n")
+
+        extract_called, file_called = [], []
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "IMAGE_DIR", tmp_path / "images"),
+            patch.object(dl_module.core, "_download_and_extract", lambda **k: extract_called.append(True)),
+            patch.object(dl_module.core, "download_file_with_progress", lambda *a, **k: file_called.append(True)),
+        ):
+            dl_module.download_enrico(on_progress=lambda *a: None)
+
+        assert not extract_called
+        assert not file_called
+
+    def test_empty_screenshots_dir_does_not_block_download(self, tmp_path):
+        """A partially-extracted empty ``screenshots/`` folder still re-downloads.
+
+        The completion probe requires an actual ``*.jpg`` to be present, so a
+        bare directory left behind by a failed run can't masquerade as done and
+        block the fetch (the RVL-CDIP / Enrico partial-state trap).
+        """
+        from vtscore.datasets import downloader as dl_module
+
+        enrico = tmp_path / "enrico"
+        (enrico / "screenshots").mkdir(parents=True)  # empty: no jpgs
+
+        def fake_extract(*, is_complete=None, **k):
+            # is_complete must reflect actual image presence, not dir existence.
+            assert is_complete is not None
+            assert is_complete() is False
+            (enrico / "1.jpg").write_bytes(b"\xff\xd8")
+
+        def fake_file(url, dest, expected=0, on_progress=None):
+            Path(dest).write_text("screen_id,topic\n1,login\n")
+
+        extract_called = []
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "IMAGE_DIR", tmp_path / "images"),
+            patch.object(
+                dl_module.core,
+                "_download_and_extract",
+                lambda **k: (extract_called.append(True), fake_extract(**k))[0],
+            ),
+            patch.object(dl_module.core, "download_file_with_progress", fake_file),
+        ):
+            dl_module.download_enrico(on_progress=lambda *a: None)
+
+        assert extract_called
+
 
 class TestLoadDemoSourceEnrico:
     """ImageMediaType.load_demo_source with source='enrico'."""
@@ -72,15 +132,20 @@ class TestLoadDemoSourceEnrico:
         emb.embed_media = MagicMock(return_value=np.zeros(768, dtype=np.float32))
         return emb
 
-    def _prepare_dir(self, tmp_path: Path, rows: list[tuple[str, str]]) -> Path:
-        """rows are (screen_id, topic) pairs; writes a flat screenshot per id + CSV."""
+    def _prepare_dir(self, tmp_path: Path, rows: list[tuple[str, str]], *, flat: bool = False) -> Path:
+        """rows are (screen_id, topic) pairs; writes a screenshot per id + CSV.
+
+        ``flat`` toggles the JPEG naming: the new flat ``<screen_id>.jpg`` in a
+        ``screenshots/`` folder vs. the older ``<screen_id>-screenshot.jpg``.
+        """
         from PIL import Image
 
         enrico = tmp_path / "enrico"
         shots = enrico / "screenshots"
         shots.mkdir(parents=True)
         for sid, _topic in rows:
-            Image.new("RGB", (40, 80), (10, 20, 30)).save(shots / f"{sid}-screenshot.jpg")
+            name = f"{sid}.jpg" if flat else f"{sid}-screenshot.jpg"
+            Image.new("RGB", (40, 80), (10, 20, 30)).save(shots / name)
         csv_lines = ["screen_id,topic"] + [f"{sid},{topic}" for sid, topic in rows]
         (enrico / "design_topics.csv").write_text("\n".join(csv_lines) + "\n")
         return enrico
@@ -97,6 +162,29 @@ class TestLoadDemoSourceEnrico:
             ("4", "maps"),  # not in the requested category subset -> dropped
         ]
         enrico = self._prepare_dir(tmp_path, rows)
+
+        clips: dict = {}
+        with patch.object(dl_module, "download_enrico", return_value=enrico):
+            ImageMediaType().load_demo_source(
+                source="enrico",
+                categories=["Login", "Chat", "MediaPlayer"],
+                slice_start=0,
+                slice_end=None,
+                clips=clips,
+                on_progress=lambda *a: None,
+                embedder=self._make_mock_embedder(),
+            )
+
+        assert len(clips) == 3
+        assert {c["category"] for c in clips.values()} == {"Login", "Chat", "MediaPlayer"}
+
+    def test_flat_jpg_naming_buckets_by_category(self, tmp_path):
+        """Flat ``<screen_id>.jpg`` names recover the id from the stem."""
+        from vtscore.datasets import downloader as dl_module
+        from vtscore.media.image.media_type import ImageMediaType
+
+        rows = [("1", "login"), ("2", "chat"), ("3", "mediaplayer")]
+        enrico = self._prepare_dir(tmp_path, rows, flat=True)
 
         clips: dict = {}
         with patch.object(dl_module, "download_enrico", return_value=enrico):

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -157,7 +157,9 @@ OPENLOGO_DOWNLOAD_WORKERS = 16
 # unlike the natural-photo image demos, the content is rendered UI, so it
 # stresses the embedder on digitally-native imagery.
 ENRICO_SCREENSHOTS_URL = "https://userinterfaces.aalto.fi/enrico/resources/screenshots.zip"
-ENRICO_TOPICS_URL = "https://userinterfaces.aalto.fi/enrico/resources/design_topics.csv"
+# The Aalto-hosted ``design_topics.csv`` now 404s; the upstream Enrico GitHub
+# repo still serves the identical ``screen_id,topic`` file, so we pull it there.
+ENRICO_TOPICS_URL = "https://raw.githubusercontent.com/luileito/enrico/master/design_topics.csv"
 
 # RICO-Screen2Words: 22,417 Android mobile-UI screenshots (built on Rico), each
 # carrying its app's Google Play *category* plus human caption summaries.
@@ -678,8 +680,9 @@ def _download_and_extract(
     download_size_mb: int,
     dataset_name: str,
     on_progress: ProgressCallback,
+    is_complete: Optional[Callable[[], bool]] = None,
 ) -> None:
-    """Download an archive and extract it if *check_path* does not already exist.
+    """Download an archive and extract it unless it is already complete.
 
     Supports ``.tar.gz`` / ``.tgz`` (gzip tar), ``.tar`` (uncompressed tar),
     ``.zip``, and ``.7z`` archives.  The archive file is deleted after
@@ -697,11 +700,22 @@ def _download_and_extract(
         extract_to: Directory into which the archive contents are extracted.
         check_path: Path whose existence signals that extraction is already
             complete (often the same as *extract_to* or a subdirectory of it).
+            Ignored when *is_complete* is given.
         download_size_mb: Expected download size in megabytes (for progress).
         dataset_name: Human-readable dataset name used in progress messages.
         on_progress: Progress callback.
+        is_complete: Optional predicate that returns ``True`` when the dataset
+            is already fully extracted.  Prefer this over *check_path* when a
+            bare directory (e.g. an empty, partially-extracted folder) would
+            otherwise be a false positive that blocks re-download: the predicate
+            can require the expected content (labeled images, etc.) to be
+            present rather than merely that a path exists.
     """
-    if check_path.exists():
+
+    def _complete() -> bool:
+        return is_complete() if is_complete is not None else check_path.exists()
+
+    if _complete():
         return
 
     unique_id = uuid.uuid4().hex[:8]
@@ -714,7 +728,7 @@ def _download_and_extract(
         download_file_with_progress(url, temp_archive, download_size_mb * 1024 * 1024, on_progress)
 
         # Another download may have finished while we were downloading.
-        if check_path.exists():
+        if _complete():
             return
 
         # Validate the downloaded file looks like a real archive before trying
@@ -728,7 +742,7 @@ def _download_and_extract(
         _extract_archive(temp_archive, archive_name, temp_extract, dataset_name, on_progress)
 
         # Another download may have finished while we were extracting.
-        if check_path.exists():
+        if _complete():
             return
 
         # Move extracted content to final location.

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -486,14 +486,17 @@ def download_enrico(on_progress: Optional[ProgressCallback] = None) -> Path:
     Enrico is a curated 1,460-screenshot subset of Rico, each Android UI screen
     labeled with one of 20 "design topic" categories (Login, Chat, Maps, …).
     Two files are fetched into ``DATA_DIR/enrico``: ``screenshots.zip`` (~110 MB
-    of JPEGs named ``<rico_screen_id>-screenshot.jpg``) and the small
-    ``design_topics.csv`` (``screen_id,topic``) that carries the labels.  MIT
-    licensed.  This is VTSearch's born-digital *screenshot* image demo.
+    of JPEGs) and the small ``design_topics.csv`` (``screen_id,topic``) that
+    carries the labels.  MIT licensed.  This is VTSearch's born-digital
+    *screenshot* image demo.
 
-    The zip's internal layout (flat vs. a top-level ``screenshots/`` folder) is
-    not relied upon: completion is detected by rglob-ing for any
-    ``*-screenshot.jpg`` under the extract dir, so a re-run never re-downloads
-    regardless of how the archive unpacks.
+    Both the zip's internal layout (flat vs. a top-level ``screenshots/``
+    folder) and the JPEG naming convention (flat ``<screen_id>.jpg`` vs. the
+    older ``<screen_id>-screenshot.jpg``) drift upstream, so neither is relied
+    upon: completion is detected by rglob-ing for *any* ``*.jpg`` under the
+    extract dir.  That predicate is also handed to ``_download_and_extract`` as
+    ``is_complete`` so an empty, partially-extracted ``screenshots/`` folder
+    can't masquerade as a finished download and block re-download.
 
     Args:
         on_progress: Optional progress callback. Falls back to the
@@ -511,7 +514,7 @@ def download_enrico(on_progress: Optional[ProgressCallback] = None) -> Path:
     topics_csv = extract_dir / "design_topics.csv"
 
     def _has_screenshots() -> bool:
-        return extract_dir.is_dir() and next(extract_dir.rglob("*-screenshot.jpg"), None) is not None
+        return extract_dir.is_dir() and next(extract_dir.rglob("*.jpg"), None) is not None
 
     if not _has_screenshots():
         _core._download_and_extract(
@@ -522,6 +525,7 @@ def download_enrico(on_progress: Optional[ProgressCallback] = None) -> Path:
             download_size_mb=_core.ENRICO_DOWNLOAD_SIZE_MB,
             dataset_name="Enrico",
             on_progress=on_progress,
+            is_complete=_has_screenshots,
         )
 
     if not topics_csv.exists():

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -773,11 +773,14 @@ def _collect_roxford_files(categories, slice_args, on_progress) -> list:
 def _collect_enrico_files(categories, slice_args, on_progress) -> list:
     """Collect Enrico screenshots grouped by their 20-way design-topic label.
 
-    Screenshots are flat JPEGs named ``<rico_screen_id>-screenshot.jpg``; the
-    label lives in ``design_topics.csv`` (``screen_id,topic``), whose ``topic``
-    values are lowercase single tokens (e.g. ``mediaplayer``).  We fold each to
-    its display category (``MediaPlayer``) with a case-insensitive lookup so the
-    stored ``category`` matches ``ENRICO_CATEGORIES`` (and the eval queries).
+    Screenshots are JPEGs keyed on the Rico screen id; upstream drift means the
+    id shows up either as a flat ``<screen_id>.jpg`` or the older
+    ``<screen_id>-screenshot.jpg``, so we accept both and recover the id from
+    the stem.  The label lives in ``design_topics.csv`` (``screen_id,topic``),
+    whose ``topic`` values are lowercase single tokens (e.g. ``mediaplayer``).
+    We fold each to its display category (``MediaPlayer``) with a
+    case-insensitive lookup so the stored ``category`` matches
+    ``ENRICO_CATEGORIES`` (and the eval queries).
     """
     import csv  # noqa: PLC0415
 
@@ -797,8 +800,10 @@ def _collect_enrico_files(categories, slice_args, on_progress) -> list:
                     id_to_cat[sid] = cat
 
     by_cat: dict = {}
-    for img_path in sorted(extract_dir.rglob("*-screenshot.jpg")):
-        cat = id_to_cat.get(img_path.name.split("-", 1)[0])
+    for img_path in sorted(extract_dir.rglob("*.jpg")):
+        stem = img_path.stem
+        sid = stem[: -len("-screenshot")] if stem.endswith("-screenshot") else stem
+        cat = id_to_cat.get(sid)
         if cat in categories:
             by_cat.setdefault(cat, []).append((img_path, cat))
     return _slice_by_category(by_cat, categories, *slice_args)


### PR DESCRIPTION
## Problem

The `enrico` image demo broke twice on upstream drift (reported in #2292):

1. **Labels CSV 404s.** `ENRICO_TOPICS_URL` (userinterfaces.aalto.fi/enrico/resources/design_topics.csv) now returns 404.
2. **Filename convention changed.** The Aalto `screenshots.zip` now unpacks to flat `<screen_id>.jpg` names instead of `<screen_id>-screenshot.jpg`. `download_enrico`'s completion probe and `_collect_enrico_files` both matched only the old `*-screenshot.jpg`, so a fresh download detected 0 images — and an empty extracted `screenshots/` dir satisfied `check_path`, blocking re-download (the partial-state trap).

## Fix

- **Labels CSV** — point `ENRICO_TOPICS_URL` at the identical `screen_id,topic` file served from the upstream Enrico GitHub repo (`raw.githubusercontent.com/luileito/enrico/master/design_topics.csv`).
- **Both filename conventions accepted** — `_collect_enrico_files` now rglobs `*.jpg` and recovers the Rico screen id from the file stem (stripping a trailing `-screenshot` when present), so flat `<screen_id>.jpg` and legacy `<screen_id>-screenshot.jpg` both work.
- **Completion probe requires images, not any-dir** — `download_enrico`'s probe now rglobs for any `*.jpg`, and that predicate is handed to `_download_and_extract` via a new optional `is_complete` parameter. A bare, partially-extracted directory can no longer masquerade as a finished download and block re-download. `is_complete` is opt-in and defaults to the existing `check_path.exists()` behavior for every other caller.

## Tests

- New coverage for flat `.jpg` detection/bucketing, and that an empty `screenshots/` dir does not block re-download.
- New coverage for `_download_and_extract`'s `is_complete` predicate (overrides `check_path`, and skips when it returns True).
- Full `./run-tests.sh` green (5686 passed).

Closes #2292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9289cCnUSSsFvG9wFNMYi)_