### PR TITLE
VTSBrowse signpost prep infrastructure (Phase 1, no-LLM)

### DIFF
--- a/.claude/hooks/ensure-test-deps.sh
+++ b/.claude/hooks/ensure-test-deps.sh
@@ -49,6 +49,14 @@ pip install --upgrade --ignore-installed pip wheel cryptography pyjwt urllib3 -q
 # uninstall it).  Force-installing a fresh copy lets Flask pick it up.
 pip install --ignore-installed blinker -q
 
+# VTSBrowse signpost naming deps (see docs/plans/vtsbrowse-toponymy.md):
+# apricot-select's legacy setup.py needs the stdlib-distutils shim and must
+# precede the main requirements pass (it's declared in pyproject.toml);
+# toponymy goes in --no-deps because its transformers<5 pin would downgrade
+# the app's transformers and is empirically unnecessary for our usage.
+SETUPTOOLS_USE_DISTUTILS=stdlib pip install apricot-select -q
+pip install --no-deps "toponymy==0.5.2" -q
+
 # Install all dependencies + editable install via pyproject.toml
 # (requirements/base.txt is just `-e .[dev]`).
 pip install --prefer-binary \

--- a/docs/plans/vtsbrowse-toponymy.md
+++ b/docs/plans/vtsbrowse-toponymy.md
@@ -1,381 +1,49 @@
-# Design: VTSBrowse Toponymy — distinguishing street signs for the browse map
+# Plan: VTSBrowse Toponymy — remaining signpost work
 
-> **Status:** Design only — nothing implemented yet. This doc scopes adding
-> **named region labels ("street signs")** to the VTSBrowse canvas so a user
-> panning a UMAP map of audio (or any media) sees human-readable names on the
-> regions. It builds on the shipped VTSBrowse pipeline
-> (`docs/plans/vtsbrowse.md`): UMAP projection → hex/square pyramid → Canvas 2D
-> renderer.
->
-> **Revision history.**
-> - *v1* proposed a from-scratch labeler with a fixed-vocabulary argmax. That
->   was flat tagging, not toponymy.
-> - *v2* corrected the model to contrastive, hierarchy-aware naming but still
->   hand-rolled the clustering / keyphrase / naming machinery.
-> - **v3 (this revision): adopt the Tutte Institute `toponymy` library**
->   (<https://github.com/TutteInstitute/toponymy>, Healy & McInnes) rather than
->   reimplement it. The library *is* the contrastive, hierarchy-aware,
->   LLM-naming pipeline we were describing; it is explicitly pluggable for
->   non-text data. We supply the audio-specific glue and the map-rendering
->   layer. This collapses three of our hand-rolled stages into "configure
->   Toponymy."
+> **Background.** The signpost infrastructure is live (Phase 1: no-LLM,
+> zero-shot-tag texts). `vtscore/projection/signpost_texts.py` computes and
+> caches one text per media on the media dict (persisted in the dataset
+> pickle; audio = CLAP top-5 AudioSet-527 tags, image = SigLIP top-5
+> OpenImages-600 tags, text = content — providers are registered per media
+> type); `signpost_build.py` wraps the Tutte Institute `toponymy` library
+> (5-D cosine clusterable UMAP, `base_min_cluster_size ∝ n`, `KeyphraseNamer`
+> no-LLM namer) and flattens the fitted topic tree into a `RegionLabelSet`
+> (medoid anchors in the frozen layout, coarsest layer at zoom band 0);
+> `signpost_prep.py` orchestrates texts → fit → cache and is hooked into all
+> three build paths — the opt-in ingest stage (texts cached **before** the
+> registry pickle write; rides the `build_projection` opt-in), the lazy
+> Browse build, and the Find→Browse subset build (in-memory only).
+> Full-dataset label sets persist in the dataset container next to the
+> projection, stamped with a `labeler_signature`
+> (`namer|texts_provider:embedder|toponymy=version`) and served only over a
+> matching `projection_id` + signature. `toponymy==0.5.2` installs
+> `--no-deps` (its `transformers<5` pin is empirically unnecessary; real deps
+> declared in `pyproject.toml`; `apricot-select` builds under the
+> stdlib-distutils shim); the `slow`-marked smoke test in
+> `tests_lib/projection/test_toponymy_smoke.py` guards that bypass.
+> Decision evidence lives in the experiment reports:
+> **`docs/reports/2026-07-12-toponymy-audio-signposts.html`** and
+> **`docs/reports/2026-07-12-toponymy-image-signposts.html`**, with reusable
+> frameworks at `scripts/experiments/toponymy_{audio,image}/`.
 
-## What toponymy actually is (unchanged — the requirement the library meets)
+## Phase 2 — real LLM namers + labeler settings
 
-A place-name distinguishes a place from its neighbors. For clusters that means
-naming region `01` by what separates it from its **parent** `0` and its
-**siblings** `00`, `02` — not by its absolute-top feature (which it usually
-*inherited* from the parent and *shares* with siblings). Naming is **top-down**
-and **collision-aware**, and the LLM's job is to **invent a distinguishing
-axis** a fixed vocabulary can't contain. The `toponymy` library implements
-exactly this: balanced multiresolution clustering → contrastive
-(`information_weighted`) keyphrase extraction per cluster → central exemplar
-selection → an LLM that synthesizes keyphrases + exemplars + sub-topic names
-into a concise distinguishing name, layer by layer.
+<!-- item-sep -->
 
-## Using the `toponymy` library
+- **LLM namer selection** — swap `KeyphraseNamer` for a bundled toponymy
+  namer (`OpenAINamer(base_url=...)` / `OllamaNamer` / local
+  `HuggingFaceNamer`), selected by new `browse_labeler` / `browse_llm_*`
+  settings with fallback order `llm → keyphrase → none`. Set
+  `llm_specific_instructions` (English-only, ≤6 words, no filler names —
+  Qwen produced "日语学习指令" and "Sounds" without them). Everything else
+  (clustering, keyphrases, texts, persistence, API, canvas) is unchanged;
+  the `labeler_signature` already carries the namer name, so switching
+  labelers invalidates persisted signs automatically.
 
-The entry point is:
+<!-- item-sep -->
 
-```python
-from toponymy import Toponymy, KeyphraseBuilder
-from toponymy.clustering import ToponymyClusterer
-from toponymy.llm_wrappers import OpenAINamer  # or Ollama/VLLM/LlamaCpp/Anthropic/...
-
-topic_model = Toponymy(
-    llm_wrapper=<a LLMWrapper>,
-    text_embedding_model=<TextEmbedderProtocol>,
-    clusterer=ToponymyClusterer(),                 # default; multiresolution
-    keyphrase_builder=KeyphraseBuilder(object_to_text=<callable>),
-    object_description="audio clips",
-    corpus_description="<dataset description>",
-)
-topic_model.fit(objects, embedding_vectors, clusterable_vectors)
-```
-
-**Guiding principle: follow Toponymy's examples wherever possible.** Adopt their
-example/default configuration rather than inventing our own knobs —
-`ToponymyClusterer(min_clusters=4, verbose=...)`, `keyphrase_method=
-"information_weighted"`, `exemplar_method="central"`, `metric="cosine"` on the
-clustering UMAP, `ENGLISH_STOP_WORDS`, etc. We only diverge where VTSearch
-*forces* it (the `object_to_text` hook for audio, the namer selection, and the
-map-rendering layer). This keeps our decision surface small and tracks upstream.
-
-`fit(objects, embedding_vectors, clusterable_vectors, exemplar_method="central",
-keyphrase_method="information_weighted", subtopic_method="central")`:
-
-- **`clusterable_vectors`** → `clusterer.fit_predict(...)` (the multiresolution
-  clustering).
-- **`embedding_vectors`** → keyphrase/exemplar alignment.
-- **`objects`** → `keyphrase_builder.fit_transform(objects)` and exemplar
-  display.
-
-### Requirements → how VTSearch meets each
-
-| Toponymy requires | What it's for | How we supply it |
-|---|---|---|
-| `clusterable_vectors: np.ndarray (n, k)` | The multiresolution clustering (docs say use UMAP/t-SNE here). | **A dedicated higher-D UMAP**, computed at build time from the CLAP matrix (`umap.UMAP(n_components≈5, metric="cosine")`, mirroring Toponymy's examples) — *not* the frozen 2-D browse layout. The 2-D layout stays for rendering + sign anchors; clustering gets the richer ~5-D map. Both reductions derive from the same embedding matrix. (Our embeddings are L2-normalized at ingest, so cosine ≡ euclidean here; we keep `cosine` to match their example.) |
-| `embedding_vectors: np.ndarray (n, d)` | Aligning keyphrases/exemplars to clusters. | **We already have it:** the in-memory CLAP matrix from `vtscore/embedding/matrix.py:get_embedding_matrix(ctx)`. |
-| `text_embedding_model: TextEmbedderProtocol` | Embeds keyphrase *strings*; alignment to clusters. | A thin adapter over the active embedder's text branch (`MediaEmbedder.embed_text`, `vtscore/media/embedder.py:678`). For **CLAP this is ideal**: keyphrase strings land in the *same* space as `embedding_vectors`, so cross-modal keyphrase→audio-cluster alignment is meaningful. Requires `embedder.supports_text`. |
-| `clusterer` | Hierarchy. | Use the bundled `ToponymyClusterer()` (multiresolution, `fast_hdbscan`-based). **This replaces our hand-rolled region tree.** |
-| `keyphrase_builder` | Contrastive keyphrases. | `KeyphraseBuilder(object_to_text=<callable>)` — see the gap below. `information_weighted` (default) does the contrastive selection. **Replaces our hand-rolled evidence extraction.** |
-| `llm_wrapper: LLMWrapper` (required) | The actual naming. | Map our `browse_llm_*` settings to a bundled namer (see *§The LLM*). |
-| `objects: List[Any]` | Keyphrase source + exemplar display. | Our list of audio media (ids/dicts), paired with `object_to_text`. |
-
-So `embedding_vectors` we already have (the CLAP matrix), `clusterable_vectors`
-is one extra higher-D UMAP fit at build time, the
-clusterer/keyphrase-builder/prompting are provided, and the contrastive +
-hierarchical naming we were going to build is the library's whole point.
-
-### The one real gap: `object_to_text` (audio → a little text)
-
-`KeyphraseBuilder(object_to_text: Callable[[Any], str])` and the exemplar
-functions' `object_to_text_function: Callable[[List[Any]], List[str]]` are the
-**official non-text hook** (default: identity, i.e. objects-are-strings).
-Toponymy needs *some text per object* to (a) mine contrastive keyphrases and
-(b) show exemplars to the LLM. Audio has no words; this callable is where we
-turn a clip into a short text. In availability order:
-
-1. **CLAP zero-shot tags (general audio, no LLM, no captioner) — primary.** For
-   each clip, the top-k vocabulary terms by CLAP similarity, e.g. `"dog,
-   barking, animal, outdoors"`. CLAP already gives us this for free; it shrinks
-   the dreaded "audio→text" problem to per-clip tagging. Toponymy's
-   `information_weighted` keyphrases then do the *contrastive* work of finding
-   which of those tags distinguish each cluster, and the LLM names it. The LLM
-   never has to caption audio — it names from tags + sibling context.
-2. **Whisper transcripts (speech) — when present.** Reuse
-   `vtscore/converters/audio2text.py`; transcripts are natural per-clip text.
-3. **A dedicated audio-captioning model — optional, heavy.** Richest per-clip
-   text; a follow-up, not v1.
-
-This also cleanly generalizes: for image datasets the same hook yields CLIP/
-SigLIP zero-shot tags; for text datasets `object_to_text` is the identity and
-Toponymy works as designed.
-
-### The LLM
-
-`Toponymy.__init__` **requires** an `llm_wrapper` (no default), and naming
-quality comes from it. The library ships wrappers covering every deployment
-shape, so we don't write our own client:
-
-- **Self-hosted / OpenAI-compatible:** `OpenAINamer(base_url=..., api_key=...,
-  model=...)`, `OllamaNamer(host=...)`, `VLLMNamer(...)`,
-  `LlamaCppNamer(model_path=...)`, `HuggingFaceNamer(model=...)` (in-process).
-- **Hosted APIs:** `OpenAINamer`, `AnthropicNamer`, `CohereNamer`,
-  `GoogleGeminiNamer`, `AzureAINamer` (+ async/batch variants).
-
-The client libraries are **optional extras** of `toponymy` (install only the
-one an environment uses), which matches "some environments have an LLM, some
-don't."
-
-**No-LLM environments.** The `LLMWrapper` ABC is tiny — two methods,
-`_call_llm(prompt, temperature, max_tokens) -> str` and
-`_call_llm_with_system_prompt(...) -> str`. We can ship a **`KeyphraseNamer`**:
-a trivial in-process `LLMWrapper` whose `_call_llm` returns the cluster's top
-`information_weighted` keyphrase instead of calling a model. This gives an
-honest no-LLM fallback that **still uses Toponymy's contrastive clustering and
-keyphrase machinery** — just without the LLM's phrasing/abstraction. (Or, for a
-small local model, point `LlamaCppNamer`/`HuggingFaceNamer` at a GGUF/HF model;
-also fully local.) The `browse_labeler` setting therefore becomes a choice of
-**namer**, not of pipeline.
-
-### Dependency footprint (a real decision)
-
-`toponymy==0.5.2` (Python ≥3.10; we run 3.11 ✓). Core deps **already in
-VTSearch**: numpy, scikit-learn, transformers (→tokenizers), pandas, scipy,
-numba (via umap-learn), tqdm. **New transitive deps it adds:** `datasets`
-(HuggingFace — the heaviest surprise), `vectorizers`, `fast_hdbscan`,
-`apricot-select`, `tenacity`, `httpx`. Plus the per-environment LLM client
-extra (`openai`/`anthropic`/`ollama`/…). Moderate but non-trivial; `deptry`
-will require adding `toponymy` to `pyproject.toml` dependencies. **This weight
-is the main argument against adoption** and is the first decision to lock.
-
----
-
-## What we still build (the glue + the map layer)
-
-Adopting Toponymy removes the clustering/keyphrase/naming code we'd otherwise
-write. What remains is VTSearch-specific:
-
-### G1 — Adapters & config
-- `object_to_text` provider (CLAP zero-shot tags / Whisper) — see the gap above.
-- `TextEmbedderProtocol` adapter over `MediaEmbedder.embed_text`.
-- Namer selection from settings (`browse_labeler` + `browse_llm_*`), including
-  the `KeyphraseNamer` no-LLM fallback. Fallback order
-  `llm → keyphrase → none`.
-
-### G2 — Run inside the build job, extract a sign list
-Run Toponymy in the existing background build (`_start_umap_build` in
-`vtsearch/routes/projection.py`), right after `build_pyramid`, where the
-embedding matrix and projection are in hand. Fit the dedicated higher-D
-clustering UMAP here (one extra reduction from the same matrix), then pass it
-as `clusterable_vectors`. From Toponymy's fitted topic tree
-(`topic_tree.py` / cluster layers) extract, per layer:
-- the topic **name** (string),
-- the cluster **membership** → compute an **anchor** = the projected coords of
-  the cluster medoid (using our frozen layout),
-- a **level** = layer index mapped to a pyramid zoom level.
-
-Produce a flat `RegionLabel(level, anchor_x, anchor_y, text, score, source)`
-list. *(To verify during implementation: the exact attributes Toponymy exposes
-for per-layer cluster membership + names; `topic_tree.py`/`cluster_layer.py`.)*
-
-### G3 — Persist strings only
-Extend the projection record (`vtscore/projection/persistence.py`,
-`vtscore/datasets/container.py`): add a `labels` block (the `RegionLabel` list
-+ a `labeler_signature` = `{namer, object_to_text_mode, model_id,
-toponymy_version}`).
-- **No vectors persisted** — only text + 2-D anchors + scalar score. Centroids,
-  keyphrases, the topic model itself are build-time-only. Allowed: the
-  No-Persisted-Vectors rule forbids embeddings/MLP weights, not derived text.
-- **Invalidation:** labels valid only while `(projection_id,
-  labeler_signature)` matches the active setting; otherwise recompute on next
-  Browse load.
-- **Subset projections** (Find→Browse): labels in-memory only, never persisted.
-
-### G4 — Labeler-selection meta
-Once namer selection (G1) exists, projection meta gains `available_labelers`
-and `labeler`.
-
-> **Background (what G2 plugs into).** The serving + rendering layers already
-> exist, so G2's output has a ready-made sink: build a
-> `RegionLabelSet(projection_id, labels)` (`vtscore/projection/labels.py`) and
-> assign it to `ctx._region_labels` (or `ctx._subset_region_labels`) at the end
-> of the build job. `GET /api/projection/labels?subset=` serves it — only over
-> a matching `projection_id` — meta reports `has_labels`, and the canvas
-> (`sign-layout.ts` + the `browse_signposts` toolbar toggle) letters the signs
-> with zoom-band sizing and de-cluttering. Each `RegionLabel.level` is a
-> (possibly fractional) **pyramid zoom level** — 0 = coarsest layer — so G2's
-> topic-layer→level mapping should target that scale.
-
----
-
-## Decisions to lock (before coding)
-
-> **Experimental evidence:** every unresolved decision below was exercised
-> end-to-end on the grid (ESC-50 / Speech Commands / Clotho, 4,445 clips, real
-> CLAP embeddings, toponymy 0.5.2, no-LLM + Qwen2.5-7B namers) — see
-> **`docs/reports/2026-07-12-toponymy-audio-signposts.html`** and the reusable
-> framework at `scripts/experiments/toponymy_audio/`.
->
-> **Image evidence (2026-07-12):** the image half of Phase 3 was exercised the
-> same way (Caltech-101 / Stanford Dogs / Enrico / RVL-CDIP / mixed, 8,874
-> images, real SigLIP embeddings, 75 fits incl. Find→Browse subset re-fits) —
-> see **`docs/reports/2026-07-12-toponymy-image-signposts.html`** and
-> `scripts/experiments/toponymy_image/`. Headline resolutions: image
-> `object_to_text` should be an **instructed ~3B VLM captioner** (cached at
-> ingest), *not* a fixed tag vocabulary — zero-shot SigLIP tags remain only a
-> no-new-models fallback (they collapse on fine-grained subsets: 0–14%
-> breed-sign hit on a 10-breed Find result, vs 56–78% for the captioner /
-> in-vocab tags; and 93–94% of their emitted vocabulary on documents and
-> screenshots is photo-term distractors). Subset re-fits are interactive
-> (~16 s for 150 images + ~12 naming calls). Duplicate signs were ~0–3% on
-> image maps, so KeyphraseNamer's audio dedup weakness doesn't carry over.
-> The LLM namer needs a "preserve exact rare terms" instruction (it rewrote
-> exact breed keyphrases into generic names, 76%→50% hit). Caption-text-space
-> browsing does NOT reproduce the audio transcript rescue (flat ARI on
-> document types) — taxonomy-grade document structure would need a
-> layout-aware embedder instead.
-
-1. **Adopt `toponymy` at all** — **RESOLVED: adopt, installed with
-   `--no-deps` + explicitly declared real dependencies.** The pipeline works
-   (fine-layer signs on ESC-50: ARI 0.87 / purity 0.97 / 91% name–category
-   hit; ~3–5 min end-to-end for 2k clips on one GPU). A plain
-   `pip install toponymy` is still off the table — toponymy 0.5.2 pins
-   `transformers<5.0.0` and a resolver dry-run downgrades the app's
-   transformers 5.12→4.57 and huggingface-hub 1.20→0.36 — but all three
-   workarounds were **tested end-to-end on the grid (2026-07-12)** in a venv
-   mirroring the app (transformers 5.12.1, hf-hub 1.x), rerunning the full
-   ESC-50 fit from cached embeddings/texts:
-
-   - **Install `--no-deps` (recommended — tested, passes):** unmodified
-     toponymy 0.5.2 imports and runs the *entire* pipeline under
-     transformers 5.12.1 — including its own `HuggingFaceNamer` driving
-     Qwen2.5-7B through the transformers-5 pipeline API — with an identical
-     topic tree (70/34/13), identical names, and timing parity (fit 113 s vs
-     108 s on transformers 4.57). The `<5` pin (upstream rationale: a
-     sentence-transformers compat concern) is empirically unnecessary for our
-     usage. Static analysis agrees: `transformers` is only *used* inside the
-     already-guarded HuggingFaceNamer block, `tokenizers` is imported but
-     never used, and `datasets` is declared but **never imported anywhere**.
-     Integration recipe: pin `toponymy==0.5.2`, install with `--no-deps` in
-     `scripts/install.sh`, and declare its actually-used deps in
-     `pyproject.toml`: `fast_hdbscan`, `vectorizers`, `apricot-select`,
-     `tenacity`, `jinja2` (numpy/pandas/scikit-learn/scipy/numba/tqdm are
-     already VTSearch deps; `httpx` arrives via huggingface-hub 1.x;
-     `tokenizers` via transformers). Add a smoke test that imports toponymy
-     and fits a tiny corpus, since `--no-deps` bypasses resolver protection
-     for future toponymy versions; deptry will need `toponymy` in
-     dependencies plus the usual per-rule config.
-   - **Vendor the core (tested, passes — fallback):** a 5-line patch (drop
-     the vestigial top-level `import tokenizers` / `import transformers` in
-     `llm_wrappers.py`, wrap `import httpx` in try/except there and in
-     `embedding_wrappers.py`) makes the whole package import-clean; full fit
-     reproduces the baseline exactly. ~13k LOC to carry if upstream ever
-     hard-breaks.
-   - **Sidecar venv/process (tested, passes — last resort):** toponymy in its
-     own 752 MB venv (its own transformers 4.57.6, **no torch**), embeddings
-     and texts passed by file, keyphrase/topic-name embedding served by the
-     app's CLAP text branch over localhost HTTP — only **4 round-trips for
-     4,352 encoded strings** end-to-end; fit parity (180 s). Working demo:
-     `scripts/experiments/toponymy_audio/sidecar/`. Operationally heaviest
-     (second venv to build/ship, process lifecycle) — keep as escape hatch.
-
-   Upstream: `main` still pins `<5` and has *added* `litellm` as a hard dep
-   (trending heavier), and #150 deliberately made transformers a base dep —
-   so don't block on upstream; file an issue offering the transformers-5
-   runtime evidence and the unused `datasets`/`tokenizers` finding, and
-   re-check before implementation in case a fixed release lands.
-2. ~~`clusterable_vectors` source~~ **RESOLVED:** cluster on a **dedicated
-   higher-D UMAP** (`n_components≈5`, `metric="cosine"`), not the 2-D browse
-   layout. Confirmed empirically (26 s for 2k clips; multiresolution tree
-   70→34→13 topics recovers ESC-50's taxonomy without labels).
-3. **Default `object_to_text` for audio** — **RESOLVED: CLAP top-5 zero-shot
-   tags against the AudioSet-527 vocabulary** (template "The sound of {}"),
-   shipping the label list as a data file, with music-genre terms filtered
-   for non-music datasets (they cause the worst sign pollution). Evidence
-   against alternatives: a small domain-matched vocabulary is *worse* than the
-   big generic one (runner-up tags become semantically distant junk); Whisper
-   is mandatory for speech datasets and useless elsewhere — and for speech the
-   CLAP *map* itself is near-random (ARI 0.05), so the better long-term answer
-   there is browsing transcript-text embeddings via the existing `audio2text`
-   converter. **Promote the audio captioner** (was Phase 3 "optional, heavy"):
-   `MU-NLPC/whisper-small-audio-captioning` is 1 GB, captions 2k clips in
-   ~90 s, and produced the cleanest signs on both ESC-50 and uncurated Clotho.
-4. **No-LLM fallback** — **RESOLVED: ship `KeyphraseNamer`** (signs are
-   genuinely usable, e.g. "sheep goat bleat livestock"), but add a cheap
-   sibling-dedup pass before rendering — without an LLM, duplicate sibling
-   signs reach 38% on hard maps.
-5. **Async/batch namers** for large datasets — still open, but now with a cost
-   model: naming ≈ 1 LLM call/topic ≈ 2 topics/s on an a100 with Qwen2.5-7B;
-   topic count ≈ n / base_min_cluster_size, so the 20k+ regime needs
-   `base_min_cluster_size` scaled up (≈50–100) and/or the async namers.
-   Also lock at implementation: raise `lowest_detail_level` (default fine-layer
-   prompts request 8–15-word names — too long for map signs) and set
-   `llm_specific_instructions` (English-only, ≤6 words, no filler names —
-   Qwen produced "日语学习指令" and "Sounds" without them).
-
-## Phasing
-
-- **Phase 1 (no LLM): Toponymy + `KeyphraseNamer` + CLAP `object_to_text` +
-  G1–G4.** A full contrastive, hierarchical, library-backed sign layer with
-  zero external infra — names are the top contrastive keyphrase per topic.
-  (The serving API and the canvas sign layer are already live — see the G4
-  background note — so Phase 1's frontend work is done.)
-- **Phase 2: real LLM namers + the setting switch + config.** Swap
-  `KeyphraseNamer` for `OpenAINamer(base_url=...)` / `OllamaNamer` / local
-  model, selected by `browse_labeler`/`browse_llm_*`. Everything else
-  (clustering, keyphrases, persistence, API, canvas) is unchanged.
-- **Phase 3 (follow-ups):** audio-captioning `object_to_text`; image/text
-  datasets; search-by-sign; user-editable signs. For images the
-  `object_to_text` question is now **resolved by experiment** (see the image
-  evidence note above): default = instructed ~3B VLM captioner
-  (Qwen2.5-VL-3B class; prompt states type + subject + key visible text),
-  computed once at ingest and cached like thumbnails; fallback = SigLIP
-  zero-shot tags vs OpenImages-600 for photo corpora / no-VLM deployments;
-  never a curated per-domain label list. Subset (Find→Browse) fits recompute
-  from cached texts (~16 s at n=150).
-
-## Testing notes
-
-- Library-tier (`tests_lib/projection/`, Flask-free): the `object_to_text`
-  provider (CLAP tags, seeded), the `TextEmbedderProtocol` adapter, the
-  `KeyphraseNamer`, `RegionLabel` extraction from a fitted topic tree (stub or
-  tiny fixture), persistence round-trip, signature invalidation. Toponymy's own
-  clustering/keyphrase correctness is the library's responsibility — we test
-  *our glue*, mocking the LLM.
-- App-tier (`tests/`): meta/labels endpoints; build→fit→persist→reload; LLM
-  namer stubbed (no real network).
-- Seed every RNG; never hit a real LLM endpoint in tests.
-- `deptry` will fail until `toponymy` is added to `pyproject.toml`; the LLM
-  client extras stay optional/per-deployment.
-
-## Eval scaffold (shipped): ground-truth signposts + a synthetic demo
-
-Ahead of the real pipeline, a **cheating** signpost path exists so the map
-*display* (zoom-band fading, multi-level hand-off, de-clutter) can be evaluated
-hands-on:
-
-- **`vtscore/projection/demo_signposts.py`** derives a hierarchical
-  `RegionLabelSet` straight from each media's `/`-separated `category` path
-  (one sign per distinct prefix; anchor = the region's medoid in the frozen
-  layout; level = depth × a fixed zoom step). It's `source="ground-truth"`, no
-  clustering/LLM. The projection route builds+caches it lazily in
-  `_label_set_for` whenever a browsed dataset has hierarchical categories — so
-  Places365-style path taxonomies light up for free too.
-- **The `synthetic_world_audio` / `synthetic_world_image` demo datasets**
-  (`vtscore/media/_toponymy_demo.py`) ship a hand-authored 4-level geographic
-  taxonomy (Continent → Country → State → City, 108 leaf cities) with *pre-baked
-  hierarchical embeddings* — no download, no model, no GPU. UMAP recovers the
-  nested clusters and the map letters ~160 signs across the four levels.
-
-This is scaffolding for evaluating the display, **not** a substitute for the
-real contrastive/LLM naming below; the real pipeline should populate
-`_region_labels` from the build job (G2), at which point it wins over the
-lazy ground-truth fallback (a set already pinned to the layout is never
-overwritten).
-
-## Open follow-ups
+- **Labeler-selection meta (was G4)** — once namer selection exists,
+  projection meta gains `available_labelers` and `labeler`.
 
 <!-- item-sep -->
 
@@ -387,10 +55,81 @@ overwritten).
 
 <!-- item-sep -->
 
-- **Captioner default validation on an uncurated image dump** — the image
-  study's datasets are curated/single-domain (mixed is synthetic); run the
-  Qwen-3B captioner default + prompt-sensitivity check on a real-world image
-  dump before shipping it as the image `object_to_text` default.
+- **Detail-level sweep** — pick `lowest_detail_level` / prompt instructions
+  that keep signs ≤6 words without losing specificity (default fine-layer
+  prompts request 8–15-word names — too long for map signs).
+
+<!-- item-sep -->
+
+- **Async/batch namers for the 20k+ regime** — naming ≈ 1 LLM call/topic ≈
+  2 topics/s (Qwen2.5-7B on an a100); `_base_min_cluster_size` already
+  scales ∝ n, but large datasets with a real LLM namer likely also want
+  toponymy's async/batch namer variants.
+
+## Phase 3 — richer `object_to_text` providers
+
+<!-- item-sep -->
+
+- **Audio captioner provider** — `MU-NLPC/whisper-small-audio-captioning`
+  (1 GB, ~90 s / 2k clips) produced the cleanest signs on both ESC-50 and
+  uncurated Clotho; promote it to the audio default once validated on GTZAN
+  + one more real-world set (its Clotho result is flattered by training
+  data). Slots in as a replacement provider in `signpost_texts`.
+
+<!-- item-sep -->
+
+- **Image VLM captioner provider** — the image study's resolved default: an
+  instructed ~3B VLM one-liner (Qwen2.5-VL-3B class; prompt states type +
+  subject + key visible text; 214 s / 1k images, ~8 GB alongside SigLIP),
+  computed once at ingest and cached like the tag texts; SigLIP tags remain
+  the no-VLM fallback (they collapse on fine-grained subsets: 0–14%
+  breed-sign hit vs 56–78% for the captioner). Validate the prompt on a
+  real-world uncurated image dump before shipping as default, and measure
+  caption cache size vs pickle bloat.
+
+<!-- item-sep -->
+
+- **Speech routing** — Whisper transcripts as the `object_to_text` for
+  speech datasets (reuse `vtscore/converters/audio2text.py`); but the CLAP
+  *map* itself is near-random for speech (ARI 0.05), so the better long-term
+  answer is browsing transcript-text embeddings via the existing `audio2text`
+  converter. Needs a routing decision (per-dataset heuristic or user pick),
+  not just a provider.
+
+<!-- item-sep -->
+
+- **Vocab-filtering ablation** — drop AudioSet's music-genre terms from the
+  tag vocabulary for non-music datasets and confirm the "Flamenco/Bluegrass"
+  sign pollution disappears (framework rerun, minutes).
+
+## Pipeline follow-ups
+
+<!-- item-sep -->
+
+- **Lazy recompute of stale labels** — a persisted label set whose
+  `labeler_signature` no longer matches the active pipeline is treated as
+  absent, and nothing currently rebuilds it (the build job won't rerun while
+  the pyramid is cached/persisted); only a forced Re-project re-letters.
+  Kick a background labeling job from the serve path on signature mismatch.
+
+<!-- item-sep -->
+
+- **Post-hoc text persistence** — signpost texts computed during the *lazy*
+  Browse build (dataset ingested without prep) are stamped on the in-memory
+  media dicts but never re-pickled, so the next process recomputes them.
+  Cheap for tags; matters once captioner providers land — consider rewriting
+  the container pickle (or a sidecar text entry) after a lazy-build labeling.
+
+<!-- item-sep -->
+
+- **KeyphraseNamer sibling dedup** — cheap pass that appends the first
+  non-shared keyphrase when sibling signs collide (38% dups on speech maps;
+  ~0–3% on image maps, so audio is the driver).
+
+<!-- item-sep -->
+
+- **Scale run** — urbansound8k_a or a ~20k mixed corpus to validate the
+  `base_min_cluster_size ∝ n` rule and the naming-cost model.
 
 <!-- item-sep -->
 
@@ -407,29 +146,7 @@ overwritten).
 
 <!-- item-sep -->
 
-- **Vocab-filtering ablation** — drop AudioSet's music-genre terms from the
-  tag vocabulary for non-music datasets and confirm the "Flamenco/Bluegrass"
-  sign pollution disappears (framework rerun, minutes).
-
-<!-- item-sep -->
-
-- **Captioner validation on a second uncurated corpus + music** — the
-  captioner's Clotho result is flattered by its training data; check GTZAN and
-  one more real-world set before making it a default for user data.
-
-<!-- item-sep -->
-
-- **Scale run** — urbansound8k_a or a ~20k mixed corpus to validate the
-  `base_min_cluster_size ∝ n` rule and the naming-cost model.
-
-<!-- item-sep -->
-
-- **KeyphraseNamer sibling dedup** — cheap pass that appends the first
-  non-shared keyphrase when sibling signs collide (38% dups on speech maps).
-
-<!-- item-sep -->
-
-- **Detail-level sweep** — pick `lowest_detail_level` / prompt instructions
-  that keep signs ≤6 words without losing specificity.
+- **Search-by-sign / user-editable signs** — original Phase 3 UI ideas;
+  unscoped.
 
 <!-- item-sep -->

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
@@ -101,7 +101,7 @@
 }
 
 @if (advancedOpen) {
-  <label class="form-label" for="import-advanced-projection" title="Build the Browse map now, while importing. Costs extra time up front but makes Browse open instantly. When off, the map is built the first time you open Browse.">
+  <label class="form-label" for="import-advanced-projection" title="Build the Browse map — and its region signposts, where supported — now, while importing. Costs extra time up front but makes Browse open instantly, already lettered. When off, the map and signs are built the first time you open Browse.">
     <input
       id="import-advanced-projection"
       type="checkbox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,19 @@ dependencies = [
     # a missing install still surfaces an actionable error, but declared here so
     # a plain `install.sh` covers the Clotho demo out of the box.
     "py7zr",
+    # The actually-used dependencies of `toponymy` (VTSBrowse signpost naming;
+    # vtscore.projection.signpost_build). toponymy itself is installed
+    # `--no-deps` by scripts/install.sh / ensure-test-deps.sh because its
+    # transformers<5 pin would downgrade the app's transformers and is
+    # empirically unnecessary for our usage — see docs/plans/vtsbrowse-toponymy.md
+    # (decision 1) — so its real deps are declared here instead. apricot-select
+    # ships a legacy setup.py that needs the stdlib-distutils shim to build;
+    # the install scripts pre-install it before the main requirements pass.
+    "fast_hdbscan",
+    "vectorizers",
+    "apricot-select",
+    "tenacity",
+    "jinja2",
 ]
 
 [project.optional-dependencies]
@@ -95,6 +108,9 @@ include = ["vtsearch*", "vtscore*"]
 # Ship the fixed VLAD visual vocabulary (a code asset, like model weights) used
 # by the structural (SIFT/VLAD) embedder.  Rebuilt via scripts/build_vlad_codebook.py.
 "vtscore.media" = ["assets/*.npy"]
+# Zero-shot tag vocabularies for the signpost text providers (AudioSet-527 /
+# OpenImages-600 class names; see vtscore.projection.signpost_texts).
+"vtscore.projection" = ["assets/*.txt"]
 
 [tool.ruff]
 line-length = 120
@@ -187,6 +203,12 @@ DEP001 = [
     "safetensors",
     "huggingface_hub",
     "cuml",
+    # Installed `--no-deps` by the install scripts (its transformers<5 pin is
+    # empirically unnecessary; see docs/plans/vtsbrowse-toponymy.md), so it
+    # cannot be declared here — declaring it would put its pins back in the
+    # resolver. Its real deps ARE declared (fast_hdbscan et al.); the smoke
+    # test in tests_lib/projection guards the --no-deps bypass.
+    "toponymy",
 ]
 # DEP003: imported as a transitive of another declared dependency.
 # ``safetensors`` and ``torchvision`` ship with ``transformers`` / ``torch``
@@ -209,6 +231,10 @@ DEP003 = [
     "torchvision",
     "huggingface_hub",
     "cuml",
+    # Same dual classification as cuml: on a box where toponymy IS installed
+    # (via the scripts' --no-deps step) deptry reclassifies the import from
+    # DEP001 (missing) to DEP003 (transitive/undeclared). See the DEP001 note.
+    "toponymy",
 ]
 # DEP002: declared but not imported. Tools we run via their CLIs
 # (pytest, ruff, …), runtime helpers loaded by name (gunicorn), or
@@ -232,6 +258,14 @@ DEP002 = [
     # Loaded via importorskip in the portable-export test; never imported
     # statically, so deptry can't see the use.
     "onnxruntime",
+    # toponymy's real dependencies, declared on its behalf because it is
+    # installed --no-deps (see the DEP001 note on "toponymy"); our code never
+    # imports them directly.
+    "fast_hdbscan",
+    "vectorizers",
+    "apricot-select",
+    "tenacity",
+    "jinja2",
 ]
 
 [tool.pytest.ini_options]
@@ -277,7 +311,7 @@ exclude_lines = [
 # docs/reports/*.html are generated experiment reports with embedded
 # base64 image data URIs, the same class of binary-ish content *.svg is
 # already skipped for.
-skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,static,model_cache,.git,*.ipynb,package-lock.json,*venv*,.venv,venv,*docs/reports/*.html"
+skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,static,model_cache,.git,*.ipynb,package-lock.json,*venv*,.venv,venv,*docs/reports/*.html,*vtscore/projection/assets*"
 # Domain terms (clap/siglip/xclip = embedder names; wrest/caller/recaller =
 # extension scaffold names), legitimate code identifiers (numer/denom in
 # slope formulas, medias as the global state proxy, goup as a TS method,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -815,8 +815,26 @@ vts_install_precommit() {
 # Installs runtime + dev dependencies and the vtsearch package itself (editable)
 # by forwarding to pyproject.toml via requirements/base.txt, which is just
 # `--extra-index-url <cpu wheel index>` + `-e .[dev]`.
+# --- toponymy (VTSBrowse signpost naming) ------------------------------------
+# Two quirks force a dedicated step (see docs/plans/vtsbrowse-toponymy.md):
+#   - apricot-select (a real toponymy dep, declared in pyproject.toml) ships a
+#     legacy setup.py that crashes under modern setuptools' bdist
+#     ("AttributeError: install_layout"); building under the stdlib-distutils
+#     shim works. It must be installed BEFORE the main requirements pass, or
+#     that pass fails trying to build it without the shim.
+#   - toponymy 0.5.2 pins transformers<5.0.0, which a plain install would
+#     honor by downgrading the app's transformers stack; the pin is
+#     empirically unnecessary for our usage (validated end-to-end on
+#     transformers 5.x), so toponymy is installed --no-deps with its real
+#     dependencies declared in pyproject.toml instead. The tests_lib
+#     projection smoke test guards this bypass against future breakage.
+vts_install_toponymy() {
+    SETUPTOOLS_USE_DISTUTILS=stdlib pip install apricot-select --progress-bar on
+    pip install --no-deps "toponymy==0.5.2" --progress-bar on
+}
+
 vts_install_cpu() {
-    vts_progress_init 4 "Installing VTSearch CPU dependencies"
+    vts_progress_init 5 "Installing VTSearch CPU dependencies"
     echo "Heads-up: the pip steps below show a download bar, but pip also goes quiet"
     echo "for 10-30s at a time while it resolves dependency versions. That silence is"
     echo "normal -- it is working, not frozen."
@@ -827,6 +845,9 @@ vts_install_cpu() {
 
     vts_progress_step "Upgrading pip / setuptools / wheel"
     pip install --upgrade pip "setuptools<82" wheel --progress-bar on
+
+    vts_progress_step "Installing signpost naming deps (apricot-select + toponymy)"
+    vts_install_toponymy
 
     vts_progress_step "Installing runtime + dev dependencies (this may take several minutes)"
     pip install -r "$REPO_ROOT/requirements/base.txt" --progress-bar on
@@ -999,7 +1020,7 @@ vts_install_gpu() {
     local cuda_tag="$1"
     local extra_index="https://download.pytorch.org/whl/${cuda_tag}"
 
-    vts_progress_init 8 "Installing VTSearch GPU dependencies (CUDA tag: ${cuda_tag})"
+    vts_progress_init 9 "Installing VTSearch GPU dependencies (CUDA tag: ${cuda_tag})"
     echo "Heads-up: the pip steps below show a download bar, but pip also goes quiet"
     echo "for 10-30s at a time while it resolves dependency versions. That silence is"
     echo "normal -- it is working, not frozen."
@@ -1037,6 +1058,9 @@ vts_install_gpu() {
       --prefer-binary \
       torch torchvision torchaudio \
       --progress-bar on
+
+    vts_progress_step "Installing signpost naming deps (apricot-select + toponymy)"
+    vts_install_toponymy
 
     # Install everything else. torch is already satisfied by the pinned build above,
     # so this --extra-index-url pass won't replace it (no --upgrade).

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -954,6 +954,67 @@ class TestProjectionLabels:
         assert ctx._region_labels is None
 
 
+class TestPersistedLabelRestore:
+    """Labels persisted in the dataset container are restored on serve.
+
+    The labeling pipeline persists the full-dataset ``RegionLabelSet`` next to
+    the projection; a fresh process (no in-memory set) must serve it back —
+    but only over the exact layout it was computed from, and only while its
+    labeler signature matches the active pipeline's (a ``None`` active
+    signature — no toponymy here — still serves: derived text pinned to the
+    right layout beats nothing).
+    """
+
+    @staticmethod
+    def _persist(tmp_path, projection_id: str, signature: str):
+        import zipfile
+
+        from vtscore.datasets.container import append_region_labels
+
+        pkl = tmp_path / "container.pkl"
+        if not pkl.exists():
+            with zipfile.ZipFile(pkl, "w") as zf:
+                zf.writestr("placeholder", b"")
+        append_region_labels(pkl, TestProjectionLabels._label_set(projection_id), signature)
+        return pkl
+
+    def _serve(self, client, monkeypatch, tmp_path, *, stored_id, stored_sig, active_sig="__unset__"):
+        ctx = get_active_context()
+        proj, pyr = TestProjectionLabels._build_hex_pyramid("live-layout")
+        ctx._projection = proj
+        ctx._pyramids = {"hex": pyr}
+        pkl = self._persist(tmp_path, stored_id, stored_sig)
+        monkeypatch.setattr("vtsearch.routes.projection._pkl_path_for", lambda dataset_id: str(pkl))
+        if active_sig != "__unset__":
+            monkeypatch.setattr("vtscore.projection.signpost_prep.labeler_signature", lambda ctx: active_sig)
+        return client.get("/api/projection/labels").get_json()
+
+    def test_restores_matching_layout(self, client, monkeypatch, tmp_path):
+        # Active signature is None here (the suite reports toponymy
+        # unavailable), so the persisted set serves unconditionally.
+        body = self._serve(client, monkeypatch, tmp_path, stored_id="live-layout", stored_sig="sig-v1")
+        assert body["status"] == "ready"
+        assert [lab["text"] for lab in body["labels"]] == ["animal sounds", "dog barking"]
+        # And it lands in the context cache like a live-built set.
+        assert get_active_context()._region_labels is not None
+
+    def test_matching_signature_serves(self, client, monkeypatch, tmp_path):
+        body = self._serve(
+            client, monkeypatch, tmp_path, stored_id="live-layout", stored_sig="sig-v1", active_sig="sig-v1"
+        )
+        assert len(body["labels"]) == 2
+
+    def test_stale_signature_treated_as_absent(self, client, monkeypatch, tmp_path):
+        body = self._serve(
+            client, monkeypatch, tmp_path, stored_id="live-layout", stored_sig="sig-old", active_sig="sig-new"
+        )
+        assert body["labels"] == []
+
+    def test_wrong_layout_treated_as_absent(self, client, monkeypatch, tmp_path):
+        body = self._serve(client, monkeypatch, tmp_path, stored_id="some-old-layout", stored_sig="sig-v1")
+        assert body["labels"] == []
+
+
 class TestDemoSignpostsLazyBuild:
     """Ground-truth signposts derived on demand from hierarchical categories.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -450,6 +450,24 @@ class _MergedSettingsPath:
 
 
 @pytest.fixture(autouse=True)
+def _no_signpost_pipeline(monkeypatch):
+    """Keep the Toponymy signpost pipeline out of the app-tier suite.
+
+    The projection build paths run signpost prep best-effort whenever the
+    ``toponymy`` library is installed, which would drag a real (numba-heavy)
+    clustering fit into otherwise-fast build tests — and make the suite's
+    behavior depend on whether the optional library is present.  Reporting it
+    unavailable makes every build path skip prep deterministically; the prep
+    glue itself is covered by ``tests_lib/projection`` with the fit seam
+    stubbed, and the real library by the ``slow``-marked smoke test.  Tests
+    that exercise the label-serving paths re-patch what they need.
+    """
+    from vtscore.projection import signpost_prep
+
+    monkeypatch.setattr(signpost_prep, "signposting_available", lambda: False)
+
+
+@pytest.fixture(autouse=True)
 def isolated_settings(tmp_path, monkeypatch):
     """Redirect both settings tiers to a temp directory for each test.
 

--- a/tests_lib/projection/test_signpost_build.py
+++ b/tests_lib/projection/test_signpost_build.py
@@ -1,0 +1,185 @@
+"""Library-tier tests for the Toponymy → RegionLabelSet extraction glue.
+
+Covers ``vtscore.projection.signpost_build`` with the library fit stubbed at
+the ``_fit_topic_layers`` seam (and the clusterable UMAP stubbed too), so no
+test here imports toponymy or compiles numba: level mapping, medoid anchors,
+noise/empty-name handling, size guards, and the text-encoder adapter.  The
+real library is exercised by the ``slow``-marked smoke test.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.projection import signpost_build as sb
+from vtscore.projection.labels import medoid
+from vtscore.projection.umap_projection import Projection
+
+
+def _proj(n: int, projection_id: str = "proj-1") -> Projection:
+    rng = np.random.default_rng(42)
+    coords = rng.standard_normal((n, 2)).astype(np.float32)
+    return Projection(projection_id, list(range(1, n + 1)), coords, "pca")
+
+
+class FakeEmbedder:
+    name = "fake_clap"
+    supports_text = True
+
+    def embed_text(self, text: str):
+        import hashlib
+
+        seed = int(hashlib.md5(text.encode()).hexdigest(), 16) % 2**32
+        rng = np.random.default_rng(seed)
+        vec = rng.standard_normal(8).astype(np.float32)
+        return vec / np.linalg.norm(vec)
+
+
+@pytest.fixture
+def stub_fit(monkeypatch):
+    """Stub the clusterable UMAP + the toponymy fit; capture the fit inputs."""
+    captured: dict = {}
+
+    def fake_clusterable(matrix, on_progress=None):
+        captured["clusterable_input"] = matrix
+        return np.asarray(matrix[:, :2], dtype=np.float32)
+
+    def fake_fit(texts, embedding_vectors, clusterable_vectors, text_encoder, **kwargs):
+        captured["texts"] = texts
+        captured["embedding_vectors"] = embedding_vectors
+        captured["kwargs"] = kwargs
+        return captured["layers"]
+
+    monkeypatch.setattr(sb, "_clusterable_vectors", fake_clusterable)
+    monkeypatch.setattr(sb, "_fit_topic_layers", fake_fit)
+    return captured
+
+
+def _build(n=60, layers=None, projection_id="proj-1", captured=None, **kwargs):
+    proj = _proj(n, projection_id)
+    matrix = np.tile(np.eye(4, dtype=np.float32), (n // 4 + 1, 2))[:n]
+    texts = [f"text {i}" for i in range(n)]
+    if captured is not None:
+        captured["layers"] = layers or []
+    return proj, sb.build_region_labels(
+        proj,
+        matrix,
+        matrix,
+        texts,
+        FakeEmbedder(),
+        object_description="things",
+        corpus_description="a test corpus",
+        **kwargs,
+    )
+
+
+class TestBuildRegionLabels:
+    def test_flattens_layers_into_pinned_labels(self, stub_fit):
+        n = 60
+        fine = (["fine-a", "fine-b"], np.array([0, 1] * (n // 2)))
+        coarse = (["coarse"], np.zeros(n, dtype=int))
+        proj, label_set = _build(n=n, layers=[fine, coarse], captured=stub_fit)
+
+        assert label_set.projection_id == proj.projection_id
+        texts = [lab.text for lab in label_set.labels]
+        assert texts == ["coarse", "fine-a", "fine-b"]  # coarse (level 0) first
+
+        # Toponymy's layer 0 is the finest: it gets the deepest zoom band.
+        by_text = {lab.text: lab for lab in label_set.labels}
+        assert by_text["coarse"].level == 0.0
+        assert by_text["fine-a"].level == pytest.approx(sb._LEVEL_STEP)
+        assert all(lab.source == "keyphrase" for lab in label_set.labels)
+
+    def test_anchor_is_layout_medoid_and_score_is_member_count(self, stub_fit):
+        n = 60
+        labels_arr = np.array([0] * 20 + [1] * 40)
+        proj, label_set = _build(n=n, layers=[(["a", "b"], labels_arr)], captured=stub_fit)
+
+        by_text = {lab.text: lab for lab in label_set.labels}
+        expected = medoid(np.asarray(proj.coords)[:20])
+        assert (by_text["a"].x, by_text["a"].y) == (pytest.approx(expected[0]), pytest.approx(expected[1]))
+        assert by_text["a"].score == 20.0
+        assert by_text["b"].score == 40.0
+
+    def test_noise_and_empty_names_are_skipped(self, stub_fit):
+        n = 60
+        # Topic 0 has no members (all noise or topic 1); topic 2's name is blank.
+        labels_arr = np.array([-1] * 30 + [1] * 20 + [2] * 10)
+        proj, label_set = _build(n=n, layers=[(["orphan", "kept", "  "], labels_arr)], captured=stub_fit)
+        assert [lab.text for lab in label_set.labels] == ["kept"]
+
+    def test_too_small_corpus_returns_empty_without_fitting(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise AssertionError("fit must not run for tiny corpora")
+
+        monkeypatch.setattr(sb, "_clusterable_vectors", boom)
+        monkeypatch.setattr(sb, "_fit_topic_layers", boom)
+        proj, label_set = _build(n=sb._MIN_POINTS - 1, layers=None, captured=None)
+        assert label_set.projection_id == proj.projection_id
+        assert label_set.labels == ()
+
+    def test_misaligned_inputs_return_empty(self, stub_fit):
+        proj = _proj(60)
+        matrix = np.zeros((59, 4), dtype=np.float32)  # one row short
+        label_set = sb.build_region_labels(
+            proj,
+            matrix,
+            matrix,
+            ["t"] * 60,
+            FakeEmbedder(),
+            object_description="things",
+            corpus_description="c",
+        )
+        assert label_set.labels == ()
+
+    def test_empty_layer_list_returns_empty(self, stub_fit):
+        _, label_set = _build(n=60, layers=[], captured=stub_fit)
+        assert label_set.labels == ()
+
+
+class TestEmbedderTextEncoder:
+    def test_encodes_into_media_space(self):
+        encoder = sb.EmbedderTextEncoder(FakeEmbedder(), dim=8)
+        out = encoder.encode(["dog", "rain"])
+        assert out.shape == (2, 8)
+        assert not np.allclose(out[0], out[1])
+
+    def test_blank_or_failing_strings_become_zero_vectors(self):
+        class Broken:
+            def embed_text(self, text):
+                raise RuntimeError("no model")
+
+        encoder = sb.EmbedderTextEncoder(Broken(), dim=8)
+        out = encoder.encode(["", "boom"])
+        assert out.shape == (2, 8)
+        assert np.allclose(out, 0.0)
+
+    def test_empty_batch(self):
+        encoder = sb.EmbedderTextEncoder(FakeEmbedder(), dim=8)
+        assert encoder.encode([]).shape == (0, 8)
+
+
+class TestScaling:
+    def test_base_min_cluster_size_tracks_corpus_size(self):
+        assert sb._base_min_cluster_size(500) == 10  # library default floor
+        assert sb._base_min_cluster_size(3_000) == 10
+        assert sb._base_min_cluster_size(21_000) == 70  # the study's 50–100 regime
+        assert sb._base_min_cluster_size(50_000) == 167
+
+
+class TestAvailability:
+    def test_availability_probe_does_not_import(self, monkeypatch):
+        import importlib.util as util
+
+        monkeypatch.setattr(util, "find_spec", lambda name: None)
+        assert sb.signposting_available() is False
+
+    def test_version_string_when_missing(self, monkeypatch):
+        from importlib import metadata
+
+        def raise_missing(name):
+            raise metadata.PackageNotFoundError(name)
+
+        monkeypatch.setattr(sb.metadata, "version", raise_missing)
+        assert sb.toponymy_version() == ""

--- a/tests_lib/projection/test_signpost_persistence.py
+++ b/tests_lib/projection/test_signpost_persistence.py
@@ -1,0 +1,89 @@
+"""Library-tier tests for region-label persistence in the dataset container.
+
+Covers ``append_region_labels`` / ``read_region_labels`` /
+``remove_region_labels`` (``vtscore.datasets.container``): the JSON
+round-trip, replacement semantics, and the rule that discarding a persisted
+projection discards its labels too (anchors are meaningless off their layout).
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import numpy as np
+import pytest
+
+from vtscore.datasets.container import (
+    append_projection,
+    append_region_labels,
+    read_projection,
+    read_region_labels,
+    remove_projections,
+    remove_region_labels,
+)
+from vtscore.projection import build_pyramid
+from vtscore.projection.labels import RegionLabel, make_label_set
+from vtscore.projection.umap_projection import Projection
+
+
+@pytest.fixture
+def container(tmp_path):
+    path = tmp_path / "dataset.pkl"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("placeholder", b"")
+    return path
+
+
+def _label_set(projection_id="proj-1"):
+    return make_label_set(
+        projection_id,
+        [
+            RegionLabel(level=0.0, x=1.5, y=-2.25, text="animal sounds", score=40.0, source="keyphrase"),
+            RegionLabel(level=1.8, x=0.5, y=0.5, text="dog barking", score=12.0, source="keyphrase"),
+        ],
+    )
+
+
+class TestRoundTrip:
+    def test_append_and_read(self, container):
+        append_region_labels(container, _label_set(), "sig-v1")
+        loaded = read_region_labels(container)
+        assert loaded is not None
+        label_set, signature = loaded
+        assert signature == "sig-v1"
+        assert label_set.projection_id == "proj-1"
+        assert label_set.labels == _label_set().labels
+
+    def test_append_replaces_previous(self, container):
+        append_region_labels(container, _label_set("old"), "sig-old")
+        append_region_labels(container, _label_set("new"), "sig-new")
+        loaded = read_region_labels(container)
+        assert loaded is not None
+        label_set, signature = loaded
+        assert (label_set.projection_id, signature) == ("new", "sig-new")
+
+    def test_read_missing_entry_returns_none(self, container):
+        assert read_region_labels(container) is None
+
+    def test_read_unreadable_container_returns_none(self, tmp_path):
+        assert read_region_labels(tmp_path / "nope.pkl") is None
+
+    def test_remove(self, container):
+        append_region_labels(container, _label_set(), "sig")
+        remove_region_labels(container)
+        assert read_region_labels(container) is None
+        remove_region_labels(container)  # no-op on absence
+
+
+class TestRemoveProjectionsDropsLabels:
+    def test_labels_go_with_the_layout(self, container):
+        rng = np.random.default_rng(5)
+        coords = rng.standard_normal((6, 2)).astype(np.float32)
+        proj = Projection("proj-1", list(range(1, 7)), coords, "pca")
+        pyr = build_pyramid(proj, n_levels=2)
+        append_projection(container, proj, pyr)
+        append_region_labels(container, _label_set("proj-1"), "sig")
+
+        remove_projections(container)
+        assert read_projection(container, pyr.bin_shape) is None
+        assert read_region_labels(container) is None

--- a/tests_lib/projection/test_signpost_prep.py
+++ b/tests_lib/projection/test_signpost_prep.py
@@ -1,0 +1,197 @@
+"""Library-tier tests for the signpost prep orchestration.
+
+Covers ``vtscore.projection.signpost_prep`` end-to-end with the toponymy fit
+stubbed at the ``_fit_topic_layers`` seam: prerequisite gating, matrix/text
+alignment, context-slot assignment (full vs subset), container persistence +
+signature stamping, and the ingest-time ``ensure_texts_for_dataset`` stage.
+No Flask; the "embedder" is a local fake resolved through a patched registry.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.projection import signpost_build as sb
+from vtscore.projection import signpost_prep as sp
+from vtscore.projection import signpost_texts as st
+from vtscore.projection.umap_projection import Projection
+from vtscore.state import DatasetContext
+
+_N = 60
+_DIM = 8
+_EMBEDDER = "fake_clap"
+
+
+class FakeEmbedder:
+    name = _EMBEDDER
+    supports_text = True
+
+    def embed_text(self, text: str):
+        import hashlib
+
+        seed = int(hashlib.md5(text.encode()).hexdigest(), 16) % 2**32
+        rng = np.random.default_rng(seed)
+        vec = rng.standard_normal(_DIM).astype(np.float32)
+        return vec / np.linalg.norm(vec)
+
+
+@pytest.fixture
+def ctx(monkeypatch):
+    """A context of ``_N`` audio medias with vectors under the fake embedder.
+
+    The fit itself is stubbed, so these tests run whether or not toponymy is
+    installed — availability is patched to True and re-patched off by the
+    tests that cover the unavailable path.
+    """
+    monkeypatch.setattr(sp, "signposting_available", lambda: True)
+    rng = np.random.default_rng(7)
+    context = DatasetContext("signpost-test")
+    for mid in range(1, _N + 1):
+        vec = rng.standard_normal(_DIM).astype(np.float32)
+        context.medias[mid] = {
+            "id": mid,
+            "media_type": "audio",
+            "embedder": _EMBEDDER,
+            "embeddings": {_EMBEDDER: vec / np.linalg.norm(vec)},
+        }
+    monkeypatch.setattr(DatasetContext, "routed_embedder", lambda self, role: _EMBEDDER)
+
+    import vtscore.media as media_registry
+
+    monkeypatch.setattr(media_registry, "get_embedder", lambda name: FakeEmbedder())
+    return context
+
+
+@pytest.fixture
+def stub_pipeline(monkeypatch):
+    """Fast deterministic stand-ins for the UMAP + toponymy stages."""
+    monkeypatch.setattr(st, "_load_vocab", lambda asset: ["dog", "rain", "car"])
+    monkeypatch.setattr(sb, "_clusterable_vectors", lambda m, p=None: np.asarray(m[:, :2], np.float32))
+
+    def fake_fit(texts, embedding_vectors, clusterable_vectors, text_encoder, **kwargs):
+        n = len(texts)
+        return [(["half-a", "half-b"], np.array([0, 1] * (n // 2))), (["everything"], np.zeros(n, dtype=int))]
+
+    monkeypatch.setattr(sb, "_fit_topic_layers", fake_fit)
+
+
+def _proj(ctx, ids=None, projection_id="prep-proj"):
+    ids = sorted(ctx.medias) if ids is None else sorted(ids)
+    rng = np.random.default_rng(3)
+    coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+    return Projection(projection_id, ids, coords, "pca")
+
+
+class TestPrepSignposts:
+    def test_full_build_assigns_and_labels(self, ctx, stub_pipeline):
+        proj = _proj(ctx)
+        label_set = sp.prep_signposts(ctx, proj, subset=False)
+
+        assert label_set is not None
+        assert ctx._region_labels is label_set
+        assert ctx._subset_region_labels is None
+        assert label_set.projection_id == proj.projection_id
+        assert {lab.text for lab in label_set.labels} == {"everything", "half-a", "half-b"}
+        # Texts were stamped onto the media dicts for reuse (e.g. Find→Browse).
+        assert all(st.TEXT_FIELD in m for m in ctx.medias.values())
+
+    def test_subset_build_uses_subset_slot_only(self, ctx, stub_pipeline):
+        ids = sorted(ctx.medias)[: _N // 2 + 10]
+        proj = _proj(ctx, ids=ids, projection_id="subset-proj")
+        label_set = sp.prep_signposts(ctx, proj, subset=True)
+
+        assert label_set is not None
+        assert ctx._subset_region_labels is label_set
+        assert ctx._region_labels is None
+
+    def test_persists_full_set_with_signature(self, ctx, stub_pipeline, tmp_path, monkeypatch):
+        pkl = tmp_path / "container.pkl"
+        import zipfile
+
+        with zipfile.ZipFile(pkl, "w") as zf:
+            zf.writestr("placeholder", b"")
+        import vtscore.datasets.registry as registry
+
+        monkeypatch.setattr(registry, "get_dataset", lambda dataset_id: {"pkl_path": str(pkl)})
+
+        proj = _proj(ctx)
+        label_set = sp.prep_signposts(ctx, proj, subset=False)
+        assert label_set is not None
+
+        from vtscore.datasets.container import read_region_labels
+
+        loaded = read_region_labels(pkl)
+        assert loaded is not None
+        stored_set, stored_signature = loaded
+        assert stored_set.projection_id == proj.projection_id
+        assert stored_set.labels == label_set.labels
+        assert stored_signature == sp.labeler_signature(ctx)
+
+    def test_subset_never_persists(self, ctx, stub_pipeline, monkeypatch):
+        import vtscore.datasets.registry as registry
+
+        def boom(dataset_id):
+            raise AssertionError("subset prep must not touch the registry")
+
+        monkeypatch.setattr(registry, "get_dataset", boom)
+        assert sp.prep_signposts(ctx, _proj(ctx), subset=True) is not None
+
+    def test_empty_fit_leaves_slot_untouched(self, ctx, stub_pipeline, monkeypatch):
+        # An empty result must not pin an empty set — that would suppress the
+        # lazy ground-truth fallback for hierarchical-category datasets.
+        monkeypatch.setattr(sb, "_fit_topic_layers", lambda *a, **k: [])
+        assert sp.prep_signposts(ctx, _proj(ctx), subset=False) is None
+        assert ctx._region_labels is None
+
+    def test_no_text_embedder_bails(self, ctx, stub_pipeline, monkeypatch):
+        monkeypatch.setattr(DatasetContext, "routed_embedder", lambda self, role: None)
+        assert sp.prep_signposts(ctx, _proj(ctx), subset=False) is None
+
+    def test_unavailable_toponymy_bails(self, ctx, stub_pipeline, monkeypatch):
+        monkeypatch.setattr(sp, "signposting_available", lambda: False)
+        assert sp.prep_signposts(ctx, _proj(ctx), subset=False) is None
+
+    def test_tiny_layout_bails_before_texts(self, ctx, stub_pipeline, monkeypatch):
+        def boom(*args, **kwargs):
+            raise AssertionError("texts must not be computed for tiny layouts")
+
+        monkeypatch.setattr(sp, "ensure_signpost_texts", boom)
+        proj = _proj(ctx, ids=sorted(ctx.medias)[: sb._MIN_POINTS - 1])
+        assert sp.prep_signposts(ctx, proj, subset=False) is None
+
+    def test_media_id_mismatch_bails(self, ctx, stub_pipeline):
+        # A layout fit on ids that are no longer (all) in the dataset must not
+        # be lettered — row order vs proj.coords could no longer be trusted.
+        proj = _proj(ctx)
+        del ctx.medias[sorted(ctx.medias)[-1]]
+        assert sp.prep_signposts(ctx, proj, subset=False) is None
+
+    def test_unsupported_media_type_bails(self, ctx, stub_pipeline):
+        for media in ctx.medias.values():
+            media["media_type"] = "no_provider_type"
+        assert sp.prep_signposts(ctx, _proj(ctx), subset=False) is None
+
+
+class TestLabelerSignature:
+    def test_signature_shape(self, ctx, stub_pipeline):
+        signature = sp.labeler_signature(ctx)
+        assert signature is not None
+        assert signature.startswith("keyphrase|tags:audioset527:fake_clap|toponymy=")
+
+    def test_none_when_unavailable(self, ctx, monkeypatch):
+        monkeypatch.setattr(sp, "signposting_available", lambda: False)
+        assert sp.labeler_signature(ctx) is None
+
+
+class TestEnsureTextsForDataset:
+    def test_stamps_all_medias(self, ctx, stub_pipeline):
+        sp.ensure_texts_for_dataset(ctx)
+        assert all(st.TEXT_FIELD in m and m[st.TEXT_FIELD] for m in ctx.medias.values())
+        source = next(iter(ctx.medias.values()))[st.SOURCE_FIELD]
+        assert source == "tags:audioset527:fake_clap"
+
+    def test_noop_without_text_embedder(self, ctx, stub_pipeline, monkeypatch):
+        monkeypatch.setattr(DatasetContext, "routed_embedder", lambda self, role: None)
+        sp.ensure_texts_for_dataset(ctx)
+        assert not any(st.TEXT_FIELD in m for m in ctx.medias.values())

--- a/tests_lib/projection/test_signpost_texts.py
+++ b/tests_lib/projection/test_signpost_texts.py
@@ -1,0 +1,218 @@
+"""Library-tier tests for the signpost text provider layer.
+
+Covers ``vtscore.projection.signpost_texts``: the zero-shot tag provider, the
+content provider, the per-media-type registry, and the cache-aware
+``ensure_signpost_texts`` entry point (stamping, signature invalidation,
+reuse).  No Flask, no models, no toponymy — pure numpy + fakes.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.projection import signpost_texts as st
+
+
+class FakeTextEmbedder:
+    """Maps "<template> <term>" strings onto fixed unit basis vectors."""
+
+    def __init__(self, terms: list[str], name: str = "fake_clap", dim: int = 8):
+        self.name = name
+        self.terms = terms
+        self.dim = dim
+        self.calls = 0
+
+    def embed_text(self, text: str):
+        self.calls += 1
+        for i, term in enumerate(self.terms):
+            if term in text:
+                vec = np.zeros(self.dim, dtype=np.float32)
+                vec[i] = 1.0
+                return vec
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _fresh_vocab_cache():
+    """Isolate the process-scoped vocabulary-vector cache between tests."""
+    saved = dict(st._vocab_cache)
+    st._vocab_cache.clear()
+    try:
+        yield
+    finally:
+        st._vocab_cache.clear()
+        st._vocab_cache.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_provider_registry():
+    """Restore the provider registry after tests that register fakes."""
+    saved = dict(st._PROVIDERS)
+    try:
+        yield
+    finally:
+        st._PROVIDERS.clear()
+        st._PROVIDERS.update(saved)
+
+
+def _basis_matrix(rows: list[int], dim: int = 8) -> np.ndarray:
+    matrix = np.zeros((len(rows), dim), dtype=np.float32)
+    for r, term_idx in enumerate(rows):
+        matrix[r, term_idx] = 1.0
+    return matrix
+
+
+class TestZeroShotTagProvider:
+    def _provider(self, monkeypatch, terms, top_k=2):
+        monkeypatch.setattr(st, "_load_vocab", lambda asset: terms)
+        return st.ZeroShotTagProvider(
+            name="tags:test", vocab_asset="unused.txt", template="The sound of {}", top_k=top_k
+        )
+
+    def test_top_tags_ranked_by_similarity(self, monkeypatch):
+        terms = ["dog", "rain", "car"]
+        provider = self._provider(monkeypatch, terms)
+        embedder = FakeTextEmbedder(terms)
+        medias = {1: {}, 2: {}}
+        matrix = _basis_matrix([2, 0])  # media 1 ≈ "car", media 2 ≈ "dog"
+
+        texts = provider.build_texts([1, 2], medias, matrix, embedder)
+        assert texts[1].split(", ")[0] == "car"
+        assert texts[2].split(", ")[0] == "dog"
+        assert len(texts[1].split(", ")) == 2  # top_k
+
+    def test_vocab_embedded_once_per_embedder(self, monkeypatch):
+        terms = ["dog", "rain", "car"]
+        provider = self._provider(monkeypatch, terms)
+        embedder = FakeTextEmbedder(terms)
+        medias = {1: {}}
+        matrix = _basis_matrix([0])
+
+        provider.build_texts([1], medias, matrix, embedder)
+        first_pass = embedder.calls
+        assert first_pass == len(terms)
+        provider.build_texts([1], medias, matrix, embedder)
+        assert embedder.calls == first_pass  # cache hit, no re-embedding
+
+    def test_unembeddable_terms_are_dropped(self, monkeypatch):
+        # "storm" never embeds; the term list and matrix must stay aligned.
+        terms = ["dog", "storm", "car"]
+        provider = self._provider(monkeypatch, terms, top_k=3)
+        embedder = FakeTextEmbedder(["dog", "car"])  # knows only two
+        texts = provider.build_texts([1], {1: {}}, _basis_matrix([0]), embedder)
+        assert "storm" not in texts[1]
+
+    def test_signature_includes_embedder(self, monkeypatch):
+        provider = self._provider(monkeypatch, ["dog"])
+        assert provider.signature(FakeTextEmbedder([], name="a")) != provider.signature(FakeTextEmbedder([], name="b"))
+
+
+class TestContentTextProvider:
+    def test_returns_truncated_content(self):
+        provider = st.ContentTextProvider(max_chars=11)
+        medias = {1: {"content": "  hello world this is long  "}, 2: {"content": ""}, 3: {}}
+        texts = provider.build_texts([1, 2, 3], medias, np.empty((3, 0)), embedder=None)
+        assert texts == {1: "hello world"}
+
+
+class TestRegistry:
+    def test_defaults_cover_audio_image_text(self):
+        audio, image = st.provider_for("audio"), st.provider_for("image")
+        assert audio is not None and audio.name == "tags:audioset527"
+        assert image is not None and image.name == "tags:openimages600"
+        assert isinstance(st.provider_for("text"), st.ContentTextProvider)
+        assert st.provider_for("weird_type") is None
+
+    def test_register_replaces(self):
+        provider = st.ContentTextProvider(field="caption")
+        st.register_signpost_text_provider("video", provider)
+        assert st.provider_for("video") is provider
+
+    def test_shipped_vocab_assets_load(self):
+        assert len(st._load_vocab("audioset527_labels.txt")) == 527
+        assert len(st._load_vocab("openimages600_labels.txt")) == 601
+
+
+class CountingProvider:
+    """Registry-pluggable provider that counts build calls."""
+
+    name = "counting"
+
+    def __init__(self, signature="counting:v1"):
+        self._signature = signature
+        self.build_calls = 0
+
+    def signature(self, embedder):
+        return self._signature
+
+    def build_texts(self, ids, medias, matrix, embedder, on_progress=None):
+        self.build_calls += 1
+        return {mid: f"text-{mid}" for mid in ids}
+
+
+class TestEnsureSignpostTexts:
+    def _medias(self, n=4, media_type="fake"):
+        return {i: {"id": i, "media_type": media_type} for i in range(1, n + 1)}
+
+    def test_computes_and_stamps_missing(self):
+        provider = CountingProvider()
+        st.register_signpost_text_provider("fake", provider)
+        medias = self._medias()
+        ids = sorted(medias)
+
+        texts = st.ensure_signpost_texts(medias, ids, np.zeros((4, 2), dtype=np.float32), None)
+        assert texts == {i: f"text-{i}" for i in ids}
+        assert medias[1][st.TEXT_FIELD] == "text-1"
+        assert medias[1][st.SOURCE_FIELD] == "counting:v1"
+
+    def test_cached_texts_are_reused(self):
+        provider = CountingProvider()
+        st.register_signpost_text_provider("fake", provider)
+        medias = self._medias()
+        ids = sorted(medias)
+        matrix = np.zeros((4, 2), dtype=np.float32)
+
+        st.ensure_signpost_texts(medias, ids, matrix, None)
+        st.ensure_signpost_texts(medias, ids, matrix, None)
+        assert provider.build_calls == 1  # second call served from the stamps
+
+    def test_signature_change_invalidates_cache(self):
+        provider = CountingProvider()
+        st.register_signpost_text_provider("fake", provider)
+        medias = self._medias()
+        ids = sorted(medias)
+        matrix = np.zeros((4, 2), dtype=np.float32)
+
+        st.ensure_signpost_texts(medias, ids, matrix, None)
+        provider._signature = "counting:v2"  # e.g. a different embedder/vocab
+        st.ensure_signpost_texts(medias, ids, matrix, None)
+        assert provider.build_calls == 2
+        assert medias[1][st.SOURCE_FIELD] == "counting:v2"
+
+    def test_partial_cache_computes_only_misses(self):
+        provider = CountingProvider()
+        st.register_signpost_text_provider("fake", provider)
+        medias = self._medias()
+        ids = sorted(medias)
+        medias[2][st.TEXT_FIELD] = "pre-cached"
+        medias[2][st.SOURCE_FIELD] = "counting:v1"
+
+        seen: list[list[int]] = []
+        original = provider.build_texts
+
+        def spying(ids, *args, **kwargs):
+            seen.append(list(ids))
+            return original(ids, *args, **kwargs)
+
+        provider.build_texts = spying
+        texts = st.ensure_signpost_texts(medias, ids, np.zeros((4, 2), dtype=np.float32), None)
+        assert seen == [[1, 3, 4]]
+        assert texts is not None and texts[2] == "pre-cached"
+
+    def test_no_provider_returns_none(self):
+        medias = self._medias(media_type="no_such_type")
+        assert st.ensure_signpost_texts(medias, sorted(medias), np.zeros((4, 2)), None) is None
+
+    def test_empty_ids_returns_none(self):
+        assert st.ensure_signpost_texts({}, [], np.empty((0, 0)), None) is None

--- a/tests_lib/projection/test_toponymy_smoke.py
+++ b/tests_lib/projection/test_toponymy_smoke.py
@@ -1,0 +1,82 @@
+"""Slow smoke test: the real toponymy library, end-to-end through our glue.
+
+toponymy is installed ``--no-deps`` (its ``transformers<5`` pin is bypassed —
+see ``docs/plans/vtsbrowse-toponymy.md``), so the resolver never checks that a
+future environment still satisfies it.  This test is that check: import the
+library for real, run :func:`build_region_labels` (clusterable UMAP →
+multiresolution clustering → contrastive keyphrases → KeyphraseNamer) on a
+tiny seeded corpus, and assert signs come out.  Numba compilation makes this
+a ~1 minute test → ``slow`` marker; run with ``-m slow``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip("toponymy")
+
+from vtscore.projection.signpost_build import build_region_labels  # noqa: E402
+from vtscore.projection.umap_projection import Projection  # noqa: E402
+
+pytestmark = pytest.mark.slow
+
+_DIM = 16
+_WORDS = {
+    0: ["dog barking", "dog growl", "puppy bark", "dog howl"],
+    1: ["rain falling", "thunder storm", "rain drops", "storm wind"],
+    2: ["car engine", "engine idle", "car horn", "traffic noise"],
+}
+
+
+class SeededEmbedder:
+    name = "seeded"
+    supports_text = True
+
+    def embed_text(self, text: str):
+        seed = int(hashlib.md5(text.encode()).hexdigest(), 16) % 2**32
+        rng = np.random.default_rng(seed)
+        vec = rng.standard_normal(_DIM).astype(np.float32)
+        return vec / np.linalg.norm(vec)
+
+
+def test_real_toponymy_fit_produces_signs():
+    rng = np.random.default_rng(42)
+    per_cluster = 100
+    centers = rng.standard_normal((3, _DIM)).astype(np.float32) * 4
+    rows, texts = [], []
+    for c in range(3):
+        rows.append(centers[c] + rng.standard_normal((per_cluster, _DIM)).astype(np.float32))
+        texts.extend(_WORDS[c][i % len(_WORDS[c])] for i in range(per_cluster))
+    matrix = np.vstack(rows)
+    matrix /= np.linalg.norm(matrix, axis=1, keepdims=True)
+
+    n = matrix.shape[0]
+    coords = rng.standard_normal((n, 2)).astype(np.float32)
+    proj = Projection("smoke-proj", list(range(1, n + 1)), coords, "pca")
+
+    label_set = build_region_labels(
+        proj,
+        matrix,
+        matrix,
+        texts,
+        SeededEmbedder(),
+        object_description="sounds",
+        corpus_description="a tiny synthetic corpus of animal, weather, and traffic sounds",
+    )
+
+    assert label_set.projection_id == "smoke-proj"
+    assert label_set.labels, "the real pipeline produced no signs"
+    assert all(lab.source == "keyphrase" for lab in label_set.labels)
+    assert all(lab.text.strip() for lab in label_set.labels)
+    # The coarsest layer sits at zoom band 0 and every anchor is a real
+    # layout point (a medoid, not a centroid off in empty space).
+    assert min(lab.level for lab in label_set.labels) == 0.0
+    coord_set = {(round(float(x), 4), round(float(y), 4)) for x, y in np.asarray(proj.coords)}
+    assert all((round(lab.x, 4), round(lab.y, 4)) in coord_set for lab in label_set.labels)
+    # The keyphrase namer names from the corpus vocabulary.
+    corpus_vocab = {w for words in _WORDS.values() for phrase in words for w in phrase.split()}
+    named_words = {w for lab in label_set.labels for w in lab.text.lower().split()}
+    assert named_words & corpus_vocab

--- a/vtscore/datasets/container.py
+++ b/vtscore/datasets/container.py
@@ -180,7 +180,9 @@ def remove_projections(path: str | Path) -> None:
     (which are shared across bin shapes).  A no-op if no entries are present.
     """
     p = Path(path)
-    entry_names = {_projection_entry_name(s) for s in ("hex", "square")}
+    # The signpost labels are anchored in the discarded layout's coordinates,
+    # so they go with it.
+    entry_names = {_projection_entry_name(s) for s in ("hex", "square")} | {_REGION_LABELS_ENTRY}
     try:
         with zipfile.ZipFile(str(p), "r") as zf:
             present = entry_names & set(zf.namelist())
@@ -208,6 +210,72 @@ def read_projection(path: str | Path, bin_shape: str = "hex") -> tuple[Any, Any]
         return None
 
     return _deserialize_projection(npz_bytes)
+
+
+#: ZIP entry holding the region signpost labels for the persisted full-dataset
+#: projection (see ``vtscore.projection.labels``).  Pure derived text + 2-D
+#: anchors — JSON, no vectors — pinned to the layout's ``projection_id`` and
+#: stamped with the labeler signature that produced it.
+_REGION_LABELS_ENTRY = "region_labels.json"
+
+
+def append_region_labels(path: str | Path, label_set: Any, labeler_signature: str) -> None:
+    """Append (or replace) the region signpost labels in a container.
+
+    *label_set* is a :class:`~vtscore.projection.labels.RegionLabelSet`; its
+    ``projection_id`` pins the signs to the frozen layout they were computed
+    from, and *labeler_signature* records the provider/namer configuration so
+    a later load can tell whether the signs match the active pipeline.
+    """
+    p = Path(path)
+    payload = {
+        "projection_id": label_set.projection_id,
+        "labeler_signature": labeler_signature,
+        "labels": label_set.payload(),
+    }
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+    with zipfile.ZipFile(str(p), "a") as zf:
+        if _REGION_LABELS_ENTRY in zf.namelist():
+            _rewrite_without(p, _REGION_LABELS_ENTRY)
+            with zipfile.ZipFile(str(p), "a") as zf2:
+                zf2.writestr(_REGION_LABELS_ENTRY, body)
+        else:
+            zf.writestr(_REGION_LABELS_ENTRY, body)
+
+    logger.info("Appended region labels (%d signs) to container: %s", len(label_set.labels), p)
+
+
+def read_region_labels(path: str | Path) -> tuple[Any, str] | None:
+    """Read ``(RegionLabelSet, labeler_signature)`` from a container, or ``None``."""
+    try:
+        with zipfile.ZipFile(str(path), "r") as zf:
+            if _REGION_LABELS_ENTRY not in zf.namelist():
+                return None
+            body = zf.read(_REGION_LABELS_ENTRY)
+        payload = json.loads(body.decode("utf-8"))
+        from vtscore.projection.labels import RegionLabel, make_label_set  # noqa: PLC0415
+
+        labels = [RegionLabel(**entry) for entry in payload.get("labels", [])]
+        label_set = make_label_set(str(payload["projection_id"]), labels)
+        return label_set, str(payload.get("labeler_signature", ""))
+    except Exception:
+        logger.warning("Failed to read region labels from container %s", path, exc_info=True)
+        return None
+
+
+def remove_region_labels(path: str | Path) -> None:
+    """Remove the region signpost labels entry from a container (no-op if absent)."""
+    p = Path(path)
+    try:
+        with zipfile.ZipFile(str(p), "r") as zf:
+            present = _REGION_LABELS_ENTRY in zf.namelist()
+    except Exception:
+        logger.warning("Failed to read container %s while clearing region labels", p, exc_info=True)
+        return
+    if present:
+        _rewrite_without(p, _REGION_LABELS_ENTRY)
+        logger.info("Removed region labels from container: %s", p)
 
 
 def _serialize_projection(projection: Any, pyramid: Any) -> bytes:

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -51,7 +51,7 @@ from vtscore.datasets.stages.finalize import (
     _collapse_near_duplicates_stage,
     _drop_none_embeddings_stage,
 )
-from vtscore.datasets.stages.projection import _build_projection_stage
+from vtscore.datasets.stages.projection import _build_projection_stage, _maybe_signpost_texts_stage
 from vtscore.datasets.stages.registry import _register_and_migrate
 
 
@@ -513,6 +513,12 @@ def _run_origin_load_in_background(
                     fin.begin("coverage")
                     _build_coverage_atlas_stage(ctx, fin)
                     tracker.check_cancelled()
+                    # Opt-in (rides the projection opt-in): cache a signpost
+                    # text per media BEFORE the registry save, so the texts —
+                    # the sign pipeline's only full-corpus model cost — are
+                    # pickled with the dataset and later browse / Find→Browse
+                    # re-fits skip the text models entirely.
+                    _maybe_signpost_texts_stage(ctx, fin, build_projection)
                     fin.begin("registry")
                     context_id, registry_entry_id = _register_and_migrate(
                         ctx, fin, task_id, origin, name, clipper, embedder, created_by, ingest_started_at

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -184,6 +184,7 @@ class FinalizeProgress:
         ("cleanup", 0.05),
         ("dedup", 0.15),
         ("coverage", 0.30),
+        ("signpost_texts", 0.05),
         ("registry", 0.45),
         ("projection", 0.05),
     )

--- a/vtscore/datasets/stages/projection.py
+++ b/vtscore/datasets/stages/projection.py
@@ -43,15 +43,60 @@ def _persist_projection_to_container(dataset_id: str, proj, pyr) -> None:
         traceback.print_exc()
 
 
+def _signpost_texts_stage(ctx: DatasetContext, tracker) -> None:
+    """Compute + cache the per-media signpost texts at ingest (opt-in).
+
+    Runs **before** the registry save so the texts land in the dataset
+    pickle: Toponymy's contrastive keyphrase mining needs a text for *every*
+    media (not just sampled exemplars), and the text is the only full-corpus
+    model cost in the sign pipeline — computed once here, every later browse
+    and Find→Browse subset re-fit reuses it.  No-op when signposting isn't
+    possible for this dataset; best-effort by the same contract as the
+    projection stage (the caller wraps it).
+    """
+    from vtscore.projection.signpost_prep import ensure_texts_for_dataset  # noqa: PLC0415
+
+    def _progress(current: int, total: int, message: str) -> None:
+        tracker.check_cancelled()
+        tracker.update(
+            "loading",
+            message,
+            current=current,
+            total=total,
+            step=_TOTAL_LOAD_STEPS,
+            total_steps=_TOTAL_LOAD_STEPS,
+        )
+
+    _progress(0, 0, "Preparing signpost texts…")
+    ensure_texts_for_dataset(ctx, _progress)
+
+
+def _maybe_signpost_texts_stage(ctx: DatasetContext, fin, enabled: bool) -> None:
+    """Run the signpost-texts stage when the projection opt-in is set.
+
+    Owns the opt-in gate and the best-effort wrapper so the load pipeline's
+    task body stays branch-free; a failure here (short of a cancellation
+    raised through the tracker) costs only the cached texts, never the load.
+    """
+    if not enabled:
+        return
+    fin.begin("signpost_texts")
+    try:
+        _signpost_texts_stage(ctx, fin)
+    except Exception:
+        traceback.print_exc()
+
+
 def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> None:
-    """Compute + persist the 2-D UMAP projection at ingest (opt-in).
+    """Compute + persist the 2-D UMAP projection and its signposts at ingest (opt-in).
 
     Runs inline as a load stage (after the dataset is registered) so the
     Browse canvas opens instantly instead of paying for the UMAP fit lazily
     on first visit.  This mirrors the on-demand
     ``POST /api/projection/build`` path: fit UMAP on the cached embedding
-    matrix, build the hex-tile pyramid, cache both on the context, and
-    persist them into the dataset container.
+    matrix, build the hex-tile pyramid, run the signpost labeling over the
+    frozen layout (see ``vtscore.projection.signpost_prep``), cache
+    everything on the context, and persist it into the dataset container.
 
     Best-effort by contract: the dataset is already registered and usable
     before this runs, so any failure here (including a cancellation during
@@ -97,6 +142,18 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
     # so build exactly the one shape this dataset will ever use.
     media_type = next(iter(ctx.medias.values())).get("media_type") if ctx.medias else None
     pyr = build_pyramid(proj, bin_shape=bin_shape_for_media_type(media_type))
+
+    # Letter the frozen layout before it's cached/persisted, so the first
+    # Browse open finds the signs together with the map (the canvas fetches
+    # labels once per projection_id).  Reuses the texts the pre-registry
+    # stage cached into the pickle; itself best-effort — a labeling failure
+    # must not cost the user the projection they just paid for.
+    try:
+        from vtscore.projection.signpost_prep import prep_signposts  # noqa: PLC0415
+
+        prep_signposts(ctx, proj, subset=False, on_progress=_progress)
+    except Exception:
+        traceback.print_exc()
     _progress(1, 1, "Projection ready")
 
     ctx._projection = proj

--- a/vtscore/projection/assets/audioset527_labels.txt
+++ b/vtscore/projection/assets/audioset527_labels.txt
@@ -1,0 +1,527 @@
+Speech
+Male speech, man speaking
+Female speech, woman speaking
+Child speech, kid speaking
+Conversation
+Narration, monologue
+Babbling
+Speech synthesizer
+Shout
+Bellow
+Whoop
+Yell
+Battle cry
+Children shouting
+Screaming
+Whispering
+Laughter
+Baby laughter
+Giggle
+Snicker
+Belly laugh
+Chuckle, chortle
+Crying, sobbing
+Baby cry, infant cry
+Whimper
+Wail, moan
+Sigh
+Singing
+Choir
+Yodeling
+Chant
+Mantra
+Male singing
+Female singing
+Child singing
+Synthetic singing
+Rapping
+Humming
+Groan
+Grunt
+Whistling
+Breathing
+Wheeze
+Snoring
+Gasp
+Pant
+Snort
+Cough
+Throat clearing
+Sneeze
+Sniff
+Run
+Shuffle
+Walk, footsteps
+Chewing, mastication
+Biting
+Gargling
+Stomach rumble
+Burping, eructation
+Hiccup
+Fart
+Hands
+Finger snapping
+Clapping
+Heart sounds, heartbeat
+Heart murmur
+Cheering
+Applause
+Chatter
+Crowd
+Hubbub, speech noise, speech babble
+Children playing
+Animal
+Domestic animals, pets
+Dog
+Bark
+Yip
+Howl
+Bow-wow
+Growling
+Whimper (dog)
+Cat
+Purr
+Meow
+Hiss
+Caterwaul
+Livestock, farm animals, working animals
+Horse
+Clip-clop
+Neigh, whinny
+Cattle, bovinae
+Moo
+Cowbell
+Pig
+Oink
+Goat
+Bleat
+Sheep
+Fowl
+Chicken, rooster
+Cluck
+Crowing, cock-a-doodle-doo
+Turkey
+Gobble
+Duck
+Quack
+Goose
+Honk
+Wild animals
+Roaring cats (lions, tigers)
+Roar
+Bird
+Bird vocalization, bird call, bird song
+Chirp, tweet
+Squawk
+Pigeon, dove
+Coo
+Crow
+Caw
+Owl
+Hoot
+Bird flight, flapping wings
+Canidae, dogs, wolves
+Rodents, rats, mice
+Mouse
+Patter
+Insect
+Cricket
+Mosquito
+Fly, housefly
+Buzz
+Bee, wasp, etc.
+Frog
+Croak
+Snake
+Rattle
+Whale vocalization
+Music
+Musical instrument
+Plucked string instrument
+Guitar
+Electric guitar
+Bass guitar
+Acoustic guitar
+Steel guitar, slide guitar
+Tapping (guitar technique)
+Strum
+Banjo
+Sitar
+Mandolin
+Zither
+Ukulele
+Keyboard (musical)
+Piano
+Electric piano
+Organ
+Electronic organ
+Hammond organ
+Synthesizer
+Sampler
+Harpsichord
+Percussion
+Drum kit
+Drum machine
+Drum
+Snare drum
+Rimshot
+Drum roll
+Bass drum
+Timpani
+Tabla
+Cymbal
+Hi-hat
+Wood block
+Tambourine
+Rattle (instrument)
+Maraca
+Gong
+Tubular bells
+Mallet percussion
+Marimba, xylophone
+Glockenspiel
+Vibraphone
+Steelpan
+Orchestra
+Brass instrument
+French horn
+Trumpet
+Trombone
+Bowed string instrument
+String section
+Violin, fiddle
+Pizzicato
+Cello
+Double bass
+Wind instrument, woodwind instrument
+Flute
+Saxophone
+Clarinet
+Harp
+Bell
+Church bell
+Jingle bell
+Bicycle bell
+Tuning fork
+Chime
+Wind chime
+Change ringing (campanology)
+Harmonica
+Accordion
+Bagpipes
+Didgeridoo
+Shofar
+Theremin
+Singing bowl
+Scratching (performance technique)
+Pop music
+Hip hop music
+Beatboxing
+Rock music
+Heavy metal
+Punk rock
+Grunge
+Progressive rock
+Rock and roll
+Psychedelic rock
+Rhythm and blues
+Soul music
+Reggae
+Country
+Swing music
+Bluegrass
+Funk
+Folk music
+Middle Eastern music
+Jazz
+Disco
+Classical music
+Opera
+Electronic music
+House music
+Techno
+Dubstep
+Drum and bass
+Electronica
+Electronic dance music
+Ambient music
+Trance music
+Music of Latin America
+Salsa music
+Flamenco
+Blues
+Music for children
+New-age music
+Vocal music
+A capella
+Music of Africa
+Afrobeat
+Christian music
+Gospel music
+Music of Asia
+Carnatic music
+Music of Bollywood
+Ska
+Traditional music
+Independent music
+Song
+Background music
+Theme music
+Jingle (music)
+Soundtrack music
+Lullaby
+Video game music
+Christmas music
+Dance music
+Wedding music
+Happy music
+Funny music
+Sad music
+Tender music
+Exciting music
+Angry music
+Scary music
+Wind
+Rustling leaves
+Wind noise (microphone)
+Thunderstorm
+Thunder
+Water
+Rain
+Raindrop
+Rain on surface
+Stream
+Waterfall
+Ocean
+Waves, surf
+Steam
+Gurgling
+Fire
+Crackle
+Vehicle
+Boat, Water vehicle
+Sailboat, sailing ship
+Rowboat, canoe, kayak
+Motorboat, speedboat
+Ship
+Motor vehicle (road)
+Car
+Vehicle horn, car horn, honking
+Toot
+Car alarm
+Power windows, electric windows
+Skidding
+Tire squeal
+Car passing by
+Race car, auto racing
+Truck
+Air brake
+Air horn, truck horn
+Reversing beeps
+Ice cream truck, ice cream van
+Bus
+Emergency vehicle
+Police car (siren)
+Ambulance (siren)
+Fire engine, fire truck (siren)
+Motorcycle
+Traffic noise, roadway noise
+Rail transport
+Train
+Train whistle
+Train horn
+Railroad car, train wagon
+Train wheels squealing
+Subway, metro, underground
+Aircraft
+Aircraft engine
+Jet engine
+Propeller, airscrew
+Helicopter
+Fixed-wing aircraft, airplane
+Bicycle
+Skateboard
+Engine
+Light engine (high frequency)
+Dental drill, dentist's drill
+Lawn mower
+Chainsaw
+Medium engine (mid frequency)
+Heavy engine (low frequency)
+Engine knocking
+Engine starting
+Idling
+Accelerating, revving, vroom
+Door
+Doorbell
+Ding-dong
+Sliding door
+Slam
+Knock
+Tap
+Squeak
+Cupboard open or close
+Drawer open or close
+Dishes, pots, and pans
+Cutlery, silverware
+Chopping (food)
+Frying (food)
+Microwave oven
+Blender
+Water tap, faucet
+Sink (filling or washing)
+Bathtub (filling or washing)
+Hair dryer
+Toilet flush
+Toothbrush
+Electric toothbrush
+Vacuum cleaner
+Zipper (clothing)
+Keys jangling
+Coin (dropping)
+Scissors
+Electric shaver, electric razor
+Shuffling cards
+Typing
+Typewriter
+Computer keyboard
+Writing
+Alarm
+Telephone
+Telephone bell ringing
+Ringtone
+Telephone dialing, DTMF
+Dial tone
+Busy signal
+Alarm clock
+Siren
+Civil defense siren
+Buzzer
+Smoke detector, smoke alarm
+Fire alarm
+Foghorn
+Whistle
+Steam whistle
+Mechanisms
+Ratchet, pawl
+Clock
+Tick
+Tick-tock
+Gears
+Pulleys
+Sewing machine
+Mechanical fan
+Air conditioning
+Cash register
+Printer
+Camera
+Single-lens reflex camera
+Tools
+Hammer
+Jackhammer
+Sawing
+Filing (rasp)
+Sanding
+Power tool
+Drill
+Explosion
+Gunshot, gunfire
+Machine gun
+Fusillade
+Artillery fire
+Cap gun
+Fireworks
+Firecracker
+Burst, pop
+Eruption
+Boom
+Wood
+Chop
+Splinter
+Crack
+Glass
+Chink, clink
+Shatter
+Liquid
+Splash, splatter
+Slosh
+Squish
+Drip
+Pour
+Trickle, dribble
+Gush
+Fill (with liquid)
+Spray
+Pump (liquid)
+Stir
+Boiling
+Sonar
+Arrow
+Whoosh, swoosh, swish
+Thump, thud
+Thunk
+Electronic tuner
+Effects unit
+Chorus effect
+Basketball bounce
+Bang
+Slap, smack
+Whack, thwack
+Smash, crash
+Breaking
+Bouncing
+Whip
+Flap
+Scratch
+Scrape
+Rub
+Roll
+Crushing
+Crumpling, crinkling
+Tearing
+Beep, bleep
+Ping
+Ding
+Clang
+Squeal
+Creak
+Rustle
+Whir
+Clatter
+Sizzle
+Clicking
+Clickety-clack
+Rumble
+Plop
+Jingle, tinkle
+Hum
+Zing
+Boing
+Crunch
+Silence
+Sine wave
+Harmonic
+Chirp tone
+Sound effect
+Pulse
+Inside, small room
+Inside, large room or hall
+Inside, public space
+Outside, urban or manmade
+Outside, rural or natural
+Reverberation
+Echo
+Noise
+Environmental noise
+Static
+Mains hum
+Distortion
+Sidetone
+Cacophony
+White noise
+Pink noise
+Throbbing
+Vibration
+Television
+Radio
+Field recording

--- a/vtscore/projection/assets/openimages600_labels.txt
+++ b/vtscore/projection/assets/openimages600_labels.txt
@@ -1,0 +1,601 @@
+Accordion
+Adhesive tape
+Aircraft
+Alarm clock
+Alpaca
+Ambulance
+Animal
+Ant
+Antelope
+Apple
+Armadillo
+Artichoke
+Auto part
+Axe
+Backpack
+Bagel
+Baked goods
+Balance beam
+Ball (Object)
+Balloon
+Banana
+Band-aid
+Banjo
+Barge
+Barrel
+Baseball bat
+Baseball glove
+Bat (Animal)
+Bathroom accessory
+Bathroom cabinet
+Bathtub
+Beaker
+Bear
+Beard
+Bed
+Bee
+Beehive
+Beer
+Beetle
+Bell pepper
+Belt
+Bench
+Bicycle
+Bicycle helmet
+Bicycle wheel
+Bidet
+Billboard
+Billiard table
+Binoculars
+Bird
+Blender
+Blue jay
+Boat
+Bomb
+Book
+Bookcase
+Boot
+Bottle
+Bottle opener
+Bow and arrow
+Bowl
+Bowling equipment
+Box
+Boy
+Brassiere
+Bread
+Briefcase
+Broccoli
+Bronze sculpture
+Brown bear
+Building
+Bull
+Burrito
+Bus
+Bust
+Butterfly
+Cabbage
+Cabinetry
+Cake
+Cake stand
+Calculator
+Camel
+Camera
+Can opener
+Canary
+Candle
+Candy
+Cannon
+Canoe
+Cantaloupe
+Car
+Carnivore
+Carrot
+Cart
+Cassette deck
+Castle
+Cat
+Cat furniture
+Caterpillar
+Cattle
+Ceiling fan
+Cello
+Centipede
+Chainsaw
+Chair
+Cheese
+Cheetah
+Chest of drawers
+Chicken
+Chime
+Chisel
+Chopsticks
+Christmas tree
+Clock
+Closet
+Clothing
+Coat
+Cocktail
+Cocktail shaker
+Coconut
+Coffee (drink)
+Coffee cup
+Coffee table
+Coffeemaker
+Coin
+Common fig
+Common sunflower
+Computer keyboard
+Computer monitor
+Computer mouse
+Container
+Convenience store
+Cookie
+Cooking spray
+Corded phone
+Cosmetics
+Couch
+Countertop
+Cowboy hat
+Crab
+Cream
+Cricket ball
+Crocodile
+Croissant
+Crown
+Crutch
+Cucumber
+Cupboard
+Curtain
+Cutting board
+Dagger
+Dairy Product
+Deer
+Desk
+Dessert
+Diaper
+Dice
+Digital clock
+Dinosaur
+Dishwasher
+Dog
+Dog bed
+Doll
+Dolphin
+Door
+Door handle
+Doughnut
+Dragonfly
+Drawer
+Dress
+Drill (Tool)
+Drink
+Drinking straw
+Drum
+Duck
+Dumbbell
+Eagle
+Earring
+Egg
+Elephant
+Envelope
+Eraser
+Face powder
+Facial tissue holder
+Falcon
+Fashion accessory
+Fast food
+Fax
+Fedora
+Filing cabinet
+Fire hydrant
+Fireplace
+Fish
+Fixed-wing aircraft
+Flag
+Flashlight
+Flower
+Flowerpot
+Flute
+Flying disc
+Food
+Food processor
+Football
+Football helmet
+Footwear
+Fork
+Fountain
+Fox
+French fries
+French horn
+Frog
+Fruit
+Frying pan
+Furniture
+Garden Asparagus
+Gas stove
+Giraffe
+Girl
+Glasses
+Glove
+Goat
+Goggles
+Goldfish
+Golf ball
+Golf cart
+Gondola
+Goose
+Grape
+Grapefruit
+Grinder
+Guacamole
+Guitar
+Hair dryer
+Hair spray
+Hamburger
+Hammer
+Hamster
+Hand dryer
+Handbag
+Handgun
+Harbor seal
+Harmonica
+Harp
+Harpsichord
+Hat
+Headphones
+Heater
+Hedgehog
+Helicopter
+Helmet
+High heels
+Hiking equipment
+Hippopotamus
+Home appliance
+Honeycomb
+Horizontal bar
+Horse
+Hot dog
+House
+Houseplant
+Human arm
+Human body
+Human ear
+Human eye
+Human face
+Human foot
+Human hair
+Human hand
+Human head
+Human leg
+Human mouth
+Human nose
+Humidifier
+Ice cream
+Indoor rower
+Infant bed
+Insect
+Invertebrate
+Ipod
+Isopod
+Jacket
+Jacuzzi
+Jaguar (Animal)
+Jeans
+Jellyfish
+Jet ski
+Jug
+Juice
+Kangaroo
+Kettle
+Kitchen & dining room table
+Kitchen appliance
+Kitchen knife
+Kitchen utensil
+Kitchenware
+Kite
+Knife
+Koala
+Ladder
+Ladle
+Ladybug
+Lamp
+Land vehicle
+Lantern
+Laptop
+Lavender (Plant)
+Lemon (plant)
+Leopard
+Light bulb
+Light switch
+Lighthouse
+Lily
+Limousine
+Lion
+Lipstick
+Lizard
+Lobster
+Loveseat
+Luggage and bags
+Lynx
+Magpie
+Mammal
+Man
+Mango
+Maple
+Maraca
+Marine invertebrates
+Marine mammal
+Measuring cup
+Mechanical fan
+Medical equipment
+Microphone
+Microwave oven
+Milk
+Miniskirt
+Mirror
+Missile
+Mixer
+Mixing bowl
+Mobile phone
+Monkey
+Moths and butterflies
+Motorcycle
+Mouse
+Muffin
+Mug
+Mule
+Mushroom
+Musical instrument
+Musical keyboard
+Nail (Construction)
+Necklace
+Nightstand
+Oboe
+Office building
+Office supplies
+Orange (fruit)
+Organ (Musical Instrument)
+Ostrich
+Otter
+Oven
+Owl
+Oyster
+Paddle
+Palm tree
+Pancake
+Panda
+Paper cutter
+Paper towel
+Parachute
+Parking meter
+Parrot
+Pasta
+Pastry
+Peach
+Pear
+Pen
+Pencil case
+Pencil sharpener
+Penguin
+Perfume
+Person
+Personal care
+Personal flotation device
+Piano
+Picnic basket
+Picture frame
+Pig
+Pillow
+Pineapple
+Pitcher (Container)
+Pizza
+Pizza cutter
+Plant
+Plastic bag
+Plate
+Platter
+Plumbing fixture
+Polar bear
+Pomegranate
+Popcorn
+Porch
+Porcupine
+Poster
+Potato
+Power plugs and sockets
+Pressure cooker
+Pretzel
+Printer
+Pumpkin
+Punching bag
+Rabbit
+Raccoon
+Racket
+Radish
+Ratchet (Device)
+Raven
+Rays and skates
+Red panda
+Refrigerator
+Remote control
+Reptile
+Rhinoceros
+Rifle
+Ring binder
+Rocket
+Roller skates
+Rose
+Rugby ball
+Ruler
+Salad
+Salt and pepper shakers
+Sandal
+Sandwich
+Saucer
+Saxophone
+Scale
+Scarf
+Scissors
+Scoreboard
+Scorpion
+Screwdriver
+Sculpture
+Sea lion
+Sea turtle
+Seafood
+Seahorse
+Seat belt
+Segway
+Serving tray
+Sewing machine
+Shark
+Sheep
+Shelf
+Shellfish
+Shirt
+Shorts
+Shotgun
+Shower
+Shrimp
+Sink
+Skateboard
+Ski
+Skirt
+Skull
+Skunk
+Skyscraper
+Slow cooker
+Snack
+Snail
+Snake
+Snowboard
+Snowman
+Snowmobile
+Snowplow
+Soap dispenser
+Sock
+Sofa bed
+Sombrero
+Sparrow
+Spatula
+Spice rack
+Spider
+Spoon
+Sports equipment
+Sports uniform
+Squash (Plant)
+Squid
+Squirrel
+Stairs
+Stapler
+Starfish
+Stationary bicycle
+Stethoscope
+Stool
+Stop sign
+Strawberry
+Street light
+Stretcher
+Studio couch
+Submarine
+Submarine sandwich
+Suit
+Suitcase
+Sun hat
+Sunglasses
+Surfboard
+Sushi
+Swan
+Swim cap
+Swimming pool
+Swimwear
+Sword
+Syringe
+Table
+Table tennis racket
+Tablet computer
+Tableware
+Taco
+Tank
+Tap
+Tart
+Taxi
+Tea
+Teapot
+Teddy bear
+Telephone
+Television
+Tennis ball
+Tennis racket
+Tent
+Tiara
+Tick
+Tie
+Tiger
+Tin can
+Tire
+Toaster
+Toilet
+Toilet paper
+Tomato
+Tool
+Toothbrush
+Torch
+Tortoise
+Towel
+Tower
+Toy
+Traffic light
+Traffic sign
+Train
+Training bench
+Treadmill
+Tree
+Tree house
+Tripod
+Trombone
+Trousers
+Truck
+Trumpet
+Turkey
+Turtle
+Umbrella
+Unicycle
+Van
+Vase
+Vegetable
+Vehicle
+Vehicle registration plate
+Violin
+Volleyball (Ball)
+Waffle
+Waffle iron
+Wall clock
+Wardrobe
+Washing machine
+Waste container
+Watch
+Watercraft
+Watermelon
+Weapon
+Whale
+Wheel
+Wheelchair
+Whisk
+Whiteboard
+Willow
+Window
+Window blind
+Wine
+Wine glass
+Wine rack
+Winter melon
+Wok
+Woman
+Wood-burning stove
+Woodpecker
+Worm
+Wrench
+Zebra
+Zucchini

--- a/vtscore/projection/demo_signposts.py
+++ b/vtscore/projection/demo_signposts.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from vtscore.projection.labels import RegionLabel, RegionLabelSet, make_label_set
+from vtscore.projection.labels import RegionLabel, RegionLabelSet, make_label_set, medoid
 
 if TYPE_CHECKING:
     from vtscore.projection.umap_projection import Projection
@@ -150,7 +150,7 @@ def build_category_signposts(
             continue
         depth = len(prefix) - 1
         pts = coords[rows]
-        anchor = _medoid(pts)
+        anchor = medoid(pts)
         labels.append(
             RegionLabel(
                 level=_level_for_depth(depth),
@@ -171,20 +171,6 @@ def build_category_signposts(
         labels = labels[:_MAX_SIGNS]
 
     return make_label_set(projection.projection_id, labels)
-
-
-def _medoid(pts: np.ndarray) -> np.ndarray:
-    """Return the member point nearest the centroid of *pts* (an ``(m, 2)`` array).
-
-    A medoid — an actual member, not the raw mean — so the anchor sits on the
-    cluster even when it's crescent-shaped or split, where the centroid could
-    land in empty space between lobes.
-    """
-    if pts.shape[0] == 1:
-        return pts[0]
-    centroid = pts.mean(axis=0)
-    d2 = np.einsum("ij,ij->i", pts - centroid, pts - centroid)
-    return pts[int(np.argmin(d2))]
 
 
 __all__ = [

--- a/vtscore/projection/labels.py
+++ b/vtscore/projection/labels.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from collections.abc import Iterable
 
+import numpy as np
+
 
 @dataclass(frozen=True)
 class RegionLabel:
@@ -61,4 +63,19 @@ def make_label_set(projection_id: str, labels: Iterable[RegionLabel]) -> RegionL
     return RegionLabelSet(projection_id=projection_id, labels=tuple(labels))
 
 
-__all__ = ["RegionLabel", "RegionLabelSet", "make_label_set"]
+def medoid(pts: np.ndarray) -> np.ndarray:
+    """Return the member point nearest the centroid of *pts* (an ``(m, 2)`` array).
+
+    A medoid — an actual member, not the raw mean — so a sign anchor sits on
+    the cluster even when it's crescent-shaped or split, where the centroid
+    could land in empty space between lobes.  Shared by every signpost
+    builder (ground-truth demo signs and the Toponymy pipeline).
+    """
+    if pts.shape[0] == 1:
+        return pts[0]
+    centroid = pts.mean(axis=0)
+    d2 = np.einsum("ij,ij->i", pts - centroid, pts - centroid)
+    return pts[int(np.argmin(d2))]
+
+
+__all__ = ["RegionLabel", "RegionLabelSet", "make_label_set", "medoid"]

--- a/vtscore/projection/signpost_build.py
+++ b/vtscore/projection/signpost_build.py
@@ -1,0 +1,290 @@
+"""Fit Toponymy over a frozen projection and extract region signposts.
+
+The build-time half of the sign pipeline (see
+``docs/plans/vtsbrowse-toponymy.md``): given a frozen 2-D layout, the media
+embedding matrices, and one text per media (``signpost_texts``), run the
+Tutte Institute ``toponymy`` library — multiresolution clustering →
+contrastive keyphrases → naming — and flatten its fitted topic tree into a
+:class:`~vtscore.projection.labels.RegionLabelSet` the canvas can letter.
+
+Two vector spaces feed the fit, and they are deliberately allowed to differ:
+
+* ``clusterable_vectors`` — a dedicated ~5-D cosine UMAP of the **score**
+  embedder's matrix, the same space the frozen 2-D layout was fit in, so the
+  named clusters are compact regions *on the map* (an anchor computed from a
+  cluster scattered across the layout would land in noise);
+* ``embedding_vectors`` — the **text-capable** embedder's matrix, the space
+  the keyphrase strings are embedded into, so Toponymy's keyphrase↔cluster
+  alignment is meaningful.
+
+For the common single cross-modal embedder (CLAP/SigLIP) the two are the same
+matrix, exactly the configuration the signpost studies validated.
+
+Everything here is build-time-only: the topic model, keyphrase vectors, and
+clusterable UMAP are dropped on the floor; only derived text + 2-D anchors +
+scalar scores leave this module (the No-Persisted-Vectors rule).
+
+``toponymy`` is an optional dependency (installed ``--no-deps``; see
+``docs/plans/vtsbrowse-toponymy.md`` for why) and is imported lazily —
+:func:`signposting_available` is the cheap probe callers gate on.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from importlib import metadata, util
+from typing import TYPE_CHECKING, Any, Callable
+
+import numpy as np
+
+from vtscore.projection.labels import RegionLabel, RegionLabelSet, make_label_set, medoid
+
+if TYPE_CHECKING:
+    from vtscore.projection.umap_projection import Projection
+
+logger = logging.getLogger(__name__)
+
+#: Zoom-level gap between adjacent topic layers — the same zoom-band step the
+#: ground-truth demo signposts use (see ``demo_signposts._LEVEL_STEP``), so the
+#: canvas hand-off feel matches whichever source lettered the map.
+_LEVEL_STEP = 1.8
+
+#: Below this many points a topic tree is degenerate (min_clusters=4 with a
+#: base min cluster size of 10 leaves nothing to name); serve no signs.
+_MIN_POINTS = 40
+
+#: Toponymy's example configuration (docs/plans/vtsbrowse-toponymy.md locks
+#: "follow their examples"): a ~5-D cosine UMAP as the clusterable space.
+_CLUSTER_DIM = 5
+
+#: Progress callback shape: ``(current, total, message)``.
+ProgressFn = Callable[[int, int, str], None]
+
+
+def signposting_available() -> bool:
+    """Whether the ``toponymy`` library is importable in this environment."""
+    return util.find_spec("toponymy") is not None
+
+
+def toponymy_version() -> str:
+    """The installed toponymy distribution version, or ``""``."""
+    try:
+        return metadata.version("toponymy")
+    except metadata.PackageNotFoundError:
+        return ""
+
+
+class EmbedderTextEncoder:
+    """Toponymy ``TextEmbedderProtocol`` adapter over ``MediaEmbedder.embed_text``.
+
+    Keyphrase strings are embedded into the same space as the media matrix, so
+    cross-modal keyphrase→cluster alignment is meaningful (CLAP/SigLIP).  A
+    string the embedder can't encode maps to a zero vector of the right width
+    rather than poisoning the batch.
+    """
+
+    def __init__(self, embedder: Any, dim: int):
+        self._embedder = embedder
+        self._dim = dim
+
+    def encode(self, texts: Any, show_progress_bar: bool = False, **kwargs: Any) -> np.ndarray:
+        out = []
+        for text in texts:
+            vec = None
+            try:
+                if str(text).strip():
+                    vec = self._embedder.embed_text(str(text))
+            except Exception:
+                vec = None
+            if vec is None:
+                vec = np.zeros(self._dim, dtype=np.float32)
+            out.append(np.asarray(vec, dtype=np.float32))
+        return np.stack(out) if out else np.empty((0, self._dim), dtype=np.float32)
+
+
+def make_keyphrase_namer() -> Any:
+    """The no-LLM namer: answer every naming prompt with the top keyphrase.
+
+    A trivial in-process ``LLMWrapper`` whose "LLM calls" parse the prompt
+    Toponymy built and return its first (top ``information_weighted``)
+    keyphrase as the topic name — an honest fallback that keeps the library's
+    contrastive clustering + keyphrase machinery and skips only the LLM's
+    phrasing.  Duplicate-name disambiguation passes echo the old names back
+    (a no-LLM namer cannot invent new distinctions).
+    """
+    from toponymy.llm_wrappers import LLMWrapper  # noqa: PLC0415
+
+    class KeyphraseNamer(LLMWrapper):  # type: ignore[misc]
+        @property
+        def supports_system_prompts(self) -> bool:
+            return False
+
+        def _respond(self, prompt: str) -> str:
+            if "new_topic_name_mapping" in prompt:
+                names = re.findall(r"^\s*(\d+)\.\s*(.+?)\s*$", prompt, re.MULTILINE)
+                mapping = {f"{i}. {n}": n for i, n in names}
+                return json.dumps({"new_topic_name_mapping": mapping, "topic_specificities": [0.5] * len(mapping)})
+            match = re.search(r"Keywords for this group include:\s*([^\n]+)", prompt)
+            name = match.group(1).split(",")[0].strip() if match else ""
+            return json.dumps({"topic_name": name or "unnamed", "topic_specificity": 0.5})
+
+        def _call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
+            return self._respond(prompt)
+
+        def _call_llm_with_system_prompt(
+            self, system_prompt: str, user_prompt: str, temperature: float, max_tokens: int
+        ) -> str:
+            return self._respond(user_prompt)
+
+    return KeyphraseNamer()
+
+
+def _base_min_cluster_size(n: int) -> int:
+    """Scale Toponymy's base min-cluster-size with corpus size.
+
+    Topic count ≈ ``n / base_min_cluster_size`` and naming costs one namer
+    call per topic, so the library default of 10 explodes past ~20k items
+    (the audio study's cost model: 50k clips → ~5,000 calls).  ``n/300``
+    tracks the study's recommendation of ~50–100 for the 20k regime while
+    leaving small datasets on the library default.
+    """
+    return max(10, round(n / 300))
+
+
+def _fit_topic_layers(
+    texts: list[str],
+    embedding_vectors: np.ndarray,
+    clusterable_vectors: np.ndarray,
+    text_encoder: Any,
+    *,
+    object_description: str,
+    corpus_description: str,
+) -> list[tuple[list[str], np.ndarray]]:
+    """Run the Toponymy fit; return ``(topic_names, cluster_labels)`` per layer.
+
+    Layers come back in Toponymy's order — index 0 is the **finest** layer —
+    and each ``cluster_labels`` array assigns every input row a topic index
+    (or ``-1`` for noise).  Isolated as the seam tests stub: everything above
+    is our glue, everything inside (including the namer, so stubbed callers
+    never import toponymy) is the library's responsibility.
+    """
+    from toponymy import Toponymy  # noqa: PLC0415
+    from toponymy.clustering import ToponymyClusterer  # noqa: PLC0415
+
+    model = Toponymy(
+        llm_wrapper=make_keyphrase_namer(),
+        text_embedding_model=text_encoder,
+        clusterer=ToponymyClusterer(
+            min_clusters=4,
+            base_min_cluster_size=_base_min_cluster_size(len(texts)),
+            show_progress_bar=False,
+        ),
+        object_description=object_description,
+        corpus_description=corpus_description,
+        show_progress_bars=False,
+    )
+    model.fit(
+        texts,
+        embedding_vectors.astype(np.float32),
+        clusterable_vectors.astype(np.float32),
+    )
+    return [
+        (list(names), np.asarray(layer.cluster_labels))
+        for names, layer in zip(model.topic_names_, model.cluster_layers_)
+    ]
+
+
+def _clusterable_vectors(matrix: np.ndarray, on_progress: ProgressFn | None = None) -> np.ndarray:
+    """The dedicated ~5-D cosine UMAP Toponymy clusters on (not the 2-D layout)."""
+    import umap  # noqa: PLC0415
+
+    if on_progress is not None:
+        on_progress(0, 0, "Clustering regions…")
+    n_components = min(_CLUSTER_DIM, matrix.shape[1], max(2, matrix.shape[0] - 2))
+    reducer = umap.UMAP(n_components=n_components, metric="cosine")
+    return np.asarray(reducer.fit_transform(matrix), dtype=np.float32)
+
+
+def build_region_labels(
+    proj: "Projection",
+    score_matrix: np.ndarray,
+    embed_matrix: np.ndarray,
+    texts: list[str],
+    embedder: Any,
+    *,
+    object_description: str,
+    corpus_description: str,
+    on_progress: ProgressFn | None = None,
+    source: str = "keyphrase",
+) -> RegionLabelSet:
+    """Fit Toponymy and flatten its topic tree into signs for *proj*'s layout.
+
+    All three per-item inputs (``score_matrix`` / ``embed_matrix`` rows and
+    ``texts``) must align with ``proj.ids``.  Per layer, each topic becomes one
+    :class:`RegionLabel`: text = the topic name, anchor = the medoid of the
+    topic's members in the frozen 2-D layout, level = the layer's depth mapped
+    to a zoom band (coarsest layer at level 0, like the ground-truth demo
+    signs), score = member count (the canvas de-clutter tiebreak).
+
+    Returns an id-pinned — possibly empty — set; too-small corpora
+    (< ``_MIN_POINTS``) short-circuit to empty rather than fitting a
+    degenerate tree.
+    """
+    empty = make_label_set(proj.projection_id, [])
+    n = len(proj.ids)
+    if n < _MIN_POINTS or n != len(texts) or score_matrix.shape[0] != n or embed_matrix.shape[0] != n:
+        return empty
+
+    clusterable = _clusterable_vectors(score_matrix, on_progress)
+    if on_progress is not None:
+        on_progress(0, 0, "Naming regions…")
+
+    encoder = EmbedderTextEncoder(embedder, dim=embed_matrix.shape[1])
+    layers = _fit_topic_layers(
+        texts,
+        embed_matrix,
+        clusterable,
+        encoder,
+        object_description=object_description,
+        corpus_description=corpus_description,
+    )
+    if not layers:
+        return empty
+
+    coords = np.asarray(proj.coords, dtype=np.float32)
+    n_layers = len(layers)
+    labels: list[RegionLabel] = []
+    for i, (names, cluster_labels) in enumerate(layers):
+        level = (n_layers - 1 - i) * _LEVEL_STEP
+        for topic_idx, name in enumerate(names):
+            text = str(name).strip()
+            if not text:
+                continue
+            members = np.nonzero(cluster_labels == topic_idx)[0]
+            if members.size == 0:
+                continue
+            anchor = medoid(coords[members])
+            labels.append(
+                RegionLabel(
+                    level=level,
+                    x=float(anchor[0]),
+                    y=float(anchor[1]),
+                    text=text,
+                    score=float(members.size),
+                    source=source,
+                )
+            )
+
+    labels.sort(key=lambda lab: (lab.level, -lab.score))
+    return make_label_set(proj.projection_id, labels)
+
+
+__all__ = [
+    "EmbedderTextEncoder",
+    "build_region_labels",
+    "make_keyphrase_namer",
+    "signposting_available",
+    "toponymy_version",
+]

--- a/vtscore/projection/signpost_prep.py
+++ b/vtscore/projection/signpost_prep.py
@@ -1,0 +1,275 @@
+"""Signpost prep orchestration: texts → Toponymy fit → cache (+ persist).
+
+The one entry point every build path calls after it has a frozen layout in
+hand (see ``docs/plans/vtsbrowse-toponymy.md``):
+
+* the **ingest** projection stage (``vtscore.datasets.stages.projection``) —
+  the user is already watching a progress bar, so prep rides along and the
+  first Browse opens lettered;
+* the **lazy Browse build** (``vtsearch.routes.projection._start_umap_build``)
+  — datasets ingested before/without prep get signs on their first Browse;
+* the **Find→Browse subset build** (``_start_subset_umap_build``) — signs are
+  re-fit over just the subset (contrastive keyphrases recompute against the
+  subset's own siblings, which the image study showed beats filtering
+  dataset-level signs), reusing the per-media texts cached at ingest so the
+  re-fit is interactive.
+
+Split of work between the stages (what must be computed when):
+
+* **Per-media texts** are the only full-corpus model cost — Toponymy's
+  keyphrase mining reads *every* object's text, not just sampled exemplars —
+  and they are clustering-independent, so they are computed once and cached
+  on the media dicts (:mod:`vtscore.projection.signpost_texts`).
+* **Clustering + naming** are layout-scoped and cheap (a ~5-D UMAP + the
+  fit), so they run fresh per layout, full or subset.
+
+Everything is best-effort: any missing prerequisite (no toponymy install, no
+text-capable embedder, no provider for the media type) returns ``None`` and
+the map simply stays unlettered.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Callable
+
+from vtscore.projection.signpost_build import (
+    _MIN_POINTS,
+    build_region_labels,
+    signposting_available,
+    toponymy_version,
+)
+from vtscore.projection.signpost_texts import ensure_signpost_texts, provider_for
+
+if TYPE_CHECKING:
+    from vtscore.projection.labels import RegionLabelSet
+    from vtscore.projection.umap_projection import Projection
+
+logger = logging.getLogger(__name__)
+
+#: Progress callback shape: ``(current, total, message)``.
+ProgressFn = Callable[[int, int, str], None]
+
+#: Minimum fraction of the fitted set that must have a usable text — below
+#: this the keyphrase stage is mining mostly-empty documents and the signs
+#: would be noise, so we skip labeling instead.
+_MIN_TEXT_COVERAGE = 0.5
+
+#: Toponymy prompt vocabulary per media type (``object_description``).
+_OBJECT_DESCRIPTIONS = {
+    "audio": "audio clips",
+    "image": "images",
+    "video": "video clips",
+    "document": "documents",
+    "text": "text documents",
+}
+
+
+def _text_embedder(ctx: Any) -> Any | None:
+    """The dataset's text-capable embedder instance, or ``None``.
+
+    Keyphrase strings must be embedded into the same space as the media
+    matrix used for alignment, so signposting requires the text slot of the
+    v3 routing table (CLAP / SigLIP / X-CLIP / E5); patch- or structural-only
+    datasets go unlettered.
+    """
+    name = ctx.routed_embedder("text")
+    if not name:
+        return None
+    try:
+        from vtscore.media import get_embedder  # noqa: PLC0415
+
+        embedder = get_embedder(name)
+    except Exception:
+        return None
+    if not getattr(embedder, "supports_text", False):
+        return None
+    return embedder
+
+
+def labeler_signature(ctx: Any) -> str | None:
+    """The signature the active pipeline would stamp on freshly built signs.
+
+    Persisted label sets carry the signature they were built under; a set
+    whose signature no longer matches is stale (different provider, embedder,
+    or toponymy version) and is not served.  ``None`` when signposting isn't
+    possible for this dataset at all.
+    """
+    from vtscore.projection.signpost_texts import texts_signature  # noqa: PLC0415
+
+    if not signposting_available():
+        return None
+    embedder = _text_embedder(ctx)
+    if embedder is None:
+        return None
+    texts_sig = texts_signature(ctx.medias, embedder)
+    if texts_sig is None:
+        return None
+    return f"keyphrase|{texts_sig}|toponymy={toponymy_version()}"
+
+
+def ensure_texts_for_dataset(ctx: Any, on_progress: ProgressFn | None = None) -> None:
+    """Compute + cache the per-media signpost texts for *ctx*'s whole dataset.
+
+    The ingest pipeline calls this **before the dataset pickle is written**, so
+    the texts — the only full-corpus model cost in the sign pipeline — persist
+    with the dataset and every later browse or Find→Browse re-fit is free of
+    text-model calls.  No-op when signposting isn't possible for this dataset
+    (no toponymy install, no text-capable embedder, no provider).
+    """
+    if not signposting_available():
+        return
+    embedder = _text_embedder(ctx)
+    if embedder is None:
+        return
+    if not ctx.medias:
+        return
+    first = next(iter(ctx.medias.values()))
+    if provider_for(first.get("media_type", "")) is None:
+        return
+    from vtscore.embedding.matrix import get_embedding_matrix  # noqa: PLC0415
+
+    try:
+        ids, matrix = get_embedding_matrix(ctx, getattr(embedder, "name", None))
+    except ValueError:
+        return
+    if matrix.size == 0:
+        return
+    ensure_signpost_texts(ctx.medias, ids, matrix, embedder, on_progress)
+
+
+def prep_signposts(
+    ctx: Any,
+    proj: "Projection",
+    *,
+    subset: bool,
+    on_progress: ProgressFn | None = None,
+) -> "RegionLabelSet | None":
+    """Build region signposts for *proj* and cache them on *ctx*.
+
+    Returns the built :class:`RegionLabelSet` (assigned to
+    ``ctx._subset_region_labels`` or ``ctx._region_labels``), or ``None``
+    when signposting isn't available for this dataset.  Full-dataset sets are
+    also persisted into the dataset container next to the projection; subset
+    sets are in-memory only, like the subset layout itself.
+
+    Raises nothing in normal operation — callers still wrap it best-effort so
+    a labeling failure can never take down the build that produced the layout.
+    """
+    prerequisites = _prep_prerequisites(ctx, proj)
+    if prerequisites is None:
+        return None
+    ids, media_type, embedder = prerequisites
+
+    matrices = _aligned_matrices(ctx, ids, embedder)
+    if matrices is None:
+        return None
+    score_matrix, embed_matrix = matrices
+
+    if on_progress is not None:
+        on_progress(0, 0, "Preparing signpost texts…")
+    texts_map = ensure_signpost_texts(ctx.medias, ids, embed_matrix, embedder, on_progress)
+    if not texts_map or len(texts_map) < _MIN_TEXT_COVERAGE * len(ids):
+        return None
+    texts = [texts_map.get(mid, "") for mid in ids]
+
+    object_description = _OBJECT_DESCRIPTIONS.get(media_type, "items")
+    label_set = build_region_labels(
+        proj,
+        score_matrix,
+        embed_matrix,
+        texts,
+        embedder,
+        object_description=object_description,
+        corpus_description=f"a collection of {object_description}",
+        on_progress=on_progress,
+    )
+    if not label_set.labels:
+        # Nothing worth lettering (tiny corpus, degenerate tree).  Leave the
+        # context slot alone rather than pinning an empty set — an empty set
+        # would suppress the lazy ground-truth fallback for datasets that
+        # ship a category hierarchy (see the routes' ``_label_set_for``).
+        return None
+
+    if subset:
+        ctx._subset_region_labels = label_set
+    else:
+        ctx._region_labels = label_set
+        _persist_region_labels(ctx, label_set)
+    return label_set
+
+
+def _prep_prerequisites(ctx: Any, proj: "Projection") -> tuple[list[int], str, Any] | None:
+    """Gate a lettering run; return ``(ids, media_type, embedder)`` or ``None``.
+
+    ``None`` means signposting isn't possible or worthwhile here: no toponymy
+    install, no text-capable embedder, a layout too small for a non-degenerate
+    topic tree (bail *before* paying for texts), or a media type with no
+    registered text provider.
+    """
+    if not signposting_available():
+        return None
+    embedder = _text_embedder(ctx)
+    if embedder is None:
+        return None
+    ids = [int(mid) for mid in proj.ids]
+    if len(ids) < _MIN_POINTS:
+        return None
+    first = ctx.medias.get(ids[0])
+    if not first:
+        return None
+    media_type = first.get("media_type", "")
+    if provider_for(media_type) is None:
+        return None
+    return ids, media_type, embedder
+
+
+def _aligned_matrices(ctx: Any, ids: list[int], embedder: Any) -> tuple[Any, Any] | None:
+    """The score + text embedding matrices, both row-aligned with *ids*.
+
+    The clustering space must match the frozen layout's (the score slot),
+    while keyphrase alignment lives in the text embedder's space; for the
+    common single cross-modal embedder these are the same matrix.  Row order
+    matters — cluster member indices index into texts/matrix rows AND into
+    ``proj.coords`` rows — and the submatrix helper returns sorted ids while
+    every projection is fit on sorted ids, so an order mismatch means medias
+    changed under the layout (anchors would lie): return ``None`` and skip.
+    """
+    from vtscore.embedding.matrix import get_embedding_submatrix  # noqa: PLC0415
+
+    score_name = ctx.routed_embedder("score")
+    text_name = getattr(embedder, "name", None)
+    try:
+        sub_ids, score_matrix = get_embedding_submatrix(ctx, ids, score_name)
+        if sub_ids != ids:
+            return None
+        if score_name == text_name:
+            return score_matrix, score_matrix
+        embed_ids, embed_matrix = get_embedding_submatrix(ctx, ids, text_name)
+        if embed_ids != ids:
+            return None
+        return score_matrix, embed_matrix
+    except ValueError:
+        return None
+
+
+def _persist_region_labels(ctx: Any, label_set: "RegionLabelSet") -> None:
+    """Best-effort save of a full-dataset label set into the dataset container."""
+    signature = labeler_signature(ctx)
+    if signature is None:
+        return
+    try:
+        from vtscore.datasets.registry import get_dataset  # noqa: PLC0415
+
+        entry = get_dataset(ctx.dataset_id)
+        pkl_path = (entry or {}).get("pkl_path")
+        if not pkl_path:
+            return
+        from vtscore.datasets.container import append_region_labels  # noqa: PLC0415
+
+        append_region_labels(pkl_path, label_set, signature)
+    except Exception:
+        logger.warning("Failed to persist region labels for %s", ctx.dataset_id, exc_info=True)
+
+
+__all__ = ["ensure_texts_for_dataset", "labeler_signature", "prep_signposts"]

--- a/vtscore/projection/signpost_texts.py
+++ b/vtscore/projection/signpost_texts.py
@@ -1,0 +1,302 @@
+"""Per-media signpost texts — the ``object_to_text`` layer of the sign pipeline.
+
+Toponymy needs *some text per object*: its contrastive (``information_weighted``)
+keyphrase extraction mines the texts of **every** object in the fitted set, not
+just the sampled exemplars it shows the LLM (see
+``docs/plans/vtsbrowse-toponymy.md``).  So the text is a full-corpus,
+per-media artifact — expensive for captioner-class providers, embarrassingly
+cacheable, and independent of any particular clustering.  We therefore compute
+it once and **cache it on the media dict** (``signpost_text`` +
+``signpost_text_source``): media dicts are the dataset pickle's payload, so a
+text computed during ingest persists with the dataset, and every later browse
+or Find→Browse subset re-fit reuses it instead of re-running a model.  Cached
+strings are derived *text*, which the No-Persisted-Vectors rule explicitly
+allows.
+
+Providers are registered per media type.  Phase 1 ships the no-new-models
+tier resolved by the audio/image signpost studies
+(``docs/reports/2026-07-12-toponymy-{audio,image}-signposts.html``):
+
+* **audio** — CLAP zero-shot tags against the AudioSet-527 vocabulary
+  (template ``"The sound of {}"``, top-5), the audio study's locked default;
+* **image** — SigLIP zero-shot tags against the OpenImages-600 vocabulary
+  (template ``"a photo of {}"``, top-5), the image study's no-VLM fallback
+  (the instructed ~3B VLM captioner default is a planned follow-up and slots
+  in as a replacement provider here);
+* **text** — the media's own content, truncated (Toponymy's native case).
+
+Zero-shot tagging costs one text-embed of the vocabulary per (embedder,
+vocabulary) pair — cached process-scoped, never persisted — plus one matrix
+product, so it is effectively free next to the embed pass that precedes it.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any, Callable, Protocol
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+#: Media-dict field holding the cached signpost text (persisted in the pickle).
+TEXT_FIELD = "signpost_text"
+#: Media-dict field stamping which provider+embedder produced the cached text;
+#: a mismatch with the active provider's signature invalidates the cache.
+SOURCE_FIELD = "signpost_text_source"
+
+#: Progress callback shape: ``(current, total, message)``.
+ProgressFn = Callable[[int, int, str], None]
+
+
+class SignpostTextProvider(Protocol):
+    """One way of turning a media item into a short text for Toponymy."""
+
+    @property
+    def name(self) -> str: ...
+
+    def signature(self, embedder: Any) -> str:
+        """Cache key for texts produced by this provider under *embedder*."""
+        ...
+
+    def build_texts(
+        self,
+        ids: list[int],
+        medias: dict[int, dict[str, Any]],
+        matrix: np.ndarray,
+        embedder: Any,
+        on_progress: ProgressFn | None = None,
+    ) -> dict[int, str]:
+        """Return a text per id.  ``matrix`` rows align with ``ids``."""
+        ...
+
+
+@dataclass(frozen=True)
+class ZeroShotTagProvider:
+    """Top-k vocabulary terms by similarity in a cross-modal embedder's space.
+
+    The embedder's text branch embeds every vocabulary term once (through
+    *template*), and each media's tag list is the top-*top_k* terms by dot
+    product against its stored media vector — both sides are L2-normalized at
+    ingest, so the dot product is cosine similarity.  The contrastive work of
+    deciding which tags *distinguish* a cluster is Toponymy's
+    ``information_weighted`` keyphrase stage, not ours; this provider only has
+    to be honest per item.
+    """
+
+    name: str
+    vocab_asset: str
+    template: str
+    top_k: int = 5
+
+    def signature(self, embedder: Any) -> str:
+        return f"{self.name}:{getattr(embedder, 'name', '')}"
+
+    def build_texts(
+        self,
+        ids: list[int],
+        medias: dict[int, dict[str, Any]],
+        matrix: np.ndarray,
+        embedder: Any,
+        on_progress: ProgressFn | None = None,
+    ) -> dict[int, str]:
+        vocab, vocab_vecs = _vocab_vectors(self.vocab_asset, self.template, embedder, on_progress)
+        if vocab_vecs.size == 0 or matrix.size == 0:
+            return {}
+        sims = matrix.astype(np.float32) @ vocab_vecs.T  # (n, v)
+        k = min(self.top_k, sims.shape[1])
+        top = np.argsort(-sims, axis=1)[:, :k]
+        return {mid: ", ".join(vocab[j] for j in top[i]) for i, mid in enumerate(ids)}
+
+
+@dataclass(frozen=True)
+class ContentTextProvider:
+    """The media's own text content, truncated — Toponymy's native case."""
+
+    name: str = "content"
+    field: str = "content"
+    max_chars: int = 2000
+
+    def signature(self, embedder: Any) -> str:
+        return self.name
+
+    def build_texts(
+        self,
+        ids: list[int],
+        medias: dict[int, dict[str, Any]],
+        matrix: np.ndarray,
+        embedder: Any,
+        on_progress: ProgressFn | None = None,
+    ) -> dict[int, str]:
+        out: dict[int, str] = {}
+        for mid in ids:
+            content = medias.get(mid, {}).get(self.field)
+            if isinstance(content, str) and content.strip():
+                out[mid] = content.strip()[: self.max_chars]
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Provider registry (per media type)
+# ---------------------------------------------------------------------------
+
+_PROVIDERS: dict[str, SignpostTextProvider] = {
+    "audio": ZeroShotTagProvider(
+        name="tags:audioset527",
+        vocab_asset="audioset527_labels.txt",
+        template="The sound of {}",
+    ),
+    "image": ZeroShotTagProvider(
+        name="tags:openimages600",
+        vocab_asset="openimages600_labels.txt",
+        template="a photo of {}",
+    ),
+    "text": ContentTextProvider(),
+}
+
+
+def register_signpost_text_provider(media_type: str, provider: SignpostTextProvider) -> None:
+    """Register (or replace) the signpost text provider for *media_type*."""
+    _PROVIDERS[media_type] = provider
+
+
+def provider_for(media_type: str) -> SignpostTextProvider | None:
+    """The registered provider for *media_type*, or ``None`` (no signposts)."""
+    return _PROVIDERS.get(media_type)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary embedding cache (process-scoped; vectors are never persisted)
+# ---------------------------------------------------------------------------
+
+_vocab_cache: dict[tuple[str, str, str], tuple[list[str], np.ndarray]] = {}
+_vocab_lock = threading.Lock()
+
+
+def _load_vocab(asset: str) -> list[str]:
+    text = (resources.files("vtscore.projection") / "assets" / asset).read_text(encoding="utf-8")
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def _vocab_vectors(
+    asset: str,
+    template: str,
+    embedder: Any,
+    on_progress: ProgressFn | None = None,
+) -> tuple[list[str], np.ndarray]:
+    """Embed a vocabulary through *embedder*'s text branch, cached per process.
+
+    The cache key includes the embedder name so multi-embedder processes keep
+    one entry per space.  Terms whose embedding fails are dropped from both the
+    returned term list and the matrix, keeping the two aligned.
+    """
+    key = (asset, template, getattr(embedder, "name", ""))
+    with _vocab_lock:
+        cached = _vocab_cache.get(key)
+    if cached is not None:
+        return cached
+
+    terms = _load_vocab(asset)
+    kept: list[str] = []
+    vecs: list[np.ndarray] = []
+    for i, term in enumerate(terms):
+        if on_progress is not None and i % 50 == 0:
+            on_progress(i, len(terms), "Preparing signpost vocabulary…")
+        try:
+            vec = embedder.embed_text(template.format(term))
+        except Exception:
+            vec = None
+        if vec is None:
+            continue
+        kept.append(term)
+        vecs.append(np.asarray(vec, dtype=np.float32))
+    matrix = np.stack(vecs) if vecs else np.empty((0, 0), dtype=np.float32)
+    with _vocab_lock:
+        _vocab_cache[key] = (kept, matrix)
+    return kept, matrix
+
+
+# ---------------------------------------------------------------------------
+# The cache-aware entry point
+# ---------------------------------------------------------------------------
+
+
+def ensure_signpost_texts(
+    medias: dict[int, dict[str, Any]],
+    ids: list[int],
+    matrix: np.ndarray,
+    embedder: Any,
+    on_progress: ProgressFn | None = None,
+) -> dict[int, str] | None:
+    """Return a signpost text per id, computing and caching what's missing.
+
+    Texts cached on the media dicts under a matching provider signature are
+    reused verbatim; only the misses are computed (all of them on the first
+    run, none on a Find→Browse re-fit of an ingest-prepped dataset).  Newly
+    computed texts are stamped back onto the media dicts, so a text computed
+    before the dataset pickle is written persists with the dataset.
+
+    Returns ``None`` when no provider is registered for the medias' type, or
+    when the provider yields no usable text at all.  ``matrix`` rows must
+    align with ``ids`` (the same contract as the embedding submatrix helpers).
+    """
+    if not ids:
+        return None
+    first = medias.get(ids[0]) or {}
+    provider = provider_for(first.get("media_type", ""))
+    if provider is None:
+        return None
+    signature = provider.signature(embedder)
+
+    texts: dict[int, str] = {}
+    missing: list[int] = []
+    for mid in ids:
+        media = medias.get(mid)
+        if media is None:
+            continue
+        cached = media.get(TEXT_FIELD)
+        if isinstance(cached, str) and cached and media.get(SOURCE_FIELD) == signature:
+            texts[mid] = cached
+        else:
+            missing.append(mid)
+
+    if missing:
+        row_of = {mid: i for i, mid in enumerate(ids)}
+        sub = matrix[[row_of[mid] for mid in missing]] if matrix.size else matrix
+        built = provider.build_texts(missing, medias, sub, embedder, on_progress)
+        for mid, text in built.items():
+            media = medias.get(mid)
+            if media is None or not text:
+                continue
+            media[TEXT_FIELD] = text
+            media[SOURCE_FIELD] = signature
+            texts[mid] = text
+
+    return texts or None
+
+
+def texts_signature(medias: dict[int, dict[str, Any]], embedder: Any) -> str | None:
+    """The active provider signature for *medias*, or ``None`` when unsupported."""
+    if not medias:
+        return None
+    first = next(iter(medias.values()))
+    provider = provider_for(first.get("media_type", ""))
+    if provider is None:
+        return None
+    return provider.signature(embedder)
+
+
+__all__ = [
+    "ContentTextProvider",
+    "SignpostTextProvider",
+    "TEXT_FIELD",
+    "SOURCE_FIELD",
+    "ZeroShotTagProvider",
+    "ensure_signpost_texts",
+    "provider_for",
+    "register_signpost_text_provider",
+    "texts_signature",
+]

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -99,19 +99,23 @@ def _label_set_for(ctx, pyr, *, subset: bool):
     was re-fit underneath it) and is treated as absent rather than served over
     the wrong coordinates.
 
-    When no set is cached for this layout, we lazily derive **ground-truth
-    signposts** from the dataset's category annotations (see
-    :func:`_maybe_build_demo_signposts`) and cache the result — including an
-    empty set, so a dataset with no usable hierarchy isn't re-probed on every
-    poll.  A set left behind by the real labeling pipeline wins: it already
-    matches the layout, so this never overwrites it.
+    When no set is cached for this layout, resolution order is: the set the
+    labeling pipeline **persisted** into the dataset container (full layouts
+    only — see :func:`_maybe_load_persisted_labels`), then lazily-derived
+    **ground-truth signposts** from the dataset's category annotations (see
+    :func:`_maybe_build_demo_signposts`).  The result — including an empty
+    set, so a dataset with no signs isn't re-probed on every poll — is cached
+    on the context.  A set left behind by the live labeling pipeline wins: it
+    already matches the layout, so this never overwrites it.
     """
     label_set = ctx._subset_region_labels if subset else ctx._region_labels
     if label_set is not None and label_set.projection_id == pyr.projection_id:
         return label_set
 
-    proj = ctx._subset_projection if subset else ctx._projection
-    built = _maybe_build_demo_signposts(proj, pyr, ctx.medias)
+    built = None if subset else _maybe_load_persisted_labels(ctx, pyr)
+    if built is None:
+        proj = ctx._subset_projection if subset else ctx._projection
+        built = _maybe_build_demo_signposts(proj, pyr, ctx.medias)
     if subset:
         ctx._subset_region_labels = built
     else:
@@ -119,6 +123,37 @@ def _label_set_for(ctx, pyr, *, subset: bool):
     if built is None or built.projection_id != pyr.projection_id:
         return None
     return built
+
+
+def _maybe_load_persisted_labels(ctx, pyr):
+    """Restore the signpost labels persisted next to the full-dataset layout.
+
+    Served only over the exact layout they were computed from
+    (``projection_id`` match), and only while their labeler signature still
+    matches what the active pipeline would produce — a changed provider,
+    embedder, or toponymy version makes them stale (recomputing stale labels
+    lazily is a planned follow-up; until then they're treated as absent).
+    When the active pipeline can't label this dataset at all (e.g. toponymy
+    isn't installed here), a persisted set is still served: it's derived text
+    pinned to the right layout, strictly better than nothing.
+    """
+    pkl_path = _pkl_path_for(ctx.dataset_id)
+    if pkl_path is None:
+        return None
+    from vtscore.datasets.container import read_region_labels
+
+    loaded = read_region_labels(pkl_path)
+    if loaded is None:
+        return None
+    label_set, stored_signature = loaded
+    if label_set.projection_id != pyr.projection_id:
+        return None
+    from vtscore.projection.signpost_prep import labeler_signature
+
+    active = labeler_signature(ctx)
+    if active is not None and active != stored_signature:
+        return None
+    return label_set
 
 
 def _maybe_build_demo_signposts(proj, pyr, medias):
@@ -307,6 +342,26 @@ def _reset_full_projection(ctx) -> None:
         logger.warning("Failed to clear persisted projection for %s", ctx.dataset_id, exc_info=True)
 
 
+def _prep_signposts_best_effort(ctx, proj, job, *, subset: bool) -> None:
+    """Run the signpost labeling pipeline inside a build job, best-effort.
+
+    Called between the pyramid build and the moment the layout is cached on
+    the context: the canvas fetches labels once per ``projection_id`` when the
+    meta first reports ready, so the signs must exist by then.  Any failure
+    (or an environment without toponymy) leaves the map unlettered, never
+    broken — signs are optional decoration.
+    """
+    try:
+        from vtscore.projection.signpost_prep import prep_signposts
+
+        def _on_progress(current: int, total: int, message: str) -> None:
+            job.update_progress(current, total, message)
+
+        prep_signposts(ctx, proj, subset=subset, on_progress=_on_progress)
+    except Exception:
+        logger.warning("Signpost labeling failed for %s", ctx.dataset_id, exc_info=True)
+
+
 def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, force: bool = False) -> dict:
     """Start (or reuse) the background UMAP fit + pyramid build for *bin_shape*.
 
@@ -358,6 +413,7 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, for
             )
             job.update_progress(0, 1, "building pyramid")
             pyr = build_pyramid(proj, bin_shape=bin_shape)
+            _prep_signposts_best_effort(ctx, proj, job, subset=False)
             job.update_progress(1, 1, "done")
 
             ctx._projection = proj
@@ -479,12 +535,17 @@ def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str,
             )
             job.update_progress(0, 1, "building pyramid")
             pyr = build_pyramid(proj, bin_shape=bin_shape)
+            # Fresh signs over just this subset: the contrastive keyphrases
+            # recompute against the subset's own siblings (better than any
+            # filtered dataset-level signs), and the per-media texts were
+            # cached at ingest, so this is the cheap half of the pipeline.
+            _prep_signposts_best_effort(ctx, proj, job, subset=True)
             job.update_progress(1, 1, "done")
 
             ctx._subset_projection = proj
             ctx._subset_pyramids[bin_shape] = pyr
             job.result = (proj, pyr)
-            # Subset projections are ephemeral — never persisted.
+            # Subset projections are ephemeral — never persisted (labels included).
 
     job = projection_jobs.start(sig, _run, dataset_id=ctx.dataset_id)
     ctx._subset_job_id = job.job_id


### PR DESCRIPTION
## What

Builds the infrastructure to prep VTSBrowse signposts, both **ahead of time** (dataset ingest, where the user is already watching a progress bar) and **on demand** (Find→Browse subset builds and the lazy first-Browse build). Implements Phase 1 of `docs/plans/vtsbrowse-toponymy.md` — the no-LLM pipeline both signpost studies validated — with no fixed labeling vocabulary baked into the naming: per-media *texts* feed Toponymy, whose contrastive keyphrases + namer produce the signs.

## How the compute is split (what must run when)

- **Per-media texts (`vtscore/projection/signpost_texts.py`)** — the only full-corpus model cost. Toponymy's `information_weighted` keyphrase extraction mines *every* object's text (only the exemplars shown to the namer are sampled), so texts are computed for all media, once, and **cached on the media dict** — persisted in the dataset pickle when computed at ingest (a new stage runs *before* the registry save, riding the existing `build_projection` opt-in). Providers are per-media-type and swappable: audio = CLAP top-5 zero-shot tags vs AudioSet-527, image = SigLIP top-5 vs OpenImages-600 (the no-VLM fallback; the instructed-captioner default is a planned follow-up provider), text = the content itself.
- **Clustering + naming (`vtscore/projection/signpost_build.py`)** — layout-scoped and comparatively cheap, so it runs fresh per layout inside every build job: dedicated 5-D cosine UMAP (in the score-embedder space so clusters are compact *on the map*; keyphrase alignment uses the text-slot embedder's matrix/space), `ToponymyClusterer(min_clusters=4)` with `base_min_cluster_size ∝ n`, `KeyphraseNamer` (no-LLM: top contrastive keyphrase per topic), topic tree flattened to `RegionLabel`s (medoid anchors in the frozen layout, coarsest layer at zoom band 0).
- **Orchestration (`vtscore/projection/signpost_prep.py`)** — hooked into all three build paths, always best-effort, and ordered fit → pyramid → **signposts** → cache/persist, because the canvas fetches labels once per `projection_id` when the meta first reports ready.

## Persistence + invalidation

Full-dataset label sets persist in the dataset container (`region_labels.json`: text + 2-D anchors + scalar scores only — no vectors), pinned to `projection_id` and stamped with a `labeler_signature` (`namer|texts_provider:embedder|toponymy=version`). They're restored on serve, treated as absent on signature mismatch, and dropped together with the projection on forced re-projects. Subset label sets are in-memory only, like the subset layout. A live/persisted set wins over the lazy ground-truth demo signposts; an empty fit result leaves the slot untouched so the demo fallback still letters hierarchical-category datasets.

## Dependencies

Per the plan's locked decision: `toponymy==0.5.2` installed `--no-deps` (its `transformers<5` pin would downgrade the app's stack and is empirically unnecessary — re-validated in this environment on transformers 5.13: full CPU fit produces a named 3-layer tree), with its actually-used deps declared in `pyproject.toml` (`fast_hdbscan`, `vectorizers`, `apricot-select`, `tenacity`, `jinja2`). `apricot-select` ships a legacy `setup.py` that needs the stdlib-distutils shim; `scripts/install.sh` (CPU + GPU) and `ensure-test-deps.sh` handle both quirks. A `slow`-marked smoke test runs the real library end-to-end to guard the resolver bypass (it runs in `./run-tests.sh projection`; the default suite never imports toponymy — the fit is stubbed at the `_fit_topic_layers` seam, and the app-tier suite reports signposting unavailable for determinism).

## Tests

- `tests_lib/projection/`: providers + caching/invalidation, fit-wrapper extraction (levels, medoid anchors, noise/empty handling, size guards), prep orchestration (slot assignment, persistence + signature, all bail paths), container round-trip, real-toponymy smoke (slow).
- `tests/api/test_projection.py`: persisted-label restore over matching layout, stale-signature/wrong-layout rejection.
- Full suite green: **ALL 5734 TESTS PASSED**, plus `./run-tests.sh projection` (181, incl. smoke) and `./run-tests.sh vtscore-clean` (2069).

## Notes

- `docs/plans/vtsbrowse-toponymy.md` pruned to remaining work (Phase 2 LLM namers + settings, captioner providers, stale-label lazy recompute, post-hoc text persistence, etc.).
- No frontend changes needed — the serving API, meta `has_labels`, and the canvas sign layer were already live; only the ingest checkbox tooltip now mentions signposts.
- Backwards compatibility: none broken; containers without a labels entry and datasets without cached texts behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SugR7RYuzdL8Vk5m6YuCaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SugR7RYuzdL8Vk5m6YuCaZ)_