### PR TITLE
Extract shared `.segmented-toggle` primitive

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -64,27 +64,22 @@ surface. When you ship it, add the affected shot ids to
 <!-- item-sep -->
 
 - **Promote shared component primitives** — "one role, N implementations" is
-  the biggest structural debt. Bespoke buttons bypass the `.btn` taxonomy:
-  `.ivc-btn` (`center-panel/...:88`), `.panel-btn` (`right-panel/...:60`),
-  `.vc-btn` (`view-controls/...:17`), plus the `.toggle-group`/`.toggle-btn`
-  View/Focus segmented control (`settings-modal.component.scss:154-198`, custom
-  padding/font/`--accent-color` fill). Tab strips are re-implemented ~7 times
-  instead of extending `.importer-tab-bar`/`.importer-tab`
-  (`_picker-shared.scss:12-45`): `.tab-bar`/`.tab-btn`
-  (`new-detector-modal.component.scss:21-46`), `.help-tabs`/`.help-tab`
-  (`keyboard-help-modal.component.scss:9-32`), and the *vertical*
-  `.settings-tabs`/`.settings-tab` (`settings-modal.component.scss:13-47`,
-  which can't `@extend` a horizontal bar — it wants a new shared
-  `.side-tab-bar`). Also duplicated: 6 data tables, 6 picker-card copies (with
-  3 different title sizes), 6 empty states, 3 progress bars, 3 pane dividers,
-  verbatim `dataset-card`/`detector-card` and `goods-actions` SCSS, and
-  hand-built inputs that skip `.form-input`/`.form-select`.
-  **Fix:** extract sanctioned shared classes — a `.btn--toolbar` variant for
-  the icon buttons, a `.segmented-toggle`, a shared vertical `.side-tab-bar`,
-  and shared picker-card / table / empty-state / divider primitives — then fold
-  the bespoke copies onto them via markup + `@extend`. Ship incrementally
-  (one primitive per PR) to keep diffs reviewable. **Files:** `_components.scss`,
-  `_picker-shared.scss`, and the listed component SCSS/templates.
+  the biggest structural debt. Each remaining primitive is tracked as its own
+  GitHub issue and shipped one-per-PR; the umbrella stays here until the last
+  is done. (Shipped: `.segmented-toggle`, folding the settings View/Focus
+  control and the view-controls size/focus toolbar onto one primitive.) Still
+  owed: a `.btn--toolbar` variant for the `.ivc-btn`/`.panel-btn` icon buttons
+  (#2300); folding the horizontal `.tab-bar`/`.help-tabs` strips onto
+  `.importer-tab-bar` (#2301); a vertical `.side-tab-bar` for the settings tabs
+  (#2302); shared picker-card (#2303), data-table (#2304), empty-state (#2305),
+  and pane-divider (#2307) primitives; unifying the 3 progress bars (#2306);
+  deduping the verbatim `dataset-card`/`detector-card` + `goods-actions` SCSS
+  (#2308); and folding hand-built inputs onto `.form-input`/`.form-select`
+  (#2309). **Fix pattern:** extract a sanctioned shared class into
+  `_components.scss` / `_picker-shared.scss`, then fold the bespoke copies onto
+  it via markup + `@extend`. Ship incrementally (one primitive per PR) to keep
+  diffs reviewable. **Files:** `_components.scss`, `_picker-shared.scss`, and
+  the listed component SCSS/templates.
 
 <!-- item-sep -->
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -36,7 +36,7 @@
 }
 
 // Top-left detail-canvas (large preview) size buttons. A segmented pair that
-// mirrors the top-right grid-thumbnail size buttons (``vc-btn--size``), but
+// mirrors the top-right grid-thumbnail size buttons (`.segmented-toggle--compact`), but
 // resizes the single large preview — and so the whole popup — instead of the
 // member thumbnails.
 .bin-popup-size-group {

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -214,7 +214,7 @@
 }
 
 // Zoom (true span) control and on-screen hex size control. Both mirror the
-// grouped pill look of the Find view's grid-size buttons (.vc-btn); the hex
+// grouped pill look of the Find view's grid-size buttons (`.segmented-toggle--compact`); the hex
 // pill reuses the image icon at 11px / 18px, the zoom pill uses +/- glyphs.
 .browse-select,
 .browse-signposts,
@@ -274,7 +274,7 @@
 
 // The active toggle (region-select) reads as pressed: filled accent surface
 // that stays lit even when not hovered, so the active mode is obvious at a
-// glance. Mirrors the Find view's ``.vc-btn--active`` treatment.
+// glance. Mirrors the Find view's `.segmented-toggle__btn--active` treatment.
 .browse-size-btn--active {
   background: var(--accent-color);
   color: var(--toggle-active-text);

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -135,11 +135,11 @@
                 <h4 class="subhead" title="Display settings for the left panel (unlabeled media list)">Left Side</h4>
                 <div class="form-group">
                   <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus Mode:</label>
-                  <div class="toggle-group">
-                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_left', activeViewTab()) === 'click'" (click)="onFocusModeChange('focus_mode_left', activeViewTab(), 'click')" title="Click an item to preview it in the center panel">
+                  <div class="segmented-toggle segmented-toggle--stretch">
+                    <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getFocusMode('focus_mode_left', activeViewTab()) === 'click'" (click)="onFocusModeChange('focus_mode_left', activeViewTab(), 'click')" title="Click an item to preview it in the center panel">
                       <vt-icon type="cursor-click" [size]="14"></vt-icon> Click
                     </button>
-                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_left', activeViewTab()) === 'hover'" (click)="onFocusModeChange('focus_mode_left', activeViewTab(), 'hover')" title="Hover over an item to immediately preview it">
+                    <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getFocusMode('focus_mode_left', activeViewTab()) === 'hover'" (click)="onFocusModeChange('focus_mode_left', activeViewTab(), 'hover')" title="Hover over an item to immediately preview it">
                       <vt-icon type="cursor-hover" [size]="14"></vt-icon> Hover
                     </button>
                   </div>
@@ -159,11 +159,11 @@
                 <h4 class="subhead" title="Display settings for the right panel (labeled goods and bads)">Right Side</h4>
                 <div class="form-group">
                   <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus Mode:</label>
-                  <div class="toggle-group">
-                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_right', activeViewTab()) === 'click'" (click)="onFocusModeChange('focus_mode_right', activeViewTab(), 'click')" title="Click an item to preview it in the center panel">
+                  <div class="segmented-toggle segmented-toggle--stretch">
+                    <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getFocusMode('focus_mode_right', activeViewTab()) === 'click'" (click)="onFocusModeChange('focus_mode_right', activeViewTab(), 'click')" title="Click an item to preview it in the center panel">
                       <vt-icon type="cursor-click" [size]="14"></vt-icon> Click
                     </button>
-                    <button class="toggle-btn" [class.toggle-btn--active]="getFocusMode('focus_mode_right', activeViewTab()) === 'hover'" (click)="onFocusModeChange('focus_mode_right', activeViewTab(), 'hover')" title="Hover over an item to immediately preview it">
+                    <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getFocusMode('focus_mode_right', activeViewTab()) === 'hover'" (click)="onFocusModeChange('focus_mode_right', activeViewTab(), 'hover')" title="Hover over an item to immediately preview it">
                       <vt-icon type="cursor-hover" [size]="14"></vt-icon> Hover
                     </button>
                   </div>
@@ -287,22 +287,22 @@
             <div class="view-tab-content browser-tab-content">
               <div class="form-group">
                 <label class="form-label" title="Slide clusters together to close the empty space between them when the map is built">Compaction<vt-field-hint-icon hint="Slides clusters together to close the empty gaps between them. Applies next time the map is built."></vt-field-hint-icon></label>
-                <div class="toggle-group">
-                  <button class="toggle-btn" [class.toggle-btn--active]="getBrowseCompact(activeBrowseTab())" (click)="onBrowseCompactChange(activeBrowseTab(), true)" title="Close the empty space between clusters">
+                <div class="segmented-toggle segmented-toggle--stretch">
+                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getBrowseCompact(activeBrowseTab())" (click)="onBrowseCompactChange(activeBrowseTab(), true)" title="Close the empty space between clusters">
                     On
                   </button>
-                  <button class="toggle-btn" [class.toggle-btn--active]="!getBrowseCompact(activeBrowseTab())" (click)="onBrowseCompactChange(activeBrowseTab(), false)" title="Keep the map's original spacing">
+                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="!getBrowseCompact(activeBrowseTab())" (click)="onBrowseCompactChange(activeBrowseTab(), false)" title="Keep the map's original spacing">
                     Off
                   </button>
                 </div>
               </div>
               <div class="form-group">
                 <label class="form-label" title="Letter named region signposts over the map when the dataset has them">Signposts<vt-field-hint-icon hint="Names the map's regions like street signs: broad names when zoomed out, finer names as you zoom in. Only shows when the dataset's map has computed labels."></vt-field-hint-icon></label>
-                <div class="toggle-group">
-                  <button class="toggle-btn" [class.toggle-btn--active]="getBrowseSignposts(activeBrowseTab())" (click)="onBrowseSignpostsChange(activeBrowseTab(), true)" title="Show region signposts on the map">
+                <div class="segmented-toggle segmented-toggle--stretch">
+                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getBrowseSignposts(activeBrowseTab())" (click)="onBrowseSignpostsChange(activeBrowseTab(), true)" title="Show region signposts on the map">
                     On
                   </button>
-                  <button class="toggle-btn" [class.toggle-btn--active]="!getBrowseSignposts(activeBrowseTab())" (click)="onBrowseSignpostsChange(activeBrowseTab(), false)" title="Hide region signposts">
+                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="!getBrowseSignposts(activeBrowseTab())" (click)="onBrowseSignpostsChange(activeBrowseTab(), false)" title="Hide region signposts">
                     Off
                   </button>
                 </div>
@@ -360,14 +360,14 @@
               </div>
               <div class="form-group">
                 <label class="form-label" title="How many mouse-wheel notches (and +/- button clicks) it takes to cross one zoom level of the bin pyramid">Mouse-zooms per level<vt-field-hint-icon hint="How many mouse-wheel notches (or +/- clicks) it takes to cross one zoom level. 1 = 2× per notch; 2 (default) = √2; 3 = ∛2."></vt-field-hint-icon></label>
-                <div class="toggle-group">
-                  <button class="toggle-btn" [class.toggle-btn--active]="getBrowseMouseZoomsPerLevel(activeBrowseTab()) === 1" (click)="onBrowseMouseZoomsPerLevelChange(activeBrowseTab(), 1)" title="One notch per level (2× per zoom)">
+                <div class="segmented-toggle segmented-toggle--stretch">
+                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getBrowseMouseZoomsPerLevel(activeBrowseTab()) === 1" (click)="onBrowseMouseZoomsPerLevelChange(activeBrowseTab(), 1)" title="One notch per level (2× per zoom)">
                     1
                   </button>
-                  <button class="toggle-btn" [class.toggle-btn--active]="getBrowseMouseZoomsPerLevel(activeBrowseTab()) === 2" (click)="onBrowseMouseZoomsPerLevelChange(activeBrowseTab(), 2)" title="Two notches per level (√2 per zoom) — the default">
+                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getBrowseMouseZoomsPerLevel(activeBrowseTab()) === 2" (click)="onBrowseMouseZoomsPerLevelChange(activeBrowseTab(), 2)" title="Two notches per level (√2 per zoom) — the default">
                     2
                   </button>
-                  <button class="toggle-btn" [class.toggle-btn--active]="getBrowseMouseZoomsPerLevel(activeBrowseTab()) === 3" (click)="onBrowseMouseZoomsPerLevelChange(activeBrowseTab(), 3)" title="Three notches per level (∛2 per zoom)">
+                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getBrowseMouseZoomsPerLevel(activeBrowseTab()) === 3" (click)="onBrowseMouseZoomsPerLevelChange(activeBrowseTab(), 3)" title="Three notches per level (∛2 per zoom)">
                     3
                   </button>
                 </div>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -151,51 +151,8 @@
   }
 }
 
-.toggle-group {
-  display: flex;
-  gap: 0;
-}
-
-.toggle-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xs);
-  flex: 1;
-  justify-content: center;
-  padding: var(--space-xs) var(--space-sm);
-  font-size: var(--font-sm);
-  font-weight: var(--weight-medium);
-  color: var(--text-secondary);
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  cursor: pointer;
-  transition: background var(--transition-base), color var(--transition-base), box-shadow var(--transition-base);
-
-  &:first-child {
-    border-radius: var(--radius-md) 0 0 var(--radius-md);
-  }
-
-  &:last-child {
-    border-radius: 0 var(--radius-md) var(--radius-md) 0;
-    border-left: none;
-  }
-
-  &:hover:not(.toggle-btn--active) {
-    background: var(--bg-secondary);
-    color: var(--text-primary);
-  }
-
-  &--active {
-    background: var(--accent-color);
-    color: var(--toggle-active-text);
-    border-color: var(--accent-color);
-    box-shadow: inset 0 1px 3px var(--shadow-dropdown);
-
-    + .toggle-btn {
-      border-left-color: var(--accent-color);
-    }
-  }
-}
+// The View/Focus pickers use the shared `.segmented-toggle` primitive
+// (stretch variant) defined in `scss/_components.scss`.
 
 
 // Read-only value display for the Server Settings tab. Styled to read as

--- a/frontend/src/app/components/view-controls/view-controls.component.html
+++ b/frontend/src/app/components/view-controls/view-controls.component.html
@@ -1,8 +1,8 @@
 <div class="view-controls">
-  <div class="vc-group">
+  <div class="segmented-toggle segmented-toggle--compact">
     <button
       type="button"
-      class="vc-btn vc-btn--size"
+      class="segmented-toggle__btn"
       [disabled]="atMinSize() || !currentMediaType()"
       (click)="bumpSize(-1)"
       title="Smaller thumbnails"
@@ -11,7 +11,7 @@
     </button>
     <button
       type="button"
-      class="vc-btn vc-btn--size"
+      class="segmented-toggle__btn"
       [disabled]="atMaxSize() || !currentMediaType()"
       (click)="bumpSize(1)"
       title="Bigger thumbnails"
@@ -21,11 +21,11 @@
   </div>
 
   @if (showFocus()) {
-  <div class="vc-group">
+  <div class="segmented-toggle segmented-toggle--compact">
     <button
       type="button"
-      class="vc-btn"
-      [class.vc-btn--active]="focusMode() === 'click'"
+      class="segmented-toggle__btn"
+      [class.segmented-toggle__btn--active]="focusMode() === 'click'"
       (click)="setFocusMode('click')"
       title="Click to preview"
       aria-label="Click focus mode"
@@ -34,8 +34,8 @@
     </button>
     <button
       type="button"
-      class="vc-btn"
-      [class.vc-btn--active]="focusMode() === 'hover'"
+      class="segmented-toggle__btn"
+      [class.segmented-toggle__btn--active]="focusMode() === 'hover'"
       (click)="setFocusMode('hover')"
       title="Hover to preview"
       aria-label="Hover focus mode"

--- a/frontend/src/app/components/view-controls/view-controls.component.scss
+++ b/frontend/src/app/components/view-controls/view-controls.component.scss
@@ -10,56 +10,5 @@
   gap: var(--space-sm) var(--space-md);
 }
 
-.vc-group {
-  display: inline-flex;
-}
-
-.vc-btn {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 26px;
-  height: 22px;
-  padding: 0 var(--space-sm);
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base), box-shadow var(--transition-base);
-
-  &:not(:first-child) {
-    margin-left: -1px;
-  }
-
-  &:first-child {
-    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
-  }
-
-  &:last-child {
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-  }
-
-  &:hover:not(:disabled):not(.vc-btn--active) {
-    color: var(--text-primary);
-    border-color: var(--text-primary);
-    z-index: 1;
-  }
-
-  &:disabled {
-    opacity: var(--opacity-disabled);
-    cursor: not-allowed;
-  }
-
-  &--active {
-    background: var(--accent-color);
-    color: var(--toggle-active-text);
-    border-color: var(--accent-color);
-    box-shadow: inset 0 1px 3px var(--shadow-dropdown);
-    z-index: 1;
-  }
-
-  &--size vt-icon {
-    line-height: 0;
-  }
-}
+// The size / focus button groups use the shared `.segmented-toggle`
+// primitive (compact variant) defined in `scss/_components.scss`.

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -153,6 +153,106 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   }
 }
 
+// --- Segmented toggle ---
+//
+// A connected row of buttons acting as a single-select control: the
+// View/Focus pickers in Settings and the size/focus toggles in the
+// center-panel view toolbar. Buttons share a border (overlapped via a
+// negative left margin, with the active/hovered button raised on top so its
+// border wins on both sides) and the group's outer corners are rounded. The
+// selected button fills with the accent and gains an inset shadow.
+//
+// Variants:
+//   .segmented-toggle--stretch  equal-width buttons filling the row (labelled toggles)
+//   .segmented-toggle--compact  dense, icon-only buttons (toolbars)
+.segmented-toggle {
+  display: inline-flex;
+}
+
+.segmented-toggle--stretch {
+  display: flex;
+
+  .segmented-toggle__btn {
+    flex: 1;
+  }
+}
+
+.segmented-toggle__btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: var(--font-sm);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base),
+    border-color var(--transition-base), box-shadow var(--transition-base);
+
+  &:not(:first-child) {
+    margin-left: -1px;
+  }
+
+  &:first-child {
+    border-radius: var(--radius-md) 0 0 var(--radius-md);
+  }
+
+  &:last-child {
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  }
+
+  &:hover:not(:disabled):not(.segmented-toggle__btn--active) {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+    z-index: 1;
+  }
+
+  &:disabled {
+    opacity: var(--opacity-disabled);
+    cursor: not-allowed;
+  }
+
+  &--active {
+    background: var(--accent);
+    color: var(--toggle-active-text);
+    border-color: var(--accent);
+    box-shadow: inset 0 1px 3px var(--shadow-dropdown);
+    z-index: 1;
+  }
+}
+
+// Dense, icon-only variant for toolbars: smaller footprint, muted resting
+// colour, tighter corners, and a border-highlight hover (no fill) to suit a
+// packed row of glyph buttons.
+.segmented-toggle--compact .segmented-toggle__btn {
+  min-width: 26px;
+  height: 22px;
+  padding: 0 var(--space-sm);
+  color: var(--text-muted);
+
+  &:first-child {
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  }
+
+  &:last-child {
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  }
+
+  &:hover:not(:disabled):not(.segmented-toggle__btn--active) {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+    background: var(--bg-panel);
+  }
+
+  vt-icon {
+    line-height: 0;
+  }
+}
+
 // --- Form elements ---
 
 .form-input {


### PR DESCRIPTION
First slice of the **Promote shared component primitives** plan item (`docs/plans/ui-style-polish.md`), shipped one-primitive-per-PR.

## What

Two near-identical segmented controls were hand-rolled independently. This extracts one sanctioned `.segmented-toggle` primitive into `frontend/src/scss/_components.scss` and folds both onto it:

- **Settings View/Focus pickers** — `.toggle-group` / `.toggle-btn` → `.segmented-toggle` + `.segmented-toggle--stretch` (equal-width labelled buttons).
- **Center-panel view toolbar** — `.vc-group` / `.vc-btn` → `.segmented-toggle` + `.segmented-toggle--compact` (dense icon-only buttons).

The base captures the distinctive, bug-prone parts — connected-border geometry (negative-margin overlap with the active/hovered button raised on top), the accent-fill active state, and the inset shadow. The two variants (`--stretch`, `--compact`) carry only the legitimate per-use differences (sizing, resting colour).

## Token cleanup

The bespoke copies used alias tokens (`--bg-primary`, `--border-color`, `--accent-color`); the extraction resolves them to their canonical names (`--bg-panel`, `--border`, `--accent`). Stale doc comments in `browse-view` / `browse-bin-popup` that named the old `.vc-btn` class now point at the new primitive.

## Tracking

The remaining primitives in this umbrella item are now split into their own issues (#2300–#2309), each to ship as its own PR. This PR closes the segmented-toggle slice.

Closes #2299

## Testing

`./run-tests.sh frontend` — Angular `build:prod` OK, `npm audit` clean, Vitest 1154 passed. Full lint/pyright/deptry/pip-audit gates green.

## Note

The `view-options` doc screenshot clips `vt-view-controls` (the refactored toolbar); it is already in `docs/user/screenshots-reshoot-queue.md` (light-ramp reason), so the refactor will be captured on the next queue drain. The refactor targets pixel parity, so no visible drift is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Maz3SR5NKVNKevV59HUEBB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Maz3SR5NKVNKevV59HUEBB)_