### PR TITLE
Modal polish package: width tokens, Close-never-primary, media-crop footer

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -88,27 +88,6 @@ surface. When you ship it, add the affected shot ids to
 
 <!-- item-sep -->
 
-- **Modal polish package** — modal chrome is inconsistent across ~24 dialogs.
-  Widths are ad-hoc (720/680/480/900/34rem, no shared scale); the "Close"
-  button has no fixed identity (styled `.btn--primary` in some, secondary in
-  others — e.g. `settings-modal.component.html:472` renders a purple-fill
-  "Close" even though settings auto-save, reading as a commit action);
-  `media-crop-modal` puts its actions *inside* the scrolling body with
-  non-`.btn` classes in reversed order; `autodetect-progress` double-pads; and
-  ~9 hard-coded nested `max-height` scroll regions live inside `.modal-body`.
-  The `.new-detector-form` also pins `width: 480px`
-  (`new-detector-modal.component.scss:64`) while the modal widens to 900px when
-  the media picker mounts, leaving empty side gutters on the Blank form.
-  **Fix:** add `--modal-w-sm/md/lg` tokens and adopt them; enforce "Close is
-  never primary" (demote/relabel the settings Close to "Done"); move the
-  media-crop actions into a real `.modal-footer`; replace the nested
-  `max-height`s with `flex: 1; min-height: 0`; make `.new-detector-form` track
-  the modal width. Also document the intentional close-less dialogs
-  (`[showCloseButton]="false"` on new-detector, clipper-chooser,
-  combine-detectors, resort-prompt, dialog-host) in `docs/style-guide.md §2.4`,
-  or restore the `×` glyph. **Files:** the listed modal SCSS/templates,
-  `_variables.scss`, `docs/style-guide.md`.
-
 <!-- item-sep -->
 
 - **Add focus management to the shared `vt-modal`** — `app/components/modal/`

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -224,6 +224,34 @@ Spacing inside modals:
 - `.modal-footer` has `gap: var(--space-md)` between buttons.
 - The modal-content uses `--shadow-lg` and `--radius-xl`.
 
+**Width scale.** A dialog that needs a fixed width picks one of the three
+tokens instead of hand-rolling a `px` value; a dialog that sizes to its content
+sets none:
+
+| Token          | Width | Use |
+|----------------|-------|-----|
+| `--modal-w-sm` | 480px | Single-column forms: label importer, combine detectors, the blank new-detector form. |
+| `--modal-w-md` | 720px | Picker / table / settings dialogs: dataset importer, export, settings, keyboard help. |
+| `--modal-w-lg` | 900px | Wide views that need room for a table + browser side by side: the new-detector / dataset media-picker view. |
+
+Set the width on `.modal-content` (via `::ng-deep`), not on an inner wrapper,
+so inner content can `width: 100%` and fill the dialog rather than leaving side
+gutters. A raw `px`/`rem` width on a `.modal-content` is a violation.
+
+**Footer buttons.** Cancel/back on the left, the primary action on the far
+right. **"Close" is never `.btn--primary`.** A Close button dismisses the
+dialog - it commits nothing - so styling it as the primary (accent-fill) action
+misreads as "save". Dismiss buttons are `.btn--secondary`. When a dialog
+auto-saves (e.g. Settings) the dismiss verb is **"Done"**, not "Close", so it
+doesn't imply the changes were pending a commit.
+
+**Close-less dialogs.** A handful of modals set `[showCloseButton]="false"` and
+render no header `×`, on purpose: they are decision points that must be resolved
+by an explicit footer action (or a `← Back`) rather than dismissed ambiguously.
+These are the new-detector modal, the clipper-chooser, combine-detectors,
+resort-prompt, and dialog-host. Every *other* modal keeps the header `×`. Do not
+add `[showCloseButton]="false"` to a new modal without a comparable reason.
+
 #### Back vs Cancel
 
 This pattern is **mandatory** for any modal with an outer→inner view (importer picker → importer form, exporter picker → exporter form, new-detector → media picker, etc.). See CLAUDE.md for the canonical writeup. Short version:

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -1,6 +1,6 @@
 :host {
   ::ng-deep .modal-content {
-    width: 640px;
+    width: var(--modal-w-md);
     max-width: 95vw;
   }
 }

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
-  width: 480px;
+  width: var(--modal-w-sm);
   max-width: 100%;
 }
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.scss
@@ -14,7 +14,7 @@
 // jumping to fit the demo table.
 :host {
   ::ng-deep .modal-content {
-    width: 720px;
+    width: var(--modal-w-md);
     min-height: 480px;
   }
 }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -3,17 +3,21 @@
 // globally and shared with the Add Dataset modal; only styles unique to
 // this component remain below.
 
-// Pin the modal to a wider size when the media picker is on screen so the
-// demo table and folder browser have room (matches the Add Dataset modal at
-// 900px). The min-height keeps the dialog from collapsing to a thin strip
-// when the picker is in its "no source selected" state.
+// The main form view sizes to `--modal-w-sm`; the modal widens to
+// `--modal-w-lg` when the media picker is on screen so the demo table and
+// folder browser have room (matches the Add Dataset modal). Driving the width
+// from the modal (not the form's own `width`) lets the form fill it, so the
+// Blank form no longer leaves empty side gutters. The min-height keeps the
+// dialog from collapsing to a thin strip in the picker's "no source selected"
+// state.
 :host {
   ::ng-deep .modal-content {
+    width: var(--modal-w-sm);
     min-height: 200px;
   }
 
   &:has(.media-picker) ::ng-deep .modal-content {
-    width: 900px;
+    width: var(--modal-w-lg);
     min-height: 480px;
   }
 }
@@ -61,8 +65,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
-  width: 480px;
-  max-width: 100%;
+  // Track the modal width (set on `.modal-content` above) instead of pinning
+  // a fixed width, so the form fills the dialog rather than leaving gutters.
+  width: 100%;
 }
 
 // `.form-group`, `.info-text`, `.error-text` come from `_components.scss`.

--- a/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.html
+++ b/frontend/src/app/components/modals/achievements-modal/achievements-modal.component.html
@@ -1,6 +1,6 @@
 <vt-modal title="Achievements" [open]="true" (closed)="close()">
   <vt-achievements-tab />
   <div modal-footer>
-    <button class="btn btn--primary" (click)="close()" title="Close the achievements panel">Close</button>
+    <button class="btn btn--secondary" (click)="close()" title="Close the achievements panel">Close</button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
@@ -7,7 +7,12 @@
 }
 
 .results-table-wrapper {
-  max-height: 300px;
+  // Claim the modal body's remaining height and scroll internally, rather
+  // than capping at a fixed height that would nest a second scrollbar inside
+  // the body's own scrollbar. The summary above and export controls below
+  // stay at natural height; this table absorbs the slack.
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   margin-bottom: var(--space-xl);
 }

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.scss
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  max-width: 34rem;
+  max-width: var(--modal-w-sm);
 
   h3 {
     margin: 0;

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -1,5 +1,5 @@
 :host ::ng-deep .modal-content {
-  width: 720px;
+  width: var(--modal-w-md);
 }
 
 .export-section {

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: var(--space-lg);
   min-width: 360px;
-  max-width: 720px;
+  max-width: var(--modal-w-md);
 }
 
 .help-tabs {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
-  width: 480px;
+  width: var(--modal-w-sm);
   max-width: 100%;
 }
 
@@ -44,7 +44,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
-  width: 480px;
+  width: var(--modal-w-sm);
   max-width: 100%;
 }
 
@@ -74,7 +74,7 @@
   margin-top: var(--space-xl);
   padding-top: var(--space-xl);
   border-top: 1px solid var(--border);
-  width: 480px;
+  width: var(--modal-w-sm);
   max-width: 100%;
 }
 

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.html
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.html
@@ -22,18 +22,6 @@
       }
     </div>
     <div class="filename">{{ file().name }}</div>
-    <div class="actions">
-      <button type="button" class="primary" (click)="onOk()">OK</button>
-      <button
-        type="button"
-        class="secondary"
-        [disabled]="!cropSupported"
-        [title]="cropSupported ? 'Crop to a sub-region' : 'Cropping not supported for this media type'"
-        (click)="onOkButCrop()">
-        OK but crop
-      </button>
-      <button type="button" class="cancel" (click)="onCancel()">Cancel</button>
-    </div>
   }
 
   @if (view === 'cropping') {
@@ -52,5 +40,20 @@
         (cancelled)="onCropOverlayCancelled()">
       </vt-audio-crop-overlay>
     }
+  }
+
+  @if (view === 'confirm') {
+    <div modal-footer>
+      <button type="button" class="btn btn--secondary" (click)="onCancel()">Cancel</button>
+      <button
+        type="button"
+        class="btn btn--secondary"
+        [disabled]="!cropSupported"
+        [title]="cropSupported ? 'Crop to a sub-region' : 'Cropping not supported for this media type'"
+        (click)="onOkButCrop()">
+        OK but crop
+      </button>
+      <button type="button" class="btn btn--primary" (click)="onOk()">OK</button>
+    </div>
   }
 </vt-modal>

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.scss
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.scss
@@ -32,41 +32,7 @@
   font-size: var(--font-md);
   color: var(--text-secondary);
   text-align: center;
-  margin-bottom: var(--space-xl);
+  // No bottom margin: this is the last body element; the footer's own
+  // spacing (via `.modal-body` margin-bottom) owns the gap to the actions.
   word-break: break-all;
-}
-
-.actions {
-  display: flex;
-  gap: var(--space-md);
-  justify-content: flex-end;
-
-  button {
-    padding: var(--space-md) var(--space-xl);
-    border-radius: var(--radius-md);
-    border: 1px solid var(--border-secondary);
-    cursor: pointer;
-    font-size: var(--font-lg);
-    background: var(--bg-secondary-btn);
-    color: var(--text-primary);
-
-    &:disabled {
-      opacity: var(--opacity-disabled);
-      cursor: not-allowed;
-    }
-
-    &.primary {
-      background: var(--accent);
-      color: var(--btn-primary-text);
-      border-color: transparent;
-    }
-
-    &.secondary {
-      background: var(--bg-secondary-btn);
-    }
-
-    &.cancel {
-      background: transparent;
-    }
-  }
 }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.scss
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.scss
@@ -1,6 +1,8 @@
 .analysis-loading {
   text-align: center;
-  padding: var(--space-2xl);
+  // Vertical breathing room only: `.modal-content` already supplies the
+  // horizontal padding, so a full box padding here double-pads the sides.
+  padding: var(--space-2xl) 0;
 
   p {
     margin-bottom: var(--space-xl);

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -469,7 +469,7 @@
         <line x1="12" y1="12" x2="21" y2="3"></line>
       </svg>
     </button>
-    <button class="btn btn--primary" (click)="close()" title="Close the settings panel">Close</button>
+    <button class="btn btn--secondary" (click)="close()" title="Close the settings panel">Done</button>
   </div>
 </vt-modal>
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -1,6 +1,6 @@
 :host {
   ::ng-deep .modal-content {
-    width: 680px;
+    width: var(--modal-w-md);
   }
 }
 

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -78,6 +78,16 @@
   --z-toast: 5000;
   --z-login: 9999;
 
+  // Modal width scale. Dialogs pick one of these instead of hand-rolling a
+  // width; keeps chrome consistent across the ~24 modals. `sm` is the simple
+  // single-column form (label importer, combine detectors, blank new-detector
+  // form); `md` the picker/table dialogs (importer, export, settings, help);
+  // `lg` the media-picker view that needs room for the demo table + folder
+  // browser. Modals with no fixed-width need size to content.
+  --modal-w-sm: 480px;
+  --modal-w-md: 720px;
+  --modal-w-lg: 900px;
+
   // --- Theme colors (dark, default) ---
 
   --bg-body: #0f1117;


### PR DESCRIPTION
Ships the **Modal polish package** item from `docs/plans/ui-style-polish.md`, bringing consistent chrome to the ~24 dialogs.

## What changed

- **Modal width scale.** Added `--modal-w-sm` (480px) / `--modal-w-md` (720px) / `--modal-w-lg` (900px) tokens to `_variables.scss` and adopted them everywhere a modal hand-rolled a width — export, settings, combine-datasets, dataset-importer, new-detector, keyboard-help, detector-portable, label-importer, combine-detectors. Replaces the ad-hoc `480/640/680/720/900/34rem` values with a shared scale (a few widths snapped to the nearest tier: settings 680→720, combine-datasets 640→720, detector-portable 544→480).
- **"Close" is never primary.** Non-committing dismiss buttons no longer render as the accent-fill primary action. Settings' Close becomes a secondary **"Done"** (settings auto-save, so "Close" as a purple commit-looking button misread); achievements' Close becomes secondary.
- **Media-crop actions moved into a real `.modal-footer`.** They were inside the scrolling body with bespoke non-`.btn` classes in reversed order; now they use `.btn` classes in the standard Cancel / OK-but-crop / OK (primary, far right) order.
- **`.new-detector-form` tracks the modal width.** The form pinned `width: 480px` while the modal widened to 900px for the media picker, leaving side gutters on the Blank form. Width now lives on `.modal-content` (`--modal-w-sm` → `--modal-w-lg` when the picker mounts) and the form fills it with `width: 100%`.
- **Nested `max-height` → `flex: 1; min-height: 0`** on the autodetect-results table wrapper, so it absorbs the modal body's slack instead of nesting a second scrollbar inside the body's own. (The other in-modal `max-height`s are intentionally-bounded sub-region lists — multi-column example grids, sub-view pick lists, a dropdown, tab-panel tables — not the body-level double-scrollbar this rule targets, so they're left as-is.)
- **Progress modal double-pad.** `.analysis-loading` added a full box padding on top of `.modal-content`'s own; trimmed to vertical-only.
- **Docs.** `docs/style-guide.md §2.4` now documents the width scale, the Close-never-primary rule (with the "Done" convention for auto-saving dialogs), and the intentional close-less dialogs (`[showCloseButton]="false"` on new-detector, clipper-chooser, combine-detectors, resort-prompt, dialog-host).

Removed the shipped item from `docs/plans/ui-style-polish.md` (sentinels left intact).

## Testing

`./run-tests.sh frontend` — ruff/codespell/deptry/pyright/pip-audit clean, frontend `build:prod` OK, `npm audit` clean, Vitest 1154 passed.

## Screenshots

No reshoot-queue edits needed: every doc shot framing a surface this touches (`settings-appearance`, `achievements`, `new-detector`, `export-picker`, `import-detector`) is already queued from the 2026-07-09 light-mode ramp, and no shot frames the media-crop or keyboard-help modals. No browser in this session to drain the queue.

Part of the UI Style Polish plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpYWhdNBoMLAcHg7VAQ6nT)_