### PR TITLE
Consolidate design-token aliases and extend the style scanner

### DIFF
--- a/.claude/scripts/style-check.py
+++ b/.claude/scripts/style-check.py
@@ -47,6 +47,15 @@ def scss_files() -> list[Path]:
     return [f for f in files if f not in EXCLUDE_FILES]
 
 
+def all_scss_files() -> list[Path]:
+    """Every SCSS file, including the token source-of-truth (_variables.scss).
+
+    The token-resolution checks below validate the token file's own internal
+    `var()` references too, so they intentionally do not exclude it.
+    """
+    return sorted(SCSS_DIR.rglob("*.scss"))
+
+
 def rel(p: Path) -> str:
     try:
         return str(p.relative_to(REPO_ROOT))
@@ -340,6 +349,162 @@ def check_redeclared_utility(files: list[Path]) -> Finding:
 
 
 # ---------------------------------------------------------------------------
+# Token resolution: broken var() references + deleted-alias usage
+# ---------------------------------------------------------------------------
+# Aliases removed in the "Consolidate design tokens" pass. Each mapped to a
+# canonical token; component SCSS was codemodded onto the canonical name and
+# the alias definitions deleted from _variables.scss. Listing them here (with
+# their canonical replacement) lets the scanner catch a resurrection - even one
+# hidden behind a var() fallback, which the generic broken-var check below
+# would let through - without needing a browser to notice the missing color.
+DELETED_ALIASES = {
+    "--border-color": "--border",
+    "--bg-secondary": "--bg-subtle",
+    "--bg-primary": "--bg-panel",
+    "--accent-color": "--accent",
+    "--color-accent": "--accent",
+    "--error": "--color-bad",
+}
+
+# Custom-property NAME token. Deliberately excludes a trailing `-`/word char so
+# `--bg-secondary` does not swallow `--bg-secondary-btn`.
+CUSTOM_PROP = re.compile(r"--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*")
+PROP_DEF = re.compile(r"^\s*(--[a-zA-Z0-9-]+)\s*:")
+# Custom properties set from Angular templates / TS (consumed by `var()` in
+# SCSS): `[style.--x]`, `style="--x: ..."`, `setProperty('--x', ...)`.
+TEMPLATE_PROP = re.compile(
+    r"\[style\.(--[a-zA-Z0-9-]+)|setProperty\(\s*['\"`](--[a-zA-Z0-9-]+)|style\s*=\s*\"[^\"]*?(--[a-zA-Z0-9-]+)\s*:"
+)
+
+
+def _strip_comments(text: str) -> str:
+    """Blank out `//` line comments and `/* */` block comments, preserving
+    every character offset and newline (comment bytes become spaces) so line
+    numbers computed against the result still match the original source.
+
+    Doc comments in _components.scss reference tokens as prose (`var(--space-*)`);
+    without this, the broken-var check would flag the wildcard `--space`.
+    """
+    out = list(text)
+    n = len(text)
+    i = 0
+    while i < n:
+        two = text[i : i + 2]
+        if two == "//":
+            j = i
+            while j < n and text[j] != "\n":
+                out[j] = " "
+                j += 1
+            i = j
+        elif two == "/*":
+            j = i
+            while j < n and text[j : j + 2] != "*/":
+                if text[j] != "\n":
+                    out[j] = " "
+                j += 1
+            # blank the closing */ too (if present)
+            for k in range(j, min(j + 2, n)):
+                if text[k] != "\n":
+                    out[k] = " "
+            i = j + 2
+        else:
+            i += 1
+    return "".join(out)
+
+
+def _var_refs(text: str):
+    """Yield (name, has_fallback, offset) for every `var(...)` in *text*.
+
+    Handles nested parens so a `var(--x, var(--y))` fallback is parsed
+    correctly: the fallback comma is the first top-level comma inside the
+    outer `var(`.
+    """
+    i = 0
+    n = len(text)
+    while True:
+        start = text.find("var(", i)
+        if start == -1:
+            return
+        j = start + 4
+        depth = 1
+        comma = -1
+        while j < n and depth > 0:
+            c = text[j]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+            elif c == "," and depth == 1 and comma == -1:
+                comma = j
+            j += 1
+        inner_end = j - 1  # index of the matching ')'
+        name_part = text[start + 4 : (comma if comma != -1 else inner_end)]
+        m = CUSTOM_PROP.search(name_part)
+        if m:
+            yield m.group(0), comma != -1, start
+        i = j
+
+
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _defined_props() -> set[str]:
+    """All custom properties that resolve at runtime: every `--x:` definition
+    across the SCSS tree plus properties set from templates/TS style bindings.
+    """
+    defined: set[str] = set()
+    for path in all_scss_files():
+        for line in path.read_text().splitlines():
+            m = PROP_DEF.match(line)
+            if m:
+                defined.add(m.group(1))
+    for path in sorted(SCSS_DIR.rglob("*.ts")) + sorted(SCSS_DIR.rglob("*.html")):
+        for m in TEMPLATE_PROP.finditer(path.read_text()):
+            defined.add(next(g for g in m.groups() if g))
+    return defined
+
+
+def check_broken_var(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="Broken var(): custom property resolves to nothing",
+        description=(
+            "A `var(--x)` with no fallback whose `--x` is not defined anywhere "
+            "(no `--x:` in the SCSS tree, no template/TS style binding) renders "
+            "as an invalid/empty value - a real bug the Angular build won't "
+            "catch. Add the token to _variables.scss, fix the name, or give it "
+            "a fallback: `var(--x, <fallback>)`."
+        ),
+    )
+    defined = _defined_props()
+    for path in files:
+        text = path.read_text()
+        for name, has_fallback, offset in _var_refs(_strip_comments(text)):
+            if has_fallback or name in defined:
+                continue
+            f.hits.append((path, _line_of(text, offset), _read_line(text, _line_of(text, offset))))
+    return f
+
+
+def check_deleted_alias(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="Deleted design-token alias in use",
+        description=(
+            "These alias tokens were removed in the token-consolidation pass; "
+            "each has a canonical replacement. Referencing one (even behind a "
+            "var() fallback) resurrects a token that no longer exists. Swap to "
+            "the canonical name: " + ", ".join(f"{a} -> {c}" for a, c in sorted(DELETED_ALIASES.items())) + "."
+        ),
+    )
+    for path in files:
+        text = path.read_text()
+        for name, _has_fallback, offset in _var_refs(_strip_comments(text)):
+            if name in DELETED_ALIASES:
+                f.hits.append((path, _line_of(text, offset), _read_line(text, _line_of(text, offset))))
+    return f
+
+
+# ---------------------------------------------------------------------------
 # Reporting
 # ---------------------------------------------------------------------------
 def print_report(findings: list[Finding]) -> int:
@@ -372,7 +537,11 @@ def print_report(findings: list[Finding]) -> int:
 
 def main() -> int:
     files = scss_files()
+    all_files = all_scss_files()
     findings = [
+        # Objective token-resolution bugs first (these have no legitimate hits).
+        check_broken_var(all_files),
+        check_deleted_alias(all_files),
         check_raw_lengths(files),
         check_hex_colors(files),
         check_bold_weight(files),

--- a/.claude/skills/style-check/SKILL.md
+++ b/.claude/skills/style-check/SKILL.md
@@ -26,6 +26,8 @@ your job is to review them and decide which to fix.
 
 | Rule | What | How |
 |---|---|---|
+| Broken `var()` | `var(--x)` with no fallback whose `--x` is defined nowhere (SCSS tree or template/TS style binding) — an invalid/empty render the Angular build won't catch | Paren-aware `var()` parser vs. the set of all defined custom properties |
+| Deleted alias | Use of a design-token alias removed in the consolidation pass (`--border-color`, `--bg-secondary`, `--bg-primary`, `--accent-color`, `--color-accent`, `--error`), even behind a `var()` fallback | Alias→canonical map |
 | §4.1-2 | Hardcoded `px`/`rem` in `padding`/`margin`/`gap`/`font-size` | Regex on the property list |
 | §4.3   | Hex color literals in component SCSS | `#xxxxxx` outside `_variables.scss` |
 | §4.6   | `font-weight: 700` / `bold` | Regex |
@@ -68,10 +70,12 @@ hit) before deciding it's a violation.
 
 When invoked by the user, run the script, then:
 
-1. **Summarise total findings** (e.g. "83 hits across 8 rules").
-2. **Highlight the clear bugs first** - anything in §4.13 or §4.15 is
-   usually genuine; §4.6 (`font-weight: 700`) and §4.10 (`transition:
-   all`) are almost always real.
+1. **Summarise total findings** (e.g. "83 hits across 10 rules").
+2. **Highlight the clear bugs first** - the two token-resolution checks
+   (**Broken `var()`** and **Deleted alias**) are objective: they have no
+   legitimate hits, so treat every one as a bug to fix. After those,
+   anything in §4.13 or §4.15 is usually genuine; §4.6 (`font-weight:
+   700`) and §4.10 (`transition: all`) are almost always real.
 3. **Group §4.14 hits by likely category** (real form/section
    containers vs. top-level layout panels) before listing.
 4. **Offer to fix categories one at a time** rather than dumping a

--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -27,21 +27,23 @@ without a browser.
 
 <!-- item-sep -->
 
-- **Consolidate design tokens and extend the style scanner** — six alias
-  tokens still live in all three theme blocks (`_variables.scss:156-161`,
-  `:248-253`, `:322-327`): `--border-color`, `--bg-secondary`, `--bg-primary`
-  (confusingly maps to `--bg-panel`), `--accent-color`, `--color-accent` (the
-  same word order-swapped), and `--error`. Alongside them: 11 raw
-  letter-spacing values with no `--tracking-wide` token, 11 ad-hoc opacity
-  values, off-scale durations/radii, hand-copied box-shadows, reinvented
-  selected-tile tints, and raw z-indexes on the browse overlays.
-  **Fix:** codemod each alias to its canonical name and delete the alias; add
-  `--tracking-wide`, a decorative-dim opacity token, and a canvas-overlay
-  `--z-*` token; round stray durations/radii onto the scale. Then extend
-  `.claude/scripts/style-check.py` to flag (a) `var(--x)` names that resolve to
-  nothing and (b) use of the deleted aliases, so this can't regress without a
-  browser. **Files:** `_variables.scss`, component SCSS using the aliases,
-  `.claude/scripts/style-check.py`.
+- **Consolidate the remaining ad-hoc token values** — the six alias tokens,
+  the `--tracking-wide` letter-spacing token, and the two style-scanner checks
+  (broken `var()` refs + deleted-alias usage) have shipped. What's still owed
+  is the rest of the value-drift consolidation: ~11 ad-hoc opacity values that
+  want a decorative-dim opacity token (distinct from the existing
+  `--opacity-disabled`); raw z-indexes on the browse overlays
+  (`browse-view.component.scss` `z-index: 1/2/3`) that want a canvas-overlay
+  `--z-*` token; off-scale transition/animation durations and stray radii that
+  should round onto the existing scales; hand-copied box-shadows that should
+  resolve through `--shadow-sm/md/lg`; and reinvented selected-tile tints that
+  should share one token. Each is judgment-heavy (which opacity sites are
+  "decorative dim" vs. animation vs. disabled; which durations are interactive
+  vs. keyframe timing that would change feel if rounded), so scope each before
+  applying. **Files:** `_variables.scss`, the listed component SCSS. **Note:**
+  the scanner (`.claude/scripts/style-check.py`) already flags any resurrected
+  alias and any broken `var()` — extend it similarly if a new token added here
+  is meant to be enforced.
 
 <!-- item-sep -->
 

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -118,7 +118,7 @@ header {
   font-size: var(--font-2xs);
   color: var(--text-dim);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-wide);
   padding: var(--space-md) var(--space-lg) var(--space-xs);
   border-top: 1px solid var(--border);
   margin-top: var(--space-xs);

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -12,7 +12,7 @@
 .achievements-total-label {
   font-size: var(--font-md);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-wide);
   color: var(--text-muted);
 }
 
@@ -70,7 +70,7 @@
 .achievement-tier {
   font-size: var(--font-xs);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-wide);
   padding: var(--space-2xs) var(--space-xs);
   border-radius: var(--radius-sm);
   background: var(--bg-hover);

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -51,7 +51,7 @@
   min-width: 26px;
   height: 22px;
   padding: 0 var(--space-sm);
-  background: var(--bg-primary);
+  background: var(--bg-panel);
   border: 1px solid var(--border);
   color: var(--text-muted);
   cursor: pointer;
@@ -97,7 +97,7 @@
   min-width: 26px;
   height: 22px;
   padding: 0 var(--space-sm);
-  background: var(--bg-primary);
+  background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
@@ -194,7 +194,7 @@
 
 .bin-popup-meta-label {
   font-size: var(--font-2xs);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
   color: var(--text-muted);
   white-space: nowrap;
@@ -307,7 +307,7 @@
 .bin-popup-count {
   flex-shrink: 0;
   font-size: var(--font-xs);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-wide);
   color: var(--text-muted);
   white-space: nowrap;
   overflow: hidden;

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -987,7 +987,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const tyMax = Math.ceil((from.centerY + halfWy) / tileH + 1);
 
     const cmap = resolveColormap(this.colormap(), this.effectiveTheme());
-    this.selAccent = this.themeColor('--accent-color') || '#4f9dff';
+    this.selAccent = this.themeColor('--accent') || '#4f9dff';
     const selectionActive = this.selection.size > 0;
     const cull = screenRadius * 2;
     // The frozen viewport copy is dropped into the centre afterwards, so a cell
@@ -1251,7 +1251,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // Resolve the colormap against the live theme once per frame, not per cell.
     const cmap = resolveColormap(this.colormap(), this.effectiveTheme());
     // Accent for selection rings + marquee, also resolved once per frame.
-    this.selAccent = this.themeColor('--accent-color') || '#4f9dff';
+    this.selAccent = this.themeColor('--accent') || '#4f9dff';
     const selectionActive = this.selection.size > 0;
 
     // The enlarged cell is deferred and redrawn last (on top of its neighbours)

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -331,7 +331,7 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
       const cellR = (this.meta()!.base_radius / Math.pow(2, level)) * f.scale;
       const cmap = resolveColormap(this.colormap(), this.effectiveTheme());
       const selActive = this.selection.size > 0;
-      const selAccent = this.themeColor('--accent-color') || '#4f9dff';
+      const selAccent = this.themeColor('--accent') || '#4f9dff';
       for (const cell of cells) {
         const [sx, sy] = this.projToMap(cell.cx, cell.cy, f);
         const single = cell.count === 1;

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -29,7 +29,7 @@
 .bsp-title {
   margin: 0;
   font-size: var(--font-sm);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-wide);
   font-weight: var(--weight-regular);
   color: var(--text-primary);
 }

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -231,7 +231,7 @@
   min-width: 30px;
   height: 28px;
   padding: 0 var(--space-sm);
-  background: var(--bg-primary);
+  background: var(--bg-panel);
   border: 1px solid var(--border);
   color: var(--text-muted);
   cursor: pointer;
@@ -276,9 +276,9 @@
 // that stays lit even when not hovered, so the active mode is obvious at a
 // glance. Mirrors the Find view's `.segmented-toggle__btn--active` treatment.
 .browse-size-btn--active {
-  background: var(--accent-color);
+  background: var(--accent);
   color: var(--toggle-active-text);
-  border-color: var(--accent-color);
+  border-color: var(--accent);
   box-shadow: inset 0 1px 3px var(--shadow-dropdown);
   z-index: 1;
 }
@@ -298,7 +298,7 @@
   margin: 0 0 0 -1px;
   padding: 0 var(--space-sm);
   box-sizing: border-box;
-  background: var(--bg-primary);
+  background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   cursor: pointer;
@@ -311,7 +311,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid var(--accent-color);
+    outline: 2px solid var(--accent);
     outline-offset: 1px;
   }
 
@@ -330,7 +330,7 @@
     margin-top: -4.5px; // centre the 12px thumb on the 3px track
     border: none;
     border-radius: 50%;
-    background: var(--accent-color);
+    background: var(--accent);
     cursor: pointer;
   }
 
@@ -346,7 +346,7 @@
     height: 12px;
     border: none;
     border-radius: 50%;
-    background: var(--accent-color);
+    background: var(--accent);
     cursor: pointer;
   }
 }

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -167,7 +167,7 @@
   cursor: pointer;
   font-size: var(--font-xs);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: var(--tracking-wide);
   transition: color var(--transition-base);
 
   &:hover {
@@ -216,7 +216,7 @@
   font-size: var(--font-xs);
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: var(--tracking-wide);
 }
 
 .metadata-value {

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -29,7 +29,7 @@
   color: var(--text-secondary);
   font-size: var(--font-sm);
   text-transform: uppercase;
-  letter-spacing: .04em;
+  letter-spacing: var(--tracking-wide);
   font-weight: var(--weight-semibold);
 }
 
@@ -64,7 +64,7 @@
     color: var(--text-secondary);
     font-size: var(--font-sm);
     text-transform: uppercase;
-    letter-spacing: .04em;
+    letter-spacing: var(--tracking-wide);
   }
 
   tfoot td {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -330,7 +330,7 @@
   margin-top: var(--space-2xs);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  background: var(--bg-primary, var(--bg-subtle));
+  background: var(--bg-panel, var(--bg-subtle));
   box-shadow: var(--shadow-md);
   overflow: hidden;
 }

--- a/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
+++ b/frontend/src/app/components/field-hint-icon/field-hint-icon.component.ts
@@ -75,7 +75,7 @@ const HOVER_DELAY_MS = 500;
         padding: 6px 8px;
         background: var(--bg-surface);
         color: var(--text-primary);
-        border: 1px solid var(--border-color);
+        border: 1px solid var(--border);
         border-radius: 4px;
         font-size: 12px;
         font-weight: 400;

--- a/frontend/src/app/components/folder-browser/folder-browser.component.scss
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.scss
@@ -81,7 +81,7 @@
   z-index: var(--z-base);
   font-size: var(--font-2xs);
   text-transform: uppercase;
-  letter-spacing: .03em;
+  letter-spacing: var(--tracking-wide);
   color: var(--text-secondary);
   user-select: none;
 }

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
@@ -192,6 +192,6 @@
   font-size: var(--font-2xs);
   color: var(--text-primary);
   font-weight: var(--weight-semibold);
-  letter-spacing: 0.5px;
+  letter-spacing: var(--tracking-wide);
   white-space: nowrap;
 }

--- a/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
+++ b/frontend/src/app/components/left-panel/inclusion-slider/inclusion-slider.component.scss
@@ -16,7 +16,7 @@ input[type="number"] {
   padding: var(--space-2xs) var(--space-xs);
   font-size: var(--font-sm);
   color: var(--text-primary);
-  background: var(--bg-secondary, transparent);
+  background: var(--bg-subtle, transparent);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   text-align: center;

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -115,7 +115,7 @@
 
 .images-header-title {
   font-size: var(--font-sm);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-wide);
   margin: 0;
   color: var(--text-secondary);
   font-weight: var(--weight-regular);

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.scss
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.scss
@@ -72,7 +72,7 @@
   font-size: var(--font-2xs);
   color: var(--accent);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-wide);
   white-space: nowrap;
 }
 

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
@@ -32,7 +32,7 @@
   th {
     position: sticky;
     top: 0;
-    background: var(--bg-secondary);
+    background: var(--bg-subtle);
   }
 }
 

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -116,7 +116,7 @@
     font-weight: var(--weight-semibold);
     font-size: var(--font-xs);
     text-transform: uppercase;
-    letter-spacing: 0.02em;
+    letter-spacing: var(--tracking-wide);
 
     // Column resize handle, pinned inside the cell's right edge so the next
     // sticky <th>'s stacking context can't paint over it (the reason the
@@ -209,7 +209,7 @@
 
   &.active {
     color: var(--text-primary);
-    border-bottom-color: var(--color-accent);
+    border-bottom-color: var(--accent);
     font-weight: var(--weight-semibold);
   }
 }

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
@@ -70,7 +70,7 @@
   }
 
   .correct {
-    color: var(--color-accent, var(--text-primary));
+    color: var(--accent, var(--text-primary));
     font-weight: var(--weight-semibold);
   }
 }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -15,7 +15,7 @@
   flex-direction: column;
   flex-shrink: 0;
   width: 140px;
-  border-right: 1px solid var(--border-color);
+  border-right: 1px solid var(--border);
   padding: var(--space-xs) 0;
 }
 
@@ -36,13 +36,13 @@
 
   &:hover {
     color: var(--text-primary);
-    background: var(--bg-secondary);
+    background: var(--bg-subtle);
   }
 
   &--active {
     color: var(--text-primary);
-    background: var(--bg-secondary);
-    border-left-color: var(--accent-color);
+    background: var(--bg-subtle);
+    border-left-color: var(--accent);
   }
 }
 
@@ -146,7 +146,7 @@
   // contextual divider styling.
   h4 {
     margin: 0;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border);
     padding-bottom: var(--space-xs);
   }
 }
@@ -161,8 +161,8 @@
 // while still sitting under a `.form-label` like every other setting.
 .server-value {
   padding: var(--space-xs) var(--space-sm);
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: var(--font-md);
@@ -186,8 +186,8 @@
 .server-list {
   margin: 0;
   padding: var(--space-xs) var(--space-sm) var(--space-xs) var(--space-xl);
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
   border-radius: var(--radius-md);
   font-size: var(--font-md);
   display: flex;

--- a/frontend/src/app/components/offline-banner/offline-banner.component.scss
+++ b/frontend/src/app/components/offline-banner/offline-banner.component.scss
@@ -10,8 +10,8 @@
   max-width: min(560px, calc(100vw - 24px));
   padding: var(--space-md) var(--space-lg);
   background: var(--bg-panel);
-  border: 1px solid var(--error);
-  border-left: 4px solid var(--error);
+  border: 1px solid var(--color-bad);
+  border-left: 4px solid var(--color-bad);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
   color: var(--text-primary);
@@ -29,7 +29,7 @@
   flex: 0 0 18px;
   width: 18px;
   height: 18px;
-  color: var(--error);
+  color: var(--color-bad);
 }
 
 .offline-banner__text {

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.scss
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.scss
@@ -16,7 +16,7 @@
 .train-context-label {
   font-size: var(--font-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-wide);
   color: var(--text-muted);
   display: block;
   line-height: 1;

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.scss
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.scss
@@ -49,7 +49,7 @@
 
 h3 {
   font-size: var(--font-sm);
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-wide);
   margin: 0;
   flex-shrink: 0;
   display: flex;

--- a/frontend/src/app/components/toast-container/toast-container.component.scss
+++ b/frontend/src/app/components/toast-container/toast-container.component.scss
@@ -31,7 +31,7 @@
 
   &:hover {
     color: var(--text-primary);
-    border-color: var(--error);
+    border-color: var(--color-bad);
     background: var(--bad-bg);
   }
 }
@@ -41,8 +41,8 @@
   min-width: min(420px, calc(100vw - 24px));
   max-width: min(720px, calc(100vw - 24px));
   background: var(--bg-panel);
-  border: 1px solid var(--error);
-  border-left: 4px solid var(--error);
+  border: 1px solid var(--color-bad);
+  border-left: 4px solid var(--color-bad);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
   color: var(--text-primary);
@@ -79,7 +79,7 @@
   flex: 0 0 18px;
   width: 18px;
   height: 18px;
-  color: var(--error);
+  color: var(--color-bad);
   margin-top: 1px;
 }
 
@@ -120,7 +120,7 @@
 
   &:hover {
     background: var(--bad-bg);
-    border-color: var(--error);
+    border-color: var(--color-bad);
   }
 }
 

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -522,9 +522,9 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   display: flex;
   gap: 0;
   margin-bottom: 0;
-  background: var(--bg-secondary);
+  background: var(--bg-subtle);
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border);
   border-bottom: none;
   padding: var(--space-xs) var(--space-xs) 0;
 }
@@ -551,16 +551,16 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 
   &--active {
     color: var(--text-primary);
-    background: var(--bg-primary);
-    border-bottom-color: var(--accent-color);
+    background: var(--bg-panel);
+    border-bottom-color: var(--accent);
   }
 }
 
 .view-tab-content {
   padding: var(--space-lg);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border);
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);
-  background: var(--bg-primary);
+  background: var(--bg-panel);
 }
 
 // --- Scrollbars ---

--- a/frontend/src/scss/_data-table.scss
+++ b/frontend/src/scss/_data-table.scss
@@ -92,7 +92,7 @@
     font-weight: var(--weight-medium);
     font-size: var(--font-xs);
     text-transform: uppercase;
-    letter-spacing: 0.03em;
+    letter-spacing: var(--tracking-wide);
     user-select: none;
 
     // Headers (other than name) are draggable for reordering. The text itself

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -127,7 +127,7 @@
     font-weight: var(--weight-medium);
     font-size: var(--font-xs);
     text-transform: uppercase;
-    letter-spacing: 0.03em;
+    letter-spacing: var(--tracking-wide);
     user-select: none;
 
     &[draggable='true'] { cursor: grab; &:active { cursor: grabbing; } }

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -29,6 +29,12 @@
   --font-2xl: 1.25rem;    // 20px
   --font-3xl: 1.5rem;     // 24px
 
+  // Letter-spacing (tracking). One canonical "wide" value for the uppercase
+  // micro-labels (section headers, table headers, tier chips) that pepper the
+  // UI - a rendered audit found a dozen hand-picked values (0.02-0.06em, plus
+  // raw 0.5px) all doing the same job. em-based so it tracks the label's font.
+  --tracking-wide: 0.05em;
+
   // Border radius scale
   --radius-sm: 3px;
   --radius-md: 4px;
@@ -165,13 +171,7 @@
   // to swap per theme the way --btn-filled-text does for accent-fill buttons.
   --badge-text-dark: #1a1a2e;
 
-  // Aliases used by component SCSS files
-  --border-color: var(--border);
-  --bg-secondary: var(--bg-subtle);
-  --bg-primary: var(--bg-panel);
-  --accent-color: var(--accent);
-  --color-accent: var(--accent);
-  --error: var(--color-bad);
+  // Error-state aliases used by component SCSS files
   --error-text: var(--color-bad);
   --error-border: var(--border-secondary);
   --error-bg: var(--bad-bg);
@@ -257,13 +257,7 @@
   --warning-bg: rgba(184, 121, 0, 0.12);
   --warning-border: rgba(184, 121, 0, 0.35);
 
-  // Aliases
-  --border-color: var(--border);
-  --bg-secondary: var(--bg-subtle);
-  --bg-primary: var(--bg-panel);
-  --accent-color: var(--accent);
-  --color-accent: var(--accent);
-  --error: var(--color-bad);
+  // Error-state aliases
   --error-text: var(--color-bad);
   --error-border: #e57373;
   --error-bg: var(--bad-bg);
@@ -331,13 +325,7 @@
   --warning-bg: rgba(255, 255, 0, 0.15);
   --warning-border: #ffff00;
 
-  // Aliases
-  --border-color: var(--border);
-  --bg-secondary: var(--bg-subtle);
-  --bg-primary: var(--bg-panel);
-  --accent-color: var(--accent);
-  --color-accent: var(--accent);
-  --error: var(--color-bad);
+  // Error-state aliases
   --error-text: var(--color-bad);
   --error-border: #ff4444;
   --error-bg: var(--bad-bg);


### PR DESCRIPTION
Ships the **Core + tracking** slice of the "Consolidate design tokens and extend the style scanner" item in `docs/plans/ui-style-polish.md`.

## Alias consolidation
Codemodded the six alias tokens onto their canonical names and deleted the aliases from all three theme blocks in `_variables.scss`:

| alias | canonical |
|---|---|
| `--border-color` | `--border` |
| `--bg-secondary` | `--bg-subtle` |
| `--bg-primary` | `--bg-panel` |
| `--accent-color` | `--accent` |
| `--color-accent` | `--accent` |
| `--error` | `--color-bad` |

This covers fallback forms (e.g. `var(--bg-primary, var(--bg-subtle))`) and the runtime `themeColor('--accent-color')` reads in `browse-canvas` / `browse-minimap` that would otherwise silently fall back to a hard-coded color once the alias was gone. The `--error-*` sibling tokens (`--error-text`, `--error-border`, `--error-bg`) are distinct and kept.

## `--tracking-wide` token
Added a canonical `--tracking-wide: 0.05em` letter-spacing token and rolled it onto the uppercase / micro-label sites that previously hand-picked values between `0.02em` and `0.06em` (plus raw `0.5px`). The non-uppercase `.folded-note` body text and a `letter-spacing: inherit` were left alone.

## Style-scanner checks
Extended `.claude/scripts/style-check.py` with two objective, browser-free checks:

- **Broken `var()`** — a `var(--x)` with no fallback whose `--x` is defined nowhere (SCSS tree or template/TS style binding). Catches an invalid/empty render the Angular build won't. Correctly ignores fallback forms like the intentional `var(--accent-highlight-hover-bg, var(--accent-highlight-bg))` extension hooks.
- **Deleted alias** — any use of the six removed aliases, *including behind a `var()` fallback*, so a resurrection can't slip in.

Both are paren-aware (handle nested `var()` fallbacks) and comment-stripped (so doc-comment prose like `var(--space-*)` doesn't false-positive). Verified they fire on injected regressions and are clean on the current tree. Updated the style-check skill doc table accordingly.

## Verification
`./run-tests.sh frontend` green: Angular `build:prod` OK, `npm audit` clean, **1154 Vitest tests passed**; ruff / codespell / deptry / pip-audit / pyright all clean.

The remaining sub-parts of this plan item (decorative-dim opacity token, canvas-overlay `--z-*` token, duration/radii rounding, shadow/tile-tint consolidation) stay tracked in `docs/plans/ui-style-polish.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)