### PR TITLE
Accessibility foundation sweep

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -154,22 +154,6 @@ surface. When you ship it, add the affected shot ids to
 
 <!-- item-sep -->
 
-- **Accessibility foundation sweep** — verified still open: dashboard section
-  titles are `<span class="dashboard-section-title">`, not headings
-  (`dashboard.component.html:6,167`; only the login screen has an `<h1>`);
-  `vt-dataset-card`/`vt-detector-card` use element selectors
-  (`dataset-card.component.ts:19`) rendered `display: table-row`, which breaks
-  table semantics; sortable `<th>` headers have no `aria-sort` and no keyboard
-  path; radio groups lack `<fieldset>`/`<legend>`; settings-modal `<label>`s
-  lack `for=` associations; some dashboard "+" buttons are `title`-only; and
-  the Find wait message has no `aria-live`. **Fix:** promote section titles to
-  real headings; switch the cards to attribute selectors
-  (`selector: 'tr[vt-dataset-card]'`); add `aria-sort` + keyboard sort;
-  add fieldsets/legends and `for=` associations; add `aria-label` on the "+"
-  buttons and `aria-live` on the Find wait region. **Files:** the listed
-  templates/components. (The three deleted focus outlines were restored in the
-  2026-07-09 report's Phase 1 — exclude those.)
-
 <!-- item-sep -->
 
 - **Copy-style guide + sweep** — microcopy drifts three ways: ellipsis is

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -3,7 +3,7 @@
   <div class="dashboard-section-wrap">
   <div class="dashboard-section">
     <div class="dashboard-section-header">
-      <span class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="cubes" [size]="18"></vt-icon> Datasets</span>
+      <h2 class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="cubes" [size]="18"></vt-icon> Datasets</h2>
       <div class="dashboard-section-actions">
         <button class="side-action-btn" (click)="combineSelectedDatasets()" [disabled]="isContextSwitching || !combineSelectedDatasetsEnabled" [title]="combineSelectedDatasetsHint" aria-label="Combine selected datasets">
           <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
@@ -24,7 +24,7 @@
         <span class="section-actions-sep" aria-hidden="true"></span>
         <button class="btn btn--primary btn--sm"
           [disabled]="isContextSwitching"
-          (click)="openImporterModal()" title="Import a new dataset"><span class="plus-icon"
+          (click)="openImporterModal()" title="Import a new dataset" aria-label="Import a new dataset"><span class="plus-icon" aria-hidden="true"
             [class.plus-open]="importerModalOpen"
             [class.plus-close]="importerClosing()"
             (animationend)="onImporterAnimationEnd()">+</span></button>
@@ -49,7 +49,7 @@
         <table class="dash-table" [class.table-fixed]="datasetCols.tableFixed" [class.actions-has-load]="anyDatasetUnloaded">
           <thead>
             <tr>
-              <th class="select-col" data-col="select" [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths['select'] : null">
+              <th scope="col" class="select-col" data-col="select" [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths['select'] : null">
                 <button class="select-checkbox header-checkbox" (click)="toggleAllDatasets()" [disabled]="isContextSwitching || datasets.length === 0" [title]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all datasets'" [attr.aria-label]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="datasetSelectionState === 'all' ? 'true' : datasetSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
                   @switch (datasetSelectionState) {
                     @case ('all') {
@@ -72,17 +72,21 @@
                   }
                 </button>
               </th>
-              <th (click)="datasetCols.sortBy('name')" class="sortable name-col" title="Dataset display name (click to sort)" data-col="name" [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths['name'] : null">Name<span class="sort-indicator" [class.active]="datasetCols.isSortActive('name')">{{ datasetCols.sortIndicator('name') }}</span></th>
+              <th (click)="datasetCols.sortBy('name')" (keydown)="onDatasetHeaderKeydown($event, 'name')" tabindex="0" scope="col" [attr.aria-sort]="datasetCols.ariaSort('name')" class="sortable name-col" title="Dataset display name (click to sort)" data-col="name" [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths['name'] : null">Name<span class="sort-indicator" [class.active]="datasetCols.isSortActive('name')">{{ datasetCols.sortIndicator('name') }}</span></th>
               @for (col of visibleDatasetColumns; track col) {
                 <th
+                  scope="col"
                   [class.sortable]="datasetCols.meta(col).sortable"
                   [class.col-drop-target]="datasetCols.isDropTarget(col)"
                   [class.col-dragging]="datasetCols.isDragging(col)"
                   [attr.data-col]="col"
+                  [attr.tabindex]="datasetCols.meta(col).sortable ? 0 : null"
+                  [attr.aria-sort]="datasetCols.meta(col).sortable ? datasetCols.ariaSort(col) : null"
                   [title]="datasetCols.meta(col).title"
                   [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths[col] : null"
                   draggable="true"
                   (click)="onDatasetHeaderClick(col)"
+                  (keydown)="onDatasetHeaderKeydown($event, col)"
                   (dragstart)="datasetCols.onColDragStart($event, col)"
                   (dragover)="datasetCols.onColDragOver($event, col)"
                   (dragleave)="datasetCols.onColDragLeave($event, col)"
@@ -92,7 +96,7 @@
               }
               <!-- Actions is a fixed, content-width column (see --actions-col-width):
                    no width binding, no resize handle — it stays pinned narrow. -->
-              <th class="actions-col" data-col="actions" [title]="datasetCols.meta('actions').title">{{ datasetCols.meta('actions').label }}</th>
+              <th scope="col" class="actions-col" data-col="actions" [title]="datasetCols.meta('actions').title">{{ datasetCols.meta('actions').label }}</th>
             </tr>
           </thead>
           <tbody>
@@ -131,7 +135,7 @@
               </tr>
             }
             @for (dataset of sortedDatasets; track dataset.id) {
-              <vt-dataset-card
+              <tr vt-dataset-card
                 [dataset]="dataset"
                 [currentUser]="currentUser()"
                 [isDefaultLogin]="isDefaultLogin()"
@@ -151,7 +155,7 @@
                 (security)="editDatasetSecurity(dataset)"
                 (cancelTask)="onCancelDatasetTask($event)"
                 (dismissTask)="onDismissDatasetTask($event)"
-              />
+              ></tr>
             }
           </tbody>
         </table>
@@ -164,7 +168,7 @@
   <div class="dashboard-section-wrap">
   <div class="dashboard-section">
     <div class="dashboard-section-header">
-      <span class="dashboard-section-title" title="Trained detectors for scoring and finding media"><vt-icon type="robot" [size]="18"></vt-icon> Detectors</span>
+      <h2 class="dashboard-section-title" title="Trained detectors for scoring and finding media"><vt-icon type="robot" [size]="18"></vt-icon> Detectors</h2>
       <div class="dashboard-section-actions">
         <button class="side-action-btn" (click)="openCombineDetectorsModal()" [disabled]="isContextSwitching || !combineSelectedDetectorsEnabled" [title]="combineSelectedDetectorsHint" aria-label="Combine selected detectors">
           <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
@@ -185,7 +189,7 @@
         <span class="section-actions-sep" aria-hidden="true"></span>
         <button class="btn btn--primary btn--sm"
           [disabled]="isContextSwitching"
-          (click)="openNewDetectorModal()" title="Create a new detector"><span class="plus-icon"
+          (click)="openNewDetectorModal()" title="Create a new detector" aria-label="Create a new detector"><span class="plus-icon" aria-hidden="true"
             [class.plus-open]="newDetectorModalOpen"
             [class.plus-close]="newDetectorClosing()"
             (animationend)="onNewDetectorAnimationEnd()">+</span></button>
@@ -210,7 +214,7 @@
         <table class="dash-table" [class.table-fixed]="detectorCols.tableFixed" [class.actions-has-load]="anyDetectorUnloaded">
           <thead>
             <tr>
-              <th class="select-col" data-col="select" [style.width.%]="detectorCols.tableFixed ? detectorCols.colWidths['select'] : null">
+              <th scope="col" class="select-col" data-col="select" [style.width.%]="detectorCols.tableFixed ? detectorCols.colWidths['select'] : null">
                 <button class="select-checkbox header-checkbox" (click)="toggleAllDetectors()" [disabled]="isContextSwitching || detectors.length === 0" [title]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all detectors'" [attr.aria-label]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="detectorSelectionState === 'all' ? 'true' : detectorSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
                   @switch (detectorSelectionState) {
                     @case ('all') {
@@ -233,17 +237,21 @@
                   }
                 </button>
               </th>
-              <th (click)="detectorCols.sortBy('name')" class="sortable name-col" title="Detector display name (click to sort)" data-col="name" [style.width.%]="detectorCols.tableFixed ? detectorCols.colWidths['name'] : null">Name<span class="sort-indicator" [class.active]="detectorCols.isSortActive('name')">{{ detectorCols.sortIndicator('name') }}</span></th>
+              <th (click)="detectorCols.sortBy('name')" (keydown)="onDetectorHeaderKeydown($event, 'name')" tabindex="0" scope="col" [attr.aria-sort]="detectorCols.ariaSort('name')" class="sortable name-col" title="Detector display name (click to sort)" data-col="name" [style.width.%]="detectorCols.tableFixed ? detectorCols.colWidths['name'] : null">Name<span class="sort-indicator" [class.active]="detectorCols.isSortActive('name')">{{ detectorCols.sortIndicator('name') }}</span></th>
               @for (col of visibleDetectorColumns; track col) {
                 <th
+                  scope="col"
                   [class.sortable]="detectorCols.meta(col).sortable"
                   [class.col-drop-target]="detectorCols.isDropTarget(col)"
                   [class.col-dragging]="detectorCols.isDragging(col)"
                   [attr.data-col]="col"
+                  [attr.tabindex]="detectorCols.meta(col).sortable ? 0 : null"
+                  [attr.aria-sort]="detectorCols.meta(col).sortable ? detectorCols.ariaSort(col) : null"
                   [title]="detectorCols.meta(col).title"
                   [style.width.%]="detectorCols.tableFixed ? detectorCols.colWidths[col] : null"
                   draggable="true"
                   (click)="onDetectorHeaderClick(col)"
+                  (keydown)="onDetectorHeaderKeydown($event, col)"
                   (dragstart)="detectorCols.onColDragStart($event, col)"
                   (dragover)="detectorCols.onColDragOver($event, col)"
                   (dragleave)="detectorCols.onColDragLeave($event, col)"
@@ -253,12 +261,12 @@
               }
               <!-- Actions is a fixed, content-width column (see --actions-col-width):
                    no width binding, no resize handle — it stays pinned narrow. -->
-              <th class="actions-col" data-col="actions" [title]="detectorCols.meta('actions').title">{{ detectorCols.meta('actions').label }}</th>
+              <th scope="col" class="actions-col" data-col="actions" [title]="detectorCols.meta('actions').title">{{ detectorCols.meta('actions').label }}</th>
             </tr>
           </thead>
           <tbody>
             @for (detector of sortedDetectors; track detector.id) {
-              <vt-detector-card
+              <tr vt-detector-card
                 [detector]="detector"
                 [currentUser]="currentUser()"
                 [isDefaultLogin]="isDefaultLogin()"
@@ -281,7 +289,7 @@
                 (security)="editDetectorSecurity(detector)"
                 (cancelTask)="loadingTasksSvc.cancelDetectorLoadingTask($event)"
                 (dismissTask)="loadingTasksSvc.dismissDetectorLoadingTask($event)"
-              />
+              ></tr>
             }
           </tbody>
         </table>

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -118,6 +118,7 @@
 }
 
 .dashboard-section-title {
+  margin: 0;  // neutralize the UA <h2> block margins; this is a real heading now
   font-size: var(--font-xl);
   font-weight: var(--weight-semibold);
   color: var(--text-primary);

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -177,6 +177,22 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
   }
 
+  /** Keyboard-activate a sortable header. Enter/Space sort the column; Space
+   *  also gets its default page-scroll suppressed. */
+  onDatasetHeaderKeydown(event: KeyboardEvent, col: string): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.onDatasetHeaderClick(col);
+    }
+  }
+
+  onDetectorHeaderKeydown(event: KeyboardEvent, col: string): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.onDetectorHeaderClick(col);
+    }
+  }
+
   private destroy$ = new Subject<void>();
   private findPolling$ = new Subject<void>();
   private knownDatasetIds = new Set<string>();

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -1,5 +1,4 @@
 :host {
-  display: table-row;
   cursor: pointer;
   transition: background var(--transition-fast);
 

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -16,7 +16,7 @@ import { buildDatasetCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } fro
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  selector: 'vt-dataset-card',
+  selector: 'tr[vt-dataset-card]',
   standalone: true,
   imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent],
   templateUrl: './dataset-card.component.html',

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -1,5 +1,4 @@
 :host {
-  display: table-row;
   cursor: pointer;
   transition: background var(--transition-fast);
 

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -15,7 +15,7 @@ import { buildDetectorCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } fr
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  selector: 'vt-detector-card',
+  selector: 'tr[vt-detector-card]',
   standalone: true,
   imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent],
   templateUrl: './detector-card.component.html',

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -41,7 +41,7 @@
   ></div>
   <div class="panel-center">
     @if (sortState.sortBusy) {
-      <div class="find-wait-overlay">
+      <div class="find-wait-overlay" role="status" aria-live="polite">
         <div class="find-wait-content">
           <p class="find-wait-message">Please wait: scoring dataset with detector…</p>
           <vt-progress-bar

--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.html
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.html
@@ -1,5 +1,5 @@
-<div class="select-mode-group">
-  <span class="sort-label" title="Choose which unlabeled item to present next for labeling.">Select:</span>
+<div class="select-mode-group" role="radiogroup" aria-labelledby="select-mode-label">
+  <span class="sort-label" id="select-mode-label" title="Choose which unlabeled item to present next for labeling.">Select:</span>
   <label class="sort-radio" [class.active]="selectMode === 'top'" title="Pick the highest-ranked unlabeled item. Best for quickly finding strong matches.">
     <input
       type="radio"

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
@@ -1,6 +1,6 @@
 <div class="sort-bar">
-  <div class="sort-mode-group">
-    <span class="sort-label" title="Choose how items are ranked. Text uses a search query, Learned trains on your votes, Load applies a saved detector.">Sort:</span>
+  <div class="sort-mode-group" role="radiogroup" aria-labelledby="sort-mode-label">
+    <span class="sort-label" id="sort-mode-label" title="Choose how items are ranked. Text uses a search query, Learned trains on your votes, Load applies a saved detector.">Sort:</span>
     <label class="sort-radio" [class.active]="sortMode === 'text'" [title]="textDisabled ? 'This dataset’s embedder does not support text queries.' : 'Rank items by how well they match a text description you type in.'">
       <input
         type="radio"

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -62,7 +62,7 @@
 
   <!-- Export controls -->
   <div class="export-controls">
-    <div class="export-sides">
+    <div class="export-sides" role="radiogroup" aria-label="Filter which predictions to show">
       <label title="Show only items predicted as good"><input type="radio" name="sides" value="good" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Good</label>
       <label title="Show only items predicted as bad"><input type="radio" name="sides" value="bad" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Bad</label>
       <label title="Show both good and bad predictions"><input type="radio" name="sides" value="both" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Both</label>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -1,8 +1,8 @@
 <vt-modal [title]="modalTitle" [open]="true" (closed)="close()">
   <!-- Category Filter -->
   <div class="export-section">
-    <h3 title="Filter which labeled items to include in the export">Categories</h3>
-    <div class="delimiter-row">
+    <h3 id="export-categories-label" title="Filter which labeled items to include in the export">Categories</h3>
+    <div class="delimiter-row" role="radiogroup" aria-labelledby="export-categories-label">
       <label class="delimiter-option" title="Include both good and bad labeled items">
         <input type="radio" name="labelFilter" value="both" [(ngModel)]="labelFilter" (ngModelChange)="onLabelFilterChange()" />
         All

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -75,8 +75,8 @@
         @if (activeSettingsTab() === 'appearance') {
           <h3>Appearance</h3>
           <div class="form-group">
-            <label class="form-label" title="Color theme for the application interface">Theme</label>
-            <select class="form-select" [ngModel]="settings().theme" (ngModelChange)="onThemeChange($event)" title="Choose the visual color scheme" aria-label="Theme">
+            <label class="form-label" for="setting-theme" title="Color theme for the application interface">Theme</label>
+            <select id="setting-theme" class="form-select" [ngModel]="settings().theme" (ngModelChange)="onThemeChange($event)" title="Choose the visual color scheme">
               <option value="system">System</option>
               <option value="dark">Dark</option>
               <option value="light">Light</option>
@@ -84,8 +84,8 @@
             </select>
           </div>
           <div class="form-group">
-            <label class="form-label" title="Choose whether decorative motion plays across the whole app">Show Animations<vt-field-hint-icon hint="Controls decorative motion across the app. “Show” forces it on, “Hide” turns it off, and “OS Setting” follows your system’s reduce-motion preference."></vt-field-hint-icon></label>
-            <select class="form-select" [ngModel]="settings().show_animations" (ngModelChange)="onAnimationModeChange($event)" title="Choose whether decorative motion plays" aria-label="Show Animations">
+            <label class="form-label" for="setting-animations" title="Choose whether decorative motion plays across the whole app">Show Animations<vt-field-hint-icon hint="Controls decorative motion across the app. “Show” forces it on, “Hide” turns it off, and “OS Setting” follows your system’s reduce-motion preference."></vt-field-hint-icon></label>
+            <select id="setting-animations" class="form-select" [ngModel]="settings().show_animations" (ngModelChange)="onAnimationModeChange($event)" title="Choose whether decorative motion plays">
               <option value="show">Show</option>
               <option value="hide">Hide</option>
               <option value="os">OS Setting</option>
@@ -145,8 +145,8 @@
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="form-label" title="Thumbnail size in the media grid">Grid Icon Size:</label>
-                  <select class="form-select" [ngModel]="getGridIconSize('grid_icon_size_left', activeViewTab())" (ngModelChange)="onGridIconSizeChange('grid_icon_size_left', activeViewTab(), $event)" title="Choose thumbnail size for the grid view" aria-label="Left grid icon size">
+                  <label class="form-label" for="setting-grid-icon-left" title="Thumbnail size in the media grid">Grid Icon Size:</label>
+                  <select id="setting-grid-icon-left" class="form-select" [ngModel]="getGridIconSize('grid_icon_size_left', activeViewTab())" (ngModelChange)="onGridIconSizeChange('grid_icon_size_left', activeViewTab(), $event)" title="Choose thumbnail size for the grid view" aria-label="Left grid icon size">
                     <option value="XS">XS</option>
                     <option value="S">S</option>
                     <option value="M">M</option>
@@ -169,8 +169,8 @@
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="form-label" title="Thumbnail size in the media grid">Grid Icon Size:</label>
-                  <select class="form-select" [ngModel]="getGridIconSize('grid_icon_size_right', activeViewTab())" (ngModelChange)="onGridIconSizeChange('grid_icon_size_right', activeViewTab(), $event)" title="Choose thumbnail size for the grid view" aria-label="Right grid icon size">
+                  <label class="form-label" for="setting-grid-icon-right" title="Thumbnail size in the media grid">Grid Icon Size:</label>
+                  <select id="setting-grid-icon-right" class="form-select" [ngModel]="getGridIconSize('grid_icon_size_right', activeViewTab())" (ngModelChange)="onGridIconSizeChange('grid_icon_size_right', activeViewTab(), $event)" title="Choose thumbnail size for the grid view" aria-label="Right grid icon size">
                     <option value="XS">XS</option>
                     <option value="S">S</option>
                     <option value="M">M</option>
@@ -195,12 +195,12 @@
             Safe thresholds
           </label>
           <div class="form-group">
-            <label class="form-label" title="Number of items to check when tuning the detector's cutoff after training">Tuning count</label>
-            <input type="number" class="form-input" [ngModel]="settings().calibrate_count" (ngModelChange)="onNumberChange('calibrate_count', $event)" min="0" title="Number of items to check when tuning the cutoff" />
+            <label class="form-label" for="setting-calibrate-count" title="Number of items to check when tuning the detector's cutoff after training">Tuning count</label>
+            <input id="setting-calibrate-count" type="number" class="form-input" [ngModel]="settings().calibrate_count" (ngModelChange)="onNumberChange('calibrate_count', $event)" min="0" title="Number of items to check when tuning the cutoff" />
           </div>
           <div class="form-group">
-            <label class="form-label" title="Fraction of labeled items to set aside for checking (0 = none, 1 = all)">Tuning fraction</label>
-            <input type="number" class="form-input" [ngModel]="settings().calibration_fraction" (ngModelChange)="onNumberChange('calibration_fraction', $event)" min="0" max="1" step="0.05" title="Fraction of labeled items to set aside for checking (0.0 to 1.0)" />
+            <label class="form-label" for="setting-calibration-fraction" title="Fraction of labeled items to set aside for checking (0 = none, 1 = all)">Tuning fraction</label>
+            <input id="setting-calibration-fraction" type="number" class="form-input" [ngModel]="settings().calibration_fraction" (ngModelChange)="onNumberChange('calibration_fraction', $event)" min="0" max="1" step="0.05" title="Fraction of labeled items to set aside for checking (0.0 to 1.0)" />
           </div>
         }
 
@@ -208,10 +208,11 @@
         @if (activeSettingsTab() === 'imports') {
           <h3>Import Defaults<vt-field-hint-icon hint="Per-media-type defaults that auto-fill the Add Dataset modal when you start a matching import."></vt-field-hint-icon></h3>
           <div class="form-group" title="Streamline the UI for a single media type. Importer and detector flows will hide their media-type pickers and lock to this type; converters that produce other types are filtered out.">
-            <label class="form-label">Solo media type@if (soloMediaTypeNote) {
+            <label class="form-label" for="setting-solo-media-type">Solo media type@if (soloMediaTypeNote) {
               <vt-field-hint-icon [hint]="soloMediaTypeNote"></vt-field-hint-icon>
             }</label>
             <select
+              id="setting-solo-media-type"
               class="form-select"
               [ngModel]="soloMediaTypeSelectValue"
               (ngModelChange)="onSoloMediaTypeChange($event)"
@@ -248,20 +249,20 @@
             Hide autopilot panel
           </label>
           <div class="form-group">
-            <label class="form-label" title="Number of Good votes needed before autopilot moves past the initial good-examples phase"># Good to start</label>
-            <input type="number" class="form-input" [ngModel]="settings().autopilot_top_greens" (ngModelChange)="onNumberChange('autopilot_top_greens', $event)" min="0" title="Good votes required to advance past the first phase" />
+            <label class="form-label" for="setting-autopilot-greens" title="Number of Good votes needed before autopilot moves past the initial good-examples phase"># Good to start</label>
+            <input id="setting-autopilot-greens" type="number" class="form-input" [ngModel]="settings().autopilot_top_greens" (ngModelChange)="onNumberChange('autopilot_top_greens', $event)" min="0" title="Good votes required to advance past the first phase" />
           </div>
           <div class="form-group">
-            <label class="form-label" title="Number of Bad votes needed before autopilot moves past the bad-examples phase"># Bad to start</label>
-            <input type="number" class="form-input" [ngModel]="settings().autopilot_hard_reds" (ngModelChange)="onNumberChange('autopilot_hard_reds', $event)" min="0" title="Bad votes required to advance past the second phase" />
+            <label class="form-label" for="setting-autopilot-reds" title="Number of Bad votes needed before autopilot moves past the bad-examples phase"># Bad to start</label>
+            <input id="setting-autopilot-reds" type="number" class="form-input" [ngModel]="settings().autopilot_hard_reds" (ngModelChange)="onNumberChange('autopilot_hard_reds', $event)" min="0" title="Bad votes required to advance past the second phase" />
           </div>
           <div class="form-group">
-            <label class="form-label" title="How many new votes to collect before autopilot triggers a re-sort (retrain + re-rank)"># Start to re-sort</label>
-            <input type="number" class="form-input" [ngModel]="settings().autopilot_resort_interval" (ngModelChange)="onNumberChange('autopilot_resort_interval', $event)" min="1" title="Votes between automatic re-sorts" />
+            <label class="form-label" for="setting-autopilot-resort" title="How many new votes to collect before autopilot triggers a re-sort (retrain + re-rank)"># Start to re-sort</label>
+            <input id="setting-autopilot-resort" type="number" class="form-input" [ngModel]="settings().autopilot_resort_interval" (ngModelChange)="onNumberChange('autopilot_resort_interval', $event)" min="1" title="Votes between automatic re-sorts" />
           </div>
           <div class="form-group">
-            <label class="form-label" title="Target diversity level for the exploration phase. Higher values mean autopilot will push you to sample from more distinct regions of the dataset.">Goal Diversity</label>
-            <input type="number" class="form-input" [ngModel]="settings().autopilot_goal_diversity" (ngModelChange)="onNumberChange('autopilot_goal_diversity', $event)" min="1" title="Target diversity level for the exploration phase" />
+            <label class="form-label" for="setting-autopilot-diversity" title="Target diversity level for the exploration phase. Higher values mean autopilot will push you to sample from more distinct regions of the dataset.">Goal Diversity</label>
+            <input id="setting-autopilot-diversity" type="number" class="form-input" [ngModel]="settings().autopilot_goal_diversity" (ngModelChange)="onNumberChange('autopilot_goal_diversity', $event)" min="1" title="Target diversity level for the exploration phase" />
           </div>
 
         }
@@ -308,13 +309,13 @@
                 </div>
               </div>
               <div class="form-group">
-                <label class="form-label" title="Colors the density heatmap. Auto follows your theme: blue (Ocean) in light mode, red→yellow (Heat) in dark mode.">Colormap<vt-field-hint-icon [hint]="browseTabUsesThumbnails(activeBrowseTab()) ? 'Thumbnail datasets (image, video) always use grayscale.' : 'Darker bins mean more items in light mode; brighter bins mean more in dark mode.'"></vt-field-hint-icon></label>
+                <label class="form-label" for="setting-browse-colormap" title="Colors the density heatmap. Auto follows your theme: blue (Ocean) in light mode, red→yellow (Heat) in dark mode.">Colormap<vt-field-hint-icon [hint]="browseTabUsesThumbnails(activeBrowseTab()) ? 'Thumbnail datasets (image, video) always use grayscale.' : 'Darker bins mean more items in light mode; brighter bins mean more in dark mode.'"></vt-field-hint-icon></label>
                 @if (browseTabUsesThumbnails(activeBrowseTab())) {
-                  <select class="form-select" disabled aria-label="Browser colormap" title="Thumbnail datasets always use grayscale">
+                  <select id="setting-browse-colormap" class="form-select" disabled aria-label="Browser colormap" title="Thumbnail datasets always use grayscale">
                     <option value="gray" selected>Grayscale</option>
                   </select>
                 } @else {
-                  <select class="form-select" [ngModel]="getBrowseColormap(activeBrowseTab())" (ngModelChange)="onBrowseColormapChange(activeBrowseTab(), $event)" aria-label="Browser colormap">
+                  <select id="setting-browse-colormap" class="form-select" [ngModel]="getBrowseColormap(activeBrowseTab())" (ngModelChange)="onBrowseColormapChange(activeBrowseTab(), $event)" aria-label="Browser colormap">
                     <option value="auto">Auto (match theme)</option>
                     <option value="heat">Heat (red → yellow)</option>
                     <option value="ocean">Ocean (blue)</option>
@@ -323,8 +324,8 @@
                 }
               </div>
               <div class="form-group">
-                <label class="form-label" title="On-screen size of the map cells">Cell size</label>
-                <select class="form-select" [ngModel]="getBrowseIconSize(activeBrowseTab())" (ngModelChange)="onBrowseIconSizeChange(activeBrowseTab(), $event)" aria-label="Browser cell size">
+                <label class="form-label" for="setting-browse-cell-size" title="On-screen size of the map cells">Cell size</label>
+                <select id="setting-browse-cell-size" class="form-select" [ngModel]="getBrowseIconSize(activeBrowseTab())" (ngModelChange)="onBrowseIconSizeChange(activeBrowseTab(), $event)" aria-label="Browser cell size">
                   <option value="XS">XS</option>
                   <option value="S">S</option>
                   <option value="M">M</option>
@@ -337,8 +338,9 @@
                 </select>
               </div>
               <div class="form-group">
-                <label class="form-label" title="Width in pixels of the colored border drawn around stacked (pile) thumbnails">Thumbnail border<vt-field-hint-icon hint="Colored band around stacked thumbnail tiles (image, video); its color shows how many items are piled there. Set to 0 to hide."></vt-field-hint-icon></label>
+                <label class="form-label" for="setting-browse-thumb-border" title="Width in pixels of the colored border drawn around stacked (pile) thumbnails">Thumbnail border<vt-field-hint-icon hint="Colored band around stacked thumbnail tiles (image, video); its color shows how many items are piled there. Set to 0 to hide."></vt-field-hint-icon></label>
                 <input
+                  id="setting-browse-thumb-border"
                   class="form-input"
                   type="number"
                   min="0"
@@ -349,8 +351,8 @@
                   aria-label="Browser thumbnail border width" />
               </div>
               <div class="form-group">
-                <label class="form-label" title="Thumbnail size in the bin popup's grid">Popup thumbnail size<vt-field-hint-icon hint="Thumbnail size in the right-click bin popup. Changing it while browsing is remembered here."></vt-field-hint-icon></label>
-                <select class="form-select" [ngModel]="getPopupGridIconSize(activeBrowseTab())" (ngModelChange)="onPopupGridIconSizeChange(activeBrowseTab(), $event)" aria-label="Bin popup thumbnail size">
+                <label class="form-label" for="setting-browse-popup-size" title="Thumbnail size in the bin popup's grid">Popup thumbnail size<vt-field-hint-icon hint="Thumbnail size in the right-click bin popup. Changing it while browsing is remembered here."></vt-field-hint-icon></label>
+                <select id="setting-browse-popup-size" class="form-select" [ngModel]="getPopupGridIconSize(activeBrowseTab())" (ngModelChange)="onPopupGridIconSizeChange(activeBrowseTab(), $event)" aria-label="Bin popup thumbnail size">
                   <option value="XS">XS</option>
                   <option value="S">S</option>
                   <option value="M">M</option>

--- a/frontend/src/app/utils/managed-columns.ts
+++ b/frontend/src/app/utils/managed-columns.ts
@@ -108,6 +108,13 @@ export class ManagedColumns<TCol extends string = string> {
     return this.sortColumn === col;
   }
 
+  /** ARIA `aria-sort` value for a header cell: the active column reports its
+   *  direction, every other sortable column reports `none`. */
+  ariaSort(col: string): 'ascending' | 'descending' | 'none' {
+    if (this.sortColumn !== col) return 'none';
+    return this.sortAsc ? 'ascending' : 'descending';
+  }
+
   // --- Resize ---
 
   private captureColumnPercentages(tableEl: HTMLTableElement): void {
@@ -212,12 +219,10 @@ export class ManagedColumns<TCol extends string = string> {
     const prevColWidth = ths[colIndex].style.width;
     ths[colIndex].style.width = '0px';
 
-    // `tbody > *` rather than `tbody tr`: dashboard rows are Angular custom
-    // elements (`<vt-dataset-card>`, `<vt-detector-card>`) with `:host {
-    // display: table-row }`, so they participate in table layout but don't
-    // match the `tr` selector. Querying for `tr` returned zero rows, so this
-    // method fell through to the `maxPx = ths[colIndex].offsetWidth` fallback
-    // and the `+ 2` below grew the column by 2px on every click.
+    // `tbody > *` matches every row regardless of kind: dashboard card rows are
+    // real `<tr>` hosts (`tr[vt-dataset-card]` / `tr[vt-detector-card]`
+    // attribute selectors) alongside the plain `<tr>` loading/error rows, so a
+    // child-of-tbody query covers them all without depending on the row's tag.
     let maxPx = 0;
     const rows = tableEl.querySelectorAll('tbody > *');
     rows.forEach((row) => {


### PR DESCRIPTION
Ships the **Accessibility foundation sweep** item from `docs/plans/ui-style-polish.md`. Structural/semantic a11y fixes only — no visual change (the section-title `<h2>` gets `margin: 0`, so it renders identically to the old span).

## What changed

- **Section titles are real headings.** The dashboard Datasets/Detectors titles were `<span class="dashboard-section-title">`; they're now `<h2>` (login was previously the only screen with a heading).
- **Card rows have real table semantics.** `vt-dataset-card` / `vt-detector-card` used element selectors rendered with a `display: table-row` hack, which produced non-`<tr>` children inside `<tbody>` and broke the row/cell relationship for AT. They're now attribute selectors on real rows (`selector: 'tr[vt-dataset-card]'`, used as `<tr vt-dataset-card …>`), and the `display: table-row` workaround is gone. Updated the `managed-columns.ts` auto-fit comment that documented the old custom-element rows.
- **Sortable column headers are keyboard- and screen-reader-operable.** Added `[attr.aria-sort]` (via a new `ManagedColumns.ariaSort()`), `scope="col"`, `tabindex`, and Enter/Space keyboard sorting to the dashboard headers; previously sort was mouse-only with no state exposed.
- **Radio groups are grouped and named.** The Select-mode, Sort-mode, export Categories, and autodetect predictions radios now sit in `role="radiogroup"` containers with accessible names (`aria-labelledby` to the existing visible label, or `aria-label`).
- **Settings-modal labels associate with their controls.** Added `id`/`for=` pairs across the Appearance, Sorting, Import Defaults, Autopilot, and Browser form controls.
- **Icon-only buttons and the Find wait region are announced.** The title-only `+` import / new-detector buttons got `aria-label`s (and their `+` glyph `aria-hidden`); the Find "scoring dataset…" overlay got `role="status"` + `aria-live="polite"`.

## Deviation from the plan wording

The plan suggested `<fieldset>`/`<legend>` for the radio groups. I used `role="radiogroup"` + accessible names instead: it's the WAI-ARIA APG radiogroup pattern, achieves the same grouping/announcement, and guarantees zero visual change on these tightly-styled inline control bars (fieldset/legend carry UA layout quirks I can't verify visually — no Chromium in this environment). The three restored focus outlines called out in the plan were left untouched, as instructed.

## Testing

- `./run-tests.sh` — **ALL 5734 tests passed** (1 skipped), including the frontend `build:prod` and 1154 Vitest unit tests.

No screenshots need reshooting: every change is either invisible (ARIA attributes) or pixel-identical (span→h2 with `margin: 0`).
