### PR TITLE
Fold hand-built inputs onto shared .form-input/.form-select

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -56,8 +56,7 @@ without a browser.
   (#2302); shared picker-card (#2303), data-table (#2304), empty-state (#2305),
   and pane-divider (#2307) primitives; unifying the 3 progress bars (#2306);
   deduping the verbatim `dataset-card`/`detector-card` + `goods-actions` SCSS
-  (#2308); and folding hand-built inputs onto `.form-input`/`.form-select`
-  (#2309). **Fix pattern:** extract a sanctioned shared class into
+  (#2308). **Fix pattern:** extract a sanctioned shared class into
   `_components.scss` / `_picker-shared.scss`, then fold the bespoke copies onto
   it via markup + `@extend`. Ship incrementally (one primitive per PR) to keep
   diffs reviewable. **Files:** `_components.scss`, `_picker-shared.scss`, and

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -62,7 +62,7 @@
                 </label>
                 <input
                   id="docs-phrase-input"
-                  class="docs-phrase-input"
+                  class="docs-phrase-input form-input"
                   type="text"
                   name="phrase"
                   autocomplete="off"

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -253,14 +253,12 @@
   color: var(--text-muted);
 }
 
+// Inherits `.form-input`; overrides only the flex sizing, the tighter
+// inline padding, and the smaller corner radius for this compact row.
 .docs-phrase-input {
   flex: 1;
-  font-size: var(--font-md);
   padding: var(--space-xs) var(--space-md);
   border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  background: var(--bg-subtle);
-  color: inherit;
 }
 
 .docs-phrase-submit {

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -63,7 +63,7 @@
       <label for="bsp-sort-select" class="sr-only">Sort selected items</label>
       <select
         id="bsp-sort-select"
-        class="bsp-sort-select"
+        class="form-select form-select--compact"
         [ngModel]="sortMode"
         (ngModelChange)="onSortChange($event)"
         title="Order selected items by when they were selected, name, or ID">

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -127,15 +127,6 @@
   color: var(--text-dim);
 }
 
-.bsp-sort-select {
-  padding: var(--space-2xs) var(--space-sm);
-  font-size: var(--font-xs);
-  background: var(--bg-surface);
-  color: var(--text-primary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-}
-
 .bsp-view-controls {
   margin-left: auto;
 }

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
@@ -16,7 +16,7 @@
         <span class="name-label">Name</span>
         <input
           type="text"
-          class="name-input"
+          class="name-input form-input"
           [(ngModel)]="name"
           placeholder="Combined dataset name"
           [disabled]="submitting()"

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -33,18 +33,12 @@
   font-weight: var(--weight-semibold);
 }
 
+// Inherits `.form-input`; only the larger type size and the on-surface
+// background (this input sits directly on the modal surface, not on a
+// subtle inset field) differ from the shared primitive.
 .name-input {
-  padding: var(--space-sm) var(--space-md);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
   background: var(--bg-surface);
-  color: var(--text-primary);
   font-size: var(--font-xl);
-
-  &:focus {
-    outline: none;
-    border-color: var(--accent);
-  }
 }
 
 .combine-table {

--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -7,6 +7,7 @@
       <label for="login-username" class="sr-only">Username</label>
       <input
         id="login-username"
+        class="form-input"
         type="text"
         [(ngModel)]="username"
         name="username"

--- a/frontend/src/app/components/login/login.component.scss
+++ b/frontend/src/app/components/login/login.component.scss
@@ -40,23 +40,15 @@ h1 { margin: 0 0 var(--space-xs); }
   gap: var(--space-lg);
 }
 
+// The username field inherits `.form-input` (border, color, focus ring, and
+// placeholder color come from there).  Only the oversized login-card sizing
+// and the panel-toned background differ.
 input {
   padding: var(--space-md) var(--space-lg);
-  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--bg-panel);
-  color: var(--text-primary);
   font-size: var(--font-xl);
-  outline: none;
   transition: border-color var(--transition-base);
-
-  &:focus {
-    border-color: var(--accent);
-  }
-
-  &::placeholder {
-    color: var(--text-placeholder);
-  }
 }
 
 button {

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
@@ -15,7 +15,7 @@
           <input
             #renameInput
             type="text"
-            class="train-rename-input"
+            class="train-rename-input form-input"
             [(ngModel)]="editValue"
             (blur)="finishRename()"
             (keydown)="onKeydown($event)"

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.scss
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.scss
@@ -50,14 +50,14 @@
   }
 }
 
+// Inherits `.form-input`; this is a compact, bold inline rename field, so it
+// overrides the type size/weight, the on-surface background, the tighter
+// radius/padding, and caps its width.
 .train-rename-input {
   font-size: var(--font-sm);
   font-weight: var(--weight-semibold);
-  color: var(--text-primary);
   background: var(--bg-surface);
-  border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   padding: 1px var(--space-xs);
-  width: 100%;
   max-width: 160px;
 }

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
@@ -3,7 +3,7 @@
   <label for="label-sort-select" class="sr-only">Sort labels</label>
   <select
     id="label-sort-select"
-    class="label-sort-select"
+    class="form-select form-select--compact"
     [ngModel]="mode"
     (ngModelChange)="onSortChange($event)"
     title="Order labeled items by time, name, detector confidence, or ID"

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.scss
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.scss
@@ -23,12 +23,3 @@
   white-space: nowrap;
   border: 0;
 }
-
-.label-sort-select {
-  padding: var(--space-2xs) var(--space-sm);
-  font-size: var(--font-xs);
-  background: var(--bg-surface);
-  color: var(--text-primary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-}

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -279,6 +279,17 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   cursor: pointer;
 }
 
+// Compact variant for dense toolbars (the label-sort bar, the browse
+// selection panel).  Same visual treatment as `.form-select`, but sized to
+// its content rather than stretched full-width, with tighter padding and a
+// smaller font so it reads as a toolbar control.
+.form-select--compact {
+  width: auto;
+  padding: var(--space-2xs) var(--space-sm);
+  background: var(--bg-surface);
+  font-size: var(--font-xs);
+}
+
 // Field header label.  Made visually distinct from `.info-text` (instruction
 // body copy) by using the primary text color and a heavier weight, so a
 // label like "Dataset Name" reads as a header above its input rather than


### PR DESCRIPTION
Part of **Promote shared component primitives** in `docs/plans/ui-style-polish.md` — ships the "fold hand-built inputs onto `.form-input`/`.form-select`" primitive.

Several text/select inputs hand-rolled the same border / radius / background / focus styling that the shared `.form-input` / `.form-select` primitives in `frontend/src/scss/_components.scss` already provide. This applies the shared classes in markup and keeps only the genuine per-component deviations, deleting the duplicated rules.

## Changes

- **combine-datasets name field**, **achievements code-phrase input**, **login username**, and the **detector-context-bar inline rename** now carry `.form-input`; their component SCSS keeps only real deviations (larger login/combine type size, compact rename/phrase padding, on-surface backgrounds).
- The **label-sort** and **browse-selection-panel** toolbar selects — which were byte-for-byte duplicates of each other — fold onto `.form-select` plus a new shared **`.form-select--compact`** modifier that restores their content-sized, tighter-padded toolbar footprint (`.form-select` is full-width via `@extend .form-input`, so the modifier sets `width: auto`).

Appearance is preserved: the only rendered changes are that the combine and achievements inputs now use the shared `--text-placeholder` placeholder color (previously the browser default), consistent with every other form field. No screenshot-framed surface is affected.

## Testing

- `./run-tests.sh frontend` — ruff/codespell/deptry/pip-audit/pyright/OpenAPI/Dockerfile/wiring checks, `build:prod`, `npm audit`, and Vitest (1151 passed) all green.

Closes #2309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4o17fBBzFdi451Fh4HF9a)_