### PR TITLE
Unify picker-card copies onto one shared primitive

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -53,8 +53,8 @@ without a browser.
   owed: a `.btn--toolbar` variant for the `.ivc-btn`/`.panel-btn` icon buttons
   (#2300); folding the horizontal `.tab-bar`/`.help-tabs` strips onto
   `.importer-tab-bar` (#2301); a vertical `.side-tab-bar` for the settings tabs
-  (#2302); shared picker-card (#2303), data-table (#2304), empty-state (#2305),
-  and pane-divider (#2307) primitives; unifying the 3 progress bars (#2306);
+  (#2302); shared data-table (#2304), empty-state (#2305), and pane-divider
+  (#2307) primitives; unifying the 3 progress bars (#2306);
   deduping the verbatim `dataset-card`/`detector-card` + `goods-actions` SCSS
   (#2308); and folding hand-built inputs onto `.form-input`/`.form-select`
   (#2309). **Fix pattern:** extract a sanctioned shared class into

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -145,10 +145,10 @@
             } @else {
               <div class="source-list">
                 @for (imp of labelImporters(); track imp.name) {
-                  <button type="button" class="importer-card" (click)="selectLabelImporter(imp)">
-                    <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
+                  <button type="button" class="picker-card" (click)="selectLabelImporter(imp)">
+                    <span class="picker-card__title">@if (imp.icon) {<span class="picker-card__icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
                     @if (imp.description) {
-                      <span class="importer-desc">{{ imp.description }}</span>
+                      <span class="picker-card__desc">{{ imp.description }}</span>
                     }
                   </button>
                 }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -221,36 +221,8 @@
   gap: var(--space-sm);
 }
 
-.importer-card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2xs);
-  padding: var(--space-md) var(--space-lg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--bg-subtle);
-  color: var(--text-primary);
-  cursor: pointer;
-  text-align: left;
-  transition: border-color var(--transition-base), background var(--transition-base);
-
-  &:hover {
-    border-color: var(--accent);
-    background: var(--bg-hover);
-  }
-}
-
-.importer-name {
-  font-weight: var(--weight-semibold);
-  font-size: var(--font-lg);
-}
-
-.importer-icon { margin-right: var(--space-xs); }
-
-.importer-desc {
-  font-size: var(--font-sm);
-  color: var(--text-muted);
-}
+// The selectable option cards use the shared `.picker-card` primitive
+// (`frontend/src/scss/_components.scss`).
 
 .empty-state {
   color: var(--text-muted);

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.html
@@ -6,10 +6,10 @@
   } @else {
     <div class="exporter-picker">
       @for (exp of exporters(); track exp.name) {
-        <button class="exporter-card" (click)="selectExporter(exp)">
-          <span class="exporter-name">@if (exp.icon) {<span class="exporter-icon"><vt-icon [icon]="exp.icon"></vt-icon></span> }{{ exp.display_name || exp.name }}</span>
+        <button class="picker-card" (click)="selectExporter(exp)">
+          <span class="picker-card__title">@if (exp.icon) {<span class="picker-card__icon"><vt-icon [icon]="exp.icon"></vt-icon></span> }{{ exp.display_name || exp.name }}</span>
           @if (exp.description) {
-            <span class="exporter-desc">{{ exp.description }}</span>
+            <span class="picker-card__desc">{{ exp.description }}</span>
           }
         </button>
       }

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.spec.ts
@@ -105,7 +105,7 @@ describe('LabelExporterModalComponent', () => {
   it('should render exporter cards', async () => {
     await flushInit();
     const el = fixture.nativeElement as HTMLElement;
-    const cards = el.querySelectorAll('.exporter-card');
+    const cards = el.querySelectorAll('.picker-card');
     expect(cards.length).toBe(2);
   });
 

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -7,10 +7,10 @@
         <p class="empty-state">No label importers available.</p>
       } @else {
         @for (imp of importers(); track imp.name) {
-          <button class="importer-card" (click)="selectImporter(imp)">
-            <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
+          <button class="picker-card" (click)="selectImporter(imp)">
+            <span class="picker-card__title">@if (imp.icon) {<span class="picker-card__icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
             @if (imp.description) {
-              <span class="importer-desc">{{ imp.description }}</span>
+              <span class="picker-card__desc">{{ imp.description }}</span>
             }
           </button>
         }

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -6,39 +6,8 @@
   max-width: 100%;
 }
 
-.importer-card {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-xs);
-  padding: var(--space-lg) var(--space-xl);
-  background: var(--bg-subtle);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  text-align: left;
-  transition: background var(--transition-base), border-color var(--transition-base);
-  color: var(--text-primary);
-
-  &:hover {
-    background: var(--bg-hover);
-    border-color: var(--accent);
-  }
-}
-
-.importer-name {
-  font-weight: var(--weight-medium);
-  font-size: var(--font-xl);
-}
-
-.importer-icon {
-  margin-right: var(--space-xs);
-}
-
-.importer-desc {
-  font-size: var(--font-sm);
-  color: var(--text-muted);
-}
+// The selectable option cards use the shared `.picker-card` primitive
+// (`frontend/src/scss/_components.scss`).
 
 .importer-form {
   display: flex;

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
@@ -114,7 +114,7 @@ describe('LabelImporterModalComponent', () => {
   it('should render importer cards', async () => {
     await flushInit();
     const el = fixture.nativeElement as HTMLElement;
-    const cards = el.querySelectorAll('.importer-card');
+    const cards = el.querySelectorAll('.picker-card');
     expect(cards.length).toBe(2);
   });
 

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -13,10 +13,10 @@
         } @else {
           <div class="source-list">
             @for (src of mediaSources(); track src.name) {
-              <button class="importer-card" (click)="selectSource(src)">
-                <span class="importer-name">@if (src.icon) {<span class="importer-icon"><vt-icon [icon]="src.icon"></vt-icon></span> }{{ src.display_name || src.name }}</span>
+              <button class="picker-card" (click)="selectSource(src)">
+                <span class="picker-card__title">@if (src.icon) {<span class="picker-card__icon"><vt-icon [icon]="src.icon"></vt-icon></span> }{{ src.display_name || src.name }}</span>
                 @if (src.description) {
-                  <span class="importer-desc">{{ src.description }}</span>
+                  <span class="picker-card__desc">{{ src.description }}</span>
                 }
               </button>
             }

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
@@ -78,37 +78,8 @@
   gap: var(--space-md);
 }
 
-.importer-card {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  padding: var(--space-md) var(--space-lg);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  background: transparent;
-  color: var(--text-primary);
-  cursor: pointer;
-  text-align: left;
-
-  &:hover {
-    background: var(--bg-hover);
-  }
-}
-
-.importer-name {
-  font-size: var(--font-md);
-  font-weight: var(--weight-medium);
-}
-
-.importer-icon {
-  margin-right: var(--space-xs);
-}
-
-.importer-desc {
-  font-size: var(--font-xs);
-  color: var(--text-secondary);
-  margin-top: var(--space-2xs);
-}
+// The selectable option cards use the shared `.picker-card` primitive
+// (`frontend/src/scss/_components.scss`).
 
 .browse-list {
   display: flex;

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
@@ -54,10 +54,10 @@
         <p class="picker-instructions">Choose a source to browse media from:</p>
         <div class="source-list">
           @for (src of mediaSources(); track src.name) {
-            <button class="importer-card" (click)="selectSource(src)">
-              <span class="importer-name">@if (src.icon) {<span class="importer-icon"><vt-icon [icon]="src.icon"></vt-icon></span> }{{ src.display_name || src.name }}</span>
+            <button class="picker-card" (click)="selectSource(src)">
+              <span class="picker-card__title">@if (src.icon) {<span class="picker-card__icon"><vt-icon [icon]="src.icon"></vt-icon></span> }{{ src.display_name || src.name }}</span>
               @if (src.description) {
-                <span class="importer-desc">{{ src.description }}</span>
+                <span class="picker-card__desc">{{ src.description }}</span>
               }
             </button>
           }

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.scss
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.scss
@@ -74,38 +74,8 @@
   gap: var(--space-sm);
 }
 
-.importer-card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2xs);
-  padding: var(--space-md) var(--space-lg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--bg-subtle);
-  color: var(--text-primary);
-  cursor: pointer;
-  text-align: left;
-  transition: border-color var(--transition-base), background var(--transition-base);
-
-  &:hover {
-    border-color: var(--accent);
-    background: var(--bg-hover);
-  }
-}
-
-.importer-name {
-  font-weight: var(--weight-semibold);
-  font-size: var(--font-lg);
-}
-
-.importer-icon {
-  margin-right: var(--space-xs);
-}
-
-.importer-desc {
-  font-size: var(--font-sm);
-  color: var(--text-muted);
-}
+// The selectable option cards use the shared `.picker-card` primitive
+// (`frontend/src/scss/_components.scss`).
 
 .browse-list {
   display: flex;

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -7,10 +7,10 @@
         <p class="empty-state">No settings exporters available.</p>
       } @else {
         @for (exp of exporters(); track exp.name) {
-          <button class="exporter-card" (click)="selectExporter(exp)">
-            <span class="exporter-name">@if (exp.icon) {<span class="exporter-icon"><vt-icon [icon]="exp.icon"></vt-icon></span> }{{ exp.display_name || exp.name }}</span>
+          <button class="picker-card" (click)="selectExporter(exp)">
+            <span class="picker-card__title">@if (exp.icon) {<span class="picker-card__icon"><vt-icon [icon]="exp.icon"></vt-icon></span> }{{ exp.display_name || exp.name }}</span>
             @if (exp.description) {
-              <span class="exporter-desc">{{ exp.description }}</span>
+              <span class="picker-card__desc">{{ exp.description }}</span>
             }
           </button>
         }

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.scss
@@ -4,39 +4,8 @@
   gap: var(--space-md);
 }
 
-.exporter-card {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-xs);
-  padding: var(--space-lg) var(--space-xl);
-  background: var(--bg-subtle);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  text-align: left;
-  transition: background var(--transition-base), border-color var(--transition-base);
-  color: var(--text-primary);
-
-  &:hover {
-    background: var(--bg-hover);
-    border-color: var(--accent);
-  }
-}
-
-.exporter-name {
-  font-weight: var(--weight-medium);
-  font-size: var(--font-xl);
-}
-
-.exporter-icon {
-  margin-right: var(--space-xs);
-}
-
-.exporter-desc {
-  font-size: var(--font-sm);
-  color: var(--text-muted);
-}
+// The selectable option cards use the shared `.picker-card` primitive
+// (`frontend/src/scss/_components.scss`).
 
 .exporter-form {
   display: flex;

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
@@ -50,7 +50,7 @@ describe('SettingsExporterModalComponent', () => {
   it('should create and render exporter cards', async () => {
     await flushInit();
     expect(component).toBeTruthy();
-    expect(fixture.nativeElement.querySelectorAll('.exporter-card').length).toBe(1);
+    expect(fixture.nativeElement.querySelectorAll('.picker-card').length).toBe(1);
   });
 
   // Zoneless staleness canary: the success message lands in an HTTP subscribe (an

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -7,10 +7,10 @@
         <p class="empty-state">No settings importers available.</p>
       } @else {
         @for (imp of importers(); track imp.name) {
-          <button class="importer-card" (click)="selectImporter(imp)">
-            <span class="importer-name">@if (imp.icon) {<span class="importer-icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
+          <button class="picker-card" (click)="selectImporter(imp)">
+            <span class="picker-card__title">@if (imp.icon) {<span class="picker-card__icon"><vt-icon [icon]="imp.icon"></vt-icon></span> }{{ imp.display_name || imp.name }}</span>
             @if (imp.description) {
-              <span class="importer-desc">{{ imp.description }}</span>
+              <span class="picker-card__desc">{{ imp.description }}</span>
             }
           </button>
         }

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.scss
@@ -4,39 +4,8 @@
   gap: var(--space-md);
 }
 
-.importer-card {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-xs);
-  padding: var(--space-lg) var(--space-xl);
-  background: var(--bg-subtle);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  text-align: left;
-  transition: background var(--transition-base), border-color var(--transition-base);
-  color: var(--text-primary);
-
-  &:hover {
-    background: var(--bg-hover);
-    border-color: var(--accent);
-  }
-}
-
-.importer-name {
-  font-weight: var(--weight-medium);
-  font-size: var(--font-xl);
-}
-
-.importer-icon {
-  margin-right: var(--space-xs);
-}
-
-.importer-desc {
-  font-size: var(--font-sm);
-  color: var(--text-muted);
-}
+// The selectable option cards use the shared `.picker-card` primitive
+// (`frontend/src/scss/_components.scss`).
 
 .importer-form {
   display: flex;

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
@@ -48,7 +48,7 @@ describe('SettingsImporterModalComponent', () => {
   it('should create and render importer cards', async () => {
     await flushInit();
     expect(component).toBeTruthy();
-    expect(fixture.nativeElement.querySelectorAll('.importer-card').length).toBe(1);
+    expect(fixture.nativeElement.querySelectorAll('.picker-card').length).toBe(1);
   });
 
   // Zoneless staleness canary: the success message lands in an HTTP subscribe (an

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -370,7 +370,18 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   gap: var(--space-md);
 }
 
-// --- Importer/Exporter picker ---
+// --- Picker cards ---
+//
+// One shared selectable option card (icon + title + description) for every
+// picker that lists choices: the settings import/export pickers, label
+// import/export, the New Detector "Trained" tab, and the load-sort /
+// resort-prompt source pickers. A single canonical title size lives here so
+// the per-modal copies can't drift into three different sizes again; the
+// `.selected` state is provided for pickers that keep a persistent choice.
+//
+// The container layout stays with each picker (a responsive grid for the
+// settings/label pickers below, a vertical `.source-list` for the others);
+// only the card itself is unified.
 
 .importer-picker,
 .exporter-picker {
@@ -379,39 +390,38 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   gap: var(--space-lg);
 }
 
-.importer-card,
-.exporter-card {
+.picker-card {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: var(--space-xs);
   padding: var(--space-lg);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--bg-subtle);
+  color: var(--text-primary);
   cursor: pointer;
   text-align: left;
   transition: border-color var(--transition-base), background var(--transition-base);
 
-  &:hover {
+  &:hover,
+  &.selected {
     border-color: var(--accent);
     background: var(--bg-hover);
   }
 }
 
-.importer-icon {
-  font-size: var(--font-2xl);
-  margin-right: var(--space-sm);
+.picker-card__icon {
+  margin-right: var(--space-xs);
 }
 
-.importer-name,
-.exporter-name {
+.picker-card__title {
   font-size: var(--font-lg);
   font-weight: var(--weight-semibold);
   color: var(--text-primary);
 }
 
-.importer-desc,
-.exporter-desc {
+.picker-card__desc {
   font-size: var(--font-sm);
   color: var(--text-secondary);
 }


### PR DESCRIPTION
## What

Extracts a single `.picker-card` primitive (icon + title + description card, one canonical title size, hover/selected states) in `frontend/src/scss/_components.scss`, replacing the old `.importer-card`/`.exporter-card` pair, and folds the six per-modal copies onto it.

The selectable option cards were re-styled per modal and had drifted to **three different title sizes**:

| Title size | Modals |
|---|---|
| `--font-xl` | settings-importer, settings-exporter, label-importer |
| `--font-lg` | new-detector (Trained tab), resort-prompt, label-exporter (already on the global default) |
| `--font-md` | load-sort |

All now render at the canonical **`--font-lg` / `--weight-semibold`**.

## How

- **`_components.scss`** — the shared `.importer-card`/`.exporter-card` block is replaced by `.picker-card` + `.picker-card__icon` / `.picker-card__title` / `.picker-card__desc`, with `:hover` and `.selected` states. (The dead `font-size: --font-2xl` on the icon is dropped — `vt-icon` sizes by its `size` input, not font-size, so it had no effect.)
- **Templates** (7) — the card markup already used identical class names, so each `.importer-card`/`.exporter-card` → `.picker-card`, `*-name` → `.picker-card__title`, `*-icon` → `.picker-card__icon`, `*-desc` → `.picker-card__desc`. Container classes (`.importer-picker`/`.exporter-picker` grid, `.source-list` list) are intentionally left as component concerns.
- **Scoped SCSS** — the six divergent per-modal card rule blocks are deleted (each replaced with a one-line pointer comment); container/form/empty-state rules are kept.
- **Specs** — four `querySelectorAll('.importer-card' | '.exporter-card')` assertions updated to `.picker-card`.

## Visual changes (intended unification)

- The three title sizes collapse to one (`--font-lg`).
- The **load-sort** picker cards (previously transparent, `--border-subtle`, `--font-md`, no hover-border) pick up the shared subtle-background card treatment with the accent hover border — the most divergent copy is brought in line.

## Backwards compatibility

The `.importer-card`/`.exporter-card`/`.importer-name`/… class names are removed (renamed to the `.picker-card` family). No external consumers; all in-repo templates and specs are updated.

## Testing

`./run-tests.sh frontend` — green: ruff/ruff-format/codespell/deptry/pip-audit/pyright clean, frontend `build:prod` OK, `npm audit` OK, Vitest **1151 passed**. No Python source changed, so pytest is unaffected (all Python linters ran via the frontend gate).

## Docs / screenshots

The one doc screenshot that frames these cards (`import-detector` — the load-sort detector picker) is already in `docs/user/screenshots-reshoot-queue.md` from prior whole-set changes, so no new reshoot rows are needed (and this container has no browser to reshoot).

Closes #2303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFJQNahAnWq5jc4Hsus57A)_