### PR TITLE
Unify the 6 data-table copies onto a shared `.data-table` primitive

### DIFF
--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
@@ -23,7 +23,7 @@
         />
       </label>
 
-      <table class="combine-table">
+      <table class="data-table combine-table">
         <thead>
           <tr>
             <th class="col-name">Dataset</th>

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -41,15 +41,15 @@
   font-size: var(--font-xl);
 }
 
+// Builds on the shared `.data-table` primitive (`_data-table.scss`); the knobs
+// give it roomier cells and a solid `--border`, and the rules below add the
+// thead/tfoot treatment, numeric/type/action columns, and mismatch rows.
 .combine-table {
-  width: 100%;
-  border-collapse: collapse;
+  --dt-cell-pad-y: var(--space-md);
+  --dt-border-color: var(--border);
   font-size: var(--font-lg);
 
   th, td {
-    padding: var(--space-md) var(--space-md);
-    border-bottom: 1px solid var(--border);
-    text-align: left;
     vertical-align: middle;
   }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -46,7 +46,7 @@
       <p class="empty-state">No datasets yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
-        <table class="dash-table" [class.table-fixed]="datasetCols.tableFixed" [class.actions-has-load]="anyDatasetUnloaded">
+        <table class="data-table data-table--grid dash-table" [class.table-fixed]="datasetCols.tableFixed" [class.actions-has-load]="anyDatasetUnloaded">
           <thead>
             <tr>
               <th scope="col" class="select-col" data-col="select" [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths['select'] : null">
@@ -211,7 +211,7 @@
       <p class="empty-state">No detectors yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
-        <table class="dash-table" [class.table-fixed]="detectorCols.tableFixed" [class.actions-has-load]="anyDetectorUnloaded">
+        <table class="data-table data-table--grid dash-table" [class.table-fixed]="detectorCols.tableFixed" [class.actions-has-load]="anyDetectorUnloaded">
           <thead>
             <tr>
               <th scope="col" class="select-col" data-col="select" [style.width.%]="detectorCols.tableFixed ? detectorCols.colWidths['select'] : null">

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
@@ -65,7 +65,7 @@
 
       @if (activeDemoTab() && demoCols) {
         <div class="demo-content-area">
-          <table class="demo-table" [class.table-fixed]="demoCols.tableFixed">
+          <table class="data-table data-table--grid demo-table" [class.table-fixed]="demoCols.tableFixed">
             <thead>
               <tr>
                 @for (col of demoCols.columnOrder; track col; let first = $first) {

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -37,7 +37,7 @@
     @if (displayHits.length === 0) {
       <p class="empty-state">No hits found.</p>
     } @else {
-      <table class="results-table">
+      <table class="data-table results-table">
         <thead>
           <tr>
             <th title="Source origin of the media item">Origin</th>

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
@@ -17,17 +17,12 @@
   margin-bottom: var(--space-xl);
 }
 
+// Builds on the shared `.data-table` primitive (`_data-table.scss`); the knob
+// tightens the cell padding and the sticky header keeps the column labels
+// visible while the results list scrolls.
 .results-table {
-  width: 100%;
-  border-collapse: collapse;
+  --dt-cell-pad-y: var(--space-xs);
   font-size: var(--font-sm);
-
-  th,
-  td {
-    padding: var(--space-xs) var(--space-md);
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-  }
 
   th {
     position: sticky;

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -4,7 +4,7 @@
   } @else if (error()) {
     <p class="error-text">{{ error() }}</p>
   } @else if (stats(); as stats) {
-    <table class="stats-table">
+    <table class="data-table stats-table">
       <tbody>
         <tr>
           <td class="stat-label" title="Total number of unique media items in this dataset">Media items</td>
@@ -30,7 +30,7 @@
     </table>
 
     <h3 class="section-title">Creation</h3>
-    <table class="stats-table">
+    <table class="data-table stats-table">
       <tbody>
         @if (importerName) {
           <tr>
@@ -57,7 +57,7 @@
 
     @if (fileTypes.length > 0) {
       <h3 class="section-title">File Types</h3>
-      <table class="stats-table">
+      <table class="data-table stats-table">
         <thead>
           <tr>
             <th title="File extension of media items">Extension</th>

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
@@ -8,24 +8,8 @@
 // `--color-bad`); both render the same red, so removing the local is
 // a no-op visually.
 
-.stats-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-bottom: var(--space-lg);
-
-  th,
-  td {
-    padding: var(--space-sm) var(--space-md);
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  th {
-    font-weight: var(--weight-semibold);
-    color: var(--text-secondary);
-    font-size: var(--font-md);
-  }
-}
+// `.stats-table` is the shared `.data-table` primitive (`_data-table.scss`);
+// this file keeps only the stat-cell text helpers.
 
 .stat-label {
   font-weight: var(--weight-medium);

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
@@ -4,7 +4,7 @@
   } @else if (error()) {
     <p class="error-text">{{ error() }}</p>
   } @else if (stats(); as stats) {
-    <table class="stats-table">
+    <table class="data-table stats-table">
       <tbody>
         <tr>
           <td class="stat-label" title="Items you voted good in this detector">Positives</td>
@@ -26,7 +26,7 @@
     </table>
 
     <h3 class="section-title">Creation</h3>
-    <table class="stats-table">
+    <table class="data-table stats-table">
       <tbody>
         <tr>
           <td class="stat-label" title="The media type this detector operates on">Media type</td>
@@ -56,7 +56,7 @@
     </table>
 
     <h3 class="section-title">Provenance</h3>
-    <table class="stats-table">
+    <table class="data-table stats-table">
       <tbody>
         <tr>
           <td class="stat-label" title="When this detector was created">Created</td>

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.scss
@@ -5,18 +5,8 @@
 
 // `.error-text` comes from `_components.scss` (uses `--color-bad`).
 
-.stats-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-bottom: var(--space-lg);
-
-  th,
-  td {
-    padding: var(--space-sm) var(--space-md);
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-}
+// `.stats-table` is the shared `.data-table` primitive (`_data-table.scss`);
+// this file keeps only the stat-cell text helpers.
 
 .stat-label {
   font-weight: var(--weight-medium);

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -49,7 +49,7 @@
       <p class="empty-state">No labeled items to export.</p>
     } @else {
       <div class="table-scroll">
-        <table class="export-table" [class.table-fixed]="tableFixed">
+        <table class="data-table export-table" [class.table-fixed]="tableFixed">
           <thead>
             <tr>
               @for (col of enabledColumns; track col.key) {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -75,9 +75,12 @@
   border-radius: var(--radius-md);
 }
 
+// Builds on the shared `.data-table` primitive (`_data-table.scss`); the
+// knobs retune it to tighter cells and a solid `--border`, and the rules
+// below add the resizable/truncating data-preview behaviour.
 .export-table {
-  width: 100%;
-  border-collapse: collapse;
+  --dt-cell-pad-y: var(--space-xs);
+  --dt-border-color: var(--border);
   font-size: var(--font-sm);
 
   // Once the user drags a divider the component freezes per-column pixel
@@ -100,13 +103,10 @@
 
   th,
   td {
-    padding: var(--space-xs) var(--space-md);
-    text-align: left;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 220px;
-    border-bottom: 1px solid var(--border);
   }
 
   th {

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
@@ -11,7 +11,7 @@
         evaluate the retrained detector.
       </p>
     }
-    <table class="stats-table">
+    <table class="data-table stats-table">
       <tbody>
         <tr>
           <td class="stat-label" title="Items the detector kept as positive (adopted, all items)">Good</td>
@@ -29,7 +29,7 @@
     </table>
 
     <h3 class="section-title">Detector Accuracy</h3>
-    <table class="stats-table confusion">
+    <table class="data-table stats-table confusion">
       <thead>
         <tr>
           <th></th>
@@ -51,7 +51,7 @@
       </tbody>
     </table>
 
-    <table class="stats-table">
+    <table class="data-table stats-table">
       <tbody>
         <tr>
           <td class="stat-label" title="Items where the adopted label matches the detector's original call, over all items">Agreement rate</td>

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
@@ -1,31 +1,11 @@
-// `.error-text` and `.section-title` are genuinely shared (`_components.scss`).
-// `.loading-text`, `.stats-table`, `.stat-label`, `.stat-value` are NOT global -
-// each stats modal (dataset/detector/find) keeps its own view-encapsulated copy;
-// this file's copy also carries the `.stats-table th` rule since this is the
-// only one of the three whose markup uses `<thead><th>`.
+// `.error-text` and `.section-title` are genuinely shared (`_components.scss`);
+// `.stats-table` is the shared `.data-table` primitive (`_data-table.scss`).
+// `.loading-text`, `.stat-label`, `.stat-value` stay view-encapsulated per
+// stats modal. The confusion-matrix deltas below are unique to this modal.
 
 .loading-text {
   color: var(--text-muted);
   font-style: italic;
-}
-
-.stats-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-bottom: var(--space-lg);
-
-  th,
-  td {
-    padding: var(--space-sm) var(--space-md);
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  th {
-    font-weight: var(--weight-semibold);
-    color: var(--text-secondary);
-    font-size: var(--font-md);
-  }
 }
 
 .stat-label {

--- a/frontend/src/scss/_data-table.scss
+++ b/frontend/src/scss/_data-table.scss
@@ -235,7 +235,7 @@
 
 // --- Stats modals (dataset / detector / find): read-only key/value tables
 //     with a semibold secondary header. Shared here so the three modals
-//     don't each re-declare the table; their text helpers stay scoped. ---
+//     don't each redeclare the table; their text helpers stay scoped. ---
 .stats-table {
   margin-bottom: var(--space-lg);
 

--- a/frontend/src/scss/_data-table.scss
+++ b/frontend/src/scss/_data-table.scss
@@ -1,41 +1,49 @@
-// Shared sortable/draggable/resizable table used by the dashboard grids.
-// Originally lived inside dashboard.component.scss and pushed that file
-// past the anyComponentStyle budget; hoisted to a global partial so the
-// rules are unencapsulated and per-component CSS stays small.
+// Shared data-table primitives used across the app: the dashboard grids
+// (`.dash-table`), the importer demo picker (`.demo-table`, in
+// `_picker-shared.scss`), the stats modals (`.stats-table`), and the
+// export / results / combine modals. Every table opts onto the base
+// `.data-table` core (width, collapsed borders, cell padding, cell
+// borders); the interactive sortable/draggable/resizable grids additionally
+// carry `.data-table--grid`. Each table then layers only its own deltas.
 //
-// The picker tables in `_picker-shared.scss` use `.demo-table` with a
-// near-identical ruleset; a future cleanup could collapse them, but
-// `.dash-table` keeps a few dashboard-specific bits (pinned select/actions
-// columns, `selected` row state) that don't belong in the picker.
+// These rules live in the global stylesheet (unencapsulated) so a
+// view-encapsulated component template can pull them in just by putting
+// `class="data-table …"` on its `<table>`. The per-table knobs below are CSS
+// custom properties so a variant can retune padding/border without
+// re-declaring the core rules.
+
+// --- Base: the header/row/cell invariants every data table shares ---
+.data-table {
+  // Per-table knobs. Defaults match the most common table (dashboard/picker/
+  // stats); the tighter/wider variants override these in their own rules.
+  --dt-cell-pad-y: var(--space-sm);
+  --dt-cell-pad-x: var(--space-md);
+  --dt-border-color: var(--border-subtle);
+
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: var(--dt-cell-pad-y) var(--dt-cell-pad-x);
+    text-align: left;
+    border-bottom: 1px solid var(--dt-border-color);
+  }
+}
 
 .table-fixed {
   table-layout: fixed;
 }
 
-.dash-table {
-  width: 100%;
-  border-collapse: collapse;
+// --- Interactive grid modifier: sortable / draggable / resizable columns
+//     with a sticky uppercase header and row hover. Shared verbatim by the
+//     dashboard grids (`.dash-table`) and the importer demo picker
+//     (`.demo-table`); each adds only its own deltas. ---
+.data-table--grid {
   font-size: var(--font-md);
 
-  // The Actions column hugs its inline icon buttons rather than flexing with
-  // the table. It carries two 22px buttons at rest (Delete, ⋯) — one 4px gap,
-  // ~48px + the cell's side padding — so it stays tight. When any row in the
-  // table is unloaded (`.actions-has-load`, set by the component) a third Load
-  // button appears, so the column widens to fit three buttons. Pinned via this
-  // width — applied to the header and body cells below, and inherited by the
-  // card rows' own `td.actions-col` — instead of the resizable percentage
-  // system, so it stays narrow in both auto and fixed table-layout.
-  --actions-col-width: 4.5rem;
-
-  &.actions-has-load {
-    --actions-col-width: 6rem;
-  }
-
-  th, td {
-    padding: var(--space-sm) var(--space-md);
-    text-align: left;
-    vertical-align: middle;
-    border-bottom: 1px solid var(--border-subtle);
+  th,
+  td {
     white-space: nowrap;
   }
 
@@ -43,43 +51,8 @@
   // their content. Header cells must NOT clip: they host the resize
   // handle which pokes 6px to the left of the cell's edge.
   td {
-    padding: var(--space-sm) var(--space-md);
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  // Pinned columns: Select on the far left, Name next, Actions on the right.
-  // Actions is held to a fixed content width (see --actions-col-width) and is
-  // excluded from the drag-resize percentage flow, so it never widens.
-  th.actions-col,
-  td.actions-col {
-    width: var(--actions-col-width);
-    text-align: right;
-  }
-
-  // Leftmost select column hosts only the bulk-select checkbox; keep it
-  // narrow and centered so it doesn't crowd the Name column.
-  th.select-col,
-  td.select-col {
-    width: 36px;
-    padding-left: var(--space-md);
-    padding-right: 0;
-    text-align: center;
-  }
-
-  // The select header isn't sortable or draggable; neutralise the inherited
-  // grab cursor and dim the master checkbox toward --text-secondary so it
-  // reads as a header-row control rather than a clickable label.
-  th.select-col {
-    cursor: default;
-
-    .header-checkbox {
-      color: var(--text-secondary);
-
-      &:hover:not(:disabled) {
-        color: var(--text-primary);
-      }
-    }
   }
 
   th {
@@ -195,10 +168,80 @@
     &:hover {
       background: var(--bg-hover);
     }
+  }
+}
 
-    &.selected {
-      background: var(--accent-highlight-bg);
-      border-color: var(--accent-highlight-border);
+// --- Dashboard grids: pinned Select/Actions columns and selected-row state
+//     on top of the shared grid. ---
+.dash-table {
+  th,
+  td {
+    vertical-align: middle;
+  }
+
+  // The Actions column hugs its inline icon buttons rather than flexing with
+  // the table. It carries two 22px buttons at rest (Delete, ⋯) — one 4px gap,
+  // ~48px + the cell's side padding — so it stays tight. When any row in the
+  // table is unloaded (`.actions-has-load`, set by the component) a third Load
+  // button appears, so the column widens to fit three buttons. Pinned via this
+  // width — applied to the header and body cells below, and inherited by the
+  // card rows' own `td.actions-col` — instead of the resizable percentage
+  // system, so it stays narrow in both auto and fixed table-layout.
+  --actions-col-width: 4.5rem;
+
+  &.actions-has-load {
+    --actions-col-width: 6rem;
+  }
+
+  // Pinned columns: Select on the far left, Name next, Actions on the right.
+  // Actions is held to a fixed content width (see --actions-col-width) and is
+  // excluded from the drag-resize percentage flow, so it never widens.
+  th.actions-col,
+  td.actions-col {
+    width: var(--actions-col-width);
+    text-align: right;
+  }
+
+  // Leftmost select column hosts only the bulk-select checkbox; keep it
+  // narrow and centered so it doesn't crowd the Name column.
+  th.select-col,
+  td.select-col {
+    width: 36px;
+    padding-left: var(--space-md);
+    padding-right: 0;
+    text-align: center;
+  }
+
+  // The select header isn't sortable or draggable; neutralise the inherited
+  // grab cursor and dim the master checkbox toward --text-secondary so it
+  // reads as a header-row control rather than a clickable label.
+  th.select-col {
+    cursor: default;
+
+    .header-checkbox {
+      color: var(--text-secondary);
+
+      &:hover:not(:disabled) {
+        color: var(--text-primary);
+      }
     }
+  }
+
+  tbody tr.selected {
+    background: var(--accent-highlight-bg);
+    border-color: var(--accent-highlight-border);
+  }
+}
+
+// --- Stats modals (dataset / detector / find): read-only key/value tables
+//     with a semibold secondary header. Shared here so the three modals
+//     don't each re-declare the table; their text helpers stay scoped. ---
+.stats-table {
+  margin-bottom: var(--space-lg);
+
+  th {
+    font-weight: var(--weight-semibold);
+    color: var(--text-secondary);
+    font-size: var(--font-md);
   }
 }

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -97,95 +97,16 @@
   overflow-x: hidden;
 }
 
-.table-fixed { table-layout: fixed; }
-
+// The demo picker table is the shared interactive grid (`.data-table
+// .data-table--grid`, in `_data-table.scss`) with two picker-only deltas:
+// slightly wider body cells and a disabled-row treatment.
 .demo-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--font-md);
+  td { padding: var(--space-sm) var(--space-lg); }
 
-  th, td {
-    padding: var(--space-sm) var(--space-md);
-    text-align: left;
-    border-bottom: 1px solid var(--border-subtle);
-    white-space: nowrap;
-  }
-
-  td {
-    padding: var(--space-sm) var(--space-lg);
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  th {
-    padding-right: 0;
-    position: sticky;
-    top: 0;
-    background: var(--bg-surface);
-    z-index: 1;
-    color: var(--text-secondary);
-    font-weight: var(--weight-medium);
-    font-size: var(--font-xs);
-    text-transform: uppercase;
-    letter-spacing: var(--tracking-wide);
-    user-select: none;
-
-    &[draggable='true'] { cursor: grab; &:active { cursor: grabbing; } }
-
-    &.sortable {
-      cursor: pointer;
-      &:hover { color: var(--text-primary); }
-    }
-
-    &[draggable='true'].sortable { cursor: grab; &:active { cursor: grabbing; } }
-
-    &.col-drop-target { box-shadow: inset 0 0 0 2px var(--accent); }
-    &.col-dragging { opacity: 0.4; }
-
-    .sort-indicator {
-      display: inline-block;
-      width: 1em;
-      text-align: center;
-      visibility: hidden;
-      &.active { visibility: visible; }
-    }
-
-    .col-resize-handle {
-      position: absolute;
-      top: 0;
-      left: -6px;
-      bottom: 0;
-      width: 12px;
-      cursor: col-resize;
-      z-index: 2;
-
-      &::after {
-        content: '';
-        position: absolute;
-        top: 20%;
-        bottom: 20%;
-        left: 5px;
-        width: 2px;
-        background: var(--accent);
-        opacity: 0.35;
-        transition: opacity var(--transition-base);
-      }
-
-      &:hover::after { opacity: 0.7; }
-    }
-  }
-
-  tbody tr {
-    cursor: pointer;
-    transition: background var(--transition-fast);
-
-    &:hover { background: var(--bg-hover); }
-
-    &.disabled {
-      cursor: not-allowed;
-      opacity: 0.55;
-      &:hover { background: none; }
-    }
+  tbody tr.disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+    &:hover { background: none; }
   }
 }
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,8 +1,8 @@
 @use 'scss/variables';
 @use 'scss/layout';
 @use 'scss/components';
-@use 'scss/picker-shared';
 @use 'scss/data-table';
+@use 'scss/picker-shared';
 
 *,
 *::before,

--- a/tests_lib/core/test_resize_handle_centering.py
+++ b/tests_lib/core/test_resize_handle_centering.py
@@ -27,14 +27,13 @@ from pathlib import Path
 import pytest
 
 REPO = Path(__file__).resolve().parents[2]
-# Both the dashboard datagrid and the shared importer-picker demo table
-# (used by both the Add Dataset and New Model > Browse Media modals) host
-# their own copies of the resize-handle rule.  The datagrid version lives
-# in ``_data-table.scss`` and the picker version in ``_picker-shared.scss``;
-# both are global partials so neither modal has a duplicate scoped copy.
+# The dashboard datagrid and the shared importer-picker demo table (used by
+# both the Add Dataset and New Model > Browse Media modals) both source the
+# resize-handle rule from the single ``.data-table--grid`` primitive in
+# ``_data-table.scss``; there is no longer a duplicate copy in
+# ``_picker-shared.scss``.
 SCSS_FILES = [
     REPO / "frontend/src/scss/_data-table.scss",
-    REPO / "frontend/src/scss/_picker-shared.scss",
 ]
 
 


### PR DESCRIPTION
Closes #2304

Part of **Promote shared component primitives** in `docs/plans/ui-style-polish.md`.

## What

Six data tables each re-implemented the same header/row/cell styling independently. This extracts a shared `.data-table` primitive and folds all six onto it.

### New primitive (`frontend/src/scss/_data-table.scss`)

- **`.data-table`** — the universal core every table shares: `width: 100%`, collapsed borders, and `th`/`td` cell padding + `text-align` + bottom border. The three things that varied across tables are exposed as CSS custom-property knobs (`--dt-cell-pad-y`, `--dt-cell-pad-x`, `--dt-border-color`), so a variant retunes them without re-declaring the core rules.
- **`.data-table--grid`** — a modifier layering the interactive sortable / draggable / resizable behaviour (sticky uppercase header, sort indicator, drag/drop states, the centered resize handle, row hover, truncating cells). Previously this ~90-line block was duplicated almost verbatim between the dashboard grids and the importer demo picker.

### Copies folded on

| Table | How it now builds |
|-------|-------------------|
| `.dash-table` (dashboard grids) | `data-table data-table--grid` + pinned Select/Actions columns and selected-row state |
| `.demo-table` (importer picker) | `data-table data-table--grid` + wider body cells and disabled-row state (its verbatim grid copy in `_picker-shared.scss` is gone) |
| `.stats-table` (dataset / detector / find stats modals) | one global rule on top of `data-table`; the three modals stopped each redeclaring the table |
| `.export-table` | `data-table` + tighter cells, sticky uppercase header, and the resizable/truncating preview behaviour |
| `.results-table` | `data-table` + tighter cells and a sticky header |
| `.combine-table` | `data-table` + roomier cells, thead/tfoot treatment, numeric/type/action columns, and mismatch rows |

All values are preserved exactly (via the knobs), so the change is visually identical — pure structural dedup.

## Notes

- `styles.scss` now loads `data-table` before `picker-shared` so the base-then-variant cascade resolves the demo table's cell-padding override at equal specificity.
- The duplicate `.table-fixed` declaration in `_picker-shared.scss` was removed (it lives in `_data-table.scss`).
- `tests_lib/core/test_resize_handle_centering.py` now points at the single consolidated resize-handle rule instead of the two former copies.

## Testing

- `./run-tests.sh` — all 5732 tests pass (1 skipped).
- Frontend gate: `build:prod` OK (no budget warnings), `npm audit` clean, Vitest 1151 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQm6aEgSfG9k3kTVCugmxL)_