### PR TITLE
Unify the 3 pane-divider copies onto a shared .pane-divider primitive

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -55,8 +55,8 @@ without a browser.
   is done. (Shipped: `.segmented-toggle`, folding the settings View/Focus
   control and the view-controls size/focus toolbar onto one primitive.) Still
   owed: a `.btn--toolbar` variant for the `.ivc-btn`/`.panel-btn` icon buttons
-  (#2300); shared data-table (#2304), empty-state (#2305), and pane-divider
-  (#2307) primitives; and unifying the 3 progress bars (#2306). **Fix pattern:** extract a sanctioned shared class into
+  (#2300); shared data-table (#2304) and empty-state (#2305) primitives; and
+  unifying the 3 progress bars (#2306). **Fix pattern:** extract a sanctioned shared class into
   `_components.scss` / `_picker-shared.scss`, then fold the bespoke copies onto
   it via markup + `@extend`. Ship incrementally (one primitive per PR) to keep
   diffs reviewable. **Files:** `_components.scss`, `_picker-shared.scss`, and

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -210,7 +210,7 @@
         </div>
 
         <div
-          class="browse-divider"
+          class="pane-divider"
           (mousedown)="onDividerMouseDown($event)"
         ></div>
 

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -131,29 +131,8 @@
   overflow: hidden;
 }
 
-// 8px hit target with a 4px visible line centered inside; same pattern as the
-// Find view's panel dividers.
-.browse-divider {
-  width: 8px;
-  cursor: col-resize;
-  background: transparent;
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 2px;
-    width: 4px;
-    background: var(--border);
-    transition: background var(--transition-base);
-  }
-
-  &:hover::after {
-    background: var(--accent);
-  }
-}
+// The draggable pane rule uses the shared `.pane-divider` primitive
+// (`scss/_components.scss`).
 
 // The docked side panel: selection list on top, then the overview minimap with
 // the density legend pinned beneath it (roughly a 2:1 split).

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -36,7 +36,7 @@
     />
   </div>
   <div
-    class="divider-left"
+    class="pane-divider"
     (mousedown)="onDividerMouseDown($event)"
   ></div>
   <div class="panel-center">
@@ -70,7 +70,7 @@
     />
   </div>
   <div
-    class="divider-right"
+    class="pane-divider"
     (mousedown)="onRightDividerMouseDown($event)"
   ></div>
   <div class="panel-right">

--- a/frontend/src/app/components/find-view/find-view.component.scss
+++ b/frontend/src/app/components/find-view/find-view.component.scss
@@ -12,30 +12,8 @@
   min-width: 0;
 }
 
-// 8px hit target with a 4px visible line centered inside; same wider-hit-zone
-// pattern as `.col-resize-handle`, easier to grab than the visible line alone.
-.divider-left {
-  width: 8px;
-  cursor: col-resize;
-  background: transparent;
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 2px;
-    width: 4px;
-    background: var(--border);
-    transition: background var(--transition-base);
-  }
-
-  &:hover::after,
-  &.dragging::after {
-    background: var(--accent);
-  }
-}
+// The draggable pane rules use the shared `.pane-divider` primitive
+// (`scss/_components.scss`).
 
 // LAYOUT INTENT: The center panel child (vt-center-panel) must stretch to fill
 // the entire grid cell. Do NOT add align-items: center or justify-content: center
@@ -47,29 +25,6 @@
   display: flex;
   min-width: 100px;
   position: relative;
-}
-
-.divider-right {
-  width: 8px;
-  cursor: col-resize;
-  background: transparent;
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 2px;
-    width: 4px;
-    background: var(--border);
-    transition: background var(--transition-base);
-  }
-
-  &:hover::after,
-  &.dragging::after {
-    background: var(--accent);
-  }
 }
 
 .panel-right {

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -49,7 +49,7 @@
     />
   </div>
   <div
-    class="divider-left"
+    class="pane-divider"
     vtPanelResize="left"
     [layoutEl]="layoutRef.nativeElement"
     [minWidth]="leftMin"
@@ -66,7 +66,7 @@
     />
   </div>
   <div
-    class="divider-right"
+    class="pane-divider"
     vtPanelResize="right"
     [layoutEl]="layoutRef.nativeElement"
     [minWidth]="RIGHT_MIN"

--- a/frontend/src/app/components/label-view/label-view.component.scss
+++ b/frontend/src/app/components/label-view/label-view.component.scss
@@ -21,30 +21,8 @@
   min-width: 0;
 }
 
-// 8px hit target with a 4px visible line centered inside; same wider-hit-zone
-// pattern as `.col-resize-handle`, easier to grab than the visible line alone.
-.divider-left {
-  width: 8px;
-  cursor: col-resize;
-  background: transparent;
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 2px;
-    width: 4px;
-    background: var(--border);
-    transition: background var(--transition-base);
-  }
-
-  &:hover::after,
-  &.dragging::after {
-    background: var(--accent);
-  }
-}
+// The draggable pane rules use the shared `.pane-divider` primitive
+// (`scss/_components.scss`); `vtPanelResize` adds `.dragging` while dragging.
 
 // LAYOUT INTENT: The center panel child (vt-center-panel) must stretch to fill
 // the entire grid cell. Do NOT add align-items: center or justify-content: center
@@ -55,29 +33,6 @@
   background: var(--bg-panel);
   display: flex;
   min-width: 100px;
-}
-
-.divider-right {
-  width: 8px;
-  cursor: col-resize;
-  background: transparent;
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 2px;
-    width: 4px;
-    background: var(--border);
-    transition: background var(--transition-base);
-  }
-
-  &:hover::after,
-  &.dragging::after {
-    background: var(--accent);
-  }
 }
 
 .panel-right {

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -392,6 +392,39 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   }
 }
 
+// --- Pane divider ---
+//
+// The draggable rule between resizable layout panes: an 8px hit target with a
+// 4px visible line centered inside (the same wider-hit-zone pattern as
+// `.col-resize-handle`, easier to grab than the thin line alone). The line
+// tracks `--border` at rest and switches to `--accent` on hover or while the
+// pane is being dragged. The drag handlers add `.dragging` to keep the accent
+// lit through the drag (bound by `vtPanelResize` in the Label view; the Find
+// and VTSBrowse views highlight on hover only). Used by the Find, Label, and
+// VTSBrowse view layouts.
+.pane-divider {
+  width: 8px;
+  cursor: col-resize;
+  background: transparent;
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 2px;
+    width: 4px;
+    background: var(--border);
+    transition: background var(--transition-base);
+  }
+
+  &:hover::after,
+  &.dragging::after {
+    background: var(--accent);
+  }
+}
+
 // --- Form elements ---
 
 .form-input {


### PR DESCRIPTION
## Summary

The thin draggable rules between resizable layout panes were hand-rolled and copy-pasted across three view layouts — five identical blocks in total:

- **Find view** — `.divider-left` + `.divider-right`
- **Label view** — `.divider-left` + `.divider-right`
- **VTSBrowse view** — `.browse-divider`

Each was the same recipe: an 8px hit target with a 4px `--border` line centered inside, switching to `--accent` on hover (and, in the Label view, while dragging).

This PR extracts one sanctioned `.pane-divider` primitive into `scss/_components.scss` and folds all five copies onto it via markup, deleting the bespoke SCSS. The rendered result is visually identical.

## Changes

- **`scss/_components.scss`** — new `.pane-divider` primitive (width, cursor, the centered `::after` line, and the `:hover` / `.dragging` accent).
- **Find / Label / VTSBrowse component templates** — divider elements now carry `class="pane-divider"` (the old style-only class names had no JS/test references).
- **Find / Label / VTSBrowse component SCSS** — removed the duplicated divider rules, leaving a one-line pointer to the shared primitive.
- **`docs/plans/ui-style-polish.md`** — removed the shipped pane-divider sub-item from the "Promote shared component primitives" umbrella.

The Label view's `vtPanelResize` directive still binds `.dragging`, which the shared primitive honors; the Find and VTSBrowse views highlight on hover only, unchanged from before.

## Testing

`./run-tests.sh frontend` — ruff/codespell/deptry/pyright/audit clean, frontend `build:prod` OK, Vitest 1151 passed.

Closes #2306

🤖 Generated with [Claude Code](https://claude.com/claude-code)