### PR TITLE
Unify the 6 empty-state copies onto a shared primitive

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -53,7 +53,7 @@ without a browser.
   is done. (Shipped: `.segmented-toggle`, folding the settings View/Focus
   control and the view-controls size/focus toolbar onto one primitive.) Still
   owed: a `.btn--toolbar` variant for the `.ivc-btn`/`.panel-btn` icon buttons
-  (#2300); shared data-table (#2304) and empty-state (#2305) primitives. **Fix pattern:** extract a sanctioned shared class into
+  (#2300); and the shared data-table (#2304) primitive. **Fix pattern:** extract a sanctioned shared class into
   `_components.scss` / `_picker-shared.scss`, then fold the bespoke copies onto
   it via markup + `@extend`. Ship incrementally (one primitive per PR) to keep
   diffs reviewable. **Files:** `_components.scss`, `_picker-shared.scss`, and

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -43,7 +43,7 @@
         }
       </ul>
     } @else if (datasets.length === 0 && loadingTasksSvc.orphanLoadingTasks.length === 0 && !loading) {
-      <p class="empty-state">No datasets yet. Click + to add one.</p>
+      <p class="empty-state empty-state--fill">No datasets yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
         <table class="data-table data-table--grid dash-table" [class.table-fixed]="datasetCols.tableFixed" [class.actions-has-load]="anyDatasetUnloaded">
@@ -208,7 +208,7 @@
         }
       </ul>
     } @else if (detectors.length === 0) {
-      <p class="empty-state">No detectors yet. Click + to add one.</p>
+      <p class="empty-state empty-state--fill">No detectors yet. Click + to add one.</p>
     } @else {
       <div class="dashboard-grid">
         <table class="data-table data-table--grid dash-table" [class.table-fixed]="detectorCols.tableFixed" [class.actions-has-load]="anyDetectorUnloaded">

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -258,15 +258,6 @@
   }
 }
 
-.empty-state {
-  flex: 1 1 0;
-  min-height: 0;
-  color: var(--text-muted);
-  text-align: center;
-  padding: var(--space-2xl);
-  font-style: italic;
-}
-
 .dashboard-skeleton-list {
   flex: 1 1 0;
   min-height: 0;

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -204,13 +204,6 @@
 // The selectable option cards use the shared `.picker-card` primitive
 // (`frontend/src/scss/_components.scss`).
 
-.empty-state {
-  color: var(--text-muted);
-  font-size: var(--font-lg);
-  text-align: center;
-  padding: var(--space-xl) 0;
-}
-
 // Media-type field row: dropdown + optional unlock button.
 .media-type-row {
   display: flex;

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -269,9 +269,3 @@
   gap: var(--space-md);
   margin-top: var(--space-md);
 }
-
-.empty-state {
-  color: var(--text-muted);
-  text-align: center;
-  padding: var(--space-xl);
-}

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -33,12 +33,6 @@
   margin-top: var(--space-md);
 }
 
-.empty-state {
-  color: var(--text-muted);
-  text-align: center;
-  padding: var(--space-xl);
-}
-
 .add-media-section {
   margin-top: var(--space-xl);
   padding-top: var(--space-xl);

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.scss
@@ -115,10 +115,3 @@
   flex-direction: column;
   gap: var(--space-md);
 }
-
-.empty-state {
-  color: var(--text-secondary);
-  font-size: var(--font-md);
-  text-align: center;
-  padding: var(--space-xl) 0;
-}

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.scss
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.scss
@@ -106,13 +106,6 @@
   }
 }
 
-.empty-state {
-  color: var(--text-muted);
-  font-size: var(--font-lg);
-  text-align: center;
-  padding: var(--space-xl) 0;
-}
-
 .breadcrumbs {
   display: flex;
   align-items: center;

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.scss
@@ -27,9 +27,3 @@
   gap: var(--space-md);
   margin-top: var(--space-md);
 }
-
-.empty-state {
-  color: var(--text-muted);
-  text-align: center;
-  padding: var(--space-xl);
-}

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.scss
@@ -27,9 +27,3 @@
   gap: var(--space-md);
   margin-top: var(--space-md);
 }
-
-.empty-state {
-  color: var(--text-muted);
-  text-align: center;
-  padding: var(--space-xl);
-}

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -685,11 +685,53 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   color: var(--text-secondary);
 }
 
+// Canonical empty-state primitive: the centered, muted placeholder shown
+// wherever a list, table, or panel has no content yet ("No datasets yet",
+// "No results", a "Loading…" notice, etc.). Stacks an optional icon, the
+// message, and an optional action — all centered. The common case is a bare
+// `<p class="empty-state">message</p>`; the richer form is:
+//
+//   <div class="empty-state">
+//     <span class="empty-state__icon"><vt-icon .../></span>
+//     <p class="empty-state__message">Nothing here yet.</p>
+//     <button class="empty-state__action btn btn--secondary">Add one</button>
+//   </div>
+//
+// Modifiers:
+//   .empty-state--fill    stretch to fill a flex-column parent and center
+//                         vertically (used by the dashboard list panels).
+//   .empty-state--inline  compact, left-aligned, italic inline notice
+//                         (defined in _picker-shared.scss).
 .empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
   font-size: var(--font-md);
   color: var(--text-muted);
   text-align: center;
   padding: var(--space-xl) 0;
+
+  &--fill {
+    flex: 1 1 0;
+    min-height: 0;
+  }
+
+  &__icon {
+    display: inline-flex;
+    color: var(--text-muted);
+    font-size: var(--font-2xl);
+    line-height: 1;
+  }
+
+  &__message {
+    margin: 0;
+  }
+
+  &__action {
+    margin-top: var(--space-xs);
+  }
 }
 
 // `.subhead` styles a heading tag (typically `<h4>`) as a small muted

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -76,11 +76,17 @@
   font-style: italic;
 }
 
+// Inline modifier for the canonical `.empty-state` primitive (see
+// `_components.scss`): a compact, left-aligned, italic notice shown inline
+// below a tab bar rather than as a full centered block. Resets the base
+// primitive's centered flex-column layout back to a simple text run.
 .empty-state--inline {
+  display: block;
   padding: var(--space-sm) var(--space-md);
   font-size: var(--font-sm);
   color: var(--text-muted);
   font-style: italic;
+  text-align: left;
 }
 
 // --- Demo media-type tabs ---


### PR DESCRIPTION
## What & why

Part of **Promote shared component primitives** in `docs/plans/ui-style-polish.md`.

Empty states ("No datasets yet", "No results", "Loading…", etc.) were styled independently in eight component SCSS files, each with slightly different font sizes, padding, colors, and one stray `font-style: italic`. This folds them all onto one canonical `.empty-state` primitive.

## Changes

- **`_components.scss`** — promote `.empty-state` from a flat muted-text rule into the canonical primitive: a centered flex column that stacks an optional `.empty-state__icon`, a `.empty-state__message`, and an optional `.empty-state__action`. The common bare `<p class="empty-state">message</p>` form still works unchanged. Adds an `.empty-state--fill` modifier for the panel-filling case.
- **`_picker-shared.scss`** — keep `.empty-state--inline` as a modifier, resetting the base's centered flex-column layout back to a compact, left-aligned italic inline notice.
- Delete the eight bespoke `.empty-state` copies from `dashboard`, `new-detector-modal`, `export-modal`, `label-importer-modal`, `settings-importer-modal`, `settings-exporter-modal`, `load-sort-modal`, and `resort-prompt-modal` component SCSS. They now inherit the global primitive.
- **`dashboard.component.html`** — the two dashboard list placeholders gain `.empty-state--fill` (replacing the old scoped `flex: 1 1 0; min-height: 0`) so they still stretch to fill the panel and now center vertically.

All other call sites (combine-datasets, autodetect-results, label-exporter, examples-editor, settings, clipper-chooser, achievements, auto-find, import-defaults, source-picker) already relied on the global class and pick up the unified look automatically.

## Notes

- Minor visual unification: the dashboard empty state loses its italic, and `load-sort` moves from `--text-secondary` to the canonical `--text-muted`; `new-detector`/`resort-prompt` move from `--font-lg` to `--font-md`. These are the intended one-consistent-look consolidation.
- No doc screenshot frames an empty-state surface (checked the manifest), so no reshoot-queue additions.

## Testing

`./run-tests.sh frontend` — build OK, audit OK, Vitest 1151 passed; ruff/codespell/deptry/pip-audit/pyright/openapi/screenshot-wiring all green.

Closes #2305