### PR TITLE
Shared primitive: add `.btn--toolbar` variant (fold `.ivc-btn` + `.panel-btn`)

### DIFF
--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -34,7 +34,7 @@
     @if (mediaType === 'image' && imageViewer) {
       <div class="image-view-controls">
         <button
-          class="ivc-btn ivc-btn-toggle"
+          class="btn btn--toolbar ivc-btn ivc-btn-toggle"
           [class.active]="imageViewer.marqueeMode"
           (click)="imageViewer.toggleMarqueeMode()"
           [title]="marqueeTitle"
@@ -45,7 +45,7 @@
         </button>
         @if (regionOverlayCapable) {
           <button
-            class="ivc-btn ivc-btn-toggle"
+            class="btn btn--toolbar ivc-btn ivc-btn-toggle"
             [class.active]="imageViewer.highlightMode"
             (click)="imageViewer.toggleHighlightMode()"
             title="Highlight: outline the region the detector matched best"
@@ -56,10 +56,10 @@
           </button>
         }
         <span class="ivc-sep" aria-hidden="true"></span>
-        <button class="ivc-btn" (click)="imageViewer.rotateLeft()" title="Rotate left ([)" aria-label="Rotate image left">&#x21BA;</button>
-        <button class="ivc-btn" (click)="imageViewer.rotateRight()" title="Rotate right (])" aria-label="Rotate image right">&#x21BB;</button>
-        <button class="ivc-btn" (click)="imageViewer.zoomOut()" title="Zoom out (-)" aria-label="Zoom out">&minus;</button>
-        <button class="ivc-btn" (click)="imageViewer.zoomIn()" title="Zoom in (+)" aria-label="Zoom in">+</button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.rotateLeft()" title="Rotate left ([)" aria-label="Rotate image left">&#x21BA;</button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.rotateRight()" title="Rotate right (])" aria-label="Rotate image right">&#x21BB;</button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.zoomOut()" title="Zoom out (-)" aria-label="Zoom out">&minus;</button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.zoomIn()" title="Zoom in (+)" aria-label="Zoom in">+</button>
         <label for="ivc-zoom" class="sr-only">Zoom</label>
         <input
           type="range"
@@ -74,7 +74,7 @@
           aria-label="Zoom level"
         />
         <span class="ivc-zoom-label">{{ imageViewer.zoomLabel }}</span>
-        <button class="ivc-btn" (click)="imageViewer.resetView()" title="Reset view" aria-label="Reset image view">Reset</button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.resetView()" title="Reset view" aria-label="Reset image view">Reset</button>
       </div>
     }
 

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -85,31 +85,26 @@
   }
 }
 
+// The image-view toolbar buttons build on the shared `.btn.btn--toolbar`
+// primitive (see scss/_components.scss). These add-ons layer only what is
+// genuinely distinct: the larger glyph size the rotate/zoom/reset controls
+// need, and the accent-fill active state for the marquee / highlight toggles.
 .ivc-btn {
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
-  cursor: pointer;
   padding: var(--space-2xs) var(--space-md);
   font-size: var(--font-xl);
-
-  &:hover {
-    background: var(--bg-hover);
-  }
 }
 
 .ivc-btn-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
   padding: var(--space-2xs) var(--space-sm);
-  line-height: 1;
+
+  &.active,
+  &.active:hover {
+    color: var(--btn-filled-text);
+  }
 
   &.active {
     background: var(--accent);
     border-color: var(--accent);
-    color: var(--btn-filled-text);
   }
 
   &.active:hover {

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -7,7 +7,7 @@
 
   @if (mode() !== 'find') {
     <div class="import-row">
-      <button class="panel-btn import-btn" [disabled]="disabled()" (click)="onImportLabels()" title="Import good/bad labels from a file or add media directly to the good or bad pile">Import Labels</button>
+      <button class="btn btn--toolbar import-btn" [disabled]="disabled()" (click)="onImportLabels()" title="Import good/bad labels from a file or add media directly to the good or bad pile">Import Labels</button>
     </div>
   }
 
@@ -129,7 +129,7 @@
   @if (mode() === 'find') {
     <div class="corrections-row">
       <button
-        class="panel-btn corrections-btn"
+        class="btn btn--toolbar corrections-btn"
         [disabled]="disabled()"
         (click)="onAddCorrections()"
         title="Add the corrections you've made (items you changed from the detector's call) into this detector's labelset and retrain it. This changes the detector, so the current evaluation no longer applies."
@@ -142,7 +142,7 @@
 
   @if (mode() !== 'find') {
     <div class="export-row">
-      <button class="panel-btn export-btn" [disabled]="disabled()" (click)="onExport()" aria-label="Export" title="Export labeled items to clipboard, file, email, or webhook">
+      <button class="btn btn--toolbar export-btn" [disabled]="disabled()" (click)="onExport()" aria-label="Export" title="Export labeled items to clipboard, file, email, or webhook">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
           <polyline points="15 3 21 3 21 9"></polyline>

--- a/frontend/src/app/components/right-panel/right-panel.component.scss
+++ b/frontend/src/app/components/right-panel/right-panel.component.scss
@@ -57,28 +57,10 @@
   border-top: 1px solid var(--border);
 }
 
-.panel-btn {
-  padding: var(--space-xs) var(--space-md);
-  font-size: var(--font-xs);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--bg-surface);
-  color: var(--text-secondary);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: all var(--transition-base);
-
-  &:hover:not(:disabled) {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-    border-color: var(--accent);
-  }
-
-  &:disabled {
-    opacity: var(--opacity-disabled);
-    cursor: not-allowed;
-  }
-}
+// The panel action buttons (Import Labels / Add Corrections / Export) use the
+// shared `.btn.btn--toolbar` primitive from `scss/_components.scss`; the
+// `.import-btn` / `.export-btn` / `.corrections-btn` add-ons below only carry
+// each button's layout (flex sizing, centering).
 
 // Icon-only action cluster projected into the good label-list header in
 // Find mode (Browse / To Dataset / Export). Mirrors the dashboard card

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -52,6 +52,7 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 //   .btn--secondary   filled secondary (neutral action)
 //   .btn--danger      destructive (red outline → red bg on hover)
 //   .btn--cancel      subtle, link-weight cancel/close (no fill, small)
+//   .btn--toolbar     compact outline button for toolbars / panel action rows
 //   .btn--sm          compact size modifier
 //   .btn--xs          inline mini size modifier (used inside table rows etc.)
 //   .btn--icon-square square 28×28 plus/icon button
@@ -141,6 +142,25 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
     padding: 0 var(--space-sm);
     font-size: var(--font-xs);
     line-height: 1.6;
+  }
+
+  // Compact outline button for toolbars and panel action rows: tighter
+  // padding than the base, a muted resting colour, and a hover that promotes
+  // the border to the accent. Shared by the right-panel action buttons
+  // (Import Labels / Add Corrections / Export) and the image-view-controls
+  // toolbar (which layers a larger glyph size and an accent-fill toggle state
+  // on top via component add-ons). `white-space: nowrap` keeps multi-word
+  // labels on a single line inside a narrow panel.
+  &--toolbar {
+    padding: var(--space-xs) var(--space-md);
+    font-size: var(--font-xs);
+    color: var(--text-secondary);
+    white-space: nowrap;
+
+    &:hover:not(:disabled) {
+      color: var(--text-primary);
+      border-color: var(--accent);
+    }
   }
 
   // Square 28×28 icon button (used for "+ add" in dashboard headers).


### PR DESCRIPTION
Part of **Promote shared component primitives** in `docs/plans/ui-style-polish.md` (one primitive per PR).

Two outline icon/toolbar button classes bypassed the `.btn` taxonomy. This adds a shared `.btn--toolbar` variant and folds both bespoke copies onto `.btn.btn--toolbar`.

## Changes

- **`_components.scss`** — new `.btn--toolbar` variant: compact padding, muted (`--text-secondary`) resting colour, `white-space: nowrap`, and a hover that promotes the border to the accent + text to primary. Added to the `.btn` anatomy comment.
- **`right-panel.component.{scss,html}`** — `.panel-btn` (Import Labels / Add Corrections / Export) deleted; markup now uses `btn btn--toolbar`. The per-button `.import-btn` / `.export-btn` / `.corrections-btn` add-ons keep only their layout (flex sizing, centering, gap).
- **`center-panel.component.{scss,html}`** — `.ivc-btn` / `.ivc-btn-toggle` slimmed to thin add-ons on top of `.btn.btn--toolbar`, layering only what's genuinely distinct: the larger glyph size (`--font-xl`) the rotate/zoom/reset controls need, and the accent-fill active state for the marquee/highlight toggles (per the issue's "keep distinct modifiers as small add-ons rather than forking the base").

## Behaviour note (minor visual normalization)

The image-view-controls glyph buttons converge onto the shared toolbar look: their resting colour moves from `--text-primary` to `--text-secondary` and hover now promotes the border to the accent (previously hover only changed the background). This is the intended consolidation.

## Testing

`./run-tests.sh frontend` — ruff/codespell/deptry/pip-audit/pyright/wiring all clean, frontend `build:prod` OK (no budget warnings), `npm audit` clean, Vitest 1151 passed.

Screenshot drift: the affected shots (`region-voting`, `find-view`) are already in `docs/user/screenshots-reshoot-queue.md` (the whole set is currently queued), so no new rows were needed.

Closes #2300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wPSBmqSVnhKpgfp4jxLM4)_