### PR TITLE
Fold horizontal tab strips onto shared .tab-bar/.tab primitive

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -53,8 +53,7 @@ without a browser.
   is done. (Shipped: `.segmented-toggle`, folding the settings View/Focus
   control and the view-controls size/focus toolbar onto one primitive.) Still
   owed: a `.btn--toolbar` variant for the `.ivc-btn`/`.panel-btn` icon buttons
-  (#2300); folding the horizontal `.tab-bar`/`.help-tabs` strips onto
-  `.importer-tab-bar` (#2301); a vertical `.side-tab-bar` for the settings tabs
+  (#2300); a vertical `.side-tab-bar` for the settings tabs
   (#2302); shared data-table (#2304), empty-state (#2305), and pane-divider
   (#2307) primitives; unifying the 3 progress bars (#2306);
   deduping the verbatim `dataset-card`/`detector-card` + `goods-actions` SCSS

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -247,7 +247,7 @@ describe('DatasetImporterModalComponent', () => {
     flushImporters();
     await settleZoneless(fixture);
     const el = fixture.nativeElement as HTMLElement;
-    const tabLabels = Array.from(el.querySelectorAll('.importer-tab')).map(
+    const tabLabels = Array.from(el.querySelectorAll('.tab-bar .tab')).map(
       (b) => (b.textContent || '').trim(),
     );
     expect(tabLabels.some((l) => l.includes('Services'))).toBe(true);

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
@@ -1,8 +1,8 @@
 <div class="importer-picker">
-  <div class="importer-tab-bar">
+  <div class="tab-bar">
     @for (tab of visibleImporterTabs(); track tab.id) {
       <button
-        class="importer-tab"
+        class="tab"
         [class.active]="activeTab() === tab.id"
         (click)="activeTabChange.emit(tab.id)"
         [title]="tabTitle(tab.label)"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.scss
@@ -1,4 +1,4 @@
-// Picker chrome styles (`.importer-tab-bar`, `.importer-subtab`,
+// Picker chrome styles (`.tab-bar`, `.importer-subtab`,
 // `.demo-tab-bar`, `.demo-table`, badges, etc.) live globally in
 // `frontend/src/scss/_picker-shared.scss` so they can be reused by any
 // modal that consumes <vt-source-picker>.  Layout-only styles unique to

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -1,12 +1,12 @@
 <vt-modal [open]="true" [title]="modalTitle" [showCloseButton]="false" (closed)="close()">
   @if (view() === 'main') {
     <div class="tab-bar" role="tablist">
-      <button type="button" class="tab-btn" role="tab"
+      <button type="button" class="tab" role="tab"
         [class.active]="tab === 'blank'"
         [attr.aria-selected]="tab === 'blank'"
         (click)="setTab('blank')"
         title="Start a fresh detector from a single text description or media example. The detector learns from your votes as you label.">Blank</button>
-      <button type="button" class="tab-btn" role="tab"
+      <button type="button" class="tab" role="tab"
         [class.active]="tab === 'trained'"
         [attr.aria-selected]="tab === 'trained'"
         (click)="onSelectTrainedTab()"
@@ -70,12 +70,12 @@
         <div class="form-group example-group">
           <label class="col-label">Example</label>
           <div class="tab-bar example-tab-bar" role="tablist">
-            <button type="button" class="tab-btn" role="tab"
+            <button type="button" class="tab" role="tab"
               [class.active]="exampleTab() === 'text'"
               [attr.aria-selected]="exampleTab() === 'text'"
               (click)="setExampleTab('text')"
               title="Describe what this detector should find in words.">Text</button>
-            <button type="button" class="tab-btn" role="tab"
+            <button type="button" class="tab" role="tab"
               [class.active]="exampleTab() === 'media'"
               [attr.aria-selected]="exampleTab() === 'media'"
               (click)="setExampleTab('media')"

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -22,31 +22,11 @@
   }
 }
 
+// Top-level Blank/Trained strip uses the shared `.tab-bar` / `.tab`
+// primitive (`_picker-shared.scss`). It sits as a sibling above the form,
+// so add the bottom spacing the shared primitive intentionally omits.
 .tab-bar {
-  display: flex;
-  gap: var(--space-xs);
-  border-bottom: 1px solid var(--border);
   margin-bottom: var(--space-lg);
-}
-
-.tab-btn {
-  background: none;
-  border: none;
-  padding: var(--space-md) var(--space-xl);
-  font-size: var(--font-lg);
-  font-weight: var(--weight-medium);
-  color: var(--text-muted);
-  cursor: pointer;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  transition: color var(--transition-base), border-color var(--transition-base);
-
-  &:hover { color: var(--text-primary); }
-
-  &.active {
-    color: var(--text-primary);
-    border-bottom-color: var(--accent);
-  }
 }
 
 .importer-form-header {
@@ -92,7 +72,7 @@
 .example-tab-bar {
   margin-bottom: var(--space-sm);
 
-  .tab-btn {
+  .tab {
     padding: var(--space-sm) var(--space-lg);
     font-size: var(--font-md);
   }

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
@@ -1,11 +1,11 @@
 <vt-modal title="Help" [open]="true" (closed)="close()">
   <div class="help">
-    <div class="help-tabs" role="tablist">
+    <div class="tab-bar" role="tablist">
       <button
         type="button"
         role="tab"
-        class="help-tab"
-        [class.help-tab--active]="activeTab() === 'shortcuts'"
+        class="tab"
+        [class.active]="activeTab() === 'shortcuts'"
         [attr.aria-selected]="activeTab() === 'shortcuts'"
         (click)="selectTab('shortcuts')"
       >
@@ -14,8 +14,8 @@
       <button
         type="button"
         role="tab"
-        class="help-tab"
-        [class.help-tab--active]="activeTab() === 'guide'"
+        class="tab"
+        [class.active]="activeTab() === 'guide'"
         [attr.aria-selected]="activeTab() === 'guide'"
         (click)="selectTab('guide')"
       >

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
@@ -6,30 +6,8 @@
   max-width: var(--modal-w-md);
 }
 
-.help-tabs {
-  display: flex;
-  gap: var(--space-xs);
-  border-bottom: 1px solid var(--border);
-}
-
-.help-tab {
-  background: transparent;
-  border: 0;
-  border-bottom: 2px solid transparent;
-  padding: var(--space-xs) var(--space-sm);
-  color: var(--text-muted);
-  font-size: var(--font-md);
-  cursor: pointer;
-
-  &:hover {
-    color: var(--text-primary);
-  }
-}
-
-.help-tab--active {
-  color: var(--text-primary);
-  border-bottom-color: var(--accent, var(--text-primary));
-}
+// The top-level Keyboard shortcuts / User guide strip uses the shared
+// `.tab-bar` / `.tab` primitive (`_picker-shared.scss`).
 
 .kbd-help {
   display: flex;
@@ -38,7 +16,7 @@
 }
 
 // Secondary tab row: one per shortcut context (Train/Find, Browser, General).
-// A lighter, pill-style variant of the top-level ``.help-tabs`` so the two
+// A lighter, pill-style variant of the top-level ``.tab-bar`` so the two
 // levels read as distinct.
 .kbd-context-tabs {
   display: flex;

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -1,15 +1,17 @@
-// Shared importer-picker styles used by both the Add Dataset modal
-// (DatasetImporterModalComponent) and the New Model > Browse Media picker
-// (NewModelModalComponent).  Lives in the global stylesheet so the rules
-// only ship once instead of being duplicated inside each component's
-// scoped CSS bundle.
+// Shared picker + tab-strip styles. Originally scoped to the Add Dataset
+// modal (DatasetImporterModalComponent) and the New Model > Browse Media
+// picker (NewModelModalComponent); the horizontal tab primitive below
+// (`.tab-bar` / `.tab`) is now the sanctioned shared strip used across
+// modals (importer picker, New Detector, keyboard help). Lives in the
+// global stylesheet so the rules only ship once instead of being
+// duplicated inside each component's scoped CSS bundle.
 //
-// All selectors here are class-only and only used by these two modals, so
-// they can safely apply globally without bleeding into other components.
+// All selectors here are class-only, so they apply globally without
+// bleeding into other components.
 
-// --- Importer category / sub-importer tabs ---
+// --- Horizontal tab strip (shared primitive) ---
 
-.importer-tab-bar {
+.tab-bar {
   display: flex;
   align-items: center;
   gap: var(--space-xs);
@@ -17,7 +19,7 @@
   border-bottom: 2px solid var(--border);
 }
 
-.importer-tab {
+.tab {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
@@ -44,10 +46,12 @@
   }
 }
 
-.importer-subtab-bar { @extend .importer-tab-bar; }
+// --- Importer sub-importer tabs ---
+
+.importer-subtab-bar { @extend .tab-bar; }
 
 .importer-subtab {
-  @extend .importer-tab;
+  @extend .tab;
 
   &.disabled, &:disabled {
     opacity: var(--opacity-disabled);
@@ -81,8 +85,8 @@
 
 // --- Demo media-type tabs ---
 
-.demo-tab-bar { @extend .importer-tab-bar; }
-.demo-tab { @extend .importer-tab; }
+.demo-tab-bar { @extend .tab-bar; }
+.demo-tab { @extend .tab; }
 
 // --- Demo table ---
 


### PR DESCRIPTION
Part of **Promote shared component primitives** in `docs/plans/ui-style-polish.md` (one primitive per PR).

Two horizontal tab strips were re-implemented instead of reusing the shared picker-tab class in `frontend/src/scss/_picker-shared.scss`. This folds both onto the shared primitive.

## What changed

- **Renamed the shared classes to role-neutral names** — `.importer-tab-bar` → `.tab-bar` and `.importer-tab` → `.tab` in `_picker-shared.scss`, since they now back tab strips beyond the importer picker. The importer sub-tab / demo-tab classes keep their names and `@extend` the new base. Updated the source-picker markup + comment and the one importer spec that queried `.importer-tab`.
- **New Detector modal** — deleted the bespoke `.tab-bar`/`.tab-btn` rules; the Blank/Trained strip and the nested Text/media strip now use `.tab-bar`/`.tab`. Kept only this component's own layout tweaks: the strip's bottom margin (it sits above the form) and the tighter nested `.example-tab-bar` padding.
- **Keyboard help modal** — deleted the bespoke `.help-tabs`/`.help-tab`/`.help-tab--active` rules; the Keyboard-shortcuts / User-guide strip now uses `.tab-bar`/`.tab` with the shared `.active` class. The pill-style `.kbd-context-tabs` sub-row is unchanged.

The minor font/padding/active-state differences between the three copies are reconciled onto the shared primitive's look (accent-colored, semibold active tab).

## Notes

- This is a GUI change to two modals. No doc screenshots frame these tab strips (checked the reshoot manifest), so no reshoot queue entry is needed.
- `./run-tests.sh frontend` passes: `build:prod` clean (no budget warnings), `npm audit` clean, 1151 Vitest tests pass, all Python lint/type gates green.

Closes #2301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0175f9izC5iLS1w725buZJzF)_