### PR TITLE
Token consolidation: canvas-overlay --z-* tokens for browse overlays

### DIFF
--- a/.claude/scripts/style-check.py
+++ b/.claude/scripts/style-check.py
@@ -221,6 +221,34 @@ def check_transition_all(files: list[Path]) -> Finding:
 
 
 # ---------------------------------------------------------------------------
+# §1.8 Raw z-index (must resolve through a --z-* token)
+# ---------------------------------------------------------------------------
+RAW_ZINDEX_RE = re.compile(r"\bz-index\s*:\s*(-?\d+)\b")
+
+
+def check_raw_zindex(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§1.8 Raw z-index (bypasses the --z-* scale)",
+        description=(
+            "Never use a raw z-index. Resolve stacking through a --z-* token "
+            "(global layers like --z-modal / --z-toast, or the canvas-overlay "
+            "scale --z-canvas-base/overlay/top). If you need a new layer, add a "
+            "token to _variables.scss instead of a bare integer."
+        ),
+    )
+    for path in files:
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("//"):
+                continue
+            if "var(--" in line:
+                continue
+            if RAW_ZINDEX_RE.search(line):
+                f.hits.append((path, lineno, line.rstrip()))
+    return f
+
+
+# ---------------------------------------------------------------------------
 # §4.13 `font: inherit` on form-input/form-select aliases
 # ---------------------------------------------------------------------------
 def check_font_inherit_trap(files: list[Path]) -> Finding:
@@ -547,6 +575,7 @@ def main() -> int:
         check_bold_weight(files),
         check_heading_restyling(files),
         check_transition_all(files),
+        check_raw_zindex(files),
         check_font_inherit_trap(files),
         check_flex_column_no_gap(files),
         check_redeclared_utility(files),

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -55,7 +55,7 @@
   position: absolute;
   top: var(--space-md);
   left: var(--space-md);
-  z-index: 2;
+  z-index: var(--z-canvas-overlay);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -119,7 +119,7 @@
 .browse-preload-cover {
   position: absolute;
   inset: 0;
-  z-index: 3;
+  z-index: var(--z-canvas-top);
   background: var(--bg-body);
 }
 
@@ -253,7 +253,7 @@
   &:hover:not(:disabled):not(.browse-size-btn--active) {
     color: var(--text-primary);
     border-color: var(--text-primary);
-    z-index: 1;
+    z-index: var(--z-canvas-base);
   }
 
   &:disabled {
@@ -280,7 +280,7 @@
   color: var(--toggle-active-text);
   border-color: var(--accent);
   box-shadow: inset 0 1px 3px var(--shadow-dropdown);
-  z-index: 1;
+  z-index: var(--z-canvas-base);
 }
 
 // Preview-volume control (audio datasets only), anchored top-left below the
@@ -307,7 +307,7 @@
 
   &:hover {
     border-color: var(--text-primary);
-    z-index: 1;
+    z-index: var(--z-canvas-base);
   }
 
   &:focus-visible {

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -87,6 +87,17 @@
   --z-toast: 5000;
   --z-login: 9999;
 
+  // Canvas-overlay stacking (browse view). A small local scale for the
+  // affordances painted over the UMAP canvas: they live inside the
+  // ``.browse-content`` / ``.browse-main`` stacking contexts, so they need
+  // their own low integers rather than a slot on the global scale above.
+  // ``base`` lifts a hovered/active control just past its siblings (border
+  // overlap); ``overlay`` floats the tool clusters over the canvas;
+  // ``top`` is the pre-reveal cover that sits over everything.
+  --z-canvas-base: 1;
+  --z-canvas-overlay: 2;
+  --z-canvas-top: 3;
+
   // Modal width scale. Dialogs pick one of these instead of hand-rolling a
   // width; keeps chrome consistent across the ~24 modals. `sm` is the simple
   // single-column form (label importer, combine detectors, blank new-detector


### PR DESCRIPTION
Part of **Consolidate the remaining ad-hoc token values** in `docs/plans/ui-style-polish.md`.

The browse overlays used raw z-indexes (`z-index: 1/2/3`) in `browse-view.component.scss` instead of resolving through the token system.

## Changes

- **`_variables.scss`** — added a canvas-overlay `--z-*` scale alongside the existing global z-index tokens:
  - `--z-canvas-base: 1` — lifts a hovered/active control just past its siblings (border overlap)
  - `--z-canvas-overlay: 2` — floats the tool clusters over the UMAP canvas
  - `--z-canvas-top: 3` — the pre-reveal cover that sits over everything

  These live in the `.browse-content` / `.browse-main` local stacking contexts, so they use their own low integers rather than a slot on the global scale.

- **`browse-view.component.scss`** — replaced all five raw `z-index` values with `var()` refs to the new tokens (`.browse-tools-left`, `.browse-preload-cover`, `.browse-size-btn:hover`, `.browse-size-btn--active`, `.browse-volume-slider:hover`).

- **`.claude/scripts/style-check.py`** — added a §1.8 check that flags any bare numeric `z-index`, enforcing the style-guide's existing "Never use a raw z-index" rule. The scanner remains informational (exits 0); it now surfaces the remaining raw z-indexes elsewhere in the tree as future consolidation work.

## Testing

`./run-tests.sh frontend` passes (build, audit, 1151 Vitest tests). The token change is a pure indirection — the resolved integer values are unchanged, so no visual change and no screenshot reshoot needed.

Closes #2321

🤖 Generated with [Claude Code](https://claude.com/claude-code)