### PR TITLE
Extract shared .side-tab-bar primitive; fold settings tabs onto it

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -55,8 +55,7 @@ without a browser.
   is done. (Shipped: `.segmented-toggle`, folding the settings View/Focus
   control and the view-controls size/focus toolbar onto one primitive.) Still
   owed: a `.btn--toolbar` variant for the `.ivc-btn`/`.panel-btn` icon buttons
-  (#2300); a vertical `.side-tab-bar` for the settings tabs
-  (#2302); shared data-table (#2304), empty-state (#2305), and pane-divider
+  (#2300); shared data-table (#2304), empty-state (#2305), and pane-divider
   (#2307) primitives; and unifying the 3 progress bars (#2306). **Fix pattern:** extract a sanctioned shared class into
   `_components.scss` / `_picker-shared.scss`, then fold the bespoke copies onto
   it via markup + `@extend`. Ship incrementally (one primitive per PR) to keep

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -3,66 +3,66 @@
     <p class="empty-state">Loading settings...</p>
   } @else {
     <div class="settings-layout">
-      <nav class="settings-tabs">
+      <nav class="side-tab-bar">
         <button
-          class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab() === 'appearance'"
+          class="side-tab"
+          [class.side-tab--active]="activeSettingsTab() === 'appearance'"
           (click)="activeSettingsTab.set('appearance')"
           title="Theme, animations, and view layout options">
           <vt-icon type="palette" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab() === 'appearance'"></vt-icon>
           Appearance
         </button>
         <button
-          class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab() === 'autofind'"
+          class="side-tab"
+          [class.side-tab--active]="activeSettingsTab() === 'autofind'"
           (click)="activeSettingsTab.set('autofind')"
           title="Detectors that auto-run on import, and what to do with their results">
           <vt-icon type="auto-find" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab() === 'autofind'"></vt-icon>
           Auto-Find
         </button>
         <button
-          class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab() === 'autopilot'"
+          class="side-tab"
+          [class.side-tab--active]="activeSettingsTab() === 'autopilot'"
           (click)="activeSettingsTab.set('autopilot')"
           title="Configure the guided autopilot labeling workflow">
           <vt-icon type="steering-wheel" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab() === 'autopilot'"></vt-icon>
           Autopilot
         </button>
         <button
-          class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab() === 'browser'"
+          class="side-tab"
+          [class.side-tab--active]="activeSettingsTab() === 'browser'"
           (click)="activeSettingsTab.set('browser')"
           title="Browse map look per media type: bin shape, density colormap, and cell size">
           <vt-icon type="eye" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab() === 'browser'"></vt-icon>
           Browser
         </button>
         <button
-          class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab() === 'imports'"
+          class="side-tab"
+          [class.side-tab--active]="activeSettingsTab() === 'imports'"
           (click)="activeSettingsTab.set('imports')"
           title="Default embedder, clipper, and converters to apply when importing each kind of dataset">
           <vt-icon type="import" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab() === 'imports'"></vt-icon>
           Import Defaults
         </button>
         <button
-          class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab() === 'server'"
+          class="side-tab"
+          [class.side-tab--active]="activeSettingsTab() === 'server'"
           (click)="activeSettingsTab.set('server')"
           title="Settings fixed when the server started; shared by everyone and read-only here">
           <vt-icon type="server" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab() === 'server'"></vt-icon>
           Server
         </button>
         <button
-          class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab() === 'sorting'"
+          class="side-tab"
+          [class.side-tab--active]="activeSettingsTab() === 'sorting'"
           (click)="activeSettingsTab.set('sorting')"
           title="Options that control how sorting and detector tuning behave">
           <vt-icon type="sort-descending" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab() === 'sorting'"></vt-icon>
           Sorting
         </button>
         <button
-          class="settings-tab"
-          [class.settings-tab--active]="activeSettingsTab() === 'huggingface'"
+          class="side-tab"
+          [class.side-tab--active]="activeSettingsTab() === 'huggingface'"
           (click)="activeSettingsTab.set('huggingface')"
           title="Sign in with HuggingFace to download gated demo datasets and gated AI models">
           <vt-icon type="globe" [size]="14" class="settings-tab-icon" [class.settings-tab-icon--active]="activeSettingsTab() === 'huggingface'"></vt-icon>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.scss
@@ -10,41 +10,9 @@
   min-height: 340px;
 }
 
-.settings-tabs {
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
-  width: 140px;
-  border-right: 1px solid var(--border);
-  padding: var(--space-xs) 0;
-}
-
-.settings-tab {
-  background: none;
-  border: none;
-  border-left: 3px solid transparent;
-  padding: var(--space-sm) var(--space-md);
-  font-size: var(--font-md);
-  font-weight: var(--weight-medium);
-  color: var(--text-secondary);
-  cursor: pointer;
-  text-align: left;
-  transition: color var(--transition-base), background var(--transition-base), border-color var(--transition-base);
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-
-  &:hover {
-    color: var(--text-primary);
-    background: var(--bg-subtle);
-  }
-
-  &--active {
-    color: var(--text-primary);
-    background: var(--bg-subtle);
-    border-left-color: var(--accent);
-  }
-}
+// The vertical tab rail uses the shared `.side-tab-bar` / `.side-tab`
+// primitive defined in `scss/_components.scss`; only the rotating
+// `.settings-tab-icon` (below) is Settings-specific.
 
 .settings-panel {
   flex: 1;

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -273,6 +273,49 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   }
 }
 
+// --- Side tab bar (vertical tab rail) ---
+//
+// The vertical counterpart to `.importer-tab-bar`: a fixed-width column of
+// tabs down the left edge of a modal, with a left-border active indicator
+// instead of the horizontal bar's underline. Currently the Settings modal's
+// tab rail; extract-and-fold target for any other vertical rail.
+.side-tab-bar {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  width: 140px;
+  border-right: 1px solid var(--border);
+  padding: var(--space-xs) 0;
+}
+
+.side-tab {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  border: none;
+  border-left: 3px solid transparent;
+  background: none;
+  color: var(--text-secondary);
+  font-size: var(--font-md);
+  font-weight: var(--weight-medium);
+  text-align: left;
+  cursor: pointer;
+  transition: color var(--transition-base), background var(--transition-base),
+    border-color var(--transition-base);
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-subtle);
+  }
+
+  &--active {
+    color: var(--text-primary);
+    background: var(--bg-subtle);
+    border-left-color: var(--accent);
+  }
+}
+
 // --- Dashboard entity cards (dataset / detector rows) ---
 //
 // `vt-dataset-card` and `vt-detector-card` render as <tr> rows in the dashboard


### PR DESCRIPTION
Part of **Promote shared component primitives** in `docs/plans/ui-style-polish.md`.

The settings modal's **vertical** tab rail was bespoke SCSS (`.settings-tabs` / `.settings-tab`) that couldn't `@extend` a horizontal bar. This extracts a shared `.side-tab-bar` / `.side-tab` primitive — the vertical counterpart to `.importer-tab-bar` — into `frontend/src/scss/_components.scss`, then folds the settings tabs onto it by applying the global classes directly in the template (the same consumption pattern already used for `.segmented-toggle`).

## Changes

- **`_components.scss`** — new `.side-tab-bar` (column flex, fixed 140px, right divider) and `.side-tab` (left-border active indicator) primitive.
- **`settings-modal.component.scss`** — removed the bespoke `.settings-tabs` / `.settings-tab` rules; only the Settings-specific rotating `.settings-tab-icon` stays scoped to the component.
- **`settings-modal.component.html`** — `settings-tabs` → `side-tab-bar`, `settings-tab` → `side-tab`, `settings-tab--active` → `side-tab--active`.
- **`docs/plans/ui-style-polish.md`** — dropped the shipped `.side-tab-bar` slice from the umbrella's "Still owed" list.

The primitive is a byte-for-byte value match of the old rules, so the rendered rail is visually unchanged (no screenshot reshoot needed). The tabs already used the canonical `--border` token, so there was no `--border-color` alias left to resolve.

## Testing

`./run-tests.sh frontend` — build OK, audit OK, 1151 Vitest tests passed; ruff/codespell/deptry/pyright all green.

Closes #2302
