### PR TITLE
Document Add-Dataset picker as intentional persistent-tab Back exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,8 @@ The `.back-btn` rule in `frontend/src/scss/_components.scss` provides the shared
 
 A flow can legitimately carry both: a nested view shows `← Back` at the top to step back one view, while the outer view's footer shows `Cancel` to dismiss the whole modal. What it should *not* do is use the word "Cancel" for an action that is really navigation back to a parent view.
 
+**Persistent-tab pickers are an intentional exception.** The rule's trigger is a view that *replaces* its outer view (the picker vanishes, the form takes over). A picker whose navigation chrome stays **persistently visible** while the selected form renders below it never hides an outer view, so there is nothing to navigate "back" to and no `.back-btn` belongs on it — switching selection is done by clicking a different tab in the always-present bar. The Add-Dataset importer picker (`vt-source-picker`'s `.importer-tab-bar` + `.importer-subtab-bar`) is the canonical case: its category/importer tabs remain on screen with the source form beneath them, so it correctly diverges from the New-detector › Trained flow's picker→form→`← Back` shape. Do not add a `.back-btn` to a persistent-tab picker to "align" it; the divergence is by design. (The footer `Cancel` on such a picker is still correct — it dismisses the whole modal, per the Back-vs-Cancel rule above.)
+
 ## Commands
 
 - **Run tests (CPU, fast)**: `./run-tests.sh` (also runs `ruff check`, `ruff format --check`, `codespell`, `deptry`, and the frontend TypeScript build)

--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -121,13 +121,3 @@ without a browser.
 
 <!-- item-sep -->
 
-- **Dataset importer picker Back affordance (V6)** (#2329) — the Add-Dataset picker
-  (`source-picker.component.html`) uses persistent `.importer-tab-bar` tabs with
-  no `.back-btn`; "going back" means clicking a different tab. The sibling
-  New-detector › Trained › Server-JSON flow uses the canonical picker → `← Back`
-  pattern, so the two diverge. This is a design-alignment call, not a mechanical
-  fix (the footer `Cancel` there legitimately dismisses the whole dialog per the
-  Back-vs-Cancel rule). Decide whether the picker should adopt the
-  form-with-`← Back` shape or stay tabbed, then align. **Files:**
-  `source-picker.component.{html,ts}`; cross-check CLAUDE.md "Nested-modal back
-  buttons".

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
@@ -9,7 +9,17 @@ import { ManagedColumns } from '../../../../utils/managed-columns';
 
 /** Shared "where does the media come from?" widget.  Renders the
  *  importer category tab bar + sub-tab bar at the top, then a
- *  source-specific picker below:
+ *  source-specific picker below.
+ *
+ *  Navigation is a *persistent* two-level tab bar: the category tabs
+ *  (`.importer-tab-bar`) and importer sub-tabs (`.importer-subtab-bar`)
+ *  stay on screen while the selected source form renders beneath them.
+ *  This intentionally diverges from the New-detector › Trained flow's
+ *  picker → form → `← Back` shape, and there is deliberately **no**
+ *  `.back-btn` here: the tabs never hide an outer view, so switching
+ *  source is done by clicking a different tab rather than retreating.
+ *  See CLAUDE.md "Nested-modal back buttons" → persistent-tab-picker
+ *  exception (issue #2329).  Source views rendered below the chrome:
  *
  *  - ``demo``                   → media-type tab bar + sortable demo table
  *  - ``server_folder``          → typed absolute-path input


### PR DESCRIPTION
## What & why

Issue #2329 flags that the Add-Dataset importer picker (`vt-source-picker`) uses a persistent `.importer-tab-bar` with no `.back-btn`, diverging from the New-detector › Trained flow's picker → form → `← Back` shape, and asks to decide whether to align the two.

This is a **design-alignment call**, and the decision is to **keep the tabbed UX**. The Add-Dataset picker's navigation chrome (category tabs + importer sub-tabs) stays *persistently visible* while the selected source form renders below it — it never hides an outer view, so the "Nested-modal back buttons" rule's trigger (a view that *replaces* its outer view) doesn't apply and no `.back-btn` belongs on it. Switching source is done by clicking a different tab in the always-present bar.

Rather than restructure a widget shared by two modals for a false-positive alignment, this records the divergence as intentional so it stops getting re-flagged.

## Changes

- **CLAUDE.md** — add a persistent-tab-picker carve-out to the "Nested-modal back buttons" rule, naming `vt-source-picker` as the canonical case.
- **`source-picker.component.ts`** — note the rationale in the `SourcePickerComponent` doc comment, pointing back at the rule.
- **`docs/plans/ui-style-polish.md`** — prune the now-shipped plan item.

No HTML or runtime behavior changed, so no GUI surface moved and no screenshot reshoot is needed. Frontend `build:prod` and codespell pass.

Closes #2329

🤖 Generated with [Claude Code](https://claude.com/claude-code)