### PR TITLE
Round off-scale durations and stray radii onto the token scales

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -209,12 +209,12 @@ header {
     // both reuse the shared header tilt keyframes.
     &.trophy-open,
     &.help-open {
-      animation: header-icon-tilt-open 0.3s ease-in-out forwards;
+      animation: header-icon-tilt-open var(--transition-slow) ease-in-out forwards;
     }
 
     &.trophy-close,
     &.help-close {
-      animation: header-icon-tilt-close 0.3s ease-in-out forwards;
+      animation: header-icon-tilt-close var(--transition-slow) ease-in-out forwards;
     }
   }
 
@@ -262,11 +262,11 @@ header {
     color: var(--header-text-dim);
 
     &.gear-open {
-      animation: header-icon-tilt-open 0.3s ease-in-out forwards;
+      animation: header-icon-tilt-open var(--transition-slow) ease-in-out forwards;
     }
 
     &.gear-close {
-      animation: header-icon-tilt-close 0.3s ease-in-out forwards;
+      animation: header-icon-tilt-close var(--transition-slow) ease-in-out forwards;
     }
   }
 

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -318,7 +318,7 @@
   // Blink/WebKit track + thumb.
   &::-webkit-slider-runnable-track {
     height: 3px;
-    border-radius: 2px;
+    border-radius: var(--radius-sm);
     background: var(--border);
   }
 
@@ -337,7 +337,7 @@
   // Firefox track + thumb.
   &::-moz-range-track {
     height: 3px;
-    border-radius: 2px;
+    border-radius: var(--radius-sm);
     background: var(--border);
   }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.scss
+++ b/frontend/src/app/components/dashboard/dashboard.component.scss
@@ -67,11 +67,11 @@
 // Delete spins to 90° while confirm dialog is up, then reverses back.
 // Hoisted out of `.side-action-btn` to keep specificity flat.
 .side-action-delete-active {
-  animation: side-action-rotate 0.3s ease-in-out forwards;
+  animation: side-action-rotate var(--transition-slow) ease-in-out forwards;
 }
 
 .side-action-delete-inactive {
-  animation: side-action-rotate 0.3s ease-in-out reverse forwards;
+  animation: side-action-rotate var(--transition-slow) ease-in-out reverse forwards;
 }
 
 @keyframes side-action-rotate {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.scss
@@ -62,7 +62,7 @@
   flex: 0 0 auto;
   color: var(--text-muted);
   font-size: var(--font-xs);
-  transition: transform 0.15s ease;
+  transition: transform var(--transition-base) ease;
 }
 
 .media-type-dropdown.open .media-type-chevron {

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.scss
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.scss
@@ -12,7 +12,7 @@
   &__warn {
     padding: 0.75rem;
     border: 1px solid var(--text-warning);
-    border-radius: 6px;
+    border-radius: var(--radius-lg);
     background: color-mix(in srgb, var(--text-warning) 12%, transparent);
 
     p {

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.scss
@@ -115,7 +115,7 @@
 .swatch {
   width: 12px;
   height: 3px;
-  border-radius: 1px;
+  border-radius: var(--radius-sm);
 }
 
 .swatch-fp {


### PR DESCRIPTION
Part of **Consolidate the remaining ad-hoc token values** in `docs/plans/ui-style-polish.md`. Scopes each off-scale duration/radius site before applying, distinguishing interactive timings (safe to consolidate) from keyframe timing whose feel would change if rounded.

## Durations
Tokenized the raw durations that already sit exactly on the scale, so they consolidate with zero feel change:
- `import-config` media-type chevron rotate: `0.15s` → `var(--transition-base)` (interactive).
- Header icon-tilt animations (`app.component`) and dashboard `side-action-rotate`: `0.3s` → `var(--transition-slow)`.

**Left alone** — deliberately-tuned keyframe/animation timings whose motion would visibly change if rounded onto the 0.1/0.15/0.3s scale:
- progress bar's `0.6s` "longer, decelerating" smooth ease (comment-justified),
- the `0.18s` card/audio swipe, `0.45s` region-box shake, `180ms` toast/offline slide-ins, and the `1.4s`/`1.5s`/`2s` spinner, pulse, and waggle loops.

## Radii
Rounded the stray border-radii onto the radius scale:
- browse-view slider tracks (webkit + moz): `2px` → `var(--radius-sm)`,
- find-stats legend swatch: `1px` → `var(--radius-sm)`,
- portable-export warning box: `6px` → `var(--radius-lg)` (exact match).

`50%` circle radii are left as-is (they're pill/circle geometry, not scale candidates).

## Testing
`./run-tests.sh frontend` — build, audit, and 1151 Vitest tests all pass.

Refs #2322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdZXtaVPaxjZ8iCqkjURxK)_