### PR TITLE
Add --opacity-dim decorative-dim token and consolidate ad-hoc opacity values

### DIFF
--- a/.claude/scripts/style-check.py
+++ b/.claude/scripts/style-check.py
@@ -249,6 +249,42 @@ def check_raw_zindex(files: list[Path]) -> Finding:
 
 
 # ---------------------------------------------------------------------------
+# §1.9 Raw decorative-dim opacity (should be var(--opacity-dim))
+# ---------------------------------------------------------------------------
+# The canonical decorative-dim value. A raw `opacity: 0.7` on a decorative or
+# secondary element (dimmed icon, chevron, accent divider, hint/note text,
+# locked row) should resolve through --opacity-dim so the "recede this
+# decoration" value stays consolidated - the same intent as flagging raw
+# --space-* / --font-* values. Kept in sync with _variables.scss.
+DIM_OPACITY_VALUE = "0.7"
+RAW_OPACITY_RE = re.compile(r"\bopacity\s*:\s*(0?\.\d+|1(?:\.0+)?|0)\b")
+
+
+def check_raw_dim_opacity(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="§1.9 Raw decorative-dim opacity",
+        description=(
+            f"A raw `opacity: {DIM_OPACITY_VALUE}` on a decorative/secondary "
+            "element should use var(--opacity-dim). Legitimate exceptions: "
+            "animation keyframes (0<->1 fades), hover-brighten rest states, and "
+            "the two-tier done/future progression dims carry their own values - "
+            "curate before fixing."
+        ),
+    )
+    for path in files:
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("//"):
+                continue
+            if "var(--opacity" in line:
+                continue
+            m = RAW_OPACITY_RE.search(line)
+            if m and m.group(1) == DIM_OPACITY_VALUE:
+                f.hits.append((path, lineno, line.rstrip()))
+    return f
+
+
+# ---------------------------------------------------------------------------
 # §4.13 `font: inherit` on form-input/form-select aliases
 # ---------------------------------------------------------------------------
 def check_font_inherit_trap(files: list[Path]) -> Finding:
@@ -576,6 +612,7 @@ def main() -> int:
         check_heading_restyling(files),
         check_transition_all(files),
         check_raw_zindex(files),
+        check_raw_dim_opacity(files),
         check_font_inherit_trap(files),
         check_flex_column_no_gap(files),
         check_redeclared_utility(files),

--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -32,8 +32,7 @@ without a browser.
   (broken `var()` refs + deleted-alias usage) have shipped. What's still owed
   is the rest of the value-drift consolidation, tracked as one GitHub issue per
   sub-slice (shipped one-per-PR; the umbrella stays here until the last is
-  done): a decorative-dim opacity token for the ~11 ad-hoc opacity values,
-  distinct from the existing `--opacity-disabled` (#2320); a canvas-overlay
+  done): a canvas-overlay
   `--z-*` token for the raw z-indexes on the browse overlays
   (`browse-view.component.scss` `z-index: 1/2/3`) (#2321); rounding off-scale
   transition/animation durations and stray radii onto the existing scales

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -131,6 +131,14 @@ There is only one disabled opacity. Don't write `opacity: 0.35` or `opacity: 0.4
 
 **Don't use opacity to disable text on a saturated background.** Opacity dims the rendered pixels toward the background, so 50% white on the accent-blue header collapses to a mid-blue that fails contrast. For buttons sitting on `--header-bg` (or any saturated surface), shift `color` to a theme-aware dimmed token (e.g. `--header-text-dim`) and keep the cursor change - skip `opacity` entirely.
 
+### 1.10 Decorative-dim state - `--opacity-dim`
+
+| Token          | Value | When to use |
+|----------------|-------|-------------|
+| `--opacity-dim` | 0.7   | A *decorative or secondary* element intentionally shown muted at rest: a dimmed type/status icon, a dropdown chevron, a faint accent divider line, a hint/note paragraph, a locked achievement row. |
+
+Distinct from `--opacity-disabled`: that one is reserved for interactive `:disabled` / `.disabled` states, this one is about visual hierarchy. Like the disabled value, there is only one decorative-dim value - don't hand-pick 0.55/0.6/0.75 for the same "recede this decoration" job. **Not** for animation keyframes (0↔1 fades), hover-brighten rest states, or the two-tier done/future progression dims; those carry their own values by design.
+
 ---
 
 ## 2. Shared component classes

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.scss
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.scss
@@ -34,5 +34,5 @@
 
 .tier-locked {
   color: var(--text-muted);
-  opacity: 0.55;
+  opacity: var(--opacity-dim);
 }

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.scss
@@ -47,7 +47,7 @@
 }
 
 .achievement-row--locked {
-  opacity: 0.75;
+  opacity: var(--opacity-dim);
 }
 
 .achievement-info {

--- a/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
+++ b/frontend/src/app/components/center-panel/voting-overlay/voting-overlay.component.scss
@@ -15,7 +15,7 @@
   color: var(--text-muted);
   font-size: var(--font-sm);
   text-align: center;
-  opacity: 0.7;
+  opacity: var(--opacity-dim);
   pointer-events: none;
 }
 

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.scss
@@ -74,7 +74,7 @@ td {
 
 .type-icon {
   flex-shrink: 0;
-  opacity: 0.7;
+  opacity: var(--opacity-dim);
 }
 
 // The trash icon spins to 90° while its confirm dialog is up, then reverses

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -69,7 +69,7 @@ td {
 
 .type-icon {
   flex-shrink: 0;
-  opacity: 0.7;
+  opacity: var(--opacity-dim);
 }
 
 // The trash icon spins to 90° while its confirm dialog is up, then reverses

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -267,7 +267,7 @@
 
 .select-arrow {
   flex-shrink: 0;
-  opacity: 0.6;
+  opacity: var(--opacity-dim);
   transition: transform var(--transition-base);
 
   .custom-select.open & { transform: rotate(180deg); }

--- a/frontend/src/app/components/drop-zone/drop-zone.component.scss
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.scss
@@ -43,7 +43,7 @@
 .drop-zone-icon {
   width: 28px;
   height: 28px;
-  opacity: 0.7;
+  opacity: var(--opacity-dim);
   pointer-events: none;
 }
 

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.scss
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.scss
@@ -64,7 +64,7 @@
     flex: 1;
     height: 1px;
     background: var(--accent);
-    opacity: 0.5;
+    opacity: var(--opacity-dim);
   }
 }
 

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.scss
@@ -51,5 +51,5 @@
   right: 0;
   height: 1px;
   background: var(--accent);
-  opacity: 0.6;
+  opacity: var(--opacity-dim);
 }

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.scss
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.scss
@@ -29,7 +29,7 @@
     margin: 0;
     font-size: var(--font-md);
     color: var(--text-primary);
-    opacity: 0.75;
+    opacity: var(--opacity-dim);
   }
 
   &__ok {

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.scss
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.scss
@@ -14,7 +14,7 @@
 .detector-type {
   margin-left: 0.5rem;
   font-size: var(--font-xs);
-  opacity: 0.6;
+  opacity: var(--opacity-dim);
 }
 
 // `.subhead` headings carry a trailing `(?)` help icon whose `title`

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -75,6 +75,18 @@
   // contrast on a saturated surface.
   --opacity-disabled: 0.5;
 
+  // Decorative-dim opacity. One value for a *decorative or secondary*
+  // element intentionally shown muted at rest - a dimmed type/status icon,
+  // a dropdown chevron, a faint accent divider line, a hint/note paragraph,
+  // a locked achievement row. Distinct from --opacity-disabled (which is
+  // reserved for interactive `:disabled` / `.disabled` states): this one is
+  // about visual hierarchy, not interactivity. A rendered audit found ~11
+  // sites hand-picking 0.5/0.55/0.6/0.7/0.75 for the same "recede this
+  // decoration" job; they all resolve here now. Do NOT use it for animation
+  // keyframes (0<->1 fades), hover-brighten rest states, or the two-tier
+  // done/future progression dims - those carry their own values by design.
+  --opacity-dim: 0.7;
+
   // Z-index scale (centralised stacking order)
   --z-base: 1;
   --z-elevated: 10;


### PR DESCRIPTION
Part of **Consolidate the remaining ad-hoc token values** in `docs/plans/ui-style-polish.md`.

Adds a shared **decorative-dim** opacity token, `--opacity-dim: 0.7`, distinct from the interactive `--opacity-disabled` (0.5), and routes the scattered decorative-dim opacity sites onto it.

## Audit

Every raw `opacity:` site was sorted into decorative-dim vs. animation/keyframe vs. disabled vs. hover-rest vs. two-tier progression. Only genuinely **decorative/secondary elements shown muted at rest** moved onto the token (11 sites, previously drifting across 0.5/0.55/0.6/0.7/0.75):

| Site | Was | Dims |
|------|-----|------|
| `media-list` | 0.5 | accent divider line |
| `stripe-overview` | 0.6 | accent threshold line |
| `auto-find-settings` `.detector-type` | 0.6 | secondary label |
| `new-detector-modal` `.select-arrow` | 0.6 | dropdown chevron |
| `dataset-card` / `detector-card` `.type-icon` | 0.7 | type icon |
| `drop-zone` `.drop-zone-icon` | 0.7 | icon |
| `voting-overlay` `.vote-hint` | 0.7 | hint text |
| `detector-portable-export` `&__note` | 0.75 | note text |
| `achievements-tab` `.achievement-row--locked` | 0.75 | locked row |
| `achievement-badge` `.tier-locked` | 0.55 | locked tier icon |

**Deliberately left alone:** animation keyframes (`0↔1` fades), hover-brighten rest states (help-icon, minimap close/resize, image-view-controls, data-table resize handle), the two-tier `.done`/`.future` autopilot progression dims (distinct values by design), and interactive `:disabled` / `.disabled` / `.is-locked` / `.is-incompatible` states (those belong to `--opacity-disabled`).

## Enforcement

Extended `.claude/scripts/style-check.py` with a `§1.9 Raw decorative-dim opacity` check that flags raw `opacity: 0.7` in component SCSS (mirroring the existing token-drift checks). Post-consolidation it surfaces only the four documented legitimate exceptions, which the report flags as curate-before-fixing. Also documented the token in `docs/style-guide.md` (§1.10).

## Testing

`./run-tests.sh frontend` — Angular `build:prod` OK, `npm audit` clean, Vitest 1151 passed.

Closes #2320

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUamyZe6UMZzgUEJJrhBJR)_