### PR TITLE
Consolidate hand-copied box-shadows onto --shadow-md

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -37,8 +37,7 @@ without a browser.
   `--z-*` token for the raw z-indexes on the browse overlays
   (`browse-view.component.scss` `z-index: 1/2/3`) (#2321); rounding off-scale
   transition/animation durations and stray radii onto the existing scales
-  (#2322); resolving hand-copied box-shadows through `--shadow-sm/md/lg`
-  (#2323); and sharing one selected-tile tint token (#2324). Each is
+  (#2322); and sharing one selected-tile tint token (#2324). Each is
   judgment-heavy (which opacity sites are "decorative dim" vs. animation vs.
   disabled; which durations are interactive vs. keyframe timing that would
   change feel if rounded), so scope each before applying. **Files:**

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -65,7 +65,7 @@ header {
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 12px var(--shadow-dropdown);
+  box-shadow: var(--shadow-md);
   min-width: 160px;
   z-index: var(--z-modal-backdrop);
   display: none;

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.scss
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.scss
@@ -7,7 +7,7 @@
   padding: var(--space-sm);
   pointer-events: none;
   max-width: 280px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
 }
 
 .hover-count {


### PR DESCRIPTION
## Summary

Two component SCSS files carried literal `0 4px 12px` `box-shadow` declarations that duplicate the `--shadow-md` token (`0 4px 12px var(--shadow-dropdown)`). This resolves both through the token, per the token-consolidation sub-slice in `docs/plans/ui-style-polish.md`.

- **`app.component.scss` (`.burger-dropdown`)** — was `0 4px 12px var(--shadow-dropdown)`, an **exact** duplicate of `--shadow-md`. Straight swap to `var(--shadow-md)`.
- **`browse-hover-preview.component.scss` (`.hover-popup`)** — was `0 4px 12px rgba(0, 0, 0, 0.3)`. Same geometry as `--shadow-md`, but a hardcoded shadow color. Rounded onto `var(--shadow-md)`: it's an md-elevation floating popup like the existing token consumers (tooltips, toasts, context menu, dropdowns), and it now inherits the theme-aware `--shadow-dropdown` color instead of a fixed rgba.

The remaining literal `box-shadow` values in the codebase are genuinely distinct — inset ring/glow shadows (`inset 0 0 0 2px var(--accent)`, region-box selection rings, etc.) that don't map to the `sm/md/lg` elevation scale — and are left as-is.

## Plan

Removed the `#2323` clause from the "Consolidate the remaining ad-hoc token values" umbrella item in `docs/plans/ui-style-polish.md`, since this sub-slice is now shipped.

## Testing

`./run-tests.sh frontend` — build OK, 1151 Vitest unit tests pass.

Closes #2323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U45jF7TCsr9Q1HwcqQVGau)_