### PR TITLE
Share one canonical selected-tile tint token (#2324)

### DIFF
--- a/.claude/scripts/style-check.py
+++ b/.claude/scripts/style-check.py
@@ -285,6 +285,37 @@ def check_raw_dim_opacity(files: list[Path]) -> Finding:
 
 
 # ---------------------------------------------------------------------------
+# Bespoke accent-tinted selection fill (must use --accent-highlight-bg)
+# ---------------------------------------------------------------------------
+# The canonical selected/highlight tint is --accent-highlight-bg. A hand-rolled
+# `color-mix(in srgb, var(--accent) N%, transparent)` reinvents it with a
+# slightly-off alpha (a static audit found a stray 18% mix). Matches only the
+# bare `var(--accent)` form, so the legitimate decorative tint that carries a
+# fallback (`var(--accent, var(--text-primary))`, e.g. keyboard keys) is not
+# flagged.
+ACCENT_MIX_RE = re.compile(r"color-mix\(\s*in\s+srgb\s*,\s*var\(--accent\)\s+\d", re.IGNORECASE)
+
+
+def check_bespoke_accent_tint(files: list[Path]) -> Finding:
+    f = Finding(
+        rule="Bespoke accent selection tint (use --accent-highlight-bg)",
+        description=(
+            "The selected/highlight tint has one canonical token, "
+            "--accent-highlight-bg. Don't hand-roll `color-mix(in srgb, "
+            "var(--accent) N%, transparent)` for a selected item/tile fill - it "
+            "drifts the alpha per component. Reach for var(--accent-highlight-bg)."
+        ),
+    )
+    for path in files:
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if line.strip().startswith("//"):
+                continue
+            if ACCENT_MIX_RE.search(line):
+                f.hits.append((path, lineno, line.rstrip()))
+    return f
+
+
+# ---------------------------------------------------------------------------
 # §4.13 `font: inherit` on form-input/form-select aliases
 # ---------------------------------------------------------------------------
 def check_font_inherit_trap(files: list[Path]) -> Finding:
@@ -613,6 +644,7 @@ def main() -> int:
         check_transition_all(files),
         check_raw_zindex(files),
         check_raw_dim_opacity(files),
+        check_bespoke_accent_tint(files),
         check_font_inherit_trap(files),
         check_flex_column_no_gap(files),
         check_redeclared_utility(files),

--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -34,9 +34,9 @@ without a browser.
   sub-slice (shipped one-per-PR; the umbrella stays here until the last is
   done): a canvas-overlay
   `--z-*` token for the raw z-indexes on the browse overlays
-  (`browse-view.component.scss` `z-index: 1/2/3`) (#2321); rounding off-scale
-  transition/animation durations and stray radii onto the existing scales
-  (#2322); and sharing one selected-tile tint token (#2324). Each is
+  (`browse-view.component.scss` `z-index: 1/2/3`) (#2321); and rounding
+  off-scale transition/animation durations and stray radii onto the existing
+  scales (#2322). Each is
   judgment-heavy (which opacity sites are "decorative dim" vs. animation vs.
   disabled; which durations are interactive vs. keyframe timing that would
   change feel if rounded), so scope each before applying. **Files:**

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -112,7 +112,7 @@
   }
 
   &.active {
-    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    background: var(--accent-highlight-bg);
     border-color: var(--accent);
     color: var(--text-primary);
   }
@@ -366,7 +366,7 @@
   // Selection: a solid accent ring at the cell edge (mirrors bin selection on
   // the canvas) plus an accent-tinted fill.
   &.selected {
-    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    background: var(--accent-highlight-bg);
     color: var(--text-primary);
     box-shadow: 0 0 0 2px var(--accent);
   }

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -155,6 +155,11 @@
   --indicator-dot: #555;
   --good-bg: rgba(76, 175, 80, 0.08);
   --bad-bg: rgba(244, 67, 54, 0.08);
+  // Canonical selected/highlight tint. The one accent-tinted fill for a
+  // selected item or tile (selected table rows, entity cards, media items,
+  // bin-popup thumbnails). Do NOT hand-roll a bespoke accent tint per
+  // component (a static audit found a stray `color-mix(accent 18%)` doing the
+  // same job) - reach for this token so the selected-state tint stays uniform.
   --accent-highlight-bg: rgba(124, 138, 255, 0.2);
   --accent-highlight-border: rgba(124, 138, 255, 0.5);
   --missing-border: #3b82f6;


### PR DESCRIPTION
## What & why

Part of **Consolidate the remaining ad-hoc token values** in `docs/plans/ui-style-polish.md`.

The selected/highlight tint was reinvented in `browse-bin-popup.component.scss` as `color-mix(in srgb, var(--accent) 18%, transparent)` — both the selected thumbnail fill and the active filter chip — diverging from the canonical `--accent-highlight-bg` token (accent at 20%/25%/20% per dark/light/highviz theme) already used on `.entity-card.selected`, selected data-table rows, media items, and elsewhere.

Rather than introduce a redundant second token, this folds the two bespoke copies onto the existing `--accent-highlight-bg`, reconciling the minor alpha difference (18% → 20%/25%).

## Changes

- **`browse-bin-popup.component.scss`** — replace both `color-mix(var(--accent) 18%)` fills with `var(--accent-highlight-bg)`.
- **`_variables.scss`** — document `--accent-highlight-bg` as the one canonical selected-tile tint (no value change).
- **`.claude/scripts/style-check.py`** — add a narrow report rule that flags a hand-rolled `color-mix(in srgb, var(--accent) N%, transparent)` selection fill and steers to the token. Matches only the bare `var(--accent)` form, so the legitimate decorative tint carrying a fallback (`var(--accent, var(--text-primary))`, e.g. keyboard keys) is not flagged.
- **`docs/plans/ui-style-polish.md`** — prune the shipped `#2324` sub-slice from the umbrella item (umbrella stays for the remaining #2320–2323 sub-slices).

## Testing

- `./run-tests.sh frontend` — ruff/format/codespell/deptry/pyright clean, frontend build OK, `npm audit` clean, 1151 Vitest tests pass.
- `style-check.py` reports the new rule clean (0 hits), confirming both copies are folded; regex sanity-checked to catch the old 18% drift while not matching the decorative fallback tint.

Closes #2324
