### PR TITLE
Simplify header and layout IA

### DIFF
--- a/docs/plans/standard-workflow-polish.md
+++ b/docs/plans/standard-workflow-polish.md
@@ -60,14 +60,14 @@ the original priority.
 
 <!-- item-sep -->
 
-- **"Email us" mailto has no recipient (`mailto-recipient`, P3)** —
-  `frontend/src/app/app.component.html:98` is
+- **"Email us" mailto has no recipient (`mailto-recipient`, P3)** — the
+  "Email us" affordance now lives in the Help modal
+  (`keyboard-help-modal.component.html`, `.help-footer`) as
   `mailto:?subject=VTSearch%20Issue%3A` — the subject typo is fixed but the
   to-address is still empty, so "Email us" opens a blank-recipient compose
-  window. **Fix:** add the recipient address. **Files:** `app.component.html`.
-  **Note:** `ui-style-polish.md` ("Simplify header and layout IA") also edits
-  this file to repoint the logo `mailto:` to Dashboard and move "email us" into
-  Help — coordinate so the two don't collide.
+  window. **Fix:** add the recipient address. **Files:**
+  `keyboard-help-modal.component.html`. (The "Simplify header and layout IA"
+  slice that moved this out of the header logo has already shipped.)
 
 <!-- item-sep -->
 

--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -87,22 +87,6 @@ without a browser.
 
 <!-- item-sep -->
 
-- **Simplify header and layout IA** (#2327) — the 3-panel grid is declared *twice* with
-  conflicting borders (`scss/_layout.scss:5` and `app.component.scss:296`, both
-  `300px 1fr 300px`) — a dead, conflicting source of truth. The fixed 300px
-  side panels don't scale on wide monitors; the burger menu and the top bar
-  duplicate the same four destinations; the logo is a `mailto:` link
-  (`app.component.html:98`) instead of navigating to the Dashboard; and there
-  are three near-identical header icon-button classes (`.help-btn`,
-  `.achievements-btn`, `.settings-btn`). **Fix:** delete one grid declaration;
-  switch side tracks to `minmax(280px, 20%)`; drop the burger-vs-topbar
-  duplication; point the logo at Dashboard and move "email us" into Help;
-  collapse the three header button classes into one `.header-icon-btn`.
-  **Files:** `_layout.scss`, `app.component.{scss,html}`. **Note:** the empty
-  `mailto:` recipient on the separate "Email us" affordance is tracked in
-  `standard-workflow-polish.md` (`mailto-recipient`) — same file, different
-  line; coordinate.
-
 <!-- item-sep -->
 
 <!-- item-sep -->

--- a/docs/user/screenshots-reshoot-queue.md
+++ b/docs/user/screenshots-reshoot-queue.md
@@ -61,6 +61,15 @@ changes size and text metrics, so **both** theme variants of every shot below
 are stale. Rows are not individually annotated with this reason — it applies
 to the whole table.
 
+**Responsive side tracks (2026-07-12).** The three-panel `.layout` grid's side
+columns changed from a fixed `300px` to `minmax(280px, 20%)`, so at the harness's
+1440px viewport each side panel renders 288px (was 300px) and the centre panel
+gains the reclaimed 24px. Every shot that frames the label/find three-panel
+layout — `three-panel`, `results-grid`, `view-options`, `autopilot-progress`,
+`autopilot-vote`, `manual-controls`, `region-voting`, `find-view` — shifts by
+these few px. All are already listed below for other reasons; this note records
+the additional layout drift so a drain session knows to expect it.
+
 | Shot id | Embedded in | Why it's stale | Flagged |
 |---------|-------------|----------------|---------|
 | `importer-picker` | `docs/user/USER_GUIDE.md#loading-a-dataset` | The shot's caption calls out "per-row readiness badges" (`.badge-ready`/`.badge-embedding`); the 2026-07-09 UI style review Phase 1 fix swapped their unreadable white text for a new `--badge-text-dark` token, changing the badge's rendered text color in both themes. Also: 2026-07-09 light-mode neutral-ramp change (see note above) shifts the light variant's background tone. | 2026-07-09 |

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -4,11 +4,11 @@
   <vt-login (loggedIn)="auth.checkStatus()" />
 } @else {
   <header>
-    <nav class="burger-menu" aria-label="Main menu">
+    <nav class="burger-menu" aria-label="Recent sessions">
       <button
         class="burger-btn"
-        title="Open main menu"
-        aria-label="Menu"
+        title="Recent sessions"
+        aria-label="Recent sessions"
         [attr.aria-expanded]="menuOpen"
         aria-haspopup="true"
         (click)="toggleMenu($event)"
@@ -21,63 +21,11 @@
         class="burger-dropdown"
         [class.show]="menuOpen"
         role="menu"
-        aria-label="Main menu"
+        aria-label="Recent sessions"
         (keydown)="onMenuKeydown($event)"
         >
-        <div
-          class="burger-item"
-          [class.disabled]="!isOnLabelView()"
-          role="menuitem"
-          tabindex="-1"
-          (click)="onDashboard()"
-          [title]="isOnLabelView() ? 'Return to the Dashboard to manage datasets and detectors' : 'Already at the Dashboard'"
-          ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <rect x="1" y="1" width="14" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
-          <rect x="3.5" y="3" width="9" height="3" rx="0.5" stroke="currentColor" stroke-width="1.0"/>
-          <rect x="3.5" y="7.5" width="9" height="3" rx="0.5" stroke="currentColor" stroke-width="1.0"/>
-          <line x1="8" y1="12" x2="8" y2="14" stroke="currentColor" stroke-width="1.2"/>
-          <line x1="5.5" y1="14" x2="10.5" y2="14" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
-        </svg> Dashboard</div>
-        <div
-          class="burger-item"
-          role="menuitem"
-          tabindex="-1"
-          (click)="onHelp()"
-          title="Show help (keyboard shortcuts and user guide)"
-          ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.2"/>
-          <path d="M5.8 6.2a2.2 2.2 0 014.4 0c0 1.1-.8 1.5-1.5 2-.5.3-.7.7-.7 1.2" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/>
-          <circle cx="8" cy="12" r="0.7" fill="currentColor"/>
-        </svg> Help</div>
-        @if (!achievementsDisabled()) {
-          <div
-            class="burger-item"
-            role="menuitem"
-            tabindex="-1"
-            (click)="onAchievements()"
-            title="Achievements: usage milestones and tier progress"
-            ><svg class="menu-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
-            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M6 4h12v4a6 6 0 0 1-12 0z"/>
-            <path d="M6 6H3a2 2 0 0 0 0 4h3"/>
-            <path d="M18 6h3a2 2 0 0 1 0 4h-3"/>
-            <line x1="10" y1="14" x2="10" y2="18"/>
-            <line x1="14" y1="14" x2="14" y2="18"/>
-            <rect x="7" y="18" width="10" height="3" rx="1"/>
-          </svg> Achievements</div>
-        }
-        <div
-          class="burger-item"
-          role="menuitem"
-          tabindex="-1"
-          (click)="onSettings()"
-          title="Open the Settings panel to configure appearance, sorting, autopilot, and autoload"
-          ><svg class="menu-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <path d="M6.7 2.2h2.6l.3 1.8a5.2 5.2 0 011.2.7l1.7-.7 1.3 2.2-1.4 1.1a5.3 5.3 0 010 1.4l1.4 1.1-1.3 2.2-1.7-.7a5.2 5.2 0 01-1.2.7l-.3 1.8H6.7l-.3-1.8a5.2 5.2 0 01-1.2-.7l-1.7.7-1.3-2.2 1.4-1.1a5.3 5.3 0 010-1.4L2.2 6.2l1.3-2.2 1.7.7a5.2 5.2 0 011.2-.7l.3-1.8z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
-          <circle cx="8" cy="8" r="1.6" fill="currentColor"/>
-        </svg> Settings</div>
+        <div class="burger-section-header">Recent sessions</div>
         @if (recentSessions().length > 0) {
-          <div class="burger-section-header">Recent sessions</div>
           @for (s of recentSessions(); track s.dataset_id + '::' + s.detector_id) {
             <div
               class="burger-item burger-subitem"
@@ -92,12 +40,19 @@
               </div>
             </div>
           }
+        } @else {
+          <div class="burger-status">No recent sessions yet.</div>
         }
       </div>
     </nav>
-    <a href="mailto:?subject=VTSearch%20Issue%3A" title="Email us with any comments, concerns, or suggestions!">
+    <button
+      class="logo-btn"
+      [class.disabled]="!isOnLabelView()"
+      (click)="onDashboard()"
+      [title]="isOnLabelView() ? 'Go to the Dashboard to manage datasets and detectors' : 'Already at the Dashboard'"
+    >
       <img src="logo.png" alt="VTSearch logo" class="header-logo">
-    </a>
+    </button>
     <button
       class="top-bar-btn"
       [class.disabled]="!isOnLabelView()"
@@ -110,7 +65,7 @@
     <span class="top-bar-spacer"></span>
     @if (!achievementsDisabled()) {
       <button
-        class="achievements-btn"
+        class="header-icon-btn"
         aria-label="Achievements"
         title="Achievements: usage milestones and tier progress"
         (click)="onAchievements()"
@@ -131,7 +86,7 @@
     </button>
   }
   <button
-    class="help-btn"
+    class="header-icon-btn"
     aria-label="Help"
     title="Help (?)"
     (click)="onHelp()"
@@ -143,7 +98,7 @@
     <circle cx="8" cy="12" r="0.7" fill="currentColor"/>
   </svg></button>
   <button
-    class="settings-btn"
+    class="header-icon-btn"
     aria-label="Settings"
     title="Settings"
     (click)="onSettings()"

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -14,6 +14,20 @@ header {
   background: var(--header-bg);
   border-bottom: 1px solid var(--header-border);
 
+  .logo-btn {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+
+    &.disabled {
+      // On the Dashboard itself the logo is a no-op, so drop the pointer cue.
+      cursor: default;
+    }
+  }
+
   .header-logo {
     height: 36px;
     width: auto;
@@ -74,12 +88,6 @@ header {
   &.show {
     display: block;
   }
-}
-
-.menu-icon {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
 }
 
 .burger-item {
@@ -186,8 +194,11 @@ header {
   flex: 1;
 }
 
-.help-btn,
-.achievements-btn {
+// Single shared class for the header's icon buttons (Achievements, Help,
+// Settings). Each flavor's open/close animation class (trophy-*, help-*,
+// gear-*) reuses the same tilt keyframes.
+.header-icon-btn {
+  position: relative;
   background: transparent;
   border: 1px solid var(--header-btn-border);
   border-radius: var(--radius-md);
@@ -204,16 +215,16 @@ header {
     height: 20px;
     color: var(--header-text-dim);
 
-    // Tilt-and-hold while the button's modal is open, mirroring the Settings
-    // gear. trophy-* lives on the Achievements icon, help-* on the Help icon;
-    // both reuse the shared header tilt keyframes.
+    // Tilt-and-hold while the button's modal is open.
     &.trophy-open,
-    &.help-open {
+    &.help-open,
+    &.gear-open {
       animation: header-icon-tilt-open var(--transition-slow) ease-in-out forwards;
     }
 
     &.trophy-close,
-    &.help-close {
+    &.help-close,
+    &.gear-close {
       animation: header-icon-tilt-close var(--transition-slow) ease-in-out forwards;
     }
   }
@@ -226,10 +237,6 @@ header {
       color: var(--header-text);
     }
   }
-}
-
-.achievements-btn {
-  position: relative;
 
   .notif-dot {
     position: absolute;
@@ -244,73 +251,10 @@ header {
   }
 }
 
-.settings-btn {
-  background: transparent;
-  border: 1px solid var(--header-btn-border);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  padding: var(--space-xs);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background var(--transition-base), border-color var(--transition-base);
-  flex-shrink: 0;
-
-  svg {
-    width: 20px;
-    height: 20px;
-    color: var(--header-text-dim);
-
-    &.gear-open {
-      animation: header-icon-tilt-open var(--transition-slow) ease-in-out forwards;
-    }
-
-    &.gear-close {
-      animation: header-icon-tilt-close var(--transition-slow) ease-in-out forwards;
-    }
-  }
-
-  &:hover {
-    background: var(--header-btn-hover-bg);
-    border-color: var(--header-btn-hover-border);
-
-    svg {
-      color: var(--header-text);
-    }
-  }
-}
-
 .main-content {
   flex: 1;
   min-height: 0;
   overflow: hidden;
-}
-
-// Keep the 3-panel layout classes for future phases (4-6)
-.layout {
-  display: grid;
-  grid-template-columns: 300px 1fr 300px;
-  flex: 1;
-  overflow: hidden;
-}
-
-.panel-left,
-.panel-center,
-.panel-right {
-  overflow-y: auto;
-  padding: var(--space-xl);
-  border-right: 1px solid var(--border);
-}
-
-.panel-right {
-  border-right: none;
-}
-
-.placeholder {
-  color: var(--text-muted);
-  text-align: center;
-  margin-top: 40%;
-  font-style: italic;
 }
 
 @keyframes header-icon-tilt-open {

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -89,39 +89,45 @@ describe('AppComponent', () => {
     expect(fixture.componentInstance.menuOpen).toBe(false);
   });
 
-  it('should render all menu items', () => {
+  it('should show the Recent sessions burger with an empty state when none exist', () => {
     const fixture = TestBed.createComponent(AppComponent);
     TestBed.tick();
-    const items = fixture.nativeElement.querySelectorAll('.burger-item');
-    expect(items.length).toBe(4);
-    expect(items[0].textContent).toContain('Dashboard');
-    expect(items[1].textContent).toContain('Help');
-    expect(items[2].textContent).toContain('Achievements');
-    expect(items[3].textContent).toContain('Settings');
+    const dropdown = fixture.nativeElement.querySelector('.burger-dropdown') as HTMLElement;
+    // The burger no longer duplicates the top-bar destinations; it is a
+    // Recent-sessions menu, empty by default in the test harness.
+    expect(dropdown.querySelector('.burger-section-header')?.textContent).toContain(
+      'Recent sessions',
+    );
+    expect(dropdown.querySelectorAll('.burger-subitem').length).toBe(0);
+    expect(dropdown.querySelector('.burger-status')?.textContent).toContain('No recent sessions');
   });
 
-  it('should disable dataset-dependent items when not on label view', () => {
+  it('should render the header icon buttons (Achievements, Help, Settings)', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    TestBed.tick();
+    const buttons = fixture.nativeElement.querySelectorAll('header .header-icon-btn');
+    const labels = Array.from(buttons).map((b) => (b as HTMLElement).getAttribute('aria-label'));
+    expect(labels).toEqual(['Achievements', 'Help', 'Settings']);
+  });
+
+  it('should disable the Dashboard logo/button when not on label view', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.componentInstance.isOnLabelView.set(false);
     TestBed.tick();
-    const items = fixture.nativeElement.querySelectorAll('.burger-item');
-    // Only Dashboard is dataset-dependent and gets disabled off the label view.
-    expect(items[0].classList).toContain('disabled');
-    // Help, Achievements, and Settings are always enabled.
-    expect(items[1].classList).not.toContain('disabled');
-    expect(items[2].classList).not.toContain('disabled');
-    expect(items[3].classList).not.toContain('disabled');
+    const logo = fixture.nativeElement.querySelector('.logo-btn') as HTMLElement;
+    const dashBtn = fixture.nativeElement.querySelector('.top-bar-btn') as HTMLButtonElement;
+    expect(logo.classList).toContain('disabled');
+    expect(dashBtn.disabled).toBe(true);
   });
 
-  it('should enable dataset-dependent items when on label view', () => {
+  it('should enable the Dashboard logo/button when on label view', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.componentInstance.isOnLabelView.set(true);
     TestBed.tick();
-    const items = fixture.nativeElement.querySelectorAll('.burger-item');
-    expect(items[0].classList).not.toContain('disabled');
-    expect(items[1].classList).not.toContain('disabled');
-    expect(items[2].classList).not.toContain('disabled');
-    expect(items[3].classList).not.toContain('disabled');
+    const logo = fixture.nativeElement.querySelector('.logo-btn') as HTMLElement;
+    const dashBtn = fixture.nativeElement.querySelector('.top-bar-btn') as HTMLButtonElement;
+    expect(logo.classList).not.toContain('disabled');
+    expect(dashBtn.disabled).toBe(false);
   });
 
   it('should not navigate to dashboard when disabled', () => {

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
@@ -74,5 +74,10 @@
         }
       </div>
     }
+
+    <p class="help-footer">
+      Comments, concerns, or suggestions?
+      <a href="mailto:?subject=VTSearch%20Issue%3A">Email us</a>.
+    </p>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.scss
@@ -117,6 +117,18 @@
   font-size: var(--font-sm);
 }
 
+.help-footer {
+  margin: 0;
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+
+  a {
+    color: var(--accent, var(--text-primary));
+  }
+}
+
 .guide {
   max-height: 70vh;
   overflow-y: auto;

--- a/frontend/src/scss/_layout.scss
+++ b/frontend/src/scss/_layout.scss
@@ -2,7 +2,9 @@
 
 .layout {
   display: grid;
-  grid-template-columns: 300px 1fr 300px;
+  // Side panels track the viewport (min 280px, up to 20% each) so they widen
+  // on large monitors instead of staying pinned at a fixed 300px.
+  grid-template-columns: minmax(280px, 20%) 1fr minmax(280px, 20%);
   flex: 1;
   overflow: hidden;
 }


### PR DESCRIPTION
Resolves the structural issues in the app shell called out in `docs/plans/ui-style-polish.md` → **Simplify header and layout IA**.

## What changed

- **One grid, source of truth.** Deleted the dead, component-scoped 3-panel grid declaration in `app.component.scss` (it never applied — Angular view-encapsulation scoped it to `app.component.html`, which has no `.layout`). The global `frontend/src/scss/_layout.scss` is now the single declaration.
- **Side panels scale on wide monitors.** The side tracks change from a fixed `300px` to `minmax(280px, 20%)`, so the panels widen with the viewport instead of staying pinned at 300px.
- **Dropped the burger-vs-topbar duplication.** Dashboard/Help/Achievements/Settings were listed in both the burger dropdown *and* the top bar. The top bar now owns those destinations; the burger becomes a **Recent sessions** menu (with a "No recent sessions yet." empty state). The unused `.menu-icon` rule was removed.
- **Logo → Dashboard.** The logo was a `mailto:` link; it's now a button that navigates to the Dashboard (disabled/no-op when already there, mirroring the top-bar Dashboard button, which was kept per design). The "Email us" affordance moved into the **Help** modal (`.help-footer`), preserving the existing `mailto:` (empty recipient is fixed separately by the `mailto-recipient` item).
- **Collapsed three header icon-button classes into one.** `.help-btn` / `.achievements-btn` / `.settings-btn` are now a single shared `.header-icon-btn` (the Achievements notification dot and the trophy/help/gear tilt animations all fold onto it).

## Tests / docs

- Rewrote the `app.component.spec.ts` cases that asserted the four burger items to cover the new IA (Recent-sessions burger + empty state, the three `.header-icon-btn` buttons, and the logo/Dashboard disabled state).
- Full suite green: `./run-tests.sh` → all 5732 tests pass; frontend build + Vitest (1155) + ruff/pyright/deptry/wiring all clean.
- **Screenshots:** the responsive side-track change shifts the label/find three-panel layout shots by a few px at the harness's 1440px viewport. No browser this session, so this is recorded in `docs/user/screenshots-reshoot-queue.md` (all affected shots were already queued from prior whole-set changes; added a note documenting the new layout drift). Also corrected the `mailto-recipient` item's file pointer in `standard-workflow-polish.md`, since the mailto moved into the Help modal.

Closes #2327

🤖 Generated with [Claude Code](https://claude.com/claude-code)