### PR TITLE
Copy-style guide + microcopy sweep

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -107,14 +107,5 @@ without a browser.
 
 <!-- item-sep -->
 
-- **Copy-style guide + sweep** (#2328) — microcopy drifts three ways: ellipsis is
-  written `...`, `…`, and `&hellip;`; Title Case and sentence case are mixed;
-  one concept has several names (Train/Label, Find/Autodetect; "model" leaks
-  into UI where the product word is "detector"); placeholder casing is
-  inconsistent. **Fix:** add a copy-style section to `docs/style-guide.md`
-  (sentence-vs-Title-case decision, `…` only, placeholder format, canonical
-  product vocabulary), then sweep the templates to match. **Files:**
-  `docs/style-guide.md` + template text.
-
 <!-- item-sep -->
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -369,7 +369,99 @@ Avoid them. The right answer is almost always "use a theme variable." If a compo
 
 ---
 
-## 4. Anti-patterns (do not do these)
+## 4. Copy style (voice, casing, vocabulary)
+
+Microcopy is styling too. Visible UI text - button labels, headings, form
+labels, placeholders, hints, empty states, tooltips - follows the same
+"one rule, applied everywhere" discipline as the tokens. The rules below are
+not machine-enforced (casing can't be reliably linted), so they live here and
+are applied by hand during review.
+
+### 4.1 Casing: Title Case for chrome, sentence case for content
+
+Two buckets, one rule each:
+
+- **Title Case** - the framing "chrome" of the UI: **modal titles** (`vt-modal
+  title="…"`), **section headings** (`<h1>`–`<h4>`, `.section-title`,
+  `.dashboard-section-title`), and **button labels** (`.btn`, toolbar/icon
+  buttons with a text label, radio-pill labels). These name a surface or an
+  action, so they read as a title.
+- **sentence case** - everything the user *reads or fills in*: **form field
+  labels** (`.form-label`, `.col-label`), **placeholders**, **hints**
+  (`.form-hint`, `.info-text`), **empty-state messages** (`.empty-state`),
+  **tooltips** (`title="…"`), **aria-labels**, and any inline description or
+  status sentence. Capitalize only the first word and proper nouns.
+
+**Title Case rule.** Capitalize the first and last word and every "major"
+word. Keep these lowercase unless they're first or last: articles (`a`, `an`,
+`the`), coordinating conjunctions (`and`, `but`, `or`, `nor`, `for`, `so`,
+`yet`), and short prepositions (`to`, `of`, `in`, `on`, `at`, `by`, `for`,
+`with`, `from`, …). So it's `Add Media to Bad`, `Sort by Detector`, `Copy to
+Clipboard` (not `Copy To Clipboard`), `Add Corrections to Detector`.
+
+| Surface | Case | Example |
+|---------|------|---------|
+| Modal title | Title Case | `Combine Datasets`, `Crop Example`, `Use This Example?` |
+| Section heading (`h2`–`h4`, `.section-title`) | Title Case | `Detector Accuracy`, `What You'll Get` |
+| Button label | Title Case | `Import Labels`, `Rebuild Map`, `Download Bundle` |
+| Form field label | sentence case | `Detector name`, `Conflict policy`, `Cell size` |
+| Placeholder | sentence case | `Combined dataset name`, `Describe what you're looking for` |
+| Hint / info / empty-state | sentence case | `No detectors yet. Click + to add one.` |
+| Tooltip (`title=`) / aria-label | sentence case | `Order labeled items by time, name, or detector confidence` |
+
+Proper nouns keep their own casing everywhere (`HuggingFace`, `VTSearch`,
+`UMAP`), as do the canonical capitalized buckets **Good** / **Bad** when they
+name the two vote piles (`Add Media to Good`, `Mark this media as a Bad
+example`).
+
+### 4.2 Ellipsis: the `…` character only
+
+Use the single Unicode ellipsis character **`…` (U+2026)**. Never the three-dot
+ASCII `...`, and never the HTML entity `&hellip;`. This holds for both templates
+and any user-facing string literal in a `.ts` file (`signal('Loading…')`,
+status messages, fallback labels).
+
+- **In-progress button/status labels** end in `…`: `Creating…`, `Importing…`,
+  `Combining…`, `Saving…`, `Scoring with example media…`.
+- **Truncation** markers use `…` too (`… 12 more rows`, `text.slice(0, 300) +
+  '…'`).
+- **Placeholders do *not* end in `…`** (see §4.3).
+
+### 4.3 Placeholder format
+
+- **Sentence case**, no trailing ellipsis, no trailing period.
+- For "here's what to type" examples, prefix with `e.g. ` and match the casing
+  of the real value: a free-text query is lowercase (`e.g. dog barking
+  sounds`), a proper name is Title Case (`e.g. Dog Barks`).
+- For "leave blank to get a default" inputs, state that: `Leave blank to use a
+  default name`.
+- For a server/file path, use the shared hint `path/to/file` (or
+  `/absolute/server/path/to/file` when an absolute path is required) - don't
+  invent a new spelling.
+
+### 4.4 Canonical product vocabulary
+
+One concept, one word. The product noun for the trained ranker is
+**detector** - **never** "model" in user-facing text. ("Model" is correct only
+when it genuinely means a HuggingFace **AI model** / embedder, e.g. the gated-model
+download copy in Settings.) Internal identifiers (`ngModel`, `trainMode.model`,
+CSS classes) are exempt - this rule is about *visible* strings only.
+
+| Concept | Canonical word | Don't write |
+|---------|----------------|-------------|
+| The trained ranker (the product's core object) | **detector** | model |
+| Making a detector by voting good/bad | **Train** (verb) / **Learned** (the sort mode) | — |
+| Running a detector across a dataset to score items | **Find** (the action) / **Auto-Find** (the automatic/CLI variant) | — |
+| The two vote piles | **Good** / **Bad** | positives/negatives (in general UI; the ML terms are fine inside a stats table) |
+
+`Train` and `Find` are the two flow verbs surfaced to users; keep them stable.
+Meaning-bearing distinctions are *not* drift and stay as-is: `Verified Good`
+vs. `Good` (a real Find-mode state), and `Positives`/`Negatives` inside the
+detector-stats table (standard ML terminology in that context).
+
+---
+
+## 5. Anti-patterns (do not do these)
 
 1. **Hardcoded `px` / `rem` for padding, margin, gap.** Pick a `--space-*` token.
 2. **Hardcoded font sizes.** Pick a `--font-*` token. `0.78rem`, `0.95rem`, `13px` are all violations.
@@ -394,7 +486,7 @@ Avoid them. The right answer is almost always "use a theme variable." If a compo
 
 ---
 
-## 5. Adding new shared styles
+## 6. Adding new shared styles
 
 When you have a pattern that recurs (the third time you copy similar SCSS from one component to another), promote it to `_components.scss` (general shared) or `_picker-shared.scss` (importer/exporter/picker domain) or `_data-table.scss` (tables). Don't let the same "kind of thing" diverge across components - that's how the codebase ends up with three "small buttons" that all look slightly different.
 
@@ -405,7 +497,7 @@ When you add a new token:
 
 ---
 
-## 6. References
+## 7. References
 
 - `frontend/src/scss/_variables.scss` - every design token.
 - `frontend/src/scss/_components.scss` - buttons, forms, modals, headings, info/error/success text.

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -186,7 +186,7 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   }
 
   private loadText(mediaId: number): void {
-    this.textContent.set('Loading...');
+    this.textContent.set('Loading…');
     // Cancel any in-flight text load so a slow earlier response can't clobber
     // the preview after the cursor has moved to another hex.
     this.textLoadAbort?.abort();
@@ -198,7 +198,7 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
       .then((data) => {
         if (this.hover()?.cell.rep_id === mediaId) {
           const text: string = data.content || '';
-          this.textContent.set(text.length > 300 ? text.slice(0, 300) + '...' : text);
+          this.textContent.set(text.length > 300 ? text.slice(0, 300) + '…' : text);
         }
       })
       .catch((err) => {

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -62,7 +62,7 @@
                 ? 'Rebuild the map from the items shown'
                 : 'Rebuild the map from all items'">
               <vt-icon type="shuffle" [size]="14"></vt-icon>
-              Rebuild map
+              Rebuild Map
             </button>
             @if (mediaType() === 'audio') {
               <div class="browse-now-playing">

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
@@ -41,7 +41,7 @@ describe('TextViewerComponent', () => {
     // setInput drives ngOnChanges (the real channel), which kicks off the fetch.
     fixture.componentRef.setInput('media', mockMedia);
     await settleZoneless(fixture);
-    expect(fixture.nativeElement.textContent).toContain('Loading...');
+    expect(fixture.nativeElement.textContent).toContain('Loading…');
     // Flush the in-flight request so afterEach httpMock.verify() sees none
     // dangling. The loading-state assertion above runs before the response.
     httpMock.expectOne('/api/medias/4/text').flush({ content: 'done' });

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
@@ -17,7 +17,7 @@ export class TextViewerComponent implements OnChanges, OnDestroy {
 
   // Signal so the HTTP response (written from a `.subscribe()` callback, which is
   // not on the zoneless CD-notification path) repaints the view.
-  readonly text = signal('Loading...');
+  readonly text = signal('Loading…');
   private sub: Subscription | null = null;
   // See ImageViewerComponent.lastMediaId; avoid re-fetching the text payload
   // every time the metadata cache hydrates a new reference for the same id.
@@ -36,7 +36,7 @@ export class TextViewerComponent implements OnChanges, OnDestroy {
 
   private loadText(): void {
     this.sub?.unsubscribe();
-    this.text.set('Loading...');
+    this.text.set('Loading…');
     this.sub = this.mediasApi.getText(this.media.id).subscribe({
       next: (data) => {
         this.text.set(data.content || '');

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
@@ -98,7 +98,7 @@
       [title]="disabledReason || 'Combine these datasets into a new one'"
     >
       @if (submitting()) {
-        Combining...
+        Combining…
       } @else {
         Combine
       }

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
@@ -19,7 +19,7 @@
     </div>
 
     <div class="form-group">
-      <label class="col-label" for="combine-new-name" title="The name of the new combined detector">New Name <span class="required">*</span></label>
+      <label class="col-label" for="combine-new-name" title="The name of the new combined detector">New name <span class="required">*</span></label>
       <input
         id="combine-new-name"
         class="form-input"
@@ -57,7 +57,7 @@
   <div modal-footer>
     <button type="button" class="btn btn--secondary" [disabled]="submitting" (click)="close()" title="Discard and close the dialog">Cancel</button>
     <button type="button" class="btn btn--primary" [disabled]="!canSubmit" (click)="submit()" title="Combine the selected detectors into a new one">
-      {{ submitting ? 'Combining...' : 'Combine' }}
+      {{ submitting ? 'Combining…' : 'Combine' }}
     </button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -104,7 +104,7 @@
               <tr class="loading-task-row" [class.loading-task-error]="!!task.error">
                 <td class="select-col"></td>
                 <td>
-                  <span class="loading-task-name">{{ task.name || 'Loading...' }}</span>
+                  <span class="loading-task-name">{{ task.name || 'Loading…' }}</span>
                 </td>
                 <td [attr.colspan]="visibleDatasetColumns.length + 1">
                   @if (task.error) {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1341,7 +1341,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const findParams = { dataset_ids: datasetIds, detector_ids: detectorIds };
 
     this.datasetState.setLoading(true);
-    this.datasetState.setProgressMessage('Checking labels...');
+    this.datasetState.setProgressMessage('Checking labels…');
 
     // Pre-flight: check if any labels fail to resolve
     this.detectorsFindApi.findCheckLabels(findParams).subscribe({
@@ -1377,7 +1377,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
           if (!progress || progress.status === 'idle') return;
 
           this.datasetState.setProgressMessage(
-            formatProgressMessage(progress, 'Running Find...'),
+            formatProgressMessage(progress, 'Running Find…'),
           );
         },
       });
@@ -1388,7 +1388,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   private runFind(findParams: Record<string, unknown>): void {
-    this.datasetState.setProgressMessage('Running Find...');
+    this.datasetState.setProgressMessage('Running Find…');
     this.startFindProgressPolling();
 
     this.detectorsFindApi.find(findParams).subscribe({

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -138,7 +138,7 @@
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="genericFormPicker.submit()" [disabled]="genericFormPicker.submitting() || !genericFormPicker.canSubmit">
         @if (genericFormPicker.submitting()) {
-          Importing...
+          Importing…
         } @else {
           Import
         }
@@ -151,7 +151,7 @@
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="localFolderPicker.submit()" [disabled]="localFolderPicker.submitting() || localFolderPicker.files().length === 0">
         @if (localFolderPicker.submitting()) {
-          Uploading...
+          Uploading…
         } @else {
           Upload &amp; Import
         }
@@ -164,7 +164,7 @@
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
       <button class="btn btn--primary" (click)="serverFolderPicker.submit()" [disabled]="serverFolderPicker.submitting() || !serverFolderPicker.folderPath()">
         @if (serverFolderPicker.submitting()) {
-          Importing...
+          Importing…
         } @else {
           Import
         }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-  <label class="form-label" for="demo-dataset-name" title="Optional name for the new dataset. Leave blank to use the demo's name.">Dataset Name</label>
+  <label class="form-label" for="demo-dataset-name" title="Optional name for the new dataset. Leave blank to use the demo's name.">Dataset name</label>
   <input
     id="demo-dataset-name"
     type="text"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.html
@@ -13,7 +13,7 @@
 }
 
 <div class="form-group">
-  <label class="form-label" for="lf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder/file name.">Dataset Name</label>
+  <label class="form-label" for="lf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder/file name.">Dataset name</label>
   <input
     id="lf-dataset-name"
     type="text"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.html
@@ -56,7 +56,7 @@
 </div>
 
 <div class="form-group">
-  <label class="form-label" for="sf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder name.">Dataset Name</label>
+  <label class="form-label" for="sf-dataset-name" title="Optional name for the new dataset. Leave blank to use the picked folder name.">Dataset name</label>
   <input
     id="sf-dataset-name"
     type="text"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
@@ -114,7 +114,7 @@ export class SourcePickerComponent {
   readonly activeDemoTabChange = output<string>();
   readonly demoSelected = output<DemoDatasetEntry>();
 
-  readonly demoLoadingText = input('Loading demo datasets...');
+  readonly demoLoadingText = input('Loading demo datasets…');
   readonly demoEmptyText = input('No demo datasets available.');
   readonly demoNoTabHint = input('Select the media type to demonstrate.');
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -16,7 +16,7 @@
     <form class="new-detector-form" (ngSubmit)="submit()">
       @if (tab === 'blank' && !effectiveSoloMediaType) {
         <div class="form-group">
-          <label class="col-label" title="The type of media this detector will process">Media Type</label>
+          <label class="col-label" title="The type of media this detector will process">Media type</label>
           <div class="media-type-row">
             <div class="custom-select"
               [class.open]="mediaTypeDropdownOpen"
@@ -136,10 +136,10 @@
       @if (tab === 'trained') {
         @if (trainedView === 'picker') {
           <div class="form-group">
-            <label class="col-label">Import Labels From <span class="required">*</span></label>
+            <label class="col-label">Import labels from <span class="required">*</span></label>
             <p class="info-text">Choose where to import labels from. The resulting detector's training data will be the imported labels.</p>
             @if (labelImportersLoading()) {
-              <p class="empty-state">Loading importers...</p>
+              <p class="empty-state">Loading importers…</p>
             } @else if (labelImporters().length === 0) {
               <p class="empty-state">No label importers available.</p>
             } @else {
@@ -271,7 +271,7 @@
       }
 
       <div class="form-group">
-        <label class="col-label" for="detector-name" title="A short name to identify this detector">Detector Name</label>
+        <label class="col-label" for="detector-name" title="A short name to identify this detector">Detector name</label>
         <input
           id="detector-name"
           class="form-input"
@@ -334,12 +334,12 @@
       @if (tab === 'blank') {
         <button class="btn btn--primary" [disabled]="!canSubmitBlank" (click)="submit()"
           title="Create the detector with the example you provided">
-          {{ submitting() ? 'Creating...' : 'Create' }}
+          {{ submitting() ? 'Creating…' : 'Create' }}
         </button>
       } @else {
         <button class="btn btn--primary" [disabled]="!canSubmitTrained" (click)="submit()"
           title="Create the detector and import labels from the selected source">
-          {{ submitting() ? 'Importing...' : 'Create & Import' }}
+          {{ submitting() ? 'Importing…' : 'Create & Import' }}
         </button>
       }
     </div>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -1075,14 +1075,14 @@ export class NewDetectorModalComponent implements OnInit {
     return typeId;
   }
 
-  /** "Browse Images...", "Browse Audio...", "Browse Media..." as a fallback. */
+  /** "Browse Images…", "Browse Audio…", "Browse Media…" as a fallback. */
   get browseMediaLabel(): string {
     const mediaType = this.mediaType();
     const name = mediaType ? this.getMediaTypeLabel(mediaType) : '';
-    if (!name) return 'Browse Media...';
+    if (!name) return 'Browse Media…';
     // audio and text don't take a plural -s in this context.
     const uncountable = mediaType === 'audio' || mediaType === 'text';
-    return `Browse ${uncountable ? name : name + 's'}...`;
+    return `Browse ${uncountable ? name : name + 's'}…`;
   }
 
   /** "Drop an image file here", "Drop a video file here", etc. */

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -577,7 +577,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   onTextSort(text: string): void {
     this.sortState.setTextQuery(text);
     this.sortState.setSortBusy(true);
-    this.sortState.setSortStatus('Sorting...');
+    this.sortState.setSortStatus('Sorting…');
     this.sortingApi.sort({ text }).pipe(takeUntil(this.destroy$)).subscribe({
       next: (response) => {
         this.sortState.setSortResults(
@@ -602,7 +602,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   onLearnedSort(autoSelect = true): void {
     if (!this.voteState.learnedSortAvailable) return;
     this.sortState.setSortBusy(true);
-    this.sortState.setSortStatus('Training...');
+    this.sortState.setSortStatus('Training…');
     this.sortingApi.learnedSort().pipe(takeUntil(this.destroy$)).subscribe({
       next: (response) => {
         if (response.status === 'done') {
@@ -1124,7 +1124,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const filenames = this.labelSession.mediaExampleFilenames;
     if (filenames.length > 0) {
       this.sortState.setSortBusy(true);
-      this.sortState.setSortStatus(filenames.length > 1 ? 'Sorting by examples...' : 'Sorting by example...');
+      this.sortState.setSortStatus(filenames.length > 1 ? 'Sorting by examples…' : 'Sorting by example…');
       this.sortingApi.exampleSortServer({ filenames }).pipe(takeUntil(this.destroy$)).subscribe({
         next: (response) => {
           this.sortState.setSortResults(

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
@@ -46,7 +46,7 @@
           <input
             class="form-input text-sort-input"
             type="text"
-            placeholder="Describe what you're looking for..."
+            placeholder="Describe what you're looking for…"
             [value]="textQuery"
             (input)="onTextInput($any($event.target).value)"
             (keyup.enter)="submitTextSort()"

--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -23,7 +23,7 @@
         <p class="login-error">{{ error }}</p>
       }
       <button type="submit" [disabled]="busy" title="Log in to VTSearch">
-        {{ busy ? 'Logging in...' : 'Log in' }}
+        {{ busy ? 'Logging in…' : 'Log in' }}
       </button>
     </form>
   </div>

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -106,7 +106,7 @@
       [rows]="clipboardRows"
       [columns]="clipboardColumns"
       buttonVariant="secondary"
-      copyLabel="Copy To Clipboard"
+      copyLabel="Copy to Clipboard"
     ></vt-clipboard-copy>
   </div>
 

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -1,6 +1,6 @@
 <vt-modal [open]="true" [title]="'Stats: ' + datasetName()" (closed)="close()">
   @if (loading()) {
-    <p class="loading-text">Loading stats...</p>
+    <p class="loading-text">Loading stats…</p>
   } @else if (error()) {
     <p class="error-text">{{ error() }}</p>
   } @else if (stats(); as stats) {

--- a/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.html
+++ b/frontend/src/app/components/modals/detector-portable-export-modal/detector-portable-export-modal.component.html
@@ -1,18 +1,18 @@
-<vt-modal [title]="'Export model: ' + detectorName()" [open]="true" (closed)="close()">
+<vt-modal [title]="'Export Detector: ' + detectorName()" [open]="true" (closed)="close()">
   <div class="pexport">
     <div class="pexport__warn" role="note">
-      <strong>⚠ This writes a trained model to disk.</strong>
+      <strong>⚠ This writes a trained detector to disk.</strong>
       <p>
-        VTSearch normally keeps trained models in memory only — this export is the
+        VTSearch normally keeps trained detectors in memory only — this export is the
         deliberate exception. The bundle contains <em>no raw media and no
         fingerprints</em>: just the small trained detector, the name of the
-        embedder to use, and the cutoff. (A trained model can still reveal some
+        embedder to use, and the cutoff. (A trained detector can still reveal some
         information about its training data, so share it only with parties you'd
         trust with the labels themselves.)
       </p>
     </div>
 
-    <h3>What you'll get</h3>
+    <h3>What You'll Get</h3>
     <ul class="pexport__list">
       <li><code>detector.onnx</code> — the trained detector (runs anywhere).</li>
       <li><code>manifest.json</code> — the embedder to use and the cutoff.</li>
@@ -20,7 +20,7 @@
     </ul>
 
     <p class="pexport__note">
-      The model is trained against the <strong>currently loaded dataset's</strong>
+      The detector is trained against the <strong>currently loaded dataset's</strong>
       embedder, so a compatible dataset must be loaded.
     </p>
 
@@ -40,7 +40,7 @@
       [disabled]="downloading()"
       title="Download the portable detector bundle"
     >
-      {{ downloading() ? 'Preparing…' : 'Download bundle' }}
+      {{ downloading() ? 'Preparing…' : 'Download Bundle' }}
     </button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.html
@@ -1,6 +1,6 @@
 <vt-modal [open]="true" [title]="'Stats: ' + detectorName()" (closed)="close()">
   @if (loading()) {
-    <p class="loading-text">Loading stats...</p>
+    <p class="loading-text">Loading stats…</p>
   } @else if (error()) {
     <p class="error-text">{{ error() }}</p>
   } @else if (stats(); as stats) {

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.html
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.html
@@ -1,6 +1,6 @@
 <vt-modal title="Edit Examples" [open]="true" (closed)="close()">
   @if (loading()) {
-    <p class="empty-state">Loading examples...</p>
+    <p class="empty-state">Loading examples…</p>
   } @else {
     <div class="examples-sections">
       <div class="examples-section">
@@ -51,7 +51,7 @@
   <div class="editor-actions" modal-footer>
     <button class="btn btn--secondary" (click)="close()">Cancel</button>
     <button class="btn btn--primary" (click)="save()" [disabled]="saving()">
-      {{ saving() ? 'Saving...' : 'Save' }}
+      {{ saving() ? 'Saving…' : 'Save' }}
     </button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -44,7 +44,7 @@
       }
     </h3>
     @if (!labelsLoaded()) {
-      <p class="empty-state">Loading labels...</p>
+      <p class="empty-state">Loading labels…</p>
     } @else if (filteredLabels.length === 0) {
       <p class="empty-state">No labeled items to export.</p>
     } @else {
@@ -81,7 +81,7 @@
             @if (filteredLabels.length > 50) {
               <tr class="truncated-row">
                 <td [attr.colspan]="enabledColumns.length">
-                  ... {{ filteredLabels.length - 50 | number }} more rows
+                  … {{ filteredLabels.length - 50 | number }} more rows
                 </td>
               </tr>
             }

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.html
@@ -64,7 +64,7 @@
       </tbody>
     </table>
 
-    <h3 class="section-title" title="Raising inclusion keeps more items: you catch more real matches but also let in more wrong ones. Pick the point that best balances the two on your data.">Missed vs. wrong matches by inclusion</h3>
+    <h3 class="section-title" title="Raising inclusion keeps more items: you catch more real matches but also let in more wrong ones. Pick the point that best balances the two on your data.">Missed vs. Wrong Matches by Inclusion</h3>
     <div class="chart-wrap">
       <svg
         class="fpfn-chart"

--- a/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/label-exporter-modal/label-exporter-modal.component.html
@@ -1,6 +1,6 @@
 <vt-modal [title]="title" [open]="true" (closed)="close()">
   @if (loading()) {
-    <p class="empty-state">Loading exporters...</p>
+    <p class="empty-state">Loading exporters…</p>
   } @else if (exporters().length === 0) {
     <p class="empty-state">No exporters available.</p>
   } @else {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -2,7 +2,7 @@
   @if (view === 'picker') {
     <div class="importer-picker">
       @if (loading()) {
-        <p class="empty-state">Loading importers...</p>
+        <p class="empty-state">Loading importers…</p>
       } @else if (importers().length === 0) {
         <p class="empty-state">No label importers available.</p>
       } @else {
@@ -19,7 +19,7 @@
 
     @if (!targetModelName()) {
     <div class="add-media-section">
-      <p class="add-media-heading">Add media directly</p>
+      <p class="add-media-heading">Add Media Directly</p>
       <div class="add-media-buttons">
         <input
           #addBadInput
@@ -33,7 +33,7 @@
           (click)="triggerAddBad()"
           title="Upload a media file and add it to the Bad pile."
         >
-          {{ addingBad() ? 'Adding to Bad pile…' : 'Add media to Bad' }}
+          {{ addingBad() ? 'Adding to Bad Pile…' : 'Add Media to Bad' }}
         </button>
         <input
           #addGoodInput
@@ -47,7 +47,7 @@
           (click)="triggerAddGood()"
           title="Upload a media file and add it to the Good pile."
         >
-          {{ addingGood() ? 'Adding to Good pile…' : 'Add media to Good' }}
+          {{ addingGood() ? 'Adding to Good Pile…' : 'Add Media to Good' }}
         </button>
       </div>
     </div>

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
@@ -125,15 +125,15 @@ describe('LabelImporterModalComponent', () => {
     expect(component.closed.emit).toHaveBeenCalled();
   });
 
-  it('should render Add media to Good and Add media to Bad buttons in picker view', async () => {
+  it('should render Add Media to Good and Add Media to Bad buttons in picker view', async () => {
     await flushInit();
     const el = fixture.nativeElement as HTMLElement;
     const addGoodBtn = el.querySelector('.btn-add-good');
     const addBadBtn = el.querySelector('.btn-add-bad');
     expect(addGoodBtn).toBeTruthy();
     expect(addBadBtn).toBeTruthy();
-    expect(addGoodBtn!.textContent!.trim()).toBe('Add media to Good');
-    expect(addBadBtn!.textContent!.trim()).toBe('Add media to Bad');
+    expect(addGoodBtn!.textContent!.trim()).toBe('Add Media to Good');
+    expect(addBadBtn!.textContent!.trim()).toBe('Add Media to Bad');
   });
 
   it('should have hidden file inputs for add-to-pile', async () => {

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.html
@@ -100,7 +100,7 @@
           Local example media
           <input type="file" (change)="onMediaFileSelected($event)" hidden />
         </label>
-        <button class="btn btn--secondary file-btn" (click)="openMediaPicker()" title="Browse server media sources to pick an example file">Browse media sources...</button>
+        <button class="btn btn--secondary file-btn" (click)="openMediaPicker()" title="Browse server media sources to pick an example file">Browse Media Sources…</button>
         @if (serverMediaFiles().length > 0) {
           <h4 class="subhead" title="Example media files available on the server">Server Example Media</h4>
           <div class="file-list">

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -112,7 +112,7 @@ export class LoadSortModalComponent implements OnInit {
 
   onCropConfirmed(result: MediaCropResult): void {
     this.pendingFile = null;
-    this.status.set('Scoring with example media...');
+    this.status.set('Scoring with example media…');
     this.sortingApi.exampleSort(result.file, result.cropParams).subscribe({
       next: (data) => {
         this.status.set('');
@@ -141,7 +141,7 @@ export class LoadSortModalComponent implements OnInit {
   }
 
   loadServerMedia(filename: string): void {
-    this.status.set('Scoring with example media...');
+    this.status.set('Scoring with example media…');
     this.sortingApi.exampleSortServer({ filenames: [filename] }).subscribe({
       next: (data) => {
         this.status.set('');

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.html
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.html
@@ -1,6 +1,6 @@
 <vt-modal
   [open]="true"
-  [title]="view === 'cropping' ? 'Crop example' : 'Use this example?'"
+  [title]="view === 'cropping' ? 'Crop Example' : 'Use This Example?'"
   (closed)="onCancel()">
   @if (view === 'confirm') {
     <div class="preview">
@@ -51,7 +51,7 @@
         [disabled]="!cropSupported"
         [title]="cropSupported ? 'Crop to a sub-region' : 'Cropping not supported for this media type'"
         (click)="onOkButCrop()">
-        OK but crop
+        OK but Crop
       </button>
       <button type="button" class="btn btn--primary" (click)="onOk()">OK</button>
     </div>

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
@@ -2,7 +2,7 @@
   @if (analyzing) {
     <div class="analysis-loading">
       @if (useCachedHistory()) {
-        <p aria-live="polite">Loading indicator history...</p>
+        <p aria-live="polite">Loading indicator history…</p>
       } @else {
         <vt-job-progress
           aria-live="polite"

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
@@ -9,7 +9,7 @@
 
       <div class="example-columns">
         <div class="example-col">
-          <label class="col-label">New Text Example</label>
+          <label class="col-label">New text example</label>
           <div class="text-input-row">
             <input
               class="form-input"
@@ -22,15 +22,15 @@
           </div>
         </div>
         <div class="example-col">
-          <label class="col-label">New Media Example</label>
-          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" title="Browse loaded media to pick a new example">Browse Media...</button>
+          <label class="col-label">New media example</label>
+          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" title="Browse loaded media to pick a new example">Browse Media…</button>
           <input
             #fileInput
             type="file"
             class="hidden-file-input"
             (change)="onLocalFileSelected($event)"
           />
-          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="fileInput.click()" title="Upload a media file from your computer">Upload File...</button>
+          <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="fileInput.click()" title="Upload a media file from your computer">Upload File…</button>
         </div>
       </div>
 
@@ -100,7 +100,7 @@
       }
 
       @if (browseLoading()) {
-        <p class="empty-state">Loading items...</p>
+        <p class="empty-state">Loading items…</p>
       }
 
       @if (selectedSource && !fileBrowsing && !browseLoading() && browseItems().length === 0) {

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -2,7 +2,7 @@
   @if (view === 'picker') {
     <div class="exporter-picker">
       @if (loading()) {
-        <p class="empty-state">Loading exporters...</p>
+        <p class="empty-state">Loading exporters…</p>
       } @else if (exporters().length === 0) {
         <p class="empty-state">No settings exporters available.</p>
       } @else {
@@ -101,7 +101,7 @@
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting()">
           <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"/><polyline points="15 3 21 3 21 9"/><line x1="12" y1="12" x2="21" y2="3"/></svg>
           @if (submitting()) {
-            Exporting...
+            Exporting…
           } @else {
             Export
           }

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -2,7 +2,7 @@
   @if (view === 'picker') {
     <div class="importer-picker">
       @if (loading()) {
-        <p class="empty-state">Loading importers...</p>
+        <p class="empty-state">Loading importers…</p>
       } @else if (importers().length === 0) {
         <p class="empty-state">No settings importers available.</p>
       } @else {
@@ -107,7 +107,7 @@
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting()">
           <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           @if (submitting()) {
-            Importing...
+            Importing…
           } @else {
             Import
           }

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
@@ -9,7 +9,7 @@
   </span>
 </h4>
 @if (loadingDetectors) {
-  <p class="empty-state">Loading detectors&hellip;</p>
+  <p class="empty-state">Loading detectors…</p>
 } @else if (detectors.length === 0) {
   <p class="empty-state">No detectors registered yet. Train or import a detector first.</p>
 } @else {
@@ -40,7 +40,7 @@
   </span>
 </h4>
 @if (loadingExporters) {
-  <p class="empty-state">Loading exporters&hellip;</p>
+  <p class="empty-state">Loading exporters…</p>
 } @else {
   <div class="view-tabs">
     <button

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -1,6 +1,6 @@
 <vt-modal title="Settings" [open]="true" (closed)="close()">
   @if (loading()) {
-    <p class="empty-state">Loading settings...</p>
+    <p class="empty-state">Loading settings…</p>
   } @else {
     <div class="settings-layout">
       <nav class="side-tab-bar">
@@ -84,7 +84,7 @@
             </select>
           </div>
           <div class="form-group">
-            <label class="form-label" for="setting-animations" title="Choose whether decorative motion plays across the whole app">Show Animations<vt-field-hint-icon hint="Controls decorative motion across the app. “Show” forces it on, “Hide” turns it off, and “OS Setting” follows your system’s reduce-motion preference."></vt-field-hint-icon></label>
+            <label class="form-label" for="setting-animations" title="Choose whether decorative motion plays across the whole app">Show animations<vt-field-hint-icon hint="Controls decorative motion across the app. “Show” forces it on, “Hide” turns it off, and “OS Setting” follows your system’s reduce-motion preference."></vt-field-hint-icon></label>
             <select id="setting-animations" class="form-select" [ngModel]="settings().show_animations" (ngModelChange)="onAnimationModeChange($event)" title="Choose whether decorative motion plays">
               <option value="show">Show</option>
               <option value="hide">Hide</option>
@@ -134,7 +134,7 @@
               <div class="view-side-section">
                 <h4 class="subhead" title="Display settings for the left panel (unlabeled media list)">Left Side</h4>
                 <div class="form-group">
-                  <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus Mode:</label>
+                  <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus mode:</label>
                   <div class="segmented-toggle segmented-toggle--stretch">
                     <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getFocusMode('focus_mode_left', activeViewTab()) === 'click'" (click)="onFocusModeChange('focus_mode_left', activeViewTab(), 'click')" title="Click an item to preview it in the center panel">
                       <vt-icon type="cursor-click" [size]="14"></vt-icon> Click
@@ -145,7 +145,7 @@
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="form-label" for="setting-grid-icon-left" title="Thumbnail size in the media grid">Grid Icon Size:</label>
+                  <label class="form-label" for="setting-grid-icon-left" title="Thumbnail size in the media grid">Grid icon size:</label>
                   <select id="setting-grid-icon-left" class="form-select" [ngModel]="getGridIconSize('grid_icon_size_left', activeViewTab())" (ngModelChange)="onGridIconSizeChange('grid_icon_size_left', activeViewTab(), $event)" title="Choose thumbnail size for the grid view" aria-label="Left grid icon size">
                     <option value="XS">XS</option>
                     <option value="S">S</option>
@@ -158,7 +158,7 @@
               <div class="view-side-section">
                 <h4 class="subhead" title="Display settings for the right panel (labeled goods and bads)">Right Side</h4>
                 <div class="form-group">
-                  <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus Mode:</label>
+                  <label class="form-label" title="How an item is selected for preview: click to select, or hover to preview on mouseover">Focus mode:</label>
                   <div class="segmented-toggle segmented-toggle--stretch">
                     <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getFocusMode('focus_mode_right', activeViewTab()) === 'click'" (click)="onFocusModeChange('focus_mode_right', activeViewTab(), 'click')" title="Click an item to preview it in the center panel">
                       <vt-icon type="cursor-click" [size]="14"></vt-icon> Click
@@ -169,7 +169,7 @@
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="form-label" for="setting-grid-icon-right" title="Thumbnail size in the media grid">Grid Icon Size:</label>
+                  <label class="form-label" for="setting-grid-icon-right" title="Thumbnail size in the media grid">Grid icon size:</label>
                   <select id="setting-grid-icon-right" class="form-select" [ngModel]="getGridIconSize('grid_icon_size_right', activeViewTab())" (ngModelChange)="onGridIconSizeChange('grid_icon_size_right', activeViewTab(), $event)" title="Choose thumbnail size for the grid view" aria-label="Right grid icon size">
                     <option value="XS">XS</option>
                     <option value="S">S</option>
@@ -261,7 +261,7 @@
             <input id="setting-autopilot-resort" type="number" class="form-input" [ngModel]="settings().autopilot_resort_interval" (ngModelChange)="onNumberChange('autopilot_resort_interval', $event)" min="1" title="Votes between automatic re-sorts" />
           </div>
           <div class="form-group">
-            <label class="form-label" for="setting-autopilot-diversity" title="Target diversity level for the exploration phase. Higher values mean autopilot will push you to sample from more distinct regions of the dataset.">Goal Diversity</label>
+            <label class="form-label" for="setting-autopilot-diversity" title="Target diversity level for the exploration phase. Higher values mean autopilot will push you to sample from more distinct regions of the dataset.">Goal diversity</label>
             <input id="setting-autopilot-diversity" type="number" class="form-input" [ngModel]="settings().autopilot_goal_diversity" (ngModelChange)="onNumberChange('autopilot_goal_diversity', $event)" min="1" title="Target diversity level for the exploration phase" />
           </div>
 


### PR DESCRIPTION
Closes #2328.

Adds a copy-style section to the frontend style guide and sweeps the templates (and user-facing `.ts` string literals) to match.

## Guide: new `## 4. Copy style` in `docs/style-guide.md`

- **Casing** — Title Case for the framing chrome (modal titles, section headings `h1`–`h4`/`.section-title`, button labels); sentence case for content the user reads or fills in (form field labels, placeholders, hints, empty states, tooltips, aria-labels, inline body). Includes the Title Case minor-word rule (`Add Media to Bad`, `Copy to Clipboard`).
- **Ellipsis** — the single `…` (U+2026) character only; never `...` or `&hellip;`, in templates and in `.ts` UI strings.
- **Placeholder format** — sentence case, no trailing ellipsis/period, `e.g.` convention, shared `path/to/file` hint.
- **Canonical vocabulary** — **detector** is the product noun, never "model" in user-facing text (except where it genuinely means a HuggingFace AI model/embedder); **Train** / **Find** as the two flow verbs. Meaning-bearing distinctions (`Verified Good` vs `Good`, `Positives`/`Negatives` in the stats table) are documented as intentional, not drift.

Inserted as §4 with the following three sections renumbered (5 Anti-patterns, 6 Adding shared styles, 7 References); the two existing cross-refs (§2.4, §3.0) are unaffected.

## Sweep

- **Ellipsis** — normalized every `...` / `&hellip;` to `…` across all templates and user-facing status/label/fallback strings in `.ts` files (spread operators left untouched).
- **Casing** — re-cased deviating buttons/headings/titles to Title Case (`Rebuild Map`, `Download Bundle`, `Add Media to Good/Bad`, `Browse Media Sources…`, `Crop Example`/`Use This Example?`, `Missed vs. Wrong Matches by Inclusion`, `What You'll Get`, `Copy to Clipboard`, `OK but Crop`) and form field labels to sentence case (`Detector name`, `Dataset name`, `Media type`, `Import labels from`, `New name`, `Show animations`, `Focus mode:`, `Grid icon size:`, `Goal diversity`, `New text/media example`).
- **Vocabulary** — fixed the `model`→`detector` leak in the portable-export modal (title, warning, and body copy). The deep Find/Score/Auto-Detect and Train/Label naming is documented as canonical but left in place (it encodes real distinctions); this PR does not rename it.

## Testing

- `./run-tests.sh frontend` — build OK, `npm audit` clean, Vitest **1154 passed**. Updated two spec assertions (`text-viewer`, `label-importer`) that pinned the old strings.

Removes the shipped **Copy-style guide + sweep** item from `docs/plans/ui-style-polish.md` (sentinels left intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuK6h4qmyGiDhGh4CAsFzp)_