### PR TITLE
Unify the icon system onto the vt-icon registry (#2326)

### DIFF
--- a/docs/plans/ui-style-polish.md
+++ b/docs/plans/ui-style-polish.md
@@ -65,14 +65,6 @@ without a browser.
 
 <!-- item-sep -->
 
-- **Unify the icon system** (#2326) — several inline SVGs are pasted 2–4× (eye/export/
-  trash/combine, the tri-state checkbox), the center-panel toolbar uses raw
-  Unicode glyphs (`⟲ ⟳ − +`) and a text "Reset", and there are three different
-  success-check renderings. **Fix:** move the duplicated SVGs into the `vt-icon`
-  registry and replace the glyphs/text with registry icons. Deep-verify each
-  duplicate against the current `vt-icon` registry when planning (some may
-  already be registered). **Files:** `vt-icon` registry + the listed templates.
-
 <!-- item-sep -->
 
 <!-- item-sep -->

--- a/docs/user/screenshots-reshoot-queue.md
+++ b/docs/user/screenshots-reshoot-queue.md
@@ -70,6 +70,19 @@ layout — `three-panel`, `results-grid`, `view-options`, `autopilot-progress`,
 these few px. All are already listed below for other reasons; this note records
 the additional layout drift so a drain session knows to expect it.
 
+**Icon-system unification (2026-07-12).** The image-view toolbar's raw
+glyphs (`⟲ ⟳ − +`) and its "Reset" text label became `vt-icon` registry
+icons (`rotate-ccw`/`rotate-cw`/`zoom-out`/`zoom-in`/`zoom-fit`), and several
+duplicated inline SVGs (Browse eye, Export, delete trash, Combine, the
+tri-state selection checkbox) plus stray `✓` success glyphs were routed
+through the `vt-icon` registry. Any frame showing the image toolbar
+(`region-voting`, `three-panel`, `autopilot-vote`), the dashboard tables
+(`dashboard-loaded`, `dashboard-manage`), the Find right pile (`find-view`),
+or the achievements checklist (`achievements`) renders those controls
+slightly differently (a uniform icon in place of a glyph/text, and a couple
+of Browse/Export icons at the registry's heavier stroke). Applies to both
+theme variants; not annotated per-row.
+
 | Shot id | Embedded in | Why it's stale | Flagged |
 |---------|-------------|----------------|---------|
 | `importer-picker` | `docs/user/USER_GUIDE.md#loading-a-dataset` | The shot's caption calls out "per-row readiness badges" (`.badge-ready`/`.badge-embedding`); the 2026-07-09 UI style review Phase 1 fix swapped their unreadable white text for a new `--badge-text-dark` token, changing the badge's rendered text color in both themes. Also: 2026-07-09 light-mode neutral-ramp change (see note above) shifts the light variant's background tone. | 2026-07-09 |

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.html
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.html
@@ -50,7 +50,7 @@
                 @for (doc of docs; track doc.id) {
                   <li class="docs-list-item" [class.docs-list-item--read]="doc.read">
                     <span class="docs-list-status" [attr.aria-label]="doc.read ? 'read' : 'unread'">
-                      {{ doc.read ? '✓' : '○' }}
+                      @if (doc.read) { <vt-icon type="check" [size]="14"></vt-icon> } @else { ○ }
                     </span>
                     <a class="docs-list-link" [href]="docRawUrl(doc.id)" target="_blank" rel="noopener noreferrer">
                       {{ doc.name }}
@@ -92,7 +92,7 @@
                 @for (mt of mediaTypes; track mt.id) {
                   <li class="ticks-list-item" [class.ticks-list-item--on]="mt.seen">
                     <span class="ticks-list-status" [attr.aria-label]="mt.seen ? 'voted' : 'not yet'">
-                      {{ mt.seen ? '✓' : '○' }}
+                      @if (mt.seen) { <vt-icon type="check" [size]="14"></vt-icon> } @else { ○ }
                     </span>
                     <span class="ticks-list-name">{{ mt.name }}</span>
                   </li>

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AchievementBadgeComponent } from '../achievement-badge/achievement-badge.component';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import { IconComponent } from '../icon/icon.component';
 import { AchievementsService } from '../../services/achievements.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import type { AchievementEntry } from '../../generated/api-client/models/achievement-entry';
@@ -30,7 +31,7 @@ interface AchievementRow extends AchievementEntry {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-achievements-tab',
   standalone: true,
-  imports: [FormsModule, AchievementBadgeComponent, ProgressBarComponent],
+  imports: [FormsModule, AchievementBadgeComponent, ProgressBarComponent, IconComponent],
   templateUrl: './achievements-tab.component.html',
   styleUrl: './achievements-tab.component.scss',
 })

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -134,23 +134,9 @@
               [attr.aria-label]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
               [attr.aria-checked]="selectionState === 'all' ? 'true' : selectionState === 'some' ? 'mixed' : 'false'">
               @switch (selectionState) {
-                @case ('all') {
-                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="3" y="3" width="18" height="18" rx="2"/>
-                    <polyline points="8 12 11 15 16 9"/>
-                  </svg>
-                }
-                @case ('some') {
-                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="3" y="3" width="18" height="18" rx="2"/>
-                    <line x1="8" y1="12" x2="16" y2="12"/>
-                  </svg>
-                }
-                @default {
-                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="3" y="3" width="18" height="18" rx="2"/>
-                  </svg>
-                }
+                @case ('all') { <vt-icon type="checkbox-checked" [size]="15"></vt-icon> }
+                @case ('some') { <vt-icon type="checkbox-some" [size]="15"></vt-icon> }
+                @default { <vt-icon type="checkbox-blank" [size]="15"></vt-icon> }
               }
             </button>
           }

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -12,26 +12,9 @@
       [title]="checkState() === 'all' ? 'Clear the whole selection' : 'Select everything in the current view'"
       (click)="onToggleCheckbox()">
       @switch (checkState()) {
-        @case ('all') {
-          <!-- Checked box: everything in view is selected. -->
-          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="3" width="18" height="18" rx="2"/>
-            <polyline points="8 12 11 15 16 9"/>
-          </svg>
-        }
-        @case ('some') {
-          <!-- Dashed box: a partial selection. -->
-          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="3" width="18" height="18" rx="2"/>
-            <line x1="8" y1="12" x2="16" y2="12"/>
-          </svg>
-        }
-        @default {
-          <!-- Empty box: nothing selected. -->
-          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="3" width="18" height="18" rx="2"/>
-          </svg>
-        }
+        @case ('all') { <vt-icon type="checkbox-checked" [size]="15"></vt-icon> }
+        @case ('some') { <vt-icon type="checkbox-some" [size]="15"></vt-icon> }
+        @default { <vt-icon type="checkbox-blank" [size]="15"></vt-icon> }
       }
     </button>
   </div>

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -8,6 +8,7 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
 import { NoFocusStealDirective } from '../../directives/no-focus-steal.directive';
+import { IconComponent } from '../icon/icon.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 
 /** Ordering for the selected-item list. No detector confidence in browse, so
@@ -39,7 +40,7 @@ interface SelectionEntry {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-selection-panel',
   standalone: true,
-  imports: [CommonModule, FormsModule, ViewControlsComponent, NoFocusStealDirective],
+  imports: [CommonModule, FormsModule, ViewControlsComponent, NoFocusStealDirective, IconComponent],
   templateUrl: './browse-selection-panel.component.html',
   styleUrl: './browse-selection-panel.component.scss',
 })

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -56,10 +56,10 @@
           </button>
         }
         <span class="ivc-sep" aria-hidden="true"></span>
-        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.rotateLeft()" title="Rotate left ([)" aria-label="Rotate image left">&#x21BA;</button>
-        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.rotateRight()" title="Rotate right (])" aria-label="Rotate image right">&#x21BB;</button>
-        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.zoomOut()" title="Zoom out (-)" aria-label="Zoom out">&minus;</button>
-        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.zoomIn()" title="Zoom in (+)" aria-label="Zoom in">+</button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.rotateLeft()" title="Rotate left ([)" aria-label="Rotate image left"><vt-icon type="rotate-ccw" [size]="16"></vt-icon></button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.rotateRight()" title="Rotate right (])" aria-label="Rotate image right"><vt-icon type="rotate-cw" [size]="16"></vt-icon></button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.zoomOut()" title="Zoom out (-)" aria-label="Zoom out"><vt-icon type="zoom-out" [size]="16"></vt-icon></button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.zoomIn()" title="Zoom in (+)" aria-label="Zoom in"><vt-icon type="zoom-in" [size]="16"></vt-icon></button>
         <label for="ivc-zoom" class="sr-only">Zoom</label>
         <input
           type="range"
@@ -74,7 +74,7 @@
           aria-label="Zoom level"
         />
         <span class="ivc-zoom-label">{{ imageViewer.zoomLabel }}</span>
-        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.resetView()" title="Reset view" aria-label="Reset image view">Reset</button>
+        <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.resetView()" title="Reset view" aria-label="Reset image view"><vt-icon type="zoom-fit" [size]="16"></vt-icon></button>
       </div>
     }
 

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -87,11 +87,11 @@
 
 // The image-view toolbar buttons build on the shared `.btn.btn--toolbar`
 // primitive (see scss/_components.scss). These add-ons layer only what is
-// genuinely distinct: the larger glyph size the rotate/zoom/reset controls
-// need, and the accent-fill active state for the marquee / highlight toggles.
+// genuinely distinct: the roomier horizontal padding for the rotate/zoom/reset
+// controls, and the accent-fill active state for the marquee / highlight
+// toggles. All glyphs are now `vt-icon`s sized via their `[size]` input.
 .ivc-btn {
   padding: var(--space-2xs) var(--space-md);
-  font-size: var(--font-xl);
 }
 
 .ivc-btn-toggle {

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -15,6 +15,7 @@ import { TextViewerComponent } from './text-viewer/text-viewer.component';
 import { DocumentViewerComponent } from './document-viewer/document-viewer.component';
 import { VotingOverlayComponent } from './voting-overlay/voting-overlay.component';
 import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
+import { IconComponent } from '../icon/icon.component';
 import { prefersReducedMotion } from '../../utils/reduced-motion';
 
 @Component({
@@ -31,6 +32,7 @@ import { prefersReducedMotion } from '../../utils/reduced-motion';
     DocumentViewerComponent,
     VotingOverlayComponent,
     CopyDetailButtonComponent,
+    IconComponent,
   ],
   templateUrl: './center-panel.component.html',
   styleUrl: './center-panel.component.scss',

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.html
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.html
@@ -45,7 +45,7 @@
             (click)="pickRow(row)"
             (mouseenter)="focusedIndex = i"
           >
-            <span class="row-glyph" [title]="glyphTitle(row)">{{ glyphFor(row) }}</span>
+            <span class="row-glyph" [title]="glyphTitle(row)">@if (row.active) { <vt-icon type="check" [size]="14"></vt-icon> } @else { {{ glyphFor(row) }} }</span>
             <span class="row-name">{{ row.name }}</span>
             <span class="row-type">· {{ row.mediaType | titlecase }}</span>
             @if (row.busy) {

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -13,6 +13,7 @@ import { DashboardSelectionService } from '../../services/dashboard-selection.se
 import { RunningJobsService, pairKey } from '../../services/running-jobs.service';
 import { SortState } from '../../utils/managed-columns';
 import { DatasetRegistryEntry } from '../../models/api.models';
+import { IconComponent } from '../icon/icon.component';
 import { DetectorRegistryEntry } from '../../generated/api-client/models/detector-registry-entry';
 import { isPairCompatible } from '../../utils/context-compat';
 
@@ -60,7 +61,7 @@ interface PulldownRow {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-context-pulldown',
   standalone: true,
-  imports: [TitleCasePipe],
+  imports: [TitleCasePipe, IconComponent],
   templateUrl: './context-pulldown.component.html',
   styleUrl: './context-pulldown.component.scss',
 })
@@ -89,8 +90,8 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
 
   /** Ids of this pulldown's rows that count as "active" — the selected
    *  table rows while the Dashboard is on screen, otherwise the single
-   *  active/loaded id from `ActiveContextService`. Drives the ✓ glyph,
-   *  the closed-state label, and keyboard focus. */
+   *  active/loaded id from `ActiveContextService`. Drives the active-row
+   *  check icon, the closed-state label, and keyboard focus. */
   private selectedIds: string[] = [];
 
   /** True between an "Add New" click in this pulldown and the resulting
@@ -388,7 +389,8 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   }
 
   glyphFor(row: PulldownRow): string {
-    if (row.active) return '✓';
+    // The active state renders a `vt-icon` check in the template; this getter
+    // only covers the loaded (●) / unloaded (○) dot for inactive rows.
     return row.loaded ? '●' : '○';
   }
 

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -6,20 +6,10 @@
       <h2 class="dashboard-section-title" title="Imported datasets available for labeling and searching"><vt-icon type="cubes" [size]="18"></vt-icon> Datasets</h2>
       <div class="dashboard-section-actions">
         <button class="side-action-btn" (click)="combineSelectedDatasets()" [disabled]="isContextSwitching || !combineSelectedDatasetsEnabled" [title]="combineSelectedDatasetsHint" aria-label="Combine selected datasets">
-          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/>
-            <path d="M3 17 C 10 17, 10 12, 17 12"/>
-            <polyline points="18 9 21 12 18 15"/>
-          </svg>
+          <vt-icon type="combine" [size]="18"></vt-icon>
         </button>
         <button class="side-action-btn side-action-delete" (click)="deleteSelectedDatasets()" [disabled]="isContextSwitching || selectedDatasetIds.size === 0" [title]="selectedDatasetIds.size === 0 ? 'No datasets selected' : 'Delete selected datasets'" aria-label="Delete selected">
-          <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedDatasetsConfirm()" [class.side-action-delete-inactive]="!deletingSelectedDatasetsConfirm() && wasDeletingSelectedDatasetsConfirm()" (animationend)="onDeleteSelectedDatasetsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="3 6 5 6 21 6"></polyline>
-            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-            <path d="M10 11v6"></path>
-            <path d="M14 11v6"></path>
-            <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-          </svg>
+          <vt-icon type="trash" [size]="16" [class.side-action-delete-active]="deletingSelectedDatasetsConfirm()" [class.side-action-delete-inactive]="!deletingSelectedDatasetsConfirm() && wasDeletingSelectedDatasetsConfirm()" (animationend)="onDeleteSelectedDatasetsAnimationEnd()"></vt-icon>
         </button>
         <span class="section-actions-sep" aria-hidden="true"></span>
         <button class="btn btn--primary btn--sm"
@@ -52,23 +42,9 @@
               <th scope="col" class="select-col" data-col="select" [style.width.%]="datasetCols.tableFixed ? datasetCols.colWidths['select'] : null">
                 <button class="card-icon-btn header-checkbox" (click)="toggleAllDatasets()" [disabled]="isContextSwitching || datasets.length === 0" [title]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all datasets'" [attr.aria-label]="datasetSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="datasetSelectionState === 'all' ? 'true' : datasetSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
                   @switch (datasetSelectionState) {
-                    @case ('all') {
-                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="3" y="3" width="18" height="18" rx="2"/>
-                        <polyline points="8 12 11 15 16 9"/>
-                      </svg>
-                    }
-                    @case ('some') {
-                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="3" y="3" width="18" height="18" rx="2"/>
-                        <line x1="8" y1="12" x2="16" y2="12"/>
-                      </svg>
-                    }
-                    @default {
-                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="3" y="3" width="18" height="18" rx="2"/>
-                      </svg>
-                    }
+                    @case ('all') { <vt-icon type="checkbox-checked" [size]="16"></vt-icon> }
+                    @case ('some') { <vt-icon type="checkbox-some" [size]="16"></vt-icon> }
+                    @default { <vt-icon type="checkbox-blank" [size]="16"></vt-icon> }
                   }
                 </button>
               </th>
@@ -171,20 +147,10 @@
       <h2 class="dashboard-section-title" title="Trained detectors for scoring and finding media"><vt-icon type="robot" [size]="18"></vt-icon> Detectors</h2>
       <div class="dashboard-section-actions">
         <button class="side-action-btn" (click)="openCombineDetectorsModal()" [disabled]="isContextSwitching || !combineSelectedDetectorsEnabled" [title]="combineSelectedDetectorsHint" aria-label="Combine selected detectors">
-          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/>
-            <path d="M3 17 C 10 17, 10 12, 17 12"/>
-            <polyline points="18 9 21 12 18 15"/>
-          </svg>
+          <vt-icon type="combine" [size]="18"></vt-icon>
         </button>
         <button class="side-action-btn side-action-delete" (click)="deleteSelectedDetectors()" [disabled]="isContextSwitching || selectedDetectorIds.size === 0" [title]="selectedDetectorIds.size === 0 ? 'No detectors selected' : 'Delete selected detectors'" aria-label="Delete selected">
-          <svg aria-hidden="true" [class.side-action-delete-active]="deletingSelectedDetectorsConfirm()" [class.side-action-delete-inactive]="!deletingSelectedDetectorsConfirm() && wasDeletingSelectedDetectorsConfirm()" (animationend)="onDeleteSelectedDetectorsAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="3 6 5 6 21 6"></polyline>
-            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-            <path d="M10 11v6"></path>
-            <path d="M14 11v6"></path>
-            <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-          </svg>
+          <vt-icon type="trash" [size]="16" [class.side-action-delete-active]="deletingSelectedDetectorsConfirm()" [class.side-action-delete-inactive]="!deletingSelectedDetectorsConfirm() && wasDeletingSelectedDetectorsConfirm()" (animationend)="onDeleteSelectedDetectorsAnimationEnd()"></vt-icon>
         </button>
         <span class="section-actions-sep" aria-hidden="true"></span>
         <button class="btn btn--primary btn--sm"
@@ -217,23 +183,9 @@
               <th scope="col" class="select-col" data-col="select" [style.width.%]="detectorCols.tableFixed ? detectorCols.colWidths['select'] : null">
                 <button class="card-icon-btn header-checkbox" (click)="toggleAllDetectors()" [disabled]="isContextSwitching || detectors.length === 0" [title]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all detectors'" [attr.aria-label]="detectorSelectionState === 'all' ? 'Deselect all' : 'Select all'" [attr.aria-checked]="detectorSelectionState === 'all' ? 'true' : detectorSelectionState === 'some' ? 'mixed' : 'false'" role="checkbox">
                   @switch (detectorSelectionState) {
-                    @case ('all') {
-                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="3" y="3" width="18" height="18" rx="2"/>
-                        <polyline points="8 12 11 15 16 9"/>
-                      </svg>
-                    }
-                    @case ('some') {
-                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="3" y="3" width="18" height="18" rx="2"/>
-                        <line x1="8" y1="12" x2="16" y2="12"/>
-                      </svg>
-                    }
-                    @default {
-                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="3" y="3" width="18" height="18" rx="2"/>
-                      </svg>
-                    }
+                    @case ('all') { <vt-icon type="checkbox-checked" [size]="16"></vt-icon> }
+                    @case ('some') { <vt-icon type="checkbox-some" [size]="16"></vt-icon> }
+                    @default { <vt-icon type="checkbox-blank" [size]="16"></vt-icon> }
                   }
                 </button>
               </th>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -2,14 +2,9 @@
 <td class="select-col">
   <button class="card-icon-btn select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect dataset' : 'Select dataset'" [attr.aria-checked]="selected ? 'true' : 'false'" role="checkbox" [attr.title]="selected ? 'Deselect' : 'Select'">
     @if (selected) {
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <rect x="3" y="3" width="18" height="18" rx="2"/>
-        <polyline points="8 12 11 15 16 9"/>
-      </svg>
+      <vt-icon type="checkbox-checked" [size]="16"></vt-icon>
     } @else {
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <rect x="3" y="3" width="18" height="18" rx="2"/>
-      </svg>
+      <vt-icon type="checkbox-blank" [size]="16"></vt-icon>
     }
   </button>
 </td>
@@ -61,10 +56,7 @@
     <td class="actions-col">
       <div class="card-actions">
         <button class="card-icon-btn" type="button" disabled aria-label="Building the map for browse" title="Building the map…">
-          <svg class="icon-waggle" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
-            <circle cx="12" cy="12" r="3"></circle>
-          </svg>
+          <vt-icon type="eye" [size]="14" class="icon-waggle"></vt-icon>
         </button>
       </div>
     </td>
@@ -125,21 +117,11 @@
     <div class="card-actions">
     @if (!dataset.loaded) {
       <button class="card-icon-btn load-btn" (click)="onLoad($event)" aria-label="Load dataset" title="Load dataset">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M13 3h5a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-5"/>
-          <polyline points="12 6 12 12 6 12"/>
-          <line x1="3" y1="3" x2="12" y2="12"/>
-        </svg>
+        <vt-icon type="import" [size]="14"></vt-icon>
       </button>
     }
     <button class="card-icon-btn card-icon-btn--danger delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete dataset">
-      <svg aria-hidden="true" [class.trash-active]="deleting" [class.trash-inactive]="!deleting && wasDeleting" (animationend)="onDeleteAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="3 6 5 6 21 6"></polyline>
-        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-        <path d="M10 11v6"></path>
-        <path d="M14 11v6"></path>
-        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-      </svg>
+      <vt-icon type="trash" [size]="14" [class.trash-active]="deleting" [class.trash-inactive]="!deleting && wasDeleting" (animationend)="onDeleteAnimationEnd()"></vt-icon>
     </button>
     <button class="card-icon-btn overflow-btn" (click)="onOverflow($event)" aria-label="More actions" title="More actions">
       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../utils/format-progress';
 import { formatTimestamp } from '../../../utils/format-date';
 import { ContextMenuComponent, ContextMenuItem } from '../../context-menu/context-menu.component';
+import { IconComponent } from '../../icon/icon.component';
 import { buildDatasetCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } from '../card-context-menu-items';
 
 @Component({
@@ -19,7 +20,7 @@ import { buildDatasetCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } fro
   selector: 'tr[vt-dataset-card]',
   standalone: true,
   host: { class: 'entity-card' },
-  imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent],
+  imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent, IconComponent],
   templateUrl: './dataset-card.component.html',
   styleUrl: './dataset-card.component.scss',
 })

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -1,14 +1,9 @@
 <td class="select-col">
   <button class="card-icon-btn select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect detector' : 'Select detector'" [attr.aria-checked]="selected ? 'true' : 'false'" role="checkbox" [attr.title]="selected ? 'Deselect' : 'Select'">
     @if (selected) {
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <rect x="3" y="3" width="18" height="18" rx="2"/>
-        <polyline points="8 12 11 15 16 9"/>
-      </svg>
+      <vt-icon type="checkbox-checked" [size]="16"></vt-icon>
     } @else {
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <rect x="3" y="3" width="18" height="18" rx="2"/>
-      </svg>
+      <vt-icon type="checkbox-blank" [size]="16"></vt-icon>
     }
   </button>
 </td>
@@ -106,21 +101,11 @@
     <div class="card-actions">
     @if (!detector.detector_loaded) {
       <button class="card-icon-btn load-btn" (click)="onLoad($event)" aria-label="Load detector" title="Load detector">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M13 3h5a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-5"/>
-          <polyline points="12 6 12 12 6 12"/>
-          <line x1="3" y1="3" x2="12" y2="12"/>
-        </svg>
+        <vt-icon type="import" [size]="14"></vt-icon>
       </button>
     }
     <button class="card-icon-btn card-icon-btn--danger delete-btn" (click)="onDelete($event)" aria-label="Delete detector" title="Delete detector">
-      <svg aria-hidden="true" [class.trash-active]="deleting" [class.trash-inactive]="!deleting && wasDeleting" (animationend)="onDeleteAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="3 6 5 6 21 6"></polyline>
-        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
-        <path d="M10 11v6"></path>
-        <path d="M14 11v6"></path>
-        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
-      </svg>
+      <vt-icon type="trash" [size]="14" [class.trash-active]="deleting" [class.trash-inactive]="!deleting && wasDeleting" (animationend)="onDeleteAnimationEnd()"></vt-icon>
     </button>
     <button class="card-icon-btn overflow-btn" (click)="onOverflow($event)" aria-label="More actions" title="More actions">
       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../utils/format-progress';
 import { formatTimestamp } from '../../../utils/format-date';
 import { ContextMenuComponent, ContextMenuItem } from '../../context-menu/context-menu.component';
+import { IconComponent } from '../../icon/icon.component';
 import { buildDetectorCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } from '../card-context-menu-items';
 
 @Component({
@@ -18,7 +19,7 @@ import { buildDetectorCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } fr
   selector: 'tr[vt-detector-card]',
   standalone: true,
   host: { class: 'entity-card' },
-  imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent],
+  imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent, IconComponent],
   templateUrl: './detector-card.component.html',
   styleUrl: './detector-card.component.scss',
 })

--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -38,6 +38,30 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
   // read as a matched in/out pair.
   import:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3h5a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-5"/><polyline points="12 6 12 12 6 12"/><line x1="3" y1="3" x2="12" y2="12"/></svg>',
+  // Data-export glyph: the mirror of `import` — a rounded box whose upper-RIGHT
+  // corner is open, with a diagonal arrow running from the centre OUT through
+  // that corner. Matches `import`'s stroke weight so the in/out pair reads as a
+  // set. Used by every Export button/menu action across the app.
+  export:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"/><polyline points="15 3 21 3 21 9"/><line x1="12" y1="12" x2="21" y2="3"/></svg>',
+  // Trash can (delete). Kept at stroke-width 1.5 to match the small (14–16px)
+  // delete buttons it backs across the dashboard rows, section headers, and the
+  // card context menu. The dashboard's delete buttons animate it by toggling a
+  // rotate class on the surrounding `vt-icon` host (see `.trash-active`).
+  trash:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>',
+  // Combine glyph: two curved branches merging into a single arrow pointing
+  // right — "merge these into one". Backs the dashboard's Combine-selected
+  // datasets / detectors actions.
+  combine:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7 C 10 7, 10 12, 17 12 L 21 12"/><path d="M3 17 C 10 17, 10 12, 17 12"/><polyline points="18 9 21 12 18 15"/></svg>',
+  // Counter-clockwise / clockwise rotate arrows, backing the image toolbar's
+  // rotate-left / rotate-right controls (they rotate the image, not undo/redo
+  // app state).
+  'rotate-ccw':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>',
+  'rotate-cw':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>',
   // Browse glyph: an eye, matching the Browse buttons used throughout the app
   // (dashboard dataset cards, the Find right-panel goods actions, etc.).
   eye:
@@ -106,8 +130,17 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v7.5a2 2 0 0 1-.3 1L4 20a1.5 1.5 0 0 0 1.3 2.2h13.4A1.5 1.5 0 0 0 20 20l-4.7-9.5a2 2 0 0 1-.3-1V2"/><line x1="8" y1="2" x2="16" y2="2"/><line x1="7" y1="15" x2="17" y2="15"/></svg>',
   cubes:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M2 6h16v16H2z"/><path d="M2 6l4-4h16v16l-4 4"/><path d="M18 6l4-4"/><path d="M10 6v16M2 14h16"/><path d="M10 6l4-4"/><path d="M18 14l4-4"/></svg>',
+  // Tri-state selection checkbox, backing the dashboard/browse row and
+  // select-all controls. The three states share a common rounded square so they
+  // read as one control: `checkbox-checked` (with a tick), `checkbox-some`
+  // (indeterminate dash, for a header whose rows are partially selected), and
+  // `checkbox-blank` (empty). Stroke-width 1.5 matches the 16px checkboxes.
   'checkbox-checked':
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3" ry="3"/><polyline points="8 12 11 15 16 9"/></svg>',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><polyline points="8 12 11 15 16 9"/></svg>',
+  'checkbox-some':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="8" y1="12" x2="16" y2="12"/></svg>',
+  'checkbox-blank':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>',
   search:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15.2" y2="15.2"/></svg>',
   trophy:

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -24,8 +24,9 @@ const KNOWN_TYPES = new Set([
   'thumbs-up', 'thumbs-down', 'factory',
   'house', 'lightning', 'flask', 'cubes', 'database',
   'clock', 'running', 'calendar',
-  'checkbox-checked', 'search', 'trophy',
+  'checkbox-checked', 'checkbox-some', 'checkbox-blank', 'search', 'trophy',
   'zoom-in', 'zoom-out', 'zoom-fit', 'help', 'copy',
+  'export', 'trash', 'combine', 'rotate-ccw', 'rotate-cw',
 ]);
 
 function emojiToType(icon: string): string {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -37,7 +37,7 @@
           >
             <div class="ap-step-marker">
               @if (step.state === 'done') {
-                <span class="ap-check" title="Complete" aria-label="Complete">&#10003;</span>
+                <span class="ap-check" title="Complete" aria-label="Complete"><vt-icon type="check" [size]="14"></vt-icon></span>
               } @else if (step.state === 'active') {
                 <span class="ap-dot active-dot" title="Current step" aria-label="Current step"></span>
               } @else {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -7,6 +7,7 @@ import {
   AutopilotState,
 } from '../../../services/autopilot-state.service';
 import { ToastService } from '../../../services/toast.service';
+import { IconComponent } from '../../icon/icon.component';
 
 export type { AutopilotPhase, AutopilotState };
 
@@ -33,7 +34,7 @@ export interface StepDisplay {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-autopilot-panel',
   standalone: true,
-  imports: [],
+  imports: [IconComponent],
   templateUrl: './autopilot-panel.component.html',
   styleUrl: './autopilot-panel.component.scss',
 })

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -22,10 +22,7 @@
             aria-label="Browse unverified positives"
             title="Browse the likely matches you haven't reviewed yet as their own map"
           >
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
-              <circle cx="12" cy="12" r="3"></circle>
-            </svg>
+            <vt-icon type="eye" [size]="14"></vt-icon>
           </button>
           <button
             class="card-icon-btn"
@@ -43,11 +40,7 @@
             aria-label="Export unverified positives"
             title="Export the likely matches you haven't reviewed yet — e.g. to re-import as a dataset"
           >
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
-              <polyline points="15 3 21 3 21 9"></polyline>
-              <line x1="12" y1="12" x2="21" y2="3"></line>
-            </svg>
+            <vt-icon type="export" [size]="14"></vt-icon>
           </button>
         </div>
       </div>

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -25,7 +25,7 @@
   @if (data.auto_export; as ax) {
     <div class="auto-export-status" [class.auto-export-status--error]="!ax.success">
       @if (ax.success) {
-        &#10003; Auto-exported via {{ ax.exporter }}{{ ax.message ? ' — ' + ax.message : '' }}
+        <vt-icon type="check" [size]="14"></vt-icon> Auto-exported via {{ ax.exporter }}{{ ax.message ? ' — ' + ax.message : '' }}
       } @else {
         &#9888; Auto-export via {{ ax.exporter }} failed{{ ax.error ? ': ' + ax.error : '' }}
       }

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -15,12 +15,13 @@ import {
   ImporterField,
 } from '../../../models/api.models';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
+import { IconComponent } from '../../icon/icon.component';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-autodetect-results-modal',
   standalone: true,
-  imports: [FormsModule, ModalComponent, ClipboardCopyComponent],
+  imports: [FormsModule, ModalComponent, ClipboardCopyComponent, IconComponent],
   templateUrl: './autodetect-results-modal.component.html',
   styleUrl: './autodetect-results-modal.component.scss',
 })

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -232,7 +232,7 @@
             [disabled]="!hasLabels || submitting()"
             title="Send exported data to the selected destination"
           >
-            <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"/><polyline points="15 3 21 3 21 9"/><line x1="12" y1="12" x2="21" y2="3"/></svg>
+            <vt-icon type="export" [size]="16" [class.icon-waggle]="submitting()"></vt-icon>
             @if (submitting()) {
               Exporting {{ filteredLabels.length | number }} labels to {{ activeTabExporter.display_name || activeTabExporter.name }}…
             } @else {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -15,6 +15,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
+import { IconComponent } from '../../icon/icon.component';
 import {
   ClipboardColumn,
   ClipboardCopyComponent,
@@ -48,6 +49,7 @@ export interface ColumnDef {
     ModalComponent,
     FieldHintIconComponent,
     ClipboardCopyComponent,
+    IconComponent,
   ],
   templateUrl: './export-modal.component.html',
   styleUrl: './export-modal.component.scss',

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -99,7 +99,7 @@
       <div class="form-actions" modal-footer>
         <button class="btn btn--secondary" (click)="close()">Cancel</button>
         <button class="btn btn--primary" (click)="submit()" [disabled]="submitting()">
-          <svg aria-hidden="true" [class.icon-waggle]="submitting()" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"/><polyline points="15 3 21 3 21 9"/><line x1="12" y1="12" x2="21" y2="3"/></svg>
+          <vt-icon type="export" [size]="16" [class.icon-waggle]="submitting()"></vt-icon>
           @if (submitting()) {
             Exporting…
           } @else {

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -461,15 +461,11 @@
     @if (version()) {
       <span class="settings-version" title="App version (UTC timestamp of the last dev to main merge). Include this when reporting issues.">v {{ version() }}</span>
     }
-    <span class="settings-saved" [class.settings-saved--visible]="savedVisible()" role="status" aria-live="polite" title="Settings auto-save as you change them">&#10003; saved</span>
+    <span class="settings-saved" [class.settings-saved--visible]="savedVisible()" role="status" aria-live="polite" title="Settings auto-save as you change them"><vt-icon type="check" [size]="14"></vt-icon> saved</span>
     <button class="btn btn--secondary" (click)="resetDefaults()" title="Reset all settings to their factory defaults">Default</button>
     <button class="btn btn--secondary" (click)="openImporter()" title="Import settings from a file">Import</button>
     <button class="btn btn--secondary" (click)="openExporter()" aria-label="Export" title="Export settings to a file">
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
-        <polyline points="15 3 21 3 21 9"></polyline>
-        <line x1="12" y1="12" x2="21" y2="3"></line>
-      </svg>
+      <vt-icon type="export" [size]="16"></vt-icon>
     </button>
     <button class="btn btn--secondary" (click)="close()" title="Close the settings panel">Done</button>
   </div>

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -68,20 +68,13 @@
       @if (mode() === 'find') {
         <div list-actions class="goods-actions">
           <button class="card-icon-btn" [disabled]="disabled() || goodIds().length === 0" (click)="onBrowse()" aria-label="Browse" title="Browse positive items (verified and unverified).">
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
-              <circle cx="12" cy="12" r="3"></circle>
-            </svg>
+            <vt-icon type="eye" [size]="14"></vt-icon>
           </button>
           <button class="card-icon-btn" [disabled]="disabled() || goodIds().length === 0" (click)="onToDataset()" aria-label="To Dataset" title="Promote the full good set (verified + unverified) into their own dataset">
             <vt-icon type="cubes" [size]="14"></vt-icon>
           </button>
           <button class="card-icon-btn" [disabled]="disabled() || goodIds().length === 0" (click)="onExportGood()" aria-label="Export" title="Export the full good set (verified + unverified) to clipboard, file, email, or webhook">
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
-              <polyline points="15 3 21 3 21 9"></polyline>
-              <line x1="12" y1="12" x2="21" y2="3"></line>
-            </svg>
+            <vt-icon type="export" [size]="14"></vt-icon>
           </button>
           <button class="card-icon-btn" [disabled]="disabled()" (click)="onStats()" aria-label="Stats" title="Detector evaluation: confusion matrix and the false-positive / false-negative tradeoff across inclusion">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -115,11 +108,7 @@
       @if (mode() === 'find') {
         <div list-actions class="goods-actions">
           <button class="card-icon-btn" [disabled]="disabled() || badIds().length === 0" (click)="onExportBad()" aria-label="Export" title="Export the full bad set (verified + unverified) to clipboard, file, email, or webhook">
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
-              <polyline points="15 3 21 3 21 9"></polyline>
-              <line x1="12" y1="12" x2="21" y2="3"></line>
-            </svg>
+            <vt-icon type="export" [size]="14"></vt-icon>
           </button>
         </div>
       }
@@ -143,11 +132,7 @@
   @if (mode() !== 'find') {
     <div class="export-row">
       <button class="btn btn--toolbar export-btn" [disabled]="disabled()" (click)="onExport()" aria-label="Export" title="Export labeled items to clipboard, file, email, or webhook">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M11 3H6a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-5"></path>
-          <polyline points="15 3 21 3 21 9"></polyline>
-          <line x1="12" y1="12" x2="21" y2="3"></line>
-        </svg>
+        <vt-icon type="export" [size]="16"></vt-icon>
       </button>
     </div>
   }


### PR DESCRIPTION
Fixes the three icon inconsistencies called out in `docs/plans/ui-style-polish.md` → **Unify the icon system**.

## What changed

**Registry (`icon-svgs-extended.ts`)** — new keys:
- `export` (a deliberate mirror of the existing `import` glyph, matching its stroke weight so the in/out pair reads as a set)
- `trash`, `combine`
- `rotate-ccw` / `rotate-cw` (image rotate arrows)
- a tri-state selection checkbox set: `checkbox-checked` (redefined to match the on-screen 1.5-stroke box, since the old `checkbox-checked` entry was unused), plus new `checkbox-some` (indeterminate dash) and `checkbox-blank`.

**Duplicated inline SVGs → `<vt-icon>`.** The eye / export / trash / combine / load(`import`) SVGs and the tri-state selection checkboxes were pasted across the dashboard, dataset/detector cards, left/right panels, browse panels, and the settings/export modals. All template copies now render from the registry. Animated sites (the delete-confirm trash rotate, the Browse-eye and Export waggles) keep their behaviour by moving the animation class + `(animationend)` onto the `vt-icon` host — the animation is a `transform: rotate`, so it rotates the whole icon.

**Center-panel image toolbar.** The raw Unicode glyphs `⟲ ⟳ − +` and the text `Reset` became `rotate-ccw` / `rotate-cw` / `zoom-out` / `zoom-in` / `zoom-fit` registry icons. The now-dead glyph `font-size` rule was removed.

**Success checks.** The stray bare `✓` glyphs (achievements checklist, context-pulldown active row, settings "saved" indicator, autopilot completed step, autodetect auto-export status) now render through `vt-icon type="check"`, matching the one place that already used it. The toast keeps its own tuned 16×16 circle-check family (check + error-circle + close-X), which is a self-consistent local set rather than a bare check — left untouched by design.

## Scope notes
- `card-context-menu-items.ts` builds its menu icons as raw SVG strings for a data-driven (`innerHTML`) menu at a uniform 1.5 stroke. It's left intact: it's a cohesive local set, not a pasted-into-a-template SVG, and folding it into the registry would either pull in four out-of-scope icons or mix stroke weights within one menu.
- The importer-submit "download arrow" glyph (settings/label importer modals) is a distinct icon, not one of the named duplicates, so it's left as-is.

## Verification
`./run-tests.sh frontend` passes: prod build clean (no warnings), `npm audit` 0 prod vulnerabilities, and all **1154** Vitest unit tests pass.

Because the container has no browser, the affected doc screenshots can't be reshot here. Every affected shot was already queued in `docs/user/screenshots-reshoot-queue.md` (the whole set is stale from the 2026-07-12 rebuild); I added a whole-set note recording the icon change so a browser-capable session picks it up.

Closes #2326

🤖 Generated with [Claude Code](https://claude.com/claude-code)