### PR TITLE
Single-fetch audio player: one download, peaks cache, audio ETag

### DIFF
--- a/docs/plans/efficiency-wins.md
+++ b/docs/plans/efficiency-wins.md
@@ -93,37 +93,6 @@ canvas renderer, LSH near-dup detection, async jobs with signature caches.
 
 <!-- item-sep -->
 
-- **Single-fetch audio player** — selecting an audio clip downloads the file
-  **twice** and decodes it every time: the `<audio>` element streams
-  `/api/medias/{id}/audio`
-  (`frontend/src/app/components/center-panel/audio-player/audio-player.component.ts:54`
-  + `.html:16`) while `drawWaveform()` independently `fetch()`es the same URL
-  (line 216) and runs `decodeAudioData`. The audio route sends no cache
-  headers (only the thumbnail route sets an ETag — see
-  `vtsearch/routes/media/list.py:683`), so the browser can't dedupe, and
-  re-selecting a previously viewed clip re-pays everything.
-  **Fix (frontend):** fetch once — `drawWaveform`'s fetch already gets the full
-  bytes; hand them to the `<audio>` element via
-  `URL.createObjectURL(new Blob([arrayBuffer], {type}))` (revoke the previous
-  object URL on media change / `ngOnDestroy`). Add a small LRU `Map` (say 20
-  entries) of decoded waveform peaks keyed by
-  `datasetId:mediaId:clipStart:clipEnd` so re-selection skips fetch+decode
-  entirely — cache the downsampled min/max arrays, not the `AudioBuffer`
-  (peaks are ~KB, buffers are ~MB).
-  **Fix (backend, complementary):** add an `ETag` (media md5 is already on the
-  media dict) + `Cache-Control` to the audio media response so even cold
-  object-URL misses turn into 304s. Mirror the thumbnail route's conditional
-  logic in `vtsearch/routes/media/list.py`.
-  **Gotchas:** preserve the existing `AbortController` handling around the
-  fetch (line ~216) and the clip-window drawing logic; the `<audio>` `[src]`
-  swap must not break the `loadedmetadata` gate (component tracks whether
-  metadata has fired for the current src — see the comment at line ~34).
-  `audio-player.component.spec.ts:34` asserts `audioSrc` equals the API URL —
-  update it deliberately. Frontend gate: `./run-tests.sh frontend`.
-  **Files touched:** `audio-player.component.{ts,html,spec.ts}`,
-  `vtsearch/routes/media/list.py` (ETag), maybe a tiny peaks-cache service.
-  Impact: high for audio-heavy voting. Complexity: medium.
-
 ## Tier 3 — worthwhile, more design judgment needed
 
 <!-- item-sep -->

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
@@ -13,7 +13,6 @@
   controls
   controlsList="nodownload"
   loop
-  [src]="audioSrc"
   [attr.aria-label]="media.filename || 'Audio media'"
   (loadedmetadata)="onLoadedMetadata()"
   (volumechange)="onVolumeChange()"

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -18,7 +18,27 @@ describe('AudioPlayerComponent', () => {
     custom_metadata: {},
   };
 
+  let originalFetch: typeof globalThis.fetch;
+  let originalCreate: typeof URL.createObjectURL;
+  let originalRevoke: typeof URL.revokeObjectURL;
+
   beforeEach(async () => {
+    // Single-fetch path: the component downloads the clip once and feeds the
+    // bytes to the <audio> element via an object URL. jsdom implements neither
+    // fetch's media pipeline nor createObjectURL usefully, so stub them.
+    originalFetch = globalThis.fetch;
+    originalCreate = URL.createObjectURL;
+    originalRevoke = URL.revokeObjectURL;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(new Blob([new Uint8Array([0])], { type: 'audio/wav' })),
+    }) as unknown as typeof globalThis.fetch;
+    URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+    URL.revokeObjectURL = vi.fn();
+    // jsdom logs "Not implemented" for these; keep the audio path quiet.
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+
     await TestBed.configureTestingModule({
       imports: [AudioPlayerComponent],
       providers: [...provideZoneless(), ActiveContextService],
@@ -27,16 +47,45 @@ describe('AudioPlayerComponent', () => {
     component = fixture.componentInstance;
   });
 
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    URL.createObjectURL = originalCreate;
+    URL.revokeObjectURL = originalRevoke;
+    vi.restoreAllMocks();
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set audioSrc when media changes', () => {
+  it('downloads the audio once and drives the <audio> element from an object URL', async () => {
+    const fakeAudio = {
+      src: '',
+      volume: 0,
+      paused: true,
+      play: () => Promise.resolve(),
+      pause: () => {},
+      load: () => {},
+    } as unknown as HTMLAudioElement;
+    // A canvas whose 2D context is unavailable, so the waveform path (which
+    // needs decodeAudioData, absent in jsdom) short-circuits after the src is set.
+    const fakeCanvas = {
+      getContext: () => null,
+      getBoundingClientRect: () => ({ width: 0 }) as DOMRect,
+      width: 600,
+      height: 120,
+    } as unknown as HTMLCanvasElement;
     component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
-    expect(component.audioSrc).toBe('/api/medias/1/audio');
+    component.audioRef = { nativeElement: fakeAudio } as ElementRef<HTMLAudioElement>;
+    component.canvasRef = { nativeElement: fakeCanvas } as ElementRef<HTMLCanvasElement>;
+
+    await (component as unknown as { loadAudio(): Promise<void> }).loadAudio();
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/medias/1/audio', expect.anything());
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(fakeAudio.src).toBe('blob:mock-url');
+    expect(component.audioSrc).toBe('blob:mock-url');
   });
 
   it('should render canvas and audio elements', async () => {

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -66,6 +66,7 @@ describe('AudioPlayerComponent', () => {
       play: () => Promise.resolve(),
       pause: () => {},
       load: () => {},
+      removeAttribute: () => {},
     } as unknown as HTMLAudioElement;
     // A canvas whose 2D context is unavailable, so the waveform path (which
     // needs decodeAudioData, absent in jsdom) short-circuits after the src is set.

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -3,6 +3,64 @@ import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { decodeAudioBuffer } from '../../../utils/decode-audio';
 
+/** Downsampled per-column waveform extrema for one clip at one canvas width. */
+interface WaveformPeaks {
+  min: Float32Array;
+  max: Float32Array;
+}
+
+// Module-level LRU cache of downsampled waveform peaks, keyed by
+// `${datasetId}:${mediaId}:${width}`. Peaks are a few KB (two Float32Arrays of
+// `width` samples); the decoded AudioBuffer they derive from is megabytes, so
+// we cache the peaks and re-derive nothing on re-selection -- the expensive
+// `decodeAudioData` pass is skipped when a clip is revisited. The cache is
+// module-level (not per-instance) so re-selecting a clip after navigating away
+// -- which destroys and recreates the player -- still hits it. Bounded so a
+// long voting session can't grow it without limit. The width is part of the
+// key because peaks are computed at the canvas width; a resize simply recomputes.
+const PEAKS_CACHE_LIMIT = 20;
+const peaksCache = new Map<string, WaveformPeaks>();
+
+function getCachedPeaks(key: string): WaveformPeaks | undefined {
+  const hit = peaksCache.get(key);
+  if (hit !== undefined) {
+    // LRU touch: re-insert so this key is treated as most-recently-used.
+    peaksCache.delete(key);
+    peaksCache.set(key, hit);
+  }
+  return hit;
+}
+
+function putCachedPeaks(key: string, peaks: WaveformPeaks): void {
+  peaksCache.delete(key);
+  peaksCache.set(key, peaks);
+  while (peaksCache.size > PEAKS_CACHE_LIMIT) {
+    const oldest = peaksCache.keys().next().value;
+    if (oldest === undefined) break;
+    peaksCache.delete(oldest);
+  }
+}
+
+/** Downsample one channel's samples to per-column (min, max) extrema. */
+function computePeaks(channelData: Float32Array, width: number): WaveformPeaks {
+  const min = new Float32Array(width);
+  const max = new Float32Array(width);
+  const step = Math.max(1, Math.ceil(channelData.length / width));
+  for (let i = 0; i < width; i++) {
+    let lo = 1.0;
+    let hi = -1.0;
+    const base = i * step;
+    for (let j = 0; j < step; j++) {
+      const datum = channelData[base + j];
+      if (datum < lo) lo = datum;
+      if (datum > hi) hi = datum;
+    }
+    min[i] = lo;
+    max[i] = hi;
+  }
+  return { min, max };
+}
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-audio-player',
@@ -22,6 +80,10 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   @ViewChild('waveformCanvas') canvasRef!: ElementRef<HTMLCanvasElement>;
   @ViewChild('audioEl') audioRef!: ElementRef<HTMLAudioElement>;
 
+  // Current object URL feeding the <audio> element (`blob:...`), or '' before
+  // the first load. Set imperatively on the native element (not via a template
+  // binding) because it's produced asynchronously after the fetch, and the app
+  // is zoneless. Revoked before it's replaced and on destroy.
   audioSrc = '';
 
   private waveformAbort: AbortController | null = null;
@@ -51,7 +113,6 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
         this.lastMediaId = this.media.id;
         this.metadataLoaded = false;
         this.stopClipEnforcement();
-        this.audioSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/audio`);
         if (this.viewReady) {
           this.loadAudio();
         }
@@ -80,6 +141,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
       audio.removeAttribute('src');
       audio.load();
     }
+    this.revokeObjectUrl();
   }
 
   onLoadedMetadata(): void {
@@ -172,12 +234,73 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
     this.volume = audio.volume;
   }
 
+  // Download the clip once and feed those bytes to BOTH the <audio> element
+  // (via an object URL) and the waveform renderer. Previously the <audio>
+  // element streamed /audio while drawWaveform() fetched the identical URL a
+  // second time and decoded it -- two downloads of the same bytes per selection.
   private async loadAudio(): Promise<void> {
-    if (!this.media || !this.canvasRef) return;
-    await this.drawWaveform(this.media.id);
-    if (this.audioRef?.nativeElement) {
-      this.audioRef.nativeElement.volume = this.volume;
+    if (!this.media) return;
+    const mediaId = this.media.id;
+    const datasetId = this.activeContext.datasetId;
+
+    // Blank the old waveform immediately so a media switch doesn't leave the
+    // previous clip's render on screen during the fetch.
+    this.clearCanvas();
+
+    this.waveformAbort?.abort();
+    const abort = new AbortController();
+    this.waveformAbort = abort;
+
+    let blob: Blob;
+    try {
+      const response = await fetch(this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`), {
+        signal: abort.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} fetching audio for media ${mediaId}`);
+      }
+      blob = await response.blob();
+    } catch (err) {
+      if (!this.wasAborted(err, abort)) {
+        console.warn('audio load failed', err);
+        this.drawWaveformError();
+      }
+      this.clearAbort(abort);
+      return;
+    }
+    if (abort.signal.aborted) {
+      this.clearAbort(abort);
+      return;
+    }
+
+    this.setAudioSource(blob);
+    await this.renderWaveform(mediaId, datasetId, blob, abort);
+    this.clearAbort(abort);
+
+    const audio = this.audioRef?.nativeElement;
+    if (audio) {
+      audio.volume = this.volume;
       this.syncPlaybackState();
+    }
+  }
+
+  // Point the <audio> element at the freshly downloaded bytes via an object
+  // URL, revoking the previous one so blobs don't accumulate.
+  private setAudioSource(blob: Blob): void {
+    const url = URL.createObjectURL(blob);
+    this.revokeObjectUrl();
+    this.audioSrc = url;
+    const audio = this.audioRef?.nativeElement;
+    if (audio) {
+      audio.src = url;
+      audio.load();
+    }
+  }
+
+  private revokeObjectUrl(): void {
+    if (this.audioSrc) {
+      URL.revokeObjectURL(this.audioSrc);
+      this.audioSrc = '';
     }
   }
 
@@ -192,83 +315,105 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
     }
   }
 
-  private async drawWaveform(mediaId: number): Promise<void> {
+  // Prepare the canvas for drawing: size it to its rendered width and paint the
+  // background. Returns the 2D context + dimensions, or null when no canvas /
+  // 2D context is available (headless test env).
+  private beginCanvas(): { ctx: CanvasRenderingContext2D; width: number; height: number } | null {
     const canvas = this.canvasRef?.nativeElement;
-    if (!canvas) return;
-
+    if (!canvas) return null;
     const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    if (!ctx) return null;
 
     const rect = canvas.getBoundingClientRect();
     if (rect.width > 0) canvas.width = Math.round(rect.width);
     const width = canvas.width;
     const height = canvas.height;
 
-    // Clear
-    ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--bg-surface').trim() || '#1a1d27';
+    ctx.fillStyle = this.cssVar('--bg-surface', '#1a1d27');
     ctx.fillRect(0, 0, width, height);
+    return { ctx, width, height };
+  }
 
-    this.waveformAbort?.abort();
-    const abort = new AbortController();
-    this.waveformAbort = abort;
+  private clearCanvas(): void {
+    this.beginCanvas();
+  }
 
-    try {
-      const response = await fetch(this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`), {
-        signal: abort.signal,
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status} fetching audio for media ${mediaId}`);
-      }
-      const arrayBuffer = await response.arrayBuffer();
-      if (abort.signal.aborted) return;
+  private async renderWaveform(
+    mediaId: number,
+    datasetId: string,
+    blob: Blob,
+    abort: AbortController,
+  ): Promise<void> {
+    const info = this.beginCanvas();
+    if (!info) return;
+    const { ctx, width, height } = info;
 
-      const audioBuffer = await decodeAudioBuffer(arrayBuffer);
-      if (abort.signal.aborted) return;
-
-      const channelData = audioBuffer.getChannelData(0);
-      const step = Math.ceil(channelData.length / width);
-      const amp = height / 2;
-
-      ctx.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#7c8aff';
-      ctx.lineWidth = 1;
-      ctx.beginPath();
-
-      for (let i = 0; i < width; i++) {
-        let min = 1.0;
-        let max = -1.0;
-        for (let j = 0; j < step; j++) {
-          const datum = channelData[i * step + j];
-          if (datum < min) min = datum;
-          if (datum > max) max = datum;
+    const key = `${datasetId}:${mediaId}:${width}`;
+    let peaks = getCachedPeaks(key);
+    if (peaks === undefined) {
+      let buffer: AudioBuffer;
+      try {
+        buffer = await decodeAudioBuffer(await blob.arrayBuffer());
+      } catch (err) {
+        if (!this.wasAborted(err, abort)) {
+          console.warn('waveform decode failed', err);
+          this.drawWaveformError();
         }
-        const yMin = (1 + min) * amp;
-        const yMax = (1 + max) * amp;
-        if (i === 0) ctx.moveTo(i, yMin);
-        ctx.lineTo(i, yMin);
-        ctx.lineTo(i, yMax);
-      }
-      ctx.stroke();
-
-      // Center line
-      ctx.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue('--border').trim() || '#2a2d3a';
-      ctx.lineWidth = 1;
-      ctx.beginPath();
-      ctx.moveTo(0, height / 2);
-      ctx.lineTo(width, height / 2);
-      ctx.stroke();
-    } catch (err) {
-      if (abort.signal.aborted || (err instanceof DOMException && err.name === 'AbortError')) {
         return;
       }
-      console.warn('waveform render failed', err);
-      ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--color-bad').trim() || '#f44336';
-      ctx.font = '12px sans-serif';
-      ctx.textAlign = 'center';
-      ctx.fillText('Unable to load waveform', width / 2, height / 2);
-    } finally {
-      if (this.waveformAbort === abort) {
-        this.waveformAbort = null;
-      }
+      if (abort.signal.aborted) return;
+      peaks = computePeaks(buffer.getChannelData(0), width);
+      putCachedPeaks(key, peaks);
     }
+    this.drawPeaks(ctx, peaks, width, height);
+  }
+
+  private drawPeaks(ctx: CanvasRenderingContext2D, peaks: WaveformPeaks, width: number, height: number): void {
+    const amp = height / 2;
+
+    ctx.strokeStyle = this.cssVar('--accent', '#7c8aff');
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    const n = Math.min(width, peaks.min.length);
+    for (let i = 0; i < n; i++) {
+      const yMin = (1 + peaks.min[i]) * amp;
+      const yMax = (1 + peaks.max[i]) * amp;
+      if (i === 0) ctx.moveTo(i, yMin);
+      ctx.lineTo(i, yMin);
+      ctx.lineTo(i, yMax);
+    }
+    ctx.stroke();
+
+    // Center line
+    ctx.strokeStyle = this.cssVar('--border', '#2a2d3a');
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, height / 2);
+    ctx.lineTo(width, height / 2);
+    ctx.stroke();
+  }
+
+  private drawWaveformError(): void {
+    const info = this.beginCanvas();
+    if (!info) return;
+    const { ctx, width, height } = info;
+    ctx.fillStyle = this.cssVar('--color-bad', '#f44336');
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Unable to load waveform', width / 2, height / 2);
+  }
+
+  private cssVar(name: string, fallback: string): string {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+  }
+
+  private clearAbort(abort: AbortController): void {
+    if (this.waveformAbort === abort) {
+      this.waveformAbort = null;
+    }
+  }
+
+  private wasAborted(err: unknown, abort: AbortController): boolean {
+    return abort.signal.aborted || (err instanceof DOMException && err.name === 'AbortError');
   }
 }

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -608,6 +608,20 @@ class TestMediaAudio:
         resp = client.get("/api/medias/0/audio")
         assert resp.status_code == 404
 
+    def test_sets_etag_and_cache_control(self, client):
+        resp = client.get("/api/medias/1/audio")
+        assert resp.status_code == 200
+        assert resp.headers.get("ETag")
+        assert resp.headers.get("Cache-Control") == "private, max-age=86400"
+
+    def test_conditional_request_returns_304(self, client):
+        first = client.get("/api/medias/1/audio")
+        etag = first.headers["ETag"]
+        second = client.get("/api/medias/1/audio", headers={"If-None-Match": etag})
+        assert second.status_code == 304
+        assert second.headers.get("Cache-Control") == "private, max-age=86400"
+        assert second.data == b""
+
 
 class TestAddToPile:
     """Tests for POST /api/medias/add-to-pile."""

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -535,11 +535,27 @@ def media_audio(media_id: int):
     media_bytes = _resolve_bytes(c)
     if media_bytes is None:
         abort(404, message="media not available")
-    return send_file(
-        io.BytesIO(media_bytes),
-        mimetype="audio/wav",
-        download_name=f"media_{media_id}.wav",
+    # A stable ``ETag`` (the media's content hash) lets the browser reuse the
+    # audio across re-selections.  The single-fetch object-URL path in the
+    # audio player still issues a cold GET per selection, and other surfaces
+    # (label view, hover preview) re-request the same clip on replay; the ETag
+    # turns those into 304s.  Mirrors the thumbnail route's conditional logic.
+    etag = c.get("md5") or hashlib.md5(media_bytes).hexdigest()
+    if etag in request.if_none_match:
+        resp = make_response("", 304)
+        resp.set_etag(etag)
+        resp.headers["Cache-Control"] = "private, max-age=86400"
+        return resp
+    resp = make_response(
+        send_file(
+            io.BytesIO(media_bytes),
+            mimetype="audio/wav",
+            download_name=f"media_{media_id}.wav",
+        )
     )
+    resp.set_etag(etag)
+    resp.headers["Cache-Control"] = "private, max-age=86400"
+    return resp
 
 
 @medias_bp.route("/api/medias/<int:media_id>/video")


### PR DESCRIPTION
Ships the **Single-fetch audio player** item from `docs/plans/efficiency-wins.md` (Tier 2).

## Problem
Selecting an audio clip downloaded the file **twice** and re-decoded it every time. The `<audio>` element streamed `/api/medias/{id}/audio` while `drawWaveform()` independently `fetch()`ed the *same* URL and ran `decodeAudioData`. The audio route sent no cache headers, so the browser couldn't dedupe and re-selecting a previously-viewed clip re-paid the whole cost.

## Change
**Frontend (`audio-player.component.{ts,html,spec.ts}`)**
- Fetch the clip **once**; the downloaded bytes feed both the `<audio>` element (via `URL.createObjectURL`) and the waveform decoder. The `[src]` binding is replaced by an imperative `audio.src` set (the URL is produced asynchronously after the fetch, and the app is zoneless); the object URL is revoked before it's replaced and on destroy.
- Added a module-level LRU cache (20 entries) of downsampled waveform peaks keyed by `datasetId:mediaId:width`, so re-selecting a clip skips the `decodeAudioData` pass. Only the ~KB min/max arrays are cached, never the multi-MB `AudioBuffer` (per the No-Persisted-Vectors spirit / plan guidance).

**Backend (`vtsearch/routes/media/list.py`)**
- Added an `ETag` (the media's md5, already on the media dict) + `Cache-Control: private, max-age=86400` to the audio route's direct-file response, mirroring the thumbnail route's conditional logic. Cold re-selections and replay paths (label view, hover preview) now short-circuit to 304s. The archive-member Range path is unchanged.

## Notes
- The waveform is computed from the full file (clip-independent, as before), so the cache key uses `width`, not the clip window.
- Backwards-compat: the audio `<audio>` element now plays from an object URL rather than streaming the API URL directly; for archive-member audio the full member was already downloaded once for the waveform, so this is not an extra download.

## Tests
- `./run-tests.sh frontend` — 1155 passed (new test asserts a single fetch + object-URL wiring).
- `./run-tests.sh core api` — 1462 passed (new `TestMediaAudio` cases cover the ETag header, `Cache-Control`, and the `If-None-Match` → 304 path).

Refs the efficiency-wins plan (item pruned from the plan file in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYJgcVsmUqSEgoTtmLvHwL)_