### PR TITLE
Address the "Email us" mailto with a configurable support address

### DIFF
--- a/app.py
+++ b/app.py
@@ -611,6 +611,17 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
                     flush=True,
                 )
 
+    # Deployment-level "Email us" recipient override from the environment,
+    # same rationale as the dataset-retention block above: the gunicorn images
+    # never parse ``--support-email``. An explicit CLI flag always wins.
+    from vtsearch.settings import get_cli_support_email, set_cli_support_email
+
+    if get_cli_support_email() is None:
+        _env_support_email = (os.environ.get("VTSEARCH_SUPPORT_EMAIL") or "").strip()
+        if _env_support_email:
+            set_cli_support_email(_env_support_email)
+            print(f"\U0001f4e7 Support email: {_env_support_email} (from VTSEARCH_SUPPORT_EMAIL)", flush=True)
+
     print("\U0001f4da Loading ML libraries...", flush=True)
     initialize_models(on_progress=lambda *a, **k: None)
     # ``--solo-media-type`` (process-level CLI fallback) tells us which

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -400,6 +400,24 @@ Because the Docker images launch under gunicorn (which never parses
 init; an explicit `--dataset-max-age-days` flag wins over it. The
 LabBench image pins `VTSEARCH_DATASET_MAX_AGE_DAYS=14`.
 
+**Support email** (`--support-email ADDRESS`): set the recipient for the
+Help modal's "Email us" contact link so it opens a pre-addressed compose
+window:
+
+```bash
+python app.py --support-email support@example.org
+```
+
+Like `--dataset-max-age-days`, this is a **server-wide override**: it
+applies to every user, overrides the persisted `support_email` in the
+settings file for the lifetime of the process, and is **not** editable
+via the Settings dialog or the settings API (it is exposed read-only so
+the frontend can build the `mailto:` link). Omit the flag to use the
+persisted value, which defaults to the built-in project address. The
+same override is also available as the `VTSEARCH_SUPPORT_EMAIL`
+environment variable for the gunicorn-launched Docker images; an
+explicit `--support-email` flag wins over it.
+
 ## Inspecting plugins and the API schema
 
 `python app.py --list-plugins` enumerates every auto-discovered plugin;

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -385,6 +385,10 @@
           "solo_media_type_explicit": {
             "type": "boolean"
           },
+          "support_email": {
+            "readOnly": true,
+            "type": "string"
+          },
           "theme": {
             "enum": [
               "dark",

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.html
@@ -77,7 +77,7 @@
 
     <p class="help-footer">
       Comments, concerns, or suggestions?
-      <a href="mailto:?subject=VTSearch%20Issue%3A">Email us</a>.
+      <a [href]="mailtoHref()">Email us</a>.
     </p>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
+++ b/frontend/src/app/components/modals/keyboard-help-modal/keyboard-help-modal.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit, output, SecurityContext, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  OnInit,
+  output,
+  SecurityContext,
+  signal,
+} from '@angular/core';
 
 import { HttpClient } from '@angular/common/http';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
@@ -6,6 +15,11 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { marked } from 'marked';
 import { ModalComponent } from '../../modal/modal.component';
 import { ThemeService, EffectiveTheme } from '../../../services/theme.service';
+import { SettingsStateService } from '../../../services/settings-state.service';
+
+/** Fallback "Email us" recipient used until server settings resolve. Matches
+ *  the backend default (``vtsearch.settings_models.DEFAULT_SUPPORT_EMAIL``). */
+const DEFAULT_SUPPORT_EMAIL = 'sam.greenberg@gmail.com';
 
 interface Shortcut {
   keys: string[];
@@ -58,6 +72,16 @@ export class KeyboardHelpModalComponent implements OnInit {
   private readonly http = inject(HttpClient);
   private readonly sanitizer = inject(DomSanitizer);
   private readonly themeService = inject(ThemeService);
+  private readonly settingsState = inject(SettingsStateService);
+
+  /** ``mailto:`` href for the "Email us" footer link, pre-addressed to the
+   *  server's configured support address (``--support-email`` /
+   *  ``VTSEARCH_SUPPORT_EMAIL`` / the persisted ``support_email`` setting),
+   *  falling back to the built-in default until settings load. */
+  readonly mailtoHref = computed(() => {
+    const email = this.settingsState.settingsSignal()?.support_email?.trim() || DEFAULT_SUPPORT_EMAIL;
+    return `mailto:${encodeURIComponent(email)}?subject=VTSearch%20Issue%3A`;
+  });
 
   readonly activeTab = signal<Tab>('shortcuts');
   /** Which shortcut context's panel is shown under the "Keyboard shortcuts" tab. */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,10 @@ DEP001 = [
     # resolver. Its real deps ARE declared (fast_hdbscan et al.); the smoke
     # test in tests_lib/projection guards the --no-deps bypass.
     "toponymy",
+    # SuperPoint/LightGlue backend for the structural (SPLG) image embedder,
+    # imported lazily inside ``vtscore.media.structural_splg`` methods and
+    # opt-in only (users install ``lightglue`` to enable structural matching).
+    "lightglue",
 ]
 # DEP003: imported as a transitive of another declared dependency.
 # ``safetensors`` and ``torchvision`` ship with ``transformers`` / ``torch``

--- a/tests/core/test_support_email.py
+++ b/tests/core/test_support_email.py
@@ -1,0 +1,80 @@
+"""Tests for the server-tier ``support_email`` contact setting.
+
+Covers the persisted server-tier value, the process-level override set by
+``--support-email`` / ``VTSEARCH_SUPPORT_EMAIL``
+(``set_cli_support_email``), the resolver (``get_effective_support_email``),
+and the API contract (read-only: exposed in ``GET /api/settings`` but not
+settable via ``PUT``). This is the address the Help modal's "Email us" link
+is pre-addressed to (issue #2357).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import app as app_module  # noqa: F401  (triggers conftest media init)
+from vtsearch import settings as settings_mod
+from vtsearch.schemas.settings import AppSettingsSchema, SettingsUpdateSchema
+from vtsearch.settings_models import DEFAULT_SUPPORT_EMAIL
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_support_email():
+    """The CLI/env override is process-global; clear it around each test."""
+    settings_mod.set_cli_support_email(None)
+    yield
+    settings_mod.set_cli_support_email(None)
+
+
+class TestEffectiveResolution:
+    def test_default_is_project_address(self):
+        assert settings_mod.get_effective_support_email() == DEFAULT_SUPPORT_EMAIL
+        assert DEFAULT_SUPPORT_EMAIL == "sam.greenberg@gmail.com"
+
+    def test_cli_override_wins_over_persisted(self, isolated_settings):
+        settings_mod.set_support_email("persisted@example.com")
+        assert settings_mod.get_support_email() == "persisted@example.com"
+        settings_mod.set_cli_support_email("cli@example.com")
+        assert settings_mod.get_effective_support_email() == "cli@example.com"
+
+    def test_falls_back_to_persisted_when_no_override(self, isolated_settings):
+        settings_mod.set_support_email("ops@example.com")
+        assert settings_mod.get_effective_support_email() == "ops@example.com"
+
+    def test_override_clears_back_to_persisted(self, isolated_settings):
+        settings_mod.set_support_email("ops@example.com")
+        settings_mod.set_cli_support_email("cli@example.com")
+        settings_mod.set_cli_support_email(None)
+        assert settings_mod.get_effective_support_email() == "ops@example.com"
+
+    def test_blank_override_is_treated_as_unset(self, isolated_settings):
+        settings_mod.set_support_email("ops@example.com")
+        settings_mod.set_cli_support_email("   ")
+        assert settings_mod.get_cli_support_email() is None
+        assert settings_mod.get_effective_support_email() == "ops@example.com"
+
+
+class TestApiContract:
+    def test_not_settable_via_put(self, client, isolated_settings):
+        """A PUT body carrying support_email is silently ignored:
+        the schema excludes it, so it never reaches a setter."""
+        settings_mod.set_support_email("ops@example.com")
+        resp = client.put("/api/settings", json={"support_email": "attacker@example.com"})
+        assert resp.status_code == 200
+        assert settings_mod.get_support_email() == "ops@example.com"
+
+    def test_get_reflects_effective_value(self, client):
+        settings_mod.set_cli_support_email("cli@example.com")
+        body = client.get("/api/settings").get_json()
+        assert body["support_email"] == "cli@example.com"
+
+    def test_get_reflects_default(self, client):
+        body = client.get("/api/settings").get_json()
+        assert body["support_email"] == DEFAULT_SUPPORT_EMAIL
+
+    def test_schema_marks_it_read_only(self):
+        # Dumpable (so the Help modal can address its mailto link) but not
+        # loadable (set via CLI/env/file, never PUT).
+        app_field = AppSettingsSchema().fields["support_email"]
+        assert app_field.dump_only is True
+        assert "support_email" not in SettingsUpdateSchema().fields

--- a/tests_lib/detectors/test_structural_geometry.py
+++ b/tests_lib/detectors/test_structural_geometry.py
@@ -21,6 +21,7 @@ def test_fit_scale_translation_recovers_model(st_correspondences):
     src, dst, s_true = st_correspondences
     model, mask = fit_scale_translation(src, dst)
     assert model is not None
+    assert mask is not None
     assert abs(model[0, 0] - s_true) < 1e-3
     assert model[0, 1] == 0.0 and model[1, 0] == 0.0  # no rotation terms
     assert mask.sum() >= 42  # the uncorrupted correspondences

--- a/vtscore/media/structural_geometry.py
+++ b/vtscore/media/structural_geometry.py
@@ -157,11 +157,7 @@ def fit_model(
         reflection = s < 0
 
     inlier_count = int(mask.sum())
-    model_ok = (
-        inlier_count >= _MIN_MODEL_INLIERS
-        and _MIN_SANE_SCALE <= scale <= _MAX_SANE_SCALE
-        and not reflection
-    )
+    model_ok = inlier_count >= _MIN_MODEL_INLIERS and _MIN_SANE_SCALE <= scale <= _MAX_SANE_SCALE and not reflection
 
     mean_err = median_err = spread = 0.0
     inlier_box = None

--- a/vtscore/media/structural_splg.py
+++ b/vtscore/media/structural_splg.py
@@ -83,9 +83,7 @@ class SplgMatcher:
 
         if self._matcher is None:
             self._matcher = (
-                LightGlue(features="superpoint", filter_threshold=_LG_FILTER_THRESHOLD)
-                .eval()
-                .to(self.device)
+                LightGlue(features="superpoint", filter_threshold=_LG_FILTER_THRESHOLD).eval().to(self.device)
             )
         return self._matcher
 
@@ -129,9 +127,7 @@ class SplgMatcher:
         ).astype(np.float32)
         return StructuralFeatures(keypoints=kp_arr, descriptors=desc.astype(np.float32))
 
-    def match(
-        self, template: StructuralFeatures, candidate: StructuralFeatures
-    ) -> tuple[np.ndarray, np.ndarray, int]:
+    def match(self, template: StructuralFeatures, candidate: StructuralFeatures) -> tuple[np.ndarray, np.ndarray, int]:
         """LightGlue correspondences ``(src, dst, tentative_count)``.
 
         The tentative count (matches above LightGlue's confidence filter) is

--- a/vtscore/media/structural_splg.py
+++ b/vtscore/media/structural_splg.py
@@ -71,7 +71,7 @@ class SplgMatcher:
         return self._device
 
     def _get_extractor(self, max_features: int):
-        from lightglue import SuperPoint  # noqa: PLC0415
+        from lightglue import SuperPoint  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
         if self._extractor is None or self._extractor_cap != max_features:
             self._extractor = SuperPoint(max_num_keypoints=int(max_features)).eval().to(self.device)
@@ -79,7 +79,7 @@ class SplgMatcher:
         return self._extractor
 
     def _get_matcher(self):
-        from lightglue import LightGlue  # noqa: PLC0415
+        from lightglue import LightGlue  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
         if self._matcher is None:
             self._matcher = (

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -295,6 +295,20 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--support-email",
+        type=str,
+        default=None,
+        dest="support_email",
+        metavar="ADDRESS",
+        help=(
+            "Recipient address for the Help modal's 'Email us' contact link. "
+            "Applies to all users and overrides any persisted support_email in "
+            "the settings file for the lifetime of the process; the value is "
+            "not editable via the settings API. Omit to use the persisted value "
+            "(defaults to the built-in project address)."
+        ),
+    )
+    parser.add_argument(
         "--progress-format",
         type=str,
         default="text",
@@ -514,6 +528,21 @@ def _apply_dataset_max_age(args, parser) -> None:
         from vtsearch.settings import set_cli_dataset_max_age_days
 
         set_cli_dataset_max_age_days(args.dataset_max_age_days)
+
+
+def _apply_support_email(args, parser) -> None:
+    """Validate and stash the process-level ``--support-email`` override."""
+    # --support-email: process-level override for the Help modal's contact
+    # address, applied to every user for the lifetime of the process (not
+    # user-editable via the API). Require a non-empty value so an accidental
+    # blank flag doesn't ship an empty mailto: recipient.
+    if getattr(args, "support_email", None) is not None:
+        email = args.support_email.strip()
+        if not email:
+            parser.error("--support-email must be a non-empty address")
+        from vtsearch.settings import set_cli_support_email
+
+        set_cli_support_email(email)
 
 
 def _authenticate_cli_user(args, parser) -> None:
@@ -783,6 +812,7 @@ def main(app, initialize_server) -> None:
     _apply_hidden_plugins(args, parser)
     _apply_solo_embedders(args, parser)
     _apply_dataset_max_age(args, parser)
+    _apply_support_email(args, parser)
 
     if args.autodetect:
         _run_autodetect(args, parser, importer, exporter)

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -206,6 +206,9 @@ def _with_effective(data: dict) -> dict:
     # force (``--dataset-max-age-days`` wins over the persisted file), so the
     # dashboard's Age-Off column reflects what new datasets are stamped with.
     data["dataset_max_age_days"] = settings.get_effective_dataset_max_age_days()
+    # Surface the CLI/env-overridable "Email us" recipient as the value
+    # actually in force, so the Help modal's mailto link is pre-addressed.
+    data["support_email"] = settings.get_effective_support_email()
     return data
 
 

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -132,6 +132,12 @@ class AppSettingsSchema(Schema):
     # gate its Age-Off column. Not in ``SettingsUpdateSchema`` - not
     # editable via PUT.
     dataset_max_age_days = fields.Integer(dump_only=True, allow_none=True)
+    # Server-tier "Email us" recipient. Set via the ``--support-email`` CLI
+    # flag / ``VTSEARCH_SUPPORT_EMAIL`` env var (process-wide, all users) or
+    # the persisted settings file; surfaced read-only here so the Help modal
+    # can build a pre-addressed ``mailto:`` link. Not in
+    # ``SettingsUpdateSchema`` - not editable via PUT.
+    support_email = fields.String(dump_only=True)
 
     # Auto-Find (per-user, editable from the Auto-Find settings tab).
     # ``autofind_detectors`` is each user's own list of detectors that auto-run

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -101,6 +101,8 @@ if TYPE_CHECKING:
     def set_max_concurrent_dataset_embeddings(value: int) -> None: ...
     def get_dataset_max_age_days() -> int | None: ...
     def set_dataset_max_age_days(value: int | None) -> None: ...
+    def get_support_email() -> str: ...
+    def set_support_email(value: str) -> None: ...
     def get_projection_n_neighbors() -> int: ...
     def set_projection_n_neighbors(value: int) -> None: ...
     def get_projection_min_dist() -> float: ...
@@ -179,6 +181,15 @@ _cli_solo_embedders: dict[str, str] = {}
 #: for the lifetime of the process; the setting is not user-editable via
 #: the API (see :func:`get_effective_dataset_max_age_days`).
 _cli_dataset_max_age_days: int | None = None
+
+#: Process-level override for the server-tier ``support_email`` setting, set
+#: by :func:`set_cli_support_email` from the ``--support-email`` flag in
+#: :mod:`app`. ``None`` means "no CLI override" - reads fall through to the
+#: persisted server setting (and then the model default). When a value is set
+#: it applies to every user and wins over the persisted file for the lifetime
+#: of the process; the setting is not user-editable via the API (see
+#: :func:`get_effective_support_email`).
+_cli_support_email: str | None = None
 
 #: Filename used for the per-user settings file inside
 #: ``get_user_data_dir(user)``.
@@ -944,6 +955,46 @@ def get_effective_dataset_max_age_days() -> int | None:
     if _cli_dataset_max_age_days is not None:
         return _cli_dataset_max_age_days
     return get_dataset_max_age_days()  # type: ignore[name-defined]  # autogen'd accessor
+
+
+def set_cli_support_email(value: str | None) -> None:
+    """Set the process-level override for the ``support_email`` setting.
+
+    Called once from ``app.py`` startup when ``--support-email`` is passed on
+    the command line. The value applies server-wide (every user) and is fixed
+    for the process lifetime; :func:`get_effective_support_email` returns it in
+    preference to the persisted server setting. Pass ``None`` (or an empty /
+    whitespace-only string) to clear the override so reads fall back to the
+    persisted file value.
+    """
+    global _cli_support_email
+    if value is not None:
+        value = value.strip() or None
+    _cli_support_email = value
+
+
+def get_cli_support_email() -> str | None:
+    """Return the process-level CLI override (``None`` if unset)."""
+    return _cli_support_email
+
+
+def get_effective_support_email() -> str:
+    """Return the "Email us" support address in force.
+
+    Resolution order:
+
+    1. The process-level CLI override set by :func:`set_cli_support_email`
+       (``--support-email``), which applies to every user for the lifetime of
+       the process.
+    2. The persisted server-tier setting (``data/settings.json``), which
+       defaults to :data:`~vtsearch.settings_models.DEFAULT_SUPPORT_EMAIL`.
+
+    This is the value surfaced at ``/api/settings`` so the Help modal's
+    "Email us" link opens a pre-addressed compose window.
+    """
+    if _cli_support_email is not None:
+        return _cli_support_email
+    return get_support_email()  # type: ignore[name-defined]  # autogen'd accessor
 
 
 def set_cli_solo_embedder(media_type: str, embedder: str | None) -> None:

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -122,6 +122,12 @@ BROWSE_MOUSE_ZOOMS_PER_LEVEL: tuple[int, int] = (1, 3)
 # ceiling matches the frontend's absolute preview cap.
 POPUP_PREVIEW_SIZE_PX: tuple[int, int] = (96, 720)
 
+# Default recipient for the Help modal's "Email us" affordance. A per-instance
+# operator can override it with the ``--support-email`` CLI flag or the
+# persisted ``support_email`` server setting (see
+# ``vtsearch.settings.get_effective_support_email``).
+DEFAULT_SUPPORT_EMAIL: str = "sam.greenberg@gmail.com"
+
 
 def _clamp(lo: float, hi: float):
     """Return a :class:`BeforeValidator` that clamps numeric input to ``[lo, hi]``."""
@@ -200,6 +206,15 @@ class ServerSettings(BaseModel):
     # datasets are stamped with an ``expires_at`` timestamp based on this
     # value.  ``None`` (the default) means datasets never expire.
     dataset_max_age_days: int | None = None
+
+    # Recipient address for the Help modal's "Email us" contact affordance.
+    # Shared across all users (single-file server tier); a per-instance
+    # operator overrides it with the ``--support-email`` CLI flag (which wins
+    # for the process lifetime) or by editing this key in the settings file.
+    # The frontend reads the effective value from ``/api/settings`` to build
+    # the ``mailto:`` link. See
+    # :func:`vtsearch.settings.get_effective_support_email`.
+    support_email: str = DEFAULT_SUPPORT_EMAIL
 
     # Browse UMAP projection knobs (Stage 1).  They change the map layout, so
     # a per-deployment operator may want to tune them.  The persisted


### PR DESCRIPTION
## What & why

The Help modal's "Email us" link had an empty `mailto:` recipient, so clicking it opened a blank-recipient compose window (#2357). This wires it to a real address with a per-instance override.

- **Default recipient**: `sam.greenberg@gmail.com` (`DEFAULT_SUPPORT_EMAIL` in `settings_models.py`).
- **Per-instance override**: a new server-tier `support_email` setting, following the exact pattern of `dataset_max_age_days` — settable at CLI startup and read-only via the API.

## How it works

- `support_email` is a field on `ServerSettings`, so it persists in `data/settings.json` and gets the usual `get_/set_` accessors.
- `--support-email ADDRESS` CLI flag (and `VTSEARCH_SUPPORT_EMAIL` env var for the gunicorn/Docker images) sets a process-level override that wins over the persisted value for the process lifetime, via `set_cli_support_email` / `get_effective_support_email`.
- The effective value is surfaced read-only at `GET /api/settings` (`dump_only` in `AppSettingsSchema`, absent from `SettingsUpdateSchema`, overlaid in `_with_effective`) — not editable via PUT, exactly like `dataset_max_age_days`.
- The frontend Help modal builds a pre-addressed `mailto:` from `settings.support_email` (computed `mailtoHref`), falling back to the default until settings resolve.

## Tests / checks

- New `tests/core/test_support_email.py` covers the resolver (CLI override vs. persisted vs. default), blank-override handling, and the read-only API contract.
- Regenerated `frontend/openapi.json` snapshot (adds the `support_email` read-only field).
- `./run-tests.sh core api` (1473 passed) and `./run-tests.sh frontend` (build + Vitest 1158 passed, OpenAPI drift check clean) both green.

### Incidental fixes

`./run-tests.sh` surfaced pre-existing failures from the recently-merged structural (SPLG) backend that were unrelated to this change; per the repo's "fix all errors" policy they're fixed here so the suite is green: `ruff format` drift in `structural_geometry.py` / `structural_splg.py`, an undeclared `lightglue` optional import (deptry + pyright), and a `None`-narrowing pyright error in `test_structural_geometry.py`.

Closes #2357

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAq2UBVgTz9edm9WYFioYt)_