### PR TITLE
Autopilot: exhausted terminal state for tiny datasets (no more blank center pane)

### DIFF
--- a/docs/plans/ui-ux-papercuts.md
+++ b/docs/plans/ui-ux-papercuts.md
@@ -22,20 +22,6 @@ Med = confusing; Low = cosmetic) so you can pick the high-value ones first.
 
 <!-- item-sep -->
 
-- **Autopilot exhausted-state for tiny datasets (High)** — on a 1-item (or
-  otherwise small) dataset, autopilot's "Find Initial Goods" needs 3 goods and
-  the bad phase needs 4 bads; those targets are unreachable, so autopilot never
-  advances, shows no "exhausted" state, and the center pane goes blank while the
-  metadata strip keeps the stale item. `autopilot-state.service.ts`
-  `INITIAL_STATE` hardcodes `goodToStart: 3, badToStart: 4`, and
-  `checkPhaseTransition()` (~87-108) gates purely on `count < target` with no
-  dataset-size awareness and no terminal branch (the `'done'` phase needs
-  ≥5 good/5 bad, so small datasets can never reach it). **Fix:** cap each phase
-  target at `min(target, remainingUnlabeledCount)` and add an explicit
-  "dataset exhausted / nothing left to label" terminal state that renders a
-  message instead of a blank pane. **Files:** `autopilot-state.service.ts`,
-  the label-view template that renders the blank pane. (edge-states B1.)
-
 <!-- item-sep -->
 
 <!-- item-sep -->

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -60,10 +60,20 @@
     (resizeEnd)="onLeftResizeEnd($event)"
   ></div>
   <div class="panel-center">
-    <vt-center-panel
-      [media]="mediaState.selectedMedia"
-      (mediaVoted)="onMediaVoted($event)"
-    />
+    @if (autopilotExhausted()) {
+      <div class="autopilot-exhausted-pane" role="status">
+        <p class="autopilot-exhausted-heading">Nothing left to label</p>
+        <p class="autopilot-exhausted-body">
+          Autopilot has labeled every item in this dataset. Review your votes in the
+          side panels, or export your results.
+        </p>
+      </div>
+    } @else {
+      <vt-center-panel
+        [media]="mediaState.selectedMedia"
+        (mediaVoted)="onMediaVoted($event)"
+      />
+    }
   </div>
   <div
     class="pane-divider"

--- a/frontend/src/app/components/label-view/label-view.component.scss
+++ b/frontend/src/app/components/label-view/label-view.component.scss
@@ -35,6 +35,34 @@
   min-width: 100px;
 }
 
+// Terminal autopilot state: every item labeled but the indicators never went
+// green (tiny dataset). Replaces the media viewer so the pane is never blank.
+.autopilot-exhausted-pane {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: var(--space-sm);
+  padding: var(--space-lg);
+}
+
+.autopilot-exhausted-heading {
+  margin: 0;
+  font-size: var(--font-xl);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.autopilot-exhausted-body {
+  margin: 0;
+  max-width: 36ch;
+  font-size: var(--font-md);
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
 .panel-right {
   overflow: hidden;
   background: var(--bg-panel);

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -93,6 +93,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly rightWidth = signal(300);
   readonly autopilotCollapsed = signal(false);
   readonly autopilotEnabled = signal(true);
+  /** True when autopilot has reached its terminal "exhausted" state — every
+   *  item in a tiny dataset is labeled but the indicators never went green.
+   *  Drives the center-pane "nothing left to label" message so the pane is
+   *  never left blank with a stale item stuck in the metadata strip. */
+  readonly autopilotExhausted = signal(false);
   progressModalMetric: ProgressMetric | null = null;
 
   // SortStateService / VoteStateService are now signal-backed (their value
@@ -303,6 +308,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(pairwise(), takeUntil(this.destroy$))
       .subscribe(([prev, curr]) => {
         if (prev.phase === curr.phase) return;
+        this.autopilotExhausted.set(curr.phase === 'exhausted');
         if (curr.phase === 'good') {
           this.sortState.setSelectMode('top');
           if (curr.retrainMode) {
@@ -1156,6 +1162,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // has already found enough greens (the panel's ngOnChanges may not have run yet).
     this.autopilotStateService.checkPhaseTransition(
       this.voteState.goodVotes.size, this.voteState.badVotes.size,
+      this.mediaState.mediasSignal().length,
     );
     const phase = this.autopilotStateService.state.phase;
     if (phase !== 'good') return;

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.html
@@ -2,7 +2,12 @@
   @if (collapsed()) {
     <div class="collapsed-steps">
       <button class="collapse-toggle" (click)="toggleCollapse.emit()" title="Show autopilot panel" aria-label="Show autopilot panel">&#9654;</button>
-      @for (step of steps; track step.phase) {
+      @if (exhausted) {
+        <span class="collapsed-step exhausted" title="Nothing left to label — autopilot has labeled every item in this dataset." aria-label="Nothing left to label">
+          <vt-icon type="check" [size]="14"></vt-icon>
+        </span>
+      } @else {
+        @for (step of steps; track step.phase) {
         <div
           class="collapsed-step"
           [class.done]="step.state === 'done'"
@@ -18,6 +23,7 @@
             <span class="collapsed-step-number" [class.struck]="step.state === 'done'">{{ step.stepNumber }}</span>
           }
         </div>
+        }
       }
     </div>
   } @else {
@@ -25,6 +31,13 @@
       <div class="autopilot-header">
         <button class="collapse-toggle" (click)="toggleCollapse.emit()" title="Hide autopilot panel" aria-label="Hide autopilot panel">&#9664;</button>
       </div>
+      @if (exhausted) {
+        <div class="autopilot-exhausted" role="status">
+          <span class="ap-exhausted-check" aria-hidden="true"><vt-icon type="check" [size]="16"></vt-icon></span>
+          <p class="ap-exhausted-title">Nothing left to label</p>
+          <p class="ap-exhausted-detail">Autopilot has labeled every item in this dataset. Review your votes or export your results.</p>
+        </div>
+      } @else {
       <div class="autopilot-steps">
         @for (step of steps; track step.phase) {
           <div
@@ -66,6 +79,7 @@
           </div>
         }
       </div>
+      }
     </div>
   }
 </div>

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.scss
@@ -195,3 +195,38 @@
   letter-spacing: var(--tracking-wide);
   white-space: nowrap;
 }
+
+.collapsed-step.exhausted {
+  color: var(--color-good);
+}
+
+// Terminal "nothing left to label" note, shown in place of the step list when
+// autopilot has exhausted a tiny dataset without reaching the all-green state.
+.autopilot-exhausted {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--space-2xs);
+  padding: var(--space-md) var(--space-sm);
+}
+
+.ap-exhausted-check {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-good);
+}
+
+.ap-exhausted-title {
+  margin: 0;
+  font-size: var(--font-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.ap-exhausted-detail {
+  margin: 0;
+  font-size: var(--font-2xs);
+  color: var(--text-muted);
+}

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -314,15 +314,14 @@ describe('AutopilotPanelComponent', () => {
   });
 
   it('reaches the exhausted state and renders a note when a 1-item dataset is labeled', async () => {
-    component.datasetSize = 1;
-    component.goodVotes = new Set([1]);
-    component.badVotes = new Set();
-    component.ngOnChanges({
-      goodVotes: { currentValue: component.goodVotes, previousValue: new Set(), firstChange: false, isFirstChange: () => false },
-    });
+    // Drive the inputs the way the template binding does, so OnPush re-renders
+    // and ngOnChanges fires the dataset-size-aware phase check.
+    fixture.componentRef.setInput('datasetSize', 1);
+    fixture.componentRef.setInput('goodVotes', new Set([1]));
+    fixture.componentRef.setInput('badVotes', new Set());
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('exhausted');
     expect(component.exhausted).toBe(true);
-    await settleZoneless(fixture);
     const note = fixture.nativeElement.querySelector('.autopilot-exhausted');
     expect(note).toBeTruthy();
     expect(note.textContent).toContain('Nothing left to label');
@@ -330,13 +329,11 @@ describe('AutopilotPanelComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('.ap-step').length).toBe(0);
   });
 
-  it('does not exhaust while the dataset size is unknown (datasetSize 0)', () => {
-    component.datasetSize = 0;
-    component.goodVotes = new Set([1]);
-    component.badVotes = new Set();
-    component.ngOnChanges({
-      goodVotes: { currentValue: component.goodVotes, previousValue: new Set(), firstChange: false, isFirstChange: () => false },
-    });
+  it('does not exhaust while the dataset size is unknown (datasetSize 0)', async () => {
+    fixture.componentRef.setInput('datasetSize', 0);
+    fixture.componentRef.setInput('goodVotes', new Set([1]));
+    fixture.componentRef.setInput('badVotes', new Set());
+    await settleZoneless(fixture);
     // Unknown size → uncapped → 1 good is not enough, still in good phase.
     expect(component.state.phase).toBe('good');
   });

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -304,4 +304,40 @@ describe('AutopilotPanelComponent', () => {
     expect(steps[1].state).toBe('future');
     expect(steps[2].state).toBe('future');
   });
+
+  it('caps the good-phase target for display on a tiny dataset', () => {
+    component.datasetSize = 1;
+    component.goodVotes = new Set();
+    component.badVotes = new Set();
+    // Default target is 3, but a 1-item dataset can supply at most 1 good.
+    expect(component.effGoodTarget).toBe(1);
+  });
+
+  it('reaches the exhausted state and renders a note when a 1-item dataset is labeled', async () => {
+    component.datasetSize = 1;
+    component.goodVotes = new Set([1]);
+    component.badVotes = new Set();
+    component.ngOnChanges({
+      goodVotes: { currentValue: component.goodVotes, previousValue: new Set(), firstChange: false, isFirstChange: () => false },
+    });
+    expect(component.state.phase).toBe('exhausted');
+    expect(component.exhausted).toBe(true);
+    await settleZoneless(fixture);
+    const note = fixture.nativeElement.querySelector('.autopilot-exhausted');
+    expect(note).toBeTruthy();
+    expect(note.textContent).toContain('Nothing left to label');
+    // The five-step list is replaced by the terminal note.
+    expect(fixture.nativeElement.querySelectorAll('.ap-step').length).toBe(0);
+  });
+
+  it('does not exhaust while the dataset size is unknown (datasetSize 0)', () => {
+    component.datasetSize = 0;
+    component.goodVotes = new Set([1]);
+    component.badVotes = new Set();
+    component.ngOnChanges({
+      goodVotes: { currentValue: component.goodVotes, previousValue: new Set(), firstChange: false, isFirstChange: () => false },
+    });
+    // Unknown size → uncapped → 1 good is not enough, still in good phase.
+    expect(component.state.phase).toBe('good');
+  });
 });

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -45,6 +45,13 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   @Input() goodVotes: Set<number> = new Set();
   @Input() badVotes: Set<number> = new Set();
   /**
+   * Number of items in the active dataset. Feeds the dataset-size-aware phase
+   * targets: on a tiny collection the default 3-good / 4-bad targets are
+   * unreachable, so they're capped to what the dataset can supply. ``0`` means
+   * unknown (still loading); the service leaves the targets uncapped then.
+   */
+  @Input() datasetSize = 0;
+  /**
    * Total "good" labels in the active detector's saved labelset, across all
    * datasets it has been used with.  When both this and ``labelsetBadCount``
    * are positive at activation time, autopilot enters retrain mode and uses
@@ -68,6 +75,31 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
 
   get running(): boolean {
     return this.autopilotState.running;
+  }
+
+  /** Terminal state: every item labeled but the indicators never went green
+   *  (typical of a tiny dataset that can't reach the good+bad quorum). */
+  get exhausted(): boolean {
+    return this.state.phase === 'exhausted';
+  }
+
+  /** Items still carrying no vote, or ``Infinity`` while the dataset size is
+   *  unknown or inconsistent with the vote counts (mirrors the service's
+   *  uncapped behavior during load; see ``checkPhaseTransition``). */
+  private get remainingUnlabeled(): number {
+    const raw = this.datasetSize - this.goodVotes.size - this.badVotes.size;
+    if (this.datasetSize <= 0 || raw < 0) return Infinity;
+    return raw;
+  }
+
+  /** Good-vote target for the current dataset, capped to what it can supply. */
+  get effGoodTarget(): number {
+    return Math.min(this.state.goodToStart, this.goodVotes.size + this.remainingUnlabeled);
+  }
+
+  /** Bad-vote target for the current dataset, capped to what it can supply. */
+  get effBadTarget(): number {
+    return Math.min(this.state.badToStart, this.badVotes.size + this.remainingUnlabeled);
   }
 
   get steps(): StepDisplay[] {
@@ -106,15 +138,26 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
       this.autopilotState.updateFromLabelingStatus(this.labelingStatus);
     }
 
-    if (changes['goodVotes'] || changes['badVotes'] || changes['labelingStatus']) {
+    if (changes['goodVotes'] || changes['badVotes'] || changes['labelingStatus'] || changes['datasetSize']) {
       const prevPhase = this.autopilotState.state.phase;
-      this.autopilotState.checkPhaseTransition(this.goodVotes.size, this.badVotes.size);
-      if (prevPhase !== 'done' && this.autopilotState.state.phase === 'done' && !this.completionAlerted) {
-        this.completionAlerted = true;
-        this.toastService.success({
-          message: 'Autopilot complete',
-          detail: 'All quality indicators are green. You can continue labeling or export your results.',
-        });
+      this.autopilotState.checkPhaseTransition(
+        this.goodVotes.size, this.badVotes.size, this.datasetSize,
+      );
+      const phase = this.autopilotState.state.phase;
+      if (prevPhase !== phase && !this.completionAlerted) {
+        if (phase === 'done') {
+          this.completionAlerted = true;
+          this.toastService.success({
+            message: 'Autopilot complete',
+            detail: 'All quality indicators are green. You can continue labeling or export your results.',
+          });
+        } else if (phase === 'exhausted') {
+          this.completionAlerted = true;
+          this.toastService.success({
+            message: 'Nothing left to label',
+            detail: 'Autopilot has labeled every item in this dataset. Review your votes or export your results.',
+          });
+        }
       }
     }
   }
@@ -131,7 +174,9 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
     // (e.g. user labeled 23 goods in Manual mode before switching to Autopilot).
     // ngOnChanges ran before ngOnInit so `running` was false and the check was
     // skipped; do it now so the phase cascades (good→bad→hard) before we emit.
-    this.autopilotState.checkPhaseTransition(this.goodVotes.size, this.badVotes.size);
+    this.autopilotState.checkPhaseTransition(
+      this.goodVotes.size, this.badVotes.size, this.datasetSize,
+    );
     this.started.emit();
   }
 
@@ -237,9 +282,9 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
     const st = this.state;
     switch (phase) {
       case 'good':
-        return `${this.goodVotes.size}/${st.goodToStart} good labels`;
+        return `${this.goodVotes.size}/${this.effGoodTarget} good labels`;
       case 'bad':
-        return `${this.badVotes.size}/${st.badToStart} bad labels`;
+        return `${this.badVotes.size}/${this.effBadTarget} bad labels`;
       case 'hard': {
         // No count target here — the phase ends when the smart and stable
         // indicators (the dots rendered right after this text) both go green.

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -201,6 +201,7 @@
         <vt-autopilot-panel
           [goodVotes]="goodVotes()"
           [badVotes]="badVotes()"
+          [datasetSize]="medias.length"
           [labelsetGoodCount]="labelsetGoodCount()"
           [labelsetBadCount]="labelsetBadCount()"
           [labelingStatus]="labelingStatus()"

--- a/frontend/src/app/services/autopilot-state.service.spec.ts
+++ b/frontend/src/app/services/autopilot-state.service.spec.ts
@@ -235,6 +235,69 @@ describe('AutopilotStateService', () => {
     expect(service.state.retrainMode).toBe(false);
   });
 
+  it('caps the good target so a 1-item dataset can advance past the good phase', () => {
+    service.activate();
+    // 1-item dataset: default good target is 3, but only 1 item exists.
+    // Voting that single item good should satisfy the (capped) good target.
+    service.checkPhaseTransition(1, 0, 1);
+    expect(service.state.phase).not.toBe('good');
+  });
+
+  it('reaches the exhausted terminal state when a tiny dataset is fully labeled', () => {
+    service.activate();
+    // 1-item dataset, single item voted good: nothing left to label and the
+    // indicators can never go green, so autopilot lands in "exhausted".
+    service.checkPhaseTransition(1, 0, 1);
+    expect(service.state.phase).toBe('exhausted');
+  });
+
+  it('reaches exhausted regardless of whether the lone item was voted good or bad', () => {
+    service.activate();
+    service.checkPhaseTransition(0, 1, 1); // single item voted bad
+    expect(service.state.phase).toBe('exhausted');
+  });
+
+  it('reaches exhausted on a small dataset that cannot meet the good+bad quorum', () => {
+    service.activate();
+    // 5 items: cannot reach 3 good AND 4 bad (needs 7). Fully labeled → exhausted.
+    service.checkPhaseTransition(3, 2, 5);
+    expect(service.state.phase).toBe('exhausted');
+  });
+
+  it('does not go exhausted while unlabeled items remain', () => {
+    service.activate();
+    // 10-item dataset, only 2 labeled: still in an early phase, not exhausted.
+    service.checkPhaseTransition(1, 1, 10);
+    expect(service.state.phase).not.toBe('exhausted');
+  });
+
+  it('prefers the all-green done state over exhausted when indicators are green', () => {
+    service.activate();
+    service.updateFromLabelingStatus(
+      makeStatus({ status: 'green' }, { status: 'green' }, { status: 'green' }),
+    );
+    // Fully labeled AND all green: the happy "done" path wins over "exhausted".
+    service.checkPhaseTransition(3, 2, 5);
+    expect(service.state.phase).toBe('done');
+  });
+
+  it('regresses out of exhausted when an unlabeled item reappears (vote cleared)', () => {
+    service.activate();
+    service.checkPhaseTransition(1, 0, 1);
+    expect(service.state.phase).toBe('exhausted');
+    // User clears the vote: now nothing is labeled again and the item is
+    // available, so the phase regresses to the good phase.
+    service.checkPhaseTransition(0, 0, 1);
+    expect(service.state.phase).toBe('good');
+  });
+
+  it('leaves targets uncapped when totalCount is unknown (default 0)', () => {
+    service.activate();
+    // No size passed: 1 good is not enough for the default target of 3.
+    service.checkPhaseTransition(1, 0);
+    expect(service.state.phase).toBe('good');
+  });
+
   it('state$ should emit on changes', () => new Promise<void>((done) => {
     const phases: string[] = [];
     service.state$.subscribe((s) => phases.push(s.phase));

--- a/frontend/src/app/services/autopilot-state.service.ts
+++ b/frontend/src/app/services/autopilot-state.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import type { LabelingStatusResponse } from '../generated/api-client/models/labeling-status-response';
 
-export type AutopilotPhase = 'idle' | 'good' | 'bad' | 'hard' | 'new' | 'done';
+export type AutopilotPhase = 'idle' | 'good' | 'bad' | 'hard' | 'new' | 'done' | 'exhausted';
 
 export interface AutopilotState {
   phase: AutopilotPhase;
@@ -84,20 +84,54 @@ export class AutopilotStateService {
     this.stateSubject.next({ ...current, fracDiversity: level });
   }
 
-  checkPhaseTransition(goodCount: number, badCount: number): void {
+  /**
+   * Recompute the phase from current vote counts and indicator statuses.
+   *
+   * ``totalCount`` is the number of items in the active dataset. When it is
+   * known (finite and positive) the phase targets are capped to what the
+   * dataset can actually supply: on a 1-item (or otherwise tiny) collection
+   * the default 3-good / 4-bad targets are unreachable, so gating purely on
+   * ``count < target`` would strand autopilot in an early phase forever. Pass
+   * ``0`` (the default) when the size is unknown to keep the targets uncapped.
+   */
+  checkPhaseTransition(goodCount: number, badCount: number, totalCount = 0): void {
     const st = this.stateSubject.value;
     if (st.phase === 'idle') return;
+
+    // How many items still carry no vote. Treat the size as "unknown" — and so
+    // leave targets uncapped and never exhaust — unless it is a finite positive
+    // number that is at least the current vote count. A total below the vote
+    // count means the number is stale/inconsistent (votes loaded before medias,
+    // or a labelset spanning several datasets), which we must not mistake for a
+    // fully-labeled tiny dataset.
+    const rawRemaining = totalCount - goodCount - badCount;
+    const sizeKnown = Number.isFinite(totalCount) && totalCount > 0 && rawRemaining >= 0;
+    const remainingUnlabeled = sizeKnown ? rawRemaining : Infinity;
+
+    // Cap each phase target at the most votes of that class the dataset could
+    // still yield (current votes of that class + everything unlabeled), so a
+    // tiny dataset can still satisfy — and advance past — the initial phases.
+    const effGoodTarget = Math.min(st.goodToStart, goodCount + remainingUnlabeled);
+    const effBadTarget = Math.min(st.badToStart, badCount + remainingUnlabeled);
 
     // Derive the correct phase from current counts and indicator statuses.
     // This allows both forward and backward transitions (e.g. if votes are
     // cleared or un-toggled, the phase regresses to match).
     let nextPhase: AutopilotPhase;
-    if (goodCount < st.goodToStart) {
+    if (goodCount < effGoodTarget) {
       nextPhase = 'good';
-    } else if (badCount < st.badToStart) {
+    } else if (badCount < effBadTarget) {
       nextPhase = 'bad';
+    } else if (st.smartStatus === 'green' && st.stableStatus === 'green' && st.spanStatus === 'green') {
+      nextPhase = 'done';
+    } else if (remainingUnlabeled === 0) {
+      // Every item is labeled but the quality indicators never went green
+      // (typical of a tiny dataset that can't reach the good+bad quorum).
+      // Land in a terminal "exhausted" state so the view can render a clear
+      // message instead of a blank pane stuck in 'hard' with nothing to select.
+      nextPhase = 'exhausted';
     } else if (st.smartStatus === 'green' && st.stableStatus === 'green') {
-      nextPhase = st.spanStatus === 'green' ? 'done' : 'new';
+      nextPhase = 'new';
     } else {
       nextPhase = 'hard';
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ DEP001 = [
     "rarfile",
     "whisper",
     "mediapipe",
+    "lightglue",
     "facenet_pytorch",
     "torchvision",
     "safetensors",

--- a/tests_lib/detectors/test_structural_geometry.py
+++ b/tests_lib/detectors/test_structural_geometry.py
@@ -21,6 +21,7 @@ def test_fit_scale_translation_recovers_model(st_correspondences):
     src, dst, s_true = st_correspondences
     model, mask = fit_scale_translation(src, dst)
     assert model is not None
+    assert mask is not None
     assert abs(model[0, 0] - s_true) < 1e-3
     assert model[0, 1] == 0.0 and model[1, 0] == 0.0  # no rotation terms
     assert mask.sum() >= 42  # the uncorrupted correspondences

--- a/vtscore/media/structural_geometry.py
+++ b/vtscore/media/structural_geometry.py
@@ -157,11 +157,7 @@ def fit_model(
         reflection = s < 0
 
     inlier_count = int(mask.sum())
-    model_ok = (
-        inlier_count >= _MIN_MODEL_INLIERS
-        and _MIN_SANE_SCALE <= scale <= _MAX_SANE_SCALE
-        and not reflection
-    )
+    model_ok = inlier_count >= _MIN_MODEL_INLIERS and _MIN_SANE_SCALE <= scale <= _MAX_SANE_SCALE and not reflection
 
     mean_err = median_err = spread = 0.0
     inlier_box = None

--- a/vtscore/media/structural_splg.py
+++ b/vtscore/media/structural_splg.py
@@ -71,7 +71,7 @@ class SplgMatcher:
         return self._device
 
     def _get_extractor(self, max_features: int):
-        from lightglue import SuperPoint  # noqa: PLC0415
+        from lightglue import SuperPoint  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
         if self._extractor is None or self._extractor_cap != max_features:
             self._extractor = SuperPoint(max_num_keypoints=int(max_features)).eval().to(self.device)
@@ -79,13 +79,11 @@ class SplgMatcher:
         return self._extractor
 
     def _get_matcher(self):
-        from lightglue import LightGlue  # noqa: PLC0415
+        from lightglue import LightGlue  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
         if self._matcher is None:
             self._matcher = (
-                LightGlue(features="superpoint", filter_threshold=_LG_FILTER_THRESHOLD)
-                .eval()
-                .to(self.device)
+                LightGlue(features="superpoint", filter_threshold=_LG_FILTER_THRESHOLD).eval().to(self.device)
             )
         return self._matcher
 
@@ -129,9 +127,7 @@ class SplgMatcher:
         ).astype(np.float32)
         return StructuralFeatures(keypoints=kp_arr, descriptors=desc.astype(np.float32))
 
-    def match(
-        self, template: StructuralFeatures, candidate: StructuralFeatures
-    ) -> tuple[np.ndarray, np.ndarray, int]:
+    def match(self, template: StructuralFeatures, candidate: StructuralFeatures) -> tuple[np.ndarray, np.ndarray, int]:
         """LightGlue correspondences ``(src, dst, tentative_count)``.
 
         The tentative count (matches above LightGlue's confidence filter) is


### PR DESCRIPTION
## Problem

On a 1-item (or otherwise small) dataset, autopilot's "Find Initial Goods" needs 3 goods and the bad phase needs 4 bads. Those targets are unreachable, so autopilot never advanced, showed no "exhausted" state, and the **center pane went blank** while the metadata strip kept the stale item.

Root cause (per the issue):
- `checkPhaseTransition()` gated purely on `count < target` with no dataset-size awareness and no terminal branch (the `'done'` phase needs all-green indicators, unreachable on tiny datasets).
- `autoSelectNext()` in `'top'` mode selects nothing once every item is voted, leaving the pane blank.

## Fix

- **`autopilot-state.service.ts`** — `checkPhaseTransition()` now takes the dataset size and caps each phase target at the most votes of that class the dataset could still yield (`current votes + everything unlabeled`). A new terminal `'exhausted'` phase fires when every item is labeled but the quality indicators never went green. Guards against inconsistent counts (votes loaded before medias, or a labelset spanning several datasets): when the reported total is below the vote count it's treated as unknown, so targets stay uncapped and exhausted never triggers spuriously mid-load. The happy all-green `'done'` path still wins over `'exhausted'`.
- **`autopilot-panel`** — displays the capped `N/target` instead of the raw `N/3`, and renders a "Nothing left to label" note (expanded) / check chip (collapsed) in place of the step list when exhausted; a toast fires on reaching the terminal state.
- **`label-view`** — the center pane renders an explicit "Nothing left to label" message instead of a blank viewer + stale metadata strip when autopilot is exhausted.

## Also in this PR

The recently-merged structural (LightGlue) backend landed with lint/type gate failures that block `./run-tests.sh` in a container where `lightglue` isn't installed. Fixed so the loop runs clean, consistent with the existing optional-import handling:
- `lightglue` added to deptry's `DEP001` per-rule ignore list (alongside `paddleocr`/`whisper`/`mediapipe`).
- `# pyright: ignore[reportMissingImports]` on the two lazy `lightglue` imports.
- `assert mask is not None` in `test_structural_geometry.py` (matches the adjacent `model is not None` guard).
- `ruff format` reflow of two structural files.

## Verification

`./run-tests.sh` is fully green (5752 passed, 1 skipped) including the frontend Vitest suite (1169 passed). New tests cover the capped targets, the `'exhausted'` transition (good/bad, tiny and small datasets), the done-over-exhausted precedence, regression out of exhausted when a vote clears, the unknown/inconsistent-size guard, and the rendered panel note.

Per the issue, a browser session would be the reliable way to watch the live center pane; this container has no Chromium, so the terminal-state behavior is covered by unit tests rather than a live repro.

Closes #2354
