### PR TITLE
Issues vs docs/plans/ policy + committed dev→main release runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,29 @@ When your change resolves a GitHub issue, **link the PR back to that issue** so 
 
 **Do not close the issue yourself.** The closing keyword will **not** auto-close the issue on merge, because GitHub only auto-closes keyword-linked issues when the PR merges into the **default branch** (`main`), and our PRs target **`dev`**. That is intentional: an issue stays open while its fix lives only on `dev`, and is closed only once the fix reaches `main` (i.e. is actually shipped to users). The `dev`→`main` merge Routine is what sweeps the now-shipped issues closed (with `state_reason: completed`); a per-fix Claude session must not close the issue early. So: link and comment, but leave the issue open.
 
+## Issues vs `docs/plans/`: one item, one home (CRITICAL)
+
+GitHub Issues and plan files are **not two copies of the same list.** They hold different kinds of work, and the split is enforced by a single invariant that makes the two stores impossible to desync:
+
+> **No task's body lives in two places.** A plan file may *reference* an issue by number, but must never duplicate the issue's content. There is nothing to "sync" because nothing is stored twice.
+
+**Division of labor:**
+
+- **GitHub Issues own every concrete, independently-shippable task** — bugs, papercuts, small self-contained features. Issues are browsable, closable, PR-linkable, and swept by the Dev2Main Routine, which is exactly what discrete tasks want. A concrete bug belongs in an issue **alone**, never also as a plan-file bullet.
+- **`docs/plans/` owns design narrative** — architecture, rationale, sequencing, the "why" and "shape" of multi-step efforts. Reserve plan files for work where the prose earns its keep. A plan that has decayed into a bag of independent one-line bullets *wants* to be N issues; promote it.
+
+**Promoting a plan item to an issue:** when a slice inside a plan becomes concrete enough to ship on its own, file the issue, then **delete that item's body from the plan.** If the plan is a genuine umbrella that needs to show "these slices belong together," leave a **one-line checkbox pointer** in place of the body — never the full text:
+
+```markdown
+- [ ] #2355 — Fill in missing demo media counts
+```
+
+The pointer carries the issue number (the durable link) and a short human-readable title (so the umbrella is legible at a glance). It does **not** restate the issue's body, file pointers, or fix notes — those live in the issue, which is now the single source of truth. Check the box (or delete the line) when the issue closes.
+
+**Dismissing an issue as unwarranted:** close it as `not_planned` with a one-line comment explaining why. If any plan file points at it (grep `docs/plans/` for `#<number>`), prune that pointer line in the same motion. Because plans carry only pointers — not bodies — this is always a trivial one-line deletion, whether the issue was dismissed or merged. (The Dev2Main Routine reconciles this automatically when it sweeps issues; a manual close should do the same pointer-prune by hand.)
+
+This is why closing an issue by hand didn't previously "trickle back": the item was **duplicated as a body** in the plan instead of **referenced as a pointer.** Store it once, point at it from anywhere else, and dismissal is just deleting the pointer.
+
 ## Plan files (`docs/plans/`) track FUTURE work only
 
 A plan file describes **work still owed**: a proposed feature, or the open parts of one in progress. Plans are **not an archive of completed work.** Git history and merged PRs are the record of what already landed; the plan is what someone reads to pick up what's left.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,4 +365,5 @@ def slow_load():
 - `docs/ML.md` — training/scoring details.
 - `docs/EXTENDING.md` + `docs/EXTENDING-plugins.md` + `docs/EXTENDING-media.md` + `docs/EXTENDING-processors.md` — how to add plugins.
 - `docs/plans/` — future-work design docs (open/proposed; shipped work is pruned out, not archived); check here before adding a "Phase N" feature.
+- `docs/RELEASE.md` — the `dev` → `main` release runbook (the procedure the Dev2Main Routine follows: vulture audit, release summary, punch-card refresh, release PR, issue close-out, plan-pointer prune).
 - `docs/style-guide.md` — frontend SCSS conventions.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -60,15 +60,19 @@ converted to plaintext.
 
 ## 4. Rebuild the punch-card graphic
 
-Refresh the PR-merge data and regenerate the image:
+`scripts/punchcard/punchcard.py` is a **pure renderer**: it reads the
+hand-maintained data file `scripts/punchcard/pr_merges.txt` (one
+`<pr_number>|<merged_at_utc_iso8601>` line per merged PR) and rewrites the PNG.
+It does **not** generate the data file — you refresh that yourself first.
 
-- Update `scripts/punchcard/pr_merges.txt` with the PRs merged since the last
-  release (one `<pr_number>|<merged_at_utc_iso8601>` line each; see the module
-  docstring in `scripts/punchcard/punchcard.py` for how the file is generated
-  from the GitHub API).
+- Append a line for each PR merged into `dev` since the last release. These are
+  the same PRs you enumerate for the release range in step 3 / step 6; take each
+  one's number and its merge timestamp (`merged_at`, UTC ISO 8601) and add
+  `<pr_number>|<merged_at>` to `scripts/punchcard/pr_merges.txt`. The file is
+  sorted-unique by PR number, so keep it that way.
 - Run `python scripts/punchcard/punchcard.py`, which rewrites
   `scripts/punchcard/vtsearch_pr_punchcard.png`.
-- Commit the regenerated PNG (and the updated `pr_merges.txt`).
+- Commit the regenerated PNG and the updated `pr_merges.txt`.
 
 ## 5. Open the release PR
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,130 @@
+# Release runbook: `dev` → `main`
+
+This is the procedure the **Dev2Main** Routine follows to promote `dev` to
+`main`. It lives in the repo (not in Claude settings) so it's versioned,
+PR-reviewable, and run by reference: the Routine prompt is a thin pointer at
+this file.
+
+> **Override for this procedure only:** the final release PR's `base` is
+> **`main`**, not `dev`. This is the one sanctioned exception to CLAUDE.md's
+> "never open a PR to `main`" rule — it applies solely to the release PR
+> opened in step 6, and only when running this runbook.
+
+Work through the steps in order.
+
+## 1. Vulture dead-code audit
+
+Run:
+
+```
+vulture vtsearch/ app.py tests/ .vulture-whitelist.py --min-confidence 60 \
+  --exclude '*/vtsearch/schemas/*,*/vtsearch/settings_models.py' \
+  --ignore-decorators '@*.route,@*.before_request,@*.after_request,@*.errorhandler,@*.teardown_request,@*.context_processor,@bp.*,@app.*,@pytest.fixture,@pytest.mark.*,@fixture,@*.fixture' \
+  --ignore-names 'Meta,model_config,_keys_to_ignore_on_load_unexpected,test_*,Test*,setup_method,teardown_method,setup_class,teardown_class,pytest_*,pytestmark,__enter__,__exit__,__package__'
+```
+
+Vulture is intentionally **not** a CI gate (false positives against the
+plugin-discovery pattern), so a non-clean exit doesn't block the promotion —
+but every finding gets triaged:
+
+- **Genuinely unused** → delete the symbol and any imports/references that fall
+  out.
+- **Used reflectively** → add it to `.vulture-whitelist.py` with a one-line
+  comment explaining the indirect use.
+
+## 2. Land the cleanup
+
+Commit the triage changes on the current branch **before** opening the PR — not
+as a follow-up. If vulture was clean, skip this step.
+
+## 3. Write the release summary
+
+Run `git fetch origin --prune`, then summarize
+`git log origin/main..origin/dev --no-merges --reverse`.
+
+**Format:** categorized bullets under these headings (collapse any with zero
+items): **Features**, **Bug fixes**, **Performance**, **Refactors /
+internals**, **Dev tooling & docs**.
+
+**Constraints:**
+
+- Hard cap **2000 characters** including spaces and markdown. If you'd exceed
+  it, drop or combine the lowest-impact items.
+- No PR numbers, no `#1234`, no commit SHAs, no author handles, no branch names,
+  no issue references. The summary is for end-users.
+- If vulture was clean, append a single line: `vulture: clean.` Otherwise:
+  `vulture: <N> findings triaged.`
+
+Use the summary verbatim as the PR body (step 6) and also output it in chat,
+converted to plaintext.
+
+## 4. Rebuild the punch-card graphic
+
+Refresh the PR-merge data and regenerate the image:
+
+- Update `scripts/punchcard/pr_merges.txt` with the PRs merged since the last
+  release (one `<pr_number>|<merged_at_utc_iso8601>` line each; see the module
+  docstring in `scripts/punchcard/punchcard.py` for how the file is generated
+  from the GitHub API).
+- Run `python scripts/punchcard/punchcard.py`, which rewrites
+  `scripts/punchcard/vtsearch_pr_punchcard.png`.
+- Commit the regenerated PNG (and the updated `pr_merges.txt`).
+
+## 5. Open the release PR
+
+- **Title:** `Release: dev → main (YYYY-MM-DD)` using today's date.
+- **Base:** `main`. **Head:** `dev`.
+- **Body:** the step-3 summary, verbatim.
+
+## 6. Close the issues shipped in this release
+
+Now that the release PR is open, close the GitHub issues whose fixes are
+included in this `dev → main` batch. This is the counterpart to the per-fix rule
+in CLAUDE.md: individual fix PRs link their issue with a `Closes #N` keyword but
+leave it **open** (their merge to `dev` can't auto-close it), and this step is
+what finally closes it once the fix reaches `main`.
+
+**Find the issues to close** from this release's PRs:
+
+- List the pull requests merged into `dev` within this release range — the same
+  `origin/main..origin/dev` window used for the summary in step 3 (inspect the
+  merge commits in that range to get the PR numbers).
+- For each such PR, read its body and collect every issue it references with a
+  **closing** keyword: `Closes #N`, `Fixes #N`, or `Resolves #N`
+  (case-insensitive). **Skip** non-closing references (`Refs #N`, `Part of #N`)
+  — those are partial and must stay open.
+
+**Then, for each collected issue that is still open:**
+
+- Close it with `state_reason: completed`.
+- Add a one-line comment noting it shipped to `main` in today's release and
+  linking the fix PR (e.g. `Shipped to main in the 2026-07-14 release — fixed
+  in #M.`).
+
+Do not close any issue that isn't linked by a closing keyword from a PR in this
+batch, and don't reopen or re-close issues already closed. If no qualifying
+issues are found, state that in chat and do nothing.
+
+## 7. Prune plan pointers for the closed issues
+
+Per CLAUDE.md's "Issues vs `docs/plans/`: one item, one home" invariant, plan
+files reference shipped issues by a one-line checkbox pointer
+(`- [ ] #N — title`) rather than duplicating their bodies. When an issue closes,
+its pointer is stale and should go.
+
+For **every** issue closed in step 6, grep `docs/plans/` for its number:
+
+```
+grep -rn '#<number>' docs/plans/
+```
+
+For each hit, delete that pointer line (or check its box, `- [x]`, if the
+umbrella deliberately keeps a shipped-slice ledger — prefer deletion unless the
+surrounding plan clearly does the latter). Leave the `<!-- item-sep -->`
+sentinels around it in place, per the plan-file policy. If the deletion empties
+a plan entirely and no follow-ups remain, delete the plan file (after absorbing
+any lasting design notes into the permanent docs), as the plan-file policy
+directs. Commit these prunes.
+
+This is what makes issue-dismissal trickle back automatically: because plans
+hold only pointers (never bodies), pruning is always a safe one-line deletion.

--- a/docs/plans/standard-workflow-polish.md
+++ b/docs/plans/standard-workflow-polish.md
@@ -19,18 +19,7 @@ the original priority.
 
 <!-- item-sep -->
 
-- **Fill in missing demo media counts (P2)** — `vtscore/datasets/demo_counts.py`
-  `DEMO_MEDIA_COUNTS` has exact counts for caltech101, eurosat, reuters21578,
-  20newsgroups, arxiv_abstracts, oxford_flowers_102, ucf101, roxford5k, and
-  bbc_news, but still falls back to an inaccurate estimate for caltech256,
-  places365, urbansound8k, gtzan, speech_commands_v2, hmdb51, kth, ucf101_full,
-  ucsf_documents, and dbpedia. **Fix:** download each and run
-  `scripts/compute_demo_counts.py <id>`, then paste the emitted lines into
-  `demo_counts.py`. **Files:** `vtscore/datasets/demo_counts.py`.
-
-<!-- item-sep -->
-
-<!-- item-sep -->
+- [ ] #2355 — Fill in missing demo media counts
 
 <!-- item-sep -->
 
@@ -44,23 +33,11 @@ the original priority.
 
 <!-- item-sep -->
 
-- **"Email us" mailto has no recipient (`mailto-recipient`, P3)** — the
-  "Email us" affordance now lives in the Help modal
-  (`keyboard-help-modal.component.html`, `.help-footer`) as
-  `mailto:?subject=VTSearch%20Issue%3A` — the subject typo is fixed but the
-  to-address is still empty, so "Email us" opens a blank-recipient compose
-  window. **Fix:** add the recipient address. **Files:**
-  `keyboard-help-modal.component.html`. (The "Simplify header and layout IA"
-  slice that moved this out of the header logo has already shipped.)
+- [ ] #2357 — "Email us" mailto has no recipient
 
 <!-- item-sep -->
 
-- **UCSF Documents listed under Image media type (P3)** —
-  `vtscore/media/image/_demo_sources.py:556` registers `ucsf_documents_a` under
-  the image `_MEDIA_TYPE_ID`, so scanned document pages appear atop the Image
-  demo list. Arguably intentional (pages are images), so this is a labeling
-  call. **Fix:** relabel to signal it's scanned documents, or recategorize.
-  **Files:** `vtscore/media/image/_demo_sources.py`.
+- [ ] #2358 — UCSF Documents listed under Image media type
 
 <!-- item-sep -->
 
@@ -74,8 +51,4 @@ the original priority.
 
 <!-- item-sep -->
 
-- **Header "Data:" label lags the active dataset (P3, verify first)** —
-  reported drift between the dashboard row-checkbox "selected" notion and the
-  header's "active dataset" label. Lower confidence this still reproduces and it
-  overlaps the nav-picker-lag item in `ui-ux-papercuts.md`; confirm in a live
-  browser before scoping, and fold into that item if it's the same root cause.
+- [ ] #2360 — Header "Data:" label lags the active dataset


### PR DESCRIPTION
## What & why

Two related process fixes: (1) codify how GitHub Issues and `docs/plans/` divide labor so they can't desync, and (2) move the `dev`→`main` promotion procedure out of copy-pasted Claude settings and into the repo.

### 1. Issues vs `docs/plans/`: one item, one home

Some issues were auto-promoted from plan audits (#2355, #2357, #2358, #2360) but their full bodies were *left behind in the plan file too* — live duplication that drifts the moment either side changes, and the reason a hand-closed issue never "trickled back" to the plan.

**The fix — one invariant:** *no task's body lives in two places.* A plan may reference an issue via a one-line checkbox pointer (`- [ ] #N — title`) but never duplicate its body. Nothing to sync because nothing is stored twice; dismissing an issue (close `not_planned`) is just deleting the pointer.

- **`CLAUDE.md`** — new "Issues vs `docs/plans/`: one item, one home" section: division of labor (Issues own concrete shippable tasks; plans own design narrative), the pointer convention, the promote-then-delete-body flow, and the dismissal path.
- **`docs/plans/standard-workflow-polish.md`** — dedupe the four already-promoted items into checkbox pointers; the two un-promoted papercuts keep their full bodies. Swept a stale empty `item-sep` run.

### 2. `docs/RELEASE.md` — committed dev→main runbook

The Dev2Main promotion procedure lived only as a prompt pasted into Claude settings — un-versioned, un-reviewable, and drifting (the old copy had broken step numbering). It's now a committed runbook the Routine follows by reference.

- **`docs/RELEASE.md`** — full procedure: vulture audit → cleanup → release summary → punch-card refresh → release PR (`base: main`, the one sanctioned exception to the no-PR-to-main rule) → issue close-out → **plan-pointer prune**. The final step implements the automatic issue→plan trickle-back that policy (1) relies on: for every issue closed in the release, grep `docs/plans/` for its number and delete the stale pointer.
- **`CLAUDE.md`** — referenced from the "More docs" list.

The Routine prompt itself shrinks to a thin pointer at `docs/RELEASE.md` (provided to the maintainer separately, not in this diff).

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoEji3czQmCPj29nxfNMRV