### PR TITLE
Fill in missing demo media counts (+ fix 3 bugs found while measuring)

### DIFF
--- a/docs/user/screenshots-reshoot-queue.md
+++ b/docs/user/screenshots-reshoot-queue.md
@@ -44,3 +44,4 @@ alone.
 | Shot id | Embedded in | Why it's stale | Flagged |
 |---------|-------------|----------------|---------|
 | `achievements` | USER_GUIDE.md#achievements | Intro paragraph copy simplified (cefadd7c, 2026-07-12): the old "settings source configured / round-trip between sessions" line now reads "Your progress is saved with your settings, so it carries over between sessions". Landed after the 2026-07-12 full reshoot, so this copy line is the only difference. | 2026-07-12 |
+| `importer-picker` | USER_GUIDE.md (demo importer) | The demo-dataset catalogue's "# Media" column (`demo.num_files`) now shows measured exact counts instead of the old per-category-average estimate for caltech256, places365, ucsf_documents, gtzan, urbansound8k, speech_commands_v2, ucf101_full, kth, hmdb51, and wikipedia_topics (issue #2355). The visible rows for the shown media type advertise different numbers than the captured PNG. | 2026-07-14 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,11 +152,10 @@ max-complexity = 10
 # safe_pickle_load is the centralized helper that calls pickle.load on
 # whitelisted bytes; flagging it would defeat the purpose of the wrapper.
 "vtscore/security/pickle.py" = ["S301"]
-# Intentional `git` / `unrar` / `ffmpeg` invocations: arguments are
+# Intentional `git` / `ffmpeg` invocations: arguments are
 # project-controlled paths, no shell expansion.
 "vtsearch/__init__.py" = ["S603", "S607"]
 "vtscore/converters/video2audio.py" = ["S603"]
-"vtscore/datasets/downloader/video.py" = ["S603", "S607"]
 "vtsearch/routes/media/list.py" = ["S603"]
 # Atom feed parsing for the arXiv text-dataset downloader.
 "vtscore/datasets/downloader/text.py" = ["S314"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,9 @@ DEP001 = [
     "safetensors",
     "huggingface_hub",
     "cuml",
+    # SuperPoint/LightGlue structural backend: lazily imported inside method
+    # bodies (guarded, GPU-oriented); users opt in by installing lightglue.
+    "lightglue",
     # Installed `--no-deps` by the install scripts (its transformers<5 pin is
     # empirically unnecessary; see docs/plans/vtsbrowse-toponymy.md), so it
     # cannot be declared here — declaring it would put its pins back in the

--- a/tests_lib/datasets/test_demo_counts.py
+++ b/tests_lib/datasets/test_demo_counts.py
@@ -50,3 +50,21 @@ class TestDemoMediaCounts:
         ll = DEMO_MEDIA_COUNTS["caltech101_l"]
         a = DEMO_MEDIA_COUNTS["caltech101_a"]
         assert s + m + ll == a
+
+    def test_all_smla_partitions_sum_to_full(self):
+        # Every source whose recorded counts include all four S/M/L/A variants
+        # slices its categories with the partitioning fractions [0,1/7],
+        # [1/7,3/7], [3/7,1], so S + M + L must equal A. This locks in the
+        # measured counts for every uneven-category source at once.
+        bases = sorted(k[:-2] for k in DEMO_MEDIA_COUNTS if k.endswith("_a"))
+        checked = []
+        for base in bases:
+            if all(f"{base}_{v}" in DEMO_MEDIA_COUNTS for v in ("s", "m", "l")):
+                s = DEMO_MEDIA_COUNTS[f"{base}_s"]
+                m = DEMO_MEDIA_COUNTS[f"{base}_m"]
+                ll = DEMO_MEDIA_COUNTS[f"{base}_l"]
+                a = DEMO_MEDIA_COUNTS[f"{base}_a"]
+                assert s + m + ll == a, f"{base}: {s}+{m}+{ll} != {a}"
+                checked.append(base)
+        # Guard against the check silently becoming a no-op.
+        assert {"caltech256", "places365", "kth", "urbansound8k"} <= set(checked)

--- a/tests_lib/detectors/test_structural_geometry.py
+++ b/tests_lib/detectors/test_structural_geometry.py
@@ -21,6 +21,7 @@ def test_fit_scale_translation_recovers_model(st_correspondences):
     src, dst, s_true = st_correspondences
     model, mask = fit_scale_translation(src, dst)
     assert model is not None
+    assert mask is not None
     assert abs(model[0, 0] - s_true) < 1e-3
     assert model[0, 1] == 0.0 and model[1, 0] == 0.0  # no rotation terms
     assert mask.sum() >= 42  # the uncorrupted correspondences

--- a/tests_lib/downloads/test_gtzan_download.py
+++ b/tests_lib/downloads/test_gtzan_download.py
@@ -243,6 +243,25 @@ class TestLoadAudioMetadataFromFolders:
         metadata = load_audio_metadata_from_folders(tmp_path, ["blues"])
         assert len(metadata) == 1
 
+    def test_skips_appledouble_dotfiles(self, tmp_path):
+        """macOS AppleDouble sidecars ('._track.wav') are not counted.
+
+        The GTZAN tarball ships one such resource fork per real track; the
+        '*.wav' glob matches them by extension, so without a dotfile guard
+        the count would double and 1000 undecodable junk clips would load.
+        """
+        from vtscore.datasets.loader import load_audio_metadata_from_folders
+
+        d = tmp_path / "blues"
+        d.mkdir()
+        (d / "blues.00001.wav").write_bytes(b"RIFF")
+        (d / "._blues.00001.wav").write_bytes(b"\x00\x05\x16\x07")  # AppleDouble
+        (d / ".DS_Store").write_bytes(b"junk")
+
+        metadata = load_audio_metadata_from_folders(tmp_path, ["blues"])
+        assert len(metadata) == 1
+        assert list(metadata) == ["blues/blues.00001.wav"]
+
 
 # ---------------------------------------------------------------------------
 # load_urbansound8k_metadata

--- a/tests_lib/downloads/test_ucsf_documents_download.py
+++ b/tests_lib/downloads/test_ucsf_documents_download.py
@@ -75,6 +75,40 @@ class TestDownloadUcsfDocuments:
         assert (result / "Tobacco").is_dir()
         assert len(list((result / "Tobacco").glob("*.pdf"))) == 2
 
+    def test_caps_docs_per_category_when_solr_overreturns(self, tmp_path):
+        """Only docs_per_category PDFs download even if Solr returns more.
+
+        The live UCSF IDL Solr endpoint ignores the ``rows`` limit and returns
+        up to 1000 ids per query, so the downloader must cap client-side or it
+        would pull ~1000 PDFs per category instead of docs_per_category.
+        """
+        from vtscore.datasets import downloader as dl_module
+
+        # Solr hands back 10 ids despite a rows=3 request.
+        solr_resp = _fake_solr_response([f"abcd{i:04d}" for i in range(10)])
+        mock_response = MagicMock()
+        mock_response.json.return_value = solr_resp
+        mock_response.raise_for_status = MagicMock()
+
+        downloads = []
+
+        def fake_download(url, dest, size, cb):
+            dest.write_bytes(b"%PDF-1.0 stub")
+            downloads.append(dest.name)
+
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "download_file_with_progress", fake_download),
+            patch("requests.get", return_value=mock_response),
+        ):
+            result = dl_module.download_ucsf_documents(
+                categories=["Tobacco"],
+                docs_per_category=3,
+                on_progress=lambda *a: None,
+            )
+
+        assert len(list((result / "Tobacco").glob("*.pdf"))) == 3
+
     def test_constructs_correct_download_url(self, tmp_path):
         """PDF download URLs follow the UCSF split-character scheme."""
         from vtscore.datasets import downloader as dl_module

--- a/tests_lib/downloads/test_video_datasets_download.py
+++ b/tests_lib/downloads/test_video_datasets_download.py
@@ -14,7 +14,15 @@ import numpy as np
 
 
 class TestDownloadHmdb51:
-    """Verify download_hmdb51 downloads, extracts nested RARs, and organises."""
+    """Verify download_hmdb51 downloads the zip, extracts, and organises."""
+
+    def _make_hmdb51_zip(self, zip_path: Path) -> None:
+        """Create a minimal hmdb51.zip with the canonical hmdb51/<cat>/ tree."""
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for cat in ("brush_hair", "cartwheel", "catch"):
+                for i in range(3):
+                    fname = f"hmdb51/{cat}/{cat}_video_{i}.avi"
+                    zf.writestr(fname, b"RIFF" + b"\x00" * 20 + b"AVI ")
 
     def test_extracts_into_category_dirs(self, tmp_path):
         """download_hmdb51 should create per-category dirs with .avi files."""
@@ -23,33 +31,16 @@ class TestDownloadHmdb51:
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         video_dir = data_dir / "video"
-
-        # Simulate what _extract_rar does: create category dirs with .avi files.
-        call_log = []
-
-        def fake_extract_rar(rar_path, extract_to):
-            call_log.append(rar_path.name)
-            if "hmdb51_org" in rar_path.name:
-                # Outer RAR: create inner .rar stubs
-                extract_to.mkdir(parents=True, exist_ok=True)
-                for cat in ("brush_hair", "cartwheel", "catch"):
-                    (extract_to / f"{cat}.rar").write_bytes(b"Rar!")
-            else:
-                # Inner RAR: create .avi files in the target dir
-                extract_to.mkdir(parents=True, exist_ok=True)
-                cat = rar_path.stem
-                for i in range(3):
-                    (extract_to / f"{cat}_video_{i}.avi").write_bytes(b"RIFF" + b"\x00" * 20 + b"AVI ")
+        zip_path = tmp_path / "hmdb51.zip"
+        self._make_hmdb51_zip(zip_path)
 
         with (
             patch.object(vid_module._core, "DATA_DIR", data_dir),
             patch.object(vid_module._core, "VIDEO_DIR", video_dir),
-            patch.object(
-                vid_module._core,
-                "download_file_with_progress",
-                lambda url, dest, size, cb: dest.write_bytes(b"Rar!"),
+            patch(
+                "vtscore.datasets.downloader.core.download_file_with_progress",
+                lambda url, dest, size, cb: shutil.copy(str(zip_path), str(dest)),
             ),
-            patch.object(vid_module, "_extract_rar", fake_extract_rar),
         ):
             result = vid_module.download_hmdb51(on_progress=lambda *a: None)
 
@@ -59,6 +50,30 @@ class TestDownloadHmdb51:
         assert (result / "cartwheel").is_dir()
         assert (result / "catch").is_dir()
         assert len(list((result / "brush_hair").glob("*.avi"))) == 3
+
+    def test_staging_dir_cleaned_up(self, tmp_path):
+        """The DATA_DIR/hmdb51 staging directory is removed after moving."""
+        from vtscore.datasets.downloader import video as vid_module
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        video_dir = data_dir / "video"
+        zip_path = tmp_path / "hmdb51.zip"
+        self._make_hmdb51_zip(zip_path)
+
+        with (
+            patch.object(vid_module._core, "DATA_DIR", data_dir),
+            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
+            patch(
+                "vtscore.datasets.downloader.core.download_file_with_progress",
+                lambda url, dest, size, cb: shutil.copy(str(zip_path), str(dest)),
+            ),
+        ):
+            vid_module.download_hmdb51(on_progress=lambda *a: None)
+
+        assert not (data_dir / "hmdb51").exists(), "Staging directory should be removed after moving"
+        leftover_dl = [p for p in data_dir.iterdir() if p.name.startswith(".dl_")]
+        assert not leftover_dl, f"Temp archive files should be cleaned up: {leftover_dl}"
 
     def test_skips_if_already_present(self, tmp_path):
         """If hmdb51/ already has videos, skip download entirely."""
@@ -75,9 +90,8 @@ class TestDownloadHmdb51:
         with (
             patch.object(vid_module._core, "DATA_DIR", data_dir),
             patch.object(vid_module._core, "VIDEO_DIR", video_dir),
-            patch.object(
-                vid_module._core,
-                "download_file_with_progress",
+            patch(
+                "vtscore.datasets.downloader.core.download_file_with_progress",
                 lambda *a, **kw: download_called.append(True),
             ),
         ):
@@ -85,64 +99,6 @@ class TestDownloadHmdb51:
 
         assert not download_called, "download should be skipped when cache exists"
         assert result.exists()
-
-    def test_temp_files_cleaned_up(self, tmp_path):
-        """Temp archive and staging dir should be removed after extraction."""
-        from vtscore.datasets.downloader import video as vid_module
-
-        data_dir = tmp_path / "data"
-        data_dir.mkdir()
-        video_dir = data_dir / "video"
-
-        def fake_extract_rar(rar_path, extract_to):
-            extract_to.mkdir(parents=True, exist_ok=True)
-            if rar_path.name.startswith(".dl_"):
-                # Treat as outer
-                for cat in ("run",):
-                    (extract_to / f"{cat}.rar").write_bytes(b"Rar!")
-            elif rar_path.suffix == ".rar" and not rar_path.name.startswith(".dl_"):
-                # Treat as outer if in staging, inner otherwise
-                if "hmdb51_org" in rar_path.name:
-                    for cat in ("run",):
-                        (extract_to / f"{cat}.rar").write_bytes(b"Rar!")
-                else:
-                    cat = rar_path.stem
-                    (extract_to / f"{cat}_v1.avi").write_bytes(b"RIFF" + b"\x00" * 20 + b"AVI ")
-
-        with (
-            patch.object(vid_module._core, "DATA_DIR", data_dir),
-            patch.object(vid_module._core, "VIDEO_DIR", video_dir),
-            patch.object(
-                vid_module._core,
-                "download_file_with_progress",
-                lambda url, dest, size, cb: dest.write_bytes(b"Rar!"),
-            ),
-            patch.object(vid_module, "_extract_rar", fake_extract_rar),
-        ):
-            vid_module.download_hmdb51(on_progress=lambda *a: None)
-
-        # No temp download files should remain in data_dir.
-        leftover_dl = [p for p in data_dir.iterdir() if p.name.startswith(".dl_")]
-        assert not leftover_dl, f"Temp archive files should be cleaned up: {leftover_dl}"
-        leftover_ex = [p for p in data_dir.iterdir() if p.name.startswith(".extract_")]
-        assert not leftover_ex, f"Temp staging dirs should be cleaned up: {leftover_ex}"
-
-
-class TestExtractRar:
-    """Unit tests for the _extract_rar helper."""
-
-    def test_raises_when_unrar_missing(self, tmp_path):
-        """_extract_rar raises RuntimeError with install instructions when unrar is absent."""
-        import pytest
-
-        from vtscore.datasets.downloader.video import _extract_rar
-
-        rar_file = tmp_path / "test.rar"
-        rar_file.write_bytes(b"Rar!")
-
-        with patch("subprocess.run", side_effect=FileNotFoundError("unrar")):
-            with pytest.raises(RuntimeError, match="unrar"):
-                _extract_rar(rar_file, tmp_path / "out")
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/downloads/test_video_datasets_download.py
+++ b/tests_lib/downloads/test_video_datasets_download.py
@@ -633,3 +633,39 @@ class TestLoadDemoSourceKth:
                 clips={},
                 on_progress=lambda *a: None,
             )
+
+
+class TestLoadVideoMetadataFromFolders:
+    """load_video_metadata_from_folders scanning behavior."""
+
+    def test_scans_category_subdirectories(self, tmp_path):
+        """Finds video files in matching category subdirectories."""
+        from vtscore.datasets.loader import load_video_metadata_from_folders
+
+        for cat in ("walking", "boxing"):
+            d = tmp_path / cat
+            d.mkdir()
+            (d / f"{cat}_01.avi").write_bytes(b"RIFF")
+
+        # Unrelated folder should be ignored.
+        other = tmp_path / "jogging"
+        other.mkdir()
+        (other / "jogging_01.avi").write_bytes(b"RIFF")
+
+        metadata = load_video_metadata_from_folders(tmp_path, ["walking", "boxing"])
+        assert len(metadata) == 2
+        assert {m["category"] for m in metadata.values()} == {"walking", "boxing"}
+
+    def test_skips_appledouble_dotfiles(self, tmp_path):
+        """macOS AppleDouble sidecars ('._clip.avi') are not counted."""
+        from vtscore.datasets.loader import load_video_metadata_from_folders
+
+        d = tmp_path / "walking"
+        d.mkdir()
+        (d / "walking_01.avi").write_bytes(b"RIFF")
+        (d / "._walking_01.avi").write_bytes(b"\x00\x05\x16\x07")  # AppleDouble
+        (d / ".DS_Store").write_bytes(b"junk")
+
+        metadata = load_video_metadata_from_folders(tmp_path, ["walking"])
+        assert len(metadata) == 1
+        assert list(metadata) == ["walking/walking_01.avi"]

--- a/vtscore/datasets/demo_counts.py
+++ b/vtscore/datasets/demo_counts.py
@@ -50,6 +50,7 @@ a consistency check.
 * ``speech_commands_v2_*`` (audio) — 15104 / 30238 / 60487 / 105829
 * ``ucf101_*`` (video) — 55 / 114 / 236 / 405 (one media per video file)
 * ``ucf101_full_*`` (video) — 1857 / 3808 / 7655 / 13320
+* ``hmdb51_*`` (video) — 943 / 1929 / 3882 / 6754 (HuggingFace zip mirror)
 * ``kth_*`` (video) — 84 / 168 / 347 / 599
 
 Datasets whose categories are uniform (e.g. ESC-50 at 40 clips/category,
@@ -85,6 +86,10 @@ DEMO_MEDIA_COUNTS: dict[str, int] = {
     "eurosat_m": 7713,
     "eurosat_s": 3853,
     "gtzan_a": 1000,
+    "hmdb51_a": 6754,
+    "hmdb51_l": 3882,
+    "hmdb51_m": 1929,
+    "hmdb51_s": 943,
     "kth_a": 599,
     "kth_l": 347,
     "kth_m": 168,

--- a/vtscore/datasets/demo_counts.py
+++ b/vtscore/datasets/demo_counts.py
@@ -35,13 +35,22 @@ source's S/M/L slices partition its categories, so ``S + M + L == A`` holds as
 a consistency check.
 
 * ``caltech101_*`` (image) — 412 / 838 / 1704 / 2954
+* ``caltech256_*`` (image) — 534 / 1087 / 2179 / 3800
 * ``eurosat_*`` (image) — 3853 / 7713 / 15434 / 27000
 * ``oxford_flowers_102_a`` (image) — 8189
+* ``places365_*`` (image) — 5110 / 10220 / 21170 / 36500
+* ``ucsf_documents_a`` (image) — 150 (6 categories × 25 PDFs each)
 * ``reuters21578_*`` (text) — 1361 / 2731 / 5463 / 9555
 * ``20newsgroups_*`` (text) — 1194 / 2389 / 4775 / 8358
 * ``arxiv_abstracts_*`` (text) — 28 / 57 / 115 / 200
 * ``bbc_news_a`` (text) — 2225
+* ``wikipedia_topics_*`` (dbpedia text) — 89992 / 179998 / 360010 / 630000
+* ``gtzan_a`` (audio) — 1000 (one media per track; AppleDouble sidecars skipped)
+* ``urbansound8k_*`` (audio) — 1240 / 2497 / 4995 / 8732
+* ``speech_commands_v2_*`` (audio) — 15104 / 30238 / 60487 / 105829
 * ``ucf101_*`` (video) — 55 / 114 / 236 / 405 (one media per video file)
+* ``ucf101_full_*`` (video) — 1857 / 3808 / 7655 / 13320
+* ``kth_*`` (video) — 84 / 168 / 347 / 599
 
 Datasets whose categories are uniform (e.g. ESC-50 at 40 clips/category,
 Food-101 at 1000/category, AG News / IMDB which are class-balanced) are already
@@ -67,21 +76,51 @@ DEMO_MEDIA_COUNTS: dict[str, int] = {
     "caltech101_l": 1704,
     "caltech101_m": 838,
     "caltech101_s": 412,
+    "caltech256_a": 3800,
+    "caltech256_l": 2179,
+    "caltech256_m": 1087,
+    "caltech256_s": 534,
     "eurosat_a": 27000,
     "eurosat_l": 15434,
     "eurosat_m": 7713,
     "eurosat_s": 3853,
+    "gtzan_a": 1000,
+    "kth_a": 599,
+    "kth_l": 347,
+    "kth_m": 168,
+    "kth_s": 84,
     "oxford_flowers_102_a": 8189,
+    "places365_a": 36500,
+    "places365_l": 21170,
+    "places365_m": 10220,
+    "places365_s": 5110,
     "reuters21578_a": 9555,
     "reuters21578_l": 5463,
     "reuters21578_m": 2731,
     "reuters21578_s": 1361,
     "roxford5k_a": 5063,
     "roxford5k_s": 501,
+    "speech_commands_v2_a": 105829,
+    "speech_commands_v2_l": 60487,
+    "speech_commands_v2_m": 30238,
+    "speech_commands_v2_s": 15104,
     "ucf101_a": 405,
+    "ucf101_full_a": 13320,
+    "ucf101_full_l": 7655,
+    "ucf101_full_m": 3808,
+    "ucf101_full_s": 1857,
     "ucf101_l": 236,
     "ucf101_m": 114,
     "ucf101_s": 55,
+    "ucsf_documents_a": 150,
+    "urbansound8k_a": 8732,
+    "urbansound8k_l": 4995,
+    "urbansound8k_m": 2497,
+    "urbansound8k_s": 1240,
+    "wikipedia_topics_a": 630000,
+    "wikipedia_topics_l": 360010,
+    "wikipedia_topics_m": 179998,
+    "wikipedia_topics_s": 89992,
 }
 
 

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -184,7 +184,11 @@ VISUAL_GENOME_IMAGES2_URL = "https://cs.stanford.edu/people/rak248/VG_100K_2/ima
 VISUAL_GENOME_OBJECTS_URL = "https://homes.cs.washington.edu/~ranjay/visualgenome/data/dataset/objects.json.zip"
 
 # HMDB51
-HMDB51_URL = "http://serre-lab.clps.brown.edu/wp-content/uploads/2013/10/hmdb51_org.rar"
+# The original Serre-Lab RAR (hmdb51_org.rar) is dead — its host now redirects
+# to a homepage that serves HTML — and the lab's current page offers the data
+# only via Google Drive links that 404.  Use a public HuggingFace zip mirror
+# that carries the same ``hmdb51/<category>/*.avi`` tree (no unrar needed).
+HMDB51_URL = "https://huggingface.co/datasets/jili5044/hmdb51/resolve/main/hmdb51.zip"
 
 # UCF101 full (ZIP mirror on HuggingFace - no auth required)
 UCF101_FULL_URL = "https://huggingface.co/datasets/quchenyuan/UCF101-ZIP/resolve/main/UCF-101.zip"

--- a/vtscore/datasets/downloader/documents.py
+++ b/vtscore/datasets/downloader/documents.py
@@ -89,6 +89,11 @@ def download_ucsf_documents(  # noqa: C901
         except Exception:
             docs = []
 
+        # The UCSF IDL Solr endpoint ignores the ``rows`` limit and returns up
+        # to 1000 ids per query, so cap client-side; otherwise every category
+        # would download ~1000 PDFs instead of ``docs_per_category``.
+        docs = docs[:docs_per_category]
+
         # Download each PDF using the UCSF split-character URL scheme.
         for doc in docs:
             doc_id = doc.get("id", "")

--- a/vtscore/datasets/downloader/video.py
+++ b/vtscore/datasets/downloader/video.py
@@ -1,40 +1,11 @@
 """Video dataset downloaders: UCF-101 subset, UCF-101 full, HMDB51, KTH Actions."""
 
 import shutil
-import subprocess
 from pathlib import Path
 from typing import Optional
 
 from vtscore.datasets.downloader import core as _core
 from vtscore.datasets.downloader.core import ProgressCallback
-
-
-def _extract_rar(rar_path: Path, extract_to: Path) -> None:
-    """Extract a RAR archive using the system ``unrar`` command.
-
-    Raises ``RuntimeError`` with installation instructions when ``unrar``
-    is not found on the system PATH, or if extraction hangs / fails.
-    """
-    extract_to.mkdir(parents=True, exist_ok=True)
-    try:
-        subprocess.run(
-            ["unrar", "x", "-o+", "-y", str(rar_path), str(extract_to) + "/"],
-            check=True,
-            capture_output=True,
-            # Cap at 30 minutes. A malformed RAR could otherwise hang the
-            # loader thread indefinitely.
-            timeout=1800,
-        )
-    except FileNotFoundError:
-        raise RuntimeError(
-            "The 'unrar' command is required to extract HMDB51 but was not found. "
-            "Install it with: apt-get install unrar (Debian/Ubuntu) or "
-            "brew install unrar (macOS)."
-        ) from None
-    except subprocess.TimeoutExpired as e:
-        raise RuntimeError(
-            f"unrar timed out after {e.timeout}s while extracting {rar_path.name}. The archive may be corrupt."
-        ) from None
 
 
 def download_ucf101_subset(on_progress: Optional[ProgressCallback] = None) -> Path:
@@ -109,12 +80,14 @@ def download_ucf101_subset(on_progress: Optional[ProgressCallback] = None) -> Pa
 def download_hmdb51(on_progress: Optional[ProgressCallback] = None) -> Path:
     """Download and extract the HMDB51 dataset.
 
-    Downloads the ~2 GB ``hmdb51_org.rar`` archive from the Serre Lab,
-    extracts the outer RAR (which contains 51 per-category ``.rar`` files),
-    then extracts each inner RAR into its own category subdirectory under
-    ``VIDEO_DIR / "hmdb51"``.
+    Downloads the ~2 GB ``hmdb51.zip`` from a public HuggingFace mirror and
+    extracts it into ``VIDEO_DIR / "hmdb51"`` with one subdirectory per action
+    class of ``.avi`` files.  The archive already carries the canonical
+    ``hmdb51/<category>/*.avi`` tree, so extraction needs no ``unrar`` step.
 
-    Requires the ``unrar`` command to be installed on the system.
+    (The original Serre-Lab ``hmdb51_org.rar`` URL is dead, and the lab's page
+    now offers only Google Drive links that 404, so the loader relies on the
+    HuggingFace mirror — see ``HMDB51_URL``.)
 
     Args:
         on_progress: Optional progress callback.
@@ -133,43 +106,22 @@ def download_hmdb51(on_progress: Optional[ProgressCallback] = None) -> Path:
     if video_dir.exists() and any(video_dir.glob("*/*.avi")):
         return video_dir
 
-    import uuid
+    # The zip's single top-level folder is ``hmdb51/``; extract it under
+    # DATA_DIR then move its category subdirectories into VIDEO_DIR/hmdb51.
+    extract_dir = _core.DATA_DIR / "hmdb51"
+    _core._download_and_extract(
+        url=_core.HMDB51_URL,
+        archive_name="hmdb51.zip",
+        extract_to=_core.DATA_DIR,
+        check_path=extract_dir,
+        download_size_mb=_core.HMDB51_DOWNLOAD_SIZE_MB,
+        dataset_name="HMDB51",
+        on_progress=on_progress,
+    )
 
-    unique_id = uuid.uuid4().hex[:8]
-    archive_path = _core.DATA_DIR / f".dl_{unique_id}_hmdb51_org.rar"
-    staging_dir = _core.DATA_DIR / f".extract_{unique_id}_hmdb51"
-    _core.DATA_DIR.mkdir(exist_ok=True, parents=True)
-
-    try:
-        on_progress("downloading", "Starting HMDB51 download...", 0, 0)
-        _core.download_file_with_progress(
-            _core.HMDB51_URL,
-            archive_path,
-            _core.HMDB51_DOWNLOAD_SIZE_MB * 1024 * 1024,
-            on_progress,
-        )
-
-        if video_dir.exists() and any(video_dir.glob("*/*.avi")):
-            return video_dir
-
-        # Extract outer RAR → 51 per-category .rar files.
-        on_progress("downloading", "Extracting HMDB51 (outer archive)...", 0, 0)
-        _extract_rar(archive_path, staging_dir)
-
-        # Extract each inner .rar into a category subdirectory.
-        inner_rars = sorted(staging_dir.glob("*.rar"))
-        total_rars = len(inner_rars)
-        video_dir.mkdir(parents=True, exist_ok=True)
-
-        for i, rar_file in enumerate(inner_rars):
-            cat_name = rar_file.stem  # e.g. "brush_hair"
-            on_progress("downloading", f"Extracting HMDB51 ({cat_name})...", i + 1, total_rars)
-            cat_dir = video_dir / cat_name
-            _extract_rar(rar_file, cat_dir)
-    finally:
-        archive_path.unlink(missing_ok=True)
-        if staging_dir.exists():
-            shutil.rmtree(staging_dir, ignore_errors=True)
+    video_dir.mkdir(parents=True, exist_ok=True)
+    _core._move_tree_contents(extract_dir, video_dir)
+    shutil.rmtree(extract_dir, ignore_errors=True)
 
     return video_dir
 

--- a/vtscore/datasets/metadata.py
+++ b/vtscore/datasets/metadata.py
@@ -83,6 +83,13 @@ def load_audio_metadata_from_folders(audio_dir: Path, categories: list[str]) -> 
 
         for ext in ["*.wav", "*.mp3", "*.flac", "*.ogg", "*.m4a", "*.au"]:
             for audio_path in category_folder.glob(ext):
+                # Skip macOS AppleDouble sidecars ("._name.wav") and other
+                # dotfiles: the ``*.wav`` glob matches them by extension, but
+                # they are metadata resource forks, not real audio (the GTZAN
+                # tarball ships one per track, which would otherwise double the
+                # count and load 1000 undecodable junk clips).
+                if audio_path.name.startswith("."):
+                    continue
                 metadata[f"{category_name}/{audio_path.name}"] = {
                     "category": category_name,
                     "path": audio_path,
@@ -297,6 +304,12 @@ def load_video_metadata_from_folders(video_dir: Path, categories: list[str]) -> 
         # Use category/filename as key to avoid collisions across categories.
         for ext in ["*.mp4", "*.avi", "*.mov", "*.webm", "*.mkv"]:
             for video_path in category_folder.glob(ext):
+                # Skip macOS AppleDouble sidecars ("._name.avi") and other
+                # dotfiles that the extension glob would otherwise match as if
+                # they were real video (see the audio loader for the GTZAN case
+                # this guards against).
+                if video_path.name.startswith("."):
+                    continue
                 metadata[f"{category_name}/{video_path.name}"] = {
                     "category": category_name,
                     "path": video_path,

--- a/vtscore/media/structural_geometry.py
+++ b/vtscore/media/structural_geometry.py
@@ -157,11 +157,7 @@ def fit_model(
         reflection = s < 0
 
     inlier_count = int(mask.sum())
-    model_ok = (
-        inlier_count >= _MIN_MODEL_INLIERS
-        and _MIN_SANE_SCALE <= scale <= _MAX_SANE_SCALE
-        and not reflection
-    )
+    model_ok = inlier_count >= _MIN_MODEL_INLIERS and _MIN_SANE_SCALE <= scale <= _MAX_SANE_SCALE and not reflection
 
     mean_err = median_err = spread = 0.0
     inlier_box = None

--- a/vtscore/media/structural_splg.py
+++ b/vtscore/media/structural_splg.py
@@ -83,9 +83,7 @@ class SplgMatcher:
 
         if self._matcher is None:
             self._matcher = (
-                LightGlue(features="superpoint", filter_threshold=_LG_FILTER_THRESHOLD)
-                .eval()
-                .to(self.device)
+                LightGlue(features="superpoint", filter_threshold=_LG_FILTER_THRESHOLD).eval().to(self.device)
             )
         return self._matcher
 
@@ -129,9 +127,7 @@ class SplgMatcher:
         ).astype(np.float32)
         return StructuralFeatures(keypoints=kp_arr, descriptors=desc.astype(np.float32))
 
-    def match(
-        self, template: StructuralFeatures, candidate: StructuralFeatures
-    ) -> tuple[np.ndarray, np.ndarray, int]:
+    def match(self, template: StructuralFeatures, candidate: StructuralFeatures) -> tuple[np.ndarray, np.ndarray, int]:
         """LightGlue correspondences ``(src, dst, tentative_count)``.
 
         The tentative count (matches above LightGlue's confidence filter) is

--- a/vtscore/media/structural_splg.py
+++ b/vtscore/media/structural_splg.py
@@ -71,7 +71,7 @@ class SplgMatcher:
         return self._device
 
     def _get_extractor(self, max_features: int):
-        from lightglue import SuperPoint  # noqa: PLC0415
+        from lightglue import SuperPoint  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
         if self._extractor is None or self._extractor_cap != max_features:
             self._extractor = SuperPoint(max_num_keypoints=int(max_features)).eval().to(self.device)
@@ -79,7 +79,7 @@ class SplgMatcher:
         return self._extractor
 
     def _get_matcher(self):
-        from lightglue import LightGlue  # noqa: PLC0415
+        from lightglue import LightGlue  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
         if self._matcher is None:
             self._matcher = (


### PR DESCRIPTION
Closes #2355.

Fills in exact `DEMO_MEDIA_COUNTS` for the demo datasets that previously fell back to the inaccurate per-category-average estimate. Each count was measured against the **real** download via `scripts/compute_demo_counts.py` (or an equivalent decode-skipping helper for the huge audio/video sets), and every S/M/L/A source satisfies `S + M + L == A`:

| Dataset | S | M | L | A |
|---|---|---|---|---|
| `caltech256_*` (image) | 534 | 1087 | 2179 | 3800 |
| `places365_*` (image) | 5110 | 10220 | 21170 | 36500 |
| `ucsf_documents_a` (image) | — | — | — | 150 |
| `wikipedia_topics_*` (dbpedia text) | 89992 | 179998 | 360010 | 630000 |
| `gtzan_a` (audio) | — | — | — | 1000 |
| `urbansound8k_*` (audio) | 1240 | 2497 | 4995 | 8732 |
| `speech_commands_v2_*` (audio) | 15104 | 30238 | 60487 | 105829 |
| `kth_*` (video) | 84 | 168 | 347 | 599 |
| `ucf101_full_*` (video) | 1857 | 3808 | 7655 | 13320 |
| `hmdb51_*` (video) | 943 | 1929 | 3882 | 6754 |

## Bugs found while measuring

Measuring each dataset surfaced three real defects that would otherwise have made the "accurate" count either wrong or impossible to obtain:

- **GTZAN AppleDouble double-count.** The GTZAN tarball ships a macOS `._track.wav` resource-fork next to every real track, and the `*.wav` extension glob matched them — doubling `gtzan_a` to 2000 and loading 1000 undecodable junk clips. The audio/video folder scanners now skip dotfiles.
- **UCSF over-download.** The UCSF IDL Solr endpoint ignores the client's `rows` limit and returns up to 1000 ids per query, so `download_ucsf_documents` pulled ~1000 PDFs/category instead of the intended 25 (inflating `ucsf_documents_a` to ~6000 pages). Now capped client-side, so the real count is 6×25 = 150.
- **HMDB51 dead source.** The Serre-Lab `hmdb51_org.rar` URL is dead (its host redirects to a homepage serving HTML) and the lab's page now offers only Google-Drive links that 404, so the hmdb51 demo could no longer download at all. Migrated `download_hmdb51` to a public HuggingFace zip mirror carrying the same `hmdb51/<category>/*.avi` tree, via the shared `_download_and_extract` helper (which also validates against HTML error pages). This drops the `unrar` dependency for HMDB51, so `_extract_rar` and its stale ruff exemption were removed. Verified end-to-end against the live mirror.

## Also fixed (pre-existing suite blockers)

`./run-tests.sh` was already red on `dev` from the structural-backend merge (masked behind the first failing gate). Fixed so the suite runs green: ruff-format drift in `structural_geometry.py`/`structural_splg.py`, an undeclared `lightglue` optional import (added to deptry's DEP001 allowlist), and two pyright errors (guarded-import annotation + Optional narrowing in a test).

## Tests

- New regression tests: dotfile-skip in the audio + video folder scanners, the UCSF `docs_per_category` cap, the HMDB51 zip-mirror download/extract, and a general `S + M + L == A` partition check across every uneven-category source.
- Full `./run-tests.sh` green: **5756 passed, 1 skipped** (ruff / format / codespell / deptry / pip-audit / pyright / frontend build all pass).

## Follow-up

The demo catalogue's "# Media" column now advertises the new numbers, so the `importer-picker` doc screenshot is queued for reshoot in `docs/user/screenshots-reshoot-queue.md` (no browser in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAEFvfJxsAQNZDfHabA42q)_