### PR TITLE
Add frontend tests for the achievements feature

### DIFF
--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.spec.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.spec.ts
@@ -1,0 +1,295 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+
+import { AchievementsTabComponent } from './achievements-tab.component';
+import { AchievementsService } from '../../services/achievements.service';
+import { SettingsStateService } from '../../services/settings-state.service';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+import type { AchievementState } from '../../generated/api-client/models/achievement-state';
+import type { AchievementEntry } from '../../generated/api-client/models/achievement-entry';
+import type { CheckPhraseResponse } from '../../generated/api-client/models/check-phrase-response';
+import type { AppSettings } from '../../generated/api-client/models/app-settings';
+
+/**
+ * The achievements tab renders the service snapshot: a score header, one row
+ * per achievement (badge, tier label, progress bar), expandable detail panels
+ * for the docs/media-type/hours rows, and the Readme-Reader phrase form. These
+ * tests drive it through a fake AchievementsService and assert on the rendered
+ * DOM. Run under the zoneless TestBed (the app is zoneless), so a state update
+ * that forgets to nudge change detection would surface as stale markup.
+ */
+describe('AchievementsTabComponent', () => {
+  let fixture: ComponentFixture<AchievementsTabComponent>;
+  let state$: BehaviorSubject<AchievementState>;
+  let checkPhrase: ReturnType<typeof vi.fn>;
+  let refresh: ReturnType<typeof vi.fn>;
+  let enableSetting: ReturnType<typeof signal<AppSettings | null>>;
+
+  const EMPTY_STATE: AchievementState = {
+    tier_names: [],
+    achievements: [],
+    pending_announcements: [],
+    pending_toasts: [],
+    docs: [],
+    media_types: [],
+    hours: [],
+  };
+
+  function makeEntry(over: Partial<AchievementEntry> = {}): AchievementEntry {
+    return {
+      id: 'votes_cast',
+      name: 'Prolific Voter',
+      description: 'Cast votes to train detectors.',
+      icon: 'thumb',
+      counter: 5,
+      tier_idx: 0,
+      tiers: [3, 25, 100, 500],
+      next_threshold: 25,
+      ...over,
+    };
+  }
+
+  function el(selector: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(selector);
+  }
+
+  function els(selector: string): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll(selector));
+  }
+
+  /** Push a new snapshot through the service stream and let CD settle. */
+  async function pushState(state: Partial<AchievementState>): Promise<void> {
+    state$.next({ ...EMPTY_STATE, ...state });
+    await settleZoneless(fixture);
+  }
+
+  /** Create + first render. Kept out of beforeEach so `enableSetting` can be
+   * seeded per-test before the constructor effect runs. */
+  async function build(): Promise<void> {
+    fixture = TestBed.createComponent(AchievementsTabComponent);
+    await settleZoneless(fixture);
+  }
+
+  /** Open a row's detail panel by clicking its Expand toggle. */
+  async function expandRow(): Promise<void> {
+    el('.expand-toggle')!.click();
+    await settleZoneless(fixture);
+  }
+
+  /** Type into the phrase input (updating the ngModel) and submit the form. */
+  async function submitPhrase(value: string): Promise<void> {
+    const input = el('.docs-phrase-input') as HTMLInputElement;
+    input.value = value;
+    input.dispatchEvent(new Event('input'));
+    await settleZoneless(fixture);
+    el('.docs-phrase-form')!.dispatchEvent(new Event('submit'));
+    await settleZoneless(fixture);
+  }
+
+  beforeEach(() => {
+    state$ = new BehaviorSubject<AchievementState>(EMPTY_STATE);
+    refresh = vi.fn();
+    checkPhrase = vi.fn<(phrase: string) => Observable<CheckPhraseResponse>>();
+    enableSetting = signal<AppSettings | null>(null);
+
+    const fakeAchievements = {
+      state: state$.asObservable(),
+      refresh,
+      checkPhrase,
+      docRawUrl: (id: string) => `/api/achievements/docs/${id}/raw`,
+    };
+
+    configureZoneless({
+      imports: [AchievementsTabComponent],
+      providers: [
+        { provide: AchievementsService, useValue: fakeAchievements },
+        { provide: SettingsStateService, useValue: { settingsSignal: enableSetting } },
+      ],
+    });
+  });
+
+  it('shows the loading placeholder until the first non-empty state arrives', async () => {
+    await build();
+    expect(el('.empty-state')?.textContent).toContain('Loading achievements');
+    expect(el('.achievements-list')).toBeNull();
+  });
+
+  it('requests a refresh on init', async () => {
+    await build();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders one row per achievement with name, tier, and description', async () => {
+    await build();
+    await pushState({ achievements: [makeEntry()] });
+
+    expect(els('.achievement-row').length).toBe(1);
+    expect(el('.achievement-name')?.textContent).toContain('Prolific Voter');
+    expect(el('.achievement-tier')?.textContent?.trim()).toBe('Bronze');
+    expect(el('.achievement-desc')?.textContent).toContain('Cast votes');
+  });
+
+  it('computes the total score as a sum of tier bit-values', async () => {
+    await build();
+    await pushState({
+      achievements: [
+        makeEntry({ id: 'a', tier_idx: 0 }), // 1
+        makeEntry({ id: 'b', tier_idx: 2 }), // 4
+        makeEntry({ id: 'c', tier_idx: -1 }), // 0 (locked)
+      ],
+    });
+    expect(el('.achievements-total-value')?.textContent?.trim()).toBe('5');
+  });
+
+  it('formats the progress label toward the next tier', async () => {
+    await build();
+    await pushState({ achievements: [makeEntry({ counter: 5, tier_idx: 0, next_threshold: 25 })] });
+    const label = el('.achievement-progress-label')?.textContent ?? '';
+    expect(label).toContain('5 / 25');
+    expect(label).toContain('Silver');
+  });
+
+  it('labels a maxed-out achievement instead of showing a next tier', async () => {
+    await build();
+    await pushState({
+      achievements: [makeEntry({ counter: 500, tier_idx: 3, next_threshold: null })],
+    });
+    expect(el('.achievement-progress-label')?.textContent).toContain('maxed out');
+  });
+
+  it('marks a locked row and surfaces the unlock hint as a tooltip', async () => {
+    await build();
+    await pushState({ achievements: [makeEntry({ counter: 0, tier_idx: -1, next_threshold: 3 })] });
+    expect(el('.achievement-row--locked')).not.toBeNull();
+    expect(el('.achievement-tier')?.getAttribute('title')).toContain('Reach 3 to unlock Bronze');
+  });
+
+  it('expands the docs panel and lists the docs with read state', async () => {
+    await build();
+    await pushState({
+      achievements: [makeEntry({ id: 'docs_read', name: 'Readme Reader', tier_idx: -1 })],
+      docs: [
+        { id: 'readme', name: 'README', path: 'README.md', read: true },
+        { id: 'arch', name: 'Architecture', path: 'docs/ARCHITECTURE.md', read: false },
+      ],
+    });
+
+    // Collapsed by default: no docs panel yet.
+    expect(el('.docs-panel')).toBeNull();
+
+    await expandRow();
+
+    expect(el('.docs-panel')).not.toBeNull();
+    expect(els('.docs-list-item').length).toBe(2);
+    expect(el('.docs-list-item--read')).not.toBeNull();
+    const link = el('.docs-list-link') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/api/achievements/docs/readme/raw');
+  });
+
+  it('submits a phrase and reports a correct match', async () => {
+    checkPhrase.mockReturnValue(
+      of<CheckPhraseResponse>({
+        matched: true,
+        doc_id: 'readme',
+        doc_name: 'README',
+        already_read: false,
+      }),
+    );
+    await build();
+    await pushState({
+      achievements: [makeEntry({ id: 'docs_read', tier_idx: -1 })],
+      docs: [{ id: 'readme', name: 'README', path: 'README.md', read: false }],
+    });
+    await expandRow();
+    await submitPhrase('all systems nominal');
+
+    expect(checkPhrase).toHaveBeenCalledWith('all systems nominal');
+    const status = el('.docs-phrase-status');
+    expect(status?.getAttribute('data-kind')).toBe('success');
+    expect(status?.textContent).toContain('README');
+  });
+
+  it('reports an already-credited phrase', async () => {
+    checkPhrase.mockReturnValue(
+      of<CheckPhraseResponse>({
+        matched: true,
+        doc_id: 'readme',
+        doc_name: 'README',
+        already_read: true,
+      }),
+    );
+    await build();
+    await pushState({
+      achievements: [makeEntry({ id: 'docs_read', tier_idx: -1 })],
+      docs: [{ id: 'readme', name: 'README', path: 'README.md', read: true }],
+    });
+    await expandRow();
+    await submitPhrase('already known');
+
+    expect(el('.docs-phrase-status')?.getAttribute('data-kind')).toBe('already');
+  });
+
+  it('reports a wrong phrase', async () => {
+    checkPhrase.mockReturnValue(
+      of<CheckPhraseResponse>({
+        matched: false,
+        doc_id: null,
+        doc_name: null,
+        already_read: false,
+      }),
+    );
+    await build();
+    await pushState({
+      achievements: [makeEntry({ id: 'docs_read', tier_idx: -1 })],
+      docs: [{ id: 'readme', name: 'README', path: 'README.md', read: false }],
+    });
+    await expandRow();
+    await submitPhrase('nope');
+
+    expect(el('.docs-phrase-status')?.getAttribute('data-kind')).toBe('wrong');
+  });
+
+  it('renders the media-types detail panel when expanded', async () => {
+    await build();
+    await pushState({
+      achievements: [makeEntry({ id: 'media_types_touched', tier_idx: 0 })],
+      media_types: [
+        { id: 'audio', name: 'Audio', seen: true },
+        { id: 'image', name: 'Image', seen: false },
+      ],
+    });
+    await expandRow();
+
+    expect(els('.ticks-list-item').length).toBe(2);
+    expect(el('.ticks-list-item--on')).not.toBeNull();
+  });
+
+  it('renders the hours grid when expanded', async () => {
+    await build();
+    await pushState({
+      achievements: [makeEntry({ id: 'hours_voted', tier_idx: 0 })],
+      hours: [
+        { hour: 0, seen: true },
+        { hour: 13, seen: false },
+      ],
+    });
+    await expandRow();
+
+    const chips = els('.hour-chip');
+    expect(chips.length).toBe(2);
+    expect(chips[0].textContent?.trim()).toBe('00');
+    expect(chips[1].textContent?.trim()).toBe('13');
+    expect(el('.hour-chip--on')).not.toBeNull();
+  });
+
+  it('explains that counters are frozen when achievements are disabled', async () => {
+    enableSetting.set({ enable_achievements: false } as AppSettings);
+    await build();
+    await pushState({
+      achievements: [makeEntry({ id: 'votes_cast', counter: 0, tier_idx: -1, next_threshold: 3 })],
+    });
+    expect(el('.achievement-tier')?.getAttribute('title')).toContain('disabled in Settings');
+  });
+});

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, effect, inject, OnDestroy, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  effect,
+  inject,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -38,6 +46,7 @@ interface AchievementRow extends AchievementEntry {
 export class AchievementsTabComponent implements OnInit, OnDestroy {
   private achievements = inject(AchievementsService);
   private settingsState = inject(SettingsStateService);
+  private cdr = inject(ChangeDetectorRef);
 
   rows: AchievementRow[] = [];
   docs: DocEntry[] = [];
@@ -108,6 +117,7 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
     this.submitting = true;
     this.achievements.checkPhrase(phrase).subscribe((result) => {
       this.submitting = false;
+      this.cdr.markForCheck();
       if (result.matched && !result.already_read) {
         this.phraseStatus = {
           kind: 'success',
@@ -138,6 +148,10 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
       (sum, a) => sum + (a.tier_idx >= 0 ? 1 << a.tier_idx : 0),
       0,
     );
+    // OnPush + manual subscribe under a zoneless app: the state stream (and the
+    // async phrase-check refresh) mutate these fields outside any CD-scheduling
+    // signal, so nudge the view to re-render (mirrors context-pulldown).
+    this.cdr.markForCheck();
   }
 
   private toRow(a: AchievementEntry): AchievementRow {

--- a/frontend/src/app/services/achievements.service.spec.ts
+++ b/frontend/src/app/services/achievements.service.spec.ts
@@ -1,0 +1,268 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+
+import { AchievementsService } from './achievements.service';
+import { SettingsStateService } from './settings-state.service';
+import { configureZoneless } from '../testing/zoneless-testbed';
+import type { AchievementState } from '../generated/api-client/models/achievement-state';
+import type { PendingAnnouncement } from '../generated/api-client/models/pending-announcement';
+import type { AppSettings } from '../generated/api-client/models/app-settings';
+
+/**
+ * AchievementsService is the whole feature's data spine: it GETs
+ * /api/achievements, exposes the snapshot as an observable, queues one-time
+ * unlock toasts (deduped in-session, marked server-side), and drives
+ * acknowledge / phrase-check side effects. These tests pin all of that against
+ * a mocked HTTP backend, plus the settings-toggle kill switch that freezes the
+ * feature to an empty state.
+ */
+describe('AchievementsService', () => {
+  let service: AchievementsService;
+  let httpMock: HttpTestingController;
+  // Stand-in for SettingsStateService: the service reads only settingsSignal().
+  let enableSetting: ReturnType<typeof signal<AppSettings | null>>;
+
+  function makeAnnouncement(over: Partial<PendingAnnouncement> = {}): PendingAnnouncement {
+    return {
+      id: 'votes_cast',
+      name: 'Prolific Voter',
+      icon: 'thumb',
+      threshold: 10,
+      tier_idx: 0,
+      tier_name: 'Bronze',
+      ...over,
+    };
+  }
+
+  function makeState(over: Partial<AchievementState> = {}): AchievementState {
+    return {
+      tier_names: ['Bronze', 'Silver', 'Gold', 'Platinum'],
+      achievements: [],
+      pending_announcements: [],
+      pending_toasts: [],
+      docs: [],
+      media_types: [],
+      hours: [],
+      ...over,
+    };
+  }
+
+  /** Answer the GET /api/achievements that refresh() issues. */
+  function flushGet(state: AchievementState): void {
+    httpMock.expectOne('/api/achievements').flush(state);
+  }
+
+  beforeEach(() => {
+    enableSetting = signal<AppSettings | null>(null);
+    configureZoneless({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: SettingsStateService, useValue: { settingsSignal: enableSetting } },
+      ],
+    });
+    service = TestBed.inject(AchievementsService);
+    // Flush the disabled-tracking effect so `disabled` is initialized.
+    TestBed.tick();
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('starts with an empty snapshot before any refresh', () => {
+    expect(service.snapshot.achievements).toEqual([]);
+    expect(service.snapshot.pending_announcements).toEqual([]);
+  });
+
+  it('refresh() GETs the state and publishes it on state$', () => {
+    const seen: AchievementState[] = [];
+    service.state.subscribe((s) => seen.push(s));
+
+    service.refresh();
+    const state = makeState({ tier_names: ['Bronze'] });
+    flushGet(state);
+
+    expect(service.snapshot.tier_names).toEqual(['Bronze']);
+    // BehaviorSubject replays the initial EMPTY_STATE, then the fetched one.
+    expect(seen.at(-1)).toEqual(state);
+  });
+
+  it('coalesces concurrent refreshes into a single request', () => {
+    service.refresh();
+    service.refresh(); // second call is a no-op while the first is in flight
+    // Exactly one request outstanding; verify() in afterEach would flag a leak.
+    flushGet(makeState());
+    // A later refresh, after the first settled, issues a fresh request.
+    service.refresh();
+    flushGet(makeState());
+  });
+
+  it('falls back to the empty state when the fetch errors', () => {
+    service.refresh();
+    service.state.subscribe();
+    httpMock
+      .expectOne('/api/achievements')
+      .flush({ error: 'boom' }, { status: 500, statusText: 'Server Error' });
+    expect(service.snapshot.achievements).toEqual([]);
+  });
+
+  it('emits pending toasts once and marks each toasted', () => {
+    const toasts: PendingAnnouncement[] = [];
+    service.unlocks.subscribe((p) => toasts.push(p));
+
+    const toast = makeAnnouncement({ id: 'votes_cast', tier_idx: 1 });
+    service.refresh();
+    flushGet(makeState({ pending_toasts: [toast] }));
+
+    expect(toasts).toEqual([toast]);
+    // The service fires a mark-toasted POST for the emitted toast.
+    const mark = httpMock.expectOne('/api/achievements/votes_cast/mark-toasted');
+    expect(mark.request.method).toBe('POST');
+    expect(mark.request.body).toEqual({ tier_idx: 1 });
+    mark.flush({});
+  });
+
+  it('does not re-emit a toast already emitted this session', () => {
+    const toasts: PendingAnnouncement[] = [];
+    service.unlocks.subscribe((p) => toasts.push(p));
+    const toast = makeAnnouncement({ id: 'votes_cast', tier_idx: 0 });
+
+    service.refresh();
+    flushGet(makeState({ pending_toasts: [toast] }));
+    httpMock.expectOne('/api/achievements/votes_cast/mark-toasted').flush({});
+
+    // Server hasn't dropped it from pending_toasts yet, but the in-session
+    // guard must prevent a duplicate pop.
+    service.refresh();
+    flushGet(makeState({ pending_toasts: [toast] }));
+
+    expect(toasts).toEqual([toast]);
+    httpMock.expectNone('/api/achievements/votes_cast/mark-toasted');
+  });
+
+  it('hasPending$ tracks the pending-announcement count', () => {
+    const flags: boolean[] = [];
+    service.hasPending$.subscribe((v) => flags.push(v));
+
+    service.refresh();
+    flushGet(makeState({ pending_announcements: [makeAnnouncement()] }));
+
+    expect(flags.at(-1)).toBe(true);
+  });
+
+  it('acknowledge() POSTs then refreshes state', () => {
+    service.acknowledge('votes_cast', 2);
+    const ack = httpMock.expectOne('/api/achievements/votes_cast/acknowledge');
+    expect(ack.request.method).toBe('POST');
+    expect(ack.request.body).toEqual({ tier_idx: 2 });
+    ack.flush({});
+    // The success handler chains a refresh.
+    flushGet(makeState());
+  });
+
+  it('acknowledgeAll() acknowledges every pending announcement', () => {
+    service.refresh();
+    flushGet(
+      makeState({
+        pending_announcements: [
+          makeAnnouncement({ id: 'votes_cast', tier_idx: 0 }),
+          makeAnnouncement({ id: 'find_media', tier_idx: 1 }),
+        ],
+      }),
+    );
+
+    service.acknowledgeAll();
+    httpMock.expectOne('/api/achievements/votes_cast/acknowledge').flush({});
+    httpMock.expectOne('/api/achievements/find_media/acknowledge').flush({});
+    // Each acknowledge chains its own refresh; the first wins, the rest coalesce.
+    flushGet(makeState());
+  });
+
+  it('checkPhrase() POSTs the phrase and refreshes on a fresh correct match', () => {
+    let result: unknown;
+    service.checkPhrase('all systems nominal').subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne('/api/achievements/check-phrase');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ phrase: 'all systems nominal' });
+    req.flush({ matched: true, doc_id: 'readme', doc_name: 'README', already_read: false });
+
+    // A newly credited doc triggers a state refresh.
+    flushGet(makeState());
+    expect(result).toEqual({
+      matched: true,
+      doc_id: 'readme',
+      doc_name: 'README',
+      already_read: false,
+    });
+  });
+
+  it('checkPhrase() does not refresh when the doc was already read', () => {
+    service.checkPhrase('old phrase').subscribe();
+    httpMock
+      .expectOne('/api/achievements/check-phrase')
+      .flush({ matched: true, doc_id: 'readme', doc_name: 'README', already_read: true });
+    // No follow-up GET: already-credited phrases don't change counters.
+    httpMock.expectNone('/api/achievements');
+  });
+
+  it('checkPhrase() resolves to a not-matched result when the request errors', () => {
+    let result: { matched: boolean } | undefined;
+    service.checkPhrase('???').subscribe((r) => (result = r));
+    httpMock
+      .expectOne('/api/achievements/check-phrase')
+      .flush({ error: 'boom' }, { status: 500, statusText: 'Server Error' });
+    expect(result).toEqual({ matched: false, doc_id: null, doc_name: null, already_read: false });
+  });
+
+  it('requestOpenPanel() emits on the open-panel request stream', () => {
+    let opened = 0;
+    service.openPanelRequest$.subscribe(() => (opened += 1));
+    service.requestOpenPanel();
+    expect(opened).toBe(1);
+  });
+
+  it('docRawUrl() builds an encoded raw-doc URL', () => {
+    expect(service.docRawUrl('user/getting started')).toBe(
+      '/api/achievements/docs/user%2Fgetting%20started/raw',
+    );
+  });
+
+  describe('when achievements are disabled in settings', () => {
+    it('refresh() short-circuits to the empty state without hitting the network', () => {
+      enableSetting.set({ enable_achievements: false } as AppSettings);
+      TestBed.tick();
+
+      service.refresh();
+      httpMock.expectNone('/api/achievements');
+      expect(service.snapshot.achievements).toEqual([]);
+    });
+
+    it('clears cached state and the emitted-toast guard when the toggle flips off', () => {
+      // Populate state and emit a toast while enabled.
+      const toast = makeAnnouncement({ id: 'votes_cast', tier_idx: 0 });
+      service.refresh();
+      flushGet(makeState({ achievements: [], pending_toasts: [toast] }));
+      httpMock.expectOne('/api/achievements/votes_cast/mark-toasted').flush({});
+
+      // Flip disabled: cached state resets to empty.
+      enableSetting.set({ enable_achievements: false } as AppSettings);
+      TestBed.tick();
+      expect(service.snapshot).toEqual(service.snapshot); // sanity: no throw
+      expect(service.snapshot.pending_toasts).toEqual([]);
+
+      // Re-enable and refresh: the same toast pops again because the guard was
+      // cleared (server counters are wiped on a re-enable).
+      const toasts: PendingAnnouncement[] = [];
+      service.unlocks.subscribe((p) => toasts.push(p));
+      enableSetting.set({ enable_achievements: true } as AppSettings);
+      TestBed.tick();
+      service.refresh();
+      flushGet(makeState({ pending_toasts: [toast] }));
+      httpMock.expectOne('/api/achievements/votes_cast/mark-toasted').flush({});
+      expect(toasts).toEqual([toast]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #2421

Adds end-to-end frontend coverage for the achievements feature, which shipped with no frontend tests.

## What's covered

**`services/achievements.service.spec.ts`** — pins the service's HTTP-backed data spine against a mocked backend:
- `refresh()` GET + publish, concurrent-call coalescing, and error → empty-state fallback
- one-time unlock toasts: emitted once, `mark-toasted` POST fired, in-session dedup guard prevents a second pop before the server watermark lands
- `hasPending$` tracking, `acknowledge()` / `acknowledgeAll()`, and the open-panel request channel
- `checkPhrase()`: refreshes on a fresh correct match, skips the refresh when already-read, and resolves to a not-matched result on error
- `docRawUrl()` encoding
- the settings kill switch: `refresh()` short-circuits without a request when disabled, and flipping the toggle clears cached state and the emitted-toast guard

**`components/achievements-tab/achievements-tab.component.spec.ts`** — drives the tab through a fake service under the zoneless `TestBed` and asserts on rendered DOM: row rendering, tier labels, total score, next-tier vs maxed-out progress labels, locked-row unlock hints, the three expandable detail panels (docs / media-types / hours), and the Readme-Reader phrase form (correct / already-credited / wrong).

The `achievements-refresh` interceptor already had a spec, so it's left as-is.

## Incidental fix

Writing the component tests under the zoneless `TestBed` surfaced a latent staleness bug. The tab is `OnPush` and updates its fields from manual `subscribe` callbacks (the state stream and the phrase-check response) with no change-detection nudge, so under the now-zoneless app those async updates never re-rendered. Fixed by injecting `ChangeDetectorRef` and calling `markForCheck()` after those mutations, mirroring `context-pulldown`.

## Testing

`./run-tests.sh frontend` — build, audit, and Vitest all green (1199 tests passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165FptaGTV727ueUKSm6ydG

---
_Generated by [Claude Code](https://claude.ai/code/session_0165FptaGTV727ueUKSm6ydG)_