### PR TITLE
Add specs for the active-context selection pipeline

### DIFF
--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.spec.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.spec.ts
@@ -1,0 +1,386 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+
+import { ContextPulldownComponent } from './context-pulldown.component';
+import { ActiveContextService } from '../../services/active-context.service';
+import { ContextSwitchService } from '../../services/context-switch.service';
+import { DatasetStateService } from '../../services/dataset-state.service';
+import { DashboardSelectionService } from '../../services/dashboard-selection.service';
+import { NewThingFlowsService } from '../../services/new-thing-flows.service';
+import { PulldownControlService } from '../../services/pulldown-control.service';
+import { RunningJobsService, pairKey } from '../../services/running-jobs.service';
+import { DatasetRegistryEntry } from '../../models/api.models';
+import { DetectorRegistryEntry } from '../../generated/api-client/models/detector-registry-entry';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+/**
+ * Specs for the top-bar context switcher UI. The pulldown is the user-facing
+ * front of the context-selection pipeline: it renders one row per registry
+ * entry, dims incompatible partners, and — off the Dashboard — drives
+ * `ContextSwitchService.switchTo` (which promotes the active pair the HTTP
+ * interceptor tags onto requests). These tests cover row construction,
+ * compatibility dimming, pick routing (switch vs Dashboard multi-select),
+ * keyboard/open behavior, and the add-new auto-select handoff.
+ */
+
+/** Stub the running-jobs poller so subscribing doesn't fire background HTTP;
+ *  tests push busy-pair snapshots directly. */
+class RunningJobsStub {
+  readonly busyPairsSubject = new BehaviorSubject<Map<string, string[]>>(new Map());
+  readonly busyPairs$ = this.busyPairsSubject.asObservable();
+}
+
+describe('ContextPulldownComponent', () => {
+  let fixture: ComponentFixture<ContextPulldownComponent>;
+  let component: ContextPulldownComponent;
+  let datasetState: DatasetStateService;
+  let activeContext: ActiveContextService;
+  let contextSwitch: ContextSwitchService;
+  let dashSelection: DashboardSelectionService;
+  let newThingFlows: NewThingFlowsService;
+  let pulldownControl: PulldownControlService;
+  let runningJobs: RunningJobsStub;
+
+  function makeDataset(
+    id: string,
+    name: string,
+    overrides: Partial<DatasetRegistryEntry> = {},
+  ): DatasetRegistryEntry {
+    return { id, name, media_type: 'audio', loaded: true, ...overrides } as DatasetRegistryEntry;
+  }
+
+  function makeDetector(
+    id: string,
+    name: string,
+    overrides: Partial<DetectorRegistryEntry> = {},
+  ): DetectorRegistryEntry {
+    return {
+      id,
+      name,
+      media_type: 'audio',
+      detector_loaded: true,
+      ...overrides,
+    } as DetectorRegistryEntry;
+  }
+
+  /** Push registry contents through the signal-backed state, then tick so the
+   *  component's `datasets$`/`detectors$` bridges emit and rebuild the rows. */
+  function setRegistry(
+    datasets: DatasetRegistryEntry[],
+    detectors: DetectorRegistryEntry[] = [],
+  ): void {
+    const ds = datasetState as unknown as {
+      _datasets: { set: (v: unknown) => void };
+      _detectors: { set: (v: unknown) => void };
+      _loaded: { set: (v: unknown) => void };
+    };
+    ds._datasets.set(datasets);
+    ds._detectors.set(detectors);
+    ds._loaded.set(true);
+    TestBed.tick();
+  }
+
+  async function createPulldown(kind: 'dataset' | 'detector' = 'dataset'): Promise<void> {
+    fixture = TestBed.createComponent(ContextPulldownComponent);
+    fixture.componentRef.setInput('kind', kind);
+    component = fixture.componentInstance;
+    // Flush the scheduled initial change detection so ngOnInit runs and wires
+    // the service subscriptions.
+    await settleZoneless(fixture);
+  }
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [ContextPulldownComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: RunningJobsService, useClass: RunningJobsStub },
+      ],
+    }).compileComponents();
+
+    datasetState = TestBed.inject(DatasetStateService);
+    activeContext = TestBed.inject(ActiveContextService);
+    contextSwitch = TestBed.inject(ContextSwitchService);
+    dashSelection = TestBed.inject(DashboardSelectionService);
+    newThingFlows = TestBed.inject(NewThingFlowsService);
+    pulldownControl = TestBed.inject(PulldownControlService);
+    runningJobs = TestBed.inject(RunningJobsService) as unknown as RunningJobsStub;
+  });
+
+  describe('row construction', () => {
+    it('builds one row per dataset for a dataset pulldown, sorted by name', async () => {
+      await createPulldown('dataset');
+      setRegistry([makeDataset('d2', 'Beta'), makeDataset('d1', 'Alpha')]);
+
+      expect(component.rows.map((r) => r.name)).toEqual(['Alpha', 'Beta']);
+      expect(component.rows.map((r) => r.id)).toEqual(['d1', 'd2']);
+    });
+
+    it('builds detector rows for a detector pulldown', async () => {
+      await createPulldown('detector');
+      setRegistry([makeDataset('d1', 'DS')], [makeDetector('m1', 'Det One')]);
+
+      expect(component.rows.map((r) => r.id)).toEqual(['m1']);
+      expect(component.rows[0].loaded).toBe(true);
+    });
+
+    it('marks the intent dataset active and reflects it in activeName', async () => {
+      await createPulldown('dataset');
+      activeContext.setIntent('d1', '');
+      setRegistry([makeDataset('d1', 'Alpha'), makeDataset('d2', 'Beta')]);
+
+      const rows = new Map(component.rows.map((r) => [r.id, r]));
+      expect(rows.get('d1')!.active).toBe(true);
+      expect(rows.get('d2')!.active).toBe(false);
+      expect(component.activeName).toBe('Alpha');
+      expect(component.activeRowExists).toBe(true);
+    });
+
+    it('shows the placeholder (empty activeName) when nothing is active', async () => {
+      await createPulldown('dataset');
+      setRegistry([makeDataset('d1', 'Alpha')]);
+      expect(component.activeName).toBe('');
+      expect(component.activeRowExists).toBe(false);
+    });
+  });
+
+  describe('compatibility dimming', () => {
+    it('dims a dataset that is incompatible with the active detector', async () => {
+      await createPulldown('dataset');
+      // Active detector half is an image detector; the audio dataset can't pair.
+      activeContext.setIntent('', 'm1');
+      setRegistry(
+        [makeDataset('d1', 'AudioDS', { media_type: 'audio' })],
+        [makeDetector('m1', 'ImgDet', { media_type: 'image' })],
+      );
+
+      const row = component.rows.find((r) => r.id === 'd1')!;
+      expect(row.compatibleWithOther).toBe(false);
+      expect(row.incompatReason).toContain('image');
+      expect(row.incompatReason).toContain('audio');
+    });
+
+    it('leaves a matching-media-type pair compatible', async () => {
+      await createPulldown('dataset');
+      activeContext.setIntent('', 'm1');
+      setRegistry(
+        [makeDataset('d1', 'AudioDS', { media_type: 'audio' })],
+        [makeDetector('m1', 'AudioDet', { media_type: 'audio' })],
+      );
+
+      const row = component.rows.find((r) => r.id === 'd1')!;
+      expect(row.compatibleWithOther).toBe(true);
+      expect(row.incompatReason).toBe('');
+    });
+  });
+
+  describe('pickRow (off the Dashboard)', () => {
+    it('switches the active pair via ContextSwitchService and closes', async () => {
+      await createPulldown('dataset');
+      activeContext.setIntent('d2', 'm1');
+      setRegistry([makeDataset('d1', 'Alpha'), makeDataset('d2', 'Beta')], [makeDetector('m1', 'Det')]);
+      const switchSpy = vi.spyOn(contextSwitch, 'switchTo').mockImplementation(() => {});
+
+      component.openMenu();
+      component.pickRow(component.rows.find((r) => r.id === 'd1')!);
+
+      // Carries the current intent detector half through.
+      expect(switchSpy).toHaveBeenCalledWith('d1', 'm1');
+      expect(component.open).toBe(false);
+    });
+
+    it('does not switch when the picked row is already active', async () => {
+      await createPulldown('dataset');
+      activeContext.setIntent('d1', '');
+      setRegistry([makeDataset('d1', 'Alpha')]);
+      const switchSpy = vi.spyOn(contextSwitch, 'switchTo');
+
+      component.openMenu();
+      component.pickRow(component.rows.find((r) => r.id === 'd1')!);
+
+      expect(switchSpy).not.toHaveBeenCalled();
+      expect(component.open).toBe(false);
+    });
+  });
+
+  describe('pickRow (Dashboard multi-select mode)', () => {
+    it('routes a pick to the Dashboard selection instead of a context switch', async () => {
+      await createPulldown('dataset');
+      dashSelection.setDashboardVisible(true);
+      setRegistry([makeDataset('d1', 'Alpha'), makeDataset('d2', 'Beta')]);
+      const selectSpy = vi.spyOn(dashSelection, 'requestSelect');
+      const switchSpy = vi.spyOn(contextSwitch, 'switchTo');
+
+      component.pickRow(component.rows.find((r) => r.id === 'd2')!);
+
+      expect(selectSpy).toHaveBeenCalledWith('dataset', 'd2');
+      expect(switchSpy).not.toHaveBeenCalled();
+    });
+
+    it('collapses a multi-selection to the "Multiple" label', async () => {
+      await createPulldown('dataset');
+      dashSelection.setDashboardVisible(true);
+      dashSelection.setDatasetIds(['d1', 'd2']);
+      setRegistry([makeDataset('d1', 'Alpha'), makeDataset('d2', 'Beta')]);
+
+      expect(component.rows.filter((r) => r.active).length).toBe(2);
+      expect(component.activeName).toBe('Multiple');
+    });
+  });
+
+  describe('open / focus behavior', () => {
+    it('focuses the first compatible row on open', async () => {
+      await createPulldown('dataset');
+      activeContext.setIntent('', 'm1');
+      setRegistry(
+        [
+          makeDataset('d1', 'Alpha', { media_type: 'image' }), // incompatible, sorts first
+          makeDataset('d2', 'Beta', { media_type: 'audio' }), // compatible
+        ],
+        [makeDetector('m1', 'AudioDet', { media_type: 'audio' })],
+      );
+
+      component.openMenu();
+      expect(component.open).toBe(true);
+      expect(component.rows[component.focusedIndex].id).toBe('d2');
+    });
+
+    it('close() resets open state and focus', async () => {
+      await createPulldown('dataset');
+      setRegistry([makeDataset('d1', 'Alpha')]);
+      component.openMenu();
+      component.close();
+      expect(component.open).toBe(false);
+      expect(component.focusedIndex).toBe(-1);
+    });
+
+    it('opens on the pulldown-control open signal', async () => {
+      await createPulldown('detector');
+      setRegistry([makeDataset('d1', 'DS')], [makeDetector('m1', 'Det')]);
+      expect(component.open).toBe(false);
+
+      pulldownControl.requestOpen('detector');
+      TestBed.tick();
+
+      expect(component.open).toBe(true);
+    });
+  });
+
+  describe('keyboard', () => {
+    function key(k: string): KeyboardEvent {
+      return { key: k, preventDefault: () => {} } as KeyboardEvent;
+    }
+
+    it('ArrowDown opens the closed menu', async () => {
+      await createPulldown('dataset');
+      setRegistry([makeDataset('d1', 'Alpha')]);
+      component.onKeydown(key('ArrowDown'));
+      expect(component.open).toBe(true);
+    });
+
+    it('ArrowDown / ArrowUp wrap around the row list when open', async () => {
+      await createPulldown('dataset');
+      setRegistry([makeDataset('d1', 'Alpha'), makeDataset('d2', 'Beta')]);
+      component.openMenu();
+      component.focusedIndex = 1; // last row
+      component.onKeydown(key('ArrowDown'));
+      expect(component.focusedIndex).toBe(0); // wrapped to first
+      component.onKeydown(key('ArrowUp'));
+      expect(component.focusedIndex).toBe(1); // wrapped back to last
+    });
+
+    it('Enter on a focused row picks it', async () => {
+      await createPulldown('dataset');
+      activeContext.setIntent('d2', '');
+      setRegistry([makeDataset('d1', 'Alpha'), makeDataset('d2', 'Beta')]);
+      const switchSpy = vi.spyOn(contextSwitch, 'switchTo').mockImplementation(() => {});
+
+      component.openMenu();
+      component.focusedIndex = component.rows.findIndex((r) => r.id === 'd1');
+      component.onKeydown(key('Enter'));
+
+      expect(switchSpy).toHaveBeenCalledWith('d1', '');
+    });
+
+    it('Escape closes the open menu', async () => {
+      await createPulldown('dataset');
+      setRegistry([makeDataset('d1', 'Alpha')]);
+      component.openMenu();
+      component.onKeydown(key('Escape'));
+      expect(component.open).toBe(false);
+    });
+  });
+
+  describe('add new', () => {
+    it('opens the importer flow for a dataset pulldown', async () => {
+      await createPulldown('dataset');
+      setRegistry([makeDataset('d1', 'Alpha')]);
+      const openSpy = vi.spyOn(newThingFlows, 'openImporter');
+
+      component.addNew();
+      expect(openSpy).toHaveBeenCalled();
+      expect(component.open).toBe(false);
+    });
+
+    it('opens the new-detector flow seeded from the active dataset', async () => {
+      await createPulldown('detector');
+      activeContext.setIntent('d1', '');
+      setRegistry(
+        [makeDataset('d1', 'Alpha', { media_type: 'image', embedder: 'siglip' })],
+        [],
+      );
+      const openSpy = vi.spyOn(newThingFlows, 'openNewDetector');
+
+      component.addNew();
+      expect(openSpy).toHaveBeenCalledWith({
+        defaultMediaType: 'image',
+        datasetEmbedder: 'siglip',
+      });
+    });
+
+    it('auto-switches to a newly created detector', async () => {
+      await createPulldown('detector');
+      activeContext.setIntent('d1', '');
+      setRegistry([makeDataset('d1', 'DS')], []);
+      const switchSpy = vi.spyOn(contextSwitch, 'switchTo').mockImplementation(() => {});
+
+      component.addNew(); // arms awaitingNew for this detector pulldown
+      newThingFlows.emitDetectorCreated('mNew');
+      TestBed.tick();
+
+      expect(switchSpy).toHaveBeenCalledWith('d1', 'mNew');
+    });
+  });
+
+  describe('busy indicator', () => {
+    it('flags a row whose pair has a running job', async () => {
+      await createPulldown('dataset');
+      activeContext.setIntent('d1', 'm1'); // active detector half = m1
+      setRegistry([makeDataset('d1', 'Alpha')], [makeDetector('m1', 'Det')]);
+
+      runningJobs.busyPairsSubject.next(new Map([[pairKey('d1', 'm1'), ['learned-sort']]]));
+      TestBed.tick();
+
+      const row = component.rows.find((r) => r.id === 'd1')!;
+      expect(row.busy).toBe(true);
+      expect(row.busyJobTypes).toEqual(['learned-sort']);
+      expect(component.busyTitle(row)).toContain('Learned sort');
+    });
+  });
+
+  describe('registry error', () => {
+    it('surfaces a registry load error', async () => {
+      await createPulldown('dataset');
+      const ds = datasetState as unknown as { _error: { set: (v: unknown) => void } };
+      ds._error.set("Couldn't load datasets and detectors.");
+      TestBed.tick();
+      expect(component.registryError).toContain("Couldn't load");
+    });
+  });
+});

--- a/frontend/src/app/guards/browse-context.guard.spec.ts
+++ b/frontend/src/app/guards/browse-context.guard.spec.ts
@@ -1,0 +1,177 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot,
+  GuardResult,
+  MaybeAsync,
+  Router,
+  UrlTree,
+  convertToParamMap,
+  provideRouter,
+} from '@angular/router';
+import { isObservable, of } from 'rxjs';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { browseContextGuard } from './browse-context.guard';
+import { ActiveContextService } from '../services/active-context.service';
+import { ContextSwitchService } from '../services/context-switch.service';
+import { DatasetStateService } from '../services/dataset-state.service';
+import { ToastService } from '../services/toast.service';
+import { DatasetRegistryEntry } from '../models/api.models';
+import { configureZoneless } from '../testing/zoneless-testbed';
+
+/**
+ * Specs for the browse route guard: given `/browse/:datasetId`, decide whether
+ * the browse view may activate, loading the dataset into the backend first when
+ * needed. Together with the active-context guard and interceptor coverage, this
+ * pins the whole context-selection pipeline the backend's header checks lean on.
+ */
+describe('browseContextGuard', () => {
+  let router: Router;
+  let datasetState: DatasetStateService;
+  let activeContext: ActiveContextService;
+  let toast: ToastService;
+  let contextSwitch: ContextSwitchService;
+
+  function makeRoute(datasetId: string | null): ActivatedRouteSnapshot {
+    return {
+      paramMap: convertToParamMap(datasetId === null ? {} : { datasetId }),
+    } as unknown as ActivatedRouteSnapshot;
+  }
+
+  /** Seed the registry as loaded with the given datasets. */
+  function setRegistry(datasets: DatasetRegistryEntry[]): void {
+    const ds = datasetState as unknown as {
+      _datasets: { set: (v: unknown) => void };
+      _loaded: { set: (v: unknown) => void };
+    };
+    ds._datasets.set(datasets);
+    ds._loaded.set(true);
+    // `loaded$` is a `toObservable` bridge over the `_loaded` signal; tick so
+    // the guard's `loaded$` subscription replays `true` when it subscribes.
+    TestBed.tick();
+  }
+
+  function runGuard(datasetId: string | null): MaybeAsync<GuardResult> {
+    return TestBed.runInInjectionContext(() => browseContextGuard(makeRoute(datasetId), {} as never));
+  }
+
+  function resolveGuard(result: MaybeAsync<GuardResult>): Promise<GuardResult> {
+    if (isObservable(result)) {
+      return new Promise<GuardResult>((resolve) => {
+        (result as { subscribe: (cb: (v: GuardResult) => void) => void }).subscribe((v) =>
+          resolve(v),
+        );
+      });
+    }
+    return Promise.resolve(result as GuardResult);
+  }
+
+  beforeEach(() => {
+    configureZoneless({
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+    });
+    router = TestBed.inject(Router);
+    datasetState = TestBed.inject(DatasetStateService);
+    activeContext = TestBed.inject(ActiveContextService);
+    toast = TestBed.inject(ToastService);
+    contextSwitch = TestBed.inject(ContextSwitchService);
+  });
+
+  it('redirects to /dashboard when the datasetId param is missing', () => {
+    const result = runGuard(null);
+    // Synchronous UrlTree, not an observable — no registry wait involved.
+    expect(result instanceof UrlTree).toBe(true);
+    expect((result as UrlTree).toString()).toBe('/dashboard');
+  });
+
+  it('short-circuits to true for ephemeral __detpos__ browse contexts', () => {
+    const applySpy = vi.spyOn(contextSwitch, 'applyActivePair');
+    const result = runGuard('__detpos__abc');
+    // Returned synchronously; the registry/load checks are skipped entirely.
+    expect(result).toBe(true);
+    expect(applySpy).not.toHaveBeenCalled();
+  });
+
+  it('redirects + toasts when the dataset id is not in the registry', async () => {
+    setRegistry([]);
+    const result = await resolveGuard(runGuard('missing'));
+    expect(result instanceof UrlTree).toBe(true);
+    expect((result as UrlTree).toString()).toBe('/dashboard');
+    expect(toast.toasts.length).toBe(1);
+    expect(toast.toasts[0].message).toContain("'missing'");
+  });
+
+  it('fast-paths to true when the active dataset is already loaded and matches', async () => {
+    setRegistry([
+      { id: 'd1', name: 'DS', media_type: 'audio', loaded: true } as DatasetRegistryEntry,
+    ]);
+    activeContext.setActivePair('d1', 'm1');
+    const applySpy = vi.spyOn(contextSwitch, 'applyActivePair');
+
+    const result = await resolveGuard(runGuard('d1'));
+    expect(result).toBe(true);
+    // Genuinely loaded + matching active id => no load needed.
+    expect(applySpy).not.toHaveBeenCalled();
+  });
+
+  it('loads via applyActivePair when the matching dataset is not loaded', async () => {
+    setRegistry([
+      { id: 'd1', name: 'DS', media_type: 'audio', loaded: false } as DatasetRegistryEntry,
+    ]);
+    activeContext.setActivePair('d1', 'm1');
+    const applySpy = vi
+      .spyOn(contextSwitch, 'applyActivePair')
+      .mockImplementation(() => of(undefined));
+
+    const result = await resolveGuard(runGuard('d1'));
+    expect(result).toBe(true);
+    // A matching active id is NOT sufficient — the dataset may have been
+    // evicted since, so the guard loads it before allowing the browse view.
+    expect(applySpy).toHaveBeenCalledWith('d1', 'm1');
+  });
+
+  it('loads via applyActivePair when a switch is in flight even if ids match', async () => {
+    setRegistry([
+      { id: 'd1', name: 'DS', media_type: 'audio', loaded: true } as DatasetRegistryEntry,
+    ]);
+    activeContext.setActivePair('d1', 'm1');
+    vi.spyOn(contextSwitch, 'switching', 'get').mockReturnValue(true);
+    const applySpy = vi
+      .spyOn(contextSwitch, 'applyActivePair')
+      .mockImplementation(() => of(undefined));
+
+    const result = await resolveGuard(runGuard('d1'));
+    expect(result).toBe(true);
+    expect(applySpy).toHaveBeenCalledWith('d1', 'm1');
+  });
+
+  it('loads via applyActivePair when the URL dataset differs from the active one', async () => {
+    setRegistry([
+      { id: 'd1', name: 'One', media_type: 'audio', loaded: true } as DatasetRegistryEntry,
+      { id: 'd2', name: 'Two', media_type: 'audio', loaded: true } as DatasetRegistryEntry,
+    ]);
+    activeContext.setActivePair('d1', 'm1');
+    const applySpy = vi
+      .spyOn(contextSwitch, 'applyActivePair')
+      .mockImplementation(() => of(undefined));
+
+    const result = await resolveGuard(runGuard('d2'));
+    expect(result).toBe(true);
+    // Carries the active detector half through to the load.
+    expect(applySpy).toHaveBeenCalledWith('d2', 'm1');
+  });
+
+  it('refreshes the registry when it has not loaded yet, then resolves once loaded', async () => {
+    const refreshSpy = vi.spyOn(datasetState, 'refresh');
+    // Registry starts unloaded (_loaded is false by default).
+    const result = runGuard('d1');
+    expect(refreshSpy).toHaveBeenCalled();
+
+    // Registry arrives with d1 loaded; the guard's `filter(loaded)` now passes.
+    setRegistry([
+      { id: 'd1', name: 'DS', media_type: 'audio', loaded: true } as DatasetRegistryEntry,
+    ]);
+    activeContext.setActivePair('d1', '');
+    expect(await resolveGuard(result)).toBe(true);
+  });
+});

--- a/frontend/src/app/services/active-context.service.spec.ts
+++ b/frontend/src/app/services/active-context.service.spec.ts
@@ -1,0 +1,175 @@
+import { TestBed } from '@angular/core/testing';
+import { ActiveContextService } from './active-context.service';
+import { configureZoneless } from '../testing/zoneless-testbed';
+
+/**
+ * Specs for the source-of-truth singleton behind the whole context-selection
+ * pipeline. The service holds two layers — **intent** (what the user picked)
+ * and **active** (what the backend has loaded, which the HTTP interceptor tags
+ * onto requests via `X-Dataset-Id` / `X-Detector-Id`). These tests pin the
+ * layer independence, the no-op-on-unchanged emission contract, and the
+ * request-id / media-url helpers the switcher and native-media paths rely on.
+ */
+describe('ActiveContextService', () => {
+  let svc: ActiveContextService;
+
+  beforeEach(() => {
+    configureZoneless();
+    svc = TestBed.inject(ActiveContextService);
+  });
+
+  it('starts with both layers empty', () => {
+    expect(svc.datasetId).toBe('');
+    expect(svc.modelId).toBe('');
+    expect(svc.intentDatasetId).toBe('');
+    expect(svc.intentModelId).toBe('');
+    expect(svc.currentRequestId).toBe(0);
+  });
+
+  describe('layer independence', () => {
+    it('setIntent moves the intent layer but leaves active pinned', () => {
+      svc.setIntent('d1', 'm1');
+      expect(svc.intentDatasetId).toBe('d1');
+      expect(svc.intentModelId).toBe('m1');
+      // Active is what the interceptor reads; it must NOT move until a load
+      // has finished and the switcher promotes it.
+      expect(svc.datasetId).toBe('');
+      expect(svc.modelId).toBe('');
+    });
+
+    it('setActive moves the active layer but leaves intent untouched', () => {
+      svc.setActive('d1', 'm1');
+      expect(svc.datasetId).toBe('d1');
+      expect(svc.modelId).toBe('m1');
+      expect(svc.intentDatasetId).toBe('');
+      expect(svc.intentModelId).toBe('');
+    });
+
+    it('setActivePair writes both layers atomically', () => {
+      svc.setActivePair('d1', 'm1');
+      expect(svc.datasetId).toBe('d1');
+      expect(svc.modelId).toBe('m1');
+      expect(svc.intentDatasetId).toBe('d1');
+      expect(svc.intentModelId).toBe('m1');
+    });
+
+    it('clear() resets both layers to empty', () => {
+      svc.setActivePair('d1', 'm1');
+      svc.clear();
+      expect(svc.datasetId).toBe('');
+      expect(svc.modelId).toBe('');
+      expect(svc.intentDatasetId).toBe('');
+      expect(svc.intentModelId).toBe('');
+    });
+  });
+
+  describe('pair$ emissions', () => {
+    it('emits once per atomic setActive, not once per half', () => {
+      const pairs: { datasetId: string; modelId: string }[] = [];
+      svc.pair$.subscribe((p) => pairs.push(p));
+      // Initial replay of the empty pair.
+      expect(pairs).toEqual([{ datasetId: '', modelId: '' }]);
+
+      svc.setActive('d1', 'm1');
+      // One emission for the pair change, not two (one per half).
+      expect(pairs.length).toBe(2);
+      expect(pairs[1]).toEqual({ datasetId: 'd1', modelId: 'm1' });
+    });
+
+    it('does not re-emit when setActive is called with the current pair', () => {
+      svc.setActive('d1', 'm1');
+      const pairs: { datasetId: string; modelId: string }[] = [];
+      svc.pair$.subscribe((p) => pairs.push(p));
+      expect(pairs.length).toBe(1); // replayed current value
+
+      svc.setActive('d1', 'm1'); // no-op
+      expect(pairs.length).toBe(1);
+    });
+
+    it('intentPair$ tracks the intent layer independently of active', () => {
+      const pairs: { datasetId: string; modelId: string }[] = [];
+      svc.intentPair$.subscribe((p) => pairs.push(p));
+      expect(pairs.length).toBe(1);
+
+      svc.setIntent('d1', 'm1');
+      expect(pairs[pairs.length - 1]).toEqual({ datasetId: 'd1', modelId: 'm1' });
+
+      // Promoting active alone must NOT push a new intentPair emission.
+      const before = pairs.length;
+      svc.setActive('d1', 'm1');
+      expect(pairs.length).toBe(before);
+    });
+  });
+
+  describe('pairKey$ / intentPairKey$', () => {
+    it('joins the active halves as `<datasetId>::<modelId>`', () => {
+      const keys: string[] = [];
+      svc.pairKey$.subscribe((k) => keys.push(k));
+      expect(keys[keys.length - 1]).toBe('::');
+
+      svc.setActive('d1', 'm1');
+      expect(keys[keys.length - 1]).toBe('d1::m1');
+    });
+
+    it('joins the intent halves independently of active', () => {
+      const keys: string[] = [];
+      svc.intentPairKey$.subscribe((k) => keys.push(k));
+
+      svc.setIntent('dX', 'mY');
+      expect(keys[keys.length - 1]).toBe('dX::mY');
+    });
+  });
+
+  describe('single-half changes', () => {
+    it('setActive updates only the changed half', () => {
+      svc.setActive('d1', 'm1');
+      svc.setActive('d1', 'm2');
+      expect(svc.datasetId).toBe('d1');
+      expect(svc.modelId).toBe('m2');
+    });
+
+    it('setIntent with no change is a no-op (no intentPair emission)', () => {
+      svc.setIntent('d1', 'm1');
+      const pairs: unknown[] = [];
+      svc.intentPair$.subscribe((p) => pairs.push(p));
+      expect(pairs.length).toBe(1);
+      svc.setIntent('d1', 'm1');
+      expect(pairs.length).toBe(1);
+    });
+  });
+
+  describe('nextRequestId', () => {
+    it('increments monotonically and currentRequestId reflects the latest', () => {
+      expect(svc.nextRequestId()).toBe(1);
+      expect(svc.nextRequestId()).toBe(2);
+      expect(svc.currentRequestId).toBe(2);
+    });
+  });
+
+  describe('mediaUrl', () => {
+    it('returns the bare path when no active ids are set', () => {
+      expect(svc.mediaUrl('/api/media/foo.wav')).toBe('/api/media/foo.wav');
+    });
+
+    it('appends only the dataset param when no detector is active', () => {
+      svc.setActive('d1', '');
+      expect(svc.mediaUrl('/api/media/foo.wav')).toBe('/api/media/foo.wav?dataset_id=d1');
+    });
+
+    it('appends both params when both halves are active', () => {
+      svc.setActive('d1', 'm1');
+      expect(svc.mediaUrl('/x')).toBe('/x?dataset_id=d1&detector_id=m1');
+    });
+
+    it('uses the active pair, not intent (intent may still be in-flight)', () => {
+      svc.setIntent('dIntent', 'mIntent');
+      svc.setActive('dActive', 'mActive');
+      expect(svc.mediaUrl('/x')).toBe('/x?dataset_id=dActive&detector_id=mActive');
+    });
+
+    it('url-encodes id values', () => {
+      svc.setActive('d 1&x', 'm/1');
+      expect(svc.mediaUrl('/x')).toBe('/x?dataset_id=d%201%26x&detector_id=m%2F1');
+    });
+  });
+});

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -74,6 +74,18 @@ class ResizeObserverMock {
 }
 (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverMock;
 
+// --- Element.scrollIntoView -------------------------------------------------
+// Several components scroll a focused/active row into view (context-pulldown,
+// media-list, folder-browser, import-config). jsdom has no layout engine and
+// omits scrollIntoView, throwing "not a function" — often from a deferred
+// setTimeout callback that surfaces as an unhandled error rather than a test
+// failure. An inert no-op keeps those paths quiet.
+Object.defineProperty(Element.prototype, 'scrollIntoView', {
+  configurable: true,
+  writable: true,
+  value: () => {},
+});
+
 // --- HTMLMediaElement play/pause/load --------------------------------------
 // The audio/video players call these; jsdom throws "Not implemented".
 Object.defineProperties(HTMLMediaElement.prototype, {


### PR DESCRIPTION
Adds frontend specs for the three untested pieces of the context-selection pipeline that the backend's `X-Dataset-Id` / `X-Detector-Id` header checks depend on. Together with the existing interceptor and active-context-watcher coverage, this closes the gap on the whole pipeline.

## What's covered

**`services/active-context.service.ts`** — the intent/active two-layer source of truth:
- Layer independence (`setIntent` moves intent only; `setActive` moves active only; `setActivePair` writes both; `clear` resets both).
- Emission contract: `pair$` fires once per atomic change (not once per half) and no-ops when the pair is unchanged; `intentPair$` tracks intent independently of active.
- `pairKey$` / `intentPairKey$` joins, `nextRequestId` counter, and `mediaUrl` (uses the *active* pair, appends only present ids, url-encodes values).

**`components/context-pulldown/context-pulldown.component.ts`** — the context switcher UI:
- Row construction and name-sorting, active-row / `activeName` (placeholder / single / "Multiple") state.
- Compatibility dimming against the other half's active id (reason string).
- Pick routing: off-Dashboard drives `ContextSwitchService.switchTo` (and no-ops on an already-active row); on the Dashboard it routes to `requestSelect`.
- Open/focus (first compatible row), `close()` reset, `pulldownControl.requestOpen` signal, keyboard nav (open on ArrowDown, wrap Up/Down, Enter picks, Escape closes).
- Add-new flows (importer vs seeded new-detector) and the created-detector auto-switch handoff; busy indicator; registry-error surfacing.

**`guards/browse-context.guard.ts`**:
- Missing-param redirect, `__detpos__` ephemeral-context fast-path, unknown-dataset redirect + toast.
- Loaded-and-matching fast-path, and the `applyActivePair` load paths (dataset not loaded, mid-switch, URL dataset differs from active), plus the not-yet-loaded registry-refresh path.

## Test-infra change

Adds an inert `Element.scrollIntoView` no-op to the shared jsdom test setup (`src/test-setup.ts`). The pulldown — and several other components — scroll a focused row into view from a deferred `setTimeout` callback, which jsdom omits and surfaces as an unhandled error.

`./run-tests.sh frontend` is green (1217 tests passed, no unhandled errors).

Closes #2419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNhfYJbJCLSFEkq4eQaUjX)_