### PR TITLE
Add specs for untested singleton services (toast, modals, caches, CRUD API)

### DIFF
--- a/frontend/src/app/services/dashboard-modals.service.spec.ts
+++ b/frontend/src/app/services/dashboard-modals.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { firstValueFrom } from 'rxjs';
 import { DashboardModalsService } from './dashboard-modals.service';
-import { DatasetRegistryEntry } from '../models/api.models';
+import { AutoDetectResultsData, DatasetRegistryEntry } from '../models/api.models';
 
 describe('DashboardModalsService', () => {
   let service: DashboardModalsService;
@@ -60,7 +60,7 @@ describe('DashboardModalsService', () => {
   });
 
   it('openFindResults carries the results payload; close resets to an empty result', () => {
-    const data = { results: { a: [1, 2] } };
+    const data: AutoDetectResultsData = { results: { det: { hits: [] } } };
     service.openFindResults(data);
     expect(service.findResults).toEqual({ open: true, data });
     service.closeFindResults();

--- a/frontend/src/app/services/dashboard-modals.service.spec.ts
+++ b/frontend/src/app/services/dashboard-modals.service.spec.ts
@@ -1,0 +1,89 @@
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { DashboardModalsService } from './dashboard-modals.service';
+import { DatasetRegistryEntry } from '../models/api.models';
+
+describe('DashboardModalsService', () => {
+  let service: DashboardModalsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [DashboardModalsService] });
+    service = TestBed.inject(DashboardModalsService);
+  });
+
+  it('every modal starts closed', () => {
+    expect(service.combineDatasets.open).toBe(false);
+    expect(service.combineDetectors.open).toBe(false);
+    expect(service.export.open).toBe(false);
+    expect(service.portableExport.open).toBe(false);
+    expect(service.addLabels.open).toBe(false);
+    expect(service.findResults.open).toBe(false);
+    expect(service.stats.open).toBe(false);
+    expect(service.detectorStats.open).toBe(false);
+  });
+
+  it('openCombineDatasets carries the dataset list; close resets it', () => {
+    const datasets = [{ id: 'd1' }, { id: 'd2' }] as DatasetRegistryEntry[];
+    service.openCombineDatasets(datasets);
+    expect(service.combineDatasets).toEqual({ open: true, datasets });
+
+    service.closeCombineDatasets();
+    expect(service.combineDatasets).toEqual({ open: false, datasets: [] });
+  });
+
+  it('openCombineDetectors / closeCombineDetectors toggles open', () => {
+    service.openCombineDetectors();
+    expect(service.combineDetectors.open).toBe(true);
+    service.closeCombineDetectors();
+    expect(service.combineDetectors.open).toBe(false);
+  });
+
+  it('openExport carries the detector name; close clears it', () => {
+    service.openExport('my-detector');
+    expect(service.export).toEqual({ open: true, detectorName: 'my-detector' });
+    service.closeExport();
+    expect(service.export).toEqual({ open: false, detectorName: '' });
+  });
+
+  it('openPortableExport carries id + name; close clears both', () => {
+    service.openPortableExport('id-1', 'Nice Name');
+    expect(service.portableExport).toEqual({ open: true, detectorId: 'id-1', detectorName: 'Nice Name' });
+    service.closePortableExport();
+    expect(service.portableExport).toEqual({ open: false, detectorId: '', detectorName: '' });
+  });
+
+  it('openAddLabels carries id + name; close clears both', () => {
+    service.openAddLabels('id-2', 'Labeller');
+    expect(service.addLabels).toEqual({ open: true, detectorId: 'id-2', detectorName: 'Labeller' });
+    service.closeAddLabels();
+    expect(service.addLabels).toEqual({ open: false, detectorId: '', detectorName: '' });
+  });
+
+  it('openFindResults carries the results payload; close resets to an empty result', () => {
+    const data = { results: { a: [1, 2] } };
+    service.openFindResults(data);
+    expect(service.findResults).toEqual({ open: true, data });
+    service.closeFindResults();
+    expect(service.findResults).toEqual({ open: false, data: { results: {} } });
+  });
+
+  it('openStats carries dataset id + name; close clears both', () => {
+    service.openStats('ds-1', 'Dataset One');
+    expect(service.stats).toEqual({ open: true, datasetId: 'ds-1', datasetName: 'Dataset One' });
+    service.closeStats();
+    expect(service.stats).toEqual({ open: false, datasetId: '', datasetName: '' });
+  });
+
+  it('openDetectorStats carries detector id + name; close clears both', () => {
+    service.openDetectorStats('det-1', 'Detector One');
+    expect(service.detectorStats).toEqual({ open: true, detectorId: 'det-1', detectorName: 'Detector One' });
+    service.closeDetectorStats();
+    expect(service.detectorStats).toEqual({ open: false, detectorId: '', detectorName: '' });
+  });
+
+  it('emits the new state to observers of the matching stream', async () => {
+    service.openExport('streamed');
+    const state = await firstValueFrom(service.export$);
+    expect(state).toEqual({ open: true, detectorName: 'streamed' });
+  });
+});

--- a/frontend/src/app/services/detectors-crud-api.service.spec.ts
+++ b/frontend/src/app/services/detectors-crud-api.service.spec.ts
@@ -1,0 +1,131 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { DetectorsCrudApiService } from './detectors-crud-api.service';
+import { ActiveContextService } from './active-context.service';
+
+describe('DetectorsCrudApiService', () => {
+  let service: DetectorsCrudApiService;
+  let httpMock: HttpTestingController;
+
+  // Stub ActiveContextService so the URL builders below are deterministic and
+  // don't pull the real context graph into the test.
+  const activeContextStub = {
+    mediaUrl: (path: string) => `${path}?dataset_id=ds1`,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ActiveContextService, useValue: activeContextStub },
+      ],
+    });
+    service = TestBed.inject(DetectorsCrudApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('list should GET /api/detectors', () => {
+    service.list().subscribe((r) => expect(r.detectors).toBeDefined());
+    const req = httpMock.expectOne('/api/detectors');
+    expect(req.request.method).toBe('GET');
+    req.flush({ detectors: [] });
+  });
+
+  it('create should POST /api/detectors with the request body', () => {
+    service.create({ name: 'd1', media_type: 'image' }).subscribe();
+    const req = httpMock.expectOne('/api/detectors');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ name: 'd1', media_type: 'image' });
+    req.flush({});
+  });
+
+  it('get should GET /api/detectors/{name}', () => {
+    service.get('my det').subscribe();
+    const req = httpMock.expectOne('/api/detectors/my%20det');
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+
+  it('delete should DELETE /api/detectors/{name}', () => {
+    service.delete('d1').subscribe();
+    const req = httpMock.expectOne('/api/detectors/d1');
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+  });
+
+  it('rename should PUT /api/detectors/{name}/rename with new_name', () => {
+    service.rename('old', 'new').subscribe();
+    const req = httpMock.expectOne('/api/detectors/old/rename');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ new_name: 'new' });
+    req.flush({});
+  });
+
+  it('setExamples should PUT /api/detectors/{name}/examples with examples', () => {
+    const examples = [{ path: 'a.png' }] as never;
+    service.setExamples('d1', examples).subscribe();
+    const req = httpMock.expectOne('/api/detectors/d1/examples');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ examples });
+    req.flush({});
+  });
+
+  it('saveLabels should POST /api/detectors/{name}/labels', () => {
+    service.saveLabels('d1').subscribe();
+    const req = httpMock.expectOne('/api/detectors/d1/labels');
+    expect(req.request.method).toBe('POST');
+    req.flush({});
+  });
+
+  it('getLabelsDetail should GET /api/detectors/{name}/labels-detail', () => {
+    service.getLabelsDetail('d1').subscribe();
+    const req = httpMock.expectOne('/api/detectors/d1/labels-detail');
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+
+  it('voteLabelElement should POST the vote target', () => {
+    service.voteLabelElement('d1', 'el-7', 'good').subscribe();
+    const req = httpMock.expectOne('/api/detectors/d1/labels/el-7/vote');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ target: 'good' });
+    req.flush({});
+  });
+
+  it('combine should POST /api/detectors/combine with names + policy', () => {
+    service.combine(['a', 'b'], 'merged', 'rename').subscribe();
+    const req = httpMock.expectOne('/api/detectors/combine');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ names: ['a', 'b'], new_name: 'merged', conflict_policy: 'rename' });
+    req.flush({});
+  });
+
+  it('combine defaults the conflict policy to drop', () => {
+    service.combine(['a', 'b'], 'merged').subscribe();
+    const req = httpMock.expectOne('/api/detectors/combine');
+    expect(req.request.body).toEqual({ names: ['a', 'b'], new_name: 'merged', conflict_policy: 'drop' });
+    req.flush({});
+  });
+
+  it('exportPortableBundle should POST for a blob', () => {
+    service.exportPortableBundle('d/1').subscribe();
+    const req = httpMock.expectOne('/api/detectors/d%2F1/portable-bundle');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.responseType).toBe('blob');
+    req.flush(new Blob(['zip']));
+  });
+
+  it('labelPreviewUrl routes through ActiveContextService.mediaUrl with encoded segments', () => {
+    const url = service.labelPreviewUrl('my det', 'el/7');
+    expect(url).toBe('/api/detectors/my%20det/labels/el%2F7/preview?dataset_id=ds1');
+  });
+
+  it('labelThumbnailUrl routes through ActiveContextService.mediaUrl with encoded segments', () => {
+    const url = service.labelThumbnailUrl('d1', 'el-7');
+    expect(url).toBe('/api/detectors/d1/labels/el-7/thumbnail?dataset_id=ds1');
+  });
+});

--- a/frontend/src/app/services/embedder-capability.service.spec.ts
+++ b/frontend/src/app/services/embedder-capability.service.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import { Observable, of } from 'rxjs';
+import { EmbedderCapabilityService } from './embedder-capability.service';
+import { DatasetsListingsApiService } from './datasets-listings-api.service';
+import type { EmbedderInfo } from '../models/api.models';
+
+describe('EmbedderCapabilityService', () => {
+  let service: EmbedderCapabilityService;
+  let getEmbedders: ReturnType<typeof vi.fn>;
+
+  const infos: EmbedderInfo[] = [
+    { name: 'clip', media_type_id: 'image', supports_text: true },
+    { name: 'dino', media_type_id: 'image', supports_text: false, supports_patch_regions: true },
+    { name: 'sift', media_type_id: 'image', supports_text: false, supports_geometric_verification: true },
+    { name: 'e5', media_type_id: 'text' }, // supports_text undefined ⇒ treated as text-capable
+  ];
+
+  beforeEach(() => {
+    getEmbedders = vi.fn((): Observable<EmbedderInfo[]> => of(infos));
+    TestBed.configureTestingModule({
+      providers: [
+        EmbedderCapabilityService,
+        { provide: DatasetsListingsApiService, useValue: { getEmbedders } },
+      ],
+    });
+    service = TestBed.inject(EmbedderCapabilityService);
+  });
+
+  it('is unloaded until the registry resolves', () => {
+    expect(service.loaded).toBe(false);
+    expect(service.infos()).toBeNull();
+  });
+
+  it('defaults to text-supported before the registry loads', () => {
+    expect(service.supportsText('anything')).toBe(true);
+  });
+
+  it('ensureLoaded loads the registry once (idempotent)', () => {
+    service.ensureLoaded();
+    expect(service.loaded).toBe(true);
+    expect(service.infos()).toEqual(infos);
+    service.ensureLoaded();
+    expect(getEmbedders).toHaveBeenCalledTimes(1);
+  });
+
+  it('ensureLoaded on error still marks the registry loaded (empty)', () => {
+    getEmbedders.mockReturnValueOnce(new Observable<EmbedderInfo[]>((o) => o.error(new Error('500'))));
+    service.ensureLoaded();
+    expect(service.loaded).toBe(true);
+    expect(service.infos()).toEqual([]);
+  });
+
+  describe('once loaded', () => {
+    beforeEach(() => service.ensureLoaded());
+
+    it('supportsText is false only for a known vision-only embedder', () => {
+      expect(service.supportsText('dino')).toBe(false);
+      expect(service.supportsText('sift')).toBe(false);
+      expect(service.supportsText('clip')).toBe(true);
+      expect(service.supportsText('e5')).toBe(true);
+    });
+
+    it('supportsText defaults to true for empty or unrecognised names', () => {
+      expect(service.supportsText('')).toBe(true);
+      expect(service.supportsText('mystery')).toBe(true);
+    });
+
+    it('supportsTextAny is true if any name is text-capable', () => {
+      expect(service.supportsTextAny(['dino', 'clip'])).toBe(true);
+      expect(service.supportsTextAny(['dino', 'sift'])).toBe(false);
+      expect(service.supportsTextAny([])).toBe(true);
+      expect(service.supportsTextAny(null)).toBe(true);
+    });
+
+    it('classifies embedders by the backend precedence', () => {
+      expect(service.embedderType('sift')).toBe('structural');
+      expect(service.embedderType('dino')).toBe('patch_semantic');
+      expect(service.embedderType('clip')).toBe('semantic');
+      expect(service.embedderType('e5')).toBe('semantic');
+      expect(service.embedderType('mystery')).toBe('');
+    });
+
+    it('suppliedTypes returns the distinct types in display order', () => {
+      expect(service.suppliedTypes(['sift', 'clip', 'dino'])).toEqual([
+        'semantic',
+        'patch_semantic',
+        'structural',
+      ]);
+      expect(service.suppliedTypes(['clip', 'e5'])).toEqual(['semantic']);
+      expect(service.suppliedTypes(null)).toEqual([]);
+    });
+
+    it('firstOfType returns the first bound embedder of a type, else empty', () => {
+      expect(service.firstOfType(['clip', 'e5'], 'semantic')).toBe('clip');
+      expect(service.firstOfType(['clip'], 'structural')).toBe('');
+      expect(service.firstOfType(['clip'], '')).toBe('');
+      expect(service.firstOfType(null, 'semantic')).toBe('');
+    });
+
+    it('supportsRegionOverlayAny covers patch-region and structural embedders', () => {
+      expect(service.supportsRegionOverlayAny(['dino'])).toBe(true);
+      expect(service.supportsRegionOverlayAny(['sift'])).toBe(true);
+      expect(service.supportsRegionOverlayAny(['clip'])).toBe(false);
+      expect(service.supportsRegionOverlayAny(null)).toBe(false);
+    });
+
+    it('supportsStructuralAny is true only for a structural embedder', () => {
+      expect(service.supportsStructuralAny(['sift'])).toBe(true);
+      expect(service.supportsStructuralAny(['dino', 'clip'])).toBe(false);
+      expect(service.supportsStructuralAny(null)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/app/services/labelset-state.service.spec.ts
+++ b/frontend/src/app/services/labelset-state.service.spec.ts
@@ -1,0 +1,149 @@
+import { TestBed } from '@angular/core/testing';
+import { Observable, Subject, of } from 'rxjs';
+import { LabelsetStateService } from './labelset-state.service';
+import { DetectorsCrudApiService } from './detectors-crud-api.service';
+import type { DetectorLabelView } from '../generated/api-client/models/detector-label-view';
+import type { DetectorLabelsDetailResponse } from '../generated/api-client/models/detector-labels-detail-response';
+
+describe('LabelsetStateService', () => {
+  let service: LabelsetStateService;
+  let getLabelsDetail: ReturnType<typeof vi.fn>;
+  let voteLabelElement: ReturnType<typeof vi.fn>;
+  let response: DetectorLabelsDetailResponse;
+
+  function view(id: string, label: 'good' | 'bad'): DetectorLabelView {
+    return { id, label } as DetectorLabelView;
+  }
+
+  beforeEach(() => {
+    response = { good: [], bad: [], media_type: '' } as DetectorLabelsDetailResponse;
+    getLabelsDetail = vi.fn((): Observable<DetectorLabelsDetailResponse> => of(response));
+    voteLabelElement = vi.fn(() => of({})); // resolves synchronously by default
+    TestBed.configureTestingModule({
+      providers: [
+        LabelsetStateService,
+        { provide: DetectorsCrudApiService, useValue: { getLabelsDetail, voteLabelElement } },
+      ],
+    });
+    service = TestBed.inject(LabelsetStateService);
+  });
+
+  it('starts empty', () => {
+    expect(service.good).toEqual([]);
+    expect(service.bad).toEqual([]);
+  });
+
+  it('setModel(name) fetches and populates good / bad / media type', () => {
+    response = { good: [view('a', 'good')], bad: [view('b', 'bad')], media_type: 'audio' };
+    service.setModel('m1');
+    expect(getLabelsDetail).toHaveBeenCalledWith('m1');
+    expect(service.good).toEqual([view('a', 'good')]);
+    expect(service.bad).toEqual([view('b', 'bad')]);
+  });
+
+  it('setModel(null) clears the labelset without fetching', () => {
+    response = { good: [view('a', 'good')], bad: [], media_type: 'audio' };
+    service.setModel('m1');
+    getLabelsDetail.mockClear();
+
+    service.setModel(null);
+    expect(service.good).toEqual([]);
+    expect(service.bad).toEqual([]);
+    expect(getLabelsDetail).not.toHaveBeenCalled();
+  });
+
+  it('setting the same model twice does not refetch', () => {
+    service.setModel('m1');
+    getLabelsDetail.mockClear();
+    service.setModel('m1');
+    expect(getLabelsDetail).not.toHaveBeenCalled();
+  });
+
+  it('vote is a no-op when no model is set', () => {
+    service.vote('a', 'good');
+    expect(voteLabelElement).not.toHaveBeenCalled();
+  });
+
+  it('re-voting an element in its current direction sends target "remove"', () => {
+    response = { good: [view('a', 'good')], bad: [], media_type: 'audio' };
+    service.setModel('m1');
+    // Pending vote so the follow-up refresh does not overwrite optimistic state.
+    voteLabelElement.mockReturnValueOnce(new Subject());
+
+    service.vote('a', 'good');
+    expect(voteLabelElement).toHaveBeenCalledWith('m1', 'a', 'remove');
+    // Optimistically removed from both lists.
+    expect(service.good).toEqual([]);
+    expect(service.bad).toEqual([]);
+  });
+
+  it('voting the opposite direction flips the element and sends the clicked target', () => {
+    response = { good: [view('a', 'good')], bad: [], media_type: 'audio' };
+    service.setModel('m1');
+    voteLabelElement.mockReturnValueOnce(new Subject());
+
+    service.vote('a', 'bad');
+    expect(voteLabelElement).toHaveBeenCalledWith('m1', 'a', 'bad');
+    expect(service.good).toEqual([]);
+    expect(service.bad).toEqual([{ id: 'a', label: 'bad' }]);
+  });
+
+  it('a successful vote triggers a refresh', () => {
+    service.setModel('m1');
+    getLabelsDetail.mockClear();
+    response = { good: [view('a', 'good')], bad: [], media_type: 'audio' };
+
+    service.vote('a', 'good');
+    // voteLabelElement resolves synchronously (of({})) → refresh runs.
+    expect(getLabelsDetail).toHaveBeenCalledWith('m1');
+  });
+
+  it('startPolling fetches on an interval; stopPolling halts it', async () => {
+    vi.useFakeTimers();
+    try {
+      service.setModel('m1');
+      getLabelsDetail.mockClear();
+
+      service.startPolling(1500);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(getLabelsDetail).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(getLabelsDetail).toHaveBeenCalledTimes(2);
+
+      service.stopPolling();
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(getLabelsDetail).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('startPolling is idempotent while already polling', async () => {
+    vi.useFakeTimers();
+    try {
+      service.setModel('m1');
+      getLabelsDetail.mockClear();
+
+      service.startPolling(1500);
+      service.startPolling(1500);
+      await vi.advanceTimersByTimeAsync(0);
+      // A second loop would have doubled the fetches.
+      expect(getLabelsDetail).toHaveBeenCalledTimes(1);
+      service.stopPolling();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a fetch error leaves the current labelset intact', () => {
+    response = { good: [view('a', 'good')], bad: [], media_type: 'audio' };
+    service.setModel('m1');
+    getLabelsDetail.mockReturnValueOnce(
+      new Observable<DetectorLabelsDetailResponse>((o) => o.error(new Error('500'))),
+    );
+
+    service.refresh();
+    expect(service.good).toEqual([view('a', 'good')]);
+  });
+});

--- a/frontend/src/app/services/labelset-state.service.spec.ts
+++ b/frontend/src/app/services/labelset-state.service.spec.ts
@@ -18,7 +18,8 @@ describe('LabelsetStateService', () => {
   beforeEach(() => {
     response = { good: [], bad: [], media_type: '' } as DetectorLabelsDetailResponse;
     getLabelsDetail = vi.fn((): Observable<DetectorLabelsDetailResponse> => of(response));
-    voteLabelElement = vi.fn(() => of({})); // resolves synchronously by default
+    // Resolves synchronously by default; some tests swap in a pending Subject.
+    voteLabelElement = vi.fn((): Observable<unknown> => of({}));
     TestBed.configureTestingModule({
       providers: [
         LabelsetStateService,
@@ -68,7 +69,7 @@ describe('LabelsetStateService', () => {
     response = { good: [view('a', 'good')], bad: [], media_type: 'audio' };
     service.setModel('m1');
     // Pending vote so the follow-up refresh does not overwrite optimistic state.
-    voteLabelElement.mockReturnValueOnce(new Subject());
+    voteLabelElement.mockReturnValueOnce(new Subject<unknown>());
 
     service.vote('a', 'good');
     expect(voteLabelElement).toHaveBeenCalledWith('m1', 'a', 'remove');
@@ -80,7 +81,7 @@ describe('LabelsetStateService', () => {
   it('voting the opposite direction flips the element and sends the clicked target', () => {
     response = { good: [view('a', 'good')], bad: [], media_type: 'audio' };
     service.setModel('m1');
-    voteLabelElement.mockReturnValueOnce(new Subject());
+    voteLabelElement.mockReturnValueOnce(new Subject<unknown>());
 
     service.vote('a', 'bad');
     expect(voteLabelElement).toHaveBeenCalledWith('m1', 'a', 'bad');

--- a/frontend/src/app/services/media-metadata-cache.service.spec.ts
+++ b/frontend/src/app/services/media-metadata-cache.service.spec.ts
@@ -1,0 +1,190 @@
+import { TestBed } from '@angular/core/testing';
+import { Observable, of } from 'rxjs';
+import { MediaMetadataCacheService } from './media-metadata-cache.service';
+import { MediasApiService } from './medias-api.service';
+import { ActiveContextService } from './active-context.service';
+import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+
+describe('MediaMetadataCacheService', () => {
+  let service: MediaMetadataCacheService;
+  let getMediasBatch: ReturnType<typeof vi.fn>;
+  let datasetId: string;
+
+  function media(id: number): MediaBatchResponse {
+    return {
+      id,
+      filename: `f${id}`,
+      md5: `m${id}`,
+      media_type: 'image',
+      custom_metadata: {},
+    } as MediaBatchResponse;
+  }
+
+  function items(ids: number[]): MediaBatchResponse[] {
+    return ids.map(media);
+  }
+
+  beforeEach(() => {
+    datasetId = 'ds1';
+    getMediasBatch = vi.fn((ids: number[]): Observable<MediaBatchResponse[]> => of(items(ids)));
+    const activeContextStub = {
+      get datasetId() {
+        return datasetId;
+      },
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        MediaMetadataCacheService,
+        { provide: MediasApiService, useValue: { getMediasBatch } },
+        { provide: ActiveContextService, useValue: activeContextStub },
+      ],
+    });
+    service = TestBed.inject(MediaMetadataCacheService);
+  });
+
+  it('starts empty', () => {
+    expect(service.size).toBe(0);
+    expect(service.get(1)).toBeUndefined();
+    expect(service.has(1)).toBe(false);
+  });
+
+  it('ensureLoaded batches a request and caches the results', async () => {
+    vi.useFakeTimers();
+    try {
+      service.ensureLoaded([1, 2]);
+      // Nothing fetched until the coalescing microtask fires.
+      expect(getMediasBatch).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(getMediasBatch).toHaveBeenCalledTimes(1);
+      expect(getMediasBatch).toHaveBeenCalledWith([1, 2]);
+      expect(service.has(1)).toBe(true);
+      expect(service.get(2)).toEqual(media(2));
+      expect(service.size).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces rapid consecutive ensureLoaded calls into a single batch', async () => {
+    vi.useFakeTimers();
+    try {
+      service.ensureLoaded([1]);
+      service.ensureLoaded([2, 3]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(getMediasBatch).toHaveBeenCalledTimes(1);
+      expect(getMediasBatch).toHaveBeenCalledWith([1, 2, 3]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('skips already-cached ids on the next ensureLoaded', async () => {
+    vi.useFakeTimers();
+    try {
+      service.ensureLoaded([1, 2]);
+      await vi.advanceTimersByTimeAsync(0);
+      getMediasBatch.mockClear();
+
+      service.ensureLoaded([2, 3]);
+      await vi.advanceTimersByTimeAsync(0);
+      // Only id 3 is new.
+      expect(getMediasBatch).toHaveBeenCalledWith([3]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does nothing when every requested id is already cached', async () => {
+    vi.useFakeTimers();
+    try {
+      service.ensureLoaded([1]);
+      await vi.advanceTimersByTimeAsync(0);
+      getMediasBatch.mockClear();
+
+      service.ensureLoaded([1]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(getMediasBatch).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('bumps version$ on each batch arrival', async () => {
+    vi.useFakeTimers();
+    try {
+      const versions: number[] = [];
+      service.version$.subscribe((v) => versions.push(v));
+      service.ensureLoaded([1]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(versions[versions.length - 1]).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('toMediaItems returns cached entries and omits unknown ids', async () => {
+    vi.useFakeTimers();
+    try {
+      service.ensureLoaded([1, 2]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(service.toMediaItems([1, 99, 2])).toEqual([media(1), media(2)]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keys cache entries per dataset so a switch never returns the wrong metadata', async () => {
+    vi.useFakeTimers();
+    try {
+      service.ensureLoaded([1]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(service.get(1)).toEqual(media(1));
+
+      datasetId = 'ds2';
+      expect(service.get(1)).toBeUndefined();
+      expect(service.has(1)).toBe(false);
+
+      datasetId = 'ds1';
+      expect(service.get(1)).toEqual(media(1));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clear empties the cache and resets the version', async () => {
+    vi.useFakeTimers();
+    try {
+      const versions: number[] = [];
+      service.version$.subscribe((v) => versions.push(v));
+      service.ensureLoaded([1]);
+      await vi.advanceTimersByTimeAsync(0);
+
+      service.clear();
+      expect(service.size).toBe(0);
+      expect(service.get(1)).toBeUndefined();
+      expect(versions[versions.length - 1]).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-queues ids after a failed batch and retries on the next ensureLoaded', async () => {
+    vi.useFakeTimers();
+    try {
+      getMediasBatch.mockReturnValueOnce(
+        new Observable<MediaBatchResponse[]>((o) => o.error(new Error('500'))),
+      );
+      service.ensureLoaded([1]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(service.has(1)).toBe(false);
+
+      // A later request re-drives the fetch; this time it succeeds.
+      service.ensureLoaded([1]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(service.has(1)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/app/services/new-thing-flows.service.spec.ts
+++ b/frontend/src/app/services/new-thing-flows.service.spec.ts
@@ -1,0 +1,124 @@
+import { TestBed } from '@angular/core/testing';
+import { NewThingFlowsService } from './new-thing-flows.service';
+import { DemoDatasetEntry } from '../generated/api-client/models/demo-dataset-entry';
+
+describe('NewThingFlowsService', () => {
+  let service: NewThingFlowsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [NewThingFlowsService] });
+    service = TestBed.inject(NewThingFlowsService);
+  });
+
+  it('both flows start closed', () => {
+    expect(service.importer.open).toBe(false);
+    expect(service.newDetector.open).toBe(false);
+  });
+
+  it('openImporter with no options defaults every field to empty', () => {
+    service.openImporter();
+    expect(service.importer).toEqual({
+      open: true,
+      initialTab: '',
+      guessedMediaType: '',
+      guessedMediaEmbedder: '',
+    });
+  });
+
+  it('openImporter carries the supplied guesses', () => {
+    service.openImporter({ initialTab: 'folder', guessedMediaType: 'audio', guessedMediaEmbedder: 'clap' });
+    expect(service.importer).toEqual({
+      open: true,
+      initialTab: 'folder',
+      guessedMediaType: 'audio',
+      guessedMediaEmbedder: 'clap',
+    });
+  });
+
+  it('closeImporter resets every field', () => {
+    service.openImporter({ initialTab: 'folder' });
+    service.closeImporter();
+    expect(service.importer).toEqual({
+      open: false,
+      initialTab: '',
+      guessedMediaType: '',
+      guessedMediaEmbedder: '',
+    });
+  });
+
+  it('openNewDetector defaults optional seed fields to undefined', () => {
+    service.openNewDetector();
+    expect(service.newDetector).toEqual({
+      open: true,
+      defaultMediaType: '',
+      datasetEmbedder: '',
+      seedMediaId: undefined,
+      seedCropParams: undefined,
+    });
+  });
+
+  it('openNewDetector carries seed media + crop params', () => {
+    const seedCropParams = { box: [0, 0, 10, 10] };
+    service.openNewDetector({
+      defaultMediaType: 'image',
+      datasetEmbedder: 'siglip',
+      seedMediaId: 42,
+      seedCropParams,
+    });
+    expect(service.newDetector).toEqual({
+      open: true,
+      defaultMediaType: 'image',
+      datasetEmbedder: 'siglip',
+      seedMediaId: 42,
+      seedCropParams,
+    });
+  });
+
+  it('closeNewDetector resets every field', () => {
+    service.openNewDetector({ seedMediaId: 7 });
+    service.closeNewDetector();
+    expect(service.newDetector).toEqual({
+      open: false,
+      defaultMediaType: '',
+      datasetEmbedder: '',
+      seedMediaId: undefined,
+      seedCropParams: undefined,
+    });
+  });
+
+  it('emitDetectorCreated fires created$ with kind detector', () => {
+    const events: unknown[] = [];
+    service.created$.subscribe((e) => events.push(e));
+    service.emitDetectorCreated('det-9');
+    expect(events).toEqual([{ kind: 'detector', id: 'det-9' }]);
+  });
+
+  it('emitDatasetCreated fires created$ with kind dataset', () => {
+    const events: unknown[] = [];
+    service.created$.subscribe((e) => events.push(e));
+    service.emitDatasetCreated('ds-9');
+    expect(events).toEqual([{ kind: 'dataset', id: 'ds-9' }]);
+  });
+
+  it('emitImportStarted fires importStarted$', () => {
+    const fired = vi.fn();
+    service.importStarted$.subscribe(fired);
+    service.emitImportStarted();
+    expect(fired).toHaveBeenCalledTimes(1);
+  });
+
+  it('emitDemoSelected fires demoSelected$ with the demo entry', () => {
+    const demo = { name: 'gtzan' } as DemoDatasetEntry;
+    const events: unknown[] = [];
+    service.demoSelected$.subscribe((e) => events.push(e));
+    service.emitDemoSelected(demo);
+    expect(events).toEqual([{ demo }]);
+  });
+
+  it('created$ is a plain Subject: late subscribers miss prior emissions', () => {
+    service.emitDetectorCreated('early');
+    const events: unknown[] = [];
+    service.created$.subscribe((e) => events.push(e));
+    expect(events).toEqual([]);
+  });
+});

--- a/frontend/src/app/services/running-jobs.service.spec.ts
+++ b/frontend/src/app/services/running-jobs.service.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { Subscription } from 'rxjs';
+import { RunningJobsService, pairKey } from './running-jobs.service';
+
+describe('pairKey', () => {
+  it('joins dataset and detector ids with a stable separator', () => {
+    expect(pairKey('ds', 'det')).toBe('ds::det');
+  });
+});
+
+describe('RunningJobsService', () => {
+  let service: RunningJobsService;
+  let httpMock: HttpTestingController;
+  const subs: Subscription[] = [];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(RunningJobsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    subs.forEach((s) => s.unsubscribe());
+    subs.length = 0;
+    httpMock.verify();
+  });
+
+  it('isBusy short-circuits to false for a half pair without polling', () => {
+    let value: boolean | undefined;
+    subs.push(service.isBusy('', 'det').subscribe((v) => (value = v)));
+    expect(value).toBe(false);
+    httpMock.expectNone('/api/jobs/active');
+  });
+
+  it('polls /api/jobs/active on first subscription and exposes busy pairs', async () => {
+    vi.useFakeTimers();
+    try {
+      let latest = new Map<string, string[]>();
+      subs.push(service.busyPairs$.subscribe((m) => (latest = m)));
+
+      await vi.advanceTimersByTimeAsync(0);
+      const req = httpMock.expectOne('/api/jobs/active');
+      expect(req.request.method).toBe('GET');
+      req.flush({ busy_pairs: [{ dataset_id: 'd', detector_id: 'x', job_types: ['eval'] }] });
+
+      expect(latest.get(pairKey('d', 'x'))).toEqual(['eval']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('isBusy reflects whether the pair has a running job', async () => {
+    vi.useFakeTimers();
+    try {
+      const seen: boolean[] = [];
+      subs.push(service.isBusy('d', 'x').subscribe((v) => seen.push(v)));
+
+      await vi.advanceTimersByTimeAsync(0);
+      httpMock
+        .expectOne('/api/jobs/active')
+        .flush({ busy_pairs: [{ dataset_id: 'd', detector_id: 'x', job_types: ['eval'] }] });
+
+      expect(seen[seen.length - 1]).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-polls on each interval tick', async () => {
+    vi.useFakeTimers();
+    try {
+      subs.push(service.busyPairs$.subscribe());
+
+      await vi.advanceTimersByTimeAsync(0);
+      httpMock.expectOne('/api/jobs/active').flush({ busy_pairs: [] });
+
+      await vi.advanceTimersByTimeAsync(5000);
+      httpMock.expectOne('/api/jobs/active').flush({ busy_pairs: [] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops polling and clears state once the last observer unsubscribes', async () => {
+    vi.useFakeTimers();
+    try {
+      let latest = new Map<string, string[]>();
+      const sub = service.busyPairs$.subscribe((m) => (latest = m));
+
+      await vi.advanceTimersByTimeAsync(0);
+      httpMock
+        .expectOne('/api/jobs/active')
+        .flush({ busy_pairs: [{ dataset_id: 'd', detector_id: 'x', job_types: ['eval'] }] });
+      expect(latest.size).toBe(1);
+
+      sub.unsubscribe();
+      // A later resubscriber must not see stale data before its first poll.
+      let resubscribed = new Map<string, string[]>();
+      subs.push(service.busyPairs$.subscribe((m) => (resubscribed = m)));
+      expect(resubscribed.size).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(0);
+      httpMock.expectOne('/api/jobs/active').flush({ busy_pairs: [] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('survives a transient poll failure and keeps polling', async () => {
+    vi.useFakeTimers();
+    try {
+      let latest = new Map<string, string[]>();
+      subs.push(service.busyPairs$.subscribe((m) => (latest = m)));
+
+      await vi.advanceTimersByTimeAsync(0);
+      httpMock.expectOne('/api/jobs/active').flush('boom', { status: 500, statusText: 'Server Error' });
+      // The error path emits an empty payload (clears stale spinners).
+      expect(latest.size).toBe(0);
+
+      // The pipeline is intact: the next tick still polls.
+      await vi.advanceTimersByTimeAsync(5000);
+      httpMock
+        .expectOne('/api/jobs/active')
+        .flush({ busy_pairs: [{ dataset_id: 'd', detector_id: 'x', job_types: [] }] });
+      expect(latest.size).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/app/services/tile-cache.service.spec.ts
+++ b/frontend/src/app/services/tile-cache.service.spec.ts
@@ -1,0 +1,136 @@
+import { TestBed } from '@angular/core/testing';
+import { Observable, Subject, of } from 'rxjs';
+import { TileCacheService } from './tile-cache.service';
+import { ProjectionApiService } from './projection-api.service';
+import type { TilePayload } from '../models/projection.models';
+
+describe('TileCacheService', () => {
+  let service: TileCacheService;
+  let getTile: ReturnType<typeof vi.fn>;
+
+  function payload(level: number, tx: number, ty: number): TilePayload {
+    return { level, tx, ty, cells: [] };
+  }
+
+  beforeEach(() => {
+    getTile = vi.fn((level: number, tx: number, ty: number): Observable<TilePayload> =>
+      of(payload(level, tx, ty)),
+    );
+    TestBed.configureTestingModule({
+      providers: [TileCacheService, { provide: ProjectionApiService, useValue: { getTile } }],
+    });
+    service = TestBed.inject(TileCacheService);
+  });
+
+  it('getTile returns null before a projection id is set', () => {
+    expect(service.getTile(0, 0, 0)).toBeNull();
+  });
+
+  it('fetches a tile once, then serves it from cache without re-hitting the API', () => {
+    service.setProjectionId('p1');
+
+    let first: TilePayload | undefined;
+    service.getTile(2, 1, 1)?.subscribe((t) => (first = t));
+    expect(first).toEqual(payload(2, 1, 1));
+    expect(getTile).toHaveBeenCalledTimes(1);
+
+    let second: TilePayload | undefined;
+    service.getTile(2, 1, 1)?.subscribe((t) => (second = t));
+    expect(second).toEqual(payload(2, 1, 1));
+    // Still one call: the second read hit the cache.
+    expect(getTile).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the subset flag and cache token through to the API', () => {
+    service.setProjectionId('proj-9');
+    service.setContentVersion(4);
+    service.setSubset(true);
+    service.getTile(1, 0, 0)?.subscribe();
+    expect(getTile).toHaveBeenCalledWith(1, 0, 0, true, 'proj-9:4');
+  });
+
+  it('dedupes concurrent in-flight requests for the same tile', () => {
+    const pending = new Subject<TilePayload>();
+    getTile.mockReturnValueOnce(pending.asObservable());
+    service.setProjectionId('p1');
+
+    const a = service.getTile(5, 2, 2);
+    const b = service.getTile(5, 2, 2);
+    expect(a).toBe(b);
+    expect(getTile).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers from a tile fetch error by emitting an empty tile', () => {
+    getTile.mockReturnValueOnce(new Observable<TilePayload>((o) => o.error(new Error('404'))));
+    service.setProjectionId('p1');
+
+    let got: TilePayload | undefined;
+    service.getTile(3, 7, 8)?.subscribe((t) => (got = t));
+    expect(got).toEqual({ level: 3, tx: 7, ty: 8, cells: [] });
+  });
+
+  it('changing the projection id clears the cache', () => {
+    service.setProjectionId('p1');
+    service.getTile(2, 1, 1)?.subscribe();
+    expect(service.getCached(2, 1, 1)).not.toBeNull();
+
+    service.setProjectionId('p2');
+    expect(service.getCached(2, 1, 1)).toBeNull();
+  });
+
+  it('setContentVersion re-keys entries so a stale version misses', () => {
+    service.setProjectionId('p1');
+    service.getTile(2, 1, 1)?.subscribe();
+    expect(service.getCached(2, 1, 1)).not.toBeNull();
+
+    service.setContentVersion(9);
+    // Same layout, different membership version → prior tile is unreachable.
+    expect(service.getCached(2, 1, 1)).toBeNull();
+  });
+
+  it('getCached returns null for an uncached tile and the tile once cached', () => {
+    service.setProjectionId('p1');
+    expect(service.getCached(4, 0, 0)).toBeNull();
+    service.getTile(4, 0, 0)?.subscribe();
+    expect(service.getCached(4, 0, 0)).toEqual(payload(4, 0, 0));
+  });
+
+  it('prefetch warms the cache and is a no-op when already cached', () => {
+    service.setProjectionId('p1');
+    service.prefetch(1, 0, 0);
+    expect(getTile).toHaveBeenCalledTimes(1);
+    service.prefetch(1, 0, 0);
+    expect(getTile).toHaveBeenCalledTimes(1);
+  });
+
+  it('clear resets the cache and requires a new projection id', () => {
+    service.setProjectionId('p1');
+    service.getTile(2, 1, 1)?.subscribe();
+    service.clear();
+    expect(service.getCached(2, 1, 1)).toBeNull();
+    expect(service.getTile(2, 1, 1)).toBeNull();
+  });
+
+  it('emits loaded tiles on tileLoaded$', () => {
+    const loaded: TilePayload[] = [];
+    service.tileLoaded$.subscribe((t) => loaded.push(t));
+    service.setProjectionId('p1');
+    service.getTile(2, 3, 4)?.subscribe();
+    expect(loaded).toEqual([payload(2, 3, 4)]);
+  });
+
+  it('evicts coarse-but-unpinned tiles under memory pressure while keeping pinned levels', () => {
+    service.setProjectionId('p1');
+    // Pinned coarse tiles (levels 0..2) must survive eviction.
+    for (let tx = 0; tx < 4; tx++) service.getTile(0, tx, 0)?.subscribe();
+    // Overfill with evictable level-4 tiles to trip the LRU sweep.
+    for (let tx = 0; tx < 2200; tx++) service.getTile(4, tx, 0)?.subscribe();
+
+    // Every pinned tile is still resident.
+    for (let tx = 0; tx < 4; tx++) {
+      expect(service.getCached(0, tx, 0)).not.toBeNull();
+    }
+    // The earliest evictable tiles were dropped to stay under budget.
+    expect(service.getCached(4, 0, 0)).toBeNull();
+  });
+});

--- a/frontend/src/app/services/toast.service.spec.ts
+++ b/frontend/src/app/services/toast.service.spec.ts
@@ -1,0 +1,179 @@
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import { ErrorContext, Toast, ToastService } from './toast.service';
+import { ProgressEventsService } from './progress-events.service';
+import { LoadingTask } from '../models/api.models';
+
+describe('ToastService', () => {
+  let service: ToastService;
+  let loadingTasks$: Subject<LoadingTask[]>;
+  let detectorLoadingTasks$: Subject<LoadingTask[]>;
+
+  function task(overrides: Partial<LoadingTask>): LoadingTask {
+    return {
+      status: 'idle',
+      message: '',
+      current: 0,
+      total: 0,
+      task_id: 't',
+      name: 'n',
+      created_at: 0,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    loadingTasks$ = new Subject<LoadingTask[]>();
+    detectorLoadingTasks$ = new Subject<LoadingTask[]>();
+    TestBed.configureTestingModule({
+      providers: [
+        ToastService,
+        { provide: ProgressEventsService, useValue: { loadingTasks$, detectorLoadingTasks$ } },
+      ],
+    });
+    service = TestBed.inject(ToastService);
+  });
+
+  it('starts with no toasts', () => {
+    expect(service.toasts).toEqual([]);
+  });
+
+  it('error() pushes an error toast and returns its id', () => {
+    const id = service.error({ message: 'boom' });
+    expect(service.toasts.length).toBe(1);
+    const toast = service.toasts[0];
+    expect(toast.id).toBe(id);
+    expect(toast.level).toBe('error');
+    expect(toast.message).toBe('boom');
+    expect(toast.timestamp).toBeTruthy();
+  });
+
+  it('assigns increasing ids to successive toasts', () => {
+    const a = service.error({ message: 'a' });
+    const b = service.error({ message: 'b' });
+    expect(b).toBeGreaterThan(a);
+  });
+
+  it('success() auto-dismisses after the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      service.success({ message: 'saved' });
+      expect(service.toasts.length).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(4999);
+      expect(service.toasts.length).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(service.toasts.length).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dedupKey replaces the existing toast instead of stacking', () => {
+    service.error({ message: 'first', dedupKey: 'k' });
+    service.error({ message: 'second', dedupKey: 'k' });
+    expect(service.toasts.length).toBe(1);
+    expect(service.toasts[0].message).toBe('second');
+  });
+
+  it('caps the stack at MAX_TOASTS, dropping the oldest', () => {
+    for (let i = 0; i < 7; i++) service.error({ message: `m${i}` });
+    expect(service.toasts.length).toBe(5);
+    // m0 and m1 were shifted off the front; m2..m6 remain.
+    expect(service.toasts.map((t) => t.message)).toEqual(['m2', 'm3', 'm4', 'm5', 'm6']);
+  });
+
+  it('dismiss() removes only the matching toast', () => {
+    const a = service.error({ message: 'a' });
+    service.error({ message: 'b' });
+    service.dismiss(a);
+    expect(service.toasts.map((t) => t.message)).toEqual(['b']);
+  });
+
+  it('dismiss() of an unknown id is a no-op (no re-emit)', () => {
+    service.error({ message: 'a' });
+    let emissions = 0;
+    service.toasts$.subscribe(() => emissions++);
+    emissions = 0; // ignore the initial BehaviorSubject replay
+    service.dismiss(9999);
+    expect(emissions).toBe(0);
+    expect(service.toasts.length).toBe(1);
+  });
+
+  it('dismissAll() clears everything', () => {
+    service.error({ message: 'a' });
+    service.error({ message: 'b' });
+    service.dismissAll();
+    expect(service.toasts).toEqual([]);
+  });
+
+  it('routes an SSE dataset-load failure to a deduped error toast', () => {
+    loadingTasks$.next([task({ task_id: 'x', status: 'idle', error: 'disk full', name: 'MyData' })]);
+    expect(service.toasts.length).toBe(1);
+    expect(service.toasts[0].message).toBe('Dataset load failed');
+    expect(service.toasts[0].detail).toBe('MyData: disk full');
+  });
+
+  it('routes an SSE detector-load failure with the detector wording', () => {
+    detectorLoadingTasks$.next([task({ task_id: 'y', status: 'idle', error: 'oom', name: 'Det' })]);
+    expect(service.toasts.length).toBe(1);
+    expect(service.toasts[0].message).toBe('Detector load failed');
+  });
+
+  it('does not re-toast the same failed task_id twice', () => {
+    loadingTasks$.next([task({ task_id: 'x', error: 'e1' })]);
+    loadingTasks$.next([task({ task_id: 'x', error: 'e1' })]);
+    expect(service.toasts.length).toBe(1);
+  });
+
+  it('ignores cancelled and non-idle tasks', () => {
+    loadingTasks$.next([task({ task_id: 'a', status: 'running', error: 'e' })]);
+    loadingTasks$.next([task({ task_id: 'b', status: 'idle', error: 'Cancelled' })]);
+    loadingTasks$.next([task({ task_id: 'c', status: 'idle', error: undefined })]);
+    expect(service.toasts.length).toBe(0);
+  });
+
+  it('formatForClipboard includes headline and full HTTP context', () => {
+    const errorContext: ErrorContext = {
+      message: 'Request failed',
+      status: 500,
+      statusText: 'Server Error',
+      method: 'POST',
+      url: '/api/thing',
+      requestId: 'req-1',
+      datasetId: 'ds-1',
+      detectorId: 'det-1',
+      extra: { foo: 'bar' },
+      rawBody: '{"err":true}',
+      timestamp: '2026-01-01T00:00:00Z',
+    };
+    const toast: Toast = {
+      id: 1,
+      level: 'error',
+      message: 'Request failed',
+      detail: 'something broke',
+      errorContext,
+      timestamp: '2026-01-01T00:00:00Z',
+    };
+    const md = service.formatForClipboard(toast);
+    expect(md).toContain('**VTSearch error**');
+    expect(md).toContain('**Message:** Request failed');
+    expect(md).toContain('**Detail:** something broke');
+    expect(md).toContain('**Status:** 500 Server Error');
+    expect(md).toContain('**Endpoint:** `POST /api/thing`');
+    expect(md).toContain('**Request ID:** `req-1`');
+    expect(md).toContain('**Dataset:** `ds-1`');
+    expect(md).toContain('**Detector:** `det-1`');
+    expect(md).toContain('"foo": "bar"');
+    expect(md).toContain('{"err":true}');
+  });
+
+  it('formatForClipboard for a plain toast carries only the headline', () => {
+    const toast: Toast = { id: 1, level: 'error', message: 'plain', timestamp: '2026-01-01T00:00:00Z' };
+    const md = service.formatForClipboard(toast);
+    expect(md).toContain('**Message:** plain');
+    expect(md).not.toContain('**Status:**');
+    expect(md).not.toContain('**Endpoint:**');
+  });
+});


### PR DESCRIPTION
Adds unit test coverage for the nine untested singleton services flagged in #2420.

## What's covered

| Service | Focus of the spec |
|---|---|
| `toast.service.ts` | push/dedup/`MAX_TOASTS` eviction, dismiss(All), success auto-dismiss timer, SSE task-error routing (dataset vs detector, dedup, cancelled/non-idle skip), `formatForClipboard` with and without `ErrorContext` |
| `dashboard-modals.service.ts` | every open/close pair, initial closed state, payload carriage, stream emission |
| `media-metadata-cache.service.ts` | batch coalescing, already-cached skipping, `version$` bumps, `toMediaItems` filtering, **per-dataset keying** (no cross-dataset leakage), `clear`, failed-batch re-queue + retry |
| `tile-cache.service.ts` | fetch-once-then-cache, subset/cache-token passthrough, in-flight dedup, error → empty tile, projection-id/content-version invalidation, `prefetch`, `clear`, LRU eviction that keeps pinned coarse levels |
| `detectors-crud-api.service.ts` | `HttpTestingController` assertions for every endpoint (list/create/get/delete/rename/examples/labels/vote/combine/portable-bundle) plus the `mediaUrl`-routed preview/thumbnail URL builders |
| `new-thing-flows.service.ts` | importer + new-detector open/close defaults & option carriage, all `emit*` event streams |
| `running-jobs.service.ts` | `pairKey`, `isBusy` half-pair short-circuit, lazy poll on first subscribe, interval re-poll, stop + state clear on last unsubscribe, transient-failure resilience |
| `labelset-state.service.ts` | `setModel` fetch/clear/no-op-on-same, optimistic vote (remove vs flip target), refresh-on-success, polling start/stop/idempotence, error leaves state intact |
| `embedder-capability.service.ts` | unloaded defaults, idempotent `ensureLoaded`, error-still-loaded, `supportsText`/`supportsTextAny`/`embedderType`/`suppliedTypes`/`firstOfType`/`supportsRegionOverlayAny`/`supportsStructuralAny` |

The API-service spec copies the established `HttpTestingController` pattern; timer-driven services (caches, polling) use Vitest fake timers (`vi.useFakeTimers` / `advanceTimersByTimeAsync`) since the frontend runs zoneless with no `fakeAsync`/`tick`.

## Testing

`./run-tests.sh frontend` passes — 1272 frontend unit tests green, TypeScript build + audit clean.

Closes #2420

🤖 Generated with [Claude Code](https://claude.com/claude-code)