### PR TITLE
Extract + unit-test browse-canvas pure logic

### DIFF
--- a/frontend/src/app/components/browse-canvas/bin-geometry.spec.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.spec.ts
@@ -95,8 +95,10 @@ describe('bin-geometry', () => {
 
   // A minimal stand-in for the 2D context, recording the path calls traceCell
   // makes so we can assert disc-vs-hex / roundRect-vs-rect without a real canvas.
+  // The vi.fn() mocks keep their `.mock` type; `ctx` is the cast passed to
+  // traceCell (which wants a full CanvasRenderingContext2D).
   function stubCtx() {
-    return {
+    const fns = {
       beginPath: vi.fn(),
       moveTo: vi.fn(),
       lineTo: vi.fn(),
@@ -104,36 +106,37 @@ describe('bin-geometry', () => {
       arc: vi.fn(),
       rect: vi.fn(),
       roundRect: vi.fn(),
-    } as unknown as CanvasRenderingContext2D & Record<string, ReturnType<typeof vi.fn>>;
+    };
+    return { ...fns, ctx: fns as unknown as CanvasRenderingContext2D };
   }
 
   describe('traceCell', () => {
     it('hex singleton draws a disc, pile draws a polygon', () => {
       const single = stubCtx();
-      hex.traceCell(single, 0, 0, 5, true);
+      hex.traceCell(single.ctx, 0, 0, 5, true);
       expect(single.arc).toHaveBeenCalledOnce();
 
       const pile = stubCtx();
-      hex.traceCell(pile, 0, 0, 5, false);
+      hex.traceCell(pile.ctx, 0, 0, 5, false);
       expect(pile.arc).not.toHaveBeenCalled();
       expect(pile.lineTo).toHaveBeenCalled();
     });
 
     it('square singleton uses roundRect, pile uses rect', () => {
       const single = stubCtx();
-      square.traceCell(single, 0, 0, 5, true);
+      square.traceCell(single.ctx, 0, 0, 5, true);
       expect(single.roundRect).toHaveBeenCalledOnce();
       expect(single.rect).not.toHaveBeenCalled();
 
       const pile = stubCtx();
-      square.traceCell(pile, 0, 0, 5, false);
+      square.traceCell(pile.ctx, 0, 0, 5, false);
       expect(pile.rect).toHaveBeenCalledOnce();
       expect(pile.roundRect).not.toHaveBeenCalled();
     });
 
     it('square cell has side radius·√3 centred on (cx, cy)', () => {
       const ctx = stubCtx();
-      square.traceCell(ctx, 10, 20, 5, false);
+      square.traceCell(ctx.ctx, 10, 20, 5, false);
       const [x, y, w, h] = ctx.rect.mock.calls[0];
       const side = 5 * SQRT3;
       expect(w).toBeCloseTo(side);

--- a/frontend/src/app/components/browse-canvas/bin-geometry.spec.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.spec.ts
@@ -170,12 +170,12 @@ describe('bin-geometry', () => {
     });
 
     it('honours the geometry shape for the contains check', () => {
-      // A point that is inside a square cell but outside the hex circle of the
-      // same radius: at (r·0.7, r·0.7) with r=5 → dist²=49.0 > 25 (outside hex),
-      // but |x|,|y| = 3.5 < half-side 4.33 (inside square).
+      // A point inside a square cell but outside the hex circle of the same
+      // radius: at (4, 4) with r=5 → dist²=32 > 25 (outside the hex circle), but
+      // |x|,|y| = 4 < half-side 4.33 (inside the square).
       const one = [{ cx: 0, cy: 0, id: 'a' }];
-      expect(pickCell(one, 3.5, 3.5, hex, 5)).toBeNull();
-      expect(pickCell(one, 3.5, 3.5, square, 5)?.id).toBe('a');
+      expect(pickCell(one, 4, 4, hex, 5)).toBeNull();
+      expect(pickCell(one, 4, 4, square, 5)?.id).toBe('a');
     });
   });
 

--- a/frontend/src/app/components/browse-canvas/bin-geometry.spec.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.spec.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  binGeometry,
+  hoverThumbHalfExtents,
+  pickCell,
+  SQRT3,
+  type BinGeometry,
+} from './bin-geometry';
+
+/**
+ * Unit coverage for the bin-shape geometry shared by the browse canvas and its
+ * minimap (see issue #2418). Covers both the hex and square `BinGeometry`
+ * implementations and the two pure hit-test / thumbnail-sizing helpers extracted
+ * from `browse-canvas.component.ts` (`pickCell`, `hoverThumbHalfExtents`).
+ */
+describe('bin-geometry', () => {
+  const hex = binGeometry('hex');
+  const square = binGeometry('square');
+
+  describe('binGeometry', () => {
+    it('selects the requested shape', () => {
+      expect(hex.shape).toBe('hex');
+      expect(square.shape).toBe('square');
+    });
+
+    it('defaults to hex for an unset or unknown shape', () => {
+      expect(binGeometry(undefined).shape).toBe('hex');
+    });
+  });
+
+  describe('cell spacing (dx / dy)', () => {
+    it('spaces hex columns by radius·√3 and rows by radius·1.5', () => {
+      expect(hex.dx(4)).toBeCloseTo(4 * SQRT3);
+      expect(hex.dy(4)).toBeCloseTo(4 * 1.5);
+    });
+
+    it('spaces square cells by radius·√3 on both axes', () => {
+      expect(square.dx(4)).toBeCloseTo(4 * SQRT3);
+      expect(square.dy(4)).toBeCloseTo(4 * SQRT3);
+    });
+  });
+
+  describe('contains (hit-test predicate)', () => {
+    it('hex: inside the circumscribed circle of radius', () => {
+      expect(hex.contains(0, 0, 5)).toBe(true);
+      expect(hex.contains(4.9, 0, 5)).toBe(true);
+      expect(hex.contains(5.1, 0, 5)).toBe(false);
+      // Just inside the circle on the diagonal.
+      expect(hex.contains(3, 3, 5)).toBe(true); // 3²+3²=18 < 25
+      expect(hex.contains(4, 4, 5)).toBe(false); // 32 > 25
+    });
+
+    it('square: inside the half-side box (side = radius·√3)', () => {
+      const half = (5 * SQRT3) / 2;
+      expect(square.contains(0, 0, 5)).toBe(true);
+      expect(square.contains(half - 0.01, half - 0.01, 5)).toBe(true);
+      expect(square.contains(half + 0.01, 0, 5)).toBe(false);
+      expect(square.contains(0, half + 0.01, 5)).toBe(false);
+    });
+  });
+
+  describe('singleCornerRadius', () => {
+    it('hex: the inscribed-disc radius (radius·√3/2)', () => {
+      expect(hex.singleCornerRadius(6)).toBeCloseTo((6 * SQRT3) / 2);
+    });
+
+    it('square: a fraction of the half-side', () => {
+      // Rounded-corner radius is smaller than the half-side it curves within.
+      const half = (6 * SQRT3) / 2;
+      expect(square.singleCornerRadius(6)).toBeGreaterThan(0);
+      expect(square.singleCornerRadius(6)).toBeLessThan(half);
+    });
+  });
+
+  describe('neighborOffsets', () => {
+    it('hex has six neighbours, all one centre-distance (√3·radius) away', () => {
+      const offs = hex.neighborOffsets();
+      expect(offs).toHaveLength(6);
+      for (const { dx, dy } of offs) {
+        // |(dx, dy)| in units of radius equals the centre-to-centre distance √3.
+        expect(Math.hypot(dx, dy)).toBeCloseTo(SQRT3);
+      }
+    });
+
+    it('square has four edge-adjacent neighbours (corners excluded)', () => {
+      const offs = square.neighborOffsets();
+      expect(offs).toHaveLength(4);
+      // Every neighbour is axis-aligned (one of dx/dy is zero).
+      for (const { dx, dy } of offs) {
+        expect(dx === 0 || dy === 0).toBe(true);
+      }
+    });
+  });
+
+  // A minimal stand-in for the 2D context, recording the path calls traceCell
+  // makes so we can assert disc-vs-hex / roundRect-vs-rect without a real canvas.
+  function stubCtx() {
+    return {
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      arc: vi.fn(),
+      rect: vi.fn(),
+      roundRect: vi.fn(),
+    } as unknown as CanvasRenderingContext2D & Record<string, ReturnType<typeof vi.fn>>;
+  }
+
+  describe('traceCell', () => {
+    it('hex singleton draws a disc, pile draws a polygon', () => {
+      const single = stubCtx();
+      hex.traceCell(single, 0, 0, 5, true);
+      expect(single.arc).toHaveBeenCalledOnce();
+
+      const pile = stubCtx();
+      hex.traceCell(pile, 0, 0, 5, false);
+      expect(pile.arc).not.toHaveBeenCalled();
+      expect(pile.lineTo).toHaveBeenCalled();
+    });
+
+    it('square singleton uses roundRect, pile uses rect', () => {
+      const single = stubCtx();
+      square.traceCell(single, 0, 0, 5, true);
+      expect(single.roundRect).toHaveBeenCalledOnce();
+      expect(single.rect).not.toHaveBeenCalled();
+
+      const pile = stubCtx();
+      square.traceCell(pile, 0, 0, 5, false);
+      expect(pile.rect).toHaveBeenCalledOnce();
+      expect(pile.roundRect).not.toHaveBeenCalled();
+    });
+
+    it('square cell has side radius·√3 centred on (cx, cy)', () => {
+      const ctx = stubCtx();
+      square.traceCell(ctx, 10, 20, 5, false);
+      const [x, y, w, h] = ctx.rect.mock.calls[0];
+      const side = 5 * SQRT3;
+      expect(w).toBeCloseTo(side);
+      expect(h).toBeCloseTo(side);
+      expect(x).toBeCloseTo(10 - side / 2);
+      expect(y).toBeCloseTo(20 - side / 2);
+    });
+  });
+
+  describe('pickCell', () => {
+    const cells = [
+      { cx: 0, cy: 0, id: 'a' },
+      { cx: 10, cy: 0, id: 'b' },
+      { cx: 0, cy: 10, id: 'c' },
+    ];
+
+    it('returns the nearest cell when the point falls inside it', () => {
+      // Right on top of cell b's centre.
+      expect(pickCell(cells, 10, 0, hex, 5)?.id).toBe('b');
+      // A hair off centre, still within the circumradius.
+      expect(pickCell(cells, 1, 1, hex, 5)?.id).toBe('a');
+    });
+
+    it('returns null over blank space between bins', () => {
+      // Midway between a, b, c — outside every cell's radius-2 circle.
+      expect(pickCell(cells, 5, 5, hex, 2)).toBeNull();
+    });
+
+    it('returns null for an empty candidate set', () => {
+      expect(pickCell([], 0, 0, hex, 5)).toBeNull();
+    });
+
+    it('honours the geometry shape for the contains check', () => {
+      // A point that is inside a square cell but outside the hex circle of the
+      // same radius: at (r·0.7, r·0.7) with r=5 → dist²=49.0 > 25 (outside hex),
+      // but |x|,|y| = 3.5 < half-side 4.33 (inside square).
+      const one = [{ cx: 0, cy: 0, id: 'a' }];
+      expect(pickCell(one, 3.5, 3.5, hex, 5)).toBeNull();
+      expect(pickCell(one, 3.5, 3.5, square, 5)?.id).toBe('a');
+    });
+  });
+
+  describe('hoverThumbHalfExtents', () => {
+    it('keeps the requested aspect ratio (hw = aspect · hh)', () => {
+      const offs = hex.neighborOffsets();
+      const { hw, hh } = hoverThumbHalfExtents(2, 10, offs);
+      expect(hw).toBeCloseTo(2 * hh);
+    });
+
+    it('grows a square thumbnail until it just reaches a neighbour centre', () => {
+      // aspect 1 on the square lattice: neighbours at ±√3·radius on each axis, so
+      // hh is bound by min |dy|·radius = √3·radius.
+      const { hh } = hoverThumbHalfExtents(1, 4, square.neighborOffsets());
+      expect(hh).toBeCloseTo(SQRT3 * 4);
+    });
+
+    it('lets a wide image grow taller than a tall one is wide, per the min rule', () => {
+      const offs = hex.neighborOffsets();
+      const wide = hoverThumbHalfExtents(3, 10, offs);
+      const tall = hoverThumbHalfExtents(1 / 3, 10, offs);
+      // Wide image is limited by the side neighbours; tall by top/bottom. Each
+      // stays inside its binding neighbour, so neither half-extent runs away.
+      expect(wide.hw).toBeGreaterThan(0);
+      expect(tall.hh).toBeGreaterThan(0);
+      // The wide thumbnail is wider than it is tall, and vice versa.
+      expect(wide.hw).toBeGreaterThan(wide.hh);
+      expect(tall.hh).toBeGreaterThan(tall.hw);
+    });
+
+    it('scales linearly with the bin radius', () => {
+      const offs = hex.neighborOffsets();
+      const small = hoverThumbHalfExtents(1.5, 5, offs);
+      const big = hoverThumbHalfExtents(1.5, 10, offs);
+      expect(big.hh).toBeCloseTo(2 * small.hh);
+      expect(big.hw).toBeCloseTo(2 * small.hw);
+    });
+  });
+
+  function customGeom(): BinGeometry {
+    // Sanity: pickCell/hoverThumbHalfExtents accept any BinGeometry, not just the
+    // two built-ins — they only touch `contains` / the passed offsets.
+    return binGeometry('hex');
+  }
+
+  it('helpers work against any BinGeometry instance', () => {
+    const g = customGeom();
+    expect(pickCell([{ cx: 0, cy: 0 }], 0, 0, g, 5)).not.toBeNull();
+  });
+});

--- a/frontend/src/app/components/browse-canvas/bin-geometry.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.ts
@@ -141,3 +141,63 @@ const SQUARE_GEOMETRY: BinGeometry = {
 export function binGeometry(shape: BinShape | undefined): BinGeometry {
   return shape === 'square' ? SQUARE_GEOMETRY : HEX_GEOMETRY;
 }
+
+/** The minimum a hit-test needs of a cell: its centre in projection space. */
+export interface CellCentre {
+  cx: number;
+  cy: number;
+}
+
+/**
+ * The nearest cell to projection-space point `(px, py)` among `cells`, returned
+ * only if that point falls *inside* it (per `geom.contains` at `radius`) — so it
+ * resolves to `null` over blank space between bins. This is the pure core of the
+ * canvas hover/click hit-test: the component gathers the candidate cells from the
+ * covering tiles around the cursor, then this picks the one under it. Kept
+ * framework-free (no tile cache, no transform) so the "nearest-then-contains"
+ * rule is unit-testable on its own.
+ */
+export function pickCell<T extends CellCentre>(
+  cells: Iterable<T>,
+  px: number,
+  py: number,
+  geom: BinGeometry,
+  radius: number,
+): T | null {
+  let best: T | null = null;
+  let bestDist = Infinity;
+  for (const cell of cells) {
+    const cdx = cell.cx - px;
+    const cdy = cell.cy - py;
+    const dist = cdx * cdx + cdy * cdy;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = cell;
+    }
+  }
+  if (best && geom.contains(best.cx - px, best.cy - py, radius)) return best;
+  return null;
+}
+
+/**
+ * Half-extents (screen px) of a hovered break-out thumbnail with the given
+ * `aspect` (image width / height), centred on a cell of screen `radius` and
+ * grown as large as possible under one rule: no neighbour cell's centre may be
+ * covered. A neighbour at offset `(dx, dy)·radius` stays uncovered while the
+ * half-height `hh ≤ max(|dx|·radius / aspect, |dy|·radius)`; the binding
+ * neighbour is the tightest of `offsets`, and the rectangle's edge then just
+ * touches that centre. Wide images grow until they reach the side neighbours,
+ * tall ones until they reach the top/bottom. Pulled out of the canvas component
+ * so the neighbour-centre rule is unit-testable without an `HTMLImageElement`.
+ */
+export function hoverThumbHalfExtents(
+  aspect: number,
+  radius: number,
+  offsets: readonly NeighborOffset[],
+): { hw: number; hh: number } {
+  let hh = Infinity;
+  for (const { dx, dy } of offsets) {
+    hh = Math.min(hh, Math.max((Math.abs(dx) * radius) / aspect, Math.abs(dy) * radius));
+  }
+  return { hw: aspect * hh, hh };
+}

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -13,7 +13,7 @@ import {
   type ResolvedColormap,
   usesThumbnails,
 } from './hex-render.util';
-import { binGeometry, BinGeometry } from './bin-geometry';
+import { binGeometry, BinGeometry, hoverThumbHalfExtents, pickCell } from './bin-geometry';
 import {
   clampedTransform,
   computeFitZoom,
@@ -1656,11 +1656,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    */
   private hoverThumbRect(img: HTMLImageElement, radius: number): { hw: number; hh: number } {
     const aspect = img.naturalWidth / img.naturalHeight;
-    let hh = Infinity;
-    for (const { dx, dy } of this.geom.neighborOffsets()) {
-      hh = Math.min(hh, Math.max((Math.abs(dx) * radius) / aspect, Math.abs(dy) * radius));
-    }
-    return { hw: aspect * hh, hh };
+    return hoverThumbHalfExtents(aspect, radius, this.geom.neighborOffsets());
   }
 
   /**
@@ -2691,28 +2687,17 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const txEst = Math.floor(px / tileW);
     const tyEst = Math.floor(py / tileH);
 
-    let best: HexCellPayload | null = null;
-    let bestDist = Infinity;
-
+    // Gather every cell from the 3×3 block of tiles around the cursor, then let
+    // the pure `pickCell` rule find the nearest-and-containing one (or null over
+    // blank space). The tile lookup stays here; the geometry is testable on its own.
+    const candidates: HexCellPayload[] = [];
     for (let dtx = -1; dtx <= 1; dtx++) {
       for (let dty = -1; dty <= 1; dty++) {
         const tile = this.tileCache.getCached(level, txEst + dtx, tyEst + dty);
-        if (!tile) continue;
-        for (const cell of tile.cells) {
-          const cdx = cell.cx - px;
-          const cdy = cell.cy - py;
-          const dist = cdx * cdx + cdy * cdy;
-          if (dist < bestDist) {
-            bestDist = dist;
-            best = cell;
-          }
-        }
+        if (tile) candidates.push(...tile.cells);
       }
     }
 
-    if (best && geom.contains(best.cx - px, best.cy - py, radius)) {
-      return best;
-    }
-    return null;
+    return pickCell(candidates, px, py, geom, radius);
   }
 }

--- a/frontend/src/app/components/browse-canvas/hex-render.util.spec.ts
+++ b/frontend/src/app/components/browse-canvas/hex-render.util.spec.ts
@@ -154,27 +154,24 @@ describe('hex-render.util', () => {
   });
 
   // A minimal stand-in for the 2D context, recording just the path calls the
-  // trace helpers make so we can assert the shape without a real canvas.
+  // trace helpers make so we can assert the shape without a real canvas. The
+  // vi.fn() mocks keep their `.mock` type; `ctx` is the cast passed to the
+  // trace helpers (which want a full CanvasRenderingContext2D).
   function stubCtx() {
-    return {
+    const fns = {
       beginPath: vi.fn(),
       moveTo: vi.fn(),
       lineTo: vi.fn(),
       closePath: vi.fn(),
       arc: vi.fn(),
-    } as unknown as CanvasRenderingContext2D & {
-      beginPath: ReturnType<typeof vi.fn>;
-      moveTo: ReturnType<typeof vi.fn>;
-      lineTo: ReturnType<typeof vi.fn>;
-      closePath: ReturnType<typeof vi.fn>;
-      arc: ReturnType<typeof vi.fn>;
     };
+    return { ...fns, ctx: fns as unknown as CanvasRenderingContext2D };
   }
 
   describe('traceHexPath', () => {
     it('traces six vertices centred on (cx, cy) at the circumradius', () => {
       const ctx = stubCtx();
-      traceHexPath(ctx, 10, 20, 5);
+      traceHexPath(ctx.ctx, 10, 20, 5);
       expect(ctx.beginPath).toHaveBeenCalledOnce();
       expect(ctx.closePath).toHaveBeenCalledOnce();
       // One moveTo (first vertex) + five lineTo (remaining vertices) = 6 total.
@@ -190,7 +187,7 @@ describe('hex-render.util', () => {
   describe('traceCellPath', () => {
     it('draws the inscribed disc for a singleton', () => {
       const ctx = stubCtx();
-      traceCellPath(ctx, 10, 20, 5, true);
+      traceCellPath(ctx.ctx, 10, 20, 5, true);
       expect(ctx.arc).toHaveBeenCalledOnce();
       const [cx, cy, r] = ctx.arc.mock.calls[0];
       expect(cx).toBe(10);
@@ -202,7 +199,7 @@ describe('hex-render.util', () => {
 
     it('draws the full hexagon for a pile (non-single)', () => {
       const ctx = stubCtx();
-      traceCellPath(ctx, 10, 20, 5, false);
+      traceCellPath(ctx.ctx, 10, 20, 5, false);
       expect(ctx.arc).not.toHaveBeenCalled();
       expect(ctx.moveTo).toHaveBeenCalledOnce();
       expect(ctx.lineTo).toHaveBeenCalledTimes(5);

--- a/frontend/src/app/components/browse-canvas/hex-render.util.spec.ts
+++ b/frontend/src/app/components/browse-canvas/hex-render.util.spec.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  BROWSE_COLORMAP_IDS,
+  DEFAULT_THUMBNAIL_BORDER,
+  densityColor,
+  gradientStops,
+  HEX_ANGLES,
+  HEX_INRADIUS_RATIO,
+  MAX_THUMBNAIL_BORDER,
+  resolveColormap,
+  rgbString,
+  SQRT3,
+  traceCellPath,
+  traceHexPath,
+  usesThumbnails,
+  type CanvasTheme,
+} from './hex-render.util';
+
+/**
+ * Unit coverage for the framework-free hex-grid rendering primitives shared by
+ * the browse canvas and its minimap (see issue #2418). These are pure functions
+ * over colours and geometry — the only "canvas" here is a tiny stub 2D context
+ * that records the path commands `traceHexPath` / `traceCellPath` emit.
+ */
+describe('hex-render.util', () => {
+  describe('usesThumbnails', () => {
+    it('is true for the four thumbnail-backed media types', () => {
+      for (const t of ['image', 'video', 'document', 'audio']) {
+        expect(usesThumbnails(t)).toBe(true);
+      }
+    });
+
+    it('is false for flat-density types like text', () => {
+      expect(usesThumbnails('text')).toBe(false);
+      expect(usesThumbnails('anything-else')).toBe(false);
+      expect(usesThumbnails('')).toBe(false);
+    });
+  });
+
+  describe('resolveColormap', () => {
+    it("picks Ocean in light mode and Heat in dark/high-viz for 'auto'", () => {
+      // Ocean darkens with density (low end lighter than high); Heat brightens.
+      const light = resolveColormap('auto', 'light');
+      const dark = resolveColormap('auto', 'dark');
+      const highviz = resolveColormap('auto', 'highviz');
+      expect(dark).toEqual(highviz);
+      // Ocean's ramp gets darker (sum falls); Heat's gets brighter (sum rises).
+      const sum = (c: readonly [number, number, number]) => c[0] + c[1] + c[2];
+      expect(sum(light.ramp[light.ramp.length - 1])).toBeLessThan(sum(light.ramp[0]));
+      expect(sum(dark.ramp[dark.ramp.length - 1])).toBeGreaterThan(sum(dark.ramp[0]));
+    });
+
+    it('returns Heat and Ocean regardless of theme for their explicit ids', () => {
+      expect(resolveColormap('heat', 'light')).toEqual(resolveColormap('heat', 'dark'));
+      expect(resolveColormap('ocean', 'light')).toEqual(resolveColormap('ocean', 'dark'));
+    });
+
+    it('flips grayscale direction with the theme', () => {
+      const grayLight = resolveColormap('gray', 'light');
+      const grayDark = resolveColormap('gray', 'dark');
+      const sum = (c: readonly [number, number, number]) => c[0] + c[1] + c[2];
+      // Light: darkens as density grows (moves away from the light background).
+      expect(sum(grayLight.ramp[grayLight.ramp.length - 1])).toBeLessThan(sum(grayLight.ramp[0]));
+      // Dark: lightens as density grows.
+      expect(sum(grayDark.ramp[grayDark.ramp.length - 1])).toBeGreaterThan(sum(grayDark.ramp[0]));
+    });
+
+    it('exposes every selectable id, auto first', () => {
+      expect(BROWSE_COLORMAP_IDS[0]).toBe('auto');
+      // Every id resolves to a non-empty ramp under every theme.
+      for (const id of BROWSE_COLORMAP_IDS) {
+        for (const theme of ['light', 'dark', 'highviz'] as CanvasTheme[]) {
+          expect(resolveColormap(id, theme).ramp.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe('rgbString', () => {
+    it('formats an [r, g, b] triple as a CSS rgb(...) string', () => {
+      expect(rgbString([1, 2, 3])).toBe('rgb(1,2,3)');
+    });
+  });
+
+  describe('densityColor', () => {
+    it('returns the ramp endpoints at t=0 and t=1', () => {
+      const ramp: [number, number, number][] = [
+        [0, 0, 0],
+        [100, 100, 100],
+        [200, 200, 200],
+      ];
+      expect(densityColor(0, ramp)).toBe('rgb(0,0,0)');
+      expect(densityColor(1, ramp)).toBe('rgb(200,200,200)');
+    });
+
+    it('interpolates linearly between adjacent stops', () => {
+      const ramp: [number, number, number][] = [
+        [0, 0, 0],
+        [100, 0, 0],
+      ];
+      // Halfway along a two-stop ramp is the midpoint colour.
+      expect(densityColor(0.5, ramp)).toBe('rgb(50,0,0)');
+    });
+
+    it('lands a quarter of the way into the first segment of a longer ramp', () => {
+      const ramp: [number, number, number][] = [
+        [0, 0, 0],
+        [40, 80, 120],
+        [200, 200, 200],
+      ];
+      // n = 2 segments; t=0.25 → idx 0.5 → halfway into segment 0.
+      expect(densityColor(0.25, ramp)).toBe('rgb(20,40,60)');
+    });
+  });
+
+  describe('gradientStops', () => {
+    it('spreads stops evenly from 0% to 100%', () => {
+      const stops = gradientStops([
+        [0, 0, 0],
+        [128, 128, 128],
+        [255, 255, 255],
+      ]);
+      expect(stops).toBe('rgb(0,0,0) 0%, rgb(128,128,128) 50%, rgb(255,255,255) 100%');
+    });
+
+    it('does not divide by zero for a single-colour ramp', () => {
+      expect(gradientStops([[10, 20, 30]])).toBe('rgb(10,20,30) 0%');
+    });
+  });
+
+  describe('HEX_ANGLES', () => {
+    it('is a pointy-top hexagon: six vertices, first straight up', () => {
+      expect(HEX_ANGLES).toHaveLength(6);
+      // First vertex at -90° (straight up) for a pointy-top hex.
+      expect(HEX_ANGLES[0]).toBeCloseTo(-Math.PI / 2);
+      // Vertices are spaced 60° apart.
+      expect(HEX_ANGLES[1] - HEX_ANGLES[0]).toBeCloseTo(Math.PI / 3);
+    });
+  });
+
+  describe('HEX_INRADIUS_RATIO', () => {
+    it('is √3/2 — the largest disc that fits inside the hex', () => {
+      expect(HEX_INRADIUS_RATIO).toBeCloseTo(SQRT3 / 2);
+      expect(HEX_INRADIUS_RATIO).toBeLessThan(1);
+    });
+  });
+
+  describe('border constants', () => {
+    it('has a sane default below the max clamp', () => {
+      expect(DEFAULT_THUMBNAIL_BORDER).toBeGreaterThan(0);
+      expect(DEFAULT_THUMBNAIL_BORDER).toBeLessThanOrEqual(MAX_THUMBNAIL_BORDER);
+    });
+  });
+
+  // A minimal stand-in for the 2D context, recording just the path calls the
+  // trace helpers make so we can assert the shape without a real canvas.
+  function stubCtx() {
+    return {
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      arc: vi.fn(),
+    } as unknown as CanvasRenderingContext2D & {
+      beginPath: ReturnType<typeof vi.fn>;
+      moveTo: ReturnType<typeof vi.fn>;
+      lineTo: ReturnType<typeof vi.fn>;
+      closePath: ReturnType<typeof vi.fn>;
+      arc: ReturnType<typeof vi.fn>;
+    };
+  }
+
+  describe('traceHexPath', () => {
+    it('traces six vertices centred on (cx, cy) at the circumradius', () => {
+      const ctx = stubCtx();
+      traceHexPath(ctx, 10, 20, 5);
+      expect(ctx.beginPath).toHaveBeenCalledOnce();
+      expect(ctx.closePath).toHaveBeenCalledOnce();
+      // One moveTo (first vertex) + five lineTo (remaining vertices) = 6 total.
+      expect(ctx.moveTo).toHaveBeenCalledOnce();
+      expect(ctx.lineTo).toHaveBeenCalledTimes(5);
+      // First vertex sits straight up from the centre at the circumradius.
+      const [x, y] = ctx.moveTo.mock.calls[0];
+      expect(x).toBeCloseTo(10);
+      expect(y).toBeCloseTo(20 - 5);
+    });
+  });
+
+  describe('traceCellPath', () => {
+    it('draws the inscribed disc for a singleton', () => {
+      const ctx = stubCtx();
+      traceCellPath(ctx, 10, 20, 5, true);
+      expect(ctx.arc).toHaveBeenCalledOnce();
+      const [cx, cy, r] = ctx.arc.mock.calls[0];
+      expect(cx).toBe(10);
+      expect(cy).toBe(20);
+      expect(r).toBeCloseTo(5 * HEX_INRADIUS_RATIO);
+      // No polygon path for a singleton disc.
+      expect(ctx.moveTo).not.toHaveBeenCalled();
+    });
+
+    it('draws the full hexagon for a pile (non-single)', () => {
+      const ctx = stubCtx();
+      traceCellPath(ctx, 10, 20, 5, false);
+      expect(ctx.arc).not.toHaveBeenCalled();
+      expect(ctx.moveTo).toHaveBeenCalledOnce();
+      expect(ctx.lineTo).toHaveBeenCalledTimes(5);
+    });
+  });
+});

--- a/frontend/src/app/components/browse-canvas/hex-render.util.spec.ts
+++ b/frontend/src/app/components/browse-canvas/hex-render.util.spec.ts
@@ -130,12 +130,16 @@ describe('hex-render.util', () => {
   });
 
   describe('HEX_ANGLES', () => {
-    it('is a pointy-top hexagon: six vertices, first straight up', () => {
+    it('is a pointy-top hexagon: six vertices 60° apart, one straight up', () => {
       expect(HEX_ANGLES).toHaveLength(6);
-      // First vertex at -90° (straight up) for a pointy-top hex.
-      expect(HEX_ANGLES[0]).toBeCloseTo(-Math.PI / 2);
+      // First vertex at -30° (top-right of the pointy-top silhouette).
+      expect(HEX_ANGLES[0]).toBeCloseTo(-Math.PI / 6);
       // Vertices are spaced 60° apart.
       expect(HEX_ANGLES[1] - HEX_ANGLES[0]).toBeCloseTo(Math.PI / 3);
+      // A pointy-top hex has a vertex pointing straight up: in screen coords
+      // (y grows down) that is sin = -1, i.e. some angle ≡ -90° (mod 360°).
+      const hasTopVertex = HEX_ANGLES.some((a) => Math.sin(a) < -0.999);
+      expect(hasTopVertex).toBe(true);
     });
   });
 
@@ -177,10 +181,13 @@ describe('hex-render.util', () => {
       // One moveTo (first vertex) + five lineTo (remaining vertices) = 6 total.
       expect(ctx.moveTo).toHaveBeenCalledOnce();
       expect(ctx.lineTo).toHaveBeenCalledTimes(5);
-      // First vertex sits straight up from the centre at the circumradius.
+      // First vertex is at angle -30° on the circumradius-5 circle about (10, 20).
       const [x, y] = ctx.moveTo.mock.calls[0];
-      expect(x).toBeCloseTo(10);
-      expect(y).toBeCloseTo(20 - 5);
+      expect(x).toBeCloseTo(10 + 5 * Math.cos(-Math.PI / 6));
+      expect(y).toBeCloseTo(20 + 5 * Math.sin(-Math.PI / 6));
+      // Every traced vertex sits on the circumradius circle.
+      const dist = Math.hypot(x - 10, y - 20);
+      expect(dist).toBeCloseTo(5);
     });
   });
 


### PR DESCRIPTION
## What

Adds unit coverage for the browse canvas's extracted pure logic, and pulls two more pure helpers out of the 2,700-line `browse-canvas.component.ts` so they're testable without a canvas.

## Changes

**New specs** for the already-pure shared primitives:
- `hex-render.util.spec.ts` — `usesThumbnails`, `resolveColormap` (auto/heat/ocean/gray across themes), `densityColor`, `gradientStops`, `rgbString`, `HEX_ANGLES`, `HEX_INRADIUS_RATIO`, and the `traceHexPath`/`traceCellPath` path emission (via a stub 2D context).
- `bin-geometry.spec.ts` — hex vs square `dx`/`dy`, `contains`, `singleCornerRadius`, `neighborOffsets`, `traceCell` (disc-vs-hex / roundRect-vs-rect), plus the two new helpers below.

**Extracted from the component** into `bin-geometry.ts` (pure, framework-free) and rewired the component to call them:
- `pickCell(cells, px, py, geom, radius)` — the nearest-then-contains core of `hitTest`. The tile-cache lookup stays in the component; the geometry rule is now unit-testable on its own.
- `hoverThumbHalfExtents(aspect, radius, offsets)` — the neighbour-centre thumbnail-sizing rule from `hoverThumbRect`, now testable without an `HTMLImageElement`.

Full canvas rendering remains out of scope for unit testing, per the issue; this covers the extractable math.

## Testing

`./run-tests.sh frontend` → 1209 passed (build + audit + Vitest).

Closes #2418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jpjj1TwrZDiRMhbjaWVnAH)_