### PR TITLE
Add net-new coverage to the merged #2420 service specs

### DIFF
--- a/frontend/src/app/services/running-jobs.service.spec.ts
+++ b/frontend/src/app/services/running-jobs.service.spec.ts
@@ -85,6 +85,25 @@ describe('RunningJobsService', () => {
     }
   });
 
+  it('ignores interval ticks while a poll is still in flight (exhaustMap)', async () => {
+    vi.useFakeTimers();
+    try {
+      subs.push(service.busyPairs$.subscribe());
+
+      await vi.advanceTimersByTimeAsync(0);
+      const inFlight = httpMock.expectOne('/api/jobs/active');
+
+      // A tick fires while the first request is still pending: exhaustMap must
+      // NOT issue a second request (at most one poll in flight at a time).
+      await vi.advanceTimersByTimeAsync(5000);
+      httpMock.expectNone('/api/jobs/active');
+
+      inFlight.flush({ busy_pairs: [] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('stops polling and clears state once the last observer unsubscribes', async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/app/services/tile-cache.service.spec.ts
+++ b/frontend/src/app/services/tile-cache.service.spec.ts
@@ -78,6 +78,16 @@ describe('TileCacheService', () => {
     expect(service.getCached(2, 1, 1)).toBeNull();
   });
 
+  it('re-setting the same projection id keeps the cache warm', () => {
+    service.setProjectionId('p1');
+    service.getTile(2, 1, 1)?.subscribe();
+    expect(service.getCached(2, 1, 1)).not.toBeNull();
+
+    // A no-op id set must not clear the cache (only a *change* invalidates).
+    service.setProjectionId('p1');
+    expect(service.getCached(2, 1, 1)).not.toBeNull();
+  });
+
   it('setContentVersion re-keys entries so a stale version misses', () => {
     service.setProjectionId('p1');
     service.getTile(2, 1, 1)?.subscribe();

--- a/frontend/src/app/services/toast.service.spec.ts
+++ b/frontend/src/app/services/toast.service.spec.ts
@@ -70,6 +70,17 @@ describe('ToastService', () => {
     }
   });
 
+  it('error() toasts persist past the success auto-dismiss window', async () => {
+    vi.useFakeTimers();
+    try {
+      service.error({ message: 'stays' });
+      await vi.advanceTimersByTimeAsync(60000);
+      expect(service.toasts.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('dedupKey replaces the existing toast instead of stacking', () => {
     service.error({ message: 'first', dedupKey: 'k' });
     service.error({ message: 'second', dedupKey: 'k' });


### PR DESCRIPTION
Issue #2420's specs for the nine singleton services already landed on `dev` via #2428. Rather than duplicate that suite, this PR rebases onto the merged specs and grafts in the three behaviours those specs don't yet pin:

- **toast** — error toasts persist past the success auto-dismiss window (dev only tests that *success* toasts auto-dismiss; nothing pins that error toasts stay put).
- **tile-cache** — re-setting the *same* projection id keeps the cache warm (dev tests the id-*change* clear, but not the no-op guard on an unchanged id).
- **running-jobs** — `exhaustMap` ignores interval ticks while a poll is in flight (dev tests re-poll *after* completion; this pins the one-poll-at-a-time guard).

Each new case matches the style, fixtures, and helper names of the existing file it's added to.

## Testing

`./run-tests.sh frontend` — all green (build, audit, Vitest: 1436 passed).

Refs #2420

🤖 Generated with [Claude Code](https://claude.com/claude-code)