### PR TITLE
Fill smaller backend coverage gaps (metadata, sync base, archive-member source, gui origin, settings_store, achievements schema)

### DIFF
--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import json
 import pathlib
 
+import pytest
+
 import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import achievements
 from vtsearch import settings as settings_mod
@@ -881,6 +883,79 @@ class TestActionHooks:
 # ---------------------------------------------------------------------------
 # enable_achievements opt-out
 # ---------------------------------------------------------------------------
+
+
+class TestAchievementSchemas:
+    """Direct serialization tests for ``vtsearch/schemas/achievements.py``.
+
+    The routes dump/validate through these schemas, but exercising them
+    against a real :func:`get_full_state` payload pins their field contract
+    (and their ``required`` flags) independently of the HTTP layer.
+    """
+
+    def test_state_schema_dumps_full_state(self):
+        from typing import cast
+
+        from vtsearch.schemas.achievements import AchievementStateSchema
+
+        achievements.record_vote("det-1", media_type="audio")
+        achievements.record_find(50)
+        dumped = cast(dict, AchievementStateSchema().dump(achievements.get_full_state()))
+        assert dumped["tier_names"] == ["Bronze", "Silver", "Gold", "Platinum"]
+        entry = next(a for a in dumped["achievements"] if a["id"] == "votes_cast")
+        assert set(entry) == {
+            "id",
+            "name",
+            "description",
+            "icon",
+            "tiers",
+            "counter",
+            "tier_idx",
+            "next_threshold",
+        }
+        assert {d["id"] for d in dumped["docs"]} == {"readme", "user_guide", "cli", "api"}
+        assert [h["hour"] for h in dumped["hours"]] == list(range(24))
+
+    def test_state_schema_round_trips_via_load(self):
+        from typing import cast
+
+        from vtsearch.schemas.achievements import AchievementStateSchema
+
+        schema = AchievementStateSchema()
+        state = achievements.get_full_state()
+        # dump → load must not raise ValidationError (every required field present).
+        loaded = cast(dict, schema.load(cast(dict, schema.dump(state))))
+        assert loaded["tier_names"] == ["Bronze", "Silver", "Gold", "Platinum"]
+
+    def test_acknowledge_request_rejects_missing_tier_idx(self):
+        from marshmallow import ValidationError
+
+        from vtsearch.schemas.achievements import AcknowledgeRequestSchema
+
+        with pytest.raises(ValidationError):
+            AcknowledgeRequestSchema().load({})
+
+    def test_acknowledge_request_rejects_non_int_tier_idx(self):
+        from marshmallow import ValidationError
+
+        from vtsearch.schemas.achievements import AcknowledgeRequestSchema
+
+        # strict=True forbids a float/bool masquerading as the integer index.
+        with pytest.raises(ValidationError):
+            AcknowledgeRequestSchema().load({"tier_idx": "2"})
+
+    def test_check_phrase_response_allows_null_doc_fields(self):
+        from vtsearch.schemas.achievements import CheckPhraseResponseSchema
+
+        dumped = CheckPhraseResponseSchema().dump(
+            {"matched": False, "doc_id": None, "doc_name": None, "already_read": False}
+        )
+        assert dumped == {
+            "matched": False,
+            "doc_id": None,
+            "doc_name": None,
+            "already_read": False,
+        }
 
 
 class TestDisableAchievements:

--- a/tests/core/test_settings_store.py
+++ b/tests/core/test_settings_store.py
@@ -1,0 +1,141 @@
+"""Direct unit tests for :mod:`vtsearch.settings_store` primitives.
+
+The settings routes exercise the store end-to-end, but its low-level file
+I/O and cross-worker sync-marker helpers are worth pinning directly: they are
+pure, path-keyed functions with several error-swallowing branches (unreadable
+file, malformed JSON, non-serialisable token) that route-level tests don't
+reliably hit.
+"""
+
+from __future__ import annotations
+
+import json
+
+from vtsearch import settings_store as store
+
+
+# ---------------------------------------------------------------------------
+# _load_path / _atomic_write
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPath:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert store._load_path(tmp_path / "nope.json") == {}
+
+    def test_reads_valid_dict(self, tmp_path):
+        p = tmp_path / "s.json"
+        p.write_text(json.dumps({"a": 1, "b": "two"}), encoding="utf-8")
+        assert store._load_path(p) == {"a": 1, "b": "two"}
+
+    def test_malformed_json_returns_empty(self, tmp_path):
+        p = tmp_path / "s.json"
+        p.write_text("{not valid json", encoding="utf-8")
+        assert store._load_path(p) == {}
+
+    def test_non_dict_json_returns_empty(self, tmp_path):
+        p = tmp_path / "s.json"
+        p.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        assert store._load_path(p) == {}
+
+
+class TestAtomicWrite:
+    def test_round_trips_via_load_path(self, tmp_path):
+        p = tmp_path / "s.json"
+        store._atomic_write(p, {"x": 42})
+        assert store._load_path(p) == {"x": 42}
+
+    def test_creates_parent_directories(self, tmp_path):
+        p = tmp_path / "deep" / "nested" / "s.json"
+        store._atomic_write(p, {"ok": True})
+        assert p.exists()
+        assert store._load_path(p) == {"ok": True}
+
+    def test_leaves_no_temp_file_behind(self, tmp_path):
+        p = tmp_path / "s.json"
+        store._atomic_write(p, {"x": 1})
+        # The per-writer "<name>.<pid>.<uuid>.tmp" scratch file is renamed into
+        # place, so no ``.tmp`` sibling should survive. (Other files in tmp_path
+        # belong to the autouse isolated_settings fixture, so scope to .tmp.)
+        assert list(tmp_path.glob("s.json.*.tmp")) == []
+
+    def test_overwrite_replaces_content(self, tmp_path):
+        p = tmp_path / "s.json"
+        store._atomic_write(p, {"v": 1})
+        store._atomic_write(p, {"v": 2})
+        assert store._load_path(p) == {"v": 2}
+
+
+# ---------------------------------------------------------------------------
+# sync marker helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSyncMarker:
+    def test_marker_path_is_sibling(self, tmp_path):
+        user = tmp_path / "user.json"
+        assert store._sync_marker_path(user) == tmp_path / "user.json.syncmark"
+
+    def test_read_absent_marker_returns_none(self, tmp_path):
+        assert store._read_sync_marker(tmp_path / "user.json") is None
+
+    def test_write_then_read_round_trips(self, tmp_path):
+        user = tmp_path / "user.json"
+        store._write_sync_marker(user, 12345)
+        assert store._read_sync_marker(user) == 12345
+
+    def test_write_string_token(self, tmp_path):
+        user = tmp_path / "user.json"
+        store._write_sync_marker(user, "etag-abc")
+        assert store._read_sync_marker(user) == "etag-abc"
+
+    def test_write_none_writes_nothing(self, tmp_path):
+        user = tmp_path / "user.json"
+        store._write_sync_marker(user, None)
+        assert not store._sync_marker_path(user).exists()
+        assert store._read_sync_marker(user) is None
+
+    def test_write_non_serialisable_is_swallowed(self, tmp_path):
+        user = tmp_path / "user.json"
+        # An object json can't encode must not raise — the marker is a hint.
+        store._write_sync_marker(user, object())
+        assert store._read_sync_marker(user) is None
+
+    def test_read_malformed_marker_returns_none(self, tmp_path):
+        user = tmp_path / "user.json"
+        store._sync_marker_path(user).write_text("{bad json", encoding="utf-8")
+        assert store._read_sync_marker(user) is None
+
+    def test_read_non_dict_marker_returns_none(self, tmp_path):
+        user = tmp_path / "user.json"
+        store._sync_marker_path(user).write_text(json.dumps([1, 2]), encoding="utf-8")
+        assert store._read_sync_marker(user) is None
+
+    def test_read_marker_without_version_key_returns_none(self, tmp_path):
+        user = tmp_path / "user.json"
+        store._sync_marker_path(user).write_text(json.dumps({"other": 1}), encoding="utf-8")
+        assert store._read_sync_marker(user) is None
+
+
+# ---------------------------------------------------------------------------
+# locking primitives
+# ---------------------------------------------------------------------------
+
+
+class TestLocking:
+    def test_path_lock_is_stable_per_path(self, tmp_path):
+        p = tmp_path / "s.json"
+        assert store._path_lock_for(p) is store._path_lock_for(p)
+
+    def test_distinct_paths_get_distinct_locks(self, tmp_path):
+        a = store._path_lock_for(tmp_path / "a.json")
+        b = store._path_lock_for(tmp_path / "b.json")
+        assert a is not b
+
+    def test_file_lock_acquires_and_releases(self, tmp_path):
+        p = tmp_path / "s.json"
+        with store.file_lock(p):
+            store._atomic_write(p, {"held": True})
+        # Re-acquiring after release must not deadlock.
+        with store.file_lock(p):
+            assert store._load_path(p) == {"held": True}

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -332,6 +332,87 @@ class TestDisplayLabelsetExporter:
         assert "3" in result["message"]
 
 
+class TestGuiOriginFormatting:
+    """The gui exporter's ``_format_origin`` and its use in the CLI/streaming
+    output paths (origin display string preceding the name)."""
+
+    def test_format_origin_none_is_empty(self):
+        from vtscore.exporters.gui import _format_origin
+
+        assert _format_origin({"filename": "x.wav"}) == ""  # no "origin" key
+        assert _format_origin({"origin": None}) == ""
+
+    def test_format_origin_renders_display_string(self):
+        from vtscore.exporters.gui import _format_origin
+
+        hit = {"origin": {"importer": "http_archive", "params": {"url": "https://ex.com/d.zip"}}}
+        assert _format_origin(hit) == "http_archive(https://ex.com/d.zip)"
+
+    def test_format_origin_importerless_falls_back_to_str(self):
+        from vtscore.exporters.gui import _format_origin
+
+        # A malformed origin dict (no "importer") makes Origin.from_dict raise;
+        # the helper degrades to ``str(origin)`` rather than crashing the export.
+        hit = {"origin": {"params": {"path": "/data"}}}
+        out = _format_origin(hit)
+        assert out == str({"params": {"path": "/data"}})
+
+    def test_export_cli_name_falls_back_to_filename(self, capsys):
+        from vtscore.exporters import get_exporter
+
+        results = {
+            "detectors_run": 1,
+            "results": {
+                "det1": {
+                    "total_hits": 1,
+                    "hits": [{"id": 1, "filename": "only_filename.wav", "score": 0.9}],
+                },
+            },
+        }
+        get_exporter("gui").export_cli(results, {})
+        captured = capsys.readouterr()
+        # No origin_name and no origin → prints just the bare filename.
+        assert "only_filename.wav" in captured.out
+
+    def test_export_cli_streaming_prints_origin_before_name(self, capsys):
+        from vtscore.exporters import get_exporter
+
+        header = {"detectors": ["det1"]}
+
+        def records():
+            yield (
+                "det1",
+                {
+                    "id": 1,
+                    "filename": "clip.mp4",
+                    "origin_name": "clip.mp4",
+                    "origin": {"importer": "server_folder", "params": {"path": "/vids"}},
+                    "label": "good",
+                },
+            )
+            # A bad hit is skipped in the streaming (predicted-Good) output.
+            yield "det1", {"id": 2, "filename": "skip.mp4", "label": "bad"}
+
+        res = get_exporter("gui").export_cli_streaming(header, records(), {})
+        captured = capsys.readouterr()
+        assert "folder(/vids)" in captured.out
+        assert "clip.mp4" in captured.out
+        assert "skip.mp4" not in captured.out
+        assert "1 hit(s)" in res["message"]
+        assert "1 detector(s)" in res["message"]
+
+    def test_export_cli_streaming_no_good_hits(self, capsys):
+        from vtscore.exporters import get_exporter
+
+        def records():
+            yield "det1", {"id": 1, "filename": "b.mp4", "label": "bad"}
+
+        res = get_exporter("gui").export_cli_streaming({"detectors": ["det1"]}, records(), {})
+        captured = capsys.readouterr()
+        assert "No items predicted as Good" in captured.out
+        assert "0 hit(s)" in res["message"]
+
+
 # ---------------------------------------------------------------------------
 # Server JSON file exporter
 # ---------------------------------------------------------------------------

--- a/tests_lib/datasets/test_local_archive_member_source.py
+++ b/tests_lib/datasets/test_local_archive_member_source.py
@@ -1,0 +1,203 @@
+"""Tests for :class:`vtscore.datasets.sources.local_archive_member.LocalArchiveMemberSource`.
+
+The manifest-backed media source re-supplies precomputed vectors straight out
+of an NPZ manifest (no byte re-derivation), so "Find from origin" works on
+archive members that have no on-disk path.  The importer twin is covered in
+``test_archive_member_import.py``; here we pin the *source* side: window-keyed
+lookup, the bare-member fallback, extension filtering, ``origin_name`` /
+``filename`` resolution, and the auto-discovery factory.
+
+No real archive is needed — the source reads only the manifest's vectors, never
+the members' bytes — so ``archives`` points at a synthetic path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from vtscore.datasets.sources.local_archive_member import (
+    SOURCE,
+    LocalArchiveMemberSource,
+)
+
+DIM = 8
+
+
+def _make_manifest(
+    tmp_path: Path,
+    *,
+    members,
+    clip_starts=None,
+    embedder_name: str | None = "xclip",
+    filenames=None,
+) -> Path:
+    rng = np.random.default_rng(3)
+    vectors = rng.standard_normal((len(members), DIM)).astype(np.float32)
+    archive = tmp_path / "shard.tar"
+    arrays = {
+        "vectors": vectors,
+        "members": np.array(members),
+        "archives": np.array(str(archive)),
+    }
+    if clip_starts is not None:
+        arrays["clip_start"] = np.array(clip_starts, dtype=np.float32)
+    if filenames is not None:
+        arrays["filenames"] = np.array(filenames)
+    if embedder_name is not None:
+        arrays["embedder_name"] = np.array(embedder_name)
+    manifest = tmp_path / "manifest.npz"
+    np.savez(manifest, **arrays)
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# list_items
+# ---------------------------------------------------------------------------
+
+
+class TestListItems:
+    def test_yields_one_item_per_member(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4", "sub/b.mp4"])
+        src = LocalArchiveMemberSource(manifest)
+        items = list(src.list_items())
+        assert {it.key for it in items} == {"a.mp4", "sub/b.mp4"}
+        assert all(it.source_name == "local_archive_member" for it in items)
+        assert {it.filename for it in items} == {"a.mp4", "b.mp4"}
+
+    def test_windowed_members_key_by_clip_start(self, tmp_path):
+        manifest = _make_manifest(
+            tmp_path,
+            members=["a.mp4", "a.mp4", "b.mp4"],
+            clip_starts=[0.0, 10.0, float("nan")],
+        )
+        src = LocalArchiveMemberSource(manifest)
+        keys = {it.key for it in src.list_items()}
+        # Two windows of a.mp4 (@0, @10) plus whole-member b.mp4.
+        assert keys == {"a.mp4@0", "a.mp4@10", "b.mp4"}
+
+    def test_extension_filter(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4", "b.wav"])
+        src = LocalArchiveMemberSource(manifest)
+        keys = {it.key for it in src.list_items(extensions=[".mp4"])}
+        assert keys == {"a.mp4"}
+
+    def test_extension_filter_is_case_insensitive(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["A.MP4"])
+        src = LocalArchiveMemberSource(manifest)
+        keys = {it.key for it in src.list_items(extensions=[".mp4"])}
+        assert keys == {"A.MP4"}
+
+
+# ---------------------------------------------------------------------------
+# fetch_item
+# ---------------------------------------------------------------------------
+
+
+class TestFetchItem:
+    def test_returns_embedding_never_path(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4"])
+        src = LocalArchiveMemberSource(manifest)
+        fetched = src.fetch_item("a.mp4")
+        assert fetched.path is None
+        assert fetched.embedding is not None
+        assert fetched.embedding.shape == (DIM,)
+        assert fetched.embedder_name == "xclip"
+
+    def test_unknown_key_returns_empty_fetch(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4"])
+        src = LocalArchiveMemberSource(manifest)
+        fetched = src.fetch_item("nope.mp4")
+        assert fetched.path is None
+        assert fetched.embedding is None
+
+    def test_blank_key_returns_empty_fetch(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4"])
+        src = LocalArchiveMemberSource(manifest)
+        assert src.fetch_item("   ").embedding is None
+
+    def test_bare_member_falls_back_to_first_window(self, tmp_path):
+        manifest = _make_manifest(
+            tmp_path,
+            members=["a.mp4", "a.mp4"],
+            clip_starts=[0.0, 10.0],
+        )
+        src = LocalArchiveMemberSource(manifest)
+        # The windowed key resolves to that specific window...
+        w0 = src.fetch_item("a.mp4@0").embedding
+        w10 = src.fetch_item("a.mp4@10").embedding
+        bare = src.fetch_item("a.mp4").embedding
+        assert w0 is not None and w10 is not None and bare is not None
+        assert not np.array_equal(w0, w10)
+        # ...and the bare member resolves to the *first* window's vector.
+        assert np.array_equal(bare, w0)
+
+    def test_archive_prefixed_origin_name_resolves(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4"])
+        src = LocalArchiveMemberSource(manifest)
+        fetched = src.fetch_item("shard.tar::a.mp4")
+        assert fetched.embedding is not None
+
+
+# ---------------------------------------------------------------------------
+# resolve_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePath:
+    def test_resolves_by_origin_name(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4"])
+        src = LocalArchiveMemberSource(manifest)
+        fetched = src.resolve_path(origin_name="a.mp4")
+        assert fetched.embedding is not None
+        assert fetched.path is None
+
+    def test_falls_back_to_filename_when_origin_missing(self, tmp_path):
+        manifest = _make_manifest(
+            tmp_path,
+            members=["sub/a.mp4"],
+            filenames=["display_name.mp4"],
+        )
+        src = LocalArchiveMemberSource(manifest)
+        # origin_name won't match, but the filename column will.
+        fetched = src.resolve_path(origin_name="unmatched", filename="display_name.mp4")
+        assert fetched.embedding is not None
+
+    def test_unresolvable_returns_empty(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4"])
+        src = LocalArchiveMemberSource(manifest)
+        fetched = src.resolve_path(origin_name="x", filename="y.mp4")
+        assert fetched.embedding is None
+        assert fetched.path is None
+
+
+# ---------------------------------------------------------------------------
+# embedder-name fallback + factory
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedderNameAndFactory:
+    def test_blank_embedder_name_falls_back_to_manifest(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4"], embedder_name="siglip")
+        src = LocalArchiveMemberSource(manifest, embedder_name="")
+        assert src.fetch_item("a.mp4").embedder_name == "siglip"
+
+    def test_explicit_embedder_name_wins(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4"], embedder_name="siglip")
+        src = LocalArchiveMemberSource(manifest, embedder_name="override")
+        assert src.fetch_item("a.mp4").embedder_name == "override"
+
+    def test_factory_creates_source_from_origin(self, tmp_path):
+        manifest = _make_manifest(tmp_path, members=["a.mp4"])
+        origin = {"params": {"manifest": str(manifest), "embedder_name": "xclip"}}
+        src = SOURCE.create_from_origin(origin)
+        assert isinstance(src, LocalArchiveMemberSource)
+        assert src.fetch_item("a.mp4").embedding is not None
+
+    def test_factory_returns_none_without_manifest(self, tmp_path):
+        assert SOURCE.create_from_origin({"params": {}}) is None
+        assert SOURCE.create_from_origin({}) is None
+
+    def test_factory_name(self):
+        assert SOURCE.name == "local_archive_member"

--- a/tests_lib/datasets/test_metadata.py
+++ b/tests_lib/datasets/test_metadata.py
@@ -1,0 +1,262 @@
+"""Tests for :mod:`vtscore.datasets.metadata` extraction loaders.
+
+Each loader turns an on-disk metadata layout (a CSV, a MAT file, a CIFAR-10
+pickle batch, or a category-folder tree) into a ``{key: metadata}`` dict.
+These are pure filesystem functions, so the tests build tiny fixtures in a
+``tmp_path`` and assert the returned shape — no network, no real datasets.
+"""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from vtscore.datasets import metadata
+
+
+# ---------------------------------------------------------------------------
+# ESC-50 CSV
+# ---------------------------------------------------------------------------
+
+
+class TestEsc50Metadata:
+    def _write_csv(self, esc50_dir: Path) -> None:
+        meta = esc50_dir / "meta"
+        meta.mkdir(parents=True)
+        (meta / "esc50.csv").write_text(
+            "filename,fold,target,category,esc10,src_file,take\n"
+            "1-100032-A-0.wav,1,0,dog,True,100032,A\n"
+            "1-100038-A-14.wav,2,14,chirping_birds,False,100038,A\n",
+            encoding="utf-8",
+        )
+
+    def test_parses_rows(self, tmp_path):
+        self._write_csv(tmp_path)
+        md = metadata.load_esc50_metadata(tmp_path)
+        assert set(md) == {"1-100032-A-0.wav", "1-100038-A-14.wav"}
+        dog = md["1-100032-A-0.wav"]
+        assert dog == {"category": "dog", "esc10": True, "target": 0, "fold": 1}
+
+    def test_esc10_flag_is_bool(self, tmp_path):
+        self._write_csv(tmp_path)
+        md = metadata.load_esc50_metadata(tmp_path)
+        assert md["1-100032-A-0.wav"]["esc10"] is True
+        assert md["1-100038-A-14.wav"]["esc10"] is False
+
+    def test_numeric_fields_are_ints(self, tmp_path):
+        self._write_csv(tmp_path)
+        md = metadata.load_esc50_metadata(tmp_path)
+        entry = md["1-100038-A-14.wav"]
+        assert entry["target"] == 14
+        assert entry["fold"] == 2
+        assert isinstance(entry["target"], int)
+
+
+# ---------------------------------------------------------------------------
+# UrbanSound8K CSV
+# ---------------------------------------------------------------------------
+
+
+class TestUrbanSound8kMetadata:
+    def _write_csv(self, us8k_dir: Path) -> None:
+        meta = us8k_dir / "metadata"
+        meta.mkdir(parents=True)
+        (meta / "UrbanSound8K.csv").write_text(
+            "slice_file_name,fsID,start,end,salience,fold,classID,class\n"
+            "100032-3-0-0.wav,100032,0,4,1,5,3,dog_bark\n"
+            "100263-2-0-3.wav,100263,0,4,1,10,2,children_playing\n",
+            encoding="utf-8",
+        )
+
+    def test_parses_rows_and_builds_path(self, tmp_path):
+        self._write_csv(tmp_path)
+        md = metadata.load_urbansound8k_metadata(tmp_path)
+        entry = md["100032-3-0-0.wav"]
+        assert entry["category"] == "dog_bark"
+        assert entry["fold"] == 5
+        assert entry["class_id"] == 3
+        assert entry["path"] == tmp_path / "audio" / "fold5" / "100032-3-0-0.wav"
+
+    def test_second_row_uses_its_own_fold(self, tmp_path):
+        self._write_csv(tmp_path)
+        md = metadata.load_urbansound8k_metadata(tmp_path)
+        entry = md["100263-2-0-3.wav"]
+        assert entry["path"] == tmp_path / "audio" / "fold10" / "100263-2-0-3.wav"
+
+
+# ---------------------------------------------------------------------------
+# Oxford Flowers 102 (MAT file, scipy)
+# ---------------------------------------------------------------------------
+
+
+class TestOxfordFlowersMetadata:
+    def test_maps_labels_to_categories(self, tmp_path):
+        scipy_io = pytest.importorskip("scipy.io")
+        (tmp_path / "jpg").mkdir()
+        # 1-indexed labels: category index = label - 1.
+        labels = np.array([[1, 3, 2]], dtype=np.int64)
+        scipy_io.savemat(str(tmp_path / "imagelabels.mat"), {"labels": labels})
+        categories = ["pink primrose", "hard-leaved pocket orchid", "canterbury bells"]
+        md = metadata.load_oxford_flowers_metadata(tmp_path, categories)
+        assert md["image_00001.jpg"]["category"] == "pink primrose"  # label 1 -> idx 0
+        assert md["image_00002.jpg"]["category"] == "canterbury bells"  # label 3 -> idx 2
+        assert md["image_00003.jpg"]["category"] == "hard-leaved pocket orchid"  # label 2 -> idx 1
+        assert md["image_00001.jpg"]["path"] == tmp_path / "jpg" / "image_00001.jpg"
+
+    def test_out_of_range_label_is_skipped(self, tmp_path):
+        scipy_io = pytest.importorskip("scipy.io")
+        (tmp_path / "jpg").mkdir()
+        labels = np.array([[1, 99]], dtype=np.int64)  # 99 exceeds the 1-long category list
+        scipy_io.savemat(str(tmp_path / "imagelabels.mat"), {"labels": labels})
+        md = metadata.load_oxford_flowers_metadata(tmp_path, ["only category"])
+        assert "image_00001.jpg" in md
+        assert "image_00002.jpg" not in md
+
+
+# ---------------------------------------------------------------------------
+# Places365 label file
+# ---------------------------------------------------------------------------
+
+
+class TestPlaces365Metadata:
+    def _write(self, places_dir: Path, lines: str) -> None:
+        (places_dir / "val_256").mkdir(parents=True)
+        (places_dir / "places365_val.txt").write_text(lines, encoding="utf-8")
+
+    def test_maps_index_to_category(self, tmp_path):
+        self._write(
+            tmp_path,
+            "Places365_val_00000001.jpg 0\nPlaces365_val_00000002.jpg 2\n",
+        )
+        categories = ["airfield", "airplane_cabin", "airport_terminal"]
+        md = metadata.load_places365_metadata(tmp_path, categories)
+        assert md["Places365_val_00000001.jpg"]["category"] == "airfield"
+        assert md["Places365_val_00000002.jpg"]["category"] == "airport_terminal"
+        assert md["Places365_val_00000001.jpg"]["path"] == tmp_path / "val_256" / "Places365_val_00000001.jpg"
+
+    def test_blank_lines_and_bad_indices_are_skipped(self, tmp_path):
+        self._write(
+            tmp_path,
+            "\n"  # blank line
+            "Places365_val_00000001.jpg 0\n"
+            "Places365_val_00000002.jpg notanint\n"  # non-numeric index
+            "Places365_val_00000003.jpg 5\n",  # out-of-range index
+        )
+        md = metadata.load_places365_metadata(tmp_path, ["airfield"])
+        assert set(md) == {"Places365_val_00000001.jpg"}
+
+
+# ---------------------------------------------------------------------------
+# CIFAR-10 pickle batch
+# ---------------------------------------------------------------------------
+
+
+class TestCifar10Batch:
+    def test_reshapes_and_returns_labels(self, tmp_path):
+        rng = np.random.default_rng(0)
+        # 4 images, 3072 = 32*32*3 flat, in the original (C, H, W) row order.
+        data = rng.integers(0, 256, size=(4, 3072), dtype=np.uint8)
+        labels = [0, 5, 9, 3]
+        batch_path = tmp_path / "data_batch_1"
+        with open(batch_path, "wb") as f:
+            pickle.dump({b"data": data, b"labels": labels}, f)
+
+        images, out_labels, label_names = metadata.load_cifar10_batch(batch_path)
+        assert images.shape == (4, 32, 32, 3)
+        assert images.dtype == np.uint8
+        assert out_labels == labels
+        assert label_names[0] == "airplane"
+        assert label_names[9] == "truck"
+        assert len(label_names) == 10
+
+    def test_channel_transpose_is_correct(self, tmp_path):
+        # First image all red (R=255) in the (3,32,32) layout -> channel 0 hot.
+        img = np.zeros((1, 3, 32, 32), dtype=np.uint8)
+        img[0, 0] = 255
+        data = img.reshape(1, 3072)
+        batch_path = tmp_path / "data_batch_1"
+        with open(batch_path, "wb") as f:
+            pickle.dump({b"data": data, b"labels": [0]}, f)
+
+        images, _, _ = metadata.load_cifar10_batch(batch_path)
+        # After transpose to (H, W, C), the red channel is index 0.
+        assert (images[0, :, :, 0] == 255).all()
+        assert (images[0, :, :, 1] == 0).all()
+        assert (images[0, :, :, 2] == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Category-folder loaders (audio / video / image / paragraph)
+# ---------------------------------------------------------------------------
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x")
+
+
+class TestAudioFolderMetadata:
+    def test_collects_only_listed_categories(self, tmp_path):
+        _touch(tmp_path / "dog" / "a.wav")
+        _touch(tmp_path / "cat" / "b.mp3")
+        _touch(tmp_path / "ignored" / "c.flac")
+        md = metadata.load_audio_metadata_from_folders(tmp_path, ["dog", "cat"])
+        assert set(md) == {"dog/a.wav", "cat/b.mp3"}
+        assert md["dog/a.wav"]["category"] == "dog"
+        assert md["dog/a.wav"]["path"] == tmp_path / "dog" / "a.wav"
+
+    def test_skips_appledouble_sidecars(self, tmp_path):
+        _touch(tmp_path / "dog" / "real.wav")
+        _touch(tmp_path / "dog" / "._real.wav")  # macOS resource fork
+        md = metadata.load_audio_metadata_from_folders(tmp_path, ["dog"])
+        assert set(md) == {"dog/real.wav"}
+
+    def test_non_directory_entries_ignored(self, tmp_path):
+        _touch(tmp_path / "dog" / "a.wav")
+        (tmp_path / "loose.wav").write_bytes(b"x")  # a file at the root, not a category
+        md = metadata.load_audio_metadata_from_folders(tmp_path, ["dog"])
+        assert set(md) == {"dog/a.wav"}
+
+
+class TestVideoFolderMetadata:
+    def test_collects_video_extensions(self, tmp_path):
+        _touch(tmp_path / "run" / "a.mp4")
+        _touch(tmp_path / "jump" / "b.mkv")
+        _touch(tmp_path / "run" / "notvideo.txt")
+        md = metadata.load_video_metadata_from_folders(tmp_path, ["run", "jump"])
+        assert set(md) == {"run/a.mp4", "jump/b.mkv"}
+
+    def test_skips_appledouble_sidecars(self, tmp_path):
+        _touch(tmp_path / "run" / "clip.mp4")
+        _touch(tmp_path / "run" / "._clip.mp4")
+        md = metadata.load_video_metadata_from_folders(tmp_path, ["run"])
+        assert set(md) == {"run/clip.mp4"}
+
+
+class TestImageFolderMetadata:
+    def test_collects_image_extensions_keyed_by_category(self, tmp_path):
+        _touch(tmp_path / "cats" / "image_0001.jpg")
+        _touch(tmp_path / "dogs" / "image_0001.jpg")  # same basename, different category
+        _touch(tmp_path / "cats" / "readme.md")  # non-image ignored
+        md = metadata.load_image_metadata_from_folders(tmp_path, ["cats", "dogs"])
+        assert set(md) == {"cats/image_0001.jpg", "dogs/image_0001.jpg"}
+        assert md["cats/image_0001.jpg"]["category"] == "cats"
+
+
+class TestParagraphFolderMetadata:
+    def test_collects_txt_and_md(self, tmp_path):
+        _touch(tmp_path / "sport" / "a.txt")
+        _touch(tmp_path / "tech" / "b.md")
+        _touch(tmp_path / "sport" / "skip.pdf")
+        md = metadata.load_paragraph_metadata_from_folders(tmp_path, ["sport", "tech"])
+        assert set(md) == {"sport/a.txt", "tech/b.md"}
+        assert md["tech/b.md"]["path"] == tmp_path / "tech" / "b.md"
+
+    def test_unlisted_category_excluded(self, tmp_path):
+        _touch(tmp_path / "sport" / "a.txt")
+        _touch(tmp_path / "politics" / "b.txt")
+        md = metadata.load_paragraph_metadata_from_folders(tmp_path, ["sport"])
+        assert set(md) == {"sport/a.txt"}

--- a/tests_lib/io/test_sync_base.py
+++ b/tests_lib/io/test_sync_base.py
@@ -1,0 +1,159 @@
+"""Tests for the :class:`vtscore.sync.SyncSource` base contract.
+
+``SyncSource`` is the abstract, library-tier base shared by
+``SettingsSource`` and ``LabelsetSource``.  Its public ``load`` / ``save`` /
+``peek_version`` methods are framework-owned wrappers that normalize
+*field_values* (whitespace-strip, template-resolve, URL/path-validate) on a
+*copy* before delegating to the underscored ``_do_*`` template methods.  The
+concrete subclasses are covered elsewhere; here we pin the base guarantees
+directly with a minimal fake subclass carrying a plain text field.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.plugins import PluginField
+from vtscore.sync import SyncSource
+
+
+class _FakeSource(SyncSource):
+    """Minimal concrete sync source with a single whitespace-trimmable field."""
+
+    name = "fake_sync"
+    display_name = "Fake Sync"
+    description = "Test double."
+    fields = [PluginField(key="label", label="Label", field_type="text", required=False)]
+
+    def __init__(self) -> None:
+        self.loaded_with: dict | None = None
+        self.saved_data = None
+        self.saved_with: dict | None = None
+        self.peeked_with: dict | None = None
+
+    def _do_load(self, field_values):
+        self.loaded_with = field_values
+        return ["item"]
+
+    def _do_save(self, data, /, field_values):
+        self.saved_data = data
+        self.saved_with = field_values
+
+    def _do_peek_version(self, field_values):
+        self.peeked_with = field_values
+        return "v1"
+
+
+# ---------------------------------------------------------------------------
+# normalize-before-delegate
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeBeforeDelegate:
+    def test_load_strips_whitespace_before_delegating(self):
+        src = _FakeSource()
+        result = src.load({"label": "  padded  "})
+        assert result == ["item"]
+        assert src.loaded_with == {"label": "padded"}
+
+    def test_save_strips_whitespace_before_delegating(self):
+        src = _FakeSource()
+        src.save({"a": 1}, field_values={"label": "  x "})
+        assert src.saved_data == {"a": 1}
+        assert src.saved_with == {"label": "x"}
+
+    def test_peek_version_normalizes_then_delegates(self):
+        src = _FakeSource()
+        token = src.peek_version({"label": " y "})
+        assert token == "v1"
+        assert src.peeked_with == {"label": "y"}
+
+    def test_callers_dict_is_not_mutated(self):
+        src = _FakeSource()
+        original = {"label": "  keep spaces  "}
+        src.load(original)
+        # The normalize pass works on a copy; the caller's dict is untouched.
+        assert original == {"label": "  keep spaces  "}
+
+    def test_missing_optional_field_becomes_empty_string(self):
+        src = _FakeSource()
+        src.load({})
+        assert src.loaded_with == {"label": ""}
+
+
+# ---------------------------------------------------------------------------
+# required-field validation surfaces through the wrapper
+# ---------------------------------------------------------------------------
+
+
+class _RequiredSource(_FakeSource):
+    name = "required_sync"
+    fields = [PluginField(key="label", label="Label", field_type="text", required=True)]
+
+
+class TestRequiredValidation:
+    def test_empty_required_field_raises_before_delegate(self):
+        src = _RequiredSource()
+        with pytest.raises(ValueError, match="required"):
+            src.load({"label": "   "})
+        # _do_load never ran.
+        assert src.loaded_with is None
+
+
+# ---------------------------------------------------------------------------
+# peek_version error handling + defaults
+# ---------------------------------------------------------------------------
+
+
+class TestPeekVersion:
+    def test_peek_version_swallows_normalize_errors_to_none(self):
+        # A required-field violation during normalize must not crash the
+        # caller's cheap freshness probe — it degrades to None.
+        src = _RequiredSource()
+        assert src.peek_version({"label": ""}) is None
+        assert src.peeked_with is None
+
+    def test_default_do_peek_version_returns_none(self):
+        class _NoPeek(SyncSource):
+            name = "no_peek"
+            display_name = "No Peek"
+            description = ""
+            fields = []
+
+            def _do_load(self, field_values):
+                return None
+
+            def _do_save(self, data, /, field_values):
+                pass
+
+        assert _NoPeek().peek_version({}) is None
+
+
+# ---------------------------------------------------------------------------
+# abstract template methods raise until overridden
+# ---------------------------------------------------------------------------
+
+
+class TestAbstractHooks:
+    def test_do_load_not_implemented(self):
+        class _Bare(SyncSource):
+            name = "bare"
+            display_name = "Bare"
+            description = ""
+            fields = []
+
+        with pytest.raises(NotImplementedError, match="_do_load"):
+            _Bare()._do_load({})
+
+    def test_do_save_not_implemented(self):
+        class _Bare(SyncSource):
+            name = "bare2"
+            display_name = "Bare2"
+            description = ""
+            fields = []
+
+        with pytest.raises(NotImplementedError, match="_do_save"):
+            _Bare()._do_save({}, {})
+
+    def test_default_icon_is_sync_arrows(self):
+        assert SyncSource.icon == "\U0001f504"


### PR DESCRIPTION
Adds focused unit tests for the thinly-covered backend modules called out in #2417. No production code changes — tests only.

## What's covered

- **`vtscore/datasets/metadata.py`** (was ~49%) — `tests_lib/datasets/test_metadata.py`: the ESC-50 / UrbanSound8K CSV loaders, the Oxford Flowers MAT loader (via scipy), the Places365 label-file loader (incl. blank-line / bad-index skipping), the CIFAR-10 pickle-batch reshape + channel transpose, and the audio/video/image/paragraph category-folder scanners (incl. AppleDouble-sidecar skipping and unlisted-category exclusion).
- **`vtscore/sync` `SyncSource` base** — `tests_lib/io/test_sync_base.py`: the normalize-before-delegate contract with a minimal fake subclass — whitespace strip before `_do_load`/`_do_save`/`_do_peek_version`, caller-dict-not-mutated, required-field validation surfacing through the public wrapper, `peek_version` swallowing normalize errors to `None`, default hooks returning `None` / raising `NotImplementedError`.
- **`LocalArchiveMemberSource`** — `tests_lib/datasets/test_local_archive_member_source.py`: window-keyed `list_items`, bare-member fallback to the first window, extension filtering (case-insensitive), `fetch_item` returning embeddings never paths, `origin_name`/`filename` resolution, the `archive::member` origin-name form, embedder-name fallback to the manifest, and the auto-discovery factory.
- **gui exporter origin formatting** — `tests/io/test_exporters.py`: `_format_origin` for a real `Origin` (`display()`), a `None` origin, and a malformed dict (degrades to `str(origin)`), plus the `export_cli` / `export_cli_streaming` paths that print the origin before the name and skip `bad` hits.
- **`vtsearch/settings_store.py`** primitives — `tests/core/test_settings_store.py`: `_load_path` / `_atomic_write` (round-trip, parent-dir creation, no temp-file leftover, overwrite) and the cross-worker sync-marker `read`/`write` helpers including their error-swallowing branches (absent / malformed / non-dict marker, `None` and non-serialisable tokens), plus the per-path lock stability.
- **`vtsearch/schemas/achievements.py`** — `tests/core/test_achievements.py`: direct `dump`/`load` serialization of a real `get_full_state()` payload and the acknowledge/check-phrase request/response schemas (previously only exercised indirectly through the routes).

## Testing

`./run-tests.sh` green — all gates (ruff, ruff format, codespell, deptry, pyright, `vtscore-clean`, frontend build) pass and **5843 tests pass** (was 5609).

Closes #2417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DearBKSjPF4bjtgSTb2Gf9)_