### PR TITLE
Hash the threshold calibration cache key (S5)

### DIFF
--- a/.claude/hooks/ensure-test-deps.sh
+++ b/.claude/hooks/ensure-test-deps.sh
@@ -43,7 +43,9 @@ pip install --upgrade setuptools -q
 #     we use --ignore-installed to drop fresh copies alongside.
 #   - urllib3 2.6.3 is a real transitive dep (via requests); newer
 #     versions patch CVE-2026-44431/44432.
-pip install --upgrade --ignore-installed pip wheel cryptography pyjwt urllib3 -q
+#   - httplib2 0.20.4 ships pre-installed (via launchpadlib, debian-managed);
+#     0.32.0 patches PYSEC-2026-3444. Unused by VTSearch.
+pip install --upgrade --ignore-installed pip wheel cryptography pyjwt urllib3 httplib2 -q
 
 # Work around debian-managed blinker (no RECORD file, so pip cannot
 # uninstall it).  Force-installing a fresh copy lets Flask pick it up.

--- a/docs/plans/scalability.md
+++ b/docs/plans/scalability.md
@@ -29,9 +29,7 @@ deferred. Items are independently shippable.
 
 ## Suggested work order (open items, max-leverage first)
 
-1. **S5** (hash the threshold cache key); trivial, eliminates a fat cache key
-   before it becomes a memory landmine.
-2. **S14** (incremental secondary indexes on `DatasetContext`); removes per-request
+1. **S14** (incremental secondary indexes on `DatasetContext`); removes per-request
    O(N) dict rebuilds; medium refactor.
 3. **S1** (mmap embedding matrix); unblocks 1 M+ datasets without OOM. Also
    decouples embeddings from the pickle, which unblocks S15.
@@ -191,12 +189,6 @@ into the embedding matrix on load (S1), replacing `media["embedding"]` with a
 row-index pointer — ~60–70% smaller per-item dict at 384-dim. The full columnar
 rewrite (per-field NumPy arrays or a Polars frame) is deferred: it touches every
 media-reading call site.
-
----
-
-### S5: threshold cache key contains full training vectors as bytes
-
-- [ ] #2406 — Hash the threshold cache key instead of storing raw training vectors (fix sketch in the issue)
 
 ---
 
@@ -417,7 +409,6 @@ embedder. Shares the S11 approach.
 | **No streaming** for large JSON / pickle payloads | S3, S13, S15 |
 | **Serial I/O** where parallelism is easy | S11, S20 |
 | **No debouncing** on high-frequency write paths | S12 |
-| **Oversized cache keys** containing raw vectors | S5 |
 | **Per-request rebuild** of secondary lookups | S14 |
 
 ---

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -9,6 +9,7 @@ from votes, caching on ``DetectorContext``) lives in
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 
 import numpy as np
@@ -101,19 +102,26 @@ def _calibration_cache_key(
     function of these inputs (RNG seeded with 42 at every cached call site)
     and are **inclusion-independent** - ``inclusion`` is deliberately *not* in
     the key, so an Inclusion change hits the cache and only re-runs the cheap
-    min-cost search.  The key encodes the raw training vectors (not just label
-    IDs) so a labelset re-resolved to different embeddings - e.g. after the
-    embedder changes - invalidates the cache automatically.  See
+    min-cost search.  The key encodes a hash of the raw training vectors (not
+    just label IDs) so a labelset re-resolved to different embeddings - e.g.
+    after the embedder changes - invalidates the cache automatically.  See
     docs/plans/find-verification-workflow.md.
     """
-    X_bytes = np.stack(X_list).astype(np.float32, copy=False).tobytes()
-    y_bytes = np.asarray(y_list, dtype=np.float32).tobytes()
+    # Hash the raw training vectors rather than embedding them in the key.
+    # The full ``(N_labels x D x 4)``-byte string reaches ~150 MB at 100k
+    # labels and would live in the calibration cache until the next call
+    # invalidates it. blake2b (fast, 128-bit digest) keeps the key tiny while
+    # still changing whenever the labelset re-resolves to different embeddings
+    # (e.g. after the embedder changes); the cache is already invalidated by any
+    # vote change, so the hash is purely for collision resistance.
+    X_hash = hashlib.blake2b(np.stack(X_list).astype(np.float32, copy=False).tobytes()).digest()
+    y_hash = hashlib.blake2b(np.asarray(y_list, dtype=np.float32).tobytes()).digest()
     # Bag membership changes the fold split and per-group max-pool, so a change
     # in grouping must invalidate the cached orderings even when X/y are equal.
     groups_key = tuple(str(g) for g in groups) if groups is not None else None
     return (
-        X_bytes,
-        y_bytes,
+        X_hash,
+        y_hash,
         int(calibrate_count),
         float(calibration_fraction),
         int(hidden_dim),


### PR DESCRIPTION
## Summary

`_calibration_cache_key` in `vtscore/training/thresholds.py` embedded the full training vectors as a raw byte string in the cache key:

```python
X_bytes = np.stack(X_list).astype(np.float32, copy=False).tobytes()
y_bytes = np.asarray(y_list, dtype=np.float32).tobytes()
```

At D=384 this is `(N_labels × D × 4)` bytes per key — ~15 MB at 10k labels, ~150 MB at 100k — and the tuple lives on `DetectorContext.calibration_cache` until the next vote change invalidates it.

This hashes the vectors with `hashlib.blake2b(...).digest()` (fast, 128-bit) instead, so the key stays tiny. The hash is deterministic, so equality/inequality semantics are unchanged: the cache still invalidates whenever the labelset re-resolves to different embeddings (e.g. after the embedder changes), and inclusion-only changes still hit the cache. The hash is purely for collision resistance — the cache is already invalidated by any vote change.

Scalability item **S5** from `docs/plans/scalability.md`; the item, work-order entry, and now-empty root-cause table row are pruned from the plan.

## Incidental

Bumped the pre-installed `httplib2` (0.20.4 → 0.32.0) in `ensure-test-deps.sh` to clear a newly-published `pip-audit` advisory (PYSEC-2026-3444) that was blocking the test gate. It ships via `launchpadlib` (a debian-managed system package) and is unused by VTSearch; the bump matches the existing urllib3/cryptography system-package upgrade pattern.

## Testing

- `./run-tests.sh` — full suite green (6100 passed)
- `./run-tests.sh sorting detectors` — calibration-cache tests green

Closes #2406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L26NqBvbk7d8dtRFSEYipW)_