### PR TITLE
Offer "Export first" escape hatch before destructive settings reset

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.spec.ts
@@ -160,7 +160,7 @@ describe('SettingsModalComponent', () => {
 
   it('should reset to defaults after confirmation', async () => {
     await flushInit();
-    vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(true));
+    vi.spyOn(component['dialog'], 'confirmDestructiveWithEscape').mockReturnValue(Promise.resolve('confirm'));
     component.resetDefaults();
     // Drain the confirm() promise continuation that issues the GET.
     await new Promise<void>((resolve) => setTimeout(resolve));
@@ -175,9 +175,19 @@ describe('SettingsModalComponent', () => {
 
   it('should not reset when confirmation is declined', async () => {
     await flushInit();
-    vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(false));
+    vi.spyOn(component['dialog'], 'confirmDestructiveWithEscape').mockReturnValue(Promise.resolve('cancel'));
     component.resetDefaults();
     await new Promise<void>((resolve) => setTimeout(resolve));
+    httpMock.expectNone('/api/settings/defaults');
+  });
+
+  it('should open the exporter and skip reset when the escape hatch is chosen', async () => {
+    await flushInit();
+    vi.spyOn(component['dialog'], 'confirmDestructiveWithEscape').mockReturnValue(Promise.resolve('escape'));
+    expect(component.showExporterModal).toBe(false);
+    component.resetDefaults();
+    await new Promise<void>((resolve) => setTimeout(resolve));
+    expect(component.showExporterModal).toBe(true);
     httpMock.expectNone('/api/settings/defaults');
   });
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -559,12 +559,19 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
   }
 
   async resetDefaults(): Promise<void> {
-    const ok = await this.dialog.confirmDestructive(
+    const choice = await this.dialog.confirmDestructiveWithEscape(
       'Reset all settings to factory defaults?',
       'Your current preferences (appearance, view modes, autopilot, sorting, and other per-user settings) will be overwritten and cannot be recovered.',
       'Reset',
+      'Export first…',
     );
-    if (!ok) return;
+    if (choice === 'cancel') return;
+    if (choice === 'escape') {
+      // Escape hatch: let the user save their current config before resetting.
+      // Reset is abandoned; they can re-initiate it after exporting.
+      this.openExporter();
+      return;
+    }
     this.settingsApi
       .getDefaults()
       .pipe(takeUntil(this.destroy$))

--- a/frontend/src/app/services/dialog.service.spec.ts
+++ b/frontend/src/app/services/dialog.service.spec.ts
@@ -46,6 +46,21 @@ describe('VtDialogService', () => {
     expect(result).toBeNull();
   });
 
+  it('confirmDestructiveWithEscape exposes Cancel, escape, and action buttons', async () => {
+    const promise = service.confirmDestructiveWithEscape('Reset?', 'Cannot be undone.', 'Reset', 'Export first…');
+    const labels = service.dialogButtons().map((b) => b.label);
+    expect(labels).toEqual(['Cancel', 'Export first…', 'Reset']);
+    // Cancel is the first non-primary button, so backdrop/Escape dismissal resolves 'cancel'.
+    service.cancel();
+    expect(await promise).toBe('cancel');
+  });
+
+  it('confirmDestructiveWithEscape resolves escape when the escape hatch is chosen', async () => {
+    const promise = service.confirmDestructiveWithEscape('Reset?', 'Cannot be undone.', 'Reset', 'Export first…');
+    service.resolve('escape');
+    expect(await promise).toBe('escape');
+  });
+
   it('getIconType should return correct icon type', () => {
     service.dialogType.set('warning');
     expect(service.getIconType()).toBe('warning');

--- a/frontend/src/app/services/dialog.service.ts
+++ b/frontend/src/app/services/dialog.service.ts
@@ -75,6 +75,34 @@ export class VtDialogService {
     }) as Promise<boolean>;
   }
 
+  /**
+   * Like {@link confirmDestructive}, but inserts a middle "escape hatch"
+   * button (e.g. "Export first…") between Cancel and the destructive action,
+   * so the user can save their state before committing. Resolves:
+   *   'confirm' — the destructive action was chosen
+   *   'escape'  — the escape-hatch action was chosen
+   *   'cancel'  — Cancel, Escape key, or backdrop dismissal
+   * Cancel stays the first non-primary button so backdrop/Escape dismissal
+   * (which resolves the first non-primary value) still reads as 'cancel'.
+   */
+  confirmDestructiveWithEscape(
+    question: string,
+    detail: string,
+    actionLabel: string,
+    escapeLabel: string,
+  ): Promise<'confirm' | 'escape' | 'cancel'> {
+    return this.show({
+      message: `${question} ${detail}`,
+      type: 'warning',
+      showInput: false,
+      buttons: [
+        { label: 'Cancel', primary: false, value: 'cancel' },
+        { label: escapeLabel, primary: false, value: 'escape' },
+        { label: actionLabel, primary: true, value: 'confirm' },
+      ],
+    }) as Promise<'confirm' | 'escape' | 'cancel'>;
+  }
+
   prompt(message: string, defaultValue = '', type: DialogType = 'info'): Promise<string | null> {
     return this.show({
       message,


### PR DESCRIPTION
## What

Resetting all settings to factory defaults (`resetDefaults()` in the settings modal) is irreversible, and the confirm dialog previously said as much ("…overwritten and cannot be recovered") without giving the user any in-flow way to save their config first.

This adds an **"Export first…"** escape-hatch button to that confirm dialog. Choosing it abandons the reset and opens the settings exporter, so the user can save their current config; they can re-initiate the reset afterward.

## How

- **`VtDialogService.confirmDestructiveWithEscape()`** (new): a three-way variant of `confirmDestructive` that inserts a middle non-primary escape-hatch button between Cancel and the destructive action. Resolves `'confirm' | 'escape' | 'cancel'`. Cancel stays the first non-primary button, so backdrop/Escape-key dismissal (which resolves the first non-primary value) still reads as `'cancel'`.
- **`resetDefaults()`**: now calls the new method. `'cancel'` → no-op; `'escape'` → opens the exporter and returns without resetting; `'confirm'` → the existing reset path.
- The dialog host already renders an arbitrary button list, so no template change was needed.

## Tests

- Updated the two existing `resetDefaults` specs to the new method and its `'confirm'`/`'cancel'` return values.
- Added a spec asserting the `'escape'` choice opens the exporter and issues no defaults request.
- Added two `VtDialogService` specs covering the new button layout (`['Cancel', 'Export first…', 'Reset']`), backdrop-dismiss → `'cancel'`, and explicit `'escape'` resolution.

Frontend Vitest suite (1439 tests) passes and `build:prod` is warning-free.

Closes #2375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017vm4dvZeF5tRdzQA5d83jS)_