### PR TITLE
Support template variables in the email exporter subject

### DIFF
--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -479,12 +479,20 @@ class TestEmailLabelsetExporter:
         keys = {f.key for f in exp.fields}
         assert "to" in keys
 
-    def test_fields_are_from_and_to(self):
+    def test_fields_are_from_to_and_subject(self):
         from vtscore.exporters import get_exporter
 
         exp = get_exporter("email_smtp")
         keys = {f.key for f in exp.fields}
-        assert keys == {"from", "to"}
+        assert keys == {"from", "to", "subject"}
+
+    def test_subject_field_is_optional_and_templated(self):
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        subject = next(f for f in exp.fields if f.key == "subject")
+        assert subject.required is False
+        assert "YYYYMMDD" in subject.template_vars
 
     def test_export_raises_on_missing_to(self):
         from vtscore.exporters import get_exporter
@@ -556,6 +564,55 @@ class TestEmailLabelsetExporter:
         assert recipients == ["you@example.com"]
         assert "message" in result
         assert "you@example.com" in result["message"]
+
+    def _mock_smtp(self):
+        mock_server = MagicMock()
+        mock_smtp_cls = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_server, mock_smtp_cls
+
+    def _sent_subject(self, mock_server):
+        _, _, raw_msg = mock_server.sendmail.call_args.args
+        import email
+
+        return email.message_from_string(raw_msg)["Subject"]
+
+    def test_custom_subject_is_used(self):
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        mock_server, mock_smtp_cls = self._mock_smtp()
+
+        with (
+            patch("vtscore.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
+            patch("vtscore.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls),
+        ):
+            exp.export(
+                SAMPLE_RESULTS,
+                {"from": "me@my-domain.example", "to": "you@example.com", "subject": "Nightly run 2026-07-14"},
+            )
+
+        assert self._sent_subject(mock_server) == "Nightly run 2026-07-14"
+
+    def test_blank_subject_falls_back_to_generated(self):
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        mock_server, mock_smtp_cls = self._mock_smtp()
+
+        with (
+            patch("vtscore.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
+            patch("vtscore.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls),
+        ):
+            exp.export(
+                SAMPLE_RESULTS,
+                {"from": "me@my-domain.example", "to": "you@example.com", "subject": ""},
+            )
+
+        subject = self._sent_subject(mock_server)
+        assert "Auto-Detect" in subject
+        assert "audio" in subject
 
     def test_plain_text_builder(self):
         from vtscore.exporters.email_smtp import _build_plain_text
@@ -723,6 +780,39 @@ class TestExportEndpoint:
         assert data["success"] is True
         assert "you@example.com" in data["message"]
         mock_server.sendmail.assert_called_once()
+
+    def test_email_exporter_substitutes_subject_template(self, client):
+        """A {template} var in the subject is resolved at route ingress."""
+        import re
+
+        mock_server = MagicMock()
+        mock_smtp_cls = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("vtscore.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
+            patch("vtscore.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls),
+        ):
+            res = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "email_smtp",
+                    "field_values": {
+                        "from": "me@my-domain.example",
+                        "to": "you@example.com",
+                        "subject": "Run {YYYYMMDD}",
+                    },
+                    "results": SAMPLE_RESULTS,
+                },
+            )
+        assert res.status_code == 200
+        import email as _email
+
+        _, _, raw_msg = mock_server.sendmail.call_args.args
+        subject = _email.message_from_string(raw_msg)["Subject"]
+        assert "{YYYYMMDD}" not in subject
+        assert re.fullmatch(r"Run \d{8}", subject)
 
     def test_export_with_empty_results_dict(self, client):
         res = client.post(

--- a/vtscore/exporters/email_smtp/__init__.py
+++ b/vtscore/exporters/email_smtp/__init__.py
@@ -138,8 +138,7 @@ class EmailLabelsetExporter(LabelsetExporter):
             required=False,
             description="Subject line for the email. Leave blank for an auto-generated summary.",
             hint=(
-                "Template variables: {YYYYMMDD-HHMMSS}, {YYYYMMDD}, {YYYY}, {MM}, {DD}, "
-                "{detector_name}, {username}."
+                "Template variables: {YYYYMMDD-HHMMSS}, {YYYYMMDD}, {YYYY}, {MM}, {DD}, {detector_name}, {username}."
             ),
             placeholder="VTSearch Auto-Detect Results {YYYYMMDD}",
             template_vars=("YYYYMMDD-HHMMSS", "YYYYMMDD", "YYYY", "MM", "DD", "detector_name", "username"),

--- a/vtscore/exporters/email_smtp/__init__.py
+++ b/vtscore/exporters/email_smtp/__init__.py
@@ -86,6 +86,13 @@ def _build_html(results: dict[str, Any]) -> str:
     )
 
 
+def _default_subject(results: dict[str, Any]) -> str:
+    """Auto-generated subject used when the user leaves the field blank."""
+    media_type = results.get("media_type", "unknown")
+    total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
+    return f"VTSearch Auto-Detect: {total_hits} hit(s) on {media_type} dataset"
+
+
 def _resolve_mx(domain: str) -> str:
     """Return the highest-priority MX host for *domain*."""
     import dns.resolver  # lazy import – dnspython is optional
@@ -124,6 +131,19 @@ class EmailLabelsetExporter(LabelsetExporter):
             description="The email address to send the results to.",
             placeholder="recipient@example.com",
         ),
+        PluginField(
+            key="subject",
+            label="Subject",
+            field_type="text",
+            required=False,
+            description="Subject line for the email. Leave blank for an auto-generated summary.",
+            hint=(
+                "Template variables: {YYYYMMDD-HHMMSS}, {YYYYMMDD}, {YYYY}, {MM}, {DD}, "
+                "{detector_name}, {username}."
+            ),
+            placeholder="VTSearch Auto-Detect Results {YYYYMMDD}",
+            template_vars=("YYYYMMDD-HHMMSS", "YYYYMMDD", "YYYY", "MM", "DD", "detector_name", "username"),
+        ),
     ]
 
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
@@ -138,9 +158,11 @@ class EmailLabelsetExporter(LabelsetExporter):
         domain = to_addr.rsplit("@", 1)[1]
         mx_host = _resolve_mx(domain)
 
-        media_type = results.get("media_type", "unknown")
         total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
-        subject = f"VTSearch Auto-Detect: {total_hits} hit(s) on {media_type} dataset"
+        # The framework substitutes any {template} vars into ``subject`` at
+        # ingress (see vtscore.plugins.normalize); a blank field falls back to
+        # the auto-generated summary so existing behaviour is preserved.
+        subject = field_values.get("subject") or _default_subject(results)
 
         msg = MIMEMultipart("alternative")
         msg["Subject"] = subject


### PR DESCRIPTION
## What

Adds an optional, templated **Subject** field to the `email_smtp` exporter so subjects can carry date stamps (and detector/username) via the shared plugin template machinery — e.g. `VTSearch Auto-Detect Results {YYYYMMDD}`.

Previously the subject was hard-generated from the run's hit count and media type with no way to customize it.

## How

- New `subject` `PluginField` (`field_type="text"`, `required=False`) declaring `template_vars=("YYYYMMDD-HHMMSS", "YYYYMMDD", "YYYY", "MM", "DD", "detector_name", "username")`. The framework substitutes these at ingress (`vtscore.plugins.normalize.normalize_field_values`) for both the HTTP and CLI paths — no new template code, it reuses exactly what the file exporters use.
- `export()` uses `field_values.get("subject")`; a **blank** subject falls back to the existing auto-generated summary (`_default_subject`), so current behaviour is preserved by default.
- Because it's a declared field, the CLI automatically gains an optional `--subject` argument.

## Tests

- Updated the field-set assertion to `{"from", "to", "subject"}` and added coverage: subject field is optional + templated, a custom subject is used verbatim, a blank subject falls back to the generated summary, and a `{YYYYMMDD}` subject is substituted end-to-end through the `/api/exporters/export` route.
- Full `./run-tests.sh` suite passes (6104 passed).

## Incidental

`ensure-test-deps.sh` now upgrades `httplib2` (0.20.4 → 0.32.0) alongside the other pre-installed Ubuntu packages, patching `PYSEC-2026-3444` so the `pip-audit` gate in `run-tests.sh` stops blocking. `httplib2` is pulled in transitively by the system `launchpadlib` apt tool, not a VTSearch dependency.

Closes #2385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011xoT1oq1Jzti2WG3iRHh9R)_