### PR TITLE
Stream the GUI label-export route via ?format=ndjson (S13)

### DIFF
--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -471,7 +471,13 @@ POST /api/textsort-suggestions
 GET /api/labels/export
 ```
 
-**Query:** `?goods_only=1` (optional): export only good labels.
+**Query:**
+- `?goods_only=1` (optional): export only good labels.
+- `?format=ndjson` (optional): stream the response as newline-delimited JSON
+  (`application/x-ndjson`), one label entry per line, instead of the buffered
+  `{"labels": [...]}` object. Use for large exports that shouldn't be
+  materialised in memory server-side. The top-level `available_columns` list
+  (see `enrich`) is omitted in this mode.
 
 → LabelSet JSON with per-element origin and MD5 info:
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -12582,6 +12582,20 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "description": "Response encoding. ``json`` (default) returns the buffered ``{labels: [...]}`` object. ``ndjson`` streams one label entry per line (newline-delimited JSON, ``application/x-ndjson``) so large exports are never materialised in memory; the top-level ``available_columns`` list is omitted in this mode since it's a whole-set aggregate a streamed response can't compute.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "enum": [
+                "json",
+                "ndjson"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/tests/io/test_labels.py
+++ b/tests/io/test_labels.py
@@ -1,4 +1,12 @@
+import json
+
 import app as app_module
+
+
+def _read_ndjson(resp):
+    """Parse a streamed NDJSON export response into a list of label dicts."""
+    text = resp.get_data(as_text=True)
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
 
 
 class TestExportLabels:
@@ -44,6 +52,76 @@ class TestExportLabels:
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         assert "dataset_creation_info" not in data
+
+
+class TestExportLabelsNdjson:
+    """The streaming ``?format=ndjson`` variant of ``GET /api/labels/export`` (S13)."""
+
+    def test_empty_export_streams_nothing(self, client):
+        resp = client.get("/api/labels/export?format=ndjson")
+        assert resp.status_code == 200
+        assert resp.mimetype == "application/x-ndjson"
+        assert _read_ndjson(resp) == []
+
+    def test_streams_one_line_per_label(self, client):
+        app_module.good_votes.update({k: None for k in [1, 2]})
+        app_module.bad_votes.update({k: None for k in [3, 4]})
+        resp = client.get("/api/labels/export?format=ndjson")
+        assert resp.mimetype == "application/x-ndjson"
+        rows = _read_ndjson(resp)
+        assert len(rows) == 4
+        assert all("md5" in r and "label" in r for r in rows)
+
+    def test_ndjson_matches_buffered_labels(self, client):
+        """The streamed rows equal the buffered ``labels`` list, entry for entry."""
+        app_module.good_votes.update({k: None for k in [1, 3, 5]})
+        app_module.bad_votes.update({k: None for k in [2, 4]})
+
+        buffered = client.get("/api/labels/export").get_json()["labels"]
+        streamed = _read_ndjson(client.get("/api/labels/export?format=ndjson"))
+        assert streamed == buffered
+
+    def test_goods_only_filter(self, client):
+        app_module.good_votes.update({k: None for k in [1, 2]})
+        app_module.bad_votes.update({k: None for k in [3, 4]})
+        resp = client.get("/api/labels/export?format=ndjson&goods_only=true")
+        rows = _read_ndjson(resp)
+        assert len(rows) == 2
+        assert all(r["label"] == "good" for r in rows)
+
+    def test_corrections_filter_streams_only_changed(self, client):
+        from vtsearch.state import set_find_initial_labels
+
+        set_find_initial_labels({1: "good", 2: "bad", 3: "good"})
+        app_module.good_votes.update({1: None, 2: None})  # 2 was bad -> correction
+        app_module.bad_votes[3] = None  # 3 was good -> correction
+
+        resp = client.get("/api/labels/export?format=ndjson&label_filter=corrections")
+        rows = _read_ndjson(resp)
+        assert len(rows) == 2
+        assert all(r["is_correction"] is True for r in rows)
+        md5s = {r["md5"] for r in rows}
+        assert app_module.medias[2]["md5"] in md5s
+        assert app_module.medias[3]["md5"] in md5s
+
+    def test_corrections_filter_empty_without_find_labels(self, client):
+        app_module.good_votes[1] = None
+        app_module.bad_votes[2] = None
+        resp = client.get("/api/labels/export?format=ndjson&label_filter=corrections")
+        assert _read_ndjson(resp) == []
+
+    def test_enrich_attaches_custom_metadata_but_no_available_columns(self, client):
+        app_module.good_votes[1] = None
+        resp = client.get("/api/labels/export?format=ndjson&enrich=true")
+        rows = _read_ndjson(resp)
+        assert len(rows) == 1
+        # ``available_columns`` is a whole-set aggregate and is never a row.
+        assert all("labels" not in r and "available_columns" not in r for r in rows)
+        assert "custom_metadata" in rows[0]
+
+    def test_invalid_format_rejected(self, client):
+        resp = client.get("/api/labels/export?format=csv")
+        assert resp.status_code == 422
 
 
 class TestImportLabels:

--- a/vtscore/datasets/labelset.py
+++ b/vtscore/datasets/labelset.py
@@ -20,7 +20,7 @@ work; new consumers get the additional provenance fields.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Iterator
 
 
 @dataclass
@@ -260,6 +260,19 @@ class LabelSet:
         if self.detector_meta is not None:
             out["detector_meta"] = dict(self.detector_meta)
         return out
+
+    def iter_dicts(self) -> Iterator[dict[str, Any]]:
+        """Yield each element's serialised dict one at a time.
+
+        The streaming counterpart to :meth:`to_dict`'s ``labels`` list: it
+        never materialises the full ``[e.to_dict() for e in self.elements]``
+        list (~50 MB at 100 k labels), so a label export can be encoded
+        element-by-element.  Used by the GUI ``?format=ndjson`` export path
+        (scalability item S13); ``detector_meta`` is not emitted here since
+        NDJSON carries one label per line, not the top-level wrapper.
+        """
+        for e in self.elements:
+            yield e.to_dict()
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> LabelSet:

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -108,7 +108,7 @@ def _make_correction_annotator(all_medias: dict):
             md5_to_id[md5_val] = mid
 
     def annotate(entry: dict) -> None:
-        media_id = md5_to_id.get(entry.get("md5"))
+        media_id = md5_to_id.get(entry.get("md5", ""))
         if media_id is not None and media_id in find_initial:
             entry["is_correction"] = entry.get("label") != find_initial[media_id]
         else:

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -83,19 +83,23 @@ def _select_vote_pools(
     return good_votes, ({} if goods_only else bad_votes)
 
 
-def _annotate_corrections(result: dict, all_medias: dict) -> None:
-    """Add ``is_correction`` to every label entry in *result* (mutates in place).
+def _make_correction_annotator(all_medias: dict):
+    """Return a per-entry ``is_correction`` annotator, or ``None`` when no find-initial state exists.
 
     A label is a correction when the detector's pre-vote label
     (``find_initial_labels``) differs from the current label. When there is
     no find-initial state (no detector was run, or the vote came from
-    outside Find), no entries are annotated.
+    outside Find), we return ``None`` so callers skip annotation entirely.
+
+    The ``md5 -> media_id`` map is built once here so the returned closure is
+    O(1) per entry, letting both the buffered and the streaming export paths
+    annotate one element at a time without re-scanning ``all_medias``.
     """
     from vtsearch.state import get_find_initial_labels
 
     find_initial = get_find_initial_labels()
     if not find_initial:
-        return
+        return None
 
     md5_to_id: dict[str, int] = {}
     for mid, m in all_medias.items():
@@ -103,12 +107,23 @@ def _annotate_corrections(result: dict, all_medias: dict) -> None:
         if md5_val and md5_val not in md5_to_id:
             md5_to_id[md5_val] = mid
 
-    for entry in result["labels"]:
+    def annotate(entry: dict) -> None:
         media_id = md5_to_id.get(entry.get("md5"))
         if media_id is not None and media_id in find_initial:
             entry["is_correction"] = entry.get("label") != find_initial[media_id]
         else:
             entry["is_correction"] = False
+
+    return annotate
+
+
+def _annotate_corrections(result: dict, all_medias: dict) -> None:
+    """Add ``is_correction`` to every label entry in *result* (mutates in place)."""
+    annotate = _make_correction_annotator(all_medias)
+    if annotate is None:
+        return
+    for entry in result["labels"]:
+        annotate(entry)
 
 
 def _build_entry_metadata(media: dict) -> dict:
@@ -142,8 +157,13 @@ def _build_entry_metadata(media: dict) -> dict:
 _BASE_EXPORT_COLUMNS = ["label", "md5", "origin_name", "filename", "category", "origin"]
 
 
-def _enrich_with_metadata(result: dict, all_medias: dict) -> None:
-    """Attach ``custom_metadata`` per entry and the ``available_columns`` list.
+def _make_enricher(all_medias: dict):
+    """Return a per-entry ``custom_metadata`` enricher.
+
+    The returned callable mutates one label entry in place (attaching
+    ``custom_metadata`` when the media has any) and returns the set of
+    metadata keys it added, so a streaming caller can annotate elements one
+    at a time.  The ``md5 -> media`` map is built once here.
 
     Flattens origin params so fields like ``contentID`` / ``mediaID`` /
     ``media_url`` surface as selectable export columns alongside the
@@ -151,15 +171,25 @@ def _enrich_with_metadata(result: dict, all_medias: dict) -> None:
     """
     md5_to_media = {m["md5"]: m for m in all_medias.values() if m.get("md5")}
 
-    all_meta_keys: set[str] = set()
-    for entry in result["labels"]:
+    def enrich(entry: dict) -> set[str]:
         media = md5_to_media.get(entry.get("md5"))
         if not media:
-            continue
+            return set()
         meta = _build_entry_metadata(media)
-        if meta:
-            entry["custom_metadata"] = meta
-            all_meta_keys.update(meta.keys())
+        if not meta:
+            return set()
+        entry["custom_metadata"] = meta
+        return set(meta.keys())
+
+    return enrich
+
+
+def _enrich_with_metadata(result: dict, all_medias: dict) -> None:
+    """Attach ``custom_metadata`` per entry and the ``available_columns`` list."""
+    enrich = _make_enricher(all_medias)
+    all_meta_keys: set[str] = set()
+    for entry in result["labels"]:
+        all_meta_keys.update(enrich(entry))
 
     base_lower = {c.lower() for c in _BASE_EXPORT_COLUMNS}
     extra_keys = sorted(k for k in all_meta_keys if k.lower() not in base_lower)
@@ -196,6 +226,10 @@ def export_labels(query: dict):
         bads,
         vote_region_boxes=snap.vote_region_boxes,
     )
+
+    if query["format"] == "ndjson":
+        return _stream_labels_ndjson(labelset, all_medias, label_filter, query["enrich"])
+
     result: dict = labelset.to_dict()
 
     _annotate_corrections(result, all_medias)
@@ -206,6 +240,45 @@ def export_labels(query: dict):
         _enrich_with_metadata(result, all_medias)
 
     return result
+
+
+def _stream_labels_ndjson(labelset, all_medias: dict, label_filter: str, enrich: bool):
+    """Stream the labelset as newline-delimited JSON, one label entry per line (S13).
+
+    Encodes one :class:`~vtscore.datasets.labelset.LabeledElement` at a time
+    via :meth:`LabelSet.iter_dicts`, wrapped in ``flask.stream_with_context``
+    so the buffered ``[e.to_dict() for e in elements]`` list (~50 MB at 100 k
+    labels) is never held in memory.  Each line carries the same
+    ``is_correction`` / ``custom_metadata`` annotations the buffered response
+    would attach, applied in the same order (annotate corrections, drop
+    non-corrections under ``label_filter=corrections``, then enrich).
+
+    The top-level ``available_columns`` list has no place in NDJSON: it's a
+    whole-set aggregate that can't be emitted before the last row is seen, and
+    consumers of a streamed export derive columns from the rows themselves.
+    """
+    import json
+
+    from flask import Response, stream_with_context
+
+    annotate = _make_correction_annotator(all_medias)
+    enricher = _make_enricher(all_medias) if enrich else None
+    corrections_only = label_filter == "corrections"
+
+    def generate():
+        for entry in labelset.iter_dicts():
+            if annotate is not None:
+                annotate(entry)
+            if corrections_only and not entry.get("is_correction"):
+                continue
+            if enricher is not None:
+                enricher(entry)
+            yield json.dumps(entry) + "\n"
+
+    return Response(
+        stream_with_context(generate()),
+        mimetype="application/x-ndjson",
+    )
 
 
 @labels_bp.route("/api/labels/import", methods=["POST"])

--- a/vtsearch/schemas/labels.py
+++ b/vtsearch/schemas/labels.py
@@ -84,6 +84,20 @@ class LabelsExportQuerySchema(Schema):
             ),
         },
     )
+    format = fields.String(
+        load_default="json",
+        validate=validate.OneOf(["json", "ndjson"]),
+        metadata={
+            "description": (
+                "Response encoding. ``json`` (default) returns the buffered "
+                "``{labels: [...]}`` object. ``ndjson`` streams one label entry "
+                "per line (newline-delimited JSON, ``application/x-ndjson``) so "
+                "large exports are never materialised in memory; the top-level "
+                "``available_columns`` list is omitted in this mode since it's a "
+                "whole-set aggregate a streamed response can't compute."
+            ),
+        },
+    )
 
     class Meta:
         # Tolerate unrelated query params (e.g. ``dataset_id`` /


### PR DESCRIPTION
## Summary

Scalability item **S13**. The GUI `export_labels` route (`vtsearch/routes/labels/vote.py`) buffered `LabelSet.to_dict()`'s full `[e.to_dict() for e in elements]` list (~50 MB at 100 k labels) before Flask JSON-encoded it. This adds a `?format=ndjson` query param that streams the response with `flask.stream_with_context`, encoding one `LabeledElement` per line so the full list is never materialised. The default (`json`) response is byte-for-byte identical — the CLI side already streamed via `--stream-results`; this is the remaining GUI half.

## Changes

- **`vtscore/datasets/labelset.py`** — new `LabelSet.iter_dicts()` generator that yields each element's dict one at a time (the streaming counterpart to `to_dict()`'s `labels` list).
- **`vtsearch/routes/labels/vote.py`** — `?format=ndjson` streams via `flask.stream_with_context` at `application/x-ndjson`, one label entry per line. The per-entry `is_correction` / `custom_metadata` annotations are factored into reusable builder helpers (`_make_correction_annotator`, `_make_enricher`) so the streaming path applies them one element at a time, in the same order as the buffered path (annotate corrections → drop non-corrections under `label_filter=corrections` → enrich). `available_columns` is omitted in ndjson mode since it's a whole-set aggregate a streamed response can't compute.
- **`vtsearch/schemas/labels.py`** — new `format` query field (`json` default, `ndjson`), regenerated `frontend/openapi.json`.
- **`tests/io/test_labels.py`** — `TestExportLabelsNdjson` covering empty stream, one-line-per-label, parity with the buffered `labels` list, `goods_only`, corrections filter (with and without find-initial state), `enrich` (custom_metadata present, no `available_columns`), and invalid-format rejection.
- **`docs/api/medias.md`** — documents the new param.

## Incidental (unblocks the test gate)

`pip-audit` in `run-tests.sh` was blocking on `PYSEC-2026-3444` in `httplib2 0.20.4`, a transitive dep of the debian-managed `launchpadlib` system package (not a VTSearch dependency), which surfaced in the advisory DB after the ignore list was last curated. `.claude/hooks/ensure-test-deps.sh` now upgrades `httplib2` to 0.32.0 alongside the other pre-installed system packages it already patches. Also fixed a `pyright` `reportArgumentType` in the refactored annotator (default the md5 lookup key to `""` so the `dict[str, int]` `.get()` never sees a `None` key).

Full `./run-tests.sh` green: 6108 passed, 1 skipped.

Closes #2407

🤖 Generated with [Claude Code](https://claude.com/claude-code)