### PR TITLE
Fill in measured OpenLogo demo media counts

### DIFF
--- a/tests_lib/datasets/test_demo_counts.py
+++ b/tests_lib/datasets/test_demo_counts.py
@@ -51,6 +51,16 @@ class TestDemoMediaCounts:
         a = DEMO_MEDIA_COUNTS["caltech101_a"]
         assert s + m + ll == a
 
+    def test_openlogo_recorded_counts(self):
+        # OpenLogo is multi-label and sliced *flat* over the in-vocab image list
+        # (not per-category), so the per-category estimate does not apply and
+        # these measured counts are required. Measured from the source's
+        # samples.json: 11985 images carry >=1 in-vocab brand; (S) is the first
+        # 1/10 of that flat list, floor(11985 * 0.1) == 1198.
+        assert DEMO_MEDIA_COUNTS["openlogo_a"] == 11985
+        assert DEMO_MEDIA_COUNTS["openlogo_s"] == 1198
+        assert DEMO_MEDIA_COUNTS["openlogo_s"] == int(DEMO_MEDIA_COUNTS["openlogo_a"] * (1 / 10))
+
     def test_all_smla_partitions_sum_to_full(self):
         # Every source whose recorded counts include all four S/M/L/A variants
         # slices its categories with the partitioning fractions [0,1/7],

--- a/vtscore/datasets/demo_counts.py
+++ b/vtscore/datasets/demo_counts.py
@@ -37,6 +37,8 @@ a consistency check.
 * ``caltech101_*`` (image) — 412 / 838 / 1704 / 2954
 * ``caltech256_*`` (image) — 534 / 1087 / 2179 / 3800
 * ``eurosat_*`` (image) — 3853 / 7713 / 15434 / 27000
+* ``openlogo_*`` (image) — 1198 (S) / 11985 (A); multi-label, sliced flat over
+  the image list, so S is 1/10 of A rather than a category partition
 * ``oxford_flowers_102_a`` (image) — 8189
 * ``places365_*`` (image) — 5110 / 10220 / 21170 / 36500
 * ``ucsf_documents_a`` (image) — 150 (6 categories × 25 PDFs each)
@@ -94,6 +96,8 @@ DEMO_MEDIA_COUNTS: dict[str, int] = {
     "kth_l": 347,
     "kth_m": 168,
     "kth_s": 84,
+    "openlogo_a": 11985,
+    "openlogo_s": 1198,
     "oxford_flowers_102_a": 8189,
     "places365_a": 36500,
     "places365_l": 21170,

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -526,8 +526,9 @@ def build_demo_datasets() -> list[DemoDataset]:
             download_size_mb=ROXFORD_IMAGES_DOWNLOAD_SIZE_MB,
         ),
         # OpenLogo is multi-label (an image may show several brands) and sliced
-        # flat over the image list, so — like Visual Genome — the advertised
-        # count is only an approximation of the per-category average.
+        # flat over the image list, so the per-category ``items_per_category``
+        # estimate does not apply; the advertised count comes from the measured
+        # DEMO_MEDIA_COUNTS entries instead (see vtscore/datasets/demo_counts.py).
         DemoDataset(
             id="openlogo_s",
             label="OpenLogo (S)",


### PR DESCRIPTION
## What & why

The `openlogo` demo advertised its pre-download `# Media` count via the per-category-average estimate, which doesn't apply to OpenLogo: it's multi-label and sliced **flat** over the in-vocab image list, not per category. So the picker showed an inaccurate figure (~4992 for (A) under the estimate vs. 11985 actual).

This measures the real counts from the source and records them in `DEMO_MEDIA_COUNTS`, mirroring the pattern for other demo sources (cf. #2355).

## Measured counts

Derived from the source's `samples.json` (the loader's collection phase: parse annotations → keep images carrying ≥1 in-vocab brand → filename-sort → flat-slice), which is what determines the post-load media count:

- `openlogo_a` = **11985** (all in-vocab images; every one of the 27,083 samples had its file present, so nothing was dropped)
- `openlogo_s` = **1198** (the first 1/10 of that flat list, `floor(11985 × 0.1)`)

## Changes

- `vtscore/datasets/demo_counts.py` — add `openlogo_a`/`openlogo_s` to `DEMO_MEDIA_COUNTS` (kept sorted) plus a docstring entry.
- `vtscore/media/image/_demo_sources.py` — update the stale "count is only an approximation" comment on the OpenLogo datasets; the advertised count now comes from the measured table.
- `tests_lib/datasets/test_demo_counts.py` — lock in the two measured counts and the S = 1/10 × A slice relationship.
- `.claude/hooks/ensure-test-deps.sh` — upgrade the pre-installed system `httplib2` (via debian's `launchpadlib`, not a VTSearch dep) to clear PYSEC-2026-3444, which was newly blocking the pip-audit gate. Follows the existing baseline-CVE upgrade block for other debian-managed packages.

Full `./run-tests.sh` passes (6101 passed).

Closes #2399
