### PR TITLE
Show "Empty" hint on zero-training detector cards

### DIFF
--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -81,7 +81,13 @@
         </td>
       }
       @case ('num_training') {
-        <td>{{ (detector.num_training ?? 0) | number }}</td>
+        <td>
+          @if (isUntrained) {
+            <span class="empty-hint" title="This detector has no labels yet — add some to train it">Empty</span>
+          } @else {
+            {{ (detector.num_training ?? 0) | number }}
+          }
+        </td>
       }
       @case ('last_trained_at') {
         <td>{{ formatDate(detector.last_trained_at) }}</td>

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.scss
@@ -61,6 +61,14 @@ td {
   font-size: var(--font-md);
 }
 
+// A zero-training detector shows this muted "Empty" hint in the # Training
+// column so a freshly created detector reads as new (awaiting labels) rather
+// than broken.
+.empty-hint {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 .type-cell {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
@@ -51,6 +51,17 @@ describe('DetectorCardComponent', () => {
   it('should display training count', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('50');
+    expect(el.querySelector('.empty-hint')).toBeNull();
+  });
+
+  it('should show an "Empty" hint instead of 0 on a zero-training detector', async () => {
+    fixture.componentRef.setInput('detector', { ...mockDetector, num_training: 0, last_trained_at: null });
+    await settleZoneless(fixture);
+    const el = fixture.nativeElement as HTMLElement;
+    const hint = el.querySelector('.empty-hint');
+    expect(hint).toBeTruthy();
+    expect(hint?.textContent?.trim()).toBe('Empty');
+    expect(component.isUntrained).toBe(true);
   });
 
   it('should enter rename mode on rename button click', async () => {

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -84,6 +84,13 @@ export class DetectorCardComponent {
   readonly checkboxToggle = output<void>();
   readonly security = output<void>();
 
+  /** True for a just-created detector that has never been trained (no labels
+   *  yet). Drives the "Empty" hint so a fresh detector reads as new rather than
+   *  broken. */
+  get isUntrained(): boolean {
+    return (this.detector?.num_training ?? 0) === 0;
+  }
+
   /** True when the current user created this detector (only the creator may
    *  rename/delete it or edit its access list). */
   get isOwner(): boolean {


### PR DESCRIPTION
## What

A just-created detector rendered `num_training` as a raw `0` in the **# Training** column, which read as "broken" rather than "new". This shows a muted, italic **Empty** hint in that column for zero-training detectors instead.

- `detector-card.component.html` — the `num_training` cell renders `Empty` (with a "add some labels to train it" tooltip) when the detector is untrained, otherwise the count as before.
- `detector-card.component.ts` — new `isUntrained` getter (`num_training ?? 0 === 0`).
- `detector-card.component.scss` — `.empty-hint` muted/italic style.
- `detector-card.component.spec.ts` — asserts the hint shows for a zero-training detector and stays absent for a trained one.

I used the short **"Empty"** label (not "Awaiting labels"), per the request.

### Screenshots
The user-doc screenshots frame *trained* detectors (`num_training > 0`), so this change—which only affects zero-training rows—doesn't alter any existing shot. No reshoot queued.

### Incidental: unblock the test gate
`pip-audit` (first step of `./run-tests.sh`) newly flags pre-installed `httplib2 0.20.4` (transitive via Ubuntu's `launchpadlib`) for PYSEC-2026-3444, blocking the whole gate. Added `httplib2` to the existing baseline system-package upgrade in `.claude/hooks/ensure-test-deps.sh` (alongside cryptography/pyjwt/urllib3); 0.32.0 patches it. Gate is green again.

## Testing
`./run-tests.sh frontend` passes: ruff/codespell/deptry/pip-audit/pyright all clean, prod build OK, 1437 Vitest tests pass.

Closes #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFXBaa9KF8K3Yvr3uDu4sj)_