### PR TITLE
Surface exact HuggingFace model id in portable-detector bundle

### DIFF
--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -40,7 +40,7 @@ GET /api/embedders
 **Query:** `?media_type=image` (optional): filter by `type_id` or
 `folder_import_name`.
 
-→ `{"embedders": [{"name": "siglip", "display_name": "SigLIP", "media_type_id": "image", ...}]}`
+→ `{"embedders": [{"name": "siglip", "display_name": "SigLIP", "model_id": "google/siglip-base-patch16-224", "media_type_id": "image", ...}]}`
 
 ### Embed on demand
 

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -352,6 +352,15 @@ export interface EmbedderInfo {
    * users can still see the registry key.
    */
   display_name?: string;
+  /**
+   * Concrete pretrained-model identifier the embedder loads — usually a
+   * HuggingFace repo id (e.g. ``"google/siglip-base-patch16-224"``), or a
+   * direct weights URL. ``null`` for embedders with no single downloadable
+   * model id (e.g. the classical SIFT/VLAD structural embedder). Surfaced in
+   * the portable-detector export bundle so a recipient knows exactly which
+   * model to run new media through.
+   */
+  model_id?: string | null;
   media_type_id: string;
   /**
    * Whether this embedder is the recommended default for its media type

--- a/tests/detectors/test_image_embedders.py
+++ b/tests/detectors/test_image_embedders.py
@@ -37,6 +37,7 @@ class TestImageClipEmbedder:
         assert ImageClipEmbedder().to_dict() == {
             "name": "clip",
             "display_name": "CLIP (general images)",
+            "model_id": "openai/clip-vit-base-patch32",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": True,
@@ -110,6 +111,7 @@ class TestImageSiglip2Embedder:
         assert ImageSiglip2Embedder().to_dict() == {
             "name": "siglip2",
             "display_name": "SigLIP 2 (general images)",
+            "model_id": "google/siglip2-base-patch16-224",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": True,
@@ -179,6 +181,7 @@ class TestImageDinov2SingleEmbedder:
         assert ImageDinov2SingleEmbedder().to_dict() == {
             "name": "dinov2_single",
             "display_name": "DINOv2 single (image vector)",
+            "model_id": "facebook/dinov2-base",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": False,
@@ -245,6 +248,7 @@ class TestImageDinov2PatchEmbedder:
         assert ImageDinov2PatchEmbedder().to_dict() == {
             "name": "dinov2_patch",
             "display_name": "DINOv2 patch (region-aware images)",
+            "model_id": "facebook/dinov2-base",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": False,
@@ -293,6 +297,7 @@ class TestImageDinov3SingleEmbedder:
         assert ImageDinov3SingleEmbedder().to_dict() == {
             "name": "dinov3_single",
             "display_name": "DINOv3 single (image vector)",
+            "model_id": "facebook/dinov3-vitb16-pretrain-lvd1689m",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": False,
@@ -357,6 +362,7 @@ class TestImageDinov3PatchEmbedder:
         assert ImageDinov3PatchEmbedder().to_dict() == {
             "name": "dinov3_patch",
             "display_name": "DINOv3 patch (region-aware images)",
+            "model_id": "facebook/dinov3-vitb16-pretrain-lvd1689m",
             "media_type_id": "image",
             "is_default": False,
             "supports_text": False,
@@ -641,6 +647,7 @@ class TestImageFaceEmbedder:
         assert ImageFaceEmbedder().to_dict() == {
             "name": "face",
             "display_name": "FaceNet (face identity, 512d)",
+            "model_id": None,
             "media_type_id": "image",
             "is_default": False,
             "supports_text": False,

--- a/tests/detectors/test_portable_export_route.py
+++ b/tests/detectors/test_portable_export_route.py
@@ -45,6 +45,8 @@ class TestPortableExport:
         assert manifest["detector_name"] == "portable-export"
         # Audio test medias bind the default CLAP embedder (512-dim).
         assert manifest["embedder"]["name"] == "clap"
+        # The exact HF checkpoint travels in the bundle so it's fully actionable.
+        assert manifest["embedder"]["model_id"] == "laion/clap-htsat-unfused"
         assert manifest["embedder"]["embedding_dim"] == 512
         assert 0.0 <= manifest["scoring"]["threshold"] <= 1.0
         assert manifest["training_labels"] == {"good": 3, "bad": 3}

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -55,6 +55,7 @@ class TestImageSiglipEmbedderProperties:
         assert d == {
             "name": "siglip",
             "display_name": "SigLIP (general images)",
+            "model_id": "google/siglip-base-patch16-224",
             "media_type_id": "image",
             "is_default": True,
             "supports_text": True,
@@ -152,6 +153,7 @@ class TestAudioClapMusicEmbedderProperties:
         assert d == {
             "name": "clap_music",
             "display_name": "CLAP (music)",
+            "model_id": "laion/larger_clap_music_and_speech",
             "media_type_id": "audio",
             "is_default": False,
             "supports_text": True,
@@ -229,6 +231,7 @@ class TestAudioClapGeneralEmbedderProperties:
         assert d == {
             "name": "clap_general",
             "display_name": "CLAP (general 2024)",
+            "model_id": "laion/larger_clap_general",
             "media_type_id": "audio",
             "is_default": False,
             "supports_text": True,
@@ -287,6 +290,7 @@ class TestAudioASTEmbedderProperties:
         assert d == {
             "name": "ast",
             "display_name": "AST (audio spectrogram)",
+            "model_id": "MIT/ast-finetuned-audioset-10-10-0.4593",
             "media_type_id": "audio",
             "is_default": False,
             "supports_text": False,
@@ -345,6 +349,7 @@ class TestAudioWhisperEncoderEmbedderProperties:
         assert d == {
             "name": "whisper_encoder",
             "display_name": "Whisper encoder (speech)",
+            "model_id": "openai/whisper-base",
             "media_type_id": "audio",
             "is_default": False,
             "supports_text": False,
@@ -419,6 +424,7 @@ class TestAudioParaSpeechClapEmbedderProperties:
         assert d == {
             "name": "paraspeechclap",
             "display_name": "ParaSpeechCLAP (speech style)",
+            "model_id": "ajd12342/paraspeechclap-combined",
             "media_type_id": "audio",
             "is_default": False,
             "supports_text": True,
@@ -514,6 +520,7 @@ class TestTextBGEEmbedderProperties:
         assert d == {
             "name": "bge",
             "display_name": "BGE (text)",
+            "model_id": "BAAI/bge-base-en-v1.5",
             "media_type_id": "text",
             "is_default": False,
             "supports_text": True,
@@ -645,6 +652,7 @@ class TestVideoLanguageBindEmbedderProperties:
         assert d == {
             "name": "languagebind",
             "display_name": "LanguageBind (video)",
+            "model_id": "LanguageBind/LanguageBind_Video_V1.5_FT",
             "media_type_id": "video",
             "is_default": False,
             "supports_text": True,
@@ -738,6 +746,7 @@ class TestVideoMAEEmbedderProperties:
         assert d == {
             "name": "videomae",
             "display_name": "VideoMAE v2 (action features)",
+            "model_id": "OpenGVLab/VideoMAEv2-Base",
             "media_type_id": "video",
             "is_default": False,
             "supports_text": False,

--- a/tests_lib/detectors/test_portable_bundle.py
+++ b/tests_lib/detectors/test_portable_bundle.py
@@ -35,6 +35,7 @@ def _sample_manifest(weights: dict) -> dict:
         media_type="image",
         embedder="siglip",
         embedder_display_name="SigLIP (general images)",
+        embedder_model_id="google/siglip-base-patch16-224",
         embedder_type="semantic",
         embedding_dim=pb.embedding_dim_from_weights(weights),
         threshold=0.6123456,
@@ -87,6 +88,7 @@ class TestManifest:
         assert manifest["format"] == pb.BUNDLE_FORMAT
         assert manifest["format_version"] == pb.BUNDLE_FORMAT_VERSION
         assert manifest["embedder"]["name"] == "siglip"
+        assert manifest["embedder"]["model_id"] == "google/siglip-base-patch16-224"
         assert manifest["embedder"]["embedding_dim"] == 768
         assert manifest["scoring"]["activation"] == "sigmoid"
         # Threshold is rounded but preserved.
@@ -99,9 +101,32 @@ class TestManifest:
         readme = pb.render_readme(_sample_manifest(weights))
         assert "SigLIP (general images)" in readme
         assert "siglip" in readme
+        assert "google/siglip-base-patch16-224" in readme  # exact HF model id
         assert "768" in readme  # embedding dim
         assert "0.612346" in readme  # threshold
         assert "onnxruntime" in readme  # inference snippet
+
+    def test_readme_omits_model_id_when_absent(self):
+        """Embedders with no model id (e.g. SIFT/VLAD) still render cleanly."""
+        weights = _trained_weights(input_dim=768)
+        manifest = pb.build_manifest(
+            detector_name="Cats",
+            media_type="image",
+            embedder="sift_vlad",
+            embedder_display_name="SIFT/VLAD (instances)",
+            embedder_model_id=None,
+            embedder_type="structural",
+            embedding_dim=pb.embedding_dim_from_weights(weights),
+            threshold=0.5,
+            good_count=3,
+            bad_count=2,
+            exported_by="vtsearch test",
+            exported_at="2026-06-30T00:00:00Z",
+        )
+        assert manifest["embedder"]["model_id"] is None
+        readme = pb.render_readme(manifest)
+        assert "SIFT/VLAD (instances)" in readme
+        assert "exact pretrained model" not in readme
 
 
 class TestBundle:

--- a/tests_lib/detectors/test_structural_embedder.py
+++ b/tests_lib/detectors/test_structural_embedder.py
@@ -277,6 +277,8 @@ class TestSiftVladEmbedder:
         assert d["supports_geometric_verification"] is True
         assert d["supports_patch_regions"] is False
         assert d["supports_text"] is False
+        # Classical local-feature embedder has no single downloadable model id.
+        assert d["model_id"] is None
 
     def test_load_models_sets_matcher_and_codebook(self):
         emb = self._fresh_embedder()

--- a/vtscore/detectors/portable_bundle.py
+++ b/vtscore/detectors/portable_bundle.py
@@ -197,11 +197,7 @@ def render_readme(manifest: dict[str, Any]) -> str:
     model_id = emb.get("model_id")
     # Surface the exact pretrained model so the bundle is fully actionable: the
     # recipient can go straight to the source instead of guessing from the slug.
-    model_id_clause = (
-        f" The exact pretrained model is **`{model_id}`** - use that checkpoint."
-        if model_id
-        else ""
-    )
+    model_id_clause = f" The exact pretrained model is **`{model_id}`** - use that checkpoint." if model_id else ""
     return f"""# Portable detector: {manifest["detector_name"]}
 
 This is a **standalone scoring model** exported from

--- a/vtscore/detectors/portable_bundle.py
+++ b/vtscore/detectors/portable_bundle.py
@@ -135,6 +135,7 @@ def build_manifest(
     media_type: str,
     embedder: str,
     embedder_display_name: str,
+    embedder_model_id: str | None,
     embedder_type: str,
     embedding_dim: int,
     threshold: float,
@@ -147,8 +148,12 @@ def build_manifest(
 
     Captures everything a consumer needs to score with the bundle: the embedder
     to run new media through, the embedding dimensionality, the scoring
-    convention (sigmoid + threshold), and provenance.  ``contains_media_data``
-    is always ``False`` - the manifest documents that the bundle carries the
+    convention (sigmoid + threshold), and provenance.  ``embedder_model_id`` is
+    the concrete pretrained-model identifier (a HuggingFace repo id, e.g.
+    ``"google/siglip-base-patch16-224"``, or a direct weights URL) so a recipient
+    knows exactly which model to run new media through; it may be ``None`` for
+    embedders with no single downloadable model id.  ``contains_media_data`` is
+    always ``False`` - the manifest documents that the bundle carries the
     classifier only, never embeddings or raw media.
     """
     return {
@@ -160,6 +165,7 @@ def build_manifest(
         "embedder": {
             "name": embedder,
             "display_name": embedder_display_name,
+            "model_id": embedder_model_id,
             "type": embedder_type,
             "embedding_dim": embedding_dim,
         },
@@ -188,6 +194,14 @@ def render_readme(manifest: dict[str, Any]) -> str:
     dim = emb["embedding_dim"]
     threshold = scoring["threshold"]
     emb_label = emb["display_name"] or emb["name"]
+    model_id = emb.get("model_id")
+    # Surface the exact pretrained model so the bundle is fully actionable: the
+    # recipient can go straight to the source instead of guessing from the slug.
+    model_id_clause = (
+        f" The exact pretrained model is **`{model_id}`** - use that checkpoint."
+        if model_id
+        else ""
+    )
     return f"""# Portable detector: {manifest["detector_name"]}
 
 This is a **standalone scoring model** exported from
@@ -209,7 +223,7 @@ well they match the trained detector, without needing VTSearch itself.
 ## How to score your own items
 
 1. **Embed** each item with the **{emb_label}** embedder
-   (VTSearch embedder id: `{emb["name"]}`, type: `{emb["type"] or "n/a"}`).
+   (VTSearch embedder id: `{emb["name"]}`, type: `{emb["type"] or "n/a"}`).{model_id_clause}
    This must be the *same* embedder family the detector was trained on, and it
    must produce a **{dim}-dimensional** vector. This bundle does **not** include
    the embedder - obtain it separately.

--- a/vtscore/media/audio/embedder_ast.py
+++ b/vtscore/media/audio/embedder_ast.py
@@ -52,6 +52,10 @@ class AudioASTEmbedder(MediaEmbedder):
         return "AST (audio spectrogram)"
 
     @property
+    def model_id(self) -> str:
+        return AST_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "audio"
 

--- a/vtscore/media/audio/embedder_paraspeechclap.py
+++ b/vtscore/media/audio/embedder_paraspeechclap.py
@@ -79,6 +79,12 @@ class AudioParaSpeechClapEmbedder(MediaEmbedder):
         return "ParaSpeechCLAP (speech style)"
 
     @property
+    def model_id(self) -> str:
+        # The identifying artifact is the ParaSpeechCLAP checkpoint repo; the
+        # WavLM/Granite towers it reconstructs are surfaced in the module docs.
+        return PARASPEECHCLAP_CHECKPOINT_REPO
+
+    @property
     def media_type_id(self) -> str:
         return "audio"
 

--- a/vtscore/media/audio/embedder_whisper.py
+++ b/vtscore/media/audio/embedder_whisper.py
@@ -59,6 +59,10 @@ class AudioWhisperEncoderEmbedder(MediaEmbedder):
         return "Whisper encoder (speech)"
 
     @property
+    def model_id(self) -> str:
+        return WHISPER_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "audio"
 

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -621,6 +621,25 @@ class MediaEmbedder(ABC):
         return self.name
 
     @property
+    def model_id(self) -> Optional[str]:
+        """Concrete identifier of the pretrained model this embedder loads.
+
+        Usually the HuggingFace Hub repo id of the checkpoint (e.g.
+        ``"google/siglip-base-patch16-224"``).  Unlike :attr:`name` (a VTSearch
+        slug) and :attr:`display_name` (a friendly label), this is the *exact*
+        model a third party would download to reproduce the embedding space, so
+        the portable-detector export surfaces it in the bundle manifest/README to
+        make the bundle fully actionable.
+
+        A direct weights URL is acceptable where there is no plain repo id (e.g.
+        EUPE, loaded from a ``.pt`` URL via ``torch.hub``).  ``None`` (the
+        default) means the embedder has no single downloadable model id worth
+        surfacing — the classical SIFT/VLAD structural embedder, or FaceNet whose
+        weights ship inside ``facenet-pytorch``.
+        """
+        return None
+
+    @property
     @abstractmethod
     def media_type_id(self) -> str:
         """The ``type_id`` of the media type this embedder works with."""
@@ -1029,6 +1048,7 @@ class MediaEmbedder(ABC):
         return {
             "name": self.name,
             "display_name": self.display_name,
+            "model_id": self.model_id,
             "media_type_id": self.media_type_id,
             "is_default": self.is_default,
             "supports_text": self.supports_text,

--- a/vtscore/media/image/_dinov2_shared.py
+++ b/vtscore/media/image/_dinov2_shared.py
@@ -54,6 +54,10 @@ class _Dinov2Base(MediaEmbedder):
         self._processor: Any = None
 
     @property
+    def model_id(self) -> str:
+        return DINOV2_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "image"
 

--- a/vtscore/media/image/_dinov3_shared.py
+++ b/vtscore/media/image/_dinov3_shared.py
@@ -65,6 +65,10 @@ class _Dinov3Base(MediaEmbedder):
         self._processor: Any = None
 
     @property
+    def model_id(self) -> str:
+        return DINOV3_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "image"
 

--- a/vtscore/media/image/_eupe_shared.py
+++ b/vtscore/media/image/_eupe_shared.py
@@ -76,6 +76,10 @@ class _EupeBase(MediaEmbedder):
         self._preprocess: Any = None
 
     @property
+    def model_id(self) -> str:
+        return EUPE_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "image"
 

--- a/vtscore/media/image/embedder_clip.py
+++ b/vtscore/media/image/embedder_clip.py
@@ -49,6 +49,10 @@ class ImageClipEmbedder(MediaEmbedder):
         return "CLIP (general images)"
 
     @property
+    def model_id(self) -> str:
+        return CLIP_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "image"
 

--- a/vtscore/media/image/embedder_siglip.py
+++ b/vtscore/media/image/embedder_siglip.py
@@ -55,6 +55,10 @@ class ImageSiglipEmbedder(MediaEmbedder):
         return "SigLIP (general images)"
 
     @property
+    def model_id(self) -> str:
+        return SIGLIP_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "image"
 

--- a/vtscore/media/image/embedder_siglip2.py
+++ b/vtscore/media/image/embedder_siglip2.py
@@ -55,6 +55,10 @@ class ImageSiglip2Embedder(MediaEmbedder):
         return "SigLIP 2 (general images)"
 
     @property
+    def model_id(self) -> str:
+        return SIGLIP2_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "image"
 

--- a/vtscore/media/text/embedder_bge.py
+++ b/vtscore/media/text/embedder_bge.py
@@ -70,6 +70,10 @@ class TextBGEEmbedder(MediaEmbedder):
         return "BGE (text)"
 
     @property
+    def model_id(self) -> str:
+        return BGE_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "text"
 

--- a/vtscore/media/text/embedder_e5.py
+++ b/vtscore/media/text/embedder_e5.py
@@ -70,6 +70,10 @@ class TextE5Embedder(MediaEmbedder):
         return "E5 (text)"
 
     @property
+    def model_id(self) -> str:
+        return E5_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "text"
 

--- a/vtscore/media/video/embedder_languagebind.py
+++ b/vtscore/media/video/embedder_languagebind.py
@@ -90,6 +90,10 @@ class VideoLanguageBindEmbedder(MediaEmbedder):
         return "LanguageBind (video)"
 
     @property
+    def model_id(self) -> str:
+        return LANGUAGEBIND_VIDEO_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "video"
 

--- a/vtscore/media/video/embedder_videomae.py
+++ b/vtscore/media/video/embedder_videomae.py
@@ -121,6 +121,10 @@ class VideoVideoMAEEmbedder(MediaEmbedder):
         return "VideoMAE v2 (action features)"
 
     @property
+    def model_id(self) -> str:
+        return VIDEOMAE_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "video"
 

--- a/vtscore/media/video/embedder_xclip.py
+++ b/vtscore/media/video/embedder_xclip.py
@@ -52,6 +52,10 @@ class VideoXClipEmbedder(MediaEmbedder):
         return "X-CLIP (video)"
 
     @property
+    def model_id(self) -> str:
+        return XCLIP_MODEL_ID
+
+    @property
     def media_type_id(self) -> str:
         return "video"
 

--- a/vtsearch/routes/detectors/export.py
+++ b/vtsearch/routes/detectors/export.py
@@ -101,9 +101,12 @@ def export_portable_bundle(detector_id: str):
     det_type = _detector_type(det_data)
     score_emb = keying_embedder_for_snap(SimpleNamespace(embedder_type=det_type), snap)
     embedder_display = score_emb or ""
+    embedder_model_id: str | None = None
     if score_emb:
         try:
-            embedder_display = get_embedder(score_emb).display_name
+            emb_obj = get_embedder(score_emb)
+            embedder_display = emb_obj.display_name
+            embedder_model_id = emb_obj.model_id
         except Exception:  # noqa: BLE001 - cosmetic only; fall back to the raw name.
             embedder_display = score_emb
 
@@ -117,6 +120,7 @@ def export_portable_bundle(detector_id: str):
         media_type=media_type,
         embedder=score_emb or "",
         embedder_display_name=embedder_display,
+        embedder_model_id=embedder_model_id,
         embedder_type=det_type,
         embedding_dim=pb.embedding_dim_from_weights(weights),
         threshold=threshold,


### PR DESCRIPTION
## What & why

The exported portable-detector bundle named the embedder (`siglip`) and its display name (`SigLIP (general images)`) but not the concrete HuggingFace repo id, because there was no uniform `model_id` on the `MediaEmbedder` ABC. A recipient had to guess which pretrained model to run their media through.

This adds a uniform `model_id` and surfaces it in the bundle's manifest and README, making the bundle fully actionable.

## Changes

- **`MediaEmbedder` ABC** (`vtscore/media/embedder.py`): new `model_id` property, `Optional[str]` defaulting to `None`, and included in `to_dict()`. Documented as the concrete pretrained-model identifier (a HuggingFace repo id, or a direct weights URL for EUPE); `None` for embedders with no single downloadable model (classical SIFT/VLAD, FaceNet).
- **Every concrete embedder** overrides `model_id` to return its `*_MODEL_ID` config constant — SigLIP, SigLIP2, CLIP, DINOv2/v3 (shared bases), EUPE (shared base), AST, Whisper, ParaSpeechCLAP (its checkpoint repo), E5, BGE, X-CLIP, LanguageBind, VideoMAE. (The CLAP family already carried `model_id`; the ABC now generalizes it.)
- **Portable bundle** (`vtscore/detectors/portable_bundle.py`): `build_manifest` takes `embedder_model_id` and writes it as `manifest.embedder.model_id`; the README names the exact checkpoint in the scoring instructions. Absent model id renders cleanly (no clause).
- **Export route** (`vtsearch/routes/detectors/export.py`): resolves the score-space embedder's `model_id` and threads it into the manifest.
- **Frontend** (`api.models.ts`): `EmbedderInfo.model_id?: string | null`.
- **Tests**: updated all embedder `to_dict()` snapshots, added manifest/README `model_id` assertions (present + absent cases), and the route test.
- **Test tooling**: `ensure-test-deps.sh` now upgrades `httplib2` to 0.32.0 (clears the newly-disclosed `PYSEC-2026-3444` on the Ubuntu-system `launchpadlib` transitive dep, which was blocking pip-audit).

## Testing

`./run-tests.sh` — all 6101 tests pass (including the frontend build).

Closes #2390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4cpe8dhoqmM1b8TEGU56q)_