### PR TITLE
Reflect implicit dashboard selection in the nav pickers

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -6,6 +6,7 @@ import { DashboardComponent } from './dashboard.component';
 import { LoadingTask } from '../../models/api.models';
 import { LabelSessionService } from '../../services/label-session.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
+import { ActiveContextService } from '../../services/active-context.service';
 import { provideZoneless } from '../../testing/zoneless-testbed';
 import { provideHttpTesting } from '../../testing/test-providers';
 
@@ -148,6 +149,47 @@ describe('DashboardComponent', () => {
     // selects only the new ones (same behavior as datasets above).
     expect(component.selectedDetectorIds.has('m1')).toBe(false);
     expect(component.selectedDetectorIds.has('m2')).toBe(true);
+  });
+
+  it('mirrors an implicitly selected dataset into the active-context intent', () => {
+    // Off the Dashboard the top-bar pulldowns read the active-context intent
+    // (not the mirrored table selection), so an auto-selected import must land
+    // there too or the picker forgets it the moment the Dashboard unmounts.
+    const activeContext = TestBed.inject(ActiveContextService);
+    const datasets = [{ id: 'd1', name: 'Only One' }];
+    flushInitialRequests(datasets);
+    expect(component.selectedDatasetIds.has('d1')).toBe(true);
+    expect(activeContext.intentDatasetId).toBe('d1');
+  });
+
+  it('mirrors an implicitly selected model into the active-context intent', () => {
+    const activeContext = TestBed.inject(ActiveContextService);
+    const models = [{ id: 'm1', name: 'Only One' }];
+    flushInitialRequests([], models);
+    expect(component.selectedDetectorIds.has('m1')).toBe(true);
+    expect(activeContext.intentModelId).toBe('m1');
+  });
+
+  it('does not blank out the intent when the selection is empty or multiple', () => {
+    // A 0- or multi-selection is ambiguous, so it must leave a previously
+    // loaded pair's intent alone rather than snapping the picker to a
+    // placeholder.
+    const activeContext = TestBed.inject(ActiveContextService);
+    activeContext.setActivePair('d0', 'm0');
+    const datasets = [
+      { id: 'd1', name: 'First' },
+      { id: 'd2', name: 'Second' },
+    ];
+    flushInitialRequests(datasets);
+    // Multiple datasets on initial load → nothing auto-selected, so the
+    // empty-selection mirror leaves the loaded pair's intent untouched.
+    expect(component.selectedDatasetIds.size).toBe(0);
+    expect(activeContext.intentDatasetId).toBe('d0');
+    // Select both at once → an ambiguous multi-selection also leaves it alone.
+    component.toggleAllDatasets();
+    expect(component.selectedDatasetIds.size).toBe(2);
+    expect(activeContext.intentDatasetId).toBe('d0');
+    expect(activeContext.intentModelId).toBe('m0');
   });
 
   it('should toggle dataset selection on click', () => {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -465,12 +465,29 @@ export class DashboardComponent implements OnInit, OnDestroy {
    *  from these id lists (filtered to ids still in the registry so a
    *  pruned-away id can't inflate the "Multiple" count). */
   private pushTopBarLabels(): void {
-    this.dashSelection.setDatasetIds(
-      this.datasets.filter((d) => this.selectedDatasetIds.has(d.id)).map((d) => d.id),
-    );
-    this.dashSelection.setDetectorIds(
-      this.detectors.filter((d) => this.selectedDetectorIds.has(d.id)).map((d) => d.id),
-    );
+    const datasetIds = this.datasets
+      .filter((d) => this.selectedDatasetIds.has(d.id))
+      .map((d) => d.id);
+    const detectorIds = this.detectors
+      .filter((d) => this.selectedDetectorIds.has(d.id))
+      .map((d) => d.id);
+    this.dashSelection.setDatasetIds(datasetIds);
+    this.dashSelection.setDetectorIds(detectorIds);
+    // While the Dashboard is on screen the pulldowns read the mirrored table
+    // selection above; the moment it unmounts they fall back to the
+    // active-context *intent*. Without also mirroring a lone pick into that
+    // intent, a freshly imported/created (implicitly selected) item is
+    // forgotten by the pulldowns as soon as you leave the Dashboard by any
+    // route that doesn't load a context — the picker snaps back to "Select
+    // a …". Mirror only an unambiguous single selection; a 0- or
+    // multi-selection leaves intent untouched so we never blank out the
+    // intent of an already-loaded pair. Intent-only (never `setActive`), so
+    // the HTTP interceptor keeps tagging the still-loaded pair, per the H25
+    // intent/active split.
+    const soleDataset = datasetIds.length === 1 ? datasetIds[0] : this.activeContext.intentDatasetId;
+    const soleDetector =
+      detectorIds.length === 1 ? detectorIds[0] : this.activeContext.intentModelId;
+    this.activeContext.setIntent(soleDataset, soleDetector);
   }
 
   toggleDatasetSelection(id: string, event: MouseEvent): void {


### PR DESCRIPTION
## Problem

After importing or creating a dataset/detector, the dashboard implicitly selects the new row (the bottom Train/Find CTA enables), but the top-bar nav pickers could fall back to "Select a dataset" / "Select a detector" — the picker only caught up once a downstream, context-loading navigation (Train/Find) promoted the pair.

Root cause: the pulldowns read two sources depending on view. **While the dashboard is mounted** they mirror the table selection via `DashboardSelectionService`; **once it unmounts** they fall back to `ActiveContextService` *intent*. The dashboard mirrored implicit selection into the table-selection source but never into the intent, so a freshly added item was forgotten by the picker the moment you left the dashboard by any route that didn't load a context.

## Fix

In the dashboard's single selection choke point (`pushTopBarLabels`), also mirror a **lone, unambiguous** selection into `ActiveContextService.setIntent`. This is intent-only (never `setActive`), so the HTTP interceptor keeps tagging the still-loaded pair — the H25 intent/active split is preserved. A 0- or multi-selection is left untouched so an already-loaded pair's intent is never blanked out.

- `frontend/src/app/components/dashboard/dashboard.component.ts` — mirror single selection → intent.
- `frontend/src/app/components/dashboard/dashboard.component.spec.ts` — 3 tests: single dataset/detector selection lands in intent; empty/multi selection leaves a loaded pair's intent alone.

## Incidental: unblock the test gate

`httplib2` 0.20.4 ships pre-installed in the Ubuntu base image (via `launchpadlib`, a debian tool — not a VTSearch dependency). A newly published 2026 CVE (PYSEC-2026-3444) began blocking the `pip-audit` gate for every session. 0.32.0 patches it, so `ensure-test-deps.sh` now upgrades it alongside the other baseline system packages (matching the existing pattern), rather than ignoring the advisory.

## Testing

`./run-tests.sh` — all green: frontend build OK, frontend audit OK, 1439 frontend unit tests, 6100 pytest.

Closes #2374

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyT9KA7J7bVQs3qHgmdQN2)_