### PR TITLE
Add install → build → run quick-start to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ A trainable media search tool. VTSearch searches collections of audio clips, ima
 
 > **New to VTSearch?** Read **[docs/user/USER_GUIDE.md](docs/user/USER_GUIDE.md)** for a walkthrough of loading a dataset, training a detector with Autopilot (or applying an existing one), and exporting the matches. Most users never need anything else.
 
+## Quick start
+
+```bash
+bash scripts/install.sh                            # install Python deps (auto-detects CPU vs GPU)
+cd frontend && npm install && npm run build:prod   # build the Angular frontend into static/
+cd .. && python app.py --local                     # start the app at http://localhost:5000
+```
+
+See [docs/SETUP.md](docs/SETUP.md) for prerequisites, virtual environment setup, and the full walkthrough.
+
 ## Setup and running tests
 
 See [docs/SETUP.md](docs/SETUP.md) for prerequisites, getting the code, virtual environment setup, installing dependencies, and running the test suite.


### PR DESCRIPTION
## What

Adds a short **Quick start** section near the top of `README.md`, above the deeper content, consolidating the three commands a new reader needs:

```bash
bash scripts/install.sh                            # install Python deps (auto-detects CPU vs GPU)
cd frontend && npm install && npm run build:prod   # build the Angular frontend into static/
cd .. && python app.py --local                     # start the app at http://localhost:5000
```

## Why

Previously these three steps were scattered: install lived only in `docs/SETUP.md`, the frontend build wasn't mentioned near the top of the README at all, and running was under "Running the app". A new reader had to assemble them from separate sections. Verified against the current top matter — no consolidated getting-started block existed, so this is a real gap, not a duplicate.

The block links onward to `docs/SETUP.md` for the full walkthrough.

Closes #2366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhBRdqGtoM3BHQp5bWQEeP)_