### PR TITLE
Add a "Cancelling…" acknowledgement state to load rows

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -104,6 +104,7 @@
                       [bar]="taskBar(task)"
                       [smooth]="true"
                       cancelTitle="Cancel this dataset load"
+                      [cancelling]="loadingTasksSvc.isCancelling(task.task_id)"
                       (cancel)="loadingTasksSvc.cancelLoadingTask(task.task_id)"
                     />
                   }

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -49,6 +49,7 @@
       [bar]="taskBar"
       [smooth]="true"
       [cancelTitle]="taskKind() === 'projection' ? 'Cancel building the map' : 'Cancel this dataset load'"
+      [cancelling]="taskCancelling"
       (cancel)="onCancelTask()"
     />
   </td>

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatasetCardComponent } from './dataset-card.component';
+import { DashboardLoadingTasksService } from '../../../services/dashboard-loading-tasks.service';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
 import { settleZoneless } from '../../../testing/settle-resource';
 
@@ -17,10 +18,21 @@ describe('DatasetCardComponent', () => {
     loaded: true,
   };
 
+  // Stub the loading-tasks service so the card doesn't drag in the real
+  // SSE/HTTP DI chain; the card only reads `isCancelling` for the badge.
+  let cancellingIds: Set<string>;
+
   beforeEach(async () => {
+    cancellingIds = new Set<string>();
     await TestBed.configureTestingModule({
       imports: [DatasetCardComponent],
-      providers: [...provideZoneless()],
+      providers: [
+        ...provideZoneless(),
+        {
+          provide: DashboardLoadingTasksService,
+          useValue: { isCancelling: (id: string) => cancellingIds.has(id) },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DatasetCardComponent);
@@ -162,5 +174,25 @@ describe('DatasetCardComponent', () => {
     fixture.componentRef.setInput('selected', true);
     await settleZoneless(fixture);
     expect(fixture.nativeElement.classList.contains('selected')).toBe(true);
+  });
+
+  it('shows a disabled "Cancelling…" badge on the loading row once its task is cancelling', async () => {
+    const task = { task_id: 'load-1', status: 'running', current: 0, total: 0 };
+    fixture.componentRef.setInput('loadingTask', task);
+    await settleZoneless(fixture);
+    // Before cancel: a live Cancel button.
+    let btn = (fixture.nativeElement as HTMLElement).querySelector('.jp__cancel') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent?.trim()).toBe('Cancel');
+
+    // The service now reports this task as cancelling; re-flow the input so
+    // the getter re-reads the stub.
+    cancellingIds.add('load-1');
+    fixture.componentRef.setInput('loadingTask', { ...task });
+    await settleZoneless(fixture);
+
+    btn = (fixture.nativeElement as HTMLElement).querySelector('.jp__cancel') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent?.trim()).toBe('Cancelling…');
   });
 });

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, input, output, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, inject, input, output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
@@ -14,6 +14,7 @@ import { formatTimestamp } from '../../../utils/format-date';
 import { ContextMenuComponent, ContextMenuItem } from '../../context-menu/context-menu.component';
 import { IconComponent } from '../../icon/icon.component';
 import { buildDatasetCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } from '../card-context-menu-items';
+import { DashboardLoadingTasksService } from '../../../services/dashboard-loading-tasks.service';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -25,6 +26,8 @@ import { buildDatasetCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } fro
   styleUrl: './dataset-card.component.scss',
 })
 export class DatasetCardComponent {
+  private readonly loadingTasksSvc = inject(DashboardLoadingTasksService);
+
   @Input() dataset: any;
   readonly currentUser = input('');
   readonly isDefaultLogin = input(true);
@@ -229,6 +232,13 @@ export class DatasetCardComponent {
     const task = this.loadingTask;
     if (!task) return { value: 0, max: 1, indeterminate: true };
     return progressBarState(task);
+  }
+
+  /** True once Cancel has been clicked on this row's task and the backend is
+   *  still unwinding it; swaps the Cancel button for a "Cancelling…" badge. */
+  get taskCancelling(): boolean {
+    const task = this.loadingTask;
+    return !!task && this.loadingTasksSvc.isCancelling(task.task_id);
   }
 
   // `vt-job-progress` stops the click before it reaches the row, so no event.

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -43,6 +43,7 @@
       [bar]="taskBar()"
       [smooth]="true"
       cancelTitle="Cancel loading"
+      [cancelling]="taskCancelling"
       (cancel)="onCancelTask()"
     />
   </td>

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DetectorCardComponent } from './detector-card.component';
+import { DashboardLoadingTasksService } from '../../../services/dashboard-loading-tasks.service';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
 import { settleZoneless } from '../../../testing/settle-resource';
 
@@ -17,10 +18,21 @@ describe('DetectorCardComponent', () => {
     loaded: true,
   };
 
+  // Stub the loading-tasks service so the card doesn't drag in the real
+  // SSE/HTTP DI chain; the card only reads `isCancelling` for the badge.
+  let cancellingIds: Set<string>;
+
   beforeEach(async () => {
+    cancellingIds = new Set<string>();
     await TestBed.configureTestingModule({
       imports: [DetectorCardComponent],
-      providers: [...provideZoneless()],
+      providers: [
+        ...provideZoneless(),
+        {
+          provide: DashboardLoadingTasksService,
+          useValue: { isCancelling: (id: string) => cancellingIds.has(id) },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DetectorCardComponent);
@@ -149,5 +161,22 @@ describe('DetectorCardComponent', () => {
     fixture.componentRef.setInput('selected', true);
     await settleZoneless(fixture);
     expect(fixture.nativeElement.classList.contains('selected')).toBe(true);
+  });
+
+  it('shows a disabled "Cancelling…" badge on the loading row once its task is cancelling', async () => {
+    const task = { task_id: 'det-1', status: 'running', current: 0, total: 0 };
+    fixture.componentRef.setInput('loadingTask', task);
+    await settleZoneless(fixture);
+    let btn = (fixture.nativeElement as HTMLElement).querySelector('.jp__cancel') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent?.trim()).toBe('Cancel');
+
+    cancellingIds.add('det-1');
+    fixture.componentRef.setInput('loadingTask', { ...task });
+    await settleZoneless(fixture);
+
+    btn = (fixture.nativeElement as HTMLElement).querySelector('.jp__cancel') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent?.trim()).toBe('Cancelling…');
   });
 });

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, input, output, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, inject, input, output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
@@ -13,6 +13,7 @@ import { formatTimestamp } from '../../../utils/format-date';
 import { ContextMenuComponent, ContextMenuItem } from '../../context-menu/context-menu.component';
 import { IconComponent } from '../../icon/icon.component';
 import { buildDetectorCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } from '../card-context-menu-items';
+import { DashboardLoadingTasksService } from '../../../services/dashboard-loading-tasks.service';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -24,6 +25,8 @@ import { buildDetectorCardMenuItems, CARD_MENU_MIN_WIDTH, overflowMenuItems } fr
   styleUrl: './detector-card.component.scss',
 })
 export class DetectorCardComponent {
+  private readonly loadingTasksSvc = inject(DashboardLoadingTasksService);
+
   @Input() detector: any;
   readonly currentUser = input('');
   readonly isDefaultLogin = input(true);
@@ -267,5 +270,12 @@ export class DetectorCardComponent {
     const task = this.loadingTask;
     if (!task) return { header: '', subtitle: '', detail: '', eta: '' };
     return formatProgressHeader(task, 'detector', task.embedder);
+  }
+
+  /** True once Cancel has been clicked on this row's task and the backend is
+   *  still unwinding it; swaps the Cancel button for a "Cancelling…" badge. */
+  get taskCancelling(): boolean {
+    const task = this.loadingTask;
+    return !!task && this.loadingTasksSvc.isCancelling(task.task_id);
   }
 }

--- a/frontend/src/app/components/job-progress/job-progress.component.html
+++ b/frontend/src/app/components/job-progress/job-progress.component.html
@@ -13,7 +13,17 @@
         >
       }
     </span>
-    @if (cancelTitle !== null) {
+    @if (cancelling) {
+      <button
+        type="button"
+        class="btn btn--cancel btn--sm jp__cancel"
+        disabled
+        aria-live="polite"
+        title="Cancelling — waiting for the job to unwind"
+      >
+        Cancelling…
+      </button>
+    } @else if (cancelTitle !== null) {
       <button
         type="button"
         class="btn btn--cancel btn--sm jp__cancel"
@@ -27,7 +37,7 @@
   <!-- Detail is a fixed-width, ellipsized column and the ETA hugs the right
        edge, so the bar between them keeps both edges still as the text changes. -->
   <div class="jp__bottom">
-    <span class="jp__detail" [title]="detail">{{ detail }}</span>
+    <span class="jp__detail" [title]="cancelling ? 'Cancelling…' : detail">{{ cancelling ? 'Cancelling…' : detail }}</span>
     <vt-progress-bar
       [value]="bar.value"
       [max]="bar.max"

--- a/frontend/src/app/components/job-progress/job-progress.component.spec.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.spec.ts
@@ -63,6 +63,37 @@ describe('JobProgressComponent', () => {
     expect(stop).toHaveBeenCalled();
   });
 
+  it('swaps the Cancel button for a disabled "Cancelling…" badge and detail when cancelling', async () => {
+    const el = fixture.nativeElement as HTMLElement;
+    fixture.componentRef.setInput('detail', '012/345 FileABC.img');
+    await settleZoneless(fixture);
+    // Before: live, enabled Cancel button.
+    let btn = el.querySelector('.jp__cancel') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent?.trim()).toBe('Cancel');
+    expect(el.querySelector('.jp__detail')?.textContent?.trim()).toBe('012/345 FileABC.img');
+
+    fixture.componentRef.setInput('cancelling', true);
+    await settleZoneless(fixture);
+
+    // After: disabled acknowledgement badge, and the detail reads "Cancelling…".
+    btn = el.querySelector('.jp__cancel') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent?.trim()).toBe('Cancelling…');
+    expect(el.querySelector('.jp__detail')?.textContent?.trim()).toBe('Cancelling…');
+  });
+
+  it('does not emit cancel while cancelling (badge has no click handler)', async () => {
+    const emit = vi.spyOn(component.cancel, 'emit');
+    fixture.componentRef.setInput('cancelling', true);
+    await settleZoneless(fixture);
+    const btn = (fixture.nativeElement as HTMLElement).querySelector(
+      '.jp__cancel',
+    ) as HTMLButtonElement;
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(emit).not.toHaveBeenCalled();
+  });
+
   it('adds the cell host class in table-cell mode', async () => {
     expect((fixture.nativeElement as HTMLElement).classList.contains('jp-host--cell')).toBe(false);
     fixture.componentRef.setInput('cell', true);

--- a/frontend/src/app/components/job-progress/job-progress.component.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.ts
@@ -47,6 +47,14 @@ export class JobProgressComponent {
   /** Cancel-button label. */
   @Input() cancelLabel = 'Cancel';
   /**
+   * Cancel-acknowledgement mode. Backends take a while to unwind, so once the
+   * user has clicked Cancel we swap the live button for a disabled
+   * "Cancelling…" badge and replace the per-item detail with "Cancelling…", so
+   * the row visibly acknowledges the click instead of freezing in its
+   * pre-cancel state and inviting repeated clicks.
+   */
+  @Input() cancelling = false;
+  /**
    * Table-cell mode: pin the host to the cell width (`width: 0; min-width:
    * 100%`) and give the detail slot a fixed width, so the loading row's text
    * never feeds the auto column-sizing algorithm.

--- a/frontend/src/app/services/dashboard-loading-tasks.service.spec.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Subject } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 import { DashboardLoadingTasksService } from './dashboard-loading-tasks.service';
 import { AchievementsService } from './achievements.service';
@@ -54,8 +54,8 @@ describe('DashboardLoadingTasksService', () => {
       setLoading: vi.fn(),
     };
     const achievementsStub = { refresh: vi.fn() };
-    const datasetsRegistryApiStub = { cancelTask: vi.fn() };
-    const detectorsRegistryApiStub = { cancelDetectorLoadingTask: vi.fn() };
+    const datasetsRegistryApiStub = { cancelTask: vi.fn(() => of(null)) };
+    const detectorsRegistryApiStub = { cancelDetectorLoadingTask: vi.fn(() => of(null)) };
 
     configureZoneless({
       providers: [
@@ -150,6 +150,45 @@ describe('DashboardLoadingTasksService', () => {
 
     detectorLoadingTasks$.next([task({ task_id: 'det-other' })]);
     expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('flags a task as cancelling on cancel and clears it once it leaves the active list', () => {
+    service.startProgressPolling();
+    loadingTasks$.next([task({ task_id: 'load-1', status: 'running' })]);
+    expect(service.isCancelling('load-1')).toBe(false);
+
+    service.cancelLoadingTask('load-1');
+    expect(service.isCancelling('load-1')).toBe(true);
+
+    // Still unwinding: the task is reported active, so the flag stays set.
+    loadingTasks$.next([task({ task_id: 'load-1', status: 'running' })]);
+    expect(service.isCancelling('load-1')).toBe(true);
+
+    // Backend finished cancelling: the task goes idle (with the Cancelled
+    // sentinel that gets filtered out), leaving the active list → flag clears.
+    loadingTasks$.next([task({ task_id: 'load-1', error: 'Cancelled' })]);
+    expect(service.isCancelling('load-1')).toBe(false);
+  });
+
+  it('flags a detector task as cancelling and clears it when it settles', () => {
+    service.startDetectorProgressPolling();
+    detectorLoadingTasks$.next([task({ task_id: 'det-1', status: 'running' })]);
+
+    service.cancelDetectorLoadingTask('det-1');
+    expect(service.isCancelling('det-1')).toBe(true);
+
+    detectorLoadingTasks$.next([task({ task_id: 'det-1', error: 'Cancelled' })]);
+    expect(service.isCancelling('det-1')).toBe(false);
+  });
+
+  it('drops cancelling flags on backend restart', () => {
+    service.startProgressPolling();
+    loadingTasks$.next([task({ task_id: 'load-1', status: 'running' })]);
+    service.cancelLoadingTask('load-1');
+    expect(service.isCancelling('load-1')).toBe(true);
+
+    serverReset$.next();
+    expect(service.isCancelling('load-1')).toBe(false);
   });
 
   it('clears pending callbacks on backend restart', () => {

--- a/frontend/src/app/services/dashboard-loading-tasks.service.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.ts
@@ -44,6 +44,13 @@ export class DashboardLoadingTasksService {
   private readonly _loadingTasks = signal<LoadingTask[]>([]);
   private readonly _detectorLoadingTasks = signal<LoadingTask[]>([]);
 
+  // Task ids the user has clicked Cancel on but whose backend hasn't finished
+  // unwinding yet. Drives the per-row "Cancelling…" acknowledgement badge so
+  // the row doesn't freeze in its pre-cancel state and invite repeated clicks.
+  // Pruned to the active set on every SSE snapshot (a task that has left the
+  // active list is done cancelling), so the flag clears itself.
+  private readonly _cancellingTaskIds = signal<ReadonlySet<string>>(new Set());
+
   private polling$ = new Subject<void>();
   private detectorPolling$ = new Subject<void>();
 
@@ -102,7 +109,33 @@ export class DashboardLoadingTasksService {
     this.detectorPollingActive = false;
     this._loadingTasks.set([]);
     this._detectorLoadingTasks.set([]);
+    this._cancellingTaskIds.set(new Set());
     this.datasetState.setLoading(false);
+  }
+
+  /** True while the user has cancelled `taskId` but the backend is still
+   *  unwinding it (the task is still in the active list). */
+  isCancelling(taskId: string): boolean {
+    return this._cancellingTaskIds().has(taskId);
+  }
+
+  private markCancelling(taskId: string): void {
+    if (this._cancellingTaskIds().has(taskId)) return;
+    const next = new Set(this._cancellingTaskIds());
+    next.add(taskId);
+    this._cancellingTaskIds.set(next);
+  }
+
+  /** Drop any cancelling flag whose task is no longer active — the backend has
+   *  finished unwinding it, so the row is about to leave the table. */
+  private pruneCancelling(activeTaskIds: Set<string>): void {
+    const current = this._cancellingTaskIds();
+    if (current.size === 0) return;
+    const next = new Set<string>();
+    for (const id of current) {
+      if (activeTaskIds.has(id)) next.add(id);
+    }
+    if (next.size !== current.size) this._cancellingTaskIds.set(next);
   }
 
   get loadingTasks(): LoadingTask[] {
@@ -179,6 +212,7 @@ export class DashboardLoadingTasksService {
           const failed = errored.filter((t) => t.error !== 'Cancelled');
 
           this._loadingTasks.set([...active, ...failed]);
+          this.pruneCancelling(new Set(active.map((t) => t.task_id)));
 
           // Detect tasks that just completed successfully so we can
           // refresh the registry immediately (not only when ALL finish).
@@ -242,6 +276,7 @@ export class DashboardLoadingTasksService {
           const failed = errored.filter((t) => t.error !== 'Cancelled');
 
           this._detectorLoadingTasks.set([...active, ...failed]);
+          this.pruneCancelling(new Set(active.map((t) => t.task_id)));
 
           // Detect tasks that just completed successfully
           const justFinished = tasks.filter(
@@ -274,6 +309,7 @@ export class DashboardLoadingTasksService {
   }
 
   cancelLoadingTask(taskId: string): void {
+    this.markCancelling(taskId);
     this.datasetsRegistryApi.cancelTask(taskId).subscribe();
   }
 
@@ -282,6 +318,7 @@ export class DashboardLoadingTasksService {
   }
 
   cancelDetectorLoadingTask(taskId: string): void {
+    this.markCancelling(taskId);
     this.detectorsRegistryApi.cancelDetectorLoadingTask(taskId).subscribe();
   }
 


### PR DESCRIPTION
## Summary

After clicking **Cancel** on a dataset- (or detector-) load row, the UI used to freeze in its pre-cancel state — same bar fill, same live **Cancel** button, same sub-status — for the ~15–20 s the backend takes to unwind, inviting repeated clicks. There was no "cancelling…" acknowledgement anywhere in the frontend.

This adds a pure-frontend acknowledgement: on cancel, the row's task is flagged **cancelling** → the per-item sub-status swaps to **Cancelling…** and the live **Cancel** button is replaced with a disabled **Cancelling…** badge. The flag clears itself the moment the task leaves the active list (backend finished unwinding), so the row's badge simply disappears with the row.

## Changes

- **`dashboard-loading-tasks.service.ts`** — owns the source of truth: a `_cancellingTaskIds` signal. `cancelLoadingTask` / `cancelDetectorLoadingTask` mark the task; each SSE polling snapshot prunes the set down to the still-active tasks (so the flag auto-clears when a task settles). `isCancelling(taskId)` exposes it; the set is cleared on backend restart. Dataset and detector rows share the one signal (task ids are unique).
- **`job-progress.component.{ts,html}`** — a new `cancelling` input. When set, the Cancel button becomes a disabled `Cancelling…` badge (reusing `.btn:disabled` styling — no new CSS) and the detail slot reads `Cancelling…`.
- **`dataset-card.component.{ts,html}`** / **`detector-card.component.{ts,html}`** — inject the service and pass `[cancelling]="taskCancelling"` (true when the row's task id is in the cancelling set).
- **`dashboard.component.html`** — the orphan loading-task rows pass `[cancelling]="loadingTasksSvc.isCancelling(task.task_id)"` so new imports get the same acknowledgement.

Projection ("build the map") cancels are owned by a separate service and keep their existing fast-teardown behavior (no cancelling badge), which is fine given their near-instant unwind.

## Tests

- `job-progress.component.spec.ts` — the badge swap (disabled, "Cancelling…" label, sub-status text) and that the badge no longer emits `cancel`.
- `dashboard-loading-tasks.service.spec.ts` — the cancelling flag is set on cancel, persists while the task is still active, clears once it leaves the active list, and drops on backend restart (dataset + detector).
- `dataset-card` / `detector-card` specs — the row surfaces the disabled `Cancelling…` badge when the service reports its task as cancelling.

`./run-tests.sh frontend` is green (1453 tests) including the full lint / typecheck / build gate.

Closes #2370

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017H7ouj5TxUJJFN8B5cawVv

---
_Generated by [Claude Code](https://claude.ai/code/session_017H7ouj5TxUJJFN8B5cawVv)_