### PR TITLE
Make selection-panel filenames retrievable via tooltip + copy button

### DIFF
--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -76,7 +76,7 @@
         role="button"
         tabindex="0"
         [attr.aria-label]="'Selected: ' + entry.name + ' (click to remove)'"
-        title="Click to remove from selection"
+        [title]="entry.name + ' — click to remove from selection'"
         (click)="onEntryClick(entry.id)"
         (keydown)="onEntryKeydown($event, entry.id)">
         @if (hasThumbnailUrl(entry.id)) {
@@ -91,7 +91,10 @@
         } @else if (placeholderIcon(entry.id)) {
           <span class="bsp-placeholder">{{ placeholderIcon(entry.id) }}</span>
         }
-        <span class="bsp-name-grid">{{ entry.name }}</span>
+        <span class="bsp-name-row">
+          <span class="bsp-name-grid">{{ entry.name }}</span>
+          <vt-copy-detail-button class="bsp-copy" [value]="entry.name" label="name" />
+        </span>
       </div>
     }
   </div>

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -225,20 +225,48 @@
   flex-shrink: 0;
 }
 
+// Row holding the (truncated) name and its copy-to-clipboard affordance. The
+// row itself stays full-width so the name centers; the copy button sits flush
+// beside it and only appears on hover/focus so a dense grid isn't peppered with
+// icons.
+.bsp-name-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+  width: 100%;
+  min-width: 0;
+  flex-shrink: 0;
+}
+
 .bsp-name-grid {
   font-size: var(--font-2xs);
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%;
+  min-width: 0;
   text-align: center;
   line-height: 1.2;
-  flex-shrink: 0;
+}
+
+// The on-screen name is frequently truncated (and hidden entirely at small
+// sizes), so a copy button gives the full name a reliable retrieval path. Keep
+// it out of the way until the entry is hovered or focused.
+.bsp-copy {
+  opacity: 0;
+  transition: opacity var(--transition-base);
+}
+
+.bsp-entry:hover .bsp-copy,
+.bsp-entry:focus-within .bsp-copy {
+  opacity: 1;
 }
 
 // At the two smallest icon sizes (XS/S, ~42px content-box) the name truncates to
-// a useless "a…", so hide it and let the grid pack tighter. M and up keep it.
+// a useless "a…", so hide it and let the grid pack tighter. The copy button
+// stays (revealed on hover) as the only way to read the full name here. M and
+// up keep the name.
 @container bsp-cell (max-width: 60px) {
   .bsp-name-grid {
     display: none;

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -9,6 +9,7 @@ import { SettingsStateService } from '../../services/settings-state.service';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
 import { NoFocusStealDirective } from '../../directives/no-focus-steal.directive';
 import { IconComponent } from '../icon/icon.component';
+import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 
 /** Ordering for the selected-item list. No detector confidence in browse, so
@@ -40,7 +41,7 @@ interface SelectionEntry {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-selection-panel',
   standalone: true,
-  imports: [CommonModule, FormsModule, ViewControlsComponent, NoFocusStealDirective, IconComponent],
+  imports: [CommonModule, FormsModule, ViewControlsComponent, NoFocusStealDirective, IconComponent, CopyDetailButtonComponent],
   templateUrl: './browse-selection-panel.component.html',
   styleUrl: './browse-selection-panel.component.scss',
 })

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
@@ -96,4 +96,23 @@ describe('BrowseSelectionPanelComponent (zoneless canary)', () => {
     nameEl = fixture.nativeElement.querySelector('.bsp-name-grid, .bsp-name');
     expect(nameEl!.textContent).toContain('kestrel.wav');
   });
+
+  it('exposes the full name via the entry tooltip and a per-entry copy button', async () => {
+    selection.addAll([7]);
+    names.set(7, 'a-very-long-filename-that-gets-truncated.wav');
+    metaVersion.next(1);
+    await settleZoneless(fixture);
+
+    // The entry title carries the full name (not the old hardcoded string), so
+    // hovering surfaces it even when the on-screen text is truncated/hidden.
+    const entry = fixture.nativeElement.querySelector('.bsp-entry') as HTMLElement;
+    expect(entry.getAttribute('title')).toBe(
+      'a-very-long-filename-that-gets-truncated.wav — click to remove from selection',
+    );
+
+    // A copy-detail button sits beside each entry, wired to copy the full name.
+    const copyBtn = entry.querySelector('.bsp-copy .copy-detail-btn') as HTMLButtonElement;
+    expect(copyBtn).not.toBeNull();
+    expect(copyBtn.getAttribute('title')).toBe('Copy name to clipboard');
+  });
 });


### PR DESCRIPTION
## Problem

In the VTSBrowse selection panel, long filenames in `bsp-name-grid` are truncated (`text-overflow: ellipsis; white-space: nowrap`) and hidden entirely below a 60px cell width. There was no fallback: each entry's `title` was hardcoded to `"Click to remove from selection"`, which overrode the native hover tooltip that would otherwise show the full name.

## Change

Both cheap options from the issue:

- **Full name in the tooltip** — the entry `title` now reads `"<name> — click to remove from selection"`, so hovering surfaces the full filename even when the on-screen text is cut off.
- **Per-entry copy button** — added a `vt-copy-detail-button` (the same affordance already used in the center-panel metadata sidebar and the bin-popup) beside each entry, wired to copy `entry.name`. It's revealed on entry hover/focus so a dense grid isn't peppered with icons, and it stays available at the smallest icon sizes where the name label is hidden — the only path to read the full name there.

Wrapped the name span and copy button in a new `.bsp-name-row` flexbox so the name still centers and truncates while the copy button sits flush beside it.

## Tests

Added a Vitest case asserting the entry tooltip carries the full name and that a wired copy button renders per entry. Full frontend gate (`./run-tests.sh frontend`) passes: build, audit, and 1454 unit tests.

Closes #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017HsHotyQVH93GUFzTSqpKW)_