### PR TITLE
Make waveform thumbnails theme-agnostic alpha masks (#2369)

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -112,11 +112,22 @@
         (click)="onPreviewClick()"
         (keydown)="onPreviewKeydown($event)">
         @if (previewUrl()) {
-          <img
-            class="bin-popup-preview-img"
-            [src]="previewUrl()"
-            [alt]="previewId != null ? name(previewId) : ''"
-            (error)="onPreviewError()" />
+          @if (isAudioWaveform) {
+            <!-- Audio waveform: tint the theme-agnostic alpha mask (issue #2369)
+                 instead of showing baked-in pixels. -->
+            <div
+              class="bin-popup-preview-wave waveform-mask"
+              role="img"
+              [attr.aria-label]="previewId != null ? name(previewId) : ''"
+              [style.-webkit-mask-image]="'url(' + previewUrl() + ')'"
+              [style.mask-image]="'url(' + previewUrl() + ')'"></div>
+          } @else {
+            <img
+              class="bin-popup-preview-img"
+              [src]="previewUrl()"
+              [alt]="previewId != null ? name(previewId) : ''"
+              (error)="onPreviewError()" />
+          }
         }
       </div>
     }
@@ -171,12 +182,20 @@
               (mouseenter)="onEntryEnter(id)">
               @if (hasThumbnailUrl(id)) {
                 <span class="bin-popup-thumb-wrap">
-                  <img
-                    class="bin-popup-thumb"
-                    [src]="thumbnailUrl(id)"
-                    [alt]="name(id)"
-                    loading="lazy"
-                    (error)="onThumbnailError(thumbnailUrl(id))" />
+                  @if (isAudioWaveform) {
+                    <!-- Audio waveform alpha mask tinted to the accent (issue #2369). -->
+                    <span
+                      class="bin-popup-thumb-wave waveform-mask"
+                      [style.-webkit-mask-image]="'url(' + thumbnailUrl(id) + ')'"
+                      [style.mask-image]="'url(' + thumbnailUrl(id) + ')'"></span>
+                  } @else {
+                    <img
+                      class="bin-popup-thumb"
+                      [src]="thumbnailUrl(id)"
+                      [alt]="name(id)"
+                      loading="lazy"
+                      (error)="onThumbnailError(thumbnailUrl(id))" />
+                  }
                 </span>
               } @else {
                 <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -258,6 +258,17 @@
   display: block;
 }
 
+// Audio waveform in the preview pane (issue #2369): the pane already paints the
+// themed surface, so this just masks the accent to the wave, contain-fit to
+// mirror ``.bin-popup-preview-img``'s ``object-fit: contain``. No ``background``
+// — the shared ``.waveform-mask`` accent must win.
+.bin-popup-preview-wave {
+  width: 100%;
+  height: 100%;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+}
+
 // The grid column: a fixed-width stack of the member-count label above the
 // scrolling thumbnail grid, so the popup hugs it plus the preview pane. The
 // count sits at the column's top-left; the grid fills the remaining height.
@@ -401,6 +412,21 @@
   height: var(--popup-cell, 28px);
   border-radius: var(--radius-sm);
   flex-shrink: 0;
+  // Themed surface behind the thumbnail: hidden under a cover-fit <img>, and the
+  // backdrop the tinted audio waveform (issue #2369) sits on.
+  background: var(--bg-body);
+  overflow: hidden;
+}
+
+// Audio waveform in the grid: the shared ``.waveform-mask`` supplies the accent
+// fill and mask chrome; here we cover-fit it (matching the <img> it replaces).
+// No ``background`` — that would out-specify the shared accent and blank the wave.
+.bin-popup-thumb-wave {
+  width: 100%;
+  height: 100%;
+  mask-size: cover;
+  -webkit-mask-size: cover;
+  border-radius: var(--radius-sm);
 }
 
 .bin-popup-thumb {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -428,6 +428,13 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
     return usesThumbnails(this.mediaType());
   }
 
+  /** True when this popup's thumbnails are audio waveforms: theme-agnostic
+   *  alpha-mask PNGs (issue #2369) rendered as a CSS mask over the accent
+   *  colour rather than a plain <img>, so they recolour with the live theme. */
+  get isAudioWaveform(): boolean {
+    return this.mediaType() === 'audio';
+  }
+
   // --- Metadata column ------------------------------------------------------
   // A column carrying the same fields the Train/Find center panel shows for the
   // focused item (name, media type, custom metadata, MD5). For thumbnail media

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -193,6 +193,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   /** Media ids whose thumbnail failed to load, so we don't retry every frame. */
   private thumbFailed = new Set<number>();
   private readonly MAX_THUMBS = 2048;
+  /** Audio waveform thumbnails are theme-agnostic alpha masks (issue #2369);
+   *  this caches each one tinted to the current theme's accent colour so the
+   *  {@link ImageBitmap}-style ``source-in`` fill runs once per (clip, theme),
+   *  not per frame. Cleared whenever the raw {@link thumbCache} is (dataset /
+   *  level switch) and — via {@link retintWaveforms} — on a theme flip. */
+  private tintedThumbCache = new Map<number, HTMLCanvasElement>();
   /** Resolution tier the {@link thumbCache} is currently filled at. Flips to
    * ``true`` once the zoom is large enough that {@link getThumb} fetches the
    * full-res ``/image`` instead of the capped ``/thumbnail``; crossing the
@@ -330,6 +336,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   // Accent colour resolved from the live theme once per frame, used for the
   // selection rings and the marquee rectangle.
   private selAccent = '#4f9dff';
+
+  // Waveform tint colours resolved from the live theme once per frame. Audio
+  // datasets paint each tile as a themed surface (``waveSurface``) with the
+  // wave masked in the accent (``waveAccent``); see {@link drawCell} and
+  // issue #2369. ``waveformTint`` is the per-frame "this dataset is audio" flag.
+  private waveformTint = false;
+  private waveAccent = '#4f9dff';
+  private waveSurface = '#1a1d27';
 
   private hoveredCell: HexCellPayload | null = null;
   /**
@@ -502,6 +516,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.thumbsAreFullRes = this.useFullResThumbs;
     this.thumbCache.clear();
     this.thumbFailed.clear();
+    this.tintedThumbCache.clear();
   }
 
   /** Geometry (hex or square) for the active projection's bin shape. */
@@ -552,7 +567,14 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.ngZone.runOutsideAngular(() => this.resize());
     });
 
-    this.themeObserver = new MutationObserver(() => this.requestRedraw());
+    this.themeObserver = new MutationObserver(() => {
+      // A theme flip changes the accent the waveform masks are tinted with, so
+      // drop the tinted cache (issue #2369); each visible wave re-tints on the
+      // redraw below. The raw mask cache is untouched — the masks are
+      // theme-agnostic, so nothing needs re-fetching.
+      this.tintedThumbCache.clear();
+      this.requestRedraw();
+    });
     this.themeObserver.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['data-theme'],
@@ -591,6 +613,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
         this.framedByUser = false;
         this.thumbCache.clear();
         this.thumbFailed.clear();
+        this.tintedThumbCache.clear();
         // A new projection (media-type switch / rebuild) re-lays-out every item,
         // so the old selection no longer maps to what's on screen — drop it. A
         // bin-shape toggle keeps the same projection id and selection, since the
@@ -661,6 +684,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     document.removeEventListener('mouseup', this.boundMouseUp);
     this.thumbCache.clear();
     this.thumbFailed.clear();
+    this.tintedThumbCache.clear();
   }
 
   private resize(): void {
@@ -1252,6 +1276,13 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     const cmap = resolveColormap(this.colormap(), this.effectiveTheme());
     // Accent for selection rings + marquee, also resolved once per frame.
     this.selAccent = this.themeColor('--accent') || '#4f9dff';
+    // Waveform tint colours (audio only), likewise resolved once per frame; the
+    // tinted-mask cache is rebuilt against these on a theme flip.
+    this.waveformTint = this.mediaType() === 'audio';
+    if (this.waveformTint) {
+      this.waveAccent = this.themeColor('--accent') || '#4f9dff';
+      this.waveSurface = this.themeColor('--bg-surface') || '#1a1d27';
+    }
     const selectionActive = this.selection.size > 0;
 
     // The enlarged cell is deferred and redrawn last (on top of its neighbours)
@@ -1500,7 +1531,20 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     if (thumb) {
       ctx.save();
       ctx.clip();
-      if (trim) {
+      if (this.waveformTint) {
+        // Audio: the thumbnail is a theme-agnostic alpha mask (issue #2369).
+        // Fill the cell with the themed surface, then paint the wave tinted to
+        // the accent colour — so the tile matches dark / light / highviz and
+        // recolours on a theme flip instead of showing baked-in pixels.
+        ctx.fillStyle = this.waveSurface;
+        ctx.fill();
+        const tinted = this.getTintedThumb(cell.rep_id, thumb);
+        if (trim) {
+          ctx.drawImage(tinted, cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2);
+        } else {
+          this.drawImageCover(ctx, tinted, cx, cy, radius);
+        }
+      } else if (trim) {
         ctx.drawImage(thumb, cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2);
       } else {
         this.drawImageCover(ctx, thumb, cx, cy, radius);
@@ -1627,18 +1671,23 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     ctx.closePath();
   }
 
-  /** Cover-fit an image over the hex's 2*radius square (the path must be clipped). */
+  /** Cover-fit an image over the hex's 2*radius square (the path must be clipped).
+   *  Accepts a tinted waveform canvas (issue #2369) as well as a raw image; a
+   *  canvas exposes its intrinsic size as ``width``/``height`` rather than
+   *  ``naturalWidth``/``naturalHeight``. */
   private drawImageCover(
     ctx: CanvasRenderingContext2D,
-    img: HTMLImageElement,
+    img: HTMLImageElement | HTMLCanvasElement,
     cx: number,
     cy: number,
     radius: number,
   ): void {
+    const iw = img instanceof HTMLCanvasElement ? img.width : img.naturalWidth;
+    const ih = img instanceof HTMLCanvasElement ? img.height : img.naturalHeight;
     const size = radius * 2;
-    const scale = Math.max(size / img.naturalWidth, size / img.naturalHeight);
-    const dw = img.naturalWidth * scale;
-    const dh = img.naturalHeight * scale;
+    const scale = Math.max(size / iw, size / ih);
+    const dw = iw * scale;
+    const dh = ih * scale;
     ctx.drawImage(img, cx - dw / 2, cy - dh / 2, dw, dh);
   }
 
@@ -1726,7 +1775,41 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     for (const key of this.thumbCache.keys()) {
       if (i++ >= toRemove) break;
       this.thumbCache.delete(key);
+      // Drop the matching tinted mask (issue #2369) so it can't outlive its
+      // raw source and leak; it re-tints on demand if the clip is revisited.
+      this.tintedThumbCache.delete(key);
     }
+  }
+
+  /**
+   * Return the audio waveform thumbnail tinted to the live theme's accent
+   * colour, built once per (clip, theme) and cached (issue #2369).
+   *
+   * The raw thumbnail is a theme-agnostic alpha mask — a transparent PNG whose
+   * only opaque pixels are the wave. Painting it to an offscreen canvas and
+   * compositing the accent through ``source-in`` recolours just the wave,
+   * leaving the background transparent so the tile's themed surface (filled by
+   * the caller) shows through. The tinted cache is cleared on a theme flip and
+   * whenever the raw {@link thumbCache} is, so it never serves a stale colour.
+   */
+  private getTintedThumb(representativeId: number, src: HTMLImageElement): HTMLCanvasElement {
+    const cached = this.tintedThumbCache.get(representativeId);
+    if (cached) return cached;
+
+    const w = src.naturalWidth || 1;
+    const h = src.naturalHeight || 1;
+    const off = document.createElement('canvas');
+    off.width = w;
+    off.height = h;
+    const octx = off.getContext('2d');
+    if (octx) {
+      octx.drawImage(src, 0, 0);
+      octx.globalCompositeOperation = 'source-in';
+      octx.fillStyle = this.waveAccent;
+      octx.fillRect(0, 0, w, h);
+    }
+    this.tintedThumbCache.set(representativeId, off);
+    return off;
   }
 
   private themeColor(varName: string): string {

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -81,12 +81,20 @@
         (keydown)="onEntryKeydown($event, entry.id)">
         @if (hasThumbnailUrl(entry.id)) {
           <span class="bsp-thumb-wrap">
-            <img
-              class="bsp-thumb"
-              [src]="thumbnailUrl(entry.id)"
-              [alt]="entry.name"
-              loading="lazy"
-              (error)="onThumbnailError(thumbnailUrl(entry.id))" />
+            @if (isAudioThumbnail(entry.id)) {
+              <!-- Audio waveform alpha mask tinted to the accent (issue #2369). -->
+              <span
+                class="bsp-thumb-wave waveform-mask"
+                [style.-webkit-mask-image]="'url(' + thumbnailUrl(entry.id) + ')'"
+                [style.mask-image]="'url(' + thumbnailUrl(entry.id) + ')'"></span>
+            } @else {
+              <img
+                class="bsp-thumb"
+                [src]="thumbnailUrl(entry.id)"
+                [alt]="entry.name"
+                loading="lazy"
+                (error)="onThumbnailError(thumbnailUrl(entry.id))" />
+            }
           </span>
         } @else if (placeholderIcon(entry.id)) {
           <span class="bsp-placeholder">{{ placeholderIcon(entry.id) }}</span>

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -200,6 +200,9 @@
   border-radius: var(--radius-sm);
   flex-shrink: 0;
   overflow: hidden;
+  // Themed surface behind the thumbnail: hidden under a contain-fit <img>, and
+  // the backdrop the tinted audio waveform (issue #2369) sits on.
+  background: var(--bg-surface);
 }
 
 .bsp-thumb {
@@ -209,6 +212,17 @@
   border-radius: var(--radius-sm);
   background: var(--bg-surface);
   display: block;
+}
+
+// Audio waveform (issue #2369): the shared ``.waveform-mask`` supplies the
+// accent fill + mask chrome; contain-fit to mirror ``.bsp-thumb``. No
+// ``background`` here — the shared accent must win over a component class.
+.bsp-thumb-wave {
+  width: 100%;
+  height: 100%;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  border-radius: var(--radius-sm);
 }
 
 .bsp-placeholder {

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -245,6 +245,12 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
     return this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
   }
 
+  /** True when this item's thumbnail is an audio waveform — a theme-agnostic
+   *  alpha-mask PNG (issue #2369) tinted via a CSS mask, not a plain <img>. */
+  isAudioThumbnail(id: number): boolean {
+    return this.metadataCache.get(id)?.media_type === 'audio';
+  }
+
   onThumbnailError(url: string): void {
     if (url) this.thumbnailFailedUrls.add(url);
   }

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -67,7 +67,17 @@
             @if (mediaType() === 'audio') {
               <div class="browse-now-playing">
                 @if (nowPlaying(); as np) {
-                  <img class="browse-now-playing-wave" [src]="np.waveUrl" alt="" aria-hidden="true" />
+                  <!-- The waveform PNG is a theme-agnostic alpha mask (issue #2369):
+                       the surface box mirrors the browse tile, and the inner element
+                       masks the accent colour to the wave shape so it recolours with
+                       the theme instead of showing baked-in pixels. -->
+                  <div class="browse-now-playing-wave" aria-hidden="true">
+                    <div
+                      class="browse-now-playing-wave-fill waveform-mask"
+                      [style.-webkit-mask-image]="'url(' + np.waveUrl + ')'"
+                      [style.mask-image]="'url(' + np.waveUrl + ')'"
+                    ></div>
+                  </div>
                 }
                 <div class="browse-volume" role="group" aria-label="Preview volume">
                   <button

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -85,17 +85,29 @@
   gap: var(--space-xs);
 }
 
-// The waveform PNG of whatever clip is currently auditioning; the same
-// thumbnail painted on its tile, stretched wide (time on X) to read at a
-// glance as "this is what's making noise".
+// The waveform of whatever clip is currently auditioning; the same shape
+// painted on its tile, stretched wide (time on X) to read at a glance as
+// "this is what's making noise". The PNG is a theme-agnostic alpha mask
+// (issue #2369): the box is the themed surface (matching the browse tile) and
+// the inner fill masks the accent colour to the wave shape, so it recolours
+// with the live theme instead of showing baked-in pixels.
 .browse-now-playing-wave {
-  display: block;
   width: 120px;
   height: 36px;
-  object-fit: fill;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-surface);
+  overflow: hidden;
+}
+
+// Tinted wave; the shared ``.waveform-mask`` supplies the accent fill and mask
+// repeat/position. Here we only stretch it to fill the box (time on X),
+// mirroring the old ``object-fit: fill`` of the raw <img>.
+.browse-now-playing-wave-fill {
+  width: 100%;
+  height: 100%;
+  mask-size: 100% 100%;
+  -webkit-mask-size: 100% 100%;
 }
 
 // Ready-state layout: the canvas region, a draggable divider, and the docked

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -110,7 +110,19 @@
                   @for (example of mediaExamples(); track example.value; let i = $index) {
                     <div class="example-row">
                       @if (exampleThumbnailUrl(example); as thumbUrl) {
-                        <img class="example-thumbnail" [src]="thumbUrl" [alt]="example.display" (error)="onExampleThumbError(i)" />
+                        @if (example.mediaType === 'audio') {
+                          <!-- Audio waveform alpha mask (issue #2369): surface box
+                               with the wave masked in the accent so it recolours
+                               with the theme. -->
+                          <span class="example-thumbnail" role="img" [attr.aria-label]="example.display">
+                            <span
+                              class="example-thumbnail-wave waveform-mask"
+                              [style.-webkit-mask-image]="'url(' + thumbUrl + ')'"
+                              [style.mask-image]="'url(' + thumbUrl + ')'"></span>
+                          </span>
+                        } @else {
+                          <img class="example-thumbnail" [src]="thumbUrl" [alt]="example.display" (error)="onExampleThumbError(i)" />
+                        }
                       } @else {
                         <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
                       }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -154,6 +154,18 @@
   border-radius: var(--radius-sm);
   flex-shrink: 0;
   background: var(--bg-subtle);
+  overflow: hidden;
+}
+
+// Audio waveform (issue #2369): fills the surface ``.example-thumbnail`` box and
+// masks the accent to the wave shape; the shared ``.waveform-mask`` supplies the
+// accent fill + mask chrome, cover-fit to mirror the <img>'s ``object-fit``.
+.example-thumbnail-wave {
+  display: block;
+  width: 100%;
+  height: 100%;
+  mask-size: cover;
+  -webkit-mask-size: cover;
 }
 
 .example-label {

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.html
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.html
@@ -14,7 +14,17 @@
 >
   <div class="thumbnail-wrap">
     @if (thumbnailUrl) {
-      <img class="media-thumbnail" [src]="thumbnailUrl" [alt]="displayName" loading="lazy" (error)="onThumbnailError()" />
+      @if (isAudioThumbnail) {
+        <!-- Audio waveform alpha mask tinted to the accent (issue #2369). -->
+        <span
+          class="media-thumbnail-wave waveform-mask"
+          [attr.aria-label]="displayName"
+          [style.-webkit-mask-image]="'url(' + thumbnailUrl + ')'"
+          [style.mask-image]="'url(' + thumbnailUrl + ')'"
+        ></span>
+      } @else {
+        <img class="media-thumbnail" [src]="thumbnailUrl" [alt]="displayName" loading="lazy" (error)="onThumbnailError()" />
+      }
     } @else if (placeholderIcon) {
       <span class="media-placeholder">{{ placeholderIcon }}</span>
     }

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.scss
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.scss
@@ -54,6 +54,11 @@
   flex-shrink: 0;
   line-height: 0;
   width: 100%;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  // Themed surface behind the thumbnail: hidden under a cover-fit <img> or the
+  // opaque placeholder, and the backdrop for the tinted audio waveform (#2369).
+  background: var(--bg-surface);
 }
 
 .media-thumbnail {
@@ -61,6 +66,18 @@
   height: auto;
   aspect-ratio: 1;
   object-fit: cover;
+  border-radius: var(--radius-sm);
+}
+
+// Audio waveform (issue #2369): the shared ``.waveform-mask`` supplies the
+// accent fill + mask chrome; cover-fit to mirror ``.media-thumbnail``. No
+// ``background`` here — the shared accent must win over a component class.
+.media-thumbnail-wave {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  mask-size: cover;
+  -webkit-mask-size: cover;
   border-radius: var(--radius-sm);
 }
 

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
@@ -80,6 +80,26 @@ describe('MediaItemComponent', () => {
     expect(component.thumbnailUrl).toBe('/api/medias/1/thumbnail');
   });
 
+  it('tints the audio waveform via a CSS mask, not a plain <img> (issue #2369)', async () => {
+    // Default mockMedia is audio.
+    await settleZoneless(fixture);
+    const el = fixture.nativeElement as HTMLElement;
+    expect(component.isAudioThumbnail).toBe(true);
+    expect(el.querySelector('img.media-thumbnail')).toBeNull();
+    const wave = el.querySelector('.media-thumbnail-wave') as HTMLElement;
+    expect(wave).toBeTruthy();
+    expect(wave.style.maskImage || wave.style.webkitMaskImage).toContain('/api/medias/1/thumbnail');
+  });
+
+  it('renders a plain <img> for image thumbnails', async () => {
+    fixture.componentRef.setInput('media', { ...mockMedia, media_type: 'image' });
+    await settleZoneless(fixture);
+    const el = fixture.nativeElement as HTMLElement;
+    expect(component.isAudioThumbnail).toBe(false);
+    expect(el.querySelector('img.media-thumbnail')).toBeTruthy();
+    expect(el.querySelector('.media-thumbnail-wave')).toBeNull();
+  });
+
   it('should not show thumbnail for text type', () => {
     component.media = { ...mockMedia, media_type: 'text' };
     expect(component.thumbnailUrl).toBeNull();

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -53,6 +53,12 @@ export class MediaItemComponent implements OnChanges {
     return null;
   }
 
+  /** True when {@link thumbnailUrl} is an audio waveform \u2014 a theme-agnostic
+   *  alpha-mask PNG (issue #2369) tinted via a CSS mask, not a plain <img>. */
+  get isAudioThumbnail(): boolean {
+    return !!this.thumbnailUrl && this.media.media_type === 'audio';
+  }
+
   get placeholderIcon(): string | null {
     if (this.thumbnailUrl) return null;
     if (this.media.media_type === 'audio') return '\u266B';

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -121,6 +121,9 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
       thumbnailUrl: this.buildThumbnailUrl(media, id),
       fallbackIcon: this.buildFallbackIcon(media),
       missing: !this.mediaMap.has(id),
+      // Audio waveforms are theme-agnostic alpha masks (issue #2369); flag them
+      // so vote-grid tints them via a CSS mask instead of a plain <img>.
+      isAudio: media?.media_type === 'audio',
     };
   }
 

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -46,6 +46,9 @@ export class LabelsetListComponent implements OnChanges {
       thumbnailUrl: this.buildThumbnailUrl(e),
       fallbackIcon: e.media_type === 'audio' ? '♫' : e.media_type === 'text' ? '¶' : '□',
       missing: e.cid === null || e.cid === undefined,
+      // Audio waveforms are theme-agnostic alpha masks (issue #2369); flag them
+      // so vote-grid tints them via a CSS mask instead of a plain <img>.
+      isAudio: e.media_type === 'audio',
     }));
     return this.sortEntries(entries);
   }

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.html
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.html
@@ -42,7 +42,16 @@
   >
     @if (entry.thumbnailUrl && !thumbnailFailedUrls.has(entry.thumbnailUrl)) {
       <span class="vote-thumbnail-wrap">
-        <img class="vote-thumbnail" [src]="entry.thumbnailUrl" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.thumbnailUrl)" />
+        @if (entry.isAudio) {
+          <!-- Audio waveform alpha mask tinted to the accent (issue #2369). -->
+          <span
+            class="vote-thumbnail-wave waveform-mask"
+            [style.-webkit-mask-image]="'url(' + entry.thumbnailUrl + ')'"
+            [style.mask-image]="'url(' + entry.thumbnailUrl + ')'"
+          ></span>
+        } @else {
+          <img class="vote-thumbnail" [src]="entry.thumbnailUrl" [alt]="entry.name" loading="lazy" (error)="onThumbnailError(entry.thumbnailUrl)" />
+        }
       </span>
     } @else if (entry.fallbackIcon) {
       <span class="vote-placeholder">{{ entry.fallbackIcon }}</span>

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.scss
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.scss
@@ -77,6 +77,9 @@
   border-radius: var(--radius-sm);
   flex-shrink: 0;
   overflow: hidden;
+  // Themed surface behind the thumbnail: hidden under a contain-fit <img>, and
+  // the backdrop the tinted audio waveform (issue #2369) sits on.
+  background: var(--bg-surface);
 }
 
 .vote-thumbnail {
@@ -86,6 +89,17 @@
   border-radius: var(--radius-sm);
   background: var(--bg-surface);
   display: block;
+}
+
+// Audio waveform (issue #2369): the shared ``.waveform-mask`` supplies the
+// accent fill + mask chrome; contain-fit to mirror ``.vote-thumbnail``. No
+// ``background`` here — the shared accent must win over a component class.
+.vote-thumbnail-wave {
+  width: 100%;
+  height: 100%;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  border-radius: var(--radius-sm);
 }
 
 .vote-placeholder {

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.spec.ts
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.spec.ts
@@ -136,6 +136,25 @@ describe('VoteGridComponent', () => {
     expect(el.querySelector('.vote-placeholder')?.textContent).toContain('♫');
   });
 
+  it('renders a plain <img> for non-audio thumbnails', async () => {
+    await setInputs({ entries: makeEntries(1, { thumbnailUrl: '/api/medias/1/thumbnail' }) });
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('img.vote-thumbnail')).toBeTruthy();
+    expect(el.querySelector('.vote-thumbnail-wave')).toBeNull();
+  });
+
+  it('tints audio waveforms via a CSS mask instead of a plain <img> (issue #2369)', async () => {
+    await setInputs({
+      entries: makeEntries(1, { thumbnailUrl: '/api/medias/1/thumbnail', isAudio: true }),
+    });
+    const el = fixture.nativeElement as HTMLElement;
+    // No raw <img> — a masked element carries the wave shape.
+    expect(el.querySelector('img.vote-thumbnail')).toBeNull();
+    const wave = el.querySelector('.vote-thumbnail-wave') as HTMLElement;
+    expect(wave).toBeTruthy();
+    expect(wave.style.maskImage || wave.style.webkitMaskImage).toContain('/api/medias/1/thumbnail');
+  });
+
   it('marks missing entries and labels them in the aria text', async () => {
     await setInputs({ label: 'good', entries: makeEntries(1, { missing: true }) });
     const el = fixture.nativeElement as HTMLElement;

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.ts
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.ts
@@ -31,6 +31,10 @@ export interface VoteGridEntry {
   fallbackIcon: string | null;
   /** True when the item isn't present in the current dataset. */
   missing: boolean;
+  /** True when {@link thumbnailUrl} is an audio waveform: a theme-agnostic
+   *  alpha-mask PNG (issue #2369) that must be tinted via a CSS mask rather
+   *  than shown as a plain <img>, so it recolours with the live theme. */
+  isAudio?: boolean;
 }
 
 /** Media types the thumbnail route can render a tile for. */

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -875,3 +875,18 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 .icon-waggle {
   animation: icon-waggle 2s ease-in-out infinite;
 }
+
+// Theme-agnostic waveform tint (issue #2369). Audio waveform thumbnails are
+// alpha-mask PNGs — a transparent image whose only opaque pixels are the wave —
+// so they carry no baked-in colour and can be tinted to any theme at render
+// time. ``.waveform-mask`` paints the accent colour and masks it to the wave
+// shape; the ``mask-image`` URL is set per-instance via a style binding, and
+// callers set the box size, ``mask-size`` (fill / contain / cover, matching the
+// ``object-fit`` the raw <img> used), and any surface background behind it.
+.waveform-mask {
+  background: var(--accent);
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+}

--- a/tests_lib/core/test_audio.py
+++ b/tests_lib/core/test_audio.py
@@ -23,6 +23,32 @@ class TestGenerateWaveformThumbnail:
         img = Image.open(io.BytesIO(result))
         assert img.size == (128, 128)
 
+    def test_is_theme_agnostic_alpha_mask(self):
+        """The thumbnail bakes in no colour: transparent background, opaque wave.
+
+        This is the contract the frontend relies on to tint the waveform to the
+        live theme (issue #2369) — an RGBA image whose corners are fully
+        transparent and whose alpha channel actually varies (the wave is drawn).
+        """
+        from PIL import Image
+
+        wav_bytes = generate_wav(440.0, 1.0)
+        result = generate_waveform_thumbnail(wav_bytes)
+        assert result is not None
+        img = Image.open(io.BytesIO(result))
+        assert img.mode == "RGBA"
+        # Corners are background → fully transparent, and *white* RGB (matching
+        # the wave) so downscaling can't fringe the wave with dark pixels.
+        w, h = img.size
+        for xy in ((0, 0), (w - 1, 0), (0, h - 1), (w - 1, h - 1)):
+            assert img.getpixel(xy) == (255, 255, 255, 0)
+        # The wave itself is drawn → some pixels are opaque.
+        alphas = img.getchannel("A").getextrema()
+        assert alphas == (0, 255)
+        # Colour is carried entirely by alpha: every pixel is white RGB.
+        rgb = img.convert("RGB")
+        assert rgb.getextrema() == ((255, 255), (255, 255), (255, 255))
+
     def test_custom_size(self):
         from PIL import Image
 

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -61,9 +61,15 @@ def _synthetic_tone_wav(city_index: int, n_cities: int) -> bytes:
     return buf.getvalue()
 
 
-# Waveform colours (dark background, bright waveform)
-_BG_COLOR = (30, 30, 30)
-_WAVE_COLOR = (0, 180, 255)
+# Waveform thumbnails are theme-agnostic alpha masks, not pre-coloured images:
+# the wave is painted fully opaque and the background left fully transparent, so
+# no colour is baked into the PNG.  The frontend tints the mask to the live
+# theme at render time — browse-canvas tiles via an offscreen ``source-in`` fill,
+# the top-left now-playing indicator via a CSS ``mask`` — so one PNG serves the
+# dark / light / highviz themes equally and recolours instantly on a theme
+# switch, with no staleness and nothing theme-specific frozen into demo-dataset
+# pickles.  See issue #2369.
+_WAVE_FILL = (255, 255, 255, 255)  # opaque; only the alpha channel is used downstream
 
 # Process-scoped cache of decoded ``(samples, sr)`` keyed by an archive member.
 # A windowed archive-member manifest fans one member into many clip windows
@@ -110,7 +116,15 @@ def _render_waveform(audio_data, *, size: int = _THUMB_SIZE) -> bytes | None:
     amp = size // 2
     mid = size // 2
 
-    img = Image.new("RGB", (size, size), _BG_COLOR)
+    # Transparent background so the frontend can tint the shape to any theme;
+    # only the wave strokes are opaque (they form the alpha mask).  The
+    # background is transparent *white* (not transparent black): giving the
+    # hidden pixels the same RGB as the opaque wave means downscaling only ever
+    # averages white-with-white, so shrinking a thumbnail to XS/M can't pull dark
+    # RGB out of the "empty" pixels and fringe the wave.  Both render paths
+    # (canvas ``source-in`` tint, CSS ``mask``) then key off the alpha channel
+    # alone, so the wave stays clean at any size.
+    img = Image.new("RGBA", (size, size), (255, 255, 255, 0))
     draw = ImageDraw.Draw(img)
 
     for i in range(cols):
@@ -119,7 +133,7 @@ def _render_waveform(audio_data, *, size: int = _THUMB_SIZE) -> bytes | None:
         # Ensure at least 1px line
         if y_top == y_bot:
             y_bot += 1
-        draw.line([(i, y_top), (i, y_bot)], fill=_WAVE_COLOR)
+        draw.line([(i, y_top), (i, y_bot)], fill=_WAVE_FILL)
 
     buf = io.BytesIO()
     img.save(buf, format="PNG", optimize=True)


### PR DESCRIPTION
## What

`generate_waveform_thumbnail` painted fixed dark colors (`_BG_COLOR` / `_WAVE_COLOR`) into the PNG regardless of theme, so audio square tiles — and every other surface that reuses the same PNG — clashed with a light or highviz map.

This takes the **theme-agnostic** route (the "optimal" option from the issue discussion): the waveform PNG now encodes only the wave *shape* as an alpha mask, and the frontend tints it to the live theme at render time. One PNG serves dark / light / highviz, recolors instantly on a theme switch, and nothing theme-specific is frozen into demo-dataset pickles.

## Backend (`vtscore/media/audio/media_type.py`)

- `_render_waveform` now emits an **RGBA alpha-mask PNG**: transparent background, opaque wave, no color baked in.
- The transparent background is **white-RGB** (`(255, 255, 255, 0)`), matching the wave, so downscaling to XS/M only ever averages the alpha channel and can't fringe the wave with dark pixels.

## Frontend tinting

- **Browse-canvas tiles**: an offscreen `source-in` fill caches each mask tinted to the accent per `(clip, theme)`; the existing `data-theme` `MutationObserver` clears that cache on a theme flip so tiles re-tint. Tiles paint the wave over a themed surface fill.
- **Every `<img>` consumer** renders the mask through a shared global `.waveform-mask` class (accent fill masked to the wave shape) on a themed surface box, instead of a plain `<img>`: the top-left now-playing indicator, bin-popup preview + member grid, left-panel media list, vote grid, saved-labelset grid, browse selection panel, and the new-detector example picker.

## Tests

- New backend test locks in the alpha-mask contract (RGBA, transparent-white corners, color carried entirely by alpha).
- New Vitest specs assert audio thumbnails render the masked element (not an `<img>`) while non-audio still render `<img>`.
- Full `./run-tests.sh core frontend` green: Python 1077 passed, Vitest 1450 passed, build + audit clean, no budget warnings.

## Notes

- **Breaking change**: the waveform PNG is no longer a self-colored image; any external consumer expecting the old dark-blue raster now gets a transparent alpha mask.
- No doc screenshots frame an audio dataset (the screenshot fixture is image-based), so nothing needed reshooting.
- The center-panel audio player is unaffected — it already draws its waveform from decoded audio, not this PNG.

Closes #2369

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmDW8ZS6o29KUCg9hDKK1j)_