### PR TITLE
Browse bin popup: sync DOM focus to the keyboard-navigated entry

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -159,6 +159,7 @@
           @for (id of row; track trackById($index, id)) {
             <div
               class="bin-popup-entry"
+              [attr.data-entry-id]="id"
               [class.selected]="isSelected(id)"
               [class.focused]="isFocused(id)"
               role="button"
@@ -168,6 +169,7 @@
               [title]="name(id)"
               (click)="onEntryClick(id)"
               (keydown)="onEntryKeydown($event, id)"
+              (focus)="onEntryFocus(id)"
               (mouseenter)="onEntryEnter(id)">
               @if (hasThumbnailUrl(id)) {
                 <span class="bin-popup-thumb-wrap">

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -809,7 +809,9 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   /**
    * Move the viewed item one grid step: ``dCol`` along a row, ``dRow`` across
    * rows (a row holds {@link columns} items). Updates the preview pane (image /
-   * video) and the grid's focus ring, and scrolls the target row into view.
+   * video) and the grid's focus ring, scrolls the target row into view, and
+   * moves DOM focus to the walked entry so activation keys (Enter / Space) act
+   * on the highlighted item rather than on whatever entry last held DOM focus.
    * No-op for a singleton/preview-only bin, where there's no grid to walk.
    */
   private moveFocus(dCol: number, dRow: number): void {
@@ -819,7 +821,30 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
     if (next === cur) return;
     this.previewId = this.ids[next];
     this.scrollRowIntoView(next);
+    this.focusEntry(next);
     this.cdr.markForCheck();
+  }
+
+  /**
+   * Move DOM focus onto the grid entry at ``index`` so keyboard activation
+   * (Enter / Space) targets the arrow-walked item. The entry may not be in the
+   * DOM yet — the row was just scrolled into view and the virtual viewport
+   * renders it on a subsequent frame — so query for it after a frame and retry
+   * (bounded) until it exists. ``preventScroll`` keeps the native focus scroll
+   * from fighting {@link scrollRowIntoView}, which already positioned the row.
+   */
+  private focusEntry(index: number, attempt = 0): void {
+    const panel = this.panelRef?.nativeElement;
+    const id = this.ids[index];
+    if (!panel || id == null) return;
+    requestAnimationFrame(() => {
+      const el = panel.querySelector<HTMLElement>(`.bin-popup-entry[data-entry-id="${id}"]`);
+      if (el) {
+        el.focus({ preventScroll: true });
+      } else if (attempt < 5) {
+        this.focusEntry(index, attempt + 1);
+      }
+    });
   }
 
   /** Index of the viewed item within {@link ids}, falling back to the
@@ -919,8 +944,23 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   onEntryKeydown(event: KeyboardEvent, id: number): void {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
+      // Stop the bubble so the document-level handler's Space fallback (which
+      // acts on {@link previewId}) doesn't also fire and double-toggle. The
+      // focused entry owns its own activation; the fallback is only for when
+      // nothing in the grid holds focus.
+      event.stopPropagation();
       this.onEntryClick(id);
     }
+  }
+
+  /** DOM focus landed on an entry (arrow-walk, Tab, or click). Keep
+   *  {@link previewId} — hence the preview pane, metadata column, and focus
+   *  ring — in step with it so the highlighted item is always the one Enter /
+   *  Space will act on, regardless of how focus arrived. */
+  onEntryFocus(id: number): void {
+    if (this.previewId === id) return;
+    this.previewId = id;
+    this.cdr.markForCheck();
   }
 
   /** True when the item currently shown in the preview pane is selected, so the
@@ -942,6 +982,10 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   onPreviewKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
+      // As with the grid entries: when the preview pane holds focus it owns its
+      // activation, so stop the bubble to keep the document-level Space fallback
+      // from also firing and cancelling the toggle.
+      event.stopPropagation();
       this.onPreviewClick();
     }
   }

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -353,3 +353,117 @@ describe('BrowseBinPopupComponent (scroll-prefetch re-wiring)', () => {
     expect(prefetchSpy.mock.calls.length).toBe(callsBeforeSecondScroll + 1);
   });
 });
+
+/**
+ * Keyboard focus sync for the member grid.
+ *
+ * Arrow keys walk the highlighted item (``previewId``), but before this they
+ * left DOM focus behind on whatever entry the user last tabbed/clicked. Enter is
+ * only caught by the focused entry's own handler, so it toggled the stale
+ * DOM-focused entry rather than the arrow-walked one; Space fired both the
+ * document fallback and the focused entry, double-toggling. The fix keeps DOM
+ * focus glued to the walked entry (and ``previewId`` glued to DOM focus), and
+ * lets the focused entry own its activation without the fallback double-firing.
+ *
+ * The member grid is virtualized and doesn't render individual entries reliably
+ * under jsdom, so these drive the sync contract directly on the component rather
+ * than through a rendered ArrowRight → ``document.activeElement`` round-trip.
+ */
+describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
+  interface GridState {
+    ids: number[];
+    columns: number;
+    previewId: number | null;
+    cdr: { markForCheck: () => void };
+    panelRef?: { nativeElement: { querySelector: (sel: string) => HTMLElement | null } };
+    mediaType: () => string;
+    scrollRowIntoView: (index: number) => void;
+    selection: { has: (id: number) => boolean; addAll: (ids: number[]) => void; remove: (id: number) => void };
+    moveFocus(dCol: number, dRow: number): void;
+  }
+
+  function makeGridComponent(): { component: BrowseBinPopupComponent; state: GridState } {
+    const component = Object.create(BrowseBinPopupComponent.prototype) as BrowseBinPopupComponent;
+    const state = component as unknown as GridState;
+    state.ids = [10, 20, 30, 40];
+    state.columns = 2;
+    state.previewId = 10;
+    state.cdr = { markForCheck: vi.fn() };
+    // Non-thumbnail media so `previewOnly` is false and the grid path is live.
+    state.mediaType = () => 'text';
+    state.scrollRowIntoView = vi.fn();
+    state.selection = { has: () => false, addAll: vi.fn(), remove: vi.fn() };
+    return { component, state };
+  }
+
+  let rafSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    // Run rAF synchronously so `focusEntry`'s deferred (and retried) focus lands
+    // within the test tick, deterministically.
+    rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+  });
+  afterEach(() => rafSpy.mockRestore());
+
+  it('moves DOM focus to the arrow-walked entry', () => {
+    const { component, state } = makeGridComponent();
+    const walked = { focus: vi.fn() } as unknown as HTMLElement;
+    state.panelRef = {
+      nativeElement: {
+        // Only the entry for id 20 (the ArrowRight target from index 0) exists.
+        querySelector: (sel: string) => (sel.includes('"20"') ? walked : null),
+      },
+    };
+
+    state.moveFocus(1, 0);
+
+    // The highlight advanced to id 20 …
+    expect(state.previewId).toBe(20);
+    // … and DOM focus followed it, so Enter/Space now act on the highlighted item.
+    expect(walked.focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('retries the focus until the virtualized entry renders, then focuses it', () => {
+    const { state } = makeGridComponent();
+    const walked = { focus: vi.fn() } as unknown as HTMLElement;
+    let calls = 0;
+    state.panelRef = {
+      nativeElement: {
+        // Absent for the first two frames (row still virtualizing in), then in.
+        querySelector: (sel: string) => {
+          if (!sel.includes('"20"')) return null;
+          return ++calls >= 3 ? walked : null;
+        },
+      },
+    };
+
+    state.moveFocus(1, 0);
+
+    expect(walked.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs the highlight to DOM focus that arrives by Tab or click', () => {
+    const { component, state } = makeGridComponent();
+    component.onEntryFocus(30);
+    expect(state.previewId).toBe(30);
+  });
+
+  it('lets the focused entry own its activation, stopping the fallback double-toggle', () => {
+    const { component, state } = makeGridComponent();
+    const event = {
+      key: 'Enter',
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent;
+
+    component.onEntryKeydown(event, 42);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    // The bubble is stopped so the document-level Space fallback (which acts on
+    // previewId) can't also fire and cancel this toggle.
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(state.selection.addAll).toHaveBeenCalledWith([42]);
+  });
+});


### PR DESCRIPTION
## Summary

In the Browse bin-detail popup, arrow keys walk the highlighted item (`previewId`) through the member grid, but DOM focus stayed on whatever entry the user last tabbed or clicked. Because `Enter` is only caught by the *focused* entry's own `(keydown)` handler, it toggled the stale DOM-focused entry rather than the arrow-walked one; `Space` was worse — the document-level fallback (acting on `previewId`) *and* the focused entry both fired, double-toggling to a net no-op.

## Fix

- **`moveFocus()`** now moves DOM focus onto the arrow-walked entry (via a new `focusEntry()` helper). Because the grid is virtualized, the entry may not be in the DOM the instant its row is scrolled into view, so `focusEntry()` queries for `.bin-popup-entry[data-entry-id="…"]` after a frame and retries (bounded) until it renders, then focuses it with `preventScroll: true` so the native focus scroll doesn't fight the popup's own scroll logic.
- **`onEntryFocus(id)`** (wired via a new `(focus)` handler on each entry) keeps `previewId` — hence the preview pane, metadata column, and focus ring — glued to DOM focus, so focus arriving by Tab or click stays consistent with the highlighted item too.
- **`onEntryKeydown` / `onPreviewKeydown`** now `stopPropagation()` on `Enter`/`Space`, so the focused entry owns its activation and the document-level Space fallback can't also fire and cancel the toggle. The fallback stays in place for the un-focused case (e.g. a freshly opened popup, or a singleton bin's preview pane).

Net effect: activation keys act on the highlighted item, regardless of how focus arrived.

## Tests

Added a `keyboard focus sync` describe block to `browse-bin-popup.zoneless.spec.ts` covering: focus following an arrow-walk, the bounded retry against the virtualized grid, `previewId` syncing to Tab/click focus, and the entry handler stopping propagation. The member grid doesn't render individual virtualized entries reliably under jsdom, so these drive the sync contract on the component directly rather than through a rendered `ArrowRight` → `document.activeElement` round-trip.

`./run-tests.sh frontend` passes (1457 unit tests, TypeScript build, lint, audit).

Closes #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016VdRcv4b8D7U44sxc81u37)_