### PR TITLE
Add audio buffering spinner to Browse now-playing widget

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -256,6 +256,11 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
 
   /** Currently-playing hover audio source, so re-entering the same row is a no-op. */
   audioSrc = '';
+  /** Media id of the clip currently auditioning, so the buffering listeners can
+   *  re-emit its now-playing state; ``null`` when silent. */
+  private nowPlayingId: number | null = null;
+  /** Whether the one-shot buffering listeners are wired onto the audio element. */
+  private audioListenersAttached = false;
 
   private readonly failedThumbs = new Set<string>();
   /** Ids whose full-res ``/image`` failed; the preview falls back to the
@@ -1019,14 +1024,18 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
     const src = this.activeContext.mediaUrl(`/api/medias/${id}/audio`);
     if (this.audioSrc === src) return;
     this.audioSrc = src;
+    this.nowPlayingId = id;
     // The autoplay-on-open path may fire before prefetchVisible has hydrated the
     // representative's metadata, so make sure its clip extents are loading (the
     // clip-window handlers read them lazily as they land).
     this.metadataCache.ensureLoaded([id]);
-    this.nowPlaying.emit({ mediaId: id, waveUrl: this.thumbnailUrl(id) });
+    // Starts loading: show the spinner on the now-playing widget until a
+    // ``playing``/``canplay`` event clears it.
+    this.nowPlaying.emit({ mediaId: id, waveUrl: this.thumbnailUrl(id), loading: true });
     setTimeout(() => {
       const el = this.audioRef?.nativeElement;
       if (!el) return;
+      this.attachBufferingListeners(el);
       el.volume = this.volume();
       // Windowed archive-member clips serve the whole file: seek to clip_start
       // and loop within [clip_start, clip_end]. Metadata is read lazily inside
@@ -1035,6 +1044,26 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
       el.load();
       el.play().catch(() => {});
     });
+  }
+
+  /** Wire the buffering listeners onto the popup's audio element once (it lives
+   *  for the popup's lifetime, reused across summons). They flip the now-playing
+   *  widget's spinner on while the clip fetches/decodes or stalls to rebuffer,
+   *  and off once it's actually sounding. */
+  private attachBufferingListeners(el: HTMLAudioElement): void {
+    if (this.audioListenersAttached) return;
+    this.audioListenersAttached = true;
+    el.addEventListener('waiting', () => this.emitNowPlaying(true));
+    el.addEventListener('playing', () => this.emitNowPlaying(false));
+    el.addEventListener('canplay', () => this.emitNowPlaying(false));
+  }
+
+  /** Re-emit the now-playing state with a fresh ``loading`` flag. A no-op once
+   *  nothing is auditioning, so events that fire after a stop don't resurrect
+   *  the widget. */
+  private emitNowPlaying(loading: boolean): void {
+    if (this.audioSrc === '' || this.nowPlayingId == null) return;
+    this.nowPlaying.emit({ mediaId: this.nowPlayingId, waveUrl: this.thumbnailUrl(this.nowPlayingId), loading });
   }
 
   /** Cursor left the grid: stop any hover audio and fall the preview back to the
@@ -1056,6 +1085,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
       el.currentTime = 0;
     }
     this.audioSrc = '';
+    this.nowPlayingId = null;
     if (wasPlaying) this.nowPlaying.emit(null);
   }
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -280,8 +280,20 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     await settlePasses(fixture);
 
     // The window opened auditioning the representative (id 8), not the list's
-    // first member (id 7), and surfaced it on the shared now-playing indicator.
-    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail' });
+    // first member (id 7), and surfaced it on the shared now-playing indicator —
+    // flagged `loading` until the clip is actually sounding.
+    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: true });
+
+    // The clip's audio element drives the buffering spinner: `playing` clears
+    // the loading flag, a `waiting` stall re-sets it.
+    const audioEl = fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
+    audioEl.dispatchEvent(new Event('playing'));
+    await settlePasses(fixture);
+    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: false });
+
+    audioEl.dispatchEvent(new Event('waiting'));
+    await settlePasses(fixture);
+    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: true });
 
     playStub.mockRestore();
     loadStub.mockRestore();

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -13,6 +13,11 @@ export interface NowPlaying {
   mediaId: number;
   /** The clip's waveform PNG — the same thumbnail painted on its tile. */
   waveUrl: string;
+  /** ``true`` while the clip is still fetching/decoding and hasn't begun to
+   *  sound yet (or has stalled to rebuffer mid-play); drives the loading
+   *  spinner on the now-playing widget. Flips to ``false`` once playback is
+   *  actually audible. */
+  loading: boolean;
 }
 
 /** How long (ms) the cursor must rest on an audio bin before its clip starts
@@ -55,6 +60,9 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   /** Never mounted in the DOM — audio here is heard, not shown; the top-left
    *  indicator is the only visual feedback that it's playing. */
   private readonly audioEl = new Audio();
+  /** Waveform PNG of the clip currently auditioning, kept so the buffering
+   *  listeners below can re-emit the now-playing state without recomputing it. */
+  private nowPlayingWaveUrl = '';
 
   constructor() {
     // Keep the live element's volume in sync when the toolbar slider moves
@@ -62,6 +70,13 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
     effect(() => {
       this.audioEl.volume = this.volume();
     });
+    // Buffering feedback: while the clip is fetching/decoding (or stalls to
+    // rebuffer), the widget shows a spinner; once it's actually sounding, the
+    // spinner clears. Listeners are attached once to the reused element and
+    // guarded by ``playingMediaId`` so stray events after a stop are ignored.
+    this.audioEl.addEventListener('waiting', () => this.emitNowPlaying(true));
+    this.audioEl.addEventListener('playing', () => this.emitNowPlaying(false));
+    this.audioEl.addEventListener('canplay', () => this.emitNowPlaying(false));
   }
 
   // --- Text / count popup (text + any other non-thumbnail type) --------------
@@ -157,6 +172,7 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   private playAudio(mediaId: number): void {
     this.playingMediaId = mediaId;
     const waveUrl = this.activeContext.mediaUrl(`/api/medias/${mediaId}/thumbnail`);
+    this.nowPlayingWaveUrl = waveUrl;
     // Hydrate clip extents (clip_start/clip_end) so windowed clips loop within
     // their window; applyClipWindow reads them lazily as they land.
     this.metadataCache.ensureLoaded([mediaId]);
@@ -165,7 +181,17 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
     this.audioEl.src = this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`);
     this.audioEl.load();
     this.audioEl.play().catch(() => {});
-    this.nowPlaying.emit({ mediaId, waveUrl });
+    // Starts loading: show the spinner until a ``playing``/``canplay`` event
+    // (wired in the constructor) clears it.
+    this.nowPlaying.emit({ mediaId, waveUrl, loading: true });
+  }
+
+  /** Re-emit the now-playing state with a fresh ``loading`` flag, from the
+   *  buffering listeners. A no-op once nothing is auditioning, so events that
+   *  fire after a stop don't resurrect the widget. */
+  private emitNowPlaying(loading: boolean): void {
+    if (this.playingMediaId == null) return;
+    this.nowPlaying.emit({ mediaId: this.playingMediaId, waveUrl: this.nowPlayingWaveUrl, loading });
   }
 
   private stopAudio(): void {

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.zoneless.spec.ts
@@ -122,10 +122,37 @@ describe('BrowseHoverPreviewComponent (zoneless canary)', () => {
     await settleZoneless(fixture);
 
     // After the dwell: playback starts and `nowPlaying` carries the clip's
-    // waveform for the top-left indicator — still no panel in the canvas.
+    // waveform for the top-left indicator — flagged `loading` until the clip is
+    // actually sounding — still no panel in the canvas.
     expect(playSpy).toHaveBeenCalled();
-    expect(emitted).toEqual({ mediaId: 7, waveUrl: '/api/medias/7/thumbnail' });
+    expect(emitted).toEqual({ mediaId: 7, waveUrl: '/api/medias/7/thumbnail', loading: true });
     expect(fixture.nativeElement.querySelector('.hover-player')).toBeNull();
+  });
+
+  it('clears the loading flag once the clip starts sounding, and re-sets it on rebuffer', async () => {
+    fixture.componentRef.setInput('mediaType', 'audio');
+    let emitted: NowPlaying | null | undefined;
+    fixture.componentInstance.nowPlaying.subscribe((e) => (emitted = e));
+
+    fixture.componentRef.setInput('hover', hoverEvent(9));
+    await wait(DWELL_MS + 60);
+    await settleZoneless(fixture);
+
+    // Auditioning starts in the loading state (fetch/decode not done yet).
+    expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: true });
+
+    // The reused (never-mounted) audio element drives the buffering listeners.
+    const audioEl = (fixture.componentInstance as unknown as { audioEl: HTMLAudioElement }).audioEl;
+
+    // The element reports it's now playing → spinner clears.
+    audioEl.dispatchEvent(new Event('playing'));
+    await settleZoneless(fixture);
+    expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: false });
+
+    // A stall to rebuffer mid-play → spinner returns.
+    audioEl.dispatchEvent(new Event('waiting'));
+    await settleZoneless(fixture);
+    expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: true });
   });
 
   it('debounces the dwell so sweeping across bins plays only the settled one', async () => {

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -70,13 +70,23 @@
                   <!-- The waveform PNG is a theme-agnostic alpha mask (issue #2369):
                        the surface box mirrors the browse tile, and the inner element
                        masks the accent colour to the wave shape so it recolours with
-                       the theme instead of showing baked-in pixels. -->
-                  <div class="browse-now-playing-wave" aria-hidden="true">
-                    <div
-                      class="browse-now-playing-wave-fill waveform-mask"
-                      [style.-webkit-mask-image]="'url(' + np.waveUrl + ')'"
-                      [style.mask-image]="'url(' + np.waveUrl + ')'"
-                    ></div>
+                       the theme instead of showing baked-in pixels. The wrap is the
+                       positioning context for the buffering spinner overlaid while
+                       the clip is still fetching/decoding (issue #2454); it sits
+                       outside the aria-hidden wave box so its status stays announced. -->
+                  <div class="browse-now-playing-wave-wrap">
+                    <div class="browse-now-playing-wave" aria-hidden="true">
+                      <div
+                        class="browse-now-playing-wave-fill waveform-mask"
+                        [style.-webkit-mask-image]="'url(' + np.waveUrl + ')'"
+                        [style.mask-image]="'url(' + np.waveUrl + ')'"
+                      ></div>
+                    </div>
+                    @if (np.loading) {
+                      <div class="browse-now-playing-loading" role="status" aria-label="Loading audio">
+                        <span class="browse-now-playing-spinner" aria-hidden="true"></span>
+                      </div>
+                    }
                   </div>
                 }
                 <div class="browse-volume" role="group" aria-label="Preview volume">

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -85,6 +85,12 @@
   gap: var(--space-xs);
 }
 
+// Positioning context so the buffering spinner can sit centred over the wave.
+.browse-now-playing-wave-wrap {
+  position: relative;
+  display: block;
+}
+
 // The waveform of whatever clip is currently auditioning; the same shape
 // painted on its tile, stretched wide (time on X) to read at a glance as
 // "this is what's making noise". The PNG is a theme-agnostic alpha mask
@@ -108,6 +114,34 @@
   height: 100%;
   mask-size: 100% 100%;
   -webkit-mask-size: 100% 100%;
+}
+
+// Shown only while the clip is fetching/decoding (or has stalled to rebuffer):
+// a scrim over the wave with a small ring spinner, so it's clear the app is
+// working and sound is on its way rather than stuck.
+.browse-now-playing-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-surface) 60%, transparent);
+}
+
+.browse-now-playing-spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-top-color: var(--accent);
+  animation: browse-now-playing-spin 0.8s linear infinite;
+}
+
+@keyframes browse-now-playing-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 // Ready-state layout: the canvas region, a draggable divider, and the docked


### PR DESCRIPTION
## What & why

On the Browse (exploration) page, auditioning an audio clip gave no feedback during the fetch/decode window before it started sounding — leaving it unclear whether the app was working or stuck. Both audio paths (`browse-hover-preview` and `browse-bin-popup`) played through a raw `HTMLAudioElement` with no buffering state, and the `<audio>` element is `sr-only` so native controls/spinner aren't visible either. The only feedback was the top-left now-playing waveform, which appears *after* playback begins.

## Change

- Add a `loading` flag to the shared `NowPlaying` state, driven by the audio element's `waiting` / `playing` / `canplay` events. It starts `true` when a clip begins loading and clears once the clip is actually sounding (re-setting on a mid-play rebuffer stall).
- Render a small ring spinner over the top-left now-playing waveform (`browse-view`) while `loading` is set. Scoped, theme-aware CSS using the existing `--accent` / `color-mix` conventions; desktop-only, no new dependencies.

This keeps the intentionally narrow scope of the issue — just the missing loading feedback anchored on the existing minimal top-left indicator; it does **not** reintroduce the floating player panel removed in d074d905.

## Tests

Updated the two zoneless specs to assert the new `loading` flag on the emitted `NowPlaying`, plus new cases covering the `playing`→clear and `waiting`→re-set buffering transitions on both paths. `./run-tests.sh frontend` passes (build + audit + 1454 Vitest tests).

Closes #2454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVJmnVkXC3MHeaq2isSSoa)_