### PR TITLE
Filter Add-Dataset picker to solo media type and clarify Settings copy

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { DatasetImporterModalComponent } from './dataset-importer-modal.component';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
-import { settleZoneless } from '../../../testing/settle-resource';
+import { settleResource, settleZoneless } from '../../../testing/settle-resource';
 import { getTabLabel } from './pickers/shared/media-type.util';
 import { provideHttpTesting } from '../../../testing/test-providers';
 
@@ -278,14 +278,17 @@ describe('DatasetImporterModalComponent', () => {
       { id: 'synth', label: 'Synthetic', order: 20 },
     ];
 
-    function initSolo(solo: string | null): void {
+    async function initSolo(solo: string | null): Promise<void> {
       TestBed.tick();
       httpMock.expectOne('/api/dataset/all-importers').flush({ importers: soloImporters, tabs: soloTabs });
       flushInitRequests(solo ? { effective_solo_media_type: solo } : {});
+      // The settings rxResource commits its value on a microtask, so let it
+      // land before reading the solo-dependent getters.
+      await settleResource();
     }
 
-    it('hides type-scoped importers whose options exclude the locked type', () => {
-      initSolo('audio');
+    it('hides type-scoped importers whose options exclude the locked type', async () => {
+      await initSolo('audio');
       // synthetic can only produce image/video, so under an audio lock it is
       // dropped - and its now-empty "Synthetic" tab disappears with it.
       const names = component.orderedImporters.map((i) => i.name);
@@ -293,15 +296,15 @@ describe('DatasetImporterModalComponent', () => {
       expect(component.visibleImporterTabs.map((t) => t.id)).toEqual(['local']);
     });
 
-    it('keeps type-scoped importers whose options include the locked type', () => {
-      initSolo('image');
+    it('keeps type-scoped importers whose options include the locked type', async () => {
+      await initSolo('image');
       const names = component.orderedImporters.map((i) => i.name);
       expect(names).toContain('synthetic');
       expect(component.visibleImporterTabs.map((t) => t.id)).toEqual(['local', 'synth']);
     });
 
-    it('keeps agnostic importers under any lock', () => {
-      initSolo('audio');
+    it('keeps agnostic importers under any lock', async () => {
+      await initSolo('audio');
       // local_folder / local_files declare no media_type field, so they
       // produce whatever the user points them at and always stay offered.
       const names = component.orderedImporters.map((i) => i.name);
@@ -309,8 +312,8 @@ describe('DatasetImporterModalComponent', () => {
       expect(names).toContain('local_files');
     });
 
-    it('shows every importer and tab when no lock is set', () => {
-      initSolo(null);
+    it('shows every importer and tab when no lock is set', async () => {
+      await initSolo(null);
       const names = component.orderedImporters.map((i) => i.name);
       expect(names).toContain('synthetic');
       expect(component.visibleImporterTabs.map((t) => t.id)).toEqual(['local', 'synth']);

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -160,18 +160,18 @@ describe('DatasetImporterModalComponent', () => {
    *  ``/api/embedders`` (no media_type), ``/api/media-types``, and the
    *  settings load (``/api/settings``).  Flush all of them so each test
    *  starts from a clean request queue. */
-  function flushInitRequests(): void {
+  function flushInitRequests(settings: Record<string, unknown> = {}): void {
     httpMock.expectOne(req => req.url === '/api/embedders' && !req.params.get('media_type'))
       .flush({ embedders: [] });
     httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });
     TestBed.tick(); // flush the SettingsStateService rxResource loader (root effect)
-    httpMock.expectOne('/api/settings').flush({});
+    httpMock.expectOne('/api/settings').flush(settings);
   }
 
-  function flushImporters(): void {
+  function flushImporters(settings: Record<string, unknown> = {}): void {
     TestBed.tick(); // run ngOnInit under zoneless (issues the init GETs); also resolves the static picker ViewChilds
     httpMock.expectOne('/api/dataset/all-importers').flush({ importers: mockImporters, tabs: mockTabs });
-    flushInitRequests();
+    flushInitRequests(settings);
   }
 
   /** Flush the embedder + clipper fetches and the embedder-aware demo-list
@@ -257,6 +257,64 @@ describe('DatasetImporterModalComponent', () => {
     // tab renders but importersForActiveTab is empty when selected.
     component.selectImporterTab('services');
     expect(component.importersForActiveTab.length).toBe(0);
+  });
+
+  describe('solo media-type filtering', () => {
+    // A type-scoped importer (only produces image/video) sitting in its own
+    // category, plus the always-agnostic Local folder/files pair.
+    const soloImporters = [
+      { name: 'local_folder', display_name: 'Folder', picker_view: 'local_folder', category: 'local', fields: [] },
+      { name: 'local_files', display_name: 'Files', picker_view: 'local_files', category: 'local', fields: [] },
+      {
+        name: 'synthetic',
+        display_name: 'Synthetic',
+        picker_view: 'form',
+        category: 'synth',
+        fields: [{ key: 'media_type', field_type: 'select', label: 'Media Type', options: ['image', 'video'] }],
+      },
+    ];
+    const soloTabs = [
+      { id: 'local', label: 'Local', order: 10 },
+      { id: 'synth', label: 'Synthetic', order: 20 },
+    ];
+
+    function initSolo(solo: string | null): void {
+      TestBed.tick();
+      httpMock.expectOne('/api/dataset/all-importers').flush({ importers: soloImporters, tabs: soloTabs });
+      flushInitRequests(solo ? { effective_solo_media_type: solo } : {});
+    }
+
+    it('hides type-scoped importers whose options exclude the locked type', () => {
+      initSolo('audio');
+      // synthetic can only produce image/video, so under an audio lock it is
+      // dropped - and its now-empty "Synthetic" tab disappears with it.
+      const names = component.orderedImporters.map((i) => i.name);
+      expect(names).not.toContain('synthetic');
+      expect(component.visibleImporterTabs.map((t) => t.id)).toEqual(['local']);
+    });
+
+    it('keeps type-scoped importers whose options include the locked type', () => {
+      initSolo('image');
+      const names = component.orderedImporters.map((i) => i.name);
+      expect(names).toContain('synthetic');
+      expect(component.visibleImporterTabs.map((t) => t.id)).toEqual(['local', 'synth']);
+    });
+
+    it('keeps agnostic importers under any lock', () => {
+      initSolo('audio');
+      // local_folder / local_files declare no media_type field, so they
+      // produce whatever the user points them at and always stay offered.
+      const names = component.orderedImporters.map((i) => i.name);
+      expect(names).toContain('local_folder');
+      expect(names).toContain('local_files');
+    });
+
+    it('shows every importer and tab when no lock is set', () => {
+      initSolo(null);
+      const names = component.orderedImporters.map((i) => i.name);
+      expect(names).toContain('synthetic');
+      expect(component.visibleImporterTabs.map((t) => t.id)).toEqual(['local', 'synth']);
+    });
   });
 
   it('should render inner importer sub-tabs for the active category', async () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -15,6 +15,7 @@ import { DatasetsListingsApiService } from '../../../services/datasets-listings-
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { EmbedderInfo, ImporterInfo, ImporterPickerTab, MediaTypeInfo } from '../../../models/api.models';
 import { DemoDatasetEntry } from '../../../generated/api-client/models/demo-dataset-entry';
+import { toTypeId } from './pickers/shared/media-type.util';
 
 /** Add Dataset modal.  Owns the importer registry, category/importer
  *  tab selection, and the shared media-type registry + Advanced-block
@@ -171,7 +172,36 @@ export class DatasetImporterModalComponent implements OnInit {
         result.push(imp);
       }
     }
-    return result;
+    return result.filter((imp) => this.importerAllowedUnderSolo(imp));
+  }
+
+  /** The set of media ``type_id``s an importer can produce, or ``null``
+   *  when it is media-type agnostic (has no fixed ``media_type`` option
+   *  list - e.g. the folder/file importers, whose type the user picks, or
+   *  the demo importer, which filters its own table).  Options are
+   *  normalised through the media-type registry so an importer that
+   *  declares folder names (``"images"``) and one that declares type_ids
+   *  (``"image"``) both resolve to the canonical id. */
+  private supportedTypeIds(importer: ImporterInfo): Set<string> | null {
+    const field = importer.fields?.find((f) => f.key === 'media_type');
+    const options = field?.options || [];
+    if (!field || options.length === 0) return null;
+    const types = new Set<string>();
+    for (const opt of options) types.add(toTypeId(this.mediaTypes(), opt));
+    return types;
+  }
+
+  /** Whether an importer is offered under the active solo media type.
+   *  With no solo lock every importer is offered; otherwise agnostic
+   *  importers stay (they preselect the solo type) and type-scoped ones
+   *  are hidden unless their option set includes the locked type, so the
+   *  picker never presents an importer that can't produce the one type
+   *  the user is streamlined to. */
+  private importerAllowedUnderSolo(importer: ImporterInfo): boolean {
+    const solo = this.effectiveSoloMediaType;
+    if (!solo) return true;
+    const supported = this.supportedTypeIds(importer);
+    return supported === null || supported.has(solo);
   }
 
   /** Title-case an importer category id when no backend declaration exists.
@@ -196,13 +226,20 @@ export class DatasetImporterModalComponent implements OnInit {
     const declared = [...this.declaredTabs()].sort(
       (a, b) => (a.order ?? 100) - (b.order ?? 100),
     );
-    for (const tab of declared) {
-      visible.push(tab);
-      seen.add(tab.id);
-    }
     const usedCategories = new Set(
       this.orderedImporters.map((imp) => imp.category || '').filter(Boolean),
     );
+    const solo = this.effectiveSoloMediaType;
+    for (const tab of declared) {
+      // Declared tabs normally render even when empty (so categories like
+      // "Services" stay visible before any extension importer is installed).
+      // Under a solo lock that would surface a category with no importer
+      // able to produce the locked type, which is exactly the confusion this
+      // streamlining removes - so drop empty tabs while solo is active.
+      if (solo && !usedCategories.has(tab.id)) continue;
+      visible.push(tab);
+      seen.add(tab.id);
+    }
     for (const id of usedCategories) {
       if (!seen.has(id)) {
         visible.push({ id, label: this.fallbackTabLabel(id) });

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -207,10 +207,8 @@
         <!-- Import Defaults -->
         @if (activeSettingsTab() === 'imports') {
           <h3>Import Defaults<vt-field-hint-icon hint="Per-media-type defaults that auto-fill the Add Dataset modal when you start a matching import."></vt-field-hint-icon></h3>
-          <div class="form-group" title="Streamline the UI for a single media type. Importer and detector flows will hide their media-type pickers and lock to this type; converters that produce other types are filtered out.">
-            <label class="form-label" for="setting-solo-media-type">Solo media type@if (soloMediaTypeNote) {
-              <vt-field-hint-icon [hint]="soloMediaTypeNote"></vt-field-hint-icon>
-            }</label>
+          <div class="form-group" title="Streamline the app to a single media type: the Add Dataset picker hides importers and tabs that can't produce it (and preselects it on the rest), the New Detector media picker and Import Defaults collapse to this type, and converters that output other types are filtered out.">
+            <label class="form-label" for="setting-solo-media-type">Solo media type<vt-field-hint-icon [hint]="soloMediaTypeHint"></vt-field-hint-icon></label>
             <select
               id="setting-solo-media-type"
               class="form-select"

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -206,6 +206,20 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     return '';
   }
 
+  /** Always-present help for the solo-mediaType select, spelling out
+   *  exactly what the lock constrains (so it isn't a mystery toggle), plus
+   *  the CLI-fallback note when one applies. */
+  get soloMediaTypeHint(): string {
+    const base =
+      'Streamlines the whole app to one media type. The Add Dataset picker ' +
+      'hides importers and tabs that can’t produce it and preselects it ' +
+      'on the ones that can; the New Detector media picker and the Import ' +
+      'Defaults tab collapse to just this type; and converters that output ' +
+      'other types are filtered out. Pick "Show everything" to turn it off.';
+    const note = this.soloMediaTypeNote;
+    return note ? `${base} ${note}` : base;
+  }
+
   onSoloMediaTypeChange(value: string): void {
     // Empty string = "Show everything"; the backend stores it as null
     // and still flips the explicit flag so the choice survives a CLI


### PR DESCRIPTION
## What

With a `solo_media_type` lock set, the Add-Dataset flow already preselected that type on the server-folder picker and collapsed the demo tab bar, but the importer **category tabs** and **importer cards** themselves were still unfiltered — so an importer like `synthetic` (which can only produce image/audio/video) would show even when the app was streamlined to `text`, and empty category tabs would render. This made it unclear what "solo" actually constrains.

This PR:

- **Filters the picker tabs/importers to the solo type.** In `DatasetImporterModalComponent`, `orderedImporters` now drops any type-scoped importer whose declared `media_type` options don't include the locked type. Media-type-agnostic importers (the folder/file importers, whose type the user picks; the demo importer, which filters its own table) always stay. A category tab with no remaining importer is hidden under a solo lock instead of rendering an empty pane. With no lock set, behavior is unchanged — every importer and declared tab still shows.
- **Clarifies the Settings copy.** The "Solo media type" field now carries an always-present hint icon spelling out exactly what the lock constrains (hides incompatible importers/tabs and preselects the type on the rest, collapses the New Detector media picker and Import Defaults tab, filters converters), plus the CLI-fallback note when it applies. The field-group tooltip is reworded to match.

Importer options are normalised through the media-type registry, so importers that declare folder names (`"images"`) and ones that declare type_ids (`"image"`) both resolve to the canonical id before matching.

## Tests

Added a `solo media-type filtering` describe block to `dataset-importer-modal.component.spec.ts` covering: hiding a type-scoped importer (and its now-empty tab) under an incompatible lock, keeping it under a compatible lock, keeping agnostic importers under any lock, and the no-lock passthrough. Full suite green (`./run-tests.sh`: 6114 passed; frontend gate: 1457 Vitest passed).

Closes #2381


---
_Generated by [Claude Code](https://claude.ai/code/session_013cRQ7pN9fmqNbi1EiSNZg2)_