### PR TITLE
Sort non-streaming CLI merge results once at the end, not per chunk

### DIFF
--- a/tests_lib/datasets/test_chunked_loading.py
+++ b/tests_lib/datasets/test_chunked_loading.py
@@ -606,10 +606,9 @@ class TestMergeDetectorResults:
         _merge_detector_results(acc, new)
         assert acc["det_a"]["total_hits"] == 2
         assert len(acc["det_a"]["hits"]) == 2
-        # Verify sorted by score descending
-        assert acc["det_a"]["hits"][0]["score"] >= acc["det_a"]["hits"][1]["score"]
 
-    def test_merge_sorts_descending(self):
+    def test_merge_appends_without_sorting(self):
+        """Merge only concatenates; ordering is deferred to _sort_detector_results."""
         from vtscore.cli import _merge_detector_results
 
         acc = {
@@ -629,8 +628,36 @@ class TestMergeDetectorResults:
             }
         }
         _merge_detector_results(acc, new)
+        # Appended in chunk order, not re-sorted per chunk.
+        assert [h["filename"] for h in acc["det_a"]["hits"]] == ["low.wav", "high.wav"]
+
+    def test_sort_orders_descending(self):
+        from vtscore.cli import _merge_detector_results, _sort_detector_results
+
+        acc = {
+            "det_a": {
+                "detector_name": "det_a",
+                "threshold": 0.5,
+                "total_hits": 1,
+                "hits": [{"filename": "low.wav", "score": 0.5}],
+                "negative_hits": [{"filename": "neg_low.wav", "score": 0.1}],
+            }
+        }
+        new = {
+            "det_a": {
+                "detector_name": "det_a",
+                "threshold": 0.5,
+                "total_hits": 1,
+                "hits": [{"filename": "high.wav", "score": 0.99}],
+                "negative_hits": [{"filename": "neg_high.wav", "score": 0.3}],
+            }
+        }
+        _merge_detector_results(acc, new)
+        _sort_detector_results(acc)
         assert acc["det_a"]["hits"][0]["filename"] == "high.wav"
         assert acc["det_a"]["hits"][1]["filename"] == "low.wav"
+        assert acc["det_a"]["negative_hits"][0]["filename"] == "neg_high.wav"
+        assert acc["det_a"]["negative_hits"][1]["filename"] == "neg_low.wav"
 
     def test_merge_multiple_detectors(self):
         from vtscore.cli import _merge_detector_results

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -366,17 +366,32 @@ def _merge_detector_results(
     accumulated: dict[str, dict[str, Any]],
     new_chunk: dict[str, dict[str, Any]],
 ) -> None:
-    """Merge detector results from a new chunk into *accumulated* in-place."""
+    """Merge detector results from a new chunk into *accumulated* in-place.
+
+    Hits are appended, not sorted: this path holds every hit in RAM by
+    design, so it defers ordering to a single final :func:`_sort_detector_results`
+    pass rather than re-sorting the growing list on every chunk.
+    """
     for det_name, det_result in new_chunk.items():
         if det_name not in accumulated:
             accumulated[det_name] = det_result
         else:
             accumulated[det_name]["hits"].extend(det_result["hits"])
             accumulated[det_name]["total_hits"] += det_result["total_hits"]
-            accumulated[det_name]["hits"].sort(key=lambda x: x["score"], reverse=True)
             if "negative_hits" in det_result:
                 accumulated[det_name].setdefault("negative_hits", []).extend(det_result["negative_hits"])
-                accumulated[det_name]["negative_hits"].sort(key=lambda x: x["score"], reverse=True)
+
+
+def _sort_detector_results(accumulated: dict[str, dict[str, Any]]) -> None:
+    """Sort every detector's hit lists by score descending, in place.
+
+    Run once after all chunks have been merged, replacing the per-chunk sort
+    that :func:`_merge_detector_results` used to do.
+    """
+    for det_result in accumulated.values():
+        det_result["hits"].sort(key=lambda x: x["score"], reverse=True)
+        if "negative_hits" in det_result:
+            det_result["negative_hits"].sort(key=lambda x: x["score"], reverse=True)
 
 
 def _load_pickle_whole(dataset_path: str) -> Iterator[dict[int, dict[str, Any]]]:
@@ -628,6 +643,8 @@ def _run_live_pipeline(
 
     if not merged_results:
         raise ValueError(empty_error)
+
+    _sort_detector_results(merged_results)
 
     if chunk_num > 1:
         cli_progress.emit(


### PR DESCRIPTION
## Summary

`_merge_detector_results` re-sorted each detector's growing hit list on every chunk. That code path holds all hits in RAM by design (the non-streaming CLI merge path), so the repeated per-chunk sorts are wasted work — `O(chunks · n log n)` where a single final sort is `O(n log n)`.

This splits the concern:
- `_merge_detector_results` now only **appends** hits/negative_hits and accumulates `total_hits` — no sorting.
- A new `_sort_detector_results` pass orders every detector's `hits` (and `negative_hits`) **once**, after all chunks are merged, in `_run_live_pipeline`.

The final exported results are identical; only the ordering work moved.

## Tests

- Updated `TestMergeDetectorResults` in `tests_lib/datasets/test_chunked_loading.py`: merge now asserted to append in chunk order (`test_merge_appends_without_sorting`), and a new `test_sort_orders_descending` covers the single final sort for both hits and negative_hits.
- Full suite green (`./run-tests.sh`): 6176 passed.

Closes #2393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYppzTDpBT55m9mbQr4FTS)_