### PR TITLE
Migrate text-sort progress to step/total_steps for the unified bar + ETA

### DIFF
--- a/tests/sorting/test_sorting.py
+++ b/tests/sorting/test_sorting.py
@@ -916,8 +916,8 @@ class TestLoadEmbedderConcurrentCallback:
         mock_mt.load_models = slow_load_models
 
         with unittest.mock.patch("vtscore.media.get", return_value=mock_mt):
-            t1 = threading.Thread(target=_load_embedder_with_progress, args=("audio", 5))
-            t2 = threading.Thread(target=_load_embedder_with_progress, args=("audio", 5))
+            t1 = threading.Thread(target=_load_embedder_with_progress)
+            t2 = threading.Thread(target=_load_embedder_with_progress)
             t1.start()
             t2.start()
             t1.join(timeout=10)
@@ -944,7 +944,7 @@ class TestLoadEmbedderConcurrentCallback:
 
         with unittest.mock.patch("vtsearch.routes.sorting._get_embedder_for_loaded_data", return_value=mock_emb):
             with pytest.raises(RuntimeError):
-                _load_embedder_with_progress("audio", 5)
+                _load_embedder_with_progress()
 
         assert mock_emb._on_progress is original_cb
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -73,7 +73,7 @@ from vtsearch.state import (
     snapshot_medias,
     vote_region_boxes,
 )
-from vtscore.concurrency.progress import update_sort_progress
+from vtscore.concurrency.progress import sort_progress, update_sort_progress
 
 if TYPE_CHECKING:
     from vtscore.media.embedder import MediaEmbedder
@@ -83,6 +83,24 @@ sorting_bp = Blueprint(
     __name__,
     description="Text / example / learned sort, votes, inclusion, safe-thresholds, coverage atlas.",
 )
+
+# Text-sort proceeds in three phases: load the embedding model, embed the text
+# query, then score every media by cosine similarity.  Reported as
+# ``step``/``total_steps`` (not ``current``/``total``) so the sort channel gets
+# the unified whole-job bar and an overall ETA, with the model load surfaced as
+# real sub-progress within step 1.
+_SORT_STEPS = 3
+# The model load dominates wall-clock on a cold start (seconds to pull CLAP /
+# SigLIP weights); embedding one short query is trivial; scoring scales with the
+# dataset but is vectorised.  Paces the unified bar; the overall ETA
+# self-corrects from measured elapsed-vs-fraction regardless of these weights.
+#                     load  embed  score
+_SORT_STEP_WEIGHTS = [0.75, 0.05, 0.20]
+
+
+def _sort_idle() -> None:
+    """Reset the sort progress bar to idle, clearing the whole-job step frame."""
+    update_sort_progress("idle", "", step=None, total_steps=None)
 
 
 def _cosine_sort(query_vec, *, role: str = "score"):
@@ -151,13 +169,15 @@ def _score_embedder_for_loaded_data() -> tuple["MediaEmbedder | None", str | Non
     return _get_embedder_for_loaded_data(), score_name
 
 
-def _load_embedder_with_progress(media_type, total_steps):
-    """Load the embedding model, forwarding progress to the sort progress bar.
+def _load_embedder_with_progress():
+    """Load the embedding model, forwarding its load progress to step 1 of the bar.
 
     If the model is already loaded this is a no-op.  A lock serialises
     concurrent callers so that only one request touches ``_on_progress``
     at a time, preventing the save/restore from trampling another
-    request's callback.
+    request's callback.  The model-load ``cur``/``tot`` is reported as the
+    within-step progress of step 1, so the unified bar animates during the
+    load instead of parking at a step floor.
     """
     emb = _get_embedder_for_loaded_data()
     if emb is None:
@@ -167,9 +187,11 @@ def _load_embedder_with_progress(media_type, total_steps):
         if getattr(emb, "_model", None) is not None:
             return
 
-        update_sort_progress("sorting", "Loading embedder…", 0, total_steps)
+        update_sort_progress("sorting", "Loading embedder…", 0, 0, step=1, total_steps=_SORT_STEPS)
         original_cb = emb._on_progress
-        emb._on_progress = lambda status, msg, cur, tot: update_sort_progress("sorting", msg, cur, tot)
+        emb._on_progress = lambda status, msg, cur, tot: update_sort_progress(
+            "sorting", msg, cur, tot, step=1, total_steps=_SORT_STEPS
+        )
         try:
             emb.load_models()
         finally:
@@ -185,17 +207,16 @@ def sort_clips(body: dict):
     """Return medias sorted by cosine similarity to a text query."""
     text = body.get("text", "").strip()
     if not text:
-        update_sort_progress("idle")
+        _sort_idle()
         abort(400, message="text is required")
 
     snap = snapshot_medias()
     if not snap:
-        update_sort_progress("idle")
+        _sort_idle()
         abort(400, message="No medias loaded")
 
     first = next(iter(snap.values()))
     media_type = first.get("media_type", "audio")
-    total_steps = 3  # load embedder, embed query, compute similarities
 
     # Resolve the dataset's bound text embedder (v3 routing table). Reject the
     # request up-front when no text slot is bound (a vision-only dataset, e.g.
@@ -207,7 +228,7 @@ def sort_clips(body: dict):
     ctx = get_active_context()
     embedder_name = ctx.routed_embedder("text")
     if embedder_name is None:
-        update_sort_progress("idle")
+        _sort_idle()
         primary = first.get("embedder", "") or "this dataset's embedder"
         abort(
             400,
@@ -216,21 +237,22 @@ def sort_clips(body: dict):
             ),
         )
 
+    sort_progress.set_step_weights(_SORT_STEP_WEIGHTS)
     try:
-        _load_embedder_with_progress(media_type, total_steps)
-        update_sort_progress("sorting", "Embedding text query…", 1, total_steps)
+        _load_embedder_with_progress()
+        update_sort_progress("sorting", "Embedding text query…", 0, 0, step=2, total_steps=_SORT_STEPS)
 
         from vtsearch import settings
 
         enrich = settings.get_enrich_descriptions()
         text_vec = embed_text_query(text, media_type, enrich=enrich, embedder_name=embedder_name)
         if text_vec is None:
-            update_sort_progress("idle")
+            _sort_idle()
             abort(500, message=f"Could not embed text for media type {media_type}")
 
-        update_sort_progress("sorting", "Computing similarities…", 2, total_steps)
+        update_sort_progress("sorting", "Computing similarities…", 0, 0, step=3, total_steps=_SORT_STEPS)
         results, threshold = _cosine_sort(text_vec, role="text")
-        update_sort_progress("idle")
+        _sort_idle()
         return {"results": results, "threshold": threshold}
     except Exception as exc:
         from werkzeug.exceptions import HTTPException
@@ -241,7 +263,7 @@ def sort_clips(body: dict):
             # in a 500.
             raise
         logging.getLogger(__name__).exception("text sort failed")
-        update_sort_progress("idle")
+        _sort_idle()
         abort(500, message=f"Text sort failed: {format_exception_detail(exc)}")
 
 


### PR DESCRIPTION
## What

`vtsearch/routes/sorting.py` encoded its three text-sort phases (load embedder, embed query, compute similarities) as `current`/`total` — where `current` was the phase index — rather than the `step`/`total_steps` fields. As a result the `sort` progress channel got no whole-job `overall` fraction and stayed a coarse 3-step bar with no overall ETA.

This refactors the `/api/sort` handler to report `step`/`total_steps`, so the sort channel now flows through `ProgressTracker._compute_overall` and gets the same unified whole-job bar + overall ETA that dataset load and Find already have.

## Changes

- `_load_embedder_with_progress()` now reports the model load as **real sub-progress within step 1** — the embedder's `cur`/`tot` callback drives `current`/`total` under `step=1, total_steps=3`, so the bar animates during the load instead of parking at a step floor. Its unused `(media_type, total_steps)` params are dropped.
- `sort_clips` reports `step=2` (embed query) and `step=3` (compute similarities), and sets per-step weights (`[0.75, 0.05, 0.20]`) so the bar paces with the load-dominated cold start; the overall ETA self-corrects from measured elapsed-vs-fraction regardless of the weights.
- A small `_sort_idle()` helper resets the bar and clears the `step`/`total_steps` frame on every exit path (success, early aborts, embed failure, and the catch-all), mirroring the Find route's `update_find_progress("idle", ..., step=None, total_steps=None)`.
- Updated the two `_load_embedder_with_progress` call sites in `tests/sorting/test_sorting.py` for the new zero-arg signature.

## Testing

- `./run-tests.sh sorting` — 323 passed (plus ruff / pyright / codespell / deptry / pip-audit / OpenAPI snapshot).
- `./run-tests.sh core api` — 1634 passed (frontend `build:prod` + SSE events channel included).

Closes #2395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rVbVaF64iosTogv4vWdyk)_