### PR TITLE
Support streaming (batched) delivery for email_smtp and webhook exporters

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -66,7 +66,7 @@ flow still accumulates every hit in memory and buffers the whole result set
 before the exporter writes it. For a media source with more items (and more
 hits) than fit in RAM — e.g. a folder tree of billions of images — add
 `--stream-results` (requires `--chunk-size` and a streaming-capable exporter:
-`server_json_file`, `server_csv_file`, or `gui`):
+`server_json_file`, `server_csv_file`, `gui`, `webhook`, or `email_smtp`):
 
 ```bash
 python app.py --autodetect --importer server_folder --path /data/images \
@@ -82,6 +82,13 @@ line. The tradeoff: streamed hits are ordered by chunk, **not** globally sorted
 by score (sort the NDJSON afterwards if you need a global ranking). Only
 above-threshold (predicted-good) hits are written; add `--keep-negatives` to
 also stream the below-threshold items (tagged `label=bad`).
+
+The delivery exporters stream too, but batch rather than flush per hit:
+`webhook` POSTs the hits in `--batch-size` groups (each request body carries the
+run metadata, a zero-based `batch_index`, and a `hits` array), and `email_smtp`
+sends one email per `--batch-size` hits. Both default to 500 hits per batch and
+always deliver at least once (even for a zero-hit run), so the receiver learns
+the run happened.
 
 **Exporting results**: by default results are printed to the console. Add `--exporter <name>` to send them elsewhere:
 

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -934,12 +934,16 @@ def export_cli_streaming(self, header, records, field_values):
 
 The `--stream-results` CLI path routes to `export_cli_streaming` instead of
 `export_cli`. Built-ins that implement it: `server_json_file` (NDJSON, one hit
-per line), `server_csv_file` (one CSV row per hit), and `gui` (prints each hit).
-Exporters that inherently need the whole payload at once — `email_smtp` (one
-email), `webhook` (one POST) — leave `supports_streaming` at `False`, and
-requesting `--stream-results` with them is rejected with a clear error. Write to
-a sibling `.tmp` path and `os.replace` on success so a crash mid-stream can't
-leave a half-written file at the destination. See
+per line), `server_csv_file` (one CSV row per hit), and `gui` (prints each hit)
+flush per hit; `webhook` and `email_smtp` are **delivery** exporters that can't
+flush one hit at a time, so they batch — accumulating up to a `batch_size` field
+(default 500) and delivering each full batch as its own POST / email before
+dropping it, which keeps peak memory bounded just the same (see
+`vtscore.exporters.base.resolve_stream_batch_size`). An exporter with no
+incremental mode at all leaves `supports_streaming` at `False`, and requesting
+`--stream-results` with it is rejected with a clear error. File-based streamers
+should write to a sibling `.tmp` path and `os.replace` on success so a crash
+mid-stream can't leave a half-written file at the destination. See
 `docs/plans/cli-stream-massive-images.md` for the full design.
 
 **Default class attributes:**

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -38,10 +38,11 @@ Available built-in exporters: `server_json_file`, `server_csv_file`, `webhook`,
 
 **Streaming support** (CLI `--autodetect --stream-results` for sources larger
 than RAM): `server_json_file` (NDJSON), `server_csv_file`, and `gui` write hits
-incrementally; `webhook` and `email_smtp` do not (they need the whole payload).
-This applies to the CLI streaming path only — the `POST /api/exporters/export`
-route above always receives a fully-materialised results dict. See
-[CLI.md](../CLI.md) and `docs/plans/cli-stream-massive-images.md`.
+incrementally; `webhook` and `email_smtp` deliver in `batch_size`-sized batches
+(one POST / one email per batch) so they too stay bounded. This applies to the
+CLI streaming path only — the `POST /api/exporters/export` route above always
+receives a fully-materialised results dict. See [CLI.md](../CLI.md) and
+`docs/plans/cli-stream-massive-images.md`.
 
 ---
 

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -1168,8 +1168,8 @@ def list_exporters() -> list[LabelsetExporter]: ...
 #   server_json_file, server_csv_file, webhook, email_smtp, gui (display-only,
 #   hidden_from_picker), holder (scaffold, hidden_from_picker until API client lands).
 # Streaming-capable (export_cli_streaming): server_json_file (NDJSON),
-#   server_csv_file, gui. webhook / email_smtp need the whole payload at once,
-#   so they are not streamable.
+#   server_csv_file, gui (per-hit flush); webhook, email_smtp (batched delivery,
+#   one POST / email per batch_size hits).
 ```
 
 ---

--- a/tests/cli/test_cli_streaming.py
+++ b/tests/cli/test_cli_streaming.py
@@ -248,10 +248,11 @@ class TestStreamingExporterGuard:
     def test_non_streaming_exporter_raises(self):
         from vtscore.cli import _run_streaming_pipeline
 
+        # holder is a registered exporter with no incremental (streaming) mode.
         with pytest.raises(ValueError, match="does not support --stream-results"):
             _run_streaming_pipeline(
                 iter([{1: _make_audio_media(1)}]),
-                exporter_name="webhook",
+                exporter_name="holder",
                 exporter_field_values={},
                 override_detectors=None,
                 autofind_detectors=[],

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -479,12 +479,12 @@ class TestEmailLabelsetExporter:
         keys = {f.key for f in exp.fields}
         assert "to" in keys
 
-    def test_fields_are_from_to_and_subject(self):
+    def test_fields_are_from_to_subject_and_batch_size(self):
         from vtscore.exporters import get_exporter
 
         exp = get_exporter("email_smtp")
         keys = {f.key for f in exp.fields}
-        assert keys == {"from", "to", "subject"}
+        assert keys == {"from", "to", "subject", "batch_size"}
 
     def test_subject_field_is_optional_and_templated(self):
         from vtscore.exporters import get_exporter
@@ -958,14 +958,38 @@ class TestStreamingExportSupport:
     def test_streaming_exporters_advertise_support(self):
         from vtscore.exporters import get_exporter
 
-        for name in ("gui", "server_json_file", "server_csv_file"):
+        for name in ("gui", "server_json_file", "server_csv_file", "webhook", "email_smtp"):
             assert get_exporter(name).supports_streaming is True
 
     def test_non_streaming_exporters_do_not(self):
         from vtscore.exporters import get_exporter
 
-        for name in ("email_smtp", "webhook"):
-            assert get_exporter(name).supports_streaming is False
+        # holder is a hidden scaffold exporter with no incremental mode.
+        assert get_exporter("holder").supports_streaming is False
+
+
+class TestResolveStreamBatchSize:
+    """The shared batch-size coercion used by the delivery streamers."""
+
+    def test_none_and_blank_fall_back_to_default(self):
+        from vtscore.exporters.base import resolve_stream_batch_size
+
+        assert resolve_stream_batch_size(None) == 500
+        assert resolve_stream_batch_size("") == 500
+        assert resolve_stream_batch_size(None, default=10) == 10
+
+    def test_int_and_numeric_string(self):
+        from vtscore.exporters.base import resolve_stream_batch_size
+
+        assert resolve_stream_batch_size(3) == 3
+        assert resolve_stream_batch_size("7") == 7
+
+    def test_non_positive_and_garbage_fall_back(self):
+        from vtscore.exporters.base import resolve_stream_batch_size
+
+        assert resolve_stream_batch_size(0) == 500
+        assert resolve_stream_batch_size(-4) == 500
+        assert resolve_stream_batch_size("nope") == 500
 
 
 class TestServerJsonStreaming:
@@ -1080,3 +1104,131 @@ class TestStreamingExportTempCollision:
     def test_csv_concurrent_exports_to_same_path(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._run_collision("server_csv_file", Path(tmp) / "hits.csv")
+
+
+class TestWebhookStreaming:
+    """webhook.export_cli_streaming POSTs hits in fixed-size batches."""
+
+    def _mock_post(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_batches_hits_into_separate_posts(self):
+        from vtscore.exporters import get_exporter
+
+        with patch("vtscore.exporters.webhook.requests.post", return_value=self._mock_post()) as mock_post:
+            res = get_exporter("webhook").export_cli_streaming(
+                _STREAM_HEADER, _stream_records(), {"url": "https://ex.com/hook", "batch_size": 2}
+            )
+
+        # 3 hits, batch_size 2 → 2 POSTs (2 hits, then 1 hit).
+        assert mock_post.call_count == 2
+        first_payload = mock_post.call_args_list[0].kwargs["json"]
+        second_payload = mock_post.call_args_list[1].kwargs["json"]
+        assert first_payload["format"] == "vtsearch-hits-batch/v1"
+        assert first_payload["batch_index"] == 0
+        assert [h["id"] for h in first_payload["hits"]] == [2, 9]
+        assert first_payload["hits"][0]["detector"] == "dog_bark"
+        assert second_payload["batch_index"] == 1
+        assert [h["id"] for h in second_payload["hits"]] == [4]
+        assert "3 hit(s)" in res["message"]
+        assert "2 batch(es)" in res["message"]
+
+    def test_auth_header_forwarded(self):
+        from vtscore.exporters import get_exporter
+
+        with patch("vtscore.exporters.webhook.requests.post", return_value=self._mock_post()) as mock_post:
+            get_exporter("webhook").export_cli_streaming(
+                _STREAM_HEADER,
+                _stream_records(),
+                {"url": "https://ex.com/hook", "auth_header": "Bearer tok", "batch_size": 100},
+            )
+
+        assert mock_post.call_args_list[0].kwargs["headers"]["Authorization"] == "Bearer tok"
+
+    def test_empty_run_still_posts_once(self):
+        from vtscore.exporters import get_exporter
+
+        def _empty():
+            return
+            yield  # pragma: no cover - makes this a generator
+
+        with patch("vtscore.exporters.webhook.requests.post", return_value=self._mock_post()) as mock_post:
+            res = get_exporter("webhook").export_cli_streaming(_STREAM_HEADER, _empty(), {"url": "https://ex.com/hook"})
+
+        assert mock_post.call_count == 1
+        assert mock_post.call_args_list[0].kwargs["json"]["hits"] == []
+        assert "0 hit(s)" in res["message"]
+        assert "1 batch(es)" in res["message"]
+
+    def test_default_batch_size_sends_single_post(self):
+        from vtscore.exporters import get_exporter
+
+        with patch("vtscore.exporters.webhook.requests.post", return_value=self._mock_post()) as mock_post:
+            get_exporter("webhook").export_cli_streaming(
+                _STREAM_HEADER, _stream_records(), {"url": "https://ex.com/hook"}
+            )
+
+        # Default batch_size is 500, so all 3 hits ride in one POST.
+        assert mock_post.call_count == 1
+        assert len(mock_post.call_args_list[0].kwargs["json"]["hits"]) == 3
+
+
+class TestEmailStreaming:
+    """email_smtp.export_cli_streaming sends one email per fixed-size batch."""
+
+    def _patches(self):
+        server = MagicMock()
+        smtp_cm = MagicMock()
+        smtp_cm.__enter__.return_value = server
+        return (
+            server,
+            patch("vtscore.exporters.email_smtp.smtplib.SMTP", return_value=smtp_cm),
+            patch("vtscore.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
+        )
+
+    def test_one_email_per_batch(self):
+        from vtscore.exporters import get_exporter
+
+        server, smtp_p, mx_p = self._patches()
+        with smtp_p as smtp, mx_p:
+            res = get_exporter("email_smtp").export_cli_streaming(
+                _STREAM_HEADER,
+                _stream_records(),
+                {"from": "vt@example.com", "to": "user@example.com", "batch_size": 2},
+            )
+
+        # 3 hits, batch_size 2 → 2 emails.
+        assert smtp.call_count == 2
+        assert server.sendmail.call_count == 2
+        assert "3 hit(s)" in res["message"]
+        assert "2 email(s)" in res["message"]
+        assert res["to"] == "user@example.com"
+
+    def test_empty_run_still_sends_one_email(self):
+        from vtscore.exporters import get_exporter
+
+        def _empty():
+            return
+            yield  # pragma: no cover - makes this a generator
+
+        server, smtp_p, mx_p = self._patches()
+        with smtp_p as smtp, mx_p:
+            res = get_exporter("email_smtp").export_cli_streaming(
+                _STREAM_HEADER, _empty(), {"from": "vt@example.com", "to": "user@example.com"}
+            )
+
+        assert smtp.call_count == 1
+        assert server.sendmail.call_count == 1
+        assert "0 hit(s)" in res["message"]
+        assert "1 email(s)" in res["message"]
+
+    def test_invalid_recipient_rejected(self):
+        from vtscore.exporters import get_exporter
+
+        with pytest.raises(ValueError, match="Recipient email address is invalid"):
+            get_exporter("email_smtp").export_cli_streaming(
+                _STREAM_HEADER, _stream_records(), {"from": "vt@example.com", "to": "not-an-email"}
+            )

--- a/vtscore/exporters/base.py
+++ b/vtscore/exporters/base.py
@@ -56,7 +56,28 @@ from typing import Any, Iterator
 
 from vtscore.plugins import PluginBase, PluginField
 
-__all__ = ["LabelsetExporter", "PluginField"]
+__all__ = ["LabelsetExporter", "PluginField", "resolve_stream_batch_size"]
+
+
+def resolve_stream_batch_size(value: Any, default: int = 500) -> int:
+    """Coerce a streaming ``batch_size`` field value to a positive ``int``.
+
+    The delivery-style streaming exporters (``webhook``, ``email_smtp``) group
+    incoming hits into fixed-size batches so peak memory stays bounded no
+    matter how many hits a run produces.  Their ``batch_size`` field arrives as
+    an ``int`` from the CLI (argparse coerces ``"number"`` fields) but may be a
+    string or absent from other call paths, so this helper normalises every
+    shape: ``None``/blank/non-numeric fall back to *default*, and any
+    non-positive value is clamped to *default* (a batch size of zero would
+    never flush).
+    """
+    if value is None or value == "":
+        return default
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return n if n > 0 else default
 
 
 class LabelsetExporter(PluginBase):
@@ -141,10 +162,12 @@ class LabelsetExporter(PluginBase):
         """Whether this exporter can write results incrementally.
 
         Exporters that override :meth:`export_cli_streaming` return ``True``
-        so the ``--stream-results`` CLI path can route to them.  Exporters
-        that inherently need the whole payload at once (e.g. sending a single
-        email or webhook POST) leave this ``False``; requesting
-        ``--stream-results`` with them is rejected with a clear error.
+        so the ``--stream-results`` CLI path can route to them.  File-based
+        exporters flush each hit as it streams; delivery-based ones
+        (``webhook``, ``email_smtp``) batch hits into fixed-size groups and
+        deliver each batch as it fills.  Exporters that leave this ``False``
+        have no incremental mode, so requesting ``--stream-results`` with them
+        is rejected with a clear error.
 
         See ``docs/plans/cli-stream-massive-images.md``.
         """

--- a/vtscore/exporters/email_smtp/__init__.py
+++ b/vtscore/exporters/email_smtp/__init__.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 
 import re
 import smtplib
+from collections import defaultdict
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Any
+from typing import Any, Iterator
 
-from vtscore.exporters.base import PluginField, LabelsetExporter
+from vtscore.exporters.base import PluginField, LabelsetExporter, resolve_stream_batch_size
 
 # Pragmatic address check: a non-empty local part, a single ``@``, and a
 # dotted domain, none of which may contain whitespace.  Not full RFC 5322
@@ -93,6 +94,64 @@ def _default_subject(results: dict[str, Any]) -> str:
     return f"VTSearch Auto-Detect: {total_hits} hit(s) on {media_type} dataset"
 
 
+def _group_batch_by_detector(batch: list[tuple[str, dict[str, Any]]]) -> dict[str, list[dict[str, Any]]]:
+    """Group a streamed ``(detector_name, hit)`` batch into ``{detector: [hits]}``."""
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for detector_name, hit in batch:
+        grouped[detector_name].append(hit)
+    return grouped
+
+
+def _build_batch_plain(media_type: str, batch: list[tuple[str, dict[str, Any]]], part: int) -> str:
+    """Render a streamed batch of hits as a plain-text summary."""
+    lines: list[str] = [
+        f"Auto-Detect Results (streamed, part {part})",
+        "=========================================",
+        f"Media Type: {media_type}",
+        f"Hits in this part: {len(batch)}",
+        "",
+    ]
+    for detector_name, hits in _group_batch_by_detector(batch).items():
+        lines.append(f"--- {detector_name} ---")
+        for hit in hits:
+            clip_id = hit.get("id")
+            label = f"Clip #{clip_id}" if clip_id is not None else "Clip"
+            lines.append(f"  {label}: {hit.get('filename', 'N/A')} (score: {hit.get('score', 'N/A')})")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _build_batch_html(media_type: str, batch: list[tuple[str, dict[str, Any]]], part: int) -> str:
+    """Render a streamed batch of hits as a minimal HTML e-mail body."""
+    from html import escape
+
+    rows = ""
+    for detector_name, hits in _group_batch_by_detector(batch).items():
+        hits_html = ""
+        for hit in hits:
+            clip_id = hit.get("id")
+            label = f"Clip #{clip_id}" if clip_id is not None else "Clip"
+            hits_html += (
+                f"<tr><td>{escape(label)}</td>"
+                f"<td>{escape(str(hit.get('filename', 'N/A')))}</td>"
+                f"<td>{escape(str(hit.get('score', 'N/A')))}</td></tr>"
+            )
+        rows += (
+            f"<h3>{escape(str(detector_name))}</h3>"
+            f"<table border='1' cellpadding='4' cellspacing='0'>"
+            f"<tr><th>Clip</th><th>Filename</th><th>Score</th></tr>"
+            f"{hits_html}</table>"
+        )
+    return (
+        f"<html><body>"
+        f"<h2>Auto-Detect Results (streamed, part {part})</h2>"
+        f"<p><strong>Media Type:</strong> {escape(str(media_type))}<br>"
+        f"<strong>Hits in this part:</strong> {len(batch)}</p>"
+        f"{rows}"
+        f"</body></html>"
+    )
+
+
 def _resolve_mx(domain: str) -> str:
     """Return the highest-priority MX host for *domain*."""
     import dns.resolver  # lazy import – dnspython is optional
@@ -143,6 +202,19 @@ class EmailLabelsetExporter(LabelsetExporter):
             placeholder="VTSearch Auto-Detect Results {YYYYMMDD}",
             template_vars=("YYYYMMDD-HHMMSS", "YYYYMMDD", "YYYY", "MM", "DD", "detector_name", "username"),
         ),
+        PluginField(
+            key="batch_size",
+            label="Batch size (streaming)",
+            field_type="number",
+            required=False,
+            default="500",
+            min="1",
+            step="1",
+            description=(
+                "When used with --stream-results, one email is sent per this many hits so a run "
+                "larger than RAM never buffers the whole result set. Ignored for one-shot exports."
+            ),
+        ),
     ]
 
     def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
@@ -179,6 +251,85 @@ class EmailLabelsetExporter(LabelsetExporter):
 
         return {
             "message": (f"Email with {total_hits} hit(s) sent to {to_addr} via {mx_host}."),
+            "to": to_addr,
+        }
+
+    @property
+    def supports_streaming(self) -> bool:
+        return True
+
+    def export_cli_streaming(
+        self,
+        header: dict[str, Any],
+        records: Iterator[tuple[str, dict[str, Any]]],
+        field_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Send one email per fixed-size batch of hits as chunks stream in.
+
+        A single email cannot hold a result set larger than RAM, so streaming
+        delivery sends the hits in ``batch_size``-sized parts: hits accumulate
+        until a batch fills, that batch is emailed, and the buffer is dropped
+        before the next hit arrives. Peak memory stays bounded by
+        ``batch_size``. Each message resolves the recipient's MX host afresh
+        and opens its own SMTP connection, so a slow scoring run between
+        batches can't leave a connection idle long enough to be dropped. One
+        email is always sent even for an empty run, so the recipient learns the
+        run finished.
+        """
+        from_addr = field_values["from"]
+        to_addr = field_values["to"]
+
+        if not _is_valid_email(from_addr):
+            raise ValueError("Sender email address is invalid.")
+        if not _is_valid_email(to_addr):
+            raise ValueError("Recipient email address is invalid.")
+
+        batch_size = resolve_stream_batch_size(field_values.get("batch_size"))
+        media_type = header.get("media_type", "unknown")
+        # The framework substitutes any {template} vars into ``subject`` at
+        # ingress; a blank field falls back to an auto-generated per-part line.
+        subject_base = field_values.get("subject") or ""
+
+        total_hits = 0
+        parts = 0
+
+        def _send(batch: list[tuple[str, dict[str, Any]]]) -> None:
+            nonlocal parts
+            part = parts + 1
+            if subject_base:
+                subject = f"{subject_base} (part {part})"
+            else:
+                subject = f"VTSearch Auto-Detect: {len(batch)} hit(s) on {media_type} dataset (part {part})"
+
+            domain = to_addr.rsplit("@", 1)[1]
+            mx_host = _resolve_mx(domain)
+
+            msg = MIMEMultipart("alternative")
+            msg["Subject"] = subject
+            msg["From"] = from_addr
+            msg["To"] = to_addr
+            msg.attach(MIMEText(_build_batch_plain(media_type, batch, part), "plain", "utf-8"))
+            msg.attach(MIMEText(_build_batch_html(media_type, batch, part), "html", "utf-8"))
+
+            with smtplib.SMTP(mx_host, 25, timeout=30) as server:
+                server.ehlo()
+                server.sendmail(from_addr, [to_addr], msg.as_string())
+            parts += 1
+
+        batch: list[tuple[str, dict[str, Any]]] = []
+        for detector_name, hit in records:
+            batch.append((detector_name, hit))
+            total_hits += 1
+            if len(batch) >= batch_size:
+                _send(batch)
+                batch = []
+        # Flush the trailing partial batch; also fire once for an empty run so
+        # the recipient always gets at least one email.
+        if batch or parts == 0:
+            _send(batch)
+
+        return {
+            "message": (f"Streamed {total_hits} hit(s) to {to_addr} in {parts} email(s)."),
             "to": to_addr,
         }
 

--- a/vtscore/exporters/webhook/__init__.py
+++ b/vtscore/exporters/webhook/__init__.py
@@ -5,11 +5,11 @@ Requires only ``requests``, which is already a core dependency.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterator
 
 import requests
 
-from vtscore.exporters.base import PluginField, LabelsetExporter
+from vtscore.exporters.base import PluginField, LabelsetExporter, resolve_stream_batch_size
 
 
 class WebhookLabelsetExporter(LabelsetExporter):
@@ -39,15 +39,31 @@ class WebhookLabelsetExporter(LabelsetExporter):
             description="Optional Bearer token or API key sent as the Authorization header.",
             required=False,
         ),
+        PluginField(
+            key="batch_size",
+            label="Batch size (streaming)",
+            field_type="number",
+            required=False,
+            default="500",
+            min="1",
+            step="1",
+            description=(
+                "When used with --stream-results, hits are POSTed in batches of this many so a "
+                "run larger than RAM never buffers the whole result set. Ignored for one-shot exports."
+            ),
+        ),
     ]
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        url = field_values["url"]
-
+    def _headers(self, field_values: dict[str, Any]) -> dict[str, str]:
         headers: dict[str, str] = {"Content-Type": "application/json"}
         auth_header = field_values.get("auth_header", "")
         if auth_header:
             headers["Authorization"] = auth_header
+        return headers
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        url = field_values["url"]
+        headers = self._headers(field_values)
 
         resp = requests.post(url, json=results, headers=headers, timeout=30, allow_redirects=False)
         resp.raise_for_status()
@@ -61,6 +77,66 @@ class WebhookLabelsetExporter(LabelsetExporter):
         return {
             "message": (f"{detail} to {url} (HTTP {resp.status_code})."),
             "status_code": resp.status_code,
+            "url": url,
+        }
+
+    @property
+    def supports_streaming(self) -> bool:
+        return True
+
+    def export_cli_streaming(
+        self,
+        header: dict[str, Any],
+        records: Iterator[tuple[str, dict[str, Any]]],
+        field_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """POST hits in fixed-size batches as scored chunks stream in.
+
+        Instead of buffering the whole result set into a single request body
+        (which defeats ``--stream-results``), hits are accumulated up to
+        ``batch_size`` and each full batch is POSTed as its own request, then
+        dropped. Peak memory stays bounded by ``batch_size`` regardless of how
+        many hits the run produces. Each batch body is a JSON object carrying
+        the run metadata, a zero-based ``batch_index``, and a ``hits`` array
+        (each hit with its ``detector`` name merged in). A single request is
+        always sent even when zero hits match, so the receiver learns the run
+        happened.
+        """
+        url = field_values["url"]
+        headers = self._headers(field_values)
+        batch_size = resolve_stream_batch_size(field_values.get("batch_size"))
+
+        meta = {
+            "format": "vtsearch-hits-batch/v1",
+            "media_type": header.get("media_type", "unknown"),
+            "detectors": header.get("detectors", []),
+            "keep_negatives": bool(header.get("keep_negatives", False)),
+        }
+
+        total_hits = 0
+        batches = 0
+
+        def _post(hits: list[dict[str, Any]]) -> None:
+            nonlocal batches
+            payload = {**meta, "batch_index": batches, "hits": hits}
+            resp = requests.post(url, json=payload, headers=headers, timeout=30, allow_redirects=False)
+            resp.raise_for_status()
+            batches += 1
+
+        batch: list[dict[str, Any]] = []
+        for detector_name, hit in records:
+            batch.append({"detector": detector_name, **hit})
+            total_hits += 1
+            if len(batch) >= batch_size:
+                _post(batch)
+                batch = []
+        # Flush the trailing partial batch; also fire once for an empty run so
+        # the receiver always gets at least one POST.
+        if batch or batches == 0:
+            _post(batch)
+
+        return {
+            "message": (f"Streamed {total_hits} hit(s) to {url} in {batches} batch(es)."),
             "url": url,
         }
 


### PR DESCRIPTION
## What

Both the `email_smtp` and `webhook` exporters rejected `--stream-results`, so a media source larger than RAM could not be delivered through them — a single email or a single POST can't hold a result set that doesn't fit in memory. This adds **chunked/batched delivery** so both stream while keeping peak memory bounded.

- **`webhook`** now POSTs hits in `batch_size`-sized groups. Each request body is a JSON object carrying the run metadata (`format: "vtsearch-hits-batch/v1"`, `media_type`, `detectors`, `keep_negatives`), a zero-based `batch_index`, and a `hits` array (each hit with its `detector` name merged in).
- **`email_smtp`** now sends one email per `batch_size` hits. Each message resolves the recipient MX afresh and opens its own SMTP connection, so a slow scoring run between batches can't leave a connection idle long enough to drop.
- Both add a `batch_size` number field (default **500**), coerced by a shared `resolve_stream_batch_size` helper in `vtscore/exporters/base.py`.
- Both always deliver **at least once** — even a zero-hit run sends one POST / one email, so the receiver learns the run happened.

Peak memory stays bounded by `batch_size` regardless of how many hits the whole run produces, matching the guarantee the file-based streamers already provide.

## How it fits the streaming interface

`export_cli_streaming(header, records, field_values)` receives the same lazy `(detector_name, hit)` iterator the file streamers get. Instead of flushing per hit, the delivery exporters accumulate into a batch, deliver each full batch, and drop it before pulling the next hit.

## Docs

Updated `docs/CLI.md`, `docs/api/io.md`, `docs/EXTENDING-plugins.md`, and `docs/vtscore-api.md` to reflect that `webhook`/`email_smtp` are now streaming-capable via batched delivery, and how `batch_size` works.

## Tests

- `TestStreamingExportSupport` now asserts all five streamers (incl. webhook/email) advertise support; `holder` stands in as the remaining non-streaming exporter.
- New `TestResolveStreamBatchSize`, `TestWebhookStreaming`, and `TestEmailStreaming` cover batching, the empty-run single-delivery guarantee, auth-header forwarding, default batch size, and recipient validation.
- Updated the CLI streaming guard test and the email field-set test for the new behavior.

Full `./run-tests.sh` passes (6185 passed, 1 skipped).

Closes #2392


---
_Generated by [Claude Code](https://claude.ai/code/session_01JgLvCd4Z3KhA46QgBNUMD3)_