### PR TITLE
Report cumulative embed progress across the multi-embedder loop

### DIFF
--- a/tests_lib/core/test_progress_overall.py
+++ b/tests_lib/core/test_progress_overall.py
@@ -259,3 +259,111 @@ class TestFinalizeProgress:
         t.cancel()
         with pytest.raises(CancelledError):
             fin.check_cancelled()
+
+
+class TestEmbedLoopProgress:
+    """The EmbedLoopProgress proxy spreads a multi-embedder ingest loop across
+    the shared embed step, so the bar advances cumulatively across the loop
+    instead of restarting at 0 for each bound embedder (the v3-trio "static
+    stretch" bug)."""
+
+    def _weights(self):
+        from vtscore.datasets.stages._common import _LOAD_STEP_WEIGHTS
+
+        return _LOAD_STEP_WEIGHTS
+
+    def _embed_tracker(self):
+        from vtscore.datasets.stages._common import _TOTAL_LOAD_STEPS
+
+        t = _tracker()
+        t.set_step_weights(self._weights())
+        # Pretend download finished so the bar sits at the start of the embed
+        # region, where the embed loop takes over.
+        t.update("downloading", "dl", current=1, total=1, step=1, total_steps=_TOTAL_LOAD_STEPS)
+        return t
+
+    def test_single_embedder_forwards_unchanged(self):
+        # n == 1 must behave exactly as the old per-embedder closure: status maps
+        # to its step and current/total pass through verbatim.
+        from vtscore.datasets.stages._common import _STATUS_TO_STEP, _TOTAL_LOAD_STEPS
+        from vtscore.datasets.stages.embedding import EmbedLoopProgress
+
+        calls = []
+
+        class _RecTracker:
+            def check_cancelled(self):
+                pass
+
+            def update(self, status, message="", current=0, total=0, **kw):
+                calls.append((status, current, total, kw.get("step"), kw.get("total_steps")))
+
+        prog = EmbedLoopProgress(_RecTracker(), 1)
+        prog.begin(0)
+        prog("loading", "Loading…", 0, 0)
+        prog("embedding", "Embedding 5…", 2, 5)
+        assert calls == [
+            ("loading", 0, 0, _STATUS_TO_STEP["loading"], _TOTAL_LOAD_STEPS),
+            ("embedding", 2, 5, _STATUS_TO_STEP["embedding"], _TOTAL_LOAD_STEPS),
+        ]
+
+    def test_cumulative_advance_across_embedders(self):
+        # Three embedders, each filling its embed pass 0→total. The overall bar
+        # must advance monotonically across the whole loop and never rewind when
+        # the next embedder restarts its own current at 0.
+        from vtscore.datasets.stages.embedding import EmbedLoopProgress
+
+        t = self._embed_tracker()
+        prog = EmbedLoopProgress(t, 3)
+        overalls = []
+
+        def emb_pass(idx):
+            prog.begin(idx)
+            prog("embedding", "Embedding 4…", 0, 4)
+            overalls.append(t.get()["overall"])
+            prog("embedding", "Embedding 4…", 4, 4)
+            overalls.append(t.get()["overall"])
+
+        emb_pass(0)
+        mid_first = t.get()["overall"]
+        emb_pass(1)
+        emb_pass(2)
+
+        assert overalls == sorted(overalls)  # never rewinds across the loop
+        # Finishing the first embedder must NOT fill the whole embed slice —
+        # the 2nd/3rd embedders still have room to advance (the fix).
+        from vtscore.datasets.stages._common import _TOTAL_LOAD_STEPS
+
+        t.update("embedding", "done", current=1, total=1, step=3, total_steps=_TOTAL_LOAD_STEPS)
+        full_embed = t.get()["overall"]
+        assert mid_first < full_embed
+
+    def test_later_embedder_model_load_does_not_rewind(self):
+        # A 2nd/3rd embedder loads its own model mid-loop. Folding that "loading"
+        # into the embed step (rather than reporting step 2) keeps the step
+        # number from going backwards, which would reset the overall clock and
+        # slam the bar to the step-2 floor.
+        from vtscore.datasets.stages.embedding import EmbedLoopProgress
+
+        t = self._embed_tracker()
+        prog = EmbedLoopProgress(t, 2)
+
+        prog.begin(0)
+        prog("loading", "Loading model…", 0, 0)
+        prog("embedding", "Embedding 4…", 4, 4)
+        after_first = t.get()["overall"]
+
+        prog.begin(1)
+        prog("loading", "Loading model…", 0, 0)  # would be step 2 → rewind, if not folded
+        after_second_load = t.get()["overall"]
+
+        assert after_second_load >= after_first
+
+    def test_check_cancelled_forwards_to_real_tracker(self):
+        from vtscore.concurrency.progress import CancelledError
+        from vtscore.datasets.stages.embedding import EmbedLoopProgress
+
+        t = self._embed_tracker()
+        prog = EmbedLoopProgress(t, 3)
+        t.cancel()
+        with pytest.raises(CancelledError):
+            prog.check_cancelled()

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -378,6 +378,75 @@ def _ordered_load_embedders(medias: dict[int, dict[str, Any]], requested: list[s
     return names or [""]
 
 
+class EmbedLoopProgress:
+    """Tracker proxy that spreads a multi-embedder ingest loop across the embed step.
+
+    :func:`_embed_missing_stage` runs each bound embedder (v3 trio: text / patch
+    / structural picks) in turn, and every :func:`embed_missing` call reports its
+    own ``current``/``total`` starting from 0.  Forwarded straight to the tracker
+    those restart the within-step fraction each embedder, so the first embedder
+    fills the embed slice and the tracker's monotonic clamp then pins the unified
+    bar for the 2nd/3rd embedders — no backslide, but a long static stretch.
+
+    This proxy gives each embedder an equal, ordered sub-range of the embed step
+    (step 3) and rewrites the within-embedder fraction into the active range
+    before forwarding, so the bar fills once, cumulatively, across the whole loop
+    instead of per embedder.  An embedder that does no work (e.g. a reload whose
+    side-channels are already present) simply emits nothing and leaves its slice
+    unfilled; the next embedder jumps the bar forward, which is monotonic.
+
+    The **first** embedder's model-load keeps the dedicated model-load step
+    (step 2) so its weighted slice of the bar still fills; **later** embedders'
+    model loads fold into the embed step at their sub-range floor, because a step
+    number going *backwards* (3 → 2) reads as a brand-new job and would reset the
+    overall clock (see :meth:`ProgressTracker._compute_overall`).
+
+    Single-embedder loads (``n_embedders <= 1``) forward every update unchanged,
+    so their pacing — download / model-load / embed / finalize — is untouched.
+    """
+
+    #: Resolution of the synthetic within-step counter forwarded to the real
+    #: tracker (the embed fraction 0..1 is reported as ``current`` out of this).
+    _SCALE = 1000
+
+    def __init__(self, tracker, n_embedders: int) -> None:
+        self._tracker = tracker
+        self._n = max(int(n_embedders), 1)
+        self._idx = 0
+
+    def begin(self, idx: int) -> None:
+        """Activate embedder *idx*; subsequent calls map into its sub-range."""
+        self._idx = idx
+
+    def check_cancelled(self) -> None:
+        self._tracker.check_cancelled()
+
+    def __call__(self, status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+        self._tracker.check_cancelled()
+        if self._n <= 1:
+            step = _STATUS_TO_STEP.get(status, _STATUS_TO_STEP["embedding"])
+            self._tracker.update(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
+            return
+        # First embedder's model-load keeps the model-load step so its bar slice
+        # fills; everything else folds into the embed step's cumulative range.
+        if status == "loading" and self._idx == 0:
+            self._tracker.update(
+                status, message, current, total, step=_STATUS_TO_STEP["loading"], total_steps=_TOTAL_LOAD_STEPS
+            )
+            return
+        within = current / total if total and total > 0 else 0.0
+        within = min(max(within, 0.0), 1.0)
+        frac = (self._idx + within) / self._n
+        self._tracker.update(
+            status,
+            message,
+            int(frac * self._SCALE),
+            self._SCALE,
+            step=_STATUS_TO_STEP["embedding"],
+            total_steps=_TOTAL_LOAD_STEPS,
+        )
+
+
 def _embed_missing_stage(
     ctx: DatasetContext,
     tracker,
@@ -390,13 +459,14 @@ def _embed_missing_stage(
     ``media["embeddings"]`` carries a per-embedder vector, the patch embedder
     also populates ``patch_regions`` / ``patch_grid``, and the structural
     embedder populates ``local_features``.
+
+    Progress is routed through :class:`EmbedLoopProgress` so a multi-embedder
+    loop reports cumulative progress across the embed step rather than restarting
+    the bar at 0 for each embedder.
     """
-
-    def _emb_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
-        tracker.check_cancelled()
-        step = _STATUS_TO_STEP.get(status, _STATUS_TO_STEP["embedding"])
-        tracker.update(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
-
-    for name in _ordered_load_embedders(ctx.medias, requested_embedders):
-        embed_missing(ctx.medias, name, on_progress=_emb_progress)
+    names = _ordered_load_embedders(ctx.medias, requested_embedders)
+    progress = EmbedLoopProgress(tracker, len(names))
+    for idx, name in enumerate(names):
+        progress.begin(idx)
+        embed_missing(ctx.medias, name, on_progress=progress)
     invalidate_embedding_matrix(ctx)


### PR DESCRIPTION
## Problem

`_embed_missing_stage` loops over each bound embedder, and every `embed_missing` call reports its own `current`/`total` starting from 0. Forwarded straight to the tracker, those restart the within-step fraction for each embedder, so the **first** embedder fills the embed slice and the tracker's monotonic clamp then pins the unified bar for the 2nd/3rd embedders — no backslide, but a long static stretch on a v3 trio (text + patch + structural). Rare for single-embedder demo imports.

## Fix

Route the embed loop's progress through a new `EmbedLoopProgress` proxy (mirroring the existing `FinalizeProgress` pattern):

- Each bound embedder gets an equal, ordered sub-range of the embed step (step 3); the within-embedder fraction is rewritten into the active range before forwarding, so the bar fills once, cumulatively, across the whole loop instead of per embedder.
- An embedder that does no work (e.g. a reload whose side-channels are already present) emits nothing and leaves its slice unfilled; the next embedder jumps the bar forward, which stays monotonic.
- The **first** embedder's model-load keeps the dedicated model-load step (step 2) so its weighted slice still fills. **Later** embedders' model loads fold into the embed step at their sub-range floor, because a step number going backwards (3 → 2) reads as a brand-new job and would reset the overall clock.
- Single-embedder loads (`n <= 1`) forward every update unchanged, so their pacing is untouched.

## Tests

Added `TestEmbedLoopProgress` to `tests_lib/core/test_progress_overall.py` covering the single-embedder passthrough, cumulative monotonic advance across three embedders, the no-rewind-on-later-model-load guard, and cancellation forwarding. Full suite (6179 tests) passes.

Closes #2394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKq3X7inP6bunf7QDbu4EW)_