### PR TITLE
Add portable_detector CLI exporter for headless detector bundle export

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -92,7 +92,28 @@ python app.py --autodetect --dataset data.pkl --settings settings.json --exporte
 python app.py --autodetect --dataset data.pkl --settings settings.json --exporter email_smtp --to recipient@example.com
 ```
 
-Available exporters: `server_json_file` (JSON to server path), `server_csv_file` (CSV to server path), `webhook` (HTTP POST, optional `--auth-header`), `email_smtp` (SMTP email, requires `--to`), `gui` (default: print to console).
+Available exporters: `server_json_file` (JSON to server path), `server_csv_file` (CSV to server path), `webhook` (HTTP POST, optional `--auth-header`), `email_smtp` (SMTP email, requires `--to`), `portable_detector` (standalone ONNX scoring bundles; see below), `gui` (default: print to console).
+
+**Exporting the detectors themselves** (`portable_detector`): instead of the
+scored hits, write one standalone, portable scoring bundle per detector the run
+trained — an ONNX MLP (sigmoid baked in) plus a `manifest.json` and `README.md`,
+carrying **no embeddings and no raw media**. This is the headless counterpart to
+the GUI's portable-export modal, letting CI/automation produce a shareable
+scoring model. The `--dataset`/`--importer` still supplies the embedder space the
+detector trains in; the media is embedded but the hits are discarded.
+
+```bash
+# One bundle per Auto-Find detector, named after the detector.
+python app.py --autodetect --dataset data.pkl --settings settings.json \
+  --exporter portable_detector --filepath 'data/{detector_name}-detector.zip'
+```
+
+The `--filepath` accepts `{detector_name}` (and the date variables
+`{YYYYMMDD-HHMMSS}`, `{YYYYMMDD}`, `{YYYY}`, `{MM}`, `{DD}`, `{username}`). When
+the path omits `{detector_name}` and the run trained more than one detector, the
+detector name is inserted before the extension so bundles don't overwrite each
+other. Detectors whose scoring isn't the plain 2-layer MLP (patch DINOv2/v3,
+structural SIFT/VLAD) are skipped with a note rather than failing the run.
 
 **How to get the files:**
 

--- a/docs/plans/detector-standalone-export.md
+++ b/docs/plans/detector-standalone-export.md
@@ -2,15 +2,17 @@
 
 **Status:** The open follow-ups below remain.
 
-Background: Phase 1 shipped a scoring-only, portable zip bundle export (GUI-only)
-for any saved detector — an ONNX MLP with sigmoid baked in, a `manifest.json`, and
-a `README.md`, deliberately carrying no embeddings or raw media. Settled design
-decisions: scoring-only (not re-trainable), ONNX (not TensorFlow or raw JSON
-weights), and a dedicated modal (not a tab in the label-centric export modal).
+Background: shipped so far is a scoring-only, portable zip bundle export for any
+saved detector — an ONNX MLP with sigmoid baked in, a `manifest.json`, and a
+`README.md`, deliberately carrying no embeddings or raw media. Available both via
+a dedicated GUI modal and headlessly via the `portable_detector` results exporter
+(`--autodetect --exporter portable_detector`, writing one bundle per trained
+detector; see `docs/CLI.md`). Settled design decisions: scoring-only (not
+re-trainable), ONNX (not TensorFlow or raw JSON weights), and a dedicated modal
+(not a tab in the label-centric export modal).
 
 ## Open follow-ups
 
-- [ ] #2391 — Add a CLI/exporter-plugin path for portable detector export
 - **Re-import.** The manifest is shaped to be re-importable, but no importer
   reads it back yet. A "import portable detector" flow could rebuild a
   read-only, score-only detector from a bundle.

--- a/tests/detectors/test_portable_detector_exporter.py
+++ b/tests/detectors/test_portable_detector_exporter.py
@@ -1,0 +1,261 @@
+"""Tests for the ``portable_detector`` results exporter (issue #2391).
+
+The exporter is the CLI / CI counterpart to the GUI's portable-export modal:
+run ``--autodetect --exporter portable_detector`` and, instead of the scored
+hits, it writes one standalone ONNX scoring bundle per trained detector.  These
+tests drive both the end-to-end CLI pipeline path and the exporter's own
+:meth:`export_cli_detectors` (skip rules, multi-detector disambiguation).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import zipfile
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+import app as app_module
+from helpers import make_dataset_file as _make_dataset_file
+from vtsearch.settings import get_detectors_dir
+from vtscore.media.audio.audio_generator import generate_wav
+
+
+@pytest.fixture(autouse=True)
+def _clean_tm_dir():
+    tm_dir = get_detectors_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+    yield
+    tm_dir = get_detectors_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+
+
+def _write_trainable_model(name: str, labelset: dict) -> Path:
+    from vtscore.detectors.store import _detector_path, _write_detector
+
+    path = _detector_path(name)
+    _write_detector(
+        path,
+        {
+            "name": name,
+            "text_query": "",
+            "media_type": "audio",
+            "examples": [],
+            "labelset": labelset,
+        },
+    )
+    return path
+
+
+def _stub_resolve(monkeypatch, file_map: dict[str, Path]) -> None:
+    import vtscore.detectors.resolver as resolver_mod
+
+    @contextmanager
+    def _fake_ctx(origin, origin_name="", filename=""):
+        yield file_map.get(origin_name) or file_map.get(filename)
+
+    monkeypatch.setattr(resolver_mod, "resolve_file_context", _fake_ctx)
+
+
+def _make_audio_files(tmp_path: Path, names: list[str]) -> dict[str, Path]:
+    out: dict[str, Path] = {}
+    for i, name in enumerate(names):
+        path = tmp_path / name
+        path.write_bytes(generate_wav(220 + 110 * i, 0.1))
+        out[name] = path
+    return out
+
+
+def _labelset(good: list[str], bad: list[str]) -> dict:
+    labels = []
+    for i, n in enumerate(good):
+        labels.append(
+            {"md5": f"{i:032x}", "label": "good", "origin": {"importer": "ds_a", "params": {}}, "origin_name": n}
+        )
+    for i, n in enumerate(bad):
+        labels.append(
+            {"md5": f"{i + 100:032x}", "label": "bad", "origin": {"importer": "ds_a", "params": {}}, "origin_name": n}
+        )
+    return {"labels": labels}
+
+
+def _settings_file(tmp_path: Path, names: list[str]) -> Path:
+    settings = {"autofind_detectors": list(names), "detectors_dir": str(get_detectors_dir())}
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps(settings))
+    return path
+
+
+def _assert_valid_bundle(zip_path: Path, *, detector_name: str) -> dict:
+    """Assert *zip_path* is a well-formed portable-detector bundle; return the manifest."""
+    from vtscore.detectors import portable_bundle as pb
+
+    assert zip_path.exists(), f"expected bundle at {zip_path}"
+    with zipfile.ZipFile(zip_path) as zf:
+        assert sorted(zf.namelist()) == ["README.md", "detector.onnx", "manifest.json"]
+        manifest = json.loads(zf.read("manifest.json"))
+        readme = zf.read("README.md").decode()
+        onnx_bytes = zf.read("detector.onnx")
+    assert manifest["format"] == pb.BUNDLE_FORMAT
+    assert manifest["detector_name"] == detector_name
+    assert manifest["contains_media_data"] is False
+    # The bundle carries the classifier only: no embeddings smuggled anywhere.
+    assert "no raw media" in readme.lower()
+    assert onnx_bytes[:4] != b"PK\x03\x04"  # sanity: it's the onnx, not a nested zip
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: CLI autodetect writes a bundle per detector
+# ---------------------------------------------------------------------------
+
+
+class TestPortableDetectorCLI:
+    def test_writes_one_bundle_per_detector(self, client, tmp_path, monkeypatch):
+        files = _make_audio_files(tmp_path, ["alpha.wav", "beta.wav", "gamma.wav"])
+        _stub_resolve(monkeypatch, files)
+        _write_trainable_model("cats", _labelset(good=["alpha.wav", "beta.wav"], bad=["gamma.wav"]))
+
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file(tmp_path, ["cats"])
+        out_template = str(tmp_path / "{detector_name}-detector.zip")
+
+        from vtscore.cli import autodetect_main
+
+        autodetect_main(
+            str(dataset_path),
+            settings_path=str(settings_path),
+            exporter_name="portable_detector",
+            exporter_field_values={"filepath": out_template},
+        )
+
+        manifest = _assert_valid_bundle(tmp_path / "cats-detector.zip", detector_name="cats")
+        assert manifest["media_type"] == "audio"
+        assert manifest["training_labels"] == {"good": 2, "bad": 1}
+        # The embedder the labels trained in is recorded so a recipient can reproduce it.
+        assert manifest["embedder"]["name"]
+        assert manifest["embedder"]["embedding_dim"] > 0
+
+    def test_multi_detector_disambiguates_when_no_placeholder(self, client, tmp_path, monkeypatch):
+        files = _make_audio_files(tmp_path, ["alpha.wav", "beta.wav", "gamma.wav"])
+        _stub_resolve(monkeypatch, files)
+        ls = _labelset(good=["alpha.wav", "beta.wav"], bad=["gamma.wav"])
+        _write_trainable_model("cats", ls)
+        _write_trainable_model("dogs", ls)
+
+        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        settings_path = _settings_file(tmp_path, ["cats", "dogs"])
+        # No {detector_name} in the path: the exporter must insert the slug so
+        # the two bundles don't overwrite each other.
+        out_path = str(tmp_path / "bundle.zip")
+
+        from vtscore.cli import autodetect_main
+
+        autodetect_main(
+            str(dataset_path),
+            settings_path=str(settings_path),
+            exporter_name="portable_detector",
+            exporter_field_values={"filepath": out_path},
+        )
+
+        _assert_valid_bundle(tmp_path / "bundle-cats.zip", detector_name="cats")
+        _assert_valid_bundle(tmp_path / "bundle-dogs.zip", detector_name="dogs")
+        assert not (tmp_path / "bundle.zip").exists()
+
+
+# ---------------------------------------------------------------------------
+# Exporter unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def _real_weights(input_dim: int = 512, hidden: int = 8) -> dict:
+    import torch  # noqa: PLC0415
+    from vtscore.detectors.training import serialize_weights  # noqa: PLC0415
+    from vtscore.training.mlp import build_model  # noqa: PLC0415
+
+    gen = torch.Generator().manual_seed(0)
+    model = build_model(input_dim, hidden_dim=hidden, dropout=0.5, generator=gen)
+    model.eval()
+    return serialize_weights(model)
+
+
+class TestExportCliDetectors:
+    def test_export_results_path_is_unsupported(self):
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("portable_detector")
+        assert exp.needs_trained_detectors is True
+        with pytest.raises(NotImplementedError, match="trained classifier"):
+            exp.export({"results": {}}, {"filepath": "x.zip"})
+
+    def test_writes_bundle_and_reports(self, tmp_path):
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("portable_detector")
+        descriptor = {
+            "detector_name": "cats",
+            "media_type": "image",
+            "weights": _real_weights(768),
+            "threshold": 0.6,
+            "embedder": "siglip",
+            "embedder_type": "semantic",
+            "good_count": 5,
+            "bad_count": 3,
+        }
+        out = tmp_path / "{detector_name}.zip"
+        result = exp.export_cli_detectors([descriptor], {"filepath": str(out)})
+
+        assert "Wrote 1" in result["message"]
+        manifest = _assert_valid_bundle(tmp_path / "cats.zip", detector_name="cats")
+        assert manifest["embedder"]["embedding_dim"] == 768
+        assert manifest["training_labels"] == {"good": 5, "bad": 3}
+
+    def test_skips_non_two_layer_mlp(self, tmp_path):
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("portable_detector")
+        # A single-layer weight dict can't be modelled by the fixed ONNX graph;
+        # the exporter must skip it rather than abort the whole export.
+        bad_descriptor = {
+            "detector_name": "structural",
+            "media_type": "image",
+            "weights": {"0.weight": [[1.0, 2.0]], "0.bias": [0.0]},
+            "threshold": 0.5,
+            "embedder": "sift_vlad",
+            "embedder_type": "structural",
+            "good_count": 2,
+            "bad_count": 2,
+        }
+        out = tmp_path / "{detector_name}.zip"
+        result = exp.export_cli_detectors([bad_descriptor], {"filepath": str(out)})
+
+        assert "No portable detector bundles written" in result["message"]
+        assert "skipped" in result["message"].lower()
+        assert not (tmp_path / "structural.zip").exists()
+
+    def test_sanitizes_detector_name_in_path(self, tmp_path):
+        """A detector name with path separators can't escape the target dir."""
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("portable_detector")
+        descriptor = {
+            "detector_name": "a/../b",
+            "media_type": "image",
+            "weights": _real_weights(512),
+            "threshold": 0.5,
+            "embedder": "",
+            "embedder_type": "",
+            "good_count": 1,
+            "bad_count": 1,
+        }
+        out = tmp_path / "{detector_name}-detector.zip"
+        result = exp.export_cli_detectors([descriptor], {"filepath": str(out)})
+
+        written = Path(result["filepaths"][0])
+        assert written.parent == tmp_path
+        assert "/" not in written.name.replace("-detector.zip", "")
+        assert written.exists()

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -214,7 +214,21 @@ def _load_and_train_detectors(
                 "The original media may not be reachable from the CLI - for example, "
                 "labels collected through the local_folder importer have no resolve_file() path."
             )
-        out[det_name] = {"mlp": det_ctx.model, "threshold": det_ctx.threshold}
+        # Alongside the scoring artifacts (mlp/threshold), carry the metadata a
+        # portable-detector export needs so the exporter never re-reads the
+        # detector file: the concrete embedder space it trained in, its locked
+        # type, and the labelset good/bad tallies.
+        from vtscore.detectors.embedder_type import detector_embedder_type_from_data  # noqa: PLC0415
+
+        out[det_name] = {
+            "mlp": det_ctx.model,
+            "threshold": det_ctx.threshold,
+            "embedder": det_ctx.embedder or "",
+            "media_type": det_media_type or media_type,
+            "embedder_type": detector_embedder_type_from_data(det),
+            "good_count": sum(1 for el in labelset.elements if el.label == "good"),
+            "bad_count": sum(1 for el in labelset.elements if el.label == "bad"),
+        }
     return out
 
 
@@ -300,8 +314,15 @@ def _run_exporter(
     exporter_name: str,
     field_values: dict[str, Any],
     results: dict[str, Any],
+    detector_mlps: dict[str, dict[str, Any]] | None = None,
 ) -> None:
-    """Validate and run a named exporter, printing its confirmation message."""
+    """Validate and run a named exporter, printing its confirmation message.
+
+    Most exporters consume the scored *results*.  An exporter that instead
+    exports the trained classifiers themselves (``needs_trained_detectors``,
+    the portable-detector bundle) is handed the *detector_mlps* the pipeline
+    trained, via :meth:`LabelsetExporter.export_cli_detectors`.
+    """
     from vtscore.exporters import get_exporter
 
     exporter = get_exporter(exporter_name)
@@ -310,9 +331,40 @@ def _run_exporter(
         raise ValueError(f"Unknown exporter: {exporter_name}. Available: {', '.join(available)}")
 
     exporter.validate_cli_field_values(field_values)
-    result = exporter.export_cli(results, field_values)
+    if getattr(exporter, "needs_trained_detectors", False):
+        descriptors = _portable_detector_descriptors(detector_mlps or {})
+        result = exporter.export_cli_detectors(descriptors, field_values)
+    else:
+        result = exporter.export_cli(results, field_values)
     message = result.get("message", "Export complete.")
     cli_progress.emit("export_complete", text=message, message=message)
+
+
+def _portable_detector_descriptors(detector_mlps: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    """Serialise each trained detector into a portable-export descriptor.
+
+    Turns the pipeline's ``{name: {"mlp", "threshold", ...}}`` map into the
+    list of plain-data dicts :meth:`LabelsetExporter.export_cli_detectors`
+    consumes - the live torch model is reduced to nested-list weights here so
+    the exporter itself stays torch-free.
+    """
+    from vtscore.detectors.training import serialize_weights
+
+    descriptors: list[dict[str, Any]] = []
+    for name, info in detector_mlps.items():
+        descriptors.append(
+            {
+                "detector_name": name,
+                "media_type": info.get("media_type", "") or "",
+                "weights": serialize_weights(info["mlp"]),
+                "threshold": info["threshold"],
+                "embedder": info.get("embedder", "") or "",
+                "embedder_type": info.get("embedder_type", "") or "",
+                "good_count": int(info.get("good_count", 0)),
+                "bad_count": int(info.get("bad_count", 0)),
+            }
+        )
+    return descriptors
 
 
 def import_labels_into_detector_from_file(
@@ -638,7 +690,7 @@ def _run_live_pipeline(
         )
 
     results = _build_multi_results_dict(merged_results, media_type or "unknown")
-    _run_exporter(exporter_name or "gui", exporter_field_values or {}, results)
+    _run_exporter(exporter_name or "gui", exporter_field_values or {}, results, detector_mlps)
 
 
 def _list_streaming_exporter_names() -> list[str]:

--- a/vtscore/exporters/base.py
+++ b/vtscore/exporters/base.py
@@ -133,6 +133,56 @@ class LabelsetExporter(PluginBase):
         return self.export(results, field_values)
 
     # ------------------------------------------------------------------
+    # Trained-detector CLI support (portable-detector export)
+    # ------------------------------------------------------------------
+
+    @property
+    def needs_trained_detectors(self) -> bool:
+        """Whether this exporter consumes the trained classifiers, not the hits.
+
+        Almost every exporter serialises the scored *results* (the hit lists).
+        The portable-detector exporter is the exception: it serialises the
+        trained MLP itself (an ONNX scoring bundle), so it needs the in-memory
+        detectors the CLI pipeline just trained rather than their output.  When
+        this returns ``True`` the pipeline routes to :meth:`export_cli_detectors`
+        instead of :meth:`export_cli`; results-consuming exporters leave it
+        ``False``.
+        """
+        return False
+
+    def export_cli_detectors(
+        self,
+        detectors: list[dict[str, Any]],
+        field_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Export the trained detectors themselves (not the scored hits).
+
+        Called by the CLI/pipeline path for exporters whose
+        :attr:`needs_trained_detectors` is ``True``.  *detectors* is the list
+        of trained detectors the pipeline produced against the loaded dataset;
+        each entry is a descriptor dict with these keys::
+
+            {
+              "detector_name": str,        # the detector's name
+              "media_type":    str,        # audio / image / video / ...
+              "weights":       dict,       # serialize_weights() nested lists
+              "threshold":     float,      # decision threshold
+              "embedder":      str,        # concrete embedder name it trained in
+              "embedder_type": str,        # the detector's locked embedder type
+              "good_count":    int,        # labelset good count
+              "bad_count":     int,        # labelset bad count
+            }
+
+        Returns a status dict with at minimum a ``"message"`` key, like
+        :meth:`export`.
+
+        Raises:
+            NotImplementedError: If the exporter does not export trained
+                detectors (the default).
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not export trained detectors")
+
+    # ------------------------------------------------------------------
     # Streaming CLI support (massive sources)
     # ------------------------------------------------------------------
 

--- a/vtscore/exporters/portable_detector/__init__.py
+++ b/vtscore/exporters/portable_detector/__init__.py
@@ -1,0 +1,217 @@
+"""Portable-detector exporter – write standalone ONNX scoring bundles headlessly.
+
+The GUI has a dedicated modal that exports a saved detector as a portable,
+scoring-only zip (an ONNX MLP + ``manifest.json`` + ``README.md``; see
+:mod:`vtscore.detectors.portable_bundle`).  This exporter is the CLI / CI
+counterpart: run ``--autodetect`` (or a ``--pipeline`` YAML) with
+``--exporter portable_detector`` and, instead of exporting the scored hits, it
+writes one bundle per detector the run trained.
+
+It is the sanctioned exception to the "No Persisted Vectors or MLPs" rule
+(``CLAUDE.md``): the bundle persists the trained MLP - never embeddings or raw
+media - so a third party can score their own media without VTSearch.
+
+Unlike every other exporter, this one consumes the *trained classifiers*, not
+the scored results, so it sets :attr:`needs_trained_detectors` and the pipeline
+hands it the detectors via :meth:`export_cli_detectors`.  Detectors whose
+scoring isn't the fixed 2-layer MLP (patch DINOv2/v3, structural SIFT/VLAD) are
+skipped with a note rather than aborting the whole export - the ONNX graph only
+models the plain linear stack (see ``docs/plans/detector-standalone-export.md``).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from vtscore.exporters.base import LabelsetExporter, PluginField
+from vtscore.io import atomic_write_bytes
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BUNDLE_PATH = "data/{detector_name}-detector.zip"
+
+
+class PortableDetectorLabelsetExporter(LabelsetExporter):
+    """Write each trained detector as a standalone, portable scoring bundle.
+
+    CLI-only: it needs the trained MLP, which only the ``--autodetect`` /
+    ``--pipeline`` path produces, so it is hidden from the GUI picker (the GUI
+    has its own portable-export modal).  One zip is written per detector; use
+    ``{detector_name}`` in the path to disambiguate a multi-detector run.
+    """
+
+    name = "portable_detector"
+    display_name = "Portable Detector Bundle"
+    description = "Write each trained detector as a standalone ONNX scoring bundle (zip)."
+    icon = "\U0001f4e6"  # package
+    # Needs the trained MLP, only available on the CLI/pipeline path; the GUI
+    # has its own dedicated portable-export modal, so keep it out of the picker.
+    hidden_from_picker = True
+    fields = [
+        PluginField(
+            key="filepath",
+            label="Save bundle to (server path)",
+            field_type="server_path",
+            description="Where on the server to write the portable-detector zip.",
+            hint=(
+                "One zip is written per detector. Use {detector_name} to give each detector its own "
+                "file; without it, a multi-detector run inserts the detector name before the "
+                "extension so bundles don't overwrite each other.\n"
+                "Date template variables are also supported: {YYYYMMDD-HHMMSS}, {YYYYMMDD}, {YYYY}, "
+                "{MM}, {DD}, {username}."
+            ),
+            placeholder=_DEFAULT_BUNDLE_PATH,
+            default=_DEFAULT_BUNDLE_PATH,
+            # NOTE: ``detector_name`` is intentionally *not* declared here - the
+            # framework would resolve it once against the active detector
+            # context, but this exporter substitutes it per-detector itself
+            # (below) so a multi-detector run gets one file each.
+            template_vars=("YYYYMMDD-HHMMSS", "YYYYMMDD", "YYYY", "MM", "DD", "username"),
+        ),
+    ]
+
+    @property
+    def needs_trained_detectors(self) -> bool:
+        return True
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Not supported: this exporter needs the trained classifier, not hits.
+
+        The results-only path (the GUI Auto-Find auto-export) can't build a
+        bundle because it never sees the trained MLP.  Use the CLI/pipeline
+        path (``--exporter portable_detector`` with ``--autodetect``) instead;
+        for interactive one-off exports, the GUI's portable-export modal.
+        """
+        raise NotImplementedError(
+            "The portable_detector exporter needs the trained classifier, which is only produced by "
+            "the CLI autodetect/pipeline path. Run `--autodetect --exporter portable_detector`, or use "
+            "the GUI's portable-export modal for a single saved detector."
+        )
+
+    def export_cli_detectors(
+        self,
+        detectors: list[dict[str, Any]],
+        field_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build and write one portable bundle per trained detector."""
+        from vtscore.detectors import portable_bundle as pb  # noqa: PLC0415
+
+        template = field_values["filepath"]
+        multi = len(detectors) > 1
+
+        written: list[str] = []
+        skipped: list[str] = []
+        for descriptor in detectors:
+            name = descriptor.get("detector_name", "") or "detector"
+            weights = descriptor.get("weights") or {}
+            try:
+                manifest = self._build_manifest(pb, descriptor)
+                bundle = pb.build_bundle(weights=weights, manifest=manifest)
+            except ValueError as exc:
+                # Non-2-layer MLP (patch / structural detector): the ONNX graph
+                # can't represent it. Skip this detector, keep exporting the rest.
+                logger.warning("portable_detector: skipping %r (%s)", name, exc)
+                skipped.append(name)
+                continue
+
+            out_path = self._resolve_path(template, name, disambiguate=multi)
+            atomic_write_bytes(out_path, bundle)
+            written.append(str(out_path.resolve()))
+
+        return self._status(written, skipped)
+
+    # -- helpers ------------------------------------------------------------
+
+    @staticmethod
+    def _build_manifest(pb: Any, descriptor: dict[str, Any]) -> dict[str, Any]:
+        """Assemble the bundle manifest for one trained detector."""
+        embedder_name = descriptor.get("embedder", "") or ""
+        embedder_display = embedder_name
+        embedder_model_id: str | None = None
+        if embedder_name:
+            try:
+                from vtscore.media import get_embedder  # noqa: PLC0415
+
+                emb_obj = get_embedder(embedder_name)
+                embedder_display = emb_obj.display_name
+                embedder_model_id = emb_obj.model_id
+            except Exception:  # noqa: BLE001 - cosmetic only; fall back to the raw name.
+                embedder_display = embedder_name
+
+        return pb.build_manifest(
+            detector_name=descriptor.get("detector_name", ""),
+            media_type=descriptor.get("media_type", "") or "",
+            embedder=embedder_name,
+            embedder_display_name=embedder_display,
+            embedder_model_id=embedder_model_id,
+            embedder_type=descriptor.get("embedder_type", "") or "",
+            embedding_dim=pb.embedding_dim_from_weights(descriptor.get("weights") or {}),
+            threshold=float(descriptor.get("threshold", 0.5)),
+            good_count=int(descriptor.get("good_count", 0)),
+            bad_count=int(descriptor.get("bad_count", 0)),
+            exported_by=_exported_by(),
+            exported_at=_utc_now_iso(),
+        )
+
+    @staticmethod
+    def _resolve_path(template: str, detector_name: str, *, disambiguate: bool) -> Path:
+        """Turn the path template into a concrete per-detector zip path.
+
+        Substitutes ``{detector_name}`` with a filesystem-safe slug of the
+        detector's name.  When the template carries no ``{detector_name}`` and
+        the run trained more than one detector, the slug is inserted before the
+        file extension so the bundles don't overwrite one another.
+        """
+        from vtscore.security.path_validation import (  # noqa: PLC0415
+            get_file_access_base_dir,
+            sanitize_template_value,
+            validate_server_filepath,
+        )
+
+        slug = sanitize_template_value(detector_name)
+        if "{detector_name}" in template:
+            resolved = template.replace("{detector_name}", slug)
+        elif disambiguate:
+            p = Path(template)
+            resolved = str(p.with_name(f"{p.stem}-{slug}{p.suffix}"))
+        else:
+            resolved = template
+
+        # Re-validate the concrete path (defence in depth): the substituted slug
+        # carries no path separators, so this can't escape the base dir, but the
+        # check keeps this ingress identical to every other server_path write.
+        return validate_server_filepath(resolved, base_dir=get_file_access_base_dir())
+
+    @staticmethod
+    def _status(written: list[str], skipped: list[str]) -> dict[str, Any]:
+        """Build the confirmation status dict from the write/skip tallies."""
+        if not written:
+            detail = f" ({len(skipped)} skipped: not a 2-layer MLP)" if skipped else ""
+            return {"message": f"No portable detector bundles written{detail}.", "filepaths": []}
+
+        parts = [f"Wrote {len(written)} portable detector bundle(s)."]
+        if skipped:
+            parts.append(f"Skipped {len(skipped)} non-exportable detector(s): {', '.join(skipped)}.")
+        return {"message": " ".join(parts), "filepaths": written}
+
+
+def _exported_by() -> str:
+    """Provenance string for the bundle: ``vtsearch <version>`` when available."""
+    try:
+        import vtsearch  # noqa: PLC0415
+
+        return f"vtsearch {vtsearch.__version__}"
+    except Exception:  # noqa: BLE001 - version is cosmetic; never block an export on it.
+        return "vtsearch"
+
+
+def _utc_now_iso() -> str:
+    """Current UTC time as an ISO-8601 ``Z``-terminated string."""
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+EXPORTER = PortableDetectorLabelsetExporter()

--- a/vtscore/io.py
+++ b/vtscore/io.py
@@ -37,6 +37,7 @@ except ImportError:  # pragma: no cover - Windows
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "atomic_write_bytes",
     "atomic_write_json",
     "atomic_write_text",
     "file_lock",
@@ -104,6 +105,32 @@ def atomic_write_text(path: Path | str, text: str) -> None:
     except Exception:
         # Best-effort tmp cleanup so a failed write doesn't leak a
         # half-written tmp file next to the destination.
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def atomic_write_bytes(path: Path | str, data: bytes) -> None:
+    """Write *data* to *path* atomically (binary twin of :func:`atomic_write_text`).
+
+    Writes to a per-writer-unique sibling ``.tmp`` file, ``fsync``\\ s it, then
+    renames into place via :func:`os.replace`, so a concurrent reader always
+    sees either the pre- or post-write content, never a partial write.  Parent
+    directories are created if needed.  Used for binary artifacts such as the
+    portable-detector zip bundle.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_name(f"{p.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        with open(tmp, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, p)
+    except Exception:
         try:
             os.unlink(tmp)
         except FileNotFoundError:


### PR DESCRIPTION
Closes #2391.

Portable detector export was GUI-only. This adds the headless counterpart: a `portable_detector` results exporter so CI/automation can produce the standalone scoring bundle (ONNX MLP + `manifest.json` + `README.md`) without a browser.

## What it does

Run autodetect (or a `--pipeline` YAML) with `--exporter portable_detector` and, instead of the scored hits, it writes **one standalone scoring bundle per detector the run trained**:

```bash
python app.py --autodetect --dataset data.pkl --settings settings.json \
  --exporter portable_detector --filepath 'data/{detector_name}-detector.zip'
```

The `--dataset`/`--importer` supplies the embedder space the detector trains in (exactly as Find does); the media is embedded but the hits are discarded. Bundles carry **no embeddings and no raw media** — the sanctioned exception is the trained classifier only, same as the GUI modal.

## How it works

Results exporters only ever see the scored hits, never the trained MLP. Rather than abuse that interface, this adds an opt-in capability mirroring the existing streaming pattern (`supports_streaming`/`export_cli_streaming`):

- **`vtscore/exporters/base.py`** — new `needs_trained_detectors` property (default `False`) + `export_cli_detectors(detectors, field_values)` hook. When an exporter sets the flag, the pipeline hands it the trained detectors instead of calling `export_cli`.
- **`vtscore/exporters/portable_detector/`** — the exporter. Hidden from the GUI picker (the GUI has its own portable-export modal; the results-only `export()` path raises a clear error since it can't see the MLP). Substitutes `{detector_name}` per detector; when the path omits it and >1 detector ran, inserts the sanitized slug before the extension so bundles don't collide. Detectors whose scoring isn't the plain 2-layer MLP (patch DINOv2/v3, structural SIFT/VLAD) are skipped with a note rather than failing the run.
- **`vtscore/cli.py`** — threads the trained MLPs from the pipeline to the exporter, serializing each to a torch-free descriptor (nested-list weights + embedder metadata + label counts).
- **`vtscore/io.py`** — `atomic_write_bytes` helper for the zip write.

Works through both `--exporter` and the `--pipeline` YAML for free (shared exporter registry).

## Docs / plan

- `docs/CLI.md` — documents the exporter, the `{detector_name}` templating, and the multi-detector disambiguation.
- `docs/plans/detector-standalone-export.md` — removed the now-shipped follow-up pointer; refreshed the background note (no longer GUI-only).

## Tests

`tests/detectors/test_portable_detector_exporter.py` — end-to-end CLI runs (one-bundle-per-detector, multi-detector disambiguation) plus exporter unit behaviour (results-path unsupported, skip non-2-layer MLP, detector-name path sanitization). Full `./run-tests.sh` passes (6181 passed) including the `vtscore-clean` library-import gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiGJhJDtdZpiQdNEPnFPvE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiGJhJDtdZpiQdNEPnFPvE)_