### PR TITLE
docs(plans): prune #2401 — Browse zoom-out gutter already fills with background

### DIFF
--- a/docs/plans/vtsbrowse.md
+++ b/docs/plans/vtsbrowse.md
@@ -96,7 +96,6 @@ Pieces of the live feature left open, to pick up alongside the follow-ups above:
   on `Projection`.
 - [ ] #2403 — Browse bin-popup: large-preview path for document media
 - [ ] #2402 — Browse: re-centre a bin's representative after a lopsided partial removal
-- [ ] #2401 — Browse canvas: fill black border falloff on zoom-out past overscan/uncached tiles
 
 ## Design spec (living)
 


### PR DESCRIPTION
## What

Removes the `#2401` pointer from `docs/plans/vtsbrowse.md` and closes the issue as not planned.

## Why

Issue #2401 asks to fill the Browse-canvas zoom-out/pan-glide margin with the background color instead of a "black falloff." Tracing the renderer shows this is **already implemented** — every path that can expose that margin fills it with the theme `--bg-body`:

- steady-state `draw()` — `browse-canvas.component.ts:1237-1239`
- zoom-out animation — `:1088-1090` (`animBg`, captured at `:967`)
- directional-pan glide — `:2512-2514` (`panAnimBg`)

The "black" wording was dark-mode shorthand: `--bg-body` is `#0f1117` (dark), `#000000` (highviz), `#dbdfea` (light). The gutter is therefore seamless with the empty canvas around the data in every theme — never a literal black rectangle against a differently-colored canvas.

The only residual (the ticket's alternate "extend the fetch/overscan" idea) is a transient bin-less — but correctly background-colored — margin during a deep zoom-out past the intentional 2× `SNAP_OVERSCAN_MAX` memory cap, which isn't the reported defect.

Refs #2401 (closed as not planned; the requested fix already shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjPe2pPraS9WKfDGfwE9tt)_