### PR TITLE
Selection panel: hover-to-play audio auditioning

### DIFF
--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -78,7 +78,9 @@
         [attr.aria-label]="'Selected: ' + entry.name + ' (click to remove)'"
         [title]="entry.name + ' — click to remove from selection'"
         (click)="onEntryClick(entry.id)"
-        (keydown)="onEntryKeydown($event, entry.id)">
+        (keydown)="onEntryKeydown($event, entry.id)"
+        (mouseenter)="onEntryEnter(entry.id)"
+        (mouseleave)="onEntryLeave()">
         @if (hasThumbnailUrl(entry.id)) {
           <span class="bsp-thumb-wrap">
             @if (isAudioThumbnail(entry.id)) {

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -11,10 +11,17 @@ import { NoFocusStealDirective } from '../../directives/no-focus-steal.directive
 import { IconComponent } from '../icon/icon.component';
 import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
+import { applyClipWindow, clearClipWindow } from '../../utils/clip-window';
+import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
 
 /** Ordering for the selected-item list. No detector confidence in browse, so
  *  the choices are recency (selection order), name, and id. */
 type SelectionSortMode = 'time-desc' | 'time-asc' | 'name-asc' | 'name-desc' | 'id-asc';
+
+/** How long (ms) the cursor must rest on an audio entry before its clip starts
+ *  auditioning, so sweeping down a large multi-select list doesn't fire a burst
+ *  of plays. Matches the canvas hover-preview's dwell (`AUDIO_DWELL_MS`). */
+const AUDIO_DWELL_MS = 200;
 
 interface SelectionEntry {
   id: number;
@@ -77,6 +84,15 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
    */
   readonly selectAllInView = output<void>();
 
+  /** Preview-audio volume (0–1), driven by the Browse toolbar's volume control,
+   *  so hover audition here stays in lockstep with the canvas + bin-popup. */
+  readonly volume = input(1);
+
+  /** The clip now auditioning from a hovered audio entry (for the top-left
+   *  now-playing indicator), or ``null`` once the hover clears — the same shared
+   *  output the canvas and bin-popup drive. */
+  readonly nowPlaying = output<NowPlaying | null>();
+
   // These are template-bound and written from the selection-refresh and
   // settings `effect()`s and the metadata-cache `version$` subscribe — none of
   // which schedule CD for a plain field under zoneless — so they are signals.
@@ -91,7 +107,31 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   private readonly thumbnailFailedUrls = new Set<string>();
   private readonly subs: Subscription[] = [];
 
+  // --- Audio audition state machine (mirrors browse-hover-preview) -----------
+  /** Never mounted in the DOM — audio here is heard, not shown; the top-left
+   *  now-playing indicator is the only visual feedback that it's playing. */
+  private readonly audioEl = new Audio();
+  /** Waveform PNG of the clip currently auditioning, kept so the buffering
+   *  listeners can re-emit the now-playing state without recomputing it. */
+  private nowPlayingWaveUrl = '';
+  private dwellTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingMediaId: number | null = null;
+  private playingMediaId: number | null = null;
+
   constructor() {
+    // Keep the live element's volume in sync when the toolbar slider moves
+    // mid-playback; starting a clip also seeds it.
+    effect(() => {
+      this.audioEl.volume = this.volume();
+    });
+    // Buffering feedback: while the clip is fetching/decoding (or stalls to
+    // rebuffer), the widget shows a spinner; once it's actually sounding, the
+    // spinner clears. Listeners are attached once to the reused element and
+    // guarded by ``playingMediaId`` so stray events after a stop are ignored.
+    this.audioEl.addEventListener('waiting', () => this.emitNowPlaying(true));
+    this.audioEl.addEventListener('playing', () => this.emitNowPlaying(false));
+    this.audioEl.addEventListener('canplay', () => this.emitNowPlaying(false));
+
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;
@@ -122,6 +162,8 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     for (const sub of this.subs) sub.unsubscribe();
+    this.cancelDwell();
+    this.stopAudio();
   }
 
   private refreshSelection(): void {
@@ -217,13 +259,95 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
 
   /** Clicking a selected item drops it from the selection. */
   onEntryClick(id: number): void {
+    // The entry is about to leave the list (its element unmounts, so no
+    // mouseleave will fire): silence it now if it's the one auditioning.
+    if (this.playingMediaId === id || this.pendingMediaId === id) this.stopAudio();
     this.selection.remove(id);
   }
 
   onEntryKeydown(event: KeyboardEvent, id: number): void {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      this.selection.remove(id);
+      this.onEntryClick(id);
+    }
+  }
+
+  // --- Audio audition on hover (audio only) ----------------------------------
+
+  /**
+   * Cursor entered an entry: for audio datasets, arm the dwell debounce so the
+   * clip starts auditioning once the cursor settles, matching the canvas
+   * hover-preview. A no-op for every other media type — Browse only plays sound
+   * for audio.
+   */
+  onEntryEnter(id: number): void {
+    if (this.mediaType() !== 'audio') return;
+    this.scheduleAudio(id);
+  }
+
+  /** Cursor left an entry: cancel a pending audition and stop anything playing.
+   *  There is no pane to bridge the cursor onto, so hover-off silences at once
+   *  (the same as the canvas path). */
+  onEntryLeave(): void {
+    this.cancelDwell();
+    this.stopAudio();
+  }
+
+  private scheduleAudio(mediaId: number): void {
+    // Already auditioning this exact clip: keep it (don't restart).
+    if (this.playingMediaId === mediaId) return;
+
+    // Debounce: (re)arm the dwell so a sweep down the list keeps resetting it and
+    // only the entry the cursor settles on actually plays.
+    this.pendingMediaId = mediaId;
+    this.cancelDwell();
+    this.dwellTimer = setTimeout(() => {
+      this.dwellTimer = null;
+      const id = this.pendingMediaId;
+      this.pendingMediaId = null;
+      if (id != null) this.playAudio(id);
+    }, AUDIO_DWELL_MS);
+  }
+
+  private playAudio(mediaId: number): void {
+    this.playingMediaId = mediaId;
+    const waveUrl = this.activeContext.mediaUrl(`/api/medias/${mediaId}/thumbnail`);
+    this.nowPlayingWaveUrl = waveUrl;
+    // Hydrate clip extents (clip_start/clip_end) so windowed clips loop within
+    // their window; applyClipWindow reads them lazily as they land.
+    this.metadataCache.ensureLoaded([mediaId]);
+    this.audioEl.volume = this.volume();
+    applyClipWindow(this.audioEl, () => this.metadataCache.get(mediaId));
+    this.audioEl.src = this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`);
+    this.audioEl.load();
+    this.audioEl.play().catch(() => {});
+    // Starts loading: show the spinner until a ``playing``/``canplay`` event
+    // (wired in the constructor) clears it.
+    this.nowPlaying.emit({ mediaId, waveUrl, loading: true });
+  }
+
+  /** Re-emit the now-playing state with a fresh ``loading`` flag, from the
+   *  buffering listeners. A no-op once nothing is auditioning, so events that
+   *  fire after a stop don't resurrect the widget. */
+  private emitNowPlaying(loading: boolean): void {
+    if (this.playingMediaId == null) return;
+    this.nowPlaying.emit({ mediaId: this.playingMediaId, waveUrl: this.nowPlayingWaveUrl, loading });
+  }
+
+  private stopAudio(): void {
+    this.pendingMediaId = null;
+    if (this.playingMediaId == null) return;
+    this.playingMediaId = null;
+    clearClipWindow(this.audioEl);
+    this.audioEl.pause();
+    this.audioEl.currentTime = 0;
+    this.nowPlaying.emit(null);
+  }
+
+  private cancelDwell(): void {
+    if (this.dwellTimer) {
+      clearTimeout(this.dwellTimer);
+      this.dwellTimer = null;
     }
   }
 

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
@@ -7,6 +7,7 @@ import { BrowseSelectionService } from '../../services/browse-selection.service'
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
+import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
 import { configureZoneless } from '../../testing/zoneless-testbed';
 import { makeActiveContextStub } from '../../testing/mocks';
 import { settleZoneless } from '../../testing/settle-resource';
@@ -27,6 +28,11 @@ describe('BrowseSelectionPanelComponent (zoneless canary)', () => {
   let selection: BrowseSelectionService;
   let metaVersion: BehaviorSubject<number>;
   let names: Map<number, string>;
+  let playSpy: ReturnType<typeof vi.spyOn>;
+
+  // Mirrors the component's dwell constant; the waits below clear it with margin.
+  const DWELL_MS = 200;
+  const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
   beforeEach(async () => {
     metaVersion = new BehaviorSubject<number>(0);
@@ -38,6 +44,11 @@ describe('BrowseSelectionPanelComponent (zoneless canary)', () => {
       get: ((id: number) =>
         names.has(id) ? { filename: names.get(id) } : undefined) as MediaMetadataCacheService['get'],
     };
+    // jsdom has no real media pipeline; keep play()/load() quiet so the audio
+    // hover path's audition kick-off doesn't spam "Not implemented".
+    playSpy = vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+
     const activeContextStub = makeActiveContextStub();
     const settingsStub: Partial<SettingsStateService> = {
       settingsSignal: signal(null) as SettingsStateService['settingsSignal'],
@@ -59,7 +70,10 @@ describe('BrowseSelectionPanelComponent (zoneless canary)', () => {
     fixture.componentRef.setInput('mediaType', 'audio');
   });
 
-  afterEach(() => fixture.destroy());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fixture.destroy();
+  });
 
   it('repaints the count + list when the selection signal bumps, no manual detectChanges', async () => {
     await settleZoneless(fixture);
@@ -114,5 +128,91 @@ describe('BrowseSelectionPanelComponent (zoneless canary)', () => {
     const copyBtn = entry.querySelector('.bsp-copy .copy-detail-btn') as HTMLButtonElement;
     expect(copyBtn).not.toBeNull();
     expect(copyBtn.getAttribute('title')).toBe('Copy name to clipboard');
+  });
+
+  // --- Hover-to-play audio (issue #2455) -------------------------------------
+  //
+  // Selection entries audition their clip on hover the same way the canvas
+  // hover-preview and bin-popup do: a dwell debounce arms on mouseenter, plays
+  // through a private (never-mounted) audio element, and emits to the shared
+  // top-left `nowPlaying` indicator; mouseleave stops it at once.
+
+  function firstEntry(): HTMLElement {
+    return fixture.nativeElement.querySelector('.bsp-entry') as HTMLElement;
+  }
+
+  it('auditions an audio entry only after the dwell elapses, emitting nowPlaying', async () => {
+    let emitted: NowPlaying | null | undefined;
+    fixture.componentInstance.nowPlaying.subscribe((e) => (emitted = e));
+    selection.addAll([7]);
+    await settleZoneless(fixture);
+
+    firstEntry().dispatchEvent(new MouseEvent('mouseenter'));
+    await settleZoneless(fixture);
+
+    // Before the dwell: nothing auditioning yet.
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(emitted).toBeUndefined();
+
+    await wait(DWELL_MS + 60);
+    await settleZoneless(fixture);
+
+    // After the dwell: playback starts and `nowPlaying` carries the clip's
+    // waveform for the top-left indicator — flagged `loading` until it sounds.
+    expect(playSpy).toHaveBeenCalled();
+    expect(emitted).toEqual({ mediaId: 7, waveUrl: '/api/medias/7/thumbnail', loading: true });
+  });
+
+  it('stops the audition and emits nowPlaying(null) as soon as the cursor leaves', async () => {
+    let emitted: NowPlaying | null | undefined;
+    fixture.componentInstance.nowPlaying.subscribe((e) => (emitted = e));
+    selection.addAll([5]);
+    await settleZoneless(fixture);
+
+    firstEntry().dispatchEvent(new MouseEvent('mouseenter'));
+    await wait(DWELL_MS + 60);
+    await settleZoneless(fixture);
+    expect(emitted?.mediaId).toBe(5);
+
+    // No hover-bridge grace period: the clip stops the instant the entry is left.
+    firstEntry().dispatchEvent(new MouseEvent('mouseleave'));
+    await settleZoneless(fixture);
+    expect(emitted).toBeNull();
+  });
+
+  it('does not audition for non-audio datasets', async () => {
+    fixture.componentRef.setInput('mediaType', 'image');
+    selection.addAll([3]);
+    await settleZoneless(fixture);
+
+    firstEntry().dispatchEvent(new MouseEvent('mouseenter'));
+    await wait(DWELL_MS + 60);
+    await settleZoneless(fixture);
+
+    expect(playSpy).not.toHaveBeenCalled();
+  });
+
+  it('silences a playing entry when it is clicked to remove', async () => {
+    let emitted: NowPlaying | null | undefined;
+    fixture.componentInstance.nowPlaying.subscribe((e) => (emitted = e));
+    selection.addAll([8, 9]);
+    await settleZoneless(fixture);
+
+    // Audition the top entry, then click it to drop it from selection.
+    const entry = firstEntry();
+    entry.dispatchEvent(new MouseEvent('mouseenter'));
+    await wait(DWELL_MS + 60);
+    await settleZoneless(fixture);
+    const playingId = emitted?.mediaId;
+    expect(playingId).not.toBeUndefined();
+
+    entry.dispatchEvent(new MouseEvent('click'));
+    await settleZoneless(fixture);
+
+    // Removal unmounts the entry (no mouseleave fires), so the click path must
+    // silence it directly: nowPlaying clears and that item is gone.
+    expect(emitted).toBeNull();
+    expect(selection.ids()).not.toContain(playingId);
+    expect(selection.ids().length).toBe(1);
   });
 });

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -239,9 +239,11 @@
             class="browse-side-selection"
             [mediaType]="mediaType()"
             [canVerify]="subset"
+            [volume]="volume()"
             (verifyGood)="onVerify('good')"
             (verifyBad)="onVerify('bad')"
             (selectAllInView)="onSelectAllInView()"
+            (nowPlaying)="onNowPlaying($event)"
           />
           <div class="browse-side-meta">
             <div class="browse-side-minimap">


### PR DESCRIPTION
## Summary

The Browse **Selection panel** listed selected items but never auditioned audio on hover, unlike the two other places Browse shows audio squares — the canvas hex tiles (`browse-hover-preview`) and the bin-popup grid (`browse-bin-popup`), both of which play a clip on hover.

This adds the same hover-to-play behavior to Selection-panel entries when `mediaType() === 'audio'`, modeled on the canvas path (the issue's suggested approach, since a large multi-select list is easy to sweep across):

- **mouseenter** arms a 200ms dwell debounce (`AUDIO_DWELL_MS`, matching the canvas), so sweeping down the list doesn't fire a burst of plays; the entry the cursor settles on plays.
- Playback runs through a private, never-mounted `Audio` element wired with `applyClipWindow` / `clearClipWindow`, so windowed clips loop within `[clip_start, clip_end]` instead of playing the whole underlying file.
- **mouseleave** stops it immediately (no hover-bridge grace — there's no pane to travel onto), and clicking an entry to remove it also silences it directly (the entry unmounts, so no mouseleave fires).
- Emits to the shared top-left `NowPlaying` indicator via a new `nowPlaying` output, and a new `volume` input tracks the Browse toolbar's volume control — both wired through `browse-view.component.html` the same way the canvas and bin-popup are.

## Testing

- Added four cases to `browse-selection-panel.zoneless.spec.ts`: dwell-then-play emitting `nowPlaying`, mouseleave stops + emits `null`, no audition for non-audio datasets, and click-to-remove silences a playing entry.
- `./run-tests.sh frontend` green (ruff/codespell/deptry/pip-audit/pyright/TS build + 1471 Vitest tests).

Closes #2455

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyEKcKp8WsQZkvDoewcE2w)_