### PR TITLE
Fix invisible audio waveform thumbnails on span-masked surfaces

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -422,6 +422,12 @@
 // fill and mask chrome; here we cover-fit it (matching the <img> it replaces).
 // No ``background`` — that would out-specify the shared accent and blank the wave.
 .bin-popup-thumb-wave {
+  // ``display: block`` is required: the wave is a <span> (a non-replaced inline
+  // element, unlike the <img> it replaced), so without it ``width``/``height``
+  // are ignored and the box collapses to nothing (issue #2369 regression). The
+  // parent ``.bin-popup-thumb-wrap`` is a fixed square, so ``height: 100%`` is
+  // definite here.
+  display: block;
   width: 100%;
   height: 100%;
   mask-size: cover;

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -218,8 +218,12 @@
 // accent fill + mask chrome; contain-fit to mirror ``.bsp-thumb``. No
 // ``background`` here — the shared accent must win over a component class.
 .bsp-thumb-wave {
+  // ``display: block`` is required: the wave is a <span> (a non-replaced inline
+  // element, unlike the <img> it replaced), so without it ``width``/``height``
+  // are ignored and the box collapses to nothing (issue #2369 regression).
+  display: block;
   width: 100%;
-  height: 100%;
+  aspect-ratio: 1;
   mask-size: contain;
   -webkit-mask-size: contain;
   border-radius: var(--radius-sm);

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.scss
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.scss
@@ -95,8 +95,12 @@
 // accent fill + mask chrome; contain-fit to mirror ``.vote-thumbnail``. No
 // ``background`` here — the shared accent must win over a component class.
 .vote-thumbnail-wave {
+  // ``display: block`` is required: the wave is a <span> (a non-replaced inline
+  // element, unlike the <img> it replaced), so without it ``width``/``height``
+  // are ignored and the box collapses to nothing (issue #2369 regression).
+  display: block;
   width: 100%;
-  height: 100%;
+  aspect-ratio: 1;
   mask-size: contain;
   -webkit-mask-size: contain;
   border-radius: var(--radius-sm);


### PR DESCRIPTION
## Problem

An audio VTSBrowser user reported losing waveform thumbnails in the **Selection panel**: on the UMAP page, clicking a group/cluster adds files to the selection panel, but those items show no waveform (just the ♫ placeholder / blank tile).

## Root cause

Commit #2369 ("Make waveform thumbnails theme-agnostic alpha masks") replaced the `<img>` waveform with a `<span>` that tints a transparent alpha-mask PNG via a CSS `mask-image` + `.waveform-mask` accent fill. An `<img>` is a **replaced** inline element, so `width`/`height` apply to it; a `<span>` is a **non-replaced** inline element, so `width`/`height` are *ignored* unless the element is given `display: block` (or a flex/grid context).

Three of the seven waveform surfaces were converted to `<span>` masks but never given `display: block`, so their boxes collapse to zero size and the masked accent paints nothing:

- `.bsp-thumb-wave` — browse **Selection panel** (the reported surface)
- `.vote-thumbnail-wave` — Find **vote grid** (Good/Bad piles)
- `.bin-popup-thumb-wave` — **bin-popup** member grid

The two surfaces that already worked (`.media-thumbnail-wave`, `.example-thumbnail-wave`) set `display: block`; the `<div>`-based surfaces (`.bin-popup-preview-wave`, `.browse-now-playing-wave-fill`) are block by default and were never affected. This is why the canvas tiles (drawn separately, via an offscreen `source-in` fill) always kept their waveforms while these DOM surfaces lost theirs.

The symptom is consistent with the report: filenames render (metadata loads fine), only the waveform is missing — i.e. the gating logic passes and the failure is purely in the collapsed-box CSS, not in metadata timing.

## Fix

Add `display: block` to the three collapsed wave classes, mirroring the proven `.media-thumbnail-wave` pattern. For the two aspect-ratio-parented surfaces (selection panel, vote grid) also swap the fragile `height: 100%` for `aspect-ratio: 1`, exactly matching the working sibling; the bin-popup grid keeps `height: 100%` since its parent is a fixed-size square.

## Testing

`./run-tests.sh frontend` passes: `build:prod` clean (no budget warnings), `npm audit` clean, 1467 Vitest unit tests pass. No screenshot reshoot needed — the doc-screenshot fixtures use image/document datasets, so no shot frames an audio waveform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014o2RZeT1DcbKSmEZaLYTVw)_