### PR TITLE
Move /api/labeling-status cache advancement off the request thread

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3533,6 +3533,9 @@
           "stable": {
             "$ref": "#/components/schemas/StatusIndicator"
           },
+          "stale": {
+            "type": "boolean"
+          },
           "total_count": {
             "type": "integer"
           }
@@ -12513,7 +12516,7 @@
     },
     "/api/labeling-status": {
       "get": {
-        "description": "Returns ``smart``, ``stable``, and ``span`` sub-objects, each with a\n``status`` field of ``\"red\"``, ``\"yellow\"``, or ``\"green\"``.",
+        "description": "Returns ``smart``, ``stable``, and ``span`` sub-objects, each with a\n``status`` field of ``\"red\"``, ``\"yellow\"``, or ``\"green\"``, plus a\n``stale`` flag.\n\nThe frontend polls this every 2 s during labeling.  When the per-step\ncache already covers the full ``label_history`` the status is computed\ninline (cheap: cached-model forward passes over the small labeled set).\nWhen the cache is *behind* - the common case on the first poll after a new\nvote, or after a polarity flip truncated the cache - advancing it would\nretrain one-or-more MLPs and score every unlabeled media, so we return the\nlast-computed snapshot immediately with ``stale = true`` and defer the\nadvancement to a background worker (issue #2397).",
         "operationId": "labeling_status_indicator",
         "responses": {
           "200": {

--- a/tests/api/test_labeling_status_async.py
+++ b/tests/api/test_labeling_status_async.py
@@ -1,0 +1,114 @@
+"""Tests for the background-refresh behaviour of ``GET /api/labeling-status``.
+
+Issue #2397 moved the per-step cache advancement off the 2 s poll thread: a
+poll that finds the cache behind ``label_history`` returns the last-computed
+snapshot immediately with ``stale = true`` and kicks a background worker to
+advance the cache, instead of retraining MLPs inline.  These tests exercise
+the stale→fresh transition, the snapshot placeholder, and the coalescing of a
+rapid poll burst into a single in-flight refresh.
+"""
+
+from __future__ import annotations
+
+import time
+
+from vtscore.concurrency.async_jobs import labeling_status_jobs
+from vtsearch.state import bad_votes, good_votes, label_history
+
+
+def _seed_votes_and_history():
+    """A handful of good/bad votes plus matching label history — enough for the
+    labeling-status cache to train real per-step MLPs."""
+    for cid in (1, 2, 3):
+        good_votes[cid] = None
+        label_history.append((cid, "good", 0.0))
+    for cid in (4, 5, 6):
+        bad_votes[cid] = None
+        label_history.append((cid, "bad", 0.0))
+
+
+def _wait_for_refresh(timeout: float = 30.0) -> None:
+    """Block until no labeling-status refresh job is running or pending."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        active = labeling_status_jobs.active_jobs()
+        if not active:
+            return
+        for job in active:
+            job.done_event.wait(timeout=1.0)
+    raise AssertionError("labeling-status refresh did not finish in time")
+
+
+class TestLabelingStatusBackgroundRefresh:
+    def test_empty_history_is_fresh_and_not_stale(self, client):
+        """With no votes the cache trivially covers the (empty) history, so the
+        status is computed inline and flagged ``stale: false``."""
+        resp = client.get("/api/labeling-status")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["stale"] is False
+        assert body["good_count"] == 0
+        assert body["bad_count"] == 0
+        for key in ("smart", "stable", "span"):
+            assert "status" in body[key]
+
+    def test_first_poll_after_votes_is_stale_then_refreshes(self, client):
+        """A cache that is behind ``label_history`` yields an immediate stale
+        response plus a background refresh; a later poll returns fresh data."""
+        _seed_votes_and_history()
+
+        first = client.get("/api/labeling-status").get_json()
+        assert first["stale"] is True
+        # Counts + span are always real even in the placeholder.
+        assert first["good_count"] == 3
+        assert first["bad_count"] == 3
+        assert "status" in first["span"]
+
+        _wait_for_refresh()
+
+        second = client.get("/api/labeling-status").get_json()
+        assert second["stale"] is False
+        assert second["good_count"] == 3
+        assert second["bad_count"] == 3
+        # Enough votes for the Smart/Stable indicators to emit a real status.
+        for key in ("smart", "stable", "span"):
+            assert second[key]["status"] in ("red", "yellow", "green")
+
+    def test_stale_poll_returns_previous_snapshot(self, client):
+        """After a fresh compute, a genuinely new vote leaves the cache one step
+        behind; the next poll serves the prior snapshot (stale) rather than
+        retraining inline."""
+        _seed_votes_and_history()
+        client.get("/api/labeling-status")
+        _wait_for_refresh()
+        fresh = client.get("/api/labeling-status").get_json()
+        assert fresh["stale"] is False
+
+        # A new (non-flip) vote grows the history without truncating the cache.
+        good_votes[7] = None
+        label_history.append((7, "good", 0.0))
+
+        stale = client.get("/api/labeling-status").get_json()
+        assert stale["stale"] is True
+        # The snapshot predates the new vote, so its indicator objects match the
+        # last fully-computed status (identical smart/stable payloads).
+        assert stale["smart"] == fresh["smart"]
+        assert stale["stable"] == fresh["stable"]
+
+        _wait_for_refresh()
+
+    def test_rapid_polls_coalesce_into_one_refresh(self, client):
+        """A burst of stale polls must not fan out parallel retrains: the job
+        manager keeps at most one running + one pending refresh at any time.
+
+        (A poll late in the burst may legitimately come back fresh once the
+        background refresh lands, so the coalescing bound - not the ``stale``
+        flag - is the invariant under test.)"""
+        _seed_votes_and_history()
+        for _ in range(6):
+            resp = client.get("/api/labeling-status")
+            assert resp.status_code == 200
+            assert isinstance(resp.get_json()["stale"], bool)
+            # Single-runner + one coalescing pending slot, by construction.
+            assert len(labeling_status_jobs.active_jobs()) <= 2
+        _wait_for_refresh()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,6 +317,15 @@ def reset_state():
     from vtscore.security.hf_auth import clear_credential as _clear_hf_credential
 
     _clear_hf_credential()
+
+    # Drain background jobs (joining any live worker) BEFORE clearing the
+    # progress cache: a labeling-status refresh from the previous test writes
+    # the status snapshot at the end of its run, so it must be stopped first or
+    # its late write would survive the clear and leak into this test.
+    from vtscore.concurrency.async_jobs import reset_all_async_jobs_for_tests
+
+    reset_all_async_jobs_for_tests()
+
     clear_progress_cache()
 
     from vtscore.embedding.helpers import clear_text_query_cache as _clear_query_cache
@@ -341,10 +350,6 @@ def reset_state():
     _eval_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _loading_tasks.reset_for_tests()
     _model_loading_tasks.reset_for_tests()
-
-    from vtscore.concurrency.async_jobs import reset_all_async_jobs_for_tests
-
-    reset_all_async_jobs_for_tests()
 
     # Cancel any debounced labelset-source push left over from the
     # previous test so its captured contexts don't fire after this

--- a/tests/detectors/test_multi_detector.py
+++ b/tests/detectors/test_multi_detector.py
@@ -486,9 +486,21 @@ class TestLabelingStatusResetOnDetectorSwitch:
         for mid in [16, 17, 18, 19, 20]:
             apply_label(mid, "bad")
 
-        # Call labeling-status to populate the progress cache
+        # Call labeling-status to populate the progress cache.  The endpoint now
+        # advances the per-step cache on a background worker (issue #2397), so
+        # wait for that refresh to finish before inspecting the cache - and so
+        # no in-flight job re-populates it after the unregister below.
+        import time
+
+        from vtscore.concurrency.async_jobs import labeling_status_jobs
+
         res = client.get("/api/labeling-status")
         assert res.status_code == 200
+
+        deadline = time.time() + 30
+        while time.time() < deadline and labeling_status_jobs.active_jobs():
+            for job in labeling_status_jobs.active_jobs():
+                job.done_event.wait(timeout=1.0)
 
         with _progress_lock:
             cached_before = len(_cached_steps)

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -229,6 +229,14 @@ def reset_contexts(tmp_path, monkeypatch):
 
     _clear_hf_credential()
 
+    # Drain background jobs (joining any live worker) BEFORE clearing the
+    # progress cache: a labeling-status refresh writes the status snapshot at
+    # the end of its run, so it must be stopped first or its late write would
+    # survive the clear and leak into this test.
+    from vtscore.concurrency.async_jobs import reset_all_async_jobs_for_tests
+
+    reset_all_async_jobs_for_tests()
+
     clear_progress_cache()
 
     from vtscore.embedding.helpers import clear_text_query_cache as _clear_query_cache
@@ -254,10 +262,6 @@ def reset_contexts(tmp_path, monkeypatch):
     _eval_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _loading_tasks.reset_for_tests()
     _model_loading_tasks.reset_for_tests()
-
-    from vtscore.concurrency.async_jobs import reset_all_async_jobs_for_tests
-
-    reset_all_async_jobs_for_tests()
 
     from vtscore.labels.sync import reset_label_sync_for_tests
 

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -425,11 +425,26 @@ class JobManager:
             return out
 
     def reset_for_tests(self) -> None:
-        """Cancel any running job and clear all stored state."""
+        """Cancel any running job, wait for its worker to exit, and clear state.
+
+        The join is what keeps background work from one test out of the next:
+        a daemon worker that outlived its test could otherwise mutate shared
+        module state (e.g. the labeling-status snapshot) after the next test's
+        reset_state has already cleared it.  Only the single running job owns a
+        live thread (pending slots never spawned one), so we wait on its
+        ``done_event`` - which ``_run_inner`` sets on every exit path,
+        including the cooperative-cancel unwind - before dropping state.
+        """
         with self._lock:
+            running = self._jobs.get(self._current_id) if self._current_id else None
             for j in self._jobs.values():
                 if j.status in ("running", "pending"):
                     j.cancel()
+        if running is not None and running.status == "running":
+            # Bounded: the deep loops poll ``check_job_cancelled`` frequently,
+            # so a cancelled job unwinds promptly; the timeout is a safety net.
+            running.done_event.wait(timeout=10)
+        with self._lock:
             self._jobs.clear()
             self._current_id = None
             self._pending = None
@@ -446,6 +461,13 @@ learned_sort_jobs = JobManager("learned-sort")
 
 #: Background runner for ``/api/eval/train-and-score``.
 eval_jobs = JobManager("eval-train-score")
+
+#: Background runner that advances the labeling-status per-step cache off the
+#: ``/api/labeling-status`` poll thread (issue #2397).  Not surfaced in
+#: ``/api/jobs/active`` - it is an internal refresh of a cheap 2 s poll, not a
+#: user-visible training job - so it is intentionally absent from
+#: ``JOB_MANAGERS`` below.
+labeling_status_jobs = JobManager("labeling-status")
 
 #: Background runner for ``/api/projection/build`` (VTSBrowse UMAP + pyramid).
 projection_jobs = JobManager("projection")
@@ -488,3 +510,6 @@ def reset_all_async_jobs_for_tests() -> None:
     """Reset every singleton job manager.  Called from the autouse fixture."""
     for mgr in JOB_MANAGERS.values():
         mgr.reset_for_tests()
+    # Not in ``JOB_MANAGERS`` (it is deliberately hidden from
+    # ``/api/jobs/active``), so reset it explicitly for test isolation.
+    labeling_status_jobs.reset_for_tests()

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -54,6 +54,14 @@ _cache_bad_ids: set[int] = set()
 _cache_prev_predictions: Optional[dict[int, int]] = None
 _cache_coverage_atlas: Any = None  # CoverageAtlas | None
 
+# Last fully-computed ``/api/labeling-status`` payload (minus the transient
+# ``stale`` flag).  ``compute_labeling_status`` refreshes it on every full
+# compute; the route returns it immediately to pollers while a background
+# worker advances the per-step cache, so the 2 s poll never blocks on an MLP
+# retrain (issue #2397).  Cleared alongside the cache so a stale detector's
+# status is never shown after a detector switch / vote clear.
+_status_snapshot: Optional[dict[str, Any]] = None
+
 # Live models injected by `train_and_score` during sorting.  Keyed by
 # ``(frozenset(good_ids), frozenset(bad_ids))`` so that ``_ensure_cache``
 # can look up the actual model that was used at each label step instead
@@ -72,7 +80,7 @@ def clear_progress_cache() -> None:
     Must be called whenever votes are cleared, medias change, or inclusion
     is altered so that stale models are not reused.
     """
-    global _cache_inclusion, _cache_prev_predictions, _cache_coverage_atlas
+    global _cache_inclusion, _cache_prev_predictions, _cache_coverage_atlas, _status_snapshot
     with _progress_lock:
         _cached_steps.clear()
         _cache_good_ids.clear()
@@ -81,6 +89,10 @@ def clear_progress_cache() -> None:
         _cache_inclusion = None
         _cache_coverage_atlas = None
         _live_models.clear()
+        # Drop the status snapshot too: it belonged to the just-cleared
+        # detector/labelset and would otherwise be served (stale) for the next
+        # one until its first background refresh lands.
+        _status_snapshot = None
 
 
 def invalidate_progress_cache_from(media_id: int) -> None:
@@ -709,6 +721,54 @@ def _compute_stable_status(
     }
 
 
+def _compute_span_status(span_info: Optional[dict[str, Any]]) -> dict[str, Any]:
+    """Compute the Span (diversity-coverage) red/yellow/green status.
+
+    Depends only on the coverage-atlas ``span_info`` passed in from the route
+    (``level`` = consecutive BFS-order seen nodes, ``depth`` = total nodes),
+    not on the per-step MLP cache, so it stays cheap and is reused verbatim by
+    the pending-status placeholder.
+    """
+    # The old metric required 4 full tree levels for green, which in a k=3
+    # tree is 1+3+9+27 = 40 nodes.  We preserve that scale: green at 40
+    # nodes (capped at total), yellow at 10, red below 10.
+    from vtscore.config import CoreConfig  # noqa: PLC0415
+
+    SPAN_GREEN = CoreConfig.from_settings().autopilot_goal_diversity
+    SPAN_YELLOW = 10
+    if span_info is None:
+        return {
+            "status": "red",
+            "reason": "Diversity tree not available.",
+            "level": 0,
+            "depth": 0,
+        }
+
+    level = span_info["level"]
+    tree_total = span_info["depth"]  # total nodes
+    green_at = min(SPAN_GREEN, tree_total)
+    yellow_at = min(SPAN_YELLOW, green_at)
+    if tree_total <= 0:
+        return {"status": "green", "reason": "Degenerate tree.", **span_info}
+    if level >= green_at:
+        return {
+            "status": "green",
+            "reason": "All tree nodes covered." if level >= tree_total else f"{level}/{tree_total} nodes covered.",
+            **span_info,
+        }
+    if level >= yellow_at:
+        return {
+            "status": "yellow",
+            "reason": f"{level}/{tree_total} nodes covered.",
+            **span_info,
+        }
+    return {
+        "status": "red",
+        "reason": "No tree coverage yet." if level == 0 else f"{level}/{tree_total} nodes covered.",
+        **span_info,
+    }
+
+
 def compute_labeling_status(
     clips_dict: dict[int, dict[str, Any]],
     label_history: list[tuple[int, str, float]],
@@ -722,7 +782,16 @@ def compute_labeling_status(
     Returns a dict with ``good_count``, ``bad_count``, ``total_count``, and
     three sub-dicts: ``smart``, ``stable``, and ``span``, each with a
     ``status`` field of ``"red"``, ``"yellow"``, or ``"green"``.
+
+    Advancing the per-step cache (``_ensure_cache``) can retrain MLPs and run a
+    forward pass over every unlabeled media, so this is the *heavy* path.  The
+    result is stashed in ``_status_snapshot`` so the ``/api/labeling-status``
+    route can serve it immediately (marked ``stale``) on subsequent polls while
+    a background worker calls this to advance the cache off the request thread
+    (issue #2397).
     """
+    global _status_snapshot
+
     good = len(current_good_votes)
     bad = len(current_bad_votes)
     total = good + bad
@@ -736,50 +805,9 @@ def compute_labeling_status(
         stable = _compute_stable_status(good, bad, total)
 
     # Span status from coverage atlas info (passed in from the route).
-    # ``level`` is the number of consecutive BFS-order seen nodes and
-    # ``depth`` is the total number of nodes (the maximum diversity level).
-    #
-    # The old metric required 4 full tree levels for green, which in a k=3
-    # tree is 1+3+9+27 = 40 nodes.  We preserve that scale: green at 40
-    # nodes (capped at total), yellow at 10, red below 10.
-    from vtscore.config import CoreConfig  # noqa: PLC0415
+    span = _compute_span_status(span_info)
 
-    SPAN_GREEN = CoreConfig.from_settings().autopilot_goal_diversity
-    SPAN_YELLOW = 10
-    if span_info is None:
-        span = {
-            "status": "red",
-            "reason": "Diversity tree not available.",
-            "level": 0,
-            "depth": 0,
-        }
-    else:
-        level = span_info["level"]
-        tree_total = span_info["depth"]  # total nodes
-        green_at = min(SPAN_GREEN, tree_total)
-        yellow_at = min(SPAN_YELLOW, green_at)
-        if tree_total <= 0:
-            span = {"status": "green", "reason": "Degenerate tree.", **span_info}
-        elif level >= green_at:
-            span = {
-                "status": "green",
-                "reason": "All tree nodes covered." if level >= tree_total else f"{level}/{tree_total} nodes covered.",
-                **span_info,
-            }
-        elif level >= yellow_at:
-            span = {
-                "status": "yellow",
-                "reason": f"{level}/{tree_total} nodes covered.",
-                **span_info,
-            }
-        else:
-            span = {
-                "status": "red",
-                "reason": "No tree coverage yet." if level == 0 else f"{level}/{tree_total} nodes covered.",
-                **span_info,
-            }
-
-    return {
+    result = {
         "good_count": good,
         "bad_count": bad,
         "total_count": total,
@@ -787,6 +815,72 @@ def compute_labeling_status(
         "stable": stable,
         "span": span,
     }
+    # Refresh the snapshot the poll route hands back while the cache is behind.
+    # Store a copy so a caller that mutates the returned dict (e.g. adding the
+    # ``stale`` flag) doesn't retroactively corrupt the snapshot.
+    with _progress_lock:
+        _status_snapshot = dict(result)
+    return result
+
+
+def is_status_cache_fresh(label_history: list[tuple[int, str, float]], inclusion_value: int) -> bool:
+    """Return ``True`` when the per-step cache already covers *label_history*.
+
+    A fresh cache means ``compute_labeling_status`` will not retrain any model,
+    so the route can compute the status inline instead of deferring to a
+    background worker.  A mismatched ``inclusion_value`` counts as not-fresh
+    because :func:`_ensure_cache` would rebuild the cache from scratch.
+    """
+    with _progress_lock:
+        if _cache_inclusion is not None and _cache_inclusion != inclusion_value:
+            return False
+        return len(_cached_steps) >= len(label_history)
+
+
+def _pending_labeling_status(
+    current_good_votes: dict[int, None],
+    current_bad_votes: dict[int, None],
+    span_info: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build a status from only the cheap fields (counts + Span).
+
+    The MLP-derived Smart / Stable indicators show a transient "computing"
+    state; :func:`stale_labeling_status` overlays the real ones from the last
+    snapshot when one exists.
+    """
+    good = len(current_good_votes)
+    bad = len(current_bad_votes)
+    computing = {"status": "yellow", "reason": "Computing indicators..."}
+    return {
+        "good_count": good,
+        "bad_count": bad,
+        "total_count": good + bad,
+        "smart": dict(computing),
+        "stable": dict(computing),
+        "span": _compute_span_status(span_info),
+    }
+
+
+def stale_labeling_status(
+    current_good_votes: dict[int, None],
+    current_bad_votes: dict[int, None],
+    span_info: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build the poll response served while a background cache refresh is pending.
+
+    Counts and the coverage-atlas Span status are recomputed live (both cheap),
+    so the panel's counters and diversity chip stay accurate the instant a vote
+    lands.  Only the expensive Smart / Stable indicators lag: they come from the
+    last ``compute_labeling_status`` snapshot, or - when none exists yet (first
+    poll after a detector switch / session start) - a transient "computing"
+    placeholder.  The caller stamps ``stale = True`` on the result.
+    """
+    status = _pending_labeling_status(current_good_votes, current_bad_votes, span_info)
+    with _progress_lock:
+        if _status_snapshot is not None:
+            status["smart"] = dict(_status_snapshot["smart"])
+            status["stable"] = dict(_status_snapshot["stable"])
+    return status
 
 
 def calculate_diversity_level_over_time(

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -16,6 +16,8 @@ from vtscore.detectors.labeling_progress import (
     calculate_error_cost_over_time,
     calculate_prediction_stability_over_time,
     compute_labeling_status,
+    is_status_cache_fresh,
+    stale_labeling_status,
 )
 from vtsearch.schemas.eval import (
     EvalTrainAndScoreCancelResponseSchema,
@@ -68,6 +70,45 @@ def labeling_progress():
         abort(500, message="Labeling progress computation failed")
 
 
+def _schedule_status_refresh(span_info) -> None:
+    """Kick (or coalesce into) a single background labeling-status cache build.
+
+    Snapshots the inputs on the request thread - like ``eval_train_and_score``
+    - so the worker advances the per-step cache against a consistent labelset
+    even if more votes arrive mid-refresh; the next stale poll simply schedules
+    another pass.  ``JobManager`` coalesces the rapid poll burst into one
+    in-flight refresh per (dataset, detector) so we never fan out parallel
+    retrains.
+    """
+    from vtscore.concurrency.async_jobs import labeling_status_jobs
+    from vtscore.state.core import get_active_context, get_active_detector_context
+
+    clips = snapshot_medias()
+    inclusion = get_inclusion()
+    history = list(label_history)
+    good_snap = dict(good_votes)
+    bad_snap = dict(bad_votes)
+
+    ds_ctx = get_active_context()
+    det_ctx = get_active_detector_context()
+
+    signature = (ds_ctx.dataset_id, det_ctx.detector_id, len(history), inclusion)
+
+    def _run(job):
+        # ``compute_labeling_status`` advances the per-step cache under
+        # ``_progress_lock`` and refreshes ``_status_snapshot``; the return
+        # value is unused - the next poll reads the snapshot.  The lock is
+        # taken only inside the worker, never across the HTTP response.
+        compute_labeling_status(clips, history, good_snap, bad_snap, inclusion, span_info=span_info)
+
+    labeling_status_jobs.start(
+        signature,
+        _run,
+        dataset_id=ds_ctx.dataset_id,
+        detector_id=det_ctx.detector_id,
+    )
+
+
 @eval_bp.route("/api/labeling-status", methods=["GET"])
 @eval_bp.response(200, LabelingStatusResponseSchema)
 @eval_bp.alt_response(500, description="Labeling-status computation failed.")
@@ -75,14 +116,40 @@ def labeling_status_indicator():
     """Return per-metric red/yellow/green labeling statuses.
 
     Returns ``smart``, ``stable``, and ``span`` sub-objects, each with a
-    ``status`` field of ``"red"``, ``"yellow"``, or ``"green"``.
+    ``status`` field of ``"red"``, ``"yellow"``, or ``"green"``, plus a
+    ``stale`` flag.
+
+    The frontend polls this every 2 s during labeling.  When the per-step
+    cache already covers the full ``label_history`` the status is computed
+    inline (cheap: cached-model forward passes over the small labeled set).
+    When the cache is *behind* - the common case on the first poll after a new
+    vote, or after a polarity flip truncated the cache - advancing it would
+    retrain one-or-more MLPs and score every unlabeled media, so we return the
+    last-computed snapshot immediately with ``stale = true`` and defer the
+    advancement to a background worker (issue #2397).
     """
     try:
         tree = get_coverage_atlas()
         span = tree.span_info() if tree is not None else None
-        return compute_labeling_status(
-            snapshot_medias(), label_history, good_votes, bad_votes, get_inclusion(), span_info=span
-        )
+        inclusion = get_inclusion()
+
+        if is_status_cache_fresh(label_history, inclusion):
+            status = compute_labeling_status(
+                snapshot_medias(), label_history, good_votes, bad_votes, inclusion, span_info=span
+            )
+            status["stale"] = False
+            return status
+
+        # Cache is behind: serve the last snapshot now, advance the cache in
+        # the background.  ``stale_labeling_status`` keeps the cheap fields
+        # (counts + Span) live and lags only the MLP-derived Smart / Stable
+        # indicators, falling back to a "computing" placeholder when no
+        # snapshot exists yet (rapid votes at session start, or the first poll
+        # after a detector switch cleared the cache).
+        _schedule_status_refresh(span)
+        status = stale_labeling_status(good_votes, bad_votes, span)
+        status["stale"] = True
+        return status
     except Exception:
         import logging
 

--- a/vtsearch/schemas/eval.py
+++ b/vtsearch/schemas/eval.py
@@ -87,6 +87,12 @@ class LabelingStatusResponseSchema(Schema):
     smart = fields.Nested(StatusIndicatorSchema, required=True)
     stable = fields.Nested(StatusIndicatorSchema, required=True)
     span = fields.Nested(StatusIndicatorSchema, required=True)
+    # ``true`` while a background worker is advancing the per-step cache: the
+    # ``smart`` / ``stable`` indicators reflect the last-computed snapshot (or a
+    # transient "computing" placeholder), not the current labelset yet. Cleared
+    # on the first poll after the refresh lands. Optional so existing clients /
+    # mocks that omit it stay valid. See issue #2397.
+    stale = fields.Boolean()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`/api/labeling-status` (polled every 2 s during labeling) synchronously advanced the per-step cache in `vtscore/detectors/labeling_progress.py` under `_progress_lock` **on the request thread**. Steady-state polls hit the cache and were cheap, but the first poll after each new vote trained an MLP (`_train_step` → `train_model`) and ran a forward pass over **all unlabeled** media (`_compute_step_stability`) — and a polarity flip truncated the cache and retrained several steps. That stall landed exactly when the user was actively voting.

This moves the advancement off the poll thread, mirroring how the sibling `/api/eval/train-and-score` was already backgrounded.

## What changed

- **Route** (`vtsearch/routes/eval.py`): the GET now returns immediately.
  - Cache already covers `label_history` → compute inline (cheap: cached-model forward passes over the small labeled set), `stale = false`.
  - Cache behind → return the last-computed snapshot with `stale = true` and defer the retrain to a background worker. The cheap fields (vote counts + coverage **Span**) are recomputed **live** so the panel's counters and diversity chip stay accurate; only the MLP-derived **Smart**/**Stable** indicators lag one poll cycle.
- **New `labeling_status_jobs` `JobManager`** (`vtscore/concurrency/async_jobs.py`): reuses the existing async-job/daemon-thread pattern. Inputs are snapshotted on the request thread (like `eval_train_and_score`); a rapid poll burst coalesces into a single in-flight refresh per `(dataset, detector)` so retrains never fan out. Intentionally kept out of `/api/jobs/active` (it's an internal refresh, not a user-visible training job).
- **Snapshot state** (`labeling_progress.py`): `compute_labeling_status` stashes each full result in `_status_snapshot`, cleared alongside the cache (so a switched-away detector's status is never served). Added `is_status_cache_fresh`, `stale_labeling_status`, and factored the Span computation into `_compute_span_status`.
- **Schema/OpenAPI**: added an optional `stale` boolean to `LabelingStatusResponseSchema` and regenerated `frontend/openapi.json`.
- **Lock ordering** is preserved: the background worker takes `_progress_lock` only inside itself, never across the HTTP response.

## Test-isolation fix

A background refresh spawned by a casual `GET /api/labeling-status` could outlive its test and mutate shared module state. `JobManager.reset_for_tests` now **joins** the running worker before clearing state, and both conftests drain async jobs **before** `clear_progress_cache()` so a joined job's late snapshot write is then cleared.

## Tests

- New `tests/api/test_labeling_status_async.py`: fresh-vs-stale path, snapshot reuse across a new vote, and poll-burst coalescing.
- Updated `test_multi_detector` and the conftests for the async behavior.
- Full suite green: `./run-tests.sh` → 6179 passed, 1 skipped, 1 xfailed.

Closes #2397

🤖 Generated with [Claude Code](https://claude.com/claude-code)