### PR TITLE
Efficiency micro-fixes: redundant lookups, repeated snapshots, per-epoch syncs, timers

### DIFF
--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
@@ -15,6 +15,7 @@
   loop
   [attr.aria-label]="media.filename || 'Audio media'"
   (loadedmetadata)="onLoadedMetadata()"
+  (timeupdate)="onTimeUpdate()"
   (volumechange)="onVolumeChange()"
   (play)="onPlay()"
   (pause)="onPause()"

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -92,7 +92,10 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   // whenever the metadata cache hydrates; without this guard, every cache
   // refresh would re-`loadAudio()` and snap playback back to t=0.
   private lastMediaId: number | null = null;
-  private clipCheckInterval: ReturnType<typeof setInterval> | null = null;
+  // Active clip window bounds while enforcement is on, else null. Enforcement is
+  // driven by the <audio> element's (timeupdate) event rather than a polling
+  // timer, so it only runs while the clip is actually playing and progressing.
+  private clipBounds: { start: number; end: number } | null = null;
   // Whether (loadedmetadata) has fired for the current audioSrc. Clip bounds
   // (clip_start/clip_end) often arrive via batch hydration *after* the audio
   // has already loaded, on a later ngOnChanges with the same media id; in that
@@ -175,27 +178,29 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   private startClipEnforcement(): void {
-    this.stopClipEnforcement();
-    if (this.media?.clip_start == null || this.media?.clip_end == null) return;
-
-    const clipStart = this.media.clip_start;
-    const clipEnd = this.media.clip_end;
-
-    // Poll every 100ms to enforce clip boundaries. When the audio reaches
-    // clip_end, loop back to clip_start instead of continuing.
-    this.clipCheckInterval = setInterval(() => {
-      const audio = this.audioRef?.nativeElement;
-      if (!audio || audio.paused) return;
-      if (audio.currentTime >= clipEnd || audio.currentTime < clipStart) {
-        audio.currentTime = clipStart;
-      }
-    }, 100);
+    if (this.media?.clip_start == null || this.media?.clip_end == null) {
+      this.clipBounds = null;
+      return;
+    }
+    // Arm enforcement; the actual boundary check runs in (timeupdate), which the
+    // <audio> element fires as playback advances (no timer while paused).
+    this.clipBounds = { start: this.media.clip_start, end: this.media.clip_end };
   }
 
   private stopClipEnforcement(): void {
-    if (this.clipCheckInterval != null) {
-      clearInterval(this.clipCheckInterval);
-      this.clipCheckInterval = null;
+    this.clipBounds = null;
+  }
+
+  // Enforce the clip window as playback advances: when the current time leaves
+  // [start, end), loop back to the window start. Driven by the element's
+  // (timeupdate) event instead of a 100ms polling interval.
+  onTimeUpdate(): void {
+    const bounds = this.clipBounds;
+    if (!bounds) return;
+    const audio = this.audioRef?.nativeElement;
+    if (!audio || audio.paused) return;
+    if (audio.currentTime >= bounds.end || audio.currentTime < bounds.start) {
+      audio.currentTime = bounds.start;
     }
   }
 

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.html
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.html
@@ -7,6 +7,7 @@
   class="video-element"
   [class.hidden]="videoError"
   (loadedmetadata)="onLoadedMetadata()"
+  (timeupdate)="onTimeUpdate()"
   (play)="onPlay()"
   (pause)="onPause()"
   (error)="onError()"

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -24,7 +24,10 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   videoSrc = '';
   videoError = false;
 
-  private clipCheckInterval: ReturnType<typeof setInterval> | null = null;
+  // Active clip window bounds while enforcement is on, else null. Enforcement is
+  // driven by the <video> element's (timeupdate) event rather than a polling
+  // timer, so it only runs while the clip is actually playing and progressing.
+  private clipBounds: { start: number; end: number } | null = null;
   // See ImageViewerComponent.lastMediaId; guards against metadata-enrichment
   // ngOnChanges cycles rebuilding videoSrc (and yanking playback) for the
   // same id.
@@ -133,27 +136,29 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   }
 
   private startClipEnforcement(): void {
-    this.stopClipEnforcement();
-    if (this.media?.clip_start == null || this.media?.clip_end == null) return;
-
-    const clipStart = this.media.clip_start;
-    const clipEnd = this.media.clip_end;
-
-    // Poll every 100ms to enforce clip boundaries. When the video
-    // reaches clip_end, loop back to clip_start instead of continuing.
-    this.clipCheckInterval = setInterval(() => {
-      const video = this.videoRef?.nativeElement;
-      if (!video || video.paused) return;
-      if (video.currentTime >= clipEnd || video.currentTime < clipStart) {
-        video.currentTime = clipStart;
-      }
-    }, 100);
+    if (this.media?.clip_start == null || this.media?.clip_end == null) {
+      this.clipBounds = null;
+      return;
+    }
+    // Arm enforcement; the actual boundary check runs in (timeupdate), which the
+    // <video> element fires as playback advances (no timer while paused).
+    this.clipBounds = { start: this.media.clip_start, end: this.media.clip_end };
   }
 
   private stopClipEnforcement(): void {
-    if (this.clipCheckInterval != null) {
-      clearInterval(this.clipCheckInterval);
-      this.clipCheckInterval = null;
+    this.clipBounds = null;
+  }
+
+  // Enforce the clip window as playback advances: when the current time leaves
+  // [start, end), loop back to the window start. Driven by the element's
+  // (timeupdate) event instead of a 100ms polling interval.
+  onTimeUpdate(): void {
+    const bounds = this.clipBounds;
+    if (!bounds) return;
+    const video = this.videoRef?.nativeElement;
+    if (!video || video.paused) return;
+    if (video.currentTime >= bounds.end || video.currentTime < bounds.start) {
+      video.currentTime = bounds.start;
     }
   }
 

--- a/frontend/src/app/services/charts.service.ts
+++ b/frontend/src/app/services/charts.service.ts
@@ -12,20 +12,48 @@ interface ChartPadding {
   left: number;
 }
 
+/** Theme colors resolved once per render (see ChartsService.resolvePalette). */
+interface ChartPalette {
+  border: string;
+  borderSubtle: string;
+  accent: string;
+  colorGood: string;
+  textSecondary: string;
+  textMuted: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class ChartsService {
   private readonly padding: ChartPadding = { top: 20, right: 20, bottom: 40, left: 50 };
 
-  private themeColor(varName: string): string {
-    return getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+  // Resolve every theme color this chart needs in a single getComputedStyle
+  // pass. getComputedStyle forces a style recalc, so calling it per-color (as
+  // the old themeColor() did, ~8-10x per render) was the cost; reading multiple
+  // properties off one live declaration is cheap.
+  private resolvePalette(): ChartPalette {
+    const style = getComputedStyle(document.documentElement);
+    const read = (varName: string) => style.getPropertyValue(varName).trim();
+    return {
+      border: read('--border'),
+      borderSubtle: read('--border-subtle'),
+      accent: read('--accent'),
+      colorGood: read('--color-good'),
+      textSecondary: read('--text-secondary'),
+      textMuted: read('--text-muted'),
+    };
   }
 
-  private drawAxes(ctx: CanvasRenderingContext2D, width: number, height: number): void {
+  private drawAxes(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    borderColor: string,
+  ): void {
     const { top, left } = this.padding;
     const chartWidth = width - left - this.padding.right;
     const chartHeight = height - top - this.padding.bottom;
 
-    ctx.strokeStyle = this.themeColor('--border');
+    ctx.strokeStyle = borderColor;
     ctx.lineWidth = 1;
     ctx.beginPath();
     ctx.moveTo(left, top);
@@ -34,12 +62,17 @@ export class ChartsService {
     ctx.stroke();
   }
 
-  private drawGrid(ctx: CanvasRenderingContext2D, width: number, height: number): void {
+  private drawGrid(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    gridColor: string,
+  ): void {
     const { top, left } = this.padding;
     const chartWidth = width - left - this.padding.right;
     const chartHeight = height - top - this.padding.bottom;
 
-    ctx.strokeStyle = this.themeColor('--border-subtle');
+    ctx.strokeStyle = gridColor;
     ctx.lineWidth = 1;
     for (let i = 1; i <= 5; i++) {
       const y = top + (chartHeight * i) / 5;
@@ -73,8 +106,13 @@ export class ChartsService {
     }
   }
 
-  private showEmpty(ctx: CanvasRenderingContext2D, width: number, height: number): void {
-    ctx.fillStyle = this.themeColor('--text-muted');
+  private showEmpty(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    mutedColor: string,
+  ): void {
+    ctx.fillStyle = mutedColor;
     ctx.font = '14px sans-serif';
     ctx.fillText('No data available', 20, height / 2);
   }
@@ -82,9 +120,10 @@ export class ChartsService {
   renderErrorCostChart(canvas: HTMLCanvasElement, data: ErrorCostDataPoint[]): void {
     const ctx = canvas.getContext('2d')!;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const palette = this.resolvePalette();
 
     if (!data || data.length === 0) {
-      this.showEmpty(ctx, canvas.width, canvas.height);
+      this.showEmpty(ctx, canvas.width, canvas.height, palette.textMuted);
       return;
     }
 
@@ -102,14 +141,14 @@ export class ChartsService {
     const yScale = (val: number) =>
       top + chartHeight - ((val - minCost) / (maxCost - minCost || 1)) * chartHeight;
 
-    this.drawAxes(ctx, canvas.width, canvas.height);
-    this.drawGrid(ctx, canvas.width, canvas.height);
+    this.drawAxes(ctx, canvas.width, canvas.height, palette.border);
+    this.drawGrid(ctx, canvas.width, canvas.height, palette.borderSubtle);
 
     const xs = numLabels.map(xScale);
     const ys = errorCosts.map(yScale);
-    this.drawLine(ctx, xs, ys, this.themeColor('--accent'));
+    this.drawLine(ctx, xs, ys, palette.accent);
 
-    ctx.fillStyle = this.themeColor('--text-secondary');
+    ctx.fillStyle = palette.textSecondary;
     ctx.font = '12px sans-serif';
     ctx.textAlign = 'center';
     ctx.fillText('Number of Labels', canvas.width / 2, canvas.height - 10);
@@ -131,9 +170,10 @@ export class ChartsService {
   renderStabilityChart(canvas: HTMLCanvasElement, data: StabilityDataPoint[]): void {
     const ctx = canvas.getContext('2d')!;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const palette = this.resolvePalette();
 
     if (!data || data.length === 0) {
-      this.showEmpty(ctx, canvas.width, canvas.height);
+      this.showEmpty(ctx, canvas.width, canvas.height, palette.textMuted);
       return;
     }
 
@@ -149,14 +189,14 @@ export class ChartsService {
     const xScale = (val: number) => left + (val / maxLabels) * chartWidth;
     const yScale = (val: number) => top + chartHeight - (val / maxFlips) * chartHeight;
 
-    this.drawAxes(ctx, canvas.width, canvas.height);
-    this.drawGrid(ctx, canvas.width, canvas.height);
+    this.drawAxes(ctx, canvas.width, canvas.height, palette.border);
+    this.drawGrid(ctx, canvas.width, canvas.height, palette.borderSubtle);
 
     const xs = numLabels.map(xScale);
     const ys = numFlips.map(yScale);
-    this.drawLine(ctx, xs, ys, this.themeColor('--color-good'));
+    this.drawLine(ctx, xs, ys, palette.colorGood);
 
-    ctx.fillStyle = this.themeColor('--text-secondary');
+    ctx.fillStyle = palette.textSecondary;
     ctx.font = '12px sans-serif';
     ctx.textAlign = 'center';
     ctx.fillText('Number of Labels', canvas.width / 2, canvas.height - 10);
@@ -178,9 +218,10 @@ export class ChartsService {
   renderDiversityChart(canvas: HTMLCanvasElement, data: DiversityDataPoint[], goalDiversity = 40): void {
     const ctx = canvas.getContext('2d')!;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const palette = this.resolvePalette();
 
     if (!data || data.length === 0) {
-      this.showEmpty(ctx, canvas.width, canvas.height);
+      this.showEmpty(ctx, canvas.width, canvas.height, palette.textMuted);
       return;
     }
 
@@ -201,11 +242,11 @@ export class ChartsService {
     const yScale = (val: number) =>
       top + chartHeight - ((val - minLevel) / (maxLevel - minLevel || 1)) * chartHeight;
 
-    this.drawAxes(ctx, canvas.width, canvas.height);
-    this.drawGrid(ctx, canvas.width, canvas.height);
+    this.drawAxes(ctx, canvas.width, canvas.height, palette.border);
+    this.drawGrid(ctx, canvas.width, canvas.height, palette.borderSubtle);
 
     // Draw green threshold line (diversity indicator turns green at goal level)
-    ctx.strokeStyle = this.themeColor('--color-good');
+    ctx.strokeStyle = palette.colorGood;
     ctx.lineWidth = 1;
     ctx.setLineDash([6, 4]);
     const greenY = yScale(greenLevel);
@@ -215,16 +256,16 @@ export class ChartsService {
     ctx.stroke();
     ctx.setLineDash([]);
 
-    ctx.fillStyle = this.themeColor('--color-good');
+    ctx.fillStyle = palette.colorGood;
     ctx.font = '11px sans-serif';
     ctx.textAlign = 'left';
     ctx.fillText(`green (${greenLevel})`, left + chartWidth - 70, greenY - 5);
 
     const xs = numLabels.map(xScale);
     const ys = levels.map(yScale);
-    this.drawLine(ctx, xs, ys, this.themeColor('--accent'));
+    this.drawLine(ctx, xs, ys, palette.accent);
 
-    ctx.fillStyle = this.themeColor('--text-secondary');
+    ctx.fillStyle = palette.textSecondary;
     ctx.font = '12px sans-serif';
     ctx.textAlign = 'center';
     ctx.fillText('Number of Labels', canvas.width / 2, canvas.height - 10);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,6 +353,12 @@ def reset_state():
 
     reset_label_sync_for_tests()
 
+    # Drop the TTL-cached detector-file mtimes so a stale entry from a prior
+    # test can't suppress a rehydrate in the next one.
+    from vtscore.detectors.dataset_sync import reset_mtime_cache_for_tests
+
+    reset_mtime_cache_for_tests()
+
     # Reset CLI progress format so a test that flips it to "json" can't
     # leak the choice into the next test.
     from vtscore import cli_progress

--- a/tests_lib/detectors/test_mlp_training.py
+++ b/tests_lib/detectors/test_mlp_training.py
@@ -83,3 +83,41 @@ class TestJobCancellation:
         X, y = _balanced_xy()
         model = train_model(X, y, input_dim=8, hidden_dim=4)
         assert sum(p.numel() for p in model.parameters()) > 0
+
+
+class TestEarlyStopDeterminism:
+    """The per-epoch ``weighted_loss.item()`` host-device sync is skipped on
+    CUDA (checked only on the patience-check cadence).  On CPU the read is
+    free, so the per-epoch early-stop path is kept unchanged.  These tests pin
+    that the CPU training path stays bit-for-bit deterministic across runs, so
+    the sync-cadence change can't silently perturb the early-stop decision on
+    the path the whole test suite exercises.
+    """
+
+    def _params_flat(self, model):
+        return torch.cat([p.detach().reshape(-1) for p in model.parameters()])
+
+    def test_same_seed_same_weights(self):
+        """Two runs with the same seed produce identical weights."""
+        X, y = _balanced_xy(seed=7)
+        m1 = train_model(X, y, input_dim=8, hidden_dim=4, seed=123)
+        m2 = train_model(X, y, input_dim=8, hidden_dim=4, seed=123)
+        assert torch.equal(self._params_flat(m1), self._params_flat(m2))
+
+    def test_early_stop_fires_deterministically(self, monkeypatch):
+        """With a tiny patience the loss plateaus and early-stop fires the same
+        way every run: identical trained weights across repeated calls.
+
+        ``train_model`` reads ``TRAIN_EPOCHS`` / ``TRAIN_PATIENCE`` off
+        ``config`` at call time, so patching the attributes forces the
+        early-stop branch without an env-var reload.
+        """
+        from vtscore import config
+
+        monkeypatch.setattr(config, "TRAIN_PATIENCE", 3, raising=False)
+        monkeypatch.setattr(config, "TRAIN_EPOCHS", 500, raising=False)
+
+        X, y = _balanced_xy(seed=3)
+        m1 = train_model(X, y, input_dim=8, hidden_dim=4, seed=99)
+        m2 = train_model(X, y, input_dim=8, hidden_dim=4, seed=99)
+        assert torch.equal(self._params_flat(m1), self._params_flat(m2))

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -22,6 +22,8 @@ can't slip in between the (request-boundary) rehydrate and the composition.
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import Any, NamedTuple
 
 
@@ -31,6 +33,45 @@ def _detector_file_mtime(path) -> float:
         return path.stat().st_mtime
     except OSError:
         return 0.0
+
+
+# Rate-limit the per-request detector-file stat in the outside-lock freshness
+# pre-check.  ``before_request`` calls it on every non-exempt request (votes
+# polls, thumbnails, media bytes), so a burst of requests would otherwise
+# ``stat()`` the same JSON dozens of times a second.  A short TTL (mirrors
+# ``_FRESHNESS_CHECK_INTERVAL`` in ``settings_store.py``) collapses that to at
+# most one stat per file per interval.  Only the *pre-check* uses this; the
+# authoritative re-check inside ``_state_lock`` still does a raw ``stat()``, so
+# a stale cache costs at most one spurious lock acquisition (which then
+# early-returns) and never corrupts vote state.
+_MTIME_CHECK_INTERVAL = 1.0
+_mtime_cache: dict[str, tuple[float, float]] = {}
+_mtime_cache_lock = threading.Lock()
+
+
+def _detector_file_mtime_cached(path) -> float:
+    """TTL-cached :func:`_detector_file_mtime` for the outside-lock pre-check.
+
+    Returns the last-seen mtime for *path* without re-``stat``-ing when the
+    previous stat is younger than ``_MTIME_CHECK_INTERVAL`` seconds; otherwise
+    stats afresh and refreshes the cache entry.
+    """
+    key = str(path)
+    now = time.monotonic()
+    with _mtime_cache_lock:
+        cached = _mtime_cache.get(key)
+        if cached is not None and (now - cached[0]) < _MTIME_CHECK_INTERVAL:
+            return cached[1]
+    mtime = _detector_file_mtime(path)
+    with _mtime_cache_lock:
+        _mtime_cache[key] = (now, mtime)
+    return mtime
+
+
+def reset_mtime_cache_for_tests() -> None:
+    """Drop the TTL-cached detector-file mtimes (test isolation only)."""
+    with _mtime_cache_lock:
+        _mtime_cache.clear()
 
 
 def ensure_votes_match_active_dataset() -> None:
@@ -85,7 +126,7 @@ def ensure_votes_match_active_dataset() -> None:
         return
 
     path = _detector_path(entry["name"])
-    current_mtime = _detector_file_mtime(path)
+    current_mtime = _detector_file_mtime_cached(path)
 
     if (
         det_ctx.votes_dataset_id == ds_ctx.dataset_id

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -96,6 +96,7 @@ from vtscore.state.coverage import (  # noqa: F401
 # Re-export media lookup ----------------------------------------------------
 from vtscore.state.media_lookup import (  # noqa: F401
     _origin_key,
+    build_md5_lookup,
     build_media_lookup,
     collapse_duplicates,
     find_missing_entries,

--- a/vtscore/state/media_lookup.py
+++ b/vtscore/state/media_lookup.py
@@ -59,6 +59,24 @@ def build_media_lookup(
     return origin_lookup, md5_lookup, name_lookup
 
 
+def build_md5_lookup(
+    media_dict: dict[int, dict[str, Any]],
+) -> dict[str, list[int]]:
+    """Build only the MD5 → media-ID lookup from *media_dict*.
+
+    Equivalent to the ``md5_lookup`` element of :func:`build_media_lookup`, but
+    skips constructing the origin and name dicts (which entail a per-item
+    ``json.dumps`` of every origin).  Use this when the caller only needs to
+    resolve a content hash to media IDs, e.g. add-to-pile dedup.
+    """
+    md5_lookup: dict[str, list[int]] = {}
+    for media in media_dict.values():
+        md5 = media.get("md5", "")
+        if md5:
+            md5_lookup.setdefault(md5, []).append(media["id"])
+    return md5_lookup
+
+
 def resolve_media_ids(
     entry: dict[str, Any],
     origin_lookup: dict[str, list[int]],

--- a/vtscore/training/mlp.py
+++ b/vtscore/training/mlp.py
@@ -232,6 +232,14 @@ def train_model(
     from contextlib import nullcontext  # noqa: PLC0415
 
     use_amp = device.type == "cuda"
+    # Reading ``weighted_loss.item()`` forces a host-device sync that stalls the
+    # CUDA stream every epoch. On GPU, only sync (and run the early-stop check)
+    # every few epochs; when no improvement is seen at a checkpoint we advance
+    # the patience counter by the whole interval, so early-stop still fires at
+    # roughly ``patience`` epochs. On CPU/MPS the read is free, so we keep the
+    # per-epoch cadence and the CPU path stays bit-for-bit as before (the seeded
+    # early-stop test exercises exactly this path).
+    loss_check_interval = 5 if device.type == "cuda" else 1
     # Prefer the modern ``torch.amp.GradScaler("cuda", ...)`` API; fall back
     # to the legacy ``torch.cuda.amp.GradScaler`` on torch <2.3.
     grad_scaler_cls = getattr(torch.amp, "GradScaler", None)
@@ -242,7 +250,7 @@ def train_model(
     autocast_ctx = torch.autocast(device_type="cuda") if use_amp else nullcontext()
     with torch.random.fork_rng(), torch.enable_grad():
         torch.manual_seed(seed)
-        for _ in range(epochs):
+        for epoch in range(epochs):
             # Honour a cancel of the background job that owns this thread at
             # the epoch boundary; a no-op outside a job (see
             # ``async_jobs.check_job_cancelled``).
@@ -255,12 +263,14 @@ def train_model(
             scaler.scale(weighted_loss).backward()
             scaler.step(optimizer)
             scaler.update()
+            if (epoch + 1) % loss_check_interval != 0:
+                continue
             cur = weighted_loss.item()
             if cur < best_loss - min_delta:
                 best_loss = cur
                 epochs_since_improve = 0
             else:
-                epochs_since_improve += 1
+                epochs_since_improve += loss_check_interval
                 if patience > 0 and epochs_since_improve >= patience:
                     break
 

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -47,7 +47,7 @@ from vtsearch.routes._shared import (
 from vtsearch.state import (
     _state_lock,
     apply_label,
-    build_media_lookup,
+    build_md5_lookup,
     get_media,
     medias,
     next_media_id,
@@ -1040,7 +1040,7 @@ def _insert_or_collide(new_media: dict[str, Any], file_md5: str) -> tuple[list[i
     is returned with ``is_new=True``.
     """
     with _state_lock:
-        _, md5_lookup_now, _ = build_media_lookup(medias)
+        md5_lookup_now = build_md5_lookup(medias)
         collided_cids = md5_lookup_now.get(file_md5, [])
         if collided_cids:
             return list(collided_cids), collided_cids[0], False
@@ -1084,7 +1084,7 @@ def add_media_to_pile():
     # before insertion (see below) because embedding holds no lock and a
     # concurrent upload of the same bytes could land between the two.
     snap = snapshot_medias()
-    _, md5_lookup, _ = build_media_lookup(snap)
+    md5_lookup = build_md5_lookup(snap)
     existing_cids = md5_lookup.get(file_md5, [])
 
     if existing_cids:

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -103,7 +103,7 @@ def _sort_idle() -> None:
     update_sort_progress("idle", "", step=None, total_steps=None)
 
 
-def _cosine_sort(query_vec, *, role: str = "score"):
+def _cosine_sort(query_vec, *, role: str = "score", snap=None):
     """Sort all loaded medias by cosine similarity to *query_vec*.
 
     Returns ``(results, threshold)`` where *results* is a list of
@@ -122,6 +122,10 @@ def _cosine_sort(query_vec, *, role: str = "score"):
     take a fast vectorised numpy path with no per-result box.
 
     Both paths live in :mod:`vtscore.training.region_similarity`.
+
+    *snap* lets the caller thread in a medias snapshot it already took, so a
+    single handler doesn't copy the full medias dict under ``_state_lock`` more
+    than once per request; when ``None`` a fresh snapshot is taken.
     """
     from vtscore.state.core import get_active_context  # noqa: PLC0415
     from vtscore.training.region_similarity import cosine_sort_with_boxes  # noqa: PLC0415
@@ -132,7 +136,8 @@ def _cosine_sort(query_vec, *, role: str = "score"):
     # valid only when the query was scored against that same embedder.
     region_aware = embedder_name is not None and embedder_name == ctx.patch_embedder
 
-    snap = snapshot_medias()
+    if snap is None:
+        snap = snapshot_medias()
     results, sims_list = cosine_sort_with_boxes(snap, query_vec, embedder_name, region_aware=region_aware)
     threshold = calculate_gmm_threshold(sims_list)
     return results, round(threshold, 4)
@@ -141,12 +146,18 @@ def _cosine_sort(query_vec, *, role: str = "score"):
 _embedder_load_lock = threading.Lock()
 
 
-def _get_embedder_for_loaded_data():
-    """Return the appropriate embedder for the currently loaded dataset."""
-    return get_embedder_for_medias(snapshot_medias())
+def _get_embedder_for_loaded_data(snap=None):
+    """Return the appropriate embedder for the currently loaded dataset.
+
+    *snap* threads in an already-taken medias snapshot to avoid re-copying the
+    medias dict under ``_state_lock``; when ``None`` a fresh snapshot is taken.
+    """
+    if snap is None:
+        snap = snapshot_medias()
+    return get_embedder_for_medias(snap)
 
 
-def _score_embedder_for_loaded_data() -> tuple["MediaEmbedder | None", str | None]:
+def _score_embedder_for_loaded_data(snap=None) -> tuple["MediaEmbedder | None", str | None]:
     """Return ``(embedder, embedder_name)`` for the dataset's score embedder.
 
     The score embedder is the patch slot if bound, else the text slot (the v3
@@ -166,10 +177,10 @@ def _score_embedder_for_loaded_data() -> tuple["MediaEmbedder | None", str | Non
             return get_embedder(score_name), score_name
         except KeyError:
             pass
-    return _get_embedder_for_loaded_data(), score_name
+    return _get_embedder_for_loaded_data(snap), score_name
 
 
-def _load_embedder_with_progress():
+def _load_embedder_with_progress(snap=None):
     """Load the embedding model, forwarding its load progress to step 1 of the bar.
 
     If the model is already loaded this is a no-op.  A lock serialises
@@ -178,8 +189,11 @@ def _load_embedder_with_progress():
     request's callback.  The model-load ``cur``/``tot`` is reported as the
     within-step progress of step 1, so the unified bar animates during the
     load instead of parking at a step floor.
+
+    *snap* threads in an already-taken medias snapshot to avoid re-copying the
+    medias dict under ``_state_lock``; when ``None`` a fresh snapshot is taken.
     """
-    emb = _get_embedder_for_loaded_data()
+    emb = _get_embedder_for_loaded_data(snap)
     if emb is None:
         return
 
@@ -239,7 +253,7 @@ def sort_clips(body: dict):
 
     sort_progress.set_step_weights(_SORT_STEP_WEIGHTS)
     try:
-        _load_embedder_with_progress()
+        _load_embedder_with_progress(snap)
         update_sort_progress("sorting", "Embedding text query…", 0, 0, step=2, total_steps=_SORT_STEPS)
 
         from vtsearch import settings
@@ -251,7 +265,7 @@ def sort_clips(body: dict):
             abort(500, message=f"Could not embed text for media type {media_type}")
 
         update_sort_progress("sorting", "Computing similarities…", 0, 0, step=3, total_steps=_SORT_STEPS)
-        results, threshold = _cosine_sort(text_vec, role="text")
+        results, threshold = _cosine_sort(text_vec, role="text", snap=snap)
         _sort_idle()
         return {"results": results, "threshold": threshold}
     except Exception as exc:
@@ -655,7 +669,7 @@ def _example_sort_from_paths(file_paths: list[Path]) -> tuple:
 
     # Embed the examples with the dataset's score embedder so the query shares
     # the space the haystack is scored against.
-    emb, _score_name = _score_embedder_for_loaded_data()
+    emb, _score_name = _score_embedder_for_loaded_data(snap)
     if emb is None:
         raise ValueError("No embedder available for loaded dataset")
     from vtscore.media.embedder import media_from_path  # noqa: PLC0415
@@ -674,7 +688,7 @@ def _example_sort_from_paths(file_paths: list[Path]) -> tuple:
         normed = [v / n if (n := float(np.linalg.norm(v))) > 0 else v for v in embeddings]
         query_vec = np.mean(np.stack(normed), axis=0)
 
-    results, threshold = _cosine_sort(query_vec)
+    results, threshold = _cosine_sort(query_vec, snap=snap)
 
     # Stage-2 structural re-rank (a no-op for non-structural datasets): for a
     # SIFT/VLAD dataset, geometrically verify the VLAD shortlist against the

--- a/vtsearch/state/__init__.py
+++ b/vtsearch/state/__init__.py
@@ -28,6 +28,7 @@ from vtscore.state import (  # noqa: F401
     assign_click_time,
     build_coverage_atlas,
     build_coverage_atlas_for_context,
+    build_md5_lookup,
     build_media_lookup,
     clear_all,
     clear_all_contexts,


### PR DESCRIPTION
A grab-bag of small, independent perf cleanups from `docs/plans/efficiency-wins.md` (efficiency review 2026-07-10). Each is individually minor.

Closes #2398

## Changes

- **md5-only lookup helper.** `add_media_to_pile` built the full 3-way media lookup (per-item `json.dumps` of every origin) twice per request — once outside and once inside `_state_lock` — just to resolve a single md5. Added `build_md5_lookup()` (skips the origin/name dicts) and routed both call sites through it.

- **Snapshot once per sort request.** `sort_clips` and the example-sort path each called `snapshot_medias()` (full dict copy under `_state_lock`) 2–3× per request via the embedder/cosine helpers. Those helpers now take an optional `snap` and the handlers thread one snapshot through.

- **GPU per-epoch host-device sync.** `train_model` read `weighted_loss.item()` every epoch — a CUDA stream stall. On GPU the loss is now synced (and early-stop checked) every 5 epochs, advancing the patience counter by the interval; on CPU/MPS the read is free so the per-epoch cadence (and bit-for-bit behavior) is unchanged. Guarded by a seeded early-stop determinism test.

- **Detector-file mtime TTL cache.** `before_request` stat'd the detector JSON on every non-exempt request. The outside-lock freshness pre-check now uses a 1s TTL-cached mtime (mirrors `_FRESHNESS_CHECK_INTERVAL`); the authoritative re-check inside `_state_lock` still does a raw stat, so a stale cache costs at most one spurious lock acquisition and never corrupts vote state.

- **Clip enforcement via `timeupdate`.** Audio/video players enforced clip bounds with a 100ms `setInterval` while playing. They now drive off the media element's `timeupdate` event — no timer while paused, work only as playback advances.

- **Chart palette resolved once.** `ChartsService` called `getComputedStyle` ~8–10× per chart render (via `themeColor`). Each `render*` now resolves all needed theme colors in a single `getComputedStyle` pass and threads them into the draw helpers.

## Testing

`./run-tests.sh detectors io core sorting api integration frontend` — all green (backend + frontend build + Vitest + pyright/ruff/codespell/deptry). Added `TestEarlyStopDeterminism` in `tests_lib/detectors/test_mlp_training.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhAbjeYkGXdr3TCE62bwkt)_