### PR TITLE
Subsample /api/labeling-status stability forward pass

### DIFF
--- a/tests_lib/detectors/test_stability_subsample.py
+++ b/tests_lib/detectors/test_stability_subsample.py
@@ -37,7 +37,14 @@ def _model(dim: int = 8) -> nn.Sequential:
 
 def _run_step(clips: dict[int, dict], model: nn.Sequential) -> dict | None:
     all_media_ids = sorted(clips.keys())
-    return lp._compute_step_stability(model, threshold=0.5, clips_dict=clips, all_media_ids=all_media_ids, t=1, num_labels=len(lp._cache_good_ids) + len(lp._cache_bad_ids))
+    return lp._compute_step_stability(
+        model,
+        threshold=0.5,
+        clips_dict=clips,
+        all_media_ids=all_media_ids,
+        t=1,
+        num_labels=len(lp._cache_good_ids) + len(lp._cache_bad_ids),
+    )
 
 
 class TestStabilitySubsample:

--- a/tests_lib/detectors/test_stability_subsample.py
+++ b/tests_lib/detectors/test_stability_subsample.py
@@ -1,0 +1,89 @@
+"""Tests for the subsampling fast-path in ``_compute_step_stability``.
+
+``/api/labeling-status`` is polled every 2 s during labeling and advances the
+per-step cache on the request thread; the stability step runs a forward pass
+over *all* unlabeled media - O(dataset) on the first poll after each new vote.
+Above ``_STABILITY_MAX_SAMPLES`` the pass scores a deterministic seeded sample
+of the eligible pool instead.  These tests pin that (a) the monitored set is
+bounded by the cap, (b) it is stable/deterministic across steps so the
+step-to-step flip comparison stays meaningful, and (c) at or below the cap the
+full unlabeled set is used unchanged.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+import vtscore.detectors.labeling_progress as lp
+from vtscore.embedding.media_vectors import EMBEDDINGS_KEY
+
+
+def _clips(n: int, dim: int = 8, seed: int = 0) -> dict[int, dict]:
+    """Build ``n`` media dicts each carrying a single seeded embedding."""
+    rng = np.random.default_rng(seed)
+    return {
+        cid: {EMBEDDINGS_KEY: {"test": rng.standard_normal(dim).astype(np.float32)}, "embedder": "test"}
+        for cid in range(n)
+    }
+
+
+def _model(dim: int = 8) -> nn.Sequential:
+    """A tiny fixed linear model producing ``(n, 1)`` logits."""
+    torch.manual_seed(0)
+    return nn.Sequential(nn.Linear(dim, 1))
+
+
+def _run_step(clips: dict[int, dict], model: nn.Sequential) -> dict | None:
+    all_media_ids = sorted(clips.keys())
+    return lp._compute_step_stability(model, threshold=0.5, clips_dict=clips, all_media_ids=all_media_ids, t=1, num_labels=len(lp._cache_good_ids) + len(lp._cache_bad_ids))
+
+
+class TestStabilitySubsample:
+    def test_monitored_set_bounded_by_cap(self, monkeypatch):
+        """Above the cap the forward pass scores at most ``_STABILITY_MAX_SAMPLES`` items."""
+        monkeypatch.setattr(lp, "_STABILITY_MAX_SAMPLES", 50)
+        clips = _clips(300)
+        lp._cache_good_ids.update({0, 1})
+        lp._cache_bad_ids.update({2, 3})
+        lp._cache_prev_predictions = None
+
+        _run_step(clips, _model())  # seeds prev predictions (stability is None first step)
+        assert lp._cache_prev_predictions is not None
+        assert len(lp._cache_prev_predictions) <= 50
+
+        stability = _run_step(clips, _model())
+        assert stability is not None
+        assert stability["num_unlabeled"] <= 50
+        assert stability["num_unlabeled"] == len(lp._cache_prev_predictions)
+
+    def test_monitored_set_deterministic_across_steps(self, monkeypatch):
+        """The sampled ids are identical across calls, so flips compare like-for-like."""
+        monkeypatch.setattr(lp, "_STABILITY_MAX_SAMPLES", 50)
+        clips = _clips(300)
+        lp._cache_good_ids.update({0, 1})
+        lp._cache_bad_ids.update({2, 3})
+
+        lp._cache_prev_predictions = None
+        _run_step(clips, _model())
+        first = set(lp._cache_prev_predictions)
+
+        lp._cache_prev_predictions = None
+        _run_step(clips, _model())
+        second = set(lp._cache_prev_predictions)
+
+        assert first == second
+
+    def test_below_cap_uses_full_unlabeled_set(self):
+        """At or below the cap every unlabeled item is scored (no sampling)."""
+        clips = _clips(300)  # well under the 50k default cap
+        lp._cache_good_ids.update({0, 1})
+        lp._cache_bad_ids.update({2, 3})
+
+        lp._cache_prev_predictions = None
+        _run_step(clips, _model())
+        stability = _run_step(clips, _model())
+
+        assert stability is not None
+        assert stability["num_unlabeled"] == 300 - 4  # all unlabeled scored

--- a/tests_lib/detectors/test_stability_subsample.py
+++ b/tests_lib/detectors/test_stability_subsample.py
@@ -74,10 +74,12 @@ class TestStabilitySubsample:
 
         lp._cache_prev_predictions = None
         _run_step(clips, _model())
+        assert lp._cache_prev_predictions is not None
         first = set(lp._cache_prev_predictions)
 
         lp._cache_prev_predictions = None
         _run_step(clips, _model())
+        assert lp._cache_prev_predictions is not None
         second = set(lp._cache_prev_predictions)
 
         assert first == second

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -65,6 +65,19 @@ _live_models: dict[tuple[frozenset[int], frozenset[int]], tuple[Any, float]] = {
 # call clear_progress_cache internally when the inclusion value changes.
 _progress_lock = threading.RLock()
 
+# Upper bound on the number of unlabeled items the per-step stability
+# forward pass evaluates.  ``/api/labeling-status`` (polled every 2 s during
+# labeling) advances this cache on the request thread, and the stability
+# pass runs a forward over *all* unlabeled media - O(dataset) per new vote.
+# Above this cap we score a deterministic seeded sample of the eligible pool
+# instead, holding the per-poll cost flat as datasets grow.  The "stable"
+# indicator keys off the flip *rate* (num_flips / num_unlabeled), for which a
+# fixed random sample is an unbiased estimator; sampling from the *full*
+# eligible pool (not the shrinking unlabeled set) keeps the monitored ids
+# stable across steps so the step-to-step flip comparison stays meaningful.
+# Mirrors ``_GMM_MAX_SAMPLES`` in ``vtscore.training.thresholds``.
+_STABILITY_MAX_SAMPLES = 50_000
+
 
 def clear_progress_cache() -> None:
     """Clear all cached progress data.
@@ -234,9 +247,19 @@ def _compute_step_stability(
     import torch  # noqa: PLC0415
 
     labeled_ids = _cache_good_ids | _cache_bad_ids
-    unlabeled_ids = [
-        cid for cid in all_media_ids if cid not in labeled_ids and media_embedding(clips_dict.get(cid, {})) is not None
-    ]
+    eligible = [cid for cid in all_media_ids if media_embedding(clips_dict.get(cid, {})) is not None]
+
+    # Bound the forward pass to a deterministic seeded sample of the eligible
+    # pool.  Sampling the full pool (rather than the per-step unlabeled set)
+    # keeps the monitored ids stable across steps, so the flip comparison
+    # against ``_cache_prev_predictions`` below stays over a consistent id set;
+    # the resulting flip *rate* is an unbiased estimate of the true rate.
+    if len(eligible) > _STABILITY_MAX_SAMPLES:
+        rng = np.random.default_rng(42)
+        monitored = set(rng.choice(np.asarray(eligible), size=_STABILITY_MAX_SAMPLES, replace=False).tolist())
+        unlabeled_ids = [cid for cid in eligible if cid not in labeled_ids and cid in monitored]
+    else:
+        unlabeled_ids = [cid for cid in eligible if cid not in labeled_ids]
 
     if not unlabeled_ids:
         return {"time_index": t, "num_labels": num_labels, "num_flips": 0, "num_unlabeled": 0}


### PR DESCRIPTION
## Summary

`/api/labeling-status` is polled every 2 s during labeling and advances the per-step cache in `vtscore/detectors/labeling_progress.py` synchronously, under `_progress_lock`, on the request thread (`vtsearch/routes/eval.py:71-90`). Steady-state polls hit the cache and are cheap; the cost lands on the **first poll after each new vote**, where `_compute_step_stability` ran a forward pass over **all unlabeled** media — O(dataset) latency on exactly the poll that fires while the user is active.

This takes the cheaper of the two approaches proposed in #2397: bound that forward pass to a deterministic seeded sample instead of moving cache advancement to a background worker.

## What changed

- Added `_STABILITY_MAX_SAMPLES = 50_000` (mirrors `_GMM_MAX_SAMPLES` in `vtscore/training/thresholds.py`).
- In `_compute_step_stability`, when the eligible pool exceeds the cap, the forward pass scores a seeded (`default_rng(42)`) sample rather than every unlabeled item. Below the cap, behavior is byte-for-byte unchanged.
- The sample is drawn from the **full eligible pool**, not the shrinking per-step unlabeled set. That keeps the monitored ids stable across steps, so the step-to-step flip comparison against `_cache_prev_predictions` stays over a consistent id set.

## Why this shape (vs. the background-job design in the issue)

The "stable" indicator keys off the flip *rate* (`num_flips / num_unlabeled`), for which a fixed random sample is an unbiased estimator — so a bounded sample preserves the metric. This avoids the recommended design's costs: no `stale` schema field, no `LabelingStatusResponseSchema`/OpenAPI snapshot churn, and no new concurrency surface over the already-intricate global cache state (live models, coverage atlas, polarity-flip truncation) guarded by a single lock. The tradeoff: the displayed per-step `num_unlabeled`/`num_flips` become sampled counts above the cap (the rate is unaffected), and this does not reduce the pure-training cost of a polarity-flip multi-step replay — but training there is already covered by live-model/prev-step reuse and runs on the small labeled set.

## Tests

- New library-tier `tests_lib/detectors/test_stability_subsample.py`: monitored set is bounded by the cap, deterministic/stable across steps, and unchanged at or below the cap.
- `./run-tests.sh` full suite green (6193 passed).

Closes #2397

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1MuHya5frxG23uzmyoXeh)_