### PR TITLE
Data-drive frontend thumbnail-type logic from served has_thumbnail

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -6,12 +6,12 @@ import { BrowseSelectionService } from '../../services/browse-selection.service'
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
+import { MediaTypeCapabilityService } from '../../services/media-type-capability.service';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
 import { IconComponent } from '../icon/icon.component';
 import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 import { applyClipWindow, clearClipWindow } from '../../utils/clip-window';
-import { usesThumbnails } from '../browse-canvas/hex-render.util';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
@@ -160,6 +160,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   private metadataCache = inject(MediaMetadataCacheService);
   private activeContext = inject(ActiveContextService);
   private settingsState = inject(SettingsStateService);
+  private mediaTypeCaps = inject(MediaTypeCapabilityService);
   private cdr = inject(ChangeDetectorRef);
   private injector = inject(Injector);
 
@@ -430,7 +431,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   /** True for media types that carry real visual thumbnails (image / video):
    *  the ones that magnify on the main canvas and are worth a large preview. */
   get showPreview(): boolean {
-    return usesThumbnails(this.mediaType());
+    return this.mediaTypeCaps.usesThumbnails(this.mediaType());
   }
 
   /** True when this popup's thumbnails are audio waveforms: theme-agnostic
@@ -1099,13 +1100,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
     const url = this.thumbnailUrl(id);
     if (this.failedThumbs.has(url)) return false;
     const media = this.metadataCache.get(id);
-    return (
-      !!media &&
-      (media.media_type === 'image' ||
-        media.media_type === 'video' ||
-        media.media_type === 'document' ||
-        media.media_type === 'audio')
-    );
+    return !!media && this.mediaTypeCaps.usesThumbnails(media.media_type);
   }
 
   thumbnailUrl(id: number): string {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -389,6 +389,7 @@ describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
     cdr: { markForCheck: () => void };
     panelRef?: { nativeElement: { querySelector: (sel: string) => HTMLElement | null } };
     mediaType: () => string;
+    mediaTypeCaps: { usesThumbnails: (t: string) => boolean };
     scrollRowIntoView: (index: number) => void;
     selection: { has: (id: number) => boolean; addAll: (ids: number[]) => void; remove: (id: number) => void };
     moveFocus(dCol: number, dRow: number): void;
@@ -403,6 +404,7 @@ describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
     state.cdr = { markForCheck: vi.fn() };
     // Non-thumbnail media so `previewOnly` is false and the grid path is live.
     state.mediaType = () => 'text';
+    state.mediaTypeCaps = { usesThumbnails: (t: string) => t !== 'text' };
     state.scrollRowIntoView = vi.fn();
     state.selection = { has: () => false, addAll: vi.fn(), remove: vi.fn() };
     return { component, state };

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -4,6 +4,7 @@ import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { BrowseViewportService } from '../../services/browse-viewport.service';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
+import { MediaTypeCapabilityService } from '../../services/media-type-capability.service';
 import {
   densityColor,
   resolveColormap,
@@ -11,7 +12,6 @@ import {
   type BrowseColormapId,
   type CanvasTheme,
   type ResolvedColormap,
-  usesThumbnails,
 } from './hex-render.util';
 import { binGeometry, BinGeometry, hoverThumbHalfExtents, pickCell } from './bin-geometry';
 import {
@@ -85,6 +85,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private activeContext = inject(ActiveContextService);
   private viewport = inject(BrowseViewportService);
   private selection = inject(BrowseSelectionService);
+  private mediaTypeCaps = inject(MediaTypeCapabilityService);
 
   @ViewChild('canvas', { static: true }) canvasRef!: ElementRef<HTMLCanvasElement>;
   readonly meta = input<ProjectionMeta | null>(null);
@@ -496,7 +497,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   /** True when cells should be painted with the central item's thumbnail. */
   private get thumbnailMode(): boolean {
-    return usesThumbnails(this.mediaType());
+    return this.mediaTypeCaps.usesThumbnails(this.mediaType());
   }
 
   /** At the largest zoom levels a cell is drawn wider (in device px) than the

--- a/frontend/src/app/components/browse-canvas/hex-render.util.spec.ts
+++ b/frontend/src/app/components/browse-canvas/hex-render.util.spec.ts
@@ -13,7 +13,6 @@ import {
   SQRT3,
   traceCellPath,
   traceHexPath,
-  usesThumbnails,
   type CanvasTheme,
 } from './hex-render.util';
 
@@ -24,20 +23,6 @@ import {
  * that records the path commands `traceHexPath` / `traceCellPath` emit.
  */
 describe('hex-render.util', () => {
-  describe('usesThumbnails', () => {
-    it('is true for the four thumbnail-backed media types', () => {
-      for (const t of ['image', 'video', 'document', 'audio']) {
-        expect(usesThumbnails(t)).toBe(true);
-      }
-    });
-
-    it('is false for flat-density types like text', () => {
-      expect(usesThumbnails('text')).toBe(false);
-      expect(usesThumbnails('anything-else')).toBe(false);
-      expect(usesThumbnails('')).toBe(false);
-    });
-  });
-
   describe('resolveColormap', () => {
     it("picks Ocean in light mode and Heat in dark/high-viz for 'auto'", () => {
       // Ocean darkens with density (low end lighter than high); Heat brightens.

--- a/frontend/src/app/components/browse-canvas/hex-render.util.ts
+++ b/frontend/src/app/components/browse-canvas/hex-render.util.ts
@@ -32,24 +32,6 @@ export type BrowseColormapId = 'auto' | 'heat' | 'ocean' | 'gray';
 export const BROWSE_COLORMAP_IDS: readonly BrowseColormapId[] = ['auto', 'heat', 'ocean', 'gray'];
 
 /**
- * Media types whose browse cells are painted with the central item's thumbnail
- * (``image``, ``video``, ``document``, ``audio`` — audio via its waveform PNG)
- * rather than flat density shading. These are pinned to the grayscale
- * colormap: the colourful presets are fun for the abstract density shading of
- * non-thumbnail types, but under real thumbnails a neutral ground reads best
- * and a coloured tint would fight the image content. Callers both force
- * ``'gray'`` for these types and hide the colormap picker for them.
- *
- * This mirrors the backend ``MediaType.has_thumbnail`` capability (the single
- * source of truth, surfaced on ``MediaTypeInfo.has_thumbnail`` via
- * ``GET /api/media-types``), which also drives the square-vs-hex bin shape.
- * Keep the two in sync; a follow-up may data-drive this from that field.
- */
-export function usesThumbnails(mediaType: string): boolean {
-  return mediaType === 'image' || mediaType === 'video' || mediaType === 'document' || mediaType === 'audio';
-}
-
-/**
  * Default width (CSS px) of the colormap-coloured border drawn around
  * multi-item ("pile") thumbnails, applied per media type when the user hasn't
  * set ``browse_thumbnail_border`` for that type. ``0`` would disable it.

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -6,6 +6,7 @@ import { BrowseSelectionService } from '../../services/browse-selection.service'
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
+import { MediaTypeCapabilityService } from '../../services/media-type-capability.service';
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
 import { NoFocusStealDirective } from '../../directives/no-focus-steal.directive';
 import { IconComponent } from '../icon/icon.component';
@@ -50,6 +51,7 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   private metadataCache = inject(MediaMetadataCacheService);
   private activeContext = inject(ActiveContextService);
   private settingsState = inject(SettingsStateService);
+  private mediaTypeCaps = inject(MediaTypeCapabilityService);
 
   /** Active media type, used to resolve the per-type view-mode + size prefs. */
   readonly mediaType = input('');
@@ -233,13 +235,7 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
     const url = this.thumbnailUrl(id);
     if (url && this.thumbnailFailedUrls.has(url)) return false;
     const media = this.metadataCache.get(id);
-    return (
-      !!media &&
-      (media.media_type === 'image' ||
-        media.media_type === 'video' ||
-        media.media_type === 'document' ||
-        media.media_type === 'audio')
-    );
+    return !!media && this.mediaTypeCaps.usesThumbnails(media.media_type);
   }
 
   thumbnailUrl(id: number): string {

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -28,11 +28,11 @@ import { BrowseSubsetService } from '../../services/browse-subset.service';
 import { MediasApiService } from '../../services/medias-api.service';
 import { VtDialogService } from '../../services/dialog.service';
 import { ToastService } from '../../services/toast.service';
+import { MediaTypeCapabilityService } from '../../services/media-type-capability.service';
 import {
   BROWSE_COLORMAP_IDS,
   DEFAULT_THUMBNAIL_BORDER,
   MAX_THUMBNAIL_BORDER,
-  usesThumbnails,
   type BrowseColormapId,
 } from '../browse-canvas/hex-render.util';
 import type { ProjectionMeta, RegionLabelPayload } from '../../models/projection.models';
@@ -79,6 +79,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private mediasApi = inject(MediasApiService);
   private dialog = inject(VtDialogService);
   private toast = inject(ToastService);
+  private mediaTypeCaps = inject(MediaTypeCapabilityService);
   private ngZone = inject(NgZone);
 
   @ViewChild(BrowseCanvasComponent) private canvas?: BrowseCanvasComponent;
@@ -338,6 +339,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.setupShiftListeners();
     this.settingsState.load();
+    // Data-drive the thumbnail-type set (bin shape, grayscale pinning, per-item
+    // thumbnails in the popup/selection panel) from the served has_thumbnail.
+    this.mediaTypeCaps.ensureLoaded();
 
     // Subset mode: the Find view handed off a set of positive ids to project
     // on their own. Detect it from the query param + the in-memory handoff.
@@ -523,7 +527,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     // Thumbnail media (image/video) are pinned to grayscale so the colourful
     // density presets never tint real thumbnails; the saved per-type value is
     // ignored for them (the Settings UI hides the picker to match).
-    if (usesThumbnails(mt)) {
+    if (this.mediaTypeCaps.usesThumbnails(mt)) {
       this.colormap.set('gray');
     } else {
       const cmap = mt ? this.perMediaValue(s.browse_colormap, mt) : '';
@@ -1084,7 +1088,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   /** Message on the pre-reveal cover: names thumbnails for media that paint
    *  them (the case this cover exists for), the projection otherwise. */
   get preloadMessage(): string {
-    return usesThumbnails(this.mediaType()) ? 'Loading thumbnails…' : 'Loading map…';
+    return this.mediaTypeCaps.usesThumbnails(this.mediaType()) ? 'Loading thumbnails…' : 'Loading map…';
   }
 
   private loadProjection(): void {

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -12,6 +12,7 @@ import { DetectorsRegistryApiService } from '../../services/detectors-registry-a
 import { SettingsStateService } from '../../services/settings-state.service';
 import { BrowseSubsetService } from '../../services/browse-subset.service';
 import { MediasApiService } from '../../services/medias-api.service';
+import { DatasetsListingsApiService } from '../../services/datasets-listings-api.service';
 import { VtDialogService } from '../../services/dialog.service';
 import { ToastService } from '../../services/toast.service';
 import type { ProjectionMeta } from '../../models/projection.models';
@@ -95,6 +96,12 @@ describe('BrowseViewComponent (zoneless canary)', () => {
         { provide: SettingsStateService, useValue: settingsStub },
         { provide: BrowseSubsetService, useValue: subsetStub },
         { provide: MediasApiService, useValue: mediasStub },
+        // ngOnInit calls MediaTypeCapabilityService.ensureLoaded(), which lazily
+        // resolves this service to fetch the thumbnail-type registry.
+        {
+          provide: DatasetsListingsApiService,
+          useValue: { getMediaTypes: () => of({ media_types: [] }) },
+        },
         { provide: VtDialogService, useValue: {} },
         { provide: ToastService, useValue: { error: () => {}, success: () => {} } },
         { provide: ActivatedRoute, useValue: routeStub },

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -97,10 +97,22 @@ describe('BrowseViewComponent (zoneless canary)', () => {
         { provide: BrowseSubsetService, useValue: subsetStub },
         { provide: MediasApiService, useValue: mediasStub },
         // ngOnInit calls MediaTypeCapabilityService.ensureLoaded(), which lazily
-        // resolves this service to fetch the thumbnail-type registry.
+        // resolves this service to fetch the thumbnail-type registry. The canary
+        // DS is audio, so the served set must mark audio as thumbnail-backed.
         {
           provide: DatasetsListingsApiService,
-          useValue: { getMediaTypes: () => of({ media_types: [] }) },
+          useValue: {
+            getMediaTypes: () =>
+              of({
+                media_types: [
+                  { type_id: 'image', name: 'Image', has_thumbnail: true },
+                  { type_id: 'video', name: 'Video', has_thumbnail: true },
+                  { type_id: 'document', name: 'Document', has_thumbnail: true },
+                  { type_id: 'audio', name: 'Audio', has_thumbnail: true },
+                  { type_id: 'text', name: 'Text', has_thumbnail: false },
+                ],
+              }),
+          },
         },
         { provide: VtDialogService, useValue: {} },
         { provide: ToastService, useValue: { error: () => {}, success: () => {} } },

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -216,9 +216,11 @@ describe('LeftPanelComponent', () => {
       // Metadata arrives late with a custom display name: the header must
       // upgrade instead of staying stuck on the fallback. The resource value
       // commits on a microtask and the deriving effect runs on the next tick,
-      // so settle before asserting.
-      const req = httpMock.expectOne((r) => r.url.includes('/api/media-types'));
-      req.flush({ media_types: [{ type_id: 'audio', name: 'Sound Clips' }] });
+      // so settle before asserting. Two GETs match here — the header's own
+      // rxResource read and the shared MediaTypeCapabilityService.ensureLoaded()
+      // fired in ngOnInit — so flush them all with the same payload.
+      const reqs = httpMock.match((r) => r.url.includes('/api/media-types'));
+      reqs.forEach((r) => r.flush({ media_types: [{ type_id: 'audio', name: 'Sound Clips' }] }));
       await settleResource();
       expect(component.mediaTypeName()).toBe('Sound Clips');
     });

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -28,6 +28,7 @@ import { Media, MediaTypeInfo } from '../../models/api.models';
 import type { LabelingStatusResponse } from '../../generated/api-client/models/labeling-status-response';
 import { DatasetsListingsApiService } from '../../services/datasets-listings-api.service';
 import { EmbedderCapabilityService } from '../../services/embedder-capability.service';
+import { MediaTypeCapabilityService } from '../../services/media-type-capability.service';
 import { SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
 
 export type { SortMode, SelectMode, SortedItem };
@@ -144,6 +145,7 @@ export class LeftPanelComponent implements OnInit, OnChanges {
 
   private readonly datasetsListingsApi = inject(DatasetsListingsApiService);
   private readonly embedderCaps = inject(EmbedderCapabilityService);
+  private readonly mediaTypeCaps = inject(MediaTypeCapabilityService);
 
   // Media-type metadata rides `rxResource`: loads once on creation (no request
   // signal = eager), wrapping the existing generated-client read so the
@@ -173,6 +175,7 @@ export class LeftPanelComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     this.embedderCaps.ensureLoaded();
+    this.mediaTypeCaps.ensureLoaded();
     if (this.panelMode() === 'find') {
       // Find mode doesn't use tabs; keep manual as a no-op default
       this.activeTab = 'manual';

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, inject, Input, input, OnChanges, ou
 import { CommonModule } from '@angular/common';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
+import { MediaTypeCapabilityService } from '../../../services/media-type-capability.service';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -13,6 +14,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
 })
 export class MediaItemComponent implements OnChanges {
   private activeContext = inject(ActiveContextService);
+  private mediaTypeCaps = inject(MediaTypeCapabilityService);
 
   @Input({ required: true }) media!: Media;
   @Input() active = false;
@@ -43,7 +45,7 @@ export class MediaItemComponent implements OnChanges {
 
   get thumbnailUrl(): string | null {
     if (this.thumbnailFailed) return null;
-    if (this.media.media_type === 'image' || this.media.media_type === 'video' || this.media.media_type === 'document' || this.media.media_type === 'audio') {
+    if (this.mediaTypeCaps.usesThumbnails(this.media.media_type)) {
       // Use the downscaled thumbnail endpoint, not the full-resolution
       // ``/image`` route: a grid of hundreds of high-res items would otherwise
       // force the browser to decode every full-size bitmap at once and exhaust

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -30,7 +30,6 @@ import {
 import {
   DEFAULT_THUMBNAIL_BORDER,
   MAX_THUMBNAIL_BORDER,
-  usesThumbnails,
 } from '../../browse-canvas/hex-render.util';
 
 @Component({
@@ -385,10 +384,11 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
   /**
    * True when *typeId* paints cells with thumbnails (image/video). These types
    * are pinned to grayscale, so the colormap picker is hidden for them and the
-   * UI shows a fixed read-only value instead.
+   * UI shows a fixed read-only value instead. Data-driven from the served
+   * ``has_thumbnail`` field on the media types this modal already loaded.
    */
   browseTabUsesThumbnails(typeId: string): boolean {
-    return usesThumbnails(typeId);
+    return this.mediaTypes().some((mt) => mt.type_id === typeId && mt.has_thumbnail === true);
   }
 
   getBrowseIconSize(typeId: string): string {

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -6,7 +6,8 @@ import { Media } from '../../../models/api.models';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
-import { THUMBNAIL_MEDIA_TYPES, VoteGridComponent, VoteGridEntry } from '../vote-grid/vote-grid.component';
+import { MediaTypeCapabilityService } from '../../../services/media-type-capability.service';
+import { VoteGridComponent, VoteGridEntry } from '../vote-grid/vote-grid.component';
 
 export interface LabelEntry extends VoteGridEntry {
   id: number;
@@ -26,6 +27,7 @@ export interface LabelEntry extends VoteGridEntry {
 export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
   private activeContext = inject(ActiveContextService);
   private metadataCache = inject(MediaMetadataCacheService);
+  private mediaTypeCaps = inject(MediaTypeCapabilityService);
 
   @Input() label: 'good' | 'bad' = 'good';
   @Input() ids: number[] = [];
@@ -128,7 +130,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private buildThumbnailUrl(media: Media | undefined, id: number): string {
-    if (!media || !THUMBNAIL_MEDIA_TYPES.has(media.media_type)) return '';
+    if (!media || !this.mediaTypeCaps.usesThumbnails(media.media_type)) return '';
     // Downscaled tile, not the full-resolution ``/image``: the labeled set can
     // hold hundreds of items, and decoding every full-size bitmap at once
     // exhausts browser memory.

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -3,7 +3,8 @@ import { CommonModule } from '@angular/common';
 import type { DetectorLabelView } from '../../../generated/api-client/models/detector-label-view';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
-import { THUMBNAIL_MEDIA_TYPES, VoteGridComponent, VoteGridEntry } from '../vote-grid/vote-grid.component';
+import { MediaTypeCapabilityService } from '../../../services/media-type-capability.service';
+import { VoteGridComponent, VoteGridEntry } from '../vote-grid/vote-grid.component';
 
 interface SortedElement extends DetectorLabelView, VoteGridEntry {
   confidence: number;
@@ -19,6 +20,7 @@ interface SortedElement extends DetectorLabelView, VoteGridEntry {
 })
 export class LabelsetListComponent implements OnChanges {
   private detectorsCrudApi = inject(DetectorsCrudApiService);
+  private mediaTypeCaps = inject(MediaTypeCapabilityService);
 
   readonly label = input<'good' | 'bad'>('good');
   readonly elements = input<DetectorLabelView[]>([]);
@@ -55,7 +57,7 @@ export class LabelsetListComponent implements OnChanges {
 
   private buildThumbnailUrl(entry: DetectorLabelView): string {
     const modelName = this.modelName();
-    if (!modelName || !THUMBNAIL_MEDIA_TYPES.has(entry.media_type)) return '';
+    if (!modelName || !this.mediaTypeCaps.usesThumbnails(entry.media_type)) return '';
     let url = this.detectorsCrudApi.labelThumbnailUrl(modelName, entry.id);
     // The route crops to the element's stored region box server-side; fold the
     // box into the URL so a re-vote with a different box busts the cached tile

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.ts
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.ts
@@ -37,14 +37,6 @@ export interface VoteGridEntry {
   isAudio?: boolean;
 }
 
-/** Media types the thumbnail route can render a tile for. */
-export const THUMBNAIL_MEDIA_TYPES: ReadonlySet<string> = new Set([
-  'image',
-  'video',
-  'document',
-  'audio',
-]);
-
 /**
  * Entry count above which the pile switches to CDK virtual scrolling.
  * Mirrors the left grid's ``GRID_VIRTUAL_THRESHOLD`` and its rationale: a few

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -207,7 +207,8 @@ export interface MediaTypeInfo {
   file_extensions?: string[];
   /** Whether items of this type have a browsable thumbnail (image/video/document,
    *  and audio via its waveform PNG). Drives the VTSBrowse square-vs-hex bin shape
-   *  and thumbnail painting; canonical source for ``usesThumbnails``. */
+   *  and thumbnail painting; the single source of truth the frontend reads via
+   *  ``MediaTypeCapabilityService.usesThumbnails``. */
   has_thumbnail?: boolean;
 }
 

--- a/frontend/src/app/services/media-type-capability.service.spec.ts
+++ b/frontend/src/app/services/media-type-capability.service.spec.ts
@@ -1,0 +1,94 @@
+import { TestBed } from '@angular/core/testing';
+import { Observable, Subject, of } from 'rxjs';
+import {
+  FALLBACK_THUMBNAIL_TYPE_IDS,
+  MediaTypeCapabilityService,
+} from './media-type-capability.service';
+import { DatasetsListingsApiService } from './datasets-listings-api.service';
+import type { MediaTypeInfo } from '../models/api.models';
+
+type MediaTypesResponse = { media_types: MediaTypeInfo[] };
+
+describe('MediaTypeCapabilityService', () => {
+  let service: MediaTypeCapabilityService;
+  let getMediaTypes: ReturnType<typeof vi.fn>;
+
+  const infos: MediaTypeInfo[] = [
+    { type_id: 'image', name: 'Image', has_thumbnail: true },
+    { type_id: 'video', name: 'Video', has_thumbnail: true },
+    { type_id: 'audio', name: 'Audio', has_thumbnail: true },
+    { type_id: 'document', name: 'Document', has_thumbnail: true },
+    { type_id: 'text', name: 'Text', has_thumbnail: false },
+    { type_id: 'point_cloud', name: 'Point Cloud', has_thumbnail: true }, // a new thumbnail type
+    { type_id: 'legacy', name: 'Legacy' }, // has_thumbnail undefined ⇒ no thumbnail
+  ];
+
+  beforeEach(() => {
+    getMediaTypes = vi.fn((): Observable<MediaTypesResponse> => of({ media_types: infos }));
+    TestBed.configureTestingModule({
+      providers: [
+        MediaTypeCapabilityService,
+        { provide: DatasetsListingsApiService, useValue: { getMediaTypes } },
+      ],
+    });
+    service = TestBed.inject(MediaTypeCapabilityService);
+  });
+
+  it('is side-effect-free on injection (no fetch, unloaded)', () => {
+    expect(getMediaTypes).not.toHaveBeenCalled();
+    expect(service.loaded).toBe(false);
+    expect(service.infos()).toBeNull();
+  });
+
+  it('answers from the fallback set before the registry loads', () => {
+    for (const t of FALLBACK_THUMBNAIL_TYPE_IDS) {
+      expect(service.usesThumbnails(t)).toBe(true);
+    }
+    expect(service.usesThumbnails('text')).toBe(false);
+    // A served-only new type is unknown until the registry loads.
+    expect(service.usesThumbnails('point_cloud')).toBe(false);
+    expect(service.usesThumbnails('')).toBe(false);
+  });
+
+  it('ensureLoaded data-drives usesThumbnails from the served has_thumbnail field', () => {
+    service.ensureLoaded();
+
+    expect(service.loaded).toBe(true);
+    for (const t of ['image', 'video', 'audio', 'document']) {
+      expect(service.usesThumbnails(t)).toBe(true);
+    }
+    // A new thumbnail type flips on purely from the served field — no frontend edit.
+    expect(service.usesThumbnails('point_cloud')).toBe(true);
+    // Non-thumbnail / absent-flag / unknown types are false.
+    expect(service.usesThumbnails('text')).toBe(false);
+    expect(service.usesThumbnails('legacy')).toBe(false);
+    expect(service.usesThumbnails('mystery')).toBe(false);
+  });
+
+  it('ensureLoaded is idempotent (fetches at most once)', () => {
+    service.ensureLoaded();
+    service.ensureLoaded();
+    expect(getMediaTypes).toHaveBeenCalledTimes(1);
+  });
+
+  it('on error marks the registry loaded and falls back to the served-empty set', () => {
+    getMediaTypes.mockReturnValueOnce(
+      new Observable<MediaTypesResponse>((o) => o.error(new Error('500'))),
+    );
+    service.ensureLoaded();
+    expect(service.loaded).toBe(true);
+    expect(service.infos()).toEqual([]);
+    // With an empty served registry, nothing is a thumbnail type.
+    expect(service.usesThumbnails('image')).toBe(false);
+  });
+
+  it('does not refetch while a load is still in flight', () => {
+    const pending = new Subject<MediaTypesResponse>();
+    getMediaTypes.mockReturnValue(pending.asObservable());
+    service.ensureLoaded();
+    service.ensureLoaded();
+    expect(getMediaTypes).toHaveBeenCalledTimes(1);
+    pending.next({ media_types: infos });
+    expect(service.loaded).toBe(true);
+  });
+});

--- a/frontend/src/app/services/media-type-capability.service.ts
+++ b/frontend/src/app/services/media-type-capability.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Injector, computed, inject, signal } from '@angular/core';
+
+import { DatasetsListingsApiService } from './datasets-listings-api.service';
+import type { MediaTypeInfo } from '../models/api.models';
+
+/**
+ * The thumbnail-backed media types, used as the default answer until the served
+ * ``GET /api/media-types`` registry resolves (and as the answer if it fails to
+ * load). This is the **only** hardcoded copy of the set left in the frontend;
+ * every per-item helper reads {@link MediaTypeCapabilityService.usesThumbnails}
+ * instead, so once the registry loads a new thumbnail type flips on purely from
+ * the backend ``MediaType.has_thumbnail`` capability — no frontend edit needed.
+ * Keeping the fallback in sync with the backend only matters for the sub-second
+ * window before the registry arrives (it avoids a flash of placeholder icons).
+ */
+export const FALLBACK_THUMBNAIL_TYPE_IDS: ReadonlySet<string> = new Set([
+  'image',
+  'video',
+  'document',
+  'audio',
+]);
+
+/**
+ * Process-wide cache of media-type capability metadata (the
+ * ``GET /api/media-types`` registry), so callers can answer "does this media
+ * type have a browsable thumbnail?" from the served ``has_thumbnail`` field
+ * instead of each reimplementing the ``{image, video, document, audio}`` set.
+ *
+ * A feature component that renders thumbnails calls {@link ensureLoaded} once
+ * (mirrors {@link EmbedderCapabilityService}); until the registry resolves (and
+ * if it fails to load) {@link usesThumbnails} answers from
+ * {@link FALLBACK_THUMBNAIL_TYPE_IDS} so behaviour is unchanged during the load
+ * window. The API service is resolved lazily inside {@link ensureLoaded} rather
+ * than injected in the constructor, so leaf components can read
+ * {@link usesThumbnails} without pulling ``HttpClient`` into their injector.
+ */
+@Injectable({ providedIn: 'root' })
+export class MediaTypeCapabilityService {
+  private readonly injector = inject(Injector);
+
+  /** Loaded media-type metadata, or ``null`` until the registry resolves. */
+  readonly infos = signal<MediaTypeInfo[] | null>(null);
+  private loading = false;
+
+  /** Type ids that have a browsable thumbnail: the served set once the registry
+   *  has loaded, or the fallback until then. */
+  private readonly thumbnailTypeIds = computed<ReadonlySet<string>>(() => {
+    const infos = this.infos();
+    if (!infos) return FALLBACK_THUMBNAIL_TYPE_IDS;
+    return new Set(infos.filter((m) => m.has_thumbnail === true).map((m) => m.type_id));
+  });
+
+  /** Kick off a one-time load of the media-type registry. Idempotent. */
+  ensureLoaded(): void {
+    if (this.infos() !== null || this.loading) return;
+    this.loading = true;
+    this.injector.get(DatasetsListingsApiService).getMediaTypes().subscribe({
+      next: (r) => {
+        this.infos.set(r.media_types ?? []);
+        this.loading = false;
+      },
+      error: () => {
+        this.infos.set([]);
+        this.loading = false;
+      },
+    });
+  }
+
+  /** True once the registry has resolved (success or failure). */
+  get loaded(): boolean {
+    return this.infos() !== null;
+  }
+
+  /**
+   * Whether items of *mediaType* have a browsable thumbnail — image/video/
+   * document tiles, or audio's waveform PNG. Data-driven from the served
+   * ``has_thumbnail`` field; falls back to {@link FALLBACK_THUMBNAIL_TYPE_IDS}
+   * until the registry loads so no thumbnail flashes to a placeholder. This is a
+   * pure read (no side effects); a feature component must call
+   * {@link ensureLoaded} for the served set to override the fallback.
+   */
+  usesThumbnails(mediaType: string): boolean {
+    return this.thumbnailTypeIds().has(mediaType);
+  }
+}


### PR DESCRIPTION
## Summary

The API and `MediaTypeInfo` already expose `has_thumbnail`, but the frontend still hardcoded the `{image, video, document, audio}` thumbnail-type set in several independent spots. This collapses them onto the served field, so a new thumbnail type now flips on from the backend `MediaType.has_thumbnail` capability with no frontend edit.

Closes #2368.

## What changed

- **New `MediaTypeCapabilityService`** (`providedIn: 'root'`, mirrors `EmbedderCapabilityService`) that caches the `GET /api/media-types` registry and answers `usesThumbnails(typeId)` from the served `has_thumbnail` field. It resolves the API service lazily (via `Injector`) so leaf components can read `usesThumbnails` without pulling `HttpClient` into their injector, and a feature component calls `ensureLoaded()` once. A single `FALLBACK_THUMBNAIL_TYPE_IDS` constant — the only hardcoded copy left — answers during the sub-second load window so no thumbnail flashes to a placeholder.

- **Collapsed every hardcoded set onto the service:**
  - `usesThumbnails` (removed from `hex-render.util.ts`) → `browse-view`, `browse-canvas`, `browse-bin-popup`
  - `THUMBNAIL_MEDIA_TYPES` (removed from `vote-grid.component.ts`) → `label-list`, `labelset-list`
  - per-item inline `hasThumbnailUrl` / `thumbnailUrl` checks → `browse-bin-popup`, `browse-selection-panel`, `media-item`
  - `settings-modal.browseTabUsesThumbnails` now reads `has_thumbnail` off the `MediaTypeInfo[]` it already loads (no redundant fetch).

- `ensureLoaded()` is triggered from the two HTTP-wired surfaces that host these components: `left-panel` (label/find view — covers the grid + right-panel label lists) and `browse-view` (covers the canvas, bin popup, and selection panel).

## Testing

- New `media-type-capability.service.spec.ts` covers the fallback-before-load behavior, data-driving from the served field (including a new served-only type), idempotent loading, and the error path.
- `./run-tests.sh frontend` — all 1471 Vitest tests pass; build, audit, ruff, pyright, OpenAPI, and screenshot-wiring gates green.
- `./run-tests.sh core` — 1081 Python tests pass (frontend build check included).

## Backwards compatibility

Behavior is unchanged for the current media types; the fallback set matches today's hardcoded set. A new backend thumbnail type is now picked up automatically once the registry loads.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HaQoYzjiQkMTGMN2ctT4cN)_