### PR TITLE
Vectorize region cosine sort in cosine_sort_with_boxes

### DIFF
--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -435,6 +435,7 @@ def _score_all_media(
     from vtscore.embedding.matrix import (  # noqa: PLC0415
         get_embedding_matrix_for_snap,
         get_region_matrix_for_snap,
+        segmented_max_pool,
     )
 
     resolved = embedder_name if embedder_name is not None else _score_embedder_for_snap(clips_dict)
@@ -468,45 +469,8 @@ def _score_all_media(
         # any real score (in ``[0, 1]``) for the same media.
         flat_scores = sigmoid_to_finite_array(model(X_all)).astype(np.float64, copy=False)
 
-    scores, best_region = _segmented_max_pool(flat_scores, media_index_per_row, region_index_per_row, len(all_ids))
+    scores, best_region = segmented_max_pool(flat_scores, media_index_per_row, region_index_per_row, len(all_ids))
     return all_ids, scores, best_region
-
-
-def _segmented_max_pool(
-    flat_scores: np.ndarray,
-    media_index_per_row: np.ndarray,
-    region_index_per_row: np.ndarray,
-    n_media: int,
-) -> tuple[list[float], list[int]]:
-    """Max-pool per-row scores down to one score + winning region per media.
-
-    *media_index_per_row* is non-decreasing and contiguous (every media owns
-    a single run of rows), and every media has at least one row, so each
-    media's rows form one ``reduceat`` segment.  Returns ``(scores,
-    best_region)`` as plain Python lists, where ``best_region[m]`` is the
-    region index of the *first* row achieving media ``m``'s max - matching
-    the strict-``>`` "first wins" tie-break of the original scalar loop.
-
-    Fully vectorised so the per-vote scoring tail holds the GIL for
-    microseconds rather than iterating hundreds of thousands of rows in
-    Python (which, in the background training thread, would stall the
-    ``gthread`` pool serving the next vote).
-    """
-    # Start of each media's contiguous run of rows.
-    seg_starts = np.searchsorted(media_index_per_row, np.arange(n_media))
-    seg_max = np.maximum.reduceat(flat_scores, seg_starts)
-
-    # First row per media that reaches its segment max (region 0 - the
-    # CLS/full-image node - is always row 0 of a segment, so an all-sentinel
-    # media resolves to region 0, exactly as the old -1.0-seeded loop did).
-    is_max = flat_scores >= seg_max[media_index_per_row]
-    cand_rows = np.flatnonzero(is_max)
-    cand_media = media_index_per_row[cand_rows]
-    first_cand = np.searchsorted(cand_media, np.arange(n_media))
-    winning_rows = cand_rows[first_cand]
-    best_region = region_index_per_row[winning_rows]
-
-    return seg_max.tolist(), best_region.tolist()
 
 
 def _format_results(

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -347,6 +347,47 @@ def get_region_matrix_for_snap(
     return list(sorted_ids), region_matrix, media_index, region_index
 
 
+def segmented_max_pool(
+    flat_scores: np.ndarray,
+    media_index_per_row: np.ndarray,
+    region_index_per_row: np.ndarray,
+    n_media: int,
+) -> tuple[list[float], list[int]]:
+    """Max-pool per-row scores down to one score + winning region per media.
+
+    Shared by the MLP scoring path (:func:`vtscore.detectors.training._score_all_media`)
+    and the region-aware cosine sort (:func:`vtscore.training.region_similarity.cosine_sort_with_boxes`),
+    both of which flatten every ``(media, region)`` pair into one ``(R,)`` score
+    vector (via :func:`get_region_matrix_for_snap`) and need to reduce it back to
+    one score + winning region index per media.
+
+    *media_index_per_row* is non-decreasing and contiguous (every media owns
+    a single run of rows), and every media has at least one row, so each
+    media's rows form one ``reduceat`` segment.  Returns ``(scores,
+    best_region)`` as plain Python lists, where ``best_region[m]`` is the
+    region index of the *first* row achieving media ``m``'s max - matching
+    the strict-``>`` "first wins" tie-break of the original scalar loop.
+
+    Fully vectorised so the scoring tail holds the GIL for microseconds
+    rather than iterating hundreds of thousands of rows in Python.
+    """
+    # Start of each media's contiguous run of rows.
+    seg_starts = np.searchsorted(media_index_per_row, np.arange(n_media))
+    seg_max = np.maximum.reduceat(flat_scores, seg_starts)
+
+    # First row per media that reaches its segment max (region 0 - the
+    # CLS/full-image node - is always row 0 of a segment, so an all-sentinel
+    # media resolves to region 0, exactly as the old -1.0-seeded loop did).
+    is_max = flat_scores >= seg_max[media_index_per_row]
+    cand_rows = np.flatnonzero(is_max)
+    cand_media = media_index_per_row[cand_rows]
+    first_cand = np.searchsorted(cand_media, np.arange(n_media))
+    winning_rows = cand_rows[first_cand]
+    best_region = region_index_per_row[winning_rows]
+
+    return seg_max.tolist(), best_region.tolist()
+
+
 def get_embedding_matrix_for_snap(
     snap: dict,
     embedder_name: str | None = None,

--- a/vtscore/training/region_similarity.py
+++ b/vtscore/training/region_similarity.py
@@ -157,9 +157,7 @@ def cosine_sort_with_boxes(
         # stable; region rows and the query are both unit-norm, so the matvec
         # is the cosine similarity of each region against the query.
         flat_sims = (region_matrix @ query_vec).astype(np.float64, copy=False)
-        scores, best_region = segmented_max_pool(
-            flat_sims, media_index_per_row, region_index_per_row, len(all_ids)
-        )
+        scores, best_region = segmented_max_pool(flat_sims, media_index_per_row, region_index_per_row, len(all_ids))
         region_results: list[dict[str, Any]] = []
         for cid, sim, bri in zip(all_ids, scores, best_region, strict=True):
             entry: dict[str, Any] = {"id": cid, "similarity": round(sim, 4)}

--- a/vtscore/training/region_similarity.py
+++ b/vtscore/training/region_similarity.py
@@ -125,26 +125,55 @@ def cosine_sort_with_boxes(
 
     Performance: zero overhead for legacy single-vector snapshots - we
     detect them via :func:`_snapshot_has_patch_regions` and take the
-    fast vectorised numpy path.  Patch-region snapshots iterate per-
-    media and are O(N · K) where K is the per-image region count
-    (typically 23).
+    fast vectorised numpy path.  Patch-region snapshots flatten every
+    ``(media, region)`` pair into one ``(R, D)`` matrix (cached on the
+    dataset context) and score them with a single matvec + segmented
+    max-pool, so the whole snapshot is one BLAS call rather than N·K
+    interpreter round-trips (K ~ the per-image region count, typically 23).
     """
     if not snap:
         return [], []
 
     use_regions = _snapshot_has_patch_regions(snap) if region_aware is None else region_aware
     if use_regions and _snapshot_has_patch_regions(snap):
-        results: list[dict] = []
-        sims: list[float] = []
-        for cid, m in snap.items():
-            sim, box = score_against_query(m, query_vec, embedder_name)
-            entry = {"id": cid, "similarity": round(sim, 4)}
-            if box is not None:
-                entry["best_region"] = list(box)
-            results.append(entry)
-            sims.append(sim)
-        results.sort(key=lambda x: x["similarity"], reverse=True)
-        return results, sims
+        # Vectorised mirror of the MLP scoring path (``_score_all_media``):
+        # flatten every (media, region) pair into one (R, D) matrix, take a
+        # single matvec against the query, then segment-max-pool back down to
+        # one score + winning region per media.  Replaces the per-media,
+        # per-region Python loop that made this O(N·K) in interpreter
+        # round-trips on a user-facing sort.
+        from vtscore.embedding.matrix import get_region_matrix_for_snap, segmented_max_pool  # noqa: PLC0415
+
+        # A zero/degenerate query dots to 0 everywhere; preserve the old
+        # ``score_against_query`` behaviour of scoring 0 with no best_region.
+        if float(np.linalg.norm(query_vec)) == 0:
+            zero_results: list[dict[str, Any]] = [{"id": cid, "similarity": 0.0} for cid in snap]
+            return zero_results, [0.0] * len(snap)
+
+        all_ids, region_matrix, media_index_per_row, region_index_per_row = get_region_matrix_for_snap(snap)
+        if not all_ids:
+            return [], []
+        # float64 matches the MLP path's max-pool dtype and keeps round(.,4)
+        # stable; region rows and the query are both unit-norm, so the matvec
+        # is the cosine similarity of each region against the query.
+        flat_sims = (region_matrix @ query_vec).astype(np.float64, copy=False)
+        scores, best_region = segmented_max_pool(
+            flat_sims, media_index_per_row, region_index_per_row, len(all_ids)
+        )
+        region_results: list[dict[str, Any]] = []
+        for cid, sim, bri in zip(all_ids, scores, best_region, strict=True):
+            entry: dict[str, Any] = {"id": cid, "similarity": round(sim, 4)}
+            regions = snap[cid].get("patch_regions")
+            if regions and 0 <= bri < len(regions):
+                entry["best_region"] = list(regions[bri].box)
+            else:
+                # Region-less media in a region-aware snapshot: the winning
+                # "region" is the full-image vector, so its box is the whole
+                # image - matching the legacy per-media path's (0, 0, 1, 1).
+                entry["best_region"] = [0.0, 0.0, 1.0, 1.0]
+            region_results.append(entry)
+        region_results.sort(key=lambda x: x["similarity"], reverse=True)
+        return region_results, scores
 
     # Fast path: pure single-vector cosine via one matrix-vector product.
     # Both the stored embeddings and *query_vec* are unit-norm (normalized


### PR DESCRIPTION
## Summary

The region branch of `cosine_sort_with_boxes` (`vtscore/training/region_similarity.py`) scored patch datasets (DINOv2/DINOv3/EUPE) with a nested Python loop: `score_against_query` did `np.asarray(r.vec)` + a scalar dot **per region**, called **per media** from the snapshot loop. At Find scale (~250k media × ~23 regions ≈ millions of interpreter round-trips) that dominated a user-facing sort.

The MLP scoring path already solved the identical problem. This change makes the region branch a vectorised mirror of `_score_all_media`, with the MLP forward replaced by a matvec:

1. `get_region_matrix_for_snap(snap)` → `(all_ids, region_matrix, media_index_per_row, region_index_per_row)` — the flattened `(R, D)` region matrix, cached on the dataset context.
2. `sims = region_matrix @ query_vec` — one BLAS call for every `(media, region)` row (region rows and the query are both unit-norm, so the matvec *is* cosine similarity).
3. `segmented_max_pool(...)` → per-media max + winning region index, with the same first-wins tie-break as the old scalar loop.

So the whole snapshot becomes one matvec + one segmented reduction instead of N·K interpreter round-trips. Zero change on single-vector datasets (they keep the existing fast path).

## Shared helper

`_segmented_max_pool` was private to `vtscore/detectors/training.py`, but both scoring paths now need it. It moved to `vtscore/embedding/matrix.py` as `segmented_max_pool` (both paths already import from `matrix.py`), which also sidesteps any `training.py` ↔ `region_similarity.py` import cycle. `training.py` imports it from there.

## Behavior preserved

- `round(sim, 4)` on the emitted similarity; float64 max-pool dtype matches the MLP path.
- Region-less media in a region-aware snapshot still get the full-image `(0, 0, 1, 1)` box (matching the legacy per-media path, and keeping `test_patch_path_emits_best_region_field` green).
- First-wins tie-break on equal region scores.
- Zero/degenerate query short-circuits to all-zero scores with no `best_region`.
- The returned similarity list still feeds GMM thresholding (order-independent).

## Testing

`./run-tests.sh` — all 6205 tests pass (1 skipped). Region-specific coverage in `tests/detectors/test_patch_embedder.py` and `tests_lib/detectors/test_region_similarity_routing.py`.

Closes #2396
