### PR TITLE
Narrow importer run() spec-error swallow to MissingMediaTypeError

### DIFF
--- a/tests_lib/io/test_importer_base_errors.py
+++ b/tests_lib/io/test_importer_base_errors.py
@@ -228,9 +228,7 @@ class TestRunPropagatesSpecValueError:
             def fetch_source_media(self, spec, field_values, thin=False):
                 yield {"filename": "unreached.png", "media_bytes": b"X"}
 
-        source_specs = json.dumps(
-            [{"source_type": "video", "converter": "no_such_converter", "params": {}}]
-        )
+        source_specs = json.dumps([{"source_type": "video", "converter": "no_such_converter", "params": {}}])
         with pytest.raises(ValueError, match="Unknown converter"):
             _SpecOnly().run({"media_type": "image", "source_specs": source_specs}, {})
 

--- a/tests_lib/io/test_importer_base_errors.py
+++ b/tests_lib/io/test_importer_base_errors.py
@@ -9,8 +9,9 @@ themes that had no coverage:
 
 - **Bad params** — the ``NotImplementedError`` "you forgot to override this"
   surfaces, the ``_ingest_spec_stream`` unknown-converter guard, and the
-  ``run()`` fallback that swallows a ``ValueError`` from
-  ``effective_source_specs``.
+  ``run()`` fallback that swallows only :class:`MissingMediaTypeError` from
+  ``effective_source_specs`` while propagating every other validation
+  ``ValueError``.
 - **Partial-batch failures** — ``None`` raw pairs and ``None`` converter
   outputs are skipped mid-stream without disturbing the IDs of the survivors.
 - **Cancellation propagation** — a :class:`CancelledError` raised from any
@@ -161,23 +162,24 @@ class TestIngestSpecStreamBadConverter:
 
 
 # ---------------------------------------------------------------------------
-# Bad params: run() swallows ValueError from effective_source_specs
+# Bad params: run() swallows only MissingMediaTypeError, propagates the rest
 # ---------------------------------------------------------------------------
 
 
-class TestRunSwallowsSpecValueError:
-    """``run`` catches ``ValueError`` from ``effective_source_specs`` and falls
-    back to the per-record path.  This is *why* a malformed ``source_specs``
-    value surfaces as a confusing ``list_records`` NotImplementedError instead
-    of a "bad source_specs" message — a characterization test that pins the
-    fallback branch so a regression there is caught at the base level.
+class TestRunPropagatesSpecValueError:
+    """``run`` swallows only :class:`MissingMediaTypeError` (the legitimate
+    "no ``media_type`` declared" fallback trigger); every *other* ``ValueError``
+    from ``effective_source_specs`` — signalling genuinely bad ``source_specs``
+    input — propagates to the caller with its original message instead of being
+    masked by a confusing ``list_records`` ``NotImplementedError``.
     """
 
-    def test_invalid_source_specs_json_falls_back_to_list_records(self):
+    def test_invalid_source_specs_json_propagates(self):
         # Only fetch_source_media is implemented (the spec path); no
         # list_records.  A bad source_specs value makes effective_source_specs
-        # raise ValueError, which run() swallows → fallback → list_records
-        # NotImplementedError.
+        # raise a plain ValueError (not MissingMediaTypeError), which run() now
+        # lets propagate with its real "Invalid source_specs JSON" message —
+        # not the old confusing list_records NotImplementedError.
         class _SpecOnly(DatasetImporter):
             name = "spec_only"
             display_name = "Spec Only"
@@ -188,8 +190,49 @@ class TestRunSwallowsSpecValueError:
                 yield {"filename": "unreached.png", "media_bytes": b"X"}
 
         imp = _SpecOnly()
-        with pytest.raises(NotImplementedError, match="list_records"):
+        with pytest.raises(ValueError, match="Invalid source_specs JSON") as exc:
             imp.run({"media_type": "image", "source_specs": "{not valid json"}, {})
+        # The real cause surfaces, not a NotImplementedError from the fallback.
+        assert not isinstance(exc.value, NotImplementedError)
+
+    def test_missing_media_type_still_falls_back_to_list_records(self):
+        """The one legitimate swallow: no ``media_type`` → per-record fallback.
+
+        A spec-only importer with no ``media_type`` field still routes to the
+        ``list_records`` path, so its unimplemented ``list_records`` surfaces —
+        confirming :class:`MissingMediaTypeError` alone triggers the fallback.
+        """
+
+        class _SpecOnly(DatasetImporter):
+            name = "spec_only_no_mt"
+            display_name = "Spec Only"
+            description = "."
+            fields: list[PluginField] = []  # no media_type → MissingMediaTypeError
+
+            def fetch_source_media(self, spec, field_values, thin=False):
+                yield {"filename": "unreached.png", "media_bytes": b"X"}
+
+        imp = _SpecOnly()
+        with pytest.raises(NotImplementedError, match="list_records"):
+            imp.run({}, {})
+
+    def test_unknown_converter_propagates(self):
+        """A genuinely invalid converter reference surfaces its real message."""
+
+        class _SpecOnly(DatasetImporter):
+            name = "spec_only_bad_conv"
+            display_name = "Spec Only"
+            description = "."
+            fields = [_media_type_field()]
+
+            def fetch_source_media(self, spec, field_values, thin=False):
+                yield {"filename": "unreached.png", "media_bytes": b"X"}
+
+        source_specs = json.dumps(
+            [{"source_type": "video", "converter": "no_such_converter", "params": {}}]
+        )
+        with pytest.raises(ValueError, match="Unknown converter"):
+            _SpecOnly().run({"media_type": "image", "source_specs": source_specs}, {})
 
     def test_non_value_error_is_not_swallowed(self):
         """Only ``ValueError`` is caught; any other error from

--- a/vtscore/datasets/importers/base/__init__.py
+++ b/vtscore/datasets/importers/base/__init__.py
@@ -75,12 +75,13 @@ from vtscore.plugins import PluginField
 from .core import ImporterBase
 from .dataset_importer import DatasetImporter
 from .origin import DATASET_NAME_FIELD_KEY
-from .specs import PickerView, SourceSpec
+from .specs import MissingMediaTypeError, PickerView, SourceSpec
 
 __all__ = [
     "DATASET_NAME_FIELD_KEY",
     "DatasetImporter",
     "ImporterBase",
+    "MissingMediaTypeError",
     "PickerView",
     "PluginField",
     "SourceSpec",

--- a/vtscore/datasets/importers/base/dataset_importer.py
+++ b/vtscore/datasets/importers/base/dataset_importer.py
@@ -13,7 +13,12 @@ from __future__ import annotations
 from typing import Any, Iterator
 
 from .core import ImporterBase
-from .specs import SourceSpec, _fill_converter_output_fields, _parse_multi_media_specs
+from .specs import (
+    MissingMediaTypeError,
+    SourceSpec,
+    _fill_converter_output_fields,
+    _parse_multi_media_specs,
+)
 
 
 class DatasetImporter(ImporterBase):
@@ -111,6 +116,13 @@ class DatasetImporter(ImporterBase):
                 :meth:`fetch_all_source_media`, :meth:`fetch_source_media`,
                 or the :meth:`list_records` + :meth:`fetch_record` hooks are
                 implemented by the subclass.
+            ValueError: If ``source_specs`` is genuinely invalid (bad JSON,
+                a non-object entry, an unknown source_type or converter, a
+                converter that does not bridge source→output, or bad
+                converter params).  Only :class:`MissingMediaTypeError` — the
+                "no ``media_type`` declared" subtype — is swallowed to trigger
+                the per-record fallback; every other validation ``ValueError``
+                propagates with its original message.
             Exception: Any exception propagates to the route handler, which
                 stores it in the progress tracker as an error message.
         """
@@ -119,7 +131,12 @@ class DatasetImporter(ImporterBase):
 
         try:
             specs = self.effective_source_specs(field_values)
-        except ValueError:
+        except MissingMediaTypeError:
+            # Legitimate "bare service importer" case: no output media_type
+            # declared, so fall through to the per-record hooks below.  Any
+            # *other* ValueError (bad JSON, unknown source_type/converter,
+            # mismatched converter, bad params) is genuine invalid input and
+            # propagates to the user with its original message.
             specs = []
 
         if specs:

--- a/vtscore/datasets/importers/base/specs.py
+++ b/vtscore/datasets/importers/base/specs.py
@@ -18,7 +18,25 @@ import json
 from dataclasses import dataclass, field as dc_field
 from typing import Any
 
-__all__ = ["SourceSpec", "PickerView"]
+__all__ = ["SourceSpec", "PickerView", "MissingMediaTypeError"]
+
+
+class MissingMediaTypeError(ValueError):
+    """The import declares no output ``media_type`` field.
+
+    Distinct from the other :class:`ValueError`\\ s raised while parsing
+    ``source_specs`` (bad JSON, unknown source_type/converter, mismatched
+    converter, bad params), which all signal genuinely *invalid* user input.
+    This one signals the *legitimate* "bare service importer" case, where
+    :meth:`DatasetImporter.run` should fall through to the per-record
+    (``list_records`` / ``fetch_record``) path.  ``run`` catches only this
+    subtype so real validation errors propagate to the user with their
+    original message instead of being masked by a confusing
+    ``NotImplementedError`` from the fallback path.
+
+    It remains a :class:`ValueError` so existing ``except ValueError``
+    validation call sites keep treating it as one.
+    """
 
 
 @dataclass
@@ -81,7 +99,7 @@ def _parse_multi_media_specs(raw: Any, output_type: str) -> list[SourceSpec]:
         specs_raw = list(raw)
 
     if not output_type:
-        raise ValueError("import requires a 'media_type' (output) field")
+        raise MissingMediaTypeError("import requires a 'media_type' (output) field")
 
     if not specs_raw:
         specs_raw = [{"source_type": output_type, "converter": None, "params": {}}]


### PR DESCRIPTION
## Summary

`DatasetImporter.run()` wrapped `effective_source_specs()` in a bare `except ValueError`, swallowing **every** validation error a malformed `source_specs` value produces and silently rerouting to the per-record path. Only one of the nine `ValueError` sites in `_parse_multi_media_specs` is a legitimate fallback trigger — the "no output `media_type` declared" case; the other eight (bad JSON, non-object entry, unknown `source_type`/converter, source/output mismatch, converter source/target mismatch, bad converter params) signal genuinely invalid input.

Under the old behavior:
- A **spec-only** importer with bad `source_specs` surfaced the misleading `NotImplementedError: list_records() is not implemented` (the #2415 "base regression → confusing subclass failure" pattern).
- A **`list_records`-bearing** importer silently ignored the bad specs and ran the wrong path with no error at all.

## Change (Option A: sentinel subtype)

- Add `MissingMediaTypeError(ValueError)` in `specs.py`, raised only by the legitimate no-`media_type` case, and exported from `vtscore.datasets.importers.base`.
- `run()` now catches **only** `MissingMediaTypeError` for the per-record fallback; every other validation `ValueError` propagates to the user with its original message.
- The no-`media_type` fallback for bare service importers is unchanged (still routes to `list_records`/`fetch_record`).
- Because it remains a `ValueError` subclass, existing `except ValueError` validation call sites are unaffected.

## Tests

Updated the #2434 characterization test (`TestRunSwallowsSpecValueError` → `TestRunPropagatesSpecValueError`) to pin the new contract:
- bad JSON now propagates `ValueError("Invalid source_specs JSON…")` (not `NotImplementedError`);
- an unknown converter propagates `ValueError("Unknown converter…")`;
- a missing `media_type` still falls back to `list_records`.

Full suite green: 6207 passed, 1 skipped.

Closes #2437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8Rv38FVrwBcaUzz7A3i3P)_