### PR TITLE
Self-heal stale signpost label sets on labeler_signature mismatch

### DIFF
--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -1014,6 +1014,78 @@ class TestPersistedLabelRestore:
         body = self._serve(client, monkeypatch, tmp_path, stored_id="some-old-layout", stored_sig="sig-v1")
         assert body["labels"] == []
 
+    def test_stale_signature_kicks_background_relabel(self, client, monkeypatch, tmp_path):
+        # A persisted set whose signature no longer matches the active pipeline
+        # is served absent, but a background rebuild is kicked so the signs
+        # self-heal to the active labeler without a forced Re-project (#2404).
+        import threading
+
+        from vtscore.concurrency.async_jobs import signpost_relabel_jobs
+        from vtscore.projection import RegionLabel, make_label_set
+
+        ctx = get_active_context()
+        rebuilt = make_label_set(
+            "live-layout",
+            [RegionLabel(level=0, x=0.0, y=0.0, text="rebuilt sign", score=0.5, source="keyphrase")],
+        )
+
+        started = threading.Event()
+        proceed = threading.Event()
+
+        def _fake_prep(c, proj, *, subset, on_progress=None):
+            # Block until the test has observed the interim (unlettered) serve,
+            # then install the rebuilt signs exactly as the real pipeline does.
+            started.set()
+            assert proceed.wait(timeout=5)
+            c._region_labels = rebuilt
+            return rebuilt
+
+        monkeypatch.setattr("vtscore.projection.signpost_prep.prep_signposts", _fake_prep)
+
+        # First serve: stale set detected → absent now, rebuild kicked.
+        body = self._serve(
+            client, monkeypatch, tmp_path, stored_id="live-layout", stored_sig="sig-old", active_sig="sig-new"
+        )
+        assert body["labels"] == []
+        job_id = ctx._relabel_job_id
+        assert job_id
+        assert started.wait(timeout=5)
+
+        # A second poll while the rebuild is in flight coalesces onto the same
+        # job instead of queueing another.
+        assert client.get("/api/projection/labels").get_json()["labels"] == []
+        assert ctx._relabel_job_id == job_id
+        assert len(signpost_relabel_jobs.active_jobs()) == 1
+
+        # Let the rebuild finish; the signs self-heal on the next serve.
+        proceed.set()
+        job = signpost_relabel_jobs.get(job_id)
+        assert job is not None
+        assert job.done_event.wait(timeout=10)
+
+        body = client.get("/api/projection/labels").get_json()
+        assert [lab["text"] for lab in body["labels"]] == ["rebuilt sign"]
+        assert client.get("/api/projection/meta").get_json()["has_labels"] is True
+
+    def test_relabel_not_kicked_without_projection(self, client, monkeypatch, tmp_path):
+        # The kick needs the frozen layout in hand; a stale set with no live
+        # projection just serves absent (no crash, no job).
+        from vtscore.concurrency.async_jobs import signpost_relabel_jobs
+
+        ctx = get_active_context()
+        pkl = self._persist(tmp_path, "live-layout", "sig-old")
+        monkeypatch.setattr("vtsearch.routes.projection._pkl_path_for", lambda dataset_id: str(pkl))
+        monkeypatch.setattr("vtscore.projection.signpost_prep.labeler_signature", lambda ctx: "sig-new")
+
+        proj, pyr = TestProjectionLabels._build_hex_pyramid("live-layout")
+        ctx._pyramids = {"hex": pyr}
+        ctx._projection = None  # layout not resolved into the context
+
+        body = client.get("/api/projection/labels").get_json()
+        assert body["labels"] == []
+        assert ctx._relabel_job_id is None
+        assert signpost_relabel_jobs.active_jobs() == []
+
 
 class TestDemoSignpostsLazyBuild:
     """Ground-truth signposts derived on demand from hierarchical categories.

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -472,6 +472,16 @@ labeling_status_jobs = JobManager("labeling-status")
 #: Background runner for ``/api/projection/build`` (VTSBrowse UMAP + pyramid).
 projection_jobs = JobManager("projection")
 
+#: Background runner that rebuilds a persisted signpost label set whose
+#: ``labeler_signature`` no longer matches the active pipeline (issue #2404).
+#: Kicked from the projection serve path when it detects the mismatch, so stale
+#: signs self-heal without a forced Re-project.  Kept on its own single slot so
+#: a self-heal never queues behind (or delays) a user-visible UMAP build in
+#: ``projection_jobs``.  Like ``labeling_status_jobs`` it is an internal
+#: refresh, not a user-visible training job, so it is intentionally absent from
+#: ``JOB_MANAGERS`` below (no ``/api/jobs/active`` spinner).
+signpost_relabel_jobs = JobManager("signpost-relabel")
+
 #: Logical name → :class:`JobManager` lookup used by ``/api/jobs/active`` to
 #: enumerate which (dataset_id, detector_id) pairs currently have background
 #: work in flight. The string keys are the public job-type names exposed in
@@ -510,6 +520,7 @@ def reset_all_async_jobs_for_tests() -> None:
     """Reset every singleton job manager.  Called from the autouse fixture."""
     for mgr in JOB_MANAGERS.values():
         mgr.reset_for_tests()
-    # Not in ``JOB_MANAGERS`` (it is deliberately hidden from
-    # ``/api/jobs/active``), so reset it explicitly for test isolation.
+    # Not in ``JOB_MANAGERS`` (they are deliberately hidden from
+    # ``/api/jobs/active``), so reset them explicitly for test isolation.
     labeling_status_jobs.reset_for_tests()
+    signpost_relabel_jobs.reset_for_tests()

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -398,6 +398,13 @@ class DatasetContext:
         # refuses to serve it over a different layout — so a stale set is
         # inert, never wrong.  Text + 2-D anchors only, no vectors.
         "_region_labels",
+        # In-flight background relabel job id (issue #2404).  When the serve
+        # path finds a persisted label set whose ``labeler_signature`` no
+        # longer matches the active pipeline, it kicks a background rebuild so
+        # the stale signs self-heal; this tracks that job so repeated polls
+        # coalesce onto the one rebuild instead of queueing a fresh one each
+        # time.  Shares the ``signpost_relabel_jobs`` runner across datasets.
+        "_relabel_job_id",
         # VTSBrowse subset projection: an ephemeral UMAP fit over just a subset
         # of this dataset's media ids (e.g. the positives of a Find run),
         # computed on demand and never persisted.  Held alongside the full
@@ -454,6 +461,7 @@ class DatasetContext:
         self._pyramids: dict[str, Any] = {}  # bin_shape -> Pyramid
         self._full_job_id: str | None = None  # in-flight full-dataset build job id
         self._region_labels: Any = None  # RegionLabelSet | None (signposts, full layout)
+        self._relabel_job_id: str | None = None  # in-flight signpost-relabel job id (#2404)
         self._subset_projection: Any = None  # Projection | None (ephemeral subset UMAP)
         self._subset_pyramids: dict[str, Any] = {}  # bin_shape -> Pyramid (subset)
         self._subset_ids: list[int] | None = None  # sorted ids the subset layout is fit on

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -119,6 +119,13 @@ def _label_set_for(ctx, pyr, *, subset: bool):
     if subset:
         ctx._subset_region_labels = built
     else:
+        # A background relabel (issue #2404) or build job may have installed a
+        # matching set on ``_region_labels`` while we were resolving the
+        # fallback; don't clobber it with a derived/empty stand-in — the
+        # freshly-built signs already match this layout and are strictly better.
+        current = ctx._region_labels
+        if current is not None and current.projection_id == pyr.projection_id:
+            return current
         ctx._region_labels = built
     if built is None or built.projection_id != pyr.projection_id:
         return None
@@ -131,8 +138,12 @@ def _maybe_load_persisted_labels(ctx, pyr):
     Served only over the exact layout they were computed from
     (``projection_id`` match), and only while their labeler signature still
     matches what the active pipeline would produce — a changed provider,
-    embedder, or toponymy version makes them stale (recomputing stale labels
-    lazily is a planned follow-up; until then they're treated as absent).
+    embedder, or toponymy version makes them stale.  On a stale set we kick a
+    background rebuild (:func:`_kick_relabel_if_idle`) so the signs self-heal
+    to the active pipeline without a forced Re-project (issue #2404), and treat
+    the stale set as absent meanwhile — the map goes briefly unlettered rather
+    than serving signs the active labeler would no longer produce.
+
     When the active pipeline can't label this dataset at all (e.g. toponymy
     isn't installed here), a persisted set is still served: it's derived text
     pinned to the right layout, strictly better than nothing.
@@ -152,8 +163,52 @@ def _maybe_load_persisted_labels(ctx, pyr):
 
     active = labeler_signature(ctx)
     if active is not None and active != stored_signature:
+        _kick_relabel_if_idle(ctx, pyr)
         return None
     return label_set
+
+
+def _kick_relabel_if_idle(ctx, pyr) -> None:
+    """Rebuild a stale persisted label set in the background (issue #2404).
+
+    A persisted set whose ``labeler_signature`` no longer matches the active
+    pipeline is served as absent, but nothing re-runs the labeler while the
+    layout stays cached/persisted — only a forced Re-project re-letters the
+    map.  This kicks a best-effort background job that re-fits the signs over
+    the frozen full-dataset layout and re-persists them under the current
+    signature, so the stale signs self-heal on an ordinary Browse.
+
+    Coalescing: repeated meta/labels polls all land here until the rebuild
+    lands, so a job already in flight for this context short-circuits — one
+    rebuild per stale layout, not one per poll.  Best-effort throughout: a
+    missing projection or a labeling failure just leaves the map unlettered.
+    """
+    proj = ctx._projection
+    if proj is None or proj.projection_id != pyr.projection_id:
+        return
+
+    from vtscore.concurrency.async_jobs import signpost_relabel_jobs
+
+    job_id = ctx._relabel_job_id
+    if job_id:
+        existing = signpost_relabel_jobs.get(job_id)
+        if existing is not None and existing.status in ("running", "pending"):
+            return
+
+    def _run(job):
+        # Runs on the relabel runner's worker thread, which the JobManager has
+        # already bound to this dataset's context.  ``prep_signposts`` (inside
+        # the best-effort wrapper) re-fits the signs, caches them on
+        # ``ctx._region_labels``, and re-persists them under the active
+        # signature — overwriting the empty interim the serve path cached.
+        _prep_signposts_best_effort(ctx, proj, job, subset=False)
+
+    job = signpost_relabel_jobs.start(
+        (ctx.dataset_id, "relabel", proj.projection_id),
+        _run,
+        dataset_id=ctx.dataset_id,
+    )
+    ctx._relabel_job_id = job.job_id
 
 
 def _maybe_build_demo_signposts(proj, pyr, medias):


### PR DESCRIPTION
## Summary

A persisted region-label set whose `labeler_signature` no longer matches the active pipeline (a changed text provider, embedder, or toponymy version) was served as absent — but nothing rebuilt it. Because the build job won't rerun while the pyramid stays cached/persisted, only a forced **Re-project** re-lettered the map.

This teaches the projection **serve path** to self-heal: when `_maybe_load_persisted_labels` detects a signature mismatch, it kicks a best-effort background relabel job that re-fits the signs over the frozen full-dataset layout and re-persists them under the current signature. The stale signs now heal on an ordinary Browse, no manual Re-project required.

## Changes

- **`vtscore/concurrency/async_jobs.py`** — new `signpost_relabel_jobs` `JobManager`, on its own single slot so a self-heal never queues behind (or delays) a user-visible UMAP build in `projection_jobs`. Like `labeling_status_jobs` it's an internal refresh, so it's deliberately absent from `JOB_MANAGERS` (no `/api/jobs/active` spinner) and reset explicitly for test isolation.
- **`vtsearch/routes/projection.py`** — `_maybe_load_persisted_labels` calls the new `_kick_relabel_if_idle` on a stale set (still serving absent meanwhile). The kick reuses `_prep_signposts_best_effort` over the cached layout and coalesces: repeated meta/labels polls short-circuit onto the one in-flight rebuild (tracked by a per-context `_relabel_job_id`) instead of queueing a job per poll.
- **`_label_set_for`** — before caching a derived/empty fallback into `_region_labels`, it re-checks for a matching set a concurrent relabel/build job may have just installed, so the background job's fresh signs are never clobbered by an interim stand-in.
- **`vtscore/state/core.py`** — new `_relabel_job_id` context slot.

## Behaviour notes

- Best-effort throughout: a missing projection, no toponymy install, or a labeling failure just leaves the map unlettered — never broken.
- A failed relabel isn't retried until the layout changes (consistent with the existing empty-fallback caching), so a poll storm can't spin the labeler.
- A persisted set is still served unconditionally when the active pipeline can't label the dataset at all (`labeler_signature` is `None`) — that path is unchanged.

## Tests

Added `TestPersistedLabelRestore::test_stale_signature_kicks_background_relabel` (deterministic via a blocking fake `prep_signposts`): stale set serves absent, one rebuild is kicked, a concurrent poll coalesces onto it, and the signs self-heal on the next serve. Also `test_relabel_not_kicked_without_projection` for the no-layout guard. Full suite green (6207 passed).

Closes #2404
