### PR TITLE
Fix stale importer form leaking into empty category tabs

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -120,7 +120,7 @@
   </vt-source-picker>
 
   <vt-generic-form-picker
-    [hidden]="activePickerView === 'demo' || activePickerView === 'local_folder' || activePickerView === 'local_files' || activePickerView === 'server_folder'"
+    [hidden]="!selectedImporter() || activePickerView === 'demo' || activePickerView === 'local_folder' || activePickerView === 'local_files' || activePickerView === 'server_folder'"
     [importers]="importers()"
     [mediaTypes]="mediaTypes()"
     [guessedMediaType]="guessedMediaType"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -259,6 +259,30 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.importersForActiveTab.length).toBe(0);
   });
 
+  it('should not leak a stale generic form into an empty category tab', async () => {
+    flushImporters();
+    // Open a generic-form importer so the (always-mounted) generic form
+    // picker holds a form for it.
+    component.selectImporter(genericForm());
+    httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
+    httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
+    await settleZoneless(fixture);
+    const el = fixture.nativeElement as HTMLElement;
+    const formPicker = el.querySelector('vt-generic-form-picker') as HTMLElement;
+    expect((formPicker as HTMLElement & { hidden: boolean }).hidden).toBe(false);
+
+    // Switch to the empty Services category: nothing is selected, so the
+    // generic form picker (which still carries the previous importer's form)
+    // must be hidden rather than leaking that stale form below the empty
+    // "No importers in this category." message.
+    component.selectImporterTab('services');
+    expect(component.selectedImporter()).toBeNull();
+    await settleZoneless(fixture);
+    expect((formPicker as HTMLElement & { hidden: boolean }).hidden).toBe(true);
+    const emptyState = el.querySelector('.empty-state--inline');
+    expect((emptyState?.textContent || '').trim()).toBe('No importers in this category.');
+  });
+
   describe('solo media-type filtering', () => {
     // A type-scoped importer (only produces image/video) sitting in its own
     // category, plus the always-agnostic Local folder/files pair.


### PR DESCRIPTION
## Problem

In the Add Dataset modal, selecting a category tab with no importers — most visibly the **Services** tab, which is intentionally kept visible even when empty so extension importers have a home — showed the "No importers in this category." message *and also* a random leftover importer form below it (e.g. the Manifest importer). Per #2485, the empty message alone is what should show.

## Cause

The generic form picker (`vt-generic-form-picker`) stays mounted for the modal's lifetime and is toggled with `[hidden]`. Its hidden condition only covered the four special picker views (`demo` / `local_folder` / `local_files` / `server_folder`). When an importer-less category is selected, `selectedImporter()` is `null` and `activePickerView` is `''`, which matched none of those views — so the picker stayed visible, still rendering whatever generic-form importer was last opened.

## Fix

Add `!selectedImporter()` to the `[hidden]` condition so the generic form picker is hidden whenever nothing is selected. The empty tab now shows only its "No importers in this category." message. The footer buttons were already guarded with `&& selectedImporter()`, so this brings the picker body in line with them.

Added a regression test that opens a generic-form importer, switches to the empty Services tab, and asserts the form picker becomes `hidden` while the empty-state message is the only content shown.

Closes #2485

---
_Generated by [Claude Code](https://claude.ai/code/session_01MATzfJ9C9K2PhjBJb2UJdZ)_