### PR TITLE
Fold "Archive members (no extract)" importer into the Manifest tab

### DIFF
--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -179,25 +179,25 @@ Some corpora are too large to unpack. WebDataset-style collections pack
 tens of thousands of audio/video chunks inside a handful of multi-GB
 `shard_*.tar` (or `.zip`) files - the multivent-raw `videos/` set alone
 is **4.1 TB across 667 shards** - so extracting a second on-disk copy
-is a non-starter. The **Server → Archive members (no extract)** importer
-(📦 in the importer picker) loads a chosen subset of those chunks
-**without unpacking anything**: each imported media records only
-`{archive path, member name}` and streams that single tar/zip member on
-demand (HTTP Range), so playing a clip transfers a few seconds of bytes
-rather than the whole shard. Nothing is written to disk, and no member
-data is read at import time - the importer only walks each referenced
-shard's tar headers to confirm the member exists and record its size.
+is a non-starter. The **Files → Manifest** importer handles this case too:
+point its *Paths file* field at a `.npz` that references members inside
+tar/zip shards, and VTSearch loads a chosen subset of those chunks
+**without unpacking anything**. The importer auto-detects the archive-member
+shape (a manifest with a `members` array) and switches to the
+no-extraction path - there is no separate tab or mode to pick. Each
+imported media records only `{archive path, member name}` and streams that
+single tar/zip member on demand (HTTP Range), so playing a clip transfers a
+few seconds of bytes rather than the whole shard. Nothing is written to
+disk, and no member data is read at import time - the importer only walks
+each referenced shard's tar headers to confirm the member exists and record
+its size.
 
-The importer has two fields:
+Set the *Dataset MediaType* to the kind of media the referenced members
+hold (e.g. `video` or `audio`). Because the manifest supplies the
+embeddings, the import needs no GPU and skips the embed stage entirely.
 
-- **Dataset MediaType** - the kind of media the referenced members hold
-  (e.g. `video` or `audio`).
-- **Manifest (.npz)** - a server-path field pointing at a single `.npz`
-  manifest that pairs the chosen members with their **pre-computed**
-  vectors. Because the embeddings are supplied, the import needs no GPU
-  and skips the embed stage entirely.
-
-**Manifest schema.** The `.npz` holds these arrays, one entry per row:
+**Manifest schema.** The archive-member `.npz` holds these arrays, one
+entry per row:
 
 | Array | Shape | Required | Meaning |
 |-------|-------|----------|---------|

--- a/tests_lib/io/test_server_files_importer.py
+++ b/tests_lib/io/test_server_files_importer.py
@@ -167,6 +167,100 @@ class TestImporterMetadata:
             "params": {"paths_file": "/a/list.txt", "media_type": "audio"},
         }
 
+    def test_archive_member_importer_hidden_from_picker(self):
+        # The archive-member importer is folded into the Manifest tab: it stays
+        # registered (so its origins/byte-serving resolve) but no longer shows a
+        # third sub-tab under Files (issue #2484).
+        imp = get_importer("local_archive_member")
+        assert imp is not None
+        assert imp.hidden_from_picker is True
+
+
+def _make_archive_manifest(tmp_path: Path):
+    """Build a one-shard tar + an archive-member ``.npz`` manifest referencing it."""
+    import io
+    import tarfile
+
+    import numpy as np
+
+    members = {"chunk_a.mp4": b"AAAA" * 8, "chunk_b.mp4": b"BBBB" * 8}
+    archive = tmp_path / "shard_000000.tar"
+    with tarfile.open(archive, "w") as tf:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+
+    rng = np.random.default_rng(11)
+    vectors = rng.standard_normal((len(members), 512)).astype(np.float32)
+    manifest = tmp_path / "manifest.npz"
+    np.savez(
+        manifest,
+        vectors=vectors,
+        members=np.array(list(members)),
+        archives=np.array(str(archive)),
+        embedder_name=np.array("xclip"),
+    )
+    return manifest, archive
+
+
+class TestManifestArchiveMemberDelegation:
+    """The Manifest importer auto-detects an archive-member ``.npz`` and delegates
+    to the no-extraction ``local_archive_member`` importer (issue #2484)."""
+
+    def test_run_delegates_and_stamps_archive_member_origin(self, tmp_path):
+        manifest, archive = _make_archive_manifest(tmp_path)
+        imp = get_importer("server_files")
+
+        medias: dict[int, dict] = {}
+        imp.run({"paths_file": str(manifest), "media_type": "video"}, medias)
+
+        assert len(medias) == 2
+        for media in medias.values():
+            # Delegated import stamps ``local_archive_member`` origins so
+            # byte-streaming and Find-from-origin resolve by name.
+            assert media["origin"]["importer"] == "local_archive_member"
+            assert media["origin"]["params"]["manifest"] == str(manifest.resolve())
+            assert media["archive_member"]["path"] == str(archive)
+            assert media["media_bytes"] is None
+
+    def test_run_chunked_yields_archive_members(self, tmp_path):
+        manifest, _archive = _make_archive_manifest(tmp_path)
+        imp = get_importer("server_files")
+
+        merged: dict[int, dict] = {}
+        for chunk in imp.run_chunked({"paths_file": str(manifest), "media_type": "video"}, chunk_size=64):
+            merged.update(chunk)
+
+        assert len(merged) == 2
+        assert all(m["origin"]["importer"] == "local_archive_member" for m in merged.values())
+
+    def test_run_cli_delegates(self, tmp_path):
+        manifest, _archive = _make_archive_manifest(tmp_path)
+        imp = get_importer("server_files")
+
+        medias: dict[int, dict] = {}
+        imp.run_cli({"paths_file": str(manifest), "media_type": "video"}, medias)
+
+        assert len(medias) == 2
+        assert all(m["origin"]["importer"] == "local_archive_member" for m in medias.values())
+
+    def test_plain_path_manifest_is_not_treated_as_archive(self, tmp_path):
+        # A .npz of file paths (no ``members`` array) must still take the normal
+        # symlink-and-embed path, not the archive-member branch.
+        assert ServerFilesDatasetImporter._archive_manifest_path({"paths_file": str(tmp_path / "none.npz")}) is None
+
+        import numpy as np
+
+        manifest = tmp_path / "paths.npz"
+        np.savez(manifest, filenames=np.array(["a.wav"]), vectors=np.zeros((1, 512), dtype=np.float32))
+        assert ServerFilesDatasetImporter._archive_manifest_path({"paths_file": str(manifest)}) is None
+
+    def test_text_paths_file_is_not_an_archive_manifest(self, tmp_path):
+        listing = tmp_path / "list.txt"
+        listing.write_text("/a.wav\n")
+        assert ServerFilesDatasetImporter._archive_manifest_path({"paths_file": str(listing)}) is None
+
     def test_reference_files_field_excluded_from_origin(self):
         """``reference_files`` is a storage choice, not part of source identity."""
         imp = ServerFilesDatasetImporter()

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -103,6 +103,32 @@ def validate_manifest_embedder_name(
     )
 
 
+def is_archive_member_manifest(npz_path: Path) -> bool:
+    """Return ``True`` if *npz_path* is a no-extraction **archive-member** manifest.
+
+    The ``Manifest`` importer accepts two shapes of ``.npz`` under one field: a
+    plain *path → vector* manifest (files that live on disk) and an
+    *archive-member* manifest (members packed inside tar/zip shards, streamed
+    without extraction).  They are told apart by a single distinguishing array:
+    an archive-member manifest carries a ``members`` (or ``member``) array,
+    which a plain path manifest never has.  This lets the importer auto-detect
+    the shape and dispatch to the archive-member path, so users never pick
+    between two tabs for what is, to them, "a manifest of pre-computed vectors".
+
+    Only ``.npz`` files can be archive manifests; a ``.txt`` / ``.list`` paths
+    file never is.  Never raises -- returns ``False`` on a missing file, a
+    non-``.npz`` suffix, or any read error.
+    """
+    p = Path(npz_path)
+    if p.suffix.lower() != ".npz" or not p.is_file():
+        return False
+    try:
+        with np.load(p, allow_pickle=False) as data:
+            return any(k in data.files for k in _MEMBERS_KEYS)
+    except Exception:
+        return False
+
+
 def read_npz_filenames_and_vectors(npz_path: Path) -> dict[str, np.ndarray]:
     """Return a ``{filename: vector}`` mapping read from *npz_path*.
 

--- a/vtscore/datasets/importers/local_archive_member/__init__.py
+++ b/vtscore/datasets/importers/local_archive_member/__init__.py
@@ -85,6 +85,13 @@ class LocalArchiveMemberImporter(ImporterBase):
     icon = "\U0001f4e6"  # 📦
     picker_view = "form"
     category = "server"
+    # Hidden from the tabbed picker: this importer is no longer its own sub-tab
+    # under Files.  The ``Manifest`` importer (``server_files``) auto-detects an
+    # archive-member ``.npz`` and delegates here, so the user meets a single
+    # "Manifest" entry instead of a confusing third tab (issue #2484).  The
+    # importer stays fully registered so its ``local_archive_member`` media
+    # origins, byte-streaming, and Find-from-origin source keep resolving by name.
+    hidden_from_picker = True
 
     fields = [
         PluginField(

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any
 
 from vtscore.datasets.importers._npz_vectors import (
+    is_archive_member_manifest,
     read_npz_embedder_name,
     read_npz_filenames_and_vectors,
     validate_manifest_embedder_name,
@@ -198,9 +199,10 @@ class ServerFilesDatasetImporter(DatasetImporter):
     name = "server_files"
     display_name = "Manifest"
     description = (
-        "Read a server-side file listing media paths (text file, one per line, "
-        "OR a .npz archive that also supplies pre-computed embedding vectors) "
-        "and embed every listed file"
+        "Read a server-side manifest and import the media it lists. Accepts a text "
+        "file of media paths (one per line), a .npz of paths plus pre-computed "
+        "embedding vectors, or a .npz that references members inside tar/zip shards "
+        "and streams them without extraction (WebDataset-style corpora)"
     )
     icon = "\U0001f5c2"  # 🗂 - falls back to a generic file icon
     picker_view = "form"
@@ -226,8 +228,11 @@ class ServerFilesDatasetImporter(DatasetImporter):
             hint=(
                 "Accepted formats:\n"
                 " • .txt / .list - UTF-8 text, one path per line (lines starting with # are comments).\n"
-                " • .npz - NumPy archive of paths plus pre-computed embedding vectors;\n"
+                " • .npz (paths) - NumPy archive of paths plus pre-computed embedding vectors;\n"
                 "   listed files skip re-embedding and use the supplied vectors.\n"
+                " • .npz (archive members) - a manifest with a 'members' + 'archives' array\n"
+                "   references media packed inside tar/zip shards; the bytes stream on demand\n"
+                "   with no extraction (built for WebDataset-style corpora too large to copy).\n"
                 "Symlinks are followed; directory entries are scanned recursively for media files."
             ),
             accept=".txt,.list,.npz",
@@ -259,6 +264,37 @@ class ServerFilesDatasetImporter(DatasetImporter):
             if f.key == "media_type":
                 f.options = all_folder_names()
                 break
+
+    @staticmethod
+    def _archive_manifest_path(field_values: dict[str, Any]) -> Path | None:
+        """Return the paths-file path when it is an archive-member ``.npz``, else ``None``.
+
+        The ``Manifest`` importer front-ends two ``.npz`` shapes: a plain
+        *path → vector* manifest and a *member → vector* archive manifest.  A
+        manifest that references tar/zip members (a ``members`` array) is handled
+        by the no-extraction :mod:`local_archive_member` importer, which this
+        importer delegates to so the user never picks between two tabs.
+        """
+        raw = (field_values.get("paths_file") or "").strip()
+        if not raw:
+            return None
+        p = Path(raw)
+        return p if is_archive_member_manifest(p) else None
+
+    @staticmethod
+    def _delegate_archive_fields(field_values: dict[str, Any]) -> dict[str, Any]:
+        """Remap this importer's field values onto the archive-member importer's fields."""
+        return {
+            "manifest": field_values.get("paths_file", ""),
+            "media_type": field_values.get("media_type", "video"),
+        }
+
+    @staticmethod
+    def _archive_member_importer():
+        """Return the registered no-extraction archive-member importer singleton."""
+        from vtscore.datasets.importers import get_importer  # noqa: PLC0415
+
+        return get_importer("local_archive_member")
 
     def _stage_paths(
         self, field_values: dict[str, Any], media_type_id: str
@@ -372,6 +408,13 @@ class ServerFilesDatasetImporter(DatasetImporter):
     def run(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         from vtscore.media import get_by_folder_name  # noqa: PLC0415
 
+        if self._archive_manifest_path(field_values) is not None:
+            # An archive-member .npz: hand off to the no-extraction importer,
+            # which stamps ``local_archive_member`` origins so byte-streaming and
+            # Find-from-origin keep resolving by name.
+            self._archive_member_importer().run(self._delegate_archive_fields(field_values), medias, thin=thin)
+            return
+
         specs = self.effective_source_specs(field_values)
         output_type = get_by_folder_name(field_values.get("media_type", "")).type_id
 
@@ -417,6 +460,9 @@ class ServerFilesDatasetImporter(DatasetImporter):
             raise FileNotFoundError(f"Paths file not found: {paths_file}")
         if not paths_file.is_file():
             raise IsADirectoryError(f"Paths file must be a file: {paths_file}")
+        if self._archive_manifest_path(field_values) is not None:
+            self._archive_member_importer().run_cli(self._delegate_archive_fields(field_values), medias, thin=thin)
+            return
         self.run(field_values, medias, thin=thin)
 
     @property
@@ -430,6 +476,15 @@ class ServerFilesDatasetImporter(DatasetImporter):
         thin: bool = False,
     ) -> Iterator[dict[int, dict[str, Any]]]:
         from vtscore.media import get as media_get, get_by_folder_name  # noqa: PLC0415
+
+        if self._archive_manifest_path(field_values) is not None:
+            # Archive-member import isn't chunked (each media is a lightweight
+            # vector reference, no bytes read); run it whole and yield one chunk.
+            chunk: dict[int, dict[str, Any]] = {}
+            self._archive_member_importer().run(self._delegate_archive_fields(field_values), chunk, thin=thin)
+            if chunk:
+                yield chunk
+            return
 
         specs = self.effective_source_specs(field_values)
         output_type = get_by_folder_name(field_values.get("media_type", "")).type_id
@@ -497,6 +552,12 @@ class ServerFilesDatasetImporter(DatasetImporter):
             raise FileNotFoundError(f"Paths file not found: {paths_file}")
         if not paths_file.is_file():
             raise IsADirectoryError(f"Paths file must be a file: {paths_file}")
+        if self._archive_manifest_path(field_values) is not None:
+            chunk: dict[int, dict[str, Any]] = {}
+            self._archive_member_importer().run_cli(self._delegate_archive_fields(field_values), chunk, thin=thin)
+            if chunk:
+                yield chunk
+            return
         yield from self.run_chunked(field_values, chunk_size, thin=thin)
 
     def default_display_name(self, field_values: dict[str, Any]) -> str:


### PR DESCRIPTION
## Problem

The Add-Dataset **Files** picker showed three sub-tabs: **Folder**, **Manifest**, and **Archive members (no extract)**. The third was confusing gibberish for a niche use case, and — like Manifest — it's driven by a `.npz` of pre-computed vectors. A separate tab for it felt excessive (issue #2484).

## Change

The **Manifest** importer (`server_files`) now auto-detects an archive-member `.npz` — one carrying a `members` array — and delegates to the no-extraction `local_archive_member` importer. There is no separate tab or mode to pick: the user drops any manifest into **Files → Manifest** and VTSearch routes it.

- **`_npz_vectors.is_archive_member_manifest()`** — new helper that tells the two `.npz` shapes apart by the presence of a `members`/`member` array (never raises).
- **`server_files`** — `run` / `run_cli` / `run_chunked` / `run_chunked_cli` short-circuit to the archive-member importer when the paths file is an archive manifest, remapping `paths_file` → `manifest`. The archive path isn't chunked (each media is a lightweight vector reference), so the chunked entry points yield it as a single chunk.
- **`local_archive_member`** — marked `hidden_from_picker = True`. It stays fully registered so its `local_archive_member` media origins, byte-streaming, and Find-from-origin source keep resolving by name; it just no longer renders a third sub-tab. Delegation preserves those origins because it calls the real importer, which stamps them.
- Updated the Manifest field description/hint and the `USER_GUIDE.md` "Archive members" section to describe the single-entry behavior.

## Tests

Added `TestManifestArchiveMemberDelegation` (and a metadata assertion) to `tests_lib/io/test_server_files_importer.py`: an archive-member `.npz` dropped into the Manifest importer imports two members with `local_archive_member` origins via `run` / `run_cli` / `run_chunked`, while plain-path `.npz` and text paths files are correctly *not* treated as archive manifests. `./run-tests.sh` is green apart from one pre-existing flaky async labeling-status test (`test_stale_poll_returns_previous_snapshot`) that passes in isolation and is unrelated to this change.

Closes #2484

---
_Generated by [Claude Code](https://claude.ai/code/session_01WovqDKn8AXyyGVbL6pPxDY)_