### PR TITLE
Model document as an explicit half media type; fix document large preview

### DIFF
--- a/docs/plans/half-media-types.md
+++ b/docs/plans/half-media-types.md
@@ -1,0 +1,103 @@
+# Half media types (document, and the general model)
+
+**Background.** `MediaType` bundles two *orthogonal* capabilities that used to
+be conflated:
+
+1. **Ingestion identity** — a distinct kind of file the user recognises and
+   picks when importing. `.pdf` is not `.png`; a folder scan tallies them
+   separately and the user wants to differentiate and decide. **Every** type
+   has this.
+2. **Embeddability** — whether the type can be turned into a vector and
+   therefore sorted / browsed / text-queried on its own. A type has this iff it
+   registers an `embedder_*.py`.
+
+`document` is the canonical **half type**: a first-class *ingestion* category
+with **no embedder**. It must be converted to an embeddable type (image via
+`document2image`, or text via `document2text`) before it is searchable. The
+clipper-chain (`vtscore/datasets/clipper_chain.py`) already runs converter
+steps at load time, so `document → image/text → embed` is a supported
+pipeline — what was missing is that the *abstraction never named the gap*, so
+each subsystem improvised. The two issues below are that improvisation showing
+through.
+
+## The model (shipped)
+
+`MediaType` now names both capabilities explicitly, and every subsystem keys
+off the right one:
+
+- `MediaType.converts_to: list[str]` — embeddable `type_id`s a non-embeddable
+  type can convert into (first = default). `document → ["image", "text"]`;
+  empty for a directly-embeddable type.
+- `MediaType.embeddable: bool` — derived from the embedder registry
+  (`embedders_for_type(type_id)`), so it is `False` for a half type and `True`
+  for image/audio/video/text automatically, with nothing to keep in sync.
+
+Both are in `MediaType.to_dict()` → `GET /api/media-types`, and on the frontend
+`MediaTypeInfo` (`embeddable?`, `converts_to?`). A "half type" is precisely
+`embeddable == False and converts_to != []` — *a category that mandates a
+conversion step*. The definition generalises past `document` (a future
+`archive` / `email` type would fit the same mold).
+
+**Guiding principle:** surface the **ingestion category** wherever the user
+differentiates (folder import, demo tabs); surface the **embedded identity**
+only *downstream of conversion* (the browse map, sort). Never render a
+document by pretending its raw bytes are an image — render it *as a document*.
+
+<!-- item-sep -->
+
+## Open work
+
+- **#2358 — full Document demo tab (convert-on-load).** Interim shipped: the
+  UCSF demo is relabelled so its document→image provenance is explicit while it
+  stays in the Image list. The structural finish is to move it to a real
+  **Document** demo tab whose load applies a converter:
+
+  - Move the `ucsf_documents_a` `DemoDataset` from `image/_demo_sources.py` to
+    `DocumentMediaType.demo_datasets`, and implement
+    `DocumentMediaType.load_demo_source("ucsf_documents", …)` to produce
+    *document* (raw-PDF) clips (download via `download_ucsf_documents`).
+  - Teach the demo picker (`…/pickers/demo/demo-picker.component.ts`) to handle
+    a non-embeddable active tab: read `converts_to[0]`, load embedders for that
+    *target* type, and pass `converter=document2image` (default; offer
+    `document2text`) on load. Today `loadDemoEmbedders(mediaType)` assumes the
+    tab type is embeddable and returns `[]` for `document`.
+  - Reconcile demo-status caching: the converter changes the pickle cache key
+    (`{dataset}__{converter}`), but `getDemoList(embedder, clipper)` does not
+    pass a converter, so per-demo `ready / needs_embedding / needs_download`
+    status must learn the converter dimension. Update
+    `vtscore/datasets/demo_counts.py` if the entry's advertised count moves.
+
+  The `document` `image_response` hook (below) already gives these document
+  clips a real thumbnail/preview, so a Document tab renders correctly.
+
+<!-- item-sep -->
+
+- **Import flow: require a converter for a non-embeddable folder.** When a
+  folder import resolves to `document` (or any `embeddable == False` type),
+  the import config should *require* the user pick a `converts_to` target
+  (Image pages / Extracted text) instead of silently importing unembeddable
+  media that can't be sorted or browsed. The clipper-chain already supports the
+  converter step; this is the UX that makes the mandatory step visible.
+  `import-config.component.ts` reads the served `converts_to`/`embeddable` to
+  drive it.
+
+<!-- item-sep -->
+
+- **Document preview: page navigation.** The bin-popup large preview now renders
+  the document's **first** page (via `image_response`). A follow-up could let
+  the preview paginate (render page N on demand) — `render_pdf_page_png` already
+  takes a `page_index`; the route/frontend would need a `?page=` parameter.
+
+<!-- item-sep -->
+
+## Done (do not re-open)
+
+- **#2403 — document large preview.** `DocumentMediaType.image_response()`
+  renders the first PDF page to PNG (memoised on the in-memory media, never
+  persisted), so `/api/medias/<id>/image` returns a real picture and the
+  bin-popup preview pane (`showPreview`, already gated on
+  `usesThumbnails('document') == true`) shows a crisp page instead of falling
+  back to the tiny grid thumbnail. The same hook makes the browse **grid**
+  thumbnail render on demand for documents that carry no precomputed
+  `thumbnail_bytes`. Non-PDF documents (`.doc` / `.ppt`, which PyMuPDF can't
+  rasterise) return `None` and fall back to the placeholder icon.


### PR DESCRIPTION
## Why

`MediaType` quietly conflated two orthogonal capabilities: **ingestion identity** (a distinct file kind the user recognises and picks — every type has it) and **embeddability** (can it become a vector, and thus be sorted/browsed/text-queried). `document` is the canonical *half type*: a first-class ingestion category with **no embedder**, so it must be converted (`document2image` / `document2text`) before it's searchable. Because the abstraction never named that gap, each subsystem improvised — which is what issues #2358 and #2403 are.

## What changed

**Name the gap on `MediaType`:**
- `converts_to: list[str]` — embeddable `type_id`s a non-embeddable type converts into (first = default). `document → ["image", "text"]`; empty for embeddable types.
- `embeddable: bool` — derived from the embedder registry, so it's `False` for a half type and `True` for image/audio/video/text automatically (nothing to keep in sync).
- Both surfaced via `MediaType.to_dict()` → `GET /api/media-types`, and on the frontend `MediaTypeInfo` (`embeddable?`, `converts_to?`). The media-types response uses an untyped dict field, so no OpenAPI snapshot drift.

**Fix document large preview (`Closes #2403`):** `DocumentMediaType.image_response()` rasterises the first PDF page to PNG (memoised on the in-memory media, never persisted — it's a render cache, not an embedding). The browse bin-popup preview pane is already gated on `usesThumbnails('document') == true`, so `/api/medias/<id>/image` now returns a real page instead of raw PDF bytes, and the same hook makes the grid **thumbnail** render on demand for documents with no precomputed `thumbnail_bytes`. Non-PDF documents (`.doc`/`.ppt`, which PyMuPDF can't rasterise) return `None` and fall back to the placeholder icon. New `render_pdf_page_png(pdf_bytes, page_index, dpi)` helper in `vtscore/datasets/pdf.py`.

**Relabel the UCSF demo (`Refs #2358`):** it renders PDF pages to images and embeds them with the image model, so it lives in the Image demo list. Relabelled so its document→image provenance is explicit rather than reading as ordinary photographs. The full structural finish — a convert-on-load **Document** demo tab — is tracked as open work in `docs/plans/half-media-types.md`, because it needs the demo picker to handle a non-embeddable tab (pick `converts_to[0]`, load the target type's embedders, pass a converter) and reconcile demo-status caching.

**Design narrative:** `docs/plans/half-media-types.md` captures the model, the guiding principle (surface the ingestion category where the user differentiates; surface the embedded identity only downstream of conversion), and the remaining structural phases (Document demo tab, import-flow mandatory converter, preview page navigation).

## Tests

- `converters` group: document `converts_to`/`embeddable`/`to_dict`, `image_response` (renders PNG, memoises, `None` for non-PDF and missing bytes), and an embeddable-type contract check (image → `embeddable True`, `converts_to []`).
- `io` group: `render_pdf_page_png` (renders requested page, out-of-range → `None`, non-PDF bytes → `None`).
- `./run-tests.sh converters io core` → 2156 passed; `./run-tests.sh frontend` → pyright 0 errors, no OpenAPI drift, build OK, Vitest 1478 passed.

Closes #2403
Refs #2358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9SUsgebVgMECzkxX3a4XK)_