### PR TITLE
Add safe_tar_extract for centralised, hardened tar extraction

### DIFF
--- a/tests_lib/core/test_archive_safety.py
+++ b/tests_lib/core/test_archive_safety.py
@@ -1,0 +1,116 @@
+"""Tests for :func:`vtscore.security.archive.safe_tar_extract`.
+
+Covers the three classes of malicious tar member the centralised extractor
+must neutralise: absolute-path members, ``../`` traversal members, and
+symlink members that point outside the destination.  Each case is exercised on
+both extraction paths — the PEP 706 ``data_filter`` branch (native on this
+interpreter) and the manual fallback used on interpreters that lack it — by
+forcing :data:`~vtscore.security.archive._HAS_DATA_FILTER` off for the second.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import tarfile
+from pathlib import Path
+
+import pytest
+
+import vtscore.security.archive as safe_archive
+from vtscore.security.archive import safe_tar_extract
+
+# Errors either branch may raise for an unsafe member: ValueError from the
+# manual fallback, tarfile.TarError (FilterError subclasses) from data_filter.
+_UNSAFE_ERRORS = (ValueError, tarfile.TarError)
+
+
+@pytest.fixture(params=[True, False], ids=["data_filter", "fallback"])
+def branch(request, monkeypatch):
+    """Run each test on both the data_filter and the manual-fallback path."""
+    if request.param and not safe_archive._HAS_DATA_FILTER:  # pragma: no cover
+        pytest.skip("interpreter lacks tarfile.data_filter")
+    monkeypatch.setattr(safe_archive, "_HAS_DATA_FILTER", request.param)
+    return request.param
+
+
+def _write_tar(path: Path, build) -> None:
+    """Create a tar at *path*; *build* receives the open TarFile to add members."""
+    with tarfile.open(path, "w") as tf:
+        build(tf)
+
+
+def _add_file(tf: tarfile.TarFile, name: str, data: bytes = b"payload") -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    tf.addfile(info, io.BytesIO(data))
+
+
+def _add_symlink(tf: tarfile.TarFile, name: str, target: str) -> None:
+    info = tarfile.TarInfo(name)
+    info.type = tarfile.SYMTYPE
+    info.linkname = target
+    tf.addfile(info)
+
+
+def _extract_all(archive: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive) as tf:
+        for member in tf.getmembers():
+            safe_tar_extract(tf, member, dest)
+
+
+def test_benign_member_extracts_inside_dest(branch, tmp_path):
+    archive = tmp_path / "ok.tar"
+    _write_tar(archive, lambda tf: _add_file(tf, "sub/good.txt", b"hello"))
+    dest = tmp_path / "out"
+    _extract_all(archive, dest)
+    assert (dest / "sub" / "good.txt").read_bytes() == b"hello"
+
+
+def test_absolute_path_member_confined_to_dest(branch, tmp_path):
+    """An absolute member name is stripped of its leading ``/`` (PEP 706) and
+    lands *inside* dest — never at the real filesystem location."""
+    archive = tmp_path / "abs.tar"
+    # Point the absolute name at a sentinel outside dest we can assert stays
+    # untouched, rather than a real system path.
+    outside = tmp_path / "evil_abs.txt"
+    abs_name = str(outside)  # e.g. "/tmp/.../evil_abs.txt"
+    assert os.path.isabs(abs_name)
+    _write_tar(archive, lambda tf: _add_file(tf, abs_name, b"nope"))
+
+    dest = tmp_path / "out"
+    _extract_all(archive, dest)
+
+    # The absolute target must not have been written.
+    assert not outside.exists()
+    # The payload landed under dest with the root stripped.
+    landed = dest / abs_name.lstrip("/")
+    assert landed.read_bytes() == b"nope"
+
+
+def test_traversal_member_rejected(branch, tmp_path):
+    archive = tmp_path / "trav.tar"
+    _write_tar(archive, lambda tf: _add_file(tf, "../escape.txt", b"nope"))
+    dest = tmp_path / "out"
+    with pytest.raises(_UNSAFE_ERRORS):
+        _extract_all(archive, dest)
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_absolute_symlink_member_rejected(branch, tmp_path):
+    archive = tmp_path / "link.tar"
+    _write_tar(archive, lambda tf: _add_symlink(tf, "link", "/etc/passwd"))
+    dest = tmp_path / "out"
+    with pytest.raises(_UNSAFE_ERRORS):
+        _extract_all(archive, dest)
+    assert not (dest / "link").exists()
+
+
+def test_escaping_relative_symlink_member_rejected(branch, tmp_path):
+    archive = tmp_path / "link2.tar"
+    _write_tar(archive, lambda tf: _add_symlink(tf, "link", "../../secret"))
+    dest = tmp_path / "out"
+    with pytest.raises(_UNSAFE_ERRORS):
+        _extract_all(archive, dest)
+    assert not (dest / "link").exists()

--- a/vtscore/datasets/archive.py
+++ b/vtscore/datasets/archive.py
@@ -47,6 +47,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional
 from uuid import uuid4
 
 from vtscore.config import DATA_DIR
+from vtscore.security.archive import safe_tar_extract
 from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
 
 if TYPE_CHECKING:
@@ -190,8 +191,7 @@ def extract_archive(
                     i,
                     total,
                 )
-                _reject_traversal(extract_dir_resolved, member.name)
-                tf.extract(member, extract_dir, filter="data")
+                safe_tar_extract(tf, member, extract_dir)
 
     elif name.endswith(".rar"):
         try:

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -20,6 +20,7 @@ from urllib.parse import urljoin
 import requests
 
 from vtscore.config import DATA_DIR
+from vtscore.security.archive import safe_tar_extract
 from vtscore.security.hf_auth import GatedResourceError, auth_header_for_url
 from vtscore.security.url_validation import validate_url
 
@@ -636,10 +637,11 @@ def _extract_archive(
     """Extract *archive_path* into *dest_dir*, dispatching by filename suffix.
 
     Supports ``.tar.gz`` / ``.tgz`` (gzip tar), ``.tar`` (uncompressed tar),
-    ``.zip``, and ``.7z`` archives.  Tar members are extracted with
-    ``filter="data"`` (which rejects unsafe absolute/traversal paths); zip and
-    7z members are validated against *dest_dir* to guard against path traversal
-    (zip-slip).  Raises ``ValueError`` for an unsupported archive format.
+    ``.zip``, and ``.7z`` archives.  Tar members go through
+    :func:`~vtscore.security.archive.safe_tar_extract` (which rejects unsafe
+    absolute/traversal/link paths); zip and 7z members are validated against
+    *dest_dir* to guard against path traversal (zip-slip).  Raises
+    ``ValueError`` for an unsupported archive format.
     """
     suffix = archive_name.lower()
     if suffix.endswith((".tar.gz", ".tgz", ".tar")):
@@ -656,7 +658,7 @@ def _extract_archive(
                 for i, member in enumerate(tar_ref):
                     if i % 100 == 0:
                         on_progress("downloading", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes)
-                    tar_ref.extract(member, dest_dir, filter="data")
+                    safe_tar_extract(tar_ref, member, dest_dir)
         on_progress("downloading", f"Extracting {dataset_name}...", total_bytes, total_bytes)
     elif suffix.endswith(".zip"):
         from vtscore.datasets.archive import _reject_traversal

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from vtscore.datasets.downloader import core as _core
 from vtscore.datasets.downloader.core import ProgressCallback
+from vtscore.security.archive import safe_tar_extract
 
 
 def download_cifar10(on_progress: Optional[ProgressCallback] = None) -> Path:
@@ -127,7 +128,7 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
             with tarfile.open(inner_tar, "r:gz") as tar_ref:
                 _extract_members(
                     tar_ref.getmembers(),
-                    lambda member, tar_ref=tar_ref: tar_ref.extract(member, inner_dest, filter="data"),
+                    lambda member, tar_ref=tar_ref: safe_tar_extract(tar_ref, member, inner_dest),
                     on_progress,
                     "Extracting 101_ObjectCategories...",
                     start=0,

--- a/vtscore/security/archive.py
+++ b/vtscore/security/archive.py
@@ -1,0 +1,91 @@
+"""Centralised, hardened tar extraction.
+
+A single audited path for pulling members out of a :class:`tarfile.TarFile`,
+so that no call site has to re-implement path-traversal / absolute-path /
+symlink protection by hand.
+
+On Python interpreters that ship PEP 706's extraction filters
+(``tarfile.data_filter``, available on CPython ≥ 3.9.17 / 3.10.12 / 3.11.4 /
+3.12), every member is extracted through the strict ``data`` filter, which:
+
+* strips a leading ``/`` from absolute member names so they land *inside* the
+  destination rather than at the filesystem root,
+* refuses ``..`` traversal that would escape the destination, and
+* refuses symlink / hardlink members whose target is absolute or points
+  outside the destination.
+
+On older interpreters (no ``data_filter``) :func:`safe_tar_extract` falls back
+to :func:`_reject_unsafe_member`, which reproduces those same guarantees
+manually before writing anything to disk.
+"""
+
+from __future__ import annotations
+
+import os
+import tarfile
+from pathlib import Path
+
+__all__ = ["safe_tar_extract"]
+
+#: True when the running interpreter provides PEP 706 extraction filters.
+_HAS_DATA_FILTER = hasattr(tarfile, "data_filter")
+
+
+def _strip_leading_root(name: str) -> str:
+    """Return *name* with any leading path root removed (PEP 706 semantics).
+
+    Drops leading ``/`` and ``\\`` separators, and a Windows drive prefix
+    (``C:\\``), so an absolute member name becomes relative and extracts
+    *inside* the destination instead of at the filesystem root.
+    """
+    # Windows drive-letter absolute path, e.g. "C:\\evil" or "C:/evil".
+    if len(name) > 1 and name[1] == ":":
+        name = name[2:]
+    return name.lstrip("/\\")
+
+
+def _reject_unsafe_member(member: tarfile.TarInfo, dest_resolved: Path) -> str:
+    """Validate *member* against *dest_resolved*; return its sanitised name.
+
+    Raises :class:`ValueError` if the member (or, for links, its target) would
+    escape *dest_resolved*.  The returned name has any absolute-path root
+    stripped, mirroring :data:`tarfile.data_filter`, so the caller can extract
+    it safely inside the destination.  Used only on interpreters that lack
+    PEP 706 filters.
+    """
+    sanitised = _strip_leading_root(member.name)
+    target = Path(os.path.normpath(dest_resolved / sanitised))
+    if target != dest_resolved and not target.is_relative_to(dest_resolved):
+        raise ValueError(f"Path traversal detected in archive member: {member.name!r}")
+
+    if member.issym() or member.islnk():
+        linkname = member.linkname
+        if os.path.isabs(linkname) or _strip_leading_root(linkname) != linkname:
+            raise ValueError(f"Absolute link target in archive member: {member.name!r} -> {linkname!r}")
+        link_target = Path(os.path.normpath(target.parent / linkname))
+        if not link_target.is_relative_to(dest_resolved):
+            raise ValueError(f"Link escapes destination in archive member: {member.name!r} -> {linkname!r}")
+
+    return sanitised
+
+
+def safe_tar_extract(tar: tarfile.TarFile, member: tarfile.TarInfo, dest: str | Path) -> None:
+    """Extract a single *member* of *tar* into *dest* with traversal protection.
+
+    On Python ≥ 3.11.4 (any interpreter exposing :data:`tarfile.data_filter`)
+    the extraction runs through the strict PEP 706 ``data`` filter.  On older
+    interpreters the member is validated by :func:`_reject_unsafe_member`
+    before being written.  Either way, absolute paths are confined to *dest*
+    and traversal / unsafe-link members are rejected.
+    """
+    if _HAS_DATA_FILTER:
+        tar.extract(member, dest, filter=tarfile.data_filter)
+        return
+
+    dest_resolved = Path(dest).resolve()
+    sanitised = _reject_unsafe_member(member, dest_resolved)
+    # Extract under the sanitised (root-stripped) name so absolute members land
+    # inside dest, matching the data-filter branch above.
+    member.name = sanitised
+    # Safe: member (and its link target) were validated by _reject_unsafe_member.
+    tar.extract(member, dest)


### PR DESCRIPTION
## Summary

Adds `vtscore/security/archive.py::safe_tar_extract(tar, member, dest)` — a single audited path for pulling members out of a `tarfile.TarFile` — and routes every direct `TarFile.extract` call in the tree through it, so path-traversal / absolute-path / symlink protection lives in one place instead of being re-implemented per call site.

## Behaviour

- **Python ≥ 3.11.4** (any interpreter exposing `tarfile.data_filter`, i.e. CPython ≥ 3.9.17 / 3.10.12 / 3.11.4 / 3.12): extraction runs through the strict PEP 706 `data` filter.
- **Older interpreters** (no `data_filter`): a manual fallback (`_reject_unsafe_member`) reproduces the same guarantees before anything is written — strips a leading `/` from absolute member names so they land *inside* the destination, rejects `..` traversal, and rejects symlink/hardlink members whose target is absolute or escapes the destination.

Both paths give identical outcomes: absolute paths are confined to `dest`, traversal and unsafe-link members raise.

## Call sites routed through it

- `vtscore/datasets/downloader/core.py` (`_extract_archive` tar branch)
- `vtscore/datasets/archive.py` (`extract_archive` tar branch — the redundant inline `_reject_traversal` + `filter="data"` pair collapses into the one helper)
- `vtscore/datasets/downloader/images.py` (Caltech-101 inner-tar extraction)

Zip and 7z branches are unchanged (they keep their existing `_reject_traversal` zip-slip guard).

## Tests

`tests_lib/core/test_archive_safety.py` covers absolute-path, `../` traversal, and symlink (absolute and escaping-relative) members. Every case runs on **both** the `data_filter` branch and the manual fallback (the latter forced on by patching `_HAS_DATA_FILTER` off), so the fallback is exercised even on an interpreter that ships `data_filter`. The absolute-path fixture asserts the payload lands inside `dest` with its root stripped and never at the real filesystem location, handling the PEP 706 leading-`/` strip.

Full `./run-tests.sh` passes (6225 passed).

Closes #2494


---
_Generated by [Claude Code](https://claude.ai/code/session_018ror1Fu5L6sey5TBaMwtz7)_