### PR TITLE
Add SigLIP-L (SO400M/384) open_clip image embedder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,14 @@ dependencies = [
     "sentencepiece",
     "protobuf",
     "Pillow",
+    # SigLIP-L image embedder: loads open_clip's ``ViT-SO400M-14-SigLIP-384``
+    # checkpoint so its 1152-d vectors match galleries embedded by open_clip
+    # itself. ``timm`` (vision backbones) and ``ftfy`` (text cleanup) are
+    # runtime deps of open_clip we never import directly — declared so a plain
+    # install covers SigLIP-L, ignored under deptry DEP002 (transitive-only).
+    "open_clip_torch",
+    "timm",
+    "ftfy",
     "ultralytics",
     "opencv-python-headless",
     "imageio-ffmpeg",
@@ -187,6 +195,7 @@ extend_exclude = [
 "imageio-ffmpeg" = "imageio_ffmpeg"
 "flask-smorest" = "flask_smorest"
 "sentence-transformers" = "sentence_transformers"
+"open_clip_torch" = "open_clip"
 
 [tool.deptry.per_rule_ignores]
 # DEP001: imported but not declared. These are optional / opportunistic
@@ -262,6 +271,11 @@ DEP002 = [
     "gunicorn",
     "sentencepiece",
     "protobuf",
+    # Runtime deps of ``open_clip_torch`` (the SigLIP-L embedder's loader):
+    # ``timm`` supplies vision backbones and ``ftfy`` cleans up text. open_clip
+    # imports them; our code never does, so they are declared-but-not-imported.
+    "timm",
+    "ftfy",
     # Loaded via importorskip in the portable-export test; never imported
     # statically, so deptry can't see the use.
     "onnxruntime",

--- a/requirements/image-embedders-gpu.txt
+++ b/requirements/image-embedders-gpu.txt
@@ -45,3 +45,11 @@ tokenizers
 # trust_remote_code=True. einops is the only extra runtime dep its
 # custom code typically pulls in.
 einops
+
+# ── SigLIP-L (open_clip ViT-SO400M-14-SigLIP-384) ────────────────────
+# Loaded through open_clip (not transformers) so its 1152-d vectors match
+# galleries embedded by open_clip itself. timm / ftfy are open_clip's own
+# runtime deps.
+open_clip_torch
+timm
+ftfy

--- a/requirements/image-embedders.txt
+++ b/requirements/image-embedders.txt
@@ -3,6 +3,8 @@
 # Image-only deployment that ships every supported image embedder:
 #   * SigLIP   (google/siglip-base-patch16-224)         - default, text-capable, ungated
 #   * SigLIP 2 (google/siglip2-base-patch16-224)        - text-capable, ungated
+#   * SigLIP-L (open_clip ViT-SO400M-14-SigLIP-384)     - text-capable, ungated, 1152-d
+
 #   * CLIP     (openai/clip-vit-base-patch32)           - text-capable, ungated
 #   * DINOv2   (facebook/dinov2-base)                   - image-only, ungated
 #   * DINOv3   (facebook/dinov3-vitb16-pretrain-lvd1689m) - image-only, gated
@@ -57,3 +59,11 @@ tokenizers
 # trust_remote_code=True. einops is the only extra runtime dep its
 # custom code typically pulls in.
 einops
+
+# ── SigLIP-L (open_clip ViT-SO400M-14-SigLIP-384) ────────────────────
+# Loaded through open_clip (not transformers) so its 1152-d vectors match
+# galleries embedded by open_clip itself. timm / ftfy are open_clip's own
+# runtime deps.
+open_clip_torch
+timm
+ftfy

--- a/tests/detectors/test_image_embedders.py
+++ b/tests/detectors/test_image_embedders.py
@@ -506,12 +506,14 @@ class TestApiEmbeddersResponseShape:
         assert resp.status_code == 200
         body = resp.get_json()
         entries = {e["name"]: e for e in body["embedders"]}
-        # All image embedders must be present; three CLIP-family bimodal
-        # models, single/patch pairs for DINOv2/DINOv3/EUPE, the FaceNet
-        # face-identity embedder, and the SIFT/VLAD structural embedder.
+        # All image embedders must be present; four CLIP-family bimodal
+        # models (siglip, siglip2, siglip_l, clip), single/patch pairs for
+        # DINOv2/DINOv3/EUPE, the FaceNet face-identity embedder, and the
+        # SIFT/VLAD structural embedder.
         assert set(entries) == {
             "siglip",
             "siglip2",
+            "siglip_l",
             "clip",
             "dinov2_single",
             "dinov2_patch",
@@ -531,6 +533,7 @@ class TestApiEmbeddersResponseShape:
             assert entry["license_notice"] is None or isinstance(entry["license_notice"], str)
         # Specific expectations.
         assert entries["siglip"]["supports_text"] is True
+        assert entries["siglip_l"]["supports_text"] is True
         for name in (
             "dinov2_single",
             "dinov2_patch",
@@ -547,6 +550,7 @@ class TestApiEmbeddersResponseShape:
         for name in (
             "siglip",
             "siglip2",
+            "siglip_l",
             "clip",
             "dinov2_single",
             "dinov3_single",
@@ -558,6 +562,7 @@ class TestApiEmbeddersResponseShape:
         for name in (
             "siglip",
             "siglip2",
+            "siglip_l",
             "clip",
             "dinov2_single",
             "dinov2_patch",

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -108,6 +108,124 @@ class TestImageSiglipEmbedderProperties:
         assert SIGLIP_MODEL_ID == "google/siglip-base-patch16-224"
 
 
+class TestImageSiglipLEmbedderProperties:
+    """Verify ImageSiglipLEmbedder class properties and registration.
+
+    Offline-safe: every assertion here exercises identity / registration /
+    guard-clause behaviour without importing ``open_clip`` or downloading the
+    SO400M checkpoint. ``open_clip`` is imported lazily inside
+    ``_load_models_impl``, so the module imports (and auto-discovers) cleanly
+    even when open_clip is not installed.
+    """
+
+    def test_name(self):
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        assert ImageSiglipLEmbedder().name == "siglip_l"
+
+    def test_media_type_id(self):
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        assert ImageSiglipLEmbedder().media_type_id == "image"
+
+    def test_is_not_default(self):
+        """SigLIP (base) stays the default image embedder; SigLIP-L is opt-in."""
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        assert ImageSiglipLEmbedder().is_default is False
+
+    def test_description_wrappers_non_empty(self):
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        wrappers = ImageSiglipLEmbedder().description_wrappers
+        assert len(wrappers) > 0
+        assert all("{text}" in w for w in wrappers)
+
+    def test_registered_in_registry(self):
+        from vtscore.media import get_embedder
+
+        emb = get_embedder("siglip_l")
+        assert emb.name == "siglip_l"
+        assert emb.media_type_id == "image"
+
+    def test_listed_in_embedders_for_type(self):
+        from vtscore.media import embedders_for_type
+
+        names = [e.name for e in embedders_for_type("image")]
+        assert "siglip_l" in names
+
+    def test_to_dict(self):
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        d = ImageSiglipLEmbedder().to_dict()
+        assert d == {
+            "name": "siglip_l",
+            "display_name": "SigLIP-L (SO400M/384)",
+            "model_id": "ViT-SO400M-14-SigLIP-384",
+            "media_type_id": "image",
+            "is_default": False,
+            "supports_text": True,
+            "supports_patch_regions": False,
+            "supports_geometric_verification": False,
+            "license_notice": None,
+        }
+
+    def test_load_models_idempotent(self):
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        emb = ImageSiglipLEmbedder()
+        # Simulate already-loaded model: a second load must be a no-op and must
+        # not attempt to import open_clip or download weights.
+        emb._model = MagicMock()
+        emb._preprocess = MagicMock()
+        emb._tokenizer = MagicMock()
+        emb.load_models()
+        assert isinstance(emb._model, MagicMock)
+
+    def test_embed_media_returns_none_when_not_loaded(self):
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        emb = ImageSiglipLEmbedder()
+        with patch.object(emb, "load_models"):
+            result = emb.embed_media({"media_path": "/nonexistent.jpg"})
+        assert result is None
+
+    def test_embed_text_returns_none_when_not_loaded(self):
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        emb = ImageSiglipLEmbedder()
+        with patch.object(emb, "load_models"):
+            result = emb.embed_text("a cat")
+        assert result is None
+
+    def test_embed_pil_image_returns_none_when_not_loaded(self):
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        emb = ImageSiglipLEmbedder()
+        with patch.object(emb, "load_models"):
+            result = emb.embed_pil_image(MagicMock())
+        assert result is None
+
+    def test_uses_correct_model_id(self):
+        from vtscore.config import SIGLIP_L_MODEL_ID, SIGLIP_L_PRETRAINED
+
+        assert SIGLIP_L_MODEL_ID == "ViT-SO400M-14-SigLIP-384"
+        assert SIGLIP_L_PRETRAINED == "webli"
+
+    def test_is_media_embedder(self):
+        from vtscore.media.embedder import MediaEmbedder
+        from vtscore.media.image.embedder_siglip_l import ImageSiglipLEmbedder
+
+        assert issubclass(ImageSiglipLEmbedder, MediaEmbedder)
+
+    def test_module_exposes_embedder_sentinel(self):
+        from vtscore.media.embedder import MediaEmbedder
+        from vtscore.media.image import embedder_siglip_l
+
+        assert isinstance(embedder_siglip_l.EMBEDDER, MediaEmbedder)
+        assert embedder_siglip_l.EMBEDDER.name == "siglip_l"
+
+
 class TestAudioClapMusicEmbedderProperties:
     """Verify AudioClapMusicEmbedder class properties and registration."""
 
@@ -869,12 +987,12 @@ class TestAllEmbeddersRegistration:
         from vtscore.media import all_embedders
 
         embedders = all_embedders()
-        # 7 original + 8 image embedders (clip, siglip2, plus single/patch
-        # variants for dinov2, dinov3, eupe) + 1 face embedder
+        # 7 original + 9 image embedders (clip, siglip2, siglip_l, plus
+        # single/patch variants for dinov2, dinov3, eupe) + 1 face embedder
         # + 1 structural image embedder (sift_vlad)
         # + 1 vision-only video embedder (videomae)
         # + 4 audio embedders (ast, clap_general, whisper_encoder, paraspeechclap).
-        assert len(embedders) == 22
+        assert len(embedders) == 23
 
     def test_all_embedders_dict_includes_supports_text(self):
         """The new ``supports_text`` flag must round-trip through ``to_dict``
@@ -884,7 +1002,7 @@ class TestAllEmbeddersRegistration:
         dicts = all_embedders_dict()
         by_name = {d["name"]: d for d in dicts}
         # Cross-modal embedders advertise text support.
-        for name in ("siglip", "siglip2", "clip", "clap", "clap_general", "paraspeechclap", "xclip"):
+        for name in ("siglip", "siglip2", "siglip_l", "clip", "clap", "clap_general", "paraspeechclap", "xclip"):
             assert by_name[name]["supports_text"] is True, name
         # Vision-only / patch-based and speech-only embedders do not.
         for name in (
@@ -914,6 +1032,7 @@ class TestAllEmbeddersRegistration:
             "paraspeechclap",
             "siglip",
             "siglip2",
+            "siglip_l",
             "clip",
             "dinov2_single",
             "dinov2_patch",
@@ -944,6 +1063,7 @@ class TestAllEmbeddersRegistration:
         assert names == {
             "siglip",
             "siglip2",
+            "siglip_l",
             "clip",
             "dinov2_single",
             "dinov2_patch",
@@ -981,12 +1101,12 @@ class TestAllEmbeddersRegistration:
         from vtscore.media import all_embedders_dict
 
         dicts = all_embedders_dict()
-        # 7 original + 8 image embedders (clip, siglip2, plus single/patch
-        # variants for dinov2, dinov3, eupe) + 1 face embedder
+        # 7 original + 9 image embedders (clip, siglip2, siglip_l, plus
+        # single/patch variants for dinov2, dinov3, eupe) + 1 face embedder
         # + 1 structural image embedder (sift_vlad)
         # + 1 vision-only video embedder (videomae)
         # + 4 audio embedders (ast, clap_general, whisper_encoder, paraspeechclap).
-        assert len(dicts) == 22
+        assert len(dicts) == 23
         for d in dicts:
             assert "name" in d
             assert "media_type_id" in d

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -219,6 +219,12 @@ XCLIP_MODEL_ID = "microsoft/xclip-base-patch32"
 E5_MODEL_ID = "intfloat/e5-base-v2"
 SIGLIP_MODEL_ID = "google/siglip-base-patch16-224"
 SIGLIP2_MODEL_ID = "google/siglip2-base-patch16-224"
+# SigLIP-L: the SO400M/384 checkpoint, loaded via ``open_clip`` (not
+# transformers) so its 1152-d vectors match galleries produced by open_clip's
+# own ``ViT-SO400M-14-SigLIP-384`` model.  The arch name is the open_clip
+# model key; the ``webli`` tag selects the WebLI-pretrained weights.
+SIGLIP_L_MODEL_ID = "ViT-SO400M-14-SigLIP-384"
+SIGLIP_L_PRETRAINED = "webli"
 CLIP_MODEL_ID = "openai/clip-vit-base-patch32"
 DINOV2_MODEL_ID = "facebook/dinov2-base"
 DINOV3_MODEL_ID = "facebook/dinov3-vitb16-pretrain-lvd1689m"

--- a/vtscore/media/image/embedder_siglip_l.py
+++ b/vtscore/media/image/embedder_siglip_l.py
@@ -1,0 +1,195 @@
+"""Image embedder - SigLIP-L (open_clip ``ViT-SO400M-14-SigLIP-384``).
+
+Unlike :mod:`vtscore.media.image.embedder_siglip` (the base SigLIP loaded via
+``transformers``), this embedder loads the larger SO400M/384 checkpoint through
+``open_clip``.  Loading through open_clip - rather than the transformers port -
+means the 1152-dimensional vectors match galleries produced by open_clip's own
+model bit-for-bit, so a SigLIP-L detector trained here is directly comparable to
+an externally-embedded open_clip gallery.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+import numpy as np
+
+from vtscore.config import SIGLIP_L_MODEL_ID, SIGLIP_L_PRETRAINED
+from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
+    MediaEmbedder,
+    embedder_load_setup,
+    intercept_tqdm_progress,
+    intercept_weight_loading_progress,
+    timed_progress,
+    to_compute_device,
+)
+from vtscore.media.image._image_bulk import bulk_embed_image_files
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+
+class ImageSiglipLEmbedder(MediaEmbedder):
+    """Embeds images using SigLIP-L (SO400M/384) via ``open_clip``.
+
+    * Images → 1152-dimensional vectors via the vision tower.
+    * Text queries → 1152-dimensional vectors via the text tower.
+    * Also exposes :meth:`embed_pil_image` for in-memory PIL Image objects
+      (used for PDF rendering and CIFAR-10 demo datasets).
+
+    The model / preprocess / tokenizer come straight from open_clip's pretrained
+    registry so vectors line up with any gallery embedded by the same open_clip
+    checkpoint.  Like every other embedder the loaded model is placed on the
+    resolved compute device via :func:`to_compute_device`, so a CUDA host runs
+    the forward pass on the GPU while a CPU-only host degrades gracefully.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Typed ``Any``: open_clip has no type stubs, so the model / preprocess /
+        # tokenizer callables are opaque to pyright; runtime ``None`` checks guard
+        # every use.
+        self._model: Any = None
+        self._preprocess: Any = None
+        self._tokenizer: Any = None
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "siglip_l"
+
+    @property
+    def display_name(self) -> str:
+        return "SigLIP-L (SO400M/384)"
+
+    @property
+    def model_id(self) -> str:
+        return SIGLIP_L_MODEL_ID
+
+    @property
+    def media_type_id(self) -> str:
+        return "image"
+
+    # ------------------------------------------------------------------
+    # Model lifecycle
+    # ------------------------------------------------------------------
+
+    def _load_models_impl(self) -> None:
+        if self._model is not None:
+            return
+
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
+            import torch  # noqa: F401, PLC0415
+
+        with timed_progress(self._on_progress, "loading", "Importing open_clip…"):
+            import open_clip  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+
+        cache_dir = embedder_load_setup(self._on_progress, "Loading SigLIP-L model weights…")
+        with (
+            intercept_tqdm_progress(self._on_progress),
+            intercept_weight_loading_progress(self._on_progress, "Loading SigLIP-L model weights…"),
+        ):
+            model, _, preprocess = open_clip.create_model_and_transforms(
+                SIGLIP_L_MODEL_ID, pretrained=SIGLIP_L_PRETRAINED, cache_dir=cache_dir
+            )
+            tokenizer = open_clip.get_tokenizer(SIGLIP_L_MODEL_ID)
+        model.eval()
+        self._model = to_compute_device(model)
+        self._preprocess = preprocess
+        self._tokenizer = tokenizer
+
+    # ------------------------------------------------------------------
+    # Embedding
+    # ------------------------------------------------------------------
+
+    @property
+    def description_wrappers(self) -> list[str]:
+        return [
+            "a photo of {text}",
+            "a photograph of {text}",
+            "an image of {text}",
+            "{text}",
+            "a picture of {text}",
+        ]
+
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._preprocess is None:
+            return None
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
+
+        source = _pil_source_for(media)
+        if source is None:
+            return None
+        image = _load_pil(source)
+        if image is None:
+            return None
+        return self.embed_pil_image(image)
+
+    def embed_pil_image(self, image: Image.Image) -> Optional[np.ndarray]:
+        """Embed a PIL Image that is already in memory (e.g. from CIFAR-10)."""
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._preprocess is None:
+            return None
+        try:
+            return self._forward_pil_batch([image])[0]
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding PIL image (SigLIP-L)")
+            return None
+
+    def _forward_pil_batch(self, images: list[Image.Image]) -> np.ndarray:
+        """Run SigLIP-L's vision tower on a list of PIL images.
+
+        Returns an ``(N, 1152)`` array.  Caller is responsible for batch
+        sizing - this runs the whole list in one forward pass.
+        """
+        import torch  # noqa: PLC0415
+
+        device = next(self._model.parameters()).device
+        batch = torch.stack([self._preprocess(im.convert("RGB")) for im in images]).to(device)
+        with torch.no_grad():
+            features = self._model.encode_image(batch)
+        return features.detach().cpu().numpy()
+
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._preprocess is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_embed_image_files(
+                medias,
+                forward_pil_batch=self._forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label="SigLIP-L",
+            )
+
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._tokenizer is None:
+            return None
+        try:
+            import torch  # noqa: PLC0415
+
+            device = next(self._model.parameters()).device
+            tokens = self._tokenizer([text]).to(device)
+            with torch.no_grad():
+                text_vec = self._model.encode_text(tokens).detach().cpu().numpy()[0]
+            return text_vec
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding text query for image (SigLIP-L)")
+            return None
+
+
+EMBEDDER = ImageSiglipLEmbedder()


### PR DESCRIPTION
## What

Adds a new `siglip_l` image embedder that loads open_clip's `ViT-SO400M-14-SigLIP-384` checkpoint (1152-d). Loading through **open_clip** rather than the transformers port means the produced vectors match galleries embedded by open_clip itself, so a SigLIP-L detector trained in VTSearch is directly comparable to an externally-embedded open_clip gallery.

## Changes

- **`vtscore/media/image/embedder_siglip_l.py`** (new) — `ImageSiglipLEmbedder`. Lazily imports `open_clip` inside `_load_models_impl` (so the module auto-discovers even when open_clip isn't installed), loads the `webli`-pretrained SO400M/384 checkpoint via `create_model_and_transforms`, and places the model on the resolved compute device via `to_compute_device` (honours `resolve_device()` — GPU on a CUDA host, CPU otherwise). Image + text towers, bulk path, and `embed_pil_image` mirror the existing SigLIP embedder.
- **`vtscore/config.py`** — `SIGLIP_L_MODEL_ID` (`ViT-SO400M-14-SigLIP-384`) and `SIGLIP_L_PRETRAINED` (`webli`).
- **`pyproject.toml`** — declares `open_clip_torch` (mapped to the `open_clip` import) plus its `timm`/`ftfy` runtime deps; `timm`/`ftfy` go in the deptry transitive-only (DEP002) list since our code never imports them directly.
- **`requirements/image-embedders*.txt`** — same three deps for the slim image-embedder Docker images.
- **Tests** — bumped the built-in embedder counts (22 → 23) and the image-embedder sets in `test_new_embedders.py` and `test_image_embedders.py`, plus an offline-safe `TestImageSiglipLEmbedderProperties` smoke suite (identity, registration, `to_dict`, guard-clause `None` behaviour, sentinel discovery) that never imports open_clip or downloads weights.

## Notes

- The existing `siglip` embedder already routes through `to_compute_device` (i.e. already honours `resolve_device()` rather than hardcoding `"cpu"`), so no device change was needed there — the issue's request predates that refactor.
- **Backwards compatibility:** no breaks; this is purely additive.
- `./run-tests.sh` is green (ruff, codespell, deptry, pip-audit, pyright, frontend build, 6229 tests passed).

Closes #2493

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3T2Rh4xwPMeDwzZKLGw4Y)_