### PR TITLE
Assert GMM subsample cap instead of wall-clock in bounded test

### DIFF
--- a/tests_lib/sorting/test_gmm_subsample.py
+++ b/tests_lib/sorting/test_gmm_subsample.py
@@ -8,7 +8,7 @@ statistically indistinguishable from the full-sample fit and (b) is determinist
 ic and bounded.
 """
 
-import time
+from unittest import mock
 
 import numpy as np
 
@@ -67,12 +67,25 @@ class TestGmmSubsample:
         assert 0.45 < threshold < 0.55
 
     def test_large_input_is_bounded(self):
-        """A 1M-point fit stays fast because only the subsample is fit.
+        """A 1M-point fit never hands the GMM more than ``_GMM_MAX_SAMPLES`` rows.
 
-        Generous ceiling (5s) so this is not flaky on a loaded machine; the
-        un-subsampled fit on 1M points would be far slower.
+        Spy on ``GaussianMixture.fit`` and assert the row count it receives is
+        capped by the subsample. This asserts the cap directly instead of timing
+        the call, so it stays deterministic under xdist load (a wall-clock bound
+        is flaky on a busy machine).
         """
+        from sklearn.mixture import GaussianMixture  # noqa: PLC0415
+
         scores = _bimodal_scores(1_000_000, seed=5)
-        start = time.perf_counter()
-        calculate_gmm_threshold(scores)
-        assert time.perf_counter() - start < 5.0
+        seen_rows: list[int] = []
+        original_fit = GaussianMixture.fit
+
+        def spy_fit(self, X, *args, **kwargs):
+            seen_rows.append(np.asarray(X).shape[0])
+            return original_fit(self, X, *args, **kwargs)
+
+        with mock.patch.object(GaussianMixture, "fit", spy_fit):
+            calculate_gmm_threshold(scores)
+
+        assert seen_rows, "GaussianMixture.fit was never called"
+        assert all(n <= _GMM_MAX_SAMPLES for n in seen_rows)


### PR DESCRIPTION
## Summary

`tests_lib/sorting/test_gmm_subsample.py::test_large_input_is_bounded` previously asserted a `< 5.0s` wall-clock bound, which is flaky under xdist load on a busy machine.

This rewrites the test to spy on `GaussianMixture.fit` and assert the input row count it receives is `≤ _GMM_MAX_SAMPLES`. This checks the subsample cap directly — the actual invariant being tested — rather than inferring it from timing, so the assertion is deterministic regardless of machine load.

## Changes

- Replaced the `time.perf_counter()` bound with an `unittest.mock` patch on `GaussianMixture.fit` that records each call's row count.
- Asserts `fit` was called and every observed row count is capped by `_GMM_MAX_SAMPLES`.
- Dropped the now-unused `import time`.

## Testing

- `./run-tests.sh sorting -- -k gmm_subsample` → all 5 tests pass (ruff, pyright, deptry, etc. green).

Closes #2505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ScSCUHPY3oELxKAPzmQa5

---
_Generated by [Claude Code](https://claude.ai/code/session_016ScSCUHPY3oELxKAPzmQa5)_