### PR TITLE
Stamp requested embedder onto blank-named pre-embedded media

### DIFF
--- a/tests_lib/datasets/test_multi_embedder_loader.py
+++ b/tests_lib/datasets/test_multi_embedder_loader.py
@@ -135,6 +135,75 @@ class TestSecondEmbedderPass:
 
 
 # ---------------------------------------------------------------------------
+# Requested-embedder stamping: an npz/sidecar import ships a vector but no
+# embedder name (blank sentinel key); the caller's pick is stamped onto it.
+# ---------------------------------------------------------------------------
+
+
+class TestRequestedEmbedderStamping:
+    def test_blank_name_stamped_on_explicit_pick(self):
+        # Pre-embedded media: vector under the blank sentinel key, no recorded
+        # embedder (the npz/sidecar shape).  A named pick stamps that name on,
+        # and the pre-computed vector is kept (no re-embed).
+        emb = _fake_embedder("siglip", dim=4)
+        rng = np.random.default_rng(1)
+        vecs = {i: rng.standard_normal(4).astype(np.float32) for i in range(1, 4)}
+        medias = {i: {"media_type": "audio", "embeddings": {"": vecs[i]}} for i in range(1, 4)}
+
+        with (
+            mock.patch("vtscore.media.get_embedder", return_value=emb),
+            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
+        ):
+            embed_missing(medias, "siglip")
+
+        # No re-embed: the pre-computed vectors were stamped, not replaced.
+        assert emb.embed_media_bulk.call_count == 0
+        for i, m in medias.items():
+            assert m["embedder"] == "siglip"
+            assert set(m["embeddings"]) == {"siglip"}
+            np.testing.assert_array_equal(m["embeddings"]["siglip"], vecs[i])
+            np.testing.assert_array_equal(media_embedding(m, "siglip"), vecs[i])
+
+    def test_blank_name_left_blank_when_no_pick(self):
+        # No explicit pick → the blank sentinel key is left untouched (the
+        # nameless vector still resolves as the primary via media_embedding).
+        emb = _fake_embedder("audio_default", dim=4)
+        rng = np.random.default_rng(2)
+        vecs = {i: rng.standard_normal(4).astype(np.float32) for i in range(1, 4)}
+        medias = {i: {"media_type": "audio", "embeddings": {"": vecs[i]}} for i in range(1, 4)}
+
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias)
+
+        assert emb.embed_media_bulk.call_count == 0
+        for i, m in medias.items():
+            assert not m.get("embedder")
+            assert set(m["embeddings"]) == {""}
+            np.testing.assert_array_equal(media_embedding(m), vecs[i])
+
+    def test_importer_set_name_preserved(self):
+        # The importer recorded a real embedder name; a different pick must not
+        # overwrite it (only blank-named media are stamped).
+        emb = _fake_embedder("siglip", dim=4)
+        rng = np.random.default_rng(3)
+        vecs = {i: rng.standard_normal(4).astype(np.float32) for i in range(1, 4)}
+        medias = {
+            i: {"media_type": "audio", "embedder": "real_name", "embeddings": {"real_name": vecs[i]}}
+            for i in range(1, 4)
+        }
+
+        with (
+            mock.patch("vtscore.media.get_embedder", return_value=emb),
+            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
+        ):
+            embed_missing(medias, "siglip")
+
+        for i, m in medias.items():
+            assert m["embedder"] == "real_name"
+            np.testing.assert_array_equal(m["embeddings"]["real_name"], vecs[i])
+
+
+# ---------------------------------------------------------------------------
 # Persistence: per-embedder vectors round-trip through save/reload
 # ---------------------------------------------------------------------------
 

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from vtscore.embedding.matrix import invalidate_embedding_matrix
 from vtscore.embedding.media_vectors import (
+    EMBEDDINGS_KEY,
+    UNKNOWN_EMBEDDER_KEY,
     ensure_embeddings_dict,
     media_embedder_names,
     media_embedding,
@@ -90,6 +92,33 @@ def _resolve_embedder(
         avail = embedders_for_type(media_type)
         emb = avail[0] if avail else None
     return emb
+
+
+def _stamp_requested_embedder(medias: dict[int, dict[str, Any]], embedder_name: str) -> None:
+    """Stamp the requested *embedder_name* onto pre-embedded media whose name is blank.
+
+    An npz/sidecar importer that ships a pre-computed vector but not its
+    producing embedder stores it under the blank sentinel key
+    (:data:`UNKNOWN_EMBEDDER_KEY`) with no recorded ``media["embedder"]``.  When
+    the caller named an embedder for this load, that nameless vector *is* that
+    embedder's vector — the archive just didn't carry the name — so re-key it
+    under *embedder_name* and record the primary.  This lets
+    ``media_embedding(m, embedder_name)`` resolve, so the named-missing check
+    below won't needlessly re-embed the media and downstream binding won't fall
+    back to the media-type default (a dimension mismatch when the pick differs).
+
+    Only media whose embedder name is blank are touched; an importer-set name is
+    never overwritten.
+    """
+    for m in medias.values():
+        if m.get("embedder"):
+            continue
+        embs = m.get(EMBEDDINGS_KEY)
+        if not isinstance(embs, dict) or UNKNOWN_EMBEDDER_KEY not in embs:
+            continue
+        vec = embs.pop(UNKNOWN_EMBEDDER_KEY)
+        embs.setdefault(embedder_name, vec)
+        m["embedder"] = embedder_name
 
 
 def _noop_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
@@ -255,6 +284,14 @@ def embed_missing(
     emb = _resolve_embedder(medias, embedder_name, media_type)
     if emb is None:
         return
+
+    # A pre-embedded media whose producing embedder the archive didn't record
+    # (npz/sidecar import → vector under the blank sentinel key) carries the
+    # caller's named embedder when one was given: stamp that name so the vector
+    # resolves under it rather than being re-embedded or leaving downstream
+    # binding to fall back to the media-type default (dimension mismatch).
+    if embedder_name:
+        _stamp_requested_embedder(medias, embedder_name)
 
     # Which items still need *this* embedder's vector.
     missing = _missing_for_embedder(medias, emb, embedder_name)

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -108,8 +108,10 @@ def _stamp_requested_embedder(medias: dict[int, dict[str, Any]], embedder_name: 
     back to the media-type default (a dimension mismatch when the pick differs).
 
     Only media whose embedder name is blank are touched; an importer-set name is
-    never overwritten.
+    never overwritten.  A no-op when *embedder_name* is blank (no pick to stamp).
     """
+    if not embedder_name:
+        return
     for m in medias.values():
         if m.get("embedder"):
             continue
@@ -290,8 +292,7 @@ def embed_missing(
     # caller's named embedder when one was given: stamp that name so the vector
     # resolves under it rather than being re-embedded or leaving downstream
     # binding to fall back to the media-type default (dimension mismatch).
-    if embedder_name:
-        _stamp_requested_embedder(medias, embedder_name)
+    _stamp_requested_embedder(medias, embedder_name)
 
     # Which items still need *this* embedder's vector.
     missing = _missing_for_embedder(medias, emb, embedder_name)


### PR DESCRIPTION
## Summary

When an npz/sidecar importer fills `media["embeddings"]` with a pre-computed vector but the archive doesn't carry the producing embedder's name, the vector is stored under the blank sentinel key (`UNKNOWN_EMBEDDER_KEY`, `""`) with no recorded `media["embedder"]`. If the caller *did* name an embedder for that load, `embed_missing()` now stamps that name onto those media so `media_embedding(m, name)` resolves.

Without this, the named-missing check saw no vector under the pick's key and re-embedded (or downstream binding fell back to the media-type default embedder — a dimension mismatch when the pick's dim differs from the default's).

## Changes

- `vtscore/datasets/stages/embedding.py`: new `_stamp_requested_embedder()` helper, called from `embed_missing()` before missing-detection. It re-keys the blank-sentinel vector under the requested name and records the primary embedder. Only media whose embedder name is blank are touched; an importer-set name is never overwritten. No-op when no embedder was named.

## Tests

`tests_lib/datasets/test_multi_embedder_loader.py` — `TestRequestedEmbedderStamping` covers the three cases:
- blank name stamped on an explicit pick (pre-computed vector kept, no re-embed),
- blank name left blank when no pick,
- importer-set name preserved against a differing pick.

Full suite: 6218 passed.

Closes #2496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7tiVuApLKAeFywixHZoxC)_