### PR TITLE
Make load_detector_and_wait fail loudly with a longer timeout

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,16 +1,23 @@
 """Test package for VTSearch."""
 
 
-def load_detector_and_wait(client, detector_id, timeout=5.0):
+def load_detector_and_wait(client, detector_id, timeout=30.0):
     """Load a detector via POST and poll until the background task finishes.
 
     After loading completes, updates the current thread's detector context
     to point to the newly loaded detector so that subsequent proxy accesses
     (votes, etc.) resolve to the correct DetectorContext.
 
+    Fails loudly via ``pytest.fail`` if the background load does not finish
+    within ``timeout`` seconds, reporting the still-active tasks. Silently
+    exhausting the deadline used to leave callers seeing 404s / empty
+    ``label_embeddings`` on many-worker xdist runs.
+
     Returns the initial POST response.
     """
     import time
+
+    import pytest
 
     from vtscore.concurrency.progress import detector_loading_tasks
 
@@ -21,11 +28,17 @@ def load_detector_and_wait(client, detector_id, timeout=5.0):
         set_thread_detector_context(None)
         return res
     deadline = time.monotonic() + timeout
+    active = None
     while time.monotonic() < deadline:
         active = [t for t in detector_loading_tasks.list_tasks() if t.get("status") != "idle"]
         if not active:
             break
         time.sleep(0.05)
+    else:
+        pytest.fail(
+            f"load_detector_and_wait timed out after {timeout}s waiting for "
+            f"detector {detector_id!r} to load; active tasks: {active!r}"
+        )
 
     # Update the test thread's context to the newly loaded model.
     from vtscore.state.core import get_detector_context, set_thread_detector_context


### PR DESCRIPTION
## Summary

`tests/__init__.py::load_detector_and_wait` polled the background detector load with a 5s ceiling and returned **silently** if it exhausted the deadline. On many-worker xdist runs the callers then saw 404s / empty `label_embeddings` — a load that hadn't actually finished, surfacing as a confusing downstream failure rather than a clear timeout.

This change:

- Raises the default `timeout` from `5.0` to `30.0` seconds.
- Replaces the silent fall-through with `pytest.fail(...)` when the deadline is hit, reporting the detector id and the still-active tasks list so the real cause is obvious.

Implemented via a `while ... else` so the failure only fires when the loop exits by exhausting the deadline (not when it breaks on a completed load).

## Testing

- `./run-tests.sh detectors` → all 1528 tests pass (ruff/format/codespell/deptry gates included).

Closes #2503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018tMs1oBGqrzsxxHxRUAPya)_