### PR TITLE
Skip test_js_contains_guessing_logic cleanly when no Angular bundle

### DIFF
--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -242,6 +242,7 @@ class TestGuessMediaType:
     These tests verify the underlying data contracts that the frontend logic relies on.
     """
 
+    @pytest.mark.usefixtures("angular_bundle")
     def test_js_contains_guessing_logic(self, client):
         """main.js should include the media-type guessing code."""
         resp = client.get("/static/main.js")


### PR DESCRIPTION
`TestGuessMediaType.test_js_contains_guessing_logic` reads `/static/main.js` directly, so on a host without a built Angular bundle the request 404s and the assertion fails instead of skipping.

Marking the test with `@pytest.mark.usefixtures("angular_bundle")` makes it skip cleanly (or build the bundle once) like every other bundle-content test in the file.

Closes #2504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHjLN4gtXvF8Yoe8QDoyPK)_