### PR TITLE
Hoist build_media_lookup out of the per-label loop

### DIFF
--- a/tests/detectors/test_labelset_elements_api.py
+++ b/tests/detectors/test_labelset_elements_api.py
@@ -180,6 +180,64 @@ class TestLabelsDetail:
 
 
 # ---------------------------------------------------------------------------
+# resolve_current_dataset_cid: threaded lookups short-circuit the rebuild
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWithThreadedLookups:
+    """`resolve_current_dataset_cid` accepts a pre-built ``build_media_lookup``
+    triple so loop callers resolve every element against one set of tables
+    instead of rebuilding them (O(labels × N) → O(N + labels))."""
+
+    def _elem(self):
+        from vtscore.datasets.labelset import LabeledElement
+
+        return LabeledElement.from_dict(
+            {
+                "md5": "a1" * 16,
+                "label": "good",
+                "origin": {"importer": "test", "params": {}},
+                "origin_name": "alpha.wav",
+                "filename": "alpha.wav",
+            }
+        )
+
+    def test_passing_lookups_skips_snapshot_and_rebuild(self, monkeypatch):
+        """When ``lookups`` is passed, neither ``snapshot_medias`` nor
+        ``build_media_lookup`` runs; resolution uses the supplied tables."""
+        import vtscore.state as state_mod
+        from vtscore.detectors.labelset_elements import resolve_current_dataset_cid
+        from vtscore.state.media_lookup import build_media_lookup
+
+        media = {
+            7: {
+                "id": 7,
+                "md5": "a1" * 16,
+                "origin": {"importer": "test", "params": {}},
+                "origin_name": "alpha.wav",
+            }
+        }
+        lookups = build_media_lookup(media)
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("per-call rebuild must be short-circuited when lookups are provided")
+
+        monkeypatch.setattr(state_mod, "snapshot_medias", _boom)
+        monkeypatch.setattr(state_mod, "build_media_lookup", _boom)
+
+        assert resolve_current_dataset_cid(self._elem(), lookups) == 7
+
+    def test_no_lookups_falls_back_to_snapshot_build(self, monkeypatch):
+        """Without ``lookups`` the single-element path builds tables from a
+        fresh snapshot; an empty snapshot resolves to ``None``."""
+        import vtscore.state as state_mod
+        from vtscore.detectors.labelset_elements import resolve_current_dataset_cid
+
+        monkeypatch.setattr(state_mod, "snapshot_medias", lambda: {})
+        assert resolve_current_dataset_cid(self._elem()) is None
+
+
+# ---------------------------------------------------------------------------
 # POST /api/detectors/<name>/labels/<id>/vote
 # ---------------------------------------------------------------------------
 

--- a/vtscore/detectors/labelset_elements.py
+++ b/vtscore/detectors/labelset_elements.py
@@ -43,11 +43,22 @@ def find_element_by_id(elements: list[LabeledElement], target_id: str) -> tuple[
     return None
 
 
-def resolve_current_dataset_cid(elem: LabeledElement) -> int | None:
+def resolve_current_dataset_cid(
+    elem: LabeledElement,
+    lookups: tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]] | None = None,
+) -> int | None:
     """Return the cid in the active dataset that matches *elem*, or ``None``.
 
     Matches by origin+name first, then by MD5.  Only consults the dataset
     snapshot - does not trigger origin-file resolution.
+
+    When *lookups* is provided (the ``(origin_lookup, md5_lookup, name_lookup)``
+    triple from :func:`~vtscore.state.media_lookup.build_media_lookup`), it is
+    used directly and no snapshot is taken.  Loop callers that resolve many
+    elements against the same dataset build the tables **once** and thread them
+    through, turning an O(labels × N) poll into O(N + labels).  When *lookups*
+    is ``None`` the tables are built from a fresh :func:`snapshot_medias`, the
+    single-element convenience path.
 
     Returning a single cid (``cids[0]``) from the union returned by
     :func:`~vtscore.state.media_lookup.resolve_media_ids` is safe because
@@ -64,10 +75,12 @@ def resolve_current_dataset_cid(elem: LabeledElement) -> int | None:
         snapshot_medias,
     )
 
-    snap = snapshot_medias()
-    if not snap:
-        return None
-    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
+    if lookups is None:
+        snap = snapshot_medias()
+        if not snap:
+            return None
+        lookups = build_media_lookup(snap)
+    origin_lookup, md5_lookup, name_lookup = lookups
     cids = resolve_media_ids(elem.to_dict(), origin_lookup, md5_lookup, name_lookup)
     return cids[0] if cids else None
 
@@ -99,14 +112,19 @@ def build_element_view(
     media_type: str,
     click_times: Mapping[int, float | int],
     learned_scores: Mapping[int, float],
+    lookups: tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]] | None = None,
 ) -> dict[str, Any]:
     """Build the JSON-serialisable dict the frontend consumes for *elem*.
 
     Includes a current-dataset ``cid`` (and its click-time / learned-score)
     when the element resolves into the active dataset; otherwise those
     fields are ``null``.
+
+    *lookups* is threaded straight into :func:`resolve_current_dataset_cid`;
+    pass the pre-built ``build_media_lookup`` triple when calling this in a
+    loop so the lookup tables aren't rebuilt per element.
     """
-    cid = resolve_current_dataset_cid(elem)
+    cid = resolve_current_dataset_cid(elem, lookups)
     name = elem.origin_name or elem.filename or (elem.md5[:12] if elem.md5 else "")
 
     score = -1.0
@@ -138,7 +156,7 @@ def build_labels_detail(detector_data: dict[str, Any]) -> dict[str, Any]:
 
     Returns ``{"good": [...], "bad": [...], "media_type": "..."}``.
     """
-    from vtscore.state import get_active_detector_context
+    from vtscore.state import build_media_lookup, get_active_detector_context, snapshot_medias
 
     media_type = detector_data.get("media_type", "") or ""
     labelset = LabelSet.from_dict(detector_data.get("labelset") or {})
@@ -146,6 +164,12 @@ def build_labels_detail(detector_data: dict[str, Any]) -> dict[str, Any]:
     det_ctx = get_active_detector_context()
     click_times = dict(det_ctx.vote_click_times)
     learned_scores = dict(det_ctx.last_learned_scores)
+
+    # Build the origin/md5/name lookup tables once and thread them through every
+    # element's view, so the labels-detail poll is O(N + labels) instead of
+    # O(labels × N) (each per-element rebuild would json.dumps every origin).
+    snap = snapshot_medias()
+    lookups = build_media_lookup(snap) if snap else None
 
     good: list[dict[str, Any]] = []
     bad: list[dict[str, Any]] = []
@@ -155,6 +179,7 @@ def build_labels_detail(detector_data: dict[str, Any]) -> dict[str, Any]:
             media_type=media_type,
             click_times=click_times,
             learned_scores=learned_scores,
+            lookups=lookups,
         )
         if el.label == "good":
             good.append(view)

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -30,6 +30,24 @@ log = logging.getLogger(__name__)
 ProgressCallback = Callable[[str, int, int], None]
 
 
+def _lookups_for_snap(
+    snap: dict[int, dict[str, Any]] | None,
+) -> tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]] | None:
+    """Build the ``(origin, md5, name)`` media-lookup triple for *snap*, once.
+
+    Returns ``None`` when *snap* is empty/absent (the in-dataset resolution
+    paths are all guarded on ``if snap:`` anyway).  Loop callers build this a
+    single time and thread it into :func:`resolve_current_dataset_cid` so the
+    per-element cid resolution is O(1) instead of rebuilding the tables (which
+    ``json.dumps`` every origin) for each of ``labels`` elements.
+    """
+    if not snap:
+        return None
+    from vtscore.state import build_media_lookup
+
+    return build_media_lookup(snap)
+
+
 def _embedder_for_active_dataset(snap: dict[int, dict[str, Any]] | None) -> str:
     """Return the embedder name to use for fresh resolve+embed work.
 
@@ -234,6 +252,7 @@ def _resolve_uncached_embedding(
     *,
     media_type: str,
     embedder_name: str,
+    lookups: tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]] | None = None,
 ) -> np.ndarray | None:
     """Produce a training vector for *elem*, not consulting the cache.
 
@@ -242,12 +261,15 @@ def _resolve_uncached_embedding(
     the media's nearest ``patch_regions`` node when the element carries one).
     Falls back to the cross-dataset path - resolve via the importer and embed
     freshly.  Returns ``None`` when neither path produces a vector.
+
+    *lookups* is the pre-built ``build_media_lookup`` triple for *snap*; loop
+    callers pass it so the cid resolution doesn't rebuild the tables per element.
     """
     from vtscore.detectors.labelset_elements import resolve_current_dataset_cid
     from vtscore.detectors.training import pool_box_from_media
 
     if snap:
-        cid = resolve_current_dataset_cid(elem)
+        cid = resolve_current_dataset_cid(elem, lookups)
         if cid is not None and cid in snap:
             media = snap[cid]
             pooled = pool_box_from_media(media, elem.region_box)
@@ -275,6 +297,7 @@ def _resolve_negative_leaves(
     *,
     media_type: str,
     embedder_name: str,
+    lookups: tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]] | None = None,
 ) -> list[np.ndarray] | None:
     """Leaf negatives (CLS + HAC leaves) for a Bad *elem* on a patch dataset.
 
@@ -284,12 +307,15 @@ def _resolve_negative_leaves(
     non-patch datasets/elements (and clipper-bearing origins, whose patch grid
     we can't reconstruct) so the caller falls back to a single image-level
     negative - i.e. no flooding, the pre-change behaviour.
+
+    *lookups* is the pre-built ``build_media_lookup`` triple for *snap*; loop
+    callers pass it so the cid resolution doesn't rebuild the tables per element.
     """
     from vtscore.detectors.labelset_elements import resolve_current_dataset_cid
     from vtscore.detectors.resolver import resolve_file_context
 
     if snap:
-        cid = resolve_current_dataset_cid(elem)
+        cid = resolve_current_dataset_cid(elem, lookups)
         if cid is not None and cid in snap:
             return _leaves_from_regions(snap[cid].get("patch_regions"))
 
@@ -339,6 +365,11 @@ def populate_label_embeddings(
 
     neg_cache: dict[str, list[np.ndarray]] = det_ctx.label_negative_regions
 
+    # Build the origin/md5/name lookup tables once from *snap* and thread them
+    # through every element's cid resolution, so the pass is O(N + labels)
+    # instead of O(labels × N).
+    lookups = _lookups_for_snap(snap)
+
     for idx, elem in enumerate(labelset.elements):
         eid = stable_element_id(elem)
         # Bad elements on a patch dataset flood their CLS + leaf negatives (the
@@ -347,7 +378,9 @@ def populate_label_embeddings(
         # (``_resolve_negative_leaves`` returns None), leaving the Bad element
         # to contribute its single image-level vector below.
         if elem.label == "bad" and eid not in neg_cache:
-            leaves = _resolve_negative_leaves(elem, snap, media_type=media_type, embedder_name=embedder_name)
+            leaves = _resolve_negative_leaves(
+                elem, snap, media_type=media_type, embedder_name=embedder_name, lookups=lookups
+            )
             if leaves is not None:
                 neg_cache[eid] = leaves
 
@@ -364,7 +397,9 @@ def populate_label_embeddings(
             cached += 1
             continue
 
-        emb = _resolve_uncached_embedding(elem, snap, media_type=media_type, embedder_name=embedder_name)
+        emb = _resolve_uncached_embedding(
+            elem, snap, media_type=media_type, embedder_name=embedder_name, lookups=lookups
+        )
         if emb is not None:
             cache[eid] = emb
             region_cache[eid] = elem.region_box
@@ -437,6 +472,7 @@ def _resolve_uncached_local_features(
     snap: dict[int, dict[str, Any]] | None,
     *,
     embedder,
+    lookups: tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]] | None = None,
 ) -> Any | None:
     """Re-derive *elem*'s :class:`StructuralFeatures`, not consulting the cache.
 
@@ -447,6 +483,9 @@ def _resolve_uncached_local_features(
     **full** (unfiltered) feature set is returned; any ``region_box`` is applied
     downstream at template-build time.  Returns ``None`` when neither path
     yields features.
+
+    *lookups* is the pre-built ``build_media_lookup`` triple for *snap*; loop
+    callers pass it so the cid resolution doesn't rebuild the tables per element.
     """
     from vtscore.detectors.labelset_elements import resolve_current_dataset_cid
     from vtscore.detectors.resolver import resolve_file_context
@@ -454,7 +493,7 @@ def _resolve_uncached_local_features(
     from vtscore.media.structural import StructuralFeatures
 
     if snap:
-        cid = resolve_current_dataset_cid(elem)
+        cid = resolve_current_dataset_cid(elem, lookups)
         if cid is not None and cid in snap:
             feats = snap[cid].get("local_features")
             if isinstance(feats, StructuralFeatures) and feats.count > 0:
@@ -513,13 +552,16 @@ def populate_label_local_features(
         return 0
 
     cache: dict[str, Any] = det_ctx.label_local_features
+    # Build the origin/md5/name lookup tables once and thread them through,
+    # so this pass is O(N + labels) instead of O(labels × N).
+    lookups = _lookups_for_snap(snap)
     for elem in labelset.elements:
         if elem.label not in ("good", "bad"):
             continue
         eid = stable_element_id(elem)
         if eid in cache:
             continue
-        feats = _resolve_uncached_local_features(elem, snap, embedder=embedder)
+        feats = _resolve_uncached_local_features(elem, snap, embedder=embedder, lookups=lookups)
         if feats is not None:
             cache[eid] = feats
     return len(cache)


### PR DESCRIPTION
## Summary

`resolve_current_dataset_cid` rebuilt the entire `(origin, md5, name)` media-lookup triple on every call — and it's called once per labelset element inside two hot loops (`build_labels_detail`, the labels-detail poll; and `populate_label_embeddings`, the label-embedding pass). Each rebuild `json.dumps` every origin in the dataset, so a detector with `L` labels against a dataset of `N` medias cost `O(L × N)`.

This threads a pre-built lookups triple through the resolution path so the loop callers build the tables **once** and reuse them, turning both passes into `O(N + L)`.

## Changes

- `vtscore/detectors/labelset_elements.py`
  - `resolve_current_dataset_cid(elem, lookups=None)` — when `lookups` is provided, use it directly and skip the snapshot + rebuild. `None` keeps the single-element convenience path (build from a fresh `snapshot_medias`), so the thumbnail and single-vote routes are unchanged.
  - `build_element_view(..., lookups=None)` — threads straight through to the resolver.
  - `build_labels_detail` — builds the tables once from the snapshot and threads them into every element's view.
- `vtscore/detectors/labelset_training.py`
  - New `_lookups_for_snap` helper; `populate_label_embeddings` and `populate_label_local_features` build the triple once and thread it through the three resolution helpers (`_resolve_uncached_embedding`, `_resolve_negative_leaves`, `_resolve_uncached_local_features`).

## Tests

- `tests/detectors/test_labelset_elements_api.py` — new `TestResolveWithThreadedLookups`: passing `lookups=` short-circuits the per-call snapshot/rebuild (asserts neither runs), and the `None` path still falls back to a snapshot build.
- Full `./run-tests.sh` suite green (6217 passed).

Closes #2502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbePMqB6sWU9cEbQ61mYgp)_