### PR TITLE
Defer entry-point plugin ImportError to first use

### DIFF
--- a/tests/core/test_plugin_entry_points.py
+++ b/tests/core/test_plugin_entry_points.py
@@ -86,7 +86,7 @@ class TestEntryPointDiscovery:
         # And a warning was emitted explaining the skip.
         assert any("clashes with built-in" in str(w.message) for w in caught)
 
-    def test_failed_load_warns_and_continues(self, monkeypatch):
+    def test_failed_load_warns_and_defers_to_first_use(self, monkeypatch):
         good = _DummyPlugin("good_plugin")
         boom = _FakeEntryPoint("broken", "pkg:OBJ", RuntimeError("nope"))
         ok = _FakeEntryPoint("good", "pkg:OBJ", good)
@@ -100,10 +100,87 @@ class TestEntryPointDiscovery:
                 label="test plugin",
                 entry_point_group="vtsearch.test_family",
             )
+            # A broken entry point does not stop a healthy sibling from resolving.
             assert registry.get("good_plugin") is good
-        assert registry.get("broken") is None
         # A warning was raised for the failure.
         assert any("Failed to load" in str(w.message) for w in caught)
+
+        # The broken plugin now resolves to a tombstone (not None)...
+        tombstone = registry.get("broken")
+        assert tombstone is not None
+        assert tombstone.name == "broken"
+        # ...but it is kept out of list() so serialising the family is safe.
+        assert tombstone not in registry.list()
+        assert good in registry.list()
+
+    def test_tombstone_raises_original_error_on_invoke(self, monkeypatch):
+        boom = _FakeEntryPoint("broken", "pkg.mod:OBJ", RuntimeError("open_clip is not installed"))
+        _patch_entry_points(monkeypatch, [boom])
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            registry: PluginRegistry = PluginRegistry(
+                package="vtscore.plugins",
+                sentinel="TEST_SENTINEL_NEVER_PRESENT",
+                label="test plugin",
+                entry_point_group="vtsearch.test_family",
+            )
+
+        tombstone = registry.get("broken")
+        assert tombstone is not None
+        # Accessing any real plugin attribute / method surfaces the original
+        # error message, chained from the captured exception.
+        with pytest.raises(ImportError, match="open_clip is not installed") as excinfo:
+            tombstone.run()
+        assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+    def test_tombstone_survives_pickle(self, monkeypatch):
+        import pickle
+
+        boom = _FakeEntryPoint("broken", "pkg.mod:OBJ", RuntimeError("missing dep"))
+        _patch_entry_points(monkeypatch, [boom])
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            registry: PluginRegistry = PluginRegistry(
+                package="vtscore.plugins",
+                sentinel="TEST_SENTINEL_NEVER_PRESENT",
+                label="test plugin",
+                entry_point_group="vtsearch.test_family",
+            )
+
+        tombstone = registry.get("broken")
+        restored = pickle.loads(pickle.dumps(tombstone))
+        assert restored.name == "broken"
+        # The restored copy still defers the original error to first use.
+        with pytest.raises(ImportError, match="missing dep"):
+            restored.export()
+
+    def test_built_in_wins_over_failed_entry_point(self, monkeypatch):
+        from vtscore.datasets.importers import list_importers
+
+        built_in_names = {imp.name for imp in list_importers()}
+        assert "server_folder" in built_in_names
+
+        # An entry point named after a built-in whose import blows up must
+        # not tombstone over the working built-in.
+        boom = _FakeEntryPoint("server_folder", "rogue:OBJ", RuntimeError("nope"))
+        _patch_entry_points(monkeypatch, [boom])
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            registry: PluginRegistry = PluginRegistry(
+                package="vtscore.datasets.importers",
+                sentinel="IMPORTER",
+                label="dataset importer",
+                entry_point_group="vtsearch.test_family",
+            )
+
+        # The built-in still resolves and is a real, usable importer.
+        entry = registry.get("server_folder")
+        assert entry is not None
+        assert entry.name == "server_folder"
+        assert entry.to_dict()["name"] == "server_folder"
 
     def test_entry_point_without_name_is_skipped(self, monkeypatch):
         class _NoName:

--- a/vtscore/docs/packages/plugins.md
+++ b/vtscore/docs/packages/plugins.md
@@ -47,8 +47,9 @@ sentinel attribute (`IMPORTER`, `EXPORTER`, `LABEL_IMPORTER`, …) as a
 plugin keyed by `plugin.name`. It then walks the matching
 `importlib.metadata` entry-point group so third-party packages can drop
 plugins in without forking the repo. Built-ins take precedence on name
-clashes; a broken third-party entry point warns and is skipped without
-disturbing the rest of the registry. The result is exposed as a
+clashes; a third-party entry point whose own import raises warns and is
+registered as a tombstone (deferring the original error to first use)
+without disturbing the rest of the registry. The result is exposed as a
 standard `(get, list)` accessor pair every family re-exports.
 
 ## `PluginField`
@@ -304,7 +305,7 @@ my_exporter = "my_pkg.exporter:EXPORTER"
 After `pip install` of your package, the plugin appears in
 `list_importers()` / `list_exporters()` / etc. without any code change
 to `vtscore`. The discovery routine is `_discover_entry_points()` at
-`vtscore/plugins/__init__.py:388`.
+`vtscore/plugins/__init__.py:649`.
 
 ### Invariants
 
@@ -313,14 +314,20 @@ to `vtscore`. The discovery routine is `_discover_entry_points()` at
   point is skipped and a `UserWarning` is emitted. This prevents an
   installed third-party package from accidentally shadowing a core
   plugin.
-- **Broken entry points warn and skip.** Any exception during
-  `entry_point.load()`, a missing `name` attribute on the loaded
-  object, or any other malformedness produces a `UserWarning` and is
-  skipped. One broken third-party plugin cannot block discovery of the
-  rest of the registry.
-- **No name attribute → rejected.** Entry-point objects without a
-  truthy `.name` attribute warn and skip - there's no fallback to the
-  entry-point name on the registry side.
+- **Broken entry points warn and defer to first use.** When
+  `entry_point.load()` raises — typically the plugin's *own* import
+  failing on a missing optional dependency (e.g. `open_clip` absent for
+  a `siglip_l` embedder) — the registry emits a `UserWarning` and
+  registers an `EntryPointTombstone` under the entry-point name. The
+  tombstone resolves via `get(name)` but re-raises the original error the
+  moment it's actually invoked, and is kept out of `list()` so
+  serialising the family never trips over it. One broken third-party
+  plugin cannot block discovery of the rest of the registry, and the
+  original error is surfaced (not swallowed) when someone tries to use
+  the plugin.
+- **No name attribute → rejected.** Entry-point objects that load
+  successfully but expose no truthy `.name` attribute warn and skip -
+  there's no fallback to the entry-point name on the registry side.
 
 If you need to verify your entry point is registering correctly, the
 inventory CLI is the fastest check:

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -55,6 +55,7 @@ FieldType = Literal[
 ]
 
 __all__ = [
+    "EntryPointTombstone",
     "FieldType",
     "PluginBase",
     "PluginField",
@@ -489,6 +490,51 @@ class PluginBase:
 
 
 # ---------------------------------------------------------------------------
+# Entry-point tombstone: defer a plugin's own ImportError to first use
+# ---------------------------------------------------------------------------
+
+
+class EntryPointTombstone:
+    """Placeholder for an entry-point plugin whose *own* import raised.
+
+    When a third-party entry point fails to load (e.g. a missing optional
+    dependency such as ``open_clip`` for a ``siglip_l`` embedder), we don't
+    want that single failure to crash discovery for every other plugin.
+    Instead the registry registers one of these under the entry point's name
+    so the plugin still *resolves* via :meth:`PluginRegistry.get`, and the
+    original error is re-raised only when the plugin is actually invoked
+    (any attribute access other than :attr:`name` / private / dunder names).
+
+    Tombstones are deliberately kept out of :meth:`PluginRegistry.list` so
+    listing/serialising the plugin family (which touches ``to_dict``,
+    ``display_name``, ``ui_mode``, ...) never trips over them; the broken
+    plugin only bites the caller who deliberately asks for it by name.
+
+    The object is a plain, picklable value: :attr:`name`, the entry-point
+    ``value`` string, and the captured exception all live in ``__dict__``,
+    so ``pickle.loads(pickle.dumps(tombstone))`` round-trips and the restored
+    copy re-raises the same error on use.
+    """
+
+    def __init__(self, name: str, value: str, error: BaseException) -> None:
+        self.name = name
+        self._ep_value = value
+        self._error = error
+
+    def __getattr__(self, attr: str) -> Any:
+        # Private / dunder lookups (``__reduce_ex__``, ``__getstate__``,
+        # ``__deepcopy__``, ...) must fall through with AttributeError so
+        # pickle and copy keep working; only "real" plugin attribute/method
+        # access re-raises the deferred import error.
+        if attr.startswith("_"):
+            raise AttributeError(attr)
+        raise ImportError(
+            f"Plugin {self.name!r} (entry point {self._ep_value!r}) is unavailable "
+            f"because its import failed: {self._error}"
+        ) from self._error
+
+
+# ---------------------------------------------------------------------------
 # PluginRegistry: generic auto-discovery registry
 # ---------------------------------------------------------------------------
 
@@ -548,6 +594,10 @@ class PluginRegistry(Generic[T]):
         self._discover_modules = discover_modules
         self._entry_point_group = entry_point_group
         self._items: dict[str, T] = {}
+        #: Entry-point plugins whose own import raised, keyed by entry-point
+        #: name.  Resolvable via :meth:`get` (re-raising the original error on
+        #: use) but deliberately excluded from :meth:`list`.
+        self._tombstones: dict[str, EntryPointTombstone] = {}
         self._discovered = False
         self._discovering = False
         self._lock = threading.Lock()
@@ -601,8 +651,12 @@ class PluginRegistry(Generic[T]):
 
         Each entry point in :attr:`_entry_point_group` is resolved to an
         object that's treated like a sentinel value; its ``.name`` is the
-        registry key.  Failures are surfaced as warnings so a single bad
-        third-party plugin can't break the rest of the registry.
+        registry key.  When an entry point's *own* import raises (e.g. a
+        missing optional dependency), the failure is surfaced as a warning
+        and a :class:`EntryPointTombstone` is registered under the entry-point
+        name so the plugin still resolves via :meth:`get` and the original
+        error is deferred to first use — a single bad third-party plugin can't
+        break discovery for the rest of the registry.
 
         Built-in plugins (discovered by the package scan above) take
         precedence: an entry point whose name clashes with a built-in is
@@ -624,10 +678,18 @@ class PluginRegistry(Generic[T]):
             try:
                 plugin = ep.load()
             except Exception as exc:
+                # The plugin's *own* import raised (e.g. a missing optional
+                # dependency).  Don't crash discovery: register a tombstone
+                # under the entry-point name so the plugin still resolves and
+                # the original error is deferred to first use.  A built-in of
+                # the same name still wins (it's already in ``_items``).
                 warnings.warn(
-                    f"Failed to load {self._label} entry point {ep.name!r} from {ep.value!r}: {exc}",
+                    f"Failed to load {self._label} entry point {ep.name!r} from {ep.value!r}: {exc}; "
+                    f"deferring the error to first use of {ep.name!r}",
                     stacklevel=2,
                 )
+                if ep.name not in self._items:
+                    self._tombstones[ep.name] = EntryPointTombstone(ep.name, ep.value, exc)
                 continue
             plugin_name = getattr(plugin, "name", None)
             if not plugin_name:
@@ -713,12 +775,25 @@ class PluginRegistry(Generic[T]):
     # -- Public API ---------------------------------------------------------
 
     def get(self, name: str) -> T | None:
-        """Return the registered plugin with *name*, or ``None``."""
+        """Return the registered plugin with *name*, or ``None``.
+
+        Falls back to a tombstone for an entry-point plugin whose own import
+        failed (see :class:`EntryPointTombstone`); the returned object
+        re-raises the original error the moment it is actually invoked.
+        """
         self._ensure_discovered()
-        return self._items.get(name)
+        item = self._items.get(name)
+        if item is not None:
+            return item
+        return self._tombstones.get(name)  # type: ignore[return-value]
 
     def list(self) -> list[T]:
-        """Return all registered plugins in discovery order."""
+        """Return all registered plugins in discovery order.
+
+        Tombstones for failed entry-point imports are excluded so that
+        listing/serialising a plugin family never trips over a broken plugin;
+        such plugins are reachable only by an explicit :meth:`get`.
+        """
         self._ensure_discovered()
         return list(self._items.values())
 


### PR DESCRIPTION
## Summary

When a third-party entry-point plugin's *own* import raises — typically a missing optional dependency (e.g. `open_clip` absent for a `siglip_l` embedder) — plugin discovery previously warned and silently dropped the plugin. This change registers a **tombstone** under the entry-point name so the plugin still resolves, deferring the original error to first use instead of making the plugin vanish.

## What changed

- **`vtscore/plugins/__init__.py`**
  - New `EntryPointTombstone` class: a plain, picklable placeholder holding the entry-point name, value, and captured exception. Any real attribute/method access re-raises the original error (chained via `from`); private/dunder lookups fall through so pickle and copy keep working.
  - `_discover_entry_points()` now registers a tombstone (keyed by entry-point name) when `ep.load()` raises, instead of skipping. A built-in of the same name still wins (the tombstone is only registered when the name isn't already in `_items`).
  - `get()` falls back to the tombstone dict; `list()` deliberately excludes tombstones so serialising a plugin family (which touches `to_dict`/`display_name`/`ui_mode`) never trips over a broken plugin.
- **`tests/core/test_plugin_entry_points.py`** — updated the failed-load test and added coverage: a broken EP still lets healthy siblings resolve; the tombstone re-raises the original message on invoke; the tombstone survives pickle; a failing EP named after a built-in doesn't shadow the working built-in.
- **`vtscore/docs/packages/plugins.md`** — documented the tombstone/defer-to-first-use behavior.

## Behavior change (backwards compatibility)

A broken entry-point plugin now **resolves** via `get(name)` (returning a tombstone that raises on use) rather than returning `None`. Listing behavior is unchanged — broken plugins still don't appear in `list()`.

## Testing

`./run-tests.sh` — all 6218 tests pass.

Closes #2500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JgnmtZxKxiUuiFRCk45Ei

---
_Generated by [Claude Code](https://claude.ai/code/session_018JgnmtZxKxiUuiFRCk45Ei)_