### PR TITLE
MLP-ensemble uncertainty: eval-harness axes + sweep runner

### DIFF
--- a/scripts/run_mlp_ensemble_sweep.py
+++ b/scripts/run_mlp_ensemble_sweep.py
@@ -1,0 +1,426 @@
+"""MLP-ensemble uncertainty sweep.
+
+Throwaway experiment script for issue #2497 ("MLP uncertainty").  It
+exercises the two ensemble axes added to the eval harness and writes the
+results (CSVs, plots, a README) under ``docs/experiments/mlp-ensemble/``:
+
+1. **Label-curve axis** (`vtscore.eval.label_curve`) - trains the single
+   MLP, the SVM baselines, and the ``mlp_ens{3,5,7,10}`` ensembles over a
+   growing label budget.  Shows whether averaging N seed-varied MLPs buys
+   any ranking (AUROC / F1@xcal) over one MLP, and traces the ensemble's
+   reported per-item uncertainty (``std_mean``) as labels accumulate.
+
+2. **Voting-order axis** (`vtscore.eval.voting_iterations`) - simulates
+   voting under ``vote_order ∈ {shuffle, balanced, ensemble_std}`` and
+   plots the inclusion-weighted cost against the number of votes cast.
+   Answers "does choosing the next vote by ensemble disagreement (active
+   learning) reach a low cost in fewer votes than random or class-balanced
+   ordering?"  Per-step cost is always the single production MLP; the
+   ensemble only *selects* the next vote.
+
+Usage::
+
+    python scripts/run_mlp_ensemble_sweep.py \\
+        --datasets urbansound8k_s \\
+        --out-dir docs/experiments/mlp-ensemble \\
+        --label-counts 5 10 20 50 \\
+        --seeds 0 1 2 \\
+        --max-votes 40
+
+Designed to be deleted once the results are committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from vtscore.eval.label_curve import run_label_curve_eval, summarise
+from vtscore.eval.voting_iterations import VOTE_ORDERS, run_voting_iterations_eval
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+DEFAULT_DATASETS = ("urbansound8k_s",)
+DEFAULT_LABEL_COUNTS = (5, 10, 20, 50)
+DEFAULT_SEEDS = (0, 1, 2)
+DEFAULT_ENSEMBLE_SIZES = (3, 5, 7, 10)
+
+
+# ---------------------------------------------------------------------------
+# Dataset loading
+# ---------------------------------------------------------------------------
+
+
+def _load_dataset(demo_id: str) -> dict[int, dict[str, Any]]:
+    """Load one demo dataset into a fresh medias dict."""
+    from vtscore.datasets.loader import load_demo_dataset
+
+    medias: dict[int, dict[str, Any]] = {}
+    load_demo_dataset(demo_id, medias)
+    return medias
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def _setup_style() -> None:
+    import matplotlib.pyplot as plt
+
+    plt.rcParams.update(
+        {
+            "figure.facecolor": "white",
+            "axes.facecolor": "white",
+            "axes.grid": True,
+            "grid.alpha": 0.3,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+        }
+    )
+
+
+def plot_label_curve(summary: "pd.DataFrame", out_dir: Path) -> list[Path]:
+    """One line per trainer: AUROC and F1@xcal vs label count, ±1 std band.
+
+    Curves are averaged over every (dataset, category) cell so the figure
+    reads as "trainer X's ranking quality at N labels", which is the axis
+    the ensemble question lives on.
+    """
+    import matplotlib.pyplot as plt
+
+    generated: list[Path] = []
+    if summary.empty:
+        return generated
+
+    palette = plt.cm.tab10.colors  # type: ignore[attr-defined]
+    trainers = sorted(summary["trainer"].unique())
+
+    for metric, ylabel in (("auroc", "AUROC"), ("f1_at_xcal", "F1 @ cross-cal threshold")):
+        mean_col, std_col = f"{metric}_mean", f"{metric}_std"
+        if mean_col not in summary.columns:
+            continue
+        fig, ax = plt.subplots(figsize=(8, 5))
+        for idx, trainer in enumerate(trainers):
+            sub = summary[summary["trainer"] == trainer]
+            agg = sub.groupby("n_labels")[[mean_col, std_col]].mean().reset_index()
+            colour = palette[idx % len(palette)]
+            n = agg["n_labels"].to_numpy()
+            mean = agg[mean_col].to_numpy()
+            std = agg[std_col].fillna(0).to_numpy()
+            ax.plot(n, mean, marker="o", label=trainer, color=colour, linewidth=1.5)
+            if (std > 0).any():
+                ax.fill_between(n, mean - std, mean + std, alpha=0.12, color=colour)
+        ax.set_xlabel("Training labels")
+        ax.set_ylabel(ylabel)
+        ax.set_title(f"Label curve: {ylabel} by trainer")
+        ax.legend(fontsize=8, loc="best")
+        fig.tight_layout()
+        path = out_dir / f"label_curve_{metric}.png"
+        fig.savefig(path, dpi=150)
+        plt.close(fig)
+        generated.append(path)
+
+    # Ensemble uncertainty: std_mean vs label count, ensemble trainers only.
+    if "std_mean_mean" in summary.columns:
+        ens = summary[summary["trainer"].str.startswith("mlp_ens")]
+        if not ens.empty:
+            fig, ax = plt.subplots(figsize=(8, 5))
+            for idx, trainer in enumerate(sorted(ens["trainer"].unique())):
+                sub = ens[ens["trainer"] == trainer]
+                agg = sub.groupby("n_labels")["std_mean_mean"].mean().reset_index()
+                colour = palette[idx % len(palette)]
+                ax.plot(
+                    agg["n_labels"].to_numpy(),
+                    agg["std_mean_mean"].to_numpy(),
+                    marker="o",
+                    label=trainer,
+                    color=colour,
+                    linewidth=1.5,
+                )
+            ax.set_xlabel("Training labels")
+            ax.set_ylabel("Mean per-item ensemble std")
+            ax.set_title("Ensemble uncertainty (std_mean) by label count")
+            ax.legend(fontsize=8, loc="best")
+            fig.tight_layout()
+            path = out_dir / "label_curve_std_mean.png"
+            fig.savefig(path, dpi=150)
+            plt.close(fig)
+            generated.append(path)
+
+    return generated
+
+
+def plot_voting_orders(df: "pd.DataFrame", out_dir: Path) -> list[Path]:
+    """Cost vs votes cast, one line per vote_order (averaged over cells)."""
+    import matplotlib.pyplot as plt
+
+    generated: list[Path] = []
+    if df.empty:
+        return generated
+
+    palette = plt.cm.tab10.colors  # type: ignore[attr-defined]
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for idx, order in enumerate(sorted(df["vote_order"].unique())):
+        sub = df[df["vote_order"] == order]
+        agg = sub.groupby("t")["cost"].agg(["mean", "std"]).reset_index()
+        colour = palette[idx % len(palette)]
+        t = agg["t"].to_numpy()
+        mean = agg["mean"].to_numpy()
+        std = agg["std"].fillna(0).to_numpy()
+        ax.plot(t, mean, label=order, color=colour, linewidth=1.5)
+        if (std > 0).any():
+            ax.fill_between(t, mean - std, mean + std, alpha=0.12, color=colour)
+    ax.set_xlabel("Votes cast (t)")
+    ax.set_ylabel("Inclusion-weighted cost")
+    ax.set_title("Voting cost by vote_order")
+    ax.legend(fontsize=8, loc="best")
+    fig.tight_layout()
+    path = out_dir / "voting_cost_by_order.png"
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    generated.append(path)
+    return generated
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def write_report(
+    *,
+    report_path: Path,
+    datasets: tuple[str, ...],
+    label_counts: tuple[int, ...],
+    seeds: tuple[int, ...],
+    ensemble_sizes: tuple[int, ...],
+    vote_orders: tuple[str, ...],
+    max_votes: int | None,
+    n_ensemble: int,
+    label_summary: "pd.DataFrame",
+    voting_df: "pd.DataFrame",
+) -> None:
+    lines: list[str] = []
+    lines.append("# MLP-ensemble uncertainty sweep")
+    lines.append("")
+    lines.append(
+        "Throwaway experiment for issue #2497.  Regenerate with "
+        "`python scripts/run_mlp_ensemble_sweep.py` (see the module "
+        "docstring for flags).  All CSVs and PNGs in this directory are "
+        "produced by that script."
+    )
+    lines.append("")
+    lines.append(
+        f"Datasets: {', '.join(f'`{d}`' for d in datasets)} · "
+        f"label counts: {list(label_counts)} · seeds: {list(seeds)} · "
+        f"ensemble sizes: {list(ensemble_sizes)} · "
+        f"vote orders: {list(vote_orders)} · "
+        f"max_votes: {max_votes} · ensemble_std n_ensemble: {n_ensemble}."
+    )
+    lines.append("")
+
+    # ---- Label-curve axis --------------------------------------------------
+    lines.append("## 1. Label curve - does an MLP ensemble out-rank one MLP?")
+    lines.append("")
+    lines.append(
+        "`mlp` is the single production MLP; `mlp_ens{N}` averages N "
+        "seed-varied MLPs and reports member disagreement as per-item "
+        "uncertainty.  VTSearch ranks by score and learns its own "
+        "threshold, so the metrics that matter are **AUROC** (ranking) "
+        "and **F1@xcal** (production-path F1); Brier / F1@0.5 stay "
+        "diagnostic.  `std_mean` is the ensemble's mean per-item "
+        "uncertainty - it is `nan` for the non-ensemble trainers."
+    )
+    lines.append("")
+    lines.append("![AUROC by trainer](label_curve_auroc.png)")
+    lines.append("")
+    lines.append("![F1@xcal by trainer](label_curve_f1_at_xcal.png)")
+    lines.append("")
+    lines.append("![Ensemble uncertainty](label_curve_std_mean.png)")
+    lines.append("")
+    lines.append("Mean AUROC / F1@xcal per trainer, collapsed over seeds and label counts:")
+    lines.append("")
+    lines.extend(_trainer_headline_table(label_summary))
+    lines.append("")
+
+    # ---- Voting-order axis -------------------------------------------------
+    lines.append("## 2. Voting order - does ensemble-uncertainty selection help?")
+    lines.append("")
+    lines.append(
+        "Cost is the inclusion-weighted `fpr_weight·FPR + fnr_weight·FNR` "
+        "on a held-out test split, measured with the single production MLP "
+        "at every step.  `shuffle` votes in random order, `balanced` keeps "
+        "the running label set class-balanced, and `ensemble_std` votes "
+        "next on the item an N-member ensemble disagrees about most (active "
+        "learning).  A lower curve, or the same cost reached at a smaller "
+        "`t`, means the ordering is more label-efficient."
+    )
+    lines.append("")
+    lines.append("![Cost by vote_order](voting_cost_by_order.png)")
+    lines.append("")
+    lines.extend(_voting_headline_table(voting_df))
+    lines.append("")
+
+    lines.append("## Files")
+    lines.append("")
+    lines.append("- `label_curve.csv` - one row per (dataset, category, trainer, n_labels, seed).")
+    lines.append("- `voting_iterations.csv` - one row per (vote_order, seed, dataset, category, t).")
+    lines.append("- `*.png` - the plots embedded above.")
+    lines.append("")
+
+    report_path.write_text("\n".join(lines))
+
+
+def _trainer_headline_table(summary: "pd.DataFrame") -> list[str]:
+    if summary.empty:
+        return ["_(no rows - every cell was skipped)_"]
+    rows = ["| trainer | AUROC | F1@xcal | mean std |", "|---|---|---|---|"]
+    for trainer in sorted(summary["trainer"].unique()):
+        sub = summary[summary["trainer"] == trainer]
+        auroc = float(sub["auroc_mean"].mean()) if "auroc_mean" in sub else float("nan")
+        f1 = float(sub["f1_at_xcal_mean"].mean()) if "f1_at_xcal_mean" in sub else float("nan")
+        std_mean = float(sub["std_mean_mean"].mean()) if "std_mean_mean" in sub else float("nan")
+        std_txt = "—" if math.isnan(std_mean) else f"{std_mean:.3f}"
+        rows.append(f"| `{trainer}` | {auroc:.3f} | {f1:.3f} | {std_txt} |")
+    return rows
+
+
+def _voting_headline_table(df: "pd.DataFrame") -> list[str]:
+    if df.empty:
+        return ["_(no rows - every cell was skipped)_"]
+    rows = ["| vote_order | steps | final cost | min cost |", "|---|---|---|---|"]
+    for order in sorted(df["vote_order"].unique()):
+        sub = df[df["vote_order"] == order]
+        # Final cost = mean cost at the largest t reached per (seed, dataset, category).
+        finals = sub.sort_values("t").groupby(["seed", "dataset", "category"]).tail(1)
+        rows.append(
+            f"| `{order}` | {int(sub['t'].max())} | "
+            f"{float(finals['cost'].mean()):.4f} | {float(sub['cost'].min()):.4f} |"
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--datasets", nargs="+", default=list(DEFAULT_DATASETS), metavar="DEMO_ID")
+    ap.add_argument("--out-dir", type=Path, default=Path("docs/experiments/mlp-ensemble"))
+    ap.add_argument("--label-counts", nargs="+", type=int, default=list(DEFAULT_LABEL_COUNTS))
+    ap.add_argument("--seeds", nargs="+", type=int, default=list(DEFAULT_SEEDS))
+    ap.add_argument("--ensemble-sizes", nargs="+", type=int, default=list(DEFAULT_ENSEMBLE_SIZES))
+    ap.add_argument(
+        "--vote-orders",
+        nargs="+",
+        default=list(VOTE_ORDERS),
+        choices=list(VOTE_ORDERS),
+        help="Vote orders to compare in the voting-iterations axis.",
+    )
+    ap.add_argument("--categories", nargs="+", default=None, metavar="CAT")
+    ap.add_argument("--inclusion", type=int, default=0)
+    ap.add_argument(
+        "--max-votes",
+        type=int,
+        default=40,
+        help="Cap on votes cast per cell (keeps the ensemble_std order tractable). "
+        "Pass 0 for no cap.",
+    )
+    ap.add_argument(
+        "--n-ensemble",
+        type=int,
+        default=5,
+        help="Ensemble size used for ensemble_std vote selection (default 5).",
+    )
+    ap.add_argument("--no-voting", action="store_true", help="Skip the voting-iterations axis.")
+    ap.add_argument("--no-label-curve", action="store_true", help="Skip the label-curve axis.")
+    args = ap.parse_args(argv)
+
+    import pandas as pd
+
+    from vtscore.embedding import initialize_models
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    _setup_style()
+    initialize_models()
+
+    print("Loading datasets…", flush=True)
+    dataset_clips: dict[str, dict[int, dict[str, Any]]] = {}
+    for demo_id in args.datasets:
+        print(f"  {demo_id}", flush=True)
+        dataset_clips[demo_id] = _load_dataset(demo_id)
+
+    categories = {ds: args.categories for ds in dataset_clips} if args.categories else None
+    max_votes = None if args.max_votes in (0, None) else args.max_votes
+
+    label_summary = pd.DataFrame()
+    voting_df = pd.DataFrame()
+
+    # ---- Label-curve axis --------------------------------------------------
+    if not args.no_label_curve:
+        trainers = ["mlp", "svm_linear", *[f"mlp_ens{n}" for n in args.ensemble_sizes]]
+        print(f"\nLabel-curve sweep: trainers={trainers}", flush=True)
+        label_df = run_label_curve_eval(
+            dataset_clips=dataset_clips,
+            trainers=trainers,
+            label_counts=tuple(args.label_counts),
+            seeds=tuple(args.seeds),
+            categories=categories,
+            inclusion_value=args.inclusion,
+            progress=True,
+        )
+        label_df.to_csv(args.out_dir / "label_curve.csv", index=False)
+        print(f"  wrote {len(label_df)} rows -> label_curve.csv", flush=True)
+        label_summary = summarise(label_df, include_diagnostics=True)
+        for p in plot_label_curve(label_summary, args.out_dir):
+            print(f"  plot -> {p.name}", flush=True)
+
+    # ---- Voting-order axis -------------------------------------------------
+    if not args.no_voting:
+        print(f"\nVoting-iterations sweep: vote_orders={args.vote_orders}", flush=True)
+        frames: list[pd.DataFrame] = []
+        for order in args.vote_orders:
+            print(f"  vote_order={order}", flush=True)
+            df = run_voting_iterations_eval(
+                dataset_clips=dataset_clips,
+                seeds=list(args.seeds),
+                categories=categories,
+                inclusion=args.inclusion,
+                vote_order=order,
+                n_ensemble=args.n_ensemble,
+                max_votes=max_votes,
+            )
+            df["vote_order"] = order
+            frames.append(df)
+        voting_df = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        voting_df.to_csv(args.out_dir / "voting_iterations.csv", index=False)
+        print(f"  wrote {len(voting_df)} rows -> voting_iterations.csv", flush=True)
+        for p in plot_voting_orders(voting_df, args.out_dir):
+            print(f"  plot -> {p.name}", flush=True)
+
+    # ---- Report ------------------------------------------------------------
+    report_path = args.out_dir / "README.md"
+    write_report(
+        report_path=report_path,
+        datasets=tuple(args.datasets),
+        label_counts=tuple(args.label_counts),
+        seeds=tuple(args.seeds),
+        ensemble_sizes=tuple(args.ensemble_sizes),
+        vote_orders=tuple(args.vote_orders),
+        max_votes=max_votes,
+        n_ensemble=args.n_ensemble,
+        label_summary=label_summary,
+        voting_df=voting_df,
+    )
+    print(f"\nwrote report -> {report_path}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_mlp_ensemble_sweep.py
+++ b/scripts/run_mlp_ensemble_sweep.py
@@ -329,8 +329,7 @@ def main(argv: list[str] | None = None) -> int:
         "--max-votes",
         type=int,
         default=40,
-        help="Cap on votes cast per cell (keeps the ensemble_std order tractable). "
-        "Pass 0 for no cap.",
+        help="Cap on votes cast per cell (keeps the ensemble_std order tractable). Pass 0 for no cap.",
     )
     ap.add_argument(
         "--n-ensemble",

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -7,7 +7,11 @@ embeddings so no real model downloads are needed.
 import numpy as np
 import pandas as pd
 
+import pytest
+
 from vtscore.eval.voting_iterations import (
+    VOTE_ORDERS,
+    _balanced_vote_sequence,
     _good_training_vec,
     _inclusion_weights,
     _make_vote_sequence,
@@ -619,3 +623,159 @@ class TestRegionVotingSimulate:
         )
         assert not df.empty
         assert (df["category"] == "apple").all()
+
+
+# ------------------------------------------------------------------
+# Vote-order / n_ensemble / max_votes axes
+# ------------------------------------------------------------------
+
+_ROW_KEYS = {
+    "seed",
+    "dataset",
+    "category",
+    "t",
+    "n_good",
+    "n_bad",
+    "cost",
+    "fpr",
+    "fnr",
+    "elapsed_seconds",
+}
+
+
+class TestBalancedVoteSequence:
+    def test_running_counts_stay_balanced(self):
+        medias = _make_separable_clips(n_per_cat=8)
+        sim_ids = list(medias.keys())
+        rng = np.random.RandomState(0)
+        seq = _balanced_vote_sequence(sim_ids, medias, "alpha", rng)
+        # Same set of votes as a plain shuffle, just reordered.
+        assert {cid for cid, _ in seq} == set(sim_ids)
+        # First two votes are one good + one bad (earliest trainable step).
+        assert {seq[0][1], seq[1][1]} == {"good", "bad"}
+        # Running good/bad counts never drift more than one apart.
+        n_good = n_bad = 0
+        for _, label in seq:
+            if label == "good":
+                n_good += 1
+            else:
+                n_bad += 1
+            assert abs(n_good - n_bad) <= 1
+
+    def test_handles_single_class_pool(self):
+        # All 'alpha' → every vote is good; sequence is just the goods.
+        medias = _make_separable_clips(n_per_cat=6)
+        alpha_ids = [cid for cid, m in medias.items() if m["category"] == "alpha"]
+        rng = np.random.RandomState(0)
+        seq = _balanced_vote_sequence(alpha_ids, medias, "alpha", rng)
+        assert len(seq) == len(alpha_ids)
+        assert all(label == "good" for _, label in seq)
+
+
+class TestVoteOrderAxis:
+    def test_vote_orders_constant_matches_supported(self):
+        assert set(VOTE_ORDERS) == {"shuffle", "balanced", "ensemble_std"}
+
+    def test_default_is_shuffle(self):
+        # Omitting vote_order reproduces the explicit "shuffle" run exactly.
+        medias = _make_separable_clips(n_per_cat=8)
+        default = simulate_voting_iterations(medias, "alpha", seed=3, calibrate_count=1)
+        shuffle = simulate_voting_iterations(medias, "alpha", seed=3, vote_order="shuffle", calibrate_count=1)
+        assert len(default) == len(shuffle)
+        for a, b in zip(default, shuffle):
+            assert {k: v for k, v in a.items() if k != "elapsed_seconds"} == {
+                k: v for k, v in b.items() if k != "elapsed_seconds"
+            }
+
+    def test_unknown_vote_order_raises(self):
+        medias = _make_separable_clips(n_per_cat=6)
+        with pytest.raises(ValueError, match="vote_order"):
+            simulate_voting_iterations(medias, "alpha", seed=0, vote_order="nope")
+
+    @pytest.mark.parametrize("order", ["shuffle", "balanced", "ensemble_std"])
+    def test_row_schema_stable_across_orders(self, order):
+        medias = _make_separable_clips(n_per_cat=8)
+        rows = simulate_voting_iterations(
+            medias, "alpha", seed=0, vote_order=order, n_ensemble=3, max_votes=8, calibrate_count=1
+        )
+        assert rows
+        for row in rows:
+            assert set(row.keys()) == _ROW_KEYS
+            assert np.isfinite(row["cost"])
+
+    def test_balanced_starts_trainable_immediately(self):
+        # Balanced ordering makes the first two votes 1 good + 1 bad, so the
+        # earliest scored step is t=2 with a 1-vs-1 model.
+        medias = _make_separable_clips(n_per_cat=8)
+        rows = simulate_voting_iterations(medias, "alpha", seed=0, vote_order="balanced", calibrate_count=1)
+        assert rows
+        assert rows[0]["t"] == 2
+        assert rows[0]["n_good"] == 1
+        assert rows[0]["n_bad"] == 1
+
+    def test_ensemble_std_deterministic(self):
+        medias = _make_separable_clips(n_per_cat=8)
+        kw = dict(vote_order="ensemble_std", n_ensemble=3, max_votes=8, calibrate_count=1)
+        rows1 = simulate_voting_iterations(medias, "alpha", seed=1, **kw)
+        rows2 = simulate_voting_iterations(medias, "alpha", seed=1, **kw)
+        assert len(rows1) == len(rows2)
+        for a, b in zip(rows1, rows2):
+            assert {k: v for k, v in a.items() if k != "elapsed_seconds"} == {
+                k: v for k, v in b.items() if k != "elapsed_seconds"
+            }
+
+    def test_n_ensemble_axis_runs(self):
+        medias = _make_separable_clips(n_per_cat=10)
+        for n in (2, 5):
+            rows = simulate_voting_iterations(
+                medias, "alpha", seed=0, vote_order="ensemble_std", n_ensemble=n, max_votes=6, calibrate_count=1
+            )
+            assert rows
+            assert all(np.isfinite(r["cost"]) for r in rows)
+
+
+class TestMaxVotes:
+    def test_caps_shuffle_steps(self):
+        medias = _make_separable_clips(n_per_cat=12)
+        rows = simulate_voting_iterations(medias, "alpha", seed=0, max_votes=5, calibrate_count=1)
+        # No scored step can exceed the vote cap.
+        assert rows
+        assert max(r["t"] for r in rows) <= 5
+
+    def test_caps_ensemble_std_steps(self):
+        medias = _make_separable_clips(n_per_cat=12)
+        rows = simulate_voting_iterations(
+            medias, "alpha", seed=0, vote_order="ensemble_std", n_ensemble=3, max_votes=5, calibrate_count=1
+        )
+        assert rows
+        assert max(r["t"] for r in rows) <= 5
+
+
+class TestRunEvalThreadsVoteOrder:
+    @pytest.mark.parametrize("order", ["balanced", "ensemble_std"])
+    def test_run_eval_threads_vote_order(self, order):
+        medias = _make_separable_clips(n_per_cat=8)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": medias},
+            seeds=[0],
+            categories={"ds1": ["alpha"]},
+            vote_order=order,
+            n_ensemble=3,
+            max_votes=8,
+            calibrate_count=1,
+        )
+        assert not df.empty
+        # Row schema is unchanged by vote_order (selection never leaks into
+        # the per-step evaluation columns).
+        assert list(df.columns) == [
+            "seed",
+            "dataset",
+            "category",
+            "t",
+            "n_good",
+            "n_bad",
+            "cost",
+            "fpr",
+            "fnr",
+            "elapsed_seconds",
+        ]

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -715,9 +715,12 @@ class TestVoteOrderAxis:
 
     def test_ensemble_std_deterministic(self):
         medias = _make_separable_clips(n_per_cat=8)
-        kw = dict(vote_order="ensemble_std", n_ensemble=3, max_votes=8, calibrate_count=1)
-        rows1 = simulate_voting_iterations(medias, "alpha", seed=1, **kw)
-        rows2 = simulate_voting_iterations(medias, "alpha", seed=1, **kw)
+        rows1 = simulate_voting_iterations(
+            medias, "alpha", seed=1, vote_order="ensemble_std", n_ensemble=3, max_votes=8, calibrate_count=1
+        )
+        rows2 = simulate_voting_iterations(
+            medias, "alpha", seed=1, vote_order="ensemble_std", n_ensemble=3, max_votes=8, calibrate_count=1
+        )
         assert len(rows1) == len(rows2)
         for a, b in zip(rows1, rows2):
             assert {k: v for k, v in a.items() if k != "elapsed_seconds"} == {

--- a/tests_lib/detectors/test_label_curve.py
+++ b/tests_lib/detectors/test_label_curve.py
@@ -7,7 +7,9 @@ import pytest
 
 from vtscore.eval.label_curve import (
     TRAINERS,
+    _as_scores,
     _auroc,
+    _auroc_std_err,
     _average_precision,
     _best_f1,
     _brier,
@@ -93,6 +95,37 @@ class TestMetricHelpers:
         scores = np.array([0.9, 0.6, 0.4, 0.1])
         labels = np.array([1, 1, 0, 0])
         assert _best_f1(scores, labels) == pytest.approx(1.0)
+
+    def test_auroc_std_err_finite_and_nonneg(self):
+        # Non-degenerate AUROC → a finite, non-negative Hanley-McNeil SE.
+        scores = np.array([0.9, 0.7, 0.6, 0.3, 0.2, 0.1])
+        labels = np.array([1, 1, 0, 1, 0, 0])
+        auroc = _auroc(scores, labels)
+        se = _auroc_std_err(scores, labels, auroc)
+        assert np.isfinite(se)
+        assert se >= 0.0
+
+    def test_auroc_std_err_zero_for_perfect_separation(self):
+        # A=1.0 makes every variance term vanish → SE == 0.
+        scores = np.array([0.9, 0.8, 0.2, 0.1])
+        labels = np.array([1, 1, 0, 0])
+        assert _auroc_std_err(scores, labels, 1.0) == pytest.approx(0.0)
+
+    def test_auroc_std_err_nan_when_single_class(self):
+        scores = np.array([0.9, 0.8, 0.7])
+        labels = np.array([1, 1, 1])
+        assert np.isnan(_auroc_std_err(scores, labels, float("nan")))
+
+
+class TestAsScores:
+    def test_passes_through_plain_array(self):
+        arr = np.array([0.1, 0.9, 0.5])
+        np.testing.assert_array_equal(_as_scores(arr), arr)
+
+    def test_extracts_scores_from_tuple(self):
+        scores = np.array([0.1, 0.9])
+        std = np.array([0.01, 0.02])
+        np.testing.assert_array_equal(_as_scores((scores, std)), scores)
 
 
 class TestSplitPool:
@@ -196,6 +229,8 @@ class TestEvaluateOne:
         "train_seconds",
         "brier",
         "f1_at_0.5",
+        "std_err_auroc",
+        "std_mean",
         "predict_seconds",
     )
 
@@ -214,6 +249,10 @@ class TestEvaluateOne:
         assert np.isfinite(row["xcal_threshold"])
         # f1_at_xcal should be high too on this trivially-separable data.
         assert row["f1_at_xcal"] > 0.7
+        # A non-ensemble trainer reports no per-item spread.
+        assert np.isnan(row["std_mean"])
+        # But the analytic AUROC standard error is always available.
+        assert np.isfinite(row["std_err_auroc"])
 
     def test_returns_row_schema_for_mlp(self):
         clips = _synth_dataset(n_pos=20, n_neg=20)
@@ -232,6 +271,85 @@ class TestEvaluateOne:
         assert pool is not None
         with pytest.raises(KeyError):
             evaluate_one(pool, trainer_name="random_forest", n_labels=10, seed=0)
+
+
+class TestEnsembleTrainers:
+    """The ``mlp_ens{N}`` factories: mean sigmoid + per-item disagreement."""
+
+    @pytest.mark.parametrize("name", ["mlp_ens3", "mlp_ens5", "mlp_ens7", "mlp_ens10"])
+    def test_registered(self, name):
+        assert name in TRAINERS
+
+    def test_predict_returns_scores_and_std(self):
+        # A 5-member ensemble's predict() returns (mean_sigmoid, per_item_std)
+        # with member disagreement strictly positive on real (noisy) inits.
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((20, 6)).astype(np.float32)
+        X[:10, 0] += 1.5
+        X[10:, 0] -= 1.5
+        y = np.array([1] * 10 + [0] * 10, dtype=np.int32)
+        predict = TRAINERS["mlp_ens5"](X, y, 0)
+        out = predict(X)
+        assert isinstance(out, tuple)
+        scores, std = out
+        assert scores.shape == (20,)
+        assert std.shape == (20,)
+        assert np.all(scores >= 0.0) and np.all(scores <= 1.0)
+        assert np.all(std >= 0.0)
+        # Distinct member seeds ⇒ some genuine disagreement somewhere.
+        assert float(std.max()) > 0.0
+
+    def test_evaluate_one_emits_std_mean(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        pool = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool is not None
+        row = evaluate_one(pool, trainer_name="mlp_ens3", n_labels=10, seed=0)
+        assert row is not None
+        assert row["trainer"] == "mlp_ens3"
+        # Ensemble trainers report a finite, non-negative mean uncertainty
+        # (unlike single-model trainers, whose std_mean is nan).
+        assert np.isfinite(row["std_mean"])
+        assert row["std_mean"] >= 0.0
+        assert np.isfinite(row["std_err_auroc"])
+        assert 0.0 <= row["auroc"] <= 1.0
+
+    def test_ensemble_is_deterministic_for_fixed_seed(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        pool = _build_split_pool(clips, "target", seed=0, sim_fraction=0.5)
+        assert pool is not None
+        row_a = evaluate_one(pool, trainer_name="mlp_ens3", n_labels=10, seed=1)
+        row_b = evaluate_one(pool, trainer_name="mlp_ens3", n_labels=10, seed=1)
+        assert row_a is not None and row_b is not None
+        assert row_a["auroc"] == row_b["auroc"]
+        assert row_a["std_mean"] == row_b["std_mean"]
+
+    def test_sweep_diagnostic_columns_present(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        df = run_label_curve_eval(
+            dataset_clips={"synth": clips},
+            trainers=("mlp_ens3",),
+            label_counts=(10,),
+            seeds=(0,),
+            categories={"synth": ["target"]},
+            progress=False,
+        )
+        assert not df.empty
+        assert {"std_err_auroc", "std_mean"} <= set(df.columns)
+        assert df["std_mean"].notna().all()
+
+    def test_summary_include_diagnostics_has_std_mean(self):
+        clips = _synth_dataset(n_pos=20, n_neg=20)
+        df = run_label_curve_eval(
+            dataset_clips={"synth": clips},
+            trainers=("mlp_ens3",),
+            label_counts=(10,),
+            seeds=(0, 1),
+            categories={"synth": ["target"]},
+            progress=False,
+        )
+        summary = summarise(df, include_diagnostics=True)
+        assert "std_mean_mean" in summary.columns
+        assert "std_err_auroc_mean" in summary.columns
 
 
 class TestRunLabelCurveEval:
@@ -367,3 +485,7 @@ class TestRegistryIntrospection:
         assert "mlp" in TRAINERS
         assert "svm_linear" in TRAINERS
         assert "svm_rbf" in TRAINERS
+
+    def test_ensemble_trainers_registered(self):
+        for n in (3, 5, 7, 10):
+            assert f"mlp_ens{n}" in TRAINERS

--- a/vtscore/eval/label_curve.py
+++ b/vtscore/eval/label_curve.py
@@ -57,11 +57,33 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-PredictFn = Callable[[np.ndarray], np.ndarray]
-"""Callable returning P(positive) in [0, 1] for each row of X."""
+PredictFn = Callable[[np.ndarray], "np.ndarray | tuple[np.ndarray, np.ndarray]"]
+"""Callable returning per-row P(positive) - optionally with per-item std.
+
+A plain trainer returns just ``scores`` (P(positive) in ``[0, 1]``).  An
+*ensemble* trainer returns ``(scores, per_item_std)`` where ``scores`` is
+the mean sigmoid across ensemble members and ``per_item_std`` is the
+member-to-member standard deviation - a cheap epistemic-uncertainty
+signal.  Callers that only need the ranking pull ``scores`` out via
+:func:`_as_scores`; callers that want the uncertainty (the diagnostic
+``std_mean`` column) unpack the tuple explicitly.
+"""
 
 TrainerFn = Callable[[np.ndarray, np.ndarray, int], PredictFn]
 """Trainer signature: ``(X_train, y_train, seed) -> predict_fn``."""
+
+
+def _as_scores(result: "np.ndarray | tuple[np.ndarray, np.ndarray]") -> np.ndarray:
+    """Return the score array from a ``predict()`` result.
+
+    Ensemble trainers return ``(scores, per_item_std)``; every other
+    trainer returns a bare score array.  This collapses both to the score
+    array so ranking metrics and threshold calibration don't have to care
+    which trainer produced the prediction.
+    """
+    if isinstance(result, tuple):
+        return np.asarray(result[0], dtype=np.float64)
+    return np.asarray(result, dtype=np.float64)
 
 
 def _train_mlp(X: np.ndarray, y: np.ndarray, seed: int) -> PredictFn:
@@ -83,6 +105,46 @@ def _train_mlp(X: np.ndarray, y: np.ndarray, seed: int) -> PredictFn:
     return predict
 
 
+def _train_mlp_ensemble_factory(n_seeds: int) -> TrainerFn:
+    """Build a trainer that averages *n_seeds* seed-varied MLPs.
+
+    Each member is a full :func:`vtscore.training.mlp.train_model` run on
+    the same labels but a different weight-init/dropout seed, so the
+    ensemble captures the MLP's epistemic uncertainty (how much the
+    decision surface wobbles under reseeding) rather than aleatoric label
+    noise.  The returned ``predict`` reports the mean sigmoid as the score
+    and the member-to-member standard deviation as ``per_item_std`` - high
+    where the members disagree, low where they agree.
+    """
+
+    def trainer(X: np.ndarray, y: np.ndarray, seed: int) -> PredictFn:
+        import torch  # noqa: PLC0415
+
+        from vtscore.training.mlp import train_model
+
+        X_t = torch.from_numpy(np.asarray(X, dtype=np.float32))
+        y_t = torch.from_numpy(np.asarray(y, dtype=np.float32)).unsqueeze(1)
+        input_dim = X.shape[1]
+        # Distinct seeds per member: ``seed + k`` keeps the whole ensemble a
+        # deterministic function of the cell's ``seed`` while decorrelating
+        # the members' weight inits.
+        models = [train_model(X_t, y_t, input_dim=input_dim, seed=seed + k) for k in range(n_seeds)]
+
+        def predict(X_test: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+            X_arr = np.asarray(X_test, dtype=np.float32)
+            member_scores: list[np.ndarray] = []
+            for model in models:
+                with torch.no_grad():
+                    t = torch.from_numpy(X_arr).to(next(model.parameters()).device)
+                    member_scores.append(torch.sigmoid(model(t)).squeeze(1).cpu().numpy())
+            stacked = np.stack(member_scores, axis=0)  # (n_seeds, n_items)
+            return stacked.mean(axis=0), stacked.std(axis=0)
+
+        return predict
+
+    return trainer
+
+
 def _train_svm_factory(kernel: str) -> TrainerFn:
     """Build a sweep-shaped trainer that fits an SVM with the given kernel."""
 
@@ -102,6 +164,14 @@ TRAINERS: dict[str, TrainerFn] = {
     "mlp": _train_mlp,
     "svm_linear": _train_svm_factory("linear"),
     "svm_rbf": _train_svm_factory("rbf"),
+    # MLP ensembles: N seed-varied members, mean sigmoid as the score and
+    # member disagreement as per-item uncertainty.  Registered at 3/5/7/10
+    # members so the sweep can trace how ranking quality and the reported
+    # ``std_mean`` move with ensemble size.
+    "mlp_ens3": _train_mlp_ensemble_factory(3),
+    "mlp_ens5": _train_mlp_ensemble_factory(5),
+    "mlp_ens7": _train_mlp_ensemble_factory(7),
+    "mlp_ens10": _train_mlp_ensemble_factory(10),
 }
 
 
@@ -139,6 +209,31 @@ def _auroc(scores: np.ndarray, labels: np.ndarray) -> float:
     n_neg = float(neg.size)
     u = pos_rank_sum - n_pos * (n_pos + 1) / 2.0
     return float(u / (n_pos * n_neg))
+
+
+def _auroc_std_err(scores: np.ndarray, labels: np.ndarray, auroc: float) -> float:
+    """Hanley-McNeil analytic standard error of the AUROC.
+
+    Uses the closed-form variance estimate from Hanley & McNeil (1982),
+    ``Var = [A(1-A) + (n_pos-1)(Q1 - A²) + (n_neg-1)(Q2 - A²)] /
+    (n_pos·n_neg)`` with ``Q1 = A/(2-A)`` and ``Q2 = 2A²/(1+A)``.  It is a
+    deterministic function of the AUROC and the class counts, so it needs
+    neither bootstrapping nor ensemble members - it is emitted for every
+    trainer as the ``std_err_auroc`` diagnostic, giving an error bar on
+    the ranking metric that complements the ensemble's ``std_mean``.
+
+    Returns ``nan`` when either class is empty or *auroc* is not finite
+    (the AUROC itself is undefined there).
+    """
+    pos = int((labels == 1).sum())
+    neg = int((labels == 0).sum())
+    if pos == 0 or neg == 0 or not np.isfinite(auroc):
+        return float("nan")
+    a = float(auroc)
+    q1 = a / (2.0 - a)
+    q2 = 2.0 * a * a / (1.0 + a)
+    var = (a * (1.0 - a) + (pos - 1) * (q1 - a * a) + (neg - 1) * (q2 - a * a)) / (pos * neg)
+    return float(np.sqrt(max(0.0, var)))
 
 
 def _average_precision(scores: np.ndarray, labels: np.ndarray) -> float:
@@ -307,6 +402,8 @@ threshold from the labels alone."
 _DIAGNOSTIC_METRICS: tuple[str, ...] = (
     "brier",
     "f1_at_0.5",
+    "std_err_auroc",
+    "std_mean",
     "predict_seconds",
 )
 """Kept on every row but excluded from the default summary.
@@ -316,6 +413,14 @@ probability with 0.5 as the operating point - neither holds in VTSearch
 (the MLP's sigmoid is uncalibrated and the operating point is the
 cross-calibrated threshold).  They stay available for anyone debugging
 score-distribution shapes.
+
+``std_err_auroc`` is the Hanley-McNeil analytic standard error of the
+AUROC - an error bar on the ranking metric, computable for every
+trainer.  ``std_mean`` is the mean per-item ensemble uncertainty (the
+member-to-member sigmoid std, averaged over the test set); it is
+``nan`` for non-ensemble trainers, which report a single score with no
+spread.  Both are diagnostics: they characterise confidence, not
+ranking quality, so they stay out of the headline summary.
 """
 
 _ROW_COLUMNS: tuple[str, ...] = (
@@ -379,7 +484,7 @@ def _cross_calibrated_threshold(
             predict = trainer_fn(X_train[tr_idx], y_train[tr_idx], seed + k)
         except ValueError:
             continue
-        cal_scores = np.asarray(predict(X_train[cal_idx]), dtype=np.float64).tolist()
+        cal_scores = _as_scores(predict(X_train[cal_idx])).tolist()
         cal_labels = [float(v) for v in y_train[cal_idx]]
         t = find_optimal_threshold(cal_scores, cal_labels, inclusion_value)
         # ``find_optimal_threshold`` can return +/-inf on degenerate
@@ -426,10 +531,22 @@ def evaluate_one(
     train_seconds = time.monotonic() - t0
 
     t0 = time.monotonic()
-    scores = predict(pool.test_X)
+    prediction = predict(pool.test_X)
     predict_seconds = time.monotonic() - t0
 
+    # Ensemble trainers return ``(scores, per_item_std)``; plain trainers
+    # return just ``scores``.  ``std_mean`` averages the per-item spread over
+    # the test set (mean epistemic uncertainty) and is ``nan`` when the trainer
+    # reports no spread.
+    if isinstance(prediction, tuple):
+        scores = np.asarray(prediction[0], dtype=np.float64)
+        std_mean = float(np.mean(np.asarray(prediction[1], dtype=np.float64)))
+    else:
+        scores = np.asarray(prediction, dtype=np.float64)
+        std_mean = float("nan")
+
     labels = pool.test_y
+    auroc = _auroc(scores, labels)
 
     # Cross-calibrated threshold mirrors the production path: split the
     # *training* labels (no test info leaks in), find the optimal
@@ -451,7 +568,7 @@ def evaluate_one(
         "n_pos": int((y_train == 1).sum()),
         "n_neg": int((y_train == 0).sum()),
         "seed": int(seed),
-        "auroc": _auroc(scores, labels),
+        "auroc": auroc,
         "average_precision": _average_precision(scores, labels),
         "best_f1": _best_f1(scores, labels),
         "xcal_threshold": float(xcal_thr),
@@ -459,6 +576,8 @@ def evaluate_one(
         "train_seconds": round(train_seconds, 4),
         "brier": _brier(np.clip(scores, 0.0, 1.0), labels),
         "f1_at_0.5": _f1_at(scores, labels, 0.5),
+        "std_err_auroc": _auroc_std_err(scores, labels, auroc),
+        "std_mean": std_mean,
         "predict_seconds": round(predict_seconds, 4),
     }
 

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -67,6 +67,23 @@ def _split_media_ids(
     return shuffled[:n_sim], shuffled[n_sim:]
 
 
+VOTE_ORDERS: tuple[str, ...] = ("shuffle", "balanced", "ensemble_std")
+"""Supported ``vote_order`` strategies for :func:`simulate_voting_iterations`.
+
+- ``shuffle`` - the historical default: vote on the simulation set in a
+  seeded random order.
+- ``balanced`` - greedily interleave Good and Bad votes so the running
+  label set stays class-balanced (the earliest trainable step is 1-vs-1,
+  and the counts never drift far apart afterwards).
+- ``ensemble_std`` - active-learning order: at each step train an
+  N-member MLP ensemble on the votes so far, score the un-voted pool, and
+  vote next on the item the ensemble disagrees about most (highest
+  member-to-member sigmoid std).  The ensemble is used *only* to pick the
+  next vote; the per-step cost is still measured with the single
+  production MLP, exactly as the other orders measure it.
+"""
+
+
 def _make_vote_sequence(
     sim_ids: list[int],
     clips_dict: dict[int, dict[str, Any]],
@@ -77,6 +94,45 @@ def _make_vote_sequence(
     votes = [(cid, "good" if media_is_positive(clips_dict[cid], target_category) else "bad") for cid in sim_ids]
     order = rng.permutation(len(votes))
     return [votes[i] for i in order]
+
+
+def _balanced_vote_sequence(
+    sim_ids: list[int],
+    clips_dict: dict[int, dict[str, Any]],
+    target_category: str,
+    rng: np.random.RandomState,
+) -> list[tuple[int, str]]:
+    """Interleave Good/Bad votes so the running label set stays balanced.
+
+    Splits the sim votes by ground-truth class, shuffles each class, then
+    greedily appends whichever class is currently under-represented.  The
+    first two votes are therefore one Good and one Bad (training starts at
+    ``t=2`` with a 1-vs-1 model), and the good/bad counts stay within one
+    of each other for the whole sequence - isolating "does class balance
+    during voting help?" from the vote *content*, which is identical to
+    the ``shuffle`` order's pool.
+    """
+    goods = [(cid, "good") for cid in sim_ids if media_is_positive(clips_dict[cid], target_category)]
+    bads = [(cid, "bad") for cid in sim_ids if not media_is_positive(clips_dict[cid], target_category)]
+    rng.shuffle(goods)
+    rng.shuffle(bads)
+
+    out: list[tuple[int, str]] = []
+    gi = bi = 0
+    n_good = n_bad = 0
+    while gi < len(goods) or bi < len(bads):
+        # Take a Good when both remain and Goods are not ahead; otherwise
+        # take whichever class still has items left.
+        take_good = (gi < len(goods) and bi < len(bads) and n_good <= n_bad) or bi >= len(bads)
+        if take_good and gi < len(goods):
+            out.append(goods[gi])
+            gi += 1
+            n_good += 1
+        else:
+            out.append(bads[bi])
+            bi += 1
+            n_bad += 1
+    return out
 
 
 def _good_training_vec(
@@ -191,12 +247,172 @@ def _evaluate_on_test(
     return {"cost": round(cost, 6), "fpr": round(fpr, 6), "fnr": round(fnr, 6)}
 
 
+def _build_train_xy(
+    good_votes: dict[int, None],
+    bad_votes: dict[int, None],
+    clips_dict: dict[int, dict[str, Any]],
+    target_category: str,
+    region_voting: bool,
+) -> tuple[list[np.ndarray], list[float]]:
+    """Assemble the ``(X_list, y_list)`` training data from the current votes.
+
+    Good votes region-pool their ground-truth box when *region_voting* is on
+    (and the media supports it); bad votes always train on the whole-image
+    vector - matching the live detector, where only Yes-votes carry a region.
+    """
+    X_list: list[np.ndarray] = []
+    y_list: list[float] = []
+    for vid in good_votes:
+        X_list.append(_good_training_vec(clips_dict[vid], target_category, region_voting))
+        y_list.append(1.0)
+    for vid in bad_votes:
+        X_list.append(media_embedding(clips_dict[vid]))
+        y_list.append(0.0)
+    return X_list, y_list
+
+
+def _score_step(
+    good_votes: dict[int, None],
+    bad_votes: dict[int, None],
+    clips_dict: dict[int, dict[str, Any]],
+    target_category: str,
+    *,
+    region_voting: bool,
+    region_aware: bool,
+    inclusion: int,
+    safe_thresholds: bool,
+    sim_clips: dict[int, dict[str, Any]] | None,
+    X_all_clips: Any,
+    calibrate_count: int,
+    calibration_fraction: float,
+    test_ids: list[int],
+    t: int,
+    seed: int,
+    dataset_name: str,
+    start_time: float,
+) -> dict[str, Any]:
+    """Train one production MLP on the current votes and score the test set.
+
+    This is the per-step body shared by every ``vote_order``: it trains and
+    thresholds exactly the way the live ``_train_and_score_xy`` /
+    ``train_and_threshold`` pipeline does (hidden dim sized from the full label
+    count and forced onto the calibration folds, folds calibrated with a fresh
+    ``RandomState(42)``), evaluates on the held-out test set, and returns one
+    result row.  Keeping it single-MLP is deliberate: even under the
+    ``ensemble_std`` order the *reported* cost measures what the real detector
+    computes; the ensemble only chooses which item to vote on next.
+    """
+    import numpy as np  # noqa: PLC0415
+    import torch  # noqa: PLC0415
+
+    X_list, y_list = _build_train_xy(good_votes, bad_votes, clips_dict, target_category, region_voting)
+
+    X = torch.tensor(np.array(X_list), dtype=torch.float32)
+    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
+    input_dim = X.shape[1]
+    n_labels = len(good_votes) + len(bad_votes)
+
+    hidden_dim = _auto_hidden_dim(n_labels)
+    threshold = calculate_cross_calibration_threshold(
+        X_list,
+        y_list,
+        input_dim,
+        inclusion,
+        rng=np.random.RandomState(42),
+        calibrate_count=calibrate_count,
+        calibration_fraction=calibration_fraction,
+        hidden_dim=hidden_dim,
+    )
+    model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
+
+    if safe_thresholds:
+        threshold = _blend_safe_threshold(threshold, model, region_aware, sim_clips, X_all_clips, n_labels)
+
+    metrics = _evaluate_on_test(
+        model, threshold, clips_dict, test_ids, target_category, inclusion, region_aware=region_aware
+    )
+
+    return {
+        "seed": seed,
+        "dataset": dataset_name,
+        "category": target_category,
+        "t": t,
+        "n_good": len(good_votes),
+        "n_bad": len(bad_votes),
+        **metrics,
+        "elapsed_seconds": round(time.monotonic() - start_time, 3),
+    }
+
+
+def _ensemble_uncertainty_pick(
+    remaining: list[tuple[int, str]],
+    good_votes: dict[int, None],
+    bad_votes: dict[int, None],
+    clips_dict: dict[int, dict[str, Any]],
+    target_category: str,
+    region_voting: bool,
+    n_ensemble: int,
+) -> int:
+    """Index into *remaining* of the item the ensemble is least sure about.
+
+    Trains *n_ensemble* seed-varied MLPs on the current votes, scores every
+    un-voted item's whole-image vector with each member, and returns the index
+    of the item with the highest member-to-member sigmoid std (maximal
+    epistemic disagreement).  Whole-image vectors are used for the selection
+    scoring regardless of region awareness - the pick is an active-learning
+    heuristic, so a single fast vector per candidate is enough; the eventual
+    per-step cost is still measured region-aware in :func:`_score_step`.
+    """
+    import numpy as np  # noqa: PLC0415
+    import torch  # noqa: PLC0415
+
+    X_list, y_list = _build_train_xy(good_votes, bad_votes, clips_dict, target_category, region_voting)
+    X = torch.tensor(np.array(X_list), dtype=torch.float32)
+    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
+    input_dim = X.shape[1]
+    hidden_dim = _auto_hidden_dim(len(good_votes) + len(bad_votes))
+
+    cand_embs = np.array([media_embedding(clips_dict[cid]) for cid, _ in remaining])
+    X_cand = torch.tensor(cand_embs, dtype=torch.float32)
+
+    member_scores: list[np.ndarray] = []
+    for k in range(n_ensemble):
+        # Fixed member seeds (42 + k) keep the pick a deterministic function of
+        # the votes cast so far, so the whole ``ensemble_std`` walk is
+        # reproducible for a given eval seed.
+        model = train_model(X, y, input_dim, seed=42 + k, hidden_dim=hidden_dim)
+        with torch.no_grad():
+            member_scores.append(torch.sigmoid(model(X_cand)).squeeze(1).cpu().numpy())
+    std = np.stack(member_scores, axis=0).std(axis=0)
+    return int(np.argmax(std))
+
+
+def _bootstrap_pick(remaining: list[tuple[int, str]], good_votes: dict[int, None], bad_votes: dict[int, None]) -> int:
+    """Pick the next vote before the model is trainable (no ensemble yet).
+
+    Until there is at least one Good and one Bad vote the ensemble can't be
+    trained, so this steers toward a trainable state fast: if exactly one class
+    is present, take the first item of the missing class; otherwise take the
+    first remaining item (the seeded shuffle already fixed the order).
+    """
+    need: str | None = None
+    if good_votes and not bad_votes:
+        need = "bad"
+    elif bad_votes and not good_votes:
+        need = "good"
+    if need is not None:
+        for i, (_, lbl) in enumerate(remaining):
+            if lbl == need:
+                return i
+    return 0
+
+
 # ------------------------------------------------------------------
 # Single (seed, dataset, category) evaluation
 # ------------------------------------------------------------------
 
 
-def simulate_voting_iterations(
+def simulate_voting_iterations(  # noqa: C901
     clips_dict: dict[int, dict[str, Any]],
     target_category: str,
     seed: int,
@@ -207,6 +423,9 @@ def simulate_voting_iterations(
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     region_voting: bool = False,
+    vote_order: str = "shuffle",
+    n_ensemble: int = 5,
+    max_votes: Optional[int] = None,
 ) -> list[dict[str, Any]]:
     """Simulate voting on *clips_dict* and evaluate at every step.
 
@@ -232,15 +451,32 @@ def simulate_voting_iterations(
             Scoring is unaffected by this flag - a patch dataset always scores
             region-aware (max-pool over regions), so the only thing this toggles
             is the Good-vote training vector, isolating region voting's effect.
+        vote_order: Which strategy orders the votes (see :data:`VOTE_ORDERS`):
+            ``"shuffle"`` (default, seeded random), ``"balanced"`` (interleave
+            Good/Bad so the running label set stays balanced), or
+            ``"ensemble_std"`` (active learning - vote next on the item an MLP
+            ensemble disagrees about most).
+        n_ensemble: Number of MLP members trained per step to pick the next
+            vote under ``vote_order="ensemble_std"``.  Ignored by the other
+            orders (default 5).
+        max_votes: Optional cap on how many votes are cast.  ``None`` (default)
+            walks the entire simulation set.  Handy for the expensive
+            ``ensemble_std`` order, which retrains ``n_ensemble`` models per
+            step.
 
     Returns:
         List of row dicts with keys ``seed, dataset, category, t, n_good,
         n_bad, cost, fpr, fnr, elapsed_seconds``. ``n_good``/``n_bad`` report
         the vote counts behind each row so callers can tell apart metrics
-        learned from a 1-vs-1 model and a many-vs-many one.
+        learned from a 1-vs-1 model and a many-vs-many one.  The row schema is
+        identical across every ``vote_order`` - selection strategy never leaks
+        into per-step evaluation, which always uses the single production MLP.
     """
     import numpy as np  # noqa: PLC0415
     import torch  # noqa: PLC0415
+
+    if vote_order not in VOTE_ORDERS:
+        raise ValueError(f"Unknown vote_order {vote_order!r}; choices: {list(VOTE_ORDERS)}")
 
     rng = np.random.RandomState(seed)
     # Note: no torch.manual_seed() here - train_model handles its own
@@ -262,8 +498,6 @@ def simulate_voting_iterations(
     # detector scores them, regardless of how the Good votes were assembled.
     region_aware = any(clips_dict[cid].get("patch_regions") for cid in clips_dict)
 
-    vote_seq = _make_vote_sequence(sim_ids, clips_dict, target_category, rng)
-
     # Pre-compute embeddings for safe-threshold GMM scoring.  Restrict to the
     # simulation set so the held-out ``test_ids`` never feed into the GMM that
     # picks the threshold - otherwise the test scores leak into calibration
@@ -283,6 +517,64 @@ def simulate_voting_iterations(
     bad_votes: dict[int, None] = {}
     rows: list[dict[str, Any]] = []
 
+    # Shared per-step scoring: identical across vote orders, so the reported
+    # cost always measures the single production MLP (the ensemble, when used,
+    # only influences which item is voted on next).
+    def _step(t: int) -> None:
+        rows.append(
+            _score_step(
+                good_votes,
+                bad_votes,
+                clips_dict,
+                target_category,
+                region_voting=region_voting,
+                region_aware=region_aware,
+                inclusion=inclusion,
+                safe_thresholds=safe_thresholds,
+                sim_clips=sim_clips,
+                X_all_clips=X_all_clips,
+                calibrate_count=calibrate_count,
+                calibration_fraction=calibration_fraction,
+                test_ids=test_ids,
+                t=t,
+                seed=seed,
+                dataset_name=dataset_name,
+                start_time=start_time,
+            )
+        )
+
+    if vote_order == "ensemble_std":
+        # Adaptive walk: the next vote depends on the current ensemble's
+        # uncertainty, so the sequence can't be precomputed.  The seeded
+        # shuffle only fixes the starting pool order and the bootstrap /
+        # tie-break order before the model is trainable.
+        remaining = _make_vote_sequence(sim_ids, clips_dict, target_category, rng)
+        cap = len(remaining) if max_votes is None else min(max_votes, len(remaining))
+        for t in range(1, cap + 1):
+            if not good_votes or not bad_votes:
+                idx = _bootstrap_pick(remaining, good_votes, bad_votes)
+            else:
+                idx = _ensemble_uncertainty_pick(
+                    remaining, good_votes, bad_votes, clips_dict, target_category, region_voting, n_ensemble
+                )
+            cid, label = remaining.pop(idx)
+            if label == "good":
+                good_votes[cid] = None
+            else:
+                bad_votes[cid] = None
+            if not good_votes or not bad_votes:
+                continue
+            _step(t)
+        return rows
+
+    # Static orders: the whole sequence is fixed up front.
+    if vote_order == "balanced":
+        vote_seq = _balanced_vote_sequence(sim_ids, clips_dict, target_category, rng)
+    else:  # "shuffle"
+        vote_seq = _make_vote_sequence(sim_ids, clips_dict, target_category, rng)
+    if max_votes is not None:
+        vote_seq = vote_seq[:max_votes]
+
     for t, (cid, label) in enumerate(vote_seq, start=1):
         if label == "good":
             good_votes[cid] = None
@@ -293,74 +585,7 @@ def simulate_voting_iterations(
         if not good_votes or not bad_votes:
             continue
 
-        # Build training data.  Good votes region-pool their ground-truth box
-        # when ``region_voting`` is on (and the media supports it); bad votes
-        # always train on the whole-image vector - matching the live detector,
-        # where only Yes-votes carry a region.
-        X_list: list[np.ndarray] = []
-        y_list: list[float] = []
-        for vid in good_votes:
-            X_list.append(_good_training_vec(clips_dict[vid], target_category, region_voting))
-            y_list.append(1.0)
-        for vid in bad_votes:
-            X_list.append(media_embedding(clips_dict[vid]))
-            y_list.append(0.0)
-
-        X = torch.tensor(np.array(X_list), dtype=torch.float32)
-        y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
-        input_dim = X.shape[1]
-        n_labels = len(good_votes) + len(bad_votes)
-
-        # Train and find threshold, matching the production
-        # ``_train_and_score_xy`` / ``train_and_threshold`` pipeline exactly so
-        # the reported cost measures what the live detector computes:
-        #   * ``hidden_dim`` is sized from the *full* label count and forced onto
-        #     the calibration folds, so the fold models share the final model's
-        #     architecture (production passes this into
-        #     ``cross_calibration_threshold_cached``).  Letting each fold
-        #     auto-size to its own smaller train split would train narrower fold
-        #     nets and report a threshold the live pipeline never produces.
-        #   * the fold splits use a fresh ``RandomState(42)`` — the fixed seed
-        #     ``cross_calibration_threshold_cached`` always calibrates with —
-        #     rather than the shared per-seed simulation RNG, so the calibration
-        #     is byte-for-byte what production runs for this vote set.  The eval
-        #     seed still varies the data (which media are voted, in what order,
-        #     and the held-out test split); only the calibration folds are now
-        #     pinned, as they are in production.
-        hidden_dim = _auto_hidden_dim(n_labels)
-        threshold = calculate_cross_calibration_threshold(
-            X_list,
-            y_list,
-            input_dim,
-            inclusion,
-            rng=np.random.RandomState(42),
-            calibrate_count=calibrate_count,
-            calibration_fraction=calibration_fraction,
-            hidden_dim=hidden_dim,
-        )
-        model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
-
-        # Apply safe threshold blending if enabled
-        if safe_thresholds:
-            threshold = _blend_safe_threshold(threshold, model, region_aware, sim_clips, X_all_clips, n_labels)
-
-        # Evaluate on held-out test set
-        metrics = _evaluate_on_test(
-            model, threshold, clips_dict, test_ids, target_category, inclusion, region_aware=region_aware
-        )
-
-        rows.append(
-            {
-                "seed": seed,
-                "dataset": dataset_name,
-                "category": target_category,
-                "t": t,
-                "n_good": len(good_votes),
-                "n_bad": len(bad_votes),
-                **metrics,
-                "elapsed_seconds": round(time.monotonic() - start_time, 3),
-            }
-        )
+        _step(t)
 
     return rows
 
@@ -380,6 +605,9 @@ def run_voting_iterations_eval(
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     region_voting: bool = False,
+    vote_order: str = "shuffle",
+    n_ensemble: int = 5,
+    max_votes: Optional[int] = None,
 ) -> pd.DataFrame:
     """Run the voting-iterations evaluation over multiple seeds/datasets/categories.
 
@@ -403,6 +631,10 @@ def run_voting_iterations_eval(
         region_voting: When ``True``, Good votes train on the ground-truth
             region-pooled vector for patch datasets (see
             :func:`simulate_voting_iterations`).
+        vote_order: Vote-ordering strategy - ``"shuffle"``, ``"balanced"``, or
+            ``"ensemble_std"`` (see :func:`simulate_voting_iterations`).
+        n_ensemble: Ensemble size for ``vote_order="ensemble_std"`` selection.
+        max_votes: Optional cap on votes cast per (seed, dataset, category).
 
     Returns:
         A :class:`~pandas.DataFrame` with columns ``seed, dataset, category,
@@ -438,6 +670,9 @@ def run_voting_iterations_eval(
                     calibrate_count=calibrate_count,
                     calibration_fraction=calibration_fraction,
                     region_voting=region_voting,
+                    vote_order=vote_order,
+                    n_ensemble=n_ensemble,
+                    max_votes=max_votes,
                 )
                 all_rows.extend(rows)
 
@@ -459,6 +694,9 @@ def run_voting_iterations_eval_from_pickles(
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     region_voting: bool = False,
+    vote_order: str = "shuffle",
+    n_ensemble: int = 5,
+    max_votes: Optional[int] = None,
 ) -> pd.DataFrame:
     """Convenience wrapper that loads datasets from pickle files.
 
@@ -476,6 +714,10 @@ def run_voting_iterations_eval_from_pickles(
         region_voting: When ``True``, Good votes train on the ground-truth
             region-pooled vector for patch datasets (see
             :func:`simulate_voting_iterations`).
+        vote_order: Vote-ordering strategy - ``"shuffle"``, ``"balanced"``, or
+            ``"ensemble_std"`` (see :func:`simulate_voting_iterations`).
+        n_ensemble: Ensemble size for ``vote_order="ensemble_std"`` selection.
+        max_votes: Optional cap on votes cast per (seed, dataset, category).
 
     Returns:
         A :class:`~pandas.DataFrame` identical to :func:`run_voting_iterations_eval`
@@ -500,4 +742,7 @@ def run_voting_iterations_eval_from_pickles(
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
         region_voting=region_voting,
+        vote_order=vote_order,
+        n_ensemble=n_ensemble,
+        max_votes=max_votes,
     )


### PR DESCRIPTION
Adds MLP-ensemble uncertainty as an axis of the eval harness, plus a runner that sweeps it.

Closes #2497.

## `vtscore/eval/label_curve.py`
- New `mlp_ens{3,5,7,10}` trainer factories: each trains N seed-varied MLPs, reports the **mean sigmoid** as the score and the **member-to-member std** as per-item epistemic uncertainty.
- `predict_fn` may now return `(scores, per_item_std)`; a `_as_scores` helper collapses both shapes so ranking metrics and threshold calibration don't care which trainer produced the prediction.
- Two new **diagnostic** columns on every row:
  - `std_err_auroc` — Hanley-McNeil analytic standard error of the AUROC (an error bar on the ranking metric, computable for every trainer).
  - `std_mean` — mean per-item ensemble std over the test set (`nan` for non-ensemble trainers, which report a single score with no spread).
  - Both stay out of the headline summary (they characterise confidence, not ranking quality).

## `vtscore/eval/voting_iterations.py`
- New `vote_order ∈ {shuffle, balanced, ensemble_std}`, `n_ensemble`, and `max_votes` parameters, threaded through `run_voting_iterations_eval` and `run_voting_iterations_eval_from_pickles`.
  - `shuffle` — the historical default (seeded random order), preserved **byte-for-byte**.
  - `balanced` — greedily interleave Good/Bad so the running label set stays class-balanced (first trainable step is 1-vs-1).
  - `ensemble_std` — active learning: train an N-member ensemble on the votes so far and vote next on the item it disagrees about most.
- The ensemble is used **only for selection**; per-step evaluation stays single-MLP, so the row schema is unchanged across every `vote_order`.
- Shared per-step training/thresholding/scoring extracted to `_score_step` so the `shuffle` path's RNG usage and production-fidelity are identical to before.

## `scripts/run_mlp_ensemble_sweep.py`
Throwaway runner that exercises both axes and writes CSVs + plots + a README to `docs/experiments/mlp-ensemble/` (label-curve AUROC/F1@xcal/std_mean by trainer; voting cost by `vote_order`).

## Tests
- `tests_lib/detectors/test_label_curve.py` — ensemble-trainer registration, `(scores, std)` predict shape, `std_mean`/`std_err_auroc` emission, determinism, and diagnostic columns in the sweep + summary.
- `tests_lib/detectors/test_eval_voting_iterations.py` — `balanced` sequence balance, `vote_order` axis (schema stability, default==shuffle, unknown raises), `ensemble_std` determinism, `n_ensemble` axis, and `max_votes` capping.

`./run-tests.sh` (full suite) green: **6245 passed, 1 skipped** — ruff / ruff-format / codespell / deptry / pip-audit / pyright all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDJZ1SibW9xwYdjjR7Zbvm)_