### PR TITLE
PluginField: labelled options + allow_free_text combobox

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -52,6 +52,7 @@ families share this one field type; each family's base module re-exports
 | `placeholder` | `str`       | `""`     | Hint shown as placeholder text in the input widget      |
 | `dynamic_options` | `bool`  | `False`  | When `True`, options for this `"select"` field are fetched at runtime from the plugin's `get_field_options()` method (see [Dynamic field options](#dynamic-field-options)) |
 | `depends_on`  | `list[str]` | `[]`     | Other field keys whose values this field's options depend on; the frontend re-fetches whenever any depended-on field changes |
+| `allow_free_text` | `bool`  | `False`  | For `"select"` fields: render as a combobox the user can type an arbitrary value into (even one the option list omits). On refresh, a typed value absent from the new list is kept; a strict `select` clears it |
 | `clears`      | `list[str]` | `[]`     | Field keys this field is mutually exclusive with; entering a non-empty value here blanks each listed field in the UI (list each peer back for symmetry), so only one of the set is active at a time |
 
 ### PluginBase
@@ -346,7 +347,7 @@ to the framework.
 |--------|-----------|-------------|
 | `_fetch_records_bulk_impl()` | `(records: list, field_values: dict, thin: bool) -> list[dict | None]` | Batched fetch hook. Default loops `fetch_record`. Override to issue concurrent / batched I/O |
 | `run_cli()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | CLI variant; default delegates to `run()`. Override when `run()` expects FileStorage objects |
-| `get_field_options()` | `(field_key: str, current_values: dict) -> list[str]` | Compute dropdown options for fields declared with `dynamic_options=True`. See [Dynamic field options](#dynamic-field-options) |
+| `get_field_options()` | `(field_key: str, current_values: dict) -> Sequence[FieldOption]` | Compute dropdown options for fields declared with `dynamic_options=True`; each option is a plain string or a `(value, label)` tuple. See [Dynamic field options](#dynamic-field-options) |
 | `run_chunked()` | `(field_values, chunk_size, thin) -> Iterator[dict]` | Yield chunks of medias for piecewise processing. Set `supports_chunked = True` |
 | `run_chunked_cli()` | `(field_values, chunk_size, thin) -> Iterator[dict]` | CLI variant of `run_chunked()` |
 | `build_origin()` | `(field_values: dict) -> dict` | Build an origin dict for provenance tracking. Default uses importer name + string field values |
@@ -552,6 +553,23 @@ class ReCallerImporter(DatasetImporter):
         return super().get_field_options(field_key, current_values)
 ```
 
+Each returned option is either a plain string (shown verbatim as its own
+label) or a `(value, label)` tuple — a `FieldOption` — so a dropdown can
+submit an opaque id while displaying a friendly name:
+
+```python
+    def get_field_options(self, field_key, current_values):
+        if field_key == "query_id":
+            # Submit the id, show the title.
+            return [(q.id, q.title) for q in _list_recent_queries(...)]
+        return super().get_field_options(field_key, current_values)
+```
+
+Pair `dynamic_options` (or a plain static `"select"`) with
+`allow_free_text=True` to let the user type an arbitrary value the option
+list doesn't include; the field renders as a combobox instead of a strict
+dropdown.
+
 The frontend wiring is fully automatic:
 
 1. When the user opens your importer, the modal pre-fetches options for
@@ -563,9 +581,11 @@ The frontend wiring is fully automatic:
    inline next to the field.
 
 API contract: `POST /api/dataset/import/<name>/options` with body
-`{"field_key": "...", "values": {...}}` returns `{"options": [...]}`.
-Any exception your `get_field_options()` raises is returned as a 502
-with the exception message; perfect for surfacing remote-service
+`{"field_key": "...", "values": {...}}` returns
+`{"options": [{"value": "...", "label": "..."}, ...]}` — both the plain-
+string and `(value, label)` shapes are coerced to `{value, label}` before
+serialisation. Any exception your `get_field_options()` raises is returned
+as a 502 with the exception message; perfect for surfacing remote-service
 errors directly to the user.
 
 ### How it gets invoked

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -214,7 +214,9 @@ current form snapshot, optional).
 Calls the importer's `get_field_options(field_key, values)` and returns
 dropdown options for a [dynamic-options field](../EXTENDING-plugins.md#dynamic-field-options).
 
-→ `{"options": ["a", "b", "c"]}`
+→ `{"options": [{"value": "a", "label": "A"}, {"value": "b", "label": "b"}]}`
+(each option carries a `value` to submit and a `label` to display; the two
+coincide for plain-string options and differ for `(value, label)` tuples).
 
 400 (unknown / non-dynamic field), 404 (unknown importer), 501 (not
 implemented), 502 (remote error).

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -67,7 +67,9 @@ POST /api/label-importers/field-options/{importer_name}
 Returns the dropdown options for a dynamic-options field on a label importer
 (used to populate dependent selects in the importer form).
 
-→ `{"options": [...]}`
+→ `{"options": [{"value": "...", "label": "..."}, ...]}` (each option carries a
+`value` to submit and a `label` to display; they coincide for plain-string
+options and differ for `(value, label)` tuples).
 
 Errors: 400 (unknown/non-dynamic field key), 404 (unknown importer),
 501 (importer does not implement `get_field_options`),

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -956,7 +956,8 @@ The discovery and field-declaration scaffolding shared by every plugin family.
 class PluginField:
     """One configurable input for a plugin. key, label, field_type, description,
     accept, options, default, required, placeholder, dynamic_options, depends_on,
-    min, max, step. Validated by the plugin framework at registration time."""
+    allow_free_text, min, max, step. Validated by the plugin framework at
+    registration time."""
 
 class PluginBase:
     """Mixin providing CLI-arg parsing, JSON serialisation, and the `name`,

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2832,6 +2832,22 @@
         ],
         "type": "object"
       },
+      "FieldOptions": {
+        "additionalProperties": false,
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "value"
+        ],
+        "type": "object"
+      },
       "FillFromSortRequest": {
         "additionalProperties": false,
         "properties": {
@@ -3247,7 +3263,7 @@
         "properties": {
           "options": {
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/FieldOptions"
             },
             "type": "array"
           }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.html
@@ -60,6 +60,25 @@
               [accept]="field.accept || ''"
               (change)="onFileSelected($event, field.key)"
             />
+          } @else if (field.field_type === 'select' && field.allow_free_text) {
+            <input
+              [id]="'field-' + field.key"
+              type="text"
+              class="form-input"
+              [attr.list]="'field-' + field.key + '-list'"
+              [(ngModel)]="formValues[field.key]"
+              [disabled]="!!dynamicFieldLoading()[field.key]"
+              [placeholder]="dynamicFieldLoading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+              (ngModelChange)="onFieldChanged(field.key)"
+            />
+            <datalist [id]="'field-' + field.key + '-list'">
+              @for (opt of optionsFor(field); track opt.value) {
+                <option [value]="opt.value">{{ opt.label }}</option>
+              }
+            </datalist>
+            @if (field.dynamic_options && dynamicFieldError()[field.key]) {
+              <p class="error-text">{{ dynamicFieldError()[field.key] }}</p>
+            }
           } @else if (field.field_type === 'select') {
             <select
               [id]="'field-' + field.key"
@@ -73,8 +92,8 @@
               } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicFieldError()[field.key]) {
                 <option [value]="''" disabled>No options available</option>
               }
-              @for (opt of optionsFor(field); track opt) {
-                <option [value]="opt">{{ opt }}</option>
+              @for (opt of optionsFor(field); track opt.value) {
+                <option [value]="opt.value">{{ opt.label }}</option>
               }
             </select>
             @if (field.dynamic_options && dynamicFieldError()[field.key]) {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
@@ -64,6 +64,36 @@ describe('GenericFormPickerComponent', () => {
     expect(started).toBe(true);
   });
 
+  it('coerces static string options into {value,label} pairs', () => {
+    const staticSelect = { key: 's', field_type: 'select', options: ['x', 'y'] } as any;
+    expect(component.optionsFor(staticSelect)).toEqual([
+      { value: 'x', label: 'x' },
+      { value: 'y', label: 'y' },
+    ]);
+  });
+
+  it('keeps a typed free-text value the refreshed options omit', () => {
+    const field = { key: 'q', field_type: 'select', dynamic_options: true, allow_free_text: true } as any;
+    component.selectedImporter.set({ name: 'imp', fields: [field] } as any);
+    component.formValues['q'] = 'hand-typed';
+    (component as any).refreshDynamicFieldOptions(field);
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/dataset/import/imp/options'))
+      .flush({ options: [{ value: 'a', label: 'A' }] });
+    expect(component.formValues['q']).toBe('hand-typed');
+  });
+
+  it('clears a strict-select value the refreshed options omit', () => {
+    const field = { key: 'q', field_type: 'select', dynamic_options: true } as any;
+    component.selectedImporter.set({ name: 'imp', fields: [field] } as any);
+    component.formValues['q'] = 'stale';
+    (component as any).refreshDynamicFieldOptions(field);
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/dataset/import/imp/options'))
+      .flush({ options: [{ value: 'a', label: 'A' }] });
+    expect(component.formValues['q']).toBe('');
+  });
+
   it('surfaces a server error without emitting importStarted', () => {
     openAndFlush();
     component.formValues['path'] = '/data/sounds';

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
@@ -14,6 +14,7 @@ import {
   ClipperParameter,
   ConverterInfo,
   EmbedderInfo,
+  FieldOption,
   ImporterField,
   ImporterInfo,
   MediaTypeInfo,
@@ -82,7 +83,7 @@ export class GenericFormPickerComponent {
 
   sourceSpecs: SourceSpec[] = [];
 
-  readonly dynamicFieldOptions = signal<Record<string, string[]>>({});
+  readonly dynamicFieldOptions = signal<Record<string, FieldOption[]>>({});
   readonly dynamicFieldLoading = signal<Record<string, boolean>>({});
   readonly dynamicFieldError = signal<Record<string, string>>({});
 
@@ -258,14 +259,18 @@ export class GenericFormPickerComponent {
     this.dynamicFieldError.update((m) => ({ ...m, [key]: '' }));
     this.datasetsCrudApi.getImporterFieldOptions(importer.name, key, { ...this.formValues }).subscribe({
       next: (res) => {
-        this.dynamicFieldOptions.update((m) => ({ ...m, [key]: res.options || [] }));
+        const options: FieldOption[] = res.options || [];
+        this.dynamicFieldOptions.update((m) => ({ ...m, [key]: options }));
         this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
         const current = this.formValues[key];
-        if (current && !this.dynamicFieldOptions()[key].includes(String(current))) {
+        const inList = options.some((o) => o.value === String(current));
+        // Strict selects clear a value the new list no longer offers; a
+        // free-text combobox keeps whatever the user typed.
+        if (current && !inList && !field.allow_free_text) {
           this.formValues[key] = '';
         }
-        if (!this.formValues[key] && field.required && this.dynamicFieldOptions()[key].length > 0) {
-          this.formValues[key] = this.dynamicFieldOptions()[key][0];
+        if (!this.formValues[key] && field.required && options.length > 0) {
+          this.formValues[key] = options[0].value;
         }
       },
       error: (err) => {
@@ -276,11 +281,12 @@ export class GenericFormPickerComponent {
     });
   }
 
-  optionsFor(field: ImporterField): string[] {
+  optionsFor(field: ImporterField): FieldOption[] {
     if (field.dynamic_options) {
       return this.dynamicFieldOptions()[field.key] || [];
     }
-    return field.options || [];
+    // Static options are plain strings; render each as its own label.
+    return (field.options || []).map((o) => ({ value: o, label: o }));
   }
 
   private loadClippers(mediaType: string): void {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -119,6 +119,25 @@
                 [(ngModel)]="formValues[field.key]"
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
               />
+            } @else if (field.field_type === 'select' && field.allow_free_text) {
+              <input
+                [id]="'lif-' + field.key"
+                type="text"
+                class="form-input"
+                [attr.list]="'lif-' + field.key + '-list'"
+                [(ngModel)]="formValues[field.key]"
+                [disabled]="!!dynamicFieldLoading()[field.key]"
+                [placeholder]="dynamicFieldLoading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+                (ngModelChange)="onFormFieldChanged(field.key)"
+              />
+              <datalist [id]="'lif-' + field.key + '-list'">
+                @for (opt of optionsFor(field); track opt.value) {
+                  <option [value]="opt.value">{{ opt.label }}</option>
+                }
+              </datalist>
+              @if (field.dynamic_options && dynamicFieldError()[field.key]) {
+                <p class="error-text">{{ dynamicFieldError()[field.key] }}</p>
+              }
             } @else if (field.field_type === 'select') {
               <select
                 [id]="'lif-' + field.key"
@@ -132,8 +151,8 @@
                 } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicFieldError()[field.key]) {
                   <option value="">No options available</option>
                 }
-                @for (opt of optionsFor(field); track opt) {
-                  <option [value]="opt">{{ opt }}</option>
+                @for (opt of optionsFor(field); track opt.value) {
+                  <option [value]="opt.value">{{ opt.label }}</option>
                 }
               </select>
               @if (field.dynamic_options && dynamicFieldError()[field.key]) {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
@@ -119,6 +119,39 @@ describe('LabelImporterModalComponent', () => {
     expect(cards.length).toBe(2);
   });
 
+  it('coerces static string options into {value,label} pairs', async () => {
+    await flushInit();
+    const staticSelect = { key: 's', field_type: 'select', options: ['x', 'y'] } as any;
+    expect(component.optionsFor(staticSelect)).toEqual([
+      { value: 'x', label: 'x' },
+      { value: 'y', label: 'y' },
+    ]);
+  });
+
+  it('keeps a typed free-text value the refreshed options omit', async () => {
+    await flushInit();
+    const field = { key: 'q', field_type: 'select', dynamic_options: true, allow_free_text: true } as any;
+    component.selectedImporter = { name: 'imp', fields: [field] } as any;
+    component.formValues['q'] = 'hand-typed';
+    (component as any).refreshDynamicFieldOptions(field);
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/label-importers/field-options/imp'))
+      .flush({ options: [{ value: 'a', label: 'A' }] });
+    expect(component.formValues['q']).toBe('hand-typed');
+  });
+
+  it('clears a strict-select value the refreshed options omit', async () => {
+    await flushInit();
+    const field = { key: 'q', field_type: 'select', dynamic_options: true } as any;
+    component.selectedImporter = { name: 'imp', fields: [field] } as any;
+    component.formValues['q'] = 'stale';
+    (component as any).refreshDynamicFieldOptions(field);
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/label-importers/field-options/imp'))
+      .flush({ options: [{ value: 'a', label: 'A' }] });
+    expect(component.formValues['q']).toBe('');
+  });
+
   it('should emit closed on close', async () => {
     await flushInit();
     vi.spyOn(component.closed, 'emit');

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -19,7 +19,7 @@ import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.co
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
 import { MediasApiService } from '../../../services/medias-api.service';
 import { VoteStateService } from '../../../services/vote-state.service';
-import { ImporterField } from '../../../models/api.models';
+import { FieldOption, ImporterField } from '../../../models/api.models';
 import type { LabelImporterEntry } from '../../../generated/api-client/models/label-importer-entry';
 import { apiErrorMessage } from '../../../utils/api-error';
 
@@ -79,7 +79,7 @@ export class LabelImporterModalComponent implements OnDestroy {
       (this.importersResource.error() ? 'Failed to load label importers' : ''),
   );
   readonly successMessage = signal('');
-  readonly dynamicFieldOptions = signal<Record<string, string[]>>({});
+  readonly dynamicFieldOptions = signal<Record<string, FieldOption[]>>({});
   readonly dynamicFieldLoading = signal<Record<string, boolean>>({});
   readonly dynamicFieldError = signal<Record<string, string>>({});
   readonly addingGood = signal(false);
@@ -142,11 +142,12 @@ export class LabelImporterModalComponent implements OnDestroy {
     }
   }
 
-  optionsFor(field: ImporterField): string[] {
+  optionsFor(field: ImporterField): FieldOption[] {
     if (field.dynamic_options) {
       return this.dynamicFieldOptions()[field.key] || [];
     }
-    return field.options || [];
+    // Static options are plain strings; render each as its own label.
+    return (field.options || []).map((o) => ({ value: o, label: o }));
   }
 
   private refreshDynamicFieldOptions(field: ImporterField): void {
@@ -159,15 +160,18 @@ export class LabelImporterModalComponent implements OnDestroy {
       .getFieldOptions(importer.name, key, { ...this.formValues })
       .subscribe({
         next: (res) => {
-          const options = res.options || [];
+          const options: FieldOption[] = res.options || [];
           this.dynamicFieldOptions.update((m) => ({ ...m, [key]: options }));
           this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
           const current = this.formValues[key];
-          if (current && !options.includes(String(current))) {
+          const inList = options.some((o) => o.value === String(current));
+          // Strict selects clear a value the new list no longer offers; a
+          // free-text combobox keeps whatever the user typed.
+          if (current && !inList && !field.allow_free_text) {
             this.formValues[key] = '';
           }
           if (!this.formValues[key] && field.required && options.length > 0) {
-            this.formValues[key] = options[0];
+            this.formValues[key] = options[0].value;
           }
         },
         error: (err) => {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -156,6 +156,15 @@ export interface ImportDefaultsForMediaType {
 }
 export type ImportDefaultsByMediaType = Record<string, ImportDefaultsForMediaType>;
 
+/** A single dropdown option for a dynamic-options field.  ``value`` is
+ *  what the form submits; ``label`` is the friendly text shown in the
+ *  dropdown.  They coincide for plain-string options and differ for
+ *  ``(value, label)`` tuple options (submit an opaque id, show a name). */
+export interface FieldOption {
+  value: string;
+  label: string;
+}
+
 export interface ImporterField {
   key: string;
   field_type: string;
@@ -179,6 +188,11 @@ export interface ImporterField {
   dynamic_options?: boolean;
   /** Field keys whose values this field's options depend on. */
   depends_on?: string[];
+  /** For ``select`` fields: when true, render as a combobox the user can
+   *  type an arbitrary value into (even one the option list omits).  When
+   *  the options refresh, a typed value absent from the new list is kept;
+   *  a strict select clears it. */
+  allow_free_text?: boolean;
   /** For ``number`` fields: minimum allowed value (empty = no min). */
   min?: string;
   /** For ``number`` fields: maximum allowed value (empty = no max). */

--- a/frontend/src/app/services/label-importers-api.service.ts
+++ b/frontend/src/app/services/label-importers-api.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { FieldOption } from '../models/api.models';
 import type { LabelImporterEntry } from '../generated/api-client/models/label-importer-entry';
 import type { IngestMissingResponse } from '../generated/api-client/models/ingest-missing-response';
 import { getLabelImporters } from '../generated/api-client/fn/label-importers/get-label-importers';
@@ -59,8 +60,8 @@ export class LabelImportersApiService {
     return this.http.post(url, params);
   }
 
-  getFieldOptions(importerName: string, fieldKey: string, values: Record<string, string>): Observable<{ options: string[] }> {
-    return this.http.post<{ options: string[] }>(
+  getFieldOptions(importerName: string, fieldKey: string, values: Record<string, string>): Observable<{ options: FieldOption[] }> {
+    return this.http.post<{ options: FieldOption[] }>(
       `/api/label-importers/field-options/${encodeURIComponent(importerName)}`,
       { field_key: fieldKey, values },
     );

--- a/tests/io/test_dynamic_field_options.py
+++ b/tests/io/test_dynamic_field_options.py
@@ -48,6 +48,9 @@ class _StubImporter(DatasetImporter):
             return [f"{mt}-q1", f"{mt}-q2"]
         return super().get_field_options(field_key, current_values)
 
+    def run(self, field_values, medias, thin=False):  # pragma: no cover; unused here
+        return None
+
 
 class _MixedOptionImporter(DatasetImporter):
     """Importer whose ``get_field_options`` mixes plain strings and
@@ -72,9 +75,6 @@ class _MixedOptionImporter(DatasetImporter):
             # (opaque id shown under a friendly name).
             return ["plain", ("q-123", "Friendly Name")]
         return super().get_field_options(field_key, current_values)
-
-    def run(self, field_values, medias, thin=False):  # pragma: no cover; unused here
-        return None
 
     def run(self, field_values, medias, thin=False):  # pragma: no cover; unused here
         return None

--- a/tests/io/test_dynamic_field_options.py
+++ b/tests/io/test_dynamic_field_options.py
@@ -15,6 +15,8 @@ Covers:
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from vtscore.datasets.importers.base import DatasetImporter
@@ -301,7 +303,7 @@ class TestAllowFreeTextValidation:
         # A free-text combobox round-trips an arbitrary typed value even
         # though it isn't one of the declared static options.
         schema = self._schema_for(allow_free_text=True)
-        loaded: dict = schema.load({"choice": "typed-by-hand"})
+        loaded = cast(dict, schema.load({"choice": "typed-by-hand"}))
         assert loaded["choice"] == "typed-by-hand"
 
     def test_strict_select_rejects_off_list_value(self):

--- a/tests/io/test_dynamic_field_options.py
+++ b/tests/io/test_dynamic_field_options.py
@@ -48,6 +48,34 @@ class _StubImporter(DatasetImporter):
             return [f"{mt}-q1", f"{mt}-q2"]
         return super().get_field_options(field_key, current_values)
 
+
+class _MixedOptionImporter(DatasetImporter):
+    """Importer whose ``get_field_options`` mixes plain strings and
+    ``(value, label)`` tuples, plus a free-text combobox field."""
+
+    name = "_stub_mixed_options"
+    display_name = "Stub Mixed Options"
+    description = "Test importer with mixed string/tuple options."
+    fields = [
+        PluginField(
+            "query_id",
+            "Query",
+            "select",
+            dynamic_options=True,
+            allow_free_text=True,
+        ),
+    ]
+
+    def get_field_options(self, field_key, current_values):
+        if field_key == "query_id":
+            # A plain string (value == label) and a (value, label) tuple
+            # (opaque id shown under a friendly name).
+            return ["plain", ("q-123", "Friendly Name")]
+        return super().get_field_options(field_key, current_values)
+
+    def run(self, field_values, medias, thin=False):  # pragma: no cover; unused here
+        return None
+
     def run(self, field_values, medias, thin=False):  # pragma: no cover; unused here
         return None
 
@@ -78,6 +106,7 @@ class TestPluginFieldDynamicAttrs:
         f = PluginField(key="x", label="X", field_type="text")
         assert f.dynamic_options is False
         assert f.depends_on == []
+        assert f.allow_free_text is False
 
     def test_to_dict_round_trip(self):
         f = PluginField(
@@ -86,10 +115,16 @@ class TestPluginFieldDynamicAttrs:
             field_type="select",
             dynamic_options=True,
             depends_on=["a", "b"],
+            allow_free_text=True,
         )
         d = f.to_dict()
         assert d["dynamic_options"] is True
         assert d["depends_on"] == ["a", "b"]
+        assert d["allow_free_text"] is True
+
+    def test_to_dict_allow_free_text_defaults_false(self):
+        f = PluginField(key="q", label="Q", field_type="select", options=["a"])
+        assert f.to_dict()["allow_free_text"] is False
 
     def test_depends_on_is_independent_per_instance(self):
         # default_factory=list should not be shared between instances.
@@ -134,7 +169,37 @@ class TestImporterFieldOptionsRoute:
         )
         assert resp.status_code == 200
         body = resp.get_json()
-        assert body == {"options": ["image-q1", "image-q2"]}
+        # Plain strings coerce to ``{"value", "label"}`` with value == label.
+        assert body == {
+            "options": [
+                {"value": "image-q1", "label": "image-q1"},
+                {"value": "image-q2", "label": "image-q2"},
+            ]
+        }
+
+    def test_mixed_string_and_tuple_options(self, client):
+        """A ``get_field_options`` returning both plain strings and
+        ``(value, label)`` tuples coerces each to ``{"value", "label"}``."""
+        from vtscore.datasets.importers import get_importer
+
+        registry = get_importer.__self__
+        registry._ensure_discovered()
+        stub = _MixedOptionImporter()
+        registry._items[stub.name] = stub
+        try:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "query_id", "values": {}},
+            )
+            assert resp.status_code == 200
+            assert resp.get_json() == {
+                "options": [
+                    {"value": "plain", "label": "plain"},
+                    {"value": "q-123", "label": "Friendly Name"},
+                ]
+            }
+        finally:
+            registry._items.pop(stub.name, None)
 
     def test_unknown_importer_returns_404(self, client):
         resp = client.post(
@@ -210,6 +275,41 @@ class TestImporterFieldOptionsRoute:
             assert resp.get_json()["message"] == "remote service down"
         finally:
             registry._items.pop(stub.name, None)
+
+
+# ---------------------------------------------------------------------------
+# allow_free_text: off-list values survive server-side validation
+# ---------------------------------------------------------------------------
+
+
+class TestAllowFreeTextValidation:
+    def _schema_for(self, **field_kwargs):
+        from vtscore.plugins.schema import make_plugin_arg_schema
+
+        class Imp(DatasetImporter):
+            name = "_t_free_text"
+            display_name = "T"
+            description = "T"
+            fields = [PluginField("choice", "Choice", "select", options=["a", "b"], **field_kwargs)]
+
+            def run(self, field_values, medias, thin=False):
+                return None
+
+        return make_plugin_arg_schema(Imp())()
+
+    def test_free_text_select_accepts_off_list_value(self):
+        # A free-text combobox round-trips an arbitrary typed value even
+        # though it isn't one of the declared static options.
+        schema = self._schema_for(allow_free_text=True)
+        loaded = schema.load({"choice": "typed-by-hand"})
+        assert loaded["choice"] == "typed-by-hand"
+
+    def test_strict_select_rejects_off_list_value(self):
+        from marshmallow import ValidationError
+
+        schema = self._schema_for()
+        with pytest.raises(ValidationError):
+            schema.load({"choice": "typed-by-hand"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/io/test_dynamic_field_options.py
+++ b/tests/io/test_dynamic_field_options.py
@@ -301,7 +301,7 @@ class TestAllowFreeTextValidation:
         # A free-text combobox round-trips an arbitrary typed value even
         # though it isn't one of the declared static options.
         schema = self._schema_for(allow_free_text=True)
-        loaded = schema.load({"choice": "typed-by-hand"})
+        loaded: dict = schema.load({"choice": "typed-by-hand"})
         assert loaded["choice"] == "typed-by-hand"
 
     def test_strict_select_rejects_off_list_value(self):

--- a/vtscore/datasets/importers/base/core.py
+++ b/vtscore/datasets/importers/base/core.py
@@ -15,10 +15,11 @@ instead, which layers that machinery on top of this base.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Iterator
 
-from vtscore.plugins import PluginBase, PluginField
+from vtscore.plugins import FieldOption, PluginBase, PluginField
 
 from .origin import _dataset_name_field, _field_in_origin, _serialise_origin_value
 
@@ -316,7 +317,7 @@ class ImporterBase(PluginBase):
         self,
         field_key: str,
         current_values: dict[str, Any],
-    ) -> list[str]:
+    ) -> Sequence[FieldOption]:
         """Return the dropdown options for *field_key* given current form values.
 
         Override this on importers that declare any
@@ -334,7 +335,9 @@ class ImporterBase(PluginBase):
                 (or empty strings for unfilled fields).
 
         Returns:
-            The list of allowed option strings for the dropdown.
+            The allowed options for the dropdown.  Each option is either a
+            plain string (shown verbatim) or a ``(value, label)`` tuple (the
+            option submits the opaque ``value`` while displaying ``label``).
 
         Raises:
             NotImplementedError: When the importer declares no dynamic

--- a/vtscore/datasets/importers/recaller/__init__.py
+++ b/vtscore/datasets/importers/recaller/__init__.py
@@ -63,9 +63,11 @@ the original ReCaller order.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Iterator
 
 from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
+from vtscore.plugins import FieldOption
 from vtscore.media import all_folder_names
 
 
@@ -205,7 +207,7 @@ class ReCallerDatasetImporter(DatasetImporter):
         ),
     ]
 
-    def get_field_options(self, field_key: str, current_values: dict[str, Any]) -> list[str]:
+    def get_field_options(self, field_key: str, current_values: dict[str, Any]) -> Sequence[FieldOption]:
         """Populate ``query_id`` from ReCaller, scoped by the output type."""
         if field_key == "query_id":
             output_type = current_values.get("media_type") or "audio"

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -448,7 +448,7 @@ class PluginBase:
                 continue
             if f.default:
                 kwargs["default"] = f.default
-            if f.field_type == "select" and f.options:
+            if f.field_type == "select" and f.options and not f.allow_free_text:
                 kwargs["choices"] = f.options
             if f.field_type == "number":
                 kwargs["type"] = int if f.is_integer_number() else float

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -54,8 +54,16 @@ FieldType = Literal[
     "checkbox",
 ]
 
+#: A single dropdown option returned by ``get_field_options``.  Either a
+#: plain string (the value is shown verbatim as the label) or a
+#: ``(value, label)`` tuple (the option submits the opaque ``value`` while
+#: displaying the friendly ``label``).  The API layer coerces both shapes
+#: to ``{"value", "label"}`` before serialising them to the frontend.
+FieldOption = str | tuple[str, str]
+
 __all__ = [
     "EntryPointTombstone",
+    "FieldOption",
     "FieldType",
     "PluginBase",
     "PluginField",
@@ -140,6 +148,12 @@ class PluginField:
     #: listed field changes, the frontend re-fetches options for this field.
     #: Only meaningful when :attr:`dynamic_options` is ``True``.
     depends_on: list[str] = field(default_factory=list)
+    #: For ``"select"`` fields: when ``True``, the dropdown renders as a
+    #: combobox the user can type an arbitrary value into, even one the
+    #: option list doesn't include.  When the option list refreshes, a
+    #: typed value that isn't in the new list is kept (a strict ``select``
+    #: — the default — clears such a value instead).
+    allow_free_text: bool = False
     #: For ``"number"`` fields: minimum allowed value (string form, empty = no min).
     min: str = ""
     #: For ``"number"`` fields: maximum allowed value (string form, empty = no max).
@@ -205,6 +219,7 @@ class PluginField:
             "hint": self.hint,
             "dynamic_options": self.dynamic_options,
             "depends_on": list(self.depends_on),
+            "allow_free_text": self.allow_free_text,
             "min": self.min,
             "max": self.max,
             "step": self.step,

--- a/vtscore/plugins/schema.py
+++ b/vtscore/plugins/schema.py
@@ -137,7 +137,9 @@ def _build_select(pf: PluginField, kwargs: dict) -> fields.Field:
     validators: list = []
     if pf.required:
         validators.append(_non_empty_after_strip)
-    if pf.options and not pf.dynamic_options:
+    # ``allow_free_text`` selects accept any typed value, so they skip the
+    # ``OneOf`` restriction that a strict select applies to its options.
+    if pf.options and not pf.dynamic_options and not pf.allow_free_text:
         validators.append(validate.OneOf([*pf.options, ""] if not pf.required else pf.options))
     if validators:
         kwargs["validate"] = validators

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -329,6 +329,29 @@ def get_plugin_or_404(get_fn, list_fn, name: str, type_label: str):
     )
 
 
+def _normalise_option(option: Any) -> dict[str, str]:
+    """Coerce a ``get_field_options`` entry to a ``{"value", "label"}`` dict.
+
+    Accepts both shapes a plugin may return (see
+    :data:`vtscore.plugins.FieldOption`):
+
+    - a plain string ``"foo"`` → ``{"value": "foo", "label": "foo"}`` (the
+      value is shown verbatim as its own label);
+    - a ``(value, label)`` 2-tuple/list ``("id", "Name")`` →
+      ``{"value": "id", "label": "Name"}`` (the option submits the opaque
+      ``value`` while displaying the friendly ``label``).
+
+    Any other iterable is coerced via ``str`` on each part; a stray
+    single-element pair falls back to using the value as its own label.
+    """
+    if isinstance(option, (tuple, list)):
+        value = str(option[0]) if len(option) > 0 else ""
+        label = str(option[1]) if len(option) > 1 else value
+        return {"value": value, "label": label}
+    text = str(option)
+    return {"value": text, "label": text}
+
+
 def get_json_or_400():
     """Parse the request body as JSON, returning a 400 response on failure.
 

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -38,7 +38,12 @@ from vtscore.datasets.registry import (
     register_dataset as _reg_register,
 )
 from vtsearch.auth import get_current_user
-from vtsearch.routes._shared import get_plugin_or_404, register_plugin_typed_routes, validate_plugin_args
+from vtsearch.routes._shared import (
+    _normalise_option,
+    get_plugin_or_404,
+    register_plugin_typed_routes,
+    validate_plugin_args,
+)
 from vtsearch.routes.datasets._helpers import _extract_clipper_params
 from vtsearch.schemas.datasets import (
     ClearStagingResponseSchema,
@@ -414,7 +419,7 @@ def importer_field_options(body: dict, importer_name: str):
 
     if not isinstance(options, list):
         abort(500, message="get_field_options must return a list")
-    return {"options": [str(o) for o in options]}
+    return {"options": [_normalise_option(o) for o in options]}
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -58,6 +58,7 @@ from flask_smorest import abort
 
 from vtscore.labels.importers import get_label_importer, list_label_importers
 from vtsearch.routes._shared import (
+    _normalise_option,
     get_plugin_or_404,
     register_plugin_typed_routes,
     require_dataset_header,
@@ -183,7 +184,7 @@ def label_importer_field_options(body: dict, importer_name: str):
 
     if not isinstance(options, list):
         abort(500, message="get_field_options must return a list")
-    return {"options": [str(o) for o in options]}
+    return {"options": [_normalise_option(o) for o in options]}
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -539,10 +539,23 @@ class ImporterFieldOptionsRequestSchema(Schema):
     values = fields.Dict(load_default=dict)
 
 
+class FieldOptionsSchema(Schema):
+    """A single dropdown option for a dynamic-options field.
+
+    ``value`` is what the form submits; ``label`` is the friendly text
+    shown in the dropdown.  For plain-string options the two coincide; for
+    ``(value, label)`` tuple options they differ so a dropdown can submit
+    an opaque id while displaying a human-readable name.
+    """
+
+    value = fields.String(required=True)
+    label = fields.String(required=True)
+
+
 class ImporterFieldOptionsResponseSchema(Schema):
     """Response for ``POST /api/dataset/import/<importer_name>/options``."""
 
-    options = fields.List(fields.String(), required=True)
+    options = fields.List(fields.Nested(FieldOptionsSchema), required=True)
 
 
 # ---------------------------------------------------------------------------
@@ -713,6 +726,7 @@ __all__ = [
     "EmbeddersListResponseSchema",
     "DatasetRegistryOkResponseSchema",
     "DatasetRegistryPreloadEmbedderResponseSchema",
+    "FieldOptionsSchema",
     "ImporterFieldOptionsRequestSchema",
     "ImporterFieldOptionsResponseSchema",
     "MediaTypesListResponseSchema",


### PR DESCRIPTION
Extends `PluginField` / `get_field_options` so a dynamic `select` can submit an opaque id while showing a friendly name, and adds an `allow_free_text` combobox variant.

Closes #2492

## Backend
- **`vtscore/plugins/__init__.py`** — new `FieldOption = str | tuple[str, str]` alias (exported); new `allow_free_text: bool` field on `PluginField`, serialised via `to_dict()`. `add_cli_arguments` skips the `choices` constraint for free-text selects.
- **`vtscore/datasets/importers/base/core.py`** & **`recaller/__init__.py`** — `get_field_options` return type widened to `Sequence[FieldOption]`.
- **`vtsearch/routes/_shared.py`** — new `_normalise_option()` coerces both option shapes (plain string, `(value, label)` tuple) to `{"value", "label"}`.
- **`vtsearch/routes/datasets/staging.py`** & **`labels/importers.py`** — both field-options endpoints emit the normalised `{value, label}` shape.
- **`vtsearch/schemas/datasets.py`** — new `FieldOptionsSchema`; `ImporterFieldOptionsResponseSchema.options` is now `List(Nested(FieldOptionsSchema))`. OpenAPI snapshot regenerated.
- **`vtscore/plugins/schema.py`** — free-text selects skip the `OneOf` restriction so an off-list typed value passes server-side validation.

## Frontend
- **`api.models.ts`** — new `FieldOption` interface; `allow_free_text?` on `ImporterField`.
- **generic-form picker** & **label-importer-modal** — consume `FieldOption[]` (`opt.value` / `opt.label`), render a `<datalist>` combobox for `allow_free_text` selects, and keep a typed value that a refreshed option list omits (only strict selects clear it).

## Tests
- `tests/io/test_dynamic_field_options.py` — mixed string+tuple option normalisation, `allow_free_text` defaults / `to_dict`, and free-text vs strict-select server-side validation round-trip.
- Frontend specs for both components — static-option coercion and the free-text keep / strict-select clear behaviour.

Backwards-compatibility note: the field-options endpoints now return `{value, label}` objects instead of bare strings; all in-repo consumers are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAvFYQb7UEhhh89z8u3KvE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAvFYQb7UEhhh89z8u3KvE)_