### PR TITLE
Clone coverage-atlas structure instead of rebuilding it on invalidate

### DIFF
--- a/docs/ML.md
+++ b/docs/ML.md
@@ -159,9 +159,10 @@ Each node stores:
 | `n` | Item count |
 | `mu`, `rbar` | Mean direction and resultant length — the sufficient statistics of a von Mises–Fisher component, so reading the tree at any depth gives a multiresolution mixture model of the dataset |
 | `t_quantiles` | A 21-point quantile grid of the node's own points' **leave-one-out** typicality scores, used to calibrate query p-values |
-| `n_pos`, `n_neg` | Labeled-evidence counts per class (session state, not serialized) |
 
-Evidence flows in from votes: every good/bad vote calls `label(id, good=...)`, which increments the class counter in the item's leaf and every ancestor; un-voting decrements; clearing votes or swapping detectors resets and replays (`resync_coverage_atlas_to_detector`). A node is **covered** when `n_pos + n_neg > 0`.
+Node records are **immutable** once built. Labeled evidence lives in a separate per-atlas **overlay** — `n_pos` / `n_neg` counts keyed by node name (session state, not serialized), plus the labeled-ID set — so two atlases can share one node table by reference while keeping independent labels. `structural_clone()` exploits this: an atlas over the same id set (e.g. the labeling-progress per-step atlas mirroring the dataset context's) is cloned with the node table shared and a fresh overlay, skipping the hierarchical-k-means re-fit.
+
+Evidence flows in from votes: every good/bad vote calls `label(id, good=...)`, which increments the class counter in the item's leaf and every ancestor; un-voting decrements; clearing votes or swapping detectors resets and replays (`resync_coverage_atlas_to_detector`, via `reset_labeled()`). A node is **covered** when `n_pos + n_neg > 0` (read through `atlas.n_pos(name)` / `atlas.n_neg(name)`).
 
 ### Diversity sampling (`next_sample`)
 

--- a/tests/core/test_votes.py
+++ b/tests/core/test_votes.py
@@ -1,4 +1,5 @@
 import app as app_module
+import vtscore.detectors.labeling_progress as labeling_progress
 from vtscore.detectors.labeling_progress import (
     _cache_good_ids,
     _cache_bad_ids,
@@ -11,6 +12,8 @@ from vtscore.detectors.labeling_progress import (
 )
 from vtscore.embedding.media_vectors import media_embedding
 from vtsearch.state import (
+    build_coverage_atlas,
+    get_coverage_atlas,
     medias,
     label_history,
 )
@@ -526,6 +529,74 @@ class TestProgressCacheInvalidatedOnVoteSwitch:
         # Invalidate a media that never appeared in the cache
         invalidate_progress_cache_from(999)
         assert len(_cached_steps) == 2, "Cache should not change for unknown media"
+
+
+class TestProgressAtlasClonesAndSurvivesInvalidate:
+    """The per-step progress atlas clones the dataset context's atlas and its
+    object identity survives cache invalidation.
+
+    Building the coverage structure is hierarchical k-means over every
+    embedding; nulling the progress atlas on every polarity flip forced a full
+    re-fit under ``_progress_lock`` on the next ``/api/labeling-status`` poll.
+    Instead ``_build_coverage_atlas`` clones the context atlas (shared node
+    table, fresh label overlay) and ``invalidate_progress_cache_from`` rewinds
+    and replays that overlay in place rather than discarding the atlas.
+    """
+
+    def _vote(self, client, votes):
+        for cid, target in votes:
+            resp = client.post(f"/api/medias/{cid}/vote", json={"target": target})
+            assert resp.status_code == 200
+
+    def test_progress_atlas_clones_context_atlas(self, client):
+        build_coverage_atlas()
+        ctx_atlas = get_coverage_atlas()
+        assert ctx_atlas is not None
+
+        self._vote(client, [(1, "good"), (2, "bad")])
+        _ensure_cache(medias, label_history, 0)
+
+        prog_atlas = labeling_progress._cache_coverage_atlas
+        assert prog_atlas is not None
+        assert prog_atlas is not ctx_atlas
+        # Immutable structure is shared by reference (no re-fit)...
+        assert prog_atlas.nodes is ctx_atlas.nodes
+        assert prog_atlas.vector_to_leaf is ctx_atlas.vector_to_leaf
+        assert prog_atlas.nodes_by_depth is ctx_atlas.nodes_by_depth
+        # ...while the label overlay is an independent object.
+        assert prog_atlas._n_pos is not ctx_atlas._n_pos
+        assert prog_atlas._n_neg is not ctx_atlas._n_neg
+        assert prog_atlas._labeled is not ctx_atlas._labeled
+
+    def test_partial_invalidate_preserves_atlas_identity(self, client):
+        build_coverage_atlas()
+        # Steps: 0=(3,good), 1=(4,bad), 2=(1,good), 3=(2,bad); media 1 at step 2.
+        self._vote(client, [(3, "good"), (4, "bad"), (1, "good"), (2, "bad")])
+        _ensure_cache(medias, label_history, 0)
+        atlas_before = labeling_progress._cache_coverage_atlas
+        assert atlas_before is not None
+        assert atlas_before.labeled_ids == {1, 2, 3, 4}
+
+        # Switch media 1 (good→bad): steps 2-3 discarded, atlas rewound in place.
+        self._vote(client, [(1, "bad")])
+        atlas_after = labeling_progress._cache_coverage_atlas
+        assert atlas_after is atlas_before, "atlas rebuilt instead of rewound"
+        # Overlay rewound to the surviving prefix (steps 0-1): media 3 good, 4 bad.
+        assert atlas_after.labeled_ids == {3, 4}
+
+    def test_step0_invalidate_preserves_atlas_identity(self, client):
+        build_coverage_atlas()
+        self._vote(client, [(1, "good"), (2, "bad")])
+        _ensure_cache(medias, label_history, 0)
+        atlas_before = labeling_progress._cache_coverage_atlas
+        assert atlas_before is not None
+
+        # Switch media 1, present from step 0: whole prefix gone, atlas emptied.
+        self._vote(client, [(1, "bad")])
+        assert len(_cached_steps) == 0
+        atlas_after = labeling_progress._cache_coverage_atlas
+        assert atlas_after is atlas_before, "atlas rebuilt on step-0 invalidate"
+        assert atlas_after.labeled_ids == set()
 
 
 class TestStableIndicatorThresholds:

--- a/tests/sorting/test_coverage_atlas_integration.py
+++ b/tests/sorting/test_coverage_atlas_integration.py
@@ -29,8 +29,7 @@ def _build_atlas():
 
 
 def _covered(atlas, name):
-    node = atlas.nodes[name]
-    return node["n_pos"] + node["n_neg"] > 0
+    return atlas.n_pos(name) + atlas.n_neg(name) > 0
 
 
 # ---------------------------------------------------------------------------
@@ -64,8 +63,8 @@ class TestBuildCoverageAtlas:
         atlas = _build_atlas()
         assert 1 in atlas.labeled_ids
         assert 2 in atlas.labeled_ids
-        assert atlas.nodes["0"]["n_pos"] == 1
-        assert atlas.nodes["0"]["n_neg"] == 1
+        assert atlas.n_pos("0") == 1
+        assert atlas.n_neg("0") == 1
 
     def test_rebuild_clears_old_state(self):
         atlas1 = _build_atlas()
@@ -247,7 +246,7 @@ class TestVoteUpdatesAtlas:
         resp = client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
         assert resp.status_code == 200
         assert cid in atlas.labeled_ids
-        assert atlas.nodes["0"]["n_pos"] == 1
+        assert atlas.n_pos("0") == 1
 
     def test_bad_vote_labels_atlas(self, client):
         atlas = _build_atlas()
@@ -255,7 +254,7 @@ class TestVoteUpdatesAtlas:
         resp = client.post(f"/api/medias/{cid}/vote", json={"target": "bad"})
         assert resp.status_code == 200
         assert cid in atlas.labeled_ids
-        assert atlas.nodes["0"]["n_neg"] == 1
+        assert atlas.n_neg("0") == 1
 
     def test_unvote_unlabels_atlas(self, client):
         atlas = _build_atlas()
@@ -273,12 +272,12 @@ class TestVoteUpdatesAtlas:
         cid = 3
         client.post(f"/api/medias/{cid}/vote", json={"target": "good"})
         assert cid in atlas.labeled_ids
-        assert atlas.nodes["0"]["n_pos"] == 1
+        assert atlas.n_pos("0") == 1
         # Switch to bad
         client.post(f"/api/medias/{cid}/vote", json={"target": "bad"})
         assert cid in atlas.labeled_ids
-        assert atlas.nodes["0"]["n_pos"] == 0
-        assert atlas.nodes["0"]["n_neg"] == 1
+        assert atlas.n_pos("0") == 0
+        assert atlas.n_neg("0") == 1
 
 
 # ---------------------------------------------------------------------------
@@ -584,7 +583,7 @@ class TestClearVotesResetsAtlas:
 
         assert atlas.coverage_level() == 0
         assert atlas.labeled_ids == set()
-        assert all(n["n_pos"] == 0 and n["n_neg"] == 0 for n in atlas.nodes.values())
+        assert all(atlas.n_pos(name) == 0 and atlas.n_neg(name) == 0 for name in atlas.nodes)
 
     def test_next_sample_starts_over_after_clear_votes(self, client):
         """After clearing votes, the very first uncovered node is the root again."""

--- a/tests_lib/sorting/test_coverage_atlas.py
+++ b/tests_lib/sorting/test_coverage_atlas.py
@@ -201,8 +201,7 @@ class TestLookup:
 
 
 def _covered(atlas, name):
-    node = atlas.nodes[name]
-    return node["n_pos"] + node["n_neg"] > 0
+    return atlas.n_pos(name) + atlas.n_neg(name) > 0
 
 
 class TestEvidence:
@@ -215,15 +214,15 @@ class TestEvidence:
         # Walk from leaf to root; all should carry positive evidence
         node = leaf
         while node is not None:
-            assert atlas.nodes[node]["n_pos"] == 1
+            assert atlas.n_pos(node) == 1
             node = atlas.nodes[node]["parent"]
 
     def test_initially_no_evidence(self):
         vecs = _make_vectors(100)
         atlas = CoverageAtlas(vecs, k=2, min_node_size=10)
-        for node in atlas.nodes.values():
-            assert node["n_pos"] == 0
-            assert node["n_neg"] == 0
+        for name in atlas.nodes:
+            assert atlas.n_pos(name) == 0
+            assert atlas.n_neg(name) == 0
 
     def test_label_tracks_labeled_ids(self):
         vecs = _make_vectors(50)
@@ -237,18 +236,18 @@ class TestEvidence:
         atlas = CoverageAtlas(vecs, k=2, min_node_size=20)
         atlas.label(1, good=True)
         atlas.label(1, good=True)
-        assert atlas.nodes["0"]["n_pos"] == 1
+        assert atlas.n_pos("0") == 1
         assert atlas.labeled_ids == {1}
 
     def test_relabel_moves_evidence_between_channels(self):
         vecs = _make_vectors(50)
         atlas = CoverageAtlas(vecs, k=2, min_node_size=20)
         atlas.label(1, good=True)
-        assert atlas.nodes["0"]["n_pos"] == 1
-        assert atlas.nodes["0"]["n_neg"] == 0
+        assert atlas.n_pos("0") == 1
+        assert atlas.n_neg("0") == 0
         atlas.label(1, good=False)
-        assert atlas.nodes["0"]["n_pos"] == 0
-        assert atlas.nodes["0"]["n_neg"] == 1
+        assert atlas.n_pos("0") == 0
+        assert atlas.n_neg("0") == 1
 
     def test_per_class_counts_accumulate(self):
         vecs = _make_vectors(50)
@@ -256,8 +255,8 @@ class TestEvidence:
         atlas.label(1, good=True)
         atlas.label(2, good=True)
         atlas.label(3, good=False)
-        assert atlas.nodes["0"]["n_pos"] == 2
-        assert atlas.nodes["0"]["n_neg"] == 1
+        assert atlas.n_pos("0") == 2
+        assert atlas.n_neg("0") == 1
 
 
 # ---------------------------------------------------------------------------
@@ -287,15 +286,15 @@ class TestUnlabeling:
         atlas.label(v2, good=False)
 
         # Root should carry evidence from both
-        assert atlas.nodes["0"]["n_pos"] == 1
-        assert atlas.nodes["0"]["n_neg"] == 1
+        assert atlas.n_pos("0") == 1
+        assert atlas.n_neg("0") == 1
 
         atlas.unlabel(v1)
 
         # Root should still be covered (v2 keeps the other branch alive)
         assert _covered(atlas, "0")
-        assert atlas.nodes["0"]["n_pos"] == 0
-        assert atlas.nodes["0"]["n_neg"] == 1
+        assert atlas.n_pos("0") == 0
+        assert atlas.n_neg("0") == 1
 
     def test_unlabel_same_leaf_keeps_coverage(self):
         """If another labeled vector is in the same leaf, leaf stays covered."""
@@ -321,20 +320,20 @@ class TestUnlabeling:
 # ---------------------------------------------------------------------------
 
 
-class TestResetEvidence:
-    def test_reset_evidence_clears_everything(self):
+class TestResetLabeled:
+    def test_reset_labeled_clears_everything(self):
         vecs = _make_clustered_vectors([30, 30], dim=32)
         atlas = CoverageAtlas(vecs, k=2, min_node_size=10)
         atlas.label(1, good=True)
         atlas.label(31, good=False)
         assert len(atlas.labeled_ids) == 2
 
-        atlas.reset_evidence()
+        atlas.reset_labeled()
         assert atlas.labeled_ids == set()
         assert atlas.coverage_level() == 0
-        for node in atlas.nodes.values():
-            assert node["n_pos"] == 0
-            assert node["n_neg"] == 0
+        for name in atlas.nodes:
+            assert atlas.n_pos(name) == 0
+            assert atlas.n_neg(name) == 0
 
     def test_reset_then_relabel_picks_up_new_state(self):
         """After reset, label calls reproduce the evidence state from scratch."""
@@ -344,7 +343,7 @@ class TestResetEvidence:
         leaf1 = atlas.lookup(1)
         assert _covered(atlas, leaf1)
 
-        atlas.reset_evidence()
+        atlas.reset_labeled()
         # Label a different vector; only its leaf+ancestors should be covered.
         atlas.label(31, good=True)
         leaf31 = atlas.lookup(31)
@@ -354,8 +353,44 @@ class TestResetEvidence:
 
     def test_reset_on_empty_atlas_is_noop(self):
         atlas = CoverageAtlas({}, k=2)
-        atlas.reset_evidence()  # must not raise
+        atlas.reset_labeled()  # must not raise
         assert atlas.labeled_ids == set()
+
+
+class TestStructuralClone:
+    def test_clone_shares_structure_by_reference(self):
+        vecs = _make_vectors(120)
+        atlas = CoverageAtlas(vecs, k=3, min_node_size=10)
+        clone = atlas.structural_clone()
+
+        # The expensive, immutable maps are shared by reference (no re-fit).
+        assert clone.nodes is atlas.nodes
+        assert clone.vector_to_leaf is atlas.vector_to_leaf
+        assert clone.nodes_by_depth is atlas.nodes_by_depth
+        assert clone.center is atlas.center
+        assert clone.k == atlas.k
+        assert clone.max_depth == atlas.max_depth
+        assert clone.min_node_size == atlas.min_node_size
+
+    def test_clone_has_independent_empty_overlay(self):
+        vecs = _make_vectors(120)
+        atlas = CoverageAtlas(vecs, k=3, min_node_size=10)
+        first = next(iter(vecs))
+        atlas.label(first, good=True)
+
+        clone = atlas.structural_clone()
+        # Clone starts label-clean even though the original carries evidence.
+        assert clone.labeled_ids == set()
+        assert clone.coverage_level() == 0
+        assert all(clone.n_pos(name) == 0 and clone.n_neg(name) == 0 for name in clone.nodes)
+
+        # Labeling the clone must not disturb the original, and vice versa.
+        second = next(i for i in vecs if i != first)
+        clone.label(second, good=False)
+        assert clone.labeled_ids == {second}
+        assert atlas.labeled_ids == {first}
+        assert atlas.n_pos("0") == 1 and atlas.n_neg("0") == 0
+        assert clone.n_pos("0") == 0 and clone.n_neg("0") == 1
 
 
 # ---------------------------------------------------------------------------
@@ -588,7 +623,7 @@ class TestNextSample:
         # covered, so BFS lands on the larger cluster's (uncovered) child.
         atlas.label(41, good=True)
         children = atlas.nodes["0"]["children"]
-        target = next(c for c in children if not (atlas.nodes[c]["n_pos"] + atlas.nodes[c]["n_neg"]))
+        target = next(c for c in children if not (atlas.n_pos(c) + atlas.n_neg(c)))
         node = atlas.nodes[target]
         assert node["rbar"] >= 0.1, "cluster cell should have a concentrated direction"
         return atlas, node
@@ -1016,7 +1051,7 @@ class TestSerialization:
 
         clone = CoverageAtlas.from_serializable(atlas.to_serializable())
         assert clone.labeled_ids == set()
-        assert all(n["n_pos"] == 0 and n["n_neg"] == 0 for n in clone.nodes.values())
+        assert all(clone.n_pos(name) == 0 and clone.n_neg(name) == 0 for name in clone.nodes)
         # Labeling still works against the restored topology.
         clone.label(first, good=True)
         assert clone.coverage_level() >= 1

--- a/tests_lib/sorting/test_coverage_atlas_restore.py
+++ b/tests_lib/sorting/test_coverage_atlas_restore.py
@@ -72,4 +72,5 @@ def test_restored_atlas_starts_with_clean_evidence_state():
     assert restore_coverage_atlas_from_cache(ctx, snap) is True
     # No votes replayed yet: the restored atlas must look unlabeled.
     assert ctx.coverage_atlas.labeled_ids == set()
-    assert all(n["n_pos"] == 0 and n["n_neg"] == 0 for n in ctx.coverage_atlas.nodes.values())
+    atlas = ctx.coverage_atlas
+    assert all(atlas.n_pos(name) == 0 and atlas.n_neg(name) == 0 for name in atlas.nodes)

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -160,7 +160,7 @@ def ensure_votes_match_active_dataset() -> None:
             det_ctx.cached_labelset_mtime = 0.0
             det_ctx.cached_labelset_media_type = ""
             if ds_ctx.coverage_atlas is not None:
-                ds_ctx.coverage_atlas.reset_evidence()
+                ds_ctx.coverage_atlas.reset_labeled()
         return
 
     from vtscore.datasets.labelset import LabelSet

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -117,7 +117,7 @@ def invalidate_progress_cache_from(media_id: int) -> None:
     appearance onward are discarded so they can be retrained and their
     stability/evaluation metrics recomputed.
     """
-    global _cache_prev_predictions, _cache_coverage_atlas
+    global _cache_prev_predictions, _status_snapshot
     with _progress_lock:
         # Find the first cached step that includes media_id in its training data.
         truncate_at = None
@@ -133,31 +133,40 @@ def invalidate_progress_cache_from(media_id: int) -> None:
             _live_models.clear()
             return
 
-        if truncate_at == 0:
-            # Media was present from the very first step - full clear.
-            clear_progress_cache()
-            return
-
         # Keep steps [0, truncate_at); discard the rest.
         del _cached_steps[truncate_at:]
 
-        # Restore running ID sets from the last kept step.
-        last = _cached_steps[-1]
+        # Restore the running ID sets to the surviving prefix's final state.
         _cache_good_ids.clear()
-        _cache_good_ids.update(last["good_ids"])
         _cache_bad_ids.clear()
-        _cache_bad_ids.update(last["bad_ids"])
+        if _cached_steps:
+            last = _cached_steps[-1]
+            _cache_good_ids.update(last["good_ids"])
+            _cache_bad_ids.update(last["bad_ids"])
+        else:
+            # truncate_at == 0: media was present from the very first step, so
+            # the whole prefix is gone and no label survives.  No cached step
+            # remains to source the Smart / Stable indicators from, so drop the
+            # stale snapshot (parity with the old step-0 full-clear path).
+            _status_snapshot = None
 
         # Reset the stability prediction chain - it will restart from the
         # truncation point when _ensure_cache replays the remaining history.
         _cache_prev_predictions = None
 
-        # Rebuild the coverage atlas on next _ensure_cache call so its label
-        # state is re-synced from the truncation point forward.
-        _cache_coverage_atlas = None
-
         # Clear live models - some may have been trained with the old label.
         _live_models.clear()
+
+        # Rewind the coverage-atlas overlay and replay the surviving labels
+        # rather than nulling the atlas (which would force a full hierarchical
+        # k-means rebuild on the next /api/labeling-status poll, starving the
+        # request pool at scale).  The structure is unchanged - only labels
+        # moved - so the atlas object identity survives the invalidate.
+        if _cache_coverage_atlas is not None:
+            _cache_coverage_atlas.reset_labeled()
+            for mid in _cache_good_ids | _cache_bad_ids:
+                if mid in _cache_coverage_atlas.vector_to_leaf:
+                    _cache_coverage_atlas.label(mid, good=mid in _cache_good_ids)
 
 
 def inject_live_model(
@@ -177,8 +186,36 @@ def inject_live_model(
         _live_models[key] = (model, threshold)
 
 
+def _active_context_atlas() -> Any:
+    """Return the active dataset context's coverage atlas, or ``None``.
+
+    Read *without* acquiring ``_state_lock``: this runs under ``_progress_lock``
+    (see the lock-ordering note at module top), which forbids taking
+    ``_state_lock`` while held.  ``get_active_context()`` itself takes no lock,
+    and the atlas it returns is only ever *read* here (its structure is
+    immutable once built), so the lock-free read is safe - at worst a stale
+    reference fails the id-set match below and we fall back to a fresh build.
+    In the ``/api/labeling-status`` background worker the dataset context is
+    bound thread-locally by ``JobManager``, so this resolves the right atlas.
+    """
+    try:
+        from vtscore.state.core import get_active_context  # noqa: PLC0415
+
+        return get_active_context().coverage_atlas
+    except Exception:
+        return None
+
+
 def _build_coverage_atlas(clips_dict: dict[int, dict[str, Any]]) -> Any:
-    """Build a CoverageAtlas from clip embeddings, or ``None`` if no embeddings."""
+    """Build a CoverageAtlas from clip embeddings, or ``None`` if no embeddings.
+
+    When the active dataset context already holds an atlas over *exactly* this
+    id set, its hierarchical-k-means structure is identical to what a rebuild
+    would produce, so we :meth:`~CoverageAtlas.structural_clone` it (sharing the
+    node table by reference, fresh label overlay) instead of re-fitting under
+    ``_progress_lock`` - which otherwise starves the request pool at N in the
+    few-thousands on every polarity-flip invalidate.
+    """
     vectors: dict[int, np.ndarray] = {
         cid: np.asarray(media_embedding(media), dtype=np.float32)
         for cid, media in clips_dict.items()
@@ -186,6 +223,11 @@ def _build_coverage_atlas(clips_dict: dict[int, dict[str, Any]]) -> Any:
     }
     if not vectors:
         return None
+
+    ctx_atlas = _active_context_atlas()
+    if ctx_atlas is not None and ctx_atlas.vector_to_leaf.keys() == vectors.keys():
+        return ctx_atlas.structural_clone()
+
     from vtscore.state.coverage_atlas import CoverageAtlas  # noqa: PLC0415
 
     return CoverageAtlas(vectors, k=3)
@@ -417,10 +459,12 @@ def _ensure_cache(
 
     if _cache_coverage_atlas is None:
         _cache_coverage_atlas = _build_coverage_atlas(clips_dict)
-        # After a partial invalidation (_cache_coverage_atlas was set to None
-        # but _cache_good_ids/_cache_bad_ids still contain IDs from kept
-        # steps), seed the fresh atlas with those pre-existing labels so that
-        # coverage_level() is correct for subsequently replayed events.
+        # A freshly built (or cloned) atlas starts with an empty label overlay.
+        # Defensively seed it with any labels already accumulated in the
+        # running ID sets so coverage_level() is correct before the history
+        # replay below runs; normally these sets are empty at first build
+        # (invalidate rewinds and replays its atlas in place rather than
+        # nulling it, so this branch no longer runs mid-history).
         if _cache_coverage_atlas is not None:
             for mid in _cache_good_ids | _cache_bad_ids:
                 if mid in _cache_coverage_atlas.vector_to_leaf:

--- a/vtscore/state/coverage.py
+++ b/vtscore/state/coverage.py
@@ -57,7 +57,7 @@ def resync_coverage_atlas_to_detector(
     atlas = ds_ctx.coverage_atlas
     if atlas is None:
         return
-    atlas.reset_evidence()
+    atlas.reset_labeled()
     for cid in det_ctx.good_votes:
         if cid in atlas.vector_to_leaf:
             atlas.label(cid, good=True)

--- a/vtscore/state/coverage_atlas.py
+++ b/vtscore/state/coverage_atlas.py
@@ -175,8 +175,11 @@ class CoverageAtlas:
         self.min_node_size = min_node_size
 
         # Node storage: name -> {ids, children, depth, parent, n, mu, rbar,
-        # t_quantiles, n_pos, n_neg}.  ``ids`` is sorted most-typical-first
-        # (descending mu . x) so ids[0] is the node's representative element.
+        # t_quantiles}.  ``ids`` is sorted most-typical-first (descending
+        # mu . x) so ids[0] is the node's representative element.  Node records
+        # are *immutable* once built — evidence lives in the separate overlay
+        # dicts below — so :meth:`structural_clone` can share this map (and the
+        # two below) by reference across atlases with independent labels.
         self.nodes: dict[str, dict] = {}
         # Vector ID -> leaf node name
         self.vector_to_leaf: dict[int, str] = {}
@@ -184,7 +187,12 @@ class CoverageAtlas:
         self.nodes_by_depth: dict[int, list[str]] = {}
         # Geometry: dataset mean direction subtracted before renormalizing.
         self.center: np.ndarray = np.zeros(0, dtype=np.float32)
-        # Evidence state: vector ID -> is_good (session state, not persisted)
+        # Label overlay (session state, not persisted; per-instance so a
+        # structural clone's labels never touch the original's):
+        #   node name -> positive / negative evidence count (absent = 0),
+        #   vector ID -> is_good.
+        self._n_pos: dict[str, int] = {}
+        self._n_neg: dict[str, int] = {}
         self._labeled: dict[int, bool] = {}
 
         if vectors:
@@ -353,8 +361,6 @@ class CoverageAtlas:
             "mu": mu,
             "rbar": rlen / n if n else 0.0,
             "t_quantiles": [float(q) for q in np.quantile(t_loo, _CALIBRATION_GRID)] if n else [],
-            "n_pos": 0,
-            "n_neg": 0,
             "_order": order,
         }
 
@@ -387,28 +393,41 @@ class CoverageAtlas:
         self._shift_evidence(vector_id, prev, -1)
 
     def _shift_evidence(self, vector_id: int, good: bool, delta: int) -> None:
-        key = "n_pos" if good else "n_neg"
+        overlay = self._n_pos if good else self._n_neg
         node = self.vector_to_leaf[vector_id]
         while node is not None:
-            self.nodes[node][key] += delta
+            count = overlay.get(node, 0) + delta
+            if count:
+                overlay[node] = count
+            else:
+                overlay.pop(node, None)
             node = self.nodes[node]["parent"]
 
-    def reset_evidence(self) -> None:
-        """Zero every node's evidence counts and forget every labeled vector ID.
+    def n_pos(self, name: str) -> int:
+        """Return the positive-evidence count accumulated at node *name*."""
+        return self._n_pos.get(name, 0)
+
+    def n_neg(self, name: str) -> int:
+        """Return the negative-evidence count accumulated at node *name*."""
+        return self._n_neg.get(name, 0)
+
+    def reset_labeled(self) -> None:
+        """Rewind the label overlay: drop every evidence count and labeled ID.
 
         Used when the labeled set is replaced wholesale - e.g. votes are
         cleared, or the active detector is swapped on the same dataset and
         the atlas's evidence state needs to be rebuilt from the new
-        detector's votes (see :func:`resync_coverage_atlas_to_detector`).
+        detector's votes (see :func:`resync_coverage_atlas_to_detector`) - or
+        when the per-step labeling-progress cache is truncated and its atlas
+        is rewound and replayed instead of rebuilt.  The shared node structure
+        is untouched, so it is safe to call on a :meth:`structural_clone`.
         """
-        for node in self.nodes.values():
-            node["n_pos"] = 0
-            node["n_neg"] = 0
+        self._n_pos.clear()
+        self._n_neg.clear()
         self._labeled.clear()
 
     def _covered(self, name: str) -> bool:
-        node = self.nodes[name]
-        return node["n_pos"] + node["n_neg"] > 0
+        return self._n_pos.get(name, 0) + self._n_neg.get(name, 0) > 0
 
     def coverage_level(self) -> int:
         """Return the number of consecutive evidence-bearing nodes in BFS order.
@@ -655,8 +674,6 @@ class CoverageAtlas:
                     "mu": np.asarray(node["mu"], dtype=np.float32),
                     "rbar": node["rbar"],
                     "t_quantiles": node["t_quantiles"],
-                    "n_pos": 0,
-                    "n_neg": 0,
                 }
                 for name, node in data["nodes"].items()
             }
@@ -664,8 +681,37 @@ class CoverageAtlas:
             atlas.nodes_by_depth = data["nodes_by_depth"]
         except KeyError as exc:
             raise ValueError(f"Incomplete coverage-atlas cache: missing {exc}") from exc
+        atlas._n_pos = {}
+        atlas._n_neg = {}
         atlas._labeled = {}
         return atlas
+
+    def structural_clone(self) -> CoverageAtlas:
+        """Return a new atlas sharing this atlas's structure, with empty labels.
+
+        The clone reuses the node table, per-vector leaf assignment, depth
+        index, geometry, and build parameters *by reference* - none of which
+        the evidence path ever rewrites - while starting with a fresh, empty
+        label overlay (``_n_pos`` / ``_n_neg`` / ``_labeled``).  Building the
+        structure is the expensive part (hierarchical k-means over every
+        embedding); cloning skips it entirely, so a second atlas over the same
+        id set - e.g. the labeling-progress per-step atlas mirroring the
+        dataset context's - costs a few dict allocations instead of a full
+        re-fit.  Labeling either atlas never affects the other because the
+        overlay dicts are per-instance.
+        """
+        clone = self.__class__.__new__(self.__class__)
+        clone.k = self.k
+        clone.max_depth = self.max_depth
+        clone.min_node_size = self.min_node_size
+        clone.center = self.center
+        clone.nodes = self.nodes
+        clone.vector_to_leaf = self.vector_to_leaf
+        clone.nodes_by_depth = self.nodes_by_depth
+        clone._n_pos = {}
+        clone._n_neg = {}
+        clone._labeled = {}
+        return clone
 
     def span_info(self) -> dict:
         """Return span level details for the labeling progress indicator.

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -53,7 +53,7 @@ def clear_votes() -> None:
         ctx.find_eval_stale = False
         ds_atlas = get_active_context().coverage_atlas
         if ds_atlas is not None:
-            ds_atlas.reset_evidence()
+            ds_atlas.reset_labeled()
     # ``_progress_lock`` is acquired strictly outside ``_state_lock`` so the
     # two locks never establish a cross-module ordering (audit M1).
     clear_progress_cache()


### PR DESCRIPTION
## Problem

The labeling-progress per-step atlas (`_cache_coverage_atlas`) rebuilt its **hierarchical-k-means structure from scratch** every time `invalidate_progress_cache_from` nulled it on a vote polarity flip. The next `/api/labeling-status` poll then ran the full re-fit under `_progress_lock`, starving the request pool at N in the few-thousands.

## Fix

The atlas *structure* (node table, per-vector leaf assignment, geometry, moments, calibration) is identical across atlases over the same id set — only the labels differ. So:

- **Separate the label overlay from the immutable structure.** `n_pos` / `n_neg` counts and the labeled-ID set move out of the per-node dicts into per-instance overlay dicts (`_n_pos`, `_n_neg`, `_labeled`) keyed by node name. Node records are now immutable once built. Evidence is read through new `atlas.n_pos(name)` / `atlas.n_neg(name)` accessors.
- **`CoverageAtlas.structural_clone()`** returns a new atlas that shares the node/leaf maps *by reference* with a fresh, empty overlay — a few dict allocations instead of a full re-fit.
- **`reset_labeled()`** (renamed from `reset_evidence`) rewinds the overlay in place.
- **`invalidate_progress_cache_from`** now rewinds the overlay and replays the surviving labels instead of nulling the atlas, so its **object identity survives** both partial and step-0 invalidation.
- **`_build_coverage_atlas`** clones the active dataset context's atlas when it already covers exactly this id set, instead of re-fitting. The context atlas is read lock-free (the module runs under `_progress_lock`, which forbids taking `_state_lock`; `get_active_context()` takes no lock and the atlas is only read).

## Tests

- `tests/core/test_votes.py`: the progress atlas clones the context atlas (shared `nodes`, independent overlay); atlas object identity survives partial and step-0 invalidate.
- `tests_lib/sorting/test_coverage_atlas.py`: `structural_clone` shares structure by reference and keeps an independent, empty overlay; `reset_labeled` tests.
- Updated every `node["n_pos"]` / `node["n_neg"]` reader across the atlas test suites to the new accessors.

Full `./run-tests.sh` passes (6220 passed, 1 skipped).

## Backwards compatibility

`reset_evidence` → `reset_labeled` is a rename (no shim, per repo policy) with all three production callers updated. Evidence counts are no longer stored on the node dicts — code reading `node["n_pos"]` must use `atlas.n_pos(name)`.

Closes #2501

🤖 Generated with [Claude Code](https://claude.com/claude-code)