### PR TITLE
Active-learning acquisition strategies + benchmark harness

### DIFF
--- a/scripts/run_mlp_ensemble_sweep.py
+++ b/scripts/run_mlp_ensemble_sweep.py
@@ -10,13 +10,14 @@ results (CSVs, plots, a README) under ``docs/experiments/mlp-ensemble/``:
    any ranking (AUROC / F1@xcal) over one MLP, and traces the ensemble's
    reported per-item uncertainty (``std_mean``) as labels accumulate.
 
-2. **Voting-order axis** (`vtscore.eval.voting_iterations`) - simulates
-   voting under ``vote_order ∈ {shuffle, balanced, ensemble_std}`` and
-   plots the inclusion-weighted cost against the number of votes cast.
-   Answers "does choosing the next vote by ensemble disagreement (active
-   learning) reach a low cost in fewer votes than random or class-balanced
-   ordering?"  Per-step cost is always the single production MLP; the
-   ensemble only *selects* the next vote.
+2. **Voting-strategy axis** (`vtscore.eval.voting_iterations`) - simulates
+   voting under acquisition ``strategy ∈ {random, balanced, ensemble_std}``
+   (the unified-registry successors of the old shuffle/balanced/ensemble_std
+   orders) and plots the inclusion-weighted cost against the number of votes
+   cast.  Answers "does choosing the next vote by ensemble disagreement
+   (active learning) reach a low cost in fewer votes than random or
+   class-balanced ordering?"  Per-step cost is always the single production
+   MLP; the strategy only *selects* the next vote.
 
 Usage::
 
@@ -25,7 +26,7 @@ Usage::
         --out-dir docs/experiments/mlp-ensemble \\
         --label-counts 5 10 20 50 \\
         --seeds 0 1 2 \\
-        --max-votes 40
+        --max-steps 40
 
 Designed to be deleted once the results are committed.
 """
@@ -37,8 +38,9 @@ import math
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from vtscore.eval.al_strategies import available_strategies
 from vtscore.eval.label_curve import run_label_curve_eval, summarise
-from vtscore.eval.voting_iterations import VOTE_ORDERS, run_voting_iterations_eval
+from vtscore.eval.voting_iterations import run_voting_iterations_eval
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -47,6 +49,10 @@ DEFAULT_DATASETS = ("urbansound8k_s",)
 DEFAULT_LABEL_COUNTS = (5, 10, 20, 50)
 DEFAULT_SEEDS = (0, 1, 2)
 DEFAULT_ENSEMBLE_SIZES = (3, 5, 7, 10)
+# Acquisition strategies compared in the voting axis: the random baseline, the
+# class-balanced oracle order, and the deep-ensemble uncertainty sampler (the
+# unified-registry successors of the old shuffle/balanced/ensemble_std orders).
+DEFAULT_VOTING_STRATEGIES = ("random", "balanced", "ensemble_std")
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +161,7 @@ def plot_label_curve(summary: "pd.DataFrame", out_dir: Path) -> list[Path]:
 
 
 def plot_voting_orders(df: "pd.DataFrame", out_dir: Path) -> list[Path]:
-    """Cost vs votes cast, one line per vote_order (averaged over cells)."""
+    """Cost vs votes cast, one line per acquisition strategy (averaged over cells)."""
     import matplotlib.pyplot as plt
 
     generated: list[Path] = []
@@ -164,19 +170,19 @@ def plot_voting_orders(df: "pd.DataFrame", out_dir: Path) -> list[Path]:
 
     palette = plt.cm.tab10.colors  # type: ignore[attr-defined]
     fig, ax = plt.subplots(figsize=(8, 5))
-    for idx, order in enumerate(sorted(df["vote_order"].unique())):
-        sub = df[df["vote_order"] == order]
+    for idx, strategy in enumerate(sorted(df["strategy"].unique())):
+        sub = df[df["strategy"] == strategy]
         agg = sub.groupby("t")["cost"].agg(["mean", "std"]).reset_index()
         colour = palette[idx % len(palette)]
         t = agg["t"].to_numpy()
         mean = agg["mean"].to_numpy()
         std = agg["std"].fillna(0).to_numpy()
-        ax.plot(t, mean, label=order, color=colour, linewidth=1.5)
+        ax.plot(t, mean, label=strategy, color=colour, linewidth=1.5)
         if (std > 0).any():
             ax.fill_between(t, mean - std, mean + std, alpha=0.12, color=colour)
     ax.set_xlabel("Votes cast (t)")
     ax.set_ylabel("Inclusion-weighted cost")
-    ax.set_title("Voting cost by vote_order")
+    ax.set_title("Voting cost by acquisition strategy")
     ax.legend(fontsize=8, loc="best")
     fig.tight_layout()
     path = out_dir / "voting_cost_by_order.png"
@@ -198,9 +204,8 @@ def write_report(
     label_counts: tuple[int, ...],
     seeds: tuple[int, ...],
     ensemble_sizes: tuple[int, ...],
-    vote_orders: tuple[str, ...],
-    max_votes: int | None,
-    n_ensemble: int,
+    strategies: tuple[str, ...],
+    max_steps: int | None,
     label_summary: "pd.DataFrame",
     voting_df: "pd.DataFrame",
 ) -> None:
@@ -218,8 +223,8 @@ def write_report(
         f"Datasets: {', '.join(f'`{d}`' for d in datasets)} · "
         f"label counts: {list(label_counts)} · seeds: {list(seeds)} · "
         f"ensemble sizes: {list(ensemble_sizes)} · "
-        f"vote orders: {list(vote_orders)} · "
-        f"max_votes: {max_votes} · ensemble_std n_ensemble: {n_ensemble}."
+        f"voting strategies: {list(strategies)} · "
+        f"max_steps: {max_steps}."
     )
     lines.append("")
 
@@ -247,20 +252,20 @@ def write_report(
     lines.extend(_trainer_headline_table(label_summary))
     lines.append("")
 
-    # ---- Voting-order axis -------------------------------------------------
-    lines.append("## 2. Voting order - does ensemble-uncertainty selection help?")
+    # ---- Voting-strategy axis ----------------------------------------------
+    lines.append("## 2. Acquisition strategy - does ensemble-uncertainty selection help?")
     lines.append("")
     lines.append(
         "Cost is the inclusion-weighted `fpr_weight·FPR + fnr_weight·FNR` "
         "on a held-out test split, measured with the single production MLP "
-        "at every step.  `shuffle` votes in random order, `balanced` keeps "
-        "the running label set class-balanced, and `ensemble_std` votes "
-        "next on the item an N-member ensemble disagrees about most (active "
-        "learning).  A lower curve, or the same cost reached at a smaller "
-        "`t`, means the ordering is more label-efficient."
+        "at every step.  `random` votes in random order, `balanced` keeps "
+        "the running label set class-balanced (an oracle order), and "
+        "`ensemble_std` votes next on the item an N-member ensemble disagrees "
+        "about most (active learning).  A lower curve, or the same cost "
+        "reached at a smaller `t`, means the strategy is more label-efficient."
     )
     lines.append("")
-    lines.append("![Cost by vote_order](voting_cost_by_order.png)")
+    lines.append("![Cost by strategy](voting_cost_by_order.png)")
     lines.append("")
     lines.extend(_voting_headline_table(voting_df))
     lines.append("")
@@ -268,7 +273,7 @@ def write_report(
     lines.append("## Files")
     lines.append("")
     lines.append("- `label_curve.csv` - one row per (dataset, category, trainer, n_labels, seed).")
-    lines.append("- `voting_iterations.csv` - one row per (vote_order, seed, dataset, category, t).")
+    lines.append("- `voting_iterations.csv` - one row per (strategy, seed, dataset, category, t).")
     lines.append("- `*.png` - the plots embedded above.")
     lines.append("")
 
@@ -292,13 +297,13 @@ def _trainer_headline_table(summary: "pd.DataFrame") -> list[str]:
 def _voting_headline_table(df: "pd.DataFrame") -> list[str]:
     if df.empty:
         return ["_(no rows - every cell was skipped)_"]
-    rows = ["| vote_order | steps | final cost | min cost |", "|---|---|---|---|"]
-    for order in sorted(df["vote_order"].unique()):
-        sub = df[df["vote_order"] == order]
+    rows = ["| strategy | steps | final cost | min cost |", "|---|---|---|---|"]
+    for strategy in sorted(df["strategy"].unique()):
+        sub = df[df["strategy"] == strategy]
         # Final cost = mean cost at the largest t reached per (seed, dataset, category).
         finals = sub.sort_values("t").groupby(["seed", "dataset", "category"]).tail(1)
         rows.append(
-            f"| `{order}` | {int(sub['t'].max())} | "
+            f"| `{strategy}` | {int(sub['t'].max())} | "
             f"{float(finals['cost'].mean()):.4f} | {float(sub['cost'].min()):.4f} |"
         )
     return rows
@@ -317,25 +322,19 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--seeds", nargs="+", type=int, default=list(DEFAULT_SEEDS))
     ap.add_argument("--ensemble-sizes", nargs="+", type=int, default=list(DEFAULT_ENSEMBLE_SIZES))
     ap.add_argument(
-        "--vote-orders",
+        "--strategies",
         nargs="+",
-        default=list(VOTE_ORDERS),
-        choices=list(VOTE_ORDERS),
-        help="Vote orders to compare in the voting-iterations axis.",
+        default=list(DEFAULT_VOTING_STRATEGIES),
+        choices=available_strategies(),
+        help="Acquisition strategies to compare in the voting-iterations axis.",
     )
     ap.add_argument("--categories", nargs="+", default=None, metavar="CAT")
     ap.add_argument("--inclusion", type=int, default=0)
     ap.add_argument(
-        "--max-votes",
+        "--max-steps",
         type=int,
         default=40,
-        help="Cap on votes cast per cell (keeps the ensemble_std order tractable). Pass 0 for no cap.",
-    )
-    ap.add_argument(
-        "--n-ensemble",
-        type=int,
-        default=5,
-        help="Ensemble size used for ensemble_std vote selection (default 5).",
+        help="Cap on votes cast per cell (keeps the ensemble_std strategy tractable). Pass 0 for no cap.",
     )
     ap.add_argument("--no-voting", action="store_true", help="Skip the voting-iterations axis.")
     ap.add_argument("--no-label-curve", action="store_true", help="Skip the label-curve axis.")
@@ -356,7 +355,7 @@ def main(argv: list[str] | None = None) -> int:
         dataset_clips[demo_id] = _load_dataset(demo_id)
 
     categories = {ds: args.categories for ds in dataset_clips} if args.categories else None
-    max_votes = None if args.max_votes in (0, None) else args.max_votes
+    max_steps = None if args.max_steps in (0, None) else args.max_steps
 
     label_summary = pd.DataFrame()
     voting_df = pd.DataFrame()
@@ -380,24 +379,17 @@ def main(argv: list[str] | None = None) -> int:
         for p in plot_label_curve(label_summary, args.out_dir):
             print(f"  plot -> {p.name}", flush=True)
 
-    # ---- Voting-order axis -------------------------------------------------
+    # ---- Voting-strategy axis ----------------------------------------------
     if not args.no_voting:
-        print(f"\nVoting-iterations sweep: vote_orders={args.vote_orders}", flush=True)
-        frames: list[pd.DataFrame] = []
-        for order in args.vote_orders:
-            print(f"  vote_order={order}", flush=True)
-            df = run_voting_iterations_eval(
-                dataset_clips=dataset_clips,
-                seeds=list(args.seeds),
-                categories=categories,
-                inclusion=args.inclusion,
-                vote_order=order,
-                n_ensemble=args.n_ensemble,
-                max_votes=max_votes,
-            )
-            df["vote_order"] = order
-            frames.append(df)
-        voting_df = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        print(f"\nVoting-iterations sweep: strategies={args.strategies}", flush=True)
+        voting_df = run_voting_iterations_eval(
+            dataset_clips=dataset_clips,
+            seeds=list(args.seeds),
+            categories=categories,
+            inclusion=args.inclusion,
+            strategies=list(args.strategies),
+            max_steps=max_steps,
+        )
         voting_df.to_csv(args.out_dir / "voting_iterations.csv", index=False)
         print(f"  wrote {len(voting_df)} rows -> voting_iterations.csv", flush=True)
         for p in plot_voting_orders(voting_df, args.out_dir):
@@ -411,9 +403,8 @@ def main(argv: list[str] | None = None) -> int:
         label_counts=tuple(args.label_counts),
         seeds=tuple(args.seeds),
         ensemble_sizes=tuple(args.ensemble_sizes),
-        vote_orders=tuple(args.vote_orders),
-        max_votes=max_votes,
-        n_ensemble=args.n_ensemble,
+        strategies=tuple(args.strategies),
+        max_steps=max_steps,
         label_summary=label_summary,
         voting_df=voting_df,
     )

--- a/tests_lib/detectors/test_al_benchmark.py
+++ b/tests_lib/detectors/test_al_benchmark.py
@@ -1,0 +1,162 @@
+"""Tests for the hermetic active-learning benchmark harness."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from vtscore.eval.al_benchmark import (
+    _final_cost_summary,
+    precomputed_source,
+    precomputed_source_from_npz,
+    run_al_benchmark,
+    synthetic_source,
+)
+from vtscore.embedding.media_vectors import media_embedding
+
+
+# ------------------------------------------------------------------
+# synthetic_source
+# ------------------------------------------------------------------
+
+
+class TestSyntheticSource:
+    def test_shape_and_counts(self):
+        clips = synthetic_source(n_per_cat=10, dim=16, n_categories=3, seed=0)
+        assert set(clips) == {"synthetic"}
+        medias = clips["synthetic"]
+        assert len(medias) == 30
+        cats = {m["category"] for m in medias.values()}
+        assert cats == {"cat0", "cat1", "cat2"}
+        for m in medias.values():
+            vec = media_embedding(m)
+            assert vec is not None
+            assert vec.shape == (16,)
+
+    def test_seed_reproducible(self):
+        a = synthetic_source(n_per_cat=5, dim=8, seed=42)["synthetic"]
+        b = synthetic_source(n_per_cat=5, dim=8, seed=42)["synthetic"]
+        for cid in a:
+            np.testing.assert_array_equal(media_embedding(a[cid]), media_embedding(b[cid]))
+
+    def test_separation_is_separable(self):
+        # High separation, low noise => classes are cleanly split in feature space.
+        clips = synthetic_source(n_per_cat=20, dim=8, n_categories=2, separation=3.0, noise=0.1, seed=1)["synthetic"]
+        cat0 = np.array([media_embedding(m) for m in clips.values() if m["category"] == "cat0"])
+        cat1 = np.array([media_embedding(m) for m in clips.values() if m["category"] == "cat1"])
+        # Between-class centroid distance dwarfs within-class spread.
+        centroid_gap = np.linalg.norm(cat0.mean(0) - cat1.mean(0))
+        within = np.linalg.norm(cat0 - cat0.mean(0), axis=1).mean()
+        assert centroid_gap > within
+
+    def test_rejects_bad_params(self):
+        with pytest.raises(ValueError):
+            synthetic_source(n_categories=1)
+        with pytest.raises(ValueError):
+            synthetic_source(n_per_cat=0)
+
+
+# ------------------------------------------------------------------
+# precomputed_source
+# ------------------------------------------------------------------
+
+
+class TestPrecomputedSource:
+    def test_wraps_features_and_labels(self):
+        rng = np.random.default_rng(0)
+        feats = rng.standard_normal((6, 4)).astype(np.float32)
+        labels = ["a", "a", "b", "b", "c", "c"]
+        clips = precomputed_source(feats, labels, name="pc")["pc"]
+        assert len(clips) == 6
+        assert {m["category"] for m in clips.values()} == {"a", "b", "c"}
+        # Media ids default to 1..n and the vectors round-trip.
+        np.testing.assert_array_equal(media_embedding(clips[1]), feats[0])
+
+    def test_custom_ids(self):
+        feats = np.zeros((2, 3), dtype=np.float32)
+        clips = precomputed_source(feats, ["x", "y"], ids=[100, 200])["precomputed"]
+        assert set(clips) == {100, 200}
+
+    def test_rejects_shape_mismatch(self):
+        with pytest.raises(ValueError):
+            precomputed_source(np.zeros((3, 4), np.float32), ["a", "b"])  # 3 rows, 2 labels
+        with pytest.raises(ValueError):
+            precomputed_source(np.zeros(4, np.float32), ["a"])  # 1D features
+
+    def test_npz_roundtrip_without_pickle(self, tmp_path):
+        rng = np.random.default_rng(1)
+        feats = rng.standard_normal((5, 4)).astype(np.float32)
+        labels = np.array(["p", "q", "p", "q", "p"])
+        path = tmp_path / "features.npz"
+        np.savez(path, features=feats, labels=labels)
+        clips = precomputed_source_from_npz(path)
+        medias = clips["features"]  # default name = file stem
+        assert len(medias) == 5
+        assert {m["category"] for m in medias.values()} == {"p", "q"}
+
+    def test_npz_missing_keys_raises(self, tmp_path):
+        path = tmp_path / "bad.npz"
+        np.savez(path, wrong=np.zeros((2, 2)))
+        with pytest.raises(ValueError):
+            precomputed_source_from_npz(path)
+
+
+# ------------------------------------------------------------------
+# run_al_benchmark + summary
+# ------------------------------------------------------------------
+
+
+class TestRunAlBenchmark:
+    def test_multiple_strategies_and_strategy_column(self):
+        clips = synthetic_source(n_per_cat=12, dim=12, seed=0)
+        df = run_al_benchmark(
+            clips,
+            strategies=["random", "margin"],
+            seeds=[0, 1],
+            calibrate_count=1,
+            max_steps=8,
+        )
+        assert not df.empty
+        assert set(df["strategy"].unique()) == {"random", "margin"}
+        assert "cost" in df.columns
+
+    def test_density_strategy_runs(self):
+        clips = synthetic_source(n_per_cat=15, dim=12, seed=2)
+        df = run_al_benchmark(
+            clips,
+            strategies=["density_margin"],
+            seeds=[0],
+            calibrate_count=1,
+            max_steps=8,
+            atlas_min_node_size=3,
+        )
+        assert not df.empty
+        assert (df["strategy"] == "density_margin").all()
+
+    def test_plot_dir_writes_pngs(self, tmp_path):
+        clips = synthetic_source(n_per_cat=10, dim=8, seed=0)
+        run_al_benchmark(
+            clips,
+            strategies=["random", "margin"],
+            seeds=[0],
+            calibrate_count=1,
+            max_steps=6,
+            plot_dir=tmp_path,
+        )
+        pngs = list(tmp_path.glob("*.png"))
+        assert {p.name for p in pngs} == {"voting_iterations_cost.png", "voting_iterations_fpr_fnr.png"}
+
+    def test_final_cost_summary_ranks_strategies(self):
+        clips = synthetic_source(n_per_cat=12, dim=12, seed=0)
+        df = run_al_benchmark(clips, strategies=["random", "margin"], seeds=[0, 1], calibrate_count=1, max_steps=8)
+        summary = _final_cost_summary(df)
+        assert list(summary.columns) == ["strategy", "final_cost"]
+        assert set(summary["strategy"]) == {"random", "margin"}
+        # Sorted ascending by final cost.
+        assert summary["final_cost"].is_monotonic_increasing
+
+    def test_final_cost_summary_empty(self):
+        empty = pd.DataFrame(
+            columns=["seed", "dataset", "category", "strategy", "t", "cost", "fpr", "fnr"]  # pyright: ignore[reportArgumentType]
+        )
+        summary = _final_cost_summary(empty)
+        assert summary.empty

--- a/tests_lib/detectors/test_al_strategies.py
+++ b/tests_lib/detectors/test_al_strategies.py
@@ -1,0 +1,300 @@
+"""Tests for the active-learning acquisition strategies.
+
+All tests build small, controlled :class:`ALContext` states so the acquisition
+maths is checked directly - no model downloads.  The model-driven samplers
+(``bald``, ``eig``) train a tiny MLP on a handful of separable points.
+"""
+
+import numpy as np
+import pytest
+
+from vtscore.eval.al_strategies import (
+    STRATEGIES,
+    ALContext,
+    _score_coreset,
+    _score_entropy,
+    _score_margin,
+    acquisition_utilities,
+    available_strategies,
+    density_weights,
+    select_next,
+)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _ctx(
+    pool_ids,
+    embeddings,
+    *,
+    labeled=None,
+    scores=None,
+    model=None,
+    threshold=0.5,
+    atlas=None,
+    seed=0,
+    input_dim=None,
+    hidden_dim=8,
+):
+    dim = input_dim if input_dim is not None else (len(next(iter(embeddings.values()))) if embeddings else 4)
+    return ALContext(
+        pool_ids=list(pool_ids),
+        embeddings=embeddings,
+        labeled=labeled or {},
+        scores=scores or {},
+        model=model,
+        threshold=threshold,
+        input_dim=dim,
+        hidden_dim=hidden_dim,
+        atlas=atlas,
+        rng=np.random.RandomState(seed),
+    )
+
+
+def _trained_model(dim=8, seed=0):
+    """Train a tiny separable MLP; return ``(model, pos_vec, neg_vec)``."""
+    import torch
+
+    from vtscore.training.mlp import train_model
+
+    rng = np.random.default_rng(seed)
+    pos = np.zeros(dim, dtype=np.float32)
+    pos[0] = 1.0
+    neg = np.zeros(dim, dtype=np.float32)
+    neg[0] = -1.0
+    X_rows = []
+    y_rows = []
+    for _ in range(6):
+        X_rows.append(pos + rng.standard_normal(dim).astype(np.float32) * 0.05)
+        y_rows.append(1.0)
+        X_rows.append(neg + rng.standard_normal(dim).astype(np.float32) * 0.05)
+        y_rows.append(0.0)
+    X = torch.tensor(np.array(X_rows), dtype=torch.float32)
+    y = torch.tensor(y_rows, dtype=torch.float32).unsqueeze(1)
+    model = train_model(X, y, dim, hidden_dim=8)
+    return model, pos, neg
+
+
+def _score_pool(model, pool_ids, embeddings):
+    import torch
+
+    X = torch.tensor(np.array([embeddings[i] for i in pool_ids]), dtype=torch.float32)
+    with torch.no_grad():
+        s = torch.sigmoid(model(X)).squeeze(1).cpu().tolist()
+    return dict(zip(pool_ids, s, strict=True))
+
+
+# ------------------------------------------------------------------
+# Registry
+# ------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_base_strategies_present(self):
+        for name in ["random", "margin", "entropy", "bald", "eig", "coreset"]:
+            assert name in STRATEGIES
+
+    def test_density_variants_present(self):
+        for name in ["density_margin", "density_entropy", "density_bald", "density_coreset"]:
+            assert name in STRATEGIES
+
+    def test_random_and_eig_have_no_density_variant(self):
+        assert "density_random" not in STRATEGIES
+        assert "density_eig" not in STRATEGIES
+
+    def test_available_strategies_sorted_and_complete(self):
+        names = available_strategies()
+        assert names == sorted(names)
+        assert set(names) == set(STRATEGIES)
+
+
+# ------------------------------------------------------------------
+# Pointwise scorers (no model needed)
+# ------------------------------------------------------------------
+
+
+class TestMargin:
+    def test_picks_score_closest_to_threshold(self):
+        emb = {
+            1: np.array([1.0, 0.0], np.float32),
+            2: np.array([0.0, 1.0], np.float32),
+            3: np.array([1.0, 1.0], np.float32),
+        }
+        # threshold 0.5: id 2's score (0.55) is closest.
+        scores = {1: 0.05, 2: 0.55, 3: 0.95}
+        ctx = _ctx([1, 2, 3], emb, scores=scores, threshold=0.5)
+        util = _score_margin(ctx)
+        assert ctx.pool_ids[int(np.argmax(util))] == 2
+        assert np.all(util >= 0.0)  # non-negative for the density multiply
+
+    def test_respects_non_half_threshold(self):
+        emb = {1: np.zeros(2, np.float32), 2: np.zeros(2, np.float32)}
+        scores = {1: 0.5, 2: 0.85}
+        ctx = _ctx([1, 2], emb, scores=scores, threshold=0.9)
+        # id 2 (0.85) sits nearest the 0.9 threshold.
+        util = _score_margin(ctx)
+        assert ctx.pool_ids[int(np.argmax(util))] == 2
+
+
+class TestEntropy:
+    def test_picks_most_uncertain(self):
+        emb = {1: np.zeros(2, np.float32), 2: np.zeros(2, np.float32), 3: np.zeros(2, np.float32)}
+        scores = {1: 0.5, 2: 0.99, 3: 0.01}
+        ctx = _ctx([1, 2, 3], emb, scores=scores)
+        util = _score_entropy(ctx)
+        assert ctx.pool_ids[int(np.argmax(util))] == 1
+        assert np.all(util >= 0.0)
+
+
+class TestCoreset:
+    def test_picks_farthest_from_labeled(self):
+        emb = {
+            1: np.array([0.1, 0.0], np.float32),  # near the labeled point
+            2: np.array([5.0, 0.0], np.float32),  # far
+            10: np.array([0.0, 0.0], np.float32),  # labeled
+        }
+        ctx = _ctx([1, 2], emb, labeled={10: 0.0})
+        util = _score_coreset(ctx)
+        assert ctx.pool_ids[int(np.argmax(util))] == 2
+
+    def test_falls_back_to_random_without_labels(self):
+        emb = {1: np.zeros(2, np.float32), 2: np.ones(2, np.float32)}
+        ctx = _ctx([1, 2], emb, labeled={})
+        util = _score_coreset(ctx)
+        assert util.shape == (2,)
+        assert np.all(np.isfinite(util))
+
+
+# ------------------------------------------------------------------
+# Model-driven scorers
+# ------------------------------------------------------------------
+
+
+class TestBald:
+    def test_mutual_information_non_negative_and_finite(self):
+        from vtscore.eval.al_strategies import _score_bald
+
+        model, pos, neg = _trained_model()
+        emb = {1: pos, 2: neg, 3: (pos + neg) / 2.0}
+        scores = _score_pool(model, [1, 2, 3], emb)
+        ctx = _ctx([1, 2, 3], emb, scores=scores, model=model, seed=1)
+        util = _score_bald(ctx)
+        assert util.shape == (3,)
+        assert np.all(util >= 0.0)
+        assert np.all(np.isfinite(util))
+
+    def test_select_returns_valid_pool_id(self):
+        model, pos, neg = _trained_model()
+        emb = {1: pos, 2: neg, 3: (pos + neg) / 2.0}
+        scores = _score_pool(model, [1, 2, 3], emb)
+        ctx = _ctx([1, 2, 3], emb, scores=scores, model=model, seed=2)
+        assert select_next("bald", ctx) in {1, 2, 3}
+
+
+class TestEig:
+    def test_utilities_finite_for_small_pool(self):
+        from vtscore.eval.al_strategies import _score_eig
+
+        model, pos, neg = _trained_model()
+        emb = {1: pos, 2: neg, 3: (pos + neg) / 2.0, 10: pos, 11: neg}
+        scores = _score_pool(model, [1, 2, 3], emb)
+        ctx = _ctx(
+            [1, 2, 3],
+            emb,
+            scores=scores,
+            model=model,
+            labeled={10: 1.0, 11: 0.0},
+            seed=0,
+        )
+        util = _score_eig(ctx)
+        assert util.shape == (3,)
+        # Pool <= _EIG_MAX_CANDIDATES, so every candidate is evaluated (finite).
+        assert np.all(np.isfinite(util))
+        assert select_next("eig", ctx) in {1, 2, 3}
+
+
+# ------------------------------------------------------------------
+# Density weighting
+# ------------------------------------------------------------------
+
+
+def _clustered_atlas(min_node_size=3):
+    """Build a coverage atlas with two well-separated clusters of unequal size."""
+    from vtscore.state.coverage_atlas import CoverageAtlas
+
+    rng = np.random.default_rng(0)
+    vectors = {}
+    vid = 1
+    # Big cluster around +e0 (15 pts), small cluster around -e0 (4 pts).
+    for _ in range(15):
+        v = np.zeros(8, np.float32)
+        v[0] = 1.0
+        vectors[vid] = (v + rng.standard_normal(8).astype(np.float32) * 0.02).astype(np.float32)
+        vid += 1
+    for _ in range(4):
+        v = np.zeros(8, np.float32)
+        v[0] = -1.0
+        vectors[vid] = (v + rng.standard_normal(8).astype(np.float32) * 0.02).astype(np.float32)
+        vid += 1
+    atlas = CoverageAtlas(vectors, k=2, max_depth=4, min_node_size=min_node_size)
+    return atlas, vectors
+
+
+class TestDensityWeights:
+    def test_weight_is_inverse_sqrt_cell_count(self):
+        atlas, vectors = _clustered_atlas()
+        ctx = _ctx(list(vectors), vectors, atlas=atlas)
+        weights = density_weights(ctx)
+        for i, cid in enumerate(ctx.pool_ids):
+            leaf = atlas.vector_to_leaf[cid]
+            expected = 1.0 / np.sqrt(atlas.nodes[leaf]["n"])
+            assert weights[i] == pytest.approx(expected)
+
+    def test_no_atlas_gives_unit_weights(self):
+        emb = {1: np.zeros(4, np.float32), 2: np.ones(4, np.float32)}
+        ctx = _ctx([1, 2], emb, atlas=None)
+        assert np.array_equal(density_weights(ctx), np.ones(2))
+
+    def test_density_variant_reweights_base_utility(self):
+        atlas, vectors = _clustered_atlas()
+        pool = list(vectors)
+        scores = {cid: 0.5 for cid in pool}
+        # Non-None model just satisfies the needs-model gate; margin reads scores.
+        ctx = _ctx(pool, vectors, scores=scores, model=object(), atlas=atlas)
+        base = acquisition_utilities("margin", ctx)
+        dens = acquisition_utilities("density_margin", ctx)
+        np.testing.assert_allclose(dens, base * density_weights(ctx))
+
+
+# ------------------------------------------------------------------
+# Selection semantics / cold start
+# ------------------------------------------------------------------
+
+
+class TestSelection:
+    @pytest.mark.parametrize("strategy", available_strategies())
+    def test_cold_start_falls_back_to_random(self, strategy):
+        """With no model yet, every strategy still returns a valid pool id."""
+        emb = {1: np.zeros(4, np.float32), 2: np.ones(4, np.float32), 3: np.full(4, 2.0, np.float32)}
+        ctx = _ctx([1, 2, 3], emb, model=None, atlas=None, seed=5)
+        assert select_next(strategy, ctx) in {1, 2, 3}
+
+    def test_empty_pool_raises(self):
+        ctx = _ctx([], {}, model=None)
+        with pytest.raises(ValueError):
+            select_next("random", ctx)
+
+    def test_unknown_strategy_raises(self):
+        emb = {1: np.zeros(4, np.float32)}
+        ctx = _ctx([1], emb)
+        with pytest.raises(KeyError):
+            select_next("nope", ctx)
+
+    def test_random_is_seed_deterministic(self):
+        emb = {i: np.full(4, float(i), np.float32) for i in range(1, 8)}
+        a = select_next("random", _ctx(list(emb), emb, seed=3))
+        b = select_next("random", _ctx(list(emb), emb, seed=3))
+        assert a == b

--- a/tests_lib/detectors/test_eval_visualize.py
+++ b/tests_lib/detectors/test_eval_visualize.py
@@ -80,7 +80,7 @@ def _make_learned_sort_result(dataset_id="test_ds", media_type="image") -> Datas
     return dr
 
 
-def _make_voting_iterations_df(n_seeds=2, n_steps=10) -> pd.DataFrame:
+def _make_voting_iterations_df(n_seeds=2, n_steps=10, strategy="random") -> pd.DataFrame:
     rows = []
     for seed in range(n_seeds):
         rng = np.random.RandomState(seed)
@@ -94,6 +94,7 @@ def _make_voting_iterations_df(n_seeds=2, n_steps=10) -> pd.DataFrame:
                     "seed": seed,
                     "dataset": "ds1",
                     "category": "alpha",
+                    "strategy": strategy,
                     "t": t,
                     "cost": cost,
                     "fpr": fpr,
@@ -105,7 +106,7 @@ def _make_voting_iterations_df(n_seeds=2, n_steps=10) -> pd.DataFrame:
     # so pyright can't see list[str] satisfies the Axes alias.
     return pd.DataFrame(
         rows,
-        columns=["seed", "dataset", "category", "t", "cost", "fpr", "fnr", "elapsed_seconds"],  # pyright: ignore[reportArgumentType]
+        columns=["seed", "dataset", "category", "strategy", "t", "cost", "fpr", "fnr", "elapsed_seconds"],  # pyright: ignore[reportArgumentType]
     )
 
 
@@ -251,3 +252,46 @@ class TestPlotVotingIterations:
         for p in paths:
             header = p.read_bytes()[:8]
             assert header[:4] == b"\x89PNG"
+
+
+class TestPlotVotingIterationsFaceting:
+    """When >1 acquisition strategy is present the charts facet by strategy."""
+
+    def _multi_strategy_df(self, strategies=("random", "margin", "entropy")):
+        frames = [_make_voting_iterations_df(n_seeds=2, strategy=s) for s in strategies]
+        return pd.concat(frames, ignore_index=True)
+
+    def test_multiple_strategies_still_two_plots(self, tmp_dir):
+        df = self._multi_strategy_df()
+        paths = plot_voting_iterations(df, output_dir=tmp_dir)
+        assert {p.name for p in paths} == {
+            "voting_iterations_cost.png",
+            "voting_iterations_fpr_fnr.png",
+        }
+        for p in paths:
+            assert p.exists()
+            assert p.read_bytes()[:4] == b"\x89PNG"
+
+    def test_single_strategy_column_renders(self, tmp_dir):
+        """A one-strategy frame renders un-faceted (single-axes) without error."""
+        df = _make_voting_iterations_df(n_seeds=2, strategy="random")
+        paths = plot_voting_iterations(df, output_dir=tmp_dir)
+        assert len(paths) == 2
+        for p in paths:
+            assert p.stat().st_size > 0
+
+    def test_missing_strategy_column_is_backwards_compatible(self, tmp_dir):
+        """A pre-strategy frame (no ``strategy`` column) still renders."""
+        df = _make_voting_iterations_df(n_seeds=2)
+        df = df.drop(columns=["strategy"])
+        paths = plot_voting_iterations(df, output_dir=tmp_dir)
+        assert len(paths) == 2
+        for p in paths:
+            assert p.exists()
+
+    def test_many_strategies_facet(self, tmp_dir):
+        df = self._multi_strategy_df(strategies=("random", "margin", "entropy", "bald", "coreset"))
+        paths = plot_voting_iterations(df, output_dir=tmp_dir)
+        assert len(paths) == 2
+        for p in paths:
+            assert p.read_bytes()[:4] == b"\x89PNG"

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -6,15 +6,11 @@ embeddings so no real model downloads are needed.
 
 import numpy as np
 import pandas as pd
-
 import pytest
 
 from vtscore.eval.voting_iterations import (
-    VOTE_ORDERS,
-    _balanced_vote_sequence,
     _good_training_vec,
     _inclusion_weights,
-    _make_vote_sequence,
     _split_media_ids,
     run_voting_iterations_eval,
     simulate_voting_iterations,
@@ -127,25 +123,6 @@ class TestSplitClipIds:
         assert test1 == test2
 
 
-class TestMakeVoteSequence:
-    def test_all_clips_voted(self):
-        medias = _make_separable_clips(n_per_cat=5)
-        sim_ids = list(medias.keys())[:5]
-        rng = np.random.RandomState(42)
-        seq = _make_vote_sequence(sim_ids, medias, "alpha", rng)
-        assert len(seq) == 5
-        assert {cid for cid, _ in seq} == set(sim_ids)
-
-    def test_labels_match_category(self):
-        medias = _make_separable_clips(n_per_cat=5)
-        sim_ids = list(medias.keys())
-        rng = np.random.RandomState(42)
-        seq = _make_vote_sequence(sim_ids, medias, "alpha", rng)
-        for cid, label in seq:
-            expected = "good" if medias[cid]["category"] == "alpha" else "bad"
-            assert label == expected
-
-
 # ------------------------------------------------------------------
 # Unit tests: simulate_voting_iterations
 # ------------------------------------------------------------------
@@ -183,6 +160,7 @@ class TestSimulateVotingIterations:
             "seed",
             "dataset",
             "category",
+            "strategy",
             "t",
             "n_good",
             "n_bad",
@@ -193,6 +171,7 @@ class TestSimulateVotingIterations:
         }
         for row in rows:
             assert set(row.keys()) == expected_keys
+            assert row["strategy"] == "random"
 
     def test_vote_counts_reported(self):
         """Each row carries the good/bad vote counts the model was trained on.
@@ -412,6 +391,7 @@ class TestRunVotingIterationsEval:
             "seed",
             "dataset",
             "category",
+            "strategy",
             "t",
             "n_good",
             "n_bad",
@@ -626,159 +606,128 @@ class TestRegionVotingSimulate:
 
 
 # ------------------------------------------------------------------
-# Vote-order / n_ensemble / max_votes axes
+# Active-learning strategy axis
 # ------------------------------------------------------------------
 
-_ROW_KEYS = {
-    "seed",
-    "dataset",
-    "category",
-    "t",
-    "n_good",
-    "n_bad",
-    "cost",
-    "fpr",
-    "fnr",
-    "elapsed_seconds",
-}
+_STRATEGIES = [
+    "random",
+    "margin",
+    "entropy",
+    "bald",
+    "ensemble_std",
+    "eig",
+    "coreset",
+    "balanced",
+    "density_margin",
+    "density_entropy",
+]
 
 
-class TestBalancedVoteSequence:
-    def test_running_counts_stay_balanced(self):
-        medias = _make_separable_clips(n_per_cat=8)
-        sim_ids = list(medias.keys())
-        rng = np.random.RandomState(0)
-        seq = _balanced_vote_sequence(sim_ids, medias, "alpha", rng)
-        # Same set of votes as a plain shuffle, just reordered.
-        assert {cid for cid, _ in seq} == set(sim_ids)
-        # First two votes are one good + one bad (earliest trainable step).
-        assert {seq[0][1], seq[1][1]} == {"good", "bad"}
-        # Running good/bad counts never drift more than one apart.
-        n_good = n_bad = 0
-        for _, label in seq:
-            if label == "good":
-                n_good += 1
-            else:
-                n_bad += 1
-            assert abs(n_good - n_bad) <= 1
+class TestStrategyAxis:
+    """``strategy=`` / ``strategies=`` / ``max_steps=`` axes and the result column."""
 
-    def test_handles_single_class_pool(self):
-        # All 'alpha' → every vote is good; sequence is just the goods.
+    def test_default_strategy_is_random(self):
         medias = _make_separable_clips(n_per_cat=6)
-        alpha_ids = [cid for cid, m in medias.items() if m["category"] == "alpha"]
-        rng = np.random.RandomState(0)
-        seq = _balanced_vote_sequence(alpha_ids, medias, "alpha", rng)
-        assert len(seq) == len(alpha_ids)
-        assert all(label == "good" for _, label in seq)
-
-
-class TestVoteOrderAxis:
-    def test_vote_orders_constant_matches_supported(self):
-        assert set(VOTE_ORDERS) == {"shuffle", "balanced", "ensemble_std"}
-
-    def test_default_is_shuffle(self):
-        # Omitting vote_order reproduces the explicit "shuffle" run exactly.
-        medias = _make_separable_clips(n_per_cat=8)
-        default = simulate_voting_iterations(medias, "alpha", seed=3, calibrate_count=1)
-        shuffle = simulate_voting_iterations(medias, "alpha", seed=3, vote_order="shuffle", calibrate_count=1)
-        assert len(default) == len(shuffle)
-        for a, b in zip(default, shuffle):
-            assert {k: v for k, v in a.items() if k != "elapsed_seconds"} == {
-                k: v for k, v in b.items() if k != "elapsed_seconds"
-            }
-
-    def test_unknown_vote_order_raises(self):
-        medias = _make_separable_clips(n_per_cat=6)
-        with pytest.raises(ValueError, match="vote_order"):
-            simulate_voting_iterations(medias, "alpha", seed=0, vote_order="nope")
-
-    @pytest.mark.parametrize("order", ["shuffle", "balanced", "ensemble_std"])
-    def test_row_schema_stable_across_orders(self, order):
-        medias = _make_separable_clips(n_per_cat=8)
-        rows = simulate_voting_iterations(
-            medias, "alpha", seed=0, vote_order=order, n_ensemble=3, max_votes=8, calibrate_count=1
-        )
+        rows = simulate_voting_iterations(medias, "alpha", seed=42, calibrate_count=1)
         assert rows
-        for row in rows:
-            assert set(row.keys()) == _ROW_KEYS
-            assert np.isfinite(row["cost"])
+        assert all(r["strategy"] == "random" for r in rows)
 
-    def test_balanced_starts_trainable_immediately(self):
-        # Balanced ordering makes the first two votes 1 good + 1 bad, so the
-        # earliest scored step is t=2 with a 1-vs-1 model.
+    @pytest.mark.parametrize("strategy", _STRATEGIES)
+    def test_every_strategy_produces_finite_rows(self, strategy):
+        medias = _make_separable_clips(n_per_cat=8, dim=12)
+        rows = simulate_voting_iterations(
+            medias,
+            "alpha",
+            seed=3,
+            strategy=strategy,
+            calibrate_count=1,
+            max_steps=8,
+            atlas_min_node_size=3,
+        )
+        assert rows  # every sampler drives the loop end-to-end
+        for row in rows:
+            assert row["strategy"] == strategy
+            assert np.isfinite(row["cost"])
+            assert np.isfinite(row["fpr"])
+            assert np.isfinite(row["fnr"])
+            # One vote per step, so the counts still sum to t.
+            assert row["n_good"] + row["n_bad"] == row["t"]
+
+    def test_max_steps_caps_votes(self):
+        medias = _make_separable_clips(n_per_cat=20)
+        rows = simulate_voting_iterations(medias, "alpha", seed=1, strategy="margin", calibrate_count=1, max_steps=5)
+        assert rows
+        # No row can reflect more than max_steps votes cast.
+        assert max(r["t"] for r in rows) <= 5
+
+    def test_strategy_determinism(self):
+        medias = _make_separable_clips(n_per_cat=10)
+        a = simulate_voting_iterations(medias, "alpha", seed=7, strategy="entropy", calibrate_count=1, max_steps=8)
+        b = simulate_voting_iterations(medias, "alpha", seed=7, strategy="entropy", calibrate_count=1, max_steps=8)
+        assert [r["t"] for r in a] == [r["t"] for r in b]
+        assert [r["cost"] for r in a] == [r["cost"] for r in b]
+
+    def test_unknown_strategy_raises(self):
+        medias = _make_separable_clips(n_per_cat=6)
+        with pytest.raises(KeyError):
+            simulate_voting_iterations(medias, "alpha", seed=1, strategy="does_not_exist", calibrate_count=1)
+
+    def test_run_eval_strategies_axis(self):
         medias = _make_separable_clips(n_per_cat=8)
-        rows = simulate_voting_iterations(medias, "alpha", seed=0, vote_order="balanced", calibrate_count=1)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": medias},
+            seeds=[1, 2],
+            categories={"ds1": ["alpha"]},
+            strategies=["random", "margin"],
+            calibrate_count=1,
+            max_steps=8,
+        )
+        assert set(df["strategy"].unique()) == {"random", "margin"}
+        # seed x strategy cross-product all present.
+        combos = df.groupby(["seed", "strategy"]).ngroups
+        assert combos == 4
+
+    def test_run_eval_defaults_to_random(self):
+        medias = _make_separable_clips(n_per_cat=6)
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": medias},
+            seeds=[1],
+            categories={"ds1": ["alpha"]},
+            calibrate_count=1,
+        )
+        assert set(df["strategy"].unique()) == {"random"}
+
+
+class TestBalancedStrategy:
+    """The oracle ``balanced`` strategy keeps the running Good/Bad counts even."""
+
+    def test_running_counts_stay_balanced(self):
+        # Every scored step's good/bad counts never drift more than one apart,
+        # and the first trainable step is a 1-vs-1 model at t=2.
+        medias = _make_separable_clips(n_per_cat=8)
+        rows = simulate_voting_iterations(medias, "alpha", seed=0, strategy="balanced", calibrate_count=1)
         assert rows
         assert rows[0]["t"] == 2
         assert rows[0]["n_good"] == 1
         assert rows[0]["n_bad"] == 1
+        for row in rows:
+            assert abs(row["n_good"] - row["n_bad"]) <= 1
+
+    def test_handles_single_class_pool(self):
+        # All 'alpha' → the held-out split has no negatives, so the run returns
+        # no rows; the balanced selector must reach that early-return without
+        # tripping on an all-one-class pool.
+        medias = {cid: m for cid, m in _make_separable_clips(n_per_cat=6).items() if m["category"] == "alpha"}
+        rows = simulate_voting_iterations(medias, "alpha", seed=0, strategy="balanced", calibrate_count=1)
+        assert rows == []
+
+
+class TestEnsembleStdStrategy:
+    """The ``ensemble_std`` deep-ensemble sampler is deterministic per seed."""
 
     def test_ensemble_std_deterministic(self):
         medias = _make_separable_clips(n_per_cat=8)
-        rows1 = simulate_voting_iterations(
-            medias, "alpha", seed=1, vote_order="ensemble_std", n_ensemble=3, max_votes=8, calibrate_count=1
-        )
-        rows2 = simulate_voting_iterations(
-            medias, "alpha", seed=1, vote_order="ensemble_std", n_ensemble=3, max_votes=8, calibrate_count=1
-        )
-        assert len(rows1) == len(rows2)
-        for a, b in zip(rows1, rows2):
-            assert {k: v for k, v in a.items() if k != "elapsed_seconds"} == {
-                k: v for k, v in b.items() if k != "elapsed_seconds"
-            }
-
-    def test_n_ensemble_axis_runs(self):
-        medias = _make_separable_clips(n_per_cat=10)
-        for n in (2, 5):
-            rows = simulate_voting_iterations(
-                medias, "alpha", seed=0, vote_order="ensemble_std", n_ensemble=n, max_votes=6, calibrate_count=1
-            )
-            assert rows
-            assert all(np.isfinite(r["cost"]) for r in rows)
-
-
-class TestMaxVotes:
-    def test_caps_shuffle_steps(self):
-        medias = _make_separable_clips(n_per_cat=12)
-        rows = simulate_voting_iterations(medias, "alpha", seed=0, max_votes=5, calibrate_count=1)
-        # No scored step can exceed the vote cap.
-        assert rows
-        assert max(r["t"] for r in rows) <= 5
-
-    def test_caps_ensemble_std_steps(self):
-        medias = _make_separable_clips(n_per_cat=12)
-        rows = simulate_voting_iterations(
-            medias, "alpha", seed=0, vote_order="ensemble_std", n_ensemble=3, max_votes=5, calibrate_count=1
-        )
-        assert rows
-        assert max(r["t"] for r in rows) <= 5
-
-
-class TestRunEvalThreadsVoteOrder:
-    @pytest.mark.parametrize("order", ["balanced", "ensemble_std"])
-    def test_run_eval_threads_vote_order(self, order):
-        medias = _make_separable_clips(n_per_cat=8)
-        df = run_voting_iterations_eval(
-            dataset_clips={"ds1": medias},
-            seeds=[0],
-            categories={"ds1": ["alpha"]},
-            vote_order=order,
-            n_ensemble=3,
-            max_votes=8,
-            calibrate_count=1,
-        )
-        assert not df.empty
-        # Row schema is unchanged by vote_order (selection never leaks into
-        # the per-step evaluation columns).
-        assert list(df.columns) == [
-            "seed",
-            "dataset",
-            "category",
-            "t",
-            "n_good",
-            "n_bad",
-            "cost",
-            "fpr",
-            "fnr",
-            "elapsed_seconds",
-        ]
+        a = simulate_voting_iterations(medias, "alpha", seed=1, strategy="ensemble_std", max_steps=8, calibrate_count=1)
+        b = simulate_voting_iterations(medias, "alpha", seed=1, strategy="ensemble_std", max_steps=8, calibrate_count=1)
+        assert [r["t"] for r in a] == [r["t"] for r in b]
+        assert [r["cost"] for r in a] == [r["cost"] for r in b]

--- a/vtscore/eval/__init__.py
+++ b/vtscore/eval/__init__.py
@@ -1,5 +1,6 @@
 """Evaluation framework for VTSearch sorting quality."""
 
+from vtscore.eval.al_strategies import STRATEGIES, ALContext, available_strategies, select_next
 from vtscore.eval.config import EVAL_DATASETS, EvalQuery
 from vtscore.eval.metrics import compute_metrics
 from vtscore.eval.runner import run_eval
@@ -12,12 +13,16 @@ from vtscore.eval.voting_iterations import (
 
 __all__ = [
     "EVAL_DATASETS",
+    "STRATEGIES",
+    "ALContext",
     "EvalQuery",
+    "available_strategies",
     "compute_metrics",
     "plot_eval_results",
     "plot_voting_iterations",
     "run_eval",
     "run_voting_iterations_eval",
     "run_voting_iterations_eval_from_pickles",
+    "select_next",
     "simulate_voting_iterations",
 ]

--- a/vtscore/eval/al_benchmark.py
+++ b/vtscore/eval/al_benchmark.py
@@ -229,7 +229,10 @@ def _final_cost_summary(df: "pd.DataFrame") -> "pd.DataFrame":
     if df.empty:
         return pd.DataFrame(columns=pd.Index(["strategy", "final_cost"]))
     last = df.sort_values("t").groupby(["strategy", "seed", "dataset", "category"]).tail(1)
-    summary = last.groupby("strategy")["cost"].mean().reset_index(name="final_cost")
+    records = [
+        {"strategy": strategy, "final_cost": float(group["cost"].mean())} for strategy, group in last.groupby("strategy")
+    ]
+    summary = pd.DataFrame(records, columns=pd.Index(["strategy", "final_cost"]))
     return summary.sort_values("final_cost").reset_index(drop=True)
 
 

--- a/vtscore/eval/al_benchmark.py
+++ b/vtscore/eval/al_benchmark.py
@@ -230,7 +230,8 @@ def _final_cost_summary(df: "pd.DataFrame") -> "pd.DataFrame":
         return pd.DataFrame(columns=pd.Index(["strategy", "final_cost"]))
     last = df.sort_values("t").groupby(["strategy", "seed", "dataset", "category"]).tail(1)
     records = [
-        {"strategy": strategy, "final_cost": float(group["cost"].mean())} for strategy, group in last.groupby("strategy")
+        {"strategy": strategy, "final_cost": float(group["cost"].mean())}
+        for strategy, group in last.groupby("strategy")
     ]
     summary = pd.DataFrame(records, columns=pd.Index(["strategy", "final_cost"]))
     return summary.sort_values("final_cost").reset_index(drop=True)

--- a/vtscore/eval/al_benchmark.py
+++ b/vtscore/eval/al_benchmark.py
@@ -1,0 +1,359 @@
+"""Hermetic benchmark harness for active-learning acquisition strategies.
+
+Wires the acquisition strategies in :mod:`vtscore.eval.al_strategies` to the
+voting-iterations evaluator (:mod:`vtscore.eval.voting_iterations`) over
+**data sources that need no model downloads**, so a strategy sweep runs in the
+plain test container:
+
+- ``synthetic`` — Gaussian category clusters generated on the fly.  Fully
+  parameterised (item count, dimensionality, class count, separation, noise) and
+  seeded, so a run is reproducible and its difficulty is a dial.
+- ``precomputed`` — feature vectors + string labels supplied directly (in
+  memory) or loaded from a ``.npz`` file (keys ``features`` / ``labels``).  This
+  is how you benchmark on *real* embeddings without re-embedding: dump a demo
+  dataset's vectors once, then sweep strategies over the frozen features.
+
+Both sources yield the ``{dataset_name: {media_id: media}}`` mapping
+:func:`vtscore.eval.voting_iterations.run_voting_iterations_eval` consumes, where
+each media carries an ``embeddings`` dict and a ``category`` — exactly the shape
+a real loaded dataset has, minus the pixels.
+
+Run it as a module::
+
+    python -m vtscore.eval.al_benchmark --source synthetic \\
+        --strategies random margin entropy bald coreset --seeds 0 1 2 \\
+        --plot-dir al_out --output al_results.csv
+
+    python -m vtscore.eval.al_benchmark --source precomputed \\
+        --features-path features.npz --strategies all
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional, Sequence
+
+import numpy as np
+
+from vtscore.eval.al_strategies import available_strategies
+from vtscore.eval.visualize import plot_voting_iterations
+from vtscore.eval.voting_iterations import run_voting_iterations_eval
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+#: Feature key used for the single stored vector on each synthetic/precomputed
+#: media.  ``media_embedding`` resolves the sole entry as the primary vector.
+_FEATURE_KEY = "feature"
+
+# The benchmark's coverage-atlas floor is well below the production default (20)
+# because hermetic sources are small: a lower floor lets the ``density_*``
+# strategies actually resolve distinct cells over a few dozen items.
+_DEFAULT_ATLAS_MIN_NODE_SIZE = 8
+
+# A fast default sweep that skips ``eig`` (the costliest sampler, ``2 x K``
+# retrains per step).  Pass ``--strategies all`` to include it.
+_DEFAULT_STRATEGIES = ["random", "margin", "entropy", "bald", "coreset"]
+
+MediaDict = dict[int, dict[str, Any]]
+DatasetClips = dict[str, MediaDict]
+
+
+# ------------------------------------------------------------------
+# Data sources
+# ------------------------------------------------------------------
+
+
+def synthetic_source(
+    *,
+    n_per_cat: int = 40,
+    dim: int = 32,
+    n_categories: int = 2,
+    separation: float = 1.0,
+    noise: float = 0.25,
+    seed: int = 0,
+    name: str = "synthetic",
+) -> DatasetClips:
+    """Build a hermetic dataset of Gaussian category clusters.
+
+    Each category is centred on its own random unit direction scaled by
+    *separation*; every item is that centre plus isotropic Gaussian *noise*.
+    Larger *separation* (or smaller *noise*) makes the classes easier to tell
+    apart.  Everything is drawn from a *seed*-seeded generator, so the dataset —
+    and therefore the benchmark — is reproducible.
+
+    Returns the ``{name: {id: media}}`` mapping the voting-iterations evaluator
+    consumes; each media carries a single ``embeddings`` vector and a
+    ``category`` label (``"cat0"`` .. ``"cat<n-1>"``).
+    """
+    if n_categories < 2:
+        raise ValueError(f"n_categories must be >= 2, got {n_categories}")
+    if n_per_cat < 1:
+        raise ValueError(f"n_per_cat must be >= 1, got {n_per_cat}")
+
+    rng = np.random.default_rng(seed)
+    means = rng.standard_normal((n_categories, dim)).astype(np.float32)
+    means /= np.maximum(np.linalg.norm(means, axis=1, keepdims=True), 1e-12)
+    means *= separation
+
+    medias: MediaDict = {}
+    media_id = 1
+    for c in range(n_categories):
+        category = f"cat{c}"
+        for _ in range(n_per_cat):
+            vec = (means[c] + rng.standard_normal(dim).astype(np.float32) * noise).astype(np.float32)
+            medias[media_id] = {"id": media_id, "embeddings": {_FEATURE_KEY: vec}, "category": category}
+            media_id += 1
+    return {name: medias}
+
+
+def precomputed_source(
+    features: Any,
+    labels: Sequence[Any],
+    *,
+    name: str = "precomputed",
+    ids: Optional[Sequence[int]] = None,
+) -> DatasetClips:
+    """Wrap precomputed feature vectors + labels into a benchmark dataset.
+
+    Args:
+        features: An ``(n_items, dim)`` array-like of feature vectors.
+        labels: One category label per row (stringified).
+        name: Dataset name in the returned mapping.
+        ids: Optional explicit media ids (default ``1 .. n``).
+
+    Returns the ``{name: {id: media}}`` mapping.  Raises ``ValueError`` on a
+    non-2D feature matrix or a label-count mismatch.
+    """
+    features = np.asarray(features, dtype=np.float32)
+    if features.ndim != 2:
+        raise ValueError(f"features must be 2D (n_items, dim), got shape {features.shape}")
+    if len(labels) != features.shape[0]:
+        raise ValueError(f"labels length {len(labels)} does not match {features.shape[0]} feature rows")
+
+    id_seq = list(ids) if ids is not None else list(range(1, features.shape[0] + 1))
+    if len(id_seq) != features.shape[0]:
+        raise ValueError(f"ids length {len(id_seq)} does not match {features.shape[0]} feature rows")
+
+    medias: MediaDict = {}
+    for media_id, vec, label in zip(id_seq, features, labels, strict=True):
+        mid = int(media_id)
+        medias[mid] = {
+            "id": mid,
+            "embeddings": {_FEATURE_KEY: np.asarray(vec, dtype=np.float32)},
+            "category": str(label),
+        }
+    return {name: medias}
+
+
+def precomputed_source_from_npz(
+    path: str | Path,
+    *,
+    name: Optional[str] = None,
+    features_key: str = "features",
+    labels_key: str = "labels",
+) -> DatasetClips:
+    """Load a ``precomputed`` source from a ``.npz`` file.
+
+    The archive must hold a 2D ``features`` array and a matching ``labels``
+    array.  Loaded **without** ``allow_pickle`` (labels ride as a numpy string
+    array), so an untrusted archive cannot execute code on load.  The dataset
+    name defaults to the file stem.
+    """
+    path = Path(path)
+    with np.load(path) as data:  # allow_pickle defaults to False
+        if features_key not in data or labels_key not in data:
+            raise ValueError(f"{path} must contain '{features_key}' and '{labels_key}' arrays")
+        features = data[features_key]
+        labels = [str(x) for x in data[labels_key].tolist()]
+    return precomputed_source(features, labels, name=name or path.stem)
+
+
+#: Names of the hermetic data sources, for CLI/help discoverability.
+DATA_SOURCES = ("synthetic", "precomputed")
+
+
+# ------------------------------------------------------------------
+# Benchmark runner
+# ------------------------------------------------------------------
+
+
+def run_al_benchmark(
+    dataset_clips: DatasetClips,
+    *,
+    strategies: list[str],
+    seeds: list[int],
+    categories: Optional[dict[str, list[str]]] = None,
+    inclusion: int = 0,
+    sim_fraction: float = 0.5,
+    max_steps: Optional[int] = None,
+    calibrate_count: int = 2,
+    atlas_min_node_size: int = _DEFAULT_ATLAS_MIN_NODE_SIZE,
+    plot_dir: Optional[str | Path] = None,
+) -> "pd.DataFrame":
+    """Run *strategies* over *dataset_clips* and return the results frame.
+
+    A thin orchestration over
+    :func:`~vtscore.eval.voting_iterations.run_voting_iterations_eval`: it adds
+    the strategy axis, applies the benchmark's lower coverage-atlas floor, and
+    (when *plot_dir* is given) renders the strategy-faceted charts.  The returned
+    :class:`~pandas.DataFrame` carries the usual voting-iterations columns plus
+    ``strategy``.
+    """
+    df = run_voting_iterations_eval(
+        dataset_clips,
+        seeds=seeds,
+        categories=categories,
+        inclusion=inclusion,
+        sim_fraction=sim_fraction,
+        calibrate_count=calibrate_count,
+        strategies=strategies,
+        max_steps=max_steps,
+        atlas_min_node_size=atlas_min_node_size,
+    )
+    if plot_dir is not None:
+        plot_voting_iterations(df, output_dir=plot_dir)
+    return df
+
+
+def _final_cost_summary(df: "pd.DataFrame") -> "pd.DataFrame":
+    """Return each strategy's mean cost at its last recorded step, ascending.
+
+    Averages over the deepest ``t`` reached per (seed, dataset, category) run so
+    strategies are ranked by where they *end up* — lower is better.
+    """
+    import pandas as pd  # noqa: PLC0415
+
+    if df.empty:
+        return pd.DataFrame(columns=pd.Index(["strategy", "final_cost"]))
+    last = df.sort_values("t").groupby(["strategy", "seed", "dataset", "category"]).tail(1)
+    summary = last.groupby("strategy")["cost"].mean().reset_index(name="final_cost")
+    return summary.sort_values("final_cost").reset_index(drop=True)
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+
+def _resolve_strategies(requested: list[str]) -> list[str]:
+    """Expand the special ``all`` token and validate every requested name."""
+    if requested == ["all"]:
+        return available_strategies()
+    unknown = [s for s in requested if s not in available_strategies()]
+    if unknown:
+        raise SystemExit(f"Unknown strategies {unknown}; available: {', '.join(available_strategies())} (or 'all')")
+    return requested
+
+
+def _build_source(args: argparse.Namespace) -> DatasetClips:
+    if args.source == "synthetic":
+        return synthetic_source(
+            n_per_cat=args.n_per_cat,
+            dim=args.dim,
+            n_categories=args.n_categories,
+            separation=args.separation,
+            noise=args.noise,
+            seed=args.data_seed,
+        )
+    if args.source == "precomputed":
+        if not args.features_path:
+            raise SystemExit("--features-path is required for --source precomputed")
+        return precomputed_source_from_npz(args.features_path)
+    raise SystemExit(f"Unknown source {args.source!r}")
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m vtscore.eval.al_benchmark",
+        description="Benchmark active-learning acquisition strategies on hermetic data sources.",
+    )
+    parser.add_argument(
+        "--source", choices=DATA_SOURCES, default="synthetic", help="Hermetic data source (default: synthetic)."
+    )
+    # Synthetic-source knobs.
+    parser.add_argument("--n-per-cat", type=int, default=40, help="Synthetic items per category (default: 40).")
+    parser.add_argument("--dim", type=int, default=32, help="Synthetic embedding dimensionality (default: 32).")
+    parser.add_argument("--n-categories", type=int, default=2, help="Synthetic category count (default: 2).")
+    parser.add_argument("--separation", type=float, default=1.0, help="Synthetic class-mean separation (default: 1.0).")
+    parser.add_argument("--noise", type=float, default=0.25, help="Synthetic isotropic noise scale (default: 0.25).")
+    parser.add_argument("--data-seed", type=int, default=0, help="Seed for the synthetic data (default: 0).")
+    # Precomputed-source input.
+    parser.add_argument(
+        "--features-path",
+        type=str,
+        default=None,
+        metavar="NPZ",
+        help="'.npz' with 'features'/'labels' for --source precomputed.",
+    )
+    # Benchmark axes.
+    parser.add_argument(
+        "--strategies",
+        nargs="+",
+        default=_DEFAULT_STRATEGIES,
+        metavar="NAME",
+        help="Strategies to compare, or 'all' (default: random margin entropy bald coreset).",
+    )
+    parser.add_argument("--seeds", nargs="+", type=int, default=[0, 1, 2], help="Simulation seeds (default: 0 1 2).")
+    parser.add_argument("--inclusion", type=int, default=0, help="Inclusion setting in [-10, 10] (default: 0).")
+    parser.add_argument(
+        "--sim-fraction", type=float, default=0.5, help="Fraction of items used for simulated voting (default: 0.5)."
+    )
+    parser.add_argument("--max-steps", type=int, default=None, help="Cap on voting steps per run (default: all).")
+    parser.add_argument(
+        "--calibrate-count",
+        type=int,
+        default=2,
+        help="Random Train/Calibrate splits for threshold calibration (default: 2).",
+    )
+    parser.add_argument(
+        "--atlas-min-node-size",
+        type=int,
+        default=_DEFAULT_ATLAS_MIN_NODE_SIZE,
+        help=f"Coverage-atlas leaf floor for density_* strategies (default: {_DEFAULT_ATLAS_MIN_NODE_SIZE}).",
+    )
+    parser.add_argument(
+        "--output", type=str, default=None, metavar="CSV", help="Write the full results frame to a CSV file."
+    )
+    parser.add_argument(
+        "--plot-dir", type=str, default=None, metavar="DIR", help="Render strategy-faceted charts into DIR."
+    )
+
+    args = parser.parse_args(argv)
+    strategies = _resolve_strategies(args.strategies)
+    dataset_clips = _build_source(args)
+
+    df = run_al_benchmark(
+        dataset_clips,
+        strategies=strategies,
+        seeds=args.seeds,
+        inclusion=args.inclusion,
+        sim_fraction=args.sim_fraction,
+        max_steps=args.max_steps,
+        calibrate_count=args.calibrate_count,
+        atlas_min_node_size=args.atlas_min_node_size,
+        plot_dir=args.plot_dir,
+    )
+
+    print(f"\n{'=' * 60}")
+    print("ACTIVE-LEARNING BENCHMARK — final cost by strategy (lower is better)")
+    print(f"{'=' * 60}")
+    summary = _final_cost_summary(df)
+    for _, row in summary.iterrows():
+        print(f"  {row['strategy']:18s}  final_cost={row['final_cost']:.4f}")
+
+    if args.output:
+        df.to_csv(args.output, index=False)
+        print(f"\nResults written to {args.output}")
+    if args.plot_dir:
+        print(f"Plots written to {args.plot_dir}/")
+
+    if df.empty:
+        print("\nNo rows produced (every split lacked a usable test set).")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/vtscore/eval/al_strategies.py
+++ b/vtscore/eval/al_strategies.py
@@ -1,0 +1,481 @@
+"""Active-learning acquisition strategies for the voting-iterations harness.
+
+The voting-iterations evaluator (:mod:`vtscore.eval.voting_iterations`) simulates
+a user labelling one item at a time and measures how fast the detector's cost
+falls.  *Which* item the simulated user is shown next is an
+**acquisition strategy**: a rule that, given the current model, its scores over
+the unlabelled pool, the embeddings, and the labels gathered so far, picks the
+next item to query.  A good strategy reaches a low-cost detector in fewer votes
+than random labelling.
+
+An :class:`ALContext` bundles that per-step state; a strategy is a callable
+``ALContext -> int`` returning the chosen pool id.  The :data:`STRATEGIES`
+registry maps a name to that callable:
+
+- ``random``   — uniform pick from the pool (the baseline every strategy is
+  measured against).
+- ``margin``   — smallest ``|p - t|``: the item whose score sits closest to the
+  decision threshold, i.e. the model is most on-the-fence about.
+- ``entropy``  — largest binary entropy ``H(p)``: maximal predictive
+  uncertainty (for a threshold at 0.5 this and ``margin`` coincide; away from
+  0.5 they diverge).
+- ``bald``     — largest MC-dropout mutual information: runs the trained net
+  with dropout left on for several stochastic passes and picks the item the
+  ensemble *disagrees* with itself about most (epistemic, not aleatoric,
+  uncertainty).
+- ``ensemble_std`` — like ``bald`` but the disagreement comes from an explicit
+  N-member *deep* ensemble: train :data:`_ENSEMBLE_MEMBERS` seed-varied MLPs on
+  the votes so far, score the pool with each, and pick the item with the
+  greatest member-to-member sigmoid std.  Costs N retrains per step (no dropout
+  needed at inference) where ``bald`` costs one train plus N cheap dropout
+  passes.
+- ``eig``      — largest expected pool-entropy reduction, estimated by
+  counterfactually retraining the model with each candidate labelled both ways
+  (``2 x K`` retrains) and scoring how much the pool's total entropy is expected
+  to drop.
+- ``coreset``  — greedy k-centre: the pool item **farthest** (in embedding
+  space) from everything labelled so far, spreading coverage rather than
+  chasing uncertainty.
+- ``balanced`` — an **oracle** ordering (not label-blind): peeks at the pool's
+  ground-truth labels to always query the currently under-represented class, so
+  the running Good/Bad counts stay balanced.  It is a diagnostic baseline
+  isolating "does class balance during voting help?" from vote *content*, only
+  usable in the simulation harness where pool labels are known; it reads
+  :attr:`ALContext.pool_labels` and degrades to ``random`` when that is absent.
+
+Each strategy above also has a ``density_<name>`` variant that multiplies its
+per-item acquisition utility by ``1 / sqrt(cell_count)`` — the reciprocal root
+of the population of the item's :class:`~vtscore.state.coverage_atlas.CoverageAtlas`
+leaf — so items in sparsely-populated regions of the dataset are up-weighted.
+This is *information density* sampling: prefer items that are both informative
+and representative of an under-explored pocket.  ``density_*`` variants exist for
+every base strategy except ``random`` and ``eig`` (``random`` is the baseline;
+``eig`` is already the most expensive sampler and its density variant buys
+little).
+
+All acquisition utilities are non-negative and higher-is-better, so the density
+multiply only ever *re-ranks* by rarity, never flips the base preference.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import torch
+
+    from vtscore.state.coverage_atlas import CoverageAtlas
+
+
+# Number of stochastic forward passes for the MC-dropout BALD estimate.  More
+# passes shrink the Monte-Carlo error on the mutual information at linear cost;
+# 20 is the usual sweet spot in the deep-AL literature.
+_BALD_PASSES = 20
+
+# Number of seed-varied MLPs trained per step for the ``ensemble_std`` deep
+# ensemble.  Members use fixed seeds ``42 + k`` so the pick is a deterministic
+# function of the votes cast so far (reproducible for a given eval seed).
+_ENSEMBLE_MEMBERS = 5
+
+# Ceiling on the number of pool candidates ``eig`` counterfactually retrains
+# for.  A retrain is expensive, so on a large pool we only evaluate the most
+# uncertain items (top-K by entropy) — the low-entropy tail is almost never the
+# information-maximising pick anyway.  ``2 x K`` retrains happen per step.
+_EIG_MAX_CANDIDATES = 32
+
+_EPS = 1e-9
+
+
+@dataclass
+class ALContext:
+    """Per-step state an acquisition strategy needs to pick the next item.
+
+    Attributes:
+        pool_ids: Candidate ids the strategy chooses among (unlabelled so far),
+            in a stable order; every utility array a scorer returns is aligned
+            to this list.
+        embeddings: ``{id: vector}`` for every id (pool and labelled) — the
+            whole-image embedding, used by ``coreset``/``eig`` and by the
+            density atlas.
+        labeled: ``{id: 1.0 | 0.0}`` for every item labelled so far
+            ("labelled-so-far").  Empty before the first vote.
+        scores: ``{pool_id: p}`` sigmoid probabilities from the current model,
+            used by ``margin``/``entropy``/``eig``.  Empty before the first
+            model exists.
+        model: The current trained MLP (``None`` before the first trainable
+            step, i.e. before one Good and one Bad vote coexist).
+        threshold: The current decision threshold ``t`` (``margin`` measures
+            ``|p - t|`` against it).
+        input_dim: Embedding dimensionality, for ``eig`` counterfactual retrains.
+        hidden_dim: Hidden width the counterfactual retrains should use (matches
+            the live model's width); ``None`` lets training auto-size.
+        atlas: The dataset's coverage atlas, for ``density_*`` variants (``None``
+            disables density weighting — every weight is 1).
+        rng: Seeded RNG driving ``random`` and the MC-dropout seed, so a run is
+            reproducible from its seed.
+        pool_labels: Ground-truth ``{pool_id: 1.0 | 0.0}`` for the pool, used
+            **only** by the ``balanced`` oracle strategy to interleave Good/Bad
+            queries.  This deliberately breaks the label-blind contract every
+            other strategy honours; it is meaningful only in the simulation
+            harness (where every pool label is known ground truth).  ``None``
+            (the default) makes ``balanced`` degrade to a random pick.
+    """
+
+    pool_ids: list[int]
+    embeddings: dict[int, np.ndarray]
+    labeled: dict[int, float]
+    scores: dict[int, float]
+    model: Optional["torch.nn.Sequential"]
+    threshold: float
+    input_dim: int
+    hidden_dim: Optional[int]
+    atlas: Optional["CoverageAtlas"]
+    rng: np.random.RandomState = field(default_factory=lambda: np.random.RandomState(0))
+    pool_labels: Optional[dict[int, float]] = None
+
+
+# ------------------------------------------------------------------
+# Utility helpers
+# ------------------------------------------------------------------
+
+
+def _binary_entropy(p: np.ndarray) -> np.ndarray:
+    """Return the binary entropy ``H(p) = -p log p - (1-p) log(1-p)`` (nats).
+
+    Clamps *p* off ``{0, 1}`` so the ``log`` stays finite; the entropy of a
+    saturated prediction is 0, which the clamp reproduces to machine precision.
+    """
+    p = np.clip(np.asarray(p, dtype=np.float64), _EPS, 1.0 - _EPS)
+    return -p * np.log(p) - (1.0 - p) * np.log(1.0 - p)
+
+
+def _pool_matrix(ctx: ALContext) -> np.ndarray:
+    """Stack the pool embeddings into an ``(n_pool, dim)`` float32 matrix."""
+    return np.array([ctx.embeddings[i] for i in ctx.pool_ids], dtype=np.float32)
+
+
+def _pool_scores(ctx: ALContext) -> np.ndarray:
+    """Return the current model's pool probabilities aligned to ``pool_ids``.
+
+    Falls back to ``0.5`` (maximal uncertainty) for any pool id without a
+    recorded score, so a scorer never trips on a missing key.
+    """
+    return np.array([ctx.scores.get(i, 0.5) for i in ctx.pool_ids], dtype=np.float64)
+
+
+# ------------------------------------------------------------------
+# Base acquisition scorers: ALContext -> per-pool-item utility (higher = pick)
+# ------------------------------------------------------------------
+
+
+def _score_random(ctx: ALContext) -> np.ndarray:
+    """Uniform-random utility — argmax of it is a uniform pick from the pool."""
+    return ctx.rng.random(len(ctx.pool_ids))
+
+
+def _score_margin(ctx: ALContext) -> np.ndarray:
+    """Margin sampling: high utility for items whose score is near the threshold.
+
+    Utility ``1 - |p - t|`` is maximal (1) when ``p == t`` and non-negative
+    everywhere (``p, t`` both in ``[0, 1]``), so its argmax is the minimal-margin
+    item and the density multiply keeps its sign.
+    """
+    p = _pool_scores(ctx)
+    return 1.0 - np.abs(p - ctx.threshold)
+
+
+def _score_entropy(ctx: ALContext) -> np.ndarray:
+    """Predictive entropy ``H(p)`` — maximal at ``p = 0.5``, non-negative."""
+    return _binary_entropy(_pool_scores(ctx))
+
+
+def _score_bald(ctx: ALContext) -> np.ndarray:
+    """MC-dropout BALD mutual information ``H(E[p]) - E[H(p)]`` per pool item.
+
+    Runs the trained net with dropout **on** for :data:`_BALD_PASSES` stochastic
+    passes; the gap between the entropy of the averaged prediction and the
+    average of the per-pass entropies is the model's epistemic uncertainty
+    (disagreement across dropout masks), which is non-negative by Jensen.  The
+    dropout RNG is forked and seeded from ``ctx.rng`` so the estimate is
+    reproducible.
+    """
+    import torch  # noqa: PLC0415
+
+    model = ctx.model
+    assert model is not None
+    X = torch.tensor(_pool_matrix(ctx), dtype=torch.float32)
+    device = next(model.parameters()).device
+    X = X.to(device)
+
+    seed = int(ctx.rng.randint(0, 2**31 - 1))
+    was_training = model.training
+    probs: list[np.ndarray] = []
+    model.train()  # enable Dropout layers
+    with torch.random.fork_rng(devices=[]), torch.no_grad():
+        torch.manual_seed(seed)
+        for _ in range(_BALD_PASSES):
+            p = torch.sigmoid(model(X)).squeeze(1).cpu().numpy()
+            probs.append(p.astype(np.float64))
+    if not was_training:
+        model.eval()
+
+    stacked = np.stack(probs, axis=0)  # (passes, n_pool)
+    mean_p = stacked.mean(axis=0)
+    entropy_of_mean = _binary_entropy(mean_p)
+    mean_of_entropy = _binary_entropy(stacked).mean(axis=0)
+    return np.maximum(entropy_of_mean - mean_of_entropy, 0.0)
+
+
+def _score_coreset(ctx: ALContext) -> np.ndarray:
+    """Greedy k-centre utility: distance from each pool item to the labelled set.
+
+    The utility of a pool item is its Euclidean distance to the **nearest**
+    already-labelled embedding; its argmax is the farthest-from-covered item,
+    the greedy k-centre pick.  With nothing labelled yet the notion is undefined,
+    so it degrades to a random utility (the very first pick is arbitrary anyway).
+    """
+    if not ctx.labeled:
+        return _score_random(ctx)
+    pool = _pool_matrix(ctx)
+    labelled = np.array([ctx.embeddings[i] for i in ctx.labeled], dtype=np.float32)
+    # Pairwise distances (n_pool, n_labelled); nearest labelled per pool item.
+    dists = np.linalg.norm(pool[:, None, :] - labelled[None, :, :], axis=2)
+    return dists.min(axis=1)
+
+
+def _score_ensemble_std(ctx: ALContext) -> np.ndarray:
+    """Deep-ensemble disagreement: per-pool member-to-member sigmoid std.
+
+    Trains :data:`_ENSEMBLE_MEMBERS` seed-varied MLPs on the votes gathered so
+    far (``ctx.labeled``), scores every pool item's embedding with each member,
+    and returns the per-item std across members — high where the ensemble
+    disagrees, i.e. maximal epistemic uncertainty.  Fixed member seeds keep the
+    utility a deterministic function of the current votes.  Requires at least
+    one Good and one Bad vote to be trainable; the cold-start guard
+    (``needs_model``) routes the pre-trainable steps to a random pick.
+    """
+    import torch  # noqa: PLC0415
+
+    from vtscore.training.mlp import train_model  # noqa: PLC0415
+
+    X = torch.tensor(np.array([ctx.embeddings[i] for i in ctx.labeled]), dtype=torch.float32)
+    y = torch.tensor([float(v) for v in ctx.labeled.values()], dtype=torch.float32).unsqueeze(1)
+    X_cand = torch.tensor(_pool_matrix(ctx), dtype=torch.float32)
+
+    member_scores: list[np.ndarray] = []
+    for k in range(_ENSEMBLE_MEMBERS):
+        model = train_model(X, y, ctx.input_dim, seed=42 + k, hidden_dim=ctx.hidden_dim)
+        with torch.no_grad():
+            Xk = X_cand.to(next(model.parameters()).device)
+            member_scores.append(torch.sigmoid(model(Xk)).squeeze(1).cpu().numpy())
+    return np.stack(member_scores, axis=0).std(axis=0).astype(np.float64)
+
+
+def _score_balanced(ctx: ALContext) -> np.ndarray:
+    """Oracle class-balancing utility: prefer the under-represented class.
+
+    Reads the pool's ground-truth labels (:attr:`ALContext.pool_labels`) — the
+    one strategy that is *not* label-blind — and gives every pool item of the
+    currently under-represented class a utility that dominates the other class,
+    with a small seeded jitter to break ties randomly.  Argmax therefore queries
+    a random item of the needed class, keeping the running Good/Bad counts within
+    one of each other.  Falls back to a plain random utility when no pool labels
+    are supplied (the harness always supplies them; a direct caller may not).
+    """
+    if ctx.pool_labels is None:
+        return _score_random(ctx)
+    labels = np.array([ctx.pool_labels.get(i, 0.0) for i in ctx.pool_ids], dtype=np.float64)
+    n_good = sum(1 for v in ctx.labeled.values() if v == 1.0)
+    n_bad = len(ctx.labeled) - n_good
+    needed = 1.0 if n_good <= n_bad else 0.0
+    # Matched items score in [1, 1.5); unmatched in [0, 0.5) — matched always
+    # wins, and the jitter randomises the pick within the needed class.  When the
+    # needed class is exhausted every item is "unmatched" and one is picked at
+    # random from whatever remains.
+    match = (labels == needed).astype(np.float64)
+    return match + 0.5 * ctx.rng.random(len(labels))
+
+
+def _score_eig(ctx: ALContext) -> np.ndarray:
+    """Expected pool-entropy reduction via ``2 x K`` counterfactual retrains.
+
+    For each evaluated candidate, retrain the model twice — once assuming the
+    candidate is labelled Good, once Bad — and score the *rest* of the pool with
+    each retrained model.  The candidate's utility is the current summed pool
+    entropy (over that same rest) minus the label-probability-weighted expected
+    entropy after the vote, i.e. how much labelling it is expected to sharpen the
+    model over everything else.  Only the top-:data:`_EIG_MAX_CANDIDATES` pool
+    items by current entropy are evaluated (a retrain is costly); the rest get
+    ``-inf`` so they are never chosen over an evaluated candidate.
+    """
+    import torch  # noqa: PLC0415
+
+    from vtscore.training.mlp import train_model  # noqa: PLC0415
+
+    pool = ctx.pool_ids
+    n = len(pool)
+    util = np.full(n, -np.inf, dtype=np.float64)
+    if n <= 1:
+        # Nothing to reduce entropy over; fall back to raw entropy so a valid
+        # pick still comes out.
+        return _score_entropy(ctx)
+
+    cur_p = _pool_scores(ctx)
+    # Evaluate the most uncertain candidates first, capped for cost.
+    order = np.argsort(-_binary_entropy(cur_p))
+    candidate_idx = order[: min(_EIG_MAX_CANDIDATES, n)]
+
+    base_X = [ctx.embeddings[i] for i in ctx.labeled]
+    base_y = [float(v) for v in ctx.labeled.values()]
+
+    for j in candidate_idx:
+        cand = pool[j]
+        rest_idx = [k for k in range(n) if k != j]
+        rest = np.array([ctx.embeddings[pool[k]] for k in rest_idx], dtype=np.float32)
+        cur_rest_entropy = float(_binary_entropy(cur_p[rest_idx]).sum())
+
+        p_good = float(cur_p[j])
+        expected_entropy = 0.0
+        for label, weight in ((1.0, p_good), (0.0, 1.0 - p_good)):
+            X = torch.tensor(np.array(base_X + [ctx.embeddings[cand]]), dtype=torch.float32)
+            y = torch.tensor(base_y + [label], dtype=torch.float32).unsqueeze(1)
+            model = train_model(X, y, ctx.input_dim, hidden_dim=ctx.hidden_dim)
+            with torch.no_grad():
+                Xr = torch.tensor(rest, dtype=torch.float32).to(next(model.parameters()).device)
+                pr = torch.sigmoid(model(Xr)).squeeze(1).cpu().numpy()
+            expected_entropy += weight * float(_binary_entropy(pr).sum())
+        util[j] = cur_rest_entropy - expected_entropy
+
+    return util
+
+
+# Base scorers and whether they require a trained model to run.  When the model
+# is absent (cold start) a model-requiring scorer degrades to a random pick.
+_BASE_SCORERS: dict[str, tuple[Callable[[ALContext], np.ndarray], bool]] = {
+    "random": (_score_random, False),
+    "margin": (_score_margin, True),
+    "entropy": (_score_entropy, True),
+    "bald": (_score_bald, True),
+    "ensemble_std": (_score_ensemble_std, True),
+    "eig": (_score_eig, True),
+    "coreset": (_score_coreset, False),
+    "balanced": (_score_balanced, False),
+}
+
+# Which base strategies get a ``density_<name>`` companion.  ``random`` is the
+# baseline and ``eig`` is already the costliest sampler, so neither is reweighted.
+_DENSITY_BASES = ["margin", "entropy", "bald", "coreset"]
+
+
+# ------------------------------------------------------------------
+# Density weighting
+# ------------------------------------------------------------------
+
+
+def density_weights(ctx: ALContext) -> np.ndarray:
+    """Return ``1 / sqrt(cell_count)`` per pool item from the coverage atlas.
+
+    ``cell_count`` is the population of the item's leaf node in the dataset's
+    :class:`~vtscore.state.coverage_atlas.CoverageAtlas`, so items in sparse
+    regions score higher.  Items with no atlas, or an id the atlas never saw,
+    get weight 1 (no reweighting).  Weights are strictly positive, so a density
+    multiply re-ranks the base utility by rarity without changing its sign.
+    """
+    n = len(ctx.pool_ids)
+    if ctx.atlas is None:
+        return np.ones(n, dtype=np.float64)
+    weights = np.ones(n, dtype=np.float64)
+    for i, cid in enumerate(ctx.pool_ids):
+        leaf = ctx.atlas.vector_to_leaf.get(cid)
+        if leaf is None:
+            continue
+        count = ctx.atlas.nodes[leaf]["n"]
+        if count > 0:
+            weights[i] = 1.0 / np.sqrt(count)
+    return weights
+
+
+def _make_selector(
+    scorer: Callable[[ALContext], np.ndarray],
+    *,
+    needs_model: bool,
+    density: bool,
+) -> Callable[[ALContext], int]:
+    """Wrap a base scorer into a full ``ALContext -> chosen id`` selector.
+
+    Applies the cold-start fallback (random utility when the scorer needs a
+    model that doesn't exist yet) and the optional density reweight, then
+    returns the argmax pool id.
+    """
+
+    def select(ctx: ALContext) -> int:
+        if needs_model and ctx.model is None:
+            util = _score_random(ctx)
+        else:
+            util = scorer(ctx)
+        if density:
+            util = util * density_weights(ctx)
+        return ctx.pool_ids[int(np.argmax(util))]
+
+    return select
+
+
+def _build_registry() -> dict[str, Callable[[ALContext], int]]:
+    """Assemble the name -> selector registry from the base scorers."""
+    registry: dict[str, Callable[[ALContext], int]] = {}
+    for name, (scorer, needs_model) in _BASE_SCORERS.items():
+        registry[name] = _make_selector(scorer, needs_model=needs_model, density=False)
+    for name in _DENSITY_BASES:
+        scorer, needs_model = _BASE_SCORERS[name]
+        registry[f"density_{name}"] = _make_selector(scorer, needs_model=needs_model, density=True)
+    return registry
+
+
+#: Registry of acquisition strategies: ``name -> (ALContext -> chosen pool id)``.
+STRATEGIES: dict[str, Callable[[ALContext], int]] = _build_registry()
+
+
+def select_next(strategy: str, ctx: ALContext) -> int:
+    """Pick the next pool id to query using the named *strategy*.
+
+    Raises ``KeyError`` (via :func:`available_strategies` message) for an unknown
+    name so a typo fails loudly instead of silently defaulting.
+    """
+    try:
+        selector = STRATEGIES[strategy]
+    except KeyError:
+        raise KeyError(
+            f"Unknown acquisition strategy {strategy!r}; available: {', '.join(available_strategies())}"
+        ) from None
+    if not ctx.pool_ids:
+        raise ValueError("select_next called with an empty pool")
+    return selector(ctx)
+
+
+def available_strategies() -> list[str]:
+    """Return the sorted list of registered acquisition strategy names."""
+    return sorted(STRATEGIES)
+
+
+def acquisition_utilities(strategy: str, ctx: ALContext) -> np.ndarray:
+    """Return the (density-weighted) per-pool-item utilities for *strategy*.
+
+    Exposes the raw utility vector the selector maximises, aligned to
+    ``ctx.pool_ids`` — useful for tests and for inspecting *why* a pick was made.
+    Mirrors the cold-start and density handling of the selector.
+    """
+    base = strategy[len("density_") :] if strategy.startswith("density_") else strategy
+    if base not in _BASE_SCORERS:
+        raise KeyError(f"Unknown acquisition strategy {strategy!r}")
+    scorer, needs_model = _BASE_SCORERS[base]
+    if needs_model and ctx.model is None:
+        util = _score_random(ctx)
+    else:
+        util = scorer(ctx)
+    if strategy.startswith("density_"):
+        util = util * density_weights(ctx)
+    return util

--- a/vtscore/eval/visualize.py
+++ b/vtscore/eval/visualize.py
@@ -415,10 +415,10 @@ def _plot_iterations_metric(
         # are directly comparable.
         ncols = len(strategies)
         fig, axes = plt.subplots(1, ncols, figsize=(5 * ncols, 4.5), squeeze=False, sharey=True)
-        for si, strat in enumerate(strategies):
+        for si, strategy in enumerate(strategies):
             ax = axes[0][si]
-            n_groups = _draw_metric_lines(ax, df[df["strategy"] == strat], metric)
-            ax.set_title(strat, fontsize=11)
+            n_groups = _draw_metric_lines(ax, df[df["strategy"] == strategy], metric)
+            ax.set_title(strategy, fontsize=11)
             ax.set_xlabel("Voting Iteration (t)")
             if si == 0:
                 ax.set_ylabel(ylabel)
@@ -459,10 +459,10 @@ def _plot_fpr_fnr_faceted(df: "Any", strategies: list[str], out: Path) -> Path:
 
     ncols = len(strategies)
     fig, axes = plt.subplots(1, ncols, figsize=(5 * ncols, 4.5), squeeze=False, sharey=True)
-    for si, strat in enumerate(strategies):
+    for si, strategy in enumerate(strategies):
         ax = axes[0][si]
-        _draw_fpr_fnr_aggregate(ax, df[df["strategy"] == strat])
-        ax.set_title(strat, fontsize=11)
+        _draw_fpr_fnr_aggregate(ax, df[df["strategy"] == strategy])
+        ax.set_title(strategy, fontsize=11)
         ax.set_xlabel("Voting Iteration (t)")
         if si == 0:
             ax.set_ylabel("Rate")

--- a/vtscore/eval/visualize.py
+++ b/vtscore/eval/visualize.py
@@ -25,6 +25,11 @@ Charts produced by :func:`plot_voting_iterations`:
    averaged with a shaded ±1 std-dev band.
 2. **FPR / FNR over voting iterations** - similar layout, with
    separate lines for FPR and FNR.
+
+When the results carry more than one active-learning acquisition
+``strategy`` (the ``strategy`` column has >1 unique value), both charts
+**facet by strategy** - one subplot per strategy - so the strategies can be
+compared side by side.  A single-strategy frame renders exactly as before.
 """
 
 from __future__ import annotations
@@ -322,12 +327,15 @@ def plot_voting_iterations(
     """Generate visualisation PNGs from voting-iterations eval results.
 
     When multiple seeds are present, lines are averaged per
-    ``(dataset, category)`` and a shaded ±1 std-dev band is drawn.
+    ``(dataset, category)`` and a shaded ±1 std-dev band is drawn.  When the
+    frame carries more than one acquisition ``strategy`` both charts facet by
+    strategy (one subplot each).
 
     Args:
-        df: :class:`pandas.DataFrame` with columns
-            ``seed, dataset, category, t, n_good, n_bad, cost, fpr, fnr`` as
-            returned by :func:`run_voting_iterations_eval`.
+        df: :class:`pandas.DataFrame` with columns ``seed, dataset, category,
+            strategy, t, n_good, n_bad, cost, fpr, fnr`` as returned by
+            :func:`run_voting_iterations_eval`.  A ``strategy`` column is
+            optional; when absent the charts render un-faceted.
         output_dir: Directory to write PNG files into (created if needed).
 
     Returns:
@@ -357,17 +365,26 @@ def plot_voting_iterations(
     return generated
 
 
-def _plot_iterations_metric(
-    df: "Any",
-    metric: str,
-    ylabel: str,
-    out: Path,
-) -> Path:
+def _strategies_in(df: "Any") -> list[str]:
+    """Return the sorted distinct acquisition strategies present in *df*.
+
+    Empty when the frame has no ``strategy`` column (pre-strategy results), so
+    callers treat that as the single-strategy (un-faceted) case.
+    """
+    if "strategy" not in df.columns:
+        return []
+    return sorted(df["strategy"].unique())
+
+
+def _draw_metric_lines(ax: "Any", df: "Any", metric: str) -> int:
+    """Draw one mean±std line per ``(dataset, category)`` group onto *ax*.
+
+    Returns the number of groups drawn so the caller can decide whether a legend
+    is legible.
+    """
     import matplotlib.pyplot as plt
 
-    fig, ax = plt.subplots(figsize=(9, 5))
     palette = plt.cm.tab10.colors  # type: ignore[attr-defined]
-
     grouped = list(df.groupby(["dataset", "category"]))
     for idx, ((ds, cat), group) in enumerate(grouped):
         colour = palette[idx % len(palette)]
@@ -379,15 +396,80 @@ def _plot_iterations_metric(
         ax.plot(t, mean, label=f"{ds}: {cat}", color=colour, linewidth=1.5)
         if (std > 0).any():
             ax.fill_between(t, mean - std, mean + std, alpha=0.15, color=colour)
+    return len(grouped)
 
+
+def _plot_iterations_metric(
+    df: "Any",
+    metric: str,
+    ylabel: str,
+    out: Path,
+) -> Path:
+    import matplotlib.pyplot as plt
+
+    strategies = _strategies_in(df)
+    path = out / f"voting_iterations_{metric}.png"
+
+    if len(strategies) > 1:
+        # Facet by strategy: one subplot per strategy, shared y so the curves
+        # are directly comparable.
+        ncols = len(strategies)
+        fig, axes = plt.subplots(1, ncols, figsize=(5 * ncols, 4.5), squeeze=False, sharey=True)
+        for si, strat in enumerate(strategies):
+            ax = axes[0][si]
+            n_groups = _draw_metric_lines(ax, df[df["strategy"] == strat], metric)
+            ax.set_title(strat, fontsize=11)
+            ax.set_xlabel("Voting Iteration (t)")
+            if si == 0:
+                ax.set_ylabel(ylabel)
+            if 0 < n_groups <= 15:
+                ax.legend(fontsize=7, loc="best")
+        fig.suptitle(f"Voting Iterations: {ylabel} (by strategy)")
+        fig.tight_layout()
+        fig.savefig(path, dpi=150)
+        plt.close(fig)
+        return path
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    n_groups = _draw_metric_lines(ax, df, metric)
     ax.set_xlabel("Voting Iteration (t)")
     ax.set_ylabel(ylabel)
     ax.set_title(f"Voting Iterations: {ylabel}")
-    if len(grouped) <= 15:
+    if n_groups <= 15:
         ax.legend(fontsize=7, loc="best")
 
     fig.tight_layout()
-    path = out / f"voting_iterations_{metric}.png"
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    return path
+
+
+def _draw_fpr_fnr_aggregate(ax: "Any", df: "Any") -> None:
+    """Draw pooled mean FPR and FNR (over all groups/seeds) vs ``t`` onto *ax*."""
+    agg = df.groupby("t").agg(fpr_mean=("fpr", "mean"), fnr_mean=("fnr", "mean")).reset_index()
+    t = agg["t"].values
+    ax.plot(t, agg["fpr_mean"].values, label="FPR", color="#C44E52", linewidth=1.5)
+    ax.plot(t, agg["fnr_mean"].values, label="FNR", color="#4C72B0", linewidth=1.5)
+    ax.set_ylim(-0.05, 1.05)
+
+
+def _plot_fpr_fnr_faceted(df: "Any", strategies: list[str], out: Path) -> Path:
+    """Facet by strategy: one subplot per strategy, pooled FPR/FNR trade-off."""
+    import matplotlib.pyplot as plt
+
+    ncols = len(strategies)
+    fig, axes = plt.subplots(1, ncols, figsize=(5 * ncols, 4.5), squeeze=False, sharey=True)
+    for si, strat in enumerate(strategies):
+        ax = axes[0][si]
+        _draw_fpr_fnr_aggregate(ax, df[df["strategy"] == strat])
+        ax.set_title(strat, fontsize=11)
+        ax.set_xlabel("Voting Iteration (t)")
+        if si == 0:
+            ax.set_ylabel("Rate")
+        ax.legend(fontsize=8)
+    fig.suptitle("Voting Iterations: FPR & FNR (by strategy)")
+    fig.tight_layout()
+    path = out / "voting_iterations_fpr_fnr.png"
     fig.savefig(path, dpi=150)
     plt.close(fig)
     return path
@@ -395,6 +477,10 @@ def _plot_iterations_metric(
 
 def _plot_iterations_fpr_fnr(df: "Any", out: Path) -> Path:
     import matplotlib.pyplot as plt
+
+    strategies = _strategies_in(df)
+    if len(strategies) > 1:
+        return _plot_fpr_fnr_faceted(df, strategies, out)
 
     groups = list(df.groupby(["dataset", "category"]))
     n_groups = len(groups)

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -6,14 +6,19 @@ For each combination of seed *s*, dataset *d*, and target category *c*:
    **D_test** (held-out) using *s* to control the random split.
 2. Assign ground-truth labels based on *c*: medias whose ``"category"``
    matches *c* are positive (``good``), others are negative (``bad``).
-3. Create a shuffled voting sequence from D_sim (order controlled by *s*).
-4. Iterate through the voting sequence.  At each step *t* (once at least
-   one good **and** one bad vote exist), train a model on votes so far,
-   find a threshold, score D_test, and record the inclusion-weighted cost
-   (``fpr_weight * FPR + fnr_weight * FNR``).
+3. Vote on D_sim one item at a time, choosing *which* item to vote on next
+   with an active-learning acquisition strategy (order seeded by *s*).
+4. At each step *t* (once at least one good **and** one bad vote exist),
+   train a model on votes so far, find a threshold, score D_test, and record
+   the inclusion-weighted cost (``fpr_weight * FPR + fnr_weight * FNR``).
+
+Which item the simulated user votes on at each step is chosen by an
+**active-learning acquisition strategy** (see :mod:`vtscore.eval.al_strategies`);
+``random`` reproduces the uniform-order baseline, while uncertainty/diversity
+strategies query more informative items first.
 
 The result is a :class:`pandas.DataFrame` with columns
-``seed, dataset, category, t, n_good, n_bad, cost, fpr, fnr``.
+``seed, dataset, category, strategy, t, n_good, n_bad, cost, fpr, fnr``.
 
 ``n_good``/``n_bad`` are the number of good/bad votes the model was trained
 on for that row. The very first scored step has only one of each, so its
@@ -35,6 +40,7 @@ if TYPE_CHECKING:
     import torch
 
 from vtscore.embedding.media_vectors import media_embedding
+from vtscore.eval.al_strategies import ALContext, select_next
 from vtscore.eval.labels import media_is_positive, region_box_for_category
 from vtscore.training.mlp import _auto_hidden_dim, train_model
 from vtscore.training.thresholds import (
@@ -65,74 +71,6 @@ def _split_media_ids(
     shuffled = rng.permutation(all_ids).tolist()
     n_sim = max(1, int(len(shuffled) * sim_fraction))
     return shuffled[:n_sim], shuffled[n_sim:]
-
-
-VOTE_ORDERS: tuple[str, ...] = ("shuffle", "balanced", "ensemble_std")
-"""Supported ``vote_order`` strategies for :func:`simulate_voting_iterations`.
-
-- ``shuffle`` - the historical default: vote on the simulation set in a
-  seeded random order.
-- ``balanced`` - greedily interleave Good and Bad votes so the running
-  label set stays class-balanced (the earliest trainable step is 1-vs-1,
-  and the counts never drift far apart afterwards).
-- ``ensemble_std`` - active-learning order: at each step train an
-  N-member MLP ensemble on the votes so far, score the un-voted pool, and
-  vote next on the item the ensemble disagrees about most (highest
-  member-to-member sigmoid std).  The ensemble is used *only* to pick the
-  next vote; the per-step cost is still measured with the single
-  production MLP, exactly as the other orders measure it.
-"""
-
-
-def _make_vote_sequence(
-    sim_ids: list[int],
-    clips_dict: dict[int, dict[str, Any]],
-    target_category: str,
-    rng: np.random.RandomState,
-) -> list[tuple[int, str]]:
-    """Build a shuffled list of ``(media_id, label)`` pairs from simulation IDs."""
-    votes = [(cid, "good" if media_is_positive(clips_dict[cid], target_category) else "bad") for cid in sim_ids]
-    order = rng.permutation(len(votes))
-    return [votes[i] for i in order]
-
-
-def _balanced_vote_sequence(
-    sim_ids: list[int],
-    clips_dict: dict[int, dict[str, Any]],
-    target_category: str,
-    rng: np.random.RandomState,
-) -> list[tuple[int, str]]:
-    """Interleave Good/Bad votes so the running label set stays balanced.
-
-    Splits the sim votes by ground-truth class, shuffles each class, then
-    greedily appends whichever class is currently under-represented.  The
-    first two votes are therefore one Good and one Bad (training starts at
-    ``t=2`` with a 1-vs-1 model), and the good/bad counts stay within one
-    of each other for the whole sequence - isolating "does class balance
-    during voting help?" from the vote *content*, which is identical to
-    the ``shuffle`` order's pool.
-    """
-    goods = [(cid, "good") for cid in sim_ids if media_is_positive(clips_dict[cid], target_category)]
-    bads = [(cid, "bad") for cid in sim_ids if not media_is_positive(clips_dict[cid], target_category)]
-    rng.shuffle(goods)
-    rng.shuffle(bads)
-
-    out: list[tuple[int, str]] = []
-    gi = bi = 0
-    n_good = n_bad = 0
-    while gi < len(goods) or bi < len(bads):
-        # Take a Good when both remain and Goods are not ahead; otherwise
-        # take whichever class still has items left.
-        take_good = (gi < len(goods) and bi < len(bads) and n_good <= n_bad) or bi >= len(bads)
-        if take_good and gi < len(goods):
-            out.append(goods[gi])
-            gi += 1
-            n_good += 1
-        else:
-            out.append(bads[bi])
-            bi += 1
-            n_bad += 1
-    return out
 
 
 def _good_training_vec(
@@ -247,19 +185,96 @@ def _evaluate_on_test(
     return {"cost": round(cost, 6), "fpr": round(fpr, 6), "fnr": round(fnr, 6)}
 
 
-def _build_train_xy(
+# ------------------------------------------------------------------
+# Active-learning acquisition helpers
+# ------------------------------------------------------------------
+
+
+def _score_pool(
+    model: torch.nn.Sequential,
+    pool_ids: list[int],
+    clips_dict: dict[int, dict[str, Any]],
+) -> dict[int, float]:
+    """Return ``{pool_id: sigmoid score}`` for the current model over the pool.
+
+    Scores each pool item by its single whole-image vector - the fast path the
+    acquisition strategies rank uncertainty over.  This intentionally uses the
+    whole-image embedding even for patch datasets (where *test* scoring
+    max-pools over regions): acquisition only needs a monotone uncertainty
+    signal to order the pool, and the whole-image score is a cheap, adequate
+    proxy for that ordering.
+    """
+    import numpy as np  # noqa: PLC0415
+    import torch  # noqa: PLC0415
+
+    if not pool_ids:
+        return {}
+    embs = np.array([media_embedding(clips_dict[cid]) for cid in pool_ids])
+    X = torch.tensor(embs, dtype=torch.float32).to(next(model.parameters()).device)
+    with torch.no_grad():
+        scores = torch.sigmoid(model(X)).squeeze(1).cpu().tolist()
+    return dict(zip(pool_ids, scores, strict=True))
+
+
+def _build_eval_atlas(embeddings: dict[int, np.ndarray], min_node_size: int) -> Any:
+    """Build a coverage atlas over *embeddings* for the ``density_*`` strategies.
+
+    Returns ``None`` when there are no vectors.  Uses the same hierarchical
+    k-means partition the live dataset builds (see
+    :class:`~vtscore.state.coverage_atlas.CoverageAtlas`); *min_node_size* is
+    exposed so a caller with a small simulation set can drive the partition
+    deeper than the production floor (20) and actually resolve density cells.
+    """
+    from vtscore.state.coverage_atlas import CoverageAtlas, auto_max_depth  # noqa: PLC0415
+
+    if not embeddings:
+        return None
+    return CoverageAtlas(
+        embeddings,
+        k=3,
+        max_depth=auto_max_depth(len(embeddings), k=3, min_node_size=min_node_size),
+        min_node_size=min_node_size,
+    )
+
+
+def _train_and_calibrate(
     good_votes: dict[int, None],
     bad_votes: dict[int, None],
     clips_dict: dict[int, dict[str, Any]],
     target_category: str,
+    *,
     region_voting: bool,
-) -> tuple[list[np.ndarray], list[float]]:
-    """Assemble the ``(X_list, y_list)`` training data from the current votes.
+    input_dim: int,
+    inclusion: int,
+    calibrate_count: int,
+    calibration_fraction: float,
+) -> tuple[torch.nn.Sequential, float, int, int]:
+    """Train the step's model and calibrate its threshold from the current votes.
 
-    Good votes region-pool their ground-truth box when *region_voting* is on
-    (and the media supports it); bad votes always train on the whole-image
-    vector - matching the live detector, where only Yes-votes carry a region.
+    Returns ``(model, threshold, hidden_dim, n_labels)``.  Good votes region-pool
+    their ground-truth box when *region_voting* is on (and the media supports
+    it); Bad votes always train on the whole-image vector - matching the live
+    detector, where only Yes-votes carry a region.
+
+    The threshold matches the production ``_train_and_score_xy`` /
+    ``train_and_threshold`` pipeline exactly so the reported cost measures what
+    the live detector computes:
+
+    * ``hidden_dim`` is sized from the *full* label count and forced onto the
+      calibration folds, so the fold models share the final model's architecture
+      (production passes this into ``cross_calibration_threshold_cached``).
+      Letting each fold auto-size to its own smaller train split would train
+      narrower fold nets and report a threshold the live pipeline never produces.
+    * the fold splits use a fresh ``RandomState(42)`` - the fixed seed
+      ``cross_calibration_threshold_cached`` always calibrates with - rather than
+      the shared per-seed simulation RNG, so the calibration is byte-for-byte
+      what production runs for this vote set.  The eval seed still varies the
+      data (which media are voted, in what order, and the held-out test split);
+      only the calibration folds are pinned, as they are in production.
     """
+    import numpy as np  # noqa: PLC0415
+    import torch  # noqa: PLC0415
+
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
     for vid in good_votes:
@@ -268,48 +283,9 @@ def _build_train_xy(
     for vid in bad_votes:
         X_list.append(media_embedding(clips_dict[vid]))
         y_list.append(0.0)
-    return X_list, y_list
-
-
-def _score_step(
-    good_votes: dict[int, None],
-    bad_votes: dict[int, None],
-    clips_dict: dict[int, dict[str, Any]],
-    target_category: str,
-    *,
-    region_voting: bool,
-    region_aware: bool,
-    inclusion: int,
-    safe_thresholds: bool,
-    sim_clips: dict[int, dict[str, Any]] | None,
-    X_all_clips: Any,
-    calibrate_count: int,
-    calibration_fraction: float,
-    test_ids: list[int],
-    t: int,
-    seed: int,
-    dataset_name: str,
-    start_time: float,
-) -> dict[str, Any]:
-    """Train one production MLP on the current votes and score the test set.
-
-    This is the per-step body shared by every ``vote_order``: it trains and
-    thresholds exactly the way the live ``_train_and_score_xy`` /
-    ``train_and_threshold`` pipeline does (hidden dim sized from the full label
-    count and forced onto the calibration folds, folds calibrated with a fresh
-    ``RandomState(42)``), evaluates on the held-out test set, and returns one
-    result row.  Keeping it single-MLP is deliberate: even under the
-    ``ensemble_std`` order the *reported* cost measures what the real detector
-    computes; the ensemble only chooses which item to vote on next.
-    """
-    import numpy as np  # noqa: PLC0415
-    import torch  # noqa: PLC0415
-
-    X_list, y_list = _build_train_xy(good_votes, bad_votes, clips_dict, target_category, region_voting)
 
     X = torch.tensor(np.array(X_list), dtype=torch.float32)
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
-    input_dim = X.shape[1]
     n_labels = len(good_votes) + len(bad_votes)
 
     hidden_dim = _auto_hidden_dim(n_labels)
@@ -324,87 +300,7 @@ def _score_step(
         hidden_dim=hidden_dim,
     )
     model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
-
-    if safe_thresholds:
-        threshold = _blend_safe_threshold(threshold, model, region_aware, sim_clips, X_all_clips, n_labels)
-
-    metrics = _evaluate_on_test(
-        model, threshold, clips_dict, test_ids, target_category, inclusion, region_aware=region_aware
-    )
-
-    return {
-        "seed": seed,
-        "dataset": dataset_name,
-        "category": target_category,
-        "t": t,
-        "n_good": len(good_votes),
-        "n_bad": len(bad_votes),
-        **metrics,
-        "elapsed_seconds": round(time.monotonic() - start_time, 3),
-    }
-
-
-def _ensemble_uncertainty_pick(
-    remaining: list[tuple[int, str]],
-    good_votes: dict[int, None],
-    bad_votes: dict[int, None],
-    clips_dict: dict[int, dict[str, Any]],
-    target_category: str,
-    region_voting: bool,
-    n_ensemble: int,
-) -> int:
-    """Index into *remaining* of the item the ensemble is least sure about.
-
-    Trains *n_ensemble* seed-varied MLPs on the current votes, scores every
-    un-voted item's whole-image vector with each member, and returns the index
-    of the item with the highest member-to-member sigmoid std (maximal
-    epistemic disagreement).  Whole-image vectors are used for the selection
-    scoring regardless of region awareness - the pick is an active-learning
-    heuristic, so a single fast vector per candidate is enough; the eventual
-    per-step cost is still measured region-aware in :func:`_score_step`.
-    """
-    import numpy as np  # noqa: PLC0415
-    import torch  # noqa: PLC0415
-
-    X_list, y_list = _build_train_xy(good_votes, bad_votes, clips_dict, target_category, region_voting)
-    X = torch.tensor(np.array(X_list), dtype=torch.float32)
-    y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
-    input_dim = X.shape[1]
-    hidden_dim = _auto_hidden_dim(len(good_votes) + len(bad_votes))
-
-    cand_embs = np.array([media_embedding(clips_dict[cid]) for cid, _ in remaining])
-    X_cand = torch.tensor(cand_embs, dtype=torch.float32)
-
-    member_scores: list[np.ndarray] = []
-    for k in range(n_ensemble):
-        # Fixed member seeds (42 + k) keep the pick a deterministic function of
-        # the votes cast so far, so the whole ``ensemble_std`` walk is
-        # reproducible for a given eval seed.
-        model = train_model(X, y, input_dim, seed=42 + k, hidden_dim=hidden_dim)
-        with torch.no_grad():
-            member_scores.append(torch.sigmoid(model(X_cand)).squeeze(1).cpu().numpy())
-    std = np.stack(member_scores, axis=0).std(axis=0)
-    return int(np.argmax(std))
-
-
-def _bootstrap_pick(remaining: list[tuple[int, str]], good_votes: dict[int, None], bad_votes: dict[int, None]) -> int:
-    """Pick the next vote before the model is trainable (no ensemble yet).
-
-    Until there is at least one Good and one Bad vote the ensemble can't be
-    trained, so this steers toward a trainable state fast: if exactly one class
-    is present, take the first item of the missing class; otherwise take the
-    first remaining item (the seeded shuffle already fixed the order).
-    """
-    need: str | None = None
-    if good_votes and not bad_votes:
-        need = "bad"
-    elif bad_votes and not good_votes:
-        need = "good"
-    if need is not None:
-        for i, (_, lbl) in enumerate(remaining):
-            if lbl == need:
-                return i
-    return 0
+    return model, threshold, hidden_dim, n_labels
 
 
 # ------------------------------------------------------------------
@@ -423,9 +319,9 @@ def simulate_voting_iterations(  # noqa: C901
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     region_voting: bool = False,
-    vote_order: str = "shuffle",
-    n_ensemble: int = 5,
-    max_votes: Optional[int] = None,
+    strategy: str = "random",
+    max_steps: Optional[int] = None,
+    atlas_min_node_size: int = 20,
 ) -> list[dict[str, Any]]:
     """Simulate voting on *clips_dict* and evaluate at every step.
 
@@ -451,32 +347,30 @@ def simulate_voting_iterations(  # noqa: C901
             Scoring is unaffected by this flag - a patch dataset always scores
             region-aware (max-pool over regions), so the only thing this toggles
             is the Good-vote training vector, isolating region voting's effect.
-        vote_order: Which strategy orders the votes (see :data:`VOTE_ORDERS`):
-            ``"shuffle"`` (default, seeded random), ``"balanced"`` (interleave
-            Good/Bad so the running label set stays balanced), or
-            ``"ensemble_std"`` (active learning - vote next on the item an MLP
-            ensemble disagrees about most).
-        n_ensemble: Number of MLP members trained per step to pick the next
-            vote under ``vote_order="ensemble_std"``.  Ignored by the other
-            orders (default 5).
-        max_votes: Optional cap on how many votes are cast.  ``None`` (default)
-            walks the entire simulation set.  Handy for the expensive
-            ``ensemble_std`` order, which retrains ``n_ensemble`` models per
-            step.
+        strategy: Active-learning acquisition strategy naming *which* pool item
+            the simulated user labels next (see
+            :data:`vtscore.eval.al_strategies.STRATEGIES`).  ``"random"``
+            (default) picks uniformly - the baseline every other strategy is
+            measured against.  Uncertainty strategies (``margin``, ``entropy``,
+            ``bald``, ``eig``) query the item the current model is least sure
+            about; ``coreset`` maximises embedding-space coverage; ``density_*``
+            variants up-weight sparsely-populated coverage-atlas cells.  Before a
+            trainable model exists (fewer than one Good *and* one Bad vote) every
+            strategy falls back to a random pick.
+        max_steps: Cap on the number of voting steps (pool items labelled).
+            ``None`` (default) votes on the entire simulation set.
+        atlas_min_node_size: Minimum leaf population for the coverage atlas the
+            ``density_*`` strategies read (default 20, the production floor).
+            Lower it for small simulation sets so density cells actually resolve.
+            Ignored for non-density strategies (no atlas is built).
 
     Returns:
-        List of row dicts with keys ``seed, dataset, category, t, n_good,
-        n_bad, cost, fpr, fnr, elapsed_seconds``. ``n_good``/``n_bad`` report
-        the vote counts behind each row so callers can tell apart metrics
-        learned from a 1-vs-1 model and a many-vs-many one.  The row schema is
-        identical across every ``vote_order`` - selection strategy never leaks
-        into per-step evaluation, which always uses the single production MLP.
+        List of row dicts with keys ``seed, dataset, category, strategy, t,
+        n_good, n_bad, cost, fpr, fnr, elapsed_seconds``. ``n_good``/``n_bad``
+        report the vote counts behind each row so callers can tell apart metrics
+        learned from a 1-vs-1 model and a many-vs-many one.
     """
     import numpy as np  # noqa: PLC0415
-    import torch  # noqa: PLC0415
-
-    if vote_order not in VOTE_ORDERS:
-        raise ValueError(f"Unknown vote_order {vote_order!r}; choices: {list(VOTE_ORDERS)}")
 
     rng = np.random.RandomState(seed)
     # Note: no torch.manual_seed() here - train_model handles its own
@@ -498,6 +392,20 @@ def simulate_voting_iterations(  # noqa: C901
     # detector scores them, regardless of how the Good votes were assembled.
     region_aware = any(clips_dict[cid].get("patch_regions") for cid in clips_dict)
 
+    import torch  # noqa: PLC0415
+
+    # Whole-image embeddings of the simulation pool.  These feed the acquisition
+    # strategies (uncertainty scoring, coreset distances, the density atlas);
+    # the Good-vote *training* vector can still be region-pooled below when
+    # ``region_voting`` is on.
+    sim_embeddings: dict[int, np.ndarray] = {
+        cid: np.asarray(media_embedding(clips_dict[cid]), dtype=np.float32) for cid in sim_ids
+    }
+    input_dim = int(next(iter(sim_embeddings.values())).shape[0])
+
+    # The ``density_*`` strategies read a coverage atlas built over the pool.
+    atlas = _build_eval_atlas(sim_embeddings, atlas_min_node_size) if strategy.startswith("density_") else None
+
     # Pre-compute embeddings for safe-threshold GMM scoring.  Restrict to the
     # simulation set so the held-out ``test_ids`` never feed into the GMM that
     # picks the threshold - otherwise the test scores leak into calibration
@@ -515,77 +423,95 @@ def simulate_voting_iterations(  # noqa: C901
 
     good_votes: dict[int, None] = {}
     bad_votes: dict[int, None] = {}
+    labeled: dict[int, float] = {}
     rows: list[dict[str, Any]] = []
 
-    # Shared per-step scoring: identical across vote orders, so the reported
-    # cost always measures the single production MLP (the ensemble, when used,
-    # only influences which item is voted on next).
-    def _step(t: int) -> None:
-        rows.append(
-            _score_step(
-                good_votes,
-                bad_votes,
-                clips_dict,
-                target_category,
-                region_voting=region_voting,
-                region_aware=region_aware,
-                inclusion=inclusion,
-                safe_thresholds=safe_thresholds,
-                sim_clips=sim_clips,
-                X_all_clips=X_all_clips,
-                calibrate_count=calibrate_count,
-                calibration_fraction=calibration_fraction,
-                test_ids=test_ids,
-                t=t,
-                seed=seed,
-                dataset_name=dataset_name,
-                start_time=start_time,
-            )
+    # Acquisition proceeds one vote at a time: the strategy picks the next pool
+    # item using the *current* model (the one trained at the previous step), the
+    # item's ground-truth label is revealed, and a fresh model is trained on all
+    # votes so far.  Before a trainable model exists every strategy falls back to
+    # a random pick (``model=None`` in the context below), so a cold start is
+    # always a random warm-up until one Good and one Bad vote coexist.
+    pool = sorted(sim_ids)
+    # Ground-truth pool labels for the ``balanced`` oracle strategy (ignored by
+    # every label-blind strategy); cheap to build once up front.
+    pool_labels = {cid: (1.0 if media_is_positive(clips_dict[cid], target_category) else 0.0) for cid in sim_ids}
+    model: torch.nn.Sequential | None = None
+    threshold = 0.5
+    pool_scores: dict[int, float] = {}
+    prev_hidden_dim: int | None = None
+    n_steps = len(pool) if max_steps is None else min(max_steps, len(pool))
+
+    for t in range(1, n_steps + 1):
+        if not pool:
+            break
+        ctx = ALContext(
+            pool_ids=pool,
+            embeddings=sim_embeddings,
+            labeled=labeled,
+            scores=pool_scores,
+            model=model,
+            threshold=threshold,
+            input_dim=input_dim,
+            hidden_dim=prev_hidden_dim,
+            atlas=atlas,
+            rng=rng,
+            pool_labels=pool_labels,
         )
-
-    if vote_order == "ensemble_std":
-        # Adaptive walk: the next vote depends on the current ensemble's
-        # uncertainty, so the sequence can't be precomputed.  The seeded
-        # shuffle only fixes the starting pool order and the bootstrap /
-        # tie-break order before the model is trainable.
-        remaining = _make_vote_sequence(sim_ids, clips_dict, target_category, rng)
-        cap = len(remaining) if max_votes is None else min(max_votes, len(remaining))
-        for t in range(1, cap + 1):
-            if not good_votes or not bad_votes:
-                idx = _bootstrap_pick(remaining, good_votes, bad_votes)
-            else:
-                idx = _ensemble_uncertainty_pick(
-                    remaining, good_votes, bad_votes, clips_dict, target_category, region_voting, n_ensemble
-                )
-            cid, label = remaining.pop(idx)
-            if label == "good":
-                good_votes[cid] = None
-            else:
-                bad_votes[cid] = None
-            if not good_votes or not bad_votes:
-                continue
-            _step(t)
-        return rows
-
-    # Static orders: the whole sequence is fixed up front.
-    if vote_order == "balanced":
-        vote_seq = _balanced_vote_sequence(sim_ids, clips_dict, target_category, rng)
-    else:  # "shuffle"
-        vote_seq = _make_vote_sequence(sim_ids, clips_dict, target_category, rng)
-    if max_votes is not None:
-        vote_seq = vote_seq[:max_votes]
-
-    for t, (cid, label) in enumerate(vote_seq, start=1):
-        if label == "good":
+        cid = select_next(strategy, ctx)
+        pool.remove(cid)
+        if media_is_positive(clips_dict[cid], target_category):
             good_votes[cid] = None
+            labeled[cid] = 1.0
         else:
             bad_votes[cid] = None
+            labeled[cid] = 0.0
 
         # Need at least 1 good and 1 bad to train
         if not good_votes or not bad_votes:
+            model = None
             continue
 
-        _step(t)
+        model, threshold, hidden_dim, n_labels = _train_and_calibrate(
+            good_votes,
+            bad_votes,
+            clips_dict,
+            target_category,
+            region_voting=region_voting,
+            input_dim=input_dim,
+            inclusion=inclusion,
+            calibrate_count=calibrate_count,
+            calibration_fraction=calibration_fraction,
+        )
+
+        # Apply safe threshold blending if enabled
+        if safe_thresholds:
+            threshold = _blend_safe_threshold(threshold, model, region_aware, sim_clips, X_all_clips, n_labels)
+
+        # Evaluate on held-out test set
+        metrics = _evaluate_on_test(
+            model, threshold, clips_dict, test_ids, target_category, inclusion, region_aware=region_aware
+        )
+
+        # Score the remaining pool with the fresh model so the next step's
+        # acquisition strategy ranks it; record the width for the next step's
+        # ``eig`` counterfactual retrains.
+        pool_scores = _score_pool(model, pool, clips_dict)
+        prev_hidden_dim = hidden_dim
+
+        rows.append(
+            {
+                "seed": seed,
+                "dataset": dataset_name,
+                "category": target_category,
+                "strategy": strategy,
+                "t": t,
+                "n_good": len(good_votes),
+                "n_bad": len(bad_votes),
+                **metrics,
+                "elapsed_seconds": round(time.monotonic() - start_time, 3),
+            }
+        )
 
     return rows
 
@@ -605,9 +531,9 @@ def run_voting_iterations_eval(
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     region_voting: bool = False,
-    vote_order: str = "shuffle",
-    n_ensemble: int = 5,
-    max_votes: Optional[int] = None,
+    strategies: Optional[list[str]] = None,
+    max_steps: Optional[int] = None,
+    atlas_min_node_size: int = 20,
 ) -> pd.DataFrame:
     """Run the voting-iterations evaluation over multiple seeds/datasets/categories.
 
@@ -631,17 +557,23 @@ def run_voting_iterations_eval(
         region_voting: When ``True``, Good votes train on the ground-truth
             region-pooled vector for patch datasets (see
             :func:`simulate_voting_iterations`).
-        vote_order: Vote-ordering strategy - ``"shuffle"``, ``"balanced"``, or
-            ``"ensemble_std"`` (see :func:`simulate_voting_iterations`).
-        n_ensemble: Ensemble size for ``vote_order="ensemble_std"`` selection.
-        max_votes: Optional cap on votes cast per (seed, dataset, category).
+        strategies: Active-learning acquisition strategies to compare (see
+            :data:`vtscore.eval.al_strategies.STRATEGIES`).  Each strategy is a
+            fourth cross-product axis (seed x dataset x category x strategy) and
+            its name is recorded in the ``strategy`` result column.  ``None``
+            (default) runs only ``"random"``.
+        max_steps: Cap on the number of voting steps per run (see
+            :func:`simulate_voting_iterations`).
+        atlas_min_node_size: Minimum coverage-atlas leaf population for the
+            ``density_*`` strategies (see :func:`simulate_voting_iterations`).
 
     Returns:
         A :class:`~pandas.DataFrame` with columns ``seed, dataset, category,
-        t, n_good, n_bad, cost, fpr, fnr, elapsed_seconds``.
+        strategy, t, n_good, n_bad, cost, fpr, fnr, elapsed_seconds``.
     """
     import pandas as pd  # noqa: PLC0415
 
+    strategy_list = strategies if strategies is not None else ["random"]
     all_rows: list[dict[str, Any]] = []
 
     for ds_name, clips_dict in dataset_clips.items():
@@ -659,27 +591,40 @@ def run_voting_iterations_eval(
 
         for seed in seeds:
             for cat in target_cats:
-                rows = simulate_voting_iterations(
-                    clips_dict,
-                    target_category=cat,
-                    seed=seed,
-                    dataset_name=ds_name,
-                    inclusion=inclusion,
-                    sim_fraction=sim_fraction,
-                    safe_thresholds=safe_thresholds,
-                    calibrate_count=calibrate_count,
-                    calibration_fraction=calibration_fraction,
-                    region_voting=region_voting,
-                    vote_order=vote_order,
-                    n_ensemble=n_ensemble,
-                    max_votes=max_votes,
-                )
-                all_rows.extend(rows)
+                for strategy in strategy_list:
+                    rows = simulate_voting_iterations(
+                        clips_dict,
+                        target_category=cat,
+                        seed=seed,
+                        dataset_name=ds_name,
+                        inclusion=inclusion,
+                        sim_fraction=sim_fraction,
+                        safe_thresholds=safe_thresholds,
+                        calibrate_count=calibrate_count,
+                        calibration_fraction=calibration_fraction,
+                        region_voting=region_voting,
+                        strategy=strategy,
+                        max_steps=max_steps,
+                        atlas_min_node_size=atlas_min_node_size,
+                    )
+                    all_rows.extend(rows)
 
     return pd.DataFrame(
         all_rows,
         columns=pd.Index(
-            ["seed", "dataset", "category", "t", "n_good", "n_bad", "cost", "fpr", "fnr", "elapsed_seconds"]
+            [
+                "seed",
+                "dataset",
+                "category",
+                "strategy",
+                "t",
+                "n_good",
+                "n_bad",
+                "cost",
+                "fpr",
+                "fnr",
+                "elapsed_seconds",
+            ]
         ),
     )
 
@@ -694,9 +639,9 @@ def run_voting_iterations_eval_from_pickles(
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     region_voting: bool = False,
-    vote_order: str = "shuffle",
-    n_ensemble: int = 5,
-    max_votes: Optional[int] = None,
+    strategies: Optional[list[str]] = None,
+    max_steps: Optional[int] = None,
+    atlas_min_node_size: int = 20,
 ) -> pd.DataFrame:
     """Convenience wrapper that loads datasets from pickle files.
 
@@ -714,15 +659,16 @@ def run_voting_iterations_eval_from_pickles(
         region_voting: When ``True``, Good votes train on the ground-truth
             region-pooled vector for patch datasets (see
             :func:`simulate_voting_iterations`).
-        vote_order: Vote-ordering strategy - ``"shuffle"``, ``"balanced"``, or
-            ``"ensemble_std"`` (see :func:`simulate_voting_iterations`).
-        n_ensemble: Ensemble size for ``vote_order="ensemble_std"`` selection.
-        max_votes: Optional cap on votes cast per (seed, dataset, category).
+        strategies: Acquisition strategies to compare (see
+            :func:`run_voting_iterations_eval`).
+        max_steps: Cap on the number of voting steps per run.
+        atlas_min_node_size: Minimum coverage-atlas leaf population for the
+            ``density_*`` strategies.
 
     Returns:
         A :class:`~pandas.DataFrame` identical to :func:`run_voting_iterations_eval`
-        (columns: ``seed, dataset, category, t, n_good, n_bad, cost, fpr, fnr,
-        elapsed_seconds``).
+        (columns: ``seed, dataset, category, strategy, t, n_good, n_bad, cost,
+        fpr, fnr, elapsed_seconds``).
     """
     from vtscore.datasets.loader import load_dataset_from_pickle
 
@@ -742,7 +688,7 @@ def run_voting_iterations_eval_from_pickles(
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
         region_voting=region_voting,
-        vote_order=vote_order,
-        n_ensemble=n_ensemble,
-        max_votes=max_votes,
+        strategies=strategies,
+        max_steps=max_steps,
+        atlas_min_node_size=atlas_min_node_size,
     )


### PR DESCRIPTION
## Summary

Adds an active-learning acquisition layer to the voting-iterations eval and a hermetic benchmark for comparing strategies.

**`vtscore/eval/al_strategies.py`** — an `ALContext` (model, pool scores, embeddings, labelled-so-far, threshold, atlas, rng) and a `STRATEGIES` registry:

- `random` — uniform baseline.
- `margin` — smallest `|p - t|` (closest to the decision threshold).
- `entropy` — largest binary entropy `H(p)`.
- `bald` — MC-dropout mutual information `H(E[p]) − E[H(p)]` (dropout left on for several stochastic passes; seed forked from the context RNG for reproducibility).
- `eig` — expected pool-entropy reduction via `2 × K` counterfactual retrains (capped at the top‑K most-uncertain candidates for cost).
- `coreset` — greedy k-centre on embeddings (farthest-from-labelled).
- `density_{margin,entropy,bald,coreset}` — reweight the base utility by `1 / √cell_count` from the dataset's `CoverageAtlas` leaf (information-density sampling).

All utilities are non-negative and higher-is-better, so the density multiply only re-ranks by rarity. Before a trainable model exists (cold start), every strategy falls back to a random pick.

**`vtscore/eval/voting_iterations.py`** — the per-step vote order is now driven by an acquisition strategy instead of a fixed shuffle. New axes:
- `simulate_voting_iterations`: `strategy=`, `max_steps=`, `atlas_min_node_size=`.
- `run_voting_iterations_eval` / `..._from_pickles`: `strategies=` (fourth cross-product axis), `max_steps=`, `atlas_min_node_size=`.
- A new `strategy` result column. The per-step calibration/training fidelity to the live pipeline is unchanged (extracted into `_train_and_calibrate`).

**`vtscore/eval/visualize.py`** — `plot_voting_iterations` **facets by strategy** (one subplot per strategy) when the frame carries more than one; a single-strategy or pre-strategy frame renders exactly as before.

**`vtscore/eval/al_benchmark.py`** — hermetic data sources (`synthetic` Gaussian clusters; `precomputed` feature/label arrays, in-memory or from an `allow_pickle=False` `.npz`), a `run_al_benchmark` runner, a final-cost-by-strategy summary, and a `python -m vtscore.eval.al_benchmark` CLI.

## Tests

- New `tests_lib/detectors/test_al_strategies.py` (registry, every sampler + `ALContext`, density weighting, cold-start/selection semantics) and `test_al_benchmark.py` (both data sources + runner).
- Updated `test_eval_voting_iterations.py` (strategy/`max_steps` axis, new column) and `test_eval_visualize.py` (strategy faceting).
- Full `./run-tests.sh` green (6275 passed); ruff / ruff-format / codespell / deptry / pip-audit / pyright all clean.

## Notes

- **Backwards compatibility:** `run_voting_iterations_eval` output gains a `strategy` column and `simulate_voting_iterations` rows gain a `strategy` key; existing eval consumers that assert on the exact column/key set need updating (done for the in-repo tests). The default strategy is `random`.

Closes #2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfQ7qVZvBLV8kjXJDPKBm9)_