### PR TITLE
VTSBrowse signposts: rigorous toponymy-install check + opt-in generative captioners

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,7 +475,13 @@ def _no_signpost_pipeline(monkeypatch):
     """
     from vtscore.projection import signpost_prep
 
+    # The build paths gate on require_signposting; the serve / signature paths
+    # on the quiet probe.  Stub both off so every app-tier path skips prep
+    # deterministically — and stubbing require_signposting (rather than letting
+    # it compute False) also keeps its one-time "install broken" error out of
+    # the suite, since nothing is actually broken here.
     monkeypatch.setattr(signpost_prep, "signposting_available", lambda: False)
+    monkeypatch.setattr(signpost_prep, "require_signposting", lambda: False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests_lib/projection/test_signpost_build.py
+++ b/tests_lib/projection/test_signpost_build.py
@@ -175,6 +175,32 @@ class TestAvailability:
         monkeypatch.setattr(util, "find_spec", lambda name: None)
         assert sb.signposting_available() is False
 
+    def test_require_signposting_true_when_present(self, monkeypatch):
+        monkeypatch.setattr(sb, "signposting_available", lambda: True)
+        assert sb.require_signposting() is True
+
+    def test_require_signposting_logs_loudly_when_missing(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setattr(sb, "signposting_available", lambda: False)
+        # Reset the one-time latch so the error is emitted for this test.
+        monkeypatch.setattr(sb, "_missing_toponymy_warned", False)
+        with caplog.at_level(logging.ERROR, logger=sb.logger.name):
+            assert sb.require_signposting() is False
+        assert any("toponymy" in r.message.lower() for r in caplog.records)
+        assert any("install.sh" in r.message for r in caplog.records)
+        assert all(r.levelno == logging.ERROR for r in caplog.records)
+
+    def test_require_signposting_logs_only_once(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setattr(sb, "signposting_available", lambda: False)
+        monkeypatch.setattr(sb, "_missing_toponymy_warned", False)
+        with caplog.at_level(logging.ERROR, logger=sb.logger.name):
+            assert sb.require_signposting() is False
+            assert sb.require_signposting() is False
+        assert sum("toponymy" in r.message.lower() for r in caplog.records) == 1
+
     def test_version_string_when_missing(self, monkeypatch):
         from importlib import metadata
 

--- a/tests_lib/projection/test_signpost_prep.py
+++ b/tests_lib/projection/test_signpost_prep.py
@@ -41,10 +41,12 @@ def ctx(monkeypatch):
     """A context of ``_N`` audio medias with vectors under the fake embedder.
 
     The fit itself is stubbed, so these tests run whether or not toponymy is
-    installed — availability is patched to True and re-patched off by the
+    installed — availability is patched to True (both the quiet probe the
+    signature path uses and the loud build-path gate) and re-patched off by the
     tests that cover the unavailable path.
     """
     monkeypatch.setattr(sp, "signposting_available", lambda: True)
+    monkeypatch.setattr(sp, "require_signposting", lambda: True)
     rng = np.random.default_rng(7)
     context = DatasetContext("signpost-test")
     for mid in range(1, _N + 1):
@@ -149,7 +151,9 @@ class TestPrepSignposts:
         assert sp.prep_signposts(ctx, _proj(ctx), subset=False) is None
 
     def test_unavailable_toponymy_bails(self, ctx, stub_pipeline, monkeypatch):
-        monkeypatch.setattr(sp, "signposting_available", lambda: False)
+        # The build path gates on require_signposting (the loud gate), not the
+        # quiet probe — a missing install is surfaced, but the build still bails.
+        monkeypatch.setattr(sp, "require_signposting", lambda: False)
         assert sp.prep_signposts(ctx, _proj(ctx), subset=False) is None
 
     def test_tiny_layout_bails_before_texts(self, ctx, stub_pipeline, monkeypatch):

--- a/vtscore/projection/signpost_build.py
+++ b/vtscore/projection/signpost_build.py
@@ -64,8 +64,46 @@ ProgressFn = Callable[[int, int, str], None]
 
 
 def signposting_available() -> bool:
-    """Whether the ``toponymy`` library is importable in this environment."""
+    """Whether the ``toponymy`` library is importable in this environment.
+
+    The silent probe: the serve / signature paths gate on this without
+    complaint, because those run on every projection poll and a ``None``
+    result there is routine.  Build paths use :func:`require_signposting`
+    instead, which treats a missing install as the error it is.
+    """
     return util.find_spec("toponymy") is not None
+
+
+#: One-time latch so a missing-toponymy install shouts exactly once per
+#: process, not on every build attempt (subset re-fits, relabel jobs, …).
+_missing_toponymy_warned = False
+
+
+def require_signposting() -> bool:
+    """Gate a signpost *build*, logging loudly if ``toponymy`` is missing.
+
+    Unlike :func:`signposting_available` (the quiet probe), ``toponymy`` is not
+    a soft optional at build time: ``scripts/install.sh`` installs it
+    unconditionally (alongside ``apricot-select``), so its absence when a build
+    actually runs means a broken or incomplete install, not a dataset that
+    legitimately can't be lettered.  We still degrade gracefully — the caller
+    returns ``None`` and the map stays unlettered rather than crashing — but we
+    surface the misconfiguration with a one-time ``error`` log so it can't hide
+    behind the genuinely-quiet no-embedder / no-provider skips.  Returns whether
+    signposting can proceed.
+    """
+    if signposting_available():
+        return True
+    global _missing_toponymy_warned
+    if not _missing_toponymy_warned:
+        _missing_toponymy_warned = True
+        logger.error(
+            "VTSBrowse signposts are disabled: the required 'toponymy' library "
+            "is not importable. It is installed by scripts/install.sh (which "
+            "also installs its apricot-select dependency); re-run that script to "
+            "repair this environment. Maps will render unlettered until then."
+        )
+    return False
 
 
 def toponymy_version() -> str:
@@ -285,6 +323,7 @@ __all__ = [
     "EmbedderTextEncoder",
     "build_region_labels",
     "make_keyphrase_namer",
+    "require_signposting",
     "signposting_available",
     "toponymy_version",
 ]

--- a/vtscore/projection/signpost_prep.py
+++ b/vtscore/projection/signpost_prep.py
@@ -23,9 +23,15 @@ Split of work between the stages (what must be computed when):
 * **Clustering + naming** are layout-scoped and cheap (a ~5-D UMAP + the
   fit), so they run fresh per layout, full or subset.
 
-Everything is best-effort: any missing prerequisite (no toponymy install, no
-text-capable embedder, no provider for the media type) returns ``None`` and
-the map simply stays unlettered.
+Everything is best-effort: any missing prerequisite returns ``None`` and the
+map simply stays unlettered.  The prerequisites are not equal, though.  A
+missing text-capable embedder or a media type with no provider is a routine,
+data-dependent skip (silent).  A missing ``toponymy`` install is *not*:
+``scripts/install.sh`` installs it unconditionally, so its absence is a broken
+environment, and the build paths gate on :func:`~vtscore.projection.signpost_build.require_signposting`
+(which logs a one-time error) rather than the silent probe.  The serve /
+signature paths still use the quiet probe, since a ``None`` there is expected
+on every poll.
 """
 
 from __future__ import annotations
@@ -36,6 +42,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from vtscore.projection.signpost_build import (
     _MIN_POINTS,
     build_region_labels,
+    require_signposting,
     signposting_available,
     toponymy_version,
 )
@@ -117,7 +124,7 @@ def ensure_texts_for_dataset(ctx: Any, on_progress: ProgressFn | None = None) ->
     text-model calls.  No-op when signposting isn't possible for this dataset
     (no toponymy install, no text-capable embedder, no provider).
     """
-    if not signposting_available():
+    if not require_signposting():
         return
     embedder = _text_embedder(ctx)
     if embedder is None:
@@ -207,7 +214,7 @@ def _prep_prerequisites(ctx: Any, proj: "Projection") -> tuple[list[int], str, A
     topic tree (bail *before* paying for texts), or a media type with no
     registered text provider.
     """
-    if not signposting_available():
+    if not require_signposting():
         return None
     embedder = _text_embedder(ctx)
     if embedder is None:


### PR DESCRIPTION
Two related VTSBrowse signpost changes on one branch.

## 1. Surface a missing `toponymy` install loudly

Signpost builds treated a **missing `toponymy` install** identically to the routine data-dependent skips (no text embedder, no provider for the media type): a silent `return None` that leaves the map unlettered. But `toponymy` is a **guaranteed dependency** — `scripts/install.sh` installs it unconditionally, as does `ensure-test-deps.sh`, and it's declared in `pyproject.toml` — so its absence at build time is a broken environment, not a dataset that legitimately can't be lettered.

- `signposting_available()` stays the **quiet probe** the serve / signature paths poll on.
- New `require_signposting()` is the **loud build-time gate**: when `toponymy` is missing it logs a **one-time error** pointing at `scripts/install.sh`, then still degrades gracefully. The build paths use it; the genuinely data-dependent skips stay silent.

Behavior on a healthy install is unchanged.

## 2. Opt-in generative signpost captioners (image + audio)

Signpost region names could previously come only from zero-shot tag *matching* (CLAP AudioSet-527 for audio, SigLIP OpenImages-600 for image) — the closest terms in a fixed vocabulary. The image study found those collapse on fine-grained subsets (0–14% breed-sign hit vs 56–78% for a generative captioner), and both Toponymy studies resolved a captioner as the preferred text source — but the captioners lived only in the offline experiment harness. This ports them into production as **opt-in** providers:

- **`vtscore/projection/signpost_captioners.py`** — `ImageCaptionProvider` (`Qwen2.5-VL-3B`, one instructed catalog line per image) and `AudioCaptionProvider` (`MU-NLPC/whisper-small-audio-captioning`). Heavy deps (torch / transformers / PIL / librosa) import lazily behind module-level model seams (stubbable in tests); media decode reuses the image media type's `_pil_source_for`/`_load_pil` and `librosa`. Models are process-scoped and never persisted — only the generated *text* is cached on the media dict (No-Persisted-Vectors).
- **Selection + fallback** — `signpost_texts.provider_for` consults the per-media-type captioner preference and, when enabled, returns the captioner wrapped in a new `FallbackTextProvider` over the tag provider: a model-load failure or a per-item decode failure quietly degrades to tags.
- **User setting** — new `browse_signpost_captioner` per-media-type setting (default: **tags**) flows through `CoreConfig.signpost_captioner` into the library tier; a **Tags | Captions** toggle appears in Settings → Browser for image/audio.

Default stays tags — the captioner is opt-in because it downloads a multi-GB model and the studies' validation-before-default work is still owed (tracked in `docs/plans/vtsbrowse-toponymy.md`).

## Testing

- `./run-tests.sh` → **6375 passed**, 1 skipped.
- `./run-tests.sh projection` → 205 passed (new captioner decode/batching/fallback/selection tests + the `slow` real-toponymy smoke).
- `./run-tests.sh frontend` → TS build OK, OpenAPI snapshot no drift, Vitest 1522 passed.

Captioner providers are unit-tested with the model seams stubbed (no multi-GB download); real-model validation on real-world datasets is the owed follow-up in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvLvbLnu5NLgC7XZEg2ezF