### PR TITLE
Add specs for import-defaults and auto-find settings sub-panels

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
@@ -1,0 +1,256 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Observable, of, throwError } from 'rxjs';
+
+import {
+  AutoFindExporterChange,
+  AutoFindSettingsComponent,
+} from './auto-find-settings.component';
+import { DetectorsRegistryApiService } from '../../../../services/detectors-registry-api.service';
+import { ExportersApiService } from '../../../../services/exporters-api.service';
+import type { ExporterEntry } from '../../../../generated/api-client/models/exporter-entry';
+import { ImporterField } from '../../../../models/api.models';
+import { provideZoneless } from '../../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../../testing/settle-resource';
+
+/**
+ * Unit spec for the Auto-Find settings sub-panel. The panel loads the detector
+ * registry (an editable Auto-Find checklist) and the pickable exporters (a tab
+ * strip whose active tab is the auto-export target), keeping per-exporter field
+ * values that it emits to the parent. Both API services are stubbed so the init
+ * subscriptions resolve synchronously.
+ */
+describe('AutoFindSettingsComponent', () => {
+  let fixture: ComponentFixture<AutoFindSettingsComponent>;
+  let component: AutoFindSettingsComponent;
+
+  const registryDetectors = [
+    { id: 'det-1', name: 'Barks', autofind: true, media_type: 'audio' },
+    { id: 'det-2', name: 'Cats', autofind: false, media_type: 'image' },
+  ];
+
+  const exporters = [
+    {
+      name: 'server_json_file',
+      display_name: 'JSON File',
+      description: 'Write results to a JSON file',
+      icon: 'download',
+      hidden_from_picker: false,
+      ui_mode: 'form',
+      fields: [
+        { key: 'filepath', field_type: 'text', label: 'File path', default: '/out.json' },
+        { key: 'mode', field_type: 'select', label: 'Mode', options: ['a', 'b'] },
+      ] as ImporterField[],
+    },
+    {
+      name: 'email',
+      display_name: 'Email',
+      description: 'Email the results',
+      icon: 'mail',
+      hidden_from_picker: false,
+      ui_mode: 'form',
+      fields: [] as ImporterField[],
+    },
+    {
+      name: 'secret_internal',
+      display_name: 'Internal',
+      description: 'hidden',
+      icon: '',
+      hidden_from_picker: true,
+      ui_mode: 'form',
+      fields: [] as ImporterField[],
+    },
+  ] as unknown as ExporterEntry[];
+
+  let registryResponse: () => Observable<unknown>;
+  let exportersResponse: () => Observable<unknown>;
+  let autofindResponse: () => Observable<unknown>;
+  let autofindCalls: Array<{ id: string; autofind: boolean }>;
+
+  beforeEach(() => {
+    autofindCalls = [];
+    registryResponse = () => of({ detectors: registryDetectors });
+    exportersResponse = () => of(exporters);
+    autofindResponse = () => of({});
+
+    const detectorsStub: Partial<DetectorsRegistryApiService> = {
+      getRegistry: () => registryResponse() as Observable<never>,
+      setAutofind: (id: string, autofind: boolean) => {
+        autofindCalls.push({ id, autofind });
+        return autofindResponse() as Observable<never>;
+      },
+    };
+    const exportersStub: Partial<ExportersApiService> = {
+      getExporters: () => exportersResponse() as Observable<never>,
+    };
+
+    TestBed.configureTestingModule({
+      imports: [AutoFindSettingsComponent],
+      providers: [
+        ...provideZoneless(),
+        { provide: DetectorsRegistryApiService, useValue: detectorsStub },
+        { provide: ExportersApiService, useValue: exportersStub },
+      ],
+    });
+  });
+
+  async function create(inputs: {
+    exporter?: string;
+    fieldValues?: Record<string, Record<string, string>>;
+  } = {}): Promise<void> {
+    fixture = TestBed.createComponent(AutoFindSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('autofindExporter', inputs.exporter ?? '');
+    fixture.componentRef.setInput('autofindExporterFieldValues', inputs.fieldValues ?? {});
+    await settleZoneless(fixture);
+  }
+
+  function captureEmits(): AutoFindExporterChange[] {
+    const out: AutoFindExporterChange[] = [];
+    component.exporterChange.subscribe((v) => out.push(v));
+    return out;
+  }
+
+  it('creates and loads the detector checklist mapped to the narrowed shape', async () => {
+    await create();
+    expect(component).toBeTruthy();
+    expect(component.loadingDetectors).toBe(false);
+    expect(component.detectors).toEqual([
+      { id: 'det-1', name: 'Barks', autofind: true, media_type: 'audio' },
+      { id: 'det-2', name: 'Cats', autofind: false, media_type: 'image' },
+    ]);
+    expect(component.detectorError).toBe('');
+  });
+
+  it('loads exporters, filtering out picker-hidden ones', async () => {
+    await create();
+    expect(component.loadingExporters).toBe(false);
+    expect(component.exporters.map((e) => e.name)).toEqual(['server_json_file', 'email']);
+  });
+
+  it('sets detectorError and clears loading when the registry fails', async () => {
+    registryResponse = () => throwError(() => new Error('nope'));
+    await create();
+    expect(component.detectorError).toBe('Failed to load detectors');
+    expect(component.loadingDetectors).toBe(false);
+    expect(component.detectors).toEqual([]);
+  });
+
+  it('clears the exporter loading flag when the exporters call fails', async () => {
+    exportersResponse = () => throwError(() => new Error('nope'));
+    await create();
+    expect(component.loadingExporters).toBe(false);
+    expect(component.exporters).toEqual([]);
+  });
+
+  it('initialises the active exporter and cloned field values from inputs', async () => {
+    const fv = { server_json_file: { filepath: '/saved.json' } };
+    await create({ exporter: 'server_json_file', fieldValues: fv });
+    expect(component.activeExporter).toBe('server_json_file');
+    expect(component.fieldValue('filepath')).toBe('/saved.json');
+    // Cloned, not aliased — editing the working copy must not touch the input.
+    component.setFieldValue('filepath', '/edited.json');
+    expect(fv.server_json_file.filepath).toBe('/saved.json');
+  });
+
+  it('reacts to input changes via ngOnChanges', async () => {
+    await create();
+    expect(component.activeExporter).toBe('');
+
+    fixture.componentRef.setInput('autofindExporter', 'email');
+    fixture.componentRef.setInput('autofindExporterFieldValues', {
+      email: { to: 'a@b.com' },
+    });
+    await settleZoneless(fixture);
+
+    expect(component.activeExporter).toBe('email');
+    expect(component.fieldValues).toEqual({ email: { to: 'a@b.com' } });
+  });
+
+  it('toggleDetector flips the flag optimistically and persists it', async () => {
+    await create();
+    const cats = component.detectors[1];
+    component.toggleDetector(cats, true);
+    expect(cats.autofind).toBe(true);
+    expect(autofindCalls).toEqual([{ id: 'det-2', autofind: true }]);
+  });
+
+  it('toggleDetector reverts and reports an error when the persist fails', async () => {
+    autofindResponse = () => throwError(() => new Error('fail'));
+    await create();
+    const cats = component.detectors[1];
+    component.toggleDetector(cats, true);
+    expect(cats.autofind).toBe(false); // reverted
+    expect(component.detectorError).toBe('Failed to update Auto-Find for "Cats"');
+  });
+
+  it('selectExporter seeds default field values on first pick and emits', async () => {
+    await create();
+    const emits = captureEmits();
+    component.selectExporter('server_json_file');
+
+    expect(component.activeExporter).toBe('server_json_file');
+    // 'filepath' has a default; 'mode' does not, so only the default is seeded.
+    expect(component.fieldValues['server_json_file']).toEqual({ filepath: '/out.json' });
+    expect(emits).toEqual([
+      { exporter: 'server_json_file', fieldValues: { server_json_file: { filepath: '/out.json' } } },
+    ]);
+  });
+
+  it('selectExporter to the None tab emits an empty exporter', async () => {
+    await create({ exporter: 'server_json_file' });
+    const emits = captureEmits();
+    component.selectExporter('');
+    expect(component.activeExporter).toBe('');
+    expect(emits.at(-1)?.exporter).toBe('');
+  });
+
+  it('does not overwrite existing field values when re-selecting an exporter', async () => {
+    await create({ exporter: 'server_json_file', fieldValues: { server_json_file: { filepath: '/keep.json' } } });
+    component.selectExporter('server_json_file');
+    expect(component.fieldValues['server_json_file']).toEqual({ filepath: '/keep.json' });
+  });
+
+  it('activeFields returns the active exporter fields, or none for the None tab', async () => {
+    await create({ exporter: 'server_json_file' });
+    expect(component.activeFields.map((f) => f.key)).toEqual(['filepath', 'mode']);
+
+    component.selectExporter('');
+    expect(component.activeFields).toEqual([]);
+  });
+
+  it('setFieldValue writes the active exporter field and emits, ignoring writes with no active tab', async () => {
+    await create({ exporter: 'server_json_file' });
+    const emits = captureEmits();
+
+    component.setFieldValue('filepath', '/new.json');
+    expect(component.fieldValue('filepath')).toBe('/new.json');
+    expect(emits.at(-1)).toEqual({
+      exporter: 'server_json_file',
+      fieldValues: { server_json_file: { filepath: '/new.json' } },
+    });
+
+    // On the None tab, writes are ignored (no emission).
+    component.selectExporter('');
+    const before = emits.length;
+    component.setFieldValue('filepath', '/ignored.json');
+    expect(emits.length).toBe(before);
+  });
+
+  it('inputType maps plugin field types to concrete input types', async () => {
+    await create();
+    expect(component.inputType({ field_type: 'password' } as ImporterField)).toBe('password');
+    expect(component.inputType({ field_type: 'email' } as ImporterField)).toBe('email');
+    expect(component.inputType({ field_type: 'url' } as ImporterField)).toBe('url');
+    expect(component.inputType({ field_type: 'text' } as ImporterField)).toBe('text');
+    expect(component.inputType({ field_type: 'anything-else' } as ImporterField)).toBe('text');
+  });
+
+  it('emits a cloned field-value map so the parent cannot mutate the working copy', async () => {
+    await create({ exporter: 'server_json_file' });
+    const emits = captureEmits();
+    component.setFieldValue('filepath', '/x.json');
+    const emitted = emits.at(-1)!.fieldValues;
+    expect(emitted).not.toBe(component.fieldValues);
+    expect(emitted['server_json_file']).not.toBe(component.fieldValues['server_json_file']);
+  });
+});

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.spec.ts
@@ -1,0 +1,323 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Observable, of, throwError } from 'rxjs';
+
+import { ImportDefaultsSettingsComponent } from './import-defaults-settings.component';
+import { DatasetsListingsApiService } from '../../../../services/datasets-listings-api.service';
+import {
+  ClipperInfo,
+  ConverterInfo,
+  EmbedderInfo,
+  ImportDefaultsByMediaType,
+  MediaTypeInfo,
+  SourceSpec,
+} from '../../../../models/api.models';
+import { provideZoneless } from '../../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../../testing/settle-resource';
+
+/**
+ * Unit spec for the Import-Defaults settings sub-panel. The panel reads a
+ * per-mediaType ``ImportDefaultsByMediaType`` map (embedder / clipper /
+ * source-specs) and emits a full replacement map on every edit. These tests
+ * drive the listings API through a stub so the lazy per-tab embedder/clipper/
+ * converter fetches resolve synchronously, and assert on the component's
+ * derived getters and the ``defaultsChange`` payloads.
+ */
+describe('ImportDefaultsSettingsComponent', () => {
+  let fixture: ComponentFixture<ImportDefaultsSettingsComponent>;
+  let component: ImportDefaultsSettingsComponent;
+
+  const mediaTypes: MediaTypeInfo[] = [
+    { type_id: 'audio', name: 'Sound', icon: 'audio' },
+    { type_id: 'image', name: 'Image', icon: 'image' },
+  ];
+
+  const audioEmbedders: EmbedderInfo[] = [
+    {
+      name: 'clap',
+      display_name: 'CLAP',
+      media_type_id: 'audio',
+      is_default: true,
+      license_notice: null,
+    },
+    {
+      name: 'wav2vec',
+      display_name: 'Wav2Vec',
+      media_type_id: 'audio',
+      is_default: false,
+      license_notice: 'Non-commercial use only',
+    },
+  ] as unknown as EmbedderInfo[];
+
+  const audioClippers: ClipperInfo[] = [
+    { name: 'whole', media_type: 'audio' },
+    { name: 'window', media_type: 'audio' },
+  ] as unknown as ClipperInfo[];
+
+  const audioConverters: ConverterInfo[] = [
+    { name: 'video_to_audio', source_type: 'video', target_type: 'audio' },
+  ];
+
+  // Records of which mediaType each listing endpoint was asked for, so tests can
+  // assert on lazy-load / caching behaviour.
+  let embedderCalls: string[];
+  let clipperCalls: string[];
+  let converterCalls: string[];
+
+  // Swappable per-test so the error-path test can make a listing throw.
+  let embeddersFor: (mt?: string) => Observable<EmbedderInfo[]>;
+  let clippersFor: (mt?: string) => Observable<ClipperInfo[]>;
+  let convertersFor: (mt?: string) => Observable<ConverterInfo[]>;
+
+  beforeEach(() => {
+    embedderCalls = [];
+    clipperCalls = [];
+    converterCalls = [];
+    embeddersFor = (mt) => of(mt === 'audio' ? audioEmbedders : []);
+    clippersFor = (mt) => of(mt === 'audio' ? audioClippers : []);
+    convertersFor = (mt) => of(mt === 'audio' ? audioConverters : []);
+
+    const listingsStub: Partial<DatasetsListingsApiService> = {
+      getEmbedders: (mt?: string) => {
+        embedderCalls.push(mt ?? '');
+        return embeddersFor(mt);
+      },
+      getClippers: (mt?: string) => {
+        clipperCalls.push(mt ?? '');
+        return clippersFor(mt);
+      },
+      getConverters: (mt?: string) => {
+        converterCalls.push(mt ?? '');
+        return convertersFor(mt);
+      },
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ImportDefaultsSettingsComponent],
+      providers: [
+        ...provideZoneless(),
+        { provide: DatasetsListingsApiService, useValue: listingsStub },
+      ],
+    });
+  });
+
+  /** Create + init the component with the given inputs. Returns after ngOnInit
+   *  (and its synchronous listing subscriptions) has run. */
+  async function create(inputs: {
+    mediaTypes?: MediaTypeInfo[];
+    defaults?: ImportDefaultsByMediaType;
+    solo?: string | null;
+  } = {}): Promise<void> {
+    fixture = TestBed.createComponent(ImportDefaultsSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('mediaTypes', inputs.mediaTypes ?? mediaTypes);
+    fixture.componentRef.setInput('defaults', inputs.defaults ?? {});
+    if (inputs.solo !== undefined) {
+      fixture.componentRef.setInput('effectiveSoloMediaType', inputs.solo);
+    }
+    await settleZoneless(fixture);
+  }
+
+  /** Subscribe to the component's ``defaultsChange`` output and collect emits. */
+  function captureEmits(): ImportDefaultsByMediaType[] {
+    const out: ImportDefaultsByMediaType[] = [];
+    component.defaultsChange.subscribe((v) => out.push(v));
+    return out;
+  }
+
+  it('creates and picks the first visible type as the active tab', async () => {
+    await create();
+    expect(component).toBeTruthy();
+    expect(component.activeType).toBe('audio');
+    // Lazy-load fired for the initial tab only.
+    expect(embedderCalls).toEqual(['audio']);
+    expect(clipperCalls).toEqual(['audio']);
+    expect(converterCalls).toEqual(['audio']);
+    expect(component.activeEmbedders).toEqual(audioEmbedders);
+    expect(component.activeClippers).toEqual(audioClippers);
+    expect(component.activeConverters).toEqual(audioConverters);
+    expect(component.isLoading).toBe(false);
+  });
+
+  it('renders no tabs when there are no media types', async () => {
+    await create({ mediaTypes: [] });
+    expect(component.visibleTypes.length).toBe(0);
+    expect(component.activeType).toBe('');
+    expect(embedderCalls).toEqual([]);
+  });
+
+  it('collapses to the solo media type when effectiveSoloMediaType is set', async () => {
+    await create({ solo: 'image' });
+    expect(component.visibleTypes.map((mt) => mt.type_id)).toEqual(['image']);
+    expect(component.activeType).toBe('image');
+    expect(embedderCalls).toEqual(['image']);
+  });
+
+  it('lazy-loads a tab on first switch and caches it afterwards', async () => {
+    await create();
+    expect(embedderCalls).toEqual(['audio']);
+
+    // Re-selecting the current tab does not refetch (already cached).
+    component.selectTab('audio');
+    expect(embedderCalls).toEqual(['audio']);
+
+    // Switching to a new tab fetches once...
+    component.selectTab('image');
+    expect(component.activeType).toBe('image');
+    expect(embedderCalls).toEqual(['audio', 'image']);
+
+    // ...and switching back does not refetch.
+    component.selectTab('audio');
+    expect(embedderCalls).toEqual(['audio', 'image']);
+  });
+
+  it('falls back to empty lists when a listing errors', async () => {
+    embeddersFor = () => throwError(() => new Error('boom'));
+    await create();
+    expect(component.activeEmbedders).toEqual([]);
+    // The other two still loaded, and the loading flag clears once all settle.
+    expect(component.activeClippers).toEqual(audioClippers);
+    expect(component.isLoading).toBe(false);
+  });
+
+  it('splits embedders into recommended vs advanced and derives the default', async () => {
+    await create();
+    expect(component.recommendedEmbedders.map((e) => e.name)).toEqual(['clap']);
+    expect(component.advancedEmbedderOptions.map((e) => e.name)).toEqual(['wav2vec']);
+    expect(component.defaultEmbedderName).toBe('clap');
+  });
+
+  it('defaultEmbedderName falls back to the first embedder when none is flagged default', async () => {
+    embeddersFor = () =>
+      of([
+        { name: 'a', media_type_id: 'audio', is_default: false },
+        { name: 'b', media_type_id: 'audio', is_default: false },
+      ] as unknown as EmbedderInfo[]);
+    await create();
+    expect(component.defaultEmbedderName).toBe('a');
+  });
+
+  it('displays the override embedder when set, otherwise the built-in default', async () => {
+    await create();
+    expect(component.currentEmbedder).toBe('');
+    expect(component.displayedEmbedder).toBe('clap');
+
+    await create({ defaults: { audio: { embedder: 'wav2vec' } } });
+    expect(component.currentEmbedder).toBe('wav2vec');
+    expect(component.displayedEmbedder).toBe('wav2vec');
+  });
+
+  it('surfaces the active embedder license notice only when an override is set', async () => {
+    await create();
+    expect(component.licenseNotice).toBeNull();
+
+    await create({ defaults: { audio: { embedder: 'wav2vec' } } });
+    expect(component.licenseNotice).toBe('Non-commercial use only');
+  });
+
+  it('onEmbedderChange emits an override for a non-default pick', async () => {
+    await create();
+    const emits = captureEmits();
+    component.onEmbedderChange('wav2vec');
+    expect(emits).toEqual([{ audio: { embedder: 'wav2vec' } }]);
+  });
+
+  it('onEmbedderChange clears the override when the built-in default is re-picked', async () => {
+    await create({ defaults: { audio: { embedder: 'wav2vec' } } });
+    const emits = captureEmits();
+    component.onEmbedderChange('clap'); // clap is the default → clears
+    expect(emits).toEqual([{}]);
+  });
+
+  it('reports whether the active type has any saved overrides', async () => {
+    await create();
+    expect(component.hasOverridesForActiveType).toBe(false);
+
+    await create({ defaults: { audio: { clipper: 'window' } } });
+    expect(component.hasOverridesForActiveType).toBe(true);
+
+    await create({ defaults: { audio: { source_specs: [] } } });
+    expect(component.hasOverridesForActiveType).toBe(false);
+  });
+
+  it('synthesises a native source-spec row when none is saved', async () => {
+    await create();
+    expect(component.currentSourceSpecsForPicker).toEqual([
+      { source_type: 'audio', converter: null, params: {} },
+    ]);
+  });
+
+  it('returns saved source specs as-is when a native row is already present', async () => {
+    const saved: SourceSpec[] = [
+      { source_type: 'audio', converter: null, params: {} },
+      { source_type: 'video', converter: 'video_to_audio', params: {} },
+    ];
+    await create({ defaults: { audio: { source_specs: saved } } });
+    expect(component.currentSourceSpecsForPicker).toEqual(saved);
+  });
+
+  it('onSourceSpecsChange persists the specs, stripping an empty list', async () => {
+    await create();
+    const emits = captureEmits();
+
+    component.onSourceSpecsChange([
+      { source_type: 'video', converter: 'video_to_audio', params: {} },
+    ]);
+    expect(emits.at(-1)).toEqual({
+      audio: { source_specs: [{ source_type: 'video', converter: 'video_to_audio', params: {} }] },
+    });
+
+    // An empty array is stripped, and with nothing else set the type key is dropped.
+    component.onSourceSpecsChange([]);
+    expect(emits.at(-1)).toEqual({});
+  });
+
+  it('opens the clipper chooser only when more than one clipper is available', async () => {
+    await create();
+    component.openClipperChooser();
+    expect(component.clipperChooserOpen).toBe(true);
+
+    // Only one clipper → no chooser.
+    clippersFor = () => of([{ name: 'whole', media_type: 'audio' }] as unknown as ClipperInfo[]);
+    await create();
+    component.openClipperChooser();
+    expect(component.clipperChooserOpen).toBe(false);
+  });
+
+  it('onClipperSelected persists the clipper + params and closes the chooser', async () => {
+    await create();
+    component.clipperChooserOpen = true;
+    const emits = captureEmits();
+
+    component.onClipperSelected({ name: 'window', params: { size: 5 } });
+    expect(component.clipperChooserOpen).toBe(false);
+    expect(emits.at(-1)).toEqual({
+      audio: { clipper: 'window', clipper_params: { size: 5 } },
+    });
+  });
+
+  it('onClipperChooserCancelled closes the chooser without emitting', async () => {
+    await create();
+    component.clipperChooserOpen = true;
+    const emits = captureEmits();
+    component.onClipperChooserCancelled();
+    expect(component.clipperChooserOpen).toBe(false);
+    expect(emits).toEqual([]);
+  });
+
+  it('resetActiveType drops only the active type from the map', async () => {
+    await create({
+      defaults: { audio: { embedder: 'wav2vec' }, image: { embedder: 'siglip' } },
+    });
+    const emits = captureEmits();
+    component.resetActiveType(); // active is 'audio'
+    expect(emits).toEqual([{ image: { embedder: 'siglip' } }]);
+  });
+
+  it('merges a patch into existing overrides for the active type', async () => {
+    await create({ defaults: { audio: { embedder: 'wav2vec' } } });
+    const emits = captureEmits();
+    component.onClipperSelected({ name: 'window', params: {} });
+    // Existing embedder override is preserved; empty clipper_params is stripped.
+    expect(emits.at(-1)).toEqual({ audio: { embedder: 'wav2vec', clipper: 'window' } });
+  });
+});


### PR DESCRIPTION
Closes #2523.

Adds Vitest unit coverage for the two settings-modal sub-panels that previously had no specs, split out from the frontend-coverage effort (#2422).

## `import-defaults-settings.component`
Covers how the panel reads/writes its `ImportDefaultsByMediaType` slice and derives its view state:
- Initial-tab selection (first visible type, solo-mediaType collapse, empty-when-no-types).
- Lazy per-tab loading of embedders/clippers/converters, caching on re-select, and the empty-list error fallback.
- Embedder derivation: recommended vs. advanced split, `defaultEmbedderName` fallback, `displayedEmbedder`, and license-notice surfacing.
- `defaultsChange` payloads for embedder change (override vs. clear-to-default), source-specs (incl. native-row synthesis and empty-list stripping), clipper selection, reset, and patch-merge — including the empty-value stripping in `updateActive`.
- Clipper-chooser open gating (>1 clipper) and open/cancel state.

## `auto-find-settings.component`
Covers the detector checklist and the results-exporter tab strip:
- Registry load mapped to the narrowed detector shape; exporter load filtering `hidden_from_picker`; both error paths clearing their loading flags.
- Input initialisation + `ngOnChanges` re-sync of `activeExporter` / cloned `fieldValues`.
- `toggleDetector` optimistic flip + persist, and revert-with-error on failure.
- `selectExporter` default-value seeding on first pick, no-overwrite on re-select, None-tab emission, and `activeFields`.
- `fieldValue`/`setFieldValue` write + emit (ignored on the None tab), `inputType` mapping, and clone-isolation of emitted field-value maps.

All specs are zoneless (`provideZoneless` + `settleZoneless`) with stubbed API services. `./run-tests.sh frontend` passes (1557 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd2iLVoFpmqsVtMYHBJzJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd2iLVoFpmqsVtMYHBJzJn)_