### PR TITLE
Add Vitest specs for media-crop overlay components

### DIFF
--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.spec.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.spec.ts
@@ -1,0 +1,210 @@
+import { ElementRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AudioCropOverlayComponent, AudioCropResult } from './audio-crop-overlay.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+
+/**
+ * These specs exercise the crop geometry and emitted crop-region state without a
+ * real browser. The waveform-decode path (`ngAfterViewInit` → `decodeAudioBuffer`)
+ * is never triggered — we skip `detectChanges()` and instead hand the component a
+ * fake `<canvas>` ref plus a known `duration`, so every pointer handler runs
+ * against a deterministic 600px-wide, 10-second timeline. `draw()` is a no-op in
+ * tests because the fake canvas's `getContext` returns null.
+ */
+describe('AudioCropOverlayComponent', () => {
+  let component: AudioCropOverlayComponent;
+  let fixture: ComponentFixture<AudioCropOverlayComponent>;
+  let capture: ReturnType<typeof vi.fn>;
+  let release: ReturnType<typeof vi.fn>;
+
+  // 600px canvas mapped onto a 10s clip → 1px == 1/60s (x px == x/60 sec).
+  const WIDTH = 600;
+  const DURATION = 10;
+
+  function ptr(clientX: number): PointerEvent {
+    return {
+      clientX,
+      clientY: 0,
+      pointerId: 1,
+      preventDefault: () => {},
+    } as unknown as PointerEvent;
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AudioCropOverlayComponent],
+      providers: [...provideZoneless()],
+    });
+    fixture = TestBed.createComponent(AudioCropOverlayComponent);
+    component = fixture.componentInstance;
+
+    capture = vi.fn();
+    release = vi.fn();
+    const canvas = {
+      width: WIDTH,
+      height: 120,
+      getContext: () => null, // draw() short-circuits; no canvas rendering in jsdom.
+      getBoundingClientRect: () =>
+        ({ left: 0, top: 0, width: WIDTH, height: 120 }) as DOMRect,
+      setPointerCapture: capture,
+      releasePointerCapture: release,
+    };
+    component.canvasRef = { nativeElement: canvas } as unknown as ElementRef<HTMLCanvasElement>;
+
+    // Pretend the waveform decoded to a 10s clip with the full range selected.
+    component.duration = DURATION;
+    component.start = 0;
+    component.end = DURATION;
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('formatTime', () => {
+    it('renders minutes:seconds with two fractional digits, zero-padded', () => {
+      expect(component.formatTime(0)).toBe('0:00.00');
+      expect(component.formatTime(9.5)).toBe('0:09.50');
+      expect(component.formatTime(65)).toBe('1:05.00');
+      expect(component.formatTime(125.25)).toBe('2:05.25');
+    });
+
+    it('guards against non-finite input', () => {
+      expect(component.formatTime(NaN)).toBe('0:00');
+      expect(component.formatTime(Infinity)).toBe('0:00');
+    });
+  });
+
+  describe('onAudioLoadedMetadata', () => {
+    function metaEvent(duration: number): Event {
+      return { target: { duration } } as unknown as Event;
+    }
+
+    it('seeds duration/end from the <audio> element when duration is still unknown', () => {
+      component.duration = 0;
+      component.end = 0;
+      component.onAudioLoadedMetadata(metaEvent(7.5));
+      expect(component.duration).toBe(7.5);
+      expect(component.end).toBe(7.5);
+    });
+
+    it('does not override a duration already known from the decoded waveform', () => {
+      component.onAudioLoadedMetadata(metaEvent(999));
+      expect(component.duration).toBe(DURATION);
+      expect(component.end).toBe(DURATION);
+    });
+
+    it('ignores a non-finite element duration (streaming/unknown length)', () => {
+      component.duration = 0;
+      component.onAudioLoadedMetadata(metaEvent(Infinity));
+      expect(component.duration).toBe(0);
+    });
+  });
+
+  describe('pointer dragging', () => {
+    beforeEach(() => {
+      // Start with a mid-clip selection: start=2s (x=120), end=8s (x=480).
+      component.start = 2;
+      component.end = 8;
+    });
+
+    it('drags the start handle, clamped to [0, end - 0.05]', () => {
+      component.onPointerDown(ptr(120)); // grab start handle at x=120
+      expect(capture).toHaveBeenCalledWith(1);
+      component.onPointerMove(ptr(60)); // 1s
+      expect(component.start).toBeCloseTo(1, 5);
+      // Drag past the end handle: clamped to end - 0.05.
+      component.onPointerMove(ptr(600));
+      expect(component.start).toBeCloseTo(8 - 0.05, 5);
+      component.onPointerUp(ptr(600));
+      expect(release).toHaveBeenCalledWith(1);
+    });
+
+    it('drags the end handle, clamped to [start + 0.05, duration]', () => {
+      component.onPointerDown(ptr(480)); // grab end handle at x=480
+      component.onPointerMove(ptr(360)); // 6s
+      expect(component.end).toBeCloseTo(6, 5);
+      // Drag past the right edge: clamped to duration.
+      component.onPointerMove(ptr(900));
+      expect(component.end).toBeCloseTo(DURATION, 5);
+    });
+
+    it('moves the whole selection, preserving its width', () => {
+      component.onPointerDown(ptr(300)); // inside selection → move mode
+      component.onPointerMove(ptr(360)); // +1s shift
+      expect(component.start).toBeCloseTo(3, 5);
+      expect(component.end).toBeCloseTo(9, 5);
+      // Width (6s) is preserved throughout.
+      expect(component.end - component.start).toBeCloseTo(6, 5);
+    });
+
+    it('clamps a move so the selection cannot slide past the clip end', () => {
+      component.onPointerDown(ptr(300)); // move mode, offset = 3s
+      component.onPointerMove(ptr(600)); // would push start to 7s → end 13s
+      expect(component.end).toBeCloseTo(DURATION, 5);
+      expect(component.start).toBeCloseTo(DURATION - 6, 5); // 4s
+    });
+
+    it('clicking outside the selection repositions the nearer handle', () => {
+      component.onPointerDown(ptr(540)); // right of end handle (x2=480)
+      expect(component.end).toBeCloseTo(9, 5); // 540px → 9s
+      expect(component.start).toBeCloseTo(2, 5); // start untouched
+    });
+
+    it('ignores pointer motion when no drag is in progress', () => {
+      component.onPointerMove(ptr(300));
+      expect(component.start).toBe(2);
+      expect(component.end).toBe(8);
+    });
+
+    it('does not start a drag before the clip duration is known', () => {
+      component.duration = 0;
+      component.onPointerDown(ptr(300));
+      expect(capture).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('apply / cancel', () => {
+    it('emits the selected region on apply', () => {
+      component.start = 1.5;
+      component.end = 6.25;
+      let result: AudioCropResult | undefined;
+      component.applied.subscribe((r) => (result = r));
+      component.apply();
+      expect(result).toEqual({ start: 1.5, end: 6.25 });
+    });
+
+    it('does not emit when the region is empty or the clip has no duration', () => {
+      const spy = vi.fn();
+      component.applied.subscribe(spy);
+      component.end = component.start; // empty selection
+      component.apply();
+      component.duration = 0;
+      component.apply();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('emits cancelled on cancel', () => {
+      const spy = vi.fn();
+      component.cancelled.subscribe(spy);
+      component.cancel();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('computePeaks', () => {
+    it('reduces channel samples to n bins holding each bin peak amplitude', () => {
+      const samples = new Float32Array([0, 0.5, 0, 0, 0.2, -0.9, 0.1, 0, 0.3, 0, 0, 0]);
+      const buffer = { getChannelData: () => samples } as unknown as AudioBuffer;
+      // 12 samples / 3 bins → 4 samples per bin.
+      const peaks = (
+        component as unknown as { computePeaks(b: AudioBuffer, n: number): number[] }
+      ).computePeaks(buffer, 3);
+      expect(peaks).toHaveLength(3);
+      expect(peaks[0]).toBeCloseTo(0.5, 5);
+      expect(peaks[1]).toBeCloseTo(0.9, 5); // abs value → 0.9, not -0.9
+      expect(peaks[2]).toBeCloseTo(0.3, 5);
+    });
+  });
+});

--- a/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.spec.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.spec.ts
@@ -1,0 +1,163 @@
+import { ElementRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ImageCropOverlayComponent, ImageCropResult } from './image-crop-overlay.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+
+/**
+ * These specs exercise the crop-box geometry (hit-testing, resize/move drags,
+ * min-size and bounds clamping) and the display→natural pixel conversion the
+ * component emits. The image ref is faked with known natural (1000×800) and
+ * displayed (500×400) dimensions so the coordinate math is deterministic; no
+ * real image load or browser layout is involved.
+ */
+describe('ImageCropOverlayComponent', () => {
+  let component: ImageCropOverlayComponent;
+  let fixture: ComponentFixture<ImageCropOverlayComponent>;
+
+  const NAT_W = 1000;
+  const NAT_H = 800;
+  const DISP_W = 500;
+  const DISP_H = 400;
+
+  /** Pointer event with a target that stubs pointer capture (jsdom lacks it). */
+  function ptr(clientX: number, clientY: number): PointerEvent {
+    return {
+      clientX,
+      clientY,
+      pointerId: 1,
+      target: { setPointerCapture: vi.fn(), releasePointerCapture: vi.fn() },
+      preventDefault: () => {},
+    } as unknown as PointerEvent;
+  }
+
+  function setImgRef() {
+    const img = {
+      naturalWidth: NAT_W,
+      naturalHeight: NAT_H,
+      clientWidth: DISP_W,
+      clientHeight: DISP_H,
+      complete: true,
+      getBoundingClientRect: () =>
+        ({ left: 0, top: 0, width: DISP_W, height: DISP_H }) as DOMRect,
+    };
+    component.imgRef = { nativeElement: img } as unknown as ElementRef<HTMLImageElement>;
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ImageCropOverlayComponent],
+      providers: [...provideZoneless()],
+    });
+    fixture = TestBed.createComponent(ImageCropOverlayComponent);
+    component = fixture.componentInstance;
+    setImgRef();
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('onImageLoaded', () => {
+    it('seeds a centred 60% crop box in displayed coordinates', () => {
+      component.onImageLoaded();
+      expect(component.cropW).toBe(300); // 60% of 500
+      expect(component.cropH).toBe(240); // 60% of 400
+      expect(component.cropX).toBe(100); // (500 - 300) / 2
+      expect(component.cropY).toBe(80); // (400 - 240) / 2
+    });
+  });
+
+  describe('dragging', () => {
+    beforeEach(() => component.onImageLoaded()); // box = {x:100, y:80, w:300, h:240}
+
+    it('moves the whole box while staying in bounds', () => {
+      component.onPointerDown(ptr(250, 200)); // inside box → move
+      component.onPointerMove(ptr(280, 230)); // +30, +30
+      expect(component.cropX).toBe(130);
+      expect(component.cropY).toBe(110);
+      expect(component.cropW).toBe(300);
+      expect(component.cropH).toBe(240);
+    });
+
+    it('resizes from the bottom-right corner', () => {
+      component.onPointerDown(ptr(400, 320)); // bottom-right corner (x2,y2)
+      component.onPointerMove(ptr(450, 360)); // +50, +40
+      expect(component.cropW).toBe(350);
+      expect(component.cropH).toBe(280);
+      expect(component.cropX).toBe(100);
+      expect(component.cropY).toBe(80);
+    });
+
+    it('clamps a top-left drag to the image edge, growing width to compensate', () => {
+      component.onPointerDown(ptr(100, 80)); // top-left corner
+      component.onPointerMove(ptr(-50, 80)); // dx=-150, dy=0
+      // Left edge clamps to 0; the extra width is absorbed rather than lost.
+      expect(component.cropX).toBe(0);
+      expect(component.cropW).toBe(400);
+      expect(component.cropY).toBe(80);
+    });
+
+    it('enforces a 5px minimum size when a side handle is over-dragged', () => {
+      component.onPointerDown(ptr(400, 200)); // right edge → 'r'
+      component.onPointerMove(ptr(50, 200)); // collapse width past zero
+      expect(component.cropW).toBe(5);
+      expect(component.cropX).toBe(100); // left edge held fixed for a right-side drag
+    });
+
+    it('ignores pointer motion outside the box (no drag started)', () => {
+      component.onPointerDown(ptr(5, 5)); // outside the centred box → 'none'
+      component.onPointerMove(ptr(400, 400));
+      expect(component.cropX).toBe(100);
+      expect(component.cropY).toBe(80);
+      expect(component.cropW).toBe(300);
+      expect(component.cropH).toBe(240);
+    });
+
+    it('stops responding once the drag ends', () => {
+      component.onPointerDown(ptr(250, 200)); // move
+      component.onPointerMove(ptr(280, 230));
+      component.onPointerUp(ptr(280, 230));
+      component.onPointerMove(ptr(500, 500)); // ignored after release
+      expect(component.cropX).toBe(130);
+      expect(component.cropY).toBe(110);
+    });
+  });
+
+  describe('apply / cancel', () => {
+    it('converts the display-space box to original-image pixels on apply', () => {
+      component.onImageLoaded(); // box {100,80,300,240}, scale 2× on both axes
+      let result: ImageCropResult | undefined;
+      component.applied.subscribe((r) => (result = r));
+      component.apply();
+      expect(result).toEqual({ box: [200, 160, 800, 640] });
+    });
+
+    it('clamps the emitted box to the natural image bounds', () => {
+      component.onImageLoaded();
+      // Push the box to the far bottom-right; conversion must not exceed 1000×800.
+      component.cropX = 400;
+      component.cropY = 300;
+      component.cropW = 100;
+      component.cropH = 100;
+      let result: ImageCropResult | undefined;
+      component.applied.subscribe((r) => (result = r));
+      component.apply();
+      expect(result).toEqual({ box: [800, 600, 1000, 800] });
+    });
+
+    it('does not emit before the image dimensions are known', () => {
+      const spy = vi.fn();
+      component.applied.subscribe(spy); // onImageLoaded not called → displayW is 0
+      component.apply();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('emits cancelled on cancel', () => {
+      const spy = vi.fn();
+      component.cancelled.subscribe(spy);
+      component.cancel();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/media-crop-modal.component.spec.ts
@@ -1,0 +1,124 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MediaCropModalComponent, MediaCropResult } from './media-crop-modal.component';
+import { provideZoneless } from '../../../testing/zoneless-testbed';
+
+/**
+ * Drives the modal's confirm/crop view switching and the crop-region payloads it
+ * forwards from the child overlays. The object-URL APIs are stubbed (jsdom lacks
+ * them); the modal is instantiated but not rendered, so `ngOnInit` is invoked
+ * directly to build `fileUrl` without pulling in the overlay children.
+ */
+describe('MediaCropModalComponent', () => {
+  let component: MediaCropModalComponent;
+  let fixture: ComponentFixture<MediaCropModalComponent>;
+  const file = new File(['bytes'], 'clip.png', { type: 'image/png' });
+
+  function build(mediaType: string): void {
+    fixture = TestBed.createComponent(MediaCropModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('file', file);
+    fixture.componentRef.setInput('mediaType', mediaType);
+    component.ngOnInit();
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [MediaCropModalComponent],
+      providers: [...provideZoneless()],
+    });
+    URL.createObjectURL = vi.fn(() => 'blob:mock');
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  it('creates an object URL for the file on init', () => {
+    build('image');
+    expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+    expect(component.fileUrl).toBe('blob:mock');
+  });
+
+  it('revokes the object URL on destroy', () => {
+    build('image');
+    component.ngOnDestroy();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+  });
+
+  describe('cropSupported', () => {
+    it('is true for image and audio', () => {
+      build('image');
+      expect(component.cropSupported).toBe(true);
+      build('audio');
+      expect(component.cropSupported).toBe(true);
+    });
+
+    it('is false for other media types', () => {
+      build('video');
+      expect(component.cropSupported).toBe(false);
+      build('');
+      expect(component.cropSupported).toBe(false);
+    });
+  });
+
+  describe('view switching', () => {
+    it('starts in the confirm view', () => {
+      build('image');
+      expect(component.view).toBe('confirm');
+    });
+
+    it('enters the cropping view when crop is supported', () => {
+      build('audio');
+      component.onOkButCrop();
+      expect(component.view).toBe('cropping');
+    });
+
+    it('confirms directly (no crop view) when crop is unsupported', () => {
+      build('video');
+      let result: MediaCropResult | undefined;
+      component.confirmed.subscribe((r) => (result = r));
+      component.onOkButCrop();
+      expect(component.view).toBe('confirm');
+      expect(result).toEqual({ file });
+    });
+
+    it('returns to the confirm view when a crop overlay is cancelled', () => {
+      build('image');
+      component.onOkButCrop();
+      component.onCropOverlayCancelled();
+      expect(component.view).toBe('confirm');
+    });
+  });
+
+  describe('emitted results', () => {
+    it('confirms with the raw file on OK', () => {
+      build('image');
+      let result: MediaCropResult | undefined;
+      component.confirmed.subscribe((r) => (result = r));
+      component.onOk();
+      expect(result).toEqual({ file });
+    });
+
+    it('forwards an image crop box as cropParams', () => {
+      build('image');
+      let result: MediaCropResult | undefined;
+      component.confirmed.subscribe((r) => (result = r));
+      component.onImageCropApplied({ box: [10, 20, 110, 220] });
+      expect(result).toEqual({ file, cropParams: { box: [10, 20, 110, 220] } });
+    });
+
+    it('forwards an audio crop range as cropParams', () => {
+      build('audio');
+      let result: MediaCropResult | undefined;
+      component.confirmed.subscribe((r) => (result = r));
+      component.onAudioCropApplied({ start: 1.5, end: 4.25 });
+      expect(result).toEqual({ file, cropParams: { start: 1.5, end: 4.25 } });
+    });
+
+    it('emits cancelled on cancel', () => {
+      build('image');
+      const spy = vi.fn();
+      component.cancelled.subscribe(spy);
+      component.onCancel();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Adds Vitest unit tests for the three media-crop overlay components, which previously had no specs (split out from #2422 frontend-coverage work).

## What's covered

- **`audio-crop-overlay.component`** — start/end/move handle dragging with `[0, end-0.05]` / `[start+0.05, duration]` clamping, click-outside-to-reposition-nearest-handle, `formatTime`, metadata-driven duration seeding (and the non-finite/already-known guards), `computePeaks` binning, and `applied`/`cancelled` emissions.
- **`image-crop-overlay.component`** — centred 60% default box, corner/side/move drags with 5px minimum-size enforcement and image-bounds clamping, plus the display→natural pixel conversion (with bounds clamp) emitted on apply.
- **`media-crop-modal.component`** — object-URL create/revoke lifecycle, `cropSupported` gating (image/audio vs. others), confirm↔crop view switching (including the unsupported-type shortcut), and the crop-region payloads forwarded from the child overlays.

## Approach

The overlays carry geometry that depends on `getBoundingClientRect`, pointer capture, and canvas 2D context — none of which jsdom implements. Rather than render, each spec instantiates the component via `TestBed` (for a valid injection context) and hands it a faked `@ViewChild` element with known, deterministic dimensions, mirroring the existing `image-viewer.zoneless.spec.ts` pattern. That keeps every pointer/geometry assertion exact and browser-free.

## Verification

`./run-tests.sh frontend` passes: build OK, lint/pyright/deptry/pip-audit/audit OK, and **1563 frontend unit tests pass** (+41 from these specs).

Closes #2522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014VvXvVWBtBNL2PjLXSdb5C)_