### PR TITLE
Add specs for dataset-importer-modal internals

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.spec.ts
@@ -1,0 +1,299 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ImportAdvancedComponent } from './import-advanced.component';
+import { provideZoneless } from '../../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../../testing/settle-resource';
+import { ClipperInfo, EmbedderInfo, SourceSpec } from '../../../../models/api.models';
+
+describe('ImportAdvancedComponent', () => {
+  let component: ImportAdvancedComponent;
+  let fixture: ComponentFixture<ImportAdvancedComponent>;
+
+  const embedders: EmbedderInfo[] = [
+    { name: 'clap', display_name: 'CLAP', is_default: true, license_notice: null } as EmbedderInfo,
+    { name: 'custom', display_name: 'Custom', is_default: false, license_notice: 'restricted' } as EmbedderInfo,
+    { name: 'patchy', is_default: false, supports_patch_regions: true, license_notice: 'patch-license' } as EmbedderInfo,
+    { name: 'struct', is_default: false, supports_geometric_verification: true } as EmbedderInfo,
+  ];
+
+  const clippers: ClipperInfo[] = [
+    { name: 'clip_default', display_name: 'Default clipper' } as ClipperInfo,
+    { name: 'sliding', display_name: 'Sliding window' } as ClipperInfo,
+  ];
+
+  async function setInputs(inputs: Record<string, unknown>): Promise<void> {
+    for (const [key, value] of Object.entries(inputs)) {
+      fixture.componentRef.setInput(key, value);
+    }
+    await settleZoneless(fixture);
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ImportAdvancedComponent],
+      providers: [...provideZoneless()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ImportAdvancedComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('toggleAdvanced', () => {
+    it('flips the advanced-open flag', () => {
+      expect(component.advancedOpen).toBe(false);
+      component.toggleAdvanced();
+      expect(component.advancedOpen).toBe(true);
+      component.toggleAdvanced();
+      expect(component.advancedOpen).toBe(false);
+    });
+  });
+
+  describe('isDefaultEmbedderSelected', () => {
+    beforeEach(async () => {
+      await setInputs({ embedders });
+    });
+
+    it('is true when no embedder is selected', async () => {
+      await setInputs({ selectedEmbedder: '' });
+      expect(component.isDefaultEmbedderSelected).toBe(true);
+    });
+
+    it('is true when the selected embedder is flagged is_default', async () => {
+      await setInputs({ selectedEmbedder: 'clap' });
+      expect(component.isDefaultEmbedderSelected).toBe(true);
+    });
+
+    it('is false when a non-default embedder is selected', async () => {
+      await setInputs({ selectedEmbedder: 'custom' });
+      expect(component.isDefaultEmbedderSelected).toBe(false);
+    });
+  });
+
+  describe('isDefaultClipperSelected', () => {
+    it('is true when the first clipper is selected', async () => {
+      await setInputs({ clippers, selectedClipper: 'clip_default' });
+      expect(component.isDefaultClipperSelected).toBe(true);
+    });
+
+    it('is false when a different clipper is selected', async () => {
+      await setInputs({ clippers, selectedClipper: 'sliding' });
+      expect(component.isDefaultClipperSelected).toBe(false);
+    });
+
+    it('is false when there are no clippers', async () => {
+      await setInputs({ clippers: [], selectedClipper: '' });
+      expect(component.isDefaultClipperSelected).toBe(false);
+    });
+  });
+
+  describe('showAdvancedToggle', () => {
+    it('is true whenever the source-specs block is offered', async () => {
+      await setInputs({ showSourceSpecs: true, embedders, selectedEmbedder: 'custom' });
+      expect(component.showAdvancedToggle).toBe(true);
+    });
+
+    it('is true when neither embedder nor clipper has been overridden', async () => {
+      await setInputs({ showSourceSpecs: false, embedders, clippers, selectedEmbedder: 'clap', selectedClipper: 'clip_default' });
+      expect(component.showAdvancedToggle).toBe(true);
+    });
+
+    it('is false when an override keeps a picker visible anyway', async () => {
+      await setInputs({ showSourceSpecs: false, embedders, clippers, selectedEmbedder: 'custom', selectedClipper: 'clip_default' });
+      expect(component.showAdvancedToggle).toBe(false);
+    });
+  });
+
+  describe('showEmbedderPicker', () => {
+    it('is hidden when a Solo embedder is locked', async () => {
+      await setInputs({ embedders, lockedEmbedder: 'clap' });
+      component.advancedOpen = true;
+      expect(component.showEmbedderPicker).toBe(false);
+    });
+
+    it('is visible when Advanced is open', async () => {
+      await setInputs({ embedders, selectedEmbedder: 'clap' });
+      component.advancedOpen = true;
+      expect(component.showEmbedderPicker).toBe(true);
+    });
+
+    it('is visible when a non-default embedder is chosen even while collapsed', async () => {
+      await setInputs({ embedders, selectedEmbedder: 'custom' });
+      component.advancedOpen = false;
+      expect(component.showEmbedderPicker).toBe(true);
+    });
+  });
+
+  describe('showClipperPicker', () => {
+    it('is visible when Advanced is open', async () => {
+      await setInputs({ clippers, selectedClipper: 'clip_default' });
+      component.advancedOpen = true;
+      expect(component.showClipperPicker).toBe(true);
+    });
+
+    it('is visible when a non-default clipper is chosen while collapsed', async () => {
+      await setInputs({ clippers, selectedClipper: 'sliding' });
+      component.advancedOpen = false;
+      expect(component.showClipperPicker).toBe(true);
+    });
+  });
+
+  describe('showStandaloneClipperButton', () => {
+    it('is false when there is at most one clipper', async () => {
+      await setInputs({ clippers: [clippers[0]], selectedClipper: 'clip_default' });
+      component.advancedOpen = true;
+      expect(component.showStandaloneClipperButton).toBe(false);
+    });
+
+    it('is false when the clipper picker is hidden', async () => {
+      await setInputs({ clippers, selectedClipper: 'clip_default' });
+      component.advancedOpen = false;
+      expect(component.showStandaloneClipperButton).toBe(false);
+    });
+
+    it('is false when the source-specs column already hosts the native Details button', async () => {
+      await setInputs({ clippers, selectedClipper: 'clip_default', showSourceSpecs: true });
+      component.advancedOpen = true;
+      expect(component.showStandaloneClipperButton).toBe(false);
+    });
+
+    it('is true when the picker is visible and no source-specs column is present', async () => {
+      await setInputs({ clippers, selectedClipper: 'clip_default', showSourceSpecs: false });
+      component.advancedOpen = true;
+      expect(component.showStandaloneClipperButton).toBe(true);
+    });
+  });
+
+  describe('embedder option grouping', () => {
+    beforeEach(async () => {
+      await setInputs({ embedders });
+    });
+
+    it('recommendedEmbedders holds the is_default embedders', () => {
+      expect(component.recommendedEmbedders.map((e) => e.name)).toEqual(['clap']);
+    });
+
+    it('advancedEmbedderOptions holds the non-default embedders', () => {
+      expect(component.advancedEmbedderOptions.map((e) => e.name)).toEqual(['custom', 'patchy', 'struct']);
+    });
+
+    it('embedderLabel prefers the display name and falls back to the name', () => {
+      expect(component.embedderLabel(embedders[0])).toBe('CLAP');
+      expect(component.embedderLabel(embedders[2])).toBe('patchy');
+    });
+
+    it('patchEmbedderOptions holds patch-capable embedders', () => {
+      expect(component.patchEmbedderOptions.map((e) => e.name)).toEqual(['patchy']);
+    });
+
+    it('structuralEmbedderOptions holds geometric-verification embedders', () => {
+      expect(component.structuralEmbedderOptions.map((e) => e.name)).toEqual(['struct']);
+    });
+  });
+
+  describe('license notices', () => {
+    beforeEach(async () => {
+      await setInputs({ embedders });
+    });
+
+    it('licenseNotice reflects the selected primary embedder', async () => {
+      await setInputs({ selectedEmbedder: 'custom' });
+      expect(component.licenseNotice).toBe('restricted');
+    });
+
+    it('licenseNotice is null when the embedder has no notice', async () => {
+      await setInputs({ selectedEmbedder: 'clap' });
+      expect(component.licenseNotice).toBeNull();
+    });
+
+    it('licenseNotice is null when nothing is selected', () => {
+      expect(component.licenseNotice).toBeNull();
+    });
+
+    it('patchLicenseNotice reflects the selected patch embedder', async () => {
+      await setInputs({ selectedPatchEmbedder: 'patchy' });
+      expect(component.patchLicenseNotice).toBe('patch-license');
+    });
+
+    it('structuralLicenseNotice is null for an embedder without a notice', async () => {
+      await setInputs({ selectedStructuralEmbedder: 'struct' });
+      expect(component.structuralLicenseNotice).toBeNull();
+    });
+  });
+
+  describe('clipperDisplayName', () => {
+    beforeEach(async () => {
+      await setInputs({ clippers });
+    });
+
+    it('is None when no clipper matches the selection', async () => {
+      await setInputs({ selectedClipper: '' });
+      expect(component.clipperDisplayName).toBe('None');
+    });
+
+    it('is None for a *_default clipper', async () => {
+      await setInputs({ selectedClipper: 'clip_default' });
+      expect(component.clipperDisplayName).toBe('None');
+    });
+
+    it('is the display name for a real clipper', async () => {
+      await setInputs({ selectedClipper: 'sliding' });
+      expect(component.clipperDisplayName).toBe('Sliding window');
+    });
+  });
+
+  describe('output emitters', () => {
+    it('onSourceSpecsChange re-emits the specs list', () => {
+      const specs: SourceSpec[] = [{ source_type: 'image', converter: null, params: {} }];
+      let emitted: SourceSpec[] | null = null;
+      component.sourceSpecsChange.subscribe((s: SourceSpec[]) => (emitted = s));
+      component.onSourceSpecsChange(specs);
+      expect(emitted).toBe(specs);
+    });
+
+    it('onEmbedderChange emits the selected embedder name', () => {
+      let emitted = '';
+      component.selectedEmbedderChange.subscribe((n: string) => (emitted = n));
+      component.onEmbedderChange('custom');
+      expect(emitted).toBe('custom');
+    });
+
+    it('onPatchEmbedderChange emits the patch embedder name', () => {
+      let emitted = '';
+      component.selectedPatchEmbedderChange.subscribe((n: string) => (emitted = n));
+      component.onPatchEmbedderChange('patchy');
+      expect(emitted).toBe('patchy');
+    });
+
+    it('onStructuralEmbedderChange emits the structural embedder name', () => {
+      let emitted = '';
+      component.selectedStructuralEmbedderChange.subscribe((n: string) => (emitted = n));
+      component.onStructuralEmbedderChange('struct');
+      expect(emitted).toBe('struct');
+    });
+
+    it('onClipperClick requests the parent chooser', () => {
+      let fired = false;
+      component.clipperChooserRequested.subscribe(() => (fired = true));
+      component.onClipperClick();
+      expect(fired).toBe(true);
+    });
+
+    it('onBuildProjectionChange emits the toggle value', () => {
+      let emitted: boolean | null = null;
+      component.buildProjectionChange.subscribe((v: boolean) => (emitted = v));
+      component.onBuildProjectionChange(true);
+      expect(emitted).toBe(true);
+    });
+
+    it('onMergeNearDuplicatesChange emits the toggle value', () => {
+      let emitted: boolean | null = null;
+      component.mergeNearDuplicatesChange.subscribe((v: boolean) => (emitted = v));
+      component.onMergeNearDuplicatesChange(true);
+      expect(emitted).toBe(true);
+    });
+  });
+});

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.spec.ts
@@ -1,0 +1,198 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ImportConfigComponent } from './import-config.component';
+import { provideZoneless } from '../../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../../testing/settle-resource';
+
+describe('ImportConfigComponent', () => {
+  let component: ImportConfigComponent;
+  let fixture: ComponentFixture<ImportConfigComponent>;
+
+  const options = ['audio', 'image', 'text'];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ImportConfigComponent],
+      providers: [...provideZoneless()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ImportConfigComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('mediaTypeOptions', options);
+    await settleZoneless(fixture);
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('id derivation', () => {
+    it('derives listboxId from the trigger field id', async () => {
+      fixture.componentRef.setInput('mediaTypeFieldId', 'sf-media-type');
+      await settleZoneless(fixture);
+      expect(component.listboxId).toBe('sf-media-type-listbox');
+    });
+
+    it('derives per-option ids from the trigger field id', async () => {
+      fixture.componentRef.setInput('mediaTypeFieldId', 'sf-media-type');
+      await settleZoneless(fixture);
+      expect(component.optionId(2)).toBe('sf-media-type-option-2');
+    });
+
+    it('activeDescendantId is null while closed', () => {
+      expect(component.activeDescendantId).toBeNull();
+    });
+
+    it('activeDescendantId points at the active option once open', () => {
+      component.toggle();
+      expect(component.open).toBe(true);
+      expect(component.activeDescendantId).toBe(component.optionId(component.activeIndex));
+    });
+  });
+
+  describe('option label + icon lookup', () => {
+    it('optionLabel returns the mapped label', async () => {
+      fixture.componentRef.setInput('mediaTypeOptionLabels', { audio: 'Audio files' });
+      await settleZoneless(fixture);
+      expect(component.optionLabel('audio')).toBe('Audio files');
+    });
+
+    it('optionLabel falls back to the raw value when unmapped', () => {
+      expect(component.optionLabel('audio')).toBe('audio');
+    });
+
+    it('iconFor returns the mapped icon or empty string', async () => {
+      fixture.componentRef.setInput('mediaTypeOptionIcons', { audio: 'audio-icon' });
+      await settleZoneless(fixture);
+      expect(component.iconFor('audio')).toBe('audio-icon');
+      expect(component.iconFor('image')).toBe('');
+    });
+  });
+
+  describe('open/close behaviour', () => {
+    it('toggle opens the popup and seeds the highlight on the current selection', () => {
+      component.mediaType = 'image';
+      component.toggle();
+      expect(component.open).toBe(true);
+      expect(component.activeIndex).toBe(options.indexOf('image'));
+    });
+
+    it('toggle seeds the highlight on the first option when nothing is selected', () => {
+      component.mediaType = '';
+      component.toggle();
+      expect(component.activeIndex).toBe(0);
+    });
+
+    it('toggle a second time closes the popup and clears the highlight', () => {
+      component.toggle();
+      component.toggle();
+      expect(component.open).toBe(false);
+      expect(component.activeIndex).toBe(-1);
+    });
+  });
+
+  describe('select', () => {
+    it('emits mediaTypeChange and closes when a new value is chosen', () => {
+      component.mediaType = 'audio';
+      component.open = true;
+      let emitted = '';
+      component.mediaTypeChange.subscribe((v: string) => (emitted = v));
+      component.select('image');
+      expect(emitted).toBe('image');
+      expect(component.open).toBe(false);
+    });
+
+    it('does not emit when the current value is re-selected', () => {
+      component.mediaType = 'audio';
+      let emitted = false;
+      component.mediaTypeChange.subscribe(() => (emitted = true));
+      component.select('audio');
+      expect(emitted).toBe(false);
+    });
+  });
+
+  describe('keyboard handling', () => {
+    function key(k: string): KeyboardEvent {
+      return new KeyboardEvent('keydown', { key: k });
+    }
+
+    it('opens the popup on ArrowDown while closed', () => {
+      component.onTriggerKeydown(key('ArrowDown'));
+      expect(component.open).toBe(true);
+    });
+
+    it('ignores other keys while closed', () => {
+      component.onTriggerKeydown(key('a'));
+      expect(component.open).toBe(false);
+    });
+
+    it('moves the highlight down and up, clamped to bounds', () => {
+      component.toggle();
+      component.activeIndex = 0;
+      component.onTriggerKeydown(key('ArrowDown'));
+      expect(component.activeIndex).toBe(1);
+      component.onTriggerKeydown(key('ArrowUp'));
+      expect(component.activeIndex).toBe(0);
+      component.onTriggerKeydown(key('ArrowUp'));
+      expect(component.activeIndex).toBe(0);
+    });
+
+    it('Home and End jump to the first and last option', () => {
+      component.toggle();
+      component.onTriggerKeydown(key('End'));
+      expect(component.activeIndex).toBe(options.length - 1);
+      component.onTriggerKeydown(key('Home'));
+      expect(component.activeIndex).toBe(0);
+    });
+
+    it('Enter commits the highlighted option', () => {
+      component.mediaType = 'audio';
+      component.toggle();
+      component.activeIndex = 1;
+      let emitted = '';
+      component.mediaTypeChange.subscribe((v: string) => (emitted = v));
+      component.onTriggerKeydown(key('Enter'));
+      expect(emitted).toBe('image');
+      expect(component.open).toBe(false);
+    });
+
+    it('Escape closes the popup without emitting', () => {
+      component.toggle();
+      let emitted = false;
+      component.mediaTypeChange.subscribe(() => (emitted = true));
+      component.onTriggerKeydown(key('Escape'));
+      expect(component.open).toBe(false);
+      expect(emitted).toBe(false);
+    });
+
+    it('Tab closes the popup', () => {
+      component.toggle();
+      component.onTriggerKeydown(key('Tab'));
+      expect(component.open).toBe(false);
+    });
+  });
+
+  describe('outside-click dismissal', () => {
+    it('closes when the click is outside the host element', () => {
+      component.open = true;
+      const outside = document.createElement('div');
+      document.body.appendChild(outside);
+      component.onDocumentClick({ target: outside } as unknown as MouseEvent);
+      expect(component.open).toBe(false);
+      outside.remove();
+    });
+
+    it('stays open when the click is inside the host element', () => {
+      component.open = true;
+      const inside = fixture.nativeElement as HTMLElement;
+      component.onDocumentClick({ target: inside } as unknown as MouseEvent);
+      expect(component.open).toBe(true);
+    });
+
+    it('is a no-op when already closed', () => {
+      component.open = false;
+      component.onDocumentClick({ target: document.body } as unknown as MouseEvent);
+      expect(component.open).toBe(false);
+    });
+  });
+});

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.spec.ts
@@ -1,0 +1,214 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SourcePickerComponent } from './source-picker.component';
+import { provideZoneless } from '../../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../../testing/settle-resource';
+import { ManagedColumns } from '../../../../utils/managed-columns';
+import { DemoDatasetEntry } from '../../../../generated/api-client/models/demo-dataset-entry';
+import { ImporterInfo, ImporterPickerTab, MediaTypeInfo } from '../../../../models/api.models';
+
+describe('SourcePickerComponent', () => {
+  let component: SourcePickerComponent;
+  let fixture: ComponentFixture<SourcePickerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SourcePickerComponent],
+      providers: [...provideZoneless()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SourcePickerComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('chrome hint templates', () => {
+    it('noImporterHint substitutes {label} with the active tab label', async () => {
+      fixture.componentRef.setInput('noImporterHintTemplate', 'Pick how to add a {label} dataset.');
+      fixture.componentRef.setInput('activeImporterTabLabel', 'Audio');
+      await settleZoneless(fixture);
+      expect(component.noImporterHint).toBe('Pick how to add a Audio dataset.');
+    });
+
+    it('tabTitle substitutes {label} with the passed label', async () => {
+      fixture.componentRef.setInput('tabTitleTemplate', 'Show {label} importers');
+      await settleZoneless(fixture);
+      expect(component.tabTitle('Local')).toBe('Show Local importers');
+    });
+  });
+
+  describe('demo media-type helpers', () => {
+    const mediaTypes: MediaTypeInfo[] = [
+      { type_id: 'audio', name: 'Audio', icon: 'audio-icon' },
+      { type_id: 'image', name: 'Image', icon: '' },
+    ];
+
+    beforeEach(async () => {
+      fixture.componentRef.setInput('mediaTypes', mediaTypes);
+      await settleZoneless(fixture);
+    });
+
+    it('getDemoTabIcon returns the matching media type icon', () => {
+      expect(component.getDemoTabIcon('audio')).toBe('audio-icon');
+    });
+
+    it('getDemoTabIcon returns empty string when the type has no icon', () => {
+      expect(component.getDemoTabIcon('image')).toBe('');
+    });
+
+    it('getDemoTabIcon returns empty string for an unknown media type', () => {
+      expect(component.getDemoTabIcon('video')).toBe('');
+    });
+
+    it('getDemoTabText returns the human name for a known type', () => {
+      expect(component.getDemoTabText('audio')).toBe('Audio');
+    });
+
+    it('getDemoTabText falls back to the raw id for an unknown type', () => {
+      expect(component.getDemoTabText('video')).toBe('video');
+    });
+  });
+
+  describe('demo row helpers', () => {
+    const demo = { name: 'gtzan', label: 'GTZAN', status: 'ready' } as DemoDatasetEntry;
+
+    it('demoRowDisabled returns false when no predicate is provided', () => {
+      expect(component.demoRowDisabled(demo)).toBe(false);
+    });
+
+    it('demoRowDisabled delegates to the provided predicate', async () => {
+      fixture.componentRef.setInput('demoRowDisabledFn', (d: DemoDatasetEntry) => d.name === 'gtzan');
+      await settleZoneless(fixture);
+      expect(component.demoRowDisabled(demo)).toBe(true);
+      expect(component.demoRowDisabled({ name: 'other' } as DemoDatasetEntry)).toBe(false);
+    });
+
+    it('demoRowTitle returns empty string when no formatter is provided', () => {
+      expect(component.demoRowTitle(demo)).toBe('');
+    });
+
+    it('demoRowTitle delegates to the provided formatter', async () => {
+      fixture.componentRef.setInput('demoRowTitleFn', (d: DemoDatasetEntry) => `title:${d.name}`);
+      await settleZoneless(fixture);
+      expect(component.demoRowTitle(demo)).toBe('title:gtzan');
+    });
+  });
+
+  describe('status badge helpers', () => {
+    it('maps status to the badge class', () => {
+      expect(component.statusBadgeClass('ready')).toBe('badge-ready');
+      expect(component.statusBadgeClass('needs_embedding')).toBe('badge-embedding');
+      expect(component.statusBadgeClass('needs_download')).toBe('badge-download');
+    });
+
+    it('maps status to the badge label', () => {
+      expect(component.statusBadgeLabel('ready')).toBe('Ready');
+      expect(component.statusBadgeLabel('needs_embedding')).toBe('Needs setup');
+      expect(component.statusBadgeLabel('needs_download')).toBe('Needs Download');
+    });
+  });
+
+  describe('onDemoHeaderClick', () => {
+    function makeCols(): ManagedColumns {
+      return new ManagedColumns(
+        ['label', 'num_files'],
+        {
+          label: { label: 'Name', title: '', sortable: true },
+          num_files: { label: 'Files', title: '', sortable: false },
+        },
+        { initialSort: 'label' },
+      );
+    }
+
+    it('sorts when the clicked column is sortable', () => {
+      const cols = makeCols();
+      component.demoCols = cols;
+      const spy = vi.spyOn(cols, 'sortBy');
+      component.onDemoHeaderClick('label');
+      expect(spy).toHaveBeenCalledWith('label');
+    });
+
+    it('does nothing when the clicked column is not sortable', () => {
+      const cols = makeCols();
+      component.demoCols = cols;
+      const spy = vi.spyOn(cols, 'sortBy');
+      component.onDemoHeaderClick('num_files');
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when demoCols is null', () => {
+      component.demoCols = null;
+      expect(() => component.onDemoHeaderClick('label')).not.toThrow();
+    });
+  });
+
+  describe('tab bar rendering + outputs', () => {
+    const tabs: ImporterPickerTab[] = [
+      { id: 'local', label: 'Local' },
+      { id: 'server', label: 'Server' },
+    ];
+    const importers: ImporterInfo[] = [
+      { name: 'server_folder', display_name: 'Server folder', description: 'From a path' },
+      { name: 'server_zip', display_name: 'Server zip' },
+    ];
+
+    it('renders one button per visible tab and emits activeTabChange on click', async () => {
+      fixture.componentRef.setInput('visibleImporterTabs', tabs);
+      await settleZoneless(fixture);
+
+      const buttons = fixture.nativeElement.querySelectorAll('.tab-bar .tab');
+      expect(buttons.length).toBe(2);
+
+      let emitted = '';
+      component.activeTabChange.subscribe((id: string) => (emitted = id));
+      buttons[1].click();
+      expect(emitted).toBe('server');
+    });
+
+    it('shows the no-tab hint when no tab is active', async () => {
+      fixture.componentRef.setInput('visibleImporterTabs', tabs);
+      fixture.componentRef.setInput('noTabHint', 'Choose a category.');
+      await settleZoneless(fixture);
+      expect(fixture.nativeElement.querySelector('.tab-bar-hint').textContent).toContain('Choose a category.');
+    });
+
+    it('renders sub-tabs for the active category and emits importerSelected on click', async () => {
+      fixture.componentRef.setInput('visibleImporterTabs', tabs);
+      fixture.componentRef.setInput('activeTab', 'server');
+      component.importersForActiveTab = importers;
+      await settleZoneless(fixture);
+
+      const subtabs = fixture.nativeElement.querySelectorAll('.importer-subtab');
+      expect(subtabs.length).toBe(2);
+
+      let picked: ImporterInfo | null = null;
+      component.importerSelected.subscribe((imp: ImporterInfo) => (picked = imp));
+      subtabs[0].click();
+      expect(picked).toBe(importers[0]);
+    });
+
+    it('shows the empty-category text when the active tab has no importers', async () => {
+      fixture.componentRef.setInput('visibleImporterTabs', tabs);
+      fixture.componentRef.setInput('activeTab', 'server');
+      fixture.componentRef.setInput('emptyCategoryText', 'Nothing here.');
+      component.importersForActiveTab = [];
+      await settleZoneless(fixture);
+      expect(fixture.nativeElement.querySelector('.importer-subtab-bar').textContent).toContain('Nothing here.');
+    });
+
+    it('hides the lone sub-tab by default but shows it when alwaysShowSubtabBar is set', async () => {
+      fixture.componentRef.setInput('visibleImporterTabs', tabs);
+      fixture.componentRef.setInput('activeTab', 'server');
+      component.importersForActiveTab = [importers[0]];
+      await settleZoneless(fixture);
+      expect(fixture.nativeElement.querySelector('.importer-subtab')).toBeNull();
+
+      fixture.componentRef.setInput('alwaysShowSubtabBar', true);
+      await settleZoneless(fixture);
+      expect(fixture.nativeElement.querySelector('.importer-subtab')).not.toBeNull();
+    });
+  });
+});

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -86,6 +86,19 @@ Object.defineProperty(Element.prototype, 'scrollIntoView', {
   value: () => {},
 });
 
+// --- CSS.escape -------------------------------------------------------------
+// import-config builds a `#${CSS.escape(id)}` selector to scroll the active
+// combobox option into view. jsdom omits the `CSS` namespace object entirely,
+// so the reference throws "Cannot read properties of undefined" from the
+// deferred queueMicrotask callback (surfacing as an unhandled error, not a
+// test failure). Provide a minimal, spec-correct escape() so the selector is
+// built and the (stubbed) scrollIntoView above runs.
+if (typeof (globalThis as { CSS?: unknown }).CSS === 'undefined') {
+  (globalThis as unknown as { CSS: { escape(value: string): string } }).CSS = {
+    escape: (value: string) => String(value).replace(/[^a-zA-Z0-9_-]/g, (ch) => `\\${ch}`),
+  };
+}
+
 // --- HTMLMediaElement play/pause/load --------------------------------------
 // The audio/video players call these; jsdom throws "Not implemented".
 Object.defineProperties(HTMLMediaElement.prototype, {


### PR DESCRIPTION
Adds Vitest unit tests for the three untested `dataset-importer-modal` sub-components, reusing the sibling picker spec patterns.

## What's covered

- **`source-picker`** — hint-template `{label}` substitution (`noImporterHint`, `tabTitle`), demo media-type helpers (`getDemoTabIcon`/`getDemoTabText`), demo-row predicate/formatter delegation, status-badge class/label mapping, sortable-header dispatch (`onDemoHeaderClick` → `ManagedColumns.sortBy`), and DOM-level rendering of the category/sub-tab bars with their `activeTabChange` / `importerSelected` outputs (including the lone-sub-tab hide rule vs `alwaysShowSubtabBar`).
- **`import-config`** — `listboxId`/`optionId`/`activeDescendantId` derivation, `optionLabel`/`iconFor` lookup with fallbacks, open/close highlight seeding, `select` emission gating (no emit on re-select), the full WAI-ARIA select-only combobox keyboard pattern (Arrow/Home/End/Enter/Escape/Tab), and outside-click dismissal.
- **`import-advanced`** — the derived-visibility getters (`isDefaultEmbedderSelected`, `isDefaultClipperSelected`, `showAdvancedToggle`, `showEmbedderPicker`, `showClipperPicker`, `showStandaloneClipperButton`), embedder option grouping (recommended/advanced/patch/structural), license-notice resolution, `clipperDisplayName`, and every output emitter.

## Test-harness change

Adds a jsdom `CSS.escape` polyfill to `test-setup.ts`. `import-config` builds a `#${CSS.escape(id)}` selector inside a deferred `queueMicrotask` to scroll the active combobox option into view; jsdom omits the `CSS` namespace, so the reference threw an unhandled error from the microtask. The polyfill sits alongside the existing browser-API stubs (the file already anticipated import-config's `scrollIntoView`).

`./run-tests.sh frontend` passes (1607 tests, 0 errors).

Closes #2521