### PR TITLE
Drop broken SETUPTOOLS_USE_DISTUTILS shim from apricot-select install step

### DIFF
--- a/docs/plans/vtsbrowse-toponymy.md
+++ b/docs/plans/vtsbrowse-toponymy.md
@@ -18,8 +18,9 @@
 > (`namer|texts_provider:embedder|toponymy=version`) and served only over a
 > matching `projection_id` + signature. `toponymy==0.5.2` installs
 > `--no-deps` (its `transformers<5` pin is empirically unnecessary; real deps
-> declared in `pyproject.toml`; `apricot-select` builds under the
-> stdlib-distutils shim); the `slow`-marked smoke test in
+> declared in `pyproject.toml`; `apricot-select` builds as a plain sdist —
+> no SETUPTOOLS_USE_DISTUTILS shim, which setuptools >= 74 rejects at
+> import); the `slow`-marked smoke test in
 > `tests_lib/projection/test_toponymy_smoke.py` guards that bypass.
 > Decision evidence lives in the experiment reports:
 > **`docs/reports/2026-07-12-toponymy-audio-signposts.html`** and

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -818,10 +818,15 @@ vts_install_precommit() {
 # --- toponymy (VTSBrowse signpost naming) ------------------------------------
 # Two quirks force a dedicated step (see docs/plans/vtsbrowse-toponymy.md):
 #   - apricot-select (a real toponymy dep, declared in pyproject.toml) ships a
-#     legacy setup.py that crashes under modern setuptools' bdist
-#     ("AttributeError: install_layout"); building under the stdlib-distutils
-#     shim works. It must be installed BEFORE the main requirements pass, or
-#     that pass fails trying to build it without the shim.
+#     legacy setup.py sdist. It must be installed BEFORE the main requirements
+#     pass so its build quirks stay contained to this step. Do NOT wrap it in
+#     SETUPTOOLS_USE_DISTUTILS=stdlib: pip's isolated build env installs the
+#     latest setuptools, and setuptools >= 74 refuses to even import with that
+#     value set, so the build dies with "BackendUnavailable: Cannot import
+#     'setuptools.build_meta'" (and Python >= 3.12 has no stdlib distutils for
+#     the shim to point at anyway). The historical "AttributeError:
+#     install_layout" crash the shim once worked around no longer reproduces
+#     with current setuptools (verified on Python 3.12 and 3.14).
 #   - toponymy 0.5.2 pins transformers<5.0.0, which a plain install would
 #     honor by downgrading the app's transformers stack; the pin is
 #     empirically unnecessary for our usage (validated end-to-end on
@@ -829,7 +834,7 @@ vts_install_precommit() {
 #     dependencies declared in pyproject.toml instead. The tests_lib
 #     projection smoke test guards this bypass against future breakage.
 vts_install_toponymy() {
-    SETUPTOOLS_USE_DISTUTILS=stdlib pip install apricot-select --progress-bar on
+    pip install apricot-select --progress-bar on
     pip install --no-deps "toponymy==0.5.2" --progress-bar on
 }
 


### PR DESCRIPTION
## Problem

Running `scripts/install.sh` on the HLTCOE grid died at step 5/9 ("Installing signpost naming deps"):

```
pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'
```

The `vts_install_toponymy` step wrapped the apricot-select install in `SETUPTOOLS_USE_DISTUTILS=stdlib`. That env var propagates into pip's isolated build env, which installs the **latest** setuptools — and setuptools >= 74 raises at import time when that value is set (Python >= 3.12 has no stdlib distutils for the shim to point at anyway). Result: the build backend can't be imported, and the whole installer aborts, leaving toponymy and everything after step 5 (remaining gpu.txt deps, cuML, smoke test) uninstalled. Anyone with a warm pip wheel cache never hits it, which is why it slipped through.

## Fix

Install apricot-select with a plain `pip install`. The historical `AttributeError: install_layout` crash the shim once worked around no longer reproduces with current setuptools.

## Verification

`pip install --no-cache-dir apricot-select` (forcing a real sdist build, exactly what the fixed line runs) succeeds on:
- Python 3.12 venv on the HLTCOE grid (the environment that hit the bug)
- Python 3.14 venv locally

Also updated the stale shim reference in `docs/plans/vtsbrowse-toponymy.md` and `bash -n`-checked the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)