### PR TITLE
Fix labeling-status stale-poll race behind flaky background-refresh test

### DIFF
--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -146,9 +146,13 @@ def labeling_status_indicator():
         # indicators, falling back to a "computing" placeholder when no
         # snapshot exists yet (rapid votes at session start, or the first poll
         # after a detector switch cleared the cache).
-        _schedule_status_refresh(span)
+        # Read the snapshot *before* kicking the refresh: the worker rewrites
+        # ``_status_snapshot`` as soon as it finishes, so scheduling first
+        # races it against this request's read and the response could reflect
+        # the in-flight recompute instead of the previous snapshot.
         status = stale_labeling_status(good_votes, bad_votes, span)
         status["stale"] = True
+        _schedule_status_refresh(span)
         return status
     except Exception:
         import logging


### PR DESCRIPTION
## Problem

`tests/api/test_labeling_status_async.py::TestLabelingStatusBackgroundRefresh::test_stale_poll_returns_previous_snapshot` was flaky in full-suite runs (while passing consistently in isolation).

The root cause is a real race in the route, not in the test. The stale path of `GET /api/labeling-status` scheduled the background cache refresh **before** reading the last snapshot:

```python
_schedule_status_refresh(span)                               # spawns worker
status = stale_labeling_status(good_votes, bad_votes, span)  # reads _status_snapshot
```

The worker's `compute_labeling_status` takes `_progress_lock` to advance the per-step cache, and the request thread's `stale_labeling_status` blocks on that same lock — handing the worker exactly the time it needs to finish and overwrite `_status_snapshot`. Whichever thread wins the next lock acquisition decides whether the poll returns the *previous* snapshot (documented behavior) or the *just-recomputed* one. Under suite load the worker sometimes won, so the response reflected the new vote and the test's `stale["smart"] == fresh["smart"]` assertion failed.

## Fix

Read the snapshot before spawning the refresh worker. This guarantees the stale response is the pre-refresh snapshot — the endpoint's documented semantics — and makes the test deterministic without touching the test itself.

## Verification

- `./run-tests.sh api` — 563 passed
- `./run-tests.sh` (full suite) — 6380 passed, 1 skipped
- `tests/api/test_labeling_status_async.py` stress-run 5× consecutively — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACHqBjmT58CLzSSwz9aVoy

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACHqBjmT58CLzSSwz9aVoy)_