### PR TITLE
Prune #2360 pointer: header Data: label verified fixed by #2452

### DIFF
--- a/docs/plans/standard-workflow-polish.md
+++ b/docs/plans/standard-workflow-polish.md
@@ -34,5 +34,3 @@ the original priority.
 - [ ] #2383 — Move keyboard focus off the Good button during Autopilot "Find Initial Bads"
 
 <!-- item-sep -->
-
-- [ ] #2360 — Header "Data:" label lags the active dataset


### PR DESCRIPTION
## What

Removes the `#2360` pointer line from `docs/plans/standard-workflow-polish.md` (sentinels left intact). No code change — the issue does not reproduce on current `dev`.

## Verification (live browser, per the issue's verify-first mandate)

Ran the eval against the GRID instance (rack7n03, dev `10ce299d`, fresh frontend build) driving Chrome through the SSH tunnel, sampling the header label and dashboard state together at 100–200ms resolution:

- **Row select / deselect** → header label follows within one sampling interval, both directions.
- **Import completion** (new synthetic dataset) → implicit selection lands in the header in the same 100ms sample as the import finishing.
- **Multi-select** → header shows `Data: Multiple` instantly (deliberate state, not drift).
- **Delete of the selected dataset** → header flips to the remaining intent dataset instantly.
- **Pulldown internal state** → matches the button label; the RAM-loaded-but-unselected dataset is marked with `●`, so loaded-vs-selected is an explicit, coherent distinction (documented at `dashboard.component.ts:922-926`, H25 intent/active split).

The one transient anomaly observed (row vanishing while the header kept the old name) was a **failed delete request** during a brief server hiccup — optimistic row removal with the header correctly reflecting the true registry state; the next poll restored the row. Not a header bug.

## Conclusion

The originally reported drift matches the nav-picker-lag root cause fixed by #2452 (closed #2374, shipped to `main` in the 2026-07-14 release). #2360 is being closed as a duplicate; this PR prunes its plan-file pointer per the one-item-one-home policy.

Refs #2360

🤖 Generated with [Claude Code](https://claude.com/claude-code)