### PR TITLE
Pin the Find-view large-dataset progress affordance in a spec (#2373)

### DIFF
--- a/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
+++ b/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
@@ -106,6 +106,36 @@ describe('FindViewComponent (zoneless canary)', () => {
     expect(fixture.nativeElement.querySelector('.find-wait-overlay')).toBeNull();
   });
 
+  // O12 (issue #2373): at 1000+ items the scoring overlay must surface real
+  // progress — a determinate bar plus a thousands-separated "N / total" count
+  // and an ETA chip — through the same SortStateService setters the find$ SSE
+  // subscription writes. Verified live against a 1,200-item dataset; a warm
+  // run finishes sub-second, so this pins the template contract the live run
+  // is too fast to observe.
+  it('renders a determinate bar, formatted count, and ETA for a large-dataset scoring run', async () => {
+    await flushInit();
+    httpMock.match('/api/dataset/status').forEach((req) => req.flush({ display_name: 'x' }));
+    await settleZoneless(fixture);
+
+    const sortState = TestBed.inject(SortStateService);
+    sortState.setSortBusy(true);
+    sortState.setSortStatus('Scoring 1200 items…');
+    sortState.setSortProgress(476, 1200, 0.79, 42);
+    await settleZoneless(fixture);
+
+    const overlay = fixture.nativeElement.querySelector('.find-wait-overlay');
+    expect(overlay).not.toBeNull();
+    // The whole-job `overall` fraction drives a determinate bar.
+    const track = overlay!.querySelector('[role="progressbar"]') as HTMLElement;
+    expect(track.getAttribute('aria-valuenow')).toBe('0.79');
+    expect(track.getAttribute('aria-valuemax')).toBe('1');
+    const fill = overlay!.querySelector('.progress-fill') as HTMLElement;
+    expect(fill.className).not.toContain('indeterminate');
+    // The count renders with a thousands separator so 1200 reads as 1,200.
+    expect(overlay!.querySelector('.find-wait-count')!.textContent).toContain('476 / 1,200');
+    expect(overlay!.querySelector('.find-wait-eta')!.textContent).toContain('sec');
+  });
+
   // Find/Train share the singleton SortStateService, so a fresh entry still
   // holds the previous session's ranking. Against a smaller dataset those stale
   // ids fire a storm of image 404s; ngOnInit resets the ranking before loading.


### PR DESCRIPTION
## Summary
Verification task from `docs/plans/progress-ux.md` O12 (#2373): confirm the Find view surfaces progress on a 1000+ item dataset rather than showing a blank view.

**Verified live** on the GRID dev instance (rack7n03) against a fresh 1,200-image synthetic dataset with a 7-label detector, driven through the real UI in Chrome:

- `POST /api/find-label` publishes the full `find` SSE sequence at scale: `Resolving detector…` (step 1/4) → `Scoring 1200 items…` (current 0→1200, step 3/4) → `Applying labels to 1200 items…` (step 4/4) → `Done` (overall 1.0).
- The `.find-wait-overlay` renders in the DOM during the run (MutationObserver-verified at ~680ms post-navigation) with the `role=progressbar` bar and Cancel button; the view then populates with the sorted ranking. No blank view at any point, no console errors.
- A warm 1,200-item run completes sub-second, so the determinate bar/count state is unobservable by eye — the new spec pins that template contract (determinate `aria-valuenow` from the whole-job `overall` fraction, thousands-separated `476 / 1,200` count, ETA chip) through the same `SortStateService` channel the `find$` SSE subscription writes.

## Testing
- `npx ng test --watch=false --include "**/find-view.zoneless.spec.ts"` — 5/5 pass on the grid worktree.

Closes #2373

🤖 Generated with [Claude Code](https://claude.com/claude-code)