### PR TITLE
CLI autodetect: re-clip the dataset to a detector's input_spec.clipper at scoring time

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -135,10 +135,15 @@ skipped entirely (with a note). When a converter fans one media out into several
 media by **max**: the video is a positive hit when *any* of its frames clears the
 threshold, and it surfaces as a single hit on the video, not one per frame.
 
-A detector trained on a specific clipper granularity (its `input_spec.clipper`)
-is still skipped when the loaded dataset wasn't clipped to match; re-load the
-dataset with the matching clipper to score it. (Auto-clipping at scoring time is
-future work — see `docs/plans/cli-detector-converter.md`.)
+**Matching the detector's clipper granularity.** A detector trained on a
+specific clipper (its `input_spec.clipper` — e.g. 2-second audio tiles, or an
+image grid) is **re-clipped at scoring time** when the loaded dataset wasn't
+already clipped to match: each routed, target-typed media is split with the
+detector's clipper and the clips are re-embedded, so a raw dataset is scored at
+the granularity the detector expects. The per-clip scores fold back to the source
+media by the same **max** rule as converter fan-out. A dataset already loaded
+with the matching clipper is scored as-is (no redundant re-clip), and a detector
+with no `input_spec.clipper` scores whole media.
 
 **How to get the files:**
 

--- a/docs/plans/cli-detector-converter.md
+++ b/docs/plans/cli-detector-converter.md
@@ -3,54 +3,38 @@
 ## Background
 
 The detector `input_spec` (`clipper` + `clipper_params`) and the `LabelSet`
-`detector_meta` round-trip are in place. **Converter routing and converter-aware
-matching have shipped:** the CLI scores a dataset of mixed source types by
-routing each media to a detector's `media_type` through a one-hop converter
-(`video2image`, `document2image`, …), aggregating a converter's fan-out (a video
-into frames) back to the source media by **max**. See
-`vtscore/detectors/converter_routing.py` and `_score_medias_with_detectors` /
-`_load_and_train_detectors` in `vtscore/cli.py`, and the "Scoring across source
-types" note in `docs/CLI.md`.
-
-The CLI still **skips** a detector whose `input_spec.clipper` doesn't match the
-loaded dataset's clipper (with a reload hint). The open work below builds the
-re-clipping pipeline on top of what shipped.
+`detector_meta` round-trip are in place. **Converter routing, converter-aware
+matching, and re-clipping at scoring time have shipped:** the CLI scores a
+dataset of mixed source types by routing each media to a detector's `media_type`
+through a one-hop converter (`video2image`, `document2image`, …); when the
+detector declares an `input_spec.clipper` the loaded dataset doesn't already
+match, it re-clips (splits + re-embeds) the routed medias to that granularity
+instead of skipping. Converter fan-out (a video into frames) and re-clip
+sub-items (a recording into tiles) both aggregate back to the source media by
+**max**. See `vtscore/detectors/converter_routing.py` and
+`_score_medias_with_detectors` / `_load_and_train_detectors` in `vtscore/cli.py`,
+and the "Scoring across source types" note in `docs/CLI.md`.
 
 ## Open follow-ups
 
 <!-- item-sep -->
 
-- **Re-clipping the loaded dataset to match a detector's `input_spec.clipper`.**
-  Today a clipper-mismatched detector is skipped with a message telling the user
-  to reload. The more ergonomic flow is "auto-clip + re-embed at scoring time":
-  when a detector declares `input_spec.clipper`, split the routed target-typed
-  medias into clips with that clipper before embedding, instead of skipping.
-  Cheaper short-circuit: when the first media's `origin.params.clipper` already
-  equals the detector's, skip the work. Needs media bytes or a resolvable file
-  path, so thin-loaded medias would have to go through `resolve_file_context`
-  first (converter outputs already carry bytes; direct thin medias don't). This
-  slots into `route_and_embed`: after routing to the target type and before the
-  embed pass, run the detector's clipper over the routed medias and extend the
-  `scoring_to_source` map so each clip still points back at its source media (the
-  existing max-aggregation then folds clip scores to the source, exactly as it
-  already folds converter frames).
-
-<!-- item-sep -->
-
-- **Clip-score aggregation toggle.** Converter fan-out and (once the item above
-  lands) clipper clips both aggregate to the source media by **max** today
-  ("find the needle": positive if *any* clip clears threshold). The design
-  proposes an explicit `input_spec.clip_aggregation` (`"max"` | `"mean"`, default
-  `"max"`) so a detector can instead score overall quality via the mean. The
-  aggregation point is the `best_by_source` reduction in `_score_one_detector`;
-  the field would select `max` vs `mean` there.
+- **Clip-score aggregation toggle.** Converter fan-out and re-clip sub-items both
+  aggregate to the source media by **max** today ("find the needle": positive if
+  *any* sub-item clears threshold). The design proposes an explicit
+  `input_spec.clip_aggregation` (`"max"` | `"mean"`, default `"max"`) so a
+  detector can instead score overall quality via the mean. The aggregation point
+  is the `best_by_source` reduction in `_score_one_detector` (`vtscore/cli.py`);
+  the field would select `max` vs `mean` there, and would need to travel on the
+  detector's scoring info the way `clipper` / `clipper_params` already do.
 
 <!-- item-sep -->
 
 - **`--override-clipper` CLI flag.** Power-user escape hatch to score with a
   different granularity than the detector was trained on. Not the primary
-  interface; only worth shipping after the auto-clip (re-clipping) path lands,
-  since it just forces a different clipper into that same path.
+  interface; it would force a chosen clipper into the re-clip path
+  (`route_and_embed`'s `clipper` argument) regardless of the detector's
+  `input_spec`, overriding the auto-clip decision in `_load_and_train_detectors`.
 
 <!-- item-sep -->
 
@@ -67,17 +51,10 @@ captured at training time from the active clipper):
 | `input_spec.clipper` | `str \| null` | Clipper used to split media into sub-clips before embedding. `null` = default (whole media). |
 
 Converters are **not** stored on the detector — the registry supplies routes by
-target type — which is why converter routing needed no new detector field. The
-clipper is the remaining piece the re-clipping item consumes.
-
-### The re-clipping step (open)
-
-Once a detector's target type is reached (native or via a converter), and the
-detector declares `input_spec.clipper`, the routed medias are split into clips
-with that clipper and each clip is embedded, mirroring the load-pipeline clipper
-stage (`vtscore/datasets/stages/clipper.py`). The per-clip scores merge back to
-the source media through the existing max-aggregation. A missing/blank
-`input_spec.clipper` keeps the current whole-media path.
+target type. The clipper drives the re-clip step, which is now wired: a
+clipper-mismatched detector carries its `clipper` / `clipper_params` on its
+scoring info, and `route_and_embed` applies it (via the load-pipeline clipper
+stage) after routing to the target type and before scoring.
 
 ### Clip-score aggregation (open)
 
@@ -88,6 +65,6 @@ quality) via `input_spec.clip_aggregation` (default `"max"`).
 ### CLI surface
 
 For the common case nothing changes — the pipeline auto-converts per the
-detector's `media_type` and (once re-clipping lands) clips per its `input_spec`.
-A niche `--override-clipper sound_tiling_5s` escape hatch would force a different
+detector's `media_type` and re-clips per its `input_spec`. A niche
+`--override-clipper sound_tiling_5s` escape hatch would force a different
 granularity than the detector was trained on.

--- a/tests/cli/test_cli_converter_routing.py
+++ b/tests/cli/test_cli_converter_routing.py
@@ -83,6 +83,40 @@ class TestCliConverterRouting:
         results = _score_medias_with_detectors(medias, detector_mlps)
         assert results == {}
 
+    def test_reclip_fanout_aggregates_to_one_hit(self, client, monkeypatch):
+        # A detector carrying a re-clip spec splits each media into clips; the
+        # per-clip scores collapse back to a single hit on the source media.
+        def _fake_apply_clipper(clips_dict, name, params, on_progress=None, chain_steps=None, embedder=None):
+            clips_dict.clear()
+            for i in (1, 2):
+                clips_dict[i] = {
+                    "media_type": "audio",
+                    "embeddings": {"fake": np.ones(4, dtype=np.float32)},
+                    "embedder": "fake",
+                    "filename": f"clip{i}",
+                }
+
+        monkeypatch.setattr("vtscore.datasets.stages.clipper._apply_clipper", _fake_apply_clipper)
+
+        medias = {9: {"id": 9, "media_type": "audio", "filename": "rec.wav"}}
+        detector_mlps = {
+            "det": {
+                "mlp": _constant_mlp(),
+                "threshold": 0.5,
+                "media_type": "audio",
+                "embedder": "fake",
+                "clipper": "sound_tiling",
+                "clipper_params": {"duration": "2.0"},
+            },
+        }
+
+        results = _score_medias_with_detectors(medias, detector_mlps)
+        det = results["det"]
+        all_ids = {h["id"] for h in det["hits"]} | {h["id"] for h in det["negative_hits"]}
+        # Two clips of source media 9 collapse to one hit on 9.
+        assert all_ids == {9}
+        assert len(det["hits"]) + len(det["negative_hits"]) == 1
+
     def test_homogeneous_direct_scoring_one_hit_per_media(self, client, monkeypatch):
         _stub_embed(monkeypatch)
         medias = {

--- a/tests/cli/test_cli_detectors.py
+++ b/tests/cli/test_cli_detectors.py
@@ -140,8 +140,10 @@ class TestAutofindDetectorsCLI:
         assert isinstance(det.get("hits"), list)
         assert det["detector_name"] == "ds-a-detector"
 
-    def test_detector_with_mismatched_input_spec_is_skipped(self, client, tmp_path, monkeypatch):
-        """A detector whose input_spec.clipper doesn't match the dataset is skipped, not run."""
+    def test_detector_with_mismatched_input_spec_is_reclipped(self, client, tmp_path, monkeypatch):
+        """A detector whose input_spec.clipper doesn't match the dataset is now
+        kept and re-clipped at scoring time (not skipped): its scoring info
+        carries the clipper to re-apply."""
         files = _make_audio_files(tmp_path, ["alpha.wav", "beta.wav", "gamma.wav"])
         _stub_resolve(monkeypatch, files)
 
@@ -177,31 +179,18 @@ class TestAutofindDetectorsCLI:
                 },
             },
         )
-        # Plus a detector with no input_spec; so the pipeline has
-        # *something* to score and doesn't error out empty-handed.
-        _write_trainable_model("ds-a-detector", labelset)
 
-        # The test fixture's medias have empty origin params (no clipper),
-        # so the mismatched detector should be skipped while the
-        # unconstrained one runs.
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
-        settings_path = _settings_file_with_detectors(tmp_path, ["spec-mismatch", "ds-a-detector"])
-        out_path = tmp_path / "hits.json"
+        # The test fixture's medias have no clipper, so the detector's
+        # sound_tiling(2.0) input_spec mismatches. It is kept (not skipped) and
+        # its scoring info records the clipper to re-apply.
+        from vtscore.cli import _load_and_train_detectors
 
-        from vtscore.cli import autodetect_main
+        snap = dict(app_module.medias)
+        trained = _load_and_train_detectors(["spec-mismatch"], "audio", snap)
 
-        autodetect_main(
-            str(dataset_path),
-            settings_path=str(settings_path),
-            exporter_name="server_json_file",
-            exporter_field_values={"filepath": str(out_path)},
-        )
-
-        body = json.loads(out_path.read_text())
-        results = body.get("results", {})
-        # Mismatched detector skipped, unconstrained one ran.
-        assert "spec-mismatch" not in results
-        assert "ds-a-detector" in results
+        assert "spec-mismatch" in trained
+        assert trained["spec-mismatch"]["clipper"] == "sound_tiling"
+        assert trained["spec-mismatch"]["clipper_params"].get("duration") == "2.0"
 
     def test_detector_with_matching_input_spec_runs(self, client, tmp_path, monkeypatch):
         """When the dataset's clipper matches the detector's input_spec, the detector runs."""

--- a/tests_lib/detectors/test_converter_routing.py
+++ b/tests_lib/detectors/test_converter_routing.py
@@ -111,3 +111,61 @@ class TestRouteAndEmbed:
 
         assert scoring == {}
         assert mapping == {}
+
+
+class TestReclip:
+    def test_reclip_splits_and_maps_sub_items_to_source(self, monkeypatch):
+        """A re-clip clipper that fans one media into N clips attributes every
+        clip back to its source media."""
+
+        def _fake_apply_clipper(clips_dict, name, params, on_progress=None, chain_steps=None, embedder=None):
+            # Split the single input media into two embedded clips.
+            clips_dict.clear()
+            for i in (1, 2):
+                clips_dict[i] = {
+                    "media_type": "audio",
+                    "embeddings": {"clap": np.ones(4, dtype=np.float32)},
+                    "embedder": "clap",
+                }
+
+        monkeypatch.setattr("vtscore.datasets.stages.clipper._apply_clipper", _fake_apply_clipper)
+
+        src = {7: {"media_type": "audio"}}
+        scoring, mapping = cr.route_and_embed(
+            src, "audio", "clap", clipper="sound_tiling", clipper_params={"duration": "2.0"}
+        )
+
+        assert len(scoring) == 2
+        # Both clips descend from source media 7.
+        assert set(mapping.values()) == {7}
+
+    def test_reclip_after_converter_route(self, monkeypatch):
+        """Video routed to image, then each frame re-clipped: sub-items still map
+        back to the source video."""
+
+        class _FakeVideo2Image:
+            source_type = "video"
+            target_type = "image"
+
+            def convert_normalized(self, media, params):
+                return [{"media_bytes": b"frame"}]
+
+        def _fake_apply_clipper(clips_dict, name, params, on_progress=None, chain_steps=None, embedder=None):
+            clips_dict.clear()
+            for i in (1, 2, 3):
+                clips_dict[i] = {
+                    "media_type": "image",
+                    "embeddings": {"clip": np.ones(4, dtype=np.float32)},
+                    "embedder": "clip",
+                }
+
+        monkeypatch.setattr(
+            cr, "converter_route_for", lambda s, t: _FakeVideo2Image() if (s, t) == ("video", "image") else None
+        )
+        monkeypatch.setattr("vtscore.datasets.stages.clipper._apply_clipper", _fake_apply_clipper)
+
+        src = {4: {"media_type": "video"}}
+        scoring, mapping = cr.route_and_embed(src, "image", "clip", clipper="image_grid")
+
+        assert len(scoring) == 3
+        assert set(mapping.values()) == {4}

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -187,23 +187,30 @@ def _load_and_train_detectors(
             )
             continue
 
+        # When the detector was trained on a clipper granularity the loaded
+        # dataset doesn't already match, re-clip the dataset to that granularity
+        # at scoring time (auto-clip + re-embed) instead of skipping. The clipper
+        # spec rides on the detector's scoring info and is applied by
+        # ``route_and_embed``. A matching (or absent) clipper needs no re-clip.
         det_input_spec = det.get("input_spec") if isinstance(det.get("input_spec"), dict) else None
+        reclip_clipper = ""
+        reclip_params: dict[str, Any] = {}
         if det_input_spec and not clipper_matches(det_input_spec, dataset_spec):
-            det_clipper = det_input_spec.get("clipper") or ""
-            dataset_clipper = (dataset_spec or {}).get("clipper") or "(none)"
-            cli_progress.emit(
-                "detector_skipped",
-                text=(
-                    f"Skipping detector '{det_name}': input_spec.clipper "
-                    f"{det_clipper!r} doesn't match dataset clipper "
-                    f"{dataset_clipper!r}. Re-load the dataset with the "
-                    f"matching clipper to use this detector."
-                ),
-                detector=det_name,
-                detector_input_spec=det_input_spec,
-                dataset_input_spec=dataset_spec or {},
-            )
-            continue
+            reclip_clipper = det_input_spec.get("clipper") or ""
+            reclip_params = dict(det_input_spec.get("clipper_params") or {})
+            if reclip_clipper:
+                dataset_clipper = (dataset_spec or {}).get("clipper") or "(none)"
+                cli_progress.emit(
+                    "detector_reclip",
+                    text=(
+                        f"Re-clipping dataset for detector '{det_name}' with "
+                        f"clipper {reclip_clipper!r} to match its input_spec "
+                        f"(dataset clipper: {dataset_clipper!r})."
+                    ),
+                    detector=det_name,
+                    detector_input_spec=det_input_spec,
+                    dataset_input_spec=dataset_spec or {},
+                )
 
         labelset = LabelSet.from_dict(det.get("labelset") or {})
         if not labelset.elements:
@@ -239,6 +246,10 @@ def _load_and_train_detectors(
             "embedder_type": detector_embedder_type_from_data(det),
             "good_count": sum(1 for el in labelset.elements if el.label == "good"),
             "bad_count": sum(1 for el in labelset.elements if el.label == "bad"),
+            # Clipper to re-apply at scoring time (empty when the dataset already
+            # matches the detector's granularity, or the detector has no clipper).
+            "clipper": reclip_clipper,
+            "clipper_params": reclip_params,
         }
     return out
 
@@ -250,16 +261,18 @@ def _score_medias_with_detectors(
     """Score *medias* against pre-trained detector MLPs, routing across types.
 
     *medias* may arrive unembedded and may mix source types.  For each group of
-    detectors sharing a target ``media_type`` + embedder, the medias are routed
-    to that target (native match scored directly, other types converted via a
-    one-hop converter such as ``video2image``) and embedded in the detector's
-    space by :func:`~vtscore.detectors.converter_routing.route_and_embed`.  A
-    converter that fans one source media out into several (a video into frames)
-    produces several scores, which are aggregated back to the source media by
-    ``max`` - a source is a positive hit when *any* of its converted clips
-    clears the threshold ("find the needle").  Homogeneous single-type datasets
-    take the identity route (no conversion, one hit per media), byte-for-byte
-    the pre-routing behaviour.
+    detectors sharing a target ``media_type`` + embedder + re-clip granularity,
+    the medias are routed to that target (native match scored directly, other
+    types converted via a one-hop converter such as ``video2image``), optionally
+    re-clipped to the detector's ``input_spec.clipper``, and embedded in the
+    detector's space by
+    :func:`~vtscore.detectors.converter_routing.route_and_embed`.  A converter or
+    clipper that fans one source media out into several (a video into frames, a
+    recording into tiles) produces several scores, which are aggregated back to
+    the source media by ``max`` - a source is a positive hit when *any* of its
+    sub-items clears the threshold ("find the needle").  Homogeneous single-type
+    datasets with no re-clip take the identity route (one hit per media),
+    byte-for-byte the pre-routing behaviour.
     """
     if not medias or not detector_mlps:
         return {}
@@ -268,15 +281,22 @@ def _score_medias_with_detectors(
 
     from vtscore.detectors.converter_routing import route_and_embed  # noqa: PLC0415
 
-    # Detectors sharing a (target type, embedder) share one routed+embedded
-    # snapshot, so a dataset scored by two image/siglip detectors is routed and
-    # embedded once, not per detector.
-    groups: dict[tuple[str, str], list[str]] = defaultdict(list)
+    # Detectors sharing a (target type, embedder, re-clip spec) share one
+    # routed+clipped+embedded snapshot, so a dataset scored by two image/siglip
+    # detectors with the same granularity is prepared once, not per detector.
+    groups: dict[tuple[str, str, str, tuple], list[str]] = defaultdict(list)
     for det_name, info in detector_mlps.items():
-        groups[(info.get("media_type") or "", info.get("embedder") or "")].append(det_name)
+        clipper_params = info.get("clipper_params") or {}
+        key = (
+            info.get("media_type") or "",
+            info.get("embedder") or "",
+            info.get("clipper") or "",
+            tuple(sorted((str(k), str(v)) for k, v in clipper_params.items())),
+        )
+        groups[key].append(det_name)
 
     results: dict[str, dict[str, Any]] = {}
-    for (target_type, embedder_name), det_names in groups.items():
+    for (target_type, embedder_name, clipper, clipper_params_items), det_names in groups.items():
         if not target_type:
             # Legacy detector with no declared media_type: score every media
             # directly against its primary embedding, exactly as before
@@ -284,7 +304,13 @@ def _score_medias_with_detectors(
             # embedding). Typed detectors take the routing path below.
             results.update(_score_direct_all(det_names, detector_mlps, medias))
             continue
-        scoring_medias, scoring_to_source = route_and_embed(medias, target_type, embedder_name)
+        scoring_medias, scoring_to_source = route_and_embed(
+            medias,
+            target_type,
+            embedder_name,
+            clipper=clipper,
+            clipper_params=dict(clipper_params_items),
+        )
         if not scoring_medias:
             continue
         for det_name in det_names:

--- a/vtscore/detectors/converter_routing.py
+++ b/vtscore/detectors/converter_routing.py
@@ -80,10 +80,53 @@ def _partition_by_route(
     return direct, converted
 
 
+def _clip_and_embed_items(
+    target_items: list[tuple[int, dict[str, Any]]],
+    clipper: str,
+    clipper_params: dict[str, Any],
+    embedder_name: str,
+) -> list[tuple[int, dict[str, Any]]]:
+    """Re-clip each target-typed media into the detector's granularity.
+
+    Splits every ``(source_id, media)`` in *target_items* with *clipper* and
+    embeds the resulting clips in the detector's space, returning a flattened
+    ``(source_id, clip)`` list - one media fans out into several clips, each
+    still attributed to its source media so the caller can fold clip scores
+    back.  Reuses the load-pipeline clipper stage
+    (:func:`~vtscore.datasets.stages.clipper._apply_clipper`), which hydrates
+    thin (reference) parents from their source file, slices, recomputes each
+    clip's MD5, and re-embeds - so a raw dataset is scored at the granularity
+    the detector was trained on.
+
+    The source media dict is shallow-copied before clipping so the shared
+    ``medias`` snapshot the caller iterates is never mutated (a media may be
+    scored by several detector groups).
+    """
+    from vtscore.datasets.stages.clipper import _apply_clipper  # noqa: PLC0415
+    from vtscore.media import get_embedder  # noqa: PLC0415
+
+    embedder = None
+    if embedder_name:
+        try:
+            embedder = get_embedder(embedder_name)
+        except KeyError:
+            embedder = None
+
+    out: list[tuple[int, dict[str, Any]]] = []
+    for sid, media in target_items:
+        one: dict[int, dict[str, Any]] = {1: dict(media)}
+        _apply_clipper(one, clipper, dict(clipper_params), embedder=embedder)
+        for clip in one.values():
+            out.append((sid, clip))
+    return out
+
+
 def route_and_embed(
     source_medias: dict[int, dict[str, Any]],
     target_type: str,
     embedder_name: str,
+    clipper: str = "",
+    clipper_params: dict[str, Any] | None = None,
 ) -> tuple[dict[int, dict[str, Any]], dict[int, int]]:
     """Prepare a *target_type* scoring snapshot from mixed *source_medias*.
 
@@ -91,13 +134,15 @@ def route_and_embed(
     a fresh 1-based id to a target-typed media carrying an embedding under
     *embedder_name*, and *scoring_to_source* maps each of those ids back to the
     source media id it descends from (identity for a direct type match, the
-    parent id for every converter output).
+    parent id for every converter output or re-clip sub-item).
 
-    Media whose type matches *target_type* are embedded in place (idempotent -
-    a no-op when they already carry the vector).  Media of another type are
-    routed through a one-hop converter, and each converter output is embedded.
-    Media with no route, and any media the embedder can't embed, are dropped;
-    the caller scores only what comes back.
+    Media whose type matches *target_type* are used directly; media of another
+    type are routed through a one-hop converter.  When *clipper* is set (the
+    detector declares an ``input_spec.clipper`` the loaded dataset doesn't
+    already match), every target-typed media is then split with that clipper so
+    it is scored at the granularity the detector was trained on; otherwise the
+    media are embedded whole.  Media with no route, and any media/clip the
+    embedder can't embed, are dropped; the caller scores only what comes back.
 
     *embedder_name* may be empty, meaning "the dataset's primary embedder": the
     embed pass then resolves the default and the presence check reads the
@@ -110,42 +155,43 @@ def route_and_embed(
     emb_key = embedder_name or None
 
     direct, converted = _partition_by_route(source_medias, target_type)
+    target_items: list[tuple[int, dict[str, Any]]] = [(sid, m) for sid, m in direct.items()]
+    target_items += [(sid, out) for sid, out in converted]
 
-    if direct:
-        embed_missing(direct, embedder_name)
-    if converted:
-        # Embed the converter outputs in one bulk pass; the throwaway integer
+    if clipper:
+        # Re-clip splits + re-embeds each media, so this replaces the whole-media
+        # embed pass below.
+        target_items = _clip_and_embed_items(target_items, clipper, clipper_params or {}, embedder_name)
+    elif target_items:
+        # Embed every target-typed media in one bulk pass; the throwaway integer
         # keys just satisfy the ``dict[int, media]`` shape ``embed_missing``
-        # iterates - only the media values matter.
-        embed_missing({i: out for i, (_sid, out) in enumerate(converted)}, embedder_name)
+        # iterates - only the media values matter. Direct medias are embedded in
+        # place (idempotent), which also caches the vector for other detector
+        # groups that share the type.
+        embed_missing({i: m for i, (_sid, m) in enumerate(target_items)}, embedder_name)
 
     scoring: dict[int, dict[str, Any]] = {}
     scoring_to_source: dict[int, int] = {}
     next_id = 1
-    dropped_direct = 0
-    for sid, media in direct.items():
+    dropped = 0
+    for sid, media in target_items:
         if media_embedding(media, emb_key) is not None:
             scoring[next_id] = media
             scoring_to_source[next_id] = sid
             next_id += 1
         else:
-            # A media of the right type that still has no vector after the embed
-            # pass (unreadable/corrupt source, thin media with no resolvable
-            # path). Drop it rather than crashing a long CLI run, mirroring the
-            # load pipeline's drop-none stage, but count it so the caller can log.
-            dropped_direct += 1
-    for sid, out in converted:
-        if media_embedding(out, emb_key) is not None:
-            scoring[next_id] = out
-            scoring_to_source[next_id] = sid
-            next_id += 1
+            # A media/clip that still has no vector after the embed pass
+            # (unreadable/corrupt source, thin media with no resolvable path).
+            # Drop it rather than crashing a long CLI run, mirroring the load
+            # pipeline's drop-none stage, but count it so we can log.
+            dropped += 1
 
-    if dropped_direct:
+    if dropped:
         import logging  # noqa: PLC0415
 
         logging.getLogger(__name__).warning(
-            "converter routing: dropped %d %s media with no embedding under %r",
-            dropped_direct,
+            "converter routing: dropped %d %s item(s) with no embedding under %r",
+            dropped,
             target_type,
             embedder_name or "(primary)",
         )


### PR DESCRIPTION
## What & why

Second slice of `docs/plans/cli-detector-converter.md`, building on the converter-routing work (#2539). A detector trained on a specific clipper granularity — 2-second audio tiles, an image grid — was previously **skipped** when the loaded dataset wasn't clipped to match, with a "re-load the dataset" hint. Now the CLI **re-clips at scoring time**: each routed, target-typed media is split with the detector's `input_spec.clipper` and the clips are re-embedded in the detector's space, so a raw dataset is scored at the granularity the detector expects — no manual reload needed.

## Changes

- **`route_and_embed`** (`vtscore/detectors/converter_routing.py`) gains optional `clipper` / `clipper_params`. When set, each target-typed media (native or converter-produced) is split via the load-pipeline clipper stage (`_apply_clipper`, which hydrates thin/reference parents from their source file, slices, recomputes each clip's MD5, and re-embeds), and every clip is attributed back to its source media. When absent, the prior whole-media embed path is unchanged.
- **`_load_and_train_detectors`** (`vtscore/cli.py`): a clipper-mismatched detector is no longer skipped — it's trained and its scoring info carries the `clipper` / `clipper_params` to re-apply (emitting a `detector_reclip` progress event instead of `detector_skipped`). A matching or absent clipper carries no re-clip spec.
- **`_score_medias_with_detectors`**: the detector grouping key now includes the re-clip spec, so detectors sharing `(media_type, embedder, clipper, params)` prepare one shared routed+clipped+embedded snapshot. The existing **max** aggregation folds re-clip sub-items back to the source media, exactly as it already folds converter frames — a recording is a positive hit when any of its tiles clears the threshold, surfacing as a single hit on the recording.

## Behaviour

- Dataset already loaded with the matching clipper → scored as-is (no redundant re-clip), via the existing `clipper_matches` check.
- Detector with no `input_spec.clipper` → scores whole media, unchanged.
- Homogeneous datasets with no re-clip → identity route, byte-for-byte prior behaviour.
- The source `medias` snapshot is never mutated during clipping (each media is shallow-copied before splitting), so a media scored by several detector groups is safe.

## Still deferred (tracked in the plan)

The explicit `input_spec.clip_aggregation` (`max`/`mean`) toggle and the `--override-clipper` flag.

## Testing

- Unit tests (`tests_lib/detectors/test_converter_routing.py`): re-clip fan-out maps every clip back to its source, including after a converter route.
- Integration test (`tests/cli/test_cli_converter_routing.py`): a detector with a re-clip spec collapses its clips to a single hit on the source media.
- Updated the former "mismatched input_spec is skipped" test to assert the detector is now kept and re-clipped (carries the clipper on its scoring info).
- Full suite green: `./run-tests.sh` → all 6400 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxpZKsbrEiULUz41ZWyfPT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxpZKsbrEiULUz41ZWyfPT)_