### PR TITLE
Fix inverted model-tiering guidance (Fable 5 is most capable, not the rote tier)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,10 +84,12 @@ This is why closing an issue by hand didn't previously "trickle back": the item 
 
 ## Recommend a Claude model in every issue you file
 
-**Every GitHub issue you create must include a recommended Claude model** for whoever picks it up, sized to the work. This lets a task be routed to the cheapest model that will do it well — a Fable-tier mechanical edit shouldn't burn Opus, and a regression-prone refactor shouldn't be handed to a model that will botch it.
+**Every GitHub issue you create must include a recommended Claude model** for whoever picks it up, sized to the work. This lets a task be routed to the cheapest model that will do it well — a Haiku-tier mechanical edit shouldn't burn Opus, and a regression-prone refactor shouldn't be handed to a model that will botch it.
+
+**Capability ladder (cheapest/weakest → most capable/most expensive): Haiku 4.5 → Sonnet 5 → Opus 4.8 → Fable 5.** Fable 5 is Anthropic's *most* capable model (and its most expensive), reserved for the hardest, longest-horizon work — it is **not** a cheap rote tier. Haiku 4.5 is the fast, cheap tier for mechanical edits. "Step up" always means moving toward Fable; "step down" toward Haiku.
 
 - Add a bolded line near the top of the body (right after the difficulty/summary), e.g. `**Recommended Claude model: Sonnet 5.**` — with a short clause on *why* when it isn't obvious.
-- Size to the hardest part of the issue, not the average. Rough guide: **Fable 5** for rote, schematic-/find-replace-shaped edits with a clear spec and no design judgment; **Sonnet 5** for normal feature/bugfix work with bounded reasoning; **Opus 4.8** for regression-prone refactors, subtle concurrency/reactivity, cross-cutting design, or anything where a wrong-but-plausible answer is costly. Use the current model names (Fable 5, Sonnet 5, Opus 4.8, Haiku 4.5).
+- Size to the hardest part of the issue, not the average. Rough guide: **Haiku 4.5** for rote, schematic-/find-replace-shaped edits with a clear spec and no design judgment; **Sonnet 5** for normal feature/bugfix work with bounded reasoning; **Opus 4.8** for regression-prone refactors, subtle concurrency/reactivity, cross-cutting design, or anything where a wrong-but-plausible answer is costly; **Fable 5** only for the most demanding, long-horizon, or research-grade work that genuinely exceeds Opus. Use the current model names (Haiku 4.5, Sonnet 5, Opus 4.8, Fable 5).
 - When one issue mixes tiers (a mechanical bulk plus one gnarly file), name the split: e.g. "Sonnet 5 for the bulk; Opus 4.8 for `foo.component.ts`."
 - If a plan file's umbrella lists issue pointers, it's fine (not required) to append the recommended model in parentheses after each pointer title, as a routing hint.
 


### PR DESCRIPTION
## What & why

The "Recommend a Claude model in every issue you file" section in `CLAUDE.md` had the tiering **backwards**: it listed **Fable 5** as the tier for "rote, schematic-/find-replace-shaped edits with a clear spec and no design judgment."

Per the authoritative Claude model catalog, **Fable 5 is Anthropic's *most* capable widely released model** — for the most demanding reasoning and long-horizon agentic work — and its most expensive ($10/$50 per MTok, above Opus-tier). The real capability ladder (cheapest/weakest → most capable/most expensive) is:

**Haiku 4.5 → Sonnet 5 → Opus 4.8 → Fable 5**

Pegging Fable 5 as the "cheap rote tier" routes trivial find-replace edits to the single priciest, slowest model — the exact opposite of the cost-routing the section is meant to enable.

## Changes

- **`CLAUDE.md`** — corrected the guidance:
  - Rote/mechanical tier is now **Haiku 4.5** (was Fable 5).
  - **Fable 5** moved to the top of the ladder, reserved for the hardest / longest-horizon work.
  - Added an explicit capability-ladder line and clarified that "step up" means toward Fable, "step down" toward Haiku.
- **Open issues** (edited directly on GitHub, not in this diff): the three "Fable-tier" signal-migration issues that inherited the backwards guidance were corrected to **Haiku 4.5**:
  - #2540 (importer pickers) — Fable 5 → Haiku 4.5
  - #2541 (progress widgets) — Fable 5 → Haiku 4.5
  - #2542 (dashboard cards + modals) — "Fable 5 … step up to Sonnet 5" → "Haiku 4.5 … step up to Sonnet 5"

The Sonnet-tier (#2543–#2547) and Opus-tier (#2548–#2550) issues were already correct and are unchanged; their "Sonnet→Opus" escalations still point the right way up the (corrected) ladder.

No code or test surface is touched — docs + issue metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaS4aZcjj7koJKpfb4QdZ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaS4aZcjj7koJKpfb4QdZ4)_