### PR TITLE
Migrate progress widgets to signal input()

### DIFF
--- a/frontend/src/app/components/job-progress/job-progress.component.html
+++ b/frontend/src/app/components/job-progress/job-progress.component.html
@@ -1,19 +1,19 @@
 <div class="jp">
   <div class="jp__top">
     <span class="jp__title">
-      <span class="jp__header" [title]="header">{{ header }}</span>
-      @if (description) {
+      <span class="jp__header" [title]="header()">{{ header() }}</span>
+      @if (description()) {
         <span
           class="jp__info"
           tabindex="0"
           role="img"
-          [attr.aria-label]="description"
-          [title]="description"
+          [attr.aria-label]="description()"
+          [title]="description()"
           >?</span
         >
       }
     </span>
-    @if (cancelling) {
+    @if (cancelling()) {
       <button
         type="button"
         class="btn btn--cancel btn--sm jp__cancel"
@@ -23,27 +23,27 @@
       >
         Cancelling…
       </button>
-    } @else if (cancelTitle !== null) {
+    } @else if (cancelTitle() !== null) {
       <button
         type="button"
         class="btn btn--cancel btn--sm jp__cancel"
         (click)="onCancelClick($event)"
-        [title]="cancelTitle"
+        [title]="cancelTitle()"
       >
-        {{ cancelLabel }}
+        {{ cancelLabel() }}
       </button>
     }
   </div>
   <!-- Detail is a fixed-width, ellipsized column and the ETA hugs the right
        edge, so the bar between them keeps both edges still as the text changes. -->
   <div class="jp__bottom">
-    <span class="jp__detail" [title]="cancelling ? 'Cancelling…' : detail">{{ cancelling ? 'Cancelling…' : detail }}</span>
+    <span class="jp__detail" [title]="cancelling() ? 'Cancelling…' : detail()">{{ cancelling() ? 'Cancelling…' : detail() }}</span>
     <vt-progress-bar
-      [value]="bar.value"
-      [max]="bar.max"
-      [indeterminate]="bar.indeterminate"
-      [smooth]="smooth"
+      [value]="bar().value"
+      [max]="bar().max"
+      [indeterminate]="bar().indeterminate"
+      [smooth]="smooth()"
     />
-    <span class="jp__eta">{{ eta }}</span>
+    <span class="jp__eta">{{ eta() }}</span>
   </div>
 </div>

--- a/frontend/src/app/components/job-progress/job-progress.component.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { ProgressBarState } from '../../utils/format-progress';
 
@@ -27,25 +27,25 @@ import { ProgressBarState } from '../../utils/format-progress';
   imports: [ProgressBarComponent],
   templateUrl: './job-progress.component.html',
   styleUrl: './job-progress.component.scss',
-  host: { '[class.jp-host--cell]': 'cell' },
+  host: { '[class.jp-host--cell]': 'cell()' },
 })
 export class JobProgressComponent {
   /** One-line title, e.g. "Loading dataset · Step 2 of 4 · Downloading source". */
-  @Input() header = '';
+  readonly header = input('');
   /** Longer explanation surfaced behind the `(?)` chip; empty hides the chip. */
-  @Input() description = '';
+  readonly description = input('');
   /** Per-item detail (left of the bar), e.g. "012/345 FileABC.img". */
-  @Input() detail = '';
+  readonly detail = input('');
   /** Right-justified status, e.g. "5.5 min left" or "45%". */
-  @Input() eta = '';
+  readonly eta = input('');
   /** Bar fill state; defaults to an indeterminate spinner. */
-  @Input() bar: ProgressBarState = { value: 0, max: 1, indeterminate: true };
+  readonly bar = input<ProgressBarState>({ value: 0, max: 1, indeterminate: true });
   /** Ease the fill for multi-phase jobs (see `vt-progress-bar`'s `smooth`). */
-  @Input() smooth = false;
+  readonly smooth = input(false);
   /** Cancel-button tooltip; `null` hides the button entirely. */
-  @Input() cancelTitle: string | null = 'Cancel';
+  readonly cancelTitle = input<string | null>('Cancel');
   /** Cancel-button label. */
-  @Input() cancelLabel = 'Cancel';
+  readonly cancelLabel = input('Cancel');
   /**
    * Cancel-acknowledgement mode. Backends take a while to unwind, so once the
    * user has clicked Cancel we swap the live button for a disabled
@@ -53,13 +53,13 @@ export class JobProgressComponent {
    * the row visibly acknowledges the click instead of freezing in its
    * pre-cancel state and inviting repeated clicks.
    */
-  @Input() cancelling = false;
+  readonly cancelling = input(false);
   /**
    * Table-cell mode: pin the host to the cell width (`width: 0; min-width:
    * 100%`) and give the detail slot a fixed width, so the loading row's text
    * never feeds the auto column-sizing algorithm.
    */
-  @Input() cell = false;
+  readonly cell = input(false);
 
   readonly cancel = output<void>();
 

--- a/frontend/src/app/components/progress-bar/progress-bar.component.html
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.html
@@ -1,15 +1,15 @@
 <div
   class="progress-track"
   role="progressbar"
-  [attr.aria-valuenow]="indeterminate ? null : value"
+  [attr.aria-valuenow]="indeterminate() ? null : value()"
   [attr.aria-valuemin]="0"
-  [attr.aria-valuemax]="max"
+  [attr.aria-valuemax]="max()"
 >
   <div
     class="progress-fill"
-    [class.indeterminate]="indeterminate"
-    [class.progress-fill--smooth]="smooth"
-    [style.width.%]="indeterminate ? 100 : percentage"
+    [class.indeterminate]="indeterminate()"
+    [class.progress-fill--smooth]="smooth()"
+    [style.width.%]="indeterminate() ? 100 : percentage"
     [style.background]="fillColor"
   ></div>
 </div>

--- a/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.spec.ts
@@ -21,20 +21,20 @@ describe('ProgressBarComponent', () => {
   });
 
   it('should calculate percentage correctly', () => {
-    component.value = 50;
-    component.max = 200;
+    fixture.componentRef.setInput('value', 50);
+    fixture.componentRef.setInput('max', 200);
     expect(component.percentage).toBe(25);
   });
 
   it('should clamp percentage to 100', () => {
-    component.value = 150;
-    component.max = 100;
+    fixture.componentRef.setInput('value', 150);
+    fixture.componentRef.setInput('max', 100);
     expect(component.percentage).toBe(100);
   });
 
   it('should handle zero max', () => {
-    component.value = 50;
-    component.max = 0;
+    fixture.componentRef.setInput('value', 50);
+    fixture.componentRef.setInput('max', 0);
     expect(component.percentage).toBe(0);
   });
 
@@ -83,37 +83,37 @@ describe('ProgressBarComponent', () => {
 
   describe('fillColor', () => {
     it('should be reddest at 0%', () => {
-      component.value = 0;
-      component.max = 100;
+      fixture.componentRef.setInput('value', 0);
+      fixture.componentRef.setInput('max', 100);
       expect(component.fillColor).toBe('color-mix(in srgb, var(--text-warning) 0%, var(--color-bad))');
     });
 
     it('should be yellowest at 50%', () => {
-      component.value = 50;
-      component.max = 100;
+      fixture.componentRef.setInput('value', 50);
+      fixture.componentRef.setInput('max', 100);
       expect(component.fillColor).toBe('color-mix(in srgb, var(--text-warning) 100%, var(--color-bad))');
     });
 
     it('should be greenest at 100%', () => {
-      component.value = 100;
-      component.max = 100;
+      fixture.componentRef.setInput('value', 100);
+      fixture.componentRef.setInput('max', 100);
       expect(component.fillColor).toBe('color-mix(in srgb, var(--color-good) 100%, var(--text-warning))');
     });
 
     it('should interpolate continuously between red and yellow below 50%', () => {
-      component.value = 25;
-      component.max = 100;
+      fixture.componentRef.setInput('value', 25);
+      fixture.componentRef.setInput('max', 100);
       expect(component.fillColor).toBe('color-mix(in srgb, var(--text-warning) 50%, var(--color-bad))');
     });
 
     it('should interpolate continuously between yellow and green above 50%', () => {
-      component.value = 75;
-      component.max = 100;
+      fixture.componentRef.setInput('value', 75);
+      fixture.componentRef.setInput('max', 100);
       expect(component.fillColor).toBe('color-mix(in srgb, var(--color-good) 50%, var(--text-warning))');
     });
 
     it('should be null while indeterminate', () => {
-      component.indeterminate = true;
+      fixture.componentRef.setInput('indeterminate', true);
       expect(component.fillColor).toBeNull();
     });
 
@@ -128,36 +128,36 @@ describe('ProgressBarComponent', () => {
 
   describe('polarity: high-bad', () => {
     beforeEach(() => {
-      component.polarity = 'high-bad';
+      fixture.componentRef.setInput('polarity', 'high-bad');
     });
 
     it('should be greenest at 0% (empty is good)', () => {
-      component.value = 0;
-      component.max = 100;
+      fixture.componentRef.setInput('value', 0);
+      fixture.componentRef.setInput('max', 100);
       expect(component.fillColor).toBe('color-mix(in srgb, var(--color-good) 100%, var(--text-warning))');
     });
 
     it('should be yellowest at 50%', () => {
-      component.value = 50;
-      component.max = 100;
+      fixture.componentRef.setInput('value', 50);
+      fixture.componentRef.setInput('max', 100);
       expect(component.fillColor).toBe('color-mix(in srgb, var(--text-warning) 100%, var(--color-bad))');
     });
 
     it('should be reddest at 100% (full is bad)', () => {
-      component.value = 100;
-      component.max = 100;
+      fixture.componentRef.setInput('value', 100);
+      fixture.componentRef.setInput('max', 100);
       expect(component.fillColor).toBe('color-mix(in srgb, var(--text-warning) 0%, var(--color-bad))');
     });
 
     it('mirrors the high-good gradient', () => {
-      component.value = 25;
-      component.max = 100;
+      fixture.componentRef.setInput('value', 25);
+      fixture.componentRef.setInput('max', 100);
       // 25% under high-bad colors as 75% would under high-good.
       expect(component.fillColor).toBe('color-mix(in srgb, var(--color-good) 50%, var(--text-warning))');
     });
 
     it('should be null while indeterminate', () => {
-      component.indeterminate = true;
+      fixture.componentRef.setInput('indeterminate', true);
       expect(component.fillColor).toBeNull();
     });
   });

--- a/frontend/src/app/components/progress-bar/progress-bar.component.ts
+++ b/frontend/src/app/components/progress-bar/progress-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 /**
  * Which direction of a progress bar reads as "good", picking the fill gradient.
@@ -15,9 +15,9 @@ export type ProgressPolarity = 'high-good' | 'high-bad';
   styleUrl: './progress-bar.component.scss',
 })
 export class ProgressBarComponent {
-  @Input() value = 0;
-  @Input() max = 100;
-  @Input() indeterminate = false;
+  readonly value = input(0);
+  readonly max = input(100);
+  readonly indeterminate = input(false);
   /**
    * Opt-in for multi-stage jobs whose `value` is a single whole-job fraction
    * stitched from several phases (the dataset-load bar). It swaps the snappy
@@ -27,7 +27,7 @@ export class ProgressBarComponent {
    * only ever eases *toward* the real reported value, so it never overstates
    * progress.
    */
-  @Input() smooth = false;
+  readonly smooth = input(false);
   /**
    * Whether a fuller bar is good or bad, which picks the direction of the
    * red -> yellow -> green fill gradient:
@@ -39,11 +39,11 @@ export class ProgressBarComponent {
    *   it fills.
    * The two are mirror images: `'high-bad'` colors by `100 - percentage`.
    */
-  @Input() polarity: ProgressPolarity = 'high-good';
+  readonly polarity = input<ProgressPolarity>('high-good');
 
   get percentage(): number {
-    if (this.max <= 0) return 0;
-    return Math.min(100, (this.value / this.max) * 100);
+    if (this.max() <= 0) return 0;
+    return Math.min(100, (this.value() / this.max()) * 100);
   }
 
   /**
@@ -59,8 +59,8 @@ export class ProgressBarComponent {
    * SCSS default (`--accent`); there is no percentage to color by.
    */
   get fillColor(): string | null {
-    if (this.indeterminate) return null;
-    const pct = this.polarity === 'high-bad' ? 100 - this.percentage : this.percentage;
+    if (this.indeterminate()) return null;
+    const pct = this.polarity() === 'high-bad' ? 100 - this.percentage : this.percentage;
     if (pct <= 50) {
       const t = (pct / 50) * 100;
       return `color-mix(in srgb, var(--text-warning) ${t}%, var(--color-bad))`;


### PR DESCRIPTION
Converts the two progress-display components from decorator `@Input` to signal `input()`, part of the Angular signal-API modernization tracked in `docs/plans/angular-22-upgrade.md`.

## Changes
- **`progress-bar.component.ts`** — 5 `@Input`s (`value`, `max`, `indeterminate`, `smooth`, `polarity`) → `input()`; getters (`percentage`, `fillColor`) now call the signals.
- **`job-progress.component.ts`** — 10 `@Input`s (`header`, `description`, `detail`, `eta`, `bar`, `smooth`, `cancelTitle`, `cancelLabel`, `cancelling`, `cell`) → `input()`; the `jp-host--cell` host binding now calls `cell()`.
- Both templates updated to invoke the input signals.
- `progress-bar.component.spec.ts` — direct property assignments switched to `fixture.componentRef.setInput(...)`. (The job-progress spec already used `setInput`.)

## Verification
- `./run-tests.sh frontend` passes: TypeScript build clean (zero `▲ [WARNING]`), all 1684 Vitest tests green.

## Acceptance criteria
- [x] No `@Input` decorators remain in either file.
- [x] `./run-tests.sh frontend` passes.

Refs #2541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPtCCEBMC6p9pfL7PoxP66)_