### PR TITLE
refactor(importer-pickers): migrate to signal inputs/outputs

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -605,13 +605,11 @@ describe('DatasetImporterModalComponent', () => {
   it('should default the demo media-type tab to the active context type when known', () => {
     flushImporters();
     // The dashboard passes the active context's single media type (e.g. an
-    // Image dataset/detector already loaded) as guessedMediaType. It is now
-    // consumed via a child @Input; a direct field write on the parent
-    // doesn't flow through an Angular input binding under OnPush unless a
-    // real change-detection pass runs, so set it on the picker directly
-    // (mirroring what the real `[guessedMediaType]` binding would deliver).
-    component.guessedMediaType = 'image';
-    component.demoPicker.guessedMediaType = 'image';
+    // Image dataset/detector already loaded) as guessedMediaType. Set it via
+    // setInput and run a change-detection pass so the `[guessedMediaType]`
+    // binding delivers it into the demo picker's signal input.
+    fixture.componentRef.setInput('guessedMediaType', 'image');
+    TestBed.tick();
 
     component.openDemoPicker();
     httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.html
@@ -46,9 +46,9 @@
       [selectedClipper]="selectedDemoClipper()"
       [selectedClipperParams]="demoClipperParamValues()"
       (clipperChooserRequested)="openClipperChooser()"
-      [buildProjection]="buildProjection"
+      [buildProjection]="buildProjection()"
       (buildProjectionChange)="buildProjectionChange.emit($event)"
-      [mergeNearDuplicates]="mergeNearDuplicates"
+      [mergeNearDuplicates]="mergeNearDuplicates()"
       (mergeNearDuplicatesChange)="mergeNearDuplicatesChange.emit($event)"
     ></vt-import-advanced>
   </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, HostListener, Input, Output, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, inject, signal, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ClipperChooserComponent, ClipperSelection } from '../../../clipper-chooser/clipper-chooser.component';
@@ -33,18 +33,18 @@ export class DemoPickerComponent {
   private importDefaults = inject(ImportDefaultsService);
   private cdr = inject(ChangeDetectorRef);
 
-  @Input() guessedMediaType = '';
-  @Input() guessedMediaEmbedder = '';
+  readonly guessedMediaType = input('');
+  readonly guessedMediaEmbedder = input('');
 
-  @Input() buildProjection = false;
-  @Output() buildProjectionChange = new EventEmitter<boolean>();
-  @Input() mergeNearDuplicates = false;
-  @Output() mergeNearDuplicatesChange = new EventEmitter<boolean>();
+  readonly buildProjection = input(false);
+  readonly buildProjectionChange = output<boolean>();
+  readonly mergeNearDuplicates = input(false);
+  readonly mergeNearDuplicatesChange = output<boolean>();
 
   /** Fired when the user commits the current row selection via the
    *  Import footer button; the parent forwards the payload to its own
    *  ``demoSelected`` output and closes the modal. */
-  @Output() demoDatasetSelected = new EventEmitter<DemoDatasetEntry & Record<string, unknown>>();
+  readonly demoDatasetSelected = output<DemoDatasetEntry & Record<string, unknown>>();
 
   readonly selectedImporter = signal<ImporterInfo | null>(null);
 
@@ -212,7 +212,7 @@ export class DemoPickerComponent {
     if (this.demoTabs().length > 0) {
       const needsSelect = !this.activeTab() || (solo && this.activeTab() !== solo);
       if (needsSelect) {
-        const guessed = this.guessedMediaType;
+        const guessed = this.guessedMediaType();
         const preferred = solo && this.demoTabs().includes(solo)
           ? solo
           : (guessed && this.demoTabs().includes(guessed)
@@ -262,7 +262,7 @@ export class DemoPickerComponent {
       next: (embedders) => {
         this.demoEmbedders.set(embedders);
         this.selectedDemoEmbedder.set(
-          this.importDefaults.pickInitialEmbedder(embedders, embeddableType, this.mediaTypes(), this.guessedMediaEmbedder),
+          this.importDefaults.pickInitialEmbedder(embedders, embeddableType, this.mediaTypes(), this.guessedMediaEmbedder()),
         );
         this.updateDemoStatuses();
         if (this.selectedDemoEmbedder()) {
@@ -421,8 +421,8 @@ export class DemoPickerComponent {
       ...(effClipper ? { clipper: effClipper, clipper_params: { ...this.demoClipperParamValues() } } : {}),
       ...(converter ? { converter } : {}),
       dataset_name: userName,
-      build_projection: this.buildProjection,
-      merge_near_duplicates: this.mergeNearDuplicates,
+      build_projection: this.buildProjection(),
+      merge_near_duplicates: this.mergeNearDuplicates(),
     } as any);
   }
 }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.html
@@ -184,9 +184,9 @@
         [selectedClipper]="selectedClipper()"
         [selectedClipperParams]="clipperParamValues()"
         (clipperChooserRequested)="openClipperChooser()"
-        [buildProjection]="buildProjection"
+        [buildProjection]="buildProjection()"
         (buildProjectionChange)="buildProjectionChange.emit($event)"
-        [mergeNearDuplicates]="mergeNearDuplicates"
+        [mergeNearDuplicates]="mergeNearDuplicates()"
         (mergeNearDuplicatesChange)="mergeNearDuplicatesChange.emit($event)"
       ></vt-import-advanced>
     </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
@@ -28,7 +28,7 @@ describe('GenericFormPickerComponent', () => {
 
     fixture = TestBed.createComponent(GenericFormPickerComponent);
     component = fixture.componentInstance;
-    component.importers = [importer];
+    fixture.componentRef.setInput('importers', [importer]);
     httpMock = TestBed.inject(HttpTestingController);
   });
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, signal, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ClipperChooserComponent, ClipperSelection } from '../../../clipper-chooser/clipper-chooser.component';
@@ -49,19 +49,19 @@ export class GenericFormPickerComponent {
 
   /** Every registered importer (used to resolve the active importer's
    *  ``available_converters_by_media_type`` for the source-specs picker). */
-  @Input() importers: ImporterInfo[] = [];
-  @Input() mediaTypes: MediaTypeInfo[] = [];
-  @Input() guessedMediaType = '';
-  @Input() guessedMediaEmbedder = '';
+  readonly importers = input<ImporterInfo[]>([]);
+  readonly mediaTypes = input<MediaTypeInfo[]>([]);
+  readonly guessedMediaType = input('');
+  readonly guessedMediaEmbedder = input('');
 
   /** "Build the 2-D Browse projection at ingest" toggle, shared across
    *  every import flow in the parent modal. */
-  @Input() buildProjection = false;
-  @Output() buildProjectionChange = new EventEmitter<boolean>();
-  @Input() mergeNearDuplicates = false;
-  @Output() mergeNearDuplicatesChange = new EventEmitter<boolean>();
+  readonly buildProjection = input(false);
+  readonly buildProjectionChange = output<boolean>();
+  readonly mergeNearDuplicates = input(false);
+  readonly mergeNearDuplicatesChange = output<boolean>();
 
-  @Output() importStarted = new EventEmitter<void>();
+  readonly importStarted = output<void>();
 
   readonly selectedImporter = signal<ImporterInfo | null>(null);
   formValues: Record<string, any> = {};
@@ -95,23 +95,23 @@ export class GenericFormPickerComponent {
   }
 
   get effectiveSoloFolderName(): string {
-    return this.importDefaults.effectiveSoloFolderName(this.mediaTypes);
+    return this.importDefaults.effectiveSoloFolderName(this.mediaTypes());
   }
 
   get mediaTypeOptionLabels(): Record<string, string> {
-    return mediaTypeOptionLabels(this.mediaTypes);
+    return mediaTypeOptionLabels(this.mediaTypes());
   }
 
   get mediaTypeLabels(): Record<string, string> {
-    return mediaTypeLabels(this.mediaTypes);
+    return mediaTypeLabels(this.mediaTypes());
   }
 
   get mediaTypeOptionIcons(): Record<string, string> {
-    return mediaTypeOptionIcons(this.mediaTypes);
+    return mediaTypeOptionIcons(this.mediaTypes());
   }
 
   lockedEmbedderFor(mediaTypeFolderOrTypeId: string, embedders: EmbedderInfo[]): string {
-    return this.importDefaults.lockedEmbedderFor(mediaTypeFolderOrTypeId, this.mediaTypes, embedders);
+    return this.importDefaults.lockedEmbedderFor(mediaTypeFolderOrTypeId, this.mediaTypes(), embedders);
   }
 
   /** Open this picker for *importer* (an importer whose ``picker_view``
@@ -145,8 +145,9 @@ export class GenericFormPickerComponent {
     }
 
     const mediaTypeField = importer.fields?.find((f) => f.key === 'media_type');
-    if (mediaTypeField && this.guessedMediaType) {
-      const folderName = toFolderName(this.mediaTypes, this.guessedMediaType);
+    const guessedMediaType = this.guessedMediaType();
+    if (mediaTypeField && guessedMediaType) {
+      const folderName = toFolderName(this.mediaTypes(), guessedMediaType);
       if (folderName && mediaTypeField.options?.includes(folderName)) {
         this.formValues['media_type'] = folderName;
       }
@@ -298,7 +299,7 @@ export class GenericFormPickerComponent {
     this.datasetsListingsApi.getClippers(mediaType).subscribe({
       next: (clippers) => {
         this.availableClippers.set(clippers);
-        const chosen = this.importDefaults.chooseClipperForType(clippers, mediaType, this.mediaTypes);
+        const chosen = this.importDefaults.chooseClipperForType(clippers, mediaType, this.mediaTypes());
         this.selectedClipper.set(chosen.name);
         if (chosen.params !== null) {
           this.clipperParamValues.set(chosen.params);
@@ -339,7 +340,7 @@ export class GenericFormPickerComponent {
       next: (embedders) => {
         this.availableEmbedders.set(embedders);
         this.selectedEmbedder.set(
-          this.importDefaults.chooseEmbedderForType(embedders, mediaType, this.mediaTypes, this.guessedMediaEmbedder),
+          this.importDefaults.chooseEmbedderForType(embedders, mediaType, this.mediaTypes(), this.guessedMediaEmbedder()),
         );
       },
     });
@@ -355,16 +356,16 @@ export class GenericFormPickerComponent {
   }
 
   get outputTypeId(): string {
-    return toTypeId(this.mediaTypes, String(this.formValues['media_type'] || ''));
+    return toTypeId(this.mediaTypes(), String(this.formValues['media_type'] || ''));
   }
 
   get availableConverters(): ConverterInfo[] {
     if (!this.selectedImporter()) return [];
-    return availableConvertersFor(this.importers, this.selectedImporter()!.name, this.outputTypeId);
+    return availableConvertersFor(this.importers(), this.selectedImporter()!.name, this.outputTypeId);
   }
 
   resetSourceSpecs(): void {
-    this.sourceSpecs = this.importDefaults.specsListWithDefaultsFor(this.mediaTypes, this.outputTypeId, this.availableConverters);
+    this.sourceSpecs = this.importDefaults.specsListWithDefaultsFor(this.mediaTypes(), this.outputTypeId, this.availableConverters);
   }
 
   onSpecsChange(specs: SourceSpec[]): void {
@@ -428,12 +429,12 @@ export class GenericFormPickerComponent {
     if (this.sourceSpecs.length > 0) {
       submitValues['source_specs'] = this.sourceSpecs;
     }
-    submitValues['build_projection'] = this.buildProjection ? 'true' : 'false';
-    submitValues['merge_near_duplicates'] = this.mergeNearDuplicates ? 'true' : 'false';
+    submitValues['build_projection'] = this.buildProjection() ? 'true' : 'false';
+    submitValues['merge_near_duplicates'] = this.mergeNearDuplicates() ? 'true' : 'false';
 
     const fileField = importer.fields?.find((f) => f.field_type === 'file');
     if (fileField && this.selectedFile) {
-      this.datasetsCrudApi.loadFile(this.selectedFile, this.buildProjection).subscribe({
+      this.datasetsCrudApi.loadFile(this.selectedFile, this.buildProjection()).subscribe({
         next: () => {
           this.submitting.set(false);
           this.offerSaveImportDefaults();
@@ -470,6 +471,6 @@ export class GenericFormPickerComponent {
       this.availableEmbedders(),
       this.availableClippers(),
     );
-    this.importDefaults.maybeOfferSaveImportDefaults(typeId, cfg, this.mediaTypes);
+    this.importDefaults.maybeOfferSaveImportDefaults(typeId, cfg, this.mediaTypes());
   }
 }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.html
@@ -44,9 +44,9 @@
     [selectedClipper]="selectedClipper()"
     [selectedClipperParams]="clipperParamValues()"
     (clipperChooserRequested)="openClipperChooser()"
-    [buildProjection]="buildProjection"
+    [buildProjection]="buildProjection()"
     (buildProjectionChange)="buildProjectionChange.emit($event)"
-    [mergeNearDuplicates]="mergeNearDuplicates"
+    [mergeNearDuplicates]="mergeNearDuplicates()"
     (mergeNearDuplicatesChange)="mergeNearDuplicatesChange.emit($event)"
   ></vt-import-advanced>
 </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.spec.ts
@@ -25,7 +25,7 @@ describe('LocalFolderPickerComponent', () => {
 
     fixture = TestBed.createComponent(LocalFolderPickerComponent);
     component = fixture.componentInstance;
-    component.importers = [localFolderImporter, localFilesImporter, serverFolderImporter];
+    fixture.componentRef.setInput('importers', [localFolderImporter, localFilesImporter, serverFolderImporter]);
     httpMock = TestBed.inject(HttpTestingController);
   });
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, signal, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ClipperChooserComponent, ClipperSelection } from '../../../clipper-chooser/clipper-chooser.component';
@@ -58,17 +58,17 @@ export class LocalFolderPickerComponent {
   private importDefaults = inject(ImportDefaultsService);
   private cdr = inject(ChangeDetectorRef);
 
-  @Input() importers: ImporterInfo[] = [];
-  @Input() mediaTypes: MediaTypeInfo[] = [];
-  @Input() guessedMediaType = '';
-  @Input() guessedMediaEmbedder = '';
+  readonly importers = input<ImporterInfo[]>([]);
+  readonly mediaTypes = input<MediaTypeInfo[]>([]);
+  readonly guessedMediaType = input('');
+  readonly guessedMediaEmbedder = input('');
 
-  @Input() buildProjection = false;
-  @Output() buildProjectionChange = new EventEmitter<boolean>();
-  @Input() mergeNearDuplicates = false;
-  @Output() mergeNearDuplicatesChange = new EventEmitter<boolean>();
+  readonly buildProjection = input(false);
+  readonly buildProjectionChange = output<boolean>();
+  readonly mergeNearDuplicates = input(false);
+  readonly mergeNearDuplicatesChange = output<boolean>();
 
-  @Output() importStarted = new EventEmitter<void>();
+  readonly importStarted = output<void>();
 
   readonly selectedImporter = signal<ImporterInfo | null>(null);
 
@@ -111,27 +111,27 @@ export class LocalFolderPickerComponent {
   }
 
   get effectiveSoloFolderName(): string {
-    return this.importDefaults.effectiveSoloFolderName(this.mediaTypes);
+    return this.importDefaults.effectiveSoloFolderName(this.mediaTypes());
   }
 
   get mediaTypeOptionLabels(): Record<string, string> {
-    return mediaTypeOptionLabels(this.mediaTypes);
+    return mediaTypeOptionLabels(this.mediaTypes());
   }
 
   get mediaTypeOptionIcons(): Record<string, string> {
-    return mediaTypeOptionIcons(this.mediaTypes);
+    return mediaTypeOptionIcons(this.mediaTypes());
   }
 
   get mediaTypeLabels(): Record<string, string> {
-    return mediaTypeLabels(this.mediaTypes);
+    return mediaTypeLabels(this.mediaTypes());
   }
 
   lockedEmbedderFor(mediaTypeFolderOrTypeId: string, embedders: EmbedderInfo[]): string {
-    return this.importDefaults.lockedEmbedderFor(mediaTypeFolderOrTypeId, this.mediaTypes, embedders);
+    return this.importDefaults.lockedEmbedderFor(mediaTypeFolderOrTypeId, this.mediaTypes(), embedders);
   }
 
   detectionHint(): string {
-    return detectionHint(this.mediaTypes, this.detection());
+    return detectionHint(this.mediaTypes(), this.detection());
   }
 
   /** First selected file's webkitRelativePath top-level segment, for display. */
@@ -155,11 +155,11 @@ export class LocalFolderPickerComponent {
     this.datasetName = '';
     this.datasetNameDirty = false;
 
-    const folderImporter = this.importers.find((imp) => imp.name === 'server_folder');
+    const folderImporter = this.importers().find((imp) => imp.name === 'server_folder');
     const mtField = folderImporter?.fields?.find((f) => f.key === 'media_type');
     this.mediaTypeOptions = mtField?.options || [];
 
-    const guessedFolder = toFolderName(this.mediaTypes, this.guessedMediaType);
+    const guessedFolder = toFolderName(this.mediaTypes(), this.guessedMediaType());
     if (guessedFolder && this.mediaTypeOptions.includes(guessedFolder)) {
       this.mediaType = guessedFolder;
     } else {
@@ -211,14 +211,14 @@ export class LocalFolderPickerComponent {
     if (!this.datasetNameDirty) {
       this.datasetName = this.derivedDatasetName();
     }
-    this.detection.set(detectFromFiles(this.mediaTypes, this.files(), this.recursive));
+    this.detection.set(detectFromFiles(this.mediaTypes(), this.files(), this.recursive));
     this.applyDetection();
   }
 
   onRecursiveChange(recursive: boolean): void {
     this.recursive = recursive;
     if (this.files().length > 0) {
-      this.detection.set(detectFromFiles(this.mediaTypes, this.files(), this.recursive));
+      this.detection.set(detectFromFiles(this.mediaTypes(), this.files(), this.recursive));
       this.applyDetection();
     }
   }
@@ -226,8 +226,8 @@ export class LocalFolderPickerComponent {
   private applyDetection(): void {
     const detection = this.detection();
     if (!detection) return;
-    const { mediaType, sourceSpecs } = autofillFromDetection(this.mediaTypes, detection, this.mediaTypeOptions, (typeId) =>
-      availableConvertersFor(this.importers, 'server_folder', typeId),
+    const { mediaType, sourceSpecs } = autofillFromDetection(this.mediaTypes(), detection, this.mediaTypeOptions, (typeId) =>
+      availableConvertersFor(this.importers(), 'server_folder', typeId),
     );
     if (mediaType && mediaType !== this.mediaType) {
       this.mediaType = mediaType;
@@ -276,7 +276,7 @@ export class LocalFolderPickerComponent {
       next: (embedders) => {
         this.embedders.set(embedders);
         this.selectedEmbedder.set(
-          this.importDefaults.chooseEmbedderForType(embedders, mediaType, this.mediaTypes, this.guessedMediaEmbedder),
+          this.importDefaults.chooseEmbedderForType(embedders, mediaType, this.mediaTypes(), this.guessedMediaEmbedder()),
         );
       },
     });
@@ -291,7 +291,7 @@ export class LocalFolderPickerComponent {
     this.datasetsListingsApi.getClippers(mediaType).subscribe({
       next: (clippers) => {
         this.clippers.set(clippers);
-        const chosen = this.importDefaults.chooseClipperForType(clippers, mediaType, this.mediaTypes);
+        const chosen = this.importDefaults.chooseClipperForType(clippers, mediaType, this.mediaTypes());
         this.selectedClipper.set(chosen.name);
         if (chosen.params !== null) {
           this.clipperParams = clippers.find((c) => c.name === chosen.name)?.parameters || [];
@@ -319,15 +319,15 @@ export class LocalFolderPickerComponent {
   }
 
   get outputTypeId(): string {
-    return toTypeId(this.mediaTypes, this.mediaType);
+    return toTypeId(this.mediaTypes(), this.mediaType);
   }
 
   get availableConverters(): ConverterInfo[] {
-    return availableConvertersFor(this.importers, 'server_folder', this.outputTypeId);
+    return availableConvertersFor(this.importers(), 'server_folder', this.outputTypeId);
   }
 
   private resetSourceSpecs(): void {
-    this.sourceSpecs = this.importDefaults.specsListWithDefaultsFor(this.mediaTypes, this.outputTypeId, this.availableConverters);
+    this.sourceSpecs = this.importDefaults.specsListWithDefaultsFor(this.mediaTypes(), this.outputTypeId, this.availableConverters);
   }
 
   onSpecsChange(specs: SourceSpec[]): void {
@@ -444,8 +444,8 @@ export class LocalFolderPickerComponent {
         formData.append('clipper_params', JSON.stringify(this.clipperParamValues()));
       }
     }
-    formData.append('build_projection', this.buildProjection ? 'true' : 'false');
-    formData.append('merge_near_duplicates', this.mergeNearDuplicates ? 'true' : 'false');
+    formData.append('build_projection', this.buildProjection() ? 'true' : 'false');
+    formData.append('merge_near_duplicates', this.mergeNearDuplicates() ? 'true' : 'false');
   }
 
   private offerSaveImportDefaults(): void {
@@ -459,6 +459,6 @@ export class LocalFolderPickerComponent {
       this.embedders(),
       this.clippers(),
     );
-    this.importDefaults.maybeOfferSaveImportDefaults(typeId, cfg, this.mediaTypes);
+    this.importDefaults.maybeOfferSaveImportDefaults(typeId, cfg, this.mediaTypes());
   }
 }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.html
@@ -87,9 +87,9 @@
     [selectedClipper]="selectedClipper()"
     [selectedClipperParams]="clipperParamValues()"
     (clipperChooserRequested)="openClipperChooser()"
-    [buildProjection]="buildProjection"
+    [buildProjection]="buildProjection()"
     (buildProjectionChange)="buildProjectionChange.emit($event)"
-    [mergeNearDuplicates]="mergeNearDuplicates"
+    [mergeNearDuplicates]="mergeNearDuplicates()"
     (mergeNearDuplicatesChange)="mergeNearDuplicatesChange.emit($event)"
   ></vt-import-advanced>
 </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.spec.ts
@@ -24,11 +24,11 @@ describe('ServerFolderPickerComponent', () => {
 
     fixture = TestBed.createComponent(ServerFolderPickerComponent);
     component = fixture.componentInstance;
-    component.importers = [serverFolderImporter];
-    component.mediaTypes = [
+    fixture.componentRef.setInput('importers', [serverFolderImporter]);
+    fixture.componentRef.setInput('mediaTypes', [
       { type_id: 'audio', name: 'Audio', folder_import_name: 'audio' } as any,
       { type_id: 'image', name: 'Image', folder_import_name: 'image' } as any,
-    ];
+    ]);
     httpMock = TestBed.inject(HttpTestingController);
   });
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, signal, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { map } from 'rxjs/operators';
@@ -59,17 +59,17 @@ export class ServerFolderPickerComponent {
   private importDefaults = inject(ImportDefaultsService);
   private cdr = inject(ChangeDetectorRef);
 
-  @Input() importers: ImporterInfo[] = [];
-  @Input() mediaTypes: MediaTypeInfo[] = [];
-  @Input() guessedMediaType = '';
-  @Input() guessedMediaEmbedder = '';
+  readonly importers = input<ImporterInfo[]>([]);
+  readonly mediaTypes = input<MediaTypeInfo[]>([]);
+  readonly guessedMediaType = input('');
+  readonly guessedMediaEmbedder = input('');
 
-  @Input() buildProjection = false;
-  @Output() buildProjectionChange = new EventEmitter<boolean>();
-  @Input() mergeNearDuplicates = false;
-  @Output() mergeNearDuplicatesChange = new EventEmitter<boolean>();
+  readonly buildProjection = input(false);
+  readonly buildProjectionChange = output<boolean>();
+  readonly mergeNearDuplicates = input(false);
+  readonly mergeNearDuplicatesChange = output<boolean>();
 
-  @Output() importStarted = new EventEmitter<void>();
+  readonly importStarted = output<void>();
 
   readonly selectedImporter = signal<ImporterInfo | null>(null);
 
@@ -129,27 +129,27 @@ export class ServerFolderPickerComponent {
   }
 
   get effectiveSoloFolderName(): string {
-    return this.importDefaults.effectiveSoloFolderName(this.mediaTypes);
+    return this.importDefaults.effectiveSoloFolderName(this.mediaTypes());
   }
 
   get mediaTypeOptionLabels(): Record<string, string> {
-    return mediaTypeOptionLabels(this.mediaTypes);
+    return mediaTypeOptionLabels(this.mediaTypes());
   }
 
   get mediaTypeOptionIcons(): Record<string, string> {
-    return mediaTypeOptionIcons(this.mediaTypes);
+    return mediaTypeOptionIcons(this.mediaTypes());
   }
 
   get mediaTypeLabels(): Record<string, string> {
-    return mediaTypeLabels(this.mediaTypes);
+    return mediaTypeLabels(this.mediaTypes());
   }
 
   lockedEmbedderFor(mediaTypeFolderOrTypeId: string, embedders: EmbedderInfo[]): string {
-    return this.importDefaults.lockedEmbedderFor(mediaTypeFolderOrTypeId, this.mediaTypes, embedders);
+    return this.importDefaults.lockedEmbedderFor(mediaTypeFolderOrTypeId, this.mediaTypes(), embedders);
   }
 
   detectionHint(): string {
-    return detectionHint(this.mediaTypes, this.detection());
+    return detectionHint(this.mediaTypes(), this.detection());
   }
 
   open(importer: ImporterInfo | null): void {
@@ -165,11 +165,11 @@ export class ServerFolderPickerComponent {
     this.datasetName = '';
     this.datasetNameDirty = false;
 
-    const folderImporter = this.importers.find((imp) => imp.name === 'server_folder');
+    const folderImporter = this.importers().find((imp) => imp.name === 'server_folder');
     const mtField = folderImporter?.fields?.find((f) => f.key === 'media_type');
     this.mediaTypeOptions = mtField?.options || [];
 
-    const guessedFolder = toFolderName(this.mediaTypes, this.guessedMediaType);
+    const guessedFolder = toFolderName(this.mediaTypes(), this.guessedMediaType());
     if (guessedFolder && this.mediaTypeOptions.includes(guessedFolder)) {
       this.mediaType.set(guessedFolder);
     } else {
@@ -273,8 +273,8 @@ export class ServerFolderPickerComponent {
   private applyDetection(): void {
     const detection = this.detection();
     if (!detection) return;
-    const { mediaType, sourceSpecs } = autofillFromDetection(this.mediaTypes, detection, this.mediaTypeOptions, (typeId) =>
-      availableConvertersFor(this.importers, 'server_folder', typeId),
+    const { mediaType, sourceSpecs } = autofillFromDetection(this.mediaTypes(), detection, this.mediaTypeOptions, (typeId) =>
+      availableConvertersFor(this.importers(), 'server_folder', typeId),
     );
     if (mediaType && mediaType !== this.mediaType()) {
       this.mediaType.set(mediaType);
@@ -313,15 +313,15 @@ export class ServerFolderPickerComponent {
   }
 
   get outputTypeId(): string {
-    return toTypeId(this.mediaTypes, this.mediaType());
+    return toTypeId(this.mediaTypes(), this.mediaType());
   }
 
   get availableConverters(): ConverterInfo[] {
-    return availableConvertersFor(this.importers, 'server_folder', this.outputTypeId);
+    return availableConvertersFor(this.importers(), 'server_folder', this.outputTypeId);
   }
 
   private resetSourceSpecs(): void {
-    this.sourceSpecs.set(this.importDefaults.specsListWithDefaultsFor(this.mediaTypes, this.outputTypeId, this.availableConverters));
+    this.sourceSpecs.set(this.importDefaults.specsListWithDefaultsFor(this.mediaTypes(), this.outputTypeId, this.availableConverters));
   }
 
   onSpecsChange(specs: SourceSpec[]): void {
@@ -340,7 +340,7 @@ export class ServerFolderPickerComponent {
       next: (embedders) => {
         this.embedders.set(embedders);
         this.selectedEmbedder.set(
-          this.importDefaults.chooseEmbedderForType(embedders, mediaType, this.mediaTypes, this.guessedMediaEmbedder),
+          this.importDefaults.chooseEmbedderForType(embedders, mediaType, this.mediaTypes(), this.guessedMediaEmbedder()),
         );
       },
     });
@@ -355,7 +355,7 @@ export class ServerFolderPickerComponent {
     this.datasetsListingsApi.getClippers(mediaType).subscribe({
       next: (clippers) => {
         this.clippers.set(clippers);
-        const chosen = this.importDefaults.chooseClipperForType(clippers, mediaType, this.mediaTypes);
+        const chosen = this.importDefaults.chooseClipperForType(clippers, mediaType, this.mediaTypes());
         this.selectedClipper.set(chosen.name);
         if (chosen.params !== null) {
           this.clipperParams = clippers.find((c) => c.name === chosen.name)?.parameters || [];
@@ -432,8 +432,8 @@ export class ServerFolderPickerComponent {
     if (this.sourceSpecs().length > 0) {
       params['source_specs'] = this.sourceSpecs();
     }
-    params['build_projection'] = this.buildProjection ? 'true' : 'false';
-    params['merge_near_duplicates'] = this.mergeNearDuplicates ? 'true' : 'false';
+    params['build_projection'] = this.buildProjection() ? 'true' : 'false';
+    params['merge_near_duplicates'] = this.mergeNearDuplicates() ? 'true' : 'false';
 
     this.datasetsCrudApi.runImporter('server_folder', params).subscribe({
       next: () => {
@@ -459,6 +459,6 @@ export class ServerFolderPickerComponent {
       this.embedders(),
       this.clippers(),
     );
-    this.importDefaults.maybeOfferSaveImportDefaults(typeId, cfg, this.mediaTypes);
+    this.importDefaults.maybeOfferSaveImportDefaults(typeId, cfg, this.mediaTypes());
   }
 }


### PR DESCRIPTION
Converts the four dataset-importer picker components from the decorator `@Input`/`@Output` APIs to signal-based `input()`/`output()` authoring, via the official Angular schematics.

### Files
- `pickers/demo/demo-picker.component.ts` — 4 inputs, 3 outputs
- `pickers/generic-form/generic-form-picker.component.ts` — 6 inputs, 3 outputs
- `pickers/local-folder/local-folder-picker.component.ts` — 6 inputs, 3 outputs
- `pickers/server-folder/server-folder-picker.component.ts` — 6 inputs, 3 outputs

### Approach
- Ran `ng generate @angular/core:signal-input-migration` and `ng generate @angular/core:output-migration` scoped to `pickers/`.
- The schematics initially skipped 5 inputs (`importers`, `mediaTypes`, `guessedMediaType`) because spec files wrote to them via plain field assignment. Converted those spec writes to `fixture.componentRef.setInput(...)` (and, in the parent modal spec, replaced the direct `demoPicker.guessedMediaType = 'image'` write with `setInput('guessedMediaType', ...)` + `TestBed.tick()`), then re-ran the input schematic to migrate all 22 inputs.
- Templates auto-updated to call the new signal inputs (e.g. `[buildProjection]="buildProjection()"`). Output subscription patterns are unchanged.

### Verification
- `./run-tests.sh frontend` passes: `build:prod` with zero `▲ [WARNING]`, `npm audit` clean, Vitest 1684 passed.
- No `@Input`/`@Output`/`EventEmitter` remain in the four picker files.

Part of the Angular signal-API modernization tracked in `docs/plans/angular-22-upgrade.md`.

Closes #2540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwpEWFZ49GiuWd2cxAsMD9)_