### PR TITLE
Signal migration: left-panel controls

### DIFF
--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -48,56 +48,46 @@ describe('AutopilotPanelComponent', () => {
     expect(steps.length).toBe(5);
   });
 
-  it('should transition from good to bad phase', () => {
-    component.goodVotes = new Set([1, 2, 3]);
-    component.ngOnChanges({
-      goodVotes: { currentValue: component.goodVotes, previousValue: new Set(), firstChange: false, isFirstChange: () => false },
-    });
+  it('should transition from good to bad phase', async () => {
+    fixture.componentRef.setInput('goodVotes', new Set([1, 2, 3]));
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('bad');
   });
 
-  it('should transition from bad to hard phase', () => {
-    // Advance to bad phase first
-    component.goodVotes = new Set([1, 2, 3]);
-    autopilotState.checkPhaseTransition(3, 0);
+  it('should transition from bad to hard phase', async () => {
+    fixture.componentRef.setInput('goodVotes', new Set([1, 2, 3]));
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('bad');
 
-    component.badVotes = new Set([4, 5, 6, 7]);
-    component.ngOnChanges({
-      badVotes: { currentValue: component.badVotes, previousValue: new Set(), firstChange: false, isFirstChange: () => false },
-    });
+    fixture.componentRef.setInput('badVotes', new Set([4, 5, 6, 7]));
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('hard');
   });
 
-  it('should transition from hard to new when smart+stable are green', () => {
+  it('should transition from hard to new when smart+stable are green', async () => {
     // Advance to hard phase
-    component.goodVotes = new Set([1, 2, 3]);
-    component.badVotes = new Set([4, 5, 6, 7]);
-    autopilotState.checkPhaseTransition(3, 0);
-    autopilotState.checkPhaseTransition(3, 4);
+    fixture.componentRef.setInput('goodVotes', new Set([1, 2, 3]));
+    fixture.componentRef.setInput('badVotes', new Set([4, 5, 6, 7]));
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('hard');
 
-    component.labelingStatus = {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'green' },
       span: { status: '' },
-    };
-    component.ngOnChanges({
-      labelingStatus: { currentValue: component.labelingStatus, previousValue: null, firstChange: false, isFirstChange: () => false },
     });
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('new');
   });
 
-  it('should transition from new to done when span is green', () => {
+  it('should transition from new to done when span is green', async () => {
     // Advance to new phase
-    component.goodVotes = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    component.badVotes = new Set([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
-    autopilotState.checkPhaseTransition(3, 0);
-    autopilotState.checkPhaseTransition(3, 4);
-    autopilotState.updateFromLabelingStatus({
+    fixture.componentRef.setInput('goodVotes', new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
+    fixture.componentRef.setInput('badVotes', new Set([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]));
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
@@ -105,30 +95,26 @@ describe('AutopilotPanelComponent', () => {
       stable: { status: 'green' },
       span: { status: '' },
     });
-    autopilotState.checkPhaseTransition(10, 10);
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('new');
 
-    component.labelingStatus = {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'green' },
       span: { status: 'green' },
-    };
-    component.ngOnChanges({
-      labelingStatus: { currentValue: component.labelingStatus, previousValue: null, firstChange: false, isFirstChange: () => false },
     });
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('done');
   });
 
-  it('should bounce from new back to hard when smart drops to yellow', () => {
+  it('should bounce from new back to hard when smart drops to yellow', async () => {
     // Advance to new phase
-    component.goodVotes = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    component.badVotes = new Set([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
-    autopilotState.checkPhaseTransition(3, 0);
-    autopilotState.checkPhaseTransition(3, 4);
-    autopilotState.updateFromLabelingStatus({
+    fixture.componentRef.setInput('goodVotes', new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
+    fixture.componentRef.setInput('badVotes', new Set([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]));
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
@@ -136,21 +122,19 @@ describe('AutopilotPanelComponent', () => {
       stable: { status: 'green' },
       span: { status: '' },
     });
-    autopilotState.checkPhaseTransition(10, 10);
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('new');
 
     // A surprise vote causes smart to drop
-    component.labelingStatus = {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: 'yellow' },
       stable: { status: 'green' },
       span: { status: 'yellow' },
-    };
-    component.ngOnChanges({
-      labelingStatus: { currentValue: component.labelingStatus, previousValue: null, firstChange: false, isFirstChange: () => false },
     });
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('hard');
   });
 
@@ -204,30 +188,30 @@ describe('AutopilotPanelComponent', () => {
     expect(component.started.emit).not.toHaveBeenCalled();
   });
 
-  it('should regress from hard to good when vote counts drop to zero', () => {
+  it('should regress from hard to good when vote counts drop to zero', async () => {
     // Advance to hard phase with sufficient votes
-    autopilotState.checkPhaseTransition(3, 4);
+    fixture.componentRef.setInput('goodVotes', new Set([1, 2, 3]));
+    fixture.componentRef.setInput('badVotes', new Set([4, 5, 6, 7]));
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('hard');
 
     // Votes are cleared (e.g. new detector session); phase should regress
-    component.goodVotes = new Set();
-    component.badVotes = new Set();
-    component.ngOnChanges({
-      goodVotes: { currentValue: component.goodVotes, previousValue: new Set([1, 2, 3]), firstChange: false, isFirstChange: () => false },
-    });
+    fixture.componentRef.setInput('goodVotes', new Set());
+    fixture.componentRef.setInput('badVotes', new Set());
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('good');
   });
 
-  it('should regress from hard to bad when good count drops below threshold', () => {
-    autopilotState.checkPhaseTransition(3, 4);
+  it('should regress from hard to bad when good count drops below threshold', async () => {
+    fixture.componentRef.setInput('goodVotes', new Set([1, 2, 3]));
+    fixture.componentRef.setInput('badVotes', new Set([4, 5, 6, 7]));
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('hard');
 
     // Good votes drop below threshold but bad are still sufficient
-    component.goodVotes = new Set([1]);
-    component.badVotes = new Set([4, 5, 6, 7]);
-    component.ngOnChanges({
-      goodVotes: { currentValue: component.goodVotes, previousValue: new Set([1, 2, 3]), firstChange: false, isFirstChange: () => false },
-    });
+    fixture.componentRef.setInput('goodVotes', new Set([1]));
+    fixture.componentRef.setInput('badVotes', new Set([4, 5, 6, 7]));
+    await settleZoneless(fixture);
     expect(component.state.phase).toBe('good');
   });
 
@@ -277,8 +261,8 @@ describe('AutopilotPanelComponent', () => {
   it('activate without labelset labels should not enter retrain mode', async () => {
     autopilotState.clear();
     const fresh = TestBed.createComponent(AutopilotPanelComponent);
-    fresh.componentInstance.labelsetGoodCount = 0;
-    fresh.componentInstance.labelsetBadCount = 0;
+    fresh.componentRef.setInput('labelsetGoodCount', 0);
+    fresh.componentRef.setInput('labelsetBadCount', 0);
     await settleZoneless(fresh);
     expect(fresh.componentInstance.state.retrainMode).toBe(false);
   });
@@ -288,10 +272,10 @@ describe('AutopilotPanelComponent', () => {
     const fresh = TestBed.createComponent(AutopilotPanelComponent);
     // Simulate "trained on DatasetA, switched to DatasetB with 0 votes here":
     // current-dataset goodVotes/badVotes empty, but labelset counts positive.
-    fresh.componentInstance.labelsetGoodCount = 5;
-    fresh.componentInstance.labelsetBadCount = 4;
-    fresh.componentInstance.goodVotes = new Set();
-    fresh.componentInstance.badVotes = new Set();
+    fresh.componentRef.setInput('labelsetGoodCount', 5);
+    fresh.componentRef.setInput('labelsetBadCount', 4);
+    fresh.componentRef.setInput('goodVotes', new Set());
+    fresh.componentRef.setInput('badVotes', new Set());
     await settleZoneless(fresh);
     expect(fresh.componentInstance.state.retrainMode).toBe(true);
     // Still in 'good' phase since current-dataset votes are below threshold.
@@ -306,16 +290,16 @@ describe('AutopilotPanelComponent', () => {
   });
 
   it('caps the good-phase target for display on a tiny dataset', () => {
-    component.datasetSize = 1;
-    component.goodVotes = new Set();
-    component.badVotes = new Set();
+    fixture.componentRef.setInput('datasetSize', 1);
+    fixture.componentRef.setInput('goodVotes', new Set());
+    fixture.componentRef.setInput('badVotes', new Set());
     // Default target is 3, but a 1-item dataset can supply at most 1 good.
     expect(component.effGoodTarget).toBe(1);
   });
 
   it('reaches the exhausted state and renders a note when a 1-item dataset is labeled', async () => {
     // Drive the inputs the way the template binding does, so OnPush re-renders
-    // and ngOnChanges fires the dataset-size-aware phase check.
+    // and the phase-transition effect fires the dataset-size-aware phase check.
     fixture.componentRef.setInput('datasetSize', 1);
     fixture.componentRef.setInput('goodVotes', new Set([1]));
     fixture.componentRef.setInput('badVotes', new Set());

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, input, OnChanges, OnInit, output, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, OnInit, output } from '@angular/core';
 
 import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
 import {
@@ -38,28 +38,28 @@ export interface StepDisplay {
   templateUrl: './autopilot-panel.component.html',
   styleUrl: './autopilot-panel.component.scss',
 })
-export class AutopilotPanelComponent implements OnInit, OnChanges {
+export class AutopilotPanelComponent implements OnInit {
   autopilotState = inject(AutopilotStateService);
   private toastService = inject(ToastService);
 
-  @Input() goodVotes: Set<number> = new Set();
-  @Input() badVotes: Set<number> = new Set();
+  readonly goodVotes = input<Set<number>>(new Set());
+  readonly badVotes = input<Set<number>>(new Set());
   /**
    * Number of items in the active dataset. Feeds the dataset-size-aware phase
    * targets: on a tiny collection the default 3-good / 4-bad targets are
    * unreachable, so they're capped to what the dataset can supply. ``0`` means
    * unknown (still loading); the service leaves the targets uncapped then.
    */
-  @Input() datasetSize = 0;
+  readonly datasetSize = input(0);
   /**
    * Total "good" labels in the active detector's saved labelset, across all
    * datasets it has been used with.  When both this and ``labelsetBadCount``
    * are positive at activation time, autopilot enters retrain mode and uses
    * learned sort throughout instead of starting with text/example sort.
    */
-  @Input() labelsetGoodCount = 0;
-  @Input() labelsetBadCount = 0;
-  @Input() labelingStatus: LabelingStatusResponse | null = null;
+  readonly labelsetGoodCount = input(0);
+  readonly labelsetBadCount = input(0);
+  readonly labelingStatus = input<LabelingStatusResponse | null>(null);
   readonly collapsed = input(false);
 
   readonly started = output<void>();
@@ -68,6 +68,44 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
   readonly refocus = output<void>();
 
   private completionAlerted = false;
+
+  constructor() {
+    // Signal inputs don't fire ``ngOnChanges``; this effect replaces the old
+    // change hook. It re-runs whenever the vote sets, dataset size, or labeling
+    // status change, driving the same phase-transition + completion-toast logic.
+    effect(() => {
+      // Read every reactive input so the effect tracks them as dependencies.
+      const goodVotes = this.goodVotes();
+      const badVotes = this.badVotes();
+      const datasetSize = this.datasetSize();
+      const labelingStatus = this.labelingStatus();
+
+      if (!this.running) return;
+
+      if (labelingStatus) {
+        this.autopilotState.updateFromLabelingStatus(labelingStatus);
+      }
+
+      const prevPhase = this.autopilotState.state.phase;
+      this.autopilotState.checkPhaseTransition(goodVotes.size, badVotes.size, datasetSize);
+      const phase = this.autopilotState.state.phase;
+      if (prevPhase !== phase && !this.completionAlerted) {
+        if (phase === 'done') {
+          this.completionAlerted = true;
+          this.toastService.success({
+            message: 'Autopilot complete',
+            detail: 'All quality indicators are green. You can continue labeling or export your results.',
+          });
+        } else if (phase === 'exhausted') {
+          this.completionAlerted = true;
+          this.toastService.success({
+            message: 'Nothing left to label',
+            detail: 'Autopilot has labeled every item in this dataset. Review your votes or export your results.',
+          });
+        }
+      }
+    });
+  }
 
   get state(): AutopilotState {
     return this.autopilotState.state;
@@ -87,19 +125,20 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
    *  unknown or inconsistent with the vote counts (mirrors the service's
    *  uncapped behavior during load; see ``checkPhaseTransition``). */
   private get remainingUnlabeled(): number {
-    const raw = this.datasetSize - this.goodVotes.size - this.badVotes.size;
-    if (this.datasetSize <= 0 || raw < 0) return Infinity;
+    const datasetSize = this.datasetSize();
+    const raw = datasetSize - this.goodVotes().size - this.badVotes().size;
+    if (datasetSize <= 0 || raw < 0) return Infinity;
     return raw;
   }
 
   /** Good-vote target for the current dataset, capped to what it can supply. */
   get effGoodTarget(): number {
-    return Math.min(this.state.goodToStart, this.goodVotes.size + this.remainingUnlabeled);
+    return Math.min(this.state.goodToStart, this.goodVotes().size + this.remainingUnlabeled);
   }
 
   /** Bad-vote target for the current dataset, capped to what it can supply. */
   get effBadTarget(): number {
-    return Math.min(this.state.badToStart, this.badVotes.size + this.remainingUnlabeled);
+    return Math.min(this.state.badToStart, this.badVotes().size + this.remainingUnlabeled);
   }
 
   get steps(): StepDisplay[] {
@@ -131,51 +170,20 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
     this.activate();
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (!this.running) return;
-
-    if (changes['labelingStatus'] && this.labelingStatus) {
-      this.autopilotState.updateFromLabelingStatus(this.labelingStatus);
-    }
-
-    if (changes['goodVotes'] || changes['badVotes'] || changes['labelingStatus'] || changes['datasetSize']) {
-      const prevPhase = this.autopilotState.state.phase;
-      this.autopilotState.checkPhaseTransition(
-        this.goodVotes.size, this.badVotes.size, this.datasetSize,
-      );
-      const phase = this.autopilotState.state.phase;
-      if (prevPhase !== phase && !this.completionAlerted) {
-        if (phase === 'done') {
-          this.completionAlerted = true;
-          this.toastService.success({
-            message: 'Autopilot complete',
-            detail: 'All quality indicators are green. You can continue labeling or export your results.',
-          });
-        } else if (phase === 'exhausted') {
-          this.completionAlerted = true;
-          this.toastService.success({
-            message: 'Nothing left to label',
-            detail: 'Autopilot has labeled every item in this dataset. Review your votes or export your results.',
-          });
-        }
-      }
-    }
-  }
-
   activate(): void {
     if (this.running) return;
     this.completionAlerted = false;
     // Retrain mode: the detector already has good+bad labels (carried over
     // from a previous dataset), so learned sort is available immediately and
     // autopilot should skip the initial text-mode phase.
-    const retrainMode = this.labelsetGoodCount > 0 && this.labelsetBadCount > 0;
+    const retrainMode = this.labelsetGoodCount() > 0 && this.labelsetBadCount() > 0;
     this.autopilotState.activate(retrainMode);
     // Immediately check whether existing votes already satisfy early phases
     // (e.g. user labeled 23 goods in Manual mode before switching to Autopilot).
-    // ngOnChanges ran before ngOnInit so `running` was false and the check was
-    // skipped; do it now so the phase cascades (good→bad→hard) before we emit.
+    // The phase-transition effect only acts once `running` is true, so seed the
+    // check here so the phase cascades (good→bad→hard) before we emit.
     this.autopilotState.checkPhaseTransition(
-      this.goodVotes.size, this.badVotes.size, this.datasetSize,
+      this.goodVotes().size, this.badVotes().size, this.datasetSize(),
     );
     this.started.emit();
   }
@@ -282,15 +290,15 @@ export class AutopilotPanelComponent implements OnInit, OnChanges {
     const st = this.state;
     switch (phase) {
       case 'good':
-        return `${this.goodVotes.size}/${this.effGoodTarget} good labels`;
+        return `${this.goodVotes().size}/${this.effGoodTarget} good labels`;
       case 'bad':
-        return `${this.badVotes.size}/${this.effBadTarget} bad labels`;
+        return `${this.badVotes().size}/${this.effBadTarget} bad labels`;
       case 'hard': {
         // No count target here — the phase ends when the smart and stable
         // indicators (the dots rendered right after this text) both go green.
         // That explanation lives in the tooltip (phaseDetailTitle); the visible
         // text stays a bare count so it never overflows the panel.
-        const total = this.goodVotes.size + this.badVotes.size;
+        const total = this.goodVotes().size + this.badVotes().size;
         return `${total} labels`;
       }
       case 'new':

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.html
@@ -1,8 +1,8 @@
 <div class="progress-check-bar">
-  @if (sortBusy) {
+  @if (sortBusy()) {
     <div class="sort-overlay" aria-live="polite">
       <vt-job-progress
-        [header]="sortStatus"
+        [header]="sortStatus()"
         [eta]="sortEta"
         [bar]="sortBar"
         cancelTitle="Cancel the running sort"

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.spec.ts
@@ -34,14 +34,14 @@ describe('ProgressIndicatorsComponent', () => {
   });
 
   it('should reflect labeling status', () => {
-    component.labelingStatus = {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: 'green' },
       stable: { status: 'yellow' },
       span: { status: '' },
-    };
+    });
     expect(component.smartStatus).toBe('green');
     expect(component.stableStatus).toBe('yellow');
     expect(component.spanStatus).toBe('');
@@ -59,38 +59,38 @@ describe('ProgressIndicatorsComponent', () => {
   });
 
   it('should show smart subtext with cost', () => {
-    component.labelingStatus = {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: 'yellow', cost: 0.123 },
       stable: { status: '' },
       span: { status: '' },
-    };
+    });
     expect(component.smartSubtext).toBe('Cost: 0.123');
   });
 
   it('should show stable subtext with flips', () => {
-    component.labelingStatus = {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: '' },
       stable: { status: 'yellow', flips: 5 },
       span: { status: '' },
-    };
+    });
     expect(component.stableSubtext).toBe('Flips: 5');
   });
 
   it('should show span subtext with diversity level', () => {
-    component.labelingStatus = {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: '' },
       stable: { status: '' },
       span: { status: 'green', diversity_level: 2.5, max_level: 4 },
-    };
+    });
     expect(component.spanSubtext).toBe('3/4');
   });
 
@@ -130,27 +130,27 @@ describe('ProgressIndicatorsComponent', () => {
   });
 
   it('should include live subtext in smart tooltip when available', () => {
-    component.labelingStatus = {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: 'yellow', cost: 0.456 },
       stable: { status: '' },
       span: { status: '' },
-    };
+    });
     expect(component.smartTooltip).toContain('Cost: 0.456');
     expect(component.smartTooltip).toContain('Smart: the model fits your votes consistently.');
   });
 
   it('should include live subtext in stable tooltip when available', () => {
-    component.labelingStatus = {
+    fixture.componentRef.setInput('labelingStatus', {
       good_count: 0,
       bad_count: 0,
       total_count: 0,
       smart: { status: '' },
       stable: { status: 'yellow', flips: 7 },
       span: { status: '' },
-    };
+    });
     expect(component.stableTooltip).toContain('Flips: 7');
     expect(component.stableTooltip).toContain('Stable: predictions stopped shifting between retrains.');
   });

--- a/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
+++ b/frontend/src/app/components/left-panel/progress-indicators/progress-indicators.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 
 import { JobProgressComponent } from '../../job-progress/job-progress.component';
 import {
@@ -17,9 +17,9 @@ import type { LabelingStatusResponse } from '../../../generated/api-client/model
   styleUrl: './progress-indicators.component.scss',
 })
 export class ProgressIndicatorsComponent {
-  @Input() labelingStatus: LabelingStatusResponse | null = null;
-  @Input() sortBusy = false;
-  @Input() sortStatus = '';
+  readonly labelingStatus = input<LabelingStatusResponse | null>(null);
+  readonly sortBusy = input(false);
+  readonly sortStatus = input('');
   readonly sortProgress = input(0);
   readonly sortProgressTotal = input(0);
   /** Whole-job fraction (0..1) for multi-step scoring; ``null`` falls back to
@@ -55,34 +55,37 @@ export class ProgressIndicatorsComponent {
   }
 
   get smartStatus(): string {
-    return this.labelingStatus?.smart.status || '';
+    return this.labelingStatus()?.smart.status || '';
   }
 
   get stableStatus(): string {
-    return this.labelingStatus?.stable.status || '';
+    return this.labelingStatus()?.stable.status || '';
   }
 
   get spanStatus(): string {
-    return this.labelingStatus?.span.status || '';
+    return this.labelingStatus()?.span.status || '';
   }
 
   get smartSubtext(): string {
-    if (!this.labelingStatus?.smart) return '';
-    const s = this.labelingStatus.smart;
+    const status = this.labelingStatus();
+    if (!status?.smart) return '';
+    const s = status.smart;
     if (s['cost'] != null) return `Cost: ${(s['cost'] as number).toFixed(3)}`;
     return '';
   }
 
   get stableSubtext(): string {
-    if (!this.labelingStatus?.stable) return '';
-    const s = this.labelingStatus.stable;
+    const status = this.labelingStatus();
+    if (!status?.stable) return '';
+    const s = status.stable;
     if (s['flips'] != null) return `Flips: ${s['flips']}`;
     return '';
   }
 
   get spanSubtext(): string {
-    if (!this.labelingStatus?.span) return '';
-    const s = this.labelingStatus.span;
+    const status = this.labelingStatus();
+    if (!status?.span) return '';
+    const s = status.span;
     if (s['diversity_level'] != null && s['max_level'] != null) {
       return `${Math.round(s['diversity_level'] as number)}/${s['max_level']}`;
     }

--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.html
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.html
@@ -1,31 +1,31 @@
 <div class="select-mode-group" role="radiogroup" aria-labelledby="select-mode-label">
   <span class="sort-label" id="select-mode-label" title="Choose which unlabeled item to present next for labeling.">Select:</span>
-  <label class="sort-radio" [class.active]="selectMode === 'top'" title="Pick the highest-ranked unlabeled item. Best for quickly finding strong matches.">
+  <label class="sort-radio" [class.active]="selectMode() === 'top'" title="Pick the highest-ranked unlabeled item. Best for quickly finding strong matches.">
     <input
       type="radio"
       name="selectMode"
       value="top"
-      [checked]="selectMode === 'top'"
+      [checked]="selectMode() === 'top'"
       (change)="onChange('top')"
     />
     Top
   </label>
-  <label class="sort-radio" [class.active]="selectMode === 'hard'" title="Pick the item closest to the good/bad cutoff. These uncertain cases improve the detector fastest.">
+  <label class="sort-radio" [class.active]="selectMode() === 'hard'" title="Pick the item closest to the good/bad cutoff. These uncertain cases improve the detector fastest.">
     <input
       type="radio"
       name="selectMode"
       value="hard"
-      [checked]="selectMode === 'hard'"
+      [checked]="selectMode() === 'hard'"
       (change)="onChange('hard')"
     />
     Hard
   </label>
-  <label class="sort-radio" [class.active]="selectMode === 'new'" title="Pick an item unlike the ones you've seen so far, to cover a broad mix of your collection.">
+  <label class="sort-radio" [class.active]="selectMode() === 'new'" title="Pick an item unlike the ones you've seen so far, to cover a broad mix of your collection.">
     <input
       type="radio"
       name="selectMode"
       value="new"
-      [checked]="selectMode === 'new'"
+      [checked]="selectMode() === 'new'"
       (change)="onChange('new')"
     />
     New

--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.spec.ts
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.spec.ts
@@ -23,7 +23,7 @@ describe('SelectModeComponent', () => {
   });
 
   it('should default to top select mode', () => {
-    expect(component.selectMode).toBe('top');
+    expect(component.selectMode()).toBe('top');
   });
 
   it('should render three radio options', () => {

--- a/frontend/src/app/components/left-panel/select-mode/select-mode.component.ts
+++ b/frontend/src/app/components/left-panel/select-mode/select-mode.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 
 import { SelectMode } from '../left-panel.component';
 
@@ -11,7 +11,7 @@ import { SelectMode } from '../left-panel.component';
   styleUrl: './select-mode.component.scss',
 })
 export class SelectModeComponent {
-  @Input() selectMode: SelectMode = 'top';
+  readonly selectMode = input<SelectMode>('top');
 
   readonly selectModeChange = output<SelectMode>();
 

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.html
@@ -1,33 +1,33 @@
 <div class="sort-bar">
   <div class="sort-mode-group" role="radiogroup" aria-labelledby="sort-mode-label">
     <span class="sort-label" id="sort-mode-label" title="Choose how items are ranked. Text uses a search query, Learned trains on your votes, Load applies a saved detector.">Sort:</span>
-    <label class="sort-radio" [class.active]="sortMode === 'text'" [title]="textDisabled ? 'This dataset’s embedder does not support text queries.' : 'Rank items by how well they match a text description you type in.'">
+    <label class="sort-radio" [class.active]="sortMode() === 'text'" [title]="textDisabled ? 'This dataset’s embedder does not support text queries.' : 'Rank items by how well they match a text description you type in.'">
       <input
         type="radio"
         name="sortMode"
         value="text"
-        [checked]="sortMode === 'text'"
+        [checked]="sortMode() === 'text'"
         [disabled]="textDisabled"
         (change)="onSortModeChange('text')"
       />
       Text
     </label>
-    <label class="sort-radio" [class.active]="sortMode === 'load'" title="Load a previously saved detector and rank items by how well it thinks they match.">
+    <label class="sort-radio" [class.active]="sortMode() === 'load'" title="Load a previously saved detector and rank items by how well it thinks they match.">
       <input
         type="radio"
         name="sortMode"
         value="load"
-        [checked]="sortMode === 'load'"
+        [checked]="sortMode() === 'load'"
         (change)="onSortModeChange('load')"
       />
       Load
     </label>
-    <label class="sort-radio" [class.active]="sortMode === 'learned'" title="Train a detector on your good/bad votes and rank items by how strong a match it thinks each one is. Requires at least 1 good and 1 bad vote.">
+    <label class="sort-radio" [class.active]="sortMode() === 'learned'" title="Train a detector on your good/bad votes and rank items by how strong a match it thinks each one is. Requires at least 1 good and 1 bad vote.">
       <input
         type="radio"
         name="sortMode"
         value="learned"
-        [checked]="sortMode === 'learned'"
+        [checked]="sortMode() === 'learned'"
         [disabled]="learnedDisabled"
         (change)="onSortModeChange('learned')"
       />
@@ -36,7 +36,7 @@
   </div>
 
   <div class="sort-mode-content">
-    @if (sortMode === 'text') {
+    @if (sortMode() === 'text') {
       @if (textDisabled) {
         <div class="text-sort-wrap">
           <span class="sort-hint">This dataset’s embedder does not support text queries.</span>
@@ -64,7 +64,7 @@
       }
     }
 
-    @if (sortMode === 'learned') {
+    @if (sortMode() === 'learned') {
       <div class="learned-sort-wrap">
         @if (learnedDisabled) {
           <span class="sort-hint">Need at least 1 good and 1 bad label</span>
@@ -74,11 +74,11 @@
       </div>
     }
 
-    @if (sortMode === 'load') {
+    @if (sortMode() === 'load') {
       <div class="load-sort-wrap">
         <div class="load-sort-row">
-          @if (loadSortLabel) {
-            <span class="sort-desc">{{ loadSortLabel }}</span>
+          @if (loadSortLabel()) {
+            <span class="sort-desc">{{ loadSortLabel() }}</span>
           } @else {
             <span class="sort-hint">No sort loaded</span>
           }

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.spec.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.spec.ts
@@ -23,7 +23,7 @@ describe('SortBarComponent', () => {
   });
 
   it('should default to text sort mode', () => {
-    expect(component.sortMode).toBe('text');
+    expect(component.sortMode()).toBe('text');
   });
 
   it('should show text input when in text mode', async () => {

--- a/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
+++ b/frontend/src/app/components/left-panel/sort-bar/sort-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, input, OnInit, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, OnInit, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { SortMode } from '../left-panel.component';
@@ -13,15 +13,15 @@ import { LoadSortModalComponent } from '../../modals/load-sort-modal/load-sort-m
   styleUrl: './sort-bar.component.scss',
 })
 export class SortBarComponent implements OnInit {
-  @Input() sortMode: SortMode = 'text';
-  @Input() loadSortLabel = '';
+  readonly sortMode = input<SortMode>('text');
+  readonly loadSortLabel = input('');
   readonly initialTextQuery = input('');
   /**
    * True when the active detector (or active votes, when no detector is
    * loaded) has at least one good and one bad label available for training.
    * Drives the gating of the "Learned" sort mode.
    */
-  @Input() learnedSortAvailable = false;
+  readonly learnedSortAvailable = input(false);
   /**
    * True when the active dataset's embedder supports text queries. ``false``
    * for vision-only encoders (DINOv3, Perception Encoder); disables the
@@ -67,7 +67,7 @@ export class SortBarComponent implements OnInit {
   }
 
   get learnedDisabled(): boolean {
-    return !this.learnedSortAvailable;
+    return !this.learnedSortAvailable();
   }
 
   get textDisabled(): boolean {

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.html
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.html
@@ -1,7 +1,7 @@
 @if (visible) {
   <div class="stripe-overview" role="img" aria-label="Media minimap" title="Minimap of all items in sort order. Green = good votes, red = bad votes, white = selected. Click to jump." (click)="onStripeClick($event)" tabindex="0" (keydown.enter)="onStripeKeyboard()" (keydown.space)="onStripeKeyboard()">
     <div class="stripe-container">
-      @for (dot of cachedDots; track $index) {
+      @for (dot of cachedDots(); track $index) {
         <div
           class="stripe-dot"
           [class.good]="dot.type === 'good'"
@@ -11,10 +11,10 @@
         ></div>
       }
 
-      @if (cachedThresholdPosition !== null) {
+      @if (cachedThresholdPosition() !== null) {
         <div
           class="stripe-threshold"
-          [style.top.%]="cachedThresholdPosition"
+          [style.top.%]="cachedThresholdPosition()"
         ></div>
       }
     </div>

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.spec.ts
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.spec.ts
@@ -27,66 +27,61 @@ describe('StripeOverviewComponent', () => {
   });
 
   it('should be visible when sort order exists', () => {
-    component.sortOrder = [
+    fixture.componentRef.setInput('sortOrder', [
       { id: 1, score: 0.9 },
       { id: 2, score: 0.5 },
-    ];
+    ]);
     expect(component.visible).toBe(true);
   });
 
   it('should generate good dots', () => {
-    component.sortOrder = [
+    fixture.componentRef.setInput('sortOrder', [
       { id: 1, score: 0.9 },
       { id: 2, score: 0.5 },
-    ];
-    component.goodVotes = new Set([1]);
-    component.ngOnChanges();
-    const dots = component.cachedDots;
+    ]);
+    fixture.componentRef.setInput('goodVotes', new Set([1]));
+    const dots = component.cachedDots();
     const goodDots = dots.filter((d: { top: number; type: string }) => d.type === 'good');
     expect(goodDots.length).toBe(1);
     expect(goodDots[0].top).toBe(0);
   });
 
   it('should generate bad dots', () => {
-    component.sortOrder = [
+    fixture.componentRef.setInput('sortOrder', [
       { id: 1, score: 0.9 },
       { id: 2, score: 0.5 },
-    ];
-    component.badVotes = new Set([2]);
-    component.ngOnChanges();
-    const dots = component.cachedDots;
+    ]);
+    fixture.componentRef.setInput('badVotes', new Set([2]));
+    const dots = component.cachedDots();
     const badDots = dots.filter((d: { top: number; type: string }) => d.type === 'bad');
     expect(badDots.length).toBe(1);
     expect(badDots[0].top).toBe(50);
   });
 
   it('should generate selected dot', () => {
-    component.sortOrder = [
+    fixture.componentRef.setInput('sortOrder', [
       { id: 1, score: 0.9 },
       { id: 2, score: 0.5 },
-    ];
-    component.selectedId = 2;
-    component.ngOnChanges();
-    const dots = component.cachedDots;
+    ]);
+    fixture.componentRef.setInput('selectedId', 2);
+    const dots = component.cachedDots();
     const selectedDots = dots.filter((d: { top: number; type: string }) => d.type === 'selected');
     expect(selectedDots.length).toBe(1);
   });
 
   it('should calculate threshold position', () => {
-    component.sortOrder = [
+    fixture.componentRef.setInput('sortOrder', [
       { id: 1, score: 0.9 },
       { id: 2, score: 0.5 },
       { id: 3, score: 0.1 },
-    ];
-    component.threshold = 0.4;
-    component.ngOnChanges();
-    expect(component.cachedThresholdPosition).toBeCloseTo(66.67, 0);
+    ]);
+    fixture.componentRef.setInput('threshold', 0.4);
+    expect(component.cachedThresholdPosition()).toBeCloseTo(66.67, 0);
   });
 
   it('should return null threshold position when no threshold', () => {
-    component.sortOrder = [{ id: 1, score: 0.9 }];
-    component.threshold = null;
-    component.ngOnChanges();
-    expect(component.cachedThresholdPosition).toBeNull();
+    fixture.componentRef.setInput('sortOrder', [{ id: 1, score: 0.9 }]);
+    fixture.componentRef.setInput('threshold', null);
+    expect(component.cachedThresholdPosition()).toBeNull();
   });
 });

--- a/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
+++ b/frontend/src/app/components/left-panel/stripe-overview/stripe-overview.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, input, OnChanges, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 
 import { SortedItem } from '../left-panel.component';
 
@@ -10,62 +10,64 @@ import { SortedItem } from '../left-panel.component';
   templateUrl: './stripe-overview.component.html',
   styleUrl: './stripe-overview.component.scss',
 })
-export class StripeOverviewComponent implements OnChanges {
-  @Input() sortOrder: SortedItem[] | null = null;
-  @Input() threshold: number | null = null;
-  @Input() selectedId: number | null = null;
-  @Input() goodVotes: Set<number> = new Set();
-  @Input() badVotes: Set<number> = new Set();
+export class StripeOverviewComponent {
+  readonly sortOrder = input<SortedItem[] | null>(null);
+  readonly threshold = input<number | null>(null);
+  readonly selectedId = input<number | null>(null);
+  readonly goodVotes = input<Set<number>>(new Set());
+  readonly badVotes = input<Set<number>>(new Set());
   readonly totalCount = input(0);
   readonly stripeClick = output<number>();
 
-  /** Cached dots, rebuilt only when inputs change. */
-  cachedDots: { top: number; type: 'good' | 'bad' | 'selected' }[] = [];
-  /** Cached threshold position, rebuilt only when inputs change. */
-  cachedThresholdPosition: number | null = null;
+  /** Dots, recomputed automatically when the inputs they depend on change. */
+  readonly cachedDots = computed(() => this.buildDots());
+  /** Threshold position, recomputed automatically when inputs change. */
+  readonly cachedThresholdPosition = computed(() => this.buildThresholdPosition());
 
   onStripeKeyboard(): void {
-    if (!this.sortOrder || this.sortOrder.length === 0) return;
-    const midIndex = Math.floor(this.sortOrder.length / 2);
+    const sortOrder = this.sortOrder();
+    if (!sortOrder || sortOrder.length === 0) return;
+    const midIndex = Math.floor(sortOrder.length / 2);
     this.stripeClick.emit(midIndex);
   }
 
   onStripeClick(event: MouseEvent): void {
-    if (!this.sortOrder || this.sortOrder.length === 0) return;
+    const sortOrder = this.sortOrder();
+    if (!sortOrder || sortOrder.length === 0) return;
     const el = event.currentTarget as HTMLElement;
     const rect = el.getBoundingClientRect();
     const y = event.clientY - rect.top;
     const percentage = y / rect.height;
-    const index = Math.max(0, Math.min(Math.floor(percentage * this.sortOrder.length), this.sortOrder.length - 1));
+    const index = Math.max(0, Math.min(Math.floor(percentage * sortOrder.length), sortOrder.length - 1));
     this.stripeClick.emit(index);
   }
 
   get visible(): boolean {
-    return this.sortOrder !== null && this.sortOrder.length > 0;
-  }
-
-  ngOnChanges(): void {
-    this.cachedDots = this.buildDots();
-    this.cachedThresholdPosition = this.buildThresholdPosition();
+    const sortOrder = this.sortOrder();
+    return sortOrder !== null && sortOrder.length > 0;
   }
 
   private buildDots(): { top: number; type: 'good' | 'bad' | 'selected' }[] {
-    if (!this.sortOrder || this.sortOrder.length === 0) return [];
+    const sortOrder = this.sortOrder();
+    if (!sortOrder || sortOrder.length === 0) return [];
 
+    const goodVotes = this.goodVotes();
+    const badVotes = this.badVotes();
+    const selectedId = this.selectedId();
     const result: { top: number; type: 'good' | 'bad' | 'selected' }[] = [];
-    const total = this.sortOrder.length;
+    const total = sortOrder.length;
 
     for (let i = 0; i < total; i++) {
-      const item = this.sortOrder[i];
+      const item = sortOrder[i];
       const topPct = (i / total) * 100;
 
-      if (this.goodVotes.has(item.id)) {
+      if (goodVotes.has(item.id)) {
         result.push({ top: topPct, type: 'good' });
-      } else if (this.badVotes.has(item.id)) {
+      } else if (badVotes.has(item.id)) {
         result.push({ top: topPct, type: 'bad' });
       }
 
-      if (item.id === this.selectedId) {
+      if (item.id === selectedId) {
         result.push({ top: topPct, type: 'selected' });
       }
     }
@@ -74,10 +76,12 @@ export class StripeOverviewComponent implements OnChanges {
   }
 
   private buildThresholdPosition(): number | null {
-    if (!this.sortOrder || this.threshold === null) return null;
-    const total = this.sortOrder.length;
+    const sortOrder = this.sortOrder();
+    const threshold = this.threshold();
+    if (!sortOrder || threshold === null) return null;
+    const total = sortOrder.length;
     for (let i = 0; i < total; i++) {
-      if (this.sortOrder[i].score < this.threshold) {
+      if (sortOrder[i].score < threshold) {
         return (i / total) * 100;
       }
     }


### PR DESCRIPTION
Converts the five left-panel control components to signal-based authoring, per the Angular signal-API modernization umbrella.

## What changed

All 18 `@Input()` decorators across the five components are now `input()` signals:

- **`autopilot-panel`** — 6 inputs (`goodVotes`, `badVotes`, `datasetSize`, `labelsetGoodCount`, `labelsetBadCount`, `labelingStatus`). The `ngOnChanges` phase-transition + completion-toast logic moved into a constructor `effect()` (signal inputs don't fire `ngOnChanges`). The effect tracks the vote sets, dataset size, and labeling status, and drives `updateFromLabelingStatus` / `checkPhaseTransition` / the done/exhausted toasts exactly as before. `activate()` still seeds the initial phase check.
- **`sort-bar`** — 3 inputs (`sortMode`, `loadSortLabel`, `learnedSortAvailable`).
- **`select-mode`** — 1 input (`selectMode`).
- **`progress-indicators`** — 3 inputs (`labelingStatus`, `sortBusy`, `sortStatus`).
- **`stripe-overview`** — 5 inputs (`sortOrder`, `threshold`, `selectedId`, `goodVotes`, `badVotes`). The `ngOnChanges` that rebuilt `cachedDots` / `cachedThresholdPosition` became two `computed()` signals, so the minimap dots and threshold marker recompute automatically from their input dependencies.

Templates and specs updated to call the signal getters. Specs that previously mutated inputs directly and called `ngOnChanges()` now use `componentRef.setInput(...)` and settle the zoneless fixture.

## Acceptance criteria

- [x] No `@Input` decorators remain; no `ngOnChanges` keyed on converted inputs.
- [x] `./run-tests.sh frontend` passes (build OK, audit OK, 1684 Vitest tests passed); left-panel controls behave identically.

Closes #2544 — part of the Angular signal-API modernization tracked in `docs/plans/angular-22-upgrade.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017G1VSma98kVer6tZnpEU1m