### PR TITLE
Signal migration: dashboard cards + create/combine modals

### DIFF
--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.ts
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, OnChanges, output, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -17,7 +17,7 @@ export interface ClipperSelection {
   templateUrl: './clipper-chooser.component.html',
   styleUrl: './clipper-chooser.component.scss',
 })
-export class ClipperChooserComponent implements OnChanges {
+export class ClipperChooserComponent {
   readonly open = input(false);
   readonly clippers = input<ClipperInfo[]>([]);
 
@@ -28,10 +28,16 @@ export class ClipperChooserComponent implements OnChanges {
   /** Per-clipper parameter values, keyed by clipper name then param key. */
   paramValues: Record<string, Record<string, number | string>> = {};
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['open'] && this.open()) {
-      this.initTabs();
-    }
+  private wasOpen = false;
+
+  constructor() {
+    effect(() => {
+      const isOpen = this.open();
+      if (isOpen && !this.wasOpen) {
+        this.initTabs();
+      }
+      this.wasOpen = isOpen;
+    });
   }
 
   private initTabs(): void {

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -42,7 +42,7 @@ export class CombineDatasetsModalComponent implements OnInit {
   private datasetsListingsApi = inject(DatasetsListingsApiService);
 
   /** Datasets pre-selected on the dashboard when the modal was opened. */
-  @Input() datasets: DatasetRegistryEntry[] = [];
+  readonly datasets = input<DatasetRegistryEntry[]>([]);
 
   readonly closed = output<void>();
   readonly combineStarted = output<CombineStartedInfo>();
@@ -56,7 +56,7 @@ export class CombineDatasetsModalComponent implements OnInit {
   name = '';
 
   ngOnInit(): void {
-    this.rows = this.datasets
+    this.rows = this.datasets()
       .map((d) => ({
         id: d.id,
         name: d.name,

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.html
@@ -1,7 +1,7 @@
 <!-- Renders as a <tr> (host selector) inside the dashboard table -->
 <td class="select-col">
-  <button class="card-icon-btn select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect dataset' : 'Select dataset'" [attr.aria-checked]="selected ? 'true' : 'false'" role="checkbox" [attr.title]="selected ? 'Deselect' : 'Select'">
-    @if (selected) {
+  <button class="card-icon-btn select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected() ? 'Deselect dataset' : 'Select dataset'" [attr.aria-checked]="selected() ? 'true' : 'false'" role="checkbox" [attr.title]="selected() ? 'Deselect' : 'Select'">
+    @if (selected()) {
       <vt-icon type="checkbox-checked" [size]="16"></vt-icon>
     } @else {
       <vt-icon type="checkbox-blank" [size]="16"></vt-icon>
@@ -22,7 +22,7 @@
     />
   } @else {
     <span class="name-cell">
-      {{ dataset.name }}
+      {{ dataset().name }}
       <button class="card-icon-btn edit-btn name-edit-btn" (click)="startRename($event)" aria-label="Rename dataset" title="Rename">
         <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
@@ -33,13 +33,13 @@
     </span>
   }
 </td>
-@if (loadingTask && !loadingTask.error) {
+@if (loadingTask() && !loadingTask()!.error) {
   <!-- Inline progress: replace the middle columns with a progress bar. For a
        projection build (the Browse button's pre-build) we keep the actions
        column so the Browse eye stays put and waggles, mirroring how Find/Train
        waggle while their job runs; a plain dataset load replaces the actions
        column too. -->
-  <td [attr.colspan]="taskKind() === 'projection' ? columnOrder.length : columnOrder.length + 1">
+  <td [attr.colspan]="taskKind() === 'projection' ? columnOrder().length : columnOrder().length + 1">
     <vt-job-progress
       [cell]="true"
       [header]="taskProgressInfo.header"
@@ -62,21 +62,21 @@
       </div>
     </td>
   }
-} @else if (loadingTask && loadingTask.error) {
+} @else if (loadingTask() && loadingTask()!.error) {
   <!-- Inline error: replace remaining columns (middle + actions) with error message -->
-  <td [attr.colspan]="columnOrder.length + 1">
+  <td [attr.colspan]="columnOrder().length + 1">
     <div class="inline-loading-failed">
-      <span class="error-msg">Failed: {{ loadingTask.error }}</span>
+      <span class="error-msg">Failed: {{ loadingTask()!.error }}</span>
       <button class="btn btn--cancel btn--sm" (click)="onDismissTask($event)" title="Dismiss this error">Dismiss</button>
     </div>
   </td>
 } @else {
-  @for (col of columnOrder; track col) {
+  @for (col of columnOrder(); track col) {
     @switch (col) {
       @case ('media_type') {
         <td>
           <span class="type-cell">
-            @switch (dataset.media_type) {
+            @switch (dataset().media_type) {
               @case ('audio') {
                 <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
               }
@@ -93,36 +93,36 @@
                 <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
               }
             }
-            {{ capitalizeType(dataset.media_type) }}
+            {{ capitalizeType(dataset().media_type) }}
           </span>
         </td>
       }
       @case ('num_items') {
-        <td>{{ dataset.num_items != null ? (dataset.num_items | number) : '-' }}</td>
+        <td>{{ dataset().num_items != null ? (dataset().num_items | number) : '-' }}</td>
       }
       @case ('created_at') {
-        <td>{{ formatDate(dataset.created_at) }}</td>
+        <td>{{ formatDate(dataset().created_at) }}</td>
       }
       @case ('expires_at') {
-        <td>{{ dataset.expires_at != null ? formatDate(dataset.expires_at) : 'Never' }}</td>
+        <td>{{ dataset().expires_at != null ? formatDate(dataset().expires_at) : 'Never' }}</td>
       }
       @case ('created_by') {
-        <td>{{ dataset.created_by || '-' }}</td>
+        <td>{{ dataset().created_by || '-' }}</td>
       }
       @case ('readers') {
-        <td [title]="(dataset.readers || []).join(', ')">{{ (dataset.readers || []).length ? (dataset.readers || []).join(', ') : '-' }}</td>
+        <td [title]="(dataset().readers || []).join(', ')">{{ (dataset().readers || []).length ? (dataset().readers || []).join(', ') : '-' }}</td>
       }
     }
   }
   <td class="actions-col">
     <div class="card-actions">
-    @if (!dataset.loaded) {
+    @if (!dataset().loaded) {
       <button class="card-icon-btn load-btn" (click)="onLoad($event)" aria-label="Load dataset" title="Load dataset">
         <vt-icon type="import" [size]="14"></vt-icon>
       </button>
     }
     <button class="card-icon-btn card-icon-btn--danger delete-btn" (click)="onDelete($event)" aria-label="Delete dataset" title="Delete dataset">
-      <vt-icon type="trash" [size]="14" [class.trash-active]="deleting" [class.trash-inactive]="!deleting && wasDeleting" (animationend)="onDeleteAnimationEnd()"></vt-icon>
+      <vt-icon type="trash" [size]="14" [class.trash-active]="deleting()" [class.trash-inactive]="!deleting() && wasDeleting" (animationend)="onDeleteAnimationEnd()"></vt-icon>
     </button>
     <button class="card-icon-btn overflow-btn" (click)="onOverflow($event)" aria-label="More actions" title="More actions">
       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">

--- a/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-card/dataset-card.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, inject, input, output, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, effect, inject, input, output, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
@@ -20,7 +20,12 @@ import { DashboardLoadingTasksService } from '../../../services/dashboard-loadin
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'tr[vt-dataset-card]',
   standalone: true,
-  host: { class: 'entity-card' },
+  host: {
+    class: 'entity-card',
+    '[class.selected]': 'selected()',
+    '[class.dimmed]': 'dimmed()',
+    '[class.loading-error]': 'hasLoadingError',
+  },
   imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent, IconComponent],
   templateUrl: './dataset-card.component.html',
   styleUrl: './dataset-card.component.scss',
@@ -28,35 +33,36 @@ import { DashboardLoadingTasksService } from '../../../services/dashboard-loadin
 export class DatasetCardComponent {
   private readonly loadingTasksSvc = inject(DashboardLoadingTasksService);
 
-  @Input() dataset: any;
+  readonly dataset = input<any>(undefined);
   readonly currentUser = input('');
   readonly isDefaultLogin = input(true);
-  @Input() columnOrder: string[] = [];
-  @Input() @HostBinding('class.selected') selected = false;
-  @Input() @HostBinding('class.dimmed') dimmed = false;
-  @Input() loadingTask?: LoadingTask;
+  readonly columnOrder = input<string[]>([]);
+  readonly selected = input(false);
+  readonly dimmed = input(false);
+  readonly loadingTask = input<LoadingTask | undefined>(undefined);
 
   /** True while this row's delete-confirm dialog is open (driven by the
    *  dashboard's `deletingDatasetId`). Spins the trash icon to 90° while open;
    *  the reverse animation plays back to 0° once the dialog resolves. */
-  @Input()
-  set deleting(value: boolean) {
-    if (value && !this._deleting) this.wasDeleting = true;
-    this._deleting = value;
-  }
-  get deleting(): boolean {
-    return this._deleting;
-  }
-  private _deleting = false;
+  readonly deleting = input(false);
   wasDeleting = false;
+  private previousDeleting = false;
   /** Which progress vocabulary to render the inline row with. ``projection``
    *  is used while the Browse button pre-builds the dataset's projection. */
   readonly taskKind = input<ProgressKind>('dataset');
 
-  @HostBinding('class.loading-error')
   get hasLoadingError(): boolean {
-    return !!this.loadingTask?.error;
+    return !!this.loadingTask()?.error;
   }
+
+  constructor() {
+    effect(() => {
+      const value = this.deleting();
+      if (value && !this.previousDeleting) this.wasDeleting = true;
+      this.previousDeleting = value;
+    });
+  }
+
   readonly rowClick = output<MouseEvent>();
 
   @HostListener('click', ['$event'])
@@ -70,7 +76,7 @@ export class DatasetCardComponent {
     if (this.editing) return;
     // A loading/errored row shows a progress bar in place of the actions, so
     // there is nothing to act on.
-    if (this.loadingTask) return;
+    if (this.loadingTask()) return;
     event.preventDefault();
     // Right-click gets the complete action list; the ⋯ button gets the overflow
     // subset (see openMenuAt).
@@ -87,10 +93,10 @@ export class DatasetCardComponent {
   readonly checkboxToggle = output<void>();
 
   get isOwner(): boolean {
-    return this.dataset?.created_by === this.currentUser();
+    return this.dataset()?.created_by === this.currentUser();
   }
 
-  @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
+  readonly renameInput = viewChild<ElementRef<HTMLInputElement>>('renameInput');
 
   editing = false;
   wasEditing = false;
@@ -110,8 +116,8 @@ export class DatasetCardComponent {
   beginRename(): void {
     this.editing = true;
     this.wasEditing = true;
-    this.editName = this.dataset.name;
-    setTimeout(() => this.renameInput?.nativeElement.focus());
+    this.editName = this.dataset().name;
+    setTimeout(() => this.renameInput()?.nativeElement.focus());
   }
 
   /** Open the shared action menu at a viewport point.
@@ -120,7 +126,7 @@ export class DatasetCardComponent {
    *  Browse, Delete) so the ⋯ button reads as "more" while right-click stays
    *  complete. */
   private openMenuAt(x: number, y: number, overflow: boolean): void {
-    const items = buildDatasetCardMenuItems(this.dataset, {
+    const items = buildDatasetCardMenuItems(this.dataset(), {
       isDefaultLogin: this.isDefaultLogin(),
       isOwner: this.isOwner,
     });
@@ -168,7 +174,7 @@ export class DatasetCardComponent {
 
   confirmRename(): void {
     const trimmed = this.editName.trim();
-    if (trimmed && trimmed !== this.dataset.name) {
+    if (trimmed && trimmed !== this.dataset().name) {
       this.rename.emit(trimmed);
     }
     this.editing = false;
@@ -185,7 +191,7 @@ export class DatasetCardComponent {
   }
 
   onDeleteAnimationEnd(): void {
-    if (!this._deleting) {
+    if (!this.deleting()) {
       this.wasDeleting = false;
     }
   }
@@ -223,13 +229,13 @@ export class DatasetCardComponent {
   }
 
   get taskProgressInfo(): ProgressHeader {
-    const task = this.loadingTask;
+    const task = this.loadingTask();
     if (!task) return { header: '', subtitle: '', detail: '', eta: '' };
     return formatProgressHeader(task, this.taskKind(), task.embedder);
   }
 
   get taskBar(): ProgressBarState {
-    const task = this.loadingTask;
+    const task = this.loadingTask();
     if (!task) return { value: 0, max: 1, indeterminate: true };
     return progressBarState(task);
   }
@@ -237,21 +243,23 @@ export class DatasetCardComponent {
   /** True once Cancel has been clicked on this row's task and the backend is
    *  still unwinding it; swaps the Cancel button for a "Cancelling…" badge. */
   get taskCancelling(): boolean {
-    const task = this.loadingTask;
+    const task = this.loadingTask();
     return !!task && this.loadingTasksSvc.isCancelling(task.task_id);
   }
 
   // `vt-job-progress` stops the click before it reaches the row, so no event.
   onCancelTask(): void {
-    if (this.loadingTask) {
-      this.cancelTask.emit(this.loadingTask.task_id);
+    const task = this.loadingTask();
+    if (task) {
+      this.cancelTask.emit(task.task_id);
     }
   }
 
   onDismissTask(event: MouseEvent): void {
     event.stopPropagation();
-    if (this.loadingTask) {
-      this.dismissTask.emit(this.loadingTask.task_id);
+    const task = this.loadingTask();
+    if (task) {
+      this.dismissTask.emit(task.task_id);
     }
   }
 }

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.html
@@ -1,6 +1,6 @@
 <td class="select-col">
-  <button class="card-icon-btn select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected ? 'Deselect detector' : 'Select detector'" [attr.aria-checked]="selected ? 'true' : 'false'" role="checkbox" [attr.title]="selected ? 'Deselect' : 'Select'">
-    @if (selected) {
+  <button class="card-icon-btn select-checkbox" (click)="onCheckboxClick($event)" [attr.aria-label]="selected() ? 'Deselect detector' : 'Select detector'" [attr.aria-checked]="selected() ? 'true' : 'false'" role="checkbox" [attr.title]="selected() ? 'Deselect' : 'Select'">
+    @if (selected()) {
       <vt-icon type="checkbox-checked" [size]="16"></vt-icon>
     } @else {
       <vt-icon type="checkbox-blank" [size]="16"></vt-icon>
@@ -21,7 +21,7 @@
     />
   } @else {
     <span class="name-cell">
-      {{ detector.name }}
+      {{ detector().name }}
       <button class="card-icon-btn edit-btn name-edit-btn" (click)="startRename($event)" aria-label="Rename detector" title="Rename">
         <svg aria-hidden="true" [class.pencil-active]="editing" [class.pencil-inactive]="!editing && wasEditing" (animationend)="onPencilAnimationEnd()" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M16.5 2.5a2.828 2.828 0 0 1 4 4L7.5 19.5L3 20L3.5 15.5L16.5 2.5z"></path>
@@ -32,8 +32,8 @@
     </span>
   }
 </td>
-@if (loadingTask && !loadingTask.error) {
-  <td [attr.colspan]="columnOrder.length + 1">
+@if (loadingTask() && !loadingTask()!.error) {
+  <td [attr.colspan]="columnOrder().length + 1">
     <vt-job-progress
       [cell]="true"
       [header]="taskProgressInfo.header"
@@ -47,20 +47,20 @@
       (cancel)="onCancelTask()"
     />
   </td>
-} @else if (loadingTask?.error) {
-  <td [attr.colspan]="columnOrder.length + 1">
+} @else if (loadingTask()?.error) {
+  <td [attr.colspan]="columnOrder().length + 1">
     <div class="loading-task-failed">
-      <span class="error-msg">Failed: {{ loadingTask?.error }}</span>
+      <span class="error-msg">Failed: {{ loadingTask()?.error }}</span>
       <button class="btn btn--cancel btn--sm" (click)="onDismissTask($event)" title="Dismiss error">Dismiss</button>
     </div>
   </td>
 } @else {
-  @for (col of columnOrder; track col) {
+  @for (col of columnOrder(); track col) {
     @switch (col) {
       @case ('media_type') {
         <td>
           <span class="type-cell">
-            @switch (detector.media_type) {
+            @switch (detector().media_type) {
               @case ('audio') {
                 <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
               }
@@ -77,7 +77,7 @@
                 <svg class="type-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
               }
             }
-            {{ capitalizeType(detector.media_type) }}
+            {{ capitalizeType(detector().media_type) }}
           </span>
         </td>
       }
@@ -86,33 +86,33 @@
           @if (isUntrained) {
             <span class="empty-hint" title="This detector has no labels yet — add some to train it">Empty</span>
           } @else {
-            {{ (detector.num_training ?? 0) | number }}
+            {{ (detector().num_training ?? 0) | number }}
           }
         </td>
       }
       @case ('last_trained_at') {
-        <td>{{ formatDate(detector.last_trained_at) }}</td>
+        <td>{{ formatDate(detector().last_trained_at) }}</td>
       }
       @case ('created_at') {
-        <td>{{ formatDate(detector.created_at) }}</td>
+        <td>{{ formatDate(detector().created_at) }}</td>
       }
       @case ('created_by') {
-        <td>{{ detector.created_by || '-' }}</td>
+        <td>{{ detector().created_by || '-' }}</td>
       }
       @case ('readers') {
-        <td [title]="(detector.readers || []).join(', ')">{{ (detector.readers || []).length ? (detector.readers || []).join(', ') : '-' }}</td>
+        <td [title]="(detector().readers || []).join(', ')">{{ (detector().readers || []).length ? (detector().readers || []).join(', ') : '-' }}</td>
       }
     }
   }
   <td class="actions-col">
     <div class="card-actions">
-    @if (!detector.detector_loaded) {
+    @if (!detector().detector_loaded) {
       <button class="card-icon-btn load-btn" (click)="onLoad($event)" aria-label="Load detector" title="Load detector">
         <vt-icon type="import" [size]="14"></vt-icon>
       </button>
     }
     <button class="card-icon-btn card-icon-btn--danger delete-btn" (click)="onDelete($event)" aria-label="Delete detector" title="Delete detector">
-      <vt-icon type="trash" [size]="14" [class.trash-active]="deleting" [class.trash-inactive]="!deleting && wasDeleting" (animationend)="onDeleteAnimationEnd()"></vt-icon>
+      <vt-icon type="trash" [size]="14" [class.trash-active]="deleting()" [class.trash-inactive]="!deleting() && wasDeleting" (animationend)="onDeleteAnimationEnd()"></vt-icon>
     </button>
     <button class="card-icon-btn overflow-btn" (click)="onOverflow($event)" aria-label="More actions" title="More actions">
       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">

--- a/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
+++ b/frontend/src/app/components/dashboard/detector-card/detector-card.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, inject, input, output, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, effect, inject, input, output, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LoadingTask } from '../../../models/api.models';
@@ -19,7 +19,12 @@ import { DashboardLoadingTasksService } from '../../../services/dashboard-loadin
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'tr[vt-detector-card]',
   standalone: true,
-  host: { class: 'entity-card' },
+  host: {
+    class: 'entity-card',
+    '[class.selected]': 'selected()',
+    '[class.dimmed]': 'dimmed()',
+    '[class.loading-error]': 'hasLoadingError',
+  },
   imports: [CommonModule, FormsModule, JobProgressComponent, ContextMenuComponent, IconComponent],
   templateUrl: './detector-card.component.html',
   styleUrl: './detector-card.component.scss',
@@ -27,31 +32,31 @@ import { DashboardLoadingTasksService } from '../../../services/dashboard-loadin
 export class DetectorCardComponent {
   private readonly loadingTasksSvc = inject(DashboardLoadingTasksService);
 
-  @Input() detector: any;
+  readonly detector = input<any>(undefined);
   readonly currentUser = input('');
   readonly isDefaultLogin = input(true);
-  @Input() columnOrder: string[] = [];
-  @Input() @HostBinding('class.selected') selected = false;
-  @Input() @HostBinding('class.dimmed') dimmed = false;
-  @Input() loadingTask?: LoadingTask;
+  readonly columnOrder = input<string[]>([]);
+  readonly selected = input(false);
+  readonly dimmed = input(false);
+  readonly loadingTask = input<LoadingTask | undefined>(undefined);
 
   /** True while this row's delete-confirm dialog is open (driven by the
    *  dashboard's `deletingDetectorId`). Spins the trash icon to 90° while open;
    *  the reverse animation plays back to 0° once the dialog resolves. */
-  @Input()
-  set deleting(value: boolean) {
-    if (value && !this._deleting) this.wasDeleting = true;
-    this._deleting = value;
-  }
-  get deleting(): boolean {
-    return this._deleting;
-  }
-  private _deleting = false;
+  readonly deleting = input(false);
   wasDeleting = false;
+  private previousDeleting = false;
 
-  @HostBinding('class.loading-error')
   get hasLoadingError(): boolean {
-    return !!this.loadingTask?.error;
+    return !!this.loadingTask()?.error;
+  }
+
+  constructor() {
+    effect(() => {
+      const value = this.deleting();
+      if (value && !this.previousDeleting) this.wasDeleting = true;
+      this.previousDeleting = value;
+    });
   }
 
   readonly rowClick = output<MouseEvent>();
@@ -67,7 +72,7 @@ export class DetectorCardComponent {
     if (this.editing) return;
     // A loading/errored row shows a progress bar in place of the actions, so
     // there is nothing to act on.
-    if (this.loadingTask) return;
+    if (this.loadingTask()) return;
     event.preventDefault();
     // Right-click gets the complete action list; the ⋯ button gets the overflow
     // subset (see openMenuAt).
@@ -91,16 +96,16 @@ export class DetectorCardComponent {
    *  yet). Drives the "Empty" hint so a fresh detector reads as new rather than
    *  broken. */
   get isUntrained(): boolean {
-    return (this.detector?.num_training ?? 0) === 0;
+    return (this.detector()?.num_training ?? 0) === 0;
   }
 
   /** True when the current user created this detector (only the creator may
    *  rename/delete it or edit its access list). */
   get isOwner(): boolean {
-    return this.detector?.created_by === this.currentUser();
+    return this.detector()?.created_by === this.currentUser();
   }
 
-  @ViewChild('renameInput') renameInput?: ElementRef<HTMLInputElement>;
+  readonly renameInput = viewChild<ElementRef<HTMLInputElement>>('renameInput');
 
   editing = false;
   wasEditing = false;
@@ -120,8 +125,8 @@ export class DetectorCardComponent {
   beginRename(): void {
     this.editing = true;
     this.wasEditing = true;
-    this.editName = this.detector.name;
-    setTimeout(() => this.renameInput?.nativeElement.focus());
+    this.editName = this.detector().name;
+    setTimeout(() => this.renameInput()?.nativeElement.focus());
   }
 
   /** Open the shared action menu at a viewport point.
@@ -130,7 +135,7 @@ export class DetectorCardComponent {
    *  Browse, Delete) so the ⋯ button reads as "more" while right-click stays
    *  complete. */
   private openMenuAt(x: number, y: number, overflow: boolean): void {
-    const items = buildDetectorCardMenuItems(this.detector, {
+    const items = buildDetectorCardMenuItems(this.detector(), {
       isDefaultLogin: this.isDefaultLogin(),
       isOwner: this.isOwner,
     });
@@ -187,7 +192,7 @@ export class DetectorCardComponent {
 
   confirmRename(): void {
     const trimmed = this.editName.trim();
-    if (trimmed && trimmed !== this.detector.name) {
+    if (trimmed && trimmed !== this.detector().name) {
       this.rename.emit(trimmed);
     }
     this.editing = false;
@@ -204,7 +209,7 @@ export class DetectorCardComponent {
   }
 
   onDeleteAnimationEnd(): void {
-    if (!this._deleting) {
+    if (!this.deleting()) {
       this.wasDeleting = false;
     }
   }
@@ -248,26 +253,28 @@ export class DetectorCardComponent {
 
   // `vt-job-progress` stops the click before it reaches the row, so no event.
   onCancelTask(): void {
-    if (this.loadingTask) {
-      this.cancelTask.emit(this.loadingTask.task_id);
+    const task = this.loadingTask();
+    if (task) {
+      this.cancelTask.emit(task.task_id);
     }
   }
 
   onDismissTask(event: MouseEvent): void {
     event.stopPropagation();
-    if (this.loadingTask) {
-      this.dismissTask.emit(this.loadingTask.task_id);
+    const task = this.loadingTask();
+    if (task) {
+      this.dismissTask.emit(task.task_id);
     }
   }
 
   taskBar(): ProgressBarState {
-    const t = this.loadingTask;
+    const t = this.loadingTask();
     if (!t) return { value: 0, max: 1, indeterminate: true };
     return progressBarState(t);
   }
 
   get taskProgressInfo(): ProgressHeader {
-    const task = this.loadingTask;
+    const task = this.loadingTask();
     if (!task) return { header: '', subtitle: '', detail: '', eta: '' };
     return formatProgressHeader(task, 'detector', task.embedder);
   }
@@ -275,7 +282,7 @@ export class DetectorCardComponent {
   /** True once Cancel has been clicked on this row's task and the backend is
    *  still unwinding it; swaps the Cancel button for a "Cancelling…" badge. */
   get taskCancelling(): boolean {
-    const task = this.loadingTask;
+    const task = this.loadingTask();
     return !!task && this.loadingTasksSvc.isCancelling(task.task_id);
   }
 }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -272,7 +272,7 @@ describe('NewDetectorModalComponent', () => {
 
   it('warns about no-text datasets only for a text-hint-only detector', () => {
     // No warning before any text is entered.
-    component.datasetEmbedder = 'dinov3';
+    fixture.componentRef.setInput('datasetEmbedder', 'dinov3');
     component.pendingText.set('');
     expect(component.showNoTextWarning).toBe(false);
 
@@ -288,13 +288,13 @@ describe('NewDetectorModalComponent', () => {
   });
 
   it('does not warn when the dataset embedder can search by text', () => {
-    component.datasetEmbedder = 'clap';
+    fixture.componentRef.setInput('datasetEmbedder', 'clap');
     component.pendingText.set('dog barking');
     expect(component.showNoTextWarning).toBe(false);
   });
 
   it('does not warn when the active dataset embedder is unknown', () => {
-    component.datasetEmbedder = '';
+    fixture.componentRef.setInput('datasetEmbedder', '');
     component.pendingText.set('dog barking');
     expect(component.showNoTextWarning).toBe(false);
   });
@@ -351,7 +351,7 @@ describe('NewDetectorModalComponent with defaultMediaType', () => {
 
     fixture = TestBed.createComponent(NewDetectorModalComponent);
     component = fixture.componentInstance;
-    component.defaultMediaType = 'image';
+    fixture.componentRef.setInput('defaultMediaType', 'image');
     httpMock = TestBed.inject(HttpTestingController);
     TestBed.tick(); // run ngOnInit under zoneless (issues the init GETs)
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, HostListener, inject, Input, input, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, inject, input, OnInit, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -74,19 +74,19 @@ export class NewDetectorModalComponent implements OnInit {
   private mediaState = inject(MediaStateService);
 
   /** Media type of the currently active dataset, if any. */
-  @Input() defaultMediaType = '';
+  readonly defaultMediaType = input('');
 
   /** Embedder of the active dataset, if one is in context. When it can't
    *  search by text, a text-only detector won't be able to start in Autopilot
    *  or use Text sort on that dataset; the form surfaces a warning. Empty when
    *  unknown, which suppresses the warning. */
-  @Input() datasetEmbedder = '';
+  readonly datasetEmbedder = input('');
 
   /** When set, the modal opens with this loaded-media id materialised into
    *  example_media/ as the seed example. The picker is bypassed and the
    *  user lands directly on the form. Cleared by callers via
    *  ``NewThingFlowsService.closeNewDetector``. */
-  @Input() seedMediaId: number | null = null;
+  readonly seedMediaId = input<number | null>(null);
 
   /** Optional crop bounds applied when materialising ``seedMediaId``. */
   readonly seedCropParams = input<Record<string, unknown> | null>(null);
@@ -262,11 +262,11 @@ export class NewDetectorModalComponent implements OnInit {
     if (solo) {
       this.mediaType.set(solo);
       this.mediaTypeLocked = true;
-    } else if (this.defaultMediaType) {
+    } else if (this.defaultMediaType()) {
       // Prefer the explicit default (active dataset's type) over the all-datasets guess.
       // When the active dataset dictates the type, lock the field so the user
       // can't change it without an explicit unlock click.
-      this.mediaType.set(this.defaultMediaType);
+      this.mediaType.set(this.defaultMediaType());
       this.mediaTypeLocked = true;
     } else {
       this.datasetsRegistryApi.getRegistry().subscribe({
@@ -281,8 +281,8 @@ export class NewDetectorModalComponent implements OnInit {
       });
     }
 
-    if (this.seedMediaId != null) {
-      this.materializeSeedFromMediaId(this.seedMediaId, this.seedCropParams() ?? undefined);
+    if (this.seedMediaId() != null) {
+      this.materializeSeedFromMediaId(this.seedMediaId()!, this.seedCropParams() ?? undefined);
     }
   }
 
@@ -396,7 +396,7 @@ export class NewDetectorModalComponent implements OnInit {
    */
   get showNoTextWarning(): boolean {
     return (
-      !this.embedderCaps.supportsText(this.datasetEmbedder) &&
+      !this.embedderCaps.supportsText(this.datasetEmbedder()) &&
       this.hasPendingText &&
       !this.hasMediaExample
     );
@@ -419,7 +419,7 @@ export class NewDetectorModalComponent implements OnInit {
     const first = medias.length > 0 ? medias[0] : null;
     const names = first?.embedders ?? (first?.embedder ? [first.embedder] : []);
     if (names.length > 0) return names;
-    return this.datasetEmbedder ? [this.datasetEmbedder] : [];
+    return this.datasetEmbedder() ? [this.datasetEmbedder()] : [];
   }
 
   /** All three embedder types, in display order — the always-available options


### PR DESCRIPTION
## Summary
- Converts `@Input`/`@ViewChild` decorators to `input()`/`viewChild()` signals in `dataset-card`, `detector-card`, `new-detector-modal`, and `combine-datasets-modal`.
- Moves `@HostBinding`-on-`@Input` combos (`selected`, `dimmed`, `loading-error`) into `@Component` `host` metadata, reading the signal inputs directly.
- Reworks the `deleting` input's setter side effect (tracking a rename-dialog spin animation) into an `effect()` that watches the transition into `true`.
- Reworks `clipper-chooser`'s `ngOnChanges` (which only reacted to `open` flipping to `true`) into an `effect()`-based transition check, since signal inputs don't fire `ngOnChanges`.
- Updates the corresponding component templates to call the new signal inputs, and updates `new-detector-modal.component.spec.ts` where tests directly assigned former `@Input` properties (now `fixture.componentRef.setInput(...)`).

## Test plan
- [x] `./run-tests.sh frontend` (ruff/codespell/deptry/pip-audit/pyright/OpenAPI-snapshot/frontend build + audit + Vitest) — all green, 1684 frontend tests passed.
- [x] `cd frontend && npm run build:prod` — clean build, no budget warnings.

Closes #2542


---
_Generated by [Claude Code](https://claude.ai/code/session_013yES4x1pn1WAQBmEEJdnWb)_