### PR TITLE
Signal migration: right-panel components

### DIFF
--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.html
@@ -1,10 +1,10 @@
-@if (visible) {
+@if (visible()) {
   <div class="train-context-bar">
     <div class="train-context-header">
       <div>
         <span class="train-context-label" title="The detector being trained on your good/bad votes in this session">Detector</span>
         @if (!editing) {
-          <span class="train-context-name">{{ detectorName }}</span>
+          <span class="train-context-name">{{ detectorName() }}</span>
           <button
             class="btn-icon train-rename-btn"
             title="Rename detector"

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.spec.ts
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.spec.ts
@@ -63,7 +63,7 @@ describe('DetectorContextBarComponent', () => {
 
   it('should emit renamed on finishRename with new name', () => {
     vi.spyOn(component.renamed, 'emit');
-    component.detectorName = 'Old Name';
+    fixture.componentRef.setInput('detectorName', 'Old Name');
     component.editing = true;
     component.editValue = 'New Name';
 
@@ -75,7 +75,7 @@ describe('DetectorContextBarComponent', () => {
 
   it('should not emit renamed if name unchanged', () => {
     vi.spyOn(component.renamed, 'emit');
-    component.detectorName = 'Same';
+    fixture.componentRef.setInput('detectorName', 'Same');
     component.editing = true;
     component.editValue = 'Same';
 
@@ -87,7 +87,7 @@ describe('DetectorContextBarComponent', () => {
 
   it('should not emit renamed if name is empty', () => {
     vi.spyOn(component.renamed, 'emit');
-    component.detectorName = 'Old';
+    fixture.componentRef.setInput('detectorName', 'Old');
     component.editing = true;
     component.editValue = '   ';
 
@@ -107,7 +107,7 @@ describe('DetectorContextBarComponent', () => {
 
   it('should finish rename on Enter', () => {
     vi.spyOn(component.renamed, 'emit');
-    component.detectorName = 'Old';
+    fixture.componentRef.setInput('detectorName', 'Old');
     component.editing = true;
     component.editValue = 'New';
 

--- a/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.ts
+++ b/frontend/src/app/components/right-panel/detector-context-bar/detector-context-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, Input, output, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, input, output, viewChild } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -11,22 +11,23 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './detector-context-bar.component.scss',
 })
 export class DetectorContextBarComponent {
-  @Input() detectorName = '';
-  @Input() visible = false;
+  readonly detectorName = input('');
+  readonly visible = input(false);
   readonly renamed = output<string>();
 
   editing = false;
   editValue = '';
 
-  @ViewChild('renameInput') renameInput!: ElementRef<HTMLInputElement>;
+  readonly renameInput = viewChild<ElementRef<HTMLInputElement>>('renameInput');
 
   startRename(): void {
-    if (!this.detectorName) return;
-    this.editValue = this.detectorName;
+    if (!this.detectorName()) return;
+    this.editValue = this.detectorName();
     this.editing = true;
     setTimeout(() => {
-      this.renameInput?.nativeElement.focus();
-      this.renameInput?.nativeElement.select();
+      const input = this.renameInput();
+      input?.nativeElement.focus();
+      input?.nativeElement.select();
     });
   }
 
@@ -34,7 +35,7 @@ export class DetectorContextBarComponent {
     if (!this.editing) return;
     const newName = this.editValue.trim();
     this.editing = false;
-    if (newName && newName !== this.detectorName) {
+    if (newName && newName !== this.detectorName()) {
       this.renamed.emit(newName);
     }
   }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.html
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.html
@@ -1,18 +1,18 @@
 <div class="vote-section">
   <div class="vote-section-header">
     <div class="vote-section-heading">
-      <h3 [class]="label" [title]="label === 'good' ? 'Items you have marked as positive examples (' + ids.length + ')' : 'Items you have marked as negative examples (' + ids.length + ')'">
-        {{ headingLabel() ?? (label === 'good' ? 'Goods' : 'Bads') }} ({{ ids.length | number }})
+      <h3 [class]="label()" [title]="label() === 'good' ? 'Items you have marked as positive examples (' + ids().length + ')' : 'Items you have marked as negative examples (' + ids().length + ')'">
+        {{ headingLabel() ?? (label() === 'good' ? 'Goods' : 'Bads') }} ({{ ids().length | number }})
       </h3>
-      @if (foldedNote) {
-        <span class="folded-note" [title]="'These items live on the left work queue; the bucket actions still include them.'">{{ foldedNote }}</span>
+      @if (foldedNote()) {
+        <span class="folded-note" [title]="'These items live on the left work queue; the bucket actions still include them.'">{{ foldedNote() }}</span>
       }
     </div>
     <ng-content select="[list-actions]"></ng-content>
   </div>
   <vt-vote-grid
     [entries]="sortedEntries()"
-    [label]="label"
+    [label]="label()"
     [gridGoalWidth]="gridGoalWidth()"
     [focusMode]="focusMode()"
     (entrySelected)="onEntrySelected($event)"

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectionStrategy, Component, inject, Input, input, OnChanges, OnDestroy, OnInit, output, signal, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { Media } from '../../../models/api.models';
 import { LabelSortMode } from '../label-sort/label-sort.component';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -24,13 +23,13 @@ export interface LabelEntry extends VoteGridEntry {
   templateUrl: './label-list.component.html',
   styleUrl: './label-list.component.scss',
 })
-export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
+export class LabelListComponent {
   private activeContext = inject(ActiveContextService);
   private metadataCache = inject(MediaMetadataCacheService);
   private mediaTypeCaps = inject(MediaTypeCapabilityService);
 
-  @Input() label: 'good' | 'bad' = 'good';
-  @Input() ids: number[] = [];
+  readonly label = input<'good' | 'bad'>('good');
+  readonly ids = input<number[]>([]);
   /**
    * Overrides the bucket heading word ("Goods"/"Bads"). Find mode passes
    * "Verified Good" / "Verified Bad" so the bucket reads as the confirmed pile.
@@ -41,17 +40,17 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
    * counting the items still on the left work queue that the bucket's actions
    * (Browse / Export / To Dataset) act on alongside the shown verified items.
    */
-  @Input() foldedNote: string | null = null;
-  @Input() medias: Media[] = [];
-  @Input() clickTimes: Record<string, number> = {};
-  @Input() learnedScores: Record<string, number> = {};
+  readonly foldedNote = input<string | null>(null);
+  readonly medias = input<Media[]>([]);
+  readonly clickTimes = input<Record<string, number>>({});
+  readonly learnedScores = input<Record<string, number>>({});
   /**
    * Normalised [x0, y0, x1, y1] region boxes keyed by media id. When an id has
    * a box (a region vote drawn on an image), its thumbnail is cropped to that
    * region rather than showing the whole frame.
    */
   readonly regionBoxes = input<Record<string, number[]>>({});
-  @Input() sortMode: LabelSortMode = 'time-desc';
+  readonly sortMode = input<LabelSortMode>('time-desc');
   readonly gridGoalWidth = input<number>(80);
   readonly focusMode = input<'click' | 'hover'>('click');
   readonly mediaSelected = output<number>();
@@ -60,58 +59,46 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
     vote: 'good' | 'bad';
 }>();
 
-  // Signal: rebuilt from the metadataCache version$ subscribe (an unpatched
-  // callback, not a zoneless CD trigger) as well as from ngOnChanges, and read in
-  // the template, so it must repaint when the cache hydrates.
-  readonly sortedEntries = signal<LabelEntry[]>([]);
-  /** Pre-built Map for O(1) media stub lookups by id (rebuilt when medias input changes). */
-  private mediaMap = new Map<number, Media>();
-  private readonly destroy$ = new Subject<void>();
+  /** Pre-built Map for O(1) media stub lookups by id (tracks the medias input). */
+  private readonly mediaMap = computed(() => new Map(this.medias().map(m => [m.id, m])));
+  // Bumped by the metadataCache version$ subscribe (an unpatched callback, not a
+  // zoneless CD trigger) so the sortedEntries computed re-derives entry names as
+  // the cache hydrates voted items.
+  private readonly cacheVersion = signal(0);
+  // Recomputes whenever the inputs it reads change (ids, medias, clickTimes,
+  // learnedScores, label, regionBoxes, sortMode) or the metadata cache hydrates;
+  // signal inputs don't fire ngOnChanges.
+  readonly sortedEntries = computed<LabelEntry[]>(() => {
+    this.cacheVersion();
+    const entries = this.ids().map(id => this.buildEntry(id));
+    return this.sortEntries(entries);
+  });
 
-  ngOnInit(): void {
-    this.mediaMap = new Map(this.medias.map(m => [m.id, m]));
-    this.metadataCache.ensureLoaded(this.ids);
-    this.sortedEntries.set(this.buildSortedEntries());
+  constructor() {
+    // Prefetch metadata for the shown ids whenever they change.
+    effect(() => {
+      this.metadataCache.ensureLoaded(this.ids());
+    });
     // Re-render entry names when the cache hydrates voted items.
     this.metadataCache.version$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed())
       .subscribe(() => {
-        this.sortedEntries.set(this.buildSortedEntries());
+        this.cacheVersion.update(v => v + 1);
       });
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['medias']) {
-      this.mediaMap = new Map(this.medias.map(m => [m.id, m]));
-    }
-    if (changes['ids']) {
-      this.metadataCache.ensureLoaded(this.ids);
-    }
-    this.sortedEntries.set(this.buildSortedEntries());
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
   private lookup(id: number): Media | undefined {
-    return this.metadataCache.get(id) ?? this.mediaMap.get(id);
-  }
-
-  private buildSortedEntries(): LabelEntry[] {
-    const entries = this.ids.map(id => this.buildEntry(id));
-    return this.sortEntries(entries);
+    return this.metadataCache.get(id) ?? this.mediaMap().get(id);
   }
 
   private buildEntry(id: number): LabelEntry {
     const media = this.lookup(id);
     const name = media ? (media.filename || `Clip #${id}`) : `Clip #${id}`;
-    const time = this.clickTimes[String(id)] ?? -1;
-    const score = this.learnedScores[String(id)] ?? -1;
+    const time = this.clickTimes()[String(id)] ?? -1;
+    const score = this.learnedScores()[String(id)] ?? -1;
     let confidence = -1;
     if (score >= 0) {
-      confidence = this.label === 'good' ? score : 1 - score;
+      confidence = this.label() === 'good' ? score : 1 - score;
     }
     return {
       id,
@@ -122,7 +109,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
       confidence,
       thumbnailUrl: this.buildThumbnailUrl(media, id),
       fallbackIcon: this.buildFallbackIcon(media),
-      missing: !this.mediaMap.has(id),
+      missing: !this.mediaMap().has(id),
       // Audio waveforms are theme-agnostic alpha masks (issue #2369); flag them
       // so vote-grid tints them via a CSS mask instead of a plain <img>.
       isAudio: media?.media_type === 'audio',
@@ -155,7 +142,7 @@ export class LabelListComponent implements OnInit, OnChanges, OnDestroy {
 
   private sortEntries(entries: LabelEntry[]): LabelEntry[] {
     const sorted = [...entries];
-    switch (this.sortMode) {
+    switch (this.sortMode()) {
       case 'time-desc':
         sorted.sort((a, b) => b.time - a.time);
         break;

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.html
@@ -4,7 +4,7 @@
   <select
     id="label-sort-select"
     class="form-select form-select--compact"
-    [ngModel]="mode"
+    [ngModel]="mode()"
     (ngModelChange)="onSortChange($event)"
     title="Order labeled items by time, name, detector confidence, or ID"
   >

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.spec.ts
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.spec.ts
@@ -23,14 +23,15 @@ describe('LabelSortComponent', () => {
   });
 
   it('should default to time-desc', () => {
-    expect(component.mode).toBe('time-desc');
+    expect(component.mode()).toBe('time-desc');
   });
 
   it('should emit modeChange on sort change', () => {
-    vi.spyOn(component.modeChange, 'emit');
+    let emitted: LabelSortMode | undefined;
+    component.mode.subscribe((v) => (emitted = v));
     component.onSortChange('name-asc');
-    expect(component.mode).toBe('name-asc');
-    expect(component.modeChange.emit).toHaveBeenCalledWith('name-asc');
+    expect(component.mode()).toBe('name-asc');
+    expect(emitted).toBe('name-asc');
   });
 
   it('should render all sort options', () => {
@@ -50,6 +51,6 @@ describe('LabelSortComponent', () => {
   it('should accept mode input', async () => {
     fixture.componentRef.setInput('mode', 'confidence-desc');
     await settleZoneless(fixture);
-    expect(component.mode).toBe('confidence-desc');
+    expect(component.mode()).toBe('confidence-desc');
   });
 });

--- a/frontend/src/app/components/right-panel/label-sort/label-sort.component.ts
+++ b/frontend/src/app/components/right-panel/label-sort/label-sort.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, model } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 export type LabelSortMode =
@@ -19,11 +19,12 @@ export type LabelSortMode =
   styleUrl: './label-sort.component.scss',
 })
 export class LabelSortComponent {
-  @Input() mode: LabelSortMode = 'time-desc';
-  readonly modeChange = output<LabelSortMode>();
+  // Two-way bindable: `[mode]` seeds it and the implicit `modeChange` output
+  // fires on selection, so `this.mode.set` both updates the local value and
+  // notifies the parent.
+  readonly mode = model<LabelSortMode>('time-desc');
 
   onSortChange(value: LabelSortMode): void {
-    this.mode = value;
-    this.modeChange.emit(value);
+    this.mode.set(value);
   }
 }

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.html
@@ -3,7 +3,7 @@
     {{ label() === 'good' ? 'Goods' : 'Bads' }} ({{ elements().length | number }})
   </h3>
   <vt-vote-grid
-    [entries]="sortedEntries"
+    [entries]="sortedEntries()"
     [label]="label()"
     [gridGoalWidth]="gridGoalWidth()"
     [focusMode]="focusMode()"

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, input, OnChanges, output, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import type { DetectorLabelView } from '../../../generated/api-client/models/detector-label-view';
 import { LabelSortMode } from '../label-sort/label-sort.component';
@@ -18,7 +18,7 @@ interface SortedElement extends DetectorLabelView, VoteGridEntry {
   templateUrl: './labelset-list.component.html',
   styleUrls: ['../label-list/label-list.component.scss'],
 })
-export class LabelsetListComponent implements OnChanges {
+export class LabelsetListComponent {
   private detectorsCrudApi = inject(DetectorsCrudApiService);
   private mediaTypeCaps = inject(MediaTypeCapabilityService);
 
@@ -34,11 +34,9 @@ export class LabelsetListComponent implements OnChanges {
     vote: 'good' | 'bad';
 }>();
 
-  sortedEntries: SortedElement[] = [];
-
-  ngOnChanges(_changes: SimpleChanges): void {
-    this.sortedEntries = this.buildSorted();
-  }
+  // Recomputes when any of the inputs it reads change (elements, label,
+  // modelName, sortMode); signal inputs don't fire ngOnChanges.
+  readonly sortedEntries = computed<SortedElement[]>(() => this.buildSorted());
 
   private buildSorted(): SortedElement[] {
     const entries: SortedElement[] = this.elements().map((e) => ({

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -1,7 +1,7 @@
 <aside class="panel-right" aria-label="Labels">
   <vt-detector-context-bar
-    [visible]="!!trainMode"
-    [detectorName]="trainMode?.model?.name ?? ''"
+    [visible]="!!trainMode()"
+    [detectorName]="trainMode()?.model?.name ?? ''"
     (renamed)="onDetectorRenamed($event)"
   />
 
@@ -55,7 +55,7 @@
       [ids]="goodDisplayIds"
       [headingLabel]="mode() === 'find' ? 'Verified Good' : null"
       [foldedNote]="mode() === 'find' ? ((unverifiedGoodCount | number) + ' Unverified Good') : null"
-      [medias]="medias"
+      [medias]="medias()"
       [clickTimes]="clickTimes()"
       [learnedScores]="learnedScores()"
       [regionBoxes]="goodRegionBoxes()"
@@ -96,7 +96,7 @@
       [ids]="badDisplayIds"
       [headingLabel]="mode() === 'find' ? 'Verified Bad' : null"
       [foldedNote]="mode() === 'find' ? ((unverifiedBadCount | number) + ' Unverified Bad') : null"
-      [medias]="medias"
+      [medias]="medias()"
       [clickTimes]="clickTimes()"
       [learnedScores]="learnedScores()"
       [sortMode]="sortMode"
@@ -145,7 +145,7 @@
 
 @if (showExport) {
   <vt-export-modal
-    [detectorName]="trainMode?.model?.name ?? ''"
+    [detectorName]="trainMode()?.model?.name ?? ''"
     (closed)="showExport = false"
     (exported)="showExport = false"
   />

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, Input, input, OnChanges, OnDestroy, OnInit, output, signal, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, OnDestroy, OnInit, output, signal, untracked } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -42,15 +42,15 @@ export interface TrainModeContext {
   templateUrl: './right-panel.component.html',
   styleUrl: './right-panel.component.scss',
 })
-export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
+export class RightPanelComponent implements OnInit, OnDestroy {
   private detectorsRegistryApi = inject(DetectorsRegistryApiService);
   voteState = inject(VoteStateService);
   labelsetState = inject(LabelsetStateService);
   private settingsState = inject(SettingsStateService);
   private dialog = inject(VtDialogService);
 
-  @Input() medias: Media[] = [];
-  @Input() trainMode: TrainModeContext | null = null;
+  readonly medias = input<Media[]>([]);
+  readonly trainMode = input<TrainModeContext | null>(null);
   readonly focusMode = input<'click' | 'hover'>('click');
   /** 'label' = Labeling mode (detector export allowed), 'find' = Finding mode (no detector export). */
   readonly mode = input<'label' | 'find'>('label');
@@ -122,6 +122,32 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
         }
       }
     });
+
+    // Track the active media type off the bound medias so the grid icon size
+    // follows the dataset. (Replaces the former `medias` ngOnChanges branch.)
+    effect(() => {
+      const medias = this.medias();
+      if (medias.length === 0) return;
+      const newType = medias[0].media_type;
+      if (newType !== untracked(this.currentMediaType)) {
+        this.currentMediaType.set(newType);
+        this.gridGoalWidth.set(iconSizeToGoalWidth(this.gridIconSizeRightDict[newType] ?? 'M'));
+      }
+    });
+
+    // Keep the labelset polling in sync with the labelset/vote source. Reads
+    // `mode` and `trainableModelName` via `useLabelset`, so it re-runs whenever
+    // either changes. (Replaces the former `trainableModelName`/`mode`
+    // ngOnChanges branch and the labelset block of ngOnInit.)
+    effect(() => {
+      if (this.useLabelset) {
+        this.labelsetState.setModel(this.trainableModelName());
+        this.labelsetState.startPolling();
+      } else {
+        this.labelsetState.stopPolling();
+        this.labelsetState.setModel(null);
+      }
+    });
   }
 
   /** True when the right pane should be sourced from the labelset (not /api/votes). */
@@ -160,30 +186,7 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   ngOnInit(): void {
     this.settingsState.load();
     this.voteState.startPolling();
-    if (this.useLabelset) {
-      this.labelsetState.setModel(this.trainableModelName());
-      this.labelsetState.startPolling();
-    }
     this.subscribeToLabelset();
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['medias'] && this.medias.length > 0) {
-      const newType = this.medias[0].media_type;
-      if (newType !== this.currentMediaType()) {
-        this.currentMediaType.set(newType);
-        this.gridGoalWidth.set(iconSizeToGoalWidth(this.gridIconSizeRightDict[newType] ?? 'M'));
-      }
-    }
-    if (changes['trainableModelName'] || changes['mode']) {
-      if (this.useLabelset) {
-        this.labelsetState.setModel(this.trainableModelName());
-        this.labelsetState.startPolling();
-      } else {
-        this.labelsetState.stopPolling();
-        this.labelsetState.setModel(null);
-      }
-    }
   }
 
   ngOnDestroy(): void {
@@ -252,12 +255,13 @@ export class RightPanelComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   onDetectorRenamed(newName: string): void {
-    if (!this.trainMode?.model?.registry_id) return;
-    const registryId = this.trainMode.model.registry_id;
+    const trainMode = this.trainMode();
+    if (!trainMode?.model?.registry_id) return;
+    const registryId = trainMode.model.registry_id;
     this.detectorsRegistryApi.renameInRegistry(registryId, newName).subscribe({
       next: response => {
-        if (this.trainMode?.model) {
-          this.trainMode.model.name = newName;
+        if (trainMode.model) {
+          trainMode.model.name = newName;
         }
         this.detectorsRegistryApi.promptMoveOrphanedLabelsetFile(
           this.dialog,

--- a/frontend/src/app/components/right-panel/right-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.zoneless.spec.ts
@@ -168,7 +168,7 @@ describe('RightPanelComponent', () => {
   });
 
   it('should rename detector via detectors-registry-api', async () => {
-    component.trainMode = { model: { name: 'Old', registry_id: 'r1' } };
+    fixture.componentRef.setInput('trainMode', { model: { name: 'Old', registry_id: 'r1' } });
     await flushInit();
 
     component.onDetectorRenamed('New Name');
@@ -177,12 +177,12 @@ describe('RightPanelComponent', () => {
     expect(req.request.body).toEqual({ name: 'New Name' });
     req.flush({});
 
-    expect(component.trainMode.model.name).toBe('New Name');
+    expect(component.trainMode()!.model.name).toBe('New Name');
     cleanup();
   });
 
   it('should not rename if no registry_id', async () => {
-    component.trainMode = { model: { name: 'Old' } };
+    fixture.componentRef.setInput('trainMode', { model: { name: 'Old' } });
     await flushInit();
 
     component.onDetectorRenamed('New');
@@ -190,7 +190,7 @@ describe('RightPanelComponent', () => {
   });
 
   it('should not rename if no trainMode', async () => {
-    component.trainMode = null;
+    fixture.componentRef.setInput('trainMode', null);
     await flushInit();
 
     component.onDetectorRenamed('New');
@@ -198,7 +198,7 @@ describe('RightPanelComponent', () => {
   });
 
   it('should render detector context bar when trainMode set', async () => {
-    component.trainMode = { model: { name: 'Test Detector', registry_id: 'r1' } };
+    fixture.componentRef.setInput('trainMode', { model: { name: 'Test Detector', registry_id: 'r1' } });
     await flushInit();
     TestBed.tick();
 
@@ -208,7 +208,7 @@ describe('RightPanelComponent', () => {
   });
 
   it('should not render detector context bar when trainMode is null', async () => {
-    component.trainMode = null;
+    fixture.componentRef.setInput('trainMode', null);
     await flushInit();
     TestBed.tick();
 

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.html
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.html
@@ -8,10 +8,10 @@
   >
     <div
       class="vote-grid-row"
-      *cdkVirtualFor="let row of rows; trackBy: trackByRow"
+      *cdkVirtualFor="let row of rows(); trackBy: trackByRow"
       [style.height.px]="rowHeight"
       [style.--grid-goal-width]="gridGoalWidth() + 'px'"
-      [style.grid-template-columns]="'repeat(' + columns + ', var(--grid-goal-width, 80px))'"
+      [style.grid-template-columns]="'repeat(' + columns() + ', var(--grid-goal-width, 80px))'"
     >
       @for (entry of row; track entry.key) {
         <ng-container [ngTemplateOutlet]="cell" [ngTemplateOutletContext]="{ $implicit: entry }" />

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.spec.ts
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.spec.ts
@@ -57,8 +57,8 @@ describe('VoteGridComponent', () => {
     expect(el.querySelector('.vote-list-plain')).toBeNull();
     // jsdom reports zero viewport width, so the column count stays 1 and each
     // entry becomes its own virtualized row.
-    expect(component.rows.length).toBe(100);
-    expect(component.rows[0].length).toBe(1);
+    expect(component.rows().length).toBe(100);
+    expect(component.rows()[0].length).toBe(1);
   });
 
   it('drops back to the plain grid when the pile shrinks', async () => {
@@ -71,11 +71,10 @@ describe('VoteGridComponent', () => {
 
   it('chunks entries into rows of the current column count', async () => {
     await setInputs({ entries: makeEntries(100) });
-    component.columns = 3;
-    component['rebuildRows']();
-    expect(component.rows.length).toBe(Math.ceil(100 / 3));
-    expect(component.rows[0].map((e) => e.key)).toEqual(['1', '2', '3']);
-    expect(component.rows.at(-1)!.length).toBe(100 % 3 || 3);
+    component.columns.set(3);
+    expect(component.rows().length).toBe(Math.ceil(100 / 3));
+    expect(component.rows()[0].map((e) => e.key)).toEqual(['1', '2', '3']);
+    expect(component.rows().at(-1)!.length).toBe(100 % 3 || 3);
   });
 
   describe('event routing', () => {

--- a/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.ts
+++ b/frontend/src/app/components/right-panel/vote-grid/vote-grid.component.ts
@@ -3,14 +3,15 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
+  effect,
   inject,
   input,
   NgZone,
-  OnChanges,
   OnDestroy,
   output,
-  SimpleChanges,
-  ViewChild,
+  signal,
+  viewChild,
 } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
@@ -72,7 +73,7 @@ const MIN_ROW_HEIGHT = 24;
   templateUrl: './vote-grid.component.html',
   styleUrl: './vote-grid.component.scss',
 })
-export class VoteGridComponent implements OnChanges, AfterViewChecked, OnDestroy {
+export class VoteGridComponent implements AfterViewChecked, OnDestroy {
   private cdr = inject(ChangeDetectorRef);
   private zone = inject(NgZone);
 
@@ -87,12 +88,20 @@ export class VoteGridComponent implements OnChanges, AfterViewChecked, OnDestroy
     vote: 'good' | 'bad';
 }>();
 
-  @ViewChild(CdkVirtualScrollViewport) virtualViewport?: CdkVirtualScrollViewport;
+  readonly virtualViewport = viewChild(CdkVirtualScrollViewport);
 
-  /** ``entries`` chunked into rows of ``columns`` cells for virtual scrolling. */
-  rows: VoteGridEntry[][] = [];
   /** Number of cells per virtualized row, derived from the viewport width. */
-  columns = 1;
+  readonly columns = signal(1);
+  /** ``entries`` chunked into rows of ``columns`` cells for virtual scrolling. */
+  readonly rows = computed<VoteGridEntry[][]>(() => {
+    const cols = Math.max(1, this.columns());
+    const entries = this.entries();
+    const rows: VoteGridEntry[][] = [];
+    for (let i = 0; i < entries.length; i += cols) {
+      rows.push(entries.slice(i, i + cols));
+    }
+    return rows;
+  });
   /** Measured stride of one virtualized row (px); fed to CDK as ``itemSize``. */
   rowHeight = ROW_HEIGHT_FALLBACK;
 
@@ -103,29 +112,33 @@ export class VoteGridComponent implements OnChanges, AfterViewChecked, OnDestroy
   private observedViewportEl?: HTMLElement;
   /** True once ``rowHeight`` has been measured from a real rendered cell. */
   private rowHeightMeasured = false;
+  /** Previous goal width, tracked so the effect only re-measures on a real change. */
+  private prevGridGoalWidth = this.gridGoalWidth();
+
+  constructor() {
+    effect(() => {
+      const gw = this.gridGoalWidth();
+      // A wider/narrower goal width changes how many cells fit per row and the
+      // height of each cell, so recompute columns and re-measure the stride.
+      // Skip the initial run (no prior layout to invalidate).
+      if (gw !== this.prevGridGoalWidth) {
+        this.prevGridGoalWidth = gw;
+        this.rowHeightMeasured = false;
+        this.recomputeColumns();
+      }
+    });
+  }
 
   /** Whether the pile is large enough to render through the CDK viewport. */
   get useVirtual(): boolean {
     return this.entries().length > PILE_VIRTUAL_THRESHOLD;
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    // A wider/narrower goal width changes how many cells fit per row and the
-    // height of each cell, so recompute columns and re-measure the stride.
-    if (changes['gridGoalWidth'] && !changes['gridGoalWidth'].firstChange) {
-      this.rowHeightMeasured = false;
-      this.recomputeColumns();
-    }
-    if (changes['entries'] || changes['gridGoalWidth']) {
-      this.rebuildRows();
-    }
-  }
-
   ngAfterViewChecked(): void {
     // Keep the viewport measured while virtualizing: a ResizeObserver tracks
     // width (→ column count) and the first rendered cell's height (→ CDK row
     // stride). Tear it down when the pile shrinks back to plain DOM.
-    if (this.useVirtual && this.virtualViewport) {
+    if (this.useVirtual && this.virtualViewport()) {
       this.setupViewport();
     } else if (this.observedViewportEl) {
       this.resizeObserver?.disconnect();
@@ -138,34 +151,24 @@ export class VoteGridComponent implements OnChanges, AfterViewChecked, OnDestroy
     this.resizeObserver?.disconnect();
   }
 
-  private rebuildRows(): void {
-    const cols = Math.max(1, this.columns);
-    const entries = this.entries();
-    const rows: VoteGridEntry[][] = [];
-    for (let i = 0; i < entries.length; i += cols) {
-      rows.push(entries.slice(i, i + cols));
-    }
-    this.rows = rows;
-  }
-
   /**
    * Recompute how many cells fit across the viewport. Returns ``true`` when
-   * the column count changed (so callers know to rebuild the rows).
+   * the column count changed (so callers know to re-measure).
    */
   private recomputeColumns(): boolean {
-    const el = this.virtualViewport?.elementRef.nativeElement;
+    const el = this.virtualViewport()?.elementRef.nativeElement;
     if (!el) return false;
     const inner = el.clientWidth;
     if (inner <= 0) return false;
     const cols = Math.max(1, Math.floor((inner + GRID_GAP_PX) / (this.gridGoalWidth() + GRID_GAP_PX)));
-    if (cols === this.columns) return false;
-    this.columns = cols;
+    if (cols === this.columns()) return false;
+    this.columns.set(cols);
     return true;
   }
 
   /** Observe the viewport for width/height changes (runs outside Angular). */
   private setupViewport(): void {
-    const vp = this.virtualViewport?.elementRef.nativeElement;
+    const vp = this.virtualViewport()?.elementRef.nativeElement;
     if (!vp || this.observedViewportEl === vp) {
       // Already observing the right element. Re-measure only until the row
       // height has been captured from a real cell, so the steady state doesn't
@@ -189,10 +192,11 @@ export class VoteGridComponent implements OnChanges, AfterViewChecked, OnDestroy
    * converges instead of looping: it only re-renders when something moved.
    */
   private measureLayout(): void {
+    // recomputeColumns() sets the columns signal, which re-derives the rows
+    // computed on its own; no explicit rebuild needed.
     let changed = this.recomputeColumns();
-    if (changed) this.rebuildRows();
 
-    const vp = this.virtualViewport?.elementRef.nativeElement;
+    const vp = this.virtualViewport()?.elementRef.nativeElement;
     const cell = vp?.querySelector('.vote-entry') as HTMLElement | null;
     if (cell) {
       const measured = Math.round(cell.getBoundingClientRect().height + GRID_GAP_PX);


### PR DESCRIPTION
Converts the right-panel cluster to signal-based authoring, part of the Angular signal-API modernization tracked in `docs/plans/angular-22-upgrade.md`.

## What changed

- **`detector-context-bar`** — `@Input() detectorName`/`visible` → `input()`; `@ViewChild('renameInput')` → `viewChild()`.
- **`label-sort`** — `@Input() mode` + `modeChange` output → `model()` (two-way bindable; `this.mode.set()` updates locally and fires the implicit `modeChange`).
- **`label-list`** — all 7 `@Input()`s → `input()`; `ngOnChanges` + `ngOnInit` rework: `mediaMap` and `sortedEntries` became `computed`s, metadata prefetch became an `effect`, and the `metadataCache.version$` subscription now bumps a `cacheVersion` signal (via `takeUntilDestroyed`) so the pile re-derives as the cache hydrates. Drops `OnInit`/`OnChanges`/`OnDestroy` and the manual `destroy$` Subject.
- **`labelset-list`** — `ngOnChanges` → `sortedEntries` `computed`.
- **`right-panel`** — `@Input() medias`/`trainMode` → `input()`; the two `ngOnChanges` branches became `effect`s (media-type/grid-width tracking, and labelset-polling sync via `useLabelset`). One-time polling lifecycle stays in `ngOnInit`/`ngOnDestroy`.
- **`vote-grid`** — `@ViewChild(CdkVirtualScrollViewport)` → `viewChild()`; `columns` → `signal`, `rows` → `computed` over `entries`/`columns` (removing `rebuildRows`); the `gridGoalWidth` re-measure branch of `ngOnChanges` became an `effect`.

Specs updated to drive inputs via `setInput` and read signals as getters.

## Verification

`./run-tests.sh frontend` passes: `build:prod` clean (no budget warnings), `npm audit` clean, and 1684 Vitest unit tests pass. No decorator inputs/outputs/queries or `ngOnChanges` remain in `right-panel/`.

Closes #2545


---
_Generated by [Claude Code](https://claude.ai/code/session_015fKv7mYakM7U2dTVU68X2G)_