### PR TITLE
Migrate top-level modals to signal inputs/queries

### DIFF
--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -1,8 +1,8 @@
 <vt-modal title="Auto-Detect Results" [open]="true" (closed)="close()">
   <!-- Summary -->
   <div class="results-summary">
-    <span><strong>Media Type:</strong> {{ data.media_type }}</span>
-    <span><strong>Detectors Run:</strong> {{ data.detectors_run }}</span>
+    <span><strong>Media Type:</strong> {{ data().media_type }}</span>
+    <span><strong>Detectors Run:</strong> {{ data().detectors_run }}</span>
     @if (exportSides === 'good') {
       <span><strong>Good Results:</strong> {{ goodCount }}</span>
     } @else if (exportSides === 'bad') {
@@ -13,16 +13,16 @@
   </div>
 
   <!-- Stale Auto-Find references (detector files deleted out from under the list) -->
-  @if (data.missing_detectors?.length) {
+  @if (data().missing_detectors?.length) {
     <div class="auto-export-status auto-export-status--error">
-      &#9888; Skipped {{ data.missing_detectors!.length }} Auto-Find detector(s) whose
-      file no longer exists: {{ data.missing_detectors!.join(', ') }}.
+      &#9888; Skipped {{ data().missing_detectors!.length }} Auto-Find detector(s) whose
+      file no longer exists: {{ data().missing_detectors!.join(', ') }}.
       Remove them from your Auto-Find list in Settings.
     </div>
   }
 
   <!-- Auto-export status (only when a results exporter ran) -->
-  @if (data.auto_export; as ax) {
+  @if (data().auto_export; as ax) {
     <div class="auto-export-status" [class.auto-export-status--error]="!ax.success">
       @if (ax.success) {
         <vt-icon type="check" [size]="14"></vt-icon> Auto-exported via {{ ax.exporter }}{{ ax.message ? ' — ' + ax.message : '' }}

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnDestroy, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -28,7 +28,7 @@ import { IconComponent } from '../../icon/icon.component';
 export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   private exportersApi = inject(ExportersApiService);
 
-  @Input() data: AutoDetectResultsData = { results: {} };
+  readonly data = input<AutoDetectResultsData>({ results: {} });
   readonly closed = output<void>();
 
   exportSides: 'good' | 'bad' | 'both' = 'good';
@@ -69,7 +69,7 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
 
   get allHits(): AutoDetectHit[] {
     const hits: AutoDetectHit[] = [];
-    for (const result of Object.values(this.data.results || {})) {
+    for (const result of Object.values(this.data().results || {})) {
       for (const hit of result.hits || []) {
         hits.push(hit);
       }
@@ -79,7 +79,7 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
 
   get goodCount(): number {
     let total = 0;
-    for (const result of Object.values(this.data.results || {})) {
+    for (const result of Object.values(this.data().results || {})) {
       total += (result.hits || []).length;
     }
     return total;
@@ -87,7 +87,7 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
 
   get badCount(): number {
     let total = 0;
-    for (const result of Object.values(this.data.results || {})) {
+    for (const result of Object.values(this.data().results || {})) {
       total += (result.negative_hits || []).length;
     }
     return total;
@@ -95,7 +95,7 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
 
   get displayHits(): AutoDetectHit[] {
     const hits: AutoDetectHit[] = [];
-    for (const result of Object.values(this.data.results || {})) {
+    for (const result of Object.values(this.data().results || {})) {
       if (this.exportSides === 'good') {
         hits.push(...(result.hits || []));
       } else if (this.exportSides === 'bad') {

--- a/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
+++ b/frontend/src/app/components/modals/examples-editor-modal/examples-editor-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnDestroy, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
 import { ModalComponent } from '../../modal/modal.component';
 import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
 import { apiErrorMessage } from '../../../utils/api-error';
@@ -21,7 +21,7 @@ interface Example {
 export class ExamplesEditorModalComponent implements OnInit, OnDestroy {
   private detectorsCrudApi = inject(DetectorsCrudApiService);
 
-  @Input() modelName = '';
+  readonly modelName = input('');
   readonly closed = output<void>();
   readonly saved = output<void>();
 
@@ -35,11 +35,12 @@ export class ExamplesEditorModalComponent implements OnInit, OnDestroy {
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   ngOnInit(): void {
-    if (!this.modelName) {
+    const modelName = this.modelName();
+    if (!modelName) {
       this.loading.set(false);
       return;
     }
-    this.detectorsCrudApi.get(this.modelName).subscribe({
+    this.detectorsCrudApi.get(modelName).subscribe({
       next: (data: any) => {
         this.examples.set(data.examples || []);
         this.loading.set(false);
@@ -75,7 +76,7 @@ export class ExamplesEditorModalComponent implements OnInit, OnDestroy {
     this.saving.set(true);
     this.error.set('');
     this.status.set('');
-    this.detectorsCrudApi.setExamples(this.modelName, this.examples()).subscribe({
+    this.detectorsCrudApi.setExamples(this.modelName(), this.examples()).subscribe({
       next: () => {
         this.saving.set(false);
         this.status.set('Saved.');

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -8,7 +8,7 @@ import {
   OnDestroy,
   output,
   signal,
-  ViewChild,
+  viewChild,
 } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 
@@ -45,8 +45,10 @@ export class LabelImporterModalComponent implements OnDestroy {
   readonly closed = output<void>();
   readonly imported = output<void>();
 
-  @ViewChild('addGoodInput') addGoodInput!: ElementRef<HTMLInputElement>;
-  @ViewChild('addBadInput') addBadInput!: ElementRef<HTMLInputElement>;
+  // Optional queries: both file inputs live behind `@if (!targetModelName())`,
+  // so they resolve to `undefined` when a target model is set.
+  readonly addGoodInput = viewChild<ElementRef<HTMLInputElement>>('addGoodInput');
+  readonly addBadInput = viewChild<ElementRef<HTMLInputElement>>('addBadInput');
 
   view: ModalView = 'picker';
 
@@ -255,11 +257,11 @@ export class LabelImporterModalComponent implements OnDestroy {
 
 
   triggerAddGood(): void {
-    this.addGoodInput.nativeElement.click();
+    this.addGoodInput()?.nativeElement.click();
   }
 
   triggerAddBad(): void {
-    this.addBadInput.nativeElement.click();
+    this.addBadInput()?.nativeElement.click();
   }
 
   onAddToPile(event: Event, label: 'good' | 'bad'): void {

--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.html
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.html
@@ -9,9 +9,9 @@
   <div class="loading">Decoding audio…</div>
 }
 
-@if (audioUrl) {
+@if (audioUrl()) {
   <audio
-    [src]="audioUrl"
+    [src]="audioUrl()"
     controls
     (loadedmetadata)="onAudioLoadedMetadata($event)">
   </audio>

--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.spec.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.spec.ts
@@ -50,7 +50,11 @@ describe('AudioCropOverlayComponent', () => {
       setPointerCapture: capture,
       releasePointerCapture: release,
     };
-    component.canvasRef = { nativeElement: canvas } as unknown as ElementRef<HTMLCanvasElement>;
+    // `canvasRef` is a signal query; stub it with a zero-arg function returning
+    // the fake canvas so `this.canvasRef()` works without a real view/query
+    // resolution (and `draw()` short-circuits on the null 2D context).
+    (component as unknown as { canvasRef: () => ElementRef<HTMLCanvasElement> }).canvasRef =
+      () => ({ nativeElement: canvas }) as unknown as ElementRef<HTMLCanvasElement>;
 
     // Pretend the waveform decoded to a 10s clip with the full range selected.
     component.duration = DURATION;

--- a/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/audio-crop-overlay.component.ts
@@ -3,11 +3,10 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  Input,
   input,
   OnDestroy,
   output,
-  ViewChild,
+  viewChild,
 } from '@angular/core';
 import { decodeAudioBuffer } from '../../../utils/decode-audio';
 
@@ -30,13 +29,15 @@ const HANDLE_HIT_PX = 12;
   styleUrl: './audio-crop-overlay.component.scss',
 })
 export class AudioCropOverlayComponent implements AfterViewInit, OnDestroy {
-  @Input() audioUrl = '';
+  readonly audioUrl = input('');
   /** Original audio file, used to decode the waveform. */
   readonly audioFile = input<File>();
   readonly applied = output<AudioCropResult>();
   readonly cancelled = output<void>();
 
-  @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
+  // Always in the DOM (not behind `@if`), so a required query is safe and it
+  // resolves before `ngAfterViewInit`, where the first draw is scheduled.
+  readonly canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
 
   duration = 0;
   start = 0;
@@ -106,7 +107,7 @@ export class AudioCropOverlayComponent implements AfterViewInit, OnDestroy {
   }
 
   private draw(): void {
-    const canvas = this.canvasRef?.nativeElement;
+    const canvas = this.canvasRef().nativeElement;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
@@ -146,7 +147,7 @@ export class AudioCropOverlayComponent implements AfterViewInit, OnDestroy {
 
   onPointerDown(event: PointerEvent): void {
     if (this.duration <= 0) return;
-    const canvas = this.canvasRef.nativeElement;
+    const canvas = this.canvasRef().nativeElement;
     const rect = canvas.getBoundingClientRect();
     const px = event.clientX - rect.left;
     const sec = (px / rect.width) * this.duration;
@@ -181,7 +182,7 @@ export class AudioCropOverlayComponent implements AfterViewInit, OnDestroy {
 
   onPointerMove(event: PointerEvent): void {
     if (this.dragMode === 'none' || this.duration <= 0) return;
-    const canvas = this.canvasRef.nativeElement;
+    const canvas = this.canvasRef().nativeElement;
     const rect = canvas.getBoundingClientRect();
     const px = event.clientX - rect.left;
     const sec = Math.max(0, Math.min((px / rect.width) * this.duration, this.duration));
@@ -209,7 +210,7 @@ export class AudioCropOverlayComponent implements AfterViewInit, OnDestroy {
   onPointerUp(event: PointerEvent): void {
     if (this.dragMode === 'none') return;
     this.dragMode = 'none';
-    this.canvasRef.nativeElement.releasePointerCapture(event.pointerId);
+    this.canvasRef().nativeElement.releasePointerCapture(event.pointerId);
   }
 
   apply(): void {

--- a/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.spec.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.spec.ts
@@ -41,7 +41,11 @@ describe('ImageCropOverlayComponent', () => {
       getBoundingClientRect: () =>
         ({ left: 0, top: 0, width: DISP_W, height: DISP_H }) as DOMRect,
     };
-    component.imgRef = { nativeElement: img } as unknown as ElementRef<HTMLImageElement>;
+    // `imgRef` is a signal query; stub it with a zero-arg function returning
+    // the fake element so `this.imgRef()` reads the deterministic dimensions
+    // without a real view/query resolution.
+    (component as unknown as { imgRef: () => ElementRef<HTMLImageElement> }).imgRef =
+      () => ({ nativeElement: img }) as ElementRef<HTMLImageElement>;
   }
 
   beforeEach(() => {

--- a/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.ts
+++ b/frontend/src/app/components/modals/media-crop-modal/image-crop-overlay.component.ts
@@ -5,7 +5,7 @@ import {
   ElementRef,
   input,
   output,
-  ViewChild,
+  viewChild,
 } from '@angular/core';
 
 
@@ -31,7 +31,9 @@ export class ImageCropOverlayComponent implements AfterViewInit {
   readonly applied = output<ImageCropResult>();
   readonly cancelled = output<void>();
 
-  @ViewChild('img') imgRef!: ElementRef<HTMLImageElement>;
+  // Always in the DOM (not behind `@if`), so a required query is safe and it
+  // resolves before `ngAfterViewInit`, where the cached-image check reads it.
+  readonly imgRef = viewChild.required<ElementRef<HTMLImageElement>>('img');
 
   /** Crop box in *displayed* (CSS) pixel coordinates relative to the image element. */
   cropX = 0;
@@ -51,14 +53,14 @@ export class ImageCropOverlayComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     // Image may already be loaded if cached.
-    const img = this.imgRef.nativeElement;
+    const img = this.imgRef().nativeElement;
     if (img.complete && img.naturalWidth > 0) {
       this.onImageLoaded();
     }
   }
 
   onImageLoaded(): void {
-    const img = this.imgRef.nativeElement;
+    const img = this.imgRef().nativeElement;
     this.naturalW = img.naturalWidth;
     this.naturalH = img.naturalHeight;
     this.displayW = img.clientWidth;
@@ -71,7 +73,7 @@ export class ImageCropOverlayComponent implements AfterViewInit {
   }
 
   onPointerDown(event: PointerEvent): void {
-    const rect = this.imgRef.nativeElement.getBoundingClientRect();
+    const rect = this.imgRef().nativeElement.getBoundingClientRect();
     const px = event.clientX - rect.left;
     const py = event.clientY - rect.top;
     this.dragMode = this.hitTest(px, py);
@@ -85,7 +87,7 @@ export class ImageCropOverlayComponent implements AfterViewInit {
 
   onPointerMove(event: PointerEvent): void {
     if (this.dragMode === 'none') return;
-    const rect = this.imgRef.nativeElement.getBoundingClientRect();
+    const rect = this.imgRef().nativeElement.getBoundingClientRect();
     const px = event.clientX - rect.left;
     const py = event.clientY - rect.top;
     const dx = px - this.dragStartX;

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -43,20 +43,20 @@ describe('ProgressModalComponent', () => {
   });
 
   it('should set title based on metric', () => {
-    component.metric = 'smart';
+    fixture.componentRef.setInput('metric', 'smart');
     expect(component.title).toContain('Detector Accuracy');
 
-    component.metric = 'stable';
+    fixture.componentRef.setInput('metric', 'stable');
     expect(component.title).toContain('Changes Its Mind');
 
-    component.metric = 'diverse';
+    fixture.componentRef.setInput('metric', 'diverse');
     expect(component.title).toContain('Your Votes Cover');
   });
 
   it('should start in analyzing state', async () => {
     vi.useFakeTimers();
     try {
-      component.metric = 'smart';
+      fixture.componentRef.setInput('metric', 'smart');
       // TestBed.tick() runs ngOnInit (kicks off the train POST) under zoneless.
       TestBed.tick();
       expect(component.analyzing).toBe(true);
@@ -93,7 +93,7 @@ describe('ProgressModalComponent', () => {
     // down the result poller, or `analyzing` hangs forever.
     vi.useFakeTimers();
     try {
-      component.metric = 'smart';
+      fixture.componentRef.setInput('metric', 'smart');
       TestBed.tick();
 
       // Job started, not a cache hit -> the component polls for the result.
@@ -140,7 +140,7 @@ describe('ProgressModalComponent', () => {
     // Cancel button does — not silently orphan it.
     vi.useFakeTimers();
     try {
-      component.metric = 'stable';
+      fixture.componentRef.setInput('metric', 'stable');
       TestBed.tick();
 
       httpMock.expectOne('/api/eval/train-and-score').flush({
@@ -166,7 +166,7 @@ describe('ProgressModalComponent', () => {
     // not leave a poller running against an already-completed `destroy$`.
     vi.useFakeTimers();
     try {
-      component.metric = 'diverse';
+      fixture.componentRef.setInput('metric', 'diverse');
       TestBed.tick();
 
       const trainReq = httpMock.expectOne('/api/eval/train-and-score');

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, input, OnDestroy, OnInit, output, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, input, OnDestroy, OnInit, output, viewChild } from '@angular/core';
 
 import { Subject, takeUntil, timer, switchMap, filter, take } from 'rxjs';
 import { ModalComponent } from '../../modal/modal.component';
@@ -30,11 +30,12 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   private settingsState = inject(SettingsStateService);
   private progressEvents = inject(ProgressEventsService);
 
-  @Input() metric: ProgressMetric = 'smart';
+  readonly metric = input<ProgressMetric>('smart');
   readonly useCachedHistory = input(false);
   readonly closed = output<void>();
 
-  @ViewChild('chartCanvas') chartCanvas!: ElementRef<HTMLCanvasElement>;
+  // Optional query: the canvas only renders in the results `@else` branch.
+  readonly chartCanvas = viewChild<ElementRef<HTMLCanvasElement>>('chartCanvas');
 
   analyzing = true;
   analysisProgress = 0;
@@ -47,7 +48,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
 
   get title(): string {
-    switch (this.metric) {
+    switch (this.metric()) {
       case 'smart':
         return 'Smart: Detector Accuracy Over Time';
       case 'stable':
@@ -72,7 +73,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
 
   private loadCachedHistory(): void {
     this.analyzing = true;
-    this.sortingApi.getIndicatorScoreHistory(this.metric).subscribe({
+    this.sortingApi.getIndicatorScoreHistory(this.metric()).subscribe({
       next: (res) => {
         this.analyzing = false;
         this.chartData = (res.history || []) as ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[];
@@ -120,7 +121,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     // `pollEvalJob()` against an already-completed `destroy$` (RxJS
     // `takeUntil` never fires on a pre-completed notifier), leaking a poller.
     this.sortingApi
-      .trainAndScore(this.metric)
+      .trainAndScore(this.metric())
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (res) => {
@@ -183,9 +184,9 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
 
   private applyEvalResult(res: EvalTrainAndScoreResponse): void {
     this.analyzing = false;
-    if (this.metric === 'smart') {
+    if (this.metric() === 'smart') {
       this.chartData = (res.error_cost || []) as ErrorCostDataPoint[];
-    } else if (this.metric === 'stable') {
+    } else if (this.metric() === 'stable') {
       this.chartData = (res.stability || []) as StabilityDataPoint[];
     } else {
       this.chartData = (res.diversity || []) as DiversityDataPoint[];
@@ -194,9 +195,10 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   }
 
   private renderChart(): void {
-    if (!this.chartCanvas) return;
-    const canvas = this.chartCanvas.nativeElement;
-    switch (this.metric) {
+    const chartCanvas = this.chartCanvas();
+    if (!chartCanvas) return;
+    const canvas = chartCanvas.nativeElement;
+    switch (this.metric()) {
       case 'smart':
         this.chartsService.renderErrorCostChart(canvas, this.chartData as ErrorCostDataPoint[]);
         break;

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.html
@@ -42,7 +42,7 @@
 
   @if (view === 'prompt') {
     <div modal-footer>
-      <button class="btn btn--secondary" (click)="onKeep()" title="Continue sorting with the current example">Keep Current{{ keepLabelsCount ? ' for ' + keepLabelsCount + ' more labels' : '' }}</button>
+      <button class="btn btn--secondary" (click)="onKeep()" title="Continue sorting with the current example">Keep Current{{ keepLabelsCount() ? ' for ' + keepLabelsCount() + ' more labels' : '' }}</button>
     </div>
   }
 

--- a/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.ts
+++ b/frontend/src/app/components/modals/resort-prompt-modal/resort-prompt-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -38,7 +38,7 @@ export class ResortPromptModalComponent {
 
   readonly currentExampleType = input<'text' | 'media'>('text');
   readonly currentExampleDisplay = input('');
-  @Input() keepLabelsCount = 0;
+  readonly keepLabelsCount = input(0);
   readonly closed = output<void>();
   readonly keepExample = output<void>();
   readonly newExample = output<ResortResult>();

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
@@ -152,7 +152,7 @@ describe('AutoFindSettingsComponent', () => {
     expect(fv.server_json_file.filepath).toBe('/saved.json');
   });
 
-  it('reacts to input changes via ngOnChanges', async () => {
+  it('reacts to input changes via the seeding effect', async () => {
     await create();
     expect(component.activeExporter).toBe('');
 

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, input, OnChanges, OnDestroy, OnInit, output, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, OnInit, output } from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
 
 import { FormsModule } from '@angular/forms';
@@ -50,9 +50,21 @@ export interface AutoFindExporterChange {
   templateUrl: './auto-find-settings.component.html',
   styleUrl: './auto-find-settings.component.scss',
 })
-export class AutoFindSettingsComponent implements OnInit, OnChanges, OnDestroy {
+export class AutoFindSettingsComponent implements OnInit, OnDestroy {
   private detectorsRegistryApi = inject(DetectorsRegistryApiService);
   private exportersApi = inject(ExportersApiService);
+
+  constructor() {
+    // Seed the active tab + working field-values from the inputs, and re-seed
+    // whenever the parent pushes new values. Replaces the old `ngOnInit`
+    // seeding + `ngOnChanges` (signal inputs don't fire `ngOnChanges`). As a
+    // component effect this runs before the first template check, so the
+    // initial tab/values are set with no flash.
+    effect(() => {
+      this.activeExporter = this.autofindExporter() || '';
+      this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues());
+    });
+  }
 
   /** Currently configured results-exporter name ('' = no auto-export). */
   readonly autofindExporter = input('');
@@ -78,19 +90,7 @@ export class AutoFindSettingsComponent implements OnInit, OnChanges, OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['autofindExporter']) {
-      this.activeExporter = this.autofindExporter() || '';
-    }
-    if (changes['autofindExporterFieldValues']) {
-      this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues());
-    }
-  }
-
   ngOnInit(): void {
-    this.activeExporter = this.autofindExporter() || '';
-    this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues());
-
     this.detectorsRegistryApi
       .getRegistry()
       .pipe(takeUntil(this.destroy$))

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.spec.ts
@@ -100,8 +100,8 @@ describe('ImportDefaultsSettingsComponent', () => {
     });
   });
 
-  /** Create + init the component with the given inputs. Returns after ngOnInit
-   *  (and its synchronous listing subscriptions) has run. */
+  /** Create + init the component with the given inputs. Returns after the
+   *  tab-seeding effect (and its synchronous listing subscriptions) has run. */
   async function create(inputs: {
     mediaTypes?: MediaTypeInfo[];
     defaults?: ImportDefaultsByMediaType;

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, input, OnChanges, OnInit, output, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -38,8 +38,18 @@ import {
   templateUrl: './import-defaults-settings.component.html',
   styleUrl: './import-defaults-settings.component.scss',
 })
-export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
+export class ImportDefaultsSettingsComponent {
   private datasetsListingsApi = inject(DatasetsListingsApiService);
+
+  constructor() {
+    // Re-pick the active tab whenever the media-type list or the solo-type
+    // filter changes. Replaces the old `ngOnInit` + `ngOnChanges` (signal
+    // inputs don't fire `ngOnChanges`); reading both inputs via `visibleTypes`
+    // inside `pickInitialTab` is what this effect tracks. As a component effect
+    // it runs before the first template check, so the initial tab is set with
+    // no flash, and again on every subsequent input change.
+    effect(() => this.pickInitialTab());
+  }
 
   /** All registered media types; drives the per-mediaType tab strip. */
   readonly mediaTypes = input<MediaTypeInfo[]>([]);
@@ -62,16 +72,6 @@ export class ImportDefaultsSettingsComponent implements OnInit, OnChanges {
   clippersByType: Record<string, ClipperInfo[]> = {};
   convertersByType: Record<string, ConverterInfo[]> = {};
   loadingByType: Record<string, boolean> = {};
-
-  ngOnInit(): void {
-    this.pickInitialTab();
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['mediaTypes'] || changes['effectiveSoloMediaType']) {
-      this.pickInitialTab();
-    }
-  }
 
   private pickInitialTab(): void {
     const visible = this.visibleTypes;

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnDestroy, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { forkJoin, Subject } from 'rxjs';
@@ -51,7 +51,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
   /** HuggingFace sign-in state, surfaced to the "HuggingFace" settings tab. */
   readonly hfStatus = this.hfAuth.status;
 
-  @Input() preselectedViewTab = '';
+  readonly preselectedViewTab = input('');
   readonly closed = output<void>();
 
   readonly settings = signal<AppSettings>({ volume: 50 });
@@ -129,7 +129,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
         this.embeddersByType.set(byType);
         const mediaTypes = this.mediaTypes();
         if (mediaTypes.length > 0) {
-          const preselected = this.preselectedViewTab;
+          const preselected = this.preselectedViewTab();
           if (preselected && mediaTypes.some((mt) => mt.type_id === preselected)) {
             this.activeViewTab.set(preselected);
             this.activeSettingsTab.set('appearance');


### PR DESCRIPTION
Converts the standalone `modals/` components to signal-based authoring (part of the Angular signal-API modernization in `docs/plans/angular-22-upgrade.md`).

## What changed

**Decorator `@Input()` → `input()`**
- `autodetect-results-modal` — `data`
- `examples-editor-modal` — `modelName`
- `progress-modal` — `metric`
- `resort-prompt-modal` — `keepLabelsCount`
- `settings-modal` — `preselectedViewTab`
- `audio-crop-overlay` — `audioUrl`

**`@ViewChild` → `viewChild()` / `viewChild.required()`**
- `label-importer-modal` — `addGoodInput` / `addBadInput` (optional; both live behind `@if (!targetModelName())`)
- `progress-modal` — `chartCanvas` (optional; only in the results `@else` branch)
- `audio-crop-overlay` — `canvasRef` (required; always in the DOM, resolves before `ngAfterViewInit`)
- `image-crop-overlay` — `imgRef` (required; always in the DOM)

**`ngOnChanges` → constructor `effect()`** (signal inputs don't fire `ngOnChanges`)
- `auto-find/auto-find-settings` — seeds the active exporter tab + working field-values from the inputs and re-seeds on input change
- `import-defaults/import-defaults-settings` — re-picks the active media-type tab when the media-type list / solo filter changes

Both effects are component (view) effects, so they run before the first template check — the initial state is set with no flash, matching the old lifecycle-hook timing. Local mutable state (`activeExporter`/`fieldValues`, `activeType`) stays plain fields, driven by the effect exactly as the old `ngOnChanges` drove them.

`media-crop-modal.component.ts` itself was already on `input.required()` and is left untouched.

## Tests
- Updated `progress-modal` spec to `componentRef.setInput('metric', …)`.
- Stubbed the crop-overlay signal queries with zero-arg functions (the specs deliberately avoid `detectChanges()` and hand in a fake ref).
- Renamed/retitled the two settings-tab spec descriptions/comments that referenced `ngOnChanges`/`ngOnInit`.
- `./run-tests.sh frontend` passes (TypeScript build clean, 1684 Vitest tests pass, audit clean).

Closes #2546

---
_Generated by [Claude Code](https://claude.ai/code/session_01Byoo2KEZRZdz6UmJarDKf2)_