### PR TITLE
Signal-migrate misc shared leaf components (#2547)

### DIFF
--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.html
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.html
@@ -4,7 +4,7 @@
   [style.width.px]="size()"
   [style.height.px]="size()"
   [attr.aria-label]="iconType() + ' badge'">
-  @if (showOuterRing || tierIdx === -1) {
+  @if (showOuterRing || tierIdx() === -1) {
     <svg
       class="achievement-decoration"
       [attr.width]="size()"
@@ -16,7 +16,7 @@
       stroke-linecap="round"
       stroke-linejoin="round"
       aria-hidden="true">
-      @if (tierIdx === -1) {
+      @if (tierIdx() === -1) {
         <circle cx="50" cy="50" r="46" stroke-width="3" stroke-dasharray="4 4" />
       }
       @if (showOuterRing) {

--- a/frontend/src/app/components/achievement-badge/achievement-badge.component.ts
+++ b/frontend/src/app/components/achievement-badge/achievement-badge.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IconComponent } from '../icon/icon.component';
 
@@ -22,12 +22,12 @@ import { IconComponent } from '../icon/icon.component';
 })
 export class AchievementBadgeComponent {
   readonly iconType = input('trophy');
-  @Input() tierIdx = -1;
+  readonly tierIdx = input(-1);
   /** Outer badge size in pixels (the inner icon is auto-scaled). */
   readonly size = input(56);
 
   get tierClass(): string {
-    switch (this.tierIdx) {
+    switch (this.tierIdx()) {
       case 0:
         return 'tier-bronze';
       case 1:
@@ -46,18 +46,18 @@ export class AchievementBadgeComponent {
   }
 
   get showOuterRing(): boolean {
-    return this.tierIdx >= 0;
+    return this.tierIdx() >= 0;
   }
 
   get showDoubleRing(): boolean {
-    return this.tierIdx >= 1;
+    return this.tierIdx() >= 1;
   }
 
   get showLaurel(): boolean {
-    return this.tierIdx >= 2;
+    return this.tierIdx() >= 2;
   }
 
   get showSparkles(): boolean {
-    return this.tierIdx >= 3;
+    return this.tierIdx() >= 3;
   }
 }

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostListener, inject, input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostListener, inject, input, OnDestroy, OnInit, viewChild } from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
 
 import { Observable, Subject } from 'rxjs';
@@ -79,7 +79,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
 
   readonly kind = input<PulldownKind>('dataset');
 
-  @ViewChild('menuRef') menuRef?: ElementRef<HTMLDivElement>;
+  readonly menuRef = viewChild<ElementRef<HTMLDivElement>>('menuRef');
 
   open = false;
   focusedIndex = -1;
@@ -426,7 +426,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   }
 
   private scrollFocusedIntoView(): void {
-    const menu = this.menuRef?.nativeElement;
+    const menu = this.menuRef()?.nativeElement;
     if (!menu || this.focusedIndex < 0) return;
     const rowEl = menu.querySelectorAll('.pulldown-row')[this.focusedIndex] as
       | HTMLElement

--- a/frontend/src/app/components/drop-zone/drop-zone.component.html
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.html
@@ -20,8 +20,8 @@
     <line x1="12" y1="3" x2="12" y2="15" />
   </svg>
   <p class="drop-zone-label">{{ label() }}</p>
-  @if (sublabel) {
-    <p class="drop-zone-sublabel">{{ sublabel }}</p>
+  @if (sublabel()) {
+    <p class="drop-zone-sublabel">{{ sublabel() }}</p>
   }
   <input
     #fileInput

--- a/frontend/src/app/components/drop-zone/drop-zone.component.ts
+++ b/frontend/src/app/components/drop-zone/drop-zone.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, Input, input, output, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, input, output, viewChild } from '@angular/core';
 
 
 @Component({
@@ -11,21 +11,21 @@ import { ChangeDetectionStrategy, Component, ElementRef, Input, input, output, V
 })
 export class DropZoneComponent {
   readonly label = input('Drop files here, or click to browse');
-  @Input() sublabel = '';
+  readonly sublabel = input('');
   readonly accept = input('');
   readonly multiple = input(false);
   readonly directory = input(false);
   readonly disabled = input(false);
   readonly filesSelected = output<File[]>();
 
-  @ViewChild('fileInput') fileInput!: ElementRef<HTMLInputElement>;
+  readonly fileInput = viewChild<ElementRef<HTMLInputElement>>('fileInput');
 
   isDragging = false;
   private dragDepth = 0;
 
   openPicker(): void {
     if (this.disabled()) return;
-    this.fileInput?.nativeElement.click();
+    this.fileInput()?.nativeElement.click();
   }
 
   onInputChange(event: Event): void {

--- a/frontend/src/app/components/file-browser/file-browser.component.ts
+++ b/frontend/src/app/components/file-browser/file-browser.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, input, OnChanges, OnInit, output, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { map } from 'rxjs/operators';
@@ -24,7 +24,7 @@ import {
   templateUrl: './file-browser.component.html',
   styleUrl: './file-browser.component.scss',
 })
-export class FileBrowserComponent implements OnInit, OnChanges {
+export class FileBrowserComponent {
   private fileBrowserApi = inject(FileBrowserApiService);
 
   /** Comma-separated extensions to filter files, e.g. ".csv,.json" */
@@ -55,14 +55,14 @@ export class FileBrowserComponent implements OnInit, OnChanges {
       })),
     );
 
-  ngOnInit(): void {
-    this.inputValue = this.value();
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['value']) {
+  constructor() {
+    // Signal inputs don't fire `ngOnChanges`, so mirror the `value` input into
+    // the editable `inputValue` field whenever the parent pushes a new value
+    // (also seeds it on first render). User keystrokes change `inputValue` via
+    // ngModel without touching `value`, so they never trigger this reset.
+    effect(() => {
       this.inputValue = this.value();
-    }
+    });
   }
 
   openBrowser(): void {

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, NgZone, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, NgZone, OnDestroy, OnInit, signal, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { Subject, Subscription } from 'rxjs';
@@ -69,8 +69,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private browseSubset = inject(BrowseSubsetService);
   private router = inject(Router);
 
-  @ViewChild('layout', { static: true }) layoutRef!: ElementRef<HTMLElement>;
-  @ViewChild(CenterPanelComponent) centerPanel?: CenterPanelComponent;
+  readonly layoutRef = viewChild.required<ElementRef<HTMLElement>>('layout');
+  readonly centerPanel = viewChild(CenterPanelComponent);
 
   // Written from non-bound callbacks (HTTP status subscribe, the settings-mirror
   // effect, the media-type effect) and read in the template, so under zoneless
@@ -189,8 +189,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
-    this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
+    this.layoutRef().nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
+    this.layoutRef().nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     // Find mode: an item's good/bad is the detector's presumption until a
     // human verifies it, so the big buttons read neutral and a click verifies
     // (rather than toggling the presumption off).  Cleared in ngOnDestroy.
@@ -277,7 +277,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    setTimeout(() => this.centerPanel?.init());
+    setTimeout(() => this.centerPanel()?.init());
   }
 
   ngOnDestroy(): void {
@@ -397,7 +397,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private onMouseMove(event: MouseEvent): void {
     if (!this.dragging) return;
-    const layoutRect = this.layoutRef.nativeElement.getBoundingClientRect();
+    const layoutRect = this.layoutRef().nativeElement.getBoundingClientRect();
     let newWidth = event.clientX - layoutRect.left;
     const leftMax = layoutRect.width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
     newWidth = Math.max(this.LEFT_MIN, Math.min(leftMax, newWidth));
@@ -405,21 +405,21 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // custom property set imperatively here — so no CD is needed and the former
     // `ngZone.run` (a zoneless no-op anyway) is dropped.
     this.leftWidth = newWidth;
-    this.layoutRef.nativeElement.style.setProperty('--left-width', `${newWidth}px`);
+    this.layoutRef().nativeElement.style.setProperty('--left-width', `${newWidth}px`);
   }
 
   private onMouseUp(): void {
     this.dragging = false;
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
-    const leftPanelEl = this.layoutRef.nativeElement.querySelector('vt-left-panel') as HTMLElement | null;
+    const leftPanelEl = this.layoutRef().nativeElement.querySelector('vt-left-panel') as HTMLElement | null;
     if (leftPanelEl) {
       const snapped = snapPanelWidthToGridColumns(leftPanelEl, this.leftWidth);
       if (snapped !== null) {
-        const leftMax = this.layoutRef.nativeElement.getBoundingClientRect().width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
+        const leftMax = this.layoutRef().nativeElement.getBoundingClientRect().width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
         const clamped = Math.max(this.LEFT_MIN, Math.min(leftMax, snapped));
         this.leftWidth = clamped;
-        this.layoutRef.nativeElement.style.setProperty('--left-width', `${clamped}px`);
+        this.layoutRef().nativeElement.style.setProperty('--left-width', `${clamped}px`);
       }
     }
     this.savePanelPx('left');
@@ -438,27 +438,27 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private onRightMouseMove(event: MouseEvent): void {
     if (!this.draggingRight) return;
-    const layoutRect = this.layoutRef.nativeElement.getBoundingClientRect();
+    const layoutRect = this.layoutRef().nativeElement.getBoundingClientRect();
     let newWidth = layoutRect.right - event.clientX;
     const rightMax = layoutRect.width - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
     newWidth = Math.max(this.RIGHT_MIN, Math.min(rightMax, newWidth));
     this.rightWidth = newWidth;
-    this.layoutRef.nativeElement.style.setProperty('--right-width', `${newWidth}px`);
+    this.layoutRef().nativeElement.style.setProperty('--right-width', `${newWidth}px`);
   }
 
   private onRightMouseUp(): void {
     this.draggingRight = false;
     document.removeEventListener('mousemove', this.boundRightMouseMove);
     document.removeEventListener('mouseup', this.boundRightMouseUp);
-    const rightPanelEl = this.layoutRef.nativeElement.querySelector('vt-right-panel') as HTMLElement | null;
+    const rightPanelEl = this.layoutRef().nativeElement.querySelector('vt-right-panel') as HTMLElement | null;
     if (rightPanelEl) {
       const snapped = snapPanelWidthToGridColumns(rightPanelEl, this.rightWidth);
       if (snapped !== null) {
-        const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
+        const layoutWidth = this.layoutRef().nativeElement.getBoundingClientRect().width;
         const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
         const clamped = Math.max(this.RIGHT_MIN, Math.min(rightMax, snapped));
         this.rightWidth = clamped;
-        this.layoutRef.nativeElement.style.setProperty('--right-width', `${clamped}px`);
+        this.layoutRef().nativeElement.style.setProperty('--right-width', `${clamped}px`);
       }
     }
     this.savePanelPx('right');
@@ -801,18 +801,18 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private applyPanelPx(mediaType: string): void {
-    const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width || 1200;
+    const layoutWidth = this.layoutRef().nativeElement.getBoundingClientRect().width || 1200;
     const leftPx = this.panelPxLeftDict[mediaType];
     if (leftPx != null) {
       const leftMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
       this.leftWidth = Math.max(this.LEFT_MIN, Math.min(leftMax, leftPx));
-      this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
+      this.layoutRef().nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     }
     const rightPx = this.panelPxRightDict[mediaType];
     if (rightPx != null) {
       const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
       this.rightWidth = Math.max(this.RIGHT_MIN, Math.min(rightMax, rightPx));
-      this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
+      this.layoutRef().nativeElement.style.setProperty('--right-width', `${this.rightWidth}px`);
     }
   }
 }

--- a/frontend/src/app/components/folder-browser/folder-browser.component.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.ts
@@ -3,15 +3,14 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  effect,
   ElementRef,
   HostListener,
   input,
-  OnChanges,
   OnDestroy,
-  OnInit,
   output,
-  SimpleChanges,
-  ViewChild,
+  untracked,
+  viewChild,
 } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 
@@ -79,7 +78,7 @@ const TYPEAHEAD_RESET_MS = 800;
   templateUrl: './folder-browser.component.html',
   styleUrl: './folder-browser.component.scss',
 })
-export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, AfterViewInit {
+export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   /** Required: returns the listing for a given relative path. */
   readonly browse = input.required<FolderBrowserBrowseFn>();
 
@@ -144,22 +143,24 @@ export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, Aft
   private typeaheadTimer: ReturnType<typeof setTimeout> | null = null;
   private currentSub?: Subscription;
 
-  @ViewChild('listEl') listEl?: ElementRef<HTMLDivElement>;
+  readonly listEl = viewChild<ElementRef<HTMLDivElement>>('listEl');
 
-  ngOnInit(): void {
-    this.loadDirectory(this.initialPath() || '');
+  constructor() {
+    // Signal inputs don't fire `ngOnChanges`. This effect does the initial load
+    // and re-loads whenever `initialPath` changes (replacing the old ngOnInit +
+    // ngOnChanges pair). `loadDirectory` runs `untracked` so `initialPath` is
+    // the only dependency — the `browse`/`showFiles` reads inside it must not
+    // turn an unrelated input change into a reload.
+    effect(() => {
+      const path = this.initialPath() || '';
+      untracked(() => this.loadDirectory(path));
+    });
   }
 
   ngAfterViewInit(): void {
     if (this.autoFocus()) {
       // Defer one tick so the list element is in the DOM.
-      setTimeout(() => this.listEl?.nativeElement.focus(), 0);
-    }
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if ('initialPath' in changes && !changes['initialPath'].firstChange) {
-      this.loadDirectory(this.initialPath() || '');
+      setTimeout(() => this.listEl()?.nativeElement.focus(), 0);
     }
   }
 
@@ -376,7 +377,7 @@ export class FolderBrowserComponent implements OnInit, OnChanges, OnDestroy, Aft
   }
 
   private scrollSelectionIntoView(): void {
-    const list = this.listEl?.nativeElement;
+    const list = this.listEl()?.nativeElement;
     if (!list) return;
     const row = list.querySelectorAll('.vfb-row')[this.selectedIndex] as HTMLElement | undefined;
     row?.scrollIntoView({ block: 'nearest' });

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, input, OnChanges } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, inject, input } from '@angular/core';
 
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
@@ -105,7 +105,7 @@ const sanitizedCache = new Map<string, SafeHtml>();
     }
   `],
 })
-export class IconComponent implements OnChanges {
+export class IconComponent {
   private sanitizer = inject(DomSanitizer);
   private cdr = inject(ChangeDetectorRef);
 
@@ -116,8 +116,12 @@ export class IconComponent implements OnChanges {
 
   protected svgHtml: SafeHtml | null = null;
 
-  ngOnChanges(): void {
-    this.renderIcon();
+  constructor() {
+    // Signal inputs don't fire `ngOnChanges`, so re-render whenever the inputs
+    // `renderIcon` reads (`icon`/`type`, via the `iconType`/`letterChar`
+    // getters) change. `size` only drives template styling, so it isn't a
+    // dependency here.
+    effect(() => this.renderIcon());
   }
 
   get iconType(): string {

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -51,7 +51,7 @@
   <div
     class="pane-divider"
     vtPanelResize="left"
-    [layoutEl]="layoutRef.nativeElement"
+    [layoutEl]="layoutRef().nativeElement"
     [minWidth]="leftMin"
     [opposingWidth]="rightWidth()"
     [centerMin]="CENTER_MIN"
@@ -78,7 +78,7 @@
   <div
     class="pane-divider"
     vtPanelResize="right"
-    [layoutEl]="layoutRef.nativeElement"
+    [layoutEl]="layoutRef().nativeElement"
     [minWidth]="RIGHT_MIN"
     [opposingWidth]="leftWidth()"
     [centerMin]="CENTER_MIN"

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, OnDestroy, OnInit, signal, untracked, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, OnDestroy, OnInit, signal, untracked, viewChild } from '@angular/core';
 
 import { EMPTY, Subject, timer, Subscription, pairwise } from 'rxjs';
 import { catchError, takeUntil, switchMap, filter, take } from 'rxjs/operators';
@@ -80,8 +80,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private toast = inject(ToastService);
   panelState = inject(LabelViewPanelStateService);
 
-  @ViewChild('layout', { static: true }) layoutRef!: ElementRef<HTMLElement>;
-  @ViewChild(CenterPanelComponent) centerPanel?: CenterPanelComponent;
+  readonly layoutRef = viewChild.required<ElementRef<HTMLElement>>('layout');
+  readonly centerPanel = viewChild(CenterPanelComponent);
 
   readonly datasetName = signal('');
   /** Name of the trainable model owning the labels shown on the right pane.
@@ -273,8 +273,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.autopilotStateService.clear();
     this.embedderCaps.ensureLoaded();
     this.voteState.clear();
-    this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth()}px`);
-    this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth()}px`);
+    this.layoutRef().nativeElement.style.setProperty('--left-width', `${this.leftWidth()}px`);
+    this.layoutRef().nativeElement.style.setProperty('--right-width', `${this.rightWidth()}px`);
     this.pendingSnapOnLoad = true;
     this.mediaState.loadMedias();
     this.voteState.loadVotes();
@@ -333,7 +333,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    setTimeout(() => this.centerPanel?.init());
+    setTimeout(() => this.centerPanel()?.init());
   }
 
   /** Triggered by the top-bar context switcher whenever the active
@@ -394,7 +394,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       this.settingsState.update({ hide_autopilot: false }).subscribe();
     }
     this.leftWidth.set(width);
-    this.layoutRef.nativeElement.style.setProperty('--left-width', `${width}px`);
+    this.layoutRef().nativeElement.style.setProperty('--left-width', `${width}px`);
   }
 
   onLeftResizeEnd(width: number): void {
@@ -406,7 +406,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   onRightWidthChange(width: number): void {
     this.cancelAutoPop('right');
     this.rightWidth.set(width);
-    this.layoutRef.nativeElement.style.setProperty('--right-width', `${width}px`);
+    this.layoutRef().nativeElement.style.setProperty('--right-width', `${width}px`);
   }
 
   onRightResizeEnd(width: number): void {
@@ -425,11 +425,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
    *  records where the user left the divider. */
   private popPanelTight(side: 'left' | 'right', animate = true): void {
     const selector = side === 'left' ? 'vt-left-panel' : 'vt-right-panel';
-    const panelEl = this.layoutRef.nativeElement.querySelector(selector) as HTMLElement | null;
+    const panelEl = this.layoutRef().nativeElement.querySelector(selector) as HTMLElement | null;
     const currentWidth = side === 'left' ? this.leftWidth() : this.rightWidth();
     const snapped = panelEl ? snapPanelWidthToGridColumns(panelEl, currentWidth) : null;
     if (snapped !== null) {
-      const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width;
+      const layoutWidth = this.layoutRef().nativeElement.getBoundingClientRect().width;
       const otherWidth = side === 'left' ? this.rightWidth() : this.leftWidth();
       const max = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - otherWidth;
       const min = side === 'left' ? this.leftMin : this.RIGHT_MIN;
@@ -438,7 +438,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
         if (animate) this.animatePop();
         const widthSignal = side === 'left' ? this.leftWidth : this.rightWidth;
         widthSignal.set(clamped);
-        this.layoutRef.nativeElement.style.setProperty(`--${side}-width`, `${clamped}px`);
+        this.layoutRef().nativeElement.style.setProperty(`--${side}-width`, `${clamped}px`);
       }
     }
     this.panelState.savePanelPx(side, side === 'left' ? this.leftWidth() : this.rightWidth());
@@ -469,7 +469,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private snapWhenGridReady(side: 'left' | 'right', attempt = 0): void {
     const MAX_ATTEMPTS = 60;
     const selector = side === 'left' ? 'vt-left-panel' : 'vt-right-panel';
-    const panelEl = this.layoutRef.nativeElement.querySelector(selector) as HTMLElement | null;
+    const panelEl = this.layoutRef().nativeElement.querySelector(selector) as HTMLElement | null;
     const currentWidth = side === 'left' ? this.leftWidth() : this.rightWidth();
     const ready = panelEl != null && snapPanelWidthToGridColumns(panelEl, currentWidth) !== null;
     if (ready) {
@@ -541,7 +541,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   /** Enable the grid-template-columns transition for one auto-pop, then strip it
    *  so live divider dragging stays instant. */
   private animatePop(): void {
-    const el = this.layoutRef.nativeElement;
+    const el = this.layoutRef().nativeElement;
     el.classList.add('layout--animate-pop');
     if (this.animatePopTimer) clearTimeout(this.animatePopTimer);
     this.animatePopTimer = setTimeout(() => {
@@ -1236,7 +1236,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     } else {
       this.leftWidth.set(this.savedLeftWidth);
     }
-    this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth()}px`);
+    this.layoutRef().nativeElement.style.setProperty('--left-width', `${this.leftWidth()}px`);
   }
 
   onAutopilotEnabledChange(enabled: boolean): void {
@@ -1284,18 +1284,18 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
    *  the current layout bounds. Called when the media type changes or when
    *  fresh per-media-type settings come in. */
   private applyPanelPx(): void {
-    const layoutWidth = this.layoutRef.nativeElement.getBoundingClientRect().width || 1200;
+    const layoutWidth = this.layoutRef().nativeElement.getBoundingClientRect().width || 1200;
     const leftPx = this.panelState.getPanelPx('left');
     if (leftPx != null && !this.autopilotCollapsed()) {
       const leftMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth();
       this.leftWidth.set(Math.max(this.LEFT_MIN, Math.min(leftMax, leftPx)));
-      this.layoutRef.nativeElement.style.setProperty('--left-width', `${this.leftWidth()}px`);
+      this.layoutRef().nativeElement.style.setProperty('--left-width', `${this.leftWidth()}px`);
     }
     const rightPx = this.panelState.getPanelPx('right');
     if (rightPx != null) {
       const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth();
       this.rightWidth.set(Math.max(this.RIGHT_MIN, Math.min(rightMax, rightPx)));
-      this.layoutRef.nativeElement.style.setProperty('--right-width', `${this.rightWidth()}px`);
+      this.layoutRef().nativeElement.style.setProperty('--right-width', `${this.rightWidth()}px`);
     }
   }
 

--- a/frontend/src/app/components/modal/modal.component.html
+++ b/frontend/src/app/components/modal/modal.component.html
@@ -19,7 +19,7 @@
   <div class="modal-content">
     <div class="modal-header">
       <h2>{{ title() }}</h2>
-      @if (showCloseButton) {
+      @if (showCloseButton()) {
         <button class="modal-close" (click)="close()" title="Close" aria-label="Close">&times;</button>
       }
     </div>

--- a/frontend/src/app/components/modal/modal.component.ts
+++ b/frontend/src/app/components/modal/modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, HostListener, Input, OnDestroy, effect, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, OnDestroy, effect, input, output } from '@angular/core';
 import { CdkTrapFocus } from '@angular/cdk/a11y';
 
 /**
@@ -23,7 +23,7 @@ const openModalStack: ModalComponent[] = [];
 export class ModalComponent implements OnDestroy {
   readonly title = input('');
   readonly open = input(false);
-  @Input() showCloseButton = true;
+  readonly showCloseButton = input(true);
   readonly closed = output<void>();
 
   constructor() {


### PR DESCRIPTION
Converts the remaining shared/leaf components to signal-based authoring, part of the Angular signal-API modernization tracked in `docs/plans/angular-22-upgrade.md`.

## Changes

**`@Input()` → `input()`**
- `achievement-badge` — `tierIdx`
- `drop-zone` — `sublabel`
- `modal` — `showCloseButton`

**`@ViewChild` → `viewChild()`**
- `context-pulldown` — `menuRef`
- `drop-zone` — `fileInput`
- `folder-browser` — `listEl`
- `find-view` / `label-view` — `layoutRef` (`viewChild.required`) + `centerPanel`

**`ngOnChanges` → constructor `effect()`** (signal inputs don't fire `ngOnChanges`)
- `icon` — re-render on `icon`/`type` change (`size` only drives template styling, so it's intentionally not a dependency)
- `file-browser` — mirror the `value` input into the editable `inputValue` field (also seeds it on first render); user keystrokes change `inputValue` via ngModel without touching `value`, so they never trigger a reset
- `folder-browser` — initial load + reload on `initialPath` change, folding the old `ngOnInit` + `ngOnChanges`. `loadDirectory` runs inside `untracked()` so `initialPath` is the sole dependency and the `browse`/`showFiles` reads inside it can't turn an unrelated input change into a reload

**`managed-columns.ts`** — no change. Despite the issue note, this class has no Angular DI: its `constructor(defaults, meta, options)` takes plain data params (the `readonly TCol[]` is a type annotation, not a parameter-property), and it's instantiated with `new`, so there is no constructor-injection site to convert to `inject()`. It already satisfies the "no constructor-injection remains" criterion.

Templates were updated for the new signal call sites (`tierIdx()`, `sublabel()`, `showCloseButton()`, `layoutRef().nativeElement`).

## Notes
- Verified empirically (throwaway probe spec) that a `viewChild.required` for a template-static element resolves and is readable in `ngOnInit` on this Angular 21.2 / zoneless setup, so `find-view` / `label-view`'s `ngOnInit` reads of `layoutRef` keep working without relocating them. `#layout` is the always-present root element in both templates.

## Verification
- `./run-tests.sh frontend` passes: `build:prod` clean (no warnings), audit OK, **1684 Vitest tests passed**. Full lint/type gate (ruff, codespell, deptry, pip-audit, pyright, OpenAPI snapshot) also clean.

## Acceptance criteria
- [x] No decorator inputs/queries or constructor-injection remain in the listed files.
- [x] `./run-tests.sh frontend` passes.

Closes #2547

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViG6QHXCc3kqxEu8Lm4LnN)_