### PR TITLE
Signal migration: importer modal shell

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.html
@@ -9,40 +9,40 @@
     (importerSelected)="selectImporter($event)"
     [activePickerView]="activePickerView"
     [mediaTypes]="mediaTypes()"
-    [demos]="demoPicker.demos()"
-    [filteredDemos]="demoPicker.filteredDemos"
-    [demoLoading]="demoPicker.demoLoading()"
-    [demoTabs]="demoPicker.demoTabs()"
-    [activeDemoTab]="demoPicker.activeTab()"
-    (activeDemoTabChange)="demoPicker.selectDemoTabWithEmbedder($event)"
-    [demoCols]="demoPicker.demoCols"
+    [demos]="demoPicker().demos()"
+    [filteredDemos]="demoPicker().filteredDemos"
+    [demoLoading]="demoPicker().demoLoading()"
+    [demoTabs]="demoPicker().demoTabs()"
+    [activeDemoTab]="demoPicker().activeTab()"
+    (activeDemoTabChange)="demoPicker().selectDemoTabWithEmbedder($event)"
+    [demoCols]="demoPicker().demoCols"
     [showDemoMediaTypeTabs]="false"
-    [selectedDemoName]="demoPicker.selectedDemo()?.name || ''"
-    (demoSelected)="demoPicker.selectDemo($event)"
-    [sfPathInputValue]="serverFolderPicker.pathInputValue()"
-    (sfPathInputValueChange)="serverFolderPicker.onPathInput($event)"
-    (sfPathApplied)="serverFolderPicker.applyPathInput()"
-    [lfPickerKind]="localFolderPicker.pickerKind()"
-    [lfFiles]="localFolderPicker.files()"
-    [lfFolderName]="localFolderPicker.folderName"
-    (lfFilesDropped)="localFolderPicker.onFilesDropped($event)"
+    [selectedDemoName]="demoPicker().selectedDemo()?.name || ''"
+    (demoSelected)="demoPicker().selectDemo($event)"
+    [sfPathInputValue]="serverFolderPicker().pathInputValue()"
+    (sfPathInputValueChange)="serverFolderPicker().onPathInput($event)"
+    (sfPathApplied)="serverFolderPicker().applyPathInput()"
+    [lfPickerKind]="localFolderPicker().pickerKind()"
+    [lfFiles]="localFolderPicker().files()"
+    [lfFolderName]="localFolderPicker().folderName"
+    (lfFilesDropped)="localFolderPicker().onFilesDropped($event)"
   >
     <ng-container demoBefore>
       @if (!effectiveSoloMediaType) {
         <vt-import-config
           mediaTypeFieldId="demo-media-type"
-          [mediaType]="demoPicker.activeTab()"
-          (mediaTypeChange)="demoPicker.selectDemoTabWithEmbedder($event)"
-          [mediaTypeOptions]="demoPicker.demoTabs()"
-          [mediaTypeOptionLabels]="demoPicker.mediaTypeLabels"
-          [mediaTypeOptionIcons]="demoPicker.demoMediaTypeIcons"
+          [mediaType]="demoPicker().activeTab()"
+          (mediaTypeChange)="demoPicker().selectDemoTabWithEmbedder($event)"
+          [mediaTypeOptions]="demoPicker().demoTabs()"
+          [mediaTypeOptionLabels]="demoPicker().mediaTypeLabels"
+          [mediaTypeOptionIcons]="demoPicker().demoMediaTypeIcons"
         ></vt-import-config>
       }
     </ng-container>
 
     <ng-container demoAfter>
       <vt-demo-picker
-        [guessedMediaType]="guessedMediaType"
+        [guessedMediaType]="guessedMediaType()"
         [guessedMediaEmbedder]="guessedMediaEmbedder()"
         [buildProjection]="buildProjection"
         (buildProjectionChange)="buildProjection = $event"
@@ -56,12 +56,12 @@
       @if (!effectiveSoloMediaType) {
         <vt-import-config
           mediaTypeFieldId="sf-media-type"
-          [mediaType]="serverFolderPicker.mediaType()"
-          (mediaTypeChange)="serverFolderPicker.onMediaTypeChange($event)"
-          [mediaTypeOptions]="serverFolderPicker.mediaTypeOptions"
-          [mediaTypeOptionLabels]="serverFolderPicker.mediaTypeOptionLabels"
-          [mediaTypeOptionIcons]="serverFolderPicker.mediaTypeOptionIcons"
-          [detectionHint]="serverFolderPicker.detectionHint()"
+          [mediaType]="serverFolderPicker().mediaType()"
+          (mediaTypeChange)="serverFolderPicker().onMediaTypeChange($event)"
+          [mediaTypeOptions]="serverFolderPicker().mediaTypeOptions"
+          [mediaTypeOptionLabels]="serverFolderPicker().mediaTypeOptionLabels"
+          [mediaTypeOptionIcons]="serverFolderPicker().mediaTypeOptionIcons"
+          [detectionHint]="serverFolderPicker().detectionHint()"
         ></vt-import-config>
       }
     </ng-container>
@@ -70,7 +70,7 @@
       <vt-server-folder-picker
         [importers]="importers()"
         [mediaTypes]="mediaTypes()"
-        [guessedMediaType]="guessedMediaType"
+        [guessedMediaType]="guessedMediaType()"
         [guessedMediaEmbedder]="guessedMediaEmbedder()"
         [buildProjection]="buildProjection"
         (buildProjectionChange)="buildProjection = $event"
@@ -81,7 +81,7 @@
     </ng-container>
 
     <ng-container lfInfo>
-      @if (localFolderPicker.pickerKind() === 'folder') {
+      @if (localFolderPicker().pickerKind() === 'folder') {
         <p class="info-text">Pick a folder on <strong>this computer</strong> (running your browser).</p>
       } @else {
         <p class="info-text">
@@ -94,12 +94,12 @@
       @if (!effectiveSoloMediaType) {
         <vt-import-config
           mediaTypeFieldId="lf-media-type"
-          [mediaType]="localFolderPicker.mediaType"
-          (mediaTypeChange)="localFolderPicker.onMediaTypeChange($event)"
-          [mediaTypeOptions]="localFolderPicker.mediaTypeOptions"
-          [mediaTypeOptionLabels]="localFolderPicker.mediaTypeOptionLabels"
-          [mediaTypeOptionIcons]="localFolderPicker.mediaTypeOptionIcons"
-          [detectionHint]="localFolderPicker.detectionHint()"
+          [mediaType]="localFolderPicker().mediaType"
+          (mediaTypeChange)="localFolderPicker().onMediaTypeChange($event)"
+          [mediaTypeOptions]="localFolderPicker().mediaTypeOptions"
+          [mediaTypeOptionLabels]="localFolderPicker().mediaTypeOptionLabels"
+          [mediaTypeOptionIcons]="localFolderPicker().mediaTypeOptionIcons"
+          [detectionHint]="localFolderPicker().detectionHint()"
         ></vt-import-config>
       }
     </ng-container>
@@ -108,7 +108,7 @@
       <vt-local-folder-picker
         [importers]="importers()"
         [mediaTypes]="mediaTypes()"
-        [guessedMediaType]="guessedMediaType"
+        [guessedMediaType]="guessedMediaType()"
         [guessedMediaEmbedder]="guessedMediaEmbedder()"
         [buildProjection]="buildProjection"
         (buildProjectionChange)="buildProjection = $event"
@@ -123,7 +123,7 @@
     [hidden]="!selectedImporter() || activePickerView === 'demo' || activePickerView === 'local_folder' || activePickerView === 'local_files' || activePickerView === 'server_folder'"
     [importers]="importers()"
     [mediaTypes]="mediaTypes()"
-    [guessedMediaType]="guessedMediaType"
+    [guessedMediaType]="guessedMediaType()"
     [guessedMediaEmbedder]="guessedMediaEmbedder()"
     [buildProjection]="buildProjection"
     (buildProjectionChange)="buildProjection = $event"
@@ -136,8 +136,8 @@
   @if (activePickerView !== 'demo' && activePickerView !== 'local_folder' && activePickerView !== 'local_files' && activePickerView !== 'server_folder' && selectedImporter()) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
-      <button class="btn btn--primary" (click)="genericFormPicker.submit()" [disabled]="genericFormPicker.submitting() || !genericFormPicker.canSubmit">
-        @if (genericFormPicker.submitting()) {
+      <button class="btn btn--primary" (click)="genericFormPicker().submit()" [disabled]="genericFormPicker().submitting() || !genericFormPicker().canSubmit">
+        @if (genericFormPicker().submitting()) {
           Importing…
         } @else {
           Import
@@ -149,8 +149,8 @@
   @if ((activePickerView === 'local_folder' || activePickerView === 'local_files') && selectedImporter()) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
-      <button class="btn btn--primary" (click)="localFolderPicker.submit()" [disabled]="localFolderPicker.submitting() || localFolderPicker.files().length === 0">
-        @if (localFolderPicker.submitting()) {
+      <button class="btn btn--primary" (click)="localFolderPicker().submit()" [disabled]="localFolderPicker().submitting() || localFolderPicker().files().length === 0">
+        @if (localFolderPicker().submitting()) {
           Uploading…
         } @else {
           Upload &amp; Import
@@ -162,8 +162,8 @@
   @if (activePickerView === 'server_folder' && selectedImporter()) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
-      <button class="btn btn--primary" (click)="serverFolderPicker.submit()" [disabled]="serverFolderPicker.submitting() || !serverFolderPicker.folderPath()">
-        @if (serverFolderPicker.submitting()) {
+      <button class="btn btn--primary" (click)="serverFolderPicker().submit()" [disabled]="serverFolderPicker().submitting() || !serverFolderPicker().folderPath()">
+        @if (serverFolderPicker().submitting()) {
           Importing…
         } @else {
           Import
@@ -175,7 +175,7 @@
   @if (activePickerView === 'demo' && selectedImporter()) {
     <div class="form-actions" modal-footer>
       <button class="btn btn--secondary" (click)="close()">Cancel</button>
-      <button class="btn btn--primary" (click)="demoPicker.submit()" [disabled]="!demoPicker.selectedDemo()">Import</button>
+      <button class="btn btn--primary" (click)="demoPicker().submit()" [disabled]="!demoPicker().selectedDemo()">Import</button>
     </div>
   }
 </vt-modal>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -209,7 +209,7 @@ describe('DatasetImporterModalComponent', () => {
   /** Helper: select a demo media-type tab and flush the embedder + clipper
    *  fetches plus the embedder-aware refetch. */
   function selectDemoTabAndFlush(tab: string, embedders: typeof mockEmbedders): void {
-    component.demoPicker.selectDemoTabWithEmbedder(tab);
+    component.demoPicker().selectDemoTabWithEmbedder(tab);
     flushDemoTabRequests(tab, embedders);
   }
 
@@ -234,13 +234,13 @@ describe('DatasetImporterModalComponent', () => {
   });
 
   it('should pre-select the initialTab once importers and tabs arrive', () => {
-    component.initialTab = 'server';
+    fixture.componentRef.setInput('initialTab', 'server');
     flushImporters();
     expect(component.activeImporterTab()).toBe('server');
   });
 
   it('should fall back to the first populated tab when initialTab matches nothing', () => {
-    component.initialTab = 'no-such-tab';
+    fixture.componentRef.setInput('initialTab', 'no-such-tab');
     flushImporters();
     expect(component.activeImporterTab()).toBe('server');
   });
@@ -403,7 +403,7 @@ describe('DatasetImporterModalComponent', () => {
     const localFiles = component.importers().find((i) => i.name === 'local_files')!;
     component.selectImporter(localFiles);
     expect(component.activePickerView).toBe('local_files');
-    expect(component.localFolderPicker.pickerKind()).toBe('files');
+    expect(component.localFolderPicker().pickerKind()).toBe('files');
     expect(component.selectedImporter()?.name).toBe('local_files');
     httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
@@ -434,9 +434,9 @@ describe('DatasetImporterModalComponent', () => {
 
     const file = new File(['contents'], 'a.wav');
     Object.defineProperty(file, 'webkitRelativePath', { value: 'mydir/a.wav' });
-    component.localFolderPicker.files.set([file]);
-    component.localFolderPicker.mediaType = 'audio';
-    component.localFolderPicker.submit();
+    component.localFolderPicker().files.set([file]);
+    component.localFolderPicker().mediaType = 'audio';
+    component.localFolderPicker().submit();
 
     const req = httpMock.expectOne('/api/dataset/import-local-folder');
     expect(req.request.method).toBe('POST');
@@ -445,7 +445,7 @@ describe('DatasetImporterModalComponent', () => {
     expect(body.getAll('files').length).toBe(1);
     req.flush({ ok: true });
 
-    expect(component.localFolderPicker.submitting()).toBe(false);
+    expect(component.localFolderPicker().submitting()).toBe(false);
     expect(component.importStarted.emit).toHaveBeenCalled();
   });
 
@@ -459,9 +459,9 @@ describe('DatasetImporterModalComponent', () => {
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
 
     const pathsFile = new File(['/a.wav\n/b.wav\n'], 'list.txt');
-    component.localFolderPicker.files.set([pathsFile]);
-    component.localFolderPicker.mediaType = 'audio';
-    component.localFolderPicker.submit();
+    component.localFolderPicker().files.set([pathsFile]);
+    component.localFolderPicker().mediaType = 'audio';
+    component.localFolderPicker().submit();
 
     const req = httpMock.expectOne('/api/dataset/import-local-files');
     expect(req.request.method).toBe('POST');
@@ -472,7 +472,7 @@ describe('DatasetImporterModalComponent', () => {
     expect(body.get('files')).toBeNull();
     req.flush({ ok: true });
 
-    expect(component.localFolderPicker.submitting()).toBe(false);
+    expect(component.localFolderPicker().submitting()).toBe(false);
     expect(component.importStarted.emit).toHaveBeenCalled();
   });
 
@@ -489,7 +489,7 @@ describe('DatasetImporterModalComponent', () => {
   it('should pre-populate default values', () => {
     flushImporters();
     component.selectImporter(genericForm());
-    expect(component.genericFormPicker.formValues['media_type']).toBe('audio');
+    expect(component.genericFormPicker().formValues['media_type']).toBe('audio');
     httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
   });
@@ -516,15 +516,15 @@ describe('DatasetImporterModalComponent', () => {
     component.selectImporter(genericForm());
     httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
-    component.genericFormPicker.formValues['path'] = '/data/sounds';
-    component.genericFormPicker.submit();
+    component.genericFormPicker().formValues['path'] = '/data/sounds';
+    component.genericFormPicker().submit();
 
     const req = httpMock.expectOne('/api/dataset/import/generic_form');
     expect(req.request.method).toBe('POST');
     expect(req.request.body['path']).toBe('/data/sounds');
     req.flush({});
 
-    expect(component.genericFormPicker.submitting()).toBe(false);
+    expect(component.genericFormPicker().submitting()).toBe(false);
     expect(component.importStarted.emit).toHaveBeenCalled();
   });
 
@@ -533,15 +533,15 @@ describe('DatasetImporterModalComponent', () => {
     component.selectImporter(genericForm());
     httpMock.expectOne(req => req.url === '/api/embedders').flush({ embedders: [] });
     httpMock.expectOne(req => req.url === '/api/clippers').flush({ clippers: [] });
-    component.genericFormPicker.submit();
+    component.genericFormPicker().submit();
 
     httpMock.expectOne('/api/dataset/import/generic_form').flush(
       { error: 'Not found' },
       { status: 404, statusText: 'Not Found' },
     );
 
-    expect(component.genericFormPicker.submitting()).toBe(false);
-    expect(component.genericFormPicker.error()).toBe('Not found');
+    expect(component.genericFormPicker().submitting()).toBe(false);
+    expect(component.genericFormPicker().error()).toBe('Not found');
   });
 
   it('should emit closed on close', () => {
@@ -557,8 +557,8 @@ describe('DatasetImporterModalComponent', () => {
 
     component.selectImporter(pickleImp());
     const mockFile = new File(['data'], 'test.pkl');
-    component.genericFormPicker.selectedFile = mockFile;
-    component.genericFormPicker.submit();
+    component.genericFormPicker().selectedFile = mockFile;
+    component.genericFormPicker().submit();
 
     const req = httpMock.expectOne('/api/dataset/load-file');
     expect(req.request.method).toBe('POST');
@@ -575,7 +575,7 @@ describe('DatasetImporterModalComponent', () => {
     expect(component.activePickerView).toBe('');
     component.openDemoPicker();
     expect(component.activePickerView).toBe('demo');
-    expect(component.demoPicker.demoLoading()).toBe(true);
+    expect(component.demoPicker().demoLoading()).toBe(true);
 
     // Flush media types and demo list requests
     httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });
@@ -586,20 +586,20 @@ describe('DatasetImporterModalComponent', () => {
     // embedder/clipper/refetch.
     flushDemoTabRequests('audio', mockEmbedders);
 
-    expect(component.demoPicker.demoLoading()).toBe(false);
-    expect(component.demoPicker.demos().length).toBe(2);
-    expect(component.demoPicker.activeTab()).toBe('audio');
+    expect(component.demoPicker().demoLoading()).toBe(false);
+    expect(component.demoPicker().demos().length).toBe(2);
+    expect(component.demoPicker().activeTab()).toBe('audio');
   });
 
   it('should build tabs from media types in demo data and auto-select the first', () => {
     flushImporters();
     openAndFlushDemoPicker();
 
-    expect(component.demoPicker.demoTabs()).toEqual(['audio', 'image']);
+    expect(component.demoPicker().demoTabs()).toEqual(['audio', 'image']);
     // buildDemoTabs auto-selects the 'audio' tab so the demo table shows
     // results immediately instead of sitting blank.
-    expect(component.demoPicker.activeTab()).toBe('audio');
-    expect(component.demoPicker.filteredDemos.length).toBe(1);
+    expect(component.demoPicker().activeTab()).toBe('audio');
+    expect(component.demoPicker().filteredDemos.length).toBe(1);
   });
 
   it('should default the demo media-type tab to the active context type when known', () => {
@@ -620,7 +620,7 @@ describe('DatasetImporterModalComponent', () => {
     // audio, so the image embedder/clipper fetches fire for that tab.
     flushDemoTabRequests('image', mockImageEmbedders);
 
-    expect(component.demoPicker.activeTab()).toBe('image');
+    expect(component.demoPicker().activeTab()).toBe('image');
   });
 
   it('should filter demos by the explicitly selected media-type tab', () => {
@@ -628,12 +628,12 @@ describe('DatasetImporterModalComponent', () => {
     openAndFlushDemoPicker();
 
     selectDemoTabAndFlush('audio', mockEmbedders);
-    expect(component.demoPicker.filteredDemos.length).toBe(1);
-    expect(component.demoPicker.filteredDemos[0].name).toBe('gtzan');
+    expect(component.demoPicker().filteredDemos.length).toBe(1);
+    expect(component.demoPicker().filteredDemos[0].name).toBe('gtzan');
 
     selectDemoTabAndFlush('image', mockImageEmbedders);
-    expect(component.demoPicker.filteredDemos.length).toBe(1);
-    expect(component.demoPicker.filteredDemos[0].name).toBe('flowers102');
+    expect(component.demoPicker().filteredDemos.length).toBe(1);
+    expect(component.demoPicker().filteredDemos[0].name).toBe('flowers102');
   });
 
   it('should sort demos by column', () => {
@@ -641,17 +641,17 @@ describe('DatasetImporterModalComponent', () => {
     openAndFlushDemoPicker();
 
     // Default sort is num_files ascending
-    expect(component.demoPicker.demoCols.sortColumn).toBe('num_files');
-    expect(component.demoPicker.demoCols.sortAsc).toBe(true);
+    expect(component.demoPicker().demoCols.sortColumn).toBe('num_files');
+    expect(component.demoPicker().demoCols.sortAsc).toBe(true);
 
     // Click same column to toggle direction
-    component.demoPicker.demoCols.sortBy('num_files');
-    expect(component.demoPicker.demoCols.sortAsc).toBe(false);
+    component.demoPicker().demoCols.sortBy('num_files');
+    expect(component.demoPicker().demoCols.sortAsc).toBe(false);
 
     // Click different column to switch
-    component.demoPicker.demoCols.sortBy('label');
-    expect(component.demoPicker.demoCols.sortColumn).toBe('label');
-    expect(component.demoPicker.demoCols.sortAsc).toBe(true);
+    component.demoPicker().demoCols.sortBy('label');
+    expect(component.demoPicker().demoCols.sortColumn).toBe('label');
+    expect(component.demoPicker().demoCols.sortAsc).toBe(true);
   });
 
   it('should record the demo selection without submitting on row click', () => {
@@ -661,10 +661,10 @@ describe('DatasetImporterModalComponent', () => {
 
     openAndFlushDemoPicker();
 
-    component.demoPicker.selectDemo(mockDemos[0] as any);
-    expect(component.demoPicker.selectedDemo()).toBe(mockDemos[0] as any);
+    component.demoPicker().selectDemo(mockDemos[0] as any);
+    expect(component.demoPicker().selectedDemo()).toBe(mockDemos[0] as any);
     // Auto-populates the Dataset Name from the chosen demo's label.
-    expect(component.demoPicker.demoDatasetName).toBe(mockDemos[0].label);
+    expect(component.demoPicker().demoDatasetName).toBe(mockDemos[0].label);
     // No emit/close until the Import footer button is clicked.
     expect(component.demoSelected.emit).not.toHaveBeenCalled();
     expect(component.closed.emit).not.toHaveBeenCalled();
@@ -677,8 +677,8 @@ describe('DatasetImporterModalComponent', () => {
 
     openAndFlushDemoPicker();
 
-    component.demoPicker.selectDemo(mockDemos[0] as any);
-    component.demoPicker.submit();
+    component.demoPicker().selectDemo(mockDemos[0] as any);
+    component.demoPicker().submit();
     expect(component.demoSelected.emit).toHaveBeenCalled();
     expect(component.closed.emit).toHaveBeenCalled();
   });
@@ -709,21 +709,21 @@ describe('DatasetImporterModalComponent', () => {
     openAndFlushDemoPicker();
     selectDemoTabAndFlush('audio', mockEmbedders);
 
-    component.demoPicker.selectDemo(mockDemos[0] as any);
-    expect(component.demoPicker.selectedDemo()).not.toBeNull();
-    expect(component.demoPicker.demoDatasetName).toBe(mockDemos[0].label);
+    component.demoPicker().selectDemo(mockDemos[0] as any);
+    expect(component.demoPicker().selectedDemo()).not.toBeNull();
+    expect(component.demoPicker().demoDatasetName).toBe(mockDemos[0].label);
 
     selectDemoTabAndFlush('image', mockImageEmbedders);
-    expect(component.demoPicker.selectedDemo()).toBeNull();
-    expect(component.demoPicker.demoDatasetName).toBe('');
+    expect(component.demoPicker().selectedDemo()).toBeNull();
+    expect(component.demoPicker().demoDatasetName).toBe('');
   });
 
   it('should get correct tab label from media types', () => {
     flushImporters();
-    component.demoPicker.mediaTypes.set(mockMediaTypes as any);
+    component.demoPicker().mediaTypes.set(mockMediaTypes as any);
 
-    expect(getTabLabel(component.demoPicker.mediaTypes(), 'audio')).toContain('Audio');
-    expect(getTabLabel(component.demoPicker.mediaTypes(), 'unknown')).toBe('unknown');
+    expect(getTabLabel(component.demoPicker().mediaTypes(), 'audio')).toContain('Audio');
+    expect(getTabLabel(component.demoPicker().mediaTypes(), 'unknown')).toBe('unknown');
   });
 
   it('should handle demo fetch failure gracefully', () => {
@@ -736,8 +736,8 @@ describe('DatasetImporterModalComponent', () => {
       { status: 500, statusText: 'Internal Server Error' },
     );
 
-    expect(component.demoPicker.demoLoading()).toBe(false);
-    expect(component.demoPicker.demos().length).toBe(0);
+    expect(component.demoPicker().demoLoading()).toBe(false);
+    expect(component.demoPicker().demos().length).toBe(0);
   });
 
   // --- Embedder-aware status tests ---
@@ -748,7 +748,7 @@ describe('DatasetImporterModalComponent', () => {
     selectDemoTabAndFlush('image', mockImageEmbedders);
 
     // Changing embedder triggers a re-fetch with the new embedder param
-    component.demoPicker.onDemoEmbedderChange('siglip');
+    component.demoPicker().onDemoEmbedderChange('siglip');
 
     const req = httpMock.expectOne(
       r => r.url === '/api/dataset/demo-list' && r.params.get('embedder') === 'siglip',
@@ -778,13 +778,13 @@ describe('DatasetImporterModalComponent', () => {
       },
     ];
 
-    component.demoPicker.demos.set(demosWithEmbedder);
-    component.demoPicker.activeTab.set('image');
-    component.demoPicker.selectedDemoEmbedder.set('siglip');
+    component.demoPicker().demos.set(demosWithEmbedder);
+    component.demoPicker().activeTab.set('image');
+    component.demoPicker().selectedDemoEmbedder.set('siglip');
 
     // Call updateDemoStatuses via the public embedder change handler
     // (we set up state directly to test the client-side logic)
-    (component.demoPicker as any).updateDemoStatuses();
+    (component.demoPicker() as any).updateDemoStatuses();
 
     expect(demosWithEmbedder[0].status).toBe('needs_embedding');
     expect(demosWithEmbedder[0].ready).toBe(false);
@@ -810,11 +810,11 @@ describe('DatasetImporterModalComponent', () => {
       },
     ];
 
-    component.demoPicker.demos.set(demosWithEmbedder);
-    component.demoPicker.activeTab.set('image');
-    component.demoPicker.selectedDemoEmbedder.set('clip');
+    component.demoPicker().demos.set(demosWithEmbedder);
+    component.demoPicker().activeTab.set('image');
+    component.demoPicker().selectedDemoEmbedder.set('clip');
 
-    (component.demoPicker as any).updateDemoStatuses();
+    (component.demoPicker() as any).updateDemoStatuses();
 
     expect(demosWithEmbedder[0].status).toBe('ready');
     expect(demosWithEmbedder[0].ready).toBe(true);
@@ -840,11 +840,11 @@ describe('DatasetImporterModalComponent', () => {
       },
     ];
 
-    component.demoPicker.demos.set(demosUnknown);
-    component.demoPicker.activeTab.set('image');
-    component.demoPicker.selectedDemoEmbedder.set('clip');
+    component.demoPicker().demos.set(demosUnknown);
+    component.demoPicker().activeTab.set('image');
+    component.demoPicker().selectedDemoEmbedder.set('clip');
 
-    (component.demoPicker as any).updateDemoStatuses();
+    (component.demoPicker() as any).updateDemoStatuses();
 
     // Since we don't know the pkl_embedder, we can't confirm it matches
     expect(demosUnknown[0].status).toBe('needs_embedding');
@@ -885,11 +885,11 @@ describe('DatasetImporterModalComponent', () => {
       },
     ];
 
-    component.demoPicker.demos.set(crossTabDemos);
-    component.demoPicker.activeTab.set('image');
-    component.demoPicker.selectedDemoEmbedder.set('siglip');  // Doesn't match 'clip'
+    component.demoPicker().demos.set(crossTabDemos);
+    component.demoPicker().activeTab.set('image');
+    component.demoPicker().selectedDemoEmbedder.set('siglip');  // Doesn't match 'clip'
 
-    (component.demoPicker as any).updateDemoStatuses();
+    (component.demoPicker() as any).updateDemoStatuses();
 
     // Image demo should be downgraded (active tab, embedder mismatch)
     expect(crossTabDemos[1].status).toBe('needs_embedding');
@@ -917,11 +917,11 @@ describe('DatasetImporterModalComponent', () => {
       },
     ];
 
-    component.demoPicker.demos.set(downloadDemos);
-    component.demoPicker.activeTab.set('audio');
-    component.demoPicker.selectedDemoEmbedder.set('clap');
+    component.demoPicker().demos.set(downloadDemos);
+    component.demoPicker().activeTab.set('audio');
+    component.demoPicker().selectedDemoEmbedder.set('clap');
 
-    (component.demoPicker as any).updateDemoStatuses();
+    (component.demoPicker() as any).updateDemoStatuses();
 
     expect(downloadDemos[0].status).toBe('needs_download');
   });

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit, ViewChild, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, input, output, signal, viewChild } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
@@ -33,7 +33,7 @@ import { toTypeId } from './pickers/shared/media-type.util';
  *  whichever picker is active; keeping every picker instantiated lets
  *  template reference variables (`#demoPicker` etc.) resolve regardless
  *  of which view is showing. (2) it lets `selectImporter` reach each
- *  picker's `open()` method via `@ViewChild` synchronously, with no
+ *  picker's `open()` method via `viewChild()` queries, with no
  *  create-on-demand timing to reason about. */
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -60,13 +60,13 @@ export class DatasetImporterModalComponent implements OnInit {
   private importDefaults = inject(ImportDefaultsService);
 
   /** Media type_id guessed from existing datasets/models (e.g. "image"). */
-  @Input() guessedMediaType = '';
+  readonly guessedMediaType = input('');
   /** Embedder name guessed from existing datasets/in-progress loads (e.g. "siglip"). */
   readonly guessedMediaEmbedder = input('');
   /** Picker tab id to pre-select when the modal opens (e.g. "server" from
    *  the dashboard's first-run welcome banner CTA).  Empty leaves the
    *  picker in the default "no tab selected" state. */
-  @Input() initialTab = '';
+  readonly initialTab = input('');
 
   readonly closed = output<void>();
   readonly importStarted = output<void>();
@@ -91,17 +91,18 @@ export class DatasetImporterModalComponent implements OnInit {
    *  media-type-scoped list on demand). */
   allEmbedders: EmbedderInfo[] = [];
 
-  // `{ static: true }`: every picker tag is unconditionally present in
-  // the template (visibility is toggled with `[hidden]` / the shared
+  // Every picker tag is unconditionally present in the template
+  // (visibility is toggled with `[hidden]` / the shared
   // `<vt-source-picker>`'s own mutually-exclusive `@if` branches, never
-  // `@if` on the picker tag itself), so each query resolves before the
-  // very first change-detection pass - required because `selectImporter`
-  // dispatches to these synchronously from `ngOnInit`'s importer-list
-  // callback.
-  @ViewChild(GenericFormPickerComponent, { static: true }) genericFormPicker!: GenericFormPickerComponent;
-  @ViewChild(ServerFolderPickerComponent, { static: true }) serverFolderPicker!: ServerFolderPickerComponent;
-  @ViewChild(LocalFolderPickerComponent, { static: true }) localFolderPicker!: LocalFolderPickerComponent;
-  @ViewChild(DemoPickerComponent, { static: true }) demoPicker!: DemoPickerComponent;
+  // `@if` on the picker tag itself), so each query always has a match by
+  // the first change-detection pass.  `selectImporter` only dispatches to
+  // these from the async importer-list HTTP callback and from user
+  // events - both after the view (and hence these queries) has resolved -
+  // so `.required()` never reads before a value is available.
+  readonly genericFormPicker = viewChild.required(GenericFormPickerComponent);
+  readonly serverFolderPicker = viewChild.required(ServerFolderPickerComponent);
+  readonly localFolderPicker = viewChild.required(LocalFolderPickerComponent);
+  readonly demoPicker = viewChild.required(DemoPickerComponent);
 
   get effectiveSoloMediaType(): string | null {
     return this.importDefaults.effectiveSoloMediaType;
@@ -112,8 +113,8 @@ export class DatasetImporterModalComponent implements OnInit {
       next: (res) => {
         this.importers.set((res.importers || []).filter((imp) => !imp['hidden_from_picker']));
         this.declaredTabs.set(res.tabs || []);
-        if (this.initialTab && this.visibleImporterTabs.some((t) => t.id === this.initialTab)) {
-          this.selectImporterTab(this.initialTab);
+        if (this.initialTab() && this.visibleImporterTabs.some((t) => t.id === this.initialTab())) {
+          this.selectImporterTab(this.initialTab());
         } else if (this.visibleImporterTabs.length) {
           // Land on the first category that actually has importers (falling
           // back to the first tab) instead of a blank pane. The New Detector
@@ -292,32 +293,32 @@ export class DatasetImporterModalComponent implements OnInit {
     this.selectedImporter.set(importer);
     const pickerView = importer.picker_view || 'form';
     if (pickerView === 'local_folder' || pickerView === 'local_files') {
-      this.localFolderPicker.open(importer);
+      this.localFolderPicker().open(importer);
     } else if (pickerView === 'server_folder') {
-      this.serverFolderPicker.open(importer);
+      this.serverFolderPicker().open(importer);
     } else if (pickerView === 'demo') {
-      this.demoPicker.open(importer);
+      this.demoPicker().open(importer);
     } else {
-      this.genericFormPicker.open(importer);
+      this.genericFormPicker().open(importer);
     }
   }
 
   openDemoPicker(importer?: ImporterInfo): void {
     const resolved = importer || this.importers().find((i) => i.name === 'demo') || null;
     this.selectedImporter.set(resolved);
-    this.demoPicker.open(resolved);
+    this.demoPicker().open(resolved);
   }
 
   openLocalFolderUploader(importer?: ImporterInfo): void {
     const resolved = importer || this.importers().find((i) => i.name === 'local_folder') || null;
     this.selectedImporter.set(resolved);
-    this.localFolderPicker.open(resolved);
+    this.localFolderPicker().open(resolved);
   }
 
   openServerFolderBrowser(importer?: ImporterInfo): void {
     const resolved = importer || this.importers().find((i) => i.name === 'server_folder') || null;
     this.selectedImporter.set(resolved);
-    this.serverFolderPicker.open(resolved);
+    this.serverFolderPicker().open(resolved);
   }
 
   /** Forward a demo picker's committed selection to the dashboard, then

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.html
@@ -18,10 +18,10 @@
       (keydown)="onTriggerKeydown($event)"
     >
       <span class="media-type-trigger-content">
-        @if (iconFor(mediaType)) {
-          <vt-icon [icon]="iconFor(mediaType)" [size]="16"></vt-icon>
+        @if (iconFor(mediaType())) {
+          <vt-icon [icon]="iconFor(mediaType())" [size]="16"></vt-icon>
         }
-        <span class="media-type-trigger-label">{{ optionLabel(mediaType) }}</span>
+        <span class="media-type-trigger-label">{{ optionLabel(mediaType()) }}</span>
       </span>
       <span class="media-type-chevron" aria-hidden="true">▾</span>
     </button>
@@ -37,9 +37,9 @@
             class="media-type-option"
             role="option"
             [id]="optionId(i)"
-            [class.selected]="opt === mediaType"
+            [class.selected]="opt === mediaType()"
             [class.active]="i === activeIndex"
-            [attr.aria-selected]="opt === mediaType"
+            [attr.aria-selected]="opt === mediaType()"
             (click)="select(opt)"
             (mouseenter)="activeIndex = i"
           >
@@ -52,7 +52,7 @@
       </ul>
     }
   </div>
-  @if (detectionHint) {
-    <p class="detection-hint">{{ detectionHint }}</p>
+  @if (detectionHint()) {
+    <p class="detection-hint">{{ detectionHint() }}</p>
   }
 </div>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.spec.ts
@@ -71,14 +71,14 @@ describe('ImportConfigComponent', () => {
 
   describe('open/close behaviour', () => {
     it('toggle opens the popup and seeds the highlight on the current selection', () => {
-      component.mediaType = 'image';
+      fixture.componentRef.setInput('mediaType', 'image');
       component.toggle();
       expect(component.open).toBe(true);
       expect(component.activeIndex).toBe(options.indexOf('image'));
     });
 
     it('toggle seeds the highlight on the first option when nothing is selected', () => {
-      component.mediaType = '';
+      fixture.componentRef.setInput('mediaType', '');
       component.toggle();
       expect(component.activeIndex).toBe(0);
     });
@@ -93,7 +93,7 @@ describe('ImportConfigComponent', () => {
 
   describe('select', () => {
     it('emits mediaTypeChange and closes when a new value is chosen', () => {
-      component.mediaType = 'audio';
+      fixture.componentRef.setInput('mediaType', 'audio');
       component.open = true;
       let emitted = '';
       component.mediaTypeChange.subscribe((v: string) => (emitted = v));
@@ -103,7 +103,7 @@ describe('ImportConfigComponent', () => {
     });
 
     it('does not emit when the current value is re-selected', () => {
-      component.mediaType = 'audio';
+      fixture.componentRef.setInput('mediaType', 'audio');
       let emitted = false;
       component.mediaTypeChange.subscribe(() => (emitted = true));
       component.select('audio');
@@ -146,7 +146,7 @@ describe('ImportConfigComponent', () => {
     });
 
     it('Enter commits the highlighted option', () => {
-      component.mediaType = 'audio';
+      fixture.componentRef.setInput('mediaType', 'audio');
       component.toggle();
       component.activeIndex = 1;
       let emitted = '';

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-config/import-config.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, HostListener, inject, Input, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, inject, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { IconComponent } from '../../../icon/icon.component';
@@ -41,7 +41,7 @@ export class ImportConfigComponent {
   /** Two-way bound output media type (folder_import_name, e.g.
    *  ``"images"``).  Parent reloads embedders/clippers/source-specs on
    *  every change. */
-  @Input() mediaType = '';
+  readonly mediaType = input('');
   readonly mediaTypeChange = output<string>();
 
   /** ``folder_import_name`` values to show in the dropdown (same list
@@ -60,7 +60,7 @@ export class ImportConfigComponent {
   /** Pre-formatted hint string from
    *  :meth:`DatasetImporterModalComponent.detectionHint`.  Empty hides
    *  the chip entirely. */
-  @Input() detectionHint = '';
+  readonly detectionHint = input('');
 
   /** Whether the custom dropdown is currently expanded. */
   open = false;
@@ -116,7 +116,7 @@ export class ImportConfigComponent {
    *  point. */
   private openPopup(): void {
     this.open = true;
-    const selected = this.mediaTypeOptions().indexOf(this.mediaType);
+    const selected = this.mediaTypeOptions().indexOf(this.mediaType());
     this.activeIndex = selected >= 0 ? selected : 0;
   }
 
@@ -127,7 +127,7 @@ export class ImportConfigComponent {
 
   select(opt: string): void {
     this.close();
-    if (opt !== this.mediaType) {
+    if (opt !== this.mediaType()) {
       this.mediaTypeChange.emit(opt);
     }
   }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.html
@@ -14,13 +14,13 @@
   }
 
   @if (activeTab()) {
-    @if (importersForActiveTab.length === 0) {
+    @if (importersForActiveTab().length === 0) {
       <div class="importer-subtab-bar">
         <span class="empty-state empty-state--inline">{{ emptyCategoryText() }}</span>
       </div>
-    } @else if (importersForActiveTab.length > 1 || alwaysShowSubtabBar()) {
+    } @else if (importersForActiveTab().length > 1 || alwaysShowSubtabBar()) {
       <div class="importer-subtab-bar">
-        @for (imp of importersForActiveTab; track imp.name) {
+        @for (imp of importersForActiveTab(); track imp.name) {
           <button
             class="importer-subtab"
             [class.active]="selectedImporter()?.name === imp.name"
@@ -63,28 +63,28 @@
 
       <ng-content select="[demoBefore]"></ng-content>
 
-      @if (activeDemoTab() && demoCols) {
+      @if (activeDemoTab() && demoCols(); as cols) {
         <div class="demo-content-area">
-          <table class="data-table data-table--grid demo-table" [class.table-fixed]="demoCols.tableFixed">
+          <table class="data-table data-table--grid demo-table" [class.table-fixed]="cols.tableFixed">
             <thead>
               <tr>
-                @for (col of demoCols.columnOrder; track col; let first = $first) {
+                @for (col of cols.columnOrder; track col; let first = $first) {
                   <th
-                    [class.sortable]="demoCols.meta(col).sortable"
-                    [class.col-drop-target]="demoCols.isDropTarget(col)"
-                    [class.col-dragging]="demoCols.isDragging(col)"
+                    [class.sortable]="cols.meta(col).sortable"
+                    [class.col-drop-target]="cols.isDropTarget(col)"
+                    [class.col-dragging]="cols.isDragging(col)"
                     [class.col-num]="col === 'num_files'"
                     [attr.data-col]="col"
-                    [title]="demoCols.meta(col).title"
-                    [style.width.%]="demoCols.tableFixed ? demoCols.colWidths[col] : null"
+                    [title]="cols.meta(col).title"
+                    [style.width.%]="cols.tableFixed ? cols.colWidths[col] : null"
                     draggable="true"
                     (click)="onDemoHeaderClick(col)"
-                    (dragstart)="demoCols.onColDragStart($event, col)"
-                    (dragover)="demoCols.onColDragOver($event, col)"
-                    (dragleave)="demoCols.onColDragLeave($event, col)"
-                    (drop)="demoCols.onColDrop($event, col)"
-                    (dragend)="demoCols.onColDragEnd($event)"
-                  >@if (!first) {<div class="col-resize-handle" (mousedown)="demoCols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>}{{ demoCols.meta(col).label }}@if (demoCols.meta(col).sortable) {<span class="sort-indicator" [class.active]="demoCols.isSortActive(col)">{{ demoCols.sortIndicator(col) }}</span>}</th>
+                    (dragstart)="cols.onColDragStart($event, col)"
+                    (dragover)="cols.onColDragOver($event, col)"
+                    (dragleave)="cols.onColDragLeave($event, col)"
+                    (drop)="cols.onColDrop($event, col)"
+                    (dragend)="cols.onColDragEnd($event)"
+                  >@if (!first) {<div class="col-resize-handle" (mousedown)="cols.startResize($event)" (click)="$event.stopPropagation()" draggable="false"></div>}{{ cols.meta(col).label }}@if (cols.meta(col).sortable) {<span class="sort-indicator" [class.active]="cols.isSortActive(col)">{{ cols.sortIndicator(col) }}</span>}</th>
                 }
               </tr>
             </thead>
@@ -103,7 +103,7 @@
                   (keydown.enter)="demoSelected.emit(demo)"
                   (keydown.space)="$event.preventDefault(); demoSelected.emit(demo)"
                 >
-                  @for (col of demoCols.columnOrder; track col) {
+                  @for (col of cols.columnOrder; track col) {
                     @switch (col) {
                       @case ('label') {
                         <td class="col-name">{{ demo.label }}</td>
@@ -142,7 +142,7 @@
         type="text"
         class="form-input"
         [placeholder]="sfPathPlaceholder()"
-        [(ngModel)]="sfPathInputValue"
+        [ngModel]="sfPathInputValue()"
         (ngModelChange)="sfPathInputValueChange.emit($event)"
         (keydown.enter)="sfPathApplied.emit(); $event.preventDefault()"
         (blur)="sfApplyOnBlur() && sfPathApplied.emit()"
@@ -183,13 +183,13 @@
           (filesSelected)="lfFilesDropped.emit($event)"
         ></vt-drop-zone>
       }
-      @if (lfShowFileCount() && lfFiles.length > 0) {
+      @if (lfShowFileCount() && lfFiles().length > 0) {
         <p class="info-text">
           @if (lfPickerKind() === 'folder') {
-            Selected <strong>{{ lfFiles.length | number }}</strong> file{{ lfFiles.length === 1 ? '' : 's' }}
-            @if (lfFolderName) { from <code>{{ lfFolderName }}</code> }
+            Selected <strong>{{ lfFiles().length | number }}</strong> file{{ lfFiles().length === 1 ? '' : 's' }}
+            @if (lfFolderName()) { from <code>{{ lfFolderName() }}</code> }
           } @else {
-            Using paths from <code>{{ lfFiles[0].name }}</code>
+            Using paths from <code>{{ lfFiles()[0].name }}</code>
           }
         </p>
       }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.spec.ts
@@ -125,7 +125,7 @@ describe('SourcePickerComponent', () => {
 
     it('sorts when the clicked column is sortable', () => {
       const cols = makeCols();
-      component.demoCols = cols;
+      fixture.componentRef.setInput('demoCols', cols);
       const spy = vi.spyOn(cols, 'sortBy');
       component.onDemoHeaderClick('label');
       expect(spy).toHaveBeenCalledWith('label');
@@ -133,14 +133,14 @@ describe('SourcePickerComponent', () => {
 
     it('does nothing when the clicked column is not sortable', () => {
       const cols = makeCols();
-      component.demoCols = cols;
+      fixture.componentRef.setInput('demoCols', cols);
       const spy = vi.spyOn(cols, 'sortBy');
       component.onDemoHeaderClick('num_files');
       expect(spy).not.toHaveBeenCalled();
     });
 
     it('is a no-op when demoCols is null', () => {
-      component.demoCols = null;
+      fixture.componentRef.setInput('demoCols', null);
       expect(() => component.onDemoHeaderClick('label')).not.toThrow();
     });
   });
@@ -178,7 +178,7 @@ describe('SourcePickerComponent', () => {
     it('renders sub-tabs for the active category and emits importerSelected on click', async () => {
       fixture.componentRef.setInput('visibleImporterTabs', tabs);
       fixture.componentRef.setInput('activeTab', 'server');
-      component.importersForActiveTab = importers;
+      fixture.componentRef.setInput('importersForActiveTab', importers);
       await settleZoneless(fixture);
 
       const subtabs = fixture.nativeElement.querySelectorAll('.importer-subtab');
@@ -194,7 +194,7 @@ describe('SourcePickerComponent', () => {
       fixture.componentRef.setInput('visibleImporterTabs', tabs);
       fixture.componentRef.setInput('activeTab', 'server');
       fixture.componentRef.setInput('emptyCategoryText', 'Nothing here.');
-      component.importersForActiveTab = [];
+      fixture.componentRef.setInput('importersForActiveTab', []);
       await settleZoneless(fixture);
       expect(fixture.nativeElement.querySelector('.importer-subtab-bar').textContent).toContain('Nothing here.');
     });
@@ -202,7 +202,7 @@ describe('SourcePickerComponent', () => {
     it('hides the lone sub-tab by default but shows it when alwaysShowSubtabBar is set', async () => {
       fixture.componentRef.setInput('visibleImporterTabs', tabs);
       fixture.componentRef.setInput('activeTab', 'server');
-      component.importersForActiveTab = [importers[0]];
+      fixture.componentRef.setInput('importersForActiveTab', [importers[0]]);
       await settleZoneless(fixture);
       expect(fixture.nativeElement.querySelector('.importer-subtab')).toBeNull();
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-picker/source-picker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IconComponent } from '../../../icon/icon.component';
@@ -68,7 +68,7 @@ export class SourcePickerComponent {
 
   /** Importers whose ``category`` matches ``activeTab`` (i.e. the
    *  sub-tabs to render). */
-  @Input() importersForActiveTab: ImporterInfo[] = [];
+  readonly importersForActiveTab = input<ImporterInfo[]>([]);
 
   readonly activeTab = input('');
   readonly selectedImporter = input<ImporterInfo | null>(null);
@@ -108,7 +108,7 @@ export class SourcePickerComponent {
   readonly demoLoading = input(false);
   readonly demoTabs = input<string[]>([]);
   readonly activeDemoTab = input('');
-  @Input() demoCols: ManagedColumns | null = null;
+  readonly demoCols = input<ManagedColumns | null>(null);
   readonly mediaTypes = input<MediaTypeInfo[]>([]);
 
   readonly activeDemoTabChange = output<string>();
@@ -141,7 +141,7 @@ export class SourcePickerComponent {
 
   // === Server folder source view ===
 
-  @Input() sfPathInputValue = '';
+  readonly sfPathInputValue = input('');
   readonly sfPathInputValueChange = output<string>();
   /** Fired when the user finalises the typed path (Enter or blur). */
   readonly sfPathApplied = output<void>();
@@ -158,8 +158,8 @@ export class SourcePickerComponent {
   // === Local folder/files source view ===
 
   readonly lfPickerKind = input<'folder' | 'files'>('folder');
-  @Input() lfFiles: File[] = [];
-  @Input() lfFolderName = '';
+  readonly lfFiles = input<File[]>([]);
+  readonly lfFolderName = input('');
   readonly lfFilesDropped = output<File[]>();
 
   /** ``vt-drop-zone`` label rendered when ``lfPickerKind === 'folder'``. */
@@ -218,7 +218,8 @@ export class SourcePickerComponent {
   }
 
   onDemoHeaderClick(col: string): void {
-    if (this.demoCols?.meta(col).sortable) this.demoCols.sortBy(col);
+    const cols = this.demoCols();
+    if (cols?.meta(col).sortable) cols.sortBy(col);
   }
 
   demoRowDisabled(demo: DemoDatasetEntry): boolean {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/source-specs-picker/source-specs-picker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, OnChanges, output, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, input, output } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 
@@ -23,7 +23,7 @@ import { ClipperInfo, ConverterInfo, SourceSpec } from '../../../../models/api.m
   templateUrl: './source-specs-picker.component.html',
   styleUrl: './source-specs-picker.component.scss',
 })
-export class SourceSpecsPickerComponent implements OnChanges {
+export class SourceSpecsPickerComponent {
   /** All converters whose ``target_type`` matches the current native
    *  type.  Comes from the importer's ``to_dict()`` payload. */
   readonly availableConverters = input<ConverterInfo[]>([]);
@@ -61,14 +61,29 @@ export class SourceSpecsPickerComponent implements OnChanges {
   private drafts = new Map<string, SourceSpec>();
   private detailsOpenSet = new Set<string>();
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['nativeType'] && !changes['nativeType'].firstChange) {
-      this.drafts.clear();
-      this.detailsOpenSet.clear();
-    }
-    for (const s of this.specs()) {
-      if (s.converter !== null) this.drafts.set(s.source_type, s);
-    }
+  /** Last native type the sync effect observed, so a genuine change can be
+   *  told apart from the initial run (which must not clear). ``undefined``
+   *  until the effect first runs. */
+  private prevNativeType: string | undefined;
+
+  constructor() {
+    // Signal inputs don't fire ngOnChanges, so this effect mirrors the old
+    // hook: when ``nativeType`` actually changes, drop the per-source drafts
+    // and open Details panels (they belonged to the previous type); then
+    // (re)seed drafts from any incoming spec that carries a converter, so
+    // the Details panels reflect the parent's current selection.
+    effect(() => {
+      const nativeType = this.nativeType();
+      const specs = this.specs();
+      if (this.prevNativeType !== undefined && nativeType !== this.prevNativeType) {
+        this.drafts.clear();
+        this.detailsOpenSet.clear();
+      }
+      this.prevNativeType = nativeType;
+      for (const s of specs) {
+        if (s.converter !== null) this.drafts.set(s.source_type, s);
+      }
+    });
   }
 
   get nonNativeSourceTypes(): string[] {


### PR DESCRIPTION
Converts the dataset-importer modal shell (the frame around the pickers) to signal-based authoring, per #2543.

## What changed

- **`dataset-importer-modal.component.ts`** — `guessedMediaType` / `initialTab` → `input()`; the four picker `@ViewChild(..., { static: true })` queries → `viewChild.required(...)`. All dispatch to the pickers happens from the async importer-list HTTP callback and user events (never synchronously during construction), so `.required()` never reads before the view has resolved — matching the old `static: true` guarantee without an `ngAfterViewInit` race.
- **`import-config.component.ts`** — `mediaType` (two-way, keeps `mediaTypeChange`) and `detectionHint` → `input()`.
- **`source-picker.component.ts`** — `importersForActiveTab`, `demoCols`, `sfPathInputValue` (two-way), `lfFiles`, `lfFolderName` → `input()`.
- **`source-specs-picker.component.ts`** — replaced `ngOnChanges` (which signal inputs don't fire) with a `constructor` `effect()` that mirrors the old behavior: reset the per-source drafts + open Details panels when `nativeType` actually changes, then (re)seed drafts from any incoming spec carrying a converter. A `prevNativeType` guard reproduces the old "skip on first change" semantics.
- Templates updated to call the new input/query signals (`x` → `x()`), including a `@if (activeDemoTab() && demoCols(); as cols)` guard so the demo table reads a non-null `cols`, and the server-folder path input switched from `[(ngModel)]` to `[ngModel]="sfPathInputValue()"` + its existing `(ngModelChange)` emit (parent-controlled value).
- Specs updated to drive the now-signal inputs via `fixture.componentRef.setInput(...)`.

No decorator inputs or queries remain in the listed files. Consumers (New Detector media picker, import-defaults settings) bind through unchanged one-way/two-way syntax, so no call sites changed. Behavior is identical across all importer sub-tabs.

## Testing

- `./run-tests.sh frontend` passes: TypeScript build OK (no warnings), audit OK, **1684 Vitest unit tests passed** — including the full importer-modal spec covering local-folder, local-files, server-folder, demo, generic-form, solo-media filtering, and tab switching.

Only reactivity plumbing changed (no GUI markup), so no doc-screenshot reshoots are triggered.

Closes #2543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeXGhENpgfAvNyWa2B2MJc)_