### PR TITLE
Signal migration: left panel — lists (left-panel, media-list, media-item)

### DIFF
--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -1,6 +1,6 @@
-<div class="left-panel" [class.collapsed-autopilot]="panelMode() === 'label' && activeTab === 'autopilot' && autopilotCollapsed()" [class.disabled]="disabled()">
-  @if (datasetName && !(panelMode() === 'label' && activeTab === 'autopilot' && autopilotCollapsed())) {
-    <div class="dataset-name" [title]="datasetName">{{ datasetName }}</div>
+<div class="left-panel" [class.collapsed-autopilot]="panelMode() === 'label' && activeTab() === 'autopilot' && autopilotCollapsed()" [class.disabled]="disabled()">
+  @if (datasetName() && !(panelMode() === 'label' && activeTab() === 'autopilot' && autopilotCollapsed())) {
+    <div class="dataset-name" [title]="datasetName()">{{ datasetName() }}</div>
   }
   @if (panelMode() === 'find') {
     <!-- Find mode: simplified view (inclusion control, media list header, media items, and stripe). -->
@@ -47,19 +47,19 @@
 
       <div class="images-header">
         <h3 class="images-header-title">
-          {{ mediaTypeName() }}s ({{ (sortOrder()?.length ?? medias.length) | number }})
+          {{ mediaTypeName() }}s ({{ (sortOrder()?.length ?? medias().length) | number }})
         </h3>
         <vt-view-controls
           side="left"
-          [currentMediaType]="medias.length > 0 ? medias[0].media_type : ''"
+          [currentMediaType]="medias().length > 0 ? medias()[0].media_type : ''"
           class="view-controls-slot" />
 
       </div>
 
-      @if (sortBusy) {
+      @if (sortBusy()) {
         <vt-progress-indicators
           [labelingStatus]="null"
-          [sortBusy]="sortBusy"
+          [sortBusy]="sortBusy()"
           [sortStatus]="sortStatus()"
           [sortProgress]="sortProgress()"
           [sortProgressTotal]="sortProgressTotal()"
@@ -71,7 +71,7 @@
 
       <div class="media-list-container">
         <vt-media-list
-          [medias]="medias"
+          [medias]="medias()"
           [sortOrder]="sortOrder()"
           [threshold]="threshold()"
           [selectedId]="selectedId()"
@@ -89,38 +89,38 @@
           [selectedId]="selectedId()"
           [goodVotes]="goodVotes()"
           [badVotes]="badVotes()"
-          [totalCount]="medias.length"
+          [totalCount]="medias().length"
           (stripeClick)="onStripeClick($event)"
         />
       </div>
     </div>
   } @else {
     <!-- Label mode: full labeling UI with tabs -->
-    @if (!(activeTab === 'autopilot' && autopilotCollapsed())) {
+    @if (!(activeTab() === 'autopilot' && autopilotCollapsed())) {
       <div class="left-tabs" role="tablist" aria-label="Panel mode">
         <button
           class="left-tab"
           role="tab"
-          [class.active]="activeTab === 'manual'"
-          [attr.aria-selected]="activeTab === 'manual'"
+          [class.active]="activeTab() === 'manual'"
+          [attr.aria-selected]="activeTab() === 'manual'"
           (click)="setTab('manual')"
           title="Browse and label items manually with full control over sort mode, selection strategy, and inclusion."
         >Manual</button>
         <button
           class="left-tab"
           role="tab"
-          [class.active]="activeTab === 'autopilot'"
-          [attr.aria-selected]="activeTab === 'autopilot'"
-          [disabled]="autopilotDisabled"
+          [class.active]="activeTab() === 'autopilot'"
+          [attr.aria-selected]="activeTab() === 'autopilot'"
+          [disabled]="autopilotDisabled()"
           (click)="setTab('autopilot')"
-          [title]="autopilotDisabled
+          [title]="autopilotDisabled()
             ? 'Autopilot needs a way to start its first sort. This dataset\'s embedder can\'t search by text, so label a few good and bad examples in Manual mode to enable it.'
             : 'Autopilot guides you through labeling in phases: good examples, bad examples, refining the good/bad cutoff, and covering a broad mix of items.'"
         ><span class="label-full">Autopilot</span><span class="label-short">Auto</span></button>
       </div>
     }
 
-    @if (activeTab === 'manual') {
+    @if (activeTab() === 'manual') {
       <div class="tab-panel-manual" role="tabpanel" aria-label="Manual mode">
         <vt-sort-bar
           [sortMode]="sortMode()"
@@ -143,7 +143,7 @@
 
         <vt-progress-indicators
           [labelingStatus]="labelingStatus()"
-          [sortBusy]="sortBusy"
+          [sortBusy]="sortBusy()"
           [sortStatus]="sortStatus()"
           [sortProgress]="sortProgress()"
           [sortProgressTotal]="sortProgressTotal()"
@@ -162,17 +162,17 @@
 
         <div class="images-header">
           <h3 class="images-header-title">
-            {{ mediaTypeName() }}s ({{ medias.length | number }})
+            {{ mediaTypeName() }}s ({{ medias().length | number }})
           </h3>
           <vt-view-controls
             side="left"
-            [currentMediaType]="medias.length > 0 ? medias[0].media_type : ''"
+            [currentMediaType]="medias().length > 0 ? medias()[0].media_type : ''"
             class="view-controls-slot" />
         </div>
 
         <div class="media-list-container">
           <vt-media-list
-            [medias]="medias"
+            [medias]="medias()"
             [sortOrder]="sortOrder()"
             [threshold]="threshold()"
             [selectedId]="selectedId()"
@@ -191,7 +191,7 @@
             [selectedId]="selectedId()"
             [goodVotes]="goodVotes()"
             [badVotes]="badVotes()"
-            [totalCount]="medias.length"
+            [totalCount]="medias().length"
             (stripeClick)="onStripeClick($event)"
           />
         </div>
@@ -201,7 +201,7 @@
         <vt-autopilot-panel
           [goodVotes]="goodVotes()"
           [badVotes]="badVotes()"
-          [datasetSize]="medias.length"
+          [datasetSize]="medias().length"
           [labelsetGoodCount]="labelsetGoodCount()"
           [labelsetBadCount]="labelsetBadCount()"
           [labelingStatus]="labelingStatus()"
@@ -215,4 +215,3 @@
     }
   }
 </div>
-

--- a/frontend/src/app/components/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HttpTestingController } from '@angular/common/http/testing';
-import { SimpleChange } from '@angular/core';
 import { LeftPanelComponent } from './left-panel.component';
 import type { Media } from '../../models/api.models';
 import { settleResource } from '../../testing/settle-resource';
@@ -28,7 +27,7 @@ describe('LeftPanelComponent', () => {
   });
 
   it('should default to autopilot tab', () => {
-    expect(component.activeTab).toBe('autopilot');
+    expect(component.activeTab()).toBe('autopilot');
   });
 
   it('should emit autopilotStart on init', () => {
@@ -41,54 +40,50 @@ describe('LeftPanelComponent', () => {
 
   it('should switch to manual tab', () => {
     component.setTab('manual');
-    expect(component.activeTab).toBe('manual');
+    expect(component.activeTab()).toBe('manual');
   });
 
   it('should default to manual tab when autopilotEnabled is false', () => {
     const fresh = TestBed.createComponent(LeftPanelComponent);
     const comp = fresh.componentInstance;
-    comp.autopilotEnabled = false;
+    fresh.componentRef.setInput('autopilotEnabled', false);
     vi.spyOn(comp.autopilotStart, 'emit');
     TestBed.tick();
-    expect(comp.activeTab).toBe('manual');
+    expect(comp.activeTab()).toBe('manual');
     expect(comp.autopilotStart.emit).not.toHaveBeenCalled();
   });
 
   it('should default to manual and not start autopilot when autopilotDisabled', () => {
     const fresh = TestBed.createComponent(LeftPanelComponent);
     const comp = fresh.componentInstance;
-    comp.autopilotDisabled = true;
+    fresh.componentRef.setInput('autopilotDisabled', true);
     vi.spyOn(comp.autopilotStart, 'emit');
     TestBed.tick();
-    expect(comp.activeTab).toBe('manual');
+    expect(comp.activeTab()).toBe('manual');
     expect(comp.autopilotStart.emit).not.toHaveBeenCalled();
   });
 
   it('should fall back to manual when autopilot becomes disabled after starting', () => {
     // Default init lands on the autopilot tab.
-    expect(component.activeTab).toBe('autopilot');
+    expect(component.activeTab()).toBe('autopilot');
     vi.spyOn(component.autopilotStop, 'emit');
-    component.autopilotDisabled = true;
-    component.ngOnChanges({
-      autopilotDisabled: new SimpleChange(false, true, false),
-    });
-    expect(component.activeTab).toBe('manual');
+    fixture.componentRef.setInput('autopilotDisabled', true);
+    TestBed.tick();
+    expect(component.activeTab()).toBe('manual');
     expect(component.autopilotStop.emit).toHaveBeenCalled();
   });
 
   it('should ignore clicks on the autopilot tab while it is disabled', () => {
     component.setTab('manual');
-    component.autopilotDisabled = true;
+    fixture.componentRef.setInput('autopilotDisabled', true);
+    TestBed.tick();
     vi.spyOn(component.autopilotStart, 'emit');
     component.setTab('autopilot');
-    expect(component.activeTab).toBe('manual');
+    expect(component.activeTab()).toBe('manual');
     expect(component.autopilotStart.emit).not.toHaveBeenCalled();
   });
 
   it('should disable the autopilot tab button when autopilotDisabled', () => {
-    // setInput fires ngOnChanges and marks the host dirty so the tick repaints
-    // consistently (a direct field write leaves derived tab state unsettled,
-    // which under zoneless surfaces as an NG0100 in the verify pass).
     fixture.componentRef.setInput('autopilotDisabled', true);
     TestBed.tick();
     const el = fixture.nativeElement as HTMLElement;
@@ -104,10 +99,6 @@ describe('LeftPanelComponent', () => {
   });
 
   it('should render manual tab content when switched', () => {
-    // Drive the switch through the tab button's (click) — a bound listener that
-    // marks the view dirty — so the panel repaints cleanly under zoneless
-    // (calling setTab() directly leaves the host undirtied and the tab
-    // conditional unsettled across the verify pass).
     const el = fixture.nativeElement as HTMLElement;
     (el.querySelectorAll<HTMLButtonElement>('.left-tab')[0]).click(); // Manual
     TestBed.tick();
@@ -177,10 +168,7 @@ describe('LeftPanelComponent', () => {
     const stub = (media_type: string): Media => ({ id: 1, media_type }) as Media;
 
     function setMedias(medias: Media[]): void {
-      component.medias = medias;
-      component.ngOnChanges({
-        medias: new SimpleChange(undefined, medias, false),
-      });
+      fixture.componentRef.setInput('medias', medias);
     }
 
     it('derives the type label from the first grid item', () => {
@@ -215,10 +203,10 @@ describe('LeftPanelComponent', () => {
 
       // Metadata arrives late with a custom display name: the header must
       // upgrade instead of staying stuck on the fallback. The resource value
-      // commits on a microtask and the deriving effect runs on the next tick,
-      // so settle before asserting. Two GETs match here — the header's own
-      // rxResource read and the shared MediaTypeCapabilityService.ensureLoaded()
-      // fired in ngOnInit — so flush them all with the same payload.
+      // commits on a microtask, so settle before asserting. Two GETs match
+      // here — the header's own rxResource read and the shared
+      // MediaTypeCapabilityService.ensureLoaded() fired in ngOnInit — so flush
+      // them all with the same payload.
       const reqs = httpMock.match((r) => r.url.includes('/api/media-types'));
       reqs.forEach((r) => r.flush({ media_types: [{ type_id: 'audio', name: 'Sound Clips' }] }));
       await settleResource();

--- a/frontend/src/app/components/left-panel/left-panel.component.ts
+++ b/frontend/src/app/components/left-panel/left-panel.component.ts
@@ -4,14 +4,12 @@ import {
   computed,
   effect,
   inject,
-  Input,
   input,
-  OnChanges,
   OnInit,
   output,
   signal,
-  SimpleChanges,
-  ViewChild,
+  untracked,
+  viewChild,
 } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
@@ -52,8 +50,8 @@ export type { SortMode, SelectMode, SortedItem };
   templateUrl: './left-panel.component.html',
   styleUrl: './left-panel.component.scss',
 })
-export class LeftPanelComponent implements OnInit, OnChanges {
-  @Input() medias: Media[] = [];
+export class LeftPanelComponent implements OnInit {
+  readonly medias = input<Media[]>([]);
   readonly sortOrder = input<SortedItem[] | null>(null);
   readonly threshold = input<number | null>(null);
   readonly selectedId = input<number | null>(null);
@@ -72,7 +70,7 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   readonly sortMode = input<SortMode>('text');
   readonly selectMode = input<SelectMode>('top');
   readonly inclusion = input<number>(0);
-  @Input() sortBusy = false;
+  readonly sortBusy = input(false);
   readonly sortStatus = input('');
   readonly sortProgress = input(0);
   readonly sortProgressTotal = input(0);
@@ -84,7 +82,7 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   readonly loadSortLabel = input('');
   readonly textQuery = input('');
   readonly autopilotCollapsed = input(false);
-  @Input() autopilotEnabled = true;
+  readonly autopilotEnabled = input(true);
   /**
    * True when Autopilot cannot run on the active (dataset, detector) pair: the
    * dataset's embedder can't search by text, the detector has no media-example
@@ -93,13 +91,13 @@ export class LeftPanelComponent implements OnInit, OnChanges {
    * panel falls back to Manual. It re-enables once Learn sort becomes available
    * (the parent flips this back to ``false`` once both label classes exist).
    */
-  @Input() autopilotDisabled = false;
+  readonly autopilotDisabled = input(false);
   /** 'label' = full labeling UI (default), 'find' = simplified media-only view */
   readonly panelMode = input<'label' | 'find'>('label');
   /** Disable all interaction (used during Find scoring). */
   readonly disabled = input(false);
   /** Display name of the current dataset. */
-  @Input() datasetName = '';
+  readonly datasetName = input('');
 
   readonly sortModeChange = output<SortMode>();
   readonly selectModeChange = output<SelectMode>();
@@ -134,14 +132,9 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   readonly autopilotToggleCollapse = output<void>();
   readonly autopilotEnabledChange = output<boolean>();
 
-  @ViewChild(MediaListComponent) mediaListComponent!: MediaListComponent;
+  readonly mediaListComponent = viewChild(MediaListComponent);
 
-  activeTab: 'manual' | 'autopilot' = 'autopilot';
-  // Written from the constructor `effect()`s (when media-type / embedder
-  // metadata arrives) as well as the sync `ngOnChanges` path, so signals — an
-  // effect writing a plain template-bound field does not repaint under zoneless.
-  readonly mediaTypeName = signal('Media');
-  readonly textSortAvailable = signal(true);
+  readonly activeTab = signal<'manual' | 'autopilot'>('autopilot');
 
   private readonly datasetsListingsApi = inject(DatasetsListingsApiService);
   private readonly embedderCaps = inject(EmbedderCapabilityService);
@@ -150,8 +143,7 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   // Media-type metadata rides `rxResource`: loads once on creation (no request
   // signal = eager), wrapping the existing generated-client read so the
   // interceptor chain still applies. Embedder capability metadata comes from
-  // the shared `EmbedderCapabilityService` cache instead. The derived labels
-  // live in plain fields recomputed by the effects below + `ngOnChanges`.
+  // the shared `EmbedderCapabilityService` cache instead.
   private readonly mediaTypesResource = rxResource({
     stream: () => this.datasetsListingsApi.getMediaTypes(),
   });
@@ -159,17 +151,56 @@ export class LeftPanelComponent implements OnInit, OnChanges {
     () => this.mediaTypesResource.value()?.media_types ?? [],
   );
 
+  /**
+   * Media-type label shown in the grid header, derived from the current grid
+   * contents.  Tracks both the medias and the media-type metadata so the
+   * header never lags behind the grid: it resets to ``'Media'`` when the grid
+   * empties, and upgrades from the capitalized fallback to the proper display
+   * name once the metadata finishes loading (which can arrive *after* the
+   * first batch of medias).
+   */
+  readonly mediaTypeName = computed(() => {
+    const medias = this.medias();
+    const typeId = medias.length > 0 ? medias[0].media_type : '';
+    if (!typeId) return 'Media';
+    const info = this.mediaTypeInfos().find((mt) => mt.type_id === typeId);
+    return info?.name ?? typeId.charAt(0).toUpperCase() + typeId.slice(1);
+  });
+
+  /**
+   * Whether the active dataset's embedder can embed text queries.  If the
+   * embedder is unknown (e.g. embedders haven't loaded yet, or the media
+   * doesn't carry an embedder field), default to ``true`` so we never hide a
+   * working feature.  ``supportsTextAny`` reads the capability signal, so this
+   * recomputes when the registry loads.
+   */
+  readonly textSortAvailable = computed(() => {
+    const medias = this.medias();
+    const first = medias.length > 0 ? medias[0] : null;
+    const names = first?.embedders ?? (first?.embedder ? [first.embedder] : []);
+    return this.embedderCaps.supportsTextAny(names);
+  });
+
+  /** Previous ``autopilotDisabled`` value; ``null`` until the effect's first run. */
+  private prevAutopilotDisabled: boolean | null = null;
+
   constructor() {
-    // Re-derive the header label / text-sort gate when the metadata arrives
-    // (it can land after the first batch of medias). Effects auto-dispose with
-    // the component, so no manual unsubscribe is needed.
     effect(() => {
-      this.mediaTypeInfos();
-      this.updateMediaTypeName();
-    });
-    effect(() => {
-      this.embedderCaps.infos();
-      this.updateTextSortAvailable();
+      const disabled = this.autopilotDisabled();
+      untracked(() => {
+        const first = this.prevAutopilotDisabled === null;
+        this.prevAutopilotDisabled = disabled;
+        if (first) return;
+        // Autopilot just became impossible (e.g. medias loaded and revealed a
+        // no-text embedder, after we optimistically started on entry). Fall
+        // back to Manual so the user can label by hand; the doomed text sort is
+        // also skipped upstream. When it flips back to available we leave the
+        // user where they are and just re-enable the tab.
+        if (disabled && this.activeTab() === 'autopilot') {
+          this.activeTab.set('manual');
+          this.autopilotStop.emit();
+        }
+      });
     });
   }
 
@@ -178,62 +209,14 @@ export class LeftPanelComponent implements OnInit, OnChanges {
     this.mediaTypeCaps.ensureLoaded();
     if (this.panelMode() === 'find') {
       // Find mode doesn't use tabs; keep manual as a no-op default
-      this.activeTab = 'manual';
+      this.activeTab.set('manual');
     } else {
-      const startAutopilot = this.autopilotEnabled && !this.autopilotDisabled;
-      this.activeTab = startAutopilot ? 'autopilot' : 'manual';
+      const startAutopilot = this.autopilotEnabled() && !this.autopilotDisabled();
+      this.activeTab.set(startAutopilot ? 'autopilot' : 'manual');
       if (startAutopilot) {
         this.autopilotStart.emit();
       }
     }
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['medias']) {
-      this.updateMediaTypeName();
-      this.updateTextSortAvailable();
-    }
-    if (changes['autopilotDisabled'] && !changes['autopilotDisabled'].firstChange) {
-      // Autopilot just became impossible (e.g. medias loaded and revealed a
-      // no-text embedder, after we optimistically started on entry). Fall back
-      // to Manual so the user can label by hand; the doomed text sort is also
-      // skipped upstream. When it flips back to available we leave the user
-      // where they are and just re-enable the tab.
-      if (this.autopilotDisabled && this.activeTab === 'autopilot') {
-        this.activeTab = 'manual';
-        this.autopilotStop.emit();
-      }
-    }
-  }
-
-  /**
-   * Re-derive the media-type label shown in the grid header from the current
-   * grid contents.  Always recomputes (no memo on the type id) so the header
-   * never lags behind the grid: it resets to ``'Media'`` when the grid empties,
-   * and upgrades from the capitalized fallback to the proper display name once
-   * the media-type metadata finishes loading (which can arrive *after* the
-   * first batch of medias).
-   */
-  private updateMediaTypeName(): void {
-    const typeId = this.medias.length > 0 ? this.medias[0].media_type : '';
-    if (!typeId) {
-      this.mediaTypeName.set('Media');
-      return;
-    }
-    const info = this.mediaTypeInfos().find((mt) => mt.type_id === typeId);
-    this.mediaTypeName.set(info?.name ?? typeId.charAt(0).toUpperCase() + typeId.slice(1));
-  }
-
-  /**
-   * Resolve whether the active dataset's embedder can embed text queries.
-   * If the embedder is unknown (e.g. embedders haven't loaded yet, or the
-   * media doesn't carry an embedder field), default to ``true`` so we never
-   * hide a working feature.
-   */
-  private updateTextSortAvailable(): void {
-    const first = this.medias.length > 0 ? this.medias[0] : null;
-    const names = first?.embedders ?? (first?.embedder ? [first.embedder] : []);
-    this.textSortAvailable.set(this.embedderCaps.supportsTextAny(names));
   }
 
   /**
@@ -256,22 +239,20 @@ export class LeftPanelComponent implements OnInit, OnChanges {
   }
 
   onStripeClick(index: number): void {
-    if (this.mediaListComponent) {
-      this.mediaListComponent.scrollToIndex(index);
-    }
+    this.mediaListComponent()?.scrollToIndex(index);
   }
 
   setTab(tab: 'manual' | 'autopilot'): void {
     // Autopilot can't be entered while it has no way to seed a first sort.
-    if (tab === 'autopilot' && this.autopilotDisabled) return;
-    if (tab === this.activeTab) {
+    if (tab === 'autopilot' && this.autopilotDisabled()) return;
+    if (tab === this.activeTab()) {
       if (tab === 'autopilot') {
         this.autopilotRefocus.emit();
       }
       return;
     }
-    const previous = this.activeTab;
-    this.activeTab = tab;
+    const previous = this.activeTab();
+    this.activeTab.set(tab);
     if (previous === 'autopilot') {
       this.autopilotStop.emit();
     }

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.html
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.html
@@ -1,10 +1,10 @@
 <div
   class="media-item"
-  [class.active]="active"
-  [class.labeled-good]="voteLabel === 'good'"
-  [class.labeled-bad]="voteLabel === 'bad'"
+  [class.active]="active()"
+  [class.labeled-good]="voteLabel() === 'good'"
+  [class.labeled-bad]="voteLabel() === 'bad'"
   role="option"
-  [attr.aria-selected]="active"
+  [attr.aria-selected]="active()"
   tabindex="0"
   (click)="onClick()"
   (contextmenu)="onContextMenu($event)"
@@ -30,7 +30,7 @@
     }
   </div>
   <span class="media-name-grid">{{ displayName }}</span>
-  @if (score !== null) {
-    <span class="media-score" title="How strong a match the detector thinks this is">{{ score | number:'1.2-2' }}</span>
+  @if (score() !== null) {
+    <span class="media-score" title="How strong a match the detector thinks this is">{{ score() | number:'1.2-2' }}</span>
   }
 </div>

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.spec.ts
@@ -38,12 +38,12 @@ describe('MediaItemComponent', () => {
   });
 
   it('should fall back to description when no filename', () => {
-    component.media = { ...mockMedia, filename: '', description: 'A sound' };
+    fixture.componentRef.setInput('media', { ...mockMedia, filename: '', description: 'A sound' });
     expect(component.displayName).toBe('A sound');
   });
 
   it('should fall back to id when no filename or description', () => {
-    component.media = { ...mockMedia, filename: '', description: undefined };
+    fixture.componentRef.setInput('media', { ...mockMedia, filename: '', description: undefined });
     expect(component.displayName).toBe('#1');
   });
 
@@ -76,7 +76,7 @@ describe('MediaItemComponent', () => {
   });
 
   it('should show thumbnail for image type', () => {
-    component.media = { ...mockMedia, media_type: 'image' };
+    fixture.componentRef.setInput('media', { ...mockMedia, media_type: 'image' });
     expect(component.thumbnailUrl).toBe('/api/medias/1/thumbnail');
   });
 
@@ -101,7 +101,7 @@ describe('MediaItemComponent', () => {
   });
 
   it('should not show thumbnail for text type', () => {
-    component.media = { ...mockMedia, media_type: 'text' };
+    fixture.componentRef.setInput('media', { ...mockMedia, media_type: 'text' });
     expect(component.thumbnailUrl).toBeNull();
   });
 
@@ -109,14 +109,13 @@ describe('MediaItemComponent', () => {
     expect(component.thumbnailUrl).toBe('/api/medias/1/thumbnail');
     component.onThumbnailError();
     expect(component.thumbnailUrl).toBeNull();
-    expect(component.placeholderIcon).toBe('\u266B');
+    expect(component.placeholderIcon).toBe('♫');
   });
 
   it('should reset thumbnailFailed when media changes', () => {
     component.onThumbnailError();
     expect(component.thumbnailUrl).toBeNull();
-    component.media = { ...mockMedia, id: 2 };
-    component.ngOnChanges({ media: {} as any });
+    fixture.componentRef.setInput('media', { ...mockMedia, id: 2 });
     expect(component.thumbnailUrl).toBe('/api/medias/2/thumbnail');
   });
 

--- a/frontend/src/app/components/left-panel/media-item/media-item.component.ts
+++ b/frontend/src/app/components/left-panel/media-item/media-item.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, input, OnChanges, output, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, linkedSignal, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -12,14 +12,14 @@ import { MediaTypeCapabilityService } from '../../../services/media-type-capabil
   templateUrl: './media-item.component.html',
   styleUrl: './media-item.component.scss',
 })
-export class MediaItemComponent implements OnChanges {
+export class MediaItemComponent {
   private activeContext = inject(ActiveContextService);
   private mediaTypeCaps = inject(MediaTypeCapabilityService);
 
-  @Input({ required: true }) media!: Media;
-  @Input() active = false;
-  @Input() voteLabel: 'good' | 'bad' | null = null;
-  @Input() score: number | null = null;
+  readonly media = input.required<Media>();
+  readonly active = input(false);
+  readonly voteLabel = input<'good' | 'bad' | null>(null);
+  readonly score = input<number | null>(null);
   readonly focusMode = input<'click' | 'hover'>('click');
 
   readonly select = output<number>();
@@ -33,54 +33,51 @@ export class MediaItemComponent implements OnChanges {
     y: number;
 }>();
 
-  thumbnailFailed = false;
-  private lastMediaId: number | null = null;
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media.id !== this.lastMediaId) {
-      this.thumbnailFailed = false;
-      this.lastMediaId = this.media.id;
-    }
-  }
+  /** Resets to ``false`` whenever the card is recycled for a different media. */
+  private readonly thumbnailFailed = linkedSignal<number, boolean>({
+    source: () => this.media().id,
+    computation: () => false,
+  });
 
   get thumbnailUrl(): string | null {
-    if (this.thumbnailFailed) return null;
-    if (this.mediaTypeCaps.usesThumbnails(this.media.media_type)) {
+    if (this.thumbnailFailed()) return null;
+    if (this.mediaTypeCaps.usesThumbnails(this.media().media_type)) {
       // Use the downscaled thumbnail endpoint, not the full-resolution
       // ``/image`` route: a grid of hundreds of high-res items would otherwise
       // force the browser to decode every full-size bitmap at once and exhaust
       // memory. The same thumbnail is reused at every zoom level.
-      return this.activeContext.mediaUrl(`/api/medias/${this.media.id}/thumbnail`);
+      return this.activeContext.mediaUrl(`/api/medias/${this.media().id}/thumbnail`);
     }
     return null;
   }
 
-  /** True when {@link thumbnailUrl} is an audio waveform \u2014 a theme-agnostic
+  /** True when {@link thumbnailUrl} is an audio waveform — a theme-agnostic
    *  alpha-mask PNG (issue #2369) tinted via a CSS mask, not a plain <img>. */
   get isAudioThumbnail(): boolean {
-    return !!this.thumbnailUrl && this.media.media_type === 'audio';
+    return !!this.thumbnailUrl && this.media().media_type === 'audio';
   }
 
   get placeholderIcon(): string | null {
     if (this.thumbnailUrl) return null;
-    if (this.media.media_type === 'audio') return '\u266B';
-    if (this.media.media_type === 'text') return '\u00B6';
-    return '\u25A1';
+    if (this.media().media_type === 'audio') return '♫';
+    if (this.media().media_type === 'text') return '¶';
+    return '□';
   }
 
   onThumbnailError(): void {
-    this.thumbnailFailed = true;
+    this.thumbnailFailed.set(true);
   }
 
   get displayName(): string {
-    return this.media.filename || this.media.description || `#${this.media.id}`;
+    const media = this.media();
+    return media.filename || media.description || `#${media.id}`;
   }
 
   onClick(): void {
     if (this.focusMode() === 'hover') {
-      this.vote.emit({ id: this.media.id, vote: 'bad' });
+      this.vote.emit({ id: this.media().id, vote: 'bad' });
     } else {
-      this.select.emit(this.media.id);
+      this.select.emit(this.media().id);
     }
   }
 
@@ -90,16 +87,16 @@ export class MediaItemComponent implements OnChanges {
       // context menu is intentionally not available so speed-labeling stays
       // fast. Users can still seed a detector via the dashboard.
       event.preventDefault();
-      this.vote.emit({ id: this.media.id, vote: 'good' });
+      this.vote.emit({ id: this.media().id, vote: 'good' });
       return;
     }
     event.preventDefault();
-    this.contextRequest.emit({ id: this.media.id, x: event.clientX, y: event.clientY });
+    this.contextRequest.emit({ id: this.media().id, x: event.clientX, y: event.clientY });
   }
 
   onMouseEnter(): void {
     if (this.focusMode() === 'hover') {
-      this.select.emit(this.media.id);
+      this.select.emit(this.media().id);
     }
   }
 }

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -63,7 +63,7 @@
       />
     }
 
-    @if (medias.length === 0) {
+    @if (medias().length === 0) {
       <div class="empty-list">No media loaded</div>
     }
   </div>

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { vi } from 'vitest';
-import { SimpleChange } from '@angular/core';
 
 import { MediaListComponent } from './media-list.component';
 import { Media } from '../../../models/api.models';
@@ -19,6 +18,16 @@ describe('MediaListComponent', () => {
     { id: 3, media_type: 'audio', filename: 'c.wav', md5: 'c3', custom_metadata: {} },
   ];
 
+  /** Spy on the (test-setup-stubbed) scrollIntoView so the selection
+   *  autoscroll — queued by the effect, performed in ngAfterViewChecked — is
+   *  observable. Cleared on install because the prototype spy persists across
+   *  tests in this file. */
+  function spyOnScrollIntoView() {
+    const spy = vi.spyOn(Element.prototype, 'scrollIntoView');
+    spy.mockClear();
+    return spy;
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MediaListComponent],
@@ -27,7 +36,7 @@ describe('MediaListComponent', () => {
 
     fixture = TestBed.createComponent(MediaListComponent);
     component = fixture.componentInstance;
-    component.medias = mockMedias;
+    fixture.componentRef.setInput('medias', mockMedias);
     TestBed.tick();
   });
 
@@ -44,16 +53,11 @@ describe('MediaListComponent', () => {
   });
 
   it('should render media items in sort order when provided', () => {
-    component.sortOrder = [
+    fixture.componentRef.setInput('sortOrder', [
       { id: 3, score: 0.9 },
       { id: 1, score: 0.5 },
       { id: 2, score: 0.2 },
-    ];
-    // Programmatic input assignment doesn't fire ngOnChanges; trigger the
-    // rebuild explicitly the way Angular would for a [sortOrder] binding.
-    component.ngOnChanges({
-      sortOrder: new SimpleChange(null, component.sortOrder, false),
-    });
+    ]);
     TestBed.tick();
     const items = component.cachedOrderedItems;
     expect(items[0].media.id).toBe(3);
@@ -62,16 +66,12 @@ describe('MediaListComponent', () => {
   });
 
   it('should insert threshold line at correct position', () => {
-    component.sortOrder = [
+    fixture.componentRef.setInput('sortOrder', [
       { id: 3, score: 0.9 },
       { id: 1, score: 0.5 },
       { id: 2, score: 0.2 },
-    ];
-    component.threshold = 0.4;
-    component.ngOnChanges({
-      sortOrder: new SimpleChange(null, component.sortOrder, false),
-      threshold: new SimpleChange(null, component.threshold, false),
-    });
+    ]);
+    fixture.componentRef.setInput('threshold', 0.4);
     TestBed.tick();
     const items = component.cachedOrderedItems;
     // Threshold is at 0.4, so item with score 0.2 should have showThreshold
@@ -81,8 +81,8 @@ describe('MediaListComponent', () => {
   });
 
   it('should return correct vote labels', () => {
-    component.goodVotes = new Set([1]);
-    component.badVotes = new Set([2]);
+    fixture.componentRef.setInput('goodVotes', new Set([1]));
+    fixture.componentRef.setInput('badVotes', new Set([2]));
     expect(component.getVoteLabel(1)).toBe('good');
     expect(component.getVoteLabel(2)).toBe('bad');
     expect(component.getVoteLabel(3)).toBeNull();
@@ -95,69 +95,70 @@ describe('MediaListComponent', () => {
   });
 
   it('should show empty message when no medias', () => {
-    // Drive the input through setInput so ngOnChanges rebuilds the ordered-items
-    // cache to empty (a direct field write leaves the cache stale, which under
-    // zoneless surfaces as an NG0100 during the verify pass) and the host view
-    // is marked dirty so the tick repaints.
     fixture.componentRef.setInput('medias', []);
     TestBed.tick();
     expect(fixture.nativeElement.querySelector('.empty-list')?.textContent).toContain('No media loaded');
   });
 
   it('should render threshold line in DOM', () => {
-    component.sortOrder = [
+    fixture.componentRef.setInput('sortOrder', [
       { id: 1, score: 0.8 },
       { id: 2, score: 0.3 },
-    ];
-    component.threshold = 0.5;
-    component.ngOnChanges({
-      sortOrder: new SimpleChange(null, component.sortOrder, false),
-      threshold: new SimpleChange(null, component.threshold, false),
-    });
+    ]);
+    fixture.componentRef.setInput('threshold', 0.5);
     TestBed.tick();
     expect(fixture.nativeElement.querySelector('.media-threshold-line')).toBeTruthy();
   });
 
-  it('queues an autoscroll when the selection changes in click mode', () => {
+  it('autoscrolls the newly-selected item into view in click mode', () => {
+    const scrollSpy = spyOnScrollIntoView();
     fixture.componentRef.setInput('focusMode', 'click');
     TestBed.tick();
-    component.ngOnChanges({ selectedId: new SimpleChange(null, 2, false) });
-    expect(component['pendingScrollToSelected']).toBe(true);
+    fixture.componentRef.setInput('selectedId', 2);
+    TestBed.tick();
+    expect(scrollSpy).toHaveBeenCalled();
   });
 
   // Regression: clicking a card in this grid selects an item that is, by
   // definition, already on screen. Autoscrolling it into view is jarring and
-  // pointless, so a selection that originated from onMediaSelect must not queue
-  // an autoscroll — even in click mode.
-  it('does not queue an autoscroll for a selection driven by clicking a card', () => {
+  // pointless, so a selection that originated from onMediaSelect must not
+  // trigger an autoscroll — even in click mode.
+  it('does not autoscroll for a selection driven by clicking a card', () => {
+    const scrollSpy = spyOnScrollIntoView();
     fixture.componentRef.setInput('focusMode', 'click');
     TestBed.tick();
     component.onMediaSelect(2);
-    component.ngOnChanges({ selectedId: new SimpleChange(null, 2, false) });
-    expect(component['pendingScrollToSelected']).toBe(false);
+    fixture.componentRef.setInput('selectedId', 2);
+    TestBed.tick();
+    expect(scrollSpy).not.toHaveBeenCalled();
   });
 
   // A click on card 2 must not suppress a *later* off-screen selection (e.g. a
-  // vote auto-advance to card 5): only the clicked id is exempt from autoscroll.
+  // vote auto-advance to card 3): only the clicked id is exempt from autoscroll.
   it('still autoscrolls a subsequent selection from elsewhere after a click', () => {
+    const scrollSpy = spyOnScrollIntoView();
     fixture.componentRef.setInput('focusMode', 'click');
     TestBed.tick();
     component.onMediaSelect(2);
-    component.ngOnChanges({ selectedId: new SimpleChange(null, 2, false) });
-    expect(component['pendingScrollToSelected']).toBe(false);
-    component.ngOnChanges({ selectedId: new SimpleChange(2, 5, false) });
-    expect(component['pendingScrollToSelected']).toBe(true);
+    fixture.componentRef.setInput('selectedId', 2);
+    TestBed.tick();
+    expect(scrollSpy).not.toHaveBeenCalled();
+    fixture.componentRef.setInput('selectedId', 3);
+    TestBed.tick();
+    expect(scrollSpy).toHaveBeenCalled();
   });
 
   // Regression: in hover mode the selection follows the cursor. Scrolling the
   // hovered item to the top shifts what's under the mouse, which re-selects and
-  // scrolls again — an infinite autoscroll loop. Hover selection must not queue
-  // an autoscroll.
-  it('does not queue an autoscroll on hover selection', () => {
+  // scrolls again — an infinite autoscroll loop. Hover selection must not
+  // trigger an autoscroll.
+  it('does not autoscroll on hover selection', () => {
+    const scrollSpy = spyOnScrollIntoView();
     fixture.componentRef.setInput('focusMode', 'hover');
     TestBed.tick();
-    component.ngOnChanges({ selectedId: new SimpleChange(null, 2, false) });
-    expect(component['pendingScrollToSelected']).toBe(false);
+    fixture.componentRef.setInput('selectedId', 2);
+    TestBed.tick();
+    expect(scrollSpy).not.toHaveBeenCalled();
   });
 
   // Regression: small datasets used to never prefetch metadata, so the list
@@ -167,10 +168,8 @@ describe('MediaListComponent', () => {
   it('eagerly prefetches metadata for every row when virtual scroll is off', () => {
     const cache = TestBed.inject(MediaMetadataCacheService);
     const spy = vi.spyOn(cache, 'ensureLoaded').mockImplementation(() => {});
-    component.medias = mockMedias;
-    component.ngOnChanges({
-      medias: { currentValue: mockMedias, previousValue: [], firstChange: false, isFirstChange: () => false },
-    });
+    fixture.componentRef.setInput('medias', [...mockMedias]);
+    TestBed.tick();
     expect(spy).toHaveBeenCalled();
     const ids = spy.mock.lastCall![0] as number[];
     expect(ids).toEqual([1, 2, 3]);
@@ -188,7 +187,7 @@ describe('MediaListComponent scroll-prefetch re-wiring', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(MediaListComponent);
     component = fixture.componentInstance;
-    component.medias = [];
+    fixture.componentRef.setInput('medias', []);
     TestBed.tick();
   });
 
@@ -197,6 +196,12 @@ describe('MediaListComponent scroll-prefetch re-wiring', () => {
       scrolledIndexChange: new Subject<number>(),
       elementRef: { nativeElement: document.createElement('div') },
     };
+  }
+
+  /** Replace the ``virtualViewport`` view-query signal with a stub returning
+   *  the given fake (the readonly field is a plain property at runtime). */
+  function setViewport(vp: unknown): void {
+    (component as never as { virtualViewport: unknown }).virtualViewport = () => vp;
   }
 
   it('re-subscribes prefetch when the viewport instance is recreated', () => {
@@ -209,7 +214,7 @@ describe('MediaListComponent scroll-prefetch re-wiring', () => {
       .mockImplementation(() => undefined);
 
     const vp1 = fakeViewport();
-    (component as never as { virtualViewport: unknown }).virtualViewport = vp1;
+    setViewport(vp1);
     component.ngAfterViewChecked();
     vp1.scrolledIndexChange.next(0);
     expect(prefetchSpy).toHaveBeenCalledTimes(1);
@@ -218,7 +223,7 @@ describe('MediaListComponent scroll-prefetch re-wiring', () => {
     // and a new instance appearing after the next dataset renders.
     vp1.scrolledIndexChange.complete();
     const vp2 = fakeViewport();
-    (component as never as { virtualViewport: unknown }).virtualViewport = vp2;
+    setViewport(vp2);
     component.ngAfterViewChecked();
 
     vp2.scrolledIndexChange.next(3);

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, ElementRef, inject, Input, input, NgZone, OnChanges, OnDestroy, OnInit, output, SimpleChanges, ViewChild } from '@angular/core';
+import { AfterViewChecked, ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, effect, ElementRef, inject, input, NgZone, OnDestroy, OnInit, output, untracked, viewChild } from '@angular/core';
 
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { Subject, Subscription } from 'rxjs';
@@ -53,18 +53,18 @@ type GridRow = { kind: 'items'; items: OrderedItem[] } | { kind: 'threshold' };
   templateUrl: './media-list.component.html',
   styleUrl: './media-list.component.scss',
 })
-export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, OnDestroy {
+export class MediaListComponent implements OnInit, AfterViewChecked, OnDestroy {
   private metadataCache = inject(MediaMetadataCacheService);
   private mediaState = inject(MediaStateService);
   private cdr = inject(ChangeDetectorRef);
   private zone = inject(NgZone);
 
-  @Input() medias: Media[] = [];
-  @Input() sortOrder: SortedItem[] | null = null;
-  @Input() threshold: number | null = null;
+  readonly medias = input<Media[]>([]);
+  readonly sortOrder = input<SortedItem[] | null>(null);
+  readonly threshold = input<number | null>(null);
   readonly selectedId = input<number | null>(null);
-  @Input() goodVotes: Set<number> = new Set();
-  @Input() badVotes: Set<number> = new Set();
+  readonly goodVotes = input<Set<number>>(new Set());
+  readonly badVotes = input<Set<number>>(new Set());
   readonly gridGoalWidth = input<number>(80);
   readonly focusMode = input<'click' | 'hover'>('click');
   readonly showScores = input(true);
@@ -79,8 +79,8 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     x: number;
     y: number;
 }>();
-  @ViewChild('listContainer') listContainer!: ElementRef<HTMLDivElement>;
-  @ViewChild(CdkVirtualScrollViewport) virtualViewport?: CdkVirtualScrollViewport;
+  readonly listContainer = viewChild<ElementRef<HTMLDivElement>>('listContainer');
+  readonly virtualViewport = viewChild(CdkVirtualScrollViewport);
 
   /** Cached ordered items, rebuilt only when inputs change, not on every CD cycle. */
   cachedOrderedItems: OrderedItem[] = [];
@@ -102,6 +102,10 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
    * autoscroll, since the target may be off-screen.
    */
   private clickSelectedId: number | null = null;
+  /** True once the selection effect has seen its initial ``selectedId``. */
+  private selectedIdSeen = false;
+  /** Previous ``gridGoalWidth`` value; ``null`` until the rebuild effect's first run. */
+  private prevGridGoalWidth: number | null = null;
   private readonly destroy$ = new Subject<void>();
   /** The viewport instance whose ``scrolledIndexChange`` is currently subscribed. */
   private scrollSubscribedViewport?: CdkVirtualScrollViewport;
@@ -118,6 +122,62 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   // zoneless (the old plain-field-written-from-an-effect path went stale).
   readonly loadingMedias = computed(() => this.mediaState.isLoading());
   readonly skeletonPlaceholders = Array.from({ length: 12 });
+
+  constructor() {
+    // Only autoscroll the newly-selected item into view in click mode. In hover
+    // mode the selection follows the cursor, so scrolling the item to the top
+    // would shift what's under the mouse, re-trigger selection, and scroll
+    // again — an infinite autoscroll loop. Let the hovered item stay put.
+    //
+    // And when the selection was driven by clicking a card in this grid, the
+    // item is already visible, so scrolling it into view is jarring and
+    // unnecessary — suppress the autoscroll for that id. Selections from
+    // elsewhere (keyboard, vote auto-advance, stripe overview) may target an
+    // off-screen item, so those still autoscroll.
+    //
+    // This effect tracks only ``selectedId``; the body runs untracked so a
+    // ``focusMode`` flip alone never queues a scroll. The queued flag is
+    // consumed by ``ngAfterViewChecked`` after the view has repainted with the
+    // new active item.
+    effect(() => {
+      const selectedId = this.selectedId();
+      untracked(() => {
+        if (!this.selectedIdSeen) {
+          this.selectedIdSeen = true;
+          return;
+        }
+        const clickedInThisGrid = selectedId === this.clickSelectedId;
+        this.clickSelectedId = null;
+        if (this.focusMode() === 'click' && !clickedInThisGrid) {
+          this.pendingScrollToSelected = true;
+        }
+      });
+    });
+
+    // Rebuild the ordered-items cache when (and only when) the inputs that
+    // shape it change. The dependencies are read explicitly up front and the
+    // work runs untracked, because ``rebuildOrderedItems`` also touches the
+    // ``virtualViewport`` view query (via prefetch) — tracking that would
+    // re-trigger a rebuild every time the ``@if`` branches swap the viewport
+    // instance. A ``gridGoalWidth`` change additionally invalidates the
+    // measured row stride and recomputes the column count *before* the rows
+    // are rebuilt, mirroring the old ``ngOnChanges`` order.
+    effect(() => {
+      const goalWidth = this.gridGoalWidth();
+      this.medias();
+      this.sortOrder();
+      this.threshold();
+      this.showScores();
+      untracked(() => {
+        if (this.prevGridGoalWidth !== null && goalWidth !== this.prevGridGoalWidth) {
+          this.gridHeightMeasured = false;
+          this.recomputeGridColumns();
+        }
+        this.prevGridGoalWidth = goalWidth;
+        this.rebuildOrderedItems();
+      });
+    });
+  }
 
   ngOnInit(): void {
     // When the cache hydrates new items, re-enrich the displayed rows so
@@ -146,63 +206,28 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     return this.cachedOrderedItems.length > GRID_VIRTUAL_THRESHOLD;
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    // Only autoscroll the newly-selected item into view in click mode. In hover
-    // mode the selection follows the cursor, so scrolling the item to the top
-    // would shift what's under the mouse, re-trigger selection, and scroll
-    // again — an infinite autoscroll loop. Let the hovered item stay put.
-    //
-    // And when the selection was driven by clicking a card in this grid, the
-    // item is already visible, so scrolling it into view is jarring and
-    // unnecessary — suppress the autoscroll for that id. Selections from
-    // elsewhere (keyboard, vote auto-advance, stripe overview) may target an
-    // off-screen item, so those still autoscroll.
-    if (changes['selectedId'] && !changes['selectedId'].firstChange) {
-      const clickedInThisGrid = changes['selectedId'].currentValue === this.clickSelectedId;
-      this.clickSelectedId = null;
-      if (this.focusMode() === 'click' && !clickedInThisGrid) {
-        this.pendingScrollToSelected = true;
-      }
-    }
-
-    // A wider/narrower goal width changes how many cards fit per grid row and
-    // the height of each card, so recompute columns and re-measure the stride.
-    if (changes['gridGoalWidth'] && !changes['gridGoalWidth'].firstChange) {
-      this.gridHeightMeasured = false;
-      this.recomputeGridColumns();
-    }
-
-    // Rebuild cache only when relevant inputs change.
-    if (
-      changes['medias'] ||
-      changes['sortOrder'] ||
-      changes['threshold'] ||
-      changes['showScores'] ||
-      changes['gridGoalWidth']
-    ) {
-      this.rebuildOrderedItems();
-    }
-  }
-
   private rebuildOrderedItems(): void {
-    // ``this.medias`` carries stubs (``{id, type, embedder?}``) from
+    // ``this.medias()`` carries stubs (``{id, type, embedder?}``) from
     // ``/api/medias/ids``.  Look up the cached full metadata for visible
     // rows; fall back to the stub so the row renders immediately and gets
     // upgraded once the batch fetch lands.
-    const stubMap = new Map(this.medias.map((m) => [m.id, m]));
+    const medias = this.medias();
+    const sortOrder = this.sortOrder();
+    const threshold = this.threshold();
+    const stubMap = new Map(medias.map((m) => [m.id, m]));
     const enrich = (id: number): Media | undefined =>
       this.metadataCache.get(id) ?? stubMap.get(id);
 
     const items: OrderedItem[] = [];
 
-    if (this.sortOrder && this.sortOrder.length > 0) {
+    if (sortOrder && sortOrder.length > 0) {
       let thresholdInserted = false;
-      for (const sorted of this.sortOrder) {
+      for (const sorted of sortOrder) {
         const media = enrich(sorted.id);
         if (!media) continue;
 
         let showThreshold = false;
-        if (!thresholdInserted && this.threshold !== null && sorted.score < this.threshold) {
+        if (!thresholdInserted && threshold !== null && sorted.score < threshold) {
           showThreshold = true;
           thresholdInserted = true;
         }
@@ -214,7 +239,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
         });
       }
     } else {
-      for (const stub of this.medias) {
+      for (const stub of medias) {
         const media = this.metadataCache.get(stub.id) ?? stub;
         items.push({ media, score: null, showThreshold: false });
       }
@@ -228,7 +253,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
 
     // `cachedOrderedItems`/`gridRows` are plain template-bound arrays; this
     // method runs from the async `metadataCache.version$` subscribe (an
-    // unpatched callback) as well as the sync `ngOnChanges` path, so notify the
+    // unpatched callback) as well as the input-driven effect, so notify the
     // scheduler explicitly to repaint the list under zoneless.
     this.cdr.markForCheck();
   }
@@ -266,7 +291,8 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
    * when the column count changed (so callers know to rebuild the rows).
    */
   private recomputeGridColumns(): boolean {
-    const el = this.virtualViewport?.elementRef.nativeElement ?? this.listContainer?.nativeElement;
+    const el =
+      this.virtualViewport()?.elementRef.nativeElement ?? this.listContainer()?.nativeElement;
     if (!el) return false;
     const inner = el.clientWidth - 2 * GRID_GAP_PX;
     if (inner <= 0) return false;
@@ -277,15 +303,15 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   }
 
   getVoteLabel(id: number): 'good' | 'bad' | null {
-    if (this.goodVotes.has(id)) return 'good';
-    if (this.badVotes.has(id)) return 'bad';
+    if (this.goodVotes().has(id)) return 'good';
+    if (this.badVotes().has(id)) return 'bad';
     return null;
   }
 
   onMediaSelect(id: number): void {
     // Remember that this selection came from a click on a visible card so the
     // resulting ``selectedId`` change doesn't autoscroll an already-on-screen
-    // item into view (see ``ngOnChanges``).
+    // item into view (see the selection effect in the constructor).
     this.clickSelectedId = id;
     this.mediaSelect.emit(id);
   }
@@ -299,11 +325,13 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
   }
 
   ngAfterViewChecked(): void {
+    const virtualViewport = this.virtualViewport();
+
     // Keep the grid viewport measured: a ResizeObserver tracks width (→ column
     // count) and the first rendered card's height (→ CDK row stride).  Tear it
     // down when we leave grid-virtual mode so the list viewport isn't probed
     // for grid cards that don't exist.
-    if (this.useGridVirtual && this.virtualViewport) {
+    if (this.useGridVirtual && virtualViewport) {
       this.setupGridViewport();
     } else if (this.observedViewportEl) {
       this.resizeObserver?.disconnect();
@@ -314,15 +342,15 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     if (this.pendingScrollToSelected) {
       this.pendingScrollToSelected = false;
       const behavior: ScrollBehavior = prefersReducedMotion() ? 'auto' : 'smooth';
-      if (this.useGridVirtual && this.virtualViewport) {
+      if (this.useGridVirtual && virtualViewport) {
         // In virtual-scroll mode, find the index and scroll to it.  Grid cards
         // are chunked into rows, so map the item index to its row first.
         const idx = this.cachedOrderedItems.findIndex((i) => i.media.id === this.selectedId());
         if (idx >= 0) {
-          this.virtualViewport.scrollToIndex(this.itemIndexToRow(idx), behavior);
+          virtualViewport.scrollToIndex(this.itemIndexToRow(idx), behavior);
         }
-      } else if (this.listContainer) {
-        const activeEl = this.listContainer.nativeElement.querySelector('.media-item.active');
+      } else if (this.listContainer()) {
+        const activeEl = this.listContainer()!.nativeElement.querySelector('.media-item.active');
         if (activeEl) {
           activeEl.scrollIntoView({ block: 'nearest', behavior });
         }
@@ -335,10 +363,10 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     // threshold), and a subscription left on the old instance's completed
     // stream never fires again — silently killing scroll-driven metadata
     // prefetch. Mirrors the `observedViewportEl` re-observe pattern above.
-    if (this.virtualViewport && this.scrollSubscribedViewport !== this.virtualViewport) {
-      this.scrollSubscribedViewport = this.virtualViewport;
+    if (virtualViewport && this.scrollSubscribedViewport !== virtualViewport) {
+      this.scrollSubscribedViewport = virtualViewport;
       this.scrollSub?.unsubscribe();
-      this.scrollSub = this.virtualViewport.scrolledIndexChange
+      this.scrollSub = virtualViewport.scrolledIndexChange
         .pipe(takeUntil(this.destroy$))
         .subscribe(() => this.prefetchVisibleMetadata());
     }
@@ -346,7 +374,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
 
   /** Observe the grid viewport for width/height changes (runs outside Angular). */
   private setupGridViewport(): void {
-    const vp = this.virtualViewport?.elementRef.nativeElement;
+    const vp = this.virtualViewport()?.elementRef.nativeElement;
     if (!vp || this.observedViewportEl === vp) {
       // Already observing the right element.  Re-measure only until the row
       // height has been captured from a real card, so the steady state doesn't
@@ -373,7 +401,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     let changed = this.recomputeGridColumns();
     if (changed) this.rebuildGridRows();
 
-    const vp = this.virtualViewport?.elementRef.nativeElement;
+    const vp = this.virtualViewport()?.elementRef.nativeElement;
     const card = vp?.querySelector('vt-media-item .media-item') as HTMLElement | null;
     if (card) {
       const measured = Math.round(card.getBoundingClientRect().height + GRID_GAP_PX);
@@ -414,8 +442,9 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
 
   scrollToIndex(index: number): void {
     const behavior: ScrollBehavior = prefersReducedMotion() ? 'auto' : 'smooth';
-    if (this.useGridVirtual && this.virtualViewport) {
-      this.virtualViewport.scrollToIndex(this.itemIndexToRow(index), behavior);
+    const virtualViewport = this.virtualViewport();
+    if (this.useGridVirtual && virtualViewport) {
+      virtualViewport.scrollToIndex(this.itemIndexToRow(index), behavior);
       // After scrolling, select the item at this index.
       const item = this.cachedOrderedItems[index];
       if (item) {
@@ -423,8 +452,9 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
       }
       return;
     }
-    if (!this.listContainer) return;
-    const container = this.listContainer.nativeElement;
+    const listContainer = this.listContainer();
+    if (!listContainer) return;
+    const container = listContainer.nativeElement;
     const items = container.querySelectorAll('vt-media-item');
     const target = items[index] as HTMLElement | undefined;
     if (!target) return;
@@ -464,17 +494,18 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnChanges, 
     const total = this.cachedOrderedItems.length;
     if (total === 0) return;
 
-    if (!this.useGridVirtual || !this.virtualViewport) {
+    const virtualViewport = this.virtualViewport();
+    if (!this.useGridVirtual || !virtualViewport) {
       const ids = this.cachedOrderedItems.map((item) => item.media.id);
       this.metadataCache.ensureLoaded(ids);
       return;
     }
 
-    const viewportEl = this.virtualViewport.elementRef.nativeElement;
+    const viewportEl = virtualViewport.elementRef.nativeElement;
     const viewportHeight = viewportEl.clientHeight || 600;
 
     // The virtualized units are rows of ``gridColumns`` cards.
-    const startRow = this.virtualViewport.measureScrollOffset('top') / this.gridRowHeight;
+    const startRow = virtualViewport.measureScrollOffset('top') / this.gridRowHeight;
     const visibleRows = Math.ceil(viewportHeight / this.gridRowHeight);
     const cols = Math.max(1, this.gridColumns);
     const bufferRows = Math.ceil(PREFETCH_BUFFER / cols);


### PR DESCRIPTION
Converts the left-panel list host and item components to signal-based authoring: all remaining decorator `@Input` properties become `input()`, `@ViewChild` queries become `viewChild()`, and every `ngOnChanges` body is reworked into reactive primitives. No decorator inputs or queries remain in the three components.

Closes #2548

## What changed

**`media-item`** — `media` (now `input.required`), `active`, `voteLabel`, `score` become signal inputs. The `ngOnChanges` that reset `thumbnailFailed` when the card is recycled for a different media is replaced by a `linkedSignal` keyed on `media().id`, which resets to `false` automatically on id change.

**`left-panel`** — `medias`, `sortBusy`, `autopilotEnabled`, `autopilotDisabled`, `datasetName` become signal inputs; the `MediaListComponent` view query becomes `viewChild()`. The `ngOnChanges`-driven recomputation of the grid-header label and the text-sort gate collapses into two `computed()`s (`mediaTypeName`, `textSortAvailable`) that track both the medias input and the async metadata signals, replacing the old writable signals + constructor effects + `updateX()` methods. `activeTab` becomes a signal so the autopilot-disabled fallback — now an `effect()` with a first-run guard mirroring the old `firstChange` check — repaints under zoneless when it forces the tab back to Manual.

**`media-list`** (the regression-prone one) — `medias`, `sortOrder`, `threshold`, `goodVotes`, `badVotes` become signal inputs; `listContainer` and the `CdkVirtualScrollViewport` query become `viewChild()`. The `ngOnChanges` body splits into two constructor effects:

- a **selection-autoscroll effect** tracking only `selectedId`, preserving the first-change skip, the hover-mode suppression, and the clicked-in-this-grid suppression (`focusMode` is read untracked so a focus-mode flip alone can never queue a scroll);
- a **rebuild effect** that reads `gridGoalWidth`/`medias`/`sortOrder`/`threshold`/`showScores` explicitly and runs the work untracked, so the `virtualViewport` view-query reads inside prefetch/measure logic don't retrigger rebuilds when the template's `@if` branches destroy/recreate the viewport. A `gridGoalWidth` change still invalidates the measured row stride and recomputes columns *before* rows are rebuilt, mirroring the old `ngOnChanges` order.

`ngAfterViewChecked` is intentionally unchanged: it still consumes the pending-scroll flag after the view repaints with the new active item, keeps the ResizeObserver measurement loop, and re-wires `scrolledIndexChange` when the viewport instance changes. The `markForCheck()` in `rebuildOrderedItems` stays because the rebuild is also invoked from the unpatched `metadataCache.version$` callback; the effect path no longer needs it.

**Specs** — direct property writes + manual `ngOnChanges(...)` calls become `fixture.componentRef.setInput(...)` + `TestBed.tick()`. The media-list autoscroll specs now observe the actual `scrollIntoView` call (via the test-setup stub on `Element.prototype`) instead of asserting the private pending flag, since the effect + `ngAfterViewChecked` pair queues and consumes it within a single tick. The viewport re-wiring spec stubs the view query with a function returning the fake viewport.

## Testing

- `./run-tests.sh frontend` — build OK (no warnings), audit OK, all 1684 Vitest tests pass.
- Full `./run-tests.sh` — all 6400 tests pass.
- **Not done:** the issue's manual smoke of long media lists (active-item auto-scroll, resort, scroll-position stability) — the cloud container has no browser. The autoscroll paths are covered by the reworked unit specs; a quick manual pass on a large dataset before relying on this in anger is still worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPBrN1mjLDtaERQtjJVahX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPBrN1mjLDtaERQtjJVahX)_