### PR TITLE
Stop toponymy signpost-naming warning flood on the console

### DIFF
--- a/tests_lib/projection/test_signpost_build.py
+++ b/tests_lib/projection/test_signpost_build.py
@@ -189,12 +189,12 @@ class TestKeyphraseNamerParsing:
         # The header layout Toponymy's `combined` disambiguation prompt uses:
         # bare `"N. name":` lines at column 0, keyword lines indented below.
         prompt = (
-            'You are an expert in images.\n\n'
+            "You are an expert in images.\n\n"
             '"1. man boy lily shirt":\n'
-            ' - Keywords for this group include: man, boy, lily, shirt\n'
+            " - Keywords for this group include: man, boy, lily, shirt\n"
             '"2. man boy jacket lily":\n'
-            ' - Keywords for this group include: man, boy, jacket, lily\n\n'
-            'The response should be formatted as JSON in the format\n'
+            " - Keywords for this group include: man, boy, jacket, lily\n\n"
+            "The response should be formatted as JSON in the format\n"
             '    {"new_topic_name_mapping": {<1. OLD_NAME1>: <NEW_NAME1>, ... }, ...}\n'
         )
         result = sb._keyphrase_disambiguation(prompt)
@@ -212,7 +212,7 @@ class TestKeyphraseNamerParsing:
         # continuing past the colon) must not be miscounted as a topic header.
         prompt = (
             '"1. only real topic":\n'
-            ' - Keywords for this group include: alpha, beta\n\n'
+            " - Keywords for this group include: alpha, beta\n\n"
             '    {"new_topic_name_mapping": {"1. OLD_NAME1": "NEW_NAME1"}, "topic_specificities": [0.5]}\n'
         )
         mapping = sb._keyphrase_disambiguation(prompt)["new_topic_name_mapping"]
@@ -225,9 +225,9 @@ class TestKeyphraseNamerParsing:
         old_names = ["man boy lily shirt", "man boy jacket lily"]
         prompt = (
             '"1. man boy lily shirt":\n'
-            ' - Keywords for this group include: man, boy\n'
+            " - Keywords for this group include: man, boy\n"
             '"2. man boy jacket lily":\n'
-            ' - Keywords for this group include: man, jacket\n'
+            " - Keywords for this group include: man, jacket\n"
         )
         mapping = sb._keyphrase_disambiguation(prompt)["new_topic_name_mapping"]
         assert len(mapping) == len(old_names)

--- a/tests_lib/projection/test_signpost_build.py
+++ b/tests_lib/projection/test_signpost_build.py
@@ -168,6 +168,75 @@ class TestScaling:
         assert sb._base_min_cluster_size(50_000) == 167
 
 
+class TestKeyphraseNamerParsing:
+    """The no-LLM namer's prompt parsing (issue #2558).
+
+    Exercised without importing toponymy — these are the module-level parse
+    helpers the ``KeyphraseNamer`` delegates to. The disambiguation test
+    reproduces the ``combined`` prompt layout the real library builds and the
+    contract its ``default_extract_topic_names`` enforces: exactly one mapping
+    entry per topic, keyed ``f"{i}. {name}"``.
+    """
+
+    def test_topic_name_uses_top_keyphrase(self):
+        prompt = "Here is the group.\n - Keywords for this group include: dog barking, puppy, howl\n"
+        assert sb._keyphrase_topic_name(prompt) == "dog barking"
+
+    def test_topic_name_defaults_when_no_keywords(self):
+        assert sb._keyphrase_topic_name("nothing useful here") == "unnamed"
+
+    def test_disambiguation_maps_every_topic(self):
+        # The header layout Toponymy's `combined` disambiguation prompt uses:
+        # bare `"N. name":` lines at column 0, keyword lines indented below.
+        prompt = (
+            'You are an expert in images.\n\n'
+            '"1. man boy lily shirt":\n'
+            ' - Keywords for this group include: man, boy, lily, shirt\n'
+            '"2. man boy jacket lily":\n'
+            ' - Keywords for this group include: man, boy, jacket, lily\n\n'
+            'The response should be formatted as JSON in the format\n'
+            '    {"new_topic_name_mapping": {<1. OLD_NAME1>: <NEW_NAME1>, ... }, ...}\n'
+        )
+        result = sb._keyphrase_disambiguation(prompt)
+        mapping = result["new_topic_name_mapping"]
+        # One entry per topic (the length Toponymy requires), keyed so the
+        # library's default_extract_topic_names maps each back to its topic.
+        assert mapping == {
+            "1. man boy lily shirt": "man boy lily shirt",
+            "2. man boy jacket lily": "man boy jacket lily",
+        }
+        assert result["topic_specificities"] == [0.5, 0.5]
+
+    def test_disambiguation_ignores_output_format_example(self):
+        # The JSON output-format example (indented, `<1. …>` placeholders,
+        # continuing past the colon) must not be miscounted as a topic header.
+        prompt = (
+            '"1. only real topic":\n'
+            ' - Keywords for this group include: alpha, beta\n\n'
+            '    {"new_topic_name_mapping": {"1. OLD_NAME1": "NEW_NAME1"}, "topic_specificities": [0.5]}\n'
+        )
+        mapping = sb._keyphrase_disambiguation(prompt)["new_topic_name_mapping"]
+        assert mapping == {"1. only real topic": "only real topic"}
+
+    def test_disambiguation_round_trips_through_library_extractor(self):
+        # Mirror toponymy.templates.default_extract_topic_names: given a mapping
+        # of the right length, it recovers one name per topic in order without
+        # raising. This is the exact contract issue #2558 was violating.
+        old_names = ["man boy lily shirt", "man boy jacket lily"]
+        prompt = (
+            '"1. man boy lily shirt":\n'
+            ' - Keywords for this group include: man, boy\n'
+            '"2. man boy jacket lily":\n'
+            ' - Keywords for this group include: man, jacket\n'
+        )
+        mapping = sb._keyphrase_disambiguation(prompt)["new_topic_name_mapping"]
+        assert len(mapping) == len(old_names)
+        recovered = []
+        for i, old in enumerate(old_names, start=1):
+            recovered.append(mapping.get(f"{i}. {old}", old))
+        assert recovered == old_names
+
+
 class TestAvailability:
     def test_availability_probe_does_not_import(self, monkeypatch):
         import importlib.util as util

--- a/vtscore/projection/signpost_build.py
+++ b/vtscore/projection/signpost_build.py
@@ -173,9 +173,7 @@ def _keyphrase_disambiguation(prompt: str) -> dict[str, Any]:
     back to the original topic) guarantees the one-per-topic count and lets
     the fix succeed on the first attempt, silently.
     """
-    mapping = {
-        f"{index}. {name}": name for index, name in _DISAMBIGUATION_HEADER_RE.findall(prompt)
-    }
+    mapping = {f"{index}. {name}": name for index, name in _DISAMBIGUATION_HEADER_RE.findall(prompt)}
     return {"new_topic_name_mapping": mapping, "topic_specificities": [0.5] * len(mapping)}
 
 

--- a/vtscore/projection/signpost_build.py
+++ b/vtscore/projection/signpost_build.py
@@ -142,6 +142,43 @@ class EmbedderTextEncoder:
         return np.stack(out) if out else np.empty((0, self._dim), dtype=np.float32)
 
 
+#: Matches one topic header in a Toponymy disambiguation prompt. The
+#: ``combined`` prompt format (the one a no-system-prompt namer gets) lists
+#: each colliding topic as a bare ``"N. topic name":`` line at column 0; the
+#: capture groups are the 1-based index and the topic name. Anchoring at line
+#: start (no leading ``\s*``) and requiring the line to *end* right after the
+#: ``":`` keeps the JSON output-format example (``{<1. OLD_NAME1>: …}``,
+#: indented and continuing past the colon) from being mistaken for a header.
+_DISAMBIGUATION_HEADER_RE = re.compile(r'^"(\d+)\.\s(.+?)":\s*$', re.MULTILINE)
+
+
+def _keyphrase_topic_name(prompt: str) -> str:
+    """The top keyphrase for a single-topic naming prompt (or ``"unnamed"``)."""
+    match = re.search(r"Keywords for this group include:\s*([^\n]+)", prompt)
+    name = match.group(1).split(",")[0].strip() if match else ""
+    return name or "unnamed"
+
+
+def _keyphrase_disambiguation(prompt: str) -> dict[str, Any]:
+    """Echo old names back for a duplicate-name disambiguation prompt.
+
+    A no-LLM namer cannot invent new distinctions, so every colliding topic
+    keeps the name Toponymy already gave it. The one thing that *must* be
+    right is the mapping's length: Toponymy's ``default_extract_topic_names``
+    raises ``ValueError`` unless the mapping has exactly one entry per topic,
+    and that exception drives three ``wait_random_exponential(4, 10)`` retries
+    per cluster before a ``UserWarning`` is emitted — the console flood and
+    multi-second-per-cluster stall of issue #2558. Parsing every
+    ``"N. name":`` header (keyed as ``f"{i}. {name}"`` so the library maps it
+    back to the original topic) guarantees the one-per-topic count and lets
+    the fix succeed on the first attempt, silently.
+    """
+    mapping = {
+        f"{index}. {name}": name for index, name in _DISAMBIGUATION_HEADER_RE.findall(prompt)
+    }
+    return {"new_topic_name_mapping": mapping, "topic_specificities": [0.5] * len(mapping)}
+
+
 def make_keyphrase_namer() -> Any:
     """The no-LLM namer: answer every naming prompt with the top keyphrase.
 
@@ -161,12 +198,8 @@ def make_keyphrase_namer() -> Any:
 
         def _respond(self, prompt: str) -> str:
             if "new_topic_name_mapping" in prompt:
-                names = re.findall(r"^\s*(\d+)\.\s*(.+?)\s*$", prompt, re.MULTILINE)
-                mapping = {f"{i}. {n}": n for i, n in names}
-                return json.dumps({"new_topic_name_mapping": mapping, "topic_specificities": [0.5] * len(mapping)})
-            match = re.search(r"Keywords for this group include:\s*([^\n]+)", prompt)
-            name = match.group(1).split(",")[0].strip() if match else ""
-            return json.dumps({"topic_name": name or "unnamed", "topic_specificity": 0.5})
+                return json.dumps(_keyphrase_disambiguation(prompt))
+            return json.dumps({"topic_name": _keyphrase_topic_name(prompt), "topic_specificity": 0.5})
 
         def _call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
             return self._respond(prompt)
@@ -208,6 +241,8 @@ def _fit_topic_layers(
     is our glue, everything inside (including the namer, so stubbed callers
     never import toponymy) is the library's responsibility.
     """
+    import warnings  # noqa: PLC0415
+
     from toponymy import Toponymy  # noqa: PLC0415
     from toponymy.clustering import ToponymyClusterer  # noqa: PLC0415
 
@@ -223,11 +258,19 @@ def _fit_topic_layers(
         corpus_description=corpus_description,
         show_progress_bars=False,
     )
-    model.fit(
-        texts,
-        embedding_vectors.astype(np.float32),
-        clusterable_vectors.astype(np.float32),
-    )
+    # Toponymy narrates naming hiccups through ``warnings.warn`` (naming
+    # fallbacks, disambiguation retries). The KeyphraseNamer above keeps those
+    # from firing, but the library is a moving target and its per-topic
+    # warnings would flood the CLI (issue #2558) if any slipped through; they
+    # are advisory noise we can't act on, so suppress toponymy-origin warnings
+    # for the duration of the fit (other libraries' warnings still surface).
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", module=r"toponymy(\..*)?")
+        model.fit(
+            texts,
+            embedding_vectors.astype(np.float32),
+            clusterable_vectors.astype(np.float32),
+        )
     return [
         (list(names), np.asarray(layer.cluster_labels))
         for names, layer in zip(model.topic_names_, model.cluster_layers_)


### PR DESCRIPTION
## Problem

Building VTSBrowse signposts spewed page after page of the same warning to the console (issue #2558):

```
.../toponymy/llm_wrappers.py:451: UserWarning: All retries exhausted for
generate_topic_cluster_names: ValueError: Failed to generate enough names
when fixing ['man boy lily shirt', 'man boy jacket lily']; got . Returning old names.
```

## Root cause

The no-LLM `KeyphraseNamer` mis-parsed Toponymy's duplicate-name **disambiguation** prompt. Its regex (`^\s*(\d+)\.\s*(.+?)\s*$`) expected bare `N. name` lines, but Toponymy's `combined` prompt (the format a no-system-prompt namer receives) lists each colliding topic as a `"N. name":` header. The regex matched nothing, so the namer returned an **empty** mapping.

Toponymy's `default_extract_topic_names` requires exactly one mapping entry per topic; a length mismatch raises `ValueError`, which drove **three `wait_random_exponential(4, 10)` retries per colliding cluster** before emitting the `UserWarning`. So every duplicate cluster cost both a console warning *and* a multi-second stall.

## Fix

- Parse the actual `"N. name":` headers so the echoed mapping has exactly one entry per topic, keyed `f"{i}. {name}"` so the library maps each back to its topic. The disambiguation now succeeds on the first attempt — no `ValueError`, no retries, no warning. (A no-LLM namer can't invent new distinctions, so it echoes the existing names; genuine sibling-dedup remains the deeper #2405 project.)
- Extracted the parse logic into module-level `_keyphrase_topic_name` / `_keyphrase_disambiguation` helpers so it's unit-testable without importing toponymy or compiling numba.
- Defense in depth: suppress any residual **toponymy-origin** warnings around `model.fit` (other libraries' warnings still surface), so a future library change can't reintroduce a console flood.

## Verification

- New library-tier unit tests cover the parse (correct per-topic count, echoed names, ignoring the JSON output-format example, and a round-trip mirroring `default_extract_topic_names`).
- Verified directly against the **real** toponymy `default_extract_topic_names`: the namer's output now yields the correct-length name list with no `ValueError`.
- The slow real-toponymy smoke test passes under `-W error::UserWarning`.
- Full `./run-tests.sh` suite green (6406 passed).

Closes #2558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G352QjdfecAT5xj7foQFUG)_