### PR TITLE
Migrate browse canvas cluster to signal viewChild/model/effect

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -1,4 +1,4 @@
-import { afterNextRender, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, ElementRef, HostListener, inject, Injector, input, OnChanges, OnDestroy, output, SimpleChanges, ViewChild } from '@angular/core';
+import { afterNextRender, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, ElementRef, HostListener, inject, Injector, input, OnDestroy, output, untracked, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { Subscription } from 'rxjs';
@@ -154,7 +154,7 @@ const PREVIEW_SIZE_STEPS = [120, 160, 208, 272, 352, 448, 560, 640, 720] as cons
   templateUrl: './browse-bin-popup.component.html',
   styleUrl: './browse-bin-popup.component.scss',
 })
-export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit, OnChanges, OnDestroy {
+export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   private host = inject<ElementRef<HTMLElement>>(ElementRef);
   private selection = inject(BrowseSelectionService);
   private metadataCache = inject(MediaMetadataCacheService);
@@ -195,10 +195,10 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
    *  the hover clears. */
   readonly nowPlaying = output<NowPlaying | null>();
 
-  @ViewChild('panel') private panelRef?: ElementRef<HTMLElement>;
-  @ViewChild('header') private headerRef?: ElementRef<HTMLElement>;
-  @ViewChild(CdkVirtualScrollViewport) private viewport?: CdkVirtualScrollViewport;
-  @ViewChild('audioEl') private audioRef?: ElementRef<HTMLAudioElement>;
+  private readonly panelRef = viewChild<ElementRef<HTMLElement>>('panel');
+  private readonly headerRef = viewChild<ElementRef<HTMLElement>>('header');
+  private readonly viewport = viewChild(CdkVirtualScrollViewport);
+  private readonly audioRef = viewChild<ElementRef<HTMLAudioElement>>('audioEl');
 
   /** Clamped on-screen position; starts at the anchor and is nudged inward. */
   left = 0;
@@ -275,10 +275,94 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   constructor() {
     // Keep the hover-to-hear preview element in step with the Browse toolbar's
     // volume slider mid-playback; ``onEntryEnter`` also seeds it when a clip
-    // starts.
+    // starts. Tracking the view query also re-seeds when the element mounts.
     effect(() => {
-      const el = this.audioRef?.nativeElement;
+      const el = this.audioRef()?.nativeElement;
       if (el) el.volume = this.volume();
+    });
+    // The input→state dispatch that used to live in ngOnChanges (signal inputs
+    // don't fire it). Each effect tracks exactly the inputs its old ngOnChanges
+    // arm keyed on, and runs its body untracked so incidental signal reads
+    // inside (mediaType in playAudio, settings-backed getters in place()) can't
+    // widen the triggers.
+    //
+    // A fresh bin (new member ids / representative): reset the popup's content.
+    effect(() => {
+      const memberIds = this.memberIds();
+      this.repId();
+      untracked(() => {
+        this.ids = memberIds ?? [];
+        this.stopAudio();
+        // Open on the bin's representative (the centroid whose thumbnail the user
+        // right-clicked) so the pane is never blank and the detail view starts on
+        // the same image — not the 1-D list's first item, which differs.
+        this.previewId = this.representativeId();
+        // Auto-play the representative's clip on open (audio) so the detail window
+        // is an "intense hover": opening it hears the rep, just like resting on the
+        // bin on the canvas. This is the only way to hear a singleton audio bin,
+        // whose member grid (and its hover-to-hear) is dropped (see previewOnly).
+        if (this.previewId != null) this.playAudio(this.previewId);
+        // A fresh bin is a fresh popup: forget any drag from the previous one so
+        // it re-anchors to the new summon point.
+        this.dragged = false;
+        this.rebuildRows();
+        // A fresh bin: scroll the list to the representative (centred) and prefetch
+        // the window around it. Deferred so the virtual viewport has the new rows
+        // (and, on first open, exists at all — it's created after this effect).
+        setTimeout(() => {
+          this.scrollToRep();
+          this.prefetchVisible();
+        });
+      });
+    });
+    // A new media type may carry a different remembered thumbnail size.
+    effect(() => {
+      this.mediaType();
+      untracked(() => this.applyViewPrefs());
+    });
+    // A genuine (re)summon — a fresh bin or a new anchor/region — re-seeds the
+    // position at the summon point (unless the user has dragged the popup),
+    // then re-clamps. A pure size change (the main-canvas thumbnail radius,
+    // the effect below) must NOT snap back to the cursor: it keeps the popup
+    // where it sits and only re-clamps it on-screen. Without this split, the
+    // first resize after opening would lurch the window from the cursor across
+    // to the clamped edge, because ``place`` was re-deriving the position from
+    // the raw summon point every time rather than from where the window had
+    // settled.
+    effect(() => {
+      const x = this.x();
+      const y = this.y();
+      this.bounds();
+      this.memberIds();
+      untracked(() => {
+        if (!this.dragged) {
+          this.left = x;
+          this.top = y;
+          // Hide the popup until it's re-clamped at the new anchor, so it doesn't
+          // flash at the raw summon point (which may be half off-screen) first.
+          this.placed = false;
+        }
+        // Measure + clamp after the new content lays out.
+        setTimeout(() => this.place());
+      });
+    });
+    // The main-canvas thumbnail radius resizes the preview pane; re-clamp the
+    // popup in place (no re-anchor — see above).
+    effect(() => {
+      this.hoverThumbRadius();
+      untracked(() => setTimeout(() => this.place()));
+    });
+    // (Re-)subscribe the member grid's scroll-driven prefetch whenever the
+    // virtual viewport instance changes — it lives behind the template's
+    // ``@if (!previewOnly)``, and the popup is reused across summons while
+    // open (right-clicking another bin only swaps inputs), so a singleton→
+    // multi transition creates a brand-new viewport. Tracking the view query
+    // re-runs this the moment that instance appears; a one-shot
+    // ``ngAfterViewInit`` wiring would strand it (mirrors media-list's
+    // viewport re-wire pattern).
+    effect(() => {
+      this.viewport();
+      untracked(() => this.ensureScrollSubscription());
     });
     // Re-read the popup's thumbnail size whenever settings change (this is how
     // the in-header size buttons take effect, and how a change on one popup
@@ -322,84 +406,26 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
     });
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['memberIds'] || changes['repId']) {
-      this.ids = this.memberIds() ?? [];
-      this.stopAudio();
-      // Open on the bin's representative (the centroid whose thumbnail the user
-      // right-clicked) so the pane is never blank and the detail view starts on
-      // the same image — not the 1-D list's first item, which differs.
-      this.previewId = this.representativeId();
-      // Auto-play the representative's clip on open (audio) so the detail window
-      // is an "intense hover": opening it hears the rep, just like resting on the
-      // bin on the canvas. This is the only way to hear a singleton audio bin,
-      // whose member grid (and its hover-to-hear) is dropped (see previewOnly).
-      if (this.previewId != null) this.playAudio(this.previewId);
-      // A fresh bin is a fresh popup: forget any drag from the previous one so
-      // it re-anchors to the new summon point.
-      this.dragged = false;
-      this.rebuildRows();
-      // A fresh bin: scroll the list to the representative (centred) and prefetch
-      // the window around it. Deferred so the virtual viewport has the new rows
-      // (and, on first open, exists at all — it's created after ngOnChanges).
-      setTimeout(() => {
-        this.scrollToRep();
-        this.prefetchVisible();
-      });
-    }
-    if (changes['mediaType']) {
-      // A new media type may carry a different remembered thumbnail size.
-      this.applyViewPrefs();
-    }
-    // A genuine (re)summon — a fresh bin or a new anchor/region — re-seeds the
-    // position at the summon point (unless the user has dragged the popup). A
-    // pure size change (the main-canvas thumbnail radius) must NOT snap back to
-    // the cursor: it keeps the popup where it sits and only re-clamps it
-    // on-screen. Without this, the first resize after opening lurches the window
-    // from the cursor across to the clamped edge, because ``place`` was
-    // re-deriving the position from the raw summon point every time rather than
-    // from where the window had settled.
-    const resummoned = changes['x'] || changes['y'] || changes['bounds'] || changes['memberIds'];
-    if (resummoned || changes['hoverThumbRadius']) {
-      if (resummoned && !this.dragged) {
-        this.left = this.x();
-        this.top = this.y();
-        // Hide the popup until it's re-clamped at the new anchor, so it doesn't
-        // flash at the raw summon point (which may be half off-screen) first.
-        this.placed = false;
-      }
-      // Measure + clamp after the new content lays out.
-      setTimeout(() => this.place());
-    }
-  }
-
   ngAfterViewInit(): void {
     this.subs.push(
       // Names/thumbnails arrive asynchronously; repaint the visible rows.
       this.metadataCache.version$.subscribe(() => this.cdr.markForCheck()),
     );
     this.settingsState.load();
-    this.ensureScrollSubscription();
     this.prefetchVisible();
     setTimeout(() => this.place());
   }
 
-  ngAfterViewChecked(): void {
-    this.ensureScrollSubscription();
-  }
-
   /**
-   * (Re-)subscribe the member grid's scroll-driven thumbnail prefetch,
-   * keyed to the viewport *instance*.  The viewport lives behind the
-   * template's ``@if (!previewOnly)``, and the popup is reused across
-   * summons while open (right-clicking another bin only swaps inputs), so
-   * a singleton→multi transition creates a brand-new viewport whose stream
-   * the one-shot ``ngAfterViewInit`` wiring never subscribed — leaving
-   * everything beyond the initially-prefetched window as ``□`` placeholders
-   * with no recovery.  Mirrors media-list's viewport re-wire pattern.
+   * (Re-)subscribe the member grid's scroll-driven thumbnail prefetch, keyed
+   * to the viewport *instance*. Driven by the constructor effect tracking the
+   * ``viewport`` view query, so a singleton→multi transition (which creates a
+   * brand-new viewport behind ``@if (!previewOnly)``) re-wires immediately —
+   * a one-shot subscription would leave everything beyond the
+   * initially-prefetched window as ``□`` placeholders with no recovery.
    */
   private ensureScrollSubscription(): void {
-    const vp = this.viewport ?? null;
+    const vp = this.viewport() ?? null;
     if (!vp || this.scrollSubscribedViewport === vp) return;
     this.scrollSubscribedViewport = vp;
     this.scrollSub?.unsubscribe();
@@ -548,7 +574,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
       // being viewed (the representative until the user hovers/arrows elsewhere)
       // so it stays in view across the size change, then clamp.
       setTimeout(() => {
-        this.viewport?.checkViewportSize();
+        this.viewport()?.checkViewportSize();
         this.centreRowFor(this.focusIndex());
         this.place();
       });
@@ -590,7 +616,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
    *  didn't take, retry on the next frame (bounded) until the viewport is
    *  scrollable and the target sticks. */
   private centreRowFor(index: number, attempt = 0): void {
-    const vp = this.viewport;
+    const vp = this.viewport();
     if (!vp) return;
     const row = Math.floor(index / Math.max(1, this.columns));
     const viewportH = vp.elementRef.nativeElement.clientHeight || this.gridHeight;
@@ -847,7 +873,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
    * from fighting {@link scrollRowIntoView}, which already positioned the row.
    */
   private focusEntry(index: number, attempt = 0): void {
-    const panel = this.panelRef?.nativeElement;
+    const panel = this.panelRef()?.nativeElement;
     const id = this.ids[index];
     if (!panel || id == null) return;
     requestAnimationFrame(() => {
@@ -876,7 +902,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   /** Scroll the grid the minimum amount so the row holding ``index`` is fully
    *  visible (no-op when it already is). */
   private scrollRowIntoView(index: number): void {
-    const vp = this.viewport;
+    const vp = this.viewport();
     if (!vp) return;
     const row = Math.floor(index / Math.max(1, this.columns));
     const rowTop = row * this.rowSize;
@@ -1034,7 +1060,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
     // ``playing``/``canplay`` event clears it.
     this.nowPlaying.emit({ mediaId: id, waveUrl: this.thumbnailUrl(id), loading: true });
     setTimeout(() => {
-      const el = this.audioRef?.nativeElement;
+      const el = this.audioRef()?.nativeElement;
       if (!el) return;
       this.attachBufferingListeners(el);
       el.volume = this.volume();
@@ -1079,7 +1105,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
 
   private stopAudio(): void {
     const wasPlaying = this.audioSrc !== '';
-    const el = this.audioRef?.nativeElement;
+    const el = this.audioRef()?.nativeElement;
     if (el) {
       clearClipWindow(el);
       el.pause();
@@ -1150,7 +1176,8 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
 
   /** Re-clamp the popup to stay fully on-screen, anchored at its *current*
    *  position. The summon point seeds {@link left}/{@link top} once, when the
-   *  popup opens (and on a genuine re-summon — see {@link ngOnChanges}); from
+   *  popup opens (and on a genuine re-summon — see the constructor's summon
+   *  effect); from
    *  then on every re-clamp (size changes, the settings-driven detail-image
    *  resize, region changes) keeps the popup where it sits rather than snapping
    *  back to the cursor. The computed clamp derives the popup size from known
@@ -1161,7 +1188,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
     // Before the panel exists there's nothing to measure/clamp; a later place()
     // call (e.g. from ngAfterViewInit) will run once it's in the DOM. Staying
     // unplaced keeps the popup hidden until then rather than showing it unclamped.
-    if (!this.panelRef?.nativeElement) return;
+    if (!this.panelRef()?.nativeElement) return;
     this.clampInto(this.left, this.top);
     // Flush the freshly-clamped position and the size caps clampInto just set
     // (bodyCapPx/previewCapPx/maxWidthPx) to the DOM. This runs in a bare
@@ -1198,7 +1225,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
    *  image's bottom with it) on-screen. Purely corrective: a no-op when the
    *  computed clamp already fits. */
   private nudgeOnScreen(): void {
-    const panel = this.panelRef?.nativeElement;
+    const panel = this.panelRef()?.nativeElement;
     if (!panel) return;
     const rect = panel.getBoundingClientRect();
     const b = this.bounds();
@@ -1267,7 +1294,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
    *  settled. When the region is too short to hold the full popup, the body is
    *  capped (and scrolls internally) so the popup still fits top-to-bottom. */
   private clampInto(desiredLeft: number, desiredTop: number): void {
-    const panel = this.panelRef?.nativeElement;
+    const panel = this.panelRef()?.nativeElement;
     if (!panel) return;
     const b = this.bounds();
     // Visible region = canvas rect clipped to the viewport. Clipping to the
@@ -1279,7 +1306,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
     const regionBottom = Math.min(b ? b.bottom : window.innerHeight, window.innerHeight);
     // The header is always rendered (not virtualized), so its height is reliable
     // immediately; fall back to a sane default before the view exists.
-    const headerH = this.headerRef?.nativeElement.getBoundingClientRect().height ?? 37;
+    const headerH = this.headerRef()?.nativeElement.getBoundingClientRect().height ?? 37;
     // Squeeze the scrolling body to whatever vertical room the region leaves, so
     // a short canvas can't make the popup taller than what's visible. The caps
     // below bound the body *content* height ({@link bodyHeight}), so the room they
@@ -1338,7 +1365,7 @@ export class BrowseBinPopupComponent implements AfterViewChecked, AfterViewInit,
   private prefetchVisible(): void {
     if (this.ids.length === 0) return;
     const cols = this.columns;
-    const vp = this.viewport;
+    const vp = this.viewport();
     if (!vp) {
       const window = Math.ceil(MAX_BODY_PX / this.rowSize) * cols + PREFETCH_BUFFER;
       this.metadataCache.ensureLoaded(this.ids.slice(0, window));

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -323,20 +323,25 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
 
 describe('BrowseBinPopupComponent (scroll-prefetch re-wiring)', () => {
   it('re-subscribes prefetch when the member-grid viewport is recreated', () => {
-    // Regression: the popup subscribed scrolledIndexChange only in
-    // ngAfterViewInit, but the viewport lives behind @if (!previewOnly) and
-    // the popup is reused across summons (right-clicking another bin only
-    // swaps inputs). A singleton→multi transition created a fresh viewport
-    // whose stream was never subscribed, so scrolling the member grid never
-    // hydrated thumbnails beyond the initially-prefetched window.
+    // Regression: the popup subscribed scrolledIndexChange only once, but the
+    // viewport lives behind @if (!previewOnly) and the popup is reused across
+    // summons (right-clicking another bin only swaps inputs). A singleton→multi
+    // transition created a fresh viewport whose stream was never subscribed, so
+    // scrolling the member grid never hydrated thumbnails beyond the
+    // initially-prefetched window. In production a constructor effect tracking
+    // the `viewport` view-query signal re-runs ensureScrollSubscription
+    // whenever the instance changes; here the query is stubbed as a plain
+    // function and the method driven directly, since the virtualized grid
+    // doesn't render reliably under jsdom.
     const component = Object.create(
       BrowseBinPopupComponent.prototype,
     ) as BrowseBinPopupComponent;
     const state = component as unknown as {
-      viewport?: unknown;
+      viewport: () => unknown;
       scrollSub: unknown;
       scrollSubscribedViewport: unknown;
       prefetchVisible(): void;
+      ensureScrollSubscription(): void;
     };
     state.scrollSub = null;
     state.scrollSubscribedViewport = null;
@@ -344,21 +349,21 @@ describe('BrowseBinPopupComponent (scroll-prefetch re-wiring)', () => {
     state.prefetchVisible = prefetchSpy;
 
     const vp1 = { scrolledIndexChange: new Subject<number>() };
-    state.viewport = vp1;
-    component.ngAfterViewChecked();
+    state.viewport = () => vp1;
+    state.ensureScrollSubscription();
     vp1.scrolledIndexChange.next(0);
     const callsAfterFirstScroll = prefetchSpy.mock.calls.length;
     expect(callsAfterFirstScroll).toBeGreaterThan(0);
 
     // Viewport destroyed (previewOnly summon) …
     vp1.scrolledIndexChange.complete();
-    state.viewport = undefined;
-    component.ngAfterViewChecked();
+    state.viewport = () => undefined;
+    state.ensureScrollSubscription();
 
     // … then a new multi-member summon creates a fresh instance.
     const vp2 = { scrolledIndexChange: new Subject<number>() };
-    state.viewport = vp2;
-    component.ngAfterViewChecked();
+    state.viewport = () => vp2;
+    state.ensureScrollSubscription();
 
     const callsBeforeSecondScroll = prefetchSpy.mock.calls.length;
     vp2.scrolledIndexChange.next(2);
@@ -387,7 +392,8 @@ describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
     columns: number;
     previewId: number | null;
     cdr: { markForCheck: () => void };
-    panelRef?: { nativeElement: { querySelector: (sel: string) => HTMLElement | null } };
+    // The `panelRef` view query is a signal; stub it as a plain function.
+    panelRef?: () => { nativeElement: { querySelector: (sel: string) => HTMLElement | null } };
     mediaType: () => string;
     mediaTypeCaps: { usesThumbnails: (t: string) => boolean };
     scrollRowIntoView: (index: number) => void;
@@ -424,12 +430,12 @@ describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
   it('moves DOM focus to the arrow-walked entry', () => {
     const { component, state } = makeGridComponent();
     const walked = { focus: vi.fn() } as unknown as HTMLElement;
-    state.panelRef = {
+    state.panelRef = () => ({
       nativeElement: {
         // Only the entry for id 20 (the ArrowRight target from index 0) exists.
         querySelector: (sel: string) => (sel.includes('"20"') ? walked : null),
       },
-    };
+    });
 
     state.moveFocus(1, 0);
 
@@ -443,7 +449,7 @@ describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
     const { state } = makeGridComponent();
     const walked = { focus: vi.fn() } as unknown as HTMLElement;
     let calls = 0;
-    state.panelRef = {
+    state.panelRef = () => ({
       nativeElement: {
         // Absent for the first two frames (row still virtualizing in), then in.
         querySelector: (sel: string) => {
@@ -451,7 +457,7 @@ describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
           return ++calls >= 3 ? walked : null;
         },
       },
-    };
+    });
 
     state.moveFocus(1, 0);
 

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, NgZone, OnChanges, OnDestroy, OnInit, output, SimpleChanges, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, NgZone, OnDestroy, output, untracked, viewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -79,7 +79,7 @@ const HOVER_RADIUS_SCALE = 1.38;
   templateUrl: './browse-canvas.component.html',
   styleUrl: './browse-canvas.component.scss',
 })
-export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
+export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
   private ngZone = inject(NgZone);
   private tileCache = inject(TileCacheService);
   private activeContext = inject(ActiveContextService);
@@ -87,7 +87,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
   private selection = inject(BrowseSelectionService);
   private mediaTypeCaps = inject(MediaTypeCapabilityService);
 
-  @ViewChild('canvas', { static: true }) canvasRef!: ElementRef<HTMLCanvasElement>;
+  private readonly canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
   readonly meta = input<ProjectionMeta | null>(null);
   /**
    * Active dataset media type. For thumbnail types (``usesThumbnails`` —
@@ -495,6 +495,71 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.requestRedraw();
   });
 
+  // The input→redraw dispatch that used to live in ngOnChanges (signal inputs
+  // don't fire it). Each effect tracks exactly the inputs its old ngOnChanges
+  // arm keyed on and runs the body untracked, so incidental signal reads inside
+  // (selection state, meta re-reads, service calls) can't widen its triggers.
+
+  /** Fresh meta re-bins (new projection, bin-shape toggle, cull). */
+  private readonly metaChanged = effect(() => {
+    const meta = this.meta();
+    if (!meta) return;
+    untracked(() => {
+      // Any zoom transition was easing the *old* data, so abandon it; the
+      // redraw below paints the new state. A boundary settle would spring
+      // toward the old bounds, so stop it too — as would a directional glide.
+      this.cancelZoomAnim();
+      this.cancelSettle();
+      this.cancelPanAnim();
+      this.tileCache.setProjectionId(meta.projection_id);
+      // A bin-shape toggle delivers fresh meta for the *same* projection id
+      // (hex and square share one UMAP layout). In that case keep the current
+      // pan/zoom and just re-bin visually; only a genuinely new projection
+      // re-frames to data and drops stale representative thumbnails.
+      if (meta.projection_id !== this.lastProjectionId) {
+        this.lastProjectionId = meta.projection_id;
+        // A brand-new projection opens auto-fit: clear the user-framed flag so a
+        // saved cell size applied right after load re-fits to keep it all in view.
+        this.framedByUser = false;
+        this.thumbCache.clear();
+        this.thumbFailed.clear();
+        this.tintedThumbCache.clear();
+        // A new projection (media-type switch / rebuild) re-lays-out every item,
+        // so the old selection no longer maps to what's on screen — drop it. A
+        // bin-shape toggle keeps the same projection id and selection, since the
+        // ids are shape-independent. A Re-project of the items already on screen
+        // arms the survive mark instead: the ids are unchanged (only positions
+        // move), so the id-based selection stays coherent and is kept.
+        if (!this.selection.consumeSurviveProjectionChange()) {
+          this.selection.clear();
+        }
+        this.fitToData();
+      } else {
+        this.updateActiveLevel();
+      }
+      this.requestRedraw();
+    });
+  });
+
+  /** Entering region-select mode: drop any hover preview/highlight that was
+   *  showing, since hover is suppressed while the mode is on. */
+  private readonly marqueeModeChanged = effect(() => {
+    if (this.marqueeMode()) untracked(() => this.clearHover());
+  });
+
+  /** Repaint-only inputs: a colormap change only affects flat (non-thumbnail)
+   *  shading; the pile-thumbnail border only changes how thumbnail cells are
+   *  stroked; labels arriving (they load async, after the tiles) or the
+   *  signpost layer toggling only changes the sign overlay. A coalesced repaint
+   *  picks any of them up without re-binning or re-fetching tiles. */
+  private readonly repaintInputsChanged = effect(() => {
+    this.colormap();
+    this.thumbnailBorder();
+    this.labels();
+    this.signposts();
+    untracked(() => this.requestRedraw());
+  });
+
   /** True when cells should be painted with the central item's thumbnail. */
   private get thumbnailMode(): boolean {
     return this.mediaTypeCaps.usesThumbnails(this.mediaType());
@@ -534,8 +599,8 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     return this.transform.zoom;
   }
 
-  ngOnInit(): void {
-    this.ctx = this.canvasRef.nativeElement.getContext('2d')!;
+  ngAfterViewInit(): void {
+    this.ctx = this.canvasRef().nativeElement.getContext('2d')!;
 
     this.tileLoadSub = this.tileCache.tileLoaded$.subscribe(() => {
       this.requestRedraw();
@@ -559,7 +624,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.resizeObserver = new ResizeObserver(() => {
       this.ngZone.runOutsideAngular(() => this.resize());
     });
-    this.resizeObserver.observe(this.canvasRef.nativeElement.parentElement!);
+    this.resizeObserver.observe(this.canvasRef().nativeElement.parentElement!);
 
     // A pure devicePixelRatio change (monitor-to-monitor drag, browser zoom, OS
     // scaling) doesn't touch the element box, so the ResizeObserver stays quiet;
@@ -582,7 +647,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     });
 
     this.ngZone.runOutsideAngular(() => {
-      const el = this.canvasRef.nativeElement;
+      const el = this.canvasRef().nativeElement;
       el.addEventListener('mousedown', this.boundMouseDown);
       el.addEventListener('wheel', this.boundWheel, { passive: false });
       el.addEventListener('mousemove', this.boundCanvasMouseMove);
@@ -590,68 +655,6 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       el.addEventListener('dblclick', this.boundDblClick);
       el.addEventListener('contextmenu', this.boundContextMenu);
     });
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    const meta = this.meta();
-    if (changes['meta'] && meta) {
-      // Fresh meta re-bins (new projection, bin-shape toggle, cull). Any zoom
-      // transition was easing the *old* data, so abandon it; the redraw below
-      // paints the new state. A boundary settle would spring toward the old
-      // bounds, so stop it too — as would a directional pan glide.
-      this.cancelZoomAnim();
-      this.cancelSettle();
-      this.cancelPanAnim();
-      this.tileCache.setProjectionId(meta.projection_id);
-      // A bin-shape toggle delivers fresh meta for the *same* projection id
-      // (hex and square share one UMAP layout). In that case keep the current
-      // pan/zoom and just re-bin visually; only a genuinely new projection
-      // re-frames to data and drops stale representative thumbnails.
-      if (meta.projection_id !== this.lastProjectionId) {
-        this.lastProjectionId = meta.projection_id;
-        // A brand-new projection opens auto-fit: clear the user-framed flag so a
-        // saved cell size applied right after load re-fits to keep it all in view.
-        this.framedByUser = false;
-        this.thumbCache.clear();
-        this.thumbFailed.clear();
-        this.tintedThumbCache.clear();
-        // A new projection (media-type switch / rebuild) re-lays-out every item,
-        // so the old selection no longer maps to what's on screen — drop it. A
-        // bin-shape toggle keeps the same projection id and selection, since the
-        // ids are shape-independent. A Re-project of the items already on screen
-        // arms the survive mark instead: the ids are unchanged (only positions
-        // move), so the id-based selection stays coherent and is kept.
-        if (!this.selection.consumeSurviveProjectionChange()) {
-          this.selection.clear();
-        }
-        this.fitToData();
-      } else {
-        this.updateActiveLevel();
-      }
-      this.requestRedraw();
-    }
-    // Entering region-select mode: drop any hover preview/highlight that was
-    // showing, since hover is suppressed while the mode is on.
-    if (changes['marqueeMode'] && this.marqueeMode()) {
-      this.clearHover();
-    }
-    // A colormap change only affects flat (non-thumbnail) shading; repaint.
-    if (changes['colormap'] && !changes['colormap'].firstChange) {
-      this.requestRedraw();
-    }
-    // The pile-thumbnail border width only changes how thumbnail cells are
-    // stroked; a repaint picks it up without re-binning or re-fetching tiles.
-    if (changes['thumbnailBorder'] && !changes['thumbnailBorder'].firstChange) {
-      this.requestRedraw();
-    }
-    // Labels arriving (they load async, after the tiles) or the signpost layer
-    // toggling only changes the sign overlay; a repaint picks either up.
-    if (
-      (changes['labels'] && !changes['labels'].firstChange) ||
-      (changes['signposts'] && !changes['signposts'].firstChange)
-    ) {
-      this.requestRedraw();
-    }
   }
 
   ngOnDestroy(): void {
@@ -674,13 +677,18 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       else if (typeof cancelIdleCallback === 'function') cancelIdleCallback(this.thumbPrefetchHandle);
     }
     if (this.firstViewTimer !== null) clearTimeout(this.firstViewTimer);
-    const el = this.canvasRef.nativeElement;
-    el.removeEventListener('mousedown', this.boundMouseDown);
-    el.removeEventListener('wheel', this.boundWheel);
-    el.removeEventListener('mousemove', this.boundCanvasMouseMove);
-    el.removeEventListener('mouseleave', this.boundCanvasMouseLeave);
-    el.removeEventListener('dblclick', this.boundDblClick);
-    el.removeEventListener('contextmenu', this.boundContextMenu);
+    // `ctx` is only assigned in ngAfterViewInit — the same place the canvas
+    // listeners are attached — so it doubles as "the view query resolved" and
+    // keeps a destroy-before-render from reading the required query.
+    if (this.ctx) {
+      const el = this.canvasRef().nativeElement;
+      el.removeEventListener('mousedown', this.boundMouseDown);
+      el.removeEventListener('wheel', this.boundWheel);
+      el.removeEventListener('mousemove', this.boundCanvasMouseMove);
+      el.removeEventListener('mouseleave', this.boundCanvasMouseLeave);
+      el.removeEventListener('dblclick', this.boundDblClick);
+      el.removeEventListener('contextmenu', this.boundContextMenu);
+    }
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
     this.thumbCache.clear();
@@ -696,12 +704,12 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     this.cancelZoomAnim();
     this.cancelSettle();
     this.cancelPanAnim();
-    const el = this.canvasRef.nativeElement.parentElement!;
+    const el = this.canvasRef().nativeElement.parentElement!;
     const rect = el.getBoundingClientRect();
     this.dpr = window.devicePixelRatio || 1;
     this.width = rect.width;
     this.height = rect.height;
-    const canvas = this.canvasRef.nativeElement;
+    const canvas = this.canvasRef().nativeElement;
     canvas.width = this.width * this.dpr;
     canvas.height = this.height * this.dpr;
     canvas.style.width = `${this.width}px`;
@@ -914,7 +922,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    * tracks the live interpolated transform, so the hand-off is seamless).
    */
   private startZoomAnim(): void {
-    const canvasEl = this.canvasRef.nativeElement;
+    const canvasEl = this.canvasRef().nativeElement;
     this.animFrom = { ...this.displayedTransform };
     this.animTo = { ...this.transform };
 
@@ -2236,7 +2244,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
    *  so it never fires while browsing bin popups. */
   private onContextMenu(event: MouseEvent): void {
     event.preventDefault();
-    const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+    const rect = this.canvasRef().nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
     // Target the bin the cursor is already hovering first, falling back to a
@@ -2297,7 +2305,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
 
   /** Canvas-relative ``[x, y]`` for a mouse event. */
   private canvasXY(event: MouseEvent): [number, number] {
-    const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+    const rect = this.canvasRef().nativeElement.getBoundingClientRect();
     return [event.clientX - rect.left, event.clientY - rect.top];
   }
 
@@ -2417,7 +2425,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
       return;
     }
 
-    const canvasEl = this.canvasRef.nativeElement;
+    const canvasEl = this.canvasRef().nativeElement;
     // Freeze from the frame on screen now (mid-glide that's the interpolated
     // centre, so a burst of presses chains seamlessly) and ease to `target`.
     this.panAnimFrom = { ...this.transform };
@@ -2666,7 +2674,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // still down) keeps the in-progress gesture coherent; the wheel resumes the
     // instant the drag ends.
     if (this.isPanning || this.isMarquee) return;
-    const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+    const rect = this.canvasRef().nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
     const wheelFactor = this.wheelZoomFactor();
@@ -2679,7 +2687,7 @@ export class BrowseCanvasComponent implements OnInit, OnChanges, OnDestroy {
     // region-select mode: the cursor is a crosshair for drawing a box, so a
     // hover preview/highlight popping up under it would just be noise.
     if (this.isPanning || this.isMarquee || this.marqueeMode()) return;
-    const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+    const rect = this.canvasRef().nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
     this.lastMouseX = mx;

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, OnChanges, OnDestroy, output, signal, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, output, signal, untracked } from '@angular/core';
 
 import { ActiveContextService } from '../../services/active-context.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
@@ -45,7 +45,7 @@ const AUDIO_DWELL_MS = 200;
   templateUrl: './browse-hover-preview.component.html',
   styleUrl: './browse-hover-preview.component.scss',
 })
-export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
+export class BrowseHoverPreviewComponent implements OnDestroy {
   private activeContext = inject(ActiveContextService);
   private metadataCache = inject(MediaMetadataCacheService);
 
@@ -65,6 +65,14 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   private nowPlayingWaveUrl = '';
 
   constructor() {
+    // The hover input drives the whole preview: show over a cell, hide on
+    // null. (The old ngOnChanges arm — signal inputs don't fire it.) The body
+    // runs untracked so its mediaType/metadata reads don't widen the trigger
+    // beyond the hover itself.
+    effect(() => {
+      const hover = this.hover();
+      untracked(() => (hover ? this.show(hover) : this.hide()));
+    });
     // Keep the live element's volume in sync when the toolbar slider moves
     // mid-playback; starting a clip also seeds it.
     effect(() => {
@@ -93,17 +101,6 @@ export class BrowseHoverPreviewComponent implements OnChanges, OnDestroy {
   private dwellTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingMediaId: number | null = null;
   private playingMediaId: number | null = null;
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['hover']) {
-      const hover = this.hover();
-      if (hover) {
-        this.show(hover);
-      } else {
-        this.hide();
-      }
-    }
-  }
 
   ngOnDestroy(): void {
     this.cancelDwell();

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.html
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.html
@@ -2,7 +2,7 @@
 @if (meta()?.point_count; as count) {
   <span class="minimap-count">{{ count | number }} {{ countNoun() }}</span>
 }
-@if (!dock) {
+@if (!dock()) {
   <button
     type="button"
     class="minimap-close"

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, ElementRef, HostBinding, inject, Input, input, NgZone, OnChanges, OnDestroy, OnInit, output, SimpleChanges, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, model, NgZone, OnDestroy, output, untracked, viewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { BrowseViewportService, ViewportBounds } from '../../services/browse-viewport.service';
@@ -39,10 +39,11 @@ export const MINIMAP_MAX_HEIGHT = 450;
   selector: 'vt-browse-minimap',
   standalone: true,
   imports: [IconComponent, DecimalPipe],
+  host: { '[class.dock]': 'dock()' },
   templateUrl: './browse-minimap.component.html',
   styleUrl: './browse-minimap.component.scss',
 })
-export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
+export class BrowseMinimapComponent implements AfterViewInit, OnDestroy {
   private ngZone = inject(NgZone);
   private tileCache = inject(TileCacheService);
   private viewport = inject(BrowseViewportService);
@@ -59,10 +60,13 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     this.requestRedraw();
   });
 
-  @ViewChild('canvas', { static: true }) canvasRef!: ElementRef<HTMLCanvasElement>;
+  private readonly canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
   readonly meta = input<ProjectionMeta | null>(null);
-  @Input() width = 200;
-  @Input() height = 150;
+  /** Rendered size (CSS px). Models rather than plain inputs because the
+   *  minimap writes them back itself: dock mode tracks its container's box and
+   *  the floating corner handle resizes by drag. */
+  readonly width = model(200);
+  readonly height = model(150);
   /** Density colormap preset; mirrors the main canvas so the overview matches. */
   readonly colormap = input<BrowseColormapId>('auto');
   /**
@@ -75,9 +79,43 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
    * meta-row) and sizes its canvas to fit via a {@link ResizeObserver},
    * rather than floating over the canvas at an explicit size. In this mode
    * the close button and corner resize handle are hidden — the panel owns
-   * the geometry — but click/drag-to-navigate stays live.
+   * the geometry — but click/drag-to-navigate stays live. Mirrored onto the
+   * host's ``dock`` class via the component's ``host`` binding.
    */
-  @Input() @HostBinding('class.dock') dock = false;
+  readonly dock = input(false);
+
+  // The input→resize/redraw dispatch that used to live in ngOnChanges (signal
+  // inputs don't fire it). Bodies run untracked so incidental reads can't
+  // widen the triggers; work needing the 2D context waits for ngAfterViewInit
+  // (which does the initial sizing/paint itself, as ngOnInit used to).
+
+  /** A size change (parent binding, dock observer, or the corner drag — the
+   *  models funnel all three here) rebuilds the canvas backing store. */
+  private readonly sizeChanged = effect(() => {
+    this.width();
+    this.height();
+    if (!this.ctx) return;
+    untracked(() => {
+      this.resizeCanvas();
+      this.requestRedraw();
+    });
+  });
+
+  /** Fresh meta: request the overview level's tiles and repaint. */
+  private readonly metaChanged = effect(() => {
+    this.meta();
+    if (!this.ctx) return;
+    untracked(() => {
+      this.requestOverviewTiles();
+      this.requestRedraw();
+    });
+  });
+
+  /** A colormap change only recolours the heatmap; repaint. */
+  private readonly colormapChanged = effect(() => {
+    this.colormap();
+    untracked(() => this.requestRedraw());
+  });
   /** Hide request from the close button (floating mode only). */
   readonly closed = output<void>();
   /** Final size after a resize drag, for persistence (floating mode only). */
@@ -117,9 +155,9 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
   private boundNavMove = this.onNavMove.bind(this);
   private boundNavUp = this.onNavUp.bind(this);
 
-  ngOnInit(): void {
-    this.ctx = this.canvasRef.nativeElement.getContext('2d')!;
-    if (this.dock) this.startDockSizing();
+  ngAfterViewInit(): void {
+    this.ctx = this.canvasRef().nativeElement.getContext('2d')!;
+    if (this.dock()) this.startDockSizing();
     this.resizeCanvas();
 
     // A pure devicePixelRatio change doesn't resize the element, so re-run the
@@ -149,21 +187,6 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     this.requestRedraw();
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (!this.ctx) return;
-    if (changes['width'] || changes['height']) {
-      this.resizeCanvas();
-      this.requestRedraw();
-    }
-    if (changes['meta'] && !changes['meta'].firstChange) {
-      this.requestOverviewTiles();
-      this.requestRedraw();
-    }
-    if (changes['colormap'] && !changes['colormap'].firstChange) {
-      this.requestRedraw();
-    }
-  }
-
   ngOnDestroy(): void {
     this.tileLoadSub?.unsubscribe();
     this.viewportSub?.unsubscribe();
@@ -178,8 +201,8 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
   /**
    * Docked mode: track the host element's box and resize the canvas to fill
    * it, so the overview grows/shrinks with the side panel's divider drag. The
-   * observer fires outside Angular, so the resize never triggers change
-   * detection — only a canvas repaint.
+   * observer fires outside Angular; writing the size models triggers the
+   * {@link sizeChanged} effect, which rebuilds the backing store and repaints.
    */
   private startDockSizing(): void {
     const el = this.host.nativeElement;
@@ -187,14 +210,13 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
       this.resizeObserver = new ResizeObserver(() => {
         const w = Math.max(MINIMAP_MIN_WIDTH, Math.round(el.clientWidth));
         const h = Math.max(MINIMAP_MIN_HEIGHT, Math.round(el.clientHeight));
-        if (w === this.width && h === this.height) return;
-        this.width = w;
-        this.height = h;
-        this.resizeCanvas();
+        if (w === this.width() && h === this.height()) return;
+        this.width.set(w);
+        this.height.set(h);
         // A large size change can shift the overview pyramid level, so make
-        // sure the tiles for the new level are requested before repainting.
+        // sure the tiles for the new level are requested before the repaint
+        // the size effect schedules.
         this.requestOverviewTiles();
-        this.requestRedraw();
       });
       this.resizeObserver.observe(el);
     });
@@ -202,11 +224,11 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
 
   private resizeCanvas(): void {
     this.dpr = window.devicePixelRatio || 1;
-    const canvas = this.canvasRef.nativeElement;
-    canvas.width = Math.round(this.width * this.dpr);
-    canvas.height = Math.round(this.height * this.dpr);
-    canvas.style.width = `${this.width}px`;
-    canvas.style.height = `${this.height}px`;
+    const canvas = this.canvasRef().nativeElement;
+    canvas.width = Math.round(this.width() * this.dpr);
+    canvas.height = Math.round(this.height() * this.dpr);
+    canvas.style.width = `${this.width()}px`;
+    canvas.style.height = `${this.height()}px`;
     this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
   }
 
@@ -295,8 +317,8 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     const dataW = xmax - xmin || 1;
     const dataH = ymax - ymin || 1;
     const margin = 4;
-    const availW = this.width - margin * 2;
-    const availH = this.height - margin * 2;
+    const availW = this.width() - margin * 2;
+    const availH = this.height() - margin * 2;
     let scale = Math.min(availW / dataW, availH / dataH);
     for (let i = 0; i < 3; i++) {
       const level = this.overviewLevel({ scale });
@@ -307,19 +329,19 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private projToMap(px: number, py: number, f: { scale: number; cx: number; cy: number }): [number, number] {
-    return [this.width / 2 + (px - f.cx) * f.scale, this.height / 2 + (py - f.cy) * f.scale];
+    return [this.width() / 2 + (px - f.cx) * f.scale, this.height() / 2 + (py - f.cy) * f.scale];
   }
 
   private mapToProj(mx: number, my: number, f: { scale: number; cx: number; cy: number }): [number, number] {
-    return [f.cx + (mx - this.width / 2) / f.scale, f.cy + (my - this.height / 2) / f.scale];
+    return [f.cx + (mx - this.width() / 2) / f.scale, f.cy + (my - this.height() / 2) / f.scale];
   }
 
   private draw(): void {
     const ctx = this.ctx;
     if (!ctx) return;
-    ctx.clearRect(0, 0, this.width, this.height);
+    ctx.clearRect(0, 0, this.width(), this.height());
     ctx.fillStyle = this.themeColor('--bg-body');
-    ctx.fillRect(0, 0, this.width, this.height);
+    ctx.fillRect(0, 0, this.width(), this.height());
 
     const f = this.fit();
     if (f) {
@@ -371,7 +393,7 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     // Frame the minimap so it reads as a distinct panel over the canvas.
     ctx.strokeStyle = this.themeColor('--border');
     ctx.lineWidth = 1;
-    ctx.strokeRect(0.5, 0.5, this.width - 1, this.height - 1);
+    ctx.strokeRect(0.5, 0.5, this.width() - 1, this.height() - 1);
   }
 
   /** Pull all cached cells of the overview *level* covering the extent. */
@@ -467,12 +489,12 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
   private recenterFromEvent(event: MouseEvent): void {
     const f = this.fit();
     if (!f) return;
-    const rect = this.canvasRef.nativeElement.getBoundingClientRect();
+    const rect = this.canvasRef().nativeElement.getBoundingClientRect();
     // Scale the cursor offset by the rendered-size ratio so the math stays
     // correct even if the canvas element is ever rendered at a size other
     // than this.width/height (e.g. under a CSS transform).
-    const mx = (event.clientX - rect.left) * (this.width / (rect.width || 1));
-    const my = (event.clientY - rect.top) * (this.height / (rect.height || 1));
+    const mx = (event.clientX - rect.left) * (this.width() / (rect.width || 1));
+    const my = (event.clientY - rect.top) * (this.height() / (rect.height || 1));
     const [px, py] = this.mapToProj(mx, my, f);
     this.viewport.requestRecenter(px, py);
   }
@@ -491,8 +513,8 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
     this.resizing = true;
     this.resizeStartX = event.clientX;
     this.resizeStartY = event.clientY;
-    this.resizeStartW = this.width;
-    this.resizeStartH = this.height;
+    this.resizeStartW = this.width();
+    this.resizeStartH = this.height();
     document.addEventListener('mousemove', this.boundResizeMove);
     document.addEventListener('mouseup', this.boundResizeUp);
   }
@@ -500,23 +522,24 @@ export class BrowseMinimapComponent implements OnInit, OnChanges, OnDestroy {
   private onResizeMove(event: MouseEvent): void {
     if (!this.resizing) return;
     // Anchored bottom-right: dragging the top-left handle up/left grows it.
+    // The model writes drive the resize/repaint via the size effect.
     const dw = this.resizeStartX - event.clientX;
     const dh = this.resizeStartY - event.clientY;
-    this.width = Math.round(
-      Math.max(MINIMAP_MIN_WIDTH, Math.min(MINIMAP_MAX_WIDTH, this.resizeStartW + dw)),
+    this.width.set(
+      Math.round(Math.max(MINIMAP_MIN_WIDTH, Math.min(MINIMAP_MAX_WIDTH, this.resizeStartW + dw))),
     );
-    this.height = Math.round(
-      Math.max(MINIMAP_MIN_HEIGHT, Math.min(MINIMAP_MAX_HEIGHT, this.resizeStartH + dh)),
+    this.height.set(
+      Math.round(
+        Math.max(MINIMAP_MIN_HEIGHT, Math.min(MINIMAP_MAX_HEIGHT, this.resizeStartH + dh)),
+      ),
     );
-    this.resizeCanvas();
-    this.requestRedraw();
   }
 
   private onResizeUp(): void {
     if (!this.resizing) return;
     this.resizing = false;
     this.detachResizeListeners();
-    this.resized.emit({ width: this.width, height: this.height });
+    this.resized.emit({ width: this.width(), height: this.height() });
   }
 
   private detachResizeListeners(): void {

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, ElementRef, HostListener, inject, NgZone, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, ElementRef, HostListener, inject, NgZone, OnDestroy, OnInit, signal, untracked, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -82,10 +82,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private mediaTypeCaps = inject(MediaTypeCapabilityService);
   private ngZone = inject(NgZone);
 
-  @ViewChild(BrowseCanvasComponent) private canvas?: BrowseCanvasComponent;
+  private readonly canvas = viewChild(BrowseCanvasComponent);
   /** The 3-column grid (canvas | divider | side panel); the divider drag
    *  measures against its box. Only present in the ``ready`` state. */
-  @ViewChild('content') private content?: ElementRef<HTMLElement>;
+  private readonly content = viewChild<ElementRef<HTMLElement>>('content');
 
   readonly meta = signal<ProjectionMeta | null>(null);
   // Written from raw/async callbacks (dataset-status subscribe, projection
@@ -507,7 +507,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     );
     if (next === this.hexScaleIndex()) return;
     this.hexScaleIndex.set(next);
-    this.canvas?.setThumbnailRadius(this.thumbnailRadius, true);
+    this.canvas()?.setThumbnailRadius(this.thumbnailRadius, true);
     this.persistBrowsePref('browse_icon_size', BrowseViewComponent.ICON_SIZES[next]);
   }
 
@@ -543,8 +543,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.hexScaleIndex.set(sizeIdx >= 0 ? sizeIdx : 2);
     // Seed the saved size as the overview granularity (no reframe): a settings
     // change re-bins at the current framing rather than zooming the viewport,
-    // and on first load the initial fit picks the matching level.
-    this.canvas?.setThumbnailRadius(this.thumbnailRadius, false);
+    // and on first load the initial fit picks the matching level. The query is
+    // read untracked: this runs inside the constructor's settings effect, and
+    // tracking it there would re-run that effect on every canvas mount/unmount,
+    // which the decorator @ViewChild it replaces never did.
+    untracked(this.canvas)?.setThumbnailRadius(this.thumbnailRadius, false);
 
     const borderMap = s.browse_thumbnail_border as { [key: string]: number } | undefined;
     const rawBorder = mt && borderMap ? borderMap[mt] : undefined;
@@ -594,7 +597,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   /** Largest the side panel can grow to while leaving the canvas its minimum. */
   private panelMax(): number {
-    const layoutWidth = this.content?.nativeElement.getBoundingClientRect().width ?? 0;
+    const layoutWidth = this.content()?.nativeElement.getBoundingClientRect().width ?? 0;
     const fit = layoutWidth - BrowseViewComponent.DIVIDER_WIDTH - BrowseViewComponent.CANVAS_MIN;
     return Math.min(BrowseViewComponent.PANEL_MAX, Math.max(this.panelMin(), fit));
   }
@@ -611,7 +614,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * before the content has laid out.
    */
   private panelMin(): number {
-    const root = this.content?.nativeElement;
+    // Untracked: reachable from the constructor's settings effect, which must
+    // not pick up the view query as a dependency (see setThumbnailRadius above).
+    const root = untracked(this.content)?.nativeElement;
     if (!root) return BrowseViewComponent.PANEL_FLOOR;
     const current = this.panelWidth();
 
@@ -659,8 +664,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   }
 
   private onPanelMouseMove(event: MouseEvent): void {
-    if (!this.dragging || !this.content) return;
-    const rect = this.content.nativeElement.getBoundingClientRect();
+    const content = this.content();
+    if (!this.dragging || !content) return;
+    const rect = content.nativeElement.getBoundingClientRect();
     // The panel is on the right, so its width grows as the cursor moves left.
     const fit = rect.width - BrowseViewComponent.DIVIDER_WIDTH - BrowseViewComponent.CANVAS_MIN;
     const max = Math.min(BrowseViewComponent.PANEL_MAX, Math.max(this.dragMin, fit));
@@ -680,7 +686,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     // The snap only ever shrinks toward the current columns — it can't pop the
     // panel back out wider — and the dynamic floor keeps at least one column and
     // the sort control on screen.
-    const side = this.content?.nativeElement.querySelector('.browse-side') as HTMLElement | null;
+    const side = this.content()?.nativeElement.querySelector('.browse-side') as HTMLElement | null;
     const snapped = side ? snapPanelWidthToGridColumns(side, this.panelWidth()) : null;
     if (snapped !== null) {
       this.panelWidth.set(this.clamp(snapped, this.panelMin(), this.panelMax()));
@@ -760,7 +766,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     // Ctrl/Cmd-A: fully select every bin whose silhouette sits entirely in view.
     if ((event.ctrlKey || event.metaKey) && !event.altKey && (event.key === 'a' || event.key === 'A')) {
       event.preventDefault();
-      this.canvas?.selectAllInView();
+      this.canvas()?.selectAllInView();
       return;
     }
     // The remaining shortcuts take no modifiers.
@@ -769,19 +775,19 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     switch (event.key) {
       case 'ArrowUp':
         event.preventDefault();
-        this.canvas?.panByKey(0, -1);
+        this.canvas()?.panByKey(0, -1);
         break;
       case 'ArrowDown':
         event.preventDefault();
-        this.canvas?.panByKey(0, 1);
+        this.canvas()?.panByKey(0, 1);
         break;
       case 'ArrowLeft':
         event.preventDefault();
-        this.canvas?.panByKey(-1, 0);
+        this.canvas()?.panByKey(-1, 0);
         break;
       case 'ArrowRight':
         event.preventDefault();
-        this.canvas?.panByKey(1, 0);
+        this.canvas()?.panByKey(1, 0);
         break;
       case '+':
       case '=':
@@ -798,17 +804,17 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   /** Zoom in one step (narrower span, cells keep their display size). */
   zoomIn(): void {
-    this.canvas?.zoomBy(this.zoomButtonFactor);
+    this.canvas()?.zoomBy(this.zoomButtonFactor);
   }
 
   /** Zoom out one step. */
   zoomOut(): void {
-    this.canvas?.zoomBy(1 / this.zoomButtonFactor);
+    this.canvas()?.zoomBy(1 / this.zoomButtonFactor);
   }
 
   /** Choose a zoom and pan so the current data just fits in view. */
   zoomToFit(): void {
-    this.canvas?.zoomToFit();
+    this.canvas()?.zoomToFit();
   }
 
   // --- Preview-audio volume (audio datasets only) -------------------------
@@ -872,7 +878,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.contextMenuOpen = false;
     // Release the canvas's pinned enlarge so live hover resumes on the bin now
     // under the cursor.
-    this.canvas?.unpinCell();
+    this.canvas()?.unpinCell();
   }
 
   /**
@@ -978,7 +984,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * this is the mouse equivalent of the ctrl-A shortcut.
    */
   onSelectAllInView(): void {
-    this.canvas?.selectAllInView();
+    this.canvas()?.selectAllInView();
   }
 
   onVerify(target: 'good' | 'bad'): void {


### PR DESCRIPTION
Converts the five VTSBrowse canvas components to signal-based authoring. No decorator inputs or queries remain in the cluster, and all `ngOnChanges` dispatch now runs via `effect()`s that track exactly the inputs the old arms keyed on (bodies run `untracked` so incidental signal reads — selection state, `mediaType` inside `playAudio`, settings-backed getters inside `place()` — can't widen the triggers).

## What changed

- **browse-canvas** — the `static: true` canvas query becomes `viewChild.required`, resolved in `ngAfterViewInit` (was `ngOnInit`); the `meta` / `marqueeMode` / repaint-only (`colormap`, `thumbnailBorder`, `labels`, `signposts`) `ngOnChanges` arms become three effects with the same semantics, ordered so meta processing (fit, level selection, cache drops) lands before the repaint requests. `ResizeObserver`, DPR listener, theme observer, and listener teardown are intact; teardown guards the required query behind `ctx` so a destroy-before-render can't throw.
- **browse-bin-popup** — the four view queries (`panel`, `header`, virtual-scroll viewport, `audioEl`) become `viewChild()` signals. The `ngOnChanges` logic splits into four effects: bin identity (memberIds/repId), mediaType→view prefs, re-summon (x/y/bounds/memberIds re-anchors + re-places), and `hoverThumbRadius` (re-places **without** re-anchoring, preserving the no-lurch-on-resize behavior). The `ngAfterViewChecked` viewport-rewire poll is replaced by an effect tracking the viewport query, keeping the singleton→multi re-subscription regression covered.
- **browse-minimap** — `width`/`height` become `model()` (the component writes them back from dock sizing and the corner-drag resize), `dock` becomes `input()` with a `host` class binding replacing `@HostBinding`; all three resize paths funnel through a single size effect.
- **browse-hover-preview** — the hover show/hide arm becomes a constructor effect.
- **browse-view** — the two `@ViewChild`s become `viewChild()` signals. Reads reachable from the constructor's settings effect (`setThumbnailRadius` seeding, `panelMin`) stay `untracked` so the effect's dependency set is identical to the decorator era.

Specs: the bin-popup prototype-based suites stub the view queries as functions and drive `ensureScrollSubscription` directly (the effect wiring replaces `ngAfterViewChecked`); everything else passes unchanged.

## Verification

- `./run-tests.sh` — all 6401 tests pass (frontend build, audit, 1684 Vitest tests included), on the branch rebased onto latest `dev`.
- **Interactive smoke of the live app** (headless chromium driving `python app.py --local` with the screenshot harness's `syn-imgs` fixture): first-view reveal cover lifts (meta effect → tiles → thumbnails → `firstViewReady`), hover enlarges a bin, right-click opens the bin popup which reveals at its clamped spot and dismisses on Escape, marquee selects 44 items, button zoom / wheel zoom / arrow-key glide / drag pan / minimap recenter all repaint, window resize rebuilds the canvas backing store — with zero console or page errors.

No visual or behavioral change is intended, so no screenshot reshoots are queued.

Closes #2550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TX5LBiGZsExhzbsqDmoNp

---
_Generated by [Claude Code](https://claude.ai/code/session_018TX5LBiGZsExhzbsqDmoNp)_