### PR TITLE
Signal migration: center-panel media viewers (audio/video/image/text/document + center-panel)

### DIFF
--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
@@ -13,7 +13,7 @@
   controls
   controlsList="nodownload"
   loop
-  [attr.aria-label]="media.filename || 'Audio media'"
+  [attr.aria-label]="media().filename || 'Audio media'"
   (loadedmetadata)="onLoadedMetadata()"
   (timeupdate)="onTimeUpdate()"
   (volumechange)="onVolumeChange()"

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -1,4 +1,3 @@
-import { ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AudioPlayerComponent } from './audio-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -59,33 +58,18 @@ describe('AudioPlayerComponent', () => {
   });
 
   it('downloads the audio once and drives the <audio> element from an object URL', async () => {
-    const fakeAudio = {
-      src: '',
-      volume: 0,
-      paused: true,
-      play: () => Promise.resolve(),
-      pause: () => {},
-      load: () => {},
-      removeAttribute: () => {},
-    } as unknown as HTMLAudioElement;
-    // A canvas whose 2D context is unavailable, so the waveform path (which
-    // needs decodeAudioData, absent in jsdom) short-circuits after the src is set.
-    const fakeCanvas = {
-      getContext: () => null,
-      getBoundingClientRect: () => ({ width: 0 }) as DOMRect,
-      width: 600,
-      height: 120,
-    } as unknown as HTMLCanvasElement;
-    component.media = mockMedia;
-    component.audioRef = { nativeElement: fakeAudio } as ElementRef<HTMLAudioElement>;
-    component.canvasRef = { nativeElement: fakeCanvas } as ElementRef<HTMLCanvasElement>;
+    // The media-change effect fires loadAudio() once the view query resolves;
+    // drive it through the real channel (setInput + render), then drain the
+    // async fetch → blob → object-URL chain.
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
+    await settleZoneless(fixture);
 
-    await (component as unknown as { loadAudio(): Promise<void> }).loadAudio();
-
+    const audio: HTMLAudioElement = fixture.nativeElement.querySelector('audio');
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     expect(globalThis.fetch).toHaveBeenCalledWith('/api/medias/1/audio', expect.anything());
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
-    expect(fakeAudio.src).toBe('blob:mock-url');
+    expect(audio.src).toBe('blob:mock-url');
     expect(component.audioSrc).toBe('blob:mock-url');
   });
 
@@ -104,40 +88,33 @@ describe('AudioPlayerComponent', () => {
     expect(audio.hasAttribute('loop')).toBe(true);
   });
 
-  it('seeks into the clip window when clip extents arrive after the audio loaded', () => {
+  it('seeks into the clip window when clip extents arrive after the audio loaded', async () => {
     // Mirrors the video player: a windowed archive-member clip first renders as
     // a stub (no clip_start/clip_end), so (loadedmetadata) fires before the
     // extents are known. Batch hydration then enriches the same media id with
-    // clip_start/clip_end on a later ngOnChanges; the player must snap into the
-    // window (display-only seek; the whole member is served).
-    const fakeAudio = {
-      volume: 0,
-      currentTime: 0,
-      paused: true,
-      play: () => Promise.resolve(),
-      pause: () => {},
-      removeAttribute: () => {},
-      load: () => {},
-    } as unknown as HTMLAudioElement;
-    component.audioRef = { nativeElement: fakeAudio } as ElementRef<HTMLAudioElement>;
-
+    // clip_start/clip_end on a later change of the `media` input; the player
+    // must snap into the window (display-only seek; the whole member is served).
     const stub: Media = { id: 9, media_type: 'audio', filename: 'clip.aac', md5: 'abc', custom_metadata: {} };
-    component.media = stub;
-    component.ngOnChanges({
-      media: { currentValue: stub, previousValue: null, firstChange: true, isFirstChange: () => true },
+    fixture.componentRef.setInput('media', stub);
+    await settleZoneless(fixture);
+
+    // jsdom has no media pipeline; give the real element a working currentTime.
+    const audio: HTMLAudioElement = fixture.nativeElement.querySelector('audio');
+    let currentTime = 0;
+    Object.defineProperty(audio, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (v: number) => (currentTime = v),
     });
+
     // Audio loads against the stub: no clip window yet, so no seek.
     component.onLoadedMetadata();
-    expect(fakeAudio.currentTime).toBe(0);
+    expect(audio.currentTime).toBe(0);
 
     // Batch hydration delivers the clip extents for the same id.
     const hydrated: Media = { ...stub, clip_start: 12, clip_end: 22 };
-    component.media = hydrated;
-    component.ngOnChanges({
-      media: { currentValue: hydrated, previousValue: stub, firstChange: false, isFirstChange: () => false },
-    });
-    expect(fakeAudio.currentTime).toBe(12);
-
-    component.ngOnDestroy();
+    fixture.componentRef.setInput('media', hydrated);
+    await settleZoneless(fixture);
+    expect(audio.currentTime).toBe(12);
   });
 });

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, inject, Input, input, OnChanges, OnDestroy, output, SimpleChanges, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, linkedSignal, OnDestroy, output, untracked, viewChild } from '@angular/core';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { decodeAudioBuffer } from '../../../utils/decode-audio';
@@ -68,17 +68,25 @@ function computePeaks(channelData: Float32Array, width: number): WaveformPeaks {
   templateUrl: './audio-player.component.html',
   styleUrl: './audio-player.component.scss',
 })
-export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit {
+export class AudioPlayerComponent implements OnDestroy {
   private activeContext = inject(ActiveContextService);
 
-  @Input() media!: Media;
-  @Input() volume = 1;
+  readonly media = input.required<Media>();
+  readonly volume = input(1);
   readonly audioPlaying = input(true);
   readonly swipeClass = input('');
   readonly playingChanged = output<boolean>();
 
-  @ViewChild('waveformCanvas') canvasRef!: ElementRef<HTMLCanvasElement>;
-  @ViewChild('audioEl') audioRef!: ElementRef<HTMLAudioElement>;
+  private readonly canvasRef = viewChild<ElementRef<HTMLCanvasElement>>('waveformCanvas');
+  // Public: CenterPanelComponent reaches through this to pause/resume the
+  // native element on navigation / tab-visibility changes.
+  readonly audioRef = viewChild<ElementRef<HTMLAudioElement>>('audioEl');
+
+  // The volume the <audio> element should currently have. Resets to the
+  // `volume` input whenever the parent pushes a new value; element-driven
+  // changes (the native volume slider, keyboard adjustVolume) are mirrored
+  // back into it so later loads restore the user's last-set volume.
+  private readonly currentVolume = linkedSignal(() => this.volume());
 
   // Current object URL feeding the <audio> element (`blob:...`), or '' before
   // the first load. Set imperatively on the native element (not via a template
@@ -87,7 +95,6 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   audioSrc = '';
 
   private waveformAbort: AbortController | null = null;
-  private viewReady = false;
   // See ImageViewerComponent.lastMediaId: the `media` input reference changes
   // whenever the metadata cache hydrates; without this guard, every cache
   // refresh would re-`loadAudio()` and snap playback back to t=0.
@@ -98,47 +105,58 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   private clipBounds: { start: number; end: number } | null = null;
   // Whether (loadedmetadata) has fired for the current audioSrc. Clip bounds
   // (clip_start/clip_end) often arrive via batch hydration *after* the audio
-  // has already loaded, on a later ngOnChanges with the same media id; in that
+  // has already loaded, on a later media change with the same media id; in that
   // case (loadedmetadata) does not fire again, so we (re)apply the bounds here.
   // Mirrors VideoPlayerComponent: archive-member audio windows serve the whole
   // member and seek/loop within [clip_start, clip_end] (display-only).
   private metadataLoaded = false;
 
-  ngAfterViewInit(): void {
-    this.viewReady = true;
-    if (this.media) this.lastMediaId = this.media.id;
-    this.loadAudio();
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media) {
-      if (this.media.id !== this.lastMediaId) {
-        this.lastMediaId = this.media.id;
+  constructor() {
+    // (Re)load the clip when the media id changes. Tracks the view query so
+    // the first load runs as soon as the <audio> element exists (view queries
+    // resolve after the first render); until then the effect is a no-op and
+    // `lastMediaId` stays null, so the pending media loads on resolution.
+    effect(() => {
+      const media = this.media();
+      if (!this.audioRef()) return;
+      if (media.id !== this.lastMediaId) {
+        this.lastMediaId = media.id;
         this.metadataLoaded = false;
         this.stopClipEnforcement();
-        if (this.viewReady) {
-          this.loadAudio();
-        }
+        untracked(() => void this.loadAudio(media));
       } else if (this.metadataLoaded) {
         // Same media id, but metadata (e.g. clip_start/clip_end) may have just
         // arrived via batch hydration. The audio already loaded, so
         // (loadedmetadata) won't fire again; apply the clip window now.
-        this.applyClipBounds();
+        untracked(() => this.applyClipBounds());
       }
-    }
-    if (changes['volume'] && this.audioRef?.nativeElement) {
-      this.audioRef.nativeElement.volume = this.volume;
-    }
-    if (changes['audioPlaying'] && !changes['media'] && this.audioRef?.nativeElement) {
-      this.syncPlaybackState();
-    }
+    });
+
+    // Push volume changes onto the element. The element is read untracked so
+    // this runs only when the volume actually changes, mirroring the old
+    // `changes['volume']` guard; the initial volume is applied by
+    // (loadedmetadata) / loadAudio(), as before.
+    effect(() => {
+      const vol = this.currentVolume();
+      const audio = untracked(this.audioRef)?.nativeElement;
+      if (audio) audio.volume = vol;
+    });
+
+    // Play/pause the element when the parent toggles `audioPlaying`. Untracked
+    // element read for the same reason: a media swap must not re-trigger this
+    // (the old code's `!changes['media']` guard) — the post-load sync happens
+    // in loadAudio()/(loadedmetadata) instead.
+    effect(() => {
+      this.audioPlaying();
+      if (untracked(this.audioRef)) untracked(() => this.syncPlaybackState());
+    });
   }
 
   ngOnDestroy(): void {
     this.stopClipEnforcement();
     this.waveformAbort?.abort();
     this.waveformAbort = null;
-    const audio = this.audioRef?.nativeElement;
+    const audio = this.audioRef()?.nativeElement;
     if (audio) {
       audio.pause();
       audio.removeAttribute('src');
@@ -148,24 +166,25 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   onLoadedMetadata(): void {
-    const audio = this.audioRef?.nativeElement;
+    const audio = this.audioRef()?.nativeElement;
     if (!audio) return;
     this.metadataLoaded = true;
-    audio.volume = this.volume;
+    audio.volume = this.currentVolume();
     this.applyClipBounds();
     this.syncPlaybackState();
   }
 
   // Seek into the clip window and (re)start boundary enforcement when the media
   // carries clip extents; otherwise tear enforcement down. Safe to call both on
-  // (loadedmetadata) and on later metadata-enrichment ngOnChanges cycles.
+  // (loadedmetadata) and on later metadata-enrichment effect cycles.
   private applyClipBounds(): void {
-    const audio = this.audioRef?.nativeElement;
+    const audio = this.audioRef()?.nativeElement;
     if (!audio) return;
 
-    if (this.media?.clip_start != null) {
-      const clipStart = this.media.clip_start;
-      const clipEnd = this.media.clip_end;
+    const media = this.media();
+    if (media.clip_start != null) {
+      const clipStart = media.clip_start;
+      const clipEnd = media.clip_end;
       // Snap into the window only when currently outside it, so we don't yank
       // audio already looping correctly within its window.
       if (audio.currentTime < clipStart || (clipEnd != null && audio.currentTime >= clipEnd)) {
@@ -178,13 +197,14 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   private startClipEnforcement(): void {
-    if (this.media?.clip_start == null || this.media?.clip_end == null) {
+    const media = this.media();
+    if (media.clip_start == null || media.clip_end == null) {
       this.clipBounds = null;
       return;
     }
     // Arm enforcement; the actual boundary check runs in (timeupdate), which the
     // <audio> element fires as playback advances (no timer while paused).
-    this.clipBounds = { start: this.media.clip_start, end: this.media.clip_end };
+    this.clipBounds = { start: media.clip_start, end: media.clip_end };
   }
 
   private stopClipEnforcement(): void {
@@ -197,7 +217,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   onTimeUpdate(): void {
     const bounds = this.clipBounds;
     if (!bounds) return;
-    const audio = this.audioRef?.nativeElement;
+    const audio = this.audioRef()?.nativeElement;
     if (!audio || audio.paused) return;
     if (audio.currentTime >= bounds.end || audio.currentTime < bounds.start) {
       audio.currentTime = bounds.start;
@@ -205,8 +225,9 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   onVolumeChange(): void {
-    if (this.audioRef?.nativeElement) {
-      this.volume = this.audioRef.nativeElement.volume;
+    const audio = this.audioRef()?.nativeElement;
+    if (audio) {
+      this.currentVolume.set(audio.volume);
     }
   }
 
@@ -223,7 +244,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   togglePlayback(): void {
-    const audio = this.audioRef?.nativeElement;
+    const audio = this.audioRef()?.nativeElement;
     if (!audio) return;
     if (audio.paused) {
       audio.play().catch(() => {});
@@ -233,19 +254,18 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   adjustVolume(delta: number): void {
-    const audio = this.audioRef?.nativeElement;
+    const audio = this.audioRef()?.nativeElement;
     if (!audio) return;
     audio.volume = Math.max(0, Math.min(1, audio.volume + delta));
-    this.volume = audio.volume;
+    this.currentVolume.set(audio.volume);
   }
 
   // Download the clip once and feed those bytes to BOTH the <audio> element
   // (via an object URL) and the waveform renderer. Previously the <audio>
   // element streamed /audio while drawWaveform() fetched the identical URL a
   // second time and decoded it -- two downloads of the same bytes per selection.
-  private async loadAudio(): Promise<void> {
-    if (!this.media) return;
-    const mediaId = this.media.id;
+  private async loadAudio(media: Media): Promise<void> {
+    const mediaId = media.id;
     const datasetId = this.activeContext.datasetId;
 
     // Blank the old waveform immediately so a media switch doesn't leave the
@@ -282,9 +302,9 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
     await this.renderWaveform(mediaId, datasetId, blob, abort);
     this.clearAbort(abort);
 
-    const audio = this.audioRef?.nativeElement;
+    const audio = this.audioRef()?.nativeElement;
     if (audio) {
-      audio.volume = this.volume;
+      audio.volume = this.currentVolume();
       this.syncPlaybackState();
     }
   }
@@ -295,7 +315,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
     const url = URL.createObjectURL(blob);
     this.revokeObjectUrl();
     this.audioSrc = url;
-    const audio = this.audioRef?.nativeElement;
+    const audio = this.audioRef()?.nativeElement;
     if (audio) {
       audio.src = url;
       audio.load();
@@ -310,7 +330,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   }
 
   private syncPlaybackState(): void {
-    const audio = this.audioRef?.nativeElement;
+    const audio = this.audioRef()?.nativeElement;
     if (!audio) return;
     const audioPlaying = this.audioPlaying();
     if (audioPlaying && audio.paused) {
@@ -324,7 +344,7 @@ export class AudioPlayerComponent implements OnChanges, OnDestroy, AfterViewInit
   // background. Returns the 2D context + dimensions, or null when no canvas /
   // 2D context is available (headless test env).
   private beginCanvas(): { ctx: CanvasRenderingContext2D; width: number; height: number } | null {
-    const canvas = this.canvasRef?.nativeElement;
+    const canvas = this.canvasRef()?.nativeElement;
     if (!canvas) return null;
     const ctx = canvas.getContext('2d');
     if (!ctx) return null;

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -1,15 +1,15 @@
-<div class="center-panel" [class.empty]="!media">
-  @if (!media) {
+<div class="center-panel" [class.empty]="!media()">
+  @if (!media()) {
     <p class="placeholder-text">Select a media item to view</p>
   } @else {
     <div class="media-swipe-wrapper" [class]="mediaType === 'audio' ? '' : swipeClass()">
       @switch (mediaType) {
         @case ('audio') {
-          <vt-audio-player [media]="media" [volume]="volume()" [audioPlaying]="audioPlaying()" [swipeClass]="swipeClass()" (playingChanged)="onPlayingChanged($event)"></vt-audio-player>
+          <vt-audio-player [media]="media()!" [volume]="volume()" [audioPlaying]="audioPlaying()" [swipeClass]="swipeClass()" (playingChanged)="onPlayingChanged($event)"></vt-audio-player>
         }
         @case ('image') {
           <vt-image-viewer
-            [media]="media"
+            [media]="media()!"
             [pendingBadConfirm]="pendingBadConfirm()"
             [highlightBox]="highlightBox"
             (regionBoxChange)="onRegionBoxChange($event)"
@@ -17,40 +17,40 @@
           ></vt-image-viewer>
         }
         @case ('video') {
-          <vt-video-player [media]="media" [volume]="volume()" [audioPlaying]="audioPlaying()" (playingChanged)="onPlayingChanged($event)"></vt-video-player>
+          <vt-video-player [media]="media()!" [volume]="volume()" [audioPlaying]="audioPlaying()" (playingChanged)="onPlayingChanged($event)"></vt-video-player>
         }
         @case ('text') {
-          <vt-text-viewer [media]="media"></vt-text-viewer>
+          <vt-text-viewer [media]="media()!"></vt-text-viewer>
         }
         @case ('document') {
-          <vt-document-viewer [media]="media"></vt-document-viewer>
+          <vt-document-viewer [media]="media()!"></vt-document-viewer>
         }
         @default {
-          <vt-document-viewer [media]="media"></vt-document-viewer>
+          <vt-document-viewer [media]="media()!"></vt-document-viewer>
         }
       }
     </div>
 
-    @if (mediaType === 'image' && imageViewer) {
+    @if (mediaType === 'image' && imageViewer(); as imageViewer) {
       <div class="image-view-controls">
         <button
           class="btn btn--toolbar ivc-btn ivc-btn-toggle"
-          [class.active]="imageViewer.marqueeMode"
+          [class.active]="imageViewer.marqueeMode()"
           (click)="imageViewer.toggleMarqueeMode()"
           [title]="marqueeTitle"
           [attr.aria-label]="marqueeAriaLabel"
-          [attr.aria-pressed]="imageViewer.marqueeMode"
+          [attr.aria-pressed]="imageViewer.marqueeMode()"
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3 2.5" aria-hidden="true"><rect x="3.5" y="5.5" width="17" height="13" rx="0.5"/></svg>
         </button>
         @if (regionOverlayCapable) {
           <button
             class="btn btn--toolbar ivc-btn ivc-btn-toggle"
-            [class.active]="imageViewer.highlightMode"
+            [class.active]="imageViewer.highlightMode()"
             (click)="imageViewer.toggleHighlightMode()"
             title="Highlight: outline the region the detector matched best"
             aria-label="Highlight: outline best-matched region"
-            [attr.aria-pressed]="imageViewer.highlightMode"
+            [attr.aria-pressed]="imageViewer.highlightMode()"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 4l6 6-8 8-6-6z"/><path d="M6 12l-2.5 6.5L10 16z" fill="currentColor"/></svg>
           </button>
@@ -68,12 +68,12 @@
           [min]="imageViewer.minZoom"
           [max]="imageViewer.maxZoom"
           [step]="imageViewer.zoomStep"
-          [value]="imageViewer.zoom"
+          [value]="imageViewer.zoom()"
           (input)="imageViewer.onZoomInput($event)"
           title="Zoom"
           aria-label="Zoom level"
         />
-        <span class="ivc-zoom-label">{{ imageViewer.zoomLabel }}</span>
+        <span class="ivc-zoom-label">{{ imageViewer.zoomLabel() }}</span>
         <button class="btn btn--toolbar ivc-btn" (click)="imageViewer.resetView()" title="Reset view" aria-label="Reset image view"><vt-icon type="zoom-fit" [size]="16"></vt-icon></button>
       </div>
     }
@@ -107,8 +107,8 @@
           <div class="metadata-item">
             <span class="metadata-label">Name</span>
             <div class="metadata-value-row">
-              <vt-copy-detail-button [value]="media.filename || 'Media #' + media.id" label="Name" />
-              <span class="metadata-value">{{ media.filename || 'Media #' + media.id }}</span>
+              <vt-copy-detail-button [value]="media()!.filename || 'Media #' + media()!.id" label="Name" />
+              <span class="metadata-value">{{ media()!.filename || 'Media #' + media()!.id }}</span>
             </div>
           </div>
           <div class="metadata-item">
@@ -130,8 +130,8 @@
           <div class="metadata-item">
             <span class="metadata-label">MD5</span>
             <div class="metadata-value-row">
-              <vt-copy-detail-button [value]="media.md5 || ''" label="MD5" />
-              <span class="metadata-value metadata-md5">{{ media.md5 }}</span>
+              <vt-copy-detail-button [value]="media()!.md5 || ''" label="MD5" />
+              <span class="metadata-value metadata-md5">{{ media()!.md5 }}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, Input, input, OnChanges, OnDestroy, output, signal, SimpleChanges, untracked, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, output, signal, untracked, viewChild } from '@angular/core';
 import { KeyValuePipe, TitleCasePipe } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { EmbedderInfo, Media } from '../../models/api.models';
@@ -37,7 +37,7 @@ import { prefersReducedMotion } from '../../utils/reduced-motion';
   templateUrl: './center-panel.component.html',
   styleUrl: './center-panel.component.scss',
 })
-export class CenterPanelComponent implements OnChanges, OnDestroy {
+export class CenterPanelComponent implements OnDestroy {
   private mediasApi = inject(MediasApiService);
   private keyboard = inject(KeyboardService);
   voteState = inject(VoteStateService);
@@ -45,16 +45,16 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   private sortState = inject(SortStateService);
   private datasetsListingsApi = inject(DatasetsListingsApiService);
 
-  @Input() media: Media | null = null;
+  readonly media = input<Media | null>(null);
   readonly disabled = input(false);
   readonly mediaVoted = output<{
     id: number;
     vote: 'good' | 'bad';
 }>();
 
-  @ViewChild(AudioPlayerComponent) audioPlayer?: AudioPlayerComponent;
-  @ViewChild(ImageViewerComponent) imageViewer?: ImageViewerComponent;
-  @ViewChild(VideoPlayerComponent) videoPlayer?: VideoPlayerComponent;
+  readonly audioPlayer = viewChild(AudioPlayerComponent);
+  readonly imageViewer = viewChild(ImageViewerComponent);
+  readonly videoPlayer = viewChild(VideoPlayerComponent);
 
   // These fields are written from non-bound callbacks — the keyboard-shortcut
   // dispatch (`KeyboardService.action$`), HTTP/vote subscriptions, and timers —
@@ -121,17 +121,19 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
       this.voteState.badVotes;
       untracked(() => this.maybeDismissLabelHint());
     });
-  }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media']) {
+    // Reset per-item transient state on every media change (including same-id
+    // reference changes from metadata-cache hydration, matching the old
+    // ngOnChanges behavior).
+    effect(() => {
+      this.media();
       this.swipeClass.set('');
       // Navigating to another item clears the armed bad-vote-confirm state.
       // ImageViewer also clears its own regionBox on media change and will emit null;
       // resetting eagerly here keeps state coherent across the swap.
       this.pendingBadConfirm.set(false);
       this.currentRegionBox = null;
-    }
+    });
   }
 
   ngOnDestroy(): void {
@@ -145,17 +147,13 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
   /** Stop all media playback (used on navigation away). */
   stopPlayback(): void {
-    if (this.audioPlayer) {
-      const audio = this.audioPlayer.audioRef?.nativeElement;
-      if (audio) {
-        audio.pause();
-      }
+    const audio = this.audioPlayer()?.audioRef()?.nativeElement;
+    if (audio) {
+      audio.pause();
     }
-    if (this.videoPlayer) {
-      const video = this.videoPlayer.videoRef?.nativeElement;
-      if (video) {
-        video.pause();
-      }
+    const video = this.videoPlayer()?.videoRef()?.nativeElement;
+    if (video) {
+      video.pause();
     }
   }
 
@@ -173,7 +171,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
       this.keyboard.action$.subscribe((action) => {
         switch (action.type) {
           case 'vote':
-            if (this.media && action.direction && !this.disabled()) {
+            if (this.media() && action.direction && !this.disabled()) {
               this.castVote(action.direction);
             }
             break;
@@ -183,18 +181,22 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
           case 'playback':
             this.togglePlayback();
             break;
-          case 'zoom':
-            if (this.imageViewer && action.zoomDirection) {
-              if (action.zoomDirection === 'in') this.imageViewer.zoomIn();
-              else this.imageViewer.zoomOut();
+          case 'zoom': {
+            const imageViewer = this.imageViewer();
+            if (imageViewer && action.zoomDirection) {
+              if (action.zoomDirection === 'in') imageViewer.zoomIn();
+              else imageViewer.zoomOut();
             }
             break;
-          case 'rotate':
-            if (this.imageViewer && action.rotateDirection) {
-              if (action.rotateDirection === 'left') this.imageViewer.rotateLeft();
-              else this.imageViewer.rotateRight();
+          }
+          case 'rotate': {
+            const imageViewer = this.imageViewer();
+            if (imageViewer && action.rotateDirection) {
+              if (action.rotateDirection === 'left') imageViewer.rotateLeft();
+              else imageViewer.rotateRight();
             }
             break;
+          }
           case 'undo':
             if (!this.disabled() && !this.isVoting()) this.voteState.undo();
             break;
@@ -226,14 +228,14 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   get mediaType(): string {
-    return this.media?.media_type || 'audio';
+    return this.media()?.media_type || 'audio';
   }
 
   /** The embedder names bound to the focused media (the v3 trio).  Prefers the
    *  full ``embeddings`` key set the backend now ships under ``embedders``;
    *  falls back to the singular primary for older payloads. */
   private boundEmbedderNames(): string[] {
-    const m = this.media;
+    const m = this.media();
     if (!m) return [];
     if (m.embedders && m.embedders.length > 0) return m.embedders;
     return m.embedder ? [m.embedder] : [];
@@ -288,19 +290,22 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
    *  ``null`` when the media wasn't scored or carries no region. Passed to the
    *  image viewer, which draws it only while Highlight is toggled on. */
   get highlightBox(): RegionBox | null {
-    if (!this.media) return null;
-    const id = this.media.id;
+    const media = this.media();
+    if (!media) return null;
+    const id = media.id;
     const box = this.sortState.sortOrder?.find((s) => s.id === id)?.bestRegion;
     if (!box || box.length !== 4) return null;
     return [box[0], box[1], box[2], box[3]];
   }
 
   get isGood(): boolean {
-    return this.media ? this.voteState.effectiveGood(this.media.id) : false;
+    const media = this.media();
+    return media ? this.voteState.effectiveGood(media.id) : false;
   }
 
   get isBad(): boolean {
-    return this.media ? this.voteState.effectiveBad(this.media.id) : false;
+    const media = this.media();
+    return media ? this.voteState.effectiveBad(media.id) : false;
   }
 
   /** True when the labeling session is fresh (no votes yet across either
@@ -312,9 +317,10 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   get customMetadata(): Record<string, unknown> {
-    if (!this.media) return {};
+    const media = this.media();
+    if (!media) return {};
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (this.media as any)['custom_metadata'] as Record<string, unknown> || {};
+    return (media as any)['custom_metadata'] as Record<string, unknown> || {};
   }
 
   /** Human-readable label for an item used in undo toasts. */
@@ -341,7 +347,8 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   }
 
   castVote(vote: 'good' | 'bad'): void {
-    if (!this.media || this.isVoting()) return;
+    const media = this.media();
+    if (!media || this.isVoting()) return;
 
     // Region annotations only attach to yes-votes (salient-area semantics).
     // A no-vote with a box drawn arms a sticky discard-confirm state; the first
@@ -351,7 +358,7 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     // fresh Shift-drag, or item navigation clear armed without voting.
     if (vote === 'bad' && this.currentRegionBox && !this.pendingBadConfirm()) {
       this.pendingBadConfirm.set(true);
-      this.imageViewer?.pulseRegionBox();
+      this.imageViewer()?.pulseRegionBox();
       return;
     }
 
@@ -360,21 +367,21 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
     this.isVoting.set(true);
 
     this.voteState
-      .submitToggleVoteAndRecord(this.media.id, vote, this.mediaDisplayName(this.media), regionBox)
+      .submitToggleVoteAndRecord(media.id, vote, this.mediaDisplayName(media), regionBox)
       .subscribe({
         next: () => {
-          const animate = this.showAnimations() && !!this.media && !prefersReducedMotion();
+          const animate = this.showAnimations() && !!this.media() && !prefersReducedMotion();
           if (animate) {
             this.swipeClass.set(vote === 'good' ? 'swipe-right' : 'swipe-left');
             this.spinningVote.set(vote);
             if (this.spinTimer) clearTimeout(this.spinTimer);
             this.spinTimer = setTimeout(() => this.spinningVote.set(null), 300);
             setTimeout(() => {
-              this.mediaVoted.emit({ id: this.media!.id, vote });
+              this.mediaVoted.emit({ id: this.media()!.id, vote });
               this.isVoting.set(false);
             }, 180);
           } else {
-            this.mediaVoted.emit({ id: this.media!.id, vote });
+            this.mediaVoted.emit({ id: this.media()!.id, vote });
             this.isVoting.set(false);
           }
         },
@@ -402,12 +409,8 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
 
   private adjustVolume(delta: number): void {
     this.volume.set(Math.max(0, Math.min(1, this.volume() + delta)));
-    if (this.audioPlayer) {
-      this.audioPlayer.adjustVolume(delta);
-    }
-    if (this.videoPlayer) {
-      this.videoPlayer.adjustVolume(delta);
-    }
+    this.audioPlayer()?.adjustVolume(delta);
+    this.videoPlayer()?.adjustVolume(delta);
     this.settingsState.update({ volume: this.volume() }).subscribe();
   }
 
@@ -432,24 +435,16 @@ export class CenterPanelComponent implements OnChanges, OnDestroy {
   };
 
   private resumePlayback(): void {
-    if (this.audioPlayer) {
-      const audio = this.audioPlayer.audioRef?.nativeElement;
-      if (audio) audio.play().catch(() => {});
-    }
-    if (this.videoPlayer) {
-      const video = this.videoPlayer.videoRef?.nativeElement;
-      if (video) video.play().catch(() => {});
-    }
+    const audio = this.audioPlayer()?.audioRef()?.nativeElement;
+    if (audio) audio.play().catch(() => {});
+    const video = this.videoPlayer()?.videoRef()?.nativeElement;
+    if (video) video.play().catch(() => {});
   }
 
   private togglePlayback(): void {
     this.audioPlaying.set(!this.audioPlaying());
-    if (this.audioPlayer) {
-      this.audioPlayer.togglePlayback();
-    }
-    if (this.videoPlayer) {
-      this.videoPlayer.togglePlayback();
-    }
+    this.audioPlayer()?.togglePlayback();
+    this.videoPlayer()?.togglePlayback();
     this.settingsState.update({ audio_playing: this.audioPlaying() }).subscribe();
   }
 }

--- a/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
@@ -170,31 +170,28 @@ describe('CenterPanelComponent', () => {
   });
 
   it('should show audio player for audio media', () => {
-    component.media = mockMedia;
+    fixture.componentRef.setInput('media', mockMedia);
     TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-audio-player')).toBeTruthy();
   });
 
   it('should show image viewer for image media', () => {
-    component.media = { ...mockMedia, media_type: 'image' };
-    // The image-view-controls block (`@if (mediaType === 'image' && imageViewer)`)
-    // gates on the `imageViewer` ViewChild, which only resolves partway through
-    // the first change-detection pass. The zoom-slider bindings it renders then
-    // settle to their real values within that same pass, which dev-mode's
-    // check-no-changes guard flags as NG0100. Skip that guard (pass `false`); the
-    // behaviour is dev-mode-only and does not occur in production.
-    fixture.detectChanges(false);
+    fixture.componentRef.setInput('media', { ...mockMedia, media_type: 'image' });
+    // The image-view-controls block gates on the `imageViewer` view query, now a
+    // signal: it resolves after the first pass and schedules a clean follow-up
+    // render, so no NG0100 workaround is needed.
+    TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-image-viewer')).toBeTruthy();
   });
 
   it('should show video player for video media', () => {
-    component.media = { ...mockMedia, media_type: 'video' };
+    fixture.componentRef.setInput('media', { ...mockMedia, media_type: 'video' });
     TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-video-player')).toBeTruthy();
   });
 
   it('should show text viewer for text media', () => {
-    component.media = { ...mockMedia, media_type: 'text' };
+    fixture.componentRef.setInput('media', { ...mockMedia, media_type: 'text' });
     TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-text-viewer')).toBeTruthy();
     // The rendered text-viewer fetches its paragraph on init; flush it so the
@@ -203,19 +200,19 @@ describe('CenterPanelComponent', () => {
   });
 
   it('should show document viewer for document media', () => {
-    component.media = { ...mockMedia, media_type: 'document' };
+    fixture.componentRef.setInput('media', { ...mockMedia, media_type: 'document' });
     TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-document-viewer')).toBeTruthy();
   });
 
   it('should show voting overlay when media is selected', () => {
-    component.media = mockMedia;
+    fixture.componentRef.setInput('media', mockMedia);
     TestBed.tick();
     expect(fixture.nativeElement.querySelector('vt-voting-overlay')).toBeTruthy();
   });
 
   it('should display metadata', () => {
-    component.media = mockMedia;
+    fixture.componentRef.setInput('media', mockMedia);
     TestBed.tick();
     const text = fixture.nativeElement.textContent;
     expect(text).toContain('test.wav');
@@ -224,7 +221,7 @@ describe('CenterPanelComponent', () => {
   });
 
   it('should send vote request on castVote', () => {
-    component.media = mockMedia;
+    fixture.componentRef.setInput('media', mockMedia);
     component.showAnimations.set(false);
     TestBed.tick();
 
@@ -245,7 +242,7 @@ describe('CenterPanelComponent', () => {
   });
 
   it('should prevent double voting', () => {
-    component.media = mockMedia;
+    fixture.componentRef.setInput('media', mockMedia);
     component.showAnimations.set(false);
     TestBed.tick();
     component.isVoting.set(true);
@@ -263,16 +260,14 @@ describe('CenterPanelComponent', () => {
   });
 
   it('should clear swipe class when media changes', () => {
-    component.media = mockMedia;
+    fixture.componentRef.setInput('media', mockMedia);
     TestBed.tick();
     // Simulate swipe ending
     component.swipeClass.set('swipe-right');
 
-    // Change to new media (triggers ngOnChanges)
-    component.media = { ...mockMedia, id: 2, filename: 'next.wav' };
-    component.ngOnChanges({
-      media: { currentValue: component.media, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
-    });
+    // Change to new media (triggers the media-change effect)
+    fixture.componentRef.setInput('media', { ...mockMedia, id: 2, filename: 'next.wav' });
+    TestBed.tick();
 
     expect(component.swipeClass()).toBe('');
   });
@@ -295,13 +290,9 @@ describe('CenterPanelComponent', () => {
     const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
 
     function setup(): void {
-      component.media = imageMedia;
+      fixture.componentRef.setInput('media', imageMedia);
       component.showAnimations.set(false);
-      // Skip dev-mode check-no-changes: rendering the image-view-controls (gated
-      // on the `imageViewer` ViewChild) settles the zoom-slider bindings within
-      // the first CD pass, which the guard would otherwise flag as NG0100. This
-      // is dev-mode-only and does not occur in production.
-      fixture.detectChanges(false);
+      TestBed.tick();
     }
 
     it('attaches region_box to a yes-vote when a box is drawn', () => {
@@ -355,13 +346,9 @@ describe('CenterPanelComponent', () => {
     const box: RegionBox = [0.1, 0.2, 0.5, 0.6];
 
     function setup(): void {
-      component.media = imageMedia;
+      fixture.componentRef.setInput('media', imageMedia);
       component.showAnimations.set(false);
-      // Skip dev-mode check-no-changes: rendering the image-view-controls (gated
-      // on the `imageViewer` ViewChild) settles the zoom-slider bindings within
-      // the first CD pass, which the guard would otherwise flag as NG0100. This
-      // is dev-mode-only and does not occur in production.
-      fixture.detectChanges(false);
+      TestBed.tick();
     }
 
     it('arms on first ← without firing a request, fires on second ←', () => {
@@ -411,15 +398,8 @@ describe('CenterPanelComponent', () => {
       expect(component.pendingBadConfirm()).toBe(true);
 
       const next: Media = { ...imageMedia, id: 2, filename: 'next.png' };
-      component.media = next;
-      component.ngOnChanges({
-        media: {
-          currentValue: next,
-          previousValue: imageMedia,
-          firstChange: false,
-          isFirstChange: () => false,
-        },
-      });
+      fixture.componentRef.setInput('media', next);
+      TestBed.tick();
       expect(component.pendingBadConfirm()).toBe(false);
       expect(component.currentRegionBox).toBeNull();
     });
@@ -464,31 +444,31 @@ describe('CenterPanelComponent', () => {
     }
 
     it('hides the overlay toggle when the embedder is single-vector (neither capability)', () => {
-      component.media = imageMedia;
+      fixture.componentRef.setInput('media', imageMedia);
       withEmbedders([info({})]);
       expect(component.regionOverlayCapable).toBe(false);
     });
 
     it('shows the overlay toggle for patch-region embedders', () => {
-      component.media = imageMedia;
+      fixture.componentRef.setInput('media', imageMedia);
       withEmbedders([info({ supports_patch_regions: true })]);
       expect(component.regionOverlayCapable).toBe(true);
     });
 
     it('shows the overlay toggle for structural embedders (geometric verification)', () => {
-      component.media = imageMedia;
+      fixture.componentRef.setInput('media', imageMedia);
       withEmbedders([info({ supports_geometric_verification: true })]);
       expect(component.regionOverlayCapable).toBe(true);
     });
 
     it('defaults to no overlay when the embedder is unknown / not yet loaded', () => {
-      component.media = imageMedia;
+      fixture.componentRef.setInput('media', imageMedia);
       withEmbedders([]);
       expect(component.regionOverlayCapable).toBe(false);
     });
 
     it('nudges marquee copy toward boxing the pattern on structural datasets', () => {
-      component.media = imageMedia;
+      fixture.componentRef.setInput('media', imageMedia);
       withEmbedders([info({ supports_geometric_verification: true })]);
       expect(component.structuralDataset).toBe(true);
       expect(component.marqueeTitle).toContain('box the pattern you want to match');
@@ -496,7 +476,7 @@ describe('CenterPanelComponent', () => {
     });
 
     it('keeps generic marquee copy on non-structural datasets', () => {
-      component.media = imageMedia;
+      fixture.componentRef.setInput('media', imageMedia);
       withEmbedders([info({ supports_patch_regions: true })]);
       expect(component.structuralDataset).toBe(false);
       expect(component.marqueeTitle).toContain('draw a region');

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.html
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.html
@@ -1,5 +1,5 @@
 <div class="document-wrap">
-  @if (mediaSrc) {
-    <object [data]="mediaSrc" class="document-embed">{{ media.filename || 'Document' }}</object>
+  @if (mediaSrc(); as mediaSrc) {
+    <object [data]="mediaSrc" class="document-embed">{{ media().filename || 'Document' }}</object>
   }
 </div>

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.spec.ts
@@ -32,14 +32,12 @@ describe('DocumentViewerComponent', () => {
   });
 
   it('should set mediaSrc when media changes', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
+    fixture.componentRef.setInput('media', mockMedia);
+    TestBed.tick();
     // mediaSrc is a trusted SafeResourceUrl (required by the `<object [data]>`
     // RESOURCE_URL sink); unwrap it to assert the underlying media URL.
     const sanitizer = TestBed.inject(DomSanitizer);
-    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, component.mediaSrc)).toBe(
+    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, component.mediaSrc())).toBe(
       '/api/medias/5/media',
     );
   });

--- a/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/document-viewer/document-viewer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, signal } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -10,26 +10,31 @@ import { ActiveContextService } from '../../../services/active-context.service';
   templateUrl: './document-viewer.component.html',
   styleUrl: './document-viewer.component.scss',
 })
-export class DocumentViewerComponent implements OnChanges {
+export class DocumentViewerComponent {
   private activeContext = inject(ActiveContextService);
   private sanitizer = inject(DomSanitizer);
 
-  @Input() media!: Media;
+  readonly media = input.required<Media>();
 
   // `<object [data]>` is a RESOURCE_URL sink, so Angular rejects a plain
   // string with NG0904. The URL is our own same-origin media endpoint, so
   // wrap it as a trusted resource URL. Null until the first media resolves.
-  mediaSrc: SafeResourceUrl | null = null;
+  // Signal: written from the effect below and read in the template.
+  readonly mediaSrc = signal<SafeResourceUrl | null>(null);
   // See ImageViewerComponent.lastMediaId; keep the iframe stable across
-  // metadata-enrichment ngOnChanges cycles for the same id.
+  // metadata-enrichment effect cycles for the same id.
   private lastMediaId: number | null = null;
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
-      this.lastMediaId = this.media.id;
-      this.mediaSrc = this.sanitizer.bypassSecurityTrustResourceUrl(
-        this.activeContext.mediaUrl(`/api/medias/${this.media.id}/media`),
+  constructor() {
+    effect(() => {
+      const media = this.media();
+      if (media.id === this.lastMediaId) return;
+      this.lastMediaId = media.id;
+      this.mediaSrc.set(
+        this.sanitizer.bypassSecurityTrustResourceUrl(
+          this.activeContext.mediaUrl(`/api/medias/${media.id}/media`),
+        ),
       );
-    }
+    });
   }
 }

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.html
@@ -8,10 +8,10 @@
 >
   <img
     #imageEl
-    [src]="imageSrc"
-    [alt]="media.filename || 'Image media'"
+    [src]="imageSrc()"
+    [alt]="media().filename || 'Image media'"
     class="image-element"
-    [class.image-loading]="!imageReady"
+    [class.image-loading]="!imageReady()"
     [style.transform]="imageTransform"
     (load)="onImageLoad()"
     (error)="onImageError()"
@@ -39,12 +39,12 @@
       [style.width.px]="renderedW()"
       [style.height.px]="renderedH()"
       [style.transform]="'translate(-50%, -50%) ' + imageTransform"
-      [style.--region-zoom]="zoom"
+      [style.--region-zoom]="zoom()"
     >
       <div
         class="region-box"
         [class.shake]="regionBoxShake()"
-        [class.armed]="pendingBadConfirm"
+        [class.armed]="pendingBadConfirm()"
         [ngStyle]="regionBoxStyle!"
         (mousedown)="onRegionBodyMouseDown($event)"
         title="Region annotation (Shift-drag to redraw, Esc to clear)"

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, OnChanges, OnDestroy, output, signal, SimpleChanges, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, OnDestroy, output, signal, untracked, viewChild } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -22,16 +22,16 @@ const MIN_BOX_SIZE = 0.01; // 1% of the image; below this we treat a draw as a s
   templateUrl: './image-viewer.component.html',
   styleUrl: './image-viewer.component.scss',
 })
-export class ImageViewerComponent implements OnChanges, OnDestroy {
+export class ImageViewerComponent implements OnDestroy {
   private activeContext = inject(ActiveContextService);
 
-  @Input() media!: Media;
+  readonly media = input.required<Media>();
   /**
    * True while the parent is in the v2 "bad-vote-with-box discard confirm" armed state.
    * The viewer uses it to (a) render the box with a sticky red pulse, and (b) route Esc /
    * mouse-on-box back to the parent via `armedConfirmCanceled` instead of clearing the box.
    */
-  @Input() pendingBadConfirm = false;
+  readonly pendingBadConfirm = input(false);
   /**
    * The region the detector/embedder matched best at inference, as a normalised
    * ``[x0, y0, x1, y1]`` box (the argmax over patch regions that produced this
@@ -41,7 +41,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
    * the Highlight toggle (``highlightMode``) is on; purely informational, never
    * interactive (no drag/resize, no vote semantics).
    */
-  @Input() highlightBox: RegionBox | null = null;
+  readonly highlightBox = input<RegionBox | null>(null);
   readonly regionBoxChange = output<RegionBox | null>();
   /**
    * Fired when the user does something that cancels the armed bad-vote-confirm without
@@ -50,17 +50,28 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
    */
   readonly armedConfirmCanceled = output<void>();
 
-  @ViewChild('imageWrap') wrapRef!: ElementRef<HTMLDivElement>;
-  @ViewChild('imageEl') imageRef!: ElementRef<HTMLImageElement>;
+  // Public: the coord-transform specs substitute a stub wrap element here.
+  readonly wrapRef = viewChild<ElementRef<HTMLDivElement>>('imageWrap');
+  private readonly imageRef = viewChild<ElementRef<HTMLImageElement>>('imageEl');
 
-  imageSrc = '';
-  imageReady = false;
-  zoom = 1;
-  rotation = 0;
-  zoomLabel = '1×';
+  // Signals: written from the media-change effect below and read in the
+  // template, so plain fields would leave the view stale under zoneless.
+  readonly imageSrc = signal('');
+  readonly imageReady = signal(false);
+  // zoom/rotation are signals: they are written from the keyboard-shortcut
+  // dispatch (an un-bound RxJS callback in CenterPanelComponent) and from the
+  // parent's toolbar buttons (click handlers bound in the PARENT's template,
+  // which mark only the parent dirty) — with a plain field, this OnPush view's
+  // transform binding silently went stale until some unrelated CD repainted it.
+  readonly zoom = signal(1);
+  readonly rotation = signal(0);
+  readonly zoomLabel = computed(() => {
+    const z = this.zoom();
+    return (z === Math.floor(z) ? z.toFixed(0) : z.toFixed(1)) + '×';
+  });
   // Track the id of the media we last reset for. The `media` input reference
   // changes whenever `MediaMetadataCacheService` hydrates richer metadata for
-  // the same id; re-running ngOnChanges for those enrichments would clobber
+  // the same id; re-running the media-change effect for those enrichments would clobber
   // `imageReady=true` back to false and, since `imageSrc` is the same string,
   // Angular wouldn't re-fire the `<img>` load event, leaving the canvas
   // permanently hidden behind `visibility: hidden`.
@@ -77,13 +88,15 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   // viewer behaves as if Shift were held: cursor is a crosshair and a left-drag draws a
   // new region instead of panning. Shift+drag remains a power-user shortcut even when
   // the toggle is off; toggling the button just turns the gesture on without a modifier.
-  marqueeMode = false;
+  // Signal for the same parent-toolbar reason as `zoom`: toggled from the
+  // parent's template, read here (crosshair cursor / region-mode class).
+  readonly marqueeMode = signal(false);
   // Sticky toggle exposed by the Highlight button in .image-view-controls. While
   // true the viewer overlays a neutral white/black dashed box (`highlightBox`)
   // around the region the detector matched best at inference. Independent of marqueeMode -
   // both can be on at once (the highlight is read-only and sits behind the
   // interactive voting box).
-  highlightMode = false;
+  readonly highlightMode = signal(false);
   // renderedW/H are written from a raw ResizeObserver callback (un-patched, no CD
   // under zoneless), so they are signals; reading them in the template keeps the
   // overlay geometry fresh when the wrap resizes.
@@ -112,26 +125,31 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
 
   constructor() {
     this.setupWindowKeyListeners();
-  }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
-      this.lastMediaId = this.media.id;
-      this.imageReady = false;
-      this.imageSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/image`);
-      this.resetView();
-      this.clearRegionBox({ emit: true });
-    }
+    // Reset the viewport for a new image when the media id changes. The id
+    // guard skips same-id metadata-enrichment reference changes (see
+    // lastMediaId above); zoom/rotation/marquee state intentionally persists.
+    effect(() => {
+      const media = this.media();
+      if (media.id === this.lastMediaId) return;
+      this.lastMediaId = media.id;
+      this.imageReady.set(false);
+      this.imageSrc.set(this.activeContext.mediaUrl(`/api/medias/${media.id}/image`));
+      untracked(() => {
+        this.resetView();
+        this.clearRegionBox({ emit: true });
+      });
+    });
   }
 
   onImageLoad(): void {
-    this.imageReady = true;
+    this.imageReady.set(true);
     this.recomputeRenderedSize();
     this.attachWrapResizeObserver();
   }
 
   onImageError(): void {
-    this.imageReady = true;
+    this.imageReady.set(true);
   }
 
   ngOnDestroy(): void {
@@ -145,33 +163,33 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   onZoomInput(event: Event): void {
-    this.zoom = parseFloat((event.target as HTMLInputElement).value);
+    this.zoom.set(parseFloat((event.target as HTMLInputElement).value));
     this.applyTransform();
   }
 
   rotateLeft(): void {
-    this.rotation -= 90;
+    this.rotation.update((r) => r - 90);
     this.applyTransform();
   }
 
   rotateRight(): void {
-    this.rotation += 90;
+    this.rotation.update((r) => r + 90);
     this.applyTransform();
   }
 
   zoomIn(): void {
-    this.zoom = this.clampZoom(this.zoom + 0.15 * this.zoom);
+    this.zoom.update((z) => this.clampZoom(z + 0.15 * z));
     this.applyTransform();
   }
 
   zoomOut(): void {
-    this.zoom = this.clampZoom(this.zoom - 0.15 * this.zoom);
+    this.zoom.update((z) => this.clampZoom(z - 0.15 * z));
     this.applyTransform();
   }
 
   resetView(): void {
-    this.zoom = 1;
-    this.rotation = 0;
+    this.zoom.set(1);
+    this.rotation.set(0);
     this.panX.set(0);
     this.panY.set(0);
     this.applyTransform();
@@ -179,17 +197,17 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
 
   onWheel(event: WheelEvent): void {
     event.preventDefault();
-    const oldZoom = this.zoom;
+    const oldZoom = this.zoom();
     const delta = event.deltaY > 0 ? -0.15 : 0.15;
-    this.zoom = this.clampZoom(this.zoom + delta * this.zoom);
+    this.zoom.set(this.clampZoom(oldZoom + delta * oldZoom));
 
-    const wrap = this.wrapRef?.nativeElement;
+    const wrap = this.wrapRef()?.nativeElement;
     if (wrap) {
       const rect = wrap.getBoundingClientRect();
       const s = this.layoutScale(wrap, rect);
       const cx = (event.clientX - rect.left - rect.width / 2) / s;
       const cy = (event.clientY - rect.top - rect.height / 2) / s;
-      const ratio = this.zoom / oldZoom;
+      const ratio = this.zoom() / oldZoom;
       this.panX.set(cx - ratio * (cx - this.panX()));
       this.panY.set(cy - ratio * (cy - this.panY()));
     }
@@ -198,20 +216,20 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
 
   /** True when a drag should draw a region (either Shift-held or Marquee toggle on). */
   get regionDrawActive(): boolean {
-    return this.shiftHeld() || this.marqueeMode;
+    return this.shiftHeld() || this.marqueeMode();
   }
 
   toggleMarqueeMode(): void {
-    this.marqueeMode = !this.marqueeMode;
+    this.marqueeMode.update((v) => !v);
   }
 
   toggleHighlightMode(): void {
-    this.highlightMode = !this.highlightMode;
+    this.highlightMode.update((v) => !v);
   }
 
   /** True when the best-match highlight box should be drawn over the image. */
   get highlightVisible(): boolean {
-    return this.highlightMode && this.highlightBoxStyle !== null;
+    return this.highlightMode() && this.highlightBoxStyle !== null;
   }
 
   /** Percent-position style for the best-match highlight overlay.  Returns null
@@ -220,7 +238,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
    *  frame round everything.  (This overlay is the only place a best-match region
    *  is drawn - thumbnails never render a best-region outline.) */
   get highlightBoxStyle(): { [k: string]: string } | null {
-    const box = this.highlightBox;
+    const box = this.highlightBox();
     if (!box || box.length !== 4) return null;
     const [x0, y0, x1, y1] = box;
     if (![x0, y0, x1, y1].every((v) => Number.isFinite(v))) return null;
@@ -246,7 +264,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
       if (!local) return;
       const x = clamp01(local.x);
       const y = clamp01(local.y);
-      if (this.pendingBadConfirm) this.armedConfirmCanceled.emit();
+      if (this.pendingBadConfirm()) this.armedConfirmCanceled.emit();
       // Remember the prior box so we can restore it on a zero-area release;
       // a stray Shift-click on empty space must not throw away real work.
       this.drag = { kind: 'draw', anchor: { x, y }, previousBox: this.regionBox() };
@@ -277,7 +295,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     event.preventDefault();
     const local = this.screenToImageNormalized(event);
     if (!local) return;
-    if (this.pendingBadConfirm) this.armedConfirmCanceled.emit();
+    if (this.pendingBadConfirm()) this.armedConfirmCanceled.emit();
     this.drag = { kind: 'move', startLocal: local, startBox: box };
     this.setupWindowMouseListeners();
   }
@@ -287,7 +305,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     if (event.button !== 0 || !box) return;
     event.stopPropagation();
     event.preventDefault();
-    if (this.pendingBadConfirm) this.armedConfirmCanceled.emit();
+    if (this.pendingBadConfirm()) this.armedConfirmCanceled.emit();
     this.drag = { kind: 'resize', handle, startBox: box };
     this.setupWindowMouseListeners();
   }
@@ -308,7 +326,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   get imageTransform(): string {
-    return `translate(${this.panX()}px, ${this.panY()}px) scale(${this.zoom}) rotate(${this.rotation}deg)`;
+    return `translate(${this.panX()}px, ${this.panY()}px) scale(${this.zoom()}) rotate(${this.rotation()}deg)`;
   }
 
   get wrapCursor(): string {
@@ -329,12 +347,12 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     };
   }
 
+  // Clamp the pan back into range for the current zoom/rotation; call after
+  // any zoom/rotation change. (zoomLabel is a computed off `zoom` now.)
   private applyTransform(): void {
     const max = this.getMaxPan();
     this.panX.set(Math.max(-max.x, Math.min(max.x, this.panX())));
     this.panY.set(Math.max(-max.y, Math.min(max.y, this.panY())));
-    const zoomVal = this.zoom;
-    this.zoomLabel = (zoomVal === Math.floor(zoomVal) ? zoomVal.toFixed(0) : zoomVal.toFixed(1)) + '×';
   }
 
   private clampZoom(val: number): number {
@@ -342,8 +360,8 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   private recomputeRenderedSize(): void {
-    const img = this.imageRef?.nativeElement;
-    const wrap = this.wrapRef?.nativeElement;
+    const img = this.imageRef()?.nativeElement;
+    const wrap = this.wrapRef()?.nativeElement;
     if (!img || !wrap) return;
     const natW = img.naturalWidth;
     const natH = img.naturalHeight;
@@ -366,7 +384,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   private attachWrapResizeObserver(): void {
-    const wrap = this.wrapRef?.nativeElement;
+    const wrap = this.wrapRef()?.nativeElement;
     if (!wrap || this.resizeObserver) return;
     if (typeof ResizeObserver === 'undefined') return;
     this.resizeObserver = new ResizeObserver(() => this.recomputeRenderedSize());
@@ -374,19 +392,19 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
   }
 
   private getMaxPan(): { x: number; y: number } {
-    const wrap = this.wrapRef?.nativeElement;
+    const wrap = this.wrapRef()?.nativeElement;
     const renderedW = this.renderedW();
     const renderedH = this.renderedH();
     if (!wrap || !renderedW || !renderedH) return { x: 0, y: 0 };
     const wrapW = wrap.clientWidth;
     const wrapH = wrap.clientHeight;
-    const rot = ((this.rotation % 360) + 360) % 360;
+    const rot = ((this.rotation() % 360) + 360) % 360;
     const swapped = rot === 90 || rot === 270;
     const effW = swapped ? renderedH : renderedW;
     const effH = swapped ? renderedW : renderedH;
     return {
-      x: Math.max(0, (effW * this.zoom - wrapW) / 2),
-      y: Math.max(0, (effH * this.zoom - wrapH) / 2),
+      x: Math.max(0, (effW * this.zoom() - wrapW) / 2),
+      y: Math.max(0, (effH * this.zoom() - wrapH) / 2),
     };
   }
 
@@ -408,7 +426,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
    *  Returns null when the image isn't laid out yet. Public so tests can drive it
    *  with a mocked wrapRef + arbitrary pan/zoom/rotate state. */
   screenToImageNormalized(event: MouseEvent): { x: number; y: number } | null {
-    const wrap = this.wrapRef?.nativeElement;
+    const wrap = this.wrapRef()?.nativeElement;
     const renderedW = this.renderedW();
     const renderedH = this.renderedH();
     if (!wrap || !renderedW || !renderedH) return null;
@@ -416,9 +434,9 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     const s = this.layoutScale(wrap, rect);
     const dx = (event.clientX - (rect.left + rect.width / 2)) / s - this.panX();
     const dy = (event.clientY - (rect.top + rect.height / 2)) / s - this.panY();
-    const sx = dx / this.zoom;
-    const sy = dy / this.zoom;
-    const rad = (-this.rotation * Math.PI) / 180;
+    const sx = dx / this.zoom();
+    const sy = dy / this.zoom();
+    const rad = (-this.rotation() * Math.PI) / 180;
     const cos = Math.cos(rad);
     const sin = Math.sin(rad);
     const rx = sx * cos - sy * sin;
@@ -454,7 +472,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     if (d.kind === 'pan') {
       // clientX deltas are VISUAL px (the app renders at zoom: 1.1) but panX is
       // a LAYOUT-px transform value; convert so the image tracks the cursor 1:1.
-      const wrap = this.wrapRef?.nativeElement;
+      const wrap = this.wrapRef()?.nativeElement;
       const s = wrap ? this.layoutScale(wrap, wrap.getBoundingClientRect()) : 1;
       this.panX.set(d.originX + (e.clientX - d.startX) / s);
       this.panY.set(d.originY + (e.clientY - d.startY) / s);
@@ -570,7 +588,7 @@ export class ImageViewerComponent implements OnChanges, OnDestroy {
     // keeps the box (per the v2 patch-embedder plan, drawing a box is real work,
     // and Esc should be the "I changed my mind about voting no" out, not "throw
     // away the box"). Only consume the key if we actually had an action to take.
-    if (this.pendingBadConfirm) {
+    if (this.pendingBadConfirm()) {
       e.preventDefault();
       this.armedConfirmCanceled.emit();
       return;

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.zoneless.spec.ts
@@ -111,78 +111,63 @@ describe('ImageViewerComponent', () => {
   });
 
   it('should set imageSrc when media changes', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
-    expect(component.imageSrc).toBe('/api/medias/2/image');
+    fixture.componentRef.setInput('media', mockMedia);
+    TestBed.tick();
+    expect(component.imageSrc()).toBe('/api/medias/2/image');
   });
 
   it('should hide image until loaded to prevent flash of old image', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
-    expect(component.imageReady).toBe(false);
+    fixture.componentRef.setInput('media', mockMedia);
+    TestBed.tick();
+    expect(component.imageReady()).toBe(false);
 
     component.onImageLoad();
-    expect(component.imageReady).toBe(true);
+    expect(component.imageReady()).toBe(true);
   });
 
   it('should reset imageReady when media changes', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
+    fixture.componentRef.setInput('media', mockMedia);
+    TestBed.tick();
     component.onImageLoad();
-    expect(component.imageReady).toBe(true);
+    expect(component.imageReady()).toBe(true);
 
     const nextMedia = { ...mockMedia, id: 3, filename: 'next.png' };
-    component.media = nextMedia;
-    component.ngOnChanges({
-      media: { currentValue: nextMedia, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
-    });
-    expect(component.imageReady).toBe(false);
+    fixture.componentRef.setInput('media', nextMedia);
+    TestBed.tick();
+    expect(component.imageReady()).toBe(false);
   });
 
   // Regression: when MediaMetadataCacheService hydrates the stub into a
   // fully-typed Media for the same id, MediaStateService.selectedMedia returns
-  // a *new reference*, which used to retrigger this ngOnChanges body. That
+  // a *new reference*, which used to retrigger the media-change reset. That
   // flipped `imageReady` back to false while leaving `imageSrc` unchanged, so
   // Angular's property binding skipped the DOM write and no fresh (load) event
   // fired, leaving the canvas hidden behind `visibility: hidden`. The id
   // guard keeps the loaded state stable across enrichment events.
   it('should not reset imageReady when the media reference changes but id is the same', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
+    fixture.componentRef.setInput('media', mockMedia);
+    TestBed.tick();
     component.onImageLoad();
-    expect(component.imageReady).toBe(true);
+    expect(component.imageReady()).toBe(true);
 
     // Same id, new object reference (typical metadata-cache enrichment).
     const enriched: Media = { ...mockMedia, filename: 'real-name.png' };
-    component.media = enriched;
-    component.ngOnChanges({
-      media: { currentValue: enriched, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
-    });
-    expect(component.imageReady).toBe(true);
+    fixture.componentRef.setInput('media', enriched);
+    TestBed.tick();
+    expect(component.imageReady()).toBe(true);
   });
 
   it('should show image on error to avoid stuck black screen', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
-    expect(component.imageReady).toBe(false);
+    fixture.componentRef.setInput('media', mockMedia);
+    TestBed.tick();
+    expect(component.imageReady()).toBe(false);
 
     component.onImageError();
-    expect(component.imageReady).toBe(true);
+    expect(component.imageReady()).toBe(true);
   });
 
   it('should render image element', () => {
-    component.media = mockMedia;
-    component.imageSrc = '/api/medias/2/image';
+    fixture.componentRef.setInput('media', mockMedia);
     TestBed.tick();
     expect(fixture.nativeElement.querySelector('img')).toBeTruthy();
   });
@@ -197,21 +182,21 @@ describe('ImageViewerComponent', () => {
   });
 
   it('should reset view', () => {
-    component.zoom = 2;
-    component.rotation = 90;
+    component.zoom.set(2);
+    component.rotation.set(90);
     component.resetView();
-    expect(component.zoom).toBe(1);
-    expect(component.rotation).toBe(0);
+    expect(component.zoom()).toBe(1);
+    expect(component.rotation()).toBe(0);
   });
 
   it('should rotate left', () => {
     component.rotateLeft();
-    expect(component.rotation).toBe(-90);
+    expect(component.rotation()).toBe(-90);
   });
 
   it('should rotate right', () => {
     component.rotateRight();
-    expect(component.rotation).toBe(90);
+    expect(component.rotation()).toBe(90);
   });
 
   it('should generate transform string', () => {
@@ -233,7 +218,7 @@ describe('ImageViewerComponent', () => {
     function setupWrap(component: ImageViewerComponent) {
       component.renderedW.set(100);
       component.renderedH.set(100);
-      component.wrapRef = {
+      (component as unknown as { wrapRef: () => ElementRef<HTMLDivElement> }).wrapRef = () => ({
         nativeElement: {
           getBoundingClientRect: () => ({
             left: 0,
@@ -247,7 +232,7 @@ describe('ImageViewerComponent', () => {
             toJSON: () => ({}),
           }),
         } as unknown as HTMLDivElement,
-      } as ElementRef<HTMLDivElement>;
+      } as ElementRef<HTMLDivElement>);
     }
 
     function makeEvent(clientX: number, clientY: number): MouseEvent {
@@ -278,7 +263,7 @@ describe('ImageViewerComponent', () => {
 
     it('compensates for zoom: screen offsets shrink in image coords as zoom grows', () => {
       setupWrap(component);
-      component.zoom = 2;
+      component.zoom.set(2);
       // 25px right of centre at 2× zoom should be 12.5px in image coords =
       // 0.125 normalised, so image x = 0.625.
       const local = component.screenToImageNormalized(makeEvent(75, 50))!;
@@ -288,7 +273,7 @@ describe('ImageViewerComponent', () => {
 
     it('compensates for pan: translating the image shifts the inferred image coords', () => {
       setupWrap(component);
-      component.zoom = 2;
+      component.zoom.set(2);
       // Image translated 20px right; a click at screen 70 used to map to image
       // 0.7 at zoom 2 (50px = 0.5 + 20/100/2 * 2... see math). Concretely:
       // dx = 70 - 50 - 20 = 0; sx = 0; image x = 0.5.
@@ -300,7 +285,7 @@ describe('ImageViewerComponent', () => {
 
     it('inverts rotation: a click on the screen-right edge maps to the image-top edge at 90° CW', () => {
       setupWrap(component);
-      component.rotation = 90;
+      component.rotation.set(90);
       // Positive rotation rotates the image clockwise, so screen-right is image-top.
       const local = component.screenToImageNormalized(makeEvent(100, 50))!;
       expect(local.x).toBeCloseTo(0.5, 5);
@@ -318,7 +303,7 @@ describe('ImageViewerComponent', () => {
       // cursor (proportional to distance from centre, sign-flipping across it).
       component.renderedW.set(100);
       component.renderedH.set(100);
-      component.wrapRef = {
+      (component as unknown as { wrapRef: () => ElementRef<HTMLDivElement> }).wrapRef = () => ({
         nativeElement: {
           clientWidth: 100,
           clientHeight: 100,
@@ -334,7 +319,7 @@ describe('ImageViewerComponent', () => {
             toJSON: () => ({}),
           }),
         } as unknown as HTMLDivElement,
-      } as ElementRef<HTMLDivElement>;
+      } as ElementRef<HTMLDivElement>);
       // Visual centre is at (55, 55). A click 11 visual px right of centre is
       // 10 layout px → 0.1 normalised, so image x = 0.6, y stays 0.5.
       const local = component.screenToImageNormalized(makeEvent(66, 55))!;
@@ -344,10 +329,10 @@ describe('ImageViewerComponent', () => {
 
     it('combines pan + zoom + rotate self-consistently', () => {
       setupWrap(component);
-      component.zoom = 2;
+      component.zoom.set(2);
       component.panX.set(10);
       component.panY.set(-5);
-      component.rotation = 90;
+      component.rotation.set(90);
       // Map a couple of points and verify the transform is invertible:
       // taking two points on screen and rotating by the matching angle, the
       // image-coord differences should respect rotation (a screen-x delta
@@ -372,20 +357,20 @@ describe('ImageViewerComponent', () => {
   describe('region box coord stability', () => {
     it('does not mutate the box coords when zoom changes', () => {
       component.regionBox.set([0.1, 0.2, 0.5, 0.6]);
-      component.zoom = 2;
+      component.zoom.set(2);
       expect(component.regionBox()).toEqual([0.1, 0.2, 0.5, 0.6]);
-      component.zoom = 4;
+      component.zoom.set(4);
       expect(component.regionBox()).toEqual([0.1, 0.2, 0.5, 0.6]);
-      component.zoom = 1;
+      component.zoom.set(1);
       expect(component.regionBox()).toEqual([0.1, 0.2, 0.5, 0.6]);
     });
 
     it('keeps regionBoxStyle (percent-of-stage) stable across zoom changes', () => {
       component.regionBox.set([0.1, 0.2, 0.5, 0.6]);
       const before = component.regionBoxStyle;
-      component.zoom = 3;
+      component.zoom.set(3);
       expect(component.regionBoxStyle).toEqual(before);
-      component.rotation = 45;
+      component.rotation.set(45);
       expect(component.regionBoxStyle).toEqual(before);
     });
 
@@ -404,7 +389,7 @@ describe('ImageViewerComponent', () => {
     function setupWrap(component: ImageViewerComponent) {
       component.renderedW.set(100);
       component.renderedH.set(100);
-      component.wrapRef = {
+      (component as unknown as { wrapRef: () => ElementRef<HTMLDivElement> }).wrapRef = () => ({
         nativeElement: {
           getBoundingClientRect: () => ({
             left: 0,
@@ -418,7 +403,7 @@ describe('ImageViewerComponent', () => {
             toJSON: () => ({}),
           }),
         } as unknown as HTMLDivElement,
-      } as ElementRef<HTMLDivElement>;
+      } as ElementRef<HTMLDivElement>);
     }
 
     it('keeps the prior box when a Shift-click resolves to zero area', () => {
@@ -474,7 +459,7 @@ describe('ImageViewerComponent', () => {
     function setupWrap(component: ImageViewerComponent) {
       component.renderedW.set(100);
       component.renderedH.set(100);
-      component.wrapRef = {
+      (component as unknown as { wrapRef: () => ElementRef<HTMLDivElement> }).wrapRef = () => ({
         nativeElement: {
           getBoundingClientRect: () => ({
             left: 0,
@@ -488,7 +473,7 @@ describe('ImageViewerComponent', () => {
             toJSON: () => ({}),
           }),
         } as unknown as HTMLDivElement,
-      } as ElementRef<HTMLDivElement>;
+      } as ElementRef<HTMLDivElement>);
     }
 
     function mouseEventAt(x: number, y: number): MouseEvent {
@@ -559,7 +544,7 @@ describe('ImageViewerComponent', () => {
     function setupWrap(component: ImageViewerComponent) {
       component.renderedW.set(100);
       component.renderedH.set(100);
-      component.wrapRef = {
+      (component as unknown as { wrapRef: () => ElementRef<HTMLDivElement> }).wrapRef = () => ({
         nativeElement: {
           getBoundingClientRect: () => ({
             left: 0,
@@ -573,15 +558,15 @@ describe('ImageViewerComponent', () => {
             toJSON: () => ({}),
           }),
         } as unknown as HTMLDivElement,
-      } as ElementRef<HTMLDivElement>;
+      } as ElementRef<HTMLDivElement>);
     }
 
     it('starts off and flips on toggle', () => {
-      expect(component.marqueeMode).toBe(false);
+      expect(component.marqueeMode()).toBe(false);
       component.toggleMarqueeMode();
-      expect(component.marqueeMode).toBe(true);
+      expect(component.marqueeMode()).toBe(true);
       component.toggleMarqueeMode();
-      expect(component.marqueeMode).toBe(false);
+      expect(component.marqueeMode()).toBe(false);
     });
 
     it('reports regionDrawActive when either Shift is held or marquee is on', () => {
@@ -589,19 +574,19 @@ describe('ImageViewerComponent', () => {
       component.shiftHeld.set(true);
       expect(component.regionDrawActive).toBe(true);
       component.shiftHeld.set(false);
-      component.marqueeMode = true;
+      component.marqueeMode.set(true);
       expect(component.regionDrawActive).toBe(true);
     });
 
     it('shows a crosshair cursor when marquee mode is on', () => {
       expect(component.wrapCursor).not.toBe('crosshair');
-      component.marqueeMode = true;
+      component.marqueeMode.set(true);
       expect(component.wrapCursor).toBe('crosshair');
     });
 
     it('starts a draw-drag on mousedown when marquee mode is on (no Shift required)', () => {
       setupWrap(component);
-      component.marqueeMode = true;
+      component.marqueeMode.set(true);
 
       const ev: MouseEvent = {
         button: 0,
@@ -618,35 +603,35 @@ describe('ImageViewerComponent', () => {
     });
 
     it('persists across media changes', () => {
-      component.marqueeMode = true;
+      fixture.componentRef.setInput('media', mockMedia);
+      TestBed.tick();
+      component.marqueeMode.set(true);
       const next: Media = { ...mockMedia, id: 99, filename: 'b.png' };
-      component.media = next;
-      component.ngOnChanges({
-        media: { currentValue: next, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
-      });
-      expect(component.marqueeMode).toBe(true);
+      fixture.componentRef.setInput('media', next);
+      TestBed.tick();
+      expect(component.marqueeMode()).toBe(true);
     });
   });
 
   describe('best-match highlight overlay', () => {
     it('starts off and flips on toggle', () => {
-      expect(component.highlightMode).toBe(false);
+      expect(component.highlightMode()).toBe(false);
       component.toggleHighlightMode();
-      expect(component.highlightMode).toBe(true);
+      expect(component.highlightMode()).toBe(true);
       component.toggleHighlightMode();
-      expect(component.highlightMode).toBe(false);
+      expect(component.highlightMode()).toBe(false);
     });
 
     it('is not visible until both the toggle is on and a box is present', () => {
       expect(component.highlightVisible).toBe(false);
-      component.highlightMode = true;
+      component.highlightMode.set(true);
       expect(component.highlightVisible).toBe(false); // no box yet
-      component.highlightBox = [0.1, 0.2, 0.6, 0.7];
+      fixture.componentRef.setInput('highlightBox', [0.1, 0.2, 0.6, 0.7]);
       expect(component.highlightVisible).toBe(true);
     });
 
     it('positions the box as percent-of-stage', () => {
-      component.highlightBox = [0.1, 0.2, 0.6, 0.8];
+      fixture.componentRef.setInput('highlightBox', [0.1, 0.2, 0.6, 0.8]);
       expect(component.highlightBoxStyle).toEqual({
         left: '10.000%',
         top: '20.000%',
@@ -656,31 +641,31 @@ describe('ImageViewerComponent', () => {
     });
 
     it('rejects malformed, degenerate, and near-full-image boxes', () => {
-      component.highlightBox = null;
+      fixture.componentRef.setInput('highlightBox', null);
       expect(component.highlightBoxStyle).toBeNull();
-      component.highlightBox = [0.5, 0.5, 0.4, 0.6]; // x1 < x0 -> zero/negative width
+      fixture.componentRef.setInput('highlightBox', [0.5, 0.5, 0.4, 0.6]); // x1 < x0 -> zero/negative width
       expect(component.highlightBoxStyle).toBeNull();
-      component.highlightBox = [0, 0, 1, 1]; // whole-image fallback
+      fixture.componentRef.setInput('highlightBox', [0, 0, 1, 1]); // whole-image fallback
       expect(component.highlightBoxStyle).toBeNull();
-      component.highlightBox = [0, 0, NaN, 0.5];
+      fixture.componentRef.setInput('highlightBox', [0, 0, NaN, 0.5]);
       expect(component.highlightBoxStyle).toBeNull();
     });
 
     it('persists the toggle across media changes', () => {
-      component.highlightMode = true;
+      fixture.componentRef.setInput('media', mockMedia);
+      TestBed.tick();
+      component.highlightMode.set(true);
       const next: Media = { ...mockMedia, id: 77, filename: 'c.png' };
-      component.media = next;
-      component.ngOnChanges({
-        media: { currentValue: next, previousValue: mockMedia, firstChange: false, isFirstChange: () => false },
-      });
-      expect(component.highlightMode).toBe(true);
+      fixture.componentRef.setInput('media', next);
+      TestBed.tick();
+      expect(component.highlightMode()).toBe(true);
     });
   });
 
   describe('armed-confirm cancel routing', () => {
     it('emits armedConfirmCanceled instead of clearing the box when Esc is pressed while armed', () => {
       component.regionBox.set([0.1, 0.2, 0.5, 0.6]);
-      component.pendingBadConfirm = true;
+      fixture.componentRef.setInput('pendingBadConfirm', true);
       let canceled = false;
       let cleared = false;
       component.armedConfirmCanceled.subscribe(() => (canceled = true));
@@ -696,7 +681,7 @@ describe('ImageViewerComponent', () => {
 
     it('clears the box on Esc when no armed confirm is pending', () => {
       component.regionBox.set([0.1, 0.2, 0.5, 0.6]);
-      component.pendingBadConfirm = false;
+      fixture.componentRef.setInput('pendingBadConfirm', false);
       let emitted: RegionBox | null | undefined = undefined;
       component.regionBoxChange.subscribe((v) => (emitted = v));
       const esc = new KeyboardEvent('keydown', { key: 'Escape' });

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.spec.ts
@@ -39,7 +39,7 @@ describe('TextViewerComponent', () => {
   });
 
   it('should display loading initially', async () => {
-    // setInput drives ngOnChanges (the real channel), which kicks off the fetch.
+    // setInput drives the media-change effect (the real channel), which kicks off the fetch.
     fixture.componentRef.setInput('media', mockMedia);
     await settleZoneless(fixture);
     expect(fixture.nativeElement.textContent).toContain('Loading…');

--- a/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/text-viewer/text-viewer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, OnDestroy, signal, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, signal, untracked } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { MediasApiService } from '../../../services/medias-api.service';
 import { Media } from '../../../models/api.models';
@@ -10,10 +10,10 @@ import { Media } from '../../../models/api.models';
   templateUrl: './text-viewer.component.html',
   styleUrl: './text-viewer.component.scss',
 })
-export class TextViewerComponent implements OnChanges, OnDestroy {
+export class TextViewerComponent implements OnDestroy {
   private mediasApi = inject(MediasApiService);
 
-  @Input() media!: Media;
+  readonly media = input.required<Media>();
 
   // Signal so the HTTP response (written from a `.subscribe()` callback, which is
   // not on the zoneless CD-notification path) repaints the view.
@@ -23,21 +23,23 @@ export class TextViewerComponent implements OnChanges, OnDestroy {
   // every time the metadata cache hydrates a new reference for the same id.
   private lastMediaId: number | null = null;
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media && this.media.id !== this.lastMediaId) {
-      this.lastMediaId = this.media.id;
-      this.loadText();
-    }
+  constructor() {
+    effect(() => {
+      const media = this.media();
+      if (media.id === this.lastMediaId) return;
+      this.lastMediaId = media.id;
+      untracked(() => this.loadText(media.id));
+    });
   }
 
   ngOnDestroy(): void {
     this.sub?.unsubscribe();
   }
 
-  private loadText(): void {
+  private loadText(mediaId: number): void {
     this.sub?.unsubscribe();
     this.text.set('Loading…');
-    this.sub = this.mediasApi.getText(this.media.id).subscribe({
+    this.sub = this.mediasApi.getText(mediaId).subscribe({
       next: (data) => {
         this.text.set(data.content || '');
       },

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.html
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.html
@@ -2,17 +2,17 @@
   #videoEl
   controls
   loop
-  [src]="videoSrc"
-  [attr.aria-label]="media.filename || 'Video media'"
+  [src]="videoSrc()"
+  [attr.aria-label]="media().filename || 'Video media'"
   class="video-element"
-  [class.hidden]="videoError"
+  [class.hidden]="videoError()"
   (loadedmetadata)="onLoadedMetadata()"
   (timeupdate)="onTimeUpdate()"
   (play)="onPlay()"
   (pause)="onPause()"
   (error)="onError()"
 ></video>
-@if (videoError) {
+@if (videoError()) {
   <div class="video-error">
     <span class="error-icon" title="Video format error">&#9888;</span>
     <span>Video cannot be played. If the format requires transcoding, install ffmpeg on the server.</span>

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.spec.ts
@@ -1,4 +1,3 @@
-import { ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VideoPlayerComponent } from './video-player.component';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -32,11 +31,9 @@ describe('VideoPlayerComponent', () => {
   });
 
   it('should set videoSrc when media changes', () => {
-    component.media = mockMedia;
-    component.ngOnChanges({
-      media: { currentValue: mockMedia, previousValue: null, firstChange: true, isFirstChange: () => true },
-    });
-    expect(component.videoSrc).toBe('/api/medias/3/video');
+    fixture.componentRef.setInput('media', mockMedia);
+    TestBed.tick();
+    expect(component.videoSrc()).toBe('/api/medias/3/video');
   });
 
   it('should render video element', async () => {
@@ -48,41 +45,33 @@ describe('VideoPlayerComponent', () => {
     expect(video.hasAttribute('loop')).toBe(true);
   });
 
-  it('seeks into the clip window when clip extents arrive after the video loaded', () => {
+  it('seeks into the clip window when clip extents arrive after the video loaded', async () => {
     // A clipped media first renders as a stub (no clip_start/clip_end), so the
     // (loadedmetadata) event fires before the extents are known. The batch
     // response then enriches the same media id with clip_start/clip_end on a
-    // later ngOnChanges. The player must snap into the window at that point.
-    const fakeVideo = {
-      volume: 0,
-      currentTime: 0,
-      paused: true,
-      play: () => Promise.resolve(),
-      pause: () => {},
-      // ngOnDestroy tears the element down via removeAttribute('src')/load();
-      // the stub needs both so cleanup doesn't throw.
-      removeAttribute: () => {},
-      load: () => {},
-    } as unknown as HTMLVideoElement;
-    component.videoRef = { nativeElement: fakeVideo } as ElementRef<HTMLVideoElement>;
-
+    // later change of the `media` input. The player must snap into the window
+    // at that point.
     const stub: Media = { id: 7, media_type: 'video', filename: 'clip.mp4', md5: 'abc', custom_metadata: {} };
-    component.media = stub;
-    component.ngOnChanges({
-      media: { currentValue: stub, previousValue: null, firstChange: true, isFirstChange: () => true },
+    fixture.componentRef.setInput('media', stub);
+    await settleZoneless(fixture);
+
+    // jsdom has no media pipeline; give the real element a working currentTime.
+    const video: HTMLVideoElement = fixture.nativeElement.querySelector('video');
+    let currentTime = 0;
+    Object.defineProperty(video, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (v: number) => (currentTime = v),
     });
+
     // Video loads against the stub: no clip window yet, so no seek.
     component.onLoadedMetadata();
-    expect(fakeVideo.currentTime).toBe(0);
+    expect(video.currentTime).toBe(0);
 
     // Batch hydration delivers the clip extents for the same id.
     const hydrated: Media = { ...stub, clip_start: 5, clip_end: 10 };
-    component.media = hydrated;
-    component.ngOnChanges({
-      media: { currentValue: hydrated, previousValue: stub, firstChange: false, isFirstChange: () => false },
-    });
-    expect(fakeVideo.currentTime).toBe(5);
-
-    component.ngOnDestroy();
+    fixture.componentRef.setInput('media', hydrated);
+    await settleZoneless(fixture);
+    expect(video.currentTime).toBe(5);
   });
 });

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, input, OnChanges, OnDestroy, output, SimpleChanges, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, OnDestroy, output, signal, untracked, viewChild } from '@angular/core';
 
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
@@ -11,59 +11,80 @@ import { ActiveContextService } from '../../../services/active-context.service';
   templateUrl: './video-player.component.html',
   styleUrl: './video-player.component.scss',
 })
-export class VideoPlayerComponent implements OnChanges, OnDestroy {
+export class VideoPlayerComponent implements OnDestroy {
   private activeContext = inject(ActiveContextService);
 
-  @Input() media!: Media;
+  readonly media = input.required<Media>();
   readonly volume = input(1);
   readonly audioPlaying = input(true);
   readonly playingChanged = output<boolean>();
 
-  @ViewChild('videoEl') videoRef!: ElementRef<HTMLVideoElement>;
+  // Public: CenterPanelComponent reaches through this to pause/resume the
+  // native element on navigation / tab-visibility changes.
+  readonly videoRef = viewChild<ElementRef<HTMLVideoElement>>('videoEl');
 
-  videoSrc = '';
-  videoError = false;
+  // Signals: written from the media-change effect below (videoSrc) and read in
+  // the template, so plain fields would leave the view stale under zoneless.
+  readonly videoSrc = signal('');
+  readonly videoError = signal(false);
 
   // Active clip window bounds while enforcement is on, else null. Enforcement is
   // driven by the <video> element's (timeupdate) event rather than a polling
   // timer, so it only runs while the clip is actually playing and progressing.
   private clipBounds: { start: number; end: number } | null = null;
   // See ImageViewerComponent.lastMediaId; guards against metadata-enrichment
-  // ngOnChanges cycles rebuilding videoSrc (and yanking playback) for the
+  // effect cycles rebuilding videoSrc (and yanking playback) for the
   // same id.
   private lastMediaId: number | null = null;
   // Whether (loadedmetadata) has fired for the current videoSrc. Clip bounds
   // (clip_start/clip_end) often arrive via batch hydration *after* the video
-  // has already loaded, on a later ngOnChanges with the same media id; in that
+  // has already loaded, on a later media change with the same media id; in that
   // case (loadedmetadata) does not fire again, so we (re)apply the bounds here.
   private metadataLoaded = false;
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['media'] && this.media) {
-      if (this.media.id !== this.lastMediaId) {
-        this.lastMediaId = this.media.id;
-        this.videoError = false;
+  constructor() {
+    // Point the element at the new clip when the media id changes; re-apply
+    // clip bounds on same-id metadata enrichment. The src rides a template
+    // binding, so no view-query dependency is needed here.
+    effect(() => {
+      const media = this.media();
+      if (media.id !== this.lastMediaId) {
+        this.lastMediaId = media.id;
+        this.videoError.set(false);
         this.metadataLoaded = false;
         this.stopClipEnforcement();
-        this.videoSrc = this.activeContext.mediaUrl(`/api/medias/${this.media.id}/video`);
+        this.videoSrc.set(this.activeContext.mediaUrl(`/api/medias/${media.id}/video`));
       } else if (this.metadataLoaded) {
         // Same media id, but metadata (e.g. clip_start/clip_end) may have just
         // arrived via batch hydration. The video already loaded, so
         // (loadedmetadata) won't fire again; apply the clip window now.
-        this.applyClipBounds();
+        untracked(() => this.applyClipBounds());
       }
-    }
-    if (changes['volume'] && this.videoRef?.nativeElement) {
-      this.videoRef.nativeElement.volume = this.volume();
-    }
-    if (changes['audioPlaying'] && !changes['media'] && this.videoRef?.nativeElement) {
-      this.syncPlaybackState();
-    }
+    });
+
+    // Push volume changes onto the element. The element is read untracked so
+    // this runs only when the volume actually changes, mirroring the old
+    // `changes['volume']` guard; the initial volume is applied by
+    // (loadedmetadata), as before.
+    effect(() => {
+      const vol = this.volume();
+      const video = untracked(this.videoRef)?.nativeElement;
+      if (video) video.volume = vol;
+    });
+
+    // Play/pause the element when the parent toggles `audioPlaying`. Untracked
+    // element read for the same reason: a media swap must not re-trigger this
+    // (the old code's `!changes['media']` guard) — the post-load sync happens
+    // in (loadedmetadata) instead.
+    effect(() => {
+      this.audioPlaying();
+      if (untracked(this.videoRef)) untracked(() => this.syncPlaybackState());
+    });
   }
 
   ngOnDestroy(): void {
     this.stopClipEnforcement();
-    const video = this.videoRef?.nativeElement;
+    const video = this.videoRef()?.nativeElement;
     if (video) {
       video.pause();
       video.removeAttribute('src');
@@ -78,7 +99,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   }
 
   onError(): void {
-    this.videoError = true;
+    this.videoError.set(true);
   }
 
   onPause(): void {
@@ -88,7 +109,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   }
 
   togglePlayback(): void {
-    const video = this.videoRef?.nativeElement;
+    const video = this.videoRef()?.nativeElement;
     if (!video) return;
     if (video.paused) {
       video.play().catch(() => {});
@@ -98,13 +119,13 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   }
 
   adjustVolume(delta: number): void {
-    const video = this.videoRef?.nativeElement;
+    const video = this.videoRef()?.nativeElement;
     if (!video) return;
     video.volume = Math.max(0, Math.min(1, video.volume + delta));
   }
 
   onLoadedMetadata(): void {
-    const video = this.videoRef?.nativeElement;
+    const video = this.videoRef()?.nativeElement;
     if (!video) return;
     this.metadataLoaded = true;
     video.volume = this.volume();
@@ -114,14 +135,15 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
 
   // Seek into the clip window and (re)start boundary enforcement when the media
   // carries clip extents; otherwise tear enforcement down. Safe to call both on
-  // (loadedmetadata) and on later metadata-enrichment ngOnChanges cycles.
+  // (loadedmetadata) and on later metadata-enrichment effect cycles.
   private applyClipBounds(): void {
-    const video = this.videoRef?.nativeElement;
+    const video = this.videoRef()?.nativeElement;
     if (!video) return;
 
-    if (this.media?.clip_start != null) {
-      const clipStart = this.media.clip_start;
-      const clipEnd = this.media.clip_end;
+    const media = this.media();
+    if (media.clip_start != null) {
+      const clipStart = media.clip_start;
+      const clipEnd = media.clip_end;
       // Snap into the window only when currently outside it. This handles the
       // initial seek and the case where the full video already started playing
       // before clip extents arrived, without yanking a video already looping
@@ -136,13 +158,14 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   }
 
   private startClipEnforcement(): void {
-    if (this.media?.clip_start == null || this.media?.clip_end == null) {
+    const media = this.media();
+    if (media.clip_start == null || media.clip_end == null) {
       this.clipBounds = null;
       return;
     }
     // Arm enforcement; the actual boundary check runs in (timeupdate), which the
     // <video> element fires as playback advances (no timer while paused).
-    this.clipBounds = { start: this.media.clip_start, end: this.media.clip_end };
+    this.clipBounds = { start: media.clip_start, end: media.clip_end };
   }
 
   private stopClipEnforcement(): void {
@@ -155,7 +178,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   onTimeUpdate(): void {
     const bounds = this.clipBounds;
     if (!bounds) return;
-    const video = this.videoRef?.nativeElement;
+    const video = this.videoRef()?.nativeElement;
     if (!video || video.paused) return;
     if (video.currentTime >= bounds.end || video.currentTime < bounds.start) {
       video.currentTime = bounds.start;
@@ -163,7 +186,7 @@ export class VideoPlayerComponent implements OnChanges, OnDestroy {
   }
 
   private syncPlaybackState(): void {
-    const video = this.videoRef?.nativeElement;
+    const video = this.videoRef()?.nativeElement;
     if (!video) return;
     const audioPlaying = this.audioPlaying();
     if (audioPlaying && video.paused) {


### PR DESCRIPTION
Closes #2549

Converts the six center-panel media viewer components to signal-based authoring: decorator `@Input`/`@ViewChild` → `input()`/`input.required()`/`viewChild()`, with every `ngOnChanges` body moved into constructor `effect()`s keyed off the (now-signal) inputs and view queries. The regression-sensitive guards are preserved: the same-media-id short-circuits (metadata-cache hydration must not re-load / snap playback to t=0), the post-`loadedmetadata` clip-bounds re-application, and the volume-restore behavior.

## Per component

- **audio-player** — the mixed decorator/signal inputs are unified. The imperative media control now runs via three effects: media+view-query load (tracks the view query so the first load fires when the `<audio>` element resolves), volume push, and playback sync. The latter two read the element `untracked`, mirroring the old `changes['volume']` / `!changes['media']` guards so a media swap can't re-trigger them. A `linkedSignal` mirrors element-driven volume changes (native slider, keyboard) so later loads restore the user's last-set volume while a new `volume` input still resets it.
- **video-player** — same effect trio; `videoSrc`/`videoError` are signals.
- **image-viewer** — media-change effect resets the viewport; `imageSrc`/`imageReady` are signals. Also signalizes `zoom`/`rotation`/`zoomLabel` (now a `computed`), `marqueeMode`, and `highlightMode`: these are written from the parent's toolbar clicks and the keyboard-shortcut subscription, so as plain fields on an OnPush view the toolbar/keyboard **zoom and rotate buttons left the image transform stale** until an unrelated repaint. This staleness reproduces on `dev` pre-migration (verified against an `origin/dev` build in a real browser), so it is a pre-existing bug fixed in passing, not a migration regression.
- **text-viewer / document-viewer** — media-change effects with the same id guard; document `mediaSrc` is a signal.
- **center-panel** — `media` is `input()`, the three player queries are `viewChild()`; the media-change reset runs in an effect; the template aliases the `media`/`imageViewer` signals. The image-view-controls NG0100 spec workaround (`detectChanges(false)`) is gone — the signal view query schedules a clean follow-up pass.

Specs are rewritten off manual `ngOnChanges(...)` calls and direct view-ref assignment onto `setInput` + `TestBed.tick()` and real rendered elements (with `Object.defineProperty` stubs for jsdom's missing `currentTime`).

## Verification

- `./run-tests.sh` fully green: ruff/codespell/deptry/pip-audit/pyright, frontend `build:prod` with no warnings, `npm audit` clean, all 1684 Vitest tests, all 6401 Python tests.
- **Manual smoke in real Chromium** against the running app with fixture datasets of all five media types, 26/26 checks green: audio object-URL load, autoplay, waveform render, keyboard volume up/down reaching the element, Space pause/resume, seek holding, item navigation swapping to a fresh object URL with volume surviving and playback continuing (no double-load / stuck-play); video src binding, decode+autoplay, pause/resume, volume; image load, toolbar zoom, keyboard zoom, rotate, controls toolbar rendering off the view-query signal; text fetch + re-fetch on navigation; document embed URL + PDF bytes served.

No doc screenshots frame a changed visual (the zoom fix is behavioral), so nothing was added to the reshoot queue; the 6 pre-existing queued reshoots were left alone since the smoke app ran with stubbed embedders and smoke datasets that would pollute dashboard-framed shots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFAE9dBeUioPSKCJSkB6JH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFAE9dBeUioPSKCJSkB6JH)_