### PR TITLE
Offer optional convert-in target (e.g. Face) in demo-dataset picker

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -189,6 +189,9 @@ describe('DatasetImporterModalComponent', () => {
         req.url === '/api/dataset/demo-list' && req.params.get('embedder') === embedders[0].name,
       ).flush({ datasets: mockDemos });
     }
+    httpMock.expectOne(req =>
+      req.url === '/api/converters' && req.params.get('source') === tab,
+    ).flush({ converters: [] });
   }
 
   /** Open the demo picker and flush the always-issued requests.  Opening
@@ -949,5 +952,9 @@ describe('DatasetImporterModalComponent', () => {
     );
     expect(refetchReq.request.method).toBe('GET');
     refetchReq.flush({ datasets: mockDemos });
+
+    httpMock.expectOne(req =>
+      req.url === '/api/converters' && req.params.get('source') === 'audio',
+    ).flush({ converters: [] });
   });
 });

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.html
@@ -10,15 +10,24 @@
   />
 </div>
 
-@if (activeTabConvertsTo().length > 1) {
+@if (activeTabConvertsToOptional() ? activeTabConvertsTo().length > 0 : activeTabConvertsTo().length > 1) {
   <div class="form-group">
-    <label class="form-label" for="demo-convert-target" title="This media type isn't embeddable on its own; pick what to convert it into on load.">Convert to</label>
+    <label
+      class="form-label"
+      for="demo-convert-target"
+      [title]="activeTabConvertsToOptional()
+        ? 'Optionally convert this media into another type on load (e.g. crop faces out of images).'
+        : 'This media type isn\'t embeddable on its own; pick what to convert it into on load.'"
+    >Convert to</label>
     <select
       id="demo-convert-target"
       class="form-input"
       [ngModel]="selectedConverterTarget()"
       (ngModelChange)="onConverterTargetChange($event)"
     >
+      @if (activeTabConvertsToOptional()) {
+        <option value="">{{ mediaTypeLabels[activeTab()] || activeTab() }} (no conversion)</option>
+      }
       @for (t of activeTabConvertsTo(); track t) {
         <option [value]="t">{{ mediaTypeLabels[t] || t }}</option>
       }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.spec.ts
@@ -39,6 +39,7 @@ describe('DemoPickerComponent', () => {
     httpMock.expectOne(req => req.url === '/api/embedders' && req.params.get('media_type') === 'audio').flush({ embedders: [{ name: 'clap' }] });
     httpMock.expectOne(req => req.url === '/api/clippers' && req.params.get('media_type') === 'audio').flush({ clippers: [] });
     httpMock.expectOne(req => req.url === '/api/dataset/demo-list' && req.params.get('embedder') === 'clap').flush({ datasets: mockDemos });
+    httpMock.expectOne(req => req.url === '/api/converters' && req.params.get('source') === 'audio').flush({ converters: [] });
   }
 
   it('open() fetches media types + demos and auto-selects the audio tab', () => {
@@ -78,5 +79,35 @@ describe('DemoPickerComponent', () => {
     component.demoDatasetSelected.subscribe(() => (emitted = true));
     component.submit();
     expect(emitted).toBe(false);
+  });
+
+  it('offers an optional "Convert to" target (e.g. Face) for an embeddable tab with a registered converter', () => {
+    openAndFlush();
+
+    component.selectDemoTabWithEmbedder('image');
+    httpMock.expectOne(req => req.url === '/api/embedders' && req.params.get('media_type') === 'image').flush({ embedders: [{ name: 'siglip' }] });
+    httpMock.expectOne(req => req.url === '/api/clippers' && req.params.get('media_type') === 'image').flush({ clippers: [] });
+    httpMock.expectOne(req => req.url === '/api/dataset/demo-list' && req.params.get('embedder') === 'siglip').flush({ datasets: mockDemos });
+    httpMock.expectOne(req => req.url === '/api/converters' && req.params.get('source') === 'image')
+      .flush({ converters: [{ name: 'image2face', source_type: 'image', target_type: 'face' }] });
+
+    expect(component.activeTabConvertsToOptional()).toBe(true);
+    expect(component.activeTabConvertsTo()).toEqual(['face']);
+    expect(component.selectedConverterTarget()).toBe('');
+
+    component.onConverterTargetChange('face');
+    httpMock.expectOne(req => req.url === '/api/embedders' && req.params.get('media_type') === 'face').flush({ embedders: [{ name: 'face' }] });
+    httpMock.expectOne(req => req.url === '/api/clippers' && req.params.get('media_type') === 'face').flush({ clippers: [] });
+    httpMock.expectOne(req => req.url === '/api/dataset/demo-list' && req.params.get('embedder') === 'face').flush({ datasets: mockDemos });
+
+    expect(component.selectedConverterTarget()).toBe('face');
+
+    component.selectDemo(mockDemos[0] as any);
+    let payload: any = null;
+    component.demoDatasetSelected.subscribe((d) => (payload = d));
+    component.submit();
+
+    expect(payload.converter).toBe('image2face');
+    expect(payload.embedder).toBe('face');
   });
 });

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.ts
@@ -65,11 +65,19 @@ export class DemoPickerComponent {
   readonly selectedDemoClipper = signal('');
   readonly demoClipperParamValues = signal<Record<string, number | string>>({});
   /** For a *convert-out* half-type tab (e.g. ``document``), the embeddable
-   *  targets it can convert into (``converts_to``). Empty for a normal
-   *  embeddable tab. Drives the "Convert to" selector. */
+   *  targets it can convert into (``converts_to``); for a directly
+   *  embeddable tab (e.g. ``image``), the *optional* convert-in targets
+   *  reachable via a registered converter (e.g. ``face``, via
+   *  ``image2face``). Empty when there's nothing to convert into either
+   *  way. Drives the "Convert to" selector. */
   readonly activeTabConvertsTo = signal<string[]>([]);
+  /** Whether ``activeTabConvertsTo`` represents an *optional* conversion
+   *  (the tab's own type is directly embeddable and stays selectable as
+   *  "no conversion") vs. a *mandatory* one (a convert-out half type that
+   *  must pick one of the listed targets). */
+  readonly activeTabConvertsToOptional = signal(false);
   /** The chosen embeddable target type for a non-embeddable tab (e.g.
-   *  ``image``), or ``''`` for a normal tab. */
+   *  ``image``), or ``''`` for a normal tab or "no conversion" selected. */
   readonly selectedConverterTarget = signal('');
   /** The convert-on-load converter name (e.g. ``document2image``), or ``''``
    *  when the active tab is directly embeddable. Passed to demo-list status
@@ -237,18 +245,33 @@ export class DemoPickerComponent {
       this.selectedDemoClipper.set('');
       this.demoClipperParamValues.set({});
       this.activeTabConvertsTo.set([]);
+      this.activeTabConvertsToOptional.set(false);
       this.selectedConverterTarget.set('');
       this.selectedDemoConverter.set('');
       return;
     }
     // A *convert-out* half type (document: embeddable === false) has no
     // embedder of its own — its demos load through a converter to an
-    // embeddable target (converts_to). Offer those targets and load the
-    // embedder/clipper choices for the (default) target instead.
+    // embeddable target (converts_to), and one of them must be picked.
     const info = this.mediaTypeInfo(mediaType);
-    const convertsTo = info && info.embeddable === false ? info.converts_to || [] : [];
-    this.activeTabConvertsTo.set(convertsTo);
-    this.applyConverterTarget(mediaType, convertsTo.length ? convertsTo[0] : '');
+    if (info && info.embeddable === false) {
+      const convertsTo = info.converts_to || [];
+      this.activeTabConvertsTo.set(convertsTo);
+      this.activeTabConvertsToOptional.set(false);
+      this.applyConverterTarget(mediaType, convertsTo.length ? convertsTo[0] : '');
+      return;
+    }
+    // A directly embeddable tab (e.g. image) may still have registered
+    // converters reading from it (e.g. image2face). Offer those as an
+    // *optional* "Convert to" choice, defaulting to no conversion.
+    this.activeTabConvertsToOptional.set(true);
+    this.applyConverterTarget(mediaType, '');
+    this.datasetsListingsApi.getConvertersForSource(mediaType).subscribe({
+      next: (converters) => {
+        const targets = Array.from(new Set(converters.map((c) => c.target_type))).filter((t) => t !== mediaType);
+        this.activeTabConvertsTo.set(targets);
+      },
+    });
   }
 
   /** Set the convert-on-load target for the active tab and (re)load the

--- a/frontend/src/app/services/datasets-listings-api.service.ts
+++ b/frontend/src/app/services/datasets-listings-api.service.ts
@@ -53,6 +53,12 @@ export class DatasetsListingsApiService {
     );
   }
 
+  getConvertersForSource(source: string): Observable<ConverterInfo[]> {
+    return convertersList(this.http, this.config.rootUrl, { source }).pipe(
+      map((r) => r.body.converters as unknown as ConverterInfo[]),
+    );
+  }
+
   getDemoList(embedder?: string, clipper?: string, converter?: string): Observable<DemoDatasetListResponse> {
     return demoDatasetList(this.http, this.config.rootUrl, { embedder, clipper, converter }).pipe(
       map((r) => r.body),


### PR DESCRIPTION
## Summary
- The demo-dataset picker's "Convert to" selector previously only handled *convert-out* half types (e.g. `document` → image/text). A directly embeddable demo tab like the VGGFace2 image demos had no way to route through a registered converter (`image2face`) into a different embedder (FaceNet); it silently loaded with the tab's default embedder (SigLIP) instead.
- `DemoPickerComponent.loadDemoEmbedders()` now also queries registered converters for an embeddable tab's source type (via the existing `GET /api/converters?source=...` endpoint) and offers them as an *optional* "Convert to" choice, defaulting to no conversion. Picking a target (e.g. Face) re-points the embedder/clipper lookups and the load payload's `converter` field at that target, exactly like the existing mandatory convert-out flow.
- No backend changes were needed — `list_converters_for_source`, the `/api/converters?source=` query param, and the demo importer's `converter`/`embedder` overrides already existed and worked correctly; this PR only wires the frontend picker to use them.

## Test plan
- [x] `cd frontend && npx ng test --watch=false` — all 1685 tests pass, including a new test verifying the "Convert to Face" flow (converter selection → embedder refetch → submitted payload has `converter: "image2face"`, `embedder: "face"`).
- [x] `./run-tests.sh` — full suite passes (6401 passed, 1 skipped, 1 xfailed).
- [x] Updated existing specs (`demo-picker.component.spec.ts`, `dataset-importer-modal.component.spec.ts`) to flush the new `GET /api/converters?source=<tab>` request fired whenever a demo media-type tab is selected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VeBhGfJQ5UFTnS8FV2KznU)_