### PR TITLE
Add playhead sweep + click-to-seek to audio Now Playing waveform

### DIFF
--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.html
@@ -1,12 +1,23 @@
 <div class="waveform-swipe-wrapper" [class]="swipeClass()">
-  <canvas
-    #waveformCanvas
-    class="waveform-canvas"
-    width="600"
-    height="120"
-    role="img"
-    aria-label="Audio waveform visualization"
-  ></canvas>
+  <div
+    class="waveform-stage"
+    (pointerdown)="onSeekPointerDown($event)"
+    (pointermove)="onSeekPointerMove($event)"
+    (pointerup)="onSeekPointerUp($event)"
+    (pointercancel)="onSeekPointerUp($event)"
+  >
+    <canvas
+      #waveformCanvas
+      class="waveform-canvas"
+      width="600"
+      height="120"
+      role="img"
+      aria-label="Audio waveform visualization"
+    ></canvas>
+    @if (playheadVisible()) {
+      <div class="waveform-playhead" [style.left.%]="playheadFraction() * 100"></div>
+    }
+  </div>
 </div>
 <audio
   #audioEl

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.scss
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.scss
@@ -34,11 +34,37 @@
   opacity: 0;
 }
 
+// Positioned container so the playhead can be absolutely overlaid on the
+// waveform. `cursor: pointer` advertises that the waveform is click-to-seek.
+.waveform-stage {
+  position: relative;
+  width: 100%;
+  display: flex;
+  cursor: pointer;
+  // The playhead line spills to the canvas edges; clip it to the rounded corners.
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
 .waveform-canvas {
   width: 100%;
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
   background: var(--bg-surface);
+}
+
+// Thin vertical line swept left->right as playback advances. Positioned by a
+// `left: %` binding driven off currentTime/duration on a rAF loop. Never
+// intercepts the stage's seek pointer events.
+.waveform-playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  margin-left: -1px;
+  background: var(--waveform-playhead);
+  pointer-events: none;
+  will-change: left;
 }
 
 .audio-element {

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.spec.ts
@@ -117,4 +117,92 @@ describe('AudioPlayerComponent', () => {
     await settleZoneless(fixture);
     expect(audio.currentTime).toBe(12);
   });
+
+  // Give the real <audio> element a mutable currentTime and a fixed duration,
+  // since jsdom exposes neither a working media clock nor metadata.
+  function stubClock(audio: HTMLAudioElement, duration: number): { set: (t: number) => void } {
+    let currentTime = 0;
+    Object.defineProperty(audio, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (v: number) => (currentTime = v),
+    });
+    Object.defineProperty(audio, 'duration', { configurable: true, get: () => duration });
+    Object.defineProperty(audio, 'paused', { configurable: true, get: () => true });
+    return { set: (t: number) => (currentTime = t) };
+  }
+
+  it('positions the playhead at currentTime/duration once metadata is known', async () => {
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
+
+    const audio: HTMLAudioElement = fixture.nativeElement.querySelector('audio');
+    const clock = stubClock(audio, 10);
+
+    // Before metadata, the line is hidden (no meaningful position yet).
+    expect(component.playheadVisible()).toBe(false);
+
+    component.onLoadedMetadata();
+    expect(component.playheadVisible()).toBe(true);
+    expect(component.playheadFraction()).toBe(0);
+
+    // A later (timeupdate) advances the fraction.
+    clock.set(2.5);
+    component.onTimeUpdate();
+    expect(component.playheadFraction()).toBeCloseTo(0.25, 5);
+  });
+
+  it('seeks to the clicked fraction of the waveform', async () => {
+    fixture.componentRef.setInput('media', mockMedia);
+    await settleZoneless(fixture);
+
+    const audio: HTMLAudioElement = fixture.nativeElement.querySelector('audio');
+    stubClock(audio, 10);
+    component.onLoadedMetadata();
+
+    const canvas: HTMLCanvasElement = fixture.nativeElement.querySelector('canvas');
+    vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+      left: 100,
+      width: 200,
+      top: 0,
+      right: 300,
+      bottom: 120,
+      height: 120,
+      x: 100,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    // Click at x=250 -> (250-100)/200 = 0.75 of a 10s clip -> 7.5s.
+    component.onSeekPointerDown({ button: 0, clientX: 250, pointerId: 1, currentTarget: null, preventDefault: () => {} } as unknown as PointerEvent);
+    expect(audio.currentTime).toBeCloseTo(7.5, 5);
+    expect(component.playheadFraction()).toBeCloseTo(0.75, 5);
+  });
+
+  it('clamps a click-seek into the clip window for a windowed clip', async () => {
+    const clip: Media = { ...mockMedia, id: 5, clip_start: 3, clip_end: 6 };
+    fixture.componentRef.setInput('media', clip);
+    await settleZoneless(fixture);
+
+    const audio: HTMLAudioElement = fixture.nativeElement.querySelector('audio');
+    stubClock(audio, 10);
+    component.onLoadedMetadata();
+
+    const canvas: HTMLCanvasElement = fixture.nativeElement.querySelector('canvas');
+    vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      width: 100,
+      top: 0,
+      right: 100,
+      bottom: 120,
+      height: 120,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    // Click at the far right (fraction ~0.9 -> 9s) is clamped to clip_end (6s).
+    component.onSeekPointerDown({ button: 0, clientX: 90, pointerId: 1, currentTarget: null, preventDefault: () => {} } as unknown as PointerEvent);
+    expect(audio.currentTime).toBe(6);
+  });
 });

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, linkedSignal, OnDestroy, output, untracked, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, linkedSignal, OnDestroy, output, signal, untracked, viewChild } from '@angular/core';
 import { Media } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { decodeAudioBuffer } from '../../../utils/decode-audio';
@@ -88,6 +88,21 @@ export class AudioPlayerComponent implements OnDestroy {
   // back into it so later loads restore the user's last-set volume.
   private readonly currentVolume = linkedSignal(() => this.volume());
 
+  // Playhead sweep state. `playheadFraction` is currentTime/duration in [0, 1];
+  // the template binds it to the overlay line's `left: %`. `playheadVisible`
+  // gates rendering until a finite duration is known (the line has no meaningful
+  // position before (loadedmetadata)). Both are driven imperatively: on a
+  // requestAnimationFrame loop while playing (see startSweep) -- (timeupdate)
+  // fires only ~4x/sec, too coarse for a smooth sweep -- and on demand after a
+  // seek or pause.
+  readonly playheadFraction = signal(0);
+  readonly playheadVisible = signal(false);
+  // Handle of the in-flight rAF sweep tick, or null when the loop is stopped.
+  private sweepRaf: number | null = null;
+  // True while a scrub gesture (pointerdown on the waveform) is in progress, so
+  // (pointermove) seeks continuously until pointerup.
+  private scrubbing = false;
+
   // Current object URL feeding the <audio> element (`blob:...`), or '' before
   // the first load. Set imperatively on the native element (not via a template
   // binding) because it's produced asynchronously after the fetch, and the app
@@ -154,6 +169,7 @@ export class AudioPlayerComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.stopClipEnforcement();
+    this.stopSweep();
     this.waveformAbort?.abort();
     this.waveformAbort = null;
     const audio = this.audioRef()?.nativeElement;
@@ -172,6 +188,10 @@ export class AudioPlayerComponent implements OnDestroy {
     audio.volume = this.currentVolume();
     this.applyClipBounds();
     this.syncPlaybackState();
+    // Duration is now known: place the playhead at the current position and, if
+    // playback is already running, start the sweep loop.
+    this.updatePlayhead();
+    if (!audio.paused) this.startSweep();
   }
 
   // Seek into the clip window and (re)start boundary enforcement when the media
@@ -215,6 +235,12 @@ export class AudioPlayerComponent implements OnDestroy {
   // [start, end), loop back to the window start. Driven by the element's
   // (timeupdate) event instead of a 100ms polling interval.
   onTimeUpdate(): void {
+    // Refresh the playhead first, unconditionally: (timeupdate) is the coarse
+    // (~4x/sec) fallback that keeps the line moving when the rAF sweep isn't
+    // running (headless env, or a background tab that throttles rAF), and it
+    // must run whether or not this clip has a window to enforce.
+    this.updatePlayhead();
+
     const bounds = this.clipBounds;
     if (!bounds) return;
     const audio = this.audioRef()?.nativeElement;
@@ -232,12 +258,17 @@ export class AudioPlayerComponent implements OnDestroy {
   }
 
   onPlay(): void {
+    this.startSweep();
     if (!this.audioPlaying()) {
       this.playingChanged.emit(true);
     }
   }
 
   onPause(): void {
+    this.stopSweep();
+    // Settle the playhead on the exact paused position (the last rAF tick may
+    // have landed a frame short).
+    this.updatePlayhead();
     if (this.audioPlaying()) {
       this.playingChanged.emit(false);
     }
@@ -251,6 +282,98 @@ export class AudioPlayerComponent implements OnDestroy {
     } else {
       audio.pause();
     }
+  }
+
+  // --- Playhead sweep + click/drag-to-seek --------------------------------
+
+  // Recompute the playhead position from the element's clock. Hides the line
+  // until a finite, positive duration is known (before (loadedmetadata) the
+  // fraction is meaningless).
+  private updatePlayhead(): void {
+    const audio = this.audioRef()?.nativeElement;
+    if (!audio) return;
+    const duration = audio.duration;
+    if (!Number.isFinite(duration) || duration <= 0) {
+      this.playheadVisible.set(false);
+      return;
+    }
+    this.playheadVisible.set(true);
+    this.playheadFraction.set(Math.max(0, Math.min(1, audio.currentTime / duration)));
+  }
+
+  // Run a requestAnimationFrame loop that advances the playhead ~60x/sec while
+  // audio plays. Self-cancels when the element pauses (so a stray pause we
+  // didn't route through onPause still stops it). Idempotent: a second call
+  // while a loop is live is a no-op.
+  private startSweep(): void {
+    if (this.sweepRaf !== null) return;
+    if (typeof requestAnimationFrame !== 'function') return;
+    const tick = (): void => {
+      this.updatePlayhead();
+      const audio = this.audioRef()?.nativeElement;
+      if (audio && !audio.paused) {
+        this.sweepRaf = requestAnimationFrame(tick);
+      } else {
+        this.sweepRaf = null;
+      }
+    };
+    this.sweepRaf = requestAnimationFrame(tick);
+  }
+
+  private stopSweep(): void {
+    if (this.sweepRaf !== null) {
+      cancelAnimationFrame(this.sweepRaf);
+      this.sweepRaf = null;
+    }
+  }
+
+  // Begin a scrub gesture: seek to the pressed position and capture the pointer
+  // so drags outside the waveform keep seeking until release.
+  onSeekPointerDown(event: PointerEvent): void {
+    // Left button / primary pointer only; ignore right-clicks and secondary.
+    if (event.button !== 0) return;
+    this.scrubbing = true;
+    const stage = event.currentTarget as HTMLElement | null;
+    stage?.setPointerCapture?.(event.pointerId);
+    this.seekToPointer(event.clientX);
+    event.preventDefault();
+  }
+
+  onSeekPointerMove(event: PointerEvent): void {
+    if (!this.scrubbing) return;
+    this.seekToPointer(event.clientX);
+  }
+
+  onSeekPointerUp(event: PointerEvent): void {
+    if (!this.scrubbing) return;
+    this.scrubbing = false;
+    const stage = event.currentTarget as HTMLElement | null;
+    stage?.releasePointerCapture?.(event.pointerId);
+  }
+
+  // Map a viewport x-coordinate over the waveform to a playback time and seek
+  // there. The waveform spans the whole decoded buffer, so the fraction across
+  // the canvas maps linearly to [0, duration]; for a windowed clip the target
+  // is clamped into [clip_start, clip_end] (the seekable region).
+  private seekToPointer(clientX: number): void {
+    const audio = this.audioRef()?.nativeElement;
+    const canvas = this.canvasRef()?.nativeElement;
+    if (!audio || !canvas) return;
+    const duration = audio.duration;
+    if (!Number.isFinite(duration) || duration <= 0) return;
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 0) return;
+
+    const fraction = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    let target = fraction * duration;
+
+    const media = this.media();
+    if (media.clip_start != null) {
+      const end = media.clip_end ?? duration;
+      target = Math.max(media.clip_start, Math.min(end, target));
+    }
+    audio.currentTime = target;
+    this.updatePlayhead();
   }
 
   adjustVolume(delta: number): void {
@@ -269,8 +392,13 @@ export class AudioPlayerComponent implements OnDestroy {
     const datasetId = this.activeContext.datasetId;
 
     // Blank the old waveform immediately so a media switch doesn't leave the
-    // previous clip's render on screen during the fetch.
+    // previous clip's render on screen during the fetch. Retract the playhead
+    // too -- its old position is meaningless for the incoming clip, and the new
+    // duration is unknown until (loadedmetadata).
     this.clearCanvas();
+    this.stopSweep();
+    this.playheadVisible.set(false);
+    this.playheadFraction.set(0);
 
     this.waveformAbort?.abort();
     const abort = new AbortController();

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -149,6 +149,9 @@
   --accent-hover: #6b79ee;
   --color-good: #4caf50;
   --color-bad: #f44336;
+  // Audio-waveform playhead: a warm line swept over the (blue --accent)
+  // waveform, so it reads as the complementary color and never blends in.
+  --waveform-playhead: #ffb300;
   --shadow-dropdown: rgba(0, 0, 0, 0.5);
   --modal-backdrop: rgba(0, 0, 0, 0.7);
   --indicator-border: #444;
@@ -253,6 +256,7 @@
   --accent-hover: #4a58c8;
   --color-good: #388e3c;
   --color-bad: #d32f2f;
+  --waveform-playhead: #e8590c;
   --shadow-dropdown: rgba(0, 0, 0, 0.15);
   --modal-backdrop: rgba(0, 0, 0, 0.4);
   --indicator-border: #bbb;
@@ -324,6 +328,8 @@
   --accent-hover: #cccc00;
   --color-good: #00ff00;
   --color-bad: #ff0000;
+  // Max-contrast red line over the yellow (--accent) waveform in highviz.
+  --waveform-playhead: #ff0000;
   --shadow-dropdown: rgba(255, 255, 255, 0.2);
   --modal-backdrop: rgba(0, 0, 0, 0.85);
   --indicator-border: #ffffff;


### PR DESCRIPTION
## What

The audio "Now Playing" viewer rendered a static waveform with no indication of playback position. This adds a thin vertical **playhead** that sweeps left→right across the waveform as the clip plays, and makes the waveform **click/drag-to-seek**.

## How

- **Sweep** — a `requestAnimationFrame` loop advances the playhead ~60×/sec while audio plays (the native `timeupdate` event fires only ~4×/sec, too coarse for a smooth sweep). The loop self-cancels on pause and on destroy; `timeupdate` still refreshes the line as a fallback for throttled/background tabs. Position is `currentTime / duration`, so it maps correctly over the full-buffer waveform, including windowed archive-member clips.
- **Click/drag-to-seek** — pointer-down on the waveform seeks to that fraction of the clip and captures the pointer so a drag keeps scrubbing until release. For a windowed clip the target is clamped into `[clip_start, clip_end]` (the seekable region). The native `<audio controls>` scrub bar still works as before.
- **Theming** — a new theme-aware `--waveform-playhead` token (amber on dark, deep-orange on light, pure red on highviz) keeps the line complementary to the blue/yellow waveform in every theme.
- The playhead retracts on media switch and stays hidden until `loadedmetadata` gives a finite duration.

## Tests

Added Vitest specs covering: playhead placement at `currentTime/duration`, click-seek to the clicked fraction, and clamping a click-seek into the clip window. Full frontend gate passes (build + audit + 1694 unit tests).

No doc screenshot frames the audio waveform surface, so nothing was queued for reshoot.


---
_Generated by [Claude Code](https://claude.ai/code/session_0117uAM54crWpcwP9FsnrHWY)_