### PR TITLE
Silence Toponymy signpost stdout; drive naming progress by layer

### DIFF
--- a/tests_lib/projection/test_toponymy_smoke.py
+++ b/tests_lib/projection/test_toponymy_smoke.py
@@ -42,9 +42,9 @@ class SeededEmbedder:
         return vec / np.linalg.norm(vec)
 
 
-def test_real_toponymy_fit_produces_signs():
+def _seeded_corpus(per_cluster: int = 100):
+    """A tiny 3-cluster seeded corpus + its 2-D layout, for the real fit."""
     rng = np.random.default_rng(42)
-    per_cluster = 100
     centers = rng.standard_normal((3, _DIM)).astype(np.float32) * 4
     rows, texts = [], []
     for c in range(3):
@@ -52,10 +52,14 @@ def test_real_toponymy_fit_produces_signs():
         texts.extend(_WORDS[c][i % len(_WORDS[c])] for i in range(per_cluster))
     matrix = np.vstack(rows)
     matrix /= np.linalg.norm(matrix, axis=1, keepdims=True)
-
     n = matrix.shape[0]
     coords = rng.standard_normal((n, 2)).astype(np.float32)
     proj = Projection("smoke-proj", list(range(1, n + 1)), coords, "pca")
+    return proj, matrix, texts
+
+
+def test_real_toponymy_fit_produces_signs():
+    proj, matrix, texts = _seeded_corpus()
 
     label_set = build_region_labels(
         proj,
@@ -80,3 +84,39 @@ def test_real_toponymy_fit_produces_signs():
     corpus_vocab = {w for words in _WORDS.values() for phrase in words for w in phrase.split()}
     named_words = {w for lab in label_set.labels for w in lab.text.lower().split()}
     assert named_words & corpus_vocab
+
+
+def test_real_toponymy_fit_is_quiet_and_reports_layers(capsys):
+    """The library's ``Layer N found M clusters`` prints and its per-cluster
+    tqdm bars must stay off; the layer/topic breakdown surfaces through the
+    ``on_progress`` callback as a determinate, per-layer naming bar instead."""
+    proj, matrix, texts = _seeded_corpus()
+
+    progress: list[tuple[int, int, str]] = []
+    build_region_labels(
+        proj,
+        matrix,
+        matrix,
+        texts,
+        SeededEmbedder(),
+        object_description="sounds",
+        corpus_description="a tiny synthetic corpus of animal, weather, and traffic sounds",
+        on_progress=lambda current, total, message: progress.append((current, total, message)),
+    )
+
+    captured = capsys.readouterr()
+    # The exact stdout flood the user reported ("Layer 0 found 65 clusters").
+    assert "found" not in captured.out.lower()
+    assert "Layer" not in captured.out
+    # tqdm progress bars (stderr) from exemplar selection / keyphrase mining
+    # must not flash by.
+    for bar_desc in ("exemplars", "informative keyphrases", "Building topic names by layer"):
+        assert bar_desc not in captured.err
+
+    # Naming reported a determinate bar broken down by layer (0-based, finest
+    # first), the "measuring layers 0,1,2" upgrade.
+    naming = [(c, t, m) for c, t, m in progress if "layer" in m.lower()]
+    assert naming, "naming never reported per-layer progress"
+    assert all(total > 0 for _, total, _ in naming), "naming bar was indeterminate"
+    assert all(current <= total for current, total, _ in naming), "naming count overran its total"
+    assert any("layer 0" in m.lower() for _, _, m in naming), "finest layer never reported"

--- a/vtscore/projection/signpost_build.py
+++ b/vtscore/projection/signpost_build.py
@@ -177,7 +177,7 @@ def _keyphrase_disambiguation(prompt: str) -> dict[str, Any]:
     return {"new_topic_name_mapping": mapping, "topic_specificities": [0.5] * len(mapping)}
 
 
-def make_keyphrase_namer() -> Any:
+def make_keyphrase_namer(on_name: Callable[[], None] | None = None) -> Any:
     """The no-LLM namer: answer every naming prompt with the top keyphrase.
 
     A trivial in-process ``LLMWrapper`` whose "LLM calls" parse the prompt
@@ -186,6 +186,10 @@ def make_keyphrase_namer() -> Any:
     contrastive clustering + keyphrase machinery and skips only the LLM's
     phrasing.  Duplicate-name disambiguation passes echo the old names back
     (a no-LLM namer cannot invent new distinctions).
+
+    ``on_name`` fires once per *topic-naming* call (not the batched
+    disambiguation passes), which is how :func:`_fit_topic_layers` drives a
+    determinate naming progress bar: one topic named ≈ one tick.
     """
     from toponymy.llm_wrappers import LLMWrapper  # noqa: PLC0415
 
@@ -197,6 +201,8 @@ def make_keyphrase_namer() -> Any:
         def _respond(self, prompt: str) -> str:
             if "new_topic_name_mapping" in prompt:
                 return json.dumps(_keyphrase_disambiguation(prompt))
+            if on_name is not None:
+                on_name()
             return json.dumps({"topic_name": _keyphrase_topic_name(prompt), "topic_specificity": 0.5})
 
         def _call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
@@ -230,6 +236,7 @@ def _fit_topic_layers(
     *,
     object_description: str,
     corpus_description: str,
+    on_progress: ProgressFn | None = None,
 ) -> list[tuple[list[str], np.ndarray]]:
     """Run the Toponymy fit; return ``(topic_names, cluster_labels)`` per layer.
 
@@ -238,23 +245,72 @@ def _fit_topic_layers(
     (or ``-1`` for noise).  Isolated as the seam tests stub: everything above
     is our glue, everything inside (including the namer, so stubbed callers
     never import toponymy) is the library's responsibility.
+
+    Progress: naming is the long pole (one namer call per topic across every
+    layer), so we turn it into a *determinate* bar.  A clusterer subclass
+    records each layer's topic count the moment Toponymy finishes clustering
+    (finest layer first), giving us the total; the no-LLM namer then ticks the
+    bar once per topic, tagged with the 0-based layer it's naming — the
+    ``Layer 0 / Layer 1 / …`` breakdown the library used to dump to stdout,
+    now surfaced through the UI instead.
     """
     import warnings  # noqa: PLC0415
 
     from toponymy import Toponymy  # noqa: PLC0415
     from toponymy.clustering import ToponymyClusterer  # noqa: PLC0415
 
+    # ``named`` counts topic-naming calls so far; ``cumulative`` is the running
+    # topic-count boundary per layer (filled in once clustering completes), so
+    # ``searchsorted`` maps the current tick to the layer being named.
+    naming = {"named": 0, "total": 0, "cumulative": np.empty(0, dtype=np.int64)}
+
+    def _on_layers(cluster_labels: list[np.ndarray]) -> None:
+        sizes = [int(labels.max()) + 1 if labels.size else 0 for labels in cluster_labels]
+        naming["cumulative"] = np.cumsum(sizes)
+        naming["total"] = int(sum(sizes))
+
+    def _on_name() -> None:
+        naming["named"] += 1
+        if on_progress is None or not naming["total"]:
+            return
+        done = min(naming["named"], naming["total"])
+        n_layers = len(naming["cumulative"])
+        layer = min(int(np.searchsorted(naming["cumulative"], done, side="left")), n_layers - 1)
+        on_progress(done, naming["total"], f"Naming regions (layer {layer} of {n_layers - 1})…")
+
+    class _ProgressClusterer(ToponymyClusterer):  # type: ignore[misc]
+        """A ``ToponymyClusterer`` that reports its layer sizes as it finds them.
+
+        Wrapping the clusterer (rather than pre-fitting one) keeps Toponymy in
+        charge of passing the naming layer_kwargs (prompt template/format,
+        exemplar delimiters), so the naming pass is byte-for-byte what an
+        unwrapped fit would produce — we only observe the layer counts.
+        """
+
+        def fit_predict(self, *args: Any, **kwargs: Any) -> Any:
+            layers, tree = super().fit_predict(*args, **kwargs)
+            _on_layers([np.asarray(layer.cluster_labels) for layer in layers])
+            return layers, tree
+
     model = Toponymy(
-        llm_wrapper=make_keyphrase_namer(),
+        llm_wrapper=make_keyphrase_namer(_on_name),
         text_embedding_model=text_encoder,
-        clusterer=ToponymyClusterer(
+        clusterer=_ProgressClusterer(
             min_clusters=4,
             base_min_cluster_size=_base_min_cluster_size(len(texts)),
-            show_progress_bar=False,
+            verbose=False,
         ),
         object_description=object_description,
         corpus_description=corpus_description,
-        show_progress_bars=False,
+        # ``verbose=False`` (not the deprecated ``show_progress_bars=False``) is
+        # load-bearing: passing only the legacy flag leaves the library's
+        # unified ``verbose`` defaulting to True, which both prints
+        # "Layer N found M clusters" to stdout and — because a True ``verbose``
+        # overrides a False ``show_progress_bar`` downstream — flashes tqdm bars
+        # through exemplar/keyphrase selection (issue: signpost stdout noise).
+        # A single ``verbose=False`` silences both and skips the deprecation
+        # warnings the legacy flags would emit.
+        verbose=False,
     )
     # Toponymy narrates naming hiccups through ``warnings.warn`` (naming
     # fallbacks, disambiguation retries). The KeyphraseNamer above keeps those
@@ -328,6 +384,7 @@ def build_region_labels(
         encoder,
         object_description=object_description,
         corpus_description=corpus_description,
+        on_progress=on_progress,
     )
     if not layers:
         return empty


### PR DESCRIPTION
## Problem

Signpost building still leaked the toponymy library's chatter to the console:

```
Layer 0 found 65 clusters
Layer 1 found 21 clusters
Layer 2 found 7 clusters
```

plus flashes of tqdm progress bars from exemplar selection and keyphrase mining.

## Root cause

We constructed the `Toponymy` model (and its `ToponymyClusterer`) with the **deprecated** `show_progress_bars=False` / `show_progress_bar=False` flags. Toponymy has since unified those into a single `verbose` flag, and its `handle_verbose_params` shim defaults `verbose` to **`True`** when only the legacy flags are supplied (`default_verbose=True` for the model). That stray `verbose=True`:

- makes the clusterer `print("Layer N found M clusters")` to stdout, and
- overrides the `False` `show_progress_bar` downstream (a non-`None` `verbose` short-circuits `handle_verbose_params`), re-enabling the exemplar/keyphrase tqdm bars.

## Fix

Pass `verbose=False` to the model (and clusterer) instead of the legacy flags. A single `verbose=False` silences both the prints and the bars, and — because it short-circuits before the legacy-parameter branch — also skips the `DeprecationWarning`s the old flags emitted.

## Bonus: per-layer naming progress

The same layer/topic structure that used to spew to stdout now feeds a **determinate, per-layer naming progress bar** (the "measure layers 0, 1, 2…" upgrade):

- A small `ToponymyClusterer` subclass records each layer's topic count the instant clustering finishes (finest layer first). Wrapping the clusterer — rather than pre-fitting one — keeps Toponymy in charge of the naming `layer_kwargs`, so the naming pass is unchanged; we only observe the counts.
- The no-LLM `KeyphraseNamer` ticks the bar once per topic named, tagged with the 0-based layer it's on, via the existing `on_progress` callback threaded through `build_region_labels`.

## Tests

- New `test_real_toponymy_fit_is_quiet_and_reports_layers` (slow, real library) asserts stdout has no `Layer … found … clusters`, stderr has no exemplar/keyphrase bar descriptions, and the naming callback reports a determinate, per-layer bar including layer 0.
- Full suite green: `ALL 6406 TESTS PASSED` (plus the `-m slow` toponymy smoke tests).

## Backwards compatibility

`make_keyphrase_namer` gains an optional `on_name` callback and `_fit_topic_layers` gains an optional `on_progress` param — both default to no-op, so existing callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KvZ1rbgL166hJWUssHwvx

---
_Generated by [Claude Code](https://claude.ai/code/session_015KvZ1rbgL166hJWUssHwvx)_