### PR TITLE
Add a "?" to every progress-bar ETA

### DIFF
--- a/frontend/src/app/utils/format-progress.spec.ts
+++ b/frontend/src/app/utils/format-progress.spec.ts
@@ -135,16 +135,16 @@ describe('formatEta', () => {
 
   it('never claims finer than 10-second granularity sub-minute', () => {
     // A few seconds left snaps below the 10s floor → "< 10 sec", never "< 5 sec".
-    expect(formatEta(3)).toBe('< 10 sec left');
-    expect(formatEta(4)).toBe('< 10 sec left');
+    expect(formatEta(3)).toBe('< 10 sec left?');
+    expect(formatEta(4)).toBe('< 10 sec left?');
     // Just over the floor rounds to the nearest 10s, not 5s.
-    expect(formatEta(12)).toBe('10 sec left');
-    expect(formatEta(18)).toBe('20 sec left');
-    expect(formatEta(34)).toBe('30 sec left');
+    expect(formatEta(12)).toBe('10 sec left?');
+    expect(formatEta(18)).toBe('20 sec left?');
+    expect(formatEta(34)).toBe('30 sec left?');
   });
 
   it('switches to minutes and hours for larger estimates', () => {
-    expect(formatEta(330)).toBe('5.5 min left');
-    expect(formatEta(7200)).toBe('2 hr left');
+    expect(formatEta(330)).toBe('5.5 min left?');
+    expect(formatEta(7200)).toBe('2 hr left?');
   });
 });

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -49,7 +49,7 @@ function snapEta(value: number, minStep: number): number {
 /** Render a snapped magnitude with at most one decimal and no trailing ``.0``. */
 function etaUnit(value: number, unit: string): string {
   const text = Number.isInteger(value) ? String(value) : value.toFixed(1);
-  return `${text} ${unit} left`;
+  return `${text} ${unit} left?`;
 }
 
 /**
@@ -71,7 +71,7 @@ export function formatEta(seconds: number | null | undefined): string {
     const s = snapEta(seconds, 10);
     // A few seconds left snaps down to 0; claiming "~0 sec" reads as "done"
     // even though work remains. Show "< 10 sec left" instead.
-    if (s <= 0) return '< 10 sec left';
+    if (s <= 0) return '< 10 sec left?';
     if (s < 60) return etaUnit(s, 'sec');
   }
   // Minutes: round to the nice fraction of a minute (minimum half-minute).


### PR DESCRIPTION
## Summary
- Appends a `?` to every ETA chip rendered by `formatEta` in `frontend/src/app/utils/format-progress.ts` (e.g. `5.5 min left?`, `< 10 sec left?`), since it's the single choke point all progress-bar ETA text flows through.
- Updated `format-progress.spec.ts` expectations to match.

## Test plan
- [x] `npm run test:ci` (frontend unit suite) — 1694 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_0118HnxiKNhBieGJ1ytghrQh)_