### PR TITLE
Hide Audio2Text and Audio2Image converters from the picker

### DIFF
--- a/vtscore/converters/audio2image.py
+++ b/vtscore/converters/audio2image.py
@@ -123,6 +123,7 @@ class Audio2ImageMediaConverter(MediaConverter):
 
     display_name = "Audio → Image (spectrogram)"
     description = "Render audio as a mel-spectrogram or CQT image"
+    hidden_from_picker = True
     summary_template = (
         "Render each audio file as a {spectrogram_type} spectrogram (first {time_window_s}s, {colormap})."
     )

--- a/vtscore/converters/audio2text.py
+++ b/vtscore/converters/audio2text.py
@@ -39,6 +39,7 @@ class Audio2TextMediaConverter(MediaConverter):
 
     display_name = "Audio → Text (Whisper ASR)"
     description = "Transcribe speech in audio to text via Whisper"
+    hidden_from_picker = True
     summary_template = "Transcribe speech with Whisper ({model_size}, language: {language})."
     fields = [
         PluginField(

--- a/vtscore/datasets/importers/base/core.py
+++ b/vtscore/datasets/importers/base/core.py
@@ -195,7 +195,7 @@ class ImporterBase(PluginBase):
         converters_by_target: dict[str, list[dict]] = {}
         for mt_info in all_types_dict():
             type_id = mt_info["type_id"]
-            convs = list_converters_for_target(type_id)
+            convs = [c for c in list_converters_for_target(type_id) if not c.hidden_from_picker]
             if convs:
                 converters_by_target[type_id] = [c.to_dict() for c in convs]
         d["available_converters_by_media_type"] = converters_by_target


### PR DESCRIPTION
## Summary
- Set `hidden_from_picker = True` on `Audio2TextMediaConverter` (Whisper ASR) and `Audio2ImageMediaConverter` (spectrogram), so they no longer appear in the converter picker.
- Fixed the importer-embedded `available_converters_by_media_type` (used by the local-folder/server-folder/generic-form source-specs pickers) to actually respect `hidden_from_picker`, which it previously bypassed unlike `/api/converters`.

Both converters remain fully functional and still discoverable/usable programmatically (e.g. detector converter-routing is unaffected) — only the picker UI is hidden.

## Test plan
- [x] `./run-tests.sh converters` — 188 passed
- [x] `./run-tests.sh io core` (includes frontend build) — 2010 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01JHd1KfMtvmFj45rkgXgHpk)_