### PR TITLE
Fix silent hover audio for byte-sliced clips (e.g. TUT clipped to 5s)

### DIFF
--- a/tests/core/test_media_list_edge_paths.py
+++ b/tests/core/test_media_list_edge_paths.py
@@ -483,14 +483,46 @@ class TestBatchMetadataBranches:
         assert item["description"] == "a described item"
         assert "origin_name" not in item
 
-    def test_clip_fields_propagated(self, client):
-        mid = _inject(clip_start=1.5, clip_end=3.0, clip_index=2)
+    def test_sliced_audio_suppresses_playback_window(self, client):
+        # The audio clipper serves the already-sliced clip bytes (a short WAV in
+        # its own 0-based timeline) but stamps the original absolute offsets.
+        # The top-level clip_start/clip_end are a *seek window into the whole
+        # served file*, so emitting the absolute offsets here would make the
+        # player seek past the end of the short clip and play silence. They must
+        # be suppressed for byte-sliced audio; clip_index (provenance) stays.
+        mid = _inject(clip_start=120.0, clip_end=125.0, clip_index=2)
+        resp = client.post("/api/medias/batch", json={"ids": [mid]})
+        assert resp.status_code == 200
+        (item,) = resp.get_json()
+        assert "clip_start" not in item
+        assert "clip_end" not in item
+        assert item["clip_index"] == 2
+        # The offsets still reach the UI as provenance via custom_metadata.
+        assert item["custom_metadata"]["Clip Start"] == 120.0
+        assert item["custom_metadata"]["Clip End"] == 125.0
+
+    def test_video_keeps_playback_window(self, client):
+        # Video clips share the parent's bytes and the player seeks within
+        # [clip_start, clip_end], so the window must survive for video.
+        mid = _inject(media_type="video", filename="clip.mp4", clip_start=1.5, clip_end=3.0, clip_index=2)
         resp = client.post("/api/medias/batch", json={"ids": [mid]})
         assert resp.status_code == 200
         (item,) = resp.get_json()
         assert item["clip_start"] == 1.5
         assert item["clip_end"] == 3.0
         assert item["clip_index"] == 2
+
+    def test_archive_member_audio_keeps_playback_window(self, client, tmp_path):
+        # A windowed archive-member (AAC/MP4) import serves the *whole* member,
+        # so the player must seek to clip_start and loop within the window; the
+        # window has to survive for these.
+        mid = _inject_archive_member(tmp_path, b"RIFFfake", "a.wav", "audio", "a.wav")
+        medias[mid].update({"clip_start": 4.0, "clip_end": 9.0})
+        resp = client.post("/api/medias/batch", json={"ids": [mid]})
+        assert resp.status_code == 200
+        (item,) = resp.get_json()
+        assert item["clip_start"] == 4.0
+        assert item["clip_end"] == 9.0
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -476,6 +476,7 @@ def batch_medias(body: dict):
     Returns a JSON array of media metadata dicts; unknown IDs are silently
     omitted.
     """
+    from vtscore.datasets.archive_stream import archive_member_ref  # noqa: PLC0415
     from vtscore.media import get as get_media_type  # noqa: PLC0415
 
     ids = body["ids"]
@@ -507,9 +508,27 @@ def batch_medias(body: dict):
         if "description" in c:
             media_data["description"] = c["description"]
         _attach_embedder_fields(media_data, c)
+        # ``clip_start`` / ``clip_end`` are a *playback window into the whole
+        # served file*: every player (hover previews, bin popup, selection
+        # panel, and the center-panel audio/video players) seeks to
+        # ``clip_start`` and loops within ``[clip_start, clip_end]``.  That
+        # contract holds for video (clips share the parent's bytes) and for
+        # archive-member windowed audio (the whole AAC/MP4 member is served),
+        # but *not* for the audio clipper / lazy-clip resolver, which serve the
+        # already-sliced clip bytes (a short WAV in its own 0-based timeline)
+        # while stamping the original absolute offsets.  Handing those offsets
+        # to a player makes it seek past the end of the short file and play
+        # silence (e.g. a 5-second TUT clip cut from a 4-minute soundscape,
+        # ``clip_start`` ~120s).  So suppress the window for byte-sliced audio;
+        # the offsets still reach the UI as provenance via ``custom_metadata``
+        # ("Clip Start" / "Clip End") from ``display_metadata`` above.
+        audio_serves_slice = media_type_id == "audio" and archive_member_ref(c) is None
         for clip_key in ("clip_start", "clip_end", "clip_index", "clip_box"):
-            if clip_key in c:
-                media_data[clip_key] = c[clip_key]
+            if clip_key not in c:
+                continue
+            if audio_serves_slice and clip_key in ("clip_start", "clip_end"):
+                continue
+            media_data[clip_key] = c[clip_key]
         result.append(media_data)
     return result
 


### PR DESCRIPTION
## Symptom

After adding TUT sound events clipped to 5 s, hovering an audio bin in VTSBrowse played **nothing** — the now-playing widget appeared but no sound.

## Root cause (not the Now-Playing playhead change)

This is **not** the recent Now-Playing playhead change (#2574) — that touched `center-panel/audio-player`, a different component — nor the signal migration (#2550), which converted the hover-preview's `ngOnChanges` arm to an equivalent effect.

The real cause is a long-standing mismatch that TUT is the first dataset to exercise hard:

- The audio clipper (`AudioTilingClipper`, `SoundClipProcessor`) and the lazy-clip resolver serve the **already-sliced** clip bytes — a short WAV living in its own `0..duration` timeline — but stamp the media with the **original absolute** `clip_start` / `clip_end` (e.g. `120.0` / `125.0`).
- The media-batch response's top-level `clip_start` / `clip_end` are, for every frontend player (`clip-window.ts` hover previews + bin popup + selection panel, and the center-panel audio/video players), a **seek window into the whole served file**: they seek to `clip_start` and loop within `[clip_start, clip_end]`.
- So the player seeked ~120 s into a 5-second file; the `timeupdate` handler kept yanking `currentTime` back to `clip_start` → total silence. It's dramatic for TUT because the ~4-minute sources yield clips whose `clip_start` is almost always ≫ the 5 s clip length (only the very first tile, `clip_start≈0`, would have played).

This "serve the whole file, seek the window" contract is correct only for **video** (clips share the parent bytes) and **archive-member windowed audio** (AAC/MP4 — the whole member is served), both documented in `vtscore/media/lazy_clip.py`'s `clip_recipe`.

## Fix

In `POST /api/medias/batch`, suppress the top-level `clip_start` / `clip_end` playback window for **byte-sliced audio** (audio that is not an archive member — the clipper/lazy-clip case). Video and archive-member audio keep the window. With the window gone, the players fall back to native full-file looping of the served clip, which is exactly right because the served bytes *are* the clip.

The absolute offsets still reach the UI as provenance via `custom_metadata` ("Clip Start" / "Clip End") from `display_metadata`, so the metadata panel is unchanged.

One backend gate fixes all four hover/selection players and the center-panel player at once; no frontend changes needed.

## Tests

- Replaced `test_clip_fields_propagated` with three focused batch-endpoint tests: byte-sliced audio suppresses the window (keeps `clip_index`, keeps provenance in `custom_metadata`); video keeps the window; archive-member audio keeps the window.
- `./run-tests.sh core api` — all 1664 pass (frontend build included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPb471JFEzjZzsDXZRe62E

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPb471JFEzjZzsDXZRe62E)_