### PR TITLE
Install FaceNet by default; replace mediapipe with facenet-pytorch's MTCNN

### DIFF
--- a/.claude/hooks/ensure-test-deps.sh
+++ b/.claude/hooks/ensure-test-deps.sh
@@ -65,6 +65,13 @@ pip install --prefer-binary \
   -r "$REPO_DIR/requirements/base.txt" \
   -q
 
+# FaceNet face-identity embedder (vtscore.media.face). facenet-pytorch pins
+# torch<2.3 / numpy<2 / Pillow<10.3, which a plain install would honor by
+# downgrading the app's stack; those pins are empirically unnecessary (the
+# model runs a correct forward pass on the modern stack), so install --no-deps
+# and let the app's own torch/torchvision/numpy/Pillow satisfy it at runtime.
+pip install --no-deps facenet-pytorch -q
+
 # Install frontend (Angular) dependencies.
 # Re-run npm install whenever package-lock.json is newer than node_modules,
 # so added/removed packages are always in sync.

--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -216,14 +216,11 @@ _cache_tile  # noqa: F821
 
 # ---------------------------------------------------------------------------
 # Mock attributes that mimic the shape of third-party return values:
-# ``conf`` / ``xyxy`` look like an ultralytics YOLO ``Result`` row;
-# ``relative_bounding_box`` / ``location_data`` look like a MediaPipe
-# detection. The production reader pulls them by name off the mock.
+# ``conf`` / ``xyxy`` look like an ultralytics YOLO ``Result`` row. The
+# production reader pulls them by name off the mock.
 # ---------------------------------------------------------------------------
 conf  # noqa: F821
 xyxy  # noqa: F821
-relative_bounding_box  # noqa: F821
-location_data  # noqa: F821
 
 # ---------------------------------------------------------------------------
 # Test-internal attributes assigned for later access through fixtures or

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,7 +87,7 @@ VTSearch/
 │   │   ├── audio2text.py           Whisper ASR transcription
 │   │   ├── document2image.py       PDF page rendering
 │   │   ├── document2text.py        Text extraction from documents
-│   │   ├── image2face.py           Face localisation + crop (MediaPipe) → face type
+│   │   ├── image2face.py           Face localisation + crop (MTCNN) → face type
 │   │   ├── image2text.py           OCR (PaddleOCR)
 │   │   ├── video2audio.py          Audio track extraction
 │   │   └── video2image.py          Frame sampling

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -115,7 +115,7 @@ Re-ingests medias from their recorded origins and applies labels.
 
 Pregen processors are the built-in autorun processors VTSearch ships with: an
 OCR extractor (PaddleOCR), a Speech extractor (Whisper Tiny), and a Face
-localizer (MediaPipe). Adding them registers each into the autorun
+localizer (MTCNN). Adding them registers each into the autorun
 extractors / localizers stores so they run automatically after a dataset
 loads. They do **not** create detectors.
 
@@ -136,7 +136,7 @@ POST /api/pregen-processors/add
 Registers every bundled pregen processor (OCR extractor, Speech extractor,
 Face localizer) into the autorun extractor / localizer stores.
 
-→ `{"success": true, "added": ["OCR (PaddleOCR)", "Speech (Whisper Tiny)", "Face (MediaPipe)"]}`
+→ `{"success": true, "added": ["OCR (PaddleOCR)", "Speech (Whisper Tiny)", "Face (MTCNN)"]}`
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,12 @@ DEP003 = [
     # (via the scripts' --no-deps step) deptry reclassifies the import from
     # DEP001 (missing) to DEP003 (transitive/undeclared). See the DEP001 note.
     "toponymy",
+    # facenet-pytorch (FaceNet embedder + MTCNN face detector) is installed
+    # --no-deps by the install scripts because its torch<2.3 / numpy<2 pins
+    # would downgrade the app's stack. Once installed, deptry reclassifies the
+    # import from DEP001 (missing) to DEP003 (present/undeclared), so it needs
+    # ignoring under both rules. See the DEP001 note.
+    "facenet_pytorch",
 ]
 # DEP002: declared but not imported. Tools we run via their CLIs
 # (pytest, ruff, …), runtime helpers loaded by name (gunicorn), or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,6 @@ DEP001 = [
     "paddleocr",
     "rarfile",
     "whisper",
-    "mediapipe",
     "lightglue",
     "facenet_pytorch",
     "torchvision",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -838,8 +838,23 @@ vts_install_toponymy() {
     pip install --no-deps "toponymy==0.5.2" --progress-bar on
 }
 
+# --- facenet-pytorch (FaceNet face-identity embedder) ------------------------
+# The `face` embedder (vtscore.media.face.embedder_facenet) loads FaceNet's
+# InceptionResnetV1 via facenet-pytorch. facenet-pytorch 2.6.0 hard-pins
+# torch<2.3, torchvision<0.18, numpy<2.0 and Pillow<10.3 -- a plain install
+# would honor those by DOWNGRADING the app's entire torch/numpy/Pillow stack.
+# Those pins are empirically unnecessary: the model builds and runs a correct
+# forward pass on the app's modern stack (verified on torch 2.13 / numpy 2.x /
+# Pillow 12). So install it --no-deps -- exactly the toponymy pattern -- and let
+# the app's own torch, torchvision, numpy, Pillow, requests and tqdm (all
+# already present) satisfy it at runtime. Pretrained weights are lazy-downloaded
+# from GitHub on first model use, not here.
+vts_install_face_deps() {
+    pip install --no-deps facenet-pytorch --progress-bar on
+}
+
 vts_install_cpu() {
-    vts_progress_init 5 "Installing VTSearch CPU dependencies"
+    vts_progress_init 6 "Installing VTSearch CPU dependencies"
     echo "Heads-up: the pip steps below show a download bar, but pip also goes quiet"
     echo "for 10-30s at a time while it resolves dependency versions. That silence is"
     echo "normal -- it is working, not frozen."
@@ -856,6 +871,9 @@ vts_install_cpu() {
 
     vts_progress_step "Installing runtime + dev dependencies (this may take several minutes)"
     pip install -r "$REPO_ROOT/requirements/base.txt" --progress-bar on
+
+    vts_progress_step "Installing FaceNet face embedder (facenet-pytorch, --no-deps)"
+    vts_install_face_deps
 
     vts_progress_step "Wiring up pre-commit git hook"
     vts_install_precommit
@@ -1025,7 +1043,7 @@ vts_install_gpu() {
     local cuda_tag="$1"
     local extra_index="https://download.pytorch.org/whl/${cuda_tag}"
 
-    vts_progress_init 9 "Installing VTSearch GPU dependencies (CUDA tag: ${cuda_tag})"
+    vts_progress_init 10 "Installing VTSearch GPU dependencies (CUDA tag: ${cuda_tag})"
     echo "Heads-up: the pip steps below show a download bar, but pip also goes quiet"
     echo "for 10-30s at a time while it resolves dependency versions. That silence is"
     echo "normal -- it is working, not frozen."
@@ -1074,6 +1092,9 @@ vts_install_gpu() {
       --prefer-binary \
       -r "$REPO_ROOT/requirements/gpu.txt" \
       --progress-bar on
+
+    vts_progress_step "Installing FaceNet face embedder (facenet-pytorch, --no-deps)"
+    vts_install_face_deps
 
     vts_progress_step "Installing optional cuML/RAPIDS accelerator (best-effort; CUDA tag: ${cuda_tag})"
     vts_install_cuml "$cuda_tag"

--- a/tests/detectors/test_processors.py
+++ b/tests/detectors/test_processors.py
@@ -316,39 +316,35 @@ class TestFaceLocalizer:
     def test_identity(self):
         from vtscore.media.image.face_localizer import FaceLocalizer
 
-        loc = FaceLocalizer(name="test-face", threshold=0.6, model_selection=0)
+        loc = FaceLocalizer(name="test-face", threshold=0.6)
         assert loc.name == "test-face"
         assert loc.media_type == "image"
         assert loc.threshold == 0.6
-        assert loc.model_selection == 0
         assert isinstance(loc, Localizer)
 
     def test_to_dict(self):
         from vtscore.media.image.face_localizer import FaceLocalizer
 
-        loc = FaceLocalizer(name="face1", threshold=0.7, model_selection=1)
+        loc = FaceLocalizer(name="face1", threshold=0.7)
         d = loc.to_dict()
         assert d["name"] == "face1"
         assert d["media_type"] == "image"
         assert d["localizer_type"] == "face"
         assert d["config"]["threshold"] == 0.7
-        assert d["config"]["model_selection"] == 1
 
     def test_from_config(self):
         from vtscore.media.image.face_localizer import FaceLocalizer
 
-        config = {"threshold": 0.3, "model_selection": 0}
+        config = {"threshold": 0.3}
         loc = FaceLocalizer.from_config("rebuilt", config)
         assert loc.name == "rebuilt"
         assert loc.threshold == 0.3
-        assert loc.model_selection == 0
 
     def test_from_config_defaults(self):
         from vtscore.media.image.face_localizer import FaceLocalizer
 
         loc = FaceLocalizer.from_config("default", {})
         assert loc.threshold == 0.5
-        assert loc.model_selection == 1
 
     def test_localize_returns_empty_when_no_clip_bytes(self):
         from vtscore.media.image.face_localizer import FaceLocalizer
@@ -415,7 +411,7 @@ class TestPregenProcessorsRoute:
         names = [p["name"] for p in data["processors"]]
         assert "OCR (PaddleOCR)" in names
         assert "Speech (Whisper Tiny)" in names
-        assert "Face (MediaPipe)" in names
+        assert "Face (MTCNN)" in names
 
     def test_add_pregen_processors(self, client):
         res = client.post("/api/pregen-processors/add")
@@ -425,7 +421,7 @@ class TestPregenProcessorsRoute:
         assert len(data["added"]) == 3
         assert "OCR (PaddleOCR)" in data["added"]
         assert "Speech (Whisper Tiny)" in data["added"]
-        assert "Face (MediaPipe)" in data["added"]
+        assert "Face (MTCNN)" in data["added"]
 
     def test_pregen_adds_to_autorun(self, client):
         from vtsearch.autorun_processors import autorun_extractors, autorun_localizers
@@ -433,7 +429,7 @@ class TestPregenProcessorsRoute:
         client.post("/api/pregen-processors/add")
         assert "OCR (PaddleOCR)" in autorun_extractors
         assert "Speech (Whisper Tiny)" in autorun_extractors
-        assert "Face (MediaPipe)" in autorun_localizers
+        assert "Face (MTCNN)" in autorun_localizers
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/detectors/test_face.py
+++ b/tests_lib/detectors/test_face.py
@@ -4,8 +4,8 @@ the image2face converter.
 Face is the mirror of document in the half-media-type model: embeddable but
 not importable (faces only ever arise from converting an image via
 ``image2face``).  These tests exercise the type's capability flags, the moved
-FaceNet embedder, and the converter's crop logic against a stubbed MediaPipe
-detector (no model weights, no mediapipe install required).
+FaceNet embedder, and the converter's crop logic against a stubbed MTCNN
+detector (no model weights, no facenet-pytorch install required).
 """
 
 from __future__ import annotations
@@ -178,28 +178,15 @@ class TestFaceEmbedder:
 # ---------------------------------------------------------------------------
 
 
-class _FakeBBox:
-    def __init__(self, xmin, ymin, width, height):
-        self.xmin = xmin
-        self.ymin = ymin
-        self.width = width
-        self.height = height
+def _fake_mtcnn(boxes, probs):
+    """Build a stub MTCNN whose ``detect()`` returns ``(boxes, probs)``.
 
-
-class _FakeLocationData:
-    def __init__(self, bbox):
-        self.relative_bounding_box = bbox
-
-
-class _FakeDetection:
-    def __init__(self, score, bbox):
-        self.score = [score]
-        self.location_data = _FakeLocationData(bbox)
-
-
-class _FakeResults:
-    def __init__(self, detections):
-        self.detections = detections
+    ``boxes`` is a list of ``[x1, y1, x2, y2]`` pixel boxes (or ``None`` for
+    "no faces"); ``probs`` the matching per-face confidences.
+    """
+    detector = MagicMock()
+    detector.detect.return_value = (boxes, probs)
+    return detector
 
 
 def _png_bytes(w=100, h=100):
@@ -228,12 +215,10 @@ class TestImage2FaceConverter:
         from vtscore.converters.image2face import Image2FaceMediaConverter
 
         conv = Image2FaceMediaConverter()
-        detector = MagicMock()
-        detector.process.return_value = _FakeResults(
-            [
-                _FakeDetection(0.9, _FakeBBox(0.1, 0.1, 0.3, 0.3)),
-                _FakeDetection(0.8, _FakeBBox(0.5, 0.5, 0.3, 0.3)),
-            ]
+        # Two faces on a 100x100 image, in pixel [x1, y1, x2, y2] coordinates.
+        detector = _fake_mtcnn(
+            boxes=[[10, 10, 40, 40], [50, 50, 80, 80]],
+            probs=[0.9, 0.8],
         )
         media = {"filename": "group.png", "media_bytes": _png_bytes()}
         with patch.object(conv, "_make_detector", return_value=detector):
@@ -250,8 +235,8 @@ class TestImage2FaceConverter:
         from vtscore.converters.image2face import Image2FaceMediaConverter
 
         conv = Image2FaceMediaConverter()
-        detector = MagicMock()
-        detector.process.return_value = _FakeResults([])
+        # MTCNN returns ``None`` for boxes when it finds no faces.
+        detector = _fake_mtcnn(boxes=None, probs=[None])
         media = {"filename": "empty.png", "media_bytes": _png_bytes()}
         with patch.object(conv, "_make_detector", return_value=detector):
             out = conv.convert_normalized(media, {})
@@ -261,10 +246,20 @@ class TestImage2FaceConverter:
         from vtscore.converters.image2face import Image2FaceMediaConverter
 
         conv = Image2FaceMediaConverter()
-        detector = MagicMock()
         # A 2px-wide box on a 100px image is below a 32px min size.
-        detector.process.return_value = _FakeResults([_FakeDetection(0.95, _FakeBBox(0.1, 0.1, 0.02, 0.02))])
+        detector = _fake_mtcnn(boxes=[[10, 10, 12, 12]], probs=[0.95])
         media = {"filename": "tiny.png", "media_bytes": _png_bytes()}
         with patch.object(conv, "_make_detector", return_value=detector):
             out = conv.convert_normalized(media, {"padding": "0", "min_size": "32"})
         assert out == []
+
+    def test_below_threshold_detections_dropped(self):
+        from vtscore.converters.image2face import Image2FaceMediaConverter
+
+        conv = Image2FaceMediaConverter()
+        # A high-confidence face and a low-confidence one; only the first survives.
+        detector = _fake_mtcnn(boxes=[[10, 10, 60, 60], [20, 20, 70, 70]], probs=[0.95, 0.2])
+        media = {"filename": "mixed.png", "media_bytes": _png_bytes()}
+        with patch.object(conv, "_make_detector", return_value=detector):
+            out = conv.convert_normalized(media, {"threshold": "0.5", "padding": "0", "min_size": "1"})
+        assert len(out) == 1

--- a/vtscore/converters/image2face.py
+++ b/vtscore/converters/image2face.py
@@ -149,6 +149,29 @@ class Image2FaceMediaConverter(MediaConverter):
         min_size = int(self.get_param(params, "min_size") or 32)
         return threshold, max(0.0, padding), max(1, min_size)
 
+    def _detect_boxes(
+        self, img: Any, w: int, h: int, threshold: float, padding: float, min_size: int
+    ) -> list[tuple[int, int, int, int, float]]:
+        """Run MTCNN on *img* and return usable pixel boxes, highest-confidence first."""
+        detector = self._make_detector()
+        if detector is None:
+            return []
+        try:
+            det_boxes, det_probs = detector.detect(img)
+        except Exception:
+            return []
+        if det_boxes is None:
+            return []
+
+        boxes: list[tuple[int, int, int, int, float]] = []
+        for box, prob in zip(det_boxes, det_probs):
+            resolved = self._box_from_detection(box, prob, w, h, threshold, padding, min_size)
+            if resolved is not None:
+                boxes.append(resolved)
+        # Highest-confidence face first so face index 0 is the "primary" face.
+        boxes.sort(key=lambda b: b[4], reverse=True)
+        return boxes
+
     # ------------------------------------------------------------------
     # Conversion
     # ------------------------------------------------------------------
@@ -174,23 +197,7 @@ class Image2FaceMediaConverter(MediaConverter):
         img_w, img_h = img.size
         fmt = img.format or "PNG"
 
-        detector = self._make_detector()
-        if detector is None:
-            return []
-        try:
-            det_boxes, det_probs = detector.detect(img)
-        except Exception:
-            return []
-        if det_boxes is None:
-            return []
-
-        boxes: list[tuple[int, int, int, int, float]] = []
-        for box, prob in zip(det_boxes, det_probs):
-            resolved = self._box_from_detection(box, prob, img_w, img_h, threshold, padding, min_size)
-            if resolved is not None:
-                boxes.append(resolved)
-        # Highest-confidence face first so face index 0 is the "primary" face.
-        boxes.sort(key=lambda b: b[4], reverse=True)
+        boxes = self._detect_boxes(img, img_w, img_h, threshold, padding, min_size)
 
         stem = (media.get("filename") or "image").rsplit(".", 1)[0]
         out_ext = "png" if fmt.upper() == "PNG" else fmt.lower()

--- a/vtscore/converters/image2face.py
+++ b/vtscore/converters/image2face.py
@@ -2,14 +2,15 @@
 
 This is the *convert-in* path for the :class:`~vtscore.media.face.media_type.FaceMediaType`
 half type: images are the only source of faces (faces have no native import),
-so every face in the app is produced here. MediaPipe Face Detection finds each
-face above the configured confidence, and each is cropped (with optional
-padding) into its own ``face``-type media, ready to be embedded in FaceNet
-identity space.
+so every face in the app is produced here. facenet-pytorch's MTCNN detector
+finds each face above the configured confidence, and each is cropped (with
+optional padding) into its own ``face``-type media, ready to be embedded in
+FaceNet identity space by the same ``facenet-pytorch`` install.
 
-``mediapipe`` is an opt-in dependency (declared in pyproject's ``DEP001``
-ignore-list, same pattern as ``facenet-pytorch``); when it is missing the
-converter degrades gracefully to producing no faces.
+``facenet-pytorch`` is an opt-in dependency (declared in pyproject's ``DEP001``
+ignore-list, installed ``--no-deps`` by the install scripts because its pins
+would downgrade the app's torch/numpy stack); when it is missing the converter
+degrades gracefully to producing no faces.
 """
 
 from __future__ import annotations
@@ -22,12 +23,12 @@ from vtscore.plugins import PluginField
 
 
 class Image2FaceMediaConverter(MediaConverter):
-    """Detect faces with MediaPipe and emit one crop per face as ``face`` media.
+    """Detect faces with MTCNN and emit one crop per face as ``face`` media.
 
     Images with **no** detected faces yield zero outputs and drop out of the
-    dataset - the intended semantic for a face-only collection. The four
+    dataset - the intended semantic for a face-only collection. The three
     tunables mirror the (now-removed) image face clipper: confidence
-    ``threshold``, crop ``padding``, ``min_size``, and detector ``model_selection``.
+    ``threshold``, crop ``padding``, and ``min_size``.
     """
 
     display_name = "Images → Faces"
@@ -66,18 +67,12 @@ class Image2FaceMediaConverter(MediaConverter):
             min="1",
             step="1",
         ),
-        PluginField(
-            key="model_selection",
-            label="Detector range",
-            field_type="number",
-            description="0 = short-range (within ~2m), 1 = full-range (within ~5m).",
-            default="1",
-            required=False,
-            min="0",
-            max="1",
-            step="1",
-        ),
     ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Lazily built, then reused across every image in a conversion run.
+        self._detector: Optional[Any] = None
 
     @property
     def source_type(self) -> str:
@@ -91,37 +86,53 @@ class Image2FaceMediaConverter(MediaConverter):
     # Detection helpers
     # ------------------------------------------------------------------
 
-    def _make_detector(self, threshold: float, model_selection: int) -> Optional[Any]:
+    def _make_detector(self) -> Optional[Any]:
+        """Return a cached, keep-all MTCNN detector, or ``None`` if unavailable.
+
+        MTCNN ships inside ``facenet-pytorch`` (the same install that provides
+        the FaceNet embedder) and carries its own bundled weights, so there is
+        no separate model download. The detector is confidence-independent — the
+        per-face ``threshold`` is applied as a post-filter in
+        :meth:`_box_from_detection` — so a single instance is reused across every
+        image in a conversion run.
+        """
+        if self._detector is not None:
+            return self._detector
         try:
-            import mediapipe as mp  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            from facenet_pytorch import MTCNN  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
         except ImportError:
-            print("Image2FaceMediaConverter requires mediapipe; producing no faces")
+            print("Image2FaceMediaConverter requires facenet-pytorch; producing no faces")
             return None
-        return mp.solutions.face_detection.FaceDetection(
-            min_detection_confidence=threshold,
-            model_selection=model_selection,
+        from vtscore.config import resolve_device  # noqa: PLC0415
+
+        self._detector = MTCNN(
+            keep_all=True,
+            select_largest=False,
+            post_process=False,
+            device=resolve_device(),
         )
+        return self._detector
 
     def _box_from_detection(
-        self, det: Any, w: int, h: int, threshold: float, padding: float, min_size: int
+        self, box: Any, prob: Any, w: int, h: int, threshold: float, padding: float, min_size: int
     ) -> tuple[int, int, int, int, float] | None:
-        """Turn one MediaPipe detection into a padded, clamped pixel box.
+        """Turn one MTCNN ``(box, prob)`` pair into a padded, clamped pixel box.
 
-        Returns ``(x1, y1, x2, y2, conf)`` in pixel coordinates, or ``None``
-        when the detection is unusable, below *threshold*, or smaller than
-        *min_size* on either axis after padding.
+        MTCNN returns boxes as ``[x1, y1, x2, y2]`` already in pixel
+        coordinates. Returns ``(x1, y1, x2, y2, conf)``, or ``None`` when the
+        detection is unusable, below *threshold*, or smaller than *min_size* on
+        either axis after padding.
         """
         try:
-            conf = float(det.score[0])
-        except (AttributeError, IndexError, TypeError):
+            conf = float(prob)
+        except (TypeError, ValueError):
             return None
         if conf < threshold:
             return None
-        rel = det.location_data.relative_bounding_box
-        fx1 = rel.xmin * w
-        fy1 = rel.ymin * h
-        fx2 = (rel.xmin + rel.width) * w
-        fy2 = (rel.ymin + rel.height) * h
+        try:
+            fx1, fy1, fx2, fy2 = (float(v) for v in box)
+        except (TypeError, ValueError):
+            return None
         pad_x = (fx2 - fx1) * padding
         pad_y = (fy2 - fy1) * padding
         x1 = max(0, int(round(fx1 - pad_x)))
@@ -132,26 +143,22 @@ class Image2FaceMediaConverter(MediaConverter):
             return None
         return (x1, y1, x2, y2, conf)
 
-    def _resolve_params(self, params: dict[str, Any] | None) -> tuple[float, float, int, int]:
+    def _resolve_params(self, params: dict[str, Any] | None) -> tuple[float, float, int]:
         threshold = float(self.get_param(params, "threshold") or 0.5)
         padding = float(self.get_param(params, "padding") or 0.0)
         min_size = int(self.get_param(params, "min_size") or 32)
-        model_selection = int(self.get_param(params, "model_selection") or 1)
-        if model_selection not in (0, 1):
-            model_selection = 1
-        return threshold, max(0.0, padding), max(1, min_size), model_selection
+        return threshold, max(0.0, padding), max(1, min_size)
 
     # ------------------------------------------------------------------
     # Conversion
     # ------------------------------------------------------------------
 
     def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
-        import numpy as np  # noqa: PLC0415
         from PIL import Image  # noqa: PLC0415
 
         from vtscore.media.embedder import media_from_path  # noqa: PLC0415
 
-        threshold, padding, min_size, model_selection = self._resolve_params(params)
+        threshold, padding, min_size = self._resolve_params(params)
 
         media_bytes = media.get("media_bytes")
         if media_bytes is None:
@@ -167,20 +174,21 @@ class Image2FaceMediaConverter(MediaConverter):
         img_w, img_h = img.size
         fmt = img.format or "PNG"
 
-        detector = self._make_detector(threshold, model_selection)
+        detector = self._make_detector()
         if detector is None:
             return []
         try:
-            results = detector.process(np.array(img))
+            det_boxes, det_probs = detector.detect(img)
         except Exception:
             return []
-        detections = getattr(results, "detections", None) or []
+        if det_boxes is None:
+            return []
 
         boxes: list[tuple[int, int, int, int, float]] = []
-        for det in detections:
-            box = self._box_from_detection(det, img_w, img_h, threshold, padding, min_size)
-            if box is not None:
-                boxes.append(box)
+        for box, prob in zip(det_boxes, det_probs):
+            resolved = self._box_from_detection(box, prob, img_w, img_h, threshold, padding, min_size)
+            if resolved is not None:
+                boxes.append(resolved)
         # Highest-confidence face first so face index 0 is the "primary" face.
         boxes.sort(key=lambda b: b[4], reverse=True)
 

--- a/vtscore/media/face/embedder_facenet.py
+++ b/vtscore/media/face/embedder_facenet.py
@@ -15,10 +15,13 @@ crop is embedded here. The model also works on un-cropped images (it just
 sees a 160×160 resize without explicit detection), but results are much
 better when the input is already a face-centred crop.
 
-``facenet-pytorch`` is an opt-in dependency (declared in pyproject's
-``DEP001`` ignore-list, same pattern as ``mediapipe``). If it is not
-installed, :meth:`load_models` raises an :class:`ImportError` that the
-:class:`MediaEmbedder` base class re-wraps with an install hint.
+``facenet-pytorch`` is installed ``--no-deps`` by the install scripts (its
+torch<2.3 / numpy<2 pins are empirically unnecessary and would otherwise
+downgrade the app's stack) and declared in pyproject's ``DEP001`` ignore-list.
+The same install also provides the MTCNN detector used by the ``image2face``
+converter and ``FaceLocalizer``. If it is not installed, :meth:`load_models`
+raises an :class:`ImportError` that the :class:`MediaEmbedder` base class
+re-wraps with an install hint.
 """
 
 from __future__ import annotations

--- a/vtscore/media/image/face_localizer.py
+++ b/vtscore/media/image/face_localizer.py
@@ -1,4 +1,4 @@
-"""Face localizer using MediaPipe Face Detection."""
+"""Face localizer using facenet-pytorch's MTCNN detector."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from vtscore.media.processors import Localizer
 
 
 class FaceLocalizer(Localizer):
-    """Localizes faces in images using MediaPipe Face Detection.
+    """Localizes faces in images using facenet-pytorch's MTCNN detector.
 
     Running :meth:`localize` on an image clip returns a list of dicts, one per
     detected face whose confidence meets the threshold::
@@ -25,19 +25,19 @@ class FaceLocalizer(Localizer):
         ]
 
     Coordinates are in pixel space (float) matching the original image size.
+    MTCNN ships inside ``facenet-pytorch`` with bundled weights, so it needs no
+    separate model download and shares the install used by the FaceNet embedder.
     """
 
-    def __init__(self, name: str, threshold: float = 0.5, model_selection: int = 1) -> None:
+    def __init__(self, name: str, threshold: float = 0.5) -> None:
         """Create a face localizer.
 
         Args:
             name: Unique name for this localizer instance.
             threshold: Minimum confidence to count a detection (0-1).
-            model_selection: 0 for short-range (within 2m), 1 for full-range (within 5m).
         """
         self._name = name
         self._threshold = threshold
-        self._model_selection = model_selection
         self._detector: Optional[Any] = None
 
     # ------------------------------------------------------------------
@@ -56,10 +56,6 @@ class FaceLocalizer(Localizer):
     def threshold(self) -> float:
         return self._threshold
 
-    @property
-    def model_selection(self) -> int:
-        return self._model_selection
-
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -67,11 +63,15 @@ class FaceLocalizer(Localizer):
     def load_model(self) -> None:
         if self._detector is not None:
             return
-        import mediapipe as mp  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        from facenet_pytorch import MTCNN  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
-        self._detector = mp.solutions.face_detection.FaceDetection(
-            min_detection_confidence=self._threshold,
-            model_selection=self._model_selection,
+        from vtscore.config import resolve_device  # noqa: PLC0415
+
+        self._detector = MTCNN(
+            keep_all=True,
+            select_largest=False,
+            post_process=False,
+            device=resolve_device(),
         )
 
     # ------------------------------------------------------------------
@@ -93,30 +93,24 @@ class FaceLocalizer(Localizer):
         if media_bytes is None:
             return []
 
-        import numpy as np  # noqa: PLC0415
-
         image = Image.open(io.BytesIO(media_bytes)).convert("RGB")
-        img_array = np.array(image)
-        h, w = img_array.shape[:2]
 
-        results = self._detector.process(img_array)
+        det_boxes, det_probs = self._detector.detect(image)
 
         hits: list[dict[str, Any]] = []
-        if not results.detections:
+        if det_boxes is None:
             return hits
 
-        for detection in results.detections:
-            conf = detection.score[0]
+        for box, prob in zip(det_boxes, det_probs):
+            if prob is None:
+                continue
+            conf = float(prob)
             if conf < self._threshold:
                 continue
-            bbox_rel = detection.location_data.relative_bounding_box
-            x1 = bbox_rel.xmin * w
-            y1 = bbox_rel.ymin * h
-            x2 = (bbox_rel.xmin + bbox_rel.width) * w
-            y2 = (bbox_rel.ymin + bbox_rel.height) * h
+            x1, y1, x2, y2 = (float(v) for v in box)
             hits.append(
                 {
-                    "confidence": round(float(conf), 4),
+                    "confidence": round(conf, 4),
                     "bbox": [round(x1, 2), round(y1, 2), round(x2, 2), round(y2, 2)],
                 }
             )
@@ -133,7 +127,6 @@ class FaceLocalizer(Localizer):
         d["localizer_type"] = "face"
         d["config"] = {
             "threshold": self._threshold,
-            "model_selection": self._model_selection,
         }
         return d
 
@@ -143,5 +136,4 @@ class FaceLocalizer(Localizer):
         return cls(
             name=name,
             threshold=config.get("threshold", 0.5),
-            model_selection=config.get("model_selection", 1),
         )

--- a/vtsearch/routes/processors/crud.py
+++ b/vtsearch/routes/processors/crud.py
@@ -221,11 +221,11 @@ _PREGEN_PROCESSORS = [
         "config": {"model_size": "tiny", "language": None},
     },
     {
-        "name": "Face (MediaPipe)",
+        "name": "Face (MTCNN)",
         "kind": "localizer",
         "processor_type": "face",
         "media_type": "image",
-        "config": {"threshold": 0.5, "model_selection": 1},
+        "config": {"threshold": 0.5},
     },
 ]
 


### PR DESCRIPTION
## Problem

Running `install.sh` and then loading the **Faces – VGGFace2** demo through the "convert to face" path failed with:

```
Faces - VGGFace2 (M): Missing dependency: No module named 'facenet_pytorch'.
Required by the 'face' embedder. Install dependencies with: pip install -e '.[cpu,dev]'. ...
```

The face-search feature (Faces demo → `image2face` converter → FaceNet embedder) needs two packages that `install.sh` never installed — `facenet_pytorch` and `mediapipe` — and the error even pointed at `pip install -e '.[cpu,dev]'`, which wouldn't install them and would *break* the app if it did.

## Why they weren't plain dependencies

`facenet-pytorch` 2.6.0 hard-pins `torch<2.3`, `torchvision<0.18`, `numpy<2.0`, `Pillow<10.3`. Declaring it normally would downgrade the app's entire torch/numpy/Pillow stack. Those pins are **empirically unnecessary** — verified a full `InceptionResnetV1` forward pass and `MTCNN.detect()` on the app's real stack (torch 2.13 / numpy 2.4.6 / Pillow 12.3) producing correct output — so it's installed `--no-deps`, mirroring the existing `toponymy` precedent.

## Dropping mediapipe

The `image2face` converter and `FaceLocalizer` used `mp.solutions.face_detection`. Every mediapipe version that still ships the `solutions` API (≤ 0.10.21) hard-requires `protobuf<5`, which conflicts with the app's protobuf stack (and fails at runtime against it); versions compatible with modern protobuf (≥ 0.10.30) **removed** `solutions`. So mediapipe can't be added cleanly either way.

Instead, both detection and embedding now come from **one** `facenet-pytorch` install: the converter and localizer use its bundled **MTCNN** detector (torch-based, no protobuf, weights ship in the package). Zero new dependencies.

## Changes

- **Install** `facenet-pytorch --no-deps` in `scripts/install.sh` (CPU + GPU paths) and `.claude/hooks/ensure-test-deps.sh`.
- **`image2face` converter + `FaceLocalizer`** switched from mediapipe to MTCNN's `detect()`. Dropped the mediapipe-specific `model_selection` knob (**breaking change**).
- Renamed the pregen processor **"Face (MediaPipe)" → "Face (MTCNN)"**.
- `pyproject.toml`: removed `mediapipe` from the deptry DEP001 ignore; added `facenet_pytorch` to DEP003 (present-but-`--no-deps`, same dual-classification as `toponymy`/`cuml`).
- Updated docstrings, the vulture whitelist, and docs (`docs/api/io.md`, `docs/ARCHITECTURE.md`).
- Updated the converter/localizer/pregen tests to the MTCNN API.

## Breaking change

The `image2face` converter and face localizer no longer accept `model_selection`; the pregen processor name changed to "Face (MTCNN)". Saved face-localizer configs carrying `model_selection` still load (the key is ignored).

## Testing

`./run-tests.sh` — **all 6407 tests pass** (1 skipped). Also independently verified `facenet-pytorch --no-deps` (MTCNN + InceptionResnetV1) runs on the app's actual installed torch 2.13 / numpy 2.4.6 / Pillow 12.3 stack with no downgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFBg9S8f8RS6mL1sijAi32

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFBg9S8f8RS6mL1sijAi32)_