### PR TITLE
Sweep a playhead across the VTSBrowse Now-Playing waveform

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -11,7 +11,7 @@ import { ViewControlsComponent } from '../view-controls/view-controls.component'
 import { IconComponent } from '../icon/icon.component';
 import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
-import { applyClipWindow, clearClipWindow } from '../../utils/clip-window';
+import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
@@ -260,6 +260,12 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   /** Media id of the clip currently auditioning, so the buffering listeners can
    *  re-emit its now-playing state; ``null`` when silent. */
   private nowPlayingId: number | null = null;
+  /** Last ``loading`` flag emitted, so the playhead sweep re-emits with the live
+   *  buffering state rather than forcing it back to ``false``. */
+  private nowPlayingLoading = false;
+  /** Handle of the in-flight requestAnimationFrame playhead sweep, or ``null``
+   *  when the loop is stopped. */
+  private sweepRaf: number | null = null;
   /** Whether the one-shot buffering listeners are wired onto the audio element. */
   private audioListenersAttached = false;
 
@@ -1058,7 +1064,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     this.metadataCache.ensureLoaded([id]);
     // Starts loading: show the spinner on the now-playing widget until a
     // ``playing``/``canplay`` event clears it.
-    this.nowPlaying.emit({ mediaId: id, waveUrl: this.thumbnailUrl(id), loading: true });
+    this.nowPlaying.emit({ mediaId: id, waveUrl: this.thumbnailUrl(id), loading: true, progress: null });
     setTimeout(() => {
       const el = this.audioRef()?.nativeElement;
       if (!el) return;
@@ -1070,6 +1076,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
       applyClipWindow(el, () => this.metadataCache.get(id));
       el.load();
       el.play().catch(() => {});
+      // Advance the playhead sweep while it sounds; self-cancels on pause/stop.
+      this.startSweep();
     });
   }
 
@@ -1085,12 +1093,40 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     el.addEventListener('canplay', () => this.emitNowPlaying(false));
   }
 
-  /** Re-emit the now-playing state with a fresh ``loading`` flag. A no-op once
-   *  nothing is auditioning, so events that fire after a stop don't resurrect
-   *  the widget. */
+  /** Re-emit the now-playing state with a fresh ``loading`` flag and the current
+   *  playhead position. A no-op once nothing is auditioning, so events that fire
+   *  after a stop don't resurrect the widget. */
   private emitNowPlaying(loading: boolean): void {
-    if (this.audioSrc === '' || this.nowPlayingId == null) return;
-    this.nowPlaying.emit({ mediaId: this.nowPlayingId, waveUrl: this.thumbnailUrl(this.nowPlayingId), loading });
+    const id = this.nowPlayingId;
+    if (this.audioSrc === '' || id == null) return;
+    this.nowPlayingLoading = loading;
+    const el = this.audioRef()?.nativeElement;
+    const progress = el ? clipProgress(el, () => this.metadataCache.get(id)) : null;
+    this.nowPlaying.emit({ mediaId: id, waveUrl: this.thumbnailUrl(id), loading, progress });
+  }
+
+  // Re-emit the now-playing state ~60×/sec so the playhead sweeps smoothly:
+  // (timeupdate) fires only ~4×/sec, too coarse for a fluid line. Self-cancels
+  // when the clip pauses or stops; idempotent while a loop is already live.
+  private startSweep(): void {
+    if (this.sweepRaf !== null || typeof requestAnimationFrame !== 'function') return;
+    const tick = (): void => {
+      const el = this.audioRef()?.nativeElement;
+      if (this.nowPlayingId == null || !el || el.paused) {
+        this.sweepRaf = null;
+        return;
+      }
+      this.emitNowPlaying(this.nowPlayingLoading);
+      this.sweepRaf = requestAnimationFrame(tick);
+    };
+    this.sweepRaf = requestAnimationFrame(tick);
+  }
+
+  private stopSweep(): void {
+    if (this.sweepRaf !== null) {
+      cancelAnimationFrame(this.sweepRaf);
+      this.sweepRaf = null;
+    }
   }
 
   /** Cursor left the grid: stop any hover audio and fall the preview back to the
@@ -1105,6 +1141,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   private stopAudio(): void {
     const wasPlaying = this.audioSrc !== '';
+    this.stopSweep();
     const el = this.audioRef()?.nativeElement;
     if (el) {
       clearClipWindow(el);

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -282,18 +282,20 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     // The window opened auditioning the representative (id 8), not the list's
     // first member (id 7), and surfaced it on the shared now-playing indicator —
     // flagged `loading` until the clip is actually sounding.
-    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: true });
+    // `progress` is null until a finite duration is known (jsdom has no media
+    // pipeline, so it never is); the sweeping playhead stays hidden meanwhile.
+    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: true, progress: null });
 
     // The clip's audio element drives the buffering spinner: `playing` clears
     // the loading flag, a `waiting` stall re-sets it.
     const audioEl = fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
     audioEl.dispatchEvent(new Event('playing'));
     await settlePasses(fixture);
-    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: false });
+    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: false, progress: null });
 
     audioEl.dispatchEvent(new Event('waiting'));
     await settlePasses(fixture);
-    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: true });
+    expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: true, progress: null });
 
     playStub.mockRestore();
     loadStub.mockRestore();

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, o
 
 import { ActiveContextService } from '../../services/active-context.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
-import { applyClipWindow, clearClipWindow } from '../../utils/clip-window';
+import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
 import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
 
 /** A clip currently auditioning from a VTSBrowse hover (a canvas bin here, or a
@@ -18,6 +18,11 @@ export interface NowPlaying {
    *  spinner on the now-playing widget. Flips to ``false`` once playback is
    *  actually audible. */
   loading: boolean;
+  /** Playback position within the (possibly windowed) clip as a fraction in
+   *  ``[0, 1]``, or ``null`` before a finite duration is known. Drives the
+   *  sweeping playhead line on the now-playing waveform, updated ~60×/sec on a
+   *  requestAnimationFrame loop while the clip sounds. */
+  progress: number | null;
 }
 
 /** How long (ms) the cursor must rest on an audio bin before its clip starts
@@ -63,6 +68,12 @@ export class BrowseHoverPreviewComponent implements OnDestroy {
   /** Waveform PNG of the clip currently auditioning, kept so the buffering
    *  listeners below can re-emit the now-playing state without recomputing it. */
   private nowPlayingWaveUrl = '';
+  /** Last ``loading`` flag emitted, so the playhead sweep re-emits with the
+   *  live buffering state rather than forcing it back to ``false``. */
+  private nowPlayingLoading = false;
+  /** Handle of the in-flight requestAnimationFrame playhead sweep, or ``null``
+   *  when the loop is stopped. */
+  private sweepRaf: number | null = null;
 
   constructor() {
     // The hover input drives the whole preview: show over a cell, hide on
@@ -104,6 +115,7 @@ export class BrowseHoverPreviewComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.cancelDwell();
+    this.stopSweep();
     this.stopAudio();
     this.textLoadAbort?.abort();
   }
@@ -180,21 +192,51 @@ export class BrowseHoverPreviewComponent implements OnDestroy {
     this.audioEl.play().catch(() => {});
     // Starts loading: show the spinner until a ``playing``/``canplay`` event
     // (wired in the constructor) clears it.
-    this.nowPlaying.emit({ mediaId, waveUrl, loading: true });
+    this.emitNowPlaying(true);
+    // Advance the playhead sweep while it sounds; self-cancels on pause/stop.
+    this.startSweep();
   }
 
-  /** Re-emit the now-playing state with a fresh ``loading`` flag, from the
-   *  buffering listeners. A no-op once nothing is auditioning, so events that
-   *  fire after a stop don't resurrect the widget. */
+  /** Re-emit the now-playing state with a fresh ``loading`` flag and the current
+   *  playhead position, from the buffering listeners and the sweep loop. A no-op
+   *  once nothing is auditioning, so events that fire after a stop don't
+   *  resurrect the widget. */
   private emitNowPlaying(loading: boolean): void {
-    if (this.playingMediaId == null) return;
-    this.nowPlaying.emit({ mediaId: this.playingMediaId, waveUrl: this.nowPlayingWaveUrl, loading });
+    const mediaId = this.playingMediaId;
+    if (mediaId == null) return;
+    this.nowPlayingLoading = loading;
+    const progress = clipProgress(this.audioEl, () => this.metadataCache.get(mediaId));
+    this.nowPlaying.emit({ mediaId, waveUrl: this.nowPlayingWaveUrl, loading, progress });
+  }
+
+  // Re-emit the now-playing state ~60×/sec so the playhead sweeps smoothly:
+  // (timeupdate) fires only ~4×/sec, too coarse for a fluid line. Self-cancels
+  // when the clip pauses or stops; idempotent while a loop is already live.
+  private startSweep(): void {
+    if (this.sweepRaf !== null || typeof requestAnimationFrame !== 'function') return;
+    const tick = (): void => {
+      if (this.playingMediaId == null || this.audioEl.paused) {
+        this.sweepRaf = null;
+        return;
+      }
+      this.emitNowPlaying(this.nowPlayingLoading);
+      this.sweepRaf = requestAnimationFrame(tick);
+    };
+    this.sweepRaf = requestAnimationFrame(tick);
+  }
+
+  private stopSweep(): void {
+    if (this.sweepRaf !== null) {
+      cancelAnimationFrame(this.sweepRaf);
+      this.sweepRaf = null;
+    }
   }
 
   private stopAudio(): void {
     this.pendingMediaId = null;
     if (this.playingMediaId == null) return;
     this.playingMediaId = null;
+    this.stopSweep();
     clearClipWindow(this.audioEl);
     this.audioEl.pause();
     this.audioEl.currentTime = 0;

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.zoneless.spec.ts
@@ -125,7 +125,9 @@ describe('BrowseHoverPreviewComponent (zoneless canary)', () => {
     // waveform for the top-left indicator — flagged `loading` until the clip is
     // actually sounding — still no panel in the canvas.
     expect(playSpy).toHaveBeenCalled();
-    expect(emitted).toEqual({ mediaId: 7, waveUrl: '/api/medias/7/thumbnail', loading: true });
+    // `progress` is null until a finite duration is known (jsdom has no media
+    // pipeline, so it never is); the sweeping playhead stays hidden meanwhile.
+    expect(emitted).toEqual({ mediaId: 7, waveUrl: '/api/medias/7/thumbnail', loading: true, progress: null });
     expect(fixture.nativeElement.querySelector('.hover-player')).toBeNull();
   });
 
@@ -139,7 +141,7 @@ describe('BrowseHoverPreviewComponent (zoneless canary)', () => {
     await settleZoneless(fixture);
 
     // Auditioning starts in the loading state (fetch/decode not done yet).
-    expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: true });
+    expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: true, progress: null });
 
     // The reused (never-mounted) audio element drives the buffering listeners.
     const audioEl = (fixture.componentInstance as unknown as { audioEl: HTMLAudioElement }).audioEl;
@@ -147,12 +149,12 @@ describe('BrowseHoverPreviewComponent (zoneless canary)', () => {
     // The element reports it's now playing → spinner clears.
     audioEl.dispatchEvent(new Event('playing'));
     await settleZoneless(fixture);
-    expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: false });
+    expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: false, progress: null });
 
     // A stall to rebuffer mid-play → spinner returns.
     audioEl.dispatchEvent(new Event('waiting'));
     await settleZoneless(fixture);
-    expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: true });
+    expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: true, progress: null });
   });
 
   it('debounces the dwell so sweeping across bins plays only the settled one', async () => {

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -12,7 +12,7 @@ import { NoFocusStealDirective } from '../../directives/no-focus-steal.directive
 import { IconComponent } from '../icon/icon.component';
 import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
-import { applyClipWindow, clearClipWindow } from '../../utils/clip-window';
+import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
 import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
 
 /** Ordering for the selected-item list. No detector confidence in browse, so
@@ -116,6 +116,12 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   /** Waveform PNG of the clip currently auditioning, kept so the buffering
    *  listeners can re-emit the now-playing state without recomputing it. */
   private nowPlayingWaveUrl = '';
+  /** Last ``loading`` flag emitted, so the playhead sweep re-emits with the
+   *  live buffering state rather than forcing it back to ``false``. */
+  private nowPlayingLoading = false;
+  /** Handle of the in-flight requestAnimationFrame playhead sweep, or ``null``
+   *  when the loop is stopped. */
+  private sweepRaf: number | null = null;
   private dwellTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingMediaId: number | null = null;
   private playingMediaId: number | null = null;
@@ -165,6 +171,7 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     for (const sub of this.subs) sub.unsubscribe();
     this.cancelDwell();
+    this.stopSweep();
     this.stopAudio();
   }
 
@@ -325,21 +332,51 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
     this.audioEl.play().catch(() => {});
     // Starts loading: show the spinner until a ``playing``/``canplay`` event
     // (wired in the constructor) clears it.
-    this.nowPlaying.emit({ mediaId, waveUrl, loading: true });
+    this.emitNowPlaying(true);
+    // Advance the playhead sweep while it sounds; self-cancels on pause/stop.
+    this.startSweep();
   }
 
-  /** Re-emit the now-playing state with a fresh ``loading`` flag, from the
-   *  buffering listeners. A no-op once nothing is auditioning, so events that
-   *  fire after a stop don't resurrect the widget. */
+  /** Re-emit the now-playing state with a fresh ``loading`` flag and the current
+   *  playhead position, from the buffering listeners and the sweep loop. A no-op
+   *  once nothing is auditioning, so events that fire after a stop don't
+   *  resurrect the widget. */
   private emitNowPlaying(loading: boolean): void {
-    if (this.playingMediaId == null) return;
-    this.nowPlaying.emit({ mediaId: this.playingMediaId, waveUrl: this.nowPlayingWaveUrl, loading });
+    const mediaId = this.playingMediaId;
+    if (mediaId == null) return;
+    this.nowPlayingLoading = loading;
+    const progress = clipProgress(this.audioEl, () => this.metadataCache.get(mediaId));
+    this.nowPlaying.emit({ mediaId, waveUrl: this.nowPlayingWaveUrl, loading, progress });
+  }
+
+  // Re-emit the now-playing state ~60×/sec so the playhead sweeps smoothly:
+  // (timeupdate) fires only ~4×/sec, too coarse for a fluid line. Self-cancels
+  // when the clip pauses or stops; idempotent while a loop is already live.
+  private startSweep(): void {
+    if (this.sweepRaf !== null || typeof requestAnimationFrame !== 'function') return;
+    const tick = (): void => {
+      if (this.playingMediaId == null || this.audioEl.paused) {
+        this.sweepRaf = null;
+        return;
+      }
+      this.emitNowPlaying(this.nowPlayingLoading);
+      this.sweepRaf = requestAnimationFrame(tick);
+    };
+    this.sweepRaf = requestAnimationFrame(tick);
+  }
+
+  private stopSweep(): void {
+    if (this.sweepRaf !== null) {
+      cancelAnimationFrame(this.sweepRaf);
+      this.sweepRaf = null;
+    }
   }
 
   private stopAudio(): void {
     this.pendingMediaId = null;
     if (this.playingMediaId == null) return;
     this.playingMediaId = null;
+    this.stopSweep();
     clearClipWindow(this.audioEl);
     this.audioEl.pause();
     this.audioEl.currentTime = 0;

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
@@ -160,7 +160,9 @@ describe('BrowseSelectionPanelComponent (zoneless canary)', () => {
     // After the dwell: playback starts and `nowPlaying` carries the clip's
     // waveform for the top-left indicator — flagged `loading` until it sounds.
     expect(playSpy).toHaveBeenCalled();
-    expect(emitted).toEqual({ mediaId: 7, waveUrl: '/api/medias/7/thumbnail', loading: true });
+    // `progress` is null until a finite duration is known (jsdom has no media
+    // pipeline, so it never is); the sweeping playhead stays hidden meanwhile.
+    expect(emitted).toEqual({ mediaId: 7, waveUrl: '/api/medias/7/thumbnail', loading: true, progress: null });
   });
 
   it('stops the audition and emits nowPlaying(null) as soon as the cursor leaves', async () => {

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -81,6 +81,17 @@
                         [style.-webkit-mask-image]="'url(' + np.waveUrl + ')'"
                         [style.mask-image]="'url(' + np.waveUrl + ')'"
                       ></div>
+                      <!-- Playhead: a thin line swept left→right as the clip
+                           sounds (issue-follow-up to #2574, which added the same
+                           sweep to the center-panel player). Positioned by a
+                           `left: %` binding off the clip-window progress fraction;
+                           hidden until a finite duration is known. -->
+                      @if (np.progress !== null) {
+                        <div
+                          class="browse-now-playing-playhead"
+                          [style.left.%]="np.progress * 100"
+                        ></div>
+                      }
                     </div>
                     @if (np.loading) {
                       <div class="browse-now-playing-loading" role="status" aria-label="Loading audio">

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -98,12 +98,29 @@
 // the inner fill masks the accent colour to the wave shape, so it recolours
 // with the live theme instead of showing baked-in pixels.
 .browse-now-playing-wave {
+  position: relative;
   width: 120px;
   height: 36px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-surface);
   overflow: hidden;
+}
+
+// Thin vertical line swept left->right as the clip plays, positioned by a
+// `left: %` binding off the playback progress fraction. Shares the warm
+// `--waveform-playhead` accent with the center-panel player so it reads as the
+// complement of the (accent-tinted) wave and never blends in. `overflow: hidden`
+// on the wave box clips it to the rounded corners; never intercepts pointer.
+.browse-now-playing-playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  margin-left: -1px;
+  background: var(--waveform-playhead);
+  pointer-events: none;
+  will-change: left;
 }
 
 // Tinted wave; the shared ``.waveform-mask`` supplies the accent fill and mask

--- a/frontend/src/app/utils/clip-window.spec.ts
+++ b/frontend/src/app/utils/clip-window.spec.ts
@@ -144,8 +144,8 @@ describe('clipProgress', () => {
 
   it('falls back to the duration as the window end when only clip_start is set', () => {
     const el = audioWithDuration(100);
-    el.currentTime = 70; // 10s into a [50, 100] span → 0.2
-    expect(clipProgress(el, () => media({ clip_start: 50 }))).toBeCloseTo(0.2);
+    el.currentTime = 70; // 20s into a [50, 100] span → 0.4
+    expect(clipProgress(el, () => media({ clip_start: 50 }))).toBeCloseTo(0.4);
   });
 
   it('clamps to [0, 1] when currentTime strays outside the window', () => {

--- a/frontend/src/app/utils/clip-window.spec.ts
+++ b/frontend/src/app/utils/clip-window.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { applyClipWindow, clearClipWindow } from './clip-window';
+import { applyClipWindow, clearClipWindow, clipProgress } from './clip-window';
 import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
 
 /**
@@ -94,5 +94,71 @@ describe('applyClipWindow', () => {
 
     expect(el.onloadedmetadata).toBeNull();
     expect(el.ontimeupdate).toBeNull();
+  });
+});
+
+/**
+ * Unit coverage for the now-playing playhead fraction: the sweeping line on the
+ * VTSBrowse Now-Playing waveform maps playback position across the same window
+ * the thumbnail PNG depicts (whole file for a plain clip, [clip_start, clip_end]
+ * for a windowed archive member). jsdom leaves `duration` as NaN, so each test
+ * stamps a finite value onto the element.
+ */
+describe('clipProgress', () => {
+  function media(partial: Partial<MediaBatchResponse>): MediaBatchResponse {
+    return {
+      id: 1,
+      media_type: 'audio',
+      filename: 'clip.wav',
+      md5: 'x',
+      custom_metadata: {},
+      ...partial,
+    } as MediaBatchResponse;
+  }
+
+  function audioWithDuration(duration: number): HTMLAudioElement {
+    const el = document.createElement('audio');
+    Object.defineProperty(el, 'duration', { value: duration, configurable: true });
+    return el;
+  }
+
+  it('returns null before a finite, positive duration is known', () => {
+    const el = document.createElement('audio'); // jsdom duration is NaN
+    expect(clipProgress(el, () => undefined)).toBeNull();
+
+    const zero = audioWithDuration(0);
+    expect(clipProgress(zero, () => undefined)).toBeNull();
+  });
+
+  it('maps currentTime across the whole file for a non-windowed clip', () => {
+    const el = audioWithDuration(100);
+    el.currentTime = 25;
+    expect(clipProgress(el, () => media({}))).toBeCloseTo(0.25);
+  });
+
+  it('maps currentTime across the [clip_start, clip_end] window for a windowed clip', () => {
+    const el = audioWithDuration(100);
+    el.currentTime = 45; // 5s into a [40, 50] window → halfway
+    expect(clipProgress(el, () => media({ clip_start: 40, clip_end: 50 }))).toBeCloseTo(0.5);
+  });
+
+  it('falls back to the duration as the window end when only clip_start is set', () => {
+    const el = audioWithDuration(100);
+    el.currentTime = 70; // 10s into a [50, 100] span → 0.2
+    expect(clipProgress(el, () => media({ clip_start: 50 }))).toBeCloseTo(0.2);
+  });
+
+  it('clamps to [0, 1] when currentTime strays outside the window', () => {
+    const el = audioWithDuration(100);
+    el.currentTime = 30; // before a [40, 50] window
+    expect(clipProgress(el, () => media({ clip_start: 40, clip_end: 50 }))).toBe(0);
+    el.currentTime = 60; // past the window end
+    expect(clipProgress(el, () => media({ clip_start: 40, clip_end: 50 }))).toBe(1);
+  });
+
+  it('returns null for a degenerate zero-length window', () => {
+    const el = audioWithDuration(100);
+    el.currentTime = 40;
+    expect(clipProgress(el, () => media({ clip_start: 40, clip_end: 40 }))).toBeNull();
   });
 });

--- a/frontend/src/app/utils/clip-window.ts
+++ b/frontend/src/app/utils/clip-window.ts
@@ -45,3 +45,30 @@ export function clearClipWindow(el: HTMLAudioElement): void {
   el.onloadedmetadata = null;
   el.ontimeupdate = null;
 }
+
+/**
+ * Playback position of ``el`` as a fraction in ``[0, 1]`` of the clip the
+ * now-playing waveform depicts, or ``null`` when no finite duration is known
+ * yet (so the caller can hide the playhead until playback has a meaningful
+ * position).
+ *
+ * The fraction is measured across the *window* the thumbnail shows, mirroring
+ * {@link applyClipWindow} and the server's ``generate_waveform_thumbnail_window``
+ * (which slices the PNG to ``[clip_start, clip_end]``): a windowed clip's
+ * playhead sweeps ``[clip_start, clip_end]`` edge-to-edge, and a non-windowed
+ * clip's sweeps ``[0, duration]``. This keeps the sweeping line aligned with the
+ * waveform pixels the user actually sees.
+ */
+export function clipProgress(
+  el: HTMLAudioElement,
+  lookup: () => MediaBatchResponse | undefined,
+): number | null {
+  const duration = el.duration;
+  if (!Number.isFinite(duration) || duration <= 0) return null;
+  const media = lookup();
+  const start = media?.clip_start ?? 0;
+  const end = media?.clip_end ?? duration;
+  const span = end - start;
+  if (span <= 0) return null;
+  return Math.max(0, Math.min(1, (el.currentTime - start) / span));
+}


### PR DESCRIPTION
## Summary

The upper-left **Now Playing** audio waveform thumbnail in VTSBrowse showed only a static wave with no time position. #2574 added a sweeping playhead (and click-to-seek) to the **center-panel** audio player, but that change never touched the VTSBrowse Now-Playing widget — a different component — so the sweep still didn't appear where this report was about. This adds the sweeping time position to the VTSBrowse widget.

## What changed

- **`NowPlaying` contract** gains a `progress: number | null` field (fraction in `[0, 1]`, or `null` before a finite duration is known). All three emitters that feed the top-left widget — `browse-hover-preview`, `browse-bin-popup`, `browse-selection-panel` — now populate it.
- **Shared `clipProgress()` helper** (`utils/clip-window.ts`) maps playback position across the *same window the thumbnail PNG depicts*: the whole file for a plain clip, `[clip_start, clip_end]` for a windowed archive member — matching the server's `generate_waveform_thumbnail_window`, which slices the PNG to that window. So the line stays aligned with the wave pixels the user sees, and sweeps edge-to-edge each loop.
- Each emitter drives a `requestAnimationFrame` loop while its clip sounds and re-emits `NowPlaying` (`timeupdate` fires only ~4×/sec, too coarse for a fluid line). The loop self-cancels on pause/stop.
- **`browse-view`** renders a thin vertical line inside the wave box, positioned by a `left: %` binding off `progress`, hidden until `progress` is known. It reuses the theme-aware `--waveform-playhead` accent introduced in #2574.

## Testing

- New `clipProgress` unit coverage (whole-file, windowed, clamping, degenerate window, unknown duration).
- Updated the three now-playing emitter specs to assert `progress: null` (jsdom has no media pipeline, so duration is never finite there).
- `./run-tests.sh frontend`: build OK, audit OK, 1707 Vitest tests pass.

No screenshot reshoot is queued: the widget only appears transiently while a clip auditions on hover, so it isn't framed by any static doc screenshot.

Refs #2574.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsSLB6xVA42Y5kCPsbMNDC)_