### PR TITLE
Honor hidden_from_picker in Add Dataset > Convert To

### DIFF
--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
@@ -34,20 +34,9 @@
       }
     </div>
 
-    <div class="form-group">
-      <label class="col-label" for="combine-policy" title="How to handle labels that disagree across sources">Conflict policy</label>
-      <select
-        id="combine-policy"
-        class="form-select"
-        [(ngModel)]="conflictPolicy"
-        name="conflictPolicy"
-        disabled
-        title="Only one policy is supported today"
-      >
-        <option value="drop">Drop conflicting labels</option>
-      </select>
-      <p class="info-text">Only one policy is supported today.</p>
-    </div>
+    <p class="info-text" title="How labels that disagree across sources are handled">
+      Labels that disagree across sources are dropped.
+    </p>
 
     @if (error) {
       <p class="error-text">{{ error }}</p>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
@@ -10,7 +10,7 @@
   </button>
 }
 
-@if (advancedOpen && showSourceSpecs()) {
+@if (advancedOpen && hasSourceSpecsColumn) {
   <label class="form-label" title="Pick which source media types feed the dataset. The native type is included directly; other types are pulled in and converted.">Include media</label>
   <vt-source-specs-picker
     [availableConverters]="availableConverters()"

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ImportAdvancedComponent } from './import-advanced.component';
 import { provideZoneless } from '../../../../testing/zoneless-testbed';
 import { settleZoneless } from '../../../../testing/settle-resource';
-import { ClipperInfo, EmbedderInfo, SourceSpec } from '../../../../models/api.models';
+import { ClipperInfo, ConverterInfo, EmbedderInfo, SourceSpec } from '../../../../models/api.models';
 
 describe('ImportAdvancedComponent', () => {
   let component: ImportAdvancedComponent;
@@ -19,6 +19,10 @@ describe('ImportAdvancedComponent', () => {
   const clippers: ClipperInfo[] = [
     { name: 'clip_default', display_name: 'Default clipper' } as ClipperInfo,
     { name: 'sliding', display_name: 'Sliding window' } as ClipperInfo,
+  ];
+
+  const converters: ConverterInfo[] = [
+    { name: 'video2image', source_type: 'video', target_type: 'image', fields: [] } as ConverterInfo,
   ];
 
   async function setInputs(inputs: Record<string, unknown>): Promise<void> {
@@ -155,7 +159,7 @@ describe('ImportAdvancedComponent', () => {
     });
 
     it('is false when the source-specs column already hosts the native Details button', async () => {
-      await setInputs({ clippers, selectedClipper: 'clip_default', showSourceSpecs: true });
+      await setInputs({ clippers, selectedClipper: 'clip_default', showSourceSpecs: true, availableConverters: converters });
       component.advancedOpen = true;
       expect(component.showStandaloneClipperButton).toBe(false);
     });
@@ -164,6 +168,32 @@ describe('ImportAdvancedComponent', () => {
       await setInputs({ clippers, selectedClipper: 'clip_default', showSourceSpecs: false });
       component.advancedOpen = true;
       expect(component.showStandaloneClipperButton).toBe(true);
+    });
+
+    it('is true when the source-specs flow is on but no converters feed it (empty column suppressed)', async () => {
+      // showSourceSpecs is true but there are no non-native converters, so the
+      // Include-media column collapses to a trivial native-only row and is
+      // hidden; the clipper chooser must stay reachable via the standalone button.
+      await setInputs({ clippers, selectedClipper: 'clip_default', showSourceSpecs: true, availableConverters: [] });
+      component.advancedOpen = true;
+      expect(component.showStandaloneClipperButton).toBe(true);
+    });
+  });
+
+  describe('hasSourceSpecsColumn', () => {
+    it('is false when the source-specs flow is off', async () => {
+      await setInputs({ showSourceSpecs: false, availableConverters: converters });
+      expect(component.hasSourceSpecsColumn).toBe(false);
+    });
+
+    it('is false when there are no non-native converters', async () => {
+      await setInputs({ showSourceSpecs: true, availableConverters: [] });
+      expect(component.hasSourceSpecsColumn).toBe(false);
+    });
+
+    it('is true when the flow is on and at least one converter feeds the native type', async () => {
+      await setInputs({ showSourceSpecs: true, availableConverters: converters });
+      expect(component.hasSourceSpecsColumn).toBe(true);
     });
   });
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
@@ -142,6 +142,18 @@ export class ImportAdvancedComponent {
     return this.clippers().length > 0 && this.clippers()[0].name === this.selectedClipper();
   }
 
+  /** Whether the source-specs "Include media" column has anything worth
+   *  showing: the importer participates in the source-specs flow AND at
+   *  least one non-native converter feeds the native type.  When a media
+   *  type has no converters into it (e.g. video, document), the column
+   *  would render only the forced, always-checked native row - a
+   *  question with no real answer - so it is suppressed entirely.  This
+   *  matches the Import Defaults settings, which gates the same block on
+   *  ``activeConverters.length > 0``. */
+  get hasSourceSpecsColumn(): boolean {
+    return this.showSourceSpecs() && this.availableConverters().length > 0;
+  }
+
   /** The Advanced toggle is shown either when the Include-media block
    *  is available (it lives strictly behind the toggle, so the toggle
    *  must be reachable) or when neither embedder nor clipper has been
@@ -169,7 +181,7 @@ export class ImportAdvancedComponent {
 
   /** Whether to render the standalone clipper "Details" button below
    *  the Advanced block.  When the source-specs column is visible
-   *  (Advanced open AND ``showSourceSpecs`` true), the native row in
+   *  (Advanced open AND :prop:`hasSourceSpecsColumn`), the native row in
    *  the column hosts its own Details button, so the standalone one
    *  would be redundant.  In every other case where the user should be
    *  able to reach the clipper chooser (Advanced collapsed but a
@@ -180,7 +192,7 @@ export class ImportAdvancedComponent {
   get showStandaloneClipperButton(): boolean {
     if (this.clippers().length <= 1) return false;
     if (!this.showClipperPicker) return false;
-    return !(this.advancedOpen && this.showSourceSpecs());
+    return !(this.advancedOpen && this.hasSourceSpecsColumn);
   }
 
   /** Embedders flagged ``is_default`` for the active media type; shown

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -68,13 +68,15 @@
       <label title="Show both good and bad predictions"><input type="radio" name="sides" value="both" [(ngModel)]="exportSides" (ngModelChange)="onSidesChange()" /> Both</label>
     </div>
 
-    <div class="export-row">
-      <select class="form-select" [ngModel]="selectedExporter()" (ngModelChange)="selectedExporter.set($event); onExporterChange()" title="Choose export destination">
-        @for (exp of exporters(); track exp.name) {
-          <option [value]="exp.name">{{ exp.display_name || exp.name }}</option>
-        }
-      </select>
-    </div>
+    @if (exporters().length > 1) {
+      <div class="export-row">
+        <select class="form-select" [ngModel]="selectedExporter()" (ngModelChange)="selectedExporter.set($event); onExporterChange()" title="Choose export destination">
+          @for (exp of exporters(); track exp.name) {
+            <option [value]="exp.name">{{ exp.display_name || exp.name }}</option>
+          }
+        </select>
+      </div>
+    }
 
     @for (field of exporterFields(); track field.key) {
       <div class="form-group">

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -53,9 +53,12 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.exportersApi.getExporters().pipe(takeUntil(this.destroy$)).subscribe({
       next: (list) => {
-        this.exporters.set(list);
-        if (list.length > 0) {
-          this.selectedExporter.set(list[0].name);
+        // Drop exporters the plugin author flagged hidden_from_picker so they
+        // never surface in this destination picker (matches the export modal).
+        const visible = list.filter((exp) => !exp.hidden_from_picker);
+        this.exporters.set(visible);
+        if (visible.length > 0) {
+          this.selectedExporter.set(visible[0].name);
           this.updateExporterFields();
         }
       },

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
@@ -30,6 +30,9 @@
 }
 
 <!-- Results Exporter ------------------------------------------------------ -->
+<!-- Hidden entirely when no exporters are available: the section would
+     otherwise degrade to a lone "None" tab (a picker with no real choice). -->
+@if (loadingExporters || exporters.length > 0) {
 <h4 class="subhead">
   Results Exporter:
   <span
@@ -106,4 +109,5 @@
       }
     }
   </div>
+}
 }

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -117,19 +117,23 @@
 
           @if (mediaTypes().length > 0) {
             <h4 class="subhead" title="Configure how media items are displayed and selected in each panel, per media type">Scroll Style</h4>
-            <div class="view-tabs">
-              @for (mt of mediaTypes(); track mt.type_id) {
-                <button
-                  class="view-tab"
-                  [class.view-tab--active]="activeViewTab() === mt.type_id"
-                  (click)="activeViewTab.set(mt.type_id)">
-                  @if (mt.icon) {
-                    <vt-icon [type]="mt.icon" [size]="14"></vt-icon>
-                  }
-                  {{ mt.name }}
-                </button>
-              }
-            </div>
+            <!-- A lone media type needs no tab bar (nothing to switch to); the
+                 content below still renders for the single active type. -->
+            @if (mediaTypes().length > 1) {
+              <div class="view-tabs">
+                @for (mt of mediaTypes(); track mt.type_id) {
+                  <button
+                    class="view-tab"
+                    [class.view-tab--active]="activeViewTab() === mt.type_id"
+                    (click)="activeViewTab.set(mt.type_id)">
+                    @if (mt.icon) {
+                      <vt-icon [type]="mt.icon" [size]="14"></vt-icon>
+                    }
+                    {{ mt.name }}
+                  </button>
+                }
+              </div>
+            }
             <div class="view-tab-content">
               <div class="view-side-section">
                 <h4 class="subhead" title="Display settings for the left panel (unlabeled media list)">Left Side</h4>
@@ -269,20 +273,24 @@
         @if (activeSettingsTab() === 'browser') {
           <h3>Browser<vt-field-hint-icon hint="How the Browse map looks, per media type. The same controls live on the map; changes here are remembered."></vt-field-hint-icon></h3>
           @if (mediaTypes().length > 0) {
-            <div class="view-tabs">
-              @for (mt of mediaTypes(); track mt.type_id) {
-                <button
-                  class="view-tab"
-                  [class.view-tab--active]="activeBrowseTab() === mt.type_id"
-                  (click)="activeBrowseTab.set(mt.type_id)"
-                  [title]="'Browser settings for ' + mt.name + ' datasets'">
-                  @if (mt.icon) {
-                    <vt-icon [type]="mt.icon" [size]="14"></vt-icon>
-                  }
-                  {{ mt.name }}
-                </button>
-              }
-            </div>
+            <!-- A lone media type needs no tab bar (nothing to switch to); the
+                 content below still renders for the single active type. -->
+            @if (mediaTypes().length > 1) {
+              <div class="view-tabs">
+                @for (mt of mediaTypes(); track mt.type_id) {
+                  <button
+                    class="view-tab"
+                    [class.view-tab--active]="activeBrowseTab() === mt.type_id"
+                    (click)="activeBrowseTab.set(mt.type_id)"
+                    [title]="'Browser settings for ' + mt.name + ' datasets'">
+                    @if (mt.icon) {
+                      <vt-icon [type]="mt.icon" [size]="14"></vt-icon>
+                    }
+                    {{ mt.name }}
+                  </button>
+                }
+              </div>
+            }
             <div class="view-tab-content browser-tab-content">
               <div class="form-group">
                 <label class="form-label" title="Slide clusters together to close the empty space between them when the map is built">Compaction<vt-field-hint-icon hint="Slides clusters together to close the empty gaps between them. Applies next time the map is built."></vt-field-hint-icon></label>

--- a/tests/converters/test_audio2image_and_image2text.py
+++ b/tests/converters/test_audio2image_and_image2text.py
@@ -435,5 +435,9 @@ class TestNewConverterRegistryIntegration:
         resp = client.get("/api/converters")
         assert resp.status_code == 200
         names = [c["name"] for c in resp.get_json()["converters"]]
-        assert "audio2image" in names
+        # image2text is a normal picker-visible converter.
         assert "image2text" in names
+        # audio2image carries hidden_from_picker=True: registered (see the
+        # list_converters_for_* tests above) but excluded from the picker
+        # endpoint.
+        assert "audio2image" not in names

--- a/tests/converters/test_audio2text.py
+++ b/tests/converters/test_audio2text.py
@@ -281,8 +281,11 @@ class TestAudio2TextRegistryIntegration:
         names = [c.name for c in list_converters_for_source("audio")]
         assert "audio2text" in names
 
-    def test_api_lists_audio2text(self, client):
+    def test_api_hides_audio2text_from_picker(self, client):
+        # audio2text carries hidden_from_picker=True: registered (see the
+        # list_converters_for_* tests above) but excluded from the
+        # picker-facing /api/converters endpoint.
         resp = client.get("/api/converters")
         assert resp.status_code == 200
         names = [c["name"] for c in resp.get_json()["converters"]]
-        assert "audio2text" in names
+        assert "audio2text" not in names

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -233,6 +233,31 @@ class TestConvertersAPI:
             assert "display_name" in c
             assert "description" in c
 
+    def test_hidden_from_picker_converters_excluded_from_full_list(self, client):
+        # audio2image / audio2text carry ``hidden_from_picker = True`` and
+        # must never surface in the picker-facing listing endpoint.
+        resp = client.get("/api/converters")
+        names = [c["name"] for c in resp.get_json()["converters"]]
+        assert "audio2image" not in names
+        assert "audio2text" not in names
+
+    def test_hidden_from_picker_converters_excluded_when_filtering_by_source(self, client):
+        # The demo picker's "Convert to" selector reads /api/converters?source=audio;
+        # the hidden audio converters must not leak into it.
+        resp = client.get("/api/converters?source=audio")
+        assert resp.status_code == 200
+        names = [c["name"] for c in resp.get_json()["converters"]]
+        assert "audio2image" not in names
+        assert "audio2text" not in names
+
+    def test_hidden_from_picker_converters_excluded_when_filtering_by_target(self, client):
+        # audio2image targets image; it must not appear among image converters.
+        image_names = [c["name"] for c in client.get("/api/converters?target=image").get_json()["converters"]]
+        assert "audio2image" not in image_names
+        # audio2text targets text; likewise for the text listing.
+        text_names = [c["name"] for c in client.get("/api/converters?target=text").get_json()["converters"]]
+        assert "audio2text" not in text_names
+
 
 # ===========================================================================
 # Importer build_cli_args / build_origin with converters

--- a/tests/converters/test_document_and_converters.py
+++ b/tests/converters/test_document_and_converters.py
@@ -700,8 +700,9 @@ class TestDemoListConverters:
         assert "video2image" in conv_names
         assert "video2audio" in conv_names
 
-    def test_demo_list_audio_demo_has_audio2image(self, client):
-        """Audio demos should list the audio2image (spectrogram) converter."""
+    def test_demo_list_audio_demo_hides_hidden_from_picker_converters(self, client):
+        """audio2image / audio2text carry ``hidden_from_picker = True`` and must
+        not appear in an audio demo's "Convert to" selector."""
         resp = client.get("/api/dataset/demo-list")
         demos = resp.get_json()["datasets"]
         audio_demos = [d for d in demos if d["media_type"] == "audio"]
@@ -709,7 +710,8 @@ class TestDemoListConverters:
             pytest.skip("No audio demo datasets registered")
         demo = audio_demos[0]
         conv_names = [c["name"] for c in demo["available_converters"]]
-        assert "audio2image" in conv_names
+        assert "audio2image" not in conv_names
+        assert "audio2text" not in conv_names
 
 
 # ===========================================================================

--- a/vtsearch/routes/datasets/listings.py
+++ b/vtsearch/routes/datasets/listings.py
@@ -113,7 +113,13 @@ def converters_list(query: dict):
     else:
         converters = list_converters()
 
-    return {"converters": [c.to_dict() for c in filter_visible_plugins("converters", converters)]}
+    # Two independent hide mechanisms both apply to this picker-facing
+    # listing: the admin-level ``hidden_plugins`` setting/CLI hide
+    # (``filter_visible_plugins``) and the plugin author's own
+    # ``hidden_from_picker`` flag. Honour both so hidden converters (e.g.
+    # ``audio2image`` / ``audio2text``) never surface in a picker.
+    visible = filter_visible_plugins("converters", converters)
+    return {"converters": [c.to_dict() for c in visible if not c.hidden_from_picker]}
 
 
 @datasets_listings_bp.route("/api/dataset/importers")

--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -209,7 +209,9 @@ def demo_dataset_list(query: dict):
                 "media_type": media_type,
                 "num_categories": len(dataset_info["categories"]),
                 "available_converters": [
-                    c.to_dict() for c in filter_visible_plugins("converters", list_converters_for_source(media_type))
+                    c.to_dict()
+                    for c in filter_visible_plugins("converters", list_converters_for_source(media_type))
+                    if not c.hidden_from_picker
                 ],
                 "pkl_embedder": pkl_embedder or "",
                 "pkl_clipper": pkl_clipper or "",


### PR DESCRIPTION
## Problem

In **Add Dataset > Convert To**, the audio→image (`audio2image`) and audio→text (`audio2text`) converters were still offered even though both carry `hidden_from_picker = True`. The "Hidden tag" was not honored on the converter picker surfaces. Separately, once hidden options are filtered out, several pickers were left rendering a question with no real answer (e.g. a "Convert to" control with nothing to choose, or a lone forced option).

## Part 1 — Honor `hidden_from_picker` on converter listings

Two independent hide mechanisms existed and were applied inconsistently:

- **`hidden_from_picker`** — the plugin author's static "keep this out of pickers" flag. Serialized in `to_dict()` and expected to be filtered before it reaches a picker.
- **`hidden_plugins`** — the admin/CLI deployment hide, filtered server-side via `filter_visible_plugins`.

Three converter picker surfaces existed; only one filtered `hidden_from_picker`. Fixed the two that didn't, server-side, matching the importer `to_dict`:

- `converters_list` (`vtsearch/routes/datasets/listings.py`) — feeds the demo picker's `getConvertersForSource` and Import Defaults' `getConverters`.
- demo-list `available_converters` (`vtsearch/routes/datasets/ui.py`).

## Part 2 — Don't render "questions" with only a trivial answer

App-wide sweep (audited every `<select>` / picker / tab bar in the frontend) for controls that render when they have zero options or a single forced option:

- **Add Dataset → Include media** (`import-advanced`): gated on a new `hasSourceSpecsColumn` (`showSourceSpecs() && availableConverters().length > 0`) so it no longer shows a lone forced native row for media types with no non-native converters (video, document). The standalone clipper button routes through the same predicate so the clipper chooser stays reachable.
- **Demo picker → Convert to**: already gated on `activeTabConvertsTo().length > 0`, so it now correctly disappears for audio after Part 1.
- **Autodetect results modal → export destination**: now filters `hidden_from_picker` exporters and hides the select unless there is more than one exporter.
- **Combine detectors → Conflict policy**: dropped the disabled single-option select (kept a plain info line; the policy is fixed to `drop`).
- **Auto-Find → Results Exporter**: the whole section is hidden when no exporters exist (it degraded to a lone "None" tab).
- **Settings → Scroll Style / Browser**: the per-media-type tab bar is hidden when only one media type exists; the content still renders for the active type.

Already-correct surfaces were left alone (Import Defaults, embedder/clipper pickers, settings importer/exporter pickers, new-detector flows — all gated on option count). Plugin-authored `select` fields that *could* declare ≤1 options are latent only (no shipped plugin does), so their generic renderers were left untouched to avoid value-preservation regressions.

## Incidental fixes (pre-existing `dev` failures surfaced by the full suite)

Per the repo's "fix all errors" policy:

- **`conftest.py` fake audio embedder** raised `KeyError: 'media_path'` on the bulk clip re-embed path (clip dicts carry `media_bytes`), spamming an ERROR log. Now seeds from `media_bytes` when present.
- **`test_batch_medias_includes_clip_fields`** asserted the old top-level `clip_start`/`clip_end` contract for audio clips, but commit `8cbb9b98` deliberately moved those to `custom_metadata` for byte-sliced audio. Updated to the current contract.

## Tests

- New backend regression tests in `test_converter_selection.py`; inverted stale assertions in `test_audio2image_and_image2text.py`, `test_audio2text.py`, `test_document_and_converters.py` (registry-level presence still asserted).
- New frontend `hasSourceSpecsColumn` / standalone-clipper coverage in `import-advanced.component.spec.ts`.
- Python suite: `6412 passed, 1 skipped`. Frontend gate: build OK, `1711` Vitest tests pass.
- No screenshot reshoots needed: the changed surfaces are either edge-case-only (single media type, zero/one exporter — absent from the screenshot deployment) or not screenshotted (combine-detectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)