### PR TITLE
install.sh: explain why the DKMS conversion offer re-appears

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -568,6 +568,20 @@ vts_maybe_convert_driver_to_dkms() {
     echo >&2
     echo "The GPU driver works, but it is NOT DKMS-managed -- it's pinned to the" >&2
     echo "running kernel ($(uname -r)), so the next kernel update will break it." >&2
+    # Explain WHY it's still non-DKMS so a repeat run doesn't look like the offer
+    # forgot a prior "yes". The usual blocker is that `dkms` itself never got
+    # installed -- a conversion can't register the module without it -- which on the
+    # RHEL family means EPEL was unreachable, so an earlier "convert" quietly bailed.
+    if ! command -v dkms >/dev/null 2>&1; then
+        echo "  Seeing this again after saying yes before? 'dkms' is not installed, so" >&2
+        echo "  no prior conversion could have registered the driver. The convert step" >&2
+        echo "  installs dkms first, but on RHEL it lives in EPEL: if that's unreachable" >&2
+        echo "  (e.g. an unregistered box) the install fails and the driver stays pinned." >&2
+        echo "  On RHEL, 'sudo dnf install -y epel-release dkms' first makes it stick." >&2
+    else
+        echo "  ('dkms' is installed but has no nvidia module registered, so the driver" >&2
+        echo "  was built outside DKMS; converting now registers it to auto-rebuild.)" >&2
+    fi
     case "$(vts_decide_dkms_conversion)" in
         convert)
             if vts_convert_driver_to_dkms; then


### PR DESCRIPTION
## Summary

`scripts/install.sh` re-offers to convert a working-but-kernel-pinned GPU driver to a DKMS build on **every** run. If a prior "Y" silently failed, the repeat offer looked like the installer had simply forgotten the earlier answer — which is confusing, because the offer is actually gated on the driver being genuinely DKMS-managed (`command -v dkms && dkms status | grep -qi nvidia`). Re-offering means that gate is *still* false, i.e. the previous conversion never registered the driver.

The common cause is RHEL-specific: `dkms` ships from EPEL, and on an unregistered box EPEL is unreachable, so the convert step's `vts_ensure_dkms_any` can't install `dkms` and bails without touching the working driver. The driver keeps working but stays kernel-pinned, so the next run offers again.

## Change

Before re-offering, `vts_maybe_convert_driver_to_dkms` now diagnoses *why* the driver is still non-DKMS:

- **`dkms` not installed** → says so plainly ("no prior conversion could have registered the driver"), explains the EPEL blocker on RHEL, and points at `sudo dnf install -y epel-release dkms` as the fix.
- **`dkms` present but no nvidia module** → notes the driver was built outside DKMS and converting will register it.

No behavior change to the conversion itself — this only adds context to the offer so a repeat run is self-explanatory instead of looking forgetful.

## Testing

- `bash -n scripts/install.sh` passes.
- Verified both diagnostic branches select correctly (dkms-absent vs dkms-present) via an isolated harness. The script has no automated shell test / shellcheck gate in `run-tests.sh`; it's exercised manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPKv2jCpRDLDTtxHrdK1Yn)_