### PR TITLE
Fix FaceNet weight-download progress bar leaking to stdout

### DIFF
--- a/tests_lib/detectors/test_face.py
+++ b/tests_lib/detectors/test_face.py
@@ -206,9 +206,7 @@ class TestFaceEmbedder:
 
         calls: list[tuple] = []
         emb = FaceEmbedder()
-        emb._on_progress = lambda status, message, current, total: calls.append(
-            (status, message, current, total)
-        )
+        emb._on_progress = lambda status, message, current, total: calls.append((status, message, current, total))
 
         with patch.dict(sys.modules, {"facenet_pytorch": fake_module}):
             emb._load_models_impl()

--- a/tests_lib/detectors/test_face.py
+++ b/tests_lib/detectors/test_face.py
@@ -172,6 +172,53 @@ class TestFaceEmbedder:
         with patch.object(emb, "load_models"):
             assert emb.embed_media({"media_path": "/nonexistent.jpg"}) is None
 
+    def test_weight_load_does_not_leak_progress_bar_to_console(self, capsys):
+        """facenet-pytorch downloads VGGFace2 weights via torch.hub, printing a
+        tqdm bar. The embedder must wrap that in intercept_tqdm_progress so the
+        bar is forwarded to the progress callback and never leaks to the console.
+
+        See the "progress-bar-stdout-leak" fix: the ~107MB download bar used to
+        print straight to stdout when starting the app.
+        """
+        import sys
+
+        import tqdm.auto
+
+        from vtscore.media.face.embedder_facenet import FaceEmbedder
+
+        class _FakeInceptionResnetV1:
+            """Stub whose construction emits a determinate tqdm bar, mimicking
+            facenet-pytorch's torch.hub weight download."""
+
+            def __init__(self, pretrained=None):
+                bar = tqdm.auto.tqdm(total=107, desc="20180402-114759-vggface2.pt")
+                bar.update(107)
+                bar.close()
+
+            def eval(self):
+                return self
+
+            def to(self, _device):
+                return self
+
+        fake_module = MagicMock()
+        fake_module.InceptionResnetV1 = _FakeInceptionResnetV1
+
+        calls: list[tuple] = []
+        emb = FaceEmbedder()
+        emb._on_progress = lambda status, message, current, total: calls.append(
+            (status, message, current, total)
+        )
+
+        with patch.dict(sys.modules, {"facenet_pytorch": fake_module}):
+            emb._load_models_impl()
+
+        captured = capsys.readouterr()
+        assert "vggface2" not in captured.out
+        assert "vggface2" not in captured.err
+        # The bar's progress should have been forwarded to the callback instead.
+        assert any(c[3] == 107 for c in calls)
+
 
 # ---------------------------------------------------------------------------
 # image2face converter

--- a/vtscore/media/face/embedder_facenet.py
+++ b/vtscore/media/face/embedder_facenet.py
@@ -33,7 +33,13 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 
-from vtscore.media.embedder import IMPORT_MODULE_ESTIMATES, MediaEmbedder, timed_progress, to_compute_device
+from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
+    MediaEmbedder,
+    intercept_tqdm_progress,
+    timed_progress,
+    to_compute_device,
+)
 from vtscore.media.image._image_bulk import bulk_embed_image_files
 
 if TYPE_CHECKING:
@@ -82,8 +88,14 @@ class FaceEmbedder(MediaEmbedder):
         ):
             import torch  # noqa: F401, PLC0415
 
-        with timed_progress(self._on_progress, "loading", "Loading FaceNet weights…", 2, 2):
-            # facenet-pytorch lazy-downloads weights on first instantiation.
+        with (
+            timed_progress(self._on_progress, "loading", "Loading FaceNet weights…", 2, 2),
+            intercept_tqdm_progress(self._on_progress),
+        ):
+            # facenet-pytorch lazy-downloads weights (~107MB VGGFace2) on first
+            # instantiation via torch.hub, which prints a tqdm bar. Wrap it in
+            # intercept_tqdm_progress so the bar is forwarded to the GUI progress
+            # callback and never leaks to stdout/stderr.
             from facenet_pytorch import InceptionResnetV1  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
             model = InceptionResnetV1(pretrained="vggface2")


### PR DESCRIPTION
## Problem

Starting the app leaked a raw tqdm download bar into stdout:

```
 * Serving Flask app 'app'
 * Debug mode: off
100%|██████████...█| 107M/107M [00:00<00:00, 312MB/s]
```

That `107M` is the VGGFace2 weights the FaceNet embedder downloads on first use.

## Root cause

`FaceEmbedder._load_models_impl` loads weights via `InceptionResnetV1(pretrained="vggface2")`, which lazy-downloads ~107MB through `torch.hub.download_url_to_file` — printing a tqdm bar. Every other embedder wraps its weight load in `intercept_tqdm_progress(self._on_progress)`, which redirects the bar to an in-memory `StringIO` sink and forwards its progress to the GUI callback. The FaceNet embedder used only `timed_progress`, so the download bar went straight to the console.

## Fix

Wrap the `InceptionResnetV1` instantiation in `intercept_tqdm_progress` alongside the existing `timed_progress` ticker. The download bar is now forwarded to the progress callback and never reaches stdout/stderr — matching the pattern used by the CLIP, SigLIP, DINOv2/3, CLAP, Whisper, X-CLIP, and other embedders.

The MTCNN detector in `image2face` was already safe (bundled weights, no download).

## Test

Added `test_weight_load_does_not_leak_progress_bar_to_console` in `tests_lib/detectors/test_face.py`: stubs `facenet_pytorch.InceptionResnetV1` to emit a determinate tqdm bar on construction, then asserts (via `capsys`) that nothing leaks to stdout/stderr and that the bar's progress is forwarded to the callback instead.

Full suite green: `ALL 1633 TESTS PASSED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012aZLc1Vw17S7bCEx4s5gB8)_