### PR TITLE
Shorten and punctuate dataset/detector selection hints

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -401,7 +401,7 @@ describe('DashboardComponent', () => {
     it('should hint about missing dataset', () => {
       flushInitialRequests();
       component.selectedDatasetIds.clear();
-      expect(component.labelHint).toBe('Select a dataset row in the table above');
+      expect(component.labelHint).toBe('Select a dataset in the table above.');
     });
 
     it('should hint about missing model', () => {
@@ -456,7 +456,7 @@ describe('DashboardComponent', () => {
       flushInitialRequests();
       component.selectedDatasetIds.clear();
       component.selectedDetectorIds.clear();
-      expect(component.findHint).toBe('Select a dataset and a detector row above');
+      expect(component.findHint).toBe('Select a dataset and detector above.');
     });
 
     it('should hint about missing dataset', () => {
@@ -464,7 +464,7 @@ describe('DashboardComponent', () => {
       flushInitialRequests([], models);
       // Single detector is auto-selected; no dataset selected.
       component.selectedDatasetIds.clear();
-      expect(component.findHint).toBe('Select a dataset row in the table above');
+      expect(component.findHint).toBe('Select a dataset in the table above.');
     });
 
     it('should hint about missing model', () => {
@@ -472,7 +472,7 @@ describe('DashboardComponent', () => {
       flushInitialRequests(datasets);
       // Single dataset is auto-selected; no detector selected.
       component.selectedDetectorIds.clear();
-      expect(component.findHint).toBe('Select a detector row in the table above');
+      expect(component.findHint).toBe('Select a detector in the table above.');
     });
 
     it('should hint about media type mismatch', () => {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1321,9 +1321,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
     // "row above": selection means checking a table row — a dataset can be
     // loaded (named in the top bar) while its row is unchecked, so a bare
     // "select a dataset" reads as already satisfied.
-    if (nDatasets === 0 && nModels === 0) return 'Select a dataset and a detector row above';
-    if (nDatasets === 0) return 'Select a dataset row in the table above';
-    if (nModels === 0) return 'Select a detector row in the table above';
+    if (nDatasets === 0 && nModels === 0) return 'Select a dataset and detector above.';
+    if (nDatasets === 0) return 'Select a dataset in the table above.';
+    if (nModels === 0) return 'Select a detector in the table above.';
     if (!this.findMediaTypesMatch()) return 'Media type mismatch';
     if (this.hasUntrainedModel()) return 'Selected detector has no training labels';
     return 'Score selected datasets with selected detectors';
@@ -1332,7 +1332,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   get labelHint(): string {
     const nDatasets = this.resolvedSelectedDatasets.length;
     const nModels = this.resolvedSelectedModels.length;
-    if (nDatasets === 0) return 'Select a dataset row in the table above';
+    if (nDatasets === 0) return 'Select a dataset in the table above.';
     if (nDatasets > 1) return 'Select exactly 1 dataset';
     if (nModels === 0) return 'Create a new detector and start training';
     if (nModels > 1) return 'Select exactly 1 detector';


### PR DESCRIPTION
## Summary
- The Dashboard's find/label hint text ("Select a dataset row in the table above", "Select a dataset and a detector row above") lacked terminating periods, and the longer one was getting cut off in the UI.
- Dropped "row" and added a period to each hint: `Select a dataset in the table above.`, `Select a detector in the table above.`, `Select a dataset and detector above.`
- Updated the corresponding spec expectations.

## Test plan
- [x] `cd frontend && npm run test:ci` — all 1711 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01BcfKb3ageEmSianeKQrs3A)_