### PR TITLE
Add a docked presentation for the VTSBrowse bin-details window

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -191,6 +191,12 @@
           "autopilot_top_greens": {
             "type": "integer"
           },
+          "bin_details_docked": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object"
+          },
           "browse_colormap": {
             "additionalProperties": {
               "type": "string"
@@ -202,6 +208,9 @@
               "type": "boolean"
             },
             "type": "object"
+          },
+          "browse_details_panel_width": {
+            "type": "integer"
           },
           "browse_icon_size": {
             "additionalProperties": {
@@ -4726,8 +4735,12 @@
           "autopilot_top_greens": {
             "type": "integer"
           },
+          "bin_details_docked": {},
           "browse_colormap": {},
           "browse_compact": {},
+          "browse_details_panel_width": {
+            "type": "integer"
+          },
           "browse_icon_size": {},
           "browse_mouse_zooms_per_level": {},
           "browse_panel_width": {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -1,11 +1,12 @@
 <div
   #panel
   class="bin-popup"
-  [style.left.px]="left"
-  [style.top.px]="top"
-  [style.maxWidth.px]="maxWidthPx"
-  [style.visibility]="placed ? 'visible' : 'hidden'"
-  role="dialog"
+  [class.bin-popup--docked]="docked()"
+  [style.left.px]="docked() ? null : left"
+  [style.top.px]="docked() ? null : top"
+  [style.maxWidth.px]="docked() ? null : maxWidthPx"
+  [style.visibility]="docked() ? null : placed ? 'visible' : 'hidden'"
+  [attr.role]="docked() ? 'complementary' : 'dialog'"
   aria-label="Bin items">
   <div
     #header
@@ -24,7 +25,7 @@
         <vt-icon type="info" [size]="15" />
       </button>
     }
-    @if (showPreview) {
+    @if (hasPane) {
       <div class="bin-popup-size-group" role="group" aria-label="Detail image size">
         <button
           type="button"
@@ -51,162 +52,203 @@
       [currentMediaType]="mediaType()"
       [showFocus]="false"
       class="bin-popup-view-controls" />
+    @if (docked()) {
+      <button
+        type="button"
+        class="bin-popup-meta-toggle"
+        (click)="popOutRequested.emit()"
+        title="Pop out into a floating window"
+        aria-label="Pop out into a floating window">
+        <vt-icon type="pop-out" [size]="14" />
+      </button>
+    } @else {
+      <button
+        type="button"
+        class="bin-popup-meta-toggle"
+        (click)="dockRequested.emit()"
+        title="Dock as a side panel"
+        aria-label="Dock as a side panel">
+        <vt-icon type="dock-left" [size]="14" />
+      </button>
+    }
     <button
       type="button"
       class="bin-popup-close"
       (click)="close()"
-      title="Close"
-      aria-label="Close">
+      [title]="docked() ? 'Clear' : 'Close'"
+      [attr.aria-label]="docked() ? 'Clear' : 'Close'">
       &times;
     </button>
   </div>
 
-  <div class="bin-popup-body" [style.height.px]="bodyOuterHeight">
-    @if (showMetadataColumn) {
-      <div class="bin-popup-meta-col" [style.width.px]="metadataColWidth">
-        <div class="bin-popup-meta-grid">
-          <div class="bin-popup-meta-item">
-            <span class="bin-popup-meta-label">Name</span>
-            <div class="bin-popup-meta-value-row">
-              <vt-copy-detail-button [value]="metadataName" label="Name" />
-              <span class="bin-popup-meta-value">{{ metadataName }}</span>
-            </div>
-          </div>
-          <div class="bin-popup-meta-item">
-            <span class="bin-popup-meta-label">Media Type</span>
-            <div class="bin-popup-meta-value-row">
-              <vt-copy-detail-button [value]="metadataMediaType | titlecase" label="Media Type" />
-              <span class="bin-popup-meta-value">{{ metadataMediaType | titlecase }}</span>
-            </div>
-          </div>
-          @for (entry of metadataCustom | keyvalue; track entry.key) {
+  <div class="bin-popup-body" [style.height.px]="docked() ? null : bodyOuterHeight">
+    <div class="bin-popup-top">
+      @if (showMetadataColumn) {
+        <div
+          class="bin-popup-meta-col"
+          [style.width.px]="docked() ? null : metadataColWidth"
+          [style.maxHeight.px]="docked() ? dockedPaneSize : null">
+          <div class="bin-popup-meta-grid">
             <div class="bin-popup-meta-item">
-              <span class="bin-popup-meta-label">{{ entry.key }}</span>
+              <span class="bin-popup-meta-label">Name</span>
               <div class="bin-popup-meta-value-row">
-                <vt-copy-detail-button [value]="formatMetadataValue(entry.key, entry.value)" [label]="entry.key" />
-                <span class="bin-popup-meta-value">{{ formatMetadataValue(entry.key, entry.value) }}</span>
+                <vt-copy-detail-button [value]="metadataName" label="Name" />
+                <span class="bin-popup-meta-value">{{ metadataName }}</span>
               </div>
             </div>
-          }
-          @if (metadataMd5) {
             <div class="bin-popup-meta-item">
-              <span class="bin-popup-meta-label">MD5</span>
+              <span class="bin-popup-meta-label">Media Type</span>
               <div class="bin-popup-meta-value-row">
-                <vt-copy-detail-button [value]="metadataMd5" label="MD5" />
-                <span class="bin-popup-meta-value bin-popup-meta-md5">{{ metadataMd5 }}</span>
+                <vt-copy-detail-button [value]="metadataMediaType | titlecase" label="Media Type" />
+                <span class="bin-popup-meta-value">{{ metadataMediaType | titlecase }}</span>
               </div>
             </div>
-          }
+            @for (entry of metadataCustom | keyvalue; track entry.key) {
+              <div class="bin-popup-meta-item">
+                <span class="bin-popup-meta-label">{{ entry.key }}</span>
+                <div class="bin-popup-meta-value-row">
+                  <vt-copy-detail-button [value]="formatMetadataValue(entry.key, entry.value)" [label]="entry.key" />
+                  <span class="bin-popup-meta-value">{{ formatMetadataValue(entry.key, entry.value) }}</span>
+                </div>
+              </div>
+            }
+            @if (metadataMd5) {
+              <div class="bin-popup-meta-item">
+                <span class="bin-popup-meta-label">MD5</span>
+                <div class="bin-popup-meta-value-row">
+                  <vt-copy-detail-button [value]="metadataMd5" label="MD5" />
+                  <span class="bin-popup-meta-value bin-popup-meta-md5">{{ metadataMd5 }}</span>
+                </div>
+              </div>
+            }
+          </div>
         </div>
-      </div>
-    }
-    @if (showPreview) {
-      <div
-        class="bin-popup-preview"
-        [class.selected]="isPreviewSelected()"
-        [style.width.px]="previewPaneSize"
-        role="button"
-        tabindex="0"
-        [attr.aria-pressed]="isPreviewSelected()"
-        [attr.aria-label]="(previewId != null ? name(previewId) : 'item') + (isPreviewSelected() ? ' (selected; click to deselect)' : ' (click to select)')"
-        (click)="onPreviewClick()"
-        (keydown)="onPreviewKeydown($event)">
-        @if (previewUrl()) {
-          @if (isAudioWaveform) {
-            <!-- Audio waveform: tint the theme-agnostic alpha mask (issue #2369)
-                 instead of showing baked-in pixels. -->
-            <div
-              class="bin-popup-preview-wave waveform-mask"
-              role="img"
-              [attr.aria-label]="previewId != null ? name(previewId) : ''"
-              [style.-webkit-mask-image]="'url(' + previewUrl() + ')'"
-              [style.mask-image]="'url(' + previewUrl() + ')'"></div>
-          } @else {
+      }
+      @if (hasPane) {
+        <div
+          class="bin-popup-preview"
+          [class.selected]="isPreviewSelected()"
+          [style.width.px]="docked() ? dockedPaneSize : previewPaneSize"
+          [style.height.px]="docked() ? dockedPaneSize : null"
+          role="button"
+          tabindex="0"
+          [attr.aria-pressed]="isPreviewSelected()"
+          [attr.aria-label]="(displayedId != null ? name(displayedId) : 'item') + (isPreviewSelected() ? ' (selected; click to deselect)' : ' (click to select)')"
+          (click)="onPreviewClick()"
+          (keydown)="onPreviewKeydown($event)">
+          @if (paneShowsPlaceholder) {
+            <span class="bin-popup-preview-glyph">{{ panePlaceholderGlyph }}</span>
+          } @else if (isAudioWaveform) {
+            @if (paneWaveUrl()) {
+              <!-- Audio waveform: tint the theme-agnostic alpha mask (issue #2369)
+                   instead of showing baked-in pixels. Docked, the pane doubles as
+                   the now-playing display: it paints the auditioning clip's wave
+                   with a sweeping playhead and a buffering spinner. -->
+              <div
+                class="bin-popup-preview-wave waveform-mask"
+                role="img"
+                [attr.aria-label]="displayedId != null ? name(displayedId) : ''"
+                [style.-webkit-mask-image]="'url(' + paneWaveUrl() + ')'"
+                [style.mask-image]="'url(' + paneWaveUrl() + ')'"></div>
+              @if (paneProgress !== null) {
+                <div class="bin-popup-preview-playhead" [style.left.%]="paneProgress * 100"></div>
+              }
+              @if (paneLoading) {
+                <div class="bin-popup-preview-loading" role="status" aria-label="Loading audio">
+                  <span class="bin-popup-preview-spinner" aria-hidden="true"></span>
+                </div>
+              }
+            }
+          } @else if (previewUrl()) {
             <img
               class="bin-popup-preview-img"
               [src]="previewUrl()"
-              [alt]="previewId != null ? name(previewId) : ''"
+              [alt]="displayedId != null ? name(displayedId) : ''"
               (error)="onPreviewError()" />
           }
-        }
-      </div>
-    }
+        </div>
+      }
+    </div>
 
-    @if (!previewOnly) {
+    @if (docked() || !previewOnly) {
       <div class="bin-popup-grid-col">
-        <div class="bin-popup-grid-header">
-          @if (ids.length > 1) {
-            <button
-              type="button"
-              class="bin-popup-select-all"
-              role="checkbox"
-              (click)="toggleAll()"
-              [title]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
-              [attr.aria-label]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
-              [attr.aria-checked]="selectionState === 'all' ? 'true' : selectionState === 'some' ? 'mixed' : 'false'">
-              @switch (selectionState) {
-                @case ('all') { <vt-icon type="checkbox-checked" [size]="15"></vt-icon> }
-                @case ('some') { <vt-icon type="checkbox-some" [size]="15"></vt-icon> }
-                @default { <vt-icon type="checkbox-blank" [size]="15"></vt-icon> }
-              }
-            </button>
-          }
-          <span
-            class="bin-popup-count"
-            [title]="'Items in this bin (' + ids.length + ')'">
-            {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
-          </span>
-        </div>
-        <cdk-virtual-scroll-viewport
-          [itemSize]="rowSize"
-          class="bin-popup-scroll"
-          (mouseleave)="onGridLeave()">
-        <div
-          *cdkVirtualFor="let row of rows; trackBy: trackByRow"
-          class="bin-popup-row"
-          [style.height.px]="rowSize"
-          [style.--popup-cols]="columns"
-          [style.--popup-cell]="gridGoalWidth + 'px'">
-          @for (id of row; track trackById($index, id)) {
-            <div
-              class="bin-popup-entry"
-              [attr.data-entry-id]="id"
-              [class.selected]="isSelected(id)"
-              [class.focused]="isFocused(id)"
-              role="button"
-              tabindex="0"
-              [attr.aria-pressed]="isSelected(id)"
-              [attr.aria-label]="name(id) + (isSelected(id) ? ' (selected; click to deselect)' : ' (click to select)')"
-              [title]="name(id)"
-              (click)="onEntryClick(id)"
-              (keydown)="onEntryKeydown($event, id)"
-              (focus)="onEntryFocus(id)"
-              (mouseenter)="onEntryEnter(id)">
-              @if (hasThumbnailUrl(id)) {
-                <span class="bin-popup-thumb-wrap">
-                  @if (isAudioWaveform) {
-                    <!-- Audio waveform alpha mask tinted to the accent (issue #2369). -->
-                    <span
-                      class="bin-popup-thumb-wave waveform-mask"
-                      [style.-webkit-mask-image]="'url(' + thumbnailUrl(id) + ')'"
-                      [style.mask-image]="'url(' + thumbnailUrl(id) + ')'"></span>
-                  } @else {
-                    <img
-                      class="bin-popup-thumb"
-                      [src]="thumbnailUrl(id)"
-                      [alt]="name(id)"
-                      loading="lazy"
-                      (error)="onThumbnailError(thumbnailUrl(id))" />
-                  }
-                </span>
-              } @else {
-                <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
-              }
-              <span class="bin-popup-name">{{ name(id) }}</span>
-            </div>
-          }
-        </div>
-        </cdk-virtual-scroll-viewport>
+        @if (ids.length > 0) {
+          <div class="bin-popup-grid-header">
+            @if (ids.length > 1) {
+              <button
+                type="button"
+                class="bin-popup-select-all"
+                role="checkbox"
+                (click)="toggleAll()"
+                [title]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
+                [attr.aria-label]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
+                [attr.aria-checked]="selectionState === 'all' ? 'true' : selectionState === 'some' ? 'mixed' : 'false'">
+                @switch (selectionState) {
+                  @case ('all') { <vt-icon type="checkbox-checked" [size]="15"></vt-icon> }
+                  @case ('some') { <vt-icon type="checkbox-some" [size]="15"></vt-icon> }
+                  @default { <vt-icon type="checkbox-blank" [size]="15"></vt-icon> }
+                }
+              </button>
+            }
+            <span
+              class="bin-popup-count"
+              [title]="'Items in this bin (' + ids.length + ')'">
+              {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
+            </span>
+          </div>
+          <cdk-virtual-scroll-viewport
+            [itemSize]="rowSize"
+            class="bin-popup-scroll"
+            (mouseleave)="onGridLeave()">
+          <div
+            *cdkVirtualFor="let row of displayRows; trackBy: trackByRow"
+            class="bin-popup-row"
+            [style.height.px]="rowSize"
+            [style.--popup-cols]="columns"
+            [style.--popup-cell]="gridGoalWidth + 'px'">
+            @for (id of row; track trackById($index, id)) {
+              <div
+                class="bin-popup-entry"
+                [attr.data-entry-id]="id"
+                [class.selected]="isSelected(id)"
+                [class.focused]="isFocused(id)"
+                role="button"
+                tabindex="0"
+                [attr.aria-pressed]="isSelected(id)"
+                [attr.aria-label]="name(id) + (isSelected(id) ? ' (selected; click to deselect)' : ' (click to select)')"
+                [title]="name(id)"
+                (click)="onEntryClick(id)"
+                (keydown)="onEntryKeydown($event, id)"
+                (focus)="onEntryFocus(id)"
+                (mouseenter)="onEntryEnter(id)">
+                @if (hasThumbnailUrl(id)) {
+                  <span class="bin-popup-thumb-wrap">
+                    @if (isAudioWaveform) {
+                      <!-- Audio waveform alpha mask tinted to the accent (issue #2369). -->
+                      <span
+                        class="bin-popup-thumb-wave waveform-mask"
+                        [style.-webkit-mask-image]="'url(' + thumbnailUrl(id) + ')'"
+                        [style.mask-image]="'url(' + thumbnailUrl(id) + ')'"></span>
+                    } @else {
+                      <img
+                        class="bin-popup-thumb"
+                        [src]="thumbnailUrl(id)"
+                        [alt]="name(id)"
+                        loading="lazy"
+                        (error)="onThumbnailError(thumbnailUrl(id))" />
+                    }
+                  </span>
+                } @else {
+                  <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
+                }
+                <span class="bin-popup-name">{{ name(id) }}</span>
+              </div>
+            }
+          </div>
+          </cdk-virtual-scroll-viewport>
+        } @else if (docked()) {
+          <p class="bin-popup-empty-hint">Right-click a bin on the map to show its items here.</p>
+        }
       </div>
     }
   </div>

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -44,7 +44,10 @@
   flex-shrink: 0;
 }
 
-.bin-popup-size-btn {
+// Shared chrome for the small header buttons: the segmented size pair and the
+// square toggles (metadata, dock / pop-out).
+.bin-popup-size-btn,
+.bin-popup-meta-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -58,6 +61,12 @@
   transition: background var(--transition-base), color var(--transition-base),
     border-color var(--transition-base);
 
+  vt-icon {
+    line-height: 0;
+  }
+}
+
+.bin-popup-size-btn {
   &:not(:first-child) {
     margin-left: -1px;
   }
@@ -80,31 +89,14 @@
     opacity: var(--opacity-disabled);
     cursor: not-allowed;
   }
-
-  vt-icon {
-    line-height: 0;
-  }
 }
 
-// Metadata-column toggle: a single square button in the header that shows/hides
-// the metadata column (left of the preview for thumbnail media, left of the grid
-// otherwise). Active (column shown) reads as a filled accent chip; inactive is a
-// muted outline like the size buttons.
+// Square header toggles (metadata show/hide, dock / pop-out). The metadata
+// toggle's active state (column shown) reads as a filled accent chip; inactive
+// is a muted outline like the size buttons.
 .bin-popup-meta-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 26px;
-  height: 22px;
-  padding: 0 var(--space-sm);
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  color: var(--text-muted);
-  cursor: pointer;
   flex-shrink: 0;
-  transition: background var(--transition-base), color var(--transition-base),
-    border-color var(--transition-base);
 
   &:hover {
     color: var(--text-primary);
@@ -115,10 +107,6 @@
     background: var(--accent-highlight-bg);
     border-color: var(--accent);
     color: var(--text-primary);
-  }
-
-  vt-icon {
-    line-height: 0;
   }
 }
 
@@ -602,14 +590,4 @@
   text-align: center;
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
+// (The hidden audio element uses the global `.sr-only` from scss/_components.scss.)

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -225,6 +225,8 @@
 .bin-popup-preview {
   flex-shrink: 0;
   height: 100%;
+  // Positioning context for the docked now-playing playhead + spinner.
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -485,6 +487,119 @@
   .bin-popup-name {
     display: none;
   }
+}
+
+// --- Docked presentation ----------------------------------------------------
+// The same component rendered as the Browse view's persistent left panel: the
+// detail pane top-left with the metadata column to its right (wrapping below
+// when the panel is narrow), and the member grid filling the rest below.
+
+// Floating: the top wrapper dissolves so the metadata column and preview pane
+// stay direct flex items of the body, exactly the historic row layout.
+.bin-popup-top {
+  display: contents;
+}
+
+.bin-popup--docked {
+  position: static;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+
+  .bin-popup-header {
+    cursor: default;
+  }
+
+  .bin-popup-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    flex-direction: column;
+  }
+
+  .bin-popup-top {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    flex-shrink: 0;
+  }
+
+  // Pane left, metadata to its right (DOM order is metadata-first for the
+  // floating layout, so flip with `order` rather than duplicating markup).
+  .bin-popup-preview {
+    order: -1;
+    height: auto;
+  }
+
+  .bin-popup-meta-col {
+    flex: 1 1 140px;
+    min-width: 140px;
+    width: auto;
+    height: auto;
+  }
+
+  .bin-popup-grid-col {
+    width: 100%;
+    height: auto;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+}
+
+// Docked audio: sweeping playhead + buffering spinner over the detail pane,
+// mirroring the toolbar now-playing widget the pane replaces.
+.bin-popup-preview-playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  margin-left: -1px;
+  background: var(--waveform-playhead);
+  pointer-events: none;
+  will-change: left;
+}
+
+.bin-popup-preview-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--bg-surface) 60%, transparent);
+  pointer-events: none;
+}
+
+.bin-popup-preview-spinner {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-top-color: var(--accent);
+  animation: bin-popup-spin 0.8s linear infinite;
+}
+
+@keyframes bin-popup-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+// Docked, non-thumbnail media (text): a large placeholder glyph in the pane.
+.bin-popup-preview-glyph {
+  font-size: 48px;
+  color: var(--text-muted);
+}
+
+// Docked empty state: no bin has been opened yet.
+.bin-popup-empty-hint {
+  margin: auto;
+  padding: var(--space-md);
+  font-size: var(--font-sm);
+  color: var(--text-muted);
+  text-align: center;
 }
 
 .sr-only {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -110,11 +110,34 @@ const BODY_PADDING_Y = 2 * BODY_PADDING;
  * {@link MIN_PREVIEW_PX}..{@link MAX_PREVIEW_PX}.
  */
 const PREVIEW_SIZE_STEPS = [120, 160, 208, 272, 352, 448, 560, 640, 720] as const;
+/** Horizontal chrome (px) around the docked panel's member grid: the body's
+ *  side padding plus room for the scrollbar. Subtracted from the panel width
+ *  to get the content width the docked grid chunks its columns against. */
+const DOCKED_GRID_CHROME = 2 * BODY_PADDING + 12;
+/** Smallest width (px) the docked metadata column is guaranteed beside the
+ *  detail pane; a wider pane pushes the metadata to wrap below it instead. */
+const DOCKED_META_MIN = 140;
 
 /**
- * The bin popup: a floating panel showing the media items in the bin the user
- * right-clicked on the VTSBrowse canvas, plus — for thumbnail media (image /
- * video) — a large preview pane on the left.
+ * The bin details: the media items in the bin the user right-clicked on the
+ * VTSBrowse canvas, plus — for thumbnail media (image / video / audio
+ * waveforms) — a large preview pane.
+ *
+ * It renders in one of two presentations, chosen per media type by the
+ * ``bin_details_docked`` setting (the dock / pop-out header buttons flip it):
+ *
+ * - **Floating** (``docked`` false, the default): a draggable popup window
+ *   summoned at the right-click point and clamped to the visible canvas.
+ * - **Docked** (``docked`` true): a persistent left panel beside the canvas.
+ *   The detail pane sits top-left with the metadata column to its right, and
+ *   the member grid fills the rest of the panel below them. The panel is
+ *   always mounted while the option is on — before any bin is opened it shows
+ *   an empty hint — and for audio its detail pane doubles as the now-playing
+ *   display ({@link nowPlayingExt}), replacing the toolbar's small waveform
+ *   widget. A singleton bin keeps the grid area allocated but empty. In this
+ *   mode all floating machinery (summon positioning, clamping, dragging,
+ *   outside-click/Escape dismissal, document-level keyboard shortcuts) is
+ *   disabled; the canvas keeps its own shortcuts.
  *
  * The members render as a virtualized thumbnail grid (always grid; there is no
  * list mode). Hovering a grid thumbnail paints that item's *full-resolution*
@@ -187,9 +210,26 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   readonly hoverThumbRadius = input(28);
   /** Preview-audio volume (0–1), driven by the Browse toolbar's volume control. */
   readonly volume = input(1);
+  /** Docked mode: render as the Browse view's left panel instead of a floating
+   *  window. Constant per instance — the browse view mounts one element or the
+   *  other, never flips this on a live instance. */
+  readonly docked = input(false);
+  /** Width (CSS px) of the docked panel, driven by the browse view's divider;
+   *  the docked grid derives its column count from it. Unused when floating. */
+  readonly availableWidth = input(0);
+  /** The clip currently auditioning anywhere in the Browse view (canvas hover
+   *  or this panel's own grid), fed back by the browse view. In docked audio
+   *  mode the detail pane + metadata track it — the panel is the now-playing
+   *  display. Unused when floating. */
+  readonly nowPlayingExt = input<NowPlaying | null>(null);
 
-  /** Emitted when the popup should close (outside click, Escape, or the X). */
+  /** Emitted when the popup should close (outside click, Escape, or the X);
+   *  in docked mode, when the X asks to clear the shown bin. */
   readonly dismissed = output<void>();
+  /** Floating header's dock button: the user wants the docked presentation. */
+  readonly dockRequested = output<void>();
+  /** Docked header's pop-out button: the user wants the floating window. */
+  readonly popOutRequested = output<void>();
   /** The clip now auditioning from a grid-row hover (for the top-left
    *  now-playing indicator, shared with the canvas hover), or ``null`` once
    *  the hover clears. */
@@ -358,6 +398,29 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
       this.hoverThumbRadius();
       untracked(() => setTimeout(() => this.place()));
     });
+    // Docked: the panel width (divider drags) re-chunks the member grid's
+    // columns and resizes the virtual viewport.
+    effect(() => {
+      const width = this.availableWidth();
+      untracked(() => {
+        if (!this.docked() || width <= 0) return;
+        this.rebuildRows();
+        setTimeout(() => {
+          this.viewport()?.checkViewportSize();
+          this.prefetchVisible();
+        });
+        this.cdr.markForCheck();
+      });
+    });
+    // Docked audio: the detail pane + metadata column track the auditioning
+    // clip (the now-playing replacement), so keep its metadata loading.
+    effect(() => {
+      const np = this.nowPlayingExt();
+      untracked(() => {
+        if (!this.docked() || !np) return;
+        this.metadataCache.ensureLoaded([np.mediaId]);
+      });
+    });
     // (Re-)subscribe the member grid's scroll-driven prefetch whenever the
     // virtual viewport instance changes — it lives behind the template's
     // ``@if (!previewOnly)``, and the popup is reused across summons while
@@ -520,16 +583,18 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     this.settingsState.update({ popup_metadata_shown: dict } as SettingsUpdate).subscribe();
   }
 
-  /** Cached metadata for the focused (previewed) item, or ``undefined`` before
-   *  it has loaded. Everything the column shows reads through this. */
+  /** Cached metadata for the focused (displayed) item, or ``undefined`` before
+   *  it has loaded. Everything the column shows reads through this. In docked
+   *  audio mode the displayed item follows the auditioning clip. */
   private focusedMedia(): MediaBatchResponse | undefined {
-    return this.previewId == null ? undefined : this.metadataCache.get(this.previewId);
+    const id = this.displayedId;
+    return id == null ? undefined : this.metadataCache.get(id);
   }
 
   /** Display name of the focused item, matching the center panel's Name field. */
   get metadataName(): string {
     const media = this.focusedMedia();
-    if (!media) return this.previewId == null ? '' : `Media #${this.previewId}`;
+    if (!media) return this.displayedId == null ? '' : `Media #${this.displayedId}`;
     return media.filename || `Media #${media.id}`;
   }
 
@@ -640,11 +705,20 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     }
   }
 
+  /** Width (px) the member grid lays its cells out in: the historic fixed
+   *  column width when floating, or the live panel width (minus the body
+   *  padding + scrollbar chrome) when docked, so the docked grid re-chunks as
+   *  the divider drags. */
+  private gridContentWidth(): number {
+    if (!this.docked()) return GRID_CONTENT_WIDTH;
+    return Math.max(this.gridGoalWidth, this.availableWidth() - DOCKED_GRID_CHROME);
+  }
+
   /** Recompute the column count + row chunking for the current thumbnail size. */
   private rebuildRows(): void {
     this.columns = Math.max(
       1,
-      Math.floor((GRID_CONTENT_WIDTH + GRID_GAP) / (this.gridGoalWidth + GRID_GAP)),
+      Math.floor((this.gridContentWidth() + GRID_GAP) / (this.gridGoalWidth + GRID_GAP)),
     );
     const cols = this.columns;
     const rows: number[][] = [];
@@ -710,7 +784,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  effect re-clamps the popup so growing the canvas can't push it off-screen. */
   bumpPreview(delta: 1 | -1): void {
     const mediaType = this.mediaType();
-    if (!this.showPreview || !mediaType) return;
+    if (!this.hasPane || !mediaType) return;
     const current = this.previewOverride ?? Math.round(this.previewDefault());
     const next =
       delta > 0
@@ -723,14 +797,14 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   /** True when the detail canvas is already at the smallest ladder rung. */
   get atMinPreview(): boolean {
-    if (!this.showPreview) return true;
+    if (!this.hasPane) return true;
     const current = this.previewOverride ?? Math.round(this.previewDefault());
     return current <= PREVIEW_SIZE_STEPS[0];
   }
 
   /** True when the detail canvas is already at the largest ladder rung. */
   get atMaxPreview(): boolean {
-    if (!this.showPreview) return true;
+    if (!this.hasPane) return true;
     const current = this.previewOverride ?? Math.round(this.previewDefault());
     return current >= PREVIEW_SIZE_STEPS[PREVIEW_SIZE_STEPS.length - 1];
   }
@@ -779,6 +853,80 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     return this.showPreview ? this.bodyHeight : 0;
   }
 
+  // --- Docked presentation --------------------------------------------------
+
+  /** Whether a detail pane renders at all: thumbnail media (image / video /
+   *  audio waveforms / document) always have one; docked, every media type
+   *  gets the pane — non-thumbnail types show a large placeholder glyph. */
+  get hasPane(): boolean {
+    return this.docked() || this.showPreview;
+  }
+
+  /** The item the detail pane + metadata column describe. Floating (and docked
+   *  non-audio) this is the hovered/arrowed item ({@link previewId}); docked
+   *  audio it follows whatever clip is auditioning anywhere in the Browse view
+   *  (canvas hover or this panel's grid) — the now-playing replacement —
+   *  falling back to the viewed item while nothing sounds. */
+  get displayedId(): number | null {
+    if (this.docked() && this.mediaType() === 'audio') {
+      return this.nowPlayingExt()?.mediaId ?? this.previewId;
+    }
+    return this.previewId;
+  }
+
+  /** Side (px) of the square docked detail pane: the same per-media-type
+   *  remembered size ({@link previewOverride}) the floating pane uses, clamped
+   *  to the docked panel's width so growing the pane can't overflow it. */
+  get dockedPaneSize(): number {
+    const desired = this.previewOverride ?? this.previewDefault();
+    const width = this.availableWidth();
+    const room = width > 0 ? width - 2 * BODY_PADDING : MAX_PREVIEW_PX;
+    return Math.round(
+      Math.max(MIN_PREVIEW_PX, Math.min(desired, Math.min(room, MAX_PREVIEW_PX))),
+    );
+  }
+
+  /** Rows the member grid renders. Docked, a singleton bin keeps the grid
+   *  area allocated but *empty* (its lone item is already shown in the detail
+   *  pane); floating keeps the historic shape ({@link previewOnly} drops the
+   *  grid column entirely for thumbnail singletons). */
+  get displayRows(): number[][] {
+    if (this.docked() && this.ids.length === 1) return [];
+    return this.rows;
+  }
+
+  /** Wave painted in the docked audio detail pane: the auditioning clip's
+   *  waveform while something sounds, else the viewed item's. */
+  paneWaveUrl(): string {
+    const np = this.docked() ? this.nowPlayingExt() : null;
+    return np ? np.waveUrl : this.previewUrl();
+  }
+
+  /** Docked audio: playhead position (0–1) while the auditioning clip sounds,
+   *  or ``null`` (no playhead) otherwise. */
+  get paneProgress(): number | null {
+    if (!this.docked()) return null;
+    return this.nowPlayingExt()?.progress ?? null;
+  }
+
+  /** Docked audio: whether the auditioning clip is still fetching/buffering
+   *  (drives the spinner over the pane, mirroring the old toolbar widget). */
+  get paneLoading(): boolean {
+    if (!this.docked()) return false;
+    return this.nowPlayingExt()?.loading ?? false;
+  }
+
+  /** Docked, non-thumbnail media (e.g. text): the pane shows a large
+   *  placeholder glyph instead of trying to load an image that doesn't exist. */
+  get paneShowsPlaceholder(): boolean {
+    return this.docked() && !this.showPreview;
+  }
+
+  /** Large placeholder glyph for {@link paneShowsPlaceholder}. */
+  get panePlaceholderGlyph(): string {
+    return this.mediaType() === 'text' ? '¶' : '□';
+  }
+
   // --- Dismissal -----------------------------------------------------------
 
   close(): void {
@@ -787,6 +935,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
+    if (this.docked()) return;
     if (!this.host.nativeElement.contains(event.target as Node)) {
       this.dismissed.emit();
     }
@@ -794,6 +943,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   @HostListener('document:keydown.escape')
   onEscape(): void {
+    if (this.docked()) return;
     this.dismissed.emit();
   }
 
@@ -807,6 +957,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    */
   @HostListener('document:keydown', ['$event'])
   onKeydown(event: KeyboardEvent): void {
+    // Docked, the panel is persistent chrome: it must not steal the canvas's
+    // document-level shortcuts (arrows pan, +/- zoom, Ctrl-A select-in-view).
+    if (this.docked()) return;
     if (shortcutsBlocked()) return;
 
     // Ctrl/Cmd-A: select every item in this bin (always select, never toggle).
@@ -927,6 +1080,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   /** Begin a drag when the user presses the header (but not the close button or
    *  the view controls, which keep their own click behavior). */
   onHeaderPointerDown(event: PointerEvent): void {
+    if (this.docked()) return;
     if (event.button !== 0) return;
     if ((event.target as HTMLElement).closest('button, vt-view-controls')) return;
     event.preventDefault();
@@ -1011,7 +1165,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   /** True when the item currently shown in the preview pane is selected, so the
    *  large detail image can render the same highlight ring as a grid entry. */
   isPreviewSelected(): boolean {
-    return this.previewId != null && this.selection.has(this.previewId);
+    const id = this.displayedId;
+    return id != null && this.selection.has(id);
   }
 
   /** Toggle selection of the item shown in the preview pane (the hovered grid
@@ -1020,7 +1175,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  is dropped; it also lets the user select by clicking the big detail image in
    *  a multi-member popup. */
   onPreviewClick(): void {
-    const id = this.previewId;
+    const id = this.displayedId;
     if (id != null) this.onEntryClick(id);
   }
 
@@ -1222,6 +1377,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  and correct any residual overflow, so the window ends up entirely on-screen
    *  even if the computed height drifts from what actually rendered. */
   private place(): void {
+    // Docked: the panel is laid out by the browse view's grid, never
+    // positioned/clamped by us.
+    if (this.docked()) return;
     // Before the panel exists there's nothing to measure/clamp; a later place()
     // call (e.g. from ngAfterViewInit) will run once it's in the DOM. Staying
     // unplaced keeps the popup hidden until then rather than showing it unclamped.

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -323,6 +323,187 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
   });
 });
 
+/**
+ * Docked presentation: the same component rendered as the Browse view's
+ * persistent left panel instead of a floating window. It must drop every piece
+ * of floating machinery (positioning, clamping, dragging, outside-click /
+ * Escape dismissal, document-level shortcuts) and instead render inline, show
+ * an empty hint before a bin is opened, keep the member-grid area allocated but
+ * empty for a singleton, and — for audio — track whatever clip is auditioning
+ * anywhere in the Browse view.
+ */
+describe('BrowseBinPopupComponent (docked presentation)', () => {
+  let settings: ReturnType<typeof signal<Record<string, unknown> | null>>;
+  let rafSpy: ReturnType<typeof vi.spyOn>;
+
+  function makeDockedFixture(
+    memberIds: number[],
+    mediaType = 'image',
+  ): ComponentFixture<BrowseBinPopupComponent> {
+    const selectionStub: Partial<BrowseSelectionService> = {
+      version: signal(0) as unknown as BrowseSelectionService['version'],
+      has: () => false,
+      selectedCountIn: () => 0,
+      addAll: () => {},
+      removeAll: () => {},
+      remove: () => {},
+    };
+    const metadataStub: Partial<MediaMetadataCacheService> = {
+      version$: of(0),
+      get: () => undefined,
+      ensureLoaded: () => {},
+    };
+    const activeContextStub = makeActiveContextStub();
+    const settingsStub: Partial<SettingsStateService> = {
+      settingsSignal: settings as unknown as SettingsStateService['settingsSignal'],
+      load: () => {},
+      update: () => of({}) as ReturnType<SettingsStateService['update']>,
+    };
+
+    TestBed.resetTestingModule();
+    configureZoneless({
+      imports: [BrowseBinPopupComponent],
+      providers: [
+        { provide: BrowseSelectionService, useValue: selectionStub },
+        { provide: MediaMetadataCacheService, useValue: metadataStub },
+        { provide: ActiveContextService, useValue: activeContextStub },
+        { provide: SettingsStateService, useValue: settingsStub },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(BrowseBinPopupComponent);
+    fixture.componentRef.setInput('docked', true);
+    fixture.componentRef.setInput('availableWidth', 340);
+    fixture.componentRef.setInput('memberIds', memberIds);
+    fixture.componentRef.setInput('repId', memberIds[0] ?? null);
+    fixture.componentRef.setInput('mediaType', mediaType);
+    return fixture;
+  }
+
+  beforeEach(() => {
+    settings = signal<Record<string, unknown> | null>({});
+    if (!Element.prototype.scrollTo) {
+      (Element.prototype as unknown as { scrollTo: () => void }).scrollTo = () => {};
+    }
+    rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      void Promise.resolve().then(() => cb(0));
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+  });
+
+  it('renders inline (no floating positioning) and is immediately visible', async () => {
+    const fixture = makeDockedFixture([1, 2, 3]);
+    await settlePasses(fixture);
+
+    const panel = fixture.nativeElement.querySelector('.bin-popup') as HTMLElement;
+    expect(panel).not.toBeNull();
+    expect(panel.classList.contains('bin-popup--docked')).toBe(true);
+    // Docked never sets the fixed-position left/top/visibility bindings.
+    expect(panel.style.left).toBe('');
+    expect(panel.style.top).toBe('');
+    expect(panel.style.visibility).toBe('');
+
+    fixture.destroy();
+  });
+
+  it('shows an empty hint when no bin has been opened', async () => {
+    const fixture = makeDockedFixture([]);
+    await settlePasses(fixture);
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('.bin-popup-empty-hint')).not.toBeNull();
+    // No grid rows and no count when empty.
+    expect(root.querySelector('.bin-popup-grid-header')).toBeNull();
+
+    fixture.destroy();
+  });
+
+  it('offers a pop-out button (not the dock button) in the header', async () => {
+    const fixture = makeDockedFixture([1, 2]);
+    await settlePasses(fixture);
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[aria-label="Pop out into a floating window"]')).not.toBeNull();
+    expect(root.querySelector('[aria-label="Dock as a side panel"]')).toBeNull();
+
+    fixture.destroy();
+  });
+
+  it('keeps the member grid empty for a docked singleton (area still allocated)', async () => {
+    const fixture = makeDockedFixture([5]);
+    await settlePasses(fixture);
+
+    const cmp = fixture.componentInstance;
+    // The grid column is present (not dropped like the floating previewOnly path)…
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('.bin-popup-grid-col')).not.toBeNull();
+    // …but renders no rows: the lone item lives in the detail pane above.
+    expect(cmp.displayRows.length).toBe(0);
+
+    fixture.destroy();
+  });
+
+  it('tracks the externally auditioning clip for docked audio (now-playing pane)', async () => {
+    const fixture = makeDockedFixture([7, 8, 9], 'audio');
+    await settlePasses(fixture);
+
+    const cmp = fixture.componentInstance;
+    // With nothing auditioning yet the pane follows the representative.
+    expect(cmp.displayedId).toBe(7);
+
+    // A canvas hover starts a clip elsewhere in the Browse view; the docked
+    // pane + metadata must follow it (the now-playing replacement).
+    fixture.componentRef.setInput('nowPlayingExt', {
+      mediaId: 42,
+      waveUrl: '/api/medias/42/thumbnail',
+      loading: true,
+      progress: 0.5,
+    } as NowPlaying);
+    await settlePasses(fixture);
+
+    expect(cmp.displayedId).toBe(42);
+    expect(cmp.paneWaveUrl()).toBe('/api/medias/42/thumbnail');
+    expect(cmp.paneProgress).toBe(0.5);
+    expect(cmp.paneLoading).toBe(true);
+
+    fixture.destroy();
+  });
+
+  it('derives the docked grid column count from the panel width', async () => {
+    const fixture = makeDockedFixture([1, 2, 3, 4, 5, 6]);
+    await settlePasses(fixture);
+
+    const cmp = fixture.componentInstance;
+    const wide = cmp.columns;
+    // Narrowing the panel (divider drag) re-chunks to fewer columns.
+    fixture.componentRef.setInput('availableWidth', 220);
+    await settlePasses(fixture);
+    expect(cmp.columns).toBeLessThanOrEqual(wide);
+
+    fixture.destroy();
+  });
+
+  it('does not dismiss on outside click or Escape when docked', async () => {
+    const fixture = makeDockedFixture([1, 2]);
+    await settlePasses(fixture);
+
+    const dismissed = vi.fn();
+    fixture.componentInstance.dismissed.subscribe(dismissed);
+
+    document.body.click();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await settlePasses(fixture);
+
+    expect(dismissed).not.toHaveBeenCalled();
+
+    fixture.destroy();
+  });
+});
+
 describe('BrowseBinPopupComponent (scroll-prefetch re-wiring)', () => {
   it('re-subscribes prefetch when the member-grid viewport is recreated', () => {
     // Regression: the popup subscribed scrolledIndexChange only once, but the

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -42,7 +42,30 @@
       <div
         class="browse-content"
         #content
-        [style.--browse-panel-width]="panelWidth() + 'px'">
+        [class.browse-content--details]="detailsDocked()"
+        [style.--browse-panel-width]="panelWidth() + 'px'"
+        [style.--browse-details-width]="detailsPanelWidth() + 'px'">
+        @if (detailsDocked()) {
+          <aside class="browse-details" aria-label="Bin details">
+            <vt-browse-bin-popup
+              [docked]="true"
+              [availableWidth]="detailsPanelWidth()"
+              [memberIds]="contextMembers"
+              [repId]="contextRepId"
+              [mediaType]="mediaType()"
+              [volume]="volume()"
+              [hoverThumbRadius]="thumbnailRadius"
+              [nowPlayingExt]="nowPlaying()"
+              (dismissed)="dismissContextMenu()"
+              (popOutRequested)="onPopOutRequested()"
+              (nowPlaying)="onNowPlaying($event)"
+            />
+          </aside>
+          <div
+            class="pane-divider"
+            (mousedown)="onDetailsDividerMouseDown($event)"
+          ></div>
+        }
         <div class="browse-main">
           <div class="browse-tools-left" vtNoFocusSteal>
             @if (subset) {
@@ -66,7 +89,9 @@
             </button>
             @if (mediaType() === 'audio') {
               <div class="browse-now-playing">
-                @if (nowPlaying(); as np) {
+                <!-- Docked bin details replace this small waveform: the panel's
+                     large detail pane is the now-playing display then. -->
+                @if (!detailsDocked() && nowPlaying(); as np) {
                   <!-- The waveform PNG is a theme-agnostic alpha mask (issue #2369):
                        the surface box mirrors the browse tile, and the inner element
                        masks the accent colour to the wave shape so it recolours with
@@ -147,7 +172,7 @@
             [volume]="volume()"
             (nowPlaying)="onNowPlaying($event)"
           />
-          @if (contextMenuOpen) {
+          @if (contextMenuOpen && !detailsDocked()) {
             <vt-browse-bin-popup
               [x]="contextMenuX"
               [y]="contextMenuY"
@@ -158,6 +183,7 @@
               [volume]="volume()"
               [hoverThumbRadius]="thumbnailRadius"
               (dismissed)="dismissContextMenu()"
+              (dockRequested)="onDockRequested()"
               (nowPlaying)="onNowPlaying($event)"
             />
           }

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -175,6 +175,29 @@
   position: relative;
 }
 
+// Docked bin-details variant: an extra left panel + divider ahead of the
+// canvas. The panel width is driven by ``--browse-details-width`` (the left
+// divider drag, persisted as ``browse_details_panel_width``).
+.browse-content--details {
+  grid-template-columns:
+    var(--browse-details-width, 340px) 8px minmax(0, 1fr) 8px
+    var(--browse-panel-width, 300px);
+}
+
+// The docked bin-details panel (left of the canvas): hosts the bin-popup
+// component in its docked presentation, filling the column.
+.browse-details {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+
+  vt-browse-bin-popup {
+    display: block;
+    height: 100%;
+  }
+}
+
 // Opaque cover over the canvas + panels until the opening view is ready. The
 // content underneath is fully laid out (so the canvas fits at its real size and
 // the reveal doesn't reflow); this just hides the mid-load grid and swallows

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -213,6 +213,31 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    *  the panel "pops back" to the stored width right after a drag. */
   private panelWidthInitialized = false;
   private dragging = false;
+
+  /**
+   * Docked bin-details mode for the active media type, mirrored from the
+   * per-media ``bin_details_docked`` setting. When on, the bin details render
+   * as a persistent left panel (large item + metadata on top, member grid
+   * below) instead of the floating right-click popup; the panel doubles as the
+   * audio now-playing display, replacing the toolbar's small waveform widget.
+   * Flipped by the dock button on the floating window and the pop-out button
+   * on the panel, both of which persist the choice.
+   */
+  readonly detailsDocked = signal(false);
+
+  /**
+   * Width (CSS px) of the docked bin-details panel, mirrored from the
+   * ``browse_details_panel_width`` setting and driven by the draggable divider
+   * between the panel and the canvas.
+   */
+  readonly detailsPanelWidth = signal(340);
+  /** Smallest the details panel may shrink to (matches the backend clamp). */
+  private static readonly DETAILS_FLOOR = 220;
+  /** Mirrors {@link panelWidthInitialized} for the details panel. */
+  private detailsWidthInitialized = false;
+  private draggingDetails = false;
+  private boundDetailsMove = this.onDetailsMouseMove.bind(this);
+  private boundDetailsUp = this.onDetailsMouseUp.bind(this);
   /** Dynamic minimum snapshotted at drag start, so the per-move handler reuses
    *  it instead of re-measuring the DOM (and thrashing layout) on every move —
    *  the thumbnail size and sort-control width can't change mid-drag anyway. */
@@ -317,6 +342,16 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
           );
           this.panelWidthInitialized = true;
         }
+        if (settings.browse_details_panel_width != null && !this.detailsWidthInitialized) {
+          this.detailsPanelWidth.set(
+            this.clamp(
+              settings.browse_details_panel_width,
+              BrowseViewComponent.DETAILS_FLOOR,
+              BrowseViewComponent.PANEL_MAX,
+            ),
+          );
+          this.detailsWidthInitialized = true;
+        }
         this.applyBrowsePrefsForMediaType();
       }
       if (settings || settingsErrored) this.maybeStartInitialLoad();
@@ -403,6 +438,8 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     if (this.pollTimer) clearTimeout(this.pollTimer);
     document.removeEventListener('mousemove', this.boundPanelMove);
     document.removeEventListener('mouseup', this.boundPanelUp);
+    document.removeEventListener('mousemove', this.boundDetailsMove);
+    document.removeEventListener('mouseup', this.boundDetailsUp);
     this.removeShiftListeners();
     this.tileCache.clear();
     this.releaseEphemeralPositivesContext();
@@ -566,6 +603,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     const signMap = s.browse_signposts as { [key: string]: boolean } | undefined;
     const rawSigns = mt && signMap ? signMap[mt] : undefined;
     this.signposts.set(rawSigns == null ? true : rawSigns);
+
+    const dockMap = s.bin_details_docked as { [key: string]: boolean } | undefined;
+    this.detailsDocked.set(!!(mt && dockMap && dockMap[mt]));
   }
 
   /** Read a ``{media_type: value}`` setting for *mt*, or ``''`` when unset. */
@@ -694,6 +734,48 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     // The user now owns the width; block the settings round-trip from resetting it.
     this.panelWidthInitialized = true;
     this.settingsState.update({ browse_panel_width: Math.round(this.panelWidth()) }).subscribe();
+  }
+
+  // --- Docked-details divider drag (left side; mirrors the right divider) ---
+
+  onDetailsDividerMouseDown(event: MouseEvent): void {
+    event.preventDefault();
+    this.draggingDetails = true;
+    this.ngZone.runOutsideAngular(() => {
+      document.addEventListener('mousemove', this.boundDetailsMove);
+      document.addEventListener('mouseup', this.boundDetailsUp);
+    });
+  }
+
+  private onDetailsMouseMove(event: MouseEvent): void {
+    const content = this.content();
+    if (!this.draggingDetails || !content) return;
+    const rect = content.nativeElement.getBoundingClientRect();
+    // The details panel is on the left, so its width grows as the cursor moves
+    // right. Leave the canvas its minimum after both dividers + the right panel.
+    const fit =
+      rect.width -
+      2 * BrowseViewComponent.DIVIDER_WIDTH -
+      BrowseViewComponent.CANVAS_MIN -
+      this.panelWidth();
+    const max = Math.min(
+      BrowseViewComponent.PANEL_MAX,
+      Math.max(BrowseViewComponent.DETAILS_FLOOR, fit),
+    );
+    const width = this.clamp(event.clientX - rect.left, BrowseViewComponent.DETAILS_FLOOR, max);
+    this.detailsPanelWidth.set(width);
+  }
+
+  private onDetailsMouseUp(): void {
+    if (!this.draggingDetails) return;
+    this.draggingDetails = false;
+    document.removeEventListener('mousemove', this.boundDetailsMove);
+    document.removeEventListener('mouseup', this.boundDetailsUp);
+    // The user now owns the width; block the settings round-trip from resetting it.
+    this.detailsWidthInitialized = true;
+    this.settingsState
+      .update({ browse_details_panel_width: Math.round(this.detailsPanelWidth()) })
+      .subscribe();
   }
 
   /** Toggle region-select mode (drag-to-marquee without holding Shift). */
@@ -859,8 +941,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   // --- Right-click bin popup ----------------------------------------------
 
-  /** Right-click on the canvas: pop the bin's item list at the cursor when it
-   *  landed on a bin; close any open popup when it hit empty space. */
+  /** Right-click on the canvas: pop the bin's item list at the cursor (or,
+   *  docked, show it in the left details panel) when it landed on a bin; clear
+   *  the open details when it hit empty space. */
   onCanvasContextMenu(event: BrowseContextMenuEvent): void {
     if (event.members.length === 0) {
       this.dismissContextMenu();
@@ -868,6 +951,14 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     }
     this.contextMembers = event.members;
     this.contextRepId = event.repId;
+    if (this.detailsDocked()) {
+      // Docked: the persistent left panel shows the bin — no floating window.
+      // Release the canvas's pinned enlarge right away so live hover keeps
+      // working while the bin stays open in the panel.
+      this.contextMenuOpen = false;
+      this.canvas()?.unpinCell();
+      return;
+    }
     this.contextMenuX = event.clientX;
     this.contextMenuY = event.clientY;
     this.contextBounds = event.bounds;
@@ -876,9 +967,54 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   dismissContextMenu(): void {
     this.contextMenuOpen = false;
+    if (this.detailsDocked()) {
+      // Docked: dismissal (the panel's X, or an empty-space right-click)
+      // clears the shown bin; the panel itself stays, showing its empty hint.
+      this.contextMembers = [];
+      this.contextRepId = null;
+    }
     // Release the canvas's pinned enlarge so live hover resumes on the bin now
     // under the cursor.
     this.canvas()?.unpinCell();
+  }
+
+  /** The floating window's dock button: remember the docked presentation for
+   *  this media type; the open bin carries over into the panel (it reads the
+   *  same ``contextMembers``). */
+  onDockRequested(): void {
+    this.contextMenuOpen = false;
+    this.canvas()?.unpinCell();
+    this.persistBinDetailsDocked(true);
+  }
+
+  /** The docked panel's pop-out button: remember the floating presentation and
+   *  re-open the current bin as a floating window over the canvas. */
+  onPopOutRequested(): void {
+    this.persistBinDetailsDocked(false);
+    if (this.contextMembers.length === 0) return;
+    // No summon point (the click was in the panel header) — anchor the window
+    // over the upper-left of the canvas; its own clamping keeps it on-screen.
+    const main = this.content()?.nativeElement.querySelector('.browse-main');
+    const rect = main ? main.getBoundingClientRect() : null;
+    this.contextBounds = rect;
+    this.contextMenuX = rect ? rect.left + rect.width / 4 : 100;
+    this.contextMenuY = rect ? rect.top + rect.height / 4 : 100;
+    this.contextMenuOpen = true;
+  }
+
+  /** Persist the docked/floating choice per media type (``bin_details_docked``)
+   *  and apply it locally, keeping the settings snapshot consistent. */
+  private persistBinDetailsDocked(value: boolean): void {
+    const mt = this.mediaType();
+    if (!mt) return;
+    this.detailsDocked.set(value);
+    const existing =
+      (this.lastSettings?.bin_details_docked as { [k: string]: boolean } | undefined) || {};
+    const map = { ...existing, [mt]: value };
+    if (this.lastSettings) {
+      (this.lastSettings as Record<string, unknown>)['bin_details_docked'] = map;
+    }
+    this.settingsState.update({ bin_details_docked: map } as SettingsUpdate).subscribe();
   }
 
   /**

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -191,6 +191,75 @@ describe('BrowseViewComponent (zoneless canary)', () => {
     expect(component.regionDrawActive).toBe(true);
   });
 
+  it('routes a right-clicked bin into the docked panel (not a floating popup) when docked', async () => {
+    await settleZoneless(fixture);
+    const component = fixture.componentInstance;
+    // Force the docked presentation for the active media type.
+    component.detailsDocked.set(true);
+
+    component.onCanvasContextMenu({
+      members: [3, 4, 5],
+      repId: 4,
+      clientX: 120,
+      clientY: 140,
+      bounds: null,
+    } as unknown as Parameters<typeof component.onCanvasContextMenu>[0]);
+
+    // The docked panel shows the bin (members carried), and NO floating popup opens.
+    expect(component.contextMembers).toEqual([3, 4, 5]);
+    expect(component.contextRepId).toBe(4);
+    expect(component.contextMenuOpen).toBe(false);
+
+    // The panel's X clears the shown bin but leaves the panel itself docked.
+    component.dismissContextMenu();
+    expect(component.contextMembers).toEqual([]);
+    expect(component.detailsDocked()).toBe(true);
+  });
+
+  it('carries the open bin across dock / pop-out toggles', async () => {
+    await settleZoneless(fixture);
+    const component = fixture.componentInstance;
+
+    // Start floating with a bin open.
+    component.onCanvasContextMenu({
+      members: [7, 8],
+      repId: 7,
+      clientX: 100,
+      clientY: 100,
+      bounds: null,
+    } as unknown as Parameters<typeof component.onCanvasContextMenu>[0]);
+    expect(component.contextMenuOpen).toBe(true);
+
+    // Dock: the floating window closes, the panel takes over the same bin.
+    component.onDockRequested();
+    expect(component.detailsDocked()).toBe(true);
+    expect(component.contextMenuOpen).toBe(false);
+    expect(component.contextMembers).toEqual([7, 8]);
+
+    // Pop out: the panel's bin re-opens as a floating window at a default anchor.
+    component.onPopOutRequested();
+    expect(component.detailsDocked()).toBe(false);
+    expect(component.contextMenuOpen).toBe(true);
+    expect(component.contextMembers).toEqual([7, 8]);
+  });
+
+  it('persists the details panel width from a divider drag, clamped', async () => {
+    await settleZoneless(fixture);
+    const component = fixture.componentInstance;
+    const updates: Record<string, unknown>[] = [];
+    const settings = TestBed.inject(SettingsStateService);
+    (settings.update as unknown) = (u: Record<string, unknown>) => {
+      updates.push(u);
+      return of({});
+    };
+
+    component.onDetailsDividerMouseDown({ preventDefault: () => {} } as MouseEvent);
+    // Release commits the settled width to settings.
+    (component as unknown as { onDetailsMouseUp(): void }).onDetailsMouseUp();
+
+    expect(updates.some((u) => 'browse_details_panel_width' in u)).toBe(true);
+  });
+
   it('drives preview-audio volume from the toolbar: slider lowers the level and mute round-trips', async () => {
     await settleZoneless(fixture);
     const component = fixture.componentInstance;

--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -162,6 +162,14 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
   // buttons in the metadata panels.
   copy:
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>',
+  // Panel with an inward arrow: dock the floating bin-details window as the
+  // Browse view's left panel.
+  'dock-left':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><line x1="9" y1="4" x2="9" y2="20"/><line x1="19" y1="12" x2="13" y2="12"/><polyline points="16 9 13 12 16 15"/></svg>',
+  // Window with an outward arrow: pop the docked bin-details panel back out
+  // into its floating window.
+  'pop-out':
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5"/><polyline points="14 4 20 4 20 10"/><line x1="20" y1="4" x2="12" y2="12"/></svg>',
   // Speaker with sound waves / muted speaker, used by the Browse toolbar's
   // preview-volume control (audio datasets only).
   volume:

--- a/frontend/src/app/components/icon/icon.component.ts
+++ b/frontend/src/app/components/icon/icon.component.ts
@@ -27,6 +27,7 @@ const KNOWN_TYPES = new Set([
   'checkbox-checked', 'checkbox-some', 'checkbox-blank', 'search', 'trophy',
   'zoom-in', 'zoom-out', 'zoom-fit', 'help', 'copy',
   'export', 'trash', 'combine', 'rotate-ccw', 'rotate-cw',
+  'dock-left', 'pop-out',
 ]);
 
 function emojiToType(icon: string): string {

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -826,6 +826,30 @@ class TestBrowserSettings:
         # Persists across a fresh read.
         assert client.get("/api/settings").get_json()["browse_signposts"]["audio"] is False
 
+    def test_update_bin_details_docked_per_type(self, client):
+        res = client.put("/api/settings", json={"bin_details_docked": {"audio": True, "image": False}})
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["bin_details_docked"]["audio"] is True
+        assert data["bin_details_docked"]["image"] is False
+        # Persists across a fresh read.
+        assert client.get("/api/settings").get_json()["bin_details_docked"]["audio"] is True
+
+    def test_update_browse_details_panel_width(self, client):
+        res = client.put("/api/settings", json={"browse_details_panel_width": 420})
+        assert res.status_code == 200
+        assert res.get_json()["browse_details_panel_width"] == 420
+        assert client.get("/api/settings").get_json()["browse_details_panel_width"] == 420
+
+    def test_browse_details_panel_width_clamps_out_of_range(self, client):
+        # Values outside the 220..800 clamp are pulled back into range.
+        res = client.put("/api/settings", json={"browse_details_panel_width": 5000})
+        assert res.status_code == 200
+        assert res.get_json()["browse_details_panel_width"] == 800
+        res2 = client.put("/api/settings", json={"browse_details_panel_width": 1})
+        assert res2.status_code == 200
+        assert res2.get_json()["browse_details_panel_width"] == 220
+
     def test_get_settings_includes_browser_prefs(self, client):
         data = client.get("/api/settings").get_json()
         # Present as (possibly empty) dicts so the frontend can index by type.
@@ -836,6 +860,7 @@ class TestBrowserSettings:
             "browse_compact",
             "browse_mouse_zooms_per_level",
             "browse_signposts",
+            "bin_details_docked",
         ):
             assert key in data
             assert isinstance(data[key], dict)
@@ -849,5 +874,6 @@ class TestBrowserSettings:
             "browse_compact",
             "browse_mouse_zooms_per_level",
             "browse_signposts",
+            "bin_details_docked",
         ):
             assert data.get(key, {}) == {}

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -90,6 +90,10 @@ class AppSettingsSchema(Schema):
     # Settings-modal widget; the panel's draggable divider drives it.
     browse_panel_width = fields.Integer()
 
+    # VTSBrowse docked bin-details panel width (CSS px). Persisted but not
+    # shown as a Settings-modal widget; the panel's draggable divider drives it.
+    browse_details_panel_width = fields.Integer()
+
     # VTSBrowse per-media-type display prefs (density colormap, on-screen cell
     # size). ``{media_type_id: value}`` dicts driven by the browse-canvas
     # toolbar and the Settings → Browser tab. (Bin shape is not stored — it is
@@ -129,6 +133,10 @@ class AppSettingsSchema(Schema):
     # the popup's own metadata toggle button; when shown, a column left of the
     # detail preview carries the focused item's Train/Find metadata fields.
     popup_metadata_shown = _PerMediaTypeBooleanDict()
+    # VTSBrowse bin-details presentation, per media type: true = docked left
+    # panel, false/unset = floating right-click popup window. Driven by the
+    # dock button on the floating window and the pop-out button on the panel.
+    bin_details_docked = _PerMediaTypeBooleanDict()
 
     # Server-tier. These are fixed at server start (config file /
     # environment / CLI flags) and shared across all users; the frontend
@@ -254,6 +262,7 @@ class SettingsUpdateSchema(Schema):
     grid_icon_size_popup = fields.Raw()
     popup_preview_size = fields.Raw()
     popup_metadata_shown = fields.Raw()
+    bin_details_docked = fields.Raw()
 
     autopilot_enabled = fields.Boolean()
     hide_autopilot = fields.Boolean()
@@ -264,6 +273,7 @@ class SettingsUpdateSchema(Schema):
     enable_achievements = fields.Boolean()
 
     browse_panel_width = fields.Integer()
+    browse_details_panel_width = fields.Integer()
 
     # Per-media-type dicts; the setters in ``settings.py`` validate each
     # value against its enum (BrowseColormap / BrowseIconSize), so these are

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -347,6 +347,13 @@ class UserSettings(BaseModel):
     # on-screen range.
     browse_panel_width: Annotated[int, _clamp(260, 800)] = 360
 
+    # VTSBrowse docked bin-details panel width (CSS px). When the bin-details
+    # window is docked (``bin_details_docked``), it renders as a left panel
+    # beside the canvas, separated by a draggable divider; this persists the
+    # width the user dragged it to. Not surfaced as a Settings-modal widget -
+    # the divider drives it. Clamped to a sane on-screen range.
+    browse_details_panel_width: Annotated[int, _clamp(220, 800)] = 340
+
     # VTSBrowse per-media-type display preferences. Each is a
     # ``{media_type_id: value}`` dict so a user can tune the projection
     # browser independently for, say, audio vs. image datasets. Empty
@@ -442,6 +449,13 @@ class UserSettings(BaseModel):
     # thus a focused item to attach the column to, but the flag is stored per media
     # type generically.
     popup_metadata_shown: dict[str, bool] = Field(default_factory=dict)
+    # VTSBrowse bin-details presentation, per media type. When true, the bin
+    # details open docked as a left panel beside the canvas (large item +
+    # metadata on top, the bin's member grid below) instead of the floating
+    # right-click popup window. Driven by the dock button on the floating
+    # window and the pop-out button on the docked panel; empty entries fall
+    # back to the floating window (false).
+    bin_details_docked: dict[str, bool] = Field(default_factory=dict)
     panel_pct_left: dict[str, int] = Field(default_factory=dict)
     panel_pct_right: dict[str, int] = Field(default_factory=dict)
 


### PR DESCRIPTION
## Summary

Adds an **optional docked presentation** for the VTSBrowse bin-details window, alongside the existing floating right-click popup. Each user gets a docked/undocked choice **per media type**, remembered in Settings.

When docked, the bin details render as a persistent **left panel** beside the canvas:

- The **large media item** sits top-left, with its **metadata to the right**.
- **All the items in the bin** render as a grid **below** them.
- For **audio**, the large item doubles as the **Now Playing** display (replacing the small top-left waveform widget): it tracks whatever clip is auditioning from any canvas or grid hover, with the sweeping playhead + buffering spinner. The toolbar's small waveform is hidden while docked.
- For **singletons**, the grid area is still allocated but left empty (the lone item is already shown large in the pane).
- When the option is on but no bin has been right-clicked yet, the panel shows an **empty hint**.

Both the existing **Larger/Smaller** controls are preserved — one pair sizes the bin thumbnails, the other sizes the large displayed item — and both persist per media type as before.

### Toggling presentations
- The floating window gets a **Dock** button; clicking it hides the popup and opens the docked panel.
- The docked panel gets a **Pop out** button; clicking it hides the panel and re-opens the floating window.
- In both directions the **currently open bin carries over** to the other presentation.

### Panel sizing
The docked panel has a **draggable divider** like the existing right selection panel; the dragged width persists (`browse_details_panel_width`). The docked member grid re-chunks its columns to the live panel width.

## Changes

**Backend**
- New settings: `bin_details_docked` (per-media-type bool) and `browse_details_panel_width` (clamped int 220–800), wired through `settings_models.py` + both marshmallow schemas; OpenAPI snapshot regenerated.

**Frontend**
- `browse-bin-popup` gains a `docked` input and a docked layout (detail pane + metadata on top, member grid below). In docked mode it drops all floating machinery (positioning, clamping, dragging, outside-click/Escape dismissal, document-level keyboard shortcuts) so the canvas keeps its own shortcuts. New `dockRequested` / `popOutRequested` outputs and a `nowPlayingExt` input (audio now-playing follow).
- `browse-view` hosts the docked panel in a new grid column with its own divider, mirrors `bin_details_docked` per media type, routes right-clicks to the panel when docked, and implements the dock/pop-out carry-over.
- Two new icons (`dock-left`, `pop-out`).

**Tests**
- Frontend: 7 docked-presentation specs on the popup + 3 browse-view integration specs (routing, dock/pop-out carry-over, divider-width persistence).
- Backend: settings round-trip/clamp tests for the two new keys.

## Testing

- `./run-tests.sh` — full Python suite passes (6421), all lint/format/codespell/deptry/pyright/OpenAPI gates green.
- `./run-tests.sh frontend` — build + audit + Vitest pass (1717 tests).

## Notes

Default behavior is unchanged (docked defaults off per media type), so the existing `browse-view` doc screenshot is unaffected and needs no reshoot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AM76YP2617xVau1sg4e7f9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM76YP2617xVau1sg4e7f9)_