### PR TITLE
Fix stuck "Loading…" placeholders in Auto-Find settings

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
@@ -8,13 +8,13 @@
     <vt-icon type="help" [size]="14"></vt-icon>
   </span>
 </h4>
-@if (loadingDetectors) {
+@if (loadingDetectors()) {
   <p class="empty-state">Loading detectors…</p>
-} @else if (detectors.length === 0) {
+} @else if (detectors().length === 0) {
   <p class="empty-state">No detectors registered yet. Train or import a detector first.</p>
 } @else {
   <div class="detector-list">
-    @for (d of detectors; track d.id) {
+    @for (d of detectors(); track d.id) {
       <label class="checkbox-row" [title]="'Auto-Find ' + d.name + (d.media_type ? ' (' + d.media_type + ')' : '')">
         <input type="checkbox" [ngModel]="d.autofind" (ngModelChange)="toggleDetector(d, $event)" />
         {{ d.name }}
@@ -25,14 +25,14 @@
     }
   </div>
 }
-@if (detectorError) {
-  <p class="error-text">{{ detectorError }}</p>
+@if (detectorError()) {
+  <p class="error-text">{{ detectorError() }}</p>
 }
 
 <!-- Results Exporter ------------------------------------------------------ -->
 <!-- Hidden entirely when no exporters are available: the section would
      otherwise degrade to a lone "None" tab (a picker with no real choice). -->
-@if (loadingExporters || exporters.length > 0) {
+@if (loadingExporters() || exporters().length > 0) {
 <h4 class="subhead">
   Results Exporter:
   <span
@@ -42,7 +42,7 @@
     <vt-icon type="help" [size]="14"></vt-icon>
   </span>
 </h4>
-@if (loadingExporters) {
+@if (loadingExporters()) {
   <p class="empty-state">Loading exporters…</p>
 } @else {
   <div class="view-tabs">
@@ -53,7 +53,7 @@
       title="Do not export results automatically">
       None
     </button>
-    @for (exp of exporters; track exp.name) {
+    @for (exp of exporters(); track exp.name) {
       <button
         class="view-tab"
         [class.view-tab--active]="activeExporter === exp.name"

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
@@ -113,33 +113,48 @@ describe('AutoFindSettingsComponent', () => {
   it('creates and loads the detector checklist mapped to the narrowed shape', async () => {
     await create();
     expect(component).toBeTruthy();
-    expect(component.loadingDetectors).toBe(false);
-    expect(component.detectors).toEqual([
+    expect(component.loadingDetectors()).toBe(false);
+    expect(component.detectors()).toEqual([
       { id: 'det-1', name: 'Barks', autofind: true, media_type: 'audio' },
       { id: 'det-2', name: 'Cats', autofind: false, media_type: 'image' },
     ]);
-    expect(component.detectorError).toBe('');
+    expect(component.detectorError()).toBe('');
   });
 
   it('loads exporters, filtering out picker-hidden ones', async () => {
     await create();
-    expect(component.loadingExporters).toBe(false);
-    expect(component.exporters.map((e) => e.name)).toEqual(['server_json_file', 'email']);
+    expect(component.loadingExporters()).toBe(false);
+    expect(component.exporters().map((e) => e.name)).toEqual(['server_json_file', 'email']);
+  });
+
+  it('clears the "Loading…" placeholders in the DOM once the loads settle (zoneless canary)', async () => {
+    // Regression guard: the loading flags are written from async subscribe
+    // callbacks. As plain properties those writes never schedule change
+    // detection under zoneless, so the DOM stayed stuck on "Loading…" forever.
+    // As signals they repaint. settleZoneless() flushes only *scheduled* CD (it
+    // does not force detectChanges), so a stale DOM here means a missing write.
+    await create();
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).not.toContain('Loading detectors…');
+    expect(text).not.toContain('Loading exporters…');
+    // The real content rendered in place of the placeholders.
+    expect(text).toContain('Barks');
+    expect(text).toContain('JSON File');
   });
 
   it('sets detectorError and clears loading when the registry fails', async () => {
     registryResponse = () => throwError(() => new Error('nope'));
     await create();
-    expect(component.detectorError).toBe('Failed to load detectors');
-    expect(component.loadingDetectors).toBe(false);
-    expect(component.detectors).toEqual([]);
+    expect(component.detectorError()).toBe('Failed to load detectors');
+    expect(component.loadingDetectors()).toBe(false);
+    expect(component.detectors()).toEqual([]);
   });
 
   it('clears the exporter loading flag when the exporters call fails', async () => {
     exportersResponse = () => throwError(() => new Error('nope'));
     await create();
-    expect(component.loadingExporters).toBe(false);
-    expect(component.exporters).toEqual([]);
+    expect(component.loadingExporters()).toBe(false);
+    expect(component.exporters()).toEqual([]);
   });
 
   it('initialises the active exporter and cloned field values from inputs', async () => {
@@ -168,7 +183,7 @@ describe('AutoFindSettingsComponent', () => {
 
   it('toggleDetector flips the flag optimistically and persists it', async () => {
     await create();
-    const cats = component.detectors[1];
+    const cats = component.detectors()[1];
     component.toggleDetector(cats, true);
     expect(cats.autofind).toBe(true);
     expect(autofindCalls).toEqual([{ id: 'det-2', autofind: true }]);
@@ -177,10 +192,10 @@ describe('AutoFindSettingsComponent', () => {
   it('toggleDetector reverts and reports an error when the persist fails', async () => {
     autofindResponse = () => throwError(() => new Error('fail'));
     await create();
-    const cats = component.detectors[1];
+    const cats = component.detectors()[1];
     component.toggleDetector(cats, true);
     expect(cats.autofind).toBe(false); // reverted
-    expect(component.detectorError).toBe('Failed to update Auto-Find for "Cats"');
+    expect(component.detectorError()).toBe('Failed to update Auto-Find for "Cats"');
   });
 
   it('selectExporter seeds default field values on first pick and emits', async () => {

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, OnInit, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
 
 import { FormsModule } from '@angular/forms';
@@ -75,11 +75,15 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
    *  persist whenever the user changes the exporter or any of its fields. */
   readonly exporterChange = output<AutoFindExporterChange>();
 
-  detectors: AutofindDetectorEntry[] = [];
-  exporters: ExporterEntry[] = [];
-  loadingDetectors = true;
-  loadingExporters = true;
-  detectorError = '';
+  // Written from the async load subscribes below (not a zoneless CD trigger)
+  // yet read in the template, so they must be signals to repaint on emit;
+  // plain-property writes inside a subscribe callback never schedule change
+  // detection under zoneless, which is what left "Loading…" stuck forever.
+  readonly detectors = signal<AutofindDetectorEntry[]>([]);
+  readonly exporters = signal<ExporterEntry[]>([]);
+  readonly loadingDetectors = signal(true);
+  readonly loadingExporters = signal(true);
+  readonly detectorError = signal('');
 
   /** Active exporter tab ('' = the "None" tab). Mirrors ``autofindExporter``
    *  but is the single source of truth for which tab body is shown. */
@@ -96,17 +100,19 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (res) => {
-          this.detectors = (res.detectors || []).map((d) => ({
-            id: String((d as Record<string, unknown>)['id'] ?? ''),
-            name: String((d as Record<string, unknown>)['name'] ?? ''),
-            autofind: Boolean((d as Record<string, unknown>)['autofind']),
-            media_type: String((d as Record<string, unknown>)['media_type'] ?? ''),
-          }));
-          this.loadingDetectors = false;
+          this.detectors.set(
+            (res.detectors || []).map((d) => ({
+              id: String((d as Record<string, unknown>)['id'] ?? ''),
+              name: String((d as Record<string, unknown>)['name'] ?? ''),
+              autofind: Boolean((d as Record<string, unknown>)['autofind']),
+              media_type: String((d as Record<string, unknown>)['media_type'] ?? ''),
+            })),
+          );
+          this.loadingDetectors.set(false);
         },
         error: () => {
-          this.detectorError = 'Failed to load detectors';
-          this.loadingDetectors = false;
+          this.detectorError.set('Failed to load detectors');
+          this.loadingDetectors.set(false);
         },
       });
 
@@ -115,11 +121,11 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (list) => {
-          this.exporters = (list || []).filter((exp) => !exp.hidden_from_picker);
-          this.loadingExporters = false;
+          this.exporters.set((list || []).filter((exp) => !exp.hidden_from_picker));
+          this.loadingExporters.set(false);
         },
         error: () => {
-          this.loadingExporters = false;
+          this.loadingExporters.set(false);
         },
       });
   }
@@ -143,7 +149,7 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
       .subscribe({
         error: () => {
           detector.autofind = prev; // revert on failure
-          this.detectorError = `Failed to update Auto-Find for "${detector.name}"`;
+          this.detectorError.set(`Failed to update Auto-Find for "${detector.name}"`);
         },
       });
   }
@@ -164,7 +170,7 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
   /** Fields of the active exporter, or ``[]`` for the "None" tab. */
   get activeFields(): ImporterField[] {
     if (!this.activeExporter) return [];
-    const exp = this.exporters.find((e) => e.name === this.activeExporter);
+    const exp = this.exporters().find((e) => e.name === this.activeExporter);
     return ((exp?.fields ?? []) as ImporterField[]) || [];
   }
 
@@ -192,7 +198,7 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
   }
 
   private defaultFieldValues(name: string): Record<string, string> {
-    const exp = this.exporters.find((e) => e.name === name);
+    const exp = this.exporters().find((e) => e.name === name);
     const out: Record<string, string> = {};
     for (const field of (exp?.fields ?? []) as ImporterField[]) {
       if (field.default) out[field.key] = field.default;


### PR DESCRIPTION
## Problem

In the Auto-Find settings panel, the **Auto-Find detectors** section and the **Results Exporter** section showed "Loading detectors…" and "Loading exporters…" forever — the placeholders never cleared even after the data loaded.

## Root cause

The app runs with `provideZonelessChangeDetection()`. In `auto-find-settings.component.ts`, `loadingDetectors`, `loadingExporters`, `detectors`, `exporters`, and `detectorError` were **plain properties** mutated inside the `getRegistry()` / `getExporters()` async subscribe callbacks. Under zoneless change detection, a plain-property write from an async callback never schedules a repaint, so the template stayed on its `@if (loadingDetectors) { Loading… }` branch indefinitely.

Every sibling component (`load-sort-modal`, `settings-exporter-modal`, `autodetect-results-modal`, etc.) already uses signals for exactly this reason — this component was the lone holdout.

## Fix

Convert the five async-written fields to signals so their writes schedule change detection, and update the template + spec to read them as signals. `activeExporter` / `fieldValues` are left as plain properties: they're written only from DOM event handlers (which do schedule CD under zoneless) and the seeding `effect` (runs during CD).

Setting `detectorError` as a signal also incidentally fixes the optimistic-toggle revert on a failed `setAutofind` call, which had the same stale-repaint problem.

## Testing

- Added a zoneless DOM canary that asserts the "Loading…" placeholders actually clear from the rendered DOM (it uses `settleZoneless`, which flushes only *scheduled* CD, so it would fail against the old plain-property code).
- `./run-tests.sh frontend` passes: build clean (no warnings), 1712 Vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125DsbKkteLhPFyrb6P6Ajp

---
_Generated by [Claude Code](https://claude.ai/code/session_0125DsbKkteLhPFyrb6P6Ajp)_