### PR TITLE
Fix Browse-on-unloaded-dataset: dataset load task never reached idle

### DIFF
--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1669,6 +1669,68 @@ class TestLoadProgressRaceCondition:
 
             unregister_dataset(dataset_id)
 
+    def test_load_registered_dataset_task_reaches_idle_on_success(self, client):
+        """The per-task tracker (``_loading_tasks``, distinct from the legacy
+        thread-local progress the previous test checks) must reach ``idle``
+        on a *successful* load, not just on cancel/error.
+
+        Regression for the Browse-an-unloaded-dataset bug: the frontend's
+        ``waitForDatasetLoad`` waits for this task's status to flip to
+        ``idle`` before promoting the dataset to active and firing the
+        projection-build request. Without an explicit ``idle`` transition on
+        the success path, the task lingered at ``status="loading"`` until
+        ``list_tasks()`` happened to prune it (several seconds later, via the
+        next SSE heartbeat), during which any request tagged with the new
+        dataset id 409'd with "Dataset is not loaded".
+        """
+        import time
+        from pathlib import Path
+
+        from vtscore.concurrency.progress import loading_tasks
+        from vtscore.datasets.loader import export_dataset_to_file
+        from vtscore.datasets.registry import register_dataset, unregister_dataset
+        from vtsearch.settings import get_saved_datasets_dir
+
+        saved = dict(app_module.medias)
+        ds_dir = get_saved_datasets_dir()
+        ds_dir.mkdir(parents=True, exist_ok=True)
+        pkl_path = str(ds_dir / "test_idle_on_success.pkl")
+        dataset_id = None
+        try:
+            Path(pkl_path).write_bytes(export_dataset_to_file(app_module.medias))
+
+            entry = register_dataset(
+                name="test_idle_on_success",
+                media_type="audio",
+                num_items=len(app_module.medias),
+                pkl_path=pkl_path,
+            )
+            dataset_id = entry["id"]
+
+            resp = client.post(f"/api/datasets/registry/{dataset_id}/load")
+            assert resp.status_code == 200
+            task_id = resp.get_json()["task_id"]
+            assert task_id
+
+            status = None
+            for _ in range(120):
+                tasks = loading_tasks.list_tasks()
+                task = next((t for t in tasks if t["task_id"] == task_id), None)
+                if task is not None:
+                    status = task["status"]
+                    if status == "idle":
+                        break
+                time.sleep(0.1)
+            assert status == "idle", (
+                "load task must reach 'idle' on success instead of lingering at 'loading' until list_tasks() prunes it"
+            )
+        finally:
+            app_module.medias.clear()
+            app_module.medias.update(saved)
+            Path(pkl_path).unlink(missing_ok=True)
+            if dataset_id:
+                unregister_dataset(dataset_id)
+
     def test_origin_load_clears_stale_error(self):
         """_run_origin_load_in_background must clear old error on new load."""
         from unittest.mock import patch

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -305,6 +305,14 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
                 # goes green immediately; text sort waits behind its own
                 # progress bar on first use if the model isn't ready yet.
                 _warmup_embedder_async(ctx.medias)
+                # Flip the tracker to "idle" so SSE listeners (the frontend's
+                # waitForDatasetLoad) see completion immediately instead of
+                # only inferring it once list_tasks() prunes this finished
+                # entry several seconds later - the gap that let the Browse
+                # button fire its projection-build request against a dataset
+                # the frontend hadn't yet promoted to active, 409ing with
+                # "Dataset is not loaded".
+                tracker.update("idle", "", 0, 0, step=None, total_steps=None)
             except CancelledError:
                 unregister_context(dataset_id)
                 _reg_remove_loaded(dataset_id)


### PR DESCRIPTION
## Summary

Fixes the reported bug: clicking Browse on an unloaded dataset failed with `Failed: Dataset is not loaded` instead of loading the dataset first.

The frontend's Browse flow (`BrowsePrepService` → `ContextSwitchService`) already had solid load-then-browse orchestration, including a `waitForDatasetLoad` step that waits for the dataset's background load task to settle (report `status: "idle"`) before promoting the dataset to active and firing the projection-build request that the Browse view needs.

The actual bug was on the backend: `load_registered_dataset`'s background `load_task()` in `vtsearch/routes/datasets/registry.py` never transitioned its per-task progress tracker to `"idle"` on the **success** path — only the `CancelledError` / `MemoryError` / generic `Exception` branches did. (The equivalent detector-load and detector-positives-browse tasks in `vtsearch/routes/detectors/registry.py` both correctly call `tracker.update("idle", ...)` on success — this was an isolated omission.)

Effect: after a successful load, the task lingered at `status: "loading"` in the SSE `loading-tasks` stream. The frontend's `waitForDatasetLoad` only resolved once `list_tasks()` happened to prune the finished-but-never-idle entry (5s after `mark_finished()`, discovered on the next 5s SSE heartbeat) — a 5-10s stall, during which any request tagged with the new dataset id (like the Browse button's projection-build call) could hit the backend before the dataset was recognized as loaded, 409ing with `dataset_not_loaded` → "Dataset is not loaded".

## Fix

Added the missing `tracker.update("idle", "", 0, 0, step=None, total_steps=None)` call on the dataset-load success path, mirroring the pattern already used everywhere else (detector load, detector-positives browse, and the load task's own error branches).

Reproduced live via a Flask test-client + real background thread before the fix (task visibly stuck at `status: "loading"` for 5+ seconds, `is_finished()` flipping straight from `False` to `False` once pruned, projection build racing a 409); confirmed resolved after the fix (task reaches `idle` in ~1.5s, projection build succeeds immediately).

## Test plan

- [x] Added `TestDatasetEndpoints.test_load_registered_dataset_task_reaches_idle_on_success` in `tests/datasets/test_datasets.py`, polling the real `_loading_tasks` tracker after a registry load to assert it reaches `idle`.
- [x] `./run-tests.sh datasets` — 892 passed, 2 skipped.
- [x] `./run-tests.sh` (full suite) — 6426 passed, 1 skipped, 2 xpassed.


---
_Generated by [Claude Code](https://claude.ai/code/session_013f4iXNYVaXntuQbMiPnqgm)_