### PR TITLE
Tab-underline slide: animate active-tab indicators

### DIFF
--- a/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.scss
+++ b/frontend/src/app/components/dashboard/clipper-chooser/clipper-chooser.component.scss
@@ -12,6 +12,7 @@
 }
 
 .clipper-tab {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-sm);
@@ -26,6 +27,23 @@
   margin-bottom: -2px;
   white-space: nowrap;
 
+  // Active-underline wipe: the accent underline grows in (scaleX 0 → 1)
+  // rather than hard-cutting on. Sits over the 2px bottom-border region so it
+  // lands exactly on the tab bar's border line.
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -2px;
+    height: 2px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform var(--transition-slow);
+    pointer-events: none;
+  }
+
   &:hover {
     color: var(--text-primary);
     background: var(--bg-subtle);
@@ -33,8 +51,9 @@
 
   &.active {
     color: var(--accent);
-    border-bottom-color: var(--accent);
     font-weight: var(--weight-semibold);
+
+    &::after { transform: scaleX(1); }
   }
 }
 

--- a/frontend/src/app/components/left-panel/left-panel.component.scss
+++ b/frontend/src/app/components/left-panel/left-panel.component.scss
@@ -43,6 +43,7 @@
 }
 
 .left-tab {
+  position: relative;
   flex: 1;
   padding: var(--space-md) var(--space-lg);
   border: none;
@@ -52,6 +53,23 @@
   font-size: var(--font-md);
   transition: background var(--transition-base), color var(--transition-base);
 
+  // Active-underline wipe: the accent underline grows in (scaleX 0 → 1)
+  // rather than hard-cutting on. A pseudo-element also avoids the 2px layout
+  // shift the old active-only bottom border introduced.
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 2px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform var(--transition-slow);
+    pointer-events: none;
+  }
+
   &:hover:not(:disabled) {
     background: var(--bg-hover);
     color: var(--text-primary);
@@ -60,7 +78,8 @@
   &.active {
     background: var(--bg-surface);
     color: var(--text-primary);
-    border-bottom: 2px solid var(--accent);
+
+    &::after { transform: scaleX(1); }
   }
 
   &:disabled {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -189,6 +189,7 @@
 }
 
 .export-tab {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-xs);
@@ -203,14 +204,32 @@
   white-space: nowrap;
   transition: color var(--transition-base), border-color var(--transition-base);
 
+  // Active-underline wipe: the accent underline grows in (scaleX 0 → 1)
+  // rather than hard-cutting on. Sits over the 2px bottom-border region so it
+  // lands exactly on the tab bar's border line.
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -2px;
+    height: 2px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform var(--transition-slow);
+    pointer-events: none;
+  }
+
   &:hover {
     color: var(--text-primary);
   }
 
   &.active {
     color: var(--text-primary);
-    border-bottom-color: var(--accent);
     font-weight: var(--weight-semibold);
+
+    &::after { transform: scaleX(1); }
   }
 }
 

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -776,6 +776,7 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 }
 
 .view-tab {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: var(--space-xs);
@@ -790,6 +791,23 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   cursor: pointer;
   transition: color var(--transition-base), border-color var(--transition-base), background var(--transition-base);
 
+  // Active-underline wipe: the accent underline grows in (scaleX 0 → 1)
+  // rather than hard-cutting on. Sits over the 2px bottom-border region so it
+  // lands on the seam where the active tab flows into `.view-tab-content`.
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -2px;
+    height: 2px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform var(--transition-slow);
+    pointer-events: none;
+  }
+
   &:hover {
     color: var(--text-primary);
     background: var(--bg-hover);
@@ -798,7 +816,8 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   &--active {
     color: var(--text-primary);
     background: var(--bg-panel);
-    border-bottom-color: var(--accent);
+
+    &::after { transform: scaleX(1); }
   }
 }
 

--- a/frontend/src/scss/_picker-shared.scss
+++ b/frontend/src/scss/_picker-shared.scss
@@ -20,6 +20,7 @@
 }
 
 .tab {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-sm);
@@ -34,6 +35,24 @@
   margin-bottom: -2px;
   white-space: nowrap;
 
+  // Active-underline wipe: instead of hard-cutting the accent border on, a
+  // pseudo-element grows in (scaleX 0 → 1) under the active tab. It sits over
+  // the 2px bottom-border region (`bottom: -2px`) so it lands exactly where
+  // the tab bar's border is — the tab's -2px margin overlaps the two.
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -2px;
+    height: 2px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform var(--transition-slow);
+    pointer-events: none;
+  }
+
   &:hover {
     color: var(--text-primary);
     background: var(--bg-subtle);
@@ -41,8 +60,9 @@
 
   &.active {
     color: var(--accent);
-    border-bottom-color: var(--accent);
     font-weight: var(--weight-semibold);
+
+    &::after { transform: scaleX(1); }
   }
 }
 


### PR DESCRIPTION
## What

Replaces the hard-cutting accent bottom-border on active tabs with a pseudo-element underline that **wipes in** (`scaleX(0) → scaleX(1)`, `transform-origin: center`) over `--transition-slow`, so the active-tab indicator eases on instead of snapping. Classic and unobtrusive.

## Approach

A true indicator that physically *travels* between tabs of variable width can't be done in pure CSS (CSS can't read a sibling tab's geometry), so per the chosen direction this is the **CSS-only wipe** variant: no JS, no template changes. Each active tab's own accent underline now grows in via an `::after` element rather than the border color hard-cutting on. The pseudo-element sits over the existing 2px bottom-border region (`bottom: -2px`, or `bottom: 0` for `.left-tab`) so it lands exactly where the underline was before — the resting appearance of an active tab is unchanged; only the transition differs.

## Strips covered

Every horizontal underline tab strip, so they all animate consistently:

- `.tab` (`_picker-shared.scss`) — the shared primitive: Add-Dataset importer picker, New Detector, keyboard help, and the `@extend`ing `.importer-subtab` / `.demo-tab`
- `.view-tab` (`_components.scss`) — Settings modal media-type strips
- `.left-tab` (`left-panel.component.scss`) — left panel Manual / Autopilot (also removes the 2px layout shift the old active-only border introduced)
- `.clipper-tab` (clipper chooser) and `.export-tab` (export modal) — near-duplicate strips, brought in line

The Achievements modal has no tab strip (it embeds the achievements list directly), so there was nothing there to animate.

## Testing

`./run-tests.sh frontend` passes: Angular `build:prod` OK, `npm audit` clean, Vitest 1722 passed. No screenshot reshoot needed — the static active-tab frame is visually identical; only the transition is new.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hb2NpuNoD9kmWVogJieTW)_