### PR TITLE
Hide copy-name button with the name at tiny thumbnail sizes in VTSBrowse selection panel

### DIFF
--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -282,11 +282,11 @@
 }
 
 // At the two smallest icon sizes (XS/S, ~42px content-box) the name truncates to
-// a useless "a…", so hide it and let the grid pack tighter. The copy button
-// stays (revealed on hover) as the only way to read the full name here. M and
-// up keep the name.
+// a useless "a…", so hide the whole name row — copy button included, since a
+// row that exists only to hold the copy button just wastes vertical space in a
+// dense grid. M and up keep the name (and its copy button).
 @container bsp-cell (max-width: 60px) {
-  .bsp-name-grid {
+  .bsp-name-row {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary
- In the VTSBrowse right-panel selection list, when thumbnails shrink to the smallest sizes the item name is hidden via `@container bsp-cell (max-width: 60px)`, but the "Copy name to clipboard" button (`vt-copy-detail-button`) stayed visible on hover, wasting vertical space in each grid cell for a button whose value (the name) is no longer shown.
- The container query now hides the whole `.bsp-name-row` (name + copy button) instead of just `.bsp-name-grid`, so no row is reserved purely to host the copy button once the name it copies isn't displayed.

## Test plan
- [x] `cd frontend && npx ng test --no-watch --include='**/browse-selection-panel*.spec.ts'` — 7 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks73FPjioEABHZzvmLwPwe)_