### PR TITLE
VTSBrowse left panel UX: undock icon, header layout, grid resize, sticky enlarge

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -13,16 +13,15 @@
     class="bin-popup-header"
     [class.dragging]="dragging"
     (pointerdown)="onHeaderPointerDown($event)">
-    @if (canToggleMetadata) {
+    @if (!docked()) {
+      <!-- Floating: "Dock as side panel" is the leftmost control in the header. -->
       <button
         type="button"
         class="bin-popup-meta-toggle"
-        [class.active]="showMetadataColumn"
-        (click)="toggleMetadata()"
-        [attr.aria-pressed]="showMetadataColumn"
-        [title]="showMetadataColumn ? 'Hide metadata' : 'Show metadata'"
-        [attr.aria-label]="showMetadataColumn ? 'Hide metadata' : 'Show metadata'">
-        <vt-icon type="info" [size]="15" />
+        (click)="dockRequested.emit()"
+        title="Dock as a side panel"
+        aria-label="Dock as a side panel">
+        <vt-icon type="dock-left" [size]="14" />
       </button>
     }
     @if (hasPane) {
@@ -47,38 +46,41 @@
         </button>
       </div>
     }
-    <vt-view-controls
-      side="popup"
-      [currentMediaType]="mediaType()"
-      [showFocus]="false"
-      class="bin-popup-view-controls" />
-    @if (docked()) {
+    <!-- Right-aligned chrome cluster: metadata toggle sits next to the dock /
+         pop-out control (close on the far right). Docked, this puts the metadata
+         toggle immediately left of the pop-out button. -->
+    <div class="bin-popup-header-end">
+      @if (canToggleMetadata) {
+        <button
+          type="button"
+          class="bin-popup-meta-toggle"
+          [class.active]="showMetadataColumn"
+          (click)="toggleMetadata()"
+          [attr.aria-pressed]="showMetadataColumn"
+          [title]="showMetadataColumn ? 'Hide metadata' : 'Show metadata'"
+          [attr.aria-label]="showMetadataColumn ? 'Hide metadata' : 'Show metadata'">
+          <vt-icon type="info" [size]="15" />
+        </button>
+      }
+      @if (docked()) {
+        <button
+          type="button"
+          class="bin-popup-meta-toggle"
+          (click)="popOutRequested.emit()"
+          title="Pop out into a floating window"
+          aria-label="Pop out into a floating window">
+          <vt-icon type="pop-out" [size]="14" />
+        </button>
+      }
       <button
         type="button"
-        class="bin-popup-meta-toggle"
-        (click)="popOutRequested.emit()"
-        title="Pop out into a floating window"
-        aria-label="Pop out into a floating window">
-        <vt-icon type="pop-out" [size]="14" />
+        class="bin-popup-close"
+        (click)="close()"
+        [title]="docked() ? 'Clear' : 'Close'"
+        [attr.aria-label]="docked() ? 'Clear' : 'Close'">
+        &times;
       </button>
-    } @else {
-      <button
-        type="button"
-        class="bin-popup-meta-toggle"
-        (click)="dockRequested.emit()"
-        title="Dock as a side panel"
-        aria-label="Dock as a side panel">
-        <vt-icon type="dock-left" [size]="14" />
-      </button>
-    }
-    <button
-      type="button"
-      class="bin-popup-close"
-      (click)="close()"
-      [title]="docked() ? 'Clear' : 'Close'"
-      [attr.aria-label]="docked() ? 'Clear' : 'Close'">
-      &times;
-    </button>
+    </div>
   </div>
 
   <div class="bin-popup-body" [style.height.px]="docked() ? null : bodyOuterHeight">
@@ -195,6 +197,14 @@
               [title]="'Items in this bin (' + ids.length + ')'">
               {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
             </span>
+            <!-- Thumbnail smaller/larger sits on the select-all row (it controls
+                 this grid), rather than in the header beside the detail-image
+                 size buttons. -->
+            <vt-view-controls
+              side="popup"
+              [currentMediaType]="mediaType()"
+              [showFocus]="false"
+              class="bin-popup-grid-view-controls" />
           </div>
           <cdk-virtual-scroll-viewport
             [itemSize]="rowSize"

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -110,8 +110,15 @@
   }
 }
 
-.bin-popup-view-controls {
+// Right-aligned cluster of header chrome (metadata toggle, dock / pop-out,
+// close). Pushed to the far right so the detail-image size buttons (and, when
+// floating, the leftmost dock button) stay on the left.
+.bin-popup-header-end {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-shrink: 0;
 }
 
 .bin-popup-close {
@@ -271,16 +278,22 @@
   min-height: 0;
 }
 
-// Top row of the grid column: the select-all control on the left and the
-// member-count label pushed to the right. With a single member there is no
-// button, so `space-between` leaves the count alone at the left as before.
+// Top row of the grid column: the select-all control + member-count label on
+// the left, and the thumbnail smaller/larger controls pushed to the right (they
+// resize this grid, so they live on its header row rather than in the window
+// header).
 .bin-popup-grid-header {
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--space-2xs);
   padding: 0 var(--space-2xs) var(--space-2xs);
+}
+
+// Thumbnail size buttons, pushed to the right end of the grid header row.
+.bin-popup-grid-view-controls {
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 // Tri-state master checkbox, mirroring the dashboard's select-all button but
@@ -534,6 +547,19 @@
     height: auto;
     flex: 1 1 auto;
     min-height: 0;
+  }
+
+  // Resize like the right (selection) panel: fixed-width columns packed to the
+  // left with a constant gap, so widening the panel keeps the thumbnails (and
+  // the gaps between them) the same size and only reveals a new column once
+  // there's room for a whole one — instead of the floating window's ``1fr``
+  // tracks, which stretch each thumbnail's cell as the panel grows. The browse
+  // view then "pops" the divider tight to the column count on release (see
+  // ``snappedPanelWidth``), mirroring the right panel's snap.
+  .bin-popup-row {
+    grid-template-columns: repeat(var(--popup-cols, 1), var(--popup-cell, 80px));
+    justify-content: start;
+    column-gap: var(--space-xs);
   }
 }
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -714,6 +714,24 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     return Math.max(this.gridGoalWidth, this.availableWidth() - DOCKED_GRID_CHROME);
   }
 
+  /**
+   * Docked only: the smallest panel width that still shows the current column
+   * count, so the browse view can "pop" the details divider tight to the columns
+   * when the user releases it — mirroring the right/selection panel's snap. Uses
+   * the same width basis as {@link rebuildRows} (panel width minus {@link
+   * DOCKED_GRID_CHROME}, chunked by ``gridGoalWidth`` + {@link GRID_GAP}), so the
+   * snapped width always re-derives exactly ``columns`` columns with no trailing
+   * empty strip and never drops a column. Returns ``null`` when floating or when
+   * there is nothing to snap to.
+   */
+  snappedPanelWidth(): number | null {
+    if (!this.docked()) return null;
+    const cols = this.columns;
+    if (cols <= 0) return null;
+    const minContent = cols * (this.gridGoalWidth + GRID_GAP) - GRID_GAP;
+    return Math.ceil(minContent + DOCKED_GRID_CHROME);
+  }
+
   /** Recompute the column count + row chunking for the current thumbnail size. */
   private rebuildRows(): void {
     this.columns = Math.max(

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -83,6 +83,10 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private ngZone = inject(NgZone);
 
   private readonly canvas = viewChild(BrowseCanvasComponent);
+  /** The active bin-details popup — the docked panel or the floating window,
+   *  whichever is mounted (they're mutually exclusive). Used to snap the details
+   *  divider tight to its grid columns on release. */
+  private readonly binPopup = viewChild(BrowseBinPopupComponent);
   /** The 3-column grid (canvas | divider | side panel); the divider drag
    *  measures against its box. Only present in the ``ready`` state. */
   private readonly content = viewChild<ElementRef<HTMLElement>>('content');
@@ -771,6 +775,17 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.draggingDetails = false;
     document.removeEventListener('mousemove', this.boundDetailsMove);
     document.removeEventListener('mouseup', this.boundDetailsUp);
+    // Pop tight to the column count the user dragged to: snap away any trailing
+    // empty strip so releasing never leaves a ragged half-column (mirrors the
+    // right panel's snap). The docked panel reports the minimum width that still
+    // shows its current columns; it only ever shrinks, so clamp just guards the
+    // floor.
+    const snapped = this.binPopup()?.snappedPanelWidth() ?? null;
+    if (snapped !== null) {
+      this.detailsPanelWidth.set(
+        this.clamp(snapped, BrowseViewComponent.DETAILS_FLOOR, this.detailsPanelWidth()),
+      );
+    }
     // The user now owns the width; block the settings round-trip from resetting it.
     this.detailsWidthInitialized = true;
     this.settingsState
@@ -953,10 +968,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.contextRepId = event.repId;
     if (this.detailsDocked()) {
       // Docked: the persistent left panel shows the bin — no floating window.
-      // Release the canvas's pinned enlarge right away so live hover keeps
-      // working while the bin stays open in the panel.
+      // Keep the canvas's pinned enlarge (the canvas pinned it on right-click)
+      // so the chosen bin stays enlarged while it's open in the panel, exactly
+      // like the floating window. It's released on dismiss (the panel's X or an
+      // empty-space right-click), or re-pinned when another bin is right-clicked.
       this.contextMenuOpen = false;
-      this.canvas()?.unpinCell();
       return;
     }
     this.contextMenuX = event.clientX;
@@ -983,7 +999,8 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    *  same ``contextMembers``). */
   onDockRequested(): void {
     this.contextMenuOpen = false;
-    this.canvas()?.unpinCell();
+    // Keep the bin pinned enlarged as it moves into the docked panel — docked
+    // bins stay enlarged too now, so there's nothing to release here.
     this.persistBinDetailsDocked(true);
   }
 

--- a/frontend/src/app/components/icon/icon-svgs-extended.ts
+++ b/frontend/src/app/components/icon/icon-svgs-extended.ts
@@ -166,10 +166,13 @@ export const EXTENDED_ICON_SVGS: Record<string, string> = {
   // Browse view's left panel.
   'dock-left':
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><line x1="9" y1="4" x2="9" y2="20"/><line x1="19" y1="12" x2="13" y2="12"/><polyline points="16 9 13 12 16 15"/></svg>',
-  // Window with an outward arrow: pop the docked bin-details panel back out
-  // into its floating window.
+  // Window (no docked "wall") with an outward arrow: pop the docked bin-details
+  // panel back out into its floating window. Deliberately the thematic inverse
+  // of ``dock-left`` — the same panel frame, but with the sidebar wall removed
+  // and the arrow pointing out (right) rather than in — so the dock/undock pair
+  // reads as a matched set.
   'pop-out':
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5"/><polyline points="14 4 20 4 20 10"/><line x1="20" y1="4" x2="12" y2="12"/></svg>',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><line x1="10" y1="12" x2="16" y2="12"/><polyline points="13 9 16 12 13 15"/></svg>',
   // Speaker with sound waves / muted speaker, used by the Browse toolbar's
   // preview-volume control (audio datasets only).
   volume:


### PR DESCRIPTION
Refines the docked VTSBrowse bin-details **left panel** (and its floating-window twin), per a batch of UX requests.

## Changes

1. **Undock icon is now a thematic pair with the dock icon.** The `pop-out` glyph was the generic "open in new window" arrow; it's now the inverse of `dock-left` — the same panel frame with the sidebar *wall* removed and the arrow pointing **out** — so dock/undock read as a matched set.
2. **"Dock as side panel" is the leftmost button** on the floating window's header.
3. **Thumbnail smaller/larger moved onto the select-all row.** Those buttons resize the member grid, so they now live on that grid's header row (beside select-all + the item count) instead of the window header. The **detail-image** size buttons stay in the header.
4. **Show/Hide-metadata toggle sits immediately left of the pop-out button** in the docked header (grouped with the panel chrome it belongs to).
5. **The docked member grid now resizes like the right/Selection panel.** It uses fixed-width columns packed to the left with a constant gap (instead of the floating window's stretch-to-fill `1fr` tracks), so widening the panel keeps thumbnails and gaps the same size and only reveals a new column once a whole one fits. On divider release the details panel "pops" tight to the column count, mirroring the right panel's snap (new `snappedPanelWidth()` on the popup, consumed by the browse view's details-divider mouseup).
6. **A right-clicked bin stays enlarged on the canvas while docked**, exactly like the floating window did — the canvas pin is no longer released immediately in docked mode. It clears when the bin is dismissed (the panel's X or an empty-space right-click) or re-pins when another bin is right-clicked.

## Files

- `icon-svgs-extended.ts` — new `pop-out` SVG (frame, no wall, outward arrow).
- `browse-bin-popup.component.{html,scss,ts}` — header restructure (dock-left / metadata-toggle / pop-out placement), thumbnail-size controls moved to the grid header, docked grid fixed-width/left-aligned columns, `snappedPanelWidth()`.
- `browse-view.component.ts` — snap the details divider on release; keep the canvas pin (bin stays enlarged) in docked mode.

## Testing

`./run-tests.sh frontend` passes: ruff / ruff-format / codespell / deptry / pip-audit / pyright / OpenAPI / Dockerfile / screenshot-wiring all clean, `build:prod` OK, `npm audit` 0 vulns, and the full Vitest suite (1722 tests) passes. Changes are frontend-only.

No doc screenshots frame the bin-popup or docked panel (the one Browse shot captures the initial map with no popup open; docking is opt-in and off by default), so nothing was added to the screenshot reshoot queue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrErU52zCXRguSDSXGg8sC)_