### PR TITLE
Fit browse-bin-popup SCSS under budget by deduping thumbnail square metrics

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -409,15 +409,21 @@
 
 // Thumbnail/placeholder square, sized to the chosen icon size (``--popup-cell``,
 // bound per row); falls back to a compact square if the variable is ever absent.
-.bin-popup-thumb-wrap {
-  display: block;
+// The real thumbnail's wrapper and the no-thumbnail placeholder are the same
+// fixed cell-sized box, so they share these metrics (and the themed ``--bg-body``
+// surface: hidden under a cover-fit <img>, and the backdrop the tinted audio
+// waveform (issue #2369) sits on).
+.bin-popup-thumb-wrap,
+.bin-popup-placeholder {
   width: var(--popup-cell, 28px);
   height: var(--popup-cell, 28px);
   border-radius: var(--radius-sm);
   flex-shrink: 0;
-  // Themed surface behind the thumbnail: hidden under a cover-fit <img>, and the
-  // backdrop the tinted audio waveform (issue #2369) sits on.
   background: var(--bg-body);
+}
+
+.bin-popup-thumb-wrap {
+  display: block;
   overflow: hidden;
 }
 
@@ -451,13 +457,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: var(--popup-cell, 28px);
-  height: var(--popup-cell, 28px);
-  border-radius: var(--radius-sm);
-  background: var(--bg-body);
   color: var(--text-muted);
   font-size: var(--font-lg);
-  flex-shrink: 0;
 }
 
 // The name stacks under the thumbnail, truncated to the cell width. Its


### PR DESCRIPTION
## Summary

`browse-bin-popup.component.scss` was 25 bytes over its 8 kB `anyComponentStyle` budget, tripping a build warning (which `run-tests.sh` treats as a hard failure).

`.bin-popup-thumb-wrap` and `.bin-popup-placeholder` are both the same fixed cell-sized square and independently declared the same five properties (`width`, `height`, `border-radius`, `flex-shrink`, `background`). I hoisted those shared metrics into a single grouped selector, leaving each rule with only its distinct properties (`display`/`overflow` for the wrapper; `display: flex` + centering + text color/size for the placeholder). No visual or behavioral change — the same declarations apply to the same elements.

Net result drops the compiled stylesheet comfortably back under budget; `npm run build:prod` now completes with no budget warning.

## Verification

- `cd frontend && npm run build:prod` → completes with exit 0, no `▲ [WARNING] ... exceeded maximum budget` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuvHdCVjwBjBa9K6B4XDWJ)_