### PR TITLE
Origin-aware modal scale-in + backdrop-fade/content-scale motion

### DIFF
--- a/docs/plans/ui-motion-vocabulary.md
+++ b/docs/plans/ui-motion-vocabulary.md
@@ -34,51 +34,15 @@ policy in `CLAUDE.md`).
 
 <!-- item-sep -->
 
-- **Modal enter/exit hook** — Today modals render via `@if` + `[open]="true"`,
-  so the node is torn out instantly on close and **leave animations are
-  impossible**. `.modal-backdrop`/`.modal-content` (`_components.scss:492-518`)
-  carry no animation at all. Add a single enter/leave hook to
-  `ModalComponent` (delay the `@if` teardown until a leave transition
-  completes, or move to a keyframed open/close state). Build once → all ~25
-  modals inherit entry/exit for free. **Prerequisite for the modal items
-  below.** Files: `components/modal/modal.component.*`, `scss/_components.scss`.
-
-<!-- item-sep -->
-
 - **Reusable flight / FLIP helper** — No measure-rect-then-tween utility exists
   (the browse-canvas zoom tween is bespoke and canvas-only). A small shared
   helper — capture `getBoundingClientRect()` before/after, tween the delta (or
-  fly a cloned ghost node between two rects) — unlocks *vote-flies-to-list*,
-  *re-sort settle*, and *origin-aware modals* as a batch. Must respect the
-  reduced-motion gate and clean up its ghost nodes. Files: new util under
-  `frontend/src/app/utils/`, consumed by center-panel / left-panel / modal.
+  fly a cloned ghost node between two rects) — unlocks *vote-flies-to-list* and
+  *re-sort settle* as a batch. Must respect the reduced-motion gate and clean
+  up its ghost nodes. Files: new util under `frontend/src/app/utils/`, consumed
+  by center-panel / left-panel / modal.
 
 <!-- item-sep -->
-
-- **Shared easing tokens** — Durations are tokenized but easing is hand-written
-  per rule (`ease-in-out`, `linear`, ad-hoc `cubic-bezier(0.4,0,1,1)` for the
-  swipe). Add `--ease-out` / `--ease-in-out` / (optionally) `--ease-spring` to
-  `_variables.scss` so new motion stays visually consistent. Cheap, low-risk,
-  and every other item benefits. Files: `scss/_variables.scss`.
-
-## Popups "from" a button (the originating request)
-
-<!-- item-sep -->
-
-- **Origin-aware modal scale-in** — On open, capture the launching button's
-  rect, set the modal's `transform-origin` to that point, and scale/fade from
-  ~0.9→1 over `--transition-slow`; reverse toward the same origin on close.
-  Reads as "this panel came from *that* button" without a literal projectile
-  crossing the screen (the restrained reading of the request). Depends on the
-  **modal enter/exit hook** and benefits from the **flight helper** for the
-  origin rect. Files: `components/modal/`, launching buttons pass their rect.
-
-<!-- item-sep -->
-
-- **Backdrop fade paired with content scale** — Fade the backdrop 0→1 while the
-  content scales, so the two don't pop in lockstep. Universally applicable,
-  hard to find annoying; the low-risk baseline even if origin-awareness is
-  deferred. Depends on the **modal enter/exit hook**. Files: `_components.scss`.
 
 ## Media & voting flow (extends the swipe language)
 
@@ -183,13 +147,14 @@ policy in `CLAUDE.md`).
 
 ## Suggested sequencing
 
-1. **Infra first:** shared easing tokens (trivial) → modal enter/exit hook →
-   flight/FLIP helper. These unlock the highest-value items.
-2. **Best payoff-to-risk:** origin-aware modal scale-in, re-sort FLIP settle,
-   list insertion/removal transitions.
+1. **Infra first:** the flight/FLIP helper (the shared easing tokens and the
+   modal enter/exit hook have shipped). It unlocks the highest-value remaining
+   items.
+2. **Best payoff-to-risk:** re-sort FLIP settle, list insertion/removal
+   transitions.
 3. **Everything else** as independent issues, sized per item.
 
 Recommended implementer models when these are promoted to issues: **Sonnet 5**
-for the self-contained CSS items (easing tokens, tab underline, count-up, fades);
-**Opus 4.8** for the flight/FLIP helper and the modal enter/exit hook (shared
-infra, reactivity-sensitive, regression-prone across ~25 modals).
+for the self-contained CSS items (tab underline, count-up, fades); **Opus 4.8**
+for the flight/FLIP helper (shared infra, reactivity-sensitive, regression-prone
+across ~25 modals).

--- a/frontend/src/app/components/modal/modal.component.html
+++ b/frontend/src/app/components/modal/modal.component.html
@@ -1,14 +1,21 @@
-@if (open()) {
+@if (rendered()) {
 <!--
   cdkTrapFocus + auto-capture gives the dialog full keyboard/screen-reader focus
   management app-wide: on open it saves the triggering element and moves focus to
   the first tabbable control inside the dialog; Tab/Shift+Tab then cycle within
-  the dialog instead of escaping to the page behind it; and on close (the `@if`
-  destroys this subtree) focus is restored to the trigger.
+  the dialog instead of escaping to the page behind it; and on close (the leave
+  animation finishes and the `@if` destroys this subtree) focus is restored to
+  the trigger.
+
+  `rendered()` (not `open()`) gates the subtree so it stays mounted through the
+  close/leave animation; `(focusin)` feeds the origin-aware scale-in — see
+  ModalComponent.onFocusIn.
 -->
 <div
   class="modal-backdrop"
+  [class.is-leaving]="leaving()"
   (click)="onBackdropClick($event)"
+  (focusin)="onFocusIn($event)"
   role="dialog"
   aria-modal="true"
   [attr.aria-label]="title()"

--- a/frontend/src/app/components/modal/modal.component.spec.ts
+++ b/frontend/src/app/components/modal/modal.component.spec.ts
@@ -138,6 +138,145 @@ describe('ModalComponent', () => {
   });
 });
 
+describe('ModalComponent enter/leave lifecycle', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [...provideZoneless()],
+    }).compileComponents();
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    // A couple of tests force the app-level reduced-motion class on <html>;
+    // never leak it into sibling specs.
+    document.documentElement.classList.remove('animations-off');
+  });
+
+  it('keeps the subtree mounted and marks it leaving when closed (leave animation runs)', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelector('.modal-backdrop')).toBeTruthy();
+
+    // Close: the node must NOT be torn out synchronously — it stays mounted
+    // with `.is-leaving` so the leave keyframes can play. settleZoneless only
+    // flushes one macrotask, not the 300ms teardown timer, so this asserts the
+    // mid-leave state deterministically.
+    host.isOpen.set(false);
+    await settleZoneless(fixture);
+    const backdrop = fixture.nativeElement.querySelector('.modal-backdrop');
+    expect(backdrop).toBeTruthy();
+    expect(backdrop.classList.contains('is-leaving')).toBe(true);
+  });
+
+  it('tears the subtree down immediately on close under reduced motion', async () => {
+    document.documentElement.classList.add('animations-off');
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelector('.modal-backdrop')).toBeTruthy();
+
+    host.isOpen.set(false);
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelector('.modal-backdrop')).toBeNull();
+  });
+
+  it('re-opening before teardown cancels the leave and drops the leaving flag', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
+    host.isOpen.set(false);
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelector('.modal-backdrop').classList.contains('is-leaving')).toBe(true);
+
+    // Re-open while the leave timer is still pending: the node stays, but is
+    // no longer leaving, and (crucially) the pending teardown is cancelled so
+    // the modal doesn't vanish mid-use.
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
+    const backdrop = fixture.nativeElement.querySelector('.modal-backdrop');
+    expect(backdrop).toBeTruthy();
+    expect(backdrop.classList.contains('is-leaving')).toBe(false);
+  });
+});
+
+describe('ModalComponent origin-aware scale-in', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let trigger: HTMLButtonElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [...provideZoneless()],
+    }).compileComponents();
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+
+    // A stand-in "launching button" outside the modal. jsdom has no layout
+    // engine, so getBoundingClientRect returns zeros; stub a real rect.
+    trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.getBoundingClientRect = () =>
+      ({ left: 100, top: 200, width: 40, height: 20, right: 140, bottom: 220, x: 100, y: 200, toJSON: () => ({}) }) as DOMRect;
+  });
+
+  afterEach(() => {
+    trigger.remove();
+  });
+
+  function stubContentRect(): HTMLElement {
+    const content = fixture.nativeElement.querySelector('.modal-content') as HTMLElement;
+    content.getBoundingClientRect = () =>
+      ({ left: 60, top: 60, width: 400, height: 300, right: 460, bottom: 360, x: 60, y: 60, toJSON: () => ({}) }) as DOMRect;
+    return content;
+  }
+
+  it('points transform-origin at the launching button (focusin relatedTarget)', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
+    const backdrop = fixture.nativeElement.querySelector('.modal-backdrop') as HTMLElement;
+    const content = stubContentRect();
+
+    backdrop.dispatchEvent(new FocusEvent('focusin', { relatedTarget: trigger, bubbles: true }));
+
+    // button center (120, 210) minus content top-left (60, 60) = (60px, 150px)
+    expect(content.style.transformOrigin).toBe('60px 150px');
+  });
+
+  it('captures the origin only once — later focusin events do not re-point it', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
+    const backdrop = fixture.nativeElement.querySelector('.modal-backdrop') as HTMLElement;
+    const content = stubContentRect();
+
+    backdrop.dispatchEvent(new FocusEvent('focusin', { relatedTarget: trigger, bubbles: true }));
+    expect(content.style.transformOrigin).toBe('60px 150px');
+
+    // A second trigger elsewhere must be ignored (tabbing within the modal, etc.).
+    const other = document.createElement('button');
+    document.body.appendChild(other);
+    other.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 10, height: 10, right: 10, bottom: 10, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+    backdrop.dispatchEvent(new FocusEvent('focusin', { relatedTarget: other, bubbles: true }));
+    expect(content.style.transformOrigin).toBe('60px 150px');
+    other.remove();
+  });
+
+  it('leaves transform-origin at default when focus comes from within the modal', async () => {
+    host.isOpen.set(true);
+    await settleZoneless(fixture);
+    const backdrop = fixture.nativeElement.querySelector('.modal-backdrop') as HTMLElement;
+    const content = stubContentRect();
+
+    // relatedTarget inside the backdrop → no meaningful origin → center scale.
+    backdrop.dispatchEvent(new FocusEvent('focusin', { relatedTarget: content, bubbles: true }));
+    expect(content.style.transformOrigin).toBe('');
+  });
+});
+
 describe('ModalComponent focus management', () => {
   // We assert the CdkTrapFocus wiring rather than live focus movement: the
   // directive's auto-capture (initial focus in, Tab trap, restore-to-trigger on

--- a/frontend/src/app/components/modal/modal.component.ts
+++ b/frontend/src/app/components/modal/modal.component.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component, HostListener, OnDestroy, effect, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, OnDestroy, effect, input, output, signal, untracked } from '@angular/core';
 import { CdkTrapFocus } from '@angular/cdk/a11y';
+import { prefersReducedMotion } from '../../utils/reduced-motion';
 
 /**
  * Stack of currently-open modal instances, in the order they opened.
@@ -11,6 +12,14 @@ import { CdkTrapFocus } from '@angular/cdk/a11y';
  * state. Only the most-recently-opened modal reacts to Escape.
  */
 const openModalStack: ModalComponent[] = [];
+
+/**
+ * How long the leave animation runs before the modal subtree is torn down,
+ * in milliseconds. Kept in lockstep with `--transition-slow` (0.3s) in
+ * `_variables.scss`, which the `.modal-backdrop`/`.modal-content` open/close
+ * keyframes use. If that token changes, change this to match.
+ */
+const LEAVE_ANIMATION_MS = 300;
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -26,24 +35,125 @@ export class ModalComponent implements OnDestroy {
   readonly showCloseButton = input(true);
   readonly closed = output<void>();
 
+  /**
+   * Whether the modal subtree is in the DOM. Tracks `open()` on entry but
+   * *lags* it on exit: when `open()` flips false we keep the node mounted and
+   * play the leave animation, tearing it down only after `LEAVE_ANIMATION_MS`.
+   * Without this lag the `@if` would rip the node out instantly and no leave
+   * animation could ever run (see the modal enter/exit hook in
+   * `docs/plans/ui-motion-vocabulary.md`).
+   */
+  readonly rendered = signal(false);
+
+  /** True while the leave animation is playing; drives the `.is-leaving` class. */
+  readonly leaving = signal(false);
+
+  /** Pending teardown timer id for the leave animation, cleared on re-open. */
+  private leaveTimer: ReturnType<typeof setTimeout> | undefined;
+
+  /**
+   * Guards origin capture to the first `focusin` after each open, so tabbing
+   * within the modal doesn't re-point `transform-origin` at an inner control.
+   */
+  private originCaptured = false;
+
   constructor() {
     // Track this instance's place in the open-modal stack. Runs on every
     // open() change; instances created already-open (the common `@if` +
     // `[open]="true"` pattern) register at creation time, which matches
-    // their visual stacking order.
+    // their visual stacking order. Stack membership follows the *logical*
+    // open state, not `rendered`: a modal mid-leave is already closing, so
+    // it should no longer capture Escape.
     effect(() => {
-      const idx = openModalStack.indexOf(this);
-      if (this.open()) {
-        if (idx === -1) openModalStack.push(this);
-      } else if (idx !== -1) {
-        openModalStack.splice(idx, 1);
-      }
+      const isOpen = this.open();
+      untracked(() => {
+        const idx = openModalStack.indexOf(this);
+        if (isOpen) {
+          if (idx === -1) openModalStack.push(this);
+        } else if (idx !== -1) {
+          openModalStack.splice(idx, 1);
+        }
+      });
+    });
+
+    // Drive the enter/leave render lifecycle off `open()`.
+    effect(() => {
+      const isOpen = this.open();
+      untracked(() => {
+        if (isOpen) {
+          this.enter();
+        } else if (this.rendered()) {
+          this.leave();
+        }
+      });
     });
   }
 
   ngOnDestroy(): void {
     const idx = openModalStack.indexOf(this);
     if (idx !== -1) openModalStack.splice(idx, 1);
+    if (this.leaveTimer !== undefined) clearTimeout(this.leaveTimer);
+  }
+
+  /** Mount (or re-mount) the subtree and let the enter animation play. */
+  private enter(): void {
+    if (this.leaveTimer !== undefined) {
+      clearTimeout(this.leaveTimer);
+      this.leaveTimer = undefined;
+    }
+    this.originCaptured = false;
+    this.leaving.set(false);
+    this.rendered.set(true);
+  }
+
+  /** Play the leave animation, then tear the subtree down. */
+  private leave(): void {
+    this.leaving.set(true);
+    // Under reduced motion the animation is suppressed to ~instant, so tear
+    // down synchronously rather than lingering an invisible, static node.
+    if (prefersReducedMotion()) {
+      this.rendered.set(false);
+      this.leaving.set(false);
+      return;
+    }
+    this.leaveTimer = setTimeout(() => {
+      this.leaveTimer = undefined;
+      this.rendered.set(false);
+      this.leaving.set(false);
+    }, LEAVE_ANIMATION_MS);
+  }
+
+  /**
+   * Origin-aware scale-in: point the content's `transform-origin` at the
+   * control that launched the modal, so it scales *from* that button.
+   *
+   * `cdkTrapFocus`'s auto-capture pulls focus into the dialog on open, and the
+   * resulting `focusin` carries `relatedTarget` = the element that just lost
+   * focus, i.e. the launching button. Reading it here needs no wiring at any of
+   * the ~25 call sites, and fires before the first paint so the origin is set
+   * before the scale animation renders. When there's no usable origin (focus
+   * came from within, or from nothing measurable) we leave `transform-origin`
+   * at its default center, which is the plain backdrop-fade + center-scale
+   * baseline.
+   */
+  onFocusIn(event: FocusEvent): void {
+    if (this.originCaptured) return;
+    this.originCaptured = true;
+
+    const related = event.relatedTarget as HTMLElement | null;
+    const backdrop = event.currentTarget as HTMLElement | null;
+    if (!related || !backdrop || backdrop.contains(related)) return;
+
+    const content = backdrop.querySelector<HTMLElement>('.modal-content');
+    if (!content) return;
+
+    const from = related.getBoundingClientRect();
+    if (!from.width || !from.height) return; // detached / zero-size trigger
+
+    const box = content.getBoundingClientRect();
+    const originX = from.left + from.width / 2 - box.left;
+    const originY = from.top + from.height / 2 - box.top;
+    content.style.transformOrigin = `${originX}px ${originY}px`;
   }
 
   onBackdropClick(event: MouseEvent): void {

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -489,6 +489,36 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 
 // --- Modal overlay ---
 
+// Modal entry/exit motion. Two paired keyframes: the backdrop fades while the
+// content scales, so the overlay and the panel don't pop in lockstep. The
+// content scales from `transform-origin`, which ModalComponent.onFocusIn points
+// at the launching button (falling back to center) — reading the scale as "this
+// panel came from that button". Enter uses `backwards` fill (not `forwards`) so
+// the content reverts to `transform: none` once settled, leaving no lingering
+// transform that would turn `.modal-content` into a containing block for any
+// `position: fixed` descendant. `--transition-slow` here is mirrored by
+// LEAVE_ANIMATION_MS in modal.component.ts; the app/OS reduce-motion rules in
+// styles.scss collapse both to ~instant.
+@keyframes modal-backdrop-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes modal-backdrop-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes modal-content-in {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes modal-content-out {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.9); }
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;
@@ -498,6 +528,11 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   justify-content: center;
   padding-top: 8vh;
   z-index: var(--z-modal-backdrop);
+  animation: modal-backdrop-in var(--transition-slow) var(--ease-out) backwards;
+
+  &.is-leaving {
+    animation: modal-backdrop-out var(--transition-slow) var(--ease-out) forwards;
+  }
 }
 
 .modal-content {
@@ -515,6 +550,11 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  animation: modal-content-in var(--transition-slow) var(--ease-out) backwards;
+
+  .modal-backdrop.is-leaving & {
+    animation: modal-content-out var(--transition-slow) var(--ease-out) forwards;
+  }
 }
 
 .modal-header {

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -58,6 +58,14 @@
   --transition-base: 0.15s;
   --transition-slow: 0.3s;
 
+  // Shared easing curves, so new motion stays visually consistent instead of
+  // hand-writing a cubic-bezier per rule.
+  //   --ease-out    → things arriving/settling (modal scale-in, panel reveal):
+  //                   fast start, gentle deceleration into place.
+  //   --ease-in-out → symmetric moves where both ends should feel eased.
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+
   // Elevation / shadow scale (resolves through --shadow-dropdown so each
   // theme tints shadows appropriately: dark/light/highviz)
   --shadow-sm: 0 1px 2px var(--shadow-dropdown);


### PR DESCRIPTION
Implements the two modal-motion items from `docs/plans/ui-motion-vocabulary.md` ("Popups from a button"), plus the shared infra they depend on.

## What changed

**Modal enter/exit hook (enabler).** `ModalComponent` now renders its subtree on a `rendered` signal that tracks `open()` on entry but *lags* it on exit: when `open()` flips false the node stays mounted for the leave animation, torn down after `LEAVE_ANIMATION_MS` (300ms, mirroring `--transition-slow`). Under reduced motion the teardown is synchronous, matching the old instant-close behavior. Before this, the `@if` ripped the node out on close and leave animations were impossible.

**Backdrop fade paired with content scale.** The backdrop fades `0→1` while `.modal-content` scales `0.9→1` over `--transition-slow`, so the overlay and panel don't pop in lockstep. This is the always-on baseline for every one of the ~25 modals.

**Origin-aware modal scale-in.** The content's `transform-origin` is pointed at the control that launched the modal, so it scales *from* that button (and reverses toward it on close). The origin is captured from the focus trap's `focusin` `relatedTarget` — which is exactly the launching button when `cdkTrapFocus` pulls focus in — so **no wiring is needed at any of the ~25 call sites**. When there's no usable origin (focus came from within, or a zero-size trigger) it falls back to a center scale, i.e. the plain backdrop-fade baseline.

**Shared easing tokens.** Added `--ease-out` / `--ease-in-out` to `_variables.scss`, used by the modal keyframes.

## Notes

- Enter uses `animation-fill-mode: backwards` (not `forwards`) so the content reverts to `transform: none` once settled — no lingering transform that would turn `.modal-content` into a containing block for `position: fixed` descendants.
- All motion routes through the existing `showAnimations()` / `prefersReducedMotion()` gates: the `suppress-motion()` mixin collapses the CSS keyframes to ~instant, and the JS teardown delay is skipped, so the app/OS "reduce motion" story is unchanged.
- No screenshot reshoots needed: animations don't alter the settled frame these docs capture.
- Plan file pruned to remove the now-shipped items (enter/exit hook, easing tokens, both modal-motion items), leaving item-sep sentinels intact.

## Testing

- `./run-tests.sh` — ALL 6426 tests pass (added 6 modal specs covering leave-lag, reduced-motion teardown, re-open cancellation, and origin capture from `focusin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpFN3SCPCkdEA7qgdfpHiH)_