### PR TITLE
Fix bin popup empty-state hint text: map -> canvas

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -257,7 +257,7 @@
           </div>
           </cdk-virtual-scroll-viewport>
         } @else if (docked()) {
-          <p class="bin-popup-empty-hint">Right-click a bin on the map to show its items here.</p>
+          <p class="bin-popup-empty-hint">Right-click a bin on the canvas to show it here.</p>
         }
       </div>
     }


### PR DESCRIPTION
## Summary
- Corrects the bin popup empty-state hint text in `browse-bin-popup.component.html`: "Right-click a bin on the map to show its items here." → "Right-click a bin on the canvas to show it here."

## Test plan
- Text-only change; no functional/behavioral change to verify.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZHH1673i8J25TvR5UFaZn)_