### PR TITLE
Drawer slide-in/out for the side panels

### DIFF
--- a/docs/plans/ui-motion-vocabulary.md
+++ b/docs/plans/ui-motion-vocabulary.md
@@ -102,11 +102,6 @@ policy in `CLAUDE.md`).
 
 <!-- item-sep -->
 
-- **Drawer slide for side panels** — Left/right/browse-selection panels toggle
-  via `@if`; a slide-in/out over `--transition-slow` matches the physicality of
-  the drag-resizable docked browse panel. Files: `left-panel/`, `right-panel/`,
-  `browse-selection-panel/`.
-
 <!-- item-sep -->
 
 - **Tab-underline slide** — Slide the active-tab indicator between tabs instead

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -1,4 +1,4 @@
-<div class="bsp" vtNoFocusSteal>
+<div class="bsp" vtNoFocusSteal animate.enter="drawer-enter-right" animate.leave="drawer-leave-right">
   <div class="bsp-header">
     <h3 class="bsp-title" [title]="'Items you have selected on the canvas (' + count() + ')'">
       Selection ({{ count() | number }})

--- a/frontend/src/app/components/left-panel/left-panel.component.html
+++ b/frontend/src/app/components/left-panel/left-panel.component.html
@@ -1,4 +1,4 @@
-<div class="left-panel" [class.collapsed-autopilot]="panelMode() === 'label' && activeTab() === 'autopilot' && autopilotCollapsed()" [class.disabled]="disabled()">
+<div class="left-panel" animate.enter="drawer-enter-left" animate.leave="drawer-leave-left" [class.collapsed-autopilot]="panelMode() === 'label' && activeTab() === 'autopilot' && autopilotCollapsed()" [class.disabled]="disabled()">
   @if (datasetName() && !(panelMode() === 'label' && activeTab() === 'autopilot' && autopilotCollapsed())) {
     <div class="dataset-name" [title]="datasetName()">{{ datasetName() }}</div>
   }

--- a/frontend/src/app/components/right-panel/right-panel.component.html
+++ b/frontend/src/app/components/right-panel/right-panel.component.html
@@ -1,4 +1,4 @@
-<aside class="panel-right" aria-label="Labels">
+<aside class="panel-right" aria-label="Labels" animate.enter="drawer-enter-right" animate.leave="drawer-leave-right">
   <vt-detector-context-bar
     [visible]="!!trainMode()"
     [detectorName]="trainMode()?.model?.name ?? ''"

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -604,6 +604,59 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   gap: var(--space-md);
 }
 
+// --- Drawer slide (side panels) ---
+//
+// The Find/Label left & right panels and the Browse selection panel mount and
+// unmount with their host view (route entry, the browse `@switch` reaching
+// `ready`). Rather than hard-cutting in/out, each panel root opts into these
+// classes via Angular's `animate.enter` / `animate.leave` bindings, so the
+// panel slides from its docked edge — the same physical read as the
+// drag-resizable docked browse-details pane. Angular applies the enter class on
+// insertion (removing it when the animation ends) and holds the leaving node
+// until the leave animation finishes before tearing it down.
+//
+// The keyframes end at the panel's natural resting state (`translateX(0)`), so
+// the enter classes need no forwards fill; `backwards` only pre-applies the
+// off-screen start so there's no first-frame flash. The leave classes use
+// `forwards` to pin the off-screen end state while the node is held. The
+// app/OS reduce-motion rules in `styles.scss` collapse the durations to
+// ~instant, so a leaving node still tears down promptly when motion is off.
+@keyframes drawer-in-left {
+  from { transform: translateX(-100%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes drawer-out-left {
+  from { transform: translateX(0); opacity: 1; }
+  to { transform: translateX(-100%); opacity: 0; }
+}
+
+@keyframes drawer-in-right {
+  from { transform: translateX(100%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes drawer-out-right {
+  from { transform: translateX(0); opacity: 1; }
+  to { transform: translateX(100%); opacity: 0; }
+}
+
+.drawer-enter-left {
+  animation: drawer-in-left var(--transition-slow) var(--ease-out) backwards;
+}
+
+.drawer-leave-left {
+  animation: drawer-out-left var(--transition-slow) var(--ease-in-out) forwards;
+}
+
+.drawer-enter-right {
+  animation: drawer-in-right var(--transition-slow) var(--ease-out) backwards;
+}
+
+.drawer-leave-right {
+  animation: drawer-out-right var(--transition-slow) var(--ease-in-out) forwards;
+}
+
 // --- Picker cards ---
 //
 // One shared selectable option card (icon + title + description) for every


### PR DESCRIPTION
## What

The Find/Label **left** & **right** panels and the Browse **selection** panel now slide from their docked edge when they mount/unmount, instead of hard-cutting in and out. This matches the physical read of the drag-resizable docked browse-details pane — a panel that arrives/leaves feels like it *slides* into place.

## How

- Added four shared drawer keyframes + helper classes (`drawer-{enter,leave}-{left,right}`) to `frontend/src/scss/_components.scss`, alongside the existing modal enter/exit motion. They translate the panel from its off-screen edge (with an opacity fade) over `--transition-slow` using the shared `--ease-out` / `--ease-in-out` tokens.
- Wired each panel root to the classes via Angular's `animate.enter` / `animate.leave` bindings (Angular 21's CSS enter/leave mechanism): the enter class is applied on insertion and dropped when the animation ends; the leaving node is held until its animation finishes before teardown.
  - `left-panel/` root → slides from the left edge.
  - `right-panel/` root → slides from the right edge.
  - `browse-selection-panel/` root → slides from the right edge (it's docked on the right of the browse view).

## Gating

No new motion gate was needed: the `suppress-motion` blanket rule in `styles.scss` (OS reduce-motion **and** the app "Show Animations = Hide" toggle) already zeroes `animation-duration` for every element, so the enter class settles instantly and a leaving node still tears down promptly when motion is off. The keyframes end at the panel's natural resting state, so no `forwards` fill lingers after enter.

## Testing

- `./run-tests.sh frontend` — ruff/pyright/deptry/pip-audit/build all clean; Angular `build:prod` compiles the new `animate.enter`/`animate.leave` bindings; 1728 Vitest unit tests pass.
- No runtime/visual verification: the cloud container has no Chromium, so the slide couldn't be observed in a live browser this session.

No screenshot reshoots are queued for this change — it's transient motion only and doesn't alter any panel's settled appearance.

Prunes the now-shipped **Drawer slide for side panels** item from `docs/plans/ui-motion-vocabulary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F69M3we6p3NsiXiMzcuJZj

---
_Generated by [Claude Code](https://claude.ai/code/session_01F69M3we6p3NsiXiMzcuJZj)_