### PR TITLE
VTSBrowse: unify selection-panel thumbnails with bin-details, drop names

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -251,7 +251,6 @@
                 } @else {
                   <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
                 }
-                <span class="bin-popup-name">{{ name(id) }}</span>
               </div>
             }
           </div>

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -348,7 +348,7 @@
   column-gap: var(--space-2xs);
 }
 
-// A grid cell: a thumbnail above its truncated name.
+// A grid cell: a single thumbnail (the name that used to sit beneath it is gone).
 .bin-popup-entry {
   box-sizing: border-box;
   cursor: pointer;
@@ -356,13 +356,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
   padding: 2px;
   border-radius: var(--radius-sm);
   width: var(--popup-cell, 80px);
-  // Query container so the name can hide itself at small icon sizes (below).
-  container-type: inline-size;
-  container-name: bin-cell;
   // Animate the "viewed" enlarge (below) so items grow/settle smoothly rather
   // than popping as focus walks the grid.
   transition: transform var(--transition-base);
@@ -459,36 +455,6 @@
   justify-content: center;
   color: var(--text-muted);
   font-size: var(--font-lg);
-}
-
-// The name stacks under the thumbnail, truncated to the cell width. Its
-// line-height is pinned (not left at the font's ``normal``, which varies by
-// platform font) so the rendered row height is deterministic and matches the
-// space reserved for it in ``rowSize`` (GRID_LABEL_HEIGHT). Without this the name
-// renders a couple px taller than its slot, forcing a stray scrollbar even on a
-// single row. 12px (``--font-xs``) × 1.25 = 15px == GRID_LABEL_HEIGHT.
-.bin-popup-name {
-  flex: 0 0 auto;
-  width: 100%;
-  max-width: var(--popup-cell, 80px);
-  min-width: 0;
-  text-align: center;
-  font-weight: var(--weight-regular);
-  font-size: var(--font-xs);
-  line-height: 1.25;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-// At the two smallest icon sizes (XS/S, ~46px content-box) the name truncates to
-// a useless "a…", so hide it and let the grid pack tighter. M and up keep it.
-// The reserved row height (GRID_LABEL_HEIGHT in the .ts) is dropped in lockstep
-// so hidden names don't leave an empty gap under each thumbnail.
-@container bin-cell (max-width: 60px) {
-  .bin-popup-name {
-    display: none;
-  }
 }
 
 // --- Docked presentation ----------------------------------------------------

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -17,26 +17,10 @@ import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.co
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
 import type { MediaBatchResponse } from '../../generated/api-client/models/media-batch-response';
 
-/** Height (px) of the name's line box under a grid thumbnail. Mirrors the pinned
- *  ``line-height`` on ``.bin-popup-name`` (``--font-xs`` = 12px × 1.25 = 15px);
- *  kept in sync so {@link rowSize} reserves exactly the space the name renders in.
- *  The name's line-height is pinned (rather than left at the font's ``normal``,
- *  which varies ~1.15–1.35 by platform font) precisely so this stays exact — an
- *  unpinned name renders a couple px taller than its slot, which is enough to
- *  force a stray scrollbar on even a single row. */
-const GRID_LABEL_HEIGHT = 15;
-/** Gap (px) between the thumbnail and its name inside a cell (``.bin-popup-entry``
- *  flex ``gap``); present only when the name shows. */
-const GRID_THUMB_NAME_GAP = 2;
 /** Vertical padding (px) inside every grid cell (``.bin-popup-entry`` 2px top +
  *  2px bottom), always present regardless of icon size. Reserved in {@link
  *  rowSize} so the cell's real rendered height never exceeds its virtual slot. */
 const GRID_CELL_PADDING = 4;
-/** Goal width (px) at/above which grid thumbnails still show their name. Below
- *  this (the XS/S icon sizes) the name truncates to a useless "a…", so the SCSS
- *  hides it (``@container … (max-width: 60px)``) and {@link rowSize} drops the
- *  reserved label height to match, keeping the grid gap-free. */
-const GRID_NAME_MIN_WIDTH = 65;
 /** Gap (px) between grid cells (and grid rows); matches ``--space-2xs``-ish. */
 const GRID_GAP = 4;
 /** Width (px) available to lay out cells inside the popup's scroll column (≈ its
@@ -746,18 +730,14 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     this.rows = rows;
   }
 
-  /** Pixel stride of one virtual grid row: the cell's real rendered height (the
-   *  thumbnail, its always-present vertical padding, and — when shown — the
-   *  thumb→name gap and name line box) plus an inter-row gap. Accounting for the
-   *  cell padding and pinned name line box keeps the row's rendered content from
-   *  overflowing its virtual slot by a sub-pixel, which would otherwise force a
-   *  stray scrollbar on even a single row. At the smallest icon sizes the name is
-   *  hidden (see {@link GRID_NAME_MIN_WIDTH}), so its gap + label height are
-   *  dropped to keep rows flush. */
+  /** Pixel stride of one virtual grid row: the thumbnail plus its always-present
+   *  vertical cell padding and an inter-row gap. The grid no longer prints a name
+   *  under each thumbnail, so only the thumbnail and padding contribute; accounting
+   *  for the cell padding keeps the row's rendered content from overflowing its
+   *  virtual slot by a sub-pixel, which would otherwise force a stray scrollbar on
+   *  even a single row. */
   get rowSize(): number {
-    const nameShown = this.gridGoalWidth >= GRID_NAME_MIN_WIDTH;
-    const nameHeight = nameShown ? GRID_THUMB_NAME_GAP + GRID_LABEL_HEIGHT : 0;
-    return this.gridGoalWidth + GRID_CELL_PADDING + nameHeight + GRID_GAP;
+    return this.gridGoalWidth + GRID_CELL_PADDING + GRID_GAP;
   }
 
   /** Height (px) the grid takes: just enough for its rows, capped (to the room

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.html
@@ -101,10 +101,6 @@
         } @else if (placeholderIcon(entry.id)) {
           <span class="bsp-placeholder">{{ placeholderIcon(entry.id) }}</span>
         }
-        <span class="bsp-name-row">
-          <span class="bsp-name-grid">{{ entry.name }}</span>
-          <vt-copy-detail-button class="bsp-copy" [value]="entry.name" label="name" />
-        </span>
       </div>
     }
   </div>

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -168,20 +168,28 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: var(--space-xs);
-  gap: var(--space-2xs);
+  // Tight cell padding (2px) matching the bin-details grid, so the thumbnails
+  // pack close together rather than floating in the roomier padding this list
+  // used when it still carried a name row.
+  padding: var(--space-2xs);
   border-radius: var(--radius-sm);
-  font-size: var(--font-sm);
   cursor: pointer;
   color: var(--text-vote);
-  line-height: 1.3;
-  // Query container so the name can hide itself at small icon sizes (below).
-  container-type: inline-size;
-  container-name: bsp-cell;
+  // Animate the hover-enlarge (below) so thumbnails grow/settle smoothly rather
+  // than popping as the cursor sweeps the grid.
+  transition: transform var(--transition-base);
 
+  // Hover cue is a SIZE/depth change (enlarge + lift), mirroring the bin-details
+  // grid's viewed-item treatment, rather than a flat background/outline: done
+  // with ``transform`` (painted, not laid out) so the scale never reflows the
+  // grid, and ``z-index`` lifts the growing thumb above its neighbours.
   &:hover {
+    position: relative;
+    z-index: 1;
     color: var(--text-primary);
     background: var(--bg-hover);
+    transform: scale(1.08);
+    filter: drop-shadow(0 3px 6px var(--shadow-dropdown));
   }
 
   &:focus-visible {
@@ -243,50 +251,3 @@
   flex-shrink: 0;
 }
 
-// Row holding the (truncated) name and its copy-to-clipboard affordance. The
-// row itself stays full-width so the name centers; the copy button sits flush
-// beside it and only appears on hover/focus so a dense grid isn't peppered with
-// icons.
-.bsp-name-row {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-2xs);
-  width: 100%;
-  min-width: 0;
-  flex-shrink: 0;
-}
-
-.bsp-name-grid {
-  font-size: var(--font-2xs);
-  color: var(--text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-  text-align: center;
-  line-height: 1.2;
-}
-
-// The on-screen name is frequently truncated (and hidden entirely at small
-// sizes), so a copy button gives the full name a reliable retrieval path. Keep
-// it out of the way until the entry is hovered or focused.
-.bsp-copy {
-  opacity: 0;
-  transition: opacity var(--transition-base);
-}
-
-.bsp-entry:hover .bsp-copy,
-.bsp-entry:focus-within .bsp-copy {
-  opacity: 1;
-}
-
-// At the two smallest icon sizes (XS/S, ~42px content-box) the name truncates to
-// a useless "a…", so hide the whole name row — copy button included, since a
-// row that exists only to hold the copy button just wastes vertical space in a
-// dense grid. M and up keep the name (and its copy button).
-@container bsp-cell (max-width: 60px) {
-  .bsp-name-row {
-    display: none;
-  }
-}

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -10,7 +10,6 @@ import { MediaTypeCapabilityService } from '../../services/media-type-capability
 import { ViewControlsComponent } from '../view-controls/view-controls.component';
 import { NoFocusStealDirective } from '../../directives/no-focus-steal.directive';
 import { IconComponent } from '../icon/icon.component';
-import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
 import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
@@ -49,7 +48,7 @@ interface SelectionEntry {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-selection-panel',
   standalone: true,
-  imports: [CommonModule, FormsModule, ViewControlsComponent, NoFocusStealDirective, IconComponent, CopyDetailButtonComponent],
+  imports: [CommonModule, FormsModule, ViewControlsComponent, NoFocusStealDirective, IconComponent],
   templateUrl: './browse-selection-panel.component.html',
   styleUrl: './browse-selection-panel.component.scss',
 })

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
@@ -93,13 +93,14 @@ describe('BrowseSelectionPanelComponent (zoneless canary)', () => {
     expect(fixture.nativeElement.querySelectorAll('.bsp-entry').length).toBe(3);
   });
 
-  it('repaints item names when the metadata cache version$ emits, no manual detectChanges', async () => {
+  it('repaints the entry name tooltip when the metadata cache version$ emits, no manual detectChanges', async () => {
     selection.addAll([7]);
     await settleZoneless(fixture);
 
-    // Before the name resolves, the entry falls back to the id placeholder.
-    let nameEl = fixture.nativeElement.querySelector('.bsp-name-grid, .bsp-name');
-    expect(nameEl!.textContent).toContain('Clip #7');
+    // The list shows only thumbnails (no visible name text), so the name lives
+    // in the entry's tooltip. Before it resolves, it falls back to the id.
+    let entry = fixture.nativeElement.querySelector('.bsp-entry') as HTMLElement;
+    expect(entry.getAttribute('title')).toContain('Clip #7');
 
     // Production channel: the metadata cache hydrates and pushes version$,
     // whose subscribe rebuilds `sortedEntries` (a signal) — must repaint.
@@ -107,27 +108,26 @@ describe('BrowseSelectionPanelComponent (zoneless canary)', () => {
     metaVersion.next(1);
     await settleZoneless(fixture);
 
-    nameEl = fixture.nativeElement.querySelector('.bsp-name-grid, .bsp-name');
-    expect(nameEl!.textContent).toContain('kestrel.wav');
+    entry = fixture.nativeElement.querySelector('.bsp-entry') as HTMLElement;
+    expect(entry.getAttribute('title')).toContain('kestrel.wav');
   });
 
-  it('exposes the full name via the entry tooltip and a per-entry copy button', async () => {
+  it('exposes the full name via the entry tooltip and no longer renders a visible name or copy button', async () => {
     selection.addAll([7]);
     names.set(7, 'a-very-long-filename-that-gets-truncated.wav');
     metaVersion.next(1);
     await settleZoneless(fixture);
 
-    // The entry title carries the full name (not the old hardcoded string), so
-    // hovering surfaces it even when the on-screen text is truncated/hidden.
+    // The entry title carries the full name so hovering surfaces it even though
+    // the list no longer prints names beneath the thumbnails.
     const entry = fixture.nativeElement.querySelector('.bsp-entry') as HTMLElement;
     expect(entry.getAttribute('title')).toBe(
       'a-very-long-filename-that-gets-truncated.wav — click to remove from selection',
     );
 
-    // A copy-detail button sits beside each entry, wired to copy the full name.
-    const copyBtn = entry.querySelector('.bsp-copy .copy-detail-btn') as HTMLButtonElement;
-    expect(copyBtn).not.toBeNull();
-    expect(copyBtn.getAttribute('title')).toBe('Copy name to clipboard');
+    // The visible name row and its Copy-name button are gone entirely.
+    expect(entry.querySelector('.bsp-name-row')).toBeNull();
+    expect(entry.querySelector('.bsp-copy')).toBeNull();
   });
 
   // --- Hover-to-play audio (issue #2455) -------------------------------------


### PR DESCRIPTION
## What & why

In VTSBrowse the two thumbnail lists looked inconsistent: the **left** (bin‑details) panel packed thumbnails tightly and enlarged the one under the cursor, while the **right** (selection) panel used roomier cells with a flat background/outline hover and printed a name + Copy‑name button under every thumbnail. This makes the right panel match the (nicer) left one, and removes the per‑thumbnail names from **both**.

## Changes

**Right panel — `browse-selection-panel`**
- Tightened cell padding (`--space-xs` → `--space-2xs`, 4px → 2px) so thumbnails pack close together like the bin‑details grid.
- Replaced the flat background/outline hover with a size‑based **enlarge + lift** cue (`transform: scale(1.08)` + drop‑shadow + `z-index`), mirroring the bin‑details grid's viewed‑item treatment. Painted (not laid out), so it never reflows the grid.
- Removed the visible name row and its per‑item **Copy‑name** button (and the now‑unused `CopyDetailButtonComponent` import and dead name/container SCSS).

**Left panel — `browse-bin-popup`**
- Removed the name that sat beneath each grid thumbnail (floating and docked).
- Updated `rowSize` to stop reserving name height, and dropped the now‑unused `GRID_LABEL_HEIGHT` / `GRID_THUMB_NAME_GAP` / `GRID_NAME_MIN_WIDTH` constants and the `.bin-popup-name` + `@container bin-cell` SCSS.

The full filename still surfaces via each entry's **tooltip**, and the bin‑details **metadata column** still shows the Name field — only the per‑thumbnail name captions and Copy‑name buttons are gone.

## Notes
- The bin‑details metadata column keeps its Copy buttons (Name / Media Type / MD5), so `CopyDetailButtonComponent` stays imported there.
- Updated the selection‑panel zoneless spec: the metadata‑`version$` repaint canary now asserts on the entry tooltip (names are no longer printed), and the name/copy test now asserts the visible name row and copy button are absent.
- No doc screenshots frame the populated browse thumbnail lists (the `browse-view` shot leaves the selection empty and never docks bin‑details), so no reshoot‑queue entry is needed.

## Testing
- `./run-tests.sh frontend` — build OK, `npm audit` clean, Vitest **1728 passed**. Lint/format/codespell/deptry/pip‑audit/pyright/OpenAPI checks all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoTaZebpapjRYV61WCNVGd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoTaZebpapjRYV61WCNVGd)_