### PR TITLE
Render full plugin fields in New Detector › Import Labels (Trained tab)

### DIFF
--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -243,6 +243,27 @@
                       [placeholder]="field.placeholder || field.description || field.label || field.key"
                       [title]="field.description || field.label || field.key"
                     />
+                  } @else if (field.field_type === 'select' && field.allow_free_text) {
+                    <input
+                      [id]="'nmm-' + field.key"
+                      type="text"
+                      class="form-input"
+                      [attr.list]="'nmm-' + field.key + '-list'"
+                      [(ngModel)]="labelImporterValues[field.key]"
+                      [name]="'nmm-' + field.key"
+                      [disabled]="!!labelImporterDynamicLoading()[field.key]"
+                      [placeholder]="labelImporterDynamicLoading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+                      [title]="field.description || field.label || field.key"
+                      (ngModelChange)="onLabelImporterFieldChanged(field.key)"
+                    />
+                    <datalist [id]="'nmm-' + field.key + '-list'">
+                      @for (opt of labelImporterOptionsFor(field); track opt.value) {
+                        <option [value]="opt.value">{{ opt.label }}</option>
+                      }
+                    </datalist>
+                    @if (field.dynamic_options && labelImporterDynamicError()[field.key]) {
+                      <p class="error-text">{{ labelImporterDynamicError()[field.key] }}</p>
+                    }
                   } @else if (field.field_type === 'select') {
                     <select
                       [id]="'nmm-' + field.key"
@@ -250,11 +271,21 @@
                       [(ngModel)]="labelImporterValues[field.key]"
                       [name]="'nmm-' + field.key"
                       [title]="field.description || field.label || field.key"
+                      (ngModelChange)="onLabelImporterFieldChanged(field.key)"
+                      [disabled]="!!labelImporterDynamicLoading()[field.key] || (!!field.dynamic_options && labelImporterOptionsFor(field).length === 0)"
                     >
-                      @for (opt of field.options || []; track opt) {
-                        <option [value]="opt">{{ opt }}</option>
+                      @if (field.dynamic_options && labelImporterDynamicLoading()[field.key]) {
+                        <option value="">Loading…</option>
+                      } @else if (field.dynamic_options && labelImporterOptionsFor(field).length === 0 && !labelImporterDynamicError()[field.key]) {
+                        <option value="">No options available</option>
+                      }
+                      @for (opt of labelImporterOptionsFor(field); track opt.value) {
+                        <option [value]="opt.value">{{ opt.label }}</option>
                       }
                     </select>
+                    @if (field.dynamic_options && labelImporterDynamicError()[field.key]) {
+                      <p class="error-text">{{ labelImporterDynamicError()[field.key] }}</p>
+                    }
                   } @else if (field.field_type === 'number') {
                     <input
                       [id]="'nmm-' + field.key"

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -336,6 +336,81 @@ describe('NewDetectorModalComponent', () => {
 
     expect(component.selectedImporter).toBeNull();
   });
+
+  // --- Trained tab: label-importer plugin field parity (issue #2597) ---
+
+  it('fetches dynamic options when a Trained-tab importer is selected', () => {
+    const field = { key: 'sheet', field_type: 'select', dynamic_options: true, required: true } as any;
+    component.selectLabelImporter({ name: 'gsheets', fields: [field] } as any);
+
+    const req = httpMock.expectOne('/api/label-importers/field-options/gsheets');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.field_key).toBe('sheet');
+    req.flush({ options: [{ value: 's1', label: 'Sheet 1' }] });
+
+    expect(component.labelImporterOptionsFor(field)).toEqual([{ value: 's1', label: 'Sheet 1' }]);
+    // A required dynamic select auto-selects the first option.
+    expect(component.labelImporterValues['sheet']).toBe('s1');
+  });
+
+  it('coerces static string options into {value,label} pairs on the Trained tab', () => {
+    const staticSelect = { key: 's', field_type: 'select', options: ['x', 'y'] } as any;
+    expect(component.labelImporterOptionsFor(staticSelect)).toEqual([
+      { value: 'x', label: 'x' },
+      { value: 'y', label: 'y' },
+    ]);
+  });
+
+  it('re-fetches a dependent field when its dependency changes', () => {
+    const parent = { key: 'doc', field_type: 'select', dynamic_options: true } as any;
+    const child = { key: 'tab', field_type: 'select', dynamic_options: true, depends_on: ['doc'] } as any;
+    component.selectLabelImporter({ name: 'gsheets', fields: [parent, child] } as any);
+
+    // Both dynamic fields fetch on select.
+    httpMock.match('/api/label-importers/field-options/gsheets').forEach((r) => r.flush({ options: [] }));
+
+    component.labelImporterValues['doc'] = 'doc-1';
+    component.onLabelImporterFieldChanged('doc');
+
+    // Only the dependent child re-fetches; its stale value is blanked first.
+    expect(component.labelImporterValues['tab']).toBe('');
+    const req = httpMock.expectOne('/api/label-importers/field-options/gsheets');
+    expect(req.request.body.field_key).toBe('tab');
+    req.flush({ options: [{ value: 't1', label: 'Tab 1' }] });
+  });
+
+  it('keeps a typed free-text value the refreshed options omit on the Trained tab', () => {
+    const field = { key: 'q', field_type: 'select', dynamic_options: true, allow_free_text: true } as any;
+    component.selectedLabelImporter = { name: 'imp', fields: [field] } as any;
+    component.labelImporterValues['q'] = 'hand-typed';
+    (component as any).refreshLabelImporterFieldOptions(field);
+    httpMock
+      .expectOne('/api/label-importers/field-options/imp')
+      .flush({ options: [{ value: 'a', label: 'A' }] });
+    expect(component.labelImporterValues['q']).toBe('hand-typed');
+  });
+
+  it('clears a strict-select value the refreshed options omit on the Trained tab', () => {
+    const field = { key: 'q', field_type: 'select', dynamic_options: true } as any;
+    component.selectedLabelImporter = { name: 'imp', fields: [field] } as any;
+    component.labelImporterValues['q'] = 'stale';
+    (component as any).refreshLabelImporterFieldOptions(field);
+    httpMock
+      .expectOne('/api/label-importers/field-options/imp')
+      .flush({ options: [{ value: 'a', label: 'A' }] });
+    expect(component.labelImporterValues['q']).toBe('');
+  });
+
+  it('surfaces a dynamic-option fetch error on the Trained tab', () => {
+    const field = { key: 'q', field_type: 'select', dynamic_options: true } as any;
+    component.selectedLabelImporter = { name: 'imp', fields: [field] } as any;
+    (component as any).refreshLabelImporterFieldOptions(field);
+    httpMock
+      .expectOne('/api/label-importers/field-options/imp')
+      .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+    expect(component.labelImporterDynamicError()['q']).toBe('boom');
+    expect(component.labelImporterOptionsFor(field)).toEqual([]);
+  });
 });
 
 describe('NewDetectorModalComponent with defaultMediaType', () => {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../services/embedder-capability.service';
 import { MediaStateService } from '../../../services/media-state.service';
 import {
+  FieldOption,
   ImporterField,
   ImporterInfo,
   ImporterPickerTab,
@@ -217,6 +218,14 @@ export class NewDetectorModalComponent implements OnInit {
   labelImporterValues: Record<string, string> = {};
   labelImporterFile: File | null = null;
   labelImporterFileFieldKey: string | null = null;
+  // Dynamic-field-option state for the Trained tab's label-importer form,
+  // mirroring label-importer-modal so plugins with dynamic_options /
+  // depends_on / allow_free_text render with full parity here too. Keyed by
+  // field key; signalized so the unpatched HTTP callbacks schedule CD under
+  // zoneless. See docs/plans/zoneless-migration.md.
+  readonly labelImporterDynamicOptions = signal<Record<string, FieldOption[]>>({});
+  readonly labelImporterDynamicLoading = signal<Record<string, boolean>>({});
+  readonly labelImporterDynamicError = signal<Record<string, string>>({});
 
   /** Type_id of the active solo-mediaType streamlining, or ``null`` when
    *  off. When non-null, the mediaType form-group is hidden in the
@@ -946,6 +955,9 @@ export class NewDetectorModalComponent implements OnInit {
     this.labelImporterFile = null;
     this.labelImporterFileFieldKey = null;
     this.error.set('');
+    this.labelImporterDynamicOptions.set({});
+    this.labelImporterDynamicLoading.set({});
+    this.labelImporterDynamicError.set({});
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -958,13 +970,80 @@ export class NewDetectorModalComponent implements OnInit {
         this.labelImporterValues[field.key] = field.options![0];
       }
     }
+    for (const field of fields) {
+      if (field.dynamic_options) {
+        this.refreshLabelImporterFieldOptions(field);
+      }
+    }
     this.trainedView = 'form';
+  }
+
+  /** Re-fetch dynamic options for any field that depends on the one the user
+   *  just changed, blanking each dependent value first so a stale selection
+   *  can't survive into the new option set. */
+  onLabelImporterFieldChanged(changedKey: string): void {
+    const importer = this.selectedLabelImporter;
+    if (!importer?.fields) return;
+    for (const field of importer.fields as ImporterField[]) {
+      if (!field.dynamic_options) continue;
+      if (!(field.depends_on || []).includes(changedKey)) continue;
+      this.labelImporterValues[field.key] = '';
+      this.refreshLabelImporterFieldOptions(field);
+    }
+  }
+
+  /** Options to render for a label-importer field: the dynamically-fetched
+   *  list for a ``dynamic_options`` field, else the static strings coerced
+   *  into ``{value,label}`` pairs. */
+  labelImporterOptionsFor(field: ImporterField): FieldOption[] {
+    if (field.dynamic_options) {
+      return this.labelImporterDynamicOptions()[field.key] || [];
+    }
+    return (field.options || []).map((o) => ({ value: o, label: o }));
+  }
+
+  private refreshLabelImporterFieldOptions(field: ImporterField): void {
+    const importer = this.selectedLabelImporter;
+    if (!importer) return;
+    const key = field.key;
+    this.labelImporterDynamicLoading.update((m) => ({ ...m, [key]: true }));
+    this.labelImporterDynamicError.update((m) => ({ ...m, [key]: '' }));
+    this.labelImportersApi
+      .getFieldOptions(importer.name, key, { ...this.labelImporterValues })
+      .subscribe({
+        next: (res) => {
+          const options: FieldOption[] = res.options || [];
+          this.labelImporterDynamicOptions.update((m) => ({ ...m, [key]: options }));
+          this.labelImporterDynamicLoading.update((m) => ({ ...m, [key]: false }));
+          const current = this.labelImporterValues[key];
+          const inList = options.some((o) => o.value === String(current));
+          // Strict selects clear a value the new list no longer offers; a
+          // free-text combobox keeps whatever the user typed.
+          if (current && !inList && !field.allow_free_text) {
+            this.labelImporterValues[key] = '';
+          }
+          if (!this.labelImporterValues[key] && field.required && options.length > 0) {
+            this.labelImporterValues[key] = options[0].value;
+          }
+        },
+        error: (err) => {
+          this.labelImporterDynamicLoading.update((m) => ({ ...m, [key]: false }));
+          this.labelImporterDynamicError.update((m) => ({
+            ...m,
+            [key]: apiErrorMessage(err, 'Could not load options'),
+          }));
+          this.labelImporterDynamicOptions.update((m) => ({ ...m, [key]: [] }));
+        },
+      });
   }
 
   backToImporterPicker(): void {
     this.trainedView = 'picker';
     this.selectedLabelImporter = null;
     this.error.set('');
+    this.labelImporterDynamicOptions.set({});
+    this.labelImporterDynamicLoading.set({});
+    this.labelImporterDynamicError.set({});
   }
 
   onLabelImporterFileSelected(event: Event, fieldName: string): void {


### PR DESCRIPTION
## Problem

Issue #2597: The **New Detector → Import Labels** flow (`new-detector-modal`'s "Trained" tab) only rendered pre-loaded label-importer options and did not support the full plugin field functionality. Importing labels as a secondary step (`label-importer-modal`) evaluates `field_type`, `dynamic_options`, `depends_on`, and `allow_free_text` — so a plugin that computes its options at runtime (e.g. a Google Sheets importer whose tab list depends on the picked document) rendered an empty/static dropdown in the New Detector flow while working correctly in the standalone Import Labels modal.

## Fix

Bring the Trained tab's label-importer form to full parity with `label-importer-modal`:

- **`dynamic_options`** — fetch options via `POST /api/label-importers/field-options/<importer>` on importer select, populate the dropdown, and auto-select the first option for required fields.
- **`depends_on`** — when a field the user changed is a dependency of a dynamic field, blank the dependent value and re-fetch its options.
- **`allow_free_text`** — render a `<datalist>`-backed combobox that keeps a typed value the refreshed option list omits (strict selects clear it).
- **Loading / error states** — show "Loading…" / "No options available" placeholders and surface fetch errors inline, all keyed per-field via signals so the unpatched HTTP callbacks schedule change detection under zoneless.

The dynamic-option state and helpers (`labelImporterDynamicOptions`, `onLabelImporterFieldChanged`, `labelImporterOptionsFor`, `refreshLabelImporterFieldOptions`) mirror the standalone modal's implementation so the two flows behave identically.

## Tests

Added Trained-tab specs to `new-detector-modal.component.spec.ts` covering dynamic-option fetch + auto-select, static-option coercion, `depends_on` re-fetch with stale-value blanking, free-text retention, strict-select clearing, and error surfacing. Full frontend gate green (`./run-tests.sh frontend`: build OK, 1728 unit tests passed).

Closes #2597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dg6LseC2YEaYKyxZmhds2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg6LseC2YEaYKyxZmhds2c)_