### PR TITLE
Shared demo-dataset cache for multi-user servers

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -234,6 +234,39 @@ UI. They are **not** downloaded at startup.
 | IMDB Movie Reviews | Text | Stanford | ~15 MB |
 | UCF-101 subset | Video | HuggingFace Datasets | ~171 MB |
 
+### Sharing demo downloads between data dirs (multi-user servers)
+
+Each data dir normally downloads its own copy of every demo dataset. On a
+shared server — or any machine with several VTSearch checkouts — the multi-GB
+demo sources only need to exist once: the downloaders skip a download whenever
+the dataset's extraction path already exists under the data dir, so a communal
+cache directory whose entries mirror that extraction layout can be symlinked
+into each data dir. [`scripts/link-demo-cache.sh`](../scripts/link-demo-cache.sh)
+does the wiring:
+
+```bash
+scripts/link-demo-cache.sh /shared/vtsearch-demos ./data            # link cached demos in
+scripts/link-demo-cache.sh /shared/vtsearch-demos ./data --harvest  # donate demos this
+                                                                    # data dir downloaded, then link
+```
+
+- The cache's entries are the extraction dirs the downloaders create under
+  `DATA_DIR` (`ESC-50-master/`, `visual_genome/`, `UrbanSound8K/`, …); the
+  script knows the full list and links whichever entries are populated.
+- `--harvest` moves demos a data dir already downloaded into the cache and
+  replaces them with symlinks, so the cache grows as users pull new demos.
+  On multi-user hosts run with a cooperative umask (e.g. `umask 002`) so
+  harvested files stay group-writable.
+- A demo downloaded through an existing symlink writes into the cache
+  through the link — no harvest needed for those.
+- **Never hand-create an empty dataset dir in the cache.** The downloaders
+  treat an existing extraction path as "download complete", so an empty dir
+  makes that demo silently load zero items. (The script only links populated
+  entries for the same reason.)
+- Temp archives still spool onto `DATA_DIR`'s own volume during a fresh
+  download, so that volume needs headroom for the largest archive even when
+  the extraction dirs are symlinked elsewhere (#2605).
+
 ### User-triggered network operations
 
 These features require network access only when explicitly used:
@@ -284,6 +317,12 @@ local-only importers instead:
 - **Folder importer:** point at a directory of media files
 - **Pickle importer:** load a pre-built `.pkl` dataset file
 - **Combine-datasets importer:** merge multiple pickle files
+
+Demo datasets *can* still load offline if their sources were downloaded (or
+copied) beforehand — see
+[Sharing demo downloads between data dirs](#sharing-demo-downloads-between-data-dirs-multi-user-servers)
+for the shared-cache/symlink pattern that provides them without any network
+access.
 
 ### Docker offline deployment
 

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -7,7 +7,7 @@ This is the reference catalogue of every demo dataset VTSearch can download and 
   <img src="user/assets/importer-picker.light.png" alt="The Demo importer with the Synthetic Media generator and the Downloaded Media catalogue" width="720" />
 </picture>
 
-Datasets are grouped by media type below. Each demo comes in size variants — **S** / **M** / **L** (progressively larger samples) and **A** (all items in the underlying dataset). Sizes are downloaded once and cached, so reloads are instant.
+Datasets are grouped by media type below. Each demo comes in size variants — **S** / **M** / **L** (progressively larger samples) and **A** (all items in the underlying dataset). Sizes are downloaded once and cached, so reloads are instant. On multi-user servers the downloaded sources can be shared between data dirs — see [DEPLOYMENT.md](DEPLOYMENT.md#sharing-demo-downloads-between-data-dirs-multi-user-servers).
 
 ## Audio
 

--- a/scripts/link-demo-cache.sh
+++ b/scripts/link-demo-cache.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# link-demo-cache.sh — share downloaded demo datasets between VTSearch data dirs.
+#
+# On a multi-user server (or any machine with several VTSearch checkouts), the
+# multi-GB demo-dataset sources only need to exist once. The demo downloaders
+# skip a download whenever the dataset's extraction path already exists under
+# the data dir (vtscore/datasets/downloader/*.py), so a communal cache
+# directory whose entries mirror that extraction layout can be symlinked into
+# each user's data dir and every linked demo is treated as already downloaded.
+#
+# Usage:
+#   scripts/link-demo-cache.sh <cache-dir> <data-dir>            # link cached demos in
+#   scripts/link-demo-cache.sh <cache-dir> <data-dir> --harvest  # first move demos this
+#         data dir already downloaded INTO the cache, then link them back
+#
+# Rules:
+#   * Only POPULATED cache entries are ever linked. Never hand-create an empty
+#     dataset dir in the cache: the downloaders treat an existing extraction
+#     path as "download complete", so an empty dir makes that demo silently
+#     load zero items.
+#   * A demo downloaded through an existing symlink writes into the cache
+#     (intended). A demo whose dir didn't exist yet appears as a real dir in
+#     the data dir instead; run --harvest periodically to donate those.
+#   * Cache entries are made group-writable (best effort) so every user of a
+#     shared cache can harvest into it. Run with a cooperative umask (e.g.
+#     `umask 002`) on multi-user hosts.
+set -euo pipefail
+
+CACHE="${1:?usage: link-demo-cache.sh <cache-dir> <data-dir> [--harvest]}"
+DATADIR="${2:?usage: link-demo-cache.sh <cache-dir> <data-dir> [--harvest]}"
+MODE="${3:-}"
+CACHE="$(cd "$CACHE" && pwd)"
+DATADIR="$(cd "$DATADIR" && pwd)"
+
+# Every demo extraction directory the downloaders create under DATA_DIR, per
+# vtscore/datasets/downloader/*.py. Deliberately excludes the per-user dirs
+# (embeddings, saved_datasets, models, detectors, staging, settings) and the
+# derived images/ + video/ media dirs. Kept in sync with the source by
+# tests_lib/downloads/test_demo_cache_script.py.
+DEMO_DIRS=(
+  aclImdb bbc-fulltext caltech-101 caltech-256 cifar-10-batches-py clotho
+  dbpedia_csv enrico ESC-50-master EuroSAT_RGB food-101 gtzan hmdb51
+  openlogo oxford_flowers places365 reuters21578 rico_screen2words roxford5k
+  rvl_cdip speech_commands_v2 tut_sound_events_2017 UCF-101 UCF101_subset
+  ucsf_documents UrbanSound8K vggface2 visual_genome
+)
+
+for name in "${DEMO_DIRS[@]}"; do
+  src="$CACHE/$name"
+  dst="$DATADIR/$name"
+
+  if [[ "$MODE" == "--harvest" && -d "$dst" && ! -L "$dst" ]]; then
+    if [[ -e "$src" ]]; then
+      echo "SKIP harvest $name: already exists in cache (resolve by hand)"
+    else
+      echo "HARVEST $name -> cache"
+      mv "$dst" "$src"
+      chmod -R g+w "$src" 2>/dev/null || true
+    fi
+  fi
+
+  # Link only populated cache entries (see the empty-dir rule above).
+  if [[ -d "$src" ]] && [[ -n "$(ls -A "$src" 2>/dev/null)" ]]; then
+    if [[ -L "$dst" ]]; then
+      : # already linked, leave it
+    elif [[ -e "$dst" ]]; then
+      echo "SKIP link $name: real copy exists in data dir (remove it to use the cache)"
+    else
+      echo "LINK $name"
+      ln -s "$src" "$dst"
+    fi
+  fi
+done
+echo "done."

--- a/scripts/slurm/README.md
+++ b/scripts/slurm/README.md
@@ -37,3 +37,15 @@ On your local machine (after adding a `cluster` host to `~/.ssh/config`):
 cp scripts/slurm/vtsearch-tunnel.sh ~/.local/bin/vtsearch-tunnel && chmod +x ~/.local/bin/vtsearch-tunnel
 vtsearch-tunnel   # forwards your local port to the GPU node; prints the URL to browse
 ```
+
+## Sharing demo datasets on a cluster
+
+Clusters usually have a communal large-dataset area on a big shared volume.
+Rather than every user downloading the multi-GB demo datasets into their own
+data dir (often on a small per-user quota), keep one shared cache there and
+symlink it into each data dir with
+[`scripts/link-demo-cache.sh`](../link-demo-cache.sh) — see
+[`docs/DEPLOYMENT.md`](../../docs/DEPLOYMENT.md#sharing-demo-downloads-between-data-dirs-multi-user-servers).
+Demo sources may also already exist elsewhere on the cluster (other groups'
+dataset folders); anything matching the extraction layout can be copied
+straight into the cache.

--- a/tests_lib/downloads/test_demo_cache_script.py
+++ b/tests_lib/downloads/test_demo_cache_script.py
@@ -1,0 +1,54 @@
+"""Keep scripts/link-demo-cache.sh's DEMO_DIRS list in sync with the downloaders.
+
+The shared demo-cache script hardcodes the set of extraction directories the
+demo downloaders create directly under ``DATA_DIR``. That set lives as string
+literals scattered across ``vtscore/datasets/downloader/*.py`` (there is no
+runtime registry of extraction dir names), so this test re-derives it from the
+source and fails when a new demo's extraction dir is missing from the script
+(or a stale one lingers).
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "link-demo-cache.sh"
+DOWNLOADER_SOURCES = [
+    *sorted((REPO_ROOT / "vtscore" / "datasets" / "downloader").glob("*.py")),
+    REPO_ROOT / "vtscore" / "datasets" / "importers" / "demo" / "__init__.py",
+]
+
+# DATA_DIR children that are not shareable demo extraction dirs: the derived
+# per-media-type dirs (loaders copy/organize into these; they can contain
+# absolute paths specific to one data dir) and single downloaded files (their
+# names carry an extension), which ride along inside their dataset's dir or
+# stay per-user.
+NON_CACHE_NAMES = {"images", "video"}
+
+
+def _expected_demo_dirs() -> set[str]:
+    literals: set[str] = set()
+    for source in DOWNLOADER_SOURCES:
+        literals.update(re.findall(r'DATA_DIR / "([^"]+)"', source.read_text()))
+    return {name for name in literals if name not in NON_CACHE_NAMES and "." not in name}
+
+
+def _script_demo_dirs() -> set[str]:
+    text = SCRIPT.read_text()
+    match = re.search(r"DEMO_DIRS=\(\n(.*?)\n\)", text, re.DOTALL)
+    assert match, "DEMO_DIRS array not found in scripts/link-demo-cache.sh"
+    return set(match.group(1).split())
+
+
+def test_script_list_matches_downloader_sources():
+    expected = _expected_demo_dirs()
+    in_script = _script_demo_dirs()
+    assert expected, "no DATA_DIR extraction literals found - did the downloaders move?"
+    missing = expected - in_script
+    stale = in_script - expected
+    assert not missing, f"add to scripts/link-demo-cache.sh DEMO_DIRS: {sorted(missing)}"
+    assert not stale, f"remove from scripts/link-demo-cache.sh DEMO_DIRS: {sorted(stale)}"
+
+
+def test_script_is_executable():
+    assert SCRIPT.stat().st_mode & 0o111, "scripts/link-demo-cache.sh must be executable"


### PR DESCRIPTION
## Summary

Generalizes the grid setup from #2557 into server-agnostic repo pieces:

- **`scripts/link-demo-cache.sh`** — wires a VTSearch data dir up to a communal demo-source cache: symlinks populated cache entries in (a symlinked extraction dir makes the downloaders treat that demo as already downloaded), and `--harvest` donates demos a data dir already downloaded back into the cache. Only populated entries are ever linked — an empty cache dir would make a demo silently load zero items.
- **`tests_lib/downloads/test_demo_cache_script.py`** — re-derives the extraction-dir list from the `DATA_DIR / "…"` literals in `vtscore/datasets/downloader/*.py` and fails if the script's list drifts (plus an executable-bit check).
- **Docs** — new "Sharing demo downloads between data dirs" section in `DEPLOYMENT.md` (with the empty-dir warning and the temp-spool caveat, #2605), a pointer from the offline-deployment section (a pre-seeded cache is also an offline story), a pointer in `demos.md`, and a cluster-flavored note in `scripts/slurm/README.md`.

Refs #2557 (the setup this generalizes; that issue stays a personal-setup item). The temp-archive spool location follow-up is #2605.

## Testing

- `pytest tests_lib/downloads tests/downloads` — 223 passed (includes the 2 new tests).
- `ruff check` / `ruff format --check` / `codespell` clean on the touched files.
- Exercised the script end-to-end against a scratch cache/data pair: links populated entries, skips empty ones, harvests real dirs and re-links them.
- Not run here: full `./run-tests.sh` (frontend build chain isn't available on this laptop; change touches no product Python/TS code paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)