### PR TITLE
Docked VTSBrowse bin-details: item fills the row, draggable metadata divider

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -209,6 +209,9 @@
             },
             "type": "object"
           },
+          "browse_details_metadata_width": {
+            "type": "integer"
+          },
           "browse_details_panel_width": {
             "type": "integer"
           },
@@ -4738,6 +4741,9 @@
           "bin_details_docked": {},
           "browse_colormap": {},
           "browse_compact": {},
+          "browse_details_metadata_width": {
+            "type": "integer"
+          },
           "browse_details_panel_width": {
             "type": "integer"
           },

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -24,7 +24,7 @@
         <vt-icon type="dock-left" [size]="14" />
       </button>
     }
-    @if (hasPane) {
+    @if (hasPane && !docked()) {
       <div class="bin-popup-size-group" role="group" aria-label="Detail image size">
         <button
           type="button"
@@ -88,7 +88,7 @@
       @if (showMetadataColumn) {
         <div
           class="bin-popup-meta-col"
-          [style.width.px]="docked() ? null : metadataColWidth"
+          [style.width.px]="docked() ? dockedMetadataWidth : metadataColWidth"
           [style.maxHeight.px]="docked() ? dockedPaneSize : null">
           <div class="bin-popup-meta-grid">
             <div class="bin-popup-meta-item">
@@ -169,6 +169,20 @@
               (error)="onPreviewError()" />
           }
         </div>
+      }
+      @if (docked() && showMetadataColumn) {
+        <!-- Draggable divider between the large item (left) and the metadata
+             column (right). Dragging it re-apportions the top row: the metadata
+             column takes its dragged width and the item fills the rest. -->
+        <div
+          class="pane-divider bin-popup-meta-divider"
+          [class.dragging]="draggingMeta"
+          [style.height.px]="dockedPaneSize"
+          (pointerdown)="onMetaDividerPointerDown($event)"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize metadata column"
+          title="Drag to resize the metadata column"></div>
       }
     </div>
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -490,24 +490,35 @@
     flex-direction: column;
   }
 
+  // A single row: the large item, then the draggable divider, then the metadata
+  // column. No wrap and no flex gap — the divider is the only spacer, and the
+  // item + metadata widths are bound so they always sum to the row. DOM order is
+  // metadata, preview, divider, so `order` lays them out item / divider / meta.
   .bin-popup-top {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
-    gap: var(--space-sm);
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    gap: 0;
     flex-shrink: 0;
   }
 
-  // Pane left, metadata to its right (DOM order is metadata-first for the
-  // floating layout, so flip with `order` rather than duplicating markup).
   .bin-popup-preview {
-    order: -1;
+    order: 1;
     height: auto;
   }
 
+  .bin-popup-meta-divider {
+    order: 2;
+    flex: 0 0 auto;
+    align-self: flex-start;
+  }
+
+  // Fixed-width column (the width is bound per render from the divider drag),
+  // stacked to the right of the divider.
   .bin-popup-meta-col {
-    flex: 1 1 140px;
-    min-width: 140px;
+    order: 3;
+    flex: 0 0 auto;
     width: auto;
     height: auto;
   }

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -98,9 +98,18 @@ const PREVIEW_SIZE_STEPS = [120, 160, 208, 272, 352, 448, 560, 640, 720] as cons
  *  side padding plus room for the scrollbar. Subtracted from the panel width
  *  to get the content width the docked grid chunks its columns against. */
 const DOCKED_GRID_CHROME = 2 * BODY_PADDING + 12;
-/** Smallest width (px) the docked metadata column is guaranteed beside the
- *  detail pane; a wider pane pushes the metadata to wrap below it instead. */
+/** Smallest width (px) the docked metadata column shrinks to (the divider drag
+ *  can't take it below this) — enough for an MD5 digest to wrap onto ~two rows,
+ *  matching the ``browse_details_metadata_width`` default. */
 const DOCKED_META_MIN = 140;
+/** Footprint (px) of the divider between the docked large item and its metadata
+ *  column, subtracted from the panel's content width when apportioning the two. */
+const META_DIVIDER_WIDTH = 8;
+/** Smallest the docked large item is squeezed to. The item takes whatever the
+ *  panel leaves after the metadata column, so narrowing the panel eats into the
+ *  item first; once it hits this floor the metadata column starts giving up
+ *  width instead. */
+const DOCKED_MAIN_MIN = 60;
 
 /**
  * The bin details: the media items in the bin the user right-clicked on the
@@ -113,15 +122,21 @@ const DOCKED_META_MIN = 140;
  * - **Floating** (``docked`` false, the default): a draggable popup window
  *   summoned at the right-click point and clamped to the visible canvas.
  * - **Docked** (``docked`` true): a persistent left panel beside the canvas.
- *   The detail pane sits top-left with the metadata column to its right, and
- *   the member grid fills the rest of the panel below them. The panel is
- *   always mounted while the option is on — before any bin is opened it shows
- *   an empty hint — and for audio its detail pane doubles as the now-playing
- *   display ({@link nowPlayingExt}), replacing the toolbar's small waveform
- *   widget. A singleton bin keeps the grid area allocated but empty. In this
- *   mode all floating machinery (summon positioning, clamping, dragging,
- *   outside-click/Escape dismissal, document-level keyboard shortcuts) is
- *   disabled; the canvas keeps its own shortcuts.
+ *   The top row holds the large item with the metadata column to its right,
+ *   separated by a draggable divider ({@link onMetaDividerPointerDown}); the
+ *   member grid fills the rest of the panel below them. The metadata column
+ *   takes its dragged width ({@link dockedMetadataWidth}, persisted under
+ *   ``browse_details_metadata_width``) and the item grows to fill whatever the
+ *   row leaves ({@link dockedPaneSize}), so the docked panel has no per-item
+ *   size buttons — the panel↔canvas divider sizes the item (and re-chunks the
+ *   grid columns) instead. The panel is always mounted while the option is on —
+ *   before any bin is opened it shows an empty hint — and for audio its detail
+ *   pane doubles as the now-playing display ({@link nowPlayingExt}), replacing
+ *   the toolbar's small waveform widget. A singleton bin keeps the grid area
+ *   allocated but empty. In this mode all floating machinery (summon
+ *   positioning, clamping, dragging, outside-click/Escape dismissal,
+ *   document-level keyboard shortcuts) is disabled; the canvas keeps its own
+ *   shortcuts.
  *
  * The members render as a virtualized thumbnail grid (always grid; there is no
  * list mode). Hovering a grid thumbnail paints that item's *full-resolution*
@@ -144,7 +159,9 @@ const DOCKED_META_MIN = 140;
  * height is the preview pane's height, growing/shrinking the detail canvas
  * resizes the whole window. That size is likewise remembered per media type,
  * under ``popup_preview_size`` (px); unset, the pane falls back to a size scaled
- * from the main-canvas thumbnail radius ({@link hoverThumbRadius}).
+ * from the main-canvas thumbnail radius ({@link hoverThumbRadius}). These
+ * buttons (and the ``popup_preview_size`` setting) are **floating-only**: the
+ * docked panel sizes its item from the panel width instead (see above).
  *
  * It shares the {@link BrowseSelectionService} instance provided by the browse
  * view, so toggling an item here is the same selection the canvas rings and the
@@ -426,6 +443,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
       this.gridSizeDict = (settings.grid_icon_size_popup as Record<string, string>) ?? {};
       this.previewSizeDict = (settings.popup_preview_size as Record<string, number>) ?? {};
       this.metadataShownDict = (settings.popup_metadata_shown as Record<string, boolean>) ?? {};
+      // Mirror the docked metadata-column width (global). Skip mid-drag so a
+      // settings round-trip can't reset the column while the user is dragging it.
+      if (!this.draggingMeta && typeof settings.browse_details_metadata_width === 'number') {
+        this.metadataWidthPx = settings.browse_details_metadata_width;
+      }
       this.applyViewPrefs();
       // A detail-canvas size change (the top-left buttons) resizes the preview
       // pane, hence the whole popup, so re-clamp it back fully on-screen. Showing
@@ -489,6 +511,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   ngOnDestroy(): void {
     for (const sub of this.subs) sub.unsubscribe();
     this.scrollSub?.unsubscribe();
+    // Drop any in-flight metadata-divider drag listeners (destroyed mid-drag).
+    document.removeEventListener('pointermove', this.boundMetaMove);
+    document.removeEventListener('pointerup', this.boundMetaUp);
     this.stopAudio();
   }
 
@@ -506,6 +531,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   /** Last applied column visibility, so the settings effect only re-clamps the
    *  popup when it actually toggled. */
   private lastMetadataShown: boolean | null = null;
+  /** Docked metadata-column width (px), mirrored from the global
+   *  ``browse_details_metadata_width`` setting and driven by the divider between
+   *  the metadata column and the large item. Read through {@link
+   *  dockedMetadataWidth}, which clamps it against the live panel width. */
+  private metadataWidthPx = 150;
 
   /** True for media types that carry real visual thumbnails (image / video):
    *  the ones that magnify on the main canvas and are worth a large preview. */
@@ -872,16 +902,84 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     return this.previewId;
   }
 
-  /** Side (px) of the square docked detail pane: the same per-media-type
-   *  remembered size ({@link previewOverride}) the floating pane uses, clamped
-   *  to the docked panel's width so growing the pane can't overflow it. */
-  get dockedPaneSize(): number {
-    const desired = this.previewOverride ?? this.previewDefault();
+  /** Content width (px) the docked top row apportions between the large item,
+   *  the metadata column, and the divider between them: the panel width less the
+   *  body's own horizontal padding. */
+  private dockedContentWidth(): number {
     const width = this.availableWidth();
-    const room = width > 0 ? width - 2 * BODY_PADDING : MAX_PREVIEW_PX;
-    return Math.round(
-      Math.max(MIN_PREVIEW_PX, Math.min(desired, Math.min(room, MAX_PREVIEW_PX))),
+    return width > 0 ? width - 2 * BODY_PADDING : MAX_PREVIEW_PX;
+  }
+
+  /** Width (px) of the docked metadata column: the user's dragged width
+   *  ({@link metadataWidthPx}), clamped to at least {@link DOCKED_META_MIN} and
+   *  to whatever still leaves the large item its {@link DOCKED_MAIN_MIN} floor.
+   *  Re-clamps live as the outer panel divider narrows the panel, so shrinking
+   *  the panel eats into the item first and only squeezes the metadata once the
+   *  item bottoms out. */
+  get dockedMetadataWidth(): number {
+    const content = this.dockedContentWidth();
+    const maxWidth = Math.max(DOCKED_META_MIN, content - META_DIVIDER_WIDTH - DOCKED_MAIN_MIN);
+    return Math.round(Math.max(DOCKED_META_MIN, Math.min(this.metadataWidthPx, maxWidth)));
+  }
+
+  /** Side (px) of the square docked detail pane. The large item takes whatever
+   *  the panel leaves after the metadata column and the divider, so it always
+   *  grows to fill the space — there is no per-item size control docked (the
+   *  panel divider sizes it). Bounded below by {@link DOCKED_MAIN_MIN} and above
+   *  by {@link MAX_PREVIEW_PX}. */
+  get dockedPaneSize(): number {
+    const content = this.dockedContentWidth();
+    const taken = this.showMetadataColumn ? this.dockedMetadataWidth + META_DIVIDER_WIDTH : 0;
+    return Math.round(Math.max(DOCKED_MAIN_MIN, Math.min(content - taken, MAX_PREVIEW_PX)));
+  }
+
+  // --- Docked metadata-column divider drag ----------------------------------
+  // A draggable divider between the large item (left) and the metadata column
+  // (right) re-apportions the top row: the metadata column takes its dragged
+  // width and the item fills the rest. Persisted globally under
+  // ``browse_details_metadata_width`` (metadata fields are media-agnostic).
+
+  /** True only mid-drag of the metadata/item divider (template drag cue). */
+  draggingMeta = false;
+  private metaDragStartX = 0;
+  private metaDragStartWidth = 0;
+  private readonly boundMetaMove = this.onMetaDividerMove.bind(this);
+  private readonly boundMetaUp = this.onMetaDividerUp.bind(this);
+
+  /** Begin dragging the metadata/item divider (docked only). */
+  onMetaDividerPointerDown(event: PointerEvent): void {
+    if (!this.docked() || event.button !== 0) return;
+    event.preventDefault();
+    this.draggingMeta = true;
+    this.metaDragStartX = event.clientX;
+    this.metaDragStartWidth = this.dockedMetadataWidth;
+    document.addEventListener('pointermove', this.boundMetaMove);
+    document.addEventListener('pointerup', this.boundMetaUp);
+  }
+
+  private onMetaDividerMove(event: PointerEvent): void {
+    if (!this.draggingMeta) return;
+    // The metadata column sits to the RIGHT of the item, so dragging the divider
+    // left (dx < 0) grows the metadata and shrinks the item, and vice versa.
+    const dx = event.clientX - this.metaDragStartX;
+    const content = this.dockedContentWidth();
+    const maxWidth = Math.max(DOCKED_META_MIN, content - META_DIVIDER_WIDTH - DOCKED_MAIN_MIN);
+    this.metadataWidthPx = Math.round(
+      Math.max(DOCKED_META_MIN, Math.min(this.metaDragStartWidth - dx, maxWidth)),
     );
+    this.cdr.markForCheck();
+  }
+
+  private onMetaDividerUp(): void {
+    if (!this.draggingMeta) return;
+    this.draggingMeta = false;
+    document.removeEventListener('pointermove', this.boundMetaMove);
+    document.removeEventListener('pointerup', this.boundMetaUp);
+    // Persist the settled (clamped) width; the settings round-trip returns the
+    // same value, so there's no visible jump on release.
+    this.settingsState
+      .update({ browse_details_metadata_width: Math.round(this.dockedMetadataWidth) })
+      .subscribe();
   }
 
   /** Rows the member grid renders. Docked, a singleton bin keeps the grid

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -502,6 +502,80 @@ describe('BrowseBinPopupComponent (docked presentation)', () => {
 
     fixture.destroy();
   });
+
+  it('drops the detail-size buttons when docked (the panel divider sizes the item)', async () => {
+    const fixture = makeDockedFixture([1, 2]);
+    await settlePasses(fixture);
+
+    const root = fixture.nativeElement as HTMLElement;
+    // No top-left smaller/bigger buttons docked — the item grows to fit the row.
+    expect(root.querySelector('.bin-popup-size-group')).toBeNull();
+
+    fixture.destroy();
+  });
+
+  it('fills the large item with whatever width the metadata column leaves', async () => {
+    const fixture = makeDockedFixture([1, 2, 3]);
+    await settlePasses(fixture);
+
+    const cmp = fixture.componentInstance;
+    const root = fixture.nativeElement as HTMLElement;
+    // A draggable divider sits between the item and the metadata column.
+    expect(root.querySelector('.bin-popup-meta-divider')).not.toBeNull();
+    // content = availableWidth(340) − 2·BODY_PADDING(6) = 328; the item takes the
+    // rest after the metadata column and the 8px divider.
+    expect(cmp.dockedPaneSize).toBe(328 - cmp.dockedMetadataWidth - 8);
+
+    fixture.destroy();
+  });
+
+  it('gives the whole row to the item (no divider) when the metadata column is hidden', async () => {
+    settings.set({ popup_metadata_shown: { image: false } });
+    const fixture = makeDockedFixture([1, 2, 3]);
+    await settlePasses(fixture);
+
+    const cmp = fixture.componentInstance;
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('.bin-popup-meta-divider')).toBeNull();
+    // The full content width (capped at MAX_PREVIEW_PX, which 328 is under).
+    expect(cmp.dockedPaneSize).toBe(328);
+
+    fixture.destroy();
+  });
+
+  it('re-apportions the row as the metadata divider drags, and persists the width', async () => {
+    const fixture = makeDockedFixture([1, 2, 3]);
+    await settlePasses(fixture);
+
+    const svc = TestBed.inject(SettingsStateService);
+    const updates: Record<string, unknown>[] = [];
+    (svc.update as unknown) = (u: Record<string, unknown>) => {
+      updates.push(u);
+      return of({});
+    };
+
+    const cmp = fixture.componentInstance as unknown as {
+      dockedMetadataWidth: number;
+      dockedPaneSize: number;
+      onMetaDividerPointerDown(e: PointerEvent): void;
+    };
+    const startMeta = cmp.dockedMetadataWidth;
+    const startPane = cmp.dockedPaneSize;
+
+    cmp.onMetaDividerPointerDown({ button: 0, clientX: 500, preventDefault() {} } as unknown as PointerEvent);
+    // The metadata column is on the right, so dragging the divider left grows it.
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 460 }));
+    await settlePasses(fixture);
+
+    expect(cmp.dockedMetadataWidth).toBe(startMeta + 40);
+    // The item gives up exactly what the metadata gained.
+    expect(cmp.dockedPaneSize).toBe(startPane - 40);
+
+    document.dispatchEvent(new MouseEvent('pointerup'));
+    expect(updates.some((u) => 'browse_details_metadata_width' in u)).toBe(true);
+
+    fixture.destroy();
+  });
 });
 
 describe('BrowseBinPopupComponent (scroll-prefetch re-wiring)', () => {

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -94,6 +94,11 @@ class AppSettingsSchema(Schema):
     # shown as a Settings-modal widget; the panel's draggable divider drives it.
     browse_details_panel_width = fields.Integer()
 
+    # VTSBrowse docked bin-details metadata-column width (CSS px). Persisted but
+    # not shown as a Settings-modal widget; the divider between the metadata
+    # column and the large item drives it.
+    browse_details_metadata_width = fields.Integer()
+
     # VTSBrowse per-media-type display prefs (density colormap, on-screen cell
     # size). ``{media_type_id: value}`` dicts driven by the browse-canvas
     # toolbar and the Settings → Browser tab. (Bin shape is not stored — it is
@@ -274,6 +279,7 @@ class SettingsUpdateSchema(Schema):
 
     browse_panel_width = fields.Integer()
     browse_details_panel_width = fields.Integer()
+    browse_details_metadata_width = fields.Integer()
 
     # Per-media-type dicts; the setters in ``settings.py`` validate each
     # value against its enum (BrowseColormap / BrowseIconSize), so these are

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -354,6 +354,17 @@ class UserSettings(BaseModel):
     # the divider drives it. Clamped to a sane on-screen range.
     browse_details_panel_width: Annotated[int, _clamp(220, 800)] = 340
 
+    # VTSBrowse docked bin-details metadata-column width (CSS px). When the
+    # docked bin-details panel shows its metadata column, a draggable divider
+    # separates that column from the large item beside it; this persists the
+    # width the user dragged the metadata column to. The large item takes
+    # whatever the panel leaves after the metadata column, so it always grows
+    # to fill the space (there is no per-item size control in the docked panel).
+    # Defaults to just enough for an MD5 digest to wrap onto two rows. Not
+    # surfaced as a Settings-modal widget - the divider drives it. Clamped to a
+    # sane on-screen range.
+    browse_details_metadata_width: Annotated[int, _clamp(120, 600)] = 150
+
     # VTSBrowse per-media-type display preferences. Each is a
     # ``{media_type_id: value}`` dict so a user can tune the projection
     # browser independently for, say, audio vs. image datasets. Empty


### PR DESCRIPTION
## Summary

Reworks the layout of the **docked** VTSBrowse bin-details left panel so the large item always grows to fill the available space, and drops its now-redundant smaller/bigger size buttons.

The docked panel's top row now holds the large item plus the (optional) metadata column, with the member grid filling the row below. A new **draggable divider** sits between the item and the metadata column:

- The metadata column takes its dragged width, defaulting to just wide enough for an MD5 digest to wrap onto ~two rows.
- The item grows to fill whatever the row leaves after the metadata column.

As a result, the **panel↔canvas divider is the only item-size control docked** — dragging it grows the item and re-chunks the left grid's columns together — so there is no per-item size button and no per-item size setting to record in the docked panel.

The **floating** bin-details window is unchanged: it keeps its top-left detail-size buttons and the `popup_preview_size` setting.

## Changes

- **`browse-bin-popup`**: header size buttons are now floating-only (`@if (hasPane && !docked())`); the docked top row lays out item / divider / metadata via `order`; `dockedPaneSize` is computed as `panelContent − metadataWidth − divider` (clamped) rather than from `popup_preview_size`; added the metadata-divider pointer-drag handlers and `dockedMetadataWidth` (clamped so shrinking the panel eats the item first, then the metadata). The divider reuses the shared `.pane-divider` primitive.
- **Settings**: new global `browse_details_metadata_width` (CSS px, clamped 120–600, default 150) persists the divider position — added to `settings_models.py`, the marshmallow schemas, and the regenerated `frontend/openapi.json`.
- **Tests**: added docked-presentation specs covering the missing size buttons, the item filling the row, the no-metadata full-width case, and the divider drag + persistence.

## Testing

- `./run-tests.sh core api` — all 1669 backend tests pass (ruff / format / codespell / deptry / pyright / OpenAPI snapshot / frontend build gates green).
- `npm run test:ci` — all 1732 frontend unit tests pass.

No doc screenshots frame the docked bin-details panel, so no reshoot is queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQo6k5HrmavVbpZXRkTZuv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQo6k5HrmavVbpZXRkTZuv)_