### PR TITLE
Fix audio clipper crash on undecodable WAV bytes

### DIFF
--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -275,6 +275,45 @@ class TestWaveFormatExtensible:
         assert result[0]["duration"] == pytest.approx(2.0, abs=0.01)
 
 
+class TestUndecodableAudio:
+    """Corrupt/unsupported audio must not abort the load (GTZAN jazz.00054.wav).
+
+    Neither stdlib ``wave`` nor the ``soundfile`` fallback can decode these
+    bytes; the clipper must degrade to returning the media unchanged instead of
+    letting ``soundfile.LibsndfileError`` ("Format not recognised") propagate.
+    """
+
+    # A blob that is neither a valid WAV (bad RIFF chunk sizes) nor any format
+    # libsndfile recognises, so both decode paths fail.
+    _GARBAGE = b"RIFF\x00\x00\x00\x00WAVEjunk" + b"\x00" * 32
+
+    def test_open_wav_raises_audio_decode_error(self):
+        from vtscore.media.audio.clipper import AudioDecodeError, _open_wav
+
+        with pytest.raises(AudioDecodeError):
+            _open_wav(self._GARBAGE)
+
+    def test_wav_duration_raises_audio_decode_error(self):
+        from vtscore.media.audio.clipper import AudioDecodeError, _wav_duration
+
+        with pytest.raises(AudioDecodeError):
+            _wav_duration(self._GARBAGE)
+
+    def test_tiling_clipper_returns_media_unchanged(self):
+        from vtscore.media.audio.clipper import SoundTilingClipper
+
+        media = {"id": 1, "media_type": "audio", "media_bytes": self._GARBAGE}
+        result = SoundTilingClipper(2.0).clip(media)
+        assert result == [media]
+
+    def test_clip_clipper_returns_media_unchanged(self):
+        from vtscore.media.audio.clipper import SoundClipClipper
+
+        media = {"id": 1, "media_type": "audio", "media_bytes": self._GARBAGE}
+        result = SoundClipClipper(1.0, 3.0).clip(media)
+        assert result == [media]
+
+
 # ---------------------------------------------------------------------------
 # SoundClipClipper
 # ---------------------------------------------------------------------------

--- a/vtscore/media/audio/clipper.py
+++ b/vtscore/media/audio/clipper.py
@@ -12,6 +12,15 @@ from typing import Any
 from vtscore.media.clipper import MediaClipper
 
 
+class AudioDecodeError(Exception):
+    """Raised when WAV bytes can't be decoded by stdlib ``wave`` or ``soundfile``.
+
+    Signals a corrupt or unsupported audio payload (e.g. GTZAN's truncated
+    ``jazz.00054.wav``, or a non-audio blob).  Clippers catch this and fall
+    back to returning the media unchanged rather than aborting the whole load.
+    """
+
+
 def _to_pcm_wav(wav_bytes: bytes) -> bytes:
     """Re-encode WAV bytes into plain PCM that stdlib ``wave`` can parse.
 
@@ -32,12 +41,18 @@ def _open_wav(wav_bytes: bytes) -> wave.Wave_read:
     """Open WAV bytes for reading, tolerating non-PCM formats.
 
     Falls back to re-encoding via :func:`_to_pcm_wav` when stdlib ``wave``
-    can't parse the container (e.g. ``WAVE_FORMAT_EXTENSIBLE``).
+    can't parse the container (e.g. ``WAVE_FORMAT_EXTENSIBLE``).  Raises
+    :class:`AudioDecodeError` when neither path can decode the bytes (corrupt
+    or unsupported payload) so callers can degrade gracefully.
     """
     try:
         return wave.open(io.BytesIO(wav_bytes), "rb")
     except (wave.Error, EOFError):
+        pass
+    try:
         return wave.open(io.BytesIO(_to_pcm_wav(wav_bytes)), "rb")
+    except Exception as exc:  # soundfile LibsndfileError, wave.Error, EOFError, ...
+        raise AudioDecodeError("could not decode audio bytes") from exc
 
 
 def _wav_duration(wav_bytes: bytes) -> float:
@@ -149,7 +164,10 @@ class SoundTilingClipper(MediaClipper):
         if wav_bytes is None:
             return [media]
 
-        total = _wav_duration(wav_bytes)
+        try:
+            total = _wav_duration(wav_bytes)
+        except AudioDecodeError:
+            return [media]
         seg = self._duration
 
         if total <= seg:
@@ -461,7 +479,10 @@ class SoundClipClipper(MediaClipper):
         if wav_bytes is None:
             return [media]
 
-        total = _wav_duration(wav_bytes)
+        try:
+            total = _wav_duration(wav_bytes)
+        except AudioDecodeError:
+            return [media]
         t0 = max(0.0, min(self._start, total))
         t1 = max(t0, min(self._end, total))
         if t1 <= t0:


### PR DESCRIPTION
## Problem

Loading a demo audio dataset (e.g. GTZAN) could abort the entire load with:

```
soundfile.LibsndfileError: Error opening <BytesIO>: Format not recognised
```

`_open_wav` in `vtscore/media/audio/clipper.py` caught only `wave.Error` / `EOFError` from the stdlib `wave` decoder, then fell back to `_to_pcm_wav` (soundfile). When **that** path also failed — a corrupt or unsupported payload such as GTZAN's notoriously truncated `jazz.00054.wav`, or any non-audio blob — soundfile's `LibsndfileError` escaped uncaught, propagated up through `SoundTilingClipper.clip` → `apply_chain_to_clips` → the load pipeline, and killed the whole dataset load.

`SoundTilingClipper` and `SoundClipClipper` called `_wav_duration` with no guard, unlike `SoundSilenceClipper` / `SoundSpeechActivityClipper`, which already degrade to returning the media unchanged on a decode failure.

## Fix

- Introduce `AudioDecodeError`, raised by `_open_wav` when **both** the stdlib and soundfile decode paths fail, normalizing the varied underlying exceptions into one catchable type.
- `SoundTilingClipper` and `SoundClipClipper` catch `AudioDecodeError` and fall back to returning the media unchanged — so one bad file becomes a single pass-through clip instead of aborting the run, matching the existing silence/speech clippers' resilience.

The `WAVE_FORMAT_EXTENSIBLE` fallback (UrbanSound8K) is unchanged and still works — only the both-paths-failed case newly degrades gracefully instead of crashing.

## Tests

Added `TestUndecodableAudio` covering `_open_wav`, `_wav_duration`, and both clippers on a blob that neither decoder can read. Full `detectors` group passes (1637 tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_0192BzTpfee2T8ANsKAsDnk9)_