### PR TITLE
Eval vote system: simulate the real user (Autopilot) flow

### DIFF
--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -228,6 +228,8 @@ plot_eval_results(results, output_dir="eval_seeds")
 
 The voting-iterations evaluation measures how classification quality improves as more votes are cast. This is useful for understanding how many labels a user needs to provide before the model converges.
 
+Votes are cast in the order the app's **Autopilot** would present them — the eval reproduces the real user flow rather than an academic active-learning heuristic. Autopilot seeds the first few positives from text sort when available (pass `seed_scores`, a per-media cosine-to-query ranking), else from a handful of random known-good examples, then gathers the initial negatives and cycles the standard Good / Bad / Hard / New phases. `autopilot` is the only vote-order strategy; every result row carries `strategy="autopilot"`.
+
 ```python
 #!/usr/bin/env python
 """Evaluate learned-sort cost over simulated voting iterations."""

--- a/scripts/run_mlp_ensemble_sweep.py
+++ b/scripts/run_mlp_ensemble_sweep.py
@@ -11,13 +11,11 @@ results (CSVs, plots, a README) under ``docs/experiments/mlp-ensemble/``:
    reported per-item uncertainty (``std_mean``) as labels accumulate.
 
 2. **Voting-strategy axis** (`vtscore.eval.voting_iterations`) - simulates
-   voting under acquisition ``strategy ∈ {random, balanced, ensemble_std}``
-   (the unified-registry successors of the old shuffle/balanced/ensemble_std
-   orders) and plots the inclusion-weighted cost against the number of votes
-   cast.  Answers "does choosing the next vote by ensemble disagreement
-   (active learning) reach a low cost in fewer votes than random or
-   class-balanced ordering?"  Per-step cost is always the single production
-   MLP; the strategy only *selects* the next vote.
+   voting under the ``autopilot`` strategy (the app's real user flow: seed from
+   text sort or random known-good examples, then Good / Bad / Hard / New) and
+   plots the inclusion-weighted cost against the number of votes cast.  Per-step
+   cost is always the single production MLP; the strategy only *selects* the
+   next vote.
 
 Usage::
 
@@ -49,10 +47,9 @@ DEFAULT_DATASETS = ("urbansound8k_s",)
 DEFAULT_LABEL_COUNTS = (5, 10, 20, 50)
 DEFAULT_SEEDS = (0, 1, 2)
 DEFAULT_ENSEMBLE_SIZES = (3, 5, 7, 10)
-# Acquisition strategies compared in the voting axis: the random baseline, the
-# class-balanced oracle order, and the deep-ensemble uncertainty sampler (the
-# unified-registry successors of the old shuffle/balanced/ensemble_std orders).
-DEFAULT_VOTING_STRATEGIES = ("random", "balanced", "ensemble_std")
+# The voting axis runs the app's real user flow; ``autopilot`` is the only
+# vote-order strategy.
+DEFAULT_VOTING_STRATEGIES = ("autopilot",)
 
 
 # ---------------------------------------------------------------------------
@@ -258,11 +255,10 @@ def write_report(
     lines.append(
         "Cost is the inclusion-weighted `fpr_weight·FPR + fnr_weight·FNR` "
         "on a held-out test split, measured with the single production MLP "
-        "at every step.  `random` votes in random order, `balanced` keeps "
-        "the running label set class-balanced (an oracle order), and "
-        "`ensemble_std` votes next on the item an N-member ensemble disagrees "
-        "about most (active learning).  A lower curve, or the same cost "
-        "reached at a smaller `t`, means the strategy is more label-efficient."
+        "at every step.  `autopilot` reproduces the app's real user flow: seed "
+        "from text sort (or random known-good examples), then the standard "
+        "Good / Bad / Hard / New phases.  A lower curve means the tool reaches "
+        "a good detector in fewer votes."
     )
     lines.append("")
     lines.append("![Cost by strategy](voting_cost_by_order.png)")
@@ -334,7 +330,7 @@ def main(argv: list[str] | None = None) -> int:
         "--max-steps",
         type=int,
         default=40,
-        help="Cap on votes cast per cell (keeps the ensemble_std strategy tractable). Pass 0 for no cap.",
+        help="Cap on votes cast per cell. Pass 0 for no cap.",
     )
     ap.add_argument("--no-voting", action="store_true", help="Skip the voting-iterations axis.")
     ap.add_argument("--no-label-curve", action="store_true", help="Skip the label-curve axis.")

--- a/tests_lib/detectors/test_al_benchmark.py
+++ b/tests_lib/detectors/test_al_benchmark.py
@@ -106,40 +106,29 @@ class TestPrecomputedSource:
 
 
 class TestRunAlBenchmark:
-    def test_multiple_strategies_and_strategy_column(self):
+    def test_autopilot_runs_and_strategy_column(self):
         clips = synthetic_source(n_per_cat=12, dim=12, seed=0)
         df = run_al_benchmark(
             clips,
-            strategies=["random", "margin"],
+            strategies=["autopilot"],
             seeds=[0, 1],
             calibrate_count=1,
-            max_steps=8,
-        )
-        assert not df.empty
-        assert set(df["strategy"].unique()) == {"random", "margin"}
-        assert "cost" in df.columns
-
-    def test_density_strategy_runs(self):
-        clips = synthetic_source(n_per_cat=15, dim=12, seed=2)
-        df = run_al_benchmark(
-            clips,
-            strategies=["density_margin"],
-            seeds=[0],
-            calibrate_count=1,
-            max_steps=8,
+            max_steps=10,
             atlas_min_node_size=3,
         )
         assert not df.empty
-        assert (df["strategy"] == "density_margin").all()
+        assert set(df["strategy"].unique()) == {"autopilot"}
+        assert "cost" in df.columns
 
     def test_plot_dir_writes_pngs(self, tmp_path):
         clips = synthetic_source(n_per_cat=10, dim=8, seed=0)
         run_al_benchmark(
             clips,
-            strategies=["random", "margin"],
+            strategies=["autopilot"],
             seeds=[0],
             calibrate_count=1,
-            max_steps=6,
+            max_steps=8,
+            atlas_min_node_size=3,
             plot_dir=tmp_path,
         )
         pngs = list(tmp_path.glob("*.png"))
@@ -147,10 +136,12 @@ class TestRunAlBenchmark:
 
     def test_final_cost_summary_ranks_strategies(self):
         clips = synthetic_source(n_per_cat=12, dim=12, seed=0)
-        df = run_al_benchmark(clips, strategies=["random", "margin"], seeds=[0, 1], calibrate_count=1, max_steps=8)
+        df = run_al_benchmark(
+            clips, strategies=["autopilot"], seeds=[0, 1], calibrate_count=1, max_steps=10, atlas_min_node_size=3
+        )
         summary = _final_cost_summary(df)
         assert list(summary.columns) == ["strategy", "final_cost"]
-        assert set(summary["strategy"]) == {"random", "margin"}
+        assert set(summary["strategy"]) == {"autopilot"}
         # Sorted ascending by final cost.
         assert summary["final_cost"].is_monotonic_increasing
 

--- a/tests_lib/detectors/test_al_strategies.py
+++ b/tests_lib/detectors/test_al_strategies.py
@@ -1,8 +1,9 @@
-"""Tests for the active-learning acquisition strategies.
+"""Tests for the autopilot vote-order strategy.
 
-All tests build small, controlled :class:`ALContext` states so the acquisition
-maths is checked directly - no model downloads.  The model-driven samplers
-(``bald``, ``eig``) train a tiny MLP on a handful of separable points.
+All tests build small, controlled :class:`ALContext` states so the phase logic
+is checked directly - no model downloads.  ``model`` is a bare sentinel object
+wherever the selector only needs "a detector exists" (it never runs the model;
+it reads ``scores``), so these stay hermetic.
 """
 
 import numpy as np
@@ -11,12 +12,7 @@ import pytest
 from vtscore.eval.al_strategies import (
     STRATEGIES,
     ALContext,
-    _score_coreset,
-    _score_entropy,
-    _score_margin,
-    acquisition_utilities,
     available_strategies,
-    density_weights,
     select_next,
 )
 
@@ -28,18 +24,18 @@ from vtscore.eval.al_strategies import (
 
 def _ctx(
     pool_ids,
-    embeddings,
+    embeddings=None,
     *,
     labeled=None,
     scores=None,
     model=None,
     threshold=0.5,
     atlas=None,
+    pool_labels=None,
+    seed_scores=None,
     seed=0,
-    input_dim=None,
-    hidden_dim=8,
 ):
-    dim = input_dim if input_dim is not None else (len(next(iter(embeddings.values()))) if embeddings else 4)
+    embeddings = embeddings if embeddings is not None else {i: np.zeros(4, np.float32) for i in pool_ids}
     return ALContext(
         pool_ids=list(pool_ids),
         embeddings=embeddings,
@@ -47,44 +43,24 @@ def _ctx(
         scores=scores or {},
         model=model,
         threshold=threshold,
-        input_dim=dim,
-        hidden_dim=hidden_dim,
         atlas=atlas,
         rng=np.random.RandomState(seed),
+        pool_labels=pool_labels,
+        seed_scores=seed_scores,
     )
 
 
-def _trained_model(dim=8, seed=0):
-    """Train a tiny separable MLP; return ``(model, pos_vec, neg_vec)``."""
-    import torch
-
-    from vtscore.training.mlp import train_model
-
-    rng = np.random.default_rng(seed)
-    pos = np.zeros(dim, dtype=np.float32)
-    pos[0] = 1.0
-    neg = np.zeros(dim, dtype=np.float32)
-    neg[0] = -1.0
-    X_rows = []
-    y_rows = []
-    for _ in range(6):
-        X_rows.append(pos + rng.standard_normal(dim).astype(np.float32) * 0.05)
-        y_rows.append(1.0)
-        X_rows.append(neg + rng.standard_normal(dim).astype(np.float32) * 0.05)
-        y_rows.append(0.0)
-    X = torch.tensor(np.array(X_rows), dtype=torch.float32)
-    y = torch.tensor(y_rows, dtype=torch.float32).unsqueeze(1)
-    model = train_model(X, y, dim, hidden_dim=8)
-    return model, pos, neg
-
-
-def _score_pool(model, pool_ids, embeddings):
-    import torch
-
-    X = torch.tensor(np.array([embeddings[i] for i in pool_ids]), dtype=torch.float32)
-    with torch.no_grad():
-        s = torch.sigmoid(model(X)).squeeze(1).cpu().tolist()
-    return dict(zip(pool_ids, s, strict=True))
+def _labels(n_good, n_bad, start=1000):
+    """A ``labeled`` dict with *n_good* good and *n_bad* bad votes on out-of-pool ids."""
+    labeled = {}
+    cid = start
+    for _ in range(n_good):
+        labeled[cid] = 1.0
+        cid += 1
+    for _ in range(n_bad):
+        labeled[cid] = 0.0
+        cid += 1
+    return labeled
 
 
 # ------------------------------------------------------------------
@@ -93,208 +69,183 @@ def _score_pool(model, pool_ids, embeddings):
 
 
 class TestRegistry:
-    def test_base_strategies_present(self):
-        for name in ["random", "margin", "entropy", "bald", "eig", "coreset"]:
-            assert name in STRATEGIES
+    def test_autopilot_is_the_only_strategy(self):
+        assert set(STRATEGIES) == {"autopilot"}
+        assert available_strategies() == ["autopilot"]
 
-    def test_density_variants_present(self):
-        for name in ["density_margin", "density_entropy", "density_bald", "density_coreset"]:
-            assert name in STRATEGIES
+    def test_random_and_academic_strategies_are_gone(self):
+        for name in ["random", "margin", "entropy", "bald", "eig", "coreset", "balanced", "ensemble_std"]:
+            assert name not in STRATEGIES
 
-    def test_random_and_eig_have_no_density_variant(self):
-        assert "density_random" not in STRATEGIES
-        assert "density_eig" not in STRATEGIES
+    def test_unknown_strategy_raises(self):
+        with pytest.raises(KeyError):
+            select_next("random", _ctx([1, 2]))
 
-    def test_available_strategies_sorted_and_complete(self):
-        names = available_strategies()
-        assert names == sorted(names)
-        assert set(names) == set(STRATEGIES)
-
-
-# ------------------------------------------------------------------
-# Pointwise scorers (no model needed)
-# ------------------------------------------------------------------
-
-
-class TestMargin:
-    def test_picks_score_closest_to_threshold(self):
-        emb = {
-            1: np.array([1.0, 0.0], np.float32),
-            2: np.array([0.0, 1.0], np.float32),
-            3: np.array([1.0, 1.0], np.float32),
-        }
-        # threshold 0.5: id 2's score (0.55) is closest.
-        scores = {1: 0.05, 2: 0.55, 3: 0.95}
-        ctx = _ctx([1, 2, 3], emb, scores=scores, threshold=0.5)
-        util = _score_margin(ctx)
-        assert ctx.pool_ids[int(np.argmax(util))] == 2
-        assert np.all(util >= 0.0)  # non-negative for the density multiply
-
-    def test_respects_non_half_threshold(self):
-        emb = {1: np.zeros(2, np.float32), 2: np.zeros(2, np.float32)}
-        scores = {1: 0.5, 2: 0.85}
-        ctx = _ctx([1, 2], emb, scores=scores, threshold=0.9)
-        # id 2 (0.85) sits nearest the 0.9 threshold.
-        util = _score_margin(ctx)
-        assert ctx.pool_ids[int(np.argmax(util))] == 2
-
-
-class TestEntropy:
-    def test_picks_most_uncertain(self):
-        emb = {1: np.zeros(2, np.float32), 2: np.zeros(2, np.float32), 3: np.zeros(2, np.float32)}
-        scores = {1: 0.5, 2: 0.99, 3: 0.01}
-        ctx = _ctx([1, 2, 3], emb, scores=scores)
-        util = _score_entropy(ctx)
-        assert ctx.pool_ids[int(np.argmax(util))] == 1
-        assert np.all(util >= 0.0)
-
-
-class TestCoreset:
-    def test_picks_farthest_from_labeled(self):
-        emb = {
-            1: np.array([0.1, 0.0], np.float32),  # near the labeled point
-            2: np.array([5.0, 0.0], np.float32),  # far
-            10: np.array([0.0, 0.0], np.float32),  # labeled
-        }
-        ctx = _ctx([1, 2], emb, labeled={10: 0.0})
-        util = _score_coreset(ctx)
-        assert ctx.pool_ids[int(np.argmax(util))] == 2
-
-    def test_falls_back_to_random_without_labels(self):
-        emb = {1: np.zeros(2, np.float32), 2: np.ones(2, np.float32)}
-        ctx = _ctx([1, 2], emb, labeled={})
-        util = _score_coreset(ctx)
-        assert util.shape == (2,)
-        assert np.all(np.isfinite(util))
+    def test_empty_pool_raises(self):
+        with pytest.raises(ValueError):
+            select_next("autopilot", _ctx([]))
 
 
 # ------------------------------------------------------------------
-# Model-driven scorers
+# Seed / Good phase
 # ------------------------------------------------------------------
 
 
-class TestBald:
-    def test_mutual_information_non_negative_and_finite(self):
-        from vtscore.eval.al_strategies import _score_bald
+class TestGoodSeedPhase:
+    def test_no_text_seeds_a_ground_truth_positive(self):
+        # Fewer than 3 goods, no text sort -> draw a random known-good example.
+        ctx = _ctx([1, 2, 3, 4], pool_labels={1: 0.0, 2: 1.0, 3: 0.0, 4: 1.0}, labeled={})
+        assert select_next("autopilot", ctx) in {2, 4}
 
-        model, pos, neg = _trained_model()
-        emb = {1: pos, 2: neg, 3: (pos + neg) / 2.0}
-        scores = _score_pool(model, [1, 2, 3], emb)
-        ctx = _ctx([1, 2, 3], emb, scores=scores, model=model, seed=1)
-        util = _score_bald(ctx)
-        assert util.shape == (3,)
-        assert np.all(util >= 0.0)
-        assert np.all(np.isfinite(util))
+    def test_no_text_seed_is_seed_deterministic(self):
+        pl = {1: 1.0, 2: 1.0, 3: 1.0, 4: 1.0, 5: 1.0}
+        a = select_next("autopilot", _ctx(list(pl), pool_labels=pl, seed=7))
+        b = select_next("autopilot", _ctx(list(pl), pool_labels=pl, seed=7))
+        assert a == b
 
-    def test_select_returns_valid_pool_id(self):
-        model, pos, neg = _trained_model()
-        emb = {1: pos, 2: neg, 3: (pos + neg) / 2.0}
-        scores = _score_pool(model, [1, 2, 3], emb)
-        ctx = _ctx([1, 2, 3], emb, scores=scores, model=model, seed=2)
-        assert select_next("bald", ctx) in {1, 2, 3}
+    def test_no_text_no_pool_labels_falls_back_to_any_pick(self):
+        ctx = _ctx([1, 2, 3], pool_labels=None, labeled={})
+        assert select_next("autopilot", ctx) in {1, 2, 3}
+
+    def test_text_seed_picks_top_of_the_ranking(self):
+        # Text sort available: the top-ranked item is the most-likely good.
+        ctx = _ctx([1, 2, 3, 4], seed_scores={1: 0.1, 2: 0.9, 3: 0.5, 4: 0.2}, labeled={})
+        assert select_next("autopilot", ctx) == 2
 
 
-class TestEig:
-    def test_utilities_finite_for_small_pool(self):
-        from vtscore.eval.al_strategies import _score_eig
+# ------------------------------------------------------------------
+# Bad phase
+# ------------------------------------------------------------------
 
-        model, pos, neg = _trained_model()
-        emb = {1: pos, 2: neg, 3: (pos + neg) / 2.0, 10: pos, 11: neg}
-        scores = _score_pool(model, [1, 2, 3], emb)
+
+class TestBadPhase:
+    def test_with_detector_picks_lowest_scored(self):
+        # 3 goods, 0 bads -> bad phase.  A detector exists, so its lowest-scored
+        # item is the likely bad.
         ctx = _ctx(
             [1, 2, 3],
-            emb,
-            scores=scores,
-            model=model,
-            labeled={10: 1.0, 11: 0.0},
-            seed=0,
+            labeled=_labels(3, 0),
+            scores={1: 0.9, 2: 0.1, 3: 0.5},
+            model=object(),
         )
-        util = _score_eig(ctx)
-        assert util.shape == (3,)
-        # Pool <= _EIG_MAX_CANDIDATES, so every candidate is evaluated (finite).
-        assert np.all(np.isfinite(util))
-        assert select_next("eig", ctx) in {1, 2, 3}
+        assert select_next("autopilot", ctx) == 2
+
+    def test_text_no_detector_picks_bottom_of_ranking(self):
+        # 3 goods, 0 bads, still no detector, but text sort exists -> the bottom
+        # of the ranking (least similar to the query) is the likely bad.
+        ctx = _ctx([1, 2, 3], labeled=_labels(3, 0), seed_scores={1: 0.9, 2: 0.1, 3: 0.5})
+        assert select_next("autopilot", ctx) == 2
+
+    def test_no_text_no_detector_picks_least_similar_to_goods(self):
+        # Good centroid points along +e0; the pool item pointing along -e0 is
+        # least similar and gets the Bad vote.
+        e_pos = np.array([1.0, 0.0], np.float32)
+        e_neg = np.array([-1.0, 0.0], np.float32)
+        embeddings = {
+            1: np.array([0.9, 0.1], np.float32),  # near the goods
+            2: e_neg,  # opposite the goods
+            10: e_pos,
+            11: e_pos,
+            12: e_pos,
+        }
+        ctx = _ctx([1, 2], embeddings=embeddings, labeled={10: 1.0, 11: 1.0, 12: 1.0})
+        assert select_next("autopilot", ctx) == 2
 
 
 # ------------------------------------------------------------------
-# Density weighting
+# Hard / New interleave
 # ------------------------------------------------------------------
 
 
-def _clustered_atlas(min_node_size=3):
-    """Build a coverage atlas with two well-separated clusters of unequal size."""
+def _two_cluster_atlas():
+    """A coverage atlas over two well-separated clusters (labels start empty)."""
     from vtscore.state.coverage_atlas import CoverageAtlas
 
     rng = np.random.default_rng(0)
     vectors = {}
     vid = 1
-    # Big cluster around +e0 (15 pts), small cluster around -e0 (4 pts).
-    for _ in range(15):
+    for _ in range(8):
         v = np.zeros(8, np.float32)
         v[0] = 1.0
         vectors[vid] = (v + rng.standard_normal(8).astype(np.float32) * 0.02).astype(np.float32)
         vid += 1
-    for _ in range(4):
+    for _ in range(8):
         v = np.zeros(8, np.float32)
         v[0] = -1.0
         vectors[vid] = (v + rng.standard_normal(8).astype(np.float32) * 0.02).astype(np.float32)
         vid += 1
-    atlas = CoverageAtlas(vectors, k=2, max_depth=4, min_node_size=min_node_size)
-    return atlas, vectors
+    return CoverageAtlas(vectors, k=2, max_depth=4, min_node_size=3), vectors
 
 
-class TestDensityWeights:
-    def test_weight_is_inverse_sqrt_cell_count(self):
-        atlas, vectors = _clustered_atlas()
-        ctx = _ctx(list(vectors), vectors, atlas=atlas)
-        weights = density_weights(ctx)
-        for i, cid in enumerate(ctx.pool_ids):
-            leaf = atlas.vector_to_leaf[cid]
-            expected = 1.0 / np.sqrt(atlas.nodes[leaf]["n"])
-            assert weights[i] == pytest.approx(expected)
+class TestHardNewInterleave:
+    def test_hard_picks_item_nearest_threshold(self):
+        # Even total past the quorum, atlas absent -> Hard (margin): the score
+        # closest to the threshold wins.
+        ctx = _ctx(
+            [1, 2, 3],
+            labeled=_labels(3, 5),  # total 8, even
+            scores={1: 0.05, 2: 0.55, 3: 0.95},
+            model=object(),
+            threshold=0.5,
+            atlas=None,
+        )
+        assert select_next("autopilot", ctx) == 2
 
-    def test_no_atlas_gives_unit_weights(self):
-        emb = {1: np.zeros(4, np.float32), 2: np.ones(4, np.float32)}
-        ctx = _ctx([1, 2], emb, atlas=None)
-        assert np.array_equal(density_weights(ctx), np.ones(2))
-
-    def test_density_variant_reweights_base_utility(self):
-        atlas, vectors = _clustered_atlas()
+    def test_odd_step_uses_the_coverage_atlas(self):
+        atlas, vectors = _two_cluster_atlas()
         pool = list(vectors)
         scores = {cid: 0.5 for cid in pool}
-        # Non-None model just satisfies the needs-model gate; margin reads scores.
-        ctx = _ctx(pool, vectors, scores=scores, model=object(), atlas=atlas)
-        base = acquisition_utilities("margin", ctx)
-        dens = acquisition_utilities("density_margin", ctx)
-        np.testing.assert_allclose(dens, base * density_weights(ctx))
+        ctx = _ctx(
+            pool,
+            embeddings=vectors,
+            labeled=_labels(3, 4),  # total 7, odd -> New phase
+            scores=scores,
+            model=object(),
+            atlas=atlas,
+        )
+        expected = atlas.next_sample(scores, 0.5)
+        assert expected in pool
+        assert select_next("autopilot", ctx) == expected
+
+    def test_new_falls_back_to_hard_when_atlas_exhausted(self):
+        # An atlas whose every node already carries evidence returns no sample,
+        # so an odd step falls back to the Hard (nearest-threshold) pick.
+        atlas, vectors = _two_cluster_atlas()
+        for cid in vectors:
+            atlas.label(cid, good=True)
+        pool = [1, 2, 3]
+        ctx = _ctx(
+            pool,
+            embeddings=vectors,
+            labeled=_labels(3, 4),  # odd
+            scores={1: 0.05, 2: 0.52, 3: 0.95},
+            model=object(),
+            threshold=0.5,
+            atlas=atlas,
+        )
+        assert select_next("autopilot", ctx) == 2
 
 
 # ------------------------------------------------------------------
-# Selection semantics / cold start
+# Selection always yields a valid id
 # ------------------------------------------------------------------
 
 
-class TestSelection:
-    @pytest.mark.parametrize("strategy", available_strategies())
-    def test_cold_start_falls_back_to_random(self, strategy):
-        """With no model yet, every strategy still returns a valid pool id."""
-        emb = {1: np.zeros(4, np.float32), 2: np.ones(4, np.float32), 3: np.full(4, 2.0, np.float32)}
-        ctx = _ctx([1, 2, 3], emb, model=None, atlas=None, seed=5)
-        assert select_next(strategy, ctx) in {1, 2, 3}
-
-    def test_empty_pool_raises(self):
-        ctx = _ctx([], {}, model=None)
-        with pytest.raises(ValueError):
-            select_next("random", ctx)
-
-    def test_unknown_strategy_raises(self):
-        emb = {1: np.zeros(4, np.float32)}
-        ctx = _ctx([1], emb)
-        with pytest.raises(KeyError):
-            select_next("nope", ctx)
-
-    def test_random_is_seed_deterministic(self):
-        emb = {i: np.full(4, float(i), np.float32) for i in range(1, 8)}
-        a = select_next("random", _ctx(list(emb), emb, seed=3))
-        b = select_next("random", _ctx(list(emb), emb, seed=3))
-        assert a == b
+class TestSelectionValidity:
+    @pytest.mark.parametrize(
+        "labeled",
+        [
+            {},  # good phase
+            _labels(3, 0),  # bad phase
+            _labels(3, 5),  # hard/new phase
+        ],
+    )
+    def test_returns_a_pool_id(self, labeled):
+        ctx = _ctx(
+            [1, 2, 3],
+            labeled=labeled,
+            pool_labels={1: 1.0, 2: 0.0, 3: 1.0},
+            scores={1: 0.3, 2: 0.6, 3: 0.9},
+            model=object(),
+        )
+        assert select_next("autopilot", ctx) in {1, 2, 3}

--- a/tests_lib/detectors/test_eval_visualize.py
+++ b/tests_lib/detectors/test_eval_visualize.py
@@ -257,7 +257,9 @@ class TestPlotVotingIterations:
 class TestPlotVotingIterationsFaceting:
     """When >1 acquisition strategy is present the charts facet by strategy."""
 
-    def _multi_strategy_df(self, strategies=("random", "margin", "entropy")):
+    def _multi_strategy_df(self, strategies=("autopilot", "baseline")):
+        # The plot facets by whatever ``strategy`` values are present; the names
+        # are opaque labels here (the eval itself only produces ``autopilot``).
         frames = [_make_voting_iterations_df(n_seeds=2, strategy=s) for s in strategies]
         return pd.concat(frames, ignore_index=True)
 
@@ -290,7 +292,7 @@ class TestPlotVotingIterationsFaceting:
             assert p.exists()
 
     def test_many_strategies_facet(self, tmp_dir):
-        df = self._multi_strategy_df(strategies=("random", "margin", "entropy", "bald", "coreset"))
+        df = self._multi_strategy_df(strategies=("s0", "s1", "s2", "s3", "s4"))
         paths = plot_voting_iterations(df, output_dir=tmp_dir)
         assert len(paths) == 2
         for p in paths:

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -171,21 +171,22 @@ class TestSimulateVotingIterations:
         }
         for row in rows:
             assert set(row.keys()) == expected_keys
-            assert row["strategy"] == "random"
+            assert row["strategy"] == "autopilot"
 
     def test_vote_counts_reported(self):
         """Each row carries the good/bad vote counts the model was trained on.
 
-        The first scored row reflects the 1-good + 1-bad minimum, and the
-        counts never exceed the votes seen so far (t).
+        The first scored row is the earliest trainable step (≥1 good and ≥1
+        bad), and the counts never exceed the votes seen so far (t).  Autopilot
+        seeds goods before bads, so that first step carries its initial bad
+        (``n_bad == 1``) alongside however many goods have been seeded.
         """
         medias = _make_separable_clips(n_per_cat=6)
         rows = simulate_voting_iterations(medias, "alpha", seed=42, calibrate_count=1)
         assert rows  # at least one scored step
         first = rows[0]
         assert first["n_good"] >= 1
-        assert first["n_bad"] >= 1
-        assert min(first["n_good"], first["n_bad"]) == 1  # earliest trainable step
+        assert first["n_bad"] == 1  # goods are seeded first, so the first bad triggers training
         for row in rows:
             assert row["n_good"] + row["n_bad"] == row["t"]
             assert row["n_good"] >= 1
@@ -606,64 +607,59 @@ class TestRegionVotingSimulate:
 
 
 # ------------------------------------------------------------------
-# Active-learning strategy axis
+# Autopilot vote-order strategy
 # ------------------------------------------------------------------
 
-_STRATEGIES = [
-    "random",
-    "margin",
-    "entropy",
-    "bald",
-    "ensemble_std",
-    "eig",
-    "coreset",
-    "balanced",
-    "density_margin",
-    "density_entropy",
-]
 
-
-class TestStrategyAxis:
+class TestAutopilotStrategy:
     """``strategy=`` / ``strategies=`` / ``max_steps=`` axes and the result column."""
 
-    def test_default_strategy_is_random(self):
+    def test_default_strategy_is_autopilot(self):
         medias = _make_separable_clips(n_per_cat=6)
         rows = simulate_voting_iterations(medias, "alpha", seed=42, calibrate_count=1)
         assert rows
-        assert all(r["strategy"] == "random" for r in rows)
+        assert all(r["strategy"] == "autopilot" for r in rows)
 
-    @pytest.mark.parametrize("strategy", _STRATEGIES)
-    def test_every_strategy_produces_finite_rows(self, strategy):
+    def test_produces_finite_rows(self):
         medias = _make_separable_clips(n_per_cat=8, dim=12)
         rows = simulate_voting_iterations(
             medias,
             "alpha",
             seed=3,
-            strategy=strategy,
             calibrate_count=1,
-            max_steps=8,
+            max_steps=10,
             atlas_min_node_size=3,
         )
-        assert rows  # every sampler drives the loop end-to-end
+        assert rows  # the autopilot flow drives the loop end-to-end
         for row in rows:
-            assert row["strategy"] == strategy
+            assert row["strategy"] == "autopilot"
             assert np.isfinite(row["cost"])
             assert np.isfinite(row["fpr"])
             assert np.isfinite(row["fnr"])
             # One vote per step, so the counts still sum to t.
             assert row["n_good"] + row["n_bad"] == row["t"]
 
+    def test_seeds_the_initial_goods_before_bads(self):
+        # No text sort: autopilot hands the tool known-good examples first, so
+        # the first trainable step already carries the full 3-good seed and its
+        # first bad (a 3-vs-1 model), never a 1-vs-1 warm-up.
+        medias = _make_separable_clips(n_per_cat=12)
+        rows = simulate_voting_iterations(medias, "alpha", seed=0, calibrate_count=1)
+        assert rows
+        assert rows[0]["n_good"] == 3
+        assert rows[0]["n_bad"] == 1
+
     def test_max_steps_caps_votes(self):
         medias = _make_separable_clips(n_per_cat=20)
-        rows = simulate_voting_iterations(medias, "alpha", seed=1, strategy="margin", calibrate_count=1, max_steps=5)
+        rows = simulate_voting_iterations(medias, "alpha", seed=1, calibrate_count=1, max_steps=6)
         assert rows
         # No row can reflect more than max_steps votes cast.
-        assert max(r["t"] for r in rows) <= 5
+        assert max(r["t"] for r in rows) <= 6
 
-    def test_strategy_determinism(self):
+    def test_determinism(self):
         medias = _make_separable_clips(n_per_cat=10)
-        a = simulate_voting_iterations(medias, "alpha", seed=7, strategy="entropy", calibrate_count=1, max_steps=8)
-        b = simulate_voting_iterations(medias, "alpha", seed=7, strategy="entropy", calibrate_count=1, max_steps=8)
+        a = simulate_voting_iterations(medias, "alpha", seed=7, calibrate_count=1, max_steps=10)
+        b = simulate_voting_iterations(medias, "alpha", seed=7, calibrate_count=1, max_steps=10)
         assert [r["t"] for r in a] == [r["t"] for r in b]
         assert [r["cost"] for r in a] == [r["cost"] for r in b]
 
@@ -672,22 +668,22 @@ class TestStrategyAxis:
         with pytest.raises(KeyError):
             simulate_voting_iterations(medias, "alpha", seed=1, strategy="does_not_exist", calibrate_count=1)
 
-    def test_run_eval_strategies_axis(self):
-        medias = _make_separable_clips(n_per_cat=8)
-        df = run_voting_iterations_eval(
-            dataset_clips={"ds1": medias},
-            seeds=[1, 2],
-            categories={"ds1": ["alpha"]},
-            strategies=["random", "margin"],
-            calibrate_count=1,
-            max_steps=8,
+    def test_text_seed_scores_change_the_ordering(self):
+        # Supplying a text-sort ranking routes the seed through the text path;
+        # a ranking that inverts the ground-truth order produces a different
+        # vote sequence (and cost curve) than the no-text random-good seed.
+        medias = _make_separable_clips(n_per_cat=12)
+        no_text = simulate_voting_iterations(medias, "alpha", seed=5, calibrate_count=1, max_steps=10)
+        # Rank every media by a synthetic "similarity" = its id, so the text
+        # seed walks the pool in a fixed, non-random order.
+        seed_scores = {cid: float(cid) for cid in medias}
+        with_text = simulate_voting_iterations(
+            medias, "alpha", seed=5, calibrate_count=1, max_steps=10, seed_scores=seed_scores
         )
-        assert set(df["strategy"].unique()) == {"random", "margin"}
-        # seed x strategy cross-product all present.
-        combos = df.groupby(["seed", "strategy"]).ngroups
-        assert combos == 4
+        assert with_text
+        assert [r["cost"] for r in with_text] != [r["cost"] for r in no_text]
 
-    def test_run_eval_defaults_to_random(self):
+    def test_run_eval_defaults_to_autopilot(self):
         medias = _make_separable_clips(n_per_cat=6)
         df = run_voting_iterations_eval(
             dataset_clips={"ds1": medias},
@@ -695,39 +691,18 @@ class TestStrategyAxis:
             categories={"ds1": ["alpha"]},
             calibrate_count=1,
         )
-        assert set(df["strategy"].unique()) == {"random"}
+        assert set(df["strategy"].unique()) == {"autopilot"}
 
-
-class TestBalancedStrategy:
-    """The oracle ``balanced`` strategy keeps the running Good/Bad counts even."""
-
-    def test_running_counts_stay_balanced(self):
-        # Every scored step's good/bad counts never drift more than one apart,
-        # and the first trainable step is a 1-vs-1 model at t=2.
+    def test_run_eval_threads_seed_scores(self):
         medias = _make_separable_clips(n_per_cat=8)
-        rows = simulate_voting_iterations(medias, "alpha", seed=0, strategy="balanced", calibrate_count=1)
-        assert rows
-        assert rows[0]["t"] == 2
-        assert rows[0]["n_good"] == 1
-        assert rows[0]["n_bad"] == 1
-        for row in rows:
-            assert abs(row["n_good"] - row["n_bad"]) <= 1
-
-    def test_handles_single_class_pool(self):
-        # All 'alpha' → the held-out split has no negatives, so the run returns
-        # no rows; the balanced selector must reach that early-return without
-        # tripping on an all-one-class pool.
-        medias = {cid: m for cid, m in _make_separable_clips(n_per_cat=6).items() if m["category"] == "alpha"}
-        rows = simulate_voting_iterations(medias, "alpha", seed=0, strategy="balanced", calibrate_count=1)
-        assert rows == []
-
-
-class TestEnsembleStdStrategy:
-    """The ``ensemble_std`` deep-ensemble sampler is deterministic per seed."""
-
-    def test_ensemble_std_deterministic(self):
-        medias = _make_separable_clips(n_per_cat=8)
-        a = simulate_voting_iterations(medias, "alpha", seed=1, strategy="ensemble_std", max_steps=8, calibrate_count=1)
-        b = simulate_voting_iterations(medias, "alpha", seed=1, strategy="ensemble_std", max_steps=8, calibrate_count=1)
-        assert [r["t"] for r in a] == [r["t"] for r in b]
-        assert [r["cost"] for r in a] == [r["cost"] for r in b]
+        seed_scores = {"ds1": {"alpha": {cid: float(cid) for cid in medias}}}
+        df = run_voting_iterations_eval(
+            dataset_clips={"ds1": medias},
+            seeds=[1],
+            categories={"ds1": ["alpha"]},
+            calibrate_count=1,
+            max_steps=10,
+            seed_scores=seed_scores,
+        )
+        assert not df.empty
+        assert set(df["strategy"].unique()) == {"autopilot"}

--- a/vtscore/docs/packages/eval.md
+++ b/vtscore/docs/packages/eval.md
@@ -224,21 +224,30 @@ through `json.dumps(indent=2)`.
 ## Voting iterations
 
 `vtscore/eval/voting_iterations.py` simulates an interactive labelling
-session - votes are cast one at a time in a shuffled order, and at
-each step (once both polarities have at least one vote) a fresh MLP is
-trained, a threshold is computed, the held-out test set is scored,
-and the inclusion-weighted cost is recorded. This is how the team
-answers "how does cost drop as the user labels?" without spinning up
-a UI session.
+session - votes are cast one at a time in the order the app's
+**Autopilot** would present them, and at each step (once both
+polarities have at least one vote) a fresh MLP is trained, a threshold
+is computed, the held-out test set is scored, and the inclusion-weighted
+cost is recorded. This is how the team answers "how does cost drop as
+the user labels?" without spinning up a UI session.
+
+The only vote-order strategy is `autopilot` (see
+`vtscore/eval/al_strategies.py`): the eval reproduces the real user flow
+rather than any academic active-learning heuristic. Autopilot seeds the
+first few positives from text sort when a `seed_scores` ranking is
+supplied, else from a handful of random known-good examples ("3 random
+examples pulled from the Good"), then gathers the initial negatives and
+cycles the standard Good / Bad / Hard / New phases.
 
 ### `simulate_voting_iterations(clips_dict, target_category, seed, ...)`
 
-`vtscore/eval/voting_iterations.py:122`. Run one `(dataset, category,
-seed)` simulation. Splits `clips_dict` into `D_sim` (used to draw
-votes) and `D_test` (held out for cost evaluation) by `sim_fraction`,
-shuffles the vote order, and iterates:
+Run one `(dataset, category, seed)` simulation. Splits `clips_dict` into
+`D_sim` (used to draw votes) and `D_test` (held out for cost evaluation)
+by `sim_fraction`, then iterates:
 
-1. Apply the next vote.
+1. Pick the next vote with the autopilot selector (seed → Good → Bad →
+   Hard → New) and apply it; mirror it onto the coverage atlas that
+   drives the New phase.
 2. When both polarities have at least one vote, train an MLP
    (`train_model`) and pick a threshold
    (`calculate_cross_calibration_threshold`, with optional
@@ -246,11 +255,16 @@ shuffles the vote order, and iterates:
 3. Score `D_test`, compute FPR / FNR, weight by inclusion, record the
    cost.
 
+Pass `seed_scores={media_id: similarity}` (each item's cosine to the
+typed query) to route the seed through text sort; omit it for the
+random-known-good seed.
+
 Returns a list of row dicts:
 
 ```python
 {
     "seed": 0, "dataset": "esc50_s", "category": "dog",
+    "strategy": "autopilot",
     "t": 7, "n_good": 3, "n_bad": 4,
     "cost": 0.124, "fpr": 0.05, "fnr": 0.21,
     "elapsed_seconds": 12.4,
@@ -258,9 +272,9 @@ Returns a list of row dicts:
 ```
 
 `n_good`/`n_bad` are the good/bad vote counts the row's model was trained
-on (they sum to `t`). The first scored step has only one of each, so its
-metrics are very noisy; carry these counts through so analysis can filter or
-weight rows by sample size instead of treating a 1-vs-1 model as reliable.
+on (they sum to `t`). Autopilot seeds goods before bads, so the first
+scored step carries the initial goods plus a single bad; carry these
+counts through so analysis can weight rows by sample size.
 
 Honours the same threshold knobs as the runner. When
 `safe_thresholds=True`, the GMM blend uses scores over the simulation
@@ -269,12 +283,13 @@ calibration.
 
 ### `run_voting_iterations_eval(dataset_clips, seeds, categories=None, ...)`
 
-`vtscore/eval/voting_iterations.py:250`. Sweep
-`simulate_voting_iterations` over `(seed × dataset × category)` and
-return a `pandas.DataFrame` with columns `seed, dataset, category, t,
-n_good, n_bad, cost, fpr, fnr, elapsed_seconds`. When `categories` is `None` or a
-dataset is missing from the dict, every unique category in that
-dataset is used.
+Sweep `simulate_voting_iterations` over `(seed × dataset × category)` and
+return a `pandas.DataFrame` with columns `seed, dataset, category,
+strategy, t, n_good, n_bad, cost, fpr, fnr, elapsed_seconds`. When
+`categories` is `None` or a dataset is missing from the dict, every
+unique category in that dataset is used. Pass
+`seed_scores={dataset: {category: {media_id: similarity}}}` to route the
+autopilot seed through text sort per (dataset, category).
 
 ```python
 from vtscore.eval.voting_iterations import run_voting_iterations_eval
@@ -289,7 +304,7 @@ df = run_voting_iterations_eval(
 
 ### `run_voting_iterations_eval_from_pickles(dataset_paths, seeds, ...)`
 
-`vtscore/eval/voting_iterations.py:315`. Convenience wrapper that
+`vtscore/eval/voting_iterations.py`. Convenience wrapper that
 loads each dataset from a pickle path (via
 `vtscore.datasets.loader.load_dataset_from_pickle`) and then calls
 `run_voting_iterations_eval`. The returned DataFrame has the same

--- a/vtscore/eval/al_benchmark.py
+++ b/vtscore/eval/al_benchmark.py
@@ -1,9 +1,9 @@
-"""Hermetic benchmark harness for active-learning acquisition strategies.
+"""Hermetic harness for the autopilot voting-iterations eval.
 
-Wires the acquisition strategies in :mod:`vtscore.eval.al_strategies` to the
-voting-iterations evaluator (:mod:`vtscore.eval.voting_iterations`) over
-**data sources that need no model downloads**, so a strategy sweep runs in the
-plain test container:
+Wires the ``autopilot`` vote-order strategy in :mod:`vtscore.eval.al_strategies`
+to the voting-iterations evaluator (:mod:`vtscore.eval.voting_iterations`) over
+**data sources that need no model downloads**, so the autopilot simulation runs
+in the plain test container:
 
 - ``synthetic`` — Gaussian category clusters generated on the fly.  Fully
   parameterised (item count, dimensionality, class count, separation, noise) and
@@ -20,12 +20,11 @@ a real loaded dataset has, minus the pixels.
 
 Run it as a module::
 
-    python -m vtscore.eval.al_benchmark --source synthetic \\
-        --strategies random margin entropy bald coreset --seeds 0 1 2 \\
+    python -m vtscore.eval.al_benchmark --source synthetic --seeds 0 1 2 \\
         --plot-dir al_out --output al_results.csv
 
     python -m vtscore.eval.al_benchmark --source precomputed \\
-        --features-path features.npz --strategies all
+        --features-path features.npz
 """
 
 from __future__ import annotations
@@ -49,13 +48,13 @@ if TYPE_CHECKING:
 _FEATURE_KEY = "feature"
 
 # The benchmark's coverage-atlas floor is well below the production default (20)
-# because hermetic sources are small: a lower floor lets the ``density_*``
-# strategies actually resolve distinct cells over a few dozen items.
+# because hermetic sources are small: a lower floor lets the autopilot New
+# phase actually resolve distinct diversity cells over a few dozen items.
 _DEFAULT_ATLAS_MIN_NODE_SIZE = 8
 
-# A fast default sweep that skips ``eig`` (the costliest sampler, ``2 x K``
-# retrains per step).  Pass ``--strategies all`` to include it.
-_DEFAULT_STRATEGIES = ["random", "margin", "entropy", "bald", "coreset"]
+# The eval simulates only the real user flow, so ``autopilot`` is the sole
+# strategy.
+_DEFAULT_STRATEGIES = ["autopilot"]
 
 MediaDict = dict[int, dict[str, Any]]
 DatasetClips = dict[str, MediaDict]
@@ -196,11 +195,10 @@ def run_al_benchmark(
     """Run *strategies* over *dataset_clips* and return the results frame.
 
     A thin orchestration over
-    :func:`~vtscore.eval.voting_iterations.run_voting_iterations_eval`: it adds
-    the strategy axis, applies the benchmark's lower coverage-atlas floor, and
-    (when *plot_dir* is given) renders the strategy-faceted charts.  The returned
-    :class:`~pandas.DataFrame` carries the usual voting-iterations columns plus
-    ``strategy``.
+    :func:`~vtscore.eval.voting_iterations.run_voting_iterations_eval`: it applies
+    the benchmark's lower coverage-atlas floor and (when *plot_dir* is given)
+    renders the charts.  The returned :class:`~pandas.DataFrame` carries the usual
+    voting-iterations columns plus ``strategy`` (always ``autopilot``).
     """
     df = run_voting_iterations_eval(
         dataset_clips,
@@ -298,7 +296,7 @@ def main(argv: Optional[list[str]] = None) -> None:
         nargs="+",
         default=_DEFAULT_STRATEGIES,
         metavar="NAME",
-        help="Strategies to compare, or 'all' (default: random margin entropy bald coreset).",
+        help="Vote-order strategies to run, or 'all' (default: autopilot, the only strategy).",
     )
     parser.add_argument("--seeds", nargs="+", type=int, default=[0, 1, 2], help="Simulation seeds (default: 0 1 2).")
     parser.add_argument("--inclusion", type=int, default=0, help="Inclusion setting in [-10, 10] (default: 0).")
@@ -316,7 +314,7 @@ def main(argv: Optional[list[str]] = None) -> None:
         "--atlas-min-node-size",
         type=int,
         default=_DEFAULT_ATLAS_MIN_NODE_SIZE,
-        help=f"Coverage-atlas leaf floor for density_* strategies (default: {_DEFAULT_ATLAS_MIN_NODE_SIZE}).",
+        help=f"Coverage-atlas leaf floor for the autopilot New phase (default: {_DEFAULT_ATLAS_MIN_NODE_SIZE}).",
     )
     parser.add_argument(
         "--output", type=str, default=None, metavar="CSV", help="Write the full results frame to a CSV file."
@@ -342,7 +340,7 @@ def main(argv: Optional[list[str]] = None) -> None:
     )
 
     print(f"\n{'=' * 60}")
-    print("ACTIVE-LEARNING BENCHMARK — final cost by strategy (lower is better)")
+    print("AUTOPILOT VOTING BENCHMARK — final cost by strategy (lower is better)")
     print(f"{'=' * 60}")
     summary = _final_cost_summary(df)
     for _, row in summary.iterrows():

--- a/vtscore/eval/al_strategies.py
+++ b/vtscore/eval/al_strategies.py
@@ -1,60 +1,36 @@
-"""Active-learning acquisition strategies for the voting-iterations harness.
+"""The autopilot vote-order simulation for the voting-iterations harness.
 
 The voting-iterations evaluator (:mod:`vtscore.eval.voting_iterations`) simulates
 a user labelling one item at a time and measures how fast the detector's cost
-falls.  *Which* item the simulated user is shown next is an
-**acquisition strategy**: a rule that, given the current model, its scores over
-the unlabelled pool, the embeddings, and the labels gathered so far, picks the
-next item to query.  A good strategy reaches a low-cost detector in fewer votes
-than random labelling.
+falls.  *Which* item the simulated user is shown next is decided here, by
+reproducing what a real VTSearch user actually does — the **Autopilot** flow —
+rather than any academic active-learning acquisition rule.  There is exactly one
+strategy, ``autopilot``; the eval only cares about how the tool itself would
+function.
 
-An :class:`ALContext` bundles that per-step state; a strategy is a callable
-``ALContext -> int`` returning the chosen pool id.  The :data:`STRATEGIES`
-registry maps a name to that callable:
+The flow mirrors the app's Autopilot phases (see
+``frontend/src/app/services/autopilot-state.service.ts``):
 
-- ``random``   — uniform pick from the pool (the baseline every strategy is
-  measured against).
-- ``margin``   — smallest ``|p - t|``: the item whose score sits closest to the
-  decision threshold, i.e. the model is most on-the-fence about.
-- ``entropy``  — largest binary entropy ``H(p)``: maximal predictive
-  uncertainty (for a threshold at 0.5 this and ``margin`` coincide; away from
-  0.5 they diverge).
-- ``bald``     — largest MC-dropout mutual information: runs the trained net
-  with dropout left on for several stochastic passes and picks the item the
-  ensemble *disagrees* with itself about most (epistemic, not aleatoric,
-  uncertainty).
-- ``ensemble_std`` — like ``bald`` but the disagreement comes from an explicit
-  N-member *deep* ensemble: train :data:`_ENSEMBLE_MEMBERS` seed-varied MLPs on
-  the votes so far, score the pool with each, and pick the item with the
-  greatest member-to-member sigmoid std.  Costs N retrains per step (no dropout
-  needed at inference) where ``bald`` costs one train plus N cheap dropout
-  passes.
-- ``eig``      — largest expected pool-entropy reduction, estimated by
-  counterfactually retraining the model with each candidate labelled both ways
-  (``2 x K`` retrains) and scoring how much the pool's total entropy is expected
-  to drop.
-- ``coreset``  — greedy k-centre: the pool item **farthest** (in embedding
-  space) from everything labelled so far, spreading coverage rather than
-  chasing uncertainty.
-- ``balanced`` — an **oracle** ordering (not label-blind): peeks at the pool's
-  ground-truth labels to always query the currently under-represented class, so
-  the running Good/Bad counts stay balanced.  It is a diagnostic baseline
-  isolating "does class balance during voting help?" from vote *content*, only
-  usable in the simulation harness where pool labels are known; it reads
-  :attr:`ALContext.pool_labels` and degrades to ``random`` when that is absent.
+1. **Seed / Good** — gather the first :data:`_GOOD_TARGET` positives.  If the
+   dataset can be text-sorted (the caller supplies ``seed_scores``, a per-item
+   similarity to the typed query), the user votes top-down on that ranking, where
+   positives cluster.  Otherwise the user hands the tool a few known-good
+   examples: :data:`_GOOD_TARGET` random ground-truth positives ("3 random
+   examples pulled from the Good").
+2. **Bad** — gather the first :data:`_BAD_TARGET` negatives.  Once a detector
+   exists (≥1 good and ≥1 bad), its lowest-scored items are the likely bads the
+   tool surfaces at the bottom of learned sort; before that, the bottom of the
+   text ranking (or, with no text, the item least similar to the good centroid —
+   an example sort) is voted bad.
+3. **Hard / New** — with the quorum reached, the tool cycles between *refining
+   the boundary* (Hard: the item nearest the decision threshold, i.e. what the
+   detector is least sure about) and *exploring diversity* (New: the coverage
+   atlas's next under-explored region).  The two are interleaved on step parity.
 
-Each strategy above also has a ``density_<name>`` variant that multiplies its
-per-item acquisition utility by ``1 / sqrt(cell_count)`` — the reciprocal root
-of the population of the item's :class:`~vtscore.state.coverage_atlas.CoverageAtlas`
-leaf — so items in sparsely-populated regions of the dataset are up-weighted.
-This is *information density* sampling: prefer items that are both informative
-and representative of an under-explored pocket.  ``density_*`` variants exist for
-every base strategy except ``random`` and ``eig`` (``random`` is the baseline;
-``eig`` is already the most expensive sampler and its density variant buys
-little).
-
-All acquisition utilities are non-negative and higher-is-better, so the density
-multiply only ever *re-ranks* by rarity, never flips the base preference.
+An :class:`ALContext` bundles the per-step state; the selector is a callable
+``ALContext -> int`` returning the chosen pool id.  :func:`select_next` dispatches
+by name and :data:`STRATEGIES` is the (single-entry) registry, both kept so the
+harness interface is unchanged.
 """
 
 from __future__ import annotations
@@ -71,58 +47,48 @@ if TYPE_CHECKING:
     from vtscore.state.coverage_atlas import CoverageAtlas
 
 
-# Number of stochastic forward passes for the MC-dropout BALD estimate.  More
-# passes shrink the Monte-Carlo error on the mutual information at linear cost;
-# 20 is the usual sweet spot in the deep-AL literature.
-_BALD_PASSES = 20
-
-# Number of seed-varied MLPs trained per step for the ``ensemble_std`` deep
-# ensemble.  Members use fixed seeds ``42 + k`` so the pick is a deterministic
-# function of the votes cast so far (reproducible for a given eval seed).
-_ENSEMBLE_MEMBERS = 5
-
-# Ceiling on the number of pool candidates ``eig`` counterfactually retrains
-# for.  A retrain is expensive, so on a large pool we only evaluate the most
-# uncertain items (top-K by entropy) — the low-entropy tail is almost never the
-# information-maximising pick anyway.  ``2 x K`` retrains happen per step.
-_EIG_MAX_CANDIDATES = 32
+# Initial-phase vote targets, matching the app's Autopilot defaults
+# (``INITIAL_STATE.goodToStart`` / ``badToStart``): three positives to teach the
+# detector what "good" looks like, then four negatives so it has both sides of
+# the cutoff.
+_GOOD_TARGET = 3
+_BAD_TARGET = 4
 
 _EPS = 1e-9
 
 
 @dataclass
 class ALContext:
-    """Per-step state an acquisition strategy needs to pick the next item.
+    """Per-step state the autopilot selector needs to pick the next item.
 
     Attributes:
-        pool_ids: Candidate ids the strategy chooses among (unlabelled so far),
-            in a stable order; every utility array a scorer returns is aligned
-            to this list.
+        pool_ids: Candidate ids the selector chooses among (unlabelled so far),
+            in a stable order.
         embeddings: ``{id: vector}`` for every id (pool and labelled) — the
-            whole-image embedding, used by ``coreset``/``eig`` and by the
-            density atlas.
-        labeled: ``{id: 1.0 | 0.0}`` for every item labelled so far
-            ("labelled-so-far").  Empty before the first vote.
-        scores: ``{pool_id: p}`` sigmoid probabilities from the current model,
-            used by ``margin``/``entropy``/``eig``.  Empty before the first
-            model exists.
+            whole-image embedding, used for the example-sort good centroid.
+        labeled: ``{id: 1.0 | 0.0}`` for every item labelled so far.  Empty
+            before the first vote; its good/bad counts drive the phase.
+        scores: ``{pool_id: p}`` sigmoid probabilities from the current detector,
+            used by the Bad (lowest-scored) and Hard (nearest-threshold) picks.
+            Empty before the first model exists.
         model: The current trained MLP (``None`` before the first trainable
             step, i.e. before one Good and one Bad vote coexist).
-        threshold: The current decision threshold ``t`` (``margin`` measures
+        threshold: The current decision threshold ``t`` (Hard measures
             ``|p - t|`` against it).
-        input_dim: Embedding dimensionality, for ``eig`` counterfactual retrains.
-        hidden_dim: Hidden width the counterfactual retrains should use (matches
-            the live model's width); ``None`` lets training auto-size.
-        atlas: The dataset's coverage atlas, for ``density_*`` variants (``None``
-            disables density weighting — every weight is 1).
-        rng: Seeded RNG driving ``random`` and the MC-dropout seed, so a run is
+        atlas: The dataset's coverage atlas, driving the New (diversity) pick
+            (``None`` disables it — the interleave then always picks Hard).
+        rng: Seeded RNG driving the random good-seed pick, so a run is
             reproducible from its seed.
-        pool_labels: Ground-truth ``{pool_id: 1.0 | 0.0}`` for the pool, used
-            **only** by the ``balanced`` oracle strategy to interleave Good/Bad
-            queries.  This deliberately breaks the label-blind contract every
-            other strategy honours; it is meaningful only in the simulation
-            harness (where every pool label is known ground truth).  ``None``
-            (the default) makes ``balanced`` degrade to a random pick.
+        pool_labels: Ground-truth ``{pool_id: 1.0 | 0.0}`` for the pool, used to
+            draw the random known-good seed examples when no text sort is
+            available.  This is not an oracle *ranking* — it stands in for the
+            handful of positives a real user supplies by hand to bootstrap.
+            ``None`` degrades the good seed to a uniform-random pick.
+        seed_scores: Optional ``{id: similarity}`` text-sort ranking (cosine of
+            each item to the typed query).  When present the seed/bad phases
+            follow the text ranking (top for goods, bottom for bads); ``None``
+            means the dataset has no text sort, so the flow seeds from random
+            known-good examples instead.
     """
 
     pool_ids: list[int]
@@ -131,325 +97,147 @@ class ALContext:
     scores: dict[int, float]
     model: Optional["torch.nn.Sequential"]
     threshold: float
-    input_dim: int
-    hidden_dim: Optional[int]
     atlas: Optional["CoverageAtlas"]
     rng: np.random.RandomState = field(default_factory=lambda: np.random.RandomState(0))
     pool_labels: Optional[dict[int, float]] = None
+    seed_scores: Optional[dict[int, float]] = None
 
 
 # ------------------------------------------------------------------
-# Utility helpers
+# Helpers
 # ------------------------------------------------------------------
 
 
-def _binary_entropy(p: np.ndarray) -> np.ndarray:
-    """Return the binary entropy ``H(p) = -p log p - (1-p) log(1-p)`` (nats).
+def _uniform_pick(ctx: ALContext, candidates: list[int]) -> int:
+    """Return a uniform-random id from *candidates* using the seeded RNG."""
+    util = ctx.rng.random(len(candidates))
+    return candidates[int(np.argmax(util))]
 
-    Clamps *p* off ``{0, 1}`` so the ``log`` stays finite; the entropy of a
-    saturated prediction is 0, which the clamp reproduces to machine precision.
+
+def _good_centroid(ctx: ALContext) -> Optional[np.ndarray]:
+    """Return the L2-normalised mean of the good-voted embeddings, or ``None``.
+
+    Mirrors the example-sort centroid the live tool builds from multiple Good
+    examples (each vector L2-normalised before averaging, so every example
+    contributes equally regardless of its norm).
     """
-    p = np.clip(np.asarray(p, dtype=np.float64), _EPS, 1.0 - _EPS)
-    return -p * np.log(p) - (1.0 - p) * np.log(1.0 - p)
+    goods = [i for i, v in ctx.labeled.items() if v == 1.0]
+    if not goods:
+        return None
+    normed = []
+    for i in goods:
+        v = np.asarray(ctx.embeddings[i], dtype=np.float32)
+        n = float(np.linalg.norm(v))
+        normed.append(v / n if n > _EPS else v)
+    return np.mean(np.stack(normed), axis=0)
 
 
-def _pool_matrix(ctx: ALContext) -> np.ndarray:
-    """Stack the pool embeddings into an ``(n_pool, dim)`` float32 matrix."""
-    return np.array([ctx.embeddings[i] for i in ctx.pool_ids], dtype=np.float32)
+def _least_similar_to_goods(ctx: ALContext) -> int:
+    """Return the pool item least similar to the good centroid (an example sort).
 
-
-def _pool_scores(ctx: ALContext) -> np.ndarray:
-    """Return the current model's pool probabilities aligned to ``pool_ids``.
-
-    Falls back to ``0.5`` (maximal uncertainty) for any pool id without a
-    recorded score, so a scorer never trips on a missing key.
+    The bottom of an example sort by the current positives is the most-likely
+    bad, exactly what the tool would surface for a Bad vote before any detector
+    exists.  Falls back to a uniform pick when no goods are labelled yet.
     """
-    return np.array([ctx.scores.get(i, 0.5) for i in ctx.pool_ids], dtype=np.float64)
+    centroid = _good_centroid(ctx)
+    if centroid is None:
+        return _uniform_pick(ctx, ctx.pool_ids)
+    cnorm = float(np.linalg.norm(centroid))
+
+    def sim(i: int) -> float:
+        v = np.asarray(ctx.embeddings[i], dtype=np.float32)
+        n = float(np.linalg.norm(v)) * cnorm
+        return float(np.dot(v, centroid) / n) if n > _EPS else 0.0
+
+    return min(ctx.pool_ids, key=sim)
+
+
+def _atlas_next(ctx: ALContext) -> Optional[int]:
+    """Return the coverage atlas's next under-explored pool item, or ``None``.
+
+    Delegates to :meth:`CoverageAtlas.next_sample` (the same call the app's New
+    phase makes), passing the current pool scores + threshold so the probe lands
+    on a representative surprise in the first evidence-free region.  Returns
+    ``None`` when the atlas is exhausted or the pick has somehow left the pool,
+    so the caller can fall back to a Hard pick.
+    """
+    atlas = ctx.atlas
+    if atlas is None:
+        return None
+    pick = atlas.next_sample(ctx.scores or None, ctx.threshold)
+    if pick is None or pick not in set(ctx.pool_ids):
+        return None
+    return pick
 
 
 # ------------------------------------------------------------------
-# Base acquisition scorers: ALContext -> per-pool-item utility (higher = pick)
+# The autopilot selector
 # ------------------------------------------------------------------
 
 
-def _score_random(ctx: ALContext) -> np.ndarray:
-    """Uniform-random utility — argmax of it is a uniform pick from the pool."""
-    return ctx.rng.random(len(ctx.pool_ids))
-
-
-def _score_margin(ctx: ALContext) -> np.ndarray:
-    """Margin sampling: high utility for items whose score is near the threshold.
-
-    Utility ``1 - |p - t|`` is maximal (1) when ``p == t`` and non-negative
-    everywhere (``p, t`` both in ``[0, 1]``), so its argmax is the minimal-margin
-    item and the density multiply keeps its sign.
-    """
-    p = _pool_scores(ctx)
-    return 1.0 - np.abs(p - ctx.threshold)
-
-
-def _score_entropy(ctx: ALContext) -> np.ndarray:
-    """Predictive entropy ``H(p)`` — maximal at ``p = 0.5``, non-negative."""
-    return _binary_entropy(_pool_scores(ctx))
-
-
-def _score_bald(ctx: ALContext) -> np.ndarray:
-    """MC-dropout BALD mutual information ``H(E[p]) - E[H(p)]`` per pool item.
-
-    Runs the trained net with dropout **on** for :data:`_BALD_PASSES` stochastic
-    passes; the gap between the entropy of the averaged prediction and the
-    average of the per-pass entropies is the model's epistemic uncertainty
-    (disagreement across dropout masks), which is non-negative by Jensen.  The
-    dropout RNG is forked and seeded from ``ctx.rng`` so the estimate is
-    reproducible.
-    """
-    import torch  # noqa: PLC0415
-
-    model = ctx.model
-    assert model is not None
-    X = torch.tensor(_pool_matrix(ctx), dtype=torch.float32)
-    device = next(model.parameters()).device
-    X = X.to(device)
-
-    seed = int(ctx.rng.randint(0, 2**31 - 1))
-    was_training = model.training
-    probs: list[np.ndarray] = []
-    model.train()  # enable Dropout layers
-    with torch.random.fork_rng(devices=[]), torch.no_grad():
-        torch.manual_seed(seed)
-        for _ in range(_BALD_PASSES):
-            p = torch.sigmoid(model(X)).squeeze(1).cpu().numpy()
-            probs.append(p.astype(np.float64))
-    if not was_training:
-        model.eval()
-
-    stacked = np.stack(probs, axis=0)  # (passes, n_pool)
-    mean_p = stacked.mean(axis=0)
-    entropy_of_mean = _binary_entropy(mean_p)
-    mean_of_entropy = _binary_entropy(stacked).mean(axis=0)
-    return np.maximum(entropy_of_mean - mean_of_entropy, 0.0)
-
-
-def _score_coreset(ctx: ALContext) -> np.ndarray:
-    """Greedy k-centre utility: distance from each pool item to the labelled set.
-
-    The utility of a pool item is its Euclidean distance to the **nearest**
-    already-labelled embedding; its argmax is the farthest-from-covered item,
-    the greedy k-centre pick.  With nothing labelled yet the notion is undefined,
-    so it degrades to a random utility (the very first pick is arbitrary anyway).
-    """
-    if not ctx.labeled:
-        return _score_random(ctx)
-    pool = _pool_matrix(ctx)
-    labelled = np.array([ctx.embeddings[i] for i in ctx.labeled], dtype=np.float32)
-    # Pairwise distances (n_pool, n_labelled); nearest labelled per pool item.
-    dists = np.linalg.norm(pool[:, None, :] - labelled[None, :, :], axis=2)
-    return dists.min(axis=1)
-
-
-def _score_ensemble_std(ctx: ALContext) -> np.ndarray:
-    """Deep-ensemble disagreement: per-pool member-to-member sigmoid std.
-
-    Trains :data:`_ENSEMBLE_MEMBERS` seed-varied MLPs on the votes gathered so
-    far (``ctx.labeled``), scores every pool item's embedding with each member,
-    and returns the per-item std across members — high where the ensemble
-    disagrees, i.e. maximal epistemic uncertainty.  Fixed member seeds keep the
-    utility a deterministic function of the current votes.  Requires at least
-    one Good and one Bad vote to be trainable; the cold-start guard
-    (``needs_model``) routes the pre-trainable steps to a random pick.
-    """
-    import torch  # noqa: PLC0415
-
-    from vtscore.training.mlp import train_model  # noqa: PLC0415
-
-    X = torch.tensor(np.array([ctx.embeddings[i] for i in ctx.labeled]), dtype=torch.float32)
-    y = torch.tensor([float(v) for v in ctx.labeled.values()], dtype=torch.float32).unsqueeze(1)
-    X_cand = torch.tensor(_pool_matrix(ctx), dtype=torch.float32)
-
-    member_scores: list[np.ndarray] = []
-    for k in range(_ENSEMBLE_MEMBERS):
-        model = train_model(X, y, ctx.input_dim, seed=42 + k, hidden_dim=ctx.hidden_dim)
-        with torch.no_grad():
-            Xk = X_cand.to(next(model.parameters()).device)
-            member_scores.append(torch.sigmoid(model(Xk)).squeeze(1).cpu().numpy())
-    return np.stack(member_scores, axis=0).std(axis=0).astype(np.float64)
-
-
-def _score_balanced(ctx: ALContext) -> np.ndarray:
-    """Oracle class-balancing utility: prefer the under-represented class.
-
-    Reads the pool's ground-truth labels (:attr:`ALContext.pool_labels`) — the
-    one strategy that is *not* label-blind — and gives every pool item of the
-    currently under-represented class a utility that dominates the other class,
-    with a small seeded jitter to break ties randomly.  Argmax therefore queries
-    a random item of the needed class, keeping the running Good/Bad counts within
-    one of each other.  Falls back to a plain random utility when no pool labels
-    are supplied (the harness always supplies them; a direct caller may not).
-    """
-    if ctx.pool_labels is None:
-        return _score_random(ctx)
-    labels = np.array([ctx.pool_labels.get(i, 0.0) for i in ctx.pool_ids], dtype=np.float64)
+def _select_autopilot(ctx: ALContext) -> int:
+    """Pick the next pool id by reproducing the app's Autopilot flow."""
     n_good = sum(1 for v in ctx.labeled.values() if v == 1.0)
     n_bad = len(ctx.labeled) - n_good
-    needed = 1.0 if n_good <= n_bad else 0.0
-    # Matched items score in [1, 1.5); unmatched in [0, 0.5) — matched always
-    # wins, and the jitter randomises the pick within the needed class.  When the
-    # needed class is exhausted every item is "unmatched" and one is picked at
-    # random from whatever remains.
-    match = (labels == needed).astype(np.float64)
-    return match + 0.5 * ctx.rng.random(len(labels))
-
-
-def _score_eig(ctx: ALContext) -> np.ndarray:
-    """Expected pool-entropy reduction via ``2 x K`` counterfactual retrains.
-
-    For each evaluated candidate, retrain the model twice — once assuming the
-    candidate is labelled Good, once Bad — and score the *rest* of the pool with
-    each retrained model.  The candidate's utility is the current summed pool
-    entropy (over that same rest) minus the label-probability-weighted expected
-    entropy after the vote, i.e. how much labelling it is expected to sharpen the
-    model over everything else.  Only the top-:data:`_EIG_MAX_CANDIDATES` pool
-    items by current entropy are evaluated (a retrain is costly); the rest get
-    ``-inf`` so they are never chosen over an evaluated candidate.
-    """
-    import torch  # noqa: PLC0415
-
-    from vtscore.training.mlp import train_model  # noqa: PLC0415
-
     pool = ctx.pool_ids
-    n = len(pool)
-    util = np.full(n, -np.inf, dtype=np.float64)
-    if n <= 1:
-        # Nothing to reduce entropy over; fall back to raw entropy so a valid
-        # pick still comes out.
-        return _score_entropy(ctx)
 
-    cur_p = _pool_scores(ctx)
-    # Evaluate the most uncertain candidates first, capped for cost.
-    order = np.argsort(-_binary_entropy(cur_p))
-    candidate_idx = order[: min(_EIG_MAX_CANDIDATES, n)]
+    # --- Seed / Good phase: gather the initial positives. ---
+    if n_good < _GOOD_TARGET:
+        if ctx.seed_scores is not None:
+            # Text sort available: vote top-down on the query ranking, where the
+            # positives cluster — exactly what a user does after typing a query.
+            return max(pool, key=lambda i: ctx.seed_scores.get(i, -np.inf))
+        # No text sort: seed with random known-good examples the user supplies
+        # by hand ("3 random examples pulled from the Good").
+        positives = [i for i in pool if ctx.pool_labels is not None and ctx.pool_labels.get(i) == 1.0]
+        return _uniform_pick(ctx, positives or pool)
 
-    base_X = [ctx.embeddings[i] for i in ctx.labeled]
-    base_y = [float(v) for v in ctx.labeled.values()]
+    # --- Bad phase: gather the initial negatives. ---
+    if n_bad < _BAD_TARGET:
+        if ctx.model is not None and ctx.scores:
+            # A detector exists: its lowest-scored items are the likely bads the
+            # tool surfaces at the bottom of learned sort.
+            return min(pool, key=lambda i: ctx.scores.get(i, 0.5))
+        if ctx.seed_scores is not None:
+            # No detector yet, but text sort exists: the bottom of the ranking
+            # (least similar to the query) is the most-likely bad.
+            return min(pool, key=lambda i: ctx.seed_scores.get(i, np.inf))
+        # No detector, no text: example-sort by the good centroid, vote the
+        # least-similar item bad.
+        return _least_similar_to_goods(ctx)
 
-    for j in candidate_idx:
-        cand = pool[j]
-        rest_idx = [k for k in range(n) if k != j]
-        rest = np.array([ctx.embeddings[pool[k]] for k in rest_idx], dtype=np.float32)
-        cur_rest_entropy = float(_binary_entropy(cur_p[rest_idx]).sum())
-
-        p_good = float(cur_p[j])
-        expected_entropy = 0.0
-        for label, weight in ((1.0, p_good), (0.0, 1.0 - p_good)):
-            X = torch.tensor(np.array(base_X + [ctx.embeddings[cand]]), dtype=torch.float32)
-            y = torch.tensor(base_y + [label], dtype=torch.float32).unsqueeze(1)
-            model = train_model(X, y, ctx.input_dim, hidden_dim=ctx.hidden_dim)
-            with torch.no_grad():
-                Xr = torch.tensor(rest, dtype=torch.float32).to(next(model.parameters()).device)
-                pr = torch.sigmoid(model(Xr)).squeeze(1).cpu().numpy()
-            expected_entropy += weight * float(_binary_entropy(pr).sum())
-        util[j] = cur_rest_entropy - expected_entropy
-
-    return util
-
-
-# Base scorers and whether they require a trained model to run.  When the model
-# is absent (cold start) a model-requiring scorer degrades to a random pick.
-_BASE_SCORERS: dict[str, tuple[Callable[[ALContext], np.ndarray], bool]] = {
-    "random": (_score_random, False),
-    "margin": (_score_margin, True),
-    "entropy": (_score_entropy, True),
-    "bald": (_score_bald, True),
-    "ensemble_std": (_score_ensemble_std, True),
-    "eig": (_score_eig, True),
-    "coreset": (_score_coreset, False),
-    "balanced": (_score_balanced, False),
-}
-
-# Which base strategies get a ``density_<name>`` companion.  ``random`` is the
-# baseline and ``eig`` is already the costliest sampler, so neither is reweighted.
-_DENSITY_BASES = ["margin", "entropy", "bald", "coreset"]
+    # --- Hard / New interleave: quorum reached.  Cycle refine-boundary and
+    # explore-diversity the way Autopilot does past the initial phases. ---
+    total = n_good + n_bad
+    if total % 2 == 1:
+        pick = _atlas_next(ctx)
+        if pick is not None:
+            return pick
+    if ctx.model is not None and ctx.scores:
+        # Hard = margin: the item nearest the decision threshold, i.e. the one
+        # the detector is least sure about.
+        return min(pool, key=lambda i: abs(ctx.scores.get(i, 0.5) - ctx.threshold))
+    # No detector to rank uncertainty by yet (only reachable on a degenerate
+    # pool): fall back to a uniform pick.
+    return _uniform_pick(ctx, pool)
 
 
-# ------------------------------------------------------------------
-# Density weighting
-# ------------------------------------------------------------------
-
-
-def density_weights(ctx: ALContext) -> np.ndarray:
-    """Return ``1 / sqrt(cell_count)`` per pool item from the coverage atlas.
-
-    ``cell_count`` is the population of the item's leaf node in the dataset's
-    :class:`~vtscore.state.coverage_atlas.CoverageAtlas`, so items in sparse
-    regions score higher.  Items with no atlas, or an id the atlas never saw,
-    get weight 1 (no reweighting).  Weights are strictly positive, so a density
-    multiply re-ranks the base utility by rarity without changing its sign.
-    """
-    n = len(ctx.pool_ids)
-    if ctx.atlas is None:
-        return np.ones(n, dtype=np.float64)
-    weights = np.ones(n, dtype=np.float64)
-    for i, cid in enumerate(ctx.pool_ids):
-        leaf = ctx.atlas.vector_to_leaf.get(cid)
-        if leaf is None:
-            continue
-        count = ctx.atlas.nodes[leaf]["n"]
-        if count > 0:
-            weights[i] = 1.0 / np.sqrt(count)
-    return weights
-
-
-def _make_selector(
-    scorer: Callable[[ALContext], np.ndarray],
-    *,
-    needs_model: bool,
-    density: bool,
-) -> Callable[[ALContext], int]:
-    """Wrap a base scorer into a full ``ALContext -> chosen id`` selector.
-
-    Applies the cold-start fallback (random utility when the scorer needs a
-    model that doesn't exist yet) and the optional density reweight, then
-    returns the argmax pool id.
-    """
-
-    def select(ctx: ALContext) -> int:
-        if needs_model and ctx.model is None:
-            util = _score_random(ctx)
-        else:
-            util = scorer(ctx)
-        if density:
-            util = util * density_weights(ctx)
-        return ctx.pool_ids[int(np.argmax(util))]
-
-    return select
-
-
-def _build_registry() -> dict[str, Callable[[ALContext], int]]:
-    """Assemble the name -> selector registry from the base scorers."""
-    registry: dict[str, Callable[[ALContext], int]] = {}
-    for name, (scorer, needs_model) in _BASE_SCORERS.items():
-        registry[name] = _make_selector(scorer, needs_model=needs_model, density=False)
-    for name in _DENSITY_BASES:
-        scorer, needs_model = _BASE_SCORERS[name]
-        registry[f"density_{name}"] = _make_selector(scorer, needs_model=needs_model, density=True)
-    return registry
-
-
-#: Registry of acquisition strategies: ``name -> (ALContext -> chosen pool id)``.
-STRATEGIES: dict[str, Callable[[ALContext], int]] = _build_registry()
+#: Registry of vote-order strategies.  The eval simulates only the real user
+#: flow, so ``autopilot`` is the sole entry.
+STRATEGIES: dict[str, Callable[[ALContext], int]] = {"autopilot": _select_autopilot}
 
 
 def select_next(strategy: str, ctx: ALContext) -> int:
     """Pick the next pool id to query using the named *strategy*.
 
-    Raises ``KeyError`` (via :func:`available_strategies` message) for an unknown
-    name so a typo fails loudly instead of silently defaulting.
+    Raises ``KeyError`` for an unknown name so a typo fails loudly instead of
+    silently defaulting.
     """
     try:
         selector = STRATEGIES[strategy]
     except KeyError:
         raise KeyError(
-            f"Unknown acquisition strategy {strategy!r}; available: {', '.join(available_strategies())}"
+            f"Unknown strategy {strategy!r}; available: {', '.join(available_strategies())}"
         ) from None
     if not ctx.pool_ids:
         raise ValueError("select_next called with an empty pool")
@@ -457,25 +245,5 @@ def select_next(strategy: str, ctx: ALContext) -> int:
 
 
 def available_strategies() -> list[str]:
-    """Return the sorted list of registered acquisition strategy names."""
+    """Return the sorted list of registered strategy names (just ``autopilot``)."""
     return sorted(STRATEGIES)
-
-
-def acquisition_utilities(strategy: str, ctx: ALContext) -> np.ndarray:
-    """Return the (density-weighted) per-pool-item utilities for *strategy*.
-
-    Exposes the raw utility vector the selector maximises, aligned to
-    ``ctx.pool_ids`` — useful for tests and for inspecting *why* a pick was made.
-    Mirrors the cold-start and density handling of the selector.
-    """
-    base = strategy[len("density_") :] if strategy.startswith("density_") else strategy
-    if base not in _BASE_SCORERS:
-        raise KeyError(f"Unknown acquisition strategy {strategy!r}")
-    scorer, needs_model = _BASE_SCORERS[base]
-    if needs_model and ctx.model is None:
-        util = _score_random(ctx)
-    else:
-        util = scorer(ctx)
-    if strategy.startswith("density_"):
-        util = util * density_weights(ctx)
-    return util

--- a/vtscore/eval/al_strategies.py
+++ b/vtscore/eval/al_strategies.py
@@ -186,7 +186,8 @@ def _select_autopilot(ctx: ALContext) -> int:
         if ctx.seed_scores is not None:
             # Text sort available: vote top-down on the query ranking, where the
             # positives cluster — exactly what a user does after typing a query.
-            return max(pool, key=lambda i: ctx.seed_scores.get(i, -np.inf))
+            seed = ctx.seed_scores
+            return max(pool, key=lambda i: seed.get(i, -np.inf))
         # No text sort: seed with random known-good examples the user supplies
         # by hand ("3 random examples pulled from the Good").
         positives = [i for i in pool if ctx.pool_labels is not None and ctx.pool_labels.get(i) == 1.0]
@@ -201,7 +202,8 @@ def _select_autopilot(ctx: ALContext) -> int:
         if ctx.seed_scores is not None:
             # No detector yet, but text sort exists: the bottom of the ranking
             # (least similar to the query) is the most-likely bad.
-            return min(pool, key=lambda i: ctx.seed_scores.get(i, np.inf))
+            seed = ctx.seed_scores
+            return min(pool, key=lambda i: seed.get(i, np.inf))
         # No detector, no text: example-sort by the good centroid, vote the
         # least-similar item bad.
         return _least_similar_to_goods(ctx)
@@ -236,9 +238,7 @@ def select_next(strategy: str, ctx: ALContext) -> int:
     try:
         selector = STRATEGIES[strategy]
     except KeyError:
-        raise KeyError(
-            f"Unknown strategy {strategy!r}; available: {', '.join(available_strategies())}"
-        ) from None
+        raise KeyError(f"Unknown strategy {strategy!r}; available: {', '.join(available_strategies())}") from None
     if not ctx.pool_ids:
         raise ValueError("select_next called with an empty pool")
     return selector(ctx)

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -6,16 +6,18 @@ For each combination of seed *s*, dataset *d*, and target category *c*:
    **D_test** (held-out) using *s* to control the random split.
 2. Assign ground-truth labels based on *c*: medias whose ``"category"``
    matches *c* are positive (``good``), others are negative (``bad``).
-3. Vote on D_sim one item at a time, choosing *which* item to vote on next
-   with an active-learning acquisition strategy (order seeded by *s*).
+3. Vote on D_sim one item at a time, choosing *which* item to vote on next by
+   reproducing the app's **Autopilot** flow (order seeded by *s*).
 4. At each step *t* (once at least one good **and** one bad vote exist),
    train a model on votes so far, find a threshold, score D_test, and record
    the inclusion-weighted cost (``fpr_weight * FPR + fnr_weight * FNR``).
 
-Which item the simulated user votes on at each step is chosen by an
-**active-learning acquisition strategy** (see :mod:`vtscore.eval.al_strategies`);
-``random`` reproduces the uniform-order baseline, while uncertainty/diversity
-strategies query more informative items first.
+Which item the simulated user votes on at each step is chosen by the
+``autopilot`` vote-order strategy (see :mod:`vtscore.eval.al_strategies`): seed
+from text sort (or a few random known-good examples), then the standard
+Good / Bad / Hard / New phases.  This is the only strategy the eval runs — the
+point is to measure how the tool itself would function, not to compare
+acquisition heuristics.
 
 The result is a :class:`pandas.DataFrame` with columns
 ``seed, dataset, category, strategy, t, n_good, n_bad, cost, fpr, fnr``.
@@ -217,7 +219,7 @@ def _score_pool(
 
 
 def _build_eval_atlas(embeddings: dict[int, np.ndarray], min_node_size: int) -> Any:
-    """Build a coverage atlas over *embeddings* for the ``density_*`` strategies.
+    """Build a coverage atlas over *embeddings* for the autopilot New phase.
 
     Returns ``None`` when there are no vectors.  Uses the same hierarchical
     k-means partition the live dataset builds (see
@@ -319,9 +321,10 @@ def simulate_voting_iterations(  # noqa: C901
     calibrate_count: int = 2,
     calibration_fraction: float = 0.5,
     region_voting: bool = False,
-    strategy: str = "random",
+    strategy: str = "autopilot",
     max_steps: Optional[int] = None,
     atlas_min_node_size: int = 20,
+    seed_scores: Optional[dict[int, float]] = None,
 ) -> list[dict[str, Any]]:
     """Simulate voting on *clips_dict* and evaluate at every step.
 
@@ -347,22 +350,21 @@ def simulate_voting_iterations(  # noqa: C901
             Scoring is unaffected by this flag - a patch dataset always scores
             region-aware (max-pool over regions), so the only thing this toggles
             is the Good-vote training vector, isolating region voting's effect.
-        strategy: Active-learning acquisition strategy naming *which* pool item
-            the simulated user labels next (see
-            :data:`vtscore.eval.al_strategies.STRATEGIES`).  ``"random"``
-            (default) picks uniformly - the baseline every other strategy is
-            measured against.  Uncertainty strategies (``margin``, ``entropy``,
-            ``bald``, ``eig``) query the item the current model is least sure
-            about; ``coreset`` maximises embedding-space coverage; ``density_*``
-            variants up-weight sparsely-populated coverage-atlas cells.  Before a
-            trainable model exists (fewer than one Good *and* one Bad vote) every
-            strategy falls back to a random pick.
+        strategy: Vote-order strategy naming *which* pool item the simulated
+            user labels next (see :data:`vtscore.eval.al_strategies.STRATEGIES`).
+            Only ``"autopilot"`` (the default) exists: it reproduces the app's
+            real user flow — seed from text sort (or random known-good examples),
+            then the standard Good / Bad / Hard / New phases.
         max_steps: Cap on the number of voting steps (pool items labelled).
             ``None`` (default) votes on the entire simulation set.
         atlas_min_node_size: Minimum leaf population for the coverage atlas the
-            ``density_*`` strategies read (default 20, the production floor).
-            Lower it for small simulation sets so density cells actually resolve.
-            Ignored for non-density strategies (no atlas is built).
+            autopilot New phase reads (default 20, the production floor).  Lower
+            it for small simulation sets so diversity cells actually resolve.
+        seed_scores: Optional ``{media_id: similarity}`` text-sort ranking (each
+            item's cosine to the typed query).  When provided the autopilot seed
+            follows the text sort (top items for the initial goods, bottom items
+            for the initial bads); ``None`` (default) means the dataset has no
+            text sort, so autopilot seeds from random known-good examples.
 
     Returns:
         List of row dicts with keys ``seed, dataset, category, strategy, t,
@@ -394,17 +396,18 @@ def simulate_voting_iterations(  # noqa: C901
 
     import torch  # noqa: PLC0415
 
-    # Whole-image embeddings of the simulation pool.  These feed the acquisition
-    # strategies (uncertainty scoring, coreset distances, the density atlas);
-    # the Good-vote *training* vector can still be region-pooled below when
+    # Whole-image embeddings of the simulation pool.  These feed the autopilot
+    # selector (the example-sort good centroid and the coverage atlas); the
+    # Good-vote *training* vector can still be region-pooled below when
     # ``region_voting`` is on.
     sim_embeddings: dict[int, np.ndarray] = {
         cid: np.asarray(media_embedding(clips_dict[cid]), dtype=np.float32) for cid in sim_ids
     }
     input_dim = int(next(iter(sim_embeddings.values())).shape[0])
 
-    # The ``density_*`` strategies read a coverage atlas built over the pool.
-    atlas = _build_eval_atlas(sim_embeddings, atlas_min_node_size) if strategy.startswith("density_") else None
+    # The autopilot New phase reads a coverage atlas built over the pool; it is
+    # labelled in lock-step with the votes below so its coverage advances.
+    atlas = _build_eval_atlas(sim_embeddings, atlas_min_node_size) if strategy == "autopilot" else None
 
     # Pre-compute embeddings for safe-threshold GMM scoring.  Restrict to the
     # simulation set so the held-out ``test_ids`` never feed into the GMM that
@@ -426,20 +429,20 @@ def simulate_voting_iterations(  # noqa: C901
     labeled: dict[int, float] = {}
     rows: list[dict[str, Any]] = []
 
-    # Acquisition proceeds one vote at a time: the strategy picks the next pool
-    # item using the *current* model (the one trained at the previous step), the
-    # item's ground-truth label is revealed, and a fresh model is trained on all
-    # votes so far.  Before a trainable model exists every strategy falls back to
-    # a random pick (``model=None`` in the context below), so a cold start is
-    # always a random warm-up until one Good and one Bad vote coexist.
+    # Voting proceeds one item at a time: the autopilot selector picks the next
+    # pool item using the *current* detector (trained at the previous step), the
+    # item's ground-truth label is revealed, a fresh model is trained on all
+    # votes so far, and the coverage atlas is labelled so its New-phase coverage
+    # advances.  Before a trainable model exists the selector runs its seed/bad
+    # phases (text sort or example sort), so a cold start still makes real picks.
     pool = sorted(sim_ids)
-    # Ground-truth pool labels for the ``balanced`` oracle strategy (ignored by
-    # every label-blind strategy); cheap to build once up front.
+    # Ground-truth pool labels: autopilot draws its random known-good seed
+    # examples from the positives here when no text sort is available.  Cheap to
+    # build once up front.
     pool_labels = {cid: (1.0 if media_is_positive(clips_dict[cid], target_category) else 0.0) for cid in sim_ids}
     model: torch.nn.Sequential | None = None
     threshold = 0.5
     pool_scores: dict[int, float] = {}
-    prev_hidden_dim: int | None = None
     n_steps = len(pool) if max_steps is None else min(max_steps, len(pool))
 
     for t in range(1, n_steps + 1):
@@ -452,27 +455,31 @@ def simulate_voting_iterations(  # noqa: C901
             scores=pool_scores,
             model=model,
             threshold=threshold,
-            input_dim=input_dim,
-            hidden_dim=prev_hidden_dim,
             atlas=atlas,
             rng=rng,
             pool_labels=pool_labels,
+            seed_scores=seed_scores,
         )
         cid = select_next(strategy, ctx)
         pool.remove(cid)
-        if media_is_positive(clips_dict[cid], target_category):
+        is_positive = media_is_positive(clips_dict[cid], target_category)
+        if is_positive:
             good_votes[cid] = None
             labeled[cid] = 1.0
         else:
             bad_votes[cid] = None
             labeled[cid] = 0.0
+        # Mirror the vote onto the coverage atlas so the New phase's next_sample
+        # advances past covered regions (the app labels the atlas the same way).
+        if atlas is not None and cid in atlas.vector_to_leaf:
+            atlas.label(cid, good=is_positive)
 
         # Need at least 1 good and 1 bad to train
         if not good_votes or not bad_votes:
             model = None
             continue
 
-        model, threshold, hidden_dim, n_labels = _train_and_calibrate(
+        model, threshold, _hidden_dim, n_labels = _train_and_calibrate(
             good_votes,
             bad_votes,
             clips_dict,
@@ -494,10 +501,8 @@ def simulate_voting_iterations(  # noqa: C901
         )
 
         # Score the remaining pool with the fresh model so the next step's
-        # acquisition strategy ranks it; record the width for the next step's
-        # ``eig`` counterfactual retrains.
+        # autopilot Bad / Hard picks rank it.
         pool_scores = _score_pool(model, pool, clips_dict)
-        prev_hidden_dim = hidden_dim
 
         rows.append(
             {
@@ -534,6 +539,7 @@ def run_voting_iterations_eval(
     strategies: Optional[list[str]] = None,
     max_steps: Optional[int] = None,
     atlas_min_node_size: int = 20,
+    seed_scores: Optional[dict[str, dict[str, dict[int, float]]]] = None,
 ) -> pd.DataFrame:
     """Run the voting-iterations evaluation over multiple seeds/datasets/categories.
 
@@ -557,15 +563,18 @@ def run_voting_iterations_eval(
         region_voting: When ``True``, Good votes train on the ground-truth
             region-pooled vector for patch datasets (see
             :func:`simulate_voting_iterations`).
-        strategies: Active-learning acquisition strategies to compare (see
-            :data:`vtscore.eval.al_strategies.STRATEGIES`).  Each strategy is a
-            fourth cross-product axis (seed x dataset x category x strategy) and
-            its name is recorded in the ``strategy`` result column.  ``None``
-            (default) runs only ``"random"``.
+        strategies: Vote-order strategies to run (see
+            :data:`vtscore.eval.al_strategies.STRATEGIES`).  ``None`` (default)
+            runs ``["autopilot"]``, the only strategy; the name is recorded in
+            the ``strategy`` result column.
         max_steps: Cap on the number of voting steps per run (see
             :func:`simulate_voting_iterations`).
         atlas_min_node_size: Minimum coverage-atlas leaf population for the
-            ``density_*`` strategies (see :func:`simulate_voting_iterations`).
+            autopilot New phase (see :func:`simulate_voting_iterations`).
+        seed_scores: Optional text-sort rankings keyed
+            ``{dataset: {category: {media_id: similarity}}}``.  When a
+            (dataset, category) has an entry, the autopilot seed follows that
+            text ranking; otherwise it seeds from random known-good examples.
 
     Returns:
         A :class:`~pandas.DataFrame` with columns ``seed, dataset, category,
@@ -573,7 +582,7 @@ def run_voting_iterations_eval(
     """
     import pandas as pd  # noqa: PLC0415
 
-    strategy_list = strategies if strategies is not None else ["random"]
+    strategy_list = strategies if strategies is not None else ["autopilot"]
     all_rows: list[dict[str, Any]] = []
 
     for ds_name, clips_dict in dataset_clips.items():
@@ -591,6 +600,7 @@ def run_voting_iterations_eval(
 
         for seed in seeds:
             for cat in target_cats:
+                cat_seed_scores = (seed_scores or {}).get(ds_name, {}).get(cat)
                 for strategy in strategy_list:
                     rows = simulate_voting_iterations(
                         clips_dict,
@@ -606,6 +616,7 @@ def run_voting_iterations_eval(
                         strategy=strategy,
                         max_steps=max_steps,
                         atlas_min_node_size=atlas_min_node_size,
+                        seed_scores=cat_seed_scores,
                     )
                     all_rows.extend(rows)
 
@@ -642,6 +653,7 @@ def run_voting_iterations_eval_from_pickles(
     strategies: Optional[list[str]] = None,
     max_steps: Optional[int] = None,
     atlas_min_node_size: int = 20,
+    seed_scores: Optional[dict[str, dict[str, dict[int, float]]]] = None,
 ) -> pd.DataFrame:
     """Convenience wrapper that loads datasets from pickle files.
 
@@ -659,11 +671,14 @@ def run_voting_iterations_eval_from_pickles(
         region_voting: When ``True``, Good votes train on the ground-truth
             region-pooled vector for patch datasets (see
             :func:`simulate_voting_iterations`).
-        strategies: Acquisition strategies to compare (see
+        strategies: Vote-order strategies to run (see
             :func:`run_voting_iterations_eval`).
         max_steps: Cap on the number of voting steps per run.
         atlas_min_node_size: Minimum coverage-atlas leaf population for the
-            ``density_*`` strategies.
+            autopilot New phase.
+        seed_scores: Optional text-sort rankings keyed
+            ``{dataset: {category: {media_id: similarity}}}`` (see
+            :func:`run_voting_iterations_eval`).
 
     Returns:
         A :class:`~pandas.DataFrame` identical to :func:`run_voting_iterations_eval`
@@ -691,4 +706,5 @@ def run_voting_iterations_eval_from_pickles(
         strategies=strategies,
         max_steps=max_steps,
         atlas_min_node_size=atlas_min_node_size,
+        seed_scores=seed_scores,
     )


### PR DESCRIPTION
## Summary

The voting-iterations eval used to pick the next vote with academic active-learning acquisition rules (`margin`, `entropy`, `bald`, `eig`, `coreset`, `ensemble_std`, and the oracle `balanced`). That measures the wrong thing — the only meaningful eval is to simulate what a VTSearch user actually does. This rebuilds the eval vote system around the app's **Autopilot** flow and makes it the *only* strategy.

`autopilot` now drives every simulated vote:

1. **Seed / Good** — if the dataset can be text-sorted (caller supplies a `seed_scores` per-media cosine-to-query ranking), the user votes top-down on that ranking; otherwise the user hands the tool a few random known-good examples ("3 random examples pulled from the Good"). Target: 3 goods (matches Autopilot's `goodToStart`).
2. **Bad** — once a detector exists, its lowest-scored items are the likely bads; before that, the bottom of the text ranking, or (no text) the item least similar to the good centroid via an example sort. Target: 4 bads (`badToStart`).
3. **Hard / New** — past the quorum, interleave *refine-boundary* (Hard = item nearest the decision threshold) and *explore-diversity* (New = the coverage atlas's next under-explored region), exactly the picks the app's Hard/New phases make. The eval labels the coverage atlas in lock-step so its coverage advances.

All the artificial strategies are gone — `random` included. `autopilot` is the sole entry in the strategy registry.

## Changes

- **`vtscore/eval/al_strategies.py`** — replaced the acquisition-scorer registry (and the density-weighting machinery) with the single `autopilot` selector. `ALContext` drops the now-unused `input_dim`/`hidden_dim` and gains `seed_scores` (the optional text-sort ranking). `STRATEGIES`/`select_next`/`available_strategies` are kept so the harness interface is unchanged.
- **`vtscore/eval/voting_iterations.py`** — default strategy is now `autopilot`; builds and labels the coverage atlas for the New phase; threads `seed_scores` (per `{dataset: {category: {media_id: similarity}}}`) through `simulate_voting_iterations` / `run_voting_iterations_eval` / `…_from_pickles`.
- **`vtscore/eval/al_benchmark.py`** — hermetic harness now runs `autopilot` by default; docstrings/CLI help reframed off the strategy-comparison framing.
- **`scripts/run_mlp_ensemble_sweep.py`** — throwaway sweep's voting axis switched to `autopilot`.
- **Docs** — `docs/EVAL.md` and `vtscore/docs/packages/eval.md` now describe the Autopilot vote order and the `seed_scores` option; corrected the stale "shuffled order" description and added the `strategy` column.
- **Tests** — rewrote `test_al_strategies.py` around the autopilot phase logic (hermetic, no model downloads); updated `test_eval_voting_iterations.py`, `test_al_benchmark.py`, and `test_eval_visualize.py` for the autopilot-only world.

## Backwards compatibility

Breaking (per repo policy, no shims): the `random`/`margin`/`entropy`/`bald`/`eig`/`coreset`/`ensemble_std`/`balanced`/`density_*` strategy names no longer exist — `select_next("random", …)` now raises `KeyError`. Result rows still carry a `strategy` column, now always `"autopilot"`.

## Testing

`./run-tests.sh` — all 6415 tests pass (ruff / format / codespell / deptry / pip-audit / pyright clean).

Closes #2604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BN3dqSLh1gybAVqznqSZUU)_