### PR TITLE
Adaptively pace the dataset-load bar per phase, calibrated from GRID runs

### DIFF
--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -258,14 +258,12 @@ export function formatProgressHeader(
       phase = 'arranging';
       subtitle = 'Arranging the items so the dataset can be browsed as a map.';
     }
+  } else if (status === 'extracting' || (status === 'downloading' && /extract/i.test(message))) {
+    phase = 'unpacking archive';
+    subtitle = 'Extracting the downloaded archive into the dataset cache.';
   } else if (status === 'downloading') {
-    if (/extract/i.test(message)) {
-      phase = 'unpacking archive';
-      subtitle = 'Extracting the downloaded archive into the dataset cache.';
-    } else {
-      phase = 'downloading source';
-      subtitle = 'Fetching the dataset archive. Cached on disk for next time.';
-    }
+    phase = 'downloading source';
+    subtitle = 'Fetching the dataset archive. Cached on disk for next time.';
   } else if (status === 'embedding') {
     phase = 'analyzing files';
   } else if (status === 'loading' && /embedding model/i.test(message)) {

--- a/scripts/profiling/fit_load_weights.py
+++ b/scripts/profiling/fit_load_weights.py
@@ -5,10 +5,11 @@ Reads the per-phase rows emitted by ``calibrate_load_weights.py`` (via the
 ``VTSEARCH_PROFILE_LOAD`` recorder) and, per ``(device, media_type, embedder)``,
 fits:
 
-    T_model    ≈ a_model                      (median warm model-load seconds)
+    T_load     ≈ a_model + b_load · n         (warm model load + per-item decode, least-squares vs n)
     T_embed    ≈ a_embed + b_embed · n        (least-squares vs n)
     T_finalize ≈ a_fin   + b_fin   · n        (least-squares vs n)
     bandwidth  ≈ download_size_mb / seconds   (cold-download rows, device-pooled)
+    extract    ≈ download_size_mb / seconds   (extract rows, pooled)
 
 and prints (a) a checked-in ``_load_cost_model.py`` body and (b) a human-readable
 summary table for docs/plans/progress-weight-calibration.md. See that plan.
@@ -74,6 +75,7 @@ def main() -> int:
     # Group phase-seconds by (device, media, embedder).
     groups: dict[tuple[str, str, str], dict[str, list[tuple[float, float]]]] = defaultdict(lambda: defaultdict(list))
     dl_by_device: dict[str, list[tuple[float, float]]] = defaultdict(list)  # (size_mb, seconds)
+    extract_pts: list[tuple[float, float]] = []  # (size_mb, seconds), device-pooled
     for r in rows:
         key = (r["device"], r["media_type"], r["embedder"])
         phase = r["phase"]
@@ -82,6 +84,12 @@ def main() -> int:
         if phase == "download":
             if r.get("cold_download") and r.get("download_size_mb"):
                 dl_by_device[r["device"]].append((float(r["download_size_mb"]), secs))
+            continue
+        if phase == "extract":
+            # Only a cold acquire actually unpacks; a cached extract dir skips
+            # the phase entirely, so any recorded row is a real extraction.
+            if r.get("download_size_mb") and secs > 0.1:
+                extract_pts.append((float(r["download_size_mb"]), secs))
             continue
         if phase.startswith("finalize:"):
             continue  # sub-slots: deferred (see plan follow-ups)
@@ -107,8 +115,18 @@ def main() -> int:
         # Warm loads skip the model phase, so a warm row is rare; floor when
         # absent. Never fall back to the (large) cold value for pacing.
         warm = g.get("model_warm")
-        a_model = statistics.median([s for _, s in warm]) if warm else _WARM_MODEL_FLOOR_S
         cold_rows = g.get("model_cold")
+        # The "model_load" phase is warm model load PLUS per-item source
+        # decode, so it scales with n: fit an affine a_model + b_load·n from
+        # the warm rows (cold rows fold in the one-time encoder download, so
+        # they only feed the intercept fallback / note).
+        if warm:
+            m_xs = [n for n, _ in warm]
+            m_ys = [s for _, s in warm]
+            a_model, b_load, r2_m = _affine_fit(m_xs, m_ys)
+            a_model = max(_WARM_MODEL_FLOOR_S if b_load <= 0 else 0.0, a_model)
+        else:
+            a_model, b_load, r2_m = _WARM_MODEL_FLOOR_S, 0.0, 0.0
         cold_model = statistics.median([s for _, s in cold_rows]) if cold_rows else a_model
         e_xs = [n for n, _ in g.get("embed", [])]
         e_ys = [s for _, s in g.get("embed", [])]
@@ -117,14 +135,15 @@ def main() -> int:
         f_ys = [s for _, s in g.get("finalize", [])]
         a_f, b_f, r2_f = _affine_fit(f_xs, f_ys)
         model[key] = {
-            "a_model": round(a_model, 4),
+            "a_model": round(max(0.0, a_model), 4),
+            "b_load": round(max(0.0, b_load), 6),
             "a_embed": round(max(0.0, a_e), 4),
             "b_embed": round(max(0.0, b_e), 6),
             "a_fin": round(max(0.0, a_f), 4),
             "b_fin": round(max(0.0, b_f), 6),
         }
         summary_lines.append(
-            f"| {dev} | {media} | {emb} | {a_model:.2f} (cold {cold_model:.1f}) | "
+            f"| {dev} | {media} | {emb} | {a_model:.2f}+{b_load * 1000:.2f}m·n (cold {cold_model:.1f}) | {r2_m:.2f} | "
             f"{a_e:.2f}+{b_e * 1000:.2f}m·n | {r2_e:.2f} | {a_f:.2f}+{b_f * 1000:.2f}m·n | {r2_f:.2f} | "
             f"{len(e_xs)} |"
         )
@@ -137,11 +156,14 @@ def main() -> int:
     print("}")
     bw_val = statistics.median(list(bw.values())) if bw else 0.0
     print(f"DOWNLOAD_MB_PER_S = {round(bw_val, 3)}  # per-device: {bw}")
+    ex_rates = [size / s for size, s in extract_pts if s > 0]
+    ex_val = statistics.median(ex_rates) if ex_rates else 0.0
+    print(f"EXTRACT_MB_PER_S = {round(ex_val, 3)}  # {len(extract_pts)} extractions")
     print()
     # ---- human-readable summary (paste under Results) ----
     print("# ===== summary =====")
-    print("| device | media | embedder | a_model s (cold) | embed a+b·n | R² | finalize a+b·n | R² | pts |")
-    print("|--------|-------|----------|------------------|-------------|----|----------------|----|----|")
+    print("| device | media | embedder | load a+b·n s (cold) | R² | embed a+b·n | R² | finalize a+b·n | R² | pts |")
+    print("|--------|-------|----------|---------------------|----|-------------|----|----------------|----|----|")
     for line in summary_lines:
         print(line)
     return 0

--- a/tests_lib/core/test_progress_overall.py
+++ b/tests_lib/core/test_progress_overall.py
@@ -34,6 +34,17 @@ class TestOverallFraction:
         t.update("embedding", "emb", current=5, total=10, step=3, total_steps=4)
         assert t.get()["overall"] == pytest.approx(0.625)
 
+    def test_within_override_beats_current_total(self):
+        t = _tracker()
+        # The ``within`` kwarg drives the overall math while current/total keep
+        # the caller's real counts (download bytes stay visible in the UI); the
+        # AdaptiveLoadPacer uses it to composite step-1 sub-phases.
+        t.update("downloading", "dl", current=999_999, total=4_000_000, step=1, total_steps=4, within=0.5)
+        snap = t.get()
+        assert snap["overall"] == pytest.approx(0.125)
+        assert snap["current"] == 999_999
+        assert snap["total"] == 4_000_000
+
     def test_step_floor_when_within_unknown(self):
         t = _tracker()
         # Indeterminate sub-step (total=0): the bar sits at the step floor, not

--- a/tests_lib/datasets/test_adaptive_load_pacer.py
+++ b/tests_lib/datasets/test_adaptive_load_pacer.py
@@ -1,0 +1,206 @@
+"""AdaptiveLoadPacer: composite step-1 pacing + evidence-based rebasing.
+
+The pacer fixes the two remaining miscalibration modes from issue #2556:
+a bar frozen (ETA climbing) through archive extraction, and weights that
+budget for a download/decode that never happens (cached archive, cached
+embedded pkl) or happens at a very different speed than calibrated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.concurrency.progress import ProgressTracker
+from vtscore.datasets.stages import _common
+from vtscore.datasets.stages._common import AdaptiveLoadPacer
+
+_OVERALL_EXTRAS = {"step": None, "total_steps": None, "overall": None, "eta_seconds": None}
+
+
+class _Clock:
+    """Deterministic stand-in for time.monotonic."""
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+@pytest.fixture()
+def clock(monkeypatch):
+    c = _Clock()
+    monkeypatch.setattr(_common.time, "monotonic", c)
+    return c
+
+
+def _make(terms):
+    tracker = ProgressTracker(extra_fields=dict(_OVERALL_EXTRAS))
+    pacer = AdaptiveLoadPacer(tracker, terms)
+    return tracker, pacer
+
+
+def _overall(tracker) -> float:
+    return tracker.get()["overall"]
+
+
+TERMS = {"download": 10.0, "extract": 5.0, "load": 5.0, "embed": 20.0, "finalize": 10.0}
+
+
+def test_extraction_advances_the_bar_after_download(clock):
+    tracker, pacer = _make(TERMS)
+    pacer.update("downloading", "dl", 0, 100, step=1)
+    clock.advance(1.0)
+    pacer.update("downloading", "dl", 100, 100, step=1)
+    after_download = _overall(tracker)
+    assert after_download > 0
+
+    # Extraction reports on a different scale; the bar must keep moving.
+    clock.advance(0.5)
+    pacer.update("extracting", "unpack", 0, 400, step=1)
+    clock.advance(1.0)
+    pacer.update("extracting", "unpack", 200, 400, step=1)
+    mid_extract = _overall(tracker)
+    assert mid_extract > after_download
+    clock.advance(1.0)
+    pacer.update("extracting", "unpack", 400, 400, step=1)
+    assert _overall(tracker) > mid_extract
+
+
+def test_cached_archive_does_not_leap_the_bar(clock):
+    # A cache-backed load never fires download/extract: the first status is
+    # already "loading". The acquire slice must collapse instead of the bar
+    # leaping straight to its end (the Caltech-101 0 -> 49% jump).
+    tracker, pacer = _make(TERMS)
+    pacer.update("loading", "Loading cached dataset...", 0, 0, step=2)
+    assert _overall(tracker) == pytest.approx(0.0, abs=1e-9)
+    pacer.update("loading", "Loading cached dataset...", 1, 2, step=2)
+    # load's rebased share: 5 / (5 + 20 + 10) of the whole bar; half done.
+    assert _overall(tracker) == pytest.approx(0.5 * 5 / 35, rel=1e-6)
+
+
+def test_skipping_straight_to_embed_rebases_over_remaining_phases(clock):
+    tracker, pacer = _make(TERMS)
+    pacer.update("embedding", "embed", 10, 100, step=3)
+    # embed's share of the remaining bar: 20 / (20 + 10).
+    assert _overall(tracker) == pytest.approx(0.1 * 20 / 30, rel=1e-6)
+
+
+def test_full_phase_sequence_is_monotone_and_ends_at_one(clock):
+    tracker, pacer = _make(TERMS)
+    seen = []
+
+    def push(status, cur, tot, step):
+        pacer.update(status, status, cur, tot, step=step)
+        seen.append(_overall(tracker))
+        clock.advance(0.7)
+
+    push("downloading", 0, 100, 1)
+    push("downloading", 60, 100, 1)
+    push("extracting", 1, 10, 1)
+    push("extracting", 10, 10, 1)
+    push("loading", 0, 0, 2)
+    push("loading", 3, 4, 2)
+    push("embedding", 50, 100, 3)
+    push("embedding", 100, 100, 3)
+    pacer.update("loading", "finalize", 500, 1000, step=4)
+    seen.append(_overall(tracker))
+    pacer.update("loading", "finalize", 1000, 1000, step=4)
+    seen.append(_overall(tracker))
+
+    assert all(b >= a - 1e-9 for a, b in zip(seen, seen[1:]))
+    assert seen[-1] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_observed_rate_shrinks_an_overweighted_download(clock):
+    # The model predicts a 100s download (10MB/s prior for a 1000MB archive),
+    # but the link is 10x faster. Once the pacer trusts the observed rate the
+    # acquire slice shrinks toward its real share.
+    terms = {"download": 100.0, "extract": 5.0, "load": 5.0, "embed": 20.0, "finalize": 10.0}
+    tracker, pacer = _make(terms)
+    pacer.update("downloading", "dl", 0, 1000, step=1)
+    clock.advance(5.0)  # 500MB in 5s -> projected 10s total, not 100s
+    pacer.update("downloading", "dl", 500, 1000, step=1)
+    assert pacer._terms["download"] == pytest.approx(10.0)
+    clock.advance(5.0)
+    pacer.update("downloading", "dl", 1000, 1000, step=1)
+    # With the corrected term, a finished download consumed ~10/50 of the bar,
+    # nowhere near the ~71% the stale prior would have claimed.
+    assert _overall(tracker) < 0.35
+
+
+def test_multi_archive_alternation_stays_monotone(clock):
+    tracker, pacer = _make(TERMS)
+    seen = []
+    for _ in range(3):  # three download->extract cycles (e.g. TUT's zips)
+        pacer.update("downloading", "dl", 0, 100, step=1)
+        clock.advance(1.0)
+        pacer.update("downloading", "dl", 100, 100, step=1)
+        seen.append(_overall(tracker))
+        pacer.update("extracting", "unpack", 0, 10, step=1)
+        clock.advance(1.0)
+        pacer.update("extracting", "unpack", 10, 10, step=1)
+        seen.append(_overall(tracker))
+    assert all(b >= a - 1e-9 for a, b in zip(seen, seen[1:]))
+    assert seen[-1] < 1.0  # step 1 never claims the whole bar
+
+    pacer.update("embedding", "embed", 100, 100, step=3)
+    assert _overall(tracker) >= seen[-1]
+
+
+def test_step1_counts_pass_through_unchanged(clock):
+    # The UI formats download bytes (e.g. "0.86/1.14GB") from current/total;
+    # the pacer must not replace them with a synthetic scale.
+    tracker, pacer = _make(TERMS)
+    pacer.update("downloading", "dl", 12345, 67890, step=1)
+    snap = tracker.get()
+    assert snap["current"] == 12345
+    assert snap["total"] == 67890
+
+
+def test_finalize_progress_composes_with_pacer(clock):
+    from vtscore.datasets.stages._common import FinalizeProgress
+
+    tracker, pacer = _make(TERMS)
+    pacer.update("embedding", "embed", 100, 100, step=3)
+    at_finalize_start = _overall(tracker)
+    fin = FinalizeProgress(pacer)
+    fin.begin("registry")
+    fin.update("loading", "Saving to registry…", 1, 2)
+    assert _overall(tracker) > at_finalize_start
+    fin.begin("projection")
+    fin.update("loading", "Projecting…", 1, 1)
+    assert _overall(tracker) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_unmapped_status_passes_through(clock):
+    tracker, pacer = _make(TERMS)
+    pacer.update("someday-status", "x", 1, 2, step=None)
+    snap = tracker.get()
+    assert snap["overall"] is None
+    assert snap["current"] == 1
+
+
+def test_slow_phase_grows_its_span_and_the_bar_follows(clock):
+    # GTZAN live run (2026-07-18): decode ran ~11x its calibrated term while
+    # its bar span stayed tiny, so the rate-extrapolated overall ETA ballooned
+    # to ~55min for a 3min load. The pacer must re-estimate the *current*
+    # phase's term from its observed pace, not only the download's.
+    terms = {"download": 0.0, "extract": 0.0, "load": 10.0, "embed": 60.0, "finalize": 5.0}
+    tracker, pacer = _make(terms)
+    pacer.update("loading", "decode", 0, 1000, step=2)
+    static_share = 10.0 / 75.0
+    # Half the files done, but ten times slower than the term predicted: the
+    # projected phase total (100s) must displace the calibrated 10s, growing
+    # load's share of the bar well past its static allocation.
+    clock.advance(50.0)
+    pacer.update("loading", "decode", 500, 1000, step=2)
+    halfway = _overall(tracker)
+    assert halfway > static_share
+    # Finishing the phase still lands short of 100% — embed+finalize remain.
+    clock.advance(50.0)
+    pacer.update("loading", "decode", 1000, 1000, step=2)
+    assert halfway < _overall(tracker) < 1.0

--- a/tests_lib/datasets/test_load_profiler.py
+++ b/tests_lib/datasets/test_load_profiler.py
@@ -55,6 +55,22 @@ def _drive_phases(tracker: ProgressTracker) -> None:
         tracker.update("loading", "", step=step, total_steps=4)
 
 
+def test_extracting_status_records_its_own_phase(monkeypatch, tmp_path, clean_seen_embedders):
+    """Step 1's two sub-phases (download vs extract) land as separate rows, so
+    the fit can estimate an extraction rate independent of network bandwidth."""
+    out = tmp_path / "prof.jsonl"
+    monkeypatch.setenv("VTSEARCH_PROFILE_LOAD", str(out))
+    tracker = _make_tracker()
+    prof = start_profiler(tracker, "audio", "clap")
+    tracker.update("downloading", "", 0, 100, step=1, total_steps=4)
+    tracker.update("extracting", "", 0, 10, step=1, total_steps=4)
+    tracker.update("loading", "", step=2, total_steps=4)
+    tracker.update("embedding", "", step=3, total_steps=4)
+    prof.finish(n=5, dataset_id="demo_x")
+    phases = [r["phase"] for r in _read_rows(out)]
+    assert phases[:4] == ["download", "extract", "model_load", "embed"]
+
+
 def _read_rows(path) -> list[dict]:
     with open(path, encoding="utf-8") as fh:
         return [json.loads(line) for line in fh if line.strip()]

--- a/tests_lib/datasets/test_load_step_weights.py
+++ b/tests_lib/datasets/test_load_step_weights.py
@@ -86,9 +86,10 @@ import pytest  # noqa: E402
 from vtscore.datasets.stages import _load_cost_model as _cm  # noqa: E402
 
 
-def _inject_row(monkeypatch, key, coeffs, *, bandwidth=10.0):
+def _inject_row(monkeypatch, key, coeffs, *, bandwidth=10.0, extract_rate=50.0):
     monkeypatch.setattr(_cm, "LOAD_COST_MODEL", {key: coeffs})
     monkeypatch.setattr(_cm, "DOWNLOAD_MB_PER_S", bandwidth)
+    monkeypatch.setattr(_cm, "EXTRACT_MB_PER_S", extract_rate)
 
 
 def test_n_aware_weights_come_from_cost_model(monkeypatch):
@@ -98,11 +99,42 @@ def test_n_aware_weights_come_from_cost_model(monkeypatch):
         ("cuda", "image", "siglip"),
         {"a_model": 0.3, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.002},
         bandwidth=10.0,
+        extract_rate=50.0,
     )
     w = load_step_weights("image", n=1000, download_size_mb=100.0, embedder="siglip")
-    # T = [download 100/10=10, model 0.3, embed 1+10=11, finalize 1+2=3] -> /24.3
-    assert w == pytest.approx([10 / 24.3, 0.3 / 24.3, 11 / 24.3, 3 / 24.3])
+    # T = [acquire 100/10 + 100/50 = 12, model 0.3, embed 1+10=11, finalize 1+2=3] -> /26.3
+    assert w == pytest.approx([12 / 26.3, 0.3 / 26.3, 11 / 26.3, 3 / 26.3])
     assert sum(w) == pytest.approx(1.0)
+
+
+def test_cost_model_terms_include_extract_and_per_item_load(monkeypatch):
+    _inject_row(
+        monkeypatch,
+        ("cuda", "image", "siglip"),
+        {"a_model": 0.5, "b_load": 0.02, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.002},
+        bandwidth=10.0,
+        extract_rate=50.0,
+    )
+    terms = _cm.cost_model_terms("cuda", "image", "siglip", n=1000, download_size_mb=100.0)
+    assert terms is not None
+    assert terms["download"] == pytest.approx(10.0)
+    assert terms["extract"] == pytest.approx(2.0)
+    # load = warm model (0.5) + per-item decode (0.02 * 1000)
+    assert terms["load"] == pytest.approx(20.5)
+    assert terms["embed"] == pytest.approx(11.0)
+    assert terms["finalize"] == pytest.approx(3.0)
+
+
+def test_cost_model_terms_collapse_acquire_when_no_archive(monkeypatch):
+    _inject_row(
+        monkeypatch,
+        ("cuda", "image", "siglip"),
+        {"a_model": 0.5, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.002},
+    )
+    terms = _cm.cost_model_terms("cuda", "image", "siglip", n=1000, download_size_mb=None)
+    assert terms is not None
+    assert terms["download"] == 0.0
+    assert terms["extract"] == 0.0
 
 
 def test_small_n_weights_model_heavier_and_large_n_weights_embed_heavier(monkeypatch):
@@ -157,10 +189,27 @@ def test_shipped_cost_model_table_is_well_formed():
     # Every checked-in coefficient row has the affine keys and yields a
     # normalized weight vector; empty table (pre-calibration) trivially passes.
     for key, coeffs in _cm.LOAD_COST_MODEL.items():
-        assert set(coeffs) >= {"a_model", "a_embed", "b_embed", "a_fin", "b_fin"}
+        assert set(coeffs) >= {"a_model", "b_load", "a_embed", "b_embed", "a_fin", "b_fin"}
         device, media, embedder = key
         w = _cm.cost_model_weights(device, media, embedder, n=1000, download_size_mb=100.0)
         assert w is not None
         assert len(w) == _TOTAL_LOAD_STEPS
         assert all(x >= 0 for x in w)
         assert sum(w) == pytest.approx(1.0)
+    assert _cm.EXTRACT_MB_PER_S > 0
+    assert _cm.DOWNLOAD_MB_PER_S > 0
+
+
+def test_load_cost_terms_static_fallback_splits_acquire(monkeypatch):
+    from vtscore.datasets.stages._common import load_cost_terms
+
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cpu")
+    # No n -> static pseudo-terms; the acquire slice splits download/extract
+    # and the four step sums reproduce the static profile exactly.
+    terms = load_cost_terms("audio")
+    assert set(terms) == {"download", "extract", "load", "embed", "finalize"}
+    assert terms["download"] + terms["extract"] == pytest.approx(_LOAD_STEP_WEIGHTS_CPU[0])
+    assert terms["load"] == pytest.approx(_LOAD_STEP_WEIGHTS_CPU[1])
+    assert terms["embed"] == pytest.approx(_LOAD_STEP_WEIGHTS_CPU[2])
+    assert terms["finalize"] == pytest.approx(_LOAD_STEP_WEIGHTS_CPU[3])
+    assert terms["download"] > terms["extract"] > 0

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -140,7 +140,7 @@ class ProgressTracker:
             self._step_weights = [float(w) for w in weights] if weights else None
 
     def _compute_overall(
-        self, current: int, total: int, step: Any, total_steps: Any
+        self, current: int, total: int, step: Any, total_steps: Any, within_override: Optional[float] = None
     ) -> tuple[Optional[float], Optional[float]]:
         """Compute the whole-job completion fraction and a true overall ETA.
 
@@ -166,7 +166,9 @@ class ProgressTracker:
 
         s = min(max(int(step), 1), int(total_steps))
         within = 0.0
-        if total and total > 0:
+        if within_override is not None:
+            within = min(max(within_override, 0.0), 1.0)
+        elif total and total > 0:
             within = min(max(current / total, 0.0), 1.0)
         raw = self._overall_raw_fraction(within, s, total_steps)
 
@@ -224,8 +226,13 @@ class ProgressTracker:
             current: Number of units completed so far.
             total: Total number of units expected (0 if unknown).
             **kwargs: Values for any extra fields declared at construction.
-                Unrecognised keys are silently ignored.
+                Unrecognised keys are silently ignored. The reserved key
+                ``within`` (float 0..1) overrides the within-step fraction
+                used for the whole-job ``overall`` math without touching the
+                displayed ``current``/``total`` — pacing layers use it to
+                composite sub-phases while byte/item counts stay visible.
         """
+        within_override = kwargs.pop("within", None)
         with self._lock:
             self._data["status"] = status
             self._data["message"] = message
@@ -242,7 +249,7 @@ class ProgressTracker:
             overall_eta = None
             if "overall" in self._extra_defaults or "eta_seconds" in self._extra_defaults:
                 overall, overall_eta = self._compute_overall(
-                    current, total, self._data.get("step"), self._data.get("total_steps")
+                    current, total, self._data.get("step"), self._data.get("total_steps"), within_override
                 )
             if "overall" in self._extra_defaults:
                 self._data["overall"] = overall

--- a/vtscore/datasets/archive.py
+++ b/vtscore/datasets/archive.py
@@ -172,7 +172,7 @@ def extract_archive(
             total = len(members)
             for i, member in enumerate(members, 1):
                 on_progress(
-                    "loading",
+                    "extracting",
                     f"Extracting {member.split('/')[-1]}...",
                     i,
                     total,
@@ -186,7 +186,7 @@ def extract_archive(
             total = len(members)
             for i, member in enumerate(members, 1):
                 on_progress(
-                    "loading",
+                    "extracting",
                     f"Extracting {member.name.split('/')[-1]}...",
                     i,
                     total,
@@ -205,7 +205,7 @@ def extract_archive(
             total = len(members)
             for i, member in enumerate(members, 1):
                 on_progress(
-                    "loading",
+                    "extracting",
                     f"Extracting {member.split('/')[-1]}...",
                     i,
                     total,

--- a/vtscore/datasets/downloader/_hf_parquet.py
+++ b/vtscore/datasets/downloader/_hf_parquet.py
@@ -125,7 +125,7 @@ def extract_images_to_folders(
     global_idx = 0  # monotonic across shards so id_of(row, idx) never collides
     for si, shard in enumerate(shard_paths):
         on_progress(
-            "downloading",
+            "extracting",
             f"Extracting {dataset_name} images (shard {si + 1}/{len(shard_paths)})...",
             si,
             len(shard_paths),
@@ -146,6 +146,6 @@ def extract_images_to_folders(
             written += 1
             if written % 500 == 0:
                 on_progress(
-                    "downloading", f"Extracting {dataset_name} images ({written} written)...", si, len(shard_paths)
+                    "extracting", f"Extracting {dataset_name} images ({written} written)...", si, len(shard_paths)
                 )
-    on_progress("downloading", f"Extracting {dataset_name} images...", len(shard_paths), len(shard_paths))
+    on_progress("extracting", f"Extracting {dataset_name} images...", len(shard_paths), len(shard_paths))

--- a/vtscore/datasets/downloader/audio.py
+++ b/vtscore/datasets/downloader/audio.py
@@ -228,7 +228,7 @@ def download_tut_sound_events_2017(on_progress: Optional[ProgressCallback] = Non
             on_progress("downloading", f"Downloading TUT Sound Events 2017 ({slug})...", i, total)
             _core.download_file_with_progress(url, zip_path, 0, on_progress)
 
-            on_progress("downloading", f"Extracting TUT Sound Events 2017 ({slug})...", i + 1, total)
+            on_progress("extracting", f"Extracting TUT Sound Events 2017 ({slug})...", i + 1, total)
             dest_dir.mkdir(parents=True, exist_ok=True)
             with zipfile.ZipFile(zip_path, "r") as zf:
                 for member in zf.namelist():

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -630,13 +630,13 @@ def _extract_7z(archive_path: Path, dest_dir: Path, dataset_name: str, on_progre
     from vtscore.datasets.archive import _reject_traversal  # noqa: PLC0415
 
     dest_resolved = Path(dest_dir).resolve()
-    on_progress("downloading", f"Extracting {dataset_name}...", 0, 0)
+    on_progress("extracting", f"Extracting {dataset_name}...", 0, 0)
     with py7zr.SevenZipFile(archive_path, mode="r") as archive:
         for name in archive.getnames():
             _reject_traversal(dest_resolved, name)
         # Safe: every member name was traversal-checked against dest_dir above.
         archive.extractall(path=dest_dir)  # noqa: S202
-    on_progress("downloading", f"Extracting {dataset_name}...", 1, 1)
+    on_progress("extracting", f"Extracting {dataset_name}...", 1, 1)
 
 
 def _extract_archive(
@@ -665,9 +665,9 @@ def _extract_archive(
             with tarfile.open(fileobj=raw_f, mode=mode) as tar_ref:
                 for i, member in enumerate(tar_ref):
                     if i % 100 == 0:
-                        on_progress("downloading", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes)
+                        on_progress("extracting", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes)
                     safe_tar_extract(tar_ref, member, dest_dir)
-        on_progress("downloading", f"Extracting {dataset_name}...", total_bytes, total_bytes)
+        on_progress("extracting", f"Extracting {dataset_name}...", total_bytes, total_bytes)
     elif suffix.endswith(".zip"):
         from vtscore.datasets.archive import _reject_traversal
 
@@ -677,7 +677,7 @@ def _extract_archive(
             total = len(members)
             for i, member in enumerate(members):
                 if i % 100 == 0 or i == total - 1:
-                    on_progress("downloading", f"Extracting {dataset_name}...", i + 1, total)
+                    on_progress("extracting", f"Extracting {dataset_name}...", i + 1, total)
                 # Guard against path traversal in zip entries.  Shares the
                 # strict check with archive.py: the previous inline
                 # startswith() prefix test lacked a trailing separator, so
@@ -774,7 +774,7 @@ def _download_and_extract(
         # error page (e.g. 404/503) which gets saved with a .tar.gz extension.
         _validate_archive(temp_archive, archive_name, dataset_name)
 
-        on_progress("downloading", f"Extracting {dataset_name}...", 0, 0)
+        on_progress("extracting", f"Extracting {dataset_name}...", 0, 0)
         temp_extract.mkdir(parents=True, exist_ok=True)
 
         _extract_archive(temp_archive, archive_name, temp_extract, dataset_name, on_progress)

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -93,7 +93,7 @@ def _extract_members(members, extract_one, on_progress, message: str, *, start: 
     for offset, member in enumerate(members):
         i = offset + start
         if i % 100 == 0 or i == total - (1 - start):
-            on_progress("downloading", message, offset + 1, total)
+            on_progress("extracting", message, offset + 1, total)
         extract_one(member)
 
 
@@ -143,7 +143,7 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
         if categories_dir.exists():
             return categories_dir
 
-        on_progress("downloading", "Extracting Caltech-101 zip...", 0, 0)
+        on_progress("extracting", "Extracting Caltech-101 zip...", 0, 0)
         temp_extract.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(temp_archive, "r") as zip_ref:
             _extract_members(
@@ -158,7 +158,7 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
         # Extract it to produce the actual category directories.
         inner_tar = temp_extract / "caltech-101" / "101_ObjectCategories.tar.gz"
         if inner_tar.exists():
-            on_progress("downloading", "Extracting 101_ObjectCategories...", 0, 0)
+            on_progress("extracting", "Extracting 101_ObjectCategories...", 0, 0)
             inner_dest = temp_extract / "caltech-101"
             with tarfile.open(inner_tar, "r:gz") as tar_ref:
                 _extract_members(

--- a/vtscore/datasets/downloader/text.py
+++ b/vtscore/datasets/downloader/text.py
@@ -199,7 +199,7 @@ def _ensure_bbc_extracted(extract_dir: Path, on_progress: ProgressCallback) -> N
         )
 
         if not extract_dir.exists():
-            on_progress("downloading", "Extracting BBC News dataset...", 0, 0)
+            on_progress("extracting", "Extracting BBC News dataset...", 0, 0)
             raw_dir = temp_extract / "raw"
             raw_dir.mkdir(parents=True, exist_ok=True)
             with zipfile.ZipFile(temp_archive, "r") as zip_ref:
@@ -210,7 +210,7 @@ def _ensure_bbc_extracted(extract_dir: Path, on_progress: ProgressCallback) -> N
                 for i, member in enumerate(members):
                     if i % 100 == 0 or i == total - 1:
                         on_progress(
-                            "downloading",
+                            "extracting",
                             "Extracting BBC News dataset...",
                             i + 1,
                             total,

--- a/vtscore/datasets/downloader/video.py
+++ b/vtscore/datasets/downloader/video.py
@@ -217,7 +217,7 @@ def download_kth(on_progress: Optional[ProgressCallback] = None) -> Path:
             on_progress("downloading", f"Downloading KTH {action}...", i, total)
             _core.download_file_with_progress(url, zip_path, 0, on_progress)
 
-            on_progress("downloading", f"Extracting KTH {action}...", i + 1, total)
+            on_progress("extracting", f"Extracting KTH {action}...", i + 1, total)
             cat_dir.mkdir(parents=True, exist_ok=True)
             with zipfile.ZipFile(zip_path, "r") as zf:
                 for member in zf.namelist():

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -36,10 +36,12 @@ from vtscore.datasets.registry import unregister_dataset as _reg_unregister
 from vtscore.state import DatasetContext, clear_all, register_context
 
 from vtscore.datasets.stages._common import (
+    AdaptiveLoadPacer,
     FinalizeProgress,
     _STATUS_TO_STEP,
     _TOTAL_LOAD_STEPS,
     _origin_to_str,
+    load_cost_terms,
     load_step_weights,
 )
 from vtscore.datasets.stages._load_profiler import start_profiler
@@ -243,22 +245,23 @@ class _LoadGateController:
         self._held = None
 
 
-def _make_stepped_progress(controller: _LoadGateController, tracker):
+def _make_stepped_progress(controller: _LoadGateController, pacer):
     """Build the importer-side progress callback.
 
-    Routes status updates into *tracker* with the right step number, and
-    triggers the download→embed gate swap on the first ``"embedding"``
-    status so a queued download can start.
+    Routes status updates into the load's :class:`AdaptiveLoadPacer` (which
+    maps them onto the unified bar) with the right step number, and triggers
+    the download→embed gate swap on the first ``"embedding"`` status so a
+    queued download can start.
     """
 
     def stepped(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
-        tracker.check_cancelled()
+        pacer.check_cancelled()
         if status == "idle":
             return
         if status == "embedding" and controller.held != "embed":
             controller.swap_to_embed()
         step = _STATUS_TO_STEP.get(status)
-        tracker.update(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
+        pacer.update(status, message, current, total, step=step, total_steps=_TOTAL_LOAD_STEPS)
 
     return stepped
 
@@ -455,14 +458,21 @@ def _run_origin_load_in_background(
         context_id = task_id
         registry_entry_id: str | None = None
         controller = _LoadGateController(tracker)
-        stepped = _make_stepped_progress(controller, tracker)
+        # Pace the unified bar from the per-phase cost terms, rebasing on what
+        # actually happens (cached archives, observed bandwidth, skipped
+        # phases). All stage progress below routes through the pacer.
+        pacer = AdaptiveLoadPacer(
+            tracker,
+            load_cost_terms(media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder),
+        )
+        stepped = _make_stepped_progress(controller, pacer)
         profiler.bind_thread()  # so FinalizeProgress.begin stamps land here (no-op when off)
 
         try:
             with thread_user(request_user), thread_dataset_context(ctx):
                 try:
                     controller.acquire_download()
-                    tracker.update("loading", "Preparing new dataset…", 0, 0, step=1, total_steps=_TOTAL_LOAD_STEPS)
+                    pacer.update("loading", "Preparing new dataset…", 0, 0, step=1, total_steps=_TOTAL_LOAD_STEPS)
                     register_context(ctx)
                     gc.collect()
 
@@ -492,15 +502,15 @@ def _run_origin_load_in_background(
 
                     apply_custom_metadata_md5(ctx.medias)
                     _tag_origins(ctx.medias, origin)
-                    _apply_clipper_stage(ctx, tracker, clipper, clipper_params, chain_steps)
-                    _embed_missing_stage(ctx, tracker, embedders if embedders else [embedder])
+                    _apply_clipper_stage(ctx, pacer, clipper, clipper_params, chain_steps)
+                    _embed_missing_stage(ctx, pacer, embedders if embedders else [embedder])
                     # Step 4 (finalize) bundles several sub-stages. Route them
                     # through a FinalizeProgress proxy so each maps into its own
                     # ordered slice of the step-4 bar instead of independently
                     # filling (and pinning at 100%) the whole slice — keeps the
                     # bar advancing and the ETA self-correcting through the
                     # serialize/disk-write window. See FinalizeProgress.
-                    fin = FinalizeProgress(tracker)
+                    fin = FinalizeProgress(pacer)
                     fin.begin("cleanup")
                     _drop_none_embeddings_stage(ctx, fin)
                     # Re-lazify clips from reference (thin) parents now that

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -7,10 +7,14 @@ individual stage modules can depend on it without forming an import cycle.
 
 from __future__ import annotations
 
+import time
 from typing import Optional
 
 # Maps the status strings emitted by inner functions to step numbers.
-# "downloading" covers both download and extraction.
+# "downloading" and "extracting" are the two sub-phases of the acquire step:
+# they share step 1 (the bar shows one unified acquire slice) but report on
+# different scales (transfer bytes vs archive members), so the pacer maps each
+# into its own ordered sub-range of the slice — see AdaptiveLoadPacer.
 # "loading"/"converting" cover model loading, pickle loading, and source→media
 # conversion (document→image, video→frames): all pre-embed work that produces
 # the medias to embed, so they share the loading slice.
@@ -24,6 +28,7 @@ from typing import Optional
 # off its track. Keep the map exhaustive instead.
 _STATUS_TO_STEP = {
     "downloading": 1,
+    "extracting": 1,
     "loading": 2,
     "converting": 2,
     "embedding": 3,
@@ -143,6 +148,65 @@ def load_step_weights(
     return list(_LOAD_STEP_WEIGHTS_CPU)
 
 
+#: Share of a static profile's acquire slice assigned to the download sub-phase
+#: when the archive size is unknown (the rest is extraction). Only shapes the
+#: initial pacing; the AdaptiveLoadPacer rebases from observed durations.
+_STATIC_DOWNLOAD_SHARE = 0.75
+
+
+def load_cost_terms(
+    media_type: str = "",
+    *,
+    n: Optional[int] = None,
+    download_size_mb: Optional[float] = None,
+    embedder: Optional[str] = None,
+) -> dict[str, float]:
+    """Predicted per-phase cost terms for a dataset load, in phase order
+    ``download``, ``extract``, ``load``, ``embed``, ``finalize``.
+
+    When ``n`` is known and a measured cost-model row exists, the terms are
+    seconds from the affine model. Otherwise they are pseudo-times derived from
+    the static per-(device, media) weight profile — only their ratios matter,
+    and the acquire slice is split between download and extraction by archive
+    size when known, else by :data:`_STATIC_DOWNLOAD_SHARE`.
+
+    Always returns a usable dict (never raises), so the pacing layer can rely
+    on it for every import path, including streaming folder importers.
+    """
+    device = _resolve_device_name()
+
+    if n is not None and n > 0:
+        from vtscore.datasets.stages._load_cost_model import cost_model_terms  # noqa: PLC0415
+
+        emb = embedder or _default_embedder_name(media_type)
+        terms = cost_model_terms(device, media_type, emb, n, download_size_mb)
+        if terms is not None:
+            return terms
+
+    if device == "cuda":
+        w = _LOAD_STEP_WEIGHTS_GPU
+    elif media_type == "image":
+        w = _LOAD_STEP_WEIGHTS_CPU_IMAGE
+    else:
+        w = _LOAD_STEP_WEIGHTS_CPU
+
+    dl_share = _STATIC_DOWNLOAD_SHARE
+    if download_size_mb:
+        from vtscore.datasets.stages._load_cost_model import DOWNLOAD_MB_PER_S, EXTRACT_MB_PER_S  # noqa: PLC0415
+
+        if DOWNLOAD_MB_PER_S > 0 and EXTRACT_MB_PER_S > 0:
+            t_dl = download_size_mb / DOWNLOAD_MB_PER_S
+            t_ex = download_size_mb / EXTRACT_MB_PER_S
+            dl_share = t_dl / (t_dl + t_ex)
+    return {
+        "download": w[0] * dl_share,
+        "extract": w[0] * (1.0 - dl_share),
+        "load": w[1],
+        "embed": w[2],
+        "finalize": w[3],
+    }
+
+
 class FinalizeProgress:
     """Tracker proxy that maps each finalize sub-stage into an ordered slice
     of step 4 (the finalize phase).
@@ -230,6 +294,205 @@ class FinalizeProgress:
             total_steps=_TOTAL_LOAD_STEPS,
             **kwargs,
         )
+
+
+#: Canonical phase order for a dataset load. ``download`` and ``extract`` are
+#: the two sub-phases of step 1 (acquire); the rest map 1:1 onto steps 2–4.
+_PHASE_ORDER: tuple[str, ...] = ("download", "extract", "load", "embed", "finalize")
+_PHASE_STEP: dict[str, int] = {"download": 1, "extract": 1, "load": 2, "embed": 3, "finalize": 4}
+
+
+class AdaptiveLoadPacer:
+    """Tracker proxy that paces the unified load bar from a per-phase cost model
+    and rebases it on what actually happens.
+
+    The static/n-aware step weights fix two of the bar's failure modes but two
+    remained (issue #2556):
+
+    - **Frozen bar during extraction.** Download and extraction both reported
+      status ``"downloading"`` against step 1 on different scales (transfer
+      bytes vs archive members), so once the download filled the acquire slice
+      the monotonic clamp pinned the bar for the whole extraction while the
+      ETA climbed. Extraction now reports ``"extracting"``, and this proxy maps
+      each sub-phase into its own ordered sub-range of the step-1 slice.
+    - **Weights that predict work that never happens (or lies).** A cached
+      archive skips download+extraction entirely, a cached embedded pkl skips
+      nearly everything, and the real network can be several times faster or
+      slower than the calibrated bandwidth. Static weights then make the bar
+      leap or crawl and the ETA start absurdly low or high. This proxy
+      re-estimates the *current phase's* term from its observed pace while
+      counts flow (a 2026-07-18 GTZAN run showed why download-only observation
+      is not enough: decode ran 11× its calibrated term, the bar span stayed
+      tiny, and the tracker's rate-extrapolated ETA ballooned to ~55 min for a
+      3-min load), and at every phase boundary re-divides the *remaining* span
+      of the bar over the phases still to come (proportional to their model
+      terms). What has been consumed stays consumed — the mapping is monotonic
+      by construction — but the future is always paced against the latest
+      evidence.
+
+    The proxy exposes the tracker surface the pipeline stages use (``update`` /
+    ``check_cancelled``), accepts the same ``step``/``total_steps`` kwargs, and
+    forwards to the real tracker with re-derived step weights and, for step-1
+    sub-phases, a composite within-step fraction (via the tracker's ``within``
+    override). The caller's ``current``/``total`` always pass through, so byte
+    and item counts stay visible in the UI; pacing is controlled purely through
+    the weight vector and the override.
+
+    Known limitation: a multi-archive source that downloads several archives
+    back-to-back under one ``"downloading"`` phase still freezes within that
+    phase after the first archive (the fractions restart on a new scale); the
+    alternating download→extract→download pattern the demos actually use is
+    handled by the re-entry rebase.
+    """
+
+    #: Observe a phase at least this long / this far before trusting its
+    #: projected duration over the calibrated prior.
+    _RATE_MIN_ELAPSED = 2.0
+    _RATE_MIN_FRACTION = 0.02
+    #: Re-derive the weights from the observed rate at most this often.
+    _RATE_REWEIGHT_INTERVAL = 1.0
+
+    def __init__(self, tracker, terms: dict[str, float]) -> None:
+        self._tracker = tracker
+        self._terms = {p: max(0.0, float(terms.get(p, 0.0))) for p in _PHASE_ORDER}
+        self._phase: str | None = None
+        self._phase_t0 = 0.0
+        self._frac = 0.0  # monotone within-phase fraction
+        self._consumed = 0.0  # overall fraction consumed when this phase began
+        self._span = 0.0  # overall span assigned to the current phase
+        self._raw = 0.0  # last overall fraction targeted (monotone)
+        self._last_rate_reweight = 0.0
+        self._weights = self._weights_vector()
+        tracker.set_step_weights(self._weights)
+
+    # -- tracker surface ----------------------------------------------------
+    def check_cancelled(self) -> None:
+        self._tracker.check_cancelled()
+
+    def update(self, status: str, message: str = "", current: int = 0, total: int = 0, **kwargs) -> None:
+        step = kwargs.pop("step", None)
+        kwargs.pop("total_steps", None)
+        phase = self._resolve_phase(status, step)
+        if phase is None:
+            # Terminal/idle (or unmapped) updates pass through untouched.
+            self._tracker.update(status, message, current, total, step=step, total_steps=None, **kwargs)
+            return
+
+        now = time.monotonic()
+        if phase != self._phase:
+            self._begin_phase(phase, now)
+        if total and total > 0:
+            self._frac = min(max(self._frac, current / total), 1.0)
+        self._observe_phase_rate(now)
+        self._raw = max(self._raw, self._consumed + self._span * self._frac)
+
+        s = _PHASE_STEP[phase]
+        if s == 1:
+            # Composite within-step fraction against step 1's actual slice
+            # (consumed so far + every step-1 share still pending), so the
+            # tracker's weight mapping lands exactly on the targeted fraction.
+            # Passed via the ``within`` override so the displayed
+            # ``current``/``total`` keep the caller's real byte/member counts.
+            w1 = self._weights[0]
+            kwargs["within"] = self._raw / w1 if w1 > 0 else 1.0
+        self._tracker.update(status, message, current, total, step=s, total_steps=_TOTAL_LOAD_STEPS, **kwargs)
+
+    # -- pacing internals ---------------------------------------------------
+    @staticmethod
+    def _resolve_phase(status: str, step) -> str | None:
+        if step == 4:
+            return "finalize"  # FinalizeProgress stamps step 4 explicitly
+        if status == "extracting":
+            return "extract"
+        if step == 1:
+            return "download"
+        if step == 2:
+            return "load"
+        if step == 3:
+            return "embed"
+        return None
+
+    def _begin_phase(self, phase: str, now: float) -> None:
+        """Rebase the remaining bar span over *phase* and the phases after it.
+
+        Whatever fraction the bar has actually consumed stays consumed; the
+        remainder is divided over the current-and-later model terms. Re-entering
+        an earlier phase (multi-archive download after an extraction) is the
+        same operation — the phase gets a fresh, proportionally smaller slice
+        of what is left, keeping the bar monotone without archive-count
+        knowledge.
+        """
+        self._consumed = self._raw
+        self._phase = phase
+        self._phase_t0 = now
+        self._frac = 0.0
+        self._span = (1.0 - self._consumed) * self._phase_share(phase)
+        self._weights = self._weights_vector()
+        self._tracker.set_step_weights(self._weights)
+
+    def _phase_share(self, phase: str) -> float:
+        idx = _PHASE_ORDER.index(phase)
+        rem = [self._terms[p] for p in _PHASE_ORDER[idx:]]
+        total = sum(rem)
+        return rem[0] / total if total > 0 else 1.0 / len(rem)
+
+    def _observe_phase_rate(self, now: float) -> None:
+        """Replace the current phase's calibrated term with one projected from
+        its observed pace (``elapsed / fraction-done``), and re-derive the
+        weights.
+
+        A phase running *slower* than its term grows its span, so the bar
+        target jumps forward to where reality says it should be and the
+        rate-extrapolated overall ETA converges instead of ballooning. A phase
+        running *faster* shrinks its span, which can momentarily target a
+        smaller overall fraction than already shown; the tracker's monotonic
+        clamp holds the bar flat until the target catches up, which reads as a
+        brief pause rather than a rewind.
+        """
+        phase = self._phase
+        if phase is None or self._frac >= 1.0:
+            # A completed phase needs no re-projection — the next phase
+            # boundary rebases anyway, and shrinking a finished phase's span
+            # would only clamp the bar below the span it just earned.
+            return
+        elapsed = now - self._phase_t0
+        if elapsed < self._RATE_MIN_ELAPSED or self._frac < self._RATE_MIN_FRACTION:
+            return
+        if now - self._last_rate_reweight < self._RATE_REWEIGHT_INTERVAL:
+            return
+        self._last_rate_reweight = now
+        self._terms[phase] = elapsed / self._frac
+        self._span = (1.0 - self._consumed) * self._phase_share(phase)
+        self._weights = self._weights_vector()
+        self._tracker.set_step_weights(self._weights)
+
+    def _weights_vector(self) -> list[float]:
+        """Express the current pacing state as a 4-step weight vector.
+
+        The vector always sums to 1: everything consumed before the current
+        step, the current phase's span, then the remaining phases' shares —
+        so the tracker's ``(Σ w[:s-1] + w[s-1]·within)/Σ w`` mapping lands
+        exactly on ``consumed + span·frac``.
+        """
+        w = [0.0] * _TOTAL_LOAD_STEPS
+        phase = self._phase if self._phase is not None else "download"
+        idx = _PHASE_ORDER.index(phase)
+        rem_phases = _PHASE_ORDER[idx:]
+        rem_terms = [self._terms[p] for p in rem_phases]
+        total_rem = sum(rem_terms)
+        remaining = 1.0 - self._consumed
+        if total_rem > 0:
+            shares = {p: remaining * t / total_rem for p, t in zip(rem_phases, rem_terms)}
+        else:
+            shares = {p: remaining / len(rem_phases) for p in rem_phases}
+        for p, share in shares.items():
+            w[_PHASE_STEP[p] - 1] += share
+        # Fold the consumed share into the first step. While step 1 is active
+        # its synthetic within-step fraction is computed against this same
+        # slice (see update); for later steps the tracker only sums the
+        # weights *before* the current step, so w[0] is as good a home as any.
+        w[0] += self._consumed
+        return w
 
 
 def _origin_to_str(origin: dict | None) -> str:

--- a/vtscore/datasets/stages/_load_cost_model.py
+++ b/vtscore/datasets/stages/_load_cost_model.py
@@ -1,15 +1,18 @@
 """Affine per-phase load-cost coefficients, fit from measured GRID timings.
 
 The dataset-load progress bar paces itself with a per-phase weight vector
-(download, model, embed, finalize). A single static vector can't be right at
-both small and large ``n``, because the phases scale with ``n`` differently:
-model-load is a fixed cost, embed and finalize grow with ``n``, and download
-tracks archive bytes. This module holds the measured affine coefficients so
-:func:`vtscore.datasets.stages._common.load_step_weights` can compute an
-``n``-aware weight vector.
+(download+extract, load, embed, finalize). A single static vector can't be
+right at both small and large ``n``, because the phases scale with ``n``
+differently: model-load is a fixed cost, per-item source decode, embed and
+finalize grow with ``n``, and download/extraction track archive bytes. This
+module holds the measured affine coefficients so
+:func:`vtscore.datasets.stages._common.load_step_weights` (and the runtime
+:class:`~vtscore.datasets.stages._common.AdaptiveLoadPacer`) can compute an
+``n``-aware phase-time model.
 
     T_download ≈ download_size_mb / DOWNLOAD_MB_PER_S
-    T_model    ≈ a_model                         (warm steady-state; cold noted in the plan)
+    T_extract  ≈ download_size_mb / EXTRACT_MB_PER_S
+    T_load     ≈ a_model + b_load · n            (warm model load + per-item source decode)
     T_embed    ≈ a_embed + b_embed · n
     T_finalize ≈ a_fin   + b_fin   · n
     weight_phase = T_phase / Σ T_phase
@@ -27,43 +30,115 @@ from typing import Optional
 
 # key: (device, media_type, embedder) -> affine coefficients (seconds).
 # ``device`` is normalized to "cuda" / "cpu"; ``embedder`` is the encoder name.
-# POPULATED FROM CALIBRATION (HLTCOE Grid, a100; see plan Results). Cells with no
-# row fall back to the static per-(device, media) profiles in ``_common``.
+# POPULATED FROM CALIBRATION (HLTCOE Grid rack8n06, 2026-07-18 run under
+# /exp/…/calib-2556; see plan Results). Cells with no row fall back to the
+# static per-(device, media) profiles in ``_common``.
+# ``b_load`` is the per-item source read/decode cost inside the "loading" step
+# (step 2 covers warm model load *plus* reading every source file into medias —
+# for a 1000-file audio demo over NFS that decode is tens of seconds, so it
+# must scale with ``n`` rather than hide inside the fixed ``a_model``).
+# NB the calibration demos (caltech101/esc50) decode inside the embed loop, so
+# no warm step-2 rows exist to fit ``b_load`` from — the audio values below are
+# measured from a live profiled GTZAN load (per-file decode path): 49.6s for
+# 455 files ≈ 0.11 s/item pure decode+clip, on both devices (decode is
+# CPU-bound regardless of the embed device). Still an underestimate for loads
+# that also unpickle a large embeddings cache in step 2, which is why the
+# AdaptiveLoadPacer re-estimates every phase's term from its observed pace.
 LOAD_COST_MODEL: dict[tuple[str, str, str], dict[str, float]] = {
     ("cpu", "image", "siglip"): {
         "a_model": 0.5,
-        "a_embed": 1.971,
-        "b_embed": 0.292716,
-        "a_fin": 0.4663,
-        "b_fin": 0.002124,
+        "b_load": 0.0,
+        "a_embed": 5.0828,
+        "b_embed": 0.583843,
+        "a_fin": 0.2884,
+        "b_fin": 0.003179,
     },
-    ("cpu", "audio", "clap"): {"a_model": 0.5, "a_embed": 0.0, "b_embed": 0.184566, "a_fin": 0.0, "b_fin": 0.002525},
+    ("cpu", "audio", "clap"): {
+        "a_model": 0.5,
+        "b_load": 0.11,
+        "a_embed": 1.1159,
+        "b_embed": 0.317579,
+        "a_fin": 0.0587,
+        "b_fin": 0.00237,
+    },
     ("cuda", "image", "siglip"): {
         "a_model": 0.5,
-        "a_embed": 2.1194,
-        "b_embed": 0.006784,
-        "a_fin": 8.0066,
-        "b_fin": 0.000195,
+        "b_load": 0.0,
+        "a_embed": 0.8928,
+        "b_embed": 0.01233,
+        "a_fin": 0.8098,
+        "b_fin": 0.003719,
     },
     ("cuda", "audio", "clap"): {
         "a_model": 0.5,
-        "a_embed": 0.6868,
-        "b_embed": 0.036626,
-        "a_fin": 0.0,
-        "b_fin": 0.003618,
+        "b_load": 0.11,
+        "a_embed": 0.0,
+        "b_embed": 0.063223,
+        "a_fin": 0.0796,
+        "b_fin": 0.003154,
     },
 }
 
 # Cold-download bandwidth (archive MB per second) over the measured hosts
-# (device-pooled; the two devices agreed within ~10%). 0 disables the download
-# term (weights then reflect only model+embed+finalize).
-DOWNLOAD_MB_PER_S: float = 10.05
+# (device-pooled median; observed 3.3–4.4 across the two device runs — the
+# cluster's shared egress swings by hours-of-day far more than by host). 0
+# disables the download term (weights then reflect only model+embed+finalize).
+# This is only the *prior*: the AdaptiveLoadPacer re-estimates the download
+# term from the observed transfer rate once bytes start flowing.
+DOWNLOAD_MB_PER_S: float = 3.836
+
+# Archive extraction rate (archive MB per second) on the measured hosts.
+# Extraction runs after the download inside the same acquire step, but its cost
+# scales with archive bytes at a very different rate than the network transfer,
+# so it gets its own term (and its own "extracting" status / bar slice).
+EXTRACT_MB_PER_S: float = 61.477
 
 
 def normalize_device(device: str) -> str:
     """Collapse ``resolve_device()`` output ("cuda:0", "cuda", "cpu", "mps"…) to
     the coarse key used by :data:`LOAD_COST_MODEL` ("cuda" / "cpu")."""
     return "cuda" if device.startswith("cuda") else "cpu"
+
+
+def cost_model_terms(
+    device: str,
+    media_type: str,
+    embedder: str,
+    n: int,
+    download_size_mb: Optional[float] = None,
+) -> Optional[dict[str, float]]:
+    """Return predicted per-phase seconds from the affine cost model, or
+    ``None`` when no coefficient row matches (so the caller can fall back to
+    the static profile).
+
+    Keys: ``download``, ``extract``, ``load``, ``embed``, ``finalize`` —
+    ``download``/``extract`` are the two sub-phases of the acquire step (step
+    1), ``load`` is warm model load plus per-item source decode (step 2).
+
+    ``download_size_mb`` of 0/``None`` collapses the download **and** extract
+    terms — which is exactly right for local-folder imports and cache-backed
+    re-adds, where no archive is fetched or unpacked.
+    """
+    row = LOAD_COST_MODEL.get((normalize_device(device), media_type, embedder))
+    if row is None or n <= 0:
+        return None
+    t_download = 0.0
+    t_extract = 0.0
+    if download_size_mb:
+        if DOWNLOAD_MB_PER_S > 0:
+            t_download = download_size_mb / DOWNLOAD_MB_PER_S
+        if EXTRACT_MB_PER_S > 0:
+            t_extract = download_size_mb / EXTRACT_MB_PER_S
+    terms = {
+        "download": max(0.0, t_download),
+        "extract": max(0.0, t_extract),
+        "load": max(0.0, row.get("a_model", 0.0) + row.get("b_load", 0.0) * n),
+        "embed": max(0.0, row.get("a_embed", 0.0) + row.get("b_embed", 0.0) * n),
+        "finalize": max(0.0, row.get("a_fin", 0.0) + row.get("b_fin", 0.0) * n),
+    }
+    if sum(terms.values()) <= 0:
+        return None
+    return terms
 
 
 def cost_model_weights(
@@ -73,25 +148,18 @@ def cost_model_weights(
     n: int,
     download_size_mb: Optional[float] = None,
 ) -> Optional[list[float]]:
-    """Return normalized ``[download, model, embed, finalize]`` weights from the
-    affine cost model, or ``None`` when no coefficient row matches (so the caller
-    can fall back to the static profile).
-
-    ``download_size_mb`` of 0/``None`` collapses the download slice — which is
-    exactly right for local-folder imports and cache-backed re-adds, where no
-    archive is fetched.
-    """
-    row = LOAD_COST_MODEL.get((normalize_device(device), media_type, embedder))
-    if row is None or n <= 0:
+    """Return normalized ``[acquire, load, embed, finalize]`` step weights from
+    the affine cost model (acquire = download + extract), or ``None`` when no
+    coefficient row matches (so the caller can fall back to the static
+    profile)."""
+    terms = cost_model_terms(device, media_type, embedder, n, download_size_mb)
+    if terms is None:
         return None
-    t_download = 0.0
-    if download_size_mb and DOWNLOAD_MB_PER_S > 0:
-        t_download = download_size_mb / DOWNLOAD_MB_PER_S
-    t_model = row.get("a_model", 0.0)
-    t_embed = row.get("a_embed", 0.0) + row.get("b_embed", 0.0) * n
-    t_finalize = row.get("a_fin", 0.0) + row.get("b_fin", 0.0) * n
-    parts = [max(0.0, t_download), max(0.0, t_model), max(0.0, t_embed), max(0.0, t_finalize)]
+    parts = [
+        terms["download"] + terms["extract"],
+        terms["load"],
+        terms["embed"],
+        terms["finalize"],
+    ]
     total = sum(parts)
-    if total <= 0:
-        return None
     return [p / total for p in parts]

--- a/vtscore/datasets/stages/_load_profiler.py
+++ b/vtscore/datasets/stages/_load_profiler.py
@@ -28,6 +28,9 @@ import time
 from typing import Any, Optional
 
 # step number (see _common._STATUS_TO_STEP / _TOTAL_LOAD_STEPS) -> phase label.
+# Step 1 covers two sub-phases: the transfer itself ("downloading") and the
+# archive unpack ("extracting"); they are recorded as separate phases so the
+# fit can estimate a per-MB extraction rate independent of network bandwidth.
 _STEP_PHASE = {1: "download", 2: "model_load", 3: "embed", 4: "finalize"}
 
 # Embedders whose model has already been loaded in THIS process. First load of a
@@ -106,12 +109,17 @@ class LoadProfiler:
 
     # -- capture ------------------------------------------------------------
     def on_update(self, snapshot: dict[str, Any]) -> None:
-        """Tracker subscriber: stamp the first time each step becomes active."""
+        """Tracker subscriber: stamp the first time each phase becomes active."""
         step = snapshot.get("step")
-        if step == self._last_step:
+        status = snapshot.get("status")
+        key = (step, status == "extracting")
+        if key == self._last_step:
             return
-        self._last_step = step
-        phase = _STEP_PHASE.get(step) if isinstance(step, int) else None
+        self._last_step = key
+        if step == 1 and status == "extracting":
+            phase: Any = "extract"
+        else:
+            phase = _STEP_PHASE.get(step) if isinstance(step, int) else None
         if phase is None:
             return
         now = time.monotonic()


### PR DESCRIPTION
## Summary

Fixes the remaining progress-bar miscalibrations from #2556: the bar frozen through archive extraction, leaps/crawls when cached phases skip work, and ETAs that balloon when a phase runs far off its calibrated cost.

- **Distinct `extracting` status + step-1 sub-phase pacing** — download and extraction report on different scales (bytes vs members); a new `AdaptiveLoadPacer` maps each into its own ordered sub-range of the acquire slice, so the monotonic clamp no longer pins the bar for the whole extraction while the ETA climbs.
- **Phase-boundary rebasing** — the pacer paces the bar from per-phase cost-model *terms* (seconds) and re-divides the remaining span over the phases still to come at every boundary. Skipped phases (cached archive, cached embeddings pkl) redistribute instead of leaping or stalling the bar.
- **Per-phase rate observation** — the current phase's term is continuously re-estimated from observed pace. A live GTZAN run showed decode running ~11x its calibrated term: with download-only observation the rate-extrapolated overall ETA climbed to ~55 min for a 3-min load; with per-phase observation it converges within seconds (measured 235 s -> 20 s -> 5 s).
- **Tracker `within` override** — pacing layers composite sub-phases without hiding the UI's real byte/item counts.
- **Refit coefficients** (2026-07-18 GRID runs, caltech101 image/siglip + esc50 audio/clap, s/m/l/a, cpu+cuda): embed/finalize R² 0.92–1.00; new `EXTRACT_MB_PER_S` (61.5) and per-item `b_load` decode term (audio 0.11 s/item, measured from a live profiled GTZAN load — the esc50 calibration demos decode inside the embed loop so no warm step-2 rows exist to fit it).

## Validation

Browser-driven against the GRID dev instance (rack8n06): one cold GTZAN import (download → extract → decode → embed → finalize) and two cache-backed re-imports. Monotone bar in all runs (0 violations across 10k+ recorded SSE snapshots); ETA converges instead of climbing. 746 backend tests + 22 frontend format-progress specs pass; ruff clean.

Closes #2556

🤖 Generated with [Claude Code](https://claude.com/claude-code)