### PR TITLE
Thread demo dataset id into load profiler rows

### DIFF
--- a/tests/datasets/test_demo_double_clip.py
+++ b/tests/datasets/test_demo_double_clip.py
@@ -118,3 +118,67 @@ class TestDemoImportSingleClip:
             clipper_stage._apply_clipper_stage(ctx, DummyTracker(), "sound_tiling", None, None)
 
         assert calls == ["sound_tiling"]
+
+
+class TestDemoDatasetIdThreading:
+    """A demo load must forward its dataset id to the load pipeline so the
+    ``VTSEARCH_PROFILE_LOAD`` recorder stamps ``dataset_id`` (and can resolve the
+    archive size) instead of writing empty rows.  Regression for #2614.
+    """
+
+    def test_demo_id_forwarded_to_origin_load(self):
+        """The demo importer's ``name`` field reaches ``_run_origin_load_in_background``."""
+        from vtscore.datasets import load_pipeline
+        from vtscore.datasets.importers.demo import IMPORTER as demo_importer
+
+        captured: dict = {}
+
+        def fake_origin_load(load_fn, origin, **kwargs):
+            captured.update(kwargs)
+            return "task-id"
+
+        with patch.object(load_pipeline, "_run_origin_load_in_background", side_effect=fake_origin_load):
+            load_pipeline._run_importer_in_background(
+                demo_importer,
+                {"name": "gtzan_a", "media_type": "audio"},
+            )
+
+        assert captured["dataset_id"] == "gtzan_a"
+
+    def test_non_demo_import_forwards_empty_id(self):
+        """A non-demo importer supplies no dataset id (empty, not the field's ``name``)."""
+        from vtscore.datasets import load_pipeline
+        from vtscore.datasets.importers.base import ImporterBase
+
+        class DummyImporter(ImporterBase):
+            name = "dummy_id_test"
+            display_name = "Dummy"
+            fields: list = []
+
+            def run(self, field_values, medias, thin=False):
+                pass
+
+        captured: dict = {}
+
+        def fake_origin_load(load_fn, origin, **kwargs):
+            captured.update(kwargs)
+            return "task-id"
+
+        with patch.object(load_pipeline, "_run_origin_load_in_background", side_effect=fake_origin_load):
+            load_pipeline._run_importer_in_background(
+                DummyImporter(),
+                {"name": "not-a-demo-id", "media_type": "audio"},
+            )
+
+        assert captured["dataset_id"] == ""
+
+    def test_demo_load_hints_returns_id_count_and_size(self):
+        """``_demo_load_hints`` reports the id alongside the n / size hints."""
+        from vtscore.datasets import load_pipeline
+        from vtscore.datasets.importers.demo import IMPORTER as demo_importer
+
+        dataset_id, n, size = load_pipeline._demo_load_hints(demo_importer, {"name": "gtzan_a"})
+
+        assert dataset_id == "gtzan_a"
+        assert n is not None and n > 0
+        assert size is not None and size > 0

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -372,6 +372,7 @@ def _run_origin_load_in_background(
     media_type: str = "",
     build_projection: bool = False,
     merge_near_duplicates: bool = False,
+    dataset_id: str = "",
     n_hint: int | None = None,
     download_size_mb_hint: float | None = None,
 ) -> str:
@@ -549,7 +550,11 @@ def _run_origin_load_in_background(
                     controller.release()
                     clear_thread_progress()
         finally:
-            profiler.finish(len(ctx.medias))  # writes JSONL + unbinds (no-op when off)
+            # Pass the demo dataset id (empty for non-demo loads) so profiler
+            # rows carry it and can resolve the archive size via
+            # ``_download_size_mb_for`` — otherwise app-recorded rows land with
+            # ``dataset_id: ""`` and can't feed fit_load_weights.py (see #2614).
+            profiler.finish(len(ctx.medias), dataset_id)  # writes JSONL + unbinds (no-op when off)
             loading_tasks.mark_finished(task_id)
 
     threading.Thread(target=task, daemon=True).start()
@@ -666,7 +671,7 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     # For demo datasets we know the expected item count + archive size up front,
     # which lets load_step_weights pace by the measured n-aware cost model rather
     # than the static asymptote. Unknown for streaming folder imports -> None.
-    n_hint, download_size_mb_hint = _demo_load_hints(importer, field_values)
+    demo_id, n_hint, download_size_mb_hint = _demo_load_hints(importer, field_values)
 
     return _run_origin_load_in_background(
         _load,
@@ -681,31 +686,35 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
         media_type=media_type_hint,
         build_projection=build_projection,
         merge_near_duplicates=merge_near_duplicates,
+        dataset_id=demo_id,
         n_hint=n_hint,
         download_size_mb_hint=download_size_mb_hint,
     )
 
 
-def _demo_load_hints(importer, field_values: dict) -> tuple[int | None, float | None]:
-    """Expected item count and archive size for a demo load, else ``(None, None)``.
+def _demo_load_hints(importer, field_values: dict) -> tuple[str, int | None, float | None]:
+    """Demo dataset id, expected item count, and archive size for a demo load,
+    else ``("", None, None)``.
 
-    Enables the ``n``-aware cost-model weights (see
-    :func:`vtscore.datasets.stages._common.load_step_weights`). Only the demo
-    importer knows ``n`` up front; folder importers stream, so they fall back to
-    the static weight profile.
+    The ``n`` / size hints enable the ``n``-aware cost-model weights (see
+    :func:`vtscore.datasets.stages._common.load_step_weights`); the id is also
+    threaded to the load profiler so its rows carry ``dataset_id`` (and can
+    resolve the archive size) rather than landing empty (see #2614). Only the
+    demo importer knows these up front; folder importers stream, so they fall
+    back to the static weight profile.
     """
     if getattr(importer, "name", "") != "demo":
-        return None, None
+        return "", None, None
     dataset_id = field_values.get("name", "")
     if not dataset_id:
-        return None, None
+        return "", None, None
     from vtscore.datasets.config import DEMO_DATASETS  # noqa: PLC0415
     from vtscore.datasets.demo_counts import exact_demo_count  # noqa: PLC0415
 
     n = exact_demo_count(dataset_id)
     info = DEMO_DATASETS.get(dataset_id) or {}
     dl = info.get("download_size_mb")
-    return n, (float(dl) if dl is not None else None)
+    return dataset_id, n, (float(dl) if dl is not None else None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Load-profiler rows recorded by `vtscore/datasets/stages/_load_profiler.py` when `VTSEARCH_PROFILE_LOAD` is armed on a running app landed with `dataset_id: ""` and `download_size_mb: null`. The load pipeline called `profiler.finish(n)` without a dataset id, and only the calibration driver set the `VTSEARCH_PROFILE_DATASET_ID` / `VTSEARCH_PROFILE_DOWNLOAD_MB` env fallbacks. Without the id, `_download_size_mb_for()` can't look up the archive size either — so app-recorded rows can't feed `scripts/profiling/fit_load_weights.py`, which needs the size for the download/extract terms and the id for grouping.

## Fix

`_demo_load_hints()` already reads the demo id from `field_values` (the same place the `n` / size hints come from). It now returns that id alongside the hints, and `_run_importer_in_background` threads it through a new `dataset_id` parameter on `_run_origin_load_in_background` to `profiler.finish(len(ctx.medias), dataset_id)`. Non-demo loads (folder / files uploads) forward an empty id, unchanged — matching the profiler's existing default.

## Tests

Added `TestDemoDatasetIdThreading` in `tests/datasets/test_demo_double_clip.py`:
- a demo import forwards its `name` field as `dataset_id` to the origin load,
- a non-demo importer forwards an empty id (not the field's `name`),
- `_demo_load_hints` reports the id alongside the `n` / size hints.

`./run-tests.sh datasets` passes (895 passed, 2 skipped); ruff/codespell/deptry green.

Closes #2614

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3mSz5zXFktopznjb2Q3yJ)_