### PR TITLE
Fix load-bar freeze on multi-file downloads (UCSF documents)

### DIFF
--- a/tests_lib/downloads/test_ucsf_documents_download.py
+++ b/tests_lib/downloads/test_ucsf_documents_download.py
@@ -225,6 +225,76 @@ class TestDownloadUcsfDocuments:
         published = list(result.rglob("abcd0001.pdf"))
         assert published, "the downloaded PDF must be published at its final path"
 
+    def test_progress_is_cumulative_and_monotone_across_pdfs(self, tmp_path):
+        """Per-PDF byte progress must not freeze the unified load bar.
+
+        Each PDF is a separate transfer under one continuous "downloading"
+        phase. Regression guard for #2616: the downloader must report on the
+        cumulative document count (so ``total`` stays ``total_docs`` and
+        ``current`` never rewinds), not each PDF's own restarting byte
+        fraction — otherwise the AdaptiveLoadPacer's monotonic clamp freezes
+        the bar after the first PDF. We assert both the raw reporting scale and
+        that the pacer's whole-job ``overall`` fraction stays monotone.
+        """
+        from vtscore.concurrency.progress import ProgressTracker
+        from vtscore.datasets import downloader as dl_module
+        from vtscore.datasets.stages._common import AdaptiveLoadPacer, _STATUS_TO_STEP, _TOTAL_LOAD_STEPS
+
+        solr_resp = _fake_solr_response([f"abcd{i:04d}" for i in range(4)])
+        mock_response = MagicMock()
+        mock_response.json.return_value = solr_resp
+        mock_response.raise_for_status = MagicMock()
+
+        def fake_download(url, dest, size, cb):
+            # Mimic download_file_with_progress: emit this PDF's own byte-scale
+            # progress (which restarts per file) so the test exercises the very
+            # reporting that used to freeze the bar.
+            cb("downloading", f"Downloading {dest.name}...", 0, 500_000)
+            cb("downloading", f"Downloading {dest.name}...", 250_000, 500_000)
+            cb("downloading", f"Downloading {dest.name}...", 500_000, 500_000)
+            dest.write_bytes(b"%PDF-1.0 stub")
+
+        events: list[tuple[str, int, int]] = []
+
+        def record(status, message="", current=0, total=0):
+            events.append((status, current, total))
+
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "download_file_with_progress", fake_download),
+            patch("requests.get", return_value=mock_response),
+        ):
+            dl_module.download_ucsf_documents(
+                categories=["Tobacco"],
+                docs_per_category=4,
+                on_progress=record,
+            )
+
+        download_events = [(cur, tot) for status, cur, tot in events if status == "downloading"]
+        assert download_events, "expected downloading progress events"
+        # Every downloading event reports on the cumulative document scale, not a
+        # per-PDF byte scale (500_000 would leak through if the inner byte
+        # fraction were forwarded unchanged).
+        assert all(tot == 4 for _cur, tot in download_events)
+        currents = [cur for cur, _tot in download_events]
+        assert currents == sorted(currents), "cumulative document count must never rewind"
+        assert max(currents) == 4  # all four PDFs finished
+
+        # Drive the captured events through the pacer exactly as the load
+        # pipeline would, and confirm the unified bar never retreats.
+        tracker = ProgressTracker(
+            extra_fields={"step": None, "total_steps": None, "overall": None, "eta_seconds": None}
+        )
+        pacer = AdaptiveLoadPacer(
+            tracker, {"download": 10.0, "extract": 5.0, "load": 5.0, "embed": 20.0, "finalize": 10.0}
+        )
+        overalls = []
+        for status, cur, tot in events:
+            step = _STATUS_TO_STEP.get(status)
+            pacer.update(status, "", cur, tot, step=step, total_steps=_TOTAL_LOAD_STEPS)
+            overalls.append(tracker.get()["overall"])
+        assert all(b >= a - 1e-9 for a, b in zip(overalls, overalls[1:])), overalls
+
     def test_handles_api_failure_gracefully(self, tmp_path):
         """If the Solr API request fails, the category is skipped."""
         from vtscore.datasets import downloader as dl_module

--- a/vtscore/datasets/downloader/documents.py
+++ b/vtscore/datasets/downloader/documents.py
@@ -58,6 +58,19 @@ def download_ucsf_documents(  # noqa: C901
     total_docs = len(categories) * docs_per_category
     downloaded = 0
 
+    # Every PDF is a separate transfer, but they all run back-to-back under one
+    # continuous "downloading" phase. If each PDF reported its own byte fraction
+    # (downloaded/size), the first completed PDF would drive that fraction to
+    # 1.0 — filling the load bar's download slice — and the pacer's monotonic
+    # clamp would then freeze the bar for every remaining PDF, since each new
+    # PDF's byte fraction restarts from 0 on its own scale (issue #2616).
+    # Reporting on the cumulative document count instead keeps the reported
+    # fraction monotone across the whole set, so the bar advances one PDF at a
+    # time and never freezes or rewinds. ``downloaded`` is read at call time, so
+    # this closure always reflects how many PDFs have finished so far.
+    def _cumulative_progress(status: str, message: str, _current: int, _total: int) -> None:
+        on_progress(status, message, downloaded, total_docs)
+
     for cat in categories:
         cat_dir = extract_dir / cat
         cat_dir.mkdir(exist_ok=True)
@@ -110,8 +123,11 @@ def download_ucsf_documents(  # noqa: C901
 
             try:
                 # Atomic (temp + rename): a partial PDF left at pdf_path by a
-                # hard kill would pass the exists() cache gate forever.
-                _core.download_file_atomic(url, pdf_path, 0, on_progress)
+                # hard kill would pass the exists() cache gate forever. Progress
+                # is reported on the cumulative document count (see
+                # _cumulative_progress) so the unified load bar stays monotone
+                # across the back-to-back PDF transfers.
+                _core.download_file_atomic(url, pdf_path, 0, _cumulative_progress)
                 downloaded += 1
                 on_progress("downloading", f"Downloaded {doc_id}.pdf", downloaded, total_docs)
             except Exception:

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -338,11 +338,16 @@ class AdaptiveLoadPacer:
     and item counts stay visible in the UI; pacing is controlled purely through
     the weight vector and the override.
 
-    Known limitation: a multi-archive source that downloads several archives
-    back-to-back under one ``"downloading"`` phase still freezes within that
-    phase after the first archive (the fractions restart on a new scale); the
-    alternating download→extract→download pattern the demos actually use is
-    handled by the re-entry rebase.
+    Multi-download caller convention: the pacer cannot tell a fresh archive's
+    restarting fraction from within-phase jitter, so a source that fetches
+    several files back-to-back under one ``"downloading"`` phase must report a
+    *cumulative* fraction across the whole set (a running byte or item count
+    against the set total) rather than each file's own 0→1 fraction — otherwise
+    the first file fills the acquire slice and the monotonic clamp freezes the
+    bar for the rest. The alternating download→extract→download demos (TUT, KTH,
+    Visual Genome) get this for free from the re-entry rebase; the one demo that
+    stays in a single continuous download phase, ``download_ucsf_documents``,
+    reports on its cumulative PDF count (issue #2616).
     """
 
     #: Observe a phase at least this long / this far before trusting its


### PR DESCRIPTION
## Summary

Follow-up to #2556 / #2613. The `AdaptiveLoadPacer` documented a known limitation: a source that downloads several files back-to-back under one continuous `"downloading"` phase freezes within that phase after the first file, because each file's byte fraction restarts on its own scale and the monotonic clamp holds the bar until the new fraction catches up.

The concrete demo that hits this is **`download_ucsf_documents`**: it fetches many PDFs in a row, and each inner `download_file_atomic` reported its *own* per-PDF byte fraction (`downloaded/size`). The first PDF drove that fraction to 1.0 — filling the pacer's acquire slice — and the clamp then pinned the bar for every remaining PDF. (The archive demos — Visual Genome, TUT, KTH, Places365 — interleave an `"extracting"` phase between downloads, so the pacer's re-entry rebase already handles them; the parquet-shard helper already reports a monotone shard count.)

## Changes

- **`download_ucsf_documents`** now reports progress on the **cumulative document count** rather than each PDF's restarting byte fraction. A small closure maps every inner download's progress onto `(documents_finished, total_docs)`, so the within-download fraction stays monotone across the whole set and the bar advances one PDF at a time instead of freezing.
- **`AdaptiveLoadPacer` docstring**: replaced the "known limitation" note with the multi-download **caller convention** — a source that fetches several files under one `"downloading"` phase must report a cumulative fraction across the set (as UCSF now does), since the pacer cannot distinguish a fresh file's restarting fraction from within-phase jitter.
- **Regression test**: drives the captured progress events through an `AdaptiveLoadPacer` and asserts both the cumulative reporting scale (`total == total_docs`, non-decreasing `current`) and a monotone whole-job `overall` fraction.

## Validation

`./run-tests.sh` — all 6435 tests pass (1 skipped). ruff/pyright/deptry/pip-audit clean.

Closes #2616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhaH9QmBp4rGDaCnJR4pBj)_