### PR TITLE
Promote progress-bar plan follow-ups to individual GitHub issues

### DIFF
--- a/docs/plans/progress-bar-consolidation.md
+++ b/docs/plans/progress-bar-consolidation.md
@@ -1,41 +1,20 @@
 # Progress-bar consolidation
 
-**Status:** The core consolidation shipped (one whole-job bar with overall ETA and step count); the open follow-ups below remain.
+**Status:** The core consolidation shipped (one whole-job bar with overall ETA
+and step count), and the load-progress weights are now adaptively paced at
+runtime from observed per-phase rates (`AdaptiveLoadPacer`, closing #2556 —
+see `docs/plans/progress-weight-calibration.md` for the remaining
+calibration-coverage work that adaptive pacing doesn't replace). The open
+follow-ups below remain.
 
 ## Open follow-ups
 
-- **Finalize lumps ~6 sub-stages into one step.** The finalize step (drop-none,
-  relazify, collapse-dup, coverage-atlas, registry, projection) is a single
-  weighted slice. The `FinalizeProgress` proxy (`stages/_common.py`) now spreads
-  it across ordered sub-ranges (cleanup 0.05, dedup 0.15, coverage 0.30,
-  registry 0.45, projection 0.05) so finishing one sub-stage no longer pins the
-  bar at 100 % while the rest run — the bar advances once, monotonically, across
-  the phase. The remaining roughness is that those sub-slot shares are static
-  ballparks (e.g. on a non-cuML GPU host the coverage k-means can outweigh the
-  registry save), not measured; a future pass could record real per-sub-stage
-  durations and feed them back in, mirroring the device-aware top-level weights.
-- **Indeterminate sub-steps park at the step floor.** A phase that reports no
-  `total` (e.g. model load) sits the bar at its weighted floor until the next
-  phase. That's honest but static; per-step weights (now shipped) mitigate it,
-  but a phase with no `total` still can't animate within itself.
-- **Weights are static guesses.** *(Largely resolved.)* The per-step weights are
-  now fit to measured per-phase durations via an affine `n`-aware cost model —
-  see `docs/plans/progress-weight-calibration.md` (executed 2026-07 for
-  `{cpu,cuda} × {image,audio}`, default embedder; coefficients in
-  `vtscore/datasets/stages/_load_cost_model.py`). The fixed model-load cost is why
-  one static vector can't serve both small and large datasets, so
-  `load_step_weights(media_type, *, n, download_size_mb, embedder)` computes the
-  vector from the cost model when `n` is known and a coefficient row exists, and
-  otherwise returns the static per-(device, media) profile (the large-`n`
-  asymptote). Remaining media/embedders/cuML cells are uncalibrated and keep the
-  static profiles (incl. the CPU **image** stopgap
-  `_LOAD_STEP_WEIGHTS_CPU_IMAGE`).
-- **Promote builds the coverage atlas synchronously.** Promote now builds + caches
-  the tree in-request (the app runs with `VTSEARCH_TIMEOUT=0`, so long creates
-  are tolerated), which means no fine-grained progress during a large promote. If
-  that becomes a pain, background the promote like the import pipeline. Other
-  cache-miss reloads (old pickles predating tree caching, or a media set that
-  shifts on load) still rebuild once; a "write the rebuilt tree back to the
-  pickle on first reload" pass would cover those too.
-- **Eval (train-and-score)** is intentionally left single-phase (one smooth
-  `current/total` bar); revisit only if it grows distinct phases.
+<!-- item-sep -->
+
+- [ ] #2621 — Zero-total (indeterminate) progress phases can't animate within themselves
+
+<!-- item-sep -->
+
+- [ ] #2622 — Dataset promote builds the coverage atlas synchronously; background it like the import pipeline
+
+<!-- item-sep -->

--- a/docs/plans/progress-weight-calibration.md
+++ b/docs/plans/progress-weight-calibration.md
@@ -7,17 +7,19 @@ and need calibration.
 
 ## Open follow-ups (remaining cells to calibrate)
 
-- **Uncalibrated cells fall back to the static per-(device, media) profile.**
-  Calibrate by re-running `scripts/profiling/calibrate_load_weights.py` for:
-  the remaining media types (`video / text / document`), the non-default
-  embedders (image: siglip2, eupe_*, face, sift_vlad; audio: whisper_encoder…),
-  and the **cuML on/off** split (cuML moves coverage-atlas k-means to GPU,
-  materially changing finalize).
-- **Finalize sub-slot shares** (`FinalizeProgress._SLOTS` ballparks) have the
-  same "static guess" problem one level down — revisit with the measured data
-  once coefficients exist.
-- **Multi-embedder (v3 trio)** embed loop may need its own `b_embed` summed
-  across bound embedders (see the trio follow-up in the consolidation doc).
+<!-- item-sep -->
+
+- [ ] #2623 — Calibrate remaining load-progress weight cells (video/text/document, non-default embedders, cuML split)
+
+<!-- item-sep -->
+
+- [ ] #2624 — Calibrate FinalizeProgress sub-slot shares from measured per-sub-stage durations
+
+<!-- item-sep -->
+
+- [ ] #2625 — Multi-embedder (v3 trio) load-progress weight model needs a per-bound-embedder `b_embed` term
+
+<!-- item-sep -->
 
 ## Reproducing calibration for a remaining cell
 
@@ -67,7 +69,9 @@ model-load; `(a_embed, b_embed)` and `(a_fin, b_fin)` = least-squares vs `n`;
 `bandwidth(device)` = fit of cold download vs `download_size_mb`. Sanity-check
 R²/residuals; fall back to the generic profile where a cell is thin.
 
-This is the concrete follow-up to the "Weights are static guesses" item in
-`docs/plans/progress-bar-consolidation.md`. Non-goals: predicting absolute load
-time (ETA self-corrects); a persistent online model (coefficients are checked-in
-constants); calibrating non-dataset bars (detector load, Find, sort).
+This is the calibration-coverage counterpart to `AdaptiveLoadPacer`
+(`vtscore/datasets/stages/_common.py`), which paces the bar at runtime from
+observed rates but doesn't replace the value of a better prior. Non-goals:
+predicting absolute load time (ETA self-corrects); a persistent online model
+(coefficients are checked-in constants); calibrating non-dataset bars
+(detector load, Find, sort).


### PR DESCRIPTION
## Summary
- Evaluated `docs/plans/progress-bar-consolidation.md` and `docs/plans/progress-weight-calibration.md` against the current code (a same-day `AdaptiveLoadPacer` commit had already overtaken part of the "weights are static guesses" item, closing #2556).
- Filed the remaining concrete, independently-shippable follow-ups as issues: #2621, #2622, #2623, #2624, #2625. (This PR only files and cross-links them — it doesn't implement any of them, so none should auto-close on merge.)
- Trimmed both plan files to one-line issue pointers (per the issues-vs-plans convention in CLAUDE.md) and fixed a dangling cross-reference to a since-pruned "trio follow-up" bullet.

## Details per item
- **Finalize sub-stage lumping** → folded into #2624 (calibrate `FinalizeProgress._SLOTS` from measured durations), since it's the same underlying gap as the calibration doc's "Finalize sub-slot shares" bullet.
- **Indeterminate sub-steps park at the step floor** → still valid, not resolved by `AdaptiveLoadPacer` (confirmed it never re-projects a zero-`total` phase). Filed as #2621.
- **Weights are static guesses** → the top-level "static weights" concern is resolved by `AdaptiveLoadPacer`; the real remaining gap (uncalibrated media/embedder/cuML cells) was already tracked in `progress-weight-calibration.md` and is now #2623.
- **Promote builds the coverage atlas synchronously** → still valid; filed as #2622 with the scope note that it needs a response-contract change (sync → task/poll), not just moving the call to a thread.
- **Eval single-phase** → not actionable work (the note explicitly says "revisit only if it grows phases"); dropped.
- **Multi-embedder (v3 trio) `b_embed` term** → was an orphaned cross-reference pointing at content the consolidation doc no longer has (dropped in an earlier prune without updating the pointer); filed as #2625 and re-homed.

## Test plan
- Docs-only change (two plan files); no code touched, so no test run.

Refs #2621, refs #2622, refs #2623, refs #2624, refs #2625

🤖 Generated with [Claude Code](https://claude.com/claude-code)