### PR TITLE
Gate portable detector export on embedder type

### DIFF
--- a/docs/plans/detector-standalone-export.md
+++ b/docs/plans/detector-standalone-export.md
@@ -15,11 +15,19 @@ re-trainable), ONNX (not TensorFlow or raw JSON weights), and a dedicated modal
 
 - **Re-import.** The manifest is shaped to be re-importable, but no importer
   reads it back yet. A "import portable detector" flow could rebuild a
-  read-only, score-only detector from a bundle.
-- **Patch / structural detectors.** The ONNX graph assumes the single-vector
-  2-layer MLP. Patch (DINOv2/v3, EUPE) and structural (SIFT/VLAD) detectors,
-  whose scoring isn't a plain MLP forward pass, are out of scope for this graph;
-  exporting them faithfully needs more than the linear stack.
+  read-only, score-only detector from a bundle. Deliberately not planned:
+  the export is a one-way trip.
+- **Patch full sub-region fidelity.** Patch (DINOv2/v3, EUPE) detectors now
+  export in a whole-item-only degraded mode (flagged via `manifest["caveats"]`
+  and the README): the bundle scores each item as a single vector rather than
+  searching sub-regions. Bundling the region-extraction recipe itself (DINOv2
+  patch forward + HAC-tree construction, `vtscore/media/patch_embed.py`) so a
+  recipient gets real sub-region scoring is unattempted and would be a much
+  larger lift — the algorithm isn't a simple "run this HF checkpoint" step.
+  Structural (SIFT/VLAD) detectors are blocked outright (409 / skipped with a
+  reason), not degraded: their stage-2 RANSAC verification against raw
+  SIFT-keypoint templates isn't ONNX-representable and the templates are raw
+  feature data this bundle format is designed to never carry.
 - **Screenshot.** The new modal is a GUI surface; if a doc screenshot frames it,
   add the shot id to `docs/user/screenshots-reshoot-queue.md` (no browser in the
   cloud container to reshoot this session).

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -10814,7 +10814,7 @@
             "description": "Detector not found."
           },
           "409": {
-            "description": "The active dataset can't supply the detector's embedder type."
+            "description": "The active dataset can't supply the detector's embedder type, or the detector's type (structural) can't be exported as a portable bundle at all."
           },
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"

--- a/tests/detectors/test_portable_detector_exporter.py
+++ b/tests/detectors/test_portable_detector_exporter.py
@@ -214,19 +214,19 @@ class TestExportCliDetectors:
         assert manifest["embedder"]["embedding_dim"] == 768
         assert manifest["training_labels"] == {"good": 5, "bad": 3}
 
-    def test_skips_non_two_layer_mlp(self, tmp_path):
+    def test_skips_malformed_weights(self, tmp_path):
         from vtscore.exporters import get_exporter
 
         exp = get_exporter("portable_detector")
         # A single-layer weight dict can't be modelled by the fixed ONNX graph;
         # the exporter must skip it rather than abort the whole export.
         bad_descriptor = {
-            "detector_name": "structural",
+            "detector_name": "malformed",
             "media_type": "image",
             "weights": {"0.weight": [[1.0, 2.0]], "0.bias": [0.0]},
             "threshold": 0.5,
-            "embedder": "sift_vlad",
-            "embedder_type": "structural",
+            "embedder": "siglip",
+            "embedder_type": "semantic",
             "good_count": 2,
             "bad_count": 2,
         }
@@ -235,7 +235,58 @@ class TestExportCliDetectors:
 
         assert "No portable detector bundles written" in result["message"]
         assert "skipped" in result["message"].lower()
+        assert not (tmp_path / "malformed.zip").exists()
+
+    def test_skips_structural_detector(self, tmp_path):
+        """A real (well-formed) structural detector is blocked, not silently mis-exported.
+
+        Structural detectors' stage-1 VLAD-space MLP is a normal 2-layer weight
+        dict indistinguishable in shape from any other detector's, so the
+        weight-shape check alone can't catch it - the exporter must gate on
+        ``embedder_type`` explicitly.
+        """
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("portable_detector")
+        descriptor = {
+            "detector_name": "structural",
+            "media_type": "image",
+            "weights": _real_weights(768),
+            "threshold": 0.5,
+            "embedder": "sift_vlad",
+            "embedder_type": "structural",
+            "good_count": 2,
+            "bad_count": 2,
+        }
+        out = tmp_path / "{detector_name}.zip"
+        result = exp.export_cli_detectors([descriptor], {"filepath": str(out)})
+
+        assert "No portable detector bundles written" in result["message"]
+        assert "structural" in result["message"].lower()
         assert not (tmp_path / "structural.zip").exists()
+
+    def test_exports_patch_semantic_with_caveat(self, tmp_path):
+        """A patch detector exports in the degraded whole-item-only mode, flagged."""
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("portable_detector")
+        descriptor = {
+            "detector_name": "patchy",
+            "media_type": "image",
+            "weights": _real_weights(768),
+            "threshold": 0.5,
+            "embedder": "dinov2",
+            "embedder_type": "patch_semantic",
+            "good_count": 4,
+            "bad_count": 4,
+        }
+        out = tmp_path / "{detector_name}.zip"
+        result = exp.export_cli_detectors([descriptor], {"filepath": str(out)})
+
+        assert "Wrote 1" in result["message"]
+        manifest = _assert_valid_bundle(tmp_path / "patchy.zip", detector_name="patchy")
+        assert len(manifest["caveats"]) == 1
+        assert "WHOLE item" in manifest["caveats"][0]
 
     def test_sanitizes_detector_name_in_path(self, tmp_path):
         """A detector name with path separators can't escape the target dir."""

--- a/tests/detectors/test_portable_export_route.py
+++ b/tests/detectors/test_portable_export_route.py
@@ -103,6 +103,51 @@ class TestPortableExport:
         finally:
             app_module.medias.update(saved)
 
+    def test_export_blocks_structural_detector(self, client, monkeypatch):
+        """A structural detector is rejected (409) rather than silently mis-exported.
+
+        Bypasses the (unrelated) dataset-type-compatibility gate via monkeypatch
+        so the new exportability gate itself is what's under test.
+        """
+        import vtsearch.routes.detectors.scoring as scoring_mod
+
+        monkeypatch.setattr(scoring_mod, "_dataset_supplies_detector_type", lambda *_a, **_kw: True)
+        detector_id = setup_trainable_model_in_registry(
+            "portable-structural",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+            embedder_type="structural",
+        )
+        resp = _export(client, detector_id)
+        assert resp.status_code == 409
+        assert "structural" in resp.get_json()["message"].lower()
+
+    def test_export_patch_semantic_gets_caveat(self, client, monkeypatch):
+        """A patch detector exports normally, flagged with the whole-item caveat."""
+        import onnx  # noqa: PLC0415
+        import vtscore.embedding.binding as binding_mod
+        import vtsearch.routes.detectors.scoring as scoring_mod
+
+        monkeypatch.setattr(scoring_mod, "_dataset_supplies_detector_type", lambda *_a, **_kw: True)
+        monkeypatch.setattr(binding_mod, "keying_embedder_for_snap", lambda *_a, **_kw: "clap")
+        detector_id = setup_trainable_model_in_registry(
+            "portable-patch",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+            embedder_type="patch_semantic",
+        )
+        resp = _export(client, detector_id)
+        assert resp.status_code == 200, resp.get_json()
+
+        with zipfile.ZipFile(io.BytesIO(resp.data)) as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+            onnx.checker.check_model(onnx.load_from_string(zf.read("detector.onnx")))
+
+        assert len(manifest["caveats"]) == 1
+        assert "WHOLE item" in manifest["caveats"][0]
+
     def test_export_detector_without_labels(self, client):
         from vtscore.detectors.registry import register_detector  # noqa: PLC0415
         from vtscore.detectors.store import _detector_path, _write_detector  # noqa: PLC0415

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -174,12 +174,14 @@ def make_video_media(media_id: int, embedding_dim: int = 512) -> dict:
     }
 
 
-def setup_trainable_model_in_registry(name, good_ids, bad_ids, snap, media_type="audio"):
+def setup_trainable_model_in_registry(name, good_ids, bad_ids, snap, media_type="audio", embedder_type=""):
     """Build a detector on disk + register it.  Returns its registry id.
 
     Writes ``<get_detectors_dir()>/<name>.json`` with a labelset built
     from *good_ids* and *bad_ids* using *snap* as the medias source, and
-    registers the model so ``/api/detectors/registry`` lists it.
+    registers the model so ``/api/detectors/registry`` lists it.  *embedder_type*
+    locks the detector's embedder type (``"semantic"``, ``"patch_semantic"``,
+    ``"structural"``); left empty (default) for a legacy/typeless detector.
     """
     from vtscore.datasets.labelset import LabelSet  # noqa: PLC0415
     from vtscore.detectors.registry import register_detector  # noqa: PLC0415
@@ -197,6 +199,8 @@ def setup_trainable_model_in_registry(name, good_ids, bad_ids, snap, media_type=
         "examples": [],
         "labelset": labelset.to_dict(),
     }
+    if embedder_type:
+        data["embedder_type"] = embedder_type
     _write_detector(_detector_path(name), data)
 
     entry = register_detector(name=name, media_type=media_type, num_training=len(labelset))

--- a/tests_lib/detectors/test_portable_bundle.py
+++ b/tests_lib/detectors/test_portable_bundle.py
@@ -128,6 +128,50 @@ class TestManifest:
         assert "SIFT/VLAD (instances)" in readme
         assert "exact pretrained model" not in readme
 
+    def test_manifest_caveats_default_empty(self):
+        weights = _trained_weights(input_dim=768)
+        assert _sample_manifest(weights)["caveats"] == []
+
+    def test_manifest_carries_given_caveats(self):
+        weights = _trained_weights(input_dim=768)
+        manifest = pb.build_manifest(
+            detector_name="Cats",
+            media_type="image",
+            embedder="dinov2",
+            embedder_display_name="DINOv2 (patch)",
+            embedder_model_id="facebook/dinov2-base",
+            embedder_type="patch_semantic",
+            embedding_dim=pb.embedding_dim_from_weights(weights),
+            threshold=0.5,
+            good_count=3,
+            bad_count=2,
+            exported_by="vtsearch test",
+            exported_at="2026-06-30T00:00:00Z",
+            caveats=pb.caveats_for_embedder_type("patch_semantic"),
+        )
+        assert manifest["caveats"] == pb.caveats_for_embedder_type("patch_semantic")
+        readme = pb.render_readme(manifest)
+        assert "WHOLE item" in readme
+
+
+class TestExportability:
+    def test_structural_is_blocked(self):
+        with pytest.raises(ValueError, match="structural"):
+            pb.check_exportable("structural")
+
+    def test_semantic_and_patch_and_legacy_are_exportable(self):
+        for embedder_type in ("semantic", "patch_semantic", ""):
+            pb.check_exportable(embedder_type)  # must not raise
+
+    def test_patch_semantic_has_one_caveat(self):
+        caveats = pb.caveats_for_embedder_type("patch_semantic")
+        assert len(caveats) == 1
+        assert "WHOLE item" in caveats[0]
+
+    def test_semantic_and_legacy_have_no_caveats(self):
+        assert pb.caveats_for_embedder_type("semantic") == []
+        assert pb.caveats_for_embedder_type("") == []
+
 
 class TestBundle:
     def test_bundle_members(self):

--- a/vtscore/detectors/portable_bundle.py
+++ b/vtscore/detectors/portable_bundle.py
@@ -22,6 +22,15 @@ The MLP architecture is fixed (``Linear -> ReLU -> Dropout -> Linear -> 1``; see
 via ``onnx.helper`` rather than going through ``torch.onnx``.  That keeps this
 module torch-free (it operates on the ``serialize_weights`` nested-list dict),
 avoids the dynamo/onnxscript export machinery, and is fully deterministic.
+
+Every detector's MLP is this same 2-layer architecture regardless of embedder
+*type* (semantic / patch_semantic / structural) - the type only changes what
+feeds the MLP, not its shape - so the weight tensors alone can't tell a plain
+detector from a patch or structural one.  Callers MUST call
+:func:`check_exportable` on the detector's locked embedder type before
+building a bundle: structural detectors are blocked outright (their stage-2
+RANSAC verification isn't ONNX-representable), and patch detectors export in
+a legitimately degraded whole-item-only mode via :func:`caveats_for_embedder_type`.
 """
 
 from __future__ import annotations
@@ -49,6 +58,61 @@ _ONNX_IR_VERSION = 8
 
 #: Where the README points consumers for context on what produced the bundle.
 _PROJECT_URL = "https://github.com/samggreenberg/vtsearch"
+
+#: Embedder types whose scoring can't be represented as a scoring-only ONNX
+#: graph at all, keyed to the reason.  Structural (SIFT/VLAD) detectors gate a
+#: stage-1 VLAD-space MLP behind a stage-2 RANSAC geometric-verification pass
+#: matched against raw SIFT-keypoint templates extracted from Good-vote
+#: training media (see ``vtscore/training/structural_similarity.py``).  That
+#: verification pass isn't an ONNX-representable forward pass, and the
+#: templates are raw feature data this bundle format is designed to never
+#: carry - so structural detectors are not exportable, not even in a degraded
+#: form.  Callers must invoke :func:`check_exportable` themselves;
+#: ``build_manifest``/``build_bundle`` stay pure builders and don't gate.
+_NOT_EXPORTABLE_REASONS = {
+    "structural": (
+        "structural (SIFT/VLAD) detectors can't be exported as a portable bundle: their "
+        "geometric-verification stage isn't representable as a scoring-only ONNX graph, and "
+        "its templates are raw feature data extracted from training media, which this bundle "
+        "format is designed to never include."
+    ),
+}
+
+#: Embedder types that export in a legitimate but degraded mode, keyed to the
+#: manifest/README caveat describing the degradation.  Patch (DINOv2/v3, EUPE)
+#: detectors train their MLP on per-region vectors and score by max-pooling
+#: over a media's region tree; the bundle has no way to ship that tree
+#: extraction, so it scores the whole item as a single vector instead - a
+#: legitimate subset of what the MLP saw during training (the untouched
+#: whole-image vector is one of the training rows), just without the
+#: best-sub-region search VTSearch itself does.
+_DEGRADED_EXPORT_CAVEATS = {
+    "patch_semantic": (
+        "This detector was trained to search sub-regions within each item (e.g. a specific "
+        "area of an image). This bundle scores the WHOLE item only, as a single vector - the "
+        "same way as any other detector. A match confined to a small part of an item may score "
+        "lower here than inside VTSearch, which can search and score the best-matching "
+        "sub-region directly."
+    ),
+}
+
+
+def check_exportable(embedder_type: str) -> None:
+    """Raise ``ValueError`` if *embedder_type* can't be exported as a portable bundle.
+
+    Callers (the CLI exporter, the GUI export route) must invoke this before
+    building a bundle; the reason string is written straight into the
+    exception, so it can be surfaced verbatim as a skip note or a 409 message.
+    """
+    reason = _NOT_EXPORTABLE_REASONS.get(embedder_type)
+    if reason:
+        raise ValueError(f"Detector not exportable: {reason}")
+
+
+def caveats_for_embedder_type(embedder_type: str) -> list[str]:
+    """Manifest/README caveats for a legitimate-but-degraded export, or ``[]``."""
+    caveat = _DEGRADED_EXPORT_CAVEATS.get(embedder_type)
+    return [caveat] if caveat else []
 
 
 def _split_linear_weights(
@@ -143,6 +207,7 @@ def build_manifest(
     bad_count: int,
     exported_by: str,
     exported_at: str,
+    caveats: list[str] | None = None,
 ) -> dict[str, Any]:
     """Assemble the machine-readable ``manifest.json`` payload.
 
@@ -154,7 +219,10 @@ def build_manifest(
     knows exactly which model to run new media through; it may be ``None`` for
     embedders with no single downloadable model id.  ``contains_media_data`` is
     always ``False`` - the manifest documents that the bundle carries the
-    classifier only, never embeddings or raw media.
+    classifier only, never embeddings or raw media.  ``caveats`` (see
+    :func:`caveats_for_embedder_type`) calls out any legitimate-but-degraded
+    scoring behaviour a recipient needs to know about; empty for a full-fidelity
+    export.
     """
     return {
         "format": BUNDLE_FORMAT,
@@ -180,6 +248,7 @@ def build_manifest(
         "exported_by": exported_by,
         "exported_at": exported_at,
         "contains_media_data": False,
+        "caveats": list(caveats or []),
         "notes": (
             "Standalone scoring model derived from labeled media. Contains the trained "
             "classifier only - no raw media and no embeddings are included."
@@ -198,6 +267,7 @@ def render_readme(manifest: dict[str, Any]) -> str:
     # Surface the exact pretrained model so the bundle is fully actionable: the
     # recipient can go straight to the source instead of guessing from the slug.
     model_id_clause = f" The exact pretrained model is **`{model_id}`** - use that checkpoint." if model_id else ""
+    caveats_md = "".join(f"\n> **Note:** {c}\n" for c in manifest.get("caveats") or [])
     return f"""# Portable detector: {manifest["detector_name"]}
 
 This is a **standalone scoring model** exported from
@@ -207,7 +277,7 @@ well they match the trained detector, without needing VTSearch itself.
 > **What's in here:** the trained classifier only. There is **no raw media and
 > there are no embeddings** in this bundle - just a small neural network and the
 > instructions to run it.
-
+{caveats_md}
 ## Files
 
 | File | Purpose |

--- a/vtscore/exporters/portable_detector/__init__.py
+++ b/vtscore/exporters/portable_detector/__init__.py
@@ -13,10 +13,13 @@ media - so a third party can score their own media without VTSearch.
 
 Unlike every other exporter, this one consumes the *trained classifiers*, not
 the scored results, so it sets :attr:`needs_trained_detectors` and the pipeline
-hands it the detectors via :meth:`export_cli_detectors`.  Detectors whose
-scoring isn't the fixed 2-layer MLP (patch DINOv2/v3, structural SIFT/VLAD) are
-skipped with a note rather than aborting the whole export - the ONNX graph only
-models the plain linear stack (see ``docs/plans/detector-standalone-export.md``).
+hands it the detectors via :meth:`export_cli_detectors`.  Structural (SIFT/VLAD)
+detectors are skipped with a note rather than aborting the whole export - their
+stage-2 RANSAC verification isn't representable as a scoring-only ONNX graph
+(see :func:`vtscore.detectors.portable_bundle.check_exportable`).  Patch
+(DINOv2/v3, EUPE) detectors export normally, in a degraded whole-item-only
+scoring mode (see :func:`vtscore.detectors.portable_bundle.caveats_for_embedder_type`);
+see ``docs/plans/detector-standalone-export.md``.
 """
 
 from __future__ import annotations
@@ -102,18 +105,21 @@ class PortableDetectorLabelsetExporter(LabelsetExporter):
         multi = len(detectors) > 1
 
         written: list[str] = []
-        skipped: list[str] = []
+        skipped: list[tuple[str, str]] = []
         for descriptor in detectors:
             name = descriptor.get("detector_name", "") or "detector"
             weights = descriptor.get("weights") or {}
+            embedder_type = descriptor.get("embedder_type", "") or ""
             try:
+                pb.check_exportable(embedder_type)
                 manifest = self._build_manifest(pb, descriptor)
                 bundle = pb.build_bundle(weights=weights, manifest=manifest)
             except ValueError as exc:
-                # Non-2-layer MLP (patch / structural detector): the ONNX graph
-                # can't represent it. Skip this detector, keep exporting the rest.
+                # Either the embedder type is blocked outright (structural), or
+                # the weight shape can't be modelled by the fixed ONNX graph.
+                # Skip this detector, keep exporting the rest.
                 logger.warning("portable_detector: skipping %r (%s)", name, exc)
-                skipped.append(name)
+                skipped.append((name, str(exc)))
                 continue
 
             out_path = self._resolve_path(template, name, disambiguate=multi)
@@ -128,6 +134,7 @@ class PortableDetectorLabelsetExporter(LabelsetExporter):
     def _build_manifest(pb: Any, descriptor: dict[str, Any]) -> dict[str, Any]:
         """Assemble the bundle manifest for one trained detector."""
         embedder_name = descriptor.get("embedder", "") or ""
+        embedder_type = descriptor.get("embedder_type", "") or ""
         embedder_display = embedder_name
         embedder_model_id: str | None = None
         if embedder_name:
@@ -146,13 +153,14 @@ class PortableDetectorLabelsetExporter(LabelsetExporter):
             embedder=embedder_name,
             embedder_display_name=embedder_display,
             embedder_model_id=embedder_model_id,
-            embedder_type=descriptor.get("embedder_type", "") or "",
+            embedder_type=embedder_type,
             embedding_dim=pb.embedding_dim_from_weights(descriptor.get("weights") or {}),
             threshold=float(descriptor.get("threshold", 0.5)),
             good_count=int(descriptor.get("good_count", 0)),
             bad_count=int(descriptor.get("bad_count", 0)),
             exported_by=_exported_by(),
             exported_at=_utc_now_iso(),
+            caveats=pb.caveats_for_embedder_type(embedder_type),
         )
 
     @staticmethod
@@ -185,15 +193,21 @@ class PortableDetectorLabelsetExporter(LabelsetExporter):
         return validate_server_filepath(resolved, base_dir=get_file_access_base_dir())
 
     @staticmethod
-    def _status(written: list[str], skipped: list[str]) -> dict[str, Any]:
+    def _status(written: list[str], skipped: list[tuple[str, str]]) -> dict[str, Any]:
         """Build the confirmation status dict from the write/skip tallies."""
         if not written:
-            detail = f" ({len(skipped)} skipped: not a 2-layer MLP)" if skipped else ""
-            return {"message": f"No portable detector bundles written{detail}.", "filepaths": []}
+            if not skipped:
+                return {"message": "No portable detector bundles written.", "filepaths": []}
+            reasons = "; ".join(f"{name} ({reason})" for name, reason in skipped)
+            return {
+                "message": f"No portable detector bundles written ({len(skipped)} skipped): {reasons}.",
+                "filepaths": [],
+            }
 
         parts = [f"Wrote {len(written)} portable detector bundle(s)."]
         if skipped:
-            parts.append(f"Skipped {len(skipped)} non-exportable detector(s): {', '.join(skipped)}.")
+            names = ", ".join(name for name, _reason in skipped)
+            parts.append(f"Skipped {len(skipped)} non-exportable detector(s): {names}.")
         return {"message": " ".join(parts), "filepaths": written}
 
 

--- a/vtsearch/routes/detectors/export.py
+++ b/vtsearch/routes/detectors/export.py
@@ -8,6 +8,13 @@ This is the sanctioned exception to the "No Persisted Vectors or MLPs" rule
 (``CLAUDE.md``): the bundle persists the trained MLP - never embeddings or raw
 media - so other parties can score their own media without VTSearch.
 
+Structural (SIFT/VLAD) detectors are rejected outright (409): their stage-2
+RANSAC verification isn't representable as a scoring-only ONNX graph.  Patch
+(DINOv2/v3, EUPE) detectors export normally in a degraded whole-item-only
+scoring mode, flagged in the manifest/README.  See
+:func:`vtscore.detectors.portable_bundle.check_exportable` /
+:func:`vtscore.detectors.portable_bundle.caveats_for_embedder_type`.
+
 Migrated to ``flask_smorest`` so the route is described in
 ``/api/openapi.json``.  The success body is a raw ``application/zip`` download,
 so (like the dataset-export route) it is left undescribed in the spec and only
@@ -39,7 +46,13 @@ detectors_export_bp = Blueprint(
 @detectors_export_bp.route("/api/detectors/<detector_id>/portable-bundle", methods=["POST"])
 @detectors_export_bp.alt_response(400, description="No medias loaded, or the detector has no labels for scoring.")
 @detectors_export_bp.alt_response(404, description="Detector not found.")
-@detectors_export_bp.alt_response(409, description="The active dataset can't supply the detector's embedder type.")
+@detectors_export_bp.alt_response(
+    409,
+    description=(
+        "The active dataset can't supply the detector's embedder type, or the detector's type "
+        "(structural) can't be exported as a portable bundle at all."
+    ),
+)
 @require_dataset_header
 def export_portable_bundle(detector_id: str):
     """Train the detector against the active dataset and stream its portable bundle.
@@ -81,6 +94,16 @@ def export_portable_bundle(detector_id: str):
     if not _dataset_supplies_detector_type(det_data, snap):
         abort(409, message=_type_incompatible_message(det_data))
 
+    # Exportability gate: structural detectors can't be represented as a
+    # scoring-only ONNX graph at all (see portable_bundle.check_exportable's
+    # docstring). Check before training so we don't waste the retrain on a
+    # detector this route will refuse to bundle.
+    det_type = _detector_type(det_data)
+    try:
+        pb.check_exportable(det_type)
+    except ValueError as exc:
+        abort(409, message=str(exc))
+
     mlp, threshold, diagnostic = resolve_or_train_detector(detector_id, det_data, media_type, snap)
     if mlp is None:
         if diagnostic is not None:
@@ -98,7 +121,6 @@ def export_portable_bundle(detector_id: str):
 
     # Score-space embedder: the concrete embedder of the detector's locked type
     # this dataset supplies (matches Find / resolve_or_train_detector's space).
-    det_type = _detector_type(det_data)
     score_emb = keying_embedder_for_snap(SimpleNamespace(embedder_type=det_type), snap)
     embedder_display = score_emb or ""
     embedder_model_id: str | None = None
@@ -128,6 +150,7 @@ def export_portable_bundle(detector_id: str):
         bad_count=bad_count,
         exported_by=f"vtsearch {vtsearch.__version__}",
         exported_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        caveats=pb.caveats_for_embedder_type(det_type),
     )
     bundle = pb.build_bundle(weights=weights, manifest=manifest)
 


### PR DESCRIPTION
## Summary

While scoping the "Patch / structural detectors" follow-up in `docs/plans/detector-standalone-export.md`, found that the exporter's existing safeguard doesn't actually work: it claims patch (DINOv2/v3, EUPE) and structural (SIFT/VLAD) detectors are skipped because they're "not a 2-layer MLP," but every detector's serialized MLP — patch, structural, or plain — is the identical 2-layer shape (patch trains on per-region vectors, structural on VLAD vectors, but the weight tensors alone can't tell them apart). So exporting a real patch or structural detector today **silently succeeds** and ships a bundle with no warning that it's missing critical scoring logic.

This PR:
- Adds an explicit `embedder_type` gate (`vtscore/detectors/portable_bundle.check_exportable`), applied in both the CLI exporter and the GUI export route.
- **Structural detectors are now genuinely blocked** with a clear reason (409 in the GUI route, a distinct skip reason in the CLI exporter's summary message) — their stage-2 RANSAC geometric verification against raw SIFT-keypoint templates isn't representable as a scoring-only ONNX graph, and the templates are raw feature data this bundle format is designed to never include.
- **Patch detectors now export successfully** in a legitimate, documented degraded mode: whole-item-only scoring (no sub-region search), since a whole-image vector is already one of the rows the MLP trains on. The degradation is surfaced via a new `manifest["caveats"]` field and a matching README callout.
- Updates `docs/plans/detector-standalone-export.md`: removes the resolved "Patch / structural detectors" item, narrows it to the remaining future work (full sub-region-fidelity export), and notes re-import is intentionally not planned (one-way export).

## Test plan
- [x] `./run-tests.sh detectors -- -k portable` — 32 passed
- [x] `./run-tests.sh detectors` — 1623 passed
- [x] `./run-tests.sh` (full suite incl. frontend build/audit/Vitest gate) — 6447 passed, 1 skipped, 1 xfailed, 1 xpassed
- [x] Regenerated `frontend/openapi.json` (the 409 `alt_response` description changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_014JDmk2bMQk97ddwUnhQV7x)_