### PR TITLE
Honest whole-job ETA for warm and uncalibrated dataset loads

### DIFF
--- a/frontend/src/app/components/job-progress/job-progress.component.html
+++ b/frontend/src/app/components/job-progress/job-progress.component.html
@@ -44,6 +44,6 @@
       [indeterminate]="bar().indeterminate"
       [smooth]="smooth()"
     />
-    <span class="jp__eta">{{ eta() }}</span>
+    <span class="jp__eta" [title]="eta() ? etaTooltip : ''">{{ eta() }}</span>
   </div>
 </div>

--- a/frontend/src/app/components/job-progress/job-progress.component.spec.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.spec.ts
@@ -33,6 +33,15 @@ describe('JobProgressComponent', () => {
     expect(text).toContain('5.5 min left');
   });
 
+  it('labels the eta chip as a whole-job estimate on hover', async () => {
+    const el = fixture.nativeElement as HTMLElement;
+    // No eta -> no tooltip (an empty chip should not invite hovering).
+    expect(el.querySelector('.jp__eta')?.getAttribute('title')).toBeFalsy();
+    fixture.componentRef.setInput('eta', '5.5 min left?');
+    await settleZoneless(fixture);
+    expect(el.querySelector('.jp__eta')?.getAttribute('title')).toContain('whole job');
+  });
+
   it('shows the info chip only when a description is provided', async () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.jp__info')).toBeNull();

--- a/frontend/src/app/components/job-progress/job-progress.component.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.ts
@@ -38,6 +38,12 @@ export class JobProgressComponent {
   readonly detail = input('');
   /** Right-justified status, e.g. "5.5 min left" or "45%". */
   readonly eta = input('');
+  /**
+   * The chip shows the backend's whole-job estimate (`eta_seconds`), never a
+   * "time left in this step" number — say so on hover, since a long remaining
+   * phase can make it read as wrong next to the current step's counts (#2615).
+   */
+  readonly etaTooltip = 'Estimated time until the whole job finishes, not just the current step';
   /** Bar fill state; defaults to an indeterminate spinner. */
   readonly bar = input<ProgressBarState>({ value: 0, max: 1, indeterminate: true });
   /** Ease the fill for multi-phase jobs (see `vt-progress-bar`'s `smooth`). */

--- a/tests_lib/core/test_progress_overall.py
+++ b/tests_lib/core/test_progress_overall.py
@@ -209,6 +209,33 @@ class TestOverallEta:
         t.update("embedding", "x", current=10, total=100, step=2, total_steps=2)
         assert t.get()["eta_seconds"] is not None
 
+    def test_warm_phases_do_not_poison_the_overall_eta(self, monkeypatch):
+        # Regression for #2615: a warm re-import completes steps 1-2 almost
+        # instantly, banking ~30% of the bar in under a second. The job-global
+        # average rate then projected the whole load at that pace ("10 sec
+        # left?" at the start of a 2.5-minute embed, creeping upward the whole
+        # time). The rate window must rebase at each step boundary so the
+        # extrapolation reflects the pace the job sustains *now*.
+        t = _tracker()
+        t.set_step_weights([0.2, 0.1, 0.3, 0.4])
+        clock = {"now": 0.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+
+        t.update("loading", "prep", current=0, total=0, step=1, total_steps=4)
+        clock["now"] = 0.5
+        # Warm archive: straight to embedding, 30% of the bar banked instantly.
+        t.update("embedding", "x", current=0, total=1000, step=3, total_steps=4)
+        assert t.get()["eta_seconds"] is None  # an instant span is not a rate signal
+        # 10s into embedding, 70/1000 done (a ~140s phase).
+        clock["now"] = 10.5
+        t.update("embedding", "x", current=70, total=1000, step=3, total_steps=4)
+        eta = t.get()["eta_seconds"]
+        assert eta is not None
+        # Phase-local extrapolation: 10s bought 0.021 of the bar, so the
+        # remaining 0.679 reads as minutes — not the tens of seconds the
+        # banked warm spans used to suggest.
+        assert eta > 100.0
+
 
 class TestFinalizeProgress:
     """The FinalizeProgress proxy maps each finalize sub-stage into its own

--- a/tests_lib/datasets/test_adaptive_load_pacer.py
+++ b/tests_lib/datasets/test_adaptive_load_pacer.py
@@ -204,3 +204,64 @@ def test_slow_phase_grows_its_span_and_the_bar_follows(clock):
     clock.advance(50.0)
     pacer.update("loading", "decode", 1000, 1000, step=2)
     assert halfway < _overall(tracker) < 1.0
+
+
+# Static-profile fallback: unitless pseudo-times (the CPU profile's ratios),
+# not seconds. Only their ratios are meaningful.
+PSEUDO_TERMS = {"download": 0.1875, "extract": 0.0625, "load": 0.10, "embed": 0.55, "finalize": 0.10}
+
+
+def _make_pseudo(terms):
+    tracker = ProgressTracker(extra_fields=dict(_OVERALL_EXTRAS))
+    pacer = AdaptiveLoadPacer(tracker, terms, calibrated=False)
+    return tracker, pacer
+
+
+def test_pseudo_terms_keep_prior_ratios_when_a_phase_is_observed(clock):
+    # Regression for #2615: with static fallback terms, a 30s observed model
+    # load was written (in seconds) over its 0.10 pseudo-term, so its share of
+    # the remaining bar became 30/(30+0.55+0.10) ~ 98% — the bar leapt to ~1.0
+    # entering embed and the whole-job ETA pinned near zero for the entire
+    # (dominant) embed phase. An observation must fix the scale, not the
+    # ratios: embed keeps its prior ratio to the observed load term.
+    tracker, pacer = _make_pseudo(PSEUDO_TERMS)
+    pacer.update("loading", "model", 0, 100, step=2)
+    clock.advance(30.0)
+    pacer.update("loading", "model", 50, 100, step=2)  # projected 60s total
+    # Load's share of the whole bar must stay near its prior ratio
+    # (0.10 / 0.75 of the post-acquire remainder), not swallow it.
+    assert pacer._terms["load"] == pytest.approx(60.0)
+    assert pacer._terms["embed"] == pytest.approx(60.0 * 0.55 / 0.10)
+    assert pacer._terms["finalize"] == pytest.approx(60.0 * 0.10 / 0.10)
+    clock.advance(30.0)
+    pacer.update("loading", "model", 100, 100, step=2)
+    pacer.update("embedding", "e", 0, 200, step=3)
+    # Entering embed, most of the bar must still be ahead of us: embed's prior
+    # dominates the profile, so consumed stays well below ~50%.
+    assert _overall(tracker) < 0.5
+
+
+def test_pseudo_terms_unbudgeted_phase_does_not_grab_the_bar(clock):
+    # A phase with a zero prior gives no seconds-per-unit scale; the pacer
+    # must keep pacing by the remaining priors rather than hand the phase the
+    # whole remaining span.
+    terms = dict(PSEUDO_TERMS, load=0.0)
+    tracker, pacer = _make_pseudo(terms)
+    pacer.update("loading", "model", 0, 100, step=2)
+    clock.advance(30.0)
+    pacer.update("loading", "model", 50, 100, step=2)
+    assert pacer._terms["embed"] == pytest.approx(0.55)
+    pacer.update("embedding", "e", 0, 200, step=3)
+    assert _overall(tracker) < 0.5
+
+
+def test_calibrated_terms_still_replace_only_the_observed_phase(clock):
+    # Seconds-mode behavior is unchanged: the observed phase's term is
+    # replaced by its projection and the others keep their measured values.
+    tracker, pacer = _make(TERMS)
+    pacer.update("loading", "decode", 0, 100, step=2)
+    clock.advance(10.0)
+    pacer.update("loading", "decode", 50, 100, step=2)  # projected 20s vs 5s term
+    assert pacer._terms["load"] == pytest.approx(20.0)
+    assert pacer._terms["embed"] == pytest.approx(TERMS["embed"])
+    assert pacer._terms["finalize"] == pytest.approx(TERMS["finalize"])

--- a/tests_lib/datasets/test_load_step_weights.py
+++ b/tests_lib/datasets/test_load_step_weights.py
@@ -206,10 +206,22 @@ def test_load_cost_terms_static_fallback_splits_acquire(monkeypatch):
     monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cpu")
     # No n -> static pseudo-terms; the acquire slice splits download/extract
     # and the four step sums reproduce the static profile exactly.
-    terms = load_cost_terms("audio")
+    terms, calibrated = load_cost_terms("audio")
+    assert calibrated is False
     assert set(terms) == {"download", "extract", "load", "embed", "finalize"}
     assert terms["download"] + terms["extract"] == pytest.approx(_LOAD_STEP_WEIGHTS_CPU[0])
     assert terms["load"] == pytest.approx(_LOAD_STEP_WEIGHTS_CPU[1])
     assert terms["embed"] == pytest.approx(_LOAD_STEP_WEIGHTS_CPU[2])
     assert terms["finalize"] == pytest.approx(_LOAD_STEP_WEIGHTS_CPU[3])
     assert terms["download"] > terms["extract"] > 0
+
+
+def test_load_cost_terms_reports_calibrated_when_a_cost_row_matches(monkeypatch):
+    from vtscore.datasets.stages._common import load_cost_terms
+
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cuda")
+    # ("cuda", "audio", "clap") is a measured row, so the terms are seconds
+    # from the affine model and flagged calibrated.
+    terms, calibrated = load_cost_terms("audio", n=1000, embedder="clap")
+    assert calibrated is True
+    assert terms["embed"] > 0

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -155,7 +155,10 @@ class ProgressTracker:
         :meth:`_compute_eta`). The fraction is clamped to be monotonic
         non-decreasing within a job so the bar never visibly retreats; a step
         going *backwards* (or ``total_steps`` changing) is read as a brand-new
-        job and resets the overall clock.
+        job and resets the overall clock. The ETA's rate window rebases at
+        every forward step boundary so each step's extrapolation reflects the
+        pace the job is sustaining *now*, not an average polluted by phases
+        that completed instantly (cached downloads) or crawled.
         """
         if not step or not total_steps or total_steps <= 0:
             self._overall_start_time = None
@@ -187,6 +190,7 @@ class ProgressTracker:
             self._overall_total_steps = total_steps
             return raw, None
 
+        step_advanced = self._overall_last_step is not None and s > self._overall_last_step
         self._overall_last_step = s
         # Clamp to monotonic non-decreasing so within-step jitter never rewinds
         # the unified bar.
@@ -199,6 +203,21 @@ class ProgressTracker:
         assert self._overall_start_time is not None
         elapsed = now - self._overall_start_time
         progressed = raw - self._overall_start_frac
+        if step_advanced:
+            # Rebase the rate window at every forward step boundary. Phases
+            # run at wildly different fraction-rates — a cached download banks
+            # its whole bar span in milliseconds — and a job-global average
+            # lets that instantly-earned span masquerade as sustained speed,
+            # so the extrapolated ETA starts absurdly low on warm loads
+            # (issue #2615) or absurdly high after a mispaced slow phase.
+            # The boundary update itself still samples the *outgoing* step's
+            # window (a full step observed over a real elapsed span is honest
+            # signal, and the min-elapsed gate below already discards the
+            # instantly-completed case); every later update extrapolates from
+            # the rate the job sustains within the current step. The smoothed
+            # EMA carries across so the displayed value stays continuous.
+            self._overall_start_time = now
+            self._overall_start_frac = raw
         if elapsed < self._ETA_MIN_ELAPSED or progressed <= 0 or raw >= 1.0:
             # Not enough signal yet (or done): hold the last smoothed estimate.
             return raw, self._overall_smoothed_eta

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -462,10 +462,10 @@ def _run_origin_load_in_background(
         # Pace the unified bar from the per-phase cost terms, rebasing on what
         # actually happens (cached archives, observed bandwidth, skipped
         # phases). All stage progress below routes through the pacer.
-        pacer = AdaptiveLoadPacer(
-            tracker,
-            load_cost_terms(media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder),
+        cost_terms, terms_calibrated = load_cost_terms(
+            media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder
         )
+        pacer = AdaptiveLoadPacer(tracker, cost_terms, calibrated=terms_calibrated)
         stepped = _make_stepped_progress(controller, pacer)
         profiler.bind_thread()  # so FinalizeProgress.begin stamps land here (no-op when off)
 

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -160,15 +160,20 @@ def load_cost_terms(
     n: Optional[int] = None,
     download_size_mb: Optional[float] = None,
     embedder: Optional[str] = None,
-) -> dict[str, float]:
+) -> tuple[dict[str, float], bool]:
     """Predicted per-phase cost terms for a dataset load, in phase order
     ``download``, ``extract``, ``load``, ``embed``, ``finalize``.
 
-    When ``n`` is known and a measured cost-model row exists, the terms are
-    seconds from the affine model. Otherwise they are pseudo-times derived from
-    the static per-(device, media) weight profile — only their ratios matter,
-    and the acquire slice is split between download and extraction by archive
-    size when known, else by :data:`_STATIC_DOWNLOAD_SHARE`.
+    Returns ``(terms, calibrated)``. When ``n`` is known and a measured
+    cost-model row exists, the terms are seconds from the affine model and
+    ``calibrated`` is ``True``. Otherwise they are pseudo-times derived from
+    the static per-(device, media) weight profile (``calibrated=False``) —
+    only their ratios matter, and the acquire slice is split between download
+    and extraction by archive size when known, else by
+    :data:`_STATIC_DOWNLOAD_SHARE`. The flag tells the
+    :class:`AdaptiveLoadPacer` whether an observed phase duration (seconds)
+    is unit-compatible with the other terms — mixing seconds into the
+    pseudo-time vector hands the observed phase essentially the whole bar.
 
     Always returns a usable dict (never raises), so the pacing layer can rely
     on it for every import path, including streaming folder importers.
@@ -181,7 +186,7 @@ def load_cost_terms(
         emb = embedder or _default_embedder_name(media_type)
         terms = cost_model_terms(device, media_type, emb, n, download_size_mb)
         if terms is not None:
-            return terms
+            return terms, True
 
     if device == "cuda":
         w = _LOAD_STEP_WEIGHTS_GPU
@@ -204,7 +209,7 @@ def load_cost_terms(
         "load": w[1],
         "embed": w[2],
         "finalize": w[3],
-    }
+    }, False
 
 
 class FinalizeProgress:
@@ -352,9 +357,16 @@ class AdaptiveLoadPacer:
     #: Re-derive the weights from the observed rate at most this often.
     _RATE_REWEIGHT_INTERVAL = 1.0
 
-    def __init__(self, tracker, terms: dict[str, float]) -> None:
+    def __init__(self, tracker, terms: dict[str, float], calibrated: bool = True) -> None:
         self._tracker = tracker
         self._terms = {p: max(0.0, float(terms.get(p, 0.0))) for p in _PHASE_ORDER}
+        # Whether the terms are measured seconds (cost model) or unitless
+        # pseudo-times (static profile fallback). Observation replaces terms
+        # with real seconds, which is only meaningful against other seconds —
+        # see _observe_phase_rate.
+        self._calibrated = calibrated
+        self._prior_terms = dict(self._terms)
+        self._observed: set[str] = set()
         self._phase: str | None = None
         self._phase_t0 = 0.0
         self._frac = 0.0  # monotone within-phase fraction
@@ -448,6 +460,17 @@ class AdaptiveLoadPacer:
         smaller overall fraction than already shown; the tracker's monotonic
         clamp holds the bar flat until the target catches up, which reads as a
         brief pause rather than a rewind.
+
+        When the terms are *pseudo-times* (static profile fallback, no
+        cost-model row), an observed duration in seconds is not comparable to
+        the other phases' unitless terms — writing it in directly hands the
+        observed phase ~100% of the remaining span (a 30 s model load vs a
+        ``0.55`` embed term), which collapses every later phase to a sliver
+        and pins the ETA near zero for the rest of the load (issue #2615).
+        The observation instead fixes the seconds-per-pseudo-unit scale: the
+        not-yet-observed phases are rescaled to keep their prior ratio to the
+        observed phase, so the bar keeps pacing by the profile's ratios while
+        phases that have real measurements use them.
         """
         phase = self._phase
         if phase is None or self._frac >= 1.0:
@@ -461,7 +484,19 @@ class AdaptiveLoadPacer:
         if now - self._last_rate_reweight < self._RATE_REWEIGHT_INTERVAL:
             return
         self._last_rate_reweight = now
-        self._terms[phase] = elapsed / self._frac
+        projected = elapsed / self._frac
+        if not self._calibrated:
+            prior = self._prior_terms.get(phase, 0.0)
+            if prior <= 0.0:
+                # An unbudgeted phase gives no usable scale; pacing by the
+                # remaining priors beats handing it the whole bar.
+                return
+            scale = projected / prior
+            for p in _PHASE_ORDER:
+                if p != phase and p not in self._observed:
+                    self._terms[p] = self._prior_terms[p] * scale
+        self._observed.add(phase)
+        self._terms[phase] = projected
         self._span = (1.0 - self._consumed) * self._phase_share(phase)
         self._weights = self._weights_vector()
         self._tracker.set_step_weights(self._weights)


### PR DESCRIPTION
## Summary

Fixes #2615 — the loading-row ETA (`eta_seconds`) was wildly wrong on warm and uncalibrated loads. Two root causes, both fixed here, plus the issue's UI-labeling ask.

First, the confirmation the investigation handoff asked for: **the dashboard row and the SSE payload cannot disagree — confirmed live.** Captured the browser row text and the raw `loading-tasks` frames at the same instants during a warm GTZAN re-import on the GRID dev: row "10 sec left?" ↔ `eta_seconds=12.4`, row "1 min left?" ↔ `eta_seconds=66.2`. The row is `formatEta(eta_seconds)`, frame-for-frame. The bug was always the payload value itself. (The original "row 2.5 min vs SSE ~3300 s" observation paired numbers from different instants of a pre-#2613 load — 3300 s is exactly the pre-pacer ballooned estimate from that session.)

### Root cause 1 — tracker: job-global rate extrapolation (`ProgressTracker._compute_overall`)

`eta = elapsed·(1−raw)/progressed` measured **since job start**. A warm re-import completes download+extract in under a second, banking ~30% of the bar instantly — the estimator reads that as sustained speed and projects "10 sec left?" at the start of a 2.5-minute embed, creeping upward the whole way (live GTZAN run: eta 12s → 66s → ~98s while true remaining went 157s → 21s, crossing from 9× under to 5× over).

**Fix:** rebase the rate window at every forward step boundary. The boundary update still samples the outgoing step's window (a fully-observed step is honest signal; the existing `_ETA_MIN_ELAPSED` gate discards the instantly-completed case), and the EMA carries across so the displayed value stays continuous. Existing ETA tests pass unchanged.

### Root cause 2 — pacer: seconds written into pseudo-time weights (`AdaptiveLoadPacer._observe_phase_rate`)

When no cost-model row matches (`load_cost_terms` static fallback — which is what every demo import without an explicit `media_type`/`embedder` gets), the terms are **unitless pseudo-times** (e.g. `load=0.10`, `embed=0.55`). The rate observation replaced the current phase's term with its projected duration **in seconds** — a 30 s model load vs `0.55` hands the observed phase ~100% of the remaining bar. Observed live (warm esc50_s, CPU): the bar leapt 0.115 → **0.977** the moment step 2 was observed, then the entire 100-second embed phase crawled 0.98 → 1.0 showing **eta < 1.5 s throughout**.

**Fix:** `load_cost_terms` now returns `(terms, calibrated)`. In pseudo mode an observation fixes the seconds-per-pseudo-unit **scale** — not-yet-observed phases are rescaled to keep their prior ratio to the observed phase. Calibrated (cost-model seconds) behavior is unchanged: only the observed phase's term is replaced.

### UI labeling

The `vt-job-progress` eta chip gets a hover title — "Estimated time until the whole job finishes, not just the current step" — so a whole-job number next to per-step counts stops reading as wrong.

## Validation (in-process on the GRID, warm esc50_s import, CPU static fallback)

| t | phase | before: overall / eta | after: overall / eta | true remaining |
|---|-------|----------------------|---------------------|----------------|
| 36s | embed 0/245 | 0.980 / 1.4s | 0.133 / 165s | ~103s |
| 75s | embed ~113/245 | 0.989 / 0.9s | 0.472 / 72s | ~56s |
| 122s | embed 225/245 | 0.998 / 0.3s | 0.807 / 27s | ~10s |

Bar paces through the dominant phase instead of pinning at 98%; ETA tracks the true remaining time and converges from ~1.6× to ~2.7× near the end of the phase instead of being off by 100×. Known residual: mid-model-load the ETA can briefly overshoot (~17 min shown at t=19s) until the phase completes ~10 s later — it is the honest "current pace continues" estimate with very little signal.

Tests: `tests_lib/core` + `tests_lib/datasets` (751 passed), new regression tests for both root causes and the pseudo-scale bridging; `job-progress.component.spec.ts` (9 passed) for the tooltip. Ruff clean.

## Deploy note

The dev server on rack8n06:11850 was restarted at 15:28 **from the main checkout before `git pull` picked up #2613** — it is still running pre-pacer code (that's what made today's live runs reproduce the pre-#2613 symptoms so faithfully). The checkout is now up to date; the next `vtsearch` launch picks up #2613, and this branch once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
