### PR TITLE
Background the dataset-promote coverage-atlas build like the import pipeline

### DIFF
--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -467,9 +467,13 @@ POST /api/dataset/promote
 dataset (both fields required, non-empty).
 
 Snapshots the selected media (preserving origins and embeddings) into a brand-
-new saved, registered dataset.
+new saved, registered dataset. The snapshot happens synchronously (a bad
+request still 400s at request time); the coverage-atlas build, pickle write,
+and registry insert run in a background task reported on the `loading-tasks`
+SSE channel. The finished task's `dataset_id` association carries the new
+dataset's id.
 
-→ `{"ok": true, "dataset_id": "abc123", "name": "My subset", "num_items": 3}`
+→ `{"ok": true, "message": "Promoting to dataset...", "task_id": "_promote_ab12cd34"}`
 
 ---
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1326,30 +1326,6 @@
         ],
         "type": "object"
       },
-      "DatasetPromoteResponse": {
-        "additionalProperties": false,
-        "properties": {
-          "dataset_id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "num_items": {
-            "type": "integer"
-          },
-          "ok": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "dataset_id",
-          "name",
-          "num_items",
-          "ok"
-        ],
-        "type": "object"
-      },
       "DatasetRegistryLoadResponse": {
         "additionalProperties": false,
         "properties": {
@@ -9087,7 +9063,7 @@
     },
     "/api/dataset/promote": {
       "post": {
-        "description": "Used by the Find interface's \"To Dataset\" button to turn the Goods\npile into its own dataset. The promoted items keep their original\norigins and in-memory embeddings (so preprocessing is preserved for\nfree; the new pickle is a self-contained snapshot). The new dataset\ngets a fresh ``created_at`` but inherits the source dataset's\n``expires_at`` (death date).",
+        "description": "Used by the Find interface's \"To Dataset\" button to turn the Goods\npile into its own dataset. The promoted items keep their original\norigins and in-memory embeddings (so preprocessing is preserved for\nfree; the new pickle is a self-contained snapshot). The new dataset\ngets a fresh ``created_at`` but inherits the source dataset's\n``expires_at`` (death date).\n\nThe subset snapshot and metadata derivation run synchronously (cheap:\nshallow copies); the expensive part \u2014 coverage-atlas build, pickle\nwrite, registry insert \u2014 runs in a background task.  The response\ncarries the ``task_id``; the caller polls the ``loading-tasks`` SSE\nchannel for progress and reads the finished task's ``dataset_id``\nassociation for the new dataset's id.",
         "operationId": "promote_to_dataset",
         "requestBody": {
           "content": {
@@ -9104,7 +9080,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DatasetPromoteResponse"
+                  "$ref": "#/components/schemas/DatasetLoadStartedResponse"
                 }
               }
             },
@@ -9115,9 +9091,6 @@
           },
           "422": {
             "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
-          },
-          "500": {
-            "description": "Failed to write or register the new dataset."
           },
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -14,6 +14,7 @@ import { MediasApiService } from '../../services/medias-api.service';
 import { DetectorsFindApiService } from '../../services/detectors-find-api.service';
 import { DatasetsRegistryApiService } from '../../services/datasets-registry-api.service';
 import { DatasetsCrudApiService } from '../../services/datasets-crud-api.service';
+import { DashboardLoadingTasksService } from '../../services/dashboard-loading-tasks.service';
 import { ToastService } from '../../services/toast.service';
 import { VtDialogService } from '../../services/dialog.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -55,6 +56,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private detectorsFindApi = inject(DetectorsFindApiService);
   private datasetsRegistryApi = inject(DatasetsRegistryApiService);
   private datasetsCrudApi = inject(DatasetsCrudApiService);
+  private loadingTasksSvc = inject(DashboardLoadingTasksService);
   private toast = inject(ToastService);
   private dialog = inject(VtDialogService);
   private ngZone = inject(NgZone);
@@ -755,8 +757,11 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
    * Promote *ids* into their own saved dataset. The promoted items keep their
    * origins and embeddings; the new dataset gets a fresh created date but
    * inherits this dataset's death date. We prompt for a name (prefilled
-   * "<dataset> <detector> Results"), then create + register it and confirm
-   * with a toast (staying in Find).
+   * "<dataset> <detector> Results"), then kick off the background promote
+   * task; progress shows on the Datasets dashboard's loading rows, and we
+   * confirm with a toast once the task settles (staying in Find). A failed
+   * task is toasted globally by the SSE error router, so the completion
+   * callback only fires on success.
    */
   private toDatasetFromIds(ids: number[]): void {
     if (ids.length === 0) return;
@@ -773,9 +778,11 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
         .pipe(takeUntil(this.destroy$))
         .subscribe({
           next: (res) => {
-            this.toast.success({
-              message: `Created dataset "${res.name}"`,
-              detail: `${res.num_items} item${res.num_items === 1 ? '' : 's'} promoted. Find it in the Datasets dashboard.`,
+            this.loadingTasksSvc.startProgressPolling(res.task_id, () => {
+              this.toast.success({
+                message: `Created dataset "${trimmed}"`,
+                detail: `${ids.length} item${ids.length === 1 ? '' : 's'} promoted. Find it in the Datasets dashboard.`,
+              });
             });
           },
         });

--- a/frontend/src/app/services/datasets-crud-api.service.ts
+++ b/frontend/src/app/services/datasets-crud-api.service.ts
@@ -10,7 +10,6 @@ import type { DatasetAllImportersListResponse } from '../generated/api-client/mo
 import type { DatasetAvailableFilesResponse } from '../generated/api-client/models/dataset-available-files-response';
 import type { DatasetClearResponse } from '../generated/api-client/models/dataset-clear-response';
 import type { DatasetCombineRequest } from '../generated/api-client/models/dataset-combine-request';
-import type { DatasetPromoteResponse } from '../generated/api-client/models/dataset-promote-response';
 import type { DatasetImportersListResponse } from '../generated/api-client/models/dataset-importers-list-response';
 import type { DatasetLoadDemoRequest } from '../generated/api-client/models/dataset-load-demo-request';
 import type { DatasetLoadSourceRequest } from '../generated/api-client/models/dataset-load-source-request';
@@ -179,8 +178,10 @@ export class DatasetsCrudApiService {
   }
 
   /** Promote a set of media items (the Find Goods pile) into their own
-   *  saved dataset. Resolves with the new dataset's id / name / count. */
-  promote(name: string, mediaIds: number[]): Observable<DatasetPromoteResponse> {
+   *  saved dataset in a background task. Resolves with the ``task_id``;
+   *  progress (and the finished task's ``dataset_id``) arrives on the
+   *  ``loading-tasks`` SSE channel. */
+  promote(name: string, mediaIds: number[]): Observable<DatasetLoadStartedResponse> {
     return promoteToDataset(this.http, this.config.rootUrl, {
       body: { name, media_ids: mediaIds },
     }).pipe(map((r) => r.body));

--- a/tests/datasets/test_promote_dataset.py
+++ b/tests/datasets/test_promote_dataset.py
@@ -4,9 +4,47 @@ The promote endpoint turns a set of media items from the active dataset
 (the Find "Goods" pile) into a brand-new saved dataset. The promoted
 items keep their origins and embeddings; the new dataset gets a fresh
 ``created_at`` but inherits the source dataset's ``expires_at``.
+
+The route follows the task-id/poll contract: the subset snapshot and
+metadata derivation happen synchronously (so a bad request still 400s at
+request time), while the coverage-atlas build, pickle write, and registry
+insert run in a background task. The response carries the ``task_id``;
+the finished task's ``dataset_id`` association identifies the new
+dataset.
 """
 
 from __future__ import annotations
+
+import time
+
+from vtscore.concurrency.progress import loading_tasks
+
+
+def _wait_for_task(task_id: str, timeout: float = 30.0) -> dict:
+    """Poll until background task *task_id* finishes; return its snapshot."""
+    deadline = time.time() + timeout
+    while not loading_tasks.is_finished(task_id) and time.time() < deadline:
+        time.sleep(0.05)
+    assert loading_tasks.is_finished(task_id), "promote task never finished"
+    snap = next((t for t in loading_tasks.list_tasks() if t["task_id"] == task_id), None)
+    assert snap is not None, "finished promote task pruned before it could be inspected"
+    return snap
+
+
+def _promote(client, name: str, media_ids: list[int], headers: dict | None = None) -> dict:
+    """Kick off a promote, wait for the background task, and return its snapshot."""
+    resp = client.post(
+        "/api/dataset/promote",
+        json={"name": name, "media_ids": media_ids},
+        headers=headers or {},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["task_id"]
+    snap = _wait_for_task(body["task_id"])
+    assert not snap.get("error"), snap
+    return snap
 
 
 class TestPromoteToDataset:
@@ -20,19 +58,12 @@ class TestPromoteToDataset:
         assert len(ids) >= 1
 
         before = len(reg.list_datasets())
-        resp = client.post(
-            "/api/dataset/promote",
-            json={"name": "My Promoted Set", "media_ids": ids},
-        )
-        assert resp.status_code == 200, resp.get_json()
-        body = resp.get_json()
-        assert body["ok"] is True
-        assert body["name"] == "My Promoted Set"
-        assert body["num_items"] == len(ids)
+        task = _promote(client, "My Promoted Set", ids)
 
-        # Registry grew by exactly one, and the new entry is findable.
+        # Registry grew by exactly one, and the new entry is findable via the
+        # finished task's dataset_id association.
         assert len(reg.list_datasets()) == before + 1
-        entry = reg.get_dataset(body["dataset_id"])
+        entry = reg.get_dataset(task["dataset_id"])
         assert entry is not None
         assert entry["name"] == "My Promoted Set"
         assert entry["num_items"] == len(ids)
@@ -60,12 +91,8 @@ class TestPromoteToDataset:
 
         ids = list(snapshot_medias().keys())[:3]
         assert len(ids) >= 1
-        resp = client.post(
-            "/api/dataset/promote",
-            json={"name": "Cached Atlas", "media_ids": ids},
-        )
-        assert resp.status_code == 200, resp.get_json()
-        entry = reg.get_dataset(resp.get_json()["dataset_id"])
+        task = _promote(client, "Cached Atlas", ids)
+        entry = reg.get_dataset(task["dataset_id"])
         assert entry is not None
 
         roundtrip: dict = {}
@@ -83,12 +110,8 @@ class TestPromoteToDataset:
         from vtsearch.state import snapshot_medias
 
         ids = list(snapshot_medias().keys())[:2]
-        resp = client.post(
-            "/api/dataset/promote",
-            json={"name": "Renumbered", "media_ids": ids},
-        )
-        assert resp.status_code == 200
-        entry = reg.get_dataset(resp.get_json()["dataset_id"])
+        task = _promote(client, "Renumbered", ids)
+        entry = reg.get_dataset(task["dataset_id"])
         assert entry is not None
         roundtrip: dict = {}
         load_dataset_from_pickle(entry["pkl_path"], roundtrip)
@@ -118,13 +141,8 @@ class TestPromoteToDataset:
             ctx.medias[cid] = snap[cid]
         state_core.register_context(ctx)
         try:
-            resp = client.post(
-                "/api/dataset/promote",
-                json={"name": "Inherited DS", "media_ids": ids},
-                headers={"X-Dataset-Id": src["id"]},
-            )
-            assert resp.status_code == 200, resp.get_json()
-            new_entry = reg.get_dataset(resp.get_json()["dataset_id"])
+            task = _promote(client, "Inherited DS", ids, headers={"X-Dataset-Id": src["id"]})
+            new_entry = reg.get_dataset(task["dataset_id"])
             assert new_entry is not None
             # Death date inherited; created date is fresh (not the source's).
             assert new_entry["expires_at"] == 99_999.0
@@ -132,6 +150,32 @@ class TestPromoteToDataset:
         finally:
             state_core.unregister_context(src["id"])
             reg.remove_loaded_id(src["id"])
+
+    def test_background_failure_reports_task_error_and_cleans_up(self, client, monkeypatch):
+        """A failure inside the background task (here: serialization) must not
+        leave a registry entry or an orphaned pkl; it surfaces as the task's
+        ``error`` field instead of an HTTP error.
+        """
+        from vtscore.datasets import registry as reg
+        from vtsearch.routes.datasets import staging as staging_module
+        from vtsearch.state import snapshot_medias
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("serialization exploded")
+
+        monkeypatch.setattr(staging_module, "export_dataset_to_file", boom)
+
+        ids = list(snapshot_medias().keys())[:2]
+        before = len(reg.list_datasets())
+        resp = client.post(
+            "/api/dataset/promote",
+            json={"name": "Doomed", "media_ids": ids},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        snap = _wait_for_task(resp.get_json()["task_id"])
+        assert "serialization exploded" in (snap.get("error") or "")
+        assert snap.get("dataset_id") is None
+        assert len(reg.list_datasets()) == before
 
     def test_rejects_unknown_ids(self, client):
         resp = client.post(

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -16,8 +16,12 @@ values raise 422.  See *Resolved questions / Plugin field endpoints*
 in the plan doc.
 """
 
+import gc
+import threading
 import time
+import traceback
 from collections import Counter
+from collections.abc import Callable
 from pathlib import Path
 from uuid import uuid4
 
@@ -25,6 +29,7 @@ from flask import jsonify, request
 from flask_smorest import Blueprint, abort
 
 import vtscore.security.path_validation as _paths
+from vtscore.concurrency.progress import CancelledError, loading_tasks
 from vtscore.config import EMBEDDINGS_DIR
 from vtscore.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers
 from vtscore.datasets.load_pipeline import (
@@ -51,7 +56,6 @@ from vtsearch.schemas.datasets import (
     DatasetCombineRequestSchema,
     DatasetLoadStartedResponseSchema,
     DatasetPromoteRequestSchema,
-    DatasetPromoteResponseSchema,
     DatasetStageDemoRequestSchema,
     DatasetStageFileResponseSchema,
     DatasetStagingStartedResponseSchema,
@@ -112,7 +116,10 @@ def combine_datasets_route(body: dict):
     return {"ok": True, "message": "Combining datasets...", "task_id": str(task_id) if task_id else ""}
 
 
-def _coverage_atlas_pickle_keys(subset: dict[int, dict]) -> dict | None:
+def _coverage_atlas_pickle_keys(
+    subset: dict[int, dict],
+    on_progress: Callable[[int, int], None] | None = None,
+) -> dict | None:
     """Return ``{"coverage_atlas": <payload>}`` to cache in a promoted pickle.
 
     Builds the atlas over *subset* at creation, exactly like a fresh import
@@ -122,20 +129,169 @@ def _coverage_atlas_pickle_keys(subset: dict[int, dict]) -> dict | None:
     a promoted dataset rebuilt from scratch each time). Returns ``None`` past
     the auto-build threshold (matching the load pipeline's deferral) or when the
     subset carries no usable vectors.
+
+    *on_progress* is forwarded to the atlas build (called as
+    ``on_progress(current, total)`` per completed k-means fit) so the
+    background promote task can report fine-grained progress.
     """
     from vtscore.state import build_coverage_atlas_serializable, should_auto_build_coverage_atlas
 
     if not should_auto_build_coverage_atlas(len(subset)):
         return None
-    payload = build_coverage_atlas_serializable(subset)
+    payload = build_coverage_atlas_serializable(subset, on_progress=on_progress)
     return {"coverage_atlas": payload} if payload is not None else None
+
+
+#: Promote runs as a 3-step background task: coverage-atlas build,
+#: pickle serialization + disk write, registry insert.
+_PROMOTE_TOTAL_STEPS = 3
+
+#: Rough wall-clock share of each promote step, tuning how the unified
+#: ``overall`` bar paces (the ETA self-corrects regardless — see
+#: :meth:`ProgressTracker._compute_overall`). The atlas's hierarchical
+#: k-means dominates, then embedding serialization; the registry write
+#: is trivial.
+_PROMOTE_STEP_WEIGHTS = [6.0, 3.5, 0.5]
+
+
+def _promote_in_background(
+    subset: dict[int, dict],
+    *,
+    name: str,
+    media_type: str,
+    embedder: str,
+    clipper: str,
+    expires_at: float | None,
+    source: dict,
+    file_type_counts: dict[str, int],
+    created_by: str,
+) -> str:
+    """Build, write, and register the promoted dataset in a daemon thread.
+
+    Mirrors :func:`vtscore.datasets.load_pipeline._stage_importer_in_background`:
+    a dedicated per-task :class:`ProgressTracker` (via ``loading_tasks``) carries
+    progress — including the coverage-atlas build, previously a long silent hang
+    in the request thread — to the ``loading-tasks`` SSE channel, and the
+    dashboard's Cancel button works through the standard task-cancel route.
+
+    Concurrency: *subset* is a private snapshot built in the request thread
+    (shallow clones of a ``snapshot_medias()`` copy), so concurrent mutation of
+    the source dataset — items added/removed, votes, even ``clear_medias()`` —
+    cannot affect this job and no lock is held while the atlas builds.  The
+    clones share embedding arrays with the live medias, but embeddings are
+    replaced (never mutated in place) throughout the codebase, so the shared
+    references stay valid.
+
+    On success the task's ``dataset_id`` association is set to the new registry
+    entry's id so the frontend's completion callback can identify the dataset.
+    Failures (and cancellation) surface as the task's ``error`` field; a
+    partially written pkl is removed.
+
+    Returns the ``task_id`` for progress polling / cancellation.
+    """
+    from vtsearch.auth import thread_user
+
+    task_id = f"_promote_{uuid4().hex[:8]}"
+    tracker = loading_tasks.create_task(
+        task_id,
+        name,
+        media_type=media_type,
+        embedder=embedder,
+        step_weights=_PROMOTE_STEP_WEIGHTS,
+    )
+    tracker.update("loading", "Preparing promoted dataset…", 0, 0, step=1, total_steps=_PROMOTE_TOTAL_STEPS)
+
+    def task():
+        pkl_path: str | None = None
+        try:
+            with thread_user(created_by):
+
+                def atlas_progress(current: int, total: int) -> None:
+                    tracker.check_cancelled()
+                    tracker.update(
+                        "loading",
+                        "Building coverage atlas…",
+                        current,
+                        total,
+                        step=1,
+                        total_steps=_PROMOTE_TOTAL_STEPS,
+                    )
+
+                extra_pickle_keys = _coverage_atlas_pickle_keys(subset, on_progress=atlas_progress)
+                tracker.check_cancelled()
+
+                tracker.update("loading", "Writing dataset file…", 0, 0, step=2, total_steps=_PROMOTE_TOTAL_STEPS)
+                ds_dir = get_saved_datasets_dir()
+                ds_dir.mkdir(parents=True, exist_ok=True)
+                pkl_path = str(ds_dir / f"ds_{uuid4().hex}.pkl")
+                data_bytes = export_dataset_to_file(
+                    subset,
+                    embedder=embedder,
+                    clipper=clipper,
+                    media_type=media_type,
+                    name=name,
+                    created_at=time.time(),
+                    expires_at=expires_at,
+                    extra_pickle_keys=extra_pickle_keys,
+                )
+                Path(pkl_path).write_bytes(data_bytes)
+                del data_bytes
+                tracker.check_cancelled()
+
+                tracker.update("loading", "Registering dataset…", 0, 0, step=3, total_steps=_PROMOTE_TOTAL_STEPS)
+                entry = _reg_register(
+                    name=name,
+                    media_type=media_type,
+                    num_items=len(subset),
+                    pkl_path=pkl_path,
+                    origin="promote",
+                    source=source,
+                    clipper=clipper,
+                    embedder=embedder,
+                    created_by=created_by,
+                    file_type_counts=file_type_counts,
+                    expires_at=expires_at,
+                )
+                loading_tasks.set_dataset_id(task_id, entry["id"])
+                tracker.update(
+                    "idle",
+                    f'Promoted {len(subset)} items to "{name}"',
+                    100,
+                    100,
+                    step=_PROMOTE_TOTAL_STEPS,
+                    total_steps=_PROMOTE_TOTAL_STEPS,
+                )
+        except CancelledError:
+            if pkl_path:
+                Path(pkl_path).unlink(missing_ok=True)
+            tracker.update("idle", "", 0, 0, error="Cancelled")
+        except MemoryError:
+            if pkl_path:
+                Path(pkl_path).unlink(missing_ok=True)
+            tracker.update(
+                "idle",
+                "",
+                0,
+                0,
+                error="Out of memory: this selection is too large. Try promoting fewer items or free up system RAM.",
+            )
+        except Exception as exc:  # noqa: BLE001 (surface the failure on the task tracker)
+            traceback.print_exc()
+            if pkl_path:
+                Path(pkl_path).unlink(missing_ok=True)
+            tracker.update("idle", "", 0, 0, error=str(exc) or repr(exc) or "Unknown error during promote")
+        finally:
+            gc.collect()
+            loading_tasks.mark_finished(task_id)
+
+    threading.Thread(target=task, daemon=True).start()
+    return task_id
 
 
 @datasets_staging_bp.route("/api/dataset/promote", methods=["POST"])
 @datasets_staging_bp.arguments(DatasetPromoteRequestSchema)
-@datasets_staging_bp.response(200, DatasetPromoteResponseSchema)
+@datasets_staging_bp.response(200, DatasetLoadStartedResponseSchema)
 @datasets_staging_bp.alt_response(400, description="No dataset loaded or none of the items resolved.")
-@datasets_staging_bp.alt_response(500, description="Failed to write or register the new dataset.")
 def promote_to_dataset(body: dict):
     """Promote a set of media items into a brand-new saved dataset.
 
@@ -145,6 +301,13 @@ def promote_to_dataset(body: dict):
     free; the new pickle is a self-contained snapshot). The new dataset
     gets a fresh ``created_at`` but inherits the source dataset's
     ``expires_at`` (death date).
+
+    The subset snapshot and metadata derivation run synchronously (cheap:
+    shallow copies); the expensive part — coverage-atlas build, pickle
+    write, registry insert — runs in a background task.  The response
+    carries the ``task_id``; the caller polls the ``loading-tasks`` SSE
+    channel for progress and reads the finished task's ``dataset_id``
+    association for the new dataset's id.
     """
     name = body["name"].strip()
     media_ids = body["media_ids"]
@@ -154,8 +317,11 @@ def promote_to_dataset(body: dict):
         abort(400, message="No dataset loaded")
 
     # Build the subset, renumbering IDs from 1 and preserving each item's
-    # origin/embedding (a shallow copy is enough; we serialise immediately
-    # and never mutate the embedding array).
+    # origin/embedding (a shallow copy is enough; the background task
+    # serialises it and never mutates the embedding array).  Snapshotting
+    # here, in the request thread, is what isolates the background job
+    # from concurrent mutation of the source dataset — see
+    # :func:`_promote_in_background`.
     subset: dict[int, dict] = {}
     new_id = 1
     for mid in media_ids:
@@ -191,28 +357,6 @@ def promote_to_dataset(body: dict):
         else:
             ext_counter["(no extension)"] += 1
 
-    now = time.time()
-    ds_dir = get_saved_datasets_dir()
-    ds_dir.mkdir(parents=True, exist_ok=True)
-    pkl_path = str(ds_dir / f"ds_{uuid4().hex}.pkl")
-
-    try:
-        data_bytes = export_dataset_to_file(
-            subset,
-            embedder=embedder,
-            clipper=clipper,
-            media_type=media_type,
-            name=name,
-            created_at=now,
-            expires_at=expires_at,
-            extra_pickle_keys=_coverage_atlas_pickle_keys(subset),
-        )
-        Path(pkl_path).write_bytes(data_bytes)
-        del data_bytes
-    except Exception as exc:  # noqa: BLE001 (surface the failure to the caller)
-        Path(pkl_path).unlink(missing_ok=True)
-        abort(500, message=f"Failed to write dataset: {exc}")
-
     source = {
         "importer": "promote",
         "params": {
@@ -220,25 +364,18 @@ def promote_to_dataset(body: dict):
             "source_name": (src_entry or {}).get("name", "") if src_entry else "",
         },
     }
-    try:
-        entry = _reg_register(
-            name=name,
-            media_type=media_type,
-            num_items=len(subset),
-            pkl_path=pkl_path,
-            origin="promote",
-            source=source,
-            clipper=clipper,
-            embedder=embedder,
-            created_by=get_current_user(),
-            file_type_counts=dict(ext_counter.most_common()),
-            expires_at=expires_at,
-        )
-    except Exception as exc:  # noqa: BLE001
-        Path(pkl_path).unlink(missing_ok=True)
-        abort(500, message=f"Failed to register dataset: {exc}")
-
-    return {"ok": True, "dataset_id": entry["id"], "name": name, "num_items": len(subset)}
+    task_id = _promote_in_background(
+        subset,
+        name=name,
+        media_type=media_type,
+        embedder=embedder,
+        clipper=clipper,
+        expires_at=expires_at,
+        source=source,
+        file_type_counts=dict(ext_counter.most_common()),
+        created_by=get_current_user(),
+    )
+    return {"ok": True, "message": "Promoting to dataset...", "task_id": task_id}
 
 
 @datasets_staging_bp.route("/api/dataset/stage-file", methods=["POST"])

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -409,7 +409,7 @@ class DatasetLoadSourceRequestSchema(Schema):
 class DatasetLoadStartedResponseSchema(Schema):
     """Response for ``POST /api/dataset/load-demo`` / ``load-file`` /
     ``load-folder`` / ``load-source`` / ``import-local-folder`` and for
-    ``POST /api/dataset/combine`` in ``staging.py``.
+    ``POST /api/dataset/combine`` / ``promote`` in ``staging.py``.
 
     ``task_id`` is the background-task tracker id (string) used by the
     SSE progress stream; it may be empty when the load completes
@@ -478,15 +478,6 @@ class DatasetPromoteRequestSchema(Schema):
         validate=validate.Length(min=1),
         metadata={"description": "IDs of the media items (in the active dataset) to promote."},
     )
-
-
-class DatasetPromoteResponseSchema(Schema):
-    """Response for ``POST /api/dataset/promote``."""
-
-    ok = fields.Boolean(required=True)
-    dataset_id = fields.String(required=True)
-    name = fields.String(required=True)
-    num_items = fields.Integer(required=True)
 
 
 class DatasetStageFileResponseSchema(Schema):


### PR DESCRIPTION
Closes #2622

## What changed

`POST /api/dataset/promote` used to build the coverage atlas, serialize the pickle, and register the new dataset **in the request thread** — a long, silent hang on large promotes (tolerated only because the app runs with `VTSEARCH_TIMEOUT=0`). It now follows the task-id/poll pattern its sibling routes (`combine`, `stage-import`, `stage-demo`) already use.

### Backend (`vtsearch/routes/datasets/staging.py`)

- The route still validates and snapshots synchronously — a bad request (no dataset, unknown ids, empty name) 400s/422s at request time exactly as before.
- The expensive part — coverage-atlas build, pickle serialization + disk write, registry insert — runs in `_promote_in_background`, a daemon thread with a dedicated per-task `ProgressTracker` (via `loading_tasks`), reporting a 3-step weighted `overall` bar on the `loading-tasks` SSE channel. The atlas build now reports fine-grained per-k-means-fit progress (`_coverage_atlas_pickle_keys` grew an `on_progress` hook).
- **Response contract**: `{ok, message, task_id}` (`DatasetLoadStartedResponse`); `DatasetPromoteResponseSchema` is deleted. The finished task's `dataset_id` association carries the new dataset's id.
- **Locking decision** (from the issue's scope): no lock. The subset is built in the request thread from a `snapshot_medias()` copy with per-media shallow clones, so the background job owns a private view that concurrent mutation of the source dataset (adds/removes/votes/`clear_medias()`) cannot affect. The clones share embedding arrays with the live medias, but embeddings are replaced, never mutated in place, throughout the codebase, so the shared references stay valid. Documented on `_promote_in_background`.
- Failures (including `MemoryError`) and cancellation surface as the task's `error` field, with any partially written pkl unlinked and no orphaned registry entry; the dashboard's standard Cancel button works through the existing task-cancel route.

### Frontend

- `DatasetsCrudApiService.promote()` now resolves with the task-started payload.
- The Find view's To-Dataset flow kicks off the task, registers a completion callback via `DashboardLoadingTasksService.startProgressPolling(task_id, …)`, and toasts "Created dataset …" once the task settles. Failed tasks are toasted globally by the SSE error router like any other load, and promote rows render on the dashboard's loading table with live progress.

### Docs / snapshot

- `docs/api/datasets.md` updated to the new contract; `frontend/openapi.json` regenerated.

## Breaking change

The promote response no longer returns `dataset_id` / `name` / `num_items` synchronously — callers must poll the `loading-tasks` channel and read the finished task's `dataset_id`. Per repo policy, no compatibility shim.

## Testing

- `tests/datasets/test_promote_dataset.py` rewritten for the async contract (poll `loading_tasks.is_finished`), including a new background-failure test asserting the task `error` surfaces and both the pkl and registry entry are cleaned up.
- `./run-tests.sh` full suite: **ALL 6449 TESTS PASSED** (ruff, codespell, deptry, pip-audit, pyright, OpenAPI drift, frontend build + Vitest included).
- **Real-browser e2e** (the issue's "needs a browser" requirement — this session had Chromium): drove the running app via Playwright using the screenshot-harness fixtures (`syn-imgs` + `doc-demo`): dashboard → Find → To Dataset → name prompt → confirm. Verified exactly one promote POST (no double-fire) returning in **14 ms** with a task id (no hang), the success toast firing from the SSE completion callback, and the new dataset row appearing on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BezoATG2JY1mKJw2snFNkz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BezoATG2JY1mKJw2snFNkz)_