### PR TITLE
Calibrate load-progress weights: all media types, all embedders, cuML split (#2623)

### DIFF
--- a/docs/plans/progress-weight-calibration.md
+++ b/docs/plans/progress-weight-calibration.md
@@ -1,9 +1,16 @@
 # Progress-weight calibration
 
-**Status:** Load-progress weights are calibrated only for image + audio × CPU +
-GPU (default embedders); the remaining media types (video/text/document),
-non-default embedders, and the cuML on/off split still use the static fallback
-and need calibration.
+**Status:** Load-progress weights are calibrated for every demo-backed media
+type (image/audio/video/text/document) × every loadable registered embedder ×
+{cpu, cuda, cuda+cuml} (issue #2623; HLTCOE Grid rack8n06 v100, 2026-07-18/19
+sweep, raw JSONL under `/exp/sgreenberg/calib-2623`). The cuML-off `cuda`
+variant is measured for the default embedders; other cuda cells fall back to
+their `cuda+cuml` row (same device, different finalize cost — closer than the
+static profile). Not calibratable because they cannot load in the measured
+environment (and equally cannot in a served app on it): `video/videomae` and
+`video/languagebind` (transformers version skew) and `audio/paraspeechclap`
+(upstream HF weights file removed); the `face` media type has no demo
+datasets. Those cells use the static fallback.
 
 ## Open follow-ups (remaining cells to calibrate)
 
@@ -86,3 +93,60 @@ observed rates but doesn't replace the value of a better prior. Non-goals:
 predicting absolute load time (ETA self-corrects); a persistent online model
 (coefficients are checked-in constants); calibrating non-dataset bars
 (detector load, Find, sort).
+
+---
+
+## Results (2026-07-18/19 sweep, rack8n06 v100 — issue #2623)
+
+Fit diagnostics from `fit_load_weights.py` over the calib-2623 JSONL (embed
+and finalize are least-squares vs `n`; slopes shown in ms/item). The audio
+rows' checked-in `b_load` (0.11 s/item decode) is carried from the live
+GTZAN measurement — see the note in `_load_cost_model.py`.
+
+| device | media | embedder | load a+b·n s (cold) | R² | embed a+b·n | R² | finalize a+b·n | R² | pts |
+|--------|-------|----------|---------------------|----|-------------|----|----------------|----|----|
+| cpu | audio | ast | 0.50+0.00m·n (cold 25.6) | 0.00 | 5.67+1213.09m·n | 1.00 | 0.17+3.87m·n | 0.98 | 3 |
+| cpu | audio | clap | 0.50+0.00m·n (cold 28.2) | 0.00 | 3.54+288.77m·n | 1.00 | -0.15+4.19m·n | 0.98 | 5 |
+| cpu | audio | clap_general | 0.50+0.00m·n (cold 25.4) | 0.00 | 16.10+402.23m·n | 1.00 | 0.06+3.87m·n | 0.95 | 3 |
+| cpu | audio | clap_music | 0.50+0.00m·n (cold 13.6) | 0.00 | 16.92+402.43m·n | 0.98 | 0.19+3.36m·n | 0.95 | 3 |
+| cpu | audio | whisper_encoder | 0.50+0.00m·n (cold 10.7) | 0.00 | 22.12+409.27m·n | 1.00 | 0.03+3.76m·n | 0.98 | 3 |
+| cpu | document |  | 0.50+0.00m·n (cold 70.1) | 0.00 | 44.73+0.00m·n | 0.00 | 15.28+0.00m·n | 0.00 | 1 |
+| cpu | image | clip | 0.50+0.00m·n (cold 21.9) | 0.00 | 16.72+51.00m·n | 0.64 | 0.13+5.72m·n | 1.00 | 3 |
+| cpu | image | dinov2_patch | 0.50+0.00m·n (cold 22.8) | 0.00 | 18.88+387.00m·n | 0.99 | -0.69+8.27m·n | 0.99 | 3 |
+| cpu | image | dinov2_single | 0.50+0.00m·n (cold 21.7) | 0.00 | 14.25+200.84m·n | 0.96 | -0.88+8.61m·n | 0.99 | 3 |
+| cpu | image | dinov3_patch | 0.50+0.00m·n (cold 22.5) | 0.00 | 22.09+312.76m·n | 0.98 | -1.05+8.91m·n | 1.00 | 3 |
+| cpu | image | dinov3_single | 0.50+0.00m·n (cold 23.9) | 0.00 | 23.41+153.09m·n | 0.94 | -0.59+7.97m·n | 0.99 | 3 |
+| cpu | image | eupe_patch | 0.50+0.00m·n (cold 3.6) | 0.00 | 32.41+284.59m·n | 0.96 | 1.40+5.83m·n | 0.54 | 3 |
+| cpu | image | eupe_single | 0.50+0.00m·n (cold 4.7) | 0.00 | 25.20+150.85m·n | 0.89 | 1.01+6.43m·n | 0.61 | 3 |
+| cpu | image | sift_vlad | 0.50+0.00m·n (cold 0.0) | 0.00 | -9.37+108.49m·n | 0.99 | 0.31+22.27m·n | 0.98 | 3 |
+| cpu | image | siglip | 0.50+0.00m·n (cold 22.9) | 0.00 | 7.50+179.47m·n | 0.99 | -0.33+7.64m·n | 0.99 | 5 |
+| cpu | image | siglip2 | 0.50+0.00m·n (cold 25.5) | 0.00 | 20.54+160.31m·n | 0.95 | -0.90+8.36m·n | 1.00 | 3 |
+| cpu | image | siglip_l | 0.50+0.00m·n (cold 37.6) | 0.00 | -50.13+2620.10m·n | 1.00 | 0.28+7.37m·n | 0.99 | 3 |
+| cpu | text | bge | 0.50+0.00m·n (cold 8.1) | 0.00 | 17.24+119.65m·n | 1.00 | -0.66+3.47m·n | 1.00 | 3 |
+| cpu | text | e5 | 0.50+0.00m·n (cold 24.3) | 0.00 | 6.81+137.53m·n | 1.00 | -2.15+4.27m·n | 1.00 | 5 |
+| cpu | video | xclip | 0.50+0.00m·n (cold 29.5) | 0.00 | 0.49+444.65m·n | 0.99 | 0.04+3.19m·n | 0.84 | 5 |
+| cuda | audio | clap | 0.50+0.00m·n (cold 25.4) | 0.00 | 9.85+95.12m·n | 0.98 | -0.19+4.23m·n | 1.00 | 9 |
+| cuda | document |  | 53.63+0.00m·n (cold 75.5) | 0.00 | 17.82+0.00m·n | 0.00 | 18.41+0.00m·n | 0.00 | 2 |
+| cuda | image | siglip | 0.50+0.00m·n (cold 21.1) | 0.00 | 4.53+14.69m·n | 0.94 | -0.33+8.61m·n | 1.00 | 8 |
+| cuda | text | e5 | 0.50+0.00m·n (cold 21.6) | 0.00 | 2.40+15.76m·n | 0.99 | -1.11+3.94m·n | 0.99 | 8 |
+| cuda | video | xclip | 0.50+0.00m·n (cold 22.2) | 0.00 | 1.95+147.66m·n | 0.99 | -0.01+3.82m·n | 0.98 | 8 |
+| cuda+cuml | audio | ast | 0.50+0.00m·n (cold 16.6) | 0.00 | 2.04+47.17m·n | 1.00 | 0.49+3.93m·n | 0.94 | 8 |
+| cuda+cuml | audio | clap | 0.50+0.00m·n (cold 28.0) | 0.00 | 2.67+109.96m·n | 1.00 | 0.59+3.84m·n | 0.96 | 8 |
+| cuda+cuml | audio | clap_general | 0.50+0.00m·n (cold 42.3) | 0.00 | 0.66+113.99m·n | 1.00 | 0.77+3.84m·n | 0.93 | 8 |
+| cuda+cuml | audio | clap_music | 0.50+0.00m·n (cold 43.9) | 0.00 | 2.55+110.02m·n | 1.00 | 0.69+3.78m·n | 0.95 | 8 |
+| cuda+cuml | audio | whisper_encoder | 0.50+0.00m·n (cold 27.5) | 0.00 | 2.45+33.55m·n | 0.99 | 0.39+3.79m·n | 0.97 | 8 |
+| cuda+cuml | document |  | 45.47+0.00m·n (cold 72.4) | 0.00 | 13.67+0.00m·n | 0.00 | 15.90+0.00m·n | 0.00 | 4 |
+| cuda+cuml | image | clip | 0.50+0.00m·n (cold 20.2) | 0.00 | 1.92+14.38m·n | 0.99 | 0.01+7.30m·n | 1.00 | 8 |
+| cuda+cuml | image | dinov2_patch | 0.50+0.00m·n (cold 26.6) | 0.00 | 0.93+33.09m·n | 1.00 | -0.05+7.59m·n | 1.00 | 8 |
+| cuda+cuml | image | dinov2_single | 0.50+0.00m·n (cold 20.6) | 0.00 | 1.85+15.57m·n | 0.98 | -0.13+7.17m·n | 1.00 | 8 |
+| cuda+cuml | image | dinov3_patch | 0.50+0.00m·n (cold 26.7) | 0.00 | 2.63+34.17m·n | 1.00 | -0.17+7.62m·n | 1.00 | 8 |
+| cuda+cuml | image | dinov3_single | 0.50+0.00m·n (cold 21.8) | 0.00 | 2.56+19.12m·n | 0.98 | -0.17+7.35m·n | 1.00 | 8 |
+| cuda+cuml | image | eupe_patch | 0.50+0.00m·n (cold 20.4) | 0.00 | 2.64+40.34m·n | 1.00 | 0.63+7.43m·n | 0.98 | 8 |
+| cuda+cuml | image | eupe_single | 0.50+0.00m·n (cold 4.5) | 0.00 | 3.02+26.01m·n | 0.98 | 0.33+7.19m·n | 1.00 | 8 |
+| cuda+cuml | image | sift_vlad | 0.50+0.00m·n (cold 0.0) | 0.00 | 4.30+81.43m·n | 1.00 | -0.20+14.84m·n | 1.00 | 8 |
+| cuda+cuml | image | siglip | 0.50+0.00m·n (cold 9.1) | 0.00 | 1.41+16.01m·n | 1.00 | -0.26+7.32m·n | 1.00 | 8 |
+| cuda+cuml | image | siglip2 | 0.50+0.00m·n (cold 32.8) | 0.00 | 3.60+14.94m·n | 0.96 | 0.44+7.31m·n | 0.99 | 8 |
+| cuda+cuml | image | siglip_l | 0.50+0.00m·n (cold 76.5) | 0.00 | 2.88+88.09m·n | 1.00 | 0.10+7.67m·n | 1.00 | 8 |
+| cuda+cuml | text | bge | 0.50+0.00m·n (cold 27.0) | 0.00 | 6.09+12.07m·n | 1.00 | 0.41+2.22m·n | 1.00 | 8 |
+| cuda+cuml | text | e5 | 0.50+0.00m·n (cold 30.5) | 0.00 | 3.84+12.50m·n | 1.00 | 0.15+2.22m·n | 0.99 | 9 |
+| cuda+cuml | video | xclip | 0.50+0.00m·n (cold 28.3) | 0.00 | -0.34+146.07m·n | 0.99 | 0.25+3.05m·n | 0.83 | 9 |

--- a/docs/plans/progress-weight-calibration.md
+++ b/docs/plans/progress-weight-calibration.md
@@ -21,16 +21,27 @@ and need calibration.
 
 <!-- item-sep -->
 
-## Reproducing calibration for a remaining cell
+## Reproducing calibration for a cell
 
 ```
-CUDA_VISIBLE_DEVICES=0 python scripts/profiling/calibrate_load_weights.py --out gpu.jsonl
+CUDA_VISIBLE_DEVICES=0 python scripts/profiling/calibrate_load_weights.py --out gpu.jsonl --embedders all
+CUDA_VISIBLE_DEVICES=0 python scripts/profiling/calibrate_load_weights.py --out gpu-cumloff.jsonl --cuml off
 CUDA_VISIBLE_DEVICES=  python scripts/profiling/calibrate_load_weights.py --out cpu.jsonl --sizes s,m,l
-python scripts/profiling/fit_load_weights.py gpu.jsonl cpu.jsonl   # prints the coefficient table
+python scripts/profiling/fit_load_weights.py gpu.jsonl gpu-cumloff.jsonl cpu.jsonl   # prints the coefficient table
 ```
 (Needs `VTSEARCH_MODELS_DIR` pointed at a warm model cache so the model phase is
 a load, not a cold HuggingFace download.) Add the fitted rows to
 `vtscore/datasets/stages/_load_cost_model.py`.
+
+The driver covers all five demo-backed media types (image/audio/video/text/
+document; face has no demo datasets and is logged as skipped). `--embedders
+all` sweeps every registered embedder for the media type, one subprocess per
+(media, embedder) cell so encoder models don't accumulate in RAM/VRAM — pass
+`--data-dir` so the cells share one source-archive cache. `--cuml off` sets
+`VTSEARCH_DISABLE_CUML=1` to measure the CPU-clustering finalize variant on a
+GPU host; the profiler stamps every row with the live cuML state and the fit
+keys cuML-on CUDA rows as device `"cuda+cuml"`. Runtime lookup tries the
+variant matching the live cuML state first and falls back to the other.
 
 ---
 

--- a/scripts/profiling/calibrate_load_weights.py
+++ b/scripts/profiling/calibrate_load_weights.py
@@ -14,14 +14,28 @@ torch imports), so run this **once per device**:
     python scripts/profiling/calibrate_load_weights.py --out cpu.jsonl               # CPU: CUDA_VISIBLE_DEVICES=""
     CUDA_VISIBLE_DEVICES=0 python scripts/profiling/calibrate_load_weights.py --out gpu.jsonl
 
-Within one process the encoder is loaded once (first load per embedder is
-``cold_model``, the rest warm) and the source archive is downloaded/extracted
-once (first load per source is ``cold_download``, the rest warm) — the recorder
-self-detects both. Between loads the demo **embeddings** cache is cleared so
-embed always re-runs, giving fresh embed/finalize timings at each ``n``.
+The cuML on/off split (it moves the coverage-atlas k-means and the UMAP
+projection to the GPU, changing the finalize phase's cost) is a third device
+variant: repeat the GPU run with ``--cuml off`` to measure the
+CPU-clustering-on-a-GPU-host cells. The profiler stamps each row with the
+active cuML state, and the fit keys cuML-on rows as device ``"cuda+cuml"``.
+
+Within one in-process run the encoder is loaded once (first load per embedder
+is ``cold_model``, the rest warm) and the source archive is
+downloaded/extracted once (first load per source is ``cold_download``, the
+rest warm) — the recorder self-detects both. Between loads the demo
+**embeddings** cache is cleared so embed always re-runs, giving fresh
+embed/finalize timings at each ``n``.
+
+``--embedders all`` covers every registered embedder for each media type.
+Each (media, embedder) cell then runs in its **own subprocess** so encoder
+models don't accumulate in RAM/VRAM across cells (a full image sweep is ~11
+resident models otherwise); the source archives are shared through a common
+``--data-dir``, so only the first cell per source pays the download.
 
 Isolation: a scratch ``VTSEARCH_DATA_DIR`` is used so nothing touches a real
-data dir; ``VTSEARCH_MODELS_DIR`` should point at a warm model cache (else the
+data dir (pass ``--data-dir`` to reuse one across runs/subprocesses);
+``VTSEARCH_MODELS_DIR`` should point at a warm model cache (else the
 model-load phase measures a cold HuggingFace download instead of a load).
 """
 
@@ -30,6 +44,7 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -42,22 +57,39 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 # media_type -> demo source id stem (size suffix appended: _s/_m/_l/_a).
+# Chosen for calibration economy: small archives with a good ``n`` spread.
+# ``ucsf_documents`` only ships an ``_a`` variant (n=150), so the document fit
+# has a single size point (constant terms, no slope).
 _SOURCE_BY_MEDIA = {
     "image": "caltech101",
     "audio": "esc50",
+    "video": "ucf101",
+    "text": "20newsgroups",
+    "document": "ucsf_documents",
 }
-# Media types we deliberately do NOT calibrate in this run (logged as skipped).
-_SKIPPED_MEDIA = ("video", "text", "document")
+# The face media type has no demo datasets, so it cannot be calibrated through
+# the demo-load path this driver exercises; it is logged as skipped.
+_NO_DEMO_MEDIA = ("face",)
 
 
 def _eprint(*a):
     print(*a, file=sys.stderr, flush=True)
 
 
-def main() -> int:
+def _parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--out", required=True, help="JSONL output path (appended)")
-    ap.add_argument("--media", default="image,audio", help="comma list of media types")
+    ap.add_argument(
+        "--media",
+        default="image,audio,video,text,document",
+        help="comma list of media types",
+    )
+    ap.add_argument(
+        "--embedders",
+        default="default",
+        help="'default' (the media type's default embedder), 'all' (every "
+        "registered embedder for the media type), or a comma list of names",
+    )
     ap.add_argument("--sizes", default="s,m,l,a", help="comma list of size suffixes")
     ap.add_argument("--reps", type=int, default=2, help="repetitions per cell (median later)")
     ap.add_argument(
@@ -65,15 +97,63 @@ def main() -> int:
         default="m",
         help="on CPU, sizes larger than this get 1 rep (they are slow)",
     )
-    args = ap.parse_args()
+    ap.add_argument(
+        "--data-dir",
+        default="",
+        help="persistent scratch VTSEARCH_DATA_DIR (shared across subprocesses "
+        "so each source archive downloads once); default: fresh temp dir",
+    )
+    ap.add_argument(
+        "--cuml",
+        choices=("auto", "off"),
+        default="auto",
+        help="'off' disables cuML (VTSEARCH_DISABLE_CUML=1) so the GPU run "
+        "measures the CPU-clustering finalize variant",
+    )
+    return ap.parse_args()
 
-    # Arm the recorder + isolate the data dir BEFORE importing the app.
-    os.environ["VTSEARCH_PROFILE_LOAD"] = os.path.abspath(args.out)
-    scratch = tempfile.mkdtemp(prefix="calib_data_")
-    os.environ["VTSEARCH_DATA_DIR"] = scratch
-    os.environ.pop("VTSEARCH_SERVER_INIT", None)
 
-    import app  # noqa: F401  wires Flask app + all plugins (media/importers/embedders)
+def _resolve_cells(media_types: list[str], embedders_arg: str) -> list[tuple[str, str]]:
+    """Resolve the (media_type, embedder_name) cells to measure.
+
+    Requires the media registry (``import app`` must have run). The document
+    media type has no embedder — it converts to another type on load — so its
+    cell carries an empty embedder name, matching what the load pipeline
+    records and what the runtime cost-model lookup uses for it.
+    """
+    from vtscore.media import embedders_for_type  # noqa: PLC0415
+
+    wanted = [e.strip() for e in embedders_arg.split(",") if e.strip()]
+    cells: list[tuple[str, str]] = []
+    for media_type in media_types:
+        if media_type in _NO_DEMO_MEDIA:
+            _eprint(f"[calib] SKIPPED media={media_type} (no demo datasets)")
+            continue
+        if media_type not in _SOURCE_BY_MEDIA:
+            _eprint(f"[calib] SKIPPED media={media_type} (no source mapped)")
+            continue
+        embs = embedders_for_type(media_type)
+        if not embs:
+            # Convert-out half types (document) load + embed via a converter
+            # target; the pipeline records their rows with an empty embedder.
+            cells.append((media_type, ""))
+            continue
+        if embedders_arg == "all":
+            names = [e.name for e in embs]
+        elif embedders_arg == "default":
+            names = [embs[0].name]  # is_default sorted first
+            for other in embs[1:]:
+                _eprint(f"[calib] SKIPPED embedder={other.name} media={media_type} (non-default)")
+        else:
+            known = {e.name for e in embs}
+            names = [n for n in wanted if n in known]
+        cells.extend((media_type, n) for n in names)
+    return cells
+
+
+def _run_cells_in_process(args: argparse.Namespace, cells: list[tuple[str, str]]) -> int:
+    """Measure *cells* (all sizes × reps) in this process. Assumes ``import
+    app`` has already wired the registries and the recorder env is armed."""
     from vtscore.config import EMBEDDINGS_DIR, resolve_device  # noqa: PLC0415
     from vtscore.datasets.config import DEMO_DATASETS  # noqa: PLC0415
     from vtscore.datasets.importers import get_importer  # noqa: PLC0415
@@ -81,10 +161,9 @@ def main() -> int:
         _run_importer_in_background,
         loading_tasks,
     )
-    from vtscore.media import embedders_for_type  # noqa: PLC0415
 
     device = resolve_device()
-    _eprint(f"[calib] device={device} data_dir={scratch} out={args.out}")
+    _eprint(f"[calib] device={device} data_dir={os.environ['VTSEARCH_DATA_DIR']} out={args.out}")
 
     # Wait on completion via mark_finished (the success path never sets status
     # to 'idle'; it only calls mark_finished — see _load_profiler / scout notes).
@@ -127,27 +206,13 @@ def main() -> int:
         _eprint(f"[calib] ok {dataset_id} ({time.monotonic() - t0:.1f}s)")
         return True
 
-    media_types = [m.strip() for m in args.media.split(",") if m.strip()]
     sizes = [s.strip() for s in args.sizes.split(",") if s.strip()]
     size_order = ["s", "m", "l", "a"]
     on_cpu = not device.startswith("cuda")
     cap_idx = size_order.index(args.max_cpu_reps_size) if args.max_cpu_reps_size in size_order else 1
 
-    for m in _SKIPPED_MEDIA:
-        _eprint(f"[calib] SKIPPED media={m} (out of scope for this run)")
-
-    for media_type in media_types:
-        stem = _SOURCE_BY_MEDIA.get(media_type)
-        if stem is None:
-            _eprint(f"[calib] SKIPPED media={media_type} (no source mapped)")
-            continue
-        embs = embedders_for_type(media_type)
-        if not embs:
-            _eprint(f"[calib] SKIPPED media={media_type} (no embedder)")
-            continue
-        embedder = embs[0].name  # is_default sorted first
-        for other in embs[1:]:
-            _eprint(f"[calib] SKIPPED embedder={other.name} media={media_type} (non-default)")
+    for media_type, embedder in cells:
+        stem = _SOURCE_BY_MEDIA[media_type]
         for size in sizes:
             dataset_id = f"{stem}_{size}"
             reps = args.reps
@@ -155,11 +220,79 @@ def main() -> int:
                 reps = 1  # large CPU cells are slow; one rep
             for r in range(reps):
                 _clear_embeddings()  # force a fresh embed (keep the extracted source)
-                _eprint(f"[calib] === {media_type}/{embedder}/{dataset_id} rep {r + 1}/{reps} ===")
+                _eprint(f"[calib] === {media_type}/{embedder or '-'}/{dataset_id} rep {r + 1}/{reps} ===")
                 _load_and_wait(dataset_id, media_type, embedder)
-
-    _eprint("[calib] DONE")
     return 0
+
+
+def _spawn_per_cell(args: argparse.Namespace, cells: list[tuple[str, str]]) -> int:
+    """Run each (media, embedder) cell as a child process of this script, so
+    encoder models never accumulate across cells. The shared ``--data-dir``
+    (already in the environment) keeps source downloads warm between children."""
+    failures = 0
+    for i, (media_type, embedder) in enumerate(cells, 1):
+        _eprint(f"[calib] ---- cell {i}/{len(cells)}: {media_type}/{embedder or '-'} ----")
+        cmd = [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--out",
+            args.out,
+            "--media",
+            media_type,
+            "--embedders",
+            embedder or "default",
+            "--sizes",
+            args.sizes,
+            "--reps",
+            str(args.reps),
+            "--max-cpu-reps-size",
+            args.max_cpu_reps_size,
+            "--data-dir",
+            os.environ["VTSEARCH_DATA_DIR"],
+            "--cuml",
+            args.cuml,
+        ]
+        rc = subprocess.call(cmd)  # noqa: S603 — re-invokes this same script via sys.executable
+        if rc != 0:
+            failures += 1
+            _eprint(f"[calib] cell {media_type}/{embedder or '-'} exited rc={rc}")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    args = _parse_args()
+
+    # Arm the recorder + isolate the data dir BEFORE importing the app.
+    os.environ["VTSEARCH_PROFILE_LOAD"] = os.path.abspath(args.out)
+    if args.data_dir:
+        scratch = os.path.abspath(args.data_dir)
+        Path(scratch).mkdir(parents=True, exist_ok=True)
+    else:
+        scratch = tempfile.mkdtemp(prefix="calib_data_")
+    os.environ["VTSEARCH_DATA_DIR"] = scratch
+    os.environ.pop("VTSEARCH_SERVER_INIT", None)
+    if args.cuml == "off":
+        os.environ["VTSEARCH_DISABLE_CUML"] = "1"
+
+    import app  # noqa: F401  wires Flask app + all plugins (media/importers/embedders)
+
+    media_types = [m.strip() for m in args.media.split(",") if m.strip()]
+    cells = _resolve_cells(media_types, args.embedders)
+    if not cells:
+        _eprint("[calib] nothing to measure")
+        return 0
+
+    if len(cells) == 1:
+        rc = _run_cells_in_process(args, cells)
+    else:
+        rc = _spawn_per_cell(args, cells)
+    _eprint("[calib] DONE")
+    # Skip interpreter teardown: with a live CUDA context (+ cuML/RMM) the
+    # C++ destructor chain can abort ("terminate called without an active
+    # exception") after everything of value has already been measured and
+    # flushed, which would make the parent misread a good cell as failed.
+    sys.stderr.flush()
+    os._exit(rc)
 
 
 if __name__ == "__main__":

--- a/scripts/profiling/calibrate_load_weights.py
+++ b/scripts/profiling/calibrate_load_weights.py
@@ -190,6 +190,16 @@ def _run_cells_in_process(args: argparse.Namespace, cells: list[tuple[str, str]]
         os.environ["VTSEARCH_PROFILE_DATASET_ID"] = dataset_id
         importer = get_importer("demo")
         fv = {"name": dataset_id, "media_type": media_type, "embedder": embedder}
+        if not embedder:
+            # Convert-out half types (document) are importable but not
+            # embeddable: without the converter the load ends with every item
+            # dropped (embedding=None). Mirror the UI's default: convert to
+            # the first ``converts_to`` target (e.g. document2image).
+            from vtscore.media import get as get_media_type  # noqa: PLC0415
+
+            targets = getattr(get_media_type(media_type), "converts_to", [])
+            if targets:
+                fv["converter"] = f"{media_type}2{targets[0]}"
         t0 = time.monotonic()
         tid = _run_importer_in_background(importer, fv)
         deadline = t0 + 3600

--- a/scripts/profiling/fit_load_weights.py
+++ b/scripts/profiling/fit_load_weights.py
@@ -72,12 +72,19 @@ def main() -> int:
         return 2
     rows = _load_rows(sys.argv[1:])
 
-    # Group phase-seconds by (device, media, embedder).
+    # Group phase-seconds by (device, media, embedder). ``device`` is collapsed
+    # to the coarse cost-model key: "cuda:0" → "cuda", and a CUDA row measured
+    # with cuML active becomes the "cuda+cuml" variant (cuML moves the
+    # coverage-atlas k-means / UMAP to the GPU, changing the finalize cost —
+    # the profiler stamps each row with the active cuML state).
     groups: dict[tuple[str, str, str], dict[str, list[tuple[float, float]]]] = defaultdict(lambda: defaultdict(list))
     dl_by_device: dict[str, list[tuple[float, float]]] = defaultdict(list)  # (size_mb, seconds)
     extract_pts: list[tuple[float, float]] = []  # (size_mb, seconds), device-pooled
     for r in rows:
-        key = (r["device"], r["media_type"], r["embedder"])
+        device = str(r["device"])
+        if device.startswith("cuda"):
+            device = "cuda+cuml" if r.get("cuml") else "cuda"
+        key = (device, r["media_type"], r["embedder"])
         phase = r["phase"]
         n = float(r.get("n") or 0)
         secs = float(r.get("seconds") or 0)

--- a/scripts/profiling/fit_load_weights.py
+++ b/scripts/profiling/fit_load_weights.py
@@ -100,6 +100,11 @@ def main() -> int:
             continue
         if phase.startswith("finalize:"):
             continue  # sub-slots: deferred (see plan follow-ups)
+        if n <= 0:
+            # A failed load (unloadable embedder, import error) still emits its
+            # phase rows but finishes with n=0; its model/embed/finalize
+            # timings describe the failure path, not a fittable cost.
+            continue
         if phase == "model_load":
             # warm rows only; fall back to all if none warm
             groups[key]["model_warm" if not r.get("cold_model") else "model_cold"].append((n, secs))

--- a/tests_lib/datasets/test_load_profiler.py
+++ b/tests_lib/datasets/test_load_profiler.py
@@ -130,6 +130,7 @@ def test_records_phases_and_writes_schema(monkeypatch, tmp_path, clean_seen_embe
         "download_size_mb",
         "cold_model",
         "cold_download",
+        "cuml",
         "phase",
         "seconds",
     }
@@ -143,6 +144,23 @@ def test_records_phases_and_writes_schema(monkeypatch, tmp_path, clean_seen_embe
         assert isinstance(r["seconds"], (int, float)) and r["seconds"] >= 0.0
         # A fast in-test load never spends >1s downloading.
         assert r["cold_download"] is False
+        assert isinstance(r["cuml"], bool)
+
+
+def test_rows_stamp_active_cuml_state(monkeypatch, tmp_path, clean_seen_embedders):
+    """Each row records whether cuML serves this process's clustering, so the
+    fit can key CUDA measurements as "cuda" vs "cuda+cuml" (the finalize cost
+    differs materially between the two)."""
+    out = tmp_path / "prof.jsonl"
+    monkeypatch.setenv("VTSEARCH_PROFILE_LOAD", str(out))
+    monkeypatch.setattr("vtscore.gpu_backends.cuml_enabled", lambda: True)
+    tracker = _make_tracker()
+
+    prof = start_profiler(tracker, "image", "siglip")
+    _drive_phases(tracker)
+    prof.finish(10, "ds")
+
+    assert all(r["cuml"] is True for r in _read_rows(out))
 
 
 def test_finalize_sub_slots_recorded(monkeypatch, tmp_path, clean_seen_embedders):

--- a/tests_lib/datasets/test_load_step_weights.py
+++ b/tests_lib/datasets/test_load_step_weights.py
@@ -185,6 +185,42 @@ def test_no_matching_cost_model_row_returns_static(monkeypatch):
     assert load_step_weights("image", n=1000, download_size_mb=100.0, embedder="siglip") == _LOAD_STEP_WEIGHTS_CPU_IMAGE
 
 
+def test_cuda_lookup_prefers_matching_cuml_variant(monkeypatch):
+    # Two measured CUDA variants with different finalize costs; the live cuML
+    # state picks which one paces the bar.
+    monkeypatch.setattr(
+        _cm,
+        "LOAD_COST_MODEL",
+        {
+            ("cuda", "image", "siglip"): {"a_model": 0.5, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 9.0},
+            ("cuda+cuml", "image", "siglip"): {"a_model": 0.5, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 2.0},
+        },
+    )
+    monkeypatch.setattr(_cm, "_cuml_active", lambda: True)
+    terms = _cm.cost_model_terms("cuda:0", "image", "siglip", n=100)
+    assert terms is not None and terms["finalize"] == pytest.approx(2.0)
+
+    monkeypatch.setattr(_cm, "_cuml_active", lambda: False)
+    terms = _cm.cost_model_terms("cuda:0", "image", "siglip", n=100)
+    assert terms is not None and terms["finalize"] == pytest.approx(9.0)
+
+
+def test_cuda_lookup_falls_back_to_other_cuml_variant(monkeypatch):
+    # Only one CUDA variant measured: a host in the other cuML state still gets
+    # it — a same-device row with a different finalize cost beats falling all
+    # the way back to the static profile.
+    monkeypatch.setattr(
+        _cm,
+        "LOAD_COST_MODEL",
+        {("cuda+cuml", "video", "xclip"): {"a_model": 0.5, "a_embed": 1.0, "b_embed": 0.1, "a_fin": 2.0}},
+    )
+    monkeypatch.setattr(_cm, "_cuml_active", lambda: False)
+    terms = _cm.cost_model_terms("cuda", "video", "xclip", n=100)
+    assert terms is not None and terms["embed"] == pytest.approx(11.0)
+    # CPU devices never borrow a CUDA row.
+    assert _cm.cost_model_terms("cpu", "video", "xclip", n=100) is None
+
+
 def test_shipped_cost_model_table_is_well_formed():
     # Every checked-in coefficient row has the affine keys and yields a
     # normalized weight vector; empty table (pre-calibration) trivially passes.

--- a/tests_lib/projection/test_gpu_backends.py
+++ b/tests_lib/projection/test_gpu_backends.py
@@ -102,6 +102,24 @@ def test_kill_switch_disables_cuml_for_rest_of_process():
     assert gb.cuml_enabled() is False
 
 
+def test_env_var_disables_cuml(monkeypatch):
+    """``VTSEARCH_DISABLE_CUML`` forces the CPU clustering libraries even when a
+    CUDA device resolves and cuML imports — the runtime opt-out the load-weight
+    calibration harness uses to measure the cuML-off finalize variant."""
+    monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cuda")
+    monkeypatch.setitem(sys.modules, "cuml", types.ModuleType("cuml"))
+
+    monkeypatch.delenv("VTSEARCH_DISABLE_CUML", raising=False)
+    assert gb.cuml_enabled() is True
+    monkeypatch.setenv("VTSEARCH_DISABLE_CUML", "1")
+    assert gb.cuml_enabled() is False
+    # "0" and empty mean not-disabled.
+    monkeypatch.setenv("VTSEARCH_DISABLE_CUML", "0")
+    assert gb.cuml_enabled() is True
+    monkeypatch.setenv("VTSEARCH_DISABLE_CUML", "")
+    assert gb.cuml_enabled() is True
+
+
 def test_repeated_failure_warns_only_once(monkeypatch, caplog):
     _install_fake_broken_cuml(monkeypatch)
     rng = np.random.default_rng(2)

--- a/vtscore/datasets/stages/_load_cost_model.py
+++ b/vtscore/datasets/stages/_load_cost_model.py
@@ -29,7 +29,14 @@ from __future__ import annotations
 from typing import Optional
 
 # key: (device, media_type, embedder) -> affine coefficients (seconds).
-# ``device`` is normalized to "cuda" / "cpu"; ``embedder`` is the encoder name.
+# ``device`` is "cpu", "cuda", or "cuda+cuml"; ``embedder`` is the encoder
+# name (empty for convert-out media like document, which embed via a
+# converter target). The "cuda+cuml" variant covers GPU hosts where cuML
+# serves the coverage-atlas k-means / UMAP (see ``vtscore/gpu_backends.py``)
+# — that moves the dominant finalize work to the GPU, so the finalize
+# coefficients differ materially from the CPU-clustering "cuda" rows. Lookup
+# tries the variant matching the live cuML state first and falls back to the
+# other, so a host missing one variant still gets the closer measured row.
 # POPULATED FROM CALIBRATION (HLTCOE Grid rack8n06, 2026-07-18 run under
 # /exp/…/calib-2556; see plan Results). Cells with no row fall back to the
 # static per-(device, media) profiles in ``_common``.
@@ -100,6 +107,36 @@ def normalize_device(device: str) -> str:
     return "cuda" if device.startswith("cuda") else "cpu"
 
 
+def _cuml_active() -> bool:
+    """Whether cuML will serve this process's clustering (never raises)."""
+    try:
+        from vtscore.gpu_backends import cuml_enabled  # noqa: PLC0415
+
+        return cuml_enabled()
+    except Exception:
+        return False
+
+
+def _lookup_row(device: str, media_type: str, embedder: str) -> Optional[dict[str, float]]:
+    """Find the closest measured coefficient row for the cell.
+
+    CPU devices map straight to their row. CUDA devices have two measured
+    variants — "cuda+cuml" (GPU clustering) and "cuda" (CPU clustering on a
+    GPU host) — and the live cuML state picks which is tried first; the other
+    is the fallback, since a same-device row with a different finalize cost
+    beats falling back to the static profile entirely.
+    """
+    dev = normalize_device(device)
+    if dev != "cuda":
+        return LOAD_COST_MODEL.get((dev, media_type, embedder))
+    variants = ("cuda+cuml", "cuda") if _cuml_active() else ("cuda", "cuda+cuml")
+    for variant in variants:
+        row = LOAD_COST_MODEL.get((variant, media_type, embedder))
+        if row is not None:
+            return row
+    return None
+
+
 def cost_model_terms(
     device: str,
     media_type: str,
@@ -119,7 +156,7 @@ def cost_model_terms(
     terms — which is exactly right for local-folder imports and cache-backed
     re-adds, where no archive is fetched or unpacked.
     """
-    row = LOAD_COST_MODEL.get((normalize_device(device), media_type, embedder))
+    row = _lookup_row(device, media_type, embedder)
     if row is None or n <= 0:
         return None
     t_download = 0.0

--- a/vtscore/datasets/stages/_load_cost_model.py
+++ b/vtscore/datasets/stages/_load_cost_model.py
@@ -37,68 +37,407 @@ from typing import Optional
 # coefficients differ materially from the CPU-clustering "cuda" rows. Lookup
 # tries the variant matching the live cuML state first and falls back to the
 # other, so a host missing one variant still gets the closer measured row.
-# POPULATED FROM CALIBRATION (HLTCOE Grid rack8n06, 2026-07-18 run under
-# /exp/…/calib-2556; see plan Results). Cells with no row fall back to the
-# static per-(device, media) profiles in ``_common``.
+# POPULATED FROM CALIBRATION (HLTCOE Grid rack8n06 v100 node, 2026-07-18/19
+# sweep under /exp/…/calib-2623, issue #2623; see plan Results). Covers every
+# demo-backed media type × every loadable registered embedder; the "cuda"
+# (cuML-off) variant was measured for the default embedders only, the
+# "cuda+cuml" sweep for all of them. Cells with no row fall back to the
+# static per-(device, media) profiles in ``_common``. Not calibratable on the
+# measurement host (and equally unloadable in a served app on it):
+# video/videomae + video/languagebind (transformers version skew) and
+# audio/paraspeechclap (upstream HF weights file removed).
 # ``b_load`` is the per-item source read/decode cost inside the "loading" step
 # (step 2 covers warm model load *plus* reading every source file into medias —
 # for a 1000-file audio demo over NFS that decode is tens of seconds, so it
 # must scale with ``n`` rather than hide inside the fixed ``a_model``).
 # NB the calibration demos (caltech101/esc50) decode inside the embed loop, so
-# no warm step-2 rows exist to fit ``b_load`` from — the audio values below are
+# no warm step-2 rows exist to fit ``b_load`` from — the audio value below is
 # measured from a live profiled GTZAN load (per-file decode path): 49.6s for
-# 455 files ≈ 0.11 s/item pure decode+clip, on both devices (decode is
-# CPU-bound regardless of the embed device). Still an underestimate for loads
-# that also unpickle a large embeddings cache in step 2, which is why the
+# 455 files ≈ 0.11 s/item pure decode+clip, applied to every audio row since
+# the decode is CPU-bound and embedder-independent. Still an underestimate for
+# loads that also unpickle a large embeddings cache in step 2, which is why the
 # AdaptiveLoadPacer re-estimates every phase's term from its observed pace.
+# The ``document`` rows (empty embedder — convert-out type) are single-size
+# constants: the load term is dominated by the document2image page
+# rasterisation, measured at n=240 pages from 150 PDFs.
+_AUDIO_B_LOAD = 0.11
+
 LOAD_COST_MODEL: dict[tuple[str, str, str], dict[str, float]] = {
-    ("cpu", "image", "siglip"): {
+    ("cpu", "audio", "ast"): {
         "a_model": 0.5,
-        "b_load": 0.0,
-        "a_embed": 5.0828,
-        "b_embed": 0.583843,
-        "a_fin": 0.2884,
-        "b_fin": 0.003179,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 5.6749,
+        "b_embed": 1.213088,
+        "a_fin": 0.1727,
+        "b_fin": 0.003869,
     },
     ("cpu", "audio", "clap"): {
         "a_model": 0.5,
-        "b_load": 0.11,
-        "a_embed": 1.1159,
-        "b_embed": 0.317579,
-        "a_fin": 0.0587,
-        "b_fin": 0.00237,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 3.5416,
+        "b_embed": 0.288775,
+        "a_fin": 0.0,
+        "b_fin": 0.004185,
+    },
+    ("cpu", "audio", "clap_general"): {
+        "a_model": 0.5,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 16.1027,
+        "b_embed": 0.40223,
+        "a_fin": 0.0639,
+        "b_fin": 0.003868,
+    },
+    ("cpu", "audio", "clap_music"): {
+        "a_model": 0.5,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 16.9172,
+        "b_embed": 0.402425,
+        "a_fin": 0.1893,
+        "b_fin": 0.003363,
+    },
+    ("cpu", "audio", "whisper_encoder"): {
+        "a_model": 0.5,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 22.1213,
+        "b_embed": 0.409268,
+        "a_fin": 0.0322,
+        "b_fin": 0.003757,
+    },
+    ("cpu", "document", ""): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 44.7291,
+        "b_embed": 0.0,
+        "a_fin": 15.2846,
+        "b_fin": 0.0,
+    },
+    ("cpu", "image", "clip"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 16.715,
+        "b_embed": 0.051,
+        "a_fin": 0.1349,
+        "b_fin": 0.005717,
+    },
+    ("cpu", "image", "dinov2_patch"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 18.8802,
+        "b_embed": 0.387,
+        "a_fin": 0.0,
+        "b_fin": 0.008272,
+    },
+    ("cpu", "image", "dinov2_single"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 14.2485,
+        "b_embed": 0.20084,
+        "a_fin": 0.0,
+        "b_fin": 0.00861,
+    },
+    ("cpu", "image", "dinov3_patch"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 22.0937,
+        "b_embed": 0.312758,
+        "a_fin": 0.0,
+        "b_fin": 0.008906,
+    },
+    ("cpu", "image", "dinov3_single"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 23.4089,
+        "b_embed": 0.153089,
+        "a_fin": 0.0,
+        "b_fin": 0.007971,
+    },
+    ("cpu", "image", "eupe_patch"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 32.4078,
+        "b_embed": 0.284594,
+        "a_fin": 1.4028,
+        "b_fin": 0.005827,
+    },
+    ("cpu", "image", "eupe_single"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 25.2026,
+        "b_embed": 0.150847,
+        "a_fin": 1.0131,
+        "b_fin": 0.006429,
+    },
+    ("cpu", "image", "sift_vlad"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 0.0,
+        "b_embed": 0.108494,
+        "a_fin": 0.3056,
+        "b_fin": 0.022271,
+    },
+    ("cpu", "image", "siglip"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 7.5042,
+        "b_embed": 0.17947,
+        "a_fin": 0.0,
+        "b_fin": 0.007637,
+    },
+    ("cpu", "image", "siglip2"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 20.5357,
+        "b_embed": 0.160309,
+        "a_fin": 0.0,
+        "b_fin": 0.008356,
+    },
+    ("cpu", "image", "siglip_l"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 0.0,
+        "b_embed": 2.6201,
+        "a_fin": 0.2769,
+        "b_fin": 0.007371,
+    },
+    ("cpu", "text", "bge"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 17.2372,
+        "b_embed": 0.11965,
+        "a_fin": 0.0,
+        "b_fin": 0.003473,
+    },
+    ("cpu", "text", "e5"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 6.8054,
+        "b_embed": 0.137529,
+        "a_fin": 0.0,
+        "b_fin": 0.004273,
+    },
+    ("cpu", "video", "xclip"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 0.488,
+        "b_embed": 0.44465,
+        "a_fin": 0.0351,
+        "b_fin": 0.003186,
+    },
+    ("cuda", "audio", "clap"): {
+        "a_model": 0.5,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 9.8547,
+        "b_embed": 0.095121,
+        "a_fin": 0.0,
+        "b_fin": 0.004233,
+    },
+    ("cuda", "document", ""): {
+        "a_model": 53.6342,
+        "b_load": 0.0,
+        "a_embed": 17.8238,
+        "b_embed": 0.0,
+        "a_fin": 18.4145,
+        "b_fin": 0.0,
     },
     ("cuda", "image", "siglip"): {
         "a_model": 0.5,
         "b_load": 0.0,
-        "a_embed": 0.8928,
-        "b_embed": 0.01233,
-        "a_fin": 0.8098,
-        "b_fin": 0.003719,
+        "a_embed": 4.534,
+        "b_embed": 0.014688,
+        "a_fin": 0.0,
+        "b_fin": 0.008609,
     },
-    ("cuda", "audio", "clap"): {
+    ("cuda", "text", "e5"): {
         "a_model": 0.5,
-        "b_load": 0.11,
+        "b_load": 0.0,
+        "a_embed": 2.3957,
+        "b_embed": 0.01576,
+        "a_fin": 0.0,
+        "b_fin": 0.003939,
+    },
+    ("cuda", "video", "xclip"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 1.952,
+        "b_embed": 0.147662,
+        "a_fin": 0.0,
+        "b_fin": 0.003823,
+    },
+    ("cuda+cuml", "audio", "ast"): {
+        "a_model": 0.5,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 2.0354,
+        "b_embed": 0.047166,
+        "a_fin": 0.4869,
+        "b_fin": 0.003928,
+    },
+    ("cuda+cuml", "audio", "clap"): {
+        "a_model": 0.5,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 2.6679,
+        "b_embed": 0.109959,
+        "a_fin": 0.5875,
+        "b_fin": 0.003837,
+    },
+    ("cuda+cuml", "audio", "clap_general"): {
+        "a_model": 0.5,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 0.6566,
+        "b_embed": 0.113987,
+        "a_fin": 0.7722,
+        "b_fin": 0.003842,
+    },
+    ("cuda+cuml", "audio", "clap_music"): {
+        "a_model": 0.5,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 2.5482,
+        "b_embed": 0.110015,
+        "a_fin": 0.685,
+        "b_fin": 0.003779,
+    },
+    ("cuda+cuml", "audio", "whisper_encoder"): {
+        "a_model": 0.5,
+        "b_load": _AUDIO_B_LOAD,
+        "a_embed": 2.4531,
+        "b_embed": 0.033555,
+        "a_fin": 0.3943,
+        "b_fin": 0.003789,
+    },
+    ("cuda+cuml", "document", ""): {
+        "a_model": 45.4673,
+        "b_load": 0.0,
+        "a_embed": 13.6691,
+        "b_embed": 0.0,
+        "a_fin": 15.8971,
+        "b_fin": 0.0,
+    },
+    ("cuda+cuml", "image", "clip"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 1.9236,
+        "b_embed": 0.014377,
+        "a_fin": 0.0086,
+        "b_fin": 0.007303,
+    },
+    ("cuda+cuml", "image", "dinov2_patch"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 0.934,
+        "b_embed": 0.033091,
+        "a_fin": 0.0,
+        "b_fin": 0.007588,
+    },
+    ("cuda+cuml", "image", "dinov2_single"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 1.8451,
+        "b_embed": 0.015571,
+        "a_fin": 0.0,
+        "b_fin": 0.007173,
+    },
+    ("cuda+cuml", "image", "dinov3_patch"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 2.6292,
+        "b_embed": 0.034172,
+        "a_fin": 0.0,
+        "b_fin": 0.007623,
+    },
+    ("cuda+cuml", "image", "dinov3_single"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 2.5573,
+        "b_embed": 0.019125,
+        "a_fin": 0.0,
+        "b_fin": 0.007347,
+    },
+    ("cuda+cuml", "image", "eupe_patch"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 2.6362,
+        "b_embed": 0.040342,
+        "a_fin": 0.6297,
+        "b_fin": 0.007429,
+    },
+    ("cuda+cuml", "image", "eupe_single"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 3.0167,
+        "b_embed": 0.026009,
+        "a_fin": 0.326,
+        "b_fin": 0.007193,
+    },
+    ("cuda+cuml", "image", "sift_vlad"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 4.2984,
+        "b_embed": 0.081432,
+        "a_fin": 0.0,
+        "b_fin": 0.014836,
+    },
+    ("cuda+cuml", "image", "siglip"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 1.4109,
+        "b_embed": 0.016008,
+        "a_fin": 0.0,
+        "b_fin": 0.007316,
+    },
+    ("cuda+cuml", "image", "siglip2"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 3.6047,
+        "b_embed": 0.014941,
+        "a_fin": 0.4438,
+        "b_fin": 0.007312,
+    },
+    ("cuda+cuml", "image", "siglip_l"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 2.884,
+        "b_embed": 0.088089,
+        "a_fin": 0.105,
+        "b_fin": 0.007667,
+    },
+    ("cuda+cuml", "text", "bge"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 6.0879,
+        "b_embed": 0.012067,
+        "a_fin": 0.4114,
+        "b_fin": 0.002217,
+    },
+    ("cuda+cuml", "text", "e5"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
+        "a_embed": 3.8359,
+        "b_embed": 0.012501,
+        "a_fin": 0.1454,
+        "b_fin": 0.002217,
+    },
+    ("cuda+cuml", "video", "xclip"): {
+        "a_model": 0.5,
+        "b_load": 0.0,
         "a_embed": 0.0,
-        "b_embed": 0.063223,
-        "a_fin": 0.0796,
-        "b_fin": 0.003154,
+        "b_embed": 0.14607,
+        "a_fin": 0.2533,
+        "b_fin": 0.003055,
     },
 }
 
 # Cold-download bandwidth (archive MB per second) over the measured hosts
-# (device-pooled median; observed 3.3–4.4 across the two device runs — the
+# (device-pooled median; observed 8.8–9.1 across the 2026-07-18/19 sweep — the
 # cluster's shared egress swings by hours-of-day far more than by host). 0
 # disables the download term (weights then reflect only model+embed+finalize).
 # This is only the *prior*: the AdaptiveLoadPacer re-estimates the download
 # term from the observed transfer rate once bytes start flowing.
-DOWNLOAD_MB_PER_S: float = 3.836
+DOWNLOAD_MB_PER_S: float = 8.967
 
 # Archive extraction rate (archive MB per second) on the measured hosts.
 # Extraction runs after the download inside the same acquire step, but its cost
 # scales with archive bytes at a very different rate than the network transfer,
 # so it gets its own term (and its own "extracting" status / bar slice).
-EXTRACT_MB_PER_S: float = 61.477
+EXTRACT_MB_PER_S: float = 45.66
 
 
 def normalize_device(device: str) -> str:

--- a/vtscore/datasets/stages/_load_profiler.py
+++ b/vtscore/datasets/stages/_load_profiler.py
@@ -72,6 +72,21 @@ def _resolve_device() -> str:
         return "unknown"
 
 
+def _cuml_active() -> bool:
+    """Whether cuML will serve this load's clustering (finalize cost variant).
+
+    Recorded per row so the fit can key CUDA measurements as "cuda" vs
+    "cuda+cuml" — cuML moves the coverage-atlas k-means / UMAP projection to
+    the GPU, which materially changes the finalize phase's cost.
+    """
+    try:
+        from vtscore.gpu_backends import cuml_enabled  # noqa: PLC0415
+
+        return cuml_enabled()
+    except Exception:
+        return False
+
+
 def _download_size_mb_for(dataset_id: str) -> Optional[float]:
     try:
         from vtscore.datasets.config import DEMO_DATASETS  # noqa: PLC0415
@@ -184,6 +199,7 @@ class LoadProfiler:
             "download_size_mb": download_size_mb,
             "cold_model": cold_model,
             "cold_download": cold_download,
+            "cuml": _cuml_active(),
         }
         rows = [{**base, "phase": phase, "seconds": round(secs, 4)} for phase, secs in durations.items()]
 

--- a/vtscore/gpu_backends.py
+++ b/vtscore/gpu_backends.py
@@ -50,6 +50,7 @@ libraries automatically.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 import numpy as np
@@ -77,6 +78,13 @@ def cuml_enabled() -> bool:
     :func:`_disable_cuml_after_failure`.
     """
     if _cuml_runtime_failed:
+        return False
+    if os.environ.get("VTSEARCH_DISABLE_CUML", "") not in ("", "0"):
+        # Runtime opt-out (distinct from the install-time VTSEARCH_SKIP_CUML):
+        # forces the CPU clustering libraries even when cuML is installed and
+        # the GPU is usable. Used by the load-weight calibration harness to
+        # measure the cuML-off finalize variant, and handy when a RAPIDS
+        # install is present but misbehaving.
         return False
     from vtscore.config import resolve_device
 


### PR DESCRIPTION
Closes #2623.

## What

The load-cost model (`vtscore/datasets/stages/_load_cost_model.py`) previously had 4 measured rows ({cpu,cuda} x {image:siglip, audio:clap}); every other cell fell back to the coarse static per-(device,media) profile. This PR extends the calibration harness to reach the remaining cells, runs the full sweep on the GRID (rack8n06 v100, same hardware as the existing rows), and lands **45 measured rows**: every demo-backed media type (image/audio/video/text/document) x every loadable registered embedder x {cpu, cuda, cuda+cuml}.

## Harness changes

- `calibrate_load_weights.py`: demo sources for video (`ucf101`), text (`20newsgroups`), document (`ucsf_documents`); `--embedders all|default|<list>` sweeping every registered embedder, one subprocess per (media, embedder) cell so encoder models never accumulate in RAM/VRAM; `--data-dir` to share source archives across cells; `--cuml off`; convert-out media (document) automatically get their `converts_to` converter (without it every PDF is dropped with `embedding=None`); `os._exit` after measurement (a live CUDA+cuML context can abort in C++ teardown after all rows are flushed, misreading a good cell as failed).
- `gpu_backends.py`: new `VTSEARCH_DISABLE_CUML` runtime opt-out (distinct from install-time `VTSEARCH_SKIP_CUML`), used for the cuML-off pass and handy when a RAPIDS install misbehaves.
- `_load_profiler.py`: rows now stamp the live cuML state.
- `fit_load_weights.py`: keys cuML-on CUDA rows as device `cuda+cuml`; skips model/embed/finalize rows from failed loads (n=0).
- `_load_cost_model.py`: lookup tries the CUDA variant matching the live cuML state first, falls back to the other (a same-device row with a different finalize cost beats the static profile).

## Measurement

2026-07-18/19 sweep on rack8n06 (11 SLURM jobs; raw JSONL in `/exp/sgreenberg/calib-2623`, reusable warm model/data caches in `/exp/scale26/datasets/external/vtsearch-calib-2623`). Fit R2 is 0.93-1.00 for nearly all embed/finalize fits — full diagnostics table appended to `docs/plans/progress-weight-calibration.md`. Audio rows carry the GTZAN-measured `b_load` = 0.11 s/item decode (esc50 decodes inside the embed loop, so the sweep cannot fit it — same documented decision as the existing table).

## Not calibratable (static fallback stands, no runtime cell exists)

- `video/videomae`, `video/languagebind`: cannot load under the venv transformers version (would fail identically in the served app).
- `audio/paraspeechclap`: upstream HF repo no longer has `paraspeechclap-combined.pth.tar` (404) — separate issue to follow.
- `face`: no demo datasets.

## Validation

- 400 tests pass (datasets/core/projection suites) incl. new coverage: cuML-variant lookup + fallback, `VTSEARCH_DISABLE_CUML`, profiler `cuml` field; ruff clean.
- Smoke-validated live on the GRID: video/text/document/cuML-off cells each measured end-to-end before the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)