### PR TITLE
Fix paraspeechclap embedder: point at renamed upstream weights file

### DIFF
--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -579,6 +579,7 @@ class TestAudioParaSpeechClapEmbedderProperties:
 
     def test_uses_correct_model_ids(self):
         from vtscore.config import (
+            PARASPEECHCLAP_CHECKPOINT_FILE,
             PARASPEECHCLAP_CHECKPOINT_REPO,
             PARASPEECHCLAP_EMBED_DIM,
             PARASPEECHCLAP_SAMPLE_RATE,
@@ -589,6 +590,8 @@ class TestAudioParaSpeechClapEmbedderProperties:
         assert PARASPEECHCLAP_SPEECH_MODEL_ID == "microsoft/wavlm-large"
         assert PARASPEECHCLAP_TEXT_MODEL_ID == "ibm-granite/granite-embedding-278m-multilingual"
         assert PARASPEECHCLAP_CHECKPOINT_REPO == "ajd12342/paraspeechclap-combined"
+        # Upstream renamed the weights file; the old name now 404s (issue #2635).
+        assert PARASPEECHCLAP_CHECKPOINT_FILE == "slap-combined.pth.tar"
         assert PARASPEECHCLAP_EMBED_DIM == 768
         assert PARASPEECHCLAP_SAMPLE_RATE == 16000
 

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -258,7 +258,9 @@ WHISPER_SAMPLE_RATE = 16000  # Whisper expects 16 kHz mono
 PARASPEECHCLAP_SPEECH_MODEL_ID = "microsoft/wavlm-large"
 PARASPEECHCLAP_TEXT_MODEL_ID = "ibm-granite/granite-embedding-278m-multilingual"
 PARASPEECHCLAP_CHECKPOINT_REPO = "ajd12342/paraspeechclap-combined"
-PARASPEECHCLAP_CHECKPOINT_FILE = "paraspeechclap-combined.pth.tar"
+# Upstream renamed the released weights to ``slap-combined.pth.tar``; the old
+# ``paraspeechclap-combined.pth.tar`` was removed and now 404s (issue #2635).
+PARASPEECHCLAP_CHECKPOINT_FILE = "slap-combined.pth.tar"
 PARASPEECHCLAP_EMBED_DIM = 768
 PARASPEECHCLAP_SAMPLE_RATE = 16000  # WavLM expects 16 kHz mono
 PARASPEECHCLAP_MAX_SAMPLES = 16000 * 30  # cap clips at 30 s to bound CPU memory/latency


### PR DESCRIPTION
## Problem

Every `paraspeechclap` load failed on cold caches with a 404:

```
Entry Not Found for url: https://huggingface.co/ajd12342/paraspeechclap-combined/resolve/main/paraspeechclap-combined.pth.tar
```

The repo `ajd12342/paraspeechclap-combined` still exists, but upstream **renamed** the released weights. The HF API `siblings` list (the source of truth) now shows only one checkpoint file: `slap-combined.pth.tar` (~2.38 GB, the full combined checkpoint). The old `paraspeechclap-combined.pth.tar` is gone, so any install without an already-warm model cache couldn't load the embedder at all.

(The repo's README still shows the *old* filename in its `huggingface-cli download` snippet — that doc is stale; the actual file listing is the new name.)

## Fix

- Update `PARASPEECHCLAP_CHECKPOINT_FILE` in `vtscore/config.py` from `paraspeechclap-combined.pth.tar` → `slap-combined.pth.tar`. Same repo, same architecture (WavLM speech + Granite text + projection heads), so the existing `strict=False` `load_state_dict` path is unchanged.
- Pin the corrected filename in the config-assertion test (`test_uses_correct_model_ids`) so a future rename can't silently reintroduce the break.

Verified the new file resolves to HTTP 200 (full 2.38 GB LFS object) at `resolve/main/slap-combined.pth.tar`.

`./run-tests.sh detectors` — all 1623 pass (ruff/codespell/deptry gate included).

Closes #2635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012kgf6iJkCCehpvuS9TiL71)_