### PR TITLE
Fix cold-boot AB-BA deadlock in settings getters

### DIFF
--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -847,3 +847,97 @@ class TestFileLockWithoutFcntl:
         settings_mod.set_inclusion(3)
         assert settings_mod.get_volume() == pytest.approx(0.5)
         assert settings_mod.get_inclusion() == 3
+
+
+class TestColdBootDeadlock:
+    """Regression for issue #2636: cold-boot AB-BA deadlock between a
+    scalar accessor's ``getter()`` and ``get_all``.
+
+    On a cold cache a ``get_<key>()`` read reaches the load path
+    (``_ensure_user_loaded`` -> ``ensure_server_loaded`` ->
+    ``_load_and_migrate_server``), which takes the cross-process server
+    ``file_lock``. The old ``getter()`` wrapped that whole read in
+    ``with _settings_lock:``, so it grabbed ``file_lock`` *while holding*
+    ``_settings_lock`` - inverting the canonical file->settings order and
+    deadlocking against a concurrent ``get_all`` /
+    ``_load_and_migrate_server`` that holds ``file_lock`` and waits on
+    ``_settings_lock``. The fix reads outside ``_settings_lock`` on every
+    accessor path.
+    """
+
+    def test_cold_getter_never_takes_file_lock_under_settings_lock(self, isolated_settings, monkeypatch):
+        """The lock-inversion invariant: a scalar getter's cold-cache read
+        must never reach ``file_lock`` while the calling thread already
+        holds ``_settings_lock``."""
+        import contextlib
+
+        from vtsearch import settings_store
+
+        settings_mod.reset()  # cold server + user caches
+
+        real_file_lock = settings_store.file_lock
+        owned_at_acquire: list[bool] = []
+
+        @contextlib.contextmanager
+        def spy_file_lock(path):
+            # Record whether THIS thread already holds _settings_lock at the
+            # moment we reach for the cross-process file lock.
+            owned_at_acquire.append(settings_mod._settings_lock._is_owned())
+            with real_file_lock(path):
+                yield
+
+        monkeypatch.setattr(settings_store, "file_lock", spy_file_lock)
+
+        # User-tier scalar read on a cold cache -> _ensure_user_loaded ->
+        # ensure_server_loaded -> _load_and_migrate_server -> server file_lock.
+        settings_mod.get_volume()
+
+        assert owned_at_acquire, "cold getter did not exercise the file-lock load path"
+        assert not any(owned_at_acquire), (
+            "getter reached file_lock while holding _settings_lock - the "
+            "issue #2636 AB-BA lock inversion has regressed"
+        )
+
+    def test_cold_boot_concurrent_getters_and_get_all_complete(self, isolated_settings):
+        """The exact wedge #2636 described: getter-path and get_all-path
+        threads hitting a cold cache together must all finish."""
+        import threading
+
+        settings_mod.reset()  # force the cold-cache load path for every thread
+
+        errors: list[Exception] = []
+        start = threading.Event()
+        n_ready = [0]
+        ready_lock = threading.Lock()
+        workers = [
+            settings_mod.get_volume,
+            settings_mod.get_all,
+            settings_mod.get_inclusion,
+            settings_mod.get_grid_icon_size_left,  # _get_dict path
+            settings_mod.get_all,
+            settings_mod.get_panel_pct_right,  # _get_dict path
+            settings_mod.get_volume,
+            settings_mod.get_all,
+        ]
+        n_threads = len(workers)
+
+        def run(fn):
+            try:
+                with ready_lock:
+                    n_ready[0] += 1
+                    if n_ready[0] == n_threads:
+                        start.set()
+                start.wait(timeout=5)
+                fn()
+            except Exception as exc:  # pragma: no cover - surfaced below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=run, args=(fn,)) for fn in workers]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        assert not errors, f"workers raised: {errors}"
+        for t in threads:
+            assert not t.is_alive(), "thread hung on cold boot (issue #2636 deadlock)"

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -881,8 +881,11 @@ class TestColdBootDeadlock:
         @contextlib.contextmanager
         def spy_file_lock(path):
             # Record whether THIS thread already holds _settings_lock at the
-            # moment we reach for the cross-process file lock.
-            owned_at_acquire.append(settings_mod._settings_lock._is_owned())
+            # moment we reach for the cross-process file lock. ``_is_owned``
+            # is a real method on the C-accelerated RLock (the standard idiom
+            # for "does the current thread hold this reentrant lock?") but is
+            # absent from typeshed's stubs, hence the ignore.
+            owned_at_acquire.append(settings_mod._settings_lock._is_owned())  # type: ignore[attr-defined]
             with real_file_lock(path):
                 yield
 

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -894,8 +894,7 @@ class TestColdBootDeadlock:
 
         assert owned_at_acquire, "cold getter did not exercise the file-lock load path"
         assert not any(owned_at_acquire), (
-            "getter reached file_lock while holding _settings_lock - the "
-            "issue #2636 AB-BA lock inversion has regressed"
+            "getter reached file_lock while holding _settings_lock - the issue #2636 AB-BA lock inversion has regressed"
         )
 
     def test_cold_boot_concurrent_getters_and_get_all_complete(self, isolated_settings):

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -643,8 +643,20 @@ def _validate_field(model: type, key: str, value: Any) -> Any:
 
 def _make_scalar_accessors(model: type, key: str):
     def getter():
-        with _settings_lock:
-            raw = _read_value(key)
+        # Do NOT hold ``_settings_lock`` across ``_read_value``. On a cold
+        # cache ``_read_value`` reaches the load path
+        # (``_ensure_server_loaded`` / ``_ensure_user_loaded``), which takes
+        # the cross-process *file* lock before ``_settings_lock`` - the
+        # canonical order. Holding ``_settings_lock`` here would invert that
+        # and deadlock against a concurrent ``get_all`` /
+        # ``_load_and_migrate_server`` that holds the file lock and wants
+        # ``_settings_lock`` (issue #2636). It is also unnecessary: the
+        # ``_ensure_*`` loaders do their own internal locking, and every
+        # published cache is *rebound* (never mutated in place) under the
+        # lock, so the snapshot ``_read_value`` reads from is stable. Mirrors
+        # ``get_all`` / ``get_user_settings`` / ``get_autofind_detectors``,
+        # which all read outside ``_settings_lock`` for the same reason.
+        raw = _read_value(key)
         try:
             return _validate_field(model, key, raw)
         except ValueError:
@@ -759,8 +771,14 @@ def _make_per_side_setting(  # noqa: C901
     def _get_dict(key: str) -> dict[str, Any]:
         side = key[len(key_base) + 1 :]
         default_val = defaults.get(side, next(iter(defaults.values())))
-        with _settings_lock:
-            raw = _read_value(key)
+        # Read outside ``_settings_lock`` - see the note in
+        # ``_make_scalar_accessors.getter``: on a cold cache ``_read_value``
+        # takes the file lock before ``_settings_lock``, so holding
+        # ``_settings_lock`` here would invert the order and deadlock
+        # (issue #2636). The ``_ensure_*`` loaders lock internally and
+        # published caches are rebound, not mutated in place, so the read is
+        # safe unlocked.
+        raw = _read_value(key)
         types = _valid_media_types()
         if not isinstance(raw, dict):
             return {tid: default_val for tid in types}


### PR DESCRIPTION
## Summary

Fixes the cold-boot AB-BA deadlock reported in #2636, where a fresh instance wedged permanently on first browser contact — every settings-touching endpoint (`/api/settings`, `/api/achievements`, `/api/sessions/recent`, `/api/detectors/registry`) hung forever.

## Root cause

The canonical lock order in the settings layer is **file lock → settings lock** (`_settings_lock`). On a cold cache, `_read_value()` reaches the load path (`_ensure_user_loaded` → `ensure_server_loaded` → `_load_and_migrate_server`), which takes the cross-process **server file lock**.

`_make_scalar_accessors.getter()` and `_make_per_side_setting._get_dict()` wrapped the entire `_read_value()` call in `with _settings_lock:`. So on a cold cache they acquired the **file lock while already holding `_settings_lock`** — inverting the canonical order. Meanwhile `get_all` / `_load_and_migrate_server` held the file lock and waited on `_settings_lock`. Classic AB-BA:

- `get_settings` thread: held `file_lock(server_path)`, blocked on `with self._lock:` (`_settings_lock`).
- scalar `getter()` threads: held `_settings_lock`, blocked inside `file_lock` on the cold-load path.

`_store._lock` **is** `_settings_lock` (shared by reference), so the two deadlocked. Warm caches skip the file-lock path, which is why long-lived instances rarely saw it and a fresh instance + dashboard reproduced it deterministically.

## Fix

Read **outside** `_settings_lock` in both accessor paths, so the cold-load path never runs while `_settings_lock` is held. This mirrors what `get_all`, `get_user_settings`, and `get_autofind_detectors` already do (ensure-then-lock, or read unlocked).

It is safe to drop the lock because:
- The `_ensure_*` loaders do their own correct internal locking (file lock before settings lock).
- Every published cache (`_server_cache`, `_user_caches[username]`) is only ever **rebound** to a fresh dict under the lock — never mutated in place after publication. So `_read_value` operates on a stable snapshot; the unlocked `.get`/`in`/`[]` reads can't tear or race a concurrent mutation.

## Tests

Added `TestColdBootDeadlock` in `tests/core/test_settings.py`:
- **Lock-inversion invariant** — monkeypatches `settings_store.file_lock` and asserts a scalar getter's cold-cache read never reaches the file lock while the calling thread holds `_settings_lock`. Deterministic; fails on the pre-fix code.
- **Cold-boot concurrency** — 8 threads mixing `get_volume` / `get_all` / `get_inclusion` / per-side dict getters against a freshly reset (cold) cache must all complete — the exact wedge #2636 described.

`./run-tests.sh core` (settings subset, 274 tests) passes, including ruff, pyright, deptry, pip-audit, and the frontend build.

Closes #2636

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSUeFr6YDqzmG3iJbyg9ST)_