### PR TITLE
Sum b_embed across bound embedders for v3 trio dataset loads

### DIFF
--- a/tests_lib/datasets/test_load_step_weights.py
+++ b/tests_lib/datasets/test_load_step_weights.py
@@ -137,6 +137,68 @@ def test_cost_model_terms_collapse_acquire_when_no_archive(monkeypatch):
     assert terms["extract"] == 0.0
 
 
+def test_cost_model_terms_sums_b_embed_across_bound_embedders(monkeypatch):
+    # A v3 trio dataset runs each bound embedder's full forward pass over all n
+    # items, so the embed term's b_embed must be the sum across every bound
+    # embedder, not just the primary embedder's own coefficient.
+    monkeypatch.setattr(
+        _cm,
+        "LOAD_COST_MODEL",
+        {
+            ("cuda", "image", "siglip"): {"a_model": 0.5, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.0},
+            ("cuda", "image", "dinov2_patch"): {
+                "a_model": 0.5,
+                "a_embed": 0.0,
+                "b_embed": 0.02,
+                "a_fin": 0.0,
+                "b_fin": 0.0,
+            },
+            ("cuda", "image", "sift_vlad"): {
+                "a_model": 0.5,
+                "a_embed": 0.0,
+                "b_embed": 0.03,
+                "a_fin": 0.0,
+                "b_fin": 0.0,
+            },
+        },
+    )
+    monkeypatch.setattr(_cm, "DOWNLOAD_MB_PER_S", 10.0)
+    monkeypatch.setattr(_cm, "EXTRACT_MB_PER_S", 50.0)
+
+    single = _cm.cost_model_terms("cuda", "image", "siglip", n=1000, download_size_mb=None)
+    assert single is not None
+    assert single["embed"] == pytest.approx(1.0 + 0.01 * 1000)
+
+    trio = _cm.cost_model_terms(
+        "cuda", "image", "siglip", n=1000, download_size_mb=None, embedders=["siglip", "dinov2_patch", "sift_vlad"]
+    )
+    assert trio is not None
+    # a_embed still comes from the primary (siglip) row only; b_embed sums across
+    # all three bound embedders.
+    assert trio["embed"] == pytest.approx(1.0 + (0.01 + 0.02 + 0.03) * 1000)
+    # Every other phase is unaffected by the trio's extra embedders.
+    assert trio["load"] == single["load"]
+    assert trio["finalize"] == single["finalize"]
+
+
+def test_cost_model_terms_trio_ignores_unmeasured_embedder(monkeypatch):
+    # An embedder with no calibrated row contributes 0 rather than dropping the
+    # whole computation.
+    monkeypatch.setattr(
+        _cm,
+        "LOAD_COST_MODEL",
+        {("cuda", "image", "siglip"): {"a_model": 0.5, "a_embed": 1.0, "b_embed": 0.01, "a_fin": 1.0, "b_fin": 0.0}},
+    )
+    monkeypatch.setattr(_cm, "DOWNLOAD_MB_PER_S", 10.0)
+    monkeypatch.setattr(_cm, "EXTRACT_MB_PER_S", 50.0)
+
+    terms = _cm.cost_model_terms(
+        "cuda", "image", "siglip", n=1000, download_size_mb=None, embedders=["siglip", "no_such_embedder"]
+    )
+    assert terms is not None
+    assert terms["embed"] == pytest.approx(1.0 + 0.01 * 1000)
+
+
 def test_small_n_weights_model_heavier_and_large_n_weights_embed_heavier(monkeypatch):
     monkeypatch.setattr("vtscore.config.resolve_device", lambda: "cuda")
     _inject_row(

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -422,7 +422,9 @@ def _run_origin_load_in_background(
         name or _origin_to_str(origin),
         media_type=media_type,
         embedder=embedder,
-        step_weights=load_step_weights(media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder),
+        step_weights=load_step_weights(
+            media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder, embedders=embedders
+        ),
     )
     # Env-gated per-phase timing recorder (VTSEARCH_PROFILE_LOAD); ``None`` and
     # zero-cost when off. Subscribed before the first phase fires. See
@@ -463,7 +465,7 @@ def _run_origin_load_in_background(
         # actually happens (cached archives, observed bandwidth, skipped
         # phases). All stage progress below routes through the pacer.
         cost_terms, terms_calibrated = load_cost_terms(
-            media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder
+            media_type, n=n_hint, download_size_mb=download_size_mb_hint, embedder=embedder, embedders=embedders
         )
         pacer = AdaptiveLoadPacer(tracker, cost_terms, calibrated=terms_calibrated)
         stepped = _make_stepped_progress(controller, pacer)

--- a/vtscore/datasets/stages/_common.py
+++ b/vtscore/datasets/stages/_common.py
@@ -114,6 +114,7 @@ def load_step_weights(
     n: Optional[int] = None,
     download_size_mb: Optional[float] = None,
     embedder: Optional[str] = None,
+    embedders: Optional[list[str]] = None,
 ) -> list[float]:
     """Return the dataset-load step weights for the active device and media type.
 
@@ -124,6 +125,11 @@ def load_step_weights(
     for large ``n``. Otherwise it returns the static per-(device, media_type)
     profile below — the large-``n`` asymptote — so callers without a known ``n``
     (folder importers that stream) keep today's behaviour unchanged.
+
+    *embedders* is the optional full set of embedders bound to the dataset (v3
+    trio: text / patch / structural picks); when set, the cost model sums each
+    bound embedder's ``b_embed`` term instead of assuming *embedder* alone
+    covers the whole embed phase (see ``_load_cost_model.cost_model_weights``).
 
     Static fallback rationale: GPU hosts embed several times faster, so the
     un-accelerated finalize phase earns a larger slice; on a CPU host an image
@@ -137,7 +143,7 @@ def load_step_weights(
         from vtscore.datasets.stages._load_cost_model import cost_model_weights  # noqa: PLC0415
 
         emb = embedder or _default_embedder_name(media_type)
-        weights = cost_model_weights(device, media_type, emb, n, download_size_mb)
+        weights = cost_model_weights(device, media_type, emb, n, download_size_mb, embedders)
         if weights is not None:
             return weights
 
@@ -160,6 +166,7 @@ def load_cost_terms(
     n: Optional[int] = None,
     download_size_mb: Optional[float] = None,
     embedder: Optional[str] = None,
+    embedders: Optional[list[str]] = None,
 ) -> tuple[dict[str, float], bool]:
     """Predicted per-phase cost terms for a dataset load, in phase order
     ``download``, ``extract``, ``load``, ``embed``, ``finalize``.
@@ -175,6 +182,10 @@ def load_cost_terms(
     is unit-compatible with the other terms — mixing seconds into the
     pseudo-time vector hands the observed phase essentially the whole bar.
 
+    *embedders* is the optional full set of embedders bound to the dataset (v3
+    trio: text / patch / structural picks); when set, the embed term sums each
+    bound embedder's ``b_embed`` (see ``_load_cost_model.cost_model_terms``).
+
     Always returns a usable dict (never raises), so the pacing layer can rely
     on it for every import path, including streaming folder importers.
     """
@@ -184,7 +195,7 @@ def load_cost_terms(
         from vtscore.datasets.stages._load_cost_model import cost_model_terms  # noqa: PLC0415
 
         emb = embedder or _default_embedder_name(media_type)
-        terms = cost_model_terms(device, media_type, emb, n, download_size_mb)
+        terms = cost_model_terms(device, media_type, emb, n, download_size_mb, embedders)
         if terms is not None:
             return terms, True
 

--- a/vtscore/datasets/stages/_load_cost_model.py
+++ b/vtscore/datasets/stages/_load_cost_model.py
@@ -26,7 +26,7 @@ measured row fall back to the static per-device/media profiles in ``_common``.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Sequence
 
 # key: (device, media_type, embedder) -> affine coefficients (seconds).
 # ``device`` is "cpu", "cuda", or "cuda+cuml"; ``embedder`` is the encoder
@@ -511,12 +511,37 @@ def _lookup_row(device: str, media_type: str, embedder: str) -> Optional[dict[st
     return None
 
 
+def _bound_b_embed_total(
+    device: str, media_type: str, embedder: str, primary_row: dict[str, float], embedders: Optional[Sequence[str]]
+) -> float:
+    """Sum the ``b_embed`` coefficient across every embedder bound to the
+    dataset, not just *embedder*'s own row.
+
+    A v3 trio dataset (text / patch / structural) runs each bound embedder's
+    full forward pass over all ``n`` items in turn (see
+    ``embedding._embed_missing_stage``), so the embed phase's per-item cost is
+    the *sum* of each bound embedder's ``b_embed``, not a single embedder's
+    coefficient. Falls back to *primary_row*'s own ``b_embed`` when *embedders*
+    is empty/``None`` (the pre-trio single-embedder path, unchanged) or names
+    only *embedder* itself. Names with no measured row contribute 0 rather
+    than dropping the whole computation.
+    """
+    names = list(dict.fromkeys(n for n in (embedders or [embedder]) if n)) or [embedder]
+    total = 0.0
+    for name in names:
+        row = primary_row if name == embedder else _lookup_row(device, media_type, name)
+        if row is not None:
+            total += row.get("b_embed", 0.0)
+    return total
+
+
 def cost_model_terms(
     device: str,
     media_type: str,
     embedder: str,
     n: int,
     download_size_mb: Optional[float] = None,
+    embedders: Optional[Sequence[str]] = None,
 ) -> Optional[dict[str, float]]:
     """Return predicted per-phase seconds from the affine cost model, or
     ``None`` when no coefficient row matches (so the caller can fall back to
@@ -529,6 +554,13 @@ def cost_model_terms(
     ``download_size_mb`` of 0/``None`` collapses the download **and** extract
     terms — which is exactly right for local-folder imports and cache-backed
     re-adds, where no archive is fetched or unpacked.
+
+    ``embedders`` is the optional full set of embedders bound to the dataset
+    (v3 trio: text / patch / structural picks). When given, the embed term's
+    ``b_embed`` is summed across all of them (see :func:`_bound_b_embed_total`)
+    instead of assuming *embedder*'s row alone covers the whole embed phase;
+    ``a_embed`` still comes from *embedder*'s row only, since it is a fixed
+    per-load overhead rather than a per-item cost.
     """
     row = _lookup_row(device, media_type, embedder)
     if row is None or n <= 0:
@@ -540,11 +572,12 @@ def cost_model_terms(
             t_download = download_size_mb / DOWNLOAD_MB_PER_S
         if EXTRACT_MB_PER_S > 0:
             t_extract = download_size_mb / EXTRACT_MB_PER_S
+    b_embed_total = _bound_b_embed_total(device, media_type, embedder, row, embedders)
     terms = {
         "download": max(0.0, t_download),
         "extract": max(0.0, t_extract),
         "load": max(0.0, row.get("a_model", 0.0) + row.get("b_load", 0.0) * n),
-        "embed": max(0.0, row.get("a_embed", 0.0) + row.get("b_embed", 0.0) * n),
+        "embed": max(0.0, row.get("a_embed", 0.0) + b_embed_total * n),
         "finalize": max(0.0, row.get("a_fin", 0.0) + row.get("b_fin", 0.0) * n),
     }
     if sum(terms.values()) <= 0:
@@ -558,12 +591,14 @@ def cost_model_weights(
     embedder: str,
     n: int,
     download_size_mb: Optional[float] = None,
+    embedders: Optional[Sequence[str]] = None,
 ) -> Optional[list[float]]:
     """Return normalized ``[acquire, load, embed, finalize]`` step weights from
     the affine cost model (acquire = download + extract), or ``None`` when no
     coefficient row matches (so the caller can fall back to the static
-    profile)."""
-    terms = cost_model_terms(device, media_type, embedder, n, download_size_mb)
+    profile). ``embedders``, when given, sums the embed term's ``b_embed``
+    across every bound embedder (see :func:`cost_model_terms`)."""
+    terms = cost_model_terms(device, media_type, embedder, n, download_size_mb, embedders)
     if terms is None:
         return None
     parts = [


### PR DESCRIPTION
## Summary

- The affine load-cost model (`vtscore/datasets/stages/_load_cost_model.py`) priced the embed phase from a single embedder's `(a_embed, b_embed)` coefficient row, but a v3 trio dataset (text/patch/structural) runs each bound embedder's full forward pass over every item in turn (see `embedding._embed_missing_stage`).
- `cost_model_terms` / `cost_model_weights` now accept an optional `embedders` list and sum `b_embed` across every distinct bound embedder, so the embed term scales correctly with the number of bound embedders rather than assuming one embedder's coefficient covers the whole embed phase. `a_embed` still comes from the primary embedder's row only (fixed per-load overhead, not a per-item cost).
- Threaded the trio's `embedders` list through `load_step_weights` / `load_cost_terms` (`vtscore/datasets/stages/_common.py`) and into both call sites in `vtscore/datasets/load_pipeline.py` (`_run_origin_load_in_background`'s step-weight init and the `AdaptiveLoadPacer` cost terms).

## Test plan

- [x] Added `test_cost_model_terms_sums_b_embed_across_bound_embedders` and `test_cost_model_terms_trio_ignores_unmeasured_embedder` in `tests_lib/datasets/test_load_step_weights.py`.
- [x] `python -m pytest tests_lib/datasets/test_load_step_weights.py -q`
- [x] `./run-tests.sh vtscore-clean`
- [x] `./run-tests.sh datasets`
- [x] `./run-tests.sh` (full suite)

Closes #2625


---
_Generated by [Claude Code](https://claude.ai/code/session_01BK1HzELgRoovAC54Qor1Y6)_