### PR TITLE
Populate measured finalize sub-slot shares from the calib-2623 sweep

### DIFF
--- a/docs/plans/progress-weight-calibration.md
+++ b/docs/plans/progress-weight-calibration.md
@@ -160,3 +160,37 @@ GTZAN measurement — see the note in `_load_cost_model.py`.
 | cuda+cuml | text | bge | 0.50+0.00m·n (cold 27.0) | 0.00 | 6.09+12.07m·n | 1.00 | 0.41+2.22m·n | 1.00 | 8 |
 | cuda+cuml | text | e5 | 0.50+0.00m·n (cold 30.5) | 0.00 | 3.84+12.50m·n | 1.00 | 0.15+2.22m·n | 0.99 | 9 |
 | cuda+cuml | video | xclip | 0.50+0.00m·n (cold 28.3) | 0.00 | -0.34+146.07m·n | 0.99 | 0.25+3.05m·n | 0.83 | 9 |
+
+### Finalize sub-slot shares (issue #2624)
+
+Fitted from the same sweep's `finalize:<slot>` rows (the profiler was already
+stamping them during the #2623 run, so no separate sweep was needed) and pasted
+into `FINALIZE_SLOT_SHARES` in `_load_cost_model.py`: median seconds per slot
+across loads, normalized per `(device, media)` cell.
+
+- The static ballpark (`registry 0.45 > coverage 0.30`) has the ratio backwards
+  for most cells: measured coverage outweighs registry for audio, text, and
+  cuda video — for text it is ~99/1 (the coverage k-means over the text
+  embeddings is essentially the whole phase). Document is the opposite extreme
+  (registry ~0.95: few items, big page-image payload to serialize).
+- Each `cuda` row pools cuML-on and cuML-off loads: splitting them moved no
+  slot's share by more than ~0.11 (image coverage 0.41 with cuML vs 0.44
+  without; video 0.65 vs 0.54), so the table keeps two device keys rather than
+  growing a `cuda+cuml` variant like `LOAD_COST_MODEL`.
+- `dedup` / `cleanup` did run and measure ~0 of the phase (default fast-hash
+  dedup; floored at 0.0001 rather than rounded to an invalid 0 weight). The
+  opt-in `projection` / `signpost_texts` never ran during calibration, emit no
+  row, and keep their static ballpark share via the `_finalize_slots` merge.
+
+| device | media | slot shares (fraction of finalize) | loads |
+|--------|-------|-------------------------------------|-------|
+| cpu | audio | cleanup 0.00, dedup 0.00, coverage 0.65, registry 0.35 | 17 |
+| cpu | document | cleanup 0.00, dedup 0.00, coverage 0.05, registry 0.95 | 1 |
+| cpu | image | cleanup 0.00, dedup 0.00, coverage 0.50, registry 0.50 | 35 |
+| cpu | text | cleanup 0.00, dedup 0.00, coverage 0.99, registry 0.01 | 8 |
+| cpu | video | cleanup 0.00, dedup 0.00, coverage 0.47, registry 0.53 | 5 |
+| cuda | audio | cleanup 0.00, dedup 0.00, coverage 0.66, registry 0.34 | 48 |
+| cuda | document | cleanup 0.00, dedup 0.00, coverage 0.04, registry 0.96 | 5 |
+| cuda | image | cleanup 0.00, dedup 0.00, coverage 0.41, registry 0.59 | 96 |
+| cuda | text | cleanup 0.00, dedup 0.00, coverage 0.99, registry 0.01 | 24 |
+| cuda | video | cleanup 0.00, dedup 0.00, coverage 0.61, registry 0.39 | 16 |

--- a/scripts/profiling/fit_load_weights.py
+++ b/scripts/profiling/fit_load_weights.py
@@ -241,7 +241,11 @@ def _fit_finalize_slots(
             continue
         known = [s for s in _FIN_SLOT_ORDER if s in slot_med]
         extra = [s for s in slot_med if s not in _FIN_SLOT_ORDER]
-        ordered = tuple((s, round(slot_med[s] / total, 4)) for s in known + extra)
+        # A measured-but-tiny slot keeps a positive floor share: rounding it to
+        # 0 would ship a zero-weight row (the checked-in table requires w > 0),
+        # while dropping it would hand the slot back its static ballpark
+        # despite the measurement saying it is ~free.
+        ordered = tuple((s, max(round(slot_med[s] / total, 4), 0.0001)) for s in known + extra)
         shares[key] = ordered
         n_loads = max((len(v) for v in fin_slots[key].values()), default=0)
         cells = ", ".join(f"{s} {frac:.2f}" for s, frac in ordered)

--- a/tests_lib/datasets/test_finalize_slot_shares.py
+++ b/tests_lib/datasets/test_finalize_slot_shares.py
@@ -86,6 +86,13 @@ def test_finalize_slots_never_raises_when_device_resolution_fails(monkeypatch):
         raise RuntimeError("no torch")
 
     monkeypatch.setattr("vtscore.config.resolve_device", _boom)
+    # Resolution failure degrades to the "cpu" device, so a populated shipped
+    # table still supplies the cpu row; the property under test is that nothing
+    # raises and every canonical slot keeps a slice.
+    slots = _finalize_slots("image")
+    assert [name for name, _ in slots] == [name for name, _ in FinalizeProgress._SLOTS]
+    # With no calibrated row either, the full static ballpark comes back.
+    monkeypatch.setattr(_cm, "FINALIZE_SLOT_SHARES", {})
     assert _finalize_slots("image") == FinalizeProgress._SLOTS
 
 
@@ -156,6 +163,22 @@ def test_fit_finalize_slots_medians_and_normalizes():
     # registry) is preserved for the slots that survive.
     assert shares == {("cuda", "image"): (("coverage", 0.8), ("registry", 0.2))}
     assert len(summary) == 1
+
+
+def test_fit_finalize_slots_floors_tiny_measured_slots_above_zero():
+    fit = _load_fit_module()
+    fin_slots = {
+        ("cuda", "audio"): {
+            "coverage": [100.0],
+            # Measured positive but <0.00005 of the phase: would round to 0.0,
+            # which the shipped table forbids (w > 0) — floored to 0.0001.
+            "cleanup": [0.001],
+        }
+    }
+    shares, _ = fit._fit_finalize_slots(fin_slots)
+    row = dict(shares[("cuda", "audio")])
+    assert row["cleanup"] == 0.0001
+    assert all(w > 0 for w in row.values())
 
 
 def test_fit_finalize_slots_orders_canonically_then_appends_unknown():

--- a/vtscore/datasets/stages/_load_cost_model.py
+++ b/vtscore/datasets/stages/_load_cost_model.py
@@ -450,15 +450,36 @@ EXTRACT_MB_PER_S: float = 45.66
 # consumer). Slot order here is the execution order; a slot omitted from a row
 # simply isn't paced separately for that cell.
 #
-# EMPTY until a calibration run populates it. The env-gated load profiler already
-# records ``finalize:<slot>`` rows (see ``_load_profiler`` /
-# ``FinalizeProgress.begin``); ``scripts/profiling/fit_load_weights.py`` fits
-# them into this table's body. Re-run that harness to refresh — do not hand-tune.
-# Cells with no measured row fall back to the static ``FinalizeProgress._SLOTS``
-# ballpark (which is why the finalize sub-stage motivating this table — a
-# non-cuML GPU host where the coverage k-means outweighs the registry save — is
-# uncalibrated here and awaits a GPU calibration run; see issue #2624).
-FINALIZE_SLOT_SHARES: dict[tuple[str, str], tuple[tuple[str, float], ...]] = {}
+# POPULATED FROM CALIBRATION (HLTCOE Grid rack8n06 v100 node, 2026-07-18/19
+# sweep under /exp/…/calib-2623 — the same JSONL that sourced LOAD_COST_MODEL;
+# the profiler was already stamping ``finalize:<slot>`` rows during that run,
+# so no separate sweep was needed; issues #2623/#2624, see plan Results).
+# ``scripts/profiling/fit_load_weights.py`` fits the rows into this table's
+# body (median seconds per slot across loads, normalized per cell). Re-run
+# that harness to refresh — do not hand-tune. Unlike LOAD_COST_MODEL there is
+# no "cuda+cuml" variant: each "cuda" row pools cuML-on and cuML-off loads,
+# because the measured split moved no slot's share by more than ~0.11 (e.g.
+# image coverage 0.41 cuML vs 0.44 without) — far from the registry/coverage
+# flip the static ballpark gets wrong, and not worth a third key. The
+# opt-in ``projection`` / ``signpost_texts`` slots never ran during
+# calibration, so they emit no row here and keep their static ballpark via
+# the :func:`_finalize_slots` merge; ``dedup`` / ``cleanup`` did run and
+# measure ~0 (the default fast-hash dedup — an opt-in near-dup merge would
+# be undersold by these shares until a calibrated run covers it). Cells with
+# no measured row fall back to the static ``FinalizeProgress._SLOTS``
+# ballpark entirely.
+FINALIZE_SLOT_SHARES: dict[tuple[str, str], tuple[tuple[str, float], ...]] = {
+    ("cpu", "audio"): (("cleanup", 0.0001), ("dedup", 0.0002), ("coverage", 0.6484), ("registry", 0.3512)),
+    ("cpu", "document"): (("cleanup", 0.0001), ("dedup", 0.0001), ("coverage", 0.0524), ("registry", 0.9476)),
+    ("cpu", "image"): (("cleanup", 0.0001), ("dedup", 0.0002), ("coverage", 0.5015), ("registry", 0.4983)),
+    ("cpu", "text"): (("cleanup", 0.0001), ("dedup", 0.0002), ("coverage", 0.988), ("registry", 0.0117)),
+    ("cpu", "video"): (("cleanup", 0.0003), ("dedup", 0.0006), ("coverage", 0.4725), ("registry", 0.5265)),
+    ("cuda", "audio"): (("cleanup", 0.0001), ("dedup", 0.0002), ("coverage", 0.6624), ("registry", 0.3373)),
+    ("cuda", "document"): (("cleanup", 0.0001), ("dedup", 0.0001), ("coverage", 0.0367), ("registry", 0.9633)),
+    ("cuda", "image"): (("cleanup", 0.0001), ("dedup", 0.0001), ("coverage", 0.4069), ("registry", 0.5929)),
+    ("cuda", "text"): (("cleanup", 0.0001), ("dedup", 0.0003), ("coverage", 0.9853), ("registry", 0.0143)),
+    ("cuda", "video"): (("cleanup", 0.0001), ("dedup", 0.0003), ("coverage", 0.608), ("registry", 0.3916)),
+}
 
 
 def finalize_slot_shares(device: str, media_type: str) -> Optional[tuple[tuple[str, float], ...]]:


### PR DESCRIPTION
## Summary

Populates `FINALIZE_SLOT_SHARES` — the measured-numbers half of #2624 that PR #2632 left as a handoff. No new sweep was needed: the load profiler was already stamping `finalize:<slot>` rows during the #2623 calibration run, so the shares are fitted from the existing calib-2623 JSONL (all 5 demo-backed media × cpu / cuda / cuda-with-cuML loads, ~1,000 finalize sub-slot rows).

The headline: the static ballpark (`registry 0.45 > coverage 0.30`) has the ratio backwards for most cells. Measured coverage outweighs registry for audio, text, and cuda video — for text it's ~99/1 (the coverage k-means is essentially the whole finalize phase). Document is the opposite extreme (registry ~0.95). The cuML-on/off split moved no slot's share by more than ~0.11, so the table keeps its two device keys (`cpu`/`cuda`, each `cuda` row pooling both variants) rather than growing a `cuda+cuml` variant like `LOAD_COST_MODEL`.

## Changes

- **`vtscore/datasets/stages/_load_cost_model.py`** — `FINALIZE_SLOT_SHARES` populated with the 10 fitted `(device, media)` rows (verbatim fit-script output); header comment updated from "EMPTY until calibrated" to the provenance + pooling notes.
- **`scripts/profiling/fit_load_weights.py`** — emitter fix found while fitting: a measured-but-tiny slot (e.g. `dedup` at ~0.00005 of the phase) rounded to an invalid `0.0` weight, which the shipped-table invariant (`w > 0`) forbids — and dropping it instead would hand the slot back its static ballpark despite being measured ~free. Floored at `0.0001`.
- **`tests_lib/datasets/test_finalize_slot_shares.py`** — new test for the floor; fixed `test_finalize_slots_never_raises_when_device_resolution_fails`, which passed vacuously with the empty shipped table (its `resolve_device` monkeypatch never actually reached `_resolve_device_name`, and resolution failure by design degrades to `"cpu"` — which now has measured rows). It now asserts the real contract: no raise + every canonical slot keeps a slice, plus the static fallback when the table is empty.
- **`docs/plans/progress-weight-calibration.md`** — finalize sub-slot shares table + fit notes appended under Results.

## Verification

`./run-tests.sh datasets core` on rack8n06 → **ALL 2007 TESTS PASSED** (42 skipped, total 2049). Targeted `test_finalize_slot_shares.py` + `test_progress_overall.py` → 36 passed. ruff check / ruff format clean on the changed files.

**Verified live** (branch served on rack8n06, CPU device, fresh data dir): imported the 20 Newsgroups (S) demo through the production `/api/dataset/load-demo` route and captured the `/api/events` SSE stream. The finalize step's within-step counter followed the measured `(cpu, text)` row, not the static ballpark:

| finalize sub-stage | static ballpark | measured shares (observed) |
|---|---|---|
| Removing duplicates… | 0.047 → 0.167 | pinned at ~0.000 |
| Building diversity index… (coverage) | 0.190 → 0.476 | **0.000 → 0.898** |
| Saving to registry… → Registering… | 0.666 → 0.952 | 0.947 → 0.954 |

(The static column is the same load driven through a build with the empty table — the coverage k-means dominated real wall-clock in both runs, ~590 of ~600 step-4 SSE frames, which is exactly what the measured shares now tell the bar.)

Two verification gotchas worth recording: the generic `/api/dataset/import/demo` plugin route strips `media_type` (the demo importer doesn't declare it as a field), so drive demo loads through `/api/dataset/load-demo`, which injects it server-side — and a worktree-served app must neutralize the venv's editable-install meta-path finder (it hijacks `import vtscore` to the main checkout regardless of `PYTHONPATH`/cwd).

Refs #2624
