### PR TITLE
S14: cache secondary media lookups on DatasetContext

### DIFF
--- a/docs/plans/scalability.md
+++ b/docs/plans/scalability.md
@@ -10,8 +10,9 @@ fix direction + implementation sketch for each item still owed.
 **Scope:** What breaks as datasets grow to 100 k / 1 M / 10 M items and as
 LabelSets grow to 1 k / 10 k / 100 k labels, GUI and CLI. Items track **future
 work only**: shipped items (S2/S8 coverage-atlas auto-defer, S9 GMM subsample,
-S16 grid virtual scroll, S18 prefetch cap, S21 CLI progress throttle) have been
-pruned per the plan-file policy — git history is their record. `S#` numbering
+S14 cached secondary lookups, S16 grid virtual scroll, S18 prefetch cap, S21 CLI
+progress throttle) have been pruned per the plan-file policy — git history is
+their record. `S#` numbering
 has gaps where those were removed; that is expected (labels are stable, never
 renumbered).
 
@@ -29,8 +30,6 @@ deferred. Items are independently shippable.
 
 ## Suggested work order (open items, max-leverage first)
 
-1. **S14** (incremental secondary indexes on `DatasetContext`); removes per-request
-   O(N) dict rebuilds; medium refactor.
 3. **S1** (mmap embedding matrix); unblocks 1 M+ datasets without OOM. Also
    decouples embeddings from the pickle, which unblocks S15.
 4. **S3 + S17 + S19** (sparse sort results, lazy ordered items); must be done
@@ -289,35 +288,6 @@ labelset. (Journal deferred until compaction semantics are defined.)
 
 ---
 
-### S14: incremental secondary lookups on `DatasetContext`
-
-**File:** `vtscore/state/core.py`, plus routes that rebuild lookup dicts
-(`vtscore/state/media_lookup.py`, `vtsearch/routes/labels/vote.py:144` does
-`{m["md5"]: m for m in all_medias.values()}` per request)
-
-Many routes rebuild `{m["md5"]: m for m in snap.values()}` (or origin-key variants)
-on every request — O(N) Python iteration + dict construction, 2–3 passes/request,
-~100 ms each at 1 M.
-
-**Fix:** Add maintained secondary indexes to `DatasetContext`:
-
-```python
-class DatasetContext:
-    __slots__ = (..., "_md5_index", "_origin_key_index")
-    # __init__: self._md5_index = {}; self._origin_key_index = {}
-```
-
-Maintain them at the same structural-mutation sites that bump `media_revision`
-(the `MediasDict` add/remove hooks are the natural home). Routes/helpers that
-rebuild lookup dicts switch to `ctx._md5_index` / `ctx._origin_key_index`
-directly.
-
-**Risk:** medium — indexes must stay in sync with `medias`. Any site that writes
-`ctx.medias` directly must go through the maintained path; the `MediasDict` hook
-already centralises structural mutations, so hang the index maintenance there.
-
----
-
 ### S15: dataset pickle loading — everything into RAM at once
 
 **Files:** `vtscore/datasets/loader_pickle.py`, `vtscore/datasets/container.py`
@@ -403,7 +373,6 @@ embedder. Shares the S11 approach.
 | **No streaming** for large JSON / pickle payloads | S3, S13, S15 |
 | **Serial I/O** where parallelism is easy | S11, S20 |
 | **No debouncing** on high-frequency write paths | S12 |
-| **Per-request rebuild** of secondary lookups | S14 |
 
 ---
 
@@ -417,8 +386,6 @@ embedder. Shares the S11 approach.
   on cache hit (no per-call `sorted()`).
 - **S7:** learned-sort job not re-fired when called twice with the same votes on
   the same `media_revision`.
-- **S14:** `_md5_index` / `_origin_key_index` stay in sync across add/remove/reload;
-  routes read them instead of rebuilding.
 
 ---
 

--- a/tests_lib/core/test_media_lookup_cache.py
+++ b/tests_lib/core/test_media_lookup_cache.py
@@ -1,0 +1,134 @@
+"""Tests for the revision-keyed secondary media-lookup cache (S14).
+
+``cached_media_lookups`` / ``cached_md5_lookup`` mirror the embedding-matrix
+cache: they build the ``(origin, md5, name)`` lookup triple once and reuse it
+until the dataset's ``media_revision`` advances (add / remove / reload), so the
+many routes that resolve label entries against the active dataset stop paying
+an O(N) ``json.dumps``-per-origin rebuild on every request.
+
+See ``tests_lib/core/test_embedding_matrix.py`` for the sibling matrix cache
+these tests are patterned on.
+"""
+
+from __future__ import annotations
+
+from vtscore.state.core import (
+    DatasetContext,
+    _request_missing_dataset_context,
+    set_thread_dataset_context,
+)
+from vtscore.state.media_lookup import (
+    _origin_key,
+    build_media_lookup,
+    cached_md5_lookup,
+    cached_media_lookups,
+)
+
+
+def _ctx(name: str = "test_lookup_cache") -> DatasetContext:
+    ctx = DatasetContext(name)
+    ctx.medias[1] = {"id": 1, "md5": "aaa", "origin": {"importer": "x"}, "origin_name": "one.wav"}
+    ctx.medias[2] = {"id": 2, "md5": "bbb", "origin": {"importer": "x"}, "origin_name": "two.wav"}
+    return ctx
+
+
+class TestLookupContents:
+    """The cached triple matches a fresh ``build_media_lookup``."""
+
+    def test_matches_build_media_lookup(self):
+        ctx = _ctx()
+        origin, md5, name = cached_media_lookups(ctx)
+        exp_origin, exp_md5, exp_name = build_media_lookup(dict(ctx.medias))
+        assert origin == exp_origin
+        assert md5 == exp_md5
+        assert name == exp_name
+        # Spot-check the actual mappings.
+        assert md5["aaa"] == [1]
+        assert md5["bbb"] == [2]
+        assert name["one.wav"] == [1]
+        assert origin[_origin_key({"importer": "x"}, "two.wav")] == [2]
+
+    def test_md5_helper_returns_md5_element(self):
+        ctx = _ctx()
+        assert cached_md5_lookup(ctx) == cached_media_lookups(ctx)[1]
+
+    def test_shared_md5_maps_to_both_ids(self):
+        ctx = DatasetContext("test_shared_md5")
+        ctx.medias[1] = {"id": 1, "md5": "dup", "origin_name": "a"}
+        ctx.medias[2] = {"id": 2, "md5": "dup", "origin_name": "b"}
+        assert cached_md5_lookup(ctx)["dup"] == [1, 2]
+
+
+class TestRevisionKeying:
+    """Root-cause Pattern #4: the lookup cache keys on ``media_revision``."""
+
+    def test_cache_reused_at_same_revision(self):
+        ctx = _ctx()
+        first = cached_media_lookups(ctx)
+        second = cached_media_lookups(ctx)
+        # Same underlying dict objects → served from cache, not rebuilt.
+        for a, b in zip(first, second):
+            assert a is b
+        assert ctx._lookup_index_revision == ctx.media_revision
+
+    def test_add_media_invalidates(self):
+        ctx = _ctx()
+        _, md5_before, _ = cached_media_lookups(ctx)
+        assert "ccc" not in md5_before
+
+        ctx.medias[3] = {"id": 3, "md5": "ccc", "origin_name": "three.wav"}
+        _, md5_after, name_after = cached_media_lookups(ctx)
+        assert md5_after["ccc"] == [3]
+        assert name_after["three.wav"] == [3]
+        # A rebuild produced a fresh dict, not the stale cached one.
+        assert md5_after is not md5_before
+
+    def test_remove_media_invalidates(self):
+        ctx = _ctx()
+        assert "bbb" in cached_md5_lookup(ctx)
+        del ctx.medias[2]
+        assert "bbb" not in cached_md5_lookup(ctx)
+
+    def test_reload_wholesale_reassignment_invalidates(self):
+        ctx = _ctx()
+        assert cached_md5_lookup(ctx)["aaa"] == [1]
+        # Reload: reassign medias to a fresh mapping (even reusing ids).
+        ctx.medias = {
+            1: {"id": 1, "md5": "zzz", "origin_name": "renamed.wav"},
+        }
+        md5 = cached_md5_lookup(ctx)
+        assert "aaa" not in md5
+        assert md5["zzz"] == [1]
+
+
+class TestEmptyAndSentinel:
+    """Empty contexts never populate the cache (the frozen sentinel refuses
+    attribute writes, so an attempted store would raise)."""
+
+    def test_empty_context_returns_empties_without_caching(self):
+        ctx = DatasetContext("test_empty_lookup")
+        origin, md5, name = cached_media_lookups(ctx)
+        assert origin == {} and md5 == {} and name == {}
+        # Nothing cached: a genuinely-empty dataset rebuilds three empty dicts.
+        assert ctx._md5_index is None
+        assert ctx._lookup_index_revision is None
+
+    def test_request_missing_sentinel_does_not_raise(self):
+        # The sentinel's medias is a frozen empty dict AND it refuses attribute
+        # assignment; the empty-guard must return before any store is attempted.
+        origin, md5, name = cached_media_lookups(_request_missing_dataset_context)
+        assert origin == {} and md5 == {} and name == {}
+
+
+class TestActiveContextDefault:
+    """With no ``ctx`` argument the accessor resolves the active context."""
+
+    def test_defaults_to_active_context(self):
+        ctx = _ctx("test_active_default")
+        set_thread_dataset_context(ctx)
+        try:
+            assert cached_md5_lookup()["aaa"] == [1]
+            # Serves the same cached objects as the explicit-ctx call.
+            assert cached_media_lookups()[1] is cached_media_lookups(ctx)[1]
+        finally:
+            set_thread_dataset_context(None)

--- a/vtscore/detectors/label_restoration.py
+++ b/vtscore/detectors/label_restoration.py
@@ -82,7 +82,7 @@ def restore_labels_from_detector(det_data: dict) -> int:
     from vtscore.datasets.labelset import LabeledElement, LabelSet
     from vtscore.state import (
         apply_label,
-        build_media_lookup,
+        cached_media_lookups,
         resolve_media_ids,
         snapshot_medias,
     )
@@ -99,7 +99,7 @@ def restore_labels_from_detector(det_data: dict) -> int:
     if not snap:
         return 0
 
-    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
+    origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
 
     restored = 0
     unresolved: list[LabeledElement] = []  # elements needing origin resolution

--- a/vtscore/detectors/labelset_elements.py
+++ b/vtscore/detectors/labelset_elements.py
@@ -70,7 +70,7 @@ def resolve_current_dataset_cid(
     invariant is covered by ``test_collapse_duplicates_yields_unique_md5_lookup``.
     """
     from vtscore.state import (
-        build_media_lookup,
+        cached_media_lookups,
         resolve_media_ids,
         snapshot_medias,
     )
@@ -79,7 +79,7 @@ def resolve_current_dataset_cid(
         snap = snapshot_medias()
         if not snap:
             return None
-        lookups = build_media_lookup(snap)
+        lookups = cached_media_lookups()
     origin_lookup, md5_lookup, name_lookup = lookups
     cids = resolve_media_ids(elem.to_dict(), origin_lookup, md5_lookup, name_lookup)
     return cids[0] if cids else None
@@ -156,7 +156,7 @@ def build_labels_detail(detector_data: dict[str, Any]) -> dict[str, Any]:
 
     Returns ``{"good": [...], "bad": [...], "media_type": "..."}``.
     """
-    from vtscore.state import build_media_lookup, get_active_detector_context, snapshot_medias
+    from vtscore.state import cached_media_lookups, get_active_detector_context, snapshot_medias
 
     media_type = detector_data.get("media_type", "") or ""
     labelset = LabelSet.from_dict(detector_data.get("labelset") or {})
@@ -165,11 +165,12 @@ def build_labels_detail(detector_data: dict[str, Any]) -> dict[str, Any]:
     click_times = dict(det_ctx.vote_click_times)
     learned_scores = dict(det_ctx.last_learned_scores)
 
-    # Build the origin/md5/name lookup tables once and thread them through every
-    # element's view, so the labels-detail poll is O(N + labels) instead of
-    # O(labels × N) (each per-element rebuild would json.dumps every origin).
+    # Reuse the active dataset's cached origin/md5/name lookup tables (S14) and
+    # thread them through every element's view, so the labels-detail poll is
+    # O(N + labels) - or O(labels) on a cache hit - instead of O(labels × N)
+    # (each per-element rebuild would json.dumps every origin).
     snap = snapshot_medias()
-    lookups = build_media_lookup(snap) if snap else None
+    lookups = cached_media_lookups() if snap else None
 
     good: list[dict[str, Any]] = []
     bad: list[dict[str, Any]] = []

--- a/vtscore/detectors/learned_sort.py
+++ b/vtscore/detectors/learned_sort.py
@@ -54,9 +54,12 @@ def resolve_labelset_local_state(labelset, snap):
     if labelset is None:
         return None, None, None, False
 
-    from vtscore.state import build_media_lookup, resolve_media_ids
+    from vtscore.state import cached_media_lookups, resolve_media_ids
 
-    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
+    # *snap* is the active dataset's medias snapshot (this runs inside the
+    # caller's ``thread_dataset_context(ds_ctx)``), so the revision-keyed cache
+    # is consistent with it - reused across clicks instead of rebuilt (S14).
+    origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
     local_good: set[int] = set()
     local_bad: set[int] = set()
     training_medias: dict[int, dict] = {}

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -53,7 +53,7 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:
     from vtscore.state import (
         _state_lock,
         apply_label,
-        build_media_lookup,
+        cached_md5_lookup,
         get_active_context,
         next_media_id,
         snapshot_medias,
@@ -69,7 +69,7 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:
     if not snap:
         return 0
 
-    _, md5_lookup, _ = build_media_lookup(snap)
+    md5_lookup = cached_md5_lookup()
     server_media_dir = DATA_DIR / "example_media"
 
     # Determine the embedder and media type from the loaded dataset so we

--- a/vtscore/detectors/workflow.py
+++ b/vtscore/detectors/workflow.py
@@ -46,7 +46,7 @@ def apply_and_retrain(  # noqa: C901
     from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
     from vtscore.state import (
         apply_label,
-        build_media_lookup,
+        cached_media_lookups,
         resolve_media_ids,
         snapshot_medias,
     )
@@ -57,7 +57,7 @@ def apply_and_retrain(  # noqa: C901
         if not snap:
             return 0, False
 
-        origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
+        origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
 
         # 1) Resolve every entry into concrete (cid, label) pairs without
         #    touching any state yet.

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -98,6 +98,8 @@ from vtscore.state.media_lookup import (  # noqa: F401
     _origin_key,
     build_md5_lookup,
     build_media_lookup,
+    cached_md5_lookup,
+    cached_media_lookups,
     collapse_duplicates,
     find_missing_entries,
     get_dupe_count,

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -378,6 +378,20 @@ class DatasetContext:
         "_region_matrix_revision",
         "_region_media_index",
         "_region_index_per_row",
+        # Cached secondary media lookups (S14): the ``(origin_key, md5, name)``
+        # triple ``build_media_lookup`` produces, keyed - like the embedding
+        # matrix above - on the ``media_revision`` it was built at
+        # (``_lookup_index_revision``).  Many routes resolve label entries
+        # against the active dataset (label import/export, find-stats,
+        # add-to-pile, learned sort); rebuilding these O(N) tables (a
+        # ``json.dumps`` per origin) on every request is what S14 removes.
+        # Built + reused by ``vtscore.state.media_lookup.cached_media_lookups``;
+        # ``None`` until first access, invalidated automatically because the
+        # revision advances on every structural medias mutation.
+        "_origin_key_index",
+        "_md5_index",
+        "_name_index",
+        "_lookup_index_revision",
         # VTSBrowse: cached projection (frozen at ingest) + per-bin-shape
         # pyramids derived from it. The projection (UMAP coords) is shared
         # across bin shapes; ``_pyramids`` maps "hex"/"square" -> Pyramid so the
@@ -457,6 +471,11 @@ class DatasetContext:
         self._region_matrix_revision: int | None = None  # media_revision the region matrix was built at
         self._region_media_index: Any = None  # np.ndarray | None, int64 (R,)
         self._region_index_per_row: Any = None  # np.ndarray | None, int64 (R,)
+        # Cached secondary media lookups (S14); see the __slots__ comment.
+        self._origin_key_index: dict[str, list[int]] | None = None
+        self._md5_index: dict[str, list[int]] | None = None
+        self._name_index: dict[str, list[int]] | None = None
+        self._lookup_index_revision: int | None = None  # media_revision the lookups were built at
         self._projection: Any = None  # Projection | None
         self._pyramids: dict[str, Any] = {}  # bin_shape -> Pyramid
         self._full_job_id: str | None = None  # in-flight full-dataset build job id
@@ -886,6 +905,10 @@ class _RequestMissingDatasetContext(DatasetContext):
         object.__setattr__(self, "_region_matrix_revision", None)
         object.__setattr__(self, "_region_media_index", None)
         object.__setattr__(self, "_region_index_per_row", None)
+        object.__setattr__(self, "_origin_key_index", None)
+        object.__setattr__(self, "_md5_index", None)
+        object.__setattr__(self, "_name_index", None)
+        object.__setattr__(self, "_lookup_index_revision", None)
         object.__setattr__(self, "_text_embedder", None)
         object.__setattr__(self, "_patch_embedder", None)
         object.__setattr__(self, "_structural_embedder", None)

--- a/vtscore/state/media_lookup.py
+++ b/vtscore/state/media_lookup.py
@@ -8,9 +8,12 @@ active :class:`DatasetContext` when the caller does not pass one in.
 from __future__ import annotations
 
 import json
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from vtscore.state.core import _state_lock, get_active_context
+
+if TYPE_CHECKING:
+    from vtscore.state.core import DatasetContext
 
 
 def _origin_key(origin: dict[str, Any], origin_name: str) -> str:
@@ -75,6 +78,68 @@ def build_md5_lookup(
         if md5:
             md5_lookup.setdefault(md5, []).append(media["id"])
     return md5_lookup
+
+
+def cached_media_lookups(
+    ctx: DatasetContext | None = None,
+) -> tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]]:
+    """Return the ``(origin_lookup, md5_lookup, name_lookup)`` triple for *ctx*, cached.
+
+    Revision-keyed cache mirroring the embedding-matrix cache
+    (:func:`vtscore.embedding.matrix.get_embedding_matrix`): the triple is
+    rebuilt via :func:`build_media_lookup` only when ``ctx.media_revision``
+    changes, so the many routes that resolve label entries against the active
+    dataset (label import/export, find-stats, add-to-pile, learned sort) stop
+    paying an O(N) ``json.dumps``-per-origin rebuild on every request (S14).
+    Because ``media_revision`` advances on every structural medias mutation
+    (and every in-place vector rewrite that bumps it), the cache invalidates
+    itself; no call site has to remember to clear it.
+
+    *ctx* defaults to the active :class:`DatasetContext`.  The returned dicts
+    are the *live cached* objects - treat them as read-only; a caller that needs
+    to mutate a lookup must copy it first.
+    """
+    if ctx is None:
+        ctx = get_active_context()
+
+    # Phase 1 (locked): serve a cache hit.
+    with _state_lock:
+        revision = ctx.media_revision
+        if ctx._md5_index is not None and ctx._lookup_index_revision == revision:
+            return ctx._origin_key_index, ctx._md5_index, ctx._name_index  # type: ignore[return-value]
+        # Shallow ref-copy so the build below reads a stable view even if
+        # ctx.medias is reassigned concurrently (cheap: pointers, not dicts).
+        medias_snapshot = dict(ctx.medias)
+
+    # An empty context never caches: the request-missing sentinel holds a frozen
+    # medias dict that also refuses attribute writes, so returning fresh empties
+    # here keeps us from ever storing on it.  A genuinely-empty loaded dataset
+    # just rebuilds three empty dicts, which is free.
+    if not medias_snapshot:
+        return {}, {}, {}
+
+    # Phase 2 (unlocked): build the triple.
+    origin_lookup, md5_lookup, name_lookup = build_media_lookup(medias_snapshot)
+
+    # Phase 3 (locked): store, double-checking the revision still matches so a
+    # medias mutation during the unlocked build can't cache a stale triple.
+    with _state_lock:
+        if ctx.media_revision == revision:
+            ctx._origin_key_index = origin_lookup
+            ctx._md5_index = md5_lookup
+            ctx._name_index = name_lookup
+            ctx._lookup_index_revision = revision
+    return origin_lookup, md5_lookup, name_lookup
+
+
+def cached_md5_lookup(ctx: DatasetContext | None = None) -> dict[str, list[int]]:
+    """Return only the cached MD5 → media-ID lookup for *ctx*.
+
+    The ``md5_lookup`` element of :func:`cached_media_lookups`; see it for the
+    caching semantics.  Callers that only need content-hash resolution
+    (add-to-pile dedup, example-media seeding) use this.
+    """
+    return cached_media_lookups(ctx)[1]
 
 
 def resolve_media_ids(

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -932,12 +932,12 @@ def _resolved_positive_count(elements) -> int:
     this is one pass rather than one rebuild per element. Returns 0 when no
     dataset is loaded.
     """
-    from vtsearch.state import build_media_lookup, resolve_media_ids, snapshot_medias
+    from vtsearch.state import cached_media_lookups, resolve_media_ids, snapshot_medias
 
     snap = snapshot_medias()
     if not snap:
         return 0
-    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snap)
+    origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
     count = 0
     for el in elements:
         if resolve_media_ids(el.to_dict(), origin_lookup, md5_lookup, name_lookup):

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -77,11 +77,10 @@ from vtsearch.schemas.labels import (
 )
 from vtsearch.state import (
     apply_label,
-    build_media_lookup,
+    cached_media_lookups,
     medias,
     find_missing_entries,
     resolve_media_ids,
-    snapshot_medias,
 )
 
 label_importers_bp = Blueprint(
@@ -223,7 +222,7 @@ def run_label_import(importer_name: str):  # noqa: C901
         return jsonify({"error": "Importer did not return a list of label dicts."}), 500
 
     # Apply labels to global vote state
-    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
+    origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
     applied, skipped, failed = _apply_labels(label_entries, origin_lookup, md5_lookup, name_lookup)
 
     # Detect entries that could not be matched at all
@@ -247,14 +246,14 @@ def run_label_import(importer_name: str):  # noqa: C901
             # `len(missing)`, so we only need to bump `applied` here.  Any
             # per-entry mutation errors from the auto-resolve pass are
             # appended to the same `failed` list as the first pass.
-            origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
+            origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
             resolved_applied, _, resolved_failed = _apply_labels(missing, origin_lookup, md5_lookup, name_lookup)
             applied += resolved_applied
             failed.extend(resolved_failed)
 
         # Check which entries still couldn't be resolved
         if ingested < len(missing):
-            origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
+            origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
             unresolved = find_missing_entries(missing, origin_lookup, md5_lookup, name_lookup)
 
     # Sync updated votes into the loaded model so the dashboard reflects
@@ -314,7 +313,7 @@ def ingest_missing(body: dict):
     ingested = ingest_missing_medias(entries, medias)
 
     # Now apply labels to the newly ingested medias
-    origin_lookup, md5_lookup, name_lookup = build_media_lookup(snapshot_medias())
+    origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
     applied, _, failed = _apply_labels(entries, origin_lookup, md5_lookup, name_lookup)
 
     # Sync updated votes into the loaded model so the dashboard reflects

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -23,9 +23,9 @@ from vtsearch.routes._shared import require_dataset_header, require_detector_hea
 from vtsearch.state import (
     apply_label,
     apply_label_with_click_time,
-    build_media_lookup,
+    cached_md5_lookup,
+    cached_media_lookups,
     resolve_media_ids,
-    snapshot_medias,
 )
 from vtscore.utils.hits import build_media_hit
 
@@ -163,16 +163,19 @@ def _make_enricher(all_medias: dict):
     The returned callable mutates one label entry in place (attaching
     ``custom_metadata`` when the media has any) and returns the set of
     metadata keys it added, so a streaming caller can annotate elements one
-    at a time.  The ``md5 -> media`` map is built once here.
+    at a time.  Resolution reuses the active dataset's cached MD5 → media-ID
+    lookup (S14) instead of building a fresh ``md5 -> media`` map on every
+    export; media are then resolved by id against the caller's snapshot.
 
     Flattens origin params so fields like ``contentID`` / ``mediaID`` /
     ``media_url`` surface as selectable export columns alongside the
     importer's own ``custom_metadata``.
     """
-    md5_to_media = {m["md5"]: m for m in all_medias.values() if m.get("md5")}
+    md5_lookup = cached_md5_lookup()
 
     def enrich(entry: dict) -> set[str]:
-        media = md5_to_media.get(entry.get("md5"))
+        cids = md5_lookup.get(entry.get("md5") or "")
+        media = all_medias.get(cids[0]) if cids else None
         if not media:
             return set()
         meta = _build_entry_metadata(media)
@@ -290,7 +293,7 @@ def import_labels(body: dict):
     """Import labels from JSON, matching medias by origin+origin_name (MD5 fallback)."""
     labels = body["labels"]
 
-    origin_lookup, md5_lookup, _ = build_media_lookup(snapshot_medias())
+    origin_lookup, md5_lookup, _ = cached_media_lookups()
 
     applied = 0
     skipped = 0

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -47,7 +47,7 @@ from vtsearch.routes._shared import (
 from vtsearch.state import (
     _state_lock,
     apply_label,
-    build_md5_lookup,
+    cached_md5_lookup,
     get_media,
     medias,
     next_media_id,
@@ -1059,7 +1059,7 @@ def _insert_or_collide(new_media: dict[str, Any], file_md5: str) -> tuple[list[i
     is returned with ``is_new=True``.
     """
     with _state_lock:
-        md5_lookup_now = build_md5_lookup(medias)
+        md5_lookup_now = cached_md5_lookup()
         collided_cids = md5_lookup_now.get(file_md5, [])
         if collided_cids:
             return list(collided_cids), collided_cids[0], False
@@ -1103,7 +1103,7 @@ def add_media_to_pile():
     # before insertion (see below) because embedding holds no lock and a
     # concurrent upload of the same bytes could land between the two.
     snap = snapshot_medias()
-    md5_lookup = build_md5_lookup(snap)
+    md5_lookup = cached_md5_lookup()
     existing_cids = md5_lookup.get(file_md5, [])
 
     if existing_cids:

--- a/vtsearch/state/__init__.py
+++ b/vtsearch/state/__init__.py
@@ -30,6 +30,8 @@ from vtscore.state import (  # noqa: F401
     build_coverage_atlas_for_context,
     build_md5_lookup,
     build_media_lookup,
+    cached_md5_lookup,
+    cached_media_lookups,
     clear_all,
     clear_all_contexts,
     clear_all_detector_contexts,


### PR DESCRIPTION
## Summary

Implements **S14** from `docs/plans/scalability.md`: removes the per-request O(N) rebuilds of the media-lookup dicts.

Routes that resolve label entries against the active dataset (label import/export, find-stats, add-to-pile, learned sort) rebuilt the `(origin, md5, name)` lookup triple from scratch on every request — an O(N) `json.dumps`-per-origin pass, 2–3 times per request (~100 ms at 1 M items). This caches the triple on `DatasetContext`, keyed on `media_revision`, **mirroring the existing embedding-matrix cache**: it rebuilds only when the medias structurally change (add / remove / reload), and is served in O(1) otherwise. Because `media_revision` already advances on every structural mutation, the cache invalidates itself — no call site has to remember to clear it.

## What changed

- **`vtscore/state/media_lookup.py`** — new `cached_media_lookups()` / `cached_md5_lookup()`. Three-phase-locked exactly like `get_embedding_matrix`: serve a cache hit under `_state_lock`, build the triple unlocked, store it back with a revision recheck so a concurrent mutation during the build can't cache a stale triple. An empty context (including the frozen request-missing sentinel, whose `medias` is frozen and which refuses attribute writes) returns fresh empties and never caches, so no store is ever attempted on the sentinel.
- **`vtscore/state/core.py`** — new `_origin_key_index` / `_md5_index` / `_name_index` / `_lookup_index_revision` slots on `DatasetContext` (and on the request-missing sentinel).
- **Call-site conversions** — the per-request rebuild sites now read the cache: vote import + export enricher, label importers, detector stats, add-to-pile, and the learned-sort / labelset-elements / workflow / label-restoration / media-seeding library helpers.
- **Left as direct builds (correctly out of scope)** — `find.py`'s cross-pkl checks build lookups over an ephemeral `temp_medias` dict (not the active context), and `labelset_training._lookups_for_snap` builds once per *train* call (not per request) over an arbitrary snap.

The export enricher's `{md5: media}` map became `cached_md5_lookup()` + id resolution against the caller's snapshot; where a shared md5 previously resolved to the last matching media it now resolves to the first (duplicates are collapsed on load, so this is behaviourally inert).

## Testing

- New `tests_lib/core/test_media_lookup_cache.py` (patterned on `test_embedding_matrix.py`): cached-triple contents match a fresh `build_media_lookup`; the cache is reused at the same revision (object identity) and rebuilt on add / remove / wholesale reload; empty contexts and the frozen request-missing sentinel return empties without raising or caching; the no-arg accessor resolves the active context.
- Full suite green: `./run-tests.sh` → 6481 passed, 1 skipped.

Refs #_ (S14 in `docs/plans/scalability.md`; pruned from the plan in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4yxnscFC5Mj7zJ6KApR7T

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4yxnscFC5Mj7zJ6KApR7T)_