### PR TITLE
S1: mmap embedding-matrix sidecar for 1M+ datasets

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,7 +100,8 @@ VTSearch/
 │   │
 │   ├── embedding/                  Embedder façades and torch runtime
 │   │   ├── helpers.py              embed_audio_file / embed_image_file / embed_text_query / …
-│   │   ├── matrix.py               Cached contiguous (N, D) embedding matrix on DatasetContext
+│   │   ├── matrix.py               Cached contiguous (N, D) embedding matrix on DatasetContext;
+│   │   │                           mmap-backed via a `<pkl_stem>.embids/embmat.npy` sidecar
 │   │   └── loader.py               initialize_models, smart_preload_in_background
 │   │
 │   ├── detectors/                  Detector lifecycle; resolve→embed→train pipeline

--- a/docs/plans/scalability.md
+++ b/docs/plans/scalability.md
@@ -9,10 +9,10 @@ fix direction + implementation sketch for each item still owed.
 
 **Scope:** What breaks as datasets grow to 100 k / 1 M / 10 M items and as
 LabelSets grow to 1 k / 10 k / 100 k labels, GUI and CLI. Items track **future
-work only**: shipped items (S2/S8 coverage-atlas auto-defer, S9 GMM subsample,
-S14 cached secondary lookups, S16 grid virtual scroll, S18 prefetch cap, S21 CLI
-progress throttle) have been pruned per the plan-file policy — git history is
-their record. `S#` numbering
+work only**: shipped items (S1 mmap embedding-matrix sidecar, S2/S8
+coverage-atlas auto-defer, S9 GMM subsample, S14 cached secondary lookups, S16
+grid virtual scroll, S18 prefetch cap, S21 CLI progress throttle) have been
+pruned per the plan-file policy — git history is their record. `S#` numbering
 has gaps where those were removed; that is expected (labels are stable, never
 renumbered).
 
@@ -30,8 +30,6 @@ deferred. Items are independently shippable.
 
 ## Suggested work order (open items, max-leverage first)
 
-3. **S1** (mmap embedding matrix); unblocks 1 M+ datasets without OOM. Also
-   decouples embeddings from the pickle, which unblocks S15.
 4. **S3 + S17 + S19** (sparse sort results, lazy ordered items); must be done
    together; unblocks 1 M+ in the frontend.
 5. **S12** (debounce the detector-JSON label-sync write); makes voting with large
@@ -59,63 +57,6 @@ deferred. Items are independently shippable.
 ---
 
 ## RAM
-
-### S1: mmap embedding matrix — one giant contiguous array per loaded dataset
-
-**Files:** `vtscore/embedding/matrix.py`, `vtscore/datasets/loader_pickle.py`
-
-All embeddings for the loaded dataset are materialised into a single `(N, D)`
-`float32` array (`matrix.py:_stack_embeddings`, `np.empty((N, D))`), held on
-`DatasetContext`, and rebuilt from per-item entries on every cold start.
-
-| N | D=384 | D=768 (E5) |
-|---|-------|-----------|
-| 100 k | 150 MB | 300 MB |
-| 1 M | 1.5 GB | 3 GB |
-| 10 M | 15 GB | 30 GB |
-
-One loaded dataset already risks OOM; multi-dataset mode doubles it. The array is
-unavoidable for vectorised scoring, but it does not need to live in RAM for the
-dataset's full lifetime — at 1 M+ it should be **memory-mapped**.
-
-**Fix (two-step):**
-
-- **Step A — sidecar `.npy`.** After all embeddings are present, write the
-  sorted-by-cid matrix to `<dataset>.emb.npy` (+ companion `<dataset>.cids.npy`,
-  int64 sorted cids) if it doesn't already exist.
-- **Step B — mmap load.** On pickle load, if both sidecars exist and the cid list
-  matches the pickle's media IDs:
-
-  ```python
-  cids = np.load(cids_path)                  # int64 array
-  matrix = np.load(emb_path, mmap_mode='r')  # zero-RAM mmap
-  ctx._emb_matrix = matrix
-  ctx._emb_matrix_ids = list(cids)
-  ctx._emb_matrix_revision = ctx.media_revision
-  ```
-
-  The OS pages in only the rows scoring accesses (a 100-item sort on a 1 M dataset
-  touches ~40 kB of a 1.5 GB file). `get_embedding_matrix` must detect the
-  cached-this-way matrix and skip the rebuild.
-
-**Sidecar invalidation:** if the pickle is newer than the sidecar, or the cid list
-doesn't match, fall back to the in-memory build (optionally rewrite sidecars).
-
-**Risk:** high — introduces filesystem state alongside pickle files. Care for:
-race between sidecar write and concurrent load; embedder-dim drift (dim change →
-sidecar invalid); Docker / read-only filesystems (fall back to in-memory). A
-`--no-emb-sidecar` flag (or settings key) disables writing where the path is
-read-only.
-
-**Sidecar cleanup on delete/expiry is already covered.** `unregister_dataset`
-(`vtscore/datasets/registry.py`) deletes every file sharing the pkl's stem, not
-just the pkl itself — a `<dataset>.emb.npy` / `<dataset>.cids.npy` sidecar named
-`ds_<uuid>.emb.npy` next to `ds_<uuid>.pkl` is swept automatically on both the
-age-off and manual-delete paths (both route through `unregister_dataset`). No
-extra registry field or bookkeeping is needed as long as the sidecar filename
-keeps the pkl's stem as a prefix.
-
----
 
 ### S3 / S17 / S19: sparse sort results — top-K API + lazy frontend
 
@@ -262,10 +203,10 @@ Dict overhead is ~250 B/entry; at 1 M items the `medias` dict alone consumes
 several hundred MB before the embedding arrays.
 
 **Fix (medium-term, long horizon):** Extract embeddings from the per-item dict
-into the embedding matrix on load (S1), replacing `media["embedding"]` with a
-row-index pointer — ~60–70% smaller per-item dict at 384-dim. The full columnar
-rewrite (per-field NumPy arrays or a Polars frame) is deferred: it touches every
-media-reading call site.
+into the embedding matrix on load (mirroring the shipped mmap embedding-matrix
+sidecar), replacing `media["embedding"]` with a row-index pointer — ~60–70%
+smaller per-item dict at 384-dim. The full columnar rewrite (per-field NumPy
+arrays or a Polars frame) is deferred: it touches every media-reading call site.
 
 ---
 
@@ -381,9 +322,13 @@ deserialises the whole pickle once (its own docstring notes this is
 **Two coupled problems:**
 
 - **Streaming load.** Pickles > some threshold (e.g. 500 MB / 100 k items) should
-  load in chunks. The embedding-matrix sidecar (S1) decouples embeddings from the
-  pickle, so the pickle becomes mostly metadata (filenames, origins, md5s) and
-  loads quickly; embeddings come from the mmap'd sidecar.
+  load in chunks. Note the shipped mmap embedding-matrix sidecar does *not* by
+  itself shrink this: `medias.pkl` still carries every item's embeddings inline
+  (the sidecar is an additional, redundant mmap-able copy used only to skip
+  rebuilding the `(N, D)` matrix cache). Making the pickle itself "mostly
+  metadata" needs S4's per-item-dict rewrite first (strip `embeddings` from each
+  entry in favor of a row-index pointer) — only then does a pickle load stop
+  paying to deserialize the embedding bytes at all.
 - **Cancel responsiveness during read (found while investigating the grid
   freeze).** On a large `.pkl` two things read as "frozen, Cancel does nothing":
   (1) `read_container` is one un-cancellable, no-progress step, and the
@@ -447,7 +392,7 @@ embedder. Shares the S11 approach.
 | Root cause | Open items it affects |
 |-----------|-----------------------|
 | **O(N log N) sorted-key comparisons** used as change detection | S6, S7 |
-| **Full in-memory arrays / dicts** for every N items | S1, S3, S4, S17, S19 |
+| **Full in-memory arrays / dicts** for every N items | S3, S4, S17, S19 |
 | **No streaming** for large JSON / pickle payloads | S3, S13, S15 |
 | **Serial I/O** where parallelism is easy | S11, S20 |
 | **No debouncing** on high-frequency write paths | S12 |
@@ -456,8 +401,6 @@ embedder. Shares the S11 approach.
 
 ## Test coverage checklist (open items)
 
-- **S1:** load, unload, reload a dataset; matrix re-used from sidecar on second
-  load without rebuilding from per-item entries.
 - **S3/S17/S19:** sort response with 200 k items contains ≤700 results;
   `/api/sort/page?offset=700&limit=200` returns the next window.
 - **S6:** matrix rebuilt exactly when medias change, reused when they don't; O(1)

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -430,6 +430,11 @@ class TestEmbeddingMatrixSidecar:
             for cid in range(1, n + 1)
         }
 
+    def _pkl_path(self, dataset_id: str) -> str:
+        entry = registry.get_dataset(dataset_id)
+        assert entry is not None
+        return entry["pkl_path"]
+
     def test_sidecar_written_after_first_build(self, tmp_path):
         dataset_id = self._register(tmp_path)
         ctx = DatasetContext(dataset_id)
@@ -437,8 +442,7 @@ class TestEmbeddingMatrixSidecar:
 
         get_embedding_matrix(ctx)
 
-        entry = registry.get_dataset(dataset_id)
-        ids_path, mat_path = matrix_mod._emb_sidecar_paths(entry["pkl_path"])
+        ids_path, mat_path = matrix_mod._emb_sidecar_paths(self._pkl_path(dataset_id))
         assert ids_path.is_file()
         assert mat_path.is_file()
         assert np.array_equal(np.load(ids_path), np.array([1, 2, 3], dtype=np.int64))
@@ -472,8 +476,7 @@ class TestEmbeddingMatrixSidecar:
     def test_id_mismatch_sidecar_falls_back_to_live_rebuild(self, tmp_path):
         """A sidecar written for a different id set must never be trusted."""
         dataset_id = self._register(tmp_path)
-        entry = registry.get_dataset(dataset_id)
-        ids_path, mat_path = matrix_mod._emb_sidecar_paths(entry["pkl_path"])
+        ids_path, mat_path = matrix_mod._emb_sidecar_paths(self._pkl_path(dataset_id))
         matrix_mod._atomic_save_npy(ids_path, np.array([1, 2, 99], dtype=np.int64))
         matrix_mod._atomic_save_npy(mat_path, np.zeros((3, 4), dtype=np.float32))
 
@@ -487,8 +490,7 @@ class TestEmbeddingMatrixSidecar:
     def test_dim_mismatch_sidecar_falls_back_to_live_rebuild(self, tmp_path):
         """A same-id-count sidecar with the wrong dimension must never be trusted."""
         dataset_id = self._register(tmp_path)
-        entry = registry.get_dataset(dataset_id)
-        ids_path, mat_path = matrix_mod._emb_sidecar_paths(entry["pkl_path"])
+        ids_path, mat_path = matrix_mod._emb_sidecar_paths(self._pkl_path(dataset_id))
         matrix_mod._atomic_save_npy(ids_path, np.array([1, 2, 3], dtype=np.int64))
         matrix_mod._atomic_save_npy(mat_path, np.zeros((3, 99), dtype=np.float32))
 
@@ -527,6 +529,5 @@ class TestEmbeddingMatrixSidecar:
         # The on-disk sidecar itself must also be refreshed (not just this
         # context's in-memory view), or a third, later-loading context would
         # still mmap the stale pre-rewrite values.
-        entry = registry.get_dataset(dataset_id)
-        _, mat_path = matrix_mod._emb_sidecar_paths(entry["pkl_path"])
+        _, mat_path = matrix_mod._emb_sidecar_paths(self._pkl_path(dataset_id))
         assert np.load(mat_path)[0, 0] == 42.0

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -13,6 +13,7 @@ import threading
 import numpy as np
 import pytest
 
+from vtscore.datasets import registry
 from vtscore.embedding import matrix as matrix_mod
 from vtscore.embedding.matrix import (
     get_embedding_matrix,
@@ -401,3 +402,131 @@ class TestMediaRevisionCounter:
         ids, mat_after = get_embedding_matrix(ctx)
         assert ids == [1, 2, 3]
         assert mat_after[0, 0] == 101.0
+
+
+class TestEmbeddingMatrixSidecar:
+    """S1 (docs/plans/scalability.md): the mmap embedding-matrix sidecar.
+
+    A dataset backed by a registry entry gets its primary matrix persisted
+    as a ``<pkl_stem>.embids.npy`` / ``<pkl_stem>.embmat.npy`` pair after the
+    first build, so a fresh ``DatasetContext`` for the same dataset can mmap
+    it instead of rebuilding from per-item embeddings.
+    """
+
+    def _register(self, tmp_path, num_items: int = 3) -> str:
+        pkl_dir = tmp_path / "saved"
+        pkl_dir.mkdir(parents=True, exist_ok=True)
+        entry = registry.register_dataset(
+            name="sidecar-test",
+            media_type="audio",
+            num_items=num_items,
+            pkl_path=str(pkl_dir / "ds_sidecar.pkl"),
+        )
+        return entry["id"]
+
+    def _medias(self, n: int = 3) -> dict:
+        return {
+            cid: {"id": cid, "embedder": "e5", "embeddings": {"e5": np.full(4, float(cid), dtype=np.float32)}}
+            for cid in range(1, n + 1)
+        }
+
+    def test_sidecar_written_after_first_build(self, tmp_path):
+        dataset_id = self._register(tmp_path)
+        ctx = DatasetContext(dataset_id)
+        ctx.medias = self._medias()
+
+        get_embedding_matrix(ctx)
+
+        entry = registry.get_dataset(dataset_id)
+        ids_path, mat_path = matrix_mod._emb_sidecar_paths(entry["pkl_path"])
+        assert ids_path.is_file()
+        assert mat_path.is_file()
+        assert np.array_equal(np.load(ids_path), np.array([1, 2, 3], dtype=np.int64))
+
+    def test_fresh_context_mmaps_the_sidecar(self, tmp_path):
+        dataset_id = self._register(tmp_path)
+        ctx1 = DatasetContext(dataset_id)
+        ctx1.medias = self._medias()
+        get_embedding_matrix(ctx1)  # writes the sidecar
+
+        # A second context for the same registered dataset stands in for a
+        # fresh process re-loading the same pkl from disk.
+        ctx2 = DatasetContext(dataset_id)
+        ctx2.medias = self._medias()
+        ids, mat = get_embedding_matrix(ctx2)
+
+        assert ids == [1, 2, 3]
+        assert mat[0, 0] == 1.0
+        assert mat[2, 0] == 3.0
+        assert isinstance(ctx2._emb_matrix, np.memmap), "expected the mmap sidecar path, not a fresh rebuild"
+
+    def test_unregistered_dataset_never_writes_a_sidecar(self, tmp_path):
+        """No registry entry -> no pkl_path -> the mmap cache stays opt-in only."""
+        ctx = DatasetContext("not_registered")
+        ctx.medias = self._medias()
+
+        get_embedding_matrix(ctx)
+
+        assert not any(tmp_path.iterdir())
+
+    def test_id_mismatch_sidecar_falls_back_to_live_rebuild(self, tmp_path):
+        """A sidecar written for a different id set must never be trusted."""
+        dataset_id = self._register(tmp_path)
+        entry = registry.get_dataset(dataset_id)
+        ids_path, mat_path = matrix_mod._emb_sidecar_paths(entry["pkl_path"])
+        matrix_mod._atomic_save_npy(ids_path, np.array([1, 2, 99], dtype=np.int64))
+        matrix_mod._atomic_save_npy(mat_path, np.zeros((3, 4), dtype=np.float32))
+
+        ctx = DatasetContext(dataset_id)
+        ctx.medias = self._medias()
+        ids, mat = get_embedding_matrix(ctx)
+
+        assert ids == [1, 2, 3]
+        assert mat[0, 0] == 1.0  # live value, not the bogus zero-filled sidecar
+
+    def test_dim_mismatch_sidecar_falls_back_to_live_rebuild(self, tmp_path):
+        """A same-id-count sidecar with the wrong dimension must never be trusted."""
+        dataset_id = self._register(tmp_path)
+        entry = registry.get_dataset(dataset_id)
+        ids_path, mat_path = matrix_mod._emb_sidecar_paths(entry["pkl_path"])
+        matrix_mod._atomic_save_npy(ids_path, np.array([1, 2, 3], dtype=np.int64))
+        matrix_mod._atomic_save_npy(mat_path, np.zeros((3, 99), dtype=np.float32))
+
+        ctx = DatasetContext(dataset_id)
+        ctx.medias = self._medias()
+        ids, mat = get_embedding_matrix(ctx)
+
+        assert ids == [1, 2, 3]
+        assert mat.shape == (3, 4)
+        assert mat[0, 0] == 1.0
+
+    def test_invalidate_disables_sidecar_for_rest_of_context_lifetime(self, tmp_path):
+        """Root-cause Pattern #4 for the sidecar: a same-id in-place vector
+        rewrite must never be served stale from the on-disk mmap cache."""
+        dataset_id = self._register(tmp_path)
+        ctx1 = DatasetContext(dataset_id)
+        ctx1.medias = self._medias()
+        get_embedding_matrix(ctx1)  # writes the sidecar with row 0 == 1.0
+
+        ctx2 = DatasetContext(dataset_id)
+        ctx2.medias = self._medias()
+        ids, mat = get_embedding_matrix(ctx2)
+        assert mat[0, 0] == 1.0
+        assert isinstance(ctx2._emb_matrix, np.memmap)
+
+        # An in-place rewrite (re-embed/clip) with the same id set - the
+        # sidecar's id-list check alone cannot see this.
+        ctx2.medias[1]["embeddings"]["e5"] = np.full(4, 42.0, dtype=np.float32)
+        invalidate_embedding_matrix(ctx2)
+        assert ctx2._emb_sidecar_disabled is True
+
+        ids, mat = get_embedding_matrix(ctx2)
+        assert mat[0, 0] == 42.0, "must reflect the in-place rewrite, not the stale mmap'd sidecar"
+        assert not isinstance(ctx2._emb_matrix, np.memmap)
+
+        # The on-disk sidecar itself must also be refreshed (not just this
+        # context's in-memory view), or a third, later-loading context would
+        # still mmap the stale pre-rewrite values.
+        entry = registry.get_dataset(dataset_id)
+        _, mat_path = matrix_mod._emb_sidecar_paths(entry["pkl_path"])
+        assert np.load(mat_path)[0, 0] == 42.0

--- a/tests_lib/projection/test_umap_projection.py
+++ b/tests_lib/projection/test_umap_projection.py
@@ -70,6 +70,17 @@ def test_ids_length_mismatch_raises():
         fit_projection(_matrix(5, 8), [1, 2, 3])
 
 
+def test_accepts_read_only_matrix():
+    """S1's embedding-matrix sidecar (docs/plans/scalability.md) hands
+    ``fit_projection`` a read-only mmap array; it must be copied internally
+    rather than crashing or silently trying to write through it."""
+    matrix = _matrix(6, 8, seed=3)
+    matrix.setflags(write=False)
+    proj = fit_projection(matrix, [10, 11, 12, 13, 14, 15], min_n_for_umap=10)
+    assert proj.method == "pca"
+    assert np.isfinite(proj.coords).all()
+
+
 def test_umap_fit_shape_and_metadata():
     # A real (seeded, reproducible) UMAP fit on a small synthetic set.
     n, d = 60, 12

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -30,6 +30,10 @@ turns that into a loud, locatable failure naming the offending cid.
 
 from __future__ import annotations
 
+import logging
+import os
+import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -39,6 +43,8 @@ from vtscore.state.core import _state_lock
 
 if TYPE_CHECKING:
     from vtscore.state.core import DatasetContext
+
+logger = logging.getLogger(__name__)
 
 
 def _collapse_to_primary(medias: dict[int, dict[str, Any]], embedder_name: str | None) -> str | None:
@@ -95,6 +101,116 @@ def _stack_embeddings(
     return matrix
 
 
+def _registered_pkl_path(dataset_id: str) -> str | None:
+    """Return the on-disk pkl path registered for *dataset_id*, or ``None``.
+
+    Datasets built purely in memory (tests, ephemeral browse contexts,
+    positives-map previews) have no registry entry and get no sidecar - the
+    mmap cache (S1, ``docs/plans/scalability.md``) is opportunistic only for
+    datasets actually backed by a saved pickle file.
+    """
+    from vtscore.datasets.registry import get_dataset  # noqa: PLC0415
+
+    try:
+        entry = get_dataset(dataset_id)
+    except Exception:
+        return None
+    return (entry or {}).get("pkl_path") or None
+
+
+def _emb_sidecar_paths(pkl_path: str) -> tuple[Path, Path]:
+    """Return ``(ids_path, matrix_path)`` sidecar paths for *pkl_path*.
+
+    Both share the pkl's stem (``ds_<uuid>``) followed by a dot, so
+    ``registry.unregister_dataset``'s stem-glob sweep deletes them alongside
+    the pkl on both age-off expiry and manual delete - no separate cleanup
+    bookkeeping needed.
+    """
+    p = Path(pkl_path)
+    return p.parent / f"{p.stem}.embids.npy", p.parent / f"{p.stem}.embmat.npy"
+
+
+def _try_load_matrix_sidecar(pkl_path: str, sorted_ids: list[int], probe_dim: int) -> np.ndarray | None:
+    """Return the mmap'd primary embedding matrix for *pkl_path* if valid, else ``None``.
+
+    Valid means: both sidecar files exist, the persisted id list matches
+    *sorted_ids* exactly (order and content), and the persisted matrix's
+    column count matches *probe_dim* (a live vector's dimension, guarding
+    against a same-id-set re-embed to a different dimension - the drift the
+    id-list check alone can't see). Any mismatch, missing file, or read error
+    returns ``None``; the caller always has a safe, correct fallback: rebuild
+    from live ``ctx.medias``.
+    """
+    ids_path, mat_path = _emb_sidecar_paths(pkl_path)
+    if not (ids_path.is_file() and mat_path.is_file()):
+        return None
+    try:
+        sidecar_ids = np.load(ids_path)
+        if sidecar_ids.shape != (len(sorted_ids),) or not np.array_equal(
+            sidecar_ids, np.asarray(sorted_ids, dtype=np.int64)
+        ):
+            return None
+        matrix = np.load(mat_path, mmap_mode="r")
+        if matrix.ndim != 2 or matrix.shape[0] != len(sorted_ids) or matrix.shape[1] != probe_dim:
+            return None
+        return matrix
+    except Exception:
+        logger.warning("Failed to load embedding-matrix sidecar for %s", pkl_path, exc_info=True)
+        return None
+
+
+def _atomic_save_npy(path: Path, arr: np.ndarray) -> None:
+    """Write *arr* to *path* as ``.npy`` bytes via write-to-temp + atomic rename.
+
+    Mirrors the tmp-file idiom used by ``vtscore.datasets.container.write_container``:
+    a crash mid-write leaves an orphan ``.tmp`` file, never a truncated file at
+    the real name, so a concurrent reader never observes a partial array.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            np.save(f, arr)
+        os.replace(tmp_name, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _maybe_persist_matrix_sidecar(pkl_path: str, sorted_ids: list[int], matrix: np.ndarray) -> None:
+    """Best-effort write of the primary embedding matrix as a mmap-able sidecar.
+
+    Lets a future cold load of the same pkl (a fresh process / DatasetContext)
+    skip rebuilding the matrix from per-item embeddings - see S1,
+    ``docs/plans/scalability.md``. A pure derived cache of data already
+    durably persisted in the dataset pickle: always regenerable from
+    ``ctx.medias``, deterministic, and swept alongside the pkl by
+    ``registry.unregister_dataset``. Any failure (read-only filesystem, full
+    disk, concurrent writer) is logged and swallowed - the sidecar is an
+    optimization, never a dependency.
+
+    Always writes (no "ids already match, skip" shortcut): the caller only
+    reaches here on a genuine cache-miss rebuild, which happens either on the
+    first-ever build for this context or after an explicit invalidation - and
+    an in-place vector rewrite (re-embed/clip) leaves the id set unchanged
+    while the *content* legitimately changed, so an ids-only check would skip
+    a write that must happen and silently entrench a stale sidecar.
+    """
+    ids_path, mat_path = _emb_sidecar_paths(pkl_path)
+    try:
+        # Matrix first: if a crash lands between the two atomic renames, a
+        # mismatched pair is caught by the shape/dim checks in
+        # ``_try_load_matrix_sidecar`` on the next read, never served as-is.
+        _atomic_save_npy(mat_path, matrix)
+        _atomic_save_npy(ids_path, np.asarray(sorted_ids, dtype=np.int64))
+    except OSError:
+        logger.info("Could not persist embedding-matrix sidecar for %s (read-only filesystem?)", pkl_path)
+    except Exception:
+        logger.warning("Failed to persist embedding-matrix sidecar for %s", pkl_path, exc_info=True)
+
+
 def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None) -> tuple[list[int], np.ndarray]:
     """Return ``(sorted_ids, (N, D) float32 matrix)`` for *ctx*'s medias.
 
@@ -141,18 +257,44 @@ def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None
         # ctx.medias is reassigned concurrently (cheap: pointers, not vectors).
         medias_snapshot = dict(ctx.medias)
 
-    # Phase 2 (unlocked): the heavy contiguous (N, D) build.
-    matrix = _stack_embeddings(sorted_ids, medias_snapshot, embedder_name)
+    # Phase 2 (unlocked): try a matching on-disk mmap sidecar first (S1,
+    # docs/plans/scalability.md), else the heavy contiguous (N, D) build.
+    # ``pkl_path`` is resolved unconditionally (used again in phase 4 to
+    # persist a fresh build); the sidecar_disabled latch only gates *reading*
+    # one back - see ``invalidate_embedding_matrix``.
+    pkl_path: str | None = None
+    matrix: np.ndarray | None = None
+    used_sidecar = False
+    if embedder_name is None:
+        pkl_path = _registered_pkl_path(ctx.dataset_id)
+        if pkl_path and not ctx._emb_sidecar_disabled:
+            probe_dim = int(np.asarray(_require_embedding(sorted_ids[0], medias_snapshot[sorted_ids[0]])).shape[-1])
+            matrix = _try_load_matrix_sidecar(pkl_path, sorted_ids, probe_dim)
+            used_sidecar = matrix is not None
+    if matrix is None:
+        matrix = _stack_embeddings(sorted_ids, medias_snapshot, embedder_name)
 
     # Phase 3 (locked): repopulate the primary cache, double-checking the
     # revision still matches so a media mutation during the unlocked build
     # cannot cache a stale matrix. The named path never touches the cache.
+    cache_populated = False
     if embedder_name is None:
         with _state_lock:
             if ctx.media_revision == revision:
                 ctx._emb_matrix_ids = sorted_ids
                 ctx._emb_matrix = matrix
                 ctx._emb_matrix_revision = revision
+                cache_populated = True
+
+    # Phase 4 (unlocked, best-effort): persist a freshly-built primary matrix
+    # as a sidecar so a future cold load of this pkl can mmap it instead of
+    # rebuilding. Skipped when we just read a valid sidecar (already on disk,
+    # nothing to refresh) or when phase 3 lost the race (that matrix no
+    # longer matches the live id set and must not be written as this pkl's
+    # cache).
+    if cache_populated and not used_sidecar and pkl_path:
+        _maybe_persist_matrix_sidecar(pkl_path, sorted_ids, matrix)
+
     return list(sorted_ids), matrix
 
 
@@ -200,6 +342,11 @@ def invalidate_embedding_matrix(ctx: "DatasetContext") -> None:
         ctx._emb_matrix_ids = None
         ctx._emb_matrix = None
         ctx._emb_matrix_revision = None
+        # An in-place rewrite can leave the id set (and dimension) unchanged,
+        # which the sidecar's validity check alone cannot detect - permanently
+        # stop trusting the on-disk mmap sidecar for this context so every
+        # later rebuild reads live ``ctx.medias``, never a stale cached file.
+        ctx._emb_sidecar_disabled = True
         ctx._region_matrix_ids = None
         ctx._region_matrix = None
         ctx._region_matrix_revision = None

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -211,6 +211,24 @@ def _maybe_persist_matrix_sidecar(pkl_path: str, sorted_ids: list[int], matrix: 
         logger.warning("Failed to persist embedding-matrix sidecar for %s", pkl_path, exc_info=True)
 
 
+def _try_primary_sidecar(
+    ctx: "DatasetContext", sorted_ids: list[int], medias_snapshot: dict[int, dict[str, Any]]
+) -> tuple[str | None, np.ndarray | None]:
+    """Return ``(pkl_path, matrix)`` for the primary-path on-disk mmap sidecar.
+
+    *matrix* is ``None`` when there is no registered pkl, the sidecar-disabled
+    latch is set (see ``invalidate_embedding_matrix``), or the sidecar is
+    missing/stale - the caller always falls back to ``_stack_embeddings`` in
+    that case. *pkl_path* is returned even on a sidecar miss (``None`` matrix)
+    since the caller still needs it to persist a freshly-built matrix.
+    """
+    pkl_path = _registered_pkl_path(ctx.dataset_id)
+    if not pkl_path or ctx._emb_sidecar_disabled:
+        return pkl_path, None
+    probe_dim = int(np.asarray(_require_embedding(sorted_ids[0], medias_snapshot[sorted_ids[0]])).shape[-1])
+    return pkl_path, _try_load_matrix_sidecar(pkl_path, sorted_ids, probe_dim)
+
+
 def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None) -> tuple[list[int], np.ndarray]:
     """Return ``(sorted_ids, (N, D) float32 matrix)`` for *ctx*'s medias.
 
@@ -259,18 +277,13 @@ def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None
 
     # Phase 2 (unlocked): try a matching on-disk mmap sidecar first (S1,
     # docs/plans/scalability.md), else the heavy contiguous (N, D) build.
-    # ``pkl_path`` is resolved unconditionally (used again in phase 4 to
-    # persist a fresh build); the sidecar_disabled latch only gates *reading*
-    # one back - see ``invalidate_embedding_matrix``.
+    # ``pkl_path`` is resolved even on a sidecar miss (used again in phase 4
+    # to persist a fresh build).
     pkl_path: str | None = None
     matrix: np.ndarray | None = None
-    used_sidecar = False
     if embedder_name is None:
-        pkl_path = _registered_pkl_path(ctx.dataset_id)
-        if pkl_path and not ctx._emb_sidecar_disabled:
-            probe_dim = int(np.asarray(_require_embedding(sorted_ids[0], medias_snapshot[sorted_ids[0]])).shape[-1])
-            matrix = _try_load_matrix_sidecar(pkl_path, sorted_ids, probe_dim)
-            used_sidecar = matrix is not None
+        pkl_path, matrix = _try_primary_sidecar(ctx, sorted_ids, medias_snapshot)
+    used_sidecar = matrix is not None
     if matrix is None:
         matrix = _stack_embeddings(sorted_ids, medias_snapshot, embedder_name)
 

--- a/vtscore/projection/signpost_build.py
+++ b/vtscore/projection/signpost_build.py
@@ -337,6 +337,10 @@ def _clusterable_vectors(matrix: np.ndarray, on_progress: ProgressFn | None = No
 
     if on_progress is not None:
         on_progress(0, 0, "Clustering regions…")
+    # Force an owned, writable copy: *matrix* may be a read-only mmap view
+    # (S1's embedding-matrix sidecar, docs/plans/scalability.md), and UMAP
+    # doesn't guarantee it never writes to its input in place.
+    matrix = np.array(matrix, dtype=np.float32, copy=True, order="C")
     n_components = min(_CLUSTER_DIM, matrix.shape[1], max(2, matrix.shape[0] - 2))
     reducer = umap.UMAP(n_components=n_components, metric="cosine")
     return np.asarray(reducer.fit_transform(matrix), dtype=np.float32)

--- a/vtscore/projection/umap_projection.py
+++ b/vtscore/projection/umap_projection.py
@@ -213,7 +213,11 @@ def fit_projection(
     engages on the UMAP path (the PCA/trivial fallbacks are too small to pack)
     and preserves each cluster's internal shape exactly.
     """
-    mat = np.ascontiguousarray(matrix, dtype=np.float32)
+    # Force an owned, writable copy (not just contiguity/dtype): *matrix* may
+    # be a read-only mmap view (S1's embedding-matrix sidecar,
+    # docs/plans/scalability.md), and neither UMAP nor PCA guarantee they
+    # never write to their input in place.
+    mat = np.array(matrix, dtype=np.float32, copy=True, order="C")
     if mat.ndim != 2:
         raise ValueError(f"matrix must be 2-D (N, d), got shape {mat.shape}")
     n = mat.shape[0]

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -362,6 +362,14 @@ class DatasetContext:
         "_emb_matrix_ids",
         "_emb_matrix",
         "_emb_matrix_revision",
+        # One-way latch: set the first time ``invalidate_embedding_matrix``
+        # fires for this context (an in-place vector rewrite - re-embed /
+        # clip). Once set, ``get_embedding_matrix`` never again considers the
+        # on-disk mmap sidecar (see S1, docs/plans/scalability.md) for this
+        # context's lifetime, even though the id list alone can't detect a
+        # same-id in-place rewrite. A fresh load gets a fresh ``DatasetContext``
+        # (and so a fresh, unset latch), so this never needs resetting.
+        "_emb_sidecar_disabled",
         # Cached *flattened region matrix* for patch-region (e.g. DINOv3)
         # datasets, mirroring ``_emb_matrix`` but expanded to one row per
         # (media, region) pair.  ``_region_matrix`` is the ``(R, D)`` float32
@@ -466,6 +474,7 @@ class DatasetContext:
         self._emb_matrix_ids: list[int] | None = None
         self._emb_matrix: Any = None  # np.ndarray | None
         self._emb_matrix_revision: int | None = None  # media_revision the matrix was built at
+        self._emb_sidecar_disabled: bool = False  # latched True by invalidate_embedding_matrix
         self._region_matrix_ids: list[int] | None = None
         self._region_matrix: Any = None  # np.ndarray | None, shape (R, D)
         self._region_matrix_revision: int | None = None  # media_revision the region matrix was built at


### PR DESCRIPTION
## Summary

Implements S1 from `docs/plans/scalability.md`: avoid materializing a second full-size `(N, D)` float32 copy of the embedding matrix in RAM on every cold load, by persisting it once as an mmap-able sidecar next to the dataset pickle.

- **`vtscore/embedding/matrix.py`**: `get_embedding_matrix`'s primary-path cache-miss build now tries a matching on-disk sidecar (`<pkl_stem>.embids.npy` + `<pkl_stem>.embmat.npy`, next to the pkl) before falling back to the existing `_stack_embeddings` rebuild. A valid sidecar is loaded via `np.load(..., mmap_mode='r')` — the OS pages in only the rows a request actually touches instead of materializing the whole array. After any genuine rebuild, the matrix is persisted back out (best-effort, swallows read-only-fs/disk-full errors) so the *next* cold load of the same dataset can mmap it.
- **Correctness guard beyond what the plan sketched**: an id-list-and-dimension match isn't enough to catch a same-id-set, same-dimension **in-place re-embed** (the exact "invisible to a dict subclass" gap `invalidate_embedding_matrix`'s docstring already calls out for the in-memory cache). Added a one-way `ctx._emb_sidecar_disabled` latch, flipped by `invalidate_embedding_matrix`, so once a context has had an in-place vector rewrite it never again trusts the on-disk sidecar for the rest of its lifetime — it always rebuilds from live `ctx.medias`. Regression-tested in `tests_lib/core/test_embedding_matrix.py::TestEmbeddingMatrixSidecar`.
- **Read-only mmap safety**: `get_embedding_matrix` can now return a read-only `np.memmap`. Audited every consumer; two UMAP/PCA fit call sites (`vtscore/projection/umap_projection.py:fit_projection`, `vtscore/projection/signpost_build.py:_clusterable_vectors`) didn't guarantee they never write to their input in place, so both now force an owned, writable copy before fitting.
- **Sidecar cleanup**: already covered by the stem-based sweep in `unregister_dataset` (#2646, merged) — no new cleanup logic needed here.
- **`docs/plans/scalability.md`**: removed the now-shipped S1 section per the plan-file policy (future work only), fixed the S4/S15 cross-references that assumed S1 would fully decouple embeddings from the pickle (it doesn't — that's still S4's job), and updated the recurring-root-causes/test-coverage tables.
- **`docs/ARCHITECTURE.md`**: one-line mention of the sidecar in the directory map.

Deliberately **not** implemented: a `--no-emb-sidecar` settings/CLI flag the plan sketched for read-only filesystems. The write path already degrades gracefully (try/except, matching the existing best-effort pattern used for projection persistence) so a dedicated flag isn't needed.

## Test plan
- [x] `tests_lib/core/test_embedding_matrix.py` — new `TestEmbeddingMatrixSidecar` class: sidecar written after first build, fresh context mmaps it, id-mismatch and dim-mismatch sidecars are rejected and fall back to a live rebuild, an in-place rewrite permanently disables the sidecar for that context and refreshes the on-disk copy, unregistered (in-memory-only) datasets never touch the filesystem.
- [x] `tests_lib/projection/test_umap_projection.py` — `fit_projection` accepts a read-only matrix without raising.
- [x] `./run-tests.sh` (full suite: ruff, format, codespell, deptry, pip-audit, pyright, OpenAPI snapshot, Dockerfiles, screenshot wiring, frontend build/audit/Vitest, full pytest) — all green, 6489 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_018yUyEazaxVhiv1dxCiQBas)_