### PR TITLE
Scalability S3/S17/S19: backend windowed sort API

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3380,6 +3380,9 @@
       "LabelFileSortResponse": {
         "additionalProperties": false,
         "properties": {
+          "above_threshold": {
+            "type": "integer"
+          },
           "loaded": {
             "type": "integer"
           },
@@ -3393,8 +3396,14 @@
           "skipped": {
             "type": "integer"
           },
+          "sort_token": {
+            "type": "string"
+          },
           "threshold": {
             "type": "number"
+          },
+          "total": {
+            "type": "integer"
           }
         },
         "required": [
@@ -4806,6 +4815,43 @@
         },
         "type": "object"
       },
+      "SortPageResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "has_more": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          },
+          "results": {
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "threshold": {
+            "nullable": true,
+            "type": "number"
+          },
+          "total": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "has_more",
+          "limit",
+          "offset",
+          "results",
+          "threshold",
+          "total"
+        ],
+        "type": "object"
+      },
       "SortRequest": {
         "additionalProperties": false,
         "properties": {
@@ -4821,6 +4867,9 @@
       "SortResponse": {
         "additionalProperties": false,
         "properties": {
+          "above_threshold": {
+            "type": "integer"
+          },
           "results": {
             "items": {
               "additionalProperties": {},
@@ -4828,8 +4877,14 @@
             },
             "type": "array"
           },
+          "sort_token": {
+            "type": "string"
+          },
           "threshold": {
             "type": "number"
+          },
+          "total": {
+            "type": "integer"
           }
         },
         "required": [
@@ -14282,6 +14337,68 @@
           }
         },
         "summary": "Return medias sorted by cosine similarity to a text query.",
+        "tags": [
+          "sorting"
+        ]
+      }
+    },
+    "/api/sort/page": {
+      "get": {
+        "description": "A sort route (``/api/sort``, ``/api/example-sort``, ``/api/label-file-sort``)\nstores its full descending ``results`` list and hands back a ``sort_token``;\nthis endpoint slices ``[offset, offset + limit)`` out of that cached list so\nthe client can scroll deep into a large ranking without receiving the whole\nthing up front (``docs/plans/scalability.md`` S3/S17/S19).\n\nThe token doubles as a sort-generation guard: a re-sort mints a new token,\nand an evicted/unknown token 404s so the client refetches from the top.",
+        "operationId": "sort_page",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 200,
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SortPageResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "Unknown or expired sort token; re-run the sort."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return one window of a previously-computed ranking.",
         "tags": [
           "sorting"
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,6 +342,10 @@ def reset_state():
 
     reset_all_async_jobs_for_tests()
 
+    from vtscore.state.sort_results_cache import sort_results_cache
+
+    sort_results_cache.reset_for_tests()
+
     clear_progress_cache()
 
     from vtscore.embedding.helpers import clear_text_query_cache as _clear_query_cache

--- a/tests/sorting/test_sort_windowing.py
+++ b/tests/sorting/test_sort_windowing.py
@@ -1,0 +1,81 @@
+"""API tests for the windowed sort response + ``/api/sort/page`` (S3/S17/S19).
+
+These assert the *additive* backend contract: every sort route still returns the
+full ``results`` list, but now also carries ``sort_token`` / ``total`` /
+``above_threshold``, and the token pages a cached window back out.  The frontend
+still consumes the full ``results`` (windowed model lands separately).
+"""
+
+from __future__ import annotations
+
+import app as app_module
+
+
+class TestSortResponseWindowMeta:
+    def test_text_sort_carries_window_meta(self, client):
+        resp = client.post("/api/sort", json={"text": "high pitched beep"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # Full list still returned (additive change).
+        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert data["total"] == app_module.NUM_MEDIAS
+        assert isinstance(data["sort_token"], str) and data["sort_token"]
+        # above_threshold matches how many rows are >= the returned threshold.
+        expected = sum(1 for r in data["results"] if r["similarity"] >= data["threshold"])
+        assert data["above_threshold"] == expected
+
+    def test_each_sort_mints_a_fresh_token(self, client):
+        t1 = client.post("/api/sort", json={"text": "beep"}).get_json()["sort_token"]
+        t2 = client.post("/api/sort", json={"text": "beep"}).get_json()["sort_token"]
+        assert t1 != t2
+
+
+class TestSortPage:
+    def test_page_returns_a_window(self, client):
+        sort = client.post("/api/sort", json={"text": "a beeping sound"}).get_json()
+        token = sort["sort_token"]
+        full_ids = [r["id"] for r in sort["results"]]
+
+        page = client.get(f"/api/sort/page?token={token}&offset=1&limit=2")
+        assert page.status_code == 200
+        body = page.get_json()
+        assert [r["id"] for r in body["results"]] == full_ids[1:3]
+        assert body["offset"] == 1
+        assert body["limit"] == 2
+        assert body["total"] == app_module.NUM_MEDIAS
+        assert body["has_more"] is (3 < app_module.NUM_MEDIAS)
+
+    def test_page_default_offset_and_limit(self, client):
+        token = client.post("/api/sort", json={"text": "tone"}).get_json()["sort_token"]
+        body = client.get(f"/api/sort/page?token={token}").get_json()
+        assert body["offset"] == 0
+        assert body["limit"] == 200
+
+    def test_unknown_token_404s(self, client):
+        resp = client.get("/api/sort/page?token=nope-not-a-real-token")
+        assert resp.status_code == 404
+
+    def test_missing_token_422s(self, client):
+        resp = client.get("/api/sort/page?offset=0&limit=10")
+        assert resp.status_code == 422
+
+    def test_limit_out_of_range_422s(self, client):
+        token = client.post("/api/sort", json={"text": "tone"}).get_json()["sort_token"]
+        assert client.get(f"/api/sort/page?token={token}&limit=0").status_code == 422
+        assert client.get(f"/api/sort/page?token={token}&limit=99999").status_code == 422
+
+    def test_full_pages_reconstruct_the_ranking(self, client):
+        sort = client.post("/api/sort", json={"text": "sine wave"}).get_json()
+        token = sort["sort_token"]
+        expected = [r["id"] for r in sort["results"]]
+
+        collected: list[int] = []
+        offset = 0
+        limit = 2
+        while True:
+            body = client.get(f"/api/sort/page?token={token}&offset={offset}&limit={limit}").get_json()
+            collected.extend(r["id"] for r in body["results"])
+            if not body["has_more"]:
+                break
+            offset += limit
+        assert collected == expected

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -237,6 +237,10 @@ def reset_contexts(tmp_path, monkeypatch):
 
     reset_all_async_jobs_for_tests()
 
+    from vtscore.state.sort_results_cache import sort_results_cache
+
+    sort_results_cache.reset_for_tests()
+
     clear_progress_cache()
 
     from vtscore.embedding.helpers import clear_text_query_cache as _clear_query_cache

--- a/tests_lib/sorting/test_sort_results_cache.py
+++ b/tests_lib/sorting/test_sort_results_cache.py
@@ -1,0 +1,119 @@
+"""Unit tests for the windowed sort-results cache (scalability.md S3/S17/S19).
+
+Library tier: the cache is Flask-free process-global state, so it belongs in
+``tests_lib``.  Covers score-key handling, above-threshold counting, window
+slicing, LRU eviction, the sort-generation (token) guard, and the per-dataset
+gate.
+"""
+
+from __future__ import annotations
+
+from vtscore.state.sort_results_cache import (
+    SortResultsCache,
+    count_above_threshold,
+    result_score,
+)
+
+
+class TestResultScore:
+    def test_prefers_score_key(self):
+        assert result_score({"id": 1, "score": 0.9, "similarity": 0.1}) == 0.9
+
+    def test_falls_back_to_similarity(self):
+        assert result_score({"id": 1, "similarity": 0.7}) == 0.7
+
+    def test_missing_both_sorts_below_any_threshold(self):
+        assert result_score({"id": 1}) == float("-inf")
+
+
+class TestCountAboveThreshold:
+    def test_counts_ge_threshold(self):
+        results = [{"id": i, "score": s} for i, s in enumerate([0.9, 0.8, 0.5, 0.2])]
+        assert count_above_threshold(results, 0.5) == 3  # 0.9, 0.8, 0.5 (>=)
+
+    def test_none_threshold_counts_all(self):
+        results = [{"id": 1, "score": 0.1}, {"id": 2, "score": 0.2}]
+        assert count_above_threshold(results, None) == 2
+
+    def test_similarity_rows_counted(self):
+        results = [{"id": 1, "similarity": 0.8}, {"id": 2, "similarity": 0.3}]
+        assert count_above_threshold(results, 0.5) == 1
+
+
+def _ranking(n: int) -> list[dict]:
+    """A descending ranking of *n* rows: id i has score (n - i) / n."""
+    return [{"id": i, "score": (n - i) / n} for i in range(n)]
+
+
+class TestSortResultsCache:
+    def test_store_returns_distinct_tokens(self):
+        cache = SortResultsCache()
+        t1 = cache.store(_ranking(3), 0.5)
+        t2 = cache.store(_ranking(3), 0.5)
+        assert t1 != t2
+
+    def test_page_slices_the_window(self):
+        cache = SortResultsCache()
+        token = cache.store(_ranking(10), 0.5)
+        page = cache.page(token, offset=2, limit=3)
+        assert page is not None
+        assert [r["id"] for r in page["results"]] == [2, 3, 4]
+        assert page["offset"] == 2
+        assert page["limit"] == 3
+        assert page["total"] == 10
+        assert page["threshold"] == 0.5
+        assert page["has_more"] is True
+
+    def test_page_last_window_has_no_more(self):
+        cache = SortResultsCache()
+        token = cache.store(_ranking(10), 0.5)
+        page = cache.page(token, offset=8, limit=5)
+        assert page is not None
+        assert [r["id"] for r in page["results"]] == [8, 9]
+        assert page["has_more"] is False
+
+    def test_page_offset_past_end_is_empty(self):
+        cache = SortResultsCache()
+        token = cache.store(_ranking(3), 0.5)
+        page = cache.page(token, offset=99, limit=10)
+        assert page is not None
+        assert page["results"] == []
+        assert page["has_more"] is False
+
+    def test_unknown_token_returns_none(self):
+        cache = SortResultsCache()
+        assert cache.page("does-not-exist", offset=0, limit=10) is None
+
+    def test_lru_evicts_oldest(self):
+        cache = SortResultsCache(max_entries=2)
+        t1 = cache.store(_ranking(1), 0.5)
+        t2 = cache.store(_ranking(1), 0.5)
+        t3 = cache.store(_ranking(1), 0.5)  # evicts t1
+        assert cache.page(t1, 0, 10) is None
+        assert cache.page(t2, 0, 10) is not None
+        assert cache.page(t3, 0, 10) is not None
+
+    def test_paging_keeps_entry_warm_against_eviction(self):
+        cache = SortResultsCache(max_entries=2)
+        t1 = cache.store(_ranking(1), 0.5)
+        cache.store(_ranking(1), 0.5)  # t2
+        cache.page(t1, 0, 10)  # touch t1 -> now most-recently-used
+        cache.store(_ranking(1), 0.5)  # t3 evicts the LRU, which is now t2 not t1
+        assert cache.page(t1, 0, 10) is not None
+
+    def test_dataset_gate_blocks_cross_dataset_paging(self):
+        cache = SortResultsCache()
+        token = cache.store(_ranking(3), 0.5, dataset_id="ds-A")
+        assert cache.page(token, 0, 10, dataset_id="ds-B") is None
+        assert cache.page(token, 0, 10, dataset_id="ds-A") is not None
+
+    def test_dataset_gate_skipped_when_entry_unscoped(self):
+        cache = SortResultsCache()
+        token = cache.store(_ranking(3), 0.5)  # no dataset_id
+        assert cache.page(token, 0, 10, dataset_id="ds-anything") is not None
+
+    def test_reset_for_tests_clears(self):
+        cache = SortResultsCache()
+        token = cache.store(_ranking(3), 0.5)
+        cache.reset_for_tests()
+        assert cache.page(token, 0, 10) is None

--- a/vtscore/state/sort_results_cache.py
+++ b/vtscore/state/sort_results_cache.py
@@ -1,0 +1,137 @@
+"""Process-global cache of full sorted result lists for windowed paging.
+
+A sort API call ranks the *whole* dataset but, at 100 k / 1 M items, must not
+ship the entire ordered list to the browser in one JSON response
+(``docs/plans/scalability.md`` S3/S17/S19).  This cache lets a sort route stash
+its full descending ``results`` list server-side and hand the client an opaque
+``sort_token``; the client then pulls deeper windows via
+``GET /api/sort/page?token=…``.
+
+Only in-memory, and only the lightweight ranking rows (``{"id", "score"}`` or
+``{"id", "similarity"[, "best_region"]}``) — never embeddings or MLP weights, so
+this stays within the "No Persisted Vectors or MLPs" rule (nothing is
+serialised; the list is re-derived on the next sort).  The cache is bounded to
+the most recent ``max_entries`` sorts (LRU), so it cannot grow without bound as
+users re-sort.
+
+The ``sort_token`` doubles as the **sort-generation token**: a client holding a
+token from one ranking cannot accidentally page into a newer ranking, because a
+re-sort mints a fresh token and the old one either still points at its own
+(now-stale-but-consistent) list or has been evicted (→ 404, refetch from the
+top).
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections import OrderedDict
+from typing import Any
+
+
+def result_score(result: dict) -> float:
+    """Read a ranking row's score regardless of which sort path produced it.
+
+    Text / example sort emit ``{"id", "similarity"}``; learned / find sort emit
+    ``{"id", "score"}``.  Prefer ``score`` then ``similarity``; a row carrying
+    neither sorts as ``-inf`` so it lands below any real threshold.
+    """
+    if "score" in result:
+        return result["score"]
+    if "similarity" in result:
+        return result["similarity"]
+    return float("-inf")
+
+
+def count_above_threshold(results: list[dict], threshold: float | None) -> int:
+    """Number of rows scoring at or above *threshold* (all of them when ``None``)."""
+    if threshold is None:
+        return len(results)
+    return sum(1 for r in results if result_score(r) >= threshold)
+
+
+class SortResultsCache:
+    """LRU cache of full sorted result lists, keyed by an opaque token.
+
+    Thread-safe: sort routes ``store`` from request threads (and background
+    learned-sort workers), while ``/api/sort/page`` reads concurrently.
+    """
+
+    def __init__(self, max_entries: int = 8) -> None:
+        self._lock = threading.Lock()
+        self._entries: OrderedDict[str, dict[str, Any]] = OrderedDict()
+        self._max_entries = max_entries
+
+    def store(
+        self,
+        results: list[dict],
+        threshold: float | None,
+        *,
+        dataset_id: str = "",
+        detector_id: str = "",
+    ) -> str:
+        """Store *results* under a fresh token and return it.
+
+        Evicts the least-recently-used entries beyond ``max_entries``.  The
+        stored list is held by reference (not copied): callers must not mutate a
+        results list after handing it off.
+        """
+        token = uuid.uuid4().hex
+        with self._lock:
+            self._entries[token] = {
+                "results": results,
+                "threshold": threshold,
+                "dataset_id": dataset_id,
+                "detector_id": detector_id,
+            }
+            self._entries.move_to_end(token)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+        return token
+
+    def page(
+        self,
+        token: str,
+        offset: int,
+        limit: int,
+        *,
+        dataset_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Return a window of the stored list, or ``None`` if the token is unknown.
+
+        ``None`` also results when *dataset_id* is given and doesn't match the
+        dataset the sort was stored against — a defence against paging one
+        dataset's ranking with another dataset's active context.
+        """
+        with self._lock:
+            entry = self._entries.get(token)
+            if entry is None:
+                return None
+            if dataset_id is not None and entry["dataset_id"] and entry["dataset_id"] != dataset_id:
+                return None
+            # Touch: paging keeps a still-in-use ranking warm against eviction.
+            self._entries.move_to_end(token)
+            results: list[dict] = entry["results"]
+            threshold = entry["threshold"]
+
+        total = len(results)
+        start = max(0, offset)
+        end = total if limit < 0 else min(total, start + limit)
+        window = results[start:end]
+        return {
+            "results": window,
+            "offset": start,
+            "limit": limit,
+            "total": total,
+            "threshold": threshold,
+            "has_more": end < total,
+        }
+
+    def reset_for_tests(self) -> None:
+        """Drop all cached lists (called from the autouse test-reset fixtures)."""
+        with self._lock:
+            self._entries.clear()
+
+
+#: Application-wide singleton used by the sort routes and ``/api/sort/page``.
+sort_results_cache = SortResultsCache()

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -554,6 +554,35 @@ def run_plugin_or_error(plugin: PluginBase, method: str, *args):
     return result, None
 
 
+def windowed_sort_extras(results: list[dict], threshold: float | None) -> dict[str, Any]:
+    """Register a full sorted ``results`` list and return the windowing extras.
+
+    Stores *results* in the process-global :data:`sort_results_cache` keyed to
+    the active (dataset, detector) pair and returns the extra fields a sort
+    response carries so a client can page deeper without holding the whole list:
+
+    - ``sort_token`` — opaque handle for ``GET /api/sort/page``; also the
+      sort-generation token (a re-sort mints a new one).
+    - ``total`` — full ranking length.
+    - ``above_threshold`` — rows scoring at or above *threshold*.
+
+    Additive: the caller still returns the full ``results`` today (the frontend
+    windowed model lands in a later slice, see ``docs/plans/scalability.md``
+    S3/S17/S19), so wiring this in never changes existing behaviour.
+    """
+    from vtscore.state.core import get_active_context, get_active_detector_context  # noqa: PLC0415
+    from vtscore.state.sort_results_cache import count_above_threshold, sort_results_cache  # noqa: PLC0415
+
+    dataset_id = getattr(get_active_context(), "dataset_id", "") or ""
+    detector_id = getattr(get_active_detector_context(), "detector_id", "") or ""
+    token = sort_results_cache.store(results, threshold, dataset_id=dataset_id, detector_id=detector_id)
+    return {
+        "sort_token": token,
+        "total": len(results),
+        "above_threshold": count_above_threshold(results, threshold),
+    }
+
+
 def get_embedder_for_medias(media_dict: dict):
     """Return the appropriate embedder for the given medias, or ``None``.
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -29,6 +29,7 @@ from vtsearch.routes._shared import (
     get_embedder_for_medias,
     require_dataset_header,
     require_detector_header,
+    windowed_sort_extras,
 )
 
 from vtscore.config import DATA_DIR
@@ -48,6 +49,8 @@ from vtsearch.schemas.sorting import (
     SafeThresholdsResponseSchema,
     SeedFromExamplesRequestSchema,
     SeedFromExamplesResponseSchema,
+    SortPageQuerySchema,
+    SortPageResponseSchema,
     SortRequestSchema,
     SortResponseSchema,
     TextsortSuggestionRequestSchema,
@@ -267,7 +270,7 @@ def sort_clips(body: dict):
         update_sort_progress("sorting", "Computing similarities…", 0, 0, step=3, total_steps=_SORT_STEPS)
         results, threshold = _cosine_sort(text_vec, role="text", snap=snap)
         _sort_idle()
-        return {"results": results, "threshold": threshold}
+        return {"results": results, "threshold": threshold, **windowed_sort_extras(results, threshold)}
     except Exception as exc:
         from werkzeug.exceptions import HTTPException
 
@@ -279,6 +282,32 @@ def sort_clips(body: dict):
         logging.getLogger(__name__).exception("text sort failed")
         _sort_idle()
         abort(500, message=f"Text sort failed: {format_exception_detail(exc)}")
+
+
+@sorting_bp.route("/api/sort/page", methods=["GET"])
+@sorting_bp.arguments(SortPageQuerySchema, location="query")
+@sorting_bp.response(200, SortPageResponseSchema)
+@sorting_bp.alt_response(404, description="Unknown or expired sort token; re-run the sort.")
+def sort_page(query: dict):
+    """Return one window of a previously-computed ranking.
+
+    A sort route (``/api/sort``, ``/api/example-sort``, ``/api/label-file-sort``)
+    stores its full descending ``results`` list and hands back a ``sort_token``;
+    this endpoint slices ``[offset, offset + limit)`` out of that cached list so
+    the client can scroll deep into a large ranking without receiving the whole
+    thing up front (``docs/plans/scalability.md`` S3/S17/S19).
+
+    The token doubles as a sort-generation guard: a re-sort mints a new token,
+    and an evicted/unknown token 404s so the client refetches from the top.
+    """
+    from vtscore.state.core import get_active_context  # noqa: PLC0415
+    from vtscore.state.sort_results_cache import sort_results_cache  # noqa: PLC0415
+
+    dataset_id = getattr(get_active_context(), "dataset_id", "") or None
+    page = sort_results_cache.page(query["token"], query["offset"], query["limit"], dataset_id=dataset_id)
+    if page is None:
+        abort(404, message="Unknown or expired sort token; re-run the sort.")
+    return page
 
 
 def _learned_sort_done_payload(job) -> dict:
@@ -789,7 +818,7 @@ def example_sort():
             # Clean up temp file even if sorting raises
             temp_path.unlink(missing_ok=True)
 
-        return {"results": results, "threshold": thresh}
+        return {"results": results, "threshold": thresh, **windowed_sort_extras(results, thresh)}
 
     except Exception as exc:
         from werkzeug.exceptions import HTTPException
@@ -938,11 +967,13 @@ def label_file_sort():
             abort(400, message="Need at least one good and one bad labeled example")
 
         results, threshold = _train_and_score_dataset(X_list, y_list, score_name)
+        threshold = round(threshold, 4)
         return {
             "results": results,
-            "threshold": round(threshold, 4),
+            "threshold": threshold,
             "loaded": loaded,
             "skipped": skipped,
+            **windowed_sort_extras(results, threshold),
         }
 
     except Exception as exc:

--- a/vtsearch/schemas/sorting.py
+++ b/vtsearch/schemas/sorting.py
@@ -62,11 +62,53 @@ class SortRequestSchema(Schema):
     text = fields.String(required=True)
 
 
+#: Windowing metadata carried alongside a full ``results`` list so a client can
+#: page deeper via ``GET /api/sort/page`` without holding the whole ranking.
+#: Additive and optional — every sort route still returns the full ``results``
+#: today (frontend windowing lands separately; see scalability.md S3/S17/S19).
+_WINDOW_META_FIELDS = {
+    # Opaque handle for /api/sort/page; also the sort-generation token.
+    "sort_token": fields.String(required=False),
+    # Full ranking length (== len(results) while the list is returned whole).
+    "total": fields.Integer(required=False),
+    # Rows scoring at or above ``threshold``.
+    "above_threshold": fields.Integer(required=False),
+}
+
+
 class SortResponseSchema(Schema):
     """Response for ``POST /api/sort`` and ``POST /api/example-sort``."""
 
     results = fields.List(fields.Dict(), required=True)
     threshold = fields.Float(required=True)
+    sort_token = _WINDOW_META_FIELDS["sort_token"]
+    total = _WINDOW_META_FIELDS["total"]
+    above_threshold = _WINDOW_META_FIELDS["above_threshold"]
+
+
+class SortPageQuerySchema(Schema):
+    """Query for ``GET /api/sort/page``."""
+
+    token = fields.String(required=True)
+    offset = fields.Integer(load_default=0, validate=validate.Range(min=0))
+    limit = fields.Integer(load_default=200, validate=validate.Range(min=1, max=2000))
+
+    class Meta:
+        # Tolerate request-context params (dataset_id / detector_id) smuggled in
+        # as query args by browser-native requests, matching the learned-sort
+        # result query schema.
+        unknown = "exclude"
+
+
+class SortPageResponseSchema(Schema):
+    """Response for ``GET /api/sort/page`` — one window of a cached ranking."""
+
+    results = fields.List(fields.Dict(), required=True)
+    offset = fields.Integer(required=True)
+    limit = fields.Integer(required=True)
+    total = fields.Integer(required=True)
+    threshold = fields.Float(required=True, allow_none=True)
+    has_more = fields.Boolean(required=True)
 
 
 # ---------------------------------------------------------------------------
@@ -268,6 +310,9 @@ class LabelFileSortResponseSchema(Schema):
     threshold = fields.Float(required=True)
     loaded = fields.Integer(required=True)
     skipped = fields.Integer(required=True)
+    sort_token = _WINDOW_META_FIELDS["sort_token"]
+    total = _WINDOW_META_FIELDS["total"]
+    above_threshold = _WINDOW_META_FIELDS["above_threshold"]
 
 
 # ---------------------------------------------------------------------------
@@ -311,6 +356,8 @@ __all__ = [
     "SafeThresholdsResponseSchema",
     "SeedFromExamplesRequestSchema",
     "SeedFromExamplesResponseSchema",
+    "SortPageQuerySchema",
+    "SortPageResponseSchema",
     "SortRequestSchema",
     "SortResponseSchema",
     "TextsortSuggestionRequestSchema",


### PR DESCRIPTION
Follow-up to #2644 (the S3/S17/S19 cleanup slice, now merged). This is the **backend windowed sort API** — the server-side machinery for windowed sort results, added **additively**: every sort route still returns the full `results` list, so nothing breaks yet. The frontend windowed model + Find server endpoints land in later slices.

## What changed
- **`SortResultsCache`** (`vtscore/state/sort_results_cache.py`): a thread-safe LRU cache of full descending ranking lists keyed by an opaque `sort_token`. In-memory only (id+score rows, never embeddings/MLPs — within the No-Persisted-Vectors rule), bounded to the most recent N sorts. The token doubles as the sort-generation guard: a re-sort mints a fresh token; an evicted/unknown token 404s so the client refetches from the top.
- **`windowed_sort_extras()`** route helper stores the ranking and returns `{sort_token, total, above_threshold}`, merged into `/api/sort`, `/api/example-sort`, and `/api/label-file-sort`.
- **`GET /api/sort/page?token=&offset=&limit=`** slices a cached ranking back out, with a per-dataset gate and a 404 on unknown/evicted tokens.
- Schemas: optional window-meta fields on the sort responses; new `SortPageQuery`/`SortPageResponse`. OpenAPI snapshot regenerated.
- Cache reset wired into both conftests; new lib-tier cache unit tests and app-tier `/api/sort` + `/api/sort/page` tests.

## Why additive
Keeping the full `results` payload means the frontend is untouched by this PR. The window fields sit alongside it, so the frontend can adopt paging (and the backend can later drop the full list) atomically in the follow-up, without a broken intermediate state.

## Testing
`./run-tests.sh` — full suite green (6495 passed, 1 skipped) on the pre-split branch, including the frontend `build:prod` + Vitest gate, ruff/pyright/codespell/deptry/pip-audit, and the OpenAPI snapshot check. This PR's diff is exactly the backend slice (slice 1 already merged via #2644).

## Follow-ups (tracked in `docs/plans/scalability.md`)
Server-side bulk/navigation endpoints for Find (all-ids-above-cutoff by token; next-unverified-above/below); then the frontend `SortStateService` → windowed model + media-list "Load more", switching Find's bulk actions and boundary walk onto the new endpoints and dropping the full `results` payload.

Refs the S3/S17/S19 items in `docs/plans/scalability.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqFkWN5vQzh8jufzXLswRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqFkWN5vQzh8jufzXLswRg)_