### PR TITLE
Extract shared cross-modal base for SigLIP / SigLIP2 / CLIP image embedders

### DIFF
--- a/tests_lib/detectors/test_image_bulk_embedding.py
+++ b/tests_lib/detectors/test_image_bulk_embedding.py
@@ -276,7 +276,7 @@ class TestSiglipBulkOverride:
         _write_image(p)
 
         with mock.patch(
-            "vtscore.media.image.embedder_siglip.bulk_embed_image_files",
+            "vtscore.media.image._cross_modal_shared.bulk_embed_image_files",
             wraps=__import__(
                 "vtscore.media.image._image_bulk", fromlist=["bulk_embed_image_files"]
             ).bulk_embed_image_files,

--- a/vtscore/media/image/_cross_modal_shared.py
+++ b/vtscore/media/image/_cross_modal_shared.py
@@ -1,0 +1,155 @@
+"""Shared base for the HF cross-modal image embedders (SigLIP, SigLIP 2, CLIP).
+
+All three embedders wrap a Hugging Face model/processor pair that exposes
+``get_image_features`` / ``get_text_features``, so the full cross-modal
+surface (single/bulk image embedding, PIL embedding, text-query embedding)
+lives here.  Subclasses provide the identity properties, their own
+:meth:`~vtscore.media.embedder.MediaEmbedder._load_models_impl` (the model
+and processor classes genuinely differ per backbone), and two class
+attributes:
+
+- :attr:`_label` - human-readable backbone name used in progress and log
+  messages (e.g. ``"SigLIP 2"``).
+- :attr:`_text_processor_kwargs` - tokenization kwargs passed to the
+  processor for text queries; the padding/truncation contract differs per
+  backbone and changing it silently changes the produced vectors.
+
+``ImageSiglipLEmbedder`` uses the open_clip runtime path instead of an HF
+processor and stays outside this base.  The underscore-prefixed filename
+keeps this module out of the auto-discovery scan in :mod:`vtscore.media`
+(only ``embedder*.py`` files are imported as plugins).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+import numpy as np
+
+from vtscore.media.embedder import (
+    MediaEmbedder,
+    extract_tensor as _extract_tensor,
+)
+from vtscore.media.image._image_bulk import bulk_embed_image_files
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+
+class _CrossModalHFEmbedder(MediaEmbedder):
+    """Cross-modal (image + text) embedding surface shared by the HF backbones."""
+
+    _label: str
+    _text_processor_kwargs: dict[str, Any]
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Typed ``Any``: transformers stubs miss several processor kwargs we
+        # pass at runtime; runtime ``None`` checks guard the calls.
+        self._model: Any = None
+        self._processor: Any = None
+
+    @property
+    def media_type_id(self) -> str:
+        return "image"
+
+    @property
+    def description_wrappers(self) -> list[str]:
+        return [
+            "a photo of {text}",
+            "a photograph of {text}",
+            "an image of {text}",
+            "{text}",
+            "a picture of {text}",
+        ]
+
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return None
+        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
+
+        source = _pil_source_for(media)
+        if source is None:
+            return None
+        image = _load_pil(source)
+        if image is None:
+            return None
+        return self.embed_pil_image(image)
+
+    def embed_pil_image(self, image: "Image.Image") -> Optional[np.ndarray]:
+        """Embed a PIL Image that is already in memory (e.g. from CIFAR-10)."""
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return None
+        try:
+            import torch  # noqa: PLC0415
+
+            image = image.convert("RGB")
+            inputs = self._processor(images=image, return_tensors="pt")
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            with torch.no_grad():
+                outputs = self._model.get_image_features(**inputs)
+                embedding = _extract_tensor(outputs).detach().cpu().numpy()
+            return embedding[0]
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding PIL image (%s)", self._label)
+            return None
+
+    def _forward_pil_batch(self, images: list["Image.Image"]) -> np.ndarray:
+        """Run the vision encoder on a list of PIL images.
+
+        Returns an ``(N, dim)`` array.  Caller is responsible for batch
+        sizing - this runs the whole list in one forward pass.
+        """
+        import torch  # noqa: PLC0415
+
+        rgb = [im.convert("RGB") for im in images]
+        inputs = self._processor(images=rgb, return_tensors="pt")
+        device = next(self._model.parameters()).device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self._model.get_image_features(**inputs)
+            return _extract_tensor(outputs).detach().cpu().numpy()
+
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return [None] * len(medias)
+        with self._embed_lock:
+            return bulk_embed_image_files(
+                medias,
+                forward_pil_batch=self._forward_pil_batch,
+                batch_size=self.embed_batch_size,
+                on_progress=self._on_progress,
+                label=self._label,
+            )
+
+    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None or self._processor is None:
+            return None
+        try:
+            import torch  # noqa: PLC0415
+
+            inputs = self._processor(text=[text], return_tensors="pt", **self._text_processor_kwargs)
+            device = next(self._model.parameters()).device
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            with torch.no_grad():
+                text_vec = _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
+            return text_vec
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding text query for image (%s)", self._label)
+            return None
+
+    # Internal helper used by loader.py bridge
+    def _get_model_and_processor(self):
+        if self._model is None:
+            self.load_models()
+        return self._model, self._processor

--- a/vtscore/media/image/embedder_clip.py
+++ b/vtscore/media/image/embedder_clip.py
@@ -2,17 +2,12 @@
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any, Optional
-
-import numpy as np
+from typing import Any
 
 from vtscore.config import CLIP_MODEL_ID
 from vtscore.media.embedder import (
     IMPORT_MODULE_ESTIMATES,
-    MediaEmbedder,
     embedder_load_setup,
-    extract_tensor as _extract_tensor,
     hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
@@ -20,25 +15,18 @@ from vtscore.media.embedder import (
     timed_progress,
     to_compute_device,
 )
-from vtscore.media.image._image_bulk import bulk_embed_image_files
-
-if TYPE_CHECKING:
-    from PIL import Image
+from vtscore.media.image._cross_modal_shared import _CrossModalHFEmbedder
 
 
-class ImageClipEmbedder(MediaEmbedder):
+class ImageClipEmbedder(_CrossModalHFEmbedder):
     """Embeds images using OpenAI CLIP (clip-vit-base-patch32).
 
     * Images → 512-dimensional vectors via CLIP's vision encoder.
     * Text queries → 512-dimensional vectors via CLIP's text encoder.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
-        # Typed ``Any``: transformers stubs miss several ``CLIPProcessor.__call__``
-        # kwargs we pass at runtime; runtime ``None`` checks guard the calls.
-        self._model: Any = None
-        self._processor: Any = None
+    _label = "CLIP"
+    _text_processor_kwargs: dict[str, Any] = {"padding": True, "truncation": True}
 
     @property
     def name(self) -> str:
@@ -51,10 +39,6 @@ class ImageClipEmbedder(MediaEmbedder):
     @property
     def model_id(self) -> str:
         return CLIP_MODEL_ID
-
-    @property
-    def media_type_id(self) -> str:
-        return "image"
 
     def _load_models_impl(self) -> None:
         if self._model is not None:
@@ -89,94 +73,6 @@ class ImageClipEmbedder(MediaEmbedder):
             self._processor = load_pretrained_local_first(
                 CLIPProcessor.from_pretrained, CLIP_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
-
-    @property
-    def description_wrappers(self) -> list[str]:
-        return [
-            "a photo of {text}",
-            "a photograph of {text}",
-            "an image of {text}",
-            "{text}",
-            "a picture of {text}",
-        ]
-
-    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return None
-        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
-
-        source = _pil_source_for(media)
-        if source is None:
-            return None
-        image = _load_pil(source)
-        if image is None:
-            return None
-        return self.embed_pil_image(image)
-
-    def embed_pil_image(self, image: Image.Image) -> Optional[np.ndarray]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return None
-        try:
-            import torch  # noqa: PLC0415
-
-            image = image.convert("RGB")
-            inputs = self._processor(images=image, return_tensors="pt")
-            device = next(self._model.parameters()).device
-            inputs = {k: v.to(device) for k, v in inputs.items()}
-            with torch.no_grad():
-                outputs = self._model.get_image_features(**inputs)
-                embedding = _extract_tensor(outputs).detach().cpu().numpy()
-            return embedding[0]
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding PIL image (CLIP)")
-            return None
-
-    def _forward_pil_batch(self, images: list[Image.Image]) -> np.ndarray:
-        import torch  # noqa: PLC0415
-
-        rgb = [im.convert("RGB") for im in images]
-        inputs = self._processor(images=rgb, return_tensors="pt")
-        device = next(self._model.parameters()).device
-        inputs = {k: v.to(device) for k, v in inputs.items()}
-        with torch.no_grad():
-            outputs = self._model.get_image_features(**inputs)
-            return _extract_tensor(outputs).detach().cpu().numpy()
-
-    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return [None] * len(medias)
-        with self._embed_lock:
-            return bulk_embed_image_files(
-                medias,
-                forward_pil_batch=self._forward_pil_batch,
-                batch_size=self.embed_batch_size,
-                on_progress=self._on_progress,
-                label="CLIP",
-            )
-
-    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return None
-        try:
-            import torch  # noqa: PLC0415
-
-            inputs = self._processor(text=[text], return_tensors="pt", padding=True, truncation=True)
-            device = next(self._model.parameters()).device
-            inputs = {k: v.to(device) for k, v in inputs.items()}
-            with torch.no_grad():
-                text_vec = _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
-            return text_vec
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding text query for image (CLIP)")
-            return None
 
 
 EMBEDDER = ImageClipEmbedder()

--- a/vtscore/media/image/embedder_siglip.py
+++ b/vtscore/media/image/embedder_siglip.py
@@ -2,17 +2,12 @@
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any, Optional
-
-import numpy as np
+from typing import Any
 
 from vtscore.config import SIGLIP_MODEL_ID
 from vtscore.media.embedder import (
     IMPORT_MODULE_ESTIMATES,
-    MediaEmbedder,
     embedder_load_setup,
-    extract_tensor as _extract_tensor,
     hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
@@ -20,13 +15,10 @@ from vtscore.media.embedder import (
     timed_progress,
     to_compute_device,
 )
-from vtscore.media.image._image_bulk import bulk_embed_image_files
-
-if TYPE_CHECKING:
-    from PIL import Image
+from vtscore.media.image._cross_modal_shared import _CrossModalHFEmbedder
 
 
-class ImageSiglipEmbedder(MediaEmbedder):
+class ImageSiglipEmbedder(_CrossModalHFEmbedder):
     """Embeds images using the SigLIP model (google/siglip-base-patch16-224).
 
     * Images → 768-dimensional vectors via SigLIP's vision encoder.
@@ -35,16 +27,9 @@ class ImageSiglipEmbedder(MediaEmbedder):
       (used for PDF rendering and CIFAR-10 demo datasets).
     """
 
-    def __init__(self) -> None:
-        super().__init__()
-        # Typed ``Any``: transformers stubs miss several ``SiglipProcessor.__call__``
-        # kwargs we pass at runtime; runtime ``None`` checks guard the calls.
-        self._model: Any = None
-        self._processor: Any = None
-
-    # ------------------------------------------------------------------
-    # Identity
-    # ------------------------------------------------------------------
+    _label = "SigLIP"
+    # SigLIP was trained with fixed-length padding and no truncation.
+    _text_processor_kwargs: dict[str, Any] = {"padding": "max_length"}
 
     @property
     def name(self) -> str:
@@ -59,16 +44,8 @@ class ImageSiglipEmbedder(MediaEmbedder):
         return SIGLIP_MODEL_ID
 
     @property
-    def media_type_id(self) -> str:
-        return "image"
-
-    @property
     def is_default(self) -> bool:
         return True
-
-    # ------------------------------------------------------------------
-    # Model lifecycle
-    # ------------------------------------------------------------------
 
     def _load_models_impl(self) -> None:
         if self._model is not None:
@@ -109,110 +86,6 @@ class ImageSiglipEmbedder(MediaEmbedder):
                 SiglipTokenizer.from_pretrained, SIGLIP_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
             self._processor = SiglipProcessor(image_processor=image_processor, tokenizer=tokenizer)
-
-    # ------------------------------------------------------------------
-    # Embedding
-    # ------------------------------------------------------------------
-
-    @property
-    def description_wrappers(self) -> list[str]:
-        return [
-            "a photo of {text}",
-            "a photograph of {text}",
-            "an image of {text}",
-            "{text}",
-            "a picture of {text}",
-        ]
-
-    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return None
-        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
-
-        source = _pil_source_for(media)
-        if source is None:
-            return None
-        image = _load_pil(source)
-        if image is None:
-            return None
-        return self.embed_pil_image(image)
-
-    def embed_pil_image(self, image: Image.Image) -> Optional[np.ndarray]:
-        """Embed a PIL Image that is already in memory (e.g. from CIFAR-10)."""
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return None
-        try:
-            import torch  # noqa: PLC0415
-
-            image = image.convert("RGB")
-            inputs = self._processor(images=image, return_tensors="pt")
-            device = next(self._model.parameters()).device
-            inputs = {k: v.to(device) for k, v in inputs.items()}
-            with torch.no_grad():
-                outputs = self._model.get_image_features(**inputs)
-                embedding = _extract_tensor(outputs).detach().cpu().numpy()
-            return embedding[0]
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding PIL image")
-            return None
-
-    def _forward_pil_batch(self, images: list[Image.Image]) -> np.ndarray:
-        """Run SigLIP's vision encoder on a list of PIL images.
-
-        Returns an ``(N, 768)`` array.  Caller is responsible for batch
-        sizing - this runs the whole list in one forward pass.
-        """
-        import torch  # noqa: PLC0415
-
-        rgb = [im.convert("RGB") for im in images]
-        inputs = self._processor(images=rgb, return_tensors="pt")
-        device = next(self._model.parameters()).device
-        inputs = {k: v.to(device) for k, v in inputs.items()}
-        with torch.no_grad():
-            outputs = self._model.get_image_features(**inputs)
-            return _extract_tensor(outputs).detach().cpu().numpy()
-
-    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return [None] * len(medias)
-        with self._embed_lock:
-            return bulk_embed_image_files(
-                medias,
-                forward_pil_batch=self._forward_pil_batch,
-                batch_size=self.embed_batch_size,
-                on_progress=self._on_progress,
-                label="SigLIP",
-            )
-
-    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return None
-        try:
-            import torch  # noqa: PLC0415
-
-            inputs = self._processor(text=[text], return_tensors="pt", padding="max_length")
-            device = next(self._model.parameters()).device
-            inputs = {k: v.to(device) for k, v in inputs.items()}
-            with torch.no_grad():
-                text_vec = _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
-            return text_vec
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding text query for image (SigLIP)")
-            return None
-
-    # Internal helper used by loader.py bridge
-    def _get_model_and_processor(self):
-        if self._model is None:
-            self.load_models()
-        return self._model, self._processor
 
 
 EMBEDDER = ImageSiglipEmbedder()

--- a/vtscore/media/image/embedder_siglip2.py
+++ b/vtscore/media/image/embedder_siglip2.py
@@ -7,17 +7,12 @@ the embedder loads on any ``transformers`` version that ships SigLIP 2 support
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any, Optional
-
-import numpy as np
+from typing import Any
 
 from vtscore.config import SIGLIP2_MODEL_ID
 from vtscore.media.embedder import (
     IMPORT_MODULE_ESTIMATES,
-    MediaEmbedder,
     embedder_load_setup,
-    extract_tensor as _extract_tensor,
     hf_token,
     intercept_tqdm_progress,
     intercept_weight_loading_progress,
@@ -25,13 +20,10 @@ from vtscore.media.embedder import (
     timed_progress,
     to_compute_device,
 )
-from vtscore.media.image._image_bulk import bulk_embed_image_files
-
-if TYPE_CHECKING:
-    from PIL import Image
+from vtscore.media.image._cross_modal_shared import _CrossModalHFEmbedder
 
 
-class ImageSiglip2Embedder(MediaEmbedder):
+class ImageSiglip2Embedder(_CrossModalHFEmbedder):
     """Embeds images using SigLIP 2 (google/siglip2-base-patch16-224).
 
     Successor to SigLIP with stronger transfer performance. Same 768-dim output
@@ -39,12 +31,8 @@ class ImageSiglip2Embedder(MediaEmbedder):
     queries, mirroring :class:`ImageSiglipEmbedder` so callers can swap.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
-        # Typed ``Any``: transformers stubs miss several processor kwargs we
-        # pass at runtime; runtime ``None`` checks guard the calls.
-        self._model: Any = None
-        self._processor: Any = None
+    _label = "SigLIP 2"
+    _text_processor_kwargs: dict[str, Any] = {"padding": "max_length", "truncation": True}
 
     @property
     def name(self) -> str:
@@ -57,10 +45,6 @@ class ImageSiglip2Embedder(MediaEmbedder):
     @property
     def model_id(self) -> str:
         return SIGLIP2_MODEL_ID
-
-    @property
-    def media_type_id(self) -> str:
-        return "image"
 
     def _load_models_impl(self) -> None:
         if self._model is not None:
@@ -95,94 +79,6 @@ class ImageSiglip2Embedder(MediaEmbedder):
             self._processor = load_pretrained_local_first(
                 AutoProcessor.from_pretrained, SIGLIP2_MODEL_ID, cache_dir=cache_dir, token=hf_token()
             )
-
-    @property
-    def description_wrappers(self) -> list[str]:
-        return [
-            "a photo of {text}",
-            "a photograph of {text}",
-            "an image of {text}",
-            "{text}",
-            "a picture of {text}",
-        ]
-
-    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return None
-        from vtscore.media.image._image_bulk import _load_pil, _pil_source_for  # noqa: PLC0415
-
-        source = _pil_source_for(media)
-        if source is None:
-            return None
-        image = _load_pil(source)
-        if image is None:
-            return None
-        return self.embed_pil_image(image)
-
-    def embed_pil_image(self, image: Image.Image) -> Optional[np.ndarray]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return None
-        try:
-            import torch  # noqa: PLC0415
-
-            image = image.convert("RGB")
-            inputs = self._processor(images=image, return_tensors="pt")
-            device = next(self._model.parameters()).device
-            inputs = {k: v.to(device) for k, v in inputs.items()}
-            with torch.no_grad():
-                outputs = self._model.get_image_features(**inputs)
-                embedding = _extract_tensor(outputs).detach().cpu().numpy()
-            return embedding[0]
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding PIL image (SigLIP 2)")
-            return None
-
-    def _forward_pil_batch(self, images: list[Image.Image]) -> np.ndarray:
-        import torch  # noqa: PLC0415
-
-        rgb = [im.convert("RGB") for im in images]
-        inputs = self._processor(images=rgb, return_tensors="pt")
-        device = next(self._model.parameters()).device
-        inputs = {k: v.to(device) for k, v in inputs.items()}
-        with torch.no_grad():
-            outputs = self._model.get_image_features(**inputs)
-            return _extract_tensor(outputs).detach().cpu().numpy()
-
-    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[Optional[np.ndarray]]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return [None] * len(medias)
-        with self._embed_lock:
-            return bulk_embed_image_files(
-                medias,
-                forward_pil_batch=self._forward_pil_batch,
-                batch_size=self.embed_batch_size,
-                on_progress=self._on_progress,
-                label="SigLIP 2",
-            )
-
-    def _embed_text_impl(self, text: str) -> Optional[np.ndarray]:
-        if self._model is None:
-            self.load_models()
-        if self._model is None or self._processor is None:
-            return None
-        try:
-            import torch  # noqa: PLC0415
-
-            inputs = self._processor(text=[text], return_tensors="pt", padding="max_length", truncation=True)
-            device = next(self._model.parameters()).device
-            inputs = {k: v.to(device) for k, v in inputs.items()}
-            with torch.no_grad():
-                text_vec = _extract_tensor(self._model.get_text_features(**inputs)).detach().cpu().numpy()[0]
-            return text_vec
-        except Exception:
-            logging.getLogger(__name__).exception("Error embedding text query for image (SigLIP 2)")
-            return None
 
 
 EMBEDDER = ImageSiglip2Embedder()


### PR DESCRIPTION
Closes #2651

`ImageSiglipEmbedder`, `ImageSiglip2Embedder`, and `ImageClipEmbedder` each re-implemented the full cross-modal surface (~360 duplicated lines). This extracts a `_CrossModalHFEmbedder` base in `vtscore/media/image/_cross_modal_shared.py` (underscore-prefixed so it stays out of the `embedder*.py` plugin auto-discovery scan, matching `_dinov2_shared.py` et al.).

**Moved into the base** (byte-identical across the three): `__init__`, `media_type_id`, `description_wrappers`, `_embed_media_impl`, `embed_pil_image`, `_forward_pil_batch`, `_embed_media_bulk_impl`, `_embed_text_impl`, and the `_get_model_and_processor` bridge helper.

**Parameterized, not flattened** (the genuine divergence the issue flagged):
- `_load_models_impl` stays a per-subclass override — SigLIP hand-assembles `SiglipProcessor` from `SiglipImageProcessor` + `SiglipTokenizer` on a concrete `SiglipModel`; SigLIP2 uses `AutoModel`/`AutoProcessor`; CLIP uses `CLIPModel`/`CLIPProcessor`. All three loader bodies are unchanged.
- `_text_processor_kwargs` class attr carries the per-backbone tokenization contract verbatim: SigLIP `{"padding": "max_length"}`, SigLIP2 `{"padding": "max_length", "truncation": True}`, CLIP `{"padding": True, "truncation": True}`.
- `_label` class attr feeds the bulk-embed progress label and log messages.

`ImageSiglipLEmbedder` (open_clip runtime path) is untouched, per the issue's out-of-scope note. The forward passes and processor calls are copied verbatim, so produced embeddings are unchanged.

One test needed updating: `test_routes_through_bulk_helper` patched `bulk_embed_image_files` at `embedder_siglip` module level; the call site now lives in `_cross_modal_shared`, so the patch target moved with it (it still asserts the SigLIP-labeled bulk routing).

Net −180 lines. Verified with `./run-tests.sh detectors` and the full `./run-tests.sh` (all 6535 tests pass, plus ruff/pyright/frontend gates).

The issue's separate note about a cross-backbone `_SinglePatchBase` consolidation remains a follow-up and is not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnFvryWgWdTBNA92kCqv3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnFvryWgWdTBNA92kCqv3Q)_