### PR TITLE
Absorb residual per-format archive filtering loops into _extract_archive

### DIFF
--- a/tests_lib/downloads/test_clotho_download.py
+++ b/tests_lib/downloads/test_clotho_download.py
@@ -103,7 +103,7 @@ class TestDownloadClotho:
         def fake_download(url, dest, size, cb):
             Path(dest).write_bytes(_SEVENZIP_HEADER)
 
-        def fake_extract(archive_path, archive_name, dest_dir, dataset_name, on_progress):
+        def fake_extract(archive_path, archive_name, dest_dir, dataset_name, on_progress, **kwargs):
             # Stand in for the real .7z extraction: lay down evaluation/*.wav.
             eval_dir = Path(dest_dir) / "evaluation"
             eval_dir.mkdir(parents=True, exist_ok=True)

--- a/vtscore/datasets/downloader/audio.py
+++ b/vtscore/datasets/downloader/audio.py
@@ -1,9 +1,6 @@
 """Audio dataset downloaders: ESC-50, GTZAN, Speech Commands v2, UrbanSound8K,
 TUT Sound Events 2017, Clotho."""
 
-import shutil
-import uuid
-import zipfile
 from pathlib import Path
 from typing import Optional
 
@@ -221,24 +218,19 @@ def download_tut_sound_events_2017(on_progress: Optional[ProgressCallback] = Non
         if dest_dir.exists() and any(dest_dir.glob("*.wav")):
             continue  # This archive already extracted.
 
-        unique_id = uuid.uuid4().hex[:8]
-        zip_path = _core.DATA_DIR / f".dl_{unique_id}_tut_{slug}.zip"
-
-        try:
-            on_progress("downloading", f"Downloading TUT Sound Events 2017 ({slug})...", i, total)
-            _core.download_file_with_progress(url, zip_path, 0, on_progress)
-
-            on_progress("extracting", f"Extracting TUT Sound Events 2017 ({slug})...", i + 1, total)
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            with zipfile.ZipFile(zip_path, "r") as zf:
-                for member in zf.namelist():
-                    # Extract only the audio, flattened into the archive's dir.
-                    if member.lower().endswith(".wav"):
-                        dest = dest_dir / Path(member).name
-                        if not dest.exists():
-                            with zf.open(member) as src, open(dest, "wb") as dst:
-                                shutil.copyfileobj(src, dst)
-        finally:
-            zip_path.unlink(missing_ok=True)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        _core._download_and_extract(
+            url=url,
+            archive_name=f"tut_{slug}.zip",
+            extract_to=dest_dir,
+            check_path=dest_dir,
+            is_complete=lambda dest_dir=dest_dir: any(dest_dir.glob("*.wav")),
+            download_size_mb=0,
+            dataset_name=f"TUT Sound Events 2017 ({slug})",
+            on_progress=on_progress,
+            member_filter=lambda m: m.lower().endswith(".wav"),
+            flatten=True,
+        )
+        on_progress("extracting", f"Extracted TUT Sound Events 2017 ({slug})...", i + 1, total)
 
     return base

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -14,7 +14,7 @@ import time
 import uuid
 import zipfile
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Literal, Optional
 from urllib.parse import urljoin
 
 import requests
@@ -641,7 +641,7 @@ def _extract_7z(archive_path: Path, dest_dir: Path, dataset_name: str, on_progre
 
 def _extract_tar(
     archive_path: Path,
-    mode: str,
+    mode: Literal["r:", "r:*"],
     dest_dir: Path,
     dataset_name: str,
     on_progress: ProgressCallback,

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -639,51 +639,113 @@ def _extract_7z(archive_path: Path, dest_dir: Path, dataset_name: str, on_progre
     on_progress("extracting", f"Extracting {dataset_name}...", 1, 1)
 
 
-def _extract_archive(
-    archive_path: Path, archive_name: str, dest_dir: Path, dataset_name: str, on_progress: ProgressCallback
+def _extract_tar(
+    archive_path: Path,
+    mode: str,
+    dest_dir: Path,
+    dataset_name: str,
+    on_progress: ProgressCallback,
+    member_filter: Optional[Callable[[str], bool]],
+    flatten: bool,
 ) -> None:
-    """Extract *archive_path* into *dest_dir*, dispatching by filename suffix.
+    # Iterate lazily instead of calling getmembers() - the latter must
+    # decompress the entire gzip stream just to read tar headers, then
+    # extraction decompresses it *again*.  Lazy iteration decompresses
+    # once and avoids a minutes-long stall on multi-GB archives.
+    total_bytes = archive_path.stat().st_size
+    with open(archive_path, "rb") as raw_f, tarfile.open(fileobj=raw_f, mode=mode) as tar_ref:
+        for i, member in enumerate(tar_ref):
+            if i % 100 == 0:
+                on_progress("extracting", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes)
+            if member_filter is not None and not member_filter(member.name):
+                continue
+            if not flatten:
+                safe_tar_extract(tar_ref, member, dest_dir)
+                continue
+            if member.isdir():
+                continue
+            src = tar_ref.extractfile(member)
+            if src is None:
+                continue
+            dest = Path(dest_dir) / Path(member.name).name
+            with src, open(dest, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+    on_progress("extracting", f"Extracting {dataset_name}...", total_bytes, total_bytes)
 
-    Supports ``.tar.gz`` / ``.tgz`` (gzip tar), ``.tar`` (uncompressed tar),
-    ``.zip``, and ``.7z`` archives.  Tar members go through
-    :func:`~vtscore.security.archive.safe_tar_extract` (which rejects unsafe
-    absolute/traversal/link paths); zip and 7z members are validated against
-    *dest_dir* to guard against path traversal (zip-slip).  Raises
-    ``ValueError`` for an unsupported archive format.
-    """
-    suffix = archive_name.lower()
-    if suffix.endswith((".tar.gz", ".tgz", ".tar")):
-        # Iterate lazily instead of calling getmembers() - the latter must
-        # decompress the entire gzip stream just to read tar headers, then
-        # extraction decompresses it *again*.  Lazy iteration decompresses
-        # once and avoids a minutes-long stall on multi-GB archives.
-        # Use "r:*" for gzip tars to auto-detect compression - some CDNs (e.g.
-        # HuggingFace Xet) transparently decompress .tar.gz files during transfer.
-        mode = "r:" if suffix.endswith(".tar") else "r:*"
-        total_bytes = archive_path.stat().st_size
-        with open(archive_path, "rb") as raw_f:
-            with tarfile.open(fileobj=raw_f, mode=mode) as tar_ref:
-                for i, member in enumerate(tar_ref):
-                    if i % 100 == 0:
-                        on_progress("extracting", f"Extracting {dataset_name}...", raw_f.tell(), total_bytes)
-                    safe_tar_extract(tar_ref, member, dest_dir)
-        on_progress("extracting", f"Extracting {dataset_name}...", total_bytes, total_bytes)
-    elif suffix.endswith(".zip"):
-        from vtscore.datasets.archive import _reject_traversal
 
-        dest_resolved = Path(dest_dir).resolve()
-        with zipfile.ZipFile(archive_path, "r") as zip_ref:
-            members = zip_ref.namelist()
-            total = len(members)
-            for i, member in enumerate(members):
-                if i % 100 == 0 or i == total - 1:
-                    on_progress("extracting", f"Extracting {dataset_name}...", i + 1, total)
+def _extract_zip(
+    archive_path: Path,
+    dest_dir: Path,
+    dataset_name: str,
+    on_progress: ProgressCallback,
+    member_filter: Optional[Callable[[str], bool]],
+    flatten: bool,
+) -> None:
+    from vtscore.datasets.archive import _reject_traversal
+
+    dest_resolved = Path(dest_dir).resolve()
+    with zipfile.ZipFile(archive_path, "r") as zip_ref:
+        members = zip_ref.namelist()
+        total = len(members)
+        for i, member in enumerate(members):
+            if i % 100 == 0 or i == total - 1:
+                on_progress("extracting", f"Extracting {dataset_name}...", i + 1, total)
+            if member_filter is not None and not member_filter(member):
+                continue
+            if not flatten:
                 # Guard against path traversal in zip entries.  Shares the
                 # strict check with archive.py: the previous inline
                 # startswith() prefix test lacked a trailing separator, so
                 # a sibling dir with the dest as a name prefix passed.
                 _reject_traversal(dest_resolved, member)
                 zip_ref.extract(member, dest_dir)
+                continue
+            if member.endswith("/"):
+                continue
+            dest = Path(dest_dir) / Path(member).name
+            with zip_ref.open(member) as src, open(dest, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+
+
+def _extract_archive(
+    archive_path: Path,
+    archive_name: str,
+    dest_dir: Path,
+    dataset_name: str,
+    on_progress: ProgressCallback,
+    *,
+    member_filter: Optional[Callable[[str], bool]] = None,
+    flatten: bool = False,
+) -> None:
+    """Extract *archive_path* into *dest_dir*, dispatching by filename suffix.
+
+    Supports ``.tar.gz`` / ``.tgz`` (gzip tar), ``.tar`` (uncompressed tar),
+    ``.zip``, and ``.7z`` archives.  Tar members go through
+    :func:`~vtscore.security.archive.safe_tar_extract` (which rejects unsafe
+    absolute/traversal/link paths); zip members are validated against
+    *dest_dir* to guard against path traversal (zip-slip).  Raises
+    ``ValueError`` for an unsupported archive format.
+
+    Args:
+        member_filter: Optional predicate on the member's archive path (e.g.
+            ``lambda m: m.lower().endswith(".wav")``).  Members for which it
+            returns ``False`` are skipped entirely.  Ignored for ``.7z``
+            (only the common zip/tar downloaders that need filtering use it).
+        flatten: When ``True``, every extracted member is written directly
+            into *dest_dir* under its basename (``Path(member).name``),
+            discarding any directory structure inside the archive.  Because
+            only the basename is used, traversal is not a concern for
+            flattened members.  Directory entries are skipped.  Ignored for
+            ``.7z``.
+    """
+    suffix = archive_name.lower()
+    if suffix.endswith((".tar.gz", ".tgz", ".tar")):
+        # Use "r:*" for gzip tars to auto-detect compression - some CDNs (e.g.
+        # HuggingFace Xet) transparently decompress .tar.gz files during transfer.
+        mode = "r:" if suffix.endswith(".tar") else "r:*"
+        _extract_tar(archive_path, mode, dest_dir, dataset_name, on_progress, member_filter, flatten)
+    elif suffix.endswith(".zip"):
+        _extract_zip(archive_path, dest_dir, dataset_name, on_progress, member_filter, flatten)
     elif suffix.endswith(".7z"):
         _extract_7z(archive_path, dest_dir, dataset_name, on_progress)
     else:
@@ -700,6 +762,8 @@ def _download_and_extract(
     dataset_name: str,
     on_progress: ProgressCallback,
     is_complete: Optional[Callable[[], bool]] = None,
+    member_filter: Optional[Callable[[str], bool]] = None,
+    flatten: bool = False,
 ) -> None:
     """Download an archive and extract it unless it is already complete.
 
@@ -739,6 +803,9 @@ def _download_and_extract(
             otherwise be a false positive that blocks re-download: the predicate
             can require the expected content (labeled images, etc.) to be
             present rather than merely that a path exists.
+        member_filter: Optional per-member predicate forwarded to
+            :func:`_extract_archive`; see its docstring.
+        flatten: Forwarded to :func:`_extract_archive`; see its docstring.
     """
 
     def _complete() -> bool:
@@ -777,7 +844,15 @@ def _download_and_extract(
         on_progress("extracting", f"Extracting {dataset_name}...", 0, 0)
         temp_extract.mkdir(parents=True, exist_ok=True)
 
-        _extract_archive(temp_archive, archive_name, temp_extract, dataset_name, on_progress)
+        _extract_archive(
+            temp_archive,
+            archive_name,
+            temp_extract,
+            dataset_name,
+            on_progress,
+            member_filter=member_filter,
+            flatten=flatten,
+        )
 
         # Another download may have finished while we were extracting.
         if _complete():

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -741,13 +741,20 @@ def download_places365(on_progress: Optional[ProgressCallback] = None) -> Path:
                 _core.PLACES365_LABELS_FILELIST_SIZE_MB * 1024 * 1024,
                 on_progress,
             )
-            with tarfile.open(filelist_archive, "r") as tar:
-                member = tar.getmember("places365_val.txt")
-                src = tar.extractfile(member)
-                if src is None:
-                    raise RuntimeError("places365_val.txt not extractable from filelist tar")
-                with open(labels_path, "wb") as dst:
-                    shutil.copyfileobj(src, dst)
+            # The filelist tarball bundles the whole train/val/test/category
+            # set; extract only the val label file we need, flattened directly
+            # to labels_path.
+            _core._extract_archive(
+                filelist_archive,
+                "places365_filelist.tar",
+                extract_dir,
+                "Places365 labels",
+                on_progress,
+                member_filter=lambda m: m.endswith("places365_val.txt"),
+                flatten=True,
+            )
+            if not labels_path.exists():
+                raise RuntimeError("places365_val.txt not extractable from filelist tar")
         finally:
             if filelist_archive.exists():
                 filelist_archive.unlink()

--- a/vtscore/datasets/downloader/text.py
+++ b/vtscore/datasets/downloader/text.py
@@ -7,7 +7,6 @@ import re
 import shutil
 import time
 import uuid
-import zipfile
 from pathlib import Path
 from typing import Any, Optional, cast
 from urllib.parse import urlencode
@@ -199,23 +198,11 @@ def _ensure_bbc_extracted(extract_dir: Path, on_progress: ProgressCallback) -> N
         )
 
         if not extract_dir.exists():
-            on_progress("extracting", "Extracting BBC News dataset...", 0, 0)
             raw_dir = temp_extract / "raw"
             raw_dir.mkdir(parents=True, exist_ok=True)
-            with zipfile.ZipFile(temp_archive, "r") as zip_ref:
-                # The zip may contain a top-level folder (e.g. "bbc/"); extract
-                # all members and then locate category directories below.
-                members = zip_ref.namelist()
-                total = len(members)
-                for i, member in enumerate(members):
-                    if i % 100 == 0 or i == total - 1:
-                        on_progress(
-                            "extracting",
-                            "Extracting BBC News dataset...",
-                            i + 1,
-                            total,
-                        )
-                    zip_ref.extract(member, raw_dir)
+            # The zip may contain a top-level folder (e.g. "bbc/"); extract
+            # all members and then locate category directories below.
+            _core._extract_archive(temp_archive, "bbc-fulltext.zip", raw_dir, "BBC News dataset", on_progress)
 
             # Find the directory that contains the category subfolders.
             _bbc_root = _find_bbc_root(raw_dir)

--- a/vtscore/datasets/downloader/video.py
+++ b/vtscore/datasets/downloader/video.py
@@ -205,30 +205,19 @@ def download_kth(on_progress: Optional[ProgressCallback] = None) -> Path:
         if cat_dir.exists() and any(cat_dir.glob("*.avi")):
             continue  # This action already extracted.
 
-        import uuid
-        import zipfile
-
-        unique_id = uuid.uuid4().hex[:8]
-        zip_name = f"{action}.zip"
-        zip_path = _core.DATA_DIR / f".dl_{unique_id}_{zip_name}"
-
-        try:
-            url = f"{_core.KTH_BASE_URL}{zip_name}"
-            on_progress("downloading", f"Downloading KTH {action}...", i, total)
-            _core.download_file_with_progress(url, zip_path, 0, on_progress)
-
-            on_progress("extracting", f"Extracting KTH {action}...", i + 1, total)
-            cat_dir.mkdir(parents=True, exist_ok=True)
-            with zipfile.ZipFile(zip_path, "r") as zf:
-                for member in zf.namelist():
-                    # Extract only .avi files, into the category directory.
-                    if member.lower().endswith(".avi"):
-                        basename = Path(member).name
-                        dest = cat_dir / basename
-                        if not dest.exists():
-                            with zf.open(member) as src, open(dest, "wb") as dst:
-                                shutil.copyfileobj(src, dst)
-        finally:
-            zip_path.unlink(missing_ok=True)
+        cat_dir.mkdir(parents=True, exist_ok=True)
+        _core._download_and_extract(
+            url=f"{_core.KTH_BASE_URL}{action}.zip",
+            archive_name=f"{action}.zip",
+            extract_to=cat_dir,
+            check_path=cat_dir,
+            is_complete=lambda cat_dir=cat_dir: any(cat_dir.glob("*.avi")),
+            download_size_mb=0,
+            dataset_name=f"KTH {action}",
+            on_progress=on_progress,
+            member_filter=lambda m: m.lower().endswith(".avi"),
+            flatten=True,
+        )
+        on_progress("extracting", f"Extracted KTH {action}...", i + 1, total)
 
     return video_dir


### PR DESCRIPTION
## Summary
- Add optional `member_filter` (predicate on archive member path) and `flatten` (write extracted members directly into `dest_dir` by basename) parameters to `_extract_archive` / `_download_and_extract` in `vtscore/datasets/downloader/core.py`.
- Delegate the four hand-rolled zip/tar filtering loops to the shared helper, removing the duplicated temp-name + `try/finally`-unlink + progress-every-100 scaffolding:
  - `download_tut_sound_events_2017` (`downloader/audio.py`) — filters `*.wav`, flattened.
  - `download_kth` (`downloader/video.py`) — filters `*.avi`, flattened.
  - `_ensure_bbc_extracted` (`downloader/text.py`) — full-archive extract, no filter needed.
  - `download_places365` label fetch (`downloader/images.py`) — filters `places365_val.txt`, flattened directly to the destination filename.
- `download_caltech101`'s nested zip-then-tar flow is left bespoke, as scoped by the issue.
- Split `_extract_archive`'s tar/zip branches into `_extract_tar` / `_extract_zip` helpers to keep cyclomatic complexity under the `ruff` C901 threshold.

## Test plan
- [x] `./run-tests.sh downloads`
- [x] `./run-tests.sh` (full suite)

Closes #2652


---
_Generated by [Claude Code](https://claude.ai/code/session_01TS7EWhCi3PTK6KbL5SUyU4)_