### PR TITLE
Extract app.py request-lifecycle hooks and error handlers into hooks.py / errors.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import warnings
 
@@ -16,7 +15,7 @@ os.environ["MKL_NUM_THREADS"] = _torch_threads
 # request_id / dataset_id / detector_id / user fields. Override via:
 #   VTSEARCH_LOG_LEVEL=INFO   (default WARNING)
 #   VTSEARCH_LOG_FORMAT=text  (default json; switch to text for local dev)
-from vtsearch.logging_config import new_request_id, setup_logging  # noqa: E402
+from vtsearch.logging_config import setup_logging  # noqa: E402
 
 setup_logging()
 
@@ -36,12 +35,9 @@ warnings.filterwarnings("ignore", message=".*HF_TOKEN.*")
 # Visual feedback for startup
 print(f"⏳ Initializing VTSearch... (PID {os.getpid()})", flush=True)
 
-from flask import Flask, g
-from werkzeug.exceptions import MethodNotAllowed, NotFound
+from flask import Flask
 
 # Import refactored modules
-from vtscore.state.core import DatasetNotLoadedError, DetectorNotLoadedError  # noqa: E402
-from vtsearch.auth import get_login_provider  # noqa: E402
 from vtscore.embedding import initialize_models, preload_predicted_embedders  # noqa: E402
 
 # Install Flask-aware request-context resolvers on the (library-candidate)
@@ -204,315 +200,18 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# Per-request user context
+# Request-lifecycle hooks and global JSON error handlers
 # ---------------------------------------------------------------------------
+# Both live in their own modules (``vtsearch.hooks`` / ``vtsearch.errors``);
+# registration is decorator-based on this module-level ``app``, so each
+# module exposes a ``register_*`` function that wires its handlers on in the
+# original order.
 
+from vtsearch.errors import register_error_handlers  # noqa: E402
+from vtsearch.hooks import register_hooks  # noqa: E402
 
-@app.before_request
-def _set_request_id():
-    """Assign a unique request id to every request.
-
-    The id is exposed on ``g.request_id`` so log records produced during
-    the request automatically carry it (via the structured-logging
-    ContextFilter), and echoed back in the ``X-Request-Id`` response
-    header so clients can quote it in bug reports. If the caller supplied
-    their own ``X-Request-Id`` header we trust it (truncated to 64 chars
-    to bound log line size), which lets gateways/load balancers propagate
-    end-to-end trace ids.
-    """
-    from flask import request
-
-    inbound = request.headers.get("X-Request-Id")
-    g.request_id = inbound[:64] if inbound else new_request_id()
-
-
-@app.before_request
-def _set_user_context():
-    """Populate ``g.user`` from the active LoginProvider on every request.
-
-    A misbehaving provider must not be able to take down the server by
-    raising from ``get_user``; swallow exceptions and fall back to
-    ``"default"``.
-    """
-    from flask import request
-
-    try:
-        provider = get_login_provider()
-        g.user = provider.get_user(request)
-    except Exception:
-        logging.getLogger(__name__).exception("Login provider get_user failed")
-        g.user = "default"
-
-
-# Endpoints whose handlers never read the dataset/detector proxies do not
-# need the lock-taking state-sync in `_set_request_context` below. Keeping
-# them off `_state_lock` stops a high-frequency poll (e.g. the jobs/active
-# spinner feed) from piling up behind a long lock-holder and exhausting
-# the worker's threads (2026-06-19: one stuck job parked 23 threads on
-# the futex and froze the whole UI).
-#
-# `/api/events` is the SSE progress stream: a long-lived, read-only request
-# that only subscribes to the *global* progress trackers and yields their
-# snapshots. It needs no per-request vote rehydration, and gating it on
-# `_state_lock` is self-defeating — while a long Find/load holds the worker
-# busy, the EventSource's reconnect would block in this hook on the very
-# lock the long job contends, so progress events never reach the client and
-# the bar sits indeterminate. Exempting it keeps progress flowing during
-# exactly the long operations the bar exists to report.
-_STATE_SYNC_EXEMPT_PREFIXES = ("/api/jobs/active", "/api/events")
-
-
-@app.before_request
-def _set_request_context():
-    """Resolve per-request dataset/detector context from HTTP headers.
-
-    If the frontend sends ``X-Dataset-Id`` or ``X-Detector-Id``, the
-    corresponding context is stashed on ``g`` so that proxy objects
-    (``medias``, ``good_votes``, etc.) resolve to it for the duration of
-    this request, without mutating global "active" state.
-
-    When a header is absent the proxies fall back to the thread-local /
-    empty context. When a header is **present but names an unloaded id**,
-    the unloaded id is stashed on ``g`` so the resolver raises
-    ``DatasetNotLoadedError`` / ``DetectorNotLoadedError`` on proxy
-    access (mapped to 409). Routes that never touch the proxies still
-    respond normally (see logical-bug-audit H16).
-
-    Any failure here must not 500 every subsequent request; fall back to
-    the default (empty) context.
-    """
-    from flask import request
-    from vtscore.state.core import (
-        get_context,
-        get_detector_context,
-    )
-
-    # Pin a marker so the request-missing-context predicate can distinguish
-    # "actively inside a route handler" from "Flask test client is still
-    # preserving the popped request context for inspection". Cleared in
-    # teardown_request below.
-    g._vts_in_request_handler = True
-
-    try:
-        # Headers (Angular HttpClient interceptor) take priority, with query
-        # params as fallback for browser-native requests (<img src>,
-        # <audio src>, <video src>) that bypass Angular's interceptor.
-        ds_id = request.headers.get("X-Dataset-Id") or request.args.get("dataset_id")
-        if ds_id:
-            ctx = get_context(ds_id)
-            if ctx is not None:
-                g._dataset_context = ctx
-            else:
-                # Header refers to a dataset that isn't loaded.  Stash the id
-                # so the resolver raises DatasetNotLoadedError at proxy
-                # access; silent fallback to the empty context hid stale
-                # results from the client (logical-bug-audit H16).  Routes
-                # that never touch the dataset proxies (registry listings,
-                # auth, file browser, etc.) still respond normally.
-                g._unloaded_dataset_id = ds_id
-
-        detector_id = request.headers.get("X-Detector-Id") or request.args.get("detector_id")
-        if detector_id:
-            det_ctx = get_detector_context(detector_id)
-            if det_ctx is not None:
-                g._detector_context = det_ctx
-            else:
-                g._unloaded_detector_id = detector_id
-    except Exception:
-        logging.getLogger(__name__).exception("Request context resolution failed")
-
-    # If the active (dataset, detector) pair has changed since the detector's
-    # cid-keyed vote dicts were last derived, rehydrate them from the on-disk
-    # labelset against the active dataset's medias.  Media ids are dataset-
-    # specific, so without this the left-pane shows stale cids from the
-    # previous dataset as if they were votes in the current one.
-    #
-    # Also drop the detector's cached MLP / per-label embedding cache when
-    # the active dataset's embedder differs from the one the MLP was
-    # trained on; scoring with a cross-space MLP either crashes (different
-    # dim) or silently produces garbage labels (same dim).  See
-    # logical-bug-audit H5.
-    # Skip the lock-taking state-sync for endpoints whose handlers never
-    # read the proxies (e.g. the jobs/active spinner poll), so a frequent
-    # poll cannot queue on `_state_lock` behind a long-running job.
-    if not request.path.startswith(_STATE_SYNC_EXEMPT_PREFIXES):
-        try:
-            from vtscore.detectors.dataset_sync import (
-                ensure_detector_model_matches_active_embedder,
-                ensure_votes_match_active_dataset,
-            )
-
-            ensure_votes_match_active_dataset()
-            ensure_detector_model_matches_active_embedder()
-        except (DatasetNotLoadedError, DetectorNotLoadedError):
-            # The route handler will hit the same error when it touches
-            # the proxies; the global error handler turns it into a 409.
-            pass
-        except Exception:
-            logging.getLogger(__name__).exception("Vote rehydrate failed")
-
-
-# ---------------------------------------------------------------------------
-# Prevent browser caching of API responses
-# ---------------------------------------------------------------------------
-
-
-@app.teardown_request
-def _clear_in_request_handler_marker(exc):  # noqa: ARG001
-    """Clear the in-handler marker so the request-missing predicate
-    doesn't fire while Flask's test client is preserving a popped
-    request context after the response."""
-    from flask import g, has_request_context
-
-    if has_request_context():
-        g._vts_in_request_handler = False
-
-
-@app.after_request
-def _no_cache_api(response):
-    """Prevent browsers from caching mutable API responses.
-
-    Without this, concurrent or rapid-fire fetches to the same endpoint
-    (e.g. ``/api/datasets/registry``) can receive stale cached data,
-    causing the frontend to miss newly loaded datasets.
-
-    Endpoints serving genuinely immutable data (e.g. frozen projection
-    tiles) opt out by setting their own ``Cache-Control`` in the view; we
-    defer to that rather than clobbering it with ``no-store``.
-    """
-    from flask import request
-
-    if request.path.startswith("/api/") and "Cache-Control" not in response.headers:
-        response.headers["Cache-Control"] = "no-store"
-    return response
-
-
-@app.after_request
-def _echo_request_id(response):
-    """Surface the per-request id on every response so clients can quote it."""
-    rid = getattr(g, "request_id", None)
-    if rid:
-        response.headers["X-Request-Id"] = rid
-    return response
-
-
-# ---------------------------------------------------------------------------
-# Global JSON error handlers
-# ---------------------------------------------------------------------------
-
-
-@app.errorhandler(NotFound)
-def _handle_404(exc):
-    """JSON 404 for unknown ``/api/`` paths.
-
-    Werkzeug's default 404 renders as HTML, which is awful for an SPA. The
-    frontend ``ErrorService`` needs JSON to show a useful banner with the
-    request_id. Non-API paths fall through to the SPA's catch-all route
-    (which serves index.html for client-side routing).
-
-    Scoped to ``NotFound`` specifically so flask-smorest's own
-    ``HTTPException`` handler (which renders ``{message, errors}`` for
-    marshmallow validation failures and custom ``abort()`` calls) keeps
-    handling 400/422/etc.; Flask resolves the most specific exception
-    class first.
-    """
-    from flask import request as _req
-    from vtsearch.routes._shared import error_response
-
-    if not _req.path.startswith("/api/"):
-        return exc
-    return error_response(exc.name, 404)
-
-
-@app.errorhandler(MethodNotAllowed)
-def _handle_405(exc):
-    """JSON 405 for wrong-method requests on ``/api/`` paths. See _handle_404."""
-    from flask import request as _req
-    from vtsearch.routes._shared import error_response
-
-    if not _req.path.startswith("/api/"):
-        return exc
-    return error_response(exc.name, 405)
-
-
-@app.errorhandler(DatasetNotLoadedError)
-def _handle_dataset_not_loaded(exc):
-    """Return a JSON 409 when ``X-Dataset-Id`` names an unloaded dataset.
-
-    Raised by the Flask resolver when a route handler touches the
-    dataset proxies and the header doesn't resolve to a loaded context.
-    Replaces the silent fallback to the empty context that returned 200
-    with stale data (logical-bug-audit H16). The frontend can
-    distinguish 409 + ``code="dataset_not_loaded"`` from a generic 500
-    and offer a load action.
-    """
-    from vtsearch.routes._shared import error_response
-
-    return error_response(
-        "Dataset is not loaded",
-        409,
-        dataset_id=exc.dataset_id,
-        code="dataset_not_loaded",
-    )
-
-
-@app.errorhandler(DetectorNotLoadedError)
-def _handle_detector_not_loaded(exc):
-    """Detector counterpart of :func:`_handle_dataset_not_loaded` (H16/H34)."""
-    from vtsearch.routes._shared import error_response
-
-    return error_response(
-        "Detector is not loaded",
-        409,
-        detector_id=exc.detector_id,
-        code="detector_not_loaded",
-    )
-
-
-from vtscore.state.core import RequestMissingContextError as _RequestMissingContextError
-
-
-@app.errorhandler(_RequestMissingContextError)
-def _handle_request_missing_context(exc):
-    """Convert ``RequestMissingContextError`` into a clean 400.
-
-    Raised by the frozen ``_RequestMissingDatasetContext`` /
-    ``_RequestMissingDetectorContext`` sentinels when a mutation endpoint
-    was hit without an ``X-Dataset-Id`` / ``X-Detector-Id`` header and no
-    thread-local pinned context exists. The unloaded-id case is handled
-    separately by :func:`_handle_dataset_not_loaded` /
-    :func:`_handle_detector_not_loaded` (409 with a specific code). See
-    logical-bug-audit H13.
-    """
-    from flask import request as _req
-    from vtsearch.routes._shared import error_response
-
-    if not _req.path.startswith("/api/"):
-        raise exc
-    return error_response(str(exc), 400)
-
-
-@app.errorhandler(Exception)
-def _handle_uncaught_exception(exc):
-    """Return a standardized JSON 500 for any uncaught exception on /api/.
-
-    Without this, an unhandled exception in a route renders Flask's HTML
-    debug page (in dev) or a plain 500 (in prod), neither of which carries the
-    request_id the user needs to file a bug. ``HTTPException`` is
-    excluded so flask-smorest's own handler (and the 404/405 handlers
-    above) keep their semantics.
-    """
-    from werkzeug.exceptions import HTTPException as _HTTPException
-
-    if isinstance(exc, _HTTPException):
-        return exc
-    from flask import request as _req
-    from vtsearch.routes._shared import error_response, format_exception_detail
-
-    logging.getLogger(__name__).exception("Unhandled exception on %s %s", _req.method, _req.path)
-    if not _req.path.startswith("/api/"):
-        raise exc
-    return error_response("Internal server error", 500, detail=format_exception_detail(exc))
+register_hooks(app)
+register_error_handlers(app)
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/errors.py
+++ b/vtsearch/errors.py
@@ -1,0 +1,145 @@
+"""Global JSON error handlers for the VTSearch app.
+
+Holds the ``@app.errorhandler`` functions that used to live inline in
+``app.py``: JSON 404/405 for ``/api/`` paths, the dataset/detector
+not-loaded → 409 mappings, the request-missing-context → 400 mapping, and
+the catch-all uncaught-exception → 500.
+
+``app.py`` calls :func:`register_error_handlers` to wire them onto its
+module-level ``app``. Registration is explicit (rather than via
+``@app.errorhandler`` decorators at import time) so the order the handlers
+are registered in is preserved and obvious.
+"""
+
+import logging
+
+from werkzeug.exceptions import MethodNotAllowed, NotFound
+
+from vtscore.state.core import (
+    DatasetNotLoadedError,
+    DetectorNotLoadedError,
+    RequestMissingContextError,
+)
+
+
+def _handle_404(exc):
+    """JSON 404 for unknown ``/api/`` paths.
+
+    Werkzeug's default 404 renders as HTML, which is awful for an SPA. The
+    frontend ``ErrorService`` needs JSON to show a useful banner with the
+    request_id. Non-API paths fall through to the SPA's catch-all route
+    (which serves index.html for client-side routing).
+
+    Scoped to ``NotFound`` specifically so flask-smorest's own
+    ``HTTPException`` handler (which renders ``{message, errors}`` for
+    marshmallow validation failures and custom ``abort()`` calls) keeps
+    handling 400/422/etc.; Flask resolves the most specific exception
+    class first.
+    """
+    from flask import request as _req
+
+    from vtsearch.routes._shared import error_response
+
+    if not _req.path.startswith("/api/"):
+        return exc
+    return error_response(exc.name, 404)
+
+
+def _handle_405(exc):
+    """JSON 405 for wrong-method requests on ``/api/`` paths. See _handle_404."""
+    from flask import request as _req
+
+    from vtsearch.routes._shared import error_response
+
+    if not _req.path.startswith("/api/"):
+        return exc
+    return error_response(exc.name, 405)
+
+
+def _handle_dataset_not_loaded(exc):
+    """Return a JSON 409 when ``X-Dataset-Id`` names an unloaded dataset.
+
+    Raised by the Flask resolver when a route handler touches the
+    dataset proxies and the header doesn't resolve to a loaded context.
+    Replaces the silent fallback to the empty context that returned 200
+    with stale data (logical-bug-audit H16). The frontend can
+    distinguish 409 + ``code="dataset_not_loaded"`` from a generic 500
+    and offer a load action.
+    """
+    from vtsearch.routes._shared import error_response
+
+    return error_response(
+        "Dataset is not loaded",
+        409,
+        dataset_id=exc.dataset_id,
+        code="dataset_not_loaded",
+    )
+
+
+def _handle_detector_not_loaded(exc):
+    """Detector counterpart of :func:`_handle_dataset_not_loaded` (H16/H34)."""
+    from vtsearch.routes._shared import error_response
+
+    return error_response(
+        "Detector is not loaded",
+        409,
+        detector_id=exc.detector_id,
+        code="detector_not_loaded",
+    )
+
+
+def _handle_request_missing_context(exc):
+    """Convert ``RequestMissingContextError`` into a clean 400.
+
+    Raised by the frozen ``_RequestMissingDatasetContext`` /
+    ``_RequestMissingDetectorContext`` sentinels when a mutation endpoint
+    was hit without an ``X-Dataset-Id`` / ``X-Detector-Id`` header and no
+    thread-local pinned context exists. The unloaded-id case is handled
+    separately by :func:`_handle_dataset_not_loaded` /
+    :func:`_handle_detector_not_loaded` (409 with a specific code). See
+    logical-bug-audit H13.
+    """
+    from flask import request as _req
+
+    from vtsearch.routes._shared import error_response
+
+    if not _req.path.startswith("/api/"):
+        raise exc
+    return error_response(str(exc), 400)
+
+
+def _handle_uncaught_exception(exc):
+    """Return a standardized JSON 500 for any uncaught exception on /api/.
+
+    Without this, an unhandled exception in a route renders Flask's HTML
+    debug page (in dev) or a plain 500 (in prod), neither of which carries the
+    request_id the user needs to file a bug. ``HTTPException`` is
+    excluded so flask-smorest's own handler (and the 404/405 handlers
+    above) keep their semantics.
+    """
+    from werkzeug.exceptions import HTTPException as _HTTPException
+
+    if isinstance(exc, _HTTPException):
+        return exc
+    from flask import request as _req
+
+    from vtsearch.routes._shared import error_response, format_exception_detail
+
+    logging.getLogger(__name__).exception("Unhandled exception on %s %s", _req.method, _req.path)
+    if not _req.path.startswith("/api/"):
+        raise exc
+    return error_response("Internal server error", 500, detail=format_exception_detail(exc))
+
+
+def register_error_handlers(app) -> None:
+    """Register all global JSON error handlers on ``app``.
+
+    Registration order is preserved from the original inline
+    ``@app.errorhandler`` sequence in ``app.py``.
+    """
+    app.errorhandler(NotFound)(_handle_404)
+    app.errorhandler(MethodNotAllowed)(_handle_405)
+    app.errorhandler(DatasetNotLoadedError)(_handle_dataset_not_loaded)
+    app.errorhandler(DetectorNotLoadedError)(_handle_detector_not_loaded)
+    app.errorhandler(RequestMissingContextError)(_handle_request_missing_context)
+    app.errorhandler(Exception)(_handle_uncaught_exception)

--- a/vtsearch/hooks.py
+++ b/vtsearch/hooks.py
@@ -1,0 +1,215 @@
+"""Flask request-lifecycle hooks for the VTSearch app.
+
+Holds the ``before_request`` / ``after_request`` / ``teardown_request``
+handlers that used to live inline in ``app.py``: per-request id + user +
+dataset/detector context resolution, the in-handler marker, and the
+API-response ``Cache-Control`` / ``X-Request-Id`` shaping.
+
+``app.py`` calls :func:`register_hooks` to wire them onto its module-level
+``app``. Registration is done explicitly (rather than via ``@app.before_request``
+decorators at import time) so the ordering the handlers run in is preserved and
+obvious: Flask runs ``before_request`` handlers in registration order and
+``after_request`` / ``teardown_request`` handlers in reverse registration order.
+"""
+
+import logging
+
+from flask import g
+
+from vtsearch.logging_config import new_request_id
+
+# Endpoints whose handlers never read the dataset/detector proxies do not
+# need the lock-taking state-sync in `_set_request_context` below. Keeping
+# them off `_state_lock` stops a high-frequency poll (e.g. the jobs/active
+# spinner feed) from piling up behind a long lock-holder and exhausting
+# the worker's threads (2026-06-19: one stuck job parked 23 threads on
+# the futex and froze the whole UI).
+#
+# `/api/events` is the SSE progress stream: a long-lived, read-only request
+# that only subscribes to the *global* progress trackers and yields their
+# snapshots. It needs no per-request vote rehydration, and gating it on
+# `_state_lock` is self-defeating — while a long Find/load holds the worker
+# busy, the EventSource's reconnect would block in this hook on the very
+# lock the long job contends, so progress events never reach the client and
+# the bar sits indeterminate. Exempting it keeps progress flowing during
+# exactly the long operations the bar exists to report.
+_STATE_SYNC_EXEMPT_PREFIXES = ("/api/jobs/active", "/api/events")
+
+
+def _set_request_id():
+    """Assign a unique request id to every request.
+
+    The id is exposed on ``g.request_id`` so log records produced during
+    the request automatically carry it (via the structured-logging
+    ContextFilter), and echoed back in the ``X-Request-Id`` response
+    header so clients can quote it in bug reports. If the caller supplied
+    their own ``X-Request-Id`` header we trust it (truncated to 64 chars
+    to bound log line size), which lets gateways/load balancers propagate
+    end-to-end trace ids.
+    """
+    from flask import request
+
+    inbound = request.headers.get("X-Request-Id")
+    g.request_id = inbound[:64] if inbound else new_request_id()
+
+
+def _set_user_context():
+    """Populate ``g.user`` from the active LoginProvider on every request.
+
+    A misbehaving provider must not be able to take down the server by
+    raising from ``get_user``; swallow exceptions and fall back to
+    ``"default"``.
+    """
+    from flask import request
+
+    from vtsearch.auth import get_login_provider
+
+    try:
+        provider = get_login_provider()
+        g.user = provider.get_user(request)
+    except Exception:
+        logging.getLogger(__name__).exception("Login provider get_user failed")
+        g.user = "default"
+
+
+def _set_request_context():
+    """Resolve per-request dataset/detector context from HTTP headers.
+
+    If the frontend sends ``X-Dataset-Id`` or ``X-Detector-Id``, the
+    corresponding context is stashed on ``g`` so that proxy objects
+    (``medias``, ``good_votes``, etc.) resolve to it for the duration of
+    this request, without mutating global "active" state.
+
+    When a header is absent the proxies fall back to the thread-local /
+    empty context. When a header is **present but names an unloaded id**,
+    the unloaded id is stashed on ``g`` so the resolver raises
+    ``DatasetNotLoadedError`` / ``DetectorNotLoadedError`` on proxy
+    access (mapped to 409). Routes that never touch the proxies still
+    respond normally (see logical-bug-audit H16).
+
+    Any failure here must not 500 every subsequent request; fall back to
+    the default (empty) context.
+    """
+    from flask import request
+
+    from vtscore.state.core import (
+        DatasetNotLoadedError,
+        DetectorNotLoadedError,
+        get_context,
+        get_detector_context,
+    )
+
+    # Pin a marker so the request-missing-context predicate can distinguish
+    # "actively inside a route handler" from "Flask test client is still
+    # preserving the popped request context for inspection". Cleared in
+    # teardown_request below.
+    g._vts_in_request_handler = True
+
+    try:
+        # Headers (Angular HttpClient interceptor) take priority, with query
+        # params as fallback for browser-native requests (<img src>,
+        # <audio src>, <video src>) that bypass Angular's interceptor.
+        ds_id = request.headers.get("X-Dataset-Id") or request.args.get("dataset_id")
+        if ds_id:
+            ctx = get_context(ds_id)
+            if ctx is not None:
+                g._dataset_context = ctx
+            else:
+                # Header refers to a dataset that isn't loaded.  Stash the id
+                # so the resolver raises DatasetNotLoadedError at proxy
+                # access; silent fallback to the empty context hid stale
+                # results from the client (logical-bug-audit H16).  Routes
+                # that never touch the dataset proxies (registry listings,
+                # auth, file browser, etc.) still respond normally.
+                g._unloaded_dataset_id = ds_id
+
+        detector_id = request.headers.get("X-Detector-Id") or request.args.get("detector_id")
+        if detector_id:
+            det_ctx = get_detector_context(detector_id)
+            if det_ctx is not None:
+                g._detector_context = det_ctx
+            else:
+                g._unloaded_detector_id = detector_id
+    except Exception:
+        logging.getLogger(__name__).exception("Request context resolution failed")
+
+    # If the active (dataset, detector) pair has changed since the detector's
+    # cid-keyed vote dicts were last derived, rehydrate them from the on-disk
+    # labelset against the active dataset's medias.  Media ids are dataset-
+    # specific, so without this the left-pane shows stale cids from the
+    # previous dataset as if they were votes in the current one.
+    #
+    # Also drop the detector's cached MLP / per-label embedding cache when
+    # the active dataset's embedder differs from the one the MLP was
+    # trained on; scoring with a cross-space MLP either crashes (different
+    # dim) or silently produces garbage labels (same dim).  See
+    # logical-bug-audit H5.
+    # Skip the lock-taking state-sync for endpoints whose handlers never
+    # read the proxies (e.g. the jobs/active spinner poll), so a frequent
+    # poll cannot queue on `_state_lock` behind a long-running job.
+    if not request.path.startswith(_STATE_SYNC_EXEMPT_PREFIXES):
+        try:
+            from vtscore.detectors.dataset_sync import (
+                ensure_detector_model_matches_active_embedder,
+                ensure_votes_match_active_dataset,
+            )
+
+            ensure_votes_match_active_dataset()
+            ensure_detector_model_matches_active_embedder()
+        except (DatasetNotLoadedError, DetectorNotLoadedError):
+            # The route handler will hit the same error when it touches
+            # the proxies; the global error handler turns it into a 409.
+            pass
+        except Exception:
+            logging.getLogger(__name__).exception("Vote rehydrate failed")
+
+
+def _clear_in_request_handler_marker(exc):  # noqa: ARG001
+    """Clear the in-handler marker so the request-missing predicate
+    doesn't fire while Flask's test client is preserving a popped
+    request context after the response."""
+    from flask import g, has_request_context
+
+    if has_request_context():
+        g._vts_in_request_handler = False
+
+
+def _no_cache_api(response):
+    """Prevent browsers from caching mutable API responses.
+
+    Without this, concurrent or rapid-fire fetches to the same endpoint
+    (e.g. ``/api/datasets/registry``) can receive stale cached data,
+    causing the frontend to miss newly loaded datasets.
+
+    Endpoints serving genuinely immutable data (e.g. frozen projection
+    tiles) opt out by setting their own ``Cache-Control`` in the view; we
+    defer to that rather than clobbering it with ``no-store``.
+    """
+    from flask import request
+
+    if request.path.startswith("/api/") and "Cache-Control" not in response.headers:
+        response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+def _echo_request_id(response):
+    """Surface the per-request id on every response so clients can quote it."""
+    rid = getattr(g, "request_id", None)
+    if rid:
+        response.headers["X-Request-Id"] = rid
+    return response
+
+
+def register_hooks(app) -> None:
+    """Register all request-lifecycle hooks on ``app``.
+
+    Ordering is preserved from the original inline registration in
+    ``app.py``: ``before_request`` handlers fire in registration order,
+    ``after_request`` / ``teardown_request`` handlers in reverse.
+    """
+    app.before_request(_set_request_id)
+    app.before_request(_set_user_context)
+    app.before_request(_set_request_context)
+    app.teardown_request(_clear_in_request_handler_marker)
+    app.after_request(_no_cache_api)
+    app.after_request(_echo_request_id)


### PR DESCRIPTION
Splits ~300 lines of self-contained request-lifecycle and error-handling code out of `app.py` (was 667 lines) into two new modules.

## What moved

- **`vtsearch/hooks.py`** — the `before_request` / `after_request` / `teardown_request` handlers: `_set_request_id`, `_set_user_context`, `_set_request_context` (dataset/detector context resolution + state-sync/rehydrate), `_clear_in_request_handler_marker`, `_no_cache_api`, `_echo_request_id`, plus the `_STATE_SYNC_EXEMPT_PREFIXES` constant they use. Exposes `register_hooks(app)`.
- **`vtsearch/errors.py`** — the global JSON error handlers: `_handle_404`, `_handle_405`, `_handle_dataset_not_loaded` (409), `_handle_detector_not_loaded` (409), `_handle_request_missing_context` (400), `_handle_uncaught_exception` (500). Exposes `register_error_handlers(app)`.

`app.py` now imports and calls `register_hooks(app)` / `register_error_handlers(app)`. Registration is done explicitly (not via `@app.decorator` at import time) so the original ordering is preserved: `before_request` in registration order, `after_request` / `teardown_request` in reverse. Error-handler registration order is preserved too.

Now-unused imports (`logging`, `flask.g`, `new_request_id`, `get_login_provider`, `MethodNotAllowed`/`NotFound`, `DatasetNotLoadedError`/`DetectorNotLoadedError`, `RequestMissingContextError`) were dropped from `app.py`; each moved module imports what it needs locally, matching the original handlers' self-contained style.

Pure mechanical extraction — no behavior change.

## Testing

`./run-tests.sh core api` — all 1696 tests pass (0 failures), including the `api` error-response contracts and `core` request-context checks, plus ruff/format/codespell/deptry and the frontend build gate.

Closes #2653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ww5hJykwQQjpbXoZCd8mMP)_