### PR TITLE
Type embedder/media-type/converter listings via generated OpenAPI models

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -924,13 +924,49 @@
         ],
         "type": "object"
       },
+      "ConverterInfo": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "fields": {
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "summary_template": {
+            "description": "One-line preview with ``{key}`` placeholders for each field. The native row of the importer source-specs picker substitutes the current field values. Falls back to ``description`` when empty.",
+            "type": "string"
+          },
+          "target_type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "source_type",
+          "target_type"
+        ],
+        "type": "object"
+      },
       "ConvertersListResponse": {
         "additionalProperties": false,
         "properties": {
           "converters": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ConverterInfo"
             },
             "type": "array"
           }
@@ -2535,13 +2571,58 @@
         ],
         "type": "object"
       },
+      "EmbedderInfo": {
+        "additionalProperties": false,
+        "properties": {
+          "display_name": {
+            "description": "Human-readable label shown in pickers, e.g. ``\"SigLIP (general images)\"``. Falls back to ``name`` for legacy embedders that don't supply a friendlier label.",
+            "type": "string"
+          },
+          "is_default": {
+            "description": "Whether this embedder is the recommended default for its media type (exactly one per media type). The dropdown surfaces this entry under a \"Recommended\" optgroup.",
+            "type": "boolean"
+          },
+          "license_notice": {
+            "description": "User-facing licence warning to show before the user picks this embedder. ``null`` for embedders with no special licensing constraints. Advisory only.",
+            "nullable": true,
+            "type": "string"
+          },
+          "media_type_id": {
+            "type": "string"
+          },
+          "model_id": {
+            "description": "Concrete pretrained-model identifier the embedder loads - usually a HuggingFace repo id (or a direct weights URL). ``null`` for embedders with no single downloadable model id (e.g. the classical SIFT/VLAD structural embedder).",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "supports_geometric_verification": {
+            "description": "Whether this embedder produces local features (keypoints + descriptors) for instance matching. ``true`` for structural embedders (SIFT/VLAD); ``false`` for every semantic embedder.",
+            "type": "boolean"
+          },
+          "supports_patch_regions": {
+            "description": "Whether this embedder produces patch-level vectors and a hierarchical region tree per image. ``true`` for patch-based encoders (DINOv2, DINOv3, EUPE).",
+            "type": "boolean"
+          },
+          "supports_text": {
+            "description": "Whether this embedder can embed text queries into the same vector space as its media. ``false`` for vision-only encoders (DINOv3, Perception Encoder).",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "media_type_id",
+          "name"
+        ],
+        "type": "object"
+      },
       "EmbeddersListResponse": {
         "additionalProperties": false,
         "properties": {
           "embedders": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/EmbedderInfo"
             },
             "type": "array"
           }
@@ -3972,13 +4053,64 @@
         ],
         "type": "object"
       },
+      "MediaTypeInfo": {
+        "additionalProperties": false,
+        "properties": {
+          "converts_to": {
+            "description": "Embeddable target type_ids a non-embeddable type can convert into (first = default). ``[\"image\", \"text\"]`` for ``document``; empty for a directly-embeddable type.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "embeddable": {
+            "description": "Whether this type can be embedded (and therefore sorted / browsed / text-queried) on its own. ``false`` for a convert-out half type like ``document`` that must be converted first.",
+            "type": "boolean"
+          },
+          "file_extensions": {
+            "description": "Glob patterns for files this media type claims, e.g. ``[\"*.jpg\", \"*.png\"]``.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "folder_import_name": {
+            "type": "string"
+          },
+          "has_thumbnail": {
+            "description": "Whether items of this type have a browsable thumbnail (image/video/document, and audio via its waveform PNG). Drives the VTSBrowse square-vs-hex bin shape and thumbnail painting.",
+            "type": "boolean"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "importable": {
+            "description": "Whether this type is a first-class ingestion category the user picks when importing (folder scan, file upload). ``false`` for a convert-in half type like ``face``.",
+            "type": "boolean"
+          },
+          "loops": {
+            "description": "Whether this media type's rendered form loops (e.g. short video/audio).",
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type_id"
+        ],
+        "type": "object"
+      },
       "MediaTypesListResponse": {
         "additionalProperties": false,
         "properties": {
           "media_types": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/MediaTypeInfo"
             },
             "type": "array"
           }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -2,6 +2,14 @@
 
 import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
 import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+import type { ConverterInfo as GeneratedConverterInfo } from '../generated/api-client/models/converter-info';
+
+// These three plugin-metadata shapes now have generated OpenAPI models
+// (their `to_dict()` payloads are fixed across plugins), so re-export the
+// generated types instead of hand-maintaining a mirror. See
+// `vtsearch/schemas/datasets.py`.
+export type { EmbedderInfo } from '../generated/api-client/models/embedder-info';
+export type { MediaTypeInfo } from '../generated/api-client/models/media-type-info';
 
 // --- Medias ---
 
@@ -117,19 +125,21 @@ export interface ImporterInfo {
   [key: string]: unknown;
 }
 
-export interface ConverterInfo {
-  name: string;
-  source_type: string;
-  target_type: string;
-  display_name?: string;
-  description?: string;
-  /** One-line preview with ``{key}`` placeholders for each field.  The
-   *  importer modal renders it next to the source-spec row, substituting
-   *  the current field values, so the user sees a live summary of what
-   *  the converter will do.  Falls back to ``description`` when empty. */
-  summary_template?: string;
+/**
+ * A converter's ``to_dict()`` payload. Derived from the generated OpenAPI
+ * model, overriding only ``fields`` to carry the richer ``ImporterField[]``
+ * type (the backend schema keeps that list opaque; the ``ImporterField``
+ * shape is out of the generated model's scope).
+ *
+ * The generated model's ``summary_template`` is a one-line preview with
+ * ``{key}`` placeholders for each field: the importer modal renders it next
+ * to the source-spec row, substituting the current field values, so the user
+ * sees a live summary of what the converter will do. Falls back to
+ * ``description`` when empty.
+ */
+export type ConverterInfo = Omit<GeneratedConverterInfo, 'fields'> & {
   fields?: ImporterField[];
-}
+};
 
 /** One row of a multi-media import specification.  See
  *  ``docs/EXTENDING-media.md``. */
@@ -210,32 +220,6 @@ export interface ImporterPickerTab {
   label: string;
   icon?: string;
   order?: number;
-}
-
-export interface MediaTypeInfo {
-  type_id: string;
-  name: string;
-  icon?: string;
-  folder_import_name?: string;
-  /** Glob patterns for files this media type claims, e.g. ``["*.jpg", "*.png"]``. */
-  file_extensions?: string[];
-  /** Whether items of this type have a browsable thumbnail (image/video/document,
-   *  and audio via its waveform PNG). Drives the VTSBrowse square-vs-hex bin shape
-   *  and thumbnail painting; the single source of truth the frontend reads via
-   *  ``MediaTypeCapabilityService.usesThumbnails``. */
-  has_thumbnail?: boolean;
-  /** Whether this type is a first-class *ingestion* category the user picks when
-   *  importing (folder scan, file upload). ``false`` for a *convert-in* half type
-   *  like ``face`` that only ever arises from converting another type. */
-  importable?: boolean;
-  /** Whether this type can be embedded (and therefore sorted / browsed / text-
-   *  queried) on its own. ``false`` for a *convert-out* half type like
-   *  ``document`` that must be converted first. */
-  embeddable?: boolean;
-  /** Embeddable target type_ids a non-embeddable type can convert into (first =
-   *  default). ``["image", "text"]`` for ``document``; empty for a directly-
-   *  embeddable type. */
-  converts_to?: string[];
 }
 
 export interface MediaTypeDetectionResponse {
@@ -368,62 +352,4 @@ export interface AutoDetectResultsData {
   [key: string]: unknown;
 }
 
-// --- Embedders ---
-
-export interface EmbedderInfo {
-  name: string;
-  /**
-   * Human-readable label shown in pickers, e.g. ``"SigLIP (general images)"``.
-   * Falls back to ``name`` for legacy embedders that don't supply a friendlier
-   * label; the raw ``name`` is also rendered as a secondary line so power
-   * users can still see the registry key.
-   */
-  display_name?: string;
-  /**
-   * Concrete pretrained-model identifier the embedder loads — usually a
-   * HuggingFace repo id (e.g. ``"google/siglip-base-patch16-224"``), or a
-   * direct weights URL. ``null`` for embedders with no single downloadable
-   * model id (e.g. the classical SIFT/VLAD structural embedder). Surfaced in
-   * the portable-detector export bundle so a recipient knows exactly which
-   * model to run new media through.
-   */
-  model_id?: string | null;
-  media_type_id: string;
-  /**
-   * Whether this embedder is the recommended default for its media type
-   * (exactly one per media type). The dropdown surfaces this entry under a
-   * "Recommended" optgroup and tucks the rest under "Advanced".
-   */
-  is_default?: boolean;
-  /**
-   * Whether this embedder can embed text queries into the same vector space as
-   * its media. ``false`` for vision-only encoders (DINOv3, Perception Encoder)
-   * so the UI hides text-search affordances for datasets using them.
-   */
-  supports_text?: boolean;
-  /**
-   * Whether this embedder produces patch-level vectors and a hierarchical
-   * region tree per image. ``true`` for patch-based encoders (DINOv2,
-   * DINOv3, EUPE) once their patch pipeline lands; the gallery card draws
-   * a faint outline over the matched region for datasets using them.
-   */
-  supports_patch_regions?: boolean;
-  /**
-   * Whether this embedder produces local features (keypoints + descriptors)
-   * for instance matching. ``true`` for structural embedders (SIFT/VLAD and
-   * learned-local-feature variants later); the loader then stores per-image
-   * local features and the geometric re-rank + match-stat verification paths
-   * activate. ``false`` (the default) for every semantic embedder.
-   */
-  supports_geometric_verification?: boolean;
-  /**
-   * User-facing licence warning to show before the user picks this embedder.
-   * ``null`` for embedders with no special licensing constraints; a short
-   * human-readable string for embedders with restrictive licences (e.g.
-   * facebookresearch/EUPE under the FAIR Noncommercial Research Licence).
-   * Advisory only; the picker shows a warning chip, it does not gate
-   * selection behind an acceptance click.
-   */
-  license_notice?: string | null;
-}
 

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -7,12 +7,18 @@ modules (``load``, ``staging``, ``registry``) involve multipart upload,
 binary streaming, and plugin-field-shaped bodies and are migrated
 separately. See ``docs/plans/openapi-schema.md``.
 
-The ``to_dict()`` payloads for media types, embedders, clippers,
-converters, and importers are intentionally declared as ``fields.Dict()``
-rather than nested schemas: the inner shapes are plugin-dependent and
-already round-trip cleanly via ``to_dict()``. Re-declaring every field
-would buy nothing; drift between schema and plugin metadata would be
-caught at the *plugin* layer, not the route.
+The ``to_dict()`` payloads split by whether the shape is fixed or
+plugin-variable:
+
+* **Media types, embedders, converters** have a *fixed* key set across every
+  plugin (no subclass overrides ``to_dict``), so they are enumerated as
+  nested schemas (``MediaTypeInfoSchema``, ``EmbedderInfoSchema``,
+  ``ConverterInfoSchema``).  This gives the generated OpenAPI client a real
+  typed model, letting the frontend drop its hand-written mirror.
+* **Clippers and importers** stay opaque ``fields.Dict()``: concrete clippers
+  add their own keys (``duration``, ``top_db``, …) and the importer payload
+  nests plugin-field lists, so a nested schema would either lose keys or need
+  an escape hatch anyway.  Drift there is caught at the *plugin* layer.
 """
 
 from __future__ import annotations
@@ -80,20 +86,177 @@ class ConvertersListQuerySchema(Schema):
     source = fields.String(load_default="")
 
 
+class MediaTypeInfoSchema(Schema):
+    """One ``MediaType.to_dict()`` payload (see ``vtscore/media/base.py``).
+
+    Fixed shape: every media type emits the same keys, so this is a real
+    nested schema rather than an opaque ``fields.Dict()``.  Only ``type_id``
+    and ``name`` are guaranteed present enough to mark ``required``; the rest
+    mirror the frontend's optional fields.
+    """
+
+    type_id = fields.String(required=True)
+    name = fields.String(required=True)
+    icon = fields.String()
+    folder_import_name = fields.String()
+    loops = fields.Boolean(
+        metadata={"description": "Whether this media type's rendered form loops (e.g. short video/audio)."}
+    )
+    file_extensions = fields.List(
+        fields.String(),
+        metadata={"description": 'Glob patterns for files this media type claims, e.g. ``["*.jpg", "*.png"]``.'},
+    )
+    has_thumbnail = fields.Boolean(
+        metadata={
+            "description": (
+                "Whether items of this type have a browsable thumbnail (image/video/document, and audio via "
+                "its waveform PNG). Drives the VTSBrowse square-vs-hex bin shape and thumbnail painting."
+            )
+        }
+    )
+    importable = fields.Boolean(
+        metadata={
+            "description": (
+                "Whether this type is a first-class ingestion category the user picks when importing (folder "
+                "scan, file upload). ``false`` for a convert-in half type like ``face``."
+            )
+        }
+    )
+    embeddable = fields.Boolean(
+        metadata={
+            "description": (
+                "Whether this type can be embedded (and therefore sorted / browsed / text-queried) on its own. "
+                "``false`` for a convert-out half type like ``document`` that must be converted first."
+            )
+        }
+    )
+    converts_to = fields.List(
+        fields.String(),
+        metadata={
+            "description": (
+                "Embeddable target type_ids a non-embeddable type can convert into (first = default). "
+                '``["image", "text"]`` for ``document``; empty for a directly-embeddable type.'
+            )
+        },
+    )
+
+
+class EmbedderInfoSchema(Schema):
+    """One ``MediaEmbedder.to_dict()`` payload (see ``vtscore/media/embedder.py``).
+
+    Fixed shape across all embedders (no subclass overrides ``to_dict``), so
+    the payload is fully enumerated here instead of ``fields.Dict()``.
+    """
+
+    name = fields.String(required=True)
+    display_name = fields.String(
+        metadata={
+            "description": (
+                'Human-readable label shown in pickers, e.g. ``"SigLIP (general images)"``. Falls back to '
+                "``name`` for legacy embedders that don't supply a friendlier label."
+            )
+        }
+    )
+    model_id = fields.String(
+        allow_none=True,
+        metadata={
+            "description": (
+                "Concrete pretrained-model identifier the embedder loads - usually a HuggingFace repo id "
+                "(or a direct weights URL). ``null`` for embedders with no single downloadable model id "
+                "(e.g. the classical SIFT/VLAD structural embedder)."
+            )
+        },
+    )
+    media_type_id = fields.String(required=True)
+    is_default = fields.Boolean(
+        metadata={
+            "description": (
+                "Whether this embedder is the recommended default for its media type (exactly one per media "
+                'type). The dropdown surfaces this entry under a "Recommended" optgroup.'
+            )
+        }
+    )
+    supports_text = fields.Boolean(
+        metadata={
+            "description": (
+                "Whether this embedder can embed text queries into the same vector space as its media. "
+                "``false`` for vision-only encoders (DINOv3, Perception Encoder)."
+            )
+        }
+    )
+    supports_patch_regions = fields.Boolean(
+        metadata={
+            "description": (
+                "Whether this embedder produces patch-level vectors and a hierarchical region tree per image. "
+                "``true`` for patch-based encoders (DINOv2, DINOv3, EUPE)."
+            )
+        }
+    )
+    supports_geometric_verification = fields.Boolean(
+        metadata={
+            "description": (
+                "Whether this embedder produces local features (keypoints + descriptors) for instance "
+                "matching. ``true`` for structural embedders (SIFT/VLAD); ``false`` for every semantic embedder."
+            )
+        }
+    )
+    license_notice = fields.String(
+        allow_none=True,
+        metadata={
+            "description": (
+                "User-facing licence warning to show before the user picks this embedder. ``null`` for "
+                "embedders with no special licensing constraints. Advisory only."
+            )
+        },
+    )
+
+
+class ConverterInfoSchema(Schema):
+    """One ``MediaConverter.to_dict()`` payload (see ``vtscore/converters/base.py``).
+
+    Fixed shape across all converters.  The plugin ``fields`` list (importer
+    fields) is kept opaque here: the ``ImporterField`` shape is out of this
+    slice's scope, and the frontend re-types it via ``ImporterField[]``.
+    """
+
+    name = fields.String(required=True)
+    source_type = fields.String(required=True)
+    target_type = fields.String(required=True)
+    display_name = fields.String()
+    description = fields.String()
+    summary_template = fields.String(
+        metadata={
+            "description": (
+                "One-line preview with ``{key}`` placeholders for each field. The native row of the importer "
+                "source-specs picker substitutes the current field values. Falls back to ``description`` when empty."
+            )
+        }
+    )
+    #: Python attribute renamed to avoid shadowing ``marshmallow.fields``;
+    #: mapped back to the ``fields`` wire key.
+    field_list = fields.List(fields.Dict(), attribute="fields", data_key="fields")
+
+
 class MediaTypesListResponseSchema(Schema):
     """Response for ``GET /api/media-types``."""
 
-    media_types = fields.List(fields.Dict(), required=True)
+    media_types = fields.List(fields.Nested(MediaTypeInfoSchema), required=True)
 
 
 class EmbeddersListResponseSchema(Schema):
     """Response for ``GET /api/embedders``."""
 
-    embedders = fields.List(fields.Dict(), required=True)
+    embedders = fields.List(fields.Nested(EmbedderInfoSchema), required=True)
 
 
 class ClippersListResponseSchema(Schema):
-    """Response for ``GET /api/clippers``."""
+    """Response for ``GET /api/clippers``.
+
+    The clipper ``to_dict()`` payload is genuinely plugin-variable (concrete
+    clippers add their own keys, e.g. ``duration``/``top_db``), so this stays
+    an opaque ``fields.Dict()`` rather than a nested schema.  See the module
+    docstring.
+    """
 
     clippers = fields.List(fields.Dict(), required=True)
 
@@ -101,7 +264,7 @@ class ClippersListResponseSchema(Schema):
 class ConvertersListResponseSchema(Schema):
     """Response for ``GET /api/converters``."""
 
-    converters = fields.List(fields.Dict(), required=True)
+    converters = fields.List(fields.Nested(ConverterInfoSchema), required=True)
 
 
 class DatasetImportersListResponseSchema(Schema):


### PR DESCRIPTION
Converges the fixed-shape slice of the hand-written `frontend/src/app/models/api.models.ts` onto generated OpenAPI types, per #2655.

## What changed

The `/api/embedders`, `/api/media-types`, and `/api/converters` listing endpoints already had registered response schemas, but their inner payloads were opaque `fields.List(fields.Dict())`, so the generated OpenAPI client produced `Array<{ [key: string]: any }>` — untyped. This PR enumerates those three payloads as nested Marshmallow schemas (`EmbedderInfoSchema`, `MediaTypeInfoSchema`, `ConverterInfoSchema`), which are safe because each plugin's `to_dict()` emits a **fixed** key set (no subclass overrides `to_dict`).

- **Backend** (`vtsearch/schemas/datasets.py`): three new nested schemas; the three list-response schemas now use `fields.Nested(...)`. Field documentation moved from the frontend interfaces onto the schema fields (`metadata={"description": ...}`) so it flows through to the generated model JSDoc.
- **Frontend** (`api.models.ts`): `EmbedderInfo` and `MediaTypeInfo` are now re-exported from the generated client; `ConverterInfo` is derived from the generated model (`Omit<…, 'fields'> & { fields?: ImporterField[] }`) to preserve the richer `ImporterField[]` typing. The three hand-written interfaces are deleted. All ~50 usage sites are untouched (they import from `api.models.ts` as before).
- **Latent drift fixed**: the backend always emitted a `loops` key on media types that `MediaTypeInfo` never declared — the nested schema now includes it.

## Scope

Deliberately **partial**. The remaining hand-written interfaces are left as-is because they are not fixed-shape:
- **Clippers / importers** — genuinely plugin-variable (`audio/clipper.py` adds `duration`/`min_overlap`, etc.), so they'd need an escape hatch regardless.
- **`ProgressEvent`** — delivered over the SSE stream (`/api/events`, a raw streaming `Response`), which flask-smorest cannot describe; it can't be converged via OpenAPI at all.

`Refs #2655` (does not close it — this is one slice of the umbrella).

## Verification

- `./run-tests.sh frontend` — build OK, Vitest 1759 passed, OpenAPI snapshot no drift, pyright/ruff/deptry/pip-audit clean.
- `./run-tests.sh datasets api core io` — 3539 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vr6e7p1UrEZfWKsboULA9c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vr6e7p1UrEZfWKsboULA9c)_