### PR TITLE
Combine Datasets: resolve embedder-type conflicts instead of refusing

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -27,7 +27,7 @@ Cross-cutting, still open:
 
 <!-- item-sep -->
 
-- [ ] #2667 — Combine Datasets triple-match guard (refuse mismatched embedder triples) (open question #2)
+- [ ] #2667 — Combine Datasets per-embedder-type conflict resolution: instead of refusing a mismatched triple, the modal detects each conflicting type (semantic / patch_semantic / structural) and lets the user re-embed every source to one winner or drop that type; the combine route bakes the choice into the load (open question #2, now addressed by resolution rather than refusal)
 
 <!-- item-sep -->
 
@@ -52,9 +52,11 @@ V3 open questions (design-level, still unresolved):
    `dataset.embedder` field probably can't just be renamed without breaking
    labelset sync. Likely: keep the legacy field as a computed read-only alias to
    the score-role slot for one release, then drop it. Confirm during impl.
-2. **Combine Datasets ergonomics.** Strict "embedder triple must match" is the
-   v3 rule; if it bites, add a "combine on the text slot only" variant. Punt
-   until real demand.
+2. **Combine Datasets ergonomics.** *(Resolved — see #2667.)* Rather than a strict
+   "embedder triple must match" refusal, combine now detects per-embedder-type
+   conflicts and offers, for each conflicting type, "re-embed every source to one
+   winner" or "drop that type". The route still refuses (400) an *unresolved*
+   conflict from a programmatic caller, so the strict guard remains the backstop.
 3. **Coverage-atlas vs score backbone (patch vs structural).** (Validation
    tracked in #2668.) Structural-over-
    patch for the shared score role is the less obvious call — a structural
@@ -193,9 +195,10 @@ is the **score** embedder (structural ▸ patch ▸ text) the model was trained 
   per bound embedder, read by `read_npz_multi_vectors` / written by
   `write_npz_multi_vectors`); the existing single-`vectors` layout maps to the
   score-role slot.
-- **Combine Datasets** requires identical
-  `(text_embedder, patch_embedder, structural_embedder)` triples. (Guard is an open
-  follow-up.)
+- **Combine Datasets** resolves per-embedder-type conflicts across the sources
+  (re-embed to one winner, or drop the type) instead of requiring identical
+  `(text_embedder, patch_embedder, structural_embedder)` triples; an unresolved
+  conflict from a non-UI caller is still refused. (See #2667.)
 
 ### Frontend
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1170,10 +1170,37 @@
           "name": {
             "default": "",
             "type": "string"
+          },
+          "resolutions": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/DatasetCombineResolution"
+            },
+            "description": "Embedder-type -> {action, embedder} conflict resolutions.",
+            "type": "object"
           }
         },
         "required": [
           "datasets"
+        ],
+        "type": "object"
+      },
+      "DatasetCombineResolution": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "enum": [
+              "reembed",
+              "drop"
+            ],
+            "type": "string"
+          },
+          "embedder": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
         ],
         "type": "object"
       },
@@ -8527,6 +8554,7 @@
     },
     "/api/dataset/combine": {
       "post": {
+        "description": "When the sources bind conflicting embedders of the same type (e.g. one\n``siglip`` dataset and one ``clip`` dataset, both semantic), the caller must\nsettle each conflict via ``resolutions`` \u2014 re-embed every source to one\nwinner, or drop that embedder type from the result.  An unresolved conflict\nis refused (400) rather than silently producing a mixed vector space; the\nCombine-Datasets modal detects the conflicts client-side and collects the\nresolutions before posting here.",
         "operationId": "combine_datasets_route",
         "requestBody": {
           "content": {
@@ -8550,7 +8578,7 @@
             "description": "OK"
           },
           "400": {
-            "description": "Invalid or missing dataset path."
+            "description": "Invalid path, or an unresolved embedder conflict."
           },
           "422": {
             "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.html
@@ -73,6 +73,49 @@
         </tfoot>
       </table>
 
+      @if (hasConflicts) {
+        <section class="conflict-panel">
+          <h3 class="conflict-title">Embedder conflicts</h3>
+          <p class="conflict-intro">
+            These datasets don't agree on one embedder per type. For each,
+            re-embed every dataset to a single embedder, or drop that embedder
+            from the combined dataset.
+          </p>
+          @for (conflict of conflicts; track conflict.type) {
+            <div class="conflict-row">
+              <div class="conflict-label">
+                <span class="conflict-type">{{ conflict.label }}</span>
+                @if (conflict.partial && conflict.options.length === 1) {
+                  <span class="conflict-detail">
+                    only some datasets have {{ embedderLabel(conflict.options[0]) }}
+                  </span>
+                } @else {
+                  <span class="conflict-detail">
+                    {{ conflict.options.length }} embedders:
+                    {{ conflictOptionsText(conflict) }}
+                  </span>
+                }
+              </div>
+              <select
+                class="conflict-select form-input"
+                [ngModel]="resolutionChoices()[conflict.type] || ''"
+                (ngModelChange)="setResolution(conflict.type, $event)"
+                [disabled]="submitting()"
+                [attr.aria-label]="'Resolve ' + conflict.label + ' embedder conflict'"
+              >
+                <option value="" disabled>Choose how to resolve…</option>
+                @for (opt of conflict.options; track opt) {
+                  <option [value]="'reembed:' + opt">
+                    Re-embed all to {{ embedderLabel(opt) }}
+                  </option>
+                }
+                <option value="drop">Drop {{ conflict.label }} embeddings</option>
+              </select>
+            </div>
+          }
+        </section>
+      }
+
       @if (disabledReason) {
         <p class="warn-text">{{ disabledReason }}</p>
       } @else {
@@ -80,6 +123,9 @@
           The combined dataset will contain up to {{ totalItems | number }}
           {{ mediaTypeLabel(sharedMediaType) || sharedMediaType }} items
           (duplicates removed automatically).
+          @if (hasConflicts) {
+            Re-embedding runs during the combine and may take a while.
+          }
         </p>
       }
 

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.scss
@@ -122,6 +122,65 @@
   font-style: italic;
 }
 
+// Per-embedder-type conflict resolution. Sits between the source table and the
+// info/warn line; each row pairs a description of the clash with a resolution
+// dropdown.
+.conflict-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-subtle);
+}
+
+.conflict-title {
+  margin: 0;
+  font-size: var(--font-md);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  color: var(--text-secondary);
+}
+
+.conflict-intro {
+  margin: 0;
+  font-size: var(--font-md);
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.conflict-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.conflict-label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  min-width: 0;
+}
+
+.conflict-type {
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-lg);
+}
+
+.conflict-detail {
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
+.conflict-select {
+  flex: 0 0 auto;
+  min-width: 220px;
+  font-size: var(--font-md);
+}
+
 // `.info-text` / `.error-text` come from `_components.scss`; only
 // `.warn-text` is local (no shared `--text-warning` utility class yet).
 .warn-text {

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.spec.ts
@@ -19,12 +19,26 @@ describe('CombineDatasetsModalComponent', () => {
     ],
   };
 
-  const ds = (id: string, name: string, type: string, num: number, pkl: string): DatasetRegistryEntry => ({
+  const mockEmbedders = [
+    { name: 'siglip', display_name: 'SigLIP' },
+    { name: 'clip', display_name: 'CLIP' },
+    { name: 'dinov3_patch', display_name: 'DINOv3 Patch' },
+  ];
+
+  const ds = (
+    id: string,
+    name: string,
+    type: string,
+    num: number,
+    pkl: string,
+    embeddersByType?: Record<string, string>,
+  ): DatasetRegistryEntry => ({
     id,
     name,
     media_type: type,
     num_items: num,
     pkl_path: pkl,
+    embedders_by_type: embeddersByType,
   });
 
   beforeEach(async () => {
@@ -48,6 +62,7 @@ describe('CombineDatasetsModalComponent', () => {
     fixture.componentRef.setInput('datasets', datasets);
     await settleZoneless(fixture);
     httpMock.expectOne('/api/media-types').flush(mockMediaTypes);
+    httpMock.expectOne((r) => r.url === '/api/embedders').flush({ embedders: mockEmbedders });
     await settleZoneless(fixture);
   }
 
@@ -139,5 +154,96 @@ describe('CombineDatasetsModalComponent', () => {
 
     component.submit();
     httpMock.expectNone('/api/dataset/combine');
+  });
+
+  it('detects no conflict when datasets share the same embedder per type', async () => {
+    await init([
+      ds('a', 'Alpha', 'image', 10, '/x/a.pkl', { semantic: 'siglip' }),
+      ds('b', 'Bravo', 'image', 20, '/x/b.pkl', { semantic: 'siglip' }),
+    ]);
+
+    expect(component.hasConflicts).toBe(false);
+    expect(component.canCombine).toBe(true);
+  });
+
+  it('flags a name-clash conflict and gates Combine until resolved', async () => {
+    await init([
+      ds('a', 'Alpha', 'image', 10, '/x/a.pkl', { semantic: 'siglip' }),
+      ds('b', 'Bravo', 'image', 20, '/x/b.pkl', { semantic: 'clip' }),
+    ]);
+
+    expect(component.hasConflicts).toBe(true);
+    const conflict = component.conflicts[0];
+    expect(conflict.type).toBe('semantic');
+    expect(conflict.options).toEqual(['siglip', 'clip']);
+    // Unresolved → cannot combine.
+    expect(component.canCombine).toBe(false);
+    expect(component.disabledReason).toContain('Resolve each embedder conflict');
+
+    component.setResolution('semantic', 'reembed:clip');
+    expect(component.canCombine).toBe(true);
+  });
+
+  it('flags partial coverage (some datasets lack a type) as a conflict', async () => {
+    await init([
+      ds('a', 'Alpha', 'image', 10, '/x/a.pkl', { semantic: 'siglip', patch_semantic: 'dinov3_patch' }),
+      ds('b', 'Bravo', 'image', 20, '/x/b.pkl', { semantic: 'siglip' }),
+    ]);
+
+    const patch = component.conflicts.find((c) => c.type === 'patch_semantic');
+    expect(patch).toBeTruthy();
+    expect(patch!.partial).toBe(true);
+    expect(patch!.options).toEqual(['dinov3_patch']);
+    // Semantic agrees → not a conflict.
+    expect(component.conflicts.some((c) => c.type === 'semantic')).toBe(false);
+  });
+
+  it('blocks dropping every conflicted embedder', async () => {
+    await init([
+      ds('a', 'Alpha', 'image', 10, '/x/a.pkl', { semantic: 'siglip' }),
+      ds('b', 'Bravo', 'image', 20, '/x/b.pkl', { semantic: 'clip' }),
+    ]);
+
+    component.setResolution('semantic', 'drop');
+    expect(component.canCombine).toBe(false);
+    expect(component.disabledReason).toContain('At least one embedder');
+  });
+
+  it('submits resolutions in the combine body', async () => {
+    await init([
+      ds('a', 'Alpha', 'image', 10, '/x/a.pkl', { semantic: 'siglip', patch_semantic: 'dinov3_patch' }),
+      ds('b', 'Bravo', 'image', 20, '/x/b.pkl', { semantic: 'clip' }),
+    ]);
+
+    component.setResolution('semantic', 'reembed:siglip');
+    component.setResolution('patch_semantic', 'drop');
+
+    component.submit();
+    const req = httpMock.expectOne('/api/dataset/combine');
+    expect(req.request.body).toEqual({
+      datasets: ['/x/a.pkl', '/x/b.pkl'],
+      name: 'Alpha + Bravo',
+      resolutions: {
+        semantic: { action: 'reembed', embedder: 'siglip' },
+        patch_semantic: { action: 'drop' },
+      },
+    });
+    req.flush({ ok: true, message: 'Combining datasets...', task_id: 't' });
+  });
+
+  it('prunes resolution choices for conflicts removed by removeRow', async () => {
+    await init([
+      ds('a', 'Alpha', 'image', 10, '/x/a.pkl', { semantic: 'siglip' }),
+      ds('b', 'Bravo', 'image', 20, '/x/b.pkl', { semantic: 'clip' }),
+      ds('c', 'Charlie', 'image', 30, '/x/c.pkl', { semantic: 'siglip' }),
+    ]);
+
+    expect(component.hasConflicts).toBe(true);
+    component.setResolution('semantic', 'reembed:clip');
+    // Removing the odd-one-out clears the conflict; its choice is pruned.
+    component.removeRow('b');
+    expect(component.hasConflicts).toBe(false);
+    expect(component.resolutionChoices()['semantic']).toBeUndefined();
+    expect(component.canCombine).toBe(true);
   });
 });

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.ts
@@ -14,7 +14,41 @@ interface CombineRow {
   media_type: string;
   num_items: number;
   pkl_path: string;
+  /** One concrete embedder per type this dataset binds. */
+  embeddersByType: Record<string, string>;
 }
+
+/**
+ * One embedder-type conflict across the datasets being combined: the datasets
+ * don't all bind the same concrete embedder of `type` (either different
+ * embedders, or some bind it and some don't). The user settles each by
+ * re-embedding every source to one winner, or dropping the type entirely.
+ */
+interface EmbedderConflict {
+  /** Embedder type key: "semantic" | "patch_semantic" | "structural". */
+  type: string;
+  /** Human label, e.g. "Semantic". */
+  label: string;
+  /** Distinct concrete embedders bound for this type, in first-seen order. */
+  options: string[];
+  /** Whether the conflict is (also) partial coverage — some datasets lack it. */
+  partial: boolean;
+}
+
+/** Wire shape of one resolution sent to the combine endpoint. */
+interface CombineResolution {
+  action: 'reembed' | 'drop';
+  embedder?: string;
+}
+
+/** Types in classification precedence order (structural ▸ patch ▸ semantic). */
+const EMBEDDER_TYPE_ORDER = ['structural', 'patch_semantic', 'semantic'];
+
+const EMBEDDER_TYPE_LABELS: Record<string, string> = {
+  semantic: 'Semantic',
+  patch_semantic: 'Patch',
+  structural: 'Structural',
+};
 
 /**
  * Payload emitted when a combine kicks off. Carries the pre-dedup source
@@ -51,9 +85,17 @@ export class CombineDatasetsModalComponent implements OnInit {
   // Signals: written from the media-types / combine subscribes (async, not a
   // zoneless CD trigger) yet read in the template, so they must repaint on emit.
   readonly mediaTypes = signal<MediaTypeInfo[]>([]);
+  readonly embedderLabels = signal<Record<string, string>>({});
   readonly submitting = signal(false);
   readonly error = signal('');
   name = '';
+
+  /**
+   * Per-type resolution choice, keyed by embedder type. The value is the raw
+   * `<select>` value: `''` (unchosen), `drop`, or `reembed:<embedder>`. Signal
+   * so a selection repaints the gated Combine button.
+   */
+  readonly resolutionChoices = signal<Record<string, string>>({});
 
   ngOnInit(): void {
     this.rows = this.datasets()
@@ -63,6 +105,7 @@ export class CombineDatasetsModalComponent implements OnInit {
         media_type: d.media_type,
         num_items: Number(d['num_items'] ?? 0),
         pkl_path: String(d['pkl_path'] ?? ''),
+        embeddersByType: (d.embedders_by_type as Record<string, string>) ?? {},
       }))
       .filter((r) => !!r.pkl_path);
 
@@ -71,6 +114,18 @@ export class CombineDatasetsModalComponent implements OnInit {
     this.datasetsListingsApi.getMediaTypes().subscribe({
       next: (res) => {
         this.mediaTypes.set(res.media_types || []);
+      },
+    });
+
+    // Friendly embedder display names for the resolution dropdowns; falls back
+    // to the raw name if the lookup hasn't arrived (or the embedder is unknown).
+    this.datasetsListingsApi.getEmbedders().subscribe({
+      next: (embs) => {
+        const map: Record<string, string> = {};
+        for (const e of embs) {
+          map[e.name] = e.display_name || e.name;
+        }
+        this.embedderLabels.set(map);
       },
     });
   }
@@ -93,8 +148,76 @@ export class CombineDatasetsModalComponent implements OnInit {
     return this.distinctMediaTypes.length === 1 ? this.distinctMediaTypes[0] : '';
   }
 
+  /**
+   * Embedder-type conflicts across the selected datasets. A type is conflicted
+   * when the datasets don't all bind the same concrete embedder for it — either
+   * two bind different embedders, or some bind it and others don't. Empty when
+   * every bound type agrees (the common single-embedder case).
+   */
+  get conflicts(): EmbedderConflict[] {
+    const out: EmbedderConflict[] = [];
+    if (this.rows.length < 2) return out;
+    for (const type of EMBEDDER_TYPE_ORDER) {
+      const reps = this.rows.map((r) => r.embeddersByType[type] || '');
+      const present = reps.filter((n) => !!n);
+      if (present.length === 0) continue;
+      const options: string[] = [];
+      for (const n of present) {
+        if (!options.includes(n)) options.push(n);
+      }
+      const partial = present.length < this.rows.length;
+      if (options.length > 1 || partial) {
+        out.push({ type, label: EMBEDDER_TYPE_LABELS[type] || type, options, partial });
+      }
+    }
+    return out;
+  }
+
+  get hasConflicts(): boolean {
+    return this.conflicts.length > 0;
+  }
+
+  embedderLabel(name: string): string {
+    return this.embedderLabels()[name] || name;
+  }
+
+  /** Comma-joined friendly names of a conflict's distinct embedders. */
+  conflictOptionsText(conflict: EmbedderConflict): string {
+    return conflict.options.map((n) => this.embedderLabel(n)).join(', ');
+  }
+
+  /** How many embedders the combined dataset would keep given current choices. */
+  private keptCount(): number {
+    // Non-conflicted present types are auto-kept; conflicted ones are kept only
+    // when resolved to "re-embed" (dropped ones contribute nothing).
+    const conflictTypes = new Set(this.conflicts.map((c) => c.type));
+    let kept = 0;
+    for (const type of EMBEDDER_TYPE_ORDER) {
+      const present = this.rows.some((r) => !!r.embeddersByType[type]);
+      if (!present) continue;
+      if (!conflictTypes.has(type)) {
+        kept += 1;
+      } else if ((this.resolutionChoices()[type] || '').startsWith('reembed:')) {
+        kept += 1;
+      }
+    }
+    return kept;
+  }
+
+  /** Whether every detected conflict has a chosen resolution. */
+  get allConflictsResolved(): boolean {
+    return this.conflicts.every((c) => !!this.resolutionChoices()[c.type]);
+  }
+
+  setResolution(type: string, value: string): void {
+    this.resolutionChoices.set({ ...this.resolutionChoices(), [type]: value });
+  }
+
   get canCombine(): boolean {
-    return this.rows.length >= 2 && this.distinctMediaTypes.length === 1;
+    if (this.rows.length < 2 || this.distinctMediaTypes.length !== 1) return false;
+    if (!this.allConflictsResolved) return false;
+    if (this.hasConflicts && this.keptCount() === 0) return false;
+    return true;
   }
 
   /** Tooltip / inline reason describing why the Combine button is disabled. */
@@ -104,6 +227,12 @@ export class CombineDatasetsModalComponent implements OnInit {
     }
     if (this.distinctMediaTypes.length > 1) {
       return `All datasets must share a media type (got ${this.distinctMediaTypes.join(', ')}).`;
+    }
+    if (!this.allConflictsResolved) {
+      return 'Resolve each embedder conflict below to continue.';
+    }
+    if (this.hasConflicts && this.keptCount() === 0) {
+      return 'At least one embedder must be kept — you cannot drop them all.';
     }
     return '';
   }
@@ -120,6 +249,27 @@ export class CombineDatasetsModalComponent implements OnInit {
 
   removeRow(id: string): void {
     this.rows = this.rows.filter((r) => r.id !== id);
+    // Prune choices for conflicts that no longer exist after the removal.
+    const live = new Set(this.conflicts.map((c) => c.type));
+    const pruned: Record<string, string> = {};
+    for (const [type, value] of Object.entries(this.resolutionChoices())) {
+      if (live.has(type)) pruned[type] = value;
+    }
+    this.resolutionChoices.set(pruned);
+  }
+
+  /** Translate the raw `<select>` values into the wire `resolutions` map. */
+  private buildResolutions(): Record<string, CombineResolution> {
+    const out: Record<string, CombineResolution> = {};
+    for (const c of this.conflicts) {
+      const value = this.resolutionChoices()[c.type] || '';
+      if (value === 'drop') {
+        out[c.type] = { action: 'drop' };
+      } else if (value.startsWith('reembed:')) {
+        out[c.type] = { action: 'reembed', embedder: value.slice('reembed:'.length) };
+      }
+    }
+    return out;
   }
 
   submit(): void {
@@ -130,7 +280,8 @@ export class CombineDatasetsModalComponent implements OnInit {
     const name = (this.name || '').trim() || this.defaultName();
     const numSources = this.rows.length;
     const totalItems = this.totalItems;
-    this.datasetsCrudApi.combineDatasets({ datasets: paths, name }).subscribe({
+    const resolutions = this.hasConflicts ? this.buildResolutions() : undefined;
+    this.datasetsCrudApi.combineDatasets({ datasets: paths, name, resolutions }).subscribe({
       next: (res) => {
         this.submitting.set(false);
         this.combineStarted.emit({ taskId: res.task_id, numSources, totalItems });

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -246,6 +246,12 @@ export interface DatasetRegistryEntry {
    *  / "structural"); a v3 trio dataset can supply several. Drives the
    *  detector/dataset compatibility gate. */
   embedder_types?: string[];
+  /** Every concrete embedder this dataset binds (primary first). */
+  bound_embedders?: string[];
+  /** One concrete embedder per type it binds, e.g.
+   *  `{ semantic: "siglip", patch_semantic: "dinov3_patch" }`. Drives the
+   *  Combine-Datasets conflict detector. */
+  embedders_by_type?: Record<string, string>;
   /** Unix timestamp (seconds) at which this dataset ages off and is
    *  automatically removed; `null`/absent means it never expires. */
   expires_at?: number | null;

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -79,16 +79,53 @@ def _make_image_clip(media_id: int, md5: str = "") -> dict:
     }
 
 
+def _make_image_clip_embedded(media_id: int, embedder: str, extra: dict | None = None) -> dict:
+    """An image clip carrying a per-embedder ``embeddings`` dict for *embedder*.
+
+    Used by the conflict-resolution tests: two sources embedded with different
+    concrete embedders (e.g. ``siglip`` vs ``clip``) exercise the strip-to-keep
+    path.  *extra* merges in side-channels (``patch_regions`` etc.).
+    """
+    raw = b"\x89PNG" + _unique_bytes(media_id)
+    clip = {
+        "id": media_id,
+        "media_type": "image",
+        "duration": 0,
+        "file_size": 2000,
+        "md5": hashlib.md5(raw).hexdigest(),
+        "embeddings": {embedder: np.array([float(media_id)], dtype=np.float32)},
+        "embedder": embedder,
+        "media_bytes": raw,
+        "media_string": None,
+        "media_path": None,
+        "filename": f"img_{media_id}.png",
+        "category": "test",
+        "origin": None,
+        "origin_name": f"img_{media_id}.png",
+        "width": 32,
+        "height": 32,
+    }
+    if extra:
+        clip.update(extra)
+    return clip
+
+
 def _write_pickle_dataset(path, clips_dict):
     """Write a dataset container file in the standard ZIP format."""
     from vtscore.datasets.container import write_container
 
-    data = {
-        "medias": {
-            cid: {k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in media.items()}
-            for cid, media in clips_dict.items()
-        }
-    }
+    def _convert(media):
+        out = {}
+        for k, v in media.items():
+            if isinstance(v, np.ndarray):
+                out[k] = v.tolist()
+            elif isinstance(v, dict):
+                out[k] = {kk: (vv.tolist() if isinstance(vv, np.ndarray) else vv) for kk, vv in v.items()}
+            else:
+                out[k] = v
+        return out
+
+    data = {"medias": {cid: _convert(media) for cid, media in clips_dict.items()}}
     pkl_bytes = pickle.dumps(data)
     write_container(path, pkl_bytes, {"format_version": 1})
 
@@ -365,6 +402,85 @@ class TestCombineDatasetsRun:
 
 
 # ---------------------------------------------------------------------------
+# Conflict resolution: strip-to-keep on the importer
+# ---------------------------------------------------------------------------
+
+
+class TestCombineKeepEmbedders:
+    def test_strips_loser_vectors_and_repoints_primary(self, tmp_path):
+        """With keep=[siglip], a clip's clip-only vector is stripped and its
+        primary re-pointed; the embed stage (not run() itself) later fills siglip."""
+        from vtscore.datasets.importers.combine_datasets import IMPORTER
+        from vtscore.embedding.media_vectors import media_embedder_names
+
+        ds1 = {1: _make_image_clip_embedded(1, "siglip")}
+        ds2 = {1: _make_image_clip_embedded(2, "clip")}
+        p1, p2 = tmp_path / "siglip.pkl", tmp_path / "clip.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+
+        medias: dict = {}
+        IMPORTER.run({"datasets": [str(p1), str(p2)], "keep_embedders": ["siglip"]}, medias)
+
+        assert len(medias) == 2
+        for m in medias.values():
+            # No media retains a "clip" vector; the siglip source keeps its own.
+            assert "clip" not in (m.get("embeddings") or {})
+            # Primary re-pointed to the kept score embedder for every media.
+            assert m["embedder"] == "siglip"
+            # media_embedder_names never surfaces the dropped embedder.
+            assert "clip" not in media_embedder_names(m)
+
+    def test_drop_role_strips_side_channels(self, tmp_path):
+        """Dropping the patch type strips patch_regions/patch_grid from media."""
+        from vtscore.datasets.importers.combine_datasets import IMPORTER
+
+        # A "patchy" image dataset carrying patch side-channels alongside a patch
+        # embedder, combined with a plain siglip dataset, keeping only siglip.
+        patchy = _make_image_clip_embedded(
+            1,
+            "siglip",
+            extra={
+                "embeddings": {
+                    "siglip": np.array([1.0], dtype=np.float32),
+                    "dinov3_patch": np.array([2.0], dtype=np.float32),
+                },
+                "patch_regions": [[0.0, 1.0]],
+                "patch_grid": [[3.0]],
+            },
+        )
+        plain = _make_image_clip_embedded(2, "siglip")
+        p1, p2 = tmp_path / "patchy.pkl", tmp_path / "plain.pkl"
+        _write_pickle_dataset(p1, {1: patchy})
+        _write_pickle_dataset(p2, {1: plain})
+
+        medias: dict = {}
+        IMPORTER.run({"datasets": [str(p1), str(p2)], "keep_embedders": ["siglip"]}, medias)
+
+        for m in medias.values():
+            assert "dinov3_patch" not in (m.get("embeddings") or {})
+            # The patch type was dropped, so its side-channels are gone.
+            assert "patch_regions" not in m
+            assert "patch_grid" not in m
+
+    def test_no_keep_embedders_leaves_vectors_untouched(self, tmp_path):
+        """Absent keep_embedders → the pre-conflict-UI behaviour (no stripping)."""
+        from vtscore.datasets.importers.combine_datasets import IMPORTER
+
+        ds1 = {1: _make_image_clip_embedded(1, "siglip")}
+        ds2 = {1: _make_image_clip_embedded(2, "clip")}
+        p1, p2 = tmp_path / "a.pkl", tmp_path / "b.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+
+        medias: dict = {}
+        IMPORTER.run({"datasets": [str(p1), str(p2)]}, medias)
+
+        embedders = {m["embedder"] for m in medias.values()}
+        assert embedders == {"siglip", "clip"}
+
+
+# ---------------------------------------------------------------------------
 # CLI support
 # ---------------------------------------------------------------------------
 
@@ -477,6 +593,96 @@ class TestCombineEndpoint:
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["ok"] is True
+
+    def test_refuses_unresolved_embedder_conflict(self, client, tmp_path):
+        """Two registry datasets binding different semantic embedders → 400 until
+        the caller resolves the conflict."""
+        from vtscore.datasets import registry
+
+        ds1 = {1: _make_image_clip_embedded(1, "siglip")}
+        ds2 = {1: _make_image_clip_embedded(2, "clip")}
+        p1, p2 = tmp_path / "siglip.pkl", tmp_path / "clip.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+        e1 = registry.register_dataset(
+            name="sig", media_type="image", num_items=1, pkl_path=str(p1), bound_embedders=["siglip"]
+        )
+        e2 = registry.register_dataset(
+            name="cli", media_type="image", num_items=1, pkl_path=str(p2), bound_embedders=["clip"]
+        )
+        try:
+            resp = client.post("/api/dataset/combine", json={"datasets": [str(p1), str(p2)]})
+            assert resp.status_code == 400
+            assert "Semantic" in resp.get_json()["message"]
+        finally:
+            registry.unregister_dataset(e1["id"])
+            registry.unregister_dataset(e2["id"])
+
+    def test_accepts_resolved_embedder_conflict(self, client, tmp_path):
+        """A conflict resolved via resolutions passes and forwards keep_embedders."""
+        from unittest.mock import patch
+
+        from vtscore.datasets import registry
+
+        ds1 = {1: _make_image_clip_embedded(1, "siglip")}
+        ds2 = {1: _make_image_clip_embedded(2, "clip")}
+        p1, p2 = tmp_path / "siglip.pkl", tmp_path / "clip.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+        e1 = registry.register_dataset(
+            name="sig", media_type="image", num_items=1, pkl_path=str(p1), bound_embedders=["siglip"]
+        )
+        e2 = registry.register_dataset(
+            name="cli", media_type="image", num_items=1, pkl_path=str(p2), bound_embedders=["clip"]
+        )
+        try:
+            with patch("vtsearch.routes.datasets.staging._run_importer_in_background") as mock_run:
+                mock_run.return_value = "task-1"
+                resp = client.post(
+                    "/api/dataset/combine",
+                    json={
+                        "datasets": [str(p1), str(p2)],
+                        "resolutions": {"semantic": {"action": "reembed", "embedder": "siglip"}},
+                    },
+                )
+            assert resp.status_code == 200
+            assert resp.get_json()["ok"] is True
+            # The route bakes the kept embedder set into the background load.
+            _importer, forwarded = mock_run.call_args[0]
+            assert forwarded["keep_embedders"] == ["siglip"]
+            assert forwarded["embedders"] == ["siglip"]
+            assert forwarded["embedder"] == "siglip"
+        finally:
+            registry.unregister_dataset(e1["id"])
+            registry.unregister_dataset(e2["id"])
+
+    def test_no_conflict_omits_keep_embedders(self, client, tmp_path):
+        """Matching embedders → no conflict → the fast path (no keep_embedders)."""
+        from unittest.mock import patch
+
+        from vtscore.datasets import registry
+
+        ds1 = {1: _make_image_clip_embedded(1, "siglip")}
+        ds2 = {1: _make_image_clip_embedded(2, "siglip")}
+        p1, p2 = tmp_path / "a.pkl", tmp_path / "b.pkl"
+        _write_pickle_dataset(p1, ds1)
+        _write_pickle_dataset(p2, ds2)
+        e1 = registry.register_dataset(
+            name="a", media_type="image", num_items=1, pkl_path=str(p1), bound_embedders=["siglip"]
+        )
+        e2 = registry.register_dataset(
+            name="b", media_type="image", num_items=1, pkl_path=str(p2), bound_embedders=["siglip"]
+        )
+        try:
+            with patch("vtsearch.routes.datasets.staging._run_importer_in_background") as mock_run:
+                mock_run.return_value = "task-1"
+                resp = client.post("/api/dataset/combine", json={"datasets": [str(p1), str(p2)]})
+            assert resp.status_code == 200
+            _importer, forwarded = mock_run.call_args[0]
+            assert "keep_embedders" not in forwarded
+        finally:
+            registry.unregister_dataset(e1["id"])
+            registry.unregister_dataset(e2["id"])
 
     def test_path_traversal_rejected(self, client, tmp_path):
         """In multi-user mode, paths outside the user dir must be rejected.

--- a/tests_lib/core/test_combine_conflicts.py
+++ b/tests_lib/core/test_combine_conflicts.py
@@ -1,0 +1,165 @@
+"""Per-embedder-type combine conflict detection + keep-set resolution.
+
+Exercises the pure helpers :func:`combine_type_state` and
+:func:`resolve_keep_embedders` in ``vtscore.embedding.binding`` that back the
+Combine-Datasets conflict-resolution UI.  Capabilities are stubbed so the tests
+don't depend on which concrete embedders are registered.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.embedding import binding as binding_mod
+from vtscore.embedding.binding import (
+    EMBEDDER_TYPE_PATCH_SEMANTIC,
+    EMBEDDER_TYPE_SEMANTIC,
+    EMBEDDER_TYPE_STRUCTURAL,
+    combine_type_state,
+    resolve_keep_embedders,
+)
+
+# embedder name -> (supports_text, supports_patch_regions, supports_geometric_verification)
+_FAKE_CAPS = {
+    "siglip": (True, False, False),
+    "clip": (True, False, False),
+    "single": (False, False, False),  # semantic, non-text single-vector (dinov2_single-like)
+    "dino_patch": (False, True, False),
+    "eupe_patch": (False, True, False),
+    "sift_vlad": (False, False, True),
+}
+
+
+def _fake_type(name: str | None) -> str:
+    caps = _FAKE_CAPS.get(name or "")
+    if caps is None:
+        return ""
+    if caps[2]:
+        return EMBEDDER_TYPE_STRUCTURAL
+    if caps[1]:
+        return EMBEDDER_TYPE_PATCH_SEMANTIC
+    return EMBEDDER_TYPE_SEMANTIC
+
+
+@pytest.fixture(autouse=True)
+def fake_caps(monkeypatch):
+    monkeypatch.setattr(binding_mod, "_capabilities", lambda name: _FAKE_CAPS.get(name or "", (False, False, False)))
+    monkeypatch.setattr(binding_mod, "embedder_type", _fake_type)
+
+
+class TestCombineTypeState:
+    def test_identical_single_embedder_no_conflict(self):
+        state = combine_type_state([["siglip"], ["siglip"]])
+        assert set(state) == {EMBEDDER_TYPE_SEMANTIC}
+        assert state[EMBEDDER_TYPE_SEMANTIC]["conflict"] is False
+        assert state[EMBEDDER_TYPE_SEMANTIC]["options"] == ["siglip"]
+
+    def test_name_clash_is_conflict(self):
+        state = combine_type_state([["siglip"], ["clip"]])
+        st = state[EMBEDDER_TYPE_SEMANTIC]
+        assert st["conflict"] is True
+        assert st["options"] == ["siglip", "clip"]
+        assert st["reps"] == ["siglip", "clip"]
+
+    def test_single_vector_vs_text_both_semantic_conflict(self):
+        # dinov2_single-like vs siglip: both classify semantic → conflict on the
+        # semantic type even though neither is a role "slot" clash.
+        state = combine_type_state([["single"], ["siglip"]])
+        st = state[EMBEDDER_TYPE_SEMANTIC]
+        assert st["conflict"] is True
+        assert st["options"] == ["single", "siglip"]
+
+    def test_partial_coverage_is_conflict(self):
+        # One dataset binds a patch embedder, the other doesn't.
+        state = combine_type_state([["siglip", "dino_patch"], ["siglip"]])
+        assert state[EMBEDDER_TYPE_SEMANTIC]["conflict"] is False
+        patch = state[EMBEDDER_TYPE_PATCH_SEMANTIC]
+        assert patch["conflict"] is True
+        assert patch["options"] == ["dino_patch"]
+        assert patch["n_present"] == 1
+        assert patch["n_total"] == 2
+        assert patch["reps"] == ["dino_patch", None]
+
+    def test_type_absent_everywhere_omitted(self):
+        state = combine_type_state([["siglip"], ["clip"]])
+        assert EMBEDDER_TYPE_STRUCTURAL not in state
+        assert EMBEDDER_TYPE_PATCH_SEMANTIC not in state
+
+    def test_full_trio_all_agree(self):
+        trio = ["siglip", "dino_patch", "sift_vlad"]
+        state = combine_type_state([list(trio), list(trio)])
+        assert set(state) == {
+            EMBEDDER_TYPE_SEMANTIC,
+            EMBEDDER_TYPE_PATCH_SEMANTIC,
+            EMBEDDER_TYPE_STRUCTURAL,
+        }
+        assert all(not st["conflict"] for st in state.values())
+
+    def test_semantic_text_wins_over_cobound_single_vector(self):
+        # A dataset binding both a text embedder and a single-vector one reports
+        # the text-capable embedder as its semantic representative.
+        state = combine_type_state([["siglip", "single"], ["siglip"]])
+        assert state[EMBEDDER_TYPE_SEMANTIC]["conflict"] is False
+        assert state[EMBEDDER_TYPE_SEMANTIC]["options"] == ["siglip"]
+
+
+class TestResolveKeepEmbedders:
+    def test_no_conflicts_keeps_agreed(self):
+        state = combine_type_state([["siglip"], ["siglip"]])
+        keep, err = resolve_keep_embedders(state, None)
+        assert err is None
+        assert keep == ["siglip"]
+
+    def test_unresolved_conflict_errors(self):
+        state = combine_type_state([["siglip"], ["clip"]])
+        keep, err = resolve_keep_embedders(state, None)
+        assert keep == []
+        assert err and "Semantic" in err
+
+    def test_reembed_winner_kept(self):
+        state = combine_type_state([["siglip"], ["clip"]])
+        keep, err = resolve_keep_embedders(
+            state, {EMBEDDER_TYPE_SEMANTIC: {"action": "reembed", "embedder": "clip"}}
+        )
+        assert err is None
+        assert keep == ["clip"]
+
+    def test_drop_omits_type(self):
+        # Drop the conflicted patch type; keep the agreed semantic one.
+        state = combine_type_state([["siglip", "dino_patch"], ["siglip"]])
+        keep, err = resolve_keep_embedders(state, {EMBEDDER_TYPE_PATCH_SEMANTIC: {"action": "drop"}})
+        assert err is None
+        assert keep == ["siglip"]
+
+    def test_invalid_winner_errors(self):
+        state = combine_type_state([["siglip"], ["clip"]])
+        keep, err = resolve_keep_embedders(
+            state, {EMBEDDER_TYPE_SEMANTIC: {"action": "reembed", "embedder": "dino_patch"}}
+        )
+        assert keep == []
+        assert err and "dino_patch" in err
+
+    def test_dropping_everything_errors(self):
+        state = combine_type_state([["siglip"], ["clip"]])
+        keep, err = resolve_keep_embedders(state, {EMBEDDER_TYPE_SEMANTIC: {"action": "drop"}})
+        assert keep == []
+        assert err and "At least one" in err
+
+    def test_mixed_reembed_and_drop(self):
+        # semantic conflict → re-embed to siglip; patch conflict → drop.
+        state = combine_type_state([["siglip", "dino_patch"], ["clip"]])
+        keep, err = resolve_keep_embedders(
+            state,
+            {
+                EMBEDDER_TYPE_SEMANTIC: {"action": "reembed", "embedder": "siglip"},
+                EMBEDDER_TYPE_PATCH_SEMANTIC: {"action": "drop"},
+            },
+        )
+        assert err is None
+        assert keep == ["siglip"]
+
+    def test_invalid_action_errors(self):
+        state = combine_type_state([["siglip"], ["clip"]])
+        keep, err = resolve_keep_embedders(state, {EMBEDDER_TYPE_SEMANTIC: {"action": "bogus"}})
+        assert keep == []
+        assert err

--- a/tests_lib/core/test_combine_conflicts.py
+++ b/tests_lib/core/test_combine_conflicts.py
@@ -118,9 +118,7 @@ class TestResolveKeepEmbedders:
 
     def test_reembed_winner_kept(self):
         state = combine_type_state([["siglip"], ["clip"]])
-        keep, err = resolve_keep_embedders(
-            state, {EMBEDDER_TYPE_SEMANTIC: {"action": "reembed", "embedder": "clip"}}
-        )
+        keep, err = resolve_keep_embedders(state, {EMBEDDER_TYPE_SEMANTIC: {"action": "reembed", "embedder": "clip"}})
         assert err is None
         assert keep == ["clip"]
 

--- a/vtscore/datasets/importers/combine_datasets/__init__.py
+++ b/vtscore/datasets/importers/combine_datasets/__init__.py
@@ -33,6 +33,66 @@ def _load_clips_from_pickle(file_path: Path, thin: bool = False) -> dict[int, di
     return temp_medias
 
 
+def _parse_keep_embedders(raw: Any) -> list[str]:
+    """Parse the ``keep_embedders`` field into a list of concrete names.
+
+    Accepts a list of names or a comma-separated string; empty / missing → ``[]``
+    (no conflict resolution requested — the combined dataset keeps every source's
+    vectors untouched, the pre-conflict-UI behaviour).
+    """
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        return [str(n).strip() for n in raw if str(n).strip()]
+    return [n.strip() for n in str(raw).split(",") if n.strip()]
+
+
+def _apply_keep_embedders(media: dict[str, Any], keep: set[str], kept_patch: str | None, kept_structural: str | None) -> None:
+    """Strip *media* down to the conflict-resolved *keep* embedder set, in place.
+
+    For each media in a conflict-resolved combine:
+
+    * every per-embedder vector whose name isn't in *keep* is dropped, so a
+      "dropped" type leaves no vector behind and a "re-embed" loser is removed
+      (the pipeline's embed stage then fills the kept winner on media that lack
+      it, since ``media_embedding(m, winner)`` is now ``None``);
+    * patch side-channels (``patch_regions`` / ``patch_grid``) are cleared unless
+      the media's own patch embedder is the kept one, and ``local_features``
+      unless its structural embedder is the kept one — a mismatch means the
+      side-channel belongs to a stripped embedder and is re-derived (or left
+      absent, if the type was dropped) by the embed stage's back-fill pass;
+    * the primary ``embedder`` marker is re-pointed at the combined score
+      embedder so every media in the merged dataset agrees on its primary.
+
+    Vectors/side-channels are never persisted independently (see the
+    no-persisted-vectors rule); this only prunes the in-memory dict the embed
+    stage then repopulates from source content.
+    """
+    from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
+    from vtscore.embedding.media_vectors import EMBEDDINGS_KEY, media_embedder_names  # noqa: PLC0415
+
+    orig_text, orig_patch, orig_structural = derive_binding_from_names(media_embedder_names(media))
+
+    embs = media.get(EMBEDDINGS_KEY)
+    if isinstance(embs, dict):
+        for name in list(embs.keys()):
+            if name not in keep:
+                del embs[name]
+
+    if orig_patch != kept_patch:
+        media.pop("patch_regions", None)
+        media.pop("patch_grid", None)
+    if orig_structural != kept_structural:
+        media.pop("local_features", None)
+
+    # Re-point the primary at the routed score marker (structural ▸ patch ▸
+    # text); a slot-less single-vector keep set has no role slots, so fall back
+    # to any kept name (its own primary vector drives cosine sort / the MLP).
+    kept_text = derive_binding_from_names(sorted(keep))[0]
+    score = kept_structural or kept_patch or kept_text
+    media["embedder"] = score or (next(iter(sorted(keep))) if keep else media.get("embedder", ""))
+
+
 def _parse_dataset_paths(raw: Any) -> list[Path]:
     """Parse the ``datasets`` field into a validated list of Paths.
 
@@ -161,6 +221,7 @@ class CombineDatasetsImporter(ImporterBase):
         - a Python list of path strings (when called from the API route).
         """
         paths = _parse_dataset_paths(field_values.get("datasets", ""))
+        keep_embedders = _parse_keep_embedders(field_values.get("keep_embedders"))
         progress = _get_progress()
 
         all_clips: list[dict[str, Any]] = []
@@ -188,6 +249,18 @@ class CombineDatasetsImporter(ImporterBase):
 
         if not all_clips:
             raise ValueError("No medias found in any of the selected datasets.")
+
+        # Conflict resolution: when the caller settled per-type embedder
+        # conflicts, prune every media to the kept embedder set so the pipeline's
+        # embed stage re-embeds the chosen winners and dropped types leave no
+        # vector behind.  No keep set → the combined dataset is untouched.
+        if keep_embedders:
+            keep_set = set(keep_embedders)
+            from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
+
+            _, kept_patch, kept_structural = derive_binding_from_names(keep_embedders)
+            for media in all_clips:
+                _apply_keep_embedders(media, keep_set, kept_patch, kept_structural)
 
         # Assign fresh sequential IDs and populate the target medias dict
         medias.clear()
@@ -221,6 +294,13 @@ class CombineDatasetsImporter(ImporterBase):
         across yields via a running ``seen_md5s`` set.
         """
         paths = _parse_dataset_paths(field_values.get("datasets", ""))
+        keep_embedders = _parse_keep_embedders(field_values.get("keep_embedders"))
+        keep_set = set(keep_embedders)
+        kept_patch = kept_structural = None
+        if keep_embedders:
+            from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
+
+            _, kept_patch, kept_structural = derive_binding_from_names(keep_embedders)
         progress = _get_progress()
         seen_md5s: set[str] = set()
         mtype_state: list[str | None] = [None]
@@ -230,6 +310,8 @@ class CombineDatasetsImporter(ImporterBase):
                 continue
             chunk_medias: dict[int, dict[str, Any]] = {}
             for new_id, media in enumerate(deduped, start=1):
+                if keep_set:
+                    _apply_keep_embedders(media, keep_set, kept_patch, kept_structural)
                 media["id"] = new_id
                 chunk_medias[new_id] = media
             yield chunk_medias

--- a/vtscore/datasets/importers/combine_datasets/__init__.py
+++ b/vtscore/datasets/importers/combine_datasets/__init__.py
@@ -47,7 +47,9 @@ def _parse_keep_embedders(raw: Any) -> list[str]:
     return [n.strip() for n in str(raw).split(",") if n.strip()]
 
 
-def _apply_keep_embedders(media: dict[str, Any], keep: set[str], kept_patch: str | None, kept_structural: str | None) -> None:
+def _apply_keep_embedders(
+    media: dict[str, Any], keep: set[str], kept_patch: str | None, kept_structural: str | None
+) -> None:
     """Strip *media* down to the conflict-resolved *keep* embedder set, in place.
 
     For each media in a conflict-resolved combine:

--- a/vtscore/datasets/registry.py
+++ b/vtscore/datasets/registry.py
@@ -151,6 +151,7 @@ def register_dataset(
     clipper: str = "",
     embedder: str = "",
     embedder_types: list[str] | None = None,
+    bound_embedders: list[str] | None = None,
     created_by: str = "default",
     readers: list[str] | None = None,
     file_type_counts: dict[str, int] | None = None,
@@ -173,14 +174,20 @@ def register_dataset(
     """
     import uuid
 
+    # The concrete embedder *names* this dataset binds (a v3 trio dataset carries
+    # several; a legacy dataset just its single primary).  Stored — names only,
+    # never vectors — so the combine flow can detect per-type embedder conflicts
+    # without loading each dataset.  Falls back to the single primary embedder.
+    if bound_embedders is None:
+        bound_embedders = [embedder] if embedder else []
+
     # The embedder *types* this dataset supplies (drives detector/dataset
     # compatibility gating without loading the dataset).  Callers that know the
-    # full bound set pass it; otherwise classify the single primary embedder.
+    # full bound set pass it; otherwise classify the bound embedder names.
     if embedder_types is None:
-        from vtscore.embedding.binding import embedder_type
+        from vtscore.embedding.binding import dataset_supplied_types
 
-        t = embedder_type(embedder)
-        embedder_types = [t] if t else []
+        embedder_types = sorted(dataset_supplied_types(bound_embedders))
 
     now = time.time()
     entry: dict[str, Any] = {
@@ -195,6 +202,7 @@ def register_dataset(
         "clipper": clipper,
         "embedder": embedder,
         "embedder_types": embedder_types,
+        "bound_embedders": bound_embedders,
         "created_by": created_by,
         "created_at": now,
         "readers": readers or [],

--- a/vtscore/datasets/stages/registry.py
+++ b/vtscore/datasets/stages/registry.py
@@ -59,12 +59,14 @@ def _auto_register_dataset(
     if not embedder:
         embedder = first.get("embedder", "")
 
-    # The full set of embedder types this dataset binds (a v3 trio dataset
-    # carries several), classified from the first media's bound embedders.
+    # The concrete embedders this dataset binds (a v3 trio dataset carries
+    # several), read from the first media's per-embedder vector dict, and the
+    # embedder *types* they cover (for detector/dataset compatibility gating).
     from vtscore.embedding.binding import dataset_supplied_types
     from vtscore.embedding.media_vectors import media_embedder_names
 
-    embedder_types = sorted(dataset_supplied_types(media_embedder_names(first)))
+    bound_embedders = media_embedder_names(first)
+    embedder_types = sorted(dataset_supplied_types(bound_embedders))
 
     if not name:
         name = display_name or origin_str or "Untitled"
@@ -137,6 +139,7 @@ def _auto_register_dataset(
             clipper=clipper,
             embedder=embedder,
             embedder_types=embedder_types,
+            bound_embedders=bound_embedders,
             created_by=created_by,
             file_type_counts=file_type_counts,
             ingest_started_at=ingest_started_at,

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -253,12 +253,9 @@ def resolve_keep_embedders(
         if action == "drop":
             continue
         if action == "reembed":
-            winner = res.get("embedder")
+            winner = str(res.get("embedder") or "")
             if winner not in st["options"]:
-                return [], (
-                    f"Invalid re-embed target {winner!r} for "
-                    f"{EMBEDDER_TYPE_LABELS.get(t, t)}."
-                )
+                return [], (f"Invalid re-embed target {winner!r} for {EMBEDDER_TYPE_LABELS.get(t, t)}.")
             keep.append(winner)
             continue
         return [], f"Invalid resolution action {action!r} for {EMBEDDER_TYPE_LABELS.get(t, t)}."

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -52,6 +52,15 @@ EMBEDDER_TYPE_LABELS: dict[str, str] = {
     EMBEDDER_TYPE_STRUCTURAL: "Structural",
 }
 
+#: The three types in classification precedence order (structural ▸ patch ▸
+#: semantic).  Iterating this rather than ``EMBEDDER_TYPE_LABELS.keys()`` keeps
+#: conflict/keep resolution deterministic regardless of dict insertion order.
+EMBEDDER_TYPES: tuple[str, str, str] = (
+    EMBEDDER_TYPE_STRUCTURAL,
+    EMBEDDER_TYPE_PATCH_SEMANTIC,
+    EMBEDDER_TYPE_SEMANTIC,
+)
+
 
 def _capabilities(embedder_name: str) -> tuple[bool, bool, bool]:
     """Return ``(supports_text, supports_patch_regions, supports_geometric_verification)``.
@@ -153,6 +162,114 @@ def detector_dataset_compatible(det_type: str, embedder_names: Iterable[str | No
     if not det_type:
         return True
     return embedder_of_type(embedder_names, det_type) is not None
+
+
+def combine_type_state(
+    per_dataset_embedders: list[list[str]],
+) -> dict[str, dict[str, Any]]:
+    """Per-embedder-type combine state across the datasets being merged.
+
+    *per_dataset_embedders* is one bound-embedder-name list per source dataset
+    (the keys of each dataset's ``media["embeddings"]``, or its single legacy
+    embedder name).  For each of the three types (:data:`EMBEDDER_TYPES`) that at
+    least one dataset supplies, returns::
+
+        {type: {
+            "reps": [concrete-name-or-None, ... one per dataset],
+            "options": [distinct concrete names, in first-seen order],
+            "conflict": bool,
+            "n_present": int,   # datasets that supply the type
+            "n_total": int,     # total datasets
+        }}
+
+    A type is **conflicted** when the datasets don't all bind the *same* concrete
+    embedder for it — either two datasets bind different concrete embedders of
+    that type (a name clash), or some datasets supply it and others don't (partial
+    coverage).  Combining a conflicted type without resolution would leave the
+    merged dataset with an incompatible or half-populated vector space for that
+    type, which is exactly what the combine conflict UI settles.
+
+    Types no dataset supplies are omitted (nothing to combine).  Per-dataset
+    representatives come from :func:`embedder_of_type`, so the semantic bucket's
+    text-capable embedder wins over a co-bound single-vector one, matching the
+    score-routing precedence.
+    """
+    n_total = len(per_dataset_embedders)
+    result: dict[str, dict[str, Any]] = {}
+    for t in EMBEDDER_TYPES:
+        reps = [embedder_of_type(names, t) for names in per_dataset_embedders]
+        present = [r for r in reps if r]
+        if not present:
+            continue
+        options: list[str] = []
+        for r in present:
+            if r not in options:
+                options.append(r)
+        conflict = len(options) > 1 or len(present) < n_total
+        result[t] = {
+            "reps": reps,
+            "options": options,
+            "conflict": conflict,
+            "n_present": len(present),
+            "n_total": n_total,
+        }
+    return result
+
+
+def resolve_keep_embedders(
+    type_state: dict[str, dict[str, Any]],
+    resolutions: dict[str, dict[str, Any]] | None,
+) -> tuple[list[str], str | None]:
+    """Turn per-type combine state + user resolutions into the kept embedder set.
+
+    *type_state* is :func:`combine_type_state`'s output; *resolutions* maps a
+    **conflicted** type to a choice of ``{"action": "reembed", "embedder": name}``
+    (re-embed every source to *name*) or ``{"action": "drop"}`` (leave that type
+    out of the combined dataset).
+
+    Returns ``(keep_embedders, error)``.  ``keep_embedders`` is the deduped set of
+    concrete embedders the combined dataset should bind:
+
+    * a **non-conflicted** type keeps its single agreed embedder automatically
+      (no resolution required);
+    * a **conflicted** type kept via ``reembed`` contributes its winner;
+    * a **conflicted** type ``drop``-ped contributes nothing.
+
+    ``error`` is a human-readable string (and ``keep_embedders`` is ``[]``) when a
+    conflicted type has no/invalid resolution, when a ``reembed`` winner isn't one
+    of that type's options, or when every type ends up dropped (an empty binding
+    has nothing to sort or search).  On success ``error`` is ``None``.
+    """
+    resolutions = resolutions or {}
+    keep: list[str] = []
+    for t, st in type_state.items():
+        if not st["conflict"]:
+            keep.append(st["options"][0])
+            continue
+        res = resolutions.get(t)
+        if not isinstance(res, dict):
+            return [], f"Unresolved embedder conflict for {EMBEDDER_TYPE_LABELS.get(t, t)}."
+        action = res.get("action")
+        if action == "drop":
+            continue
+        if action == "reembed":
+            winner = res.get("embedder")
+            if winner not in st["options"]:
+                return [], (
+                    f"Invalid re-embed target {winner!r} for "
+                    f"{EMBEDDER_TYPE_LABELS.get(t, t)}."
+                )
+            keep.append(winner)
+            continue
+        return [], f"Invalid resolution action {action!r} for {EMBEDDER_TYPE_LABELS.get(t, t)}."
+
+    deduped: list[str] = []
+    for name in keep:
+        if name not in deduped:
+            deduped.append(name)
+    if not deduped:
+        return [], "At least one embedder must be kept in the combined dataset."
+    return deduped, None
 
 
 def derive_binding(embedder_name: str | None) -> tuple[str | None, str | None, str | None]:

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -108,14 +108,26 @@ def list_registered_datasets():
         entry.setdefault("num_dupes", 0)
         entry.setdefault("embedder", "")
         entry.setdefault("readers", [])
+        # The concrete embedders this dataset binds.  Legacy entries (registered
+        # before the field existed) fall back to their single primary embedder.
+        bound = entry.get("bound_embedders")
+        if not bound:
+            bound = [entry["embedder"]] if entry.get("embedder") else []
+            entry["bound_embedders"] = bound
         # The embedder types this dataset supplies, for the detector/dataset
-        # compatibility gate.  Fall back to classifying the single primary
-        # embedder for legacy entries registered before the field existed.
+        # compatibility gate.  Fall back to classifying the bound embedders.
         if not entry.get("embedder_types"):
-            from vtscore.embedding.binding import embedder_type
+            from vtscore.embedding.binding import dataset_supplied_types
 
-            t = embedder_type(entry.get("embedder", ""))
-            entry["embedder_types"] = [t] if t else []
+            entry["embedder_types"] = sorted(dataset_supplied_types(bound))
+        # One concrete embedder per type (semantic / patch_semantic / structural),
+        # so the Combine-Datasets modal can detect per-type conflicts client-side
+        # without shipping the capability taxonomy to the frontend.
+        from vtscore.embedding.binding import EMBEDDER_TYPES, embedder_of_type
+
+        entry["embedders_by_type"] = {
+            t: name for t in EMBEDDER_TYPES if (name := embedder_of_type(bound, t))
+        }
         # Resolve clipper name to display name; default clippers show as "-"
         raw_clipper = entry.get("clipper", "")
         if raw_clipper:

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -125,9 +125,7 @@ def list_registered_datasets():
         # without shipping the capability taxonomy to the frontend.
         from vtscore.embedding.binding import EMBEDDER_TYPES, embedder_of_type
 
-        entry["embedders_by_type"] = {
-            t: name for t in EMBEDDER_TYPES if (name := embedder_of_type(bound, t))
-        }
+        entry["embedders_by_type"] = {t: name for t in EMBEDDER_TYPES if (name := embedder_of_type(bound, t))}
         # Resolve clipper name to display name; default clippers show as "-"
         raw_clipper = entry.get("clipper", "")
         if raw_clipper:

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -38,6 +38,7 @@ from vtscore.datasets.load_pipeline import (
     _stage_importer_in_background,
 )
 from vtscore.datasets.registry import (
+    find_by_pkl_path as _reg_find_by_pkl,
     get_dataset as _reg_get,
     get_saved_datasets_dir,
     register_dataset as _reg_register,
@@ -89,15 +90,43 @@ def available_dataset_files():
     return {"files": files}
 
 
+def _bound_embedders_for_path(path: str) -> list[str]:
+    """The concrete embedders a to-be-combined dataset binds, for conflict checks.
+
+    Reads the persisted ``bound_embedders`` off the registry entry whose pkl this
+    path names (falling back to its single legacy ``embedder``).  A path with no
+    registry entry (a raw staged / demo pkl) returns ``[]`` — its embedders are
+    unknown without loading it, so it contributes nothing to conflict detection.
+    """
+    entry = _reg_find_by_pkl(path)
+    if entry is None:
+        return []
+    bound = entry.get("bound_embedders")
+    if bound:
+        return [str(n) for n in bound if n]
+    emb = entry.get("embedder")
+    return [emb] if emb else []
+
+
 @datasets_staging_bp.route("/api/dataset/combine", methods=["POST"])
 @datasets_staging_bp.arguments(DatasetCombineRequestSchema)
 @datasets_staging_bp.response(200, DatasetLoadStartedResponseSchema)
-@datasets_staging_bp.alt_response(400, description="Invalid or missing dataset path.")
+@datasets_staging_bp.alt_response(400, description="Invalid path, or an unresolved embedder conflict.")
 @datasets_staging_bp.alt_response(500, description="The combine_datasets importer is unavailable.")
 def combine_datasets_route(body: dict):
-    """Combine multiple pickle datasets in a background thread."""
+    """Combine multiple pickle datasets in a background thread.
+
+    When the sources bind conflicting embedders of the same type (e.g. one
+    ``siglip`` dataset and one ``clip`` dataset, both semantic), the caller must
+    settle each conflict via ``resolutions`` — re-embed every source to one
+    winner, or drop that embedder type from the result.  An unresolved conflict
+    is refused (400) rather than silently producing a mixed vector space; the
+    Combine-Datasets modal detects the conflicts client-side and collects the
+    resolutions before posting here.
+    """
     dataset_paths = body["datasets"]
     name = str(body.get("name", "") or "").strip()
+    resolutions = body.get("resolutions") or {}
 
     _base = _paths.get_file_access_base_dir()
     for p in dataset_paths:
@@ -112,7 +141,33 @@ def combine_datasets_route(body: dict):
     if importer is None:
         abort(500, message="combine_datasets importer not available")
 
-    task_id = _run_importer_in_background(importer, {"datasets": dataset_paths, "name": name})
+    field_values: dict = {"datasets": dataset_paths, "name": name}
+
+    # Detect per-embedder-type conflicts across the sources and, when present,
+    # bake the caller's resolution into the load: pass the kept embedder set so
+    # the combine importer prunes to it and the pipeline's embed stage re-embeds
+    # the winners.  No conflict → the pre-conflict-UI fast path (no re-embed).
+    from vtscore.embedding.binding import (
+        combine_type_state,
+        derive_binding_from_names,
+        resolve_keep_embedders,
+    )
+
+    # Only datasets whose embedders are *known* (registry-backed) inform conflict
+    # detection; a raw staged pkl with unknown embedders is skipped rather than
+    # counted as "missing" (which would flag a spurious partial-coverage conflict).
+    per_dataset = [be for p in dataset_paths if (be := _bound_embedders_for_path(str(p)))]
+    type_state = combine_type_state(per_dataset)
+    if any(st["conflict"] for st in type_state.values()):
+        keep, err = resolve_keep_embedders(type_state, resolutions)
+        if err:
+            abort(400, message=err)
+        text, patch, structural = derive_binding_from_names(keep)
+        field_values["keep_embedders"] = keep
+        field_values["embedders"] = keep
+        field_values["embedder"] = structural or patch or text or (keep[0] if keep else "")
+
+    task_id = _run_importer_in_background(importer, field_values)
     return {"ok": True, "message": "Combining datasets...", "task_id": str(task_id) if task_id else ""}
 
 

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -609,6 +609,19 @@ class DatasetAvailableFilesResponseSchema(Schema):
     files = fields.List(fields.Nested(_AvailableDatasetFileSchema), required=True)
 
 
+class DatasetCombineResolutionSchema(Schema):
+    """One per-embedder-type conflict resolution in a combine request.
+
+    ``action`` is ``"reembed"`` (re-embed every source dataset to *embedder* so
+    the whole combined dataset shares that concrete embedder) or ``"drop"``
+    (leave that embedder type out of the combined dataset entirely).  ``embedder``
+    is required for ``reembed`` and ignored for ``drop``.
+    """
+
+    action = fields.String(required=True, validate=validate.OneOf(["reembed", "drop"]))
+    embedder = fields.String(load_default="")
+
+
 class DatasetCombineRequestSchema(Schema):
     """Body for ``POST /api/dataset/combine``."""
 
@@ -619,6 +632,16 @@ class DatasetCombineRequestSchema(Schema):
         metadata={"description": "At least two server-side pickle file paths to merge."},
     )
     name = fields.String(load_default="")
+    #: Per-embedder-type conflict resolutions, keyed by embedder type
+    #: (``semantic`` / ``patch_semantic`` / ``structural``).  Present only when
+    #: the sources bind conflicting embedders of the same type; the combine route
+    #: refuses (400) a conflict left unresolved here.
+    resolutions = fields.Dict(
+        keys=fields.String(),
+        values=fields.Nested(DatasetCombineResolutionSchema),
+        load_default=dict,
+        metadata={"description": "Embedder-type -> {action, embedder} conflict resolutions."},
+    )
 
 
 class DatasetPromoteRequestSchema(Schema):
@@ -860,6 +883,7 @@ __all__ = [
     "DatasetAvailableFilesResponseSchema",
     "DatasetClearResponseSchema",
     "DatasetCombineRequestSchema",
+    "DatasetCombineResolutionSchema",
     "DatasetDomainShiftResponseSchema",
     "DatasetImportersListResponseSchema",
     "DatasetLoadDemoRequestSchema",


### PR DESCRIPTION
## Summary

Issue #2667 asked Combine Datasets to **refuse** a mismatched embedder triple. Per follow-up direction, this instead gives the user a **window to settle the conflict**: for each of the three embedder *types* (semantic / patch_semantic / structural), when the selected datasets don't agree on one concrete embedder, the modal offers **re-embed every source to one winner** or **drop that type** from the combined dataset.

The strict refusal is kept as a **backstop for programmatic callers**: the combine route still returns `400` on an *unresolved* conflict, so #2667's guard holds for anything that doesn't go through the modal.

Refs #2667 (behavior superseded: resolve rather than refuse; the refusal remains as the unresolved-conflict backstop).

## What counts as a conflict

Conflict detection uses the codebase's **type taxonomy** (`binding.py::embedder_type`: semantic / patch_semantic / structural), not just the text/patch/structural role slots — so a `dinov2_single`-vs-`siglip` mix (both semantic) is caught, not only role-slot clashes. A type is conflicted when the datasets bind **different** concrete embedders of it **or** some bind it and others don't (partial coverage). Both are settled by the same re-embed / drop choice.

## How it works

- **Detection (pure, library-tier):** `combine_type_state()` computes per-type reps/options/conflict across the sources; `resolve_keep_embedders()` turns the user's choices into the final kept-embedder set (non-conflicted types auto-kept; dropping everything is rejected).
- **Registry:** datasets now persist `bound_embedders` (concrete names — never vectors/MLPs, per the no-persisted-vectors rule); the `/api/datasets/registry` listing exposes `embedders_by_type` so the modal detects conflicts client-side (no capability logic on the frontend, instant reaction to row removal).
- **Apply:** the combine route bakes the resolution into the background load by passing `keep_embedders` + `embedders`. The importer prunes each media to the kept set (stripping loser vectors and stale patch/structural side-channels and re-pointing the primary); the pipeline's **existing** embed stage then re-embeds the winners from source content and re-derives side-channels. Dropped types simply leave no vector. No conflict → the original fast path (no re-embed), byte-for-byte.
- **Frontend:** a per-type resolution panel in the Combine modal gates the Combine button until every conflict is settled and at least one embedder remains.

## Tests

- `tests_lib/core/test_combine_conflicts.py` — conflict detection + keep-set resolution (name clash, single-vector-vs-text, partial coverage, drop-everything rejection, mixed re-embed/drop).
- `tests/datasets/test_combine_datasets.py` — importer strip-to-keep (loser vectors + side-channels + primary re-point) and route behavior (refuse unresolved, accept resolved and forward `keep_embedders`, no-conflict fast path).
- Combine-modal Vitest — conflict detection, gating, resolution submission, choice-pruning on row removal.
- Full `./run-tests.sh` green (6582 passed); OpenAPI snapshot regenerated; pyright clean.

## Notes

- OpenAPI snapshot (`frontend/openapi.json`) regenerated for the new `resolutions` request field / `DatasetCombineResolution` schema.
- Non-registry (raw staged/demo) pkls have unknown embedders and are skipped from conflict detection rather than flagged as spurious partial-coverage conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHjUWnudUarW9pHwmTkGn7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHjUWnudUarW9pHwmTkGn7)_