### PR TITLE
NPZ server_files importer: per-embedder vectors_&lt;name&gt; layout

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -189,8 +189,10 @@ is the **score** embedder (structural ▸ patch ▸ text) the model was trained 
 - **`ConcurrencyGate`** (`load_pipeline.py`) gates embed work; a multi-embedder
   dataset takes proportionally longer, gated under the same `_embed_gate` limit.
 - **Dataset pickle schema version** bumps; old pickles load via the read-time re-key.
-- **NPZ paths-file** grows an optional `vectors_<embedder_name>` layout; the existing
-  single-`vectors` layout maps to the score-role slot. (Open follow-up.)
+- **NPZ paths-file** accepts an optional `vectors_<embedder_name>` layout (one array
+  per bound embedder, read by `read_npz_multi_vectors` / written by
+  `write_npz_multi_vectors`); the existing single-`vectors` layout maps to the
+  score-role slot.
 - **Combine Datasets** requires identical
   `(text_embedder, patch_embedder, structural_embedder)` triples. (Guard is an open
   follow-up.)

--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -243,10 +243,14 @@ class TestWriteNpzMultiVectors:
     def test_round_trips_through_reader(self, tmp_path):
         rng = np.random.default_rng(7)
         mapping = {
-            "a.jpg": {"siglip": rng.standard_normal(3).astype(np.float32),
-                      "dinov3_patch": rng.standard_normal(4).astype(np.float32)},
-            "b.jpg": {"siglip": rng.standard_normal(3).astype(np.float32),
-                      "dinov3_patch": rng.standard_normal(4).astype(np.float32)},
+            "a.jpg": {
+                "siglip": rng.standard_normal(3).astype(np.float32),
+                "dinov3_patch": rng.standard_normal(4).astype(np.float32),
+            },
+            "b.jpg": {
+                "siglip": rng.standard_normal(3).astype(np.float32),
+                "dinov3_patch": rng.standard_normal(4).astype(np.float32),
+            },
         }
         npz = tmp_path / "out.npz"
         write_npz_multi_vectors(npz, mapping, primary_embedder="dinov3_patch")

--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -22,7 +22,12 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from vtscore.datasets.importers._npz_vectors import read_npz_embedder_name, read_npz_filenames_and_vectors
+from vtscore.datasets.importers._npz_vectors import (
+    read_npz_embedder_name,
+    read_npz_filenames_and_vectors,
+    read_npz_multi_vectors,
+    write_npz_multi_vectors,
+)
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.datasets.importers.server_files import (
     ServerFilesDatasetImporter,
@@ -143,6 +148,139 @@ class TestReadNpzEmbedderName:
 # ---------------------------------------------------------------------------
 # server_files paths-file plumbing
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# read_npz_multi_vectors / write_npz_multi_vectors (per-embedder trio layout)
+# ---------------------------------------------------------------------------
+
+
+class TestReadNpzMultiVectors:
+    def test_returns_none_without_per_embedder_keys(self, tmp_path):
+        # A plain single-``vectors`` archive has no vectors_<name> key, so the
+        # multi reader declines it (signalling the single-vector fallback).
+        npz = tmp_path / "single.npz"
+        np.savez(npz, filenames=np.array(["a.wav"]), vectors=np.zeros((1, 4), dtype=np.float32))
+        assert read_npz_multi_vectors(npz) is None
+
+    def test_reads_per_embedder_columns(self, tmp_path):
+        siglip = np.arange(6, dtype=np.float32).reshape(2, 3)
+        patch = (np.arange(8, dtype=np.float32) + 100).reshape(2, 4)
+        npz = tmp_path / "multi.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["a.jpg", "b.jpg"]),
+            vectors_siglip=siglip,
+            vectors_dinov3_patch=patch,
+        )
+        mapping, primary = read_npz_multi_vectors(npz)
+        assert set(mapping) == {"a.jpg", "b.jpg"}
+        assert set(mapping["a.jpg"]) == {"siglip", "dinov3_patch"}
+        np.testing.assert_array_equal(mapping["a.jpg"]["siglip"], siglip[0])
+        np.testing.assert_array_equal(mapping["b.jpg"]["dinov3_patch"], patch[1])
+        # No scalar embedder_name → the first column (archive order) is primary.
+        assert primary == "siglip"
+
+    def test_embedder_name_scalar_designates_primary(self, tmp_path):
+        npz = tmp_path / "multi.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["a.jpg"]),
+            vectors_siglip=np.zeros((1, 3), dtype=np.float32),
+            vectors_dinov3_patch=np.zeros((1, 4), dtype=np.float32),
+            embedder_name=np.array("dinov3_patch"),
+        )
+        _mapping, primary = read_npz_multi_vectors(npz)
+        assert primary == "dinov3_patch"
+
+    def test_primary_falls_back_when_scalar_not_a_column(self, tmp_path):
+        # A scalar naming an embedder that has no vectors_<name> column can't be
+        # the primary; the leading column wins instead.
+        npz = tmp_path / "multi.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["a.jpg"]),
+            vectors_siglip=np.zeros((1, 3), dtype=np.float32),
+            embedder_name=np.array("clip"),
+        )
+        _mapping, primary = read_npz_multi_vectors(npz)
+        assert primary == "siglip"
+
+    def test_embedder_name_with_underscores_preserved(self, tmp_path):
+        # Only the leading ``vectors_`` prefix is stripped, so an embedder name
+        # that itself contains underscores survives intact.
+        npz = tmp_path / "multi.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["a.jpg"]),
+            vectors_dinov3_patch=np.zeros((1, 4), dtype=np.float32),
+        )
+        mapping, _primary = read_npz_multi_vectors(npz)
+        assert set(mapping["a.jpg"]) == {"dinov3_patch"}
+
+    def test_mismatched_column_length_raises(self, tmp_path):
+        npz = tmp_path / "multi.npz"
+        np.savez(
+            npz,
+            filenames=np.array(["a.jpg", "b.jpg"]),
+            vectors_siglip=np.zeros((1, 3), dtype=np.float32),  # only 1 row for 2 files
+        )
+        with pytest.raises(ValueError, match="mismatched lengths"):
+            read_npz_multi_vectors(npz)
+
+    def test_missing_filenames_raises(self, tmp_path):
+        npz = tmp_path / "multi.npz"
+        np.savez(npz, vectors_siglip=np.zeros((2, 3), dtype=np.float32))
+        with pytest.raises(ValueError, match="filenames"):
+            read_npz_multi_vectors(npz)
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_npz_multi_vectors(tmp_path / "nope.npz")
+
+
+class TestWriteNpzMultiVectors:
+    def test_round_trips_through_reader(self, tmp_path):
+        rng = np.random.default_rng(7)
+        mapping = {
+            "a.jpg": {"siglip": rng.standard_normal(3).astype(np.float32),
+                      "dinov3_patch": rng.standard_normal(4).astype(np.float32)},
+            "b.jpg": {"siglip": rng.standard_normal(3).astype(np.float32),
+                      "dinov3_patch": rng.standard_normal(4).astype(np.float32)},
+        }
+        npz = tmp_path / "out.npz"
+        write_npz_multi_vectors(npz, mapping, primary_embedder="dinov3_patch")
+
+        read_back, primary = read_npz_multi_vectors(npz)
+        assert primary == "dinov3_patch"
+        assert set(read_back) == set(mapping)
+        for fname, cols in mapping.items():
+            for emb, vec in cols.items():
+                np.testing.assert_array_equal(read_back[fname][emb], vec)
+
+    def test_compressed_round_trips(self, tmp_path):
+        mapping = {"a.jpg": {"siglip": np.ones(3, dtype=np.float32)}}
+        npz = tmp_path / "out.npz"
+        write_npz_multi_vectors(npz, mapping, compressed=True)
+        read_back, _primary = read_npz_multi_vectors(npz)
+        np.testing.assert_array_equal(read_back["a.jpg"]["siglip"], np.ones(3, dtype=np.float32))
+
+    def test_empty_mapping_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="empty"):
+            write_npz_multi_vectors(tmp_path / "out.npz", {})
+
+    def test_misaligned_columns_raise(self, tmp_path):
+        mapping = {
+            "a.jpg": {"siglip": np.zeros(3, dtype=np.float32), "dinov3_patch": np.zeros(4, dtype=np.float32)},
+            "b.jpg": {"siglip": np.zeros(3, dtype=np.float32)},  # missing dinov3_patch column
+        }
+        with pytest.raises(ValueError, match="columns must align"):
+            write_npz_multi_vectors(tmp_path / "out.npz", mapping)
+
+    def test_primary_not_a_column_raises(self, tmp_path):
+        mapping = {"a.jpg": {"siglip": np.zeros(3, dtype=np.float32)}}
+        with pytest.raises(ValueError, match="not among"):
+            write_npz_multi_vectors(tmp_path / "out.npz", mapping, primary_embedder="clip")
 
 
 class TestServerFilesFieldsAdvertiseNpz:
@@ -359,6 +497,109 @@ class TestServerFilesNpzRunsEndToEnd:
         assert len(medias) == 1
         media = next(iter(medias.values()))
         assert media["origin_name"] == str(src)
+
+
+# ---------------------------------------------------------------------------
+# server_files end-to-end: per-embedder vectors_<name> archive (V3 trio, #2669)
+# ---------------------------------------------------------------------------
+
+
+class TestServerFilesMultiVectorsEndToEnd:
+    def _write_wavs(self, tmp_path):
+        from helpers import make_raw_wav_bytes
+
+        src_a = tmp_path / "src_a.wav"
+        src_b = tmp_path / "src_b.wav"
+        src_a.write_bytes(make_raw_wav_bytes())
+        src_b.write_bytes(make_raw_wav_bytes() + b"\x00\x00")
+        return src_a, src_b
+
+    def test_read_npz_paths_file_returns_per_embedder_dicts(self, tmp_path):
+        src_a, src_b = self._write_wavs(tmp_path)
+        npz = tmp_path / "multi.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(src_a), str(src_b)]),
+            vectors_clap=np.arange(8, dtype=np.float32).reshape(2, 4),
+            vectors_ast=(np.arange(8, dtype=np.float32) + 50).reshape(2, 4),
+            embedder_name=np.array("clap"),
+        )
+        paths, path_to_vector, embedder_name = _read_npz_paths_file(npz)
+        assert paths == [src_a, src_b]
+        assert embedder_name == "clap"
+        # Each resolved path maps to a per-embedder dict, not a bare vector.
+        assert set(path_to_vector[str(src_a)]) == {"clap", "ast"}
+
+    def test_both_embedders_stored_on_media(self, tmp_path):
+        """A vectors_<name> archive lands one vector per embedder under
+        media['embeddings'], with the scalar embedder_name as the primary."""
+        src_a, src_b = self._write_wavs(tmp_path)
+        rng = np.random.default_rng(3)
+        clap = rng.standard_normal((2, 512)).astype(np.float32)
+        ast = rng.standard_normal((2, 512)).astype(np.float32)
+        npz = tmp_path / "multi.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(src_a), str(src_b)]),
+            vectors_clap=clap,
+            vectors_ast=ast,
+            embedder_name=np.array("clap"),
+        )
+
+        imp = ServerFilesDatasetImporter()
+        medias: dict = {}
+        imp.run({"paths_file": str(npz), "media_type": "audio"}, medias)
+
+        assert len(medias) == 2
+        by_source = {m["origin_name"]: m for m in medias.values()}
+        for src, i in ((src_a, 0), (src_b, 1)):
+            media = by_source[str(src)]
+            # Both embedders' vectors are present and unmodified.
+            np.testing.assert_array_equal(media_embedding(media, "clap"), clap[i])
+            np.testing.assert_array_equal(media_embedding(media, "ast"), ast[i])
+            # The scalar embedder_name is recorded as the primary/score embedder.
+            assert media["embedder"] == "clap"
+            np.testing.assert_array_equal(media_embedding(media), clap[i])
+
+    def test_binding_derives_a_slot_per_capable_embedder(self, tmp_path):
+        """The dataset binding recovered from a multi-vector media's embedder
+        keys fills a distinct role slot per capable embedder (siglip→text,
+        dinov3_patch→patch)."""
+        from vtscore.embedding.binding import derive_binding_from_names
+        from vtscore.embedding.media_vectors import init_embeddings, media_embedder_names
+
+        media = {
+            "embedder": "siglip",
+            "embeddings": init_embeddings(
+                "siglip",
+                {"siglip": np.zeros(3, dtype=np.float32), "dinov3_patch": np.zeros(4, dtype=np.float32)},
+            ),
+        }
+        names = media_embedder_names(media)
+        assert set(names) == {"siglip", "dinov3_patch"}
+        text, patch, structural = derive_binding_from_names(names)
+        assert text == "siglip"
+        assert patch == "dinov3_patch"
+        assert structural is None
+
+    def test_unregistered_column_name_rejected_at_import(self, tmp_path):
+        """Every named column binds a role slot, so an unroutable name in *any*
+        column is rejected up front (not just the primary)."""
+        src_a, _src_b = self._write_wavs(tmp_path)
+        npz = tmp_path / "multi.npz"
+        np.savez(
+            npz,
+            filenames=np.array([str(src_a)]),
+            vectors_clap=np.zeros((1, 512), dtype=np.float32),
+            vectors_not_a_real_embedder=np.zeros((1, 512), dtype=np.float32),
+            embedder_name=np.array("clap"),
+        )
+        imp = ServerFilesDatasetImporter()
+        medias: dict = {}
+        with pytest.raises(ValueError) as exc:
+            imp.run({"paths_file": str(npz), "media_type": "audio"}, medias)
+        assert "not_a_real_embedder" in str(exc.value)
+        assert medias == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -37,6 +37,13 @@ from vtscore.datasets.importers.server_files import (
 )
 
 
+def _read_multi(npz):
+    """Read a per-embedder archive, asserting it is recognised (narrows None)."""
+    result = read_npz_multi_vectors(npz)
+    assert result is not None
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Low-level NPZ reader helper
 # ---------------------------------------------------------------------------
@@ -173,7 +180,7 @@ class TestReadNpzMultiVectors:
             vectors_siglip=siglip,
             vectors_dinov3_patch=patch,
         )
-        mapping, primary = read_npz_multi_vectors(npz)
+        mapping, primary = _read_multi(npz)
         assert set(mapping) == {"a.jpg", "b.jpg"}
         assert set(mapping["a.jpg"]) == {"siglip", "dinov3_patch"}
         np.testing.assert_array_equal(mapping["a.jpg"]["siglip"], siglip[0])
@@ -190,7 +197,7 @@ class TestReadNpzMultiVectors:
             vectors_dinov3_patch=np.zeros((1, 4), dtype=np.float32),
             embedder_name=np.array("dinov3_patch"),
         )
-        _mapping, primary = read_npz_multi_vectors(npz)
+        _mapping, primary = _read_multi(npz)
         assert primary == "dinov3_patch"
 
     def test_primary_falls_back_when_scalar_not_a_column(self, tmp_path):
@@ -203,7 +210,7 @@ class TestReadNpzMultiVectors:
             vectors_siglip=np.zeros((1, 3), dtype=np.float32),
             embedder_name=np.array("clip"),
         )
-        _mapping, primary = read_npz_multi_vectors(npz)
+        _mapping, primary = _read_multi(npz)
         assert primary == "siglip"
 
     def test_embedder_name_with_underscores_preserved(self, tmp_path):
@@ -215,7 +222,7 @@ class TestReadNpzMultiVectors:
             filenames=np.array(["a.jpg"]),
             vectors_dinov3_patch=np.zeros((1, 4), dtype=np.float32),
         )
-        mapping, _primary = read_npz_multi_vectors(npz)
+        mapping, _primary = _read_multi(npz)
         assert set(mapping["a.jpg"]) == {"dinov3_patch"}
 
     def test_mismatched_column_length_raises(self, tmp_path):
@@ -255,7 +262,7 @@ class TestWriteNpzMultiVectors:
         npz = tmp_path / "out.npz"
         write_npz_multi_vectors(npz, mapping, primary_embedder="dinov3_patch")
 
-        read_back, primary = read_npz_multi_vectors(npz)
+        read_back, primary = _read_multi(npz)
         assert primary == "dinov3_patch"
         assert set(read_back) == set(mapping)
         for fname, cols in mapping.items():
@@ -266,7 +273,7 @@ class TestWriteNpzMultiVectors:
         mapping = {"a.jpg": {"siglip": np.ones(3, dtype=np.float32)}}
         npz = tmp_path / "out.npz"
         write_npz_multi_vectors(npz, mapping, compressed=True)
-        read_back, _primary = read_npz_multi_vectors(npz)
+        read_back, _primary = _read_multi(npz)
         np.testing.assert_array_equal(read_back["a.jpg"]["siglip"], np.ones(3, dtype=np.float32))
 
     def test_empty_mapping_raises(self, tmp_path):

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -346,7 +346,8 @@ def write_npz_multi_vectors(
         arrays["embedder_name"] = np.array(primary_embedder)
 
     save = np.savez_compressed if compressed else np.savez
-    save(str(npz_path), **arrays)
+    # numpy's savez stub mis-binds unpacked kwargs to allow_pickle.
+    save(str(npz_path), **arrays)  # pyright: ignore[reportArgumentType]
 
 
 def read_npz_archive_member_rows(npz_path: Path) -> list[dict]:

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -4,7 +4,7 @@ The ``server_files`` and ``local_files`` importers accept an ``.npz`` archive
 of pre-computed embeddings instead of (or alongside) raw media files, so
 users who have already embedded their data don't have to re-embed it.
 
-Two NPZ layouts are supported:
+Three NPZ layouts are supported:
 
 1. **filenames + vectors** (preferred) - Two top-level arrays,
    ``filenames`` (1-D string-like) and ``vectors`` (2-D float).  The
@@ -19,10 +19,23 @@ Two NPZ layouts are supported:
    ``dict``, so it carries a noticeable memory overhead at scale (roughly
    ~450 MB resident for 100k rows of 1152-dim ``float32``).  Fine for
    ~10k-row archives; prefer layout 1 above that.
+3. **filenames + per-embedder vectors** (V3 trio) - ``filenames`` plus one
+   ``vectors_<embedder_name>`` array per bound embedder (e.g.
+   ``vectors_siglip`` + ``vectors_dinov3_patch``), each ``(N, D)`` and aligned
+   with ``filenames``.  A single pre-embedded archive can then carry every
+   bound embedder's vector at once, so importing it populates all of a trio
+   dataset's role slots (``media["embeddings"]`` becomes a per-embedder dict).
+   An optional scalar ``embedder_name`` names the **primary** (score-role)
+   embedder; absent, the first ``vectors_<name>`` key (archive order) leads.
+   Read by :func:`read_npz_multi_vectors`, written by
+   :func:`write_npz_multi_vectors` (the symmetric producer, so the layout has
+   an in-repo round-trip: export a dataset's per-embedder vectors, re-import
+   them).
 
-The standard layout is tried first; if neither expected key is present
-the per-key layout is assumed.  ``allow_pickle`` is disabled to avoid
-loading arbitrary Python objects from untrusted archives.
+Layout 3 (per-embedder) is detected first (any ``vectors_<name>`` key), then
+the standard ``filenames`` + ``vectors`` layout, and finally the per-key
+layout.  ``allow_pickle`` is disabled to avoid loading arbitrary Python
+objects from untrusted archives.
 """
 
 from __future__ import annotations
@@ -36,6 +49,12 @@ import numpy as np
 
 _FILENAMES_KEYS = ("filenames", "names", "paths", "filename")
 _VECTORS_KEYS = ("vectors", "embeddings", "vecs", "embedding")
+#: Prefixes that mark a per-embedder vector array in the V3 trio layout.  A key
+#: ``vectors_siglip`` (or ``embeddings_siglip`` / ``vecs_siglip``) contributes a
+#: vector for the embedder named by the text after the prefix.  The trailing
+#: underscore keeps these from colliding with the bare single-vector keys in
+#: ``_VECTORS_KEYS`` ("vectors" never matches "vectors_").
+_VECTORS_PREFIXES = ("vectors_", "embeddings_", "vecs_")
 _EMBEDDER_NAME_KEYS = ("embedder_name", "embedder")
 _MEMBERS_KEYS = ("members", "member")
 _ARCHIVES_KEYS = ("archives", "archive", "shards", "shard")
@@ -174,6 +193,146 @@ def read_npz_filenames_and_vectors(npz_path: Path) -> dict[str, np.ndarray]:
         for k in keys:
             mapping[k] = np.asarray(data[k])
         return mapping
+
+
+def _multi_vectors_embedder_name(key: str) -> str:
+    """Return the embedder name a ``vectors_<name>`` key encodes, or ``""``.
+
+    Strips the first matching :data:`_VECTORS_PREFIXES` prefix and returns the
+    (trimmed) remainder.  A bare single-vector key ("vectors", "embeddings", …)
+    has no trailing underscore and so yields ``""``, keeping the two layouts
+    from colliding.  Only the leading prefix is stripped, so an embedder name
+    that itself contains underscores (``dinov3_patch``) survives intact.
+    """
+    for prefix in _VECTORS_PREFIXES:
+        if key.startswith(prefix):
+            return key[len(prefix) :].strip()
+    return ""
+
+
+def read_npz_multi_vectors(npz_path: Path) -> tuple[dict[str, dict[str, np.ndarray]], str] | None:
+    """Read the per-embedder ``vectors_<name>`` layout, or ``None`` if absent.
+
+    Returns ``(mapping, primary_embedder_name)`` where *mapping* is
+    ``{filename: {embedder_name: vector}}`` (insertion order preserved) and
+    *primary_embedder_name* is the score-role embedder: the scalar
+    ``embedder_name`` value when it names one of the present arrays, else the
+    first ``vectors_<name>`` key in archive order.  Every per-media dict carries
+    the same embedder-name set, so importing the archive binds each embedder to
+    its role slot.
+
+    Returns ``None`` (not an error) when the archive holds **no**
+    ``vectors_<name>`` key, signalling the caller to fall back to the
+    single-``vectors`` reader.  Raises ``FileNotFoundError`` for a missing file
+    and ``ValueError`` for a malformed per-embedder archive (missing
+    ``filenames``, a column whose length disagrees with ``filenames``, or one
+    that yields no rows).
+    """
+    p = Path(npz_path)
+    if not p.is_file():
+        raise FileNotFoundError(f"NPZ file not found: {p}")
+
+    with np.load(p, allow_pickle=False) as data:
+        # Preserve archive order so the primary-fallback and role derivation are
+        # deterministic; dict keeps first-seen order.
+        vec_keys: dict[str, str] = {}
+        for key in data.files:
+            name = _multi_vectors_embedder_name(key)
+            if name and name not in vec_keys:
+                vec_keys[name] = key
+        if not vec_keys:
+            return None
+
+        key_set = set(data.files)
+        filenames_key = next((k for k in _FILENAMES_KEYS if k in key_set), None)
+        if filenames_key is None:
+            raise ValueError(
+                f"NPZ per-embedder layout in {p} needs a filenames array "
+                f"(one of {_FILENAMES_KEYS}) alongside its vectors_<name> arrays"
+            )
+        names_arr = data[filenames_key]
+        if names_arr.ndim != 1:
+            raise ValueError(f"NPZ '{filenames_key}' array must be 1-D, got shape {names_arr.shape}")
+        n = len(names_arr)
+
+        columns: dict[str, np.ndarray] = {}
+        for emb_name, key in vec_keys.items():
+            arr = data[key]
+            if len(arr) != n:
+                raise ValueError(
+                    f"NPZ '{key}' and '{filenames_key}' have mismatched lengths ({len(arr)} vs {n})"
+                )
+            columns[emb_name] = arr
+
+        primary = ""
+        for name_key in _EMBEDDER_NAME_KEYS:
+            if name_key in key_set:
+                val = data[name_key]
+                primary = (str(val) if val.ndim == 0 else str(val.flat[0])).strip()
+                break
+        if primary not in columns:
+            primary = next(iter(columns))
+
+        mapping: dict[str, dict[str, np.ndarray]] = {}
+        for i, raw_name in enumerate(names_arr):
+            fname = str(raw_name).strip()
+            if not fname:
+                continue
+            mapping[fname] = {emb: np.asarray(col[i]) for emb, col in columns.items()}
+        if not mapping:
+            raise ValueError(f"NPZ '{filenames_key}' array is empty")
+        return mapping, primary
+
+
+def write_npz_multi_vectors(
+    npz_path: Path,
+    mapping: dict[str, dict[str, np.ndarray]],
+    primary_embedder: str = "",
+    *,
+    compressed: bool = False,
+) -> None:
+    """Write the per-embedder ``vectors_<name>`` layout read by :func:`read_npz_multi_vectors`.
+
+    *mapping* is ``{filename: {embedder_name: vector}}`` - the exact shape the
+    reader returns, so a dataset's per-embedder vectors round-trip through this
+    pair.  Every entry must carry the **same** embedder-name set (the archive's
+    columns are aligned by filename), and at least one embedder must be present.
+    *primary_embedder*, when given, is written as the scalar ``embedder_name``
+    so the archive records its score-role embedder; it must be one of the
+    embedder names present.  Set *compressed* to use ``np.savez_compressed``.
+
+    Raises ``ValueError`` for an empty mapping, an entry whose embedder set
+    diverges from the first entry's, or a *primary_embedder* not among the
+    embedder names.
+    """
+    if not mapping:
+        raise ValueError("write_npz_multi_vectors: mapping is empty")
+
+    filenames = list(mapping)
+    embedder_names = list(mapping[filenames[0]])
+    if not embedder_names:
+        raise ValueError("write_npz_multi_vectors: first entry carries no embedder vectors")
+    expected = set(embedder_names)
+    for fname in filenames:
+        if set(mapping[fname]) != expected:
+            raise ValueError(
+                f"write_npz_multi_vectors: entry {fname!r} has embedder set "
+                f"{sorted(mapping[fname])}, expected {sorted(expected)} (columns must align)"
+            )
+    if primary_embedder and primary_embedder not in expected:
+        raise ValueError(
+            f"write_npz_multi_vectors: primary_embedder {primary_embedder!r} is not among the "
+            f"archive's embedders {sorted(expected)}"
+        )
+
+    arrays: dict[str, np.ndarray] = {"filenames": np.array(filenames)}
+    for emb_name in embedder_names:
+        arrays[f"vectors_{emb_name}"] = np.stack([np.asarray(mapping[f][emb_name]) for f in filenames])
+    if primary_embedder:
+        arrays["embedder_name"] = np.array(primary_embedder)
+
+    save = np.savez_compressed if compressed else np.savez
+    save(str(npz_path), **arrays)
 
 
 def read_npz_archive_member_rows(npz_path: Path) -> list[dict]:

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -210,6 +210,54 @@ def _multi_vectors_embedder_name(key: str) -> str:
     return ""
 
 
+def _multi_vector_columns(data, p: Path) -> tuple[dict[str, np.ndarray], np.ndarray] | None:
+    """Return ``(columns, filenames_arr)`` for a per-embedder archive, or ``None``.
+
+    *columns* is ``{embedder_name: (N, D) array}`` in archive order; ``None``
+    signals no ``vectors_<name>`` key is present.  Raises ``ValueError`` for a
+    missing / malformed ``filenames`` array or a column length mismatch.
+    """
+    vec_keys: dict[str, str] = {}
+    for key in data.files:
+        name = _multi_vectors_embedder_name(key)
+        if name and name not in vec_keys:
+            vec_keys[name] = key
+    if not vec_keys:
+        return None
+
+    filenames_key = next((k for k in _FILENAMES_KEYS if k in set(data.files)), None)
+    if filenames_key is None:
+        raise ValueError(
+            f"NPZ per-embedder layout in {p} needs a filenames array "
+            f"(one of {_FILENAMES_KEYS}) alongside its vectors_<name> arrays"
+        )
+    names_arr = data[filenames_key]
+    if names_arr.ndim != 1:
+        raise ValueError(f"NPZ '{filenames_key}' array must be 1-D, got shape {names_arr.shape}")
+    n = len(names_arr)
+
+    columns: dict[str, np.ndarray] = {}
+    for emb_name, key in vec_keys.items():
+        arr = data[key]
+        if len(arr) != n:
+            raise ValueError(f"NPZ '{key}' and '{filenames_key}' have mismatched lengths ({len(arr)} vs {n})")
+        columns[emb_name] = arr
+    return columns, names_arr
+
+
+def _resolve_multi_primary(data, columns: dict[str, np.ndarray]) -> str:
+    """Pick the score-role embedder: the scalar ``embedder_name`` if it names a
+    present column, else the first column in archive order."""
+    for name_key in _EMBEDDER_NAME_KEYS:
+        if name_key in set(data.files):
+            val = data[name_key]
+            primary = (str(val) if val.ndim == 0 else str(val.flat[0])).strip()
+            if primary in columns:
+                return primary
+            break
+    return next(iter(columns))
+
+
 def read_npz_multi_vectors(npz_path: Path) -> tuple[dict[str, dict[str, np.ndarray]], str] | None:
     """Read the per-embedder ``vectors_<name>`` layout, or ``None`` if absent.
 
@@ -233,45 +281,11 @@ def read_npz_multi_vectors(npz_path: Path) -> tuple[dict[str, dict[str, np.ndarr
         raise FileNotFoundError(f"NPZ file not found: {p}")
 
     with np.load(p, allow_pickle=False) as data:
-        # Preserve archive order so the primary-fallback and role derivation are
-        # deterministic; dict keeps first-seen order.
-        vec_keys: dict[str, str] = {}
-        for key in data.files:
-            name = _multi_vectors_embedder_name(key)
-            if name and name not in vec_keys:
-                vec_keys[name] = key
-        if not vec_keys:
+        resolved = _multi_vector_columns(data, p)
+        if resolved is None:
             return None
-
-        key_set = set(data.files)
-        filenames_key = next((k for k in _FILENAMES_KEYS if k in key_set), None)
-        if filenames_key is None:
-            raise ValueError(
-                f"NPZ per-embedder layout in {p} needs a filenames array "
-                f"(one of {_FILENAMES_KEYS}) alongside its vectors_<name> arrays"
-            )
-        names_arr = data[filenames_key]
-        if names_arr.ndim != 1:
-            raise ValueError(f"NPZ '{filenames_key}' array must be 1-D, got shape {names_arr.shape}")
-        n = len(names_arr)
-
-        columns: dict[str, np.ndarray] = {}
-        for emb_name, key in vec_keys.items():
-            arr = data[key]
-            if len(arr) != n:
-                raise ValueError(
-                    f"NPZ '{key}' and '{filenames_key}' have mismatched lengths ({len(arr)} vs {n})"
-                )
-            columns[emb_name] = arr
-
-        primary = ""
-        for name_key in _EMBEDDER_NAME_KEYS:
-            if name_key in key_set:
-                val = data[name_key]
-                primary = (str(val) if val.ndim == 0 else str(val.flat[0])).strip()
-                break
-        if primary not in columns:
-            primary = next(iter(columns))
+        columns, names_arr = resolved
+        primary = _resolve_multi_primary(data, columns)
 
         mapping: dict[str, dict[str, np.ndarray]] = {}
         for i, raw_name in enumerate(names_arr):
@@ -280,7 +294,7 @@ def read_npz_multi_vectors(npz_path: Path) -> tuple[dict[str, dict[str, np.ndarr
                 continue
             mapping[fname] = {emb: np.asarray(col[i]) for emb, col in columns.items()}
         if not mapping:
-            raise ValueError(f"NPZ '{filenames_key}' array is empty")
+            raise ValueError("NPZ per-embedder filenames array is empty")
         return mapping, primary
 
 

--- a/vtscore/datasets/importers/server_files/__init__.py
+++ b/vtscore/datasets/importers/server_files/__init__.py
@@ -37,6 +37,7 @@ from vtscore.datasets.importers._npz_vectors import (
     is_archive_member_manifest,
     read_npz_embedder_name,
     read_npz_filenames_and_vectors,
+    read_npz_multi_vectors,
     validate_manifest_embedder_name,
 )
 from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
@@ -79,16 +80,23 @@ def _read_npz_paths_file(paths_file: Path) -> tuple[list[Path], dict[str, Any], 
 
     Returns ``(paths, path_to_vector, embedder_name)`` where keys of
     *path_to_vector* are the absolute path strings of the resolved entries
-    (the same strings that appear in *paths*), and *embedder_name* is the
-    value stored under ``"embedder_name"`` or ``"embedder"`` in the archive
-    (``""`` when absent).
+    (the same strings that appear in *paths*).  Each value is either a bare
+    vector (single-``vectors`` layout) or a ``{embedder_name: vector}`` dict
+    (the per-embedder ``vectors_<name>`` layout), and *embedder_name* is the
+    **primary** (score-role) embedder: the scalar ``"embedder_name"`` /
+    ``"embedder"`` value, or the leading per-embedder column for a trio
+    archive (``""`` when absent).
     """
-    name_to_vector = read_npz_filenames_and_vectors(paths_file)
-    embedder_name = read_npz_embedder_name(paths_file)
+    multi = read_npz_multi_vectors(paths_file)
+    if multi is not None:
+        name_to_value, embedder_name = multi
+    else:
+        name_to_value = read_npz_filenames_and_vectors(paths_file)
+        embedder_name = read_npz_embedder_name(paths_file)
     base_dir = paths_file.resolve().parent
     paths: list[Path] = []
     path_to_vector: dict[str, Any] = {}
-    for raw_name, vec in name_to_vector.items():
+    for raw_name, value in name_to_value.items():
         line = raw_name.strip()
         if not line:
             continue
@@ -96,7 +104,7 @@ def _read_npz_paths_file(paths_file: Path) -> tuple[list[Path], dict[str, Any], 
         if not candidate.is_absolute():
             candidate = (base_dir / candidate).resolve()
         paths.append(candidate)
-        path_to_vector[str(candidate)] = vec
+        path_to_vector[str(candidate)] = value
     return paths, path_to_vector, embedder_name
 
 
@@ -114,6 +122,25 @@ def _read_paths_file(paths_file: Path) -> list[Path]:
         paths, _, _embedder = _read_npz_paths_file(paths_file)
         return paths
     return _read_text_paths_file(paths_file)
+
+
+def _npz_embedder_names(primary: str, path_to_vector: dict[str, Any]) -> list[str]:
+    """Return every embedder name an NPZ archive binds (primary first).
+
+    For a single-``vectors`` archive this is just the (possibly empty) primary
+    name.  For a per-embedder ``vectors_<name>`` archive it is the union of the
+    primary plus every column name across the dict-valued entries, so the
+    importer can reject an unroutable name in *any* column before staging.
+    """
+    names: list[str] = []
+    if primary:
+        names.append(primary)
+    for value in path_to_vector.values():
+        if isinstance(value, dict):
+            for name in value:
+                if name and name not in names:
+                    names.append(name)
+    return names
 
 
 def _read_paths_and_vectors(paths_file: Path) -> tuple[list[Path], dict[str, Any], str]:
@@ -201,7 +228,8 @@ class ServerFilesDatasetImporter(DatasetImporter):
     description = (
         "Read a server-side manifest and import the media it lists. Accepts a text "
         "file of media paths (one per line), a .npz of paths plus pre-computed "
-        "embedding vectors, or a .npz that references members inside tar/zip shards "
+        "embedding vectors (one shared array, or one vectors_<embedder> array per "
+        "bound embedder), or a .npz that references members inside tar/zip shards "
         "and streams them without extraction (WebDataset-style corpora)"
     )
     icon = "\U0001f5c2"  # 🗂 - falls back to a generic file icon
@@ -229,7 +257,9 @@ class ServerFilesDatasetImporter(DatasetImporter):
                 "Accepted formats:\n"
                 " • .txt / .list - UTF-8 text, one path per line (lines starting with # are comments).\n"
                 " • .npz (paths) - NumPy archive of paths plus pre-computed embedding vectors;\n"
-                "   listed files skip re-embedding and use the supplied vectors.\n"
+                "   listed files skip re-embedding and use the supplied vectors. Supply a single\n"
+                "   'vectors' array, or one 'vectors_<embedder>' array per bound embedder to\n"
+                "   populate every role slot of a multi-embedder dataset at once.\n"
                 " • .npz (archive members) - a manifest with a 'members' + 'archives' array\n"
                 "   references media packed inside tar/zip shards; the bytes stream on demand\n"
                 "   with no extraction (built for WebDataset-style corpora too large to copy).\n"
@@ -323,8 +353,11 @@ class ServerFilesDatasetImporter(DatasetImporter):
             raise ValueError(f"No paths found in {paths_file}")
         # Reject an unroutable NPZ embedder name before staging anything, so the
         # failure is an actionable import-time error rather than a confusing
-        # "does not support text queries" 400 at search time.
-        validate_manifest_embedder_name(embedder_name, media_type_id, source_label=f"paths file {paths_file.name}")
+        # "does not support text queries" 400 at search time.  A per-embedder
+        # ``vectors_<name>`` archive binds *every* named column to a role slot,
+        # so validate all of them, not just the primary.
+        for name in _npz_embedder_names(embedder_name, path_to_vector):
+            validate_manifest_embedder_name(name, media_type_id, source_label=f"paths file {paths_file.name}")
 
         staging = Path(tempfile.mkdtemp(prefix="server_files_"))
         name_to_source = _symlink_paths(paths, staging)

--- a/vtscore/embedding/media_vectors.py
+++ b/vtscore/embedding/media_vectors.py
@@ -75,6 +75,10 @@ def init_embeddings(embedder_name: str | None, vec: Any) -> dict[str, Any]:
     * ``vec is None`` → ``{}`` (the deferred-embed placeholder a creation site
       uses when the vector is filled later by the embed stage via
       :func:`set_media_embedding`).
+    * ``vec`` is already a ``{embedder_name: vector}`` dict → a shallow copy of
+      it: a per-embedder ``vectors_<name>`` NPZ import supplies one vector per
+      bound embedder as a ready-made dict, and ``embedder_name`` (the primary)
+      is recorded separately on ``media["embedder"]`` by the caller.
     * vector present, ``embedder_name`` set → ``{embedder_name: vec}``.
     * vector present, ``embedder_name`` empty/``None`` → ``{UNKNOWN_EMBEDDER_KEY:
       vec}``: a pre-computed externally-supplied vector (``content_vectors`` /
@@ -86,6 +90,8 @@ def init_embeddings(embedder_name: str | None, vec: Any) -> dict[str, Any]:
     """
     if vec is None:
         return {}
+    if isinstance(vec, dict):
+        return dict(vec)
     return {embedder_name or UNKNOWN_EMBEDDER_KEY: vec}
 
 


### PR DESCRIPTION
## What & why

Extends the `server_files` ("Manifest") NPZ importer to accept a **per-embedder `vectors_<embedder_name>` layout** — one aligned array per bound embedder — in addition to the legacy single-`vectors` array. In the V3 trio world a dataset can bind up to three embedders (text / patch / structural), so a single pre-embedded archive can now supply every role slot's vector at once instead of just one.

This was the remaining half of the `#2669` gate. The multi-embed *schema* it targets already landed (`media["embeddings"]` is a per-embedder dict; datasets bind three role slots), so the reader was implementable. The deferral reason the issue named was "no producer writes `vectors_` arrays yet" — so this PR adds the producer too, giving the layout an in-repo round-trip.

## Changes

- **Reader** — `read_npz_multi_vectors` in `vtscore/datasets/importers/_npz_vectors.py`: detects any `vectors_<name>` (also `embeddings_<name>` / `vecs_<name>`) key, reads one column per embedder aligned to `filenames`, and resolves the primary (score-role) embedder from the scalar `embedder_name` (falling back to the leading column). Returns `None` when no per-embedder key is present, so the single-`vectors` path is unchanged.
- **Producer** — `write_npz_multi_vectors` (symmetric): writes `{filename: {embedder: vector}}` back to the columnar layout, so a dataset's per-embedder vectors round-trip through the pair.
- **Importer wiring** — `server_files` tries the multi reader first; each media lands one vector per embedder under `media["embeddings"]`, keyed by name, with the scalar `embedder_name` as the primary. The dataset binding derives a distinct role slot per capable embedder automatically. Backwards-readable: a single-`vectors` archive still maps to the score-role slot.
- **Validation** — every named column is validated against the embedder registry at import (each binds a role slot), not just the primary, so an unroutable name in any column fails up front with the valid options listed.
- **`init_embeddings`** now accepts a ready-made per-embedder dict.
- Updated the importer's user-facing hint/description and the V3 design note in `docs/plans/patch-embedder.md` (the layout is no longer an open follow-up).

## Tests

Added reader/writer unit tests (per-embedder columns, primary resolution, underscore-in-name preservation, malformed archives, round-trip incl. compressed) and end-to-end importer tests (both embedders stored on media, binding derives a slot per capable embedder, unregistered column rejected at import). Full `./run-tests.sh` green (6578 passed).

## Notes

- Side-channel data (`patch_regions` / `local_features`) is still re-derived from source by the embed stage rather than carried in the NPZ — the archive carries vectors only, matching existing single-`vectors` behavior.
- Breaking-compat: none. The single-`vectors` layout is untouched.

Closes #2669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZZaSCH2VkszGeisw66Mbg)_