### PR TITLE
Prune #2670 plan pointer (evaluated, closed not_planned)

### DIFF
--- a/docs/plans/patch-embedder.md
+++ b/docs/plans/patch-embedder.md
@@ -39,8 +39,6 @@ Per-detector embedder-type follow-ups:
 
 <!-- item-sep -->
 
-- [ ] #2670 — Detector in-memory primary can drift across A→B→A dataset switches
-
 <!-- item-sep -->
 
 - **Per-detector coverage atlas** and **changing a detector's type after


### PR DESCRIPTION
## Summary

Evaluated issue #2670 (detector in-memory primary can drift across A→B→A dataset switches on a multi-embedder dataset). **Conclusion: not worth doing; closed as `not_planned`.** This PR only prunes the now-stale plan pointer from `docs/plans/patch-embedder.md`.

## Why not_planned

The drift is real but benign, and the marker's staleness is load-bearing by design:

- **`DetectorContext.embedder` is only a cache-validity marker, never the scoring-space source of truth.** Every training/scoring path re-resolves the space fresh from `(detector type, current snap)` via `keying_embedder_for_snap` (`model_loading.py:96`, `learned_sort.py:115`, `find.py:260`); the stale marker is never used to pick the space.
- **A "live model + drifted marker" state can't reach a scoring call.** `ensure_detector_model_matches_active_embedder` (`before_request`) invalidates the cached MLP on every dataset switch whose resolved embedder differs, and model + marker are stamped together at train time (`update_det_ctx_with_trained_model`).
- **The staleness is intentional.** `dataset_sync.py:221-236` deliberately leaves the marker at the old value so `maybe_start_label_reembed` can detect the mismatch and fire its *progress-visible* re-embed. The proposed eager re-stamp would make that check see `marker == new` and skip the visible re-embed — the "mask the symptom" trap the issue itself flagged.
- Persisted `embedder_type` is never touched; the marker self-heals on the first detector op on a dataset supplying its type.

No correctness or scoring impact, and the naive fix would regress the re-embed UX.

## Changes

- Remove the `#2670` pointer line from `docs/plans/patch-embedder.md` (sentinels left in place per plan-file conventions).

Refs #2670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011wkXC93q2RLkQQoNV3HpzB)_