### PR TITLE
Float VTSBrowser signposts toward the viewer with zoom-depth drop shadows

### DIFF
--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -36,6 +36,7 @@ import {
 import {
   layoutSigns,
   SIGN_FONT_FAMILY,
+  signShadow,
   viewLevelForZoom,
 } from './sign-layout';
 import { prefersReducedMotion } from '../../utils/reduced-motion';
@@ -1481,12 +1482,27 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     const textColor = this.themeColor('--text-primary') || '#e0e0e0';
     for (const sign of placed) {
       // The pill sits behind the text at a lower opacity so the sign reads as
-      // lettering over the map, not an opaque card punched through it.
+      // lettering over the map, not an opaque card punched through it. A drop
+      // shadow under the pill floats the sign off the map toward the viewer as
+      // the zoom grows past it: the smallest signs are flat (no shadow), and
+      // larger (more zoomed-past) ones cast a progressively bigger, softer,
+      // more-offset shadow — see `signShadow`.
+      const shadow = signShadow(sign.scale, sign.fontPx);
       ctx.globalAlpha = sign.alpha * 0.6;
       ctx.fillStyle = pillBg;
+      if (shadow) {
+        ctx.shadowColor = `rgba(0, 0, 0, ${shadow.alpha})`;
+        ctx.shadowBlur = shadow.blur;
+        ctx.shadowOffsetY = shadow.offsetY;
+      }
       ctx.beginPath();
       ctx.roundRect(sign.sx - sign.w / 2, sign.sy - sign.h / 2, sign.w, sign.h, sign.h / 2);
       ctx.fill();
+      // Clear the shadow before the text so the lettering isn't double-shadowed
+      // and the next sign starts clean.
+      ctx.shadowColor = 'transparent';
+      ctx.shadowBlur = 0;
+      ctx.shadowOffsetY = 0;
       ctx.globalAlpha = sign.alpha;
       ctx.fillStyle = textColor;
       ctx.font = this.signFont(sign.fontPx);

--- a/frontend/src/app/components/browse-canvas/sign-layout.spec.ts
+++ b/frontend/src/app/components/browse-canvas/sign-layout.spec.ts
@@ -6,7 +6,10 @@ import {
   SIGN_EXPIRE_DELTA,
   SIGN_FADE_IN_SPAN,
   SIGN_FADE_OUT_SPAN,
+  SIGN_SHADOW_MAX_SCALE,
+  SIGN_SHADOW_MIN_SCALE,
   signAppearance,
+  signShadow,
   viewLevelForZoom,
   type SignViewContext,
 } from './sign-layout';
@@ -100,6 +103,51 @@ describe('signAppearance', () => {
   });
 });
 
+describe('signShadow', () => {
+  it('is flat (no shadow) at and below the minimum scale — the smallest signs', () => {
+    expect(signShadow(SIGN_SHADOW_MIN_SCALE, 13)).toBeNull();
+    expect(signShadow(SIGN_SHADOW_MIN_SCALE - 0.05, 13)).toBeNull();
+    expect(signShadow(0.65, 13)).toBeNull();
+  });
+
+  it('casts a shadow for medium signs, deeper for larger ones', () => {
+    const medium = signShadow(1.0, SIGN_BASE_FONT_PX)!;
+    const large = signShadow(1.25, SIGN_BASE_FONT_PX * 1.25)!;
+    expect(medium).not.toBeNull();
+    // Every dimension of the depth cue grows as the sign gets bigger.
+    expect(large.blur).toBeGreaterThan(medium.blur);
+    expect(large.offsetY).toBeGreaterThan(medium.offsetY);
+    expect(large.alpha).toBeGreaterThan(medium.alpha);
+  });
+
+  it('is deepest at the maximum scale — about to float past the viewer', () => {
+    const fontPx = SIGN_BASE_FONT_PX * SIGN_SHADOW_MAX_SCALE;
+    const biggest = signShadow(SIGN_SHADOW_MAX_SCALE, fontPx)!;
+    // lift saturates at 1, so blur/offset are the full per-em fraction of fontPx
+    // and the shadow is at its configured peak opacity.
+    expect(biggest.blur).toBeCloseTo(fontPx * 1.2, 5);
+    expect(biggest.offsetY).toBeCloseTo(fontPx * 0.55, 5);
+    expect(biggest.alpha).toBeCloseTo(0.55, 5);
+  });
+
+  it('clamps beyond the maximum scale rather than over-lifting', () => {
+    const fontPx = SIGN_BASE_FONT_PX * SIGN_SHADOW_MAX_SCALE;
+    const atMax = signShadow(SIGN_SHADOW_MAX_SCALE, fontPx)!;
+    const beyond = signShadow(SIGN_SHADOW_MAX_SCALE + 1, fontPx)!;
+    expect(beyond.blur).toBeCloseTo(atMax.blur, 10);
+    expect(beyond.alpha).toBeCloseTo(atMax.alpha, 10);
+  });
+
+  it('scales the shadow with font size so it stays proportional', () => {
+    const small = signShadow(1.2, 10)!;
+    const big = signShadow(1.2, 20)!;
+    // Same lift, double the font → double the blur/offset.
+    expect(big.blur).toBeCloseTo(small.blur * 2, 10);
+    expect(big.offsetY).toBeCloseTo(small.offsetY * 2, 10);
+    expect(big.alpha).toBeCloseTo(small.alpha, 10);
+  });
+});
+
 describe('layoutSigns', () => {
   it('places a visible sign at its projected screen position', () => {
     const placed = layoutSigns([label({ x: 0, y: 0 })], centeredView(0), measure);
@@ -107,6 +155,7 @@ describe('layoutSigns', () => {
     expect(placed[0].sx).toBe(400);
     expect(placed[0].sy).toBe(300);
     expect(placed[0].fontPx).toBeCloseTo(SIGN_BASE_FONT_PX * 0.9, 5);
+    expect(placed[0].scale).toBeCloseTo(0.9, 5);
     expect(placed[0].alpha).toBe(1);
   });
 

--- a/frontend/src/app/components/browse-canvas/sign-layout.ts
+++ b/frontend/src/app/components/browse-canvas/sign-layout.ts
@@ -41,6 +41,11 @@ export interface PlacedSign {
   sy: number;
   /** Resolved font size (CSS px) after the appearance scale. */
   fontPx: number;
+  /** The {@link SignAppearance.scale} this sign rendered at (multiplier on
+   *  {@link SIGN_BASE_FONT_PX}). Drives the drop-shadow depth cue — see
+   *  {@link signShadow} — so a bigger (more zoomed-past) sign lifts further off
+   *  the map. */
+  scale: number;
   alpha: number;
   /** Pill box (CSS px), centred on `(sx, sy)`. */
   w: number;
@@ -83,6 +88,56 @@ const SIGN_SCALE_STOPS: readonly [number, number][] = [
   [1.5, 1.25],
   [SIGN_EXPIRE_DELTA, 1.45],
 ];
+
+/** Render scale at or below which a sign lies flat on the map and casts no
+ *  shadow — the smallest, just-appeared signs. Between here and
+ *  {@link SIGN_SHADOW_MAX_SCALE} the shadow depth ramps linearly. */
+export const SIGN_SHADOW_MIN_SCALE = 0.75;
+/** Render scale at which a sign casts its deepest shadow — the largest tier
+ *  (the top of {@link SIGN_SCALE_STOPS}), read as floating just past the
+ *  viewer's shoulder. */
+export const SIGN_SHADOW_MAX_SCALE = SIGN_SCALE_STOPS[SIGN_SCALE_STOPS.length - 1][1];
+/** Blur radius of a fully-lifted sign's shadow, as a multiple of its font px. */
+const SIGN_SHADOW_BLUR_EM = 1.2;
+/** Downward offset of a fully-lifted sign's shadow, as a multiple of its font
+ *  px — the sign's apparent height above the map plane. */
+const SIGN_SHADOW_OFFSET_EM = 0.55;
+/** Opacity of a fully-lifted sign's shadow. */
+const SIGN_SHADOW_MAX_ALPHA = 0.55;
+
+/** Drop shadow a sign casts: how far it floats off the map. */
+export interface SignShadow {
+  /** Gaussian blur radius (CSS px) for `ctx.shadowBlur`. */
+  blur: number;
+  /** Downward offset (CSS px) for `ctx.shadowOffsetY`. */
+  offsetY: number;
+  /** 0..1 shadow opacity. */
+  alpha: number;
+}
+
+/**
+ * Drop-shadow depth cue for a sign rendered at `scale` (its
+ * {@link SignAppearance.scale}) and `fontPx`. As the viewer zooms in, a sign
+ * grows past full size and reads as lifting off the map toward them, so it casts
+ * a progressively larger, softer, more-offset shadow. Below
+ * {@link SIGN_SHADOW_MIN_SCALE} the sign lies flat on the map and casts nothing
+ * (returns `null`); by {@link SIGN_SHADOW_MAX_SCALE} the shadow is deepest, as if
+ * the sign is about to float past the viewer's shoulder. Magnitudes scale with
+ * `fontPx`, so the shadow stays proportional to the sign at every size (a bigger
+ * sign both is larger and throws a larger shadow, compounding the "coming toward
+ * you" read). Pure and total — the canvas painter just applies the result.
+ */
+export function signShadow(scale: number, fontPx: number): SignShadow | null {
+  const span = SIGN_SHADOW_MAX_SCALE - SIGN_SHADOW_MIN_SCALE;
+  const lift = span > 0 ? (scale - SIGN_SHADOW_MIN_SCALE) / span : 0;
+  if (!(lift > 0)) return null;
+  const l = Math.min(1, lift);
+  return {
+    blur: fontPx * SIGN_SHADOW_BLUR_EM * l,
+    offsetY: fontPx * SIGN_SHADOW_OFFSET_EM * l,
+    alpha: SIGN_SHADOW_MAX_ALPHA * l,
+  };
+}
 
 /** Minimum gap (CSS px) enforced between sign pills by the de-clutter pass. */
 const SIGN_GAP_PX = 4;
@@ -171,7 +226,7 @@ export function layoutSigns(
     if (sx + w / 2 < 0 || sx - w / 2 > view.width) continue;
     if (sy + h / 2 < 0 || sy - h / 2 > view.height) continue;
 
-    candidates.push({ label, sx, sy, fontPx, alpha: appearance.alpha, w, h });
+    candidates.push({ label, sx, sy, fontPx, scale: appearance.scale, alpha: appearance.alpha, w, h });
   }
 
   // Priority: bigger signs first (they're the ones nearest their own zoom


### PR DESCRIPTION
## What & why

In VTSBrowser, region signposts grow as you zoom past their pyramid level (scale `0.65×`→`1.45×`), but they read as flat lettering pinned to the map at every size. This adds a drop-shadow depth cue so signs appear to lift off the map and come toward the viewer as they enlarge:

- **Smallest visible signs → flat** (no shadow), sitting on the map.
- **Medium / full-size signs → a soft, offset shadow**, as if floating just above the plane.
- **Largest signs → a larger, softer, more-offset shadow**, as if about to float past the viewer's shoulder.

The effect is continuous, so it tracks the existing smooth grow/fade of a sign through a zoom rather than snapping between tiers.

## How

Signposts are canvas-painted (no DOM/SCSS), so the shadow is `ctx.shadow*` on the pill fill.

- **`sign-layout.ts`** — added a pure, testable `signShadow(scale, fontPx)` that returns `{ blur, offsetY, alpha }` (or `null` below `SIGN_SHADOW_MIN_SCALE`, keeping the smallest signs flat). Depth ramps linearly from `SIGN_SHADOW_MIN_SCALE` (0.75) to `SIGN_SHADOW_MAX_SCALE` (the top scale stop, 1.45), and every magnitude scales with `fontPx` so the shadow stays proportional — a bigger sign is both larger and throws a larger shadow, compounding the "coming toward you" read. Exposed the render `scale` on `PlacedSign` so the painter has it directly.
- **`browse-canvas.component.ts`** — `drawSigns` now sets the shadow under each pill and clears it before drawing the text (so the lettering isn't double-shadowed and the next sign starts clean). `ctx.save()/restore()` already scopes the shadow state to the sign layer.

## Notes

- All shadow geometry lives in the framework-free `sign-layout.ts` module, mirroring its existing appearance/de-clutter math; new unit tests cover the flat-at-smallest, deeper-when-larger, saturates-at-max, and proportional-to-font-size behaviour.
- No screenshot reshoot: the only Browse doc shot (`browse-view`) is a zoomed-out synthetic 60-point map with no toponymy labeler run, so it frames no signposts.

## Testing

`./run-tests.sh frontend` — ruff/codespell/deptry/pip-audit/pyright/OpenAPI/build/audit clean; Vitest **1771 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvLtUqkZ6692ovb3WtAyqc)_