### PR TITLE
Enlarge VTSBrowser left-panel/popup hover thumbnail to scale(1.35)

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -396,7 +396,7 @@
   &.focused {
     position: relative;
     z-index: 1;
-    transform: scale(1.08);
+    transform: scale(1.35);
     filter: drop-shadow(0 3px 6px var(--shadow-dropdown));
   }
 

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.scss
@@ -188,7 +188,7 @@
     z-index: 1;
     color: var(--text-primary);
     background: var(--bg-hover);
-    transform: scale(1.08);
+    transform: scale(1.35);
     filter: drop-shadow(0 3px 6px var(--shadow-dropdown));
   }
 


### PR DESCRIPTION
## What

In VTSBrowser, hovering a thumbnail in the **left selection panel** or the **bin-detail popup** grid enlarges it only by `scale(1.08)` (+8%) — far subtler than the main canvas break-out, where a hovered square thumbnail grows to roughly `1.5×` (and even more for wide/tall images, plus it un-crops to full aspect).

This raises the on-grid hover/viewed cue in both surfaces to `scale(1.35)`, so the enlargement reads much closer to the canvas magnitude while staying laid-out-stable (still a painted `transform`, so no reflow of the grid).

## Changes

- `browse-selection-panel.component.scss` — `.bsp-entry:hover` transform `scale(1.08)` → `scale(1.35)`.
- `browse-bin-popup.component.scss` — `.focused` (viewed/arrow-walked item) transform `scale(1.08)` → `scale(1.35)`.

Both keep their existing `drop-shadow` lift, `z-index: 1`, and `--transition-base` timing. No TypeScript or geometry changes; the main-canvas break-out is untouched.

## Testing

`./run-tests.sh frontend` — ruff/pyright/build/audit all clean; frontend unit suite 1766 passed. The change is hover/focus-only, so no static doc screenshot frames it (nothing added to the reshoot queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014HCncotgnfTQGnrrUn73N5)_