### PR TITLE
Add row divider to VTSBrowse docked details panel

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -186,6 +186,21 @@
       }
     </div>
 
+    @if (docked()) {
+      <!-- Horizontal divider between the focused-item / metadata row and the
+           member grid. Dragging it vertically resizes the whole panel: the
+           focused item is square, so a taller item is a wider panel, so the
+           browse view maps this drag onto the panel↔canvas divider. -->
+      <div
+        class="pane-divider bin-popup-row-divider"
+        [class.dragging]="rowDividerDragging()"
+        (mousedown)="rowDividerMouseDown.emit($event)"
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize the panel"
+        title="Drag to resize the panel"></div>
+    }
+
     @if (docked() || !previewOnly) {
       <div class="bin-popup-grid-col">
         @if (ids.length > 0) {

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -530,6 +530,28 @@
     min-height: 0;
   }
 
+  // Horizontal grab bar between the focused-item row and the member grid.
+  // Dragging it resizes the whole panel (the browse view maps the vertical drag
+  // onto the panel↔canvas width), so it reads as a full-width row-resize bar
+  // rather than the vertical `.pane-divider` default. Overrides the shared
+  // primitive's vertical geometry: full width, 8px tall, with a horizontal fill
+  // bar instead of a vertical one.
+  .bin-popup-row-divider {
+    width: 100%;
+    height: 8px;
+    flex: 0 0 auto;
+    cursor: row-resize;
+
+    &::after {
+      top: 2px;
+      bottom: auto;
+      left: 0;
+      right: 0;
+      width: auto;
+      height: 4px;
+    }
+  }
+
   // Resize like the right (selection) panel: fixed-width columns packed to the
   // left with a constant gap, so widening the panel keeps the thumbnails (and
   // the gaps between them) the same size and only reveals a new column once

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -223,10 +223,19 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  mode the detail pane + metadata track it — the panel is the now-playing
    *  display. Unused when floating. */
   readonly nowPlayingExt = input<NowPlaying | null>(null);
+  /** Docked only: whether the browse view is currently dragging the in-panel row
+   *  divider (see {@link rowDividerMouseDown}). Reflected as the divider's drag
+   *  cue so it stays lit while the cursor is off it mid-drag. */
+  readonly rowDividerDragging = input(false);
 
   /** Emitted when the popup should close (outside click, Escape, or the X);
    *  in docked mode, when the X asks to clear the shown bin. */
   readonly dismissed = output<void>();
+  /** Docked only: the user grabbed the horizontal divider between the
+   *  focused-item/metadata row and the member grid. The browse view runs the
+   *  drag — the focused item is square, so a taller item is a wider panel, so
+   *  the vertical drag resizes the whole panel via the panel↔canvas width. */
+  readonly rowDividerMouseDown = output<MouseEvent>();
   /** Floating header's dock button: the user wants the docked presentation. */
   readonly dockRequested = output<void>();
   /** Docked header's pop-out button: the user wants the floating window. */

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -129,7 +129,11 @@ const DOCKED_MAIN_MIN = 60;
  *   ``browse_details_metadata_width``) and the item grows to fill whatever the
  *   row leaves ({@link dockedPaneSize}), so the docked panel has no per-item
  *   size buttons — the panel↔canvas divider sizes the item (and re-chunks the
- *   grid columns) instead. The panel is always mounted while the option is on —
+ *   grid columns) instead. A second, horizontal divider between that top row and
+ *   the member grid ({@link rowDividerMouseDown}) is a friendlier handle onto the
+ *   same size: the item is square, so dragging it down (a taller item) is just a
+ *   wider panel, which the browse view applies by moving the panel↔canvas
+ *   divider. The panel is always mounted while the option is on —
  *   before any bin is opened it shows an empty hint — and for audio its detail
  *   pane doubles as the now-playing display ({@link nowPlayingExt}), replacing
  *   the toolbar's small waveform widget. A singleton bin keeps the grid area

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -56,8 +56,10 @@
               [volume]="volume()"
               [hoverThumbRadius]="thumbnailRadius"
               [nowPlayingExt]="nowPlaying()"
+              [rowDividerDragging]="draggingDetailsRow()"
               (dismissed)="dismissContextMenu()"
               (popOutRequested)="onPopOutRequested()"
+              (rowDividerMouseDown)="onDetailsRowDividerMouseDown($event)"
               (nowPlaying)="onNowPlaying($event)"
             />
           </aside>

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -242,6 +242,20 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   private draggingDetails = false;
   private boundDetailsMove = this.onDetailsMouseMove.bind(this);
   private boundDetailsUp = this.onDetailsMouseUp.bind(this);
+
+  /**
+   * True while the docked details panel's *horizontal* row divider (between the
+   * focused-item/metadata row and the member grid, inside the panel) is being
+   * dragged. That divider resizes the whole panel — the focused item is square,
+   * so a taller item means a wider panel — by mapping the vertical drag onto the
+   * same {@link detailsPanelWidth} the panel↔canvas divider drives. A signal so
+   * the drag-cue class round-trips to the panel under zoneless.
+   */
+  readonly draggingDetailsRow = signal(false);
+  private detailsRowStartY = 0;
+  private detailsRowStartWidth = 0;
+  private boundDetailsRowMove = this.onDetailsRowMouseMove.bind(this);
+  private boundDetailsRowUp = this.onDetailsRowMouseUp.bind(this);
   /** Dynamic minimum snapshotted at drag start, so the per-move handler reuses
    *  it instead of re-measuring the DOM (and thrashing layout) on every move —
    *  the thumbnail size and sort-control width can't change mid-drag anyway. */
@@ -444,6 +458,8 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     document.removeEventListener('mouseup', this.boundPanelUp);
     document.removeEventListener('mousemove', this.boundDetailsMove);
     document.removeEventListener('mouseup', this.boundDetailsUp);
+    document.removeEventListener('mousemove', this.boundDetailsRowMove);
+    document.removeEventListener('mouseup', this.boundDetailsRowUp);
     this.removeShiftListeners();
     this.tileCache.clear();
     this.releaseEphemeralPositivesContext();
@@ -751,22 +767,32 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     });
   }
 
-  private onDetailsMouseMove(event: MouseEvent): void {
-    const content = this.content();
-    if (!this.draggingDetails || !content) return;
-    const rect = content.nativeElement.getBoundingClientRect();
-    // The details panel is on the left, so its width grows as the cursor moves
-    // right. Leave the canvas its minimum after both dividers + the right panel.
+  /** Largest the details panel can grow to while leaving the canvas its minimum
+   *  after both dividers and the right (selection) panel. Shared by both the
+   *  panel↔canvas divider drag and the in-panel row divider drag. */
+  private detailsMax(rect: DOMRect): number {
     const fit =
       rect.width -
       2 * BrowseViewComponent.DIVIDER_WIDTH -
       BrowseViewComponent.CANVAS_MIN -
       this.panelWidth();
-    const max = Math.min(
+    return Math.min(
       BrowseViewComponent.PANEL_MAX,
       Math.max(BrowseViewComponent.DETAILS_FLOOR, fit),
     );
-    const width = this.clamp(event.clientX - rect.left, BrowseViewComponent.DETAILS_FLOOR, max);
+  }
+
+  private onDetailsMouseMove(event: MouseEvent): void {
+    const content = this.content();
+    if (!this.draggingDetails || !content) return;
+    const rect = content.nativeElement.getBoundingClientRect();
+    // The details panel is on the left, so its width grows as the cursor moves
+    // right.
+    const width = this.clamp(
+      event.clientX - rect.left,
+      BrowseViewComponent.DETAILS_FLOOR,
+      this.detailsMax(rect),
+    );
     this.detailsPanelWidth.set(width);
   }
 
@@ -775,6 +801,12 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.draggingDetails = false;
     document.removeEventListener('mousemove', this.boundDetailsMove);
     document.removeEventListener('mouseup', this.boundDetailsUp);
+    this.finishDetailsDrag();
+  }
+
+  /** Snap + persist the settled details-panel width. Shared by both details
+   *  dividers on release. */
+  private finishDetailsDrag(): void {
     // Pop tight to the column count the user dragged to: snap away any trailing
     // empty strip so releasing never leaves a ragged half-column (mirrors the
     // right panel's snap). The docked panel reports the minimum width that still
@@ -791,6 +823,48 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.settingsState
       .update({ browse_details_panel_width: Math.round(this.detailsPanelWidth()) })
       .subscribe();
+  }
+
+  // --- Docked-details in-panel row divider drag ----------------------------
+  // A horizontal divider inside the docked panel, between the focused-item /
+  // metadata row and the member grid. It resizes the *panel width*, not a row
+  // height: the focused item is square, so dragging the divider down (a taller
+  // item) is the same as widening the panel. Mapping the vertical delta 1:1 onto
+  // the panel↔canvas width lets the user grow the item's vertical space directly
+  // instead of reaching for the side divider and reasoning about width→height.
+
+  onDetailsRowDividerMouseDown(event: MouseEvent): void {
+    event.preventDefault();
+    this.draggingDetailsRow.set(true);
+    this.detailsRowStartY = event.clientY;
+    this.detailsRowStartWidth = this.detailsPanelWidth();
+    this.ngZone.runOutsideAngular(() => {
+      document.addEventListener('mousemove', this.boundDetailsRowMove);
+      document.addEventListener('mouseup', this.boundDetailsRowUp);
+    });
+  }
+
+  private onDetailsRowMouseMove(event: MouseEvent): void {
+    const content = this.content();
+    if (!this.draggingDetailsRow() || !content) return;
+    const rect = content.nativeElement.getBoundingClientRect();
+    // Down (positive dy) grows the square item's height, hence the panel width;
+    // up shrinks it. 1:1 because the item's height tracks the panel width.
+    const dy = event.clientY - this.detailsRowStartY;
+    const width = this.clamp(
+      this.detailsRowStartWidth + dy,
+      BrowseViewComponent.DETAILS_FLOOR,
+      this.detailsMax(rect),
+    );
+    this.detailsPanelWidth.set(width);
+  }
+
+  private onDetailsRowMouseUp(): void {
+    if (!this.draggingDetailsRow()) return;
+    this.draggingDetailsRow.set(false);
+    document.removeEventListener('mousemove', this.boundDetailsRowMove);
+    document.removeEventListener('mouseup', this.boundDetailsRowUp);
+    this.finishDetailsDrag();
   }
 
   /** Toggle region-select mode (drag-to-marquee without holding Shift). */

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -260,6 +260,47 @@ describe('BrowseViewComponent (zoneless canary)', () => {
     expect(updates.some((u) => 'browse_details_panel_width' in u)).toBe(true);
   });
 
+  it('resizes the details panel from the in-panel row divider: a vertical drag maps 1:1 to panel width', async () => {
+    await settleZoneless(fixture);
+    const component = fixture.componentInstance;
+    const updates: Record<string, unknown>[] = [];
+    const settings = TestBed.inject(SettingsStateService);
+    (settings.update as unknown) = (u: Record<string, unknown>) => {
+      updates.push(u);
+      return of({});
+    };
+
+    // A wide layout so neither the floor nor the max clamps this drag.
+    (component as unknown as { content: () => unknown }).content = () => ({
+      nativeElement: { getBoundingClientRect: () => ({ width: 2000, left: 0, right: 2000 }) },
+    });
+
+    const startWidth = component.detailsPanelWidth();
+    component.onDetailsRowDividerMouseDown({
+      preventDefault: () => {},
+      clientY: 100,
+    } as unknown as MouseEvent);
+    expect(component.draggingDetailsRow()).toBe(true);
+
+    // Dragging the divider DOWN 60px grows the panel by 60 — the focused item is
+    // square, so a taller item is a wider panel (the whole point of this divider).
+    (component as unknown as { onDetailsRowMouseMove(e: MouseEvent): void }).onDetailsRowMouseMove({
+      clientY: 160,
+    } as unknown as MouseEvent);
+    expect(component.detailsPanelWidth()).toBeCloseTo(startWidth + 60);
+
+    // Dragging back UP past the start shrinks it below the start width.
+    (component as unknown as { onDetailsRowMouseMove(e: MouseEvent): void }).onDetailsRowMouseMove({
+      clientY: 60,
+    } as unknown as MouseEvent);
+    expect(component.detailsPanelWidth()).toBeLessThan(startWidth);
+
+    // Release ends the drag and commits the settled width to settings.
+    (component as unknown as { onDetailsRowMouseUp(): void }).onDetailsRowMouseUp();
+    expect(component.draggingDetailsRow()).toBe(false);
+    expect(updates.some((u) => 'browse_details_panel_width' in u)).toBe(true);
+  });
+
   it('drives preview-audio volume from the toolbar: slider lowers the level and mute round-trips', async () => {
     await settleZoneless(fixture);
     const component = fixture.componentInstance;

--- a/tests_lib/detectors/test_mlp_vs_svm_experiment.py
+++ b/tests_lib/detectors/test_mlp_vs_svm_experiment.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 from vtscore.eval.timing_benchmark import run_timing_benchmark
-from vtscore.eval.trainers import _parse_trainer_spec, resolve_trainer
+from vtscore.eval.trainers import _as_scores, _parse_trainer_spec, resolve_trainer
 from vtscore.eval.voting_iterations import (
     _downsample_to_prevalence,
     _prevalence,
@@ -118,7 +118,7 @@ class TestTrainerResolver:
         X = np.vstack([rng.normal(1, 0.3, (20, 8)), rng.normal(-1, 0.3, (20, 8))]).astype(np.float32)
         y = np.array([1] * 20 + [0] * 20, dtype=np.int32)
         predict = resolve_trainer("svm_rbf@C=3,gamma=0.5x")(X, y, 0)
-        scores = predict(X)
+        scores = _as_scores(predict(X))
         assert scores.shape == (40,)
 
     def test_unknown_name_raises(self):


### PR DESCRIPTION
## What & why

In the VTSBrowse docked bin-details **left panel**, the focused item is square: its vertical size tracks the panel's *horizontal* width. So to give the main item more vertical space you had to drag the **panel↔canvas** divider (taking horizontal space from the canvas) and rely on the height scaling with it — a confusing, indirect gesture.

This adds a **horizontal divider between the item/metadata row and the thumbnail-grid row** of the docked panel. Dragging it vertically resizes the whole panel: the browse view maps the vertical delta 1:1 onto the same `detailsPanelWidth` the side divider drives, so **dragging down (a taller item) simply widens the panel**, and the panel↔canvas divider moves accordingly.

Per the request, the metadata column (when shown) keeps its dragged width — only its **height** changes, since it matches the focused item's height.

## Changes

- **`browse-bin-popup`**: new `rowDividerMouseDown` output + `rowDividerDragging` input; the docked template renders a full-width `row-resize` grab bar between `.bin-popup-top` and the member grid; SCSS overrides the shared `.pane-divider` primitive to a horizontal orientation.
- **`browse-view`**: owns the drag (it owns `detailsPanelWidth`). New `onDetailsRowDividerMouseDown` maps `clientY` delta → panel width; shares the clamp (`detailsMax`) and the snap-and-persist release path (`finishDetailsDrag`) with the existing side divider, which was refactored out of `onDetailsMouseUp`.
- Added a zoneless spec covering the vertical→width mapping and persistence.
- Drive-by: fixed a pre-existing `pyright` error in `tests_lib/detectors/test_mlp_vs_svm_experiment.py` (normalized the trainer's predict result through `_as_scores`) that was blocking `./run-tests.sh`.

## Testing

`./run-tests.sh frontend` — build OK, pyright clean, 1772 Vitest tests pass (incl. the new one). Verified the touched Python test at runtime.

Note: this affordance only appears in the docked details panel (off by default), so no user-doc screenshots are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwRmqpWQt5pSVVjJkPzPWw)_