### PR TITLE
VTSBrowse: keep terminal (leaf/root) signposts visible instead of fading into a void

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4654,6 +4654,16 @@
       "RegionLabel": {
         "additionalProperties": false,
         "properties": {
+          "has_coarser": {
+            "default": true,
+            "description": "Whether a coarser sign names this region one zoom band out (a parent). False for a root region, which the canvas keeps visible when zoomed out instead of fading in under a parent.",
+            "type": "boolean"
+          },
+          "has_finer": {
+            "default": true,
+            "description": "Whether a finer sign names this region one zoom band in (a child). False for a leaf region, which the canvas keeps visible when zoomed in instead of expiring with nothing to hand off to.",
+            "type": "boolean"
+          },
           "level": {
             "description": "Pyramid zoom level the sign belongs to (0 = coarsest). May be fractional; the canvas interpolates visibility on a continuous axis.",
             "type": "number"

--- a/frontend/src/app/components/browse-canvas/sign-layout.spec.ts
+++ b/frontend/src/app/components/browse-canvas/sign-layout.spec.ts
@@ -103,6 +103,47 @@ describe('signAppearance', () => {
   });
 });
 
+describe('signAppearance — terminal signs (no hand-off neighbour)', () => {
+  it('a root (no coarser parent) stays opaque below its coarse edge instead of fading/culling', () => {
+    // A normal sign is culled far below its coarse edge...
+    expect(signAppearance(-5)).toBeNull();
+    // ...but a root persists at full opacity (nothing coarser names the area).
+    const root = signAppearance(-5, false, true)!;
+    expect(root).not.toBeNull();
+    expect(root.alpha).toBe(1);
+    // And inside the fade-in band it's opaque where a normal sign is half-faded.
+    const d = SIGN_APPEAR_DELTA + SIGN_FADE_IN_SPAN / 2;
+    expect(signAppearance(d)!.alpha).toBeCloseTo(0.5, 10);
+    expect(signAppearance(d, false, true)!.alpha).toBe(1);
+  });
+
+  it('still expires a root at its fine edge — only the coarse-edge fade is skipped', () => {
+    expect(signAppearance(10, false, true)).toBeNull();
+  });
+
+  it('a leaf (no finer child) stays opaque above its fine edge instead of expiring', () => {
+    // A normal sign is gone far above its fine edge...
+    expect(signAppearance(10)).toBeNull();
+    // ...but a leaf persists at full opacity (nothing finer takes over).
+    const leaf = signAppearance(10, true, false)!;
+    expect(leaf).not.toBeNull();
+    expect(leaf.alpha).toBe(1);
+    // And inside the fade-out band it's opaque where a normal sign is half-faded.
+    const d = SIGN_EXPIRE_DELTA - SIGN_FADE_OUT_SPAN / 2;
+    expect(signAppearance(d)!.alpha).toBeCloseTo(0.5, 10);
+    expect(signAppearance(d, true, false)!.alpha).toBe(1);
+  });
+
+  it('still hides a leaf below its coarse edge — only the fine-edge fade is skipped', () => {
+    expect(signAppearance(-5, true, false)).toBeNull();
+  });
+
+  it('an isolated sign (both edges terminal) is visible on both sides of the band', () => {
+    expect(signAppearance(-5, false, false)!.alpha).toBe(1);
+    expect(signAppearance(10, false, false)!.alpha).toBe(1);
+  });
+});
+
 describe('signShadow', () => {
   it('is flat (no shadow) at and below the minimum scale — the smallest signs', () => {
     expect(signShadow(SIGN_SHADOW_MIN_SCALE, 13)).toBeNull();
@@ -216,5 +257,21 @@ describe('layoutSigns', () => {
 
   it('skips empty-text labels', () => {
     expect(layoutSigns([label({ text: '' })], centeredView(0), measure)).toHaveLength(0);
+  });
+
+  it('keeps a leaf island lettered when zoomed far past it', () => {
+    // A normal level-0 sign has expired by view level 3...
+    expect(layoutSigns([label({ level: 0 })], centeredView(3), measure)).toHaveLength(0);
+    // ...but a leaf (no finer child to hand off to) stays on the map.
+    const placed = layoutSigns([label({ level: 0, has_finer: false })], centeredView(3), measure);
+    expect(placed).toHaveLength(1);
+  });
+
+  it('keeps a root island lettered when zoomed out past it', () => {
+    // A normal level-3 sign is invisible at view level 0...
+    expect(layoutSigns([label({ level: 3 })], centeredView(0), measure)).toHaveLength(0);
+    // ...but a root (no coarser parent naming the area) stays on the map.
+    const placed = layoutSigns([label({ level: 3, has_coarser: false })], centeredView(0), measure);
+    expect(placed).toHaveLength(1);
   });
 });

--- a/frontend/src/app/components/browse-canvas/sign-layout.ts
+++ b/frontend/src/app/components/browse-canvas/sign-layout.ts
@@ -20,6 +20,18 @@
 //
 // so panning down through the zoom stack dissolves coarse names into the finer
 // names that refine them, the way a paper map hands "EUROPE" off to "France".
+//
+// Those two fade edges only make sense as a *hand-off*: a sign fades in at its
+// coarse edge because a coarser parent is already naming the area, and fades
+// out at its fine edge because a finer child is taking over. A **terminal**
+// sign has no such neighbour on one side (`has_coarser` / `has_finer` on the
+// payload), and fading there would leave the region nameless — the reported
+// bug of an on-screen island whose only name appears then vanishes as you zoom
+// past it. So a root sign (no coarser parent) skips the coarse-edge fade and
+// stays visible when zoomed out; a leaf sign (no finer child) skips the fine-
+// edge fade and stays visible when zoomed in. The size curve is unchanged —
+// `interpolateScale` clamps outside the band — so a terminal sign simply holds
+// its smallest/largest size at full opacity past the edge instead of vanishing.
 
 import type { RegionLabelPayload, ViewTransform } from '../../models/projection.models';
 import { projToScreen } from './view-transform';
@@ -163,17 +175,30 @@ export function viewLevelForZoom(baseRadius: number, effZoom: number, targetRadi
  * (`delta = viewLevel - sign.level`), or `null` when the sign is outside its
  * visibility band entirely. Pure and total — see the module comment for the
  * band-by-band behaviour.
+ *
+ * `hasCoarser` / `hasFiner` are the sign's tree neighbours (default `true`, the
+ * pre-flag fading). A **root** (`hasCoarser=false`) keeps full opacity below its
+ * coarse edge instead of fading in and disappearing — nothing coarser names the
+ * area when zoomed out. A **leaf** (`hasFiner=false`) keeps full opacity above
+ * its fine edge instead of expiring — nothing finer takes over when zoomed in.
  */
-export function signAppearance(delta: number): SignAppearance | null {
+export function signAppearance(
+  delta: number,
+  hasCoarser = true,
+  hasFiner = true,
+): SignAppearance | null {
   if (!Number.isFinite(delta)) return null;
-  if (delta <= SIGN_APPEAR_DELTA || delta >= SIGN_EXPIRE_DELTA) return null;
+  // Only cull past an edge that hands off to a neighbour; a terminal edge stays
+  // visible (its size clamps via `interpolateScale`).
+  if (delta <= SIGN_APPEAR_DELTA && hasCoarser) return null;
+  if (delta >= SIGN_EXPIRE_DELTA && hasFiner) return null;
 
   let alpha = 1;
   const fadeInEnd = SIGN_APPEAR_DELTA + SIGN_FADE_IN_SPAN;
   const fadeOutStart = SIGN_EXPIRE_DELTA - SIGN_FADE_OUT_SPAN;
-  if (delta < fadeInEnd) {
+  if (delta < fadeInEnd && hasCoarser) {
     alpha = (delta - SIGN_APPEAR_DELTA) / SIGN_FADE_IN_SPAN;
-  } else if (delta > fadeOutStart) {
+  } else if (delta > fadeOutStart && hasFiner) {
     alpha = (SIGN_EXPIRE_DELTA - delta) / SIGN_FADE_OUT_SPAN;
   }
 
@@ -215,7 +240,11 @@ export function layoutSigns(
   const candidates: PlacedSign[] = [];
   for (const label of labels) {
     if (!label.text) continue;
-    const appearance = signAppearance(view.viewLevel - label.level);
+    const appearance = signAppearance(
+      view.viewLevel - label.level,
+      label.has_coarser ?? true,
+      label.has_finer ?? true,
+    );
     if (!appearance || appearance.alpha <= 0.02) continue;
 
     const [sx, sy] = projToScreen(label.x, label.y, view.transform, view.width, view.height);

--- a/frontend/src/app/models/projection.models.ts
+++ b/frontend/src/app/models/projection.models.ts
@@ -50,6 +50,22 @@ export interface RegionLabelPayload {
   score?: number;
   /** Which namer produced the sign (e.g. "keyphrase", "llm"). */
   source?: string;
+  /**
+   * Whether a coarser sign names this region one zoom band out (a parent in the
+   * topic tree). `false` marks a **root** region: the canvas skips the coarse-
+   * edge fade-in and keeps the sign visible when zoomed out, so the region
+   * isn't left nameless with nothing coarser covering it. Absent ⇒ `true`
+   * (treated as having a parent — the pre-flag fading behaviour).
+   */
+  has_coarser?: boolean;
+  /**
+   * Whether a finer sign names this region one zoom band in (a child in the
+   * topic tree). `false` marks a **leaf** region: the canvas skips the fine-
+   * edge fade-out and keeps the sign visible as you zoom in, so an on-screen
+   * island's only name doesn't expire with nothing finer to hand off to.
+   * Absent ⇒ `true`.
+   */
+  has_finer?: boolean;
 }
 
 /** Response of ``GET /api/projection/labels``. */

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -906,7 +906,11 @@ class TestProjectionLabels:
         assert first["level"] == 0
         assert first["score"] == 0.9
         assert first["source"] == "keyphrase"
-        assert set(first) == {"level", "x", "y", "text", "score", "source"}
+        # Terminal-neighbour flags default True (present but not pinned to a tree
+        # in this hand-built set); the canvas fades such signs as before.
+        assert first["has_coarser"] is True
+        assert first["has_finer"] is True
+        assert set(first) == {"level", "x", "y", "text", "score", "source", "has_coarser", "has_finer"}
 
         assert client.get("/api/projection/meta").get_json()["has_labels"] is True
 

--- a/tests_lib/detectors/test_mlp_vs_svm_experiment.py
+++ b/tests_lib/detectors/test_mlp_vs_svm_experiment.py
@@ -118,6 +118,7 @@ class TestTrainerResolver:
         X = np.vstack([rng.normal(1, 0.3, (20, 8)), rng.normal(-1, 0.3, (20, 8))]).astype(np.float32)
         y = np.array([1] * 20 + [0] * 20, dtype=np.int32)
         predict = resolve_trainer("svm_rbf@C=3,gamma=0.5x")(X, y, 0)
+        # A PredictFn may return scores or (scores, std); coerce to the score array.
         scores = _as_scores(predict(X))
         assert scores.shape == (40,)
 

--- a/tests_lib/projection/test_demo_signposts.py
+++ b/tests_lib/projection/test_demo_signposts.py
@@ -165,19 +165,20 @@ class TestBuildCategorySignposts:
         assert only.has_finer is False  # no child prefix
 
     def test_leaf_when_every_child_prefix_is_pruned_as_singleton(self):
-        # "B" has two members (earns a sign) but each of its child cities has a
-        # single item and is pruned below _MIN_MEMBERS. With no child sign to
-        # hand off to, "B" is a leaf even though the path goes one level deeper.
+        # "Region" has two members (earns a sign) but each of its child cities
+        # has a single item and is pruned below _MIN_MEMBERS. With no child sign
+        # to hand off to, "Region" is a leaf even though the path goes deeper.
+        # (Multi-char segments so clean_category_path keeps the first one.)
         medias = {
-            1: {"category": "A/B/Solo"},
-            2: {"category": "A/B/Other"},
+            1: {"category": "Land/Region/Solo"},
+            2: {"category": "Land/Region/Other"},
         }
         proj = _proj([1, 2], [[0, 0], [1, 1]])
         ls = build_category_signposts(proj, medias)
         by_text = {lab.text: lab for lab in ls.labels}
         assert "Solo" not in by_text and "Other" not in by_text
-        assert by_text["B"].has_finer is False  # both children pruned → leaf
-        assert by_text["B"].has_coarser is True  # sits under "A"
+        assert by_text["Region"].has_finer is False  # both children pruned → leaf
+        assert by_text["Region"].has_coarser is True  # sits under "Land"
 
 
 class TestSyntheticToponymyDemo:

--- a/tests_lib/projection/test_demo_signposts.py
+++ b/tests_lib/projection/test_demo_signposts.py
@@ -143,6 +143,42 @@ class TestBuildCategorySignposts:
         assert {round(lab.level, 2) for lab in ls.labels} == {0.0}
         assert {lab.text for lab in ls.labels} == {"dog"}
 
+    def test_terminal_flags_track_the_prefix_tree(self):
+        medias, proj = self._hierarchical_medias()
+        ls = build_category_signposts(proj, medias)
+        by_text = {lab.text: lab for lab in ls.labels}
+        # Continents are roots (no parent) but have countries below them.
+        assert by_text["Europe"].has_coarser is False
+        assert by_text["Europe"].has_finer is True
+        # Countries have both a continent above and cities below.
+        assert by_text["EuropeCo1"].has_coarser is True
+        assert by_text["EuropeCo1"].has_finer is True
+        # Cities are leaves (no finer prefix) sitting under a country.
+        assert by_text["EuropeCo1City1"].has_coarser is True
+        assert by_text["EuropeCo1City1"].has_finer is False
+
+    def test_flat_category_sign_is_fully_terminal(self):
+        medias = {i + 1: {"category": "dog"} for i in range(4)}
+        proj = _proj(list(medias.keys()), np.zeros((4, 2)))
+        (only,) = build_category_signposts(proj, medias).labels
+        assert only.has_coarser is False  # depth 0
+        assert only.has_finer is False  # no child prefix
+
+    def test_leaf_when_every_child_prefix_is_pruned_as_singleton(self):
+        # "B" has two members (earns a sign) but each of its child cities has a
+        # single item and is pruned below _MIN_MEMBERS. With no child sign to
+        # hand off to, "B" is a leaf even though the path goes one level deeper.
+        medias = {
+            1: {"category": "A/B/Solo"},
+            2: {"category": "A/B/Other"},
+        }
+        proj = _proj([1, 2], [[0, 0], [1, 1]])
+        ls = build_category_signposts(proj, medias)
+        by_text = {lab.text: lab for lab in ls.labels}
+        assert "Solo" not in by_text and "Other" not in by_text
+        assert by_text["B"].has_finer is False  # both children pruned → leaf
+        assert by_text["B"].has_coarser is True  # sits under "A"
+
 
 class TestSyntheticToponymyDemo:
     def test_generator_is_deterministic(self):

--- a/tests_lib/projection/test_labels.py
+++ b/tests_lib/projection/test_labels.py
@@ -23,10 +23,26 @@ class TestRegionLabelSet:
         )
         payload = label_set.payload()
         assert payload == [
-            {"level": 0, "x": 1.5, "y": -2.0, "text": "speech", "score": 0.8, "source": "llm",
-             "has_coarser": True, "has_finer": True},
-            {"level": 2.5, "x": 0.0, "y": 0.0, "text": "dog barking", "score": 1.0, "source": "",
-             "has_coarser": True, "has_finer": True},
+            {
+                "level": 0,
+                "x": 1.5,
+                "y": -2.0,
+                "text": "speech",
+                "score": 0.8,
+                "source": "llm",
+                "has_coarser": True,
+                "has_finer": True,
+            },
+            {
+                "level": 2.5,
+                "x": 0.0,
+                "y": 0.0,
+                "text": "dog barking",
+                "score": 1.0,
+                "source": "",
+                "has_coarser": True,
+                "has_finer": True,
+            },
         ]
 
     def test_make_label_set_normalises_to_tuple(self):

--- a/tests_lib/projection/test_labels.py
+++ b/tests_lib/projection/test_labels.py
@@ -23,8 +23,10 @@ class TestRegionLabelSet:
         )
         payload = label_set.payload()
         assert payload == [
-            {"level": 0, "x": 1.5, "y": -2.0, "text": "speech", "score": 0.8, "source": "llm"},
-            {"level": 2.5, "x": 0.0, "y": 0.0, "text": "dog barking", "score": 1.0, "source": ""},
+            {"level": 0, "x": 1.5, "y": -2.0, "text": "speech", "score": 0.8, "source": "llm",
+             "has_coarser": True, "has_finer": True},
+            {"level": 2.5, "x": 0.0, "y": 0.0, "text": "dog barking", "score": 1.0, "source": "",
+             "has_coarser": True, "has_finer": True},
         ]
 
     def test_make_label_set_normalises_to_tuple(self):

--- a/tests_lib/projection/test_signpost_build.py
+++ b/tests_lib/projection/test_signpost_build.py
@@ -138,6 +138,65 @@ class TestBuildRegionLabels:
         assert label_set.labels == ()
 
 
+class TestTerminalFlags:
+    """`has_coarser` / `has_finer`: the tree-neighbour flags the canvas fades on.
+
+    Derived from adjacent-layer cluster membership — a topic whose members are
+    *noise* in the layer one step coarser (or finer) has no sign to hand off to
+    on that side, so it's terminal and the canvas keeps it visible there.
+    """
+
+    def test_region_is_covered_majority_rule(self):
+        members = np.array([0, 1, 2, 3])
+        # 3/4 named → covered; 2/4 named → covered (ties count); 1/4 → not.
+        assert sb._region_is_covered(members, np.array([0, 5, 1, -1])) is True
+        assert sb._region_is_covered(members, np.array([0, -1, 2, -1])) is True
+        assert sb._region_is_covered(members, np.array([0, -1, -1, -1])) is False
+
+    def test_region_is_covered_edge_cases(self):
+        # No adjacent layer (pyramid edge) or no members → nothing to hand off to.
+        assert sb._region_is_covered(np.array([0, 1]), None) is False
+        assert sb._region_is_covered(np.array([], dtype=int), np.array([0, 0])) is False
+
+    def test_finest_layer_is_leaf_coarsest_is_root(self, stub_fit):
+        n = 60
+        fine = (["fine-a", "fine-b"], np.array([0, 1] * (n // 2)))
+        coarse = (["coarse"], np.zeros(n, dtype=int))
+        _, label_set = _build(n=n, layers=[fine, coarse], captured=stub_fit)
+        by_text = {lab.text: lab for lab in label_set.labels}
+
+        # Coarsest layer: no parent above (root); its whole span is named finer.
+        assert by_text["coarse"].has_coarser is False
+        assert by_text["coarse"].has_finer is True
+        # Finest layer: no child below (leaf); both fine topics sit inside "coarse".
+        assert by_text["fine-a"].has_finer is False
+        assert by_text["fine-a"].has_coarser is True
+        assert by_text["fine-b"].has_finer is False
+
+    def test_region_unnamed_in_coarser_layer_is_a_root_island(self, stub_fit):
+        # The reported bug: an island named only at a fine level, with no coarser
+        # name covering it. Coarse layer leaves rows 30–59 as noise; the fine
+        # topic there (fine-b) is both a root (no parent) and a leaf (finest) —
+        # so the canvas must keep it visible at every zoom.
+        n = 60
+        fine = (["fine-a", "fine-b"], np.array([0] * 30 + [1] * 30))
+        coarse = (["coarse"], np.array([0] * 30 + [-1] * 30))
+        _, label_set = _build(n=n, layers=[fine, coarse], captured=stub_fit)
+        by_text = {lab.text: lab for lab in label_set.labels}
+
+        assert by_text["fine-a"].has_coarser is True  # sits under "coarse"
+        assert by_text["fine-b"].has_coarser is False  # coarse layer noise → root
+        assert by_text["fine-b"].has_finer is False  # finest layer → leaf
+
+    def test_single_layer_signs_are_fully_terminal(self, stub_fit):
+        # With one layer every name is the only name for its region: no parent,
+        # no child, so it should show at every zoom (both edges terminal).
+        _, label_set = _build(n=60, layers=[(["only"], np.zeros(60, dtype=int))], captured=stub_fit)
+        (only,) = label_set.labels
+        assert only.has_coarser is False
+        assert only.has_finer is False
+
+
 class TestEmbedderTextEncoder:
     def test_encodes_into_media_space(self):
         encoder = sb.EmbedderTextEncoder(FakeEmbedder(), dim=8)

--- a/tests_lib/projection/test_signpost_persistence.py
+++ b/tests_lib/projection/test_signpost_persistence.py
@@ -62,6 +62,18 @@ class TestRoundTrip:
         label_set, signature = loaded
         assert (label_set.projection_id, signature) == ("new", "sig-new")
 
+    def test_terminal_flags_round_trip(self, container):
+        # A leaf/root sign's terminal flags must survive the JSON round-trip so a
+        # reloaded layout letters its islands the same way it did when built.
+        label_set = make_label_set(
+            "proj-1",
+            [RegionLabel(level=3.6, x=0.0, y=0.0, text="island", has_coarser=False, has_finer=False)],
+        )
+        append_region_labels(container, label_set, "sig")
+        loaded, _ = read_region_labels(container)
+        (sign,) = loaded.labels
+        assert (sign.has_coarser, sign.has_finer) == (False, False)
+
     def test_read_missing_entry_returns_none(self, container):
         assert read_region_labels(container) is None
 

--- a/tests_lib/projection/test_signpost_persistence.py
+++ b/tests_lib/projection/test_signpost_persistence.py
@@ -70,7 +70,9 @@ class TestRoundTrip:
             [RegionLabel(level=3.6, x=0.0, y=0.0, text="island", has_coarser=False, has_finer=False)],
         )
         append_region_labels(container, label_set, "sig")
-        loaded, _ = read_region_labels(container)
+        result = read_region_labels(container)
+        assert result is not None
+        loaded, _ = result
         (sign,) = loaded.labels
         assert (sign.has_coarser, sign.has_finer) == (False, False)
 

--- a/vtscore/projection/demo_signposts.py
+++ b/vtscore/projection/demo_signposts.py
@@ -144,6 +144,14 @@ def build_category_signposts(
     if not members:
         return empty
 
+    # A prefix earns a sign only with enough members; a sign is terminal on its
+    # fine edge (a **leaf**) when no one-segment-longer prefix also earns one,
+    # and terminal on its coarse edge (a **root**) at depth 0.  Its parent
+    # prefix has at least as many members, so a kept child always has a kept
+    # parent — ``has_coarser`` reduces to ``depth > 0``.
+    earned = {prefix for prefix, rows in members.items() if len(rows) >= _MIN_MEMBERS}
+    parents_with_children = {prefix[:-1] for prefix in earned if len(prefix) >= 2}
+
     labels: list[RegionLabel] = []
     for prefix, rows in members.items():
         if len(rows) < _MIN_MEMBERS:
@@ -161,6 +169,8 @@ def build_category_signposts(
                 # member count as the score makes that ordering explicit.
                 score=float(len(rows)),
                 source="ground-truth",
+                has_coarser=depth > 0,
+                has_finer=prefix in parents_with_children,
             )
         )
 

--- a/vtscore/projection/labels.py
+++ b/vtscore/projection/labels.py
@@ -38,6 +38,19 @@ class RegionLabel:
     score: float = 1.0
     #: Which namer produced the sign (e.g. ``"keyphrase"``, ``"llm"``).
     source: str = ""
+    #: Whether a *coarser* sign names this region one zoom band out (a parent in
+    #: the topic tree).  The canvas fades a sign in at its coarse edge only to
+    #: hand a coarser name off to it; a **root** region (``has_coarser=False``)
+    #: has no such parent, so the canvas keeps it visible when zoomed out
+    #: instead of leaving the region nameless.  Defaults ``True`` so any sign not
+    #: explicitly marked terminal fades exactly as before.
+    has_coarser: bool = True
+    #: Whether a *finer* sign names this region one zoom band in (a child in the
+    #: topic tree).  The canvas fades a sign out at its fine edge only to hand
+    #: off to a finer name; a **leaf** region (``has_finer=False``) has no such
+    #: child, so the canvas keeps it visible when zoomed in rather than
+    #: expiring an on-screen island's only name.  Defaults ``True``.
+    has_finer: bool = True
 
 
 @dataclass(frozen=True)

--- a/vtscore/projection/signpost_build.py
+++ b/vtscore/projection/signpost_build.py
@@ -331,6 +331,23 @@ def _fit_topic_layers(
     ]
 
 
+def _region_is_covered(members: np.ndarray, adjacent: np.ndarray | None) -> bool:
+    """Whether a topic's *members* fall mostly inside a named cluster of *adjacent*.
+
+    *adjacent* is a coarser- or finer-layer per-row topic assignment (``-1`` =
+    noise), or ``None`` when there is no such layer (this topic sits at the
+    pyramid's edge — the coarsest or finest layer).  Returns ``True`` when a
+    majority of *members* are named (topic index ``>= 0``) there, i.e. some
+    coarser/finer sign covers this region and the canvas has a name to hand off
+    to.  ``None`` or an all-noise adjacent layer means nothing covers the region
+    → the sign is terminal on that side and must not fade there.
+    """
+    if adjacent is None or members.size == 0:
+        return False
+    named = int(np.count_nonzero(adjacent[members] >= 0))
+    return named * 2 >= members.size
+
+
 def _clusterable_vectors(matrix: np.ndarray, on_progress: ProgressFn | None = None) -> np.ndarray:
     """The dedicated ~5-D cosine UMAP Toponymy clusters on (not the 2-D layout)."""
     import umap  # noqa: PLC0415
@@ -398,6 +415,12 @@ def build_region_labels(
     labels: list[RegionLabel] = []
     for i, (names, cluster_labels) in enumerate(layers):
         level = (n_layers - 1 - i) * _LEVEL_STEP
+        # Layers come back finest-first (index 0), so a *finer* sign lives at
+        # ``i-1`` and a *coarser* one at ``i+1``.  A topic whose members are
+        # noise (unnamed) in an adjacent layer has no sign to hand off to on
+        # that side, and the canvas keeps such terminal signs visible there.
+        finer = layers[i - 1][1] if i > 0 else None
+        coarser = layers[i + 1][1] if i + 1 < n_layers else None
         for topic_idx, name in enumerate(names):
             text = str(name).strip()
             if not text:
@@ -414,6 +437,8 @@ def build_region_labels(
                     text=text,
                     score=float(members.size),
                     source=source,
+                    has_coarser=_region_is_covered(members, coarser),
+                    has_finer=_region_is_covered(members, finer),
                 )
             )
 

--- a/vtsearch/schemas/projection.py
+++ b/vtsearch/schemas/projection.py
@@ -95,6 +95,26 @@ class RegionLabelSchema(Schema):
         load_default="",
         metadata={"description": 'Which namer produced the sign (e.g. "keyphrase", "llm").'},
     )
+    has_coarser = fields.Boolean(
+        load_default=True,
+        metadata={
+            "description": (
+                "Whether a coarser sign names this region one zoom band out (a "
+                "parent). False for a root region, which the canvas keeps "
+                "visible when zoomed out instead of fading in under a parent."
+            ),
+        },
+    )
+    has_finer = fields.Boolean(
+        load_default=True,
+        metadata={
+            "description": (
+                "Whether a finer sign names this region one zoom band in (a "
+                "child). False for a leaf region, which the canvas keeps visible "
+                "when zoomed in instead of expiring with nothing to hand off to."
+            ),
+        },
+    )
 
 
 class ProjectionLabelsResponseSchema(Schema):


### PR DESCRIPTION
## The bug

An island of media in the VTSBrowse map could show **no signpost when zoomed out**, have its name **fade in as you zoom toward it**, and then have that same name **fade out again as you zoom in further** — leaving the island fully on screen but nameless.

## Root cause

Signpost visibility (`sign-layout.ts`) keys entirely off `delta = viewLevel − sign.level`, with a fixed band for **every** sign:

```
delta ≤ −1.5   invisible (view far coarser than the sign)
−1.5 → +2.5    visible (fades in at the coarse edge, out at the fine edge)
delta ≥ +2.5   invisible (view zoomed past the sign)
```

Those two fade edges implement a **hand-off cascade**: a sign fades in at its coarse edge because a coarser *parent* already names the area, and fades out at its fine edge because a finer *child* is taking over ("EUROPE" → "France"). That only makes sense when a neighbour actually exists on that side.

The reported island's only sign is a mid/fine-level name that is **both a root** (no coarser sign names the area) **and a leaf** (no finer sign refines it). So both fade edges fire into a void: zoomed out it's below its fade-in edge with nothing coarser covering it, and zoomed in it expires past `+2.5` with nothing finer to replace it.

## The fix

A hand-off edge should only apply when there's something to hand off to. Each signpost now carries two flags describing its tree neighbours, and the canvas suppresses the fade on any **terminal** edge:

- **root** (`has_coarser=false`) → skip the coarse-edge fade-in; the sign stays visible when zoomed out so the region is named.
- **leaf** (`has_finer=false`) → skip the fine-edge fade-out; the sign stays visible when zoomed in so an on-screen island keeps its only name.

The size curve is untouched (`interpolateScale` already clamps outside the band), so a terminal sign simply holds its smallest/largest size at full opacity past the edge instead of vanishing. Non-terminal signs fade exactly as before, so the EUROPE→France cascade is unchanged where real hand-offs exist.

The flags are derived at **build time** from the real hierarchy, not guessed geometrically:

- **Toponymy pipeline** (`signpost_build.py`): a topic is covered on a side when a majority of its members are *named* (non-noise) in the adjacent finer/coarser layer. The finest layer is always a leaf; the coarsest always a root; a region that's noise in the coarser layer is a root island — exactly the reported case.
- **Ground-truth demo signs** (`demo_signposts.py`): derived from the category-path tree — `has_coarser` = depth > 0, `has_finer` = some one-segment-longer prefix also earned a sign.

Defaults are `True` (has both neighbours), so any label without the flags — older persisted sets, hand-built sets — fades exactly as before.

## Changes

- `vtscore/projection/labels.py` — add `has_coarser` / `has_finer` to `RegionLabel` (default `True`); they round-trip through `payload()` / persistence automatically.
- `vtscore/projection/signpost_build.py` — `_region_is_covered` helper + per-topic flag derivation from adjacent layers.
- `vtscore/projection/demo_signposts.py` — flag derivation from the path-prefix tree.
- `vtsearch/schemas/projection.py` + `frontend/openapi.json` — expose the two fields on `RegionLabel`.
- `frontend/src/app/models/projection.models.ts` — optional payload fields.
- `frontend/src/app/components/browse-canvas/sign-layout.ts` — `signAppearance` honours the flags; `layoutSigns` threads them through; module docs updated.
- Tests: terminal-sign appearance/layout (Vitest), build/demo flag derivation and persistence round-trip (pytest), updated exact-payload assertions.

Also fixed a pre-existing pyright error in `tests_lib/detectors/test_mlp_vs_svm_experiment.py` (a `PredictFn` union was `.shape`-accessed without coercion) so the suite stays green.

## Testing

`./run-tests.sh` — all 6638 tests pass (1 skipped). OpenAPI snapshot regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014NcNQTRisEPDjF4bLdP3sc)_