### PR TITLE
Don't auto-select the first option for free-text plugin field selects

### DIFF
--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
@@ -72,6 +72,31 @@ describe('GenericFormPickerComponent', () => {
     ]);
   });
 
+  it('does not auto-select the first static option for a free-text combobox', () => {
+    const freeTextImporter = {
+      name: 'free_text_importer',
+      fields: [{ key: 'q', field_type: 'select', options: ['a', 'b'], allow_free_text: true }],
+    } as any;
+    component.open(freeTextImporter);
+    expect(component.formValues['q']).toBeUndefined();
+  });
+
+  it('does not auto-select the first option for a required free-text combobox once options load', () => {
+    const field = {
+      key: 'q',
+      field_type: 'select',
+      dynamic_options: true,
+      required: true,
+      allow_free_text: true,
+    } as any;
+    component.selectedImporter.set({ name: 'imp', fields: [field] } as any);
+    (component as any).refreshDynamicFieldOptions(field);
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/dataset/import/imp/options'))
+      .flush({ options: [{ value: 'a', label: 'A' }] });
+    expect(component.formValues['q']).toBeUndefined();
+  });
+
   it('keeps a typed free-text value the refreshed options omit', () => {
     const field = { key: 'q', field_type: 'select', dynamic_options: true, allow_free_text: true } as any;
     component.selectedImporter.set({ name: 'imp', fields: [field] } as any);

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
@@ -137,6 +137,7 @@ export class GenericFormPickerComponent {
         } else if (
           field.field_type === 'select' &&
           !field.dynamic_options &&
+          !field.allow_free_text &&
           (field.options?.length ?? 0) > 0
         ) {
           this.formValues[field.key] = field.options![0];
@@ -270,7 +271,7 @@ export class GenericFormPickerComponent {
         if (current && !inList && !field.allow_free_text) {
           this.formValues[key] = '';
         }
-        if (!this.formValues[key] && field.required && options.length > 0) {
+        if (!this.formValues[key] && field.required && !field.allow_free_text && options.length > 0) {
           this.formValues[key] = options[0].value;
         }
       },

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -353,6 +353,30 @@ describe('NewDetectorModalComponent', () => {
     expect(component.labelImporterValues['sheet']).toBe('s1');
   });
 
+  it('does not auto-select the first option for a required free-text combobox', () => {
+    const field = {
+      key: 'sheet',
+      field_type: 'select',
+      dynamic_options: true,
+      required: true,
+      allow_free_text: true,
+    } as any;
+    component.selectLabelImporter({ name: 'gsheets', fields: [field] } as any);
+
+    httpMock
+      .expectOne('/api/label-importers/field-options/gsheets')
+      .flush({ options: [{ value: 's1', label: 'Sheet 1' }] });
+
+    expect(component.labelImporterValues['sheet']).toBeUndefined();
+  });
+
+  it('does not auto-select the first static option for a free-text combobox', () => {
+    const field = { key: 's', field_type: 'select', options: ['x', 'y'], allow_free_text: true } as any;
+    component.selectLabelImporter({ name: 'imp', fields: [field] } as any);
+
+    expect(component.labelImporterValues['s']).toBeUndefined();
+  });
+
   it('coerces static string options into {value,label} pairs on the Trained tab', () => {
     const staticSelect = { key: 's', field_type: 'select', options: ['x', 'y'] } as any;
     expect(component.labelImporterOptionsFor(staticSelect)).toEqual([

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -965,6 +965,7 @@ export class NewDetectorModalComponent implements OnInit {
       } else if (
         field.field_type === 'select' &&
         !field.dynamic_options &&
+        !field.allow_free_text &&
         (field.options?.length ?? 0) > 0
       ) {
         this.labelImporterValues[field.key] = field.options![0];
@@ -1022,7 +1023,7 @@ export class NewDetectorModalComponent implements OnInit {
           if (current && !inList && !field.allow_free_text) {
             this.labelImporterValues[key] = '';
           }
-          if (!this.labelImporterValues[key] && field.required && options.length > 0) {
+          if (!this.labelImporterValues[key] && field.required && !field.allow_free_text && options.length > 0) {
             this.labelImporterValues[key] = options[0].value;
           }
         },

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -151,6 +151,24 @@ describe('ExportModalComponent', () => {
     req.flush({ success: true });
   });
 
+  it('does not auto-select the first option for a free-text combobox field', async () => {
+    await flushInit();
+    const exporter = {
+      name: 'free_text_exporter',
+      display_name: 'Free Text Exporter',
+      fields: [
+        {
+          key: 'q',
+          field_type: 'select',
+          options: ['a', 'b'],
+          allow_free_text: true,
+        },
+      ],
+    };
+    component.startExporter(exporter as never);
+    expect(component.formValues['q']).toBe('');
+  });
+
   it('emits closed on close', async () => {
     await flushInit();
     vi.spyOn(component.closed, 'emit');

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -418,6 +418,7 @@ export class ExportModalComponent implements OnInit {
     if (
       field.field_type === 'select' &&
       !field.dynamic_options &&
+      !field.allow_free_text &&
       (field.options?.length ?? 0) > 0
     ) {
       return field.options![0];

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
@@ -128,6 +128,33 @@ describe('LabelImporterModalComponent', () => {
     ]);
   });
 
+  it('does not auto-select the first static option for a free-text combobox', async () => {
+    await flushInit();
+    const freeTextImporter = {
+      name: 'free_text_importer',
+      fields: [{ key: 'q', field_type: 'select', options: ['a', 'b'], allow_free_text: true }],
+    } as any;
+    component.selectImporter(freeTextImporter);
+    expect(component.formValues['q']).toBeUndefined();
+  });
+
+  it('does not auto-select the first option for a required free-text combobox once options load', async () => {
+    await flushInit();
+    const field = {
+      key: 'q',
+      field_type: 'select',
+      dynamic_options: true,
+      required: true,
+      allow_free_text: true,
+    } as any;
+    component.selectedImporter = { name: 'imp', fields: [field] } as any;
+    (component as any).refreshDynamicFieldOptions(field);
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/label-importers/field-options/imp'))
+      .flush({ options: [{ value: 'a', label: 'A' }] });
+    expect(component.formValues['q']).toBeUndefined();
+  });
+
   it('keeps a typed free-text value the refreshed options omit', async () => {
     await flushInit();
     const field = { key: 'q', field_type: 'select', dynamic_options: true, allow_free_text: true } as any;

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -120,6 +120,7 @@ export class LabelImporterModalComponent implements OnDestroy {
       } else if (
         field.field_type === 'select' &&
         !field.dynamic_options &&
+        !field.allow_free_text &&
         (field.options?.length ?? 0) > 0
       ) {
         this.formValues[field.key] = field.options![0];
@@ -172,7 +173,7 @@ export class LabelImporterModalComponent implements OnDestroy {
           if (current && !inList && !field.allow_free_text) {
             this.formValues[key] = '';
           }
-          if (!this.formValues[key] && field.required && options.length > 0) {
+          if (!this.formValues[key] && field.required && !field.allow_free_text && options.length > 0) {
             this.formValues[key] = options[0].value;
           }
         },

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
@@ -54,6 +54,16 @@ describe('SettingsExporterModalComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('.picker-card').length).toBe(1);
   });
 
+  it('does not auto-select the first option for a free-text combobox', async () => {
+    await flushInit();
+    const freeTextExporter = {
+      name: 'free_text_exporter',
+      fields: [{ key: 'q', field_type: 'select', options: ['a', 'b'], allow_free_text: true }],
+    } as any;
+    component.selectExporter(freeTextExporter);
+    expect(component.formValues['q']).toBeUndefined();
+  });
+
   // Zoneless staleness canary: the success message lands in an HTTP subscribe (an
   // unpatched callback) and repaints only because `successMessage` is a signal
   // read in the template. Drive a successful export and assert it renders with no

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -80,6 +80,7 @@ export class SettingsExporterModalComponent implements OnDestroy {
       } else if (
         field.field_type === 'select' &&
         !field.dynamic_options &&
+        !field.allow_free_text &&
         (field.options?.length ?? 0) > 0
       ) {
         this.formValues[field.key] = field.options![0];

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
@@ -52,6 +52,16 @@ describe('SettingsImporterModalComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('.picker-card').length).toBe(1);
   });
 
+  it('does not auto-select the first option for a free-text combobox', async () => {
+    await flushInit();
+    const freeTextImporter = {
+      name: 'free_text_importer',
+      fields: [{ key: 'q', field_type: 'select', options: ['a', 'b'], allow_free_text: true }],
+    } as any;
+    component.selectImporter(freeTextImporter);
+    expect(component.formValues['q']).toBeUndefined();
+  });
+
   // Zoneless staleness canary: the success message lands in an HTTP subscribe (an
   // unpatched callback) and repaints only because `successMessage` is a signal
   // read in the template. Drive a successful import and assert it renders with no

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -83,6 +83,7 @@ export class SettingsImporterModalComponent implements OnDestroy {
       } else if (
         field.field_type === 'select' &&
         !field.dynamic_options &&
+        !field.allow_free_text &&
         (field.options?.length ?? 0) > 0
       ) {
         this.formValues[field.key] = field.options![0];


### PR DESCRIPTION
## Summary

- `PluginField` select fields with `allow_free_text=True` render as a text input backed by a `<datalist>`, not a native `<select>`. Every picker was pre-filling that input with `options[0]` on open, so the user had to delete the text before the datalist would show the rest of the options.
- Skip the `options[0]` default for `allow_free_text` fields — both the initial static default and the required-field fallback applied once dynamic options finish loading — across every picker that renders plugin fields: dataset importer (`generic-form-picker`), label importer modal, label importer tab in the new-detector modal, settings importer/exporter modals, and the label export modal.
- Strict (non-free-text) selects are unaffected and continue to default to the first option as before.

## Test plan

- [x] Added unit tests to each touched component's spec file asserting a free-text select field is left unset (or `''` for the exporter, which unconditionally seeds `formValues` from `defaultFor`) after opening/selecting the importer/exporter, and after a required dynamic free-text field's options load.
- [x] `cd frontend && npm run test:ci` — 1788 tests passed
- [x] `./run-tests.sh core` — ruff/format/codespell/deptry/pip-audit/pyright/OpenAPI-snapshot/Dockerfile/screenshot-wiring checks, frontend TypeScript build + npm audit, and 1148 pytest tests all passed

Closes #2689

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9b1SQmuXbZGwYZvuFCNbi)_