### PR TITLE
Ingest imported labelset media so an imported detector is exportable

### DIFF
--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -2487,3 +2487,94 @@ class TestRegisterModelFromLabelset:
         # Labels resolved into the loaded detector's votes (matched by md5).
         assert 1 in good_votes
         assert 2 in bad_votes
+
+    def test_foreign_media_is_ingested_so_labels_export(self, client, tmp_path):
+        """Import whose media isn't in the active dataset is still exportable (#2690).
+
+        The ordinary "import someone else's detector" case: the labelset's
+        elements resolve to files on disk but to no loaded media.  The import
+        must pull them in, so ``GET /api/labels/export`` - which composes from
+        vote state intersected with the active dataset's medias - returns the
+        imported labels straight away.  Before the fix, export returned an
+        empty labelset until the user ran Browse Positives / Find / Train,
+        even though the right pane (labelset-sourced) showed the labels.
+        """
+        import hashlib
+
+        from helpers import make_wav_file
+
+        clips_dir = tmp_path / "foreign_clips"
+        clips_dir.mkdir()
+        origin = {
+            "importer": "server_folder",
+            "params": {"path": str(clips_dir), "media_type": "audio"},
+        }
+        entries = []
+        for i, (freq, label) in enumerate(((330.0, "good"), (550.0, "bad")), start=1):
+            path = make_wav_file(clips_dir, f"foreign_{i}.wav", frequency=freq)
+            entries.append(
+                {
+                    "md5": hashlib.md5(path.read_bytes()).hexdigest(),
+                    "label": label,
+                    "origin": origin,
+                    "origin_name": path.name,
+                    "filename": path.name,
+                }
+            )
+        labels_path = tmp_path / "foreign_labels.json"
+        labels_path.write_text(json.dumps({"labels": entries}))
+
+        res = client.post(
+            "/api/detectors/registry/from-labelset/server_json_file",
+            json={"name": "Foreign", "filepath": str(labels_path)},
+        )
+        assert res.status_code == 201, res.get_json()
+        assert res.get_json()["ingested"] == 2, "imported media must be pulled into the active dataset"
+        detector_id = res.get_json()["detector"]["id"]
+
+        _load_detector_and_wait(client, detector_id)
+
+        exported = client.get(
+            "/api/labels/export?label_filter=both",
+            headers={"X-Detector-Id": detector_id},
+        ).get_json()["labels"]
+        by_name = {e["origin_name"]: e["label"] for e in exported}
+        assert by_name == {"foreign_1.wav": "good", "foreign_2.wav": "bad"}
+
+    def test_ingest_is_skipped_without_an_active_dataset(self, client, tmp_path):
+        """No dataset loaded → nothing to ingest into, and the import still succeeds."""
+        import hashlib
+
+        from helpers import make_wav_file
+        from vtsearch.state import clear_all_contexts
+
+        clips_dir = tmp_path / "no_dataset_clips"
+        clips_dir.mkdir()
+        path = make_wav_file(clips_dir, "orphan.wav", frequency=440.0)
+        labels_path = tmp_path / "orphan_labels.json"
+        labels_path.write_text(
+            json.dumps(
+                {
+                    "labels": [
+                        {
+                            "md5": hashlib.md5(path.read_bytes()).hexdigest(),
+                            "label": "good",
+                            "origin": {
+                                "importer": "server_folder",
+                                "params": {"path": str(clips_dir), "media_type": "audio"},
+                            },
+                            "origin_name": path.name,
+                        }
+                    ]
+                }
+            )
+        )
+
+        clear_all_contexts()
+        res = client.post(
+            "/api/detectors/registry/from-labelset/server_json_file",
+            json={"name": "NoDataset", "filepath": str(labels_path)},
+        )
+        assert res.status_code == 201, res.get_json()
+        assert res.get_json()["ingested"] == 0
+        assert res.get_json()["num_labels"] == 1

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -213,6 +213,51 @@ def register_detector_route(body: dict):
 # ---------------------------------------------------------------------------
 
 
+def _ingest_imported_labelset_media(label_dicts: list[dict]) -> int:
+    """Pull an imported labelset's media into the active dataset.
+
+    A labelset is origin-keyed and dataset-agnostic, but everything
+    downstream of it - vote state, the labeling grid, and above all
+    ``GET /api/labels/export``, which composes its payload from
+    ``LabelSet.from_clips_and_votes(active_medias, goods, bads)`` - can only
+    see labels whose media resolve to the *active* dataset's medias.  Without
+    this step, importing a detector whose labels came from somewhere else
+    leaves the right pane showing the imported labels (it reads the labelset)
+    while export returns nothing (it reads votes), and the user has to Browse
+    Positives / Find / Train first to materialise the media before the labels
+    become exportable at all (issue #2690).
+
+    Mirrors what :func:`~vtsearch.routes.labels.importers.run_label_import`
+    already does for the in-session label importer, so the two import paths
+    land the same media in the same place.  The subsequent detector load then
+    restores those labels into votes normally.
+
+    Best-effort: the detector is created either way, so an unreachable origin
+    costs the caller nothing beyond an un-ingested media.  Returns the number
+    of medias ingested.
+    """
+    from vtscore.state.core import get_active_context, is_request_missing_dataset_context
+
+    try:
+        ds_ctx = get_active_context()
+        if not ds_ctx.dataset_id or is_request_missing_dataset_context(ds_ctx):
+            # No dataset to ingest into; the labels stay origin-only until a
+            # dataset is loaded and the detector is (re)loaded against it.
+            return 0
+
+        from vtscore.datasets.ingest import ingest_missing_medias
+        from vtsearch.state import cached_media_lookups, find_missing_entries, medias
+
+        origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
+        missing = find_missing_entries(label_dicts, origin_lookup, md5_lookup, name_lookup)
+        if not missing:
+            return 0
+        return ingest_missing_medias(missing, medias)
+    except Exception:
+        logger.exception("Ingesting imported labelset media failed")
+        return 0
+
+
 @detectors_registry_bp.route(
     "/api/detectors/registry/from-labelset/<importer_name>",
     methods=["POST"],
@@ -327,6 +372,11 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
     entry["num_training"] = len(labelset)
     entry["last_trained_at"] = time.time()
 
+    # Materialise any imported label whose media isn't in the active dataset,
+    # so the labels are exportable / visible immediately instead of only after
+    # a Browse Positives / Find / Train pass (issue #2690).
+    ingested = _ingest_imported_labelset_media([el.to_dict() for el in elements])
+
     return jsonify(
         {
             "ok": True,
@@ -334,6 +384,7 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
             "applied": applied,
             "skipped": skipped,
             "num_labels": len(labelset),
+            "ingested": ingested,
         }
     ), 201
 


### PR DESCRIPTION
Closes #2690

## Diagnosis

Not the reporter's importer extension — this reproduces with the built-in `server_json_file` label importer.

`GET /api/labels/export` builds its payload from cid-keyed **vote state intersected with the active dataset's medias**:

```python
labelset = LabelSet.from_clips_and_votes(all_medias, goods, bads, ...)   # vote.py:226
```

The detector's canonical on-disk labelset (origin/md5-keyed, dataset-agnostic) is never consulted. Meanwhile `POST /api/detectors/registry/from-labelset/<importer>` wrote the labelset to disk and stopped there. The frontend's follow-up `loadDetector` call does run, and `restore_labels_from_detector` does its job — it just legitimately restores **0** labels, because a labelset imported from another dataset or machine matches no loaded media by origin+name, md5, or origin-file→md5.

Net effect: the right pane showed the imported labels (it reads the labelset) while Export returned an empty set, and in Find mode the export buttons were literally disabled (`goodIds().length === 0`, `right-panel.component.html:76,110`). Browse Positives "fixed" it only because it builds an ephemeral `__detpos__<id>` dataset out of the positives' origins — which is also why the workaround recovered the good labels and never the bad ones. "No metadata in the detector grid" is the same root cause, not a separate bug: the entry is stamped `embedder: ''` because nothing has been resolved against a dataset yet.

Reproduced before the fix:

```
LABELSET endpoint labels: 2      ← right pane shows both
EXPORT post-load:        0       ← export returns nothing
BROWSE POSITIVES → EXPORT: 1     ← the good one, and only the good one
```

## Change

The in-session label importer already handles exactly this: `run_label_import` calls `ingest_missing_medias(missing, medias)` to pull unmatched entries in from their origins (`labels/importers.py:239-241`). The detector-import path did not. This adds the same step to `register_detector_from_labelset` via a new `_ingest_imported_labelset_media` helper, so the two import paths land the same media in the same place, and the subsequent detector load restores those labels into votes normally.

- Best-effort: the detector is created either way, so an unreachable origin costs nothing beyond an un-ingested media.
- No-op when no dataset is active (the labels stay origin-only until a dataset is loaded and the detector is reloaded against it).
- The count is reported as `ingested` on the 201 response.

## Tests

Two regression tests on `TestRegisterModelFromLabelset`:

- `test_foreign_media_is_ingested_so_labels_export` — imports a labelset whose media resolve to files on disk but to no loaded media, then asserts `/api/labels/export` returns both labels straight after the load. Verified to fail without the fix (`assert 0 == 2`).
- `test_ingest_is_skipped_without_an_active_dataset` — the no-dataset guard; verified by probe to take the intended branch rather than the exception fallback.

`./run-tests.sh`: **6640 passed, 1 skipped, 2 xpassed**.

## Follow-ups

Filed separately rather than left in this description:

- #2702 — a detector imported in an earlier session, or loaded against a partially-overlapping dataset, still exports fewer labels than its labelset holds. The general fix is a labelset fallback in the export route.
- #2703 — the ingest runs synchronously inside the import request, so a large labelset blocks the New Detector modal. Pre-existing shape shared with `run_label_import`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uk8GxpVVHwnL9gzika3gT5