### PR TITLE
Default VTSBrowse bin-details panel to docked (left panel)

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -119,9 +119,10 @@ const DOCKED_MAIN_MIN = 60;
  * It renders in one of two presentations, chosen per media type by the
  * ``bin_details_docked`` setting (the dock / pop-out header buttons flip it):
  *
- * - **Floating** (``docked`` false, the default): a draggable popup window
- *   summoned at the right-click point and clamped to the visible canvas.
- * - **Docked** (``docked`` true): a persistent left panel beside the canvas.
+ * - **Floating** (``docked`` false): a draggable popup window summoned at the
+ *   right-click point and clamped to the visible canvas.
+ * - **Docked** (``docked`` true, the default): a persistent left panel beside
+ *   the canvas.
  *   The top row holds the large item with the metadata column to its right,
  *   separated by a draggable divider ({@link onMetaDividerPointerDown}); the
  *   member grid fills the rest of the panel below them. The metadata column

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -220,14 +220,15 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
   /**
    * Docked bin-details mode for the active media type, mirrored from the
-   * per-media ``bin_details_docked`` setting. When on, the bin details render
-   * as a persistent left panel (large item + metadata on top, member grid
-   * below) instead of the floating right-click popup; the panel doubles as the
-   * audio now-playing display, replacing the toolbar's small waveform widget.
+   * per-media ``bin_details_docked`` setting. When on (the default for a
+   * media type with no saved choice), the bin details render as a persistent
+   * left panel (large item + metadata on top, member grid below) instead of
+   * the floating right-click popup; the panel doubles as the audio
+   * now-playing display, replacing the toolbar's small waveform widget.
    * Flipped by the dock button on the floating window and the pop-out button
    * on the panel, both of which persist the choice.
    */
-  readonly detailsDocked = signal(false);
+  readonly detailsDocked = signal(true);
 
   /**
    * Width (CSS px) of the docked bin-details panel, mirrored from the
@@ -625,7 +626,8 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.signposts.set(rawSigns == null ? true : rawSigns);
 
     const dockMap = s.bin_details_docked as { [key: string]: boolean } | undefined;
-    this.detailsDocked.set(!!(mt && dockMap && dockMap[mt]));
+    const dockedValue = mt && dockMap ? dockMap[mt] : undefined;
+    this.detailsDocked.set(dockedValue === undefined ? true : dockedValue);
   }
 
   /** Read a ``{media_type: value}`` setting for *mt*, or ``''`` when unset. */

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -220,7 +220,8 @@ describe('BrowseViewComponent (zoneless canary)', () => {
     await settleZoneless(fixture);
     const component = fixture.componentInstance;
 
-    // Start floating with a bin open.
+    // Force the floating presentation (docked is the default) before opening a bin.
+    component.detailsDocked.set(false);
     component.onCanvasContextMenu({
       members: [7, 8],
       repId: 7,

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -465,7 +465,8 @@ class UserSettings(BaseModel):
     # metadata on top, the bin's member grid below) instead of the floating
     # right-click popup window. Driven by the dock button on the floating
     # window and the pop-out button on the docked panel; empty entries fall
-    # back to the floating window (false).
+    # back to the docked left panel (true) — the pop-out button persists an
+    # explicit ``false`` for a media type the user chose to float instead.
     bin_details_docked: dict[str, bool] = Field(default_factory=dict)
     panel_pct_left: dict[str, int] = Field(default_factory=dict)
     panel_pct_right: dict[str, int] = Field(default_factory=dict)


### PR DESCRIPTION
## Summary
- VTSBrowse's bin-details view (opened by right-clicking a bin on the canvas) now defaults to the **docked left panel** presentation instead of the floating popup window, for any media type with no saved `bin_details_docked` choice.
- The floating popup remains available via the panel's pop-out button, and that explicit choice is still persisted and respected per media type.

## Details
- `browse-view.component.ts`: the settings-application logic now treats an unset per-media `bin_details_docked` entry as `true` (docked), mirroring the existing pattern used for `browse_signposts`. An explicit `false` (set via the pop-out button) still floats.
- Updated doc comments in `browse-view.component.ts`, `browse-bin-popup.component.ts`, and `vtsearch/settings_models.py` to describe the new default.
- Updated a zoneless spec test that implicitly relied on the old floating default to explicitly start from the floating state, since it's testing the dock/pop-out toggle behavior rather than the default.

Closes #2692

## Test plan
- [x] `./run-tests.sh core` — 1148 passed (includes the frontend TypeScript build check)
- [x] `./run-tests.sh api` — 563 passed
- [x] `cd frontend && npm run test:ci` — 1779 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01E26553HRcZ2vGvTk1aZW6s)_