### PR TITLE
Auto-default plugin icons to a boxed capital-letter glyph

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -67,8 +67,28 @@ serialisation. All plugin base classes inherit from it.
 | `name`         | `str`               | Yes      | Snake_case identifier, used in API URL path   |
 | `display_name` | `str`               | Yes      | Human-readable label for the UI               |
 | `description`  | `str`               | Yes      | One-sentence subtitle                         |
-| `icon`         | `str`               | No       | Emoji/icon string (each family has a default) |
+| `icon`         | `str`               | No       | Emoji/icon string (auto-derived if unset — see below) |
 | `fields`       | `list[PluginField]` | Yes      | Ordered list of user-facing input fields      |
+
+**Auto-derived defaults.** `name`, `display_name`, `description`, and `icon`
+don't actually have to be set — a subclass that omits any of them gets a
+default filled in automatically:
+
+- `name`: the class name with its family suffix (`DatasetImporter`,
+  `LabelsetExporter`, `MediaConverter`, ...) stripped and the remainder
+  snake-cased, e.g. `MyShinyExporter` → `"my_shiny"`.
+- `display_name`: title-cased `name`, e.g. `"My Shiny"`.
+- `description`: the first line of the class docstring.
+- `icon`: the first letter of `display_name`, upper-cased, e.g. `"M"`. The
+  frontend renders any single capital letter A–Z as a boxed letter-glyph
+  icon, so a plugin author doesn't have to design (or even pick) an icon
+  to get something better than every plugin in the family sharing the
+  same generic emoji. Write `class GoogleDatasetImporter(DatasetImporter):
+  ...` with no `icon` and it shows a "G" outline by default; give it a
+  proper `icon = "🔍"` (or an SVG-type string) whenever you want something
+  fancier.
+
+An explicit value always wins over the derived default.
 
 **Optional class attributes:**
 

--- a/tests_lib/core/test_plugin_metadata_defaults.py
+++ b/tests_lib/core/test_plugin_metadata_defaults.py
@@ -94,6 +94,50 @@ class TestDefaultDescription:
         assert FooDatasetImporter.description == ""
 
 
+class TestDefaultIcon:
+    def test_derives_letter_from_display_name(self):
+        class GoogleDatasetImporter(_FakeDatasetImporter):
+            """Doc."""
+
+        assert GoogleDatasetImporter.icon == "G"
+
+    def test_explicit_icon_wins(self):
+        class GoogleDatasetImporter(_FakeDatasetImporter):
+            """Doc."""
+
+            icon = "☁️"  # cloud
+
+        assert GoogleDatasetImporter.icon == "☁️"
+
+    def test_overrides_family_stock_icon(self):
+        # ``ImporterBase.icon`` is the generic "\U0001f50c" plug emoji
+        # shared by every dataset importer that doesn't customise it;
+        # a concrete subclass should get its own letter instead.
+        from vtscore.datasets.importers.base import DatasetImporter
+
+        class FreshDatasetImporter(DatasetImporter):
+            """Doc."""
+
+            fields: list[PluginField] = []
+
+            def run(self, field_values):  # noqa: D102
+                raise NotImplementedError
+
+        assert FreshDatasetImporter.icon == "F"
+
+    def test_no_alpha_display_name_keeps_family_stock_icon(self):
+        class _123DatasetImporter(_FakeDatasetImporter):
+            """Doc."""
+
+            name = "123"
+            display_name = "123"
+
+        # No alphabetic character to derive a letter from, so the
+        # inherited family-stock icon (empty on the fake base) is left
+        # untouched rather than being blanked out.
+        assert _123DatasetImporter.icon == ""
+
+
 class TestAbstractIntermediateNotPolluted:
     def test_family_base_name_skipped(self):
         # The literal abstract base name ``DatasetImporter`` would

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -223,6 +223,10 @@ class TestImporterBaseIcon:
         assert d["icon"] == "🧪"
 
     def test_to_dict_uses_default_icon_when_not_overridden(self):
+        # An importer that doesn't set its own ``icon`` no longer falls
+        # back to the generic family emoji shared by every importer;
+        # instead it gets a distinguishing boxed-letter icon derived from
+        # its display name (see ``_default_plugin_letter_icon``).
         from vtscore.datasets.importers.base import DatasetImporter
 
         class MinimalImporter(DatasetImporter):
@@ -235,7 +239,7 @@ class TestImporterBaseIcon:
                 pass
 
         d = MinimalImporter().to_dict()
-        assert d["icon"] == "🔌"
+        assert d["icon"] == "M"
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -278,6 +278,7 @@ _PLUGIN_NAME_SUFFIXES: tuple[str, ...] = (
 #: ``_is_plugin_family_base = True`` in their own ``__dict__``.
 _PLUGIN_FAMILY_BASE_NAMES: frozenset[str] = frozenset(
     {
+        "ImporterBase",
         "DatasetImporter",
         "LabelsetExporter",
         "LabelImporter",
@@ -288,6 +289,22 @@ _PLUGIN_FAMILY_BASE_NAMES: frozenset[str] = frozenset(
         "MediaConverter",
         "MediaSource",
         "SyncSource",
+    }
+)
+
+
+#: Generic emoji stamped directly onto each plugin-family's abstract base
+#: (e.g. :attr:`ImporterBase.icon`).  A concrete subclass that hasn't set
+#: its own ``icon`` inherits one of these through the MRO; treated as "no
+#: icon chosen" so :func:`_autoderive_plugin_metadata` can replace it with
+#: a distinguishing letter glyph instead (see :func:`_default_plugin_letter_icon`).
+_FAMILY_STOCK_ICONS: frozenset[str] = frozenset(
+    {
+        "\U0001f50c",  # dataset importer (plug)
+        "\U0001f4e4",  # labelset / settings exporter (outbox tray)
+        "\U0001f3f7️",  # label importer (label)
+        "\U0001f504",  # sync source (counterclockwise arrows)
+        "⚙️",  # settings importer (gear)
     }
 )
 
@@ -322,6 +339,27 @@ def _default_plugin_description(cls: type) -> str:
     return doc.splitlines()[0].strip()
 
 
+def _default_plugin_letter_icon(cls: type) -> str:
+    """Return the first alphabetic character of *cls*'s display name (or
+    its snake_case ``name`` as a fallback), upper-cased.
+
+    Gives every plugin a distinguishing default icon (a boxed capital
+    letter, rendered by the frontend's ``vt-icon`` component) without its
+    author having to design or pick one.  Returns ``""`` when neither
+    resolves to a usable string, e.g. a
+    :class:`~vtscore.converters.base.MediaConverter` subclass, whose
+    ``name`` / ``display_name`` are computed properties rather than plain
+    class attributes at ``__init_subclass__`` time.
+    """
+    for attr in ("display_name", "name"):
+        value = getattr(cls, attr, None)
+        if isinstance(value, str):
+            for ch in value:
+                if ch.isalpha():
+                    return ch.upper()
+    return ""
+
+
 def _mro_provides(cls: type, attr: str) -> bool:
     """Return True if any ancestor (above *cls*) already provides *attr*
     as a non-empty string or a descriptor (e.g. a ``property``).
@@ -343,8 +381,8 @@ def _mro_provides(cls: type, attr: str) -> bool:
 
 def _autoderive_plugin_metadata(cls: type) -> None:
     """Fill in default :attr:`name` / :attr:`display_name` /
-    :attr:`description` on *cls* when neither *cls* itself nor any
-    ancestor already provides them.
+    :attr:`description` / :attr:`icon` on *cls* when neither *cls* itself
+    nor any ancestor already provides them.
 
     Called from :meth:`PluginBase.__init_subclass__`.  Framework-level
     abstract bases (named in :data:`_PLUGIN_FAMILY_BASE_NAMES`) and
@@ -363,6 +401,12 @@ def _autoderive_plugin_metadata(cls: type) -> None:
         cls.display_name = _default_plugin_display_name(derived_name) if isinstance(derived_name, str) else ""
     if "description" not in cls.__dict__ and not _mro_provides(cls, "description"):
         cls.description = _default_plugin_description(cls)
+    if "icon" not in cls.__dict__:
+        current_icon = getattr(cls, "icon", "")
+        if not current_icon or current_icon in _FAMILY_STOCK_ICONS:
+            letter = _default_plugin_letter_icon(cls)
+            if letter:
+                cls.icon = letter
 
 
 class PluginBase:
@@ -371,8 +415,8 @@ class PluginBase:
 
     Default metadata
     ----------------
-    Subclasses that don't declare :attr:`name`, :attr:`display_name`, or
-    :attr:`description` get auto-derived defaults via
+    Subclasses that don't declare :attr:`name`, :attr:`display_name`,
+    :attr:`description`, or :attr:`icon` get auto-derived defaults via
     :meth:`__init_subclass__`:
 
     - :attr:`name`: class name with the trailing family suffix
@@ -381,6 +425,16 @@ class PluginBase:
       ``MyShinyExporter`` → ``"my_shiny"``.
     - :attr:`display_name`: title-cased :attr:`name`.
     - :attr:`description`: first line of the class docstring.
+    - :attr:`icon`: the first letter of :attr:`display_name`, upper-cased
+      (e.g. ``MyShinyExporter`` → ``"M"``).  The frontend renders any
+      single capital letter as a boxed letter-glyph icon, so a plugin
+      author who hasn't designed a custom icon still gets a
+      distinguishing default instead of every plugin in the family
+      sharing the same generic emoji.  This only fires when *cls* hasn't
+      set its own ``icon`` and would otherwise inherit either nothing
+      (``""``) or one of the generic family defaults (e.g.
+      :attr:`~vtscore.datasets.importers.base.core.ImporterBase.icon`);
+      an author is always free to set a fancier emoji or SVG-type string.
 
     Explicit declarations always win.  The defaults only fire when
     nothing further up the MRO already provides a string value or a
@@ -395,7 +449,9 @@ class PluginBase:
     display_name: str
     #: One-sentence description shown as a subtitle in the UI.
     description: str
-    #: Emoji or icon string shown next to the display name.
+    #: Emoji or icon string shown next to the display name.  Left unset,
+    #: this defaults to a boxed capital-letter glyph derived from
+    #: :attr:`display_name` (see "Default metadata" above).
     icon: str = ""
     #: Ordered list of fields the user must fill.
     fields: list[PluginField]


### PR DESCRIPTION
## Summary

- The frontend `vt-icon` component already renders any single capital letter A–Z as a boxed letter-glyph SVG (added incidentally in an earlier bundle-splitting refactor), but nothing on the Python side ever produced one: a plugin author who didn't set `icon` always inherited their family's generic stock emoji (🔌 for dataset importers, 📤 for exporters, 🏷️ for label importers, 🔄 for sync sources, ⚙️ for settings importers) — every plugin in a family looked identical.
- `vtscore/plugins/__init__.py`'s `_autoderive_plugin_metadata` (which already auto-derives `name` / `display_name` / `description`) now also auto-derives `icon`: when a concrete plugin doesn't set its own `icon` and would otherwise only inherit an empty string or one of the generic family-stock emoji, it gets the first letter of its `display_name`, upper-cased, instead (e.g. a bare `class GoogleDatasetImporter(DatasetImporter): ...` now shows a "G" outline instead of the generic plug emoji). An explicit `icon` on the plugin always wins.
- Fixed a latent bug this surfaced: `ImporterBase` (the thin base under `DatasetImporter`) was missing from the family-base skip-list, so it got its *own* auto-derived `name`/`display_name` ("importer_base"/"Importer Base") stamped onto it, which then leaked down to any subclass that didn't declare its own `name` explicitly. Every in-tree importer already sets its own `name`, so this was dormant, but it would have silently broken both name and icon derivation for exactly the minimal "just subclass and go" plugin author this issue is about.
- Documented the new default (and the pre-existing name/display_name/description auto-derivation, which wasn't written down anywhere) in `docs/EXTENDING-plugins.md`.

## Test plan

- [x] `python -m pytest tests_lib/core/test_plugin_metadata_defaults.py -q` — new `TestDefaultIcon` cases (derives letter, explicit icon wins, overrides family-stock icon via a real `DatasetImporter` subclass, no-alpha display name keeps the inherited icon)
- [x] Updated `tests_lib/io/test_importers.py::TestImporterBaseIcon::test_to_dict_uses_default_icon_when_not_overridden` to expect the new letter default
- [x] `./run-tests.sh` — full suite (ruff, format, codespell, deptry, frontend build/audit/unit tests, 6642 pytest tests) all green

Closes #2691


---
_Generated by [Claude Code](https://claude.ai/code/session_01YcAiH9uZFePKtELW1M6jw5)_