### PR TITLE
Route content fingerprints through vtscore.utils.hashing (FIPS-safe MD5)

### DIFF
--- a/tests/cli/test_chunked_id_renumber.py
+++ b/tests/cli/test_chunked_id_renumber.py
@@ -11,7 +11,6 @@ by running the actual CLI through to a JSON export and asserting the
 
 from __future__ import annotations
 
-import hashlib
 import json
 import pickle
 import shutil
@@ -20,6 +19,7 @@ from pathlib import Path
 import pytest
 
 from vtsearch.settings import get_detectors_dir
+from vtscore.utils.hashing import content_md5
 
 
 def _unique_bytes(media_id: int) -> bytes:
@@ -30,7 +30,7 @@ def _unique_bytes(media_id: int) -> bytes:
 def _make_audio_media(media_id: int) -> dict:
     """Build a minimal audio media dict suitable for a thin pickle."""
     raw = _unique_bytes(media_id)
-    md5 = hashlib.md5(raw).hexdigest()
+    md5 = content_md5(raw)
     return {
         "id": media_id,
         "media_type": "audio",

--- a/tests/cli/test_cli_streaming.py
+++ b/tests/cli/test_cli_streaming.py
@@ -9,7 +9,6 @@ when the chosen exporter can't stream.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import pickle
 import shutil
@@ -18,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from vtsearch.settings import get_detectors_dir
+from vtscore.utils.hashing import content_md5
 
 
 def _unique_bytes(media_id: int) -> bytes:
@@ -37,7 +37,7 @@ def _make_audio_media(media_id: int) -> dict:
         "media_type": "audio",
         "duration": 1.0,
         "file_size": len(raw),
-        "md5": hashlib.md5(raw).hexdigest(),
+        "md5": content_md5(raw),
         "embedding": [e0, e1],
         "embedder": "clap",
         "media_bytes": None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 import pytest
 
 import vtscore.config as config
+from vtscore.utils.hashing import content_md5
 
 # ---------------------------------------------------------------------------
 # Auto-assign test group markers based on the test file's parent directory,
@@ -59,7 +60,6 @@ def _fake_embed_audio(arg):
     ``media_path``; seed off those bytes so distinct clips still get distinct
     vectors, falling back to the media id only when neither is present.
     """
-    import hashlib
 
     data = None
     if isinstance(arg, dict):
@@ -79,7 +79,7 @@ def _fake_embed_audio(arg):
                 data = f.read(1000)
         except Exception:
             data = str(arg).encode()
-    seed = int(hashlib.md5(data).hexdigest(), 16) % 2**31
+    seed = int(content_md5(data), 16) % 2**31
     rng = np.random.RandomState(seed)
     vec = rng.randn(_EMBEDDING_DIM).astype(np.float32)
     # Real embedders now L2-normalize at ingest, so the fakes must too:

--- a/tests/converters/test_converter_selection.py
+++ b/tests/converters/test_converter_selection.py
@@ -12,7 +12,6 @@ These tests verify:
 
 from __future__ import annotations
 
-import hashlib
 import io
 from unittest.mock import MagicMock, patch
 
@@ -20,6 +19,7 @@ import pytest
 
 from vtscore.datasets.importers.base import SourceSpec
 from vtscore.embedding.media_vectors import media_embedding
+from vtscore.utils.hashing import content_md5
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -709,20 +709,20 @@ class TestEmbedAndMd5Helpers:
         from vtscore.converters.runner import _compute_md5
 
         data = b"hello world"
-        expected = hashlib.md5(data).hexdigest()
+        expected = content_md5(data)
         assert _compute_md5({"media_bytes": data}) == expected
 
     def test_compute_md5_string(self):
         from vtscore.converters.runner import _compute_md5
 
         text = "hello world"
-        expected = hashlib.md5(text.encode("utf-8")).hexdigest()
+        expected = content_md5(text.encode("utf-8"))
         assert _compute_md5({"media_string": text}) == expected
 
     def test_compute_md5_empty(self):
         from vtscore.converters.runner import _compute_md5
 
-        assert _compute_md5({}) == hashlib.md5(b"").hexdigest()
+        assert _compute_md5({}) == content_md5(b"")
 
 
 # ===========================================================================

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -1,4 +1,3 @@
-import hashlib
 import io
 import wave
 
@@ -6,6 +5,7 @@ import numpy as np
 
 import app as app_module
 from vtscore.embedding.media_vectors import media_embedding
+from vtscore.utils.hashing import content_md5
 
 
 class TestInitMedias:
@@ -64,7 +64,7 @@ class TestMediaMD5:
 
     def test_md5_matches_media_bytes(self):
         for media in app_module.medias.values():
-            expected_md5 = hashlib.md5(media["media_bytes"]).hexdigest()
+            expected_md5 = content_md5(media["media_bytes"])
             assert media["md5"] == expected_md5
 
     def test_md5_deterministic(self):
@@ -72,7 +72,7 @@ class TestMediaMD5:
         media = app_module.medias[1]
         # Regenerate the WAV with the same parameters and verify MD5
         wav_bytes = app_module.generate_wav(media["frequency"], media["duration"])
-        assert hashlib.md5(wav_bytes).hexdigest() == media["md5"]
+        assert content_md5(wav_bytes) == media["md5"]
 
 
 class TestApplyCustomMetadataMD5:
@@ -227,7 +227,7 @@ class TestCustomMetadataMapInLoader:
         )
 
         media = next(iter(medias_dict.values()))
-        expected_md5 = hashlib.md5(wav_bytes).hexdigest()
+        expected_md5 = content_md5(wav_bytes)
         assert media["md5"] == expected_md5
         # custom_metadata should still be attached
         assert media["custom_metadata"]["source"] == "external_db"
@@ -245,7 +245,7 @@ class TestCustomMetadataMapInLoader:
         load_dataset_from_folder(tmp_path, "audio", medias_dict)
 
         media = next(iter(medias_dict.values()))
-        expected_md5 = hashlib.md5(wav_bytes).hexdigest()
+        expected_md5 = content_md5(wav_bytes)
         assert media["md5"] == expected_md5
         assert "custom_metadata" not in media
 
@@ -678,7 +678,7 @@ class TestAddToPile:
         assert new_id in app_module.good_votes
         # Verify the new media has proper fields
         new_media = app_module.medias[new_id]
-        assert new_media["md5"] == hashlib.md5(wav_bytes).hexdigest()
+        assert new_media["md5"] == content_md5(wav_bytes)
         assert new_media["filename"] == "new_sound.wav"
         assert new_media["origin"]["importer"] == "add_to_pile"
         assert isinstance(media_embedding(new_media), np.ndarray)
@@ -859,7 +859,7 @@ class TestAddToPile:
 
         # The single inserted media carries the uploaded bytes' md5.
         inserted_id = next(iter(media_ids))
-        assert app_module.medias[inserted_id]["md5"] == hashlib.md5(wav_bytes).hexdigest()
+        assert app_module.medias[inserted_id]["md5"] == content_md5(wav_bytes)
         assert inserted_id in app_module.good_votes
 
     def _setup_loaded_detector(self, client, name="H33Detector"):

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -17,11 +17,11 @@ Covers:
 
 from __future__ import annotations
 
-import hashlib
 import pickle
 
 import numpy as np
 import pytest
+from vtscore.utils.hashing import content_md5
 
 
 def _unique_bytes(media_id: int) -> bytes:
@@ -35,7 +35,7 @@ def _make_audio_clip(media_id: int, md5: str = "", filename: str = "") -> dict:
         filename = f"clip_{media_id}.wav"
     raw = _unique_bytes(media_id)
     if not md5:
-        md5 = hashlib.md5(raw).hexdigest()
+        md5 = content_md5(raw)
     return {
         "id": media_id,
         "media_type": "audio",
@@ -58,7 +58,7 @@ def _make_image_clip(media_id: int, md5: str = "") -> dict:
     """Return a minimal image media dict for testing."""
     raw = b"\x89PNG" + _unique_bytes(media_id)
     if not md5:
-        md5 = hashlib.md5(raw).hexdigest()
+        md5 = content_md5(raw)
     return {
         "id": media_id,
         "media_type": "image",
@@ -92,7 +92,7 @@ def _make_image_clip_embedded(media_id: int, embedder: str, extra: dict | None =
         "media_type": "image",
         "duration": 0,
         "file_size": 2000,
-        "md5": hashlib.md5(raw).hexdigest(),
+        "md5": content_md5(raw),
         "embeddings": {embedder: np.array([float(media_id)], dtype=np.float32)},
         "embedder": embedder,
         "media_bytes": raw,

--- a/tests/datasets/test_coverage_atlas_endpoint.py
+++ b/tests/datasets/test_coverage_atlas_endpoint.py
@@ -12,7 +12,6 @@ active dataset without hands-on verification.
 
 from __future__ import annotations
 
-import hashlib
 import time
 
 import numpy as np
@@ -23,6 +22,7 @@ from vtscore.state.core import (
     register_context,
     set_thread_dataset_context,
 )
+from vtscore.utils.hashing import content_md5
 
 
 def _make_media(media_id: int, *, seed_offset: int = 0, shifted: bool = False) -> dict:
@@ -45,7 +45,7 @@ def _make_media(media_id: int, *, seed_offset: int = 0, shifted: bool = False) -
         "embedder": "clap",
         "duration": 1.0,
         "file_size": 100,
-        "md5": hashlib.md5(f"atlas_{seed_offset}_{media_id}".encode()).hexdigest(),
+        "md5": content_md5(f"atlas_{seed_offset}_{media_id}".encode()),
         "embeddings": {"clap": emb},
         "media_bytes": b"fake",
         "filename": f"atlas_{media_id}.wav",

--- a/tests/datasets/test_multi_dataset.py
+++ b/tests/datasets/test_multi_dataset.py
@@ -1,8 +1,6 @@
 """Tests for multi-dataset support: loading, activating, switching, and unloading
 multiple datasets without re-resolving media or re-embedding vectors."""
 
-import hashlib
-
 import numpy as np
 
 from tests import load_detector_and_wait as _load_detector_and_wait
@@ -20,6 +18,7 @@ from vtscore.state.core import (
     set_thread_detector_context,
     unregister_context,
 )
+from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
@@ -232,7 +231,7 @@ class TestMultiDatasetSwitching:
             "embedder": "clap",
             "duration": 1.0,
             "file_size": 100,
-            "md5": hashlib.md5(f"media_{media_id}".encode()).hexdigest(),
+            "md5": content_md5(f"media_{media_id}".encode()),
             "embedding": rng.standard_normal(512).astype(np.float32),
             "media_bytes": b"fake",
             "filename": f"media_{media_id}.wav",
@@ -388,7 +387,7 @@ class TestMultiDatasetAPI:
             "embedder": "clap",
             "duration": 1.0,
             "file_size": 100,
-            "md5": hashlib.md5(f"api_media_{media_id}".encode()).hexdigest(),
+            "md5": content_md5(f"api_media_{media_id}".encode()),
             "embedding": rng.standard_normal(512).astype(np.float32),
             "media_bytes": b"fake",
             "filename": f"api_media_{media_id}.wav",

--- a/tests/detectors/test_clipper_workflow.py
+++ b/tests/detectors/test_clipper_workflow.py
@@ -10,7 +10,6 @@ Validates:
 7. The /api/medias endpoint exposes clip metadata to the frontend.
 """
 
-import hashlib
 import io
 
 import numpy as np
@@ -21,6 +20,7 @@ from vtsearch.state import (
     good_votes,
     bad_votes,
 )
+from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
@@ -40,7 +40,7 @@ def _make_audio_media(media_id: int, duration: float = 5.1, *, origin_path: str 
         "filename": f"clip_{media_id}.wav",
         "media_bytes": wav,
         "duration": duration,
-        "md5": hashlib.md5(wav).hexdigest(),
+        "md5": content_md5(wav),
         "embedding": rng.standard_normal(512).astype(np.float32),
         "origin": {"importer": "server_folder", "params": {"path": origin_path, "media_type": "audio"}},
         "origin_name": f"clip_{media_id}.wav",
@@ -63,7 +63,7 @@ def _make_image_media(media_id: int, width: int = 300, height: int = 100) -> dic
         "media_bytes": img_bytes,
         "width": width,
         "height": height,
-        "md5": hashlib.md5(img_bytes).hexdigest(),
+        "md5": content_md5(img_bytes),
         "embedding": rng.standard_normal(512).astype(np.float32),
         "origin": {"importer": "server_folder", "params": {"path": "/data/images", "media_type": "image"}},
         "origin_name": f"img_{media_id}.png",
@@ -80,7 +80,7 @@ def _make_text_media(media_id: int, text: str = "First sentence. Second sentence
         "filename": f"text_{media_id}.txt",
         "media_string": text,
         "media_bytes": text_bytes,
-        "md5": hashlib.md5(text_bytes).hexdigest(),
+        "md5": content_md5(text_bytes),
         "embedding": rng.standard_normal(512).astype(np.float32),
         "origin": {"importer": "server_folder", "params": {"path": "/data/texts", "media_type": "text"}},
         "origin_name": f"text_{media_id}.txt",
@@ -97,7 +97,7 @@ def _make_video_media(media_id: int, duration: float = 10.0) -> dict:
         "filename": f"video_{media_id}.mp4",
         "media_bytes": fake_bytes,
         "duration": duration,
-        "md5": hashlib.md5(fake_bytes).hexdigest(),
+        "md5": content_md5(fake_bytes),
         "embedding": rng.standard_normal(512).astype(np.float32),
         "origin": {"importer": "server_folder", "params": {"path": "/data/videos", "media_type": "video"}},
         "origin_name": f"video_{media_id}.mp4",
@@ -166,7 +166,7 @@ class TestApplyClipperMD5:
         # All clip MD5s are recomputed from actual clip bytes, not the parent
         for clip in clips_dict.values():
             assert clip["md5"] != parent_md5, "clip MD5 should differ from parent"
-            assert clip["md5"] == hashlib.md5(clip["media_bytes"]).hexdigest()
+            assert clip["md5"] == content_md5(clip["media_bytes"])
 
     def test_image_clips_get_recomputed_md5s(self):
         from vtscore.datasets.stages.clipper import _apply_clipper
@@ -178,7 +178,7 @@ class TestApplyClipperMD5:
         assert len(clips_dict) == 3  # 300/100 = 3 tiles
         for clip in clips_dict.values():
             assert clip["md5"] != parent_md5
-            assert clip["md5"] == hashlib.md5(clip["media_bytes"]).hexdigest()
+            assert clip["md5"] == content_md5(clip["media_bytes"])
 
     def test_text_clips_get_unique_md5s(self):
         from vtscore.datasets.stages.clipper import _apply_clipper
@@ -238,7 +238,7 @@ class TestApplyClipperMD5:
                 "importer-provided MD5 must be replaced for clips"
             )
             # The new MD5 should be computed from the actual clip bytes
-            assert clip["md5"] == hashlib.md5(clip["media_bytes"]).hexdigest()
+            assert clip["md5"] == content_md5(clip["media_bytes"])
 
     def test_importer_provided_embedding_replaced_for_clips(self):
         """An importer may pre-compute embeddings for full media items.
@@ -698,7 +698,7 @@ class TestMultipleMediasClipped:
         assert len(clips_dict) == 6
         # Each clip's MD5 should be computed from its actual bytes
         for clip in clips_dict.values():
-            assert clip["md5"] == hashlib.md5(clip["media_bytes"]).hexdigest()
+            assert clip["md5"] == content_md5(clip["media_bytes"])
 
     def test_multiple_text_medias_clipped(self):
         from vtscore.datasets.stages.clipper import _apply_clipper

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -8,6 +8,7 @@ import pytest
 from tests import load_detector_and_wait as _load_detector_and_wait
 from vtscore.embedding.media_vectors import media_embedding
 from vtsearch.settings import get_detectors_dir
+from vtscore.utils.hashing import content_md5
 
 
 @pytest.fixture(autouse=True)
@@ -1105,7 +1106,6 @@ class TestLoadModelEndpoint:
         id-space and unrelated B-medias whose ids happen to coincide with
         A's voted ids appear as voted in B's labeling UI.
         """
-        import hashlib
 
         import numpy as np
 
@@ -1156,7 +1156,7 @@ class TestLoadModelEndpoint:
                 "id": cid,
                 "media_type": "audio",
                 "embedder": "clap",
-                "md5": hashlib.md5(f"ds_b_{cid}".encode()).hexdigest(),
+                "md5": content_md5(f"ds_b_{cid}".encode()),
                 "embeddings": {"clap": np.zeros(512, dtype=np.float32)},
                 "media_bytes": b"fake-b",
                 "filename": f"ds_b_{cid}.wav",
@@ -1255,7 +1255,6 @@ class TestEmbedderMismatchInvalidatesStaleModel:
         embedder triggers invalidation of the active detector's MLP via
         ``ensure_detector_model_matches_active_embedder``.
         """
-        import hashlib
         from unittest.mock import MagicMock
 
         import numpy as np
@@ -1305,7 +1304,7 @@ class TestEmbedderMismatchInvalidatesStaleModel:
                 "id": cid,
                 "media_type": "audio",
                 "embedder": "shiny-new-embedder",
-                "md5": hashlib.md5(f"h5_b_{cid}".encode()).hexdigest(),
+                "md5": content_md5(f"h5_b_{cid}".encode()),
                 "embeddings": {"shiny-new-embedder": np.zeros(512, dtype=np.float32)},
                 "media_bytes": b"fake-b",
                 "filename": f"h5_b_{cid}.wav",
@@ -2093,7 +2092,6 @@ class TestLoadModelCrossDatasetResolution:
         mode.  The label restore should follow origin trails, compute MD5s,
         and match against loaded medias.
         """
-        import hashlib
 
         import numpy as np
 
@@ -2116,8 +2114,8 @@ class TestLoadModelCrossDatasetResolution:
         good_file.write_bytes(b"shared_good_content")
         bad_file.write_bytes(b"shared_bad_content")
 
-        good_md5 = hashlib.md5(b"shared_good_content").hexdigest()
-        bad_md5 = hashlib.md5(b"shared_bad_content").hexdigest()
+        good_md5 = content_md5(b"shared_good_content")
+        bad_md5 = content_md5(b"shared_bad_content")
 
         label_origin = {
             "importer": "server_folder",

--- a/tests/detectors/test_labelset_elements_api.py
+++ b/tests/detectors/test_labelset_elements_api.py
@@ -17,6 +17,7 @@ import shutil
 import pytest
 
 from vtsearch.settings import get_detectors_dir
+from vtscore.utils.hashing import content_md5
 
 
 @pytest.fixture(autouse=True)
@@ -355,7 +356,6 @@ class TestLabelElementThumbnail:
         to origin resolution that 404s, so the right pane showed no thumbnails
         even though clicking an entry rendered the full image fine.
         """
-        import hashlib
 
         from helpers import make_png_bytes
 
@@ -367,7 +367,7 @@ class TestLabelElementThumbnail:
         png = make_png_bytes(color=(10, 20, 30))
         img_file = tmp_path / "folder_img.png"
         img_file.write_bytes(png)
-        md5 = hashlib.md5(png).hexdigest()  # noqa: S324 - identity key, not security
+        md5 = content_md5(png)
 
         origin = {"importer": "folder", "params": {"path": str(tmp_path)}}
         cid = 987654

--- a/tests/detectors/test_multi_detector.py
+++ b/tests/detectors/test_multi_detector.py
@@ -1,7 +1,6 @@
 """Tests for multiple loaded detectors: DetectorContext lifecycle, vote isolation,
 model registry multi-loaded support, activate/unload endpoints, and MLP caching."""
 
-import hashlib
 import shutil
 
 import numpy as np
@@ -9,6 +8,7 @@ import pytest
 
 from tests import load_detector_and_wait as _load_detector_and_wait
 from vtsearch.settings import get_detectors_dir
+from vtscore.utils.hashing import content_md5
 
 
 @pytest.fixture(autouse=True)
@@ -31,7 +31,7 @@ def _make_test_media(media_id: int, media_type: str = "audio") -> dict:
         "embedder": "clap",
         "duration": 1.0,
         "file_size": 100,
-        "md5": hashlib.md5(f"media_{media_id}".encode()).hexdigest(),
+        "md5": content_md5(f"media_{media_id}".encode()),
         "embedding": rng.standard_normal(512).astype(np.float32),
         "media_bytes": b"fake",
         "filename": f"media_{media_id}.wav",

--- a/tests/fixtures/medias.py
+++ b/tests/fixtures/medias.py
@@ -1,6 +1,5 @@
 """Test media generation."""
 
-import hashlib
 import io
 import os
 
@@ -10,6 +9,7 @@ from vtscore.config import DATA_DIR
 NUM_MEDIAS = 20
 from vtscore.embedding import embed_audio_file
 from vtsearch.state import medias
+from vtscore.utils.hashing import content_md5
 
 
 def _worker_suffix():
@@ -66,7 +66,7 @@ def init_medias():
             "frequency": freq,
             "duration": duration,
             "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "md5": content_md5(wav_bytes),
             "embeddings": {"clap": embedding},
             "media_bytes": wav_bytes,
             "thumbnail_bytes": thumbnail,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,7 @@ import io
 import struct
 import wave
 from pathlib import Path
+from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +102,6 @@ def make_minimal_mp4_bytes() -> bytes:
 
 def make_image_media(media_id: int, embedding_dim: int = 512) -> dict:
     """Build a test image media dict with a solid-color PNG and fake embedding."""
-    import hashlib  # noqa: PLC0415
 
     import numpy as np  # noqa: PLC0415
 
@@ -115,7 +115,7 @@ def make_image_media(media_id: int, embedding_dim: int = 512) -> dict:
         "width": 16,
         "height": 16,
         "file_size": len(img),
-        "md5": hashlib.md5(img).hexdigest(),
+        "md5": content_md5(img),
         "embeddings": {"siglip": rng.randn(embedding_dim).astype("float32")},
         "media_bytes": img,
         "filename": f"image_{media_id}.png",
@@ -127,7 +127,6 @@ def make_image_media(media_id: int, embedding_dim: int = 512) -> dict:
 
 def make_text_media(media_id: int, embedding_dim: int = 512) -> dict:
     """Build a test text media dict with a short string and fake embedding."""
-    import hashlib  # noqa: PLC0415
 
     import numpy as np  # noqa: PLC0415
 
@@ -140,7 +139,7 @@ def make_text_media(media_id: int, embedding_dim: int = 512) -> dict:
         "word_count": len(content.split()),
         "character_count": len(content),
         "file_size": len(content.encode()),
-        "md5": hashlib.md5(content.encode()).hexdigest(),
+        "md5": content_md5(content.encode()),
         "embeddings": {"e5": rng.randn(embedding_dim).astype("float32")},
         "media_string": content,
         "filename": f"text_{media_id}.txt",
@@ -152,7 +151,6 @@ def make_text_media(media_id: int, embedding_dim: int = 512) -> dict:
 
 def make_video_media(media_id: int, embedding_dim: int = 512) -> dict:
     """Build a test video media dict with a minimal MP4 header and fake embedding."""
-    import hashlib  # noqa: PLC0415
 
     import numpy as np  # noqa: PLC0415
 
@@ -164,7 +162,7 @@ def make_video_media(media_id: int, embedding_dim: int = 512) -> dict:
         "embedder": "xclip",
         "duration": 1.0,
         "file_size": len(mp4),
-        "md5": hashlib.md5(mp4).hexdigest(),
+        "md5": content_md5(mp4),
         "embeddings": {"xclip": rng.randn(embedding_dim).astype("float32")},
         "media_bytes": mp4,
         "filename": f"video_{media_id}.mp4",

--- a/tests/io/test_dataset_importer_media.py
+++ b/tests/io/test_dataset_importer_media.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from helpers import make_raw_wav_bytes as _make_wav_bytes
 from vtscore.embedding.media_vectors import media_embedding
+from vtscore.utils.hashing import content_md5
 
 
 def _write_wav(path: Path) -> None:
@@ -247,12 +248,11 @@ class TestImporterProvidedMD5s:
         assert medias[1]["md5"] == pre_md5
 
     def test_mixed_importer_and_computed_md5s(self, tmp_path):
-        import hashlib
 
         pre_md5 = "c" * 32
         _write_wav(tmp_path / "pre.wav")
         _write_wav(tmp_path / "computed.wav")
-        computed_md5 = hashlib.md5((tmp_path / "computed.wav").read_bytes()).hexdigest()
+        computed_md5 = content_md5((tmp_path / "computed.wav").read_bytes())
 
         mt, emb = _make_mock_media_type()
         imp = _VectorAndMD5Importer.create(

--- a/tests/io/test_label_import_endpoint.py
+++ b/tests/io/test_label_import_endpoint.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 
 import app as app_module
+from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
@@ -528,7 +529,6 @@ class TestLabelImportMissingElements:
 
     def test_auto_resolve_ingests_and_applies(self, client, tmp_path):
         """Missing elements are auto-resolved from their origin during import."""
-        import hashlib
 
         # Save/restore medias since auto-resolve adds new entries
         saved = dict(app_module.medias)
@@ -538,7 +538,7 @@ class TestLabelImportMissingElements:
             text_dir.mkdir()
             content = "Hello world, this is a test paragraph for auto-resolve embedding."
             (text_dir / "hello.txt").write_text(content)
-            md5 = hashlib.md5(content.encode()).hexdigest()
+            md5 = content_md5(content.encode())
 
             origin = {"importer": "server_folder", "params": {"path": str(text_dir), "media_type": "text"}}
 

--- a/tests/io/test_label_import_ingestion.py
+++ b/tests/io/test_label_import_ingestion.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from vtscore.embedding.media_vectors import media_embedding
+from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
@@ -254,7 +255,6 @@ class TestIngestMissingClips:
 
     def test_ingest_with_folder_importer(self, tmp_path):
         """Ingest missing medias from a real folder origin."""
-        import hashlib
 
         import numpy as np
 
@@ -289,7 +289,7 @@ class TestIngestMissingClips:
 
         missing_entries = [
             {
-                "md5": hashlib.md5(b"Hello world, this is a test paragraph for embedding.").hexdigest(),
+                "md5": content_md5(b"Hello world, this is a test paragraph for embedding."),
                 "label": "good",
                 "origin": origin,
                 "origin_name": "hello.txt",
@@ -317,7 +317,6 @@ class TestIngestMissingClips:
 class TestClippedReingest:
     def test_audio_clip_md5_is_clip_not_parent(self, tmp_path):
         """A re-ingested audio clip's MD5 hashes the *clip* bytes, not the parent file."""
-        import hashlib
 
         import numpy as np
 
@@ -333,8 +332,8 @@ class TestClippedReingest:
 
         clip_start, clip_end = 0.0, 2.0
         clip_bytes = _wav_slice(wav, clip_start, clip_end)
-        expected_clip_md5 = hashlib.md5(clip_bytes).hexdigest()
-        parent_md5 = hashlib.md5(wav).hexdigest()
+        expected_clip_md5 = content_md5(clip_bytes)
+        parent_md5 = content_md5(wav)
         assert expected_clip_md5 != parent_md5, "clip and parent MD5s must differ"
 
         origin = {

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -20,6 +20,7 @@ import os
 import pytest
 
 import vtscore.config as config
+from vtscore.utils.hashing import content_md5
 
 
 _NON_GROUP_DIRS = {"tests_lib", "fixtures", "__pycache__"}
@@ -79,13 +80,12 @@ _EMBEDDING_DIM = 512
 
 
 def _fake_embed_audio(arg):
-    import hashlib
 
     path = arg["media_path"] if isinstance(arg, dict) else arg
     try:
         with open(path, "rb") as f:
             data = f.read(1000)
-        seed = int(hashlib.md5(data).hexdigest(), 16) % 2**31
+        seed = int(content_md5(data), 16) % 2**31
     except Exception:
         seed = hash(str(path)) % 2**31
     rng = np.random.RandomState(seed)

--- a/tests_lib/datasets/test_chunked_loading.py
+++ b/tests_lib/datasets/test_chunked_loading.py
@@ -6,7 +6,6 @@ functions, the ``DatasetImporter.run_chunked`` / ``run_chunked_cli``
 interface, and the CLI ``_merge_detector_results`` helper.
 """
 
-import hashlib
 import pickle
 from pathlib import Path
 from typing import Any
@@ -22,6 +21,7 @@ from vtscore.embedding.media_vectors import media_embedding
 
 
 from helpers import make_wav_bytes as _make_wav_bytes, make_wav_file as _make_wav_file
+from vtscore.utils.hashing import content_md5
 
 
 def _make_pickle_with_base_freq(tmp_path: Path, num_clips: int, base_freq: float = 440.0) -> Path:
@@ -34,7 +34,7 @@ def _make_pickle_with_base_freq(tmp_path: Path, num_clips: int, base_freq: float
             "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "md5": content_md5(wav_bytes),
             "embedder": "clap",
             "embedding": np.random.RandomState(42).randn(512).tolist(),
             "filename": f"clip_{i}.wav",
@@ -60,7 +60,7 @@ def _make_pickle(tmp_path: Path, num_clips: int, inline_bytes: bool = True) -> P
             "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "md5": content_md5(wav_bytes),
             "embedder": "clap",
             "embedding": np.random.RandomState(42).randn(512).tolist(),
             "filename": f"clip_{i}.wav",

--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -5,7 +5,6 @@ instead of media_bytes) and that lazy loading correctly resolves media
 content when needed.
 """
 
-import hashlib
 import pickle
 from pathlib import Path
 from typing import Any
@@ -13,29 +12,29 @@ from typing import Any
 import numpy as np
 
 from vtscore.datasets.loader import (
-    _streaming_md5,
     load_dataset_from_folder,
     load_dataset_from_pickle,
 )
 from vtscore.embedding.media_vectors import media_embedding
+from vtscore.utils.hashing import content_md5, file_md5
 
 
 from helpers import make_wav_bytes as _make_wav_bytes, make_wav_file as _make_wav_file  # noqa: F401
 
 
-class TestStreamingMD5:
+class TestFileMD5:
     def test_matches_regular_md5(self, tmp_path):
         content = b"hello world test data"
         p = tmp_path / "test.bin"
         p.write_bytes(content)
-        assert _streaming_md5(p) == hashlib.md5(content).hexdigest()
+        assert file_md5(p) == content_md5(content)
 
     def test_large_file(self, tmp_path):
         # File larger than the 8192 chunk size
         content = b"x" * 20000
         p = tmp_path / "large.bin"
         p.write_bytes(content)
-        assert _streaming_md5(p) == hashlib.md5(content).hexdigest()
+        assert file_md5(p) == content_md5(content)
 
 
 class TestThinLoadFromFolder:
@@ -76,7 +75,7 @@ class TestThinLoadFromFolder:
 
     def test_thin_clips_have_correct_md5(self, tmp_path):
         wav_path = _make_wav_file(tmp_path, "test.wav")
-        expected_md5 = hashlib.md5(wav_path.read_bytes()).hexdigest()
+        expected_md5 = content_md5(wav_path.read_bytes())
         medias: dict[int, dict[str, Any]] = {}
         load_dataset_from_folder(tmp_path, "audio", medias, thin=True)
         assert medias[1]["md5"] == expected_md5
@@ -115,7 +114,7 @@ class TestThinLoadFromPickle:
             "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "md5": content_md5(wav_bytes),
             "embedding": np.zeros(512).tolist(),
             "embedder": "clap",
             "filename": "test.wav",
@@ -192,7 +191,7 @@ class TestFullModeMediaPathReference:
             "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "md5": content_md5(wav_bytes),
             "embedding": np.zeros(512).tolist(),
             "embedder": "clap",
             "filename": "test.wav",
@@ -256,7 +255,7 @@ class TestPickleNullEmbedding:
             "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "md5": content_md5(wav_bytes),
             "filename": "test.wav",
             "category": "test",
         }
@@ -310,7 +309,7 @@ class TestPickleNullEmbedding:
             "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "md5": content_md5(wav_bytes),
             "embedding": np.zeros(512).tolist(),
             "embedder": "clap",
             "filename": "good.wav",
@@ -322,7 +321,7 @@ class TestPickleNullEmbedding:
             "media_type": "audio",
             "duration": 0.1,
             "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes + b"x").hexdigest(),
+            "md5": content_md5(wav_bytes + b"x"),
             "embedding": None,
             "filename": "bad.wav",
             "category": "test",
@@ -351,7 +350,7 @@ class TestPickleNullEmbedding:
                     "media_type": "audio",
                     "duration": 0.1,
                     "file_size": len(wav_bytes),
-                    "md5": hashlib.md5(wav_bytes).hexdigest(),
+                    "md5": content_md5(wav_bytes),
                     "embedding": np.zeros(512).tolist(),
                     "embedder": "clap",
                     "filename": "a.wav",
@@ -363,7 +362,7 @@ class TestPickleNullEmbedding:
                     "media_type": "audio",
                     "duration": 0.1,
                     "file_size": len(wav_bytes),
-                    "md5": hashlib.md5(wav_bytes + b"x").hexdigest(),
+                    "md5": content_md5(wav_bytes + b"x"),
                     "embedding": None,
                     "filename": "b.wav",
                     "category": "test",
@@ -441,7 +440,7 @@ class TestPickleMD5Preservation:
 
         medias: dict[int, dict[str, Any]] = {}
         load_dataset_from_pickle(pkl_path, medias, thin=False)
-        assert medias[1]["md5"] == hashlib.md5(wav_bytes).hexdigest()
+        assert medias[1]["md5"] == content_md5(wav_bytes)
 
     def test_thin_mode_uses_md5_from_pickle(self, tmp_path):
         """Thin mode should also preserve the MD5 from the pickle."""
@@ -507,7 +506,7 @@ class TestThinImporters:
                     "media_type": "audio",
                     "duration": 0.1,
                     "file_size": len(wav_bytes),
-                    "md5": hashlib.md5(wav_bytes).hexdigest(),
+                    "md5": content_md5(wav_bytes),
                     "embedding": np.zeros(512).tolist(),
                     "embedder": "clap",
                     "filename": "test.wav",

--- a/tests_lib/detectors/test_clipper_chain.py
+++ b/tests_lib/detectors/test_clipper_chain.py
@@ -22,6 +22,7 @@ import json
 
 import numpy as np
 import pytest
+from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
@@ -40,7 +41,7 @@ def _make_text_media(media_id: int, text: str, *, origin_path: str = "/data/text
         "duration": 0,
         "word_count": len(text.split()),
         "character_count": len(text),
-        "md5": hashlib.md5(text.encode("utf-8")).hexdigest(),
+        "md5": content_md5(text.encode("utf-8")),
         "embedding": rng.standard_normal(384).astype(np.float32),
         "origin": {
             "importer": "server_folder",
@@ -356,7 +357,7 @@ class TestReplayChainOnFile:
         source = tmp_path / "doc.txt"
         source.write_text("Alpha. Bravo. Charlie.", encoding="utf-8")
 
-        target_hash = hashlib.md5(b"Charlie.").hexdigest()[:12]
+        target_hash = content_md5(b"Charlie.")[:12]
         steps = [
             {
                 "kind": "clipper",

--- a/tests_lib/detectors/test_label_restoration.py
+++ b/tests_lib/detectors/test_label_restoration.py
@@ -18,12 +18,12 @@ gates without contaminating the per-session Smart/Stable trends.
 
 from __future__ import annotations
 
-import hashlib
 from contextlib import contextmanager
 
 from vtscore.datasets.labelset import LabelSet, LabeledElement
 from vtscore.detectors.label_restoration import restore_labels_from_detector
 from vtscore.state import get_active_context, get_active_detector_context
+from vtscore.utils.hashing import content_md5
 
 
 def _det_data(elements: list[LabeledElement]) -> dict:
@@ -161,7 +161,7 @@ class TestUnmatchedFallbackPass:
         m1 = get_active_context().medias[1]
         resolved = tmp_path / "resolved.wav"
         resolved.write_bytes(m1["media_bytes"])
-        assert hashlib.md5(resolved.read_bytes()).hexdigest() == m1["md5"]
+        assert content_md5(resolved.read_bytes()) == m1["md5"]
 
         monkeypatch.setattr(
             "vtscore.detectors.resolver.resolve_file_context",

--- a/tests_lib/detectors/test_video_clip_embedding.py
+++ b/tests_lib/detectors/test_video_clip_embedding.py
@@ -14,7 +14,6 @@ These tests cover all three layers.
 
 from __future__ import annotations
 
-import hashlib
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +21,7 @@ import numpy as np
 import pytest
 
 from vtscore.embedding.media_vectors import media_embedding
+from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
@@ -290,7 +290,7 @@ class TestBuildClipEmbedInput:
 def _make_tiled_video_clips() -> list[dict]:
     """Build three tiles of one parent video; same bytes, distinct boundaries."""
     parent_bytes = b"parent-video-bytes"
-    parent_md5 = hashlib.md5(parent_bytes).hexdigest()
+    parent_md5 = content_md5(parent_bytes)
     tiles = []
     for idx, (t0, t1) in enumerate([(0.0, 2.0), (2.0, 4.0), (4.0, 6.0)]):
         tiles.append(

--- a/tests_lib/fixtures/medias.py
+++ b/tests_lib/fixtures/medias.py
@@ -1,6 +1,5 @@
 """Test media generation."""
 
-import hashlib
 import io
 import os
 
@@ -10,6 +9,7 @@ from vtscore.config import DATA_DIR
 NUM_MEDIAS = 20
 from vtscore.embedding import embed_audio_file
 from vtsearch.state import medias
+from vtscore.utils.hashing import content_md5
 
 
 def _worker_suffix():
@@ -66,7 +66,7 @@ def init_medias():
             "frequency": freq,
             "duration": duration,
             "file_size": len(wav_bytes),
-            "md5": hashlib.md5(wav_bytes).hexdigest(),
+            "md5": content_md5(wav_bytes),
             "embeddings": {"clap": embedding},
             "media_bytes": wav_bytes,
             "thumbnail_bytes": thumbnail,

--- a/tests_lib/helpers.py
+++ b/tests_lib/helpers.py
@@ -6,6 +6,7 @@ import io
 import struct
 import wave
 from pathlib import Path
+from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +102,6 @@ def make_minimal_mp4_bytes() -> bytes:
 
 def make_image_media(media_id: int, embedding_dim: int = 512) -> dict:
     """Build a test image media dict with a solid-color PNG and fake embedding."""
-    import hashlib  # noqa: PLC0415
 
     import numpy as np  # noqa: PLC0415
 
@@ -115,7 +115,7 @@ def make_image_media(media_id: int, embedding_dim: int = 512) -> dict:
         "width": 16,
         "height": 16,
         "file_size": len(img),
-        "md5": hashlib.md5(img).hexdigest(),
+        "md5": content_md5(img),
         "embeddings": {"siglip": rng.randn(embedding_dim).astype("float32")},
         "media_bytes": img,
         "filename": f"image_{media_id}.png",
@@ -127,7 +127,6 @@ def make_image_media(media_id: int, embedding_dim: int = 512) -> dict:
 
 def make_text_media(media_id: int, embedding_dim: int = 512) -> dict:
     """Build a test text media dict with a short string and fake embedding."""
-    import hashlib  # noqa: PLC0415
 
     import numpy as np  # noqa: PLC0415
 
@@ -140,7 +139,7 @@ def make_text_media(media_id: int, embedding_dim: int = 512) -> dict:
         "word_count": len(content.split()),
         "character_count": len(content),
         "file_size": len(content.encode()),
-        "md5": hashlib.md5(content.encode()).hexdigest(),
+        "md5": content_md5(content.encode()),
         "embeddings": {"e5": rng.randn(embedding_dim).astype("float32")},
         "media_string": content,
         "filename": f"text_{media_id}.txt",
@@ -152,7 +151,6 @@ def make_text_media(media_id: int, embedding_dim: int = 512) -> dict:
 
 def make_video_media(media_id: int, embedding_dim: int = 512) -> dict:
     """Build a test video media dict with a minimal MP4 header and fake embedding."""
-    import hashlib  # noqa: PLC0415
 
     import numpy as np  # noqa: PLC0415
 
@@ -164,7 +162,7 @@ def make_video_media(media_id: int, embedding_dim: int = 512) -> dict:
         "embedder": "xclip",
         "duration": 1.0,
         "file_size": len(mp4),
-        "md5": hashlib.md5(mp4).hexdigest(),
+        "md5": content_md5(mp4),
         "embeddings": {"xclip": rng.randn(embedding_dim).astype("float32")},
         "media_bytes": mp4,
         "filename": f"video_{media_id}.mp4",

--- a/tests_lib/io/test_clip_reembed_bulk.py
+++ b/tests_lib/io/test_clip_reembed_bulk.py
@@ -11,7 +11,6 @@ established in Phase A, handing the embedder ``media_bytes`` /
 
 from __future__ import annotations
 
-import hashlib
 import io
 import unittest.mock as mock
 
@@ -20,6 +19,7 @@ import pytest
 
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.media.audio.audio_generator import generate_wav
+from vtscore.utils.hashing import content_md5
 
 
 def _make_audio_media(media_id: int, duration: float = 5.1) -> dict:
@@ -31,7 +31,7 @@ def _make_audio_media(media_id: int, duration: float = 5.1) -> dict:
         "filename": f"clip_{media_id}.wav",
         "media_bytes": wav,
         "duration": duration,
-        "md5": hashlib.md5(wav).hexdigest(),
+        "md5": content_md5(wav),
         "embedder": "clap",
         "embeddings": {"clap": rng.standard_normal(512).astype(np.float32)},
         "origin": {"importer": "server_folder", "params": {"path": "/data/audio", "media_type": "audio"}},
@@ -54,7 +54,7 @@ def _make_image_media(media_id: int, width: int = 300, height: int = 100) -> dic
         "media_bytes": img_bytes,
         "width": width,
         "height": height,
-        "md5": hashlib.md5(img_bytes).hexdigest(),
+        "md5": content_md5(img_bytes),
         "embedder": "siglip",
         "embeddings": {"siglip": rng.standard_normal(512).astype(np.float32)},
         "origin": {"importer": "server_folder", "params": {"path": "/data/images", "media_type": "image"}},
@@ -71,7 +71,7 @@ def _make_text_media(media_id: int, text: str = "First sentence. Second sentence
         "filename": f"text_{media_id}.txt",
         "media_string": text,
         "media_bytes": text_bytes,
-        "md5": hashlib.md5(text_bytes).hexdigest(),
+        "md5": content_md5(text_bytes),
         "embedder": "e5",
         "embeddings": {"e5": rng.standard_normal(512).astype(np.float32)},
         "origin": {"importer": "server_folder", "params": {"path": "/data/texts", "media_type": "text"}},
@@ -274,7 +274,7 @@ class TestBulkClipReembedMD5UnchangedByRefactor:
 
         for clip in clips_dict.values():
             assert clip["md5"] != parent_md5
-            assert clip["md5"] == hashlib.md5(clip["media_bytes"]).hexdigest()
+            assert clip["md5"] == content_md5(clip["media_bytes"])
 
 
 class TestSingleOutputClipperMD5Recompute:
@@ -293,8 +293,8 @@ class TestSingleOutputClipperMD5Recompute:
 
         parent_bytes = b"parent-image-bytes"
         crop_bytes = b"crop-from-parent-bytes"
-        parent_md5 = hashlib.md5(parent_bytes).hexdigest()
-        expected_crop_md5 = hashlib.md5(crop_bytes).hexdigest()
+        parent_md5 = content_md5(parent_bytes)
+        expected_crop_md5 = content_md5(crop_bytes)
 
         # Simulates the state a single-output crop clipper leaves behind:
         # media_bytes replaced with the crop, but md5 still carries the
@@ -324,8 +324,8 @@ class TestSingleOutputClipperMD5Recompute:
 
         parent_text = "the full document text"
         clip_text = "first sentence only"
-        parent_md5 = hashlib.md5(parent_text.encode("utf-8")).hexdigest()
-        expected_clip_md5 = hashlib.md5(clip_text.encode("utf-8")).hexdigest()
+        parent_md5 = content_md5(parent_text.encode("utf-8"))
+        expected_clip_md5 = content_md5(clip_text.encode("utf-8"))
 
         clip = {
             "id": 1,

--- a/tests_lib/io/test_importer_loading.py
+++ b/tests_lib/io/test_importer_loading.py
@@ -18,6 +18,7 @@ import pytest
 
 from helpers import make_raw_wav_bytes as _make_wav_bytes
 from vtscore.embedding.media_vectors import media_embedding
+from vtscore.utils.hashing import content_md5
 
 
 class TestLoadDatasetContentVectors:
@@ -267,7 +268,6 @@ class TestLoadDatasetContentMD5s:
 
     def test_computes_md5_when_not_in_content_md5s(self, tmp_path):
         """A file NOT in content_md5s falls back to computing the hash."""
-        import hashlib
         import unittest.mock as mock
 
         import numpy as np
@@ -276,7 +276,7 @@ class TestLoadDatasetContentMD5s:
 
         wav = tmp_path / "b.wav"
         self._write_wav(wav)
-        expected_md5 = hashlib.md5(wav.read_bytes()).hexdigest()
+        expected_md5 = content_md5(wav.read_bytes())
 
         mt = self._make_fake_media_type(embed_return=np.zeros(3))
 
@@ -293,7 +293,6 @@ class TestLoadDatasetContentMD5s:
 
     def test_mixed_content_md5s_and_computed(self, tmp_path):
         """Only files in content_md5s skip MD5 computation; others are hashed."""
-        import hashlib
         import unittest.mock as mock
 
         import numpy as np
@@ -306,7 +305,7 @@ class TestLoadDatasetContentMD5s:
         self._write_wav(wav_b)
 
         pre_md5 = "f" * 32
-        computed_md5 = hashlib.md5(wav_b.read_bytes()).hexdigest()
+        computed_md5 = content_md5(wav_b.read_bytes())
         mt = self._make_fake_media_type(embed_return=np.zeros(3))
 
         medias: dict = {}
@@ -324,7 +323,6 @@ class TestLoadDatasetContentMD5s:
 
     def test_no_content_md5s_param_computes_all(self, tmp_path):
         """When content_md5s is None (default), all files are hashed."""
-        import hashlib
         import unittest.mock as mock
 
         import numpy as np
@@ -333,7 +331,7 @@ class TestLoadDatasetContentMD5s:
 
         wav = tmp_path / "c.wav"
         self._write_wav(wav)
-        expected_md5 = hashlib.md5(wav.read_bytes()).hexdigest()
+        expected_md5 = content_md5(wav.read_bytes())
 
         mt = self._make_fake_media_type(embed_return=np.zeros(3))
 

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -22,6 +22,7 @@ import pytest
 
 from helpers import make_raw_wav_bytes as _make_wav_bytes
 from vtscore.embedding.media_vectors import media_embedding, set_media_embedding
+from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
@@ -1394,7 +1395,6 @@ class TestIngestSpecStreamRequiredFields:
 
     def test_file_size_and_md5_computed_from_bytes(self, monkeypatch):
         """file_size and md5 are derived from media_bytes when the converter omits them."""
-        import hashlib
         import json
 
         from vtscore.converters import get_converter
@@ -1417,7 +1417,7 @@ class TestIngestSpecStreamRequiredFields:
         assert len(medias) == 1
         m = medias[1]
         assert m["file_size"] == len(png)
-        assert m["md5"] == hashlib.md5(png).hexdigest()
+        assert m["md5"] == content_md5(png)
 
     def test_embedding_embedder_category_defaulted(self, monkeypatch):
         """embedding=None, embedder='', category='custom' are set on converter outputs."""
@@ -1466,7 +1466,6 @@ class TestIngestSpecStreamRequiredFields:
 
     def test_no_bytes_yields_empty_md5(self, monkeypatch):
         """A converter that produces no bytes gets md5=md5(b'')."""
-        import hashlib
         import json
 
         from vtscore.converters import get_converter
@@ -1484,7 +1483,7 @@ class TestIngestSpecStreamRequiredFields:
         source_specs = json.dumps([{"source_type": "video", "converter": "video2image", "params": {}}])
         imp.run({"media_type": "image", "source_specs": source_specs}, medias)
 
-        assert medias[1]["md5"] == hashlib.md5(b"").hexdigest()
+        assert medias[1]["md5"] == content_md5(b"")
         assert medias[1]["file_size"] == 0
 
     def test_direct_spec_not_affected(self):
@@ -1613,7 +1612,6 @@ class TestConverterOutputEndToEnd:
 
     def test_pickle_round_trip_preserves_all_fields(self, monkeypatch, tmp_path):
         """Fields set by _fill_converter_output_fields survive export → reload intact."""
-        import hashlib
 
         import numpy as np
 
@@ -1639,7 +1637,7 @@ class TestConverterOutputEndToEnd:
         m = reloaded[1]
         assert m["media_type"] == "image"
         assert m["file_size"] == len(png)
-        assert m["md5"] == hashlib.md5(png).hexdigest()
+        assert m["md5"] == content_md5(png)
         assert m["duration"] == 0
         assert m["category"] == "custom"
         # set_media_embedding stamped the embedder name when storing the vector.
@@ -1703,7 +1701,6 @@ class TestConverterOutputEndToEnd:
 
     def test_text_converter_file_size_and_md5_from_string(self, monkeypatch):
         """Text converters (returning media_string) get file_size and md5 from the string."""
-        import hashlib
         import json
 
         from vtscore.converters import get_converter
@@ -1739,7 +1736,7 @@ class TestConverterOutputEndToEnd:
         m = medias[1]
         encoded = caption.encode("utf-8")
         assert m["file_size"] == len(encoded)
-        assert m["md5"] == hashlib.md5(encoded).hexdigest()
+        assert m["md5"] == content_md5(encoded)
 
     def test_text_converter_export_does_not_raise(self, monkeypatch, tmp_path):
         """export_dataset_to_file must not raise on text-converter outputs."""
@@ -1803,7 +1800,6 @@ class TestConverterOutputEndToEnd:
 
     def test_labelset_clip_to_elements_md5_is_correct(self, monkeypatch):
         """md5 seen by _clip_to_elements matches the computed hash of the frame bytes."""
-        import hashlib
 
         from vtscore.datasets.labelset import _clip_to_elements
 
@@ -1815,7 +1811,7 @@ class TestConverterOutputEndToEnd:
         )
 
         elements = _clip_to_elements(medias[1], "bad")
-        assert elements[0].md5 == hashlib.md5(frame_data).hexdigest()
+        assert elements[0].md5 == content_md5(frame_data)
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/projection/test_signpost_build.py
+++ b/tests_lib/projection/test_signpost_build.py
@@ -15,6 +15,7 @@ import pytest
 from vtscore.projection import signpost_build as sb
 from vtscore.projection.labels import medoid
 from vtscore.projection.umap_projection import Projection
+from vtscore.utils.hashing import content_md5
 
 
 def _proj(n: int, projection_id: str = "proj-1") -> Projection:
@@ -28,9 +29,8 @@ class FakeEmbedder:
     supports_text = True
 
     def embed_text(self, text: str):
-        import hashlib
 
-        seed = int(hashlib.md5(text.encode()).hexdigest(), 16) % 2**32
+        seed = int(content_md5(text.encode()), 16) % 2**32
         rng = np.random.default_rng(seed)
         vec = rng.standard_normal(8).astype(np.float32)
         return vec / np.linalg.norm(vec)

--- a/tests_lib/projection/test_signpost_prep.py
+++ b/tests_lib/projection/test_signpost_prep.py
@@ -17,6 +17,7 @@ from vtscore.projection import signpost_prep as sp
 from vtscore.projection import signpost_texts as st
 from vtscore.projection.umap_projection import Projection
 from vtscore.state import DatasetContext
+from vtscore.utils.hashing import content_md5
 
 _N = 60
 _DIM = 8
@@ -28,9 +29,8 @@ class FakeEmbedder:
     supports_text = True
 
     def embed_text(self, text: str):
-        import hashlib
 
-        seed = int(hashlib.md5(text.encode()).hexdigest(), 16) % 2**32
+        seed = int(content_md5(text.encode()), 16) % 2**32
         rng = np.random.default_rng(seed)
         vec = rng.standard_normal(_DIM).astype(np.float32)
         return vec / np.linalg.norm(vec)

--- a/tests_lib/projection/test_toponymy_smoke.py
+++ b/tests_lib/projection/test_toponymy_smoke.py
@@ -11,7 +11,6 @@ a ~1 minute test → ``slow`` marker; run with ``-m slow``.
 
 from __future__ import annotations
 
-import hashlib
 
 import numpy as np
 import pytest
@@ -20,6 +19,7 @@ pytest.importorskip("toponymy")
 
 from vtscore.projection.signpost_build import build_region_labels  # noqa: E402
 from vtscore.projection.umap_projection import Projection  # noqa: E402
+from vtscore.utils.hashing import content_md5
 
 pytestmark = pytest.mark.slow
 
@@ -36,7 +36,7 @@ class SeededEmbedder:
     supports_text = True
 
     def embed_text(self, text: str):
-        seed = int(hashlib.md5(text.encode()).hexdigest(), 16) % 2**32
+        seed = int(content_md5(text.encode()), 16) % 2**32
         rng = np.random.default_rng(seed)
         vec = rng.standard_normal(_DIM).astype(np.float32)
         return vec / np.linalg.norm(vec)

--- a/vtscore/converters/runner.py
+++ b/vtscore/converters/runner.py
@@ -11,11 +11,11 @@ in after the importer returns.
 
 from __future__ import annotations
 
-import hashlib
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
+from vtscore.utils.hashing import content_md5
 
 ProgressCallback = Callable[[str, str, int, int], None]
 
@@ -362,11 +362,11 @@ def _compute_md5(output: dict[str, Any]) -> str:
     """Compute MD5 from converter output bytes or string."""
     data = output.get("media_bytes")
     if data:
-        return hashlib.md5(data).hexdigest()
+        return content_md5(data)
     text = output.get("media_string", "")
     if text:
-        return hashlib.md5(text.encode("utf-8")).hexdigest()
-    return hashlib.md5(b"").hexdigest()
+        return content_md5(text.encode("utf-8"))
+    return content_md5(b"")
 
 
 def apply_converter_to_demo(

--- a/vtscore/datasets/archive.py
+++ b/vtscore/datasets/archive.py
@@ -36,7 +36,6 @@ exception to the no-persist rule.
 
 from __future__ import annotations
 
-import hashlib
 import os
 import shutil
 import tarfile
@@ -49,6 +48,7 @@ from uuid import uuid4
 from vtscore.config import DATA_DIR
 from vtscore.security.archive import safe_tar_extract
 from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
+from vtscore.utils.hashing import content_md5
 
 if TYPE_CHECKING:
     from vtscore.datasets.importers.base import SourceSpec
@@ -244,7 +244,7 @@ def extract_archive_cached(
     resolved = archive_path.resolve()
     st = resolved.stat()
     signature = f"{resolved}|{st.st_size}|{st.st_mtime_ns}".encode()
-    digest = hashlib.md5(signature).hexdigest()[:16]
+    digest = content_md5(signature)[:16]
     cached_dir = DATA_DIR / f"local_archive_{digest}"
 
     if cached_dir.is_dir():

--- a/vtscore/datasets/clipper_chain.py
+++ b/vtscore/datasets/clipper_chain.py
@@ -18,7 +18,6 @@ one code path.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
@@ -27,6 +26,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from marshmallow import ValidationError
+from vtscore.utils.hashing import content_md5
 
 log = logging.getLogger(__name__)
 
@@ -42,10 +42,10 @@ def _content_hash(clip: dict[str, Any]) -> str | None:
     """
     s = clip.get("media_string")
     if isinstance(s, str) and s:
-        return hashlib.md5(s.encode("utf-8")).hexdigest()[:12]
+        return content_md5(s.encode("utf-8"))[:12]
     b = clip.get("media_bytes")
     if isinstance(b, (bytes, bytearray)) and b:
-        return hashlib.md5(bytes(b)).hexdigest()[:12]
+        return content_md5(bytes(b))[:12]
     return None
 
 

--- a/vtscore/datasets/importers/base/specs.py
+++ b/vtscore/datasets/importers/base/specs.py
@@ -13,10 +13,10 @@ converter loop) without pulling in the full importer base.
 
 from __future__ import annotations
 
-import hashlib
 import json
 from dataclasses import dataclass, field as dc_field
 from typing import Any
+from vtscore.utils.hashing import content_md5
 
 __all__ = ["SourceSpec", "PickerView", "MissingMediaTypeError"]
 
@@ -173,11 +173,11 @@ def _fill_converter_output_fields(media: dict[str, Any]) -> None:
     if "md5" not in media:
         mb = media.get("media_bytes")
         if mb:
-            media["md5"] = hashlib.md5(mb).hexdigest()
+            media["md5"] = content_md5(mb)
         elif media.get("media_string"):
-            media["md5"] = hashlib.md5((media["media_string"] or "").encode("utf-8")).hexdigest()
+            media["md5"] = content_md5((media["media_string"] or "").encode("utf-8"))
         else:
-            media["md5"] = hashlib.md5(b"").hexdigest()
+            media["md5"] = content_md5(b"")
     media.setdefault("embeddings", {})
     media.setdefault("embedder", "")
     media.setdefault("category", "custom")

--- a/vtscore/datasets/importers/local_archive_member/__init__.py
+++ b/vtscore/datasets/importers/local_archive_member/__init__.py
@@ -29,7 +29,6 @@ folds in the window so dedup / voting stay per-window unique.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from pathlib import Path
 from typing import Any
@@ -47,6 +46,7 @@ from vtscore.datasets.importers._npz_vectors import (
 )
 from vtscore.datasets.importers.base import ImporterBase, PluginField
 from vtscore.embedding.media_vectors import init_embeddings
+from vtscore.utils.hashing import content_md5
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ def _synthetic_md5(archive: str, member: str, suffix: str = "") -> str:
     is *content*-based label transfer across unrelated datasets, which these
     precomputed-embedding corpora don't use.
     """
-    return hashlib.md5(f"{archive}::{member}{suffix}".encode()).hexdigest()
+    return content_md5(f"{archive}::{member}{suffix}".encode())
 
 
 class LocalArchiveMemberImporter(ImporterBase):

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -16,7 +16,6 @@ full importer - this is much faster when only a few medias are missing.
 
 from __future__ import annotations
 
-import hashlib
 import json
 from typing import Any, Callable, Optional
 
@@ -24,6 +23,7 @@ from vtscore.state import next_media_id
 from vtscore.embedding.media_vectors import init_embeddings
 from vtscore.embedding.normalize import l2_normalize
 from vtscore.state.core import _state_lock
+from vtscore.utils.hashing import content_md5
 
 ProgressCallback = Callable[[str, str, int, int], None]
 
@@ -200,7 +200,7 @@ def _resolve_clip_content_and_embedding(
             return None
         embedding, clip_bytes = result
         if clip_bytes is not None:
-            return embedding, clip_bytes, hashlib.md5(clip_bytes).hexdigest()
+            return embedding, clip_bytes, content_md5(clip_bytes)
 
         # Metadata-only clip (video) or fall-through: use parent bytes,
         # but disambiguate the MD5 via a boundary tag so distinct clips of
@@ -208,17 +208,17 @@ def _resolve_clip_content_and_embedding(
         parent_bytes = file_path.read_bytes()
         tag = _boundary_tag(origin_dict.get("params", {}))
         if tag:
-            combined = hashlib.md5(parent_bytes).hexdigest() + tag
-            md5 = hashlib.md5(combined.encode()).hexdigest()
+            combined = content_md5(parent_bytes) + tag
+            md5 = content_md5(combined.encode())
         else:
-            md5 = hashlib.md5(parent_bytes).hexdigest()
+            md5 = content_md5(parent_bytes)
         return embedding, parent_bytes, md5
 
     embedding = embed_file(file_path, media_type_id, embedder_name) if media_type_id else None
     if embedding is None:
         return None
     parent_bytes = file_path.read_bytes()
-    return embedding, parent_bytes, hashlib.md5(parent_bytes).hexdigest()
+    return embedding, parent_bytes, content_md5(parent_bytes)
 
 
 def _ingest_via_source(
@@ -280,7 +280,7 @@ def _ingest_via_source(
                 file_bytes = item.path.read_bytes()
                 embedding = item.embedding
                 effective_embedder = item.embedder_name or embedder_name
-                md5 = hashlib.md5(file_bytes).hexdigest()
+                md5 = content_md5(file_bytes)
             else:
                 # Resolve embedding + clip-aware bytes/md5 - if any step fails,
                 # fall back to the legacy full-import path so we don't produce

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -19,10 +19,8 @@ to use these functions outside the Flask app.
 
 from __future__ import annotations
 
-import hashlib
 import io
 import pickle
-from pathlib import Path
 from typing import Any, Callable
 
 import numpy as np
@@ -97,15 +95,6 @@ def _get_embedding_value(d: dict[str, Any]) -> Any:
     Returns ``None`` when the key is absent.
     """
     return d.get("embedding")
-
-
-def _streaming_md5(file_path: Path) -> str:
-    """Compute MD5 hash of a file using constant memory."""
-    h = hashlib.md5()
-    with open(file_path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
-    return h.hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -13,7 +13,6 @@ Split out from :mod:`vtscore.datasets.loader` for navigability.
 from __future__ import annotations
 
 import gc
-import hashlib
 import logging
 import os
 from collections import defaultdict
@@ -27,7 +26,6 @@ from vtscore.datasets.loader import (
     _get_embedding_value,
     _get_md5_value,
     _pop_md5_key,
-    _streaming_md5,
 )
 from vtscore.embedding.media_vectors import init_embeddings
 from vtscore.security.path_validation import (
@@ -36,6 +34,7 @@ from vtscore.security.path_validation import (
     iter_rglob_follow_symlinks,
     rglob_follow_symlinks,
 )
+from vtscore.utils.hashing import content_md5, file_md5
 
 logger = logging.getLogger(__name__)
 
@@ -336,8 +335,9 @@ def _resolve_file_md5(
     """Resolve a file's MD5 with the standard precedence.
 
     custom_metadata MD5 → content_md5s[rel_path] → content_md5s[basename]
-    → streaming hash (thin mode, ``file_bytes`` is None) → ``hashlib.md5``
-    over ``file_bytes`` (full mode).
+    → :func:`~vtscore.utils.hashing.file_md5` (thin mode, ``file_bytes`` is
+    None) → :func:`~vtscore.utils.hashing.content_md5` over ``file_bytes``
+    (full mode).
     """
     if cm_md5:
         return cm_md5
@@ -346,8 +346,8 @@ def _resolve_file_md5(
     if content_md5s and file_path.name in content_md5s:
         return content_md5s[file_path.name]
     if file_bytes is None:
-        return _streaming_md5(file_path)
-    return hashlib.md5(file_bytes).hexdigest()
+        return file_md5(file_path)
+    return content_md5(file_bytes)
 
 
 def _build_folder_media_data(

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -8,7 +8,6 @@ out from :mod:`vtscore.datasets.loader` for navigability.
 from __future__ import annotations
 
 import gc
-import hashlib
 import logging
 from pathlib import Path
 from typing import Any, Iterator
@@ -17,6 +16,7 @@ from vtscore.datasets.loader import (
     ProgressCallback,
 )
 from vtscore.embedding.normalize import l2_normalize
+from vtscore.utils.hashing import content_md5
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +183,7 @@ def _build_pickle_full_media(
         "embedder": media_info.get("embedder", ""),
         "duration": media_info.get("duration", 0),
         "file_size": media_info.get("file_size", len(media_bytes)),
-        "md5": media_info.get("md5") or hashlib.md5(media_bytes).hexdigest(),
+        "md5": media_info.get("md5") or content_md5(media_bytes),
         "embeddings": _load_embeddings_dict(media_info),
         "media_bytes": media_bytes,
         "media_string": media_string,

--- a/vtscore/datasets/pdf.py
+++ b/vtscore/datasets/pdf.py
@@ -10,10 +10,10 @@ expands every PDF in a directory into per-page image medias (used by the
 
 from __future__ import annotations
 
-import hashlib
 import io
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from vtscore.utils.hashing import content_md5
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -134,7 +134,7 @@ def load_pdf_images_into(
                 "media_type": mt.type_id,
                 "embedder": "",
                 "file_size": len(image_bytes),
-                "md5": hashlib.md5(image_bytes).hexdigest(),
+                "md5": content_md5(image_bytes),
                 "embeddings": {},
                 "filename": full_page_name,
                 "category": "custom",

--- a/vtscore/datasets/stages/clipper.py
+++ b/vtscore/datasets/stages/clipper.py
@@ -15,6 +15,7 @@ from vtscore.embedding.matrix import invalidate_embedding_matrix
 from vtscore.embedding.media_vectors import media_embedding
 
 from vtscore.datasets.stages._common import _STATUS_TO_STEP, _TOTAL_LOAD_STEPS
+from vtscore.utils.hashing import content_md5
 
 if TYPE_CHECKING:
     from vtscore.state import DatasetContext
@@ -325,7 +326,6 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
     per invocation so GPU-backed embedders can fuse the forward pass.
     Failures fall back to keeping the clip's existing embedding.
     """
-    import hashlib
 
     total_clips = len(clips)
     embed_indices: list[int] = []
@@ -348,7 +348,7 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
         # ImageBboxClipper) would otherwise inherit the parent's MD5 via
         # ``dict(media)`` and cause dedup to merge distinct crops.
         if content_bytes is not None:
-            clip["md5"] = hashlib.md5(content_bytes).hexdigest()
+            clip["md5"] = content_md5(content_bytes)
         elif recompute:
             # Metadata-only clips (e.g. video): bytes unchanged but
             # boundaries differ; create a unique MD5 by hashing the
@@ -356,8 +356,8 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
             # distinct clips.
             parent_bytes = clip.get("media_bytes", b"")
             boundary_tag = f"|clip_start={clip.get('clip_start')}|clip_end={clip.get('clip_end')}"
-            combined = hashlib.md5(parent_bytes).hexdigest() + boundary_tag
-            clip["md5"] = hashlib.md5(combined.encode()).hexdigest()
+            combined = content_md5(parent_bytes) + boundary_tag
+            clip["md5"] = content_md5(combined.encode())
         embed_indices.append(clip_idx)
         embed_inputs.append(_build_clip_embed_input(clip, media_type))
 

--- a/vtscore/detectors/label_restoration.py
+++ b/vtscore/detectors/label_restoration.py
@@ -7,6 +7,8 @@ resolving origin files for cross-dataset scenarios.
 
 from __future__ import annotations
 
+from vtscore.utils.hashing import file_md5
+
 
 def _resolve_unmatched(unresolved: list, md5_lookup: dict[str, list[int]]) -> int:
     """Resolve unmatched labelset entries from their origin files.
@@ -19,7 +21,6 @@ def _resolve_unmatched(unresolved: list, md5_lookup: dict[str, list[int]]) -> in
 
     Returns the number of labels restored via this fallback path.
     """
-    import hashlib
     import logging
 
     from vtscore.detectors.resolver import resolve_file_context
@@ -39,11 +40,7 @@ def _resolve_unmatched(unresolved: list, md5_lookup: dict[str, list[int]]) -> in
 
             # Compute MD5 of the resolved file and check against loaded medias
             try:
-                h = hashlib.md5()
-                with open(resolved_path, "rb") as f:
-                    for chunk in iter(lambda: f.read(8192), b""):
-                        h.update(chunk)
-                resolved_md5 = h.hexdigest()
+                resolved_md5 = file_md5(resolved_path)
             except OSError:
                 _log.debug("restore-labels: could not read resolved file %s", resolved_path)
                 continue

--- a/vtscore/detectors/labelset_elements.py
+++ b/vtscore/detectors/labelset_elements.py
@@ -10,13 +10,13 @@ helpers used by the preview and vote routes.
 
 from __future__ import annotations
 
-import hashlib
 import json as _json
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator, Mapping
 
 from vtscore.datasets.labelset import LabeledElement, LabelSet, element_key
+from vtscore.utils.hashing import content_sha1
 
 
 def stable_element_id(elem: LabeledElement) -> str:
@@ -32,7 +32,7 @@ def stable_element_id(elem: LabeledElement) -> str:
         payload = _json.dumps(elem.to_dict(), sort_keys=True)
     else:
         payload = _json.dumps(key, default=str, sort_keys=True)
-    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+    return content_sha1(payload.encode("utf-8"))[:16]
 
 
 def find_element_by_id(elements: list[LabeledElement], target_id: str) -> tuple[int, LabeledElement] | None:

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -5,6 +5,7 @@ files, matches them to loaded dataset medias by MD5, and votes them good.
 """
 
 from __future__ import annotations
+from vtscore.utils.hashing import content_md5
 
 
 def _ensure_embedder(embedder, dataset_embedder_name: str, dataset_media_type: str):
@@ -47,7 +48,6 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:
 
     Returns the number of example entries successfully seeded.
     """
-    import hashlib
 
     from vtscore.config import DATA_DIR
     from vtscore.state import (
@@ -92,7 +92,7 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:
             continue
 
         file_bytes = file_path.read_bytes()
-        file_md5 = hashlib.md5(file_bytes).hexdigest()
+        file_md5 = content_md5(file_bytes)
         cids = md5_lookup.get(file_md5, [])
 
         if cids:

--- a/vtscore/docs/packages/converters.md
+++ b/vtscore/docs/packages/converters.md
@@ -307,7 +307,7 @@ The runner builds each output media dict via
     "media_type": <converter.target_type>,
     "embedder": <name of target media type's default embedder>,
     "file_size": <len of media_bytes or media_string.encode()>,
-    "md5": <hashlib.md5 of bytes/string>,
+    "md5": <content_md5 of bytes/string>,
     "embedding": <vector from target_emb.embed_media(...)>,
     "filename": <converter output's filename>,
     "category": "custom",

--- a/vtscore/docs/packages/datasets.md
+++ b/vtscore/docs/packages/datasets.md
@@ -43,7 +43,7 @@ subset that `export_dataset_to_file` preserves (see
 `vtscore/datasets/loader.py:142`).
 
 **MD5 gotcha:** `md5` is the hash of the **raw source file bytes**,
-computed via `_streaming_md5` (`vtscore/datasets/loader.py:102`). It is
+computed via `file_md5` (`vtscore/utils/hashing.py`). It is
 *not* the hash of the embedding, of `media_bytes` after any in-memory
 transformation, or of a clipped sub-region. Folder-importer subclasses
 can short-circuit this calculation by populating `content_md5s` on the

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -22,6 +22,7 @@ from vtscore.media.base import (
     _noop_progress,
     demo_slice,
 )
+from vtscore.utils.hashing import content_md5
 
 # Thumbnail dimensions (square)
 _THUMB_SIZE = 128
@@ -822,7 +823,6 @@ class AudioMediaType(MediaType):
         signpost layer straight from those paths — the friction-free way to eval
         the VTSBrowse sign display.  See :mod:`vtscore.media._toponymy_demo`.
         """
-        import hashlib  # noqa: PLC0415
 
         from vtscore.media._toponymy_demo import generate_items, total_cities  # noqa: PLC0415
 
@@ -845,7 +845,7 @@ class AudioMediaType(MediaType):
                 "embedder": emb_name,
                 "duration": _SYNTH_TONE_SECONDS,
                 "file_size": len(wav_bytes),
-                "md5": hashlib.md5(wav_bytes).hexdigest(),
+                "md5": content_md5(wav_bytes),
                 "embeddings": {emb_name: item.embedding},
                 "media_bytes": wav_bytes,
                 "thumbnail_bytes": thumb,
@@ -981,7 +981,6 @@ class AudioMediaType(MediaType):
         skip_embedding=False,
         **kwargs,
     ):
-        import hashlib  # noqa: PLC0415
 
         if on_progress is None:
             from vtscore.concurrency.progress import update_progress
@@ -1051,7 +1050,7 @@ class AudioMediaType(MediaType):
                 "embedder": embedder.name,
                 "duration": media_fields["duration"],
                 "file_size": len(wav_bytes),
-                "md5": hashlib.md5(wav_bytes).hexdigest(),
+                "md5": content_md5(wav_bytes),
                 "embeddings": {} if skip_embedding else {embedder.name: embedding},
                 "media_bytes": wav_bytes,
                 "thumbnail_bytes": media_fields.get("thumbnail_bytes"),

--- a/vtscore/media/document/media_type.py
+++ b/vtscore/media/document/media_type.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from pathlib import Path
 from typing import Optional
 
@@ -17,6 +16,7 @@ from vtscore.media.base import (
     _noop_progress,
     demo_slice,
 )
+from vtscore.utils.hashing import content_md5
 
 #: Industries queried against the UCSF Industry Documents Library for the
 #: ``ucsf_documents`` demo.  Owned here (not shared with the old image entry)
@@ -175,7 +175,7 @@ class DocumentMediaType(MediaType):
                 "embedder": "",
                 "duration": 0,
                 "file_size": len(pdf_bytes),
-                "md5": hashlib.md5(pdf_bytes).hexdigest(),
+                "md5": content_md5(pdf_bytes),
                 "embeddings": {},
                 "media_bytes": pdf_bytes,
                 "media_string": None,

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -35,6 +35,7 @@ from vtscore.media.image._demo_categories import (
     VGGFACE2_IDENTITIES,
     VISUAL_GENOME_CATEGORIES,
 )
+from vtscore.utils.hashing import content_md5
 
 
 _MEDIA_TYPE_ID = "image"
@@ -1049,7 +1050,6 @@ def _load_synthetic_toponymy(clips, embedder, on_progress, demo_origin) -> None:
     hierarchical embedding, so browsing lights up the ground-truth signpost
     layer straight from those paths.  See :mod:`vtscore.media._toponymy_demo`.
     """
-    import hashlib  # noqa: PLC0415
 
     from vtscore.media._toponymy_demo import generate_items  # noqa: PLC0415
     from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
@@ -1072,7 +1072,7 @@ def _load_synthetic_toponymy(clips, embedder, on_progress, demo_origin) -> None:
             "embedder": emb_name,
             "duration": 0,
             "file_size": len(png_bytes),
-            "md5": hashlib.md5(png_bytes).hexdigest(),
+            "md5": content_md5(png_bytes),
             "embeddings": {emb_name: item.embedding},
             "media_bytes": png_bytes,
             "media_string": None,
@@ -1091,7 +1091,6 @@ def _load_synthetic_toponymy(clips, embedder, on_progress, demo_origin) -> None:
 
 def _embed_file_images(selected, clips, embedder, on_progress, demo_origin, skip_embedding=False) -> None:
     """Embed a list of (img_path, category) tuples into ``clips``."""
-    import hashlib  # noqa: PLC0415
 
     from PIL import Image  # noqa: PLC0415
 
@@ -1128,7 +1127,7 @@ def _embed_file_images(selected, clips, embedder, on_progress, demo_origin, skip
             "embedder": embedder.name,
             "duration": 0,
             "file_size": len(image_bytes),
-            "md5": hashlib.md5(image_bytes).hexdigest(),
+            "md5": content_md5(image_bytes),
             "embeddings": {} if skip_embedding else {embedder.name: embedding},
             "media_bytes": image_bytes,
             "media_string": None,
@@ -1144,7 +1143,6 @@ def _embed_file_images(selected, clips, embedder, on_progress, demo_origin, skip
 
 def _embed_pil_pages(selected_pages, clips, embedder, on_progress, demo_origin, skip_embedding=False) -> None:
     """Embed a list of (page_name, PIL.Image, category) tuples into ``clips``."""
-    import hashlib  # noqa: PLC0415
     import io as _io  # noqa: PLC0415
 
     if not skip_embedding:
@@ -1175,7 +1173,7 @@ def _embed_pil_pages(selected_pages, clips, embedder, on_progress, demo_origin, 
             "embedder": embedder.name,
             "duration": 0,
             "file_size": len(image_bytes),
-            "md5": hashlib.md5(image_bytes).hexdigest(),
+            "md5": content_md5(image_bytes),
             "embeddings": {} if skip_embedding else {embedder.name: embedding},
             "media_bytes": image_bytes,
             "media_string": None,
@@ -1191,7 +1189,6 @@ def _embed_pil_pages(selected_pages, clips, embedder, on_progress, demo_origin, 
 
 def _embed_cifar_arrays(selected, clips, embedder, on_progress, demo_origin, skip_embedding=False) -> None:
     """Embed a list of (image_array, category) tuples into ``clips``."""
-    import hashlib  # noqa: PLC0415
     import io as _io  # noqa: PLC0415
 
     from PIL import Image  # noqa: PLC0415
@@ -1224,7 +1221,7 @@ def _embed_cifar_arrays(selected, clips, embedder, on_progress, demo_origin, ski
             "embedder": embedder.name,
             "duration": 0,
             "file_size": len(image_bytes),
-            "md5": hashlib.md5(image_bytes).hexdigest(),
+            "md5": content_md5(image_bytes),
             "embeddings": {} if skip_embedding else {embedder.name: embedding},
             "media_bytes": image_bytes,
             "media_string": None,
@@ -1266,7 +1263,6 @@ def _embed_vg_images(selected, clips, embedder, on_progress, demo_origin, skip_e
     ``category`` primary (first positive, for legacy single-label readers), and
     a store-only ``regions`` list of normalized ground-truth boxes.
     """
-    import hashlib  # noqa: PLC0415
 
     from PIL import Image  # noqa: PLC0415
 
@@ -1304,7 +1300,7 @@ def _embed_vg_images(selected, clips, embedder, on_progress, demo_origin, skip_e
             "embedder": embedder.name,
             "duration": 0,
             "file_size": len(image_bytes),
-            "md5": hashlib.md5(image_bytes).hexdigest(),
+            "md5": content_md5(image_bytes),
             "embeddings": {} if skip_embedding else {embedder.name: embedding},
             "media_bytes": image_bytes,
             "media_string": None,
@@ -1330,7 +1326,6 @@ def _embed_openlogo_images(selected, clips, embedder, on_progress, demo_origin, 
     template seed for a structural detector, and the boxes let the Calibration &
     Evaluation flow score against ground truth).
     """
-    import hashlib  # noqa: PLC0415
 
     from PIL import Image  # noqa: PLC0415
 
@@ -1368,7 +1363,7 @@ def _embed_openlogo_images(selected, clips, embedder, on_progress, demo_origin, 
             "embedder": embedder.name,
             "duration": 0,
             "file_size": len(image_bytes),
-            "md5": hashlib.md5(image_bytes).hexdigest(),
+            "md5": content_md5(image_bytes),
             "embeddings": {} if skip_embedding else {embedder.name: embedding},
             "media_bytes": image_bytes,
             "media_string": None,

--- a/vtscore/media/text/media_type.py
+++ b/vtscore/media/text/media_type.py
@@ -15,6 +15,7 @@ from vtscore.media.base import (
     _noop_progress,
     demo_slice,
 )
+from vtscore.utils.hashing import content_md5
 
 
 class TextMediaType(MediaType):
@@ -542,7 +543,6 @@ class TextMediaType(MediaType):
         skip_embedding=False,
         **kwargs,
     ):
-        import hashlib  # noqa: PLC0415
 
         if on_progress is None:
             from vtscore.concurrency.progress import update_progress
@@ -610,7 +610,7 @@ class TextMediaType(MediaType):
                 "embedder": embedder.name,
                 "duration": 0,
                 "file_size": len(text_bytes),
-                "md5": hashlib.md5(text_bytes).hexdigest(),
+                "md5": content_md5(text_bytes),
                 "embeddings": {} if skip_embedding else {embedder.name: embedding},
                 "media_bytes": None,
                 "media_string": text_content,

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -15,6 +15,7 @@ from vtscore.media.base import (
     _noop_progress,
     demo_slice,
 )
+from vtscore.utils.hashing import content_md5
 
 if TYPE_CHECKING:
     import numpy as np
@@ -701,7 +702,6 @@ class VideoMediaType(MediaType):
         skip_embedding=False,
         **kwargs,
     ):
-        import hashlib  # noqa: PLC0415
 
         if on_progress is None:
             from vtscore.concurrency.progress import update_progress
@@ -783,7 +783,7 @@ class VideoMediaType(MediaType):
                 "embedder": embedder.name,
                 "duration": media_fields["duration"],
                 "file_size": len(video_bytes),
-                "md5": hashlib.md5(video_bytes).hexdigest(),
+                "md5": content_md5(video_bytes),
                 "embeddings": {} if skip_embedding else {embedder.name: embedding},
                 "media_bytes": video_bytes,
                 "thumbnail_bytes": media_fields.get("thumbnail_bytes"),

--- a/vtscore/utils/__init__.py
+++ b/vtscore/utils/__init__.py
@@ -6,6 +6,10 @@ to their own top-level packages - see ``vtsearch/state``, ``vtsearch/plugins``,
 ``vtsearch/media/audio``.
 
 Remaining here:
+- :mod:`vtscore.utils.hashing` - ``content_md5``/``content_sha1``/``file_md5``
+  content fingerprints. Use these instead of ``hashlib`` directly so the
+  non-security declaration stays in one place (keeps MD5 working on
+  FIPS-enabled hosts).
 - :mod:`vtscore.utils.hits` - ``build_media_hit`` helper for scoring/route hit dicts.
 - :mod:`vtscore.utils.scores` - ``sigmoid_to_finite_scores``/``finite_or`` for
   JSON-safe MLP scoring (no NaN/Infinity leaks to strict clients).

--- a/vtscore/utils/hashing.py
+++ b/vtscore/utils/hashing.py
@@ -1,0 +1,74 @@
+"""Content fingerprinting helpers.
+
+Every hash VTSearch computes over media bytes is a **content-identity
+fingerprint**: it answers "are these the same bytes?" for dedup, cache keys,
+ETags, and origin tracking.  None of them is a security primitive - nothing
+here authenticates, signs, or protects anything.
+
+That distinction has a runtime consequence.  On a FIPS-enabled host, OpenSSL
+refuses to hand out MD5 (and SHA-1) at all, and ``hashlib.md5(...)`` raises
+``ValueError: [digital envelope routines] unsupported``.  CPython normally
+falls back to its built-in ``_md5`` implementation, but the Python builds
+shipped by FIPS-oriented distributions (RHEL, Fedora) deliberately strip that
+fallback so the policy cannot be bypassed.  Passing ``usedforsecurity=False``
+is the supported escape hatch: it declares the non-security use, and those
+builds then allow the digest.
+
+Routing every call site through this module means the declaration is made in
+exactly one place, and the next environment quirk is a one-file change rather
+than a hundred-site sweep.  Call these helpers instead of ``hashlib``
+directly for anything that fingerprints content.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+__all__ = [
+    "content_md5",
+    "content_sha1",
+    "file_md5",
+    "new_md5",
+]
+
+# Bytes read per chunk when hashing a file incrementally.
+_CHUNK_SIZE = 8192
+
+
+def _as_bytes(data: bytes | str) -> bytes:
+    """Coerce *data* to bytes, encoding text as UTF-8."""
+    return data.encode("utf-8") if isinstance(data, str) else data
+
+
+def content_md5(data: bytes | str) -> str:
+    """Return the hex MD5 fingerprint of *data*.
+
+    Accepts bytes or text; text is encoded as UTF-8 first.
+    """
+    return hashlib.md5(_as_bytes(data), usedforsecurity=False).hexdigest()
+
+
+def content_sha1(data: bytes | str) -> str:
+    """Return the hex SHA-1 fingerprint of *data*.
+
+    Accepts bytes or text; text is encoded as UTF-8 first.
+    """
+    return hashlib.sha1(_as_bytes(data), usedforsecurity=False).hexdigest()
+
+
+def new_md5() -> hashlib._Hash:
+    """Return a fresh incremental MD5 hasher for ``.update()`` streaming.
+
+    Use :func:`file_md5` instead when the input is simply a file on disk.
+    """
+    return hashlib.md5(usedforsecurity=False)
+
+
+def file_md5(file_path: Path | str) -> str:
+    """Return the hex MD5 fingerprint of a file, read in constant memory."""
+    h = new_md5()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(_CHUNK_SIZE), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import io
 import logging
 from functools import wraps
@@ -11,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Callable
 from flask import g, jsonify, make_response, request, send_file
 from flask_smorest import abort
 from marshmallow import ValidationError
+
+from vtscore.utils.hashing import content_md5, new_md5
 
 if TYPE_CHECKING:
     from vtscore.plugins import PluginBase
@@ -39,7 +40,7 @@ def cached_thumbnail_response(thumb_bytes: bytes, download_name: str):
     fingerprints the thumbnail bytes so the browser reuses one tile per item
     across scrolls and zoom levels, short-circuiting to a 304.
     """
-    etag = hashlib.md5(thumb_bytes).hexdigest()
+    etag = content_md5(thumb_bytes)
     if etag in request.if_none_match:
         resp = make_response("", 304)
         resp.set_etag(etag)
@@ -84,7 +85,8 @@ def image_thumbnail_response(
 
     crop_box = normalize_region_crop(crop) if crop is not None else None
 
-    hasher = hashlib.md5(image_bytes)
+    hasher = new_md5()
+    hasher.update(image_bytes)
     if crop_box is not None:
         hasher.update(repr(crop_box).encode("ascii"))
     etag = hasher.hexdigest()

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -14,7 +14,6 @@ because the request shape isn't a single marshmallow schema.
 
 from __future__ import annotations
 
-import hashlib
 import io
 import subprocess
 import tempfile
@@ -27,6 +26,7 @@ from flask_smorest import Blueprint, abort
 from vtscore.embedding.media_vectors import init_embeddings, media_embedder_names
 from vtscore.media.audio.ffmpeg import get_ffmpeg_exe
 from vtscore.media.base import MediaResponse
+from vtscore.utils.hashing import content_md5
 from vtsearch.schemas.media import (
     MediaAddToPileResponseSchema,
     MediaBatchRequestSchema,
@@ -559,7 +559,7 @@ def media_audio(media_id: int):
     # audio player still issues a cold GET per selection, and other surfaces
     # (label view, hover preview) re-request the same clip on replay; the ETag
     # turns those into 304s.  Mirrors the thumbnail route's conditional logic.
-    etag = c.get("md5") or hashlib.md5(media_bytes).hexdigest()
+    etag = c.get("md5") or content_md5(media_bytes)
     if etag in request.if_none_match:
         resp = make_response("", 304)
         resp.set_etag(etag)
@@ -1095,7 +1095,7 @@ def add_media_to_pile():
     ``label`` (``"good"`` or ``"bad"``).
     """
     file, file_bytes, label = _read_pile_upload()
-    file_md5 = hashlib.md5(file_bytes).hexdigest()
+    file_md5 = content_md5(file_bytes)
 
     # First-pass MD5 lookup (outside _state_lock). When this hits we can
     # skip the expensive embedding step and vote the existing media right


### PR DESCRIPTION
Closes #2687

## The problem

Bare `hashlib.md5()` raises `ValueError: [digital envelope routines] unsupported` on FIPS-enabled hosts. OpenSSL refuses to hand out MD5 at all under FIPS policy, and while stock CPython falls back to its built-in `_md5`, the Python builds shipped by FIPS-oriented distributions (RHEL, Fedora) deliberately strip that fallback so the policy can't be bypassed. On such a machine VTSearch fails the moment it fingerprints anything.

Note the reported trigger — an offline/air-gapped laptop — isn't the operative cause on its own: computing an MD5 never touches the network, and OpenSSL is a local library. The property that actually breaks it is FIPS mode, which those hardened machines commonly have on.

## The fix

Every MD5/SHA-1 in this codebase is a **content-identity fingerprint** — dedup keys, ETags, cache keys, origin tracking. None authenticates or protects anything. `usedforsecurity=False` is the supported way to declare that, and FIPS-patched builds honor it.

New `vtscore/utils/hashing.py` exposes four helpers, each passing the flag once:

| Helper | Use |
|---|---|
| `content_md5(bytes \| str)` | one-shot fingerprint |
| `content_sha1(bytes \| str)` | one-shot, for stable labelset element ids |
| `file_md5(path)` | constant-memory streaming read |
| `new_md5()` | incremental hasher for `.update()` |

All ~110 call sites across `vtscore/`, `vtsearch/`, and both test tiers now route through it. Centralizing matters more than the flag itself: the issue proposed patching `loader_folder.py:350`, but that's one of ~35 production sites on the same code paths — the next one fails immediately. With one module owning the declaration, the next environment quirk is a one-file change.

## On the pycryptodome suggestion

It does work — pycryptodome ships its own MD5 and bypasses OpenSSL entirely — but it's the wrong lever here. It's a compiled C extension, so installing it on the air-gapped machine the issue is about means pre-staging a matching wheel, whereas `usedforsecurity=False` is stdlib and needs nothing. It also adds a third-party dependency for a digest the stdlib already computes identically.

If a stricter FIPS-only provider ever blocks MD5 even with the flag set, the centralized helper is the single place to add a fallback — that's the design's main payoff.

## Incidental cleanup

- `loader._streaming_md5` deleted in favour of `file_md5`, which does the same constant-memory read.
- The open-coded chunk loop in `label_restoration.py` replaced with `file_md5`.
- Stale `# noqa: S324` and prose references to the old helpers updated.

## Verification

Digests are unchanged — `usedforsecurity` only controls whether the provider hands out the algorithm, not what it computes. Verified directly against stdlib output for all four helpers, so existing dataset pickles and stored MD5s stay valid.

- `./run-tests.sh` — ALL 6638 TESTS PASSED (1 skipped)
- `./run-tests.sh vtscore-clean` — ALL 2664 TESTS PASSED
- `ruff check` / `ruff format --check` clean

One caveat worth stating plainly: the FIPS diagnosis is inferred from the symptom, not confirmed against the reporter's environment — no FIPS host was available to test on. The reporter's traceback would settle it, and `ValueError: [digital envelope routines] unsupported` would confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pR1QeBnfXfuFoYSCu7mDn

---
_Generated by [Claude Code](https://claude.ai/code/session_018pR1QeBnfXfuFoYSCu7mDn)_