### PR TITLE
Add Browse Duplicates: registry endpoint + Export-style modal

### DIFF
--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -576,6 +576,37 @@ Returns ingest statistics for a registered dataset.
 
 404 if the dataset does not exist.
 
+### Dataset duplicates
+
+```
+GET /api/datasets/registry/{dataset_id}/duplicates
+```
+
+Returns the collapsed duplicate sets of a **loaded** dataset, expanded to
+their full membership so the caller can see which items were collapsed
+together and where each one came from. Each set corresponds to one
+`dupe_set` representative in the dataset's in-memory context; exact-dupe
+members share the representative's MD5, near-dupe members keep their own.
+
+→ ```json
+{
+  "duplicate_sets": [
+    {
+      "name": "a.wav",
+      "members": [
+        {"md5": "abc123", "filename": "a.wav", "category": "dogs",
+         "origin_name": "a.wav", "importer": "server_folder"},
+        {"md5": "abc123", "filename": "b.wav", "category": "pets",
+         "origin_name": "b.wav", "importer": "http_archive"}
+      ]
+    }
+  ]
+}
+```
+
+400 if the dataset isn't loaded (duplicate provenance lives only in memory);
+403 if access is denied; 404 if the dataset does not exist.
+
 ### Set dataset readers
 
 ```

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1389,6 +1389,21 @@
         ],
         "type": "object"
       },
+      "DatasetRegistryDuplicatesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "duplicate_sets": {
+            "items": {
+              "$ref": "#/components/schemas/DuplicateSet"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "duplicate_sets"
+        ],
+        "type": "object"
+      },
       "DatasetRegistryLoadResponse": {
         "additionalProperties": false,
         "properties": {
@@ -2595,6 +2610,53 @@
         },
         "required": [
           "detectors"
+        ],
+        "type": "object"
+      },
+      "DuplicateSet": {
+        "additionalProperties": false,
+        "properties": {
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/DuplicateSetMember"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "members",
+          "name"
+        ],
+        "type": "object"
+      },
+      "DuplicateSetMember": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "importer": {
+            "type": "string"
+          },
+          "md5": {
+            "type": "string"
+          },
+          "origin_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "category",
+          "filename",
+          "importer",
+          "md5",
+          "origin_name"
         ],
         "type": "object"
       },
@@ -10019,6 +10081,51 @@
           }
         },
         "summary": "Report domain shift of the active dataset against *dataset_id*'s atlas.",
+        "tags": [
+          "datasets_registry"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "dataset_id",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/api/datasets/registry/{dataset_id}/duplicates": {
+      "get": {
+        "description": "Each set is one ``dupe_set`` representative in the dataset's in-memory\ncontext, expanded to its full membership so the user can see which items\nwere collapsed together and where each one came from.  Duplicate origins\nlive only in memory (they are part of each representative's origin dict),\nso the dataset must be loaded.",
+        "operationId": "get_dataset_duplicates",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRegistryDuplicatesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Dataset is not currently loaded."
+          },
+          "403": {
+            "description": "Access denied for the current user."
+          },
+          "404": {
+            "description": "Dataset not found."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return the collapsed duplicate sets of a loaded dataset.",
         "tags": [
           "datasets_registry"
         ]

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -12,7 +12,16 @@
         </tr>
         <tr>
           <td class="stat-label" title="Number of duplicate items that were detected and collapsed">Duplicate groups</td>
-          <td class="stat-value">{{ stats.num_dupes | number }}</td>
+          <td class="stat-value">
+            {{ stats.num_dupes | number }}
+            @if (stats.num_dupes > 0) {
+              <button
+                class="btn btn--secondary btn--sm view-dupes-btn"
+                (click)="showDuplicates.set(true)"
+                title="See which items were collapsed together and the origins of each duplicate"
+              >View</button>
+            }
+          </td>
         </tr>
         <tr>
           <td class="stat-label" title="Timestamp when the dataset import process began">Ingest started</td>
@@ -80,3 +89,11 @@
     <button class="btn btn--secondary" (click)="close()">Close</button>
   </div>
 </vt-modal>
+
+@if (showDuplicates()) {
+  <vt-duplicates-modal
+    [datasetId]="datasetId()"
+    [datasetName]="datasetName()"
+    (closed)="showDuplicates.set(false)"
+  />
+}

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.scss
@@ -21,6 +21,12 @@
   color: var(--text-primary);
 }
 
+// "View" affordance beside the Duplicate-groups count (opens the child
+// Duplicates modal).
+.view-dupes-btn {
+  margin-left: var(--space-md);
+}
+
 // Section rhythm provided by the shared `.section-title` utility in
 // _components.scss (asymmetric top/bottom margins so each title binds to the
 // content BELOW it). No per-component overrides needed.

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
@@ -63,6 +63,29 @@ describe('DatasetStatsModalComponent', () => {
     expect(text).toContain('1m 15s'); // duration getter
   });
 
+  it('opens the Duplicates child modal from the Duplicate-groups View button', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(mockStats);
+    await settleZoneless(fixture);
+
+    const viewBtn = fixture.nativeElement.querySelector('.view-dupes-btn') as HTMLButtonElement;
+    expect(viewBtn).toBeTruthy();
+    viewBtn.click();
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.querySelector('vt-duplicates-modal')).toBeTruthy();
+    // The child modal fetches the duplicate sets for the same dataset.
+    httpMock.expectOne('/api/datasets/registry/ds1/duplicates').flush({ duplicate_sets: [] });
+    await settleZoneless(fixture);
+  });
+
+  it('hides the View button when the dataset has no duplicates', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/datasets/registry/ds1/stats').flush({ ...mockStats, num_dupes: 0 });
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelector('.view-dupes-btn')).toBeFalsy();
+  });
+
   it('repaints the error text on a failed load (zoneless canary)', async () => {
     await fixture.whenStable();
     httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, input, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from '../../modal/modal.component';
+import { DuplicatesModalComponent } from '../duplicates-modal/duplicates-modal.component';
 import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
 import type { DatasetRegistryStatsResponse } from '../../../generated/api-client/models/dataset-registry-stats-response';
 import { formatTimestamp as formatTs } from '../../../utils/format-date';
@@ -10,7 +11,7 @@ import { apiErrorMessage } from '../../../utils/api-error';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-dataset-stats-modal',
   standalone: true,
-  imports: [CommonModule, ModalComponent],
+  imports: [CommonModule, ModalComponent, DuplicatesModalComponent],
   templateUrl: './dataset-stats-modal.component.html',
   styleUrl: './dataset-stats-modal.component.scss',
 })
@@ -26,6 +27,9 @@ export class DatasetStatsModalComponent implements OnInit {
   readonly loading = signal(true);
   readonly error = signal('');
   readonly stats = signal<DatasetRegistryStatsResponse | null>(null);
+
+  /** Child Duplicates modal (issue #2697), opened from the Duplicate-groups row. */
+  readonly showDuplicates = signal(false);
 
   ngOnInit(): void {
     this.datasetsRegistryApi.getDatasetStats(this.datasetId()).subscribe({

--- a/frontend/src/app/components/modals/duplicates-modal/duplicates-modal.component.html
+++ b/frontend/src/app/components/modals/duplicates-modal/duplicates-modal.component.html
@@ -1,0 +1,70 @@
+<vt-modal [title]="'Duplicates: ' + datasetName()" [open]="true" (closed)="close()">
+  <button class="btn btn--secondary btn--sm back-btn" (click)="close()" title="Return to dataset stats">&larr; Back</button>
+
+  @if (loading()) {
+    <p class="loading-text">Loading duplicates…</p>
+  } @else if (error()) {
+    <p class="error-text">{{ error() }}</p>
+  } @else if (rows().length === 0) {
+    <p class="empty-state">No duplicate sets in this dataset.</p>
+  } @else {
+    <!-- Column Selection -->
+    <div class="dupes-section">
+      <h3 title="Choose which fields to show in the table and include in the copied output">Columns</h3>
+      <div class="column-checkboxes">
+        @for (col of columns; track col.key) {
+          <label class="column-toggle">
+            <input type="checkbox" [(ngModel)]="col.enabled" />
+            {{ col.label }}
+          </label>
+        }
+      </div>
+    </div>
+
+    <!-- Duplicate members table -->
+    <div class="dupes-section">
+      <h3>
+        Duplicates
+        <span class="preview-count">({{ rows().length | number }} items in {{ numSets | number }} sets)</span>
+      </h3>
+      <div class="table-scroll">
+        <table class="data-table dupes-table">
+          <thead>
+            <tr>
+              @for (col of enabledColumns; track col.key) {
+                <th [title]="col.label">{{ col.label }}</th>
+              }
+            </tr>
+          </thead>
+          <tbody>
+            @for (row of previewRows; track $index) {
+              <tr [class.set-start]="isSetStart($index)">
+                @for (col of enabledColumns; track col.key) {
+                  <td>{{ getCellValue(row, col) }}</td>
+                }
+              </tr>
+            }
+            @if (truncatedCount > 0) {
+              <tr class="truncated-row">
+                <td [attr.colspan]="enabledColumns.length">
+                  … {{ truncatedCount | number }} more rows (Copy includes all)
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Clipboard copy -->
+    <div class="dupes-section">
+      <vt-clipboard-copy
+        mode="table"
+        [rows]="clipboardRows"
+        [columns]="clipboardColumns"
+        [disabled]="enabledColumns.length === 0"
+        copyLabel="Copy"
+      ></vt-clipboard-copy>
+    </div>
+  }
+</vt-modal>

--- a/frontend/src/app/components/modals/duplicates-modal/duplicates-modal.component.scss
+++ b/frontend/src/app/components/modals/duplicates-modal/duplicates-modal.component.scss
@@ -1,0 +1,90 @@
+:host ::ng-deep .modal-content {
+  width: var(--modal-w-md);
+}
+
+// `.back-btn`, `.empty-state`, `.error-text` come from `_components.scss`;
+// `.column-checkboxes` / `.column-toggle` mirror the Export window's column
+// picker; the table builds on the shared `.data-table` primitive.
+
+.dupes-section {
+  margin-bottom: var(--space-2xl);
+
+  h3 { margin: 0 0 var(--space-md); }
+}
+
+.loading-text {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.preview-count {
+  font-weight: var(--weight-regular);
+  font-size: var(--font-sm);
+  color: var(--text-muted);
+}
+
+.column-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+}
+
+.column-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--font-md);
+  cursor: pointer;
+  user-select: none;
+
+  input[type='checkbox'] {
+    cursor: pointer;
+  }
+}
+
+.table-scroll {
+  max-height: 320px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.dupes-table {
+  --dt-cell-pad-y: var(--space-xs);
+  --dt-border-color: var(--border);
+  font-size: var(--font-sm);
+
+  th,
+  td {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 220px;
+  }
+
+  th {
+    position: sticky;
+    top: 0;
+    background: var(--bg-subtle);
+    font-weight: var(--weight-semibold);
+    font-size: var(--font-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+  }
+
+  tbody tr:hover {
+    background: var(--bg-hover);
+  }
+
+  // Heavier rule between consecutive dupe sets so each set reads as a block.
+  tbody tr.set-start td {
+    border-top: 2px solid var(--border);
+  }
+}
+
+.truncated-row td {
+  text-align: center;
+  color: var(--text-muted);
+  font-style: italic;
+  border-bottom: none;
+}

--- a/frontend/src/app/components/modals/duplicates-modal/duplicates-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/duplicates-modal/duplicates-modal.component.spec.ts
@@ -1,0 +1,116 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HttpTestingController } from '@angular/common/http/testing';
+import { DuplicatesModalComponent } from './duplicates-modal.component';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
+import { provideHttpTesting } from '../../../testing/test-providers';
+
+describe('DuplicatesModalComponent', () => {
+  let component: DuplicatesModalComponent;
+  let fixture: ComponentFixture<DuplicatesModalComponent>;
+  let httpMock: HttpTestingController;
+
+  const mockDupes = {
+    duplicate_sets: [
+      {
+        name: 'a.wav',
+        members: [
+          { md5: 'm1', filename: 'a.wav', category: 'c1', origin_name: 'a.wav', importer: 'server_folder' },
+          { md5: 'm1', filename: 'b.wav', category: 'c2', origin_name: 'b.wav', importer: 'http_archive' },
+        ],
+      },
+      {
+        name: 'x.txt',
+        members: [
+          { md5: 'm2', filename: 'x.txt', category: 'c1', origin_name: 'x.txt', importer: 'demo' },
+          { md5: 'm3', filename: 'y.txt', category: 'c1', origin_name: 'y.txt', importer: 'demo' },
+        ],
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [DuplicatesModalComponent],
+      providers: [...provideHttpTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DuplicatesModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('datasetId', 'ds1');
+    fixture.componentRef.setInput('datasetName', 'My Dataset');
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  async function flushInit(payload: object = mockDupes): Promise<void> {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/datasets/registry/ds1/duplicates').flush(payload);
+    await settleZoneless(fixture);
+  }
+
+  it('should create', async () => {
+    await flushInit();
+    expect(component).toBeTruthy();
+  });
+
+  it('flattens sets to one row per member, numbering sets 1-based', async () => {
+    await flushInit();
+    const rows = component.rows();
+    expect(rows.length).toBe(4);
+    expect(rows.map((r) => r.dupe_set)).toEqual(['1', '1', '2', '2']);
+    expect(rows[1].filename).toBe('b.wav');
+    expect(rows[1].importer).toBe('http_archive');
+  });
+
+  it('renders the table with a Dupe Set column and a separator between sets', async () => {
+    await flushInit();
+    const headers = Array.from(
+      fixture.nativeElement.querySelectorAll('thead th') as NodeListOf<HTMLElement>,
+    ).map((th) => th.textContent?.trim());
+    expect(headers).toContain('Dupe Set');
+    expect(headers).not.toContain('Label');
+    // Separator sits on the first row of the second set (index 2), not within a set.
+    expect(component.isSetStart(0)).toBe(false);
+    expect(component.isSetStart(1)).toBe(false);
+    expect(component.isSetStart(2)).toBe(true);
+    expect(fixture.nativeElement.querySelectorAll('tbody tr.set-start').length).toBe(1);
+  });
+
+  it('drops a toggled-off column from the table and the clipboard payload', async () => {
+    await flushInit();
+    const md5Col = component.columns.find((c) => c.key === 'md5')!;
+    md5Col.enabled = false;
+    expect(component.enabledColumns.map((c) => c.key)).not.toContain('md5');
+    expect(component.clipboardColumns.map((c) => c.key)).not.toContain('md5');
+  });
+
+  it('shows the empty state when there are no duplicate sets', async () => {
+    await flushInit({ duplicate_sets: [] });
+    expect(fixture.nativeElement.querySelector('.empty-state')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.dupes-table')).toBeFalsy();
+  });
+
+  it('surfaces the not-loaded 400 message from the backend', async () => {
+    await fixture.whenStable();
+    httpMock.expectOne('/api/datasets/registry/ds1/duplicates').flush(
+      { message: 'Load the dataset to browse its duplicates' },
+      { status: 400, statusText: 'Bad Request' },
+    );
+    await settleZoneless(fixture);
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('Load the dataset');
+  });
+
+  it('emits closed from the Back button', async () => {
+    await flushInit();
+    vi.spyOn(component.closed, 'emit');
+    (fixture.nativeElement.querySelector('.back-btn') as HTMLButtonElement).click();
+    expect(component.closed.emit).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/components/modals/duplicates-modal/duplicates-modal.component.ts
+++ b/frontend/src/app/components/modals/duplicates-modal/duplicates-modal.component.ts
@@ -1,0 +1,143 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  OnInit,
+  output,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ModalComponent } from '../../modal/modal.component';
+import {
+  ClipboardColumn,
+  ClipboardCopyComponent,
+} from '../../clipboard-copy/clipboard-copy.component';
+import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
+import { apiErrorMessage } from '../../../utils/api-error';
+import type { DuplicateSet } from '../../../generated/api-client/models/duplicate-set';
+
+/** One preview/clipboard row: a duplicate-set member flattened with its
+ *  1-based set number, so members of the same set share a "Dupe Set" value. */
+export interface DuplicateRow {
+  dupe_set: string;
+  md5: string;
+  filename: string;
+  category: string;
+  origin_name: string;
+  importer: string;
+}
+
+export interface DupeColumnDef {
+  key: keyof DuplicateRow;
+  label: string;
+  enabled: boolean;
+}
+
+/**
+ * Browse the collapsed duplicate sets of a loaded dataset (issue #2697): a
+ * lightweight take on the Export window's preview-table + clipboard shape,
+ * with a "Dupe Set" column in place of "Label" so the user can see which
+ * items were collapsed together and the origins of each member. Opened as a
+ * child modal from the Dataset Stats modal's "Duplicate groups" row.
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'vt-duplicates-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ModalComponent, ClipboardCopyComponent],
+  templateUrl: './duplicates-modal.component.html',
+  styleUrl: './duplicates-modal.component.scss',
+})
+export class DuplicatesModalComponent implements OnInit {
+  private readonly datasetsRegistryApi = inject(DatasetsRegistryApiService);
+
+  readonly datasetId = input('');
+  readonly datasetName = input('');
+  readonly closed = output<void>();
+
+  readonly loading = signal(true);
+  readonly error = signal('');
+  private readonly sets = signal<DuplicateSet[]>([]);
+
+  /** Preview row cap, mirroring the Export window's preview truncation. */
+  private static readonly PREVIEW_LIMIT = 50;
+
+  /** Column toggles; `enabled` is checkbox-bound, so a mutable field. */
+  columns: DupeColumnDef[] = [
+    { key: 'dupe_set', label: 'Dupe Set', enabled: true },
+    { key: 'md5', label: 'MD5', enabled: true },
+    { key: 'filename', label: 'Filename', enabled: true },
+    { key: 'category', label: 'Category', enabled: true },
+    { key: 'origin_name', label: 'Origin', enabled: true },
+    { key: 'importer', label: 'Importer', enabled: true },
+  ];
+
+  ngOnInit(): void {
+    this.datasetsRegistryApi.getDatasetDuplicates(this.datasetId()).subscribe({
+      next: (data) => {
+        this.sets.set(data.duplicate_sets);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.error.set(apiErrorMessage(err, 'Failed to load duplicates'));
+        this.loading.set(false);
+      },
+    });
+  }
+
+  /** All members of all sets, flattened to one row per member. */
+  readonly rows = computed<DuplicateRow[]>(() =>
+    this.sets().flatMap((set, setIndex) =>
+      set.members.map((m) => ({
+        dupe_set: String(setIndex + 1),
+        md5: m.md5,
+        filename: m.filename,
+        category: m.category,
+        origin_name: m.origin_name,
+        importer: m.importer,
+      })),
+    ),
+  );
+
+  get enabledColumns(): DupeColumnDef[] {
+    return this.columns.filter((c) => c.enabled);
+  }
+
+  get numSets(): number {
+    return this.sets().length;
+  }
+
+  get previewRows(): DuplicateRow[] {
+    return this.rows().slice(0, DuplicatesModalComponent.PREVIEW_LIMIT);
+  }
+
+  get truncatedCount(): number {
+    return Math.max(0, this.rows().length - DuplicatesModalComponent.PREVIEW_LIMIT);
+  }
+
+  /** True on the first row of every set after the first, so the preview can
+   *  draw a separator line between consecutive sets. */
+  isSetStart(index: number): boolean {
+    const rows = this.previewRows;
+    return index > 0 && rows[index - 1].dupe_set !== rows[index].dupe_set;
+  }
+
+  getCellValue(row: DuplicateRow, col: DupeColumnDef): string {
+    return row[col.key];
+  }
+
+  get clipboardColumns(): ClipboardColumn[] {
+    return this.enabledColumns.map((c) => ({ key: c.key, label: c.label }));
+  }
+
+  get clipboardRows(): Record<string, string>[] {
+    return this.rows() as unknown as Record<string, string>[];
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/frontend/src/app/services/datasets-registry-api.service.ts
+++ b/frontend/src/app/services/datasets-registry-api.service.ts
@@ -10,6 +10,7 @@ import type { DatasetRegistryLoadResponse } from '../generated/api-client/models
 import type { DatasetRegistryOkResponse } from '../generated/api-client/models/dataset-registry-ok-response';
 import type { DatasetRegistryReadersResponse } from '../generated/api-client/models/dataset-registry-readers-response';
 import type { DatasetRegistryRenameResponse } from '../generated/api-client/models/dataset-registry-rename-response';
+import type { DatasetRegistryDuplicatesResponse } from '../generated/api-client/models/dataset-registry-duplicates-response';
 import type { DatasetRegistryStatsResponse } from '../generated/api-client/models/dataset-registry-stats-response';
 import type { DatasetsRegistryListResponse } from '../generated/api-client/models/datasets-registry-list-response';
 import type { DatasetStatusResponse } from '../generated/api-client/models/dataset-status-response';
@@ -18,6 +19,7 @@ import { cancelDatasetLoadTask } from '../generated/api-client/fn/datasets-statu
 import { datasetStatus } from '../generated/api-client/fn/datasets-status/dataset-status';
 import { datasetDomainShift } from '../generated/api-client/fn/datasets-registry/dataset-domain-shift';
 import { deleteRegisteredDataset } from '../generated/api-client/fn/datasets-registry/delete-registered-dataset';
+import { getDatasetDuplicates } from '../generated/api-client/fn/datasets-registry/get-dataset-duplicates';
 import { getDatasetStats } from '../generated/api-client/fn/datasets-registry/get-dataset-stats';
 import { listRegisteredDatasets } from '../generated/api-client/fn/datasets-registry/list-registered-datasets';
 import { loadRegisteredDataset } from '../generated/api-client/fn/datasets-registry/load-registered-dataset';
@@ -101,6 +103,15 @@ export class DatasetsRegistryApiService {
 
   getDatasetStats(datasetId: string): Observable<DatasetRegistryStatsResponse> {
     return getDatasetStats(this.http, this.config.rootUrl, {
+      dataset_id: datasetId,
+    }).pipe(map((r) => r.body));
+  }
+
+  /** The collapsed duplicate sets of a *loaded* dataset, expanded to their
+   *  full membership. The backend refuses (400) when the dataset isn't
+   *  loaded — duplicate provenance lives only in memory. */
+  getDatasetDuplicates(datasetId: string): Observable<DatasetRegistryDuplicatesResponse> {
+    return getDatasetDuplicates(this.http, this.config.rootUrl, {
       dataset_id: datasetId,
     }).pipe(map((r) => r.body));
   }

--- a/tests/datasets/test_duplicates.py
+++ b/tests/datasets/test_duplicates.py
@@ -4,6 +4,7 @@ Covers:
 - ``collapse_duplicates`` function (pure state manipulation)
 - ``get_dupe_count`` helper
 - ``/api/dataset/status`` reporting ``num_dupes``
+- ``/api/datasets/registry/<id>/duplicates`` browsing the collapsed sets
 - Label export expanding dupe sets to all members
 - Label import collapsing by MD5 back to the representative
 """
@@ -231,6 +232,69 @@ class TestDatasetStatusDupes:
         finally:
             app_module.medias.clear()
             app_module.medias.update(saved)
+
+
+class TestDatasetDuplicatesEndpoint:
+    """Tests for GET /api/datasets/registry/<id>/duplicates."""
+
+    def _register_loaded_dataset(self, media_dict):
+        """Register a dataset and publish *media_dict* as its loaded context."""
+        from vtscore.datasets.registry import register_dataset
+        from vtsearch.state import DatasetContext, register_context
+
+        entry = register_dataset(
+            name="dupes-ep", media_type="audio", num_items=len(media_dict), pkl_path="/tmp/dupes-ep.pkl"
+        )
+        ctx = DatasetContext(entry["id"])
+        ctx.medias.update(media_dict)
+        register_context(ctx)
+        return entry["id"]
+
+    def test_returns_collapsed_sets_with_members(self, client):
+        media_dict = {
+            1: _make_media(1, md5="same", filename="a.wav", origin_importer="server_folder"),
+            2: _make_media(2, md5="same", filename="b.wav", origin_importer="http_archive"),
+            3: _make_media(3, md5="uniq", filename="c.wav"),
+        }
+        collapse_duplicates(media_dict)
+        dataset_id = self._register_loaded_dataset(media_dict)
+
+        resp = client.get(f"/api/datasets/registry/{dataset_id}/duplicates")
+        assert resp.status_code == 200
+        sets = resp.get_json()["duplicate_sets"]
+        assert len(sets) == 1
+        assert sets[0]["name"] == "a.wav"
+        members = sets[0]["members"]
+        assert [m["filename"] for m in members] == ["a.wav", "b.wav"]
+        assert [m["importer"] for m in members] == ["server_folder", "http_archive"]
+        # Exact-dupe members share the representative's MD5
+        assert all(m["md5"] == "same" for m in members)
+        assert all(m["category"] == "cat" for m in members)
+        assert members[0]["origin_name"] == "a.wav"
+
+    def test_no_dupes_returns_empty_list(self, client):
+        media_dict = {
+            1: _make_media(1, md5="aaa"),
+            2: _make_media(2, md5="bbb"),
+        }
+        collapse_duplicates(media_dict)
+        dataset_id = self._register_loaded_dataset(media_dict)
+
+        resp = client.get(f"/api/datasets/registry/{dataset_id}/duplicates")
+        assert resp.status_code == 200
+        assert resp.get_json()["duplicate_sets"] == []
+
+    def test_400_when_not_loaded(self, client):
+        from vtscore.datasets.registry import register_dataset
+
+        entry = register_dataset(name="not-loaded", media_type="audio", num_items=5, pkl_path="/tmp/nl.pkl")
+        resp = client.get(f"/api/datasets/registry/{entry['id']}/duplicates")
+        assert resp.status_code == 400
+        assert "Load the dataset" in resp.get_json()["message"]
+
+    def test_404_when_unknown_dataset(self, client):
+        resp = client.get("/api/datasets/registry/nonexistent-id/duplicates")
+        assert resp.status_code == 404
 
 
 class TestLabelExportExpandsDupes:

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -23,6 +23,7 @@ DELETE /api/datasets/registry/<id>                  Remove a dataset from the re
 PUT    /api/datasets/registry/<id>/rename           Rename a registered dataset.
 PUT    /api/datasets/registry/<id>/readers          Update the readers ACL.
 GET    /api/datasets/registry/<id>/stats            Return ingest statistics.
+GET    /api/datasets/registry/<id>/duplicates       Return the collapsed duplicate sets.
 """
 
 from __future__ import annotations
@@ -52,6 +53,7 @@ from vtscore.datasets.registry import (
 )
 from vtsearch.schemas.datasets import (
     DatasetDomainShiftResponseSchema,
+    DatasetRegistryDuplicatesResponseSchema,
     DatasetRegistryLoadResponseSchema,
     DatasetRegistryPreloadEmbedderResponseSchema,
     DatasetRegistryReadersRequestSchema,
@@ -654,3 +656,50 @@ def get_dataset_stats(dataset_id: str):
         "clipper": clipper_display,
         "embedder": entry.get("embedder", ""),
     }
+
+
+@datasets_registry_bp.route("/api/datasets/registry/<dataset_id>/duplicates")
+@datasets_registry_bp.response(200, DatasetRegistryDuplicatesResponseSchema)
+@datasets_registry_bp.alt_response(400, description="Dataset is not currently loaded.")
+@datasets_registry_bp.alt_response(403, description="Access denied for the current user.")
+@datasets_registry_bp.alt_response(404, description="Dataset not found.")
+def get_dataset_duplicates(dataset_id: str):
+    """Return the collapsed duplicate sets of a loaded dataset.
+
+    Each set is one ``dupe_set`` representative in the dataset's in-memory
+    context, expanded to its full membership so the user can see which items
+    were collapsed together and where each one came from.  Duplicate origins
+    live only in memory (they are part of each representative's origin dict),
+    so the dataset must be loaded.
+    """
+    from vtsearch.auth import get_current_user
+    from vtsearch.state import get_context
+
+    entry = _reg_get(dataset_id)
+    if entry is None:
+        abort(404, message="Dataset not found in registry")
+    if not _reg_can_access(dataset_id, get_current_user()):
+        abort(403, message="Access denied")
+    ctx = get_context(dataset_id)
+    if ctx is None:
+        abort(400, message="Load the dataset to browse its duplicates")
+
+    duplicate_sets = []
+    for cid in sorted(ctx.medias):
+        media = ctx.medias[cid]
+        origin = media.get("origin")
+        if not (isinstance(origin, dict) and origin.get("importer") == "dupe_set"):
+            continue
+        members = [
+            {
+                "md5": member.get("md5", "") or media.get("md5", ""),
+                "filename": member.get("filename", ""),
+                "category": member.get("category", ""),
+                "origin_name": member.get("origin_name", ""),
+                "importer": (member.get("origin") or {}).get("importer", ""),
+            }
+            for member in origin.get("members", [])
+        ]
+        name = (origin.get("params") or {}).get("name") or media.get("origin_name", "")
+        duplicate_sets.append({"name": name, "members": members})
+    return {"duplicate_sets": duplicate_sets}

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -863,6 +863,29 @@ class DatasetRegistryStatsResponseSchema(Schema):
     embedder = fields.String(required=True)
 
 
+class DuplicateSetMemberSchema(Schema):
+    """One member of a collapsed duplicate set (its pre-collapse provenance)."""
+
+    md5 = fields.String(required=True)
+    filename = fields.String(required=True)
+    category = fields.String(required=True)
+    origin_name = fields.String(required=True)
+    importer = fields.String(required=True)
+
+
+class DuplicateSetSchema(Schema):
+    """One collapsed duplicate set: its display name and every member."""
+
+    name = fields.String(required=True)
+    members = fields.List(fields.Nested(DuplicateSetMemberSchema), required=True)
+
+
+class DatasetRegistryDuplicatesResponseSchema(Schema):
+    """Response for ``GET /api/datasets/registry/<id>/duplicates``."""
+
+    duplicate_sets = fields.List(fields.Nested(DuplicateSetSchema), required=True)
+
+
 __all__ = [
     "BrowseMediaFilesQuerySchema",
     "BrowseMediaFilesResponseSchema",
@@ -890,6 +913,7 @@ __all__ = [
     "DatasetLoadFolderRequestSchema",
     "DatasetLoadSourceRequestSchema",
     "DatasetLoadStartedResponseSchema",
+    "DatasetRegistryDuplicatesResponseSchema",
     "DatasetRegistryLoadResponseSchema",
     "DatasetRegistryReadersRequestSchema",
     "DatasetRegistryReadersResponseSchema",


### PR DESCRIPTION
The Dataset Stats page reports how many duplicate sets were collapsed, but everyone's next question is "WHICH are the duplicates?". This adds a lightweight browse surface shaped like the Export window, with a **Dupe Set** column in place of **Label**, so the user can see which items were collapsed together and the origins of each member.

Closes #2697

## Backend

- **`GET /api/datasets/registry/<id>/duplicates`** (`vtsearch/routes/datasets/registry.py`): expands each `dupe_set` representative in the dataset's loaded context to its full membership — `md5`, `filename`, `category`, `origin_name`, and the member's original `importer`. Exact-dupe members share the representative's MD5 (their member dicts carry none); near-dupe members keep their own. Returns 400 when the dataset isn't loaded, since duplicate provenance lives only in each representative's in-memory origin dict; 403/404 mirror the sibling registry routes.
- New marshmallow schemas (`DatasetRegistryDuplicatesResponseSchema` + nested set/member schemas) so the endpoint lands in the OpenAPI snapshot; `frontend/openapi.json` regenerated.
- Documented in `docs/api/datasets.md`.

## Frontend

- **New `vt-duplicates-modal`**: an Export-window-style table — column toggles (Dupe Set, MD5, Filename, Category, Origin, Importer), a 50-row preview with a heavier rule separating consecutive sets, and the shared `vt-clipboard-copy` control (which copies **all** rows, not just the preview). Exporter tabs are intentionally omitted: those plugins consume labeled elements, and the clipboard covers the "get this into a spreadsheet" need.
- **Dataset Stats modal**: the Duplicate-groups row gains a **View** button (hidden at 0 dupes) that opens the Duplicates modal as a child, with the standard `← Back` affordance returning to Stats.

## Tests

- Backend: `TestDatasetDuplicatesEndpoint` in `tests/datasets/test_duplicates.py` (collapsed sets + members/importers/MD5s, empty case, 400 not-loaded, 404 unknown).
- Frontend: new Vitest spec for the Duplicates modal (flattening, set separators, column toggles, empty state, 400 message, Back) plus Stats-modal specs for the View button wiring.
- `./run-tests.sh` full suite: **ALL 6642 TESTS PASSED**; frontend gate (build + audit + 1788 Vitest tests) green; no OpenAPI drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyV28oJWoGDAc2TErsTf4r

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyV28oJWoGDAc2TErsTf4r)_