### PR TITLE
Stats window: carry every Dashboard grid column

### DIFF
--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -562,17 +562,32 @@ PUT /api/datasets/registry/{dataset_id}/rename
 GET /api/datasets/registry/{dataset_id}/stats
 ```
 
-Returns ingest statistics for a registered dataset.
+Returns registry and ingest statistics for a registered dataset. The
+response is a superset of the Dashboard grid's row (`name`, `media_type`,
+`num_items`, `created_at`, `expires_at`, `created_by`, `readers`), so the
+Stats window can show everything the grid does while it covers the grid up.
 
 → ```json
 {
+  "name": "Field recordings",
+  "media_type": "audio",
   "num_items": 1250,
   "num_dupes": 45,
-  "file_type_counts": {"audio/wav": 800, "audio/mp3": 450},
-  "ingest_started_at": "2025-03-31T10:15:00",
-  "ingest_finished_at": "2025-03-31T10:45:00"
+  "file_type_counts": {"wav": 800, "mp3": 450},
+  "created_at": 1743415500.0,
+  "expires_at": null,
+  "created_by": "alice",
+  "readers": ["bob"],
+  "ingest_started_at": 1743413700.0,
+  "ingest_finished_at": 1743415500.0,
+  "origin": "server_folder",
+  "source": {"importer": "server_folder", "params": {"path": "/data/sounds"}},
+  "clipper": "5 seconds",
+  "embedder": "clap"
 }
 ```
+
+`expires_at` is `null` when the dataset never ages off.
 
 404 if the dataset does not exist.
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1531,8 +1531,17 @@
           "clipper": {
             "type": "string"
           },
+          "created_at": {
+            "nullable": true
+          },
+          "created_by": {
+            "type": "string"
+          },
           "embedder": {
             "type": "string"
+          },
+          "expires_at": {
+            "nullable": true
           },
           "file_type_counts": {
             "additionalProperties": {
@@ -1546,6 +1555,12 @@
           "ingest_started_at": {
             "nullable": true
           },
+          "media_type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
           "num_dupes": {
             "type": "integer"
           },
@@ -1555,6 +1570,12 @@
           "origin": {
             "type": "string"
           },
+          "readers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "source": {
             "additionalProperties": {},
             "type": "object"
@@ -1562,11 +1583,15 @@
         },
         "required": [
           "clipper",
+          "created_by",
           "embedder",
           "file_type_counts",
+          "media_type",
+          "name",
           "num_dupes",
           "num_items",
           "origin",
+          "readers",
           "source"
         ],
         "type": "object"

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -348,6 +348,8 @@
   <vt-dataset-stats-modal
     [datasetId]="modals.stats.datasetId"
     [datasetName]="modals.stats.datasetName"
+    [isDefaultLogin]="isDefaultLogin()"
+    [serverSetsAgeOff]="serverSetsAgeOff()"
     (closed)="modals.closeStats()"
   />
 }

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -7,6 +7,10 @@
     <table class="data-table stats-table">
       <tbody>
         <tr>
+          <td class="stat-label" title="Media type: audio, image, text, video, or document">Type</td>
+          <td class="stat-value">{{ mediaType }}</td>
+        </tr>
+        <tr>
           <td class="stat-label" title="Total number of unique media items in this dataset">Media items</td>
           <td class="stat-value">{{ stats.num_items | number }}</td>
         </tr>
@@ -22,18 +26,6 @@
               >View</button>
             }
           </td>
-        </tr>
-        <tr>
-          <td class="stat-label" title="Timestamp when the dataset import process began">Ingest started</td>
-          <td class="stat-value">{{ formatTimestamp(stats.ingest_started_at) }}</td>
-        </tr>
-        <tr>
-          <td class="stat-label" title="Timestamp when the dataset import process completed">Ingest finished</td>
-          <td class="stat-value">{{ formatTimestamp(stats.ingest_finished_at) }}</td>
-        </tr>
-        <tr>
-          <td class="stat-label" title="Total time taken to import the dataset">Duration</td>
-          <td class="stat-value">{{ duration }}</td>
         </tr>
       </tbody>
     </table>
@@ -63,6 +55,50 @@
         </tr>
       </tbody>
     </table>
+
+    <h3 class="section-title">Timeline</h3>
+    <table class="data-table stats-table">
+      <tbody>
+        <tr>
+          <td class="stat-label" title="When the dataset was first imported">Created</td>
+          <td class="stat-value">{{ formatTimestamp(stats.created_at) }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="Timestamp when the dataset import process began">Ingest started</td>
+          <td class="stat-value">{{ formatTimestamp(stats.ingest_started_at) }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="Timestamp when the dataset import process completed">Ingest finished</td>
+          <td class="stat-value">{{ formatTimestamp(stats.ingest_finished_at) }}</td>
+        </tr>
+        <tr>
+          <td class="stat-label" title="Total time taken to import the dataset">Duration</td>
+          <td class="stat-value">{{ duration }}</td>
+        </tr>
+        @if (showAgeOff) {
+          <tr>
+            <td class="stat-label" title="When this dataset ages off and is automatically removed">Age-Off</td>
+            <td class="stat-value">{{ ageOff }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+
+    @if (showAccess) {
+      <h3 class="section-title">Access</h3>
+      <table class="data-table stats-table">
+        <tbody>
+          <tr>
+            <td class="stat-label" title="User who created this dataset">Creator</td>
+            <td class="stat-value">{{ stats.created_by || '-' }}</td>
+          </tr>
+          <tr>
+            <td class="stat-label" title="Users with access to this dataset">Readers</td>
+            <td class="stat-value">{{ readers }}</td>
+          </tr>
+        </tbody>
+      </table>
+    }
 
     @if (fileTypes.length > 0) {
       <h3 class="section-title">File Types</h3>

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
@@ -12,8 +12,14 @@ describe('DatasetStatsModalComponent', () => {
   let httpMock: HttpTestingController;
 
   const mockStats = {
+    name: 'My Dataset',
+    media_type: 'audio',
     num_items: 100,
     num_dupes: 3,
+    created_at: 1700000075,
+    expires_at: null,
+    created_by: 'alice',
+    readers: ['bob', 'carol'],
     ingest_started_at: 1700000000,
     ingest_finished_at: 1700000075,
     clipper: 'whole',
@@ -84,6 +90,63 @@ describe('DatasetStatsModalComponent', () => {
     httpMock.expectOne('/api/datasets/registry/ds1/stats').flush({ ...mockStats, num_dupes: 0 });
     await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelector('.view-dupes-btn')).toBeFalsy();
+  });
+
+  // Issue #2698: the Stats window covers the Dashboard grid, so it has to
+  // carry the grid's own columns (Type / # Items / Created / Age-Off /
+  // Creator / Readers) rather than force the user to dismiss it to look.
+  it('renders every Dashboard grid column', async () => {
+    fixture.componentRef.setInput('isDefaultLogin', false);
+    fixture.componentRef.setInput('serverSetsAgeOff', true);
+    await fixture.whenStable();
+    httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(mockStats);
+    await settleZoneless(fixture);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Type');
+    expect(text).toContain('Audio'); // capitalized media_type
+    expect(text).toContain('Created');
+    expect(text).toContain('Age-Off');
+    expect(text).toContain('Never'); // expires_at === null
+    expect(text).toContain('Creator');
+    expect(text).toContain('alice');
+    expect(text).toContain('Readers');
+    expect(text).toContain('bob, carol');
+  });
+
+  it('hides Creator/Readers under the default login, as the grid does', async () => {
+    fixture.componentRef.setInput('isDefaultLogin', true);
+    await fixture.whenStable();
+    httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(mockStats);
+    await settleZoneless(fixture);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).not.toContain('Creator');
+    expect(text).not.toContain('Readers');
+  });
+
+  it('hides Age-Off when the server stamps no expiry and the dataset has none', async () => {
+    fixture.componentRef.setInput('serverSetsAgeOff', false);
+    await fixture.whenStable();
+    httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(mockStats);
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.textContent as string).not.toContain('Age-Off');
+  });
+
+  // A stamped expiry outlives the server setting being turned back off;
+  // hiding a real death date would be a lie, so the row survives.
+  it('shows Age-Off for a stamped dataset even with the setting off', async () => {
+    fixture.componentRef.setInput('serverSetsAgeOff', false);
+    await fixture.whenStable();
+    httpMock
+      .expectOne('/api/datasets/registry/ds1/stats')
+      .flush({ ...mockStats, expires_at: 1800000000 });
+    await settleZoneless(fixture);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Age-Off');
+    expect(text).not.toContain('Never');
   });
 
   it('repaints the error text on a failed load (zoneless canary)', async () => {

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -20,6 +20,14 @@ export class DatasetStatsModalComponent implements OnInit {
 
   readonly datasetId = input('');
   readonly datasetName = input('');
+  /** Mirrors the Dashboard grid's own column gating so the Stats window
+   *  hides exactly what the grid hides: Creator/Readers are noise on a
+   *  single-user (default-login) install. */
+  readonly isDefaultLogin = input(true);
+  /** True when the server stamps datasets with an age-off. Gates the
+   *  Age-Off row the same way the grid gates its Age-Off column — except
+   *  a dataset that already carries an expiry always shows it. */
+  readonly serverSetsAgeOff = input(false);
   readonly closed = output<void>();
 
   // Signalized so the `ngOnInit` subscribe (an unpatched callback under zoneless)
@@ -54,6 +62,37 @@ export class DatasetStatsModalComponent implements OnInit {
     return Object.entries(counts)
       .sort(([, a], [, b]) => b - a)
       .map(([ext, count]) => ({ ext, count }));
+  }
+
+  /** Media type as the grid renders it: capitalized, `-` when unset. */
+  get mediaType(): string {
+    const t = this.stats()?.media_type;
+    if (!t) return '-';
+    return t.charAt(0).toUpperCase() + t.slice(1);
+  }
+
+  /** Age-off date, or the grid's "Never" when the dataset has no expiry. */
+  get ageOff(): string {
+    const expires = this.stats()?.expires_at;
+    return expires != null ? formatTs(expires) : 'Never';
+  }
+
+  /** Show the Age-Off row when the server stamps age-offs, or whenever this
+   *  particular dataset already carries one (a stamp survives the setting
+   *  being turned back off, and hiding a real death date would be a lie). */
+  get showAgeOff(): boolean {
+    return this.serverSetsAgeOff() || this.stats()?.expires_at != null;
+  }
+
+  /** Creator/Readers are meaningless on a single-user install, exactly as
+   *  in the grid, which drops both columns under the default login. */
+  get showAccess(): boolean {
+    return !this.isDefaultLogin();
+  }
+
+  get readers(): string {
+    const list = this.stats()?.readers ?? [];
+    return list.length ? list.join(', ') : '-';
   }
 
   get importerName(): string {

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -2092,3 +2092,55 @@ class TestClearDatasetHeaderGuard:
             assert len(app_module.medias) == len(saved)
         finally:
             app_module.medias.update(saved)
+
+
+class TestDatasetRegistryStats:
+    """``GET /api/datasets/registry/<id>/stats`` is a superset of the
+    Dashboard grid row, so the Stats window (which covers the grid) can
+    show every field the grid does."""
+
+    def _register(self, **overrides):
+        from vtscore.datasets.registry import register_dataset
+
+        kwargs = {
+            "name": "stats-ds",
+            "media_type": "audio",
+            "num_items": 42,
+            "pkl_path": "/tmp/stats.pkl",
+            "num_dupes": 7,
+            "embedder": "clap",
+            "created_by": "alice",
+            "readers": ["bob", "carol"],
+            "file_type_counts": {"wav": 30, "mp3": 12},
+            "ingest_started_at": 1700000000.0,
+        }
+        kwargs.update(overrides)
+        return register_dataset(**kwargs)
+
+    def test_stats_include_every_grid_column(self, client):
+        entry = self._register(expires_at=1800000000.0)
+        resp = client.get(f"/api/datasets/registry/{entry['id']}/stats")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # The grid's own columns.
+        assert data["name"] == "stats-ds"
+        assert data["media_type"] == "audio"
+        assert data["num_items"] == 42
+        assert data["created_at"] == entry["created_at"]
+        assert data["expires_at"] == 1800000000.0
+        assert data["created_by"] == "alice"
+        assert data["readers"] == ["bob", "carol"]
+        # ...alongside the stats the window already showed.
+        assert data["num_dupes"] == 7
+        assert data["file_type_counts"] == {"wav": 30, "mp3": 12}
+        assert data["ingest_started_at"] == 1700000000.0
+        assert data["embedder"] == "clap"
+
+    def test_never_expiring_dataset_reports_null_expiry(self, client):
+        entry = self._register()
+        resp = client.get(f"/api/datasets/registry/{entry['id']}/stats")
+        assert resp.status_code == 200
+        assert resp.get_json()["expires_at"] is None
+
+    def test_missing_dataset_is_404(self, client):
+        assert client.get("/api/datasets/registry/nope/stats").status_code == 404

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -646,7 +646,15 @@ def get_dataset_stats(dataset_id: str):
             clipper_display = raw_clipper
 
     return {
+        # The Dashboard grid's own columns, so the Stats window can show
+        # everything the grid does (it covers the grid up while open).
+        "name": entry.get("name", ""),
+        "media_type": entry.get("media_type", ""),
         "num_items": entry.get("num_items", 0),
+        "created_at": entry.get("created_at"),
+        "expires_at": entry.get("expires_at"),
+        "created_by": entry.get("created_by", ""),
+        "readers": entry.get("readers") or [],
         "num_dupes": entry.get("num_dupes", 0),
         "file_type_counts": entry.get("file_type_counts", {}),
         "ingest_started_at": entry.get("ingest_started_at"),

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -850,11 +850,23 @@ class DatasetDomainShiftResponseSchema(Schema):
 
 
 class DatasetRegistryStatsResponseSchema(Schema):
-    """Response for ``GET /api/datasets/registry/<id>/stats``."""
+    """Response for ``GET /api/datasets/registry/<id>/stats``.
 
+    A superset of the Dashboard grid row: ``name``, ``media_type``,
+    ``num_items``, ``created_at``, ``expires_at``, ``created_by`` and
+    ``readers`` are the grid's own columns, so the Stats window can show
+    everything the grid does while it covers the grid up.
+    """
+
+    name = fields.String(required=True)
+    media_type = fields.String(required=True)
     num_items = fields.Integer(required=True)
     num_dupes = fields.Integer(required=True)
     file_type_counts = fields.Dict(keys=fields.String(), values=fields.Integer(), required=True)
+    created_at = fields.Raw(allow_none=True)
+    expires_at = fields.Raw(allow_none=True)
+    created_by = fields.String(required=True)
+    readers = fields.List(fields.String(), required=True)
     ingest_started_at = fields.Raw(allow_none=True)
     ingest_finished_at = fields.Raw(allow_none=True)
     origin = fields.String(required=True)


### PR DESCRIPTION
The Dataset Stats modal opens on top of the Dashboard grid it was launched from, so any field the grid showed and the modal didn't was simply unreadable while the modal was up — you had to dismiss Stats to go re-read the row. This widens the stats payload to a superset of the grid row and reorganizes the modal around it.

## Backend

`GET /api/datasets/registry/<id>/stats` now returns the grid's own columns alongside the ingest stats it already served: `name`, `media_type`, `created_at`, `expires_at`, `created_by`, `readers`. All six come straight off the registry entry, so there's no new computation and no new persisted state.

Schema (`DatasetRegistryStatsResponseSchema`), the OpenAPI snapshot, and `docs/api/datasets.md` are updated to match.

## Frontend

The modal's flat "everything then Creation then File Types" layout regroups into sections that answer distinct questions:

| Section | Rows |
|---|---|
| *(untitled overview)* | Type, Media items, Duplicate groups |
| **Creation** | Importer, importer params, Clipper, Embedder |
| **Timeline** | Created, Ingest started, Ingest finished, Duration, Age-Off |
| **Access** | Creator, Readers |
| **File Types** | extension → count |

The three ingest timestamps moved out of the top table into **Timeline**, where the grid's `Created` and `Age-Off` join them; the top table is now purely "what is this dataset". Values render exactly as the grid renders them — capitalized media type, `Never` for a null expiry, comma-joined readers, `-` for empty.

Visibility follows the grid's own gating, via two new inputs (`isDefaultLogin`, `serverSetsAgeOff`) bound from the Dashboard:

- **Access** is hidden under the default login, where Creator/Readers are noise — same as the grid dropping those two columns.
- **Age-Off** is hidden when the server stamps no age-off, with one deliberate divergence: a dataset that already *carries* a stamped expiry shows the row regardless, since the stamp outlives the setting being turned back off and hiding a real death date would be a lie.

## Testing

`./run-tests.sh` — all 6641 tests pass (1 skipped, 1 xfailed).

New coverage: three backend tests on the stats endpoint (every grid column present, null expiry for a never-expiring dataset, 404 for an unknown id — the endpoint previously had none) and four frontend tests on the modal (all grid columns render, Access hidden under default login, Age-Off hidden with no expiry, Age-Off shown for a stamped expiry with the setting off).

No screenshot reshoot is queued: no shot in `docs/user/screenshots.manifest.ts` frames the Dataset Stats modal.

Closes #2698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xUe8i51mEHoD8fHm8G2eB

---
_Generated by [Claude Code](https://claude.ai/code/session_017xUe8i51mEHoD8fHm8G2eB)_