### PR TITLE
Add a --semantic-only server lock for the prototype embedder types

### DIFF
--- a/app.py
+++ b/app.py
@@ -270,6 +270,78 @@ app.register_blueprint(hf_auth_bp)
 # ---------------------------------------------------------------------------
 
 
+def _apply_env_dataset_max_age() -> None:
+    """Honour ``VTSEARCH_DATASET_MAX_AGE_DAYS`` when no CLI flag was passed.
+
+    The gunicorn-launched images never parse ``--dataset-max-age-days`` (the
+    argparse path only runs under ``python app.py``), so the same override is
+    reachable from the environment. An explicit CLI flag always wins. Like the
+    flag, this applies to every user for the lifetime of the process and is not
+    editable via the settings API.
+    """
+    from vtsearch.settings import get_cli_dataset_max_age_days, set_cli_dataset_max_age_days
+
+    if get_cli_dataset_max_age_days() is not None:
+        return
+    raw = os.environ.get("VTSEARCH_DATASET_MAX_AGE_DAYS")
+    if not raw:
+        return
+    try:
+        days = int(raw)
+    except ValueError:
+        days = 0
+    if days >= 1:
+        set_cli_dataset_max_age_days(days)
+        print(f"\U0001f5d3️  Dataset max age: {days}d (from VTSEARCH_DATASET_MAX_AGE_DAYS)", flush=True)
+    else:
+        print(
+            f"⚠️  Ignoring VTSEARCH_DATASET_MAX_AGE_DAYS={raw!r} (want a positive integer number of days)",
+            flush=True,
+        )
+
+
+def _apply_env_support_email() -> None:
+    """Honour ``VTSEARCH_SUPPORT_EMAIL`` when no CLI flag was passed.
+
+    Same rationale as :func:`_apply_env_dataset_max_age`: the gunicorn images
+    never parse ``--support-email``. An explicit CLI flag always wins.
+    """
+    from vtsearch.settings import get_cli_support_email, set_cli_support_email
+
+    if get_cli_support_email() is not None:
+        return
+    email = (os.environ.get("VTSEARCH_SUPPORT_EMAIL") or "").strip()
+    if email:
+        set_cli_support_email(email)
+        print(f"\U0001f4e7 Support email: {email} (from VTSEARCH_SUPPORT_EMAIL)", flush=True)
+
+
+def _apply_env_semantic_only() -> None:
+    """Honour ``VTSEARCH_SEMANTIC_ONLY`` when no CLI flag was passed.
+
+    Same rationale as the two helpers above (gunicorn never parses
+    ``--semantic-only``); any of ``1``/``true``/``yes``/``on`` enables the
+    lock. Reports the lock however it arrived - flag, env var, or the persisted
+    ``semantic_only`` setting - so an operator can confirm from the startup log
+    that the prototype embedder types are off.
+    """
+    from vtsearch.settings import (
+        get_cli_semantic_only,
+        get_effective_semantic_only,
+        set_cli_semantic_only,
+    )
+
+    source = "--semantic-only"
+    if get_cli_semantic_only() is None:
+        if (os.environ.get("VTSEARCH_SEMANTIC_ONLY") or "").strip().lower() in ("1", "true", "yes", "on"):
+            set_cli_semantic_only(True)
+            source = "VTSEARCH_SEMANTIC_ONLY"
+        else:
+            source = "the semantic_only server setting"
+    if get_effective_semantic_only():
+        print(f"\U0001f512 Semantic embedders only (from {source})", flush=True)
+
+
 def initialize_server(mode_label: str = "PRODUCTION") -> None:
     """Load models and preload media types.
 
@@ -285,41 +357,11 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
     """
     print(f"\U0001f680 Running in {mode_label} mode", flush=True)
 
-    # Deployment-level dataset retention override from the environment, for
-    # the gunicorn-launched images that never parse ``--dataset-max-age-days``
-    # (the argparse path below only runs under ``python app.py``). An explicit
-    # CLI flag, if one was passed, always wins. Like the flag, this applies to
-    # every user for the lifetime of the process and is not editable via the
-    # settings API.
-    from vtsearch.settings import get_cli_dataset_max_age_days, set_cli_dataset_max_age_days
-
-    if get_cli_dataset_max_age_days() is None:
-        _env_max_age = os.environ.get("VTSEARCH_DATASET_MAX_AGE_DAYS")
-        if _env_max_age:
-            try:
-                _days = int(_env_max_age)
-            except ValueError:
-                _days = 0
-            if _days >= 1:
-                set_cli_dataset_max_age_days(_days)
-                print(f"\U0001f5d3️  Dataset max age: {_days}d (from VTSEARCH_DATASET_MAX_AGE_DAYS)", flush=True)
-            else:
-                print(
-                    f"⚠️  Ignoring VTSEARCH_DATASET_MAX_AGE_DAYS={_env_max_age!r} "
-                    "(want a positive integer number of days)",
-                    flush=True,
-                )
-
-    # Deployment-level "Email us" recipient override from the environment,
-    # same rationale as the dataset-retention block above: the gunicorn images
-    # never parse ``--support-email``. An explicit CLI flag always wins.
-    from vtsearch.settings import get_cli_support_email, set_cli_support_email
-
-    if get_cli_support_email() is None:
-        _env_support_email = (os.environ.get("VTSEARCH_SUPPORT_EMAIL") or "").strip()
-        if _env_support_email:
-            set_cli_support_email(_env_support_email)
-            print(f"\U0001f4e7 Support email: {_env_support_email} (from VTSEARCH_SUPPORT_EMAIL)", flush=True)
+    # Deployment-level overrides that the gunicorn-launched images can only
+    # reach through the environment (they never parse argv).
+    _apply_env_dataset_max_age()
+    _apply_env_support_email()
+    _apply_env_semantic_only()
 
     print("\U0001f4da Loading ML libraries...", flush=True)
     initialize_models(on_progress=lambda *a, **k: None)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -569,7 +569,7 @@ suggestions) and resolve via the active `DatasetContext` /
 
 Persistent settings live in `vtsearch/settings.py`, split across two
 tiers.  **Server tier** (shared, `data/settings.json`): `saved_datasets_dir`,
-`detectors_dir`, `max_concurrent_*`, `hidden_plugins`.
+`detectors_dir`, `max_concurrent_*`, `hidden_plugins`, `semantic_only`.
 **Per-user tier** (`<user_data_dir>/user_settings.json`): everything else;
 `volume`, `theme`, `inclusion`, `enrich_descriptions`, `safe_thresholds`,
 `calibrate_count`, `calibration_fraction`, `audio_playing`, `show_animations`,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -469,6 +469,41 @@ same override is also available as the `VTSEARCH_SUPPORT_EMAIL`
 environment variable for the gunicorn-launched Docker images; an
 explicit `--support-email` flag wins over it.
 
+**Semantic embedders only** (`--semantic-only`): lock the instance to the
+**Semantic** embedder type, hiding the still-prototype **Patch Semantic**
+and **Structural** types from every surface:
+
+```bash
+python app.py --semantic-only
+```
+
+With the lock on:
+
+- `GET /api/embedders` withholds every patch / structural embedder, so
+  Add Dataset ▸ Advanced shows no "Region embedder" / "Instance embedder"
+  picker and the primary Embedder picker lists Semantic embedders only.
+- The New-detector modal drops its "Detector Embedder Type" picker (one
+  option is not a choice) and creates Semantic detectors.
+- `POST /api/detectors` and the dataset-import routes reject a
+  patch/structural type with **400**, so a stale client or a hand-rolled
+  request can't bind one behind the UI's back.
+
+This is a coarser tool than `--hide-plugin embedders:<name>`, which hides
+one named embedder: use `--semantic-only` when you want the whole
+prototype tier gone and don't want to track which embedders belong to it.
+
+Like `--dataset-max-age-days` and `--support-email`, this is a
+**server-wide override**: it applies to every user, overrides the
+persisted `semantic_only` in the settings file for the lifetime of the
+process, and is **not** editable via the Settings dialog or the settings
+API (it is exposed read-only, and the Settings ▸ Server tab reports it).
+The flag can only *enable* the lock — there is no `--no-semantic-only` —
+so a deployment that sets `semantic_only: true` in its settings file
+can't have the restriction loosened by a stray flag. The same override is
+available as the `VTSEARCH_SEMANTIC_ONLY` environment variable (`1` /
+`true` / `yes` / `on`) for the gunicorn-launched Docker images; an
+explicit `--semantic-only` flag wins over it.
+
 ## Inspecting plugins and the API schema
 
 `python app.py --list-plugins` enumerates every auto-discovered plugin;

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -388,6 +388,10 @@
             "readOnly": true,
             "type": "string"
           },
+          "semantic_only": {
+            "readOnly": true,
+            "type": "boolean"
+          },
           "show_animations": {
             "enum": [
               "show",
@@ -11813,7 +11817,7 @@
     },
     "/api/embedders": {
       "get": {
-        "description": "Query parameters:\nmedia_type: A ``type_id`` (e.g. ``\"image\"``) or ``folder_import_name``\n    (e.g. ``\"images\"``).  When provided, only embedders whose\n    ``media_type_id`` matches are returned.",
+        "description": "Two deployment-level hides apply on top of that filter: the admin's\n``hidden_plugins`` / ``--hide-plugin`` list, and the ``semantic_only``\nlock (``--semantic-only``), which withholds every patch / structural\nembedder so the prototype types never reach a picker.\n\nQuery parameters:\n    media_type: A ``type_id`` (e.g. ``\"image\"``) or ``folder_import_name``\n        (e.g. ``\"images\"``).  When provided, only embedders whose\n        ``media_type_id`` matches are returned.",
         "operationId": "embedders_list",
         "parameters": [
           {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -332,44 +332,48 @@
         />
       </div>
 
-      <div class="form-group advanced-group">
-        <button
-          type="button"
-          class="advanced-toggle"
-          (click)="toggleAdvanced()"
-          [attr.aria-expanded]="advancedOpen()"
-          title="Advanced options: the kind of embedder this detector works with."
-        >
-          Advanced {{ advancedOpen() ? '▴' : '▾' }}
-        </button>
-
-        @if (advancedOpen()) {
-          <label class="col-label" for="detector-embedder-type"
-            title="The kind of embedder this detector works with. An embedder is the tool that analyzes your items so they can be searched. The detector stays compatible with any dataset that uses this kind of embedder. Pick the kind you expect to use — you can create a detector before adding any dataset.">
-            Detector Embedder Type
-          </label>
-          <select
-            id="detector-embedder-type"
-            class="form-select"
-            name="detectorEmbedderType"
-            [ngModel]="effectiveEmbedderType"
-            (ngModelChange)="onEmbedderTypeChange($event)"
+      @if (showAdvancedToggle) {
+        <div class="form-group advanced-group">
+          <button
+            type="button"
+            class="advanced-toggle"
+            (click)="toggleAdvanced()"
+            [attr.aria-expanded]="advancedOpen()"
+            title="Advanced options: the kind of embedder this detector works with."
           >
-            @for (type of embedderTypeOptions; track type) {
-              <option [value]="type">{{ embedderTypeLabel(type) }}</option>
+            Advanced {{ advancedOpen() ? '▴' : '▾' }}
+          </button>
+
+          @if (advancedOpen()) {
+            @if (showEmbedderTypePicker) {
+              <label class="col-label" for="detector-embedder-type"
+                title="The kind of embedder this detector works with. An embedder is the tool that analyzes your items so they can be searched. The detector stays compatible with any dataset that uses this kind of embedder. Pick the kind you expect to use — you can create a detector before adding any dataset.">
+                Detector Embedder Type
+              </label>
+              <select
+                id="detector-embedder-type"
+                class="form-select"
+                name="detectorEmbedderType"
+                [ngModel]="effectiveEmbedderType"
+                (ngModelChange)="onEmbedderTypeChange($event)"
+              >
+                @for (type of embedderTypeOptions; track type) {
+                  <option [value]="type">{{ embedderTypeLabel(type) }}</option>
+                }
+              </select>
+              @if (embedderTypeUnavailable) {
+                <p class="info-text">
+                  The current dataset has no {{ embedderTypeLabel(effectiveEmbedderType) }} embedder, so
+                  this detector won't run here — it'll be available on datasets that bind one.
+                </p>
+              }
             }
-          </select>
-          @if (embedderTypeUnavailable) {
-            <p class="info-text">
-              The current dataset has no {{ embedderTypeLabel(effectiveEmbedderType) }} embedder, so
-              this detector won't run here — it'll be available on datasets that bind one.
-            </p>
+            @if (primaryLicenseNotice; as notice) {
+              <div class="license-warning" role="note">⚠ {{ notice }}</div>
+            }
           }
-          @if (primaryLicenseNotice; as notice) {
-            <div class="license-warning" role="note">⚠ {{ notice }}</div>
-          }
-        }
-      </div>
+        </div>
+      }
 
       @if (error()) {
         <p class="error-text">{{ error() }}</p>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -452,3 +452,57 @@ describe('NewDetectorModalComponent with defaultMediaType', () => {
     expect(component.mediaTypeLocked).toBe(true);
   });
 });
+
+describe('NewDetectorModalComponent (semantic_only server)', () => {
+  let component: NewDetectorModalComponent;
+  let fixture: ComponentFixture<NewDetectorModalComponent>;
+  let httpMock: HttpTestingController;
+
+  async function setup(semanticOnly: boolean) {
+    await TestBed.configureTestingModule({
+      imports: [NewDetectorModalComponent],
+      providers: [...provideZoneless(), ...provideHttpTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NewDetectorModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('defaultMediaType', 'image');
+    httpMock = TestBed.inject(HttpTestingController);
+    TestBed.tick();
+
+    httpMock.expectOne('/api/media-types').flush({
+      media_types: [{ type_id: 'image', name: 'Image', icon: 'image' }],
+    });
+    httpMock.expectOne('/api/embedders').flush({ embedders: [{ name: 'siglip', supports_text: true }] });
+    TestBed.tick();
+    httpMock.expectOne('/api/settings').flush({ semantic_only: semanticOnly });
+    TestBed.tick();
+  }
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('offers all three types and shows the Advanced toggle when unlocked', async () => {
+    await setup(false);
+    expect(component.embedderTypeOptions).toEqual(['semantic', 'patch_semantic', 'structural']);
+    expect(component.showEmbedderTypePicker).toBe(true);
+    expect(component.showAdvancedToggle).toBe(true);
+  });
+
+  it('drops the one-option type picker (and the Advanced toggle) when locked', async () => {
+    await setup(true);
+    expect(component.embedderTypeOptions).toEqual(['semantic']);
+    expect(component.showEmbedderTypePicker).toBe(false);
+    // Nothing else lives under Advanced for this dataset, so the toggle goes too.
+    expect(component.primaryLicenseNotice).toBeNull();
+    expect(component.showAdvancedToggle).toBe(false);
+  });
+
+  it('pins the created detector to semantic when locked', async () => {
+    await setup(true);
+    // Even a stale explicit pick can't escape the lock.
+    component.onEmbedderTypeChange('structural');
+    expect(component.effectiveEmbedderType).toBe('semantic');
+  });
+});

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -15,7 +15,6 @@ import { SettingsStateService } from '../../../services/settings-state.service';
 import {
   EmbedderCapabilityService,
   EMBEDDER_TYPE_LABELS,
-  EMBEDDER_TYPE_ORDER,
   type EmbedderType,
 } from '../../../services/embedder-capability.service';
 import { MediaStateService } from '../../../services/media-state.service';
@@ -431,11 +430,26 @@ export class NewDetectorModalComponent implements OnInit {
     return this.datasetEmbedder() ? [this.datasetEmbedder()] : [];
   }
 
-  /** All three embedder types, in display order — the always-available options
-   *  in the Advanced picker. A detector locks a type as *declared intent*, so
-   *  the choice isn't constrained to what the active dataset (if any) binds. */
+  /** The embedder types offered in the Advanced picker — all three in display
+   *  order normally, Semantic alone on a `semantic_only` server. A detector
+   *  locks a type as *declared intent*, so the choice isn't constrained to what
+   *  the active dataset (if any) binds. */
   get embedderTypeOptions(): EmbedderType[] {
-    return EMBEDDER_TYPE_ORDER;
+    return this.embedderCaps.offeredTypes;
+  }
+
+  /** Whether to render the type picker at all. A one-option picker is a
+   *  question with no answer, so a `semantic_only` server drops it (and the
+   *  "not on this dataset" hint under it) rather than showing a dead select. */
+  get showEmbedderTypePicker(): boolean {
+    return this.embedderTypeOptions.length > 1;
+  }
+
+  /** Whether the Advanced toggle is worth showing. Normally yes (it hosts the
+   *  type picker); on a `semantic_only` server only when there is a license
+   *  notice left to surface, so the block never opens onto nothing. */
+  get showAdvancedToggle(): boolean {
+    return this.showEmbedderTypePicker || !!this.primaryLicenseNotice;
   }
 
   /** The embedder *types* the active dataset supplies, or `[]` when no dataset
@@ -446,8 +460,11 @@ export class NewDetectorModalComponent implements OnInit {
 
   /** The type shown in the picker: the user's explicit pick, else the active
    *  dataset's primary supplied type, else `semantic`. Computed lazily so it
-   *  reflects the dataset/registry as they load (no pre-load race). */
+   *  reflects the dataset/registry as they load (no pre-load race). A
+   *  `semantic_only` server pins it to `semantic`, so a dataset that still
+   *  binds a prototype type can't seed a detector the server would reject. */
   get effectiveEmbedderType(): EmbedderType {
+    if (this.embedderCaps.semanticOnly()) return 'semantic';
     return this.embedderType() || this.datasetSuppliedTypes[0] || 'semantic';
   }
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -435,6 +435,10 @@
             <div class="server-value">{{ settings().max_concurrent_dataset_embeddings ?? '—' }}</div>
           </div>
           <div class="form-group">
+            <label class="form-label" title="When on, this server offers Semantic embedders only: the prototype Patch Semantic and Structural types are hidden from every picker and rejected by the API. Set with --semantic-only, VTSEARCH_SEMANTIC_ONLY, or the semantic_only setting.">Semantic embedders only</label>
+            <div class="server-value">{{ settings().semantic_only ? 'On' : 'Off' }}</div>
+          </div>
+          <div class="form-group">
             <label class="form-label" title="Plugins hidden from pickers and listings for this deployment (still callable by name). Combines the persisted setting with any --hide-plugin CLI flags.">Hidden plugins</label>
             @if (hiddenPluginsDisplay.length > 0) {
               <ul class="server-list">

--- a/frontend/src/app/services/embedder-capability.service.spec.ts
+++ b/frontend/src/app/services/embedder-capability.service.spec.ts
@@ -1,12 +1,16 @@
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Observable, of } from 'rxjs';
 import { EmbedderCapabilityService } from './embedder-capability.service';
 import { DatasetsListingsApiService } from './datasets-listings-api.service';
+import { SettingsStateService } from './settings-state.service';
 import type { EmbedderInfo } from '../models/api.models';
 
 describe('EmbedderCapabilityService', () => {
   let service: EmbedderCapabilityService;
   let getEmbedders: ReturnType<typeof vi.fn>;
+  // Stand-in for SettingsStateService: the service reads only settingsSignal().
+  let settingsSignal: ReturnType<typeof signal<{ semantic_only?: boolean } | null>>;
 
   const infos: EmbedderInfo[] = [
     { name: 'clip', media_type_id: 'image', supports_text: true },
@@ -17,10 +21,12 @@ describe('EmbedderCapabilityService', () => {
 
   beforeEach(() => {
     getEmbedders = vi.fn((): Observable<EmbedderInfo[]> => of(infos));
+    settingsSignal = signal<{ semantic_only?: boolean } | null>(null);
     TestBed.configureTestingModule({
       providers: [
         EmbedderCapabilityService,
         { provide: DatasetsListingsApiService, useValue: { getEmbedders } },
+        { provide: SettingsStateService, useValue: { settingsSignal } },
       ],
     });
     service = TestBed.inject(EmbedderCapabilityService);
@@ -108,6 +114,34 @@ describe('EmbedderCapabilityService', () => {
       expect(service.supportsStructuralAny(['sift'])).toBe(true);
       expect(service.supportsStructuralAny(['dino', 'clip'])).toBe(false);
       expect(service.supportsStructuralAny(null)).toBe(false);
+    });
+  });
+
+  describe('semantic_only lock', () => {
+    it('is off before settings load, so nothing is hidden on missing metadata', () => {
+      expect(service.semanticOnly()).toBe(false);
+      expect(service.offeredTypes).toEqual(['semantic', 'patch_semantic', 'structural']);
+    });
+
+    it('is off when the server reports semantic_only false', () => {
+      settingsSignal.set({ semantic_only: false });
+      expect(service.semanticOnly()).toBe(false);
+      expect(service.offeredTypes).toEqual(['semantic', 'patch_semantic', 'structural']);
+    });
+
+    it('narrows the offered types to Semantic when the server reports the lock', () => {
+      settingsSignal.set({ semantic_only: true });
+      expect(service.semanticOnly()).toBe(true);
+      expect(service.offeredTypes).toEqual(['semantic']);
+    });
+
+    it('does not change how bound embedders are classified', () => {
+      service.ensureLoaded();
+      settingsSignal.set({ semantic_only: true });
+      // A dataset that still binds a prototype embedder keeps its real type;
+      // the lock governs what is *offered*, not how existing data reads.
+      expect(service.embedderType('sift')).toBe('structural');
+      expect(service.suppliedTypes(['clip', 'dino'])).toEqual(['semantic', 'patch_semantic']);
     });
   });
 });

--- a/frontend/src/app/services/embedder-capability.service.ts
+++ b/frontend/src/app/services/embedder-capability.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, inject, signal } from '@angular/core';
+import { Injectable, computed, inject, signal } from '@angular/core';
 
 import { DatasetsListingsApiService } from './datasets-listings-api.service';
+import { SettingsStateService } from './settings-state.service';
 import type { EmbedderInfo } from '../models/api.models';
 
 /**
@@ -36,10 +37,33 @@ export const EMBEDDER_TYPE_ORDER: EmbedderType[] = ['semantic', 'patch_semantic'
 @Injectable({ providedIn: 'root' })
 export class EmbedderCapabilityService {
   private readonly api = inject(DatasetsListingsApiService);
+  private readonly settingsState = inject(SettingsStateService);
 
   /** Loaded embedder metadata, or `null` until the registry resolves. */
   readonly infos = signal<EmbedderInfo[] | null>(null);
   private loading = false;
+
+  /**
+   * Whether this deployment is locked to Semantic embedders (the server-tier
+   * `semantic_only` setting, set with `--semantic-only` /
+   * `VTSEARCH_SEMANTIC_ONLY`). The prototype Patch Semantic and Structural
+   * types are then withheld from `GET /api/embedders` as well, so the concrete
+   * embedder pickers empty out on their own; this flag is what the *type*-level
+   * UI (the New-detector modal's Detector Embedder Type picker) reads, since a
+   * type is declared intent and has no registry entry to filter.
+   *
+   * Defaults to `false` until settings load, so nothing is hidden on missing
+   * metadata.
+   */
+  readonly semanticOnly = computed(() => this.settingsState.settingsSignal()?.semantic_only === true);
+
+  /**
+   * The embedder types this deployment offers as a *choice*: all three
+   * normally, Semantic alone under the lock.
+   */
+  get offeredTypes(): EmbedderType[] {
+    return this.semanticOnly() ? ['semantic'] : EMBEDDER_TYPE_ORDER;
+  }
 
   /** Kick off a one-time load of the embedder registry. Idempotent. */
   ensureLoaded(): void {

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -37,6 +37,7 @@ def _restore_cli_overrides():
         dict(settings_mod._cli_solo_embedders),
         settings_mod._cli_dataset_max_age_days,
         settings_mod._cli_support_email,
+        settings_mod._cli_semantic_only,
     )
     yield
     (
@@ -45,6 +46,7 @@ def _restore_cli_overrides():
         solo_emb,
         settings_mod._cli_dataset_max_age_days,
         settings_mod._cli_support_email,
+        settings_mod._cli_semantic_only,
     ) = saved
     settings_mod._cli_hidden_plugins.clear()
     settings_mod._cli_hidden_plugins.update(hidden)
@@ -616,6 +618,19 @@ class TestApplyOverrides:
         monkeypatch.setattr(cli_main, "_run_server", lambda *a: None)
         _run_main(monkeypatch, ["--support-email", "help@example.com"])
         assert settings_mod.get_cli_support_email() == "help@example.com"
+
+    def test_semantic_only_flag_is_stashed(self, monkeypatch):
+        monkeypatch.setattr(cli_main, "_run_server", lambda *a: None)
+        _run_main(monkeypatch, ["--semantic-only"])
+        assert settings_mod.get_cli_semantic_only() is True
+        assert settings_mod.get_effective_semantic_only() is True
+
+    def test_semantic_only_omitted_leaves_the_setting_in_charge(self, monkeypatch):
+        """No flag means no override: the persisted server setting decides, so
+        a deployment can turn the lock on from settings.json alone."""
+        monkeypatch.setattr(cli_main, "_run_server", lambda *a: None)
+        _run_main(monkeypatch, [])
+        assert settings_mod.get_cli_semantic_only() is None
 
 
 class TestApplyVerbosity:

--- a/tests/core/test_semantic_only.py
+++ b/tests/core/test_semantic_only.py
@@ -110,7 +110,12 @@ class TestDetectorCreateRejection:
         settings_mod.set_cli_semantic_only(True)
         resp = client.post(
             "/api/detectors",
-            json={"name": "locked-structural", "media_type": "image", "text_query": "a dog", "embedder_type": "structural"},
+            json={
+                "name": "locked-structural",
+                "media_type": "image",
+                "text_query": "a dog",
+                "embedder_type": "structural",
+            },
         )
         assert resp.status_code == 400
         assert "Semantic" in resp.get_json()["message"]
@@ -119,7 +124,12 @@ class TestDetectorCreateRejection:
         settings_mod.set_cli_semantic_only(True)
         resp = client.post(
             "/api/detectors",
-            json={"name": "locked-patch", "media_type": "image", "text_query": "a dog", "embedder_type": "patch_semantic"},
+            json={
+                "name": "locked-patch",
+                "media_type": "image",
+                "text_query": "a dog",
+                "embedder_type": "patch_semantic",
+            },
         )
         assert resp.status_code == 400
 
@@ -134,7 +144,12 @@ class TestDetectorCreateRejection:
     def test_structural_detector_allowed_when_unlocked(self, client):
         resp = client.post(
             "/api/detectors",
-            json={"name": "unlocked-structural", "media_type": "image", "text_query": "a dog", "embedder_type": "structural"},
+            json={
+                "name": "unlocked-structural",
+                "media_type": "image",
+                "text_query": "a dog",
+                "embedder_type": "structural",
+            },
         )
         assert resp.status_code == 201
 

--- a/tests/core/test_semantic_only.py
+++ b/tests/core/test_semantic_only.py
@@ -1,0 +1,185 @@
+"""Tests for the server-tier ``semantic_only`` embedder-type lock.
+
+Covers the persisted server-tier value, the process-level override set by
+``--semantic-only`` / ``VTSEARCH_SEMANTIC_ONLY`` (``set_cli_semantic_only``),
+the resolver (``get_effective_semantic_only``), the API contract (read-only:
+exposed in ``GET /api/settings`` but not settable via ``PUT``), the
+``GET /api/embedders`` filter, and the route-level rejection of a
+patch/structural embedder or detector type (issue #2696).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import app as app_module  # noqa: F401  (triggers conftest media init)
+from vtsearch import settings as settings_mod
+from vtsearch.schemas.settings import AppSettingsSchema, SettingsUpdateSchema
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_semantic_only():
+    """The CLI/env override is process-global; clear it around each test."""
+    settings_mod.set_cli_semantic_only(None)
+    yield
+    settings_mod.set_cli_semantic_only(None)
+
+
+class TestEffectiveResolution:
+    def test_default_is_off(self):
+        assert settings_mod.get_effective_semantic_only() is False
+
+    def test_cli_override_wins_over_persisted(self, isolated_settings):
+        settings_mod.set_semantic_only(False)
+        settings_mod.set_cli_semantic_only(True)
+        assert settings_mod.get_effective_semantic_only() is True
+
+    def test_falls_back_to_persisted_when_no_override(self, isolated_settings):
+        settings_mod.set_semantic_only(True)
+        assert settings_mod.get_cli_semantic_only() is None
+        assert settings_mod.get_effective_semantic_only() is True
+
+    def test_override_clears_back_to_persisted(self, isolated_settings):
+        settings_mod.set_semantic_only(True)
+        settings_mod.set_cli_semantic_only(False)
+        assert settings_mod.get_effective_semantic_only() is False
+        settings_mod.set_cli_semantic_only(None)
+        assert settings_mod.get_effective_semantic_only() is True
+
+
+class TestApiContract:
+    def test_not_settable_via_put(self, client, isolated_settings):
+        """A PUT body carrying semantic_only is silently ignored: the update
+        schema excludes it, so it never reaches a setter."""
+        resp = client.put("/api/settings", json={"semantic_only": True})
+        assert resp.status_code == 200
+        assert settings_mod.get_semantic_only() is False
+
+    def test_get_reflects_effective_value(self, client):
+        settings_mod.set_cli_semantic_only(True)
+        assert client.get("/api/settings").get_json()["semantic_only"] is True
+
+    def test_get_reflects_default(self, client):
+        assert client.get("/api/settings").get_json()["semantic_only"] is False
+
+    def test_schema_marks_it_read_only(self):
+        # Dumpable (so the New-detector modal can drop its type picker) but not
+        # loadable (set via CLI/env/file, never PUT).
+        assert AppSettingsSchema().fields["semantic_only"].dump_only is True
+        assert "semantic_only" not in SettingsUpdateSchema().fields
+
+
+class TestEmbeddersListing:
+    """``GET /api/embedders`` is the chokepoint every picker reads."""
+
+    @staticmethod
+    def _names(client, **params) -> list[str]:
+        resp = client.get("/api/embedders", query_string=params)
+        assert resp.status_code == 200
+        return [e["name"] for e in resp.get_json()["embedders"]]
+
+    def test_prototypes_listed_when_unlocked(self, client):
+        names = self._names(client, media_type="image")
+        assert "dinov3_patch" in names
+        assert "sift_vlad" in names
+
+    def test_prototypes_withheld_when_locked(self, client):
+        settings_mod.set_cli_semantic_only(True)
+        names = self._names(client, media_type="image")
+        assert "dinov3_patch" not in names
+        assert "sift_vlad" not in names
+        # ...but the Semantic image embedders are all still on offer.
+        assert "siglip" in names
+
+    def test_lock_applies_to_the_unfiltered_listing_too(self, client):
+        settings_mod.set_cli_semantic_only(True)
+        names = self._names(client)
+        assert not {"dinov2_patch", "dinov3_patch", "eupe_patch", "sift_vlad"} & set(names)
+        assert "clap" in names
+
+    def test_semantic_only_media_types_are_untouched(self, client):
+        """Audio/text/video bind no prototype embedder, so the lock is a no-op
+        for them - the pickers there must not shrink."""
+        before = self._names(client, media_type="audio")
+        settings_mod.set_cli_semantic_only(True)
+        assert self._names(client, media_type="audio") == before
+
+
+class TestDetectorCreateRejection:
+    def test_structural_detector_rejected_when_locked(self, client):
+        settings_mod.set_cli_semantic_only(True)
+        resp = client.post(
+            "/api/detectors",
+            json={"name": "locked-structural", "media_type": "image", "text_query": "a dog", "embedder_type": "structural"},
+        )
+        assert resp.status_code == 400
+        assert "Semantic" in resp.get_json()["message"]
+
+    def test_patch_detector_rejected_when_locked(self, client):
+        settings_mod.set_cli_semantic_only(True)
+        resp = client.post(
+            "/api/detectors",
+            json={"name": "locked-patch", "media_type": "image", "text_query": "a dog", "embedder_type": "patch_semantic"},
+        )
+        assert resp.status_code == 400
+
+    def test_semantic_detector_still_allowed_when_locked(self, client):
+        settings_mod.set_cli_semantic_only(True)
+        resp = client.post(
+            "/api/detectors",
+            json={"name": "locked-semantic", "media_type": "image", "text_query": "a dog", "embedder_type": "semantic"},
+        )
+        assert resp.status_code == 201
+
+    def test_structural_detector_allowed_when_unlocked(self, client):
+        resp = client.post(
+            "/api/detectors",
+            json={"name": "unlocked-structural", "media_type": "image", "text_query": "a dog", "embedder_type": "structural"},
+        )
+        assert resp.status_code == 201
+
+
+class TestImportRejection:
+    """A hand-rolled import must not bind a type the pickers hide."""
+
+    def test_patch_embedder_rejected_when_locked(self, client):
+        settings_mod.set_cli_semantic_only(True)
+        resp = client.post(
+            "/api/dataset/import/server_folder",
+            json={
+                "path": "/tmp/whatever",
+                "media_type": "image",
+                "embedder": "siglip",
+                "embedders": ["siglip", "dinov3_patch"],
+            },
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert "dinov3_patch" in body["message"]
+
+    def test_structural_primary_embedder_rejected_when_locked(self, client):
+        settings_mod.set_cli_semantic_only(True)
+        resp = client.post(
+            "/api/dataset/import/server_folder",
+            json={"path": "/tmp/whatever", "media_type": "image", "embedder": "sift_vlad"},
+        )
+        assert resp.status_code == 400
+        assert "sift_vlad" in resp.get_json()["message"]
+
+    def test_semantic_embedder_passes_the_gate_when_locked(self):
+        """The Semantic path is untouched by the lock. Asserted against the
+        guard directly rather than through the route, so the request doesn't
+        start a real background import just to prove it wasn't rejected."""
+        from vtsearch.routes._shared import abort_if_semantic_only_embedders
+
+        settings_mod.set_cli_semantic_only(True)
+        # No raise == not rejected. Unknown names are left to their own
+        # downstream validation, so they pass the gate too.
+        abort_if_semantic_only_embedders(["siglip", "clap", ""])
+        abort_if_semantic_only_embedders([])
+        abort_if_semantic_only_embedders(["not_a_registered_embedder"])
+
+    def test_guard_is_a_no_op_when_unlocked(self):
+        from vtsearch.routes._shared import abort_if_semantic_only_embedders
+
+        abort_if_semantic_only_embedders(["sift_vlad", "dinov3_patch"])

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -309,6 +309,23 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--semantic-only",
+        action="store_true",
+        default=False,
+        dest="semantic_only",
+        help=(
+            "Lock this instance to Semantic embedders. The prototype Patch "
+            "Semantic and Structural embedder types are dropped from "
+            "/api/embedders (so no Region / Instance embedder picker appears "
+            "under Add Dataset > Advanced), the New-detector modal offers no "
+            "embedder-type choice, and any request that asks for a "
+            "patch/structural embedder is rejected with 400. Applies to all "
+            "users and overrides any persisted semantic_only in the settings "
+            "file for the lifetime of the process; the value is not editable "
+            "via the settings API."
+        ),
+    )
+    parser.add_argument(
         "--progress-format",
         type=str,
         default="text",
@@ -543,6 +560,20 @@ def _apply_support_email(args, parser) -> None:
         from vtsearch.settings import set_cli_support_email
 
         set_cli_support_email(email)
+
+
+def _apply_semantic_only(args, parser) -> None:
+    """Stash the process-level ``--semantic-only`` lock."""
+    # --semantic-only is a one-way switch: passing it locks the process to
+    # Semantic embedders, omitting it leaves the persisted server setting in
+    # charge (so a deployment can enable the lock from settings.json without
+    # the flag). There is no --no-semantic-only counterpart for the same
+    # reason --hide-plugin can only add hides: a flag should not silently
+    # loosen a restriction the settings file asked for.
+    if getattr(args, "semantic_only", False):
+        from vtsearch.settings import set_cli_semantic_only
+
+        set_cli_semantic_only(True)
 
 
 def _authenticate_cli_user(args, parser) -> None:
@@ -813,6 +844,7 @@ def main(app, initialize_server) -> None:
     _apply_solo_embedders(args, parser)
     _apply_dataset_max_age(args, parser)
     _apply_support_email(args, parser)
+    _apply_semantic_only(args, parser)
 
     if args.autodetect:
         _run_autodetect(args, parser, importer, exporter)

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -634,6 +634,56 @@ def get_embedder_for_medias(media_dict: dict):
     return avail[0] if avail else None
 
 
+#: Message used by both Semantic-lock guards below, so the API surfaces one
+#: consistent explanation whichever route the request hit.
+SEMANTIC_ONLY_MESSAGE = (
+    "This server is locked to Semantic embedders (semantic_only). "
+    "Patch Semantic and Structural embedders are unavailable here."
+)
+
+
+def abort_if_semantic_only_type(embedder_type: str) -> None:
+    """Reject a non-Semantic detector *embedder_type* on a Semantic-locked server.
+
+    The type is the detector's declared intent, so this is the one gate that
+    keeps a hand-rolled ``POST /api/detectors`` (or a portable bundle carrying a
+    Structural detector) from creating a detector this deployment can never
+    run. Empty / ``"semantic"`` pass through untouched, as does every request
+    when the lock is off.
+    """
+    if not embedder_type or embedder_type == "semantic":
+        return
+    from vtsearch.settings import get_effective_semantic_only  # noqa: PLC0415 - avoid import cycle
+
+    if get_effective_semantic_only():
+        abort(400, message=SEMANTIC_ONLY_MESSAGE)
+
+
+def abort_if_semantic_only_embedders(embedder_names) -> None:
+    """Reject patch / structural *embedder_names* on a Semantic-locked server.
+
+    Guards the dataset-load routes, whose ``embedders`` trio arrives straight
+    from the client: the pickers never offer a prototype embedder under the
+    lock (``GET /api/embedders`` filters them out), so a request that names one
+    is either stale or hand-rolled and should fail loudly rather than quietly
+    binding a type the rest of the UI hides. Unknown names are left alone --
+    they fail their own validation downstream.
+    """
+    names = [n for n in (embedder_names or ()) if n]
+    if not names:
+        return
+    from vtsearch.settings import get_effective_semantic_only  # noqa: PLC0415 - avoid import cycle
+
+    if not get_effective_semantic_only():
+        return
+
+    from vtscore.embedding.binding import embedder_type as _classify  # noqa: PLC0415
+
+    offenders = sorted({n for n in names if _classify(n) in ("patch_semantic", "structural")})
+    if offenders:
+        abort(400, message=f"{SEMANTIC_ONLY_MESSAGE} Rejected: {', '.join(offenders)}.")
+
+
 def _scrub_server_paths(text: str) -> str:
     """Rewrite absolute paths under the server data dir to be relative to it.
 

--- a/vtsearch/routes/datasets/listings.py
+++ b/vtsearch/routes/datasets/listings.py
@@ -14,7 +14,11 @@ from flask_smorest import Blueprint
 from vtscore.datasets import list_importers
 from vtscore.datasets.registry import list_datasets as _reg_list_all
 from vtsearch.routes.datasets._helpers import _normalize_media_type_param
-from vtsearch.settings import filter_visible_plugin_dicts, filter_visible_plugins
+from vtsearch.settings import (
+    filter_semantic_only_embedder_dicts,
+    filter_visible_plugin_dicts,
+    filter_visible_plugins,
+)
 from vtsearch.schemas.datasets import (
     ClippersListQuerySchema,
     ClippersListResponseSchema,
@@ -49,6 +53,11 @@ def media_types_list():
 def embedders_list(query: dict):
     """Return all registered embedders, optionally filtered by media type.
 
+    Two deployment-level hides apply on top of that filter: the admin's
+    ``hidden_plugins`` / ``--hide-plugin`` list, and the ``semantic_only``
+    lock (``--semantic-only``), which withholds every patch / structural
+    embedder so the prototype types never reach a picker.
+
     Query parameters:
         media_type: A ``type_id`` (e.g. ``"image"``) or ``folder_import_name``
             (e.g. ``"images"``).  When provided, only embedders whose
@@ -62,7 +71,7 @@ def embedders_list(query: dict):
     else:
         embedders = filter_visible_plugin_dicts("embedders", all_embedders_dict())
 
-    return {"embedders": embedders}
+    return {"embedders": filter_semantic_only_embedder_dicts(embedders)}
 
 
 @datasets_listings_bp.route("/api/clippers")

--- a/vtsearch/routes/datasets/load.py
+++ b/vtsearch/routes/datasets/load.py
@@ -39,7 +39,11 @@ from vtscore.datasets.load_pipeline import (
     _run_origin_load_in_background,
 )
 from vtscore.datasets.registry import remove_loaded_id as _reg_remove_loaded
-from vtsearch.routes._shared import format_exception_detail, require_dataset_header
+from vtsearch.routes._shared import (
+    abort_if_semantic_only_embedders,
+    format_exception_detail,
+    require_dataset_header,
+)
 from vtsearch.routes.datasets._helpers import _safe_relative_upload_path
 from vtsearch.schemas.datasets import (
     DatasetClearResponseSchema,
@@ -71,10 +75,15 @@ def _parse_form_embedders(form, primary: str) -> list[str] | None:
     array string under ``embedders``.  Returns ``None`` when absent (the caller
     falls back to the single ``embedder`` field).  The *primary* embedder leads
     the list even if the client omitted it from the array.
+
+    Doubles as the Semantic-lock gate for the two local-upload routes: a
+    ``semantic_only`` instance rejects (400) a request naming a patch or
+    structural embedder, which its own pickers never offer.
     """
     embedders = _parse_embedder_list(form.get("embedders"))
     if embedders and primary and primary not in embedders:
         embedders = [primary, *embedders]
+    abort_if_semantic_only_embedders(embedders or [primary])
     return embedders
 
 
@@ -395,6 +404,7 @@ def load_demo_dataset_route(body: dict):
     demo_embedders = body.get("embedders")
     if demo_embedders:
         field_values["embedders"] = demo_embedders
+    abort_if_semantic_only_embedders([embedder_name, *(_parse_embedder_list(demo_embedders) or [])])
 
     task_id = _run_importer_in_background(importer, field_values)
     return {"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""}

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -46,6 +46,7 @@ from vtscore.datasets.registry import (
 from vtsearch.auth import get_current_user
 from vtsearch.routes._shared import (
     _normalise_option,
+    abort_if_semantic_only_embedders,
     get_plugin_or_404,
     register_plugin_typed_routes,
     validate_plugin_args,
@@ -106,6 +107,20 @@ def _bound_embedders_for_path(path: str) -> list[str]:
         return [str(n) for n in bound if n]
     emb = entry.get("embedder")
     return [emb] if emb else []
+
+
+def _abort_if_semantic_only(field_values: dict) -> None:
+    """400 when *field_values* names a patch/structural embedder under the lock.
+
+    Covers both slots the importer body can carry: the scalar ``embedder``
+    (primary) and the ``embedders`` trio, which arrives as a JSON array string
+    on multipart bodies and a real list on JSON ones.
+    """
+    from vtscore.datasets.load_pipeline import _parse_embedder_list  # noqa: PLC0415
+
+    names = [str(field_values.get("embedder") or "")]
+    names.extend(_parse_embedder_list(field_values.get("embedders")) or [])
+    abort_if_semantic_only_embedders(names)
 
 
 @datasets_staging_bp.route("/api/dataset/combine", methods=["POST"])
@@ -650,6 +665,11 @@ def import_dataset(importer_name: str):
             "merge_near_duplicates",
         ),
     )
+
+    # A Semantic-locked instance never offers a patch/structural embedder in a
+    # picker, so an import that names one is stale or hand-rolled: reject it
+    # here rather than binding a type the rest of the UI hides.
+    _abort_if_semantic_only(field_values)
 
     # ``clipper_params`` is multipart-encoded as a JSON string when the
     # importer has file fields; the per-plugin schema treats it as an

--- a/vtsearch/routes/detectors/crud.py
+++ b/vtsearch/routes/detectors/crud.py
@@ -142,10 +142,12 @@ def create_detector(body: dict):
         abort(409, message=f"A detector named '{name}' already exists")
 
     from vtscore.detectors.embedder_type import resolve_detector_embedder_type
+    from vtsearch.routes._shared import abort_if_semantic_only_type
 
     embedder_type, type_err = resolve_detector_embedder_type(body.get("embedder_type", ""))
     if type_err:
         abort(400, message=type_err)
+    abort_if_semantic_only_type(embedder_type)
 
     # Build examples list; if text_query/media_example provided without
     # explicit examples, create a single example from it for backward compat.

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -160,10 +160,12 @@ def register_detector_route(body: dict):
         abort(400, message="media_type is required (must be a specific type, not 'any')")
 
     from vtscore.detectors.embedder_type import resolve_detector_embedder_type
+    from vtsearch.routes._shared import abort_if_semantic_only_type
 
     embedder_type, type_err = resolve_detector_embedder_type(body.get("embedder_type", ""))
     if type_err:
         abort(400, message=type_err)
+    abort_if_semantic_only_type(embedder_type)
 
     examples = body.get("examples") or []
     if not examples and text_query:
@@ -227,6 +229,7 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
     from vtscore.labels.importers import get_label_importer, list_label_importers
     from vtscore.detectors.registry import register_detector, update_detector
     from vtsearch.routes._shared import (
+        abort_if_semantic_only_type,
         get_plugin_or_404,
         run_plugin_or_error,
         validate_plugin_args,
@@ -252,6 +255,7 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
     embedder_type_val, type_err = resolve_detector_embedder_type(requested_type)
     if type_err:
         abort(400, message=type_err)
+    abort_if_semantic_only_type(embedder_type_val)
 
     det_path = _detector_path(name)
     if det_path.exists():

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -209,6 +209,10 @@ def _with_effective(data: dict) -> dict:
     # Surface the CLI/env-overridable "Email us" recipient as the value
     # actually in force, so the Help modal's mailto link is pre-addressed.
     data["support_email"] = settings.get_effective_support_email()
+    # Surface the CLI/env-overridable Semantic-only lock as the value actually
+    # in force, so the New-detector modal can drop its embedder-type picker and
+    # the Server settings tab can report the restriction.
+    data["semantic_only"] = settings.get_effective_semantic_only()
     return data
 
 

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -164,6 +164,13 @@ class AppSettingsSchema(Schema):
     # can build a pre-addressed ``mailto:`` link. Not in
     # ``SettingsUpdateSchema`` - not editable via PUT.
     support_email = fields.String(dump_only=True)
+    # Server-tier "Semantic embedders only" lock. Set via the
+    # ``--semantic-only`` CLI flag / ``VTSEARCH_SEMANTIC_ONLY`` env var
+    # (process-wide, all users) or the persisted settings file; surfaced
+    # read-only here so the New-detector modal can hide its embedder-type
+    # picker and the Server settings tab can report the restriction. Not in
+    # ``SettingsUpdateSchema`` - not editable via PUT.
+    semantic_only = fields.Boolean(dump_only=True)
 
     # Auto-Find (per-user, editable from the Auto-Find settings tab).
     # ``autofind_detectors`` is each user's own list of detectors that auto-run

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -107,6 +107,8 @@ if TYPE_CHECKING:
     def set_dataset_max_age_days(value: int | None) -> None: ...
     def get_support_email() -> str: ...
     def set_support_email(value: str) -> None: ...
+    def get_semantic_only() -> bool: ...
+    def set_semantic_only(value: bool) -> None: ...
     def get_projection_n_neighbors() -> int: ...
     def set_projection_n_neighbors(value: int) -> None: ...
     def get_projection_min_dist() -> float: ...
@@ -196,6 +198,15 @@ _cli_dataset_max_age_days: int | None = None
 #: of the process; the setting is not user-editable via the API (see
 #: :func:`get_effective_support_email`).
 _cli_support_email: str | None = None
+
+#: Process-level override for the server-tier ``semantic_only`` setting, set by
+#: :func:`set_cli_semantic_only` from the ``--semantic-only`` flag (or the
+#: ``VTSEARCH_SEMANTIC_ONLY`` env var) in :mod:`app`. ``None`` means "no CLI
+#: override" - reads fall through to the persisted server setting. ``True``
+#: locks the instance to Semantic embedders for the lifetime of the process;
+#: the setting is not user-editable via the API (see
+#: :func:`get_effective_semantic_only`).
+_cli_semantic_only: bool | None = None
 
 #: Filename used for the per-user settings file inside
 #: ``get_user_data_dir(user)``.
@@ -1008,6 +1019,45 @@ def get_effective_support_email() -> str:
     return get_support_email()  # type: ignore[name-defined]  # autogen'd accessor
 
 
+def set_cli_semantic_only(value: bool | None) -> None:
+    """Set the process-level override for the ``semantic_only`` setting.
+
+    Called once from ``app.py`` startup when ``--semantic-only`` is passed (or
+    ``VTSEARCH_SEMANTIC_ONLY`` is set). The value applies server-wide (every
+    user) and is fixed for the process lifetime;
+    :func:`get_effective_semantic_only` returns it in preference to the
+    persisted server setting. Pass ``None`` to clear the override so reads fall
+    back to the persisted file value.
+    """
+    global _cli_semantic_only
+    _cli_semantic_only = None if value is None else bool(value)
+
+
+def get_cli_semantic_only() -> bool | None:
+    """Return the process-level CLI override (``None`` if unset)."""
+    return _cli_semantic_only
+
+
+def get_effective_semantic_only() -> bool:
+    """Return whether this instance is locked to Semantic embedders.
+
+    Resolution order:
+
+    1. The process-level CLI override set by :func:`set_cli_semantic_only`
+       (``--semantic-only`` / ``VTSEARCH_SEMANTIC_ONLY``), which applies to
+       every user for the lifetime of the process.
+    2. The persisted server-tier setting (``data/settings.json``), which
+       defaults to ``False``.
+
+    When true, the prototype Patch Semantic / Structural embedder types are
+    hidden from every picker (``GET /api/embedders`` filters them out) and
+    rejected by the dataset-load and detector-create routes.
+    """
+    if _cli_semantic_only is not None:
+        return _cli_semantic_only
+    return bool(get_semantic_only())  # type: ignore[name-defined]  # autogen'd accessor
+
+
 def set_cli_solo_embedder(media_type: str, embedder: str | None) -> None:
     """Set or clear a process-level solo-embedder fallback for *media_type*.
 
@@ -1277,6 +1327,24 @@ def filter_visible_plugin_dicts(
     if not hidden:
         return list(plugin_dicts)
     return [d for d in plugin_dicts if d.get(id_key) not in hidden]
+
+
+def filter_semantic_only_embedder_dicts(embedder_dicts: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop patch / structural embedders when the instance is Semantic-locked.
+
+    The single chokepoint for ``GET /api/embedders``: with
+    :func:`get_effective_semantic_only` true, an embedder that advertises
+    ``supports_patch_regions`` or ``supports_geometric_verification`` is
+    withheld from the listing, so every picker fed by that endpoint (the Add
+    Dataset "Advanced" block's Embedder / Region embedder / Instance embedder
+    selects, the Import Defaults tab) offers Semantic embedders only.
+
+    A no-op when the lock is off, so the ordinary deployment pays one boolean.
+    """
+    dicts = list(embedder_dicts)
+    if not get_effective_semantic_only():
+        return dicts
+    return [d for d in dicts if not d.get("supports_patch_regions") and not d.get("supports_geometric_verification")]
 
 
 # -------------------------------------------------------------------

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -251,6 +251,20 @@ class ServerSettings(BaseModel):
     # :func:`vtsearch.settings.get_effective_support_email`.
     support_email: str = DEFAULT_SUPPORT_EMAIL
 
+    # Lock this deployment to **Semantic** embedders only.  The Patch Semantic
+    # and Structural embedder types are still prototypes; an operator running a
+    # production instance can hide them wholesale rather than naming each
+    # prototype embedder in ``hidden_plugins``.  When true, ``GET
+    # /api/embedders`` drops every patch/structural embedder (so the Add Dataset
+    # "Advanced" block shows no Region / Instance embedder pickers), the
+    # New-detector modal offers no embedder-type choice, and the dataset-load /
+    # detector-create routes reject a non-semantic type outright.  Set with the
+    # ``--semantic-only`` CLI flag / ``VTSEARCH_SEMANTIC_ONLY`` env var
+    # (process-wide, wins for the process lifetime) or by editing this key in
+    # the settings file.  See
+    # :func:`vtsearch.settings.get_effective_semantic_only`.
+    semantic_only: bool = False
+
     # Browse UMAP projection knobs (Stage 1).  They change the map layout, so
     # a per-deployment operator may want to tune them.  The persisted
     # projection is keyed on these values (see


### PR DESCRIPTION
Closes #2696

Structural and Patch Semantic are still prototypes, and on a production instance they clutter the Add Dataset ▸ Advanced block ("Region embedder", "Instance embedder") and the New-detector modal's type picker. An operator could already hide them one at a time with `--hide-plugin embedders:<name>`, but that means knowing which embedders belong to the prototype tier and keeping the list current. This adds one switch that removes the tier wholesale.

## Admin surface

A new server-tier setting, `semantic_only`, reachable three ways (CLI wins, then env, then the settings file) — the same shape as `--dataset-max-age-days` / `--support-email`:

```bash
python app.py --semantic-only          # or VTSEARCH_SEMANTIC_ONLY=1, or semantic_only: true
```

It's read-only over the API (`dump_only`, so `PUT /api/settings` can't touch it) and reported in Settings ▸ Server as "Semantic embedders only: On/Off", alongside Hidden plugins. Startup logs the lock and where it came from. There is deliberately no `--no-semantic-only`: like `--hide-plugin`, the flag can only tighten, so a stray flag can't loosen a restriction the settings file asked for.

## What the lock does

- **`GET /api/embedders`** withholds every embedder advertising `supports_patch_regions` or `supports_geometric_verification`. That one chokepoint feeds every picker, so the Region / Instance embedder selects disappear on their own (their option lists empty out) and the primary Embedder select lists Semantic embedders only. Media types with no prototype embedder (audio, text, video) are untouched.
- **New-detector modal** drops the "Detector Embedder Type" picker — one option is not a choice — and the Advanced toggle with it when there's no license notice left to show. `effectiveEmbedderType` is pinned to `semantic`, so a dataset that still binds a prototype type can't seed a detector the server would reject.
- **Server-side enforcement**, so the lock holds against a stale client or a hand-rolled request rather than being UI-deep: detector create / import (`POST /api/detectors`, `/api/detectors/registry`, the label-importer path) reject a non-semantic `embedder_type` with 400, and the dataset-import routes (`/api/dataset/import/<name>`, the two local-upload routes, load-demo) reject a patch/structural name in `embedder` / `embedders` with 400 naming the offender.

Classification of *existing* data is untouched: a dataset that already binds a prototype embedder keeps its real type. The lock governs what is offered, not how stored data reads.

## Notes

- `initialize_server` grew past the complexity gate with a third env-override block, so the three blocks are now `_apply_env_dataset_max_age` / `_apply_env_support_email` / `_apply_env_semantic_only`. No behaviour change to the first two.
- Docs: `docs/CLI.md` gets a section next to `--support-email`; `docs/ARCHITECTURE.md`'s server-tier settings list gains the key.
- No screenshot reshoots needed — every UI change is either on the Server settings tab (not framed by a shot) or only visible with the lock on, which is not the default.

## Testing

`./run-tests.sh` — 6660 passed, 1 skipped; frontend gate green (1786 Vitest tests, `build:prod` clean, pyright/ruff/deptry/pip-audit/OpenAPI-snapshot all clean).

New coverage in `tests/core/test_semantic_only.py` (resolution order, read-only API contract, the embedders-listing filter, and the detector/import rejections), `tests/cli/test_cli_main.py` (flag parsing, and that omitting it leaves the persisted setting in charge), plus specs for `EmbedderCapabilityService.offeredTypes` and the New-detector modal's gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9cAfWsmeQm2hH5DRjg94H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9cAfWsmeQm2hH5DRjg94H)_