### PR TITLE
Export falls back to the on-disk labelset for origin-only elements

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3703,6 +3703,10 @@
           "origin_name": {
             "type": "string"
           },
+          "origin_only": {
+            "description": "True when the entry was rendered straight from the detector's persisted labelset because its media doesn't resolve into the active dataset; absent for vote-derived entries.",
+            "type": "boolean"
+          },
           "region_box": {
             "items": {
               "type": "number"
@@ -13061,7 +13065,7 @@
     },
     "/api/labels/export": {
       "get": {
-        "description": "Each label entry includes the element's ``origin`` and ``origin_name``\nso consumers know exactly where each labeled element came from. The\nformat is a superset of the legacy export format; old consumers\nthat only read ``md5`` and ``label`` keys continue to work unchanged.",
+        "description": "Each label entry includes the element's ``origin`` and ``origin_name``\nso consumers know exactly where each labeled element came from. The\nformat is a superset of the legacy export format; old consumers\nthat only read ``md5`` and ``label`` keys continue to work unchanged.\n\nThe payload is composed from the session's votes intersected with the\nactive dataset, then topped up with persisted labelset elements that\ndon't resolve into the active dataset (marked ``origin_only: true``) so\nthe export is always a faithful rendering of the detector's labelset -\nsee :func:`_origin_only_fallback_entries`.",
         "operationId": "export_labels",
         "parameters": [
           {
@@ -13075,7 +13079,7 @@
             }
           },
           {
-            "description": "Filter mode: ``good``, ``bad``, ``both`` (default), ``corrections`` (entries where the user changed the detector's original label), ``unverified`` (Find work-queue items the human hasn't acted on), or ``verified`` (items the human has confirmed). Overrides ``goods_only``.",
+            "description": "Filter mode: ``good``, ``bad``, ``both`` (default), ``corrections`` (entries where the user changed the detector's original label), ``unverified`` (Find work-queue items the human hasn't acted on), or ``verified`` (items the human has confirmed). Overrides ``goods_only``. The session-scoped filters (``corrections`` / ``unverified`` / ``verified``) never include ``origin_only`` fallback entries.",
             "in": "query",
             "name": "label_filter",
             "required": false,

--- a/tests/io/test_labels.py
+++ b/tests/io/test_labels.py
@@ -407,7 +407,9 @@ class TestExportOriginOnlyFallback:
             },
         )
         det_ctx = get_active_detector_context()
-        path = _detector_path(get_detector(detector_id)["name"])
+        entry = get_detector(detector_id)
+        assert entry is not None
+        path = _detector_path(entry["name"])
         det_ctx.cached_labelset_mtime = path.stat().st_mtime
 
         data = client.get("/api/labels/export").get_json()

--- a/tests/io/test_labels.py
+++ b/tests/io/test_labels.py
@@ -1,6 +1,9 @@
 import json
 
+import pytest
+
 import app as app_module
+from tests import load_detector_and_wait as _load_detector_and_wait
 
 
 def _read_ndjson(resp):
@@ -241,3 +244,184 @@ class TestImportLabels:
             assert 2 in app_module.good_votes
         finally:
             app_module.medias[2]["md5"] = original_md5
+
+
+class TestExportOriginOnlyFallback:
+    """Persisted labelset elements that don't resolve into the active dataset
+    still export, marked ``origin_only`` (issue #2702).
+
+    The export route composes from cid-keyed votes ∩ active medias; these
+    tests plant elements in the detector's on-disk labelset whose origin/md5
+    match nothing loaded, and verify they surface in the export instead of
+    silently vanishing.
+    """
+
+    GHOST_GOOD = {
+        "md5": "f" * 32,
+        "label": "good",
+        "origin": {"importer": "test", "params": {"shard": "elsewhere"}},
+        "origin_name": "ghost_good.wav",
+        "filename": "ghost_good.wav",
+        "category": "elsewhere",
+        "metadata": {"contentID": "c-123"},
+    }
+    GHOST_BAD = {
+        "md5": "e" * 32,
+        "label": "bad",
+        "origin": {"importer": "test", "params": {"shard": "elsewhere"}},
+        "origin_name": "ghost_bad.wav",
+        "filename": "ghost_bad.wav",
+        "category": "elsewhere",
+    }
+
+    def _setup_detector(self, client, with_votes=True):
+        """Create + load a registry detector; optionally cast one good + one bad vote.
+
+        Returns ``(detector_id, good_cid, bad_cid)``.
+        """
+        from vtsearch.state import medias
+
+        if len(medias) < 2:
+            pytest.skip("Need at least 2 medias")
+        ids = list(medias.keys())
+        good_cid, bad_cid = ids[0], ids[1]
+
+        client.post(
+            "/api/detectors",
+            json={"name": "OriginOnlyExport", "media_type": "audio", "text_query": "test"},
+        )
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "OriginOnlyExport", "media_type": "audio", "text_query": "test"},
+        )
+        detector_id = res.get_json()["detector"]["id"]
+        _load_detector_and_wait(client, detector_id)
+
+        if with_votes:
+            client.post(f"/api/medias/{good_cid}/vote", json={"target": "good"})
+            client.post(f"/api/medias/{bad_cid}/vote", json={"target": "bad"})
+        return detector_id, good_cid, bad_cid
+
+    def _inject_elements(self, detector_id, *elements):
+        """Append raw label entries to the detector's on-disk labelset."""
+        from vtscore.detectors.dataset_sync import reset_mtime_cache_for_tests
+        from vtscore.detectors.registry import get_detector
+        from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
+
+        entry = get_detector(detector_id)
+        assert entry is not None
+        path = _detector_path(entry["name"])
+        data = _read_detector(path)
+        assert data is not None
+        labelset = data.get("labelset") or {"labels": []}
+        labelset.setdefault("labels", []).extend(dict(e) for e in elements)
+        data["labelset"] = labelset
+        _write_detector(path, data)
+        # Drop the TTL-cached mtime so the next request's rehydrate sees the
+        # write immediately.
+        reset_mtime_cache_for_tests()
+
+    def test_unresolvable_element_exports_with_origin_only_flag(self, client):
+        detector_id, good_cid, bad_cid = self._setup_detector(client)
+        self._inject_elements(detector_id, self.GHOST_GOOD)
+
+        data = client.get("/api/labels/export").get_json()
+        by_name = {e.get("origin_name"): e for e in data["labels"]}
+        ghost = by_name.get("ghost_good.wav")
+        assert ghost is not None, f"origin-only element missing from export: {list(by_name)}"
+        assert ghost["origin_only"] is True
+        assert ghost["label"] == "good"
+        # Vote-derived entries stay unmarked.
+        vote_derived = [e for e in data["labels"] if e.get("origin_name") != "ghost_good.wav"]
+        assert len(vote_derived) >= 2
+        assert all("origin_only" not in e for e in vote_derived)
+
+    def test_export_of_fully_nonoverlapping_labelset(self, client):
+        """A detector whose labelset shares nothing with the active dataset
+        exports the whole labelset instead of an empty set (the #2702 headline)."""
+        detector_id, _, _ = self._setup_detector(client, with_votes=False)
+        self._inject_elements(detector_id, self.GHOST_GOOD, self.GHOST_BAD)
+
+        data = client.get("/api/labels/export").get_json()
+        assert {e["origin_name"] for e in data["labels"]} == {"ghost_good.wav", "ghost_bad.wav"}
+        assert all(e["origin_only"] is True for e in data["labels"])
+
+    def test_ndjson_includes_origin_only_rows(self, client):
+        detector_id, _, _ = self._setup_detector(client)
+        self._inject_elements(detector_id, self.GHOST_GOOD, self.GHOST_BAD)
+
+        buffered = client.get("/api/labels/export").get_json()["labels"]
+        streamed = _read_ndjson(client.get("/api/labels/export?format=ndjson"))
+        assert streamed == buffered
+        assert sum(1 for r in streamed if r.get("origin_only")) == 2
+
+    def test_good_bad_filters_apply_to_origin_only_entries(self, client):
+        detector_id, _, _ = self._setup_detector(client)
+        self._inject_elements(detector_id, self.GHOST_GOOD, self.GHOST_BAD)
+
+        goods = client.get("/api/labels/export?goods_only=true").get_json()["labels"]
+        assert "ghost_good.wav" in {e.get("origin_name") for e in goods}
+        assert "ghost_bad.wav" not in {e.get("origin_name") for e in goods}
+
+        bads = client.get("/api/labels/export?label_filter=bad").get_json()["labels"]
+        assert {e.get("origin_name") for e in bads if e.get("origin_only")} == {"ghost_bad.wav"}
+        assert all(e["label"] == "bad" for e in bads)
+
+    def test_vote_scoped_filters_exclude_origin_only_entries(self, client):
+        """corrections / unverified / verified partition session vote state;
+        origin-only elements were never part of the session, so they opt out."""
+        detector_id, _, _ = self._setup_detector(client)
+        self._inject_elements(detector_id, self.GHOST_GOOD, self.GHOST_BAD)
+
+        for label_filter in ("corrections", "unverified", "verified"):
+            data = client.get(f"/api/labels/export?label_filter={label_filter}").get_json()
+            assert all(not e.get("origin_only") for e in data["labels"]), label_filter
+
+    def test_resolved_but_unvoted_element_is_not_resurrected(self, client):
+        """An element that resolves into the active dataset but has no vote was
+        unlabelled this session; the fallback must not re-export it from disk."""
+        from vtscore.detectors.registry import get_detector
+        from vtscore.detectors.store import _detector_path
+        from vtscore.state.core import get_active_detector_context
+        from vtsearch.state import medias
+
+        detector_id, good_cid, bad_cid = self._setup_detector(client)
+        good_media = medias[good_cid]
+
+        # Un-vote the good media (the vote sync also drops it from disk).
+        client.post(f"/api/medias/{good_cid}/vote", json={"target": "none"})
+
+        # Plant a stale on-disk entry for the unvoted media, then re-stamp the
+        # context's cached mtime so ``ensure_votes_match_active_dataset``
+        # doesn't treat the write as a labelset change and restore it as a
+        # vote.  This reproduces the state where disk and session disagree
+        # about a *resolvable* element - the session must win.
+        self._inject_elements(
+            detector_id,
+            {
+                "md5": good_media["md5"],
+                "label": "good",
+                "origin": good_media.get("origin"),
+                "origin_name": good_media.get("origin_name", ""),
+                "filename": good_media.get("filename", ""),
+            },
+        )
+        det_ctx = get_active_detector_context()
+        path = _detector_path(get_detector(detector_id)["name"])
+        det_ctx.cached_labelset_mtime = path.stat().st_mtime
+
+        data = client.get("/api/labels/export").get_json()
+        assert all(e["md5"] != good_media["md5"] for e in data["labels"])
+
+    def test_enrich_degrades_gracefully_for_origin_only_entries(self, client):
+        """Origin-only rows can't be enriched from a media dict; their
+        custom_metadata degrades to origin params + stored element metadata."""
+        detector_id, _, _ = self._setup_detector(client)
+        self._inject_elements(detector_id, self.GHOST_GOOD)
+
+        data = client.get("/api/labels/export?enrich=true").get_json()
+        ghost = next(e for e in data["labels"] if e.get("origin_only"))
+        assert ghost["custom_metadata"]["contentID"] == "c-123"
+        assert ghost["custom_metadata"]["shard"] == "elsewhere"
+        assert "contentID" in data["available_columns"]
+        assert "shard" in data["available_columns"]

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -25,6 +25,7 @@ from vtsearch.state import (
     apply_label_with_click_time,
     cached_md5_lookup,
     cached_media_lookups,
+    get_active_detector_context,
     resolve_media_ids,
 )
 from vtscore.utils.hits import build_media_hit
@@ -156,6 +157,136 @@ def _build_entry_metadata(media: dict) -> dict:
 
 _BASE_EXPORT_COLUMNS = ["label", "md5", "origin_name", "filename", "category", "origin"]
 
+#: Find-mode partitions of the *session's* vote state.  ``verified`` /
+#: ``unverified`` split the current Find run's work queue by ``verified_ids``
+#: and ``corrections`` compares against the session's ``find_initial_labels``;
+#: none of these are properties of the persisted labelset, so labelset
+#: elements that never resolved into the active dataset (and therefore were
+#: never part of the session) are excluded from these exports by design.
+_VOTE_SCOPED_FILTERS = frozenset({"corrections", "unverified", "verified"})
+
+
+def _fallback_passes_filter(label: str, label_filter: str, goods_only: bool) -> bool:
+    """Apply the good/bad export filters to an origin-only labelset element.
+
+    Mirrors :func:`_select_vote_pools` for the labelset-shaped filters
+    (``""`` / ``good`` / ``bad`` / ``both``); the vote-scoped filters never
+    reach this function (see ``_VOTE_SCOPED_FILTERS``).
+    """
+    if label_filter == "good":
+        return label == "good"
+    if label_filter == "bad":
+        return label == "bad"
+    if not label_filter and goods_only:
+        return label == "good"
+    return True
+
+
+def _persisted_labelset_for_active_detector():
+    """Return the active detector's on-disk :class:`LabelSet`, or ``None``.
+
+    Reads the detector JSON fresh so the fallback sees writes made through
+    the labelset-element vote route (which bypasses the in-memory vote
+    dicts).  Falls back to the context's ``cached_labelset`` when the
+    registry entry or file is missing (e.g. a test-constructed context).
+    """
+    from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.registry import get_detector
+    from vtscore.detectors.store import _detector_path, _read_detector
+
+    det_ctx = get_active_detector_context()
+    if not det_ctx.detector_id:
+        return None
+    entry = get_detector(det_ctx.detector_id)
+    if entry and entry.get("name"):
+        data = _read_detector(_detector_path(entry["name"]))
+        if data is not None:
+            return LabelSet.from_dict(data.get("labelset") or {})
+    return det_ctx.cached_labelset
+
+
+def _origin_only_fallback_entries(
+    labelset,
+    all_medias: dict,
+    label_filter: str,
+    goods_only: bool,
+) -> list[dict]:
+    """Serialise persisted labelset elements the vote path cannot represent.
+
+    ``GET /api/labels/export`` composes its payload from cid-keyed votes
+    intersected with the active dataset's medias, but the detector's
+    labelset is origin-keyed and dataset-agnostic: elements whose media were
+    never ingested into any loaded dataset (imported detectors whose origins
+    were unreachable, registry detectors from another host, partial dataset
+    overlap) have no cid and would silently vanish from the export.  This
+    fallback appends those elements straight from the on-disk labelset so an
+    export is always a faithful rendering of the labelset.
+
+    Elements that *do* resolve into the active dataset are never added here:
+    for them the session's vote state is the source of truth (an element
+    that resolves but has no vote was unlabelled by the user this session,
+    and resurrecting it from disk would undo that).  Each returned entry is
+    marked ``origin_only: true`` so consumers can tell a resolved label from
+    one rendered purely from provenance.
+
+    Vote-scoped filters (``corrections`` / ``unverified`` / ``verified``)
+    return no fallback entries - they partition the current session's vote
+    state, which origin-only elements were never part of.
+    """
+    if label_filter in _VOTE_SCOPED_FILTERS:
+        return []
+
+    persisted = _persisted_labelset_for_active_detector()
+    if persisted is None or not persisted.elements:
+        return []
+
+    from vtscore.datasets.labelset import element_key
+
+    if all_medias:
+        origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
+    else:
+        origin_lookup, md5_lookup, name_lookup = {}, {}, {}
+
+    seen = {element_key(el) for el in labelset.elements}
+    seen.discard(None)
+
+    entries: list[dict] = []
+    for el in persisted.elements:
+        if el.label not in ("good", "bad"):
+            continue
+        if not _fallback_passes_filter(el.label, label_filter, goods_only):
+            continue
+        key = element_key(el)
+        if key is not None and key in seen:
+            continue
+        entry = el.to_dict()
+        if resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup):
+            continue
+        entry["origin_only"] = True
+        entries.append(entry)
+    return entries
+
+
+def _build_unresolved_entry_metadata(entry: dict) -> dict:
+    """Return the metadata blob for a label entry with no media to enrich from.
+
+    Degraded counterpart of :func:`_build_entry_metadata` for entries whose
+    MD5 doesn't resolve into the active dataset (origin-only labelset
+    elements, dupe-set members collapsed out of the dataset): there is no
+    media dict to take display metadata from, so the blob is composed from
+    what the entry itself carries - flattened origin params plus the
+    element's stored ``metadata``.
+    """
+    meta: dict = {}
+    origin = entry.get("origin")
+    if isinstance(origin, dict):
+        for k, v in (origin.get("params") or {}).items():
+            meta.setdefault(k, v)
+    stored = entry.get("metadata")
+    if isinstance(stored, dict):
+        meta.update(stored)
+    return meta
+
 
 def _make_enricher(all_medias: dict):
     """Return a per-entry ``custom_metadata`` enricher.
@@ -169,16 +300,15 @@ def _make_enricher(all_medias: dict):
 
     Flattens origin params so fields like ``contentID`` / ``mediaID`` /
     ``media_url`` surface as selectable export columns alongside the
-    importer's own ``custom_metadata``.
+    importer's own ``custom_metadata``.  Entries with no media in the active
+    dataset degrade to :func:`_build_unresolved_entry_metadata`.
     """
     md5_lookup = cached_md5_lookup()
 
     def enrich(entry: dict) -> set[str]:
         cids = md5_lookup.get(entry.get("md5") or "")
         media = all_medias.get(cids[0]) if cids else None
-        if not media:
-            return set()
-        meta = _build_entry_metadata(media)
+        meta = _build_entry_metadata(media) if media else _build_unresolved_entry_metadata(entry)
         if not meta:
             return set()
         entry["custom_metadata"] = meta
@@ -209,6 +339,12 @@ def export_labels(query: dict):
     so consumers know exactly where each labeled element came from. The
     format is a superset of the legacy export format; old consumers
     that only read ``md5`` and ``label`` keys continue to work unchanged.
+
+    The payload is composed from the session's votes intersected with the
+    active dataset, then topped up with persisted labelset elements that
+    don't resolve into the active dataset (marked ``origin_only: true``) so
+    the export is always a faithful rendering of the detector's labelset -
+    see :func:`_origin_only_fallback_entries`.
     """
     from vtscore.datasets.labelset import LabelSet
 
@@ -230,10 +366,13 @@ def export_labels(query: dict):
         vote_region_boxes=snap.vote_region_boxes,
     )
 
+    fallback_entries = _origin_only_fallback_entries(labelset, all_medias, label_filter, query["goods_only"])
+
     if query["format"] == "ndjson":
-        return _stream_labels_ndjson(labelset, all_medias, label_filter, query["enrich"])
+        return _stream_labels_ndjson(labelset, all_medias, label_filter, query["enrich"], fallback_entries)
 
     result: dict = labelset.to_dict()
+    result["labels"].extend(fallback_entries)
 
     _annotate_corrections(result, all_medias)
     if label_filter == "corrections":
@@ -245,7 +384,9 @@ def export_labels(query: dict):
     return result
 
 
-def _stream_labels_ndjson(labelset, all_medias: dict, label_filter: str, enrich: bool):
+def _stream_labels_ndjson(
+    labelset, all_medias: dict, label_filter: str, enrich: bool, fallback_entries: list[dict] | None = None
+):
     """Stream the labelset as newline-delimited JSON, one label entry per line (S13).
 
     Encodes one :class:`~vtscore.datasets.labelset.LabeledElement` at a time
@@ -255,12 +396,15 @@ def _stream_labels_ndjson(labelset, all_medias: dict, label_filter: str, enrich:
     ``is_correction`` / ``custom_metadata`` annotations the buffered response
     would attach, applied in the same order (annotate corrections, drop
     non-corrections under ``label_filter=corrections``, then enrich).
+    *fallback_entries* (origin-only labelset elements, already serialised)
+    stream after the vote-derived rows through the same annotation pipeline.
 
     The top-level ``available_columns`` list has no place in NDJSON: it's a
     whole-set aggregate that can't be emitted before the last row is seen, and
     consumers of a streamed export derive columns from the rows themselves.
     """
     import json
+    from itertools import chain
 
     from flask import Response, stream_with_context
 
@@ -269,7 +413,7 @@ def _stream_labels_ndjson(labelset, all_medias: dict, label_filter: str, enrich:
     corrections_only = label_filter == "corrections"
 
     def generate():
-        for entry in labelset.iter_dicts():
+        for entry in chain(labelset.iter_dicts(), fallback_entries or ()):
             if annotate is not None:
                 annotate(entry)
             if corrections_only and not entry.get("is_correction"):

--- a/vtsearch/schemas/labels.py
+++ b/vtsearch/schemas/labels.py
@@ -37,9 +37,10 @@ class LabeledElementSchema(Schema):
 
     Mirrors :meth:`vtscore.datasets.labelset.LabeledElement.to_dict`. Only
     ``md5`` and ``label`` are guaranteed; the other keys appear when the
-    underlying element has them set. ``is_correction`` and
-    ``custom_metadata`` are added by the export route (under
-    ``find_initial_labels`` and ``enrich=true`` respectively).
+    underlying element has them set. ``is_correction``, ``custom_metadata``,
+    and ``origin_only`` are added by the export route (under
+    ``find_initial_labels``, ``enrich=true``, and the persisted-labelset
+    fallback respectively).
     """
 
     md5 = fields.String(required=True)
@@ -52,6 +53,15 @@ class LabeledElementSchema(Schema):
     region_box = fields.List(fields.Float())
     is_correction = fields.Boolean()
     custom_metadata = fields.Dict()
+    origin_only = fields.Boolean(
+        metadata={
+            "description": (
+                "True when the entry was rendered straight from the detector's "
+                "persisted labelset because its media doesn't resolve into the "
+                "active dataset; absent for vote-derived entries."
+            ),
+        },
+    )
 
     class Meta:
         # Element-level extension keys (e.g. enrichment-added columns)
@@ -72,7 +82,9 @@ class LabelsExportQuerySchema(Schema):
                 "``corrections`` (entries where the user changed the "
                 "detector's original label), ``unverified`` (Find work-queue "
                 "items the human hasn't acted on), or ``verified`` (items the "
-                "human has confirmed). Overrides ``goods_only``."
+                "human has confirmed). Overrides ``goods_only``. The "
+                "session-scoped filters (``corrections`` / ``unverified`` / "
+                "``verified``) never include ``origin_only`` fallback entries."
             ),
         },
     )


### PR DESCRIPTION
Closes #2702

## Problem

`GET /api/labels/export` composed its payload exclusively from cid-keyed vote state intersected with the **active dataset's** medias, while the detector's labelset is origin-keyed and dataset-agnostic. Any detector whose labels don't resolve into the active dataset (imported on a machine where the #2701 ingest never ran, partial dataset overlap, registry detectors whose media the host can't reach) exported fewer labels than the right pane showed — or none at all. Two different answers to "what are this detector's labels".

## Fix

The export route now tops up the vote-derived payload with persisted labelset elements that don't resolve into the active dataset, so an export is always a faithful rendering of the labelset:

- **`origin_only: true` marker** on each fallback entry (also added to `LabeledElementSchema` + regenerated OpenAPI snapshot) so consumers can tell a resolved label from one rendered purely from provenance.
- **Resolved-but-unvoted elements are never resurrected.** An element that resolves into the active dataset but has no vote was unlabelled this session; the session's vote state stays the source of truth for everything that resolves.
- **Session-scoped filters opt out.** `label_filter=corrections` / `unverified` / `verified` partition the current session's vote state (Find-mode partitions), which origin-only elements were never part of, so they return no fallback entries — the explicit decision the issue asked for. The labelset-shaped filters (`good` / `bad` / `both` / `goods_only`) apply to fallback entries the same way they apply to vote pools.
- **Enrichment degrades gracefully.** Origin-only rows have no media dict to enrich from, so their `custom_metadata` is composed from flattened origin params plus the element's stored `metadata`, and those keys feed `available_columns` as usual. (This also improves dupe-set member rows, which previously got no enrichment at all when their MD5 was collapsed out of the dataset.)
- Both the buffered JSON and streaming NDJSON paths emit the fallback entries through the same annotate/enrich pipeline.

The fallback reads the detector JSON fresh (falling back to the context's cached labelset when the registry entry or file is missing), so writes made through the labelset-element vote route are visible immediately.

## Tests

New `TestExportOriginOnlyFallback` class (7 tests) covering: the origin-only marker, the fully-non-overlapping-labelset headline case, NDJSON/buffered parity, good/bad filters, session-scoped filter opt-out, no resurrection of resolved-but-unvoted elements, and enrichment degradation. Full suite: **ALL 6645 TESTS PASSED (1 skipped)** via `./run-tests.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL8ksWErE3f8scdqMjbAKH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BL8ksWErE3f8scdqMjbAKH)_