### PR TITLE
Surface signpost captions/tags as item metadata ("AI Caption" / "AI Tags")

### DIFF
--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -222,6 +222,16 @@ changes to `vtscore/media/__init__.py` are needed.
 | `embed_text(text)`            | `(str) -> Optional[np.ndarray]`    | Inline text embedding (legacy)     |
 | `load_demo_source(...)`       | See docstring                      | Download and embed a demo dataset  |
 
+> **Always merge the base `display_metadata`.** Override it to *prepend* your
+> type-specific fields, then fold in whatever the base produced that you did
+> not already set — the shipped types all end with
+> `result.update({k: v for k, v in super().display_metadata(media).items() if k not in result})`.
+> The base contributes the shared fields (Category, File Size, the `Clip *`
+> provenance) plus the **"AI Caption" / "AI Tags"** row, which surfaces the
+> per-media signpost text a Browse-prepped dataset already carries (see
+> `vtscore/projection/signpost_texts.py`). A type that returns its own dict
+> without merging silently drops all of them.
+
 ### What happens automatically after registration
 
 | Subsystem              | What happens                                                  |

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -214,10 +214,15 @@
   letter-spacing: var(--tracking-wide);
 }
 
+// Break between words, not inside them: values are now prose as often as they
+// are identifiers (an "AI Caption" row carries a full sentence), and break-all
+// chops those mid-word in a narrow grid cell. The genuinely unbreakable value
+// is the MD5, which opts back into break-all below -- the same split the browse
+// bin popup's metadata already uses.
 .metadata-value {
   font-size: var(--font-md);
   color: var(--text-primary);
-  word-break: break-all;
+  word-break: break-word;
   flex: 1 1 auto;
   min-width: 0;
 }
@@ -225,6 +230,7 @@
 .metadata-md5 {
   font-family: monospace;
   font-size: var(--font-xs);
+  word-break: break-all;
 }
 
 // Sticky-armed-state hint banner for the bad-vote-with-box discard flow

--- a/tests/core/test_media_list_edge_paths.py
+++ b/tests/core/test_media_list_edge_paths.py
@@ -483,6 +483,24 @@ class TestBatchMetadataBranches:
         assert item["description"] == "a described item"
         assert "origin_name" not in item
 
+    def test_signpost_text_reaches_the_client_as_an_ai_row(self, client):
+        # A Browse-prepped dataset carries a model-generated text per media.
+        # It rides to the UI through display_metadata, titled by kind so the
+        # user reads it as a model's guess rather than curated truth.
+        from vtscore.projection import signpost_texts as st  # noqa: PLC0415
+
+        mid = _inject(**{st.TEXT_FIELD: "Rain, Thunderstorm, Wind", st.KIND_FIELD: st.KIND_TAGS})
+        resp = client.post("/api/medias/batch", json={"ids": [mid]})
+        assert resp.status_code == 200
+        (item,) = resp.get_json()
+        assert item["custom_metadata"]["AI Tags"] == "Rain, Thunderstorm, Wind"
+
+    def test_media_without_a_signpost_text_gets_no_ai_row(self, client):
+        resp = client.post("/api/medias/batch", json={"ids": [_inject()]})
+        assert resp.status_code == 200
+        (item,) = resp.get_json()
+        assert not [key for key in item["custom_metadata"] if key.startswith("AI ")]
+
     def test_sliced_audio_suppresses_playback_window(self, client):
         # The audio clipper serves the already-sliced clip bytes (a short WAV in
         # its own 0-based timeline) but stamps the original absolute offsets.

--- a/tests_lib/datasets/test_signpost_text_persistence.py
+++ b/tests_lib/datasets/test_signpost_text_persistence.py
@@ -1,0 +1,79 @@
+"""Library-tier tests for signpost texts surviving the pickle round-trip.
+
+The signpost text is the sign pipeline's only full-corpus model cost, and the
+ingest stage computes it *before* the registry save specifically so it rides
+along in the dataset container.  ``export_dataset_to_file`` writes an explicit
+field list, so the three fields the text layer owns
+(``signpost_texts.PERSISTED_FIELDS``) have to be named there — and restored on
+load — or every reload silently re-runs the caption/tag models and drops the
+item's "AI Caption" / "AI Tags" metadata row.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from vtscore.datasets.loader import export_dataset_to_file
+from vtscore.datasets.loader_pickle import load_dataset_from_pickle
+from vtscore.media.audio.media_type import AudioMediaType
+from vtscore.projection import signpost_texts as st
+
+
+def _media(**extra) -> dict:
+    rng = np.random.default_rng(11)
+    return {
+        "id": 1,
+        "media_type": "audio",
+        "duration": 1.0,
+        "file_size": 64,
+        "md5": "abc",
+        "embedder": "clap",
+        "embeddings": {"clap": rng.standard_normal(16).astype(np.float32)},
+        "filename": "a.wav",
+        "category": "test",
+        "media_bytes": b"\x00" * 64,
+        **extra,
+    }
+
+
+def _round_trip(media: dict, tmp_path: Path) -> dict:
+    container = export_dataset_to_file({1: media}, embedder="clap", media_type="audio")
+    pkl = tmp_path / "ds.pkl"
+    pkl.write_bytes(container)
+    loaded: dict = {}
+    load_dataset_from_pickle(pkl, loaded)
+    return loaded[1]
+
+
+class TestSignpostTextSurvivesPickleRoundTrip:
+    def test_text_source_and_kind_persist(self, tmp_path: Path):
+        media = _media(
+            **{
+                st.TEXT_FIELD: "Rain, Thunderstorm, Wind",
+                st.SOURCE_FIELD: "tags:audioset527:clap",
+                st.KIND_FIELD: st.KIND_TAGS,
+            }
+        )
+        out = _round_trip(media, tmp_path)
+
+        assert out[st.TEXT_FIELD] == "Rain, Thunderstorm, Wind"
+        assert out[st.SOURCE_FIELD] == "tags:audioset527:clap"
+        assert out[st.KIND_FIELD] == st.KIND_TAGS
+
+    def test_metadata_row_survives_the_round_trip(self, tmp_path: Path):
+        media = _media(
+            **{
+                st.TEXT_FIELD: "birds chirping in a forest",
+                st.SOURCE_FIELD: "caption:whisper-audio",
+                st.KIND_FIELD: st.KIND_CAPTION,
+            }
+        )
+        out = _round_trip(media, tmp_path)
+
+        assert AudioMediaType().display_metadata(out)["AI Caption"] == "birds chirping in a forest"
+
+    def test_unprepped_media_gains_no_fields(self, tmp_path: Path):
+        out = _round_trip(_media(), tmp_path)
+        assert not [field for field in st.PERSISTED_FIELDS if field in out]

--- a/tests_lib/projection/test_signpost_item_metadata.py
+++ b/tests_lib/projection/test_signpost_item_metadata.py
@@ -1,0 +1,83 @@
+"""Library-tier tests for signpost texts surfacing as item metadata.
+
+A dataset prepped for Browse already carries a model-generated text per media
+(the caption / tag list that letters the map).  ``MediaType.display_metadata``
+surfaces it in the labeling UI's metadata grid under an explicitly hedged
+label — "AI Caption" / "AI Tags", never a bare "Description" — so a user reads
+it as a model's guess rather than curated truth.
+
+These tests lock the wiring (every media type inherits the row through the
+base implementation, without disturbing the type-specific fields) and the
+honesty of the labeling.
+"""
+
+from __future__ import annotations
+
+from vtscore.media.audio.media_type import AudioMediaType
+from vtscore.media.image.media_type import ImageMediaType
+from vtscore.media.text.media_type import TextMediaType
+from vtscore.projection import signpost_texts as st
+
+
+def _image_media(**extra) -> dict:
+    return {
+        "id": 1,
+        "media_type": "image",
+        "category": "dogs",
+        "file_size": 4096,
+        "width": 800,
+        "height": 600,
+        **extra,
+    }
+
+
+class TestCaptionsAppearAsItemMetadata:
+    def test_caption_row_is_titled_ai_caption(self):
+        media = _image_media(**{st.TEXT_FIELD: "a golden retriever on a beach", st.KIND_FIELD: st.KIND_CAPTION})
+        meta = ImageMediaType().display_metadata(media)
+        assert meta["AI Caption"] == "a golden retriever on a beach"
+
+    def test_tag_row_is_titled_ai_tags(self):
+        media = {
+            "id": 2,
+            "media_type": "audio",
+            "category": "field",
+            "file_size": 1024,
+            st.TEXT_FIELD: "Rain, Thunderstorm, Wind",
+            st.KIND_FIELD: st.KIND_TAGS,
+        }
+        meta = AudioMediaType().display_metadata(media)
+        assert meta["AI Tags"] == "Rain, Thunderstorm, Wind"
+
+    def test_type_specific_fields_are_untouched(self):
+        media = _image_media(**{st.TEXT_FIELD: "a cat", st.KIND_FIELD: st.KIND_CAPTION})
+        meta = ImageMediaType().display_metadata(media)
+        assert meta["Dimensions"] == "800×600"
+        assert meta["Category"] == "dogs"
+        assert meta["File Size"] == 4096
+
+    def test_unprepped_media_gets_no_extra_row(self):
+        # The overwhelmingly common case: a dataset that never ran the signpost
+        # stage must produce exactly the metadata it did before.
+        meta = ImageMediaType().display_metadata(_image_media())
+        assert set(meta) == {"Category", "Dimensions", "File Size"}
+
+    def test_text_media_own_content_is_not_surfaced(self):
+        # The text provider's "text" is the item's own content, which the
+        # viewer already shows — and no model wrote it, so no "AI …" row.
+        media = {
+            "id": 3,
+            "media_type": "text",
+            "word_count": 12,
+            st.TEXT_FIELD: "the paragraph itself",
+            st.KIND_FIELD: st.KIND_CONTENT,
+        }
+        meta = TextMediaType().display_metadata(media)
+        assert not [key for key in meta if key.startswith("AI ")]
+        assert meta["Word Count"] == 12
+
+    def test_no_label_claims_to_be_authoritative(self):
+        media = _image_media(**{st.TEXT_FIELD: "a cat", st.KIND_FIELD: st.KIND_CAPTION})
+        meta = ImageMediaType().display_metadata(media)
+        generated = [key for key in meta if key not in {"Category", "Dimensions", "File Size"}]
+        assert generated == ["AI Caption"]

--- a/tests_lib/projection/test_signpost_texts.py
+++ b/tests_lib/projection/test_signpost_texts.py
@@ -164,6 +164,8 @@ class CountingProvider:
     """Registry-pluggable provider that counts build calls."""
 
     name = "counting"
+    #: Declares no kind — the runtime tolerance path (see ``_infer_kind``).
+    text_kind = ""
 
     def __init__(self, signature="counting:v1"):
         self._signature = signature
@@ -191,6 +193,24 @@ class TestEnsureSignpostTexts:
         assert texts == {i: f"text-{i}" for i in ids}
         assert medias[1][st.TEXT_FIELD] == "text-1"
         assert medias[1][st.SOURCE_FIELD] == "counting:v1"
+
+    def test_kind_is_stamped_from_the_provider(self):
+        provider = CountingProvider()
+        provider.text_kind = st.KIND_TAGS
+        st.register_signpost_text_provider("fake", provider)
+        medias = self._medias()
+
+        st.ensure_signpost_texts(medias, sorted(medias), np.zeros((4, 2), dtype=np.float32), None)
+        assert medias[1][st.KIND_FIELD] == st.KIND_TAGS
+
+    def test_provider_without_a_kind_leaves_the_field_off(self):
+        # CountingProvider declares no ``text_kind``; rather than stamping a
+        # blank we leave the field absent so display-time inference can try.
+        st.register_signpost_text_provider("fake", CountingProvider())
+        medias = self._medias()
+
+        st.ensure_signpost_texts(medias, sorted(medias), np.zeros((4, 2), dtype=np.float32), None)
+        assert st.KIND_FIELD not in medias[1]
 
     def test_cached_texts_are_reused(self):
         provider = CountingProvider()
@@ -247,6 +267,8 @@ class TestEnsureSignpostTexts:
 class _DictProvider:
     """Primary-like provider that returns a fixed subset of texts, ignores matrix."""
 
+    text_kind = ""
+
     def __init__(self, texts: dict[int, str], name: str = "caption:test"):
         self._texts = texts
         self.name = name
@@ -260,6 +282,7 @@ class _DictProvider:
 
 class _RaisingProvider:
     name = "caption:broken"
+    text_kind = ""
 
     def signature(self, embedder):
         return self.name
@@ -270,6 +293,7 @@ class _RaisingProvider:
 
 class _RecordingFallback:
     name = "tags:rec"
+    text_kind = ""
 
     def __init__(self):
         self.seen_ids: list[int] | None = None
@@ -318,6 +342,102 @@ class TestFallbackTextProvider:
     def test_signature_composes_both_sides(self):
         fp = st.FallbackTextProvider(_DictProvider({}, name="cap:x"), _RecordingFallback())
         assert fp.signature(None) == "cap:x|fallback=tags:rec"
+
+
+class _KindedProvider(_DictProvider):
+    """A ``_DictProvider`` that also declares which kind of text it makes."""
+
+    def __init__(self, texts, name="caption:test", kind=st.KIND_CAPTION):
+        super().__init__(texts, name=name)
+        self.text_kind = kind
+
+
+class _KindedFallback(_RecordingFallback):
+    """The recording fallback, declaring the tag kind like a real one does."""
+
+    text_kind = st.KIND_TAGS
+
+
+class TestBuildKindedTexts:
+    def test_plain_provider_stamps_its_own_kind(self):
+        provider = _KindedProvider({1: "cap1", 2: "cap2"})
+        built = st.build_kinded_texts(provider, [1, 2], {1: {}, 2: {}}, np.zeros((2, 3), dtype=np.float32), None)
+        assert built == {1: ("cap1", st.KIND_CAPTION), 2: ("cap2", st.KIND_CAPTION)}
+
+    def test_provider_without_a_kind_yields_blank(self):
+        built = st.build_kinded_texts(_DictProvider({1: "x"}), [1], {1: {}}, np.zeros((1, 3), dtype=np.float32), None)
+        assert built == {1: ("x", "")}
+
+    def test_empty_texts_are_dropped(self):
+        provider = _KindedProvider({1: "cap1", 2: ""})
+        built = st.build_kinded_texts(provider, [1, 2], {1: {}, 2: {}}, np.zeros((2, 3), dtype=np.float32), None)
+        assert built == {1: ("cap1", st.KIND_CAPTION)}
+
+    def test_fallback_reports_the_kind_that_produced_each_item(self):
+        # The whole point of a per-item kind: with the captioner enabled, an
+        # item it couldn't decode is honestly labeled tags, not a caption.
+        fp = st.FallbackTextProvider(_KindedProvider({1: "cap1"}), _KindedFallback())
+
+        built = st.build_kinded_texts(fp, [1, 2], {1: {}, 2: {}}, np.zeros((2, 3), dtype=np.float32), None)
+        assert built == {1: ("cap1", st.KIND_CAPTION), 2: ("tag-2", st.KIND_TAGS)}
+
+    def test_ensure_stamps_the_per_item_kind_through_a_fallback(self):
+        provider = st.FallbackTextProvider(_KindedProvider({1: "cap1"}), _KindedFallback())
+        st.register_signpost_text_provider("fake", provider)
+        medias = {i: {"id": i, "media_type": "fake"} for i in (1, 2)}
+
+        st.ensure_signpost_texts(medias, [1, 2], np.zeros((2, 3), dtype=np.float32), None)
+        assert medias[1][st.KIND_FIELD] == st.KIND_CAPTION
+        assert medias[2][st.KIND_FIELD] == st.KIND_TAGS
+        # Both halves stamp the *composite* signature, so neither recomputes.
+        assert medias[1][st.SOURCE_FIELD] == medias[2][st.SOURCE_FIELD]
+
+
+class TestSignpostMetadataEntry:
+    def test_caption_is_titled_ai_caption(self):
+        media = {st.TEXT_FIELD: "a dog on a beach", st.KIND_FIELD: st.KIND_CAPTION}
+        assert st.signpost_metadata_entry(media) == ("AI Caption", "a dog on a beach")
+
+    def test_tags_are_titled_ai_tags(self):
+        media = {st.TEXT_FIELD: "rain, thunder", st.KIND_FIELD: st.KIND_TAGS}
+        assert st.signpost_metadata_entry(media) == ("AI Tags", "rain, thunder")
+
+    def test_labels_never_overclaim(self):
+        # The hedge is the point: every surfaced label says where it came from.
+        assert all(label.startswith("AI ") for label in st.TEXT_KIND_LABELS.values())
+
+    def test_content_kind_is_not_surfaced(self):
+        # The item's own text is already shown by the viewer, and nothing
+        # generated it — so it gets no row.
+        media = {st.TEXT_FIELD: "the full paragraph", st.KIND_FIELD: st.KIND_CONTENT}
+        assert st.signpost_metadata_entry(media) is None
+
+    def test_missing_or_blank_text_yields_nothing(self):
+        assert st.signpost_metadata_entry({}) is None
+        assert st.signpost_metadata_entry({st.TEXT_FIELD: "   ", st.KIND_FIELD: st.KIND_TAGS}) is None
+
+    def test_text_is_stripped(self):
+        media = {st.TEXT_FIELD: "  a cat  ", st.KIND_FIELD: st.KIND_CAPTION}
+        assert st.signpost_metadata_entry(media) == ("AI Caption", "a cat")
+
+    def test_legacy_media_infers_kind_from_the_signature(self):
+        # Datasets prepped before the kind field existed carry only a
+        # single-provider signature, which names its kind in the first segment.
+        assert st.signpost_metadata_entry(
+            {st.TEXT_FIELD: "rain, thunder", st.SOURCE_FIELD: "tags:audioset527:clap"}
+        ) == ("AI Tags", "rain, thunder")
+        assert st.signpost_metadata_entry({st.TEXT_FIELD: "a dog", st.SOURCE_FIELD: "caption:whisper-audio"}) == (
+            "AI Caption",
+            "a dog",
+        )
+
+    def test_legacy_composite_signature_is_not_guessed(self):
+        # "caption enabled" is not "this item got a caption" — refuse to guess.
+        media = {st.TEXT_FIELD: "rain, thunder", st.SOURCE_FIELD: "caption:x|fallback=tags:audioset527:clap"}
+        assert st.signpost_metadata_entry(media) is None
+
+    def test_unrecognized_signature_yields_nothing(self):
+        assert st.signpost_metadata_entry({st.TEXT_FIELD: "x", st.SOURCE_FIELD: "mystery:v1"}) is None
 
 
 class TestCaptionerSelection:

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -212,6 +212,7 @@ def export_dataset_to_file(
     # the round-trip.  Build the type→fields map once and merge each media's
     # extra fields into its serialized entry below.
     from vtscore.media import all_types  # noqa: PLC0415
+    from vtscore.projection.signpost_texts import PERSISTED_FIELDS as SIGNPOST_FIELDS  # noqa: PLC0415
 
     extra_fields_by_type: dict[str, list[str]] = {mt.type_id: mt.pickle_extra_fields for mt in all_types()}
 
@@ -243,6 +244,14 @@ def export_dataset_to_file(
         }
         for field in extra_fields_by_type.get(media.get("media_type", ""), ()):
             entry[field] = media.get(field)
+        # The signpost text (the caption / tag list that letters the Browse map
+        # and titles the item's "AI …" metadata row) is the sign pipeline's only
+        # full-corpus model cost, computed at ingest *before* this save precisely
+        # so it rides along.  Write it only when present, so datasets that never
+        # ran the stage keep the same entry shape.
+        for field in SIGNPOST_FIELDS:
+            if media.get(field):
+                entry[field] = media[field]
         # Persist a precomputed grid/list thumbnail so reloads stream the bytes
         # instead of decoding the full-resolution original on every cold tile
         # fetch (the browse first-paint delay).  Image *demos* never generate

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -133,6 +133,23 @@ def _load_pickle_media_payload(
         return f.read(), None, str(ext_path.resolve()), False
 
 
+def _restore_signpost_text(media_data: dict[str, Any], media_info: dict[str, Any]) -> None:
+    """Carry a pickled signpost text (+ its signature and kind) onto the media.
+
+    Written at ingest by the signpost-texts stage; restoring it is what makes
+    a later browse (or Find→Browse re-fit) skip the caption/tag models, and
+    what keeps the item's "AI Caption" / "AI Tags" metadata row across a
+    reload.  Absent fields are left off entirely rather than set to ``None``,
+    so an unprepped dataset's medias keep the shape they had before.
+    """
+    from vtscore.projection.signpost_texts import PERSISTED_FIELDS  # noqa: PLC0415
+
+    for field in PERSISTED_FIELDS:
+        value = media_info.get(field)
+        if value:
+            media_data[field] = value
+
+
 def _build_pickle_thin_media(
     new_id: int,
     media_info: dict[str, Any],
@@ -163,6 +180,7 @@ def _build_pickle_thin_media(
     cm = media_info.get("custom_metadata")
     if cm:
         media_data["custom_metadata"] = cm
+    _restore_signpost_text(media_data, media_info)
     return media_data
 
 
@@ -198,6 +216,7 @@ def _build_pickle_full_media(
     cm = media_info.get("custom_metadata")
     if cm:
         media_data["custom_metadata"] = cm
+    _restore_signpost_text(media_data, media_info)
     return media_data
 
 

--- a/vtscore/media/base.py
+++ b/vtscore/media/base.py
@@ -363,6 +363,12 @@ class MediaType(ABC):
         Importers can additionally set ``media["custom_metadata"]`` to
         supply per-item fields (e.g. ``{"Uploaded By": "alice"}``).  The
         API route merges both sources before sending the response.
+
+        A dataset prepped for Browse already carries a model-generated
+        signpost text per media (the caption / tag list that letters the
+        map); the base implementation surfaces it here under an explicitly
+        hedged label so the work is visible in the labeling UI too.  See
+        :func:`vtscore.projection.signpost_texts.signpost_metadata_entry`.
         """
         result: dict[str, Any] = {}
         cat = media.get("category")
@@ -384,6 +390,14 @@ class MediaType(ABC):
         ci = media.get("clip_index")
         if ci is not None:
             result["Clip Index"] = ci
+        # Imported here rather than at module scope: the signpost text layer
+        # reaches back into the media types to decode items, so an eager
+        # import would close a cycle.
+        from vtscore.projection.signpost_texts import signpost_metadata_entry  # noqa: PLC0415
+
+        entry = signpost_metadata_entry(media)
+        if entry is not None:
+            result[entry[0]] = entry[1]
         return result
 
     # ------------------------------------------------------------------

--- a/vtscore/projection/signpost_captioners.py
+++ b/vtscore/projection/signpost_captioners.py
@@ -239,6 +239,12 @@ class ImageCaptionProvider:
     max_new_tokens: int = 48
     batch_size: int = 8
 
+    @property
+    def text_kind(self) -> str:
+        from vtscore.projection.signpost_texts import KIND_CAPTION  # noqa: PLC0415
+
+        return KIND_CAPTION
+
     def signature(self, embedder: Any) -> str:
         # Captions are generated from pixels + prompt, independent of the media
         # embedder — so the cache key is the model, not the embedder.
@@ -276,6 +282,12 @@ class AudioCaptionProvider:
     name: str = "caption:whisper-audio"
     model_id: str = "MU-NLPC/whisper-small-audio-captioning"
     batch_size: int = 16
+
+    @property
+    def text_kind(self) -> str:
+        from vtscore.projection.signpost_texts import KIND_CAPTION  # noqa: PLC0415
+
+        return KIND_CAPTION
 
     def signature(self, embedder: Any) -> str:
         return self.name

--- a/vtscore/projection/signpost_texts.py
+++ b/vtscore/projection/signpost_texts.py
@@ -6,12 +6,18 @@ just the sampled exemplars it shows the LLM (see
 ``docs/plans/vtsbrowse-toponymy.md``).  So the text is a full-corpus,
 per-media artifact — expensive for captioner-class providers, embarrassingly
 cacheable, and independent of any particular clustering.  We therefore compute
-it once and **cache it on the media dict** (``signpost_text`` +
-``signpost_text_source``): media dicts are the dataset pickle's payload, so a
-text computed during ingest persists with the dataset, and every later browse
-or Find→Browse subset re-fit reuses it instead of re-running a model.  Cached
-strings are derived *text*, which the No-Persisted-Vectors rule explicitly
-allows.
+it once and **cache it on the media dict** (:data:`PERSISTED_FIELDS`: the text,
+the provider signature it was built under, and its *kind*): media dicts are the
+dataset pickle's payload, so a text computed during ingest persists with the
+dataset, and every later browse or Find→Browse subset re-fit reuses it instead
+of re-running a model.  Cached strings are derived *text*, which the
+No-Persisted-Vectors rule explicitly allows.
+
+Because the text is per media and already paid for, it is also worth showing:
+:func:`signpost_metadata_entry` hands it to the media types'
+``display_metadata`` so a Browse-prepped dataset explains each item in the
+labeling UI too, titled by kind ("AI Caption" / "AI Tags") rather than passed
+off as curated truth.
 
 Providers are registered per media type.  Phase 1 ships the no-new-models
 tier resolved by the audio/image signpost studies
@@ -55,6 +61,38 @@ TEXT_FIELD = "signpost_text"
 #: Media-dict field stamping which provider+embedder produced the cached text;
 #: a mismatch with the active provider's signature invalidates the cache.
 SOURCE_FIELD = "signpost_text_source"
+#: Media-dict field stamping *what flavour* of text was cached — see
+#: :data:`TEXT_KINDS`.  Unlike :data:`SOURCE_FIELD` (which names the active
+#: provider as a whole) this is per item, so a fallback-composite provider
+#: records whether *this* item got a caption or degraded to tags.
+KIND_FIELD = "signpost_text_kind"
+
+#: The media-dict fields the signpost text layer owns.  Listed here so the
+#: dataset (de)serializers can carry them through the pickle round-trip in one
+#: place instead of repeating the names.
+PERSISTED_FIELDS = (TEXT_FIELD, SOURCE_FIELD, KIND_FIELD)
+
+#: A model-generated free-text description of the item.
+KIND_CAPTION = "caption"
+#: Vocabulary terms matched against the item by a zero-shot embedder.
+KIND_TAGS = "tags"
+#: The item's own text content — not generated, just excerpted.
+KIND_CONTENT = "content"
+
+TEXT_KINDS = (KIND_CAPTION, KIND_TAGS, KIND_CONTENT)
+
+#: How each kind is titled in the item's metadata grid — and which kinds are
+#: shown there at all (a kind absent from this map gets no row).
+#:
+#: The wording is deliberately hedged.  These strings are a small model's
+#: best guess at what the item *is*, produced to letter a map, not curated
+#: ground truth: a caption misreads occasionally and a tag list is only the
+#: top-k nearest vocabulary terms, which always returns *something* even for
+#: an item nothing in the vocabulary describes.  Titling the row "AI Caption"
+#: / "AI Tags" tells the user where it came from and how much to trust it;
+#: "Description" or "Category" would not.  :data:`KIND_CONTENT` is absent
+#: because it is the item's own text, already shown by the viewer.
+TEXT_KIND_LABELS = {KIND_CAPTION: "AI Caption", KIND_TAGS: "AI Tags"}
 
 #: Progress callback shape: ``(current, total, message)``.
 ProgressFn = Callable[[int, int, str], None]
@@ -65,6 +103,17 @@ class SignpostTextProvider(Protocol):
 
     @property
     def name(self) -> str: ...
+
+    @property
+    def text_kind(self) -> str:
+        """Which of :data:`TEXT_KINDS` this provider produces.
+
+        Drives how the text is titled where it surfaces to the user (see
+        :data:`TEXT_KIND_LABELS`), so it describes the *flavour* of the text,
+        not the model: every generative captioner is ``caption``, every
+        zero-shot vocabulary matcher is ``tags``.
+        """
+        ...
 
     def signature(self, embedder: Any) -> str:
         """Cache key for texts produced by this provider under *embedder*."""
@@ -107,6 +156,10 @@ class ZeroShotTagProvider:
     top_k: int = 5
     #: User-supplied vocabulary; empty ⇒ load ``vocab_asset`` from the package.
     vocab_terms: tuple[str, ...] = ()
+
+    @property
+    def text_kind(self) -> str:
+        return KIND_TAGS
 
     def with_terms(self, terms: tuple[str, ...] | list[str]) -> ZeroShotTagProvider:
         """Return a copy tagging against *terms* instead of the shipped asset.
@@ -152,6 +205,10 @@ class ContentTextProvider:
     field: str = "content"
     max_chars: int = 2000
 
+    @property
+    def text_kind(self) -> str:
+        return KIND_CONTENT
+
     def signature(self, embedder: Any) -> str:
         return self.name
 
@@ -191,8 +248,45 @@ class FallbackTextProvider:
     def name(self) -> str:
         return f"{self.primary.name}+{self.fallback.name}"
 
+    @property
+    def text_kind(self) -> str:
+        """The *primary*'s kind — the composite's nominal flavour.
+
+        Only a nominal answer: which half actually produced any given item is
+        decided per item, so callers that need the true per-item kind use
+        :meth:`build_kinded` (or :func:`build_kinded_texts`) instead.
+        """
+        return self.primary.text_kind
+
     def signature(self, embedder: Any) -> str:
         return f"{self.primary.signature(embedder)}|fallback={self.fallback.signature(embedder)}"
+
+    def build_kinded(
+        self,
+        ids: list[int],
+        medias: dict[int, dict[str, Any]],
+        matrix: np.ndarray,
+        embedder: Any,
+        on_progress: ProgressFn | None = None,
+    ) -> dict[int, tuple[str, str]]:
+        """Texts paired with the kind of the half that produced each one."""
+        try:
+            produced = build_kinded_texts(self.primary, ids, medias, matrix, embedder, on_progress)
+        except Exception:
+            logger.warning(
+                "Signpost captioner %r failed to run; falling back to %r.",
+                self.primary.name,
+                self.fallback.name,
+                exc_info=True,
+            )
+            produced = {}
+        missing = [mid for mid in ids if not produced.get(mid, ("", ""))[0]]
+        if missing:
+            row_of = {mid: i for i, mid in enumerate(ids)}
+            sub = matrix[[row_of[mid] for mid in missing]] if matrix.size else matrix
+            filled = build_kinded_texts(self.fallback, missing, medias, sub, embedder, on_progress)
+            produced = {**filled, **produced}
+        return produced
 
     def build_texts(
         self,
@@ -202,23 +296,33 @@ class FallbackTextProvider:
         embedder: Any,
         on_progress: ProgressFn | None = None,
     ) -> dict[int, str]:
-        try:
-            produced = self.primary.build_texts(ids, medias, matrix, embedder, on_progress)
-        except Exception:
-            logger.warning(
-                "Signpost captioner %r failed to run; falling back to %r.",
-                self.primary.name,
-                self.fallback.name,
-                exc_info=True,
-            )
-            produced = {}
-        missing = [mid for mid in ids if not produced.get(mid)]
-        if missing:
-            row_of = {mid: i for i, mid in enumerate(ids)}
-            sub = matrix[[row_of[mid] for mid in missing]] if matrix.size else matrix
-            filled = self.fallback.build_texts(missing, medias, sub, embedder, on_progress)
-            produced = {**filled, **produced}
-        return produced
+        return {
+            mid: text for mid, (text, _kind) in self.build_kinded(ids, medias, matrix, embedder, on_progress).items()
+        }
+
+
+def build_kinded_texts(
+    provider: SignpostTextProvider,
+    ids: list[int],
+    medias: dict[int, dict[str, Any]],
+    matrix: np.ndarray,
+    embedder: Any,
+    on_progress: ProgressFn | None = None,
+) -> dict[int, tuple[str, str]]:
+    """Run *provider*, pairing each text with the kind that produced it.
+
+    A plain provider stamps every text with its own :attr:`text_kind`; a
+    composite that resolves items from more than one source (today only
+    :class:`FallbackTextProvider`) answers per item through an optional
+    ``build_kinded`` method.  Empty texts are dropped either way, so a caller
+    can treat "present in the mapping" as "has a usable text".
+    """
+    kinded = getattr(provider, "build_kinded", None)
+    if kinded is not None:
+        return kinded(ids, medias, matrix, embedder, on_progress)
+    kind = getattr(provider, "text_kind", "")
+    built = provider.build_texts(ids, medias, matrix, embedder, on_progress)
+    return {mid: (text, kind) for mid, text in built.items() if text}
 
 
 # ---------------------------------------------------------------------------
@@ -414,16 +518,60 @@ def ensure_signpost_texts(
     if missing:
         row_of = {mid: i for i, mid in enumerate(ids)}
         sub = matrix[[row_of[mid] for mid in missing]] if matrix.size else matrix
-        built = provider.build_texts(missing, medias, sub, embedder, on_progress)
-        for mid, text in built.items():
+        built = build_kinded_texts(provider, missing, medias, sub, embedder, on_progress)
+        for mid, (text, kind) in built.items():
             media = medias.get(mid)
             if media is None or not text:
                 continue
             media[TEXT_FIELD] = text
             media[SOURCE_FIELD] = signature
+            if kind:
+                # A third-party provider that declares no kind leaves the field
+                # off rather than stamping a blank; ``_infer_kind`` still gets a
+                # shot at recovering one from the signature at display time.
+                media[KIND_FIELD] = kind
             texts[mid] = text
 
     return texts or None
+
+
+def _infer_kind(source: Any) -> str:
+    """Best-effort kind for a text cached before :data:`KIND_FIELD` existed.
+
+    Datasets prepped by an earlier build stamped only the provider signature.
+    A single-provider signature names its own kind in its first segment
+    (``tags:openimages600:siglip``, ``caption:qwen2.5-vl-3b``, ``content``),
+    so it can be recovered exactly.  A composite ``…|fallback=…`` signature
+    cannot: it says the captioner was *active*, not that it produced *this*
+    item, and calling a degraded tag list a caption is precisely the kind of
+    over-claiming the labels exist to avoid.  So that case yields no kind —
+    and therefore no metadata row — rather than a guess.
+    """
+    if not isinstance(source, str) or "|fallback=" in source:
+        return ""
+    head = source.split(":", 1)[0]
+    return head if head in TEXT_KINDS else ""
+
+
+def signpost_metadata_entry(media: dict[str, Any]) -> tuple[str, str] | None:
+    """``(label, text)`` for *media*'s cached signpost text, or ``None``.
+
+    The bridge from the sign pipeline's per-media text to the item metadata
+    the labeling UI shows: media types call this from ``display_metadata`` so
+    a dataset prepped for Browse also explains each item in the focus view.
+    Returns ``None`` when the media has no cached text, or when its kind
+    isn't one we surface (see :data:`TEXT_KIND_LABELS`).
+    """
+    text = media.get(TEXT_FIELD)
+    if not isinstance(text, str) or not text.strip():
+        return None
+    kind = media.get(KIND_FIELD)
+    if not isinstance(kind, str) or not kind:
+        kind = _infer_kind(media.get(SOURCE_FIELD))
+    label = TEXT_KIND_LABELS.get(kind)
+    if label is None:
+        return None
+    return label, text.strip()
 
 
 def texts_signature(medias: dict[int, dict[str, Any]], embedder: Any) -> str | None:
@@ -456,13 +604,22 @@ _register_default_captioners()
 __all__ = [
     "ContentTextProvider",
     "FallbackTextProvider",
+    "KIND_CAPTION",
+    "KIND_CONTENT",
+    "KIND_FIELD",
+    "KIND_TAGS",
+    "PERSISTED_FIELDS",
     "SignpostTextProvider",
     "TEXT_FIELD",
+    "TEXT_KINDS",
+    "TEXT_KIND_LABELS",
     "SOURCE_FIELD",
     "ZeroShotTagProvider",
+    "build_kinded_texts",
     "ensure_signpost_texts",
     "provider_for",
     "register_signpost_captioner",
     "register_signpost_text_provider",
+    "signpost_metadata_entry",
     "texts_signature",
 ]


### PR DESCRIPTION
A dataset prepped for Browse already pays for a model-generated text per media — the caption (image VLM / audio captioner) or top-k tag list (zero-shot CLAP/SigLIP) that letters the Toponymy map. Until now only the sign pipeline read it. This surfaces it in the labeling UI's metadata grid, so the item view says what the model thinks the item is.

### Titled by kind, deliberately hedged

The row is **"AI Caption"** or **"AI Tags"** — never a bare "Description" or "Category". A caption misreads occasionally, and a tag list is only the nearest vocabulary terms, which always returns *something* even for an item nothing in the vocabulary describes. The label's job is to say where the text came from and how much to trust it. The mapping lives in one place (`TEXT_KIND_LABELS`); a kind absent from it gets no row, which is how the text media type's own content stays out (nothing generated it, and the viewer already shows it).

### Per-item kind, not per-provider

With a captioner enabled, `FallbackTextProvider` serves tags for any item the model couldn't decode — so a signature-level answer would label those a caption, which is exactly the over-claiming the hedge exists to prevent. Providers now declare a `text_kind`; the composite reports it *per item* via a new `build_kinded`; `ensure_signpost_texts` stamps `signpost_text_kind` alongside the text and signature.

Datasets prepped before that field existed still get a row: `_infer_kind` recovers the kind from a single-provider signature (`tags:…`, `caption:…`, `content`), and returns nothing for a `…|fallback=…` composite rather than guessing.

### Pickle round-trip fix

`export_dataset_to_file` writes an explicit field list, so `signpost_text` / `signpost_text_source` silently dropped on every save — despite the ingest stage caching them *before* the registry write specifically to persist them. In practice every reload was re-running the caption/tag models. All three fields (`PERSISTED_FIELDS`) now round-trip, restored on both the thin and full pickle-load paths.

### Frontend

`.metadata-value` now breaks between words instead of mid-word (`break-all` stays on the MD5), matching what the browse bin popup already does — the grid carries prose values now, not just identifiers. No other frontend change: the row flows through `custom_metadata`, which the center panel and bin popup already render.

### Tests

- `tests_lib/projection/test_signpost_texts.py` — kind declaration, `build_kinded_texts`, per-item kinds through a fallback, stamping, and every `signpost_metadata_entry` branch (including the legacy-signature inference and its refusal on a composite).
- `tests_lib/projection/test_signpost_item_metadata.py` — the row through `display_metadata` on image/audio/text, type-specific fields untouched, and no extra row on an unprepped media.
- `tests_lib/datasets/test_signpost_text_persistence.py` — the pickle round-trip.
- `tests/core/test_media_list_edge_paths.py` — the row arriving over `POST /api/medias/batch`.

`./run-tests.sh` green: 6736 passed, 1 skipped, 1 xfailed, 1 xpassed.

### Notes

- **No screenshot reshoots queued.** The new row only appears on signpost-prepped datasets, and the doc-screenshot fixtures are synthetic and unprepped; the wrap change only differs where a value wraps mid-word, which the short values in the framed tray don't.
- Label exports (`/api/labels/export`) go through the same `display_metadata`, so a prepped dataset's exports gain an "AI Caption"/"AI Tags" column in `available_columns`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011k7HV9qM6ccYBgpieALQAD)_