### PR TITLE
Move labelset media ingest off the request thread onto a progress task

### DIFF
--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -255,6 +255,44 @@ all of them.
 
 → `{"ok": true, "detector": {...}}` (201)
 
+### Register detector from a label importer
+
+```
+POST /api/detectors/registry/from-labelset/{importer_name}
+```
+
+**Form or Body:** `name`, optional `embedder_type`, plus the importer's own
+fields (plugin-dependent, so not described in `/api/openapi.json`).
+
+Runs the label importer and creates a detector seeded with the labels it
+returns. The media type is inferred from the labels' origins; labels spanning
+more than one media type are rejected (400).
+
+→ ```json
+{
+  "ok": true,
+  "detector": {...},
+  "applied": 12,
+  "skipped": 0,
+  "num_labels": 12,
+  "ingest_task_id": "_detingest_<detector_id>"
+}
+```
+
+An imported labelset usually references media the active dataset doesn't have,
+which must be pulled in from their origins for the labels to be visible and
+exportable. That fetch + embed runs on a **background task** streamed on the
+`detector-loading-tasks` channel of [`/api/events`](events.md), so the request
+returns immediately; `ingest_task_id` names it, and is `""` when there is
+nothing to ingest (no active dataset, or every label already resolves).
+
+**Wait for that task before loading the detector.** Loading restores the
+labelset into votes by resolving each label against the active dataset's
+media, so a load that starts mid-ingest silently drops the labels whose media
+haven't landed yet. The task's terminal frame carries
+`"ingest_result": {"ingested": 12}`; cancel it with
+`POST /api/detectors/cancel/{task_id}`.
+
 ### Toggle Auto-Find flag
 
 ```

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -77,6 +77,12 @@ phase, so consumers should prefer it for the progress bar and fall back to
 `dataset_id`, `detector_id`, `media_type`, `embedder` are only present
 when the task carries that information.
 
+Some tasks add a terminal result payload, `null` until they finish:
+combine-datasets staging publishes `staging_result`, and a labelset-media
+ingest (see [detectors.md](detectors.md) and [io.md](io.md)) publishes
+`ingest_result` — `{"ingested", "applied", "unresolved", "failed"}`, with only
+`ingested` present on the detector-import path.
+
 ## Frame format
 
 ```

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -87,15 +87,34 @@ POST /api/label-importers/import/{importer_name}
 {
   "applied": 8,
   "skipped": 2,
-  "missing_count": 3,
-  "missing": [...],
-  "ingested": 1,
-  "message": "Applied 8 label(s), skipped 2. Auto-resolved 1 missing element(s) from their sources. 3 element(s) could not be resolved."
+  "missing_count": 0,
+  "missing": [],
+  "ingest_task_id": "_labelingest_<detector_id>",
+  "ingest_pending_count": 3,
+  "failed_count": 0,
+  "failed": [],
+  "message": "Applied 8 label(s), skipped 2. Resolving 3 missing element(s) from their sources in the background…"
 }
 ```
 
-When `missing_count > 0`, the frontend can call `ingest-missing` to pull those
-medias from their origins.
+`applied` / `skipped` describe only the entries that matched media already in
+the active dataset. Entries that matched nothing are auto-resolved from their
+origins on a **background task** — one fetch + embed per entry is far too slow
+to run inside the request. `ingest_pending_count` is how many were handed off
+and `ingest_task_id` names the task on the `detector-loading-tasks` SSE
+channel; `missing_count` / `missing` stay empty because nothing is known to be
+unresolvable until that task finishes. Both are `""` / `0` when every entry
+matched.
+
+Watch the task on `/api/events`; its terminal frame carries
+
+```json
+"ingest_result": {"ingested": 3, "applied": 3, "unresolved": 0, "failed": 0}
+```
+
+The task re-applies the labels of whatever it ingested and re-syncs the loaded
+detector, so no follow-up call is needed. Cancel it with
+`POST /api/detectors/cancel/{task_id}`.
 
 ### Ingest missing medias
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -375,6 +375,18 @@
         </div>
       }
 
+      @if (ingestTask()) {
+        <div class="ingest-progress">
+          <vt-progress-bar
+            [value]="ingestBar.value"
+            [max]="ingestBar.max"
+            [indeterminate]="ingestBar.indeterminate"
+            [pulsing]="!!ingestBar.pulsing"
+          ></vt-progress-bar>
+          <p class="info-text">{{ ingestMessage }}</p>
+        </div>
+      }
+
       @if (error()) {
         <p class="error-text">{{ error() }}</p>
       }

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.scss
@@ -341,3 +341,12 @@
   &:hover { color: var(--text-primary); text-decoration: underline; }
   &:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 }
+
+// Progress readout for the background media ingest that Create & Import waits
+// on, so a long fetch reads as work in flight instead of a stuck dialog.
+.ingest-progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  margin-top: var(--space-sm);
+}

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -1,7 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HttpTestingController } from '@angular/common/http/testing';
+import { Subject } from 'rxjs';
 import { NewDetectorModalComponent } from './new-detector-modal.component';
+import { ProgressEventsService } from '../../../services/progress-events.service';
+import type { LoadingTask } from '../../../models/api.models';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
 import { provideHttpTesting } from '../../../testing/test-providers';
 
@@ -434,6 +437,64 @@ describe('NewDetectorModalComponent', () => {
       .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
     expect(component.labelImporterDynamicError()['q']).toBe('boom');
     expect(component.labelImporterOptionsFor(field)).toEqual([]);
+  });
+
+  // --- Create & Import: the background labelset-media ingest (#2703) ---
+
+  /** Fill in the Trained tab's form and submit it. */
+  function submitTrained(): void {
+    component.tab = 'trained';
+    component.trainedView = 'form';
+    component.selectedLabelImporter = { name: 'server_json_file' } as any;
+    component.name.set('Imported');
+    component.submit();
+  }
+
+  it('waits for the labelset-media ingest before loading the new detector', () => {
+    const feed = new Subject<LoadingTask>();
+    const spy = vi
+      .spyOn(TestBed.inject(ProgressEventsService), 'detectorTaskUntilDone$')
+      .mockReturnValue(feed.asObservable());
+    vi.spyOn(component.created, 'emit');
+
+    submitTrained();
+    httpMock
+      .expectOne('/api/detectors/registry/from-labelset/server_json_file')
+      .flush({ ok: true, detector: { id: 'd9' }, ingest_task_id: '_detingest_d9' });
+
+    expect(spy).toHaveBeenCalledWith('_detingest_d9');
+    // Loading now would restore the labels against media that aren't in the
+    // dataset yet (#2690), so the load must not have gone out.
+    httpMock.expectNone('/api/detectors/registry/load');
+    expect(component.submitting()).toBe(true);
+
+    feed.next({ task_id: '_detingest_d9', status: 'loading', current: 1, total: 2 } as LoadingTask);
+    expect(component.ingestTask()?.current).toBe(1);
+    expect(component.ingestBar).toEqual({ value: 1, max: 2, indeterminate: false });
+    httpMock.expectNone('/api/detectors/registry/load');
+
+    feed.complete();
+    const load = httpMock.expectOne('/api/detectors/registry/load');
+    expect(load.request.body.detector_id).toBe('d9');
+    load.flush({ ok: true });
+
+    expect(component.ingestTask()).toBeNull();
+    expect(component.submitting()).toBe(false);
+    expect(component.created.emit).toHaveBeenCalledWith('d9');
+  });
+
+  it('loads straight away when the import had nothing to ingest', () => {
+    const spy = vi.spyOn(TestBed.inject(ProgressEventsService), 'detectorTaskUntilDone$');
+    vi.spyOn(component.created, 'emit');
+
+    submitTrained();
+    httpMock
+      .expectOne('/api/detectors/registry/from-labelset/server_json_file')
+      .flush({ ok: true, detector: { id: 'd0' }, ingest_task_id: '' });
+
+    expect(spy).not.toHaveBeenCalled();
+    httpMock.expectOne('/api/detectors/registry/load').flush({ ok: true });
+    expect(component.created.emit).toHaveBeenCalledWith('d0');
   });
 });
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -11,6 +11,7 @@ import { DatasetsRegistryApiService } from '../../../services/datasets-registry-
 import { DatasetsUiApiService } from '../../../services/datasets-ui-api.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
+import { ProgressEventsService } from '../../../services/progress-events.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import {
   EmbedderCapabilityService,
@@ -23,9 +24,12 @@ import {
   ImporterField,
   ImporterInfo,
   ImporterPickerTab,
+  LoadingTask,
   Media,
   MediaTypeInfo,
 } from '../../../models/api.models';
+import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { formatProgressMessage, progressBarState, type ProgressBarState } from '../../../utils/format-progress';
 import type { LabelImporterEntry } from '../../../generated/api-client/models/label-importer-entry';
 import { DemoDatasetEntry } from '../../../generated/api-client/models/demo-dataset-entry';
 import {
@@ -57,7 +61,7 @@ interface MediaExampleItem {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-new-detector-modal',
   standalone: true,
-  imports: [FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent, FieldHintIconComponent],
+  imports: [FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent, FieldHintIconComponent, ProgressBarComponent],
   templateUrl: './new-detector-modal.component.html',
   styleUrl: './new-detector-modal.component.scss',
 })
@@ -69,6 +73,7 @@ export class NewDetectorModalComponent implements OnInit {
   private datasetsUiApi = inject(DatasetsUiApiService);
   private sortingApi = inject(SortingApiService);
   private labelImportersApi = inject(LabelImportersApiService);
+  private progressEvents = inject(ProgressEventsService);
   private settingsState = inject(SettingsStateService);
   private embedderCaps = inject(EmbedderCapabilityService);
   private mediaState = inject(MediaStateService);
@@ -111,6 +116,11 @@ export class NewDetectorModalComponent implements OnInit {
   readonly mediaTypeInfos = signal<MediaTypeInfo[]>([]);
   readonly submitting = signal(false);
   readonly error = signal('');
+
+  /** Live snapshot of the background task that pulls the imported labels'
+   *  media into the active dataset, while Create & Import waits it out.
+   *  ``null`` when no ingest is running. */
+  readonly ingestTask = signal<LoadingTask | null>(null);
 
   /** The user's *explicit* embedder-type pick (the detector's locked scoring
    *  space *kind*). Empty means "not chosen": the displayed value falls back to
@@ -1108,15 +1118,22 @@ export class NewDetectorModalComponent implements OnInit {
             this.error.set('Server did not return a detector id');
             return;
           }
-          this.detectorsRegistryApi.loadDetector(newId).subscribe({
-            next: () => {
-              this.submitting.set(false);
-              this.created.emit(newId);
-            },
-            error: () => {
-              // Model exists in registry even if load failed; still emit.
-              this.submitting.set(false);
-              this.created.emit(newId);
+          const ingestTaskId = String(resp?.ingest_task_id || '');
+          if (!ingestTaskId) {
+            this.loadAndFinish(newId);
+            return;
+          }
+          // The imported labels' media are still being fetched and embedded in
+          // the background (#2703). Loading the detector now would restore its
+          // labels against media that aren't in the dataset yet, so wait the
+          // ingest out — showing its bar instead of an opaque spinner. A failed
+          // ingest still completes the stream: the detector exists either way,
+          // and the failure surfaces as a toast from the SSE error router.
+          this.progressEvents.detectorTaskUntilDone$(ingestTaskId).subscribe({
+            next: (task) => this.ingestTask.set(task),
+            complete: () => {
+              this.ingestTask.set(null);
+              this.loadAndFinish(newId);
             },
           });
         },
@@ -1125,6 +1142,31 @@ export class NewDetectorModalComponent implements OnInit {
           this.error.set(apiErrorMessage(err, 'Failed to create detector from labelset'));
         },
       });
+  }
+
+  /** Load the freshly-created detector, then hand its id back to the caller.
+   *  A failed load still emits: the detector is in the registry regardless. */
+  private loadAndFinish(detectorId: string): void {
+    this.detectorsRegistryApi.loadDetector(detectorId).subscribe({
+      next: () => {
+        this.submitting.set(false);
+        this.created.emit(detectorId);
+      },
+      error: () => {
+        this.submitting.set(false);
+        this.created.emit(detectorId);
+      },
+    });
+  }
+
+  /** Bar geometry for the running media ingest. */
+  get ingestBar(): ProgressBarState {
+    return progressBarState(this.ingestTask());
+  }
+
+  /** One-line status for the running media ingest. */
+  get ingestMessage(): string {
+    return formatProgressMessage(this.ingestTask(), 'Fetching the imported labels’ media…');
   }
 
   // --- Submit ---

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -184,6 +184,18 @@
         <p class="info-text">This importer requires no additional configuration.</p>
       }
 
+      @if (ingestTask()) {
+        <div class="ingest-progress">
+          <vt-progress-bar
+            [value]="ingestBar.value"
+            [max]="ingestBar.max"
+            [indeterminate]="ingestBar.indeterminate"
+            [pulsing]="!!ingestBar.pulsing"
+          ></vt-progress-bar>
+          <p class="info-text">{{ ingestMessage }}</p>
+        </div>
+      }
+
       @if (error()) {
         <p class="error-text">{{ error() }}</p>
       }

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.scss
@@ -112,3 +112,12 @@
     cursor: not-allowed;
   }
 }
+
+// Progress readout for the background auto-resolve of entries whose media
+// weren't in the dataset, so a long fetch reads as work in flight.
+.ingest-progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  margin-top: var(--space-sm);
+}

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
@@ -1,7 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HttpTestingController } from '@angular/common/http/testing';
+import { Subject } from 'rxjs';
 import { LabelImporterModalComponent } from './label-importer-modal.component';
+import { ProgressEventsService } from '../../../services/progress-events.service';
+import type { LoadingTask } from '../../../models/api.models';
 import { configureZoneless } from '../../../testing/zoneless-testbed';
 import { settleResource, settleZoneless } from '../../../testing/settle-resource';
 import { provideHttpTesting } from '../../../testing/test-providers';
@@ -223,5 +226,83 @@ describe('LabelImporterModalComponent', () => {
     const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
     expect(err).toBeTruthy();
     expect(err.textContent).toContain('Import blew up');
+  });
+
+  // --- Background auto-resolve of unmatched entries (#2703) ---
+
+  /** Start an import that hands its unmatched entries to a background task. */
+  async function submitWithPendingIngest(taskId = '_labelingest_d1') {
+    await flushInit();
+    const feed = new Subject<LoadingTask>();
+    vi.spyOn(TestBed.inject(ProgressEventsService), 'detectorTaskUntilDone$').mockReturnValue(
+      feed.asObservable(),
+    );
+    component.selectImporter(mockImporters[0] as any);
+    component.submit();
+    httpMock.expectOne('/api/label-importers/import/server_json_file').flush({
+      applied: 3,
+      skipped: 0,
+      missing_count: 0,
+      missing: [],
+      ingest_task_id: taskId,
+      ingest_pending_count: 2,
+      failed_count: 0,
+      failed: [],
+      message: 'Applied 3 label(s), skipped 0. Resolving 2 missing element(s)…',
+    });
+    return feed;
+  }
+
+  it('stays busy while the auto-resolve task runs, then reports the totals', async () => {
+    const feed = await submitWithPendingIngest();
+    // The response landed, but the import isn't done: the missing entries are
+    // still being fetched, so the dialog keeps its progress affordance.
+    expect(component.submitting()).toBe(true);
+
+    feed.next({ task_id: '_labelingest_d1', status: 'loading', current: 1, total: 2 } as LoadingTask);
+    expect(component.ingestTask()?.current).toBe(1);
+    expect(component.ingestBar).toEqual({ value: 1, max: 2, indeterminate: false });
+
+    feed.next({
+      task_id: '_labelingest_d1',
+      status: 'idle',
+      ingest_result: { ingested: 2, applied: 2, unresolved: 0, failed: 0 },
+    } as LoadingTask);
+    feed.complete();
+
+    expect(component.submitting()).toBe(false);
+    expect(component.ingestTask()).toBeNull();
+    // 3 applied in the request + 2 the background pass resolved.
+    expect(component.successMessage()).toBe(
+      'Applied 5 label(s). Auto-resolved 2 missing element(s) from their sources.',
+    );
+    expect(component.error()).toBe('');
+    component.close();
+  });
+
+  it('surfaces entries the auto-resolve pass could not reach', async () => {
+    const feed = await submitWithPendingIngest();
+    feed.next({
+      task_id: '_labelingest_d1',
+      status: 'idle',
+      ingest_result: { ingested: 0, applied: 0, unresolved: 2, failed: 0 },
+    } as LoadingTask);
+    feed.complete();
+
+    expect(component.successMessage()).toBe('Applied 3 label(s).');
+    expect(component.error()).toBe(
+      '2 element(s) could not be resolved from their original sources.',
+    );
+    component.close();
+  });
+
+  it('reports a failed auto-resolve task as an error', async () => {
+    const feed = await submitWithPendingIngest();
+    feed.next({ task_id: '_labelingest_d1', status: 'idle', error: 'origin unreachable' } as LoadingTask);
+    feed.complete();
+
+    expect(component.submitting()).toBe(false);
+    expect(component.error()).toBe('Could not resolve the missing elements: origin unreachable');
+    component.close();
   });
 });

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -16,26 +16,40 @@ import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { FieldHintIconComponent } from '../../field-hint-icon/field-hint-icon.component';
+import { Subscription } from 'rxjs';
 import { LabelImportersApiService } from '../../../services/label-importers-api.service';
 import { MediasApiService } from '../../../services/medias-api.service';
+import { ProgressEventsService } from '../../../services/progress-events.service';
 import { VoteStateService } from '../../../services/vote-state.service';
-import { FieldOption, ImporterField } from '../../../models/api.models';
+import { FieldOption, ImporterField, LoadingTask } from '../../../models/api.models';
 import type { LabelImporterEntry } from '../../../generated/api-client/models/label-importer-entry';
 import { apiErrorMessage } from '../../../utils/api-error';
+import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
+import { formatProgressMessage, progressBarState, type ProgressBarState } from '../../../utils/format-progress';
 
 type ModalView = 'picker' | 'form';
+
+/** Terminal counts an auto-resolve ingest task publishes as `ingest_result`
+ *  (see `vtsearch/routes/labels/importers.py::_apply_ingested_labels`). */
+interface IngestResult {
+  ingested?: number;
+  applied?: number;
+  unresolved?: number;
+  failed?: number;
+}
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-label-importer-modal',
   standalone: true,
-  imports: [FormsModule, ModalComponent, IconComponent, FieldHintIconComponent],
+  imports: [FormsModule, ModalComponent, IconComponent, FieldHintIconComponent, ProgressBarComponent],
   templateUrl: './label-importer-modal.component.html',
   styleUrl: './label-importer-modal.component.scss',
 })
 export class LabelImporterModalComponent implements OnDestroy {
   private labelImportersApi = inject(LabelImportersApiService);
   private mediasApi = inject(MediasApiService);
+  private progressEvents = inject(ProgressEventsService);
   private voteState = inject(VoteStateService);
 
   /** When set, labels are imported directly into this trainable model
@@ -86,6 +100,11 @@ export class LabelImporterModalComponent implements OnDestroy {
   readonly dynamicFieldError = signal<Record<string, string>>({});
   readonly addingGood = signal(false);
   readonly addingBad = signal(false);
+
+  /** Live snapshot of the background task that pulls in the media of labels
+   *  the active dataset didn't have. ``null`` when no ingest is running. */
+  readonly ingestTask = signal<LoadingTask | null>(null);
+  private ingestSub: Subscription | null = null;
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   get modalTitle(): string {
@@ -228,32 +247,96 @@ export class LabelImporterModalComponent implements OnDestroy {
 
     request$.subscribe({
       next: (res: any) => {
-        this.submitting.set(false);
         this.successMessage.set(res.message || `Applied ${res.applied ?? 0} labels`);
+        // The labels that already resolved are live now, so refresh the grid
+        // even while the auto-resolve pass is still fetching the rest.
         this.imported.emit();
 
-        if (res.missing_count > 0 && res.missing?.length) {
-          // Show unresolved elements as a warning but don't prompt; the
-          // backend already tried to auto-resolve them.
-          this.importError.set(
-            `${res.missing_count} element(s) could not be resolved from their original sources.`,
-          );
-        } else if (res.failed_count > 0) {
-          // Per-entry application failures (logical-bug-audit H31); the
-          // import partially landed and the user should know which entries
-          // need to be retried.
-          this.importError.set(
-            `${res.failed_count} element(s) failed to apply. The remaining labels were applied successfully.`,
-          );
+        const ingestTaskId = String(res?.ingest_task_id || '');
+        if (ingestTaskId) {
+          this.awaitAutoResolve(ingestTaskId, Number(res.applied ?? 0));
+          return;
         }
-        const hasIssue = res.missing_count > 0 || res.failed_count > 0;
-        this.closeTimer = setTimeout(() => this.close(), hasIssue ? 3000 : 1500);
+        this.submitting.set(false);
+        this.finishImport(
+          res.message || `Applied ${res.applied ?? 0} labels`,
+          res.missing_count ?? 0,
+          res.failed_count ?? 0,
+        );
       },
       error: (err) => {
         this.submitting.set(false);
         this.importError.set(apiErrorMessage(err, 'Import failed'));
       },
     });
+  }
+
+  /**
+   * Track the background auto-resolve of entries whose media weren't in the
+   * dataset (#2703) and report its outcome once it lands.
+   *
+   * The import response only describes the in-request pass; fetching and
+   * embedding the missing media happens on a detector task, which publishes
+   * the rest of the numbers as `ingest_result`. `appliedInRequest` is what the
+   * first pass already applied, so the final line can report the total.
+   */
+  private awaitAutoResolve(taskId: string, appliedInRequest: number): void {
+    this.ingestSub?.unsubscribe();
+    this.ingestSub = this.progressEvents.detectorTaskUntilDone$(taskId).subscribe({
+      next: (task) => this.ingestTask.set(task),
+      complete: () => {
+        const task = this.ingestTask();
+        this.ingestTask.set(null);
+        this.ingestSub = null;
+        this.submitting.set(false);
+
+        if (task?.error) {
+          this.importError.set(`Could not resolve the missing elements: ${task.error}`);
+          this.finishImport(`Applied ${appliedInRequest} label(s).`, 0, 0);
+          return;
+        }
+        const result = (task?.ingest_result ?? {}) as IngestResult;
+        const resolved = result.ingested ?? 0;
+        let message = `Applied ${appliedInRequest + (result.applied ?? 0)} label(s).`;
+        if (resolved > 0) {
+          message += ` Auto-resolved ${resolved} missing element(s) from their sources.`;
+          // The re-applied labels are new votes; refresh so they show up.
+          this.imported.emit();
+        }
+        this.finishImport(message, result.unresolved ?? 0, result.failed ?? 0);
+      },
+    });
+  }
+
+  /** Render the terminal outcome and schedule the auto-close. */
+  private finishImport(message: string, missingCount: number, failedCount: number): void {
+    this.successMessage.set(message);
+    if (missingCount > 0) {
+      // Show unresolved elements as a warning but don't prompt; the
+      // backend already tried to auto-resolve them.
+      this.importError.set(
+        `${missingCount} element(s) could not be resolved from their original sources.`,
+      );
+    } else if (failedCount > 0) {
+      // Per-entry application failures (logical-bug-audit H31); the
+      // import partially landed and the user should know which entries
+      // need to be retried.
+      this.importError.set(
+        `${failedCount} element(s) failed to apply. The remaining labels were applied successfully.`,
+      );
+    }
+    const hasIssue = missingCount > 0 || failedCount > 0;
+    this.closeTimer = setTimeout(() => this.close(), hasIssue ? 3000 : 1500);
+  }
+
+  /** Bar geometry for the running auto-resolve ingest. */
+  get ingestBar(): ProgressBarState {
+    return progressBarState(this.ingestTask());
+  }
+
+  /** One-line status for the running auto-resolve ingest. */
+  get ingestMessage(): string {
+    return formatProgressMessage(this.ingestTask(), 'Resolving missing elements…');
   }
 
 
@@ -315,5 +398,9 @@ export class LabelImporterModalComponent implements OnDestroy {
       clearTimeout(this.closeTimer);
       this.closeTimer = null;
     }
+    // The ingest itself keeps running on the server (and reports on the
+    // dashboard); we just stop rendering it.
+    this.ingestSub?.unsubscribe();
+    this.ingestSub = null;
   }
 }

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -77,6 +77,12 @@ export interface ProgressEvent {
   overall?: number | null;
   /** Dataset-only: payload returned by combine-datasets staging. */
   staging_result?: unknown;
+  /**
+   * Detector-only: terminal counts published by a labelset-media ingest task
+   * (`{ingested, applied, unresolved, failed}`); see
+   * `vtscore/datasets/ingest_task.py`. `null`/absent until the task finishes.
+   */
+  ingest_result?: unknown;
   [key: string]: unknown;
 }
 

--- a/frontend/src/app/services/progress-events.service.spec.ts
+++ b/frontend/src/app/services/progress-events.service.spec.ts
@@ -2,6 +2,7 @@ import { Component, WritableSignal, inject, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProgressEventsService } from './progress-events.service';
 import { ConnectionStateService, ConnectionStatus } from './connection-state.service';
+import type { LoadingTask } from '../models/api.models';
 import { configureZoneless } from '../testing/zoneless-testbed';
 import { settleZoneless } from '../testing/settle-resource';
 
@@ -97,6 +98,75 @@ describe('ProgressEventsService liveness wiring', () => {
     recordSuccess.mockClear();
     es.emit('dataset', { status: 'loading', current: 5, total: 10 });
     expect(recordSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  // --- detectorTaskUntilDone$: awaiting one task's terminal frame (#2703) ---
+
+  /** Subscribe to `detectorTaskUntilDone$` and record what it emits. */
+  function watchTask(taskId: string) {
+    const seen: LoadingTask[] = [];
+    const state = { completed: false };
+    TestBed.inject(ProgressEventsService)
+      .detectorTaskUntilDone$(taskId)
+      .subscribe({
+        next: (task) => seen.push(task),
+        complete: () => {
+          state.completed = true;
+        },
+      });
+    return { seen, state };
+  }
+
+  it('emits only the named task and completes on its terminal frame', () => {
+    const es = connectedSource();
+    const { seen, state } = watchTask('_detingest_d9');
+    TestBed.tick();
+
+    es.emit('detector-loading-tasks', [{ task_id: '_detload_other', status: 'loading' }]);
+    TestBed.tick();
+    expect(seen).toEqual([]);
+
+    es.emit('detector-loading-tasks', [
+      { task_id: '_detingest_d9', status: 'loading', current: 2, total: 5 },
+    ]);
+    TestBed.tick();
+    expect(seen.map((t) => t.current)).toEqual([2]);
+    expect(state.completed).toBe(false);
+
+    es.emit('detector-loading-tasks', [
+      { task_id: '_detingest_d9', status: 'idle', ingest_result: { ingested: 5 } },
+    ]);
+    TestBed.tick();
+    expect(seen.at(-1)?.ingest_result).toEqual({ ingested: 5 });
+    expect(state.completed).toBe(true);
+  });
+
+  it('completes when a task it has seen is pruned from the feed', () => {
+    const es = connectedSource();
+    const { state } = watchTask('_detingest_d9');
+    TestBed.tick();
+
+    es.emit('detector-loading-tasks', [{ task_id: '_detingest_d9', status: 'loading' }]);
+    TestBed.tick();
+    expect(state.completed).toBe(false);
+
+    // The tracker drops finished tasks after their stale-prune window.
+    es.emit('detector-loading-tasks', []);
+    TestBed.tick();
+    expect(state.completed).toBe(true);
+  });
+
+  it('keeps waiting while the task has not appeared yet', () => {
+    const es = connectedSource();
+    const { seen, state } = watchTask('_detingest_d9');
+    TestBed.tick();
+
+    // The backend registers the task before answering the request that hands
+    // back its id, so an empty feed here just means the frame is in flight.
+    es.emit('detector-loading-tasks', []);
+    TestBed.tick();
+    expect(seen).toEqual([]);
+    expect(state.completed).toBe(false);
   });
 });
 

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnDestroy, computed, effect, inject, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { filter, map, takeWhile } from 'rxjs/operators';
 import {
   LoadingTask,
   ProgressEvent,
@@ -110,6 +111,34 @@ export class ProgressEventsService implements OnDestroy {
   });
 
   readonly votingIterations$ = toObservable(this.votingIterations);
+
+  /**
+   * Snapshots of one detector-loading task, completing once it finishes.
+   *
+   * Emits every snapshot of `taskId` seen on the `detector-loading-tasks`
+   * channel and completes on the terminal one (`status === 'idle'`, which
+   * carries the task's `error` / `ingest_result`), so a caller can render a
+   * live bar in `next` and take the follow-up step in `complete`. A task that
+   * vanishes from the feed after being seen — the tracker prunes finished
+   * entries — also completes the stream.
+   *
+   * Snapshots *before* the task appears are ignored rather than treated as
+   * completion: the backend registers the task before answering the request
+   * that returned its id, so the row is either already in the current
+   * snapshot or one frame away.
+   */
+  detectorTaskUntilDone$(taskId: string): Observable<LoadingTask> {
+    let seen = false;
+    return this.detectorLoadingTasks$.pipe(
+      map((tasks) => tasks.find((t) => t.task_id === taskId) ?? null),
+      filter((task) => {
+        if (task) seen = true;
+        return seen;
+      }),
+      map((task) => task ?? ({ task_id: taskId, status: 'idle' } as LoadingTask)),
+      takeWhile((task) => task.status !== 'idle', true),
+    );
+  }
 
   // -------------------------------------------------------------------------
   // EventSource lifecycle.

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -313,6 +313,9 @@ export function formatProgressHeader(
   } else if (/converting/i.test(message)) {
     phase = 'converting media';
     subtitle = 'Running the converter on each input file.';
+  } else if (kind === 'detector' && /missing media|re-?ingesting/i.test(message)) {
+    phase = 'fetching media';
+    subtitle = "Pulling the imported labels' media in from their original sources.";
   } else if (kind === 'detector' && /restoring labels/i.test(message)) {
     phase = 'restoring labels';
     subtitle = 'Reading the saved labelset for this detector.';

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,32 @@
 """Test package for VTSearch."""
 
 
+def wait_for_detector_task(task_id, timeout=30.0):
+    """Block until the detector task *task_id* finishes; return its snapshot.
+
+    Used by tests of the label-import paths, whose media ingest now runs on a
+    background task (issue #2703) rather than inside the request. The returned
+    snapshot carries the task's terminal ``error`` / ``ingest_result``.
+
+    Fails loudly via ``pytest.fail`` on timeout rather than letting the caller
+    assert against a half-finished ingest.
+    """
+    import time
+
+    import pytest
+
+    from vtscore.concurrency.progress import detector_loading_tasks
+
+    assert task_id, "wait_for_detector_task needs a task id"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if detector_loading_tasks.is_finished(task_id):
+            tracker = detector_loading_tasks.get_tracker(task_id)
+            return tracker.get() if tracker is not None else {}
+        time.sleep(0.02)
+    pytest.fail(f"wait_for_detector_task timed out after {timeout}s waiting for {task_id!r}")
+
+
 def load_detector_and_wait(client, detector_id, timeout=30.0):
     """Load a detector via POST and poll until the background task finishes.
 

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -6,6 +6,7 @@ import shutil
 import pytest
 
 from tests import load_detector_and_wait as _load_detector_and_wait
+from tests import wait_for_detector_task as _wait_for_detector_task
 from vtscore.embedding.media_vectors import media_embedding
 from vtsearch.settings import get_detectors_dir
 from vtscore.utils.hashing import content_md5
@@ -2600,8 +2601,13 @@ class TestRegisterModelFromLabelset:
             json={"name": "Foreign", "filepath": str(labels_path)},
         )
         assert res.status_code == 201, res.get_json()
-        assert res.get_json()["ingested"] == 2, "imported media must be pulled into the active dataset"
-        detector_id = res.get_json()["detector"]["id"]
+        body = res.get_json()
+        # The ingest runs on a background task (#2703); the detector must not be
+        # loaded until it lands, or label restore runs against absent media.
+        snapshot = _wait_for_detector_task(body["ingest_task_id"])
+        assert snapshot.get("error") in (None, ""), snapshot
+        assert snapshot["ingest_result"] == {"ingested": 2}, "imported media must be pulled into the active dataset"
+        detector_id = body["detector"]["id"]
 
         _load_detector_and_wait(client, detector_id)
 
@@ -2647,5 +2653,5 @@ class TestRegisterModelFromLabelset:
             json={"name": "NoDataset", "filepath": str(labels_path)},
         )
         assert res.status_code == 201, res.get_json()
-        assert res.get_json()["ingested"] == 0
+        assert res.get_json()["ingest_task_id"] == ""
         assert res.get_json()["num_labels"] == 1

--- a/tests/io/test_label_import_endpoint.py
+++ b/tests/io/test_label_import_endpoint.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 
 import app as app_module
+from tests import wait_for_detector_task
 from vtscore.utils.hashing import content_md5
 
 
@@ -510,9 +511,14 @@ class TestLabelImportMissingElements:
         assert res.status_code == 200
         result = res.get_json()
         assert result["applied"] == 1
-        assert result["missing_count"] == 1
-        assert result["missing"][0]["md5"] == "unknown_abc123"
-        assert result["missing"][0]["origin"]["importer"] == "server_folder"
+        # Unmatched entries are handed to a background auto-resolve task
+        # (#2703), so the response reports how many are pending, not how many
+        # turned out to be unresolvable.
+        assert result["ingest_pending_count"] == 1
+        assert result["missing_count"] == 0
+        assert result["missing"] == []
+        snapshot = wait_for_detector_task(result["ingest_task_id"])
+        assert snapshot["ingest_result"]["unresolved"] == 1
 
     def test_no_missing_when_all_match(self, client, tmp_path):
         md5 = app_module.medias[1]["md5"]
@@ -565,13 +571,15 @@ class TestLabelImportMissingElements:
             )
             assert res.status_code == 200
             result = res.get_json()
-            # Both labels should be applied (1 existing + 1 auto-resolved)
-            assert result["applied"] == 2
-            assert result["ingested"] == 1
-            assert result["missing_count"] == 0
-            assert result["missing"] == []
+            # The in-request pass applies only what already resolved; the
+            # auto-resolve of the rest runs on a background task (#2703).
+            assert result["applied"] == 1
+            assert result["ingest_pending_count"] == 1
             # Auto-resolved entries must not double-decrement skipped (regression).
             assert result["skipped"] == 0
+
+            snapshot = wait_for_detector_task(result["ingest_task_id"])
+            assert snapshot["ingest_result"] == {"ingested": 1, "applied": 1, "unresolved": 0, "failed": 0}
             # The new media should be in the dataset and labeled
             new_ids = [cid for cid, m in app_module.medias.items() if m.get("md5") == md5]
             assert len(new_ids) == 1
@@ -605,9 +613,11 @@ class TestLabelImportMissingElements:
         assert res.status_code == 200
         result = res.get_json()
         assert result["applied"] == 1
-        assert result["missing_count"] == 1
-        assert result["missing"][0]["md5"] == "totally_unknown_md5"
-        assert "could not be resolved" in result["message"]
+        assert result["ingest_pending_count"] == 1
+        assert "in the background" in result["message"]
+        # The origin path doesn't exist, so the background pass resolves none.
+        snapshot = wait_for_detector_task(result["ingest_task_id"])
+        assert snapshot["ingest_result"] == {"ingested": 0, "applied": 0, "unresolved": 1, "failed": 0}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/io/test_label_import_endpoint.py
+++ b/tests/io/test_label_import_endpoint.py
@@ -69,8 +69,10 @@ class TestLabelImportEndpoint:
         assert res.status_code == 200
         result = res.get_json()
         assert result["applied"] == 0
-        assert result["missing_count"] == 1
-        assert len(result["missing"]) == 1
+        # Unmatched rows go to the background auto-resolve pass (#2703).
+        assert result["ingest_pending_count"] == 1
+        snapshot = wait_for_detector_task(result["ingest_task_id"])
+        assert snapshot["ingest_result"]["unresolved"] == 1
 
     def test_json_importer_skips_invalid_label_value(self, client, tmp_path):
         md5 = app_module.medias[1]["md5"]
@@ -113,7 +115,9 @@ class TestLabelImportEndpoint:
         assert res.status_code == 200
         result = res.get_json()
         assert result["applied"] == 0
-        assert result["missing_count"] == 1
+        assert result["ingest_pending_count"] == 1
+        snapshot = wait_for_detector_task(result["ingest_task_id"])
+        assert snapshot["ingest_result"]["unresolved"] == 1
 
     def test_import_overrides_existing_label(self, client, tmp_path):
         app_module.good_votes[1] = None

--- a/tests/io/test_label_importers.py
+++ b/tests/io/test_label_importers.py
@@ -14,6 +14,7 @@ import json
 import pytest
 
 import app as app_module
+from tests import wait_for_detector_task
 
 
 # ---------------------------------------------------------------------------
@@ -482,5 +483,8 @@ class TestServerCsvLabelImporter:
         assert result["applied"] == 0, "no labels should be applied via basename collision"
         assert 1 not in app_module.good_votes
         assert 2 not in app_module.bad_votes
-        # The rows are reported as missing (subject to ingest-missing recovery).
-        assert result["missing_count"] >= 0
+        # The rows are handed to the background auto-resolve pass (#2703),
+        # which can't reach them either (no origin), so they stay unresolved.
+        assert result["ingest_pending_count"] == 2
+        snapshot = wait_for_detector_task(result["ingest_task_id"])
+        assert snapshot["ingest_result"]["unresolved"] == 2

--- a/tests/io/test_labelset_ingest_task.py
+++ b/tests/io/test_labelset_ingest_task.py
@@ -1,0 +1,205 @@
+"""The labelset media ingest runs as a background task, not inside the request.
+
+Both import paths pull the media of labels the active dataset doesn't have in
+from their origins, which is one fetch + embed per label.  Issue #2703: that
+used to run inline, so the request hung for the duration (and a long enough
+ingest hit a gateway timeout with the import already half-applied).  Both now
+hand the work to ``detector_loading_tasks`` and answer immediately with a
+task id.
+
+Covers, for ``POST /api/detectors/registry/from-labelset/<importer>`` and
+``POST /api/label-importers/import/<importer>``:
+
+- the request returns while the ingest is still running,
+- the task is visible on the detector-task tracker (the SSE feed's source),
+- cancelling the task surfaces as ``error="Cancelled"``,
+- the task publishes its terminal counts as ``ingest_result``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from vtscore.concurrency.progress import detector_loading_tasks
+from vtscore.datasets import ingest as ingest_module
+
+from tests import wait_for_detector_task
+
+
+@pytest.fixture
+def foreign_labels(tmp_path):
+    """A labels JSON file whose two entries resolve to no loaded media.
+
+    Returns ``(labels_path, clips_dir)``.  The clips are real files on disk so
+    a non-stubbed ingest can actually resolve them.
+    """
+    from helpers import make_wav_file
+
+    clips_dir = tmp_path / "ingest_task_clips"
+    clips_dir.mkdir()
+    origin = {
+        "importer": "server_folder",
+        "params": {"path": str(clips_dir), "media_type": "audio"},
+    }
+    entries = []
+    for i, (freq, label) in enumerate(((311.0, "good"), (523.0, "bad")), start=1):
+        path = make_wav_file(clips_dir, f"task_{i}.wav", frequency=freq)
+        entries.append(
+            {
+                "md5": hashlib.md5(path.read_bytes()).hexdigest(),
+                "label": label,
+                "origin": origin,
+                "origin_name": path.name,
+                "filename": path.name,
+            }
+        )
+    labels_path = tmp_path / "task_labels.json"
+    labels_path.write_text(json.dumps({"labels": entries}))
+    return labels_path, clips_dir
+
+
+class _BlockingIngest:
+    """Stand-in for ``ingest_missing_medias`` that parks until released."""
+
+    def __init__(self) -> None:
+        self.started = threading.Event()
+        self.release = threading.Event()
+        self.entry_count = 0
+
+    def __call__(self, entries, medias, on_progress=None):
+        self.entry_count = len(entries)
+        self.started.set()
+        if on_progress is not None:
+            on_progress("ingesting", "Re-ingesting from server_folder…", 0, len(entries))
+        # Deliberately unbounded except for the release: a bounded loop can
+        # outrun a slow cancel on a loaded machine (see CLAUDE.md).
+        self.release.wait(timeout=30)
+        if on_progress is not None:
+            # The real ingest reports per item, so a cancel raised between
+            # items is what actually stops it; report once more so a test that
+            # cancelled mid-park sees the same path.
+            on_progress("ingesting", "Re-ingesting from server_folder…", 1, len(entries))
+        return 0
+
+
+def _active_task(task_id: str) -> dict:
+    """The tracker snapshot for *task_id*, asserted to still be running."""
+    matches = [t for t in detector_loading_tasks.list_tasks() if t["task_id"] == task_id]
+    assert matches, f"task {task_id!r} is not on the detector task tracker"
+    assert matches[0]["status"] != "idle", f"task {task_id!r} already finished"
+    return matches[0]
+
+
+class TestFromLabelsetIngestIsBackgrounded:
+    def test_request_returns_while_ingest_runs(self, client, foreign_labels):
+        labels_path, _ = foreign_labels
+        blocker = _BlockingIngest()
+
+        with patch.object(ingest_module, "ingest_missing_medias", blocker):
+            res = client.post(
+                "/api/detectors/registry/from-labelset/server_json_file",
+                json={"name": "BackgroundIngest", "filepath": str(labels_path)},
+            )
+            assert res.status_code == 201, res.get_json()
+            task_id = res.get_json()["ingest_task_id"]
+            assert task_id, "the route must hand back the ingest task id"
+            assert blocker.started.wait(timeout=10)
+            # The response landed while the ingest is still parked, which is
+            # the whole point: the modal is no longer held open by the fetch.
+            assert _active_task(task_id)["detector_id"] == res.get_json()["detector"]["id"]
+            assert blocker.entry_count == 2
+            blocker.release.set()
+
+        wait_for_detector_task(task_id)
+
+    def test_cancel_stops_the_ingest(self, client, foreign_labels):
+        labels_path, _ = foreign_labels
+        blocker = _BlockingIngest()
+
+        with patch.object(ingest_module, "ingest_missing_medias", blocker):
+            res = client.post(
+                "/api/detectors/registry/from-labelset/server_json_file",
+                json={"name": "CancelledIngest", "filepath": str(labels_path)},
+            )
+            task_id = res.get_json()["ingest_task_id"]
+            assert blocker.started.wait(timeout=10)
+
+            cancel = client.post(f"/api/detectors/cancel/{task_id}")
+            assert cancel.status_code == 200
+            blocker.release.set()
+
+        snapshot = wait_for_detector_task(task_id)
+        # The stub reports progress once *after* the cancel flag is set, and
+        # the task's progress callback is what raises CancelledError.
+        assert snapshot["error"] == "Cancelled"
+
+    def test_ingest_result_reports_what_landed(self, client, foreign_labels):
+        labels_path, _ = foreign_labels
+        res = client.post(
+            "/api/detectors/registry/from-labelset/server_json_file",
+            json={"name": "ResultIngest", "filepath": str(labels_path)},
+        )
+        assert res.status_code == 201, res.get_json()
+        snapshot = wait_for_detector_task(res.get_json()["ingest_task_id"])
+        assert not snapshot["error"]
+        assert snapshot["ingest_result"] == {"ingested": 2}
+
+
+class TestLabelImportIngestIsBackgrounded:
+    def test_request_returns_while_auto_resolve_runs(self, client, foreign_labels):
+        labels_path, _ = foreign_labels
+        blocker = _BlockingIngest()
+
+        with patch.object(ingest_module, "ingest_missing_medias", blocker):
+            res = client.post(
+                "/api/label-importers/import/server_json_file",
+                json={"filepath": str(labels_path)},
+            )
+            assert res.status_code == 200, res.get_json()
+            body = res.get_json()
+            task_id = body["ingest_task_id"]
+            assert task_id
+            assert body["ingest_pending_count"] == 2
+            assert "in the background" in body["message"]
+            assert blocker.started.wait(timeout=10)
+            _active_task(task_id)
+            blocker.release.set()
+
+        wait_for_detector_task(task_id)
+
+    def test_auto_resolve_applies_labels_and_publishes_counts(self, client, foreign_labels):
+        """The backgrounded pass still lands the votes the inline one used to."""
+        import app as app_module
+
+        labels_path, _ = foreign_labels
+        saved = dict(app_module.medias)
+        try:
+            res = client.post(
+                "/api/label-importers/import/server_json_file",
+                json={"filepath": str(labels_path)},
+            )
+            assert res.status_code == 200, res.get_json()
+            snapshot = wait_for_detector_task(res.get_json()["ingest_task_id"])
+            assert snapshot["ingest_result"] == {
+                "ingested": 2,
+                "applied": 2,
+                "unresolved": 0,
+                "failed": 0,
+            }
+            names = {m.get("origin_name") for m in app_module.medias.values()}
+            assert {"task_1.wav", "task_2.wav"} <= names
+            voted = set(app_module.good_votes) | set(app_module.bad_votes)
+            ingested_ids = {
+                cid
+                for cid, m in app_module.medias.items()
+                if m.get("origin_name") in ("task_1.wav", "task_2.wav")
+            }
+            assert ingested_ids <= voted, "auto-resolved media must carry their labels"
+        finally:
+            app_module.medias.clear()
+            app_module.medias.update(saved)

--- a/tests/io/test_labelset_ingest_task.py
+++ b/tests/io/test_labelset_ingest_task.py
@@ -195,9 +195,7 @@ class TestLabelImportIngestIsBackgrounded:
             assert {"task_1.wav", "task_2.wav"} <= names
             voted = set(app_module.good_votes) | set(app_module.bad_votes)
             ingested_ids = {
-                cid
-                for cid, m in app_module.medias.items()
-                if m.get("origin_name") in ("task_1.wav", "task_2.wav")
+                cid for cid, m in app_module.medias.items() if m.get("origin_name") in ("task_1.wav", "task_2.wav")
             }
             assert ingested_ids <= voted, "auto-resolved media must carry their labels"
         finally:

--- a/tests_lib/io/test_ingest_task.py
+++ b/tests_lib/io/test_ingest_task.py
@@ -24,14 +24,19 @@ def _sync_spawn(target, name=None):
 ENTRIES = [{"md5": "a", "origin": {"importer": "server_folder", "params": {}}}]
 
 
+def _snapshot(task_id: str) -> dict:
+    """The tracker snapshot for *task_id*, asserted to exist."""
+    tracker = detector_loading_tasks.get_tracker(task_id)
+    assert tracker is not None, f"task {task_id!r} was never registered"
+    return tracker.get()
+
+
 class TestStartIngestTask:
     def test_publishes_ingested_count_as_ingest_result(self):
         with patch.object(ingest_module, "ingest_missing_medias", lambda *a, **k: 3):
-            task_id = start_ingest_task(
-                ENTRIES, {}, task_id="_t_ok", name="Det", spawn=_sync_spawn, detector_id="d1"
-            )
+            task_id = start_ingest_task(ENTRIES, {}, task_id="_t_ok", name="Det", spawn=_sync_spawn, detector_id="d1")
         assert task_id == "_t_ok"
-        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+        snapshot = _snapshot(task_id)
         assert snapshot["status"] == "idle"
         assert snapshot["error"] in (None, "")
         assert snapshot["ingest_result"] == {"ingested": 3}
@@ -49,7 +54,7 @@ class TestStartIngestTask:
                 ENTRIES, {}, task_id="_t_after", name="Det", spawn=_sync_spawn, after_ingest=after
             )
         assert seen == {"ingested": 3}
-        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+        snapshot = _snapshot(task_id)
         assert snapshot["ingest_result"] == {"ingested": 3, "applied": 2, "unresolved": 0}
 
     def test_task_row_carries_its_association_fields(self):
@@ -73,10 +78,8 @@ class TestStartIngestTask:
             raise RuntimeError("origin unreachable")
 
         with patch.object(ingest_module, "ingest_missing_medias", boom):
-            task_id = start_ingest_task(
-                ENTRIES, {}, task_id="_t_err", name="Det", spawn=_sync_spawn
-            )
-        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+            task_id = start_ingest_task(ENTRIES, {}, task_id="_t_err", name="Det", spawn=_sync_spawn)
+        snapshot = _snapshot(task_id)
         assert snapshot["error"] == "origin unreachable"
         assert snapshot["ingest_result"] is None
         assert detector_loading_tasks.is_finished(task_id)
@@ -84,14 +87,13 @@ class TestStartIngestTask:
     def test_cancel_surfaces_as_cancelled(self):
         def cancel_then_report(entries, medias, on_progress=None):
             detector_loading_tasks.cancel_task("_t_cancel")
+            assert on_progress is not None
             on_progress("ingesting", "fetching", 0, 1)
             raise AssertionError("progress callback must raise after a cancel")
 
         with patch.object(ingest_module, "ingest_missing_medias", cancel_then_report):
-            task_id = start_ingest_task(
-                ENTRIES, {}, task_id="_t_cancel", name="Det", spawn=_sync_spawn
-            )
-        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+            task_id = start_ingest_task(ENTRIES, {}, task_id="_t_cancel", name="Det", spawn=_sync_spawn)
+        snapshot = _snapshot(task_id)
         assert snapshot["error"] == "Cancelled"
         assert detector_loading_tasks.is_finished(task_id)
 
@@ -110,11 +112,9 @@ class TestStartIngestTask:
             return 1
 
         with patch.object(ingest_module, "ingest_missing_medias", report_via_thread_hook):
-            task_id = start_ingest_task(
-                ENTRIES, {}, task_id="_t_hook", name="Det", spawn=_sync_spawn
-            )
+            task_id = start_ingest_task(ENTRIES, {}, task_id="_t_hook", name="Det", spawn=_sync_spawn)
         # Terminal update resets the counters, so assert the hook was bound and
         # the run completed cleanly rather than the mid-flight numbers.
-        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+        snapshot = _snapshot(task_id)
         assert snapshot["ingest_result"] == {"ingested": 1}
         assert get_thread_progress() is None, "the hook must be cleared afterwards"

--- a/tests_lib/io/test_ingest_task.py
+++ b/tests_lib/io/test_ingest_task.py
@@ -1,0 +1,120 @@
+"""Unit tests for :func:`vtscore.datasets.ingest_task.start_ingest_task`.
+
+Library tier: no Flask, no routes.  A synchronous ``spawn`` stand-in runs the
+worker inline so the task's bookkeeping (tracker registration, terminal
+``ingest_result``, cancel / error handling, thread-progress binding) can be
+asserted without threading.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from vtscore.concurrency.progress import detector_loading_tasks
+from vtscore.datasets import ingest as ingest_module
+from vtscore.datasets.ingest_task import start_ingest_task
+
+
+def _sync_spawn(target, name=None):
+    """A ``spawn`` stand-in that runs *target* inline."""
+    target()
+    return None
+
+
+ENTRIES = [{"md5": "a", "origin": {"importer": "server_folder", "params": {}}}]
+
+
+class TestStartIngestTask:
+    def test_publishes_ingested_count_as_ingest_result(self):
+        with patch.object(ingest_module, "ingest_missing_medias", lambda *a, **k: 3):
+            task_id = start_ingest_task(
+                ENTRIES, {}, task_id="_t_ok", name="Det", spawn=_sync_spawn, detector_id="d1"
+            )
+        assert task_id == "_t_ok"
+        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+        assert snapshot["status"] == "idle"
+        assert snapshot["error"] in (None, "")
+        assert snapshot["ingest_result"] == {"ingested": 3}
+        assert detector_loading_tasks.is_finished(task_id)
+
+    def test_after_ingest_contributes_to_the_result(self):
+        seen = {}
+
+        def after(ingested: int) -> dict:
+            seen["ingested"] = ingested
+            return {"applied": 2, "unresolved": 0}
+
+        with patch.object(ingest_module, "ingest_missing_medias", lambda *a, **k: 3):
+            task_id = start_ingest_task(
+                ENTRIES, {}, task_id="_t_after", name="Det", spawn=_sync_spawn, after_ingest=after
+            )
+        assert seen == {"ingested": 3}
+        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+        assert snapshot["ingest_result"] == {"ingested": 3, "applied": 2, "unresolved": 0}
+
+    def test_task_row_carries_its_association_fields(self):
+        with patch.object(ingest_module, "ingest_missing_medias", lambda *a, **k: 0):
+            task_id = start_ingest_task(
+                ENTRIES,
+                {},
+                task_id="_t_assoc",
+                name="My Detector",
+                spawn=_sync_spawn,
+                detector_id="det-42",
+                media_type="audio",
+            )
+        row = next(t for t in detector_loading_tasks.list_tasks() if t["task_id"] == task_id)
+        assert row["name"] == "My Detector"
+        assert row["detector_id"] == "det-42"
+        assert row["media_type"] == "audio"
+
+    def test_failure_surfaces_on_the_tracker_and_finishes(self):
+        def boom(*a, **k):
+            raise RuntimeError("origin unreachable")
+
+        with patch.object(ingest_module, "ingest_missing_medias", boom):
+            task_id = start_ingest_task(
+                ENTRIES, {}, task_id="_t_err", name="Det", spawn=_sync_spawn
+            )
+        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+        assert snapshot["error"] == "origin unreachable"
+        assert snapshot["ingest_result"] is None
+        assert detector_loading_tasks.is_finished(task_id)
+
+    def test_cancel_surfaces_as_cancelled(self):
+        def cancel_then_report(entries, medias, on_progress=None):
+            detector_loading_tasks.cancel_task("_t_cancel")
+            on_progress("ingesting", "fetching", 0, 1)
+            raise AssertionError("progress callback must raise after a cancel")
+
+        with patch.object(ingest_module, "ingest_missing_medias", cancel_then_report):
+            task_id = start_ingest_task(
+                ENTRIES, {}, task_id="_t_cancel", name="Det", spawn=_sync_spawn
+            )
+        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+        assert snapshot["error"] == "Cancelled"
+        assert detector_loading_tasks.is_finished(task_id)
+
+    def test_nested_importer_progress_lands_on_this_task(self):
+        """The legacy ingest path reports via ``get_thread_progress``.
+
+        Those frames must reach this task's tracker, not the global dataset
+        bar, or an unrelated progress row lights up mid-import.
+        """
+        from vtscore.concurrency.progress import get_thread_progress
+
+        def report_via_thread_hook(entries, medias, on_progress=None):
+            cb = get_thread_progress()
+            assert cb is not None, "the task must bind the thread-progress hook"
+            cb("ingesting", "Re-ingesting from server_folder", 4, 9)
+            return 1
+
+        with patch.object(ingest_module, "ingest_missing_medias", report_via_thread_hook):
+            task_id = start_ingest_task(
+                ENTRIES, {}, task_id="_t_hook", name="Det", spawn=_sync_spawn
+            )
+        # Terminal update resets the counters, so assert the hook was bound and
+        # the run completed cleanly rather than the mid-flight numbers.
+        snapshot = detector_loading_tasks.get_tracker(task_id).get()
+        assert snapshot["ingest_result"] == {"ingested": 1}
+        assert get_thread_progress() is None, "the hook must be cleared afterwards"

--- a/vtscore/datasets/ingest_task.py
+++ b/vtscore/datasets/ingest_task.py
@@ -1,0 +1,121 @@
+"""Run :func:`~vtscore.datasets.ingest.ingest_missing_medias` as a background task.
+
+Ingesting a labelset's missing media fetches and embeds one file per label
+from its origin, so for a labelset of any real size it is far too slow to sit
+inside a request handler: the caller hangs with no progress and a long enough
+ingest trips a proxy/gateway timeout with the import already half-applied
+(issue #2703).
+
+:func:`start_ingest_task` moves that work onto the same
+``detector_loading_tasks`` tracker the detector load already uses, so it
+streams progress over the existing ``/api/events`` SSE feed and the caller
+gets a task id back immediately.  Both import paths use it — the
+detector-from-labelset route and the in-session label importer — so neither
+one can reintroduce the blocking shape.
+
+The one app-tier dependency, ``vtsearch.threading.spawn`` (which replays the
+request's user / dataset / detector thread-locals into the worker), is
+injected by the caller so this module stays Flask-free, matching
+:mod:`vtscore.detectors.embedder_sync`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+# A ``spawn``-style callable: ``spawn(target, *, name=...) -> Thread``.
+SpawnFn = Callable[..., Any]
+
+#: Called on the worker thread once the ingest itself has finished, with the
+#: number of medias ingested.  Whatever dict it returns is merged into the
+#: task's terminal ``ingest_result`` payload, so a caller can publish the
+#: downstream numbers (labels re-applied, entries still unresolved) that only
+#: become known after the ingest.
+AfterIngest = Callable[[int], "dict[str, Any] | None"]
+
+
+def start_ingest_task(
+    entries: list[dict[str, Any]],
+    medias: Any,
+    *,
+    task_id: str,
+    name: str,
+    spawn: SpawnFn,
+    detector_id: str = "",
+    media_type: str = "",
+    after_ingest: AfterIngest | None = None,
+) -> str:
+    """Ingest *entries* into *medias* on a background thread; return *task_id*.
+
+    Registers a ``detector_loading_tasks`` entry **before** returning, so the
+    caller can hand the id straight back to the client and the SSE feed has
+    already published the row by the time the response lands.
+
+    The task publishes its terminal numbers as an ``ingest_result`` dict on
+    the tracker (``{"ingested": n, ...}`` plus anything *after_ingest*
+    contributes), mirroring how combine-datasets staging publishes
+    ``staging_result``.  A cancel surfaces as ``error="Cancelled"``; any other
+    failure surfaces its message, matching the detector-load task.
+
+    *medias* is the live dataset dict to extend, usually the request-scoped
+    ``medias`` proxy — ``spawn`` replays the dataset context, so the proxy
+    resolves to the same dataset inside the worker.
+    """
+    from vtscore.concurrency.progress import detector_loading_tasks
+
+    tracker = detector_loading_tasks.create_task(
+        task_id,
+        name,
+        detector_id=detector_id,
+        media_type=media_type,
+        extra_fields={"ingest_result": None},
+    )
+    base_msg = f"Fetching {len(entries)} missing media…"
+    tracker.update("loading", base_msg, 0, len(entries), step=1, total_steps=1)
+
+    def ingest_task() -> None:
+        from vtscore.concurrency.progress import (
+            CancelledError,
+            clear_thread_progress,
+            set_thread_progress,
+        )
+        from vtscore.datasets.ingest import ingest_missing_medias
+
+        def _on_progress(status: str, message: str, current: int, total: int) -> None:
+            tracker.check_cancelled()
+            tracker.update("loading", message or base_msg, current, total, step=1, total_steps=1)
+
+        try:
+            # Bind the thread-progress hook too: the legacy ingest path runs a
+            # whole dataset importer, and importers report through
+            # ``get_thread_progress()``.  Without this their frames would land
+            # on the global dataset tracker and light up an unrelated bar.
+            set_thread_progress(_on_progress)
+            try:
+                ingested = ingest_missing_medias(entries, medias, on_progress=_on_progress)
+                result: dict[str, Any] = {"ingested": ingested}
+                if after_ingest is not None:
+                    result.update(after_ingest(ingested) or {})
+            finally:
+                clear_thread_progress()
+            tracker.update("idle", "", 0, 0, ingest_result=result, step=None, total_steps=None)
+        except CancelledError:
+            tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
+        except Exception as e:
+            import traceback as _tb
+
+            _tb.print_exc()
+            tracker.update(
+                "idle",
+                "",
+                0,
+                0,
+                error=str(e) or repr(e) or "Unknown error ingesting missing media",
+                step=None,
+                total_steps=None,
+            )
+        finally:
+            detector_loading_tasks.mark_finished(task_id)
+
+    spawn(ingest_task, name=f"labelset-ingest-{task_id[-12:]}")
+    return task_id

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -215,8 +215,8 @@ def register_detector_route(body: dict):
 # ---------------------------------------------------------------------------
 
 
-def _ingest_imported_labelset_media(label_dicts: list[dict]) -> int:
-    """Pull an imported labelset's media into the active dataset.
+def _start_imported_labelset_ingest(label_dicts: list[dict], entry: dict) -> str:
+    """Start the background pull of an imported labelset's media into the active dataset.
 
     A labelset is origin-keyed and dataset-agnostic, but everything
     downstream of it - vote state, the labeling grid, and above all
@@ -232,11 +232,14 @@ def _ingest_imported_labelset_media(label_dicts: list[dict]) -> int:
     Mirrors what :func:`~vtsearch.routes.labels.importers.run_label_import`
     already does for the in-session label importer, so the two import paths
     land the same media in the same place.  The subsequent detector load then
-    restores those labels into votes normally.
+    restores those labels into votes normally - which is why the caller must
+    let this task *finish* before loading the detector, or label restore runs
+    against medias that aren't there yet.
 
-    Best-effort: the detector is created either way, so an unreachable origin
-    costs the caller nothing beyond an un-ingested media.  Returns the number
-    of medias ingested.
+    The fetch+embed itself is far too slow to run inline (issue #2703), so it
+    goes onto the detector task tracker and reports through the SSE feed.
+    Returns the task id, or ``""`` when there is nothing to ingest (no active
+    dataset, or every label already resolves).
     """
     from vtscore.state.core import get_active_context, is_request_missing_dataset_context
 
@@ -245,19 +248,29 @@ def _ingest_imported_labelset_media(label_dicts: list[dict]) -> int:
         if not ds_ctx.dataset_id or is_request_missing_dataset_context(ds_ctx):
             # No dataset to ingest into; the labels stay origin-only until a
             # dataset is loaded and the detector is (re)loaded against it.
-            return 0
+            return ""
 
-        from vtscore.datasets.ingest import ingest_missing_medias
+        from vtscore.datasets.ingest_task import start_ingest_task
         from vtsearch.state import cached_media_lookups, find_missing_entries, medias
+        from vtsearch.threading import spawn
 
         origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
         missing = find_missing_entries(label_dicts, origin_lookup, md5_lookup, name_lookup)
         if not missing:
-            return 0
-        return ingest_missing_medias(missing, medias)
+            return ""
+        detector_id = entry.get("id", "")
+        return start_ingest_task(
+            missing,
+            medias,
+            task_id=f"_detingest_{detector_id}",
+            name=entry.get("name", detector_id),
+            spawn=spawn,
+            detector_id=detector_id,
+            media_type=entry.get("media_type", "") or "",
+        )
     except Exception:
         logger.exception("Ingesting imported labelset media failed")
-        return 0
+        return ""
 
 
 @detectors_registry_bp.route(
@@ -378,8 +391,11 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
 
     # Materialise any imported label whose media isn't in the active dataset,
     # so the labels are exportable / visible immediately instead of only after
-    # a Browse Positives / Find / Train pass (issue #2690).
-    ingested = _ingest_imported_labelset_media([el.to_dict() for el in elements])
+    # a Browse Positives / Find / Train pass (issue #2690).  Runs in the
+    # background (issue #2703): the caller polls ``ingest_task_id`` on the
+    # detector-task SSE channel and must wait for it before loading the
+    # detector, since label restore resolves against the ingested medias.
+    ingest_task_id = _start_imported_labelset_ingest([el.to_dict() for el in elements], entry)
 
     return jsonify(
         {
@@ -388,7 +404,7 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
             "applied": applied,
             "skipped": skipped,
             "num_labels": len(labelset),
-            "ingested": ingested,
+            "ingest_task_id": ingest_task_id,
         }
     ), 201
 

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -43,6 +43,18 @@ sync block (``sync_labels_to_loaded_detector``,
 ``sync_to_labelset_source``, ``record_detector_import``) whenever
 ``applied > 0`` so the in-memory detector, the labelset source, and the
 achievement counters all reflect what actually landed.
+
+Background auto-resolve
+-----------------------
+Entries whose media aren't in the active dataset are pulled in from their
+origins, which means one fetch + embed per entry - far too slow to run
+inside the request (issue #2703).  :func:`_start_auto_resolve` moves that
+onto the ``detector_loading_tasks`` tracker and the import response carries
+``ingest_task_id`` / ``ingest_pending_count`` instead of the final numbers.
+The task re-applies those labels, re-syncs, and publishes
+``{"ingested", "applied", "unresolved", "failed"}`` as its terminal
+``ingest_result``, which the client reads off the ``detector-loading-tasks``
+SSE channel to report the outcome.
 """
 
 from __future__ import annotations
@@ -129,6 +141,77 @@ def _apply_labels(
         applied += 1
 
     return applied, skipped, failed
+
+
+def _sync_after_import() -> None:
+    """Publish freshly-applied labels: detector, labelset source, achievements.
+
+    Shared by the in-request pass and the background auto-resolve task so the
+    dashboard's ``num_training``, the labelset file, and the import
+    achievement all reflect whatever actually landed, whichever pass landed
+    it.  ``record_detector_import`` dedupes by detector id, so running this
+    from both passes counts the import once.
+    """
+    from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
+    from vtscore.labels.sync import sync_to_labelset_source
+    from vtsearch.achievements import record_detector_import
+    from vtscore.state.core import get_active_detector_context
+
+    sync_labels_to_loaded_detector()
+    sync_to_labelset_source()
+    record_detector_import(get_active_detector_context().detector_id)
+
+
+def _apply_ingested_labels(missing: list[dict], ingested: int) -> dict:
+    """Apply *missing*'s labels once their media have been ingested.
+
+    Runs on the ingest task's worker thread (see
+    :func:`~vtscore.datasets.ingest_task.start_ingest_task`), which replays
+    the request's dataset / detector context, so the lookups and vote writes
+    land where the request's first pass did.  The returned dict is published
+    as the task's terminal ``ingest_result`` so the client can report the
+    same numbers the synchronous response used to carry.
+    """
+    applied = 0
+    failed: list[dict] = []
+    if ingested > 0:
+        origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
+        applied, _, failed = _apply_labels(missing, origin_lookup, md5_lookup, name_lookup)
+
+    unresolved: list[dict] = []
+    if ingested < len(missing):
+        origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
+        unresolved = find_missing_entries(missing, origin_lookup, md5_lookup, name_lookup)
+
+    if applied > 0:
+        _sync_after_import()
+
+    return {"applied": applied, "unresolved": len(unresolved), "failed": len(failed)}
+
+
+def _start_auto_resolve(missing: list[dict]) -> str:
+    """Start the background fetch+embed of *missing*, then re-apply their labels.
+
+    Fetching and embedding one file per missing label is far too slow to run
+    inside the request (issue #2703), so it goes onto the detector task
+    tracker: the caller gets a task id back immediately and watches the
+    existing SSE feed for progress and for the terminal ``ingest_result``.
+    """
+    from vtscore.datasets.ingest_task import start_ingest_task
+    from vtscore.state.core import get_active_detector_context
+    from vtsearch.threading import spawn
+
+    det_ctx = get_active_detector_context()
+    detector_id = det_ctx.detector_id or ""
+    return start_ingest_task(
+        missing,
+        medias,
+        task_id=f"_labelingest_{detector_id}",
+        name=det_ctx.name or "Label import",
+        spawn=spawn,
+        detector_id=detector_id,
+        after_ingest=lambda ingested: _apply_ingested_labels(missing, ingested),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -231,52 +314,20 @@ def run_label_import(importer_name: str):  # noqa: C901
     # by _apply_labels, but we report them separately now.
     skipped -= len(missing)
 
-    # Auto-resolve: try to ingest missing medias from their origins
-    ingested = 0
-    resolved_applied = 0
-    unresolved: list[dict] = []
-    if missing:
-        from vtscore.datasets.ingest import ingest_missing_medias
-
-        ingested = ingest_missing_medias(missing, medias)
-
-        if ingested > 0:
-            # Re-apply labels now that new medias are available.  These entries
-            # were already removed from `skipped` above when we subtracted
-            # `len(missing)`, so we only need to bump `applied` here.  Any
-            # per-entry mutation errors from the auto-resolve pass are
-            # appended to the same `failed` list as the first pass.
-            origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
-            resolved_applied, _, resolved_failed = _apply_labels(missing, origin_lookup, md5_lookup, name_lookup)
-            applied += resolved_applied
-            failed.extend(resolved_failed)
-
-        # Check which entries still couldn't be resolved
-        if ingested < len(missing):
-            origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
-            unresolved = find_missing_entries(missing, origin_lookup, md5_lookup, name_lookup)
+    # Auto-resolve: pull the missing medias in from their origins.  The fetch
+    # + embed runs on a background task (issue #2703) and re-applies those
+    # labels when it lands, so the counts below describe only the in-request
+    # pass; the task publishes its own numbers as ``ingest_result``.
+    ingest_task_id = _start_auto_resolve(missing) if missing else ""
 
     # Sync updated votes into the loaded model so the dashboard reflects
     # the new label count (num_training) immediately.
     if applied > 0:
-        from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
-
-        sync_labels_to_loaded_detector()
-
-        from vtscore.labels.sync import sync_to_labelset_source
-
-        sync_to_labelset_source()
-
-        from vtsearch.achievements import record_detector_import
-        from vtscore.state.core import get_active_detector_context
-
-        record_detector_import(get_active_detector_context().detector_id)
+        _sync_after_import()
 
     msg = f"Applied {applied} label(s), skipped {skipped}."
-    if ingested > 0:
-        msg += f" Auto-resolved {ingested} missing element(s) from their sources."
-    if unresolved:
-        msg += f" {len(unresolved)} element(s) could not be resolved."
+    if ingest_task_id:
+        msg += f" Resolving {len(missing)} missing element(s) from their sources in the background…"
     if failed:
         msg += f" {len(failed)} element(s) failed to apply (see 'failed' for details)."
 
@@ -284,9 +335,13 @@ def run_label_import(importer_name: str):  # noqa: C901
         {
             "applied": applied,
             "skipped": skipped,
-            "missing_count": len(unresolved),
-            "missing": unresolved,
-            "ingested": ingested,
+            # Resolution of the missing entries is still in flight, so nothing
+            # is known to be unresolvable yet; the ingest task's terminal
+            # ``ingest_result`` reports what it couldn't reach.
+            "missing_count": 0,
+            "missing": [],
+            "ingest_task_id": ingest_task_id,
+            "ingest_pending_count": len(missing),
             "failed_count": len(failed),
             "failed": failed,
             "message": msg,


### PR DESCRIPTION
Closes #2703

Both label-import paths pulled the media of unmatched labels in from their origins **inside the request handler** — one fetch + embed per entry. For a labelset of any real size that hung the request for the duration, left the New Detector › Trained modal on an opaque `submitting` spinner, and risked a proxy/gateway timeout with the detector already created and its media half-ingested.

## Backend

New `vtscore/datasets/ingest_task.py::start_ingest_task` runs the ingest on the `detector_loading_tasks` tracker (the one the detector load already uses), so it streams over the existing `/api/events` SSE feed and the detector row renders it. It publishes its terminal counts as an `ingest_result` payload on the tracker, mirroring how combine-datasets staging publishes `staging_result`. Library tier, Flask-free: `vtsearch.threading.spawn` is injected, same shape as `vtscore/detectors/embedder_sync.py`. It also binds `set_thread_progress` so the legacy ingest path's importer frames land on this task instead of the global dataset bar.

Both call sites now hand the work off and answer immediately:

- **`POST /api/detectors/registry/from-labelset/<importer>`** returns `ingest_task_id` in place of `ingested` (`""` when there is nothing to ingest).
- **`POST /api/label-importers/import/<importer>`** returns `ingest_task_id` + `ingest_pending_count`. The task re-applies those labels and re-syncs the loaded detector when it lands, so `missing_count` / `missing` stay empty in the response — nothing is known to be unresolvable until the task reports. Its `ingest_result` carries `{ingested, applied, unresolved, failed}`.

## Frontend

`ProgressEventsService.detectorTaskUntilDone$(taskId)` resolves one task from the SSE feed, emitting each snapshot and completing on the terminal frame (or when a seen task is pruned).

- **New Detector modal** shows that task's bar and waits for it before calling `loadDetector`. This ordering is load-bearing: loading mid-ingest restores labels against media that aren't in the dataset yet, which is exactly the #2690 bug.
- **Label-importer modal** shows the bar and composes its final message from `ingest_result`, including the unresolved / failed / task-error branches.

## Breaking changes

- `from-labelset` no longer returns `ingested`; use `ingest_task_id` and read `ingest_result` off the task.
- `POST /api/label-importers/import/<name>` no longer returns `ingested`, and its `missing` / `missing_count` now describe only what the *in-request* pass knows (always empty when an ingest task was started).

## Tests

- `tests_lib/io/test_ingest_task.py` — the helper: terminal `ingest_result`, `after_ingest` merge, task-row association fields, error, cancel, thread-progress binding.
- `tests/io/test_labelset_ingest_task.py` — both routes: the request returns while a blocked ingest is still parked, the task is live on the tracker, cancel surfaces as `Cancelled`, and the backgrounded pass still lands the votes the inline one used to.
- Frontend specs for `detectorTaskUntilDone$` and both modals' wait-then-finish sequencing.
- Existing tests that asserted the synchronous `ingested` / `missing_count` were updated to wait on the task.

`./run-tests.sh` green (6720 passed, 1 skipped); frontend suite green (1843 passed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVafwZEaL3xG5xAm4AuyKK)_