### PR TITLE
Hide the VTSBrowse details panel when its X is pressed with nothing shown

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -76,8 +76,8 @@
         type="button"
         class="bin-popup-close"
         (click)="close()"
-        [title]="docked() ? 'Clear' : 'Close'"
-        [attr.aria-label]="docked() ? 'Clear' : 'Close'">
+        [title]="closeLabel"
+        [attr.aria-label]="closeLabel">
         &times;
       </button>
     </div>

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -1039,6 +1039,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   // --- Dismissal -----------------------------------------------------------
 
+  /**
+   * What the header's X does right now. Floating it closes the window. Docked
+   * it clears the bin on show; on an already-empty panel there is nothing left
+   * to clear, so the browse view hides the panel instead — say so, since that's
+   * a bigger step than "Clear" implies.
+   */
+  get closeLabel(): string {
+    if (!this.docked()) return 'Close';
+    return this.ids.length === 0 ? 'Hide this panel' : 'Clear';
+  }
+
   close(): void {
     this.dismissed.emit();
   }

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -422,6 +422,22 @@ describe('BrowseBinPopupComponent (docked presentation)', () => {
     fixture.destroy();
   });
 
+  it('labels the X for what it does: Clear with a bin showing, Hide once empty', async () => {
+    const withBin = makeDockedFixture([1, 2]);
+    await settlePasses(withBin);
+    let close = (withBin.nativeElement as HTMLElement).querySelector('.bin-popup-close')!;
+    expect(close.getAttribute('title')).toBe('Clear');
+    withBin.destroy();
+
+    // Empty: there is nothing left to clear, so the X hides the panel — say so.
+    const empty = makeDockedFixture([]);
+    await settlePasses(empty);
+    close = (empty.nativeElement as HTMLElement).querySelector('.bin-popup-close')!;
+    expect(close.getAttribute('title')).toBe('Hide this panel');
+    expect(close.getAttribute('aria-label')).toBe('Hide this panel');
+    empty.destroy();
+  });
+
   it('offers a pop-out button (not the dock button) in the header', async () => {
     const fixture = makeDockedFixture([1, 2]);
     await settlePasses(fixture);

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -42,10 +42,10 @@
       <div
         class="browse-content"
         #content
-        [class.browse-content--details]="detailsDocked()"
+        [class.browse-content--details]="detailsPanelShown()"
         [style.--browse-panel-width]="panelWidth() + 'px'"
         [style.--browse-details-width]="detailsPanelWidth() + 'px'">
-        @if (detailsDocked()) {
+        @if (detailsPanelShown()) {
           <aside class="browse-details" aria-label="Bin details">
             <vt-browse-bin-popup
               [docked]="true"
@@ -57,7 +57,7 @@
               [hoverThumbRadius]="thumbnailRadius"
               [nowPlayingExt]="nowPlaying()"
               [rowDividerDragging]="draggingDetailsRow()"
-              (dismissed)="dismissContextMenu()"
+              (dismissed)="onDetailsDismiss()"
               (popOutRequested)="onPopOutRequested()"
               (rowDividerMouseDown)="onDetailsRowDividerMouseDown($event)"
               (nowPlaying)="onNowPlaying($event)"
@@ -91,9 +91,10 @@
             </button>
             @if (mediaType() === 'audio') {
               <div class="browse-now-playing">
-                <!-- Docked bin details replace this small waveform: the panel's
-                     large detail pane is the now-playing display then. -->
-                @if (!detailsDocked() && nowPlaying(); as np) {
+                <!-- A shown docked bin-details panel replaces this small
+                     waveform: the panel's large detail pane is the now-playing
+                     display then. Dismissing the panel hands the job back here. -->
+                @if (!detailsPanelShown() && nowPlaying(); as np) {
                   <!-- The waveform PNG is a theme-agnostic alpha mask (issue #2369):
                        the surface box mirrors the browse tile, and the inner element
                        masks the accent colour to the wave shape so it recolours with

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, ElementRef, HostListener, inject, NgZone, OnDestroy, OnInit, signal, untracked, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, HostListener, inject, NgZone, OnDestroy, OnInit, signal, untracked, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -230,6 +230,23 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * on the panel, both of which persist the choice.
    */
   readonly detailsDocked = signal(true);
+
+  /**
+   * Whether the user has dismissed the (docked) details panel for now. The
+   * panel's X clears the bin it's showing; pressed again on an already-empty
+   * panel it hides the panel altogether, handing its width back to the canvas.
+   * Right-clicking a bin brings the panel straight back with that bin in it
+   * (see {@link onCanvasContextMenu}), so this is a transient, per-visit
+   * dismissal rather than a remembered presentation choice — the docked /
+   * floating choice stays with {@link detailsDocked}.
+   */
+  readonly detailsPanelHidden = signal(false);
+
+  /** Whether the docked details panel actually renders: docked *and* not
+   *  dismissed. Everything that keys off the panel's presence (the grid
+   *  template, the panel element, the toolbar's now-playing waveform the panel
+   *  otherwise replaces) reads this rather than {@link detailsDocked}. */
+  readonly detailsPanelShown = computed(() => this.detailsDocked() && !this.detailsPanelHidden());
 
   /**
    * Width (CSS px) of the docked bin-details panel, mirrored from the
@@ -1059,6 +1076,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.contextMembers = event.members;
     this.contextRepId = event.repId;
     if (this.detailsDocked()) {
+      // A right-click on a bin always wants the details visible, so it undoes a
+      // previous dismissal (the panel's X on an empty panel) — the panel comes
+      // back, showing this bin. It comes back *docked*: dismissing it never
+      // changed the docked/floating choice.
+      this.detailsPanelHidden.set(false);
       // Docked: the persistent left panel shows the bin — no floating window.
       // Keep the canvas's pinned enlarge (the canvas pinned it on right-click)
       // so the chosen bin stays enlarged while it's open in the panel, exactly
@@ -1071,6 +1093,21 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.contextMenuY = event.clientY;
     this.contextBounds = event.bounds;
     this.contextMenuOpen = true;
+  }
+
+  /**
+   * The docked panel's X. With a bin showing it clears the bin (leaving the
+   * empty panel and its hint); pressed on an already-empty panel there is
+   * nothing left to clear, so it hides the panel itself and gives the width
+   * back to the canvas. Right-clicking any bin brings it back
+   * ({@link onCanvasContextMenu}).
+   */
+  onDetailsDismiss(): void {
+    if (this.contextMembers.length === 0) {
+      this.detailsPanelHidden.set(true);
+      return;
+    }
+    this.dismissContextMenu();
   }
 
   dismissContextMenu(): void {
@@ -1091,6 +1128,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    *  same ``contextMembers``). */
   onDockRequested(): void {
     this.contextMenuOpen = false;
+    // Docking is an explicit ask for the panel, so it clears any earlier
+    // dismissal — otherwise the window would vanish into a hidden panel.
+    this.detailsPanelHidden.set(false);
     // Keep the bin pinned enlarged as it moves into the docked panel — docked
     // bins stay enlarged too now, so there's nothing to release here.
     this.persistBinDetailsDocked(true);

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -211,9 +211,62 @@ describe('BrowseViewComponent (zoneless canary)', () => {
     expect(component.contextMenuOpen).toBe(false);
 
     // The panel's X clears the shown bin but leaves the panel itself docked.
-    component.dismissContextMenu();
+    component.onDetailsDismiss();
     expect(component.contextMembers).toEqual([]);
     expect(component.detailsDocked()).toBe(true);
+    expect(component.detailsPanelShown()).toBe(true);
+  });
+
+  it("hides the empty details panel on a second X, and a right-clicked bin brings it back docked", async () => {
+    await settleZoneless(fixture);
+    const component = fixture.componentInstance;
+    component.detailsDocked.set(true);
+    expect(component.detailsPanelShown()).toBe(true);
+
+    // X with nothing showing: there is no bin left to clear, so the panel itself
+    // goes away and the canvas takes back its width.
+    component.onDetailsDismiss();
+    expect(component.detailsPanelHidden()).toBe(true);
+    expect(component.detailsPanelShown()).toBe(false);
+    // Dismissing is not a presentation change: the docked choice is untouched.
+    expect(component.detailsDocked()).toBe(true);
+
+    // Right-clicking a bin brings the panel back — docked, showing that bin,
+    // with no floating window.
+    component.onCanvasContextMenu({
+      members: [11, 12],
+      repId: 11,
+      clientX: 60,
+      clientY: 70,
+      bounds: null,
+    } as unknown as Parameters<typeof component.onCanvasContextMenu>[0]);
+    expect(component.detailsPanelHidden()).toBe(false);
+    expect(component.detailsPanelShown()).toBe(true);
+    expect(component.contextMenuOpen).toBe(false);
+    expect(component.contextMembers).toEqual([11, 12]);
+  });
+
+  it('un-hides the details panel when a floating window is docked into it', async () => {
+    await settleZoneless(fixture);
+    const component = fixture.componentInstance;
+
+    // Hide the docked panel, then work in the floating presentation instead.
+    component.onDetailsDismiss();
+    expect(component.detailsPanelHidden()).toBe(true);
+    component.detailsDocked.set(false);
+    component.onCanvasContextMenu({
+      members: [21],
+      repId: 21,
+      clientX: 10,
+      clientY: 10,
+      bounds: null,
+    } as unknown as Parameters<typeof component.onCanvasContextMenu>[0]);
+    expect(component.contextMenuOpen).toBe(true);
+
+    // Docking that window must not drop it into a hidden panel.
+    component.onDockRequested();
+    expect(component.detailsPanelHidden()).toBe(false);
+    expect(component.detailsPanelShown()).toBe(true);
   });
 
   it('carries the open bin across dock / pop-out toggles', async () => {


### PR DESCRIPTION
The docked bin-details panel (VTSBrowse's left panel) has an X in its header. With a bin showing it clears the bin; with the panel already empty it had nothing to clear, so it silently did nothing.

Pressed on an empty panel it now **dismisses the panel itself**, handing its width back to the canvas. Right-clicking any bin brings the panel straight back — docked, showing that bin, never as a floating window.

## What changed

- **`browse-view.component.ts`** — new transient `detailsPanelHidden` signal plus a derived `detailsPanelShown() = detailsDocked() && !detailsPanelHidden()`. The panel's `(dismissed)` now routes to `onDetailsDismiss()`, which clears the shown bin when there is one and hides the panel when there isn't. `onCanvasContextMenu` clears the dismissal whenever a bin is right-clicked; `onDockRequested` clears it too, so docking a floating window can't drop it into a panel that isn't there.
- **`browse-view.component.html`** — everything keyed off the panel's presence reads `detailsPanelShown()`: the `browse-content--details` grid template, the `.browse-details` element, and the toolbar's small now-playing waveform (which the docked panel otherwise replaces, so dismissing the panel hands that job back to the toolbar).
- **`browse-bin-popup.component.{ts,html}`** — the header X relabels itself via a new `closeLabel` getter: `Close` floating, `Clear` docked with a bin showing, `Hide this panel` docked once empty — hiding is a bigger step than "Clear" implies.

## Design note

The dismissal is deliberately **transient view state**, separate from the persisted per-media `bin_details_docked` setting. Hiding the panel is not a switch to the floating presentation, and the very next bin right-click undoes it, so there is nothing worth persisting (and no settings-schema change).

## Testing

- New `browse-view.zoneless.spec.ts` cases: the second-X hide + right-click-restore cycle (asserting the panel returns *docked*, with no floating window), and that docking a floating window un-hides the panel.
- New `browse-bin-popup.zoneless.spec.ts` case for the X's `Clear` / `Hide this panel` labelling.
- `./run-tests.sh` — ALL 6747 TESTS PASSED (1 skipped); frontend gate green (build, audit, 1846 Vitest tests).

No screenshot reshoot queued: the panel still renders by default, so no doc shot's framing changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1ToPGEkpW75E6v6xsW66r)_