### PR TITLE
Settings: plain checkboxes for the Browser On/Off toggles

### DIFF
--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -302,28 +302,14 @@
               </div>
             }
             <div class="view-tab-content browser-tab-content">
-              <div class="form-group">
-                <label class="form-label" title="Slide clusters together to close the empty space between them when the map is built">Compaction<vt-field-hint-icon hint="Slides clusters together to close the empty gaps between them. Applies next time the map is built."></vt-field-hint-icon></label>
-                <div class="segmented-toggle segmented-toggle--stretch">
-                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getBrowseCompact(activeBrowseTab())" (click)="onBrowseCompactChange(activeBrowseTab(), true)" title="Close the empty space between clusters">
-                    On
-                  </button>
-                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="!getBrowseCompact(activeBrowseTab())" (click)="onBrowseCompactChange(activeBrowseTab(), false)" title="Keep the map's original spacing">
-                    Off
-                  </button>
-                </div>
-              </div>
-              <div class="form-group">
-                <label class="form-label" title="Letter named region signposts over the map when the dataset has them">Signposts<vt-field-hint-icon hint="Names the map's regions like street signs: broad names when zoomed out, finer names as you zoom in. Only shows when the dataset's map has computed labels."></vt-field-hint-icon></label>
-                <div class="segmented-toggle segmented-toggle--stretch">
-                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="getBrowseSignposts(activeBrowseTab())" (click)="onBrowseSignpostsChange(activeBrowseTab(), true)" title="Show region signposts on the map">
-                    On
-                  </button>
-                  <button class="segmented-toggle__btn" [class.segmented-toggle__btn--active]="!getBrowseSignposts(activeBrowseTab())" (click)="onBrowseSignpostsChange(activeBrowseTab(), false)" title="Hide region signposts">
-                    Off
-                  </button>
-                </div>
-              </div>
+              <label class="checkbox-row" title="Slide clusters together to close the empty space between them when the map is built">
+                <input type="checkbox" [ngModel]="getBrowseCompact(activeBrowseTab())" (ngModelChange)="onBrowseCompactChange(activeBrowseTab(), $event)" aria-label="Compaction" />
+                <span>Compaction<vt-field-hint-icon hint="Slides clusters together to close the empty gaps between them. Applies next time the map is built."></vt-field-hint-icon></span>
+              </label>
+              <label class="checkbox-row" title="Letter named region signposts over the map when the dataset has them">
+                <input type="checkbox" [ngModel]="getBrowseSignposts(activeBrowseTab())" (ngModelChange)="onBrowseSignpostsChange(activeBrowseTab(), $event)" aria-label="Signposts" />
+                <span>Signposts<vt-field-hint-icon hint="Names the map's regions like street signs: broad names when zoomed out, finer names as you zoom in. Only shows when the dataset's map has computed labels."></vt-field-hint-icon></span>
+              </label>
               @if (browseTabHasCaptioner(activeBrowseTab())) {
                 <div class="form-group">
                   <label class="form-label" title="How signpost region names are generated for this media type">Signpost text<vt-field-hint-icon hint="Tags names regions from a fixed vocabulary (fast, no download). Captions runs a generative model to describe each item (sharper on fine-grained sets, but downloads a multi-GB model and runs at build time)."></vt-field-hint-icon></label>


### PR DESCRIPTION
## What

Settings → Browser rendered **Compaction** and **Signposts** — two plain booleans — as full-width two-button `.segmented-toggle--stretch` controls labelled `On` / `Off`. Both are now single `.checkbox-row` checkboxes, matching every other boolean in the Settings modal (Show metadata panel, Enable achievements, Enrich descriptions, Safe thresholds, Hide autopilot panel).

Each checkbox keeps the setting's `title` tooltip and its `vt-field-hint-icon`; the hint icon sits inside the `<label>` but stops click propagation, so clicking `?` opens the tooltip without flipping the checkbox.

## What is deliberately unchanged

The other two-value pickers in the modal keep their segmented toggles, because their options carry distinct meanings rather than reading as "this setting, enabled":

- **Focus mode** — Click / Hover (with icons)
- **Signpost text** — Tags / Captions
- **Mouse-zooms per level** — 1 / 2 / 3 (three-valued anyway)

The read-only `On` / `Off` value on the Server tab (`semantic_only`) is display text, not a control, and is untouched.

## Notes

- No behaviour or settings-schema change: same `getBrowseCompact` / `onBrowseCompactChange` (and signposts equivalents), same per-media-type `browse_compact` / `browse_signposts` dicts.
- No screenshot drift: the only Settings shot in the manifest is `settings-appearance`, which frames the Appearance tab.

## Testing

`./run-tests.sh` — ALL 6747 TESTS PASSED (1 skipped, 1 xfailed). Frontend gate clean: build, `npm audit`, and 1846 Vitest tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GweH7H5jL4k9jm8UQhcW1j)_