### PR TITLE
Make solo media type a server setting instead of a user setting

### DIFF
--- a/app.py
+++ b/app.py
@@ -365,16 +365,17 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
 
     print("\U0001f4da Loading ML libraries...", flush=True)
     initialize_models(on_progress=lambda *a, **k: None)
-    # ``--solo-media-type`` (process-level CLI fallback) tells us which
-    # mediaType's default embedder to warm even if no datasets or detectors
-    # are registered yet. Per-user explicit values are not consulted here
-    # because there is no current user at startup.
-    from vtsearch.settings import get_cli_solo_embedders, get_cli_solo_media_type
+    # The solo-mediaType restriction (``--solo-media-type`` or the persisted
+    # server setting) tells us which mediaType's default embedder to warm even
+    # if no datasets or detectors are registered yet. It is server-tier, so it
+    # resolves without a current user at startup.
+    from vtsearch.settings import get_cli_solo_embedders, get_cli_solo_media_type, get_effective_solo_media_type
 
-    cli_solo = get_cli_solo_media_type()
-    extra_types = [cli_solo] if cli_solo else None
-    if cli_solo:
-        print(f"\U0001f3af Solo mediaType: {cli_solo} (from --solo-media-type)", flush=True)
+    solo = get_effective_solo_media_type()
+    extra_types = [solo] if solo else None
+    if solo:
+        origin = "--solo-media-type" if get_cli_solo_media_type() else "the solo_media_type setting"
+        print(f"\U0001f3af Solo mediaType: {solo} (from {origin})", flush=True)
     cli_solo_embedders = get_cli_solo_embedders()
     extra_embedders = list(cli_solo_embedders.values()) if cli_solo_embedders else None
     if cli_solo_embedders:

--- a/docker/Dockerfile.labbench
+++ b/docker/Dockerfile.labbench
@@ -8,13 +8,14 @@
 #
 # Streamlining knobs (all baked into this image; no flags required):
 #
-#   * Seeded ``data/default/user_settings.json`` locks the UI to
-#     ``solo_media_type = "image"`` and
+#   * Seeded ``data/settings.json`` sets ``solo_media_type = "image"``
+#     (an admin-set server restriction users cannot change) and seeded
+#     ``data/default/user_settings.json`` sets
 #     ``solo_embedder_per_media_type = {"image": "siglip"}``, so the
 #     dataset-importer modal hides both its mediaType picker and the
-#     embedder dropdown. Users can override either in
-#     Settings → Appearance.
-#   * Seeded ``data/settings.json`` sets ``hidden_plugins`` so the
+#     embedder dropdown. Users can override the embedder in
+#     Settings → Import Defaults; the mediaType lock is fixed.
+#   * Seeded ``data/settings.json`` also sets ``hidden_plugins`` so the
 #     Aud2Img (spectrogram) converter and the Downloaded Demo Media
 #     importer are dropped from every picker / listing API response.
 #     See ``vtsearch.settings.get_effective_hidden_plugins`` for the
@@ -120,15 +121,17 @@ RUN if [ -n "$VTSEARCH_VERSION" ]; then echo "$VTSEARCH_VERSION" > vtsearch/_ver
 #   above is only written into a fresh volume). The value is not editable
 #   via the settings API.
 #
+# * ``solo_media_type=image`` locks the dataset-importer and
+#   new-detector flows to image mediaType; the mediaType picker
+#   disappears entirely. It is an admin-set server restriction, so it
+#   applies to every user and is not editable via the settings API (the
+#   Server settings tab shows it read-only). The ``--solo-media-type``
+#   CLI flag would do the same, but there is no argv in the
+#   gunicorn-launched server path, so the setting is seeded into the file
+#   instead.
+#
 # Per-user tier (``data/default/user_settings.json``; the
 # ``DefaultLoginProvider`` resolves to the ``default`` user):
-#
-# * ``solo_media_type=image`` + ``solo_media_type_explicit=true`` locks
-#   the dataset-importer and new-detector flows to image mediaType; the
-#   mediaType picker disappears entirely. ``_explicit=true`` is required
-#   because there's no ``--solo-media-type`` CLI flag in the
-#   gunicorn-launched server path; without it the resolver would
-#   treat the value as unset and fall back to "show everything".
 #
 # * ``solo_embedder_per_media_type={"image": "siglip"}`` hides the
 #   embedder dropdown for image flows and silently uses SigLIP; the
@@ -137,6 +140,7 @@ RUN mkdir -p /app/data /app/data/default && \
     printf '%s\n' \
       '{' \
       '  "dataset_max_age_days": 14,' \
+      '  "solo_media_type": "image",' \
       '  "hidden_plugins": {' \
       '    "converters": ["audio2image"],' \
       '    "importers": ["demo"]' \
@@ -145,8 +149,6 @@ RUN mkdir -p /app/data /app/data/default && \
       > /app/data/settings.json && \
     printf '%s\n' \
       '{' \
-      '  "solo_media_type": "image",' \
-      '  "solo_media_type_explicit": true,' \
       '  "solo_embedder_per_media_type": {"image": "siglip"}' \
       '}' \
       > /app/data/default/user_settings.json

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -570,12 +570,13 @@ suggestions) and resolve via the active `DatasetContext` /
 
 Persistent settings live in `vtsearch/settings.py`, split across two
 tiers.  **Server tier** (shared, `data/settings.json`): `saved_datasets_dir`,
-`detectors_dir`, `max_concurrent_*`, `hidden_plugins`, `semantic_only`.
+`detectors_dir`, `max_concurrent_*`, `hidden_plugins`, `semantic_only`,
+`solo_media_type`.
 **Per-user tier** (`<user_data_dir>/user_settings.json`): everything else;
 `volume`, `theme`, `inclusion`, `enrich_descriptions`, `safe_thresholds`,
 `calibrate_count`, `calibration_fraction`, `audio_playing`, `show_animations`,
 `show_metadata`, `grid_icon_size_*`, `focus_mode_*`,
-`panel_pct_*`, `autopilot_*`, `solo_media_type`, `settings_source`,
+`panel_pct_*`, `autopilot_*`, `settings_source`,
 `achievement_state`, and the **Auto-Find** keys `autofind_detectors`,
 `autofind_exporter`, `autofind_exporter_field_values`.  The Auto-Find keys read
 through to the server file for the built-in `default` user (CLI / single-user

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -383,11 +383,14 @@ python app.py --solo-media-type image
 ```
 
 Valid values are the registered media-type ids (`audio`, `image`,
-`video`, `text`, `document`). The flag is a per-process **fallback**:
-any user who explicitly sets their own solo mediaType (or explicitly
-opts back into "show everything") via the Settings dialog overrides
-the CLI value for themselves, and the choice persists across restarts.
-A user who has never touched the setting sees the CLI value.
+`video`, `text`, `document`). This is an **admin-set server
+restriction**, not a user preference: it applies to every user, users
+cannot change or opt out of it from the Settings dialog (the Server tab
+shows it read-only), and `PUT /api/settings` refuses to touch it. The
+flag is a process-level override of the server-tier `solo_media_type`
+key, so an operator can also set it persistently by writing
+`"solo_media_type": "image"` into `data/settings.json`; the flag wins
+for the lifetime of the process.
 
 **Solo mediaEmbedder** (`--solo-embedder`): lock the embedding model
 for one or more mediaTypes so the dataset-importer modal hides its
@@ -401,9 +404,10 @@ python app.py --solo-embedder image=siglip --solo-embedder audio=clap
 
 Other mediaTypes still show the normal embedder picker. The flag warms
 each locked embedder at startup even when no datasets or detectors are
-registered yet. Same fallback semantics as `--solo-media-type`: any
-user can override per-mediaType via the Settings dialog ("Ask each
-time" is the opt-out), and their choice persists across restarts.
+registered yet. Unlike `--solo-media-type`, this one is a per-process
+**fallback** over a per-user setting: any user can override it
+per-mediaType via the Settings dialog ("Ask each time" is the opt-out),
+and their choice persists across restarts.
 
 **Hidden plugins** (`--hide-plugin family:name`, repeatable): drop a
 plugin from picker / listing API responses for this deployment without

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -579,10 +579,12 @@ controls, remembered per media type:
 
 ### Solo media type - streamline for one media type
 
-If you only ever work with one kind of media (e.g. you exclusively
-search images, optionally pulled in from videos and documents via
-the built-in converters), pick that type under the **Import Defaults**
-tab in the Settings modal (**Solo media type**). Once set:
+If everyone on a server only ever works with one kind of media (e.g.
+they exclusively search images, optionally pulled in from videos and
+documents via the built-in converters), an operator can restrict the
+whole instance to that type. This is an **admin setting, not a user
+preference**: it's set when the server starts and shown read-only on the
+Settings modal's **Server** tab. Once set:
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/settings-appearance.dark.png" />
@@ -594,13 +596,13 @@ tab in the Settings modal (**Solo media type**). Once set:
 - Converter offerings filter to those that produce your type
   (so picking "image" still lets you import videos-as-frames and
   documents-as-pages, just not raw audio).
-- Your chosen type's default embedder is warmed at startup so the
+- The chosen type's default embedder is warmed at startup so the
   first detector run is fast.
 
-Pick **Show everything** to opt back out. Operators can also pass
-`--solo-media-type image` (or any type id) on the command line as a
-fallback for new users - anyone who explicitly changes the setting
-overrides the CLI value for themselves.
+Operators set it by passing `--solo-media-type image` (or any type id)
+on the command line, or by writing `"solo_media_type": "image"` into
+`data/settings.json`. It applies to every user, and there is no
+per-user override.
 
 ---
 
@@ -626,9 +628,9 @@ The Settings modal (gear icon) is organised into eight tabs:
 - **HuggingFace** - sign in with HuggingFace to download gated demo
   datasets and gated AI models.
 - **Import Defaults** - default embedder, clipper, and converters per
-  media type, plus the **Solo media type** picker.
+  media type.
 - **Server** - read-only settings fixed when the server started and
-  shared by everyone.
+  shared by everyone, including the **Solo media type** restriction.
 - **Sorting** - options that control how the trained ranking behaves.
 
 ---

--- a/docs/user/screenshots.manifest.ts
+++ b/docs/user/screenshots.manifest.ts
@@ -289,7 +289,7 @@ export const SHOTS: Shot[] = [
   {
     id: 'settings-appearance',
     embeddedIn: 'docs/user/USER_GUIDE.md#solo-media-type--streamline-for-one-media-type',
-    caption: 'The Settings → Appearance pane: theme picker, the Show Animations pulldown (Show / Hide / OS Setting), the metadata-panel / achievements toggles, and the per-media-type Scroll Style controls (Solo media type lives on the Import Defaults tab)',
+    caption: 'The Settings → Appearance pane: theme picker, the Show Animations pulldown (Show / Hide / OS Setting), the metadata-panel / achievements toggles, and the per-media-type Scroll Style controls (Solo media type is an admin setting, shown read-only on the Server tab)',
     themes: BOTH,
     async recipe(_page, h) {
       await h.dashboard();

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -287,11 +287,6 @@
             "readOnly": true,
             "type": "object"
           },
-          "effective_solo_media_type": {
-            "nullable": true,
-            "readOnly": true,
-            "type": "string"
-          },
           "enable_achievements": {
             "type": "boolean"
           },
@@ -419,10 +414,8 @@
           },
           "solo_media_type": {
             "nullable": true,
+            "readOnly": true,
             "type": "string"
-          },
-          "solo_media_type_explicit": {
-            "type": "boolean"
           },
           "support_email": {
             "readOnly": true,
@@ -5189,10 +5182,6 @@
           },
           "solo_embedder_per_media_type": {
             "nullable": true
-          },
-          "solo_media_type": {
-            "nullable": true,
-            "type": "string"
           },
           "theme": {
             "enum": [
@@ -14511,7 +14500,7 @@
     },
     "/api/settings": {
       "get": {
-        "description": "Augments the persisted dict with the resolver-computed read-only views\n(effective solo mediaType / embedder, effective hidden plugins) via\n:func:`_with_effective`. The frontend reads the ``effective_*`` keys\nwhen deciding whether to hide pickers; the raw ``solo_media_type`` /\n``solo_media_type_explicit`` pair is still exposed for the settings UI\nto render the current state.",
+        "description": "Augments the persisted dict with the resolver-computed read-only views\n(the effective solo mediaType / embedder locks, effective hidden\nplugins) via :func:`_with_effective`. The frontend reads those keys\nwhen deciding whether to hide pickers.",
         "operationId": "get_settings",
         "responses": {
           "200": {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -308,7 +308,7 @@ describe('DatasetImporterModalComponent', () => {
     async function initSolo(solo: string | null): Promise<void> {
       TestBed.tick();
       httpMock.expectOne('/api/dataset/all-importers').flush({ importers: soloImporters, tabs: soloTabs });
-      flushInitRequests(solo ? { effective_solo_media_type: solo } : {});
+      flushInitRequests(solo ? { solo_media_type: solo } : {});
       // The settings rxResource commits its value on a microtask, so let it
       // land before reading the solo-dependent getters.
       await settleResource();

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/import-defaults.service.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/import-defaults.service.spec.ts
@@ -40,7 +40,7 @@ describe('ImportDefaultsService', () => {
   });
 
   it('effectiveSoloMediaType/effectiveSoloFolderName resolve the solo lock', () => {
-    settings.set({ effective_solo_media_type: 'image' });
+    settings.set({ solo_media_type: 'image' });
     expect(service.effectiveSoloMediaType).toBe('image');
     expect(service.effectiveSoloFolderName(mediaTypes)).toBe('images');
   });

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/import-defaults.service.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/import-defaults.service.ts
@@ -67,10 +67,10 @@ export class ImportDefaultsService {
   private settingsState = inject(SettingsStateService);
   private toastService = inject(ToastService);
 
-  /** Type_id (e.g. ``"image"``) of the solo-mediaType streamlining, or
-   *  ``null`` when not active. */
+  /** Type_id (e.g. ``"image"``) of the server's solo-mediaType
+   *  restriction, or ``null`` when not active. */
   get effectiveSoloMediaType(): string | null {
-    const v = this.settingsState.settingsSignal()?.effective_solo_media_type;
+    const v = this.settingsState.settingsSignal()?.solo_media_type;
     return v ? v : null;
   }
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -236,11 +236,11 @@ export class NewDetectorModalComponent implements OnInit {
   readonly labelImporterDynamicLoading = signal<Record<string, boolean>>({});
   readonly labelImporterDynamicError = signal<Record<string, string>>({});
 
-  /** Type_id of the active solo-mediaType streamlining, or ``null`` when
+  /** Type_id of the server's solo-mediaType restriction, or ``null`` when
    *  off. When non-null, the mediaType form-group is hidden in the
    *  template and ``mediaType`` is locked to this value on init. */
   get effectiveSoloMediaType(): string | null {
-    const v = this.settingsState.settingsSignal()?.effective_solo_media_type;
+    const v = this.settingsState.settingsSignal()?.solo_media_type;
     return v ? v : null;
   }
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -211,20 +211,6 @@
         <!-- Import Defaults -->
         @if (activeSettingsTab() === 'imports') {
           <h3>Import Defaults<vt-field-hint-icon hint="Per-media-type defaults that auto-fill the Add Dataset modal when you start a matching import."></vt-field-hint-icon></h3>
-          <div class="form-group" title="Streamline the app to a single media type: the Add Dataset picker hides importers and tabs that can't produce it (and preselects it on the rest), the New Detector media picker and Import Defaults collapse to this type, and converters that output other types are filtered out.">
-            <label class="form-label" for="setting-solo-media-type">Solo media type<vt-field-hint-icon [hint]="soloMediaTypeHint"></vt-field-hint-icon></label>
-            <select
-              id="setting-solo-media-type"
-              class="form-select"
-              [ngModel]="soloMediaTypeSelectValue"
-              (ngModelChange)="onSoloMediaTypeChange($event)"
-              aria-label="Solo media type">
-              <option value="">Show everything</option>
-              @for (mt of mediaTypes(); track mt.type_id) {
-                <option [value]="mt.type_id">{{ mt.name }}</option>
-              }
-            </select>
-          </div>
           <vt-import-defaults-settings
             [mediaTypes]="mediaTypes()"
             [defaults]="importDefaults"
@@ -447,6 +433,10 @@
           <div class="form-group">
             <label class="form-label" title="When on, this server offers Semantic embedders only: the prototype Patch Semantic and Structural types are hidden from every picker and rejected by the API. Set with --semantic-only, VTSEARCH_SEMANTIC_ONLY, or the semantic_only setting.">Semantic embedders only</label>
             <div class="server-value">{{ settings().semantic_only ? 'On' : 'Off' }}</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label" title="When set, this server is streamlined to a single media type: the Add Dataset picker hides importers and tabs that can't produce it (and preselects it on the rest), the New Detector media picker and Import Defaults collapse to this type, and converters that output other types are filtered out. Set with --solo-media-type or the solo_media_type setting.">Solo media type</label>
+            <div class="server-value" [class.server-value--empty]="!effectiveSoloMediaType">{{ soloMediaTypeDisplay }}</div>
           </div>
           <div class="form-group">
             <label class="form-label" title="Plugins hidden from pickers and listings for this deployment (still callable by name). Combines the persisted setting with any --hide-plugin CLI flags.">Hidden plugins</label>

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -176,61 +176,14 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     this.save();
   }
 
-  /** Value shown in the "Solo media type" select. Empty string means
-   *  "Show everything"; otherwise it's the type_id. We display the
-   *  user's explicit choice when set, falling back to the CLI's
-   *  effective value so a fresh user sees what the streamlined mode is
-   *  currently locking them to (rather than a misleading empty state). */
-  get soloMediaTypeSelectValue(): string {
-    const settings = this.settings();
-    const explicit = settings.solo_media_type_explicit;
-    if (explicit) {
-      return settings.solo_media_type || '';
-    }
-    return settings.effective_solo_media_type || '';
-  }
-
-  /** Hint text under the solo-mediaType select. Surfaces "from
-   *  ``--solo-media-type``" when the value comes from the CLI fallback
-   *  so the user understands why the picker is non-empty without ever
-   *  having touched it. */
-  get soloMediaTypeNote(): string {
-    const settings = this.settings();
-    const explicit = settings.solo_media_type_explicit;
-    const effective = settings.effective_solo_media_type || '';
-    if (!explicit && effective) {
-      return `Currently set to ${effective} by the --solo-media-type CLI flag. ` +
-        'Choose any value here to override it.';
-    }
-    return '';
-  }
-
-  /** Always-present help for the solo-mediaType select, spelling out
-   *  exactly what the lock constrains (so it isn't a mystery toggle), plus
-   *  the CLI-fallback note when one applies. */
-  get soloMediaTypeHint(): string {
-    const base =
-      'Streamlines the whole app to one media type. The Add Dataset picker ' +
-      'hides importers and tabs that can’t produce it and preselects it ' +
-      'on the ones that can; the New Detector media picker and the Import ' +
-      'Defaults tab collapse to just this type; and converters that output ' +
-      'other types are filtered out. Pick "Show everything" to turn it off.';
-    const note = this.soloMediaTypeNote;
-    return note ? `${base} ${note}` : base;
-  }
-
-  onSoloMediaTypeChange(value: string): void {
-    // Empty string = "Show everything"; the backend stores it as null
-    // and still flips the explicit flag so the choice survives a CLI
-    // fallback on the next launch.
-    const next = value || null;
-    this.settings.update((s) => ({
-      ...(s as Record<string, unknown>),
-      solo_media_type: next,
-      solo_media_type_explicit: true,
-      effective_solo_media_type: next,
-    }) as AppSettings);
-    this.save();
+  /** Display name of the admin-set solo media type for the read-only
+   *  Server settings row. Falls back to the raw type_id when the registry
+   *  hasn't loaded (or no longer carries the type), and to "Show
+   *  everything" when no restriction is in force. */
+  get soloMediaTypeDisplay(): string {
+    const value = this.effectiveSoloMediaType;
+    if (!value) return 'Show everything';
+    return this.mediaTypes().find((mt) => mt.type_id === value)?.name || value;
   }
 
   /** Embedder options for a given media type, used by the per-type
@@ -281,8 +234,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     const userMap = { ...(settings.solo_embedder_per_media_type || {}) };
     // Empty value = "Ask each time". Persist it as the opt-out sentinel
     // (an empty-string entry) so it overrides any ``--solo-embedder``
-    // CLI fallback for this type; same pattern as solo_media_type's
-    // explicit-null override of --solo-media-type.
+    // CLI fallback for this type.
     userMap[typeId] = value || '';
     // Optimistically update the effective map so the dropdown reflects
     // the new choice immediately; the PUT response will replace it with
@@ -604,16 +556,12 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     this.save();
   }
 
-  /** Effective solo-mediaType for the import-defaults tab: collapses
-   *  the per-mediaType picker to a single tab when the user is in solo
-   *  mode (so they only configure what they'll actually import). */
+  /** The admin-set solo mediaType in force, or ``null`` when the server
+   *  isn't restricting one. The import-defaults tab uses it to collapse
+   *  the per-mediaType picker to a single tab (so the user only configures
+   *  what they can actually import). */
   get effectiveSoloMediaType(): string | null {
-    const settings = this.settings();
-    const explicit = settings.solo_media_type_explicit;
-    if (explicit) {
-      return settings.solo_media_type || null;
-    }
-    return settings.effective_solo_media_type || null;
+    return this.settings().solo_media_type || null;
   }
 
   /** Configured Auto-Find results-exporter name (''=none), read from the

--- a/tests/api/test_settings_dispatch.py
+++ b/tests/api/test_settings_dispatch.py
@@ -81,7 +81,6 @@ class TestSchemaBackedByModels:
         # stored Pydantic field; everything else must be model-backed.
         extras = set(AppSettingsSchema().fields) - _pydantic_fields()
         assert extras == {
-            "effective_solo_media_type",
             "effective_solo_embedder_per_media_type",
         }, f"Unexpected non-model AppSettingsSchema fields: {sorted(extras)}"
 

--- a/tests/core/test_solo_media_type.py
+++ b/tests/core/test_solo_media_type.py
@@ -1,10 +1,10 @@
-"""Tests for the solo-mediaType streamlining setting and CLI fallback.
+"""Tests for the solo-mediaType server restriction and its CLI override.
 
-Covers the per-user ``solo_media_type`` + ``solo_media_type_explicit`` pair,
-the process-level CLI fallback (``set_cli_solo_media_type``), the resolver
-(``get_effective_solo_media_type``), the route handler
-(``PUT /api/settings``), and the preload extension
-(``preload_predicted_embedders(extra_media_types=...)``).
+Covers the server-tier ``solo_media_type`` setting, the process-level CLI
+override (``set_cli_solo_media_type``), the resolver
+(``get_effective_solo_media_type``), the settings route (which surfaces the
+effective value read-only and refuses to change it), and the preload
+extension (``preload_predicted_embedders(extra_media_types=...)``).
 """
 
 from __future__ import annotations
@@ -19,127 +19,97 @@ from vtsearch import settings as settings_mod
 
 @pytest.fixture(autouse=True)
 def _reset_cli_solo():
-    """The CLI fallback is process-global; clear it around each test."""
+    """The CLI override is process-global; clear it around each test."""
     settings_mod.set_cli_solo_media_type(None)
     yield
     settings_mod.set_cli_solo_media_type(None)
 
 
 class TestSoloMediaTypeSettings:
-    def test_default_is_none_and_not_explicit(self):
+    def test_default_is_none(self):
         assert settings_mod.get_solo_media_type() is None
-        assert settings_mod.get_solo_media_type_explicit() is False
         assert settings_mod.get_effective_solo_media_type() is None
 
-    def test_apply_user_solo_media_type_sets_both_fields(self, isolated_settings):
-        settings_mod.apply_user_solo_media_type("image")
-        assert settings_mod.get_solo_media_type() == "image"
-        assert settings_mod.get_solo_media_type_explicit() is True
+    def test_is_a_server_tier_setting(self):
+        assert "solo_media_type" in settings_mod._SERVER_KEYS
+
+    def test_persisted_value_is_effective(self, isolated_settings):
+        settings_mod.set_solo_media_type("image")
         assert settings_mod.get_effective_solo_media_type() == "image"
 
-        # Persisted to the per-user file (not the server file).
-        raw = json.loads(isolated_settings.read_text())
+        # Persisted to the server settings file, not a per-user file.
+        raw = json.loads(settings_mod.SETTINGS_PATH.read_text())
         assert raw["solo_media_type"] == "image"
-        assert raw["solo_media_type_explicit"] is True
 
-    def test_apply_user_solo_media_type_none_means_show_everything(self):
-        settings_mod.apply_user_solo_media_type(None)
-        assert settings_mod.get_solo_media_type() is None
-        assert settings_mod.get_solo_media_type_explicit() is True
+    def test_persisted_empty_string_normalises_to_none(self):
+        settings_mod.set_solo_media_type("   ")
         assert settings_mod.get_effective_solo_media_type() is None
 
-    def test_apply_user_solo_media_type_empty_string_normalises_to_none(self):
-        settings_mod.apply_user_solo_media_type("")
-        assert settings_mod.get_solo_media_type() is None
-        assert settings_mod.get_solo_media_type_explicit() is True
 
-
-class TestCliFallback:
-    def test_cli_fallback_applies_when_not_explicit(self):
+class TestCliOverride:
+    def test_cli_override_applies_with_no_persisted_value(self):
         settings_mod.set_cli_solo_media_type("audio")
         assert settings_mod.get_cli_solo_media_type() == "audio"
-        # User hasn't touched their setting -> CLI value wins.
-        assert settings_mod.get_solo_media_type_explicit() is False
         assert settings_mod.get_effective_solo_media_type() == "audio"
 
-    def test_explicit_user_choice_overrides_cli_fallback(self):
+    def test_cli_override_wins_over_persisted_value(self):
+        settings_mod.set_solo_media_type("image")
         settings_mod.set_cli_solo_media_type("audio")
-        settings_mod.apply_user_solo_media_type("image")
-        assert settings_mod.get_effective_solo_media_type() == "image"
+        assert settings_mod.get_effective_solo_media_type() == "audio"
+        # The persisted value is untouched; only the resolver prefers the CLI.
+        assert settings_mod.get_solo_media_type() == "image"
 
-    def test_user_can_opt_out_against_cli_fallback(self):
-        # CLI says solo=image, but user explicitly picks "show everything".
-        settings_mod.set_cli_solo_media_type("image")
-        settings_mod.apply_user_solo_media_type(None)
-        assert settings_mod.get_effective_solo_media_type() is None
-        # The CLI value is still recorded; only the resolver hides it.
-        assert settings_mod.get_cli_solo_media_type() == "image"
-
-    def test_cli_fallback_clears_to_none(self):
+    def test_clearing_cli_override_falls_back_to_persisted(self):
+        settings_mod.set_solo_media_type("image")
         settings_mod.set_cli_solo_media_type("video")
         settings_mod.set_cli_solo_media_type(None)
         assert settings_mod.get_cli_solo_media_type() is None
-        assert settings_mod.get_effective_solo_media_type() is None
+        assert settings_mod.get_effective_solo_media_type() == "image"
 
-    def test_cli_fallback_strips_whitespace(self):
+    def test_cli_override_strips_whitespace(self):
         settings_mod.set_cli_solo_media_type("  ")
         assert settings_mod.get_cli_solo_media_type() is None
+        assert settings_mod.get_effective_solo_media_type() is None
 
 
 class TestSettingsApiRoute:
-    def test_get_settings_includes_effective_solo_media_type(self, client):
+    def test_get_settings_includes_solo_media_type(self, client):
         res = client.get("/api/settings")
         assert res.status_code == 200
         body = res.get_json()
-        assert "effective_solo_media_type" in body
-        assert body["effective_solo_media_type"] is None
-
-    def test_put_solo_media_type_via_api(self, client):
-        res = client.put("/api/settings", json={"solo_media_type": "image"})
-        assert res.status_code == 200
-        body = res.get_json()
-        assert body["solo_media_type"] == "image"
-        assert body["solo_media_type_explicit"] is True
-        assert body["effective_solo_media_type"] == "image"
-
-    def test_put_solo_media_type_null_clears(self, client):
-        # First set it, then clear it explicitly.
-        client.put("/api/settings", json={"solo_media_type": "image"})
-        res = client.put("/api/settings", json={"solo_media_type": None})
-        assert res.status_code == 200
-        body = res.get_json()
+        assert "solo_media_type" in body
         assert body["solo_media_type"] is None
-        # Still marked explicit so a future CLI fallback wouldn't reapply.
-        assert body["solo_media_type_explicit"] is True
-        assert body["effective_solo_media_type"] is None
 
-    def test_put_invalid_solo_media_type_returns_400(self, client):
-        res = client.put("/api/settings", json={"solo_media_type": "garbage"})
-        assert res.status_code == 400
-        body = res.get_json()
-        assert "garbage" in str(body)
-
-    def test_get_returns_cli_fallback_when_user_not_explicit(self, client):
+    def test_get_returns_cli_override(self, client):
         settings_mod.set_cli_solo_media_type("audio")
         res = client.get("/api/settings")
         assert res.status_code == 200
-        body = res.get_json()
-        assert body["effective_solo_media_type"] == "audio"
-        # The raw per-user value still shows None / not-explicit.
-        assert body["solo_media_type"] is None
-        assert body["solo_media_type_explicit"] is False
+        assert res.get_json()["solo_media_type"] == "audio"
 
-    def test_effective_solo_media_type_is_read_only(self, client):
-        # Sending effective_solo_media_type in PUT body is silently ignored.
-        res = client.put(
-            "/api/settings",
-            json={"effective_solo_media_type": "image"},
-        )
+    def test_get_returns_persisted_server_value(self, client):
+        settings_mod.set_solo_media_type("image")
+        res = client.get("/api/settings")
         assert res.status_code == 200
-        body = res.get_json()
-        # Did not mutate the raw value.
-        assert body["solo_media_type"] is None
-        assert body["solo_media_type_explicit"] is False
+        assert res.get_json()["solo_media_type"] == "image"
+
+    def test_put_solo_media_type_is_ignored(self, client):
+        """It is admin-set: PUT can neither set nor clear it."""
+        res = client.put("/api/settings", json={"solo_media_type": "image"})
+        assert res.status_code == 200
+        assert res.get_json()["solo_media_type"] is None
+        assert settings_mod.get_solo_media_type() is None
+
+    def test_put_cannot_clear_the_server_restriction(self, client):
+        settings_mod.set_solo_media_type("image")
+        res = client.put("/api/settings", json={"solo_media_type": None})
+        assert res.status_code == 200
+        assert res.get_json()["solo_media_type"] == "image"
+        assert settings_mod.get_effective_solo_media_type() == "image"
+
+    def test_solo_media_type_is_not_in_the_update_schema(self):
+        from vtsearch.schemas.settings import SettingsUpdateSchema
+
+        assert "solo_media_type" not in SettingsUpdateSchema().fields
 
 
 class TestPreloadIntegration:

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -437,7 +437,7 @@ def predict_embedders_to_preload(
     - For every media type in *extra_media_types*: the default embedder
       for that type. Used by the solo-mediaType streamlined mode (see
       :func:`vtsearch.settings.get_effective_solo_media_type`) so the
-      user's chosen type has its default embedder warm at startup even
+      admin-chosen type has its default embedder warm at startup even
       when no datasets or detectors are registered yet.
     - For every embedder name in *extra_embedders*: the embedder itself
       (if it exists in the registry). Used by the solo-mediaEmbedder

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -253,9 +253,10 @@ def _build_parser() -> argparse.ArgumentParser:
             "in the dataset-importer and new-detector flows, locks them to the "
             "given type, filters converter offerings to converters whose output "
             "is this type, and preloads that type's default embedder at startup. "
-            "Acts as a per-process fallback only. Any user who explicitly sets "
-            "their own solo mediaType (including 'show everything') via the "
-            "settings UI overrides this flag for themselves. Valid values are "
+            "This is an admin-set restriction: it applies to every user, and "
+            "users cannot change or opt out of it from the settings UI. "
+            "Overrides the persisted ``solo_media_type`` key in the server "
+            "settings file for the lifetime of the process. Valid values are "
             "the registered media-type ids (e.g. audio, image, video, text, "
             "document)."
         ),
@@ -454,7 +455,7 @@ def _apply_verbosity(args) -> None:
 
 
 def _apply_solo_media_type(args, parser) -> None:
-    """Validate and stash ``--solo-media-type`` as a process-level fallback."""
+    """Validate and stash ``--solo-media-type`` as a process-level override."""
     # --solo-media-type applies to both the autodetect CLI path and the
     # server path: validate and stash before any code reads the resolver.
     if getattr(args, "solo_media_type", None) is not None:

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -73,26 +73,6 @@ def _apply_inclusion(value) -> None:
     set_inclusion(clamped)
 
 
-def _apply_solo_media_type(value) -> None:
-    """Validate *value* against the registry and apply via the combined setter.
-
-    ``None`` / ``""`` clears solo mode (still marks the choice explicit so
-    the user's "show everything" opt-out is preserved against the CLI
-    fallback). Any other string must match a registered media-type id.
-    """
-    if value is None or (isinstance(value, str) and not value.strip()):
-        settings.apply_user_solo_media_type(None)
-        return
-    if not isinstance(value, str):
-        abort(400, message="solo_media_type must be a string or null")
-    from vtscore.media import all_type_ids
-
-    valid = set(all_type_ids())
-    if value not in valid:
-        abort(400, message=f"Unknown media type: {value!r}. Valid: {sorted(valid)}")
-    settings.apply_user_solo_media_type(value)
-
-
 def _apply_solo_embedder_per_media_type(value) -> None:
     """Validate the ``{media_type: embedder}`` map and persist it.
 
@@ -100,9 +80,8 @@ def _apply_solo_embedder_per_media_type(value) -> None:
     mapping registered media-type ids to embedder names that exist for
     that type (per :func:`vtscore.media.embedders_for_type`). An empty
     string value is preserved as a **per-type opt-out sentinel**; it
-    overrides the ``--solo-embedder`` CLI fallback for that type
-    (analog of setting ``solo_media_type=null`` to override
-    ``--solo-media-type``). Any other invalid pairing raises 400.
+    overrides the ``--solo-embedder`` CLI fallback for that type. Any
+    other invalid pairing raises 400.
     """
     if value is None:
         settings.apply_user_solo_embedder_per_media_type(None)
@@ -186,9 +165,9 @@ def _with_effective(data: dict) -> dict:
 
     Centralises the augmentation shared by the GET and PUT responses:
 
-    * ``effective_solo_media_type`` / ``effective_solo_embedder_per_media_type``
-      - the per-user values layered over their CLI fallbacks; the frontend
-      reads these to decide whether to hide mediaType / embedder pickers.
+    * ``effective_solo_embedder_per_media_type`` - the per-user embedder
+      locks layered over their CLI fallbacks; the frontend reads this to
+      decide whether to hide the embedder picker for a given mediaType.
     * ``hidden_plugins`` - the persisted server setting unioned with any
       ``--hide-plugin`` CLI flags, normalised to sorted lists so the
       "Server" settings tab can render what's actually in force.
@@ -197,7 +176,6 @@ def _with_effective(data: dict) -> dict:
     value can't 500 the endpoint (see :func:`_coerce_dict_fields`).
     """
     _coerce_dict_fields(data)
-    data["effective_solo_media_type"] = settings.get_effective_solo_media_type()
     data["effective_solo_embedder_per_media_type"] = settings.get_effective_solo_embedders()
     data["hidden_plugins"] = {
         family: sorted(names) for family, names in settings.get_effective_hidden_plugins().items()
@@ -213,6 +191,10 @@ def _with_effective(data: dict) -> dict:
     # in force, so the New-detector modal can drop its embedder-type picker and
     # the Server settings tab can report the restriction.
     data["semantic_only"] = settings.get_effective_semantic_only()
+    # Surface the CLI-overridable solo-mediaType restriction as the value
+    # actually in force, so the importer / new-detector / import-defaults
+    # surfaces lock their mediaType pickers to what the admin allowed.
+    data["solo_media_type"] = settings.get_effective_solo_media_type()
     return data
 
 
@@ -222,11 +204,9 @@ def get_settings():
     """Return the merged server + per-user settings dict.
 
     Augments the persisted dict with the resolver-computed read-only views
-    (effective solo mediaType / embedder, effective hidden plugins) via
-    :func:`_with_effective`. The frontend reads the ``effective_*`` keys
-    when deciding whether to hide pickers; the raw ``solo_media_type`` /
-    ``solo_media_type_explicit`` pair is still exposed for the settings UI
-    to render the current state.
+    (the effective solo mediaType / embedder locks, effective hidden
+    plugins) via :func:`_with_effective`. The frontend reads those keys
+    when deciding whether to hide pickers.
     """
     return _with_effective(settings.get_all())
 
@@ -236,7 +216,6 @@ def get_settings():
 #: entry below).
 _READ_ONLY_KEYS = frozenset(
     {
-        "effective_solo_media_type",
         "effective_solo_embedder_per_media_type",
     }
 )
@@ -315,7 +294,6 @@ _CUSTOM_SETTERS: dict[str, Callable[[Any], None]] = {
     "saved_datasets_dir": _apply_saved_datasets_dir,
     "detectors_dir": _apply_detectors_dir,
     "enable_achievements": _apply_enable_achievements_guarded,
-    "solo_media_type": _apply_solo_media_type,
     "solo_embedder_per_media_type": _apply_solo_embedder_per_media_type,
     "autofind_exporter": _apply_autofind_exporter,
     "autofind_exporter_field_values": _apply_autofind_exporter_field_values,
@@ -345,9 +323,10 @@ _STATE_TIER_SETTERS: dict[str, Callable[[Any], Any]] = {
 #:   not by the settings form.
 #:
 #: (``dataset_max_age_days`` is a server-tier retention policy set via the
-#: ``--dataset-max-age-days`` CLI flag / settings file, not via PUT; it is
-#: ``dump_only`` in the schema, so it is not "loadable" and needs no entry
-#: here.)
+#: ``--dataset-max-age-days`` CLI flag / settings file, not via PUT, and
+#: ``solo_media_type`` is a server-tier restriction set via
+#: ``--solo-media-type`` / the settings file. Both are ``dump_only`` in the
+#: schema, so neither is "loadable" and neither needs an entry here.)
 #:
 #: They are listed here so the drift-guard test
 #: (``tests/api/test_settings_dispatch.py``) treats their absence from the

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -177,6 +177,13 @@ class AppSettingsSchema(Schema):
     # picker and the Server settings tab can report the restriction. Not in
     # ``SettingsUpdateSchema`` - not editable via PUT.
     semantic_only = fields.Boolean(dump_only=True)
+    # Server-tier solo-mediaType restriction. Set via the
+    # ``--solo-media-type`` CLI flag (process-wide, all users) or the
+    # persisted settings file; surfaced read-only here as the value actually
+    # in force, so the importer / new-detector / import-defaults surfaces can
+    # lock their mediaType pickers and the Server settings tab can report the
+    # restriction. Not in ``SettingsUpdateSchema`` - not editable via PUT.
+    solo_media_type = fields.String(dump_only=True, allow_none=True)
 
     # Auto-Find (per-user, editable from the Auto-Find settings tab).
     # ``autofind_detectors`` is each user's own list of detectors that auto-run
@@ -208,16 +215,6 @@ class AppSettingsSchema(Schema):
     # shape; the field is declared as a free-form dict here because the
     # nested values are heterogeneous (string, dict, list).
     import_defaults_by_media_type = fields.Dict(keys=fields.String(), values=fields.Raw())
-
-    # Solo mediaType streamlining. ``solo_media_type`` is the user's raw
-    # value (None or a media-type id); ``solo_media_type_explicit`` is True
-    # once the user has changed it from settings (so the CLI fallback no
-    # longer applies). ``effective_solo_media_type`` is the resolver's
-    # output the frontend should read to decide whether to hide mediaType
-    # pickers; it accounts for the CLI fallback and the explicit flag.
-    solo_media_type = fields.String(allow_none=True)
-    solo_media_type_explicit = fields.Boolean()
-    effective_solo_media_type = fields.String(allow_none=True, dump_only=True)
 
     # Solo mediaEmbedder per mediaType. ``solo_embedder_per_media_type`` is
     # the user's raw map (``{media_type_id: embedder_name}``);
@@ -324,11 +321,10 @@ class SettingsUpdateSchema(Schema):
     last_embedder_per_media_type = fields.Raw()
     import_defaults_by_media_type = fields.Raw()
 
-    # The route layer validates ``solo_media_type`` against the media-type
-    # registry and applies it via ``apply_user_solo_media_type`` so the
-    # ``solo_media_type_explicit`` flag flips automatically. Accept either
-    # a string id or ``null`` for "show everything".
-    solo_media_type = fields.String(allow_none=True)
+    # NB: solo_media_type is intentionally absent - it is a server-tier
+    # restriction set by the admin via --solo-media-type (or the settings
+    # file), not editable via PUT /api/settings. It is dump_only in
+    # AppSettingsSchema.
 
     # ``{media_type_id: embedder_name}`` map. The route layer validates
     # each entry against the embedder registry and rejects unknown

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -140,8 +140,6 @@ if TYPE_CHECKING:
 
     def get_solo_media_type() -> str | None: ...
     def set_solo_media_type(value: str | None) -> None: ...
-    def get_solo_media_type_explicit() -> bool: ...
-    def set_solo_media_type_explicit(value: bool) -> None: ...
 
     def get_solo_embedder_per_media_type() -> dict[str, str]: ...
     def set_solo_embedder_per_media_type(value: dict[str, str]) -> None: ...
@@ -157,13 +155,13 @@ if TYPE_CHECKING:
 #: ``set_settings_path()`` helper also points it at a different file.
 SETTINGS_PATH: Path = DATA_DIR / "settings.json"
 
-#: Process-level fallback for the per-user ``solo_media_type`` setting, set
-#: by :func:`set_cli_solo_media_type` from the ``--solo-media-type`` flag
-#: in :mod:`app`. ``None`` means "no CLI default"; a user with
-#: ``solo_media_type_explicit=False`` will see this value (or ``None``) as
-#: their effective solo mediaType. A user who has explicitly set their own
-#: value (including explicitly ``None`` for "show everything") overrides
-#: this fallback - see :func:`get_effective_solo_media_type`.
+#: Process-level override for the server-tier ``solo_media_type`` setting,
+#: set by :func:`set_cli_solo_media_type` from the ``--solo-media-type``
+#: flag in :mod:`app`. ``None`` means "no CLI override" - reads fall
+#: through to the persisted server setting. When a value is set it applies
+#: to every user and wins over the persisted file for the lifetime of the
+#: process; the setting is not user-editable via the API (see
+#: :func:`get_effective_solo_media_type`).
 _cli_solo_media_type: str | None = None
 
 #: Process-level fallback for the ``hidden_plugins`` server setting, set
@@ -883,14 +881,15 @@ def set_last_embedder_for_media_type(media_type: str, embedder: str) -> None:
 
 
 def set_cli_solo_media_type(value: str | None) -> None:
-    """Set the process-level fallback for the per-user ``solo_media_type`` setting.
+    """Set the process-level override for the ``solo_media_type`` setting.
 
     Called once from ``app.py`` startup when ``--solo-media-type`` is
-    passed on the command line. The value is consulted by
-    :func:`get_effective_solo_media_type` for any user who has not
-    explicitly set their own ``solo_media_type`` via the settings UI.
-    Pass ``None`` (or call from a process where ``--solo-media-type`` was
-    not passed) to disable the fallback.
+    passed on the command line. The value applies server-wide (every user)
+    and is fixed for the process lifetime;
+    :func:`get_effective_solo_media_type` returns it in preference to the
+    persisted server setting. Pass ``None`` (or an empty / whitespace-only
+    string) to clear the override so reads fall back to the persisted file
+    value.
     """
     global _cli_solo_media_type
     if value is not None:
@@ -899,47 +898,33 @@ def set_cli_solo_media_type(value: str | None) -> None:
 
 
 def get_cli_solo_media_type() -> str | None:
-    """Return the process-level CLI fallback (``None`` if unset)."""
+    """Return the process-level CLI override (``None`` if unset)."""
     return _cli_solo_media_type
 
 
 def get_effective_solo_media_type() -> str | None:
-    """Return the effective solo mediaType for the current user.
+    """Return the solo mediaType restriction in force.
 
     Resolution order:
 
-    1. The user's explicit choice (``solo_media_type`` when
-       ``solo_media_type_explicit`` is True), including an explicit
-       ``None`` for "show everything".
-    2. The process-level CLI fallback set by
-       :func:`set_cli_solo_media_type`.
-    3. ``None`` (no streamlining - show every mediaType).
+    1. The process-level CLI override set by
+       :func:`set_cli_solo_media_type` (``--solo-media-type``), which
+       applies to every user for the lifetime of the process.
+    2. The persisted server-tier setting (``data/settings.json``), which
+       defaults to ``None``.
 
     Returns ``None`` to mean "no solo mode active"; any other return
-    value is a mediaType id (e.g. ``"image"``) that the UI should lock
-    its pickers to.
+    value is a mediaType id (e.g. ``"image"``) that the UI locks its
+    pickers to. This is an admin-set restriction: there is no per-user
+    override, and ``PUT /api/settings`` cannot change it.
     """
-    if get_solo_media_type_explicit():  # type: ignore[name-defined]  # autogen'd accessor
-        explicit = get_solo_media_type()  # type: ignore[name-defined]  # autogen'd accessor
-        # Empty string from JSON drift normalises to None.
-        if isinstance(explicit, str) and not explicit.strip():
-            return None
-        return explicit
-    return _cli_solo_media_type
-
-
-def apply_user_solo_media_type(value: str | None) -> None:
-    """Persist *value* as the user's solo mediaType choice and flip ``explicit``.
-
-    Used by the settings PUT route so a single UI change updates both
-    fields atomically. ``value=None`` (or an empty string) means "show
-    everything"; any other string is validated against the media-type
-    registry by the route layer before this is called.
-    """
-    if isinstance(value, str) and not value.strip():
-        value = None
-    set_solo_media_type(value)  # type: ignore[name-defined]  # autogen'd accessor
-    set_solo_media_type_explicit(True)  # type: ignore[name-defined]  # autogen'd accessor
+    if _cli_solo_media_type is not None:
+        return _cli_solo_media_type
+    persisted = get_solo_media_type()  # type: ignore[name-defined]  # autogen'd accessor
+    # Empty string from JSON drift normalises to None.
+    if isinstance(persisted, str) and not persisted.strip():
+        return None
+    return persisted
 
 
 def set_cli_dataset_max_age_days(value: int | None) -> None:
@@ -1092,9 +1077,8 @@ def get_effective_solo_embedders() -> dict[str, str]:
     missing user keys fall through to the CLI value. An **empty-string
     value** in the user map is a per-type opt-out sentinel - it removes
     that type from the merged map even if the CLI fallback has a
-    value for it. This is the analog of setting ``solo_media_type=null``
-    with ``solo_media_type_explicit=True`` to override
-    ``--solo-media-type``.
+    value for it. (``solo_media_type`` has no such per-user opt-out: it is
+    an admin-set server restriction.)
 
     Validity (does the embedder still exist for this type?) is *not*
     checked here - the frontend resolves it against the live embedder

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -277,6 +277,19 @@ class ServerSettings(BaseModel):
     # :func:`vtsearch.settings.get_effective_semantic_only`.
     semantic_only: bool = False
 
+    # Solo-mediaType streamlining. An admin-set restriction: when set, the
+    # importer and new-detector flows hide their mediaType pickers and lock to
+    # this type, the converter picker filters to converters whose output is
+    # this type, and the mediaType-picking step in tabbed UIs is skipped.
+    # ``None`` (the default) means "show everything" (the non-streamlined
+    # experience). Users cannot change it - it exists so an operator can
+    # narrow the app down to the one media type their deployment is for,
+    # both to show less and to ask fewer questions. Set with the
+    # ``--solo-media-type`` CLI flag (process-wide, wins for the process
+    # lifetime) or by editing this key in the settings file. See
+    # :func:`vtsearch.settings.get_effective_solo_media_type`.
+    solo_media_type: str | None = None
+
     # Browse UMAP projection knobs (Stage 1).  They change the map layout, so
     # a per-deployment operator may want to tune them.  The persisted
     # projection is keyed on these values (see
@@ -530,21 +543,6 @@ class UserSettings(BaseModel):
     #     }
     # Any missing sub-key falls back to the importer's existing default.
     import_defaults_by_media_type: dict[str, dict[str, Any]] = Field(default_factory=dict)
-
-    # Solo-mediaType streamlining. When set, the importer and new-detector
-    # flows hide their mediaType pickers and lock to this type, the converter
-    # picker filters to converters whose output is this type, and the
-    # mediaType-picking step in tabbed UIs is skipped. ``None`` means "show
-    # everything" (the default, non-streamlined experience).
-    #
-    # Resolution at read time is ``solo_media_type`` if
-    # ``solo_media_type_explicit`` is True, else the process-level CLI
-    # fallback (``settings.set_cli_solo_media_type``), else None. The
-    # ``explicit`` flag is set to True whenever the user changes the value
-    # through the settings UI - so once a user opts out (sets it to None),
-    # the CLI flag no longer reapplies on future launches for that user.
-    solo_media_type: str | None = None
-    solo_media_type_explicit: bool = False
 
     # Solo mediaEmbedder streamlining (per mediaType). When a media-type id
     # appears as a key here, the dataset-importer modal hides its embedder


### PR DESCRIPTION
Solo media type is an admin-set restriction: an operator narrows the deployment to a single media type so users see fewer choices and get asked fewer questions. It was modelled as a per-user preference with a CLI *fallback* and an `explicit` opt-out flag, which meant any user could turn the restriction off for themselves from the Settings dialog — the opposite of what the setting is for.

This moves it to the server tier, alongside `semantic_only` / `dataset_max_age_days` / `support_email`, and follows that pattern exactly.

## Changes

**Storage & resolver**
- `ServerSettings.solo_media_type` replaces the `UserSettings` `solo_media_type` + `solo_media_type_explicit` pair.
- `get_effective_solo_media_type()` now resolves `--solo-media-type` over the persisted server key (was: user-explicit over the CLI fallback). `apply_user_solo_media_type()` is gone.

**API**
- The key is `dump_only` in `AppSettingsSchema` and absent from `SettingsUpdateSchema`, so `PUT /api/settings` can neither set nor clear it (the same shape as `semantic_only`).
- The derived `effective_solo_media_type` view is dropped — the raw `solo_media_type` key now carries the effective value, so there is only one thing for the frontend to read.

**Frontend**
- The editable "Solo media type" select moves off the Import Defaults tab and becomes a read-only row on the Server tab.
- `ImportDefaultsService` / `NewDetectorModalComponent` read `solo_media_type` instead of `effective_solo_media_type`.

**Startup / deployment**
- The startup embedder preload warms the *effective* type, so a value set only in `data/settings.json` works in the gunicorn path where there is no argv to carry `--solo-media-type`.
- `docker/Dockerfile.labbench` seeds `solo_media_type` into `data/settings.json` instead of the per-user file, which also drops the `solo_media_type_explicit: true` workaround its comments had to explain.

Docs (`CLI.md`, `USER_GUIDE.md`, `ARCHITECTURE.md`), the CLI `--help` text, the OpenAPI snapshot, and the settings-dispatch drift guard are all updated to match. `tests/core/test_solo_media_type.py` is rewritten around the server-tier semantics, including coverage that PUT can neither set nor clear the restriction.

**Breaking:** per-user `solo_media_type` / `solo_media_type_explicit` values in existing `user_settings.json` files are ignored. Operators set the key in `data/settings.json` or pass `--solo-media-type`.

## Testing

`./run-tests.sh` — ALL 6746 TESTS PASSED (1 skipped). `./run-tests.sh frontend` — build, audit, and 1846 Vitest tests OK; pyright/ruff/codespell/deptry/pip-audit/OpenAPI-drift/screenshot-wiring all clean.

No screenshot reshoot is queued: no shot in the manifest frames the Import Defaults or Server tab. The `settings-appearance` caption's stale parenthetical about where Solo media type lives was corrected in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJPEb3NGmdGqkVCAH2oRRw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJPEb3NGmdGqkVCAH2oRRw)_