### PR TITLE
HAC tree: spread seed NMS + beta feature assignment as production defaults

### DIFF
--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -314,6 +314,131 @@ class TestBuildRegionTree:
                 assert ci < i and cj < i
 
 
+def _recovered_seed(leaf, sal):
+    """Approximate a leaf's seed = its highest-saliency cell (seeds are peaks)."""
+    ys, xs = np.where(leaf.cell_mask)
+    j = int(np.argmax(sal[ys, xs]))
+    return (int(ys[j]), int(xs[j]))
+
+
+def _mask(region: RegionVector) -> np.ndarray:
+    """A leaf's cell_mask, type-narrowed (propose_leaves always sets it)."""
+    assert region.cell_mask is not None
+    return region.cell_mask
+
+
+class TestLeafSeedingAndAssignment:
+    """The `seeding` / `assignment` knobs on propose_leaves.  Production
+    defaults are `spread` / `feature`; the `topk` / `spatial` alternatives are
+    the v1 baseline kept for ablation and must still work."""
+
+    def test_defaults_are_spread_feature(self):
+        out = _make_output(h=6, w=6, d=16, seed=2)
+        default = propose_leaves(out.patch_grid, out.patch_saliency, k=6)
+        explicit = propose_leaves(
+            out.patch_grid, out.patch_saliency, k=6, seeding="spread", assignment="feature", beta=0.5
+        )
+        for a, b in zip(default, explicit, strict=True):
+            assert a.box == b.box
+            np.testing.assert_array_equal(a.vec, b.vec)
+            np.testing.assert_array_equal(a.cell_mask, b.cell_mask)
+
+    def test_spread_spreads_seeds_further_than_topk(self):
+        # Two separated saliency bumps: a very bright 2x2 cluster (top-left) and
+        # one moderate isolated peak (bottom-right). top-K grabs both seeds from
+        # the bright cluster; spread's NMS forces the 2nd seed onto the far peak.
+        rng = np.random.default_rng(0)
+        grid = _normed(rng, (8, 8, 8))
+        sal = np.full((8, 8), 0.01, np.float32)
+        sal[0, 0], sal[0, 1], sal[1, 0], sal[1, 1] = 1.0, 0.95, 0.9, 0.85
+        sal[7, 7] = 0.5
+
+        topk = propose_leaves(grid, sal, k=2, seeding="topk")
+        spread = propose_leaves(grid, sal, k=2, seeding="spread")
+
+        def min_seed_dist(leaves):
+            s = [_recovered_seed(le, sal) for le in leaves]
+            return min(
+                ((s[i][0] - s[j][0]) ** 2 + (s[i][1] - s[j][1]) ** 2) ** 0.5
+                for i in range(len(s))
+                for j in range(i + 1, len(s))
+            )
+
+        assert min_seed_dist(spread) > min_seed_dist(topk)
+        # And the far peak (7,7) becomes its own seed only under spread.
+        assert any(_recovered_seed(le, sal) == (7, 7) for le in spread)
+        assert not any(_recovered_seed(le, sal) == (7, 7) for le in topk)
+
+    def test_feature_assignment_changes_membership(self):
+        # Pure-cosine assignment (beta=1) binds cells by feature, not geometry,
+        # so the partition must differ from the spatial Voronoi for some seed.
+        differs = False
+        for seed in range(5):
+            out = _make_output(h=6, w=6, d=16, seed=seed)
+            spatial = propose_leaves(out.patch_grid, out.patch_saliency, k=6, assignment="spatial")
+            feature = propose_leaves(out.patch_grid, out.patch_saliency, k=6, assignment="feature", beta=1.0)
+            if any(not np.array_equal(_mask(a), _mask(b)) for a, b in zip(spatial, feature, strict=True)):
+                differs = True
+                break
+        assert differs, "feature assignment never changed leaf membership across 5 seeds"
+
+    def test_still_returns_exactly_k_leaves(self):
+        out = _make_output(h=6, w=6, d=16, seed=4)
+        for seeding in ("topk", "spread"):
+            for assignment in ("spatial", "feature"):
+                leaves = propose_leaves(out.patch_grid, out.patch_saliency, k=7, seeding=seeding, assignment=assignment)
+                assert len(leaves) == 7
+                for le in leaves:
+                    np.testing.assert_allclose(np.linalg.norm(le.vec), 1.0, atol=1e-5)
+
+    def test_invalid_knobs_raise(self):
+        out = _make_output()
+        with pytest_raises(ValueError):
+            propose_leaves(out.patch_grid, out.patch_saliency, k=4, seeding="bogus")
+        with pytest_raises(ValueError):
+            propose_leaves(out.patch_grid, out.patch_saliency, k=4, assignment="bogus")
+
+    def test_feature_beta0_equals_spatial(self):
+        # beta=0 makes the feature blend purely spatial, so it must reproduce the
+        # spatial Voronoi assignment exactly (same leaf masks + boxes).
+        for seed in range(4):
+            out = _make_output(h=6, w=6, d=16, seed=seed)
+            spatial = propose_leaves(out.patch_grid, out.patch_saliency, k=6, assignment="spatial")
+            feat0 = propose_leaves(out.patch_grid, out.patch_saliency, k=6, assignment="feature", beta=0.0)
+            for a, b in zip(spatial, feat0, strict=True):
+                assert a.box == b.box
+                np.testing.assert_array_equal(a.cell_mask, b.cell_mask)
+
+    def test_build_region_tree_threads_knobs(self):
+        # The baseline knobs must still be reachable through the top-level entry
+        # point (the defaults are spread/feature).
+        out = _make_output(h=6, w=6, d=16, seed=1)
+        tree = build_region_tree(out, k=6, alpha=0.5, seeding="topk", leaf_assign="spatial")
+        assert len(tree) == 2 * 6
+        for node in tree:
+            assert node.vec.shape == (16,)
+
+    def test_build_region_tree_defaults_match_explicit_knobs(self):
+        # No-knob call == explicit spread/feature with beta reusing alpha.
+        out = _make_output(h=6, w=6, d=16, seed=3)
+        default = build_region_tree(out, k=6, alpha=0.5)
+        explicit = build_region_tree(out, k=6, alpha=0.5, seeding="spread", leaf_assign="feature", leaf_beta=0.5)
+        for a, b in zip(default, explicit, strict=True):
+            assert a.box == b.box
+            assert a.children == b.children
+            np.testing.assert_array_equal(a.vec, b.vec)
+
+    def test_leaf_beta_decouples_from_alpha(self):
+        # leaf_beta overrides the assignment blend independently of the merge alpha;
+        # None reuses alpha (the default), a value can differ.
+        out = _make_output(h=6, w=6, d=16, seed=2)
+        reuse = build_region_tree(out, k=6, alpha=1.0, leaf_beta=None)  # beta:=alpha=1.0
+        beta0 = build_region_tree(out, k=6, alpha=1.0, leaf_beta=0.0)  # spatial assign
+        # Leaf cell masks (indices 1..K) must differ: beta=1 (cosine) vs beta=0 (spatial).
+        differs = any(not np.array_equal(_mask(reuse[i]), _mask(beta0[i])) for i in range(1, 7))
+        assert differs, "leaf_beta=0 vs reuse-alpha(=1.0) produced identical leaves"
+
+
 # ---------------------------------------------------------------------------
 # to_fp16
 # ---------------------------------------------------------------------------

--- a/vtscore/media/patch_embed.py
+++ b/vtscore/media/patch_embed.py
@@ -255,27 +255,112 @@ def eupe_features_to_patch_output(
     )
 
 
+def _spread_seed_indices(order: np.ndarray, k: int, height: int, width: int) -> np.ndarray:
+    """Greedy saliency peaks with spatial non-max suppression → K seed indices.
+
+    Walks patches high→low saliency (*order* = flat indices), accepting a peak
+    only when it is at least ``radius ≈ min(H, W) / (2·√k)`` grid cells from
+    every seed already chosen, so seeds spread across distinct objects.  If NMS
+    yields fewer than K, back-fills from the remaining top peaks so exactly K
+    seeds emit.
+    """
+    radius = max(1.0, min(height, width) / (2.0 * float(k) ** 0.5))
+    r2 = radius * radius
+    chosen: list[int] = []
+    chosen_rc: list[tuple[int, int]] = []
+    for idx in order:
+        r, c = int(idx // width), int(idx % width)
+        if all((r - pr) ** 2 + (c - pc) ** 2 >= r2 for pr, pc in chosen_rc):
+            chosen.append(int(idx))
+            chosen_rc.append((r, c))
+            if len(chosen) == k:
+                break
+    if len(chosen) < k:  # NMS too aggressive → back-fill from remaining top peaks
+        picked = set(chosen)
+        for idx in order:
+            if int(idx) not in picked:
+                chosen.append(int(idx))
+                if len(chosen) == k:
+                    break
+    return np.asarray(chosen[:k], dtype=np.int64)
+
+
+def _feature_assignments(
+    dist_stack: np.ndarray,
+    patch_grid: np.ndarray,
+    seeds: list[tuple[int, int]],
+    beta: float,
+) -> np.ndarray:
+    """Assign each cell to the seed maximising ``beta·cosine + (1-beta)·spatial``.
+
+    *beta* is the **assignment** blend weight — deliberately distinct from the HAC
+    *merge* ``alpha`` (they control different stages).  ``beta = 0`` reduces to pure
+    spatial (``argmax`` of the spatial similarity = ``argmin`` distance = the Voronoi
+    assignment), so ``assignment="spatial"`` is exactly the ``beta = 0`` corner.
+
+    *dist_stack* is the (k, H, W) per-seed squared spatial distance.  Cosine is
+    computed against each seed's patch vector (``patch_grid`` is L2-normalised,
+    so the dot product is the cosine); the spatial half reuses *dist_stack*,
+    scaled into ``[0, 1]``.  Returns a (H, W) argmax over the K seeds.
+    """
+    height, width, depth = patch_grid.shape
+    grid_vecs = patch_grid.reshape(-1, depth).astype(np.float32, copy=False)  # (H*W, D)
+    seed_vecs = np.stack([patch_grid[sr, sc] for (sr, sc) in seeds]).astype(np.float32)  # (k, D)
+    cosine = (grid_vecs @ seed_vecs.T).reshape(height, width, len(seeds)).transpose(2, 0, 1)  # (k, H, W)
+    max_d = float(((height - 1) ** 2 + (width - 1) ** 2) ** 0.5) or 1.0
+    spatial_sim = 1.0 - np.sqrt(dist_stack) / max_d  # (k, H, W), in [0, 1]
+    score = beta * cosine + (1.0 - beta) * spatial_sim
+    return np.argmax(score, axis=0)
+
+
 def propose_leaves(
     patch_grid: np.ndarray,
     patch_saliency: np.ndarray,
     k: int,
+    *,
+    seeding: str = "spread",
+    assignment: str = "feature",
+    beta: float = 0.5,
 ) -> list[RegionVector]:
     """Cluster a patch grid into K spatially-coherent leaf regions.
 
-    Algorithm: pick the top-K saliency peaks as seeds, then assign every
-    remaining patch cell to its **nearest seed by Euclidean spatial
-    distance** (ties broken by saliency).  Each leaf's box is the tight
-    bounding box around its cells, in normalised image coordinates.  Each
-    leaf's vector is the saliency-weighted mean of its constituent patch
-    vectors, L2-normalised.
+    Algorithm: pick K seeds, then assign every patch cell to a seed.  Each
+    leaf's box is the tight bounding box around its cells, in normalised
+    image coordinates; each leaf's vector is the saliency-weighted mean of
+    its constituent patch vectors, L2-normalised.
 
-    This is a deliberately simple baseline.  It produces spatially-
-    coherent, non-overlapping leaves with complete grid coverage.  The
-    quality of the HAC merges (which the MLP and similarity actually score)
-    depends more on the relative arrangement of leaves than on the exact
-    boundaries; the simple baseline is good enough for v1.  Future work
-    can swap in SLIC superpixels or watershed if the empirical sweep on
-    caltech101_s shows clear leaf-quality wins.
+    Two knobs control the two stages (the defaults are the production
+    behaviour; the alternatives are the original v1 baseline, kept for
+    ablation):
+
+    * *seeding* — how the K seeds are chosen:
+        - ``"spread"`` (default): greedy saliency peaks with **spatial
+          non-max suppression** — walk patches high→low saliency, accept a
+          peak only when it is at least ``radius`` grid cells from every
+          seed already chosen (``radius ≈ min(H, W) / (2·√k)``).  This
+          spreads seeds across distinct objects so a small object can win
+          its own seed instead of being swallowed by the single brightest
+          region.  If NMS yields fewer than K, the remainder is back-filled
+          from the top peaks (dropping the radius constraint) so exactly K
+          seeds emit.
+        - ``"topk"``: the K highest-saliency patches (the v1 baseline,
+          which piles seeds onto the brightest object).
+    * *assignment* — how each cell is bound to a seed:
+        - ``"feature"`` (default): the seed maximising ``beta·cosine(cell,
+          seed) + (1 - beta)·spatial_proximity``, so leaf boundaries follow
+          content instead of pure geometry.  ``beta`` is the **assignment**
+          blend and is independent of the HAC *merge* ``alpha`` (a separate
+          stage).  ``beta = 0`` reproduces ``"spatial"`` exactly.
+        - ``"spatial"``: nearest seed by Euclidean grid distance (the v1
+          baseline — a spatial Voronoi partition).
+
+    *beta* is used only when ``assignment == "feature"``.
+
+    Both settings preserve the v1 partition/coverage contract:
+    spatially-coherent, non-overlapping leaves with complete grid coverage.
+    Farther-reaching options (SLIC superpixels, watershed, overlapping
+    multi-scale proposals) remain future work if the empirical sweep shows
+    clear leaf-quality wins.
 
     Parameters
     ----------
@@ -285,6 +370,15 @@ def propose_leaves(
         Per-patch importance; not required to sum to 1.
     k : int
         Number of leaves to produce.  Must be ``>= 1`` and ``<= H * W``.
+    seeding : {"spread", "topk"}
+        Seed-selection strategy (see Algorithm above).  Default ``"spread"``.
+    assignment : {"feature", "spatial"}
+        Cell-to-seed binding strategy (see Algorithm above).  Default
+        ``"feature"``.
+    beta : float
+        Assignment cosine/spatial blend weight, used only when ``assignment ==
+        "feature"``.  Independent of the HAC merge ``alpha``; ``beta = 0`` ==
+        ``"spatial"``.
 
     Returns
     -------
@@ -298,19 +392,28 @@ def propose_leaves(
     num_cells = height * width
     if not 1 <= k <= num_cells:
         raise ValueError(f"k must be in [1, {num_cells}]; got {k}")
+    if seeding not in ("topk", "spread"):
+        raise ValueError(f"seeding must be 'topk' or 'spread'; got {seeding!r}")
+    if assignment not in ("spatial", "feature"):
+        raise ValueError(f"assignment must be 'spatial' or 'feature'; got {assignment!r}")
 
     flat_sal = patch_saliency.reshape(-1).astype(np.float32, copy=False)
-    seed_indices = np.argsort(-flat_sal, kind="stable")[:k]
+    order = np.argsort(-flat_sal, kind="stable")  # patch indices, high→low saliency
+    seed_indices = order[:k] if seeding == "topk" else _spread_seed_indices(order, k, height, width)
     seeds = [(int(idx // width), int(idx % width)) for idx in seed_indices]
 
     rows = np.arange(height, dtype=np.float32)[:, None]
     cols = np.arange(width, dtype=np.float32)[None, :]
 
-    # For each cell, distance² to each seed: shape (k, H, W). Pick argmin.
+    # Per-cell squared spatial distance to each seed: shape (k, H, W).
     dist_stack = np.empty((k, height, width), dtype=np.float32)
     for i, (sr, sc) in enumerate(seeds):
         dist_stack[i] = (rows - sr) ** 2 + (cols - sc) ** 2
-    assignments = np.argmin(dist_stack, axis=0)
+
+    if assignment == "spatial":
+        assignments = np.argmin(dist_stack, axis=0)
+    else:  # "feature"
+        assignments = _feature_assignments(dist_stack, patch_grid, seeds, beta)
 
     leaves: list[RegionVector] = []
     for i, (sr, sc) in enumerate(seeds):
@@ -680,8 +783,18 @@ def build_region_tree(
     *,
     k: int = 12,
     alpha: float = 0.5,
+    seeding: str = "spread",
+    leaf_assign: str = "feature",
+    leaf_beta: Optional[float] = None,
 ) -> list[RegionVector]:
     """Build the full ``media["patch_regions"]`` list from one embedder output.
+
+    ``alpha`` blends cosine/spatial for the HAC **merge** order.  ``leaf_beta``
+    is the independent blend for the ``leaf_assign="feature"`` patch→seed
+    **assignment**; ``None`` (default) reuses ``alpha``, any float decouples
+    it.  ``leaf_beta = 0`` == spatial assignment.  ``seeding``/``leaf_assign``
+    are threaded to :func:`propose_leaves`; the defaults (``spread`` +
+    ``feature``) are the production behaviour.
 
     Layout of the returned list:
 
@@ -700,7 +813,14 @@ def build_region_tree(
         cell_mask=None,
         weight=0.0,
     )
-    leaves = propose_leaves(output.patch_grid, output.patch_saliency, k=k)
+    leaves = propose_leaves(
+        output.patch_grid,
+        output.patch_saliency,
+        k=k,
+        seeding=seeding,
+        assignment=leaf_assign,
+        beta=alpha if leaf_beta is None else leaf_beta,
+    )
     hac = build_hac_tree(
         leaves,
         alpha=alpha,


### PR DESCRIPTION
Ports the two HAC-tree leaf-proposal improvements from the `evaluation-framework` branch (Matthew Lucio's work) into `dev`, and makes them the production defaults.

## What was taken

Both live in `vtscore/media/patch_embed.py`:

1. **"Spread" seeding** (`_spread_seed_indices`) — instead of taking the K highest-saliency patches as leaf seeds (which piles all seeds onto the single brightest object), walk patches high→low saliency and accept a peak only when it is at least `radius ≈ min(H, W) / (2·√k)` grid cells from every already-chosen seed (spatial non-max suppression). If NMS under-fills, the remainder is back-filled from the top peaks so exactly K seeds always emit. A small object can now win its own seed.
2. **Beta feature assignment** (`_feature_assignments`) — patch cells bind to the seed maximising `β·cosine + (1−β)·spatial` instead of pure nearest-seed grid distance, so leaf boundaries follow content rather than geometry. `β` is the **assignment** blend and is deliberately independent of the HAC **merge** `α` (they control different stages); `β = 0` reproduces the old spatial Voronoi exactly. `build_region_tree(leaf_beta=None)` (the default) reuses `α`; any float decouples them.

## What changed relative to the source branch

- On `evaluation-framework` these were opt-in sweep knobs (defaults `topk`/`spatial`, byte-identical to old production). Here the defaults are **flipped** to `seeding="spread"`, `leaf_assign="feature"` (β reusing α = 0.5), so both production call sites (`vtscore/datasets/stages/embedding.py`, `vtscore/detectors/labelset_training.py`) pick them up with no call-site changes. The v1 `topk`/`spatial` baseline remains reachable as explicit arguments for ablation.
- The branch's third HAC change (`pca_dims` PCA-reduced merge ordering) was deliberately **not** ported.
- His tests for both features were ported (`TestLeafSeedingAndAssignment`), adapted to the flipped defaults, plus a new test pinning that the no-knob call equals the explicit spread/feature configuration.

## Behavior change (intentional)

Newly built region trees for DINO-patch datasets will differ from trees built before this change: leaf placement and boundaries change, which cascades into HAC merge topology and region vectors. Existing dataset pickles keep their stored `patch_regions` as-is; anything re-derived from origins (cross-dataset detector resolve, fresh loads) uses the new behavior. Per repo policy, no compatibility shim is added.

## Testing

Full `./run-tests.sh` passes: 6763 tests (1 skipped), including ruff, pyright, codespell, deptry, and the frontend build/Vitest gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWVrHkAs89fhbZLJXMd4P5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWVrHkAs89fhbZLJXMd4P5)_