### PR TITLE
Fix the Max-Patch harness's geometry, calibration bags, and scale sampling

### DIFF
--- a/docs/experiments/max-patch/REPORT.md
+++ b/docs/experiments/max-patch/REPORT.md
@@ -4,6 +4,42 @@ _An Autopilot simulation study on the HLTCOE Grid. Tables and figures are
 generated deterministically from the per-cell CSVs by `analyze.py`; the prose is
 written on top of those numbers._
 
+> ## ⚠️ Correction — the Caltech-101 MaxPatch numbers are invalid
+>
+> **The Caltech-101 MaxPatch arm below measured a harness defect, not a property
+> of raw-patch max-pooling.** Everything this report says about MaxPatch
+> "mis-calibrating on easy, boxless content" — the Verdict, the FNR 0.686 at
+> FPR 0.000, and the "calibration, not ranking" take-away — rests on that arm
+> and does not survive. Two defects, both since fixed on the experiment tier:
+>
+> 1. **A boxless Good vote trained on a vector the scorer never evaluated.**
+>    Caltech carries no ground-truth boxes, so `MaxPatchStyle.good_vec` fell back
+>    to the DINOv3 CLS vector — which was not among the 196 raw-patch rows
+>    `MaxPatchStyle` scored. Each Bad vote floods raw patches as negatives, so the
+>    classifier separated "CLS-like" from "patch-like", calibration measured
+>    positives in CLS space against negatives in patch space, and the threshold
+>    landed in a gap the production score distribution never reaches. `max_hac`
+>    was immune because `patch_regions[0]` **is** the CLS full-image node — it is
+>    both flooded and pooled — not because of its "smoothed 24-node pool".
+> 2. **Asymmetric calibration bags.** A Good bag was one row while a Bad bag was
+>    ~196, and each bag collapses with `max`. Calibration compared a max-over-1
+>    positive against a max-over-196 negative while production is max-over-196
+>    for both, biasing the cut high. This one touches **Visual Genome too**, so
+>    those numbers are also unrefreshed rather than confirmed.
+>
+> The tell is in the report's own table: Caltech MaxPatch cost degrades
+> monotonically from t=25 (0.206 → 0.368 → 0.729 → 0.686) while AP stays at
+> 1.000 — a geometry mismatch widening with every Bad vote, not a ranking limit.
+>
+> **Still trustworthy:** the threshold-free ranking results, which no part of
+> this touches — MaxPatch's AP win on Visual Genome (0.498 vs 0.441), the
+> scale story in Figure 4, and DINOv3-CLS being the worst arm on cluttered
+> scenes. **Not trustworthy:** every ErrorCost / FPR / FNR number, the Verdict,
+> and "Plans for moving forward" #2.
+>
+> Tracked in **#2730** (rerun + rewrite). The production-tier echo of defect (2)
+> is **#2731**.
+
 ## BLUF
 
 VTSearch's Autopilot learns a concept from a handful of Good/Bad votes and ranks

--- a/docs/plans/max-patch-experiment.md
+++ b/docs/plans/max-patch-experiment.md
@@ -1,7 +1,10 @@
 # Max-Patch experiment — MaxHAC vs MaxPatch (vs whole-image)
 
-**Status:** Code shipped (styles + harness wiring + GRID runner + tests); the
-open work is running the study on the Grid and acting on its verdict.
+**Status:** Code shipped (styles + harness wiring + GRID runner + tests). A
+first run completed but its Caltech-101 arm measured a harness defect rather
+than MaxPatch (fixed; see #2730 and the correction atop the report), so the
+open work is re-running the study on the Grid and acting on the corrected
+verdict.
 
 ## Question
 
@@ -46,8 +49,21 @@ Implemented; kept here as the running spec.
   (`HF_TOKEN`).
 - **Datasets**: `visual_genome_m` and `openlogo_a` (ground-truth region
   boxes → real region votes; cluttered scenes / small logos are the regime
-  patch scoring exists for) plus `caltech101_m` (boxless centered objects —
-  the control where patch machinery should win nothing).
+  patch scoring exists for) plus `caltech101_m` (boxless centered objects).
+  **`caltech101_m` is the image-level-voting control, not the large-target
+  control** — it has no boxes, so every Good vote on it is image-level
+  regardless of how big the object is. It answers "what happens when the user
+  ignores region voting", which is a real usage mode but *not* evidence about
+  scale. The large-target evidence comes from the top scale bands of the boxed
+  datasets (see below); do not read Caltech as covering that regime.
+- **Category selection = scale bands.** Boxed datasets sample
+  `N_PER_BAND` categories from each of four `SCALE_BANDS` straddling the patch
+  (~0.51 % area) and leaf (~8.3 %) reference scales, so the sample spans the
+  axis the hypothesis is about instead of leaving it to chance. Scale is always
+  the median **voted (union) box** area — what a Good vote actually drags — and
+  categories whose median voted box exceeds `MAX_VOTED_AREA` (default 80 %) are
+  dropped, because at that size a region vote *is* an image-level vote.
+  Boxless datasets have no scale axis and keep the prevalence spread.
 - **Metrics** per step: `average_precision` (ranking), `cost` at the trained
   (cross-calibrated) threshold — the inclusion-weighted FPR/FNR the live
   tool optimises — plus AUROC and train/score wall clocks; prepare records
@@ -82,6 +98,16 @@ even when instances are patch scale; (b) VG spreads enormously per category
 11%, `wall` 17%, `sky` 33%), so the per-category break-down is where the
 scale story will actually show.
 
+**The table above is per *instance*, which is the wrong unit for every
+scale question in this study** — it is kept only as a description of the raw
+annotations. Nuance (a) is not a footnote: the union box is what the detector
+trains and scores against, and the gap is ~2.7× at the median and far worse for
+multi-instance categories (scattered `arm`s give ~1 %-area instances but a
+near-frame union box). Selection and Figure 4 both use
+`vtscore.eval.labels.category_scale_stats`, whose `voted_area` is the union box
+and whose `union_inflation` (`voted_area / instance_area`) flags the categories
+where the two diverge. Anything reasoning about scale must use `voted_area`.
+
 ## Hypotheses (pre-registered, honest priors)
 
 - MaxPatch should have the *better trained-threshold behaviour on Bad-heavy
@@ -113,35 +139,21 @@ scale story will actually show.
 
 <!-- item-sep -->
 
-- **DONE (2026-07-29) — study run + report at
-  [`docs/experiments/max-patch/REPORT.md`](../experiments/max-patch/REPORT.md).**
-  Verdict: **the answer is regime-dependent.** On cluttered, boxed scenes
-  (Visual Genome, 12 cats × 5 seeds) MaxPatch beats production MaxHAC at the
-  final vote budget (ErrorCost 0.387 vs 0.489, paired Holm p < 0.001), winning
-  on both FPR and FNR and on ranking (AP), with the edge concentrated on
-  sub-leaf-scale objects (Spearman ρ = 0.57). Both patch styles crush
-  whole-image scoring — DINOv3's CLS vector is the *worst* arm, below SigLIP. But
-  on boxless, centred data (Caltech-101) MaxPatch's 196-way max-pool
-  *mis-calibrates*: perfect ranking (AP 1.0) yet ErrorCost 0.686 (FNR 0.69 at
-  FPR 0), while MaxHAC ties the whole-image control. **Recommendation:** adopt
-  MaxPatch for region-vote scoring on cluttered/small-object collections (and
-  drop the HAC tree there); do not blanket-replace whole-image scoring —
-  gate raw-patch scoring on a genuine sub-image region vote, or fix the
-  max-pool threshold calibration first. See the report for the hybrid path.
-
-  **Harness fix shipped alongside (was silently broken):** the demo-cache pickle
-  never persisted `patch_grid`/`patch_regions`/`regions`/`categories`, and
-  `load_demo_dataset` never ran the patch back-fill — so every style would have
-  collapsed to whole-image. Fixed via `embed_missing` in prepare + a lossless
-  `_cells_io` serializer (see the report's Reproducibility section).
+- [ ] #2730 — Re-run the study and rewrite the verdict: the Caltech-101 arm
+  measured a harness defect (boxless Good votes trained on a vector the scorer
+  never evaluated; Good/Bad calibration bags of different widths), not a
+  property of raw-patch max-pooling (Opus 4.8). The rerun uses the scale-band
+  category selection, so it also fixes the thin large-target coverage — verify
+  at prepare time that no band logs `** UNDER-POPULATED **`, especially
+  `above_4x`; if VG can't fill the top bands from `visual_genome_m`'s 4 % slice,
+  step up to `visual_genome_l` rather than running a 2-category band.
 
 <!-- item-sep -->
 
-- **Optional follow-up arms, only if the first run is ambiguous** — (a) Good
+- **Optional follow-up arms, only if the rerun is ambiguous** — (a) Good
   vote = *mean of patches inside the box* instead of the single nearest patch
   (the other natural reading of "closest patch", better for multi-patch
-  objects); (b) Bad flood = leaves+patches union; (c) `max_patch` scoring with
-  the CLS row included so whole-image evidence can also win.
+  objects); (b) Bad flood = leaves+patches union.
 
 <!-- item-sep -->
 
@@ -158,3 +170,8 @@ scale story will actually show.
   behaviour of *not* flooding Bad votes on patch datasets (it predates region
   flooding).  The style path is the production-faithful one; the default path
   is left untouched for reproducibility of earlier studies.
+- The style path calibrates in **inference geometry** (each bag collapses over
+  `style.score_rows`), which production does *not* yet do — production still
+  compares a max-over-1 Good bag against a max-over-13 Bad bag (#2731).  So the
+  harness is now *more* faithful to what inference scores than the live vote
+  path is; when #2731 lands the two converge again.

--- a/scripts/experiments/max_patch/README.md
+++ b/scripts/experiments/max_patch/README.md
@@ -53,9 +53,36 @@ sbatch --array=0-$((N-1))%24 ... --wrap "... python run_cells.py"
 python summarize.py
 ```
 
-Default grid: 3 datasets × 3 embedders × 6 categories × 4 seeds = **216 array
-cells** (all of an embedder's styles run inside its cell → 504 style-runs),
-150 votes each.
+Default grid on a **boxed** dataset: 4 scale bands × 6 categories = 24
+categories, so 3 embedders × 24 categories × 4 seeds = **288 array cells per
+dataset** (all of an embedder's styles run inside its cell), 150 votes each.
+Boxless datasets keep the old prevalence spread at `MAXPATCH_N_CATEGORIES`.
+
+## Category selection: scale bands, not prevalence
+
+The study's question is about object **scale**, so a boxed dataset's categories
+are sampled to span scale on purpose — `MAXPATCH_N_PER_BAND` from each of the
+four `SCALE_BANDS`, which straddle the two reference scales (one DINOv3 patch,
+~0.51 % of image area; one HAC leaf, ~8.3 %, the smallest candidate the tree can
+propose). Selecting by prevalence instead left scale coverage to chance, which
+is how the first run ended up with only 5 categories above leaf scale — the
+exact regime the hypothesis is about.
+
+Two rules make the sample honest:
+
+- **Scale means the *voted* box.** A category's scale is the median area of
+  `region_box_for_category` — the **union** over every annotated instance,
+  which is what a Good vote actually drags — never the median per-instance
+  area. The two diverge sharply on multi-instance categories.
+- **Near-frame votes are dropped.** A category whose median voted box exceeds
+  `MAXPATCH_MAX_VOTED_AREA` is excluded: at that size a "region vote" is an
+  image-level vote, and the cell would measure what the boxless Caltech-101 arm
+  measured (what happens when the user ignores region voting) rather than what
+  happens when the target is large. Drops are logged by name, never silent.
+
+Within a band, ties break toward the lowest **union inflation**
+(`voted_area / instance_area`) — categories whose vote is typically one clean
+object rather than a union over scattered instances.
 
 ## Sizing knobs (env vars, read by `experiment_config.py`)
 
@@ -64,7 +91,9 @@ cells** (all of an embedder's styles run inside its cell → 504 style-runs),
 | `MAXPATCH_DATASETS` | `visual_genome_m,openlogo_a,caltech101_m` | Demo datasets |
 | `MAXPATCH_EMBEDDERS` | `dinov2_patch,dinov3_patch,siglip` | Embedders |
 | `MAXPATCH_PATCH_STYLES` | `max_hac,max_patch,whole_image` | Styles run on patch embedders |
-| `MAXPATCH_N_CATEGORIES` | `6` | Categories per dataset (spanning common→rare) |
+| `MAXPATCH_N_PER_BAND` | `6` | Categories per scale band (boxed datasets) |
+| `MAXPATCH_MAX_VOTED_AREA` | `0.80` | Drop categories whose median voted box exceeds this |
+| `MAXPATCH_N_CATEGORIES` | `6` | Categories for **boxless** datasets (spanning common→rare) |
 | `MAXPATCH_N_SEEDS` | `4` | Seeds (paired across arms) |
 | `MAXPATCH_MAX_STEPS` | `150` | Vote budget per trajectory |
 | `MAXPATCH_EXEMPLAR_CANDIDATES` | `8` | Cropped exemplars pre-embedded per category |

--- a/scripts/experiments/max_patch/analyze.py
+++ b/scripts/experiments/max_patch/analyze.py
@@ -32,6 +32,10 @@ from _cells_io import load_medias  # noqa: E402
 RESULTS = common.RESULTS
 FIGS = RESULTS / "figures"
 BUDGETS = [10, 25, 50, 100, 150]
+#: Field order of the ``examples_*`` tuples emitted into ``metrics.json``.
+#: ``voted_area`` is the union box a Good vote drags, never a per-instance area.
+_EXAMPLE_KEYS = ["dataset", "category", "voted_area", "maxpatch", "maxhac", "delta", "union_inflation"]
+
 LEAF_AREA_PCT = 8.3  # mean HAC-leaf area, % of image (from the plan's measurements)
 PATCH_AREA_PCT = 0.51  # one DINOv3 patch, % of image area
 
@@ -131,7 +135,17 @@ def _holm(pairs):
 
 
 def _category_scale(df):
-    """Median instance-box area (fraction of image) per (dataset, category)."""
+    """Median **voted** (union) box area per (dataset, category), fraction of image.
+
+    This is the box a simulated Good vote actually drags, which is the scale the
+    hypothesis is about.  It is deliberately *not* the median per-instance area:
+    the two diverge sharply on multi-instance categories (an image with arms
+    scattered across it has ~1 %-area instances but a near-frame union box), and
+    plotting per-instance area put such categories at the small end of the axis
+    while the detector was really being handed a large region.
+    """
+    from vtscore.eval.labels import category_scale_stats
+
     scale = {}
     for ds in df["dataset"].unique():
         pkl = common.DATADIR / "embeddings" / cfg.pickle_name(ds, "dinov3_patch")
@@ -142,14 +156,9 @@ def _category_scale(df):
         except Exception:
             continue
         for cat in df[df["dataset"] == ds]["category"].unique():
-            areas = []
-            for m in medias.values():
-                for r in m.get("regions") or []:
-                    if r.get("label") == cat and r.get("box"):
-                        x0, y0, x1, y1 = r["box"]
-                        areas.append(abs((x1 - x0) * (y1 - y0)))
-            if areas:
-                scale[(ds, cat)] = float(np.median(areas))
+            stats = category_scale_stats(medias, cat)
+            if stats is not None:
+                scale[(ds, cat)] = stats
     return scale
 
 
@@ -208,7 +217,7 @@ def _fig_scale(final, scale, fname):
     rows = []
     for (ds, cat), r in piv.iterrows():
         if (ds, cat) in scale and not (pd.isna(r.get(MP)) or pd.isna(r.get(MH))):
-            rows.append((ds, cat, scale[(ds, cat)], float(r[MP] - r[MH])))
+            rows.append((ds, cat, scale[(ds, cat)]["voted_area"], float(r[MP] - r[MH])))
     if not rows:
         return None, []
     fig, ax = plt.subplots(figsize=(7.4, 4.9))
@@ -229,8 +238,23 @@ def _fig_scale(final, scale, fname):
         color="#777",
     )
     ax.axvline(PATCH_AREA_PCT, color="#bbb", lw=1, ls=":")
+    # Shade the scale bands the categories were sampled from, so an
+    # under-populated band is visible in the figure rather than only in the log.
+    for i, (name, lo, hi) in enumerate(cfg.SCALE_BANDS):
+        if i % 2 == 0:
+            ax.axvspan(max(lo * 100, 1e-3), min(hi * 100, 100.0), color="#000", alpha=0.035, zorder=0)
+        ax.annotate(
+            name,
+            (max(lo * 100, 1e-3), ax.get_ylim()[0]),
+            fontsize=6,
+            color="#999",
+            va="bottom",
+            ha="left",
+            xytext=(2, 2),
+            textcoords="offset points",
+        )
     ax.set_xscale("log")
-    ax.set_xlabel("median object area (% of image, log scale)")
+    ax.set_xlabel("median VOTED (union) box area (% of image, log scale)")
     ax.set_ylabel("cost(MaxPatch) − cost(MaxHAC)\n(negative = MaxPatch better)")
     ax.set_title("Where raw patches beat the HAC tree, by object scale")
     ax.legend(fontsize=8)
@@ -390,7 +414,18 @@ def main() -> int:
     if MP in fp.columns and MH in fp.columns:
         for (ds, cat), r in fp.iterrows():
             if not (pd.isna(r.get(MP)) or pd.isna(r.get(MH))):
-                ex.append((ds, cat, scale.get((ds, cat)), float(r[MP]), float(r[MH]), float(r[MP] - r[MH])))
+                st = scale.get((ds, cat))
+                ex.append(
+                    (
+                        ds,
+                        cat,
+                        st["voted_area"] if st else None,
+                        float(r[MP]),
+                        float(r[MH]),
+                        float(r[MP] - r[MH]),
+                        st["union_inflation"] if st else None,
+                    )
+                )
     ex_sorted = sorted(ex, key=lambda e: e[5])
 
     # scale correlation
@@ -418,12 +453,8 @@ def main() -> int:
         "stats": stat_tables,
         "category_scale": {f"{k[0]}/{k[1]}": v for k, v in scale.items()},
         "spearman_scale_vs_delta": spearman,
-        "examples_maxpatch_best": [
-            dict(zip(["dataset", "category", "scale", "maxpatch", "maxhac", "delta"], e)) for e in ex_sorted[:5]
-        ],
-        "examples_maxhac_best": [
-            dict(zip(["dataset", "category", "scale", "maxpatch", "maxhac", "delta"], e)) for e in ex_sorted[-5:][::-1]
-        ],
+        "examples_maxpatch_best": [dict(zip(_EXAMPLE_KEYS, e, strict=True)) for e in ex_sorted[:5]],
+        "examples_maxhac_best": [dict(zip(_EXAMPLE_KEYS, e, strict=True)) for e in ex_sorted[-5:][::-1]],
     }
     (RESULTS / "metrics.json").write_text(json.dumps(metrics, indent=2, default=float))
 
@@ -501,7 +532,9 @@ def main() -> int:
         L.append("")
         cap = (
             "**Figure 4. The scale story.** Each point is a Visual Genome category: x = median "
-            "object area (log scale), y = final ErrorCost(MaxPatch) − ErrorCost(MaxHAC). Points below "
+            "**voted (union) box** area — the region a Good vote actually drags, not the area of a "
+            "single annotated instance — (log scale), y = final ErrorCost(MaxPatch) − ErrorCost(MaxHAC). "
+            "Shaded stripes are the scale bands categories were sampled from. Points below "
             "the dashed zero line are categories where the tree-free raw-patch strategy wins; the "
             "dotted line marks the HAC leaf scale (~8.3% area), the smallest candidate the tree can "
             "propose."
@@ -521,7 +554,8 @@ def main() -> int:
                 {
                     "dataset": e[0],
                     "category": e[1],
-                    "obj area %": (e[2] * 100 if e[2] is not None else float("nan")),
+                    "voted area %": (e[2] * 100 if e[2] is not None else float("nan")),
+                    "union infl.": (e[6] if e[6] is not None else float("nan")),
                     "MaxPatch cost": e[3],
                     "MaxHAC cost": e[4],
                     "Δ(MP−MH)": e[5],
@@ -529,7 +563,16 @@ def main() -> int:
                 for e in (ex_sorted[:5] + ex_sorted[-5:][::-1])
             ]
         )
-        L += _md(exdf, {"obj area %": 2, "MaxPatch cost": 3, "MaxHAC cost": 3, "Δ(MP−MH)": 3})
+        L += _md(
+            exdf,
+            {
+                "voted area %": 2,
+                "union infl.": 1,
+                "MaxPatch cost": 3,
+                "MaxHAC cost": 3,
+                "Δ(MP−MH)": 3,
+            },
+        )
         L.append("")
         L.append(
             "Top block: categories where MaxPatch beats MaxHAC most; bottom block: where MaxHAC wins "

--- a/scripts/experiments/max_patch/experiment_config.py
+++ b/scripts/experiments/max_patch/experiment_config.py
@@ -60,6 +60,34 @@ MEDIA_TYPE = "image"
 # --- Minimum positives a category needs to be usable ---
 _MIN_CATEGORY_COUNT = int(os.environ.get("MAXPATCH_MIN_CAT_COUNT", "20"))
 
+# --- Scale bands (the axis the study's hypothesis is actually about) ---
+# Reference scales as fractions of image area: one DINOv3 patch is 1/196, the
+# smallest pooled candidate the HAC tree can propose (a leaf) is ~1/12.
+PATCH_AREA = 1 / 196  # ~0.51 %
+LEAF_AREA = 1 / 12  # ~8.3 %
+
+#: Band edges over the **voted** (union) box area.  The pre-registered
+#: hypothesis says MaxPatch should win below leaf scale and MaxHAC above it, so
+#: the bands straddle ``LEAF_AREA`` with a wide band on each side.
+SCALE_BANDS: list[tuple[str, float, float]] = [
+    ("sub_patch", 0.0, PATCH_AREA),
+    ("patch_to_leaf", PATCH_AREA, LEAF_AREA),
+    ("leaf_to_4x", LEAF_AREA, 4 * LEAF_AREA),
+    ("above_4x", 4 * LEAF_AREA, 1.01),
+]
+
+#: Categories per scale band.  Total grid size is
+#: ``len(SCALE_BANDS) * N_PER_BAND`` categories per dataset, so raising this
+#: multiplies SLURM cells - see the runner's README before bumping it.
+N_PER_BAND = int(os.environ.get("MAXPATCH_N_PER_BAND", "6"))
+
+#: Drop categories whose median voted box covers more than this fraction of the
+#: image.  Above it a "region vote" is indistinguishable from an image-level
+#: vote, which is the exact confound that made the boxless Caltech-101 arm
+#: uninformative about large targets: we would be measuring "what happens when
+#: the user ignores region voting", not "what happens when the target is large".
+MAX_VOTED_AREA = float(os.environ.get("MAXPATCH_MAX_VOTED_AREA", "0.80"))
+
 
 def is_patch_embedder(embedder: str) -> bool:
     """True for embedders that produce a patch grid + HAC tree."""
@@ -90,13 +118,16 @@ def category_rng_seed(category: str) -> int:
     return zlib.crc32(category.encode("utf-8")) & 0x7FFFFFFF
 
 
-def select_categories(category_counts: dict[str, int], n: int = N_CATEGORIES) -> list[str]:
+def select_categories_by_prevalence(category_counts: dict[str, int], n: int = N_CATEGORIES) -> list[str]:
     """Pick *n* categories spanning common->rare, deterministically.
 
     Categories with fewer than ``_MIN_CATEGORY_COUNT`` positives are dropped
     (their held-out test sets would be too small to estimate FNR).  The rest are
     sorted by count and sampled at even rank intervals, so the chosen set spans
     the prevalence range present in the dataset rather than clustering at one end.
+
+    Used for **boxless** datasets, where no scale axis exists.  Boxed datasets
+    take :func:`select_categories_by_scale` instead - see :func:`select_categories`.
     """
     usable = sorted(
         ((c, n_) for c, n_ in category_counts.items() if n_ >= _MIN_CATEGORY_COUNT),
@@ -107,6 +138,103 @@ def select_categories(category_counts: dict[str, int], n: int = N_CATEGORIES) ->
         return [c for c, _ in usable]
     idx = [round(i * (len(usable) - 1) / (n - 1)) for i in range(n)]
     return [usable[i][0] for i in sorted(set(idx))]
+
+
+def band_for_area(area: float) -> str | None:
+    """Name the :data:`SCALE_BANDS` entry *area* falls in, or ``None`` if outside."""
+    for name, lo, hi in SCALE_BANDS:
+        if lo <= area < hi:
+            return name
+    return None
+
+
+def select_categories_by_scale(
+    medias: dict,
+    category_counts: dict[str, int],
+    n_per_band: int = N_PER_BAND,
+) -> tuple[list[str], dict]:
+    """Pick categories **stratified by voted-box scale**, deterministically.
+
+    The study's hypothesis is about object *scale* (does the tree's smallest
+    pooled candidate still match the object?), so the sample has to span scale
+    on purpose.  Selecting by prevalence - the old behaviour - left scale
+    coverage to chance, which is how the first run ended up with 7 of 12
+    categories below leaf scale and only 5 above, mixed in sign, with the
+    crossover the study exists to locate resting on those 5 points.
+
+    Selection, per band:
+
+    1. Drop categories with fewer than ``_MIN_CATEGORY_COUNT`` positives (their
+       held-out test sets are too small to estimate FNR).
+    2. Drop categories with no boxes at all, and those whose median voted box
+       exceeds :data:`MAX_VOTED_AREA` - at that size a "region vote" *is* an
+       image-level vote and the cell measures nothing about scale.
+    3. Bucket the survivors by their **voted** (union) box area, never by
+       per-instance area - see :func:`vtscore.eval.labels.voted_box_area`.
+    4. Within each band keep the ``n_per_band`` categories with the lowest
+       ``union_inflation``, i.e. those whose vote is typically one clean object
+       rather than a union over scattered instances.  Ties break on category
+       name so the pick is reproducible.
+
+    Returns ``(selected, report)``.  *report* records every band's candidates,
+    picks, and the categories dropped by the whole-image cap, so the run can
+    log what it left out instead of silently truncating.
+    """
+    from vtscore.eval.labels import category_scale_stats  # noqa: PLC0415
+
+    stats: dict[str, dict] = {}
+    dropped_large: list[tuple[str, float]] = []
+    for cat, count in category_counts.items():
+        if count < _MIN_CATEGORY_COUNT:
+            continue
+        s = category_scale_stats(medias, cat)
+        if s is None:
+            continue
+        if s["voted_area"] > MAX_VOTED_AREA:
+            dropped_large.append((cat, s["voted_area"]))
+            continue
+        stats[cat] = s
+
+    selected: list[str] = []
+    report: dict = {
+        "dropped_above_max_voted_area": sorted(dropped_large),
+        "max_voted_area": MAX_VOTED_AREA,
+        "bands": {},
+    }
+    for name, lo, hi in SCALE_BANDS:
+        in_band = sorted(
+            (c for c, s in stats.items() if lo <= s["voted_area"] < hi),
+            key=lambda c: (stats[c]["union_inflation"], c),
+        )
+        picks = in_band[:n_per_band]
+        selected.extend(picks)
+        report["bands"][name] = {
+            "range": [lo, hi],
+            "target": n_per_band,
+            "n_candidates": len(in_band),
+            "under_populated": len(picks) < n_per_band,
+            "selected": picks,
+            "not_selected": in_band[n_per_band:],
+            "scales": {c: stats[c] for c in picks},
+        }
+    return sorted(selected), report
+
+
+def select_categories(medias: dict, category_counts: dict[str, int]) -> tuple[list[str], dict]:
+    """Choose this dataset's categories: scale-stratified when boxed, else prevalence.
+
+    A dataset with no ground-truth boxes has no scale axis to stratify - every
+    Good vote on it is image-level regardless of how big the object is - so it
+    falls back to the prevalence spread and its ``report`` says so.
+    """
+    selected, report = select_categories_by_scale(medias, category_counts)
+    if selected:
+        report["mode"] = "scale_bands"
+        return selected, report
+    return select_categories_by_prevalence(category_counts), {
+        "mode": "prevalence",
+        "reason": "dataset carries no ground-truth region boxes; no scale axis to stratify",
+    }
 
 
 def array_cells(categories_by_dataset: dict[str, dict[str, list[str]]]) -> list[dict]:

--- a/scripts/experiments/max_patch/prepare_data.py
+++ b/scripts/experiments/max_patch/prepare_data.py
@@ -181,13 +181,27 @@ def main(argv: list[str] | None = None) -> int:
                 for c in m.get("categories") or [m.get("category")]:
                     if c:
                         cats[c] = cats.get(c, 0) + 1
-            selected = cfg.select_categories(cats)
+            selected, sel_report = cfg.select_categories(medias, cats)
             dim = int(len(media_embedding(next(iter(medias.values()))))) if medias else None
             n_patch = sum(1 for m in medias.values() if m.get("patch_grid") is not None)
             common.log(
                 f"{ds} x {emb_name}: {len(medias)} medias (patch grids on {n_patch}), dim={dim}, "
-                f"{len(cats)} categories -> selected {selected}"
+                f"{len(cats)} categories -> selected {len(selected)} by {sel_report.get('mode')}"
             )
+            # Report the scale sample explicitly: an under-populated band is the
+            # difference between testing the crossover and merely bracketing it.
+            for band, info_b in (sel_report.get("bands") or {}).items():
+                lo, hi = info_b["range"]
+                common.log(
+                    f"  band {band:14s} [{lo * 100:5.2f}%, {hi * 100:6.2f}%): "
+                    f"{len(info_b['selected'])}/{info_b['target']} from {info_b['n_candidates']} candidates"
+                    f"{'  ** UNDER-POPULATED **' if info_b['under_populated'] else ''} -> {info_b['selected']}"
+                )
+            for cat, area in sel_report.get("dropped_above_max_voted_area") or []:
+                common.log(
+                    f"  dropped {cat!r}: median voted box covers {area * 100:.0f}% of the image "
+                    f"(> {cfg.MAX_VOTED_AREA * 100:.0f}% cap) - its region vote is an image-level vote"
+                )
 
             with common.timed(f"crops:{ds}:{emb_name}", timings):
                 vectors, candidates = _exemplar_crops(medias, selected, embedder)
@@ -200,6 +214,7 @@ def main(argv: list[str] | None = None) -> int:
                 "dim": dim,
                 "category_counts": cats,
                 "selected_categories": selected,
+                "category_selection": sel_report,
                 "load_seconds": timings.get(f"load:{ds}:{emb_name}"),
                 "embed_seconds_per_image": round(timings.get(f"load:{ds}:{emb_name}", 0.0) / max(len(medias), 1), 4),
                 "crops_seconds": timings.get(f"crops:{ds}:{emb_name}"),

--- a/tests_lib/detectors/test_eval.py
+++ b/tests_lib/detectors/test_eval.py
@@ -638,6 +638,77 @@ class TestRegionBoxForCategory:
         assert region_box_for_category(media, "apple") is None
 
 
+class TestVotedBoxScale:
+    """Scale of the region a Good vote actually drags (the union box).
+
+    The distinction from per-instance area is the whole point: a multi-instance
+    category has tiny instances but a near-frame union box, and the union is
+    what the detector trains and scores against.
+    """
+
+    def test_voted_area_is_the_union_not_an_instance(self):
+        from vtscore.eval.labels import voted_box_area
+
+        # Two 1%-area instances at opposite corners -> a ~64% union box.
+        media = {
+            "regions": [
+                {"box": [0.10, 0.10, 0.20, 0.20], "label": "arm"},
+                {"box": [0.80, 0.80, 0.90, 0.90], "label": "arm"},
+            ]
+        }
+        assert voted_box_area(media, "arm") == pytest.approx(0.64)
+
+    def test_voted_area_none_without_a_box(self):
+        from vtscore.eval.labels import voted_box_area
+
+        assert voted_box_area({"category": "apple"}, "apple") is None
+        assert voted_box_area({"regions": [{"box": [0, 0, 1, 1], "label": "man"}]}, "apple") is None
+
+    def test_instance_areas_are_per_box(self):
+        from vtscore.eval.labels import instance_box_areas
+
+        media = {
+            "regions": [
+                {"box": [0.10, 0.10, 0.20, 0.20], "label": "arm"},
+                {"box": [0.80, 0.80, 0.90, 0.90], "label": "arm"},
+                {"box": [0.00, 0.00, 1.00, 1.00], "label": "sky"},
+            ]
+        }
+        assert instance_box_areas(media, "arm") == pytest.approx([0.01, 0.01])
+        assert instance_box_areas(media, "sky") == pytest.approx([1.0])
+
+    def test_union_inflation_separates_scattered_from_single_object(self):
+        from vtscore.eval.labels import category_scale_stats
+
+        scattered = {
+            i: {
+                "regions": [
+                    {"box": [0.10, 0.10, 0.20, 0.20], "label": "arm"},
+                    {"box": [0.80, 0.80, 0.90, 0.90], "label": "arm"},
+                ]
+            }
+            for i in range(5)
+        }
+        single = {i: {"regions": [{"box": [0.30, 0.30, 0.70, 0.70], "label": "bed"}]} for i in range(5)}
+
+        s_arm = category_scale_stats(scattered, "arm")
+        s_bed = category_scale_stats(single, "bed")
+        assert s_arm is not None and s_bed is not None
+        # A single-object category's vote IS its instance: inflation ~1.
+        assert s_bed["union_inflation"] == pytest.approx(1.0)
+        assert s_bed["voted_area"] == pytest.approx(0.16)
+        # The scattered category looks tiny per instance but votes a huge box -
+        # exactly the case that used to plot at the small end of the scale axis.
+        assert s_arm["instance_area"] == pytest.approx(0.01)
+        assert s_arm["voted_area"] == pytest.approx(0.64)
+        assert s_arm["union_inflation"] == pytest.approx(64.0)
+
+    def test_stats_none_when_category_unboxed(self):
+        from vtscore.eval.labels import category_scale_stats
+
+        assert category_scale_stats({1: {"category": "apple"}}, "apple") is None
+
+
 class TestRegionVotingLearnedSort:
     """eval_learned_sort wires ground-truth boxes into train_and_score."""
 

--- a/tests_lib/detectors/test_max_patch_selection.py
+++ b/tests_lib/detectors/test_max_patch_selection.py
@@ -1,0 +1,186 @@
+"""Tests for the Max-Patch study's scale-stratified category selection.
+
+``scripts/experiments/max_patch/experiment_config.py`` decides which categories
+the study runs on, which is to say it decides what the study can conclude.  The
+first run selected by *prevalence*, leaving scale coverage to chance: 7 of 12
+categories landed below HAC-leaf scale and only 5 above, so the crossover the
+study exists to locate rested on those 5 mixed-sign points.  These tests pin the
+scale-band selection that replaced it.
+
+The config module is a loose script, not a package member, so it is loaded by
+path.  Everything runs on hand-built region dicts - no dataset, no models.
+"""
+
+import importlib.util
+import math
+from pathlib import Path
+
+import pytest
+
+_CONFIG_PATH = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "max_patch" / "experiment_config.py"
+
+
+@pytest.fixture(scope="module")
+def cfg():
+    spec = importlib.util.spec_from_file_location("_maxpatch_experiment_config", _CONFIG_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _square_box(area: float, x0: float = 0.0, y0: float = 0.0) -> list[float]:
+    """An axis-aligned square of exactly *area*, anchored at (x0, y0)."""
+    side = math.sqrt(area)
+    return [x0, y0, x0 + side, y0 + side]
+
+
+def _medias(spec: dict[str, float], n: int = 25) -> dict[int, dict]:
+    """``n`` medias per category, each carrying one box of the given area.
+
+    Single-instance, so voted area == instance area and union inflation is 1.
+    """
+    medias: dict[int, dict] = {}
+    mid = 0
+    for cat, area in spec.items():
+        for _ in range(n):
+            medias[mid] = {"id": mid, "categories": [cat], "regions": [{"box": _square_box(area), "label": cat}]}
+            mid += 1
+    return medias
+
+
+def _counts(spec: dict[str, float], n: int = 25) -> dict[str, int]:
+    return {cat: n for cat in spec}
+
+
+class TestScaleBands:
+    def test_bands_tile_the_range_without_gaps_or_overlap(self, cfg):
+        bands = cfg.SCALE_BANDS
+        assert bands[0][1] == 0.0
+        assert bands[-1][2] > 1.0, "the top band must contain a whole-image box"
+        # Deliberately not strict: pairing each band with its successor is one
+        # shorter than the band list.
+        for (_, _, hi), (_, lo_next, _) in zip(bands, bands[1:], strict=False):
+            assert hi == lo_next, "bands must abut exactly - a gap silently drops categories"
+
+    def test_band_edges_straddle_the_leaf_scale(self, cfg):
+        """The hypothesis' crossover is the HAC leaf, so a band edge sits there."""
+        edges = {lo for _, lo, _ in cfg.SCALE_BANDS} | {hi for _, _, hi in cfg.SCALE_BANDS}
+        assert any(abs(e - cfg.LEAF_AREA) < 1e-9 for e in edges)
+        assert any(abs(e - cfg.PATCH_AREA) < 1e-9 for e in edges)
+
+    @pytest.mark.parametrize(
+        ("area", "expected"),
+        [
+            (0.002, "sub_patch"),
+            (0.02, "patch_to_leaf"),
+            (0.15, "leaf_to_4x"),
+            (0.50, "above_4x"),
+            (1.00, "above_4x"),
+        ],
+    )
+    def test_band_for_area(self, cfg, area, expected):
+        assert cfg.band_for_area(area) == expected
+
+
+class TestSelectCategoriesByScale:
+    def test_each_band_gets_its_own_categories(self, cfg):
+        spec = {"tiny": 0.002, "small": 0.02, "big": 0.15, "huge": 0.50}
+        selected, report = cfg.select_categories_by_scale(_medias(spec), _counts(spec))
+
+        assert sorted(selected) == ["big", "huge", "small", "tiny"]
+        assert report["bands"]["sub_patch"]["selected"] == ["tiny"]
+        assert report["bands"]["patch_to_leaf"]["selected"] == ["small"]
+        assert report["bands"]["leaf_to_4x"]["selected"] == ["big"]
+        assert report["bands"]["above_4x"]["selected"] == ["huge"]
+
+    def test_whole_image_votes_are_dropped_and_reported(self, cfg):
+        """A near-frame voted box is an image-level vote wearing a box.
+
+        Keeping it would rebuild the exact confound that made the boxless
+        Caltech-101 arm uninformative about large targets.
+        """
+        spec = {"bed": 0.50, "sky": 0.95}
+        selected, report = cfg.select_categories_by_scale(_medias(spec), _counts(spec))
+
+        assert selected == ["bed"]
+        dropped = dict(report["dropped_above_max_voted_area"])
+        assert "sky" in dropped
+        assert dropped["sky"] == pytest.approx(0.95)
+        assert "bed" not in dropped
+
+    def test_low_union_inflation_wins_a_contested_band(self, cfg):
+        """When a band is oversubscribed, prefer clean single-object votes.
+
+        ``scattered`` and ``single`` have the same voted-box area, so they land
+        in the same band; only ``scattered``'s box is a union over instances
+        nowhere near each other, which is not a region a user would drag.
+        """
+        medias: dict[int, dict] = {}
+        mid = 0
+        for _ in range(25):
+            # One 0.15-area object: voted area == instance area.
+            medias[mid] = {
+                "id": mid,
+                "categories": ["single"],
+                "regions": [{"box": _square_box(0.15), "label": "single"}],
+            }
+            mid += 1
+            # Two far-apart specks whose union is also ~0.15 area.
+            side = math.sqrt(0.15)
+            medias[mid] = {
+                "id": mid,
+                "categories": ["scattered"],
+                "regions": [
+                    {"box": [0.0, 0.0, 0.02, 0.02], "label": "scattered"},
+                    {"box": [side - 0.02, side - 0.02, side, side], "label": "scattered"},
+                ],
+            }
+            mid += 1
+
+        counts = {"single": 25, "scattered": 25}
+        _sel, report = cfg.select_categories_by_scale(medias, counts, n_per_band=1)
+        band = report["bands"]["leaf_to_4x"]
+        assert band["selected"] == ["single"]
+        assert band["not_selected"] == ["scattered"]
+        assert band["scales"]["single"]["union_inflation"] == pytest.approx(1.0)
+
+    def test_n_per_band_caps_each_band_independently(self, cfg):
+        spec = {f"c{i}": 0.02 for i in range(5)}
+        spec["lonely"] = 0.15
+        selected, report = cfg.select_categories_by_scale(_medias(spec), _counts(spec), n_per_band=2)
+
+        assert len(report["bands"]["patch_to_leaf"]["selected"]) == 2
+        assert len(report["bands"]["patch_to_leaf"]["not_selected"]) == 3
+        assert report["bands"]["leaf_to_4x"]["selected"] == ["lonely"]
+        assert len(selected) == 3
+
+    def test_rare_categories_are_dropped(self, cfg):
+        spec = {"common": 0.02, "rare": 0.02}
+        counts = {"common": 25, "rare": cfg._MIN_CATEGORY_COUNT - 1}
+        selected, _report = cfg.select_categories_by_scale(_medias(spec), counts)
+        assert selected == ["common"]
+
+    def test_selection_is_deterministic(self, cfg):
+        spec = {f"c{i}": 0.02 for i in range(8)}
+        medias, counts = _medias(spec), _counts(spec)
+        a, _ = cfg.select_categories_by_scale(medias, counts, n_per_band=3)
+        b, _ = cfg.select_categories_by_scale(medias, counts, n_per_band=3)
+        assert a == b
+
+
+class TestSelectCategoriesDispatch:
+    def test_boxed_dataset_uses_scale_bands(self, cfg):
+        spec = {"tiny": 0.002, "big": 0.15}
+        selected, report = cfg.select_categories(_medias(spec), _counts(spec))
+        assert report["mode"] == "scale_bands"
+        assert sorted(selected) == ["big", "tiny"]
+
+    def test_boxless_dataset_falls_back_to_prevalence(self, cfg):
+        """Caltech-101's shape: categories, no regions, so no scale axis."""
+        medias = {i: {"id": i, "category": "a" if i < 30 else "b"} for i in range(60)}
+        counts = {"a": 30, "b": 30}
+        selected, report = cfg.select_categories(medias, counts)
+        assert report["mode"] == "prevalence"
+        assert "no ground-truth region boxes" in report["reason"]
+        assert sorted(selected) == ["a", "b"]

--- a/tests_lib/detectors/test_max_patch_style.py
+++ b/tests_lib/detectors/test_max_patch_style.py
@@ -8,6 +8,8 @@ Covers the pieces added for ``docs/plans/max-patch-experiment.md``: the
 Everything runs on small synthetic patch grids - no model downloads.
 """
 
+from typing import Any
+
 import numpy as np
 import pytest
 import torch
@@ -175,13 +177,17 @@ class TestMaxPatchStyle:
         style = MaxPatchStyle()
         np.testing.assert_allclose(style.good_vec(media, None), media["embeddings"]["emb"])
 
-    def test_bad_vecs_flood_every_patch(self):
+    def test_bad_vecs_flood_whole_image_vector_and_every_patch(self):
         rng = np.random.default_rng(12)
         media = _patch_media(1, "cat1", rng)
         vecs = MaxPatchStyle().bad_vecs(media)
-        assert len(vecs) == GRID * GRID
+        # The full-image row leads, then every raw patch: a Bad vote must
+        # suppress the *entire* scoring pool, exactly as ``max_hac`` floods its
+        # CLS node alongside the HAC leaves.
+        assert len(vecs) == GRID * GRID + 1
+        np.testing.assert_allclose(vecs[0], media["embeddings"]["emb"], rtol=1e-3)
         flat = np.asarray(media["patch_grid"], dtype=np.float32).reshape(-1, DIM)
-        np.testing.assert_allclose(np.stack(vecs), flat, rtol=1e-3)
+        np.testing.assert_allclose(np.stack(vecs[1:]), flat, rtol=1e-3)
 
     def test_gridless_media_falls_back_to_whole_image(self):
         media = {"id": 1, "category": "c", "embeddings": {"emb": _unit(np.ones(DIM))}}
@@ -199,9 +205,10 @@ class TestMaxPatchStyle:
         style = MaxPatchStyle()
         scores = style.score_media(_linear_scorer(target), {1: planted, 2: noise})
         assert scores[1] > scores[2]
-        # The planted image's score equals the sigmoid of its best patch row.
-        flat = np.asarray(planted["patch_grid"], dtype=np.float32).reshape(-1, DIM)
-        expected = float(1.0 / (1.0 + np.exp(-(flat @ (target * 10.0)).max())))
+        # The planted image's score equals the sigmoid of its best scoring row
+        # (the full-image row plus every patch).
+        rows = style.score_rows(planted)
+        expected = float(1.0 / (1.0 + np.exp(-(rows @ (target * 10.0)).max())))
         assert abs(scores[1] - expected) < 1e-3
 
     def test_exemplar_sims_max_over_patches(self):
@@ -212,6 +219,229 @@ class TestMaxPatchStyle:
         sims = MaxPatchStyle().exemplar_sims({1: planted, 2: noise}, target)
         assert sims[1] > sims[2]
         assert sims[1] == pytest.approx(1.0, abs=2e-3)
+
+
+# ---------------------------------------------------------------------------
+# Train/score geometry parity - the invariant that broke MaxPatch on Caltech
+# ---------------------------------------------------------------------------
+
+
+class TestTrainScoreGeometryParity:
+    """Every vector a style can train a vote on must be a row it also scores.
+
+    When it is not, the classifier learns to separate the *training* geometry
+    from the *scoring* geometry (each Bad vote floods scoring-geometry rows as
+    negatives), calibration measures positives in a geometry inference never
+    evaluates, and the threshold lands outside the production score range -
+    perfect ranking, FPR 0, catastrophic FNR.  ``max_hac`` always satisfied
+    this because ``patch_regions[0]`` is the CLS full-image node; ``max_patch``
+    did not until the full-image row was added to its pool.
+    """
+
+    @pytest.mark.parametrize("style_cls", [MaxPatchStyle, MaxHacStyle, WholeImageStyle])
+    def test_boxless_good_vote_trains_on_a_scored_row(self, style_cls):
+        rng = np.random.default_rng(40)
+        media = _patch_media(1, "cat0", rng)
+        style = style_cls()
+        # A boxless Good vote (Caltech-101: no ground-truth regions at all).
+        vote_vec = np.asarray(style.good_vec(media, None), dtype=np.float32)
+        rows = style.score_rows(media)
+        assert any(np.allclose(r, vote_vec, atol=2e-3) for r in rows), (
+            f"{style_cls.__name__}: boxless Good vote trains on a vector that is "
+            f"not among the {len(rows)} rows this style max-pools at inference"
+        )
+
+    @pytest.mark.parametrize("style_cls", [MaxPatchStyle, MaxHacStyle, WholeImageStyle])
+    def test_boxed_good_vote_trains_on_a_scored_row(self, style_cls):
+        rng = np.random.default_rng(41)
+        media = _patch_media(1, "cat0", rng)
+        style = style_cls()
+        vote_vec = np.asarray(style.good_vec(media, _cell_box(2, 1)), dtype=np.float32)
+        rows = style.score_rows(media)
+        assert any(np.allclose(r, vote_vec, atol=2e-3) for r in rows)
+
+    @pytest.mark.parametrize("style_cls", [MaxPatchStyle, WholeImageStyle])
+    def test_bad_vote_suppresses_every_scored_row(self, style_cls):
+        """A Bad vote asserts *no* row of the image should score high, so its
+        flood must cover the whole scoring pool - otherwise an un-suppressed
+        row survives to max-pool the image back up at inference."""
+        rng = np.random.default_rng(42)
+        media = _patch_media(1, "cat1", rng)
+        style = style_cls()
+        flooded = [np.asarray(v, dtype=np.float32) for v in style.bad_vecs(media)]
+        for row in style.score_rows(media):
+            assert any(np.allclose(row, f, atol=2e-3) for f in flooded), (
+                f"{style_cls.__name__}: a scored row is never trained down by a Bad vote"
+            )
+
+    def test_max_hac_floods_every_scored_row_except_hac_internals(self):
+        """``max_hac``'s flood covers the CLS node and the leaves, but not the
+        HAC **internal** nodes - which it nonetheless max-pools at inference.
+
+        That gap is deliberate (``bad_negative_vecs`` drops internals as
+        saliency-weighted pools of leaves it already suppresses, so they would
+        add correlated duplicates without adding coverage), but it means
+        ``max_hac`` scores rows no Bad vote trains down directly.  Pinned here
+        so the exception stays explicit rather than silent.
+        """
+        rng = np.random.default_rng(46)
+        media = _patch_media(1, "cat1", rng)
+        style = MaxHacStyle()
+        flooded = [np.asarray(v, dtype=np.float32) for v in style.bad_vecs(media)]
+        regions = media["patch_regions"]
+        rows = style.score_rows(media)
+        assert len(rows) == len(regions)
+        uncovered = [i for i, row in enumerate(rows) if not any(np.allclose(row, f, atol=2e-3) for f in flooded)]
+        assert uncovered, "expected the HAC internals to be uncovered"
+        # Every uncovered row is an internal node; no leaf and not the CLS node.
+        assert all(regions[i].children is not None for i in uncovered)
+        assert 0 not in uncovered
+
+    @pytest.mark.parametrize("style_cls", [MaxPatchStyle, MaxHacStyle, WholeImageStyle])
+    def test_score_media_is_max_pool_over_score_rows(self, style_cls):
+        rng = np.random.default_rng(43)
+        media = _patch_media(1, "c", rng)
+        direction = _unit(rng.normal(0, 1, DIM))
+        style = style_cls()
+        got = style.score_media(_linear_scorer(direction), {1: media})[1]
+        rows = style.score_rows(media)
+        expected = float(1.0 / (1.0 + np.exp(-(rows @ (direction * 10.0)).max())))
+        assert got == pytest.approx(expected, abs=2e-3)
+
+    def test_max_patch_score_rows_lead_with_whole_image_vector(self):
+        rng = np.random.default_rng(44)
+        media = _patch_media(1, "c", rng)
+        rows = MaxPatchStyle().score_rows(media)
+        assert rows.shape == (GRID * GRID + 1, DIM)
+        np.testing.assert_allclose(rows[0], media["embeddings"]["emb"], rtol=1e-3)
+
+    def test_max_hac_score_rows_include_the_cls_node(self):
+        """The structural reason ``max_hac`` never showed the Caltech failure."""
+        rng = np.random.default_rng(45)
+        media = _patch_media(1, "c", rng)
+        regions = media["patch_regions"]
+        assert regions[0].children is None
+        assert regions[0].box == (0.0, 0.0, 1.0, 1.0)
+        rows = MaxHacStyle().score_rows(media)
+        np.testing.assert_allclose(rows[0], np.asarray(regions[0].vec, dtype=np.float32), rtol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Calibration in inference geometry
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationInInferenceGeometry:
+    """``compute_fold_orderings(score_rows_by_group=...)`` collapses each bag
+    over the rows the *scorer* pools, not the rows the fold model trained on.
+
+    Without it a Good bag is a max over its 1 training row while a Bad bag is a
+    max over the ~197 it flooded; ``max`` is an upward-biased order statistic,
+    so the min-cost cut lands systematically high and over-rejects positives.
+    """
+
+    @staticmethod
+    def _fixed_model_patch(monkeypatch, direction):
+        """Pin every fold fit to one known linear model, so fold scores are exact."""
+        import vtscore.training.mlp as mlp_mod
+
+        model = _linear_scorer(direction)
+        monkeypatch.setattr(mlp_mod, "train_model", lambda *a, **k: model)
+        return model
+
+    @staticmethod
+    def _bags(rng, n_good=3, n_bad=3, bad_rows=5):
+        X, y, groups = [], [], []
+        for g in range(n_good):
+            X.append(_unit(rng.normal(0, 1, DIM)))
+            y.append(1.0)
+            groups.append(("g", g))
+        for b in range(n_bad):
+            for _ in range(bad_rows):
+                X.append(_unit(rng.normal(0, 1, DIM)))
+                y.append(0.0)
+                groups.append(("b", b))
+        return X, y, groups
+
+    def test_group_score_is_max_over_supplied_rows(self, monkeypatch):
+        from vtscore.training.thresholds import compute_fold_orderings
+
+        rng = np.random.default_rng(50)
+        direction = _unit(rng.normal(0, 1, DIM))
+        self._fixed_model_patch(monkeypatch, direction)
+        X, y, groups = self._bags(rng)
+
+        # Give every bag - Good and Bad alike - a 4-row inference stack.
+        score_rows = {g: np.stack([_unit(rng.normal(0, 1, DIM)) for _ in range(4)]) for g in set(groups)}
+        orderings, fallback = compute_fold_orderings(
+            X,
+            y,
+            DIM,
+            rng=np.random.RandomState(42),
+            calibrate_count=1,
+            hidden_dim=8,
+            groups=groups,
+            score_rows_by_group=score_rows,
+        )
+        assert fallback is None
+        scores, labels = orderings[0]
+        assert len(scores) == len(labels)
+        # Every returned score must be the max-pooled sigmoid over that bag's
+        # supplied rows - and must match one of the bags exactly.
+        pooled = {float(1.0 / (1.0 + np.exp(-(rows @ (direction * 10.0)).max()))) for rows in score_rows.values()}
+        for s in scores:
+            assert any(abs(s - p) < 1e-4 for p in pooled)
+
+    def test_override_changes_the_ordering_vs_training_geometry(self, monkeypatch):
+        """The override is not a no-op: pooling over inference rows gives a
+        different calibration ordering than pooling over training rows."""
+        from vtscore.training.thresholds import compute_fold_orderings
+
+        rng = np.random.default_rng(51)
+        direction = _unit(rng.normal(0, 1, DIM))
+        self._fixed_model_patch(monkeypatch, direction)
+        X, y, groups = self._bags(rng)
+
+        # A fresh RandomState per call: it is stateful, so sharing one instance
+        # would give the two calls different fold splits and prove nothing.
+        def _kwargs() -> dict[str, Any]:
+            return dict(rng=np.random.RandomState(42), calibrate_count=1, hidden_dim=8, groups=groups)
+
+        base, _ = compute_fold_orderings(X, y, DIM, **_kwargs())
+        # Give each Good bag the wide stack it would really be scored over:
+        # its single training row plus extra rows that can only raise the max.
+        score_rows = {}
+        for g in set(groups):
+            rows = [X[i] for i, gg in enumerate(groups) if gg == g]
+            if g[0] == "g":
+                rows = rows + [_unit(direction + 0.01 * rng.normal(0, 1, DIM))]
+            score_rows[g] = np.stack(rows)
+        widened, _ = compute_fold_orderings(X, y, DIM, score_rows_by_group=score_rows, **_kwargs())
+
+        base_pos = [s for s, lbl in zip(*base[0], strict=True) if lbl == 1.0]
+        wide_pos = [s for s, lbl in zip(*widened[0], strict=True) if lbl == 1.0]
+        assert base_pos and wide_pos
+        # Max over a superset can only be >=, and here it strictly rises: the
+        # single-row Good bag was understating what production will score.
+        assert all(w >= b - 1e-9 for w, b in zip(wide_pos, base_pos, strict=True))
+        assert any(w > b + 1e-6 for w, b in zip(wide_pos, base_pos, strict=True))
+
+    def test_none_override_leaves_production_path_byte_identical(self):
+        """Every live caller passes ``None``; that path must not shift."""
+        from vtscore.training.thresholds import compute_fold_orderings
+
+        rng = np.random.default_rng(52)
+        X, y, groups = self._bags(rng)
+
+        def _kwargs() -> dict[str, Any]:
+            return dict(rng=np.random.RandomState(42), calibrate_count=2, hidden_dim=8, groups=groups)
+
+        torch.manual_seed(0)
+        a, fa = compute_fold_orderings(X, y, DIM, **_kwargs())
+        torch.manual_seed(0)
+        b, fb = compute_fold_orderings(X, y, DIM, score_rows_by_group=None, **_kwargs())
+        assert fa == fb
+        assert a == b
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/eval/labels.py
+++ b/vtscore/eval/labels.py
@@ -69,3 +69,76 @@ def region_box_for_category(media: dict[str, Any], category: str) -> Optional[tu
     x1 = max(float(b[2]) for b in boxes)
     y1 = max(float(b[3]) for b in boxes)
     return (x0, y0, x1, y1)
+
+
+def voted_box_area(media: dict[str, Any], category: str) -> Optional[float]:
+    """Area of the box a simulated Good vote actually drags, as a fraction of the image.
+
+    This is the area of :func:`region_box_for_category` - the **union** over
+    every annotated instance - not the area of a single instance.  The two
+    diverge sharply on multi-instance categories: an image with arms scattered
+    across it has ~1 %-area instances but a union box approaching the whole
+    frame, and the union is what the detector trains and scores against.
+
+    Use this, never a per-instance area, whenever the question is about the
+    scale of the *region vote*.  Returns ``None`` when the media carries no box
+    for *category* (the caller's vote would be image-level).
+    """
+    box = region_box_for_category(media, category)
+    if box is None:
+        return None
+    x0, y0, x1, y1 = box
+    return abs((x1 - x0) * (y1 - y0))
+
+
+def instance_box_areas(media: dict[str, Any], category: str) -> list[float]:
+    """Area of each individual annotated instance of *category* on *media*.
+
+    The per-instance counterpart of :func:`voted_box_area`.  Their ratio
+    measures how much a category's votes are inflated by scattered instances -
+    see :func:`category_scale_stats`.
+    """
+    regions = media.get("regions")
+    if not regions:
+        return []
+    out = []
+    for r in regions:
+        if r.get("label") == category and r.get("box"):
+            x0, y0, x1, y1 = r["box"]
+            out.append(abs((float(x1) - float(x0)) * (float(y1) - float(y0))))
+    return out
+
+
+def category_scale_stats(medias: dict[int, dict[str, Any]], category: str) -> Optional[dict[str, float]]:
+    """Scale summary for *category* over *medias*, or ``None`` when unboxed.
+
+    Returns:
+        A dict with
+
+        - ``voted_area`` - median area of the box a Good vote drags (the
+          union box).  **This is the scale the scale hypothesis is about.**
+        - ``instance_area`` - median area of a single annotated instance.
+        - ``union_inflation`` - ``voted_area / instance_area``.  ~1.0 means a
+          category is typically one object per image, so its vote is a clean
+          sub-image region; large values mean scattered instances whose union
+          box is far bigger than anything the user would really drag.
+        - ``n_boxed`` - how many images contributed a box.
+    """
+    import statistics  # noqa: PLC0415
+
+    voted, instances = [], []
+    for media in medias.values():
+        area = voted_box_area(media, category)
+        if area is not None:
+            voted.append(area)
+        instances.extend(instance_box_areas(media, category))
+    if not voted or not instances:
+        return None
+    v = float(statistics.median(voted))
+    i = float(statistics.median(instances))
+    return {
+        "voted_area": v,
+        "instance_area": i,
+        "union_inflation": (v / i) if i > 0 else float("inf"),
+        "n_boxed": float(len(voted)),
+    }

--- a/vtscore/eval/patch_styles.py
+++ b/vtscore/eval/patch_styles.py
@@ -20,14 +20,27 @@ a cropped exemplar seeds the startup sort.  Three styles exist:
 * ``max_patch`` - the HAC-free alternative under test: a Good region-vote
   trains on the **single raw patch** closest to the voted box
   (:func:`vtscore.media.patch_embed.nearest_patch_to_box`), a Bad vote floods
-  **every raw patch** of the image as a negative, and an image scores by
-  max-pooling the MLP over all ``H x W`` raw patch vectors.  No region tree is
-  consulted at any point.
+  the full-image vector + **every raw patch** of the image as negatives, and an
+  image scores by max-pooling the MLP over the full-image vector plus all
+  ``H x W`` raw patch vectors.  No region tree is consulted at any point.
 
 Each style also maps a *query vector* (e.g. the full-image embedding of a
 cropped exemplar) to per-image similarities for the Autopilot seed phase:
 whole-image cosine, max-over-region-nodes cosine, and max-over-patches cosine
 respectively.
+
+**Every vector a style can train a vote on must also be a row that style
+scores over.**  ``max_hac`` gets this for free: ``patch_regions[0]`` is the
+CLS full-image node (``children=None``), so it is both flooded by
+:func:`~vtscore.detectors.training.bad_negative_vecs` and pooled at inference,
+and a *boxless* Good vote - which falls back to the image-level vector - trains
+in a geometry inference actually evaluates.  ``max_patch`` originally scored raw
+patches only, so a boxless Good vote trained on a vector that was never scored;
+the classifier then separated "full-image-like" from "raw-patch-like" (every Bad
+vote floods raw patches as negatives) and the calibrated threshold landed in a
+gap the production score distribution never reaches - perfect ranking, zero FPR,
+catastrophic FNR.  The full-image row in :meth:`MaxPatchStyle.score_rows` (and
+its matching negative in :meth:`MaxPatchStyle.bad_vecs`) closes that hole.
 
 Styles are **stateful per run**: :func:`resolve_style` returns a fresh instance
 whose flattened score matrices are memoised per media-id set, so repeated
@@ -95,6 +108,11 @@ class WholeImageStyle:
     def bad_vecs(self, media: dict[str, Any]) -> list["np.ndarray"]:
         return [media_embedding(media)]
 
+    def score_rows(self, media: dict[str, Any]) -> "np.ndarray":
+        import numpy as np  # noqa: PLC0415
+
+        return np.asarray(media_embedding(media), dtype=np.float32)[None, :]
+
     def score_media(self, model: "nn.Sequential", clips_dict: dict[int, dict[str, Any]]) -> dict[int, float]:
         import numpy as np  # noqa: PLC0415
 
@@ -134,6 +152,18 @@ class _FlattenedStyle:
 
     def _rows_for_media(self, media: dict[str, Any]) -> "np.ndarray":
         raise NotImplementedError
+
+    def score_rows(self, media: dict[str, Any]) -> "np.ndarray":
+        """The rows this style max-pools over when scoring *media* at inference.
+
+        Public counterpart of :meth:`_rows_for_media`, upcast to float32.  The
+        calibrator uses it to collapse each vote's bag in **inference**
+        geometry rather than in the geometry it happened to train on - see
+        :func:`vtscore.training.thresholds.compute_fold_orderings`.
+        """
+        import numpy as np  # noqa: PLC0415
+
+        return np.asarray(self._rows_for_media(media), dtype=np.float32)
 
     def _flattened(self, clips_dict: dict[int, dict[str, Any]]) -> tuple[list[int], "np.ndarray", "np.ndarray"]:
         import numpy as np  # noqa: PLC0415
@@ -217,22 +247,38 @@ class MaxPatchStyle(_FlattenedStyle):
         return media_embedding(media)
 
     def bad_vecs(self, media: dict[str, Any]) -> list["np.ndarray"]:
+        """The full-image vector plus every raw patch, as negatives.
+
+        The full-image row is included for the same reason ``max_hac`` floods
+        the CLS node: a Bad vote asserts that *no* row of this image should
+        score high, and :meth:`_rows_for_media` max-pools the full-image row at
+        inference.  Leaving it out would hand every image an un-suppressed
+        scoring row.
+        """
         import numpy as np  # noqa: PLC0415
 
         grid = media.get("patch_grid")
         if grid is None:
             return [media_embedding(media)]
         flat = np.asarray(grid, dtype=np.float32).reshape(-1, np.asarray(grid).shape[-1])
-        return list(flat)
+        return [np.asarray(media_embedding(media), dtype=np.float32), *flat]
 
     def _rows_for_media(self, media: dict[str, Any]) -> "np.ndarray":
+        """The full-image vector stacked above every raw patch.
+
+        Row 0 is the image-level (CLS) vector - the ``max_hac`` tree carries the
+        same node at ``patch_regions[0]``, and without it a boxless Good vote
+        (:meth:`good_vec` with ``box=None``) would train on a vector this
+        scorer never evaluates.  See the module docstring.
+        """
         import numpy as np  # noqa: PLC0415
 
+        cls_row = np.asarray(media_embedding(media), dtype=np.float16)[None, :]
         grid = media.get("patch_grid")
         if grid is None:
-            return np.asarray(media_embedding(media), dtype=np.float16)[None, :]
+            return cls_row
         arr = np.asarray(grid, dtype=np.float16)
-        return arr.reshape(-1, arr.shape[-1])
+        return np.concatenate([cls_row, arr.reshape(-1, arr.shape[-1])], axis=0)
 
 
 #: Style-name registry.  Values are *classes*; :func:`resolve_style` returns a

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -532,6 +532,13 @@ def _style_train_and_calibrate(
     than flooded rows, the calibration folds split by bag, and the final fit
     weights each bag equally.  On a whole-image style every bag is one row, so
     this collapses to the historical single-vector behaviour.
+
+    Calibration additionally runs in **inference geometry**: each bag is handed
+    its ``style.score_rows`` stack so a Good bag collapses the same way a Bad
+    bag (and every held-out image) does.  Without this a Good bag is a max over
+    its 1 training row while a Bad bag is a max over the ~197 rows it flooded,
+    and the fold's min-cost cut lands above the score range production actually
+    produces - see :func:`vtscore.training.thresholds.compute_fold_orderings`.
     """
     import numpy as np  # noqa: PLC0415
     import torch  # noqa: PLC0415
@@ -541,16 +548,19 @@ def _style_train_and_calibrate(
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
     groups: list = []
+    score_rows_by_group: dict = {}
     for vid in good_votes:
         box = region_box_for_category(clips_dict[vid], target_category) if region_voting else None
         X_list.append(np.asarray(style_obj.good_vec(clips_dict[vid], box), dtype=np.float32))
         y_list.append(1.0)
         groups.append(("g", vid))
+        score_rows_by_group[("g", vid)] = style_obj.score_rows(clips_dict[vid])
     for vid in bad_votes:
         for vec in style_obj.bad_vecs(clips_dict[vid]):
             X_list.append(np.asarray(vec, dtype=np.float32))
             y_list.append(0.0)
             groups.append(("b", vid))
+        score_rows_by_group[("b", vid)] = style_obj.score_rows(clips_dict[vid])
 
     X = torch.tensor(np.array(X_list), dtype=torch.float32)
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
@@ -568,6 +578,7 @@ def _style_train_and_calibrate(
         calibration_fraction=calibration_fraction,
         hidden_dim=hidden_dim,
         groups=cal_groups,
+        score_rows_by_group=score_rows_by_group if cal_groups is not None else None,
     )
     xcal_seconds = time.monotonic() - t_xcal
     t_train = time.monotonic()

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -300,6 +300,45 @@ def _per_bag_fit_weights(
     return w
 
 
+def _pooled_group_scores(
+    model: Any,
+    cal_groups: list,
+    rows_by_group: dict,
+    X_np: np.ndarray,
+    score_rows_by_group: dict | None,
+) -> list[float]:
+    """Collapse each calibration group to one max-pooled sigmoid score.
+
+    With *score_rows_by_group* each group pools over the rows the scorer will
+    max-pool at **inference**; otherwise it pools over the rows it trained on
+    (the historical behaviour every production caller takes).
+    """
+    import torch  # noqa: PLC0415
+
+    from vtscore.utils.scores import sigmoid_to_finite_scores  # noqa: PLC0415
+
+    device = next(model.parameters()).device
+    if score_rows_by_group is not None:
+        blocks = [np.asarray(score_rows_by_group[g], dtype=np.float32) for g in cal_groups]
+        sizes = [b.shape[0] for b in blocks]
+        with torch.no_grad():
+            X_cal = torch.tensor(np.concatenate(blocks, axis=0), dtype=torch.float32).to(device)
+            flat = sigmoid_to_finite_scores(model(X_cal))
+        out: list[float] = []
+        offset = 0
+        for size in sizes:
+            out.append(max(flat[offset : offset + size]))
+            offset += size
+        return out
+
+    cal_idx = [i for g in cal_groups for i in rows_by_group[g]]
+    with torch.no_grad():
+        X_cal = torch.tensor(X_np[cal_idx], dtype=torch.float32).to(device)
+        row_scores = sigmoid_to_finite_scores(model(X_cal))
+    by_row = dict(zip(cal_idx, row_scores, strict=True))
+    return [max(by_row[i] for i in rows_by_group[g]) for g in cal_groups]
+
+
 def _compute_fold_orderings_grouped(
     X_list: list[np.ndarray],
     y_list: list[float],
@@ -309,6 +348,7 @@ def _compute_fold_orderings_grouped(
     calibrate_count: int,
     calibration_fraction: float,
     hidden_dim: int | None,
+    score_rows_by_group: dict | None = None,
 ) -> tuple[list[tuple[list[float], list[float]]], float | None]:
     """Bag-aware variant of :func:`compute_fold_orderings`.
 
@@ -317,11 +357,13 @@ def _compute_fold_orderings_grouped(
     split over votes not rows, weight-balances each fold fit per-bag, and
     collapses every calibration group to a single max-pooled score (an image
     scores by its best region, as at inference).
+
+    *score_rows_by_group* overrides which rows a calibration group collapses
+    over - see :func:`compute_fold_orderings`.
     """
     import torch  # noqa: PLC0415
 
     from vtscore.training.mlp import train_model  # noqa: PLC0415
-    from vtscore.utils.scores import sigmoid_to_finite_scores  # noqa: PLC0415
 
     _rng = rng if rng is not None else np.random
     X_np = np.array(X_list)
@@ -374,18 +416,10 @@ def _compute_fold_orderings_grouped(
         fold_w = torch.tensor(_per_bag_fit_weights(y_np[train_idx], [grp[i] for i in train_idx]), dtype=torch.float32)
         model = train_model(X_train, y_train, input_dim, hidden_dim=hidden_dim, sample_weights=fold_w)
 
-        # Score every calibration row, then max-pool per group to one score.
-        cal_idx = [i for g in cal_groups for i in rows_by_group[g]]
-        with torch.no_grad():
-            X_cal = torch.tensor(X_np[cal_idx], dtype=torch.float32).to(next(model.parameters()).device)
-            row_scores = sigmoid_to_finite_scores(model(X_cal))
-        pos_in_cal = {i: s for i, s in zip(cal_idx, row_scores, strict=True)}
-        group_scores: list[float] = []
-        group_labels: list[float] = []
-        for g in cal_groups:
-            rows = rows_by_group[g]
-            group_scores.append(max(pos_in_cal[i] for i in rows))
-            group_labels.append(float(label_by_group[g]))
+        # Collapse each calibration group to one max-pooled score, so a Good
+        # bag and a Bad bag are pooled the same way the scorer pools an image.
+        group_scores = _pooled_group_scores(model, cal_groups, rows_by_group, X_np, score_rows_by_group)
+        group_labels = [float(label_by_group[g]) for g in cal_groups]
         orderings.append((group_scores, group_labels))
 
     return orderings, None
@@ -400,6 +434,7 @@ def compute_fold_orderings(
     calibration_fraction: float = 0.5,
     hidden_dim: int | None = None,
     groups: list | None = None,
+    score_rows_by_group: dict | None = None,
 ) -> tuple[list[tuple[list[float], list[float]]], float | None]:
     """Train the K calibration folds and return their held-out orderings.
 
@@ -424,6 +459,18 @@ def compute_fold_orderings(
     and each calibration group collapses to one max-pooled score - matching how
     inference scores an image by its best region.  When *groups* is ``None``
     (every non-flooded caller) the historical row-wise path runs unchanged.
+
+    *score_rows_by_group* (grouped path only) maps each group id to the row
+    stack that group should be **scored** over, decoupling "what the fold model
+    trains on" from "what a calibration bag collapses to".  It exists because
+    the two are not the same whenever a Good vote contributes fewer rows than a
+    Bad vote floods: the Good bag then collapses to a max over 1 row while the
+    Bad bag - and every image at inference - collapses to a max over N, and
+    ``max`` is an upward-biased order statistic, so the fold's min-cost cut
+    lands systematically high and the threshold over-rejects positives.  Passing
+    each vote's inference rows here puts both classes in the geometry and at the
+    width the scorer will actually use.  ``None`` (every production caller)
+    keeps the historical "collapse over the training rows" behaviour.
     """
     if groups is not None:
         return _compute_fold_orderings_grouped(
@@ -435,6 +482,7 @@ def compute_fold_orderings(
             calibrate_count=calibrate_count,
             calibration_fraction=calibration_fraction,
             hidden_dim=hidden_dim,
+            score_rows_by_group=score_rows_by_group,
         )
     n = len(X_list)
     if n < 4:
@@ -540,6 +588,7 @@ def calculate_cross_calibration_threshold(
     calibration_fraction: float = 0.5,
     hidden_dim: int | None = None,
     groups: list | None = None,
+    score_rows_by_group: dict | None = None,
 ) -> float:
     """Estimate a decision threshold using k-fold calibration.
 
@@ -585,6 +634,8 @@ def calculate_cross_calibration_threshold(
             When ``None`` (default), each fold model auto-sizes based on its
             own training-set size.  Pass the full-data hidden dim to ensure
             fold models match the final model's architecture.
+        score_rows_by_group: Per-group inference row stacks; see
+            :func:`compute_fold_orderings`.  Grouped path only.
 
     Returns:
         A float threshold. Returns 0.5 when calibration is not possible:
@@ -603,6 +654,7 @@ def calculate_cross_calibration_threshold(
         calibration_fraction=calibration_fraction,
         hidden_dim=hidden_dim,
         groups=groups,
+        score_rows_by_group=score_rows_by_group,
     )
     if fallback is not None:
         return fallback


### PR DESCRIPTION
## What this is

An investigation into why the Max-Patch study's Caltech-101 arm calibrated so badly, plus the three harness defects it turned up.

The reported failure was perfect ranking (AP 1.000) alongside a broken operating point (**FNR 0.686 at FPR 0.000**). `REPORT.md` blamed raw-patch max-pooling for "compressing positive and negative scores together near the top" — a real symptom, but not the cause. A threshold calibrated on a compressed distribution sits *inside* it, not *above* it.

## 1. A boxless Good vote trained on a vector the scorer never scored

Caltech-101 has no ground-truth `regions`, so `region_box_for_category` returns `None` and `MaxPatchStyle.good_vec` fell back to the DINOv3 CLS vector. But `MaxPatchStyle._rows_for_media` returned only the raw `patch_grid`:

```
MaxHAC   scoring rows: (24, 32) | CLS vector present: True
MaxPatch scoring rows: (196, 32) | CLS vector present: False
```

Every Bad vote floods raw patches as negatives, so "looks like a raw patch" became evidence of Bad. Calibration saw positives in CLS-space against negatives in patch-space, found a clean gap, and cut inside it. Production scores from raw patches alone, so the entire test set landed on the negative side — FPR → 0, FNR → huge, ranking untouched.

`max_hac` was immune for a structural reason, not the "smoothed 24-node region pool" the report credits: `patch_regions[0]` **is** the CLS full-image node (`children=None`, box `(0,0,1,1)`), so it is both flooded and pooled.

## 2. Calibration bags of different widths

`_style_train_and_calibrate` gave a Good vote one row and a Bad vote ~196, and `_compute_fold_orderings_grouped` collapses each bag with `max`. Calibration compared a **max-over-1** positive against a **max-over-196** negative while production is max-over-196 for both. `max` is an upward-biased order statistic, so the cut landed high — biased toward rejecting true matches. Confirmed with one trained model held fixed:

```
GOOD votes : calibration median 0.5430   production median 0.5270   shift -0.0161
BAD  votes : calibration median 0.5256   production median 0.5256   shift +0.0000
```

The Bad Bags were the one part already correct.

## 3. Scale was sampled by accident, and measured in the wrong unit

`select_categories` sorted by **positive count** and sampled at even rank intervals — it spanned *prevalence*. Scale was never a selection criterion, so coverage was incidental: 7 of 12 categories below HAC-leaf scale, 5 above. Reading the 5 off Figure 4:

| category | area | Δ(MaxPatch − MaxHAC) | winner |
|---|---|---|---|
| giraffe | 10.1% | ~+0.045 | MaxHAC |
| water | 11.8% | ~+0.107 | MaxHAC |
| building | 13.3% | ~−0.054 | MaxPatch |
| floor | 20.0% | ~−0.080 | MaxPatch |
| bed | 25.5% | ~−0.003 | tie |

The only MaxHAC wins anywhere in the boxed dataset are above the leaf line, so the pre-registered crossover is *visible* — but it's 5 mixed-sign points, and that is what ρ = 0.57 at **p = 0.051** rests on. Caltech could not help: with no boxes it measures image-level voting, not large targets.

Worse, the x-axis was the wrong variable. `region_box_for_category` votes the **union box over every instance**, but Figure 4 plotted the **median instance area**. The two diverge sharply on multi-instance categories — an image with `arm`s scattered across it has ~1%-area instances but a near-frame union box — so categories plotted at the small end were really being handed large regions.

Boxed datasets now sample `N_PER_BAND` categories from each of four `SCALE_BANDS` straddling the patch (~0.51%) and leaf (~8.3%) reference scales, selected on **voted** box area, with near-frame categories dropped (`MAX_VOTED_AREA`, default 80%) since a whole-image "region vote" rebuilds the Caltech confound. Bands log under-population and drops by name:

```
mode: scale_bands | selected 14
  band sub_patch      [ 0.00%,   0.51%): 2/6 from 2  ** UNDER-POPULATED ** -> ['clock', 'eye']
  band patch_to_leaf  [ 0.51%,   8.33%): 6/6 from 6 -> ['arm', 'bird', 'girl', 'grass', 'leg', 'shirt']
  band leaf_to_4x     [ 8.33%,  33.33%): 4/6 from 4  ** UNDER-POPULATED ** -> ['bed', 'building', 'floor', 'giraffe']
  band above_4x       [33.33%, 101.00%): 2/6 from 2  ** UNDER-POPULATED ** -> ['elephant', 'train']
  dropped 'sky': median voted box covers 93% of the image
```

## Changes

- **`vtscore/eval/patch_styles.py`** — `MaxPatchStyle.score_rows` leads with the full-image vector (197 rows); `bad_vecs` floods it too. Public `score_rows` on all three styles.
- **`vtscore/training/thresholds.py`** — optional `score_rows_by_group` on `compute_fold_orderings`; pooling extracted to `_pooled_group_scores`.
- **`vtscore/eval/labels.py`** — `voted_box_area`, `instance_box_areas`, `category_scale_stats` (with `union_inflation`), so "scale" has one definition shared by selection and analysis.
- **`vtscore/eval/voting_iterations.py`** — harness passes each vote's `style.score_rows`.
- **`scripts/experiments/max_patch/`** — scale-band selection with the whole-image cap and loud under-population logging; `analyze.py` plots voted-box area with band shading; README documents the sampling rules.
- **Tests** — `TestTrainScoreGeometryParity`, `TestCalibrationInInferenceGeometry`, `TestVotedBoxScale`, and a new `test_max_patch_selection.py` (the experiment scripts previously had no coverage at all).

## Backwards compatibility

`max_patch` scoring changes shape (196 → 197 rows) and category selection changes on boxed datasets, so cached experiment output is not comparable across this change. Production is untouched: every live caller passes `score_rows_by_group=None`, pinned byte-identical by `test_none_override_leaves_production_path_byte_identical`.

## What is not fixed here

Production has its own milder echo of defect 2 — `_build_vote_xy` gives a Good vote 1 row and a Bad vote ~13 — so live MaxHAC thresholds carry the same FNR-ward bias. Deliberately out of scope; filed as **#2731**.

## Validation

- Full suite green: **6827 passed, 1 skipped**.
- A synthetic reproduction (real code paths) reproduced the FPR=0.000/FNR=1.000 signature before the fix and its disappearance after; AP rose 0.688 → 1.000 once the full-image row entered the pool. It could **not** validate the end-to-end operating point — its fold models sat near chance — which is what the rerun is for.
- Band selection and the rewritten Figure 4 were smoke-tested on synthetic VG-shaped data (output above; figure renders with band shading).
- **The experiment's numbers are not regenerated by this change.** `REPORT.md` carries a correction notice marking every ErrorCost/FPR/FNR figure and the Verdict as unrefreshed.

Refs #2730, refs #2731

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoJPpLZQ4oPR16cSQWWjMF