### PR TITLE
Precompute thumbnails on thin loads so referenced datasets browse fast

### DIFF
--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -80,12 +80,18 @@ class TestThinLoadFromFolder:
         load_dataset_from_folder(tmp_path, "audio", medias, thin=True)
         assert medias[1]["md5"] == expected_md5
 
-    def test_thin_no_duration(self, tmp_path):
-        """Thin mode skips load_media_data, so duration stays at default 0."""
+    def test_thin_has_duration_and_waveform(self, tmp_path):
+        """Thin mode still builds the ingest-time display fields.
+
+        Audio has a browsable thumbnail (its waveform PNG), so a thin load runs
+        ``load_thin_media_data`` and picks up the decoded duration alongside it.
+        Only the *payload* is withheld — see ``test_thin_clips_have_no_bytes``.
+        """
         _make_wav_file(tmp_path, "test.wav")
         medias: dict[int, dict[str, Any]] = {}
         load_dataset_from_folder(tmp_path, "audio", medias, thin=True)
-        assert medias[1]["duration"] == 0
+        assert medias[1]["duration"] > 0
+        assert medias[1]["thumbnail_bytes"]
 
     def test_full_mode_has_bytes(self, tmp_path):
         """Full mode (thin=False) should still load bytes as before."""

--- a/tests_lib/datasets/test_thumbnail_persistence.py
+++ b/tests_lib/datasets/test_thumbnail_persistence.py
@@ -9,18 +9,24 @@ original on a cold tile fetch.  These tests lock two things:
 2. ``export_dataset_to_file`` writes every media type's ``pickle_extra_fields``
    (not just a hardcoded list), so ``thumbnail_bytes`` survives a pickle
    round-trip.  This previously silently dropped for audio/video too.
+3. A **thin** load (the "Reference files in place" option / CLI ``--thin``)
+   precomputes the same thumbnail as a full load while still leaving
+   ``media_bytes`` empty, so referenced datasets browse at the same speed as
+   copied ones.
 """
 
 from __future__ import annotations
 
 import io
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from PIL import Image
 
-from vtscore.datasets.loader import export_dataset_to_file
+from vtscore.datasets.loader import export_dataset_to_file, load_dataset_from_folder
 from vtscore.datasets.loader_pickle import load_dataset_from_pickle
+from vtscore.media.document.media_type import DocumentMediaType
 from vtscore.media.image.media_type import ImageMediaType
 
 
@@ -87,3 +93,75 @@ class TestThumbnailSurvivesPickleRoundTrip:
         load_dataset_from_pickle(pkl, loaded)
 
         assert loaded[1]["thumbnail_bytes"] == thumb
+
+
+def _thin_load_images(folder: Path) -> dict[int, dict[str, Any]]:
+    medias: dict[int, dict[str, Any]] = {}
+    load_dataset_from_folder(folder, "image", medias, thin=True)
+    return medias
+
+
+class TestThinLoadPrecomputesThumbnails:
+    """A thin load keeps the payload out of memory but not the preview."""
+
+    def test_thin_image_load_has_thumbnail_but_no_bytes(self, tmp_path: Path):
+        (tmp_path / "a.png").write_bytes(_png_bytes())
+        (tmp_path / "b.png").write_bytes(_png_bytes(color=(200, 30, 30)))
+
+        medias = _thin_load_images(tmp_path)
+
+        assert len(medias) == 2
+        for media in medias.values():
+            # Still a pure path reference: the point of a thin load.
+            assert media["media_bytes"] is None
+            assert media["media_string"] is None
+            assert Path(media["media_path"]).exists()
+            # ...but the browse/grid tile no longer decodes the original.
+            assert media["thumbnail_bytes"]
+            with Image.open(io.BytesIO(media["thumbnail_bytes"])) as thumb:
+                assert max(thumb.size) <= 384
+
+    def test_thin_load_records_dimensions(self, tmp_path: Path):
+        (tmp_path / "a.png").write_bytes(_png_bytes(size=(1200, 800)))
+
+        media = _thin_load_images(tmp_path)[1]
+
+        assert (media["width"], media["height"]) == (1200, 800)
+
+    def test_thin_and_full_loads_produce_the_same_thumbnail(self, tmp_path: Path):
+        (tmp_path / "a.png").write_bytes(_png_bytes())
+
+        thin = _thin_load_images(tmp_path)[1]
+        full: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "image", full, thin=False)
+
+        assert thin["thumbnail_bytes"] == full[1]["thumbnail_bytes"]
+
+    def test_thin_thumbnail_survives_pickle_round_trip(self, tmp_path: Path):
+        (tmp_path / "a.png").write_bytes(_png_bytes())
+        medias = _thin_load_images(tmp_path)
+        rng = np.random.default_rng(11)
+        medias[1]["embeddings"] = {"siglip": rng.standard_normal(512).astype(np.float32)}
+
+        pkl = tmp_path / "ds.pkl"
+        pkl.write_bytes(export_dataset_to_file(medias, embedder="siglip", media_type="image"))
+        loaded: dict = {}
+        load_dataset_from_pickle(pkl, loaded)
+
+        # Without an ingest-time thumbnail the save-side backfill can't help a
+        # thin media (it needs ``media_bytes``), so this would be None before.
+        assert loaded[1]["thumbnail_bytes"] == medias[1]["thumbnail_bytes"]
+
+    def test_undecodable_source_thins_without_raising(self, tmp_path: Path):
+        (tmp_path / "bad.png").write_bytes(b"not an image")
+
+        media = _thin_load_images(tmp_path)[1]
+
+        assert media["media_bytes"] is None
+        assert media["thumbnail_bytes"] is None
+
+
+class TestThinLoadSkipsTypesWithNoIngestArtifact:
+    def test_document_thin_load_reads_nothing(self, tmp_path: Path):
+        """Documents rasterise their preview on request, so a thin load stays pure."""
+        assert DocumentMediaType().load_thin_media_data(tmp_path / "missing.pdf") == {}

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -453,6 +453,13 @@ def _build_per_file_media(
             file_path.stat().st_size,
             origin,
         )
+        # Thin keeps the *payload* out of memory, not the preview: without an
+        # ingest-time thumbnail every grid / VTSBrowse tile re-decodes the
+        # full-resolution original on each cold request.  Merge in the display
+        # fields only (see ``MediaType.load_thin_media_data``); ``media_bytes``
+        # stays None, so the media is still a path reference.
+        if mt.has_thumbnail:
+            media_data.update(mt.load_thin_media_data(file_path))
     else:
         with open(file_path, "rb") as f:
             file_bytes = f.read()

--- a/vtscore/datasets/pdf.py
+++ b/vtscore/datasets/pdf.py
@@ -104,6 +104,7 @@ def load_pdf_images_into(
     provenance points back to the source document.
     """
     from vtscore.media import get_by_folder_name  # noqa: PLC0415
+    from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
     from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks  # noqa: PLC0415
 
     pdf_files = sorted(rglob_follow_symlinks(folder, "*.pdf") if recursive else glob_top_level(folder, "*.pdf"))
@@ -129,6 +130,12 @@ def load_pdf_images_into(
             else:
                 full_page_name = page_name
 
+            # Downscale to a grid/list thumbnail now, while the rendered page is
+            # already in hand.  A thin load discards ``image_bytes`` entirely and
+            # a full one only keeps them until save, so without this every tile
+            # re-renders the whole PDF page at request time.
+            thumb = make_image_thumbnail(image_bytes)
+
             media_data: dict[str, Any] = {
                 "id": media_id,
                 "media_type": mt.type_id,
@@ -146,6 +153,7 @@ def load_pdf_images_into(
                 "duration": 0,
                 "width": pil_image.width,
                 "height": pil_image.height,
+                "thumbnail_bytes": thumb[0] if thumb is not None else None,
             }
             medias[media_id] = media_data
             media_id += 1

--- a/vtscore/media/base.py
+++ b/vtscore/media/base.py
@@ -516,6 +516,36 @@ class MediaType(ABC):
             {"media_bytes": b"...", "duration": 0, "width": 32, "height": 32}
         """
 
+    #: Keys that carry a media's full payload.  A thin load stores a
+    #: ``media_path`` reference instead of these, so
+    #: :meth:`load_thin_media_data` strips them from whatever
+    #: :meth:`load_media_data` returns.
+    _PAYLOAD_KEYS = ("media_bytes", "media_string")
+
+    def load_thin_media_data(self, file_path: Path) -> dict:
+        """Return the *display* fields for a thin load: no payload, no re-read later.
+
+        A thin load (the "Reference files in place" importer option, and every
+        CLI ``--thin`` workflow) deliberately keeps a media's bytes out of
+        memory.  It used to skip :meth:`load_media_data` wholesale, which also
+        skipped the ingest-time ``thumbnail_bytes`` — so every grid / VTSBrowse
+        tile fell back to decoding the full-resolution original on each cold
+        request (~200 ms for a 12 MP photo, paid again after any reload).
+
+        This hook produces the same display artifacts the full path does
+        (``thumbnail_bytes``, ``width`` / ``height``, ``duration``) while
+        leaving the payload behind.  The default reads the file once through
+        :meth:`load_media_data` and drops :data:`_PAYLOAD_KEYS`; peak memory is
+        therefore one file at a time rather than the whole dataset.  Override
+        when the artifacts can be derived from the path without reading the
+        bytes at all (see the video type), or return ``{}`` when the type has
+        no ingest-time artifact worth the read.
+
+        Only called for types whose items have a browsable thumbnail
+        (:attr:`has_thumbnail`); everything else keeps the pure-reference load.
+        """
+        return {k: v for k, v in self.load_media_data(file_path).items() if k not in self._PAYLOAD_KEYS}
+
     # ------------------------------------------------------------------
     # HTTP serving
     # ------------------------------------------------------------------

--- a/vtscore/media/document/media_type.py
+++ b/vtscore/media/document/media_type.py
@@ -206,6 +206,16 @@ class DocumentMediaType(MediaType):
                 media_bytes = f.read()
         return {"media_bytes": media_bytes, "duration": 0}
 
+    def load_thin_media_data(self, file_path: Path) -> dict:
+        """No ingest-time artifact: a document's preview is rasterised on request.
+
+        Unlike image / audio / video, this type produces no ``thumbnail_bytes``
+        at ingest — the grid tile comes from :meth:`image_response`, which
+        renders the first PDF page on demand.  So the base default's read would
+        buy nothing but a full file copy; skip it and keep the thin load pure.
+        """
+        return {}
+
     # ------------------------------------------------------------------
     # HTTP serving
     # ------------------------------------------------------------------

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -808,6 +808,18 @@ class VideoMediaType(MediaType):
         if media_bytes is None:
             with open(file_path, "rb") as f:
                 media_bytes = f.read()
+        return {"media_bytes": media_bytes, **self.load_thin_media_data(file_path)}
+
+    def load_thin_media_data(self, file_path: Path) -> dict:
+        """Duration + mid-frame thumbnail, both read straight from the path.
+
+        Overrides the base default (which routes through
+        :meth:`load_media_data` and strips the payload) because neither
+        artifact needs the file's bytes in memory: OpenCV reads the container
+        headers by path, and the thumbnail grabs a single decoded frame.  A
+        thin video load therefore never buffers a multi-GB file just to get a
+        preview frame.
+        """
         try:
             import cv2  # noqa: PLC0415
 
@@ -820,8 +832,7 @@ class VideoMediaType(MediaType):
                 cap.release()
         except Exception:
             duration = 0.0
-        thumbnail = generate_video_thumbnail_from_file(file_path)
-        return {"media_bytes": media_bytes, "duration": duration, "thumbnail_bytes": thumbnail}
+        return {"duration": duration, "thumbnail_bytes": generate_video_thumbnail_from_file(file_path)}
 
     # ------------------------------------------------------------------
     # HTTP serving


### PR DESCRIPTION
Closes #2737
Refs #2738

## Problem

Browsing an image dataset imported with **"Reference files in place (don't copy)"** was far slower than one imported with copying, on the same files.

Browse tiles come from `GET /api/medias/<id>/thumbnail`, which streams `thumbnail_bytes` when the media has them and otherwise decodes the full-resolution original, resizes, re-encodes, and memoises. Those bytes are precomputed in `ImageMediaType.load_media_data`, which the folder loader only called on its **non-thin** branch — a thin load skipped it wholesale. That correctly withheld the payload, but it also withheld the preview, so every grid and VTSBrowse tile paid a cold decode:

| Source image | Per-tile decode + resize |
|---|---|
| 1600×1200 (1.2 MB) | 46 ms |
| 4000×3000 (7.6 MB) | 197 ms |
| 6000×4000 (15 MB) | 378 ms |

The browse canvas requests one per representative cell plus idle preloads, so a few hundred tiles is a visible stall. It was also paid again after every reload: the save-side backfill in `export_dataset_to_file` needs `media_bytes`, which a thin media doesn't have.

## Change

Add `MediaType.load_thin_media_data()`, returning the *display* fields (`thumbnail_bytes`, `width`/`height`, `duration`) without the payload:

- **Default** routes through `load_media_data` and strips `media_bytes` / `media_string`, so peak memory is one file at a time rather than the whole dataset — and any third-party media type gets thin thumbnails for free.
- **Video** overrides it to read duration and the mid-frame straight from the path, so a thin video load never buffers a multi-GB file just to get a preview frame.
- **Document** returns `{}` — its preview rasterises on request, so the base default's read would buy nothing but a full copy.

The folder loader calls it on the thin branch for types with a browsable thumbnail (`has_thumbnail`), leaving text on the pure-reference path.

Separately: PDF page ingest never emitted a thumbnail in *either* mode. Since the page is already rendered in memory there, generate one so tiles stop re-rasterising the page.

## Measurements

50 × 12 MP JPEGs (379 MB):

| | Import | Thumbnails | `media_bytes` held |
|---|---|---|---|
| thin, before | 0.7 s | 0/50 | 0 MB |
| thin, after | 10.5 s | 50/50 | 0 MB |
| full/copy | 11.2 s | 50/50 | 379 MB |

Thin now pays the same ingest cost as a full import while keeping its entire memory benefit. That's the intended trade: move the decode from per-tile-on-every-browse to once at ingest, where it also persists through save.

## Scope note

This fixes reference-mode imports. It does **not** fix **archive-member manifests** — a `.npz` with `members` + `archives` arrays, which `server_files` delegates to `local_archive_member`. That importer builds media from manifest rows alone and deliberately reads no member bytes, so it has no file to decode at ingest and its tiles still stream a tar member and decode per request. Tracked separately in #2738, which is why that issue is referenced rather than closed here.

## Testing

`./run-tests.sh` — 6833 passed, 1 skipped.

New coverage in `tests_lib/datasets/test_thumbnail_persistence.py`: thin loads carry a thumbnail with `media_bytes` still `None`, record dimensions, produce byte-identical thumbnails to a full load, survive a pickle round-trip, and tolerate undecodable sources.

`test_thin_no_duration` in `test_thin_loading.py` was updated: it asserted duration stays 0 because thin skipped `load_media_data`. Audio has a browsable thumbnail (its waveform), so a thin load now decodes and picks up the real duration alongside it. Renamed to `test_thin_has_duration_and_waveform`; `test_thin_clips_have_no_bytes` still locks the payload guarantee.

## Backwards compatibility

Thin loads now populate `duration`, `width`/`height`, and `thumbnail_bytes` where they previously left them at defaults, and thin imports are slower in exchange. No shims added, per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3256aLtes7zWkYvBMBxSq