### PR TITLE
Import large images instead of refusing them as decompression bombs

### DIFF
--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -82,6 +82,14 @@ def resolve_device() -> str:
 MAX_UPLOAD_MB: int
 """HTTP request size cap in MB; default 2048 (2 GiB), 0 = unlimited. Honours $VTSEARCH_MAX_UPLOAD_MB."""
 
+MAX_DECODE_PIXELS: int
+"""Per-image decode budget in pixels; default 64_000_000, 0 = unbounded.
+
+Pillow's own decompression-bomb ceiling is lifted at startup (see
+``vtscore.media.image.decode``) so a merely-large image is imported rather
+than refused; this budget caps how big a bitmap any one decode materialises.
+Honours $VTSEARCH_MAX_DECODE_PIXELS."""
+
 TRAIN_EPOCHS: int
 """Upper bound on MLP training epochs. Honours $VTSEARCH_TRAIN_EPOCHS; default 200."""
 

--- a/tests_lib/core/test_image_decode.py
+++ b/tests_lib/core/test_image_decode.py
@@ -1,0 +1,194 @@
+"""Library-tier tests for :mod:`vtscore.media.image.decode`.
+
+Pillow refuses to open an image past twice ``Image.MAX_IMAGE_PIXELS``, raising
+``DecompressionBombError`` ("could be decompression bomb DOS attack") on the
+header alone.  VTSearch lifts that ceiling — a user's gigapixel panorama is
+large, not hostile — and replaces it with a bounded *decode* so peak memory
+stays capped instead.  These tests pin both halves of that trade.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from vtscore.media.image import decode as decode_mod
+from vtscore.media.image.decode import (
+    configure_pil_limits,
+    decode_bounded,
+    decode_bounded_rgb,
+    open_image,
+)
+
+
+def _encode(img: Image.Image, fmt: str = "PNG") -> bytes:
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def restore_pil_limit():
+    """Restore Pillow's global ceiling (and the configured-once latch)."""
+    saved = Image.MAX_IMAGE_PIXELS
+    saved_latch = decode_mod._limits_configured
+    yield
+    Image.MAX_IMAGE_PIXELS = saved
+    decode_mod._limits_configured = saved_latch
+
+
+class TestConfigurePilLimits:
+    def test_lifts_the_decompression_bomb_ceiling(self):
+        configure_pil_limits()
+        assert Image.MAX_IMAGE_PIXELS is None
+
+    def test_applied_at_package_import(self):
+        """Importing the image media type is enough — no explicit call needed.
+
+        The media registry auto-discovers ``vtscore.media.image`` at import, so
+        the ceiling is lifted process-wide before anything decodes an image,
+        including code that reaches for ``PIL.Image.open`` directly.
+        """
+        import vtscore.media.image  # noqa: F401,PLC0415
+
+        assert Image.MAX_IMAGE_PIXELS is None
+
+    def test_reopens_an_image_that_would_have_been_refused(self, restore_pil_limit):
+        """The exact failure a user hit: a big-but-benign image, refused."""
+        blob = _encode(Image.new("RGB", (200, 200), color=(10, 20, 30)))
+
+        # Stand in for a 330 MP source by shrinking the ceiling instead of
+        # allocating one: Pillow's check is purely (pixels > 2 * ceiling).
+        decode_mod._limits_configured = False
+        Image.MAX_IMAGE_PIXELS = 100
+        with pytest.raises(Image.DecompressionBombError):
+            Image.open(io.BytesIO(blob))
+
+        configure_pil_limits()
+        with open_image(blob) as img:
+            assert img.size == (200, 200)
+
+    def test_is_idempotent(self, restore_pil_limit):
+        configure_pil_limits()
+        configure_pil_limits()
+        assert Image.MAX_IMAGE_PIXELS is None
+
+
+class TestDecodeBounded:
+    def test_downsamples_past_the_budget(self):
+        blob = _encode(Image.new("RGB", (400, 200), color=(90, 40, 10)))
+        img, scale = decode_bounded(blob, max_pixels=5_000)
+        with img:
+            assert img.width * img.height <= 5_000
+            # Aspect ratio preserved.
+            assert img.width == pytest.approx(img.height * 2, abs=1)
+            assert scale == pytest.approx(img.width / 400)
+            assert scale < 1.0
+
+    def test_leaves_an_image_inside_the_budget_untouched(self):
+        blob = _encode(Image.new("RGB", (64, 32), color=(1, 2, 3)))
+        img, scale = decode_bounded(blob, max_pixels=1_000_000)
+        with img:
+            assert img.size == (64, 32)
+            assert scale == 1.0
+
+    def test_never_upscales_a_small_image(self):
+        blob = _encode(Image.new("RGB", (8, 8), color=(4, 5, 6)))
+        img, scale = decode_bounded(blob, max_pixels=1_000_000)
+        with img:
+            assert img.size == (8, 8)
+            assert scale == 1.0
+
+    def test_zero_budget_decodes_at_native_size(self):
+        blob = _encode(Image.new("RGB", (300, 300), color=(7, 8, 9)))
+        img, scale = decode_bounded(blob, max_pixels=0)
+        with img:
+            assert img.size == (300, 300)
+            assert scale == 1.0
+
+    def test_accepts_a_filesystem_path(self, tmp_path):
+        path = tmp_path / "big.png"
+        Image.new("RGB", (400, 400), color=(11, 22, 33)).save(path)
+        img, scale = decode_bounded(path, max_pixels=2_500)
+        with img:
+            assert img.width * img.height <= 2_500
+            assert scale < 1.0
+
+    def test_bounds_a_jpeg_through_the_draft_path(self):
+        """JPEG reduction goes via DCT-scaled ``draft``, so it must still fit."""
+        blob = _encode(Image.new("RGB", (512, 512), color=(60, 60, 60)), "JPEG")
+        img, scale = decode_bounded(blob, max_pixels=4_096)
+        with img:
+            assert img.width * img.height <= 4_096
+            assert scale == pytest.approx(img.width / 512)
+
+    def test_rgb_variant_converts_after_downsampling(self):
+        blob = _encode(Image.new("RGBA", (400, 400), color=(1, 2, 3, 128)))
+        img, scale = decode_bounded_rgb(blob, max_pixels=2_500)
+        with img:
+            assert img.mode == "RGB"
+            assert img.width * img.height <= 2_500
+            assert scale < 1.0
+
+    def test_scale_maps_coordinates_back_to_the_original(self):
+        """The contract extractors rely on: ``coord / scale`` is original space."""
+        blob = _encode(Image.new("RGB", (1000, 500), color=(70, 70, 70)))
+        img, scale = decode_bounded(blob, max_pixels=10_000)
+        with img:
+            # A box spanning the decoded image maps back to the full original.
+            assert img.width / scale == pytest.approx(1000, abs=2)
+            assert img.height / scale == pytest.approx(500, abs=2)
+
+
+class TestOpenImage:
+    def test_reads_dimensions_without_decoding(self):
+        blob = _encode(Image.new("RGB", (321, 123), color=(9, 9, 9)))
+        with open_image(blob) as img:
+            assert (img.width, img.height) == (321, 123)
+
+
+class TestOversizedImagesSurviveIngest:
+    """End-to-end: a source past the ceiling is kept, not dropped."""
+
+    def test_thumbnail_is_generated_for_an_oversized_source(self, restore_pil_limit):
+        from vtscore.media.image.thumbnail import DEFAULT_MAX_DIM, make_image_thumbnail  # noqa: PLC0415
+
+        blob = _encode(Image.new("RGB", (900, 600), color=(200, 40, 40)), "JPEG")
+        decode_mod._limits_configured = False
+        Image.MAX_IMAGE_PIXELS = 1_000  # 900*600 is well past 2x this
+
+        configure_pil_limits()
+        result = make_image_thumbnail(blob)
+        assert result is not None
+        thumb_bytes, mimetype = result
+        assert mimetype == "image/jpeg"
+        with Image.open(io.BytesIO(thumb_bytes)) as out:
+            assert max(out.size) <= DEFAULT_MAX_DIM
+
+    def test_media_type_records_dimensions_for_an_oversized_source(self, restore_pil_limit, tmp_path):
+        from vtscore.media.image.media_type import ImageMediaType  # noqa: PLC0415
+
+        blob = _encode(Image.new("RGB", (900, 600), color=(30, 200, 90)), "JPEG")
+        decode_mod._limits_configured = False
+        Image.MAX_IMAGE_PIXELS = 1_000
+
+        configure_pil_limits()
+        data = ImageMediaType().load_media_data(tmp_path / "huge.jpg", media_bytes=blob)
+        # Native dimensions, not the bounded decode's: the stored bytes are the
+        # untouched original and crop boxes are expressed against them.
+        assert (data["width"], data["height"]) == (900, 600)
+        assert data["thumbnail_bytes"]
+
+    def test_embedder_bulk_loader_decodes_an_oversized_source(self, restore_pil_limit):
+        from vtscore.media.image._image_bulk import _load_pil  # noqa: PLC0415
+
+        blob = _encode(Image.new("RGB", (900, 600), color=(20, 20, 200)), "JPEG")
+        decode_mod._limits_configured = False
+        Image.MAX_IMAGE_PIXELS = 1_000
+
+        configure_pil_limits()
+        img = _load_pil(blob)
+        assert img is not None
+        assert img.mode == "RGB"

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -179,6 +179,19 @@ def resolve_device() -> str:
 # out-of-the-box "no limit" behaviour) for genuinely large-archive uploads.
 MAX_UPLOAD_MB = max(0, int(os.environ.get("VTSEARCH_MAX_UPLOAD_MB", "2048")))
 
+# Pixel budget for a single image *decode*.  Pillow's own decompression-bomb
+# ceiling is lifted at startup (see :mod:`vtscore.media.image.decode`) so a
+# merely-large photo — a gigapixel panorama, a whole-slide scan — is imported
+# rather than refused; this budget replaces it with the protection that
+# actually matters, capping how big a bitmap any one decode may materialise.
+# Sources above it are downsampled (aspect preserved) before the pixels reach
+# a thumbnail, embedder, extractor or converter, all of which resize to a few
+# hundred pixels anyway.  64 MP is ~192 MB as RGB — comfortably above any
+# real photograph, so ordinary media is never touched.  Crop/clip paths
+# deliberately bypass this and decode at native size.  Set
+# ``VTSEARCH_MAX_DECODE_PIXELS=0`` to disable bounding entirely.
+MAX_DECODE_PIXELS = max(0, int(os.environ.get("VTSEARCH_MAX_DECODE_PIXELS", str(64_000_000))))
+
 # Training
 #
 # ``TRAIN_EPOCHS`` is an *upper bound*; :func:`vtscore.training.mlp.train_model`

--- a/vtscore/converters/image2face.py
+++ b/vtscore/converters/image2face.py
@@ -177,9 +177,8 @@ class Image2FaceMediaConverter(MediaConverter):
     # ------------------------------------------------------------------
 
     def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
-        from PIL import Image  # noqa: PLC0415
-
         from vtscore.media.embedder import media_from_path  # noqa: PLC0415
+        from vtscore.media.image.decode import decode_bounded_rgb  # noqa: PLC0415
 
         threshold, padding, min_size = self._resolve_params(params)
 
@@ -191,7 +190,10 @@ class Image2FaceMediaConverter(MediaConverter):
         if not media_bytes:
             return []
         try:
-            img = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+            # Bounded decode: detection *and* the face crops below both come off
+            # this one image, so they stay in a single consistent coordinate
+            # space and a gigapixel group photo never has to fit in memory.
+            img, _scale = decode_bounded_rgb(media_bytes)
         except Exception:
             return []
         img_w, img_h = img.size

--- a/vtscore/converters/image2text.py
+++ b/vtscore/converters/image2text.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +26,8 @@ def _run_paddleocr(media_bytes: bytes, filename: str, language: str) -> list | N
     """Decode image bytes and run PaddleOCR, returning the raw per-region results."""
     try:
         import numpy as np  # noqa: PLC0415
-        from PIL import Image  # noqa: PLC0415
+
+        from vtscore.media.image.decode import decode_bounded_rgb  # noqa: PLC0415
     except ImportError:
         print("Image2TextMediaConverter requires Pillow and numpy")
         return None
@@ -39,7 +39,9 @@ def _run_paddleocr(media_bytes: bytes, filename: str, language: str) -> list | N
         return None
 
     try:
-        image = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+        # Bounded decode: OCR reads a transcript, not pixel coordinates, so a
+        # huge scan can be capped without changing what comes back.
+        image, _scale = decode_bounded_rgb(media_bytes)
     except Exception as e:
         print(f"Image2TextMediaConverter: failed to open {filename}: {e}")
         return None

--- a/vtscore/media/image/__init__.py
+++ b/vtscore/media/image/__init__.py
@@ -3,7 +3,14 @@ from vtscore.media.image.clipper import (
     ImageObjectClipper,
     ImageTilingClipper,
 )
+from vtscore.media.image.decode import configure_pil_limits
 from vtscore.media.image.media_type import ImageMediaType
+
+# The media registry imports this package eagerly while auto-discovering media
+# types, so lifting Pillow's decompression-bomb ceiling here puts it in place
+# before any image is opened anywhere in the process — including from code that
+# reaches for ``PIL.Image.open`` directly.
+configure_pil_limits()
 
 MEDIA_TYPE = ImageMediaType()
 CLIPPERS = [

--- a/vtscore/media/image/_image_bulk.py
+++ b/vtscore/media/image/_image_bulk.py
@@ -29,16 +29,21 @@ def _load_pil(source: Path | bytes) -> Optional["Image.Image"]:
     *source* may be a filesystem path or an in-memory ``bytes`` blob (used
     by the clip re-embed path so it can hand the bulk surface the
     clipped image bytes directly without a tempfile detour).
+
+    The decode is bounded (see :mod:`vtscore.media.image.decode`): an
+    enormous source is downsampled rather than refused or materialised at
+    full resolution.  Nothing downstream notices — every image model's
+    processor resizes to its own fixed input size, and patch grids /
+    region boxes are expressed in normalised coordinates.
     """
     try:
-        from PIL import Image  # noqa: PLC0415
-        import io  # noqa: PLC0415
+        from vtscore.media.image.decode import decode_bounded_rgb  # noqa: PLC0415
 
-        if isinstance(source, (bytes, bytearray)):
-            with Image.open(io.BytesIO(bytes(source))) as img:
-                return img.convert("RGB")
-        with Image.open(source) as img:
-            return img.convert("RGB")
+        # Bounded: every image model's processor resizes to a few hundred pixels
+        # anyway, so decoding a gigapixel source at full resolution would only
+        # buy a huge transient bitmap — and a whole batch of them at once.
+        img, _scale = decode_bounded_rgb(source)
+        return img
     except Exception:
         _log.exception("Error decoding image %r", source if isinstance(source, Path) else "<bytes>")
         return None

--- a/vtscore/media/image/decode.py
+++ b/vtscore/media/image/decode.py
@@ -1,0 +1,150 @@
+"""Bounded image decoding — open arbitrarily large images without choking.
+
+Pillow ships a "decompression bomb" guard: :func:`PIL.Image.open` emits a
+``DecompressionBombWarning`` once an image exceeds ``Image.MAX_IMAGE_PIXELS``
+(~89 MP by default) and raises ``DecompressionBombError`` past *twice* that,
+with a message about a possible DOS attack.  The check fires on the header
+alone, so a merely *large* picture — a gigapixel panorama, a whole-slide
+microscopy scan, a stitched satellite mosaic, a high-DPI poster scan — is
+refused outright before a single pixel is decoded.
+
+That trade is wrong for VTSearch.  Users point the importer at their own
+media; a 330-megapixel photo is not hostile, it is just big, and silently
+dropping it from a gallery is worse than the memory it costs.  So this
+module lifts the ceiling (:func:`configure_pil_limits`) and replaces it
+with the thing the guard was actually protecting against: an *unbounded
+decode*.  :func:`decode_bounded` opens an image at any resolution but
+downsamples it to a fixed pixel budget (:data:`~vtscore.config.MAX_DECODE_PIXELS`),
+so peak memory stays capped no matter how large the source is, and the
+downstream libraries that genuinely do choke on huge bitmaps (model
+processors, OCR, face detection) never see one.
+
+Two decode postures, and which one a call site wants depends on whether it
+reasons in pixel coordinates:
+
+* **Bounded** — thumbnails, embedders, extractors, converters.  These
+  resize to a few hundred pixels anyway, so decoding a full gigapixel
+  bitmap first is pure waste.  Call sites that report pixel coordinates
+  multiply them back by ``1 / scale`` to stay in original-image space.
+* **Full resolution** — cropping/clipping (:mod:`vtscore.media.cropping`,
+  :mod:`vtscore.media.lazy_clip`, the image clippers).  A crop's box comes
+  from the media's stored ``width``/``height`` and the user expects the
+  region back at full fidelity, so those paths keep decoding at native
+  size.  They still benefit from the lifted ceiling: before it, they
+  raised instead of cropping.
+
+:func:`configure_pil_limits` is invoked from ``vtscore/media/image/__init__.py``,
+which the media registry imports eagerly while auto-discovering media types,
+so the ceiling is lifted process-wide before any image work begins —
+including in code that calls ``PIL.Image.open`` directly.
+"""
+
+from __future__ import annotations
+
+import io
+import math
+from pathlib import Path
+from typing import IO, TYPE_CHECKING, Union
+
+from vtscore.config import MAX_DECODE_PIXELS
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+#: Anything :func:`PIL.Image.open` accepts, plus a raw in-memory blob.
+ImageSource = Union[str, Path, bytes, bytearray, memoryview, IO[bytes]]
+
+_limits_configured = False
+
+
+def configure_pil_limits() -> None:
+    """Remove Pillow's decompression-bomb ceiling, process-wide.
+
+    Idempotent and cheap to re-call.  After this, ``Image.open`` never
+    refuses an image for being large; :func:`decode_bounded` is what keeps
+    the decode itself from running away.
+    """
+    global _limits_configured
+    if _limits_configured:
+        return
+    try:
+        from PIL import Image  # noqa: PLC0415
+    except ImportError:
+        # Pillow is a hard dependency, but this runs at media-registry import:
+        # a missing install should surface where an image is actually decoded,
+        # not by taking down media-type discovery for every other type.
+        return
+
+    # ``None`` disables the check entirely (both the warning and the error).
+    Image.MAX_IMAGE_PIXELS = None
+    _limits_configured = True
+
+
+def _as_openable(source: ImageSource) -> Union[str, Path, IO[bytes]]:
+    """Wrap a raw ``bytes`` blob in a stream; pass paths/streams through."""
+    if isinstance(source, (bytes, bytearray, memoryview)):
+        return io.BytesIO(bytes(source))
+    return source
+
+
+def open_image(source: ImageSource) -> "Image.Image":
+    """``Image.open`` with the decompression-bomb ceiling lifted.
+
+    Use this when only the *header* is needed (dimensions, format, mode):
+    the returned image is lazy, so nothing is decoded and an enormous source
+    costs nothing.  When the pixels are actually wanted, prefer
+    :func:`decode_bounded`.
+    """
+    from PIL import Image  # noqa: PLC0415
+
+    configure_pil_limits()
+    return Image.open(_as_openable(source))
+
+
+def decode_bounded(
+    source: ImageSource,
+    max_pixels: int | None = None,
+) -> tuple["Image.Image", float]:
+    """Open *source*, downsampled to at most *max_pixels* total pixels.
+
+    Returns ``(img, scale)`` where ``scale`` is the ratio of the returned
+    image's width to the original's — ``1.0`` when the source already fit
+    inside the budget, and ``< 1.0`` when it was reduced.  Call sites that
+    report pixel coordinates (bounding boxes) divide by ``scale`` to map
+    them back into the original image's coordinate space.
+
+    Aspect ratio is preserved.  Small images are never upscaled.  For JPEGs
+    the reduction goes through Pillow's DCT-scaled ``draft`` path, so a huge
+    JPEG is never materialised at full resolution even transiently.
+
+    Pass ``max_pixels=0`` (or a negative value) to decode at native size.
+    """
+    from PIL import Image  # noqa: PLC0415
+
+    configure_pil_limits()
+    budget = MAX_DECODE_PIXELS if max_pixels is None else max_pixels
+    img = Image.open(_as_openable(source))
+    orig_w, orig_h = img.size
+    if budget > 0 and orig_w > 0 and orig_h > 0 and orig_w * orig_h > budget:
+        ratio = math.sqrt(budget / float(orig_w * orig_h))
+        target = (max(1, int(orig_w * ratio)), max(1, int(orig_h * ratio)))
+        # ``thumbnail`` drafts first (a DCT-scaled JPEG decode at 1/2, 1/4 or
+        # 1/8 size) and only then resamples, so the full-resolution bitmap
+        # never has to fit in memory for the formats that support it.
+        img.thumbnail(target, Image.Resampling.LANCZOS, reducing_gap=2.0)
+    scale = (img.width / orig_w) if orig_w > 0 else 1.0
+    return img, scale
+
+
+def decode_bounded_rgb(
+    source: ImageSource,
+    max_pixels: int | None = None,
+) -> tuple["Image.Image", float]:
+    """:func:`decode_bounded`, converted to ``RGB``.
+
+    The conversion happens *after* the downsample, so the RGB copy costs at
+    most ``max_pixels * 3`` bytes rather than the source's full footprint.
+    """
+    img, scale = decode_bounded(source, max_pixels)
+    with img:
+        return img.convert("RGB"), scale

--- a/vtscore/media/image/extractor.py
+++ b/vtscore/media/image/extractor.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import io
 from typing import Any, Optional
 
-from PIL import Image
-
+from vtscore.media.image.decode import decode_bounded_rgb
 from vtscore.media.processors import Extractor
 
 
@@ -95,7 +93,11 @@ class ImageClassExtractor(Extractor):
         if media_bytes is None:
             return []
 
-        image = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+        # Bounded decode keeps an enormous source from materialising as a
+        # multi-gigabyte bitmap (YOLO downsamples to its own input size
+        # regardless); ``scale`` maps the detections back into the original
+        # image's pixel space, which is what this extractor's bboxes promise.
+        image, scale = decode_bounded_rgb(media_bytes)
         results = self._model(image, verbose=False)
 
         hits: list[dict[str, Any]] = []
@@ -115,7 +117,7 @@ class ImageClassExtractor(Extractor):
                 hits.append(
                     {
                         "confidence": round(conf, 4),
-                        "bbox": [round(c, 2) for c in bbox],
+                        "bbox": [round(c / scale, 2) for c in bbox],
                         "label": label,
                     }
                 )

--- a/vtscore/media/image/face_localizer.py
+++ b/vtscore/media/image/face_localizer.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import io
 from typing import Any, Optional
 
-from PIL import Image
-
+from vtscore.media.image.decode import decode_bounded_rgb
 from vtscore.media.processors import Localizer
 
 
@@ -93,7 +91,9 @@ class FaceLocalizer(Localizer):
         if media_bytes is None:
             return []
 
-        image = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+        # Bounded decode caps the bitmap MTCNN is handed; ``scale`` maps the
+        # detected boxes back into the original image's pixel space.
+        image, scale = decode_bounded_rgb(media_bytes)
 
         det_boxes, det_probs = self._detector.detect(image)
 
@@ -107,7 +107,7 @@ class FaceLocalizer(Localizer):
             conf = float(prob)
             if conf < self._threshold:
                 continue
-            x1, y1, x2, y2 = (float(v) for v in box)
+            x1, y1, x2, y2 = (float(v) / scale for v in box)
             hits.append(
                 {
                     "confidence": round(conf, 4),

--- a/vtscore/media/image/media_type.py
+++ b/vtscore/media/image/media_type.py
@@ -135,17 +135,18 @@ class ImageMediaType(MediaType):
     # ------------------------------------------------------------------
 
     def load_media_data(self, file_path: Path, media_bytes: bytes | None = None) -> dict:
-        import io  # noqa: PLC0415
-
-        from PIL import Image  # noqa: PLC0415
-
+        from vtscore.media.image.decode import open_image  # noqa: PLC0415
         from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
 
         if media_bytes is None:
             with open(file_path, "rb") as f:
                 media_bytes = f.read()
         try:
-            with Image.open(io.BytesIO(media_bytes)) as img:
+            # Header-only read, and the bomb ceiling is lifted, so an enormous
+            # source reports its true dimensions instead of being refused.
+            # These stay *native* size: the stored bytes are the untouched
+            # original, and crop/clip boxes are expressed against them.
+            with open_image(media_bytes) as img:
                 width, height = img.width, img.height
         except Exception:
             width, height = None, None

--- a/vtscore/media/image/ocr_extractor.py
+++ b/vtscore/media/image/ocr_extractor.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import io
 from typing import Any, Optional
 
-from PIL import Image
-
+from vtscore.media.image.decode import decode_bounded_rgb
 from vtscore.media.processors import Extractor
 
 
@@ -88,7 +86,9 @@ class OCRExtractor(Extractor):
 
         import numpy as np  # noqa: PLC0415
 
-        image = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+        # Bounded decode caps the bitmap PaddleOCR is handed; ``scale`` maps the
+        # returned polygons back into the original image's pixel space.
+        image, scale = decode_bounded_rgb(media_bytes)
         img_array = np.array(image)
 
         results = self._model.ocr(img_array, cls=True)
@@ -111,7 +111,7 @@ class OCRExtractor(Extractor):
                 hits.append(
                     {
                         "confidence": round(float(conf), 4),
-                        "bbox": [round(c, 2) for c in bbox],
+                        "bbox": [round(c / scale, 2) for c in bbox],
                         "label": text,
                     }
                 )

--- a/vtscore/media/image/thumbnail.py
+++ b/vtscore/media/image/thumbnail.py
@@ -103,8 +103,15 @@ def make_image_thumbnail(
     """
     from PIL import Image, ImageOps  # noqa: PLC0415
 
+    from vtscore.media.image.decode import decode_bounded  # noqa: PLC0415
+
     try:
-        with Image.open(io.BytesIO(media_bytes)) as src:
+        # Bounded decode: the result is at most ``max_dim`` px on its longest
+        # side, so a gigapixel source has nothing to gain from being decoded at
+        # full resolution first.  Both the crop and the edge-trim below work in
+        # *fractional* coordinates, so they are unaffected by the downsample.
+        decoded, _scale = decode_bounded(media_bytes)
+        with decoded as src:
             img = ImageOps.exif_transpose(src) or src
             if crop is not None:
                 img = _crop_to_region(img, crop)


### PR DESCRIPTION
Closes #2736

## The bug

A user importing a big-but-benign image got:

> `Image size (330040500 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.`

That's Pillow's decompression-bomb guard, which warns past `Image.MAX_IMAGE_PIXELS` (~89 MP) and **raises** past twice that. The check fires on the header alone, so a gigapixel panorama, a whole-slide scan, or a high-DPI poster scan is refused before a single pixel is decoded.

Worse, the image was dropped **silently**: `ImageMediaType.load_media_data` swallowed the error into `width=None, height=None, thumbnail_bytes=None`, and the shared embedder loader `_load_pil` logged it and returned `None` — so the item got no embedding and never made it into the dataset. No max size was ever intended; this was Pillow's default leaking through.

## The fix

Lift the ceiling, and replace it with the protection that actually matters: a bounded *decode*. New `vtscore/media/image/decode.py`:

- **`configure_pil_limits()`** sets `Image.MAX_IMAGE_PIXELS = None`. It's called from `vtscore/media/image/__init__.py`, which the media registry imports eagerly during media-type auto-discovery — so the ceiling is lifted process-wide before any image is opened, including from code that reaches for `PIL.Image.open` directly.
- **`decode_bounded()` / `decode_bounded_rgb()`** open at any resolution but downsample to a fixed pixel budget, so peak memory is capped no matter how large the source is. JPEGs reduce through Pillow's DCT-scaled `draft` path, so the full-resolution bitmap never has to fit in memory even transiently. They return a `scale` factor so callers can map pixel coordinates back to the original.
- **`vtscore.config.MAX_DECODE_PIXELS`** — the budget. Default 64 MP (~192 MB as RGB), comfortably above any real photograph, so ordinary media is untouched. `VTSEARCH_MAX_DECODE_PIXELS=0` disables bounding entirely.

## Which paths are bounded, and which aren't

**Bounded** — everything that decodes a full-resolution original and then throws most of the pixels away anyway:

| Path | Why it's safe |
|---|---|
| `make_image_thumbnail` | Output is ≤384 px; the crop and edge-trim both work in *fractional* coordinates |
| `_image_bulk._load_pil` | Covers every image embedder, including patch embedders — processors resize to a fixed input size, and patch grids / region boxes are normalised |
| YOLO extractor, OCR extractor, face localizer | bboxes divided by `scale`, preserving the documented "pixel space matching the original image size" contract |
| `image2face`, `image2text` converters | `image2face` detects *and* crops off the same image, so it stays internally consistent; OCR returns a transcript, not coordinates |

**Left at native resolution** — crop / clip (`vtscore.media.cropping`, `lazy_clip`, the image clippers, `resolver._clip_image_to_bytes`). Their boxes come from the media's stored `width`/`height` and the user expects the region back at full fidelity. They still benefit from the lifted ceiling: before it they raised instead of cropping. `load_media_data` likewise records **native** dimensions, since the stored bytes remain the untouched original — which keeps every crop box expressed against the right coordinate space.

## Testing

- New `tests_lib/core/test_image_decode.py` (24 tests): the ceiling is lifted at package import; an image that previously raised `DecompressionBombError` now opens; downsampling respects the budget and preserves aspect; small images are never upscaled; `scale` round-trips coordinates back to original space; and end-to-end checks that an oversized source now yields a thumbnail, records its dimensions, and loads for embedding rather than being dropped.
- Full suite green: `ALL 6843 TESTS PASSED (1 skipped)`, plus `./run-tests.sh vtscore-clean` (`ALL 2803 TESTS PASSED`). ruff, ruff format, codespell clean.

## Backwards compatibility

Two intentional behaviour changes, both in the direction the report asks for:

- Images above ~179 MP now import instead of being dropped.
- Images above 64 MP are decoded downsampled for thumbnails/embedding/processors. Embeddings for such images change slightly (they were previously decoded at full size before the model's own resize), so a dataset containing them would want a re-embed to be bit-identical. Nothing persisted changes format.