### PR TITLE
Stop the progress-plot modal blocking on an inline cache rebuild

### DIFF
--- a/docs/api/labeling.md
+++ b/docs/api/labeling.md
@@ -90,10 +90,21 @@ GET /api/indicator-score-history
 
 **Query params:** `metric`: one of `"smart"`, `"stable"`, `"diverse"`.
 
-→ `{"metric": "smart", "history": [...]}`
+→ `{"metric": "smart", "history": [...], "complete": true}`
 
-Returns cached per-step indicator data (computed during labeling-status
-polling).
+Returns per-step indicator data straight from the cache that the
+`labeling-status` background worker advances. This route is **read-only**: it
+never advances the cache and never retrains a model, so it returns promptly
+whatever the dataset size or label-history length.
+
+When the cache does not yet cover the whole label history — the normal state
+while the user is actively labeling, since `labeling-status` defers the advance
+to a background worker — the response is `{"metric": ..., "history": [],
+"complete": false}`. Clients should then fall back to
+`POST /api/eval/train-and-score` (below), which computes the same series on a
+background thread with live progress and cancellation. `complete: false` is
+also returned if the cache is momentarily locked by an in-flight refresh, so
+the read never waits on a build.
 
 ### Evaluate metric (train-and-score)
 

--- a/docs/plans/scalability.md
+++ b/docs/plans/scalability.md
@@ -398,6 +398,17 @@ embedder. Shares the S11 approach.
   `POST /api/datasets/registry/<id>/coverage-atlas` when a loaded dataset has no
   tree (auto-build is skipped above 50 k). No dataset/tree-status panel hosts it
   today, so it needs a UI home; the endpoint is meanwhile reachable via API/CLI.
+- **Share the coverage atlas with the progress cache instead of rebuilding it:**
+  `labeling_progress._build_coverage_atlas` clones the dataset context's atlas
+  only when the id sets match exactly; otherwise it fits a throwaway private one
+  under `_progress_lock`. On a dataset past the 50 k auto-build cutoff (so the
+  context has no atlas) that fit dominates a cold progress-cache build —
+  measured ~27 s of a 40 s build at 20 k media. It can't write the result back
+  to the context from there because `_progress_lock` is held and the lock
+  ordering forbids taking `_state_lock` under it. Fix direction: build the atlas
+  before acquiring `_progress_lock` and publish it to the context so both paths
+  share one structure. Now off the request thread (the plot modal runs it as a
+  background job), so this is a cost problem, not a latency-hang.
 - **Columnar `medias` storage** (S4 full rewrite): deferred; requires redesign of
   every media-reading call site.
 - **Append-only vote journal** for labelset sources (S12 long-term): deferred

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3608,6 +3608,9 @@
       "IndicatorScoreHistoryResponse": {
         "additionalProperties": false,
         "properties": {
+          "complete": {
+            "type": "boolean"
+          },
           "history": {
             "items": {
               "additionalProperties": {},
@@ -3625,6 +3628,7 @@
           }
         },
         "required": [
+          "complete",
           "history",
           "metric"
         ],
@@ -12809,7 +12813,7 @@
     },
     "/api/indicator-score-history": {
       "get": {
-        "description": "Reads only the per-step cache populated by the labeling-status\npolling; no models are retrained.",
+        "description": "Reads only the per-step cache advanced by the ``/api/labeling-status``\nbackground worker; **no models are retrained and the cache is never\nadvanced here**, so the response is always fast regardless of dataset size\nor label-history length.\n\nWhen the cache does not yet cover the whole ``label_history`` the response\ncarries ``complete: false`` and an empty ``history``.  Clients should then\nfall back to ``POST /api/eval/train-and-score``, which computes the same\nseries on a background thread with live progress and cancellation.\n\nThis route used to call the ``calculate_*_over_time`` helpers directly.\nThose advance the cache via ``_ensure_cache`` - retraining one MLP per\nuncached label step plus a forward pass over the unlabeled pool, and on a\ncold cache a full hierarchical-k-means coverage-atlas build - all inline on\nthe request thread under ``_progress_lock``.  Since ``/api/labeling-status``\ndeliberately defers exactly that work to a background worker (issue #2397),\nthe cache is behind for most of a labeling session, and this endpoint\nabsorbed the entire deferred build: tens of seconds on a mid-size dataset,\ngrowing with both media count and vote count.",
         "operationId": "indicator_score_history",
         "parameters": [
           {
@@ -12848,7 +12852,7 @@
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }
         },
-        "summary": "Return cached indicator score history for a given metric.",
+        "summary": "Return the cached indicator score history for a given metric.",
         "tags": [
           "eval"
         ]

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -103,7 +103,6 @@
 @if (progressModalMetric) {
   <vt-progress-modal
     [metric]="progressModalMetric"
-    [useCachedHistory]="true"
     (closed)="onProgressModalClosed()"
   />
 }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
@@ -1,7 +1,7 @@
 <vt-modal [title]="title" [open]="true" (closed)="onCancel()">
   @if (analyzing) {
     <div class="analysis-loading">
-      @if (useCachedHistory()) {
+      @if (!runningJob) {
         <p aria-live="polite">Loading indicator history…</p>
       } @else {
         <vt-job-progress

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -38,6 +38,15 @@ describe('ProgressModalComponent', () => {
     httpMock.verify();
   });
 
+  const isHistory = (req: HttpRequest<unknown>) => req.url === '/api/indicator-score-history';
+  const isResult = (req: HttpRequest<unknown>) => req.url === '/api/eval/train-and-score/result';
+
+  /** Flush the cached-history GET that `ngOnInit` always issues first, with a
+   *  cache miss so the component falls through to the async job. */
+  const missCachedHistory = (metric = 'smart') => {
+    httpMock.expectOne(isHistory).flush({ metric, history: [], complete: false });
+  };
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -57,14 +66,15 @@ describe('ProgressModalComponent', () => {
     vi.useFakeTimers();
     try {
       fixture.componentRef.setInput('metric', 'smart');
-      // TestBed.tick() runs ngOnInit (kicks off the train POST) under zoneless.
+      // TestBed.tick() runs ngOnInit (the cached read) under zoneless.
       TestBed.tick();
       expect(component.analyzing).toBe(true);
+      missCachedHistory('smart');
 
       // Progress now arrives over the `eval` SSE channel, not via HTTP polling.
-      // The only HTTP call is the train-and-score POST, which returns a job
-      // envelope; on a cache hit (status=done) the component applies the data
-      // inline without polling.
+      // The only other HTTP call is the train-and-score POST, which returns a
+      // job envelope; on a cache hit (status=done) the component applies the
+      // data inline without polling.
       const trainReq = httpMock.expectOne('/api/eval/train-and-score');
       trainReq.flush({
         job_id: 'abc',
@@ -95,6 +105,7 @@ describe('ProgressModalComponent', () => {
     try {
       fixture.componentRef.setInput('metric', 'smart');
       TestBed.tick();
+      missCachedHistory('smart');
 
       // Job started, not a cache hit -> the component polls for the result.
       httpMock.expectOne('/api/eval/train-and-score').flush({
@@ -108,9 +119,6 @@ describe('ProgressModalComponent', () => {
       // SSE says done *before* the result endpoint flips. This used to kill
       // the poller; it must only stop the progress watcher now.
       votingIterations$.next({ progress: 5, total: 5, done: true });
-
-      const isResult = (req: HttpRequest<unknown>) =>
-        req.url === '/api/eval/train-and-score/result';
 
       // First poll still sees `running`.
       await vi.advanceTimersByTimeAsync(200);
@@ -142,6 +150,7 @@ describe('ProgressModalComponent', () => {
     try {
       fixture.componentRef.setInput('metric', 'stable');
       TestBed.tick();
+      missCachedHistory('stable');
 
       httpMock.expectOne('/api/eval/train-and-score').flush({
         job_id: 'j2',
@@ -168,6 +177,7 @@ describe('ProgressModalComponent', () => {
     try {
       fixture.componentRef.setInput('metric', 'diverse');
       TestBed.tick();
+      missCachedHistory('diverse');
 
       const trainReq = httpMock.expectOne('/api/eval/train-and-score');
       component.ngOnDestroy();
@@ -180,6 +190,112 @@ describe('ProgressModalComponent', () => {
       httpMock.expectNone((req: HttpRequest<unknown>) =>
         req.url === '/api/eval/train-and-score/result',
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('renders a complete cached history without starting a job', async () => {
+    // The warm-cache fast path: the per-step cache already covers the label
+    // history, so the plot paints straight from the cheap GET and no MLP
+    // retraining is triggered at all.
+    vi.useFakeTimers();
+    try {
+      fixture.componentRef.setInput('metric', 'smart');
+      TestBed.tick();
+
+      httpMock.expectOne(isHistory).flush({
+        metric: 'smart',
+        history: [{ num_labels: 5, error_cost: 0.5 }],
+        complete: true,
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.runningJob).toBe(false);
+      expect(component.chartData.length).toBe(1);
+      httpMock.expectNone('/api/eval/train-and-score');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to the async job when the cached history is incomplete', async () => {
+    // Regression for the hang: the GET must never block on a cache advance, so
+    // an incomplete cache reports `complete: false` and the modal hands off to
+    // the background job — which is what surfaces the progress bar + Cancel.
+    vi.useFakeTimers();
+    try {
+      fixture.componentRef.setInput('metric', 'stable');
+      TestBed.tick();
+
+      expect(component.runningJob).toBe(false);
+      missCachedHistory('stable');
+      expect(component.runningJob).toBe(true);
+      expect(component.analyzing).toBe(true);
+
+      httpMock.expectOne('/api/eval/train-and-score').flush({
+        job_id: 'j3',
+        status: 'done',
+        metric: 'stable',
+        stability: [{ num_labels: 5, num_flips: 1 }],
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.chartData.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to the async job when the cached read fails', async () => {
+    // A failed cached read is recoverable: the job recomputes the series from
+    // scratch, so the modal must not settle on the "no history" empty state.
+    vi.useFakeTimers();
+    try {
+      fixture.componentRef.setInput('metric', 'diverse');
+      TestBed.tick();
+
+      httpMock.expectOne(isHistory).flush(
+        { message: 'Score history computation failed' },
+        { status: 500, statusText: 'Server Error' },
+      );
+      expect(component.runningJob).toBe(true);
+      expect(component.emptyHistory).toBe(false);
+
+      httpMock.expectOne('/api/eval/train-and-score').flush({
+        job_id: 'j4',
+        status: 'done',
+        metric: 'diverse',
+        diversity: [{ num_labels: 5, diversity_level: 2 }],
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.chartData.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows the empty state when a finished job yields no points', async () => {
+    vi.useFakeTimers();
+    try {
+      fixture.componentRef.setInput('metric', 'smart');
+      TestBed.tick();
+      missCachedHistory('smart');
+
+      httpMock.expectOne('/api/eval/train-and-score').flush({
+        job_id: 'j5',
+        status: 'done',
+        metric: 'smart',
+        error_cost: [],
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.emptyHistory).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -31,7 +31,6 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   private progressEvents = inject(ProgressEventsService);
 
   readonly metric = input<ProgressMetric>('smart');
-  readonly useCachedHistory = input(false);
   readonly closed = output<void>();
 
   // Optional query: the canvas only renders in the results `@else` branch.
@@ -41,6 +40,9 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   analysisProgress = 0;
   chartData: ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[] = [];
   emptyHistory = false;
+  /** True once we've fallen back to the async train-and-score job, which
+   *  swaps the brief "loading" line for a real progress bar + Cancel. */
+  runningJob = false;
   /** Job id of the in-flight eval train-and-score run. Set once the
    *  backend hands back a job envelope; consumed by ``onCancel``. */
   private currentJobId: string | null = null;
@@ -59,11 +61,12 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    if (this.useCachedHistory()) {
-      this.loadCachedHistory();
-    } else {
-      this.runAnalysis();
-    }
+    // Always try the cached read first: it never advances the per-step cache,
+    // so it returns immediately whether or not the cache is warm. When the
+    // background `/api/labeling-status` worker has kept up (the common case)
+    // the plot paints instantly; otherwise we fall back to the async job,
+    // which does the retraining off the request thread with a progress bar.
+    this.loadCachedHistory();
   }
 
   ngOnDestroy(): void {
@@ -73,24 +76,35 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
 
   private loadCachedHistory(): void {
     this.analyzing = true;
-    this.sortingApi.getIndicatorScoreHistory(this.metric()).subscribe({
-      next: (res) => {
-        this.analyzing = false;
-        this.chartData = (res.history || []) as ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[];
-        this.emptyHistory = this.chartData.length === 0;
-        if (!this.emptyHistory) {
-          setTimeout(() => this.renderChart(), 50);
-        }
-      },
-      error: () => {
-        this.analyzing = false;
-        this.emptyHistory = true;
-      },
-    });
+    this.sortingApi
+      .getIndicatorScoreHistory(this.metric())
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          // `complete: false` means the per-step cache is behind the label
+          // history. The endpoint deliberately does not advance it (that build
+          // is what used to hang this modal for tens of seconds), so hand off
+          // to the background job instead of rendering a truncated series.
+          if (!res.complete) {
+            this.runAnalysis();
+            return;
+          }
+          this.analyzing = false;
+          this.chartData = (res.history || []) as ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[];
+          this.emptyHistory = this.chartData.length === 0;
+          if (!this.emptyHistory) {
+            setTimeout(() => this.renderChart(), 50);
+          }
+        },
+        // A failed cached read is not fatal: the job path recomputes the
+        // series from scratch, so fall back rather than showing "no history".
+        error: () => this.runAnalysis(),
+      });
   }
 
   private runAnalysis(): void {
     this.analyzing = true;
+    this.runningJob = true;
     this.analysisProgress = 0;
 
     // Progress comes from the `eval` SSE channel on /api/events. Use a
@@ -184,6 +198,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
 
   private applyEvalResult(res: EvalTrainAndScoreResponse): void {
     this.analyzing = false;
+    this.runningJob = false;
     if (this.metric() === 'smart') {
       this.chartData = (res.error_cost || []) as ErrorCostDataPoint[];
     } else if (this.metric() === 'stable') {
@@ -191,7 +206,13 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     } else {
       this.chartData = (res.diversity || []) as DiversityDataPoint[];
     }
-    setTimeout(() => this.renderChart(), 50);
+    // Same empty-state handling as the cached path: a job that legitimately
+    // produces no points (too little history) shows the explanatory message
+    // rather than an empty set of axes.
+    this.emptyHistory = this.chartData.length === 0;
+    if (!this.emptyHistory) {
+      setTimeout(() => this.renderChart(), 50);
+    }
   }
 
   private renderChart(): void {

--- a/tests/api/test_eval_routes_failures.py
+++ b/tests/api/test_eval_routes_failures.py
@@ -84,12 +84,51 @@ class TestIndicatorScoreHistoryFailures:
 
     def test_computation_error_returns_500(self, client):
         with unittest.mock.patch(
-            "vtsearch.routes.eval.calculate_error_cost_over_time",
+            "vtsearch.routes.eval.cached_indicator_history",
             side_effect=RuntimeError("boom"),
         ):
             resp = client.get("/api/indicator-score-history?metric=smart")
         assert resp.status_code == 500
         assert "score history" in resp.get_json()["message"].lower()
+
+
+class TestIndicatorScoreHistoryIsReadOnly:
+    """GET /api/indicator-score-history must never advance the per-step cache.
+
+    Advancing it inline is what made the progress-plot modal hang: it retrains
+    an MLP per uncached label step on the request thread, which is precisely the
+    work ``/api/labeling-status`` defers to a background worker (issue #2397).
+    """
+
+    def test_cold_cache_returns_incomplete_and_trains_nothing(self, client):
+        import vtscore.detectors.labeling_progress as lp
+
+        _seed_votes_and_history()
+        lp.clear_progress_cache()
+
+        with unittest.mock.patch.object(lp, "train_model", side_effect=AssertionError("retrained")):
+            resp = client.get("/api/indicator-score-history?metric=smart")
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["complete"] is False
+        assert body["history"] == []
+        assert lp._cached_steps == []
+
+    def test_warm_cache_returns_the_series(self, client):
+        import vtscore.detectors.labeling_progress as lp
+
+        _seed_votes_and_history()
+        lp.clear_progress_cache()
+        # The background worker's job, done inline here.
+        client.post("/api/eval/train-and-score", json={"metric": "smart", "wait": True})
+
+        resp = client.get("/api/indicator-score-history?metric=smart")
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["complete"] is True
+        assert len(body["history"]) > 0
 
 
 class TestEvalTrainAndScoreStartFailures:

--- a/tests_lib/detectors/test_indicator_history_cache.py
+++ b/tests_lib/detectors/test_indicator_history_cache.py
@@ -1,0 +1,222 @@
+"""Tests for the read-only indicator-history path and its per-step cache costs.
+
+The progress-plot modal used to load its series through the
+``calculate_*_over_time`` helpers, which call ``_ensure_cache`` and therefore
+retrain one MLP per uncached label step - plus, on a cold cache, a full
+hierarchical-k-means coverage-atlas build - on the calling thread while holding
+``_progress_lock``.  ``/api/labeling-status`` deliberately defers exactly that
+work to a background worker (issue #2397), so the cache is behind for most of a
+labeling session and the modal absorbed the whole deferred build.
+
+These tests pin the three pieces that fixed it:
+
+* :func:`cached_indicator_history` reads the cache and **never advances it**,
+  reporting ``complete=False`` instead, and never blocks on ``_progress_lock``.
+* The stability pass's monitored pool is materialised once per cache lifetime
+  rather than once per label step.
+* The fallback coverage-atlas build applies the same depth cap as every other
+  build site.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+
+import vtscore.detectors.labeling_progress as lp
+from vtscore.embedding.media_vectors import EMBEDDINGS_KEY
+
+
+def _clips(n: int, dim: int = 8, seed: int = 0) -> dict[int, dict]:
+    rng = np.random.default_rng(seed)
+    return {
+        cid: {EMBEDDINGS_KEY: {"test": rng.standard_normal(dim).astype(np.float32)}, "embedder": "test"}
+        for cid in range(n)
+    }
+
+
+def _history(n_votes: int) -> list[tuple[int, str, float]]:
+    return [(k, "good" if k % 2 == 0 else "bad", float(k)) for k in range(n_votes)]
+
+
+def _votes(n_votes: int) -> tuple[dict[int, None], dict[int, None]]:
+    good = {k: None for k in range(n_votes) if k % 2 == 0}
+    bad = {k: None for k in range(n_votes) if k % 2 == 1}
+    return good, bad
+
+
+class TestCachedIndicatorHistory:
+    def test_cold_cache_reports_incomplete_without_advancing(self):
+        """The whole point: a cold read must not trigger any per-step training."""
+        clips = _clips(60)
+        history = _history(8)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+
+        data, complete = lp.cached_indicator_history("smart", clips, history, good, bad, 0)
+
+        assert complete is False
+        assert data == []
+        # No steps were built: the cache is exactly as cold as we left it.
+        assert lp._cached_steps == []
+
+    def test_warm_cache_returns_series_for_every_metric(self):
+        clips = _clips(60)
+        history = _history(8)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+
+        # Advance the cache the way the background worker does.
+        lp.calculate_error_cost_over_time(clips, history, good, bad, 0)
+
+        for metric in ("smart", "stable", "diverse"):
+            data, complete = lp.cached_indicator_history(metric, clips, history, good, bad, 0)
+            assert complete is True, metric
+            assert len(data) > 0, metric
+
+    def test_partially_advanced_cache_reports_incomplete(self):
+        """A cache covering only a prefix must not yield a truncated plot."""
+        clips = _clips(60)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+
+        lp.calculate_error_cost_over_time(clips, _history(4), good, bad, 0)
+        # More votes have landed since the last background refresh.
+        data, complete = lp.cached_indicator_history("smart", clips, _history(8), good, bad, 0)
+
+        assert complete is False
+        assert data == []
+
+    def test_inclusion_change_reports_incomplete(self):
+        """A cache built for another inclusion value would be rebuilt on read."""
+        clips = _clips(60)
+        history = _history(8)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+
+        lp.calculate_error_cost_over_time(clips, history, good, bad, 0)
+        _, complete = lp.cached_indicator_history("smart", clips, history, good, bad, 5)
+
+        assert complete is False
+        # The read must not have rebuilt the cache under the new inclusion.
+        assert lp._cache_inclusion == 0
+
+    def test_does_not_block_on_an_in_flight_cache_build(self, monkeypatch):
+        """A click landing mid-refresh falls through instead of hanging.
+
+        The background worker holds ``_progress_lock`` for the entire build, so
+        a blocking read would reintroduce exactly the hang this path exists to
+        avoid.
+        """
+        monkeypatch.setattr(lp, "_CACHE_READ_LOCK_TIMEOUT", 0.05)
+        clips = _clips(60)
+        history = _history(8)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+        lp.calculate_error_cost_over_time(clips, history, good, bad, 0)
+
+        holding = threading.Event()
+        release = threading.Event()
+
+        def _hold_lock():
+            with lp._progress_lock:
+                holding.set()
+                release.wait(timeout=5)
+
+        holder = threading.Thread(target=_hold_lock, daemon=True)
+        holder.start()
+        try:
+            assert holding.wait(timeout=5)
+            # The cache is complete, but the lock is held: report unavailable
+            # rather than waiting for the holder.
+            data, complete = lp.cached_indicator_history("smart", clips, history, good, bad, 0)
+            assert complete is False
+            assert data == []
+        finally:
+            release.set()
+            holder.join(timeout=5)
+
+        # Once the lock frees up the same read succeeds.
+        _, complete = lp.cached_indicator_history("smart", clips, history, good, bad, 0)
+        assert complete is True
+
+
+class TestMonitoredPoolReuse:
+    def test_pool_tensor_is_built_once_per_cache_lifetime(self):
+        """Advancing further steps must reuse the pool, not re-materialise it.
+
+        Rebuilding it per step was an O(N x D) numpy materialisation on every
+        label-history step and dominated the cost of advancing the cache.
+        """
+        clips = _clips(200)
+        good, bad = _votes(6)
+        lp.clear_progress_cache()
+
+        lp.calculate_prediction_stability_over_time(clips, _history(6), 0)
+        first = lp._cache_monitored_X
+        assert first is not None
+        assert lp._cache_monitored_ids is not None
+
+        # Advance the cache with more steps: same pool object, no rebuild.
+        lp.calculate_prediction_stability_over_time(clips, _history(12), 0)
+        assert lp._cache_monitored_X is first
+
+    def test_pool_is_dropped_on_cache_clear(self):
+        """Medias may have changed, so the derived pool must not survive."""
+        clips = _clips(60)
+        lp.clear_progress_cache()
+        lp.calculate_prediction_stability_over_time(clips, _history(6), 0)
+        assert lp._cache_monitored_X is not None
+
+        lp.clear_progress_cache()
+
+        assert lp._cache_monitored_X is None
+        assert lp._cache_monitored_ids is None
+        assert lp._cache_monitored_set is None
+
+    def test_stability_counts_match_the_unsampled_pool(self):
+        """Scoring the whole pool and dropping labels must not change the counts."""
+        clips = _clips(60)
+        lp.clear_progress_cache()
+
+        stability = lp.calculate_prediction_stability_over_time(clips, _history(6), 0)
+
+        assert stability
+        for entry in stability:
+            # 60 medias, `num_labels` of them labeled at that step.
+            assert entry["num_unlabeled"] == 60 - entry["num_labels"]
+
+
+class TestFallbackAtlasDepth:
+    def test_fallback_build_applies_the_depth_cap(self, monkeypatch):
+        """The fallback atlas must not be deeper than the context atlas it stands in for.
+
+        Omitting ``max_depth`` left this build on ``COVERAGE_ATLAS_MAX_DEPTH``
+        while every other build site passes ``auto_max_depth``, so the throwaway
+        atlas cost many more k-means fits than the real one.
+        """
+        import vtscore.state.coverage_atlas as ca
+
+        monkeypatch.setattr(lp, "_active_context_atlas", lambda: None)
+        monkeypatch.setattr(ca, "auto_max_depth", lambda n, k=3, **kw: 2)
+
+        atlas = lp._build_coverage_atlas(_clips(120))
+
+        assert atlas is not None
+        assert atlas.max_depth == 2
+
+    def test_reuses_the_context_atlas_structure_when_ids_match(self, monkeypatch):
+        """The clone path skips the hierarchical k-means entirely."""
+        from vtscore.state.coverage_atlas import CoverageAtlas
+
+        clips = _clips(120)
+        vectors = {cid: media[EMBEDDINGS_KEY]["test"] for cid, media in clips.items()}
+        ctx_atlas = CoverageAtlas(vectors, k=3)
+        monkeypatch.setattr(lp, "_active_context_atlas", lambda: ctx_atlas)
+
+        atlas = lp._build_coverage_atlas(clips)
+
+        assert atlas is not ctx_atlas
+        # Structure shared by reference; only the label overlay is fresh.
+        assert atlas.nodes is ctx_atlas.nodes

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -54,6 +54,15 @@ _cache_bad_ids: set[int] = set()
 _cache_prev_predictions: Optional[dict[int, int]] = None
 _cache_coverage_atlas: Any = None  # CoverageAtlas | None
 
+# Fixed pool the per-step stability forward pass scores, built once per cache
+# lifetime and reused by every step (see ``_monitored_pool``).  ``_cache_
+# monitored_X`` is a device-resident float tensor of the pool's embeddings;
+# ``_cache_monitored_set`` is the id set for O(labels) unlabeled counting.
+# In-memory only - never serialized (see the "No Persisted Vectors" rule).
+_cache_monitored_ids: Optional[list[int]] = None
+_cache_monitored_X: Any = None  # torch.Tensor | None
+_cache_monitored_set: Optional[set[int]] = None
+
 # Last fully-computed ``/api/labeling-status`` payload (minus the transient
 # ``stale`` flag).  ``compute_labeling_status`` refreshes it on every full
 # compute; the route returns it immediately to pollers while a background
@@ -73,18 +82,24 @@ _live_models: dict[tuple[frozenset[int], frozenset[int]], tuple[Any, float]] = {
 # call clear_progress_cache internally when the inclusion value changes.
 _progress_lock = threading.RLock()
 
-# Upper bound on the number of unlabeled items the per-step stability
-# forward pass evaluates.  ``/api/labeling-status`` (polled every 2 s during
-# labeling) advances this cache on the request thread, and the stability
-# pass runs a forward over *all* unlabeled media - O(dataset) per new vote.
+# Upper bound on the number of items the per-step stability forward pass
+# evaluates.  Advancing this cache (from the ``/api/labeling-status``
+# background worker, or the ``/api/eval/train-and-score`` job) runs a forward
+# over the whole monitored pool once per label step - O(dataset) per new vote.
 # Above this cap we score a deterministic seeded sample of the eligible pool
-# instead, holding the per-poll cost flat as datasets grow.  The "stable"
+# instead, holding the per-step cost flat as datasets grow.  The "stable"
 # indicator keys off the flip *rate* (num_flips / num_unlabeled), for which a
 # fixed random sample is an unbiased estimator; sampling from the *full*
 # eligible pool (not the shrinking unlabeled set) keeps the monitored ids
 # stable across steps so the step-to-step flip comparison stays meaningful.
 # Mirrors ``_GMM_MAX_SAMPLES`` in ``vtscore.training.thresholds``.
 _STABILITY_MAX_SAMPLES = 50_000
+
+# How long :func:`cached_indicator_history` will wait for ``_progress_lock``
+# before declaring the cache unreadable.  Long enough to ride out the brief
+# holds taken by status reads, short enough that a click landing mid-build
+# falls through to the async job instead of hanging on it.
+_CACHE_READ_LOCK_TIMEOUT = 0.25
 
 
 def clear_progress_cache() -> None:
@@ -94,6 +109,7 @@ def clear_progress_cache() -> None:
     is altered so that stale models are not reused.
     """
     global _cache_inclusion, _cache_prev_predictions, _cache_coverage_atlas, _status_snapshot
+    global _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set
     with _progress_lock:
         _cached_steps.clear()
         _cache_good_ids.clear()
@@ -101,6 +117,11 @@ def clear_progress_cache() -> None:
         _cache_prev_predictions = None
         _cache_inclusion = None
         _cache_coverage_atlas = None
+        # The monitored pool is derived from ``clips_dict``; medias may have
+        # changed under us, so drop it alongside everything else.
+        _cache_monitored_ids = None
+        _cache_monitored_X = None
+        _cache_monitored_set = None
         _live_models.clear()
         # Drop the status snapshot too: it belonged to the just-cleared
         # detector/labelset and would otherwise be served (stale) for the next
@@ -228,9 +249,16 @@ def _build_coverage_atlas(clips_dict: dict[int, dict[str, Any]]) -> Any:
     if ctx_atlas is not None and ctx_atlas.vector_to_leaf.keys() == vectors.keys():
         return ctx_atlas.structural_clone()
 
-    from vtscore.state.coverage_atlas import CoverageAtlas  # noqa: PLC0415
+    from vtscore.state.coverage_atlas import CoverageAtlas, auto_max_depth  # noqa: PLC0415
 
-    return CoverageAtlas(vectors, k=3)
+    # Cap the depth exactly as every other build site does
+    # (``build_coverage_atlas`` / ``build_coverage_atlas_for_context``).
+    # Omitting it left this fallback on ``COVERAGE_ATLAS_MAX_DEPTH``, so the
+    # atlas built here was *deeper* - and cost many more k-means fits - than
+    # the context atlas it stands in for.  That is the whole cost of a cold
+    # progress-cache build on a dataset large enough to skip the load-time
+    # atlas build, and it runs under ``_progress_lock``.
+    return CoverageAtlas(vectors, k=3, max_depth=auto_max_depth(len(vectors), k=3))
 
 
 def _apply_label_event(media_id: int, label: str) -> bool:
@@ -288,6 +316,54 @@ def _collect_training_data(
     return X_list, y_list
 
 
+def _monitored_pool(
+    clips_dict: dict[int, dict[str, Any]],
+    all_media_ids: list[int],
+) -> tuple[list[int], Any, set[int]]:
+    """Return the fixed ``(ids, X, id_set)`` pool the stability pass scores.
+
+    The pool is the embeddable subset of *all_media_ids*, bounded to a
+    deterministic seeded sample of ``_STABILITY_MAX_SAMPLES``.  Sampling the
+    full eligible pool (rather than the per-step unlabeled set) keeps the
+    monitored ids stable across steps, so the flip comparison against
+    ``_cache_prev_predictions`` stays over a consistent id set; the resulting
+    flip *rate* is an unbiased estimate of the true rate.
+
+    Built once per cache lifetime and memoised.  It used to be rebuilt inside
+    every step - an O(N x D) numpy materialisation per label-history step,
+    which dominated the cost of advancing the cache.  The pool depends only on
+    *clips_dict*, which cannot change without a ``clear_progress_cache()``,
+    so one build per cache lifetime is sound.
+    """
+    global _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set
+
+    if _cache_monitored_ids is not None:
+        return _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set  # type: ignore[return-value]
+
+    import torch  # noqa: PLC0415
+
+    from vtscore.embedding.loader import ensure_torch_configured, get_torch_device  # noqa: PLC0415
+
+    eligible = [cid for cid in all_media_ids if media_embedding(clips_dict.get(cid, {})) is not None]
+    if len(eligible) > _STABILITY_MAX_SAMPLES:
+        rng = np.random.default_rng(42)
+        sampled = set(rng.choice(np.asarray(eligible), size=_STABILITY_MAX_SAMPLES, replace=False).tolist())
+        eligible = [cid for cid in eligible if cid in sampled]
+
+    if eligible:
+        ensure_torch_configured()
+        embs = np.array([media_embedding(clips_dict[cid]) for cid in eligible])
+        # Park the tensor on the training device once so per-step scoring is a
+        # pure forward pass with no host->device copy.
+        _cache_monitored_X = torch.tensor(embs, dtype=torch.float32).to(get_torch_device())
+    else:
+        _cache_monitored_X = None
+
+    _cache_monitored_ids = eligible
+    _cache_monitored_set = set(eligible)
+    return _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set
+
+
 def _compute_step_stability(
     model: nn.Sequential,
     threshold: float,
@@ -300,33 +376,27 @@ def _compute_step_stability(
     global _cache_prev_predictions
     import torch  # noqa: PLC0415
 
+    monitored_ids, X_monitored, monitored_set = _monitored_pool(clips_dict, all_media_ids)
+
     labeled_ids = _cache_good_ids | _cache_bad_ids
-    eligible = [cid for cid in all_media_ids if media_embedding(clips_dict.get(cid, {})) is not None]
+    # Labels are few relative to the pool, so count the overlap from the
+    # labelset rather than rescanning the pool.
+    num_unlabeled = len(monitored_ids) - sum(1 for cid in labeled_ids if cid in monitored_set)
 
-    # Bound the forward pass to a deterministic seeded sample of the eligible
-    # pool.  Sampling the full pool (rather than the per-step unlabeled set)
-    # keeps the monitored ids stable across steps, so the flip comparison
-    # against ``_cache_prev_predictions`` below stays over a consistent id set;
-    # the resulting flip *rate* is an unbiased estimate of the true rate.
-    if len(eligible) > _STABILITY_MAX_SAMPLES:
-        rng = np.random.default_rng(42)
-        monitored = set(rng.choice(np.asarray(eligible), size=_STABILITY_MAX_SAMPLES, replace=False).tolist())
-        unlabeled_ids = [cid for cid in eligible if cid not in labeled_ids and cid in monitored]
-    else:
-        unlabeled_ids = [cid for cid in eligible if cid not in labeled_ids]
-
-    if not unlabeled_ids:
+    if num_unlabeled <= 0 or X_monitored is None:
         return {"time_index": t, "num_labels": num_labels, "num_flips": 0, "num_unlabeled": 0}
 
-    unlabeled_embs = np.array([media_embedding(clips_dict[cid]) for cid in unlabeled_ids])
-    X_unlabeled = torch.tensor(unlabeled_embs, dtype=torch.float32)
-
+    # Score the whole monitored pool in one pass and drop the currently-labeled
+    # ids afterwards.  Scoring the handful of extra (labeled) rows is far
+    # cheaper than re-materialising a per-step tensor of the unlabeled subset.
     with torch.no_grad():
-        X_unlabeled = X_unlabeled.to(next(model.parameters()).device)
-        scores_unl = torch.sigmoid(model(X_unlabeled)).squeeze(1).cpu().tolist()
+        X_in = X_monitored.to(next(model.parameters()).device)
+        scores_unl = torch.sigmoid(model(X_in)).squeeze(1).cpu().tolist()
 
     predictions: dict[int, int] = {
-        cid: 1 if score >= threshold else 0 for cid, score in zip(unlabeled_ids, scores_unl, strict=True)
+        cid: 1 if score >= threshold else 0
+        for cid, score in zip(monitored_ids, scores_unl, strict=True)
+        if cid not in labeled_ids
     }
 
     stability: Optional[dict[str, Any]] = None
@@ -340,7 +410,7 @@ def _compute_step_stability(
             "time_index": t,
             "num_labels": num_labels,
             "num_flips": num_flips,
-            "num_unlabeled": len(unlabeled_ids),
+            "num_unlabeled": num_unlabeled,
         }
     # else: no prior predictions to compare - leave stability as None.
 
@@ -888,6 +958,55 @@ def compute_labeling_status(
     with _progress_lock:
         _status_snapshot = dict(result)
     return result
+
+
+def cached_indicator_history(
+    metric: str,
+    clips_dict: dict[int, dict[str, Any]],
+    label_history: list[tuple[int, str, float]],
+    current_good_votes: dict[int, None],
+    current_bad_votes: dict[int, None],
+    inclusion_value: int = 0,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Read *metric*'s per-step history **without advancing the cache**.
+
+    Returns ``(history, complete)``.  ``complete`` is ``False`` - with an empty
+    history - whenever the per-step cache does not already cover the whole of
+    *label_history*; the caller is expected to fall back to the async
+    ``/api/eval/train-and-score`` job, which does the same work on a background
+    thread with progress and cancellation.
+
+    This is the counterpart to the ``calculate_*_over_time`` functions, which
+    call :func:`_ensure_cache` and therefore retrain an MLP per uncached step
+    on the calling thread.  Doing that inline is exactly what
+    ``/api/labeling-status`` refuses to do (issue #2397), so the read path that
+    backs the progress-plot modal must not do it either.
+
+    When the cache *is* complete every branch is cheap: ``smart`` runs forward
+    passes of the cached models over the (small) labeled set, and ``stable`` /
+    ``diverse`` are plain reads of values recorded during the cache build.
+    """
+    # Reading the cache needs ``_progress_lock``, but a background worker holds
+    # that lock for the *entire* duration of a cache build - which is exactly
+    # the multi-second work this function exists to avoid waiting on.  Blocking
+    # here would reintroduce the hang whenever the click lands mid-refresh, so
+    # give up quickly and report the cache as unavailable: the caller falls back
+    # to the async job, which is the right answer in that state anyway.
+    if not _progress_lock.acquire(timeout=_CACHE_READ_LOCK_TIMEOUT):
+        return [], False
+    try:
+        if not is_status_cache_fresh(label_history, inclusion_value):
+            return [], False
+
+        if metric == "smart":
+            data = _eval_cached_models(clips_dict, current_good_votes, current_bad_votes, inclusion_value)
+        elif metric == "stable":
+            data = [step["stability"] for step in _cached_steps if step["stability"] is not None]
+        else:
+            data = [step["diversity"] for step in _cached_steps if step.get("diversity") is not None]
+        return data, True
+    finally:
+        _progress_lock.release()
 
 
 def is_status_cache_fresh(label_history: list[tuple[int, str, float]], inclusion_value: int) -> bool:

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -12,6 +12,7 @@ from flask_smorest import Blueprint, abort
 
 from vtscore.detectors.labeling_progress import (
     analyze_labeling_progress,
+    cached_indicator_history,
     calculate_diversity_level_over_time,
     calculate_error_cost_over_time,
     calculate_prediction_stability_over_time,
@@ -166,10 +167,27 @@ def labeling_status_indicator():
 @eval_bp.response(200, IndicatorScoreHistoryResponseSchema)
 @eval_bp.alt_response(500, description="Score-history computation failed.")
 def indicator_score_history(query: dict):
-    """Return cached indicator score history for a given metric.
+    """Return the cached indicator score history for a given metric.
 
-    Reads only the per-step cache populated by the labeling-status
-    polling; no models are retrained.
+    Reads only the per-step cache advanced by the ``/api/labeling-status``
+    background worker; **no models are retrained and the cache is never
+    advanced here**, so the response is always fast regardless of dataset size
+    or label-history length.
+
+    When the cache does not yet cover the whole ``label_history`` the response
+    carries ``complete: false`` and an empty ``history``.  Clients should then
+    fall back to ``POST /api/eval/train-and-score``, which computes the same
+    series on a background thread with live progress and cancellation.
+
+    This route used to call the ``calculate_*_over_time`` helpers directly.
+    Those advance the cache via ``_ensure_cache`` - retraining one MLP per
+    uncached label step plus a forward pass over the unlabeled pool, and on a
+    cold cache a full hierarchical-k-means coverage-atlas build - all inline on
+    the request thread under ``_progress_lock``.  Since ``/api/labeling-status``
+    deliberately defers exactly that work to a background worker (issue #2397),
+    the cache is behind for most of a labeling session, and this endpoint
+    absorbed the entire deferred build: tens of seconds on a mid-size dataset,
+    growing with both media count and vote count.
     """
     metric = query["metric"]
 
@@ -177,13 +195,8 @@ def indicator_score_history(query: dict):
     inclusion = get_inclusion()
 
     try:
-        if metric == "smart":
-            data = calculate_error_cost_over_time(clips, label_history, good_votes, bad_votes, inclusion)
-        elif metric == "stable":
-            data = calculate_prediction_stability_over_time(clips, label_history, inclusion)
-        else:
-            data = calculate_diversity_level_over_time(clips, label_history, inclusion)
-        return {"metric": metric, "history": data}
+        data, complete = cached_indicator_history(metric, clips, label_history, good_votes, bad_votes, inclusion)
+        return {"metric": metric, "history": data, "complete": complete}
     except Exception:
         import logging
 

--- a/vtsearch/schemas/eval.py
+++ b/vtsearch/schemas/eval.py
@@ -120,6 +120,11 @@ class IndicatorScoreHistoryResponseSchema(Schema):
 
     metric = fields.String(required=True, validate=_METRIC_VALIDATOR)
     history = fields.List(fields.Dict(), required=True)
+    # ``false`` when the per-step cache does not yet cover the whole label
+    # history, in which case ``history`` is empty and the client should fall
+    # back to the async ``POST /api/eval/train-and-score`` job.  The route
+    # never advances the cache itself; see its docstring.
+    complete = fields.Boolean(required=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2740

## The bug

Clicking **Smart / Stable / Diverse** in the Manual panel could hang the modal for tens of seconds.

`GET /api/indicator-score-history` documented itself as *"Reads only the per-step cache … no models are retrained."* That was false. All three `calculate_*_over_time` helpers call `_ensure_cache`, which — synchronously on the request thread, under `_progress_lock` — retrains one MLP per uncached label step, runs a stability forward pass per step, and on a cold cache fits a full hierarchical-k-means coverage atlas.

That's exactly the work `/api/labeling-status` deliberately refuses to do inline (#2397), deferring it to a background worker. So the cache is behind for most of a labeling session, and this endpoint absorbed the entire deferred build. Manual mode is where it bites because that panel is the only host for the indicator dots and their plots — Autopilot renders read-only dots.

Measured end-to-end through the Flask test client:

| dataset | before (blocking GET) | after: cached read | after: fallback job |
|---|---|---|---|
| 3k media / 40 votes | 5.7s | 0.006s | 2.8s |
| 10k / 60 votes | 14.8s | 0.007s | 2.1s |
| 20k / 120 votes | **40.3s** | **0.008s** | 5.6s |

(Fallback-job column with the dataset context's atlas present; warm re-open of the plot is ~0.02s.)

## The fix

**Make the read honest and non-blocking.** New `cached_indicator_history` reads the per-step cache without ever advancing it, reporting `complete: false` instead. It also gives up on `_progress_lock` after a short timeout, so a click landing mid-refresh falls through rather than queueing behind a multi-second build — the same hang by another route.

**Use the async job that already existed.** The modal now tries the cached read first and falls back to `POST /api/eval/train-and-score`, which computes the same series on a background thread with live progress and cancellation. That path was already fully wired in `ProgressModalComponent` (`runAnalysis` / `pollEvalJob` / `onCancel`) but unreachable, because `label-view` pinned `[useCachedHistory]="true"`. That input is gone. Warm cache → plot paints instantly; cold cache → progress bar + working Cancel.

**Two cost fixes behind it:**

- Hoist the stability pass's monitored pool out of the per-step loop (`_monitored_pool`). It was re-materialising an O(N × D) numpy array on *every* label step; it now builds once per cache lifetime, parks on the training device, and is scored in place with labeled ids dropped afterward. Per-step work dropped ~2.4× (13.2s → 5.6s at 20k/120).
- Pass `auto_max_depth` to the fallback coverage-atlas build, matching `build_coverage_atlas` / `build_coverage_atlas_for_context`. Without it that throwaway atlas ran at `COVERAGE_ATLAS_MAX_DEPTH` — deeper, and many more k-means fits, than the context atlas it stands in for. Bites at ≥80k media, which is also where the load-time auto-build is skipped and this fallback is guaranteed to run.

## API change (breaking)

`GET /api/indicator-score-history` gains a required `complete` field and no longer computes missing history on demand; when `complete` is `false`, `history` is empty and clients should fall back to `/api/eval/train-and-score`. OpenAPI snapshot and `docs/api/labeling.md` updated.

## Tests

- `tests_lib/detectors/test_indicator_history_cache.py` (new): the cold read trains nothing and leaves `_cached_steps` empty; partial/inclusion-mismatched caches report incomplete; the read does not block behind a held `_progress_lock`; the monitored pool is built once per cache lifetime and dropped on clear; stability counts are unchanged by scoring the full pool; the fallback atlas applies the depth cap and the clone path shares structure.
- `tests/api/test_eval_routes_failures.py`: route-level cold read returns `complete: false` with `train_model` patched to raise, proving no retraining; warm read returns the series.
- `progress-modal.component.spec.ts`: warm cache renders without touching the job endpoint; incomplete cache and failed cached read both fall back to the job; finished-but-empty job shows the empty state.

Full suite green: 6839 passed, 1 skipped. Frontend: 1850 passed.

## Follow-up

The remaining cost — a private coverage-atlas fit when the dataset context has none — is recorded as an open item in `docs/plans/scalability.md`. It can't be published back to the context from `_build_coverage_atlas` because `_progress_lock` is held and the lock ordering forbids taking `_state_lock` under it; the fix is to build before acquiring the lock. It's now a cost problem rather than a latency hang, since it runs in the background job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvePkBiLVzNWHji22bbsgA