### PR TITLE
Decode video frames via ffmpeg instead of in-process OpenCV (FIPS crash)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,7 +76,9 @@ VTSearch/
 │   │   │                           FaceLocalizer, OCRExtractor
 │   │   ├── text/                   Text media type, embedders (E5 default, BGE), clippers
 │   │   ├── video/                  Video media type, embedders (X-CLIP default, LanguageBind,
-│   │   │                           VideoMAE), clippers
+│   │   │                           VideoMAE), clippers, decode.py (all frame decoding, via an
+│   │   │                           ffmpeg subprocess — never in-process OpenCV; see DEPLOYMENT.md
+│   │   │                           "FATAL FIPS SELFTEST FAILURE")
 │   │   ├── document/               Document media type — convert-out half type (importable, no
 │   │   │                           embedder; converts_to image/text), clipper, UCSF demo
 │   │   └── face/                   Face media type — convert-in half type (embeddable, not

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -634,12 +634,12 @@ bash scripts/install.sh gpu
 | `sentence-transformers` | latest | E5 text embeddings |
 | `numpy` | latest | Numeric arrays |
 | `flask` | latest | Web server |
-| `opencv-python-headless` | `<4.10` | Video frame extraction |
+| `opencv-python-headless` | latest | Image processing (structural embedder, YOLO). **Not** used for video decoding — see [FIPS](#video-import-crashes-with-fatal-fips-selftest-failure) |
 | `ultralytics` | latest | YOLO-based image processing |
 | `laion_clap` | latest | Audio embedding preprocessing |
 | `librosa` | latest | Audio analysis (spectrograms, silence splitting) |
 | `soundfile` / `soxr` | latest | Audio decoding and resampling (`vtscore.media.audio.decode`) |
-| `imageio-ffmpeg` | latest | Bundled ffmpeg binary; decodes codecs libsndfile can't (AAC/M4A/MP4) |
+| `imageio-ffmpeg` | latest | Bundled ffmpeg binary; audio codecs libsndfile can't read (AAC/M4A/MP4), and all video frame decoding (`vtscore.media.video.decode`) |
 | `PyMuPDF` | latest | Document (PDF/DOC/PPT) rendering and text extraction |
 
 ---
@@ -685,6 +685,44 @@ with `docker volume ls` and verify the `vtsearch-data` volume exists.
 
 **Fix**: Check internet connectivity. For offline use, import data locally
 via the folder or pickle importer instead.
+
+### Video import crashes with `FATAL FIPS SELFTEST FAILURE`
+
+**Symptom**: on a FIPS-enabled host, importing a video kills the process
+outright — no traceback, just a core dump and:
+
+```
+crypto/fips/fips.c:154 OpenSSL internal error: FATAL FIPS SELFTEST FAILURE
+```
+
+**Cause**: the `opencv-python-headless` wheel vendors its own OpenSSL.
+`cv2.abi3.so` needs `libavformat`, which needs the `libssl`/`libcrypto`
+1.1.1 pair shipped inside `opencv_python_headless.libs`, so merely
+importing `cv2` maps a second, non-FIPS OpenSSL into a process that
+already holds the system's FIPS-validated one. The duplicate trips the
+FIPS self-test and OpenSSL responds with `abort()`. Downgrading does not
+help — every wheel from 4.9 through 5.0 vendors the same OpenSSL 1.1.1w.
+
+**Fix**: none needed for video. All video decoding goes through ffmpeg
+(`vtscore.media.video.decode`), which runs out-of-process and so never
+loads OpenSSL into the interpreter. Confirm the host resolved to it:
+
+```bash
+python -c "from vtscore.media.video import decode; print(decode.backend())"
+```
+
+`ffmpeg` is the expected answer. If it prints `opencv`, this install has
+no ffmpeg at all and video decoding will fall back to `cv2` and crash —
+install one (`dnf install ffmpeg`, or `pip install imageio-ffmpeg` for
+the bundled static binary).
+
+**Still applies to image features.** The structural image embedder and
+the YOLO-based image processors import `cv2` directly, so those remain
+unusable on a FIPS host. To use them, replace the wheel with a build
+that links the system OpenSSL instead of vendoring one — a distro
+package (`dnf install python3-opencv`), or `opencv-python` built from
+source. Everything else, including the whole video workflow, works with
+the stock wheel installed.
 
 ### "No module named" errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ max-complexity = 10
 "vtsearch/__init__.py" = ["S603", "S607"]
 "vtscore/converters/video2audio.py" = ["S603"]
 "vtscore/media/audio/decode.py" = ["S603"]
+"vtscore/media/video/decode.py" = ["S603"]
 "vtsearch/routes/media/list.py" = ["S603"]
 # Atom feed parsing for the arXiv text-dataset downloader.
 "vtscore/datasets/downloader/text.py" = ["S314"]

--- a/tests/converters/test_document_and_converters.py
+++ b/tests/converters/test_document_and_converters.py
@@ -47,29 +47,21 @@ def _make_two_page_pdf() -> bytes:
 
 
 def _make_minimal_video(frames: int = 30, width: int = 64, height: int = 64) -> bytes:
-    """Create a minimal MP4 video using OpenCV.
-
-    Returns the MP4 bytes, or calls pytest.skip() if cv2 is unavailable.
-    """
-    try:
-        import cv2
-    except ImportError:
-        pytest.skip("OpenCV not installed")
+    """Create a minimal 10 fps MP4 with the bundled ffmpeg.  Returns its bytes."""
+    from vtscore.utils.synthetic.video import _encode_frames
 
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
-        tmp_path = f.name
+        tmp_path = Path(f.name)
 
-    # cv2 stubs miss VideoWriter_fourcc (runtime-only opencv builtin).
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # pyright: ignore[reportAttributeAccessIssue]
-    writer = cv2.VideoWriter(tmp_path, fourcc, 10.0, (width, height))
-    for i in range(frames):
-        frame = np.full((height, width, 3), fill_value=(i * 8) % 256, dtype=np.uint8)
-        writer.write(frame)
-    writer.release()
-
-    video_bytes = Path(tmp_path).read_bytes()
-    Path(tmp_path).unlink(missing_ok=True)
-    return video_bytes
+    try:
+        _encode_frames(
+            tmp_path,
+            [np.full((height, width, 3), fill_value=(i * 8) % 256, dtype=np.uint8) for i in range(frames)],
+            fps=10,
+        )
+        return tmp_path.read_bytes()
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 # ===========================================================================

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -1676,21 +1676,11 @@ class TestVideoSceneClipper:
         assert d["threshold"] == 0.4
         assert d["min_scene_duration"] == 1.5
 
-    def test_detect_scene_boundaries_no_cv2(self, monkeypatch):
-        """When OpenCV is not available, clip returns the media unchanged."""
-        import builtins
-
+    def test_detect_scene_boundaries_undecodable(self):
+        """When the bytes can't be decoded, clip returns the media unchanged."""
         from vtscore.media.video.clipper import VideoSceneClipper
 
-        real_import = builtins.__import__
-
-        def mock_import(name, *args, **kwargs):
-            if name == "cv2":
-                raise ImportError("no cv2")
-            return real_import(name, *args, **kwargs)
-
         media = {"id": 1, "media_type": "video", "media_bytes": b"fake", "duration": 10.0}
-        monkeypatch.setattr(builtins, "__import__", mock_import)
         result = VideoSceneClipper().clip(media)
         assert result == [media]
 

--- a/tests_lib/core/test_video.py
+++ b/tests_lib/core/test_video.py
@@ -6,29 +6,28 @@ seek-to-time, from bytes and from a file), the frame-seek math and its
 byte/format edge cases, the ``VideoMediaType`` display/serving surface, and
 the error paths on every branch.
 
-Frame decoding goes through OpenCV (``cv2``), which cannot decode the tiny
-synthetic clips used in the rest of the suite.  So the happy paths inject a
-**fake ``cv2``** (a real ndarray frame, then the real PIL/PNG pipeline runs)
-via ``sys.modules``; the error paths use genuinely undecodable input and the
-real (or absent) ``cv2`` so the ``return None`` guards are exercised for
-real.  The two together cover every branch without depending on a working
-video codec being present in the container.
+Frame decoding goes through :mod:`vtscore.media.video.decode`, which shells
+out to ffmpeg and so cannot decode the tiny synthetic clips used in the rest
+of the suite.  The happy paths therefore install a **fake decoder** (a real
+ndarray frame, then the real PIL/PNG pipeline runs); the error paths use
+genuinely undecodable input and the real decoder so the ``return None``
+guards are exercised for real.  The two together cover every branch without
+depending on a particular codec being present in the container.
 """
 
 from __future__ import annotations
 
 import io
-import sys
-import types
 
 import numpy as np
 import pytest
 from PIL import Image
 
+from vtscore.media.video import decode
 from vtscore.media.video.media_type import (
     _VIDEO_MIME_TYPES,
     VideoMediaType,
-    _frame_at_time,
+    _seek_time,
     generate_video_thumbnail,
     generate_video_thumbnail_at,
     generate_video_thumbnail_from_file,
@@ -39,89 +38,53 @@ _PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 
 
 # ---------------------------------------------------------------------------
-# Fake cv2 decoder
+# Fake decoder
 # ---------------------------------------------------------------------------
 
-# Sentinel values for the CAP_PROP_* / COLOR_* constants.  The fake reads them
-# by identity, so their concrete values are irrelevant.
-_PROP_FRAME_COUNT = "cap_prop_frame_count"
-_PROP_FPS = "cap_prop_fps"
-_PROP_POS_FRAMES = "cap_prop_pos_frames"
-_COLOR_BGR2RGB = "color_bgr2rgb"
 
+class _FakeDecoder:
+    """Stand-in for the ffmpeg decode layer with configurable metadata.
 
-class _FakeCapture:
-    """Stand-in for ``cv2.VideoCapture`` with configurable metadata.
-
-    ``read`` returns a solid-colour frame whose fill byte encodes the last
-    frame index requested via ``set(POS_FRAMES, ...)``, so seeking to two
-    different frames yields two visibly different frames (and thus different
-    thumbnail bytes).
+    ``frame_at`` returns a solid-colour frame whose red channel encodes the
+    requested timestamp's frame index, so two different seeks yield two
+    visibly different frames (and thus different thumbnail bytes).  Every
+    requested timestamp is recorded in :attr:`requested_times`.
     """
 
-    def __init__(self, *, opened=True, frame_count=200, fps=30.0, read_ok=True, dim=256):
-        self._opened = opened
-        self._frame_count = frame_count
+    def __init__(self, *, probe_ok=True, duration=6.0, fps=30.0, read_ok=True, dim=256):
+        self._probe_ok = probe_ok
+        self._duration = duration
         self._fps = fps
         self._read_ok = read_ok
         self._dim = dim
-        self.requested_frame: int | None = None
-        self.released = False
+        self.requested_times: list[float] = []
+        self.probed_paths: list[object] = []
 
-    def isOpened(self):  # noqa: N802 - cv2 API name
-        return self._opened
+    def probe(self, path):
+        self.probed_paths.append(path)
+        if not self._probe_ok:
+            return None
+        return decode.VideoInfo(duration=self._duration, fps=self._fps, width=self._dim, height=self._dim)
 
-    def get(self, prop):
-        if prop == _PROP_FRAME_COUNT:
-            return float(self._frame_count)
-        if prop == _PROP_FPS:
-            return float(self._fps)
-        return 0.0
-
-    def set(self, prop, value):
-        if prop == _PROP_POS_FRAMES:
-            self.requested_frame = int(value)
-
-    def read(self):
+    def frame_at(self, _path, time_seconds):
+        self.requested_times.append(float(time_seconds))
         if not self._read_ok:
-            return False, None
-        fill = (self.requested_frame or 0) % 256
-        # A BGR frame (channel 0 carries the fill so BGR->RGB is observable).
+            return None
+        fill = int(round(time_seconds * self._fps)) % 256
         frame = np.zeros((self._dim, self._dim, 3), dtype=np.uint8)
         frame[..., 0] = fill
-        return True, frame
-
-    def release(self):
-        self.released = True
-
-
-def _fake_cv2(**capture_cfg) -> types.SimpleNamespace:
-    """Build a fake ``cv2`` module whose ``VideoCapture`` yields ``_FakeCapture``.
-
-    A ``SimpleNamespace`` stands in for the module object in ``sys.modules``;
-    ``import cv2`` binds to whatever is registered there.
-    """
-
-    def cvt_color(frame, code):
-        assert code == _COLOR_BGR2RGB
-        return frame[..., ::-1].copy()
-
-    return types.SimpleNamespace(
-        CAP_PROP_FRAME_COUNT=_PROP_FRAME_COUNT,
-        CAP_PROP_FPS=_PROP_FPS,
-        CAP_PROP_POS_FRAMES=_PROP_POS_FRAMES,
-        COLOR_BGR2RGB=_COLOR_BGR2RGB,
-        VideoCapture=lambda _path: _FakeCapture(**capture_cfg),
-        cvtColor=cvt_color,
-    )
+        return frame
 
 
 @pytest.fixture
-def install_fake_cv2(monkeypatch):
-    """Return an installer that swaps ``cv2`` for a configured fake in ``sys.modules``."""
+def install_fake_decoder(monkeypatch):
+    """Return an installer that swaps the decode layer for a configured fake."""
 
-    def _install(**capture_cfg):
-        monkeypatch.setitem(sys.modules, "cv2", _fake_cv2(**capture_cfg))
+    def _install(**cfg) -> _FakeDecoder:
+        fake = _FakeDecoder(**cfg)
+        monkeypatch.setattr(decode, "probe", fake.probe)
+        monkeypatch.setattr(decode, "frame_at", fake.frame_at)
+        return fake
 
     return _install
 
@@ -137,137 +100,109 @@ def _thumb_size(png_bytes: bytes) -> tuple[int, int]:
 
 
 class TestMiddleFrameThumbnail:
-    def test_from_bytes_returns_png(self, install_fake_cv2):
-        install_fake_cv2(frame_count=100, fps=30.0)
+    def test_from_bytes_returns_png(self, install_fake_decoder):
+        install_fake_decoder()
         out = generate_video_thumbnail(b"ignored-by-fake")
         assert out is not None
         assert out[:8] == _PNG_MAGIC
 
-    def test_from_bytes_default_thumb_size(self, install_fake_cv2):
-        install_fake_cv2(dim=256)
+    def test_from_bytes_default_thumb_size(self, install_fake_decoder):
+        install_fake_decoder(dim=256)
         out = generate_video_thumbnail(b"x")
         assert out is not None
         assert _thumb_size(out) == (128, 128)
 
-    def test_from_bytes_custom_size(self, install_fake_cv2):
-        install_fake_cv2(dim=256)
+    def test_from_bytes_custom_size(self, install_fake_decoder):
+        install_fake_decoder(dim=256)
         out = generate_video_thumbnail(b"x", size=64)
         assert out is not None
         assert _thumb_size(out) == (64, 64)
 
-    def test_from_bytes_seeks_to_middle_frame(self, install_fake_cv2):
-        # frame_count=100 -> mid index 50; the fill byte encodes the frame.
-        install_fake_cv2(frame_count=100, fps=30.0, dim=8)
+    def test_from_bytes_seeks_to_middle(self, install_fake_decoder):
+        fake = install_fake_decoder(duration=10.0, fps=30.0, dim=8)
         out = generate_video_thumbnail(b"x")
         assert out is not None
+        assert fake.requested_times == [5.0]
         with Image.open(io.BytesIO(out)) as img:
-            # The fill byte encodes the seeked frame index (50); BGR->RGB moves
-            # the fake's channel-0 fill into the blue channel.
+            # The fill encodes the seeked frame index (5.0s * 30fps = 150).
             pixel = img.convert("RGB").getpixel((0, 0))
             assert isinstance(pixel, tuple)
-            assert pixel[2] == 50
+            assert pixel[0] == 150
 
-    def test_from_file_returns_png(self, install_fake_cv2, tmp_path):
-        install_fake_cv2(frame_count=40)
+    def test_from_file_returns_png(self, install_fake_decoder, tmp_path):
+        install_fake_decoder()
         out = generate_video_thumbnail_from_file(tmp_path / "clip.mp4")
         assert out is not None
         assert out[:8] == _PNG_MAGIC
 
-    def test_from_bytes_not_opened_returns_none(self, install_fake_cv2):
-        install_fake_cv2(opened=False)
+    def test_from_bytes_empty_input_returns_none(self, install_fake_decoder):
+        install_fake_decoder()
+        assert generate_video_thumbnail(b"") is None
+
+    def test_from_bytes_probe_failure_returns_none(self, install_fake_decoder):
+        install_fake_decoder(probe_ok=False)
         assert generate_video_thumbnail(b"x") is None
 
-    def test_from_bytes_zero_frames_returns_none(self, install_fake_cv2):
-        install_fake_cv2(frame_count=0)
+    def test_from_bytes_read_failure_returns_none(self, install_fake_decoder):
+        install_fake_decoder(read_ok=False)
         assert generate_video_thumbnail(b"x") is None
 
-    def test_from_bytes_read_failure_returns_none(self, install_fake_cv2):
-        install_fake_cv2(read_ok=False)
-        assert generate_video_thumbnail(b"x") is None
-
-    def test_from_file_not_opened_returns_none(self, install_fake_cv2, tmp_path):
-        install_fake_cv2(opened=False)
+    def test_from_file_probe_failure_returns_none(self, install_fake_decoder, tmp_path):
+        install_fake_decoder(probe_ok=False)
         assert generate_video_thumbnail_from_file(tmp_path / "clip.mp4") is None
 
-    def test_from_file_zero_frames_returns_none(self, install_fake_cv2, tmp_path):
-        install_fake_cv2(frame_count=0)
-        assert generate_video_thumbnail_from_file(tmp_path / "clip.mp4") is None
-
-    def test_from_file_read_failure_returns_none(self, install_fake_cv2, tmp_path):
-        install_fake_cv2(read_ok=False)
+    def test_from_file_read_failure_returns_none(self, install_fake_decoder, tmp_path):
+        install_fake_decoder(read_ok=False)
         assert generate_video_thumbnail_from_file(tmp_path / "clip.mp4") is None
 
 
 # ---------------------------------------------------------------------------
-# Error paths without a working decoder
+# Error paths with the real decoder
 # ---------------------------------------------------------------------------
 
 
 class TestThumbnailErrorPaths:
-    def test_from_bytes_cv2_unavailable_returns_none(self, monkeypatch):
-        # `import cv2` raises when the module object is None -> caught -> None.
-        monkeypatch.setitem(sys.modules, "cv2", None)
-        assert generate_video_thumbnail(b"anything") is None
-        assert generate_video_thumbnail_at(b"anything", 1.0) is None
-
-    def test_from_file_cv2_unavailable_returns_none(self, monkeypatch, tmp_path):
-        monkeypatch.setitem(sys.modules, "cv2", None)
-        assert generate_video_thumbnail_from_file(tmp_path / "x.mp4") is None
-        assert generate_video_thumbnail_from_file_at(tmp_path / "x.mp4", 1.0) is None
-
     def test_from_bytes_undecodable_input_returns_none(self):
-        # Real (or absent) cv2 cannot decode this; every path yields None.
+        # The real decoder cannot decode this; every path yields None.
         assert generate_video_thumbnail(b"not a video at all") is None
+        assert generate_video_thumbnail_at(b"not a video at all", 1.0) is None
 
     def test_from_file_missing_path_returns_none(self, tmp_path):
-        # VideoCapture on a nonexistent file never opens -> None (and the
-        # from-file guard also swallows any decode exception).
+        # Probing a nonexistent file finds no video stream -> None.
         assert generate_video_thumbnail_from_file(tmp_path / "nope.mp4") is None
+        assert generate_video_thumbnail_from_file_at(tmp_path / "nope.mp4", 1.0) is None
 
 
 # ---------------------------------------------------------------------------
-# Seek-to-time frame math (_frame_at_time)
+# Seek-time clamping (_seek_time)
 # ---------------------------------------------------------------------------
 
 
-class TestFrameAtTime:
-    def _cap_with_fake_cv2(self, install_fake_cv2, **cfg):
-        install_fake_cv2()  # only the constants matter here
-        return _FakeCapture(**cfg)
+class TestSeekTime:
+    def _info(self, duration=10.0, fps=30.0):
+        return decode.VideoInfo(duration=duration, fps=fps, width=64, height=64)
 
-    def test_seeks_by_fps(self, install_fake_cv2):
-        cap = self._cap_with_fake_cv2(install_fake_cv2, frame_count=300, fps=30.0)
-        frame = _frame_at_time(cap, 2.0)
-        assert frame is not None
-        assert cap.requested_frame == 60  # round(2.0 * 30)
+    def test_none_seeks_to_middle(self):
+        assert _seek_time(self._info(), None) == pytest.approx(5.0)
 
-    def test_rounds_to_nearest_frame(self, install_fake_cv2):
-        cap = self._cap_with_fake_cv2(install_fake_cv2, frame_count=300, fps=30.0)
-        _frame_at_time(cap, 1.017)  # 30.51 -> 31
-        assert cap.requested_frame == 31
+    def test_passes_through_in_range_time(self):
+        assert _seek_time(self._info(), 2.0) == pytest.approx(2.0)
 
-    def test_clamps_beyond_end_to_last_frame(self, install_fake_cv2):
-        cap = self._cap_with_fake_cv2(install_fake_cv2, frame_count=100, fps=30.0)
-        _frame_at_time(cap, 9999.0)
-        assert cap.requested_frame == 99  # frame_count - 1
+    def test_clamps_beyond_end_to_last_frame(self):
+        # One frame of headroom so the seek still lands on decodable video.
+        assert _seek_time(self._info(), 9999.0) == pytest.approx(10.0 - 1 / 30)
 
-    def test_clamps_negative_time_to_zero(self, install_fake_cv2):
-        cap = self._cap_with_fake_cv2(install_fake_cv2, frame_count=100, fps=30.0)
-        _frame_at_time(cap, -5.0)
-        assert cap.requested_frame == 0
+    def test_clamps_negative_time_to_zero(self):
+        assert _seek_time(self._info(), -5.0) == 0.0
 
-    def test_falls_back_to_middle_when_fps_zero(self, install_fake_cv2):
-        cap = self._cap_with_fake_cv2(install_fake_cv2, frame_count=80, fps=0.0)
-        _frame_at_time(cap, 3.0)
-        assert cap.requested_frame == 40  # frame_count // 2
+    def test_unknown_fps_uses_default_frame_headroom(self):
+        assert _seek_time(self._info(fps=0.0), 9999.0) == pytest.approx(10.0 - 0.04)
 
-    def test_zero_frame_count_returns_none(self, install_fake_cv2):
-        cap = self._cap_with_fake_cv2(install_fake_cv2, frame_count=0, fps=30.0)
-        assert _frame_at_time(cap, 1.0) is None
+    def test_unknown_duration_passes_time_through(self):
+        assert _seek_time(self._info(duration=0.0), 3.0) == pytest.approx(3.0)
 
-    def test_read_failure_returns_none(self, install_fake_cv2):
-        cap = self._cap_with_fake_cv2(install_fake_cv2, frame_count=100, fps=30.0, read_ok=False)
-        assert _frame_at_time(cap, 1.0) is None
+    def test_unknown_duration_seeks_to_start_for_middle(self):
+        assert _seek_time(self._info(duration=0.0), None) == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -276,41 +211,42 @@ class TestFrameAtTime:
 
 
 class TestThumbnailAtTime:
-    def test_from_bytes_returns_png(self, install_fake_cv2):
-        install_fake_cv2(frame_count=300, fps=30.0)
+    def test_from_bytes_returns_png(self, install_fake_decoder):
+        fake = install_fake_decoder(duration=10.0, fps=30.0)
         out = generate_video_thumbnail_at(b"x", 2.0)
         assert out is not None
         assert out[:8] == _PNG_MAGIC
+        assert fake.requested_times == [2.0]
 
-    def test_from_bytes_custom_size(self, install_fake_cv2):
-        install_fake_cv2(dim=256)
+    def test_from_bytes_custom_size(self, install_fake_decoder):
+        install_fake_decoder(dim=256)
         out = generate_video_thumbnail_at(b"x", 1.0, size=32)
         assert out is not None
         assert _thumb_size(out) == (32, 32)
 
-    def test_different_times_produce_different_thumbnails(self, install_fake_cv2):
-        install_fake_cv2(frame_count=300, fps=30.0, dim=8)
-        early = generate_video_thumbnail_at(b"x", 1.0)  # frame 30
-        late = generate_video_thumbnail_at(b"x", 5.0)  # frame 150
+    def test_different_times_produce_different_thumbnails(self, install_fake_decoder):
+        install_fake_decoder(duration=10.0, fps=30.0, dim=8)
+        early = generate_video_thumbnail_at(b"x", 1.0)
+        late = generate_video_thumbnail_at(b"x", 5.0)
         assert early is not None and late is not None
         assert early != late
 
-    def test_from_file_returns_png(self, install_fake_cv2, tmp_path):
-        install_fake_cv2(frame_count=120, fps=24.0)
+    def test_from_file_returns_png(self, install_fake_decoder, tmp_path):
+        install_fake_decoder(duration=5.0, fps=24.0)
         out = generate_video_thumbnail_from_file_at(tmp_path / "clip.mp4", 1.5)
         assert out is not None
         assert out[:8] == _PNG_MAGIC
 
-    def test_from_bytes_not_opened_returns_none(self, install_fake_cv2):
-        install_fake_cv2(opened=False)
+    def test_from_bytes_probe_failure_returns_none(self, install_fake_decoder):
+        install_fake_decoder(probe_ok=False)
         assert generate_video_thumbnail_at(b"x", 1.0) is None
 
-    def test_from_bytes_zero_frames_returns_none(self, install_fake_cv2):
-        install_fake_cv2(frame_count=0)
+    def test_from_bytes_read_failure_returns_none(self, install_fake_decoder):
+        install_fake_decoder(read_ok=False)
         assert generate_video_thumbnail_at(b"x", 1.0) is None
 
-    def test_from_file_read_failure_returns_none(self, install_fake_cv2, tmp_path):
-        install_fake_cv2(read_ok=False)
+    def test_from_file_read_failure_returns_none(self, install_fake_decoder, tmp_path):
+        install_fake_decoder(read_ok=False)
         assert generate_video_thumbnail_from_file_at(tmp_path / "clip.mp4", 1.0) is None
 
 
@@ -421,29 +357,31 @@ class TestVideoLoadMediaData:
     def setup_method(self):
         self.mt = VideoMediaType()
 
-    def test_computes_duration_and_thumbnail(self, install_fake_cv2, tmp_path):
-        install_fake_cv2(frame_count=90, fps=30.0)
+    def test_computes_duration_and_thumbnail(self, install_fake_decoder, tmp_path):
+        install_fake_decoder(duration=3.0, fps=30.0)
         path = tmp_path / "clip.mp4"
         path.write_bytes(b"raw-video-bytes")
         data = self.mt.load_media_data(path)
         assert data["media_bytes"] == b"raw-video-bytes"  # read from disk
-        assert data["duration"] == pytest.approx(3.0)  # 90 / 30
+        assert data["duration"] == pytest.approx(3.0)
         assert data["thumbnail_bytes"][:8] == _PNG_MAGIC
 
-    def test_uses_provided_bytes_without_reading_file(self, install_fake_cv2, tmp_path):
-        install_fake_cv2(frame_count=60, fps=30.0)
+    def test_uses_provided_bytes_without_reading_file(self, install_fake_decoder, tmp_path):
+        install_fake_decoder(duration=2.0, fps=30.0)
         data = self.mt.load_media_data(tmp_path / "does-not-exist.mp4", media_bytes=b"inline")
         assert data["media_bytes"] == b"inline"
         assert data["duration"] == pytest.approx(2.0)
 
-    def test_zero_fps_yields_zero_duration(self, install_fake_cv2, tmp_path):
-        install_fake_cv2(frame_count=90, fps=0.0)
-        data = self.mt.load_media_data(tmp_path / "x.mp4", media_bytes=b"b")
-        assert data["duration"] == 0.0
+    def test_probes_the_path_once(self, install_fake_decoder, tmp_path):
+        """The thumbnail reuses the thin load's probe instead of re-probing."""
+        fake = install_fake_decoder(duration=4.0, fps=25.0)
+        data = self.mt.load_thin_media_data(tmp_path / "x.mp4")
+        assert data["duration"] == pytest.approx(4.0)
+        assert data["thumbnail_bytes"][:8] == _PNG_MAGIC
+        assert len(fake.probed_paths) == 1
 
-    def test_decode_failure_yields_zero_duration(self, monkeypatch, tmp_path):
-        # cv2 unavailable -> the try/except sets duration 0.0 and thumbnail None.
-        monkeypatch.setitem(sys.modules, "cv2", None)
+    def test_decode_failure_yields_zero_duration(self, install_fake_decoder, tmp_path):
+        install_fake_decoder(probe_ok=False)
         data = self.mt.load_media_data(tmp_path / "x.mp4", media_bytes=b"b")
         assert data["duration"] == 0.0
         assert data["thumbnail_bytes"] is None
@@ -465,8 +403,8 @@ class TestVideoImageResponse:
         assert resp.mimetype == "image/png"
         assert resp.download_name == "media_7_thumb.png"
 
-    def test_generates_and_memoises_from_media_bytes(self, install_fake_cv2):
-        install_fake_cv2(frame_count=50, fps=30.0)
+    def test_generates_and_memoises_from_media_bytes(self, install_fake_decoder):
+        install_fake_decoder()
         media = {"id": 3, "media_bytes": b"raw"}
         resp = self.mt.image_response(media)
         assert resp is not None
@@ -477,8 +415,8 @@ class TestVideoImageResponse:
     def test_returns_none_when_no_bytes_resolvable(self):
         assert self.mt.image_response({"id": 9}) is None
 
-    def test_returns_none_when_generation_fails(self, install_fake_cv2):
-        install_fake_cv2(read_ok=False)
+    def test_returns_none_when_generation_fails(self, install_fake_decoder):
+        install_fake_decoder(read_ok=False)
         media = {"id": 4, "media_bytes": b"undecodable"}
         assert self.mt.image_response(media) is None
         assert "thumbnail_bytes" not in media

--- a/tests_lib/core/test_video.py
+++ b/tests_lib/core/test_video.py
@@ -373,9 +373,9 @@ class TestVideoLoadMediaData:
         assert data["duration"] == pytest.approx(2.0)
 
     def test_probes_the_path_once(self, install_fake_decoder, tmp_path):
-        """The thumbnail reuses the thin load's probe instead of re-probing."""
+        """The thumbnail reuses the duration's probe instead of re-probing."""
         fake = install_fake_decoder(duration=4.0, fps=25.0)
-        data = self.mt.load_thin_media_data(tmp_path / "x.mp4")
+        data = self.mt.load_media_data(tmp_path / "x.mp4", media_bytes=b"inline")
         assert data["duration"] == pytest.approx(4.0)
         assert data["thumbnail_bytes"][:8] == _PNG_MAGIC
         assert len(fake.probed_paths) == 1

--- a/tests_lib/core/test_video_decode.py
+++ b/tests_lib/core/test_video_decode.py
@@ -1,0 +1,252 @@
+"""Library-tier tests for :mod:`vtscore.media.video.decode`.
+
+The decode layer exists to keep OpenCV - and the OpenSSL its wheel vendors,
+which aborts the interpreter on FIPS-enabled hosts - out of the process, so
+these tests pin down both halves of it:
+
+* the **banner parser**, exercised against canned ``ffmpeg -i`` output so the
+  metadata edge cases (no video stream, unknown duration, odd resolutions)
+  are covered without spawning anything;
+* the **real decode round-trip**, against short mp4s encoded on the fly by the
+  same bundled ffmpeg, so probing and frame extraction are checked end to end.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.media.video import decode
+from vtscore.utils.synthetic.video import _encode_frames
+
+# A representative ``ffmpeg -i`` banner for a plain H.264 mp4.
+_BANNER = """
+Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'clip.mp4':
+  Metadata:
+    major_brand     : isom
+  Duration: 00:01:03.48, start: 0.000000, bitrate: 1234 kb/s
+  Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(tv, bt709), \
+1920x1080 [SAR 1:1 DAR 16:9], 1200 kb/s, 29.97 fps, 29.97 tbr, 30k tbn (default)
+  Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 128 kb/s
+At least one output file must be specified
+"""
+
+
+# ---------------------------------------------------------------------------
+# Banner parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseProbe:
+    def test_parses_duration_fps_and_size(self):
+        info = decode._parse_probe(_BANNER)
+        assert info is not None
+        assert info.duration == pytest.approx(63.48)
+        assert info.fps == pytest.approx(29.97)
+        assert (info.width, info.height) == (1920, 1080)
+
+    def test_fourcc_tag_is_not_mistaken_for_a_resolution(self):
+        info = decode._parse_probe(_BANNER)
+        assert info is not None
+        assert info.width == 1920  # not parsed out of "0x31637661"
+
+    def test_no_video_stream_returns_none(self):
+        audio_only = "\n".join(line for line in _BANNER.splitlines() if "Video:" not in line)
+        assert decode._parse_probe(audio_only) is None
+
+    def test_missing_file_output_returns_none(self):
+        assert decode._parse_probe("clip.mp4: No such file or directory\n") is None
+
+    def test_unknown_duration_is_zero(self):
+        banner = _BANNER.replace("Duration: 00:01:03.48", "Duration: N/A")
+        info = decode._parse_probe(banner)
+        assert info is not None
+        assert info.duration == 0.0
+        assert info.fps == pytest.approx(29.97)
+
+    def test_hours_are_carried(self):
+        banner = _BANNER.replace("00:01:03.48", "02:03:04.50")
+        info = decode._parse_probe(banner)
+        assert info is not None
+        assert info.duration == pytest.approx(2 * 3600 + 3 * 60 + 4.5)
+
+
+class TestVideoInfo:
+    def test_frame_count_from_duration_and_fps(self):
+        assert decode.VideoInfo(duration=10.0, fps=30.0).frame_count == 300
+
+    def test_frame_count_zero_when_unknown(self):
+        assert decode.VideoInfo(duration=0.0, fps=30.0).frame_count == 0
+        assert decode.VideoInfo(duration=10.0, fps=0.0).frame_count == 0
+
+    def test_frame_count_never_rounds_a_real_video_to_zero(self):
+        assert decode.VideoInfo(duration=0.01, fps=1.0).frame_count == 1
+
+    def test_frame_seconds_from_fps(self):
+        assert decode.VideoInfo(duration=1.0, fps=25.0).frame_seconds == pytest.approx(0.04)
+
+    def test_frame_seconds_falls_back_when_fps_unknown(self):
+        assert decode.VideoInfo(duration=1.0, fps=0.0).frame_seconds == pytest.approx(0.04)
+
+
+class TestScaledSize:
+    def test_leaves_narrow_frames_alone(self):
+        assert decode._scaled_size(320, 240, 640) == (320, 240)
+
+    def test_no_max_width_is_a_passthrough(self):
+        assert decode._scaled_size(1920, 1080, None) == (1920, 1080)
+
+    def test_clamps_and_preserves_aspect(self):
+        assert decode._scaled_size(1920, 1080, 320) == (320, 180)
+
+    def test_never_scales_height_to_zero(self):
+        assert decode._scaled_size(1000, 2, 10) == (10, 1)
+
+
+# ---------------------------------------------------------------------------
+# Real decode round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def clip(tmp_path_factory) -> tuple[object, list[np.ndarray]]:
+    """A 3 s, 10 fps, 64x48 mp4 whose frames step through distinct fills."""
+    frames = [np.full((48, 64, 3), (i * 8) % 256, dtype=np.uint8) for i in range(30)]
+    path = tmp_path_factory.mktemp("decode") / "clip.mp4"
+    _encode_frames(path, frames, fps=10)
+    return path, frames
+
+
+class TestProbeRealFile:
+    def test_reports_duration_fps_and_size(self, clip):
+        path, _ = clip
+        info = decode.probe(path)
+        assert info is not None
+        assert info.duration == pytest.approx(3.0, abs=0.2)
+        assert info.fps == pytest.approx(10.0)
+        assert (info.width, info.height) == (64, 48)
+        assert info.frame_count == pytest.approx(30, abs=2)
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert decode.probe(tmp_path / "nope.mp4") is None
+
+    def test_non_video_file_returns_none(self, tmp_path):
+        junk = tmp_path / "junk.mp4"
+        junk.write_bytes(b"not a video at all")
+        assert decode.probe(junk) is None
+
+
+class TestFrameAtRealFile:
+    def test_returns_rgb_frame(self, clip):
+        path, _ = clip
+        frame = decode.frame_at(path, 0.0)
+        assert frame is not None
+        assert frame.shape == (48, 64, 3)
+        assert frame.dtype == np.uint8
+        assert frame.flags.writeable
+
+    def test_seeks_to_the_requested_time(self, clip):
+        path, frames = clip
+        # Frame fills step by 8 per frame, so 0.0s and 2.0s differ markedly.
+        early = decode.frame_at(path, 0.0)
+        late = decode.frame_at(path, 2.0)
+        assert early is not None and late is not None
+        assert float(early.mean()) == pytest.approx(float(frames[0].mean()), abs=12)
+        assert float(late.mean()) == pytest.approx(float(frames[20].mean()), abs=12)
+
+    def test_negative_time_clamps_to_the_start(self, clip):
+        path, _ = clip
+        frame = decode.frame_at(path, -5.0)
+        first = decode.frame_at(path, 0.0)
+        assert frame is not None and first is not None
+        assert np.array_equal(frame, first)
+
+    def test_past_the_end_returns_none(self, clip):
+        path, _ = clip
+        assert decode.frame_at(path, 60.0) is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert decode.frame_at(tmp_path / "nope.mp4", 1.0) is None
+
+
+class TestFramesAtRealFile:
+    def test_returns_one_frame_per_timestamp(self, clip):
+        path, _ = clip
+        frames = decode.frames_at(path, [0.0, 1.0, 2.0])
+        assert len(frames) == 3
+        assert all(f.shape == (48, 64, 3) for f in frames)
+
+    def test_drops_undecodable_timestamps(self, clip):
+        path, _ = clip
+        frames = decode.frames_at(path, [0.0, 60.0, 1.0])
+        assert len(frames) == 2  # the out-of-range seek is dropped
+
+    def test_empty_request_returns_empty(self, clip):
+        path, _ = clip
+        assert decode.frames_at(path, []) == []
+
+
+class TestIterFramesRealFile:
+    def test_walks_the_video_at_the_requested_cadence(self, clip):
+        path, _ = clip
+        got = list(decode.iter_frames(path, interval=1.0))
+        assert len(got) == 3  # a 3 s clip at one frame per second
+        times = [t for t, _ in got]
+        assert times == pytest.approx([0.0, 1.0, 2.0])
+        assert all(frame.shape == (48, 64, 3) for _, frame in got)
+
+    def test_downscales_to_max_width(self, clip):
+        path, _ = clip
+        got = list(decode.iter_frames(path, interval=1.0, max_width=32))
+        assert got
+        assert all(frame.shape == (24, 32, 3) for _, frame in got)
+
+    def test_early_exit_does_not_leak_the_process(self, clip):
+        path, _ = clip
+        frames = decode.iter_frames(path, interval=0.1)
+        next(frames)
+        frames.close()  # kills ffmpeg mid-stream; must not raise
+
+    def test_missing_file_yields_nothing(self, tmp_path):
+        assert list(decode.iter_frames(tmp_path / "nope.mp4", interval=1.0)) == []
+
+    def test_rejects_non_positive_interval(self, clip):
+        path, _ = clip
+        with pytest.raises(ValueError, match="interval must be positive"):
+            list(decode.iter_frames(path, interval=0.0))
+
+
+class TestBackendSelection:
+    def test_reports_ffmpeg_when_available(self):
+        assert decode.backend() == "ffmpeg"
+
+    def test_falls_back_to_opencv_without_ffmpeg(self, monkeypatch):
+        monkeypatch.setattr(decode, "get_ffmpeg_exe", _missing_ffmpeg)
+        assert decode.backend() == "opencv"
+
+    def test_probe_routes_to_opencv_without_ffmpeg(self, monkeypatch):
+        monkeypatch.setattr(decode, "get_ffmpeg_exe", _missing_ffmpeg)
+        calls: list[str] = []
+        monkeypatch.setattr(decode, "_cv2_probe", lambda path: calls.append(str(path)))
+        decode.probe("clip.mp4")
+        assert calls == ["clip.mp4"]
+
+    def test_frame_at_routes_to_opencv_without_ffmpeg(self, monkeypatch):
+        monkeypatch.setattr(decode, "get_ffmpeg_exe", _missing_ffmpeg)
+        calls: list[tuple[str, float]] = []
+        monkeypatch.setattr(decode, "_cv2_frame_at", lambda path, t: calls.append((str(path), t)))
+        decode.frame_at("clip.mp4", 2.0)
+        assert calls == [("clip.mp4", 2.0)]
+
+    def test_iter_frames_routes_to_opencv_without_ffmpeg(self, monkeypatch):
+        monkeypatch.setattr(decode, "get_ffmpeg_exe", _missing_ffmpeg)
+        monkeypatch.setattr(
+            decode,
+            "_cv2_iter_frames",
+            lambda path, *, interval, max_width=None: iter([(0.0, np.zeros((1, 1, 3), dtype=np.uint8))]),
+        )
+        assert len(list(decode.iter_frames("clip.mp4", interval=1.0))) == 1
+
+
+def _missing_ffmpeg() -> str:
+    raise FileNotFoundError("ffmpeg not found")

--- a/tests_lib/detectors/test_video_clip_embedding.py
+++ b/tests_lib/detectors/test_video_clip_embedding.py
@@ -6,8 +6,8 @@ embedding because:
   1. ``_build_clip_embed_input`` dropped ``clip_start`` / ``clip_end``;
   2. ``_fixup_clip_md5_and_embeddings`` skipped re-embedding for video
      (since video clippers don't slice bytes);
-  3. The video embedders sampled ``np.linspace(0, frame_count - 1, n)``
-     unconditionally; ignoring the clip range.
+  3. The video embedders sampled the whole video unconditionally;
+     ignoring the clip range.
 
 These tests cover all three layers.
 """
@@ -21,136 +21,114 @@ import numpy as np
 import pytest
 
 from vtscore.embedding.media_vectors import media_embedding
+from vtscore.media.video import decode
 from vtscore.utils.hashing import content_md5
 
 
 # ---------------------------------------------------------------------------
-# _frame_index_range: boundary math
+# _frame_time_range: boundary math
 # ---------------------------------------------------------------------------
 
 
-class TestFrameIndexRange:
+def _info(duration: float, fps: float) -> decode.VideoInfo:
+    return decode.VideoInfo(duration=duration, fps=fps, width=1, height=1)
+
+
+class TestFrameTimeRange:
     def test_full_range_when_no_boundaries(self):
-        from vtscore.media.video._frame_sampling import _frame_index_range
+        from vtscore.media.video._frame_sampling import _frame_time_range
 
         media: dict[str, Any] = {}
-        start, end = _frame_index_range(media, frame_count=100, fps=10.0)
-        assert (start, end) == (0, 99)
+        start, end = _frame_time_range(media, _info(10.0, 10.0))
+        # Stops one frame short of the duration, where nothing decodes.
+        assert start == pytest.approx(0.0)
+        assert end == pytest.approx(9.9)
 
-    def test_clip_boundaries_map_to_indices(self):
-        from vtscore.media.video._frame_sampling import _frame_index_range
+    def test_clip_boundaries_map_to_times(self):
+        from vtscore.media.video._frame_sampling import _frame_time_range
 
         media = {"clip_start": 2.0, "clip_end": 5.0}
-        start, end = _frame_index_range(media, frame_count=100, fps=10.0)
-        # 2.0s @ 10fps = frame 20; 5.0s @ 10fps -> last frame = 50 - 1 = 49.
-        assert start == 20
-        assert end == 49
+        start, end = _frame_time_range(media, _info(10.0, 10.0))
+        assert start == pytest.approx(2.0)
+        assert end == pytest.approx(4.9)  # 5.0 minus one 10fps frame
 
     def test_clip_boundaries_clamped_to_video(self):
-        from vtscore.media.video._frame_sampling import _frame_index_range
+        from vtscore.media.video._frame_sampling import _frame_time_range
 
         media = {"clip_start": 99.0, "clip_end": 200.0}
-        start, end = _frame_index_range(media, frame_count=100, fps=10.0)
-        # clip_start far past end: clamp to last frame; end must not precede start.
-        assert start == 99
-        assert end == 99
+        start, end = _frame_time_range(media, _info(10.0, 10.0))
+        # clip_start far past the end: clamp to the last frame; end must not
+        # precede start.
+        assert start == pytest.approx(9.9)
+        assert end == pytest.approx(9.9)
 
-    def test_falls_back_to_full_when_fps_zero(self):
-        from vtscore.media.video._frame_sampling import _frame_index_range
+    def test_boundaries_honoured_when_fps_unknown(self):
+        from vtscore.media.video._frame_sampling import _frame_time_range
 
+        # Seconds don't need a frame rate to be meaningful, so an unknown fps
+        # no longer forces the full range.
         media = {"clip_start": 1.0, "clip_end": 2.0}
-        start, end = _frame_index_range(media, frame_count=50, fps=0.0)
-        assert (start, end) == (0, 49)
+        start, end = _frame_time_range(media, _info(5.0, 0.0))
+        assert start == pytest.approx(1.0)
+        assert end == pytest.approx(1.96)
 
     def test_falls_back_to_full_when_end_le_start(self):
-        from vtscore.media.video._frame_sampling import _frame_index_range
+        from vtscore.media.video._frame_sampling import _frame_time_range
 
         media = {"clip_start": 3.0, "clip_end": 3.0}
-        start, end = _frame_index_range(media, frame_count=50, fps=10.0)
-        assert (start, end) == (0, 49)
+        start, end = _frame_time_range(media, _info(5.0, 10.0))
+        assert start == pytest.approx(0.0)
+        assert end == pytest.approx(4.9)
 
     def test_distinct_tiles_get_distinct_ranges(self):
-        from vtscore.media.video._frame_sampling import _frame_index_range
+        from vtscore.media.video._frame_sampling import _frame_time_range
 
-        # Parent: 10s @ 25fps -> 250 frames.  Tile into 2s segments.
-        tile_a = {"clip_start": 0.0, "clip_end": 2.0}
-        tile_b = {"clip_start": 2.0, "clip_end": 4.0}
-        tile_c = {"clip_start": 8.0, "clip_end": 10.0}
+        # Parent: 10s @ 25fps.  Tile into 2s segments.
+        info = _info(10.0, 25.0)
+        a = _frame_time_range({"clip_start": 0.0, "clip_end": 2.0}, info)
+        b = _frame_time_range({"clip_start": 2.0, "clip_end": 4.0}, info)
+        c = _frame_time_range({"clip_start": 8.0, "clip_end": 10.0}, info)
 
-        a = _frame_index_range(tile_a, frame_count=250, fps=25.0)
-        b = _frame_index_range(tile_b, frame_count=250, fps=25.0)
-        c = _frame_index_range(tile_c, frame_count=250, fps=25.0)
-
-        assert a == (0, 49)
-        assert b == (50, 99)
-        assert c == (200, 249)
+        assert a == pytest.approx((0.0, 1.96))
+        assert b == pytest.approx((2.0, 3.96))
+        assert c == pytest.approx((8.0, 9.96))
 
 
 # ---------------------------------------------------------------------------
-# sample_video_frames: uses clip_start/clip_end to pick frame indices
+# sample_video_frames: uses clip_start/clip_end to pick timestamps
 # ---------------------------------------------------------------------------
 
 
-class _FakeCapture:
-    """Stand-in for ``cv2.VideoCapture`` that records seeks.
+class _FakeDecoder:
+    """Decode-layer stand-in that records every timestamp it was asked for.
 
-    Returns deterministic 1x1 BGR frames so the helper produces a list of
-    PIL Images we can introspect.  ``positions_seen`` exposes every frame
-    index the caller seeked to via ``CAP_PROP_POS_FRAMES``.
+    Returns deterministic 1x1 RGB frames so the helper produces a list of PIL
+    Images we can introspect.
     """
 
     def __init__(self, *, frame_count: int, fps: float):
-        self._frame_count = frame_count
         self._fps = fps
-        self.positions_seen: list[int] = []
-        self._next_pos = 0
+        self._duration = frame_count / fps if fps > 0 else 0.0
+        self.times_seen: list[float] = []
 
-    def isOpened(self) -> bool:  # noqa: N802 (cv2 API)
-        return True
+    def probe(self, _path):
+        return decode.VideoInfo(duration=self._duration, fps=self._fps, width=1, height=1)
 
-    def get(self, prop: int) -> float:
-        import cv2  # noqa: PLC0415
-
-        if prop == cv2.CAP_PROP_FRAME_COUNT:
-            return float(self._frame_count)
-        if prop == cv2.CAP_PROP_FPS:
-            return self._fps
-        return 0.0
-
-    def set(self, prop: int, value: float) -> bool:
-        import cv2  # noqa: PLC0415
-
-        if prop == cv2.CAP_PROP_POS_FRAMES:
-            self._next_pos = int(value)
-            self.positions_seen.append(self._next_pos)
-        return True
-
-    def read(self):
-        # Encode the position into the frame so different seeks produce
-        # different PIL Images; useful as a sanity check.
-        b = max(0, min(255, self._next_pos))
-        frame = np.full((1, 1, 3), b, dtype=np.uint8)
-        return True, frame
-
-    def release(self) -> None:
-        pass
+    def frame_at(self, _path, time_seconds: float):
+        self.times_seen.append(float(time_seconds))
+        value = max(0, min(255, int(round(time_seconds * self._fps))))
+        return np.full((1, 1, 3), value, dtype=np.uint8)
 
 
 @pytest.fixture
 def fake_video(monkeypatch):
-    """Patch cv2.VideoCapture with a captured _FakeCapture instance."""
-    import cv2
+    """Return an installer that swaps the decode layer for a recording fake."""
 
-    captures: list[_FakeCapture] = []
-
-    def _factory(*, frame_count: int, fps: float):
-        def _ctor(_path):
-            cap = _FakeCapture(frame_count=frame_count, fps=fps)
-            captures.append(cap)
-            return cap
-
-        monkeypatch.setattr(cv2, "VideoCapture", _ctor)
-        return captures
+    def _factory(*, frame_count: int, fps: float) -> _FakeDecoder:
+        fake = _FakeDecoder(frame_count=frame_count, fps=fps)
+        monkeypatch.setattr(decode, "probe", fake.probe)
+        monkeypatch.setattr(decode, "frame_at", fake.frame_at)
+        return fake
 
     return _factory
 
@@ -159,22 +137,20 @@ class TestSampleVideoFrames:
     def test_full_range_sampled_without_boundaries(self, fake_video, tmp_path):
         from vtscore.media.video._frame_sampling import sample_video_frames
 
-        captures = fake_video(frame_count=100, fps=10.0)
+        fake = fake_video(frame_count=100, fps=10.0)
         video = tmp_path / "v.mp4"
         video.write_bytes(b"fake")
         frames = sample_video_frames({"media_path": str(video)}, num_frames=8)
 
         assert len(frames) == 8
-        assert len(captures) == 1
-        # 8 frames linspace'd over [0, 99].
-        seen = captures[0].positions_seen
-        assert seen[0] == 0
-        assert seen[-1] == 99
+        # 8 timestamps linspace'd over the whole 10s video.
+        assert fake.times_seen[0] == pytest.approx(0.0)
+        assert fake.times_seen[-1] == pytest.approx(9.9)
 
     def test_clip_boundaries_restrict_sampled_frames(self, fake_video, tmp_path):
         from vtscore.media.video._frame_sampling import sample_video_frames
 
-        captures = fake_video(frame_count=250, fps=25.0)
+        fake = fake_video(frame_count=250, fps=25.0)
         video = tmp_path / "v.mp4"
         video.write_bytes(b"fake")
 
@@ -183,20 +159,19 @@ class TestSampleVideoFrames:
             num_frames=8,
         )
         assert len(frames) == 8
-        seen = captures[0].positions_seen
-        # Range [50, 99] from clip_start=2.0s and clip_end=4.0s @ 25fps.
-        assert min(seen) >= 50
-        assert max(seen) <= 99
-        assert seen[0] == 50
-        assert seen[-1] == 99
+        seen = fake.times_seen
+        assert min(seen) >= 2.0
+        assert max(seen) <= 4.0
+        assert seen[0] == pytest.approx(2.0)
+        assert seen[-1] == pytest.approx(3.96)
 
-    def test_distinct_tiles_produce_distinct_frame_indices(self, fake_video, tmp_path):
+    def test_distinct_tiles_produce_distinct_timestamps(self, fake_video, tmp_path):
         from vtscore.media.video._frame_sampling import sample_video_frames
 
         # Tile A and Tile B share the same media_path/bytes but cover
-        # disjoint time ranges; the frame indices the embedder samples
-        # must therefore be disjoint.
-        captures = fake_video(frame_count=250, fps=25.0)
+        # disjoint time ranges; the timestamps the embedder samples must
+        # therefore be disjoint.
+        fake = fake_video(frame_count=250, fps=25.0)
         video = tmp_path / "v.mp4"
         video.write_bytes(b"fake")
 
@@ -204,21 +179,21 @@ class TestSampleVideoFrames:
             {"media_path": str(video), "clip_start": 0.0, "clip_end": 2.0},
             num_frames=8,
         )
+        a_times = set(fake.times_seen)
+        fake.times_seen.clear()
         sample_video_frames(
             {"media_path": str(video), "clip_start": 8.0, "clip_end": 10.0},
             num_frames=8,
         )
-        a_positions = set(captures[0].positions_seen)
-        b_positions = set(captures[1].positions_seen)
-        assert a_positions.isdisjoint(b_positions)
+        assert a_times.isdisjoint(set(fake.times_seen))
 
     def test_falls_back_to_tempfile_when_no_path(self, fake_video):
         from vtscore.media.video._frame_sampling import sample_video_frames
 
-        captures = fake_video(frame_count=100, fps=10.0)
+        fake = fake_video(frame_count=100, fps=10.0)
         frames = sample_video_frames({"media_bytes": b"\x00\x01\x02"}, num_frames=8)
         assert len(frames) == 8
-        assert len(captures) == 1
+        assert len(fake.times_seen) == 8
 
     def test_returns_empty_without_path_or_bytes(self):
         from vtscore.media.video._frame_sampling import sample_video_frames

--- a/tests_lib/detectors/test_video_frame_sampler.py
+++ b/tests_lib/detectors/test_video_frame_sampler.py
@@ -13,11 +13,10 @@ fix did not address:
   test locks in the contract so a future contributor can't accidentally
   "fix" M20 by rejecting short videos.
 
-* The **partial-read warning**: when ``cap.read()`` returns ``ret=False``
-  for some of the requested indices (corrupted middle frames, VFR videos
-  where ``CAP_PROP_POS_FRAMES`` seek doesn't actually move, codec
-  quirks), the helper silently dropped them and the pad step biased the
-  embedding toward the last readable frame. The fix logs a warning so
+* The **partial-read warning**: when some of the requested timestamps fail
+  to decode (corrupted middle frames, VFR videos whose seeks land oddly,
+  codec quirks), the helper silently dropped them and the pad step biased
+  the embedding toward the last readable frame. The fix logs a warning so
   the failure is visible. We must also verify the M20 single-frame case
   does NOT trigger this warning (it's the legitimate-short-video path,
   not a partial-read failure).
@@ -26,83 +25,52 @@ fix did not address:
 from __future__ import annotations
 
 import logging
-import tempfile
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import pytest
 
+from vtscore.media.video import decode
 
-class _FakeCapture:
-    """``cv2.VideoCapture`` stand-in with configurable per-read success.
 
-    ``read_results`` is consumed one entry per ``read()`` call. ``True`` →
-    return a (True, frame) pair; ``False`` → return (False, None). Lets us
-    simulate codec quirks where some seeks succeed and others don't.
+class _FakeDecoder:
+    """Decode-layer stand-in with configurable per-timestamp success.
+
+    ``read_results`` is consumed one entry per ``frame_at()`` call: ``True``
+    yields a frame, ``False`` yields ``None``. Lets us simulate codec quirks
+    where some seeks succeed and others don't.
     """
 
-    def __init__(self, *, frame_count: int, fps: float, read_results: list[bool]) -> None:
-        self._frame_count = frame_count
+    def __init__(self, *, frame_count: int, fps: float, read_results: list[bool] | None) -> None:
         self._fps = fps
-        self._read_results = iter(read_results)
-        self._next_pos = 0
+        self._duration = frame_count / fps if fps > 0 else 0.0
+        self._read_results = iter(read_results if read_results is not None else [True] * frame_count)
 
-    def isOpened(self) -> bool:  # noqa: N802 (cv2 API)
-        return True
+    def probe(self, _path):
+        return decode.VideoInfo(duration=self._duration, fps=self._fps, width=1, height=1)
 
-    def get(self, prop: int) -> float:
-        import cv2  # noqa: PLC0415
-
-        if prop == cv2.CAP_PROP_FRAME_COUNT:
-            return float(self._frame_count)
-        if prop == cv2.CAP_PROP_FPS:
-            return self._fps
-        return 0.0
-
-    def set(self, prop: int, value: float) -> bool:
-        import cv2  # noqa: PLC0415
-
-        if prop == cv2.CAP_PROP_POS_FRAMES:
-            self._next_pos = int(value)
-        return True
-
-    def read(self) -> tuple[bool, Any]:
+    def frame_at(self, _path, time_seconds: float):
         try:
             ok = next(self._read_results)
         except StopIteration:
             ok = False
         if not ok:
-            return False, None
-        # Encode position into the pixel value so different seeks yield
-        # distinguishable frames; useful for the all-identical assertions.
-        b = max(0, min(255, self._next_pos))
-        frame = np.full((1, 1, 3), b, dtype=np.uint8)
-        return True, frame
-
-    def release(self) -> None:
-        pass
+            return None
+        # Encode the seek position into the pixel value so different seeks
+        # yield distinguishable frames; useful for all-identical assertions.
+        value = max(0, min(255, int(round(time_seconds * self._fps))))
+        return np.full((1, 1, 3), value, dtype=np.uint8)
 
 
 @pytest.fixture
 def fake_video(monkeypatch):
-    """Build and install a ``_FakeCapture`` factory; return the captures list."""
+    """Return an installer that swaps the decode layer for a configured fake."""
 
-    def _factory(*, frame_count: int, fps: float, read_results: list[bool] | None = None):
-        import cv2
-
-        captures: list[_FakeCapture] = []
-
-        def _ctor(_path):
-            # Default: every read succeeds; fast path for tests that don't
-            # care about partial-read behaviour.
-            results = read_results if read_results is not None else [True] * frame_count
-            cap = _FakeCapture(frame_count=frame_count, fps=fps, read_results=list(results))
-            captures.append(cap)
-            return cap
-
-        monkeypatch.setattr(cv2, "VideoCapture", _ctor)
-        return captures
+    def _factory(*, frame_count: int, fps: float, read_results: list[bool] | None = None) -> _FakeDecoder:
+        fake = _FakeDecoder(frame_count=frame_count, fps=fps, read_results=read_results)
+        monkeypatch.setattr(decode, "probe", fake.probe)
+        monkeypatch.setattr(decode, "frame_at", fake.frame_at)
+        return fake
 
     return _factory
 
@@ -152,12 +120,12 @@ class TestSingleFrameVideoContract:
 
 
 class TestPartialReadWarning:
-    """``cap.read()`` returning False for some indices must log a warning."""
+    """A timestamp that fails to decode must log a warning."""
 
     def test_partial_read_logs_warning(self, fake_video, tmp_path, caplog):
         from vtscore.media.video._frame_sampling import sample_video_frames
 
-        # 8 indices requested, only the first 5 succeed → 3 silent drops.
+        # 8 timestamps requested, only the first 5 succeed → 3 silent drops.
         fake_video(frame_count=100, fps=10.0, read_results=[True] * 5 + [False] * 3)
 
         with caplog.at_level(logging.WARNING, logger="vtscore.media.video._frame_sampling"):
@@ -165,7 +133,7 @@ class TestPartialReadWarning:
 
         assert len(frames) == 8  # still padded out
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert warnings, "expected a warning when some cap.read() calls fail"
+        assert warnings, "expected a warning when some frame reads fail"
         assert "Partial frame-read failure" in warnings[0].getMessage()
 
     def test_complete_read_does_not_warn(self, fake_video, tmp_path, caplog):
@@ -188,7 +156,7 @@ class TestPartialReadWarning:
         assert frames == []
 
     def test_partial_read_with_short_video_warns(self, fake_video, tmp_path, caplog):
-        """A 4-frame video where only 2 reads succeed: 4 indices requested,
+        """A 4-frame video where only 2 reads succeed: 4 timestamps requested,
         2 returned → still a partial-read failure (distinct from the
         legitimately-short single-frame case)."""
         from vtscore.media.video._frame_sampling import sample_video_frames
@@ -203,25 +171,34 @@ class TestPartialReadWarning:
         assert warnings, "partial read on a short video should still warn"
 
 
+class TestUndecodableSource:
+    """Guards on the real decode layer, no fake installed."""
+
+    def test_missing_path_returns_empty(self, tmp_path):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        frames = sample_video_frames({"media_path": str(tmp_path / "nope.mp4")}, num_frames=8)
+        assert frames == []
+
+    def test_undecodable_bytes_return_empty(self):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        frames = sample_video_frames({"media_bytes": b"not a video at all"}, num_frames=8)
+        assert frames == []
+
+
 class TestRealSingleFrameVideo:
-    """End-to-end check with a real (cv2-encoded) 1-frame MP4."""
+    """End-to-end check with a real (ffmpeg-encoded) 1-frame MP4."""
 
     def _make_video(self, frames: int, tmp_path: Path) -> Path:
-        try:
-            import cv2
-        except ImportError:
-            pytest.skip("OpenCV not installed")
+        from vtscore.utils.synthetic.video import _encode_frames
+
         path = tmp_path / f"v_{frames}f.mp4"
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
-            tmp = Path(f.name)
-        fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # pyright: ignore[reportAttributeAccessIssue]
-        writer = cv2.VideoWriter(str(tmp), fourcc, 10.0, (64, 64))
-        for i in range(frames):
-            frame = np.full((64, 64, 3), fill_value=(i * 23) % 256, dtype=np.uint8)
-            writer.write(frame)
-        writer.release()
-        path.write_bytes(tmp.read_bytes())
-        tmp.unlink(missing_ok=True)
+        _encode_frames(
+            path,
+            [np.full((64, 64, 3), fill_value=(i * 23) % 256, dtype=np.uint8) for i in range(frames)],
+            fps=10,
+        )
         return path
 
     def test_real_one_frame_video_pads_without_warning(self, tmp_path, caplog):
@@ -233,3 +210,13 @@ class TestRealSingleFrameVideo:
         assert len(frames) == 8
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert not warnings
+
+    def test_real_multi_frame_video_samples_across_the_clip(self, tmp_path):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        video_path = self._make_video(30, tmp_path)
+        frames = sample_video_frames({"media_path": str(video_path)}, num_frames=4)
+        assert len(frames) == 4
+        # Distinct fills per source frame, so distinct samples across the clip.
+        means = [float(np.asarray(f).mean()) for f in frames]
+        assert len(set(round(m) for m in means)) > 1

--- a/tests_lib/detectors/test_video_scene_detection.py
+++ b/tests_lib/detectors/test_video_scene_detection.py
@@ -1,0 +1,119 @@
+"""Library-tier tests for the video scene detector's histogram machinery.
+
+``_detect_scene_boundaries`` used to lean on OpenCV for both decoding and
+the colour-histogram comparison.  Decoding now goes through ffmpeg (see
+:mod:`vtscore.media.video.decode`) and the histogram work is numpy/PIL, so
+these tests pin down the replacements: the histogram's shape and
+normalisation, the correlation's agreement with ``HISTCMP_CORREL``
+semantics, and an end-to-end detection over a real clip with hard cuts.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.media.video.clipper import (
+    _detect_scene_boundaries,
+    _histogram_correlation,
+    _hue_saturation_histogram,
+)
+from vtscore.utils.synthetic.video import _encode_frames
+
+
+def _solid(color: tuple[int, int, int], size: int = 32) -> np.ndarray:
+    frame = np.zeros((size, size, 3), dtype=np.uint8)
+    frame[:] = color
+    return frame
+
+
+def _textured(color: tuple[int, int, int], seed: int, size: int = 32) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    frame = _solid(color, size)
+    noise = rng.integers(0, 40, size=(size, size, 3), dtype=np.uint8)
+    return np.clip(frame.astype(np.int16) + noise, 0, 255).astype(np.uint8)
+
+
+class TestHueSaturationHistogram:
+    def test_shape_matches_the_declared_bins(self):
+        hist = _hue_saturation_histogram(_textured((200, 30, 30), seed=1))
+        assert hist.shape == (50, 60)
+
+    def test_is_l2_normalised(self):
+        hist = _hue_saturation_histogram(_textured((30, 200, 30), seed=2))
+        assert float(np.linalg.norm(hist)) == pytest.approx(1.0)
+
+    def test_black_frame_normalises_without_dividing_by_zero(self):
+        # A pure black frame has zero saturation everywhere: one populated bin,
+        # so the norm is finite and the result stays L2-normalised.
+        hist = _hue_saturation_histogram(_solid((0, 0, 0)))
+        assert np.isfinite(hist).all()
+        assert float(np.linalg.norm(hist)) == pytest.approx(1.0)
+
+    def test_different_hues_populate_different_bins(self):
+        red = _hue_saturation_histogram(_textured((220, 20, 20), seed=3))
+        blue = _hue_saturation_histogram(_textured((20, 20, 220), seed=3))
+        assert not np.array_equal(red, blue)
+
+
+class TestHistogramCorrelation:
+    def test_identical_histograms_correlate_perfectly(self):
+        hist = _hue_saturation_histogram(_textured((200, 30, 30), seed=4))
+        assert _histogram_correlation(hist, hist) == pytest.approx(1.0)
+
+    def test_similar_frames_correlate_highly(self):
+        a = _hue_saturation_histogram(_textured((200, 30, 30), seed=5))
+        b = _hue_saturation_histogram(_textured((200, 30, 30), seed=6))
+        assert _histogram_correlation(a, b) > 0.5
+
+    def test_different_scenes_correlate_weakly(self):
+        a = _hue_saturation_histogram(_textured((220, 20, 20), seed=7))
+        b = _hue_saturation_histogram(_textured((20, 20, 220), seed=8))
+        assert _histogram_correlation(a, b) < 0.3
+
+    def test_flat_histogram_reads_as_no_change(self):
+        # Undefined correlation must not manufacture a scene boundary.
+        flat = np.full((50, 60), 0.5)
+        other = _hue_saturation_histogram(_textured((200, 30, 30), seed=9))
+        assert _histogram_correlation(flat, other) == pytest.approx(1.0)
+        assert _histogram_correlation(flat, flat) == pytest.approx(1.0)
+
+
+class TestDetectSceneBoundaries:
+    def _three_scene_clip(self, tmp_path, fps: int = 10, seconds: int = 3):
+        """A clip of three hard-cut scenes, each *seconds* long."""
+        frames: list[np.ndarray] = []
+        for color in ((200, 30, 30), (30, 30, 200), (30, 200, 30)):
+            for i in range(fps * seconds):
+                frame = _solid(color, size=64)
+                frame[10:30, 10 + i : 30 + i] = (255, 255, 255)  # motion within the scene
+                frames.append(frame)
+        path = tmp_path / "scenes.mp4"
+        _encode_frames(path, frames, fps=fps)
+        return path
+
+    def test_finds_the_hard_cuts(self, tmp_path):
+        path = self._three_scene_clip(tmp_path)
+        boundaries = _detect_scene_boundaries(str(path), threshold=0.3, min_scene_duration=1.0)
+        assert boundaries == pytest.approx([3.0, 6.0])
+
+    def test_min_scene_duration_suppresses_close_boundaries(self, tmp_path):
+        path = self._three_scene_clip(tmp_path)
+        boundaries = _detect_scene_boundaries(str(path), threshold=0.3, min_scene_duration=5.0)
+        # The 6.0s cut is 3s after the 3.0s one, so it can't open a new scene;
+        # the trailing-scene guard then drops what's left.
+        assert boundaries == []
+
+    def test_single_scene_has_no_boundaries(self, tmp_path):
+        frames = [_textured((200, 30, 30), seed=i, size=64) for i in range(30)]
+        path = tmp_path / "one.mp4"
+        _encode_frames(path, frames, fps=10)
+        assert _detect_scene_boundaries(str(path), threshold=0.3, min_scene_duration=1.0) == []
+
+    def test_undecodable_video_returns_no_boundaries(self, tmp_path):
+        junk = tmp_path / "junk.mp4"
+        junk.write_bytes(b"not a video at all")
+        assert _detect_scene_boundaries(str(junk), threshold=0.3, min_scene_duration=1.0) == []
+
+    def test_missing_video_returns_no_boundaries(self, tmp_path):
+        assert _detect_scene_boundaries(str(tmp_path / "nope.mp4"), 0.3, 1.0) == []

--- a/vtscore/converters/video2image.py
+++ b/vtscore/converters/video2image.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from vtscore.converters.base import MediaConverter
+from vtscore.media.video import decode
 from vtscore.plugins import PluginField
 
 
@@ -30,7 +31,8 @@ class Video2ImageMediaConverter(MediaConverter):
     """Cut a video into evenly-spaced segments and extract the middle frame
     from each segment as a PNG image.
 
-    Uses OpenCV (``cv2``) to read the video and sample frames.
+    Frames are decoded out-of-process by ffmpeg (see
+    :mod:`vtscore.media.video.decode`).
 
     The number of frames is driven by one of two mutually-exclusive,
     user-configurable parameters — supply one *or* the other, never both:
@@ -123,13 +125,12 @@ class Video2ImageMediaConverter(MediaConverter):
         stem = Path(filename).stem
 
         try:
-            import cv2  # noqa: PLC0415
             from PIL import Image  # noqa: PLC0415
         except ImportError:
-            print("Video2ImageMediaConverter requires opencv-python and Pillow")
+            print("Video2ImageMediaConverter requires Pillow")
             return []
 
-        # We need a file path for cv2.VideoCapture
+        # The decoder needs a seekable file path, not a buffer.
         tmp_file = None
         if media_path and Path(media_path).exists():
             video_path = str(media_path)
@@ -151,49 +152,38 @@ class Video2ImageMediaConverter(MediaConverter):
 
         results: list[dict[str, Any]] = []
         try:
-            cap = cv2.VideoCapture(video_path)
-            try:
-                if not cap.isOpened():
-                    return []
-                frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-                if frame_count <= 0:
-                    return []
+            info = decode.probe(video_path)
+            if info is None or info.duration <= 0:
+                return []
 
-                # "Seconds per frame" wins when supplied: derive the frame
-                # count from the video's duration so longer videos yield more
-                # frames.  Otherwise fall back to the fixed "frames per video".
-                fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0) if seconds_per_frame > 0 else 0.0
-                n = _compute_n_frames(frame_count, fps, n_clips, seconds_per_frame)
-                # Divide video into n equal segments, pick middle frame of each
-                segment_size = frame_count / n
-                mid_indices = [int((i + 0.5) * segment_size) for i in range(n)]
-                # Clamp to valid range
-                mid_indices = [min(idx, frame_count - 1) for idx in mid_indices]
+            # "Seconds per frame" wins when supplied: derive the frame count
+            # from the video's duration so longer videos yield more frames.
+            # Otherwise fall back to the fixed "frames per video".
+            frame_count = max(1, info.frame_count or 1)
+            fps = info.fps if seconds_per_frame > 0 else 0.0
+            n = _compute_n_frames(frame_count, fps, n_clips, seconds_per_frame)
+            # Divide the video into n equal segments and take the middle of each,
+            # stopping a frame short of the end where nothing decodes.
+            last = max(0.0, info.duration - info.frame_seconds)
+            segment = info.duration / n
+            mid_times = [min((i + 0.5) * segment, last) for i in range(n)]
 
-                for clip_num, frame_idx in enumerate(mid_indices):
-                    cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
-                    ret, frame = cap.read()
-                    if not ret:
-                        continue
+            for clip_num, frame_rgb in enumerate(decode.frames_at(video_path, mid_times)):
+                img = Image.fromarray(frame_rgb)
 
-                    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                    img = Image.fromarray(frame_rgb)
+                buf = io.BytesIO()
+                img.save(buf, format="PNG")
+                png_bytes = buf.getvalue()
 
-                    buf = io.BytesIO()
-                    img.save(buf, format="PNG")
-                    png_bytes = buf.getvalue()
-
-                    results.append(
-                        {
-                            "filename": f"{stem}_clip_{clip_num + 1}.png",
-                            "media_bytes": png_bytes,
-                            "duration": 0,
-                            "width": img.width,
-                            "height": img.height,
-                        }
-                    )
-            finally:
-                cap.release()
+                results.append(
+                    {
+                        "filename": f"{stem}_clip_{clip_num + 1}.png",
+                        "media_bytes": png_bytes,
+                        "duration": 0,
+                        "width": img.width,
+                        "height": img.height,
+                    }
+                )
         finally:
             if tmp_file is not None:
                 import os  # noqa: PLC0415

--- a/vtscore/media/video/_frame_sampling.py
+++ b/vtscore/media/video/_frame_sampling.py
@@ -17,7 +17,12 @@ import os
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import TYPE_CHECKING, Any, Iterator, Optional
+
+from vtscore.media.video import decode
+
+if TYPE_CHECKING:
+    from vtscore.media.video.decode import VideoInfo
 
 _logger = logging.getLogger(__name__)
 
@@ -47,22 +52,24 @@ def _resolve_video_path(media: dict) -> Iterator[Optional[Path]]:
             pass
 
 
-def _frame_index_range(media: dict, frame_count: int, fps: float) -> tuple[int, int]:
-    """Map ``clip_start``/``clip_end`` to ``[start_frame, end_frame]`` indices.
+def _frame_time_range(media: dict, info: "VideoInfo") -> tuple[float, float]:
+    """Map ``clip_start``/``clip_end`` to a ``[start, end]`` window in seconds.
 
-    Falls back to the full video range when boundaries are absent or ``fps``
-    is non-positive.  ``end_frame`` is inclusive.
+    Falls back to the full video when boundaries are absent or unusable.  The
+    window stops one frame short of the duration so the end of the range still
+    decodes to a real frame.
     """
+    frame_seconds = info.frame_seconds
+    last = max(0.0, info.duration - frame_seconds)
+
     clip_start = media.get("clip_start")
     clip_end = media.get("clip_end")
-    if clip_start is None or clip_end is None or not fps or fps <= 0 or float(clip_end) <= float(clip_start):
-        return 0, frame_count - 1
+    if clip_start is None or clip_end is None or float(clip_end) <= float(clip_start):
+        return 0.0, last
 
-    start_idx = int(round(float(clip_start) * fps))
-    end_idx = int(round(float(clip_end) * fps)) - 1
-    start_idx = max(0, min(start_idx, frame_count - 1))
-    end_idx = max(start_idx, min(end_idx, frame_count - 1))
-    return start_idx, end_idx
+    start = max(0.0, min(float(clip_start), last))
+    end = max(start, min(float(clip_end) - frame_seconds, last))
+    return start, end
 
 
 def sample_video_frames(media: dict, num_frames: int) -> list[Any]:
@@ -77,54 +84,41 @@ def sample_video_frames(media: dict, num_frames: int) -> list[Any]:
     *num_frames* entries, matching the per-embedder padding loops it
     replaces.  Returns ``[]`` on any decoding failure.
     """
-    import cv2  # noqa: PLC0415
     import numpy as np  # noqa: PLC0415
     from PIL import Image  # noqa: PLC0415
 
     with _resolve_video_path(media) as path:
         if path is None:
             return []
-        cap = cv2.VideoCapture(str(path))
-        if not cap.isOpened():
+        info = decode.probe(path)
+        if info is None or info.duration <= 0:
             return []
-        try:
-            frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-            if frame_count <= 0:
-                return []
-            fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0)
-            start_idx, end_idx = _frame_index_range(media, frame_count, fps)
-            n_avail = end_idx - start_idx + 1
-            n_to_sample = min(num_frames, max(1, n_avail))
-            if n_to_sample == 1:
-                indices = np.array([start_idx], dtype=int)
-            else:
-                indices = np.linspace(start_idx, end_idx, n_to_sample, dtype=int)
 
-            frames: list[Any] = []
-            for idx in indices:
-                cap.set(cv2.CAP_PROP_POS_FRAMES, int(idx))
-                ret, frame = cap.read()
-                if ret:
-                    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                    frames.append(Image.fromarray(frame_rgb))
-        finally:
-            cap.release()
+        start, end = _frame_time_range(media, info)
+        n_avail = max(1, int(round((end - start) * info.fps)) + 1) if info.fps > 0 else num_frames
+        n_to_sample = min(num_frames, n_avail)
+        if n_to_sample <= 1:
+            times = np.array([start], dtype=float)
+        else:
+            times = np.linspace(start, end, n_to_sample, dtype=float)
+
+        decoded = decode.frames_at(path, [float(t) for t in times])
+        frames: list[Any] = [Image.fromarray(frame) for frame in decoded]
 
     if not frames:
         return []
-    # Partial-read failure: cap.read() returned False for some of the
-    # requested indices (corrupted middle frames, VFR videos where
-    # CAP_PROP_POS_FRAMES doesn't actually seek, codec quirks). The
-    # remaining pad step will repeat the last successful frame, which
-    # biases the embedding toward the readable portion of the file -
-    # warn so the failure is visible in logs instead of silent.
-    if len(frames) < len(indices):
+    # Partial-read failure: some requested timestamps didn't decode (corrupted
+    # middle frames, VFR videos whose seeks land oddly, codec quirks).  The
+    # remaining pad step will repeat the last successful frame, which biases
+    # the embedding toward the readable portion of the file - warn so the
+    # failure is visible in logs instead of silent.
+    if len(frames) < len(times):
         _logger.warning(
-            "Partial frame-read failure for %s: %d/%d requested indices succeeded; "
+            "Partial frame-read failure for %s: %d/%d requested timestamps succeeded; "
             "padding with the last readable frame will bias the embedding.",
             path,
             len(frames),
-            len(indices),
+            len(times),
         )
     while len(frames) < num_frames:
         frames.append(frames[-1])

--- a/vtscore/media/video/clipper.py
+++ b/vtscore/media/video/clipper.py
@@ -3,9 +3,20 @@
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from vtscore.media.clipper import MediaClipper
+from vtscore.media.video import decode
+
+if TYPE_CHECKING:
+    import numpy as np
+
+#: Width the scene detector downscales sampled frames to.  Colour histograms
+#: are scale-insensitive, so full-resolution frames only cost decode time.
+_SCENE_SAMPLE_WIDTH = 320
+
+#: Hue x saturation bin counts for the scene-change histogram.
+_SCENE_HIST_BINS = (50, 60)
 
 
 class VideoDefaultClipper(MediaClipper):
@@ -251,6 +262,39 @@ class VideoAutoClipper(MediaClipper):
         return d
 
 
+def _hue_saturation_histogram(frame_rgb: "np.ndarray") -> "np.ndarray":
+    """Return an L2-normalised hue x saturation histogram of an RGB frame."""
+    import numpy as np  # noqa: PLC0415
+    from PIL import Image  # noqa: PLC0415
+
+    hsv = np.asarray(Image.fromarray(frame_rgb).convert("HSV"))
+    hist, _, _ = np.histogram2d(
+        hsv[..., 0].ravel(),
+        hsv[..., 1].ravel(),
+        bins=_SCENE_HIST_BINS,
+        range=[[0, 256], [0, 256]],
+    )
+    norm = float(np.linalg.norm(hist))
+    return hist / norm if norm > 0 else hist
+
+
+def _histogram_correlation(a: "np.ndarray", b: "np.ndarray") -> float:
+    """Pearson correlation between two histograms (OpenCV's ``HISTCMP_CORREL``).
+
+    Returns 1.0 ("no change") when a histogram is perfectly flat and the
+    correlation is undefined, so a degenerate frame can't manufacture a scene
+    boundary.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    da = a.ravel() - a.mean()
+    db = b.ravel() - b.mean()
+    denom = float(np.sqrt(np.dot(da, da) * np.dot(db, db)))
+    if denom == 0.0:
+        return 1.0
+    return float(np.dot(da, db) / denom)
+
+
 def _detect_scene_boundaries(
     video_path: str,
     threshold: float,
@@ -265,65 +309,38 @@ def _detect_scene_boundaries(
     since the previous boundary.
 
     The function samples one frame per second to keep the cost manageable
-    for long videos.
+    for long videos, and works on downscaled frames because a colour
+    histogram doesn't need full resolution.
 
     Returns a sorted list of boundary timestamps **not** including 0 or
     the video end.  An empty list means no scene changes were detected.
     """
-    import cv2  # noqa: PLC0415
-
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
+    info = decode.probe(video_path)
+    if info is None or info.duration <= 0:
         return []
+    total_duration = info.duration
 
-    try:
-        fps = cap.get(cv2.CAP_PROP_FPS)
-        if fps <= 0:
-            return []
-        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        if frame_count <= 0:
-            return []
-        total_duration = frame_count / fps
+    prev_hist = None
+    boundaries: list[float] = []
+    last_boundary_time = 0.0
 
-        # Sample roughly one frame per second.
-        sample_interval = max(1, int(round(fps)))
+    for current_time, frame in decode.iter_frames(video_path, interval=1.0, max_width=_SCENE_SAMPLE_WIDTH):
+        hist = _hue_saturation_histogram(frame)
 
-        prev_hist = None
-        boundaries: list[float] = []
-        last_boundary_time = 0.0
+        if prev_hist is not None:
+            corr = _histogram_correlation(prev_hist, hist)
+            if corr < threshold and (current_time - last_boundary_time) >= min_scene_duration:
+                boundaries.append(round(current_time, 6))
+                last_boundary_time = current_time
 
-        frame_idx = 0
-        while True:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
-            ret, frame = cap.read()
-            if not ret:
-                break
+        prev_hist = hist
 
-            # Convert to HSV and compute a normalised hue-saturation histogram.
-            hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
-            hist = cv2.calcHist([hsv], [0, 1], None, [50, 60], [0, 180, 0, 256])
-            cv2.normalize(hist, hist)
+    # Drop any boundary that would create a trailing scene shorter than
+    # min_scene_duration.
+    if boundaries and (total_duration - boundaries[-1]) < min_scene_duration:
+        boundaries.pop()
 
-            if prev_hist is not None:
-                corr = cv2.compareHist(prev_hist, hist, cv2.HISTCMP_CORREL)
-                current_time = frame_idx / fps
-                if corr < threshold and (current_time - last_boundary_time) >= min_scene_duration:
-                    boundaries.append(round(current_time, 6))
-                    last_boundary_time = current_time
-
-            prev_hist = hist
-            frame_idx += sample_interval
-            if frame_idx >= frame_count:
-                break
-
-        # Drop any boundary that would create a trailing scene shorter than
-        # min_scene_duration.
-        if boundaries and (total_duration - boundaries[-1]) < min_scene_duration:
-            boundaries.pop()
-
-        return boundaries
-    finally:
-        cap.release()
+    return boundaries
 
 
 class VideoSceneClipper(MediaClipper):

--- a/vtscore/media/video/decode.py
+++ b/vtscore/media/video/decode.py
@@ -32,7 +32,7 @@ import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator, Sequence
+from typing import Generator, Sequence
 
 import numpy as np
 
@@ -250,7 +250,7 @@ def iter_frames(
     *,
     interval: float,
     max_width: int | None = None,
-) -> Iterator[tuple[float, np.ndarray]]:
+) -> Generator[tuple[float, np.ndarray], None, None]:
     """Yield ``(timestamp, frame)`` every *interval* seconds through the video.
 
     One ffmpeg process decodes the file linearly and pipes raw RGB, which is
@@ -380,7 +380,7 @@ def _cv2_iter_frames(
     *,
     interval: float,
     max_width: int | None = None,
-) -> Iterator[tuple[float, np.ndarray]]:
+) -> Generator[tuple[float, np.ndarray], None, None]:
     try:
         import cv2  # noqa: PLC0415
 

--- a/vtscore/media/video/decode.py
+++ b/vtscore/media/video/decode.py
@@ -1,0 +1,409 @@
+"""Decode video frames through ffmpeg instead of loading OpenCV in-process.
+
+Every video path used to call ``cv2.VideoCapture``.  That is a problem beyond
+OpenCV itself: ``cv2.abi3.so`` lists ``libavformat`` in its ``DT_NEEDED``
+entries, and the wheel's ``libavformat`` in turn needs the ``libssl`` /
+``libcrypto`` 1.1.1 pair vendored inside ``opencv_python_headless.libs``.  So
+merely importing ``cv2`` maps a second, non-FIPS OpenSSL into a process that
+(on a FIPS-enabled host) already holds the system's FIPS-validated one.  The
+duplicate trips the FIPS self-test and OpenSSL answers with ``abort()``:
+
+    crypto/fips/fips.c:154 OpenSSL internal error: FATAL FIPS SELFTEST FAILURE
+
+That kills the interpreter outright - no exception, no traceback, just a core
+dump - so it cannot be caught and handled at the call site.  Downgrading does
+not help either: every ``opencv-python-headless`` wheel from 4.9 through 5.0
+vendors the same OpenSSL 1.1.1w.
+
+The fix is to keep OpenSSL out of *our* address space.  ffmpeg runs as a
+separate process, so whatever it links is its own business, and it is already
+a hard dependency (``imageio-ffmpeg`` ships a static binary; a system ffmpeg on
+``$PATH`` wins when present) used for audio decoding and video transcoding.
+
+``cv2`` remains as a fallback for installs with no ffmpeg at all.  It is
+deliberately *not* used when ffmpeg is present but fails on a particular file:
+a decode failure is not worth risking the process on.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Sequence
+
+import numpy as np
+
+from vtscore.media.audio.ffmpeg import get_ffmpeg_exe
+
+#: Seconds to wait for a single-frame extract or a container probe.  Generous
+#: for a slow seek into a large file, bounded so a wedged subprocess can't hang
+#: a worker forever.
+FFMPEG_TIMEOUT = 120.0
+
+#: Header line ffmpeg prints for the container: ``Duration: 00:01:03.48, ...``.
+_DURATION_RE = re.compile(r"Duration:\s*(\d+):(\d{2}):(\d{2}(?:\.\d+)?)")
+
+#: The first video stream's summary line, e.g.
+#: ``Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 640x480 ...``
+_VIDEO_STREAM_RE = re.compile(r"^\s*Stream #\d+:\d+.*: Video: .*$", re.MULTILINE)
+
+#: ``640x480`` inside a stream line.  Two digits minimum so the ``0x...`` fourcc
+#: tag that precedes it can't match.
+_SIZE_RE = re.compile(r"(?<![\dx])(\d{2,5})x(\d{2,5})(?![\dx])")
+
+#: ``30 fps`` / ``29.97 fps`` (``tbr``/``tbn`` deliberately not matched).
+_FPS_RE = re.compile(r"(\d+(?:\.\d+)?)\s+fps")
+
+
+@dataclass(frozen=True)
+class VideoInfo:
+    """Container metadata for a video file.  Zeroed fields mean "unknown"."""
+
+    duration: float = 0.0
+    fps: float = 0.0
+    width: int = 0
+    height: int = 0
+
+    @property
+    def frame_count(self) -> int:
+        """Frames in the video, derived from duration x fps (0 when unknown)."""
+        if self.duration <= 0 or self.fps <= 0:
+            return 0
+        return max(1, int(round(self.duration * self.fps)))
+
+    @property
+    def frame_seconds(self) -> float:
+        """How long one frame lasts, falling back to 25fps when unknown.
+
+        Callers use it as the headroom that keeps a seek to the end of a video
+        from landing past its last frame, where nothing decodes.
+        """
+        return 1.0 / self.fps if self.fps > 0 else 0.04
+
+
+# ---------------------------------------------------------------------------
+# Backend selection
+# ---------------------------------------------------------------------------
+
+
+def _ffmpeg_exe() -> str | None:
+    """Return the ffmpeg binary, or ``None`` when this install has none."""
+    try:
+        return get_ffmpeg_exe()
+    except FileNotFoundError:
+        return None
+
+
+def backend() -> str:
+    """Return the decoder in use: ``"ffmpeg"`` or ``"opencv"``.
+
+    Exposed so deployments can confirm which one a host resolved to - on a
+    FIPS-enabled host, ``"opencv"`` means video decoding will crash the
+    process, and ffmpeg needs installing.
+    """
+    return "ffmpeg" if _ffmpeg_exe() is not None else "opencv"
+
+
+def _run(cmd: list[str], *, timeout: float = FFMPEG_TIMEOUT) -> subprocess.CompletedProcess[bytes] | None:
+    """Run *cmd* to completion, returning ``None`` if it could not be run."""
+    try:
+        # Always hand ffmpeg an empty stdin so the child never inherits - and
+        # blocks on - the parent's terminal.
+        return subprocess.run(cmd, input=b"", capture_output=True, timeout=timeout, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Probing
+# ---------------------------------------------------------------------------
+
+
+def _parse_probe(stderr: str) -> VideoInfo | None:
+    """Parse ``ffmpeg -i`` banner output into a :class:`VideoInfo`.
+
+    Returns ``None`` when the input has no video stream (unreadable file,
+    audio-only container, ...).
+    """
+    stream = _VIDEO_STREAM_RE.search(stderr)
+    if stream is None:
+        return None
+    line = stream.group(0)
+
+    width = height = 0
+    size = _SIZE_RE.search(line)
+    if size is not None:
+        width, height = int(size.group(1)), int(size.group(2))
+
+    fps = 0.0
+    fps_match = _FPS_RE.search(line)
+    if fps_match is not None:
+        fps = float(fps_match.group(1))
+
+    duration = 0.0
+    dur = _DURATION_RE.search(stderr)
+    if dur is not None:
+        duration = int(dur.group(1)) * 3600 + int(dur.group(2)) * 60 + float(dur.group(3))
+
+    return VideoInfo(duration=duration, fps=fps, width=width, height=height)
+
+
+def probe(path: str | Path) -> VideoInfo | None:
+    """Return metadata for the video at *path*, or ``None`` if it can't be read."""
+    exe = _ffmpeg_exe()
+    if exe is None:
+        return _cv2_probe(path)
+
+    # ffmpeg exits non-zero on "no output file specified" after printing the
+    # stream summary we're after, so the return code is deliberately ignored.
+    result = _run([exe, "-hide_banner", "-nostdin", "-i", str(path)])
+    if result is None:
+        return None
+    return _parse_probe(result.stderr.decode(errors="replace"))
+
+
+# ---------------------------------------------------------------------------
+# Single-frame extraction
+# ---------------------------------------------------------------------------
+
+
+def _decode_png(blob: bytes) -> np.ndarray | None:
+    """Decode a PNG blob to an ``(h, w, 3)`` uint8 RGB array."""
+    from PIL import Image  # noqa: PLC0415
+
+    try:
+        with Image.open(io.BytesIO(blob)) as img:
+            return np.array(img.convert("RGB"), dtype=np.uint8)
+    except Exception:
+        return None
+
+
+def frame_at(path: str | Path, time_seconds: float) -> np.ndarray | None:
+    """Return the frame at *time_seconds* as an ``(h, w, 3)`` uint8 RGB array.
+
+    Returns ``None`` when the video can't be decoded or the timestamp lies
+    past its last frame.
+    """
+    exe = _ffmpeg_exe()
+    if exe is None:
+        return _cv2_frame_at(path, time_seconds)
+
+    cmd = [
+        exe,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-nostdin",
+        # Input-side seek: jumps to the nearest keyframe before decoding
+        # forward to the exact timestamp, so cost stays flat on long videos.
+        "-ss",
+        f"{max(0.0, float(time_seconds)):.6f}",
+        "-i",
+        str(path),
+        "-map",
+        "0:v:0",
+        "-frames:v",
+        "1",
+        "-f",
+        "image2pipe",
+        "-vcodec",
+        "png",
+        "pipe:1",
+    ]
+    result = _run(cmd)
+    if result is None or result.returncode != 0 or not result.stdout:
+        return None
+    return _decode_png(result.stdout)
+
+
+def frames_at(path: str | Path, times: Sequence[float]) -> list[np.ndarray]:
+    """Return the frames at *times*, skipping any that fail to decode.
+
+    The result can therefore be shorter than *times*; callers that care about
+    partial failure compare the two lengths.
+    """
+    frames: list[np.ndarray] = []
+    for t in times:
+        frame = frame_at(path, t)
+        if frame is not None:
+            frames.append(frame)
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Streaming extraction (one process for the whole video)
+# ---------------------------------------------------------------------------
+
+
+def _scaled_size(width: int, height: int, max_width: int | None) -> tuple[int, int]:
+    """Return the output size after clamping *width* to *max_width*."""
+    if not max_width or width <= max_width:
+        return width, height
+    return max_width, max(1, int(round(height * max_width / width)))
+
+
+def iter_frames(
+    path: str | Path,
+    *,
+    interval: float,
+    max_width: int | None = None,
+) -> Iterator[tuple[float, np.ndarray]]:
+    """Yield ``(timestamp, frame)`` every *interval* seconds through the video.
+
+    One ffmpeg process decodes the file linearly and pipes raw RGB, which is
+    far cheaper than seeking per sample.  *max_width* downscales wide frames
+    (aspect preserved) for callers that only need coarse image statistics.
+    """
+    if interval <= 0:
+        raise ValueError("interval must be positive")
+
+    exe = _ffmpeg_exe()
+    if exe is None:
+        yield from _cv2_iter_frames(path, interval=interval, max_width=max_width)
+        return
+
+    info = probe(path)
+    if info is None or info.width <= 0 or info.height <= 0:
+        return
+    out_w, out_h = _scaled_size(info.width, info.height, max_width)
+
+    # ``-noautorotate`` keeps the raw stream dimensions we just probed: with
+    # autorotation on, a 90-degree display matrix would swap them and every
+    # reshape below would be off.
+    filters = f"fps={1.0 / interval:.6f}"
+    if (out_w, out_h) != (info.width, info.height):
+        filters += f",scale={out_w}:{out_h}"
+    cmd = [
+        exe,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-nostdin",
+        "-noautorotate",
+        "-i",
+        str(path),
+        "-map",
+        "0:v:0",
+        "-vf",
+        filters,
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        "pipe:1",
+    ]
+
+    frame_bytes = out_w * out_h * 3
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return
+
+    try:
+        assert proc.stdout is not None
+        index = 0
+        while True:
+            buf = proc.stdout.read(frame_bytes)
+            if buf is None or len(buf) < frame_bytes:
+                break
+            yield index * interval, np.frombuffer(bytearray(buf), dtype=np.uint8).reshape(out_h, out_w, 3)
+            index += 1
+    finally:
+        # Covers both the normal end-of-stream and an early ``break`` in the
+        # consumer, which would otherwise leave ffmpeg blocked on a full pipe.
+        if proc.stdout is not None:
+            proc.stdout.close()
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# OpenCV fallback - only reached when the host has no ffmpeg at all
+# ---------------------------------------------------------------------------
+
+
+def _cv2_probe(path: str | Path) -> VideoInfo | None:
+    try:
+        import cv2  # noqa: PLC0415
+
+        cap = cv2.VideoCapture(str(path))
+        try:
+            if not cap.isOpened():
+                return None
+            fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0)
+            frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+            height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        finally:
+            cap.release()
+    except Exception:
+        return None
+    duration = frame_count / fps if fps > 0 and frame_count > 0 else 0.0
+    return VideoInfo(duration=duration, fps=fps, width=max(0, width), height=max(0, height))
+
+
+def _cv2_frame_at(path: str | Path, time_seconds: float) -> np.ndarray | None:
+    try:
+        import cv2  # noqa: PLC0415
+
+        cap = cv2.VideoCapture(str(path))
+        try:
+            if not cap.isOpened():
+                return None
+            fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0)
+            frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            if frame_count <= 0:
+                return None
+            target = int(round(time_seconds * fps)) if fps > 0 else frame_count // 2
+            cap.set(cv2.CAP_PROP_POS_FRAMES, max(0, min(target, frame_count - 1)))
+            ok, frame = cap.read()
+            if not ok:
+                return None
+            return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        finally:
+            cap.release()
+    except Exception:
+        return None
+
+
+def _cv2_iter_frames(
+    path: str | Path,
+    *,
+    interval: float,
+    max_width: int | None = None,
+) -> Iterator[tuple[float, np.ndarray]]:
+    try:
+        import cv2  # noqa: PLC0415
+
+        cap = cv2.VideoCapture(str(path))
+    except Exception:
+        return
+    try:
+        if not cap.isOpened():
+            return
+        fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0)
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        if fps <= 0 or frame_count <= 0:
+            return
+        step = max(1, int(round(fps * interval)))
+        for frame_idx in range(0, frame_count, step):
+            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+            ok, frame = cap.read()
+            if not ok:
+                return
+            rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            out_w, out_h = _scaled_size(rgb.shape[1], rgb.shape[0], max_width)
+            if (out_w, out_h) != (rgb.shape[1], rgb.shape[0]):
+                rgb = cv2.resize(rgb, (out_w, out_h), interpolation=cv2.INTER_AREA)
+            yield frame_idx / fps, rgb
+    finally:
+        cap.release()

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -15,6 +15,7 @@ from vtscore.media.base import (
     _noop_progress,
     demo_slice,
 )
+from vtscore.media.video import decode
 from vtscore.utils.hashing import content_md5
 
 if TYPE_CHECKING:
@@ -23,171 +24,90 @@ if TYPE_CHECKING:
 _THUMB_SIZE = 128
 
 
-def generate_video_thumbnail(video_bytes: bytes, *, size: int = _THUMB_SIZE) -> bytes | None:
-    """Extract the middle frame of a video and return it as a PNG thumbnail.
+def _seek_time(info: decode.VideoInfo, time_seconds: float | None) -> float:
+    """Clamp *time_seconds* to a readable position; ``None`` means the middle."""
+    if time_seconds is None:
+        return info.duration / 2 if info.duration > 0 else 0.0
+    if info.duration <= 0:
+        return max(0.0, time_seconds)
+    return max(0.0, min(time_seconds, max(0.0, info.duration - info.frame_seconds)))
 
-    Uses OpenCV to decode the video and PIL to produce the PNG.  Returns
-    ``None`` if the video cannot be decoded or has no frames.
-    """
+
+def _encode_thumbnail(frame_rgb: "np.ndarray", size: int) -> bytes | None:
+    """Shrink an RGB frame to fit *size* and encode it as PNG bytes."""
     try:
-        import cv2  # noqa: PLC0415
         from PIL import Image  # noqa: PLC0415
+
+        img = Image.fromarray(frame_rgb)
+        img.thumbnail((size, size))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG", optimize=True)
+        return buf.getvalue()
     except Exception:
         return None
 
+
+def _thumbnail_from_path(
+    file_path: Path,
+    time_seconds: float | None,
+    size: int,
+    info: decode.VideoInfo | None = None,
+) -> bytes | None:
+    """Grab one frame from *file_path* and return it as a PNG thumbnail.
+
+    *info* lets a caller that already probed the container hand the result in
+    rather than paying for a second probe.
+    """
+    if info is None:
+        info = decode.probe(file_path)
+    if info is None:
+        return None
+    frame = decode.frame_at(file_path, _seek_time(info, time_seconds))
+    if frame is None:
+        return None
+    return _encode_thumbnail(frame, size)
+
+
+def _thumbnail_from_bytes(video_bytes: bytes, time_seconds: float | None, size: int) -> bytes | None:
+    """Spill *video_bytes* to a temp file (decoders need a seekable path) and thumbnail it."""
+    if not video_bytes:
+        return None
     tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
     try:
         tmp.write(video_bytes)
         tmp.close()
-
-        cap = cv2.VideoCapture(tmp.name)
-        try:
-            if not cap.isOpened():
-                return None
-            frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-            if frame_count <= 0:
-                return None
-            mid = frame_count // 2
-            cap.set(cv2.CAP_PROP_POS_FRAMES, mid)
-            ret, frame = cap.read()
-            if not ret:
-                return None
-        finally:
-            cap.release()
+        return _thumbnail_from_path(Path(tmp.name), time_seconds, size)
     finally:
         import os  # noqa: PLC0415
 
         os.unlink(tmp.name)
 
-    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-    img = Image.fromarray(frame_rgb)
-    img.thumbnail((size, size))
 
-    buf = io.BytesIO()
-    img.save(buf, format="PNG", optimize=True)
-    return buf.getvalue()
+def generate_video_thumbnail(video_bytes: bytes, *, size: int = _THUMB_SIZE) -> bytes | None:
+    """Extract the middle frame of a video and return it as a PNG thumbnail.
+
+    Decoding runs out-of-process through ffmpeg (see
+    :mod:`vtscore.media.video.decode`) and PIL produces the PNG.  Returns
+    ``None`` if the video cannot be decoded or has no frames.
+    """
+    return _thumbnail_from_bytes(video_bytes, None, size)
 
 
 def generate_video_thumbnail_from_file(file_path: Path, *, size: int = _THUMB_SIZE) -> bytes | None:
     """Extract the middle frame of a video file and return it as a PNG thumbnail."""
-    try:
-        import cv2  # noqa: PLC0415
-        from PIL import Image  # noqa: PLC0415
-    except Exception:
-        return None
-
-    try:
-        cap = cv2.VideoCapture(str(file_path))
-        try:
-            if not cap.isOpened():
-                return None
-            frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-            if frame_count <= 0:
-                return None
-            mid = frame_count // 2
-            cap.set(cv2.CAP_PROP_POS_FRAMES, mid)
-            ret, frame = cap.read()
-            if not ret:
-                return None
-        finally:
-            cap.release()
-    except Exception:
-        return None
-
-    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-    img = Image.fromarray(frame_rgb)
-    img.thumbnail((size, size))
-
-    buf = io.BytesIO()
-    img.save(buf, format="PNG", optimize=True)
-    return buf.getvalue()
-
-
-def _frame_at_time(cap, time_seconds: float) -> "np.ndarray | None":
-    """Seek *cap* to *time_seconds* and read one frame.  Returns the frame array or ``None``."""
-    import cv2  # noqa: PLC0415
-
-    fps = cap.get(cv2.CAP_PROP_FPS)
-    frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    if frame_count <= 0:
-        return None
-    if fps and fps > 0:
-        target = max(0, min(int(round(time_seconds * fps)), frame_count - 1))
-    else:
-        target = frame_count // 2
-    cap.set(cv2.CAP_PROP_POS_FRAMES, target)
-    ret, frame = cap.read()
-    if not ret:
-        return None
-    return frame
+    return _thumbnail_from_path(file_path, None, size)
 
 
 def generate_video_thumbnail_at(video_bytes: bytes, time_seconds: float, *, size: int = _THUMB_SIZE) -> bytes | None:
     """Extract a frame at *time_seconds* from *video_bytes* and return it as a PNG thumbnail."""
-    try:
-        import cv2  # noqa: PLC0415
-        from PIL import Image  # noqa: PLC0415
-    except Exception:
-        return None
-
-    tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
-    try:
-        tmp.write(video_bytes)
-        tmp.close()
-
-        cap = cv2.VideoCapture(tmp.name)
-        try:
-            if not cap.isOpened():
-                return None
-            frame = _frame_at_time(cap, time_seconds)
-            if frame is None:
-                return None
-        finally:
-            cap.release()
-    finally:
-        import os  # noqa: PLC0415
-
-        os.unlink(tmp.name)
-
-    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-    img = Image.fromarray(frame_rgb)
-    img.thumbnail((size, size))
-
-    buf = io.BytesIO()
-    img.save(buf, format="PNG", optimize=True)
-    return buf.getvalue()
+    return _thumbnail_from_bytes(video_bytes, time_seconds, size)
 
 
 def generate_video_thumbnail_from_file_at(
     file_path: Path, time_seconds: float, *, size: int = _THUMB_SIZE
 ) -> bytes | None:
     """Extract a frame at *time_seconds* from a video file and return it as a PNG thumbnail."""
-    try:
-        import cv2  # noqa: PLC0415
-        from PIL import Image  # noqa: PLC0415
-    except Exception:
-        return None
-
-    try:
-        cap = cv2.VideoCapture(str(file_path))
-        try:
-            if not cap.isOpened():
-                return None
-            frame = _frame_at_time(cap, time_seconds)
-            if frame is None:
-                return None
-        finally:
-            cap.release()
-    except Exception:
-        return None
-
-    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-    img = Image.fromarray(frame_rgb)
-    img.thumbnail((size, size))
-
-    buf = io.BytesIO()
-    img.save(buf, format="PNG", optimize=True)
-    return buf.getvalue()
+    return _thumbnail_from_path(file_path, time_seconds, size)
 
 
 _VIDEO_MIME_TYPES: dict[str, str] = {
@@ -808,19 +728,11 @@ class VideoMediaType(MediaType):
         if media_bytes is None:
             with open(file_path, "rb") as f:
                 media_bytes = f.read()
-        try:
-            import cv2  # noqa: PLC0415
-
-            cap = cv2.VideoCapture(str(file_path))
-            try:
-                fps = cap.get(cv2.CAP_PROP_FPS)
-                frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-                duration = frame_count / fps if fps > 0 else 0.0
-            finally:
-                cap.release()
-        except Exception:
-            duration = 0.0
-        thumbnail = generate_video_thumbnail_from_file(file_path)
+        # One probe serves both the duration and the thumbnail's mid-frame
+        # seek, so a load costs one container read rather than two.
+        info = decode.probe(file_path)
+        duration = info.duration if info is not None else 0.0
+        thumbnail = _thumbnail_from_path(file_path, None, _THUMB_SIZE, info=info)
         return {"media_bytes": media_bytes, "duration": duration, "thumbnail_bytes": thumbnail}
 
     # ------------------------------------------------------------------

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -121,7 +121,10 @@ def _transcode_to_mp4(src_bytes: bytes, filename: str) -> bytes | None:  # noqa:
 
     Tries ffmpeg first (preserves audio, H.264 output).  Falls back to OpenCV
     (video-only, MPEG-4 Part 2) so that videos are at least viewable when
-    ffmpeg is not installed.
+    ffmpeg is not installed - but *only* then: importing ``cv2`` pulls a
+    vendored OpenSSL into the process, which aborts the interpreter on
+    FIPS-enabled hosts (see :mod:`vtscore.media.video.decode`), so it is not
+    worth reaching for when ffmpeg is present and simply failed on this file.
 
     Returns the MP4 bytes on success, or ``None`` if transcoding fails.
     """
@@ -159,10 +162,9 @@ def _transcode_to_mp4(src_bytes: bytes, filename: str) -> bytes | None:  # noqa:
         except FileNotFoundError:
             pass  # ffmpeg not installed; fall through to cv2
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-            pass
+            return None
         else:
-            if dst_path.exists() and dst_path.stat().st_size > 0:
-                return dst_path.read_bytes()
+            return dst_path.read_bytes() if dst_path.exists() and dst_path.stat().st_size > 0 else None
 
         # --- Attempt 2: OpenCV (video-only, no audio) --------------------
         try:


### PR DESCRIPTION
Closes #2735

## The crash

On a FIPS-enabled host, importing a video kills the interpreter outright — no exception, no traceback, just a core dump and `crypto/fips/fips.c:154 OpenSSL internal error: FATAL FIPS SELFTEST FAILURE`.

Cause: `cv2.abi3.so` lists `libavformat` in its `DT_NEEDED` entries, and that `libavformat` needs the `libssl`/`libcrypto` 1.1.1 pair vendored inside `opencv_python_headless.libs`. So merely importing `cv2` maps a second, non-FIPS OpenSSL into a process that already holds the system's FIPS-validated one; the duplicate trips the FIPS self-test and OpenSSL responds with `abort()`. Because every video path imported `cv2` lazily, the crash landed exactly at video import.

**The version pin proposed in the issue would not have fixed it.** Both the 4.9.0.80 and 5.0.0.93 wheels vendor OpenSSL 1.1.1w and reach it the same way:

```
$ readelf -d opencv_python_headless.libs/libavformat-*.so.* | grep NEEDED
  4.9.0.80 → libssl-28bef1ac.so.1.1, libcrypto-0c9efecc.so.1.1
  5.0.0.93 → libssl-28bef1ac.so.1.1, libcrypto-8ad0c0b6.so.1.1   # same OpenSSL 1.1.1w
```

## The fix

`vtscore/media/video/decode.py` — `probe` / `frame_at` / `frames_at` / `iter_frames`, backed by the ffmpeg binary already shipped as a hard dependency (`imageio-ffmpeg`'s static binary, or a system ffmpeg on `$PATH` when present). ffmpeg decodes out-of-process, so nothing it links enters our address space.

Every video decode now routes through it:

- thumbnails and duration probing (`media/video/media_type.py`) — one probe feeds both the duration and the thumbnail's mid-frame seek, so a load costs one container read rather than two;
- embedder frame sampling for X-CLIP / LanguageBind / VideoMAE (`media/video/_frame_sampling.py`), now expressed in timestamps rather than frame indices;
- scene-boundary detection (`media/video/clipper.py`) — histograms move to numpy/PIL, and one ffmpeg process walks the video instead of seeking per sample;
- the video→image converter (`converters/video2image.py`);
- the MP4 transcode route (`routes/media/list.py`) falls back to `cv2` only when ffmpeg is *missing*, not when it fails on a file.

`cv2` stays as a fallback for installs with no ffmpeg at all, and `decode.backend()` reports which one a host resolved to.

Verified the new scene detector reproduces the old cv2 boundaries exactly on hard-cut clips across thresholds 0.3/0.5/0.8, and produces no false positives on the synthetic motion clips.

## Behaviour changes

- Clip boundaries are honoured even when a container reports no frame rate (seconds don't need one); previously an unknown fps silently widened the sample to the whole video.
- `_frame_at_time` and `_frame_index_range` are gone, replaced by `_seek_time` and `_frame_time_range`.
- Video import costs one extra subprocess spawn per file (probe + extract) versus one `VideoCapture` open. Scene detection gets faster on long videos: linear decode instead of a seek per sampled second.

## Known limitation

The structural image embedder and the YOLO-based image processors import `cv2` directly, so those features remain unusable on a FIPS host. Documented in `docs/DEPLOYMENT.md` with the workaround (replace the wheel with a distro build that links the system OpenSSL). The whole video workflow now works with the stock wheel installed.

## Tests

`./run-tests.sh` — 6899 passed, 1 skipped (rebased onto current `dev`). The video suites now fake the decode layer rather than `cv2.VideoCapture`; new coverage in `tests_lib/core/test_video_decode.py` (banner parsing, real ffmpeg round-trips, OpenCV-fallback routing) and `tests_lib/detectors/test_video_scene_detection.py` (histogram helpers, end-to-end cut detection). Test helpers that encoded fixture videos with `cv2.VideoWriter` now use the bundled ffmpeg encoder, so the suite no longer needs OpenCV at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JzanE86XaijUi1wXBuFbp