### PR TITLE
Keep archive-member and URL-backed media on full-mode pickle load

### DIFF
--- a/tests/datasets/test_registry_reload_archive_member.py
+++ b/tests/datasets/test_registry_reload_archive_member.py
@@ -1,0 +1,105 @@
+"""End-to-end regression: reloading an archive-member dataset from the registry.
+
+``POST /api/datasets/registry/<id>/load`` reads the saved ``.pkl`` in *full*
+mode.  Items whose bytes live only as a byte range inside an unextracted tar
+shard (``local_archive_member`` - audio tiles, video windows) carry no inline
+bytes and no ``media_path``, so full mode used to drop every one of them: the
+reload produced a context with 0 medias, the registry row's ``num_items`` was
+overwritten with 0, and the next Browse attempt 409'd with "Dataset is empty -
+nothing to project".
+"""
+
+from __future__ import annotations
+
+import pickle
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _archive_member_media(media_id: int, tmp_path: Path) -> dict[str, Any]:
+    """One archive-member audio media: bytes exist only inside a tar shard."""
+    return {
+        "id": media_id,
+        "media_type": "audio",
+        "duration": 0,
+        "file_size": 4096,
+        "md5": f"md5-{media_id}",
+        "embeddings": {"clap": np.zeros(512, dtype=np.float32)},
+        "embedder": "clap",
+        "filename": f"shard0/clip{media_id}.m4a",
+        "category": "custom",
+        "origin": {
+            "importer": "local_archive_member",
+            "params": {
+                "archive_path": str(tmp_path / "shard0.tar"),
+                "member": f"clip{media_id}.m4a",
+                "media_type": "audio",
+                "clip_start": 0.0,
+                "clip_end": 10.0,
+            },
+        },
+        "origin_name": f"shard0.tar::clip{media_id}.m4a",
+        "media_bytes": None,
+        "media_string": None,
+        "media_path": None,
+    }
+
+
+def _wait_for_task(task_id: str, timeout: float = 12.0) -> str | None:
+    """Poll the loading-task tracker until it reports ``idle``."""
+    from vtscore.concurrency.progress import loading_tasks
+
+    status = None
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        task = next((t for t in loading_tasks.list_tasks() if t["task_id"] == task_id), None)
+        if task is not None:
+            status = task["status"]
+            if status == "idle":
+                return status
+        time.sleep(0.1)
+    return status
+
+
+class TestRegistryReloadArchiveMemberDataset:
+    def test_reload_keeps_every_item(self, client, tmp_path):
+        from vtscore.datasets.container import write_container
+        from vtscore.datasets.registry import get_dataset, register_dataset, unregister_dataset
+        from vtscore.state.core import get_context
+        from vtsearch.settings import get_saved_datasets_dir
+
+        medias = {i: _archive_member_media(i, tmp_path) for i in (1, 2, 3)}
+        ds_dir = get_saved_datasets_dir()
+        ds_dir.mkdir(parents=True, exist_ok=True)
+        pkl_path = ds_dir / "test_archive_member_reload.pkl"
+        write_container(pkl_path, pickle.dumps({"medias": medias}), {"format_version": 1})
+
+        entry = register_dataset(
+            name="archive member reload",
+            media_type="audio",
+            num_items=len(medias),
+            pkl_path=str(pkl_path),
+            embedder="clap",
+            created_by="default",
+        )
+        dataset_id = entry["id"]
+        try:
+            resp = client.post(f"/api/datasets/registry/{dataset_id}/load")
+            assert resp.status_code == 200
+            task_id = resp.get_json()["task_id"]
+            assert _wait_for_task(task_id) == "idle"
+
+            ctx = get_context(dataset_id)
+            assert ctx is not None
+            assert len(ctx.medias) == len(medias)
+            # The registry stat must not be overwritten with 0.
+            assert get_dataset(dataset_id)["num_items"] == len(medias)
+            # Kept lazily: the member is streamed from its shard on demand.
+            assert all(m["media_bytes"] is None for m in ctx.medias.values())
+        finally:
+            client.post(f"/api/datasets/registry/{dataset_id}/unload")
+            unregister_dataset(dataset_id)
+            pkl_path.unlink(missing_ok=True)

--- a/tests/datasets/test_registry_reload_archive_member.py
+++ b/tests/datasets/test_registry_reload_archive_member.py
@@ -96,7 +96,9 @@ class TestRegistryReloadArchiveMemberDataset:
             assert ctx is not None
             assert len(ctx.medias) == len(medias)
             # The registry stat must not be overwritten with 0.
-            assert get_dataset(dataset_id)["num_items"] == len(medias)
+            reloaded_entry = get_dataset(dataset_id)
+            assert reloaded_entry is not None
+            assert reloaded_entry["num_items"] == len(medias)
             # Kept lazily: the member is streamed from its shard on demand.
             assert all(m["media_bytes"] is None for m in ctx.medias.values())
         finally:

--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -231,6 +231,95 @@ class TestFullModeMediaPathReference:
         assert medias == {}
 
 
+class TestFullModeExternalByteSource:
+    """Full-mode pickle load must keep media whose bytes live outside the pickle.
+
+    An archive-member media (``local_archive_member``: audio/video tiles cut
+    from tar shards we never extract) and a URL-backed media (``recaller``
+    thin mode) both carry no inline bytes and no local file - their bytes
+    re-resolve on demand from the shard / the URL.  Full mode used to drop
+    every such entry, so reopening the dataset from the dashboard registry
+    (which loads the pickle in full mode) produced an *empty* dataset and a
+    "Dataset is empty - nothing to project" failure on Browse.
+    """
+
+    def _write_pickle(self, tmp_path: Path, media: dict[str, Any]) -> Path:
+        from vtscore.datasets.container import write_container
+
+        pkl_path = tmp_path / "external.pkl"
+        write_container(pkl_path, pickle.dumps({"medias": {1: media}}), {"format_version": 1})
+        return pkl_path
+
+    def _base_media(self) -> dict[str, Any]:
+        return {
+            "id": 1,
+            "media_type": "audio",
+            "duration": 0,
+            "file_size": 4096,
+            "md5": "deadbeef",
+            "embeddings": {"clap": np.zeros(512, dtype=np.float32)},
+            "embedder": "clap",
+            "filename": "shard0/clip.m4a",
+            "category": "custom",
+            "media_bytes": None,
+            "media_string": None,
+            "media_path": None,
+        }
+
+    def test_full_mode_keeps_archive_member_media(self, tmp_path):
+        media = self._base_media()
+        media["origin"] = {
+            "importer": "local_archive_member",
+            "params": {
+                "archive_path": str(tmp_path / "shard0.tar"),
+                "member": "clip.m4a",
+                "media_type": "audio",
+                "clip_start": 0.0,
+                "clip_end": 10.0,
+            },
+        }
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(self._write_pickle(tmp_path, media), medias, thin=False)
+        assert len(medias) == 1
+        # Kept lazily: the member is streamed from its shard on demand.
+        assert medias[1]["media_bytes"] is None
+        assert medias[1]["origin"]["importer"] == "local_archive_member"
+        assert isinstance(media_embedding(medias[1]), np.ndarray)
+
+    def test_full_mode_keeps_url_backed_media(self, tmp_path):
+        media = self._base_media()
+        media["origin"] = {"importer": "recaller", "params": {}}
+        media["media_url"] = "https://example.invalid/clip.wav"
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(self._write_pickle(tmp_path, media), medias, thin=False)
+        assert len(medias) == 1
+        assert medias[1]["media_bytes"] is None
+        # The URL is the media's byte source, so it has to survive the reload.
+        assert medias[1]["media_url"] == "https://example.invalid/clip.wav"
+
+    def test_full_mode_still_drops_media_with_no_source(self, tmp_path):
+        """A media with no bytes, no file, no shard and no URL stays dropped."""
+        media = self._base_media()
+        media["origin"] = {"importer": "server_folder", "params": {}}
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(self._write_pickle(tmp_path, media), medias, thin=False)
+        assert medias == {}
+
+    def test_media_url_survives_export_round_trip(self, tmp_path):
+        """``export_dataset_to_file`` must persist ``media_url``."""
+        from vtscore.datasets.loader import export_dataset_to_file
+
+        media = self._base_media()
+        media["origin"] = {"importer": "recaller", "params": {}}
+        media["media_url"] = "https://example.invalid/clip.wav"
+        pkl_path = tmp_path / "roundtrip.pkl"
+        pkl_path.write_bytes(export_dataset_to_file({1: media}, embedder="clap", media_type="audio"))
+
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+        assert medias[1]["media_url"] == "https://example.invalid/clip.wav"
+
+
 class TestPickleNullEmbedding:
     """Skip-on-None pickle entries (audit M8 / M12).
 

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -236,6 +236,10 @@ def export_dataset_to_file(
             "media_bytes": media.get("media_bytes"),
             "media_string": media.get("media_string"),
             "media_path": media.get("media_path"),
+            # A URL-backed media (``recaller``) has no inline bytes and no local
+            # file: the URL *is* its byte source, so it has to ride along or the
+            # item reloads with nothing to serve.
+            "media_url": media.get("media_url"),
             "word_count": media.get("word_count"),
             "character_count": media.get("character_count"),
             "width": media.get("width"),

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -100,6 +100,26 @@ def _resolve_thin_media_path(
     return None
 
 
+def _has_external_byte_source(media_info: dict[str, Any]) -> bool:
+    """Return ``True`` when a media's bytes re-derive from outside the pickle.
+
+    A full-mode load resolves bytes up front from the pickle's inline payload
+    or a file on disk, but some media carry neither and are still perfectly
+    serveable: an *archive member* streams its bytes from a byte range inside a
+    tar/zip shard we deliberately never extract (``local_archive_member``, e.g.
+    audio tiles cut from tar shards), and a *URL-backed* media fetches them
+    from ``media_url`` (e.g. the ``recaller`` importer's thin mode).  Both
+    re-resolve on demand in
+    :meth:`~vtscore.media.base.MediaType._resolve_media_bytes`, so such an
+    entry must be kept lazily rather than dropped as unresolvable.
+    """
+    from vtscore.datasets.archive_stream import archive_member_ref  # noqa: PLC0415
+
+    if archive_member_ref(media_info) is not None:
+        return True
+    return bool(media_info.get("media_url"))
+
+
 def _load_pickle_media_payload(
     media_type: str,
     media_info: dict[str, Any],
@@ -150,6 +170,19 @@ def _restore_signpost_text(media_data: dict[str, Any], media_info: dict[str, Any
             media_data[field] = value
 
 
+def _restore_media_url(media_data: dict[str, Any], media_info: dict[str, Any]) -> None:
+    """Carry a pickled ``media_url`` onto the media when one is recorded.
+
+    URL-backed media (the ``recaller`` importer) keep the remote URL as their
+    byte source; it is what lets a reloaded item still serve content when the
+    pickle holds no inline bytes and no local file.  Set only when present, so
+    the far more common file-backed media keep the shape they had before.
+    """
+    url = media_info.get("media_url")
+    if url:
+        media_data["media_url"] = url
+
+
 def _build_pickle_thin_media(
     new_id: int,
     media_info: dict[str, Any],
@@ -177,6 +210,7 @@ def _build_pickle_thin_media(
     }
     for field in extra_fields:
         media_data[field] = media_info.get(field)
+    _restore_media_url(media_data, media_info)
     cm = media_info.get("custom_metadata")
     if cm:
         media_data["custom_metadata"] = cm
@@ -213,6 +247,7 @@ def _build_pickle_full_media(
     }
     for field in extra_fields:
         media_data[field] = media_info.get(field)
+    _restore_media_url(media_data, media_info)
     cm = media_info.get("custom_metadata")
     if cm:
         media_data["custom_metadata"] = cm
@@ -267,6 +302,14 @@ def _convert_one_pickle_media(
         # reads the bytes on demand from ``media_path`` at serve/embed time.
         ref_path = _resolve_thin_media_path(media_type, media_info, data, dir_keys)
         if ref_path and Path(ref_path).exists():
+            return _build_pickle_thin_media(new_id, media_info, media_type, ref_path, extra_fields), False
+        # Bytes that live outside the pickle *and* outside the filesystem - an
+        # archive member inside an unextracted tar/zip shard, or a URL-backed
+        # media - re-resolve on demand at serve time.  Keep the entry lazy too,
+        # so an archive-member/clip dataset (whose items never have a
+        # standalone file) survives the registry save -> full-mode reopen
+        # instead of reloading as an empty dataset.
+        if _has_external_byte_source(media_info):
             return _build_pickle_thin_media(new_id, media_info, media_type, ref_path, extra_fields), False
         # A reference whose file has gone counts as missing so the load-time
         # warning fires, even when there is no companion dir for


### PR DESCRIPTION
Closes #2742

## Evaluation

The issue reproduces exactly as reported. Confirmed against a synthetic archive-member pickle:

```
thin=False: loaded 0 of 2 -> ids []
thin=True:  loaded 2 of 2 -> ids [1, 2]
```

`load_registered_dataset()` loads in full mode, and `_convert_one_pickle_media` drops any entry with no inline `media_bytes`/`media_string` and no resolvable `media_path` — the exact shape of a `local_archive_member` dataset, whose bytes only ever exist as a byte range inside a `.tar` shard. `_reg_update(..., num_items=len(ctx.medias))` then overwrites the stat with 0 and Browse 409s.

## Why not `thin=True` at the registry

The issue's suggested fix (pass `thin=True` in `load_registered_dataset()`, mirroring the CLI) does fix the repro, but it trades a hard failure for a quieter one: `_build_pickle_thin_media` discards inline `media_bytes`/`media_string` unconditionally, so any dataset whose items were saved with inline bytes and no local path would reload with nothing to serve. That's fine for the CLI (it only needs embeddings for scoring) but not for the web app, which serves the bytes. A `recaller` import is a concrete case — its media carry inline bytes with `media_path: None`.

So the fix goes where the drop happens instead, and full mode keeps its inline bytes.

## Change

`_convert_one_pickle_media` already has a fallback that keeps a media *lazily* when it has no bytes but a `media_path` that exists on disk (the reference-dataset case). This extends that fallback to bytes that live outside both the pickle and the filesystem but still re-resolve on demand in `MediaType._resolve_media_bytes`:

- **Archive members** (`local_archive_member`) — resolved via `archive_member_ref()`, which reads `origin.params` and so survives the pickle round-trip.
- **URL-backed media** (`recaller` thin mode) — resolved via `media_url`.

For the `media_url` arm to mean anything, the URL has to survive the round-trip, so `media_url` is now serialized by `export_dataset_to_file` and restored by both pickle media builders (set only when present, so file-backed media keep their existing dict shape). Without that, a thin `recaller` import was dropped on reload for the same root cause and couldn't be recovered at all.

A media with no bytes, no file, no shard and no URL is still dropped, and a `media_path` that has gone still counts as missing for the load-time warning.

## The issue's noted follow-up

The "`_build_pickle_thin_media` discards inline bytes" follow-up is moot for the Dashboard path now, since the registry reload stays in full mode. It remains true of thin mode itself, which is by design — thin exists to avoid pulling payloads into RAM.

## Separate bug found while verifying

Filed as #2747: top-level `clip_start`/`clip_end`/`clip_index`/`clip_box` are not serialized at all, so a windowed archive-member item reloads without its playback window (every window of a tar member plays the whole member from 0), and clipped media lose their "Clip Start"/"Clip End" metadata rows. It predates this change and affects clipped datasets of every type, so it's left out of this PR.

## Tests

- `tests_lib/datasets/test_thin_loading.py::TestFullModeExternalByteSource` — full mode keeps an archive-member media and a URL-backed media, still drops a media with no source, and `media_url` survives an export round-trip.
- `tests/datasets/test_registry_reload_archive_member.py` — end-to-end: `POST /api/datasets/registry/<id>/load` on an archive-member dataset keeps all 3 items and leaves `num_items` at 3.

All four new assertions fail without the fix (`assert 0 == 3`) and pass with it. Full `./run-tests.sh`: **6853 passed, 1 skipped, 2 xpassed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013F4NyDMmnyibE31FJS23GN

---
_Generated by [Claude Code](https://claude.ai/code/session_013F4NyDMmnyibE31FJS23GN)_