### PR TITLE
Add the first four MediaCleaners: edge trim, silence trim, text cleanup

### DIFF
--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -739,6 +739,18 @@ entry.
 | Cleaner | Name | Media Type | Default | Description |
 |---------|------|------------|---------|-------------|
 | `ImageExifOrientCleaner` | `image_exif_orient` | `image` | **on** | Bake a photo's EXIF display orientation into its pixels so the embedder sees it upright |
+| `ImageEdgeTrimCleaner` | `image_edge_trim` | `image` | off | Crop near-solid white/black margins (letterbox, pillarbox, whitespace around a logo) |
+| `AudioSilenceTrimCleaner` | `audio_silence_trim` | `audio` | off | Drop the silence at the head and tail of a clip, keeping internal pauses |
+| `TextMarkupStripCleaner` | `text_markup_strip` | `text` | off | Remove HTML tags and Markdown syntax, keeping the text inside |
+| `TextWhitespaceCleaner` | `text_whitespace` | `text` | off | Collapse whitespace runs, drop control characters, rejoin hyphen-broken words |
+
+Two of these share their detector with another caller rather than owning a
+second copy of the heuristic: `image_edge_trim` and the grid thumbnail both call
+`vtscore/media/image/edge_trim.py`, and `audio_silence_trim` and
+`SoundSilenceClipper` both call `vtscore/media/audio/silence.py`. When a cleaner
+answers a question something else in the codebase already answers, extract the
+detector; a cleaner that disagrees with the thumbnail about where the content
+starts is worse than no cleaner.
 
 ### What to implement
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -122,7 +122,10 @@ type can pass through before it is embedded (see
 [EXTENDING-media.md § Adding a Media Cleaner](../EXTENDING-media.md#adding-a-media-cleaner)).
 They are listed separately from clippers because the UI treats them
 differently: a clipper is a radio choice, cleaners are a checkbox list where
-any combination can be enabled.
+any combination can be enabled. An entry may also carry `parameters` (same
+descriptor shape as a clipper's); the import form renders those inputs beneath
+the cleaner's checkbox once it is ticked, and the chosen values ride along in
+the `cleaners` field's per-entry `params`.
 
 Each cleaner object carries the same fields as a clipper (`name`,
 `display_name`, `media_type`, optional `description` / `parameters` /

--- a/docs/plans/media-cleaners.md
+++ b/docs/plans/media-cleaners.md
@@ -26,33 +26,6 @@ still bear on the open work:
 
 <!-- item-sep -->
 
-- **Image: solid-border trim** — crop near-solid white/black margins
-  (letterbox, pillarbox, whitespace around logos). Promote
-  `_trim_solid_edges` out of `thumbnail.py` into shared code with one
-  implementation and two callers; the tuned caps (`_EDGE_TOL`,
-  `_MAX_EDGE_TRIM`, `_MIN_EDGE_TRIM`) carry over as parameters.
-
-<!-- item-sep -->
-
-- **Audio: leading/trailing silence trim** — keep
-  `[first_start, last_end]` of the non-silent intervals detected by the
-  `SoundSilenceClipper._detect_segments` machinery (share it, don't copy).
-  Same `top_db` / `pad` parameters. Redundant-but-harmless when combined
-  with the silence clipper itself.
-
-<!-- item-sep -->
-
-- **Text: whitespace + de-hyphenation cleanup** — collapse whitespace
-  runs, strip control characters, re-join words hyphen-broken across line
-  breaks. Highest value on `document2text` output (PDF extraction junk).
-
-<!-- item-sep -->
-
-- **Text: markup strip** — remove HTML tags / markdown syntax so the
-  embedder sees prose, not angle brackets.
-
-<!-- item-sep -->
-
 - **Video: letterbox bar crop** — run the edge-trim analysis on a few
   sampled frames and crop the consensus box from all frames.
 

--- a/tests/api/test_cleaner_routes.py
+++ b/tests/api/test_cleaner_routes.py
@@ -111,9 +111,20 @@ class TestCleanersApiEndpoint:
         assert all(c["media_type"] == "image" for c in cleaners)
 
     def test_filter_with_no_registered_cleaners_is_empty(self, client):
-        resp = client.get("/api/cleaners?media_type=audio")
+        # A type nobody has written a cleaner for filters down to nothing rather
+        # than falling back to the unfiltered list.  Deliberately not a real
+        # media type: the roster in ``docs/plans/media-cleaners.md`` eventually
+        # gives every shipped type at least one gate.
+        resp = client.get("/api/cleaners?media_type=no_such_media_type")
         assert resp.status_code == 200
         assert resp.get_json()["cleaners"] == []
+
+    def test_filter_by_audio_lists_the_silence_trim_gate(self, client):
+        resp = client.get("/api/cleaners?media_type=audio")
+        assert resp.status_code == 200
+        cleaners = resp.get_json()["cleaners"]
+        assert [c["name"] for c in cleaners] == ["audio_silence_trim"]
+        assert all(c["media_type"] == "audio" for c in cleaners)
 
     def test_exif_cleaner_defaults_on(self, client):
         resp = client.get("/api/cleaners?media_type=image")

--- a/tests_lib/core/test_image_thumbnail.py
+++ b/tests_lib/core/test_image_thumbnail.py
@@ -11,9 +11,9 @@ import io
 
 from PIL import Image
 
+from vtscore.media.image.edge_trim import trim_solid_edges
 from vtscore.media.image.thumbnail import (
     DEFAULT_MAX_DIM,
-    _trim_solid_edges,
     make_image_thumbnail,
     normalize_region_crop,
 )
@@ -106,45 +106,45 @@ class TestTrimSolidEdges:
     def test_trims_black_letterbox_top_and_bottom(self):
         # 100px black bars top & bottom, red content in the middle 200px.
         img = self._content_box(400, 400, (0, 100, 400, 300), (0, 0, 0), (200, 30, 30))
-        out = _trim_solid_edges(img)
+        out = trim_solid_edges(img)
         assert out.size[0] == 400  # full width kept (no side bars)
         assert abs(out.size[1] - 200) <= 6  # ~top/bottom bars removed
 
     def test_trims_white_pillarbox_left_and_right(self):
         # 100px white bars left & right, content in the middle 200px column.
         img = self._content_box(400, 400, (100, 0, 300, 400), (255, 255, 255), (40, 90, 160))
-        out = _trim_solid_edges(img)
+        out = trim_solid_edges(img)
         assert out.size[1] == 400  # full height kept (no top/bottom bars)
         assert abs(out.size[0] - 200) <= 6
 
     def test_trims_a_single_padded_edge_independently(self):
         # White margin only on the left; the other three edges are content.
         img = self._content_box(400, 200, (120, 0, 400, 200), (255, 255, 255), (10, 120, 40))
-        out = _trim_solid_edges(img)
+        out = trim_solid_edges(img)
         assert out.size[1] == 200  # top/bottom untouched
         assert abs(out.size[0] - 280) <= 6  # only the ~120px left bar removed
 
     def test_leaves_a_content_filled_frame_unchanged(self):
         img = Image.new("RGB", (300, 200), color=(120, 60, 180))
-        out = _trim_solid_edges(img)
+        out = trim_solid_edges(img)
         assert out.size == (300, 200)
 
     def test_leaves_a_wholly_solid_frame_unchanged(self):
         # Nothing but solid tone — no content to pull the box toward.
-        assert _trim_solid_edges(Image.new("RGB", (300, 200), (255, 255, 255))).size == (300, 200)
-        assert _trim_solid_edges(Image.new("RGB", (300, 200), (0, 0, 0))).size == (300, 200)
+        assert trim_solid_edges(Image.new("RGB", (300, 200), (255, 255, 255))).size == (300, 200)
+        assert trim_solid_edges(Image.new("RGB", (300, 200), (0, 0, 0))).size == (300, 200)
 
     def test_caps_trim_so_a_tiny_subject_does_not_explode(self):
         # A 10px dot centred in a 400px white field: an uncapped trim would crop
         # to ~10px, but the per-edge cap keeps the middle 10% each way (40px).
         img = self._content_box(400, 400, (195, 195, 205, 205), (255, 255, 255), (200, 0, 0))
-        out = _trim_solid_edges(img)
+        out = trim_solid_edges(img)
         assert out.size == (40, 40)
 
     def test_does_not_trim_a_solid_coloured_border(self):
         # A saturated (non white/black) border is content, not padding.
         img = self._content_box(400, 200, (100, 0, 300, 200), (0, 200, 0), (0, 0, 200))
-        assert _trim_solid_edges(img).size == (400, 200)
+        assert trim_solid_edges(img).size == (400, 200)
 
 
 class TestMakeImageThumbnailTrim:

--- a/tests_lib/detectors/test_cleaner_roster.py
+++ b/tests_lib/detectors/test_cleaner_roster.py
@@ -1,0 +1,475 @@
+"""Tests for the shipped roster of :class:`~vtscore.media.cleaner.MediaCleaner`s.
+
+The framework itself (registry, chain placement, dual payload, replay) is
+covered by ``test_media_cleaners.py``; this file exercises what each concrete
+gate actually does to a payload.  Every cleaner shares one contract, so every
+class below checks the same three things:
+
+- it removes what it claims to remove,
+- it returns the media object **itself** when there is nothing to remove (that
+  identity is what tells the chain runner to skip the ``original_*`` snapshot),
+- a degenerate or undecodable payload is a no-op, never an error.
+
+Covered: ``image_edge_trim``, ``audio_silence_trim``, ``text_whitespace``,
+``text_markup_strip``.
+"""
+
+from __future__ import annotations
+
+import io
+import wave
+
+import pytest
+from PIL import Image
+from vtscore.media import get_cleaner
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _encode(img: Image.Image, fmt: str = "PNG") -> bytes:
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def _padded(w: int, h: int, box: tuple[int, int, int, int], bg, fg) -> Image.Image:
+    """A *bg*-filled frame with an *fg* rectangle painted at *box*."""
+    img = Image.new("RGB", (w, h), color=bg)
+    x0, y0, x1, y1 = box
+    img.paste(Image.new("RGB", (x1 - x0, y1 - y0), color=fg), (x0, y0))
+    return img
+
+
+def _image_media(img: Image.Image, fmt: str = "PNG") -> dict:
+    data = _encode(img, fmt)
+    return {
+        "id": 1,
+        "media_type": "image",
+        "media_bytes": data,
+        "width": img.size[0],
+        "height": img.size[1],
+        "file_size": len(data),
+    }
+
+
+def _concat_wavs(*wavs: bytes) -> bytes:
+    """Concatenate WAV byte strings sharing a sample rate/width/channel count."""
+    frames: list[bytes] = []
+    params = None
+    for wb in wavs:
+        with wave.open(io.BytesIO(wb), "rb") as wf:
+            if params is None:
+                params = wf.getparams()
+            frames.append(wf.readframes(wf.getnframes()))
+    assert params is not None
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as out:
+        out.setparams(params)
+        out.writeframes(b"".join(frames))
+    return buf.getvalue()
+
+
+def _tone(duration: float, frequency: float = 440.0) -> bytes:
+    from vtscore.media.audio.audio_generator import generate_wav
+
+    return generate_wav(frequency, duration)
+
+
+def _audio_media(wav: bytes, duration: float) -> dict:
+    return {
+        "id": 1,
+        "media_type": "audio",
+        "media_bytes": wav,
+        "duration": duration,
+        "file_size": len(wav),
+    }
+
+
+def _text_media(text: str) -> dict:
+    return {
+        "id": 1,
+        "media_type": "text",
+        "media_string": text,
+        "word_count": len(text.split()),
+        "character_count": len(text),
+        "file_size": len(text.encode("utf-8")),
+    }
+
+
+def _wav_duration(wav: bytes) -> float:
+    with wave.open(io.BytesIO(wav), "rb") as wf:
+        return wf.getnframes() / wf.getframerate()
+
+
+# ---------------------------------------------------------------------------
+# image_edge_trim
+# ---------------------------------------------------------------------------
+
+
+class TestImageEdgeTrimCleaner:
+    def test_identity(self):
+        cleaner = get_cleaner("image_edge_trim")
+        assert cleaner.media_type == "image"
+        assert cleaner.display_name == "Edge Trim"
+        # Cropping is a judgment call about what counts as padding, so the box
+        # is unchecked until the user asks for it.
+        assert cleaner.default_enabled is False
+
+    def test_crops_black_letterbox_bars(self):
+        # 100 px black bars top and bottom, red content across the middle 200 px.
+        media = _image_media(_padded(400, 400, (0, 100, 400, 300), (0, 0, 0), (200, 30, 30)))
+        out = get_cleaner("image_edge_trim").clean(media)
+
+        assert out is not media
+        assert out["width"] == 400  # no side bars to lose
+        assert abs(out["height"] - 200) <= 6
+        assert out["file_size"] == len(out["media_bytes"])
+        with Image.open(io.BytesIO(out["media_bytes"])) as img:
+            assert img.size == (out["width"], out["height"])
+
+    def test_crops_a_single_padded_edge(self):
+        # White margin only on the left; the other three edges are content.
+        media = _image_media(_padded(400, 200, (120, 0, 400, 200), (255, 255, 255), (10, 120, 40)))
+        out = get_cleaner("image_edge_trim").clean(media)
+
+        assert out["height"] == 200
+        assert abs(out["width"] - 280) <= 6
+
+    def test_content_filled_frame_is_a_no_op(self):
+        media = _image_media(Image.new("RGB", (300, 200), (120, 60, 180)), fmt="JPEG")
+        # The *same* dict back: an unchanged item must not be re-encoded, or
+        # every JPEG in the dataset would pay a generation loss and a snapshot.
+        assert get_cleaner("image_edge_trim").clean(media) is media
+
+    def test_wholly_solid_frame_is_a_no_op(self):
+        cleaner = get_cleaner("image_edge_trim")
+        for tone in ((255, 255, 255), (0, 0, 0)):
+            media = _image_media(Image.new("RGB", (300, 200), tone))
+            assert cleaner.clean(media) is media
+
+    def test_saturated_border_is_content_not_padding(self):
+        media = _image_media(_padded(400, 200, (100, 0, 300, 200), (0, 200, 0), (0, 0, 200)))
+        assert get_cleaner("image_edge_trim").clean(media) is media
+
+    def test_trim_is_capped_so_a_tiny_subject_cannot_explode(self):
+        # A 10 px dot centred in a 400 px white field: uncapped this would crop
+        # to ~10 px; the per-side cap keeps the middle 10% each way.
+        media = _image_media(_padded(400, 400, (195, 195, 205, 205), (255, 255, 255), (200, 0, 0)))
+        out = get_cleaner("image_edge_trim").clean(media)
+        assert (out["width"], out["height"]) == (40, 40)
+
+    def test_undecodable_and_empty_payloads_are_no_ops(self):
+        cleaner = get_cleaner("image_edge_trim")
+        for media in (
+            {"media_type": "image", "media_bytes": b"<svg/>"},
+            {"media_type": "image", "media_bytes": b""},
+            {"media_type": "image"},
+        ):
+            assert cleaner.clean(media) is media
+
+    def test_params_override_the_thresholds(self):
+        from vtscore.media.image.cleaner import ImageEdgeTrimCleaner
+
+        cleaner = get_cleaner("image_edge_trim")
+        assert isinstance(cleaner, ImageEdgeTrimCleaner)
+        assert [p["key"] for p in cleaner.parameters] == ["edge_tol", "max_edge_trim", "min_edge_trim"]
+
+        tighter = cleaner.with_params({"max_edge_trim": 0.1})
+        assert tighter is not cleaner
+        assert tighter.max_edge_trim == 0.1
+        assert tighter.edge_tol == cleaner.edge_tol  # unnamed params carry over
+
+        # The same tiny-dot frame: a 0.1 cap leaves 80% of each axis standing.
+        media = _image_media(_padded(400, 400, (195, 195, 205, 205), (255, 255, 255), (200, 0, 0)))
+        out = tighter.clean(media)
+        assert (out["width"], out["height"]) == (320, 320)
+
+    def test_a_margin_thinner_than_min_edge_trim_is_left_alone(self):
+        # A 4 px white margin on a 400 px frame is 1%, under the 2% floor.
+        media = _image_media(_padded(400, 400, (4, 4, 396, 396), (255, 255, 255), (30, 30, 200)))
+        assert get_cleaner("image_edge_trim").clean(media) is media
+
+    def test_crop_preserves_an_unbaked_exif_orientation(self):
+        """Trimming must not silently un-rotate a photo.
+
+        ``image_edge_trim`` can run with ``image_exif_orient`` switched off, in
+        which case the payload still carries an orientation tag that viewers
+        honour.  Dropping it during the re-encode would leave the trimmed copy
+        displayed sideways.
+        """
+        img = _padded(400, 400, (0, 100, 400, 300), (0, 0, 0), (200, 30, 30))
+        exif = Image.Exif()
+        exif[274] = 6
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", exif=exif)
+        media = {"media_type": "image", "media_bytes": buf.getvalue(), "width": 400, "height": 400}
+
+        out = get_cleaner("image_edge_trim").clean(media)
+        assert out is not media
+        with Image.open(io.BytesIO(out["media_bytes"])) as trimmed:
+            assert trimmed.getexif().get(274) == 6
+
+
+class TestEdgeTrimIsSharedWithThumbnails:
+    def test_one_detector_backs_both_callers(self):
+        """The cleaner and the thumbnail agree on where the content starts."""
+        from vtscore.media.image.edge_trim import solid_edge_box, trim_solid_edges
+
+        img = _padded(400, 400, (0, 100, 400, 300), (0, 0, 0), (200, 30, 30))
+        box = solid_edge_box(img)
+        assert box is not None
+        assert trim_solid_edges(img).size == (box[2] - box[0], box[3] - box[1])
+
+        media = _image_media(img)
+        out = get_cleaner("image_edge_trim").clean(media)
+        assert (out["width"], out["height"]) == (box[2] - box[0], box[3] - box[1])
+
+
+# ---------------------------------------------------------------------------
+# audio_silence_trim
+# ---------------------------------------------------------------------------
+
+
+class TestAudioSilenceTrimCleaner:
+    def test_identity(self):
+        from vtscore.media.audio.cleaner import AudioSilenceTrimCleaner
+
+        cleaner = get_cleaner("audio_silence_trim")
+        assert isinstance(cleaner, AudioSilenceTrimCleaner)
+        assert cleaner.media_type == "audio"
+        assert cleaner.display_name == "Silence Trim"
+        assert cleaner.default_enabled is False
+        assert cleaner.top_db == 40.0
+        assert cleaner.pad == 0.05
+
+    def test_rejects_invalid_construction(self):
+        from vtscore.media.audio.cleaner import AudioSilenceTrimCleaner
+
+        with pytest.raises(ValueError):
+            AudioSilenceTrimCleaner(top_db=0)
+        with pytest.raises(ValueError):
+            AudioSilenceTrimCleaner(pad=-0.1)
+
+    def test_trims_lead_in_and_tail(self):
+        wav = _concat_wavs(_tone(0.7, 0), _tone(1.0), _tone(0.7, 0))
+        media = _audio_media(wav, 2.4)
+        out = get_cleaner("audio_silence_trim").clean(media)
+
+        assert out is not media
+        assert out["duration"] == pytest.approx(1.1, abs=0.2)
+        assert out["file_size"] == len(out["media_bytes"])
+        assert _wav_duration(out["media_bytes"]) == pytest.approx(out["duration"], abs=0.01)
+
+    def test_keeps_the_pause_in_the_middle(self):
+        """Internal silence is content (rhythm); only the ends are wasted."""
+        wav = _concat_wavs(_tone(0.7, 0), _tone(0.5), _tone(1.0, 0), _tone(0.5), _tone(0.7, 0))
+        out = get_cleaner("audio_silence_trim").clean(_audio_media(wav, 3.4))
+
+        # ~2.0 s of audible span (0.5 + 1.0 gap + 0.5) survives, not 1.0 s.
+        assert out["duration"] == pytest.approx(2.1, abs=0.25)
+
+    def test_pure_tone_is_a_no_op(self):
+        media = _audio_media(_tone(1.0), 1.0)
+        assert get_cleaner("audio_silence_trim").clean(media) is media
+
+    def test_pure_silence_is_a_no_op(self):
+        # No audible content to anchor a span: leave the clip alone rather than
+        # trim it to nothing.
+        media = _audio_media(_tone(1.0, 0), 1.0)
+        assert get_cleaner("audio_silence_trim").clean(media) is media
+
+    def test_negligible_trim_is_a_no_op(self):
+        # 30 ms of silence at each end is under the trim floor; re-encoding to
+        # shave it would cost a full ``original_*`` snapshot for nothing.
+        wav = _concat_wavs(_tone(0.03, 0), _tone(1.0), _tone(0.03, 0))
+        media = _audio_media(wav, 1.06)
+        assert get_cleaner("audio_silence_trim").clean(media) is media
+
+    def test_undecodable_and_empty_payloads_are_no_ops(self):
+        cleaner = get_cleaner("audio_silence_trim")
+        for media in (
+            {"media_type": "audio", "media_bytes": b"not a wav"},
+            {"media_type": "audio", "media_bytes": b""},
+            {"media_type": "audio", "duration": 3.0},
+        ):
+            assert cleaner.clean(media) is media
+
+    def test_params_override_the_thresholds(self):
+        from vtscore.media.audio.cleaner import AudioSilenceTrimCleaner
+
+        cleaner = get_cleaner("audio_silence_trim")
+        assert isinstance(cleaner, AudioSilenceTrimCleaner)
+        assert [p["key"] for p in cleaner.parameters] == ["top_db", "pad"]
+
+        padded = cleaner.with_params({"pad": 0.4})
+        assert padded is not cleaner
+        assert (padded.pad, padded.top_db) == (0.4, cleaner.top_db)
+
+        wav = _concat_wavs(_tone(0.7, 0), _tone(1.0), _tone(0.7, 0))
+        tight = cleaner.clean(_audio_media(wav, 2.4))["duration"]
+        loose = padded.clean(_audio_media(wav, 2.4))["duration"]
+        assert loose > tight  # more padding kept => a longer surviving span
+
+    def test_shares_the_detector_with_the_silence_clipper(self):
+        """One detector, two policies: N clips vs one trimmed span."""
+        from vtscore.media.audio.clipper import SoundSilenceClipper
+        from vtscore.media.audio.silence import detect_nonsilent_segments
+
+        wav = _concat_wavs(_tone(0.7, 0), _tone(0.5), _tone(1.0, 0), _tone(0.5), _tone(0.7, 0))
+        segments = detect_nonsilent_segments(wav, top_db=40.0, pad=0.05)
+        assert segments is not None and len(segments) == 2
+
+        clips = SoundSilenceClipper(top_db=40.0, min_clip_duration=0.0, pad=0.05).clip(_audio_media(wav, 3.4))
+        assert len(clips) == 2  # the clipper emits one clip per segment...
+
+        trimmed = get_cleaner("audio_silence_trim").clean(_audio_media(wav, 3.4))
+        # ...while the cleaner keeps the single span that covers both.
+        assert trimmed["duration"] == pytest.approx(segments[-1][1] - segments[0][0], abs=0.01)
+
+
+class TestCleanedAudioWaveform:
+    def test_waveform_is_not_re_sliced_for_materialized_bytes(self):
+        """A trimmed clip's waveform must render its own bytes, whole.
+
+        The cleaner drops ``thumbnail_bytes`` (the old one describes the
+        pre-clean payload), so the waveform is regenerated on demand.  The
+        item's ``clip_start`` / ``clip_end`` are relative to the *source* file,
+        so applying them to the already-trimmed bytes would render the wrong
+        stretch of audio.
+        """
+        from vtscore.media import get as get_media_type
+
+        wav = _concat_wavs(_tone(0.7, 0), _tone(1.0), _tone(0.7, 0))
+        trimmed = get_cleaner("audio_silence_trim").clean(_audio_media(wav, 2.4))
+        trimmed.pop("thumbnail_bytes", None)
+        # A window from the parent clipper that no longer describes these bytes.
+        trimmed["clip_start"], trimmed["clip_end"] = 8.0, 10.4
+
+        audio_type = get_media_type("audio")
+        windowed = audio_type.ensure_thumbnail_bytes(dict(trimmed))
+        bare = {k: v for k, v in trimmed.items() if k not in ("clip_start", "clip_end")}
+        assert windowed is not None
+        assert windowed == audio_type.ensure_thumbnail_bytes(bare)
+
+
+# ---------------------------------------------------------------------------
+# text_whitespace
+# ---------------------------------------------------------------------------
+
+
+class TestTextWhitespaceCleaner:
+    def test_identity(self):
+        cleaner = get_cleaner("text_whitespace")
+        assert cleaner.media_type == "text"
+        assert cleaner.default_enabled is False
+
+    def test_rejoins_a_word_hyphen_broken_across_lines(self):
+        media = _text_media("the repre-\nsentation of data")
+        out = get_cleaner("text_whitespace").clean(media)
+        assert out["media_string"] == "the representation of data"
+        assert out["word_count"] == 4
+        assert out["character_count"] == len(out["media_string"])
+        assert out["file_size"] == len(out["media_string"].encode("utf-8"))
+
+    def test_keeps_a_genuine_hyphenated_compound(self):
+        # No line break after the hyphen, so it is a real compound word.
+        media = _text_media("a state-of-the-art result")
+        assert get_cleaner("text_whitespace").clean(media) is media
+
+    def test_collapses_horizontal_runs_and_blank_lines(self):
+        media = _text_media("one   two\t\tthree\n\n\n\nfour   \n")
+        out = get_cleaner("text_whitespace").clean(media)
+        assert out["media_string"] == "one two three\n\nfour"
+
+    def test_normalises_line_endings_and_exotic_spaces(self):
+        media = _text_media("a\r\nb c d　e")
+        out = get_cleaner("text_whitespace").clean(media)
+        assert out["media_string"] == "a\nb\nc d e"
+
+    def test_strips_control_and_zero_width_characters(self):
+        media = _text_media("clean​word\x07 and­more")
+        out = get_cleaner("text_whitespace").clean(media)
+        assert out["media_string"] == "cleanword andmore"
+
+    def test_already_clean_text_is_a_no_op(self):
+        media = _text_media("A tidy paragraph.\n\nAnd a second one.")
+        assert get_cleaner("text_whitespace").clean(media) is media
+
+    def test_paragraph_breaks_survive(self):
+        media = _text_media("First para.\n\nSecond para.")
+        assert get_cleaner("text_whitespace").clean(media) is media
+
+    def test_empty_and_non_text_payloads_are_no_ops(self):
+        cleaner = get_cleaner("text_whitespace")
+        for media in ({"media_type": "text", "media_string": ""}, {"media_type": "text"}):
+            assert cleaner.clean(media) is media
+
+
+# ---------------------------------------------------------------------------
+# text_markup_strip
+# ---------------------------------------------------------------------------
+
+
+class TestTextMarkupStripCleaner:
+    def test_identity(self):
+        cleaner = get_cleaner("text_markup_strip")
+        assert cleaner.media_type == "text"
+        assert cleaner.display_name == "Markup Strip"
+        assert cleaner.default_enabled is False
+
+    def test_strips_html_tags_and_unescapes_entities(self):
+        media = _text_media("<p>Hello <b>world</b> &amp; friends.</p>")
+        out = get_cleaner("text_markup_strip").clean(media)
+        assert out["media_string"] == "Hello world & friends."
+
+    def test_drops_script_and_style_bodies(self):
+        media = _text_media("<style>.a{color:red}</style>Keep me<script>var x = 1;</script>")
+        out = get_cleaner("text_markup_strip").clean(media)
+        assert out["media_string"] == "Keep me"
+
+    def test_drops_html_comments(self):
+        media = _text_media("before<!-- nav chrome -->after")
+        assert get_cleaner("text_markup_strip").clean(media)["media_string"] == "beforeafter"
+
+    def test_block_tags_keep_words_apart(self):
+        media = _text_media("<div>alpha</div><div>beta</div>")
+        out = get_cleaner("text_markup_strip").clean(media)
+        assert "alphabeta" not in out["media_string"]
+        assert out["media_string"].split() == ["alpha", "beta"]
+
+    def test_collapses_markdown_links_and_images_to_their_labels(self):
+        media = _text_media("see [the docs](http://x.y/a?b=1) and ![a cat](cat.png)")
+        out = get_cleaner("text_markup_strip").clean(media)
+        assert out["media_string"] == "see the docs and a cat"
+
+    def test_strips_headings_bullets_quotes_and_emphasis(self):
+        media = _text_media("## Title\n\n- a **bold** point\n- an _italic_ one\n\n> quoted\n\n---\n")
+        out = get_cleaner("text_markup_strip").clean(media)
+        assert out["media_string"] == "Title\n\na bold point\nan italic one\n\nquoted"
+
+    def test_leaves_snake_case_identifiers_alone(self):
+        media = _text_media("call load_media_bytes then media_string")
+        assert get_cleaner("text_markup_strip").clean(media) is media
+
+    def test_leaves_comparison_operators_alone(self):
+        # Not a tag: no element name follows the "<".
+        media = _text_media("holds when a < b and b > c")
+        assert get_cleaner("text_markup_strip").clean(media) is media
+
+    def test_plain_prose_is_a_no_op(self):
+        media = _text_media("An ordinary sentence, with punctuation.")
+        assert get_cleaner("text_markup_strip").clean(media) is media
+
+    def test_empty_and_non_text_payloads_are_no_ops(self):
+        cleaner = get_cleaner("text_markup_strip")
+        for media in ({"media_type": "text", "media_string": ""}, {"media_type": "text"}):
+            assert cleaner.clean(media) is media
+
+    def test_runs_before_whitespace_in_registration_order(self):
+        """The strip leaves gaps; the whitespace gate mops them up afterwards."""
+        from vtscore.media import cleaners_for_type
+
+        order = [c.name for c in cleaners_for_type("text")]
+        assert order.index("text_markup_strip") < order.index("text_whitespace")

--- a/tests_lib/detectors/test_media_cleaners.py
+++ b/tests_lib/detectors/test_media_cleaners.py
@@ -154,8 +154,13 @@ class TestCleanerRegistry:
     def test_cleaners_for_type_filters(self, registered_cleaners):
         from vtscore.media import cleaners_for_type
 
-        assert [c.name for c in cleaners_for_type("image")] == ["image_exif_orient"]
-        assert [c.name for c in cleaners_for_type("text")] == ["text_test_upper", "text_test_suffix"]
+        assert [c.name for c in cleaners_for_type("image")] == ["image_exif_orient", "image_edge_trim"]
+        assert [c.name for c in cleaners_for_type("text")] == [
+            "text_markup_strip",
+            "text_whitespace",
+            "text_test_upper",
+            "text_test_suffix",
+        ]
 
     def test_to_dict_carries_default_enabled(self, registered_cleaners):
         from vtscore.media import get_cleaner

--- a/vtscore/media/audio/__init__.py
+++ b/vtscore/media/audio/__init__.py
@@ -1,3 +1,4 @@
+from vtscore.media.audio.cleaner import AudioSilenceTrimCleaner
 from vtscore.media.audio.clipper import (
     SoundDefaultClipper,
     SoundSilenceClipper,
@@ -13,3 +14,4 @@ CLIPPERS = [
     SoundSilenceClipper(),
     SoundSpeechActivityClipper(),
 ]
+CLEANERS = [AudioSilenceTrimCleaner()]

--- a/vtscore/media/audio/cleaner.py
+++ b/vtscore/media/audio/cleaner.py
@@ -1,0 +1,157 @@
+"""Audio cleaners - 1→1 cleanup gates run on each clip before embedding."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from vtscore.media.cleaner import MediaCleaner
+
+log = logging.getLogger(__name__)
+
+#: Don't rewrite the payload for a trim this small (seconds, summed over both
+#: ends).  Re-encoding a clip to shave a few milliseconds costs a second copy of
+#: its bytes (the ``original_*`` snapshot) and buys the embedder nothing.
+_MIN_TRIM_SECONDS = 0.1
+
+
+class AudioSilenceTrimCleaner(MediaCleaner):
+    """Drop the leading and trailing silence from a clip.
+
+    A recording that opens with two seconds of room tone and ends with a
+    three-second tail spends a large fraction of the embedder's fixed-length
+    window on nothing.  This gate keeps the single span
+    ``[first_start, last_end]`` of the audible material and discards only what
+    lies outside it - internal pauses are left exactly as they are, because they
+    are part of the content's rhythm.
+
+    Silence detection is the same machinery
+    (:func:`~vtscore.media.audio.silence.detect_nonsilent_segments`) that backs
+    :class:`~vtscore.media.audio.clipper.SoundSilenceClipper`, so the two agree
+    on what counts as quiet.  Running both is harmless: the clipper's output
+    already starts and ends on audible content, so this gate no-ops on it.
+
+    Parameters mirror the clipper's:
+
+    top_db:
+        Audio quieter than this many dB below the clip's reference level counts
+        as silence.  Defaults to 40.0.
+    pad:
+        Seconds of the surrounding silence kept on each side, so an attack or
+        decay isn't clipped.  Defaults to 0.05.
+    """
+
+    def __init__(self, top_db: float = 40.0, pad: float = 0.05) -> None:
+        if top_db <= 0:
+            raise ValueError("top_db must be positive")
+        if pad < 0:
+            raise ValueError("pad must be non-negative")
+        self._top_db = top_db
+        self._pad = pad
+
+    @property
+    def name(self) -> str:
+        return "audio_silence_trim"
+
+    @property
+    def media_type(self) -> str:
+        return "audio"
+
+    @property
+    def display_name(self) -> str:
+        return "Silence Trim"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Trim the silence off the head and tail of each clip so the embedder's window is spent "
+            "on audible content. Internal pauses are kept."
+        )
+
+    @property
+    def summary_template(self) -> str:
+        return "Trim head/tail audio quieter than {top_db}dB, keeping {pad}s of padding."
+
+    @property
+    def top_db(self) -> float:
+        return self._top_db
+
+    @property
+    def pad(self) -> float:
+        return self._pad
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "top_db",
+                "label": "Silence threshold (dB)",
+                "description": (
+                    "Audio quieter than this many dB below the reference is treated as silence. "
+                    "Lower values are more aggressive - more gets trimmed."
+                ),
+                "type": "number",
+                "default": self._top_db,
+                "min": 5,
+                "max": 80,
+                "step": 1,
+            },
+            {
+                "key": "pad",
+                "label": "Padding (seconds)",
+                "description": "Silence kept on each side of the audible span so attack/decay isn't trimmed.",
+                "type": "number",
+                "default": self._pad,
+                "min": 0,
+                "max": 5,
+                "step": 0.05,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "AudioSilenceTrimCleaner":
+        return AudioSilenceTrimCleaner(
+            top_db=float(params.get("top_db", self._top_db)),
+            pad=float(params.get("pad", self._pad)),
+        )
+
+    def clean(self, media: dict[str, Any]) -> dict[str, Any]:
+        """Return *media* with its head/tail silence removed, or unchanged.
+
+        Unchanged when there are no bytes, the audio can't be decoded or sliced,
+        no silence structure is detectable (a clip that is uniformly loud, or
+        uniformly silent), or the two ends together account for less than
+        :data:`_MIN_TRIM_SECONDS`.
+        """
+        from vtscore.media.audio.clipper import _wav_duration, _wav_slice  # noqa: PLC0415
+        from vtscore.media.audio.silence import detect_nonsilent_segments  # noqa: PLC0415
+
+        payload = media.get("media_bytes")
+        if not isinstance(payload, (bytes, bytearray)) or not payload:
+            return media
+        media_bytes = bytes(payload)
+
+        segments = detect_nonsilent_segments(media_bytes, top_db=self._top_db, pad=self._pad)
+        if not segments:
+            return media
+
+        t0, t1 = segments[0][0], segments[-1][1]
+        if t1 <= t0:
+            return media
+
+        try:
+            total = _wav_duration(media_bytes)
+            if t0 < _MIN_TRIM_SECONDS and (total - t1) < _MIN_TRIM_SECONDS:
+                return media  # nothing meaningful at either end
+            trimmed = _wav_slice(media_bytes, t0, t1)
+        except Exception:
+            log.debug("audio_silence_trim: undecodable payload, leaving unchanged", exc_info=True)
+            return media
+
+        if not trimmed:
+            return media
+
+        cleaned = dict(media)
+        cleaned["media_bytes"] = trimmed
+        cleaned["file_size"] = len(trimmed)
+        cleaned["duration"] = round(t1 - t0, 6)
+        return cleaned

--- a/vtscore/media/audio/clipper.py
+++ b/vtscore/media/audio/clipper.py
@@ -310,48 +310,18 @@ class SoundSilenceClipper(MediaClipper):
     def _detect_segments(self, media_bytes: bytes) -> list[tuple[float, float]] | None:
         """Detect non-silent ``(start, end)`` ranges (seconds) in *media_bytes*.
 
-        Returns ``None`` if the audio cannot be decoded or librosa is
-        unavailable.  Returns an empty list if no intervals survive the
-        ``min_clip_duration`` filter.
+        Thin wrapper over :func:`~vtscore.media.audio.silence.detect_nonsilent_segments`
+        that supplies this clipper's thresholds; the detector is shared with
+        :class:`~vtscore.media.audio.cleaner.AudioSilenceTrimCleaner`.
         """
-        try:
-            import librosa  # noqa: PLC0415
+        from vtscore.media.audio.silence import detect_nonsilent_segments  # noqa: PLC0415
 
-            from vtscore.media.audio.decode import decode_audio  # noqa: PLC0415
-        except ImportError:
-            return None
-
-        try:
-            audio_data, sr = decode_audio(media_bytes, sr=None, mono=True)
-        except Exception:
-            return None
-
-        if audio_data.size == 0 or sr <= 0:
-            return None
-
-        try:
-            intervals = librosa.effects.split(audio_data, top_db=self._top_db)
-        except Exception:
-            return None
-
-        if len(intervals) == 0:
-            return []
-
-        total_samples = len(audio_data)
-        # librosa's effects.split returns a single full-coverage interval on
-        # degenerate input (e.g. pure silence - ref amplitude is zero, so the
-        # dB threshold is meaningless).  Treat that as "no segmentation".
-        if len(intervals) == 1 and int(intervals[0][0]) <= 0 and int(intervals[0][1]) >= total_samples:
-            return []
-
-        total = total_samples / sr
-        segments: list[tuple[float, float]] = []
-        for s0, s1 in intervals:
-            t0 = max(0.0, float(s0) / sr - self._pad)
-            t1 = min(total, float(s1) / sr + self._pad)
-            if t1 - t0 >= self._min_clip_duration:
-                segments.append((t0, t1))
-        return segments
+        return detect_nonsilent_segments(
+            media_bytes,
+            top_db=self._top_db,
+            pad=self._pad,
+            min_duration=self._min_clip_duration,
+        )
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
         media_bytes = media.get("media_bytes")

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -1093,14 +1093,27 @@ class AudioMediaType(MediaType):
         (AAC/M4A/MP4) included), slice to the clip window so each of a member's
         windows shows its own waveform, and cache the decoded member so its
         windows don't each re-stream and re-decode it.
+
+        The window is applied **only** when the bytes have to be resolved from
+        the source.  Materialized ``media_bytes`` already *are* this clip - a
+        clipper's slice, or a cleaner's trimmed payload - so re-applying the
+        source-relative ``clip_start`` / ``clip_end`` would slice a second time
+        and render the wrong stretch of audio.
         """
         ref = media.get("archive_member")
         member = ref.get("member", "") if isinstance(ref, dict) else ""
-        cache_key = (ref["path"], member) if isinstance(ref, dict) and ref.get("path") else None
+        materialized = media.get("media_bytes") is not None
+        cache_key = (
+            None
+            if materialized  # a per-clip payload must not be cached under a per-member key
+            else (ref["path"], member)
+            if isinstance(ref, dict) and ref.get("path")
+            else None
+        )
         return generate_waveform_thumbnail_window(
             lambda: self._resolve_media_bytes(media),
-            clip_start=media.get("clip_start"),
-            clip_end=media.get("clip_end"),
+            clip_start=None if materialized else media.get("clip_start"),
+            clip_end=None if materialized else media.get("clip_end"),
             cache_key=cache_key,
         )
 

--- a/vtscore/media/audio/silence.py
+++ b/vtscore/media/audio/silence.py
@@ -1,0 +1,74 @@
+"""Non-silent interval detection, shared by the silence clipper and cleaner.
+
+Two consumers ask the same question - *where is this recording actually
+audible?* - and answer it differently:
+
+* :class:`~vtscore.media.audio.clipper.SoundSilenceClipper` emits **one clip per
+  interval**, dropping the gaps between them.
+* :class:`~vtscore.media.audio.cleaner.AudioSilenceTrimCleaner` keeps the single
+  span ``[first_start, last_end]``, dropping only the lead-in and tail.
+
+The detector itself lives here once so the two can never drift apart on what
+counts as silence.
+"""
+
+from __future__ import annotations
+
+
+def detect_nonsilent_segments(
+    media_bytes: bytes,
+    *,
+    top_db: float,
+    pad: float = 0.0,
+    min_duration: float = 0.0,
+) -> list[tuple[float, float]] | None:
+    """Detect non-silent ``(start, end)`` ranges (seconds) in *media_bytes*.
+
+    Audio quieter than *top_db* below the clip's reference level counts as
+    silence.  Each surviving interval is widened by *pad* seconds on both sides
+    (clamped to the clip) so attack and decay aren't shaved off, and intervals
+    shorter than *min_duration* after padding are discarded.
+
+    Returns ``None`` if the audio cannot be decoded or ``librosa`` is
+    unavailable, and an empty list when nothing is left to report - either the
+    clip has no detectable silence structure at all, or no interval survived the
+    *min_duration* filter.  Callers treat both as "leave the media alone".
+    """
+    try:
+        import librosa  # noqa: PLC0415
+
+        from vtscore.media.audio.decode import decode_audio  # noqa: PLC0415
+    except ImportError:
+        return None
+
+    try:
+        audio_data, sr = decode_audio(media_bytes, sr=None, mono=True)
+    except Exception:
+        return None
+
+    if audio_data.size == 0 or sr <= 0:
+        return None
+
+    try:
+        intervals = librosa.effects.split(audio_data, top_db=top_db)
+    except Exception:
+        return None
+
+    if len(intervals) == 0:
+        return []
+
+    total_samples = len(audio_data)
+    # librosa's effects.split returns a single full-coverage interval on
+    # degenerate input (e.g. pure silence - ref amplitude is zero, so the
+    # dB threshold is meaningless).  Treat that as "no segmentation".
+    if len(intervals) == 1 and int(intervals[0][0]) <= 0 and int(intervals[0][1]) >= total_samples:
+        return []
+
+    total = total_samples / sr
+    segments: list[tuple[float, float]] = []
+    for s0, s1 in intervals:
+        t0 = max(0.0, float(s0) / sr - pad)
+        t1 = min(total, float(s1) / sr + pad)
+        if t1 - t0 >= min_duration:
+            segments.append((t0, t1))
+    return segments

--- a/vtscore/media/image/__init__.py
+++ b/vtscore/media/image/__init__.py
@@ -1,4 +1,4 @@
-from vtscore.media.image.cleaner import ImageExifOrientCleaner
+from vtscore.media.image.cleaner import ImageEdgeTrimCleaner, ImageExifOrientCleaner
 from vtscore.media.image.clipper import (
     ImageDefaultClipper,
     ImageObjectClipper,
@@ -12,4 +12,6 @@ CLIPPERS = [
     ImageTilingClipper(),
     ImageObjectClipper(),
 ]
-CLEANERS = [ImageExifOrientCleaner()]
+# Registration order is run order: bake the display rotation in *before*
+# looking for solid margins, so the edge box is measured on the upright frame.
+CLEANERS = [ImageExifOrientCleaner(), ImageEdgeTrimCleaner()]

--- a/vtscore/media/image/cleaner.py
+++ b/vtscore/media/image/cleaner.py
@@ -7,6 +7,12 @@ import logging
 from typing import Any
 
 from vtscore.media.cleaner import MediaCleaner
+from vtscore.media.image.edge_trim import (
+    DEFAULT_EDGE_TOL,
+    DEFAULT_MAX_EDGE_TRIM,
+    DEFAULT_MIN_EDGE_TRIM,
+    solid_edge_box,
+)
 
 log = logging.getLogger(__name__)
 
@@ -92,6 +98,170 @@ class ImageExifOrientCleaner(MediaCleaner):
         cleaned = dict(media)
         cleaned["media_bytes"] = rotated_bytes
         cleaned["file_size"] = len(rotated_bytes)
+        cleaned["width"] = width
+        cleaned["height"] = height
+        return cleaned
+
+
+#: Formats whose Pillow encoder accepts an ``exif=`` keyword.  A cropped copy
+#: keeps the source's EXIF block for these so a photo that still carries an
+#: unbaked orientation tag (i.e. ``image_exif_orient`` is switched off) is not
+#: silently un-rotated by the crop.
+_EXIF_WRITABLE_FORMATS = frozenset({"JPEG", "PNG", "TIFF", "WEBP", "MPO"})
+
+
+class ImageEdgeTrimCleaner(MediaCleaner):
+    """Crop away near-solid white or black border margins.
+
+    Letterbox bars, a pillarbox on one side, and the whitespace around a centred
+    logo are all content-free: the embedder spends real capacity encoding "this
+    is a black rectangle" and the padding dilutes whatever signal the subject
+    carries.  This gate finds the tight bounding box of non-padding content and
+    crops to it, each of the four edges independently, so a frame padded only on
+    top loses just that margin.
+
+    The same detector backs the grid thumbnail (see
+    :mod:`vtscore.media.image.edge_trim`), so a trimmed item's preview and its
+    embedding finally agree about where the picture starts.
+
+    Conservative by construction: no side is ever pulled in by more than
+    *max_edge_trim*, a frame whose margins are all thinner than *min_edge_trim*
+    is left alone, and an image that is nothing *but* solid tone is left alone
+    too (there is no content to pull the box toward).
+    """
+
+    def __init__(
+        self,
+        edge_tol: float = DEFAULT_EDGE_TOL,
+        max_edge_trim: float = DEFAULT_MAX_EDGE_TRIM,
+        min_edge_trim: float = DEFAULT_MIN_EDGE_TRIM,
+    ) -> None:
+        self._edge_tol = edge_tol
+        self._max_edge_trim = max_edge_trim
+        self._min_edge_trim = min_edge_trim
+
+    @property
+    def name(self) -> str:
+        return "image_edge_trim"
+
+    @property
+    def media_type(self) -> str:
+        return "image"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Crop near-solid white or black margins - letterbox bars, pillarboxes, whitespace "
+            "around a logo - so the embedder sees the picture, not its padding."
+        )
+
+    @property
+    def summary_template(self) -> str:
+        return "Crop near-solid white/black margins, never more than {max_edge_trim} of any one side."
+
+    @property
+    def edge_tol(self) -> float:
+        return self._edge_tol
+
+    @property
+    def max_edge_trim(self) -> float:
+        return self._max_edge_trim
+
+    @property
+    def min_edge_trim(self) -> float:
+        return self._min_edge_trim
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "edge_tol",
+                "label": "Solid tolerance (0-255)",
+                "description": (
+                    "How far from pure white or pure black a pixel may sit and still count as padding. "
+                    "Higher values treat more of the border as blank."
+                ),
+                "type": "number",
+                "default": self._edge_tol,
+                "min": 0,
+                "max": 64,
+                "step": 1,
+            },
+            {
+                "key": "max_edge_trim",
+                "label": "Maximum trim per side",
+                "description": (
+                    "Never remove more than this fraction of the width or height from any single side, "
+                    "so a small subject in a large blank field can't blow up to fill the frame."
+                ),
+                "type": "number",
+                "default": self._max_edge_trim,
+                "min": 0,
+                "max": 0.5,
+                "step": 0.05,
+            },
+            {
+                "key": "min_edge_trim",
+                "label": "Minimum trim to bother",
+                "description": (
+                    "Leave the image untouched when every margin is thinner than this fraction - not worth a re-encode."
+                ),
+                "type": "number",
+                "default": self._min_edge_trim,
+                "min": 0,
+                "max": 0.5,
+                "step": 0.01,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "ImageEdgeTrimCleaner":
+        return ImageEdgeTrimCleaner(
+            edge_tol=float(params.get("edge_tol", self._edge_tol)),
+            max_edge_trim=float(params.get("max_edge_trim", self._max_edge_trim)),
+            min_edge_trim=float(params.get("min_edge_trim", self._min_edge_trim)),
+        )
+
+    def clean(self, media: dict[str, Any]) -> dict[str, Any]:
+        """Return *media* cropped to its content box, or unchanged.
+
+        Unchanged when there are no bytes to work with, the payload can't be
+        decoded or re-encoded in its own format (SVG, a corrupt file), or the
+        detector finds nothing worth trimming - the common case, which costs one
+        decode plus a small resample and re-encodes nothing.
+        """
+        media_bytes = media.get("media_bytes")
+        if not isinstance(media_bytes, (bytes, bytearray)) or not media_bytes:
+            return media
+
+        from PIL import Image  # noqa: PLC0415
+
+        try:
+            with Image.open(io.BytesIO(media_bytes)) as src:
+                box = solid_edge_box(
+                    src,
+                    edge_tol=self._edge_tol,
+                    max_edge_trim=self._max_edge_trim,
+                    min_edge_trim=self._min_edge_trim,
+                )
+                if box is None:
+                    return media
+                fmt = src.format or "PNG"
+                save_kwargs: dict[str, Any] = {}
+                exif = src.info.get("exif")
+                if exif and fmt in _EXIF_WRITABLE_FORMATS:
+                    save_kwargs["exif"] = exif
+                cropped = src.crop(box)
+                out = io.BytesIO()
+                cropped.save(out, format=fmt, **save_kwargs)
+                width, height = cropped.size
+        except Exception:
+            log.debug("image_edge_trim: undecodable payload, leaving unchanged", exc_info=True)
+            return media
+
+        trimmed_bytes = out.getvalue()
+        cleaned = dict(media)
+        cleaned["media_bytes"] = trimmed_bytes
+        cleaned["file_size"] = len(trimmed_bytes)
         cleaned["width"] = width
         cleaned["height"] = height
         return cleaned

--- a/vtscore/media/image/edge_trim.py
+++ b/vtscore/media/image/edge_trim.py
@@ -1,0 +1,128 @@
+"""Near-solid border detection: the shared half of "shave the padding off".
+
+Many sources ship images already padded - letterbox bars top/bottom, a
+pillarbox on one side, whitespace around a centred logo - and that padding is
+content-free in two different places:
+
+* **Thumbnails** (:func:`~vtscore.media.image.thumbnail.make_image_thumbnail`)
+  want the *content's* aspect ratio, or the browse canvas' "half-crop,
+  half-pad" fit ends up padding the padding.
+* **Embeddings** (:class:`~vtscore.media.image.cleaner.ImageEdgeTrimCleaner`)
+  want the embedder to spend its capacity on the subject rather than on a
+  frame of blank pixels.
+
+Both callers ask the same question - *where does the content actually start?* -
+so the detector lives here once and each caller supplies its own thresholds.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Per-channel distance from pure white (255) or pure black (0) that a pixel may
+#: still fall within and count as part of a "solid" edge margin.  Wide enough to
+#: absorb JPEG ringing and video-level black (~16) without swallowing genuine
+#: near-white/near-black content.
+DEFAULT_EDGE_TOL = 16
+
+#: Never trim more than this fraction off any single side.  A tiny subject
+#: floating in a vast blank margin would otherwise blow up into a full-frame
+#: crop; this caps how tight the content box may pull each edge.
+DEFAULT_MAX_EDGE_TRIM = 0.45
+
+#: Ignore a candidate trim smaller than this fraction on every side - not worth
+#: the re-crop, and it keeps a frame that's merely *near* solid-free untouched.
+DEFAULT_MIN_EDGE_TRIM = 0.02
+
+#: Detect edges on a copy no larger than this (longest side, px).  The trim box
+#: is fractional and applied to the full-resolution image, so the scan cost
+#: stays fixed and tiny no matter how large the source is.
+EDGE_ANALYSIS_DIM = 256
+
+
+def solid_edge_box(
+    img: Any,
+    *,
+    edge_tol: float = DEFAULT_EDGE_TOL,
+    max_edge_trim: float = DEFAULT_MAX_EDGE_TRIM,
+    min_edge_trim: float = DEFAULT_MIN_EDGE_TRIM,
+) -> tuple[int, int, int, int] | None:
+    """Return the pixel crop box that drops *img*'s near-solid border margins.
+
+    Finds the tight bounding box of *content* (any pixel that is neither
+    near-white nor near-black within *edge_tol*), so each of the four edges is
+    trimmed independently: a frame padded only on top, or only on the left,
+    loses just that margin.
+
+    Detection runs on a copy downscaled to at most :data:`EDGE_ANALYSIS_DIM` px,
+    so the added cost is a single small resample regardless of the source
+    resolution; the resulting box is fractional and applied to the full image.
+    No single side is ever pulled in by more than *max_edge_trim*, so a small
+    subject in a large blank field can't explode into a full-frame crop.
+
+    Returns ``None`` when there is nothing worth trimming: an image too small to
+    analyse, a frame that's entirely one solid tone (no content to pull the box
+    toward), or margins all thinner than *min_edge_trim*.
+    """
+    import numpy as np  # noqa: PLC0415
+    from PIL import Image  # noqa: PLC0415
+
+    w, h = img.size
+    if w < 4 or h < 4:
+        return None
+
+    scale = min(1.0, EDGE_ANALYSIS_DIM / max(w, h))
+    if scale < 1.0:
+        aw, ah = max(1, round(w * scale)), max(1, round(h * scale))
+        analysis = img.resize((aw, ah), Image.Resampling.BILINEAR)
+    else:
+        analysis = img
+
+    arr = np.asarray(analysis.convert("RGB"), dtype=np.int16)
+    near_white = np.all(arr >= 255 - edge_tol, axis=2)
+    near_black = np.all(arr <= edge_tol, axis=2)
+    content = ~(near_white | near_black)
+    if not content.any():
+        return None  # nothing but solid tone - no content to pull the box toward
+
+    rows = np.flatnonzero(content.any(axis=1))
+    cols = np.flatnonzero(content.any(axis=0))
+    ch, cw = content.shape
+    fx0, fx1 = cols[0] / cw, (cols[-1] + 1) / cw
+    fy0, fy1 = rows[0] / ch, (rows[-1] + 1) / ch
+
+    # Cap how far each edge may pull in so a tiny subject can't blow up.
+    fx0, fy0 = min(fx0, max_edge_trim), min(fy0, max_edge_trim)
+    fx1, fy1 = max(fx1, 1.0 - max_edge_trim), max(fy1, 1.0 - max_edge_trim)
+
+    if fx0 < min_edge_trim and fy0 < min_edge_trim and (1.0 - fx1) < min_edge_trim and (1.0 - fy1) < min_edge_trim:
+        return None  # margins negligible on every side; leave the frame as-is
+
+    px0, px1 = int(round(fx0 * w)), int(round(fx1 * w))
+    py0, py1 = int(round(fy0 * h)), int(round(fy1 * h))
+    px1, py1 = max(px1, px0 + 1), max(py1, py0 + 1)
+    if (px0, py0, px1, py1) == (0, 0, w, h):
+        return None
+    return (px0, py0, px1, py1)
+
+
+def trim_solid_edges(
+    img: Any,
+    *,
+    edge_tol: float = DEFAULT_EDGE_TOL,
+    max_edge_trim: float = DEFAULT_MAX_EDGE_TRIM,
+    min_edge_trim: float = DEFAULT_MIN_EDGE_TRIM,
+) -> Any:
+    """Crop away *img*'s near-solid white/black border margins.
+
+    Thin wrapper over :func:`solid_edge_box`: returns ``img`` unchanged (the
+    same object) when there is nothing worth trimming, so callers can use it
+    unconditionally.
+    """
+    box = solid_edge_box(
+        img,
+        edge_tol=edge_tol,
+        max_edge_trim=max_edge_trim,
+        min_edge_trim=min_edge_trim,
+    )
+    return img if box is None else img.crop(box)

--- a/vtscore/media/image/thumbnail.py
+++ b/vtscore/media/image/thumbnail.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import io
 
+from vtscore.media.image.edge_trim import trim_solid_edges
+
 #: Longest-side length (px) of a generated thumbnail.  Comfortably covers the
 #: largest grid tile (XL ≈ 200 px CSS, ≈ 400 px on a 2× display) while keeping
 #: the decoded bitmap small (≈ ``MAX_DIM`` × ``MAX_DIM`` × 4 bytes).  The same
@@ -28,26 +30,6 @@ DEFAULT_MAX_DIM = 384
 #: skipping.  Mirrors the frontend's near-full-image guard in
 #: ``media-item.component.ts`` (``bestRegionStyle``).
 _FULL_BOX_THRESHOLD = 0.99
-
-#: Per-channel distance from pure white (255) or pure black (0) that a pixel may
-#: still fall within and count as part of a "solid" edge margin.  Wide enough to
-#: absorb JPEG ringing and video-level black (~16) without swallowing genuine
-#: near-white/near-black content.
-_EDGE_TOL = 16
-
-#: Never trim more than this fraction off any single side.  A tiny subject
-#: floating in a vast blank margin would otherwise blow up into a full-frame
-#: crop; this caps how tight the content box may pull each edge.
-_MAX_EDGE_TRIM = 0.45
-
-#: Ignore a candidate trim smaller than this fraction on every side — not worth
-#: the re-crop, and it keeps a frame that's merely *near* solid-free untouched.
-_MIN_EDGE_TRIM = 0.02
-
-#: Detect edges on a copy no larger than this (longest side, px).  The trim box
-#: is fractional and applied to the full-resolution image, so the scan cost
-#: stays fixed and tiny no matter how large the source is.
-_EDGE_ANALYSIS_DIM = 256
 
 
 def normalize_region_crop(
@@ -114,7 +96,7 @@ def make_image_thumbnail(
                 # aspect ratio of its content rather than its padding.  Only the
                 # thumbnail is affected — the full-resolution route still streams
                 # the untouched original for the detail viewer / main canvas.
-                img = _trim_solid_edges(img)
+                img = trim_solid_edges(img)
             has_alpha = img.mode in ("RGBA", "LA") or (img.mode == "P" and "transparency" in img.info)
             img.thumbnail((max_dim, max_dim), Image.Resampling.LANCZOS)
             out = io.BytesIO()
@@ -127,67 +109,6 @@ def make_image_thumbnail(
             return out.getvalue(), mimetype
     except Exception:
         return None
-
-
-def _trim_solid_edges(img):
-    """Crop away near-solid white/black border margins from a PIL image.
-
-    Many sources ship already padded — letterbox bars top/bottom, a pillarbox
-    on one side, whitespace around a centred logo — which makes the image's
-    stored aspect ratio a poor guide for a preview tile (the browse canvas'
-    "half-crop, half-pad" fit then pads the padding).  This finds the tight
-    bounding box of *content* (any pixel that is neither near-white nor
-    near-black within :data:`_EDGE_TOL`) and crops to it, so each of the four
-    edges is trimmed independently: a frame padded only on top, or only on the
-    left, loses just that margin.
-
-    Detection runs on a copy downscaled to at most :data:`_EDGE_ANALYSIS_DIM`
-    px, so the added cost is a single small resample regardless of the source
-    resolution; the resulting box is fractional and applied to the full image.
-    Returns ``img`` unchanged when there is nothing worth trimming: a frame
-    that's entirely one solid tone (no content to pull toward), or whose
-    margins are all thinner than :data:`_MIN_EDGE_TRIM`.  No single side is ever
-    trimmed by more than :data:`_MAX_EDGE_TRIM`, so a small subject in a large
-    blank field can't explode into a full-frame crop.
-    """
-    import numpy as np  # noqa: PLC0415
-    from PIL import Image  # noqa: PLC0415
-
-    w, h = img.size
-    if w < 4 or h < 4:
-        return img
-
-    scale = min(1.0, _EDGE_ANALYSIS_DIM / max(w, h))
-    if scale < 1.0:
-        aw, ah = max(1, round(w * scale)), max(1, round(h * scale))
-        analysis = img.resize((aw, ah), Image.Resampling.BILINEAR)
-    else:
-        analysis = img
-
-    arr = np.asarray(analysis.convert("RGB"), dtype=np.int16)
-    near_white = np.all(arr >= 255 - _EDGE_TOL, axis=2)
-    near_black = np.all(arr <= _EDGE_TOL, axis=2)
-    content = ~(near_white | near_black)
-    if not content.any():
-        return img  # nothing but solid tone — no content to pull the box toward
-
-    rows = np.flatnonzero(content.any(axis=1))
-    cols = np.flatnonzero(content.any(axis=0))
-    ch, cw = content.shape
-    fx0, fx1 = cols[0] / cw, (cols[-1] + 1) / cw
-    fy0, fy1 = rows[0] / ch, (rows[-1] + 1) / ch
-
-    # Cap how far each edge may pull in so a tiny subject can't blow up.
-    fx0, fy0 = min(fx0, _MAX_EDGE_TRIM), min(fy0, _MAX_EDGE_TRIM)
-    fx1, fy1 = max(fx1, 1.0 - _MAX_EDGE_TRIM), max(fy1, 1.0 - _MAX_EDGE_TRIM)
-
-    if fx0 < _MIN_EDGE_TRIM and fy0 < _MIN_EDGE_TRIM and (1.0 - fx1) < _MIN_EDGE_TRIM and (1.0 - fy1) < _MIN_EDGE_TRIM:
-        return img  # margins negligible on every side; leave the frame as-is
-
-    px0, px1 = int(round(fx0 * w)), int(round(fx1 * w))
-    py0, py1 = int(round(fy0 * h)), int(round(fy1 * h))
-    px1, py1 = max(px1, px0 + 1), max(py1, py0 + 1)
-    return img.crop((px0, py0, px1, py1))
 
 
 def _crop_to_region(img, crop: tuple[float, float, float, float]):

--- a/vtscore/media/text/__init__.py
+++ b/vtscore/media/text/__init__.py
@@ -1,5 +1,9 @@
+from vtscore.media.text.cleaner import TextMarkupStripCleaner, TextWhitespaceCleaner
 from vtscore.media.text.clipper import TextDefaultClipper, TextParagraphClipper, TextSentenceClipper
 from vtscore.media.text.media_type import TextMediaType
 
 MEDIA_TYPE = TextMediaType()
 CLIPPERS = [TextDefaultClipper(), TextParagraphClipper(), TextSentenceClipper()]
+# Registration order is run order: pull the markup out first, then normalise the
+# whitespace the strip leaves behind.
+CLEANERS = [TextMarkupStripCleaner(), TextWhitespaceCleaner()]

--- a/vtscore/media/text/cleaner.py
+++ b/vtscore/media/text/cleaner.py
@@ -1,0 +1,224 @@
+"""Text cleaners - 1→1 cleanup gates run on each text unit before embedding."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any
+
+from vtscore.media.cleaner import MediaCleaner
+
+
+def _retype_text(media: dict[str, Any], text: str) -> dict[str, Any]:
+    """Return a copy of *media* carrying *text* and its refreshed counts.
+
+    Returns *media* itself when nothing changed, which is what tells the chain
+    runner to skip the ``original_*`` snapshot for this item.
+    """
+    if text == media.get("media_string"):
+        return media
+    cleaned = dict(media)
+    cleaned["media_string"] = text
+    cleaned["word_count"] = len(text.split())
+    cleaned["character_count"] = len(text)
+    if media.get("file_size") is not None:
+        cleaned["file_size"] = len(text.encode("utf-8"))
+    return cleaned
+
+
+class TextWhitespaceCleaner(MediaCleaner):
+    """Normalise whitespace and repair words broken across line ends.
+
+    Text extracted from a PDF, a scanned page, or a scraped article arrives full
+    of layout artifacts that carry no meaning: a hard line break every 80
+    columns, words split by a hyphen at the right margin ("para-\\ngraph"),
+    runs of spaces where a column gutter used to be, soft hyphens and
+    zero-width joiners left over from typesetting, and stray control bytes.  The
+    tokenizer sees every one of them - ``para`` and ``graph`` become two
+    unrelated tokens - so the embedding of a paragraph depends partly on the
+    page width it was typeset at.
+
+    This gate rewrites the text as flowing prose:
+
+    * Unicode line/paragraph separators and CRLF become plain newlines.
+    * Control characters (other than newline and tab) and zero-width formatting
+      characters are dropped; non-breaking and other exotic spaces become plain
+      spaces.
+    * A word hyphenated across a line break is rejoined (``"para-\\ngraph"``
+      → ``"paragraph"``).
+    * Runs of spaces/tabs collapse to one space, trailing space is stripped from
+      each line, and runs of three or more newlines collapse to a blank line.
+
+    Paragraph structure survives on purpose: a single blank line still separates
+    paragraphs, so a downstream reader (and a human looking at the Original
+    toggle) sees the same document, just without the typesetter's debris.
+    """
+
+    #: Characters that are invisible but tokenize: soft hyphen, zero-width
+    #: space/non-joiner/joiner, word joiner, BOM.
+    _INVISIBLE = str.maketrans({c: None for c in "\u00ad\u200b\u200c\u200d\u2060\ufeff"})
+
+    #: Unicode separators that mean "newline": LINE / PARAGRAPH SEPARATOR.
+    _LINE_SEPARATORS = re.compile("[\u2028\u2029]")
+    #: Separators that mean "space": NBSP, ogham space, the en/em quad family,
+    #: narrow NBSP, medium mathematical space, ideographic space.
+    _EXOTIC_SPACES = re.compile("[\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000]")
+
+    #: A word split by a hyphen at a line break: letter, hyphen (any dash the
+    #: typesetter may have used), end of line, then the rest of the word.
+    _BROKEN_WORD = re.compile(r"(\w)[-\u2010\u2011]\n[ \t]*(\w)")
+
+    _HORIZONTAL_RUN = re.compile(r"[ \t]{2,}")
+    _TRAILING_SPACE = re.compile(r"[ \t]+\n")
+    _BLANK_RUN = re.compile(r"\n{3,}")
+
+    @property
+    def name(self) -> str:
+        return "text_whitespace"
+
+    @property
+    def media_type(self) -> str:
+        return "text"
+
+    @property
+    def display_name(self) -> str:
+        return "Whitespace & Hyphenation"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Collapse whitespace runs, drop control characters, and rejoin words hyphen-broken "
+            "across line endings. Highest value on text extracted from PDFs."
+        )
+
+    def clean(self, media: dict[str, Any]) -> dict[str, Any]:
+        text = media.get("media_string")
+        if not isinstance(text, str) or not text:
+            return media
+
+        out = text.replace("\r\n", "\n").replace("\r", "\n")
+        out = self._LINE_SEPARATORS.sub("\n", out)
+        out = out.translate(self._INVISIBLE)
+        out = self._EXOTIC_SPACES.sub(" ", out)
+        out = "".join(c for c in out if c in "\n\t" or unicodedata.category(c) != "Cc")
+        # De-hyphenate before collapsing, so the line break is still there to
+        # tell a broken word from a genuine hyphenated compound.
+        out = self._BROKEN_WORD.sub(r"\1\2", out)
+        out = self._HORIZONTAL_RUN.sub(" ", out)
+        out = self._TRAILING_SPACE.sub("\n", out)
+        out = self._BLANK_RUN.sub("\n\n", out)
+        out = out.strip()
+
+        return _retype_text(media, out)
+
+
+class TextMarkupStripCleaner(MediaCleaner):
+    """Strip HTML tags and Markdown syntax so the embedder sees prose.
+
+    Scraped pages and README-style corpora carry their formatting inline.  The
+    embedder has no notion of markup, so ``<div class="col-md-6">`` and
+    ``**bold**`` are just tokens competing with the sentence they wrap: two
+    articles about different subjects can end up neighbours because they share a
+    site template.
+
+    What this removes:
+
+    * HTML comments, and the *contents* of ``<script>`` / ``<style>`` blocks
+      (code and CSS are never the content the user meant to search).
+    * HTML tags, replaced by nothing inside a line and by a space for block-level
+      tags so words don't fuse; HTML entities are then unescaped.
+    * Markdown fences and inline code ticks, heading markers, blockquote
+      markers, list bullets, horizontal rules, and emphasis markers - the text
+      inside each is kept.
+    * Link and image syntax collapses to its label: ``[docs](url)`` → ``docs``,
+      ``![a cat](url)`` → ``a cat``.
+
+    Deliberately conservative: only a well-formed tag-looking token is treated
+    as a tag (so ``a < b and b > c`` survives), and ``_`` is only stripped when
+    it wraps a span at word boundaries, so ``snake_case`` identifiers are left
+    alone.
+    """
+
+    _COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+    _SCRIPT_STYLE = re.compile(r"<(script|style)\b[^>]*>.*?</\1\s*>", re.DOTALL | re.IGNORECASE)
+    #: An opening/closing tag with a real element name - not a bare "<" in prose.
+    _TAG = re.compile(r"</?[A-Za-z][A-Za-z0-9:-]*(?:\s[^<>]*?)?/?>")
+    #: Block-level elements become a space (or a newline for the big ones) so
+    #: the words on either side don't run together once the tag is gone.
+    _BLOCK_TAG = re.compile(
+        r"</?(?:p|div|br|hr|li|ul|ol|tr|td|th|table|section|article|header|footer|nav|aside|"
+        r"h[1-6]|blockquote|pre|figure|figcaption)\b[^<>]*>",
+        re.IGNORECASE,
+    )
+
+    _FENCE = re.compile(r"^[ \t]*(?:```|~~~).*$", re.MULTILINE)
+    _INLINE_CODE = re.compile(r"`+")
+    _IMAGE = re.compile(r"!\[([^\]]*)\]\([^)]*\)")
+    _LINK = re.compile(r"\[([^\]]*)\]\((?:[^)]*)\)")
+    _REF_LINK = re.compile(r"\[([^\]]*)\]\[[^\]]*\]")
+    _AUTOLINK = re.compile(r"<(https?://[^>\s]+)>")
+    _HEADING = re.compile(r"^[ \t]{0,3}#{1,6}[ \t]+", re.MULTILINE)
+    _HORIZONTAL_RULE = re.compile(r"^[ \t]{0,3}(?:[-*_][ \t]*){3,}$", re.MULTILINE)
+    _QUOTE = re.compile(r"^[ \t]{0,3}>[ \t]?", re.MULTILINE)
+    _BULLET = re.compile(r"^([ \t]*)(?:[-*+]|\d{1,3}[.)])[ \t]+", re.MULTILINE)
+    _BOLD_ITALIC = re.compile(r"(\*{1,3})(\S(?:.*?\S)?)\1", re.DOTALL)
+    #: ``_emphasis_`` only at word boundaries, so ``snake_case`` is untouched.
+    _UNDERSCORE_EMPHASIS = re.compile(r"(?<![\w_])(_{1,3})(\S(?:.*?\S)?)\1(?![\w_])", re.DOTALL)
+    _STRIKE = re.compile(r"~~(\S(?:.*?\S)?)~~", re.DOTALL)
+
+    _HORIZONTAL_RUN = re.compile(r"[ \t]{2,}")
+    _TRAILING_SPACE = re.compile(r"[ \t]+\n")
+    _BLANK_RUN = re.compile(r"\n{3,}")
+
+    @property
+    def name(self) -> str:
+        return "text_markup_strip"
+
+    @property
+    def media_type(self) -> str:
+        return "text"
+
+    @property
+    def display_name(self) -> str:
+        return "Markup Strip"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Remove HTML tags and Markdown syntax, keeping the text inside, so the embedder reads "
+            "prose instead of angle brackets and asterisks."
+        )
+
+    def clean(self, media: dict[str, Any]) -> dict[str, Any]:
+        import html  # noqa: PLC0415
+
+        text = media.get("media_string")
+        if not isinstance(text, str) or not text:
+            return media
+
+        out = self._COMMENT.sub("", text)
+        out = self._SCRIPT_STYLE.sub(" ", out)
+        out = self._AUTOLINK.sub(r"\1", out)
+        out = self._BLOCK_TAG.sub("\n", out)
+        out = self._TAG.sub("", out)
+        out = html.unescape(out)
+
+        out = self._FENCE.sub("", out)
+        out = self._IMAGE.sub(r"\1", out)
+        out = self._LINK.sub(r"\1", out)
+        out = self._REF_LINK.sub(r"\1", out)
+        out = self._HORIZONTAL_RULE.sub("", out)
+        out = self._HEADING.sub("", out)
+        out = self._QUOTE.sub("", out)
+        out = self._BULLET.sub(r"\1", out)
+        out = self._STRIKE.sub(r"\1", out)
+        out = self._BOLD_ITALIC.sub(r"\2", out)
+        out = self._UNDERSCORE_EMPHASIS.sub(r"\2", out)
+        out = self._INLINE_CODE.sub("", out)
+
+        out = self._HORIZONTAL_RUN.sub(" ", out)
+        out = self._TRAILING_SPACE.sub("\n", out)
+        out = self._BLANK_RUN.sub("\n\n", out)
+        out = out.strip()
+
+        return _retype_text(media, out)


### PR DESCRIPTION
The `MediaCleaner` framework shipped without a roster. This adds the four highest-priority gates from `docs/plans/media-cleaners.md`, and prunes those items from the plan.

## The cleaners

| Name | Type | Default | What it does |
|------|------|---------|--------------|
| `image_edge_trim` | image | off | Crops near-solid white/black margins — letterbox, pillarbox, whitespace around a logo |
| `audio_silence_trim` | audio | off | Keeps `[first_start, last_end]` of the audible material; internal pauses survive |
| `text_whitespace` | text | off | Collapses whitespace runs, drops control/zero-width characters, rejoins hyphen-broken words |
| `text_markup_strip` | text | off | Removes HTML tags and Markdown syntax, keeping the text inside |

Each gate defaults off (they all make a judgment call about what counts as wasted content), no-ops by returning the media object *itself* — which is what tells the chain runner to skip the `original_*` snapshot — and treats an undecodable payload as a no-op rather than an error.

## Shared detectors, not copied heuristics

Two of these answer a question the codebase already answers, so the detector moved rather than being duplicated:

- `_trim_solid_edges` is promoted out of `thumbnail.py` into `vtscore/media/image/edge_trim.py`, with the tuned caps (`_EDGE_TOL` / `_MAX_EDGE_TRIM` / `_MIN_EDGE_TRIM`) becoming user-facing parameters. The grid preview and the embedder now agree on where the picture starts.
- `SoundSilenceClipper._detect_segments` moves to `vtscore/media/audio/silence.py` and both the clipper (one clip per interval) and the cleaner (one trimmed span) call it.

## Conservatism

`image_edge_trim` never pulls a side in by more than `max_edge_trim`, leaves margins under `min_edge_trim` alone, and leaves a wholly-solid frame alone. It preserves the source EXIF block so trimming a photo whose orientation is *not* baked in (i.e. `image_exif_orient` switched off) doesn't silently un-rotate it. `audio_silence_trim` skips trims under 100 ms so an item isn't re-encoded — and doesn't pay for an `original_*` snapshot — to shave a few frames. `text_markup_strip` only treats a well-formed tag as a tag, so `a < b and b > c` survives, and only strips `_` at word boundaries, so `snake_case` survives.

## Drive-by fix

`AudioMediaType._waveform_for_media` applied the source-relative `clip_start`/`clip_end` window to bytes that were already materialized (a clipper's slice, or now a cleaner's trimmed payload), rendering the wrong stretch of audio; it also cached a per-clip payload under a per-member key. Latent before this PR — the cleaner drops `thumbnail_bytes`, which makes the regeneration path reachable for cleaned audio.

## Testing

`./run-tests.sh` — 7050 passed, 1 skipped. New coverage in `tests_lib/detectors/test_cleaner_roster.py` (4 gates × removes-what-it-claims / identity-on-no-op / degenerate-payload, plus both shared-detector agreements and the waveform regression). Registry-shape assertions in `test_media_cleaners.py` and `test_cleaner_routes.py` updated for the new entries.

## Docs

`docs/EXTENDING-media.md` built-in cleaner table, a note in `docs/api/datasets.md` about cleaner `parameters`, and the four shipped items deleted from `docs/plans/media-cleaners.md` (sentinels left in place). No screenshot drift: the import Cleanup list stays collapsed while the selection matches defaults, and all four gates default off.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ez5qnsJ6zjUMEgsgV4ipR)_