### PR TITLE
Keep the import Cleanup gates strictly under Advanced

### DIFF
--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -734,6 +734,16 @@ in their **own registry**, so they never appear in a clipper chooser:
 `GET /api/cleaners` lists them and the import form renders one checkbox per
 entry.
 
+That checkbox list lives **strictly behind the Add Dataset modal's "Advanced ▾"
+toggle** and never escapes it. This is deliberate and differs from the embedder
+and clipper pickers, which stay on screen with Advanced collapsed once the user
+overrides them: cleanup is the most technical knob in the modal, so a
+non-default selection does *not* pull the block back into view — it is surfaced
+only in the Advanced toggle's tooltip (`Cleanup: <enabled gates>`). Because the
+block cannot be reached any other way, registering a cleaner for a media type
+also forces the Advanced toggle itself to render, even in flows that would
+otherwise hide it. Do not add a cleaner affordance outside that block.
+
 ### Built-in cleaners
 
 | Cleaner | Name | Media Type | Default | Description |

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.html
@@ -4,7 +4,7 @@
     class="advanced-toggle"
     (click)="toggleAdvanced()"
     [attr.aria-expanded]="advancedOpen"
-    title="Show advanced options: included media types, embedder, and pre-processing clipper"
+    [title]="advancedToggleTitle"
   >
     Advanced {{ advancedOpen ? '▴' : '▾' }}
   </button>

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.spec.ts
@@ -132,6 +132,13 @@ describe('ImportAdvancedComponent', () => {
       await setInputs({ showSourceSpecs: false, embedders, clippers, selectedEmbedder: 'custom', selectedClipper: 'clip_default' });
       expect(component.showAdvancedToggle).toBe(false);
     });
+
+    it('is true whenever cleaners exist, even with a picker overridden', async () => {
+      // Cleanup lives strictly behind the toggle, so hiding the toggle would
+      // strand the gates with no way back to them.
+      await setInputs({ showSourceSpecs: false, embedders, clippers, selectedEmbedder: 'custom', selectedClipper: 'clip_default', cleaners });
+      expect(component.showAdvancedToggle).toBe(true);
+    });
   });
 
   describe('showEmbedderPicker', () => {
@@ -364,10 +371,21 @@ describe('ImportAdvancedComponent', () => {
       expect(component.showCleanupSection).toBe(true);
     });
 
-    it('a non-default selection keeps the block visible with Advanced collapsed', async () => {
+    it('a non-default selection stays hidden with Advanced collapsed', async () => {
+      // Unlike the embedder/clipper pickers, cleanup does NOT escape the
+      // toggle when overridden: it is too technical to show unprompted.
       await setInputs({ cleaners, selectedCleaners: [] });
       expect(component.isDefaultCleanupSelected).toBe(false);
+      expect(component.showCleanupSection).toBe(false);
+      component.advancedOpen = true;
       expect(component.showCleanupSection).toBe(true);
+    });
+
+    it('renders no cleanup markup at all while Advanced is collapsed', async () => {
+      await setInputs({ cleaners, selectedCleaners: [{ name: 'trim', params: { tol: 4 } }] });
+      expect(fixture.nativeElement.querySelectorAll('.cleanup-row').length).toBe(0);
+      expect(fixture.nativeElement.querySelectorAll('.cleanup-param').length).toBe(0);
+      expect(fixture.nativeElement.textContent).not.toContain('Cleanup');
     });
 
     it('a parameter override counts as non-default', async () => {
@@ -375,11 +393,15 @@ describe('ImportAdvancedComponent', () => {
       expect(component.isDefaultCleanupSelected).toBe(false);
     });
 
-    it('a non-default cleanup selection also keeps the Advanced toggle visible', async () => {
-      await setInputs({ cleaners, selectedCleaners: [], embedders, clippers, selectedClipper: 'clip_default' });
-      expect(component.showAdvancedToggle).toBe(false);
-      await setInputs({ selectedCleaners: defaultSelection });
-      expect(component.showAdvancedToggle).toBe(true);
+    it('advancedToggleTitle names the enabled gates only once off the default', async () => {
+      await setInputs({ cleaners, selectedCleaners: defaultSelection });
+      expect(component.advancedToggleTitle).not.toContain('Cleanup:');
+
+      await setInputs({ selectedCleaners: [{ name: 'trim', params: {} }] });
+      expect(component.advancedToggleTitle).toContain('Cleanup: Solid Border Trim');
+
+      await setInputs({ selectedCleaners: [] });
+      expect(component.advancedToggleTitle).toContain('Cleanup: none');
     });
 
     it('isCleanerEnabled reflects the selection', async () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/import-advanced/import-advanced.component.ts
@@ -176,8 +176,8 @@ export class ImportAdvancedComponent {
 
   /** True when the cleanup checkboxes still match the registry's own
    *  recommendation (each cleaner's ``default_enabled``) with no parameter
-   *  overrides.  A user who changed them keeps the block visible even with
-   *  Advanced collapsed, so their override never hides. */
+   *  overrides.  Only feeds :prop:`advancedToggleTitle`; the block's own
+   *  visibility no longer depends on it. */
   get isDefaultCleanupSelected(): boolean {
     const wanted = this.cleaners().filter((c) => c.default_enabled);
     const selected = this.selectedCleaners();
@@ -188,14 +188,29 @@ export class ImportAdvancedComponent {
     });
   }
 
-  /** The Advanced toggle is shown either when the Include-media block
-   *  is available (it lives strictly behind the toggle, so the toggle
-   *  must be reachable) or when no picker in the block has been
+  /** Tooltip for the Advanced toggle.  Gains a trailing cleanup line only
+   *  once the user has moved the gates off the registry default, so the
+   *  override stays discoverable while Advanced is collapsed without
+   *  putting any of it on screen for the default user. */
+  get advancedToggleTitle(): string {
+    const base = 'Show advanced options: included media types, embedder, pre-processing clipper, and cleanup gates';
+    if (this.cleaners().length === 0 || this.isDefaultCleanupSelected) return base;
+    const enabled = this.cleaners()
+      .filter((c) => this.isCleanerEnabled(c.name))
+      .map((c) => this.cleanerLabel(c));
+    return `${base}\nCleanup: ${enabled.length > 0 ? enabled.join(', ') : 'none'}`;
+  }
+
+  /** The Advanced toggle is shown either when a block that lives
+   *  *strictly* behind it is available - Include media, or the Cleanup
+   *  gates - in which case the toggle must stay reachable or that block
+   *  becomes unreachable; or when no picker in the block has been
    *  overridden (otherwise those pickers stay visible anyway and the
    *  toggle would be redundant). */
   get showAdvancedToggle(): boolean {
     if (this.showSourceSpecs()) return true;
-    return this.isDefaultEmbedderSelected && this.isDefaultClipperSelected && this.isDefaultCleanupSelected;
+    if (this.cleaners().length > 0) return true;
+    return this.isDefaultEmbedderSelected && this.isDefaultClipperSelected;
   }
 
   /** Embedder picker is visible when Advanced is open OR when the user
@@ -213,10 +228,14 @@ export class ImportAdvancedComponent {
     return this.advancedOpen || !this.isDefaultClipperSelected;
   }
 
-  /** Cleanup block is visible when Advanced is open OR when the user has
-   *  changed the cleanup selection away from the registry defaults. */
+  /** Cleanup block is visible only while Advanced is open.  Unlike the
+   *  embedder and clipper pickers, a non-default selection does *not* keep
+   *  it on screen with Advanced collapsed: cleanup is the most technical
+   *  knob in the modal and the default user should never meet it, so it
+   *  stays behind the toggle even for a user who has changed it.  What the
+   *  selection is instead surfaces in :prop:`advancedToggleTitle`. */
   get showCleanupSection(): boolean {
-    return this.cleaners().length > 0 && (this.advancedOpen || !this.isDefaultCleanupSelected);
+    return this.cleaners().length > 0 && this.advancedOpen;
   }
 
   /** Human label for a cleaner's checkbox row. */


### PR DESCRIPTION
The MediaCleaner checkbox list already lived inside the Add Dataset modal's `Advanced ▾` block, but it had two escape hatches that put it in front of users who never opened Advanced.

## What changed

**`showCleanupSection` now follows the toggle and nothing else.** It previously returned `true` whenever the selection differed from the registry default, mirroring the embedder/clipper pickers' "an override never hides" rule. Cleanup is the most technical knob in the modal, so it no longer gets pulled back into view by a non-default selection.

**`showAdvancedToggle` no longer folds in `isDefaultCleanupSelected`.** That was the worse of the two leaks: in a flow with no source-specs column (the demo picker), ticking a gate made the toggle *disappear* while leaving the cleanup block stranded on its own — technical UI on screen, with no way back to the rest of Advanced.

**Registering a cleaner now forces the Advanced toggle to render.** Since the block is unreachable any other way, the toggle has to stay available whenever `cleaners` is non-empty, even in flows that would otherwise hide it.

**An override stays discoverable with zero on-screen footprint.** The Advanced toggle's tooltip gains a `Cleanup: <enabled gates>` line, but only once the selection moves off the registry default — so the default user never encounters it, and a user who did change something can still find their way back.

## Scope

Import-flow only, as asked. The media viewer's `Showing: Clean | Original` toggle is untouched: it is a per-item affordance that only appears for an item a cleaner actually rewrote, and it answers "why does this look different?" at the point the question comes up.

Because all four roster cleaners default off and the block was already hidden in the default state, no doc screenshot changes — nothing captured in `docs/user/assets/` moves.

`docs/EXTENDING-media.md` § Adding a Media Cleaner now records the Advanced-only rule and why it diverges from the embedder/clipper visibility convention, so a future cleaner doesn't re-add an affordance outside the block.

## Testing

`./run-tests.sh` — ALL 7050 TESTS PASSED (1 skipped, 1 xfailed). Frontend gate green: build, audit, 1860 Vitest tests.

Spec updates in `import-advanced.component.spec.ts`: the two tests that asserted the old escape-hatch behavior are rewritten, plus new coverage for the toggle-forcing rule, for no cleanup markup rendering at all while collapsed, and for the tooltip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrU5x2tXhkSRfvbQfLTcUA)_