### PR TITLE
Restore #2733, #2734, and #2739, silently reverted by 08f835dc's bad rebase

### DIFF
--- a/docs/api/labeling.md
+++ b/docs/api/labeling.md
@@ -90,10 +90,21 @@ GET /api/indicator-score-history
 
 **Query params:** `metric`: one of `"smart"`, `"stable"`, `"diverse"`.
 
-→ `{"metric": "smart", "history": [...]}`
+→ `{"metric": "smart", "history": [...], "complete": true}`
 
-Returns cached per-step indicator data (computed during labeling-status
-polling).
+Returns per-step indicator data straight from the cache that the
+`labeling-status` background worker advances. This route is **read-only**: it
+never advances the cache and never retrains a model, so it returns promptly
+whatever the dataset size or label-history length.
+
+When the cache does not yet cover the whole label history — the normal state
+while the user is actively labeling, since `labeling-status` defers the advance
+to a background worker — the response is `{"metric": ..., "history": [],
+"complete": false}`. Clients should then fall back to
+`POST /api/eval/train-and-score` (below), which computes the same series on a
+background thread with live progress and cancellation. `complete: false` is
+also returned if the cache is momentarily locked by an in-flight refresh, so
+the read never waits on a build.
 
 ### Evaluate metric (train-and-score)
 

--- a/docs/plans/scalability.md
+++ b/docs/plans/scalability.md
@@ -398,6 +398,17 @@ embedder. Shares the S11 approach.
   `POST /api/datasets/registry/<id>/coverage-atlas` when a loaded dataset has no
   tree (auto-build is skipped above 50 k). No dataset/tree-status panel hosts it
   today, so it needs a UI home; the endpoint is meanwhile reachable via API/CLI.
+- **Share the coverage atlas with the progress cache instead of rebuilding it:**
+  `labeling_progress._build_coverage_atlas` clones the dataset context's atlas
+  only when the id sets match exactly; otherwise it fits a throwaway private one
+  under `_progress_lock`. On a dataset past the 50 k auto-build cutoff (so the
+  context has no atlas) that fit dominates a cold progress-cache build —
+  measured ~27 s of a 40 s build at 20 k media. It can't write the result back
+  to the context from there because `_progress_lock` is held and the lock
+  ordering forbids taking `_state_lock` under it. Fix direction: build the atlas
+  before acquiring `_progress_lock` and publish it to the context so both paths
+  share one structure. Now off the request thread (the plot modal runs it as a
+  background job), so this is a cost problem, not a latency-hang.
 - **Columnar `medias` storage** (S4 full rewrite): deferred; requires redesign of
   every media-reading call site.
 - **Append-only vote journal** for labelset sources (S12 long-term): deferred

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -82,6 +82,14 @@ def resolve_device() -> str:
 MAX_UPLOAD_MB: int
 """HTTP request size cap in MB; default 2048 (2 GiB), 0 = unlimited. Honours $VTSEARCH_MAX_UPLOAD_MB."""
 
+MAX_DECODE_PIXELS: int
+"""Per-image decode budget in pixels; default 64_000_000, 0 = unbounded.
+
+Pillow's own decompression-bomb ceiling is lifted at startup (see
+``vtscore.media.image.decode``) so a merely-large image is imported rather
+than refused; this budget caps how big a bitmap any one decode materialises.
+Honours $VTSEARCH_MAX_DECODE_PIXELS."""
+
 TRAIN_EPOCHS: int
 """Upper bound on MLP training epochs. Honours $VTSEARCH_TRAIN_EPOCHS; default 200."""
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3628,6 +3628,9 @@
       "IndicatorScoreHistoryResponse": {
         "additionalProperties": false,
         "properties": {
+          "complete": {
+            "type": "boolean"
+          },
           "history": {
             "items": {
               "additionalProperties": {},
@@ -3645,6 +3648,7 @@
           }
         },
         "required": [
+          "complete",
           "history",
           "metric"
         ],
@@ -12912,7 +12916,7 @@
     },
     "/api/indicator-score-history": {
       "get": {
-        "description": "Reads only the per-step cache populated by the labeling-status\npolling; no models are retrained.",
+        "description": "Reads only the per-step cache advanced by the ``/api/labeling-status``\nbackground worker; **no models are retrained and the cache is never\nadvanced here**, so the response is always fast regardless of dataset size\nor label-history length.\n\nWhen the cache does not yet cover the whole ``label_history`` the response\ncarries ``complete: false`` and an empty ``history``.  Clients should then\nfall back to ``POST /api/eval/train-and-score``, which computes the same\nseries on a background thread with live progress and cancellation.\n\nThis route used to call the ``calculate_*_over_time`` helpers directly.\nThose advance the cache via ``_ensure_cache`` - retraining one MLP per\nuncached label step plus a forward pass over the unlabeled pool, and on a\ncold cache a full hierarchical-k-means coverage-atlas build - all inline on\nthe request thread under ``_progress_lock``.  Since ``/api/labeling-status``\ndeliberately defers exactly that work to a background worker (issue #2397),\nthe cache is behind for most of a labeling session, and this endpoint\nabsorbed the entire deferred build: tens of seconds on a mid-size dataset,\ngrowing with both media count and vote count.",
         "operationId": "indicator_score_history",
         "parameters": [
           {
@@ -12951,7 +12955,7 @@
             "$ref": "#/components/responses/DEFAULT_ERROR"
           }
         },
-        "summary": "Return cached indicator score history for a given metric.",
+        "summary": "Return the cached indicator score history for a given metric.",
         "tags": [
           "eval"
         ]

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -103,7 +103,6 @@
 @if (progressModalMetric) {
   <vt-progress-modal
     [metric]="progressModalMetric"
-    [useCachedHistory]="true"
     (closed)="onProgressModalClosed()"
   />
 }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
@@ -1,7 +1,7 @@
 <vt-modal [title]="title" [open]="true" (closed)="onCancel()">
   @if (analyzing) {
     <div class="analysis-loading">
-      @if (useCachedHistory()) {
+      @if (!runningJob) {
         <p aria-live="polite">Loading indicator history…</p>
       } @else {
         <vt-job-progress

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -38,6 +38,15 @@ describe('ProgressModalComponent', () => {
     httpMock.verify();
   });
 
+  const isHistory = (req: HttpRequest<unknown>) => req.url === '/api/indicator-score-history';
+  const isResult = (req: HttpRequest<unknown>) => req.url === '/api/eval/train-and-score/result';
+
+  /** Flush the cached-history GET that `ngOnInit` always issues first, with a
+   *  cache miss so the component falls through to the async job. */
+  const missCachedHistory = (metric = 'smart') => {
+    httpMock.expectOne(isHistory).flush({ metric, history: [], complete: false });
+  };
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -57,14 +66,15 @@ describe('ProgressModalComponent', () => {
     vi.useFakeTimers();
     try {
       fixture.componentRef.setInput('metric', 'smart');
-      // TestBed.tick() runs ngOnInit (kicks off the train POST) under zoneless.
+      // TestBed.tick() runs ngOnInit (the cached read) under zoneless.
       TestBed.tick();
       expect(component.analyzing).toBe(true);
+      missCachedHistory('smart');
 
       // Progress now arrives over the `eval` SSE channel, not via HTTP polling.
-      // The only HTTP call is the train-and-score POST, which returns a job
-      // envelope; on a cache hit (status=done) the component applies the data
-      // inline without polling.
+      // The only other HTTP call is the train-and-score POST, which returns a
+      // job envelope; on a cache hit (status=done) the component applies the
+      // data inline without polling.
       const trainReq = httpMock.expectOne('/api/eval/train-and-score');
       trainReq.flush({
         job_id: 'abc',
@@ -95,6 +105,7 @@ describe('ProgressModalComponent', () => {
     try {
       fixture.componentRef.setInput('metric', 'smart');
       TestBed.tick();
+      missCachedHistory('smart');
 
       // Job started, not a cache hit -> the component polls for the result.
       httpMock.expectOne('/api/eval/train-and-score').flush({
@@ -108,9 +119,6 @@ describe('ProgressModalComponent', () => {
       // SSE says done *before* the result endpoint flips. This used to kill
       // the poller; it must only stop the progress watcher now.
       votingIterations$.next({ progress: 5, total: 5, done: true });
-
-      const isResult = (req: HttpRequest<unknown>) =>
-        req.url === '/api/eval/train-and-score/result';
 
       // First poll still sees `running`.
       await vi.advanceTimersByTimeAsync(200);
@@ -142,6 +150,7 @@ describe('ProgressModalComponent', () => {
     try {
       fixture.componentRef.setInput('metric', 'stable');
       TestBed.tick();
+      missCachedHistory('stable');
 
       httpMock.expectOne('/api/eval/train-and-score').flush({
         job_id: 'j2',
@@ -168,6 +177,7 @@ describe('ProgressModalComponent', () => {
     try {
       fixture.componentRef.setInput('metric', 'diverse');
       TestBed.tick();
+      missCachedHistory('diverse');
 
       const trainReq = httpMock.expectOne('/api/eval/train-and-score');
       component.ngOnDestroy();
@@ -180,6 +190,112 @@ describe('ProgressModalComponent', () => {
       httpMock.expectNone((req: HttpRequest<unknown>) =>
         req.url === '/api/eval/train-and-score/result',
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('renders a complete cached history without starting a job', async () => {
+    // The warm-cache fast path: the per-step cache already covers the label
+    // history, so the plot paints straight from the cheap GET and no MLP
+    // retraining is triggered at all.
+    vi.useFakeTimers();
+    try {
+      fixture.componentRef.setInput('metric', 'smart');
+      TestBed.tick();
+
+      httpMock.expectOne(isHistory).flush({
+        metric: 'smart',
+        history: [{ num_labels: 5, error_cost: 0.5 }],
+        complete: true,
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.runningJob).toBe(false);
+      expect(component.chartData.length).toBe(1);
+      httpMock.expectNone('/api/eval/train-and-score');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to the async job when the cached history is incomplete', async () => {
+    // Regression for the hang: the GET must never block on a cache advance, so
+    // an incomplete cache reports `complete: false` and the modal hands off to
+    // the background job — which is what surfaces the progress bar + Cancel.
+    vi.useFakeTimers();
+    try {
+      fixture.componentRef.setInput('metric', 'stable');
+      TestBed.tick();
+
+      expect(component.runningJob).toBe(false);
+      missCachedHistory('stable');
+      expect(component.runningJob).toBe(true);
+      expect(component.analyzing).toBe(true);
+
+      httpMock.expectOne('/api/eval/train-and-score').flush({
+        job_id: 'j3',
+        status: 'done',
+        metric: 'stable',
+        stability: [{ num_labels: 5, num_flips: 1 }],
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.chartData.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to the async job when the cached read fails', async () => {
+    // A failed cached read is recoverable: the job recomputes the series from
+    // scratch, so the modal must not settle on the "no history" empty state.
+    vi.useFakeTimers();
+    try {
+      fixture.componentRef.setInput('metric', 'diverse');
+      TestBed.tick();
+
+      httpMock.expectOne(isHistory).flush(
+        { message: 'Score history computation failed' },
+        { status: 500, statusText: 'Server Error' },
+      );
+      expect(component.runningJob).toBe(true);
+      expect(component.emptyHistory).toBe(false);
+
+      httpMock.expectOne('/api/eval/train-and-score').flush({
+        job_id: 'j4',
+        status: 'done',
+        metric: 'diverse',
+        diversity: [{ num_labels: 5, diversity_level: 2 }],
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.chartData.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows the empty state when a finished job yields no points', async () => {
+    vi.useFakeTimers();
+    try {
+      fixture.componentRef.setInput('metric', 'smart');
+      TestBed.tick();
+      missCachedHistory('smart');
+
+      httpMock.expectOne('/api/eval/train-and-score').flush({
+        job_id: 'j5',
+        status: 'done',
+        metric: 'smart',
+        error_cost: [],
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(component.analyzing).toBe(false);
+      expect(component.emptyHistory).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -31,7 +31,6 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   private progressEvents = inject(ProgressEventsService);
 
   readonly metric = input<ProgressMetric>('smart');
-  readonly useCachedHistory = input(false);
   readonly closed = output<void>();
 
   // Optional query: the canvas only renders in the results `@else` branch.
@@ -41,6 +40,9 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   analysisProgress = 0;
   chartData: ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[] = [];
   emptyHistory = false;
+  /** True once we've fallen back to the async train-and-score job, which
+   *  swaps the brief "loading" line for a real progress bar + Cancel. */
+  runningJob = false;
   /** Job id of the in-flight eval train-and-score run. Set once the
    *  backend hands back a job envelope; consumed by ``onCancel``. */
   private currentJobId: string | null = null;
@@ -59,11 +61,12 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    if (this.useCachedHistory()) {
-      this.loadCachedHistory();
-    } else {
-      this.runAnalysis();
-    }
+    // Always try the cached read first: it never advances the per-step cache,
+    // so it returns immediately whether or not the cache is warm. When the
+    // background `/api/labeling-status` worker has kept up (the common case)
+    // the plot paints instantly; otherwise we fall back to the async job,
+    // which does the retraining off the request thread with a progress bar.
+    this.loadCachedHistory();
   }
 
   ngOnDestroy(): void {
@@ -73,24 +76,35 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
 
   private loadCachedHistory(): void {
     this.analyzing = true;
-    this.sortingApi.getIndicatorScoreHistory(this.metric()).subscribe({
-      next: (res) => {
-        this.analyzing = false;
-        this.chartData = (res.history || []) as ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[];
-        this.emptyHistory = this.chartData.length === 0;
-        if (!this.emptyHistory) {
-          setTimeout(() => this.renderChart(), 50);
-        }
-      },
-      error: () => {
-        this.analyzing = false;
-        this.emptyHistory = true;
-      },
-    });
+    this.sortingApi
+      .getIndicatorScoreHistory(this.metric())
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          // `complete: false` means the per-step cache is behind the label
+          // history. The endpoint deliberately does not advance it (that build
+          // is what used to hang this modal for tens of seconds), so hand off
+          // to the background job instead of rendering a truncated series.
+          if (!res.complete) {
+            this.runAnalysis();
+            return;
+          }
+          this.analyzing = false;
+          this.chartData = (res.history || []) as ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[];
+          this.emptyHistory = this.chartData.length === 0;
+          if (!this.emptyHistory) {
+            setTimeout(() => this.renderChart(), 50);
+          }
+        },
+        // A failed cached read is not fatal: the job path recomputes the
+        // series from scratch, so fall back rather than showing "no history".
+        error: () => this.runAnalysis(),
+      });
   }
 
   private runAnalysis(): void {
     this.analyzing = true;
+    this.runningJob = true;
     this.analysisProgress = 0;
 
     // Progress comes from the `eval` SSE channel on /api/events. Use a
@@ -184,6 +198,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
 
   private applyEvalResult(res: EvalTrainAndScoreResponse): void {
     this.analyzing = false;
+    this.runningJob = false;
     if (this.metric() === 'smart') {
       this.chartData = (res.error_cost || []) as ErrorCostDataPoint[];
     } else if (this.metric() === 'stable') {
@@ -191,7 +206,13 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     } else {
       this.chartData = (res.diversity || []) as DiversityDataPoint[];
     }
-    setTimeout(() => this.renderChart(), 50);
+    // Same empty-state handling as the cached path: a job that legitimately
+    // produces no points (too little history) shows the explanatory message
+    // rather than an empty set of axes.
+    this.emptyHistory = this.chartData.length === 0;
+    if (!this.emptyHistory) {
+      setTimeout(() => this.renderChart(), 50);
+    }
   }
 
   private renderChart(): void {

--- a/tests/api/test_eval_routes_failures.py
+++ b/tests/api/test_eval_routes_failures.py
@@ -84,12 +84,51 @@ class TestIndicatorScoreHistoryFailures:
 
     def test_computation_error_returns_500(self, client):
         with unittest.mock.patch(
-            "vtsearch.routes.eval.calculate_error_cost_over_time",
+            "vtsearch.routes.eval.cached_indicator_history",
             side_effect=RuntimeError("boom"),
         ):
             resp = client.get("/api/indicator-score-history?metric=smart")
         assert resp.status_code == 500
         assert "score history" in resp.get_json()["message"].lower()
+
+
+class TestIndicatorScoreHistoryIsReadOnly:
+    """GET /api/indicator-score-history must never advance the per-step cache.
+
+    Advancing it inline is what made the progress-plot modal hang: it retrains
+    an MLP per uncached label step on the request thread, which is precisely the
+    work ``/api/labeling-status`` defers to a background worker (issue #2397).
+    """
+
+    def test_cold_cache_returns_incomplete_and_trains_nothing(self, client):
+        import vtscore.detectors.labeling_progress as lp
+
+        _seed_votes_and_history()
+        lp.clear_progress_cache()
+
+        with unittest.mock.patch.object(lp, "train_model", side_effect=AssertionError("retrained")):
+            resp = client.get("/api/indicator-score-history?metric=smart")
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["complete"] is False
+        assert body["history"] == []
+        assert lp._cached_steps == []
+
+    def test_warm_cache_returns_the_series(self, client):
+        import vtscore.detectors.labeling_progress as lp
+
+        _seed_votes_and_history()
+        lp.clear_progress_cache()
+        # The background worker's job, done inline here.
+        client.post("/api/eval/train-and-score", json={"metric": "smart", "wait": True})
+
+        resp = client.get("/api/indicator-score-history?metric=smart")
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["complete"] is True
+        assert len(body["history"]) > 0
 
 
 class TestEvalTrainAndScoreStartFailures:

--- a/tests_lib/core/test_image_decode.py
+++ b/tests_lib/core/test_image_decode.py
@@ -1,0 +1,194 @@
+"""Library-tier tests for :mod:`vtscore.media.image.decode`.
+
+Pillow refuses to open an image past twice ``Image.MAX_IMAGE_PIXELS``, raising
+``DecompressionBombError`` ("could be decompression bomb DOS attack") on the
+header alone.  VTSearch lifts that ceiling — a user's gigapixel panorama is
+large, not hostile — and replaces it with a bounded *decode* so peak memory
+stays capped instead.  These tests pin both halves of that trade.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from vtscore.media.image import decode as decode_mod
+from vtscore.media.image.decode import (
+    configure_pil_limits,
+    decode_bounded,
+    decode_bounded_rgb,
+    open_image,
+)
+
+
+def _encode(img: Image.Image, fmt: str = "PNG") -> bytes:
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def restore_pil_limit():
+    """Restore Pillow's global ceiling (and the configured-once latch)."""
+    saved = Image.MAX_IMAGE_PIXELS
+    saved_latch = decode_mod._limits_configured
+    yield
+    Image.MAX_IMAGE_PIXELS = saved
+    decode_mod._limits_configured = saved_latch
+
+
+class TestConfigurePilLimits:
+    def test_lifts_the_decompression_bomb_ceiling(self):
+        configure_pil_limits()
+        assert Image.MAX_IMAGE_PIXELS is None
+
+    def test_applied_at_package_import(self):
+        """Importing the image media type is enough — no explicit call needed.
+
+        The media registry auto-discovers ``vtscore.media.image`` at import, so
+        the ceiling is lifted process-wide before anything decodes an image,
+        including code that reaches for ``PIL.Image.open`` directly.
+        """
+        import vtscore.media.image  # noqa: F401,PLC0415
+
+        assert Image.MAX_IMAGE_PIXELS is None
+
+    def test_reopens_an_image_that_would_have_been_refused(self, restore_pil_limit):
+        """The exact failure a user hit: a big-but-benign image, refused."""
+        blob = _encode(Image.new("RGB", (200, 200), color=(10, 20, 30)))
+
+        # Stand in for a 330 MP source by shrinking the ceiling instead of
+        # allocating one: Pillow's check is purely (pixels > 2 * ceiling).
+        decode_mod._limits_configured = False
+        Image.MAX_IMAGE_PIXELS = 100
+        with pytest.raises(Image.DecompressionBombError):
+            Image.open(io.BytesIO(blob))
+
+        configure_pil_limits()
+        with open_image(blob) as img:
+            assert img.size == (200, 200)
+
+    def test_is_idempotent(self, restore_pil_limit):
+        configure_pil_limits()
+        configure_pil_limits()
+        assert Image.MAX_IMAGE_PIXELS is None
+
+
+class TestDecodeBounded:
+    def test_downsamples_past_the_budget(self):
+        blob = _encode(Image.new("RGB", (400, 200), color=(90, 40, 10)))
+        img, scale = decode_bounded(blob, max_pixels=5_000)
+        with img:
+            assert img.width * img.height <= 5_000
+            # Aspect ratio preserved.
+            assert img.width == pytest.approx(img.height * 2, abs=1)
+            assert scale == pytest.approx(img.width / 400)
+            assert scale < 1.0
+
+    def test_leaves_an_image_inside_the_budget_untouched(self):
+        blob = _encode(Image.new("RGB", (64, 32), color=(1, 2, 3)))
+        img, scale = decode_bounded(blob, max_pixels=1_000_000)
+        with img:
+            assert img.size == (64, 32)
+            assert scale == 1.0
+
+    def test_never_upscales_a_small_image(self):
+        blob = _encode(Image.new("RGB", (8, 8), color=(4, 5, 6)))
+        img, scale = decode_bounded(blob, max_pixels=1_000_000)
+        with img:
+            assert img.size == (8, 8)
+            assert scale == 1.0
+
+    def test_zero_budget_decodes_at_native_size(self):
+        blob = _encode(Image.new("RGB", (300, 300), color=(7, 8, 9)))
+        img, scale = decode_bounded(blob, max_pixels=0)
+        with img:
+            assert img.size == (300, 300)
+            assert scale == 1.0
+
+    def test_accepts_a_filesystem_path(self, tmp_path):
+        path = tmp_path / "big.png"
+        Image.new("RGB", (400, 400), color=(11, 22, 33)).save(path)
+        img, scale = decode_bounded(path, max_pixels=2_500)
+        with img:
+            assert img.width * img.height <= 2_500
+            assert scale < 1.0
+
+    def test_bounds_a_jpeg_through_the_draft_path(self):
+        """JPEG reduction goes via DCT-scaled ``draft``, so it must still fit."""
+        blob = _encode(Image.new("RGB", (512, 512), color=(60, 60, 60)), "JPEG")
+        img, scale = decode_bounded(blob, max_pixels=4_096)
+        with img:
+            assert img.width * img.height <= 4_096
+            assert scale == pytest.approx(img.width / 512)
+
+    def test_rgb_variant_converts_after_downsampling(self):
+        blob = _encode(Image.new("RGBA", (400, 400), color=(1, 2, 3, 128)))
+        img, scale = decode_bounded_rgb(blob, max_pixels=2_500)
+        with img:
+            assert img.mode == "RGB"
+            assert img.width * img.height <= 2_500
+            assert scale < 1.0
+
+    def test_scale_maps_coordinates_back_to_the_original(self):
+        """The contract extractors rely on: ``coord / scale`` is original space."""
+        blob = _encode(Image.new("RGB", (1000, 500), color=(70, 70, 70)))
+        img, scale = decode_bounded(blob, max_pixels=10_000)
+        with img:
+            # A box spanning the decoded image maps back to the full original.
+            assert img.width / scale == pytest.approx(1000, abs=2)
+            assert img.height / scale == pytest.approx(500, abs=2)
+
+
+class TestOpenImage:
+    def test_reads_dimensions_without_decoding(self):
+        blob = _encode(Image.new("RGB", (321, 123), color=(9, 9, 9)))
+        with open_image(blob) as img:
+            assert (img.width, img.height) == (321, 123)
+
+
+class TestOversizedImagesSurviveIngest:
+    """End-to-end: a source past the ceiling is kept, not dropped."""
+
+    def test_thumbnail_is_generated_for_an_oversized_source(self, restore_pil_limit):
+        from vtscore.media.image.thumbnail import DEFAULT_MAX_DIM, make_image_thumbnail  # noqa: PLC0415
+
+        blob = _encode(Image.new("RGB", (900, 600), color=(200, 40, 40)), "JPEG")
+        decode_mod._limits_configured = False
+        Image.MAX_IMAGE_PIXELS = 1_000  # 900*600 is well past 2x this
+
+        configure_pil_limits()
+        result = make_image_thumbnail(blob)
+        assert result is not None
+        thumb_bytes, mimetype = result
+        assert mimetype == "image/jpeg"
+        with Image.open(io.BytesIO(thumb_bytes)) as out:
+            assert max(out.size) <= DEFAULT_MAX_DIM
+
+    def test_media_type_records_dimensions_for_an_oversized_source(self, restore_pil_limit, tmp_path):
+        from vtscore.media.image.media_type import ImageMediaType  # noqa: PLC0415
+
+        blob = _encode(Image.new("RGB", (900, 600), color=(30, 200, 90)), "JPEG")
+        decode_mod._limits_configured = False
+        Image.MAX_IMAGE_PIXELS = 1_000
+
+        configure_pil_limits()
+        data = ImageMediaType().load_media_data(tmp_path / "huge.jpg", media_bytes=blob)
+        # Native dimensions, not the bounded decode's: the stored bytes are the
+        # untouched original and crop boxes are expressed against them.
+        assert (data["width"], data["height"]) == (900, 600)
+        assert data["thumbnail_bytes"]
+
+    def test_embedder_bulk_loader_decodes_an_oversized_source(self, restore_pil_limit):
+        from vtscore.media.image._image_bulk import _load_pil  # noqa: PLC0415
+
+        blob = _encode(Image.new("RGB", (900, 600), color=(20, 20, 200)), "JPEG")
+        decode_mod._limits_configured = False
+        Image.MAX_IMAGE_PIXELS = 1_000
+
+        configure_pil_limits()
+        img = _load_pil(blob)
+        assert img is not None
+        assert img.mode == "RGB"

--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -80,12 +80,18 @@ class TestThinLoadFromFolder:
         load_dataset_from_folder(tmp_path, "audio", medias, thin=True)
         assert medias[1]["md5"] == expected_md5
 
-    def test_thin_no_duration(self, tmp_path):
-        """Thin mode skips load_media_data, so duration stays at default 0."""
+    def test_thin_has_duration_and_waveform(self, tmp_path):
+        """Thin mode still builds the ingest-time display fields.
+
+        Audio has a browsable thumbnail (its waveform PNG), so a thin load runs
+        ``load_thin_media_data`` and picks up the decoded duration alongside it.
+        Only the *payload* is withheld — see ``test_thin_clips_have_no_bytes``.
+        """
         _make_wav_file(tmp_path, "test.wav")
         medias: dict[int, dict[str, Any]] = {}
         load_dataset_from_folder(tmp_path, "audio", medias, thin=True)
-        assert medias[1]["duration"] == 0
+        assert medias[1]["duration"] > 0
+        assert medias[1]["thumbnail_bytes"]
 
     def test_full_mode_has_bytes(self, tmp_path):
         """Full mode (thin=False) should still load bytes as before."""

--- a/tests_lib/datasets/test_thumbnail_persistence.py
+++ b/tests_lib/datasets/test_thumbnail_persistence.py
@@ -9,18 +9,24 @@ original on a cold tile fetch.  These tests lock two things:
 2. ``export_dataset_to_file`` writes every media type's ``pickle_extra_fields``
    (not just a hardcoded list), so ``thumbnail_bytes`` survives a pickle
    round-trip.  This previously silently dropped for audio/video too.
+3. A **thin** load (the "Reference files in place" option / CLI ``--thin``)
+   precomputes the same thumbnail as a full load while still leaving
+   ``media_bytes`` empty, so referenced datasets browse at the same speed as
+   copied ones.
 """
 
 from __future__ import annotations
 
 import io
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from PIL import Image
 
-from vtscore.datasets.loader import export_dataset_to_file
+from vtscore.datasets.loader import export_dataset_to_file, load_dataset_from_folder
 from vtscore.datasets.loader_pickle import load_dataset_from_pickle
+from vtscore.media.document.media_type import DocumentMediaType
 from vtscore.media.image.media_type import ImageMediaType
 
 
@@ -87,3 +93,75 @@ class TestThumbnailSurvivesPickleRoundTrip:
         load_dataset_from_pickle(pkl, loaded)
 
         assert loaded[1]["thumbnail_bytes"] == thumb
+
+
+def _thin_load_images(folder: Path) -> dict[int, dict[str, Any]]:
+    medias: dict[int, dict[str, Any]] = {}
+    load_dataset_from_folder(folder, "image", medias, thin=True)
+    return medias
+
+
+class TestThinLoadPrecomputesThumbnails:
+    """A thin load keeps the payload out of memory but not the preview."""
+
+    def test_thin_image_load_has_thumbnail_but_no_bytes(self, tmp_path: Path):
+        (tmp_path / "a.png").write_bytes(_png_bytes())
+        (tmp_path / "b.png").write_bytes(_png_bytes(color=(200, 30, 30)))
+
+        medias = _thin_load_images(tmp_path)
+
+        assert len(medias) == 2
+        for media in medias.values():
+            # Still a pure path reference: the point of a thin load.
+            assert media["media_bytes"] is None
+            assert media["media_string"] is None
+            assert Path(media["media_path"]).exists()
+            # ...but the browse/grid tile no longer decodes the original.
+            assert media["thumbnail_bytes"]
+            with Image.open(io.BytesIO(media["thumbnail_bytes"])) as thumb:
+                assert max(thumb.size) <= 384
+
+    def test_thin_load_records_dimensions(self, tmp_path: Path):
+        (tmp_path / "a.png").write_bytes(_png_bytes(size=(1200, 800)))
+
+        media = _thin_load_images(tmp_path)[1]
+
+        assert (media["width"], media["height"]) == (1200, 800)
+
+    def test_thin_and_full_loads_produce_the_same_thumbnail(self, tmp_path: Path):
+        (tmp_path / "a.png").write_bytes(_png_bytes())
+
+        thin = _thin_load_images(tmp_path)[1]
+        full: dict[int, dict[str, Any]] = {}
+        load_dataset_from_folder(tmp_path, "image", full, thin=False)
+
+        assert thin["thumbnail_bytes"] == full[1]["thumbnail_bytes"]
+
+    def test_thin_thumbnail_survives_pickle_round_trip(self, tmp_path: Path):
+        (tmp_path / "a.png").write_bytes(_png_bytes())
+        medias = _thin_load_images(tmp_path)
+        rng = np.random.default_rng(11)
+        medias[1]["embeddings"] = {"siglip": rng.standard_normal(512).astype(np.float32)}
+
+        pkl = tmp_path / "ds.pkl"
+        pkl.write_bytes(export_dataset_to_file(medias, embedder="siglip", media_type="image"))
+        loaded: dict = {}
+        load_dataset_from_pickle(pkl, loaded)
+
+        # Without an ingest-time thumbnail the save-side backfill can't help a
+        # thin media (it needs ``media_bytes``), so this would be None before.
+        assert loaded[1]["thumbnail_bytes"] == medias[1]["thumbnail_bytes"]
+
+    def test_undecodable_source_thins_without_raising(self, tmp_path: Path):
+        (tmp_path / "bad.png").write_bytes(b"not an image")
+
+        media = _thin_load_images(tmp_path)[1]
+
+        assert media["media_bytes"] is None
+        assert media["thumbnail_bytes"] is None
+
+
+class TestThinLoadSkipsTypesWithNoIngestArtifact:
+    def test_document_thin_load_reads_nothing(self, tmp_path: Path):
+        """Documents rasterise their preview on request, so a thin load stays pure."""
+        assert DocumentMediaType().load_thin_media_data(tmp_path / "missing.pdf") == {}

--- a/tests_lib/detectors/test_indicator_history_cache.py
+++ b/tests_lib/detectors/test_indicator_history_cache.py
@@ -1,0 +1,222 @@
+"""Tests for the read-only indicator-history path and its per-step cache costs.
+
+The progress-plot modal used to load its series through the
+``calculate_*_over_time`` helpers, which call ``_ensure_cache`` and therefore
+retrain one MLP per uncached label step - plus, on a cold cache, a full
+hierarchical-k-means coverage-atlas build - on the calling thread while holding
+``_progress_lock``.  ``/api/labeling-status`` deliberately defers exactly that
+work to a background worker (issue #2397), so the cache is behind for most of a
+labeling session and the modal absorbed the whole deferred build.
+
+These tests pin the three pieces that fixed it:
+
+* :func:`cached_indicator_history` reads the cache and **never advances it**,
+  reporting ``complete=False`` instead, and never blocks on ``_progress_lock``.
+* The stability pass's monitored pool is materialised once per cache lifetime
+  rather than once per label step.
+* The fallback coverage-atlas build applies the same depth cap as every other
+  build site.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+
+import vtscore.detectors.labeling_progress as lp
+from vtscore.embedding.media_vectors import EMBEDDINGS_KEY
+
+
+def _clips(n: int, dim: int = 8, seed: int = 0) -> dict[int, dict]:
+    rng = np.random.default_rng(seed)
+    return {
+        cid: {EMBEDDINGS_KEY: {"test": rng.standard_normal(dim).astype(np.float32)}, "embedder": "test"}
+        for cid in range(n)
+    }
+
+
+def _history(n_votes: int) -> list[tuple[int, str, float]]:
+    return [(k, "good" if k % 2 == 0 else "bad", float(k)) for k in range(n_votes)]
+
+
+def _votes(n_votes: int) -> tuple[dict[int, None], dict[int, None]]:
+    good = {k: None for k in range(n_votes) if k % 2 == 0}
+    bad = {k: None for k in range(n_votes) if k % 2 == 1}
+    return good, bad
+
+
+class TestCachedIndicatorHistory:
+    def test_cold_cache_reports_incomplete_without_advancing(self):
+        """The whole point: a cold read must not trigger any per-step training."""
+        clips = _clips(60)
+        history = _history(8)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+
+        data, complete = lp.cached_indicator_history("smart", clips, history, good, bad, 0)
+
+        assert complete is False
+        assert data == []
+        # No steps were built: the cache is exactly as cold as we left it.
+        assert lp._cached_steps == []
+
+    def test_warm_cache_returns_series_for_every_metric(self):
+        clips = _clips(60)
+        history = _history(8)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+
+        # Advance the cache the way the background worker does.
+        lp.calculate_error_cost_over_time(clips, history, good, bad, 0)
+
+        for metric in ("smart", "stable", "diverse"):
+            data, complete = lp.cached_indicator_history(metric, clips, history, good, bad, 0)
+            assert complete is True, metric
+            assert len(data) > 0, metric
+
+    def test_partially_advanced_cache_reports_incomplete(self):
+        """A cache covering only a prefix must not yield a truncated plot."""
+        clips = _clips(60)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+
+        lp.calculate_error_cost_over_time(clips, _history(4), good, bad, 0)
+        # More votes have landed since the last background refresh.
+        data, complete = lp.cached_indicator_history("smart", clips, _history(8), good, bad, 0)
+
+        assert complete is False
+        assert data == []
+
+    def test_inclusion_change_reports_incomplete(self):
+        """A cache built for another inclusion value would be rebuilt on read."""
+        clips = _clips(60)
+        history = _history(8)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+
+        lp.calculate_error_cost_over_time(clips, history, good, bad, 0)
+        _, complete = lp.cached_indicator_history("smart", clips, history, good, bad, 5)
+
+        assert complete is False
+        # The read must not have rebuilt the cache under the new inclusion.
+        assert lp._cache_inclusion == 0
+
+    def test_does_not_block_on_an_in_flight_cache_build(self, monkeypatch):
+        """A click landing mid-refresh falls through instead of hanging.
+
+        The background worker holds ``_progress_lock`` for the entire build, so
+        a blocking read would reintroduce exactly the hang this path exists to
+        avoid.
+        """
+        monkeypatch.setattr(lp, "_CACHE_READ_LOCK_TIMEOUT", 0.05)
+        clips = _clips(60)
+        history = _history(8)
+        good, bad = _votes(8)
+        lp.clear_progress_cache()
+        lp.calculate_error_cost_over_time(clips, history, good, bad, 0)
+
+        holding = threading.Event()
+        release = threading.Event()
+
+        def _hold_lock():
+            with lp._progress_lock:
+                holding.set()
+                release.wait(timeout=5)
+
+        holder = threading.Thread(target=_hold_lock, daemon=True)
+        holder.start()
+        try:
+            assert holding.wait(timeout=5)
+            # The cache is complete, but the lock is held: report unavailable
+            # rather than waiting for the holder.
+            data, complete = lp.cached_indicator_history("smart", clips, history, good, bad, 0)
+            assert complete is False
+            assert data == []
+        finally:
+            release.set()
+            holder.join(timeout=5)
+
+        # Once the lock frees up the same read succeeds.
+        _, complete = lp.cached_indicator_history("smart", clips, history, good, bad, 0)
+        assert complete is True
+
+
+class TestMonitoredPoolReuse:
+    def test_pool_tensor_is_built_once_per_cache_lifetime(self):
+        """Advancing further steps must reuse the pool, not re-materialise it.
+
+        Rebuilding it per step was an O(N x D) numpy materialisation on every
+        label-history step and dominated the cost of advancing the cache.
+        """
+        clips = _clips(200)
+        good, bad = _votes(6)
+        lp.clear_progress_cache()
+
+        lp.calculate_prediction_stability_over_time(clips, _history(6), 0)
+        first = lp._cache_monitored_X
+        assert first is not None
+        assert lp._cache_monitored_ids is not None
+
+        # Advance the cache with more steps: same pool object, no rebuild.
+        lp.calculate_prediction_stability_over_time(clips, _history(12), 0)
+        assert lp._cache_monitored_X is first
+
+    def test_pool_is_dropped_on_cache_clear(self):
+        """Medias may have changed, so the derived pool must not survive."""
+        clips = _clips(60)
+        lp.clear_progress_cache()
+        lp.calculate_prediction_stability_over_time(clips, _history(6), 0)
+        assert lp._cache_monitored_X is not None
+
+        lp.clear_progress_cache()
+
+        assert lp._cache_monitored_X is None
+        assert lp._cache_monitored_ids is None
+        assert lp._cache_monitored_set is None
+
+    def test_stability_counts_match_the_unsampled_pool(self):
+        """Scoring the whole pool and dropping labels must not change the counts."""
+        clips = _clips(60)
+        lp.clear_progress_cache()
+
+        stability = lp.calculate_prediction_stability_over_time(clips, _history(6), 0)
+
+        assert stability
+        for entry in stability:
+            # 60 medias, `num_labels` of them labeled at that step.
+            assert entry["num_unlabeled"] == 60 - entry["num_labels"]
+
+
+class TestFallbackAtlasDepth:
+    def test_fallback_build_applies_the_depth_cap(self, monkeypatch):
+        """The fallback atlas must not be deeper than the context atlas it stands in for.
+
+        Omitting ``max_depth`` left this build on ``COVERAGE_ATLAS_MAX_DEPTH``
+        while every other build site passes ``auto_max_depth``, so the throwaway
+        atlas cost many more k-means fits than the real one.
+        """
+        import vtscore.state.coverage_atlas as ca
+
+        monkeypatch.setattr(lp, "_active_context_atlas", lambda: None)
+        monkeypatch.setattr(ca, "auto_max_depth", lambda n, k=3, **kw: 2)
+
+        atlas = lp._build_coverage_atlas(_clips(120))
+
+        assert atlas is not None
+        assert atlas.max_depth == 2
+
+    def test_reuses_the_context_atlas_structure_when_ids_match(self, monkeypatch):
+        """The clone path skips the hierarchical k-means entirely."""
+        from vtscore.state.coverage_atlas import CoverageAtlas
+
+        clips = _clips(120)
+        vectors = {cid: media[EMBEDDINGS_KEY]["test"] for cid, media in clips.items()}
+        ctx_atlas = CoverageAtlas(vectors, k=3)
+        monkeypatch.setattr(lp, "_active_context_atlas", lambda: ctx_atlas)
+
+        atlas = lp._build_coverage_atlas(clips)
+
+        assert atlas is not ctx_atlas
+        # Structure shared by reference; only the label overlay is fresh.
+        assert atlas.nodes is ctx_atlas.nodes

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -179,6 +179,19 @@ def resolve_device() -> str:
 # out-of-the-box "no limit" behaviour) for genuinely large-archive uploads.
 MAX_UPLOAD_MB = max(0, int(os.environ.get("VTSEARCH_MAX_UPLOAD_MB", "2048")))
 
+# Pixel budget for a single image *decode*.  Pillow's own decompression-bomb
+# ceiling is lifted at startup (see :mod:`vtscore.media.image.decode`) so a
+# merely-large photo — a gigapixel panorama, a whole-slide scan — is imported
+# rather than refused; this budget replaces it with the protection that
+# actually matters, capping how big a bitmap any one decode may materialise.
+# Sources above it are downsampled (aspect preserved) before the pixels reach
+# a thumbnail, embedder, extractor or converter, all of which resize to a few
+# hundred pixels anyway.  64 MP is ~192 MB as RGB — comfortably above any
+# real photograph, so ordinary media is never touched.  Crop/clip paths
+# deliberately bypass this and decode at native size.  Set
+# ``VTSEARCH_MAX_DECODE_PIXELS=0`` to disable bounding entirely.
+MAX_DECODE_PIXELS = max(0, int(os.environ.get("VTSEARCH_MAX_DECODE_PIXELS", str(64_000_000))))
+
 # Training
 #
 # ``TRAIN_EPOCHS`` is an *upper bound*; :func:`vtscore.training.mlp.train_model`

--- a/vtscore/converters/image2face.py
+++ b/vtscore/converters/image2face.py
@@ -177,9 +177,8 @@ class Image2FaceMediaConverter(MediaConverter):
     # ------------------------------------------------------------------
 
     def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
-        from PIL import Image  # noqa: PLC0415
-
         from vtscore.media.embedder import media_from_path  # noqa: PLC0415
+        from vtscore.media.image.decode import decode_bounded_rgb  # noqa: PLC0415
 
         threshold, padding, min_size = self._resolve_params(params)
 
@@ -191,7 +190,10 @@ class Image2FaceMediaConverter(MediaConverter):
         if not media_bytes:
             return []
         try:
-            img = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+            # Bounded decode: detection *and* the face crops below both come off
+            # this one image, so they stay in a single consistent coordinate
+            # space and a gigapixel group photo never has to fit in memory.
+            img, _scale = decode_bounded_rgb(media_bytes)
         except Exception:
             return []
         img_w, img_h = img.size

--- a/vtscore/converters/image2text.py
+++ b/vtscore/converters/image2text.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +26,8 @@ def _run_paddleocr(media_bytes: bytes, filename: str, language: str) -> list | N
     """Decode image bytes and run PaddleOCR, returning the raw per-region results."""
     try:
         import numpy as np  # noqa: PLC0415
-        from PIL import Image  # noqa: PLC0415
+
+        from vtscore.media.image.decode import decode_bounded_rgb  # noqa: PLC0415
     except ImportError:
         print("Image2TextMediaConverter requires Pillow and numpy")
         return None
@@ -39,7 +39,9 @@ def _run_paddleocr(media_bytes: bytes, filename: str, language: str) -> list | N
         return None
 
     try:
-        image = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+        # Bounded decode: OCR reads a transcript, not pixel coordinates, so a
+        # huge scan can be capped without changing what comes back.
+        image, _scale = decode_bounded_rgb(media_bytes)
     except Exception as e:
         print(f"Image2TextMediaConverter: failed to open {filename}: {e}")
         return None

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -453,6 +453,13 @@ def _build_per_file_media(
             file_path.stat().st_size,
             origin,
         )
+        # Thin keeps the *payload* out of memory, not the preview: without an
+        # ingest-time thumbnail every grid / VTSBrowse tile re-decodes the
+        # full-resolution original on each cold request.  Merge in the display
+        # fields only (see ``MediaType.load_thin_media_data``); ``media_bytes``
+        # stays None, so the media is still a path reference.
+        if mt.has_thumbnail:
+            media_data.update(mt.load_thin_media_data(file_path))
     else:
         with open(file_path, "rb") as f:
             file_bytes = f.read()

--- a/vtscore/datasets/pdf.py
+++ b/vtscore/datasets/pdf.py
@@ -104,6 +104,7 @@ def load_pdf_images_into(
     provenance points back to the source document.
     """
     from vtscore.media import get_by_folder_name  # noqa: PLC0415
+    from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
     from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks  # noqa: PLC0415
 
     pdf_files = sorted(rglob_follow_symlinks(folder, "*.pdf") if recursive else glob_top_level(folder, "*.pdf"))
@@ -129,6 +130,12 @@ def load_pdf_images_into(
             else:
                 full_page_name = page_name
 
+            # Downscale to a grid/list thumbnail now, while the rendered page is
+            # already in hand.  A thin load discards ``image_bytes`` entirely and
+            # a full one only keeps them until save, so without this every tile
+            # re-renders the whole PDF page at request time.
+            thumb = make_image_thumbnail(image_bytes)
+
             media_data: dict[str, Any] = {
                 "id": media_id,
                 "media_type": mt.type_id,
@@ -146,6 +153,7 @@ def load_pdf_images_into(
                 "duration": 0,
                 "width": pil_image.width,
                 "height": pil_image.height,
+                "thumbnail_bytes": thumb[0] if thumb is not None else None,
             }
             medias[media_id] = media_data
             media_id += 1

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -54,6 +54,15 @@ _cache_bad_ids: set[int] = set()
 _cache_prev_predictions: Optional[dict[int, int]] = None
 _cache_coverage_atlas: Any = None  # CoverageAtlas | None
 
+# Fixed pool the per-step stability forward pass scores, built once per cache
+# lifetime and reused by every step (see ``_monitored_pool``).  ``_cache_
+# monitored_X`` is a device-resident float tensor of the pool's embeddings;
+# ``_cache_monitored_set`` is the id set for O(labels) unlabeled counting.
+# In-memory only - never serialized (see the "No Persisted Vectors" rule).
+_cache_monitored_ids: Optional[list[int]] = None
+_cache_monitored_X: Any = None  # torch.Tensor | None
+_cache_monitored_set: Optional[set[int]] = None
+
 # Last fully-computed ``/api/labeling-status`` payload (minus the transient
 # ``stale`` flag).  ``compute_labeling_status`` refreshes it on every full
 # compute; the route returns it immediately to pollers while a background
@@ -73,18 +82,24 @@ _live_models: dict[tuple[frozenset[int], frozenset[int]], tuple[Any, float]] = {
 # call clear_progress_cache internally when the inclusion value changes.
 _progress_lock = threading.RLock()
 
-# Upper bound on the number of unlabeled items the per-step stability
-# forward pass evaluates.  ``/api/labeling-status`` (polled every 2 s during
-# labeling) advances this cache on the request thread, and the stability
-# pass runs a forward over *all* unlabeled media - O(dataset) per new vote.
+# Upper bound on the number of items the per-step stability forward pass
+# evaluates.  Advancing this cache (from the ``/api/labeling-status``
+# background worker, or the ``/api/eval/train-and-score`` job) runs a forward
+# over the whole monitored pool once per label step - O(dataset) per new vote.
 # Above this cap we score a deterministic seeded sample of the eligible pool
-# instead, holding the per-poll cost flat as datasets grow.  The "stable"
+# instead, holding the per-step cost flat as datasets grow.  The "stable"
 # indicator keys off the flip *rate* (num_flips / num_unlabeled), for which a
 # fixed random sample is an unbiased estimator; sampling from the *full*
 # eligible pool (not the shrinking unlabeled set) keeps the monitored ids
 # stable across steps so the step-to-step flip comparison stays meaningful.
 # Mirrors ``_GMM_MAX_SAMPLES`` in ``vtscore.training.thresholds``.
 _STABILITY_MAX_SAMPLES = 50_000
+
+# How long :func:`cached_indicator_history` will wait for ``_progress_lock``
+# before declaring the cache unreadable.  Long enough to ride out the brief
+# holds taken by status reads, short enough that a click landing mid-build
+# falls through to the async job instead of hanging on it.
+_CACHE_READ_LOCK_TIMEOUT = 0.25
 
 
 def clear_progress_cache() -> None:
@@ -94,6 +109,7 @@ def clear_progress_cache() -> None:
     is altered so that stale models are not reused.
     """
     global _cache_inclusion, _cache_prev_predictions, _cache_coverage_atlas, _status_snapshot
+    global _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set
     with _progress_lock:
         _cached_steps.clear()
         _cache_good_ids.clear()
@@ -101,6 +117,11 @@ def clear_progress_cache() -> None:
         _cache_prev_predictions = None
         _cache_inclusion = None
         _cache_coverage_atlas = None
+        # The monitored pool is derived from ``clips_dict``; medias may have
+        # changed under us, so drop it alongside everything else.
+        _cache_monitored_ids = None
+        _cache_monitored_X = None
+        _cache_monitored_set = None
         _live_models.clear()
         # Drop the status snapshot too: it belonged to the just-cleared
         # detector/labelset and would otherwise be served (stale) for the next
@@ -228,9 +249,16 @@ def _build_coverage_atlas(clips_dict: dict[int, dict[str, Any]]) -> Any:
     if ctx_atlas is not None and ctx_atlas.vector_to_leaf.keys() == vectors.keys():
         return ctx_atlas.structural_clone()
 
-    from vtscore.state.coverage_atlas import CoverageAtlas  # noqa: PLC0415
+    from vtscore.state.coverage_atlas import CoverageAtlas, auto_max_depth  # noqa: PLC0415
 
-    return CoverageAtlas(vectors, k=3)
+    # Cap the depth exactly as every other build site does
+    # (``build_coverage_atlas`` / ``build_coverage_atlas_for_context``).
+    # Omitting it left this fallback on ``COVERAGE_ATLAS_MAX_DEPTH``, so the
+    # atlas built here was *deeper* - and cost many more k-means fits - than
+    # the context atlas it stands in for.  That is the whole cost of a cold
+    # progress-cache build on a dataset large enough to skip the load-time
+    # atlas build, and it runs under ``_progress_lock``.
+    return CoverageAtlas(vectors, k=3, max_depth=auto_max_depth(len(vectors), k=3))
 
 
 def _apply_label_event(media_id: int, label: str) -> bool:
@@ -288,6 +316,54 @@ def _collect_training_data(
     return X_list, y_list
 
 
+def _monitored_pool(
+    clips_dict: dict[int, dict[str, Any]],
+    all_media_ids: list[int],
+) -> tuple[list[int], Any, set[int]]:
+    """Return the fixed ``(ids, X, id_set)`` pool the stability pass scores.
+
+    The pool is the embeddable subset of *all_media_ids*, bounded to a
+    deterministic seeded sample of ``_STABILITY_MAX_SAMPLES``.  Sampling the
+    full eligible pool (rather than the per-step unlabeled set) keeps the
+    monitored ids stable across steps, so the flip comparison against
+    ``_cache_prev_predictions`` stays over a consistent id set; the resulting
+    flip *rate* is an unbiased estimate of the true rate.
+
+    Built once per cache lifetime and memoised.  It used to be rebuilt inside
+    every step - an O(N x D) numpy materialisation per label-history step,
+    which dominated the cost of advancing the cache.  The pool depends only on
+    *clips_dict*, which cannot change without a ``clear_progress_cache()``,
+    so one build per cache lifetime is sound.
+    """
+    global _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set
+
+    if _cache_monitored_ids is not None:
+        return _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set  # type: ignore[return-value]
+
+    import torch  # noqa: PLC0415
+
+    from vtscore.embedding.loader import ensure_torch_configured, get_torch_device  # noqa: PLC0415
+
+    eligible = [cid for cid in all_media_ids if media_embedding(clips_dict.get(cid, {})) is not None]
+    if len(eligible) > _STABILITY_MAX_SAMPLES:
+        rng = np.random.default_rng(42)
+        sampled = set(rng.choice(np.asarray(eligible), size=_STABILITY_MAX_SAMPLES, replace=False).tolist())
+        eligible = [cid for cid in eligible if cid in sampled]
+
+    if eligible:
+        ensure_torch_configured()
+        embs = np.array([media_embedding(clips_dict[cid]) for cid in eligible])
+        # Park the tensor on the training device once so per-step scoring is a
+        # pure forward pass with no host->device copy.
+        _cache_monitored_X = torch.tensor(embs, dtype=torch.float32).to(get_torch_device())
+    else:
+        _cache_monitored_X = None
+
+    _cache_monitored_ids = eligible
+    _cache_monitored_set = set(eligible)
+    return _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set
+
+
 def _compute_step_stability(
     model: nn.Sequential,
     threshold: float,
@@ -300,33 +376,27 @@ def _compute_step_stability(
     global _cache_prev_predictions
     import torch  # noqa: PLC0415
 
+    monitored_ids, X_monitored, monitored_set = _monitored_pool(clips_dict, all_media_ids)
+
     labeled_ids = _cache_good_ids | _cache_bad_ids
-    eligible = [cid for cid in all_media_ids if media_embedding(clips_dict.get(cid, {})) is not None]
+    # Labels are few relative to the pool, so count the overlap from the
+    # labelset rather than rescanning the pool.
+    num_unlabeled = len(monitored_ids) - sum(1 for cid in labeled_ids if cid in monitored_set)
 
-    # Bound the forward pass to a deterministic seeded sample of the eligible
-    # pool.  Sampling the full pool (rather than the per-step unlabeled set)
-    # keeps the monitored ids stable across steps, so the flip comparison
-    # against ``_cache_prev_predictions`` below stays over a consistent id set;
-    # the resulting flip *rate* is an unbiased estimate of the true rate.
-    if len(eligible) > _STABILITY_MAX_SAMPLES:
-        rng = np.random.default_rng(42)
-        monitored = set(rng.choice(np.asarray(eligible), size=_STABILITY_MAX_SAMPLES, replace=False).tolist())
-        unlabeled_ids = [cid for cid in eligible if cid not in labeled_ids and cid in monitored]
-    else:
-        unlabeled_ids = [cid for cid in eligible if cid not in labeled_ids]
-
-    if not unlabeled_ids:
+    if num_unlabeled <= 0 or X_monitored is None:
         return {"time_index": t, "num_labels": num_labels, "num_flips": 0, "num_unlabeled": 0}
 
-    unlabeled_embs = np.array([media_embedding(clips_dict[cid]) for cid in unlabeled_ids])
-    X_unlabeled = torch.tensor(unlabeled_embs, dtype=torch.float32)
-
+    # Score the whole monitored pool in one pass and drop the currently-labeled
+    # ids afterwards.  Scoring the handful of extra (labeled) rows is far
+    # cheaper than re-materialising a per-step tensor of the unlabeled subset.
     with torch.no_grad():
-        X_unlabeled = X_unlabeled.to(next(model.parameters()).device)
-        scores_unl = torch.sigmoid(model(X_unlabeled)).squeeze(1).cpu().tolist()
+        X_in = X_monitored.to(next(model.parameters()).device)
+        scores_unl = torch.sigmoid(model(X_in)).squeeze(1).cpu().tolist()
 
     predictions: dict[int, int] = {
-        cid: 1 if score >= threshold else 0 for cid, score in zip(unlabeled_ids, scores_unl, strict=True)
+        cid: 1 if score >= threshold else 0
+        for cid, score in zip(monitored_ids, scores_unl, strict=True)
+        if cid not in labeled_ids
     }
 
     stability: Optional[dict[str, Any]] = None
@@ -340,7 +410,7 @@ def _compute_step_stability(
             "time_index": t,
             "num_labels": num_labels,
             "num_flips": num_flips,
-            "num_unlabeled": len(unlabeled_ids),
+            "num_unlabeled": num_unlabeled,
         }
     # else: no prior predictions to compare - leave stability as None.
 
@@ -888,6 +958,55 @@ def compute_labeling_status(
     with _progress_lock:
         _status_snapshot = dict(result)
     return result
+
+
+def cached_indicator_history(
+    metric: str,
+    clips_dict: dict[int, dict[str, Any]],
+    label_history: list[tuple[int, str, float]],
+    current_good_votes: dict[int, None],
+    current_bad_votes: dict[int, None],
+    inclusion_value: int = 0,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Read *metric*'s per-step history **without advancing the cache**.
+
+    Returns ``(history, complete)``.  ``complete`` is ``False`` - with an empty
+    history - whenever the per-step cache does not already cover the whole of
+    *label_history*; the caller is expected to fall back to the async
+    ``/api/eval/train-and-score`` job, which does the same work on a background
+    thread with progress and cancellation.
+
+    This is the counterpart to the ``calculate_*_over_time`` functions, which
+    call :func:`_ensure_cache` and therefore retrain an MLP per uncached step
+    on the calling thread.  Doing that inline is exactly what
+    ``/api/labeling-status`` refuses to do (issue #2397), so the read path that
+    backs the progress-plot modal must not do it either.
+
+    When the cache *is* complete every branch is cheap: ``smart`` runs forward
+    passes of the cached models over the (small) labeled set, and ``stable`` /
+    ``diverse`` are plain reads of values recorded during the cache build.
+    """
+    # Reading the cache needs ``_progress_lock``, but a background worker holds
+    # that lock for the *entire* duration of a cache build - which is exactly
+    # the multi-second work this function exists to avoid waiting on.  Blocking
+    # here would reintroduce the hang whenever the click lands mid-refresh, so
+    # give up quickly and report the cache as unavailable: the caller falls back
+    # to the async job, which is the right answer in that state anyway.
+    if not _progress_lock.acquire(timeout=_CACHE_READ_LOCK_TIMEOUT):
+        return [], False
+    try:
+        if not is_status_cache_fresh(label_history, inclusion_value):
+            return [], False
+
+        if metric == "smart":
+            data = _eval_cached_models(clips_dict, current_good_votes, current_bad_votes, inclusion_value)
+        elif metric == "stable":
+            data = [step["stability"] for step in _cached_steps if step["stability"] is not None]
+        else:
+            data = [step["diversity"] for step in _cached_steps if step.get("diversity") is not None]
+        return data, True
+    finally:
+        _progress_lock.release()
 
 
 def is_status_cache_fresh(label_history: list[tuple[int, str, float]], inclusion_value: int) -> bool:

--- a/vtscore/media/base.py
+++ b/vtscore/media/base.py
@@ -522,6 +522,36 @@ class MediaType(ABC):
             {"media_bytes": b"...", "duration": 0, "width": 32, "height": 32}
         """
 
+    #: Keys that carry a media's full payload.  A thin load stores a
+    #: ``media_path`` reference instead of these, so
+    #: :meth:`load_thin_media_data` strips them from whatever
+    #: :meth:`load_media_data` returns.
+    _PAYLOAD_KEYS = ("media_bytes", "media_string")
+
+    def load_thin_media_data(self, file_path: Path) -> dict:
+        """Return the *display* fields for a thin load: no payload, no re-read later.
+
+        A thin load (the "Reference files in place" importer option, and every
+        CLI ``--thin`` workflow) deliberately keeps a media's bytes out of
+        memory.  It used to skip :meth:`load_media_data` wholesale, which also
+        skipped the ingest-time ``thumbnail_bytes`` — so every grid / VTSBrowse
+        tile fell back to decoding the full-resolution original on each cold
+        request (~200 ms for a 12 MP photo, paid again after any reload).
+
+        This hook produces the same display artifacts the full path does
+        (``thumbnail_bytes``, ``width`` / ``height``, ``duration``) while
+        leaving the payload behind.  The default reads the file once through
+        :meth:`load_media_data` and drops :data:`_PAYLOAD_KEYS`; peak memory is
+        therefore one file at a time rather than the whole dataset.  Override
+        when the artifacts can be derived from the path without reading the
+        bytes at all (see the video type), or return ``{}`` when the type has
+        no ingest-time artifact worth the read.
+
+        Only called for types whose items have a browsable thumbnail
+        (:attr:`has_thumbnail`); everything else keeps the pure-reference load.
+        """
+        return {k: v for k, v in self.load_media_data(file_path).items() if k not in self._PAYLOAD_KEYS}
+
     def ensure_thumbnail_bytes(self, media: dict) -> bytes | None:
         """Populate and return *media*'s ``thumbnail_bytes``, generating if absent.
 

--- a/vtscore/media/document/media_type.py
+++ b/vtscore/media/document/media_type.py
@@ -206,6 +206,16 @@ class DocumentMediaType(MediaType):
                 media_bytes = f.read()
         return {"media_bytes": media_bytes, "duration": 0}
 
+    def load_thin_media_data(self, file_path: Path) -> dict:
+        """No ingest-time artifact: a document's preview is rasterised on request.
+
+        Unlike image / audio / video, this type produces no ``thumbnail_bytes``
+        at ingest — the grid tile comes from :meth:`image_response`, which
+        renders the first PDF page on demand.  So the base default's read would
+        buy nothing but a full file copy; skip it and keep the thin load pure.
+        """
+        return {}
+
     # ------------------------------------------------------------------
     # HTTP serving
     # ------------------------------------------------------------------

--- a/vtscore/media/image/__init__.py
+++ b/vtscore/media/image/__init__.py
@@ -4,7 +4,14 @@ from vtscore.media.image.clipper import (
     ImageObjectClipper,
     ImageTilingClipper,
 )
+from vtscore.media.image.decode import configure_pil_limits
 from vtscore.media.image.media_type import ImageMediaType
+
+# The media registry imports this package eagerly while auto-discovering media
+# types, so lifting Pillow's decompression-bomb ceiling here puts it in place
+# before any image is opened anywhere in the process — including from code that
+# reaches for ``PIL.Image.open`` directly.
+configure_pil_limits()
 
 MEDIA_TYPE = ImageMediaType()
 CLIPPERS = [

--- a/vtscore/media/image/_image_bulk.py
+++ b/vtscore/media/image/_image_bulk.py
@@ -29,16 +29,21 @@ def _load_pil(source: Path | bytes) -> Optional["Image.Image"]:
     *source* may be a filesystem path or an in-memory ``bytes`` blob (used
     by the clip re-embed path so it can hand the bulk surface the
     clipped image bytes directly without a tempfile detour).
+
+    The decode is bounded (see :mod:`vtscore.media.image.decode`): an
+    enormous source is downsampled rather than refused or materialised at
+    full resolution.  Nothing downstream notices — every image model's
+    processor resizes to its own fixed input size, and patch grids /
+    region boxes are expressed in normalised coordinates.
     """
     try:
-        from PIL import Image  # noqa: PLC0415
-        import io  # noqa: PLC0415
+        from vtscore.media.image.decode import decode_bounded_rgb  # noqa: PLC0415
 
-        if isinstance(source, (bytes, bytearray)):
-            with Image.open(io.BytesIO(bytes(source))) as img:
-                return img.convert("RGB")
-        with Image.open(source) as img:
-            return img.convert("RGB")
+        # Bounded: every image model's processor resizes to a few hundred pixels
+        # anyway, so decoding a gigapixel source at full resolution would only
+        # buy a huge transient bitmap — and a whole batch of them at once.
+        img, _scale = decode_bounded_rgb(source)
+        return img
     except Exception:
         _log.exception("Error decoding image %r", source if isinstance(source, Path) else "<bytes>")
         return None

--- a/vtscore/media/image/decode.py
+++ b/vtscore/media/image/decode.py
@@ -1,0 +1,150 @@
+"""Bounded image decoding — open arbitrarily large images without choking.
+
+Pillow ships a "decompression bomb" guard: :func:`PIL.Image.open` emits a
+``DecompressionBombWarning`` once an image exceeds ``Image.MAX_IMAGE_PIXELS``
+(~89 MP by default) and raises ``DecompressionBombError`` past *twice* that,
+with a message about a possible DOS attack.  The check fires on the header
+alone, so a merely *large* picture — a gigapixel panorama, a whole-slide
+microscopy scan, a stitched satellite mosaic, a high-DPI poster scan — is
+refused outright before a single pixel is decoded.
+
+That trade is wrong for VTSearch.  Users point the importer at their own
+media; a 330-megapixel photo is not hostile, it is just big, and silently
+dropping it from a gallery is worse than the memory it costs.  So this
+module lifts the ceiling (:func:`configure_pil_limits`) and replaces it
+with the thing the guard was actually protecting against: an *unbounded
+decode*.  :func:`decode_bounded` opens an image at any resolution but
+downsamples it to a fixed pixel budget (:data:`~vtscore.config.MAX_DECODE_PIXELS`),
+so peak memory stays capped no matter how large the source is, and the
+downstream libraries that genuinely do choke on huge bitmaps (model
+processors, OCR, face detection) never see one.
+
+Two decode postures, and which one a call site wants depends on whether it
+reasons in pixel coordinates:
+
+* **Bounded** — thumbnails, embedders, extractors, converters.  These
+  resize to a few hundred pixels anyway, so decoding a full gigapixel
+  bitmap first is pure waste.  Call sites that report pixel coordinates
+  multiply them back by ``1 / scale`` to stay in original-image space.
+* **Full resolution** — cropping/clipping (:mod:`vtscore.media.cropping`,
+  :mod:`vtscore.media.lazy_clip`, the image clippers).  A crop's box comes
+  from the media's stored ``width``/``height`` and the user expects the
+  region back at full fidelity, so those paths keep decoding at native
+  size.  They still benefit from the lifted ceiling: before it, they
+  raised instead of cropping.
+
+:func:`configure_pil_limits` is invoked from ``vtscore/media/image/__init__.py``,
+which the media registry imports eagerly while auto-discovering media types,
+so the ceiling is lifted process-wide before any image work begins —
+including in code that calls ``PIL.Image.open`` directly.
+"""
+
+from __future__ import annotations
+
+import io
+import math
+from pathlib import Path
+from typing import IO, TYPE_CHECKING, Union
+
+from vtscore.config import MAX_DECODE_PIXELS
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+#: Anything :func:`PIL.Image.open` accepts, plus a raw in-memory blob.
+ImageSource = Union[str, Path, bytes, bytearray, memoryview, IO[bytes]]
+
+_limits_configured = False
+
+
+def configure_pil_limits() -> None:
+    """Remove Pillow's decompression-bomb ceiling, process-wide.
+
+    Idempotent and cheap to re-call.  After this, ``Image.open`` never
+    refuses an image for being large; :func:`decode_bounded` is what keeps
+    the decode itself from running away.
+    """
+    global _limits_configured
+    if _limits_configured:
+        return
+    try:
+        from PIL import Image  # noqa: PLC0415
+    except ImportError:
+        # Pillow is a hard dependency, but this runs at media-registry import:
+        # a missing install should surface where an image is actually decoded,
+        # not by taking down media-type discovery for every other type.
+        return
+
+    # ``None`` disables the check entirely (both the warning and the error).
+    Image.MAX_IMAGE_PIXELS = None
+    _limits_configured = True
+
+
+def _as_openable(source: ImageSource) -> Union[str, Path, IO[bytes]]:
+    """Wrap a raw ``bytes`` blob in a stream; pass paths/streams through."""
+    if isinstance(source, (bytes, bytearray, memoryview)):
+        return io.BytesIO(bytes(source))
+    return source
+
+
+def open_image(source: ImageSource) -> "Image.Image":
+    """``Image.open`` with the decompression-bomb ceiling lifted.
+
+    Use this when only the *header* is needed (dimensions, format, mode):
+    the returned image is lazy, so nothing is decoded and an enormous source
+    costs nothing.  When the pixels are actually wanted, prefer
+    :func:`decode_bounded`.
+    """
+    from PIL import Image  # noqa: PLC0415
+
+    configure_pil_limits()
+    return Image.open(_as_openable(source))
+
+
+def decode_bounded(
+    source: ImageSource,
+    max_pixels: int | None = None,
+) -> tuple["Image.Image", float]:
+    """Open *source*, downsampled to at most *max_pixels* total pixels.
+
+    Returns ``(img, scale)`` where ``scale`` is the ratio of the returned
+    image's width to the original's — ``1.0`` when the source already fit
+    inside the budget, and ``< 1.0`` when it was reduced.  Call sites that
+    report pixel coordinates (bounding boxes) divide by ``scale`` to map
+    them back into the original image's coordinate space.
+
+    Aspect ratio is preserved.  Small images are never upscaled.  For JPEGs
+    the reduction goes through Pillow's DCT-scaled ``draft`` path, so a huge
+    JPEG is never materialised at full resolution even transiently.
+
+    Pass ``max_pixels=0`` (or a negative value) to decode at native size.
+    """
+    from PIL import Image  # noqa: PLC0415
+
+    configure_pil_limits()
+    budget = MAX_DECODE_PIXELS if max_pixels is None else max_pixels
+    img = Image.open(_as_openable(source))
+    orig_w, orig_h = img.size
+    if budget > 0 and orig_w > 0 and orig_h > 0 and orig_w * orig_h > budget:
+        ratio = math.sqrt(budget / float(orig_w * orig_h))
+        target = (max(1, int(orig_w * ratio)), max(1, int(orig_h * ratio)))
+        # ``thumbnail`` drafts first (a DCT-scaled JPEG decode at 1/2, 1/4 or
+        # 1/8 size) and only then resamples, so the full-resolution bitmap
+        # never has to fit in memory for the formats that support it.
+        img.thumbnail(target, Image.Resampling.LANCZOS, reducing_gap=2.0)
+    scale = (img.width / orig_w) if orig_w > 0 else 1.0
+    return img, scale
+
+
+def decode_bounded_rgb(
+    source: ImageSource,
+    max_pixels: int | None = None,
+) -> tuple["Image.Image", float]:
+    """:func:`decode_bounded`, converted to ``RGB``.
+
+    The conversion happens *after* the downsample, so the RGB copy costs at
+    most ``max_pixels * 3`` bytes rather than the source's full footprint.
+    """
+    img, scale = decode_bounded(source, max_pixels)
+    with img:
+        return img.convert("RGB"), scale

--- a/vtscore/media/image/extractor.py
+++ b/vtscore/media/image/extractor.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import io
 from typing import Any, Optional
 
-from PIL import Image
-
+from vtscore.media.image.decode import decode_bounded_rgb
 from vtscore.media.processors import Extractor
 
 
@@ -95,7 +93,11 @@ class ImageClassExtractor(Extractor):
         if media_bytes is None:
             return []
 
-        image = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+        # Bounded decode keeps an enormous source from materialising as a
+        # multi-gigabyte bitmap (YOLO downsamples to its own input size
+        # regardless); ``scale`` maps the detections back into the original
+        # image's pixel space, which is what this extractor's bboxes promise.
+        image, scale = decode_bounded_rgb(media_bytes)
         results = self._model(image, verbose=False)
 
         hits: list[dict[str, Any]] = []
@@ -115,7 +117,7 @@ class ImageClassExtractor(Extractor):
                 hits.append(
                     {
                         "confidence": round(conf, 4),
-                        "bbox": [round(c, 2) for c in bbox],
+                        "bbox": [round(c / scale, 2) for c in bbox],
                         "label": label,
                     }
                 )

--- a/vtscore/media/image/face_localizer.py
+++ b/vtscore/media/image/face_localizer.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import io
 from typing import Any, Optional
 
-from PIL import Image
-
+from vtscore.media.image.decode import decode_bounded_rgb
 from vtscore.media.processors import Localizer
 
 
@@ -93,7 +91,9 @@ class FaceLocalizer(Localizer):
         if media_bytes is None:
             return []
 
-        image = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+        # Bounded decode caps the bitmap MTCNN is handed; ``scale`` maps the
+        # detected boxes back into the original image's pixel space.
+        image, scale = decode_bounded_rgb(media_bytes)
 
         det_boxes, det_probs = self._detector.detect(image)
 
@@ -107,7 +107,7 @@ class FaceLocalizer(Localizer):
             conf = float(prob)
             if conf < self._threshold:
                 continue
-            x1, y1, x2, y2 = (float(v) for v in box)
+            x1, y1, x2, y2 = (float(v) / scale for v in box)
             hits.append(
                 {
                     "confidence": round(conf, 4),

--- a/vtscore/media/image/media_type.py
+++ b/vtscore/media/image/media_type.py
@@ -135,17 +135,18 @@ class ImageMediaType(MediaType):
     # ------------------------------------------------------------------
 
     def load_media_data(self, file_path: Path, media_bytes: bytes | None = None) -> dict:
-        import io  # noqa: PLC0415
-
-        from PIL import Image  # noqa: PLC0415
-
+        from vtscore.media.image.decode import open_image  # noqa: PLC0415
         from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
 
         if media_bytes is None:
             with open(file_path, "rb") as f:
                 media_bytes = f.read()
         try:
-            with Image.open(io.BytesIO(media_bytes)) as img:
+            # Header-only read, and the bomb ceiling is lifted, so an enormous
+            # source reports its true dimensions instead of being refused.
+            # These stay *native* size: the stored bytes are the untouched
+            # original, and crop/clip boxes are expressed against them.
+            with open_image(media_bytes) as img:
                 width, height = img.width, img.height
         except Exception:
             width, height = None, None
@@ -174,10 +175,7 @@ class ImageMediaType(MediaType):
         thumb = media.get("thumbnail_bytes")
         if thumb:
             return thumb
-        import io  # noqa: PLC0415
-
-        from PIL import Image  # noqa: PLC0415
-
+        from vtscore.media.image.decode import open_image  # noqa: PLC0415
         from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
 
         data = self._resolve_media_bytes(media)
@@ -185,7 +183,9 @@ class ImageMediaType(MediaType):
             return None
         if media.get("width") is None or media.get("height") is None:
             try:
-                with Image.open(io.BytesIO(data)) as img:
+                # Header-only read with the bomb ceiling lifted, mirroring
+                # load_media_data: dimensions stay native size.
+                with open_image(data) as img:
                     media["width"], media["height"] = img.width, img.height
             except Exception:
                 pass

--- a/vtscore/media/image/ocr_extractor.py
+++ b/vtscore/media/image/ocr_extractor.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import io
 from typing import Any, Optional
 
-from PIL import Image
-
+from vtscore.media.image.decode import decode_bounded_rgb
 from vtscore.media.processors import Extractor
 
 
@@ -88,7 +86,9 @@ class OCRExtractor(Extractor):
 
         import numpy as np  # noqa: PLC0415
 
-        image = Image.open(io.BytesIO(media_bytes)).convert("RGB")
+        # Bounded decode caps the bitmap PaddleOCR is handed; ``scale`` maps the
+        # returned polygons back into the original image's pixel space.
+        image, scale = decode_bounded_rgb(media_bytes)
         img_array = np.array(image)
 
         results = self._model.ocr(img_array, cls=True)
@@ -111,7 +111,7 @@ class OCRExtractor(Extractor):
                 hits.append(
                     {
                         "confidence": round(float(conf), 4),
-                        "bbox": [round(c, 2) for c in bbox],
+                        "bbox": [round(c / scale, 2) for c in bbox],
                         "label": text,
                     }
                 )

--- a/vtscore/media/image/thumbnail.py
+++ b/vtscore/media/image/thumbnail.py
@@ -85,8 +85,15 @@ def make_image_thumbnail(
     """
     from PIL import Image, ImageOps  # noqa: PLC0415
 
+    from vtscore.media.image.decode import decode_bounded  # noqa: PLC0415
+
     try:
-        with Image.open(io.BytesIO(media_bytes)) as src:
+        # Bounded decode: the result is at most ``max_dim`` px on its longest
+        # side, so a gigapixel source has nothing to gain from being decoded at
+        # full resolution first.  Both the crop and the edge-trim below work in
+        # *fractional* coordinates, so they are unaffected by the downsample.
+        decoded, _scale = decode_bounded(media_bytes)
+        with decoded as src:
             img = ImageOps.exif_transpose(src) or src
             if crop is not None:
                 img = _crop_to_region(img, crop)

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -728,12 +728,24 @@ class VideoMediaType(MediaType):
         if media_bytes is None:
             with open(file_path, "rb") as f:
                 media_bytes = f.read()
+        return {"media_bytes": media_bytes, **self.load_thin_media_data(file_path)}
+
+    def load_thin_media_data(self, file_path: Path) -> dict:
+        """Duration + mid-frame thumbnail, both read straight from the path.
+
+        Overrides the base default (which routes through
+        :meth:`load_media_data` and strips the payload) because neither
+        artifact needs the file's bytes in memory: ffmpeg probes the container
+        by path and the thumbnail grabs a single decoded frame.  A thin video
+        load therefore never buffers a multi-GB file just to get a preview
+        frame.
+        """
         # One probe serves both the duration and the thumbnail's mid-frame
         # seek, so a load costs one container read rather than two.
         info = decode.probe(file_path)
         duration = info.duration if info is not None else 0.0
         thumbnail = _thumbnail_from_path(file_path, None, _THUMB_SIZE, info=info)
-        return {"media_bytes": media_bytes, "duration": duration, "thumbnail_bytes": thumbnail}
+        return {"duration": duration, "thumbnail_bytes": thumbnail}
 
     # ------------------------------------------------------------------
     # HTTP serving

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -12,6 +12,7 @@ from flask_smorest import Blueprint, abort
 
 from vtscore.detectors.labeling_progress import (
     analyze_labeling_progress,
+    cached_indicator_history,
     calculate_diversity_level_over_time,
     calculate_error_cost_over_time,
     calculate_prediction_stability_over_time,
@@ -166,10 +167,27 @@ def labeling_status_indicator():
 @eval_bp.response(200, IndicatorScoreHistoryResponseSchema)
 @eval_bp.alt_response(500, description="Score-history computation failed.")
 def indicator_score_history(query: dict):
-    """Return cached indicator score history for a given metric.
+    """Return the cached indicator score history for a given metric.
 
-    Reads only the per-step cache populated by the labeling-status
-    polling; no models are retrained.
+    Reads only the per-step cache advanced by the ``/api/labeling-status``
+    background worker; **no models are retrained and the cache is never
+    advanced here**, so the response is always fast regardless of dataset size
+    or label-history length.
+
+    When the cache does not yet cover the whole ``label_history`` the response
+    carries ``complete: false`` and an empty ``history``.  Clients should then
+    fall back to ``POST /api/eval/train-and-score``, which computes the same
+    series on a background thread with live progress and cancellation.
+
+    This route used to call the ``calculate_*_over_time`` helpers directly.
+    Those advance the cache via ``_ensure_cache`` - retraining one MLP per
+    uncached label step plus a forward pass over the unlabeled pool, and on a
+    cold cache a full hierarchical-k-means coverage-atlas build - all inline on
+    the request thread under ``_progress_lock``.  Since ``/api/labeling-status``
+    deliberately defers exactly that work to a background worker (issue #2397),
+    the cache is behind for most of a labeling session, and this endpoint
+    absorbed the entire deferred build: tens of seconds on a mid-size dataset,
+    growing with both media count and vote count.
     """
     metric = query["metric"]
 
@@ -177,13 +195,8 @@ def indicator_score_history(query: dict):
     inclusion = get_inclusion()
 
     try:
-        if metric == "smart":
-            data = calculate_error_cost_over_time(clips, label_history, good_votes, bad_votes, inclusion)
-        elif metric == "stable":
-            data = calculate_prediction_stability_over_time(clips, label_history, inclusion)
-        else:
-            data = calculate_diversity_level_over_time(clips, label_history, inclusion)
-        return {"metric": metric, "history": data}
+        data, complete = cached_indicator_history(metric, clips, label_history, good_votes, bad_votes, inclusion)
+        return {"metric": metric, "history": data, "complete": complete}
     except Exception:
         import logging
 

--- a/vtsearch/schemas/eval.py
+++ b/vtsearch/schemas/eval.py
@@ -120,6 +120,11 @@ class IndicatorScoreHistoryResponseSchema(Schema):
 
     metric = fields.String(required=True, validate=_METRIC_VALIDATOR)
     history = fields.List(fields.Dict(), required=True)
+    # ``false`` when the per-step cache does not yet cover the whole label
+    # history, in which case ``history`` is empty and the client should fall
+    # back to the async ``POST /api/eval/train-and-score`` job.  The route
+    # never advances the cache itself; see its docstring.
+    complete = fields.Boolean(required=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2746

## What happened

Commit 08f835dc ("Record and surface the source file of converter/clipper output") carried, alongside its legitimate provenance work, a wholesale revert of the three PRs merged immediately before it — every file of all three back to its exact pre-merge blob, tests included, so the suite stayed green:

- **#2733** — thin loads precompute thumbnails (`load_thin_media_data`, `_PAYLOAD_KEYS`, video/document overrides, folder-loader thin branch)
- **#2734** — large images import instead of being refused as decompression bombs (`vtscore/media/image/decode.py`, `open_image`, `decode_bounded`, the `MAX_DECODE_PIXELS` config, and all the wiring in thumbnail/extractor/localizer/OCR/converters/pdf)
- **#2739** — the indicator-history plot no longer blocks on an inline cache rebuild (`cached_indicator_history`, the `complete: false` fallback to `train-and-score`, the progress-modal rework). This one is a **third victim** beyond the two the issue names — it was 08f835dc's own parent merge, which cements the bad-rebase diagnosis.

## How it was restored

Classification was mechanical: for every file 08f835dc touched, compare its blob against the pre-#2733 state (`763ea2d5^1`) and against `df7321bb` (08f835dc's parent, the last good state). Thirty files were byte-identical to the pre-merge state (pure revert); the union of the reverted files exactly equals the union of the three PRs' file lists, so nothing else was clobbered and no provenance work depended on the removals.

- **Dev untouched since** (24 files): taken straight from `df7321bb`.
- **Dev moved since** (6 files): three-way merged with base `08f835dc` — `config.py`, `image/{__init__,media_type,thumbnail}.py`, `test_thin_loading.py`, `video/media_type.py`.
- **`video/media_type.py`** (the one conflict): `load_thin_media_data` is restored as the path-based override, but implemented on the ffmpeg single-probe path (`decode.probe` + `_thumbnail_from_path`) that replaced the in-process OpenCV decode after the revert — not the original OpenCV body.
- **`base.py`** (mixed file): keeps 08f835dc's legitimate `display_metadata` provenance hunk and regains `_PAYLOAD_KEYS` + `load_thin_media_data`.
- **#2745 collision**: `ImageMediaType.ensure_thumbnail_bytes` (landed after the revert) now routes its dimension probe through the restored `open_image`, as the issue anticipated.
- **`frontend/openapi.json`** regenerated; the diff is exactly the restored `complete` field on `IndicatorScoreHistoryResponse`.

Both deleted test files (`tests_lib/core/test_image_decode.py`, `tests_lib/detectors/test_indicator_history_cache.py`) and the trimmed cases in `test_thumbnail_persistence.py` / `test_thin_loading.py` are back.

## Audit for other victims

Ran the same pre-merge-blob check across **every merge into `dev` since 2026-07-27** (all ~40): no other merge has any file sitting at its pre-merge state on current `dev`. The detector correctly flags the three known victims and nothing else. 08f835dc was the only bad commit.

## Testing

`./run-tests.sh` (full suite): **ALL 7084 TESTS PASSED** (1 skipped), including ruff/codespell/deptry/pyright, the OpenAPI snapshot check, and the frontend build + Vitest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgFqV8iYRb5hKt3ewumHrq

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgFqV8iYRb5hKt3ewumHrq)_