### PR TITLE
Persist top-level clip window across the pickle round-trip

### DIFF
--- a/tests/datasets/test_registry_reload_archive_member.py
+++ b/tests/datasets/test_registry_reload_archive_member.py
@@ -20,7 +20,13 @@ import numpy as np
 
 
 def _archive_member_media(media_id: int, tmp_path: Path) -> dict[str, Any]:
-    """One archive-member audio media: bytes exist only inside a tar shard."""
+    """One archive-member audio media: bytes exist only inside a tar shard.
+
+    Carries a top-level playback window too (each item is one window of its
+    member): the whole member is served, so the player seeks to ``clip_start``
+    and loops within ``[clip_start, clip_end]``, and losing the window on
+    reload would collapse every window of a member into the same item.
+    """
     return {
         "id": media_id,
         "media_type": "audio",
@@ -37,11 +43,13 @@ def _archive_member_media(media_id: int, tmp_path: Path) -> dict[str, Any]:
                 "archive_path": str(tmp_path / "shard0.tar"),
                 "member": f"clip{media_id}.m4a",
                 "media_type": "audio",
-                "clip_start": 0.0,
-                "clip_end": 10.0,
+                "clip_start": float(media_id * 10),
+                "clip_end": float(media_id * 10 + 10),
             },
         },
         "origin_name": f"shard0.tar::clip{media_id}.m4a",
+        "clip_start": float(media_id * 10),
+        "clip_end": float(media_id * 10 + 10),
         "media_bytes": None,
         "media_string": None,
         "media_path": None,
@@ -101,6 +109,13 @@ class TestRegistryReloadArchiveMemberDataset:
             assert reloaded_entry["num_items"] == len(medias)
             # Kept lazily: the member is streamed from its shard on demand.
             assert all(m["media_bytes"] is None for m in ctx.medias.values())
+            # Each item's playback window survives, so the windows of a shared
+            # member still sound (and draw) like different stretches of audio.
+            assert sorted((m["clip_start"], m["clip_end"]) for m in ctx.medias.values()) == [
+                (10.0, 20.0),
+                (20.0, 30.0),
+                (30.0, 40.0),
+            ]
         finally:
             client.post(f"/api/datasets/registry/{dataset_id}/unload")
             unregister_dataset(dataset_id)

--- a/tests_lib/datasets/test_clip_window_persistence.py
+++ b/tests_lib/datasets/test_clip_window_persistence.py
@@ -1,0 +1,174 @@
+"""Library-tier tests for clip windows surviving the pickle round-trip.
+
+A clipped or windowed media's playback window lives in four *top-level* fields
+(``provenance.CLIP_WINDOW_FIELDS``): every player seeks to ``clip_start`` and
+loops within ``[clip_start, clip_end]``, the audio waveform is sliced by the
+same pair, and ``display_metadata`` renders them as the "Clip …" rows.  The
+same extents also sit in ``origin.params``, but only as a re-derivation recipe
+in a different shape, so they do not stand in — ``export_dataset_to_file``
+writes an explicit field list, so the window has to be named there and restored
+on load or every window of a shared source reloads playing the whole source
+from 0 (a manifest that windows one tar member N times reloads as N
+identical-sounding items).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from vtscore.datasets.loader import export_dataset_to_file
+from vtscore.datasets.loader_pickle import load_dataset_from_pickle
+from vtscore.media.audio.media_type import AudioMediaType
+from vtscore.media.provenance import CLIP_WINDOW_FIELDS
+
+
+def _media(media_type: str = "audio", **extra) -> dict[str, Any]:
+    rng = np.random.default_rng(7)
+    return {
+        "id": 1,
+        "media_type": media_type,
+        "duration": 10.0,
+        "file_size": 64,
+        "md5": "abc",
+        "embedder": "clap",
+        "embeddings": {"clap": rng.standard_normal(16).astype(np.float32)},
+        "filename": f"a.{media_type}",
+        "category": "test",
+        "media_bytes": b"\x00" * 64,
+        "media_string": None,
+        "media_path": None,
+        **extra,
+    }
+
+
+def _archive_member_media(**extra) -> dict[str, Any]:
+    """A windowed archive member: bytes stream from a tar shard, never inline."""
+    return _media(
+        media_bytes=None,
+        filename="shard0/chunk.m4a",
+        origin={
+            "importer": "local_archive_member",
+            "params": {
+                "archive_path": "/data/shard0.tar",
+                "member": "chunk.m4a",
+                "media_type": "audio",
+                "clip_start": 5.0,
+                "clip_end": 15.0,
+            },
+        },
+        origin_name="shard0.tar::chunk.m4a",
+        **extra,
+    )
+
+
+def _round_trip(media: dict[str, Any], tmp_path: Path, thin: bool = False) -> dict[str, Any]:
+    container = export_dataset_to_file(
+        {1: media},
+        embedder="clap",
+        media_type=media.get("media_type", "audio"),
+    )
+    pkl = tmp_path / "ds.pkl"
+    pkl.write_bytes(container)
+    loaded: dict[int, dict[str, Any]] = {}
+    load_dataset_from_pickle(pkl, loaded, thin=thin)
+    return loaded[1]
+
+
+class TestClipWindowSurvivesPickleRoundTrip:
+    def test_archive_member_window_persists(self, tmp_path: Path):
+        out = _round_trip(_archive_member_media(clip_start=5.0, clip_end=15.0), tmp_path)
+
+        assert out["clip_start"] == 5.0
+        assert out["clip_end"] == 15.0
+
+    def test_two_windows_of_one_member_stay_distinct(self, tmp_path: Path):
+        """The point of the window: N rows off one member must not collapse."""
+        first = _archive_member_media(clip_start=0.0, clip_end=10.0)
+        second = _archive_member_media(clip_start=10.0, clip_end=20.0)
+        second["id"] = 2
+        second["md5"] = "def"
+        container = export_dataset_to_file({1: first, 2: second}, embedder="clap", media_type="audio")
+        pkl = tmp_path / "windows.pkl"
+        pkl.write_bytes(container)
+        loaded: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl, loaded)
+
+        assert [(m["clip_start"], m["clip_end"]) for m in loaded.values()] == [(0.0, 10.0), (10.0, 20.0)]
+
+    def test_video_clip_window_and_index_persist(self, tmp_path: Path):
+        out = _round_trip(
+            _media("video", clip_start=1.5, clip_end=4.25, clip_index=3),
+            tmp_path,
+        )
+
+        assert (out["clip_start"], out["clip_end"], out["clip_index"]) == (1.5, 4.25, 3)
+
+    def test_image_clip_box_persists_as_a_list(self, tmp_path: Path):
+        """``clip_box`` is a 4-int list top-level (comma-joined only in origin params)."""
+        out = _round_trip(_media("image", clip_box=[10, 20, 110, 120]), tmp_path)
+
+        assert out["clip_box"] == [10, 20, 110, 120]
+
+    def test_window_persists_through_a_thin_load(self, tmp_path: Path):
+        out = _round_trip(_archive_member_media(clip_start=5.0, clip_end=15.0), tmp_path, thin=True)
+
+        assert (out["clip_start"], out["clip_end"]) == (5.0, 15.0)
+
+    def test_display_metadata_keeps_the_clip_rows(self, tmp_path: Path):
+        out = _round_trip(_archive_member_media(clip_start=5.0, clip_end=15.0), tmp_path)
+        meta = AudioMediaType().display_metadata(out)
+
+        assert meta["Clip Start"] == 5.0
+        assert meta["Clip End"] == 15.0
+
+    def test_unclipped_media_gains_no_clip_fields(self, tmp_path: Path):
+        out = _round_trip(_media(), tmp_path)
+
+        assert not [field for field in CLIP_WINDOW_FIELDS if field in out]
+
+
+class TestWaveformWindowingAfterReload:
+    """The restored window must not re-slice bytes that are already the clip."""
+
+    def _captured_window(self, monkeypatch, media: dict[str, Any]) -> tuple:
+        from vtscore.media.audio import media_type as audio_module
+
+        captured: dict[str, Any] = {}
+
+        def fake_window(_loader, clip_start=None, clip_end=None, cache_key=None):
+            captured["window"] = (clip_start, clip_end)
+            return b"png"
+
+        monkeypatch.setattr(audio_module, "generate_waveform_thumbnail_window", fake_window)
+        AudioMediaType()._waveform_for_media(media)
+        return captured["window"]
+
+    def test_archive_member_window_is_applied(self, monkeypatch):
+        """The whole member is served, so the waveform has to window it."""
+        media = _archive_member_media(clip_start=5.0, clip_end=15.0)
+
+        assert self._captured_window(monkeypatch, media) == (5.0, 15.0)
+
+    def test_lazy_audio_clip_is_not_windowed_twice(self, monkeypatch):
+        """A byte-sliced clip resolves as its own 0-based file; windowing it again
+        would render the wrong stretch."""
+        media = _media(
+            media_bytes=None,
+            media_path="/data/soundscape.wav",
+            clip_start=120.0,
+            clip_end=125.0,
+            origin={
+                "importer": "server_folder",
+                "params": {"clipper": "fixed_window", "clip_start": 120.0, "clip_end": 125.0},
+            },
+        )
+
+        assert self._captured_window(monkeypatch, media) == (None, None)
+
+    def test_materialized_clip_is_not_windowed_twice(self, monkeypatch):
+        media = _media(clip_start=120.0, clip_end=125.0)
+
+        assert self._captured_window(monkeypatch, media) == (None, None)

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -227,6 +227,7 @@ def export_dataset_to_file(
     # the round-trip.  Build the type→fields map once and merge each media's
     # extra fields into its serialized entry below.
     from vtscore.media import all_types  # noqa: PLC0415
+    from vtscore.media.provenance import CLIP_WINDOW_FIELDS  # noqa: PLC0415
     from vtscore.projection.signpost_texts import PERSISTED_FIELDS as SIGNPOST_FIELDS  # noqa: PLC0415
 
     extra_fields_by_type: dict[str, list[str]] = {mt.type_id: mt.pickle_extra_fields for mt in all_types()}
@@ -271,6 +272,18 @@ def export_dataset_to_file(
         # ran the stage keep the same entry shape.
         for field in SIGNPOST_FIELDS:
             if media.get(field):
+                entry[field] = media[field]
+        # The clip window (``clip_start`` / ``clip_end`` / ``clip_index`` /
+        # ``clip_box``) is what a player seeks to and loops within, what the
+        # audio waveform is sliced by, and what renders the "Clip Start" /
+        # "Clip End" metadata rows -- all off the *top-level* fields.  The same
+        # extents live in ``origin.params``, but only as a re-derivation recipe
+        # in a different shape, so they do not stand in: without these keys
+        # every clipped or windowed media reloads playing its whole source from
+        # 0 (14 windows of one tar member become 14 identical-sounding items).
+        # Written only when present, so unclipped media keep their entry shape.
+        for field in CLIP_WINDOW_FIELDS:
+            if media.get(field) is not None:
                 entry[field] = media[field]
         # Persist a precomputed grid/list thumbnail so reloads stream the bytes
         # instead of decoding the full-resolution original on every cold tile

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -178,6 +178,26 @@ def _copy_original_payload(entry: dict[str, Any], media: dict[str, Any]) -> None
             entry[field] = media[field]
 
 
+def _copy_clip_window(entry: dict[str, Any], media: dict[str, Any]) -> None:
+    """Copy a clipped / windowed item's playback window into its pickle entry.
+
+    The clip window (``clip_start`` / ``clip_end`` / ``clip_index`` /
+    ``clip_box``) is what a player seeks to and loops within, what the audio
+    waveform is sliced by, and what renders the "Clip …" metadata rows -- all
+    off the *top-level* fields.  The same extents live in ``origin.params``, but
+    only as a re-derivation recipe in a different shape, so they do not stand
+    in: without these keys every clipped or windowed media reloads playing its
+    whole source from 0 (14 windows of one tar member become 14
+    identical-sounding items).  Written only when present, so an unclipped
+    dataset keeps the same entry shape.
+    """
+    from vtscore.media.provenance import CLIP_WINDOW_FIELDS  # noqa: PLC0415
+
+    for field in CLIP_WINDOW_FIELDS:
+        if media.get(field) is not None:
+            entry[field] = media[field]
+
+
 def export_dataset_to_file(
     medias: dict[int, dict[str, Any]],
     *,
@@ -227,7 +247,6 @@ def export_dataset_to_file(
     # the round-trip.  Build the type→fields map once and merge each media's
     # extra fields into its serialized entry below.
     from vtscore.media import all_types  # noqa: PLC0415
-    from vtscore.media.provenance import CLIP_WINDOW_FIELDS  # noqa: PLC0415
     from vtscore.projection.signpost_texts import PERSISTED_FIELDS as SIGNPOST_FIELDS  # noqa: PLC0415
 
     extra_fields_by_type: dict[str, list[str]] = {mt.type_id: mt.pickle_extra_fields for mt in all_types()}
@@ -273,18 +292,7 @@ def export_dataset_to_file(
         for field in SIGNPOST_FIELDS:
             if media.get(field):
                 entry[field] = media[field]
-        # The clip window (``clip_start`` / ``clip_end`` / ``clip_index`` /
-        # ``clip_box``) is what a player seeks to and loops within, what the
-        # audio waveform is sliced by, and what renders the "Clip Start" /
-        # "Clip End" metadata rows -- all off the *top-level* fields.  The same
-        # extents live in ``origin.params``, but only as a re-derivation recipe
-        # in a different shape, so they do not stand in: without these keys
-        # every clipped or windowed media reloads playing its whole source from
-        # 0 (14 windows of one tar member become 14 identical-sounding items).
-        # Written only when present, so unclipped media keep their entry shape.
-        for field in CLIP_WINDOW_FIELDS:
-            if media.get(field) is not None:
-                entry[field] = media[field]
+        _copy_clip_window(entry, media)
         # Persist a precomputed grid/list thumbnail so reloads stream the bytes
         # instead of decoding the full-resolution original on every cold tile
         # fetch (the browse first-paint delay).  Image *demos* never generate

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -201,6 +201,27 @@ def _restore_media_url(media_data: dict[str, Any], media_info: dict[str, Any]) -
         media_data["media_url"] = url
 
 
+def _restore_clip_window(media_data: dict[str, Any], media_info: dict[str, Any]) -> None:
+    """Carry a pickled clip window onto the media when one is recorded.
+
+    ``clip_start`` / ``clip_end`` / ``clip_index`` / ``clip_box`` are the
+    playback window of a clipped or windowed item: the players seek to
+    ``clip_start`` and loop within ``[clip_start, clip_end]``, the audio
+    waveform is sliced by the same pair, and ``display_metadata`` renders them
+    as the item's "Clip …" rows.  Restoring them is what keeps each window of a
+    shared source distinct after a reload; without it a manifest that windows
+    one tar member N times reloads as N items that all play (and draw) the
+    whole member from 0.  Set only when present, so an unclipped media keeps
+    the shape it had before.
+    """
+    from vtscore.media.provenance import CLIP_WINDOW_FIELDS  # noqa: PLC0415
+
+    for field in CLIP_WINDOW_FIELDS:
+        value = media_info.get(field)
+        if value is not None:
+            media_data[field] = value
+
+
 def _build_pickle_thin_media(
     new_id: int,
     media_info: dict[str, Any],
@@ -234,6 +255,7 @@ def _build_pickle_thin_media(
         media_data["custom_metadata"] = cm
     _restore_signpost_text(media_data, media_info)
     _restore_original_payload(media_data, media_info)
+    _restore_clip_window(media_data, media_info)
     return media_data
 
 
@@ -272,6 +294,7 @@ def _build_pickle_full_media(
         media_data["custom_metadata"] = cm
     _restore_signpost_text(media_data, media_info)
     _restore_original_payload(media_data, media_info)
+    _restore_clip_window(media_data, media_info)
     return media_data
 
 

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -1094,26 +1094,29 @@ class AudioMediaType(MediaType):
         windows shows its own waveform, and cache the decoded member so its
         windows don't each re-stream and re-decode it.
 
-        The window is applied **only** when the bytes have to be resolved from
-        the source.  Materialized ``media_bytes`` already *are* this clip - a
-        clipper's slice, or a cleaner's trimmed payload - so re-applying the
-        source-relative ``clip_start`` / ``clip_end`` would slice a second time
-        and render the wrong stretch of audio.
+        The window is applied **only** when the resolved bytes are the whole
+        source.  Bytes that already *are* this clip - a clipper's materialized
+        slice, a cleaner's trimmed payload, or a lazy clip the resolver cuts
+        from the source on demand - carry their own 0-based timeline, so
+        re-applying the source-relative ``clip_start`` / ``clip_end`` would
+        slice a second time and render the wrong stretch of audio.
         """
+        from vtscore.media.lazy_clip import clip_recipe  # noqa: PLC0415
+
         ref = media.get("archive_member")
         member = ref.get("member", "") if isinstance(ref, dict) else ""
-        materialized = media.get("media_bytes") is not None
+        serves_clip_bytes = media.get("media_bytes") is not None or clip_recipe(media) is not None
         cache_key = (
             None
-            if materialized  # a per-clip payload must not be cached under a per-member key
+            if serves_clip_bytes  # a per-clip payload must not be cached under a per-member key
             else (ref["path"], member)
             if isinstance(ref, dict) and ref.get("path")
             else None
         )
         return generate_waveform_thumbnail_window(
             lambda: self._resolve_media_bytes(media),
-            clip_start=None if materialized else media.get("clip_start"),
-            clip_end=None if materialized else media.get("clip_end"),
+            clip_start=None if serves_clip_bytes else media.get("clip_start"),
+            clip_end=None if serves_clip_bytes else media.get("clip_end"),
             cache_key=cache_key,
         )
 

--- a/vtscore/media/provenance.py
+++ b/vtscore/media/provenance.py
@@ -53,6 +53,18 @@ DERIVED_VIA_LABEL = "Derived Via"
 #: Display label for the importer that brought the corpus in.
 IMPORTED_VIA_LABEL = "Imported Via"
 
+#: Top-level media keys describing a clipped / windowed item's playback window.
+#: Every reader of a clip window reads these *top-level* fields, not
+#: ``origin.params``: the players seek to ``clip_start`` and loop within
+#: ``[clip_start, clip_end]``, the audio waveform is windowed by them, and
+#: ``MediaType.display_metadata`` renders them as the "Clip Start" / "Clip End" /
+#: "Clip Index" / "Clip Box" rows.  ``origin.params`` records the same extents,
+#: but only as a re-derivation *recipe* and in a different shape (``clip_box``
+#: is comma-joined there), so the two are not interchangeable — which is why
+#: :func:`vtscore.datasets.loader.export_dataset_to_file` has to persist these
+#: fields in their own right.
+CLIP_WINDOW_FIELDS = ("clip_start", "clip_end", "clip_index", "clip_box")
+
 #: ``origin.params`` keys left out of the ``Imported Via`` line.  These are
 #: either represented by the curated fields above, duplicated by a dedicated
 #: ``display_metadata`` entry (``clip_start`` → "Clip Start"), a machine-only
@@ -64,10 +76,7 @@ HIDDEN_ORIGIN_PARAMS = frozenset(
         "converter_content_hash",
         "converter_n_out",
         "converter_out_index",
-        "clip_box",
-        "clip_end",
-        "clip_index",
-        "clip_start",
+        *CLIP_WINDOW_FIELDS,
         "clipper",
         "media_type",
         "source_file",


### PR DESCRIPTION
A clipped or windowed media's playback window lives in four **top-level** fields — `clip_start` / `clip_end` / `clip_index` / `clip_box` — but `export_dataset_to_file()` never wrote them and neither pickle media builder restored them. Every clipped item therefore reloaded with no window: archive-member windows all played (and drew) their whole tar member from 0, video clips played the parent from the start, and the "Clip Start" / "Clip End" metadata rows vanished (doubly invisible, since `HIDDEN_ORIGIN_PARAMS` hides those params from "Imported Via" precisely because `display_metadata` is supposed to cover them).

`origin.params` records the same extents, but only as a re-derivation recipe and in a different shape (`clip_box` is comma-joined there), so it can't stand in for the top-level fields. This persists them in their own right.

## Changes

- **`vtscore/media/provenance.py`** — new `CLIP_WINDOW_FIELDS` constant naming the four top-level fields; `HIDDEN_ORIGIN_PARAMS` now splats it instead of repeating the names.
- **`vtscore/datasets/loader.py`** — `_copy_clip_window()` writes the window into each pickle entry, only when present, so unclipped media keep their entry shape (same pattern as `_copy_original_payload`). Extracted as a module-level helper to keep `export_dataset_to_file` under the complexity limit.
- **`vtscore/datasets/loader_pickle.py`** — `_restore_clip_window()` copies the window back, called from both `_build_pickle_thin_media` and `_build_pickle_full_media`.
- **`vtscore/media/audio/media_type.py`** — the waveform's "don't window twice" guard tested only for materialized `media_bytes`. With the window now restored, a *thin*-loaded byte-sliced clip (bytes resolved lazily by the clip resolver, already the clip) would have been sliced a second time against its own 0-based timeline. The guard now also treats a lazy clip recipe as clip bytes; `materialized` is renamed `serves_clip_bytes` to match what it means. The `cache_key` branch is unaffected — `clip_recipe` returns `None` for archive members, the only case where that key is non-`None`.

The batch route's deliberate window-suppression for byte-sliced audio (`vtsearch/routes/media/list.py`) is untouched.

## Tests

- New `tests_lib/datasets/test_clip_window_persistence.py`: window survives export → load for archive-member audio (full and thin), video clips (incl. `clip_index`), and image `clip_box` (still a list, not the comma-joined origin form); two windows of one member stay distinct; the "Clip Start" / "Clip End" rows come back; an unclipped media gains no clip fields. Plus waveform coverage: an archive member *is* windowed, a lazy clip and a materialized clip are not.
- `tests/datasets/test_registry_reload_archive_member.py` now gives each fixture item its own top-level window and asserts all three survive the registry reload end to end.

`./run-tests.sh`: 7060 passed, 1 skipped.

Closes #2747

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn3TmkRQUn54qGD1GmCPXE)_