### PR TITLE
Add video media cleaners: letterbox crop and blank-frame trim

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -771,8 +771,12 @@ recoverable long after the import job ended:
   `clip_start` / `clip_end` / `clip_box` / `clip_index`.  A chain may also
   carry `kind: "cleaner"` steps — the 1→1 cleanup gates that run last, on the
   finished units — whose trail entries record `changed` (did this gate rewrite
-  *this* item?) alongside the usual `content_hash`.  Cleaner steps stamp no
-  legacy keys: with one output there is no sibling to disambiguate.
+  *this* item?) alongside the usual `content_hash`.  A gate that cleaned by
+  *narrowing metadata* rather than rewriting a payload (the video gates: they
+  trim `clip_start` / `clip_end` and record a `clip_box`, because every clip of
+  a video shares the parent's bytes) additionally records the new window / box
+  on its entry.  Cleaner steps stamp no legacy keys: with one output there is
+  no sibling to disambiguate.
 
 Both are machine-readable recipes: `vtscore/media/lazy_clip.py` replays them
 to reproduce the bytes on demand, which is what makes reference-mode derived

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -753,14 +753,17 @@ otherwise hide it. Do not add a cleaner affordance outside that block.
 | `AudioSilenceTrimCleaner` | `audio_silence_trim` | `audio` | off | Drop the silence at the head and tail of a clip, keeping internal pauses |
 | `TextMarkupStripCleaner` | `text_markup_strip` | `text` | off | Remove HTML tags and Markdown syntax, keeping the text inside |
 | `TextWhitespaceCleaner` | `text_whitespace` | `text` | off | Collapse whitespace runs, drop control characters, rejoin hyphen-broken words |
+| `VideoLetterboxCropCleaner` | `video_letterbox_crop` | `video` | off | Record the letterbox / pillarbox crop every sampled frame agrees on as the unit's `clip_box` |
+| `VideoBlankTrimCleaner` | `video_blank_trim` | `video` | off | Narrow the unit's `clip_start` / `clip_end` past its blank head and tail (black leader, fade-ins, empty tail cards) |
 
-Two of these share their detector with another caller rather than owning a
-second copy of the heuristic: `image_edge_trim` and the grid thumbnail both call
-`vtscore/media/image/edge_trim.py`, and `audio_silence_trim` and
-`SoundSilenceClipper` both call `vtscore/media/audio/silence.py`. When a cleaner
-answers a question something else in the codebase already answers, extract the
-detector; a cleaner that disagrees with the thumbnail about where the content
-starts is worse than no cleaner.
+Three of these share their detector with another caller rather than owning a
+second copy of the heuristic: `image_edge_trim`, `video_letterbox_crop`, and the
+grid thumbnail all call `vtscore/media/image/edge_trim.py`, and
+`audio_silence_trim` and `SoundSilenceClipper` both call
+`vtscore/media/audio/silence.py`. When a cleaner answers a question something
+else in the codebase already answers, extract the detector; a cleaner that
+disagrees with the thumbnail about where the content starts is worse than no
+cleaner.
 
 ### What to implement
 
@@ -834,8 +837,8 @@ CLEANERS = [TextWhitespaceCleaner()]
   conservative by construction — cap how much you are willing to remove.
 - **Never mutate the input in place.** Build the output with `dict(media)` and
   overwrite the payload keys. The runner detects "nothing changed" by comparing
-  the payload before and after, and an in-place mutation leaves it no pre-clean
-  version to keep.
+  the payload (and the window / box keys, see below) before and after, and an
+  in-place mutation leaves it no pre-clean version to keep.
 - **Update the metadata you invalidated** — `file_size`, `width` / `height`,
   `duration`, `character_count`. MD5, embeddings, and thumbnails are redone for
   you (see below).
@@ -868,6 +871,38 @@ payload the first time a cleaner actually changes an item, under
 A cleaned item is flagged for MD5 + embedding + thumbnail recomputation, and its
 trail entry records `changed`, so provenance's "Derived Via" line lists only the
 gates that actually did something to that item.
+
+### Cleaning by metadata instead of payload
+
+A **video** unit is a `(parent bytes, time window)` pair: every clip of a tiled
+video shares the parent's payload and says which slice of it it is via
+`clip_start` / `clip_end`. A video cleaner therefore cleans by *narrowing
+metadata* rather than by rewriting bytes — re-encoding a cleaned copy per unit
+would duplicate the payload once per tile and desync the window, which still
+indexes the parent's timeline.
+
+The runner treats a change to any of `clip_start`, `clip_end`, `clip_box`
+(`CLEANED_METADATA_KEYS` in `vtscore/datasets/clipper_chain.py`) as a real
+change: the item is flagged for MD5 + embedding + thumbnail recomputation, its
+trail entry records `changed` plus the new window / box, and its stale
+thumbnail is dropped. What it does **not** do is snapshot an `original_*`
+payload — there is no second payload, the served file is untouched, and the
+player already loops within `[clip_start, clip_end]`. Two consequences, both
+good: a metadata-cleaned unit costs no extra storage, and a reference (thin)
+import keeps its byte savings on it.
+
+The spatial half of that contract, `clip_box`, is *honoured* rather than baked
+in, by three readers that have to agree (the parsing and the crop live once in
+`vtscore/media/video/crop.py`):
+
+| Reader | Why it needs the box |
+|--------|---------------------|
+| `sample_video_frames` (`vtscore/media/video/_frame_sampling.py`) | what the embedder actually sees |
+| the video thumbnailers (`vtscore/media/video/media_type.py`) | so the grid preview frames the same picture |
+| `_fixup_clip_md5_and_embeddings` (`vtscore/datasets/stages/clipper.py`) | folds the box into the boundary-tag MD5 so two crops of one parent don't collide |
+
+If you add a media type whose units are likewise metadata-only, follow the same
+shape: narrow the keys, let the readers honour them, and snapshot nothing.
 
 ---
 

--- a/docs/plans/media-cleaners.md
+++ b/docs/plans/media-cleaners.md
@@ -5,14 +5,17 @@
 The core is shipped: `MediaCleaner` (a `MediaClipper` subclass whose `clean()`
 is 1→1), its own registry, `kind: "cleaner"` chain steps, the Clean/Original
 dual payload, `GET /api/cleaners`, the import-flow Cleanup checkbox list, and
-the detail-viewer toggle. The permanent documentation lives in
-**`docs/EXTENDING-media.md` § Adding a Media Cleaner** (what to implement, the
-`clean()` contract, the dual payload) and `docs/api/datasets.md` /
-`docs/api/medias.md` (the `cleaners` field and `?variant=original`).
+the detail-viewer toggle. Metadata-only cleaning is shipped too: a gate may
+clean by narrowing `clip_start` / `clip_end` / `clip_box` instead of rewriting
+a payload, which is how the video gates work. The permanent documentation lives
+in **`docs/EXTENDING-media.md` § Adding a Media Cleaner** (what to implement,
+the `clean()` contract, the dual payload, cleaning by metadata) and
+`docs/api/datasets.md` / `docs/api/medias.md` (the `cleaners` field and
+`?variant=original`).
 
-What remains is the **roster**: each entry below is a new `MediaCleaner`
-subclass plus its `CLEANERS` registration and tests. Two design points that
-still bear on the open work:
+What remains is the rest of the **roster**: each entry below is a new
+`MediaCleaner` subclass plus its `CLEANERS` registration and tests. Two design
+points that still bear on the open work:
 
 - **Cleaners run last, on the finished units.** Only cleaners matching the
   chain's *final* media type apply. Known cost: a letterboxed image fed to
@@ -26,23 +29,19 @@ still bear on the open work:
 
 <!-- item-sep -->
 
-- **Video: letterbox bar crop** — run the edge-trim analysis on a few
-  sampled frames and crop the consensus box from all frames.
-
-<!-- item-sep -->
-
-- **Video: leading/trailing black-frame trim** — the silence-trim analog
-  (fade-ins, slates, tail cards).
-
-<!-- item-sep -->
-
 - **Audio: loudness normalization** — peak or RMS normalize; quiet
   recordings embed worse with CLAP. Moderate value, low risk.
 
 <!-- item-sep -->
 
-- **Document: blank-page drop** — still 1→1 (document in, thinner
-  document out); helps everything downstream of `document2*`.
+- **Document: blank-page drop** — *blocked on a pre-convert stage.* The
+  cleaner itself is easy (document in, thinner document out, via PyMuPDF),
+  but it can never run as written: cleaners run last, on the chain's final
+  media type, and a `document` dataset is not embeddable (`converts_to =
+  ["image", "text"]`), so a document-typed gate behind a `document2*`
+  converter fails `validate_chain`'s type check. It needs the `stage`
+  property from Open questions — a `"pre_convert"` gate running on the
+  document *before* the converter — so ship that first or drop the item.
 
 <!-- item-sep -->
 
@@ -83,7 +82,30 @@ cropping (can eat context the detector needs), audio noise reduction
   by teaching `lazy_clip` a cleaner recipe (replay the chain's cleaner steps on
   the source, keyed off the trail) — at which point a cleaned reference item
   can go back to storing only a recipe, and its "Original" is just the source
-  file.
+  file. (Metadata-only cleans are already exempt: they snapshot nothing, so a
+  video-cleaned reference item stays lazy.)
+
+<!-- item-sep -->
+
+- **A video unit's crop box is invisible in the player** — `clip_box` reaches
+  the frontend on the media payload and the server-rendered grid thumbnail is
+  cropped to it, but `<video>` plays the uncropped file, so a letterbox-cropped
+  item previews cropped and plays padded. Either crop the player's viewport
+  with a CSS transform keyed off `clip_box`, or accept the divergence and say
+  so in the UI (the trim half already shows up for free, since the player loops
+  within `[clip_start, clip_end]`).
+
+<!-- item-sep -->
+
+- **Video labeled-example replay ignores the unit's window and box** —
+  `replay_chain_on_file` writes the final unit to a tempfile and calls
+  `embed_file`, which for video embeds the *whole* container: `clip_start` /
+  `clip_end` / `clip_box` are dropped, so a re-embedded video label lands in a
+  slightly different distribution from the dataset item it was taken from.
+  This predates the cleaners (video tiles already replayed as whole files), but
+  the metadata gates widen it from "the wrong slice" to "the wrong slice at the
+  wrong framing". Fix by threading the media dict — not a bare path — into the
+  video embed path so the sampler sees the window and the box.
 
 <!-- item-sep -->
 
@@ -98,6 +120,10 @@ cropping (can eat context the detector needs), audio noise reduction
 - **Storage controls** — `original_*` retention doubles per-item storage
   when a cleaner mutates. Is a per-import "keep originals" toggle (default
   on) worth it, or is the mutating-items-only bound enough in practice?
-- **Pre-clip stage** — whether tiling-vs-edge-trim ordering hurts enough
-  to justify a per-cleaner `stage` property (see Background above), and
-  what "Original" means for a pre-clip-cleaned sub-clip if so.
+  (Metadata-only gates sidestep this entirely — they store nothing.)
+- **Pre-clip / pre-convert stage** — a per-cleaner `stage` property is now
+  wanted by two items: tiling-vs-edge-trim ordering (does a tiled letterbox
+  hurt enough to justify it?) and the document blank-page gate, which is
+  blocked without a `"pre_convert"` placement. Open sub-questions: what
+  "Original" means for a pre-clip-cleaned sub-clip, and whether pre-convert
+  and pre-clip are one stage or two.

--- a/tests/api/test_cleaner_routes.py
+++ b/tests/api/test_cleaner_routes.py
@@ -126,6 +126,15 @@ class TestCleanersApiEndpoint:
         assert [c["name"] for c in cleaners] == ["audio_silence_trim"]
         assert all(c["media_type"] == "audio" for c in cleaners)
 
+    def test_filter_by_video_lists_both_metadata_gates(self, client):
+        resp = client.get("/api/cleaners?media_type=video")
+        assert resp.status_code == 200
+        cleaners = resp.get_json()["cleaners"]
+        # Crop before trim: the blank scan measures the cropped region.
+        assert [c["name"] for c in cleaners] == ["video_letterbox_crop", "video_blank_trim"]
+        assert all(c["media_type"] == "video" for c in cleaners)
+        assert all(c["default_enabled"] is False for c in cleaners)
+
     def test_exif_cleaner_defaults_on(self, client):
         resp = client.get("/api/cleaners?media_type=image")
         exif = next(c for c in resp.get_json()["cleaners"] if c["name"] == "image_exif_orient")

--- a/tests_lib/detectors/test_cleaner_roster.py
+++ b/tests_lib/detectors/test_cleaner_roster.py
@@ -10,18 +10,25 @@ class below checks the same three things:
   identity is what tells the chain runner to skip the ``original_*`` snapshot),
 - a degenerate or undecodable payload is a no-op, never an error.
 
+The two *video* gates add a fourth thing to check: they clean by narrowing
+metadata (the unit's time window and pixel box) rather than by rewriting a
+payload, so every test also asserts the payload came through untouched.
+
 Covered: ``image_edge_trim``, ``audio_silence_trim``, ``text_whitespace``,
-``text_markup_strip``.
+``text_markup_strip``, ``video_letterbox_crop``, ``video_blank_trim``.
 """
 
 from __future__ import annotations
 
 import io
 import wave
+from pathlib import Path
 
+import numpy as np
 import pytest
 from PIL import Image
 from vtscore.media import get_cleaner
+from vtscore.media.video import decode
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -473,3 +480,416 @@ class TestTextMarkupStripCleaner:
 
         order = [c.name for c in cleaners_for_type("text")]
         assert order.index("text_markup_strip") < order.index("text_whitespace")
+
+
+# ---------------------------------------------------------------------------
+# Video helpers
+# ---------------------------------------------------------------------------
+
+#: Frame rate of every fabricated video below, so a frame index and a timestamp
+#: convert cleanly (frame 6 of a 12fps clip is at 0.5s).
+_VIDEO_FPS = 12.0
+
+
+def _solid_frame(width: int, height: int, color: tuple[int, int, int]) -> np.ndarray:
+    return np.full((height, width, 3), color, dtype=np.uint8)
+
+
+def _barred_frame(width: int, height: int, bar: int, color: tuple[int, int, int]) -> np.ndarray:
+    """A *color* frame with black bars *bar* px deep along the top and bottom."""
+    frame = _solid_frame(width, height, color)
+    frame[:bar] = 0
+    frame[height - bar :] = 0
+    return frame
+
+
+class _FakeVideo:
+    """Decode-layer stand-in serving a fixed frame list, recording every seek."""
+
+    def __init__(self, frames: list[np.ndarray]) -> None:
+        self.frames = frames
+        self.times: list[float] = []
+
+    def probe(self, _path):
+        height, width, _ = self.frames[0].shape
+        return decode.VideoInfo(
+            duration=len(self.frames) / _VIDEO_FPS,
+            fps=_VIDEO_FPS,
+            width=width,
+            height=height,
+        )
+
+    def frame_at(self, _path, time_seconds: float):
+        self.times.append(round(float(time_seconds), 6))
+        index = int(round(float(time_seconds) * _VIDEO_FPS))
+        if index < 0 or index >= len(self.frames):
+            return None
+        return self.frames[index]
+
+    def frames_at(self, path, times):
+        got = [self.frame_at(path, t) for t in times]
+        return [f for f in got if f is not None]
+
+
+@pytest.fixture
+def fake_video(monkeypatch):
+    """Return an installer swapping the video decode layer for a frame list."""
+
+    def _install(frames: list[np.ndarray]) -> _FakeVideo:
+        fake = _FakeVideo(frames)
+        monkeypatch.setattr(decode, "probe", fake.probe)
+        monkeypatch.setattr(decode, "frame_at", fake.frame_at)
+        monkeypatch.setattr(decode, "frames_at", fake.frames_at)
+        return fake
+
+    return _install
+
+
+def _video_media(tmp_path: Path, **extra) -> dict:
+    """A video media dict backed by a real (if bogus) file the cleaners can open."""
+    path = tmp_path / "clip.mp4"
+    if not path.exists():
+        path.write_bytes(b"not really a video; the decode layer is faked")
+    media = {
+        "id": 1,
+        "media_type": "video",
+        "filename": "clip.mp4",
+        "media_path": str(path),
+        "thumbnail_bytes": b"stale-thumb",
+    }
+    media.update(extra)
+    return media
+
+
+def _assert_payload_untouched(before: dict, after: dict) -> None:
+    """A video gate must clean by metadata alone, never by rewriting bytes."""
+    assert after.get("media_bytes") == before.get("media_bytes")
+    assert after.get("media_string") == before.get("media_string")
+    assert "original_media_bytes" not in after
+    assert "original_media_string" not in after
+
+
+# ---------------------------------------------------------------------------
+# video_letterbox_crop
+# ---------------------------------------------------------------------------
+
+
+class TestVideoLetterboxCropCleaner:
+    def test_identity(self):
+        from vtscore.media.video.cleaner import VideoLetterboxCropCleaner
+
+        cleaner = get_cleaner("video_letterbox_crop")
+        assert isinstance(cleaner, VideoLetterboxCropCleaner)
+        assert cleaner.media_type == "video"
+        assert cleaner.display_name == "Letterbox Crop"
+        # Cropping is a judgment call about what counts as padding.
+        assert cleaner.default_enabled is False
+
+    def test_records_the_bars_as_a_clip_box(self, fake_video, tmp_path):
+        fake_video([_barred_frame(200, 100, 25, (200, 40, 40)) for _ in range(24)])
+        media = _video_media(tmp_path)
+        out = get_cleaner("video_letterbox_crop").clean(media)
+
+        assert out is not media
+        assert out["clip_box"] == [0, 25, 200, 75]
+        _assert_payload_untouched(media, out)
+
+    def test_the_stale_parent_thumbnail_is_not_carried_forward_by_the_runner(self, fake_video, tmp_path):
+        """The gate itself copies the dict; the chain runner drops the thumbnail.
+
+        Asserted here so the pair stays honest: a cropped unit whose preview
+        still showed the bars would contradict the crop.
+        """
+        from vtscore.datasets.clipper_chain import _run_cleaner_step
+
+        fake_video([_barred_frame(200, 100, 25, (200, 40, 40)) for _ in range(24)])
+        media = _video_media(tmp_path)
+        (out,), (entry,) = _run_cleaner_step(media, {"kind": "cleaner", "name": "video_letterbox_crop", "params": {}})
+        assert entry["changed"] is True
+        assert "thumbnail_bytes" not in out
+
+    def test_the_union_of_the_sampled_frames_wins(self, fake_video, tmp_path):
+        """A margin is cropped only where *every* sampled frame agrees it is bar.
+
+        The subject drifts into the upper bar half way through the clip; the
+        union keeps that room, an intersection would have cut it off.
+        """
+        deep = [_barred_frame(200, 100, 25, (200, 40, 40)) for _ in range(12)]
+        shallow = [_barred_frame(200, 100, 10, (200, 40, 40)) for _ in range(12)]
+        fake_video(deep + shallow)
+        out = get_cleaner("video_letterbox_crop").clean(_video_media(tmp_path))
+        assert out["clip_box"] == [0, 10, 200, 90]
+
+    def test_content_to_the_edges_is_a_no_op(self, fake_video, tmp_path):
+        fake_video([_solid_frame(200, 100, (90, 140, 60)) for _ in range(24)])
+        media = _video_media(tmp_path)
+        assert get_cleaner("video_letterbox_crop").clean(media) is media
+
+    def test_one_unpadded_frame_vetoes_the_crop(self, fake_video, tmp_path):
+        """Bars for most of the clip, but one frame fills the frame: no crop."""
+        frames = [_barred_frame(200, 100, 25, (200, 40, 40)) for _ in range(24)]
+        frames[12] = _solid_frame(200, 100, (90, 140, 60))
+        fake_video(frames)
+        media = _video_media(tmp_path)
+        assert get_cleaner("video_letterbox_crop").clean(media) is media
+
+    def test_a_wholly_blank_frame_does_not_veto_the_crop(self, fake_video, tmp_path):
+        """A fade-to-black frame says nothing about where the bars are."""
+        frames = [_barred_frame(200, 100, 25, (200, 40, 40)) for _ in range(24)]
+        frames[12] = _solid_frame(200, 100, (0, 0, 0))
+        fake_video(frames)
+        out = get_cleaner("video_letterbox_crop").clean(_video_media(tmp_path))
+        assert out["clip_box"] == [0, 25, 200, 75]
+
+    def test_an_all_blank_clip_is_a_no_op(self, fake_video, tmp_path):
+        fake_video([_solid_frame(200, 100, (0, 0, 0)) for _ in range(24)])
+        media = _video_media(tmp_path)
+        assert get_cleaner("video_letterbox_crop").clean(media) is media
+
+    def test_a_margin_thinner_than_min_edge_trim_is_left_alone(self, fake_video, tmp_path):
+        # A 1 px bar on a 100 px frame is 1%, under the 2% floor.
+        fake_video([_barred_frame(200, 100, 1, (200, 40, 40)) for _ in range(24)])
+        media = _video_media(tmp_path)
+        assert get_cleaner("video_letterbox_crop").clean(media) is media
+
+    def test_only_the_units_own_window_is_sampled(self, fake_video, tmp_path):
+        """A tile must measure its own frames, not the whole parent video's."""
+        fake = fake_video([_barred_frame(200, 100, 25, (200, 40, 40)) for _ in range(24)])
+        media = _video_media(tmp_path, clip_start=1.0, clip_end=1.5)
+        get_cleaner("video_letterbox_crop").clean(media)
+        assert fake.times
+        assert all(1.0 <= t <= 1.5 for t in fake.times)
+
+    def test_composes_with_an_earlier_crop(self, fake_video, tmp_path):
+        """The box is stored in source-frame coordinates, so crops compose.
+
+        The unit already covers rows 10-90; inside *that* region the bars are
+        another 15 px deep, which lands back at the true content box.
+        """
+        fake_video([_barred_frame(200, 100, 25, (200, 40, 40)) for _ in range(24)])
+        out = get_cleaner("video_letterbox_crop").clean(_video_media(tmp_path, clip_box=[0, 10, 200, 90]))
+        assert out["clip_box"] == [0, 25, 200, 75]
+
+    def test_an_already_cropped_unit_is_a_no_op(self, fake_video, tmp_path):
+        fake_video([_barred_frame(200, 100, 25, (200, 40, 40)) for _ in range(24)])
+        media = _video_media(tmp_path, clip_box=[0, 25, 200, 75])
+        assert get_cleaner("video_letterbox_crop").clean(media) is media
+
+    def test_undecodable_and_pathless_payloads_are_no_ops(self, tmp_path):
+        cleaner = get_cleaner("video_letterbox_crop")
+        for media in (
+            {"media_type": "video", "media_path": str(tmp_path / "nope.mp4")},
+            {"media_type": "video", "media_bytes": b"not a video at all"},
+            {"media_type": "video"},
+        ):
+            assert cleaner.clean(media) is media
+
+    def test_params_override_the_thresholds(self, fake_video, tmp_path):
+        from vtscore.media.video.cleaner import VideoLetterboxCropCleaner
+
+        cleaner = get_cleaner("video_letterbox_crop")
+        assert [p["key"] for p in cleaner.parameters] == [
+            "samples",
+            "edge_tol",
+            "max_edge_trim",
+            "min_edge_trim",
+        ]
+
+        looser = cleaner.with_params({"min_edge_trim": 0.005, "samples": 2})
+        assert isinstance(cleaner, VideoLetterboxCropCleaner)
+        assert isinstance(looser, VideoLetterboxCropCleaner)
+        assert looser is not cleaner
+        assert looser.samples == 2
+        assert looser.edge_tol == cleaner.edge_tol  # unnamed params carry over
+
+        # The 1 px bar the default floor ignores is now worth cropping.
+        fake = fake_video([_barred_frame(200, 100, 1, (200, 40, 40)) for _ in range(24)])
+        out = looser.clean(_video_media(tmp_path))
+        assert out["clip_box"] == [0, 1, 200, 99]
+        assert len(fake.times) == 2
+
+    def test_the_crop_is_capped_per_side(self, fake_video, tmp_path):
+        # A 10 px dot in a 200x200 black field: uncapped this would crop to the
+        # dot; the 0.45 cap keeps the middle 10% of each axis.
+        frame = _solid_frame(200, 200, (0, 0, 0))
+        frame[95:105, 95:105] = (220, 30, 30)
+        fake_video([frame for _ in range(24)])
+        out = get_cleaner("video_letterbox_crop").clean(_video_media(tmp_path))
+        assert out["clip_box"] == [90, 90, 110, 110]
+
+
+# ---------------------------------------------------------------------------
+# video_blank_trim
+# ---------------------------------------------------------------------------
+
+
+def _blank_led_frames(lead: int, content: int, tail: int) -> list[np.ndarray]:
+    """``lead`` black frames, ``content`` coloured ones, ``tail`` black ones."""
+    black = _solid_frame(160, 90, (0, 0, 0))
+    lit = _solid_frame(160, 90, (180, 90, 40))
+    return [black] * lead + [lit] * content + [black] * tail
+
+
+class TestVideoBlankTrimCleaner:
+    def test_identity(self):
+        from vtscore.media.video.cleaner import VideoBlankTrimCleaner
+
+        cleaner = get_cleaner("video_blank_trim")
+        assert isinstance(cleaner, VideoBlankTrimCleaner)
+        assert cleaner.media_type == "video"
+        assert cleaner.display_name == "Blank Frame Trim"
+        assert cleaner.default_enabled is False
+
+    def test_narrows_the_window_past_the_blank_head_and_tail(self, fake_video, tmp_path):
+        # 24 frames at 12fps: 6 black, 12 lit, 6 black.
+        fake_video(_blank_led_frames(6, 12, 6))
+        media = _video_media(tmp_path)
+        out = get_cleaner("video_blank_trim").clean(media)
+
+        assert out is not media
+        # The cut lands on a scan step and never crosses the first frame with
+        # content in it, so one 0.25s step of black survives at each end.
+        assert (out["clip_start"], out["clip_end"]) == (0.25, 1.75)
+        assert out["duration"] == 1.5
+        _assert_payload_untouched(media, out)
+
+    def test_the_cut_never_crosses_into_content(self, fake_video, tmp_path):
+        """Trimming to the first content probe would eat up to a step of picture."""
+        fake_video(_blank_led_frames(6, 12, 6))
+        out = get_cleaner("video_blank_trim").clean(_video_media(tmp_path))
+        first_content = 6 / _VIDEO_FPS
+        last_content = 18 / _VIDEO_FPS
+        assert out["clip_start"] <= first_content
+        assert out["clip_end"] >= last_content
+
+    def test_content_at_both_ends_costs_two_probes(self, fake_video, tmp_path):
+        fake = fake_video(_blank_led_frames(0, 24, 0))
+        media = _video_media(tmp_path)
+        assert get_cleaner("video_blank_trim").clean(media) is media
+        assert len(fake.times) == 2
+
+    def test_blank_frames_inside_the_clip_are_kept(self, fake_video, tmp_path):
+        """A mid-clip cut to black is content rhythm, not waste."""
+        frames = _blank_led_frames(0, 24, 0)
+        frames[10:14] = [_solid_frame(160, 90, (0, 0, 0))] * 4
+        fake_video(frames)
+        media = _video_media(tmp_path)
+        assert get_cleaner("video_blank_trim").clean(media) is media
+
+    def test_a_white_card_counts_as_blank(self, fake_video, tmp_path):
+        frames = [_solid_frame(160, 90, (255, 255, 255))] * 6 + [_solid_frame(160, 90, (180, 90, 40))] * 18
+        fake_video(frames)
+        out = get_cleaner("video_blank_trim").clean(_video_media(tmp_path))
+        assert out["clip_start"] == 0.25
+
+    def test_a_trim_shorter_than_the_floor_is_a_no_op(self, fake_video, tmp_path):
+        # One black frame (~0.083s) at the head, under the 0.1s floor.
+        fake_video(_blank_led_frames(1, 23, 0))
+        media = _video_media(tmp_path)
+        assert get_cleaner("video_blank_trim").clean(media) is media
+
+    def test_the_trim_is_capped_per_end(self, fake_video, tmp_path):
+        """An almost entirely blank clip loses at most max_trim off each end."""
+        fake_video(_blank_led_frames(11, 2, 11))
+        out = get_cleaner("video_blank_trim").clean(_video_media(tmp_path))
+        # 2s clip, 0.25 cap: 0.5s off each end and no more.
+        assert (out["clip_start"], out["clip_end"]) == (0.5, 1.5)
+
+    def test_trims_within_a_tiles_own_window(self, fake_video, tmp_path):
+        """A tile's blank head is trimmed relative to the tile, not the parent."""
+        fake_video(_blank_led_frames(12, 12, 0))
+        media = _video_media(tmp_path, clip_start=0.5, clip_end=1.5, duration=1.0)
+        out = get_cleaner("video_blank_trim").clean(media)
+        assert (out["clip_start"], out["clip_end"]) == (0.75, 1.5)
+        assert out["duration"] == 0.75
+
+    def test_high_contrast_content_is_not_blank(self, fake_video, tmp_path):
+        """Black-on-white content is two flat tones, but neither dominates."""
+        frame = _solid_frame(160, 90, (255, 255, 255))
+        frame[:, :80] = 0
+        fake_video([frame] * 24)
+        media = _video_media(tmp_path)
+        assert get_cleaner("video_blank_trim").clean(media) is media
+
+    def test_undecodable_and_pathless_payloads_are_no_ops(self, tmp_path):
+        cleaner = get_cleaner("video_blank_trim")
+        for media in (
+            {"media_type": "video", "media_path": str(tmp_path / "nope.mp4")},
+            {"media_type": "video", "media_bytes": b"not a video at all"},
+            {"media_type": "video"},
+        ):
+            assert cleaner.clean(media) is media
+
+    def test_params_override_the_thresholds(self, fake_video, tmp_path):
+        from vtscore.media.video.cleaner import VideoBlankTrimCleaner
+
+        cleaner = get_cleaner("video_blank_trim")
+        assert [p["key"] for p in cleaner.parameters] == ["blank_ratio", "max_trim", "step"]
+
+        tighter = cleaner.with_params({"max_trim": 0.1})
+        assert isinstance(cleaner, VideoBlankTrimCleaner)
+        assert isinstance(tighter, VideoBlankTrimCleaner)
+        assert tighter is not cleaner
+        assert tighter.max_trim == 0.1
+        assert tighter.step == cleaner.step  # unnamed params carry over
+
+        fake_video(_blank_led_frames(6, 12, 6))
+        out = tighter.clean(_video_media(tmp_path))
+        assert (out["clip_start"], out["clip_end"]) == (0.2, 1.8)
+
+    def test_the_probe_count_stays_bounded_on_a_long_clip(self, fake_video, tmp_path):
+        """The scan step coarsens with duration instead of probing every 0.25s."""
+        from vtscore.media.video.cleaner import _MAX_PROBES_PER_END
+
+        # 20 minutes of black: a fixed 0.25s step would be 1200 probes per end.
+        fake = fake_video([_solid_frame(64, 36, (0, 0, 0))] * int(_VIDEO_FPS * 1200))
+        get_cleaner("video_blank_trim").clean(_video_media(tmp_path))
+        assert len(fake.times) <= 2 * (_MAX_PROBES_PER_END + 1)
+
+    def test_the_pair_runs_crop_first(self):
+        """Cropping before the blank scan keeps the two gates order-insensitive.
+
+        Bars are near-black, so an uncropped frame reads as far blanker than
+        the picture inside it does.
+        """
+        from vtscore.media import cleaners_for_type
+
+        order = [c.name for c in cleaners_for_type("video")]
+        assert order.index("video_letterbox_crop") < order.index("video_blank_trim")
+
+
+class TestVideoGatesOnRealVideo:
+    """End-to-end over ffmpeg-encoded files, no faked decode layer."""
+
+    def _encode(self, frames: list[np.ndarray], tmp_path: Path, name: str) -> Path:
+        from vtscore.utils.synthetic.video import _encode_frames
+
+        path = tmp_path / name
+        _encode_frames(path, frames, fps=int(_VIDEO_FPS))
+        return path
+
+    def test_real_letterboxed_video_is_cropped_to_its_content(self, tmp_path):
+        path = self._encode([_barred_frame(160, 96, 24, (210, 40, 40)) for _ in range(24)], tmp_path, "bars.mp4")
+        out = get_cleaner("video_letterbox_crop").clean({"media_type": "video", "media_path": str(path)})
+        x0, y0, x1, y1 = out["clip_box"]
+        assert (x0, x1) == (0, 160)  # no side bars to lose
+        assert abs(y0 - 24) <= 3
+        assert abs(y1 - 72) <= 3
+
+    def test_real_unpadded_video_is_a_no_op(self, tmp_path):
+        frames = []
+        rng = np.random.default_rng(0)
+        for _ in range(24):
+            frames.append(rng.integers(40, 210, size=(96, 160, 3), dtype=np.uint8))
+        path = self._encode(frames, tmp_path, "noise.mp4")
+        media = {"media_type": "video", "media_path": str(path)}
+        assert get_cleaner("video_letterbox_crop").clean(media) is media
+
+    def test_real_black_led_video_is_trimmed(self, tmp_path):
+        path = self._encode(_blank_led_frames(6, 12, 6), tmp_path, "leader.mp4")
+        media = {"media_type": "video", "media_path": str(path)}
+        out = get_cleaner("video_blank_trim").clean(media)
+        assert out is not media
+        assert out["clip_start"] >= 0.25
+        assert out["clip_end"] <= 1.75
+        assert out["duration"] == round(out["clip_end"] - out["clip_start"], 6)

--- a/tests_lib/detectors/test_media_cleaners.py
+++ b/tests_lib/detectors/test_media_cleaners.py
@@ -83,6 +83,42 @@ class _SuffixTextCleaner(MediaCleaner):
         return cleaned
 
 
+class _WindowTrimVideoCleaner(MediaCleaner):
+    """Third test cleaner: cleans by **metadata**, never by rewriting a payload.
+
+    Stands in for the shipped video gates (``video_blank_trim`` /
+    ``video_letterbox_crop``) without needing a decodable video.  What the
+    runner has to get right for those is that narrowing a unit's window / box
+    counts as a change - it changes what gets embedded - while snapshotting
+    nothing, because there is no second payload to keep.
+
+    A unit that already carries the trimmed window is a no-op, so one dataset
+    exercises both branches.
+    """
+
+    @property
+    def name(self) -> str:
+        return "video_test_window"
+
+    @property
+    def media_type(self) -> str:
+        return "video"
+
+    @property
+    def description(self) -> str:
+        return "Narrow the unit's window and pixel box."
+
+    def clean(self, media: dict[str, Any]) -> dict[str, Any]:
+        if media.get("clip_start") == 0.5:
+            return media
+        cleaned = dict(media)
+        cleaned["clip_start"] = 0.5
+        cleaned["clip_end"] = 1.5
+        cleaned["duration"] = 1.0
+        cleaned["clip_box"] = [0, 10, 100, 90]
+        return cleaned
+
+
 @pytest.fixture
 def registered_cleaners():
     """Register the test cleaners for one test, then restore the registry."""
@@ -91,6 +127,7 @@ def registered_cleaners():
     before = dict(media_registry._cleaner_registry)
     media_registry.register_cleaner(_UpperTextCleaner())
     media_registry.register_cleaner(_SuffixTextCleaner())
+    media_registry.register_cleaner(_WindowTrimVideoCleaner())
     try:
         yield
     finally:
@@ -116,6 +153,26 @@ def _make_text_media(media_id: int, text: str) -> dict:
         "origin": {"importer": "server_folder", "params": {"path": "/data/text", "media_type": "text"}},
         "origin_name": f"doc_{media_id}.txt",
     }
+
+
+def _make_video_media(media_id: int, **extra) -> dict:
+    rng = np.random.default_rng(media_id)
+    media = {
+        "id": media_id,
+        "media_type": "video",
+        "filename": f"clip_{media_id}.mp4",
+        "media_bytes": b"video-payload",
+        "duration": 2.0,
+        "file_size": 13,
+        "md5": content_md5(b"video-payload"),
+        "embeddings": {"xclip": rng.standard_normal(512).astype(np.float32)},
+        "embedder": "xclip",
+        "thumbnail_bytes": b"stale-thumbnail",
+        "origin": {"importer": "server_folder", "params": {"path": "/data/video", "media_type": "video"}},
+        "origin_name": f"clip_{media_id}.mp4",
+    }
+    media.update(extra)
+    return media
 
 
 def _exif_jpeg(orientation: int, size: tuple[int, int] = (40, 20)) -> bytes:
@@ -414,6 +471,97 @@ class TestApplyChainWithCleaner:
             on_progress=lambda cur, total, phase: phases.append(phase),
         )
         assert phases == ["cleaning"]
+
+
+class TestMetadataOnlyClean:
+    """A cleaner may clean by narrowing metadata instead of rewriting a payload.
+
+    Video units are metadata-only - every clip of a parent shares its bytes -
+    so the video gates trim the time window and record a pixel box.  The runner
+    has to count that as a change (it changes what gets embedded and what the
+    thumbnail should show) while snapshotting nothing.
+    """
+
+    def test_counts_as_changed_and_needs_recompute(self, registered_cleaners):
+        from vtscore.datasets.clipper_chain import apply_chain_to_clips
+
+        clips = {1: _make_video_media(1), 2: _make_video_media(2, clip_start=0.5, clip_end=1.5)}
+        result = apply_chain_to_clips(clips, [{"kind": "cleaner", "name": "video_test_window", "params": {}}])
+        assert result is not None
+        assert result[0] == "video"
+        assert clips[1]["clip_start"] == 0.5
+        assert clips[1]["clip_box"] == [0, 10, 100, 90]
+        # The trimmed unit's MD5 / embedding / thumbnail all describe the old
+        # window, so only it needs the fixup.
+        assert result[1] == [True, False]
+
+    def test_snapshots_nothing(self, registered_cleaners):
+        """There is no second payload: the served file is untouched, and the
+        player already loops within ``[clip_start, clip_end]``."""
+        from vtscore.datasets.clipper_chain import ORIGINAL_PAYLOAD_KEYS, apply_chain_to_clips, has_original_payload
+
+        clips = {1: _make_video_media(1)}
+        apply_chain_to_clips(clips, [{"kind": "cleaner", "name": "video_test_window", "params": {}}])
+        assert clips[1]["media_bytes"] == b"video-payload"
+        assert not has_original_payload(clips[1])
+        for key in ORIGINAL_PAYLOAD_KEYS:
+            assert key not in clips[1]
+
+    def test_drops_the_stale_thumbnail(self, registered_cleaners):
+        """The parent's poster frame shows the old window at the old framing."""
+        from vtscore.datasets.clipper_chain import apply_chain_to_clips
+
+        clips = {1: _make_video_media(1), 2: _make_video_media(2, clip_start=0.5, clip_end=1.5)}
+        apply_chain_to_clips(clips, [{"kind": "cleaner", "name": "video_test_window", "params": {}}])
+        assert "thumbnail_bytes" not in clips[1]
+        assert clips[2]["thumbnail_bytes"] == b"stale-thumbnail"
+
+    def test_the_trail_records_the_new_window_and_box(self, registered_cleaners):
+        from vtscore.datasets.clipper_chain import apply_chain_to_clips
+
+        clips = {1: _make_video_media(1), 2: _make_video_media(2, clip_start=0.5, clip_end=1.5)}
+        apply_chain_to_clips(clips, [{"kind": "cleaner", "name": "video_test_window", "params": {}}])
+
+        entry = json.loads(clips[1]["origin"]["params"]["clipper_chain"])[0]
+        assert entry["changed"] is True
+        assert (entry["clip_start"], entry["clip_end"]) == ("0.5", "1.5")
+        assert entry["clip_box"] == "0,10,100,90"
+
+        # A gate that no-opped records no window: there is nothing it did.
+        no_op = json.loads(clips[2]["origin"]["params"]["clipper_chain"])[0]
+        assert no_op["changed"] is False
+        assert "clip_start" not in no_op
+
+    def test_a_metadata_clean_appears_in_derived_via(self, registered_cleaners):
+        from vtscore.datasets.clipper_chain import apply_chain_to_clips
+        from vtscore.media.provenance import _describe_derivation
+
+        clips = {1: _make_video_media(1)}
+        apply_chain_to_clips(clips, [{"kind": "cleaner", "name": "video_test_window", "params": {}}])
+        # Rendered by display name, like every other step in the chain.
+        assert _describe_derivation(clips[1]["origin"]["params"]) == "Test Window"
+
+    def test_a_metadata_cleaned_reference_clip_stays_lazy(self, registered_cleaners):
+        """Unlike a payload clean, this one costs a thin import nothing.
+
+        ``lazy_clip`` reproduces the unit by reading the source file and
+        honouring the window / box, which is exactly what the cleaner recorded -
+        so there is no reason to hold the bytes.
+        """
+        from vtscore.datasets.clipper_chain import apply_chain_to_clips
+        from vtscore.datasets.stages.clipper import _relazify_reference_clips_stage
+        from vtscore.state import DatasetContext
+
+        clips = {1: _make_video_media(1, _lazy_source="/data/video/clip_1.mp4")}
+        apply_chain_to_clips(clips, [{"kind": "cleaner", "name": "video_test_window", "params": {}}])
+        ctx = DatasetContext("metadata-clean-relazify-test")
+        ctx.medias.update(clips)
+
+        _relazify_reference_clips_stage(ctx)
+
+        assert clips[1]["media_bytes"] is None
+        assert clips[1]["media_path"] == "/data/video/clip_1.mp4"
+        assert clips[1]["clip_start"] == 0.5
 
 
 class TestResolvedParamsBaseKeys:

--- a/tests_lib/detectors/test_video_frame_sampler.py
+++ b/tests_lib/detectors/test_video_frame_sampler.py
@@ -171,6 +171,54 @@ class TestPartialReadWarning:
         assert warnings, "partial read on a short video should still warn"
 
 
+class TestClipBoxCrop:
+    """A unit's ``clip_box`` frames what the embedder sees.
+
+    Video units are metadata-only, so a letterbox crop is *honoured* here
+    rather than baked into a re-encoded copy (see
+    :class:`~vtscore.media.video.cleaner.VideoLetterboxCropCleaner`).
+    """
+
+    @pytest.fixture
+    def wide_video(self, monkeypatch):
+        """Install a decoder serving 40x20 frames with a 4 px bar top/bottom."""
+        frame = np.full((20, 40, 3), 200, dtype=np.uint8)
+        frame[:4] = 0
+        frame[16:] = 0
+
+        def probe(_path):
+            return decode.VideoInfo(duration=2.0, fps=10.0, width=40, height=20)
+
+        monkeypatch.setattr(decode, "probe", probe)
+        monkeypatch.setattr(decode, "frame_at", lambda _p, _t: frame)
+
+    def test_frames_are_cropped_to_the_box(self, wide_video, tmp_path):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        media = _media(tmp_path)
+        media["clip_box"] = [0, 4, 40, 16]
+        frames = sample_video_frames(media, num_frames=4)
+        assert len(frames) == 4
+        assert all(f.size == (40, 12) for f in frames)
+        # Only the bars were black, so nothing black survives the crop.
+        assert all(np.asarray(f).min() == 200 for f in frames)
+
+    def test_no_box_leaves_the_full_frame(self, wide_video, tmp_path):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        frames = sample_video_frames(_media(tmp_path), num_frames=2)
+        assert all(f.size == (40, 20) for f in frames)
+
+    def test_a_malformed_box_is_ignored_rather_than_fatal(self, wide_video, tmp_path):
+        from vtscore.media.video._frame_sampling import sample_video_frames
+
+        media = _media(tmp_path)
+        for bad in ("nonsense", [1, 2], [0, 0, 0, 0], None):
+            media["clip_box"] = bad
+            frames = sample_video_frames(media, num_frames=2)
+            assert all(f.size == (40, 20) for f in frames)
+
+
 class TestUndecodableSource:
     """Guards on the real decode layer, no fake installed."""
 

--- a/vtscore/datasets/clipper_chain.py
+++ b/vtscore/datasets/clipper_chain.py
@@ -288,6 +288,26 @@ def _payload_changed(before: dict[str, Any], after: dict[str, Any]) -> bool:
     )
 
 
+#: Keys that say *which part* of a payload a unit is: the time window
+#: (``clip_start`` / ``clip_end``) and the pixel region (``clip_box``).  Video
+#: units are metadata-only - every clip of a parent shares its bytes - so a
+#: video cleaner cleans by narrowing these instead of rewriting a payload (see
+#: :mod:`vtscore.media.video.cleaner`).
+CLEANED_METADATA_KEYS = ("clip_start", "clip_end", "clip_box")
+
+
+def _metadata_changed(before: dict[str, Any], after: dict[str, Any]) -> bool:
+    """True iff a cleaner narrowed which part of the payload the unit covers.
+
+    A metadata-only clean is a real change - it changes what gets embedded and
+    what the thumbnail should show - but there is no rewritten payload, so it
+    is deliberately *not* snapshotted under the ``original_*`` keys: the served
+    file is untouched and the player already loops within
+    ``[clip_start, clip_end]``.
+    """
+    return any(before.get(k) != after.get(k) for k in CLEANED_METADATA_KEYS)
+
+
 def _snapshot_original(source: dict[str, Any], cleaned: dict[str, Any]) -> None:
     """Stamp *cleaned* with *source*'s payload under the ``original_*`` keys.
 
@@ -312,11 +332,17 @@ def _run_cleaner_step(media: dict[str, Any], step: ChainStep) -> tuple[list[dict
     """Run a cleaner step on one media. Returns (outputs, per-output trail entries).
 
     Always one output.  The runner - not each cleaner - owns the pre-clean
-    snapshot: it compares the payload before and after :meth:`clean` and stamps
-    the ``original_*`` keys only on a real change.  The trail entry records
-    ``changed`` so provenance can render the gates that actually did something
-    without re-deriving it, and ``content_hash`` of the cleaned payload so
-    cross-dataset replay embeds the same bytes.
+    snapshot: it compares the unit before and after :meth:`clean` and stamps the
+    ``original_*`` keys only when the *payload* was rewritten.  A cleaner that
+    cleaned by narrowing metadata instead (:data:`CLEANED_METADATA_KEYS`, the
+    video gates) counts as changed but snapshots nothing - there is no second
+    payload to keep.
+
+    The trail entry records ``changed`` so provenance can render the gates that
+    actually did something without re-deriving it, ``content_hash`` of the
+    cleaned payload so cross-dataset replay embeds the same bytes, and the
+    post-clean window / box of a metadata-only clean so the trail says what the
+    gate did (the legacy origin keys still describe the last *clipper*).
     """
     from vtscore.media import get_cleaner
 
@@ -325,8 +351,10 @@ def _run_cleaner_step(media: dict[str, Any], step: ChainStep) -> tuple[list[dict
         cleaner = cleaner.with_params(step["params"])
     effective = _resolved_clipper_params(cleaner)
     cleaned = cleaner.clean(media)
-    changed = _payload_changed(media, cleaned)
-    if changed:
+    payload_changed = _payload_changed(media, cleaned)
+    metadata_changed = _metadata_changed(media, cleaned)
+    changed = payload_changed or metadata_changed
+    if payload_changed:
         if cleaned is media:
             # A cleaner that mutated its input in place leaves us no pre-clean
             # payload to snapshot; treat it as unsnapshottable rather than
@@ -334,11 +362,12 @@ def _run_cleaner_step(media: dict[str, Any], step: ChainStep) -> tuple[list[dict
             log.warning("clipper_chain: cleaner %r mutated its input in place; no Original kept", cleaner.name)
         else:
             _snapshot_original(media, cleaned)
+    if changed:
         # Cleaners build their output with ``dict(media)``, which carries the
         # parent's ingest-time thumbnail forward. That thumbnail now describes
-        # the *pre*-clean payload, so drop it and let the thumbnail route (or
-        # the load stage's audio/video regeneration) rebuild it from the
-        # canonical bytes.
+        # the *pre*-clean payload (or the pre-crop framing), so drop it and let
+        # the thumbnail route (or the load stage's audio/video regeneration)
+        # rebuild it from the canonical bytes.
         cleaned.pop("thumbnail_bytes", None)
     entry: ChainStep = {
         "kind": "cleaner",
@@ -348,6 +377,13 @@ def _run_cleaner_step(media: dict[str, Any], step: ChainStep) -> tuple[list[dict
         "n_out": 1,
         "changed": changed,
     }
+    if metadata_changed:
+        if cleaned.get("clip_start") is not None:
+            entry["clip_start"] = str(cleaned["clip_start"])
+        if cleaned.get("clip_end") is not None:
+            entry["clip_end"] = str(cleaned["clip_end"])
+        if cleaned.get("clip_box") is not None:
+            entry["clip_box"] = ",".join(str(v) for v in cleaned["clip_box"])
     ch = _content_hash(cleaned)
     if ch is not None:
         entry["content_hash"] = ch

--- a/vtscore/datasets/stages/clipper.py
+++ b/vtscore/datasets/stages/clipper.py
@@ -271,8 +271,11 @@ def _thumb_for(clip: dict, media_type: str) -> bytes | None:
     For ``audio`` clips, render a waveform thumbnail from the clip's
     ``media_bytes`` (or its ``media_path`` when bytes aren't held).  For
     ``video`` clips, render a frame at the midpoint of
-    ``clip_start``/``clip_end``; a clip missing either boundary yields
-    ``None``.  Other media types yield ``None``.
+    ``clip_start``/``clip_end``, cropped to the clip's ``clip_box`` when it
+    carries one, so a letterbox-cropped unit previews the way it embeds.  A
+    video clip with neither boundaries nor a box yields ``None`` - there is
+    nothing about it the parent's thumbnail gets wrong.  Other media types
+    yield ``None``.
     """
     if media_type == "audio":
         from vtscore.media.audio.media_type import (
@@ -290,21 +293,32 @@ def _thumb_for(clip: dict, media_type: str) -> bytes | None:
 
     if media_type == "video":
         from vtscore.media.video.media_type import (
+            generate_video_thumbnail,
             generate_video_thumbnail_at,
+            generate_video_thumbnail_from_file,
             generate_video_thumbnail_from_file_at,
         )
 
         t0 = clip.get("clip_start")
         t1 = clip.get("clip_end")
+        box = clip.get("clip_box")
         if t0 is None or t1 is None:
-            return None
+            # No window of its own: only a crop can make the parent's
+            # thumbnail wrong, and the middle frame is the right one to show.
+            if box is None:
+                return None
+            video_bytes = clip.get("media_bytes")
+            if video_bytes is not None:
+                return generate_video_thumbnail(video_bytes, crop_box=box)
+            path = clip.get("media_path")
+            return generate_video_thumbnail_from_file(Path(path), crop_box=box) if path else None
         mid = (float(t0) + float(t1)) / 2.0
         video_bytes = clip.get("media_bytes")
         if video_bytes is not None:
-            return generate_video_thumbnail_at(video_bytes, mid)
+            return generate_video_thumbnail_at(video_bytes, mid, crop_box=box)
         path = clip.get("media_path")
         if path:
-            return generate_video_thumbnail_from_file_at(Path(path), mid)
+            return generate_video_thumbnail_from_file_at(Path(path), mid, crop_box=box)
         return None
 
     return None
@@ -389,6 +403,11 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
             # distinct clips.
             parent_bytes = clip.get("media_bytes", b"")
             boundary_tag = f"|clip_start={clip.get('clip_start')}|clip_end={clip.get('clip_end')}"
+            box = clip.get("clip_box")
+            if box is not None:
+                # Only appended when a box exists, so an uncropped video clip's
+                # MD5 is exactly what it was before crops became possible.
+                boundary_tag += "|clip_box=" + ",".join(str(v) for v in box)
             combined = content_md5(parent_bytes) + boundary_tag
             clip["md5"] = content_md5(combined.encode())
         embed_indices.append(clip_idx)
@@ -498,10 +517,11 @@ def _build_clip_embed_input(clip: dict, media_type: str) -> dict:
     ``filename`` so embedders that surface diagnostic paths still log
     something useful.
 
-    Video clips additionally carry ``clip_start`` / ``clip_end`` (and
-    ``media_path`` when available) because the underlying parent bytes
-    are shared across every tile; the embedder uses the boundary
-    metadata to sample distinct frame ranges per tile.
+    Video clips additionally carry ``clip_start`` / ``clip_end`` / ``clip_box``
+    (and ``media_path`` when available) because the underlying parent bytes
+    are shared across every tile; the embedder uses the boundary metadata to
+    sample distinct frame ranges per tile, and the box to crop each sampled
+    frame to the region a cleaner marked as content.
     """
     base: dict = {
         "origin_name": clip.get("origin_name", ""),
@@ -518,6 +538,8 @@ def _build_clip_embed_input(clip: dict, media_type: str) -> dict:
             base["clip_start"] = clip["clip_start"]
         if "clip_end" in clip:
             base["clip_end"] = clip["clip_end"]
+        if clip.get("clip_box") is not None:
+            base["clip_box"] = clip["clip_box"]
     return base
 
 

--- a/vtscore/media/video/__init__.py
+++ b/vtscore/media/video/__init__.py
@@ -1,5 +1,11 @@
+from vtscore.media.video.cleaner import VideoBlankTrimCleaner, VideoLetterboxCropCleaner
 from vtscore.media.video.clipper import VideoAutoClipper, VideoDefaultClipper, VideoSceneClipper, VideoTilingClipper
 from vtscore.media.video.media_type import VideoMediaType
 
 MEDIA_TYPE = VideoMediaType()
 CLIPPERS = [VideoAutoClipper(), VideoDefaultClipper(), VideoTilingClipper(2.0), VideoSceneClipper()]
+#: Registration order is run order.  Cropping first means the blank-frame scan
+#: measures the region that will actually be embedded (bars are near-black, and
+#: they would otherwise drag every frame's blank share up), so the pair is
+#: order-insensitive in practice: each gate reads the other's metadata.
+CLEANERS = [VideoLetterboxCropCleaner(), VideoBlankTrimCleaner()]

--- a/vtscore/media/video/_frame_sampling.py
+++ b/vtscore/media/video/_frame_sampling.py
@@ -28,8 +28,13 @@ _logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def _resolve_video_path(media: dict) -> Iterator[Optional[Path]]:
-    """Yield a usable filesystem path for *media*'s video, tempfile if needed."""
+def resolve_video_path(media: dict) -> Iterator[Optional[Path]]:
+    """Yield a usable filesystem path for *media*'s video, tempfile if needed.
+
+    Public within the ``video`` package: the cleaners
+    (:mod:`vtscore.media.video.cleaner`) need the same two-source resolution
+    before they can probe or sample a unit.
+    """
     path_str = media.get("media_path")
     if path_str:
         yield Path(path_str)
@@ -80,6 +85,11 @@ def sample_video_frames(media: dict, num_frames: int) -> list[Any]:
     produce distinct frame sets (and therefore distinct embeddings).
     Otherwise the whole video is sampled.
 
+    When ``media`` carries a ``clip_box`` (written by
+    :class:`~vtscore.media.video.cleaner.VideoLetterboxCropCleaner`), every
+    sampled frame is cropped to it, so the embedder sees the picture rather
+    than the letterbox bars around it.
+
     The returned list is padded by repeating the last frame to exactly
     *num_frames* entries, matching the per-embedder padding loops it
     replaces.  Returns ``[]`` on any decoding failure.
@@ -87,7 +97,9 @@ def sample_video_frames(media: dict, num_frames: int) -> list[Any]:
     import numpy as np  # noqa: PLC0415
     from PIL import Image  # noqa: PLC0415
 
-    with _resolve_video_path(media) as path:
+    from vtscore.media.video.crop import crop_frame  # noqa: PLC0415
+
+    with resolve_video_path(media) as path:
         if path is None:
             return []
         info = decode.probe(path)
@@ -103,7 +115,8 @@ def sample_video_frames(media: dict, num_frames: int) -> list[Any]:
             times = np.linspace(start, end, n_to_sample, dtype=float)
 
         decoded = decode.frames_at(path, [float(t) for t in times])
-        frames: list[Any] = [Image.fromarray(frame) for frame in decoded]
+        box = media.get("clip_box")
+        frames: list[Any] = [Image.fromarray(crop_frame(frame, box)) for frame in decoded]
 
     if not frames:
         return []

--- a/vtscore/media/video/cleaner.py
+++ b/vtscore/media/video/cleaner.py
@@ -1,0 +1,555 @@
+"""Video cleaners - 1→1 cleanup gates run on each video unit before embedding.
+
+Both gates here are **metadata-only**, and deliberately so.  A video unit is a
+``(parent bytes, time window)`` pair: every clip of a tiled video shares the
+parent's payload and says which slice of it it is via ``clip_start`` /
+``clip_end``.  Re-encoding a cleaned copy per unit would duplicate that payload
+once per tile *and* desync the window, which still indexes the parent's
+timeline.  So these cleaners narrow the window (:class:`VideoBlankTrimCleaner`)
+and record a pixel region (:class:`VideoLetterboxCropCleaner`) instead of
+rewriting bytes, and the readers honour both:
+:func:`~vtscore.media.video._frame_sampling.sample_video_frames` for the
+embedding and the thumbnailers for the grid preview.
+
+Two consequences of staying metadata-only, both good: nothing is snapshotted
+under the ``original_*`` keys (there is no rewritten payload to keep an
+"Original" of - the served file is untouched, and the player already loops
+within ``[clip_start, clip_end]``), so a cleaned video costs no extra storage
+and a reference (thin) import keeps its byte savings.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from vtscore.media.cleaner import MediaCleaner
+from vtscore.media.image.edge_trim import (
+    DEFAULT_EDGE_TOL,
+    DEFAULT_MAX_EDGE_TRIM,
+    DEFAULT_MIN_EDGE_TRIM,
+    solid_edge_box,
+)
+from vtscore.media.video import decode
+from vtscore.media.video._frame_sampling import resolve_video_path
+from vtscore.media.video.crop import clamp_clip_box, crop_frame
+
+log = logging.getLogger(__name__)
+
+#: Don't rewrite a unit's window for a trim this small (seconds, summed over
+#: both ends).  Shaving a few frames buys the embedder nothing and only makes
+#: the item look edited.
+_MIN_TRIM_SECONDS = 0.1
+
+#: Never leave a unit shorter than this (seconds).  Guards the degenerate case
+#: where a clip is blank end to end.
+_MIN_SPAN_SECONDS = 0.1
+
+#: Hard ceiling on frame probes per end for the blank scan.  Each probe is one
+#: ffmpeg seek+decode, so the scan step is coarsened on a long unit rather than
+#: letting the probe count grow with its duration.
+_MAX_PROBES_PER_END = 16
+
+#: Row/column stride used when measuring how blank a frame is.  A blank frame is
+#: blank at any sampling density, and this keeps the check ~16x cheaper than a
+#: full-resolution pass.
+_BLANK_STRIDE = 4
+
+#: Dominant-tone share at which :class:`VideoLetterboxCropCleaner` writes a
+#: frame off as wholly blank (a fade, a leader) and skips it rather than letting
+#: it veto the crop.
+_BLANK_FRAME_SHARE = 0.99
+
+
+def _unit_window(media: dict[str, Any], info: decode.VideoInfo) -> tuple[float, float]:
+    """Return the ``[start, end]`` seconds of the video this unit covers.
+
+    Falls back to the whole container when the unit carries no usable
+    boundaries (an untiled video, or a clipper that recorded none).
+    """
+    total = info.duration
+    start = media.get("clip_start")
+    end = media.get("clip_end")
+    try:
+        t0 = max(0.0, min(float(start), total)) if start is not None else 0.0
+        t1 = max(0.0, min(float(end), total)) if end is not None else total
+    except (TypeError, ValueError):
+        return 0.0, total
+    if t1 <= t0:
+        return 0.0, total
+    return t0, t1
+
+
+def _blank_share(frame_rgb: np.ndarray, tone_tol: float) -> float:
+    """Return the share of *frame_rgb* taken by its dominant flat tone.
+
+    A frame counts as blank when one tone - near-black or near-white within
+    *tone_tol* - covers almost all of it: a fade-to-black frame, a black
+    leader, a white flash, an empty card.  Taking the larger of the two shares
+    rather than their sum is what keeps genuinely high-contrast content (black
+    text on a white page, a monochrome line drawing) from reading as blank.
+    """
+    small = frame_rgb[::_BLANK_STRIDE, ::_BLANK_STRIDE]
+    if small.size == 0:
+        return 0.0
+    near_black = float((small.max(axis=2) <= tone_tol).mean())
+    near_white = float((small.min(axis=2) >= 255 - tone_tol).mean())
+    return max(near_black, near_white)
+
+
+class VideoBlankTrimCleaner(MediaCleaner):
+    """Trim leading and trailing blank frames off a video unit.
+
+    The video analog of
+    :class:`~vtscore.media.audio.cleaner.AudioSilenceTrimCleaner`: a clip that
+    opens on a second of black before the fade-in, or ends on a blank tail
+    card, spends that share of the embedder's fixed frame budget on nothing.
+    This gate walks in from each end while the frames are blank and narrows the
+    unit's ``clip_start`` / ``clip_end`` to the first and last frame with
+    content in it.  Blank frames *inside* the clip are left alone - a cut to
+    black mid-scene is part of the content's rhythm.
+
+    Nothing is re-encoded: the window is metadata the embedder's frame sampler
+    and the player both already honour, so a trimmed unit still serves the
+    parent's bytes and the player simply loops within the tighter span.
+
+    Costs one frame probe per end in the common case (the first frame has
+    content, so the scan stops immediately) and at most
+    :data:`_MAX_PROBES_PER_END` when it doesn't.
+
+    Parameters
+    ----------
+    blank_ratio:
+        Share of a frame that must be one flat tone (near-black or near-white)
+        for the frame to count as blank.  Defaults to 0.99.
+    max_trim:
+        Never trim more than this fraction of the unit's duration off either
+        end, so a mostly-blank clip can't collapse to a sliver.  Defaults
+        to 0.25.
+    step:
+        Seconds between frame probes while scanning in from an end.  Also the
+        resolution of the cut - up to one step of blank can survive, because
+        the trim never crosses the first frame seen with content in it.
+        Coarsened automatically on a long unit so the probe count stays
+        bounded.  Defaults to 0.25.
+    """
+
+    def __init__(self, blank_ratio: float = 0.99, max_trim: float = 0.25, step: float = 0.25) -> None:
+        if not 0 < blank_ratio <= 1:
+            raise ValueError("blank_ratio must be in (0, 1]")
+        if not 0 <= max_trim < 0.5:
+            raise ValueError("max_trim must be in [0, 0.5)")
+        if step <= 0:
+            raise ValueError("step must be positive")
+        self._blank_ratio = blank_ratio
+        self._max_trim = max_trim
+        self._step = step
+
+    @property
+    def name(self) -> str:
+        return "video_blank_trim"
+
+    @property
+    def media_type(self) -> str:
+        return "video"
+
+    @property
+    def display_name(self) -> str:
+        return "Blank Frame Trim"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Trim leading and trailing blank frames - black leader, fade-ins, empty tail cards - so the "
+            "embedder's frame budget is spent on content. Blank frames inside the clip are kept."
+        )
+
+    @property
+    def summary_template(self) -> str:
+        return "Trim head/tail frames that are {blank_ratio} one flat tone, up to {max_trim} of each end."
+
+    @property
+    def blank_ratio(self) -> float:
+        return self._blank_ratio
+
+    @property
+    def max_trim(self) -> float:
+        return self._max_trim
+
+    @property
+    def step(self) -> float:
+        return self._step
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "blank_ratio",
+                "label": "Blank threshold",
+                "description": (
+                    "Share of a frame that must be one flat tone (near-black or near-white) for it to "
+                    "count as blank. Lower values treat busier frames as blank - more gets trimmed."
+                ),
+                "type": "number",
+                "default": self._blank_ratio,
+                "min": 0.5,
+                "max": 1,
+                "step": 0.01,
+            },
+            {
+                "key": "max_trim",
+                "label": "Maximum trim per end",
+                "description": (
+                    "Never trim more than this fraction of the clip's duration off either end, so a "
+                    "mostly-blank clip can't collapse to a sliver."
+                ),
+                "type": "number",
+                "default": self._max_trim,
+                "min": 0,
+                "max": 0.45,
+                "step": 0.05,
+            },
+            {
+                "key": "step",
+                "label": "Scan step (seconds)",
+                "description": (
+                    "Seconds between frames while scanning in from each end, and the resolution of the "
+                    "cut. Coarsened automatically on long clips so the number of probes stays bounded."
+                ),
+                "type": "number",
+                "default": self._step,
+                "min": 0.02,
+                "max": 5,
+                "step": 0.01,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "VideoBlankTrimCleaner":
+        return VideoBlankTrimCleaner(
+            blank_ratio=float(params.get("blank_ratio", self._blank_ratio)),
+            max_trim=float(params.get("max_trim", self._max_trim)),
+            step=float(params.get("step", self._step)),
+        )
+
+    def _scan_in(
+        self,
+        path: Path,
+        *,
+        origin: float,
+        budget: float,
+        direction: int,
+        box: Any,
+    ) -> float:
+        """Return how far in from *origin* the blank run reaches (seconds).
+
+        Walks *direction* (+1 forward from the head, -1 back from the tail) in
+        steps while every probed frame is blank, stopping at *budget* seconds.
+        A frame that fails to decode ends the run: an unreadable frame is not
+        evidence of blankness.
+
+        Returns the last offset actually *seen* blank, never the first offset
+        seen with content: the cut therefore lands on a scan step and can leave
+        up to one step of blank standing, which is the right way round.
+        Trimming to the content probe instead would delete up to a step of real
+        picture between the two, and a gate must not eat content to tidy an
+        edge.  A caller who wants a tighter cut lowers ``step``.
+        """
+        if budget <= 0:
+            return 0.0
+        step = max(self._step, budget / _MAX_PROBES_PER_END)
+        blank = 0.0
+        offset = 0.0
+        while offset <= budget:
+            frame = decode.frame_at(path, origin + direction * offset)
+            if frame is None:
+                break
+            if _blank_share(crop_frame(frame, box), DEFAULT_EDGE_TOL) < self._blank_ratio:
+                # Content: everything from here in stays, including the gap back
+                # to the last blank probe.
+                return blank
+            blank = offset
+            offset += step
+        # Blank as far as we looked (or as far as the frames decoded).
+        return min(offset, budget)
+
+    def clean(self, media: dict[str, Any]) -> dict[str, Any]:
+        """Return *media* with its blank head/tail trimmed off, or unchanged.
+
+        Unchanged when the video can't be resolved or probed, the unit is
+        already shorter than a trim would leave it, no blank run reaches
+        :data:`_MIN_TRIM_SECONDS`, or the frames simply have content at both
+        ends - the common case, which costs two frame probes.
+        """
+        with resolve_video_path(media) as path:
+            if path is None:
+                return media
+            info = decode.probe(path)
+            if info is None or info.duration <= 0:
+                return media
+
+            t0, t1 = _unit_window(media, info)
+            span = t1 - t0
+            if span <= _MIN_SPAN_SECONDS:
+                return media
+
+            box = media.get("clip_box")
+            budget = span * self._max_trim
+            # The tail probe starts one frame short of the end, where a seek
+            # still lands on a real frame.
+            head = self._scan_in(path, origin=t0, budget=budget, direction=1, box=box)
+            tail_origin = max(t0, t1 - info.frame_seconds)
+            tail = self._scan_in(path, origin=tail_origin, budget=budget, direction=-1, box=box)
+
+        if head + tail < _MIN_TRIM_SECONDS:
+            return media
+        new_t0, new_t1 = t0 + head, t1 - tail
+        if new_t1 - new_t0 < _MIN_SPAN_SECONDS:
+            return media
+
+        cleaned = dict(media)
+        cleaned["clip_start"] = round(new_t0, 6)
+        cleaned["clip_end"] = round(new_t1, 6)
+        cleaned["duration"] = round(new_t1 - new_t0, 6)
+        return cleaned
+
+
+class VideoLetterboxCropCleaner(MediaCleaner):
+    """Crop away a video's letterbox bars and pillarbox margins.
+
+    A 4:3 broadcast re-published in a 16:9 container, a phone clip padded to
+    landscape, a slide capture framed in black: the bars are content-free, and
+    the embedder spends real capacity encoding "these edges are a black
+    rectangle" while the padding shrinks the subject inside its fixed input
+    window.  This gate samples a handful of frames across the unit, asks the
+    same detector the image gate uses
+    (:func:`~vtscore.media.image.edge_trim.solid_edge_box`) where the content
+    starts in each, and records the **union** of those content boxes as the
+    unit's ``clip_box``.
+
+    Taking the union rather than the intersection is what makes the crop safe
+    on moving pictures: a margin is removed only when *every* sampled frame
+    agrees it is blank, so a subject that drifts into the top of frame
+    mid-clip keeps its room.  A frame with content all the way to its edges
+    aborts the crop outright; a wholly blank frame (a fade, a black leader)
+    is skipped, since it says nothing about where the bars are.
+
+    Nothing is re-encoded - the box is honoured by the embedder's frame
+    sampler and by the thumbnailers, so a cropped unit's preview and its
+    embedding frame the same picture.
+
+    Parameters
+    ----------
+    samples:
+        How many frames to analyse across the unit.  Defaults to 5.
+    edge_tol:
+        How far from pure white or pure black a pixel may sit and still count
+        as bar.  Defaults to :data:`~vtscore.media.image.edge_trim.DEFAULT_EDGE_TOL`.
+    max_edge_trim:
+        Never crop more than this fraction off any single side.  Defaults to
+        :data:`~vtscore.media.image.edge_trim.DEFAULT_MAX_EDGE_TRIM`.
+    min_edge_trim:
+        Leave the unit uncropped when every margin is thinner than this
+        fraction.  Defaults to
+        :data:`~vtscore.media.image.edge_trim.DEFAULT_MIN_EDGE_TRIM`.
+    """
+
+    def __init__(
+        self,
+        samples: int = 5,
+        edge_tol: float = DEFAULT_EDGE_TOL,
+        max_edge_trim: float = DEFAULT_MAX_EDGE_TRIM,
+        min_edge_trim: float = DEFAULT_MIN_EDGE_TRIM,
+    ) -> None:
+        if samples < 1:
+            raise ValueError("samples must be at least 1")
+        self._samples = int(samples)
+        self._edge_tol = edge_tol
+        self._max_edge_trim = max_edge_trim
+        self._min_edge_trim = min_edge_trim
+
+    @property
+    def name(self) -> str:
+        return "video_letterbox_crop"
+
+    @property
+    def media_type(self) -> str:
+        return "video"
+
+    @property
+    def display_name(self) -> str:
+        return "Letterbox Crop"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Crop letterbox bars and pillarbox margins off each clip, using the tightest box every "
+            "sampled frame agrees is content, so the embedder sees the picture instead of its padding."
+        )
+
+    @property
+    def summary_template(self) -> str:
+        return "Crop bars agreed on by {samples} sampled frames, never more than {max_edge_trim} of a side."
+
+    @property
+    def samples(self) -> int:
+        return self._samples
+
+    @property
+    def edge_tol(self) -> float:
+        return self._edge_tol
+
+    @property
+    def max_edge_trim(self) -> float:
+        return self._max_edge_trim
+
+    @property
+    def min_edge_trim(self) -> float:
+        return self._min_edge_trim
+
+    @property
+    def parameters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "samples",
+                "label": "Frames sampled",
+                "description": (
+                    "How many frames across the clip to analyse. More frames make the crop safer on "
+                    "moving content and cost one decode each."
+                ),
+                "type": "number",
+                "default": self._samples,
+                "min": 1,
+                "max": 32,
+                "step": 1,
+            },
+            {
+                "key": "edge_tol",
+                "label": "Solid tolerance (0-255)",
+                "description": (
+                    "How far from pure white or pure black a pixel may sit and still count as bar. "
+                    "Higher values treat more of the border as padding."
+                ),
+                "type": "number",
+                "default": self._edge_tol,
+                "min": 0,
+                "max": 64,
+                "step": 1,
+            },
+            {
+                "key": "max_edge_trim",
+                "label": "Maximum crop per side",
+                "description": (
+                    "Never remove more than this fraction of the width or height from any single side, "
+                    "so a small subject in a large blank field can't blow up to fill the frame."
+                ),
+                "type": "number",
+                "default": self._max_edge_trim,
+                "min": 0,
+                "max": 0.5,
+                "step": 0.05,
+            },
+            {
+                "key": "min_edge_trim",
+                "label": "Minimum crop to bother",
+                "description": "Leave the clip uncropped when every margin is thinner than this fraction.",
+                "type": "number",
+                "default": self._min_edge_trim,
+                "min": 0,
+                "max": 0.5,
+                "step": 0.01,
+            },
+        ]
+
+    def with_params(self, params: dict[str, Any]) -> "VideoLetterboxCropCleaner":
+        return VideoLetterboxCropCleaner(
+            samples=int(float(params.get("samples", self._samples))),
+            edge_tol=float(params.get("edge_tol", self._edge_tol)),
+            max_edge_trim=float(params.get("max_edge_trim", self._max_edge_trim)),
+            min_edge_trim=float(params.get("min_edge_trim", self._min_edge_trim)),
+        )
+
+    def _sample_times(self, t0: float, t1: float, info: decode.VideoInfo) -> list[float]:
+        """Return the timestamps to analyse, spread across ``[t0, t1]``."""
+        last = max(t0, t1 - info.frame_seconds)
+        if self._samples == 1 or last <= t0:
+            return [t0]
+        return [float(t) for t in np.linspace(t0, last, self._samples)]
+
+    def _content_box(self, frame_rgb: np.ndarray) -> tuple[int, int, int, int] | None:
+        """Return one frame's content box, or ``None`` when it constrains nothing.
+
+        ``None`` covers both "content reaches the edges" (there is no bar to
+        crop, so the caller must abort) and "wholly blank frame" (a fade or
+        leader, which the caller skips); the caller tells them apart with
+        :func:`_blank_share`.
+        """
+        from PIL import Image  # noqa: PLC0415
+
+        return solid_edge_box(
+            Image.fromarray(frame_rgb),
+            edge_tol=self._edge_tol,
+            max_edge_trim=self._max_edge_trim,
+            min_edge_trim=self._min_edge_trim,
+        )
+
+    def clean(self, media: dict[str, Any]) -> dict[str, Any]:
+        """Return *media* carrying the bars' crop box, or unchanged.
+
+        Unchanged when the video can't be resolved, probed, or decoded, when
+        any sampled frame carries content to its edges, when every sampled
+        frame is blank, or when the agreed box crops less than
+        *min_edge_trim* off every side - the common case for content that was
+        never padded.
+        """
+        with resolve_video_path(media) as path:
+            if path is None:
+                return media
+            info = decode.probe(path)
+            if info is None or info.duration <= 0:
+                return media
+            t0, t1 = _unit_window(media, info)
+            prior = media.get("clip_box")
+            frames = decode.frames_at(path, self._sample_times(t0, t1, info))
+
+        if not frames:
+            return media
+
+        boxes: list[tuple[int, int, int, int]] = []
+        for frame in frames:
+            # Analyse the region this unit actually embeds, so an earlier crop
+            # composes with this one instead of being measured through.
+            region = crop_frame(frame, prior)
+            box = self._content_box(region)
+            if box is None:
+                if _blank_share(region, self._edge_tol) >= _BLANK_FRAME_SHARE:
+                    continue  # a fade or leader frame says nothing about the bars
+                return media  # content reaches the edges: nothing to crop
+            boxes.append(box)
+
+        if not boxes:
+            return media  # every sampled frame was blank
+
+        union = (
+            min(b[0] for b in boxes),
+            min(b[1] for b in boxes),
+            max(b[2] for b in boxes),
+            max(b[3] for b in boxes),
+        )
+        full_height, full_width = frames[0].shape[:2]
+        height, width = crop_frame(frames[0], prior).shape[:2]
+        if clamp_clip_box(union, width, height) is None:
+            return media  # the frames agree on the whole region; no bars
+        margins = (union[0] / width, union[1] / height, 1.0 - union[2] / width, 1.0 - union[3] / height)
+        if max(margins) < self._min_edge_trim:
+            return media  # negligible on every side once the frames are combined
+
+        # The box is stored in *source frame* coordinates, so an earlier crop's
+        # origin has to be added back onto the region-relative union.
+        base = clamp_clip_box(prior, full_width, full_height)
+        dx, dy = (base[0], base[1]) if base is not None else (0, 0)
+        cleaned = dict(media)
+        cleaned["clip_box"] = [union[0] + dx, union[1] + dy, union[2] + dx, union[3] + dy]
+        return cleaned

--- a/vtscore/media/video/crop.py
+++ b/vtscore/media/video/crop.py
@@ -1,0 +1,83 @@
+"""The per-unit ``clip_box``: which pixel region of a video frame is the content.
+
+Video units are **metadata-only**: every clip of a parent video shares the
+parent's bytes and carries a time window (``clip_start`` / ``clip_end``) saying
+which slice of it this unit is.  A crop is the spatial half of the same idea -
+``clip_box`` says which *pixel region* of each frame this unit is - and it is
+honoured, not baked in, for exactly the same reason: re-encoding a cropped copy
+of the file per unit would duplicate the payload and desync the time window
+that still indexes the parent's timeline.
+
+Three readers therefore have to agree about the box, so the parsing and the
+crop live here once:
+
+* :func:`~vtscore.media.video._frame_sampling.sample_video_frames` - what the
+  embedder actually sees.
+* :mod:`vtscore.media.video.media_type`'s thumbnailers - what the user sees in
+  the grid, so preview and embedding frame the same picture.
+* :class:`~vtscore.media.video.cleaner.VideoLetterboxCropCleaner` - the gate
+  that writes the box in the first place, and
+  :class:`~vtscore.media.video.cleaner.VideoBlankTrimCleaner`, which measures
+  blankness inside it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def parse_clip_box(raw: Any) -> tuple[int, int, int, int] | None:
+    """Parse a ``clip_box`` into a 4-int ``(x0, y0, x1, y1)`` tuple, or ``None``.
+
+    Accepts the native list/tuple carried on a media dict as well as the
+    ``"x0,y0,x1,y1"`` string form that rides in ``origin.params``.  Returns
+    ``None`` for anything malformed - a bad box must degrade to "no crop"
+    rather than raise in the middle of an embed.
+    """
+    if isinstance(raw, (list, tuple)):
+        parts: list[Any] = list(raw)
+    elif isinstance(raw, str):
+        parts = [p for p in raw.split(",") if p != ""]
+    else:
+        return None
+    if len(parts) != 4:
+        return None
+    try:
+        return (int(float(parts[0])), int(float(parts[1])), int(float(parts[2])), int(float(parts[3])))
+    except (TypeError, ValueError):
+        return None
+
+
+def clamp_clip_box(raw: Any, width: int, height: int) -> tuple[int, int, int, int] | None:
+    """Return *raw* as a usable box within a *width* x *height* frame, or ``None``.
+
+    ``None`` means "no crop applies": the box is missing or malformed, it is
+    degenerate once clamped to the frame, or it already covers the whole frame.
+    """
+    box = parse_clip_box(raw)
+    if box is None:
+        return None
+    x0, y0, x1, y1 = box
+    x0, y0 = max(0, min(x0, width)), max(0, min(y0, height))
+    x1, y1 = max(0, min(x1, width)), max(0, min(y1, height))
+    if x1 - x0 < 1 or y1 - y0 < 1:
+        return None
+    if (x0, y0, x1, y1) == (0, 0, width, height):
+        return None
+    return (x0, y0, x1, y1)
+
+
+def crop_frame(frame_rgb: np.ndarray, raw: Any) -> np.ndarray:
+    """Return *frame_rgb* cropped to *raw*, or the frame itself when no crop applies.
+
+    Safe to call unconditionally: a missing, malformed, degenerate, or
+    full-frame box leaves the frame untouched.
+    """
+    height, width = frame_rgb.shape[:2]
+    box = clamp_clip_box(raw, width, height)
+    if box is None:
+        return frame_rgb
+    x0, y0, x1, y1 = box
+    return frame_rgb[y0:y1, x0:x1]

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import io
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vtscore.media.base import (
     DemoDataset,
@@ -16,6 +16,7 @@ from vtscore.media.base import (
     demo_slice,
 )
 from vtscore.media.video import decode
+from vtscore.media.video.crop import crop_frame
 from vtscore.utils.hashing import content_md5
 
 if TYPE_CHECKING:
@@ -52,11 +53,14 @@ def _thumbnail_from_path(
     time_seconds: float | None,
     size: int,
     info: decode.VideoInfo | None = None,
+    crop_box: Any = None,
 ) -> bytes | None:
     """Grab one frame from *file_path* and return it as a PNG thumbnail.
 
     *info* lets a caller that already probed the container hand the result in
-    rather than paying for a second probe.
+    rather than paying for a second probe.  *crop_box* is a unit's ``clip_box``
+    (see :mod:`vtscore.media.video.crop`); passing it keeps a cropped unit's
+    preview framed like the frames its embedder sees.
     """
     if info is None:
         info = decode.probe(file_path)
@@ -65,10 +69,12 @@ def _thumbnail_from_path(
     frame = decode.frame_at(file_path, _seek_time(info, time_seconds))
     if frame is None:
         return None
-    return _encode_thumbnail(frame, size)
+    return _encode_thumbnail(crop_frame(frame, crop_box), size)
 
 
-def _thumbnail_from_bytes(video_bytes: bytes, time_seconds: float | None, size: int) -> bytes | None:
+def _thumbnail_from_bytes(
+    video_bytes: bytes, time_seconds: float | None, size: int, crop_box: Any = None
+) -> bytes | None:
     """Spill *video_bytes* to a temp file (decoders need a seekable path) and thumbnail it."""
     if not video_bytes:
         return None
@@ -76,38 +82,42 @@ def _thumbnail_from_bytes(video_bytes: bytes, time_seconds: float | None, size: 
     try:
         tmp.write(video_bytes)
         tmp.close()
-        return _thumbnail_from_path(Path(tmp.name), time_seconds, size)
+        return _thumbnail_from_path(Path(tmp.name), time_seconds, size, crop_box=crop_box)
     finally:
         import os  # noqa: PLC0415
 
         os.unlink(tmp.name)
 
 
-def generate_video_thumbnail(video_bytes: bytes, *, size: int = _THUMB_SIZE) -> bytes | None:
+def generate_video_thumbnail(video_bytes: bytes, *, size: int = _THUMB_SIZE, crop_box: Any = None) -> bytes | None:
     """Extract the middle frame of a video and return it as a PNG thumbnail.
 
     Decoding runs out-of-process through ffmpeg (see
     :mod:`vtscore.media.video.decode`) and PIL produces the PNG.  Returns
     ``None`` if the video cannot be decoded or has no frames.
     """
-    return _thumbnail_from_bytes(video_bytes, None, size)
+    return _thumbnail_from_bytes(video_bytes, None, size, crop_box)
 
 
-def generate_video_thumbnail_from_file(file_path: Path, *, size: int = _THUMB_SIZE) -> bytes | None:
+def generate_video_thumbnail_from_file(
+    file_path: Path, *, size: int = _THUMB_SIZE, crop_box: Any = None
+) -> bytes | None:
     """Extract the middle frame of a video file and return it as a PNG thumbnail."""
-    return _thumbnail_from_path(file_path, None, size)
+    return _thumbnail_from_path(file_path, None, size, crop_box=crop_box)
 
 
-def generate_video_thumbnail_at(video_bytes: bytes, time_seconds: float, *, size: int = _THUMB_SIZE) -> bytes | None:
+def generate_video_thumbnail_at(
+    video_bytes: bytes, time_seconds: float, *, size: int = _THUMB_SIZE, crop_box: Any = None
+) -> bytes | None:
     """Extract a frame at *time_seconds* from *video_bytes* and return it as a PNG thumbnail."""
-    return _thumbnail_from_bytes(video_bytes, time_seconds, size)
+    return _thumbnail_from_bytes(video_bytes, time_seconds, size, crop_box)
 
 
 def generate_video_thumbnail_from_file_at(
-    file_path: Path, time_seconds: float, *, size: int = _THUMB_SIZE
+    file_path: Path, time_seconds: float, *, size: int = _THUMB_SIZE, crop_box: Any = None
 ) -> bytes | None:
     """Extract a frame at *time_seconds* from a video file and return it as a PNG thumbnail."""
-    return _thumbnail_from_path(file_path, time_seconds, size)
+    return _thumbnail_from_path(file_path, time_seconds, size, crop_box=crop_box)
 
 
 _VIDEO_MIME_TYPES: dict[str, str] = {
@@ -759,6 +769,10 @@ class VideoMediaType(MediaType):
         import) is indistinguishable from one computed by the loader.  The
         resolved payload is dropped as soon as the frame is grabbed, keeping a
         warm-up over multi-GB shards to one member at a time.
+
+        A unit carrying a ``clip_box`` (letterbox-cropped by a cleaner) is
+        framed to it, so a preview warmed here matches one the load stage
+        rendered.
         """
         thumb = media.get("thumbnail_bytes")
         if thumb:
@@ -766,7 +780,7 @@ class VideoMediaType(MediaType):
         raw = self._resolve_media_bytes(media)
         if not raw:
             return None
-        thumb = generate_video_thumbnail(raw)
+        thumb = generate_video_thumbnail(raw, crop_box=media.get("clip_box"))
         if thumb:
             media["thumbnail_bytes"] = thumb
         return thumb


### PR DESCRIPTION
## Summary

Ships the top two items from the `docs/plans/media-cleaners.md` roster: `VideoLetterboxCropCleaner` and `VideoBlankTrimCleaner`.

- Both are **metadata-only** by construction: a video unit shares its parent's bytes (every tile of a tiled video points at the same file), so re-encoding a cleaned copy per unit would duplicate the payload and desync the time window that still indexes the parent's timeline. `VideoLetterboxCropCleaner` instead records a `clip_box` — the union of what every sampled frame agrees is content, so a subject that drifts into a bar mid-clip keeps its room — and `VideoBlankTrimCleaner` narrows `clip_start`/`clip_end` past a blank head/tail (black leader, fade-ins, empty tail cards), leaving mid-clip cuts-to-black alone.
- `sample_video_frames` and the video thumbnailers now honor `clip_box`, so the embedder and the grid preview frame the same picture. The crop detector is shared with `ImageEdgeTrimCleaner` (`vtscore/media/image/edge_trim.py`) rather than duplicated.
- The chain runner (`clipper_chain.py`) now treats a change to `clip_start`/`clip_end`/`clip_box` as a real change — flagging MD5/embedding/thumbnail recomputation and recording the new window/box on the trail entry — **without** snapshotting an `original_*` payload, since there's no second payload to keep. Two consequences: a cleaned video costs no extra storage, and a reference (thin) import keeps its byte savings on it.
- `docs/EXTENDING-media.md` and `docs/ARCHITECTURE.md` gain a "cleaning by metadata instead of payload" section documenting the pattern for future metadata-only cleaners.
- `docs/plans/media-cleaners.md` is pruned of the shipped items and records three findings surfaced by this work as open items: the document blank-page cleaner is blocked on a pre-convert `stage` property, a cropped video's `clip_box` isn't reflected in the `<video>` player (only the trim half is, via the existing loop window), and labeled-example replay ignores a video unit's window/box entirely (pre-existing, widened by these gates).

## Test plan

- [x] `tests_lib/detectors/test_cleaner_roster.py` — new `TestVideoLetterboxCropCleaner` / `TestVideoBlankTrimCleaner` classes, including real ffmpeg-encoded end-to-end cases
- [x] `tests_lib/detectors/test_media_cleaners.py` — new `TestMetadataOnlyClean` class covering the runner's metadata-change path (recompute flag, no snapshot, stale-thumbnail drop, trail contents, provenance, lazy-clip compatibility)
- [x] `tests_lib/detectors/test_video_frame_sampler.py` — `TestClipBoxCrop` covering crop honoring and malformed-box handling
- [x] `tests/api/test_cleaner_routes.py` — `GET /api/cleaners?media_type=video` lists both gates in run order
- [x] `./run-tests.sh` (full suite, including ruff/codespell/deptry/pyright/frontend build): **7136 passed**, 1 skipped, 1 xfailed, 1 xpassed

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCM1ByTfd2tQsGx82JEBAz)_