### PR TITLE
Type dataset items by content, not just filename extension

### DIFF
--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -623,6 +623,16 @@ Stats window can show everything the grid does while it covers the grid up.
 
 `expires_at` is `null` when the dataset never ages off.
 
+`file_type_counts` keys are file types, not necessarily filename extensions:
+each item is typed by its filename extension when it has one, and otherwise by
+the format sniffed from its bytes, so a service importer that names items after
+an opaque content id still reports `{"jpg": 437}` instead of one useless bucket.
+Items that no signal could type land in a parenthesised `"(unknown)"` key (the
+parenthesis is what tells a sentinel from a real extension). When the stored
+histogram is uninformative — every item unknown — and the dataset happens to be
+loaded, the endpoint recounts it from the in-memory medias and writes the repair
+back to the registry.
+
 404 if the dataset does not exist.
 
 ### Dataset duplicates

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1565,6 +1565,7 @@
             "additionalProperties": {
               "type": "integer"
             },
+            "description": "File type \u2192 item count. The type is the item's filename extension, or the format sniffed from its bytes when it has none (a service importer may name items after an opaque content id). Items no signal could type land in a parenthesised \"(unknown)\" bucket.",
             "type": "object"
           },
           "ingest_finished_at": {

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.html
@@ -105,14 +105,14 @@
       <table class="data-table stats-table">
         <thead>
           <tr>
-            <th title="File extension of media items">Extension</th>
-            <th title="Number of items with this file extension">Count</th>
+            <th title="File extension of each media item, or the format detected from its contents when it has no extension">Type</th>
+            <th title="Number of items of this file type">Count</th>
           </tr>
         </thead>
         <tbody>
           @for (ft of fileTypes; track ft.ext) {
             <tr>
-              <td>.{{ ft.ext }}</td>
+              <td>{{ ft.label }}</td>
               <td>{{ ft.count | number }}</td>
             </tr>
           }

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
@@ -149,6 +149,19 @@ describe('DatasetStatsModalComponent', () => {
     expect(text).not.toContain('Never');
   });
 
+  it('dots real file types but passes the unknown sentinel through verbatim', async () => {
+    await fixture.whenStable();
+    httpMock
+      .expectOne('/api/datasets/registry/ds1/stats')
+      .flush({ ...mockStats, file_type_counts: { jpg: 400, '(unknown)': 37 } });
+    await settleZoneless(fixture);
+
+    expect(component.fileTypes.map((ft) => ft.label)).toEqual(['.jpg', '(unknown)']);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('.jpg');
+    expect(text).not.toContain('.(unknown)');
+  });
+
   it('repaints the error text on a failed load (zoneless canary)', async () => {
     await fixture.whenStable();
     httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.ts
@@ -56,12 +56,20 @@ export class DatasetStatsModalComponent implements OnInit {
     this.closed.emit();
   }
 
-  get fileTypes(): { ext: string; count: number }[] {
+  get fileTypes(): { ext: string; label: string; count: number }[] {
     const counts = this.stats()?.file_type_counts;
     if (!counts) return [];
     return Object.entries(counts)
       .sort(([, a], [, b]) => b - a)
-      .map(([ext, count]) => ({ ext, count }));
+      .map(([ext, count]) => ({ ext, label: this.fileTypeLabel(ext), count }));
+  }
+
+  /** Render a file-type bucket. Real types get the leading dot users expect
+   *  (`jpg` → `.jpg`); the server's parenthesised sentinel for items whose
+   *  type nothing could establish is passed through as-is, so the row reads
+   *  "(unknown)" and not ".(unknown)". */
+  private fileTypeLabel(ext: string): string {
+    return ext.startsWith('(') ? ext : `.${ext}`;
   }
 
   /** Media type as the grid renders it: capitalized, `-` when unset. */

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -2144,3 +2144,43 @@ class TestDatasetRegistryStats:
 
     def test_missing_dataset_is_404(self, client):
         assert client.get("/api/datasets/registry/nope/stats").status_code == 404
+
+    def _register_loaded(self, media_dict, **overrides):
+        """Register a dataset and publish *media_dict* as its loaded context."""
+        from vtsearch.state import DatasetContext, register_context
+
+        entry = self._register(num_items=len(media_dict), **overrides)
+        ctx = DatasetContext(entry["id"])
+        ctx.medias.update(media_dict)
+        register_context(ctx)
+        return entry["id"]
+
+    def test_uninformative_counts_are_recounted_from_the_loaded_dataset(self, client):
+        """An entry stamped by an importer whose items had no filename extension
+        carries one useless bucket; recount from the bytes when we can."""
+        jpeg = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01"
+        media_dict = {i: {"id": i, "filename": f"id{i}", "media_bytes": jpeg} for i in range(1, 4)}
+        dataset_id = self._register_loaded(media_dict, file_type_counts={"(no extension)": 3})
+
+        resp = client.get(f"/api/datasets/registry/{dataset_id}/stats")
+        assert resp.status_code == 200
+        assert resp.get_json()["file_type_counts"] == {"jpg": 3}
+
+        # The repair is written back, so it survives the dataset being unloaded.
+        from vtscore.datasets.registry import get_dataset
+
+        assert get_dataset(dataset_id)["file_type_counts"] == {"jpg": 3}
+
+    def test_real_counts_are_never_recounted(self, client):
+        media_dict = {1: {"id": 1, "filename": "only.flac"}}
+        dataset_id = self._register_loaded(media_dict, file_type_counts={"wav": 30, "mp3": 12})
+
+        resp = client.get(f"/api/datasets/registry/{dataset_id}/stats")
+        assert resp.get_json()["file_type_counts"] == {"wav": 30, "mp3": 12}
+
+    def test_unloaded_dataset_keeps_its_stamped_counts(self, client):
+        """Nothing to recount from when the dataset isn't in memory; the stored
+        histogram is returned as-is rather than blanked."""
+        entry = self._register(file_type_counts={"(no extension)": 437})
+        resp = client.get(f"/api/datasets/registry/{entry['id']}/stats")
+        assert resp.get_json()["file_type_counts"] == {"(no extension)": 437}

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -2169,7 +2169,9 @@ class TestDatasetRegistryStats:
         # The repair is written back, so it survives the dataset being unloaded.
         from vtscore.datasets.registry import get_dataset
 
-        assert get_dataset(dataset_id)["file_type_counts"] == {"jpg": 3}
+        stored = get_dataset(dataset_id)
+        assert stored is not None
+        assert stored["file_type_counts"] == {"jpg": 3}
 
     def test_real_counts_are_never_recounted(self, client):
         media_dict = {1: {"id": 1, "filename": "only.flac"}}

--- a/tests_lib/datasets/test_file_types.py
+++ b/tests_lib/datasets/test_file_types.py
@@ -1,0 +1,164 @@
+"""Tests for :mod:`vtscore.datasets.file_types`.
+
+The histogram the Stats window shows used to come from each item's
+``filename`` alone, so a service-style importer that names items after an
+opaque content id put every item in one useless bucket.  These tests pin the
+fallback chain (name → path → URL → magic numbers) that fixes that.
+"""
+
+from __future__ import annotations
+
+from vtscore.datasets.file_types import (
+    UNKNOWN_FILE_TYPE,
+    count_file_types,
+    counts_are_uninformative,
+    media_file_type,
+    sniff_file_type,
+)
+
+
+# Minimal but genuine headers for the formats an image/audio/video import hits.
+JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01"
+PNG = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+GIF = b"GIF89a\x10\x00\x10\x00"
+WEBP = b"RIFF\x24\x00\x00\x00WEBPVP8 "
+WAV = b"RIFF\x24\x00\x00\x00WAVEfmt "
+AVI = b"RIFF\x24\x00\x00\x00AVI LIST"
+MP4 = b"\x00\x00\x00\x20ftypisom\x00\x00\x02\x00"
+MOV = b"\x00\x00\x00\x14ftypqt  \x00\x00\x02\x00"
+HEIC = b"\x00\x00\x00\x18ftypheic\x00\x00\x00\x00"
+MKV = b"\x1a\x45\xdf\xa3\x01\x00\x00\x00\x00\x00\x00\x1f" + b"matroska" + b"\x00" * 8
+WEBM = b"\x1a\x45\xdf\xa3\x01\x00\x00\x00\x00\x00\x00\x1f" + b"webm" + b"\x00" * 8
+PDF = b"%PDF-1.7\n%\xc7\xec\x8f\xa2"
+MP3_TAGGED = b"ID3\x03\x00\x00\x00\x00\x00\x00"
+MP3_BARE = b"\xff\xfb\x90\x64\x00\x00\x00\x00"
+ZIP = b"PK\x03\x04\x14\x00\x00\x00\x08\x00"
+
+
+class TestSniffFileType:
+    """Magic-number recognition for the containers VTSearch ingests."""
+
+    def test_recognises_image_formats(self):
+        assert sniff_file_type(JPEG) == "jpg"
+        assert sniff_file_type(PNG) == "png"
+        assert sniff_file_type(GIF) == "gif"
+        assert sniff_file_type(WEBP) == "webp"
+        assert sniff_file_type(b"BM\x8a\x00\x00\x00\x00\x00") == "bmp"
+        assert sniff_file_type(b"II*\x00\x08\x00\x00\x00") == "tif"
+        assert sniff_file_type(HEIC) == "heic"
+
+    def test_recognises_audio_formats(self):
+        assert sniff_file_type(WAV) == "wav"
+        assert sniff_file_type(b"fLaC\x00\x00\x00\x22") == "flac"
+        assert sniff_file_type(b"OggS\x00\x02\x00\x00") == "ogg"
+        assert sniff_file_type(MP3_TAGGED) == "mp3"
+        assert sniff_file_type(MP3_BARE) == "mp3"
+
+    def test_recognises_video_formats(self):
+        assert sniff_file_type(MP4) == "mp4"
+        assert sniff_file_type(MOV) == "mov"
+        assert sniff_file_type(AVI) == "avi"
+        assert sniff_file_type(MKV) == "mkv"
+        # Matroska and WebM share a magic number; the DocType breaks the tie.
+        assert sniff_file_type(WEBM) == "webm"
+
+    def test_recognises_documents_and_archives(self):
+        assert sniff_file_type(PDF) == "pdf"
+        assert sniff_file_type(ZIP) == "zip"
+        assert sniff_file_type(b"\x1f\x8b\x08\x00\x00\x00\x00\x00") == "gz"
+
+    def test_unrecognised_and_truncated_data_yield_nothing(self):
+        assert sniff_file_type(b"hello, world, this is not a container") == ""
+        assert sniff_file_type(b"\xff\xd8") == ""
+        assert sniff_file_type(b"") == ""
+
+    def test_accepts_any_bytes_like_payload(self):
+        assert sniff_file_type(bytearray(PNG)) == "png"
+        assert sniff_file_type(memoryview(JPEG)) == "jpg"
+
+
+class TestMediaFileType:
+    """The fallback chain, in the order :func:`media_file_type` walks it."""
+
+    def test_filename_extension_wins(self):
+        assert media_file_type({"filename": "kitten.JPG", "media_bytes": PNG}) == "jpg"
+
+    def test_only_the_final_path_segment_counts(self):
+        assert media_file_type({"filename": "run.v2/audio"}) == UNKNOWN_FILE_TYPE
+        assert media_file_type({"filename": "run.v2/audio.wav"}) == "wav"
+        assert media_file_type({"filename": r"C:\clips\take.wav"}) == "wav"
+
+    def test_dotted_ids_and_dates_are_not_extensions(self):
+        # A trailing dotted chunk that no filesystem would call an extension
+        # must not become its own one-item bucket in the histogram.
+        assert media_file_type({"filename": "photo.2024-06-01-final"}) == UNKNOWN_FILE_TYPE
+        assert media_file_type({"filename": "id.9f3ca77e1b4d"}) == UNKNOWN_FILE_TYPE
+        assert media_file_type({"filename": "clip.12345"}) == UNKNOWN_FILE_TYPE
+
+    def test_falls_back_to_origin_name_then_path(self):
+        assert media_file_type({"filename": "a7f3c9e2", "origin_name": "kitten.png"}) == "png"
+        assert media_file_type({"filename": "a7f3c9e2", "media_path": "/data/kitten.gif"}) == "gif"
+
+    def test_falls_back_to_url_ignoring_query_and_fragment(self):
+        media = {"filename": "a7f3c9e2", "media_url": "https://host/media/kitten.webp?token=abc#x"}
+        assert media_file_type(media) == "webp"
+
+    def test_falls_back_to_sniffing_the_bytes(self):
+        # The reported shape: a service importer names items after a content
+        # id and the URL carries no extension either, so only the bytes know.
+        media = {
+            "filename": "a7f3c9e2",
+            "origin_name": "a7f3c9e2",
+            "media_url": "https://host/api/v1/media/a7f3c9e2",
+            "media_bytes": JPEG,
+        }
+        assert media_file_type(media) == "jpg"
+
+    def test_inline_text_with_no_file_counts_as_txt(self):
+        assert media_file_type({"filename": "row_5", "media_string": "some text"}) == "txt"
+        assert media_file_type({"filename": "row_6", "media_string": ""}) == "txt"
+
+    def test_unknowable_media_lands_in_the_sentinel_bucket(self):
+        assert media_file_type({}) == UNKNOWN_FILE_TYPE
+        assert media_file_type({"filename": "a7f3c9e2", "media_bytes": b"not a container"}) == UNKNOWN_FILE_TYPE
+
+    def test_sentinel_is_distinguishable_from_a_real_extension(self):
+        # The frontend keys off the leading paren to skip its leading dot.
+        assert UNKNOWN_FILE_TYPE.startswith("(")
+
+
+class TestCountFileTypes:
+    def test_tallies_most_common_first(self):
+        medias = [
+            {"filename": "a.wav"},
+            {"filename": "b.mp3"},
+            {"filename": "c.wav"},
+            {"filename": "d.wav"},
+        ]
+        assert count_file_types(medias) == {"wav": 3, "mp3": 1}
+        assert list(count_file_types(medias)) == ["wav", "mp3"]
+
+    def test_extensionless_image_import_reports_the_real_format(self):
+        # Regression: 437 sniffable images used to collapse into one bucket.
+        medias = [{"filename": f"id{i}", "media_bytes": JPEG} for i in range(437)]
+        assert count_file_types(medias) == {"jpg": 437}
+
+    def test_mixes_named_and_sniffed_items(self):
+        medias = [
+            {"filename": "a.png"},
+            {"filename": "b", "media_bytes": PNG},
+            {"filename": "c", "media_bytes": b"???"},
+        ]
+        assert count_file_types(medias) == {"png": 2, UNKNOWN_FILE_TYPE: 1}
+
+
+class TestCountsAreUninformative:
+    def test_empty_and_all_unknown_counts_are_uninformative(self):
+        assert counts_are_uninformative({})
+        assert counts_are_uninformative({UNKNOWN_FILE_TYPE: 437})
+        # The bucket name entries stamped before this module existed used.
+        assert counts_are_uninformative({"(no extension)": 437})
+
+    def test_any_real_type_makes_counts_informative(self):
+        assert not counts_are_uninformative({"jpg": 1})
+        assert not counts_are_uninformative({"jpg": 400, UNKNOWN_FILE_TYPE: 37})

--- a/vtscore/datasets/file_types.py
+++ b/vtscore/datasets/file_types.py
@@ -1,0 +1,179 @@
+"""Best-effort file-type labelling for media dicts.
+
+The dataset registry stamps a ``file_type_counts`` histogram at ingest so the
+Stats window can show what a dataset is made of.  Deriving that histogram from
+each item's ``filename`` alone works for folder-shaped imports but collapses
+for service-style importers, which name items after an opaque content id
+(``"a7f3c9e2"``) rather than a file on disk: every item lands in one useless
+``(unknown)`` bucket, and the Stats window reports nothing.
+
+:func:`media_file_type` therefore walks a chain of increasingly indirect
+signals — the filename, the origin name, the backing path, the backing URL and
+finally the media bytes' magic numbers — returning the first that yields a
+plausible type.  Nothing here does I/O: only bytes that are *already* in the
+media dict are sniffed, so counting a large dataset stays cheap and never
+reaches out to the network or the filesystem.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Iterable, Mapping
+
+__all__ = ["UNKNOWN_FILE_TYPE", "count_file_types", "media_file_type", "sniff_file_type"]
+
+#: Bucket for items whose type no signal could establish.  Parenthesised so
+#: the frontend can tell a sentinel from a real extension and skip the leading
+#: dot it renders for ``jpg`` / ``wav`` / ….
+UNKNOWN_FILE_TYPE = "(unknown)"
+
+#: Longest run of characters after the final dot still treated as an
+#: extension.  Keeps ``photo.2024-06-01-final`` and ``id.9f3ca77e1b`` out of
+#: the histogram as bogus one-item "extensions".
+_MAX_EXT_LEN = 5
+
+
+def _ext_from_name(name: str) -> str:
+    """Return the lowercase extension of *name*, or ``""`` when it has none.
+
+    Only the final path segment is considered (so ``v1.2/audio`` has no
+    extension), and the candidate must look like a real extension: short, and
+    alphanumeric ASCII with at least one letter.
+    """
+    if not name:
+        return ""
+    base = name.replace("\\", "/").rsplit("/", 1)[-1]
+    if "." not in base:
+        return ""
+    ext = base.rsplit(".", 1)[-1].lower()
+    if not ext or len(ext) > _MAX_EXT_LEN:
+        return ""
+    if not (ext.isascii() and ext.isalnum()) or ext.isdigit():
+        return ""
+    return ext
+
+
+def _ext_from_url(url: str) -> str:
+    """Return the extension of *url*'s path, ignoring its query and fragment."""
+    if not url:
+        return ""
+    path = url.split("#", 1)[0].split("?", 1)[0]
+    return _ext_from_name(path)
+
+
+def _ftyp_file_type(brand: bytes) -> str:
+    """Map an ISO-BMFF ``ftyp`` major brand to a conventional extension."""
+    b = brand.lower()
+    if b == b"qt  ":
+        return "mov"
+    if b.startswith(b"m4a"):
+        return "m4a"
+    if b.startswith(b"m4v"):
+        return "m4v"
+    if b in (b"heic", b"heix", b"hevc", b"hevx", b"mif1", b"msf1"):
+        return "heic"
+    if b in (b"avif", b"avis"):
+        return "avif"
+    return "mp4"
+
+
+def sniff_file_type(data: bytes) -> str:  # noqa: C901,PLR0911,PLR0912
+    """Return a conventional extension for *data*'s format, or ``""``.
+
+    Recognises the container formats VTSearch actually ingests (images, audio,
+    video, PDFs and the archive types importers unpack) from their leading
+    magic numbers.  The returned label is the format's usual extension, not
+    the item's real filename: a JPEG named ``a7f3c9e2`` counts as ``jpg``.
+    """
+    head = bytes(data[:64])
+    if len(head) < 4:
+        return ""
+    if head[:3] == b"\xff\xd8\xff":
+        return "jpg"
+    if head[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if head[:6] in (b"GIF87a", b"GIF89a"):
+        return "gif"
+    if head[:4] in (b"II*\x00", b"MM\x00*"):
+        return "tif"
+    if head[:4] == b"%PDF":
+        return "pdf"
+    if head[:4] == b"fLaC":
+        return "flac"
+    if head[:4] == b"OggS":
+        return "ogg"
+    if head[:4] == b"RIFF":
+        # RIFF is a family: the type lives in the fourcc after the size field.
+        return {b"WEBP": "webp", b"WAVE": "wav", b"AVI ": "avi"}.get(head[8:12], "")
+    if head[:4] == b"FORM" and head[8:12] in (b"AIFF", b"AIFC"):
+        return "aiff"
+    if head[:4] == b"\x1a\x45\xdf\xa3":
+        # Matroska and WebM share the EBML magic; the DocType string sits in
+        # the EBML header, well inside the bytes we already read.
+        return "webm" if b"webm" in head else "mkv"
+    if head[4:8] == b"ftyp":
+        return _ftyp_file_type(head[8:12])
+    if head[:3] == b"FLV":
+        return "flv"
+    if head[:3] == b"ID3":
+        return "mp3"
+    if head[:2] == b"\x1f\x8b":
+        return "gz"
+    if head[:4] == b"7z\xbc\xaf":
+        return "7z"
+    if head[:4] == b"Rar!":
+        return "rar"
+    if head[:2] == b"PK":
+        # Also covers the zip-backed office formats; without reading the
+        # central directory we can only honestly say "zip".
+        return "zip"
+    if head[:2] == b"BM":
+        return "bmp"
+    if head[0] == 0xFF and (head[1] & 0xE0) == 0xE0:
+        # MPEG audio frame sync, for MP3s with no ID3 tag.  Checked last
+        # because it is the loosest test here.
+        return "mp3"
+    return ""
+
+
+def media_file_type(media: Mapping[str, Any]) -> str:
+    """Return a file-type label for one media dict.
+
+    Tries the item's name-shaped fields first (they carry what the user would
+    call the file), then its backing location, then the magic numbers of any
+    bytes already in memory.  Inline text with no file behind it counts as
+    ``txt``; anything left over lands in :data:`UNKNOWN_FILE_TYPE`.
+    """
+    for key in ("filename", "origin_name", "media_path"):
+        ext = _ext_from_name(str(media.get(key) or ""))
+        if ext:
+            return ext
+    ext = _ext_from_url(str(media.get("media_url") or ""))
+    if ext:
+        return ext
+    data = media.get("media_bytes")
+    if data:
+        sniffed = sniff_file_type(data)
+        if sniffed:
+            return sniffed
+    if media.get("media_string") is not None:
+        return "txt"
+    return UNKNOWN_FILE_TYPE
+
+
+def count_file_types(medias: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    """Tally :func:`media_file_type` over *medias*, most common first."""
+    counter: Counter[str] = Counter()
+    for media in medias:
+        counter[media_file_type(media)] += 1
+    return dict(counter.most_common())
+
+
+def counts_are_uninformative(counts: Mapping[str, int]) -> bool:
+    """True when *counts* tells the user nothing about a dataset's contents.
+
+    Either empty, or every item sits in an unknown bucket — including the
+    ``"(no extension)"`` bucket that entries stamped before
+    :func:`media_file_type` existed use.
+    """
+    return not counts or all(key.startswith("(") for key in counts)

--- a/vtscore/datasets/file_types.py
+++ b/vtscore/datasets/file_types.py
@@ -77,7 +77,7 @@ def _ftyp_file_type(brand: bytes) -> str:
     return "mp4"
 
 
-def sniff_file_type(data: bytes) -> str:  # noqa: C901,PLR0911,PLR0912
+def sniff_file_type(data: bytes | bytearray | memoryview) -> str:  # noqa: C901,PLR0911,PLR0912
     """Return a conventional extension for *data*'s format, or ``""``.
 
     Recognises the container formats VTSearch actually ingests (images, audio,

--- a/vtscore/datasets/stages/registry.py
+++ b/vtscore/datasets/stages/registry.py
@@ -80,17 +80,11 @@ def _auto_register_dataset(
         if isinstance(m.get("origin"), dict) and m["origin"].get("importer") == "dupe_set"
     )
 
-    # Count file types by extension
-    from collections import Counter
+    # Count file types (filename extension, or the format sniffed from the
+    # bytes when the importer names items after an opaque content id)
+    from vtscore.datasets.file_types import count_file_types
 
-    ext_counter: Counter[str] = Counter()
-    for m in media_dict.values():
-        fn = m.get("filename", "")
-        if fn and "." in fn:
-            ext_counter[fn.rsplit(".", 1)[-1].lower()] += 1
-        else:
-            ext_counter["(no extension)"] += 1
-    file_type_counts = dict(ext_counter.most_common())
+    file_type_counts = count_file_types(media_dict.values())
 
     ds_dir = get_saved_datasets_dir()
     ds_dir.mkdir(parents=True, exist_ok=True)

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -625,6 +625,32 @@ def update_dataset_readers(body: dict, dataset_id: str):
     return {"ok": True, "readers": readers}
 
 
+def _repaired_file_type_counts(dataset_id: str, stored: dict) -> dict:
+    """Return usable file-type counts for *dataset_id*, recounting if needed.
+
+    An entry stamped by an older build — or by an importer whose items had no
+    filename extension to go on — carries a histogram with everything in one
+    unknown bucket, which tells the user nothing.  When the dataset happens to
+    be loaded we can do better: recount from the in-memory medias, where
+    :func:`~vtscore.datasets.file_types.media_file_type` can sniff the actual
+    bytes.  A recount that improves on the stored counts is written back, so
+    the repair sticks for later opens (and for when the dataset is unloaded).
+    """
+    from vtscore.datasets.file_types import count_file_types, counts_are_uninformative
+    from vtsearch.state import get_context
+
+    if not counts_are_uninformative(stored):
+        return stored
+    ctx = get_context(dataset_id)
+    if ctx is None:
+        return stored
+    recounted = count_file_types(ctx.medias.values())
+    if counts_are_uninformative(recounted):
+        return stored
+    _reg_update(dataset_id, file_type_counts=recounted)
+    return recounted
+
+
 @datasets_registry_bp.route("/api/datasets/registry/<dataset_id>/stats")
 @datasets_registry_bp.response(200, DatasetRegistryStatsResponseSchema)
 @datasets_registry_bp.alt_response(404, description="Dataset not found.")
@@ -656,7 +682,7 @@ def get_dataset_stats(dataset_id: str):
         "created_by": entry.get("created_by", ""),
         "readers": entry.get("readers") or [],
         "num_dupes": entry.get("num_dupes", 0),
-        "file_type_counts": entry.get("file_type_counts", {}),
+        "file_type_counts": _repaired_file_type_counts(dataset_id, entry.get("file_type_counts") or {}),
         "ingest_started_at": entry.get("ingest_started_at"),
         "ingest_finished_at": entry.get("ingest_finished_at"),
         "origin": entry.get("origin", ""),

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -20,7 +20,6 @@ import gc
 import threading
 import time
 import traceback
-from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
 from uuid import uuid4
@@ -32,6 +31,7 @@ import vtscore.security.path_validation as _paths
 from vtscore.concurrency.progress import CancelledError, loading_tasks
 from vtscore.config import EMBEDDINGS_DIR
 from vtscore.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers
+from vtscore.datasets.file_types import count_file_types
 from vtscore.datasets.load_pipeline import (
     STAGING_DIR,
     _run_importer_in_background,
@@ -419,14 +419,6 @@ def promote_to_dataset(body: dict):
     clipper = (src_entry or {}).get("clipper", "") if src_entry else ""
     expires_at = (src_entry or {}).get("expires_at") if src_entry else None
 
-    ext_counter: Counter[str] = Counter()
-    for m in subset.values():
-        fn = m.get("filename", "")
-        if fn and "." in fn:
-            ext_counter[fn.rsplit(".", 1)[-1].lower()] += 1
-        else:
-            ext_counter["(no extension)"] += 1
-
     source = {
         "importer": "promote",
         "params": {
@@ -442,7 +434,7 @@ def promote_to_dataset(body: dict):
         clipper=clipper,
         expires_at=expires_at,
         source=source,
-        file_type_counts=dict(ext_counter.most_common()),
+        file_type_counts=count_file_types(subset.values()),
         created_by=get_current_user(),
     )
     return {"ok": True, "message": "Promoting to dataset...", "task_id": task_id}

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -888,7 +888,19 @@ class DatasetRegistryStatsResponseSchema(Schema):
     media_type = fields.String(required=True)
     num_items = fields.Integer(required=True)
     num_dupes = fields.Integer(required=True)
-    file_type_counts = fields.Dict(keys=fields.String(), values=fields.Integer(), required=True)
+    file_type_counts = fields.Dict(
+        keys=fields.String(),
+        values=fields.Integer(),
+        required=True,
+        metadata={
+            "description": (
+                "File type → item count. The type is the item's filename extension, or the format "
+                "sniffed from its bytes when it has none (a service importer may name items after an "
+                "opaque content id). Items no signal could type land in a parenthesised "
+                '"(unknown)" bucket.'
+            )
+        },
+    )
     created_at = fields.Raw(allow_none=True)
     expires_at = fields.Raw(allow_none=True)
     created_by = fields.String(required=True)


### PR DESCRIPTION
## The bug

The Stats window's **File Types** table derived each item's type from its `filename` alone:

```python
if fn and "." in fn:
    ext_counter[fn.rsplit(".", 1)[-1].lower()] += 1
else:
    ext_counter["(no extension)"] += 1
```

That works for folder-shaped imports, where `filename` is a real path. It falls apart for service-style importers, which name items after an opaque content id (`a7f3c9e2`) rather than a file on disk — every item lands in one bucket, and an image import of 437 files reports nothing about what it holds. The frontend then rendered the bucket name through its unconditional leading dot, producing the literal `.(no extension)  437`.

## The fix

New `vtscore/datasets/file_types.py` walks a chain of increasingly indirect signals and returns the first that yields a plausible type:

1. `filename` extension — only the final path segment, and only when the candidate looks like a real extension (short, alphanumeric ASCII, not all digits), so `photo.2024-06-01-final` and `id.9f3ca77e1b` don't become their own one-item "extensions".
2. `origin_name`, then `media_path`.
3. `media_url`, ignoring query string and fragment.
4. Magic numbers of bytes already in the media dict — images (JPEG/PNG/GIF/WebP/BMP/TIFF/HEIC/AVIF), audio (WAV/MP3/FLAC/Ogg/AIFF), video (MP4/MOV/AVI/MKV/WebM/FLV), PDFs, and the archive formats importers unpack.
5. Inline text with no file behind it counts as `txt`; anything left lands in `(unknown)`.

Nothing here does I/O — only in-memory bytes are sniffed, so counting a large dataset stays cheap and never touches the network or filesystem. So an extensionless image import now reports `.jpg 437`.

Both places that stamp the histogram (the registry stage and the promote endpoint) count through the new module.

## Repairing datasets that are already imported

The histogram is stamped at ingest, so a fix to the ingest path alone would leave existing datasets showing the useless bucket forever. `GET /api/datasets/registry/<id>/stats` now recounts from the in-memory medias when the stored histogram is uninformative (empty, or everything in a parenthesised bucket — including the old `(no extension)` name) **and** the dataset happens to be loaded, and writes the repair back to the registry so it sticks after unload. A histogram with any real type in it is never recounted; an unloaded dataset keeps its stored counts rather than being blanked.

## Frontend

The File Types table's column becomes **Type** (it's no longer strictly an extension), and the leading dot is applied per row: `jpg` → `.jpg`, while the parenthesised sentinel passes through as `(unknown)` instead of `.(unknown)`.

## Backwards compatibility

The unknown bucket is renamed `(no extension)` → `(unknown)` (the label is now about what nothing could establish, not about a missing extension). Registry entries stamped with the old name still render correctly and are eligible for repair-on-read.

## Tests

- `tests_lib/datasets/test_file_types.py` — magic-number recognition per media family, the full fallback chain, the dotted-id/date rejections, and the 437-extensionless-images regression.
- `tests/datasets/test_datasets.py` — the stats endpoint's repair-on-read: recount + write-back when loaded, no recount when the counts are real, stored counts preserved when unloaded.
- `dataset-stats-modal.component.spec.ts` — dots real types, passes the sentinel through verbatim.

`./run-tests.sh` green: 7158 passed, 1 skipped, 2 xpassed. Frontend gate green (build + audit + 1865 Vitest tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_016EqSWFzdRpEvoJw25QPXwb)_