### PR TITLE
Default metadata panel to hidden

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -417,7 +417,7 @@ and auto-saved on every change. Schema:
   "calibration_fraction": 0.5,
   "audio_playing": true,
   "show_animations": "show",
-  "show_metadata": true,
+  "show_metadata": false,
   "focus_mode_left": {},
   "focus_mode_right": {},
   "grid_icon_size_left": {},

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -21,7 +21,7 @@ GET /api/settings
   "calibration_fraction": 0.5,
   "audio_playing": true,
   "show_animations": "show",
-  "show_metadata": true,
+  "show_metadata": false,
   "focus_mode_left": {},
   "focus_mode_right": {},
   "grid_icon_size_left": {},

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -539,7 +539,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  popup when the detail-canvas size actually changed. */
   private lastPreviewOverride: number | null = null;
   /** Per-media-type memory of whether the metadata column is shown, mirrored
-   *  from the ``popup_metadata_shown`` setting. Absent entries default to shown
+   *  from the ``popup_metadata_shown`` setting. Absent entries default to hidden
    *  (mirroring the Train/Find center panel's metadata default). */
   private metadataShownDict: Record<string, boolean> = {};
   /** Last applied column visibility, so the settings effect only re-clamps the
@@ -581,12 +581,13 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   }
 
   /** Whether the user has the metadata column shown for the active media type.
-   *  Absent entries default to shown, mirroring the center panel's metadata
-   *  tray, which is expanded by default. */
+   *  Absent entries default to hidden, mirroring the center panel's metadata
+   *  tray, which is collapsed by default so users judge the item itself
+   *  rather than its notes. */
   get metadataShown(): boolean {
     const mediaType = this.mediaType();
     const value = mediaType ? this.metadataShownDict[mediaType] : undefined;
-    return value !== false;
+    return value === true;
   }
 
   /** Whether the metadata column actually renders: the metadata feature is

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -221,8 +221,9 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     // Text is a non-thumbnailed type: no magnified preview pane on the canvas or
     // in the popup. (Audio now tiles as waveform thumbnails, so it is no longer
     // this branch.) The metadata panel is media-agnostic, though, so the Info
-    // button and the (default-shown) metadata column must still be offered, so
+    // button and the metadata column (once shown) must still be offered, so
     // hovering a bin member surfaces its metadata just like it does for images.
+    settings.set({ popup_metadata_shown: { text: true } });
     const fixture = makeFixture();
     fixture.componentRef.setInput('mediaType', 'text');
     fixture.componentRef.setInput('memberIds', [1, 2]);
@@ -531,6 +532,7 @@ describe('BrowseBinPopupComponent (docked presentation)', () => {
   });
 
   it('fills the large item with whatever width the metadata column leaves', async () => {
+    settings.set({ popup_metadata_shown: { image: true } });
     const fixture = makeDockedFixture([1, 2, 3]);
     await settlePasses(fixture);
 
@@ -560,6 +562,7 @@ describe('BrowseBinPopupComponent (docked presentation)', () => {
   });
 
   it('re-apportions the row as the metadata divider drags, and persists the width', async () => {
+    settings.set({ popup_metadata_shown: { image: true } });
     const fixture = makeDockedFixture([1, 2, 3]);
     await settlePasses(fixture);
 

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -65,7 +65,7 @@ export class CenterPanelComponent implements OnDestroy {
   readonly volume = signal(1);
   readonly audioPlaying = signal(true);
   readonly showAnimations = signal(true);
-  readonly showMetadata = signal(true);
+  readonly showMetadata = signal(false);
   readonly swipeClass = signal('');
   readonly spinningVote = signal<'good' | 'bad' | null>(null);
 
@@ -113,7 +113,7 @@ export class CenterPanelComponent implements OnDestroy {
       this.volume.set(settings.volume ?? 1);
       this.audioPlaying.set(settings.audio_playing !== false);
       this.showAnimations.set(settings.show_animations !== 'hide');
-      this.showMetadata.set(settings.show_metadata !== false);
+      this.showMetadata.set(settings.show_metadata === true);
       this.labelHintDismissed.set(settings.label_hint_dismissed === true);
     });
 

--- a/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
@@ -213,6 +213,7 @@ describe('CenterPanelComponent', () => {
 
   it('should display metadata', () => {
     fixture.componentRef.setInput('media', mockMedia);
+    component.showMetadata.set(true);
     TestBed.tick();
     const text = fixture.nativeElement.textContent;
     expect(text).toContain('test.wav');

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -192,7 +192,7 @@ class TestSettingsModule:
         assert raw["show_metadata"] is False
 
     def test_show_metadata_default(self):
-        assert settings_mod.get_show_metadata() is True
+        assert settings_mod.get_show_metadata() is False
 
     def test_show_metadata_persists_across_reset(self, isolated_settings):
         settings_mod.set_show_metadata(False)
@@ -455,7 +455,7 @@ class TestSettingsModule:
         assert defaults["calibrate_count"] == 2
         assert defaults["calibration_fraction"] == 0.5
         assert defaults["safe_thresholds"] is False
-        assert defaults["show_metadata"] is True
+        assert defaults["show_metadata"] is False
         assert isinstance(defaults["grid_icon_size_left"], dict)
         for v in defaults["grid_icon_size_left"].values():
             assert v == "M"

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -352,7 +352,7 @@ class UserSettings(BaseModel):
     # platform ``prefers-reduced-motion`` preference. See the "Show Animations"
     # pulldown in the appearance settings.
     show_animations: Annotated[AnimationMode, BeforeValidator(coerce_animation_mode)] = "show"
-    show_metadata: bool = True
+    show_metadata: bool = False
     # Set to True once the user dismisses the zero-votes "Use ← / → or click"
     # hint that overlays the Good/Bad buttons when a fresh labeling session
     # has no votes yet. Persisting it keeps the hint from re-appearing every


### PR DESCRIPTION
## Summary
- Users should vote based on the media item itself, not the metadata/notes attached to it, so the metadata tray (center panel) and metadata column (Browse bin popup) now default to **hidden** for new users instead of expanded.
- Changed `show_metadata` default from `True` to `False` in `vtsearch/settings_models.py`, and updated the frontend (`center-panel.component.ts`, `browse-bin-popup.component.ts`) to match — absent settings now resolve to hidden rather than shown.
- Existing users who already have `show_metadata` persisted keep their explicit preference; this only changes the default for settings that have never been set.
- Updated tests and docs (`docs/api/settings.md`, `docs/DEPLOYMENT.md`, `tests/core/test_settings.py`, frontend specs) that asserted the old default.

## Test plan
- [x] `./run-tests.sh` — full suite (7135 passed)
- [x] `cd frontend && npm run test:ci` (targeted specs) — 78 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_019CnmTVTh4C3E7HvqkbZEsE)_