### PR TITLE
Autopilot: hand the user back to the Dashboard on completion

### DIFF
--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -1,29 +1,58 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
 import { AutopilotPanelComponent } from './autopilot-panel.component';
 import { AutopilotStateService } from '../../../services/autopilot-state.service';
+import { ToastService } from '../../../services/toast.service';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
 import { settleZoneless } from '../../../testing/settle-resource';
+
+/** Green-across-the-board status payload: drives the phase machine to 'done'. */
+const ALL_GREEN = {
+  good_count: 0,
+  bad_count: 0,
+  total_count: 0,
+  smart: { status: 'green' },
+  stable: { status: 'green' },
+  span: { status: 'green' },
+};
 
 describe('AutopilotPanelComponent', () => {
   let component: AutopilotPanelComponent;
   let fixture: ComponentFixture<AutopilotPanelComponent>;
   let autopilotState: AutopilotStateService;
+  let toasts: ToastService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AutopilotPanelComponent],
-      providers: [...provideZoneless()],
+      providers: [...provideZoneless(), provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AutopilotPanelComponent);
     component = fixture.componentInstance;
     autopilotState = TestBed.inject(AutopilotStateService);
+    toasts = TestBed.inject(ToastService);
     await settleZoneless(fixture);
   });
 
   afterEach(() => {
     autopilotState.clear();
+    toasts.dismissAll();
+    vi.useRealTimers();
   });
+
+  /**
+   * Drive the phase machine to 'done' (every indicator green, votes past the
+   * initial targets) — the state that fires the completion toast. Uses
+   * `TestBed.tick()` rather than `settleZoneless` so it also works under
+   * `vi.useFakeTimers()`, where a real `setTimeout` would never resolve.
+   */
+  function reachDone(): void {
+    fixture.componentRef.setInput('goodVotes', new Set([1, 2, 3, 4, 5]));
+    fixture.componentRef.setInput('badVotes', new Set([11, 12, 13, 14, 15]));
+    fixture.componentRef.setInput('labelingStatus', ALL_GREEN);
+    TestBed.tick();
+  }
 
   it('should create', () => {
     expect(component).toBeTruthy();
@@ -311,6 +340,90 @@ describe('AutopilotPanelComponent', () => {
     expect(note.textContent).toContain('Nothing left to label');
     // The five-step list is replaced by the terminal note.
     expect(fixture.nativeElement.querySelectorAll('.ap-step').length).toBe(0);
+  });
+
+  describe('completion hand-off', () => {
+    it('announces where the user is being taken, with a countdown and an escape', () => {
+      vi.useFakeTimers();
+      reachDone();
+      expect(component.state.phase).toBe('done');
+
+      const [t] = toasts.toasts;
+      expect(t.message).toContain('Done!');
+      expect(t.countdown).toBeTruthy();
+      expect(t.countdown!.label).toContain('Dashboard');
+      expect(t.countdown!.remaining).toBe(5);
+      expect(t.action!.label).toBe('Stay here');
+    });
+
+    it('ticks the countdown down each second', async () => {
+      vi.useFakeTimers();
+      reachDone();
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(toasts.toasts[0].countdown!.remaining).toBe(3);
+    });
+
+    it('navigates to the Dashboard when the countdown runs out', async () => {
+      vi.useFakeTimers();
+      const router = TestBed.inject(Router);
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      reachDone();
+
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(navigate).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(navigate).toHaveBeenCalledWith(['/dashboard']);
+      // The toast is gone by the time the view changes.
+      expect(toasts.toasts.length).toBe(0);
+    });
+
+    it('stays in the Train window when the escape button is used', async () => {
+      vi.useFakeTimers();
+      const router = TestBed.inject(Router);
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      reachDone();
+
+      // What the toast's action button does: run the handler, drop the toast.
+      const t = toasts.toasts[0];
+      t.action!.onClick();
+      toasts.dismiss(t.id);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('cancels the pending return when the panel is torn down', async () => {
+      vi.useFakeTimers();
+      const router = TestBed.inject(Router);
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      reachDone();
+      expect(toasts.toasts.length).toBe(1);
+
+      // Leaving the Train window (tab switch / view change) destroys the panel.
+      fixture.destroy();
+      expect(toasts.toasts.length).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('counts down from the exhausted state too', async () => {
+      vi.useFakeTimers();
+      const router = TestBed.inject(Router);
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      fixture.componentRef.setInput('datasetSize', 1);
+      fixture.componentRef.setInput('goodVotes', new Set([1]));
+      TestBed.tick();
+      expect(component.state.phase).toBe('exhausted');
+      expect(toasts.toasts[0].message).toContain('Done!');
+      expect(toasts.toasts[0].countdown!.remaining).toBe(5);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(navigate).toHaveBeenCalledWith(['/dashboard']);
+    });
   });
 
   it('does not exhaust while the dataset size is unknown (datasetSize 0)', async () => {

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -112,10 +112,7 @@ export class AutopilotPanelComponent implements OnInit, OnDestroy {
       const phase = this.autopilotState.state.phase;
       if (prevPhase !== phase && !this.completionAlerted) {
         if (phase === 'done') {
-          this.announceCompletion(
-            'Done! Your detector is trained.',
-            'All quality indicators are green.',
-          );
+          this.announceCompletion('Done! Your detector is trained.');
         } else if (phase === 'exhausted') {
           this.announceCompletion(
             'Done! Nothing left to label.',
@@ -204,7 +201,7 @@ export class AutopilotPanelComponent implements OnInit, OnDestroy {
    * a "Stay here" button for the user who wants to keep labeling instead.
    * Dismissing the toast by any means cancels the return.
    */
-  private announceCompletion(message: string, detail: string): void {
+  private announceCompletion(message: string, detail?: string): void {
     this.completionAlerted = true;
     this.completionToastId = this.toastService.success({
       message,

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -1,4 +1,14 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, OnInit, output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  input,
+  OnDestroy,
+  OnInit,
+  output,
+} from '@angular/core';
+import { Router } from '@angular/router';
 
 import type { LabelingStatusResponse } from '../../../generated/api-client/models/labeling-status-response';
 import {
@@ -30,6 +40,13 @@ export interface StepDisplay {
   intent: string;
 }
 
+/**
+ * Seconds the completion toast counts down before returning the user to the
+ * Dashboard. Long enough to read the headline and reach the "Stay here"
+ * button, short enough that a user who is done doesn't sit waiting.
+ */
+const RETURN_COUNTDOWN_SECONDS = 5;
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-autopilot-panel',
@@ -38,9 +55,10 @@ export interface StepDisplay {
   templateUrl: './autopilot-panel.component.html',
   styleUrl: './autopilot-panel.component.scss',
 })
-export class AutopilotPanelComponent implements OnInit {
+export class AutopilotPanelComponent implements OnInit, OnDestroy {
   autopilotState = inject(AutopilotStateService);
   private toastService = inject(ToastService);
+  private router = inject(Router);
 
   readonly goodVotes = input<Set<number>>(new Set());
   readonly badVotes = input<Set<number>>(new Set());
@@ -68,6 +86,9 @@ export class AutopilotPanelComponent implements OnInit {
   readonly refocus = output<void>();
 
   private completionAlerted = false;
+  /** Id of the live completion toast, or ``null`` when none is showing. Kept
+   *  so leaving the Train window cancels the pending auto-return. */
+  private completionToastId: number | null = null;
 
   constructor() {
     // Signal inputs don't fire ``ngOnChanges``; this effect replaces the old
@@ -91,17 +112,15 @@ export class AutopilotPanelComponent implements OnInit {
       const phase = this.autopilotState.state.phase;
       if (prevPhase !== phase && !this.completionAlerted) {
         if (phase === 'done') {
-          this.completionAlerted = true;
-          this.toastService.success({
-            message: 'Autopilot complete',
-            detail: 'All quality indicators are green. You can continue labeling or export your results.',
-          });
+          this.announceCompletion(
+            'Done! Your detector is trained.',
+            'All quality indicators are green.',
+          );
         } else if (phase === 'exhausted') {
-          this.completionAlerted = true;
-          this.toastService.success({
-            message: 'Nothing left to label',
-            detail: 'Autopilot has labeled every item in this dataset. Review your votes or export your results.',
-          });
+          this.announceCompletion(
+            'Done! Nothing left to label.',
+            'Autopilot has labeled every item in this dataset.',
+          );
         }
       }
     });
@@ -170,9 +189,58 @@ export class AutopilotPanelComponent implements OnInit {
     this.activate();
   }
 
+  ngOnDestroy(): void {
+    // Leaving the Train window (tab switch, autopilot stopped, view change)
+    // calls off any pending auto-return: dismissing the toast cancels its
+    // countdown without running the navigation.
+    this.cancelCompletionToast();
+  }
+
+  /**
+   * Announce a terminal autopilot phase and start the auto-return countdown.
+   *
+   * A bare "Done!" leaves the user parked in the Train window with no next
+   * step, so the toast says where they are being taken and when — and carries
+   * a "Stay here" button for the user who wants to keep labeling instead.
+   * Dismissing the toast by any means cancels the return.
+   */
+  private announceCompletion(message: string, detail: string): void {
+    this.completionAlerted = true;
+    this.completionToastId = this.toastService.success({
+      message,
+      detail,
+      countdown: {
+        label: 'Taking you back to the Dashboard in',
+        seconds: RETURN_COUNTDOWN_SECONDS,
+        onExpire: () => this.returnToDashboard(),
+      },
+      action: {
+        label: 'Stay here',
+        title: 'Stay in the Train window and keep labeling',
+        onClick: () => {
+          this.completionToastId = null;
+        },
+      },
+    });
+  }
+
+  private returnToDashboard(): void {
+    // Cleared first so the ``ngOnDestroy`` that the navigation triggers does
+    // not try to dismiss an already-dismissed toast.
+    this.completionToastId = null;
+    void this.router.navigate(['/dashboard']);
+  }
+
+  private cancelCompletionToast(): void {
+    if (this.completionToastId === null) return;
+    this.toastService.dismiss(this.completionToastId);
+    this.completionToastId = null;
+  }
+
   activate(): void {
     if (this.running) return;
     this.completionAlerted = false;
+    this.cancelCompletionToast();
     // Retrain mode: the detector already has good+bad labels (carried over
     // from a previous dataset), so learned sort is available immediately and
     // autopilot should skip the initial text-mode phase.
@@ -189,6 +257,8 @@ export class AutopilotPanelComponent implements OnInit {
   }
 
   deactivate(): void {
+    // Turning autopilot off is itself a "stay here" — drop any pending return.
+    this.cancelCompletionToast();
     this.autopilotState.deactivate();
     this.stopped.emit();
   }

--- a/frontend/src/app/components/toast-container/toast-container.component.html
+++ b/frontend/src/app/components/toast-container/toast-container.component.html
@@ -32,6 +32,13 @@
           @if (t.detail) {
             <div class="toast__detail">{{ t.detail }}</div>
           }
+          @if (t.countdown; as cd) {
+            <!-- aria-live="off" so the per-second tick isn't re-announced by a
+                 screen reader; the toast's role="alert" already read the line once. -->
+            <div class="toast__countdown" aria-live="off">
+              {{ cd.label }} <span class="toast__countdown-seconds">{{ cd.remaining }}</span>&hellip;
+            </div>
+          }
         </div>
         <div class="toast__actions">
           @if (t.action) {

--- a/frontend/src/app/components/toast-container/toast-container.component.scss
+++ b/frontend/src/app/components/toast-container/toast-container.component.scss
@@ -101,6 +101,20 @@
   word-wrap: break-word;
 }
 
+// Live "this is about to happen" line, e.g. "Taking you back to the Dashboard
+// in 3…". Ticks once a second, so the seconds sit in a tabular-numeral span to
+// stop the trailing ellipsis jittering as the digit changes.
+.toast__countdown {
+  margin-top: var(--space-2xs);
+  color: var(--text-primary);
+  font-size: var(--font-xs);
+}
+
+.toast__countdown-seconds {
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--weight-semibold);
+}
+
 .toast__actions {
   flex: 0 0 auto;
   display: flex;

--- a/frontend/src/app/components/toast-container/toast-container.component.spec.ts
+++ b/frontend/src/app/components/toast-container/toast-container.component.spec.ts
@@ -73,4 +73,70 @@ describe('ToastContainerComponent', () => {
     await settleZoneless(fixture);
     expect(fixture.nativeElement.querySelectorAll('.toast').length).toBe(0);
   });
+
+  describe('countdown toasts', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('renders the remaining seconds and repaints each tick', async () => {
+      vi.useFakeTimers();
+      toast.success({
+        message: 'Done!',
+        countdown: { label: 'Taking you back to the Dashboard in', seconds: 5, onExpire: () => {} },
+      });
+      TestBed.tick();
+
+      const line = () => fixture.nativeElement.querySelector('.toast__countdown');
+      expect(line().textContent).toContain('Taking you back to the Dashboard in');
+      expect(line().textContent).toContain('5');
+
+      await vi.advanceTimersByTimeAsync(1000);
+      TestBed.tick();
+      expect(line().textContent).toContain('4');
+    });
+
+    it('runs the expiry handler once the countdown empties, then drops the toast', async () => {
+      vi.useFakeTimers();
+      const onExpire = vi.fn();
+      toast.success({ message: 'Done!', countdown: { label: 'Leaving in', seconds: 2, onExpire } });
+      TestBed.tick();
+
+      await vi.advanceTimersByTimeAsync(2000);
+      TestBed.tick();
+      expect(onExpire).toHaveBeenCalledTimes(1);
+      expect(fixture.nativeElement.querySelector('.toast')).toBeNull();
+    });
+
+    it('cancels the expiry handler when the toast is dismissed first', async () => {
+      vi.useFakeTimers();
+      const onExpire = vi.fn();
+      const id = toast.success({
+        message: 'Done!',
+        countdown: { label: 'Leaving in', seconds: 3, onExpire },
+      });
+      TestBed.tick();
+
+      toast.dismiss(id);
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(onExpire).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-dismiss a countdown toast out from under its own timer', async () => {
+      vi.useFakeTimers();
+      const onExpire = vi.fn();
+      // Plain success toasts auto-dismiss at 5s; a 10s countdown must outlive
+      // that, or the user watches the message vanish mid-count.
+      toast.success({ message: 'Done!', countdown: { label: 'Leaving in', seconds: 10, onExpire } });
+      TestBed.tick();
+
+      await vi.advanceTimersByTimeAsync(6000);
+      TestBed.tick();
+      expect(fixture.nativeElement.querySelector('.toast')).toBeTruthy();
+      expect(onExpire).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(onExpire).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/frontend/src/app/services/toast.service.ts
+++ b/frontend/src/app/services/toast.service.ts
@@ -37,6 +37,27 @@ export interface ToastAction {
   onClick: () => void;
 }
 
+/**
+ * A visible "this is about to happen" timer on a toast. The toast renders
+ * ``<label> <remaining>…`` and ticks once a second; on reaching zero it
+ * dismisses itself and runs ``onExpire``.
+ *
+ * Dismissing the toast first — via its action button, its close button, or
+ * ``dismiss``/``dismissAll`` — cancels the countdown, and ``onExpire`` never
+ * runs. That is what makes the countdown escapable: every way of getting rid
+ * of the toast is also a way of calling off the pending action.
+ */
+export interface ToastCountdown {
+  /** Lead-in text, e.g. ``'Taking you back to the Dashboard in'``. */
+  label: string;
+  /** Seconds left. Ticks down to zero. */
+  remaining: number;
+  /** Seconds the countdown started from (for progress rendering). */
+  total: number;
+  /** Ran once when the countdown reaches zero. */
+  onExpire: () => void;
+}
+
 export interface Toast {
   id: number;
   level: ToastLevel;
@@ -46,6 +67,8 @@ export interface Toast {
   errorContext?: ErrorContext;
   /** Optional follow-up action button (see :class:`ToastAction`). */
   action?: ToastAction;
+  /** Optional escapable countdown (see :class:`ToastCountdown`). */
+  countdown?: ToastCountdown;
   /**
    * Optional dedup key. Pushing a new toast with the same key replaces
    * the existing one (resetting its auto-dismiss timer). Used to avoid
@@ -60,6 +83,12 @@ interface ShowOptions {
   detail?: string;
   errorContext?: ErrorContext;
   action?: ToastAction;
+  /**
+   * Attach an escapable countdown. Supplying this suppresses the plain
+   * auto-dismiss timer — the countdown owns the toast's lifetime instead, so
+   * the seconds the user sees are the seconds they actually have.
+   */
+  countdown?: { label: string; seconds: number; onExpire: () => void };
   dedupKey?: string;
 }
 
@@ -87,6 +116,7 @@ export class ToastService {
   readonly toasts$ = this.toastsSubject.asObservable();
   private readonly seenTaskKeys = new Set<string>();
   private readonly autoDismissTimers = new Map<number, ReturnType<typeof setTimeout>>();
+  private readonly countdownTimers = new Map<number, ReturnType<typeof setInterval>>();
 
   constructor() {
     const progressEvents = inject(ProgressEventsService);
@@ -123,10 +153,11 @@ export class ToastService {
    * through a modal for "X is done" style messages.
    */
   success(opts: ShowOptions): number {
-    return this.push('success', opts, SUCCESS_AUTO_DISMISS_MS);
+    return this.push('success', opts, opts.countdown ? 0 : SUCCESS_AUTO_DISMISS_MS);
   }
 
   private push(level: ToastLevel, opts: ShowOptions, autoDismissMs = 0): number {
+    const cd = opts.countdown;
     const toast: Toast = {
       id: this.nextId++,
       level,
@@ -134,6 +165,9 @@ export class ToastService {
       detail: opts.detail,
       errorContext: opts.errorContext,
       action: opts.action,
+      countdown: cd
+        ? { label: cd.label, remaining: cd.seconds, total: cd.seconds, onExpire: cd.onExpire }
+        : undefined,
       dedupKey: opts.dedupKey,
       timestamp: new Date().toISOString(),
     };
@@ -160,6 +194,12 @@ export class ToastService {
         setTimeout(() => this.dismiss(toast.id), autoDismissMs),
       );
     }
+    if (toast.countdown) {
+      this.countdownTimers.set(
+        toast.id,
+        setInterval(() => this.tickCountdown(toast.id), 1000),
+      );
+    }
     return toast.id;
   }
 
@@ -173,7 +213,37 @@ export class ToastService {
 
   dismissAll(): void {
     for (const id of this.autoDismissTimers.keys()) this.clearTimer(id);
+    for (const id of this.countdownTimers.keys()) this.clearTimer(id);
     this.toastsSubject.next([]);
+  }
+
+  /**
+   * Advance one countdown by a second. Emits a replacement toast object each
+   * tick so ``OnPush`` renderers repaint the remaining seconds. At zero the
+   * toast is dismissed *before* ``onExpire`` runs, so a handler that navigates
+   * away never leaves a stale countdown on screen.
+   */
+  private tickCountdown(id: number): void {
+    const list = this.toastsSubject.value;
+    const idx = list.findIndex((t) => t.id === id);
+    const countdown = idx >= 0 ? list[idx].countdown : undefined;
+    if (!countdown) {
+      // Toast already gone (dismissed by the user, or evicted by MAX_TOASTS):
+      // the pending action is cancelled along with it.
+      this.clearTimer(id);
+      return;
+    }
+
+    const remaining = countdown.remaining - 1;
+    if (remaining > 0) {
+      const next = list.slice();
+      next[idx] = { ...list[idx], countdown: { ...countdown, remaining } };
+      this.toastsSubject.next(next);
+      return;
+    }
+
+    this.dismiss(id);
+    countdown.onExpire();
   }
 
   private clearTimer(id: number): void {
@@ -181,6 +251,11 @@ export class ToastService {
     if (t !== undefined) {
       clearTimeout(t);
       this.autoDismissTimers.delete(id);
+    }
+    const c = this.countdownTimers.get(id);
+    if (c !== undefined) {
+      clearInterval(c);
+      this.countdownTimers.delete(id);
     }
   }
 


### PR DESCRIPTION
## What changed

A finished Autopilot run used to pop a bare **"Autopilot complete"** toast and leave the user parked in the Train window with no next step. Completion now tells them where they're going and when, and counts down:

> **Done! Your detector is trained.**
> All quality indicators are green.
> *Taking you back to the Dashboard in 5…*  &nbsp; `[ Stay here ]`

The seconds tick down live (5 → 4 → 3 …); at zero the toast dismisses itself and the app navigates to `/dashboard`.

Both terminal phases hand off, each with its own headline:

| Phase | Headline | Detail |
|---|---|---|
| `done` | Done! Your detector is trained. | All quality indicators are green. |
| `exhausted` | Done! Nothing left to label. | Autopilot has labeled every item in this dataset. |

## The escape hatch

The point of the countdown is that it's escapable, so **every** way out of the toast cancels the pending navigation, not just the button:

- **"Stay here"** — the explicit affordance (`ToastAction`; clicking it dismisses the toast).
- The toast's **✕**, `dismiss()`, `dismissAll()`, and `MAX_TOASTS` eviction — all route through `clearTimer`, which now also kills the countdown interval.
- **Leaving the Train window** — the panel's `ngOnDestroy` (tab switch, view change) and `deactivate()` (autopilot stopped) both cancel it. Walking away is itself a "stay here", and a stale countdown can't follow the user into another view.

## Implementation

**`ToastService` gains an escapable countdown** (`ToastCountdown`). `push` starts a per-second interval that emits a replacement toast object each tick (so `OnPush` renderers repaint the digit) and, at zero, dismisses the toast *before* running `onExpire` — so a handler that navigates never leaves a countdown on screen. A countdown also suppresses the plain 5s success auto-dismiss; otherwise a longer count would vanish mid-tick.

**`ToastContainerComponent`** renders the countdown line under the detail, with the seconds in a tabular-numeral span so the trailing ellipsis doesn't jitter, and `aria-live="off"` so a screen reader isn't re-announced at every tick (the toast's `role="alert"` already read the line once).

**`AutopilotPanelComponent`** injects `Router`, tracks the live toast id, and routes both terminal phases through one `announceCompletion` helper.

## Tests

10 new specs; full suite green (`./run-tests.sh` → 7135 passed, frontend 1874 passed).

- **Panel** — the toast carries a countdown, a Dashboard label and a "Stay here" action; the count ticks; expiry navigates to `/dashboard`; the escape button and panel teardown each prevent navigation; `exhausted` counts down too.
- **Toast container** — the remaining seconds render and repaint each tick; expiry fires `onExpire` once and drops the toast; dismissing first cancels it; a 10s countdown outlives the 5s success auto-dismiss.

## Notes

- **Backwards compatibility:** the "Autopilot complete" / "Nothing left to label" toast copy is replaced. No API or persisted-state change.
- No screenshot reshoots queued — no manifest shot frames a toast, and the Autopilot phase panel's own rendering is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_018AJe1xtnRNgd2VdwUoXH3y)_