### PR TITLE
Calibrate production thresholds in inference geometry

### DIFF
--- a/docs/plans/max-patch-experiment.md
+++ b/docs/plans/max-patch-experiment.md
@@ -183,7 +183,6 @@ where the two diverge. Anything reasoning about scale must use `voted_area`.
   flooding).  The style path is the production-faithful one; the default path
   is left untouched for reproducibility of earlier studies.
 - The style path calibrates in **inference geometry** (each bag collapses over
-  `style.score_rows`), which production does *not* yet do — production still
-  compares a max-over-1 Good bag against a max-over-13 Bad bag (#2731).  So the
-  harness is now *more* faithful to what inference scores than the live vote
-  path is; when #2731 lands the two converge again.
+  `style.score_rows`), which the production vote / labelset paths now do too
+  (each bag collapses over its full `patch_regions` node stack), so the harness
+  and the live path agree on what a calibration bag scores.

--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -2145,11 +2145,17 @@ class TestBadVoteRegionFlooding:
         bad_media, _ = self._patch_media(2)
         clips = {1: good_media, 2: bad_media}
 
-        X, y, groups = _build_vote_xy(clips, {1: None}, {2: None}, {}, "dinov3_patch")
+        X, y, groups, score_rows = _build_vote_xy(clips, {1: None}, {2: None}, {}, "dinov3_patch")
         # 1 good row + 3 flooded bad rows.
         assert y == [1.0, 0.0, 0.0, 0.0]
         assert groups == [("g", 1), ("b", 2), ("b", 2), ("b", 2)]
         assert len(X) == 4
+        # Both bags carry the *scoring* stack (all 4 region nodes, internals
+        # included) so calibration collapses them the way inference does -
+        # not 1 row against 3.
+        assert set(score_rows) == {("g", 1), ("b", 2)}
+        assert score_rows[("g", 1)].shape == (4, 8)
+        assert score_rows[("b", 2)].shape == (4, 8)
 
     def test_per_bag_weights_balance_bag_not_rows(self):
         from vtscore.training.thresholds import _per_bag_fit_weights
@@ -2189,7 +2195,7 @@ class TestBadVoteRegionFlooding:
         leaves = [np.array([0, 0, 1, 0], dtype=np.float32), np.array([0, 0, 0, 1], dtype=np.float32)]
         det.label_negative_regions[bid] = leaves
 
-        X, y, groups = build_xy_from_labelset(det, LabelSet([good, bad]))
+        X, y, groups, _score_rows = build_xy_from_labelset(det, LabelSet([good, bad]))
         assert y == [1.0, 0.0, 0.0]
         assert groups == [("g", gid), ("b", bid), ("b", bid)]
         np.testing.assert_array_equal(X[1], leaves[0])

--- a/tests_lib/detectors/test_calibration_inference_geometry.py
+++ b/tests_lib/detectors/test_calibration_inference_geometry.py
@@ -1,0 +1,337 @@
+"""Production threshold calibration runs in inference geometry.
+
+Issue #2731: on a patch dataset ``_build_vote_xy`` gives a Good vote one row
+and a Bad vote its ~13 flooded leaves, and the calibrator collapses each bag
+with ``max``.  ``max`` is an upward-biased order statistic, so 13 draws beat 1
+with no signal at all - calibration understated what a positive scores relative
+to a negative, while :func:`_score_all_media` scores *every* image as a max over
+all ~24 region nodes.
+
+The fix hands each bag the row stack the scorer will pool
+(:func:`~vtscore.detectors.training.inference_score_rows`), so both classes are
+max-over-24 exactly as at inference.  These tests pin the wiring, the
+all-or-nothing coverage rule, the legacy no-op, and the cache-key invalidation.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from vtscore.detectors.training import (
+    _build_vote_xy,
+    _calibration_score_rows,
+    _flood_context,
+    _score_all_media,
+    inference_score_rows,
+)
+from vtscore.media.patch_embed import RegionVector
+
+
+DIM = 8
+
+
+def _unit(v):
+    v = np.asarray(v, dtype=np.float32)
+    return v / max(float(np.linalg.norm(v)), 1e-12)
+
+
+def _patch_media(cid: int, rng) -> dict[str, Any]:
+    """A media with a 4-node region tree: CLS + 2 leaves + 1 internal."""
+    cls = _unit(rng.standard_normal(DIM))
+    leaf1 = _unit(rng.standard_normal(DIM))
+    leaf2 = _unit(rng.standard_normal(DIM))
+    return {
+        "id": cid,
+        "md5": f"md5-{cid:04x}",
+        "media_type": "image",
+        "embedder": "dinov3_patch",
+        "embeddings": {"dinov3_patch": cls},
+        "patch_regions": [
+            RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=cls, children=None),
+            RegionVector(box=(0.0, 0.0, 0.5, 1.0), vec=leaf1, children=None),
+            RegionVector(box=(0.5, 0.0, 1.0, 1.0), vec=leaf2, children=None),
+            RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=_unit(leaf1 + leaf2), children=(1, 2)),
+        ],
+    }
+
+
+def _legacy_media(cid: int, rng) -> dict[str, Any]:
+    vec = _unit(rng.standard_normal(DIM))
+    return {
+        "id": cid,
+        "md5": f"md5-{cid:04x}",
+        "media_type": "image",
+        "embedder": "siglip",
+        "embeddings": {"siglip": vec},
+    }
+
+
+def _linear_scorer(direction):
+    linear = nn.Linear(DIM, 1)
+    with torch.no_grad():
+        linear.weight.copy_(torch.tensor(np.asarray(direction, dtype=np.float32)[None, :] * 10.0))
+        linear.bias.zero_()
+    model = nn.Sequential(linear)
+    model.eval()
+    return model
+
+
+# ---------------------------------------------------------------------------
+# inference_score_rows
+# ---------------------------------------------------------------------------
+
+
+class TestInferenceScoreRows:
+    def test_patch_media_yields_every_region_node(self):
+        media = _patch_media(1, np.random.default_rng(0))
+        rows = inference_score_rows(media, "dinov3_patch")
+        assert rows is not None
+        # All 4 nodes - internals included, unlike ``bad_negative_vecs``.
+        assert rows.shape == (4, DIM)
+        for i, node in enumerate(media["patch_regions"]):
+            np.testing.assert_allclose(rows[i], node.vec)
+
+    def test_matches_the_rows_score_all_media_pools(self):
+        """The stack must be exactly what the scorer max-pools, or calibration
+        is measuring a different geometry than inference."""
+        rng = np.random.default_rng(1)
+        clips = {1: _patch_media(1, rng), 2: _patch_media(2, rng)}
+        model = _linear_scorer(_unit(rng.standard_normal(DIM)))
+
+        _ids, scores, _best = _score_all_media(model, clips, "dinov3_patch")
+        for cid, scored in zip(sorted(clips), scores, strict=True):
+            rows = inference_score_rows(clips[cid], "dinov3_patch")
+            with torch.no_grad():
+                pooled = float(torch.sigmoid(model(torch.tensor(rows))).max())
+            assert abs(scored - pooled) < 1e-6
+
+    def test_region_less_media_yields_its_single_image_vector(self):
+        media = _legacy_media(1, np.random.default_rng(2))
+        rows = inference_score_rows(media, "siglip")
+        assert rows is not None
+        assert rows.shape == (1, DIM)
+        np.testing.assert_allclose(rows[0], media["embeddings"]["siglip"])
+
+    def test_none_when_the_media_has_no_vector_at_all(self):
+        assert inference_score_rows({"id": 1, "embeddings": {}}, "siglip") is None
+
+
+# ---------------------------------------------------------------------------
+# _build_vote_xy wiring
+# ---------------------------------------------------------------------------
+
+
+class TestBuildVoteXyScoreRows:
+    def test_both_classes_get_the_same_width_stack(self):
+        rng = np.random.default_rng(3)
+        clips = {1: _patch_media(1, rng), 2: _patch_media(2, rng)}
+        X, y, groups, score_rows = _build_vote_xy(clips, {1: None}, {2: None}, {}, "dinov3_patch")
+
+        # Training is still asymmetric - 1 Good row vs 3 flooded Bad rows...
+        assert y == [1.0, 0.0, 0.0, 0.0]
+        assert len(X) == 4
+        # ...but every bag is *scored* over its full 4-node tree.
+        assert set(score_rows) == {("g", 1), ("b", 2)}
+        assert score_rows[("g", 1)].shape == score_rows[("b", 2)].shape == (4, DIM)
+
+    def test_legacy_dataset_stacks_are_single_rows(self):
+        rng = np.random.default_rng(4)
+        clips = {1: _legacy_media(1, rng), 2: _legacy_media(2, rng)}
+        _X, _y, groups, score_rows = _build_vote_xy(clips, {1: None}, {2: None}, {}, "siglip")
+        assert groups == [("g", 1), ("b", 2)]
+        assert all(rows.shape == (1, DIM) for rows in score_rows.values())
+
+
+# ---------------------------------------------------------------------------
+# _calibration_score_rows - the gate
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationScoreRowsGate:
+    @staticmethod
+    def _flooded():
+        rng = np.random.default_rng(5)
+        clips = {1: _patch_media(1, rng), 2: _patch_media(2, rng)}
+        return _build_vote_xy(clips, {1: None}, {2: None}, {}, "dinov3_patch")
+
+    def test_covered_flooded_labels_produce_a_stack_per_bag(self):
+        X, y, groups, score_rows = self._flooded()
+        _n, cal_groups, _w = _flood_context(X, y, groups)
+        out = _calibration_score_rows(groups, cal_groups, score_rows)
+        assert out is not None
+        assert set(out) == {("g", 1), ("b", 2)}
+        assert all(isinstance(v, np.ndarray) and v.shape == (4, DIM) for v in out.values())
+
+    def test_unflooded_labels_are_a_no_op(self):
+        """Legacy datasets must reach the calibrator byte-identically."""
+        rng = np.random.default_rng(6)
+        clips = {1: _legacy_media(1, rng), 2: _legacy_media(2, rng)}
+        X, y, groups, score_rows = _build_vote_xy(clips, {1: None}, {2: None}, {}, "siglip")
+        _n, cal_groups, _w = _flood_context(X, y, groups)
+        assert cal_groups is None
+        assert _calibration_score_rows(groups, cal_groups, score_rows) is None
+
+    def test_partial_coverage_declines_rather_than_skewing(self):
+        """A missing Good stack would leave that bag at max-over-1 while the Bad
+        bags widened to max-over-4 - deeper than the bias being corrected."""
+        X, y, groups, score_rows = self._flooded()
+        _n, cal_groups, _w = _flood_context(X, y, groups)
+        score_rows.pop(("g", 1))
+        assert _calibration_score_rows(groups, cal_groups, score_rows) is None
+
+    def test_empty_score_rows_declines(self):
+        X, y, groups, _score_rows = self._flooded()
+        _n, cal_groups, _w = _flood_context(X, y, groups)
+        assert _calibration_score_rows(groups, cal_groups, {}) is None
+        assert _calibration_score_rows(groups, cal_groups, None) is None
+
+
+# ---------------------------------------------------------------------------
+# The bias this corrects
+# ---------------------------------------------------------------------------
+
+
+class TestGoodBagNoLongerUnderstated:
+    """With one model held fixed, widening a Good bag from its 1 training row to
+    its full scoring stack can only raise that bag's calibration score - which
+    is exactly the understatement the old geometry baked in."""
+
+    @staticmethod
+    def _bags(rng, n_good=3, n_bad=3, bad_rows=4):
+        X, y, groups, score_rows = [], [], [], {}
+        for g in range(n_good):
+            rows = np.stack([_unit(rng.normal(0, 1, DIM)) for _ in range(4)])
+            X.append(rows[0])  # the snapped node the Good vote trains on
+            y.append(1.0)
+            groups.append(("g", g))
+            score_rows[("g", g)] = rows
+        for b in range(n_bad):
+            rows = np.stack([_unit(rng.normal(0, 1, DIM)) for _ in range(bad_rows)])
+            for vec in rows[:bad_rows]:
+                X.append(vec)
+                y.append(0.0)
+                groups.append(("b", b))
+            score_rows[("b", b)] = rows
+        return X, y, groups, score_rows
+
+    def test_positive_calibration_scores_rise_to_inference_width(self, monkeypatch):
+        import vtscore.training.mlp as mlp_mod
+        from vtscore.training.thresholds import compute_fold_orderings
+
+        rng = np.random.default_rng(7)
+        model = _linear_scorer(_unit(rng.normal(0, 1, DIM)))
+        monkeypatch.setattr(mlp_mod, "train_model", lambda *a, **k: model)
+        X, y, groups, score_rows = self._bags(rng)
+
+        # A fresh RandomState per call - it is stateful, so sharing one instance
+        # would give the two calls different fold splits and prove nothing.
+        def _kwargs() -> dict[str, Any]:
+            return dict(rng=np.random.RandomState(42), calibrate_count=1, hidden_dim=8, groups=groups)
+
+        before, _ = compute_fold_orderings(X, y, DIM, **_kwargs())
+        after, _ = compute_fold_orderings(X, y, DIM, score_rows_by_group=score_rows, **_kwargs())
+
+        before_pos = [s for s, lbl in zip(*before[0], strict=True) if lbl == 1.0]
+        after_pos = [s for s, lbl in zip(*after[0], strict=True) if lbl == 1.0]
+        assert before_pos and after_pos
+        # Max over a superset can only be >=, and here it strictly rises.
+        assert all(a >= b - 1e-9 for a, b in zip(after_pos, before_pos, strict=True))
+        assert any(a > b + 1e-6 for a, b in zip(after_pos, before_pos, strict=True))
+
+    def test_bad_bags_gain_the_internal_nodes_they_never_flooded(self, monkeypatch):
+        """A Bad vote trains its leaves down but is *scored* over the internals
+        too; calibration now sees those rows."""
+        import vtscore.training.mlp as mlp_mod
+        from vtscore.training.thresholds import _pooled_group_scores
+
+        rng = np.random.default_rng(8)
+        model = _linear_scorer(_unit(rng.normal(0, 1, DIM)))
+        monkeypatch.setattr(mlp_mod, "train_model", lambda *a, **k: model)
+        X, y, groups, score_rows = self._bags(rng, n_good=1, n_bad=1, bad_rows=2)
+        # The Bad bag trained on 2 rows but is scored over 4.
+        rows_by_group = {("b", 0): [1, 2], ("g", 0): [0]}
+        X_np = np.stack(X)
+        trained = _pooled_group_scores(model, [("b", 0)], rows_by_group, X_np, None)
+        scored = _pooled_group_scores(model, [("b", 0)], rows_by_group, X_np, score_rows)
+        assert scored[0] >= trained[0] - 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Calibration cache
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationCacheKey:
+    @staticmethod
+    def _key(score_rows):
+        from vtscore.training.thresholds import _calibration_cache_key
+
+        rng = np.random.default_rng(9)
+        X = [_unit(rng.normal(0, 1, DIM)) for _ in range(4)]
+        y = [1.0, 1.0, 0.0, 0.0]
+        groups = [("g", 0), ("g", 1), ("b", 2), ("b", 3)]
+        return _calibration_cache_key(X, y, 2, 0.5, 8, groups, score_rows)
+
+    def test_score_rows_enter_the_key(self):
+        rng = np.random.default_rng(10)
+        rows_a = {("g", 0): np.stack([_unit(rng.normal(0, 1, DIM)) for _ in range(3)])}
+        rows_b = {("g", 0): np.stack([_unit(rng.normal(0, 1, DIM)) for _ in range(3)])}
+        assert self._key(None) != self._key(rows_a)
+        assert self._key(rows_a) != self._key(rows_b)
+        assert self._key(rows_a) == self._key(dict(rows_a))
+
+    def test_key_is_insertion_order_independent(self):
+        rng = np.random.default_rng(11)
+        a = np.stack([_unit(rng.normal(0, 1, DIM)) for _ in range(3)])
+        b = np.stack([_unit(rng.normal(0, 1, DIM)) for _ in range(3)])
+        assert self._key({("g", 0): a, ("b", 1): b}) == self._key({("b", 1): b, ("g", 0): a})
+
+    def test_cached_orderings_are_not_served_across_a_geometry_change(self):
+        from vtscore.state.core import DetectorContext
+        from vtscore.training.thresholds import cross_calibration_threshold_cached
+
+        rng = np.random.default_rng(12)
+        X = [_unit(rng.normal(0, 1, DIM)) for _ in range(4)]
+        X += [_unit(rng.normal(0, 1, DIM)) for _ in range(2)]
+        y = [1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
+        groups = [("g", 0), ("g", 1), ("b", 2), ("b", 2), ("b", 3), ("b", 3)]
+        score_rows = {g: np.stack([_unit(rng.normal(0, 1, DIM)) for _ in range(4)]) for g in set(groups)}
+
+        det = DetectorContext("d1")
+
+        def _call(rows):
+            return cross_calibration_threshold_cached(
+                X,
+                y,
+                DIM,
+                0,
+                calibrate_count=1,
+                calibration_fraction=0.5,
+                hidden_dim=8,
+                det_ctx=det,
+                groups=groups,
+                score_rows_by_group=rows,
+            )
+
+        _call(None)
+        cached = det.calibration_cache
+        assert cached is not None
+        key_without = cached[0]
+        _call(score_rows)
+        cached = det.calibration_cache
+        assert cached is not None
+        assert cached[0] != key_without
+
+
+@pytest.mark.parametrize("embedder", ["dinov3_patch", None])
+def test_score_rows_survive_a_missing_embedder_name(embedder):
+    """``_build_vote_xy`` resolves the embedder itself when handed ``None``; the
+    region stack is read off the tree either way."""
+    rng = np.random.default_rng(13)
+    clips = {1: _patch_media(1, rng), 2: _patch_media(2, rng)}
+    _X, _y, _groups, score_rows = _build_vote_xy(clips, {1: None}, {2: None}, {}, embedder)
+    assert set(score_rows) == {("g", 1), ("b", 2)}
+    assert all(rows.shape == (4, DIM) for rows in score_rows.values())

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -143,6 +143,24 @@ def _leaves_from_regions(regions) -> list[np.ndarray] | None:
     return leaves or None
 
 
+def _embedder_supports_patch_regions(embedder_name: str) -> bool:
+    """Whether *embedder_name* produces a ``patch_regions`` tree at all.
+
+    Gates the region-stack resolution below: on a legacy single-vector detector
+    there is no tree to rebuild, so probing every element's origin file would be
+    pure I/O for a guaranteed ``None``.
+    """
+    if not embedder_name:
+        return False
+    from vtscore.media import get_embedder
+
+    try:
+        embedder = get_embedder(embedder_name)
+    except (KeyError, ValueError):
+        return False
+    return bool(getattr(embedder, "supports_patch_regions", False))
+
+
 def _patch_pooled_from_file(
     file_path: Path,
     *,
@@ -238,8 +256,10 @@ def _maybe_clear_cache_on_embedder_switch(det_ctx, embedder_name: str) -> None:
     if det_ctx.embedder and embedder_name and det_ctx.embedder != embedder_name:
         det_ctx.label_embeddings.clear()
         det_ctx.label_embedding_regions.clear()
-        # Flooded leaf negatives live in the old embedder's space too.
+        # Flooded leaf negatives and the region scoring stacks live in the old
+        # embedder's space too.
         det_ctx.label_negative_regions.clear()
+        det_ctx.label_score_regions.clear()
         # Local features are descriptor sets in the old embedder's feature space;
         # a switch invalidates them too (a SIFT template can't verify against a
         # learned-feature candidate, nor vice versa).
@@ -291,22 +311,34 @@ def _resolve_uncached_embedding(
     return np.asarray(emb) if emb is not None else None
 
 
-def _resolve_negative_leaves(
+def _all_region_vecs(regions) -> list[np.ndarray] | None:
+    """Every node's vector from a ``patch_regions`` list - the scoring stack.
+
+    The rows :func:`vtscore.detectors.training._score_all_media` max-pools an
+    image over: CLS, HAC internals, and HAC leaves alike (a superset of the
+    leaf set a Bad vote floods).  Returns ``None`` for an empty/absent list.
+    """
+    if not regions:
+        return None
+    return [np.asarray(r.vec, dtype=np.float32) for r in regions]
+
+
+def _resolve_region_nodes(
     elem: LabeledElement,
     snap: dict[int, dict[str, Any]] | None,
     *,
     media_type: str,
     embedder_name: str,
     lookups: tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]] | None = None,
-) -> list[np.ndarray] | None:
-    """Leaf negatives (CLS + HAC leaves) for a Bad *elem* on a patch dataset.
+):
+    """The ``patch_regions`` tree behind *elem*, or ``None``.
 
-    In-dataset: read the resolved media's ``patch_regions`` leaves (no I/O).
-    Cross-dataset: rebuild the region tree from the origin file via
-    :func:`_region_tree_from_file` and take its leaves.  Returns ``None`` for
-    non-patch datasets/elements (and clipper-bearing origins, whose patch grid
-    we can't reconstruct) so the caller falls back to a single image-level
-    negative - i.e. no flooding, the pre-change behaviour.
+    In-dataset: read the resolved media's stored tree (no I/O).
+    Cross-dataset: rebuild it from the origin file via
+    :func:`_region_tree_from_file`.  Returns ``None`` for non-patch
+    datasets/elements (and clipper-bearing origins, whose patch grid we can't
+    reconstruct) so the callers fall back to their image-level behaviour - a
+    single negative for a Bad element, the training row as the scoring row.
 
     *lookups* is the pre-built ``build_media_lookup`` triple for *snap*; loop
     callers pass it so the cid resolution doesn't rebuild the tables per element.
@@ -317,7 +349,7 @@ def _resolve_negative_leaves(
     if snap:
         cid = resolve_current_dataset_cid(elem, lookups)
         if cid is not None and cid in snap:
-            return _leaves_from_regions(snap[cid].get("patch_regions"))
+            return snap[cid].get("patch_regions") or None
 
     origin = elem.origin or {}
     params = origin.get("params", {}) if isinstance(origin, dict) else {}
@@ -327,8 +359,47 @@ def _resolve_negative_leaves(
     with resolve_file_context(elem.origin, elem.origin_name, elem.filename) as file_path:
         if file_path is None:
             return None
-        regions = _region_tree_from_file(file_path, media_type=media_type, embedder_name=embedder_name)
-    return _leaves_from_regions(regions)
+        return _region_tree_from_file(file_path, media_type=media_type, embedder_name=embedder_name)
+
+
+def _cache_region_vectors(
+    elem: LabeledElement,
+    eid: str,
+    snap: dict[int, dict[str, Any]] | None,
+    *,
+    media_type: str,
+    embedder_name: str,
+    lookups: tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]] | None,
+    neg_cache: dict[str, list[np.ndarray]],
+    score_cache: dict[str, list[np.ndarray]],
+    patch_capable: bool,
+) -> None:
+    """Top up *elem*'s two region caches from a single tree resolution.
+
+    A patch element's ``patch_regions`` tree feeds both: the CLS + leaf
+    negatives a Bad element floods (the cross-dataset counterpart of
+    :func:`~vtscore.detectors.training.bad_negative_vecs`), and the full node
+    stack the *scorer* max-pools that image over - which threshold calibration
+    collapses every bag, Good and Bad alike, over.  Resolved once per element
+    and cached so re-sorts don't re-resolve.
+
+    The scoring stack is skipped entirely on a legacy single-vector detector
+    (*patch_capable* is ``False``, where the resolution would return ``None``
+    anyway), so no origin file is probed for a tree that cannot exist.
+    """
+    wants_negatives = elem.label == "bad" and eid not in neg_cache
+    wants_score_rows = patch_capable and elem.label in ("good", "bad") and eid not in score_cache
+    if not (wants_negatives or wants_score_rows):
+        return
+    regions = _resolve_region_nodes(elem, snap, media_type=media_type, embedder_name=embedder_name, lookups=lookups)
+    if wants_negatives:
+        leaves = _leaves_from_regions(regions)
+        if leaves is not None:
+            neg_cache[eid] = leaves
+    if wants_score_rows:
+        rows = _all_region_vecs(regions)
+        if rows is not None:
+            score_cache[eid] = rows
 
 
 def populate_label_embeddings(
@@ -364,6 +435,8 @@ def populate_label_embeddings(
     cached = 0
 
     neg_cache: dict[str, list[np.ndarray]] = det_ctx.label_negative_regions
+    score_cache: dict[str, list[np.ndarray]] = det_ctx.label_score_regions
+    patch_capable = _embedder_supports_patch_regions(embedder_name)
 
     # Build the origin/md5/name lookup tables once from *snap* and thread them
     # through every element's cid resolution, so the pass is O(N + labels)
@@ -372,17 +445,17 @@ def populate_label_embeddings(
 
     for idx, elem in enumerate(labelset.elements):
         eid = stable_element_id(elem)
-        # Bad elements on a patch dataset flood their CLS + leaf negatives (the
-        # cross-dataset counterpart of ``bad_negative_vecs``); cache the leaf
-        # set once so re-sorts don't re-resolve.  A no-op on non-patch datasets
-        # (``_resolve_negative_leaves`` returns None), leaving the Bad element
-        # to contribute its single image-level vector below.
-        if elem.label == "bad" and eid not in neg_cache:
-            leaves = _resolve_negative_leaves(
-                elem, snap, media_type=media_type, embedder_name=embedder_name, lookups=lookups
-            )
-            if leaves is not None:
-                neg_cache[eid] = leaves
+        _cache_region_vectors(
+            elem,
+            eid,
+            snap,
+            media_type=media_type,
+            embedder_name=embedder_name,
+            lookups=lookups,
+            neg_cache=neg_cache,
+            score_cache=score_cache,
+            patch_capable=patch_capable,
+        )
 
         # Cache hit only when the cached vector was built against the same
         # ``region_box`` the element currently carries.  Region-voted
@@ -422,8 +495,8 @@ def populate_label_embeddings(
 def build_xy_from_labelset(
     det_ctx,
     labelset: LabelSet,
-) -> tuple[list[np.ndarray], list[float], list]:
-    """Build ``(X_list, y_list, groups)`` from the cached embeddings on *det_ctx*.
+) -> tuple[list[np.ndarray], list[float], list, dict]:
+    """Build ``(X_list, y_list, groups, score_rows)`` from *det_ctx*'s caches.
 
     A Good element contributes its single cached vector.  A Bad element on a
     patch dataset contributes its flooded CLS + leaf negatives (cached in
@@ -433,14 +506,29 @@ def build_xy_from_labelset(
     trainer/calibrator balance and split by element (image), not by row.  When
     nothing floods, every bag holds one row and the downstream path is
     byte-for-byte the pre-flood behaviour.
+
+    ``score_rows`` maps each bag id to the full region-node stack that element's
+    media is *scored* over at inference (``label_score_regions``), so threshold
+    calibration collapses a Good bag exactly the way it collapses a Bad bag and
+    the way the scorer collapses any image - see
+    :func:`vtscore.detectors.training._calibration_score_rows`.  Empty on a
+    legacy dataset, where there is nothing to correct.
     """
     from vtscore.detectors.labelset_elements import stable_element_id
 
     cache: dict[str, np.ndarray] = det_ctx.label_embeddings
     neg_cache: dict[str, list[np.ndarray]] = det_ctx.label_negative_regions
+    score_cache: dict[str, list[np.ndarray]] = det_ctx.label_score_regions
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
     groups: list = []
+    score_rows: dict = {}
+
+    def _record(group: tuple, eid: str) -> None:
+        rows = score_cache.get(eid)
+        if rows:
+            score_rows[group] = np.stack(rows)
+
     for elem in labelset.elements:
         if elem.label not in ("good", "bad"):
             continue
@@ -452,14 +540,17 @@ def build_xy_from_labelset(
                     X_list.append(vec)
                     y_list.append(0.0)
                     groups.append(("b", eid))
+                _record(("b", eid), eid)
                 continue
         emb = cache.get(eid)
         if emb is None:
             continue
         X_list.append(emb)
         y_list.append(1.0 if elem.label == "good" else 0.0)
-        groups.append(("g" if elem.label == "good" else "b", eid))
-    return X_list, y_list, groups
+        group = ("g" if elem.label == "good" else "b", eid)
+        groups.append(group)
+        _record(group, eid)
+    return X_list, y_list, groups, score_rows
 
 
 # ---------------------------------------------------------------------------
@@ -661,7 +752,7 @@ def train_from_labelset(
         snap=snap,
         on_progress=on_progress,
     )
-    X_list, y_list, groups = build_xy_from_labelset(det_ctx, labelset)
+    X_list, y_list, groups, score_rows = build_xy_from_labelset(det_ctx, labelset)
     if len(X_list) < 2:
         return False
     if not any(y == 1.0 for y in y_list) or not any(y == 0.0 for y in y_list):
@@ -674,7 +765,13 @@ def train_from_labelset(
     # Pass det_ctx so the fold orderings are cached for a no-retrain Inclusion
     # slide (otherwise the slide can't move the cutoff — see train_and_threshold).
     mlp, threshold = train_and_threshold(
-        X_list, y_list, snap=snap, embedder_name=det_ctx.embedder or None, det_ctx=det_ctx, groups=groups
+        X_list,
+        y_list,
+        snap=snap,
+        embedder_name=det_ctx.embedder or None,
+        det_ctx=det_ctx,
+        groups=groups,
+        score_rows=score_rows,
     )
     det_ctx.model = mlp
     det_ctx.threshold = threshold
@@ -706,7 +803,7 @@ def labelset_train_and_score(
     from vtscore.detectors.training import _train_and_score_xy
 
     populate_label_embeddings(det_ctx, labelset, media_type=media_type, snap=clips_dict)
-    X_list, y_list, groups = build_xy_from_labelset(det_ctx, labelset)
+    X_list, y_list, groups, score_rows = build_xy_from_labelset(det_ctx, labelset)
     results, threshold, model = _train_and_score_xy(
         X_list,
         y_list,
@@ -717,6 +814,7 @@ def labelset_train_and_score(
         calibration_fraction=calibration_fraction,
         det_ctx=det_ctx,
         groups=groups,
+        score_rows=score_rows,
     )
 
     # Stage-2 structural re-rank for a saved structural detector reloaded

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -126,6 +126,40 @@ def _flood_context(
     return n_votes, cal_groups, sample_weights
 
 
+def _calibration_score_rows(
+    groups: list | None,
+    cal_groups: list | None,
+    score_rows: dict | None,
+) -> dict | None:
+    """Per-bag **inference** row stacks for the calibrator, or ``None``.
+
+    Calibration collapses each held-out bag with ``max``.  Left to the training
+    rows that is an unfair comparison on a patch dataset: a Good vote holds one
+    row while a Bad vote holds its ~13 flooded leaves, and ``max`` over 13 draws
+    beats ``max`` over 1 with no signal at all - so the cut lands high and the
+    detector over-rejects true matches.  Handing the calibrator each voted
+    image's *scoring* stack (all ~24 region nodes, exactly what
+    :func:`_score_all_media` max-pools) puts both classes in the geometry
+    inference actually uses.
+
+    Coverage is **all-or-nothing**: unless every bag has a stack this returns
+    ``None`` and the calibrator keeps pooling over the training rows.  Partial
+    coverage is worse than none - a Good bag left on its 1 training row while
+    the Bad bags widen from 13 rows to 24 would deepen the very bias this
+    corrects - so an unresolvable media declines the correction rather than
+    skewing it.
+
+    Also returns ``None`` when *cal_groups* is ``None``: nothing flooded, so
+    every bag is already a single row and the row-wise path runs unchanged.
+    """
+    if cal_groups is None or groups is None or not score_rows:
+        return None
+    bag_ids = set(groups)
+    if not bag_ids <= set(score_rows):
+        return None
+    return {g: np.asarray(score_rows[g], dtype=np.float32) for g in bag_ids}
+
+
 def train_and_threshold(
     X_list: list,
     y_list: list[float],
@@ -133,6 +167,7 @@ def train_and_threshold(
     embedder_name: str | None = None,
     det_ctx: Any = None,
     groups: list | None = None,
+    score_rows: dict | None = None,
 ) -> tuple[Any, float]:
     """Train an MLP and compute a calibrated threshold.
 
@@ -165,6 +200,11 @@ def train_and_threshold(
             :func:`vtscore.state.core.recompute_detector_thresholds_for_inclusion`
             and docs/plans/find-verification-workflow.md.  ``None`` keeps the
             legacy (uncached) behaviour for callers that don't own a context.
+        groups: Per-row bag ids (one voted image per bag); see
+            :func:`_flood_context`.
+        score_rows: Per-bag inference row stacks; see
+            :func:`_calibration_score_rows`.  Only consulted when *groups*
+            reveals flooding.
 
     Returns:
         ``(model, threshold)``
@@ -193,6 +233,7 @@ def train_and_threshold(
     # per bag.  On a legacy label set every bag is one row, so this collapses
     # to the historical behaviour.
     n_votes, cal_groups, sample_weights = _flood_context(X_list, y_list, groups)
+    cal_score_rows = _calibration_score_rows(groups, cal_groups, score_rows)
 
     # Size the hidden layer from the vote count (the same width train_model()
     # picks by default when unflooded), so when we cache the fold orderings
@@ -227,6 +268,7 @@ def train_and_threshold(
             hidden_dim=hidden_dim,
             det_ctx=det_ctx,
             groups=cal_groups,
+            score_rows_by_group=cal_score_rows,
         )
     else:
         threshold = calculate_cross_calibration_threshold(
@@ -237,6 +279,7 @@ def train_and_threshold(
             calibrate_count=get_calibrate_count(),
             calibration_fraction=get_calibration_fraction(),
             groups=cal_groups,
+            score_rows_by_group=cal_score_rows,
         )
 
     if sample_weights is not None:
@@ -361,14 +404,41 @@ def bad_negative_vecs(
     return [media_embedding(media, embedder_name)]
 
 
+def inference_score_rows(
+    media: dict[str, Any],
+    embedder_name: str | None = None,
+) -> np.ndarray | None:
+    """The row stack *media* is max-pooled over at inference, or ``None``.
+
+    Mirrors :func:`vtscore.embedding.matrix._build_region_arrays`, the matrix
+    :func:`_score_all_media` scores: a patch media contributes **every**
+    ``patch_regions`` node - CLS, HAC internals, and HAC leaves alike, ~24 rows
+    - and a region-less media contributes its single image-level vector.
+
+    Used to calibrate in inference geometry: a voted image's bag must collapse
+    over the same rows the scorer will pool, not over the (Good: 1, Bad: ~13)
+    rows the fold model happened to train on.  See
+    :func:`_calibration_score_rows`.
+    """
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
+    regions = media.get("patch_regions")
+    if regions:
+        return np.stack([np.asarray(r.vec, dtype=np.float32) for r in regions])
+    emb = media_embedding(media, embedder_name)
+    if emb is None:
+        return None
+    return np.asarray(emb, dtype=np.float32).reshape(1, -1)
+
+
 def _build_vote_xy(
     clips_dict: dict[int, dict[str, Any]],
     good_votes: dict[int, None],
     bad_votes: dict[int, None],
     region_boxes: dict[int, tuple[float, float, float, float]],
     embedder_name: str | None = None,
-) -> tuple[list[np.ndarray], list[float], list]:
-    """Build ``(X_list, y_list, groups)`` from filtered votes.
+) -> tuple[list[np.ndarray], list[float], list, dict]:
+    """Build ``(X_list, y_list, groups, score_rows)`` from filtered votes.
 
     Good votes that designated a region are region-pooled via
     :func:`_training_vec_for_vote` (one row each).  Bad votes are expanded by
@@ -383,6 +453,13 @@ def _build_vote_xy(
     The caller (:func:`_train_and_score_xy`) enforces the ≥2-samples /
     ≥1-good / ≥1-bad guard.
 
+    ``score_rows`` maps each bag id to the row stack that voted image is
+    *scored* over at inference (:func:`inference_score_rows`) - the whole
+    ~24-node region tree on a patch media - so calibration can collapse a Good
+    bag and a Bad bag the same way :func:`_score_all_media` collapses any
+    image.  Without it a Good bag is a max over its 1 training row against a
+    Bad bag's max over ~13, and the calibrated cut lands high.
+
     *embedder_name* is the detector's primary embedder; when ``None`` the
     dataset score precedence for *clips_dict* is used (the pre-per-detector
     behaviour).  Either way the MLP trains in the same space
@@ -393,18 +470,27 @@ def _build_vote_xy(
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
     groups: list = []
+    score_rows: dict = {}
+
+    def _record_score_rows(group: tuple, cid: int) -> None:
+        rows = inference_score_rows(clips_dict[cid], embedder_name)
+        if rows is not None:
+            score_rows[group] = rows
+
     for cid in good_votes:
         if cid in clips_dict:
             X_list.append(_training_vec_for_vote(clips_dict[cid], region_boxes.get(cid), embedder_name))
             y_list.append(1.0)
             groups.append(("g", cid))
+            _record_score_rows(("g", cid), cid)
     for cid in bad_votes:
         if cid in clips_dict:
             for vec in bad_negative_vecs(clips_dict[cid], embedder_name):
                 X_list.append(vec)
                 y_list.append(0.0)
                 groups.append(("b", cid))
-    return X_list, y_list, groups
+            _record_score_rows(("b", cid), cid)
+    return X_list, y_list, groups, score_rows
 
 
 def _score_all_media(
@@ -536,6 +622,7 @@ def _train_and_score_xy(
     calibration_fraction: float,
     det_ctx: Any,
     groups: list | None = None,
+    score_rows: dict | None = None,
 ) -> tuple[list[dict[str, Any]], float, nn.Sequential | None]:
     """Train an MLP on ``(X_list, y_list)`` and score every media in *clips_dict*.
 
@@ -551,10 +638,12 @@ def _train_and_score_xy(
     the model width or shift the small-count threshold ramp.  When *groups*
     reveals at least one multi-row bag (flooding actually happened), the
     calibration split, fold fits, and final fit all run **bag-aware**
-    (grouped fold split, per-bag loss weights); otherwise every row is its own
-    bag and the path is byte-for-byte the pre-flood behaviour.  Returns
-    ``([], 0.5, None)`` when the labels don't satisfy ≥2 samples AND ≥1 good
-    AND ≥1 bad.
+    (grouped fold split, per-bag loss weights), and each calibration bag
+    collapses over the *scoring* rows *score_rows* supplies rather than the
+    rows it trained on (see :func:`_calibration_score_rows`); otherwise every
+    row is its own bag and the path is byte-for-byte the pre-flood behaviour.
+    Returns ``([], 0.5, None)`` when the labels don't satisfy ≥2 samples AND
+    ≥1 good AND ≥1 bad.
     """
     import torch  # noqa: PLC0415
 
@@ -581,6 +670,7 @@ def _train_and_score_xy(
     # Bag-aware setup (region flooding): size on votes not rows, split/weight
     # per bag when a Bad vote flooded its leaf set; a no-op on legacy datasets.
     n_votes, cal_groups, sample_weights = _flood_context(X_list, y_list, groups)
+    cal_score_rows = _calibration_score_rows(groups, cal_groups, score_rows)
     hidden_dim = _auto_hidden_dim(n_votes)
 
     # Skip k-fold calibration *only* when safe-thresholds is on and the label
@@ -612,6 +702,7 @@ def _train_and_score_xy(
             hidden_dim=hidden_dim,
             det_ctx=det_ctx,
             groups=cal_groups,
+            score_rows_by_group=cal_score_rows,
         )
 
     # A Good vote trains on one region (the snapped box); a Bad vote trains on
@@ -689,7 +780,7 @@ def train_and_score(
           training was not possible).
     """
     region_boxes = vote_region_boxes or {}
-    X_list, y_list, groups = _build_vote_xy(
+    X_list, y_list, groups, score_rows = _build_vote_xy(
         clips_dict, good_votes, bad_votes, region_boxes, detector_score_embedder(det_ctx, clips_dict)
     )
     results, threshold, model = _train_and_score_xy(
@@ -702,6 +793,7 @@ def train_and_score(
         calibration_fraction=calibration_fraction,
         det_ctx=det_ctx,
         groups=groups,
+        score_rows=score_rows,
     )
 
     # Stage-2 structural re-rank: a no-op for every non-structural dataset

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -753,6 +753,15 @@ class DetectorContext:
         # In-memory only, re-derived from origins, never persisted; cleared on
         # embedder switch alongside ``label_embeddings``.
         "label_negative_regions",
+        # Full region-node stacks for the labelset's elements on patch datasets:
+        # str → list[np.ndarray], keyed by stable_element_id, holding *every*
+        # ``patch_regions`` vector (CLS + HAC internals + leaves) - the rows the
+        # scorer max-pools that element's media over.  Lets threshold
+        # calibration collapse a Good bag and a Bad bag the same way inference
+        # collapses any image, instead of comparing a max-over-1 against a
+        # max-over-13.  In-memory only, re-derived from origins, never
+        # persisted; cleared on embedder switch alongside ``label_embeddings``.
+        "label_score_regions",
         "model",  # nn.Sequential | None (current trained MLP)
         # Structural (SIFT/VLAD) detectors carry a *second* learned object next
         # to the retrieval MLP: the match-statistic verification classifier
@@ -845,6 +854,7 @@ class DetectorContext:
         self.label_embedding_regions: dict[str, tuple[float, float, float, float] | None] = {}
         self.label_local_features: dict[str, Any] = {}
         self.label_negative_regions: dict[str, list[Any]] = {}
+        self.label_score_regions: dict[str, list[Any]] = {}
         self.model: Any = None  # nn.Sequential | None
         # Match-statistic verification classifier for structural detectors;
         # None for non-structural detectors and until first trained.
@@ -1091,6 +1101,7 @@ class _RequestMissingDetectorContext(DetectorContext):
         object.__setattr__(self, "label_embedding_regions", _FrozenDict("detector"))
         object.__setattr__(self, "label_local_features", _FrozenDict("detector"))
         object.__setattr__(self, "label_negative_regions", _FrozenDict("detector"))
+        object.__setattr__(self, "label_score_regions", _FrozenDict("detector"))
         object.__setattr__(self, "model", None)
         object.__setattr__(self, "verification_classifier", None)
         object.__setattr__(self, "threshold", 0.5)

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -99,6 +99,23 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
         return float(np.median(arr))
 
 
+def _score_rows_digest(score_rows_by_group: dict | None) -> bytes | None:
+    """Digest of the per-bag **inference** row stacks, for the calibration key.
+
+    ``None`` when no override is in play, so a call that pools each bag over
+    its training rows keeps a distinct cache key from one that pools over the
+    scorer's rows - otherwise a cached ordering computed under the old geometry
+    would be served after the wiring changed.
+    """
+    if score_rows_by_group is None:
+        return None
+    h = hashlib.blake2b()
+    for g in sorted(score_rows_by_group, key=repr):
+        h.update(repr(g).encode())
+        h.update(np.asarray(score_rows_by_group[g], dtype=np.float32).tobytes())
+    return h.digest()
+
+
 def _calibration_cache_key(
     X_list: list,
     y_list: list[float],
@@ -106,6 +123,7 @@ def _calibration_cache_key(
     calibration_fraction: float,
     hidden_dim: int,
     groups: list | None = None,
+    score_rows_by_group: dict | None = None,
 ) -> tuple:
     """Build a deterministic cache key for the calibration **fold orderings**.
 
@@ -137,6 +155,7 @@ def _calibration_cache_key(
         float(calibration_fraction),
         int(hidden_dim),
         groups_key,
+        _score_rows_digest(score_rows_by_group),
     )
 
 
@@ -151,6 +170,7 @@ def cross_calibration_threshold_cached(
     hidden_dim: int,
     det_ctx: Any = None,
     groups: list | None = None,
+    score_rows_by_group: dict | None = None,
 ) -> float:
     """Memoized wrapper around :func:`calculate_cross_calibration_threshold`.
 
@@ -163,12 +183,22 @@ def cross_calibration_threshold_cached(
     rule over the cached orderings - no ~200-epoch fold fits.
 
     A real label change produces a different cache key and falls through to a
-    fresh calibration - no explicit invalidation needed.
+    fresh calibration - no explicit invalidation needed.  *score_rows_by_group*
+    (see :func:`compute_fold_orderings`) enters the key too, so a change in the
+    rows a bag is scored over can never be served from a stale ordering.
     """
     payload: tuple[list[tuple[list[float], list[float]]], float | None] | None = None
     key = None
     if det_ctx is not None:
-        key = _calibration_cache_key(X_list, y_list, calibrate_count, calibration_fraction, hidden_dim, groups)
+        key = _calibration_cache_key(
+            X_list,
+            y_list,
+            calibrate_count,
+            calibration_fraction,
+            hidden_dim,
+            groups,
+            score_rows_by_group,
+        )
         cached = getattr(det_ctx, "calibration_cache", None)
         if cached is not None and cached[0] == key:
             payload = cached[1]
@@ -184,6 +214,7 @@ def cross_calibration_threshold_cached(
             calibration_fraction=calibration_fraction,
             hidden_dim=hidden_dim,
             groups=groups,
+            score_rows_by_group=score_rows_by_group,
         )
         if det_ctx is not None and key is not None:
             det_ctx.calibration_cache = (key, payload)
@@ -466,8 +497,11 @@ def compute_fold_orderings(
     ``max`` is an upward-biased order statistic, so the calibrated cut
     lands systematically high and the threshold over-rejects positives.  Passing
     each vote's inference rows here puts both classes in the geometry and at the
-    width the scorer will actually use.  ``None`` (every production caller)
-    keeps the historical "collapse over the training rows" behaviour.
+    width the scorer will actually use.  The production vote / labelset paths
+    supply each voted image's full region-node stack
+    (:func:`vtscore.detectors.training.inference_score_rows`); ``None`` keeps
+    the "collapse over the training rows" behaviour for callers that have no
+    inference geometry to offer.
     """
     if groups is not None:
         return _compute_fold_orderings_grouped(

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -639,7 +639,7 @@ def find_evidence_coverage():
     # already populated from its saved labelset — cross-user by construction,
     # nothing persisted.  Good rows are y == 1, Bad (incl. patch-flood
     # negatives) are y == 0.
-    x_list, y_list, _groups = build_xy_from_labelset(det_ctx, labelset)
+    x_list, y_list, _groups, _score_rows = build_xy_from_labelset(det_ctx, labelset)
     if not x_list:
         return _empty_evidence_coverage()
     x = np.asarray(x_list, dtype=np.float32)


### PR DESCRIPTION
Refs #2731

## The defect

On a patch dataset the calibrator collapsed each held-out bag with `max` over the rows the fold model **trained** on: a Good vote's single snapped region node against a Bad vote's ~13 flooded leaves. `max` is an upward-biased order statistic, so the two classes were never comparable — while `_score_all_media` scores *every* image, positive and negative alike, as a max over all ~24 region nodes.

The bag-aware calibration path was added so a Bad bag "scores as one image, as at inference". The Good bag never got the same treatment.

## The fix

Wire the production vote and labelset paths to the `score_rows_by_group` hook (added experiment-tier-only in #2732), so each calibration bag collapses over the stack the *scorer* pools:

- **`inference_score_rows()`** (`vtscore/detectors/training.py`) returns a media's full `patch_regions` node stack — CLS + HAC internals + leaves — mirroring `_build_region_arrays`, the matrix `_score_all_media` actually scores. A region-less media returns its single image-level vector. A test pins it against `_score_all_media`'s own output so the two geometries cannot drift.
- **`_build_vote_xy` / `build_xy_from_labelset`** now return a per-bag `score_rows` map alongside `(X, y, groups)`.
- **`_calibration_score_rows()`** gates it:
  - `None` when nothing flooded, so legacy single-vector datasets reach the calibrator byte-identically;
  - **all-or-nothing on coverage** — a bag with no resolvable stack declines the correction rather than skewing it. Partial coverage is *worse* than none: a Good bag left at max-over-1 while the Bad bags widened from 13 rows to 24 would deepen the very bias being fixed.
- **Labelset path**: each element's node stack is cached on the new `DetectorContext.label_score_regions`, resolved from the same tree that already feeds `label_negative_regions` (`_resolve_negative_leaves` became `_resolve_region_nodes`, returning the tree so both caches come from one resolution). Cleared on embedder switch alongside `label_embeddings`. In-memory only, re-derived from origins, never persisted. The extra tree resolution for Good elements is skipped entirely on a detector whose embedder doesn't support patch regions, so no origin file is probed for a tree that cannot exist.
- **`_calibration_cache_key`** hashes the stacks, so cached fold orderings can never be served across a geometry change.

Nothing about the fold split, the fold fits, or the final fit changes — only which rows a calibration bag is scored over.

## Measured before/after

Synthetic patch detector, 8 seeds, 6 Good + 6 Bad votes over 300 media with real `build_region_tree` HAC trees, mean AP 0.58 (i.e. the detector genuinely ranks):

| | before | after | inference |
|---|---|---|---|
| calibration mean **positive** score | 0.5294 | **0.5513** | 0.5459 (median true-pos) |
| calibration mean **negative** score | 0.5339 | 0.5341 | 0.5311 (median true-neg) |
| threshold | 0.5184 | 0.5396 | — |
| FPR / FNR at that threshold | 0.997 / 0.000 | 0.256 / 0.226 | — |

Two things to note. First, calibration previously believed a positive scored *below* the negatives' mean — inverted relative to what inference produces; after the fix it lands in line with the real positive distribution. Second, the negative side is essentially unmoved (0.5339 → 0.5341), confirming the issue's instrumentation finding that the Bad side already matched production.

## The bias runs the other way from the issue's prediction

The issue predicts "the min-cost cut lands high" and a bias toward **FNR**. Measured, it is the opposite: the old geometry set the cut too **low** and the bias was toward over-inclusion (FPR 0.997 — a cut so low that essentially nothing was excluded).

The "lands high" reasoning was for the min-cost argmin the conformal rule replaced in #2693. Under the conformal rule the threshold is `min(fn_cap, max(fp_guard, walk))` with `fn_cap = quantile(pos, 0.25)`, so a deflated positive distribution dominates the `min` and drags the cut down. The defect and the fix are unchanged; only the direction of the damage differs.

## Tests

New `tests_lib/detectors/test_calibration_inference_geometry.py` (library tier, import-clean): `inference_score_rows` vs `_score_all_media` parity, both classes getting equal-width stacks, the legacy no-op, the all-or-nothing coverage gate, the widened-positive invariant under a fixed model, and cache-key invalidation. `tests/detectors/test_patch_embedder.py` extended for the new `_build_vote_xy` return.

`./run-tests.sh` — 7152 passed. `./run-tests.sh vtscore-clean` — 3084 passed.

## Not addressed

The issue's "Related, smaller" note — `bad_negative_vecs` deliberately drops internal HAC nodes from the flood while `_score_all_media` pools them. This PR does not change what a Bad vote trains down; it only makes calibration *score* those internals (as inference does). `test_max_hac_floods_every_scored_row_except_hac_internals` still pins the exception, so it stays visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBxMNKXudVhDa6EL1hcCEU)_