### PR TITLE
Converge api.models.ts onto generated OpenAPI types (and fix the blank Auto-Find results table)

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,6 +149,7 @@ from flask_smorest import Api  # noqa: E402
 
 from vtsearch.openapi_postprocess import (  # noqa: E402
     assign_operation_ids,
+    collapse_nullable_refs,
     normalize_unprocessable_response,
 )
 
@@ -169,6 +170,7 @@ def _to_dict_with_operation_ids() -> dict:
     spec = _apispec_to_dict()
     assign_operation_ids(app, spec)
     normalize_unprocessable_response(spec)
+    collapse_nullable_refs(spec)
     return spec
 
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -471,8 +471,7 @@
         "additionalProperties": false,
         "properties": {
           "auto_export": {
-            "additionalProperties": {},
-            "type": "object"
+            "$ref": "#/components/schemas/_AutoFindExportStatus"
           },
           "detectors_run": {
             "type": "integer"
@@ -2704,16 +2703,9 @@
             "type": "boolean"
           },
           "pending_labelset_move": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PendingLabelsetMove"
-              },
-              {
-                "nullable": true,
-                "type": "object"
-              }
-            ],
-            "default": null
+            "$ref": "#/components/schemas/PendingLabelsetMove",
+            "default": null,
+            "nullable": true
           }
         },
         "required": [
@@ -2838,16 +2830,9 @@
             "type": "string"
           },
           "pending_labelset_move": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PendingLabelsetMove"
-              },
-              {
-                "nullable": true,
-                "type": "object"
-              }
-            ],
-            "default": null
+            "$ref": "#/components/schemas/PendingLabelsetMove",
+            "default": null,
+            "nullable": true
           },
           "success": {
             "type": "boolean"
@@ -4271,9 +4256,8 @@
             "type": "object"
           },
           "origin": {
-            "additionalProperties": {},
-            "nullable": true,
-            "type": "object"
+            "$ref": "#/components/schemas/Origin",
+            "nullable": true
           },
           "origin_name": {
             "type": "string"
@@ -4613,7 +4597,6 @@
         "type": "object"
       },
       "MediaBatchResponse": {
-        "additionalProperties": true,
         "properties": {
           "clip_box": {
             "items": {
@@ -4915,6 +4898,23 @@
         },
         "required": [
           "ok"
+        ],
+        "type": "object"
+      },
+      "Origin": {
+        "additionalProperties": false,
+        "properties": {
+          "importer": {
+            "type": "string"
+          },
+          "params": {
+            "additionalProperties": {},
+            "description": "Identifying import parameters; the key set is importer-specific.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "importer"
         ],
         "type": "object"
       },
@@ -6146,6 +6146,30 @@
         ],
         "type": "object"
       },
+      "_AutoFindExportStatus": {
+        "additionalProperties": true,
+        "properties": {
+          "error": {
+            "description": "Failure reason; present instead of ``message`` on failure.",
+            "type": "string"
+          },
+          "exporter": {
+            "type": "string"
+          },
+          "message": {
+            "description": "Human-readable outcome; present on success.",
+            "type": "string"
+          },
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "exporter",
+          "success"
+        ],
+        "type": "object"
+      },
       "_AutoLocalizePerProcessor": {
         "additionalProperties": false,
         "properties": {
@@ -6504,9 +6528,8 @@
             "type": "string"
           },
           "origin": {
-            "additionalProperties": {},
-            "nullable": true,
-            "type": "object"
+            "$ref": "#/components/schemas/Origin",
+            "nullable": true
           },
           "origin_name": {
             "type": "string"
@@ -6545,17 +6568,72 @@
         "type": "object"
       },
       "_Hit": {
-        "additionalProperties": true,
         "properties": {
+          "clip_box": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "clip_end": {
+            "type": "number"
+          },
+          "clip_index": {
+            "type": "integer"
+          },
+          "clip_start": {
+            "type": "number"
+          },
+          "custom_metadata": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "embedder": {
+            "type": "string"
+          },
+          "embedders": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "has_original": {
+            "description": "Present and ``true`` when a MediaCleaner rewrote this item at load time and its pre-clean payload was kept. The byte routes then accept ``?variant=original`` and the detail viewer offers a Clean/Original toggle. Absent otherwise.",
+            "type": "boolean"
+          },
           "id": {
             "type": "integer"
+          },
+          "md5": {
+            "type": "string"
+          },
+          "media_type": {
+            "type": "string"
+          },
+          "origin": {
+            "$ref": "#/components/schemas/Origin",
+            "description": "Where this item was ingested from; rendered as the results table's Origin column.",
+            "nullable": true
+          },
+          "origin_name": {
+            "type": "string"
           },
           "score": {
             "type": "number"
           }
         },
         "required": [
+          "custom_metadata",
+          "filename",
           "id",
+          "md5",
+          "media_type",
           "score"
         ],
         "type": "object"

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -896,13 +896,55 @@
         ],
         "type": "object"
       },
+      "CleanerInfo": {
+        "additionalProperties": true,
+        "properties": {
+          "creation_questions": {
+            "description": "Parameters to ask about when the user first picks this clipper. Defaults to ``parameters``.",
+            "items": {
+              "$ref": "#/components/schemas/ClipperParameter"
+            },
+            "type": "array"
+          },
+          "default_enabled": {
+            "description": "Whether the import form checks this cleaner by default. True only for cleaners that fix an outright representation bug (EXIF orientation), where leaving it off ships known-wrong vectors.",
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "media_type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parameters": {
+            "items": {
+              "$ref": "#/components/schemas/ClipperParameter"
+            },
+            "type": "array"
+          },
+          "summary_template": {
+            "description": "One-line preview with ``{key}`` placeholders for each parameter. The native row of the importer source-specs picker substitutes the current parameter values, so the user sees a live summary of what the clipper will do. Falls back to ``description`` when empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "media_type",
+          "name"
+        ],
+        "type": "object"
+      },
       "CleanersListResponse": {
         "additionalProperties": false,
         "properties": {
           "cleaners": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/CleanerInfo"
             },
             "type": "array"
           }
@@ -924,13 +966,98 @@
         ],
         "type": "object"
       },
+      "ClipperInfo": {
+        "additionalProperties": true,
+        "properties": {
+          "creation_questions": {
+            "description": "Parameters to ask about when the user first picks this clipper. Defaults to ``parameters``.",
+            "items": {
+              "$ref": "#/components/schemas/ClipperParameter"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "media_type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parameters": {
+            "items": {
+              "$ref": "#/components/schemas/ClipperParameter"
+            },
+            "type": "array"
+          },
+          "summary_template": {
+            "description": "One-line preview with ``{key}`` placeholders for each parameter. The native row of the importer source-specs picker substitutes the current parameter values, so the user sees a live summary of what the clipper will do. Falls back to ``description`` when empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "media_type",
+          "name"
+        ],
+        "type": "object"
+      },
+      "ClipperParameter": {
+        "additionalProperties": false,
+        "properties": {
+          "default": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "max": {
+            "type": "number"
+          },
+          "min": {
+            "type": "number"
+          },
+          "step": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "number",
+              "string"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "default",
+          "key",
+          "label",
+          "type"
+        ],
+        "type": "object"
+      },
       "ClippersListResponse": {
         "additionalProperties": false,
         "properties": {
           "clippers": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ClipperInfo"
             },
             "type": "array"
           }
@@ -951,8 +1078,7 @@
           },
           "fields": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ImporterField"
             },
             "type": "array"
           },
@@ -1126,15 +1252,13 @@
         "properties": {
           "importers": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ImporterInfo"
             },
             "type": "array"
           },
           "tabs": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ImporterPickerTab"
             },
             "type": "array"
           }
@@ -1265,8 +1389,7 @@
         "properties": {
           "importers": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ImporterInfo"
             },
             "type": "array"
           }
@@ -1427,6 +1550,115 @@
         },
         "required": [
           "duplicate_sets"
+        ],
+        "type": "object"
+      },
+      "DatasetRegistryEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "bound_embedders": {
+            "description": "Every concrete embedder this dataset binds (primary first).",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "clipper": {
+            "description": "Resolved clipper display name, or ``\"-\"`` when the dataset used its media type's default clipper.",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "Unix timestamp (seconds) at which the dataset was registered.",
+            "type": "number"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "embedder": {
+            "description": "Name of the embedder this dataset's media were vectorised with.",
+            "type": "string"
+          },
+          "embedder_types": {
+            "description": "The embedder *types* this dataset supplies (``semantic`` / ``patch_semantic`` / ``structural``); a v3 trio dataset can supply several. Drives the detector/dataset compatibility gate.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "embedders_by_type": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "One concrete embedder per type it binds, e.g. ``{\"semantic\": \"siglip\", \"patch_semantic\": \"dinov3_patch\"}``. Drives the Combine-Datasets conflict detector.",
+            "type": "object"
+          },
+          "expires_at": {
+            "description": "Unix timestamp (seconds) at which this dataset ages off and is automatically removed; ``null``/absent means it never expires.",
+            "nullable": true,
+            "type": "number"
+          },
+          "file_type_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Per-extension file counts observed during ingest.",
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "ingest_finished_at": {
+            "nullable": true,
+            "type": "number"
+          },
+          "ingest_started_at": {
+            "nullable": true,
+            "type": "number"
+          },
+          "loaded": {
+            "description": "Whether this dataset is currently resident in memory.",
+            "type": "boolean"
+          },
+          "media_type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "num_dupes": {
+            "description": "How many items were collapsed as near-duplicates.",
+            "type": "integer"
+          },
+          "num_items": {
+            "description": "Item count after near-duplicate collapsing.",
+            "type": "integer"
+          },
+          "origin": {
+            "description": "Name of the importer that produced this dataset.",
+            "type": "string"
+          },
+          "pkl_path": {
+            "description": "Server-side path of the dataset pickle.",
+            "type": "string"
+          },
+          "readers": {
+            "description": "Usernames granted read access. Empty means creator-only; ``[\"*\"]`` means visible to everyone.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "source": {
+            "additionalProperties": {},
+            "description": "The importer's origin dict for this dataset (importer name plus its field values). Inner keys are importer-specific, so this stays an opaque map.",
+            "nullable": true,
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "media_type",
+          "name"
         ],
         "type": "object"
       },
@@ -1714,8 +1946,7 @@
         "properties": {
           "datasets": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/DatasetRegistryEntry"
             },
             "type": "array"
           }
@@ -2664,6 +2895,28 @@
         ],
         "type": "object"
       },
+      "DiversityPoint": {
+        "additionalProperties": false,
+        "properties": {
+          "depth": {
+            "description": "Total nodes in the coverage atlas.",
+            "type": "integer"
+          },
+          "diversity_level": {
+            "description": "Coverage level reached by the labels so far.",
+            "type": "number"
+          },
+          "num_labels": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "depth",
+          "diversity_level",
+          "num_labels"
+        ],
+        "type": "object"
+      },
       "DuplicateSet": {
         "additionalProperties": false,
         "properties": {
@@ -2795,6 +3048,35 @@
         },
         "type": "object"
       },
+      "ErrorCostPoint": {
+        "additionalProperties": false,
+        "properties": {
+          "error_cost": {
+            "description": "``fpr_weight * fpr + fnr_weight * fnr`` for the model trained at this step.",
+            "type": "number"
+          },
+          "fnr": {
+            "description": "False-negative rate on the held-out eval set.",
+            "type": "number"
+          },
+          "fpr": {
+            "description": "False-positive rate on the held-out eval set.",
+            "type": "number"
+          },
+          "num_labels": {
+            "type": "integer"
+          },
+          "time_index": {
+            "description": "Zero-based index of this step in the label history.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "error_cost",
+          "num_labels"
+        ],
+        "type": "object"
+      },
       "EvalTrainAndScoreCancelResponse": {
         "additionalProperties": false,
         "properties": {
@@ -2837,8 +3119,7 @@
           },
           "diversity": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/DiversityPoint"
             },
             "type": "array"
           },
@@ -2847,8 +3128,7 @@
           },
           "error_cost": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ErrorCostPoint"
             },
             "type": "array"
           },
@@ -2860,8 +3140,7 @@
           },
           "stability": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/StabilityPoint"
             },
             "type": "array"
           },
@@ -3567,6 +3846,106 @@
         ],
         "type": "object"
       },
+      "ImporterField": {
+        "additionalProperties": false,
+        "properties": {
+          "accept": {
+            "description": "For ``file`` fields: comma-separated extensions, e.g. ``\".pkl\"``.",
+            "type": "string"
+          },
+          "allow_free_text": {
+            "description": "For ``select`` fields: when true, render as a combobox the user can type an arbitrary value into. When the options refresh, a typed value absent from the new list is kept; a strict select clears it.",
+            "type": "boolean"
+          },
+          "clears": {
+            "description": "Field keys this field is mutually exclusive with. Entering a non-empty value here blanks each listed field (and they list this one back), so only one of the set is ever active at a time.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "default": {
+            "type": "string"
+          },
+          "depends_on": {
+            "description": "Field keys whose values this field's options depend on.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "dynamic_options": {
+            "description": "When true, ``options`` is computed at runtime by calling ``POST /api/dataset/import/<importer>/options`` with the current field values. The frontend re-fetches whenever any field listed in ``depends_on`` changes.",
+            "type": "boolean"
+          },
+          "field_type": {
+            "enum": [
+              "file",
+              "folder",
+              "url",
+              "text",
+              "password",
+              "email",
+              "number",
+              "select",
+              "server_path",
+              "checkbox"
+            ],
+            "type": "string"
+          },
+          "hint": {
+            "description": "Inline format-hint text rendered as a visible chip below the input. Distinct from ``description`` (which feeds the placeholder): the hint stays visible after the user starts typing, so it is the right place for accepted extensions or a short sample file layout.",
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "max": {
+            "description": "For ``number`` fields: maximum allowed value (empty = no max).",
+            "type": "string"
+          },
+          "min": {
+            "description": "For ``number`` fields: minimum allowed value (empty = no min).",
+            "type": "string"
+          },
+          "options": {
+            "description": "For ``select`` fields: the statically-declared allowed values. Runtime-computed options come from ``POST /api/dataset/import/<importer>/options`` instead and carry their own ``(value, label)`` shape; see ``ImporterFieldOptionsResponseSchema``.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "placeholder": {
+            "description": "Hint shown as placeholder text inside the input widget.",
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "step": {
+            "description": "For ``number`` fields: step increment (empty / ``\"any\"`` = unconstrained).",
+            "type": "string"
+          },
+          "template_vars": {
+            "description": "Framework-substituted template variable names (e.g. ``detector_name``, ``YYYYMMDD``) replaced in this field's value before the plugin runs. Advisory for clients; substitution is server-side.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "field_type",
+          "key"
+        ],
+        "type": "object"
+      },
       "ImporterFieldOptionsRequest": {
         "additionalProperties": false,
         "properties": {
@@ -3596,6 +3975,85 @@
         },
         "required": [
           "options"
+        ],
+        "type": "object"
+      },
+      "ImporterInfo": {
+        "additionalProperties": false,
+        "properties": {
+          "available_converters_by_media_type": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/ConverterInfo"
+              },
+              "type": "array"
+            },
+            "description": "Map of output media-type id -> converters whose ``target_type`` matches that id. Drives the \"Include rows\" UI without an extra round-trip to ``/api/converters``.",
+            "type": "object"
+          },
+          "category": {
+            "description": "Picker tab this importer belongs to. One of ``services``, ``server``, ``local``, ``demo``, or ``\"\"`` (uncategorised).",
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "enabled": {
+            "description": "Only set on ``combine_datasets`` by ``GET /api/dataset/all-importers``: false when fewer than two saved datasets share a media type, so there is nothing to combine.",
+            "type": "boolean"
+          },
+          "fields": {
+            "items": {
+              "$ref": "#/components/schemas/ImporterField"
+            },
+            "type": "array"
+          },
+          "hidden_from_picker": {
+            "type": "boolean"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "picker_view": {
+            "description": "Which view the dataset-importer modal opens for this card: ``form`` (default), ``demo``, ``server_folder``, ``local_folder``, or ``local_files``.",
+            "type": "string"
+          },
+          "ui_mode": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "ImporterPickerTab": {
+        "additionalProperties": false,
+        "properties": {
+          "icon": {
+            "description": "``vt-icon`` type name.",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "order": {
+            "description": "Lower values render first.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "label"
         ],
         "type": "object"
       },
@@ -3842,22 +4300,19 @@
         "properties": {
           "diversity_level_over_time": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/DiversityPoint"
             },
             "type": "array"
           },
           "error_cost_over_time": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ErrorCostPoint"
             },
             "type": "array"
           },
           "stability_over_time": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/StabilityPoint"
             },
             "type": "array"
           },
@@ -5306,6 +5761,31 @@
         ],
         "type": "object"
       },
+      "StabilityPoint": {
+        "additionalProperties": false,
+        "properties": {
+          "num_flips": {
+            "description": "How many still-unlabeled items changed predicted class between the previous step's model and this one.",
+            "type": "integer"
+          },
+          "num_labels": {
+            "type": "integer"
+          },
+          "num_unlabeled": {
+            "description": "Size of the monitored pool the flip count was measured over.",
+            "type": "integer"
+          },
+          "time_index": {
+            "description": "Zero-based index of this step in the label history.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "num_flips",
+          "num_labels"
+        ],
+        "type": "object"
+      },
       "StatusIndicator": {
         "additionalProperties": true,
         "properties": {
@@ -5772,8 +6252,7 @@
         "properties": {
           "available_converters": {
             "items": {
-              "additionalProperties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ConverterInfo"
             },
             "type": "array"
           },

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -12,7 +12,7 @@ import { PulldownControlService } from '../../services/pulldown-control.service'
 import { DashboardColumnsService } from '../../services/dashboard-columns.service';
 import { DashboardSelectionService } from '../../services/dashboard-selection.service';
 import { RunningJobsService, pairKey } from '../../services/running-jobs.service';
-import { SortState } from '../../utils/managed-columns';
+import { SortState, sortRowsByColumn } from '../../utils/managed-columns';
 import { DatasetRegistryEntry } from '../../models/api.models';
 import { IconComponent } from '../icon/icon.component';
 import { DetectorRegistryEntry } from '../../generated/api-client/models/detector-registry-entry';
@@ -450,15 +450,9 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
    *  (column + direction read from `DashboardColumnsService`). Mirrors
    *  the comparator in `DashboardComponent.sortedDatasets` /
    *  `sortedDetectors`. */
-  private applySort<T extends { name: string; [k: string]: unknown }>(arr: T[]): T[] {
+  private applySort<T>(arr: T[]): T[] {
     const { column, asc } = this.sortState;
-    const dir = asc ? 1 : -1;
-    return [...arr].sort((a, b) => {
-      const va = a[column] ?? '';
-      const vb = b[column] ?? '';
-      if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * dir;
-      return String(va).localeCompare(String(vb)) * dir;
-    });
+    return sortRowsByColumn(arr, column, asc);
   }
 
   private findActiveIndex(): number {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -33,6 +33,7 @@ import {
   formatProgressMessage,
   progressBarState,
 } from '../../utils/format-progress';
+import { sortRowsByColumn } from '../../utils/managed-columns';
 import {
   DashboardColumnsService,
   DatasetColumn,
@@ -1260,14 +1261,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   // --- Sorting ---
 
   get sortedDatasets(): DatasetRegistryEntry[] {
-    const col = this.datasetCols.sortColumn;
-    const asc = this.datasetCols.sortAsc ? 1 : -1;
-    return [...this.datasets].sort((a, b) => {
-      const va = a[col] ?? '';
-      const vb = b[col] ?? '';
-      if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * asc;
-      return String(va).localeCompare(String(vb)) * asc;
-    });
+    return sortRowsByColumn(this.datasets, this.datasetCols.sortColumn, this.datasetCols.sortAsc);
   }
 
   get sortedDetectors(): DetectorRegistryEntry[] {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -6,13 +6,14 @@ import { provideZoneless } from '../../../testing/zoneless-testbed';
 import { settleResource, settleZoneless } from '../../../testing/settle-resource';
 import { getTabLabel } from './pickers/shared/media-type.util';
 import { provideHttpTesting } from '../../../testing/test-providers';
+import type { ImporterInfo } from '../../../models/api.models';
 
 describe('DatasetImporterModalComponent', () => {
   let component: DatasetImporterModalComponent;
   let fixture: ComponentFixture<DatasetImporterModalComponent>;
   let httpMock: HttpTestingController;
 
-  const mockImporters = [
+  const mockImporters: ImporterInfo[] = [
     {
       name: 'local_folder',
       display_name: 'Folder',

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
@@ -16,7 +16,7 @@ import {
   ClipperParameter,
   ConverterInfo,
   EmbedderInfo,
-  FieldOption,
+  FieldOptions,
   ImporterField,
   ImporterInfo,
   MediaTypeInfo,
@@ -89,7 +89,7 @@ export class GenericFormPickerComponent {
 
   sourceSpecs: SourceSpec[] = [];
 
-  readonly dynamicFieldOptions = signal<Record<string, FieldOption[]>>({});
+  readonly dynamicFieldOptions = signal<Record<string, FieldOptions[]>>({});
   readonly dynamicFieldLoading = signal<Record<string, boolean>>({});
   readonly dynamicFieldError = signal<Record<string, string>>({});
 
@@ -269,7 +269,7 @@ export class GenericFormPickerComponent {
     this.dynamicFieldError.update((m) => ({ ...m, [key]: '' }));
     this.datasetsCrudApi.getImporterFieldOptions(importer.name, key, { ...this.formValues }).subscribe({
       next: (res) => {
-        const options: FieldOption[] = res.options || [];
+        const options: FieldOptions[] = res.options || [];
         this.dynamicFieldOptions.update((m) => ({ ...m, [key]: options }));
         this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
         const current = this.formValues[key];
@@ -291,7 +291,7 @@ export class GenericFormPickerComponent {
     });
   }
 
-  optionsFor(field: ImporterField): FieldOption[] {
+  optionsFor(field: ImporterField): FieldOptions[] {
     if (field.dynamic_options) {
       return this.dynamicFieldOptions()[field.key] || [];
     }

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/local-folder/local-folder-picker.component.ts
@@ -15,7 +15,7 @@ import {
   ConverterInfo,
   EmbedderInfo,
   ImporterInfo,
-  MediaTypeDetectionResponse,
+  DetectMediaTypeResponse,
   MediaTypeInfo,
   SourceSpec,
 } from '../../../../../models/api.models';
@@ -85,7 +85,7 @@ export class LocalFolderPickerComponent {
    *  the sibling `<vt-source-picker>` in the parent's template - a
    *  signal so this component's own `detectionHint()` read notifies
    *  correctly regardless of ancestor-marking. */
-  readonly detection = signal<MediaTypeDetectionResponse | null>(null);
+  readonly detection = signal<DetectMediaTypeResponse | null>(null);
   readonly submitting = signal(false);
   readonly error = signal('');
   recursive = true;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/server-folder/server-folder-picker.component.ts
@@ -17,7 +17,7 @@ import {
   ConverterInfo,
   EmbedderInfo,
   ImporterInfo,
-  MediaTypeDetectionResponse,
+  DetectMediaTypeResponse,
   MediaTypeInfo,
   SourceSpec,
 } from '../../../../../models/api.models';
@@ -108,7 +108,7 @@ export class ServerFolderPickerComponent {
   datasetName = '';
   private datasetNameDirty = false;
   readonly sourceSpecs = signal<SourceSpec[]>([]);
-  readonly detection = signal<MediaTypeDetectionResponse | null>(null);
+  readonly detection = signal<DetectMediaTypeResponse | null>(null);
 
   /** Whether the inline server-filesystem folder browser is expanded. */
   browserOpen = false;

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/media-type.util.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/media-type.util.spec.ts
@@ -68,7 +68,7 @@ describe('media-type.util', () => {
   });
 
   it('detectionHint describes a single-type detection', () => {
-    const hint = detectionHint(mediaTypes, { sample_size: 2, counts_by_type: { audio: 2 }, extensions: {}, dominant: 'audio' });
+    const hint = detectionHint(mediaTypes, { sample_size: 2, counts_by_type: { audio: 2 }, extensions: {}, dominant: 'audio', truncated: false });
     expect(hint).toBe('Detected: Audio (2 of 2 files)');
   });
 
@@ -78,13 +78,14 @@ describe('media-type.util', () => {
       counts_by_type: { audio: 2, image: 1 },
       extensions: {},
       dominant: 'audio',
+      truncated: false,
     });
     expect(hint).toBe('Detected: Audio (2) + Image (1) of 3 files');
   });
 
   it('detectionHint is empty for a null or empty detection', () => {
     expect(detectionHint(mediaTypes, null)).toBe('');
-    expect(detectionHint(mediaTypes, { sample_size: 0, counts_by_type: {}, extensions: {}, dominant: null })).toBe('');
+    expect(detectionHint(mediaTypes, { sample_size: 0, counts_by_type: {}, extensions: {}, dominant: null, truncated: false })).toBe('');
   });
 
   it('availableConvertersFor reads the importer registry map', () => {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/media-type.util.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/media-type.util.ts
@@ -1,4 +1,4 @@
-import { ConverterInfo, ImporterInfo, MediaTypeDetectionResponse, MediaTypeInfo, SourceSpec } from '../../../../../models/api.models';
+import { ConverterInfo, ImporterInfo, DetectMediaTypeResponse, MediaTypeInfo, SourceSpec } from '../../../../../models/api.models';
 
 /** Pure helpers for translating between the media-type registry's two
  *  addressing schemes - ``type_id`` (canonical, e.g. ``"image"``) and
@@ -80,7 +80,7 @@ function extensionToTypeId(mediaTypes: MediaTypeInfo[]): Map<string, string> {
 }
 
 /** Count media types in a browser-side ``File[]`` and shape the result
- *  like :type:`MediaTypeDetectionResponse` so the rest of the modal can
+ *  like :type:`DetectMediaTypeResponse` so the rest of the modal can
  *  treat local- and server-side detections identically.
  *
  *  When ``recursive`` is ``false`` files whose ``webkitRelativePath``
@@ -91,7 +91,7 @@ export function detectFromFiles(
   files: File[],
   recursive: boolean,
   limit = 50,
-): MediaTypeDetectionResponse {
+): DetectMediaTypeResponse {
   const extMap = extensionToTypeId(mediaTypes);
   const countsByType: Record<string, number> = {};
   const extensions: Record<string, number> = {};
@@ -120,14 +120,17 @@ export function detectFromFiles(
       dominant = typeId;
     }
   }
-  return { sample_size: examined, counts_by_type: countsByType, extensions, dominant };
+  // ``truncated`` reports the server walk giving up on its directory-count or
+  // wall-clock budget *before* reaching the file cap. Stopping at ``limit`` is
+  // the cap doing its job, not a truncated sample, so this is always false.
+  return { sample_size: examined, counts_by_type: countsByType, extensions, dominant, truncated: false };
 }
 
 /** Human-readable description of a detection result, suitable for a hint
  *  chip next to the media-type dropdown. */
 export function detectionHint(
   mediaTypes: MediaTypeInfo[],
-  detection: MediaTypeDetectionResponse | null,
+  detection: DetectMediaTypeResponse | null,
 ): string {
   if (!detection || detection.sample_size === 0) return '';
   const entries = Object.entries(detection.counts_by_type)
@@ -158,7 +161,7 @@ export function detectionHint(
  *  the caller decides which view's state to update. */
 export function autofillFromDetection(
   mediaTypes: MediaTypeInfo[],
-  detection: MediaTypeDetectionResponse,
+  detection: DetectMediaTypeResponse,
   availableOptions: string[],
   convertersForType: (outputTypeId: string) => ConverterInfo[],
 ): { mediaType: string | null; sourceSpecs: SourceSpec[] | null } {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -20,7 +20,7 @@ import {
 } from '../../../services/embedder-capability.service';
 import { MediaStateService } from '../../../services/media-state.service';
 import {
-  FieldOption,
+  FieldOptions,
   ImporterField,
   ImporterInfo,
   ImporterPickerTab,
@@ -232,7 +232,7 @@ export class NewDetectorModalComponent implements OnInit {
   // depends_on / allow_free_text render with full parity here too. Keyed by
   // field key; signalized so the unpatched HTTP callbacks schedule CD under
   // zoneless. See docs/plans/zoneless-migration.md.
-  readonly labelImporterDynamicOptions = signal<Record<string, FieldOption[]>>({});
+  readonly labelImporterDynamicOptions = signal<Record<string, FieldOptions[]>>({});
   readonly labelImporterDynamicLoading = signal<Record<string, boolean>>({});
   readonly labelImporterDynamicError = signal<Record<string, string>>({});
 
@@ -1023,7 +1023,7 @@ export class NewDetectorModalComponent implements OnInit {
   /** Options to render for a label-importer field: the dynamically-fetched
    *  list for a ``dynamic_options`` field, else the static strings coerced
    *  into ``{value,label}`` pairs. */
-  labelImporterOptionsFor(field: ImporterField): FieldOption[] {
+  labelImporterOptionsFor(field: ImporterField): FieldOptions[] {
     if (field.dynamic_options) {
       return this.labelImporterDynamicOptions()[field.key] || [];
     }
@@ -1040,7 +1040,7 @@ export class NewDetectorModalComponent implements OnInit {
       .getFieldOptions(importer.name, key, { ...this.labelImporterValues })
       .subscribe({
         next: (res) => {
-          const options: FieldOption[] = res.options || [];
+          const options: FieldOptions[] = res.options || [];
           this.labelImporterDynamicOptions.update((m) => ({ ...m, [key]: options }));
           this.labelImporterDynamicLoading.update((m) => ({ ...m, [key]: false }));
           const current = this.labelImporterValues[key];

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -21,7 +21,7 @@ import { LabelImportersApiService } from '../../../services/label-importers-api.
 import { MediasApiService } from '../../../services/medias-api.service';
 import { ProgressEventsService } from '../../../services/progress-events.service';
 import { VoteStateService } from '../../../services/vote-state.service';
-import { FieldOption, ImporterField, LoadingTask } from '../../../models/api.models';
+import { FieldOptions, ImporterField, LoadingTask } from '../../../models/api.models';
 import type { LabelImporterEntry } from '../../../generated/api-client/models/label-importer-entry';
 import { apiErrorMessage } from '../../../utils/api-error';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
@@ -95,7 +95,7 @@ export class LabelImporterModalComponent implements OnDestroy {
       (this.importersResource.error() ? 'Failed to load label importers' : ''),
   );
   readonly successMessage = signal('');
-  readonly dynamicFieldOptions = signal<Record<string, FieldOption[]>>({});
+  readonly dynamicFieldOptions = signal<Record<string, FieldOptions[]>>({});
   readonly dynamicFieldLoading = signal<Record<string, boolean>>({});
   readonly dynamicFieldError = signal<Record<string, string>>({});
   readonly addingGood = signal(false);
@@ -164,7 +164,7 @@ export class LabelImporterModalComponent implements OnDestroy {
     }
   }
 
-  optionsFor(field: ImporterField): FieldOption[] {
+  optionsFor(field: ImporterField): FieldOptions[] {
     if (field.dynamic_options) {
       return this.dynamicFieldOptions()[field.key] || [];
     }
@@ -182,7 +182,7 @@ export class LabelImporterModalComponent implements OnDestroy {
       .getFieldOptions(importer.name, key, { ...this.formValues })
       .subscribe({
         next: (res) => {
-          const options: FieldOption[] = res.options || [];
+          const options: FieldOptions[] = res.options || [];
           this.dynamicFieldOptions.update((m) => ({ ...m, [key]: options }));
           this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
           const current = this.formValues[key];

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -8,9 +8,9 @@ import { ChartsService } from '../../../services/charts.service';
 import { SettingsStateService } from '../../../services/settings-state.service';
 import { ProgressEventsService } from '../../../services/progress-events.service';
 import {
-  ErrorCostDataPoint,
-  StabilityDataPoint,
-  DiversityDataPoint,
+  ErrorCostPoint,
+  StabilityPoint,
+  DiversityPoint,
 } from '../../../models/api.models';
 import type { EvalTrainAndScoreResponse } from '../../../generated/api-client/models/eval-train-and-score-response';
 
@@ -38,7 +38,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
 
   analyzing = true;
   analysisProgress = 0;
-  chartData: ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[] = [];
+  chartData: ErrorCostPoint[] | StabilityPoint[] | DiversityPoint[] = [];
   emptyHistory = false;
   /** True once we've fallen back to the async train-and-score job, which
    *  swaps the brief "loading" line for a real progress bar + Cancel. */
@@ -90,7 +90,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
             return;
           }
           this.analyzing = false;
-          this.chartData = (res.history || []) as ErrorCostDataPoint[] | StabilityDataPoint[] | DiversityDataPoint[];
+          this.chartData = (res.history || []) as ErrorCostPoint[] | StabilityPoint[] | DiversityPoint[];
           this.emptyHistory = this.chartData.length === 0;
           if (!this.emptyHistory) {
             setTimeout(() => this.renderChart(), 50);
@@ -200,11 +200,11 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     this.analyzing = false;
     this.runningJob = false;
     if (this.metric() === 'smart') {
-      this.chartData = (res.error_cost || []) as ErrorCostDataPoint[];
+      this.chartData = (res.error_cost || []) as ErrorCostPoint[];
     } else if (this.metric() === 'stable') {
-      this.chartData = (res.stability || []) as StabilityDataPoint[];
+      this.chartData = (res.stability || []) as StabilityPoint[];
     } else {
-      this.chartData = (res.diversity || []) as DiversityDataPoint[];
+      this.chartData = (res.diversity || []) as DiversityPoint[];
     }
     // Same empty-state handling as the cached path: a job that legitimately
     // produces no points (too little history) shows the explanatory message
@@ -221,15 +221,15 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     const canvas = chartCanvas.nativeElement;
     switch (this.metric()) {
       case 'smart':
-        this.chartsService.renderErrorCostChart(canvas, this.chartData as ErrorCostDataPoint[]);
+        this.chartsService.renderErrorCostChart(canvas, this.chartData as ErrorCostPoint[]);
         break;
       case 'stable':
-        this.chartsService.renderStabilityChart(canvas, this.chartData as StabilityDataPoint[]);
+        this.chartsService.renderStabilityChart(canvas, this.chartData as StabilityPoint[]);
         break;
       case 'diverse':
         this.chartsService.renderDiversityChart(
           canvas,
-          this.chartData as DiversityDataPoint[],
+          this.chartData as DiversityPoint[],
           this.settingsState.settingsSignal()?.autopilot_goal_diversity ?? 40,
         );
         break;

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
@@ -208,7 +208,12 @@ describe('AutoFindSettingsComponent', () => {
     expect(component.inputType({ field_type: 'email' } as ImporterField)).toBe('email');
     expect(component.inputType({ field_type: 'url' } as ImporterField)).toBe('url');
     expect(component.inputType({ field_type: 'text' } as ImporterField)).toBe('text');
-    expect(component.inputType({ field_type: 'anything-else' } as ImporterField)).toBe('text');
+    // Double cast on purpose: `field_type` is a closed union in the generated
+    // model, so this stands in for a *future* backend field type the frontend
+    // doesn't map yet — which must still fall back to a plain text input.
+    expect(component.inputType({ field_type: 'anything-else' } as unknown as ImporterField)).toBe(
+      'text',
+    );
   });
 
   it('emits a cloned field-value map so the parent cannot mutate the working copy', async () => {

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -1,15 +1,39 @@
-/* TypeScript interfaces matching the Flask API response shapes. */
+/* TypeScript interfaces matching the Flask API response shapes.
+ *
+ * Everything the backend describes in its OpenAPI schemas is re-exported
+ * from `../generated/api-client` rather than mirrored by hand, so a backend
+ * field rename breaks this build instead of silently reaching runtime.  What
+ * remains hand-written below is exactly what the spec cannot describe:
+ *
+ * - **SSE payloads** (`ProgressEvent`, `LoadingTask`,
+ *   `VotingIterationsResponse`) arrive over `/api/events`, a raw streaming
+ *   `Response` that flask-smorest does not model.
+ * - **Client-side shapes** (`PayloadVariant`, `AutoDetectResultsData`'s
+ *   Find-mode fields) that no endpoint returns.
+ * - **Request-side settings shapes** (`SourceSpec`, `ImportDefaults*`,
+ *   `CleanerSelection`) the frontend builds and posts.
+ */
 
 import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
 import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
-import type { ConverterInfo as GeneratedConverterInfo } from '../generated/api-client/models/converter-info';
 
-// These three plugin-metadata shapes now have generated OpenAPI models
-// (their `to_dict()` payloads are fixed across plugins), so re-export the
-// generated types instead of hand-maintaining a mirror. See
-// `vtsearch/schemas/datasets.py`.
+// Plugin-metadata and listing payloads, all described by nested Marshmallow
+// schemas in `vtsearch/schemas/datasets.py` and `vtsearch/schemas/eval.py`.
 export type { EmbedderInfo } from '../generated/api-client/models/embedder-info';
 export type { MediaTypeInfo } from '../generated/api-client/models/media-type-info';
+export type { ConverterInfo } from '../generated/api-client/models/converter-info';
+export type { ImporterInfo } from '../generated/api-client/models/importer-info';
+export type { ImporterField } from '../generated/api-client/models/importer-field';
+export type { ImporterPickerTab } from '../generated/api-client/models/importer-picker-tab';
+export type { ClipperInfo } from '../generated/api-client/models/clipper-info';
+export type { ClipperParameter } from '../generated/api-client/models/clipper-parameter';
+export type { CleanerInfo } from '../generated/api-client/models/cleaner-info';
+export type { DatasetRegistryEntry } from '../generated/api-client/models/dataset-registry-entry';
+export type { DetectMediaTypeResponse } from '../generated/api-client/models/detect-media-type-response';
+export type { FieldOptions } from '../generated/api-client/models/field-options';
+export type { ErrorCostPoint } from '../generated/api-client/models/error-cost-point';
+export type { StabilityPoint } from '../generated/api-client/models/stability-point';
+export type { DiversityPoint } from '../generated/api-client/models/diversity-point';
 
 // --- Medias ---
 
@@ -109,44 +133,6 @@ export interface LoadingTask extends ProgressEvent {
   embedder?: string;
 }
 
-export interface ImporterInfo {
-  name: string;
-  display_name?: string;
-  description?: string;
-  icon?: string;
-  fields?: ImporterField[];
-  ui_mode?: string;
-  /** Which view the dataset-importer modal opens for this card.
-   *  ``"form"`` (default), ``"demo"``, ``"server_folder"``, ``"local_folder"``,
-   *  or ``"local_files"``. */
-  picker_view?: string;
-  hidden_from_picker?: boolean;
-  /** Picker tab this importer belongs to.  One of ``"services"``,
-   *  ``"server"``, ``"local"``, ``"demo"``, or ``""`` (uncategorised). */
-  category?: string;
-  /** Map of output media-type id → converters whose ``target_type``
-   *  matches that id.  Drives the "Include rows" UI without an extra
-   *  round-trip to ``/api/converters``. */
-  available_converters_by_media_type?: Record<string, ConverterInfo[]>;
-  [key: string]: unknown;
-}
-
-/**
- * A converter's ``to_dict()`` payload. Derived from the generated OpenAPI
- * model, overriding only ``fields`` to carry the richer ``ImporterField[]``
- * type (the backend schema keeps that list opaque; the ``ImporterField``
- * shape is out of the generated model's scope).
- *
- * The generated model's ``summary_template`` is a one-line preview with
- * ``{key}`` placeholders for each field: the importer modal renders it next
- * to the source-spec row, substituting the current field values, so the user
- * sees a live summary of what the converter will do. Falls back to
- * ``description`` when empty.
- */
-export type ConverterInfo = Omit<GeneratedConverterInfo, 'fields'> & {
-  fields?: ImporterField[];
-};
-
 /** One row of a multi-media import specification.  See
  *  ``docs/EXTENDING-media.md``. */
 export interface SourceSpec {
@@ -172,138 +158,7 @@ export interface ImportDefaultsForMediaType {
 }
 export type ImportDefaultsByMediaType = Record<string, ImportDefaultsForMediaType>;
 
-/** A single dropdown option for a dynamic-options field.  ``value`` is
- *  what the form submits; ``label`` is the friendly text shown in the
- *  dropdown.  They coincide for plain-string options and differ for
- *  ``(value, label)`` tuple options (submit an opaque id, show a name). */
-export interface FieldOption {
-  value: string;
-  label: string;
-}
-
-export interface ImporterField {
-  key: string;
-  field_type: string;
-  label?: string;
-  description?: string;
-  accept?: string;
-  options?: string[];
-  default?: string;
-  required?: boolean;
-  placeholder?: string;
-  /** Inline format-hint text rendered as a visible chip below the input.
-   *  Distinct from ``description`` (which feeds the placeholder): the hint
-   *  stays visible after the user starts typing, so it's the right place
-   *  for accepted file extensions, expected schemas, or a short sample of
-   *  the file layout. */
-  hint?: string;
-  /** When true, ``options`` is computed at runtime by calling
-   *  ``POST /api/dataset/import/<importer>/options`` with the current
-   *  field values.  The frontend re-fetches whenever any field listed in
-   *  ``depends_on`` changes. */
-  dynamic_options?: boolean;
-  /** Field keys whose values this field's options depend on. */
-  depends_on?: string[];
-  /** For ``select`` fields: when true, render as a combobox the user can
-   *  type an arbitrary value into (even one the option list omits).  When
-   *  the options refresh, a typed value absent from the new list is kept;
-   *  a strict select clears it. */
-  allow_free_text?: boolean;
-  /** For ``number`` fields: minimum allowed value (empty = no min). */
-  min?: string;
-  /** For ``number`` fields: maximum allowed value (empty = no max). */
-  max?: string;
-  /** For ``number`` fields: step increment (empty / ``"any"`` = unconstrained). */
-  step?: string;
-  /** Field keys this field is mutually exclusive with.  Entering a
-   *  non-empty value here blanks each listed field (and they list this
-   *  one back), so only one of the set is ever active at a time. */
-  clears?: string[];
-}
-
-export interface ImporterPickerTab {
-  id: string;
-  label: string;
-  icon?: string;
-  order?: number;
-}
-
-export interface MediaTypeDetectionResponse {
-  sample_size: number;
-  counts_by_type: Record<string, number>;
-  extensions: Record<string, number>;
-  dominant: string | null;
-  /** ``true`` when the backend stopped walking before reaching the file
-   *  cap because the directory-count cap or wall-clock budget fired.  The
-   *  rest of the response is still meaningful; it's just a less complete
-   *  sample than usual. */
-  truncated?: boolean;
-}
-
-export interface DatasetRegistryEntry {
-  id: string;
-  name: string;
-  media_type: string;
-  loaded?: boolean;
-  readers?: string[];
-  /** Name of the embedder this dataset's media were vectorised with. */
-  embedder?: string;
-  /** The embedder *types* this dataset supplies ("semantic" / "patch_semantic"
-   *  / "structural"); a v3 trio dataset can supply several. Drives the
-   *  detector/dataset compatibility gate. */
-  embedder_types?: string[];
-  /** Every concrete embedder this dataset binds (primary first). */
-  bound_embedders?: string[];
-  /** One concrete embedder per type it binds, e.g.
-   *  `{ semantic: "siglip", patch_semantic: "dinov3_patch" }`. Drives the
-   *  Combine-Datasets conflict detector. */
-  embedders_by_type?: Record<string, string>;
-  /** Unix timestamp (seconds) at which this dataset ages off and is
-   *  automatically removed; `null`/absent means it never expires. */
-  expires_at?: number | null;
-  [key: string]: unknown;
-}
-
-// --- Clippers ---
-
-export interface ClipperParameter {
-  key: string;
-  label: string;
-  description?: string;
-  type: 'number' | 'string';
-  default: number | string;
-  min?: number;
-  max?: number;
-  step?: number;
-}
-
-export interface ClipperInfo {
-  name: string;
-  display_name?: string;
-  description?: string;
-  /** One-line preview with ``{key}`` placeholders for each parameter.  The
-   *  native row of the importer source-specs picker substitutes the current
-   *  parameter values, so the user sees a live summary of what the clipper
-   *  will do.  Falls back to ``description`` when empty. */
-  summary_template?: string;
-  media_type: string;
-  parameters?: ClipperParameter[];
-  creation_questions?: ClipperParameter[];
-  [key: string]: unknown;
-}
-
 // --- Cleaners ---
-
-/** One optional 1-to-1 cleanup gate items pass through before embedding.
- *  Shares the clipper descriptor shape (see `MediaCleaner`, which subclasses
- *  `MediaClipper`) and adds `default_enabled`: the import form pre-checks a
- *  cleaner's box when it is true. */
-export interface CleanerInfo extends ClipperInfo {
-  /** Whether the import form checks this cleaner by default.  True only for
-   *  cleaners that fix an outright representation bug (EXIF orientation),
-   *  where leaving it off ships known-wrong vectors. */
-  default_enabled?: boolean;
-}
 
 /** A cleaner the user enabled for an import, with its parameter overrides.
  *  Serialised as the `cleaners` field of every import request. */
@@ -319,22 +174,6 @@ export interface CleanerSelection {
 export type PayloadVariant = '' | 'original';
 
 // --- Eval / Progress Charts ---
-
-export interface ErrorCostDataPoint {
-  num_labels: number;
-  error_cost: number;
-}
-
-export interface StabilityDataPoint {
-  num_labels: number;
-  num_flips: number;
-}
-
-export interface DiversityDataPoint {
-  num_labels: number;
-  diversity_level: number;
-  depth: number;
-}
 
 export interface VotingIterationsResponse {
   progress: number;

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -16,6 +16,10 @@
 
 import type { MediaIdsListResponse } from '../generated/api-client/models/media-ids-list-response';
 import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+import type { AutoDetectResult } from '../generated/api-client/models/auto-detect-result';
+import type { AutoFindExportStatus } from '../generated/api-client/models/auto-find-export-status';
+import type { FindResultRow } from '../generated/api-client/models/find-result-row';
+import type { Hit } from '../generated/api-client/models/hit';
 
 // Plugin-metadata and listing payloads, all described by nested Marshmallow
 // schemas in `vtsearch/schemas/datasets.py` and `vtsearch/schemas/eval.py`.
@@ -38,16 +42,6 @@ export type { DiversityPoint } from '../generated/api-client/models/diversity-po
 // --- Medias ---
 
 /**
- * Strip a type's catch-all index signature (``[key: string]: any``) so
- * intersecting it with another type doesn't force every property access
- * to go through the bracket form (TS4111 under
- * ``noPropertyAccessFromIndexSignature``).
- */
-type RemoveIndex<T> = {
-  [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K];
-};
-
-/**
  * The renderable media shape: a stub from ``GET /api/medias/ids``
  * (``id``, ``type``, optional ``embedder``) optionally augmented with the
  * full per-item metadata returned by ``POST /api/medias/batch``
@@ -59,7 +53,7 @@ type RemoveIndex<T> = {
  * cache miss) or a hydrated batch entry.
  */
 export type Media = MediaIdsListResponse &
-  Partial<Omit<RemoveIndex<MediaBatchResponse>, keyof MediaIdsListResponse>>;
+  Partial<Omit<MediaBatchResponse, keyof MediaIdsListResponse>>;
 
 // --- Progress ---
 
@@ -184,35 +178,40 @@ export interface VotingIterationsResponse {
 
 // --- Auto-detect Results ---
 
-export interface AutoDetectHit {
-  md5: string;
-  filename?: string;
-  origin_name?: string;
-  origin?: {
-    importer?: string;
-    params?: Record<string, string>;
-  };
-  label?: string;
-  [key: string]: unknown;
-}
+export type { AutoFindExportStatus } from '../generated/api-client/models/auto-find-export-status';
 
-export interface AutoDetectDetectorResult {
+/**
+ * One row of the Auto-Find results table.
+ *
+ * The table is fed from two endpoints with different guarantees: `Hit` from
+ * `POST /api/auto-detect`, and `FindResultRow` from `POST /api/find` (adapted
+ * into this shape by `dashboard.component.ts`). Every field is therefore
+ * optional — but the *names and types* still come from the generated models,
+ * so a backend rename breaks the template that renders the column.
+ *
+ * `label` is the exception: the modal stamps it client-side when showing the
+ * good and bad sides in one list.
+ */
+export type AutoDetectHit = Partial<Hit> &
+  Partial<Pick<FindResultRow, 'dataset_name' | 'detector_verdicts'>> & {
+    /** `'good'` / `'bad'`, set by the modal when both sides share one list. */
+    label?: string;
+  };
+
+/** One detector's column of results, from either source (see `AutoDetectHit`). */
+export type AutoDetectDetectorResult = Partial<
+  Omit<AutoDetectResult, 'hits' | 'negative_hits'>
+> & {
   hits: AutoDetectHit[];
   negative_hits?: AutoDetectHit[];
-  total_hits?: number;
-  [key: string]: unknown;
-}
+};
 
-/** Outcome of auto-exporting Auto-Find results, present on the auto-detect
- *  response only when a results exporter is configured in settings. */
-export interface AutoFindExportStatus {
-  exporter: string;
-  success: boolean;
-  message?: string;
-  error?: string;
-  [key: string]: unknown;
-}
-
+/**
+ * What the Auto-Find results modal renders: the `POST /api/auto-detect`
+ * response, or the `POST /api/find` response adapted to look like one. Find
+ * mode contributes the four `detectors`/`datasets` fields, which no endpoint
+ * returns under these names.
+ */
 export interface AutoDetectResultsData {
   media_type?: string;
   detectors_run?: string | number;
@@ -226,7 +225,5 @@ export interface AutoDetectResultsData {
   datasets?: string[];
   multiple_datasets?: boolean;
   multiple_detectors?: boolean;
-  [key: string]: unknown;
 }
-
 

--- a/frontend/src/app/services/charts.service.ts
+++ b/frontend/src/app/services/charts.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import {
-  ErrorCostDataPoint,
-  StabilityDataPoint,
-  DiversityDataPoint,
+  ErrorCostPoint,
+  StabilityPoint,
+  DiversityPoint,
 } from '../models/api.models';
 
 interface ChartPadding {
@@ -117,7 +117,7 @@ export class ChartsService {
     ctx.fillText('No data available', 20, height / 2);
   }
 
-  renderErrorCostChart(canvas: HTMLCanvasElement, data: ErrorCostDataPoint[]): void {
+  renderErrorCostChart(canvas: HTMLCanvasElement, data: ErrorCostPoint[]): void {
     const ctx = canvas.getContext('2d')!;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     const palette = this.resolvePalette();
@@ -167,7 +167,7 @@ export class ChartsService {
     ctx.fillText(minCost.toFixed(2), left - 5, top + chartHeight + 5);
   }
 
-  renderStabilityChart(canvas: HTMLCanvasElement, data: StabilityDataPoint[]): void {
+  renderStabilityChart(canvas: HTMLCanvasElement, data: StabilityPoint[]): void {
     const ctx = canvas.getContext('2d')!;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     const palette = this.resolvePalette();
@@ -215,7 +215,7 @@ export class ChartsService {
     ctx.fillText('0', left - 5, top + chartHeight + 5);
   }
 
-  renderDiversityChart(canvas: HTMLCanvasElement, data: DiversityDataPoint[], goalDiversity = 40): void {
+  renderDiversityChart(canvas: HTMLCanvasElement, data: DiversityPoint[], goalDiversity = 40): void {
     const ctx = canvas.getContext('2d')!;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     const palette = this.resolvePalette();

--- a/frontend/src/app/services/dataset-state.service.ts
+++ b/frontend/src/app/services/dataset-state.service.ts
@@ -68,9 +68,7 @@ export class DatasetStateService implements OnDestroy {
             if (!this._loaded()) this._loaded.set(true);
             return;
           }
-          this._datasets.set(
-            (res.datasets.datasets || []) as unknown as DatasetRegistryEntry[],
-          );
+          this._datasets.set(res.datasets.datasets || []);
           this._detectors.set(res.detectors.detectors || []);
           if (this._error() !== null) this._error.set(null);
           if (!this._loaded()) this._loaded.set(true);

--- a/frontend/src/app/services/datasets-crud-api.service.ts
+++ b/frontend/src/app/services/datasets-crud-api.service.ts
@@ -36,14 +36,8 @@ import { loadDatasetFromSource } from '../generated/api-client/fn/datasets-load/
 import { loadDemoDatasetRoute } from '../generated/api-client/fn/datasets-load/load-demo-dataset-route';
 import { stageDemo } from '../generated/api-client/fn/datasets-staging/stage-demo';
 
-/** The importer/clipper/embedder/converter listings return plugin
- *  ``to_dict()`` payloads; the generated types describe them as
- *  ``Array<{[key: string]: any}>`` because the inner shapes are
- *  plugin-dependent.  The richer ``ImporterInfo`` / ``ClipperInfo`` /
- *  ``EmbedderInfo`` / ``ConverterInfo`` interfaces in
- *  ``frontend/src/app/models/api.models.ts`` describe the actual fields
- *  consumers read off these payloads; this service casts at the boundary
- *  so callers don't have to. */
+/** ``GET /api/dataset/importers`` omits ``tabs``; ``/all-importers`` includes
+ *  it.  One union type lets both callers share the picker code. */
 type ImportersResponse = { importers: ImporterInfo[]; tabs?: ImporterPickerTab[] };
 
 /** Dataset CRUD: importer listings, import, stage, clear, export,
@@ -55,15 +49,11 @@ export class DatasetsCrudApiService {
   private config = inject(ApiConfiguration);
 
   getImporters(): Observable<ImportersResponse> {
-    return datasetImporters(this.http, this.config.rootUrl).pipe(
-      map((r) => r.body as unknown as ImportersResponse),
-    );
+    return datasetImporters(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   getAllImporters(): Observable<ImportersResponse> {
-    return datasetAllImporters(this.http, this.config.rootUrl).pipe(
-      map((r) => r.body as unknown as ImportersResponse),
-    );
+    return datasetAllImporters(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   /** Best-effort media-type hint for a picked folder. A 404 here is an

--- a/frontend/src/app/services/datasets-listings-api.service.ts
+++ b/frontend/src/app/services/datasets-listings-api.service.ts
@@ -21,25 +21,23 @@ import { demoDatasetList } from '../generated/api-client/fn/datasets-ui/demo-dat
 import { embeddersList } from '../generated/api-client/fn/datasets-listings/embedders-list';
 import { mediaTypesList } from '../generated/api-client/fn/datasets-listings/media-types-list';
 
-/** Plugin / media-type listings used by import-config widgets,
- *  settings panels, and the demo dataset picker.  Each listing returns
- *  plugin ``to_dict()`` payloads cast at the boundary to the richer
- *  ``ClipperInfo`` / ``EmbedderInfo`` / ``ConverterInfo`` /
- *  ``MediaTypeInfo`` interfaces in ``frontend/src/app/models/api.models.ts``. */
+/** Plugin / media-type listings used by import-config widgets, settings
+ *  panels, and the demo dataset picker.  Every payload here is described by a
+ *  nested Marshmallow schema in ``vtsearch/schemas/datasets.py``, so the
+ *  generated models are the real types and nothing is cast at the boundary:
+ *  a backend field rename fails this build. */
 @Injectable({ providedIn: 'root' })
 export class DatasetsListingsApiService {
   private http = inject(HttpClient);
   private config = inject(ApiConfiguration);
 
   getMediaTypes(): Observable<{ media_types: MediaTypeInfo[] }> {
-    return mediaTypesList(this.http, this.config.rootUrl).pipe(
-      map((r) => r.body as unknown as { media_types: MediaTypeInfo[] }),
-    );
+    return mediaTypesList(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   getClippers(mediaType?: string): Observable<ClipperInfo[]> {
     return clippersList(this.http, this.config.rootUrl, { media_type: mediaType }).pipe(
-      map((r) => r.body.clippers as unknown as ClipperInfo[]),
+      map((r) => r.body.clippers),
     );
   }
 
@@ -48,25 +46,25 @@ export class DatasetsListingsApiService {
    *  one checkbox per entry, pre-checked when `default_enabled` is set. */
   getCleaners(mediaType?: string): Observable<CleanerInfo[]> {
     return cleanersList(this.http, this.config.rootUrl, { media_type: mediaType }).pipe(
-      map((r) => r.body.cleaners as unknown as CleanerInfo[]),
+      map((r) => r.body.cleaners),
     );
   }
 
   getEmbedders(mediaType?: string): Observable<EmbedderInfo[]> {
     return embeddersList(this.http, this.config.rootUrl, { media_type: mediaType }).pipe(
-      map((r) => r.body.embedders as unknown as EmbedderInfo[]),
+      map((r) => r.body.embedders),
     );
   }
 
   getConverters(target?: string): Observable<ConverterInfo[]> {
     return convertersList(this.http, this.config.rootUrl, { target }).pipe(
-      map((r) => r.body.converters as unknown as ConverterInfo[]),
+      map((r) => r.body.converters),
     );
   }
 
   getConvertersForSource(source: string): Observable<ConverterInfo[]> {
     return convertersList(this.http, this.config.rootUrl, { source }).pipe(
-      map((r) => r.body.converters as unknown as ConverterInfo[]),
+      map((r) => r.body.converters),
     );
   }
 

--- a/frontend/src/app/services/label-importers-api.service.ts
+++ b/frontend/src/app/services/label-importers-api.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
-import type { FieldOption } from '../models/api.models';
+import type { FieldOptions } from '../models/api.models';
 import type { LabelImporterEntry } from '../generated/api-client/models/label-importer-entry';
 import type { IngestMissingResponse } from '../generated/api-client/models/ingest-missing-response';
 import { getLabelImporters } from '../generated/api-client/fn/label-importers/get-label-importers';
@@ -60,8 +60,8 @@ export class LabelImportersApiService {
     return this.http.post(url, params);
   }
 
-  getFieldOptions(importerName: string, fieldKey: string, values: Record<string, string>): Observable<{ options: FieldOption[] }> {
-    return this.http.post<{ options: FieldOption[] }>(
+  getFieldOptions(importerName: string, fieldKey: string, values: Record<string, string>): Observable<{ options: FieldOptions[] }> {
+    return this.http.post<{ options: FieldOptions[] }>(
       `/api/label-importers/field-options/${encodeURIComponent(importerName)}`,
       { field_key: fieldKey, values },
     );

--- a/frontend/src/app/utils/managed-columns.ts
+++ b/frontend/src/app/utils/managed-columns.ts
@@ -358,3 +358,27 @@ export class ManagedColumns<TCol extends string = string> {
     return this.dragCol === col;
   }
 }
+
+/**
+ * Sort *rows* by the value of the column named `column`.
+ *
+ * A table column id is not necessarily a field on the row objects: purely
+ * presentational columns (`actions`, `select`) have no value, and rows typed
+ * against a generated OpenAPI model expose only the fields the backend
+ * declares.  So the lookup is deliberately widened to a `Record` here rather
+ * than each caller's row type carrying a catch-all index signature — the
+ * index signature is what used to hide backend/frontend schema drift.
+ *
+ * Numbers compare numerically; everything else compares as a locale string,
+ * with a missing value sorting as `''`.
+ */
+export function sortRowsByColumn<T>(rows: readonly T[], column: string, asc: boolean): T[] {
+  const dir = asc ? 1 : -1;
+  const valueAt = (row: T): unknown => (row as Record<string, unknown>)[column];
+  return [...rows].sort((a, b) => {
+    const va = valueAt(a) ?? '';
+    const vb = valueAt(b) ?? '';
+    if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * dir;
+    return String(va).localeCompare(String(vb)) * dir;
+  });
+}

--- a/tests/detectors/test_find_label.py
+++ b/tests/detectors/test_find_label.py
@@ -247,6 +247,59 @@ class TestAutoDetect:
         assert "negative_hits" in result
         assert len(result["hits"]) + len(result["negative_hits"]) == app_module.NUM_MEDIAS
 
+    def test_autofind_hits_carry_the_media_fields_the_table_renders(self, client):
+        """Hits must carry the media fields the Auto-Find results table shows.
+
+        ``_HitSchema`` used to declare only ``id``/``score``, and a declared
+        marshmallow schema drops every undeclared key on dump (``unknown =
+        "include"`` is load-only), so the table's Origin / Name / MD5 /
+        Filename columns came back blank.
+        """
+        from vtsearch.settings import add_autofind_detector
+
+        snap = snapshot_medias()
+        setup_trainable_model_in_registry(
+            "auto-detect-fields",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snap,
+        )
+        add_autofind_detector("auto-detect-fields")
+
+        resp = client.post("/api/auto-detect", json={})
+        assert resp.status_code == 200, resp.get_json()
+        result = resp.get_json()["results"]["auto-detect-fields"]
+        hits = result["hits"] + result["negative_hits"]
+        assert hits, "expected at least one scored hit"
+        for hit in hits:
+            assert hit["md5"] == snap[hit["id"]]["md5"]
+            assert hit["filename"] == snap[hit["id"]]["filename"]
+
+    def test_autofind_hits_never_carry_vectors_or_bytes(self, client):
+        """The hit allowlist is what keeps embeddings off the wire.
+
+        Two independent layers have to hold: ``_media_info_for_response``
+        strips the heavyweight keys from the media dict, and ``_HitSchema``
+        serves only its declared fields.  Assert the observable outcome so
+        neither can regress into leaking a vector.
+        """
+        from vtsearch.settings import add_autofind_detector
+
+        setup_trainable_model_in_registry(
+            "auto-detect-no-vectors",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        add_autofind_detector("auto-detect-no-vectors")
+
+        resp = client.post("/api/auto-detect", json={})
+        assert resp.status_code == 200, resp.get_json()
+        result = resp.get_json()["results"]["auto-detect-no-vectors"]
+        for hit in result["hits"] + result["negative_hits"]:
+            for banned in ("embeddings", "embedding", "media_bytes", "media_string", "thumbnail_bytes"):
+                assert banned not in hit, f"{banned} leaked into an auto-detect hit"
+
     def test_autofind_filters_by_media_type(self, client):
         from vtsearch.settings import add_autofind_detector
 

--- a/vtsearch/openapi_postprocess.py
+++ b/vtsearch/openapi_postprocess.py
@@ -153,3 +153,46 @@ def assign_operation_ids(app: Flask, spec: dict[str, Any]) -> None:
     for name, op_keys in by_view.items():
         for (op_path, op_method), op_id in _operation_ids_for_view(name, op_keys).items():
             paths[op_path][op_method]["operationId"] = op_id
+
+
+def _is_apispec_null_branch(branch: Any) -> bool:
+    """True for the placeholder apispec adds to express "nullable $ref"."""
+    return branch == {"type": "object", "nullable": True}
+
+
+def collapse_nullable_refs(node: Any) -> None:
+    """Rewrite apispec's ``anyOf`` nullable-``$ref`` idiom into a plain ref.
+
+    OpenAPI 3.0 has no way to say "this ``$ref``, or null", so apispec renders
+    ``fields.Nested(X, allow_none=True)`` as::
+
+        {"anyOf": [{"type": "object", "nullable": true},
+                   {"$ref": "#/components/schemas/X"}]}
+
+    That untyped ``{"type": "object"}`` branch is pure noise, but ng-openapi-gen
+    takes it literally and emits ``X | {} | null``. The empty-object arm then
+    swallows every property access on the union, so consumers of a nullable
+    nested model lose exactly the typing the nested schema was added to give
+    them. Collapse the pair back to the ref (keeping ``nullable``), which is
+    what every generator reads as "X or null".
+
+    Only the exact two-branch shape apispec produces is touched; a genuine
+    hand-written ``anyOf`` is left alone.
+    """
+    if isinstance(node, dict):
+        branches = node.get("anyOf")
+        if (
+            isinstance(branches, list)
+            and len(branches) == 2
+            and sum(1 for b in branches if _is_apispec_null_branch(b)) == 1
+            and sum(1 for b in branches if isinstance(b, dict) and set(b) == {"$ref"}) == 1
+        ):
+            ref = next(b for b in branches if isinstance(b, dict) and set(b) == {"$ref"})
+            node.pop("anyOf")
+            node["nullable"] = True
+            node.update(ref)
+        for value in node.values():
+            collapse_nullable_refs(value)
+    elif isinstance(node, list):
+        for item in node:
+            collapse_nullable_refs(item)

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -19,6 +19,7 @@ from flask_smorest import Blueprint, abort
 from vtscore.concurrency.memory_budget import cap_workers_by_memory
 from vtscore.concurrency.progress import CancelledError, find_progress, update_find_progress
 from vtscore.detectors.model_loading import resolve_or_train_detector
+from vtscore.embedding.media_vectors import EMBEDDINGS_KEY
 from vtsearch.routes._shared import require_dataset_header, require_detector_header
 from vtsearch.schemas.detectors import (
     AutoDetectRequestSchema,
@@ -41,8 +42,17 @@ detector_scoring_bp = Blueprint(
     "or run every Auto-Find detector at once (auto-detect).",
 )
 
-# Keys excluded from API responses (large binary/vector data).
-_HEAVYWEIGHT_KEYS = ("embedding", "media_bytes", "media_string", "thumbnail_bytes")
+# Keys excluded from API responses (large binary/vector data).  ``embeddings``
+# is the v3 dict-keyed vector store (``vtscore/embedding/media_vectors.py``);
+# ``embedding`` is its dropped legacy singular form, kept here so a media dict
+# rehydrated from an old pickle can't leak one either.
+_HEAVYWEIGHT_KEYS = (
+    EMBEDDINGS_KEY,
+    "embedding",
+    "media_bytes",
+    "media_string",
+    "thumbnail_bytes",
+)
 
 
 def _detector_type(det_data: dict | None) -> str:

--- a/vtsearch/routes/processors/scoring.py
+++ b/vtsearch/routes/processors/scoring.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from flask_smorest import Blueprint, abort
 
 from vtscore.concurrency.memory_budget import cap_workers_by_memory
-from vtscore.embedding.media_vectors import media_embedding
+from vtscore.embedding.media_vectors import EMBEDDINGS_KEY, media_embedding
 from vtsearch.routes.processors.crud import _build_extractor, _build_localizer
 from vtsearch.schemas.processors import (
     AutoExtractResponseSchema,
@@ -33,8 +33,17 @@ processors_scoring_bp = Blueprint(
     description="Run extractors / localizers against the active dataset, either one-off or via autorun.",
 )
 
-# Keys excluded from API responses (large binary/vector data).
-_HEAVYWEIGHT_KEYS = ("embedding", "media_bytes", "media_string", "thumbnail_bytes")
+# Keys excluded from API responses (large binary/vector data).  ``embeddings``
+# is the v3 dict-keyed vector store (``vtscore/embedding/media_vectors.py``);
+# ``embedding`` is its dropped legacy singular form, kept here so a media dict
+# rehydrated from an old pickle can't leak one either.
+_HEAVYWEIGHT_KEYS = (
+    EMBEDDINGS_KEY,
+    "embedding",
+    "media_bytes",
+    "media_string",
+    "thumbnail_bytes",
+)
 
 
 def _media_info_for_response(media: dict) -> dict:

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -242,7 +242,9 @@ class ImporterFieldSchema(Schema):
     )
     label = fields.String()
     description = fields.String()
-    accept = fields.String(metadata={"description": 'For ``file`` fields: comma-separated extensions, e.g. ``".pkl"``.'})
+    accept = fields.String(
+        metadata={"description": 'For ``file`` fields: comma-separated extensions, e.g. ``".pkl"``.'}
+    )
     options = fields.List(
         fields.String(),
         metadata={
@@ -255,9 +257,7 @@ class ImporterFieldSchema(Schema):
     )
     default = fields.String()
     required = fields.Boolean()
-    placeholder = fields.String(
-        metadata={"description": "Hint shown as placeholder text inside the input widget."}
-    )
+    placeholder = fields.String(metadata={"description": "Hint shown as placeholder text inside the input widget."})
     hint = fields.String(
         metadata={
             "description": (
@@ -449,7 +449,7 @@ class ImporterInfoSchema(Schema):
     category = fields.String(
         metadata={
             "description": (
-                'Picker tab this importer belongs to. One of ``services``, ``server``, ``local``, ``demo``, '
+                "Picker tab this importer belongs to. One of ``services``, ``server``, ``local``, ``demo``, "
                 'or ``""`` (uncategorised).'
             )
         }
@@ -1045,12 +1045,14 @@ class DatasetRegistryEntrySchema(Schema):
             )
         }
     )
-    embedder = fields.String(metadata={"description": "Name of the embedder this dataset's media were vectorised with."})
+    embedder = fields.String(
+        metadata={"description": "Name of the embedder this dataset's media were vectorised with."}
+    )
     embedder_types = fields.List(
         fields.String(),
         metadata={
             "description": (
-                'The embedder *types* this dataset supplies (``semantic`` / ``patch_semantic`` / ``structural``); '
+                "The embedder *types* this dataset supplies (``semantic`` / ``patch_semantic`` / ``structural``); "
                 "a v3 trio dataset can supply several. Drives the detector/dataset compatibility gate."
             )
         },

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -7,23 +7,28 @@ modules (``load``, ``staging``, ``registry``) involve multipart upload,
 binary streaming, and plugin-field-shaped bodies and are migrated
 separately. See ``docs/plans/openapi-schema.md``.
 
-The ``to_dict()`` payloads split by whether the shape is fixed or
-plugin-variable:
+Every ``to_dict()`` payload here is enumerated as a nested schema so the
+generated OpenAPI client carries a real typed model and the frontend can
+delete its hand-written mirror.  Two flavours, depending on whether the
+plugin family can add keys of its own:
 
-* **Media types, embedders, converters** have a *fixed* key set across every
-  plugin (no subclass overrides ``to_dict``), so they are enumerated as
-  nested schemas (``MediaTypeInfoSchema``, ``EmbedderInfoSchema``,
-  ``ConverterInfoSchema``).  This gives the generated OpenAPI client a real
-  typed model, letting the frontend drop its hand-written mirror.
-* **Clippers and importers** stay opaque ``fields.Dict()``: concrete clippers
-  add their own keys (``duration``, ``top_db``, …) and the importer payload
-  nests plugin-field lists, so a nested schema would either lose keys or need
-  an escape hatch anyway.  Drift there is caught at the *plugin* layer.
+* **Media types, embedders, converters, importers, picker tabs, registry
+  entries** have a *fixed* key set (no subclass overrides ``to_dict``
+  beyond the documented base), so their schemas are strict: an undeclared
+  key is a bug, and dropping it on dump is the correct signal.
+* **Clippers and cleaners** genuinely vary — concrete clippers append their
+  own keys (``duration``, ``top_db``, ``box``, …) on top of the fixed base.
+  Their schemas enumerate the base and set ``unknown = INCLUDE`` plus a
+  :func:`~marshmallow.post_dump` passthrough, so the fixed fields get real
+  types while the plugin extras still reach the client verbatim.  The
+  generated model picks up an index signature from
+  ``additionalProperties: true``, which is exactly the shape the frontend
+  used to hand-maintain.
 """
 
 from __future__ import annotations
 
-from marshmallow import Schema, ValidationError, fields, validate
+from marshmallow import INCLUDE, Schema, ValidationError, fields, post_dump, validate
 
 from vtsearch.schemas.file_browser import BrowseDirectoryEntrySchema, BrowseFileEntrySchema
 
@@ -215,12 +220,103 @@ class EmbedderInfoSchema(Schema):
     )
 
 
+class ImporterFieldSchema(Schema):
+    """One ``PluginField.to_dict()`` payload (see ``vtscore/plugins/__init__.py``).
+
+    Shared by every plugin family that renders a form: dataset importers,
+    converters, label importers/exporters.  Fixed shape - ``PluginField`` is
+    a dataclass and ``to_dict`` emits all of its wire fields unconditionally.
+
+    Optionality mirrors what the frontend treats as optional rather than what
+    the backend always emits (same convention as
+    :class:`MediaTypeInfoSchema`): only ``key`` and ``field_type`` are the
+    fields a consumer can never do without.
+    """
+
+    key = fields.String(required=True)
+    field_type = fields.String(
+        required=True,
+        validate=validate.OneOf(
+            ["file", "folder", "url", "text", "password", "email", "number", "select", "server_path", "checkbox"]
+        ),
+    )
+    label = fields.String()
+    description = fields.String()
+    accept = fields.String(metadata={"description": 'For ``file`` fields: comma-separated extensions, e.g. ``".pkl"``.'})
+    options = fields.List(
+        fields.String(),
+        metadata={
+            "description": (
+                "For ``select`` fields: the statically-declared allowed values. Runtime-computed options come "
+                "from ``POST /api/dataset/import/<importer>/options`` instead and carry their own "
+                "``(value, label)`` shape; see ``ImporterFieldOptionsResponseSchema``."
+            )
+        },
+    )
+    default = fields.String()
+    required = fields.Boolean()
+    placeholder = fields.String(
+        metadata={"description": "Hint shown as placeholder text inside the input widget."}
+    )
+    hint = fields.String(
+        metadata={
+            "description": (
+                "Inline format-hint text rendered as a visible chip below the input. Distinct from "
+                "``description`` (which feeds the placeholder): the hint stays visible after the user starts "
+                "typing, so it is the right place for accepted extensions or a short sample file layout."
+            )
+        }
+    )
+    dynamic_options = fields.Boolean(
+        metadata={
+            "description": (
+                "When true, ``options`` is computed at runtime by calling "
+                "``POST /api/dataset/import/<importer>/options`` with the current field values. The frontend "
+                "re-fetches whenever any field listed in ``depends_on`` changes."
+            )
+        }
+    )
+    depends_on = fields.List(
+        fields.String(), metadata={"description": "Field keys whose values this field's options depend on."}
+    )
+    allow_free_text = fields.Boolean(
+        metadata={
+            "description": (
+                "For ``select`` fields: when true, render as a combobox the user can type an arbitrary value "
+                "into. When the options refresh, a typed value absent from the new list is kept; a strict "
+                "select clears it."
+            )
+        }
+    )
+    min = fields.String(metadata={"description": "For ``number`` fields: minimum allowed value (empty = no min)."})
+    max = fields.String(metadata={"description": "For ``number`` fields: maximum allowed value (empty = no max)."})
+    step = fields.String(
+        metadata={"description": 'For ``number`` fields: step increment (empty / ``"any"`` = unconstrained).'}
+    )
+    clears = fields.List(
+        fields.String(),
+        metadata={
+            "description": (
+                "Field keys this field is mutually exclusive with. Entering a non-empty value here blanks each "
+                "listed field (and they list this one back), so only one of the set is ever active at a time."
+            )
+        },
+    )
+    template_vars = fields.List(
+        fields.String(),
+        metadata={
+            "description": (
+                "Framework-substituted template variable names (e.g. ``detector_name``, ``YYYYMMDD``) replaced "
+                "in this field's value before the plugin runs. Advisory for clients; substitution is server-side."
+            )
+        },
+    )
+
+
 class ConverterInfoSchema(Schema):
     """One ``MediaConverter.to_dict()`` payload (see ``vtscore/converters/base.py``).
 
-    Fixed shape across all converters.  The plugin ``fields`` list (importer
-    fields) is kept opaque here: the ``ImporterField`` shape is out of this
-    slice's scope, and the frontend re-types it via ``ImporterField[]``.
+    Fixed shape across all converters.
     """
 
     name = fields.String(required=True)
@@ -238,7 +334,158 @@ class ConverterInfoSchema(Schema):
     )
     #: Python attribute renamed to avoid shadowing ``marshmallow.fields``;
     #: mapped back to the ``fields`` wire key.
-    field_list = fields.List(fields.Dict(), attribute="fields", data_key="fields")
+    field_list = fields.List(fields.Nested(ImporterFieldSchema), attribute="fields", data_key="fields")
+
+
+class ClipperParameterSchema(Schema):
+    """One entry of a clipper's ``parameters`` / ``creation_questions`` list.
+
+    See ``MediaClipper.parameters`` in ``vtscore/media/clipper.py`` for the
+    descriptor contract.  ``min`` / ``max`` / ``step`` are only meaningful for
+    ``number`` parameters.
+    """
+
+    key = fields.String(required=True)
+    label = fields.String(required=True)
+    description = fields.String()
+    type = fields.String(required=True, validate=validate.OneOf(["number", "string"]))
+    default = fields.Raw(required=True, metadata={"oneOf": [{"type": "number"}, {"type": "string"}]})
+    min = fields.Float()
+    max = fields.Float()
+    step = fields.Float()
+
+
+class ClipperInfoSchema(Schema):
+    """One ``MediaClipper.to_dict()`` payload (see ``vtscore/media/clipper.py``).
+
+    The base key set is fixed, but concrete clippers append their own
+    resolved parameter values (``duration``, ``top_db``, ``box``, …), so this
+    enumerates the base and lets the extras through untouched.  See the
+    module docstring for why that beats either an opaque ``fields.Dict()`` or
+    a strict schema that would silently drop those keys.
+    """
+
+    class Meta:
+        unknown = INCLUDE
+
+    name = fields.String(required=True)
+    media_type = fields.String(required=True)
+    display_name = fields.String()
+    description = fields.String()
+    summary_template = fields.String(
+        metadata={
+            "description": (
+                "One-line preview with ``{key}`` placeholders for each parameter. The native row of the "
+                "importer source-specs picker substitutes the current parameter values, so the user sees a live "
+                "summary of what the clipper will do. Falls back to ``description`` when empty."
+            )
+        }
+    )
+    parameters = fields.List(fields.Nested(ClipperParameterSchema))
+    creation_questions = fields.List(
+        fields.Nested(ClipperParameterSchema),
+        metadata={
+            "description": (
+                "Parameters to ask about when the user first picks this clipper. Defaults to ``parameters``."
+            )
+        },
+    )
+
+    @post_dump(pass_original=True)
+    def _include_plugin_extras(self, data: dict, original: dict, **_: object) -> dict:
+        # ``unknown = INCLUDE`` only affects ``load``; a declared schema drops
+        # undeclared keys on ``dump``.  Re-merge the concrete clipper's own
+        # keys so clients receive the full descriptor.
+        if isinstance(original, dict):
+            for k, v in original.items():
+                if k not in data:
+                    data[k] = v
+        return data
+
+
+class CleanerInfoSchema(ClipperInfoSchema):
+    """One ``MediaCleaner.to_dict()`` payload (see ``vtscore/media/cleaner.py``).
+
+    ``MediaCleaner`` subclasses ``MediaClipper``, so this is the clipper
+    descriptor plus the cleaner-only ``default_enabled`` flag.
+    """
+
+    default_enabled = fields.Boolean(
+        metadata={
+            "description": (
+                "Whether the import form checks this cleaner by default. True only for cleaners that fix an "
+                "outright representation bug (EXIF orientation), where leaving it off ships known-wrong vectors."
+            )
+        }
+    )
+
+
+class ImporterInfoSchema(Schema):
+    """One ``ImporterBase.to_dict()`` payload (see ``vtscore/datasets/importers/base/core.py``).
+
+    Fixed shape: ``PluginBase.to_dict()`` emits the shared plugin metadata
+    and ``ImporterBase.to_dict()`` appends ``picker_view`` / ``category`` /
+    ``available_converters_by_media_type``.  No concrete importer overrides
+    ``to_dict``, so this schema is strict.
+    """
+
+    name = fields.String(required=True)
+    display_name = fields.String()
+    description = fields.String()
+    icon = fields.String()
+    #: Python attribute renamed to avoid shadowing ``marshmallow.fields``;
+    #: mapped back to the ``fields`` wire key.
+    field_list = fields.List(fields.Nested(ImporterFieldSchema), attribute="fields", data_key="fields")
+    ui_mode = fields.String()
+    hidden_from_picker = fields.Boolean()
+    picker_view = fields.String(
+        metadata={
+            "description": (
+                "Which view the dataset-importer modal opens for this card: ``form`` (default), ``demo``, "
+                "``server_folder``, ``local_folder``, or ``local_files``."
+            )
+        }
+    )
+    category = fields.String(
+        metadata={
+            "description": (
+                'Picker tab this importer belongs to. One of ``services``, ``server``, ``local``, ``demo``, '
+                'or ``""`` (uncategorised).'
+            )
+        }
+    )
+    available_converters_by_media_type = fields.Dict(
+        keys=fields.String(),
+        values=fields.List(fields.Nested(ConverterInfoSchema)),
+        metadata={
+            "description": (
+                "Map of output media-type id -> converters whose ``target_type`` matches that id. Drives the "
+                '"Include rows" UI without an extra round-trip to ``/api/converters``.'
+            )
+        },
+    )
+    enabled = fields.Boolean(
+        metadata={
+            "description": (
+                "Only set on ``combine_datasets`` by ``GET /api/dataset/all-importers``: false when fewer than "
+                "two saved datasets share a media type, so there is nothing to combine."
+            )
+        }
+    )
+
+
+class ImporterPickerTabSchema(Schema):
+    """One entry of the ``tabs`` array from ``GET /api/dataset/all-importers``.
+
+    Registered by plugins via
+    :func:`vtscore.datasets.importers.tabs.register_picker_tab`; ``id``
+    matches the importers' ``category``.
+    """
+
+    id = fields.String(required=True)
+    label = fields.String(required=True)
+    icon = fields.String(metadata={"description": "``vt-icon`` type name."})
+    order = fields.Integer(metadata={"description": "Lower values render first."})
 
 
 class MediaTypesListResponseSchema(Schema):
@@ -254,26 +501,15 @@ class EmbeddersListResponseSchema(Schema):
 
 
 class ClippersListResponseSchema(Schema):
-    """Response for ``GET /api/clippers``.
+    """Response for ``GET /api/clippers``."""
 
-    The clipper ``to_dict()`` payload is genuinely plugin-variable (concrete
-    clippers add their own keys, e.g. ``duration``/``top_db``), so this stays
-    an opaque ``fields.Dict()`` rather than a nested schema.  See the module
-    docstring.
-    """
-
-    clippers = fields.List(fields.Dict(), required=True)
+    clippers = fields.List(fields.Nested(ClipperInfoSchema), required=True)
 
 
 class CleanersListResponseSchema(Schema):
-    """Response for ``GET /api/cleaners``.
+    """Response for ``GET /api/cleaners``."""
 
-    Same opaque ``fields.Dict()`` treatment as ``ClippersListResponseSchema``:
-    a cleaner's ``to_dict()`` carries whatever parameters that cleaner declares,
-    plus the cleaner-only ``default_enabled`` flag.
-    """
-
-    cleaners = fields.List(fields.Dict(), required=True)
+    cleaners = fields.List(fields.Nested(CleanerInfoSchema), required=True)
 
 
 class ConvertersListResponseSchema(Schema):
@@ -285,19 +521,18 @@ class ConvertersListResponseSchema(Schema):
 class DatasetImportersListResponseSchema(Schema):
     """Response for ``GET /api/dataset/importers``."""
 
-    importers = fields.List(fields.Dict(), required=True)
+    importers = fields.List(fields.Nested(ImporterInfoSchema), required=True)
 
 
 class DatasetAllImportersListResponseSchema(Schema):
     """Response for ``GET /api/dataset/all-importers``.
 
-    ``tabs`` is the picker-tab layout (id, label, icon, order); the
-    ``combine_datasets`` importer is annotated with an ``enabled`` flag
-    by the handler.
+    ``tabs`` is the picker-tab layout; the ``combine_datasets`` importer is
+    annotated with an ``enabled`` flag by the handler.
     """
 
-    importers = fields.List(fields.Dict(), required=True)
-    tabs = fields.List(fields.Dict(), required=True)
+    importers = fields.List(fields.Nested(ImporterInfoSchema), required=True)
+    tabs = fields.List(fields.Nested(ImporterPickerTabSchema), required=True)
 
 
 # ---------------------------------------------------------------------------
@@ -339,7 +574,7 @@ class _DemoDatasetEntrySchema(Schema):
     description = fields.String(required=True)
     media_type = fields.String(required=True)
     num_categories = fields.Integer(required=True)
-    available_converters = fields.List(fields.Dict(), required=True)
+    available_converters = fields.List(fields.Nested(ConverterInfoSchema), required=True)
     pkl_embedder = fields.String(required=True)
     pkl_clipper = fields.String(required=True)
 
@@ -770,17 +1005,101 @@ class ImporterFieldOptionsResponseSchema(Schema):
 # ---------------------------------------------------------------------------
 
 
-class DatasetsRegistryListResponseSchema(Schema):
-    """Response for ``GET /api/datasets/registry``.
+class DatasetRegistryEntrySchema(Schema):
+    """One entry of ``GET /api/datasets/registry``.
 
-    Each entry's inner shape is the registry record (plus a derived
-    ``loaded`` flag and resolved ``clipper`` display name). Declared as
-    ``fields.Dict`` to avoid duplicating the registry record schema;
-    drift between schema and registry would be caught at the registry
-    layer, not the route.
+    The persisted registry record (written in exactly one place,
+    :func:`vtscore.datasets.registry.register_dataset`) plus the fields the
+    route derives per request: ``loaded``, ``embedders_by_type``, the
+    ``clipper`` display-name resolution, and the legacy fallbacks for
+    ``bound_embedders`` / ``embedder_types``.  The writer's key set is closed,
+    so this is a strict schema.
+
+    Optionality mirrors what the frontend treats as optional (same convention
+    as :class:`MediaTypeInfoSchema`), not what the current writer always
+    emits: entries persisted by older versions can legitimately lack the
+    newer fields.
     """
 
-    datasets = fields.List(fields.Dict(), required=True)
+    id = fields.String(required=True)
+    name = fields.String(required=True)
+    media_type = fields.String(required=True)
+    loaded = fields.Boolean(metadata={"description": "Whether this dataset is currently resident in memory."})
+    num_items = fields.Integer(metadata={"description": "Item count after near-duplicate collapsing."})
+    num_dupes = fields.Integer(metadata={"description": "How many items were collapsed as near-duplicates."})
+    pkl_path = fields.String(metadata={"description": "Server-side path of the dataset pickle."})
+    origin = fields.String(metadata={"description": "Name of the importer that produced this dataset."})
+    source = fields.Dict(
+        allow_none=True,
+        metadata={
+            "description": (
+                "The importer's origin dict for this dataset (importer name plus its field values). Inner keys "
+                "are importer-specific, so this stays an opaque map."
+            )
+        },
+    )
+    clipper = fields.String(
+        metadata={
+            "description": (
+                'Resolved clipper display name, or ``"-"`` when the dataset used its media type\'s default clipper.'
+            )
+        }
+    )
+    embedder = fields.String(metadata={"description": "Name of the embedder this dataset's media were vectorised with."})
+    embedder_types = fields.List(
+        fields.String(),
+        metadata={
+            "description": (
+                'The embedder *types* this dataset supplies (``semantic`` / ``patch_semantic`` / ``structural``); '
+                "a v3 trio dataset can supply several. Drives the detector/dataset compatibility gate."
+            )
+        },
+    )
+    bound_embedders = fields.List(
+        fields.String(), metadata={"description": "Every concrete embedder this dataset binds (primary first)."}
+    )
+    embedders_by_type = fields.Dict(
+        keys=fields.String(),
+        values=fields.String(),
+        metadata={
+            "description": (
+                'One concrete embedder per type it binds, e.g. ``{"semantic": "siglip", "patch_semantic": '
+                '"dinov3_patch"}``. Drives the Combine-Datasets conflict detector.'
+            )
+        },
+    )
+    readers = fields.List(
+        fields.String(),
+        metadata={
+            "description": (
+                'Usernames granted read access. Empty means creator-only; ``["*"]`` means visible to everyone.'
+            )
+        },
+    )
+    created_by = fields.String()
+    created_at = fields.Float(metadata={"description": "Unix timestamp (seconds) at which the dataset was registered."})
+    file_type_counts = fields.Dict(
+        keys=fields.String(),
+        values=fields.Integer(),
+        metadata={"description": "Per-extension file counts observed during ingest."},
+    )
+    ingest_started_at = fields.Float(allow_none=True)
+    ingest_finished_at = fields.Float(allow_none=True)
+    expires_at = fields.Float(
+        allow_none=True,
+        metadata={
+            "description": (
+                "Unix timestamp (seconds) at which this dataset ages off and is automatically removed; "
+                "``null``/absent means it never expires."
+            )
+        },
+    )
+
+
+class DatasetsRegistryListResponseSchema(Schema):
+    """Response for ``GET /api/datasets/registry``."""
+
+    datasets = fields.List(fields.Nested(DatasetRegistryEntrySchema), required=True)
 
 
 class DatasetRegistryLoadResponseSchema(Schema):

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -68,9 +68,10 @@ The labelset-element shape is shared with :mod:`vtsearch.schemas.labels`.
 
 from __future__ import annotations
 
-from marshmallow import Schema, ValidationError, fields, validate
+from marshmallow import INCLUDE, Schema, ValidationError, fields, post_dump, validate
 
 from vtsearch.schemas.labels import LabeledElementSchema
+from vtsearch.schemas.media import MediaEntrySchema, OriginSchema
 
 #: Upper bound on user-supplied detector names.  A name this long is already
 #: past any reasonable display use, and capping it here keeps the derived
@@ -644,20 +645,27 @@ class FindBoundaryNextResponseSchema(Schema):
     side = fields.String(required=True, allow_none=True, validate=validate.OneOf(["above", "below"]))
 
 
-class _HitSchema(Schema):
-    """One scored media entry inside an auto-detect / find ``hits`` list.
+class _HitSchema(MediaEntrySchema):
+    """One scored media entry inside an auto-detect ``hits`` list.
 
-    The shape is a media dict (filename, type, md5, origin, ...) augmented
-    with a ``score`` (and, for ``/api/find``, a ``verdict``). The set of
-    media-dict fields is intentionally open; different importers
-    populate different keys.
+    A media dict augmented with a ``score``.  It reuses
+    :class:`~vtsearch.schemas.media.MediaEntrySchema` so the media half
+    is enumerated exactly once, in the place that already vetted which media
+    fields are safe to serve.
+
+    That enumeration is load-bearing, not cosmetic: a declared schema **drops**
+    undeclared keys on dump (``unknown = "include"`` is load-only), and that is
+    the last line of defence keeping a media's embedding vectors out of the
+    response.  Do not add a ``post_dump`` passthrough here — it would serve the
+    whole media dict, vectors included.
     """
 
-    id = fields.Integer(required=True)
     score = fields.Float(required=True)
-
-    class Meta:
-        unknown = "include"
+    origin = fields.Nested(
+        OriginSchema,
+        allow_none=True,
+        metadata={"description": "Where this item was ingested from; rendered as the results table's Origin column."},
+    )
 
 
 class _AutoDetectResultSchema(Schema):
@@ -668,6 +676,38 @@ class _AutoDetectResultSchema(Schema):
     total_hits = fields.Integer(required=True)
     hits = fields.List(fields.Nested(_HitSchema), required=True)
     negative_hits = fields.List(fields.Nested(_HitSchema), required=True)
+
+
+class _AutoFindExportStatusSchema(Schema):
+    """Outcome of auto-exporting an Auto-Find run's results.
+
+    Built by ``_run_autofind_export``: a fixed ``{exporter, success}`` base
+    plus ``message`` on success / ``error`` on failure, and then whatever extra
+    keys the chosen exporter's outcome dict carried (``filepath`` for
+    file-based exporters, and so on).  Those extras are exporter-specific, so
+    the base is enumerated and the rest passed through, same as the clipper
+    descriptors in :mod:`vtsearch.schemas.datasets`.
+    """
+
+    exporter = fields.String(required=True)
+    success = fields.Boolean(required=True)
+    message = fields.String(metadata={"description": "Human-readable outcome; present on success."})
+    error = fields.String(metadata={"description": "Failure reason; present instead of ``message`` on failure."})
+
+    class Meta:
+        unknown = INCLUDE
+
+    @post_dump(pass_original=True)
+    def _include_exporter_extras(self, data: dict, original: dict, **_: object) -> dict:
+        # ``unknown = INCLUDE`` only affects ``load``; a declared schema drops
+        # undeclared keys on ``dump``.  Safe to re-merge here: the values come
+        # from an exporter's own JSON-serialisable outcome dict, not a media
+        # dict, so there are no vectors or raw bytes to leak.
+        if isinstance(original, dict):
+            for k, v in original.items():
+                if k not in data:
+                    data[k] = v
+        return data
 
 
 class AutoDetectRequestSchema(Schema):
@@ -702,10 +742,8 @@ class AutoDetectResponseSchema(Schema):
     # never silently drops a detector the user thinks is still active.
     missing_detectors = fields.List(fields.String(), required=True)
     # Present only when an Auto-Find results exporter is configured: the
-    # outcome of auto-exporting these results. ``{exporter, success,
-    # message?, error?, ...}`` (extra keys like ``filepath`` may appear for
-    # file-based exporters). See ``docs/plans/auto-find-settings-tab.md``.
-    auto_export = fields.Dict(keys=fields.String(), values=fields.Raw(), required=False)
+    # outcome of auto-exporting these results.
+    auto_export = fields.Nested(_AutoFindExportStatusSchema)
 
 
 # ---------------------------------------------------------------------------
@@ -769,7 +807,7 @@ class _FindResultRowSchema(Schema):
     filename = fields.String(required=True)
     md5 = fields.String(required=True)
     origin_name = fields.String(required=True)
-    origin = fields.Dict(allow_none=True)
+    origin = fields.Nested(OriginSchema, allow_none=True)
     dataset_name = fields.String(required=True)
     detector_verdicts = fields.Dict(
         keys=fields.String(),

--- a/vtsearch/schemas/eval.py
+++ b/vtsearch/schemas/eval.py
@@ -69,8 +69,7 @@ class StabilityPointSchema(Schema):
         required=True,
         metadata={
             "description": (
-                "How many still-unlabeled items changed predicted class between the previous step's model and "
-                "this one."
+                "How many still-unlabeled items changed predicted class between the previous step's model and this one."
             )
         },
     )

--- a/vtsearch/schemas/eval.py
+++ b/vtsearch/schemas/eval.py
@@ -12,10 +12,18 @@ Covers four routes in ``vtsearch/routes/eval.py``:
                                                     -> :class:`EvalTrainAndScoreResponseSchema`
 
 The per-step ``error_cost`` / ``stability`` / ``diversity`` lists are
-declared as ``fields.List(fields.Dict())`` rather than fully nested
-schemas; the inner shapes are computed by
-``vtscore.detectors.labeling_progress`` and round-trip cleanly as
-plain dicts.
+enumerated as nested schemas (:class:`ErrorCostPointSchema`,
+:class:`StabilityPointSchema`, :class:`DiversityPointSchema`).  Each shape is
+built in exactly one place inside ``vtscore.detectors.labeling_progress``, so
+the key sets are fixed and the frontend charts can consume the generated
+models instead of a hand-written mirror.
+
+``GET /api/indicator-score-history`` is the one exception: its ``history``
+array holds *whichever* of the three point shapes matches the requested
+``metric``, so it stays an opaque list of dicts rather than committing to one
+of them.  Expressing that as an OpenAPI ``oneOf`` would mean hand-writing
+component ``$ref`` strings in field metadata, which silently rots the moment
+a schema class is renamed; the single client-side cast is the cheaper trade.
 
 The two train-and-score endpoints share a single response schema with
 ``unknown = "include"``: the metric-specific data key
@@ -36,12 +44,58 @@ _METRIC_VALIDATOR = validate.OneOf(["smart", "stable", "diverse"])
 # ---------------------------------------------------------------------------
 
 
+class ErrorCostPointSchema(Schema):
+    """One step of the error-cost series (``_eval_cached_models``)."""
+
+    num_labels = fields.Integer(required=True)
+    error_cost = fields.Float(
+        required=True,
+        metadata={"description": "``fpr_weight * fpr + fnr_weight * fnr`` for the model trained at this step."},
+    )
+    time_index = fields.Integer(metadata={"description": "Zero-based index of this step in the label history."})
+    fpr = fields.Float(metadata={"description": "False-positive rate on the held-out eval set."})
+    fnr = fields.Float(metadata={"description": "False-negative rate on the held-out eval set."})
+
+
+class StabilityPointSchema(Schema):
+    """One step of the prediction-stability series.
+
+    Absent for the first step, which has no prior predictions to compare
+    against.
+    """
+
+    num_labels = fields.Integer(required=True)
+    num_flips = fields.Integer(
+        required=True,
+        metadata={
+            "description": (
+                "How many still-unlabeled items changed predicted class between the previous step's model and "
+                "this one."
+            )
+        },
+    )
+    time_index = fields.Integer(metadata={"description": "Zero-based index of this step in the label history."})
+    num_unlabeled = fields.Integer(
+        metadata={"description": "Size of the monitored pool the flip count was measured over."}
+    )
+
+
+class DiversityPointSchema(Schema):
+    """One step of the coverage-diversity series (from the coverage atlas)."""
+
+    num_labels = fields.Integer(required=True)
+    diversity_level = fields.Float(
+        required=True, metadata={"description": "Coverage level reached by the labels so far."}
+    )
+    depth = fields.Integer(required=True, metadata={"description": "Total nodes in the coverage atlas."})
+
+
 class LabelingProgressResponseSchema(Schema):
     """Response for ``POST /api/labeling-progress``."""
 
-    error_cost_over_time = fields.List(fields.Dict(), required=True)
-    stability_over_time = fields.List(fields.Dict(), required=True)
-    diversity_level_over_time = fields.List(fields.Dict(), required=True)
+    error_cost_over_time = fields.List(fields.Nested(ErrorCostPointSchema), required=True)
+    stability_over_time = fields.List(fields.Nested(StabilityPointSchema), required=True)
+    diversity_level_over_time = fields.List(fields.Nested(DiversityPointSchema), required=True)
     total_labels = fields.Integer(required=True)
     total_medias = fields.Integer(required=True)
 
@@ -119,6 +173,8 @@ class IndicatorScoreHistoryResponseSchema(Schema):
     """Response for ``GET /api/indicator-score-history``."""
 
     metric = fields.String(required=True, validate=_METRIC_VALIDATOR)
+    #: Whichever of ``ErrorCostPoint`` / ``StabilityPoint`` / ``DiversityPoint``
+    #: matches ``metric``; kept opaque here (see the module docstring).
     history = fields.List(fields.Dict(), required=True)
     # ``false`` when the per-step cache does not yet cover the whole label
     # history, in which case ``history`` is empty and the client should fall
@@ -173,9 +229,9 @@ class EvalTrainAndScoreResponseSchema(Schema):
     metric = fields.String()
     current = fields.Integer()
     total = fields.Integer()
-    error_cost = fields.List(fields.Dict())
-    stability = fields.List(fields.Dict())
-    diversity = fields.List(fields.Dict())
+    error_cost = fields.List(fields.Nested(ErrorCostPointSchema))
+    stability = fields.List(fields.Nested(StabilityPointSchema))
+    diversity = fields.List(fields.Nested(DiversityPointSchema))
     error = fields.String()
 
     class Meta:

--- a/vtsearch/schemas/labels.py
+++ b/vtsearch/schemas/labels.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 from marshmallow import Schema, fields, validate
 
+from vtsearch.schemas.media import OriginSchema
+
 
 class LabeledElementSchema(Schema):
     """A single entry in an exported :class:`~vtscore.datasets.labelset.LabelSet`.
@@ -45,7 +47,7 @@ class LabeledElementSchema(Schema):
 
     md5 = fields.String(required=True)
     label = fields.String(required=True, metadata={"description": "``good`` or ``bad``."})
-    origin = fields.Dict(allow_none=True)
+    origin = fields.Nested(OriginSchema, allow_none=True)
     origin_name = fields.String()
     filename = fields.String()
     category = fields.String()

--- a/vtsearch/schemas/media.py
+++ b/vtsearch/schemas/media.py
@@ -48,6 +48,22 @@ from __future__ import annotations
 from marshmallow import Schema, fields, validate
 
 
+class OriginSchema(Schema):
+    """A serialised :class:`~vtscore.datasets.origin.Origin`.
+
+    ``Origin.to_dict`` is the single writer and always emits exactly these two
+    keys, so the *envelope* is fixed even though the ``params`` map inside it
+    is importer-specific.  Enumerating the envelope is what lets clients read
+    ``origin.importer`` directly instead of indexing into an opaque dict.
+    """
+
+    importer = fields.String(required=True)
+    params = fields.Dict(
+        keys=fields.String(),
+        metadata={"description": "Identifying import parameters; the key set is importer-specific."},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shared payload-variant query
 # ---------------------------------------------------------------------------
@@ -124,12 +140,18 @@ class MediaBatchRequestSchema(Schema):
     )
 
 
-class _MediaBatchEntrySchema(Schema):
-    """One entry in the ``POST /api/medias/batch`` response array.
+class MediaEntrySchema(Schema):
+    """The per-media metadata block the API serves for one item.
 
-    Importers populate different keys, so unknown fields flow through
-    on dump. ``custom_metadata`` is a free-form dict whose inner keys
-    vary per importer / media type.
+    Used directly by ``POST /api/medias/batch`` (via
+    :class:`MediaBatchResponseSchema`) and as the base of the auto-detect hit
+    schema (``vtsearch.schemas.detectors._HitSchema``), which adds a score.
+
+    The field list is an **allowlist**, and deliberately so: a declared
+    marshmallow schema drops every undeclared key on dump, which is what keeps
+    a media's embedding vectors and raw bytes out of the response even if a
+    caller forgets to strip them first.  ``custom_metadata`` is the sanctioned
+    escape hatch for importer-specific display fields.
     """
 
     id = fields.Integer(required=True)
@@ -157,10 +179,15 @@ class _MediaBatchEntrySchema(Schema):
     )
 
     class Meta:
-        unknown = "include"
+        # Response-only schema, so this governs nothing at runtime — dump is an
+        # allowlist either way.  ``exclude`` rather than ``include`` so the
+        # generated OpenAPI model says what the server actually sends: no
+        # ``additionalProperties``, hence no index signature for a frontend
+        # typo to hide behind.
+        unknown = "exclude"
 
 
-class MediaBatchResponseSchema(_MediaBatchEntrySchema):
+class MediaBatchResponseSchema(MediaEntrySchema):
     """Response wrapper for ``POST /api/medias/batch``.
 
     Used with ``many=True`` at the decorator call site so the OpenAPI


### PR DESCRIPTION
Closes #2655.

Finishes the backend-schema-first convergence: every hand-written frontend interface that mirrors an API response is now re-exported from the generated client, and all nine `[key: string]: unknown` escape hatches on convergeable shapes are gone.

## The framing correction

The issue (and the #2665 follow-up comment) concluded that clippers and importers were "genuinely plugin-variable" and would keep an escape hatch anyway. Two findings changed that:

- **Importers are not plugin-variable at the top level.** No concrete importer overrides `to_dict`; `PluginBase.to_dict()` + `ImporterBase.to_dict()` is the whole key set, and `PluginField.to_dict()` is a fixed 18-key dataclass dump. `ImporterInfo` and `ImporterField` are fully enumerable with no escape hatch.
- **Clippers are variable, but that doesn't force a hand-written mirror.** `unknown = INCLUDE` + a `post_dump(pass_original=True)` passthrough (the pattern `schemas/eval.py` already used) gives enumerated base fields *and* `additionalProperties: true`, which ng-openapi-gen renders as an index signature. That is precisely the shape the frontend was hand-maintaining — so it can be generated instead.

`ProgressEvent` / `LoadingTask` / `VotingIterationsResponse` stay hand-written, as the issue's comment said: they come over `/api/events`, a raw streaming response flask-smorest can't describe.

## Bug found while doing it

`POST /api/auto-detect` was serving hits stripped to `{id, score}`. `_HitSchema` declared only those two fields, and a declared marshmallow schema **drops undeclared keys on dump** — `unknown = "include"` is load-only. So the Auto-Find results table's Origin / Name / MD5 / Filename columns rendered blank, and its rows tracked by an undefined `md5`. `AutoDetectHit`'s `[key: string]: unknown` is exactly why nothing caught it.

The fix is deliberately *not* a passthrough: that same implicit stripping is what keeps a media's embedding vectors off the wire. `_HitSchema` now extends the media-batch entry schema (promoted to a public `MediaEntrySchema`) and inherits its already-vetted allowlist. Two regression tests pin both halves — hits carry the rendered fields, and hits never carry vectors or raw bytes.

Related, surfaced while confirming that: `_HEAVYWEIGHT_KEYS` still named the legacy singular `embedding` key. V3 moved per-media vectors to the `embeddings` dict, so the defense-in-depth strip in `_media_info_for_response` had silently stopped covering them and only the schema allowlist was holding. Both copies now strip `EMBEDDINGS_KEY`.

## Backend

New nested schemas: `ImporterFieldSchema`, `ImporterInfoSchema`, `ImporterPickerTabSchema`, `ClipperInfoSchema`, `ClipperParameterSchema`, `CleanerInfoSchema`, `DatasetRegistryEntrySchema`, `OriginSchema`, `_AutoFindExportStatusSchema`, and the three labeling-progress point schemas. `ConverterInfoSchema.fields` and the demo list's `available_converters` nest real models too.

`MediaEntrySchema` declares `unknown = "exclude"` so the spec stops advertising `additionalProperties` it never sends, and `collapse_nullable_refs` in the OpenAPI post-processor rewrites apispec's `anyOf: [{type: object, nullable}, $ref]` idiom to a plain nullable `$ref` — without it ng-openapi-gen emits `X | {} | null`, and the empty-object arm swallows every property access on the union.

Verified against every registered plugin (16 clippers, 7 cleaners, 11 importers, 3 tabs, 8 converters) that no response key is dropped, and that `DatasetRegistryEntrySchema` covers its writer's full key set.

## Frontend

`api.models.ts` re-exports the generated models and drops every `as unknown as` cast at the three service boundaries. Renames follow the generated names (`FieldOption` → `FieldOptions`, `MediaTypeDetectionResponse` → `DetectMediaTypeResponse`, `*DataPoint` → `*Point`) rather than aliasing them back, and the `RemoveIndex` workaround is retired.

Losing the row index signature broke three sort-by-column-name comparators; they now share `sortRowsByColumn` in `managed-columns.ts`, which widens the lookup in one place instead of asking each row type to carry a catch-all index signature.

## Breaking changes

- Public API shapes gain fields (they were being stripped) rather than losing any. The one narrowing is `/api/auto-detect` hits, which now serve the vetted media allowlist instead of an arbitrary media dict.
- `vtsearch.schemas.media._MediaBatchEntrySchema` is renamed to the public `MediaEntrySchema`.

## Verify

`./run-tests.sh` — **ALL 7137 TESTS PASSED** (1 skipped), including the OpenAPI snapshot gate, `ruff`/`codespell`/`deptry`/`pyright`, the Angular `build:prod` warning gate, and 1864 Vitest tests.

No doc screenshot frames a surface this changes, so the reshoot queue is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm6RAP6xsrwu8xvZGCiT9H

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hm6RAP6xsrwu8xvZGCiT9H)_