### PR TITLE
Tune progress timings per environment, and make ETAs humble

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,6 +188,12 @@ VTSearch/
 │   │   ├── near_dupes.py           Near-duplicate detection / grouping
 │   │   └── media_lookup.py         Origin-keyed lookup, collapse_duplicates
 │   │
+│   ├── timing/                     Per-environment cost model for progress-bar pacing + ETAs
+│   │   ├── tasks.py                TaskSpec registry: each long-running task's ordered steps
+│   │   ├── profile.py              VTSEARCH_TIMING_PROFILE loader + (device, media, embedder) lookup
+│   │   ├── recorder.py             VTSEARCH_TIMING_RECORD step-boundary recorder (off by default)
+│   │   └── fit.py                  Fits recorded rows into a profile document
+│   │
 │   ├── plugins/                    PluginBase, PluginField, PluginRegistry (shared plugin infra)
 │   ├── security/                   Path/URL/pickle safety (path_validation, url_validation, pickle)
 │   ├── sync/                       SyncSource[LoadT, SaveT] generic base class
@@ -480,11 +486,27 @@ load_dataset_from_folder(
 
 ### Progress tracking
 
-**Files:** `vtscore/concurrency/progress.py`
+**Files:** `vtscore/concurrency/progress.py`, `vtscore/timing/`
 
 A thread-safe progress tracker with no framework dependencies.  Uses
 `threading.Lock` and module-level dicts.  Can be dropped into any
 application as-is.
+
+A task that reports `step` / `total_steps` gets a single whole-job `overall`
+fraction and an `eta_seconds`, both derived from a per-step **weight vector**.
+Those weights come from `vtscore/timing/`, which models each step's cost as
+`a + b·n + per_mb·archive_mb` per `(device, media_type, embedder)` cell. Each
+long-running task is registered in `vtscore/timing/tasks.py` and asks for its
+weights at its entry point rather than carrying a literal vector; an admin
+profile at `VTSEARCH_TIMING_PROFILE` (measured by
+`scripts/profiling/tune_timing_profile.py`) overrides the shipped defaults per
+cell. See [DEPLOYMENT.md](DEPLOYMENT.md#progress-bar-timing-profile).
+
+`eta_seconds` is published **coarse and sticky**: the tracker snaps its
+internally-smoothed estimate onto a geometric ladder and holds each rung until
+the estimate clears a neighbour by a hysteresis margin, so a converging estimate
+reads as a steady "About 10 min left" instead of walking the user through every
+revision. Only the published field is quantized; the EMA keeps full precision.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,9 +11,10 @@ installation and getting started, see [SETUP.md](SETUP.md).
 3. [Network dependencies](#network-dependencies)
 4. [Offline deployment](#offline-deployment)
 5. [Data directory layout](#data-directory-layout)
-6. [Docker production notes](#docker-production-notes)
-7. [Dependency structure](#dependency-structure)
-8. [Troubleshooting](#troubleshooting)
+6. [Progress-bar timing profile](#progress-bar-timing-profile)
+7. [Docker production notes](#docker-production-notes)
+8. [Dependency structure](#dependency-structure)
+9. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -27,6 +28,13 @@ installation and getting started, see [SETUP.md](SETUP.md).
 | `VTSEARCH_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). `INFO`/`DEBUG` also turn on the per-request access log. |
 | `VTSEARCH_MODELS_DIR` | `data/models` | Directory for HuggingFace model cache |
 | `VTSEARCH_SUPPORT_EMAIL` | built-in project address | Recipient for the Help modal's "Email us" link. Overrides the persisted `support_email` setting for the process lifetime (all users; not editable via the API). Equivalent to the `--support-email` CLI flag, for the gunicorn images that never parse `argv`; an explicit flag wins. |
+
+### Progress-bar timing
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VTSEARCH_TIMING_PROFILE` | unset | Path to a timing-profile JSON measured on this environment's hardware. Tells every instance how long each step of each long-running task takes here, so progress bars pace and predict against reality instead of the shipped defaults. See [Progress-bar timing profile](#progress-bar-timing-profile). |
+| `VTSEARCH_TIMING_RECORD` | unset | Path to a JSONL sink. When set, every long-running task appends one row per step as it finishes. This is how you gather the measurements the profile is fit from; leave it unset in steady state. |
 
 ### Dataset-ingest concurrency
 
@@ -481,6 +489,130 @@ Notable fields:
 - `grid_icon_size_*`, `focus_mode_*`, `panel_pct_*`:
   per-media-type UI layout preferences (keyed by media type ID)
 - `autopilot_enabled`: whether the autopilot feature is active
+
+---
+
+## Progress-bar timing profile
+
+Every long-running operation — importing a dataset, opening one, loading a
+detector, a text search, a Find, a train-and-score, a promote — shows one
+progress bar that fills across several steps and reports a remaining-time
+estimate. To pace that bar the server needs a prior for what each step *costs*,
+and to keep the estimate from drifting it needs that prior to be roughly right.
+
+VTSearch ships defaults for those costs, measured on one GPU cluster. Your
+hardware is not that cluster. A profile replaces the shipped numbers with ones
+measured here.
+
+### What a profile changes (and what it can't)
+
+A profile only affects **pacing and prediction**. A wrong or missing profile
+makes a bar race one phase and crawl the next, and makes its ETA converge slowly;
+it never affects correctness, results, or what gets stored. Deploying without one
+is entirely supported — that is what the shipped defaults are for.
+
+What it buys you is worth having, though. The cost of each step is affine in the
+job's size:
+
+```
+seconds ≈ a + b·n + per_mb·archive_mb
+```
+
+The fixed part `a` matters enormously at small `n` (an 8-second encoder load *is*
+a 1000-item text search) and not at all at large `n`. A single fixed weight
+vector cannot be right at both ends, which is exactly the failure that makes a
+bar's estimate climb: the job is paced as if the expensive phase were nearly
+over.
+
+### Gathering the measurements
+
+**Recommended: observe real usage.** Point the recorder at a file and run
+normally:
+
+```bash
+VTSEARCH_TIMING_RECORD=/var/lib/vtsearch/timings.jsonl \
+VTSEARCH_SERVER_INIT=1 gunicorn ...
+```
+
+Each task appends one row per step as it completes. This has no side effects and
+no performance cost worth measuring (a file append per task), and it captures the
+datasets your users actually load at the sizes they actually are — a mix no
+synthetic sweep reproduces. Let it run for a day or a week, then fit:
+
+```bash
+python scripts/profiling/tune_timing_profile.py --fit-only \
+    --out /etc/vtsearch/timing-profile.json \
+    /var/lib/vtsearch/timings.jsonl
+```
+
+**Alternative: drive the workloads.** When you want numbers immediately —
+commissioning a node, or after a hardware change — the script can exercise the
+tasks itself against datasets and detectors you name:
+
+```bash
+python scripts/profiling/tune_timing_profile.py --drive \
+    --out timing-profile.json --datasets ds-a,ds-b,ds-c --reps 3
+```
+
+By default `--drive` runs only the read-only families (opening a dataset, text
+search, Find). The others mutate state — loading a detector seeds example votes,
+**train-and-score overwrites the active dataset's labels**, promote creates a
+dataset, an import writes one — so they require `--allow-mutating` and should be
+pointed at a scratch `--data-dir`, never at live user data.
+
+Either way the script ends by printing a coverage report naming which task
+families got measured and which fell back to the defaults, so a thin sweep is
+visible rather than silently half-effective.
+
+### Deploying it
+
+```bash
+VTSEARCH_TIMING_PROFILE=/etc/vtsearch/timing-profile.json
+```
+
+The file is read once per process at startup. It is plain JSON and safe to
+hand-edit; a malformed one logs a warning and falls back to the defaults rather
+than failing the server. Coefficients are keyed by a *cell* —
+`device|media_type|embedder` — with `*` or an empty component as a wildcard, and
+lookup walks from the most specific key to the least:
+
+```json
+{
+  "schema": "vtsearch-timing-profile",
+  "version": 1,
+  "host": "prod-gpu-01",
+  "tasks": {
+    "text_sort": {
+      "cells": {
+        "cuda+cuml|image|siglip": {
+          "samples": 12,
+          "steps": {
+            "load_model":  {"a": 8.2},
+            "embed_query": {"a": 0.04},
+            "score":       {"a": 0.1, "b": 0.00012}
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The fit emits rollup cells (`cuda||`) alongside precise ones, so measuring three
+exemplar datasets still improves pacing for every dataset that host will see.
+
+Re-run the tuning whenever the hardware, storage, or GPU stack changes. Nothing
+expires a profile automatically; a stale one costs accuracy, never correctness.
+
+### A note on the ETA itself
+
+Even a perfectly tuned profile cannot make a remaining-time estimate exact — it
+is an extrapolation from a rate that is still changing. So the server never
+publishes its raw estimate: it snaps to a coarse ladder and holds each rung until
+the underlying estimate moves decisively, which is why the UI says
+"About 10 min left" and keeps saying it rather than counting through every
+revision. A genuinely slowing job still reports the increase; what it no longer
+does is twitch.
 
 ---
 

--- a/docs/plans/progress-weight-calibration.md
+++ b/docs/plans/progress-weight-calibration.md
@@ -1,5 +1,14 @@
 # Progress-weight calibration
 
+**Background:** the checked-in coefficients this plan produced are now the
+*shipped defaults* for `dataset_load`, not the last word. A deployment can
+measure its own hardware with `scripts/profiling/tune_timing_profile.py` and
+override any cell (plus every non-dataset task) through a
+`VTSEARCH_TIMING_PROFILE` JSON — see `vtscore/timing/` and
+`docs/DEPLOYMENT.md` § *Progress-bar timing profile*. The remaining work below
+is about widening the checked-in defaults' coverage; it is not a prerequisite
+for a tuned deployment.
+
 **Status:** Load-progress weights are calibrated for every demo-backed media
 type (image/audio/video/text/document) × every loadable registered embedder ×
 {cpu, cuda, cuda+cuml} (issue #2623; HLTCOE Grid rack8n06 v100, 2026-07-18/19

--- a/frontend/src/app/components/job-progress/job-progress.component.spec.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.spec.ts
@@ -25,19 +25,19 @@ describe('JobProgressComponent', () => {
   it('renders the header, detail and eta', async () => {
     fixture.componentRef.setInput('header', 'Loading dataset · Step 2 of 4 · Downloading source');
     fixture.componentRef.setInput('detail', '012/345 FileABC.img');
-    fixture.componentRef.setInput('eta', '5.5 min left');
+    fixture.componentRef.setInput('eta', 'About 10 min left');
     await settleZoneless(fixture);
     const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
     expect(text).toContain('Downloading source');
     expect(text).toContain('FileABC.img');
-    expect(text).toContain('5.5 min left');
+    expect(text).toContain('About 10 min left');
   });
 
   it('labels the eta chip as a whole-job estimate on hover', async () => {
     const el = fixture.nativeElement as HTMLElement;
     // No eta -> no tooltip (an empty chip should not invite hovering).
     expect(el.querySelector('.jp__eta')?.getAttribute('title')).toBeFalsy();
-    fixture.componentRef.setInput('eta', '5.5 min left?');
+    fixture.componentRef.setInput('eta', 'About 10 min left');
     await settleZoneless(fixture);
     expect(el.querySelector('.jp__eta')?.getAttribute('title')).toContain('whole job');
   });

--- a/frontend/src/app/components/job-progress/job-progress.component.ts
+++ b/frontend/src/app/components/job-progress/job-progress.component.ts
@@ -36,7 +36,7 @@ export class JobProgressComponent {
   readonly description = input('');
   /** Per-item detail (left of the bar), e.g. "012/345 FileABC.img". */
   readonly detail = input('');
-  /** Right-justified status, e.g. "5.5 min left" or "45%". */
+  /** Right-justified status, e.g. "About 10 min left" or "45%". */
   readonly eta = input('');
   /**
    * The chip shows the backend's whole-job estimate (`eta_seconds`), never a

--- a/frontend/src/app/utils/format-progress.spec.ts
+++ b/frontend/src/app/utils/format-progress.spec.ts
@@ -164,18 +164,28 @@ describe('formatEta', () => {
     expect(formatEta(Infinity)).toBe('');
   });
 
-  it('never claims finer than 10-second granularity sub-minute', () => {
-    // A few seconds left snaps below the 10s floor → "< 10 sec", never "< 5 sec".
-    expect(formatEta(3)).toBe('< 10 sec left?');
-    expect(formatEta(4)).toBe('< 10 sec left?');
-    // Just over the floor rounds to the nearest 10s, not 5s.
-    expect(formatEta(12)).toBe('10 sec left?');
-    expect(formatEta(18)).toBe('20 sec left?');
-    expect(formatEta(34)).toBe('30 sec left?');
+  it('hedges every estimate with "About"', () => {
+    // The backend already snapped this to a coarse rung and will hold it there
+    // (ProgressTracker._humble_eta); the wording has to match that promise
+    // rather than implying a number anyone should check.
+    expect(formatEta(15)).toBe('About 15 sec left');
+    expect(formatEta(600)).toBe('About 10 min left');
+    expect(formatEta(7200)).toBe('About 2 hr left');
   });
 
-  it('switches to minutes and hours for larger estimates', () => {
-    expect(formatEta(330)).toBe('5.5 min left?');
-    expect(formatEta(7200)).toBe('2 hr left?');
+  it('picks the largest unit that keeps the value readable', () => {
+    expect(formatEta(45)).toBe('About 45 sec left');
+    expect(formatEta(90)).toBe('About 1.5 min left');
+    expect(formatEta(2700)).toBe('About 45 min left');
+    expect(formatEta(3600)).toBe('About 1 hr left');
+    expect(formatEta(5400)).toBe('About 1.5 hr left');
+    expect(formatEta(86400)).toBe('About 24 hr left');
+  });
+
+  it('renders an off-ladder value sanely instead of pretending to precision', () => {
+    // Nothing on the wire should be off-ladder, but a caller passing a raw
+    // estimate must not produce "About 5.516666666666667 min left".
+    expect(formatEta(331)).toBe('About 5.5 min left');
+    expect(formatEta(12.4)).toBe('About 12 sec left');
   });
 });

--- a/frontend/src/app/utils/format-progress.ts
+++ b/frontend/src/app/utils/format-progress.ts
@@ -20,69 +20,36 @@ export function formatProgressFraction(current: number, total: number): string {
   return `${current.toLocaleString()}/${total.toLocaleString()}`;
 }
 
-/**
- * The fraction of an estimate we allow ourselves to claim as precision. An ETA
- * is snapped to a "nice" step roughly this size relative to its own magnitude,
- * so the bigger the estimate the coarser it reads: a ~5.5 min job rounds to the
- * half-minute, a ~2 hr job to the half-hour. Keeping every chip deliberately
- * approximate is the point — an under-specified ETA can't be held to a
- * precision the backend never actually had.
- */
-const ETA_ROUND_RATIO = 0.1;
-
-/** Nice rounding steps, expressed in the chosen display unit (sec/min/hr). */
-const ETA_NICE_STEPS = [0.5, 1, 2, 5, 10, 15, 30];
-
-/**
- * Snap ``value`` to the nearest "nice" step whose size is about
- * ``ETA_ROUND_RATIO`` of the value itself (never smaller than ``minStep``).
- */
-function snapEta(value: number, minStep: number): number {
-  const target = value * ETA_ROUND_RATIO;
-  let step = minStep;
-  for (const candidate of ETA_NICE_STEPS) {
-    if (candidate >= minStep && candidate <= target) step = candidate;
-  }
-  return Math.round(value / step) * step;
-}
-
-/** Render a snapped magnitude with at most one decimal and no trailing ``.0``. */
+/** Render a magnitude with at most one decimal and no trailing ``.0``. */
 function etaUnit(value: number, unit: string): string {
   const text = Number.isInteger(value) ? String(value) : value.toFixed(1);
-  return `${text} ${unit} left?`;
+  return `About ${text} ${unit} left`;
 }
 
 /**
  * Format a remaining-seconds estimate into a deliberately humble, single-unit
- * chip: ``35 sec left`` / ``5.5 min left`` / ``2 hr left``. The value is
- * rounded to a nice step that scales with its magnitude (see
- * ``ETA_ROUND_RATIO``), so we never claim more precision than a noisy estimate
- * deserves and never show an over-precise ``5 min 34 sec``-style breakdown.
- * Returns an empty string for ``null``, non-positive, or non-finite values so
- * the caller can drop it from concatenation unconditionally.
+ * chip: ``About 45 sec left`` / ``About 10 min left`` / ``About 2 hr left``.
+ *
+ * The vagueness is not this function's doing — it is the backend's. Every
+ * ``eta_seconds`` on the wire has already been snapped to a coarse ladder and
+ * held there by hysteresis (see ``ProgressTracker._humble_eta``), so a job whose
+ * true estimate wanders between 8 and 11 minutes reports a steady ``600`` the
+ * whole time instead of walking the user through every revision. That is
+ * deliberate: an estimate reported to the half-minute invites you to check it,
+ * and checking it is how you notice it going *up*.
+ *
+ * All this does is pick the unit and say "About". Ladder rungs are chosen to be
+ * round in whichever unit they land in, so nothing is rounded a second time
+ * here; a value that somehow arrives off-ladder still renders sanely at one
+ * decimal. Returns an empty string for ``null``, non-positive, or non-finite
+ * values so the caller can drop it from concatenation unconditionally.
  */
 export function formatEta(seconds: number | null | undefined): string {
   if (seconds == null || !isFinite(seconds) || seconds <= 0) return '';
-  // Sub-minute: round to a nice multiple of seconds. We are deliberately
-  // imprecise about ETAs, so the granularity floor is 10s — never finer.
-  // Showing "< 5 sec" for what can be 10+ seconds of work reads as
-  // over-confident; "< 10 sec" is the honest floor.
-  if (seconds < 60) {
-    const s = snapEta(seconds, 10);
-    // A few seconds left snaps down to 0; claiming "~0 sec" reads as "done"
-    // even though work remains. Show "< 10 sec left" instead.
-    if (s <= 0) return '< 10 sec left?';
-    if (s < 60) return etaUnit(s, 'sec');
-  }
-  // Minutes: round to the nice fraction of a minute (minimum half-minute).
+  if (seconds < 60) return etaUnit(Math.round(seconds), 'sec');
   const minutes = seconds / 60;
-  if (minutes < 60) {
-    const m = snapEta(minutes, 0.5);
-    if (m < 60) return etaUnit(m, 'min');
-  }
-  // Hours: round to the nice fraction of an hour (minimum half-hour).
-  const h = snapEta(seconds / 3600, 0.5);
-  return etaUnit(h, 'hr');
+  if (minutes < 60) return etaUnit(Math.round(minutes * 10) / 10, 'min');
+  return etaUnit(Math.round((seconds / 3600) * 10) / 10, 'hr');
 }
 
 /**
@@ -92,7 +59,7 @@ export function formatEta(seconds: number | null | undefined): string {
  * Each piece is optional:
  *   - The ``[Step S/T]`` prefix appears only when ``total_steps > 1``.
  *   - The ``(C/T)`` fraction appears only when ``total > 0``.
- *   - The ``· 5.5 min left`` tail appears only when ``eta_seconds > 0``; the
+ *   - The ``· About 10 min left`` tail appears only when ``eta_seconds > 0``; the
  *     backend gates this on at least 5s of elapsed work, so it stays hidden
  *     for short bars.
  *   - When none are present, returns the bare ``message`` (or
@@ -209,7 +176,7 @@ export function isProgressIndeterminate(
  *     is omitted here; it is returned separately as ``eta`` so the UI can pin it
  *     to the right of the progress bar where it stays visible even when a long
  *     file path ellipsizes the detail.
- *   - ``eta``: the bare ``5.5 min left`` chip, or empty when no estimate is available.
+ *   - ``eta``: the bare ``About 10 min left`` chip, or empty when no estimate is available.
  */
 export interface ProgressHeader {
   header: string;

--- a/scripts/profiling/tune_timing_profile.py
+++ b/scripts/profiling/tune_timing_profile.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Build a per-environment timing profile for every long-running VTSearch task.
+
+A progress bar's ETA is only as good as its idea of what the *next* phase costs.
+Shipped defaults are one cluster's measurements; your hardware, disks, and
+network are not that cluster. This script measures yours and writes the JSON that
+``VTSEARCH_TIMING_PROFILE`` points at, after which every instance in the
+environment predicts its own timings (see :mod:`vtscore.timing`).
+
+There are two ways to gather the timings, and they produce the same file.
+
+**1. Observe real usage (recommended).** Start the server with the recorder armed
+and let people use it::
+
+    VTSEARCH_TIMING_RECORD=/var/lib/vtsearch/timings.jsonl python app.py
+    # ... a day or a week of normal work ...
+    python scripts/profiling/tune_timing_profile.py --fit-only \\
+        --out /etc/vtsearch/timing-profile.json /var/lib/vtsearch/timings.jsonl
+
+This has no side effects, needs no exemplar data, and measures the datasets your
+users actually load at the sizes they actually are — a mix no synthetic sweep
+reproduces. It is the right default for a production system.
+
+**2. Drive the workloads.** When you want numbers *now* — commissioning a new
+node, or after a hardware change — ``--drive`` exercises the task families
+against datasets and detectors you name::
+
+    python scripts/profiling/tune_timing_profile.py --drive \\
+        --out timing-profile.json --datasets ds-a,ds-b,ds-c --reps 3
+
+By default ``--drive`` runs only the **read-only** families: opening a dataset,
+text search, and Find. The rest mutate state — loading a detector seeds example
+votes, train-and-score *overwrites the active dataset's labels*, promote creates
+a dataset, and an import writes one — so they need ``--allow-mutating`` and
+should be pointed at a scratch ``--data-dir``, never at live user data.
+
+Both modes end the same way: the fit runs, the profile is written, and a coverage
+report says exactly which task families got measured and which fell back to the
+built-in defaults. Deploy it with::
+
+    VTSEARCH_TIMING_PROFILE=/etc/vtsearch/timing-profile.json
+
+Re-run it whenever the hardware changes. The profile only ever affects how
+progress bars pace and predict; a stale or missing one costs accuracy, never
+correctness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ``python scripts/profiling/x.py`` only puts the script's own directory on
+# sys.path, so make the repo root (where app.py lives) importable from any cwd.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+#: Families whose driver only reads: safe to run against live production data.
+_READ_ONLY_TASKS = ("dataset_open", "text_sort", "find")
+
+#: Families whose driver writes something a user would notice. Gated behind
+#: ``--allow-mutating`` with the specific hazard named, because "the tuning
+#: script wiped my votes" is not a tradeoff anyone would have accepted if asked.
+_MUTATING_TASKS = {
+    "detector_load": "loads detectors and seeds their example votes into the active dataset",
+    "train_and_score": "OVERWRITES every label in the active dataset (replace_all)",
+    "dataset_promote": "creates new datasets in the registry",
+    "dataset_load": "imports demo datasets, downloading and writing them",
+}
+
+#: How long to wait for one background task before giving up on the cell.
+_TASK_TIMEOUT_S = 3600
+
+
+def _log(*parts: object) -> None:
+    print("[tune]", *parts, file=sys.stderr, flush=True)
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("jsonl", nargs="*", help="recorded JSONL to fit (with --fit-only)")
+    ap.add_argument("--out", required=True, help="profile JSON to write")
+    ap.add_argument(
+        "--record",
+        default="",
+        help="JSONL sink the drivers record into (default: <out>.jsonl)",
+    )
+    ap.add_argument(
+        "--fit-only",
+        action="store_true",
+        help="fit the given JSONL without driving anything (the observe-real-usage flow)",
+    )
+    ap.add_argument("--drive", action="store_true", help="exercise the task families in-process")
+    ap.add_argument(
+        "--tasks",
+        default="",
+        help=f"comma list of task families to drive (default: {','.join(_READ_ONLY_TASKS)})",
+    )
+    ap.add_argument(
+        "--allow-mutating",
+        action="store_true",
+        help="permit drivers that change state; point --data-dir at scratch data first",
+    )
+    ap.add_argument("--datasets", default="", help="comma list of registry dataset ids or names")
+    ap.add_argument("--detectors", default="", help="comma list of registry detector ids or names")
+    ap.add_argument("--demo", default="", help="comma list of demo dataset ids for dataset_load")
+    ap.add_argument(
+        "--queries",
+        default="a person,an outdoor scene,music",
+        help="comma list of text-search queries for text_sort",
+    )
+    ap.add_argument("--reps", type=int, default=2, help="repetitions per cell (default 2)")
+    ap.add_argument(
+        "--min-samples",
+        type=int,
+        default=2,
+        help="drop fitted cells with fewer runs than this (default 2)",
+    )
+    ap.add_argument("--data-dir", default="", help="VTSEARCH_DATA_DIR for the driven run")
+    ap.add_argument("--notes", default="", help="free-text note stored in the profile")
+    ap.add_argument("--dry-run", action="store_true", help="print the plan and exit")
+    return ap.parse_args()
+
+
+def _split(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _resolve_tasks(args: argparse.Namespace) -> list[str]:
+    """Resolve which families to drive, refusing mutating ones unless allowed."""
+    from vtscore.timing import known_tasks  # noqa: PLC0415
+
+    wanted = _split(args.tasks) or list(_READ_ONLY_TASKS)
+    valid = set(known_tasks())
+    resolved: list[str] = []
+    for task in wanted:
+        if task not in valid:
+            _log(f"SKIPPED {task}: not a known task family")
+            continue
+        hazard = _MUTATING_TASKS.get(task)
+        if hazard and not args.allow_mutating:
+            _log(f"SKIPPED {task}: {hazard}. Pass --allow-mutating (with a scratch --data-dir) to include it.")
+            continue
+        resolved.append(task)
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Drivers
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_task(registry, task_id: str, label: str) -> bool:
+    """Block until a background task finishes. Returns ``False`` on timeout."""
+    if not task_id:
+        return False
+    deadline = time.monotonic() + _TASK_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if registry.is_finished(task_id):
+            return True
+        time.sleep(0.25)
+    _log(f"TIMEOUT waiting for {label}")
+    return False
+
+
+def _resolve_datasets(names: list[str]) -> list[dict]:
+    """Registry entries for the requested ids/names (all accessible if empty)."""
+    from vtscore.datasets.registry import list_datasets  # noqa: PLC0415
+
+    entries = list_datasets()
+    if not names:
+        return entries
+    wanted = set(names)
+    picked = [e for e in entries if e.get("id") in wanted or e.get("name") in wanted]
+    for name in wanted - {e.get("id") for e in picked} - {e.get("name") for e in picked}:
+        _log(f"SKIPPED dataset {name!r}: not in the registry")
+    return picked
+
+
+def _resolve_detectors(names: list[str]) -> list[dict]:
+    """Registry entries for the requested detector ids/names (all if empty)."""
+    from vtscore.detectors.registry import list_detectors  # noqa: PLC0415
+
+    entries = list_detectors()
+    if not names:
+        return entries
+    wanted = set(names)
+    picked = [e for e in entries if e.get("id") in wanted or e.get("name") in wanted]
+    for name in wanted - {e.get("id") for e in picked} - {e.get("name") for e in picked}:
+        _log(f"SKIPPED detector {name!r}: not in the registry")
+    return picked
+
+
+def _open_dataset(client, dataset_id: str, *, reopen: bool) -> bool:
+    """Load a dataset, optionally unloading first so the load is really measured."""
+    from vtscore.concurrency.progress import loading_tasks  # noqa: PLC0415
+
+    if reopen:
+        client.post(f"/api/datasets/registry/{dataset_id}/unload")
+    resp = client.post(f"/api/datasets/registry/{dataset_id}/load")
+    if resp.status_code != 200:
+        _log(f"SKIPPED dataset {dataset_id}: load returned {resp.status_code}")
+        return False
+    task_id = (resp.get_json() or {}).get("task_id") or ""
+    if not task_id:
+        return True  # already loaded; nothing was measured but the state is right
+    return _wait_for_task(loading_tasks, task_id, f"dataset {dataset_id}")
+
+
+def drive_dataset_open(client, datasets: list[dict], reps: int) -> None:
+    """Measure opening each dataset from its pkl (read + dedup, coverage atlas)."""
+    for entry in datasets:
+        for rep in range(reps):
+            _log(f"dataset_open {entry.get('name')} rep {rep + 1}/{reps}")
+            _open_dataset(client, entry["id"], reopen=True)
+
+
+def drive_text_sort(client, datasets: list[dict], queries: list[str], reps: int) -> None:
+    """Measure a text search (encoder load, query embed, score) per dataset."""
+    for entry in datasets:
+        if not _open_dataset(client, entry["id"], reopen=False):
+            continue
+        headers = {"X-Dataset-Id": entry["id"]}
+        for rep in range(reps):
+            for query in queries:
+                _log(f"text_sort {entry.get('name')} {query!r} rep {rep + 1}/{reps}")
+                resp = client.post("/api/sort", json={"text": query}, headers=headers)
+                if resp.status_code != 200:
+                    _log(f"SKIPPED text_sort on {entry.get('name')}: {resp.status_code}")
+                    break
+
+
+def drive_find(client, datasets: list[dict], detectors: list[dict], reps: int) -> None:
+    """Measure a Find pass over every (dataset, detector) media-type match."""
+    if not detectors:
+        _log("SKIPPED find: no detectors in the registry")
+        return
+    for entry in datasets:
+        matching = [d for d in detectors if d.get("media_type") == entry.get("media_type")]
+        if not matching:
+            _log(f"SKIPPED find on {entry.get('name')}: no detector of media type {entry.get('media_type')!r}")
+            continue
+        body = {"dataset_ids": [entry["id"]], "detector_ids": [d["id"] for d in matching]}
+        for rep in range(reps):
+            _log(f"find {entry.get('name')} × {len(matching)} detectors rep {rep + 1}/{reps}")
+            resp = client.post("/api/find", json=body)
+            if resp.status_code != 200:
+                _log(f"SKIPPED find on {entry.get('name')}: {resp.status_code}")
+                break
+
+
+def drive_detector_load(client, datasets: list[dict], detectors: list[dict], reps: int) -> None:
+    """Measure loading each detector (restore labels, seed examples, train)."""
+    from vtscore.concurrency.progress import detector_loading_tasks  # noqa: PLC0415
+
+    for detector in detectors:
+        host = next((d for d in datasets if d.get("media_type") == detector.get("media_type")), None)
+        if host is None or not _open_dataset(client, host["id"], reopen=False):
+            _log(f"SKIPPED detector_load {detector.get('name')}: no loadable dataset of its media type")
+            continue
+        headers = {"X-Dataset-Id": host["id"]}
+        for rep in range(reps):
+            _log(f"detector_load {detector.get('name')} rep {rep + 1}/{reps}")
+            client.post(f"/api/detectors/registry/{detector['id']}/unload", headers=headers)
+            resp = client.post(
+                "/api/detectors/registry/load",
+                json={"detector_id": detector["id"]},
+                headers=headers,
+            )
+            if resp.status_code != 200:
+                _log(f"SKIPPED detector_load {detector.get('name')}: {resp.status_code}")
+                break
+            task_id = (resp.get_json() or {}).get("task_id") or ""
+            _wait_for_task(detector_loading_tasks, task_id, f"detector {detector['id']}")
+
+
+def drive_train_and_score(client, datasets: list[dict], detectors: list[dict], reps: int) -> None:
+    """Measure a train-and-score pass. Destroys the active dataset's labels."""
+    for entry in datasets:
+        matching = [d for d in detectors if d.get("media_type") == entry.get("media_type")]
+        if not matching or not _open_dataset(client, entry["id"], reopen=False):
+            continue
+        headers = {"X-Dataset-Id": entry["id"], "X-Detector-Id": matching[0]["id"]}
+        for rep in range(reps):
+            _log(f"train_and_score {entry.get('name')} / {matching[0].get('name')} rep {rep + 1}/{reps}")
+            resp = client.post("/api/find-label", json={"detector_id": matching[0]["id"]}, headers=headers)
+            if resp.status_code != 200:
+                _log(f"SKIPPED train_and_score on {entry.get('name')}: {resp.status_code}")
+                break
+
+
+def drive_dataset_promote(client, datasets: list[dict], reps: int) -> None:
+    """Measure promoting a subset into a new dataset (atlas, serialize, register)."""
+    from vtscore.concurrency.progress import loading_tasks  # noqa: PLC0415
+
+    for entry in datasets:
+        if not _open_dataset(client, entry["id"], reopen=False):
+            continue
+        headers = {"X-Dataset-Id": entry["id"]}
+        listing = client.get("/api/medias", headers=headers)
+        if listing.status_code != 200:
+            _log(f"SKIPPED dataset_promote on {entry.get('name')}: cannot list medias")
+            continue
+        media_ids = [m["id"] for m in (listing.get_json() or {}).get("medias", [])]
+        if not media_ids:
+            _log(f"SKIPPED dataset_promote on {entry.get('name')}: no medias")
+            continue
+        for rep in range(reps):
+            _log(f"dataset_promote {entry.get('name')} ({len(media_ids)} items) rep {rep + 1}/{reps}")
+            resp = client.post(
+                "/api/dataset/promote",
+                json={"name": f"_tuning_{entry['id'][:8]}_{rep}", "media_ids": media_ids},
+                headers=headers,
+            )
+            if resp.status_code != 200:
+                _log(f"SKIPPED dataset_promote on {entry.get('name')}: {resp.status_code}")
+                break
+            task_id = (resp.get_json() or {}).get("task_id") or ""
+            _wait_for_task(loading_tasks, task_id, f"promote {entry['id']}")
+    _log("NOTE: dataset_promote left '_tuning_*' datasets in the registry; delete them when done.")
+
+
+def drive_dataset_load(demo_ids: list[str], reps: int) -> None:
+    """Measure importing demo datasets end to end (acquire, load, embed, finalize)."""
+    from vtscore.concurrency.progress import loading_tasks  # noqa: PLC0415
+    from vtscore.datasets.config import DEMO_DATASETS  # noqa: PLC0415
+    from vtscore.datasets.importers import get_importer  # noqa: PLC0415
+    from vtscore.datasets.load_pipeline import _run_importer_in_background  # noqa: PLC0415
+
+    if not demo_ids:
+        _log("SKIPPED dataset_load: no --demo ids given")
+        return
+    importer = get_importer("demo")
+    for demo_id in demo_ids:
+        info = DEMO_DATASETS.get(demo_id)
+        if info is None:
+            _log(f"SKIPPED demo {demo_id}: unknown demo dataset")
+            continue
+        for rep in range(reps):
+            _log(f"dataset_load {demo_id} rep {rep + 1}/{reps}")
+            task_id = _run_importer_in_background(
+                importer,
+                {"name": demo_id, "media_type": info.get("media_type", ""), "embedder": ""},
+            )
+            _wait_for_task(loading_tasks, task_id, f"demo {demo_id}")
+
+
+def run_drivers(args: argparse.Namespace, tasks: list[str]) -> None:
+    """Dispatch each requested family's driver against the resolved inputs."""
+    import app as app_module  # noqa: PLC0415 - wires Flask + every plugin registry
+
+    app_module.app.config["TESTING"] = True
+    datasets = _resolve_datasets(_split(args.datasets))
+    detectors = _resolve_detectors(_split(args.detectors))
+    if not datasets and tasks != ["dataset_load"]:
+        _log("nothing to drive: no datasets matched. Load or name at least one registry dataset.")
+    with app_module.app.test_client() as client:
+        if "dataset_open" in tasks:
+            drive_dataset_open(client, datasets, args.reps)
+        if "text_sort" in tasks:
+            drive_text_sort(client, datasets, _split(args.queries), args.reps)
+        if "find" in tasks:
+            drive_find(client, datasets, detectors, args.reps)
+        if "detector_load" in tasks:
+            drive_detector_load(client, datasets, detectors, args.reps)
+        if "train_and_score" in tasks:
+            drive_train_and_score(client, datasets, detectors, args.reps)
+        if "dataset_promote" in tasks:
+            drive_dataset_promote(client, datasets, args.reps)
+    if "dataset_load" in tasks:
+        drive_dataset_load(_split(args.demo), args.reps)
+
+
+# ---------------------------------------------------------------------------
+# Fit + emit
+# ---------------------------------------------------------------------------
+
+
+def write_profile(args: argparse.Namespace, jsonl_paths: list[str]) -> int:
+    """Fit the recorded rows, write the profile, and print the coverage report."""
+    from vtscore.timing.fit import coverage_report, fit_profile, load_rows  # noqa: PLC0415
+
+    existing = [p for p in jsonl_paths if Path(p).is_file()]
+    missing = [p for p in jsonl_paths if p not in existing]
+    for path in missing:
+        _log(f"SKIPPED {path}: no such file")
+    if not existing:
+        _log("no timing rows to fit — nothing written")
+        return 1
+
+    rows = load_rows(existing)
+    _log(f"read {len(rows)} recorded rows from {len(existing)} file(s)")
+    profile = fit_profile(
+        rows,
+        min_samples=args.min_samples,
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        host=socket.gethostname(),
+        notes=args.notes,
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    _log(f"wrote {out}")
+    _log("coverage:")
+    for line in coverage_report(rows, profile):
+        print(line, file=sys.stderr)
+    if not profile.get("tasks"):
+        _log("WARNING: no cell had enough runs to fit. The profile is empty and every")
+        _log("         task will keep using its built-in defaults. Record more runs,")
+        _log("         or lower --min-samples if you accept thinner evidence.")
+        return 1
+    _log(f"deploy with: VTSEARCH_TIMING_PROFILE={out.resolve()}")
+    return 0
+
+
+def main() -> int:
+    args = _parse_args()
+    record_path = args.record or f"{args.out}.jsonl"
+
+    if not args.fit_only and not args.drive:
+        _log("pass --drive to exercise the workloads, or --fit-only to fit already-recorded JSONL.")
+        return 2
+
+    if args.fit_only:
+        sources = args.jsonl or ([args.record] if args.record else [])
+        if not sources:
+            _log("--fit-only needs at least one recorded JSONL path (or --record).")
+            return 2
+        if args.dry_run:
+            _log(f"would fit {sources} into {args.out}")
+            return 0
+        return write_profile(args, sources)
+
+    # Drive mode: arm the recorder and isolate the data dir *before* importing
+    # the app, since both are read at import time.
+    os.environ["VTSEARCH_TIMING_RECORD"] = os.path.abspath(record_path)
+    if args.data_dir:
+        Path(args.data_dir).mkdir(parents=True, exist_ok=True)
+        os.environ["VTSEARCH_DATA_DIR"] = os.path.abspath(args.data_dir)
+    # A profile already in the environment would pace the very loads being
+    # measured, folding the old profile's opinions into the new one's timings.
+    os.environ.pop("VTSEARCH_TIMING_PROFILE", None)
+
+    tasks = _resolve_tasks(args)
+    if not tasks:
+        _log("no task families left to drive")
+        return 2
+    _log(f"driving: {', '.join(tasks)}  (reps={args.reps}, record={record_path})")
+    if args.dry_run:
+        return 0
+
+    run_drivers(args, tasks)
+    return write_profile(args, [record_path] + list(args.jsonl))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -123,15 +123,18 @@ class TestProgressTrackerEta:
         tracker.update("loading", "", 0, 100)
         now[0] += 10.0
         tracker.update("loading", "", 10, 100)
-        first = tracker.get()["eta_seconds"]
+        first = tracker._smoothed_eta
         assert first is not None
 
         # Pretend the rate suddenly doubles: 10 more units in just 1s.
         now[0] += 1.0
         tracker.update("loading", "", 20, 100)
-        smoothed = tracker.get()["eta_seconds"]
+        smoothed = tracker._smoothed_eta
         # Raw new ETA = (11 / 20) * 80 = 44s. Smoothed with alpha=0.3 against
         # the previous ~90s sample sits well above 44 and below the old 90.
+        # Asserted on the *internal* estimate: what gets published is snapped to
+        # the coarse ETA ladder (see TestHumbleEta), and a step this small is
+        # precisely what the ladder exists to absorb.
         assert smoothed is not None
         assert 44.0 < smoothed < first
 

--- a/tests_lib/core/test_progress_overall.py
+++ b/tests_lib/core/test_progress_overall.py
@@ -10,11 +10,18 @@ import time
 
 import pytest
 
-from vtscore.concurrency.progress import ProgressTracker, _PROGRESS_COMMON_EXTRAS
+from vtscore.concurrency.progress import _ETA_LADDER, ProgressTracker, _PROGRESS_COMMON_EXTRAS
 
 
 def _tracker() -> ProgressTracker:
     return ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
+
+
+def _shown(tracker: ProgressTracker, raw: float) -> float:
+    """The rung ``tracker`` would publish for *raw*, narrowed to non-``None``."""
+    rung = tracker._humble_eta(float(raw))
+    assert rung is not None, f"expected a rung for {raw}"
+    return rung
 
 
 class TestOverallFraction:
@@ -235,6 +242,94 @@ class TestOverallEta:
         # remaining 0.679 reads as minutes — not the tens of seconds the
         # banked warm spans used to suggest.
         assert eta > 100.0
+
+
+class TestHumbleEta:
+    """The published ``eta_seconds`` is coarse and sticky.
+
+    A raw estimate reported to the second reads as a system that has no idea:
+    "9 min left … 10 min … 9.5 min … 11 min". The tracker therefore publishes the
+    nearest rung of a coarse ladder and holds it until the estimate moves
+    decisively. These tests pin both halves — the coarseness and the stickiness —
+    plus the cases where the display *must* still move.
+    """
+
+    def test_published_values_are_always_ladder_rungs(self):
+        t = _tracker()
+        for raw in (3, 12, 47, 121, 400, 1000, 5000, 40_000, 10**7):
+            t._eta_rung = None  # each value judged fresh
+            assert t._humble_eta(float(raw)) in _ETA_LADDER
+
+    def test_a_wobbling_estimate_never_moves_the_display(self):
+        # The exact complaint this exists to fix: an estimate oscillating around
+        # ten minutes must read "about 10 min" the entire time.
+        t = _tracker()
+        shown = [t._humble_eta(float(raw)) for raw in (540, 600, 570, 660, 620, 700, 520, 480)]
+        assert set(shown) == {600.0}
+
+    def test_a_sustained_slowdown_is_still_reported(self):
+        # Humility is not silence. A job that really is taking longer must say
+        # so; clamping the display to never rise would move the lie from the
+        # number to its trend.
+        t = _tracker()
+        shown = [_shown(t, raw) for raw in (600, 900, 1300, 2000, 3000)]
+        assert shown[-1] > shown[0]
+        assert shown == sorted(shown)
+
+    def test_a_large_correction_jumps_straight_to_the_new_rung(self):
+        # One rung per update would lag badly on a slow-updating job; a decisive
+        # move should be believed at once.
+        t = _tracker()
+        assert t._humble_eta(600.0) == 600.0
+        assert t._humble_eta(30.0) == 30.0
+
+    def test_small_moves_toward_a_neighbour_do_not_cross_it(self):
+        t = _tracker()
+        assert t._humble_eta(600.0) == 600.0
+        # 450 and 900 are the neighbours; their boundaries with 600 sit at
+        # ~520 and ~735, and the hysteresis margin pushes those further out.
+        assert t._humble_eta(530.0) == 600.0
+        assert t._humble_eta(720.0) == 600.0
+
+    def test_below_and_above_the_ladder_clamp_to_its_ends(self):
+        t = _tracker()
+        assert t._humble_eta(0.4) == _ETA_LADDER[0]
+        t2 = _tracker()
+        assert t2._humble_eta(10**9) == _ETA_LADDER[-1]
+
+    @pytest.mark.parametrize("bad", [None, 0.0, -5.0, float("inf"), float("nan")])
+    def test_no_estimate_clears_the_held_rung(self, bad):
+        t = _tracker()
+        t._humble_eta(600.0)
+        assert t._humble_eta(bad) is None
+        assert t._eta_rung is None
+
+    def test_a_new_job_does_not_inherit_the_previous_rung(self, monkeypatch):
+        t = _tracker()
+        clock = {"now": 0.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+        t.update("downloading", "x", current=0, total=100, step=1, total_steps=2)
+        clock["now"] = 20.0
+        t.update("downloading", "x", current=10, total=100, step=1, total_steps=2)
+        assert t.get()["eta_seconds"] is not None
+        # A different step structure reads as a brand-new job.
+        t.update("running", "y", current=0, total=10, step=1, total_steps=3)
+        assert t.get()["eta_seconds"] is None
+        assert t._eta_rung is None
+
+    def test_the_internal_estimate_stays_unquantized(self, monkeypatch):
+        # Feeding the snapped value back into the EMA would let the ladder
+        # capture the estimate and stop it converging at all, so only the
+        # published field is coarsened.
+        t = _tracker()
+        clock = {"now": 0.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+        t.update("embedding", "x", current=0, total=1000)
+        clock["now"] = 10.0
+        t.update("embedding", "x", current=70, total=1000)
+        # 10s bought 70 of 1000 items, so 930 remain at 7/s ≈ 132.9s.
+        assert t._smoothed_eta == pytest.approx(132.857, rel=1e-3)
+        assert t.get()["eta_seconds"] == 120.0  # the nearest rung
 
 
 class TestFinalizeProgress:

--- a/tests_lib/core/test_timing_profile.py
+++ b/tests_lib/core/test_timing_profile.py
@@ -1,0 +1,291 @@
+"""Tests for the per-environment timing profile (:mod:`vtscore.timing`).
+
+Three things have to hold for the profile to be worth having:
+
+1. **An instance with no profile behaves exactly as it always did.** The shipped
+   defaults reproduce the hand-tuned vectors these tasks carried before, so
+   adopting the mechanism is not itself a behaviour change.
+2. **A profile actually changes the pacing, in the direction the measurement
+   says.** A cheap step should get a small slice, and the same task at two very
+   different sizes should get two different splits.
+3. **A broken profile costs nothing but accuracy.** Bad JSON, an unknown task, a
+   future schema version — none of them may raise into a progress update.
+"""
+
+import json
+
+import pytest
+
+from vtscore import timing
+from vtscore.timing import profile as timing_profile
+from vtscore.timing.profile import EMPTY_PROFILE, StepCoeffs, parse_profile
+from vtscore.timing.tasks import TASKS
+
+
+@pytest.fixture(autouse=True)
+def _clean_profile():
+    """Every test starts and ends with the built-in defaults active."""
+    timing.reload_profile("")
+    yield
+    timing.reload_profile("")
+
+
+def _write(tmp_path, doc, name="profile.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return str(path)
+
+
+def _profile(tasks):
+    return {"schema": "vtsearch-timing-profile", "version": 1, "tasks": tasks}
+
+
+def _weights(task: str, **kwargs) -> list[float]:
+    """``step_weights`` narrowed to non-``None`` (its no-coverage return)."""
+    weights = timing.step_weights(task, **kwargs)
+    assert weights is not None, f"expected weights for {task}"
+    return weights
+
+
+def _terms(task: str, **kwargs) -> dict[str, float]:
+    """``step_terms`` narrowed to non-``None`` (its no-coverage return)."""
+    terms = timing.step_terms(task, **kwargs)
+    assert terms is not None, f"expected terms for {task}"
+    return terms
+
+
+def _shares(task: str, step: str, **kwargs) -> dict[str, float]:
+    """``slot_shares`` narrowed to non-``None``."""
+    shares = timing.slot_shares(task, step, **kwargs)
+    assert shares is not None, f"expected slot shares for {task}.{step}"
+    return shares
+
+
+class TestShippedDefaults:
+    def test_every_task_declares_a_consistent_spec(self):
+        for name, spec in TASKS.items():
+            assert spec.name == name
+            assert len(spec.step_index) == len(spec.steps)
+            assert max(spec.step_index) == spec.tracker_steps
+            assert set(spec.byte_scaled) <= set(spec.steps)
+
+    def test_defaults_reproduce_the_pre_profile_vectors(self):
+        # These are the literal vectors the tasks shipped with before the
+        # profile existed. An instance with no VTSEARCH_TIMING_PROFILE must
+        # pace identically to how it did then.
+        assert _weights("text_sort", device="cpu") == pytest.approx([0.75, 0.05, 0.20])
+        assert _weights("find", device="cpu") == pytest.approx([0.10, 0.30, 0.60])
+        assert _weights("train_and_score", device="cpu") == pytest.approx([0.10, 0.45, 0.40, 0.05])
+        assert _weights("detector_load", device="cpu") == pytest.approx([0.15, 0.15, 0.70])
+        assert _weights("dataset_open", device="cpu") == pytest.approx([0.15, 0.85])
+        assert _weights("dataset_promote", device="cpu") == pytest.approx([0.6, 0.35, 0.05])
+
+    def test_unknown_task_returns_the_callers_fallback(self):
+        assert timing.step_weights("not_a_task", fallback=[1.0, 2.0]) == [1.0, 2.0]
+        assert timing.step_weights("not_a_task") is None
+
+    def test_dataset_load_defers_to_its_own_cost_model(self):
+        # dataset_load deliberately ships no flat default terms: its default is
+        # the measured affine table in _load_cost_model, which is n-aware.
+        assert TASKS["dataset_load"].default_terms == ()
+        assert timing.step_terms("dataset_load", device="cpu", n=100) is None
+
+
+class TestCellLookup:
+    def test_keys_run_specific_to_general(self):
+        keys = timing.cell_keys("cpu", "image", "siglip")
+        assert keys == ("cpu|image|siglip", "cpu|image|", "cpu||")
+
+    def test_cuda_tries_both_cuml_variants_before_generalizing(self, monkeypatch):
+        monkeypatch.setattr(timing_profile, "cuml_active", lambda: True)
+        keys = timing.cell_keys("cuda:0", "image", "siglip")
+        # cuML-on first (it matches this host), but the cuML-off row for the
+        # exact media+embedder still beats a media-agnostic row.
+        assert keys[:2] == ("cuda+cuml|image|siglip", "cuda|image|siglip")
+        assert keys[-1] == "cuda||"
+
+    def test_exact_cell_wins_over_rollup(self, tmp_path):
+        path = _write(
+            tmp_path,
+            _profile(
+                {
+                    "text_sort": {
+                        "cells": {
+                            "cpu|image|siglip": {"steps": {"load_model": 90.0, "score": 10.0}},
+                            "cpu||": {"steps": {"load_model": 1.0, "score": 99.0}},
+                        }
+                    }
+                }
+            ),
+        )
+        timing.reload_profile(path)
+        exact = _weights("text_sort", device="cpu", media_type="image", embedder="siglip")
+        rollup = _weights("text_sort", device="cpu", media_type="audio", embedder="clap")
+        assert exact[0] > exact[2]  # the exact cell says the model load dominates
+        assert rollup[0] < rollup[2]  # the rollup says scoring does
+
+    def test_wildcard_spellings_are_equivalent(self, tmp_path):
+        path = _write(tmp_path, _profile({"find": {"cells": {"cpu|*|*": {"steps": {"score": 100.0}}}}}))
+        timing.reload_profile(path)
+        weights = _weights("find", device="cpu", media_type="video", embedder="xclip")
+        assert weights[2] > 0.9
+
+    def test_unnamed_steps_keep_their_shipped_default(self, tmp_path):
+        # A partial measurement improves the steps it covers without blanking
+        # the ones it doesn't.
+        path = _write(tmp_path, _profile({"text_sort": {"cells": {"cpu||": {"steps": {"load_model": 3.0}}}}}))
+        timing.reload_profile(path)
+        terms = _terms("text_sort", device="cpu")
+        assert terms["load_model"] == pytest.approx(3.0)
+        assert terms["embed_query"] == pytest.approx(0.05)  # shipped default
+        assert terms["score"] == pytest.approx(0.20)  # shipped default
+
+
+class TestAffineScaling:
+    def test_same_task_paces_differently_at_different_sizes(self, tmp_path):
+        # The whole point: an 8s encoder load is most of a 1000-item sort and a
+        # rounding error on a 500k-item one. One static vector cannot say both.
+        path = _write(
+            tmp_path,
+            _profile(
+                {
+                    "text_sort": {
+                        "cells": {
+                            "cpu||": {
+                                "steps": {
+                                    "load_model": {"a": 8.0},
+                                    "embed_query": {"a": 0.04},
+                                    "score": {"a": 0.1, "b": 0.0002},
+                                }
+                            }
+                        }
+                    }
+                }
+            ),
+        )
+        timing.reload_profile(path)
+        small = _weights("text_sort", device="cpu", n=1_000)
+        large = _weights("text_sort", device="cpu", n=500_000)
+        assert small[0] > 0.9  # tiny sort: the model load is the whole job
+        assert large[2] > 0.9  # huge sort: scoring is
+        assert sum(small) == pytest.approx(1.0)
+        assert sum(large) == pytest.approx(1.0)
+
+    def test_byte_scaled_terms_track_archive_size(self):
+        coeffs = StepCoeffs(per_mb=0.1)
+        assert coeffs.seconds(n=999_999, size_mb=100.0) == pytest.approx(10.0)
+        assert coeffs.seconds(n=999_999, size_mb=0.0) == pytest.approx(0.0)
+
+    def test_negative_intercept_is_clamped(self):
+        # A steep least-squares slope can overshoot into a negative intercept;
+        # a step must never be handed a negative slice of the bar.
+        assert StepCoeffs(a=-5.0, b=0.001).seconds(n=100) == 0.0
+
+    def test_phases_sharing_a_tracker_step_are_summed(self, tmp_path):
+        # dataset_load's download and extract both report against step 1, so the
+        # weight vector is 4 long even though the cost model has 5 phases.
+        path = _write(
+            tmp_path,
+            _profile(
+                {
+                    "dataset_load": {
+                        "cells": {
+                            "cpu||": {
+                                "steps": {
+                                    "download": {"a": 30.0},
+                                    "extract": {"a": 10.0},
+                                    "load": {"a": 10.0},
+                                    "embed": {"a": 40.0},
+                                    "finalize": {"a": 10.0},
+                                }
+                            }
+                        }
+                    }
+                }
+            ),
+        )
+        timing.reload_profile(path)
+        weights = _weights("dataset_load", device="cpu", n=100)
+        assert len(weights) == 4
+        assert weights[0] == pytest.approx(0.4)  # download + extract share step 1
+
+
+class TestSlotShares:
+    def test_slot_shares_resolve_through_the_same_cell_chain(self, tmp_path):
+        path = _write(
+            tmp_path,
+            _profile(
+                {
+                    "dataset_load": {
+                        "cells": {
+                            "cpu|image|": {
+                                "steps": {"finalize": {"a": 1.0}},
+                                "slots": {"finalize": {"coverage": 0.8, "registry": 0.2}},
+                            }
+                        }
+                    }
+                }
+            ),
+        )
+        timing.reload_profile(path)
+        shares = _shares("dataset_load", "finalize", device="cpu", media_type="image")
+        assert shares == {"coverage": 0.8, "registry": 0.2}
+        assert timing.slot_shares("dataset_load", "finalize", device="cpu", media_type="audio") is None
+        assert timing.slot_shares("dataset_load", "embed", device="cpu", media_type="image") is None
+
+
+class TestMalformedProfilesAreHarmless:
+    @pytest.mark.parametrize(
+        "doc",
+        [
+            "not an object",
+            {"schema": "something-else", "version": 1, "tasks": {}},
+            {"schema": "vtsearch-timing-profile", "version": 99, "tasks": {}},
+            {"schema": "vtsearch-timing-profile", "version": 0, "tasks": {}},
+            {"schema": "vtsearch-timing-profile", "version": 1},
+        ],
+    )
+    def test_unusable_documents_yield_an_empty_profile(self, doc):
+        assert parse_profile(doc, source="test") is EMPTY_PROFILE
+
+    def test_invalid_json_falls_back_to_defaults(self, tmp_path):
+        path = tmp_path / "broken.json"
+        path.write_text("{ this is not json", encoding="utf-8")
+        timing.reload_profile(str(path))
+        assert not timing.active_profile()
+        assert _weights("text_sort", device="cpu") == pytest.approx([0.75, 0.05, 0.20])
+
+    def test_missing_file_falls_back_to_defaults(self, tmp_path):
+        timing.reload_profile(str(tmp_path / "nope.json"))
+        assert not timing.active_profile()
+        assert _weights("find", device="cpu") == pytest.approx([0.10, 0.30, 0.60])
+
+    def test_unknown_task_and_step_are_dropped_not_fatal(self, tmp_path):
+        path = _write(
+            tmp_path,
+            _profile(
+                {
+                    "task_from_the_future": {"cells": {"cpu||": {"steps": {"whatever": 1.0}}}},
+                    "text_sort": {"cells": {"cpu||": {"steps": {"score": 5.0, "not_a_step": 99.0}}}},
+                }
+            ),
+        )
+        timing.reload_profile(path)
+        terms = _terms("text_sort", device="cpu")
+        assert terms["score"] == pytest.approx(5.0)
+        assert set(terms) == set(TASKS["text_sort"].steps)
+
+    def test_all_zero_cell_falls_back_rather_than_dividing_by_zero(self, tmp_path):
+        path = _write(
+            tmp_path,
+            _profile({"find": {"cells": {"cpu||": {"steps": {"prepare": 0.0, "load": 0.0, "score": 0.0}}}}}),
+        )
+        timing.reload_profile(path)
+        assert timing.step_terms("find", device="cpu") is None
+        assert timing.step_weights("find", device="cpu", fallback=[1.0, 1.0, 1.0]) == [1.0, 1.0, 1.0]
+
+    def test_bare_number_is_shorthand_for_a_fixed_cost(self):
+        assert StepCoeffs.from_json(4) == StepCoeffs(a=4.0)
+        assert StepCoeffs.from_json("nope") is None
+        assert StepCoeffs.from_json({"a": "nope"}) is None
+        assert StepCoeffs.from_json(True) is None

--- a/tests_lib/core/test_timing_recorder_and_fit.py
+++ b/tests_lib/core/test_timing_recorder_and_fit.py
@@ -1,0 +1,398 @@
+"""Tests for the timing recorder and the fit that turns its rows into a profile.
+
+The recorder and the fitter are the two halves of the tuning loop, so they are
+tested together and end-to-end: rows recorded from a simulated task must fit into
+a profile that the reader then loads and paces with. If that round trip works,
+an admin's sweep works.
+"""
+
+import json
+
+import pytest
+
+from vtscore import timing
+from vtscore.concurrency.progress import _PROGRESS_COMMON_EXTRAS, ProgressTracker
+from vtscore.timing import profile as timing_profile
+from vtscore.timing import recorder as timing_recorder
+from vtscore.timing.fit import (
+    affine_fit,
+    coverage_report,
+    device_key,
+    fit_profile,
+    fit_step,
+    load_rows,
+    normalize_row,
+)
+from vtscore.timing.profile import StepCoeffs
+from vtscore.timing.recorder import RECORD_ENV_VAR, record_task, recording_enabled
+
+
+def _row(raw: dict) -> dict:
+    """``normalize_row`` narrowed to non-``None`` (its reject return)."""
+    row = normalize_row(raw)
+    assert row is not None, f"expected {raw} to normalize"
+    return row
+
+
+def _fit(samples: list[dict], *, byte_scaled: bool) -> StepCoeffs:
+    """``fit_step`` narrowed to non-``None`` (its no-samples return)."""
+    coeffs = fit_step(samples, byte_scaled)
+    assert coeffs is not None
+    return coeffs
+
+
+def _weights(task: str, **kwargs) -> list[float]:
+    """``step_weights`` narrowed to non-``None`` (its no-coverage return)."""
+    weights = timing.step_weights(task, **kwargs)
+    assert weights is not None, f"expected weights for {task}"
+    return weights
+
+
+def _tracker() -> ProgressTracker:
+    return ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
+
+
+@pytest.fixture
+def sink(tmp_path, monkeypatch):
+    """Arm the recorder at a temp JSONL and yield a reader for what it wrote.
+
+    Reading goes through :func:`load_rows`, so every test that inspects recorded
+    output also exercises the path the tuning script takes.
+    """
+    path = tmp_path / "timings.jsonl"
+    monkeypatch.setenv(RECORD_ENV_VAR, str(path))
+
+    def read():
+        return load_rows([str(path)]) if path.exists() else []
+
+    read.path = str(path)
+    return read
+
+
+class TestRecorderArming:
+    def test_disarmed_by_default(self, monkeypatch):
+        monkeypatch.delenv(RECORD_ENV_VAR, raising=False)
+        assert not recording_enabled()
+        # The no-op stand-in must accept the whole surface without a tracker
+        # ever being subscribed, so call sites need no branching.
+        tracker = _tracker()
+        with record_task(tracker, "text_sort") as rec:
+            rec.set_scale(n=10)
+        rec.finish(ok=True)
+        assert tracker._subscribers == []
+
+    def test_armed_recorder_unsubscribes_on_finish(self, sink, monkeypatch):
+        tracker = _tracker()
+        rec = record_task(tracker, "text_sort")
+        rec.start()
+        assert len(tracker._subscribers) == 1
+        rec.finish()
+        assert tracker._subscribers == []
+
+
+class TestRecordedRows:
+    def _run_text_sort(self, tracker, rec, *, skip_model_load=False):
+        if not skip_model_load:
+            tracker.update("sorting", "loading", 0, 0, step=1, total_steps=3)
+        tracker.update("sorting", "embedding", 0, 0, step=2, total_steps=3)
+        tracker.update("sorting", "scoring", 0, 0, step=3, total_steps=3)
+        rec.set_scale(n=1234)
+
+    def test_one_row_per_declared_step(self, sink):
+        tracker = _tracker()
+        with record_task(tracker, "text_sort", media_type="image", embedder="siglip") as rec:
+            self._run_text_sort(tracker, rec)
+        rows = sink()
+        assert [r["step"] for r in rows] == ["load_model", "embed_query", "score"]
+        assert all(r["task"] == "text_sort" and r["n"] == 1234 for r in rows)
+        assert all(r["ok"] and r["complete"] for r in rows)
+
+    def test_a_skipped_step_is_recorded_as_zero_not_dropped(self, sink):
+        # A warm text sort never enters load_model because the encoder is
+        # already resident. That is a real measurement of zero, and dropping it
+        # would leave the fit permanently over-budgeting the phase.
+        tracker = _tracker()
+        with record_task(tracker, "text_sort") as rec:
+            self._run_text_sort(tracker, rec, skip_model_load=True)
+        rows = {r["step"]: r for r in sink()}
+        assert set(rows) == {"load_model", "embed_query", "score"}
+        assert rows["load_model"]["seconds"] == 0.0
+        assert rows["load_model"]["complete"] is True
+
+    def test_a_run_that_stops_early_is_marked_incomplete(self, sink):
+        tracker = _tracker()
+        rec = record_task(tracker, "text_sort")
+        rec.start()
+        tracker.update("sorting", "loading", 0, 0, step=1, total_steps=3)
+        rec.finish(ok=False)
+        rows = sink()
+        assert rows and all(not r["complete"] and not r["ok"] for r in rows)
+        assert [r["step"] for r in rows] == ["load_model"]
+
+    def test_exception_inside_the_context_marks_the_run_bad(self, sink):
+        tracker = _tracker()
+        with pytest.raises(RuntimeError):
+            with record_task(tracker, "find") as rec:
+                tracker.update("running", "prepare", 0, 0, step=1, total_steps=3)
+                rec.set_scale(n=5)
+                raise RuntimeError("boom")
+        assert all(not r["ok"] for r in sink())
+
+    def test_auto_finish_closes_on_a_terminal_status(self, sink):
+        # Singleton trackers (sort_progress, find_progress) end by parking at
+        # "idle" on every exit path, which is a far more reliable end-of-task
+        # signal than a finally on a route handler full of aborts.
+        tracker = _tracker()
+        rec = record_task(tracker, "find", auto_finish=True)
+        rec.start()
+        for step in (1, 2, 3):
+            tracker.update("running", "x", 0, 0, step=step, total_steps=3)
+        rec.set_scale(n=99)
+        tracker.update("idle", "", 0, 0, step=None, total_steps=None)
+        assert tracker._subscribers == []  # closed itself
+        rows = sink()
+        assert [r["step"] for r in rows] == ["prepare", "load", "score"]
+        assert all(r["ok"] and r["complete"] for r in rows)
+
+    def test_auto_finish_marks_an_errored_end_bad(self, sink):
+        tracker = _tracker()
+        rec = record_task(tracker, "find", auto_finish=True)
+        rec.start()
+        tracker.update("running", "x", 0, 0, step=1, total_steps=3)
+        tracker.update("idle", "", 0, 0, step=None, total_steps=None, error="Cancelled")
+        assert all(not r["ok"] for r in sink())
+
+    def test_status_phases_disambiguate_a_shared_step(self, sink):
+        # dataset_load's step 1 is both the transfer and the unpack; only the
+        # status tells them apart.
+        tracker = _tracker()
+        with record_task(tracker, "dataset_load", status_phases={"extracting": "extract"}) as rec:
+            tracker.update("downloading", "", 0, 0, step=1, total_steps=4)
+            tracker.update("extracting", "", 0, 0, step=1, total_steps=4)
+            tracker.update("loading", "", 0, 0, step=2, total_steps=4)
+            tracker.update("embedding", "", 0, 0, step=3, total_steps=4)
+            tracker.update("finalizing", "", 0, 0, step=4, total_steps=4)
+            rec.set_scale(n=500, size_mb=120.0)
+        rows = sink()
+        assert [r["step"] for r in rows] == ["download", "extract", "load", "embed", "finalize"]
+        assert all(r["size_mb"] == 120.0 for r in rows)
+
+    def test_a_run_with_no_steps_writes_nothing(self, sink):
+        tracker = _tracker()
+        with record_task(tracker, "text_sort"):
+            tracker.update("idle", "", 0, 0)
+        assert sink() == []
+
+
+class TestNormalizeRow:
+    def test_generic_row_round_trips(self):
+        row = _row(
+            {
+                "task": "find",
+                "device": "cuda:0",
+                "cuml": True,
+                "media_type": "image",
+                "embedder": "siglip",
+                "n": 10,
+                "size_mb": 0,
+                "step": "score",
+                "seconds": 1.5,
+                "ok": True,
+                "complete": True,
+            }
+        )
+        assert row["device"] == "cuda+cuml"
+        assert row["step"] == "score"
+        assert row["seconds"] == 1.5
+
+    def test_legacy_load_profiler_row_is_understood(self):
+        # An existing dataset-load calibration sweep folds into a new profile
+        # rather than having to be re-measured.
+        row = _row(
+            {
+                "device": "cuda",
+                "media_type": "image",
+                "embedder": "siglip",
+                "n": 500,
+                "download_size_mb": 120.0,
+                "phase": "model_load",
+                "seconds": 0.5,
+                "cuml": False,
+            }
+        )
+        assert row["task"] == "dataset_load"
+        assert row["step"] == "load"  # phase name mapped onto the registry's
+        assert row["device"] == "cuda"
+        assert row["size_mb"] == 120.0
+
+    def test_legacy_sub_slot_row_becomes_a_slot_sample(self):
+        row = _row(
+            {
+                "device": "cpu",
+                "media_type": "image",
+                "embedder": "",
+                "n": 5,
+                "phase": "finalize:coverage",
+                "seconds": 2.0,
+            }
+        )
+        assert (row["step"], row["slot"]) == ("finalize", "coverage")
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            {"task": "text_sort", "step": "score", "seconds": 1.0, "ok": False, "complete": True},
+            {"task": "text_sort", "step": "score", "seconds": 1.0, "ok": True, "complete": False},
+            {"task": "text_sort", "step": "not_a_step", "seconds": 1.0},
+            {"task": "who_knows", "step": "score", "seconds": 1.0},
+            {"phase": "embed", "seconds": 1.0, "n": 0},  # legacy failed load
+            {"task": "text_sort", "step": "score"},  # no duration
+            {"seconds": 1.0},  # neither shape
+        ],
+    )
+    def test_unusable_rows_are_rejected(self, raw):
+        assert normalize_row(raw) is None
+
+    def test_device_key_splits_cuda_on_cuml(self):
+        assert device_key("cuda:0", True) == "cuda+cuml"
+        assert device_key("cuda", False) == "cuda"
+        assert device_key("cpu", True) == "cpu"
+
+
+class TestFitting:
+    def test_affine_fit_recovers_a_known_line(self):
+        xs = [0.0, 10.0, 20.0, 30.0]
+        ys = [2.0 + 0.5 * x for x in xs]
+        a, b, r2 = affine_fit(xs, ys)
+        assert a == pytest.approx(2.0)
+        assert b == pytest.approx(0.5)
+        assert r2 == pytest.approx(1.0)
+
+    def test_no_spread_in_n_yields_no_slope(self):
+        a, b, _ = affine_fit([100.0, 100.0, 100.0], [3.0, 4.0, 5.0])
+        assert b == 0.0
+        assert a == pytest.approx(4.0)
+
+    def test_a_negative_slope_collapses_to_the_median(self):
+        # Noise beating signal on a short step must not ship a coefficient that
+        # extrapolates to "this gets faster the bigger it gets".
+        samples = [
+            {"n": 100.0, "size_mb": 0.0, "seconds": 5.0},
+            {"n": 200.0, "size_mb": 0.0, "seconds": 3.0},
+            {"n": 300.0, "size_mb": 0.0, "seconds": 1.0},
+        ]
+        coeffs = _fit(samples, byte_scaled=False)
+        assert coeffs.b == 0.0
+        assert coeffs.a == pytest.approx(3.0)
+
+    def test_byte_scaled_step_fits_a_per_mb_rate(self):
+        samples = [
+            {"n": 500.0, "size_mb": 100.0, "seconds": 10.0},
+            {"n": 5000.0, "size_mb": 400.0, "seconds": 40.0},
+        ]
+        coeffs = _fit(samples, byte_scaled=True)
+        assert coeffs.per_mb == pytest.approx(0.1)
+        assert (coeffs.a, coeffs.b) == (0.0, 0.0)
+
+    def test_byte_scaled_step_with_no_archive_is_a_real_zero(self):
+        # Every measured load hit a warm cache: this deployment genuinely pays
+        # nothing to acquire, which is a measurement, not a missing one.
+        coeffs = _fit([{"n": 5.0, "size_mb": 0.0, "seconds": 0.0}], byte_scaled=True)
+        assert coeffs.per_mb == 0.0
+
+    def test_thin_cells_are_dropped(self):
+        rows = [
+            {
+                "task": "find",
+                "device": "cpu",
+                "media_type": "image",
+                "embedder": "siglip",
+                "n": 10,
+                "size_mb": 0,
+                "step": "score",
+                "seconds": 1.0,
+                "ok": True,
+                "complete": True,
+            }
+        ]
+        assert fit_profile(rows, min_samples=2)["tasks"] == {}
+        assert fit_profile(rows, min_samples=1)["tasks"]["find"]["cells"]
+
+    def test_rollup_cells_are_emitted_alongside_the_exact_one(self):
+        rows = []
+        for n in (100, 200):
+            rows.append(
+                {
+                    "task": "find",
+                    "device": "cpu",
+                    "media_type": "image",
+                    "embedder": "siglip",
+                    "n": n,
+                    "size_mb": 0,
+                    "step": "score",
+                    "seconds": 0.01 * n,
+                    "ok": True,
+                    "complete": True,
+                }
+            )
+        cells = fit_profile(rows, min_samples=2)["tasks"]["find"]["cells"]
+        assert set(cells) == {"cpu|image|siglip", "cpu|image|", "cpu||"}
+
+
+class TestRoundTrip:
+    def test_recorded_rows_fit_into_a_profile_that_paces_the_task(self, sink, tmp_path, monkeypatch):
+        # The whole tuning loop in one test: record a task at two sizes, fit,
+        # load the result, and check the pacing now reflects what was measured.
+        monkeypatch.setattr(timing_profile, "resolve_device_name", lambda: "cpu")
+        monkeypatch.setattr(timing_recorder, "resolve_device_name", lambda: "cpu")
+        monkeypatch.setattr(timing_profile, "cuml_active", lambda: False)
+        monkeypatch.setattr(timing_recorder, "cuml_active", lambda: False)
+
+        clock = {"t": 0.0}
+        monkeypatch.setattr(timing_recorder.time, "monotonic", lambda: clock["t"])
+
+        for n, score_secs in ((1_000, 1.0), (100_000, 100.0)):
+            tracker = _tracker()
+            with record_task(tracker, "text_sort", media_type="image", embedder="siglip") as rec:
+                tracker.update("sorting", "", 0, 0, step=1, total_steps=3)
+                clock["t"] += 8.0  # a fixed 8s encoder load, whatever the size
+                tracker.update("sorting", "", 0, 0, step=2, total_steps=3)
+                clock["t"] += 0.05
+                tracker.update("sorting", "", 0, 0, step=3, total_steps=3)
+                clock["t"] += score_secs  # scoring scales with n
+                rec.set_scale(n=n)
+
+        profile = fit_profile(sink(), min_samples=2)
+        path = tmp_path / "fitted.json"
+        path.write_text(json.dumps(profile), encoding="utf-8")
+
+        try:
+            timing.reload_profile(str(path))
+            small = _weights("text_sort", device="cpu", media_type="image", embedder="siglip", n=1_000)
+            large = _weights("text_sort", device="cpu", media_type="image", embedder="siglip", n=100_000)
+            # 8s load vs 1s score at n=1k; 8s load vs 100s score at n=100k.
+            assert small[0] > small[2]
+            assert large[2] > large[0]
+        finally:
+            timing.reload_profile("")
+
+    def test_coverage_report_names_the_unmeasured_families(self):
+        rows = [
+            {
+                "task": "find",
+                "device": "cpu",
+                "media_type": "",
+                "embedder": "",
+                "n": n,
+                "size_mb": 0,
+                "step": "score",
+                "seconds": 1.0,
+                "ok": True,
+                "complete": True,
+            }
+            for n in (10, 20)
+        ]
+        lines = "\n".join(coverage_report(rows, fit_profile(rows, min_samples=2)))
+        assert "find" in lines
+        assert "NOT MEASURED" in lines
+        assert "text_sort" in lines

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -1,10 +1,79 @@
 """Progress tracking for long-running operations."""
 
+import math
 import time
 import threading
 from typing import Any, Callable, Optional
 
 _UNSET = object()  # sentinel for "caller did not provide this argument"
+
+
+# ---------------------------------------------------------------------------
+# ETA humility
+# ---------------------------------------------------------------------------
+# A remaining-time estimate is an extrapolation from a rate that is still
+# changing. Reported to the second it is not just wrong, it is *visibly* wrong:
+# "9 min left … 10 min … 9.5 min … 11 min" reads as a system that has no idea,
+# because a number that precise invites you to check it. The same underlying
+# estimate reported as "about 10 min" is right the whole time.
+#
+# So the tracker never publishes its raw estimate. It publishes the nearest rung
+# of a coarse ladder, and it *stays* on that rung until the estimate has moved
+# decisively past a neighbour. Two separate mechanisms, both needed:
+#
+#   - The **ladder** removes false precision. Rungs step by roughly 1.5×, and
+#     every rung is a round number in the unit it will be displayed in (45 s,
+#     7.5 min, 1.5 hr), so no renderer has to round again and re-introduce the
+#     jitter this is here to remove.
+#   - The **hysteresis** removes the flip-flop. Snapping alone still oscillates
+#     when the estimate sits near a boundary, which is exactly where a
+#     converging estimate spends its time. A rung is only abandoned once the raw
+#     value clears the boundary to its neighbour by :data:`_ETA_HYSTERESIS`.
+#
+# The estimate can still *rise*: a job that genuinely slowed down should say so,
+# and pinning the display to a never-increasing value would just move the lie
+# from the number to its trend. What it can't do any more is twitch.
+#
+# The smoothed internal estimate stays raw — only the published value is
+# snapped. Feeding a quantized value back into the EMA would let the ladder
+# capture the estimate and stop it converging at all.
+# fmt: off
+_ETA_LADDER: tuple[float, ...] = (
+    10, 15, 20, 30, 45,                                  # 10 sec – 45 sec
+    60, 90, 120, 180, 300, 450, 600, 900, 1200, 1800, 2700,   # 1 min – 45 min
+    3600, 5400, 7200, 10800, 14400, 21600, 28800, 43200, 86400,  # 1 hr – 24 hr
+)
+# fmt: on
+
+#: How far past the boundary between two rungs the raw estimate must travel
+#: before the displayed rung changes. 0.15 means a 15% overshoot: enough that
+#: ordinary convergence noise never crosses it, small enough that a real
+#: slowdown is reported within a couple of updates.
+_ETA_HYSTERESIS = 0.15
+
+
+def _nearest_rung(seconds: float) -> float:
+    """Return the ladder rung closest to *seconds* in ratio terms.
+
+    Ratio rather than absolute distance, because the ladder is geometric: 400 s
+    is closer to 300 than to 450 on an absolute scale, but proportionally it sits
+    almost exactly between them, and proportional error is what a reader of an
+    ETA actually perceives.
+    """
+    if seconds <= _ETA_LADDER[0]:
+        return _ETA_LADDER[0]
+    if seconds >= _ETA_LADDER[-1]:
+        return _ETA_LADDER[-1]
+    return min(_ETA_LADDER, key=lambda rung: abs(math.log(seconds / rung)))
+
+
+def _adjacent_rung(rung: float, upward: bool) -> float:
+    """The next rung above (or below) *rung*, or *rung* itself at the ends."""
+    index = _ETA_LADDER.index(rung)
+    neighbour = index + 1 if upward else index - 1
+    if 0 <= neighbour < len(_ETA_LADDER):
+        return _ETA_LADDER[neighbour]
+    return rung
 
 
 class CancelledError(Exception):
@@ -60,6 +129,10 @@ class ProgressTracker:
         self._phase_start: float | None = None
         self._phase_current_start: int = 0
         self._smoothed_eta: float | None = None
+        # Ladder rung currently being published as ``eta_seconds``. Held across
+        # updates so the displayed estimate is sticky; see :meth:`_humble_eta`
+        # and the "ETA humility" notes at the top of this module.
+        self._eta_rung: float | None = None
         # Overall (whole-job) progress state, used when the caller reports a
         # ``step``/``total_steps`` structure.  See :meth:`_compute_overall`.
         self._overall_start_time: float | None = None
@@ -104,6 +177,43 @@ class ProgressTracker:
             alpha = self._ETA_SMOOTHING_ALPHA
             self._smoothed_eta = alpha * raw_eta + (1.0 - alpha) * self._smoothed_eta
         return self._smoothed_eta
+
+    def _humble_eta(self, raw: Optional[float]) -> Optional[float]:
+        """Snap *raw* onto the coarse ETA ladder, sticking to the current rung.
+
+        This is the only place a remaining-time estimate becomes user-visible,
+        and it is deliberately the last step: everything upstream — the EMA, the
+        per-phase rate windows, the pacer's re-weighting — keeps working at full
+        precision, and only the published number is coarsened.
+
+        Returns ``None`` (and forgets the held rung) whenever there is no
+        estimate to show, so the next job starts from a clean slate rather than
+        inheriting the last one's rung.
+        """
+        if raw is None or not math.isfinite(raw) or raw <= 0:
+            self._eta_rung = None
+            return None
+
+        target = _nearest_rung(raw)
+        current = self._eta_rung
+        if current is None or current == target:
+            self._eta_rung = target
+            return target
+
+        # Leaving a rung costs an overshoot. The boundary between two rungs is
+        # their geometric mean (the ladder is geometric); the estimate must
+        # clear it by ``_ETA_HYSTERESIS`` in the direction of travel. A large
+        # move jumps straight to ``target`` rather than walking rung by rung, so
+        # a genuinely mistaken estimate is corrected at once while a wobbling
+        # one is not.
+        upward = target > current
+        boundary = math.sqrt(current * _adjacent_rung(current, upward))
+        if upward and raw < boundary * (1.0 + _ETA_HYSTERESIS):
+            return current
+        if not upward and raw > boundary / (1.0 + _ETA_HYSTERESIS):
+            return current
+        self._eta_rung = target
+        return target
 
     def _overall_raw_fraction(self, within: float, s: int, total_steps: int) -> float:
         """Map a within-step fraction to a whole-job fraction in ``[0, 1]``.
@@ -273,9 +383,11 @@ class ProgressTracker:
             if "overall" in self._extra_defaults:
                 self._data["overall"] = overall
             if "eta_seconds" in self._extra_defaults:
-                self._data["eta_seconds"] = (
-                    overall_eta if overall is not None else self._compute_eta(status, current, total)
-                )
+                raw_eta = overall_eta if overall is not None else self._compute_eta(status, current, total)
+                # Published coarse and sticky — see :meth:`_humble_eta`. Every
+                # consumer (SSE, the CLI bars, the frontend chips) reads this
+                # one field, so humility applied here applies everywhere.
+                self._data["eta_seconds"] = self._humble_eta(raw_eta)
             snapshot = dict(self._data)
         self._notify(snapshot)
 

--- a/vtscore/datasets/stages/_load_cost_model.py
+++ b/vtscore/datasets/stages/_load_cost_model.py
@@ -22,11 +22,23 @@ the calibration harness (``scripts/profiling/calibrate_load_weights.py``); see
 ``docs/plans/progress-weight-calibration.md`` (Results) for the runs and fit
 diagnostics. Re-run that harness to refresh — do not hand-tune. Cells with no
 measured row fall back to the static per-device/media profiles in ``_common``.
+
+**These are the shipped defaults, not the last word.** They were measured on one
+GPU cluster; a deployment on different hardware, different storage, or a
+different network can be several times faster or slower. An admin who runs
+``scripts/profiling/tune_timing_profile.py`` on their own machines gets a
+``VTSEARCH_TIMING_PROFILE`` JSON whose ``dataset_load`` cells override the table
+below, per cell, without touching this file (see :mod:`vtscore.timing`). The
+lookups here consult that profile first and fall back to these constants.
 """
 
 from __future__ import annotations
 
 from typing import Optional
+
+from vtscore import timing
+from vtscore.timing.profile import cuml_active as _cuml_enabled
+from vtscore.timing.profile import normalize_device as _normalize_device
 
 # key: (device, media_type, embedder) -> affine coefficients (seconds).
 # ``device`` is "cpu", "cuda", or "cuda+cuml"; ``embedder`` is the encoder
@@ -482,14 +494,19 @@ FINALIZE_SLOT_SHARES: dict[tuple[str, str], tuple[tuple[str, float], ...]] = {
 }
 
 
-def finalize_slot_shares(device: str, media_type: str) -> Optional[tuple[tuple[str, float], ...]]:
-    """Return the measured finalize sub-slot ``(slot, share)`` tuples for
-    ``(device, media_type)``, or ``None`` when no calibrated row exists (so the
-    caller falls back to the static ``FinalizeProgress._SLOTS`` ballpark).
+def finalize_slot_shares(device: str, media_type: str, embedder: str = "") -> Optional[tuple[tuple[str, float], ...]]:
+    """Return the measured finalize sub-slot ``(slot, share)`` tuples for this
+    cell, or ``None`` when nothing measured covers it (so the caller falls back
+    to the static ``FinalizeProgress._SLOTS`` ballpark).
 
-    ``device`` is normalized to "cuda" / "cpu"; the shares are returned verbatim
-    (raw weights) — the consumer normalizes them into ordered sub-ranges.
+    An admin ``VTSEARCH_TIMING_PROFILE`` wins over the checked-in table, since
+    it was measured on the hardware actually serving the app. ``device`` is
+    normalized to "cuda" / "cpu"; the shares are returned verbatim (raw
+    weights) — the consumer normalizes them into ordered sub-ranges.
     """
+    tuned = timing.slot_shares("dataset_load", "finalize", device=device, media_type=media_type, embedder=embedder)
+    if tuned:
+        return tuple(tuned.items())
     row = FINALIZE_SLOT_SHARES.get((normalize_device(device), media_type))
     if not row:
         return None
@@ -499,17 +516,12 @@ def finalize_slot_shares(device: str, media_type: str) -> Optional[tuple[tuple[s
 def normalize_device(device: str) -> str:
     """Collapse ``resolve_device()`` output ("cuda:0", "cuda", "cpu", "mps"…) to
     the coarse key used by :data:`LOAD_COST_MODEL` ("cuda" / "cpu")."""
-    return "cuda" if device.startswith("cuda") else "cpu"
+    return _normalize_device(device)
 
 
 def _cuml_active() -> bool:
     """Whether cuML will serve this process's clustering (never raises)."""
-    try:
-        from vtscore.gpu_backends import cuml_enabled  # noqa: PLC0415
-
-        return cuml_enabled()
-    except Exception:
-        return False
+    return _cuml_enabled()
 
 
 def _lookup_row(device: str, media_type: str, embedder: str) -> Optional[dict[str, float]]:
@@ -550,7 +562,30 @@ def cost_model_terms(
     ``download_size_mb`` of 0/``None`` collapses the download **and** extract
     terms — which is exactly right for local-folder imports and cache-backed
     re-adds, where no archive is fetched or unpacked.
+
+    An admin ``VTSEARCH_TIMING_PROFILE`` measured on this deployment's own
+    hardware takes precedence over the checked-in table; only cells the profile
+    does not cover fall through to the constants above.
     """
+    if n > 0:
+        tuned = timing.step_terms(
+            "dataset_load",
+            device=device,
+            media_type=media_type,
+            embedder=embedder,
+            n=n,
+            size_mb=download_size_mb or 0.0,
+        )
+        if tuned is not None:
+            if not download_size_mb:
+                # No archive to fetch or unpack (local folder, warm cache): zero
+                # the byte-scaled phases even if the profile carries a fixed
+                # intercept for them, so a cached re-add doesn't budget a
+                # download slice for work that will never run.
+                tuned = {**tuned, "download": 0.0, "extract": 0.0}
+            if sum(tuned.values()) > 0:
+                return tuned
+
     row = _lookup_row(device, media_type, embedder)
     if row is None or n <= 0:
         return None

--- a/vtscore/timing/__init__.py
+++ b/vtscore/timing/__init__.py
@@ -1,0 +1,80 @@
+"""Per-task timing model: how long each step of a long-running task will take.
+
+Every long-running VTSearch operation — a dataset load, a detector load, a text
+sort, a Find, a train-and-score, a promote — reports progress as
+``step``/``total_steps`` and paces its unified bar with a per-step **weight
+vector** (see :meth:`vtscore.concurrency.progress.ProgressTracker.set_step_weights`).
+Those vectors used to be hand-guessed constants sitting next to each task's
+code. A guess that is wrong in the same direction for the whole job is exactly
+what makes a progress bar race one phase, crawl the next, and walk its ETA
+*upward* while the user watches.
+
+This package replaces the guesses with a **measurable, per-environment cost
+model**. Each task declares its ordered step names (:mod:`vtscore.timing.tasks`);
+each step gets an affine cost::
+
+    T_step ≈ a + b · n + per_mb · archive_mb
+
+where ``n`` is the task's natural scale variable (items to embed, labels to
+train on, medias to score) and ``archive_mb`` covers the byte-scaled phases of a
+download. Coefficients are keyed by a **cell** — ``(device, media_type,
+embedder)`` — because the same step costs wildly different amounts on a V100
+versus a laptop CPU, and on 200-character texts versus 30-second videos.
+
+Three layers resolve a cell, most specific first:
+
+1. **The admin profile.** A JSON file named by ``VTSEARCH_TIMING_PROFILE``,
+   produced by ``scripts/profiling/tune_timing_profile.py`` on the hardware that
+   will actually serve the app. This is the whole point of the package: a
+   deployment measures itself once and every instance in that environment
+   predicts its own timings thereafter.
+2. **The shipped defaults** in :mod:`vtscore.timing.tasks` (and, for
+   ``dataset_load``, the calibrated table in
+   :mod:`vtscore.datasets.stages._load_cost_model`). These reproduce the
+   pre-profile hand-tuned weights exactly, so an instance with no profile
+   behaves as it always did.
+3. **Equal weighting**, if a task is unknown entirely.
+
+Nothing here persists to disk at runtime and nothing is cached across
+processes: the profile is read once per process at first use and can be
+re-read with :func:`reload_profile`.
+
+See ``docs/TIMING.md`` for the admin workflow and the JSON schema.
+"""
+
+from __future__ import annotations
+
+from vtscore.timing.profile import (
+    StepCoeffs,
+    TimingProfile,
+    active_profile,
+    cell_keys,
+    known_tasks,
+    normalize_device,
+    profile_covers,
+    reload_profile,
+    slot_shares,
+    step_terms,
+    step_weights,
+)
+from vtscore.timing.recorder import record_task, recording_enabled
+from vtscore.timing.tasks import TASKS, TaskSpec, task_spec
+
+__all__ = [
+    "TASKS",
+    "StepCoeffs",
+    "TaskSpec",
+    "TimingProfile",
+    "active_profile",
+    "cell_keys",
+    "known_tasks",
+    "normalize_device",
+    "profile_covers",
+    "record_task",
+    "recording_enabled",
+    "reload_profile",
+    "slot_shares",
+    "step_terms",
+    "step_weights",
+    "task_spec",
+]

--- a/vtscore/timing/fit.py
+++ b/vtscore/timing/fit.py
@@ -1,0 +1,343 @@
+"""Turn recorded step timings into a timing-profile document.
+
+This is the writer for the format :mod:`vtscore.timing.profile` reads. It lives
+here, next to the reader, so the two cannot drift: a change to the schema has to
+be made in one directory or it will not round-trip.
+
+Input is JSONL from either recorder — the generic one
+(:mod:`vtscore.timing.recorder`) or the older dataset-load profiler
+(:mod:`vtscore.datasets.stages._load_profiler`) — because an admin should be
+able to fold an existing calibration sweep into a new profile rather than
+re-measuring what has already been measured. :func:`normalize_row` flattens both
+shapes into one.
+
+The fit itself is deliberately plain. Per ``(task, cell, step)``:
+
+- **Byte-scaled steps** (a dataset download and its unpack) get a per-MB rate:
+  the median of ``seconds / archive_mb``. Regressing them against item count
+  would ask ``n`` to explain something it cannot see — 500 videos and 500 text
+  files are the same ``n`` and two orders of magnitude apart in bytes.
+- **Everything else** gets ordinary least squares against ``n``, giving the
+  intercept (what the step costs at all — loading an encoder, opening a file)
+  and the slope (what each additional item adds).
+- A fit with no spread in ``n``, or one that comes back with a *negative* slope
+  (noise beating signal on a short step), collapses to ``median seconds`` with
+  no slope. A confidently wrong slope extrapolates badly at sizes the sweep
+  never visited, and "we only know the average" is the honest answer there.
+
+Cells are emitted at three specificities — exact ``(device, media, embedder)``,
+then ``(device, media, *)``, then ``(device, *, *)``. The rollups are what make a
+small sweep worth running: an admin who measures three exemplar datasets still
+improves the pacing of every task on every dataset that host will ever see,
+because the least-specific cell always matches.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import defaultdict
+from typing import Any, Iterable, Optional
+
+from vtscore.timing.profile import SCHEMA_NAME, SCHEMA_VERSION, StepCoeffs
+from vtscore.timing.tasks import TASKS, task_spec
+
+#: Phase names the older dataset-load profiler writes, mapped onto the task
+#: registry's step names for ``dataset_load``.
+_LEGACY_PHASE_TO_STEP = {
+    "download": "download",
+    "extract": "extract",
+    "model_load": "load",
+    "embed": "embed",
+    "finalize": "finalize",
+}
+
+#: A byte-scaled step under this many seconds is dominated by setup overhead
+#: rather than transfer, so it makes a poor per-MB rate sample.
+_MIN_BYTE_STEP_SECONDS = 0.1
+
+
+def load_rows(paths: Iterable[str]) -> list[dict]:
+    """Read JSONL from every path, skipping blank and unparseable lines.
+
+    A recorder appends from live worker threads, so a file can end mid-line if
+    the process died; one truncated row must not cost the sweep every good row
+    before it.
+    """
+    import json  # noqa: PLC0415 - only needed on the file path
+
+    rows: list[dict] = []
+    for path in paths:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except ValueError:
+                    continue
+    return rows
+
+
+def device_key(device: str, cuml: bool) -> str:
+    """Collapse a recorded device onto the profile's device key.
+
+    CUDA splits in two: cuML moves the clustering work onto the GPU, which
+    changes what the finalize-shaped steps cost enough that pooling the two
+    would average away the thing being measured.
+    """
+    if not str(device).startswith("cuda"):
+        return "cpu"
+    return "cuda+cuml" if cuml else "cuda"
+
+
+def normalize_row(raw: dict) -> Optional[dict]:
+    """Flatten one recorded row into ``{task, device, media_type, embedder, n,
+    size_mb, step, slot, seconds}``, or ``None`` if it is not a usable sample.
+
+    Handles both recorder shapes. Rejects rows that describe something other
+    than a completed unit of work: a failed or partial run, or a legacy row with
+    ``n <= 0`` (which is how the old profiler marks a load that died before
+    producing any items).
+    """
+    seconds = raw.get("seconds")
+    if seconds is None:
+        return None
+    try:
+        seconds = float(seconds)
+    except (TypeError, ValueError):
+        return None
+
+    task = raw.get("task")
+    phase = raw.get("phase")
+    slot = ""
+    if task:
+        step = raw.get("step")
+        if not raw.get("ok", True) or not raw.get("complete", True):
+            return None
+        size_mb = float(raw.get("size_mb") or 0.0)
+    elif phase:
+        # Legacy dataset-load profiler row.
+        task = "dataset_load"
+        if float(raw.get("n") or 0) <= 0:
+            return None
+        if str(phase).startswith("finalize:"):
+            step, slot = "finalize", str(phase).split(":", 1)[1]
+        else:
+            step = _LEGACY_PHASE_TO_STEP.get(str(phase))
+        size_mb = float(raw.get("download_size_mb") or 0.0)
+    else:
+        return None
+
+    spec = task_spec(str(task))
+    if spec is None or not step or (not slot and step not in spec.steps):
+        return None
+
+    return {
+        "task": str(task),
+        "device": device_key(str(raw.get("device", "cpu")), bool(raw.get("cuml"))),
+        "media_type": str(raw.get("media_type", "")),
+        "embedder": str(raw.get("embedder", "")),
+        "n": float(raw.get("n") or 0.0),
+        "size_mb": size_mb,
+        "step": str(step),
+        "slot": slot,
+        "seconds": max(0.0, seconds),
+    }
+
+
+def affine_fit(xs: list[float], ys: list[float]) -> tuple[float, float, float]:
+    """Ordinary least squares ``y ≈ a + b·x``, returning ``(a, b, r2)``.
+
+    Falls back to ``(mean, 0, 0)`` when ``x`` has no spread — one dataset size
+    can tell you what a step costs, but nothing about how it scales.
+    """
+    count = len(xs)
+    if count == 0:
+        return 0.0, 0.0, 0.0
+    mean_x = sum(xs) / count
+    mean_y = sum(ys) / count
+    sxx = sum((x - mean_x) ** 2 for x in xs)
+    if sxx <= 1e-9 or count < 2:
+        return mean_y, 0.0, 0.0
+    sxy = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    slope = sxy / sxx
+    intercept = mean_y - slope * mean_x
+    ss_tot = sum((y - mean_y) ** 2 for y in ys)
+    ss_res = sum((y - (intercept + slope * x)) ** 2 for x, y in zip(xs, ys))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 1e-9 else 1.0
+    return intercept, slope, r2
+
+
+def fit_step(samples: list[dict], byte_scaled: bool) -> Optional[StepCoeffs]:
+    """Fit one step's coefficients from its samples, or ``None`` if unusable."""
+    if not samples:
+        return None
+    if byte_scaled:
+        rates = [
+            s["seconds"] / s["size_mb"] for s in samples if s["size_mb"] > 0 and s["seconds"] >= _MIN_BYTE_STEP_SECONDS
+        ]
+        if not rates:
+            # Every sample was a cached/absent archive: this deployment's loads
+            # genuinely pay nothing here, which is a real (zero) measurement.
+            return StepCoeffs()
+        return StepCoeffs(per_mb=statistics.median(rates))
+
+    xs = [s["n"] for s in samples]
+    ys = [s["seconds"] for s in samples]
+    intercept, slope, _r2 = affine_fit(xs, ys)
+    if slope <= 0:
+        # No credible scaling signal (a flat step, or noise swamping a short
+        # one). Report the typical cost and claim nothing about growth.
+        return StepCoeffs(a=max(0.0, statistics.median(ys)))
+    return StepCoeffs(a=max(0.0, intercept), b=slope)
+
+
+def _cell_variants(row: dict) -> tuple[tuple[str, str, str], ...]:
+    """The cell keys *row* contributes to: exact, then the two rollups."""
+    device, media, embedder = row["device"], row["media_type"], row["embedder"]
+    variants = [(device, media, embedder), (device, media, ""), (device, "", "")]
+    seen: list[tuple[str, str, str]] = []
+    for variant in variants:
+        if variant not in seen:
+            seen.append(variant)
+    return tuple(seen)
+
+
+def _run_count(step_samples: dict[str, list[dict]]) -> int:
+    """How many distinct runs fed a cell (its best-covered step's sample count)."""
+    return max((len(v) for v in step_samples.values()), default=0)
+
+
+#: ``task -> cell -> step -> samples``, plus the same shape one level deeper for
+#: sub-slot durations (``… -> step -> slot -> seconds``).
+_CellSamples = dict[tuple[str, str, str], dict[str, list[dict]]]
+_CellSlots = dict[tuple[str, str, str], dict[str, dict[str, list[float]]]]
+
+
+def _bucket_rows(rows: Iterable[dict]) -> tuple[dict[str, _CellSamples], dict[str, _CellSlots]]:
+    """Group normalized rows by task and cell, splitting out sub-slot durations.
+
+    Each row lands in *every* cell it qualifies for — exact and both rollups —
+    so the broader cells are fit from strictly more evidence than the narrow
+    ones they back up.
+    """
+    by_cell: dict[str, _CellSamples] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+    slot_secs: dict[str, _CellSlots] = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list))))
+    for raw in rows:
+        row = normalize_row(raw)
+        if row is None:
+            continue
+        for cell in _cell_variants(row):
+            if row["slot"]:
+                slot_secs[row["task"]][cell][row["step"]][row["slot"]].append(row["seconds"])
+            else:
+                by_cell[row["task"]][cell][row["step"]].append(row)
+    return by_cell, slot_secs
+
+
+def _fit_task_cells(spec, cells: _CellSamples, slots: _CellSlots, min_samples: int) -> dict[str, Any]:
+    """Fit every sufficiently-sampled cell of one task into its JSON entry."""
+    cells_out: dict[str, Any] = {}
+    for cell, step_samples in cells.items():
+        runs = _run_count(step_samples)
+        if runs < min_samples:
+            continue
+        steps_out: dict[str, Any] = {}
+        for step, samples in step_samples.items():
+            coeffs = fit_step(samples, step in spec.byte_scaled)
+            if coeffs is not None:
+                steps_out[step] = coeffs.to_json()
+        if not steps_out:
+            continue
+        entry: dict[str, Any] = {"samples": runs, "steps": steps_out}
+        slots_out = _fit_slots(slots.get(cell, {}))
+        if slots_out:
+            entry["slots"] = slots_out
+        cells_out["|".join(cell)] = entry
+    return cells_out
+
+
+def fit_profile(
+    rows: Iterable[dict],
+    *,
+    min_samples: int = 2,
+    generated_at: str = "",
+    host: str = "",
+    notes: str = "",
+) -> dict[str, Any]:
+    """Fit every ``(task, cell, step)`` present in *rows* into a profile document.
+
+    Cells with fewer than *min_samples* runs are dropped: a single timing is an
+    anecdote, and shipping it as a coefficient would replace a considered
+    default with one machine's one bad afternoon. Dropped cells simply fall
+    through to the next-broader cell — or, if none survives, to the built-in
+    defaults, which is the correct outcome for a thin sweep.
+
+    Returns a JSON-serializable dict ready to write and hand to
+    ``VTSEARCH_TIMING_PROFILE``.
+    """
+    by_cell, slot_secs = _bucket_rows(rows)
+
+    tasks_out: dict[str, Any] = {}
+    for task, cells in by_cell.items():
+        cells_out = _fit_task_cells(TASKS[task], cells, slot_secs.get(task, {}), min_samples)
+        if cells_out:
+            tasks_out[task] = {"cells": cells_out}
+
+    doc: dict[str, Any] = {
+        "schema": SCHEMA_NAME,
+        "version": SCHEMA_VERSION,
+        "tasks": tasks_out,
+    }
+    if generated_at:
+        doc["generated_at"] = generated_at
+    if host:
+        doc["host"] = host
+    if notes:
+        doc["notes"] = notes
+    return doc
+
+
+def _fit_slots(step_slots: dict[str, dict[str, list[float]]]) -> dict[str, dict[str, float]]:
+    """Normalize per-step sub-slot durations into shares of that step.
+
+    Median seconds per slot (robust to the one run where the disk stalled), then
+    normalized across the step. A slot that measured no time at all is dropped
+    rather than shipped as a zero weight — the consumer merges what is here over
+    its own defaults, so an unmeasured slot keeps a sane share instead of being
+    told it is free.
+    """
+    out: dict[str, dict[str, float]] = {}
+    for step, slots in step_slots.items():
+        medians = {slot: statistics.median(v) for slot, v in slots.items() if v}
+        total = sum(medians.values())
+        if total <= 0:
+            continue
+        shares = {slot: round(value / total, 4) for slot, value in medians.items() if value > 0}
+        if shares:
+            out[step] = shares
+    return out
+
+
+def coverage_report(rows: Iterable[dict], profile: dict[str, Any]) -> list[str]:
+    """Human-readable lines describing what the sweep did and did not cover.
+
+    Printed by the tuning script so a thin sweep is *visible* rather than
+    quietly shipping a profile that improves two cells and leaves the rest to
+    the defaults. Silent partial coverage is how a tuning run gets mistaken for
+    a tuned system.
+    """
+    normalized = [n for n in (normalize_row(r) for r in rows) if n is not None]
+    seen_tasks = {n["task"] for n in normalized}
+    lines: list[str] = []
+    for task in TASKS:
+        cells = profile.get("tasks", {}).get(task, {}).get("cells", {})
+        if cells:
+            samples = sum(int(c.get("samples", 0)) for c in cells.values())
+            lines.append(f"  {task:<16} {len(cells)} cells, {samples} step-samples")
+        elif task in seen_tasks:
+            lines.append(f"  {task:<16} measured but too few runs to fit — using built-in defaults")
+        else:
+            lines.append(f"  {task:<16} NOT MEASURED — using built-in defaults")
+    return lines

--- a/vtscore/timing/profile.py
+++ b/vtscore/timing/profile.py
@@ -1,0 +1,565 @@
+"""Load, resolve, and apply the per-environment timing profile.
+
+The profile is a JSON file whose path comes from ``VTSEARCH_TIMING_PROFILE``.
+It is produced by ``scripts/profiling/tune_timing_profile.py`` on the hardware
+that will serve the app, and read once per process at first use::
+
+    {
+      "schema": "vtsearch-timing-profile",
+      "version": 1,
+      "generated_at": "2026-07-30T12:00:00Z",
+      "host": "prod-gpu-01",
+      "notes": "measured on 4 exemplar datasets, 3 reps each",
+      "tasks": {
+        "text_sort": {
+          "cells": {
+            "cuda|image|siglip": {
+              "samples": 12,
+              "steps": {
+                "load_model":  {"a": 8.2},
+                "embed_query": {"a": 0.04},
+                "score":       {"a": 0.1, "b": 0.00012}
+              }
+            }
+          }
+        }
+      }
+    }
+
+A **cell key** is ``"<device>|<media_type>|<embedder>"``. Empty (or ``"*"``)
+components are wildcards, so ``"cuda||"`` is "any media, any embedder, on CUDA"
+and ``"||"`` is the task's environment-wide default. Lookup walks from the most
+specific key to the least (see :func:`cell_keys`) and takes the first hit, so a
+profile can carry one broad row plus a handful of precise overrides.
+
+Every coefficient is optional and defaults to zero:
+
+``a``
+    Fixed seconds for the step, however big the job is (loading an encoder).
+``b``
+    Seconds per unit of the task's scale variable ``n`` (per item embedded, per
+    label trained on, per media scored).
+``per_mb``
+    Seconds per megabyte of downloaded archive, for the byte-scaled phases.
+
+Nothing in this module raises on a malformed profile. A deployment that ships a
+broken JSON file gets a warning in the log and the built-in defaults — a bad
+timing table must never take the app down, because all it can ever affect is how
+smoothly a progress bar moves.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from vtscore.timing.tasks import TASKS, task_spec
+
+logger = logging.getLogger(__name__)
+
+#: Environment variable naming the profile JSON. Unset (or empty) means "use the
+#: shipped defaults", which is the correct behaviour for a fresh install: the
+#: defaults reproduce the pre-profile pacing exactly.
+PROFILE_ENV_VAR = "VTSEARCH_TIMING_PROFILE"
+
+#: Schema marker + highest version this build understands. A profile with a
+#: higher version is rejected wholesale rather than half-read, so a newer
+#: tuning script's output can't be silently misinterpreted by an older app.
+SCHEMA_NAME = "vtsearch-timing-profile"
+SCHEMA_VERSION = 1
+
+#: Wildcard spellings accepted in a cell key component.
+_WILDCARDS = ("", "*")
+
+
+# ---------------------------------------------------------------------------
+# Device resolution
+# ---------------------------------------------------------------------------
+
+
+def normalize_device(device: str) -> str:
+    """Collapse a resolved device string to the coarse profile key.
+
+    ``resolve_device()`` returns things like ``"cuda:0"``, ``"cuda"``, ``"cpu"``,
+    or ``"mps"``; timing only distinguishes "has a GPU doing the tensor work"
+    from "does not", because that is the split that moves phase costs by an
+    order of magnitude.
+    """
+    return "cuda" if device.startswith("cuda") else "cpu"
+
+
+def resolve_device_name() -> str:
+    """Return ``"cuda"``/``"cpu"`` for the active device.
+
+    Defaults to ``"cpu"`` when torch can't be resolved, so a library-only caller
+    (or a machine mid-driver-upgrade) never crashes inside progress pacing.
+    """
+    try:
+        from vtscore.config import resolve_device  # noqa: PLC0415
+
+        return normalize_device(resolve_device())
+    except Exception:
+        return "cpu"
+
+
+def cuml_active() -> bool:
+    """Whether cuML will serve this process's clustering (never raises).
+
+    cuML moves the coverage-atlas k-means and the UMAP projection onto the GPU,
+    which materially changes the cost of any step that clusters — enough that
+    CUDA cells are measured as two variants, ``"cuda+cuml"`` and ``"cuda"``.
+    """
+    try:
+        from vtscore.gpu_backends import cuml_enabled  # noqa: PLC0415
+
+        return cuml_enabled()
+    except Exception:
+        return False
+
+
+def device_candidates(device: Optional[str] = None) -> tuple[str, ...]:
+    """Device keys to try, best match first.
+
+    A CPU host has exactly one key. A CUDA host has two — with and without cuML
+    — and the live cuML state decides which is tried first; the other still
+    beats falling back to a generic row, because a same-device measurement with
+    a different clustering backend is much closer than no measurement at all.
+    """
+    dev = normalize_device(device) if device else resolve_device_name()
+    if dev != "cuda":
+        return (dev,)
+    return ("cuda+cuml", "cuda") if cuml_active() else ("cuda", "cuda+cuml")
+
+
+def cell_keys(device: Optional[str], media_type: str = "", embedder: str = "") -> tuple[str, ...]:
+    """Cell keys to look up, most specific first.
+
+    Specificity of ``(media_type, embedder)`` outranks the CUDA cuML variant: a
+    row measured for exactly this media type and encoder on the other clustering
+    backend predicts far better than a media-agnostic row on the right one.
+    """
+    devices = device_candidates(device)
+    specificities = ((media_type, embedder), (media_type, ""), ("", ""))
+    keys: list[str] = []
+    for media, emb in specificities:
+        for dev in devices:
+            key = f"{dev}|{media}|{emb}"
+            if key not in keys:
+                keys.append(key)
+    return tuple(keys)
+
+
+def _canonical_cell_key(raw: str) -> str:
+    """Normalize a cell key as written in JSON into its lookup form.
+
+    Accepts ``"*"`` for a wildcard component (friendlier to hand-edit than an
+    empty string) and tolerates surrounding whitespace, so a hand-tweaked
+    profile matches what :func:`cell_keys` generates.
+    """
+    parts = [p.strip() for p in raw.split("|")]
+    while len(parts) < 3:
+        parts.append("")
+    parts = ["" if p in _WILDCARDS else p for p in parts[:3]]
+    return "|".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Profile data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StepCoeffs:
+    """Affine cost of one step: ``a + b · n + per_mb · archive_mb`` seconds."""
+
+    a: float = 0.0
+    b: float = 0.0
+    per_mb: float = 0.0
+
+    def seconds(self, n: float = 0.0, size_mb: float = 0.0) -> float:
+        """Predicted wall-clock seconds for this step, never negative.
+
+        A least-squares fit over noisy timings can land a negative intercept
+        (a steep slope overshooting at small ``n``); clamping here keeps a
+        pathological row from handing a step a negative slice of the bar.
+        """
+        return max(0.0, self.a + self.b * max(0.0, n) + self.per_mb * max(0.0, size_mb))
+
+    @classmethod
+    def from_json(cls, raw: Any) -> Optional["StepCoeffs"]:
+        """Parse one step's coefficients, or ``None`` if unusable.
+
+        A bare number is accepted as shorthand for a fixed cost, so a
+        hand-written profile can say ``"embed_query": 0.04``.
+        """
+        if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+            return cls(a=float(raw))
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return cls(
+                a=float(raw.get("a", 0.0)),
+                b=float(raw.get("b", 0.0)),
+                per_mb=float(raw.get("per_mb", 0.0)),
+            )
+        except (TypeError, ValueError):
+            return None
+
+    def to_json(self) -> dict[str, float]:
+        """Serialize, omitting zero terms so a profile stays readable."""
+        out: dict[str, float] = {"a": round(self.a, 6)}
+        if self.b:
+            out["b"] = round(self.b, 9)
+        if self.per_mb:
+            out["per_mb"] = round(self.per_mb, 6)
+        return out
+
+
+@dataclass(frozen=True)
+class TimingProfile:
+    """A parsed profile: per-task, per-cell step coefficients and slot shares.
+
+    ``steps`` maps ``task -> cell_key -> step_name -> StepCoeffs``.
+    ``slots`` maps ``task -> cell_key -> step_name -> slot_name -> share`` and
+    covers steps that are themselves split into ordered sub-stages (the dataset
+    load's finalize phase is the only one today).
+
+    An empty profile — the default when no ``VTSEARCH_TIMING_PROFILE`` is set —
+    is falsy, so callers can cheaply skip the lookup entirely.
+    """
+
+    steps: dict[str, dict[str, dict[str, StepCoeffs]]] = field(default_factory=dict)
+    slots: dict[str, dict[str, dict[str, dict[str, float]]]] = field(default_factory=dict)
+    source: str = ""
+    generated_at: str = ""
+    host: str = ""
+    notes: str = ""
+
+    def __bool__(self) -> bool:
+        return bool(self.steps or self.slots)
+
+    def describe(self) -> str:
+        """One-line human summary, for startup logs and the tuning script."""
+        if not self:
+            return "timing profile: none (built-in defaults)"
+        cells = sum(len(c) for c in self.steps.values())
+        where = f" from {self.source}" if self.source else ""
+        when = f", generated {self.generated_at}" if self.generated_at else ""
+        on = f" on {self.host}" if self.host else ""
+        return f"timing profile: {len(self.steps)} tasks / {cells} cells{where}{when}{on}"
+
+
+EMPTY_PROFILE = TimingProfile()
+
+
+def _header_ok(raw: dict, source: str) -> bool:
+    """Whether the document's schema marker and version are ones we understand."""
+    schema = raw.get("schema", SCHEMA_NAME)
+    if schema != SCHEMA_NAME:
+        logger.warning("timing profile %s: unknown schema %r; ignoring", source, schema)
+        return False
+    try:
+        version = int(raw.get("version", SCHEMA_VERSION))
+    except (TypeError, ValueError):
+        version = -1
+    if version > SCHEMA_VERSION or version < 1:
+        logger.warning(
+            "timing profile %s: version %r not supported by this build (max %d); ignoring",
+            source,
+            raw.get("version"),
+            SCHEMA_VERSION,
+        )
+        return False
+    return True
+
+
+def _parse_task(
+    task: str,
+    task_raw: Any,
+    source: str,
+) -> tuple[dict[str, dict[str, StepCoeffs]], dict[str, dict[str, dict[str, float]]]]:
+    """Parse one task's cells into ``(steps_by_cell, slots_by_cell)``."""
+    steps: dict[str, dict[str, StepCoeffs]] = {}
+    slots: dict[str, dict[str, dict[str, float]]] = {}
+    if not isinstance(task_raw, dict):
+        return steps, slots
+    spec = task_spec(task)
+    if spec is None:
+        # Forward-compatible: a profile generated by a newer build may name
+        # tasks this one has never heard of. Keeping them out of the tables
+        # (rather than erroring) lets one profile serve a mixed fleet.
+        logger.info("timing profile %s: skipping unknown task %r", source, task)
+        return steps, slots
+    cells_raw = task_raw.get("cells")
+    if not isinstance(cells_raw, dict):
+        return steps, slots
+    known_steps = set(spec.steps)
+    for cell, cell_raw in cells_raw.items():
+        if not isinstance(cell_raw, dict):
+            continue
+        key = _canonical_cell_key(str(cell))
+        parsed = _parse_cell_steps(cell_raw.get("steps"), known_steps)
+        if parsed:
+            steps[key] = parsed
+        parsed_slots = _parse_cell_slots(cell_raw.get("slots"), known_steps)
+        if parsed_slots:
+            slots[key] = parsed_slots
+    return steps, slots
+
+
+def parse_profile(raw: Any, source: str = "") -> TimingProfile:
+    """Parse a decoded profile document into a :class:`TimingProfile`.
+
+    Structurally invalid pieces are dropped with a warning rather than raising:
+    one malformed cell must not cost the deployment every other measured cell.
+    Returns :data:`EMPTY_PROFILE` when the document itself is unusable.
+    """
+    where = source or "<inline>"
+    if not isinstance(raw, dict):
+        logger.warning("timing profile %s: top level is not an object; ignoring", where)
+        return EMPTY_PROFILE
+    if not _header_ok(raw, where):
+        return EMPTY_PROFILE
+    tasks_raw = raw.get("tasks")
+    if not isinstance(tasks_raw, dict):
+        logger.warning("timing profile %s: missing 'tasks' object; ignoring", where)
+        return EMPTY_PROFILE
+
+    steps: dict[str, dict[str, dict[str, StepCoeffs]]] = {}
+    slots: dict[str, dict[str, dict[str, dict[str, float]]]] = {}
+    for task, task_raw in tasks_raw.items():
+        task_steps, task_slots = _parse_task(task, task_raw, where)
+        if task_steps:
+            steps[task] = task_steps
+        if task_slots:
+            slots[task] = task_slots
+
+    return TimingProfile(
+        steps=steps,
+        slots=slots,
+        source=source,
+        generated_at=str(raw.get("generated_at", "")),
+        host=str(raw.get("host", "")),
+        notes=str(raw.get("notes", "")),
+    )
+
+
+def _parse_cell_steps(raw: Any, known_steps: set[str]) -> dict[str, StepCoeffs]:
+    """Parse one cell's ``steps`` map, dropping unknown or unparseable steps."""
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, StepCoeffs] = {}
+    for step, coeff_raw in raw.items():
+        if step not in known_steps:
+            continue
+        coeffs = StepCoeffs.from_json(coeff_raw)
+        if coeffs is not None:
+            out[step] = coeffs
+    return out
+
+
+def _parse_cell_slots(raw: Any, known_steps: set[str]) -> dict[str, dict[str, float]]:
+    """Parse one cell's ``slots`` map (``step -> slot -> share``)."""
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, dict[str, float]] = {}
+    for step, slot_raw in raw.items():
+        if step not in known_steps or not isinstance(slot_raw, dict):
+            continue
+        shares: dict[str, float] = {}
+        for slot, value in slot_raw.items():
+            try:
+                share = float(value)
+            except (TypeError, ValueError):
+                continue
+            if share > 0:
+                shares[str(slot)] = share
+        if shares:
+            out[step] = shares
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Process-wide active profile
+# ---------------------------------------------------------------------------
+
+_profile_lock = threading.Lock()
+_profile: Optional[TimingProfile] = None
+
+
+def _read_profile(path: str) -> TimingProfile:
+    """Read and parse the profile at *path*, or :data:`EMPTY_PROFILE` on any error."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except OSError as exc:
+        logger.warning("timing profile %s: cannot read (%s); using built-in defaults", path, exc)
+        return EMPTY_PROFILE
+    except json.JSONDecodeError as exc:
+        logger.warning("timing profile %s: invalid JSON (%s); using built-in defaults", path, exc)
+        return EMPTY_PROFILE
+    return parse_profile(raw, source=path)
+
+
+def active_profile() -> TimingProfile:
+    """Return the process's profile, reading it on first use.
+
+    Thread-safe and read-once: every long-running task consults this on its way
+    into the work, so it must not re-stat a file per progress update.
+    """
+    global _profile
+    if _profile is not None:
+        return _profile
+    with _profile_lock:
+        if _profile is None:
+            path = os.environ.get(PROFILE_ENV_VAR, "").strip()
+            _profile = _read_profile(path) if path else EMPTY_PROFILE
+            if _profile:
+                logger.info("%s", _profile.describe())
+    return _profile
+
+
+def reload_profile(path: Optional[str] = None) -> TimingProfile:
+    """Re-read the profile, optionally from an explicit *path*.
+
+    Passing ``path=""`` clears the profile back to the built-in defaults. Used
+    by the tuning script (to verify what it just wrote) and by tests; the app
+    itself reads the profile once at startup and never reloads it.
+    """
+    global _profile
+    with _profile_lock:
+        target = path if path is not None else os.environ.get(PROFILE_ENV_VAR, "").strip()
+        _profile = _read_profile(target) if target else EMPTY_PROFILE
+    return _profile
+
+
+def _lookup_cell(task: str, device: Optional[str], media_type: str, embedder: str) -> dict[str, StepCoeffs]:
+    """Return the best-matching cell's step coefficients (empty when none)."""
+    profile = active_profile()
+    cells = profile.steps.get(task)
+    if not cells:
+        return {}
+    for key in cell_keys(device, media_type, embedder):
+        row = cells.get(key)
+        if row:
+            return row
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Public lookup API
+# ---------------------------------------------------------------------------
+
+
+def step_terms(
+    task: str,
+    *,
+    device: Optional[str] = None,
+    media_type: str = "",
+    embedder: str = "",
+    n: float = 0.0,
+    size_mb: float = 0.0,
+) -> Optional[dict[str, float]]:
+    """Predicted seconds per step for *task*, keyed by step name.
+
+    Returns ``None`` when neither a profile cell nor a shipped default covers
+    the task, so the caller can keep its own fallback. When a profile cell
+    exists but only names *some* of the task's steps, the unnamed steps fall
+    back to their shipped default term — a partial measurement improves the
+    steps it covers without blanking the others.
+
+    ``n`` is the task's scale variable (see :attr:`TaskSpec.scale`); ``size_mb``
+    is the archive size for byte-scaled phases. Both may be zero, which simply
+    collapses their terms.
+    """
+    spec = task_spec(task)
+    if spec is None:
+        return None
+    measured = _lookup_cell(task, device, media_type, embedder)
+    defaults = dict(zip(spec.steps, spec.default_terms)) if spec.default_terms else {}
+    if not measured and not defaults:
+        return None
+    terms: dict[str, float] = {}
+    for step in spec.steps:
+        coeffs = measured.get(step)
+        terms[step] = coeffs.seconds(n, size_mb) if coeffs is not None else max(0.0, defaults.get(step, 0.0))
+    if sum(terms.values()) <= 0:
+        # An all-zero prediction carries no pacing information and would make
+        # the weight vector a division by zero; the caller's fallback is better.
+        return None
+    return terms
+
+
+def step_weights(
+    task: str,
+    *,
+    device: Optional[str] = None,
+    media_type: str = "",
+    embedder: str = "",
+    n: float = 0.0,
+    size_mb: float = 0.0,
+    fallback: Optional[list[float]] = None,
+) -> Optional[list[float]]:
+    """Normalized per-tracker-step weights for *task*, or *fallback*.
+
+    The returned vector has one entry per tracker step (``TaskSpec.tracker_steps``)
+    and sums to 1, ready for
+    :meth:`~vtscore.concurrency.progress.ProgressTracker.set_step_weights`.
+    Phases that share a tracker step have their predicted seconds summed into
+    that step's slot.
+    """
+    spec = task_spec(task)
+    terms = step_terms(task, device=device, media_type=media_type, embedder=embedder, n=n, size_mb=size_mb)
+    if spec is None or terms is None:
+        return fallback
+    weights = [0.0] * spec.tracker_steps
+    for step, index in zip(spec.steps, spec.step_index):
+        weights[index - 1] += terms[step]
+    total = sum(weights)
+    if total <= 0:
+        return fallback
+    return [w / total for w in weights]
+
+
+def slot_shares(
+    task: str,
+    step: str,
+    *,
+    device: Optional[str] = None,
+    media_type: str = "",
+    embedder: str = "",
+) -> Optional[dict[str, float]]:
+    """Measured sub-stage shares within one step, or ``None`` when unprofiled.
+
+    Only steps that pace several ordered sub-stages behind a single step number
+    use this — today just the dataset load's ``finalize``. Shares are raw
+    weights; the consumer normalizes them.
+    """
+    profile = active_profile()
+    cells = profile.slots.get(task)
+    if not cells:
+        return None
+    for key in cell_keys(device, media_type, embedder):
+        row = cells.get(key)
+        if row and step in row:
+            return dict(row[step])
+    return None
+
+
+def profile_covers(task: str) -> bool:
+    """Whether the active profile carries any measured cell for *task*.
+
+    Used by the tuning script's coverage report and by the dataset-load path,
+    which only wants to bypass its own calibrated table when a profile actually
+    has something to say about it.
+    """
+    return bool(active_profile().steps.get(task))
+
+
+def known_tasks() -> tuple[str, ...]:
+    """Names of every registered task family, in registry order."""
+    return tuple(TASKS)

--- a/vtscore/timing/recorder.py
+++ b/vtscore/timing/recorder.py
@@ -1,0 +1,297 @@
+"""Env-gated recorder that measures how long each step of a task really took.
+
+Arm it by pointing ``VTSEARCH_TIMING_RECORD`` at a JSONL path. Every task that
+wraps its work in :func:`record_task` then appends one row per step::
+
+    {"task": "text_sort", "device": "cuda", "cuml": true, "media_type": "image",
+     "embedder": "siglip", "n": 12403, "size_mb": 0.0, "step": "score",
+     "seconds": 1.83, "ok": true}
+
+``scripts/profiling/tune_timing_profile.py`` fits those rows into the profile
+JSON that :mod:`vtscore.timing.profile` reads back. Because the recorder lives
+behind an env var and touches nothing when unset, an admin has two ways to
+gather data, and both produce the same file:
+
+- **Drive it.** Run the tuning script, which exercises each task family against
+  exemplar datasets with the recorder armed.
+- **Watch it.** Set ``VTSEARCH_TIMING_RECORD`` on the real server and let real
+  users generate the timings, then fit the accumulated JSONL. This measures the
+  production mix directly — the datasets people actually load, at the sizes they
+  actually are — which no synthetic sweep can reproduce.
+
+When disarmed the cost is one ``os.environ`` lookup per task and a couple of
+no-op method calls; there is no tracker subscription and no file handle.
+
+The dataset-load pipeline has its own older, richer recorder
+(:mod:`vtscore.datasets.stages._load_profiler`) that additionally distinguishes
+cold from warm model loads and cold from cached downloads. It stays as-is; the
+tuning script's fitter reads both row shapes, so a pre-existing dataset-load
+calibration sweep still folds into a profile.
+
+Kept in ``vtscore`` (no Flask) so a plain CLI or library run records the same
+way a served request does.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Optional
+
+from vtscore.timing.profile import cuml_active, resolve_device_name
+from vtscore.timing.tasks import task_spec
+
+logger = logging.getLogger(__name__)
+
+#: Environment variable naming the JSONL sink. Unset means "record nothing".
+RECORD_ENV_VAR = "VTSEARCH_TIMING_RECORD"
+
+
+def recording_enabled() -> bool:
+    """True when the ``VTSEARCH_TIMING_RECORD`` sink is armed."""
+    return bool(os.environ.get(RECORD_ENV_VAR, "").strip())
+
+
+class TaskTimingRecorder:
+    """Measures per-step durations for one run of one task.
+
+    Subscribes to the task's :class:`~vtscore.concurrency.progress.ProgressTracker`
+    and stamps the first moment each step becomes active; a step's duration is
+    the gap to the next step's start, and the last step runs to :meth:`finish`.
+    That gives the same boundaries the user sees on the bar, which is the point —
+    the model being fit predicts *displayed* phases, not internal function calls.
+
+    Use it as a context manager; ``n`` is usually only known partway through, so
+    set it whenever you learn it::
+
+        with record_task(tracker, "text_sort", media_type=mt) as rec:
+            ...
+            rec.set_scale(n=len(medias))
+    """
+
+    #: Statuses that mean "this task is over". A task whose tracker is a
+    #: long-lived singleton (``sort_progress``, ``find_progress``) ends by
+    #: setting one of these, and every early-abort path does the same — which
+    #: makes them a far more reliable end-of-task signal than a ``finally``
+    #: bolted onto a route handler with a dozen ``abort()`` exits.
+    TERMINAL_STATUSES = frozenset({"idle", "error", "cancelled"})
+
+    def __init__(
+        self,
+        tracker: Any,
+        task: str,
+        *,
+        media_type: str = "",
+        embedder: str = "",
+        status_phases: Optional[dict[str, str]] = None,
+        auto_finish: bool = False,
+    ) -> None:
+        self._tracker = tracker
+        self._task = task
+        self._spec = task_spec(task)
+        self._media_type = media_type or ""
+        self._embedder = embedder or ""
+        # Maps a status string onto a phase name, for tasks where one tracker
+        # step covers several cost phases and only the status tells them apart
+        # (the dataset load's step 1 is both "downloading" and "extracting").
+        self._status_phases = dict(status_phases or {})
+        self._auto_finish = auto_finish
+        self._path = os.environ.get(RECORD_ENV_VAR, "").strip()
+        self._lock = threading.Lock()
+        self._phase_start: dict[str, float] = {}
+        self._phase_order: list[str] = []
+        self._last_seen: Any = None
+        self._n = 0.0
+        self._size_mb = 0.0
+        self._ok = True
+        self._subscribed = False
+
+    # -- lifecycle ----------------------------------------------------------
+    def __enter__(self) -> "TaskTimingRecorder":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        # A run that raised measured a failure path, not a cost: mark it so the
+        # fitter drops it rather than fitting a slope to an exception's timing.
+        self.finish(ok=exc_type is None)
+        return False
+
+    def start(self) -> None:
+        """Subscribe to the tracker. Idempotent."""
+        if self._subscribed:
+            return
+        try:
+            self._tracker.subscribe(self._on_update)
+        except Exception:  # pragma: no cover - a tracker without subscribe()
+            logger.debug("timing recorder: tracker for %s has no subscribe()", self._task)
+            return
+        self._subscribed = True
+
+    def set_scale(self, n: Optional[float] = None, size_mb: Optional[float] = None) -> None:
+        """Record the job's scale variables once they are known.
+
+        Safe to call repeatedly and from any thread; the last value wins.
+        """
+        with self._lock:
+            if n is not None:
+                self._n = float(n)
+            if size_mb is not None:
+                self._size_mb = float(size_mb)
+
+    def finish(self, n: Optional[float] = None, size_mb: Optional[float] = None, ok: bool = True) -> None:
+        """Unsubscribe and append this run's rows. Idempotent."""
+        self.set_scale(n, size_mb)
+        with self._lock:
+            self._ok = self._ok and ok
+        if self._subscribed:
+            try:
+                self._tracker.unsubscribe(self._on_update)
+            except Exception:  # pragma: no cover
+                pass
+            self._subscribed = False
+            self._emit()
+
+    # -- capture ------------------------------------------------------------
+    def _on_update(self, snapshot: dict[str, Any]) -> None:
+        """Tracker subscriber: stamp the first time each phase becomes active."""
+        step = snapshot.get("step")
+        status = snapshot.get("status")
+        seen = (step, status)
+        if seen == self._last_seen:
+            return
+        self._last_seen = seen
+        if self._auto_finish and status in self.TERMINAL_STATUSES:
+            # Unsubscribing from inside a callback is safe: the tracker notifies
+            # over a copy of its subscriber list.
+            self.finish(ok=status == "idle" and not snapshot.get("error"))
+            return
+        phase = self._resolve_phase(step, status)
+        if phase is None:
+            return
+        now = time.monotonic()
+        with self._lock:
+            if phase not in self._phase_start:
+                self._phase_start[phase] = now
+                self._phase_order.append(phase)
+
+    def _resolve_phase(self, step: Any, status: Any) -> Optional[str]:
+        """Map a progress snapshot onto one of the task's declared phase names."""
+        mapped = self._status_phases.get(str(status)) if status else None
+        if mapped:
+            return mapped
+        if self._spec is None or not isinstance(step, int):
+            return None
+        for name, index in zip(self._spec.steps, self._spec.step_index):
+            if index == step:
+                return name
+        return None
+
+    # -- emit ---------------------------------------------------------------
+    def _emit(self) -> None:
+        end = time.monotonic()
+        if not self._path:
+            return
+        with self._lock:
+            order = list(self._phase_order)
+            starts = dict(self._phase_start)
+            n, size_mb, ok = self._n, self._size_mb, self._ok
+        if not order:
+            return
+        # "Complete" means the job reached its *last* declared step, not that it
+        # visited every one. Steps legitimately skip: a warm text sort never
+        # enters ``load_model`` because the encoder is already resident, and a
+        # cache-backed dataset re-add never downloads. Those runs are perfectly
+        # good cost samples. What is *not* a sample is a run that gave up
+        # partway, because its final recorded step's duration runs to whenever
+        # the task bailed rather than to a real phase boundary.
+        declared = self._spec.steps if self._spec is not None else tuple(order)
+        complete = bool(declared) and declared[-1] in starts
+        base = {
+            "task": self._task,
+            "device": resolve_device_name(),
+            "cuml": cuml_active(),
+            "media_type": self._media_type,
+            "embedder": self._embedder,
+            "n": n,
+            "size_mb": size_mb,
+            "ok": ok,
+            "complete": complete,
+        }
+        durations = {
+            phase: max(0.0, (starts[order[i + 1]] if i + 1 < len(order) else end) - starts[phase])
+            for i, phase in enumerate(order)
+        }
+        # A skipped step on an otherwise-complete run really did cost nothing, so
+        # it is recorded as a zero rather than left out: the fit should learn
+        # that this deployment's warm model loads are free, not silently drop
+        # every warm run's evidence and over-budget the phase forever.
+        rows = [
+            {**base, "step": phase, "seconds": round(durations.get(phase, 0.0), 4)}
+            for phase in (declared if complete else order)
+        ]
+        try:
+            with open(self._path, "a", encoding="utf-8") as fh:
+                fh.write("".join(json.dumps(r) + "\n" for r in rows))
+        except OSError as exc:
+            logger.warning("timing recorder: cannot append to %s (%s)", self._path, exc)
+
+
+class _NullRecorder:
+    """No-op stand-in returned when recording is off.
+
+    Exposes the same surface so call sites never branch on ``None`` — the
+    disarmed path is a few method calls that do nothing.
+    """
+
+    def __enter__(self) -> "_NullRecorder":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def start(self) -> None:
+        pass
+
+    def set_scale(self, n: Optional[float] = None, size_mb: Optional[float] = None) -> None:
+        pass
+
+    def finish(self, n: Optional[float] = None, size_mb: Optional[float] = None, ok: bool = True) -> None:
+        pass
+
+
+_NULL_RECORDER = _NullRecorder()
+
+
+def record_task(
+    tracker: Any,
+    task: str,
+    *,
+    media_type: str = "",
+    embedder: str = "",
+    status_phases: Optional[dict[str, str]] = None,
+    auto_finish: bool = False,
+):
+    """Return a recorder for one run of *task*, or a no-op when disarmed.
+
+    Always returns an object supporting ``with``/``set_scale``/``finish``, so
+    callers use it unconditionally and pay nothing when the env var is unset.
+
+    Set *auto_finish* when the task reports through a long-lived singleton
+    tracker that it parks at ``"idle"`` on the way out (every exit path,
+    including aborts). The recorder then closes itself on that signal, so a
+    route handler with a dozen early ``abort()``s needs no ``finally``.
+    """
+    if not recording_enabled():
+        return _NULL_RECORDER
+    return TaskTimingRecorder(
+        tracker,
+        task,
+        media_type=media_type,
+        embedder=embedder,
+        status_phases=status_phases,
+        auto_finish=auto_finish,
+    )

--- a/vtscore/timing/tasks.py
+++ b/vtscore/timing/tasks.py
@@ -1,0 +1,174 @@
+"""Canonical registry of long-running task families and their ordered steps.
+
+Every task that drives a progress bar with a ``step``/``total_steps`` structure
+registers here. The registry is the shared vocabulary between three parties that
+would otherwise drift apart:
+
+- the **task code**, which paces its bar with a weight vector one entry per
+  tracker step;
+- the **recorder** (:mod:`vtscore.timing.recorder`), which needs to label a
+  measured duration with the name of the step it belongs to;
+- the **tuning script**, which fits ``a + b · n`` per step and writes the
+  profile JSON keyed by these same names.
+
+Adding a new long-running task means adding a :class:`TaskSpec` here, then
+calling :func:`vtscore.timing.step_weights` at the task's entry point instead of
+writing a literal vector.
+
+**Phases vs tracker steps.** Usually they are the same thing and
+``step_index`` is just ``(1, 2, 3, …)``. A task may model a step as several
+cost *phases* that scale differently — ``dataset_load``'s step 1 covers both the
+network transfer (scales with archive bytes) and the archive unpack (scales with
+archive bytes at a very different rate) — in which case several phases share one
+tracker step and :func:`vtscore.timing.step_weights` sums their terms back into
+that step's slot.
+
+**Default terms** reproduce the hand-tuned vectors these tasks shipped with
+before the profile existed, so an instance with no ``VTSEARCH_TIMING_PROFILE``
+paces exactly as it did. They are *pseudo-seconds*: only their ratios are
+meaningful, because nobody measured them. A profile replaces them with real
+seconds, which is what makes the ETA stop drifting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TaskSpec:
+    """Declares one long-running task family's step structure.
+
+    Attributes:
+        name: Stable identifier used as the profile JSON's task key, in recorded
+            JSONL rows, and in ``--tasks`` selections. Never rename one of these
+            without migrating the profiles admins have already generated.
+        steps: Ordered cost-phase names. Profile coefficients are keyed by these.
+        step_index: 1-based tracker step each phase reports against, parallel to
+            ``steps``. Several phases may share one step (see module docstring).
+        tracker_steps: How many step numbers the task reports — the length of
+            the weight vector ``set_step_weights`` expects.
+        scale: Human description of what the ``n`` scale variable counts, for
+            the tuning script's ``--help`` and the profile's self-documentation.
+        default_terms: Shipped fallback pseudo-seconds, parallel to ``steps``.
+            Empty means "this task has its own richer default model" — only
+            ``dataset_load``, whose calibrated table lives in
+            :mod:`vtscore.datasets.stages._load_cost_model`.
+        byte_scaled: Steps whose cost tracks downloaded **bytes** rather than
+            item count. The tuning script fits these as a per-MB rate instead of
+            regressing them against ``n``, because a 2 GB archive of 500 videos
+            and a 20 MB archive of 500 texts take wildly different times to
+            fetch for reasons ``n`` cannot see.
+    """
+
+    name: str
+    steps: tuple[str, ...]
+    step_index: tuple[int, ...]
+    tracker_steps: int
+    scale: str
+    default_terms: tuple[float, ...] = ()
+    byte_scaled: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if len(self.step_index) != len(self.steps):
+            raise ValueError(f"{self.name}: step_index must be parallel to steps")
+        if self.default_terms and len(self.default_terms) != len(self.steps):
+            raise ValueError(f"{self.name}: default_terms must be parallel to steps")
+
+
+def _linear(name: str, steps: tuple[str, ...], scale: str, terms: tuple[float, ...]) -> TaskSpec:
+    """Build a spec whose phases map 1:1 onto tracker steps (the common case)."""
+    return TaskSpec(
+        name=name,
+        steps=steps,
+        step_index=tuple(range(1, len(steps) + 1)),
+        tracker_steps=len(steps),
+        scale=scale,
+        default_terms=terms,
+    )
+
+
+#: Every registered task family, keyed by :attr:`TaskSpec.name`.
+#:
+#: The default terms below are transcribed from the literal vectors these tasks
+#: carried before the timing profile existed; each site's original reasoning is
+#: preserved in the comments here rather than in six scattered constants.
+TASKS: dict[str, TaskSpec] = {
+    # Importing a dataset: acquire the source, read/convert it into medias,
+    # embed every item, then dedup + coverage-atlas + registry save. Deliberately
+    # carries no default terms — its shipped model is the measured affine table
+    # in ``_load_cost_model``, which is already ``n``-aware per (device, media,
+    # embedder) and far better than any flat vector could be here.
+    "dataset_load": TaskSpec(
+        name="dataset_load",
+        steps=("download", "extract", "load", "embed", "finalize"),
+        step_index=(1, 1, 2, 3, 4),
+        tracker_steps=4,
+        scale="media items embedded",
+        byte_scaled=("download", "extract"),
+    ),
+    # Re-opening an already-imported dataset from its pkl. Step 1 (pickle read +
+    # convert + the near-instant exact-dedup) is seconds at most; step 2 is the
+    # coverage atlas, instant when the cached atlas restores but a minutes-long
+    # hierarchical-k-means rebuild when it does not.
+    "dataset_open": _linear(
+        "dataset_open",
+        ("items", "coverage"),
+        "media items in the pkl",
+        (0.15, 0.85),
+    ),
+    # Promoting a staged subset into a real dataset. The atlas's hierarchical
+    # k-means dominates, then embedding serialization; the registry write is
+    # trivial.
+    "dataset_promote": _linear(
+        "dataset_promote",
+        ("coverage", "serialize", "registry"),
+        "media items in the promoted subset",
+        (6.0, 3.5, 0.5),
+    ),
+    # Loading a saved detector: read its labelset, pull the label examples back
+    # into the active dataset, retrain the MLP. Training dominates; the other
+    # two are quick I/O.
+    "detector_load": _linear(
+        "detector_load",
+        ("restore_labels", "seed_examples", "train"),
+        "labels in the detector's labelset",
+        (0.15, 0.15, 0.70),
+    ),
+    # Text search: load the embedder, embed the one-line query, score every
+    # media by cosine similarity. The model load dominates on a cold start
+    # (seconds to pull CLAP / SigLIP weights); embedding one short query is
+    # trivial; scoring scales with the dataset but is vectorised.
+    "text_sort": _linear(
+        "text_sort",
+        ("load_model", "embed_query", "score"),
+        "medias scored",
+        (0.75, 0.05, 0.20),
+    ),
+    # Running saved detectors across saved datasets. Scoring dominates; loading
+    # datasets from pkl is moderate; preparing detector configs is quick.
+    "find": _linear(
+        "find",
+        ("prepare", "load", "score"),
+        "medias scored across all selected datasets",
+        (0.10, 0.30, 0.60),
+    ),
+    # Train-and-score against the active dataset: resolve the detector, train
+    # its MLP, score every media, apply the resulting labels. Train + score
+    # carry the cost; resolve/apply are quick.
+    "train_and_score": _linear(
+        "train_and_score",
+        ("resolve", "train", "score", "apply"),
+        "medias scored",
+        (0.10, 0.45, 0.40, 0.05),
+    ),
+}
+
+
+def task_spec(task: str) -> TaskSpec | None:
+    """Return the :class:`TaskSpec` for *task*, or ``None`` if unregistered.
+
+    Unregistered is not an error: a caller that passes an unknown task simply
+    gets no profile-derived weights and keeps whatever fallback it supplied.
+    """
+    return TASKS.get(task)

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -211,7 +211,20 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
     # as the dominant slice keeps a rebuild advancing the bar across its whole
     # span instead of the old equal split, where the instant dedup drove step 2
     # to ~100% and the bar then sat frozen there through the entire rebuild.
-    tracker.set_step_weights([0.15, 0.85])
+    # That reasoning is the *fallback*; an admin ``VTSEARCH_TIMING_PROFILE``
+    # replaces it with the split this host's disk and clustering backend
+    # actually produce at this dataset's size.
+    from vtscore import timing
+
+    _open_media_type = entry.get("media_type", "")
+    _open_embedder = entry.get("embedder", "") or ""
+    _open_n = int(entry.get("num_items") or 0)
+    tracker.set_step_weights(
+        timing.step_weights("dataset_open", media_type=_open_media_type, embedder=_open_embedder, n=_open_n)
+    )
+    timing_recorder = timing.record_task(tracker, "dataset_open", media_type=_open_media_type, embedder=_open_embedder)
+    timing_recorder.start()
+    timing_recorder.set_scale(n=_open_n)
     tracker.update("loading", "Loading dataset from file...", step=1, total_steps=_LOAD_STEPS)
 
     def _pickle_progress(status, message, current, total):
@@ -344,6 +357,10 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
                 error_msg = str(e) or repr(e) or "Unknown error during dataset loading"
                 tracker.update("idle", "", 0, 0, error=error_msg, step=None, total_steps=None)
             finally:
+                # Every branch above parks the tracker at "idle", setting
+                # ``error`` when it failed or was cancelled — which is what says
+                # whether these phase timings describe a real load.
+                timing_recorder.finish(ok=not tracker.get().get("error"))
                 clear_thread_progress()
                 _reg_end_load(dataset_id)
                 _loading_tasks.mark_finished(task_id)

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -216,12 +216,12 @@ def _coverage_atlas_pickle_keys(
 #: pickle serialization + disk write, registry insert.
 _PROMOTE_TOTAL_STEPS = 3
 
-#: Rough wall-clock share of each promote step, tuning how the unified
-#: ``overall`` bar paces (the ETA self-corrects regardless — see
-#: :meth:`ProgressTracker._compute_overall`). The atlas's hierarchical
-#: k-means dominates, then embedding serialization; the registry write
-#: is trivial.
-_PROMOTE_STEP_WEIGHTS = [6.0, 3.5, 0.5]
+#: Timing-profile task name; its step names and shipped fallback weights live in
+#: :data:`vtscore.timing.tasks.TASKS`. An admin ``VTSEARCH_TIMING_PROFILE``
+#: replaces those with measured seconds, which matters most here: whether the
+#: atlas k-means or the pickle write dominates depends entirely on whether the
+#: host has cuML and how fast its disk is.
+_PROMOTE_TASK = "dataset_promote"
 
 
 def _promote_in_background(
@@ -261,14 +261,19 @@ def _promote_in_background(
     """
     from vtsearch.auth import thread_user
 
+    from vtscore import timing
+
     task_id = f"_promote_{uuid4().hex[:8]}"
     tracker = loading_tasks.create_task(
         task_id,
         name,
         media_type=media_type,
         embedder=embedder,
-        step_weights=_PROMOTE_STEP_WEIGHTS,
+        step_weights=timing.step_weights(_PROMOTE_TASK, media_type=media_type, embedder=embedder, n=len(subset)),
     )
+    timing_recorder = timing.record_task(tracker, _PROMOTE_TASK, media_type=media_type, embedder=embedder)
+    timing_recorder.start()
+    timing_recorder.set_scale(n=len(subset))
     tracker.update("loading", "Preparing promoted dataset…", 0, 0, step=1, total_steps=_PROMOTE_TOTAL_STEPS)
 
     def task():
@@ -351,6 +356,10 @@ def _promote_in_background(
                 Path(pkl_path).unlink(missing_ok=True)
             tracker.update("idle", "", 0, 0, error=str(exc) or repr(exc) or "Unknown error during promote")
         finally:
+            # Every branch above parks the tracker at "idle", setting ``error``
+            # when it failed or was cancelled — which is what says whether these
+            # phase timings describe a real promote.
+            timing_recorder.finish(ok=not tracker.get().get("error"))
             gc.collect()
             loading_tasks.mark_finished(task_id)
 

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -44,10 +44,11 @@ detector_find_bp = Blueprint(
 
 # Number of high-level Find steps: prepare detectors, load data, score.
 _FIND_STEPS = 3
-# Scoring dominates; loading datasets from pkl is moderate; preparing detector
-# configs is quick. Paces the unified whole-job bar (ETA self-corrects).
-#                  prepare  load  score
-_FIND_STEP_WEIGHTS = [0.10, 0.30, 0.60]
+#: Timing-profile task name; its step names and shipped fallback weights live in
+#: :data:`vtscore.timing.tasks.TASKS`. An admin ``VTSEARCH_TIMING_PROFILE``
+#: replaces those with seconds measured on this deployment's own storage, which
+#: is what the "load datasets from pkl" step actually varies with.
+_FIND_TASK = "find"
 
 
 def _load_pkl_for_check(pkl_path: str) -> dict | None:
@@ -616,7 +617,6 @@ def multi_find(body: dict):
     # Clear a leftover cancel flag from a previously-cancelled run so
     # the new operation doesn't trip on it immediately.
     find_progress.reset_cancel()
-    find_progress.set_step_weights(_FIND_STEP_WEIGHTS)
 
     update_find_progress(
         "running",
@@ -628,6 +628,27 @@ def multi_find(body: dict):
     )
 
     datasets = _resolve_find_datasets(dataset_ids)
+
+    # Pace against the actual size of this Find: the scoring step scales with
+    # every media in every selected dataset, and the pkl-load step with the same
+    # count on this host's storage. Both are known now that the registry entries
+    # are resolved, so the weights need not fall back to a size-blind guess.
+    from vtscore import timing  # noqa: PLC0415
+
+    n_scored = sum(int(ds.get("num_items") or 0) for ds in datasets)
+    find_media_type = next((ds.get("media_type", "") for ds in datasets if ds.get("media_type")), "")
+    find_embedder = next((ds.get("embedder", "") for ds in datasets if ds.get("embedder")), "")
+    find_progress.set_step_weights(
+        timing.step_weights(_FIND_TASK, media_type=find_media_type, embedder=find_embedder, n=n_scored)
+    )
+    # Every exit below — success, cancel, and abort alike — parks the tracker at
+    # "idle", which is what closes the recorder.
+    recorder = timing.record_task(
+        find_progress, _FIND_TASK, media_type=find_media_type, embedder=find_embedder, auto_finish=True
+    )
+    recorder.start()
+    recorder.set_scale(n=n_scored)
+
     detectors = _resolve_find_detectors(detector_ids)
     detector_configs = _build_detector_configs(detectors)
     detector_names = [dc["name"] for dc in detector_configs]
@@ -663,7 +684,13 @@ def multi_find(body: dict):
             if not detected_media_type and ds_media_type:
                 detected_media_type = ds_media_type
     except CancelledError:
+        # A cancelled run's phase timings describe a partial job, so they are
+        # recorded as not-ok and the fit drops them.
+        recorder.finish(ok=False)
         _abort_find(409, "Find cancelled")
+    except Exception:
+        recorder.finish(ok=False)
+        raise
 
     update_find_progress("idle", "", step=None, total_steps=None)
 

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -415,8 +415,11 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
 
 
 _LOAD_STEPS = 3  # restore labels, seed examples, train MLP
-# MLP training dominates; label restore + example seeding are quick I/O.
-_LOAD_STEP_WEIGHTS = [0.15, 0.15, 0.70]
+#: Timing-profile task name; its step names and shipped fallback weights live in
+#: :data:`vtscore.timing.tasks.TASKS`. An admin ``VTSEARCH_TIMING_PROFILE``
+#: replaces those with seconds measured here, so a detector with 40 labels and
+#: one with 4000 no longer get the same three-way split of the bar.
+_DETECTOR_LOAD_TASK = "detector_load"
 
 
 def _run_detector_load_task(
@@ -670,14 +673,25 @@ def load_detector_route(body: dict):
         media_type=entry.get("media_type", ""),
     )
 
+    from vtscore import timing
+
+    det_media_type = entry.get("media_type", "")
+    det_embedder = entry.get("embedder", "") or ""
+    n_labels = int(entry.get("num_training") or 0)
+
     task_id = f"_detload_{detector_id}"
     tracker = detector_loading_tasks.create_task(
         task_id,
         entry.get("name", detector_id),
         detector_id=detector_id,
-        media_type=entry.get("media_type", ""),
-        step_weights=_LOAD_STEP_WEIGHTS,
+        media_type=det_media_type,
+        step_weights=timing.step_weights(
+            _DETECTOR_LOAD_TASK, media_type=det_media_type, embedder=det_embedder, n=n_labels
+        ),
     )
+    timing_recorder = timing.record_task(tracker, _DETECTOR_LOAD_TASK, media_type=det_media_type, embedder=det_embedder)
+    timing_recorder.start()
+    timing_recorder.set_scale(n=n_labels)
     tracker.update("loading", "Preparing…", 0, 0, step=1, total_steps=_LOAD_STEPS)
 
     det_name = entry.get("name", "")
@@ -687,14 +701,20 @@ def load_detector_route(body: dict):
     _thread_ds_ctx = get_active_context()
 
     def load_task():
-        _run_detector_load_task(
-            detector_id=detector_id,
-            det_ctx=det_ctx,
-            thread_ds_ctx=_thread_ds_ctx,
-            det_name=det_name,
-            tracker=tracker,
-            task_id=task_id,
-        )
+        try:
+            _run_detector_load_task(
+                detector_id=detector_id,
+                det_ctx=det_ctx,
+                thread_ds_ctx=_thread_ds_ctx,
+                det_name=det_name,
+                tracker=tracker,
+                task_id=task_id,
+            )
+        finally:
+            # The worker reports failures on the tracker rather than raising,
+            # so the tracker — not an exception — is what says whether these
+            # timings describe a real load or an aborted one.
+            timing_recorder.finish(ok=not tracker.get().get("error"))
 
     from vtsearch.threading import spawn
 

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -146,17 +146,17 @@ def find_label(body: dict):
 
     # Total high-level steps: resolve(1) + optional train(2) + score(3) + apply(4)
     _FIND_LABEL_STEPS = 4
-    # Train + score carry the cost; resolve/apply are quick. Paces the unified
-    # whole-job bar (ETA self-corrects from the real rate).
-    #                       resolve  train  score  apply
-    _FIND_LABEL_STEP_WEIGHTS = [0.10, 0.45, 0.40, 0.05]
+    #: Timing-profile task name; its step names and shipped fallback weights
+    #: live in :data:`vtscore.timing.tasks.TASKS`. An admin
+    #: ``VTSEARCH_TIMING_PROFILE`` replaces them with the seconds this
+    #: deployment's GPU actually spends training and scoring.
+    _TRAIN_SCORE_TASK = "train_and_score"
 
     detector_id = body["detector_id"]
 
     # Clear a leftover cancel flag from a previously-cancelled run so
     # the new operation doesn't trip on it immediately.
     find_progress.reset_cancel()
-    find_progress.set_step_weights(_FIND_LABEL_STEP_WEIGHTS)
 
     update_find_progress(
         "running",
@@ -178,6 +178,26 @@ def find_label(body: dict):
         abort(400, message="No medias loaded")
 
     media_type = d.get("media_type", "") or next(iter(snap.values())).get("media_type", "image")
+
+    # Both the train and score steps scale with the active dataset, so the bar
+    # can be paced against its real size instead of a fixed guess. Every exit
+    # below — success and abort alike — parks the tracker at "idle", which is
+    # what closes the recorder.
+    from vtscore import timing  # noqa: PLC0415
+
+    score_embedder = next(iter(snap.values())).get("embedder", "")
+    find_progress.set_step_weights(
+        timing.step_weights(_TRAIN_SCORE_TASK, media_type=media_type, embedder=score_embedder, n=len(snap))
+    )
+    recorder = timing.record_task(
+        find_progress,
+        _TRAIN_SCORE_TASK,
+        media_type=media_type,
+        embedder=score_embedder,
+        auto_finish=True,
+    )
+    recorder.start()
+    recorder.set_scale(n=len(snap))
     det_path = _detector_path(d["name"])
     det_data = _read_detector(det_path)
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -93,12 +93,11 @@ sorting_bp = Blueprint(
 # the unified whole-job bar and an overall ETA, with the model load surfaced as
 # real sub-progress within step 1.
 _SORT_STEPS = 3
-# The model load dominates wall-clock on a cold start (seconds to pull CLAP /
-# SigLIP weights); embedding one short query is trivial; scoring scales with the
-# dataset but is vectorised.  Paces the unified bar; the overall ETA
-# self-corrects from measured elapsed-vs-fraction regardless of these weights.
-#                     load  embed  score
-_SORT_STEP_WEIGHTS = [0.75, 0.05, 0.20]
+#: Timing-profile task name; its step names and shipped fallback weights live in
+#: :data:`vtscore.timing.tasks.TASKS`. An admin ``VTSEARCH_TIMING_PROFILE``
+#: measured on this deployment replaces those weights with real seconds, which
+#: is what keeps the sort ETA from drifting on a cold model load.
+_SORT_TASK = "text_sort"
 
 
 def _sort_idle() -> None:
@@ -254,7 +253,18 @@ def sort_clips(body: dict):
             ),
         )
 
-    sort_progress.set_step_weights(_SORT_STEP_WEIGHTS)
+    from vtscore import timing  # noqa: PLC0415
+
+    sort_progress.set_step_weights(
+        timing.step_weights(_SORT_TASK, media_type=media_type, embedder=embedder_name, n=len(snap))
+    )
+    # Every exit below — success and abort alike — parks the tracker at "idle"
+    # via ``_sort_idle()``, which is what closes the recorder.
+    recorder = timing.record_task(
+        sort_progress, _SORT_TASK, media_type=media_type, embedder=embedder_name, auto_finish=True
+    )
+    recorder.start()
+    recorder.set_scale(n=len(snap))
     try:
         _load_embedder_with_progress(snap)
         update_sort_progress("sorting", "Embedding text query…", 0, 0, step=2, total_steps=_SORT_STEPS)
@@ -272,6 +282,7 @@ def sort_clips(body: dict):
         _sort_idle()
         return windowed_sort_response(results, threshold)
     except Exception as exc:
+        recorder.finish(ok=False)
         from werkzeug.exceptions import HTTPException
 
         if isinstance(exc, HTTPException):


### PR DESCRIPTION
Two independent fixes for the same complaint: a progress bar whose ETA goes **up** while you watch it.

## 1. A per-environment timing profile (`vtscore/timing/`)

Every long-running task paced its bar with a hand-guessed weight vector sitting next to its own code — `[0.75, 0.05, 0.20]` for text sort, `[0.10, 0.30, 0.60]` for Find, and so on. Two problems:

- Those numbers were guessed on someone's machine, not measured on yours.
- **No single vector can be right at two sizes.** An 8-second encoder load *is* a 1000-item text search and is a rounding error on a 500k-item one. A vector that splits the difference is wrong at both ends, and being wrong in the same direction all job long is exactly what walks an ETA upward.

Each task family now registers its ordered steps in `vtscore/timing/tasks.py` and asks for weights at its entry point instead of carrying a literal. Cost is modelled affinely per `(device, media_type, embedder)` cell:

```
seconds ≈ a + b·n + per_mb·archive_mb
```

An admin measures their own hardware and points `VTSEARCH_TIMING_PROFILE` at the resulting JSON. The shipped defaults reproduce the previous vectors *exactly*, so an instance without a profile paces identically to before — adopting the mechanism is not itself a behaviour change.

**Gathering the measurements** (`scripts/profiling/tune_timing_profile.py`) works two ways, both producing the same file:

- **Observe real usage** (recommended): set `VTSEARCH_TIMING_RECORD` on the server, let people work, then `--fit-only`. No side effects, and it measures the datasets users actually load at the sizes they actually are.
- **Drive the workloads** (`--drive`): for commissioning a node. Defaults to the read-only families; the ones that mutate state — notably train-and-score, which **overwrites the active dataset's labels** — are gated behind `--allow-mutating` with the hazard named.

Either way the run ends with a coverage report naming which families were measured and which fell back to defaults, so a thin sweep is visible rather than quietly half-effective.

All seven families are wired: `dataset_load` (its existing calibrated table becomes the overridable default), `dataset_open`, `dataset_promote`, `detector_load`, `text_sort`, `find`, `train_and_score`.

## 2. Humble ETAs

> "9 min left? …10 min left? … 9.5 min left? … 11 min left?" just feels bad.

It reads as a system with no idea, because a number that precise invites you to check it. `ProgressTracker` now publishes the nearest rung of a coarse geometric ladder and **holds that rung** until the underlying estimate clears a neighbour by a hysteresis margin. The same wandering estimate reads **"About 10 min left"** the whole time.

Snapping alone wasn't enough — the old formatter already snapped, but re-snapped every event, so a value drifting near a boundary flipped back and forth. Stickiness is the half that was missing.

A genuinely slowing job still reports the increase (per the chosen option: sticky buckets, not a never-rise clamp) — pinning the display to a non-increasing value would just move the lie from the number to its trend. What it can't do any more is twitch. The internal EMA stays unquantized so it keeps converging.

## Notes

- **Breaking:** the ETA text changed from `5.5 min left?` to `About 10 min left`, and `eta_seconds` on the wire is now a coarse ladder rung rather than a raw estimate. No API shape changed.
- No doc screenshot frames a loading bar with an ETA chip, so the reshoot queue is untouched.
- Docs: `DEPLOYMENT.md` § *Progress-bar timing profile* (workflow + JSON schema + the two new env vars), `ARCHITECTURE.md` (directory map + progress-tracking section).

## Testing

`./run-tests.sh` — **7202 passed, 1 skipped**; `./run-tests.sh frontend` — **1865 passed**. All gates green (ruff, codespell, deptry, pip-audit, pyright, OpenAPI snapshot, Angular build + audit).

New coverage: `tests_lib/core/test_timing_profile.py` (defaults reproduce the old vectors, cell fallback, affine scaling, malformed profiles are inert), `tests_lib/core/test_timing_recorder_and_fit.py` (recorder semantics, both row shapes, the fit, and a record → fit → load → pace round trip), plus `TestHumbleEta` in `test_progress_overall.py` pinning both the coarseness and the stickiness.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSq8MgQ47E7KXv2bS3k4Cr)_