### PR TITLE
Dynamic DataSourceImporter picker for adding example media items

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,6 +82,7 @@ from vtsearch.routes import (  # noqa: E402
     health_bp,
     jobs_bp,
     labels_bp,
+    datasource_importers_bp,
     media_server_bp,
     medias_bp,
     datasets_listings_bp,
@@ -233,6 +234,7 @@ api.register_blueprint(health_bp)
 api.register_blueprint(jobs_bp)
 api.register_blueprint(labels_bp)
 api.register_blueprint(media_server_bp)
+api.register_blueprint(datasource_importers_bp)
 api.register_blueprint(main_bp)
 api.register_blueprint(medias_bp)
 api.register_blueprint(sorting_bp)

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -16,6 +16,7 @@ extractors).
 - [Shared Plugin Architecture](#shared-plugin-architecture): PluginField,
   PluginRegistry, discovery, route generation
 - [Adding a Data Importer](#adding-a-data-importer)
+- [Adding a Datasource Importer](#adding-a-datasource-importer)
 - [Adding a Media Converter](#adding-a-media-converter)
 - [Adding a Results Exporter](#adding-a-results-exporter)
 - [Adding a Label Importer](#adding-a-label-importer)
@@ -752,6 +753,89 @@ behavioural change.
 See [`EXTENDING-media.md` § Adding a Media Converter](EXTENDING-media.md#adding-a-media-converter)
 for how converters compose with importers. (The original `multi-media-import`
 design plan was removed once the feature shipped; its history is in git.)
+
+---
+
+## Adding a Datasource Importer
+
+A datasource importer is the **single-item sibling of a dataset importer**:
+it fetches exactly one media item's bytes from some source (a URL, a server
+path, a third-party service) so users can supply exemplar media — e.g. the
+seed examples of a new detector — from the same kinds of places a whole
+dataset can come from. The New Detector modal's example-media picker lists
+every registered datasource importer and renders its declared fields as a
+dynamic form, exactly like the Add Dataset modal does for dataset importers
+(GitHub issue #2767).
+
+### File structure
+
+```
+vtscore/datasource_importers/<your_importer>/
+└── __init__.py       # Importer class + DATASOURCE_IMPORTER instance (required)
+```
+
+Third-party packages can instead register through the
+`vtscore.datasource_importers` entry-point group (same mechanism as the
+other families; see
+[Third-party plugins](#third-party-plugins-via-importlibmetadata-entry-points)).
+
+### What to implement
+
+Subclass `DataSourceImporter` from `vtscore.datasource_importers`, declare
+`fields`, pick a `category` (the picker tab: `"services"`, `"server"`,
+`"local"`, or `"demo"`), and implement `fetch()`. Expose a module-level
+`DATASOURCE_IMPORTER` instance.
+
+```python
+# vtscore/datasource_importers/pastebin/__init__.py
+from vtscore.datasource_importers import DataSourceImporter, FetchedMediaItem
+from vtscore.plugins import PluginField
+
+
+class PastebinDataSourceImporter(DataSourceImporter):
+    """Fetch a text snippet from a pastebin service."""
+
+    category = "services"
+    fields = [
+        PluginField(key="paste_id", label="Paste id", field_type="text", required=True),
+    ]
+
+    def fetch(self, field_values):
+        data = ...  # download the snippet's bytes
+        return FetchedMediaItem(data=data, filename=f"{field_values['paste_id']}.txt")
+
+
+DATASOURCE_IMPORTER = PastebinDataSourceImporter()
+```
+
+`fetch()` receives the validated + normalized form values (text stripped;
+`url` / `server_path` fields already passed the shared SSRF /
+path-traversal validators — see `vtscore/plugins/normalize.py`). `file`
+fields arrive as `UploadedFile` objects. Raise `ValueError` for bad user
+input (surfaced as a 400); any other exception is reported as an upstream
+failure (502). The returned `FetchedMediaItem.filename` should keep the
+source's real extension — it drives media-type inference downstream.
+
+Dynamic select options work exactly as for dataset importers: declare a
+field with `dynamic_options=True` and implement
+`get_field_options(field_key, current_values)`
+(see [Dynamic field options](#dynamic-field-options)).
+
+### How it gets invoked
+
+- `GET /api/datasource-importers` lists every importer (with its fields
+  and category) plus the shared picker-tab declarations.
+- `POST /api/datasource-import/<name>` validates the body against the
+  importer's fields, calls `fetch()`, saves the returned bytes into the
+  per-user `example_media/` directory, and returns `{filename,
+  original_name}` — the same contract as the example-media upload
+  endpoint, so the fetched item plugs into the detector-example model
+  (`{type: "media", value: <filename>}`) unchanged.
+- `POST /api/datasource-import/<name>/options` serves dynamic field
+  options.
+
+Built-in examples: `server_file` (a `server_path` field with the inline
+file browser) and `url_download` (an SSRF-guarded single-file download).
 
 ---
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1956,6 +1956,72 @@
         ],
         "type": "object"
       },
+      "DatasourceImporterEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "fields": {
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "hidden_from_picker": {
+            "type": "boolean"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ui_mode": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "category",
+          "description",
+          "display_name",
+          "fields",
+          "hidden_from_picker",
+          "icon",
+          "name",
+          "ui_mode"
+        ],
+        "type": "object"
+      },
+      "DatasourceImportersListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "importers": {
+            "items": {
+              "$ref": "#/components/schemas/DatasourceImporterEntry"
+            },
+            "type": "array"
+          },
+          "tabs": {
+            "items": {
+              "$ref": "#/components/schemas/ImporterPickerTab"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "importers",
+          "tabs"
+        ],
+        "type": "object"
+      },
       "DemoCategoriesResponse": {
         "additionalProperties": false,
         "properties": {
@@ -6828,6 +6894,30 @@
         ],
         "type": "object"
       },
+      "datasource_import_ServerFileDataSourceImporter_Args": {
+        "additionalProperties": true,
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "datasource_import_UrlDownloadDataSourceImporter_Args": {
+        "additionalProperties": true,
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
       "import_dataset_CombineDatasetsImporter_Args": {
         "additionalProperties": true,
         "properties": {
@@ -11115,6 +11205,177 @@
         "summary": "Unload a specific dataset from memory.",
         "tags": [
           "datasets_registry"
+        ]
+      }
+    },
+    "/api/datasource-import/server_file": {
+      "post": {
+        "description": "Plugin-dependent body shape (JSON, or multipart when the importer\ndeclares ``file`` fields).  On success the fetched bytes are saved\ninto the per-user ``example_media/`` directory and the saved\n``filename`` (persistence key) plus the human-readable\n``original_name`` are returned, matching the upload endpoint's\ncontract.",
+        "operationId": "datasource_import__server_file",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/datasource_import_ServerFileDataSourceImporter_Args"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Fetch one media item via the named datasource importer.",
+        "tags": [
+          "datasource_importers"
+        ]
+      }
+    },
+    "/api/datasource-import/url_download": {
+      "post": {
+        "description": "Plugin-dependent body shape (JSON, or multipart when the importer\ndeclares ``file`` fields).  On success the fetched bytes are saved\ninto the per-user ``example_media/`` directory and the saved\n``filename`` (persistence key) plus the human-readable\n``original_name`` are returned, matching the upload endpoint's\ncontract.",
+        "operationId": "datasource_import__url_download",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/datasource_import_UrlDownloadDataSourceImporter_Args"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Fetch one media item via the named datasource importer.",
+        "tags": [
+          "datasource_importers"
+        ]
+      }
+    },
+    "/api/datasource-import/{importer_name}": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "importer_name",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Plugin-dependent body shape (JSON, or multipart when the importer\ndeclares ``file`` fields).  On success the fetched bytes are saved\ninto the per-user ``example_media/`` directory and the saved\n``filename`` (persistence key) plus the human-readable\n``original_name`` are returned, matching the upload endpoint's\ncontract.",
+        "operationId": "run_datasource_import",
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Fetch one media item via the named datasource importer.",
+        "tags": [
+          "datasource_importers"
+        ]
+      }
+    },
+    "/api/datasource-import/{importer_name}/options": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "importer_name",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Same contract as ``POST /api/dataset/import/<name>/options``: the\nimporter's ``get_field_options(field_key, current_values)`` is called\nwith the supplied snapshot of current form values, and plugin errors\n(network failure, auth error, etc.) surface as a 502 with the\noriginal message so the frontend can display them inline.",
+        "operationId": "datasource_importer_field_options",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImporterFieldOptionsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImporterFieldOptionsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Unknown or non-dynamic field key."
+          },
+          "404": {
+            "description": "Unknown datasource importer name."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "500": {
+            "description": "get_field_options did not return a list."
+          },
+          "501": {
+            "description": "Importer does not implement get_field_options."
+          },
+          "502": {
+            "description": "Remote service backing dynamic options raised an error."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return dropdown options for a dynamic-options field.",
+        "tags": [
+          "datasource_importers"
+        ]
+      }
+    },
+    "/api/datasource-importers": {
+      "get": {
+        "description": "``tabs`` are the dataset-importer picker-tab declarations; datasource\nimporters use the same category ids so both families share one tab\nbar in the example-media picker.",
+        "operationId": "list_datasource_importers_route",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasourceImportersListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "List available datasource importers and the shared picker tabs.",
+        "tags": [
+          "datasource_importers"
         ]
       }
     },
@@ -16136,6 +16397,10 @@
     {
       "description": "Server-side example media files and example-sort routes.",
       "name": "media_server"
+    },
+    {
+      "description": "Datasource importers: fetch a single media item into example_media/.",
+      "name": "datasource_importers"
     },
     {
       "description": "App version and SPA / static-file serving.",

--- a/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.html
@@ -1,0 +1,158 @@
+<div class="datasource-import-form">
+  @if (importer().description) {
+    <p class="info-text">{{ importer().description }}</p>
+  }
+
+  @for (field of importerFields; track field.key) {
+    <div class="form-group">
+      <label class="col-label" [for]="'dsi-' + field.key"
+        [title]="field.description || field.label || field.key">
+        {{ field.label || field.key }}
+        @if (field.required) {
+          <span class="required">*</span>
+        }
+        @if (field.hint) {
+          <vt-field-hint-icon [hint]="field.hint"></vt-field-hint-icon>
+        }
+      </label>
+
+      @if (field.field_type === 'server_path') {
+        <vt-file-browser
+          [value]="values[field.key] || ''"
+          [extensions]="field.accept || ''"
+          [placeholder]="field.placeholder || field.description || field.label || field.key"
+          (pathSelected)="onServerPathSelected(field.key, $event)"
+        ></vt-file-browser>
+      } @else if (field.field_type === 'file') {
+        <input
+          [id]="'dsi-' + field.key"
+          type="file"
+          class="form-input"
+          [accept]="field.accept || ''"
+          [title]="field.description || field.label || field.key"
+          (change)="onFileSelected($event, field.key)"
+        />
+      } @else if (field.field_type === 'password') {
+        <input
+          [id]="'dsi-' + field.key"
+          type="password"
+          class="form-input"
+          [(ngModel)]="values[field.key]"
+          [name]="'dsi-' + field.key"
+          [placeholder]="field.placeholder || field.description || field.label || field.key"
+          [title]="field.description || field.label || field.key"
+        />
+      } @else if (field.field_type === 'email') {
+        <input
+          [id]="'dsi-' + field.key"
+          type="email"
+          class="form-input"
+          [(ngModel)]="values[field.key]"
+          [name]="'dsi-' + field.key"
+          [placeholder]="field.placeholder || field.description || field.label || field.key"
+          [title]="field.description || field.label || field.key"
+        />
+      } @else if (field.field_type === 'url') {
+        <input
+          [id]="'dsi-' + field.key"
+          type="url"
+          class="form-input"
+          [(ngModel)]="values[field.key]"
+          [name]="'dsi-' + field.key"
+          [placeholder]="field.placeholder || field.description || field.label || field.key"
+          [title]="field.description || field.label || field.key"
+          (keydown.enter)="$event.preventDefault(); submit()"
+        />
+      } @else if (field.field_type === 'select' && field.allow_free_text) {
+        <input
+          [id]="'dsi-' + field.key"
+          type="text"
+          class="form-input"
+          [attr.list]="'dsi-' + field.key + '-list'"
+          [(ngModel)]="values[field.key]"
+          [name]="'dsi-' + field.key"
+          [disabled]="!!dynamicLoading()[field.key]"
+          [placeholder]="dynamicLoading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+          [title]="field.description || field.label || field.key"
+          (ngModelChange)="onFieldChanged(field.key)"
+        />
+        <datalist [id]="'dsi-' + field.key + '-list'">
+          @for (opt of optionsFor(field); track opt.value) {
+            <option [value]="opt.value">{{ opt.label }}</option>
+          }
+        </datalist>
+        @if (field.dynamic_options && dynamicError()[field.key]) {
+          <p class="error-text">{{ dynamicError()[field.key] }}</p>
+        }
+      } @else if (field.field_type === 'select') {
+        <select
+          [id]="'dsi-' + field.key"
+          class="form-select"
+          [(ngModel)]="values[field.key]"
+          [name]="'dsi-' + field.key"
+          [title]="field.description || field.label || field.key"
+          (ngModelChange)="onFieldChanged(field.key)"
+          [disabled]="!!dynamicLoading()[field.key] || (!!field.dynamic_options && optionsFor(field).length === 0)"
+        >
+          @if (field.dynamic_options && dynamicLoading()[field.key]) {
+            <option value="">Loading…</option>
+          } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicError()[field.key]) {
+            <option value="">No options available</option>
+          }
+          @for (opt of optionsFor(field); track opt.value) {
+            <option [value]="opt.value">{{ opt.label }}</option>
+          }
+        </select>
+        @if (field.dynamic_options && dynamicError()[field.key]) {
+          <p class="error-text">{{ dynamicError()[field.key] }}</p>
+        }
+      } @else if (field.field_type === 'number') {
+        <input
+          [id]="'dsi-' + field.key"
+          type="number"
+          class="form-input"
+          [(ngModel)]="values[field.key]"
+          [name]="'dsi-' + field.key"
+          [placeholder]="field.placeholder || field.description || field.label || field.key"
+          [title]="field.description || field.label || field.key"
+          [attr.min]="field.min || null"
+          [attr.max]="field.max || null"
+          [attr.step]="field.step || null"
+        />
+      } @else if (field.field_type === 'checkbox') {
+        <input
+          [id]="'dsi-' + field.key"
+          type="checkbox"
+          [checked]="values[field.key] === 'true'"
+          (change)="values[field.key] = $any($event.target).checked ? 'true' : 'false'"
+          [title]="field.description || field.label || field.key"
+        />
+      } @else {
+        <input
+          [id]="'dsi-' + field.key"
+          type="text"
+          class="form-input"
+          [(ngModel)]="values[field.key]"
+          [name]="'dsi-' + field.key"
+          [placeholder]="field.placeholder || field.description || field.label || field.key"
+          [title]="field.description || field.label || field.key"
+          (keydown.enter)="$event.preventDefault(); submit()"
+        />
+      }
+    </div>
+  }
+
+  <button
+    type="button"
+    class="btn btn--primary load-btn"
+    [disabled]="!canSubmit"
+    (click)="submit()"
+    title="Fetch this media item and use it as the example"
+  >
+    @if (submitting()) { Loading… } @else { Load }
+  </button>
+
+  @if (error()) {
+    <p class="error-text">{{ error() }}</p>
+  }
+</div>

--- a/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.scss
+++ b/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.scss
@@ -1,0 +1,9 @@
+.datasource-import-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  .load-btn {
+    align-self: flex-start;
+  }
+}

--- a/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.spec.ts
@@ -131,7 +131,8 @@ describe('DatasourceImportFormComponent', () => {
 
     const req = httpMock.expectOne('/api/datasource-import/uploader');
     expect(req.request.body instanceof FormData).toBe(true);
-    expect((req.request.body as FormData).get('file')).toBe(file);
+    // FormData.append clones the File under jsdom, so compare by name.
+    expect(((req.request.body as FormData).get('file') as File).name).toBe('clip.wav');
     req.flush({ filename: 'x.wav', original_name: 'clip.wav' });
   });
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.spec.ts
@@ -1,0 +1,166 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HttpTestingController } from '@angular/common/http/testing';
+import { DatasourceImportFormComponent } from './datasource-import-form.component';
+import { provideZoneless } from '../../../../testing/zoneless-testbed';
+import { provideHttpTesting } from '../../../../testing/test-providers';
+
+describe('DatasourceImportFormComponent', () => {
+  let component: DatasourceImportFormComponent;
+  let fixture: ComponentFixture<DatasourceImportFormComponent>;
+  let httpMock: HttpTestingController;
+
+  function setImporter(importer: unknown): void {
+    fixture.componentRef.setInput('importer', importer);
+    TestBed.tick(); // run the reset effect under zoneless
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DatasourceImportFormComponent],
+      providers: [...provideZoneless(), ...provideHttpTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatasourceImportFormComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('seeds defaults and the first static select option', () => {
+    setImporter({
+      name: 'imp',
+      fields: [
+        { key: 'mode', field_type: 'select', options: ['a', 'b'] },
+        { key: 'path', field_type: 'text', default: '/tmp/x' },
+        { key: 'free', field_type: 'text' },
+      ],
+    });
+
+    expect(component.values['mode']).toBe('a');
+    expect(component.values['path']).toBe('/tmp/x');
+    expect(component.values['free']).toBeUndefined();
+  });
+
+  it('fetches dynamic options on selection and auto-picks for a required strict select', () => {
+    const field = { key: 'sheet', field_type: 'select', dynamic_options: true, required: true };
+    setImporter({ name: 'svc', fields: [field] });
+
+    const req = httpMock.expectOne('/api/datasource-import/svc/options');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.field_key).toBe('sheet');
+    req.flush({ options: [{ value: 's1', label: 'Sheet 1' }] });
+
+    expect(component.optionsFor(field as never)).toEqual([{ value: 's1', label: 'Sheet 1' }]);
+    expect(component.values['sheet']).toBe('s1');
+  });
+
+  it('re-fetches a dependent field when its dependency changes', () => {
+    const parent = { key: 'doc', field_type: 'select', dynamic_options: true };
+    const child = { key: 'tab', field_type: 'select', dynamic_options: true, depends_on: ['doc'] };
+    setImporter({ name: 'svc', fields: [parent, child] });
+    httpMock.match('/api/datasource-import/svc/options').forEach((r) => r.flush({ options: [] }));
+
+    component.values['doc'] = 'doc-1';
+    component.onFieldChanged('doc');
+
+    expect(component.values['tab']).toBe('');
+    const req = httpMock.expectOne('/api/datasource-import/svc/options');
+    expect(req.request.body.field_key).toBe('tab');
+    req.flush({ options: [] });
+  });
+
+  it('surfaces a dynamic-option fetch error inline', () => {
+    const field = { key: 'q', field_type: 'select', dynamic_options: true };
+    setImporter({ name: 'svc', fields: [field] });
+    httpMock
+      .expectOne('/api/datasource-import/svc/options')
+      .flush({ message: 'boom' }, { status: 502, statusText: 'Bad Gateway' });
+
+    expect(component.dynamicError()['q']).toBe('boom');
+    expect(component.optionsFor(field as never)).toEqual([]);
+  });
+
+  it('blocks submit until every required field is filled', () => {
+    setImporter({
+      name: 'url_download',
+      fields: [{ key: 'url', field_type: 'url', required: true }],
+    });
+    expect(component.canSubmit).toBe(false);
+
+    component.values['url'] = 'https://example.com/a.wav';
+    expect(component.canSubmit).toBe(true);
+  });
+
+  it('posts the values and emits the fetched item on success', () => {
+    vi.spyOn(component.imported, 'emit');
+    setImporter({
+      name: 'url_download',
+      fields: [{ key: 'url', field_type: 'url', required: true }],
+    });
+    component.values['url'] = 'https://example.com/a.wav';
+
+    component.submit();
+
+    const req = httpMock.expectOne('/api/datasource-import/url_download');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ url: 'https://example.com/a.wav' });
+    req.flush({ filename: 'abc.wav', original_name: 'a.wav' });
+
+    expect(component.imported.emit).toHaveBeenCalledWith({
+      filename: 'abc.wav',
+      original_name: 'a.wav',
+    });
+    expect(component.submitting()).toBe(false);
+  });
+
+  it('sends multipart when the importer declares a file field', () => {
+    setImporter({
+      name: 'uploader',
+      fields: [{ key: 'file', field_type: 'file', required: true }],
+    });
+    const file = new File([new Uint8Array([1, 2, 3])], 'clip.wav');
+    component.selectedFile = file;
+    component.fileFieldKey = 'file';
+    component.values['file'] = 'clip.wav';
+
+    component.submit();
+
+    const req = httpMock.expectOne('/api/datasource-import/uploader');
+    expect(req.request.body instanceof FormData).toBe(true);
+    expect((req.request.body as FormData).get('file')).toBe(file);
+    req.flush({ filename: 'x.wav', original_name: 'clip.wav' });
+  });
+
+  it('surfaces a run failure without emitting', () => {
+    vi.spyOn(component.imported, 'emit');
+    setImporter({
+      name: 'server_file',
+      fields: [{ key: 'path', field_type: 'server_path', required: true }],
+    });
+    component.values['path'] = '/nope.wav';
+
+    component.submit();
+    httpMock
+      .expectOne('/api/datasource-import/server_file')
+      .flush({ message: 'File not found: /nope.wav' }, { status: 400, statusText: 'Bad Request' });
+
+    expect(component.error()).toBe('File not found: /nope.wav');
+    expect(component.imported.emit).not.toHaveBeenCalled();
+    expect(component.submitting()).toBe(false);
+  });
+
+  it('resets state when the parent selects a different importer', () => {
+    setImporter({ name: 'a', fields: [{ key: 'x', field_type: 'text' }] });
+    component.values['x'] = 'typed';
+    component.error.set('stale');
+
+    setImporter({ name: 'b', fields: [{ key: 'y', field_type: 'text', default: 'd' }] });
+
+    expect(component.values).toEqual({ y: 'd' });
+    expect(component.error()).toBe('');
+  });
+});

--- a/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/datasource-import-form/datasource-import-form.component.ts
@@ -1,0 +1,191 @@
+import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
+
+import { FormsModule } from '@angular/forms';
+
+import { FieldOptions, ImporterField, ImporterInfo } from '../../../../models/api.models';
+import {
+  DatasourceImportersApiService,
+  DatasourceImportResult,
+} from '../../../../services/datasource-importers-api.service';
+import { apiErrorMessage } from '../../../../utils/api-error';
+import { FieldHintIconComponent } from '../../../field-hint-icon/field-hint-icon.component';
+import { FileBrowserComponent } from '../../../file-browser/file-browser.component';
+
+/** Dynamic form for one datasource importer, rendered from its declared
+ *  plugin fields (the single-item sibling of the Add Dataset modal's
+ *  generic importer form).  Submitting runs the importer server-side; the
+ *  fetched item lands in ``example_media/`` and is emitted as
+ *  ``{filename, original_name}`` for the caller to use as a media
+ *  example. */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'vt-datasource-import-form',
+  standalone: true,
+  imports: [FormsModule, FieldHintIconComponent, FileBrowserComponent],
+  templateUrl: './datasource-import-form.component.html',
+  styleUrl: './datasource-import-form.component.scss',
+})
+export class DatasourceImportFormComponent {
+  private api = inject(DatasourceImportersApiService);
+
+  /** The datasource importer whose fields to render. */
+  readonly importer = input.required<ImporterInfo>();
+
+  /** Emits the fetched item once the importer run succeeds. */
+  readonly imported = output<DatasourceImportResult>();
+
+  values: Record<string, string> = {};
+  selectedFile: File | null = null;
+  fileFieldKey: string | null = null;
+  readonly submitting = signal(false);
+  readonly error = signal('');
+  // Dynamic-field-option state, keyed by field key; signalized so the
+  // unpatched HTTP callbacks schedule CD under zoneless (see
+  // docs/plans/zoneless-migration.md).
+  readonly dynamicOptions = signal<Record<string, FieldOptions[]>>({});
+  readonly dynamicLoading = signal<Record<string, boolean>>({});
+  readonly dynamicError = signal<Record<string, string>>({});
+
+  constructor() {
+    // Re-seed the form whenever the parent selects a different importer.
+    effect(() => {
+      this.resetFor(this.importer());
+    });
+  }
+
+  /** Typed view of the importer's plugin fields for the template. */
+  get importerFields(): ImporterField[] {
+    return (this.importer().fields ?? []) as ImporterField[];
+  }
+
+  private resetFor(importer: ImporterInfo): void {
+    this.values = {};
+    this.selectedFile = null;
+    this.fileFieldKey = null;
+    this.submitting.set(false);
+    this.error.set('');
+    this.dynamicOptions.set({});
+    this.dynamicLoading.set({});
+    this.dynamicError.set({});
+    const fields = (importer.fields ?? []) as ImporterField[];
+    for (const field of fields) {
+      if (field.default) {
+        this.values[field.key] = field.default;
+      } else if (
+        field.field_type === 'select' &&
+        !field.dynamic_options &&
+        !field.allow_free_text &&
+        (field.options?.length ?? 0) > 0
+      ) {
+        this.values[field.key] = field.options![0];
+      }
+    }
+    for (const field of fields) {
+      if (field.dynamic_options) {
+        this.refreshFieldOptions(field);
+      }
+    }
+  }
+
+  /** Re-fetch dynamic options for any field that depends on the one the
+   *  user just changed, blanking each dependent value first so a stale
+   *  selection can't survive into the new option set. */
+  onFieldChanged(changedKey: string): void {
+    for (const field of this.importerFields) {
+      if (!field.dynamic_options) continue;
+      if (!(field.depends_on || []).includes(changedKey)) continue;
+      this.values[field.key] = '';
+      this.refreshFieldOptions(field);
+    }
+  }
+
+  /** Options to render for a field: the dynamically-fetched list for a
+   *  ``dynamic_options`` field, else the static strings coerced into
+   *  ``{value,label}`` pairs. */
+  optionsFor(field: ImporterField): FieldOptions[] {
+    if (field.dynamic_options) {
+      return this.dynamicOptions()[field.key] || [];
+    }
+    return (field.options || []).map((o) => ({ value: o, label: o }));
+  }
+
+  private refreshFieldOptions(field: ImporterField): void {
+    const key = field.key;
+    this.dynamicLoading.update((m) => ({ ...m, [key]: true }));
+    this.dynamicError.update((m) => ({ ...m, [key]: '' }));
+    this.api.getFieldOptions(this.importer().name, key, { ...this.values }).subscribe({
+      next: (res) => {
+        const options: FieldOptions[] = res.options || [];
+        this.dynamicOptions.update((m) => ({ ...m, [key]: options }));
+        this.dynamicLoading.update((m) => ({ ...m, [key]: false }));
+        const current = this.values[key];
+        const inList = options.some((o) => o.value === String(current));
+        // Strict selects clear a value the new list no longer offers; a
+        // free-text combobox keeps whatever the user typed.
+        if (current && !inList && !field.allow_free_text) {
+          this.values[key] = '';
+        }
+        if (!this.values[key] && field.required && !field.allow_free_text && options.length > 0) {
+          this.values[key] = options[0].value;
+        }
+      },
+      error: (err) => {
+        this.dynamicLoading.update((m) => ({ ...m, [key]: false }));
+        this.dynamicError.update((m) => ({
+          ...m,
+          [key]: apiErrorMessage(err, 'Could not load options'),
+        }));
+        this.dynamicOptions.update((m) => ({ ...m, [key]: [] }));
+      },
+    });
+  }
+
+  onFileSelected(event: Event, fieldKey: string): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.selectedFile = input.files[0];
+      this.fileFieldKey = fieldKey;
+      this.values[fieldKey] = input.files[0].name;
+    }
+  }
+
+  onServerPathSelected(fieldKey: string, path: string): void {
+    this.values[fieldKey] = path;
+  }
+
+  get canSubmit(): boolean {
+    if (this.submitting()) return false;
+    for (const field of this.importerFields) {
+      if (!field.required) continue;
+      if (field.field_type === 'file') {
+        if (!this.selectedFile) return false;
+      } else if (!(this.values[field.key] || '').trim()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  submit(): void {
+    if (!this.canSubmit) return;
+    this.submitting.set(true);
+    this.error.set('');
+    this.api
+      .run(
+        this.importer().name,
+        { ...this.values },
+        this.selectedFile ?? undefined,
+        this.fileFieldKey ?? undefined,
+      )
+      .subscribe({
+        next: (res) => {
+          this.submitting.set(false);
+          this.imported.emit(res);
+        },
+        error: (err) => {
+          this.submitting.set(false);
+          this.error.set(apiErrorMessage(err, 'Failed to fetch the media item'));
+        },
+      });
+  }
+}

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -438,13 +438,6 @@
         (demoSelected)="selectDemo($event)"
         [demoRowDisabledFn]="demoRowDisabledFn"
         [demoRowTitleFn]="demoRowTitleFn"
-        [sfPathInputValue]="sfTypedPath"
-        (sfPathInputValueChange)="sfTypedPath = $event"
-        (sfPathApplied)="submitSfTypedPath()"
-        [sfApplyOnBlur]="false"
-        [sfPathLabel]="'Path to a media file on the server'"
-        [sfPathPlaceholder]="'/absolute/server/path/to/file'"
-        [sfPathFieldId]="'sf-example-path-input'"
         [lfPickerKind]="lfPickerKind"
         [lfShowFieldLabel]="false"
         [lfShowFileCount]="false"
@@ -455,20 +448,6 @@
         [lfFilesAcceptAttr]="''"
         (lfFilesDropped)="onLocalFileDropped($event)"
       >
-        <ng-container sfAfter>
-          <button
-            type="button"
-            class="btn btn--primary"
-            [disabled]="sfFileSelecting() || !sfTypedPath.trim()"
-            (click)="submitSfTypedPath()"
-          >
-            @if (sfFileSelecting()) { Loading… } @else { Load }
-          </button>
-          @if (sfBrowseError()) {
-            <p class="error-text">{{ sfBrowseError() }}</p>
-          }
-        </ng-container>
-
         <ng-container lfInfo>
           <p class="info-text">
             Pick a media file on <strong>this computer</strong>. It will be uploaded to the server
@@ -485,6 +464,16 @@
           }
         </ng-container>
       </vt-source-picker>
+
+      <!-- Datasource importer form: fetches one media item via the selected
+           importer's declared plugin fields (server file, URL download,
+           third-party datasource importers). -->
+      @if (selectedDatasourceImporter; as dsImporter) {
+        <vt-datasource-import-form
+          [importer]="dsImporter"
+          (imported)="onDatasourceImported($event)"
+        ></vt-datasource-import-form>
+      }
 
       <!-- Demo file picker: appears after picking a demo from the table.
            Source-picker hides its demo view (activePickerView passed as '')

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -316,28 +316,86 @@ describe('NewDetectorModalComponent', () => {
   });
 
   it('auto-selects the lone importer when a single-source category is opened', () => {
-    // "Files" has exactly one importer (server_folder), so opening it should
-    // skip the redundant one-button sub-tab bar and land on the path input.
+    // "Files" has exactly one importer (the server_file datasource
+    // importer), so opening it should skip the redundant one-button
+    // sub-tab bar and land on its form.
+    component.datasourceImporters.set([
+      { name: 'server_file', category: 'server' },
+    ]);
     component.mediaImporters.set([
-      { name: 'server_folder', picker_view: 'server_folder', category: 'server' },
       { name: 'demo', picker_view: 'demo', category: 'demo' },
     ]);
 
     component.selectImporterTab('server');
 
-    expect(component.selectedImporter?.name).toBe('server_folder');
-    expect(component.activePickerView).toBe('server_folder');
+    expect(component.selectedImporter?.name).toBe('server_file');
+    expect(component.selectedDatasourceImporter?.name).toBe('server_file');
   });
 
   it('does not auto-select when a category holds more than one importer', () => {
-    component.mediaImporters.set([
-      { name: 'server_folder', picker_view: 'server_folder', category: 'server' },
-      { name: 'server_other', picker_view: 'server_folder', category: 'server' },
+    component.datasourceImporters.set([
+      { name: 'server_file', category: 'server' },
+      { name: 'server_other', category: 'server' },
     ]);
 
     component.selectImporterTab('server');
 
     expect(component.selectedImporter).toBeNull();
+  });
+
+  // --- Datasource importers in the media picker (issue #2767) ---
+
+  it('merges datasource importers into the picker after the dataset browse views', () => {
+    component.mediaImporters.set([
+      { name: 'local_files', picker_view: 'local_files', category: 'local' },
+      { name: 'demo', picker_view: 'demo', category: 'demo' },
+    ]);
+    component.datasourceImporters.set([
+      { name: 'server_file', category: 'server' },
+      { name: 'url_download', category: 'services' },
+      { name: 'my_cloud_thing', category: 'services' },
+    ]);
+
+    expect(component.orderedImporters.map((i) => i.name)).toEqual([
+      'local_files',
+      'server_file',
+      'demo',
+      'url_download',
+      'my_cloud_thing',
+    ]);
+  });
+
+  it('reports an empty picker view for a selected datasource importer', () => {
+    const dsImporter = { name: 'url_download', category: 'services' };
+    component.datasourceImporters.set([dsImporter]);
+
+    component.selectImporter(dsImporter);
+
+    // The source picker renders none of its dedicated widgets; the modal
+    // renders the importer's dynamic form instead.
+    expect(component.activePickerView).toBe('');
+    expect(component.selectedDatasourceImporter).toBe(dsImporter);
+  });
+
+  it('routes a dataset importer that shares a datasource importer name by identity', () => {
+    const datasetDemo = { name: 'demo', picker_view: 'demo', category: 'demo' };
+    component.mediaImporters.set([datasetDemo]);
+    component.datasourceImporters.set([{ name: 'demo', category: 'services' }]);
+
+    expect(component.isDatasourceImporter(datasetDemo)).toBe(false);
+  });
+
+  it('adds the fetched item to the example stack and returns to the form', () => {
+    component.view.set('media-picker');
+    component.mediaType.set('');
+
+    component.onDatasourceImported({ filename: 'abc123.wav', original_name: 'bark.wav' });
+
+    expect(component.mediaExamples().map((e) => e.value)).toEqual(['abc123.wav']);
+    expect(component.mediaExamples()[0].display).toBe('bark.wav');
+    // Media type is inferred from the original filename's extension.
+    expect(component.mediaExamples()[0].mediaType).toBe('audio');
+    expect(component.view()).toBe('main');
   });
 
   // --- Trained tab: label-importer plugin field parity (issue #2597) ---

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -38,6 +38,11 @@ import {
 } from '../../modals/media-crop-modal/media-crop-modal.component';
 import { DropZoneComponent } from '../../drop-zone/drop-zone.component';
 import { SourcePickerComponent } from '../dataset-importer-modal/source-picker/source-picker.component';
+import { DatasourceImportFormComponent } from './datasource-import-form/datasource-import-form.component';
+import {
+  DatasourceImportersApiService,
+  DatasourceImportResult,
+} from '../../../services/datasource-importers-api.service';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 import { apiErrorMessage } from '../../../utils/api-error';
 
@@ -61,7 +66,7 @@ interface MediaExampleItem {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-new-detector-modal',
   standalone: true,
-  imports: [FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent, FieldHintIconComponent, ProgressBarComponent],
+  imports: [FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent, DatasourceImportFormComponent, FieldHintIconComponent, ProgressBarComponent],
   templateUrl: './new-detector-modal.component.html',
   styleUrl: './new-detector-modal.component.scss',
 })
@@ -72,6 +77,7 @@ export class NewDetectorModalComponent implements OnInit {
   private datasetsRegistryApi = inject(DatasetsRegistryApiService);
   private datasetsUiApi = inject(DatasetsUiApiService);
   private sortingApi = inject(SortingApiService);
+  private datasourceImportersApi = inject(DatasourceImportersApiService);
   private labelImportersApi = inject(LabelImportersApiService);
   private progressEvents = inject(ProgressEventsService);
   private settingsState = inject(SettingsStateService);
@@ -147,10 +153,14 @@ export class NewDetectorModalComponent implements OnInit {
 
   // --- Media picker state (shares structure with the Add Dataset modal) ---
 
-  /** All importers discovered from the backend, filtered to picker_views we
-   *  can use to select a single example file (demo, server_folder,
-   *  local_folder, local_files). */
+  /** Dataset importers discovered from the backend, filtered to picker_views
+   *  we can use to browse for a single example file (demo, local_folder,
+   *  local_files). */
   readonly mediaImporters = signal<ImporterInfo[]>([]);
+  /** Datasource importers (single-item fetchers: server file, URL,
+   *  third-party services).  Each renders as a dynamic form built from its
+   *  declared plugin fields, like the Add Dataset generic importer form. */
+  readonly datasourceImporters = signal<ImporterInfo[]>([]);
   /** Tab declarations (categories) returned by the backend. */
   readonly declaredImporterTabs = signal<ImporterPickerTab[]>([]);
   /** Currently selected category tab (e.g. ``"demo"``, ``"server"``). */
@@ -163,17 +173,17 @@ export class NewDetectorModalComponent implements OnInit {
   private static readonly PICKER_ORDER = [
     'local_folder',
     'local_files',
-    'server_folder',
-    'server_files',
+    'server_file',
     'demo',
+    'url_download',
   ];
 
-  /** Picker views supported by the single-file example picker.  Importers
-   *  whose ``picker_view`` is anything else (e.g. ``"form"``) are hidden
-   *  here; the user can still use them via the Add Dataset modal. */
+  /** Dataset-importer picker views supported by the single-file example
+   *  picker (dedicated browse/upload widgets).  Server files and every
+   *  other source go through datasource importers instead, which render
+   *  as dynamic forms. */
   private static readonly SUPPORTED_PICKER_VIEWS = new Set([
     'demo',
-    'server_folder',
     'local_folder',
     'local_files',
   ]);
@@ -209,11 +219,6 @@ export class NewDetectorModalComponent implements OnInit {
   readonly demoFileLoading = signal(false);
   demoTypedPath = '';
   readonly demoTypedPathError = signal('');
-
-  // --- Server example-media picker. Path is validated when submitted. ---
-  readonly sfBrowseError = signal('');
-  readonly sfFileSelecting = signal(false);
-  sfTypedPath = '';
 
   // Pending crop confirmation state.
   pendingFile: File | null = null;
@@ -570,7 +575,6 @@ export class NewDetectorModalComponent implements OnInit {
     this.activeImporterTab = '';
     this.selectedImporter = null;
     this.resetDemoPickerState();
-    this.resetServerFolderState();
     this.loadMediaImporters();
   }
 
@@ -585,18 +589,35 @@ export class NewDetectorModalComponent implements OnInit {
         this.declaredImporterTabs.set(res.tabs || []);
       },
     });
+    this.datasourceImportersApi.list().subscribe({
+      next: (res) => {
+        this.datasourceImporters.set(
+          (res.importers || []).filter((imp) => !imp['hidden_from_picker']),
+        );
+      },
+    });
   }
 
-  /** Importers ordered like the Add Dataset modal: known picker_views
-   *  first, then any extras in registry order. */
+  /** True when *importer* is a datasource importer (single-item fetcher
+   *  rendered as a dynamic form) rather than a dataset-importer browse
+   *  view.  Identity check against the datasource list, so a name shared
+   *  across the two families can't misroute. */
+  isDatasourceImporter(importer: ImporterInfo | null): boolean {
+    return importer != null && this.datasourceImporters().includes(importer);
+  }
+
+  /** Importers ordered like the Add Dataset modal: known names first,
+   *  then any extras (e.g. third-party datasource importers) in registry
+   *  order. */
   get orderedImporters(): ImporterInfo[] {
+    const all = [...this.mediaImporters(), ...this.datasourceImporters()];
     const order = NewDetectorModalComponent.PICKER_ORDER;
     const result: ImporterInfo[] = [];
     for (const name of order) {
-      const imp = this.mediaImporters().find((i) => i.name === name);
+      const imp = all.find((i) => i.name === name);
       if (imp) result.push(imp);
     }
-    for (const imp of this.mediaImporters()) {
+    for (const imp of all) {
       if (!order.includes(imp.name)) result.push(imp);
     }
     return result;
@@ -652,7 +673,6 @@ export class NewDetectorModalComponent implements OnInit {
     this.activeImporterTab = tabId;
     this.selectedImporter = null;
     this.resetDemoPickerState();
-    this.resetServerFolderState();
     // A category with a single source has no meaningful sub-tab choice, so
     // skip straight to that source's input (e.g. opening "Files" lands the
     // user on the server-path entry instead of a one-button sub-tab bar).
@@ -665,23 +685,41 @@ export class NewDetectorModalComponent implements OnInit {
   selectImporter(importer: ImporterInfo): void {
     this.selectedImporter = importer;
     this.error.set('');
-    const view = importer.picker_view || '';
-    if (view === 'demo') {
+    if (!this.isDatasourceImporter(importer) && (importer.picker_view || '') === 'demo') {
       this.openDemoPicker();
-    } else if (view === 'server_folder') {
-      this.openServerFolderBrowser();
     } else {
-      // local_folder / local_files: just reveal the upload input below.
+      // Datasource importers render their dynamic form below the sub-tab
+      // row; local_folder / local_files just reveal the upload input.
       this.resetDemoPickerState();
-      this.resetServerFolderState();
     }
   }
 
   /** Picker view of the currently selected importer, or empty when nothing
    *  is selected.  Drives which inline widget set is rendered below the
-   *  inner sub-tab row. */
+   *  inner sub-tab row.  Datasource importers report empty so the source
+   *  picker renders none of its dedicated widgets; their dynamic form is
+   *  rendered by this modal instead. */
   get activePickerView(): string {
+    if (this.isDatasourceImporter(this.selectedImporter)) return '';
     return this.selectedImporter?.picker_view || '';
+  }
+
+  /** The selected importer when it is a datasource importer, else null.
+   *  Template convenience for rendering the dynamic form view. */
+  get selectedDatasourceImporter(): ImporterInfo | null {
+    return this.isDatasourceImporter(this.selectedImporter) ? this.selectedImporter : null;
+  }
+
+  /** A datasource importer fetched an item into ``example_media/``: add
+   *  it to the example stack and land back on the main form. */
+  onDatasourceImported(result: DatasourceImportResult): void {
+    const display = result.original_name || result.filename;
+    this.addMediaExample(
+      result.filename,
+      display,
+      this.mediaType() || this.mediaTypeFromFilename(display),
+    );
+    this.view.set('main');
   }
 
   // --- Demo picker ---
@@ -818,42 +856,6 @@ export class NewDetectorModalComponent implements OnInit {
     this.demoFileBrowseLabel = '';
     this.demoTypedPath = '';
     this.demoTypedPathError.set('');
-  }
-
-  // --- Server example-media (typed path) ---
-
-  private resetServerFolderState(): void {
-    this.sfBrowseError.set('');
-    this.sfFileSelecting.set(false);
-    this.sfTypedPath = '';
-  }
-
-  private openServerFolderBrowser(): void {
-    this.resetServerFolderState();
-  }
-
-  /** Submit the typed absolute server path. Server validates and returns
-   *  the materialised filename for the example sort. */
-  submitSfTypedPath(): void {
-    const raw = (this.sfTypedPath || '').trim();
-    if (!raw) return;
-    this.sfFileSelecting.set(true);
-    this.sfBrowseError.set('');
-    this.datasetsUiApi.selectBrowsedFile('server_fs', raw).subscribe({
-      next: (res) => {
-        this.addMediaExample(
-          res.filename,
-          res.original_name || raw,
-          this.mediaType() || this.mediaTypeFromFilename(raw),
-        );
-        this.sfFileSelecting.set(false);
-        this.view.set('main');
-      },
-      error: (err) => {
-        this.sfBrowseError.set(err?.error?.message || 'Path not found on the server.');
-        this.sfFileSelecting.set(false);
-      },
-    });
   }
 
   // --- Local file upload (single file for the example) ---

--- a/frontend/src/app/services/datasource-importers-api.service.ts
+++ b/frontend/src/app/services/datasource-importers-api.service.ts
@@ -1,0 +1,70 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { FieldOptions, ImporterInfo, ImporterPickerTab } from '../models/api.models';
+
+/** Response of ``GET /api/datasource-importers``. */
+export interface DatasourceImportersResponse {
+  importers: ImporterInfo[];
+  tabs: ImporterPickerTab[];
+}
+
+/** Response of ``POST /api/datasource-import/<name>`` (same contract as
+ *  the example-media upload endpoint). */
+export interface DatasourceImportResult {
+  filename: string;
+  original_name: string;
+}
+
+/** API client for datasource importers: plugins that fetch a *single*
+ *  media item (from a URL, a server path, a third-party service) into
+ *  the server-side example-media directory.
+ *
+ *  Uses plain ``HttpClient`` because the run endpoint's body shape is
+ *  plugin-dependent (same convention as ``runImporter`` in
+ *  {@link DatasetsCrudApiService}). */
+@Injectable({ providedIn: 'root' })
+export class DatasourceImportersApiService {
+  private http = inject(HttpClient);
+
+  /** List available datasource importers plus the shared picker tabs. */
+  list(): Observable<DatasourceImportersResponse> {
+    return this.http.get<DatasourceImportersResponse>('/api/datasource-importers');
+  }
+
+  /** Run the named importer with the given form-field values.  When the
+   *  importer declares a ``file`` field, pass the picked ``File`` and its
+   *  field key so the request goes out as multipart. */
+  run(
+    importerName: string,
+    values: Record<string, string>,
+    file?: File,
+    fileFieldKey?: string,
+  ): Observable<DatasourceImportResult> {
+    const url = `/api/datasource-import/${encodeURIComponent(importerName)}`;
+    if (file && fileFieldKey) {
+      const formData = new FormData();
+      formData.append(fileFieldKey, file, file.name);
+      for (const [key, value] of Object.entries(values)) {
+        if (key !== fileFieldKey) {
+          formData.append(key, String(value ?? ''));
+        }
+      }
+      return this.http.post<DatasourceImportResult>(url, formData);
+    }
+    return this.http.post<DatasourceImportResult>(url, values);
+  }
+
+  /** Fetch the current options for a ``dynamic_options`` select field. */
+  getFieldOptions(
+    importerName: string,
+    fieldKey: string,
+    values: Record<string, string>,
+  ): Observable<{ options: FieldOptions[] }> {
+    return this.http.post<{ options: FieldOptions[] }>(
+      `/api/datasource-import/${encodeURIComponent(importerName)}/options`,
+      { field_key: fieldKey, values },
+    );
+  }
+}

--- a/tests/io/test_datasource_importer_routes.py
+++ b/tests/io/test_datasource_importer_routes.py
@@ -1,0 +1,181 @@
+"""API tests for the datasource-importer routes (list / run / field options)."""
+
+import io
+
+import pytest
+
+from vtscore.datasource_importers import get_datasource_importer
+from vtscore.datasource_importers.base import DataSourceImporter, FetchedMediaItem
+from vtscore.plugins import PluginField
+from vtsearch.routes.media.server import SERVER_MEDIA_DIR
+
+
+@pytest.fixture
+def example_media_cleanup():
+    """Track and remove files this test adds to ``example_media/``."""
+    before = set(SERVER_MEDIA_DIR.glob("*")) if SERVER_MEDIA_DIR.exists() else set()
+    yield
+    if SERVER_MEDIA_DIR.exists():
+        for f in set(SERVER_MEDIA_DIR.glob("*")) - before:
+            f.unlink(missing_ok=True)
+
+
+class TestDatasourceImportersList:
+    def test_lists_builtins_with_fields_and_tabs(self, client):
+        resp = client.get("/api/datasource-importers")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        by_name = {imp["name"]: imp for imp in data["importers"]}
+        assert by_name["server_file"]["category"] == "server"
+        assert [f["key"] for f in by_name["server_file"]["fields"]] == ["path"]
+        assert by_name["url_download"]["category"] == "services"
+        assert {t["id"] for t in data["tabs"]} >= {"services", "server", "demo"}
+
+    def test_hidden_plugins_filtered(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "vtsearch.settings.get_effective_hidden_plugins",
+            lambda: {"datasource_importers": {"url_download"}},
+        )
+        resp = client.get("/api/datasource-importers")
+        names = [imp["name"] for imp in resp.get_json()["importers"]]
+        assert "url_download" not in names
+        assert "server_file" in names
+
+
+class TestDatasourceImportRun:
+    def test_server_file_fetches_into_example_media(self, client, tmp_path, example_media_cleanup):
+        src = tmp_path / "bark.wav"
+        src.write_bytes(b"RIFFxxxxWAVE")
+
+        resp = client.post("/api/datasource-import/server_file", json={"path": str(src)})
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["original_name"] == "bark.wav"
+        assert data["filename"].endswith(".wav")
+
+        saved = SERVER_MEDIA_DIR / data["filename"]
+        assert saved.read_bytes() == b"RIFFxxxxWAVE"
+
+    def test_unknown_importer_404_lists_available(self, client):
+        resp = client.post("/api/datasource-import/nope", json={})
+        assert resp.status_code == 404
+        assert "server_file" in str(resp.get_json())
+
+    def test_missing_required_field_rejected(self, client):
+        resp = client.post("/api/datasource-import/server_file", json={})
+        assert resp.status_code in (400, 422)
+
+    def test_missing_file_maps_to_400(self, client, tmp_path):
+        resp = client.post(
+            "/api/datasource-import/server_file",
+            json={"path": str(tmp_path / "missing.wav")},
+        )
+        assert resp.status_code == 400
+        assert "File not found" in resp.get_json()["message"]
+
+    def test_url_ssrf_rejected(self, client):
+        resp = client.post(
+            "/api/datasource-import/url_download",
+            json={"url": "http://127.0.0.1/x.wav"},
+        )
+        assert resp.status_code == 400
+        assert "private/internal" in resp.get_json()["message"]
+
+    def test_upstream_error_maps_to_502(self, client, tmp_path, monkeypatch):
+        def _boom(field_values):
+            raise RuntimeError("upstream fell over")
+
+        monkeypatch.setattr(get_datasource_importer("server_file"), "fetch", _boom)
+        src = tmp_path / "a.wav"
+        src.write_bytes(b"x")
+        resp = client.post("/api/datasource-import/server_file", json={"path": str(src)})
+        assert resp.status_code == 502
+        assert "upstream fell over" in resp.get_json()["message"]
+
+    def test_file_field_importer_accepts_multipart(self, client, monkeypatch, example_media_cleanup):
+        class UploadThingDataSourceImporter(DataSourceImporter):
+            """Test-only importer with a file field."""
+
+            fields = [PluginField(key="file", label="File", field_type="file", required=True)]
+
+            def fetch(self, field_values):
+                upload = field_values["file"]
+                return FetchedMediaItem(data=upload.read(), filename=upload.filename)
+
+        fake = UploadThingDataSourceImporter()
+        monkeypatch.setattr(
+            "vtsearch.routes.media.datasource.get_datasource_importer",
+            lambda name: fake if name == "upload_thing" else None,
+        )
+
+        resp = client.post(
+            "/api/datasource-import/upload_thing",
+            data={"file": (io.BytesIO(b"\x01\x02"), "pick.png")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["original_name"] == "pick.png"
+        assert (SERVER_MEDIA_DIR / data["filename"]).read_bytes() == b"\x01\x02"
+
+
+class TestDatasourceImportFieldOptions:
+    def test_unknown_field_400(self, client):
+        resp = client.post(
+            "/api/datasource-import/server_file/options",
+            json={"field_key": "nope", "values": {}},
+        )
+        assert resp.status_code == 400
+
+    def test_non_dynamic_field_400(self, client):
+        resp = client.post(
+            "/api/datasource-import/server_file/options",
+            json={"field_key": "path", "values": {}},
+        )
+        assert resp.status_code == 400
+        assert "not dynamic" in resp.get_json()["message"]
+
+    def test_unknown_importer_404(self, client):
+        resp = client.post(
+            "/api/datasource-import/nope/options",
+            json={"field_key": "x", "values": {}},
+        )
+        assert resp.status_code == 404
+
+    def test_unimplemented_dynamic_options_501(self, client, monkeypatch):
+        imp = get_datasource_importer("server_file")
+        monkeypatch.setattr(imp.fields[0], "dynamic_options", True)
+        resp = client.post(
+            "/api/datasource-import/server_file/options",
+            json={"field_key": "path", "values": {}},
+        )
+        assert resp.status_code == 501
+
+    def test_options_normalised_to_value_label(self, client, monkeypatch):
+        imp = get_datasource_importer("server_file")
+        monkeypatch.setattr(imp.fields[0], "dynamic_options", True)
+        monkeypatch.setattr(imp, "get_field_options", lambda key, values: ["plain", ("id1", "Label 1")])
+        resp = client.post(
+            "/api/datasource-import/server_file/options",
+            json={"field_key": "path", "values": {}},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["options"] == [
+            {"value": "plain", "label": "plain"},
+            {"value": "id1", "label": "Label 1"},
+        ]
+
+    def test_plugin_error_maps_to_502(self, client, monkeypatch):
+        imp = get_datasource_importer("server_file")
+        monkeypatch.setattr(imp.fields[0], "dynamic_options", True)
+
+        def _boom(key, values):
+            raise RuntimeError("service auth failed")
+
+        monkeypatch.setattr(imp, "get_field_options", _boom)
+        resp = client.post(
+            "/api/datasource-import/server_file/options",
+            json={"field_key": "path", "values": {}},
+        )
+        assert resp.status_code == 502
+        assert "service auth failed" in resp.get_json()["message"]

--- a/tests_lib/io/test_datasource_importers.py
+++ b/tests_lib/io/test_datasource_importers.py
@@ -1,0 +1,119 @@
+"""Library-tier tests for the DataSource Importer plugin family."""
+
+import pytest
+
+from vtscore.datasource_importers import (
+    DataSourceImporter,
+    FetchedMediaItem,
+    get_datasource_importer,
+    list_datasource_importers,
+)
+from vtscore.plugins import PluginField
+
+
+class TestDatasourceImporterRegistry:
+    def test_builtins_discovered(self):
+        names = [imp.name for imp in list_datasource_importers()]
+        assert "server_file" in names
+        assert "url_download" in names
+
+    def test_get_by_name(self):
+        imp = get_datasource_importer("server_file")
+        assert imp is not None
+        assert imp.display_name == "Server File"
+
+    def test_get_unknown_returns_none(self):
+        assert get_datasource_importer("nope_not_real") is None
+
+
+class TestDatasourceImporterMetadata:
+    def test_to_dict_includes_category_and_fields(self):
+        imp = get_datasource_importer("url_download")
+        d = imp.to_dict()
+        assert d["category"] == "services"
+        assert d["name"] == "url_download"
+        assert [f["key"] for f in d["fields"]] == ["url"]
+        assert d["fields"][0]["field_type"] == "url"
+
+    def test_family_suffix_stripped_from_auto_name(self):
+        class MyShinyDataSourceImporter(DataSourceImporter):
+            """Fetches shiny things."""
+
+            fields = []
+
+            def fetch(self, field_values):  # pragma: no cover - never called
+                raise NotImplementedError
+
+        imp = MyShinyDataSourceImporter()
+        assert imp.name == "my_shiny"
+        assert imp.display_name == "My Shiny"
+        assert imp.description == "Fetches shiny things."
+
+    def test_family_base_keeps_stock_icon_and_no_derived_name(self):
+        # The abstract base must not have auto-derived metadata stamped on
+        # it (that would leak down the MRO to every concrete subclass).
+        assert "name" not in DataSourceImporter.__dict__
+        assert DataSourceImporter.icon == "\U0001f4e5"
+
+    def test_default_category_is_services(self):
+        class ThingDataSourceImporter(DataSourceImporter):
+            fields = []
+
+            def fetch(self, field_values):  # pragma: no cover - never called
+                raise NotImplementedError
+
+        assert ThingDataSourceImporter().category == "services"
+
+    def test_get_field_options_default_raises(self):
+        imp = get_datasource_importer("server_file")
+        with pytest.raises(NotImplementedError):
+            imp.get_field_options("path", {})
+
+
+class TestServerFileFetch:
+    def test_fetch_reads_bytes_and_filename(self, tmp_path):
+        f = tmp_path / "clip.wav"
+        f.write_bytes(b"RIFFxxxxWAVE")
+        item = get_datasource_importer("server_file").fetch({"path": str(f)})
+        assert isinstance(item, FetchedMediaItem)
+        assert item.data == b"RIFFxxxxWAVE"
+        assert item.filename == "clip.wav"
+
+    def test_fetch_missing_file_raises_value_error(self, tmp_path):
+        with pytest.raises(ValueError, match="File not found"):
+            get_datasource_importer("server_file").fetch({"path": str(tmp_path / "nope.wav")})
+
+    def test_fetch_empty_path_raises_value_error(self):
+        with pytest.raises(ValueError, match="required"):
+            get_datasource_importer("server_file").fetch({"path": "   "})
+
+
+class TestUrlDownloadFetch:
+    def test_private_url_rejected_without_network(self):
+        with pytest.raises(ValueError, match="private/internal"):
+            get_datasource_importer("url_download").fetch({"url": "http://127.0.0.1/x.wav"})
+
+    def test_empty_url_raises_value_error(self):
+        with pytest.raises(ValueError, match="required"):
+            get_datasource_importer("url_download").fetch({"url": ""})
+
+    def test_filename_derived_from_url_path(self):
+        from vtscore.datasource_importers.url_download import _filename_from_url
+
+        assert _filename_from_url("https://x.test/a/b/dog%20bark.wav?tok=1") == "dog bark.wav"
+        assert _filename_from_url("https://x.test/") == "download.bin"
+
+
+class TestDatasourceImporterFields:
+    def test_fields_are_plugin_fields(self):
+        for imp in list_datasource_importers():
+            for f in imp.fields:
+                assert isinstance(f, PluginField)
+
+    def test_inventory_includes_family(self):
+        from vtscore.plugins.inventory import gather_plugins
+
+        inventory = gather_plugins()
+        assert "datasource_importers" in inventory
+        names = [e.name for e in inventory["datasource_importers"]]
+        assert "server_file" in names and "url_download" in names

--- a/vtscore/datasource_importers/__init__.py
+++ b/vtscore/datasource_importers/__init__.py
@@ -1,0 +1,28 @@
+"""DataSource Importer plugin registry.
+
+DataSource importers fetch a *single media item* from some source (a URL,
+a server path, a third-party service) so users can supply exemplar media
+from the same kinds of places a dataset can come from.  See
+:mod:`vtscore.datasource_importers.base` for the plugin contract.
+
+Built-in importers live in sub-packages of this package; third-party
+importers register through the ``vtscore.datasource_importers`` entry-point
+group.  Each exposes a module-level ``DATASOURCE_IMPORTER`` instance.
+"""
+
+from vtscore.datasource_importers.base import DataSourceImporter, FetchedMediaItem
+from vtscore.plugins import make_plugin_registry
+
+get_datasource_importer, list_datasource_importers = make_plugin_registry(
+    package=__name__,
+    sentinel="DATASOURCE_IMPORTER",
+    label="datasource importer",
+    entry_point_group="vtscore.datasource_importers",
+)
+
+__all__ = [
+    "DataSourceImporter",
+    "FetchedMediaItem",
+    "get_datasource_importer",
+    "list_datasource_importers",
+]

--- a/vtscore/datasource_importers/base.py
+++ b/vtscore/datasource_importers/base.py
@@ -1,0 +1,104 @@
+"""Base class for DataSource Importers.
+
+A **DataSource Importer** fetches a *single media item* from some source —
+a URL, a file on the server, a third-party service — so the user can supply
+exemplar media (e.g. to seed a detector search) from the same kinds of
+places a whole dataset can come from.  It is the single-item sibling of
+:class:`~vtscore.datasets.importers.base.DatasetImporter`: where a dataset
+importer's ``run`` yields a whole collection, a datasource importer's
+:meth:`~DataSourceImporter.fetch` returns exactly one item's bytes.
+
+To add a new datasource importer, subclass :class:`DataSourceImporter`,
+declare its class attributes and :meth:`~DataSourceImporter.fetch`, then
+expose a module-level ``DATASOURCE_IMPORTER`` instance in a sub-package of
+``vtscore/datasource_importers/`` (or via the
+``vtscore.datasource_importers`` entry-point group)::
+
+    from vtscore.datasource_importers.base import DataSourceImporter, FetchedMediaItem
+    from vtscore.plugins import PluginField
+
+    class PastebinDataSourceImporter(DataSourceImporter):
+        \"\"\"Fetch a text snippet from a pastebin service.\"\"\"
+
+        category = "services"
+        fields = [
+            PluginField(key="paste_id", label="Paste id", field_type="text", required=True),
+        ]
+
+        def fetch(self, field_values):
+            data = ...  # download the snippet's bytes
+            return FetchedMediaItem(data=data, filename=f"{field_values['paste_id']}.txt")
+
+    DATASOURCE_IMPORTER = PastebinDataSourceImporter()
+
+The web app renders each importer's :attr:`~vtscore.plugins.PluginBase.fields`
+as a dynamic form (the same way the Add Dataset modal renders dataset
+importers) and calls ``POST /api/datasource-import/<name>``, which saves the
+fetched bytes into the server-side example-media directory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from vtscore.plugins import FieldOption, PluginBase
+
+
+@dataclass
+class FetchedMediaItem:
+    """One media item returned by :meth:`DataSourceImporter.fetch`.
+
+    Attributes
+    ----------
+    data:
+        The item's raw bytes.
+    filename:
+        A human-meaningful filename for the item.  Its suffix matters: it
+        drives media-type inference and how downstream code decodes the
+        saved file, so keep the source's real extension.
+    """
+
+    data: bytes
+    filename: str
+
+
+class DataSourceImporter(PluginBase):
+    """Abstract base class for single-media-item importers."""
+
+    #: Stock emoji for the family (inbox tray).  Concrete subclasses that
+    #: don't pick their own icon get a letter glyph instead (see
+    #: ``_autoderive_plugin_metadata``).
+    icon: str = "\U0001f4e5"
+
+    #: Picker tab this importer belongs to in the example-media picker.
+    #: Uses the same category ids as dataset importers ("services",
+    #: "server", "local", "demo") so both families share one tab bar.
+    category: str = "services"
+
+    def fetch(self, field_values: dict[str, Any]) -> FetchedMediaItem:
+        """Fetch one media item described by *field_values*.
+
+        *field_values* is the validated + normalized form-field dict (text
+        stripped, ``url`` / ``server_path`` fields security-checked; see
+        :mod:`vtscore.plugins.normalize`).  ``file``-typed fields arrive as
+        :class:`~vtscore.plugins.uploads.UploadedFile` objects.
+
+        Raises :class:`ValueError` for bad user input (missing file,
+        malformed reference); any other exception is reported as an
+        upstream/source failure.
+        """
+        raise NotImplementedError
+
+    def get_field_options(self, field_key: str, current_values: dict[str, Any]) -> list[FieldOption]:
+        """Return the current options for a ``dynamic_options`` select field.
+
+        Mirrors :meth:`vtscore.datasets.importers.base.ImporterBase.get_field_options`.
+        Only called for fields declared with ``dynamic_options=True``.
+        """
+        raise NotImplementedError(f"{self.name} does not provide dynamic options for field '{field_key}'")
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["category"] = self.category
+        return d

--- a/vtscore/datasource_importers/server_file/__init__.py
+++ b/vtscore/datasource_importers/server_file/__init__.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from vtscore.datasource_importers.base import DataSourceImporter, FetchedMediaItem
 from vtscore.plugins import PluginField
-from vtscore.security.path_validation import get_file_access_base_dir, validate_server_filepath
 
 
 class ServerFileDataSourceImporter(DataSourceImporter):
@@ -28,6 +27,10 @@ class ServerFileDataSourceImporter(DataSourceImporter):
     ]
 
     def fetch(self, field_values: dict[str, Any]) -> FetchedMediaItem:
+        # Call-time import so monkeypatched validators (e.g. the tests_lib
+        # tmp-path widening) are honoured, mirroring plugins/normalize.py.
+        from vtscore.security.path_validation import get_file_access_base_dir, validate_server_filepath
+
         raw = str(field_values.get("path") or "").strip()
         if not raw:
             raise ValueError("Media file path is required.")

--- a/vtscore/datasource_importers/server_file/__init__.py
+++ b/vtscore/datasource_importers/server_file/__init__.py
@@ -1,0 +1,43 @@
+"""Server-file datasource importer: pick one media file from the server's filesystem."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vtscore.datasource_importers.base import DataSourceImporter, FetchedMediaItem
+from vtscore.plugins import PluginField
+from vtscore.security.path_validation import get_file_access_base_dir, validate_server_filepath
+
+
+class ServerFileDataSourceImporter(DataSourceImporter):
+    """Use a media file already on the server's filesystem."""
+
+    name = "server_file"
+    display_name = "Server File"
+    icon = "\U0001f4c4"
+    category = "server"
+    fields = [
+        PluginField(
+            key="path",
+            label="Media file",
+            field_type="server_path",
+            description="Path to a media file on the server",
+            placeholder="/absolute/server/path/to/file",
+            required=True,
+        ),
+    ]
+
+    def fetch(self, field_values: dict[str, Any]) -> FetchedMediaItem:
+        raw = str(field_values.get("path") or "").strip()
+        if not raw:
+            raise ValueError("Media file path is required.")
+        # The HTTP/CLI ingress already confined the path via
+        # normalize_field_values; re-validate so direct library callers get
+        # the same per-user confinement (idempotent on validated paths).
+        path = validate_server_filepath(raw, base_dir=get_file_access_base_dir())
+        if not path.is_file():
+            raise ValueError(f"File not found: {raw}")
+        return FetchedMediaItem(data=path.read_bytes(), filename=path.name)
+
+
+DATASOURCE_IMPORTER = ServerFileDataSourceImporter()

--- a/vtscore/datasource_importers/url_download/__init__.py
+++ b/vtscore/datasource_importers/url_download/__init__.py
@@ -1,0 +1,59 @@
+"""URL datasource importer: download one media file from a public URL."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from vtscore.datasource_importers.base import DataSourceImporter, FetchedMediaItem
+from vtscore.plugins import PluginField
+from vtscore.security.url_validation import validate_url
+
+
+def _filename_from_url(url: str) -> str:
+    """Derive a filename (with its real extension) from *url*'s path."""
+    name = Path(unquote(urlparse(url).path)).name
+    return name or "download.bin"
+
+
+class UrlDownloadDataSourceImporter(DataSourceImporter):
+    """Download a media file from a public http(s) URL."""
+
+    name = "url_download"
+    display_name = "URL"
+    icon = "\U0001f310"
+    category = "services"
+    fields = [
+        PluginField(
+            key="url",
+            label="Media URL",
+            field_type="url",
+            description="Public http(s) URL of a single media file",
+            placeholder="https://example.com/sound.wav",
+            required=True,
+        ),
+    ]
+
+    def fetch(self, field_values: dict[str, Any]) -> FetchedMediaItem:
+        raw = str(field_values.get("url") or "").strip()
+        if not raw:
+            raise ValueError("Media URL is required.")
+        # Re-validate for direct library callers (idempotent after the
+        # ingress normalize pass); the downloader re-checks every redirect
+        # hop against the same SSRF guard.
+        url = validate_url(raw)
+
+        from vtscore.datasets.downloader import download_file_with_progress
+
+        with tempfile.TemporaryDirectory(prefix="vts_datasource_url_") as tmp_dir:
+            dest = Path(tmp_dir) / "download"
+            download_file_with_progress(url, dest, on_progress=lambda *a, **k: None)
+            data = dest.read_bytes()
+        if not data:
+            raise ValueError(f"The URL returned no data: {url}")
+        return FetchedMediaItem(data=data, filename=_filename_from_url(url))
+
+
+DATASOURCE_IMPORTER = UrlDownloadDataSourceImporter()

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -252,6 +252,7 @@ class PluginField:
 #: suffixes come first so ``HolderLabelsetExporter`` strips
 #: ``LabelsetExporter`` rather than just ``Exporter``.
 _PLUGIN_NAME_SUFFIXES: tuple[str, ...] = (
+    "DataSourceImporter",
     "DatasetImporter",
     "LabelsetExporter",
     "LabelImporter",
@@ -279,6 +280,7 @@ _PLUGIN_NAME_SUFFIXES: tuple[str, ...] = (
 _PLUGIN_FAMILY_BASE_NAMES: frozenset[str] = frozenset(
     {
         "ImporterBase",
+        "DataSourceImporter",
         "DatasetImporter",
         "LabelsetExporter",
         "LabelImporter",
@@ -301,6 +303,7 @@ _PLUGIN_FAMILY_BASE_NAMES: frozenset[str] = frozenset(
 _FAMILY_STOCK_ICONS: frozenset[str] = frozenset(
     {
         "\U0001f50c",  # dataset importer (plug)
+        "\U0001f4e5",  # datasource importer (inbox tray)
         "\U0001f4e4",  # labelset / settings exporter (outbox tray)
         "\U0001f3f7️",  # label importer (label)
         "\U0001f504",  # sync source (counterclockwise arrows)

--- a/vtscore/plugins/inventory.py
+++ b/vtscore/plugins/inventory.py
@@ -164,6 +164,12 @@ def _load_importers() -> Iterable[Any]:
     return list_importers()
 
 
+def _load_datasource_importers() -> Iterable[Any]:
+    from vtscore.datasource_importers import list_datasource_importers
+
+    return list_datasource_importers()
+
+
 def _load_exporters() -> Iterable[Any]:
     from vtscore.exporters import list_exporters
 
@@ -223,6 +229,7 @@ def _load_cleaners() -> Iterable[Any]:
 # :func:`vtsearch.shim.register_app_plugin_families`.
 _LIBRARY_FAMILIES: tuple[FamilyProvider, ...] = (
     FamilyProvider("importers", "Dataset importers", _load_importers),
+    FamilyProvider("datasource_importers", "Datasource importers", _load_datasource_importers),
     FamilyProvider("exporters", "Results exporters", _load_exporters),
     FamilyProvider("label_importers", "Label importers", _load_label_importers),
     FamilyProvider("labelset_sources", "Labelset sources", _load_labelset_sources),

--- a/vtsearch/routes/__init__.py
+++ b/vtsearch/routes/__init__.py
@@ -26,7 +26,7 @@ from vtsearch.routes.health import health_bp
 from vtsearch.routes.jobs import jobs_bp
 from vtsearch.routes.labels import exporters_bp, label_importers_bp, labels_bp
 from vtsearch.routes.main import main_bp
-from vtsearch.routes.media import embed_bp, media_server_bp, medias_bp
+from vtsearch.routes.media import datasource_importers_bp, embed_bp, media_server_bp, medias_bp
 from vtsearch.routes.processors import processors_crud_bp, processors_scoring_bp
 from vtsearch.routes.projection import projection_bp
 from vtsearch.routes.sessions import sessions_bp
@@ -49,6 +49,7 @@ __all__ = [
     "detectors_export_bp",
     "detectors_labels_bp",
     "detectors_registry_bp",
+    "datasource_importers_bp",
     "embed_bp",
     "eval_bp",
     "events_bp",

--- a/vtsearch/routes/media/__init__.py
+++ b/vtsearch/routes/media/__init__.py
@@ -1,7 +1,8 @@
 """Media-related route blueprints (listing, serving, embedding)."""
 
+from vtsearch.routes.media.datasource import datasource_importers_bp
 from vtsearch.routes.media.embed import embed_bp
 from vtsearch.routes.media.list import medias_bp
 from vtsearch.routes.media.server import media_server_bp
 
-__all__ = ["embed_bp", "media_server_bp", "medias_bp"]
+__all__ = ["datasource_importers_bp", "embed_bp", "media_server_bp", "medias_bp"]

--- a/vtsearch/routes/media/datasource.py
+++ b/vtsearch/routes/media/datasource.py
@@ -1,0 +1,171 @@
+"""Blueprint for datasource importers: fetch one media item into ``example_media/``.
+
+Datasource importers (:mod:`vtscore.datasource_importers`) are the
+single-item siblings of dataset importers: each fetches exactly one media
+item from some source (a URL, a server path, a third-party service).  The
+routes here power the dynamic example-media picker in the New Detector
+modal, mirroring the dataset-importer trio of list / run / field-options
+endpoints:
+
+* ``GET  /api/datasource-importers`` ->
+        :class:`~vtsearch.schemas.media.DatasourceImportersListResponseSchema`
+* ``POST /api/datasource-import/<importer_name>`` ->
+        :class:`~vtsearch.schemas.media.ServerMediaUploadResponseSchema`
+        (plugin-dependent body; per-plugin typed routes are registered for
+        the OpenAPI spec, file-field plugins use multipart)
+* ``POST /api/datasource-import/<importer_name>/options`` -> dynamic
+        select options, same contract as the dataset-importer variant.
+
+The run endpoint saves the fetched bytes into the per-user
+``example_media/`` directory and returns the same ``{filename,
+original_name}`` contract as ``POST /api/server-media-files/upload``, so a
+fetched item plugs into the existing ``{type: "media", value: <filename>}``
+detector-example model unchanged.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from flask_smorest import Blueprint, abort
+
+from vtscore.datasource_importers import get_datasource_importer, list_datasource_importers
+from vtsearch.routes._shared import (
+    _normalise_option,
+    get_plugin_or_404,
+    register_plugin_typed_routes,
+    validate_plugin_args,
+)
+from vtsearch.schemas.datasets import (
+    ImporterFieldOptionsRequestSchema,
+    ImporterFieldOptionsResponseSchema,
+)
+from vtsearch.schemas.media import (
+    DatasourceImportersListResponseSchema,
+    ServerMediaUploadResponseSchema,
+)
+from vtsearch.settings import filter_visible_plugins
+
+datasource_importers_bp = Blueprint(
+    "datasource_importers",
+    __name__,
+    description="Datasource importers: fetch a single media item into example_media/.",
+)
+
+
+@datasource_importers_bp.route("/api/datasource-importers")
+@datasource_importers_bp.response(200, DatasourceImportersListResponseSchema)
+def list_datasource_importers_route():
+    """List available datasource importers and the shared picker tabs.
+
+    ``tabs`` are the dataset-importer picker-tab declarations; datasource
+    importers use the same category ids so both families share one tab
+    bar in the example-media picker.
+    """
+    from vtscore.datasets.importers.tabs import list_picker_tabs
+
+    importers = [imp.to_dict() for imp in filter_visible_plugins("datasource_importers", list_datasource_importers())]
+    return {"importers": importers, "tabs": list_picker_tabs()}
+
+
+@datasource_importers_bp.route("/api/datasource-import/<importer_name>", methods=["POST"])
+def run_datasource_import(importer_name: str):
+    """Fetch one media item via the named datasource importer.
+
+    Plugin-dependent body shape (JSON, or multipart when the importer
+    declares ``file`` fields).  On success the fetched bytes are saved
+    into the per-user ``example_media/`` directory and the saved
+    ``filename`` (persistence key) plus the human-readable
+    ``original_name`` are returned, matching the upload endpoint's
+    contract.
+    """
+    from vtsearch.routes.media.server import _get_server_media_dir
+
+    importer, err = get_plugin_or_404(
+        get_datasource_importer, list_datasource_importers, importer_name, "datasource importer"
+    )
+    if err:
+        return err
+    assert importer is not None  # narrowed by err check
+
+    field_values = validate_plugin_args(importer)
+
+    try:
+        item = importer.fetch(field_values)
+    except ValueError as exc:
+        abort(400, message=str(exc))
+    except NotImplementedError as exc:
+        abort(501, message=str(exc) or f"{importer_name} does not implement fetch")
+    except Exception as exc:  # noqa: BLE001 (surface source/network errors verbatim)
+        abort(502, message=str(exc) or type(exc).__name__)
+
+    if not item.data:
+        abort(502, message=f"Datasource importer '{importer_name}' returned no data")
+
+    suffix = Path(item.filename).suffix or ".bin"
+    safe_name = f"{uuid.uuid4().hex}{suffix}"
+    media_dir = _get_server_media_dir()
+    media_dir.mkdir(parents=True, exist_ok=True)
+    (media_dir / safe_name).write_bytes(item.data)
+
+    return ServerMediaUploadResponseSchema().dump({"filename": safe_name, "original_name": item.filename}), 201
+
+
+@datasource_importers_bp.route("/api/datasource-import/<importer_name>/options", methods=["POST"])
+@datasource_importers_bp.arguments(ImporterFieldOptionsRequestSchema)
+@datasource_importers_bp.response(200, ImporterFieldOptionsResponseSchema)
+@datasource_importers_bp.alt_response(400, description="Unknown or non-dynamic field key.")
+@datasource_importers_bp.alt_response(404, description="Unknown datasource importer name.")
+@datasource_importers_bp.alt_response(500, description="get_field_options did not return a list.")
+@datasource_importers_bp.alt_response(501, description="Importer does not implement get_field_options.")
+@datasource_importers_bp.alt_response(502, description="Remote service backing dynamic options raised an error.")
+def datasource_importer_field_options(body: dict, importer_name: str):
+    """Return dropdown options for a dynamic-options field.
+
+    Same contract as ``POST /api/dataset/import/<name>/options``: the
+    importer's ``get_field_options(field_key, current_values)`` is called
+    with the supplied snapshot of current form values, and plugin errors
+    (network failure, auth error, etc.) surface as a 502 with the
+    original message so the frontend can display them inline.
+    """
+    importer, err = get_plugin_or_404(
+        get_datasource_importer, list_datasource_importers, importer_name, "datasource importer"
+    )
+    if err:
+        return err
+    assert importer is not None  # narrowed by err check
+
+    field_key = body["field_key"].strip()
+    values = body.get("values") or {}
+
+    field = next((f for f in importer.fields if f.key == field_key), None)
+    if field is None:
+        abort(400, message=f"Unknown field: {field_key!r}")
+    if not getattr(field, "dynamic_options", False):
+        abort(400, message=f"Field {field_key!r} is not dynamic")
+
+    try:
+        options = importer.get_field_options(field_key, values)
+    except NotImplementedError as exc:
+        abort(501, message=str(exc) or "Importer does not implement get_field_options")
+    except Exception as exc:  # noqa: BLE001 (surface remote-service errors verbatim)
+        abort(502, message=str(exc) or type(exc).__name__)
+
+    if not isinstance(options, list):
+        abort(500, message="get_field_options must return a list")
+    return {"options": [_normalise_option(o) for o in options]}
+
+
+# Per-plugin typed routes for /api/datasource-import/<name>, so each known
+# importer gets a static URL whose body schema is described in
+# /api/openapi.json with real per-field types.  Unknown names fall through
+# to the parameterized route above; plugins with file fields stay on the
+# multipart fallback.
+register_plugin_typed_routes(
+    datasource_importers_bp,
+    list_plugins=list_datasource_importers,
+    path_template="/api/datasource-import/{plugin_name}",
+    endpoint_prefix="datasource_import",
+    delegate=run_datasource_import,
+)

--- a/vtsearch/schemas/media.py
+++ b/vtsearch/schemas/media.py
@@ -47,6 +47,8 @@ from __future__ import annotations
 
 from marshmallow import Schema, fields, validate
 
+from vtsearch.schemas.datasets import ImporterPickerTabSchema
+
 
 class OriginSchema(Schema):
     """A serialised :class:`~vtscore.datasets.origin.Origin`.
@@ -466,7 +468,48 @@ class ExampleSortResponseSchema(Schema):
     threshold = fields.Float(required=True)
 
 
+class DatasourceImporterEntrySchema(Schema):
+    """One entry in ``GET /api/datasource-importers``.
+
+    Mirrors :meth:`vtscore.datasource_importers.base.DataSourceImporter.to_dict`;
+    the ``fields`` array's inner shape mirrors
+    :meth:`vtscore.plugins.PluginField.to_dict` but is declared as
+    ``fields.Dict()`` to avoid duplicating the source of truth across
+    schema and dataclass (same convention as the other plugin-listing
+    schemas).
+    """
+
+    name = fields.String(required=True)
+    display_name = fields.String(required=True)
+    description = fields.String(required=True)
+    icon = fields.String(required=True)
+    ui_mode = fields.String(required=True)
+    hidden_from_picker = fields.Boolean(required=True)
+    category = fields.String(required=True)
+    # Renamed to avoid shadowing :attr:`marshmallow.Schema.fields`;
+    # ``data_key`` / ``attribute`` keep the wire name as ``"fields"``.
+    plugin_fields = fields.List(
+        fields.Dict(),
+        required=True,
+        data_key="fields",
+        attribute="fields",
+    )
+
+
+class DatasourceImportersListResponseSchema(Schema):
+    """Response for ``GET /api/datasource-importers``.
+
+    ``tabs`` reuses the dataset-importer picker-tab declarations so both
+    families share one category tab bar in the example-media picker.
+    """
+
+    importers = fields.List(fields.Nested(DatasourceImporterEntrySchema), required=True)
+    tabs = fields.List(fields.Nested(ImporterPickerTabSchema), required=True)
+
+
 __all__ = [
+    "DatasourceImporterEntrySchema",
+    "DatasourceImportersListResponseSchema",
     "ExampleSortByIdRequestSchema",
     "ExampleSortOriginRequestSchema",
     "ExampleSortResponseSchema",


### PR DESCRIPTION
Closes #2767

Like "Add Dataset" asks which dataset importer to use and renders a form from its declared fields, "Add MediaItem" (the New Detector modal's example-media picker) now asks which **datasource importer** to use and renders a dynamic form for it — so exemplar seeds can come from any source, not just file upload.

## New plugin family: `DataSourceImporter`

- `vtscore/datasource_importers/` — the single-item sibling of `DatasetImporter`: declares `fields` + `category` and implements `fetch(field_values) -> FetchedMediaItem(data, filename)`. Registered via the standard `make_plugin_registry` (sentinel `DATASOURCE_IMPORTER`, entry-point group `vtscore.datasource_importers`), with the usual auto-derived metadata, plugin inventory entry, and admin `hidden_plugins` support.
- Built-ins:
  - **`server_file`** — pick a file on the server via a `server_path` field (renders the inline file browser; previously the server path could only be typed blind).
  - **`url_download`** — new capability: download one media file from a public URL, reusing the SSRF-guarded, redirect-revalidating downloader.
- Field values go through the shared validation/normalization pass (`validate_url`, `validate_server_filepath`, template vars), same as every other plugin family.

## API

- `GET /api/datasource-importers` — importers (with fields + category) plus the shared picker-tab declarations.
- `POST /api/datasource-import/<name>` — validates the plugin-dependent body (multipart when the importer declares `file` fields), runs `fetch()`, saves the bytes into the per-user `example_media/` directory, and returns the upload endpoint's `{filename, original_name}` contract — so fetched items plug into the existing `{type: "media", value: <filename>}` detector-example model unchanged. Per-plugin typed routes are registered for the OpenAPI spec.
- `POST /api/datasource-import/<name>/options` — dynamic select options, same contract as the dataset-importer variant.

## Frontend

- New `vt-datasource-import-form`: renders any datasource importer's fields (text/url/password/email/number/select/checkbox/file/`server_path` with the file browser), with full dynamic-options support (`dynamic_options`, `depends_on`, `allow_free_text`), and emits the fetched item.
- The New Detector media picker now merges datasource importers into its category tab bar alongside the dedicated demo/local browse views. Selecting one shows its form; third-party datasource importers appear automatically. The old typed-path-only "server folder" view is replaced by the `server_file` form (browse + type), and its dead state/handlers are removed.

## Tests & docs

- `tests_lib/io/test_datasource_importers.py` — registry discovery, auto-metadata, `server_file`/`url_download` fetch behavior (no network).
- `tests/io/test_datasource_importer_routes.py` — list/run/options endpoints: success path into `example_media/`, 404/400/422/501/502 mappings, SSRF rejection, multipart file-field importers, hidden-plugin filtering.
- Vitest specs for the new form component and the picker integration.
- `docs/EXTENDING-plugins.md` gains an "Adding a Datasource Importer" section; OpenAPI snapshot regenerated.
- Full `./run-tests.sh` passes (7192 tests + lint/typecheck/frontend gates). No doc screenshot frames the changed picker view, so no reshoot queue entry.

Follow-ups filed: #2771 (offer datasource importers in the re-sort prompt modal), #2772 (delete the orphaned examples-editor-modal), #2774 (give exemplar media a real origin instead of the `example_media` sentinel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tv7yTidZyo3NYMz4vPEp6p