### PR TITLE
Add select-all checkbox for export modal column toggles

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -24,7 +24,23 @@
 
   <!-- Column Selection -->
   <div class="export-section">
-    <h3 title="Choose which data fields to include in the exported output">Columns</h3>
+    <div class="export-section-header">
+      <h3 title="Choose which data fields to include in the exported output">Columns</h3>
+      <button
+        type="button"
+        class="column-select-all"
+        role="checkbox"
+        [attr.aria-checked]="columnSelectionState === 'all' ? 'true' : columnSelectionState === 'some' ? 'mixed' : 'false'"
+        [attr.aria-label]="columnSelectionState === 'all' ? 'Deselect all columns' : 'Select all columns'"
+        [title]="columnSelectionState === 'all' ? 'Deselect all columns' : 'Select all columns'"
+        (click)="toggleAllColumns()">
+        @switch (columnSelectionState) {
+          @case ('all') { <vt-icon type="checkbox-checked" [size]="15"></vt-icon> }
+          @case ('some') { <vt-icon type="checkbox-some" [size]="15"></vt-icon> }
+          @default { <vt-icon type="checkbox-blank" [size]="15"></vt-icon> }
+        }
+      </button>
+    </div>
     <div class="column-checkboxes">
       @for (col of columns; track col.key) {
         <label class="column-toggle">

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.scss
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.scss
@@ -17,6 +17,37 @@
 
 // --- Column checkboxes ---
 
+.export-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+
+  h3 { margin-bottom: 0; }
+}
+
+// Tri-state master checkbox (empty / dash / check for none / partial / all),
+// mirroring the dashboard/bin-popup/browse-selection-panel select-all controls.
+.column-select-all {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--space-2xs);
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--transition-base), background var(--transition-base);
+
+  &:hover {
+    background: var(--btn-icon-hover-bg);
+    color: var(--text-primary);
+  }
+}
+
 .column-checkboxes {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -88,6 +88,25 @@ describe('ExportModalComponent', () => {
     expect(extraCol?.label).toBe('Extra'); // unknown keys fall back to title-casing
   });
 
+  it('reports the tri-state column selection and toggles all on/off', async () => {
+    await flushInit();
+    expect(component.columnSelectionState).toBe('all'); // every column starts enabled
+
+    component.columns[0].enabled = false;
+    expect(component.columnSelectionState).toBe('some');
+
+    component.toggleAllColumns(); // 'some' -> select all
+    expect(component.columnSelectionState).toBe('all');
+    expect(component.columns.every((c) => c.enabled)).toBe(true);
+
+    component.toggleAllColumns(); // 'all' -> deselect all
+    expect(component.columnSelectionState).toBe('none');
+    expect(component.columns.every((c) => !c.enabled)).toBe(true);
+
+    component.toggleAllColumns(); // 'none' -> select all
+    expect(component.columnSelectionState).toBe('all');
+  });
+
   it('slices the fetched labels by the active category', async () => {
     await flushInit();
     component.labelFilter = 'good';

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -252,6 +252,20 @@ export class ExportModalComponent implements OnInit {
     return this.columns.filter((c) => c.enabled);
   }
 
+  /** Tri-state of the column select-all control: how many columns are enabled. */
+  get columnSelectionState(): 'none' | 'some' | 'all' {
+    const enabled = this.enabledColumns.length;
+    if (enabled === 0) return 'none';
+    if (enabled >= this.columns.length) return 'all';
+    return 'some';
+  }
+
+  /** From [x] (all enabled), clear every column; from [ ]/[-], enable them all. */
+  toggleAllColumns(): void {
+    const enable = this.columnSelectionState !== 'all';
+    for (const col of this.columns) col.enabled = enable;
+  }
+
   // --- Preview column resize ---
   //
   // The preview table's columns default to auto layout (`width: 100%`, each


### PR DESCRIPTION
## Summary
- Adds a tri-state select-all checkbox button next to the "Columns" heading in the export modal, so all metadata columns can be toggled on or off in one click instead of clicking each checkbox individually.
- Mirrors the existing tri-state checkbox widget used elsewhere (dashboard header checkbox, bin-popup, browse-selection-panel): empty/dash/check icons (`checkbox-blank`/`checkbox-some`/`checkbox-checked`) with matching `role="checkbox"` + `aria-checked` semantics.
- `columnSelectionState` getter reports `none`/`some`/`all` based on how many columns are enabled; `toggleAllColumns()` flips all columns on when not fully selected, off when fully selected.

Closes #2769

## Test plan
- [x] `cd frontend && npm run test:ci` — all 1890 tests pass, including new coverage for `columnSelectionState`/`toggleAllColumns`
- [x] `./run-tests.sh frontend` — ruff, codespell, deptry, pip-audit, pyright, OpenAPI snapshot check, frontend build, frontend audit, and Vitest all pass

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fu51xPhoG9ctVGESt72tKd)_