### PR TITLE
Export modal: keep origin columns out of clipboard copies

### DIFF
--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -107,6 +107,23 @@ describe('ExportModalComponent', () => {
     expect(component.columnSelectionState).toBe('all');
   });
 
+  it('copies exactly the checked columns, without the always-export keys', async () => {
+    await flushInit();
+    for (const col of component.columns) col.enabled = col.key === 'md5';
+
+    // The clipboard flattens rows client-side, so `origin` could only ever
+    // reach the paste as `[object Object]`; it stays out entirely (issue #2770).
+    expect(component.clipboardColumns.map((c) => c.key)).toEqual(['md5']);
+    expect(component.clipboardRows[0]).toEqual({ md5: 'a' });
+
+    // Plugin exports still get them appended - there the exporter receives the
+    // real dict and serializes it as JSON.
+    component.startExporter(mockExporters[0] as never);
+    const req = httpMock.expectOne('/api/exporters/export');
+    expect(req.request.body.results.selected_columns).toEqual(['md5', 'origin', 'origin_name']);
+    req.flush({ message: 'ok' });
+  });
+
   it('slices the fetched labels by the active category', async () => {
     await flushInit();
     component.labelFilter = 'good';

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -149,7 +149,19 @@ export class ExportModalComponent implements OnInit {
     { key: 'category', label: 'Category' },
   ];
 
-  /** Columns excluded from checkboxes/preview but always appended to exports. */
+  /**
+   * Columns excluded from checkboxes/preview but always appended to *plugin*
+   * exports (CSV/JSON files, webhooks), where they make the payload
+   * re-importable: the exporter receives the whole `LabeledElement`s, so
+   * `origin` reaches the file as a real dict and is JSON-serialized on the way
+   * out (and JSON-parsed back on re-import).
+   *
+   * They are deliberately **not** appended to the clipboard, which flattens
+   * rows to strings client-side: `origin` would stringify to `[object Object]`,
+   * which no importer can parse back. Two unselectable junk columns that buy
+   * zero matching power is a strictly worse paste, so the clipboard honours the
+   * user's column selection exactly (issue #2770).
+   */
   private static readonly ALWAYS_EXPORT_KEYS = ['origin', 'origin_name'];
 
   constructor() {
@@ -374,7 +386,9 @@ export class ExportModalComponent implements OnInit {
     return String((entry as unknown as Record<string, unknown>)[col.key] ?? '');
   }
 
-  /** Columns to export: user-selected columns plus always-export columns appended at the end. */
+  /** Columns sent to a plugin exporter: user-selected columns plus the
+   *  always-export columns appended at the end. Clipboard copies use
+   *  {@link enabledColumns} instead; see {@link ALWAYS_EXPORT_KEYS}. */
   private get exportColumns(): ColumnDef[] {
     const cols = [...this.enabledColumns];
     for (const key of ExportModalComponent.ALWAYS_EXPORT_KEYS) {
@@ -383,14 +397,15 @@ export class ExportModalComponent implements OnInit {
     return cols;
   }
 
-  /** Columns passed to the shared clipboard control (table mode). */
+  /** Columns passed to the shared clipboard control (table mode): exactly the
+   *  ones the user checked, matching what the preview table shows. */
   get clipboardColumns(): ClipboardColumn[] {
-    return this.exportColumns.map((c) => ({ key: c.key, label: c.label }));
+    return this.enabledColumns.map((c) => ({ key: c.key, label: c.label }));
   }
 
   /** Labels flattened to `{ columnKey: value }` rows for the clipboard control. */
   get clipboardRows(): Record<string, string>[] {
-    const cols = this.exportColumns;
+    const cols = this.enabledColumns;
     return this.filteredLabels.map((entry) => {
       const row: Record<string, string> = {};
       for (const c of cols) row[c.key] = this.getCellValue(entry, c);


### PR DESCRIPTION
Refs #2770

## The problem

Copying from the export modal appended two columns the user never selected and cannot deselect — `origin` and `origin_name` — and the `origin` cell always pasted as `[object Object]`.

The clipboard control flattens rows to strings client-side (`getCellValue` → `String(entry['origin'])`), so a dict-valued column can only ever reach the paste as `[object Object]`. No label importer can parse that back (`vtscore/labels/importers/server_csv_file` JSON-parses the origin cell and silently drops it on failure), so the two extra columns bought exactly zero matching power while making the paste unusable as-is.

## The change

`clipboardColumns` / `clipboardRows` now use `enabledColumns` instead of `exportColumns`, so a copy contains exactly the checked columns — matching what the preview table already showed.

**Plugin exports are unchanged.** `exportColumns` (with the always-export keys) still feeds `selected_columns` on the `/api/exporters/export` POST. Those exporters receive the whole `LabeledElement`s, so `origin` arrives as a real dict and `server_csv_file` JSON-serializes it (`json.dumps(val, sort_keys=True)`) into a column the CSV label importer parses back. The lossless round-trip that motivated `ALWAYS_EXPORT_KEYS` in the first place still holds on every path where it actually worked.

The `ALWAYS_EXPORT_KEYS` doc comment now spells out that split so the next reader doesn't "restore" the clipboard behaviour.

## Testing

- New spec case in `export-modal.component.spec.ts` pins both halves: with only `md5` checked, `clipboardColumns`/`clipboardRows` carry `md5` alone, while the export POST still sends `selected_columns: ['md5', 'origin', 'origin_name']`.
- `./run-tests.sh` — `ALL 7276 TESTS PASSED (1 skipped)`, frontend gate included (build + audit + 1890 Vitest tests).

## Not addressed here

Scoped deliberately to the clipboard. Two related findings from the investigation are left alone:

- **File exports still force `origin` on.** `server_csv_file` strips it out of `selected_columns` and re-appends it as the last column regardless of what the user checked, so the "unselectable extra column" complaint remains true for CSV files. That one at least works, hence leaving it.
- **Always-emitting `origin` can *reduce* cross-dataset matches.** `resolve_media_ids` only tries the basename fallback when an entry has neither an origin key nor an md5 (`vtscore/state/media_lookup.py:185-194`, deliberate — basename-matching content that provably isn't in this dataset would mislabel collisions). So against a *different* dataset where neither the origin key nor the md5 hits, a CSV carrying `origin` matches strictly fewer items than a name-only one. That tradeoff isn't documented in the export docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGev3WrH1srYiW7qy8YZDH)_