### PR TITLE
Carry real origins on exemplar media instead of the example_media sentinel

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -816,6 +816,21 @@ input (surfaced as a 400); any other exception is reported as an upstream
 failure (502). The returned `FetchedMediaItem.filename` should keep the
 source's real extension — it drives media-type inference downstream.
 
+When the fetched item has a durable external identity (a URL, a server
+path, a service item id), also set `FetchedMediaItem.origin` to a
+`{"importer": <name>, "params": {...}}` dict. The origin is stored on the
+detector example and stamped onto the seeded media, so the item can be
+re-fetched on demand (cross-dataset label resolution, re-deriving a
+deleted `example_media/` cache file) instead of the byte snapshot being
+the only record. A param named `path` resolves with no extra code (the
+resolver's generic path fallback); any other param shape needs a matching
+`MediaSource` factory registered under the importer's name — see
+`vtscore/datasets/sources/url_download.py` for the pattern (it re-runs
+`validate_url` at fetch time, since the stored URL was originally
+user-supplied). Leave `origin` unset when the bytes have no re-derivable
+source (uploads): the example then keeps the `example_media` sentinel
+origin, by design.
+
 Dynamic select options work exactly as for dataset importers: declare a
 field with `dynamic_options=True` and implement
 `get_field_options(field_key, current_values)`
@@ -828,9 +843,10 @@ field with `dynamic_options=True` and implement
 - `POST /api/datasource-import/<name>` validates the body against the
   importer's fields, calls `fetch()`, saves the returned bytes into the
   per-user `example_media/` directory, and returns `{filename,
-  original_name}` — the same contract as the example-media upload
-  endpoint, so the fetched item plugs into the detector-example model
-  (`{type: "media", value: <filename>}`) unchanged.
+  original_name, origin}` — the example-media upload contract plus the
+  item's durable origin (`null` when the importer reports none), so the
+  fetched item plugs into the detector-example model
+  (`{type: "media", value: <filename>, origin: {...}}`).
 - `POST /api/datasource-import/<name>/options` serves dynamic field
   options.
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -11210,7 +11210,7 @@
     },
     "/api/datasource-import/server_file": {
       "post": {
-        "description": "Plugin-dependent body shape (JSON, or multipart when the importer\ndeclares ``file`` fields).  On success the fetched bytes are saved\ninto the per-user ``example_media/`` directory and the saved\n``filename`` (persistence key) plus the human-readable\n``original_name`` are returned, matching the upload endpoint's\ncontract.",
+        "description": "Plugin-dependent body shape (JSON, or multipart when the importer\ndeclares ``file`` fields).  On success the fetched bytes are saved\ninto the per-user ``example_media/`` directory and the saved\n``filename`` (persistence key) plus the human-readable\n``original_name`` are returned, matching the upload endpoint's\ncontract, along with the item's durable ``origin`` when the importer\nreports one (``null`` otherwise).",
         "operationId": "datasource_import__server_file",
         "requestBody": {
           "content": {
@@ -11238,7 +11238,7 @@
     },
     "/api/datasource-import/url_download": {
       "post": {
-        "description": "Plugin-dependent body shape (JSON, or multipart when the importer\ndeclares ``file`` fields).  On success the fetched bytes are saved\ninto the per-user ``example_media/`` directory and the saved\n``filename`` (persistence key) plus the human-readable\n``original_name`` are returned, matching the upload endpoint's\ncontract.",
+        "description": "Plugin-dependent body shape (JSON, or multipart when the importer\ndeclares ``file`` fields).  On success the fetched bytes are saved\ninto the per-user ``example_media/`` directory and the saved\n``filename`` (persistence key) plus the human-readable\n``original_name`` are returned, matching the upload endpoint's\ncontract, along with the item's durable ``origin`` when the importer\nreports one (``null`` otherwise).",
         "operationId": "datasource_import__url_download",
         "requestBody": {
           "content": {
@@ -11277,7 +11277,7 @@
         }
       ],
       "post": {
-        "description": "Plugin-dependent body shape (JSON, or multipart when the importer\ndeclares ``file`` fields).  On success the fetched bytes are saved\ninto the per-user ``example_media/`` directory and the saved\n``filename`` (persistence key) plus the human-readable\n``original_name`` are returned, matching the upload endpoint's\ncontract.",
+        "description": "Plugin-dependent body shape (JSON, or multipart when the importer\ndeclares ``file`` fields).  On success the fetched bytes are saved\ninto the per-user ``example_media/`` directory and the saved\n``filename`` (persistence key) plus the human-readable\n``original_name`` are returned, matching the upload endpoint's\ncontract, along with the item's durable ``origin`` when the importer\nreports one (``null`` otherwise).",
         "operationId": "run_datasource_import",
         "responses": {
           "default": {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -395,7 +395,28 @@ describe('NewDetectorModalComponent', () => {
     expect(component.mediaExamples()[0].display).toBe('bark.wav');
     // Media type is inferred from the original filename's extension.
     expect(component.mediaExamples()[0].mediaType).toBe('audio');
+    // No origin reported → none stored (the example seeds via the sentinel).
+    expect(component.mediaExamples()[0].origin).toBeNull();
     expect(component.view()).toBe('main');
+  });
+
+  // --- Durable example origins (issue #2774) ---
+
+  it('keeps the datasource item origin and sends it with the examples payload', () => {
+    const origin = { importer: 'url_download', params: { url: 'https://x.test/bark.wav' } };
+    component.view.set('media-picker');
+    component.mediaType.set('audio');
+
+    component.onDatasourceImported({ filename: 'abc123.wav', original_name: 'bark.wav', origin });
+
+    expect(component.mediaExamples()[0].origin).toEqual(origin);
+
+    component.name.set('Barks');
+    component.submit();
+
+    const req = httpMock.expectOne('/api/detectors/registry');
+    expect(req.request.body.examples).toEqual([{ type: 'media', value: 'abc123.wav', origin }]);
+    req.flush({ ok: true, detector: { id: '789', name: 'Barks' } });
   });
 
   // --- Trained tab: label-importer plugin field parity (issue #2597) ---

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -60,6 +60,10 @@ interface MediaExampleItem {
   mediaType: string;
   /** True once the thumbnail endpoint failed; falls back to the icon. */
   thumbFailed: boolean;
+  /** Durable origin dict reported by a datasource importer (URL, server
+   *  path); sent with the example so the seeded media points back at its
+   *  real source. Absent for uploads and other non-re-derivable picks. */
+  origin?: Record<string, unknown> | null;
 }
 
 @Component({
@@ -334,10 +338,15 @@ export class NewDetectorModalComponent implements OnInit {
   /** Append a picked media example to the stack. Clears any pending text
    *  (text and media examples are mutually exclusive), switches to the
    *  media tab, and auto-fills the name from the first example. */
-  private addMediaExample(value: string, display: string, mediaType: string): void {
+  private addMediaExample(
+    value: string,
+    display: string,
+    mediaType: string,
+    origin?: Record<string, unknown> | null,
+  ): void {
     this.mediaExamples.update((list) => [
       ...list,
-      { value, display, mediaType, thumbFailed: false },
+      { value, display, mediaType, thumbFailed: false, origin: origin ?? null },
     ]);
     this.pendingText.set('');
     this.exampleTab.set('media');
@@ -711,13 +720,15 @@ export class NewDetectorModalComponent implements OnInit {
   }
 
   /** A datasource importer fetched an item into ``example_media/``: add
-   *  it to the example stack and land back on the main form. */
+   *  it to the example stack (carrying its durable origin, if any) and
+   *  land back on the main form. */
   onDatasourceImported(result: DatasourceImportResult): void {
     const display = result.original_name || result.filename;
     this.addMediaExample(
       result.filename,
       display,
       this.mediaType() || this.mediaTypeFromFilename(display),
+      result.origin,
     );
     this.view.set('main');
   }
@@ -1202,7 +1213,11 @@ export class NewDetectorModalComponent implements OnInit {
     const mediaExample = mediaExamples[0]?.value || '';
     const examplesPayload = textQuery
       ? [{ type: 'text', value: textQuery }]
-      : mediaExamples.map((ex) => ({ type: 'media', value: ex.value }));
+      : mediaExamples.map((ex) =>
+          // The origin key is additive: examples without one keep the
+          // legacy {type, value} shape and seed via the sentinel path.
+          ex.origin ? { type: 'media', value: ex.value, origin: ex.origin } : { type: 'media', value: ex.value },
+        );
 
     this.detectorsRegistryApi
       .registerDetector({

--- a/frontend/src/app/components/datasource-import-form/datasource-import-form.component.spec.ts
+++ b/frontend/src/app/components/datasource-import-form/datasource-import-form.component.spec.ts
@@ -108,11 +108,14 @@ describe('DatasourceImportFormComponent', () => {
     const req = httpMock.expectOne('/api/datasource-import/url_download');
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({ url: 'https://example.com/a.wav' });
-    req.flush({ filename: 'abc.wav', original_name: 'a.wav' });
+    const origin = { importer: 'url_download', params: { url: 'https://example.com/a.wav' } };
+    req.flush({ filename: 'abc.wav', original_name: 'a.wav', origin });
 
+    // The durable origin passes through untouched (issue #2774).
     expect(component.imported.emit).toHaveBeenCalledWith({
       filename: 'abc.wav',
       original_name: 'a.wav',
+      origin,
     });
     expect(component.submitting()).toBe(false);
   });

--- a/frontend/src/app/services/datasource-importers-api.service.ts
+++ b/frontend/src/app/services/datasource-importers-api.service.ts
@@ -10,11 +10,16 @@ export interface DatasourceImportersResponse {
   tabs: ImporterPickerTab[];
 }
 
-/** Response of ``POST /api/datasource-import/<name>`` (same contract as
- *  the example-media upload endpoint). */
+/** Response of ``POST /api/datasource-import/<name>`` (the example-media
+ *  upload contract plus the fetched item's durable origin). */
 export interface DatasourceImportResult {
   filename: string;
   original_name: string;
+  /** Durable origin dict (`{importer, params}`) when the importer's items
+   *  have a re-fetchable identity (a URL, a server path); persisted on the
+   *  detector example so the seed survives the example_media/ cache file.
+   *  `null` for items with no re-derivable source. */
+  origin?: Record<string, unknown> | null;
 }
 
 /** API client for datasource importers: plugins that fetch a *single*

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1959,6 +1959,170 @@ class TestSeedVotesFromExamples:
         assert example_labels[0]["label"] == "good"
         assert example_labels[0]["origin"]["params"]["filename"] == fname
 
+    # ---- Durable example origins (issue #2774) ----
+
+    def test_seed_with_origin_stamps_real_origin(self, client, tmp_path):
+        """An example carrying a datasource origin seeds a media that points
+        back at its real source instead of the example_media sentinel."""
+        from vtsearch.state import good_votes, medias
+
+        src = tmp_path / "novel_src.wav"
+        src.write_bytes(b"origin-novel-bytes")
+        fname = self._create_example_file(src.read_bytes(), "origin_novel.wav")
+        origin = {"importer": "server_file", "params": {"path": str(src)}}
+
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname, "origin": origin}]},
+        )
+        assert res.status_code == 200
+        assert res.get_json()["seeded"] == 1
+
+        new_id = max(medias.keys())
+        assert new_id in good_votes
+        new_media = medias[new_id]
+        assert new_media["origin"] == origin
+        assert new_media["origin_name"] == str(src)
+        # The example_media filename stays the local byte-cache key.
+        assert new_media["filename"] == fname
+
+    def test_seed_stamped_origin_resolves_without_cache_file(self, client, tmp_path):
+        """The stamped origin must resolve after the example_media/ file is gone."""
+        from vtscore.config import DATA_DIR
+        from vtscore.detectors.resolver import resolve_file_from_origin
+        from vtsearch.state import medias
+
+        src = tmp_path / "resolvable.wav"
+        src.write_bytes(b"resolvable-bytes")
+        fname = self._create_example_file(src.read_bytes(), "resolvable_cache.wav")
+        origin = {"importer": "server_file", "params": {"path": str(src)}}
+
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname, "origin": origin}]},
+        )
+        assert res.get_json()["seeded"] == 1
+
+        (DATA_DIR / "example_media" / fname).unlink()
+        new_media = medias[max(medias.keys())]
+        resolved = resolve_file_from_origin(new_media["origin"], new_media["origin_name"], new_media["filename"])
+        assert resolved == src
+
+    def test_seed_rederives_missing_cache_file_from_origin(self, client, tmp_path):
+        """With the cache file gone entirely, seeding re-fetches from the origin."""
+        from vtscore.utils.hashing import content_md5
+        from vtsearch.state import good_votes, medias
+
+        src = tmp_path / "rederive.wav"
+        src.write_bytes(b"rederive-bytes")
+        fname = "never_cached.wav"  # deliberately not written to example_media/
+        origin = {"importer": "server_file", "params": {"path": str(src)}}
+
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname, "origin": origin}]},
+        )
+        assert res.status_code == 200
+        assert res.get_json()["seeded"] == 1
+
+        new_id = max(medias.keys())
+        assert new_id in good_votes
+        new_media = medias[new_id]
+        assert new_media["md5"] == content_md5(b"rederive-bytes")
+        assert new_media["origin"] == origin
+
+    def test_seed_url_origin_stamped(self, client):
+        """A url_download origin is stored verbatim; origin_name is the URL."""
+        from vtsearch.state import medias
+
+        fname = self._create_example_file(b"url-novel-bytes", "url_novel.wav")
+        origin = {"importer": "url_download", "params": {"url": "https://x.test/bark.wav"}}
+
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname, "origin": origin}]},
+        )
+        assert res.get_json()["seeded"] == 1
+        new_media = medias[max(medias.keys())]
+        assert new_media["origin"] == origin
+        assert new_media["origin_name"] == "https://x.test/bark.wav"
+
+    def test_seed_origin_escaping_confinement_falls_back_to_sentinel(self, client, monkeypatch, tmp_path):
+        """In multi-user mode an origin whose path escapes the user's dir is
+        discarded: the media seeds via the example_media sentinel instead."""
+        import vtscore.security.path_validation as paths_mod
+        from vtsearch.state import medias
+
+        monkeypatch.setattr(paths_mod, "get_file_access_base_dir", lambda: tmp_path)
+
+        fname = self._create_example_file(b"confined-novel-bytes", "confined_novel.wav")
+        origin = {"importer": "server_file", "params": {"path": "/etc/passwd"}}
+
+        res = client.post(
+            "/api/votes/seed-from-examples",
+            json={"examples": [{"type": "media", "value": fname, "origin": origin}]},
+        )
+        assert res.get_json()["seeded"] == 1
+        new_media = medias[max(medias.keys())]
+        assert new_media["origin"] == {"importer": "example_media", "params": {"filename": fname}}
+
+    def test_registry_create_persists_example_origin(self, client):
+        """The origin key on an example survives the registry-create round trip."""
+        origin = {"importer": "url_download", "params": {"url": "https://x.test/persist.wav"}}
+        res = client.post(
+            "/api/detectors/registry",
+            json={
+                "name": "PersistOrigin",
+                "media_type": "audio",
+                "text_query": "",
+                "media_example": "persist.wav",
+                "examples": [{"type": "media", "value": "persist.wav", "origin": origin}],
+            },
+        )
+        assert res.status_code == 201
+
+        data = client.get("/api/detectors/PersistOrigin").get_json()
+        assert data["examples"] == [{"type": "media", "value": "persist.wav", "origin": origin}]
+
+    def test_load_detector_reseeds_url_example_after_cache_loss(self, client, monkeypatch):
+        """Round trip (issue #2774): a url_download exemplar whose
+        example_media/ cache file is gone is re-fetched from its URL when
+        the detector loads, and the seeded media carries the URL origin."""
+        import vtscore.datasets.downloader as downloader_mod
+        import vtscore.security.url_validation as url_mod
+        from vtsearch.state import good_votes, medias
+
+        url = "https://x.test/roundtrip/bark.wav"
+
+        def _download(u, dest_path, expected_size=0, on_progress=None):
+            dest_path.write_bytes(b"url-roundtrip-bytes")
+
+        monkeypatch.setattr(downloader_mod, "download_file_with_progress", _download)
+        monkeypatch.setattr(url_mod, "validate_url", lambda u: u)
+
+        origin = {"importer": "url_download", "params": {"url": url}}
+        fname = "url_roundtrip_never_cached.wav"  # deliberately absent from example_media/
+
+        res = client.post(
+            "/api/detectors/registry",
+            json={
+                "name": "UrlRoundtrip",
+                "media_type": "audio",
+                "text_query": "",
+                "media_example": fname,
+                "examples": [{"type": "media", "value": fname, "origin": origin}],
+            },
+        )
+        detector_id = res.get_json()["detector"]["id"]
+        client.post("/api/votes/clear")
+
+        _load_detector_and_wait(client, detector_id)
+
+        seeded = [m for m in medias.values() if m.get("origin") == origin]
+        assert len(seeded) == 1
+        assert seeded[0]["origin_name"] == url
+        assert seeded[0]["id"] in good_votes
+
     def test_new_example_usable_in_training(self, client):
         """Inserted examples should have embeddings usable by learned-sort."""
         from vtsearch.state import (

--- a/tests/io/test_datasource_importer_routes.py
+++ b/tests/io/test_datasource_importer_routes.py
@@ -52,9 +52,24 @@ class TestDatasourceImportRun:
         data = resp.get_json()
         assert data["original_name"] == "bark.wav"
         assert data["filename"].endswith(".wav")
+        # The durable origin is returned so the client can persist it on
+        # the detector example (issue #2774).
+        assert data["origin"]["importer"] == "server_file"
+        assert data["origin"]["params"]["path"] == str(src.resolve())
 
         saved = SERVER_MEDIA_DIR / data["filename"]
         assert saved.read_bytes() == b"RIFFxxxxWAVE"
+
+    def test_origin_null_when_importer_reports_none(self, client, monkeypatch, example_media_cleanup):
+        """Importers whose items have no re-derivable source return origin: null."""
+
+        def _fetch(field_values):
+            return FetchedMediaItem(data=b"\x01", filename="pick.png")
+
+        monkeypatch.setattr(get_datasource_importer("server_file"), "fetch", _fetch)
+        resp = client.post("/api/datasource-import/server_file", json={"path": "/ignored"})
+        assert resp.status_code == 201
+        assert resp.get_json()["origin"] is None
 
     def test_unknown_importer_404_lists_available(self, client):
         resp = client.post("/api/datasource-import/nope", json={})

--- a/tests_lib/core/test_origin_validation.py
+++ b/tests_lib/core/test_origin_validation.py
@@ -1,0 +1,66 @@
+"""Tests for externally-supplied origin confinement validation.
+
+:func:`vtscore.security.origin_validation.check_origin_param_confinement`
+guards flows that accept a full origin dict from outside the server (the
+example-sort-origin route, a detector's saved media examples) before the
+origin's path-like params are used for filesystem access (issue #2774).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.security.origin_validation import check_origin_param_confinement
+
+
+@pytest.fixture
+def confined_base(monkeypatch, tmp_path):
+    """Simulate multi-user mode: confine file access to a per-user dir."""
+    import vtscore.security.path_validation as paths_mod
+
+    base = tmp_path / "userdata"
+    base.mkdir()
+    monkeypatch.setattr(paths_mod, "get_file_access_base_dir", lambda: base)
+    return base
+
+
+class TestSingleUserMode:
+    def test_any_path_allowed_when_unconfined(self, monkeypatch):
+        import vtscore.security.path_validation as paths_mod
+
+        monkeypatch.setattr(paths_mod, "get_file_access_base_dir", lambda: None)
+        check_origin_param_confinement({"importer": "server_file", "params": {"path": "/etc/passwd"}})
+
+
+class TestMultiUserConfinement:
+    def test_confined_path_passes(self, confined_base):
+        inside = confined_base / "clip.wav"
+        check_origin_param_confinement({"importer": "server_file", "params": {"path": str(inside)}})
+
+    def test_escaping_path_raises(self, confined_base):
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            check_origin_param_confinement({"importer": "server_file", "params": {"path": "/etc/passwd"}})
+
+    def test_url_params_are_exempt(self, confined_base):
+        # URLs are re-validated by validate_url at fetch time; the path
+        # check must not spuriously reject them in multi-user mode.
+        check_origin_param_confinement(
+            {"importer": "url_download", "params": {"url": "https://media.example.test/a.wav"}}
+        )
+
+    def test_pathless_params_ignored(self, confined_base):
+        check_origin_param_confinement({"importer": "example_media", "params": {"filename": "abc.wav"}})
+
+    def test_dupe_set_members_are_recursed(self, confined_base):
+        origin = {
+            "importer": "dupe_set",
+            "members": [
+                {"origin": {"importer": "server_file", "params": {"path": "/etc/passwd"}}},
+            ],
+        }
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            check_origin_param_confinement(origin)
+
+    def test_non_dict_origin_is_a_noop(self, confined_base):
+        check_origin_param_confinement(None)
+        check_origin_param_confinement("not-a-dict")

--- a/tests_lib/datasets/test_url_download_source.py
+++ b/tests_lib/datasets/test_url_download_source.py
@@ -1,0 +1,114 @@
+"""Tests for the url_download media source (re-fetch an exemplar from its URL).
+
+Backs origins stamped by the ``url_download`` datasource importer so a
+URL-fetched exemplar stays resolvable after the ``example_media/`` cache
+file is gone (issue #2774).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vtscore.datasets.sources import get_source_for_origin
+from vtscore.datasets.sources.url_download import UrlDownloadSource
+
+
+URL = "https://media.example.test/sounds/dog%20bark.wav?tok=1"
+
+
+@pytest.fixture
+def fake_download(monkeypatch):
+    """Stub the downloader + URL validator; records every fetched URL."""
+    calls: list[str] = []
+
+    def _download(url, dest_path, expected_size=0, on_progress=None):
+        calls.append(url)
+        Path(dest_path).write_bytes(b"RIFFxxxxWAVE")
+
+    import vtscore.datasets.downloader as downloader_mod
+    import vtscore.security.url_validation as url_mod
+
+    monkeypatch.setattr(downloader_mod, "download_file_with_progress", _download)
+    monkeypatch.setattr(url_mod, "validate_url", lambda u: u)
+    return calls
+
+
+class TestFactory:
+    def test_get_source_for_origin_builds_url_source(self):
+        source = get_source_for_origin({"importer": "url_download", "params": {"url": URL}})
+        assert isinstance(source, UrlDownloadSource)
+
+    def test_missing_url_param_returns_none(self):
+        assert get_source_for_origin({"importer": "url_download", "params": {}}) is None
+
+
+class TestUrlDownloadSource:
+    def test_resolve_path_downloads_with_real_extension(self, fake_download):
+        source = UrlDownloadSource(URL)
+        try:
+            item = source.resolve_path(origin_name=URL, filename="abc.wav")
+            assert item.path is not None
+            assert item.path.read_bytes() == b"RIFFxxxxWAVE"
+            # Suffix comes from the URL path (drives downstream decode).
+            assert item.path.name == "dog bark.wav"
+            assert fake_download == [URL]
+        finally:
+            source.cleanup()
+
+    def test_repeat_access_downloads_once(self, fake_download):
+        source = UrlDownloadSource(URL)
+        try:
+            first = source.resolve_path().path
+            second = source.fetch_item("anything").path
+            assert first == second
+            assert fake_download == [URL]
+        finally:
+            source.cleanup()
+
+    def test_cleanup_removes_temp_download(self, fake_download):
+        source = UrlDownloadSource(URL)
+        path = source.resolve_path().path
+        assert path is not None and path.is_file()
+        source.cleanup()
+        assert not path.exists()
+
+    def test_private_url_is_never_fetched(self, monkeypatch):
+        """The stored URL is re-validated with the real SSRF guard before any fetch."""
+        calls = []
+
+        import vtscore.datasets.downloader as downloader_mod
+
+        monkeypatch.setattr(
+            downloader_mod,
+            "download_file_with_progress",
+            lambda *a, **k: calls.append(a),
+        )
+        source = UrlDownloadSource("http://127.0.0.1/x.wav")
+        assert source.resolve_path().path is None
+        assert calls == []
+
+    def test_list_items_yields_single_item_without_downloading(self, fake_download):
+        source = UrlDownloadSource(URL)
+        items = list(source.list_items())
+        assert [i.filename for i in items] == ["dog bark.wav"]
+        assert fake_download == []
+
+    def test_list_items_extension_filter(self, fake_download):
+        source = UrlDownloadSource(URL)
+        assert list(source.list_items(extensions=[".png"])) == []
+        assert len(list(source.list_items(extensions=[".wav"]))) == 1
+
+
+class TestResolverDispatch:
+    def test_resolve_file_from_origin_refetches_from_url(self, fake_download):
+        """End-to-end: a url_download origin resolves via source dispatch."""
+        from vtscore.detectors.resolver import resolve_file_context
+
+        origin = {"importer": "url_download", "params": {"url": URL}}
+        with resolve_file_context(origin, URL, "abc.wav") as path:
+            assert path is not None
+            assert path.read_bytes() == b"RIFFxxxxWAVE"
+        # The ExitStack ran the source's cleanup on exit.
+        assert not path.exists()

--- a/tests_lib/io/test_datasource_importers.py
+++ b/tests_lib/io/test_datasource_importers.py
@@ -79,6 +79,15 @@ class TestServerFileFetch:
         assert item.data == b"RIFFxxxxWAVE"
         assert item.filename == "clip.wav"
 
+    def test_fetch_reports_path_origin(self, tmp_path):
+        """The validated server path is the item's durable origin (issue #2774)."""
+        f = tmp_path / "clip.wav"
+        f.write_bytes(b"RIFFxxxxWAVE")
+        item = get_datasource_importer("server_file").fetch({"path": str(f)})
+        assert item.origin is not None
+        assert item.origin["importer"] == "server_file"
+        assert item.origin["params"]["path"] == str(f.resolve())
+
     def test_fetch_missing_file_raises_value_error(self, tmp_path):
         with pytest.raises(ValueError, match="File not found"):
             get_datasource_importer("server_file").fetch({"path": str(tmp_path / "nope.wav")})
@@ -102,6 +111,23 @@ class TestUrlDownloadFetch:
 
         assert _filename_from_url("https://x.test/a/b/dog%20bark.wav?tok=1") == "dog bark.wav"
         assert _filename_from_url("https://x.test/") == "download.bin"
+
+    def test_fetch_reports_url_origin(self, monkeypatch, tmp_path):
+        """The URL is the item's durable origin (issue #2774)."""
+        import vtscore.datasets.downloader as downloader_mod
+        import vtscore.datasource_importers.url_download as url_mod
+
+        url = "https://x.test/a/bark.wav"
+
+        def _download(u, dest_path, expected_size=0, on_progress=None):
+            dest_path.write_bytes(b"RIFFxxxxWAVE")
+
+        monkeypatch.setattr(downloader_mod, "download_file_with_progress", _download)
+        monkeypatch.setattr(url_mod, "validate_url", lambda u: u)
+
+        item = get_datasource_importer("url_download").fetch({"url": url})
+        assert item.data == b"RIFFxxxxWAVE"
+        assert item.origin == {"importer": "url_download", "params": {"url": url}}
 
 
 class TestDatasourceImporterFields:

--- a/vtscore/datasets/sources/url_download.py
+++ b/vtscore/datasets/sources/url_download.py
@@ -1,0 +1,112 @@
+"""URL-download media source - re-fetch a single file from its public URL.
+
+Backs origins stamped by the ``url_download`` datasource importer
+(``{"importer": "url_download", "params": {"url": ...}}``), so an exemplar
+fetched from a URL keeps a live origin: cross-dataset label resolution and
+example-sort can re-download the file on demand instead of depending on the
+local ``example_media/`` byte cache.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Iterator
+from urllib.parse import unquote, urlparse
+
+from vtscore.datasets.sources.base import FetchedItem, MediaItem, MediaSource
+
+__all__ = ["UrlDownloadSource"]
+
+log = logging.getLogger(__name__)
+
+
+def _filename_from_url(url: str) -> str:
+    """Derive a filename (with its real extension) from *url*'s path.
+
+    The suffix matters: it drives how downstream code (embedders, media
+    decode) interprets the downloaded bytes.
+    """
+    name = Path(unquote(urlparse(url).path)).name
+    return name or "download.bin"
+
+
+class UrlDownloadSource(MediaSource):
+    """A media source backed by a single public http(s) URL.
+
+    The download happens lazily on first access, into a temporary directory
+    owned by the source; :meth:`cleanup` removes it.  The stored URL was
+    originally user-supplied, so it is re-validated with the same SSRF guard
+    the ingress ran (:func:`~vtscore.security.url_validation.validate_url`)
+    before any fetch; the downloader re-checks every redirect hop.
+    """
+
+    name = "url_download"
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self._tmp_dir: tempfile.TemporaryDirectory | None = None
+        self._path: Path | None = None
+        self._failed = False
+
+    def _download(self) -> Path | None:
+        """Fetch the URL once; return the local path, or ``None`` on failure."""
+        if self._path is not None:
+            return self._path
+        if self._failed:
+            return None
+
+        from vtscore.datasets.downloader import download_file_with_progress
+        from vtscore.security.url_validation import validate_url
+
+        try:
+            url = validate_url(self._url)
+            self._tmp_dir = tempfile.TemporaryDirectory(prefix="vts_url_source_")
+            dest = Path(self._tmp_dir.name) / _filename_from_url(url)
+            download_file_with_progress(url, dest, on_progress=lambda *a, **k: None)
+            if not dest.is_file() or dest.stat().st_size == 0:
+                raise ValueError(f"The URL returned no data: {url}")
+        except Exception:
+            log.warning("UrlDownloadSource: could not fetch %r", self._url, exc_info=True)
+            self._failed = True
+            self.cleanup()
+            return None
+
+        self._path = dest
+        return dest
+
+    def list_items(self, extensions: list[str] | None = None) -> Iterator[MediaItem]:
+        """Yield the source's single item (without downloading it)."""
+        filename = _filename_from_url(self._url)
+        if extensions is not None and Path(filename).suffix.lower() not in {e.lower() for e in extensions}:
+            return
+        yield MediaItem(key=filename, filename=filename, source_name=self.name)
+
+    def fetch_item(self, key: str) -> FetchedItem:  # noqa: ARG002 (single-item source; any key maps to the URL)
+        return FetchedItem(path=self._download())
+
+    def resolve_path(self, origin_name: str = "", filename: str = "") -> FetchedItem:
+        return FetchedItem(path=self._download())
+
+    def cleanup(self) -> None:
+        if self._tmp_dir is not None:
+            self._tmp_dir.cleanup()
+            self._tmp_dir = None
+        self._path = None
+
+
+class _UrlDownloadSourceFactory:
+    """Factory for auto-discovery by :class:`~vtscore.plugins.PluginRegistry`.
+
+    Resolves origins emitted by the ``url_download`` datasource importer.
+    """
+
+    name = "url_download"
+
+    def create_from_origin(self, origin: dict) -> UrlDownloadSource | None:
+        url = origin.get("params", {}).get("url", "")
+        return UrlDownloadSource(url) if url else None
+
+
+SOURCE = _UrlDownloadSourceFactory()

--- a/vtscore/datasource_importers/base.py
+++ b/vtscore/datasource_importers/base.py
@@ -57,10 +57,23 @@ class FetchedMediaItem:
         A human-meaningful filename for the item.  Its suffix matters: it
         drives media-type inference and how downstream code decodes the
         saved file, so keep the source's real extension.
+    origin:
+        Optional durable origin dict (``{"importer": <name>, "params":
+        {...}}``) describing where the item came from, so it can be
+        re-fetched on demand later (cross-dataset label resolution,
+        re-deriving a deleted ``example_media/`` cache file).  Importers
+        whose items have a stable external identity (a URL, a server path)
+        should set this; leave it ``None`` when the bytes have no
+        re-derivable source and the saved byte snapshot is the only record.
+        Params named ``path`` are resolvable with no extra code (the
+        resolver's generic path fallback); other param shapes need a
+        matching :class:`~vtscore.datasets.sources.base.MediaSource`
+        factory registered under the importer's name.
     """
 
     data: bytes
     filename: str
+    origin: dict[str, Any] | None = None
 
 
 class DataSourceImporter(PluginBase):

--- a/vtscore/datasource_importers/server_file/__init__.py
+++ b/vtscore/datasource_importers/server_file/__init__.py
@@ -40,7 +40,14 @@ class ServerFileDataSourceImporter(DataSourceImporter):
         path = validate_server_filepath(raw, base_dir=get_file_access_base_dir())
         if not path.is_file():
             raise ValueError(f"File not found: {raw}")
-        return FetchedMediaItem(data=path.read_bytes(), filename=path.name)
+        return FetchedMediaItem(
+            data=path.read_bytes(),
+            filename=path.name,
+            # The validated server path is the item's durable identity; the
+            # ``path`` param name makes the resolver's generic path fallback
+            # resolve it with no dedicated source.
+            origin={"importer": self.name, "params": {"path": str(path)}},
+        )
 
 
 DATASOURCE_IMPORTER = ServerFileDataSourceImporter()

--- a/vtscore/datasource_importers/url_download/__init__.py
+++ b/vtscore/datasource_importers/url_download/__init__.py
@@ -53,7 +53,14 @@ class UrlDownloadDataSourceImporter(DataSourceImporter):
             data = dest.read_bytes()
         if not data:
             raise ValueError(f"The URL returned no data: {url}")
-        return FetchedMediaItem(data=data, filename=_filename_from_url(url))
+        return FetchedMediaItem(
+            data=data,
+            filename=_filename_from_url(url),
+            # The URL is the item's durable identity: stored on the example /
+            # seeded media so the file can be re-fetched on demand (resolved
+            # by the url_download MediaSource).
+            origin={"importer": self.name, "params": {"url": url}},
+        )
 
 
 DATASOURCE_IMPORTER = UrlDownloadDataSourceImporter()

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -5,6 +5,11 @@ files, matches them to loaded dataset medias by MD5, and votes them good.
 """
 
 from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+
 from vtscore.utils.hashing import content_md5
 
 
@@ -32,32 +37,199 @@ def _ensure_embedder(embedder, dataset_embedder_name: str, dataset_media_type: s
     return embedder
 
 
+def _real_example_origin(ex: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the example's validated real origin dict, or ``None``.
+
+    An example saved by a datasource importer carries the item's durable
+    origin (``{"importer": "url_download", "params": {"url": ...}}``,
+    ``{"importer": "server_file", "params": {"path": ...}}``, ...) so the
+    seeded media points back at its source instead of at the dead-end
+    ``example_media`` sentinel.  Examples saved before origins existed (and
+    genuinely un-re-derivable ones: uploads, add-to-pile snapshots) have no
+    ``origin`` key and fall back to the sentinel.
+
+    Security: the origin comes from a detector JSON / request body, so its
+    path-like params must pass the same per-user confinement the ingress
+    applies; an origin that fails the check is discarded (sentinel
+    fallback).  URL params are re-validated by the url_download source at
+    fetch time (``validate_url`` plus per-redirect-hop checks in the
+    downloader).
+    """
+    origin = ex.get("origin")
+    if not isinstance(origin, dict):
+        return None
+    importer = origin.get("importer")
+    if not isinstance(importer, str) or not importer or importer == "example_media":
+        return None
+    if not isinstance(origin.get("params"), dict):
+        return None
+
+    from vtscore.security.origin_validation import check_origin_param_confinement
+
+    try:
+        check_origin_param_confinement(origin)
+    except ValueError:
+        return None
+    return origin
+
+
+def _example_origin_name(origin: dict[str, Any] | None, filename: str) -> str:
+    """Human-meaningful origin name: the URL / path for a real origin, else the cache filename."""
+    if origin is not None:
+        params = origin.get("params", {})
+        name = params.get("url") or params.get("path") or ""
+        if isinstance(name, str) and name:
+            return name
+    return filename
+
+
+def _example_file_path(server_media_dir: Path, filename: str) -> Path | None:
+    """The example's path inside ``example_media/``, or ``None`` on a traversal attempt."""
+    file_path = server_media_dir / filename
+    try:
+        file_path.resolve().relative_to(server_media_dir.resolve())
+    except ValueError:
+        return None
+    return file_path
+
+
+def _insert_example_media(
+    origin: dict[str, Any] | None,
+    origin_name: str,
+    filename: str,
+    file_bytes: bytes,
+    file_md5: str,
+    embedding,
+    dataset_media_type: str,
+    dataset_embedder_name: str,
+) -> None:
+    """Insert an embedded example into the active context's medias and vote it good."""
+    from vtscore.state import _state_lock, apply_label, get_active_context, next_media_id
+
+    with _state_lock:
+        active_medias = get_active_context().medias
+        new_id = next_media_id(active_medias)
+        active_medias[new_id] = {
+            "id": new_id,
+            "media_type": dataset_media_type,
+            "embedder": dataset_embedder_name,
+            "md5": file_md5,
+            "embeddings": {dataset_embedder_name: embedding},
+            "media_bytes": file_bytes,
+            "filename": filename,
+            "file_size": len(file_bytes),
+            "category": "",
+            "origin": origin
+            if origin is not None
+            else {
+                "importer": "example_media",
+                "params": {"filename": filename},
+            },
+            "origin_name": origin_name,
+        }
+
+    apply_label(new_id, "good", record_achievement=False)
+
+
+def _seed_one_example(
+    ex: dict[str, Any],
+    server_media_dir: Path,
+    md5_lookup: dict,
+    dataset_media_type: str,
+    dataset_embedder_name: str,
+    embedder,
+) -> tuple[int, Any]:
+    """Seed a single media example.
+
+    Returns ``(1 or 0, embedder)`` - whether the example was seeded, plus
+    the (possibly lazily-loaded) embedder for the caller to reuse.
+    """
+    from vtscore.detectors.resolver import resolve_file_context
+    from vtscore.state import apply_label
+
+    filename = ex["value"].strip()
+    file_path = _example_file_path(server_media_dir, filename)
+    if file_path is None:
+        return 0, embedder
+
+    origin = _real_example_origin(ex)
+    origin_name = _example_origin_name(origin, filename)
+
+    # Hold any resolver-backed source alive (its temp file must survive
+    # until the example is read and embedded below).
+    with ExitStack() as stack:
+        if file_path.is_file():
+            embed_path: Path | None = file_path
+        elif origin is not None:
+            # The example_media/ cache file is gone; the origin is the
+            # canonical form, so re-derive the bytes from it.
+            embed_path = stack.enter_context(resolve_file_context(origin, origin_name, filename))
+        else:
+            embed_path = None
+        if embed_path is None or not embed_path.is_file():
+            return 0, embedder
+
+        file_bytes = embed_path.read_bytes()
+        file_md5 = content_md5(file_bytes)
+        cids = md5_lookup.get(file_md5, [])
+
+        if cids:
+            # Example matches existing dataset media - just vote good.
+            # System-driven seeding from a detector's saved examples, not a
+            # user vote action, so don't credit achievement counters.
+            for cid in cids:
+                apply_label(cid, "good", record_achievement=False)
+            return 1, embedder
+
+        # Example is NOT in the dataset - embed and insert as new media.
+        embedder = _ensure_embedder(embedder, dataset_embedder_name, dataset_media_type)
+        if embedder is None:
+            # No embedder available; the caller's remaining examples will
+            # skip here too.
+            return 0, embedder
+
+        from vtscore.media.embedder import media_from_path  # noqa: PLC0415
+
+        embedding = embedder.embed_media(media_from_path(embed_path))
+        if embedding is None:
+            return 0, embedder
+
+        _insert_example_media(
+            origin,
+            origin_name,
+            filename,
+            file_bytes,
+            file_md5,
+            embedding,
+            dataset_media_type,
+            dataset_embedder_name,
+        )
+        return 1, embedder
+
+
 def seed_good_votes_from_examples(examples: list[dict]) -> int:
     """Seed good votes from a model's media examples.
 
     For each ``type: "media"`` example, reads the file from
-    ``data/example_media/`` and adds it to ``good_votes``:
+    ``data/example_media/`` (re-fetching it from the example's ``origin``
+    when the cached file is gone) and adds it to ``good_votes``:
 
     * **Match by MD5** - if a loaded media has the same content hash,
       that media is voted good (keeping its original dataset origin).
     * **No match** - the example file is embedded using the dataset's
-      embedder, inserted into the ``medias`` dict as a new item with
-      an ``example_media`` origin, and voted good.  This makes it
-      available for training (its embedding is in the medias snapshot)
-      and for label export (LabelSet picks it up from medias + votes).
+      embedder, inserted into the ``medias`` dict as a new item, and voted
+      good.  This makes it available for training (its embedding is in the
+      medias snapshot) and for label export (LabelSet picks it up from
+      medias + votes).  The inserted media carries the example's real
+      origin when it has one (so the resulting labels resolve against any
+      dataset), falling back to the ``example_media`` sentinel origin for
+      examples with no re-derivable source.
 
     Returns the number of example entries successfully seeded.
     """
 
     from vtscore.config import DATA_DIR
-    from vtscore.state import (
-        _state_lock,
-        apply_label,
-        cached_md5_lookup,
-        get_active_context,
-        next_media_id,
-        snapshot_medias,
-    )
+    from vtscore.state import cached_md5_lookup, snapshot_medias
 
     media_examples = [
         ex for ex in examples if isinstance(ex, dict) and ex.get("type") == "media" and ex.get("value", "").strip()
@@ -81,61 +253,14 @@ def seed_good_votes_from_examples(examples: list[dict]) -> int:
 
     seeded = 0
     for ex in media_examples:
-        filename = ex["value"].strip()
-        file_path = server_media_dir / filename
-        # Prevent directory traversal
-        try:
-            file_path.resolve().relative_to(server_media_dir.resolve())
-        except ValueError:
-            continue
-        if not file_path.is_file():
-            continue
-
-        file_bytes = file_path.read_bytes()
-        file_md5 = content_md5(file_bytes)
-        cids = md5_lookup.get(file_md5, [])
-
-        if cids:
-            # Example matches existing dataset media - just vote good.
-            # System-driven seeding from a detector's saved examples, not a
-            # user vote action, so don't credit achievement counters.
-            for cid in cids:
-                apply_label(cid, "good", record_achievement=False)
-            seeded += 1
-        else:
-            # Example is NOT in the dataset - embed and insert as new media.
-            embedder = _ensure_embedder(embedder, dataset_embedder_name, dataset_media_type)
-            if embedder is None:
-                # No embedder available; skip remaining examples.
-                continue
-
-            from vtscore.media.embedder import media_from_path  # noqa: PLC0415
-
-            embedding = embedder.embed_media(media_from_path(file_path))
-            if embedding is None:
-                continue
-
-            with _state_lock:
-                active_medias = get_active_context().medias
-                new_id = next_media_id(active_medias)
-                active_medias[new_id] = {
-                    "id": new_id,
-                    "media_type": dataset_media_type,
-                    "embedder": dataset_embedder_name,
-                    "md5": file_md5,
-                    "embeddings": {dataset_embedder_name: embedding},
-                    "media_bytes": file_bytes,
-                    "filename": filename,
-                    "file_size": len(file_bytes),
-                    "category": "",
-                    "origin": {
-                        "importer": "example_media",
-                        "params": {"filename": filename},
-                    },
-                    "origin_name": filename,
-                }
-
-            apply_label(new_id, "good", record_achievement=False)
-            seeded += 1
+        delta, embedder = _seed_one_example(
+            ex,
+            server_media_dir,
+            md5_lookup,
+            dataset_media_type,
+            dataset_embedder_name,
+            embedder,
+        )
+        seeded += delta
 
     return seeded

--- a/vtscore/security/origin_validation.py
+++ b/vtscore/security/origin_validation.py
@@ -1,0 +1,56 @@
+"""Confinement validation for origin dicts that arrive from outside the server.
+
+An origin dict (``{"importer": ..., "params": {...}}``) is normally stamped
+by the server at import time and trusted thereafter.  Some flows, however,
+accept a full origin from a request body or a detector JSON file (the
+``POST /api/example-sort-origin`` route, a detector's saved media examples),
+and resolving such an origin re-runs filesystem or network access from
+originally user-supplied parameters.  Before an externally-supplied origin
+is used, its path-like params must pass the same per-user confinement the
+ingress applies.
+
+URL-valued params are deliberately *not* path-checked here: they are
+re-validated with :func:`~vtscore.security.url_validation.validate_url` at
+fetch time by the URL-backed sources (and the downloader re-checks every
+redirect hop), and running them through the path validator would spuriously
+reject them in multi-user mode.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def check_origin_param_confinement(origin: Any) -> None:
+    """Raise :class:`ValueError` if a path-like origin param escapes the user's allowed dir.
+
+    Recurses into ``dupe_set``-style ``members`` so a nested member origin
+    cannot smuggle an unvalidated path.  A no-op in single-user mode, where
+    the base dir is unrestricted (see
+    :func:`~vtscore.security.path_validation.get_file_access_base_dir`).
+    """
+    from vtscore.security.path_validation import get_file_access_base_dir
+
+    _check(origin, get_file_access_base_dir())
+
+
+def _check(origin: Any, base_dir: Any) -> None:
+    if not isinstance(origin, dict):
+        return
+
+    from vtscore.security.path_validation import validate_server_filepath
+
+    params = origin.get("params")
+    if isinstance(params, dict):
+        for val in params.values():
+            if not isinstance(val, str) or ("/" not in val and "\\" not in val):
+                continue
+            if val.startswith(("http://", "https://")):
+                continue  # re-validated by validate_url at fetch time
+            validate_server_filepath(val, base_dir=base_dir)
+
+    members = origin.get("members")
+    if isinstance(members, list):
+        for member in members:
+            if isinstance(member, dict):
+                _check(member.get("origin"), base_dir)

--- a/vtsearch/routes/media/datasource.py
+++ b/vtsearch/routes/media/datasource.py
@@ -10,7 +10,7 @@ endpoints:
 * ``GET  /api/datasource-importers`` ->
         :class:`~vtsearch.schemas.media.DatasourceImportersListResponseSchema`
 * ``POST /api/datasource-import/<importer_name>`` ->
-        :class:`~vtsearch.schemas.media.ServerMediaUploadResponseSchema`
+        :class:`~vtsearch.schemas.media.DatasourceImportResponseSchema`
         (plugin-dependent body; per-plugin typed routes are registered for
         the OpenAPI spec, file-field plugins use multipart)
 * ``POST /api/datasource-import/<importer_name>/options`` -> dynamic
@@ -20,7 +20,9 @@ The run endpoint saves the fetched bytes into the per-user
 ``example_media/`` directory and returns the same ``{filename,
 original_name}`` contract as ``POST /api/server-media-files/upload``, so a
 fetched item plugs into the existing ``{type: "media", value: <filename>}``
-detector-example model unchanged.
+detector-example model unchanged.  It additionally returns the item's
+durable ``origin`` (when the importer reports one) for the client to store
+on the example, keeping the item re-fetchable after the cache file is gone.
 """
 
 from __future__ import annotations
@@ -43,7 +45,7 @@ from vtsearch.schemas.datasets import (
 )
 from vtsearch.schemas.media import (
     DatasourceImportersListResponseSchema,
-    ServerMediaUploadResponseSchema,
+    DatasourceImportResponseSchema,
 )
 from vtsearch.settings import filter_visible_plugins
 
@@ -78,7 +80,8 @@ def run_datasource_import(importer_name: str):
     into the per-user ``example_media/`` directory and the saved
     ``filename`` (persistence key) plus the human-readable
     ``original_name`` are returned, matching the upload endpoint's
-    contract.
+    contract, along with the item's durable ``origin`` when the importer
+    reports one (``null`` otherwise).
     """
     from vtsearch.routes.media.server import _get_server_media_dir
 
@@ -109,7 +112,12 @@ def run_datasource_import(importer_name: str):
     media_dir.mkdir(parents=True, exist_ok=True)
     (media_dir / safe_name).write_bytes(item.data)
 
-    return ServerMediaUploadResponseSchema().dump({"filename": safe_name, "original_name": item.filename}), 201
+    return (
+        DatasourceImportResponseSchema().dump(
+            {"filename": safe_name, "original_name": item.filename, "origin": item.origin}
+        ),
+        201,
+    )
 
 
 @datasource_importers_bp.route("/api/datasource-import/<importer_name>/options", methods=["POST"])

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -294,20 +294,17 @@ def _validate_origin_param_confinement(origin: dict) -> None:
     param must pass the same confinement check ``_load_from_origin`` applies
     before it can point a filesystem-backed source (server_folder,
     server_files) outside the user's allowed directory.  A no-op in
-    single-user mode, where the base dir is unrestricted.
+    single-user mode, where the base dir is unrestricted.  URL params are
+    exempt from the path check: the URL-backed sources re-run
+    ``validate_url`` at fetch time (see
+    :mod:`vtscore.security.origin_validation`).
     """
-    from vtscore.security.path_validation import get_file_access_base_dir, validate_server_filepath
+    from vtscore.security.origin_validation import check_origin_param_confinement
 
-    params = origin.get("params") if isinstance(origin, dict) else None
-    if not isinstance(params, dict):
-        return
-    base = get_file_access_base_dir()
-    for val in params.values():
-        if isinstance(val, str) and ("/" in val or "\\" in val):
-            try:
-                validate_server_filepath(val, base_dir=base)
-            except ValueError as exc:
-                abort(400, message=str(exc))
+    try:
+        check_origin_param_confinement(origin)
+    except ValueError as exc:
+        abort(400, message=str(exc))
 
 
 @media_server_bp.route("/api/example-sort-origin", methods=["POST"])

--- a/vtsearch/schemas/media.py
+++ b/vtsearch/schemas/media.py
@@ -507,7 +507,21 @@ class DatasourceImportersListResponseSchema(Schema):
     tabs = fields.List(fields.Nested(ImporterPickerTabSchema), required=True)
 
 
+class DatasourceImportResponseSchema(ServerMediaUploadResponseSchema):
+    """Response for ``POST /api/datasource-import/<name>``.
+
+    Extends the upload contract with the fetched item's durable ``origin``
+    (``{"importer": ..., "params": {...}}``) when the datasource importer
+    reports one, so the client can persist it on the detector example and
+    the item stays re-fetchable after the ``example_media/`` cache file is
+    gone.  ``None`` for importers whose items have no re-derivable source.
+    """
+
+    origin = fields.Dict(dump_default=None, allow_none=True)
+
+
 __all__ = [
+    "DatasourceImportResponseSchema",
     "DatasourceImporterEntrySchema",
     "DatasourceImportersListResponseSchema",
     "ExampleSortByIdRequestSchema",


### PR DESCRIPTION
Closes #2774.

Exemplar media fetched by a datasource importer now carry their real, durable origin end to end, so the "origins are canonical, re-derive on demand" invariant holds for them and `example_media/` becomes a true cache rather than load-bearing storage.

## What changed

**Datasource importers describe their own origin.** `FetchedMediaItem` gains an optional `origin` field. `url_download` reports `{"importer": "url_download", "params": {"url": ...}}`; `server_file` reports `{"importer": "server_file", "params": {"path": ...}}` (the `path` key means the resolver's existing generic fallback resolves it with no new code). Importers whose items have no re-derivable source (uploads) leave it unset, by design.

**The origin rides the example.** `POST /api/datasource-import/<name>` returns the origin alongside `{filename, original_name}` (new `DatasourceImportResponseSchema`); the New Detector modal stores it on the picked example and sends `{type: "media", value, origin}` in the examples payload. The key is additive on the untyped example dicts, so examples saved before this change keep working unchanged.

**Seeding stamps and uses it.** `seed_good_votes_from_examples` stamps the example's validated origin (and a meaningful `origin_name` — the URL / path) onto the inserted media instead of the `example_media` sentinel, falling back to the sentinel when no origin is present (the whole back-compat story — no migration). When the `example_media/` cache file is missing, seeding now re-derives the bytes from the origin via the resolver instead of silently skipping the example.

**Resolution.** New `url_download` `MediaSource` (`vtscore/datasets/sources/url_download.py`) lazily re-downloads the URL into a source-owned temp dir, so cross-dataset label resolution and example-sort-by-origin re-fetch a URL exemplar on demand. `server_file` needs nothing (generic `path` fallback).

## Security

Externally-supplied origins (request bodies, detector JSON) are validated before use by a shared helper, `vtscore/security/origin_validation.py`: path-like params must pass the per-user `validate_server_filepath` confinement (recursing into `dupe_set` members), and an example origin that fails the check is discarded in favor of the sentinel. The `POST /api/example-sort-origin` guard now delegates to the same helper; URL params are exempt from the path check there because the `url_download` source re-runs `validate_url` at fetch time (and the downloader re-checks every redirect hop), which also keeps URL origins from being spuriously rejected in multi-user mode.

## Tests

- Round trip: a `url_download` exemplar whose cache file is gone is re-fetched from its URL at detector load and the seeded media carries the URL origin (`tests/detectors/test_detectors.py`).
- Stamped origins resolve after the cache file is deleted; seeding re-derives a never-cached example from its origin; examples without an `origin` key still seed via the sentinel (back-compat).
- SSRF/confinement: a private URL is never fetched by the source (real `validate_url`); an origin path escaping the per-user dir falls back to the sentinel; `dupe_set` member recursion (`tests_lib/core/test_origin_validation.py`, `tests_lib/datasets/test_url_download_source.py`).
- Route/plumbing: import response carries the origin (`null` when the importer reports none); registry create persists it into the detector JSON; frontend specs cover origin passthrough form → example stack → examples payload.

`./run-tests.sh` fully green: 7302 backend tests + frontend build + 1890 Vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133agQ8zszBDM7ECFEFA56R

---
_Generated by [Claude Code](https://claude.ai/code/session_0133agQ8zszBDM7ECFEFA56R)_