### PR TITLE
Threshold-stability study (#2790): Stage-A replay + selectable threshold rules

### DIFF
--- a/scripts/experiments/threshold_stability/README.md
+++ b/scripts/experiments/threshold_stability/README.md
@@ -1,0 +1,46 @@
+# Threshold-stability study runner (#2790)
+
+Grid runner for the pre-registered study in `docs/plans/threshold-stability-experiment.md`
+(on `dev`). Measures the step-to-step MLP threshold jumps on the COCO stop-sign ×
+SigLIP 2 × `whole` labeling loop and A/Bs candidate threshold rules. **CPU-only** —
+it reuses the #2790 SigLIP 2 / whole embedding cache and trains only tiny MLPs.
+
+**Read `scripts/sod/THRESHOLD_STABILITY_STATUS.md` first** for the plan-vs-reality
+reframe: on `evaluation-framework` the sweep calibrates with min-cost **argmin**, but
+production Autopilot uses the **conformal** rule — so `argmin` is the infidelity and
+`conformal` is the fidelity-correct arm.
+
+## Arms (`experiment_config.py`)
+`argmin-k2` (baseline), `argmin-k8`, `conformal-k2`, `conformal-k8`,
+`conformal-k2-med3`, `rank-transfer-k2`. Each is a set of `sweep.py` flags
+(`--threshold-rule`, `--threshold-smooth`, `--calibrate-count`). 5 classes × 10 seeds.
+
+## Two stages, per (class, seed) cell (`run_cells.py`)
+- **Stage B** — one `scripts/sod/sweep.py` run per arm with `--labeling-trace`
+  (live loop, includes selection feedback).
+- **Stage A** — `scripts/sod/replay_thresholds.py` over the `argmin-k2` baseline
+  trace: recompute every rule on the frozen votes (exactly paired; no selection
+  feedback) and decompose the variance.
+
+## Prerequisites
+- `VTS_REPO` → this worktree; `THRSTAB_CACHE_DIR` → the populated #2790 SigLIP 2 /
+  whole cache (`docs/experiments/sod-sweep/cache` from the original run).
+- If the cache is incomplete, pre-populate it with one GPU `sweep.py` run
+  (`scripts/sod/README.md`) — the study itself needs no GPU.
+
+## Run
+```bash
+export VTS_REPO=/exp/$USER/projects/vts-evalfw
+export THRSTAB_CACHE_DIR=/exp/$USER/threshold-stability/cache
+bash launch_all.sh          # sizes + submits the CPU array + analyze
+python run_cells.py --index 0   # or one cell locally, once the cache exists
+```
+Outputs under `$THRSTAB_RESULTS` (`results/cells/<class>__seed<n>/`), aggregated by
+`analyze.py` into `results/summary.json` + `results/REPORT.md`.
+
+## Before a full launch — validate on one cell
+`replay_thresholds.py::CacheVectorLoader` implements the whole-path vote→vector
+assembly from the npz cache; confirm it matches `region_curve.py::_train_pool_head`
+on one real cell (all exemplar rows vs first; the `final_pool_scores` source for
+rank-transfer) before submitting all 50. The `THRSTAB_*` env knobs
+(`experiment_config.py`, `common.py`) size everything.

--- a/scripts/experiments/threshold_stability/analyze.py
+++ b/scripts/experiments/threshold_stability/analyze.py
@@ -1,0 +1,110 @@
+"""Aggregate threshold-stability cells into the pre-registered #2790 deliverables.
+
+Concatenates every cell's Stage B ``results.jsonl`` (per-arm live-loop curves) and
+Stage A ``replay.csv`` (frozen-trace variance decomposition), then computes the
+headline metrics from the plan: per-arm ``sd(Δthreshold)`` and spike incidence over
+``t >= 20``, mean regret over ``t in [40, 60]``, and the across-seed cost sd vs the
+oracle-cost sd (the ranking-variance floor — threshold noise is the gap). Writes
+``results/summary.json``, ``results/agg/*.csv``, and a ``results/REPORT.md`` draft.
+
+Kept deliberately small: the figures + verdict prose are filled in once real Grid
+data exists (see ``docs/plans/threshold-stability-experiment.md`` decision rules).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import common
+
+common.setup_env()
+
+import experiment_config as cfg  # noqa: E402
+
+
+def _load_stage_a(cells_dir: Path):
+    import pandas as pd  # noqa: PLC0415
+
+    files = sorted(cells_dir.glob("*/replay.csv"))
+    frames = []
+    for p in files:
+        try:
+            df = pd.read_csv(p)
+        except Exception:  # noqa: BLE001 - empty/partial cell
+            continue
+        if df.empty:
+            continue
+        slug = p.parent.name  # <class_slug>__seed<seed>
+        df["cell"] = slug
+        frames.append(df)
+    return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+
+
+def _load_stage_b(cells_dir: Path):
+    import pandas as pd  # noqa: PLC0415
+
+    rows = []
+    for jl in sorted(cells_dir.glob("*/arm_*/results.jsonl")):
+        arm = jl.parent.name.removeprefix("arm_")
+        for line in jl.read_text().splitlines():
+            if line.strip():
+                rec = json.loads(line)
+                rec["arm"] = arm
+                rows.append(rec)
+    return pd.DataFrame(rows)
+
+
+def main() -> int:
+    cells_dir = common.RESULTS / "cells"
+    agg_dir = common.RESULTS / "agg"
+    agg_dir.mkdir(parents=True, exist_ok=True)
+
+    stage_a = _load_stage_a(cells_dir)
+    stage_b = _load_stage_b(cells_dir)
+    summary: dict = {"n_cells_stage_a": int(stage_a["cell"].nunique()) if not stage_a.empty else 0}
+
+    if not stage_a.empty:
+        stage_a.to_csv(agg_dir / "stage_a_replay.csv", index=False)
+        # Headline: mean sd_threshold + spike_rate per rule over t>=20 (replay already filters warmup).
+        by_rule = stage_a.groupby("rule").agg(
+            mean_sd_threshold=("sd_threshold", "mean"),
+            mean_spike_rate=("spike_rate", "mean"),
+        )
+        by_rule.to_csv(agg_dir / "stage_a_by_rule.csv")
+        summary["stage_a_by_rule"] = by_rule.reset_index().to_dict("records")
+
+    if not stage_b.empty:
+        stage_b.to_csv(agg_dir / "stage_b_curves.csv", index=False)
+        if {"arm", "t", "cost"} <= set(stage_b.columns):
+            late = stage_b[stage_b["t"].between(40, 60)]
+            summary["stage_b_mean_cost_late"] = late.groupby("arm")["cost"].mean().reset_index().to_dict("records")
+
+    (common.RESULTS / "summary.json").write_text(json.dumps(summary, indent=2, default=str))
+    _write_report(summary)
+    common.log(f"summary -> {common.RESULTS / 'summary.json'}; report -> {common.RESULTS / 'REPORT.md'}")
+    return 0
+
+
+def _write_report(summary: dict) -> None:
+    lines = [
+        "# Threshold-stability study (#2790) — results",
+        "",
+        "Reframe: `argmin` = the sweep's current (infidelic) rule; `conformal` = production",
+        "Autopilot's rule. Arms: " + ", ".join(a[0] for a in cfg.ARMS) + ".",
+        "",
+        f"Stage A cells replayed: {summary.get('n_cells_stage_a', 0)}",
+        "",
+        "## Stage A — per-rule threshold noise (mean over cells, t>=20)",
+        "",
+        "| rule | mean sd(threshold) | mean spike_rate |",
+        "|---|---|---|",
+    ]
+    for r in summary.get("stage_a_by_rule", []):
+        lines.append(f"| {r['rule']} | {r['mean_sd_threshold']:.4f} | {r['mean_spike_rate']:.4f} |")
+    lines += ["", "_Verdict per the plan's decision rules is filled in once the full Grid run lands._", ""]
+    (common.RESULTS / "REPORT.md").write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/threshold_stability/common.py
+++ b/scripts/experiments/threshold_stability/common.py
@@ -1,0 +1,54 @@
+"""Shared setup for the threshold-stability cluster experiment (issue #2790).
+
+Every stage imports this and calls :func:`setup_env` before importing anything
+under ``vtscore``. Mirrors the calibration / max_patch runners: point vtscore + HF
+at the experiment dirs, put the worktree on ``sys.path``, and neutralise the main
+venv's editable-install finder so ``import vtscore`` resolves to *this* branch.
+
+CPU-only: no models are downloaded (the SigLIP 2 embeddings are read from the
+reused #2790 cache), so this study needs no GPU partition.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+USER = os.environ.get("USER", "sgreenberg")
+REPO = Path(os.environ.get("VTS_REPO", f"/exp/{USER}/projects/vts-evalfw"))
+EXP = Path(os.environ.get("THRSTAB_EXP", f"/exp/{USER}/threshold-stability"))
+RESULTS = Path(os.environ.get("THRSTAB_RESULTS", str(EXP / "results")))
+#: The reused #2790 SigLIP 2 / whole embedding cache (see the plan). Defaults to the
+#: sweep's own cache dir; override with THRSTAB_CACHE_DIR to point at the real run.
+CACHE_DIR = Path(os.environ.get("THRSTAB_CACHE_DIR", str(EXP / "cache")))
+WARM_HF = f"/exp/{USER}/.cache/huggingface"
+
+
+def setup_env() -> None:
+    os.environ.setdefault("VTSEARCH_DATA_DIR", str(EXP / "datadir"))
+    os.environ.setdefault("VTSEARCH_MODELS_DIR", str(EXP / "models"))
+    os.environ.setdefault("HF_HOME", WARM_HF if Path(WARM_HF).exists() else str(EXP / "hf"))
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    for var in ("VTSEARCH_DATA_DIR", "VTSEARCH_MODELS_DIR", "HF_HOME"):
+        Path(os.environ[var]).mkdir(parents=True, exist_ok=True)
+    RESULTS.mkdir(parents=True, exist_ok=True)
+    if str(REPO) not in sys.path:
+        sys.path.insert(0, str(REPO))
+    _neutralise_editable_finder()
+
+
+def _neutralise_editable_finder() -> None:
+    """Drop the main venv's ``__editable__.vtsearch`` meta-path finder, if present."""
+    keep = []
+    for finder in sys.meta_path:
+        mod = type(finder).__module__ or ""
+        name = f"{mod}.{type(finder).__name__}".lower()
+        if "editable" in name and ("vtsearch" in name or "vtscore" in name):
+            continue
+        keep.append(finder)
+    sys.meta_path[:] = keep
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)

--- a/scripts/experiments/threshold_stability/experiment_config.py
+++ b/scripts/experiments/threshold_stability/experiment_config.py
@@ -1,0 +1,62 @@
+"""Pre-registered grid for the threshold-stability study (issue #2790).
+
+One place the runner and the analyzer agree on. See
+``docs/plans/threshold-stability-experiment.md`` (on ``dev``) for the design and
+``scripts/sod/THRESHOLD_STABILITY_STATUS.md`` for the plan-vs-reality reframe (the
+sweep's default ``argmin`` rule is the *infidelity*; the ``conformal`` rule is what
+production Autopilot actually runs).
+
+Six arms A/B the whole/box-pool path's threshold rule + smoothing + fold count, on
+the #2790 config (COCO, SigLIP 2, ``whole``, ``--neg-multiple 100``,
+``--min-box-frac 0.03``). Each arm is a set of ``sweep.py`` flags; a cell is one
+``(class, seed)`` and runs **every arm** inside it, sharing the embedding cache so
+the arms are paired on identical data and the same startup exemplar. CPU-only —
+the embeddings come from the #2790 cache, and the MLPs are tiny.
+"""
+
+from __future__ import annotations
+
+import os
+
+# --- Fixed #2790 repro config (pre-registered) ---
+DATASET = os.environ.get("THRSTAB_DATASET", "coco")
+EMBEDDER = os.environ.get("THRSTAB_EMBEDDER", "siglip2")  # user OK'd SigLIP 1 <-> 2 either way
+PROPOSAL = "whole"
+MAX_LABELS = int(os.environ.get("THRSTAB_MAX_LABELS", "60"))
+NEG_MULTIPLE = int(os.environ.get("THRSTAB_NEG_MULTIPLE", "100"))
+MIN_BOX_FRAC = os.environ.get("THRSTAB_MIN_BOX_FRAC", "0.03")
+INCLUSION = int(os.environ.get("THRSTAB_INCLUSION", "0"))
+
+# --- Sizing (variance is the measurand, so more seeds than the plots' 3) ---
+CLASSES = os.environ.get("THRSTAB_CLASSES", "stop sign,traffic light,fire hydrant,parking meter,bus").split(",")
+SEEDS = list(range(int(os.environ.get("THRSTAB_N_SEEDS", "10"))))
+
+#: Each arm: (name, threshold_rule, threshold_smooth, calibrate_count). ``argmin-k2``
+#: is the status quo baseline whose trace Stage A replays; the rest isolate one
+#: factor each (rule = S1, fold count = S2, med3 = temporal hysteresis, and
+#: rank-transfer = the S3 fold->final scale probe, applied by the replay tool).
+ARMS: list[tuple[str, str, str, int]] = [
+    ("argmin-k2", "argmin", "none", 2),
+    ("argmin-k8", "argmin", "none", 8),
+    ("conformal-k2", "conformal", "none", 2),
+    ("conformal-k8", "conformal", "none", 8),
+    ("conformal-k2-med3", "conformal", "med3", 2),
+    ("rank-transfer-k2", "rank-transfer", "none", 2),
+]
+
+#: The baseline arm whose recorded --labeling-trace Stage A replays (frozen votes).
+BASELINE_ARM = "argmin-k2"
+
+#: Stage A replay depth (fold-split seeds × trainer seeds), per the plan.
+REPLAY_FOLD_SEEDS = int(os.environ.get("THRSTAB_REPLAY_FOLD_SEEDS", "10"))
+REPLAY_TRAINER_SEEDS = int(os.environ.get("THRSTAB_REPLAY_TRAINER_SEEDS", "10"))
+
+
+def class_slug(cls: str) -> str:
+    """Filesystem-safe class slug matching the sweep's own slugging."""
+    return cls.strip().replace(" ", "_").replace("/", "-")
+
+
+def array_cells() -> list[dict]:
+    """Enumerate ``(class, seed)`` cells for the SLURM array (stable order)."""
+    return [{"cls": cls, "seed": seed} for cls in CLASSES for seed in SEEDS]

--- a/scripts/experiments/threshold_stability/launch_all.sh
+++ b/scripts/experiments/threshold_stability/launch_all.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Threshold-stability study (#2790) full pipeline on the HLTCOE Grid.
+#
+# CPU-only: reuses the #2790 SigLIP 2 / whole embedding cache (point THRSTAB_CACHE_DIR
+# at it), so no prepare/GPU stage is needed — the sweep reads vectors from the cache
+# and trains only tiny MLPs. If the cache is incomplete, pre-populate it with one
+# GPU sweep run first (see scripts/sod/README.md), then run this.
+#
+# Usage:
+#   export VTS_REPO=/exp/$USER/projects/vts-evalfw
+#   export THRSTAB_CACHE_DIR=/exp/$USER/threshold-stability/cache   # the reused #2790 cache
+#   bash launch_all.sh
+set -uo pipefail
+
+WT="${VTS_REPO:-/exp/$USER/projects/vts-evalfw}"
+exec bash "$WT/scripts/experiments/threshold_stability/launch_cells.sh"

--- a/scripts/experiments/threshold_stability/launch_cells.sh
+++ b/scripts/experiments/threshold_stability/launch_cells.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Threshold-stability study (#2790) SLURM array: one CPU task per (class, seed),
+# all arms inside, then the Stage-A replay. No GPU — the SigLIP 2 / whole
+# embeddings are read from the reused #2790 cache (THRSTAB_CACHE_DIR), so a fully
+# cached run never touches a model. If the cache is incomplete the sweep will try
+# to embed (needs a GPU); pre-populate the cache first.
+#
+# Usage: bash launch_cells.sh   (after exporting THRSTAB_* + VTS_REPO)
+set -uo pipefail
+
+WT="${VTS_REPO:-/exp/$USER/projects/vts-evalfw}"
+HERE="$WT/scripts/experiments/threshold_stability"
+export THRSTAB_EXP="${THRSTAB_EXP:-/exp/$USER/threshold-stability}"
+export THRSTAB_RESULTS="${THRSTAB_RESULTS:-$THRSTAB_EXP/results}"
+export THRSTAB_CACHE_DIR="${THRSTAB_CACHE_DIR:-$THRSTAB_EXP/cache}"
+LOGS="$THRSTAB_EXP/logs"
+mkdir -p "$LOGS" "$THRSTAB_RESULTS/cells"
+
+MEM="${THRSTAB_MEM:-16G}"
+CPUS="${THRSTAB_CPUS:-4}"
+TIME="${THRSTAB_TIME:-4:00:00}"
+CONC="${THRSTAB_CONC:-16}"
+PART="${THRSTAB_PARTITION:-cpu}"
+
+ENVX="export THRSTAB_EXP=$THRSTAB_EXP THRSTAB_RESULTS=$THRSTAB_RESULTS THRSTAB_CACHE_DIR=$THRSTAB_CACHE_DIR VTS_REPO=$WT"
+
+N=$(cd "$HERE" && eval "$ENVX"; python run_cells.py --print-cells 2>/dev/null | tail -1)
+if ! [[ "$N" =~ ^[0-9]+$ ]] || [[ "$N" -eq 0 ]]; then
+  echo "ERROR: could not determine cell count (got '$N')" >&2
+  exit 1
+fi
+echo "cells to run: $N (array 0-$((N-1))%$CONC, partition=$PART)"
+
+B=$(sbatch --parsable --job-name=thrstab-cells --array=0-$((N-1))%$CONC \
+  --mem="$MEM" --cpus-per-task="$CPUS" --time="$TIME" --partition="$PART" \
+  --export=ALL --output="$LOGS/cells-%A_%a.out" \
+  --wrap="source $WT/gridenv.sh && $ENVX && cd $HERE && python run_cells.py")
+echo "cells array: $B"
+
+A=$(sbatch --parsable --dependency=afterany:$B --job-name=thrstab-analyze --mem=8G \
+  --cpus-per-task=2 --time=0:30:00 --partition="$PART" \
+  --export=ALL --output="$LOGS/analyze-%j.out" \
+  --wrap="source $WT/gridenv.sh && $ENVX && cd $HERE && python analyze.py")
+echo "analyze: $A"
+echo "Report -> $THRSTAB_RESULTS/REPORT.md   Logs -> $LOGS"

--- a/scripts/experiments/threshold_stability/run_cells.py
+++ b/scripts/experiments/threshold_stability/run_cells.py
@@ -1,0 +1,148 @@
+"""Threshold-stability study: one SLURM-array task per ``(class, seed)`` (issue #2790).
+
+Each task runs **all arms** for its cell (they share the SigLIP 2 / whole embedding
+cache, so arms are paired on identical data + startup exemplar), then replays the
+baseline arm's frozen trace for the Stage A variance decomposition:
+
+* **Stage B (live loop)** — one ``scripts/sod/sweep.py`` run per arm, with that arm's
+  ``--threshold-rule`` / ``--threshold-smooth`` / ``--calibrate-count`` and
+  ``--labeling-trace``, into a per-arm out-dir. Includes selection feedback (S5).
+* **Stage A (frozen replay)** — ``scripts/sod/replay_thresholds.py`` over the
+  ``argmin-k2`` baseline trace, recomputing every arm's rule on the frozen votes
+  (exactly paired; no S5). CPU-only, reuses the cache.
+
+Run directly with ``--index N`` for one cell, or via SLURM with
+``$SLURM_ARRAY_TASK_ID``; ``--print-cells`` prints the count for the array sizing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import common
+
+common.setup_env()
+
+import experiment_config as cfg  # noqa: E402
+
+SOD = common.REPO / "scripts" / "sod"
+
+
+def _sweep_cmd(cls: str, seed: int, arm: tuple[str, str, str, int], out_dir: Path) -> list[str]:
+    _name, rule, smooth, kcount = arm
+    return [
+        sys.executable,
+        str(SOD / "sweep.py"),
+        "--datasets",
+        cfg.DATASET,
+        "--classes",
+        cls,
+        "--embedders",
+        cfg.EMBEDDER,
+        "--proposals",
+        cfg.PROPOSAL,
+        "--iterations",
+        str(seed + 1),  # sweep seeds 0..N-1; run just this seed's row via array
+        "--max-labels",
+        str(cfg.MAX_LABELS),
+        "--neg-multiple",
+        str(cfg.NEG_MULTIPLE),
+        "--min-box-frac",
+        str(cfg.MIN_BOX_FRAC),
+        "--inclusion",
+        str(cfg.INCLUSION),
+        "--calibrate-count",
+        str(kcount),
+        "--threshold-rule",
+        rule,
+        "--threshold-smooth",
+        smooth,
+        "--cache-dir",
+        str(common.CACHE_DIR),
+        "--out-dir",
+        str(out_dir),
+        "--labeling-trace",
+    ]
+
+
+def _replay_cmd(cls: str, trace_dir: Path, out_csv: Path) -> list[str]:
+    return [
+        sys.executable,
+        str(SOD / "replay_thresholds.py"),
+        "--trace-dir",
+        str(trace_dir),
+        "--cache-dir",
+        str(common.CACHE_DIR),
+        "--dataset",
+        cfg.DATASET,
+        "--embedder",
+        cfg.EMBEDDER,
+        "--class-slug",
+        cfg.class_slug(cls),
+        "--proposal-slug",
+        cfg.PROPOSAL,
+        "--rules",
+        "argmin,conformal,rank-transfer",
+        "--fold-seeds",
+        str(cfg.REPLAY_FOLD_SEEDS),
+        "--trainer-seeds",
+        str(cfg.REPLAY_TRAINER_SEEDS),
+        "--inclusion",
+        str(cfg.INCLUSION),
+        "--out",
+        str(out_csv),
+    ]
+
+
+def _run(cmd: list[str]) -> int:
+    common.log("$ " + " ".join(cmd))
+    return subprocess.run(cmd, check=False).returncode  # noqa: S603 - fixed argv, no shell
+
+
+def run_cell(cell: dict) -> None:
+    cls, seed = cell["cls"], cell["seed"]
+    cell_dir = common.RESULTS / "cells" / f"{cfg.class_slug(cls)}__seed{seed}"
+    cell_dir.mkdir(parents=True, exist_ok=True)
+
+    baseline_trace: Path | None = None
+    for arm in cfg.ARMS:
+        name = arm[0]
+        out_dir = cell_dir / f"arm_{name}"
+        _run(_sweep_cmd(cls, seed, arm, out_dir))
+        # The sweep writes labeling_trace/<slug>/<config>/seed<seed>/; find this seed's dir.
+        traces = sorted(out_dir.glob(f"labeling_trace/*/*/seed{seed}"))
+        if name == cfg.BASELINE_ARM and traces:
+            baseline_trace = traces[0]
+
+    if baseline_trace is not None:
+        _run(_replay_cmd(cls, baseline_trace, cell_dir / "replay.csv"))
+    else:
+        common.log(f"WARN: no baseline trace for {cls} seed{seed}; Stage A replay skipped")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Threshold-stability: one cell (class, seed).")
+    ap.add_argument("--index", type=int, default=None, help="Cell index; defaults to $SLURM_ARRAY_TASK_ID.")
+    ap.add_argument("--print-cells", action="store_true")
+    args = ap.parse_args(argv)
+
+    cells = cfg.array_cells()
+    if args.print_cells:
+        print(len(cells))
+        return 0
+    idx = args.index if args.index is not None else int(os.environ.get("SLURM_ARRAY_TASK_ID", "0"))
+    if idx >= len(cells):
+        common.log(f"index {idx} >= {len(cells)} cells; nothing to do")
+        return 0
+    cell = cells[idx]
+    common.log(f"cell {idx}/{len(cells)}: class={cell['cls']!r} seed={cell['seed']} arms={[a[0] for a in cfg.ARMS]}")
+    run_cell(cell)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sod/THRESHOLD_STABILITY_STATUS.md
+++ b/scripts/sod/THRESHOLD_STABILITY_STATUS.md
@@ -52,32 +52,34 @@ Consequence to confirm before Stage B: porting the conformal rule changes the
   - Tests: `tests_lib/sorting/test_replay_thresholds.py` (5, all pass) — order,
     dedup, per-step rows, med3 = median of last 3, decomposition.
 
-172/172 `tests_lib/sorting` pass; ruff/codespell clean.
+- **Stage B live-loop wiring** (owner confirmed the reframe): `sweep.py` gains
+  `--threshold-rule {argmin,conformal,rank-transfer}` + `--threshold-smooth {none,med3}`,
+  threaded through `evaluate_realistic_curve` → `_realistic_one_seed` →
+  `_resolve_step_head` → `_train_pool_head`, where the whole/box-pool threshold now
+  dispatches through `calibrated_threshold`. med3 smoothing + per-step diagnostic
+  trace columns (`delta_threshold`, `spike`, `regret`, `threshold_rule`) added.
+  **Default `argmin`/`none` is byte-identical** — all 42 `test_region_curve.py` pass.
+- **CPU Grid runner** `scripts/experiments/threshold_stability/` — `experiment_config`
+  (6 arms × 5 classes × 10 seeds = 50 cells), `common`, `run_cells` (Stage B sweep
+  per arm + Stage A replay of the baseline trace), `launch_all.sh`/`launch_cells.sh`
+  (CPU, no gres), `analyze.py`, `README.md`. Reuses the #2790 SigLIP2/whole cache.
 
-## Remaining work (owner-gated)
+63 targeted tests pass (16 rules + 5 replay + 42 region_curve); 172/172 sorting-lib;
+ruff/codespell clean on all new files.
 
-1. **Validate `CacheVectorLoader` against one real cell** — confirm the whole-path
-   pooling in `region_curve.py::_train_pool_head` (all exemplar rows vs first) and
-   the `final_pool_scores` source for rank-transfer. Isolated to one class so this
-   is a one-file edit.
-2. **Port the conformal rule into the live loop (Stage B)** — add
-   `--threshold-rule {argmin,conformal,rank-transfer}` + `--threshold-smooth {none,med3}`
-   to `sweep.py`, wire `calibrated_threshold` into `region_curve.py:713` (whole) and
-   the rv path; default `argmin`/`none` = byte-identical. Add the per-step diagnostic
-   trace columns (`delta_threshold`, `spike`, `regret`, per-fold thresholds,
-   `n_folds_used/skipped`) to the trace dict (`region_curve.py:1015`) + csv writer
-   (`viz.py:847`). Confirm the plan reframe first (see decisions).
-3. **Runner** `scripts/experiments/threshold_stability/` — copy the `max_patch/`
-   template (**CPU-only**, drop the gpu gres): `experiment_config.py` (6 arms ×
-   5 classes × 10 seeds; `THRSTAB_*` env knobs), `common.py`, `run_cells.py`
-   (one array cell per (class, seed), all arms inside, both stages), `launch_all.sh`
-   /`launch_cells.sh`, `analyze.py`. Reuse the #2790 SigLIP2/whole cache in
-   `docs/experiments/sod-sweep/cache` as-is (no re-embed).
-4. **Run + report** → `docs/experiments/threshold-stability/REPORT.md`, verdict via
-   the plan's decision rules.
+## Remaining work (owner-gated, needs the Grid)
 
-## Open decisions for the owner
-- PR target: this repo's policy is "all PRs → `dev`", but this harness only exists
-  on `evaluation-framework`. Where should this branch land?
-- Confirm the plan reframe (argmin = infidelity, conformal = production Autopilot)
-  before wiring Stage B, since it changes what the arms mean.
+1. **Validate `CacheVectorLoader` on one real cell** — confirm the whole-path vote→vector
+   assembly matches `_train_pool_head` (all exemplar rows vs first; the `final_pool_scores`
+   source for rank-transfer) before the full 50-cell launch. One-file edit.
+2. **Region-voting path conformal** — the rv/`train_rv_head` grouped path still
+   calibrates via argmin; wiring the conformal rule there needs grouped stratified
+   folds (a separate, larger port). The whole path — the #2790 case — is done.
+3. **Run + report** → `docs/experiments/threshold-stability/REPORT.md`, verdict via the
+   plan's decision rules. `analyze.py` scaffolds the aggregation.
+
+## Notes for the merge
+- PR **#2795** targets `evaluation-framework` (owner's call).
+- `./run-tests.sh` runs a pyright gate; `scripts/sod/sweep.py` carries **pre-existing**
+  pyright optional-member warnings (lines ~179-192, the `_sod_orig_*` PIL monkey-patch)
+  unrelated to this change — surfaced but not introduced here.

--- a/scripts/sod/THRESHOLD_STABILITY_STATUS.md
+++ b/scripts/sod/THRESHOLD_STABILITY_STATUS.md
@@ -1,0 +1,83 @@
+# Threshold-stability study (#2790) — build status & handoff
+
+Branch `claude/threshold-stability-2790` off `evaluation-framework`. This is the
+harness half of the pre-registered study in `docs/plans/threshold-stability-experiment.md`
+(on `dev`). Real runs are Grid-gated (no GPU/COCO/SigLIP cache on the laptop), so
+what landed here is **code + offline synthetic-data tests + Grid staging**; the
+Grid run and report are the remaining owner-gated work.
+
+## Headline finding — plan vs. reality (read first)
+
+The plan says the sweep's region-voting path "already uses the production conformal
+rule (`cross_calibration_threshold_cached`)." **On this branch it does not.**
+`evaluation-framework` predates #2784, so *both* threshold paths reduce to
+`find_optimal_threshold` = min-cost **argmin**:
+
+- whole / box-pool path → `vtscore/eval/xcal.py::cross_calibrated_threshold` (argmin, unstratified folds)
+- region-voting path → `cross_calibration_threshold_cached` → `threshold_from_fold_orderings` → per-fold argmin
+
+The split-conformal quantile + gap-midpoint rule (#2784) that **production Autopilot
+actually runs** is absent here. Per the owner's steering ("match a simulation of
+Autopilot over the plan whenever they conflict"), the `conformal` arm is the
+*fidelity-correct* behaviour and the current `argmin` arm is the *infidelity*. The
+study therefore measures whether making the sim match the app kills the #2790
+threshold jumps — a cleaner framing than the plan's.
+
+Consequence to confirm before Stage B: porting the conformal rule changes the
+**region-voting** path too (it also uses argmin here), not just the whole path.
+
+## What landed (tested)
+
+- `vtscore/eval/threshold_rules.py` — selectable rules, head-agnostic, Flask-free:
+  - `conformal_threshold(scores, labels, k)` — **verbatim port** of dev's #2784 rule
+    (constants `CONFORMAL_BASE_BUDGET=0.25`, `CONFORMAL_QPOS_MAX=0.75`).
+  - `stratified_fold_orderings(...)` — class-stratified folds (never single-class;
+    the guard the argmin path lacks → plan S4), returns pooled held-out orderings.
+  - `calibrated_threshold(..., rule=)` — dispatch: `argmin` delegates **byte-identically**
+    to `xcal.cross_calibrated_threshold`; `conformal`/`rank-transfer` pool stratified
+    folds and apply `conformal_threshold`.
+  - `rank_transfer_cut(cut, fold_scores, final_scores)` — S3 scale-mismatch probe.
+  - `median_smooth(history, window=3)` — the `med3` temporal fix.
+  - Tests: `tests_lib/sorting/test_threshold_rules.py` (16, all pass) — gap-midpoint
+    below every positive on a separated task, monotone in inclusion, argmin≡xcal,
+    stratified folds never single-class, med3, rank-transfer.
+- `scripts/sod/replay_thresholds.py` — **Stage A** frozen-trace replay:
+  - Pure core (cache-free, tested): `reconstruct_vote_sets` (accumulate frozen
+    good/bad ids from the trace order), `replay_step_thresholds` (recompute the
+    threshold per step × rule × fold-seed × trainer-seed over an injected loader),
+    `decompose_variance` (per-(rule,t) `sd_threshold`, `spike_rate`, med3 means).
+  - `CacheVectorLoader` — reads frozen vote vectors from the npz FeatureCache
+    (`regions/.../<id>.npz::whole_vec` for bad, globbed `exemplars/.../<id>_*.npz`
+    for good). **VALIDATE-ON-GRID** (see below).
+  - Tests: `tests_lib/sorting/test_replay_thresholds.py` (5, all pass) — order,
+    dedup, per-step rows, med3 = median of last 3, decomposition.
+
+172/172 `tests_lib/sorting` pass; ruff/codespell clean.
+
+## Remaining work (owner-gated)
+
+1. **Validate `CacheVectorLoader` against one real cell** — confirm the whole-path
+   pooling in `region_curve.py::_train_pool_head` (all exemplar rows vs first) and
+   the `final_pool_scores` source for rank-transfer. Isolated to one class so this
+   is a one-file edit.
+2. **Port the conformal rule into the live loop (Stage B)** — add
+   `--threshold-rule {argmin,conformal,rank-transfer}` + `--threshold-smooth {none,med3}`
+   to `sweep.py`, wire `calibrated_threshold` into `region_curve.py:713` (whole) and
+   the rv path; default `argmin`/`none` = byte-identical. Add the per-step diagnostic
+   trace columns (`delta_threshold`, `spike`, `regret`, per-fold thresholds,
+   `n_folds_used/skipped`) to the trace dict (`region_curve.py:1015`) + csv writer
+   (`viz.py:847`). Confirm the plan reframe first (see decisions).
+3. **Runner** `scripts/experiments/threshold_stability/` — copy the `max_patch/`
+   template (**CPU-only**, drop the gpu gres): `experiment_config.py` (6 arms ×
+   5 classes × 10 seeds; `THRSTAB_*` env knobs), `common.py`, `run_cells.py`
+   (one array cell per (class, seed), all arms inside, both stages), `launch_all.sh`
+   /`launch_cells.sh`, `analyze.py`. Reuse the #2790 SigLIP2/whole cache in
+   `docs/experiments/sod-sweep/cache` as-is (no re-embed).
+4. **Run + report** → `docs/experiments/threshold-stability/REPORT.md`, verdict via
+   the plan's decision rules.
+
+## Open decisions for the owner
+- PR target: this repo's policy is "all PRs → `dev`", but this harness only exists
+  on `evaluation-framework`. Where should this branch land?
+- Confirm the plan reframe (argmin = infidelity, conformal = production Autopilot)
+  before wiring Stage B, since it changes what the arms mean.

--- a/scripts/sod/replay_thresholds.py
+++ b/scripts/sod/replay_thresholds.py
@@ -1,0 +1,352 @@
+"""Stage A of the threshold-stability study (#2790): frozen-trace threshold replay.
+
+Records nothing itself — it *consumes* a run's ``--labeling-trace`` output plus the
+run's npz feature cache, and at every labeling step ``t`` re-derives the decision
+threshold under each candidate rule (``argmin`` / ``conformal`` / ``rank-transfer``,
+optionally med3-smoothed) over the **frozen** vote set at that step. Because the
+votes are frozen, arms and RNG seeds are exactly paired, so the step-to-step
+variance decomposes:
+
+* variance across **fold-split seeds** at fixed ``t`` → split noise (plan S2/S4);
+* variance across **trainer seeds** at fixed ``(t, split)`` → fold-fit noise (S3);
+* ``Δthreshold`` across adjacent ``t`` at fixed seeds → label-increment sensitivity;
+* rule differences at identical inputs → the fidelity gap (S1: argmin vs the
+  conformal rule production Autopilot actually runs).
+
+Replay cannot see selection feedback (S5) — the vote *sequence* is fixed by the
+recorded trace — so it brackets the effect together with the live-loop Stage B; it
+is the cheap, exactly-paired half.
+
+**Two layers, so the science is testable without the cache.** The pure core
+(:func:`reconstruct_vote_sets`, :func:`replay_step_thresholds`,
+:func:`decompose_variance`) is model-/cache-free and unit-tested on synthetic
+traces. The cache glue (:class:`CacheVectorLoader`) reads the run's npz feature
+cache written by ``scripts/sod/features.py`` and is the one piece that must be
+validated against a real cache on the Grid (there is no cache on a laptop). It is
+injected into the core as a ``vote_vectors`` callable so the two never entangle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+# scripts/sod is import-pathed as a package sibling of vtscore on the sweep venv.
+from vtscore.eval.threshold_rules import RULES, calibrated_threshold, median_smooth, rank_transfer_cut
+
+#: A per-step frozen vote set: the good/bad image ids accumulated through step t.
+VoteSet = tuple[list[int], list[int]]
+
+#: Loader contract: given the good/bad image ids voted so far, return the training
+#: matrices ``(X, y)`` exactly as the live loop's ``_train_pool_head`` builds them
+#: for the whole/box-pool path (pos = each good image's exemplar rows, neg = each
+#: bad image's whole vector), plus the final-model pool scores for rank-transfer.
+VoteVectorsFn = Callable[[list[int], list[int]], "StepVectors | None"]
+
+
+@dataclass
+class StepVectors:
+    """Frozen training inputs for one replay step."""
+
+    X: np.ndarray
+    y: np.ndarray
+    #: The whole-image score pool for the current model over the ranking pool,
+    #: used only by ``rank-transfer`` (may be empty → rank-transfer == conformal).
+    final_pool_scores: np.ndarray = field(default_factory=lambda: np.empty(0))
+
+
+def reconstruct_vote_sets(trace_rows: Sequence[dict]) -> list[tuple[int, VoteSet]]:
+    """Accumulate the frozen ``(good_ids, bad_ids)`` vote set at each labeled step.
+
+    The recorded trace has one row per labeled item, in labeling order, each with
+    an ``image_id`` and a ``gt_label`` (``"good"``/``"bad"`` or 1/0). One item is
+    revealed per step, so the vote set at step ``t`` is every item labeled at rows
+    ``<= t``. Returns ``[(t, (good_ids, bad_ids)), ...]`` in step order. Rows are
+    read in the order given (the trace is already ordered); a missing/duplicate
+    ``image_id`` is tolerated (dedup keeps first vote for an id).
+    """
+    good: list[int] = []
+    bad: list[int] = []
+    seen: set[int] = set()
+    out: list[tuple[int, VoteSet]] = []
+    for row in trace_rows:
+        iid = int(row["image_id"])
+        label = row.get("gt_label")
+        is_good = label in (1, 1.0, "good", "1", "True", True)
+        if iid not in seen:
+            seen.add(iid)
+            (good if is_good else bad).append(iid)
+        t = int(row.get("t", len(out)))
+        out.append((t, (list(good), list(bad))))
+    return out
+
+
+def replay_step_thresholds(
+    vote_sets: Sequence[tuple[int, VoteSet]],
+    vote_vectors: VoteVectorsFn,
+    trainer_fn_factory: Callable[[], Callable],
+    *,
+    rules: Sequence[str] = RULES,
+    fold_seeds: Sequence[int] = tuple(range(10)),
+    trainer_seeds: Sequence[int] = (0,),
+    inclusion_value: int = 0,
+    calibrate_count: int = 2,
+    cal_fraction: float = 0.5,
+    smooth: str = "none",
+) -> list[dict]:
+    """Recompute the threshold at every step × rule × fold-seed × trainer-seed.
+
+    ``vote_vectors(good_ids, bad_ids)`` supplies the frozen ``StepVectors`` for a
+    step (``None`` → the step is skipped, e.g. a cold-start step with no trained
+    head). ``trainer_fn_factory()`` returns a fresh ``trainer_fn`` (``(X, y, seed)
+    -> predict``); the ``argmin``/``conformal`` fold machinery drives it.
+    ``fold_seeds`` vary the split RNG (isolating split noise); ``trainer_seeds``
+    are folded into the fold RNG offset (isolating fit noise). With
+    ``smooth="med3"`` each (rule, fold_seed, trainer_seed) trajectory is passed
+    through :func:`median_smooth` over its own raw-threshold history.
+
+    Returns one row per (t, rule, fold_seed, trainer_seed) with ``threshold`` (raw)
+    and ``threshold_smoothed``; :func:`decompose_variance` aggregates these.
+    """
+    # Per-trajectory raw-threshold history, keyed by (rule, fold_seed, trainer_seed).
+    history: dict[tuple[str, int, int], list[float]] = {}
+    rows: list[dict] = []
+    for t, (good_ids, bad_ids) in vote_sets:
+        sv = vote_vectors(good_ids, bad_ids)
+        if sv is None:
+            continue
+        for rule in rules:
+            for fs in fold_seeds:
+                for ts in trainer_seeds:
+                    trainer_fn = trainer_fn_factory()
+                    raw = calibrated_threshold(
+                        sv.X,
+                        sv.y,
+                        trainer_fn,
+                        seed=fs * 1000 + ts,
+                        rule=rule,
+                        inclusion_value=inclusion_value,
+                        calibrate_count=calibrate_count,
+                        cal_fraction=cal_fraction,
+                    )
+                    if rule == "rank-transfer" and sv.final_pool_scores.size:
+                        # Map the conformal cut into the final model's score pool.
+                        pooled = _pooled_fold_scores(
+                            sv, trainer_fn_factory(), fs * 1000 + ts, calibrate_count, cal_fraction
+                        )
+                        raw = rank_transfer_cut(raw, pooled, sv.final_pool_scores)
+                    key = (rule, fs, ts)
+                    hist = history.setdefault(key, [])
+                    hist.append(float(raw))
+                    smoothed = median_smooth(hist) if smooth == "med3" else float(raw)
+                    rows.append(
+                        {
+                            "t": t,
+                            "rule": rule,
+                            "fold_seed": fs,
+                            "trainer_seed": ts,
+                            "threshold": float(raw),
+                            "threshold_smoothed": float(smoothed),
+                            "n_good": len(good_ids),
+                            "n_bad": len(bad_ids),
+                        }
+                    )
+    return rows
+
+
+def _pooled_fold_scores(
+    sv: StepVectors, trainer_fn: Callable, seed: int, calibrate_count: int, cal_fraction: float
+) -> list[float]:
+    """Pooled held-out fold scores for rank-transfer's source distribution."""
+    from vtscore.eval.threshold_rules import stratified_fold_orderings  # noqa: PLC0415
+
+    orderings = stratified_fold_orderings(
+        sv.X, sv.y, trainer_fn, seed, calibrate_count=calibrate_count, cal_fraction=cal_fraction
+    )
+    return [s for scores, _ in orderings for s in scores]
+
+
+def decompose_variance(rows: Sequence[dict], *, warmup_t: int = 20, spike_delta: float = 0.1) -> list[dict]:
+    """Aggregate replay rows into the pre-registered per-(rule, t) variance stats.
+
+    For each (rule, t) past ``warmup_t`` (the GMM ramp), reports:
+
+    * ``sd_threshold`` — spread of the raw threshold across all fold/trainer seeds
+      (the paired threshold noise the study wants shrunk);
+    * ``mean_threshold`` / ``mean_threshold_smoothed``;
+    * ``spike_rate`` — fraction of seeds whose ``|Δthreshold|`` from the previous
+      ``t`` exceeds ``spike_delta`` (single-step excursions, #2790's symptom).
+
+    ``Δthreshold`` is computed within a (fold_seed, trainer_seed) trajectory so it
+    measures label-increment sensitivity, not cross-seed spread.
+    """
+    import statistics  # noqa: PLC0415
+
+    by_rt: dict[tuple[str, int], list[dict]] = {}
+    for r in rows:
+        by_rt.setdefault((r["rule"], r["t"]), []).append(r)
+
+    # Previous-t threshold per trajectory, for Δ / spike computation.
+    prev: dict[tuple[str, int, int], float] = {}
+    out: list[dict] = []
+    for (rule, t), group in sorted(by_rt.items()):
+        thrs = [g["threshold"] for g in group]
+        spikes = 0
+        for g in group:
+            key = (g["rule"], g["fold_seed"], g["trainer_seed"])
+            if key in prev and abs(g["threshold"] - prev[key]) > spike_delta:
+                spikes += 1
+            prev[key] = g["threshold"]
+        if t < warmup_t:
+            continue
+        out.append(
+            {
+                "rule": rule,
+                "t": t,
+                "n_seeds": len(group),
+                "mean_threshold": statistics.fmean(thrs),
+                "sd_threshold": statistics.pstdev(thrs) if len(thrs) > 1 else 0.0,
+                "mean_threshold_smoothed": statistics.fmean([g["threshold_smoothed"] for g in group]),
+                "spike_rate": spikes / len(group),
+            }
+        )
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Cache glue — the one Grid-validated layer (no cache exists on a laptop).
+# --------------------------------------------------------------------------- #
+
+
+class CacheVectorLoader:
+    """Reads frozen vote vectors from a run's npz feature cache (whole path).
+
+    Mirrors ``_train_pool_head``'s whole/box-pool assembly using the npz files
+    ``scripts/sod/features.py::FeatureCache`` wrote: a **good** image contributes
+    its exemplar rows (``exemplars/<ds>/<class_slug>/<embedder>/<slug>/<id>_*.npz``,
+    globbed so the gt-box-hash suffix need not be recomputed), a **bad** image
+    contributes its whole vector (``regions/<ds>/<embedder>/<slug>/<id>.npz`` →
+    ``whole_vec``). Reads only cache hits (no image pixels, no embedder, no GPU),
+    so it runs on the Grid over the #2790 SigLIP2/whole cache as-is.
+
+    VALIDATE-ON-GRID: the exact pooling in ``_train_pool_head`` (does a good vote
+    use all exemplar rows or the first?) and the ``final_pool_scores`` source must
+    be confirmed against one real cell before a full launch; this loader implements
+    the documented whole-path shape and is deliberately isolated so that check is a
+    one-file edit. See docs REPORT for the checklist.
+    """
+
+    def __init__(self, cache_dir: Path, dataset: str, embedder: str, class_slug: str, proposal_slug: str = "whole"):
+        self.regions_dir = Path(cache_dir) / "regions" / dataset / embedder / proposal_slug
+        self.exem_dir = Path(cache_dir) / "exemplars" / dataset / class_slug / embedder / proposal_slug
+
+    def _whole_vec(self, image_id: int) -> np.ndarray | None:
+        p = self.regions_dir / f"{image_id}.npz"
+        if not p.exists():
+            return None
+        with np.load(p) as z:
+            return np.asarray(z["whole_vec"], dtype=np.float64)
+
+    def _exemplars(self, image_id: int) -> np.ndarray | None:
+        matches = sorted(self.exem_dir.glob(f"{image_id}_*.npz"))
+        if not matches:
+            return None
+        with np.load(matches[0]) as z:
+            return np.asarray(z["exemplars"], dtype=np.float64)
+
+    def __call__(self, good_ids: list[int], bad_ids: list[int]) -> StepVectors | None:
+        pos_rows = [self._exemplars(i) for i in good_ids]
+        neg_rows = [self._whole_vec(i) for i in bad_ids]
+        pos = [r for r in pos_rows if r is not None]
+        neg = [r.reshape(1, -1) for r in neg_rows if r is not None]
+        if not pos or not neg:
+            return None
+        X = np.concatenate(pos + neg, axis=0)
+        y = np.concatenate([np.ones(sum(len(r) for r in pos)), np.zeros(len(neg))])
+        return StepVectors(X=X, y=y)
+
+
+def _read_trace(seed_dir: Path) -> list[dict]:
+    tj = seed_dir / "trace.json"
+    if tj.exists():
+        return json.loads(tj.read_text())
+    raise FileNotFoundError(f"no trace.json under {seed_dir}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Replay decision thresholds over a frozen labeling trace (#2790).")
+    ap.add_argument("--trace-dir", required=True, help="A .../labeling_trace/<slug>/<config>/seed<N> dir.")
+    ap.add_argument("--cache-dir", required=True)
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--embedder", required=True)
+    ap.add_argument("--class-slug", required=True)
+    ap.add_argument("--proposal-slug", default="whole")
+    ap.add_argument("--rules", default=",".join(RULES))
+    ap.add_argument("--fold-seeds", type=int, default=10)
+    ap.add_argument("--trainer-seeds", type=int, default=10)
+    ap.add_argument("--inclusion", type=int, default=0)
+    ap.add_argument("--calibrate-count", type=int, default=2)
+    ap.add_argument("--smooth", choices=["none", "med3"], default="none")
+    ap.add_argument("--out", required=True, help="Output CSV path for the decomposition.")
+    args = ap.parse_args(argv)
+
+    from vtscore.training.mlp import train_model  # noqa: PLC0415
+
+    def trainer_fn_factory():
+        def trainer_fn(X, y, seed):  # noqa: ARG001 - signature fixed by TrainerFn
+            import torch  # noqa: PLC0415
+
+            model = train_model(
+                torch.tensor(np.asarray(X), dtype=torch.float32),
+                torch.tensor(np.asarray(y), dtype=torch.float32).unsqueeze(1),
+                X.shape[1],
+            )
+
+            def predict(Xc):
+                with torch.no_grad():
+                    return model(torch.tensor(np.asarray(Xc), dtype=torch.float32)).squeeze(-1).numpy()
+
+            return predict
+
+        return trainer_fn
+
+    trace = _read_trace(Path(args.trace_dir))
+    vote_sets = reconstruct_vote_sets(trace)
+    loader = CacheVectorLoader(Path(args.cache_dir), args.dataset, args.embedder, args.class_slug, args.proposal_slug)
+    rows = replay_step_thresholds(
+        vote_sets,
+        loader,
+        trainer_fn_factory,
+        rules=[r for r in args.rules.split(",") if r],
+        fold_seeds=range(args.fold_seeds),
+        trainer_seeds=range(args.trainer_seeds),
+        inclusion_value=args.inclusion,
+        calibrate_count=args.calibrate_count,
+        smooth=args.smooth,
+    )
+    agg = decompose_variance(rows)
+    _write_csv(Path(args.out), agg)
+    print(f"replayed {len(vote_sets)} steps -> {len(rows)} rows -> {len(agg)} (rule,t) cells -> {args.out}")
+    return 0
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    import csv  # noqa: PLC0415
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("")
+        return
+    with path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sod/sweep.py
+++ b/scripts/sod/sweep.py
@@ -455,6 +455,8 @@ def _run_cell(cell: dict, args, cache_root: Path) -> list[dict]:
         retrain_cadence=args.retrain_cadence,
         stop_at_done=args.stop_at_done,
         return_finals=args.viz or args.labeling_trace,
+        threshold_rule=args.threshold_rule,
+        threshold_smooth=args.threshold_smooth,
     )
     rows: list[dict] = []
     if args.viz or args.labeling_trace:
@@ -626,6 +628,11 @@ def main() -> int:
     ap.add_argument("--inclusion", type=int, default=0, help="0=FPR+FNR; >0 favors recall; <0 favors precision")
     ap.add_argument("--safe-thresholds", action=argparse.BooleanOptionalAction, default=True)
     ap.add_argument("--calibrate-count", type=int, default=2)
+    # Threshold-stability arms (#2790): the whole/box-pool path's calibration rule
+    # and an optional temporal smoother. Defaults reproduce the historical sweep
+    # (min-cost argmin, no smoothing) byte-for-byte.
+    ap.add_argument("--threshold-rule", choices=["argmin", "conformal", "rank-transfer"], default="argmin")
+    ap.add_argument("--threshold-smooth", choices=["none", "med3"], default="none")
     ap.add_argument("--cal-fraction", type=float, default=0.5)
     ap.add_argument("--scales", type=_floats, default=(1.0, 0.75, 0.5, 0.3))
     ap.add_argument("--overlap", type=float, default=0.5)

--- a/tests_lib/sorting/test_replay_thresholds.py
+++ b/tests_lib/sorting/test_replay_thresholds.py
@@ -1,0 +1,135 @@
+"""Pure-core tests for the Stage-A threshold replay tool (issue #2790).
+
+Exercise the cache-free layer — vote-set reconstruction, per-step replay over an
+injected vector loader, and the variance decomposition — on synthetic traces, so
+the science is verified with no npz cache, no models, and no GPU (the
+:class:`CacheVectorLoader` glue is Grid-validated separately). The replay import
+lives under ``scripts/sod``; the test adds that dir to ``sys.path`` the same way
+the sweep venv does.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "sod"))
+
+from replay_thresholds import (  # noqa: E402
+    StepVectors,
+    decompose_variance,
+    reconstruct_vote_sets,
+    replay_step_thresholds,
+)
+
+
+def _linear_trainer_factory():
+    def factory():
+        def trainer_fn(X, y, seed):  # noqa: ARG001
+            def predict(Xc):
+                return np.asarray(Xc, dtype=np.float64)[:, 0]
+
+            return predict
+
+        return trainer_fn
+
+    return factory
+
+
+class TestReconstructVoteSets:
+    def test_accumulates_in_labeling_order(self):
+        trace = [
+            {"t": 0, "image_id": 10, "gt_label": "good"},
+            {"t": 1, "image_id": 20, "gt_label": "bad"},
+            {"t": 2, "image_id": 30, "gt_label": "good"},
+        ]
+        vs = reconstruct_vote_sets(trace)
+        assert [t for t, _ in vs] == [0, 1, 2]
+        assert vs[0][1] == ([10], [])
+        assert vs[1][1] == ([10], [20])
+        assert vs[2][1] == ([10, 30], [20])
+
+    def test_accepts_numeric_and_bool_labels_and_dedups(self):
+        trace = [
+            {"t": 0, "image_id": 1, "gt_label": 1},
+            {"t": 1, "image_id": 2, "gt_label": 0.0},
+            {"t": 2, "image_id": 1, "gt_label": 1},  # duplicate id: ignored
+        ]
+        vs = reconstruct_vote_sets(trace)
+        assert vs[-1][1] == ([1], [2])
+
+
+class TestReplayAndDecompose:
+    def _vote_vectors(self):
+        rng = np.random.default_rng(0)
+        # A fixed 1-D-separable embedding per image id, so the injected loader is
+        # deterministic and the linear trainer separates the classes.
+        coord = {i: float(v) for i, v in enumerate(rng.uniform(-2, 2, size=200))}
+
+        def loader(good_ids, bad_ids):
+            if not good_ids or not bad_ids:
+                return None
+            X = np.array([[coord[i] + 1.0] for i in good_ids] + [[coord[i] - 1.0] for i in bad_ids])
+            y = np.array([1.0] * len(good_ids) + [0.0] * len(bad_ids))
+            return StepVectors(X=X, y=y)
+
+        return loader
+
+    def _trace(self, n=30):
+        # Alternate good/bad so both classes appear early; ids unique.
+        return [{"t": t, "image_id": t, "gt_label": "good" if t % 2 == 0 else "bad"} for t in range(n)]
+
+    def test_replay_emits_row_per_step_rule_seed_after_valid_split(self):
+        vs = reconstruct_vote_sets(self._trace())
+        rows = replay_step_thresholds(
+            vs,
+            self._vote_vectors(),
+            _linear_trainer_factory(),
+            rules=["argmin", "conformal"],
+            fold_seeds=range(3),
+            trainer_seeds=range(2),
+            calibrate_count=2,
+        )
+        # Every emitted row carries the identifying keys and a finite threshold.
+        assert rows, "expected replay rows once both classes are present"
+        for r in rows:
+            assert set(r) >= {"t", "rule", "fold_seed", "trainer_seed", "threshold", "threshold_smoothed"}
+            assert np.isfinite(r["threshold"])
+        assert {r["rule"] for r in rows} == {"argmin", "conformal"}
+
+    def test_med3_smoothing_is_median_of_last_three(self):
+        vs = reconstruct_vote_sets(self._trace())
+        rows = replay_step_thresholds(
+            vs,
+            self._vote_vectors(),
+            _linear_trainer_factory(),
+            rules=["conformal"],
+            fold_seeds=[0],
+            trainer_seeds=[0],
+            smooth="med3",
+        )
+        traj = [r["threshold"] for r in rows]
+        smoothed = [r["threshold_smoothed"] for r in rows]
+        # The 3rd+ smoothed value equals the median of the trailing 3 raw values.
+        for i in range(2, len(traj)):
+            assert smoothed[i] == float(np.median(traj[i - 2 : i + 1]))
+
+    def test_decompose_variance_reports_sd_and_spike_rate(self):
+        vs = reconstruct_vote_sets(self._trace(40))
+        rows = replay_step_thresholds(
+            vs,
+            self._vote_vectors(),
+            _linear_trainer_factory(),
+            rules=["conformal"],
+            fold_seeds=range(4),
+            trainer_seeds=[0],
+        )
+        agg = decompose_variance(rows, warmup_t=20)
+        assert agg, "expected aggregated cells past warmup"
+        for a in agg:
+            assert a["t"] >= 20  # warmup filter honored
+            assert a["sd_threshold"] >= 0.0
+            assert 0.0 <= a["spike_rate"] <= 1.0
+            assert a["n_seeds"] == 4

--- a/tests_lib/sorting/test_threshold_rules.py
+++ b/tests_lib/sorting/test_threshold_rules.py
@@ -1,0 +1,165 @@
+"""Unit tests for the selectable threshold rules (issue #2790 threshold-stability).
+
+Pure ``(scores, labels)`` / synthetic-``trainer_fn`` tests — no models, no cache,
+no Flask — so they run in the library tier. They pin the fidelity-critical
+properties of the conformal port and the variance-reducing behaviours the study
+A/Bs: the gap midpoint sits below every calibration positive on a separated task,
+the cut is monotone in inclusion, ``argmin`` stays byte-identical to the sweep's
+current ``xcal`` path, stratified folds never go single-class, and the med3 /
+rank-transfer transforms do what the plan says.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.eval.threshold_rules import (
+    calibrated_threshold,
+    conformal_threshold,
+    median_smooth,
+    rank_transfer_cut,
+    stratified_fold_orderings,
+)
+from vtscore.eval.xcal import cross_calibrated_threshold
+
+
+def _linear_trainer(query: np.ndarray):
+    """A no-op ``trainer_fn`` whose ``predict`` is a fixed linear score ``X @ query``.
+
+    Deterministic and model-free: lets the fold machinery run without training an
+    MLP, so the tests exercise the split/pool/threshold logic in isolation.
+    """
+
+    def trainer_fn(X, y, seed):  # noqa: ARG001 - signature fixed by TrainerFn
+        def predict(Xc):
+            return np.asarray(Xc, dtype=np.float64) @ query
+
+        return predict
+
+    return trainer_fn
+
+
+class TestConformalThreshold:
+    def test_empty_and_single_class_return_half(self):
+        assert conformal_threshold([], []) == 0.5
+        assert conformal_threshold([0.1, 0.2, 0.3], [1.0, 1.0, 1.0]) == 0.5
+        assert conformal_threshold([0.1, 0.2, 0.3], [0.0, 0.0, 0.0]) == 0.5
+
+    def test_gap_midpoint_below_every_positive_when_separated(self):
+        # Cleanly separated: negatives in [0, 0.3], positives in [0.7, 1.0].
+        neg = [0.05, 0.1, 0.2, 0.25, 0.3]
+        pos = [0.7, 0.8, 0.9, 0.95, 1.0]
+        scores = neg + pos
+        labels = [0.0] * len(neg) + [1.0] * len(pos)
+        thr = conformal_threshold(scores, labels, inclusion_value=0)
+        # The k=0 cut is the midpoint of the gap: above the top negative, strictly
+        # below the lowest positive (so no user-voted Good is ever excluded).
+        assert max(neg) < thr < min(pos)
+        # It is the max-margin midpoint, not pinned to the lowest positive.
+        assert thr < min(pos) - 1e-6
+
+    def test_monotone_non_increasing_in_inclusion(self):
+        rng = np.random.default_rng(0)
+        neg = rng.uniform(0.0, 0.5, size=40).tolist()
+        pos = rng.uniform(0.4, 1.0, size=40).tolist()
+        scores = neg + pos
+        labels = [0.0] * len(neg) + [1.0] * len(pos)
+        thrs = [conformal_threshold(scores, labels, inclusion_value=k) for k in range(-10, 11)]
+        # Higher inclusion (larger k) can only lower the cut (include more).
+        for a, b in zip(thrs, thrs[1:], strict=True):
+            assert b <= a + 1e-9
+
+    def test_overlap_regime_collapses_to_fp_guard(self):
+        # Heavy overlap: no empty band, so the midpoint collapses onto the guard
+        # and the cut stays inside the shared score range (FPR-controlled regime).
+        rng = np.random.default_rng(3)
+        scores = rng.uniform(0.3, 0.7, size=80).tolist()
+        labels = [float(i % 2) for i in range(80)]
+        thr = conformal_threshold(scores, labels, inclusion_value=0)
+        assert 0.3 <= thr <= 0.7
+
+
+class TestStratifiedFolds:
+    def test_never_single_class_and_pairs_scores_with_labels(self):
+        rng = np.random.default_rng(1)
+        # 6 positives, 6 negatives in 1-D; the linear trainer scores by the coord.
+        X = np.concatenate([rng.normal(1.0, 0.1, size=(6, 1)), rng.normal(-1.0, 0.1, size=(6, 1))]).astype(np.float64)
+        y = np.array([1.0] * 6 + [0.0] * 6)
+        orderings = stratified_fold_orderings(X, y, _linear_trainer(np.array([1.0])), seed=7, calibrate_count=4)
+        assert len(orderings) == 4
+        for scores, labels in orderings:
+            assert len(scores) == len(labels)
+            assert 0.0 in labels and 1.0 in labels  # both classes present in every cal fold
+
+    def test_too_few_or_single_class_returns_empty(self):
+        assert (
+            stratified_fold_orderings(np.zeros((3, 1)), np.array([1.0, 0.0, 1.0]), _linear_trainer(np.array([1.0])), 0)
+            == []
+        )
+        X = np.ones((6, 1))
+        assert stratified_fold_orderings(X, np.ones(6), _linear_trainer(np.array([1.0])), 0) == []
+
+
+class TestCalibratedThresholdDispatch:
+    def _data(self, seed=2):
+        rng = np.random.default_rng(seed)
+        X = np.concatenate([rng.normal(1.0, 0.3, size=(20, 1)), rng.normal(-1.0, 0.3, size=(20, 1))]).astype(np.float64)
+        y = np.array([1.0] * 20 + [0.0] * 20)
+        return X, y
+
+    def test_argmin_is_byte_identical_to_xcal(self):
+        X, y = self._data()
+        trainer = _linear_trainer(np.array([1.0]))
+        got = calibrated_threshold(X, y, trainer, seed=5, rule="argmin", calibrate_count=2)
+        want = cross_calibrated_threshold(X, y, trainer, 5, calibrate_count=2)
+        assert got == want
+
+    def test_conformal_runs_and_lands_in_gap(self):
+        X, y = self._data()
+        trainer = _linear_trainer(np.array([1.0]))
+        thr = calibrated_threshold(X, y, trainer, seed=5, rule="conformal", calibrate_count=2)
+        assert np.isfinite(thr)
+
+    def test_unknown_rule_raises(self):
+        X, y = self._data()
+        try:
+            calibrated_threshold(X, y, _linear_trainer(np.array([1.0])), 0, rule="bogus")
+        except ValueError as e:
+            assert "bogus" in str(e)
+        else:  # pragma: no cover
+            raise AssertionError("expected ValueError for unknown rule")
+
+    def test_too_few_votes_falls_back_to_half(self):
+        X = np.ones((3, 1))
+        y = np.array([1.0, 0.0, 1.0])
+        assert calibrated_threshold(X, y, _linear_trainer(np.array([1.0])), 0, rule="conformal") == 0.5
+
+
+class TestMedianSmooth:
+    def test_median_of_last_three(self):
+        assert median_smooth([0.5, 0.4, 0.35, 0.9]) == 0.4  # median(0.4, 0.35, 0.9)
+
+    def test_kills_single_spike(self):
+        # A lone spike among stable values is smoothed away.
+        assert median_smooth([0.5, 0.5, 0.9]) == 0.5
+
+    def test_shorter_history_uses_what_exists(self):
+        assert median_smooth([0.42]) == 0.42
+        assert median_smooth([0.4, 0.6]) == 0.5
+
+    def test_drops_non_finite(self):
+        assert median_smooth([0.5, np.inf, 0.5]) == 0.5
+
+
+class TestRankTransfer:
+    def test_maps_quantile_between_score_pools(self):
+        fold = [0.0, 0.25, 0.5, 0.75, 1.0]
+        # Cut at 0.5 = the 0.6 quantile of the fold pool (3 of 5 <= 0.5).
+        # Final pool is shifted; the same quantile lands lower.
+        final = [0.0, 0.1, 0.2, 0.3, 0.4]
+        got = rank_transfer_cut(0.5, fold, final)
+        assert got == float(np.quantile(np.asarray(final), 0.6))
+
+    def test_degenerate_pools_return_cut_unchanged(self):
+        assert rank_transfer_cut(0.42, [], [0.1, 0.2]) == 0.42
+        assert rank_transfer_cut(0.42, [0.1, 0.2], []) == 0.42

--- a/tests_lib/sorting/test_threshold_rules.py
+++ b/tests_lib/sorting/test_threshold_rules.py
@@ -66,7 +66,7 @@ class TestConformalThreshold:
         labels = [0.0] * len(neg) + [1.0] * len(pos)
         thrs = [conformal_threshold(scores, labels, inclusion_value=k) for k in range(-10, 11)]
         # Higher inclusion (larger k) can only lower the cut (include more).
-        for a, b in zip(thrs, thrs[1:], strict=True):
+        for a, b in zip(thrs, thrs[1:], strict=False):
             assert b <= a + 1e-9
 
     def test_overlap_regime_collapses_to_fp_guard(self):

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -34,6 +34,7 @@ import numpy as np
 
 from vtscore.eval.error_metrics import f1_at, max_f1, min_weighted_cost, weighted_error
 from vtscore.eval.scoring_heads import CosineHead, MLPHead, max_pool_over_images, max_pool_with_argmax
+from vtscore.eval.threshold_rules import calibrated_threshold, median_smooth
 from vtscore.eval.xcal import cross_calibrated_threshold
 
 
@@ -664,11 +665,19 @@ def _train_pool_head(
     safe_thresholds: bool,
     calibrate_count: int,
     cal_fraction: float,
+    threshold_rule: str = "argmin",
 ):
     """Train a head on the current good/bad votes; returns
     ``(predict_fn, raw_threshold, n_votes, calib_mode)`` or ``None`` on a
     single-class / empty budget. Region-voting reuses :func:`train_rv_head`
-    (snapped positives + leaf-flood bags); otherwise a box-pool/whole MLP."""
+    (snapped positives + leaf-flood bags); otherwise a box-pool/whole MLP.
+
+    *threshold_rule* selects the whole/box-pool path's calibration rule (#2790):
+    ``"argmin"`` (default) is byte-identical to the historical ``xcal`` behaviour;
+    ``"conformal"`` / ``"rank-transfer"`` run production Autopilot's split-conformal
+    rule via :func:`vtscore.eval.threshold_rules.calibrated_threshold`. (The
+    region-voting branch still calibrates through :func:`train_rv_head`; wiring the
+    rule into that grouped path is tracked separately — see THRESHOLD_STABILITY_STATUS.)"""
     good = sorted(good_ids)
     bad = sorted(bad_ids)
     if not good or not bad:
@@ -710,11 +719,12 @@ def _train_pool_head(
     x = np.vstack([pos, neg]).astype(np.float32)
     y = np.array([1.0] * pos.shape[0] + [0.0] * neg.shape[0], dtype=np.float32)
     head = MLPHead(inputs.input_dim)
-    raw_thr = cross_calibrated_threshold(
+    raw_thr = calibrated_threshold(
         x,
         y,
         head.trainer_fn(),
         seed,
+        rule=threshold_rule,
         inclusion_value=inclusion,
         calibrate_count=calibrate_count,
         cal_fraction=cal_fraction,
@@ -790,6 +800,7 @@ def _resolve_step_head(
     safe_thresholds,
     calibrate_count,
     cal_fraction,
+    threshold_rule="argmin",
 ):
     """Return ``(cached, steps_since_train)`` for one step.
 
@@ -812,6 +823,7 @@ def _resolve_step_head(
             safe_thresholds=safe_thresholds,
             calibrate_count=calibrate_count,
             cal_fraction=cal_fraction,
+            threshold_rule=threshold_rule,
         )
         if res is not None:
             predict, raw_thr, n_votes, calib = res
@@ -901,6 +913,8 @@ def _realistic_one_seed(
     bad_to_start: int,
     retrain_cadence: int,
     stop_at_done: bool,
+    threshold_rule: str = "argmin",
+    threshold_smooth: str = "none",
 ) -> tuple[list[dict], dict | None]:
     """Run one seed's labeling loop. Returns ``(rows, final)`` where ``final`` is a dict
     ``{predict, threshold, n_good, n_bad, t, trace}`` for the last step (head + blended
@@ -936,6 +950,8 @@ def _realistic_one_seed(
     }
     cached = None  # (predict, raw_thr, n_votes, calib, blend)
     steps_since_train = 0
+    raw_threshold_history: list[float] = []  # blended thresholds, for the med3 smoother
+    prev_threshold: float | None = None  # previous step's threshold, for delta/spike diagnostics
     trace: list[dict] = []  # per-step labeling record (order, id, phase, head, threshold, …)
     final: dict | None = None  # {predict, threshold, n_good, n_bad, t, trace} of the last step
 
@@ -963,6 +979,7 @@ def _realistic_one_seed(
             safe_thresholds=safe_thresholds,
             calibrate_count=calibrate_count,
             cal_fraction=cal_fraction,
+            threshold_rule=threshold_rule,
         )
         predict, raw_thr, n_votes, calib, blend = cached
 
@@ -973,6 +990,11 @@ def _realistic_one_seed(
             if (blend and safe_thresholds)
             else raw_thr
         )
+        # Temporal smoothing (#2790 med3 arm): median of the last 3 blended
+        # thresholds. Off by default (``none``) so the trace is byte-identical.
+        raw_threshold_history.append(float(threshold))
+        if threshold_smooth == "med3":
+            threshold = median_smooth(raw_threshold_history)
 
         err = weighted_error(test_scores, [float(v) for v in test_labels], threshold, inclusion)
         oracle = min_weighted_cost(test_scores, [float(v) for v in test_labels], inclusion)
@@ -1038,8 +1060,16 @@ def _realistic_one_seed(
                 "fnr": err["fnr"],
                 "f1": f1,
                 "stop_recommended": stop_recommended,
+                # Threshold-stability diagnostics (#2790): jump size vs the prior
+                # step, a spike flag (|Δcost| > 0.1), and this step's calibration
+                # regret (trained cost minus the oracle's best-cut cost).
+                "delta_threshold": (None if prev_threshold is None else round(float(threshold) - prev_threshold, 6)),
+                "spike": int(len(cost_history) > 1 and abs(cost_history[-1] - cost_history[-2]) > 0.1),
+                "regret": round(float(err["cost"]) - float(oracle), 6),
+                "threshold_rule": threshold_rule,
             }
         )
+        prev_threshold = float(threshold)
         final = {
             "predict": predict,
             "threshold": float(threshold),
@@ -1076,6 +1106,8 @@ def evaluate_realistic_curve(
     retrain_cadence: int = 1,
     stop_at_done: bool = False,
     return_finals: bool = False,
+    threshold_rule: str = "argmin",
+    threshold_smooth: str = "none",
 ) -> list[dict] | tuple[list[dict], dict[int, dict]]:
     """Realistic active-learning labeling curve: cost/fpr/fnr/F1/IoU vs ``t`` (total
     annotations), one row per ``(seed, t)``.
@@ -1116,6 +1148,8 @@ def evaluate_realistic_curve(
             bad_to_start=bad_to_start,
             retrain_cadence=retrain_cadence,
             stop_at_done=stop_at_done,
+            threshold_rule=threshold_rule,
+            threshold_smooth=threshold_smooth,
         )
         # Amortize the seed's wall-clock over its rows (per-step retrain dominates).
         per = round((time.perf_counter() - t0) * 1000.0 / max(len(seed_rows), 1), 3)

--- a/vtscore/eval/threshold_rules.py
+++ b/vtscore/eval/threshold_rules.py
@@ -1,0 +1,307 @@
+"""Selectable decision-threshold rules for the threshold-stability study (#2790).
+
+The realistic labeling loop's whole / box-pool path calibrates its threshold with
+:func:`vtscore.eval.xcal.cross_calibrated_threshold` — a per-fold min-cost
+**argmin** averaged over unstratified Train/Calibrate splits. The production app's
+Autopilot does **not** do this: it calibrates with the split-conformal quantile +
+gap-midpoint rule (issues #2693, #2784), pooling stratified fold orderings and
+taking one conformal cut. So the sweep's ``argmin`` behaviour is a *fidelity gap*
+vs. what a user actually experiences, and the violent single-step threshold jumps
+#2790 reports are exactly the failure the conformal rule was introduced to fix
+(an extreme order statistic — the lowest held-out calibration positive — moving
+from one vote to the next).
+
+This module makes the rule a **selectable knob** so the sweep can A/B the current
+``argmin`` behaviour against the fidelity-correct ``conformal`` rule (and a couple
+of diagnostic variants), keeping ``argmin`` byte-identical as the default.
+
+Rules (``rule=`` argument):
+
+* ``"argmin"`` — the historical sod behaviour. Delegates unchanged to
+  :func:`vtscore.eval.xcal.cross_calibrated_threshold`.
+* ``"conformal"`` — production Autopilot's rule. Stratified per-class folds, pool
+  every fold's held-out ``(score, label)`` pairs, and apply :func:`conformal_threshold`
+  once (ported verbatim from ``vtscore.training.thresholds`` on ``dev``). This is
+  what the real app computes; the arm exists because ``evaluation-framework``
+  predates #2784 and has no conformal rule of its own.
+* ``"rank-transfer"`` — the ``conformal`` cut converted to a quantile of the pooled
+  fold scores, then re-applied at that quantile of the **final** model's own score
+  pool. Probes the fold→final scale mismatch (S3): if a cut that is stable in
+  *rank* space wanders in *score* space, this arm is stable where ``conformal`` is
+  not. Requires the final model's pool scores, so it is applied via
+  :func:`rank_transfer_cut` after the final model exists.
+
+:func:`median_smooth` is an orthogonal temporal smoother (the ``med3`` variant):
+median of the last ``window`` raw thresholds, the cheapest possible hysteresis fix.
+
+Everything here is head-agnostic (it takes a ``trainer_fn`` exactly like
+:mod:`vtscore.eval.xcal`) and free of Flask / app imports, so it lives in the
+library tier and is unit-testable on synthetic ``(scores, labels)`` with no models.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+from vtscore.eval.xcal import PredictFn, TrainerFn, cross_calibrated_threshold
+
+#: The inclusion knob's base budget: at ``k = 0`` the false-negative cap and the
+#: false-positive guard are the 0.25 / 0.75 quantiles respectively. Kept in sync
+#: with ``vtscore.training.thresholds`` on ``dev`` (the value the app ships).
+CONFORMAL_BASE_BUDGET = 0.25
+#: Positive-score quantile the ``k = -10`` end of the inclusion walk reaches.
+CONFORMAL_QPOS_MAX = 0.75
+
+RULES = ("argmin", "conformal", "rank-transfer")
+
+
+def conformal_threshold(
+    scores: Sequence[float],
+    labels: Sequence[float],
+    inclusion_value: int = 0,
+) -> float:
+    """Split-conformal quantile threshold over held-out calibration scores.
+
+    Ported verbatim from ``vtscore.training.thresholds.conformal_threshold`` on
+    ``dev`` (issue #2784) so the ``conformal`` arm matches production Autopilot
+    exactly. Maps ``inclusion_value`` (``k``) to a decision threshold via
+    quantiles of the calibration score distributions rather than a min-cost
+    search over observed cuts:
+
+    * a **false-negative cap** ``alpha(k) = min(1, BASE * 2^-k)`` — the cut never
+      exceeds the ``alpha``-quantile of the calibration *positives*;
+    * a **false-positive guard** for ``k <= 0`` at the ``1 - BASE * 2^k`` quantile
+      of the *negatives*, with a walk *up* toward the positives as ``k`` drops;
+    * the **gap midpoint** at ``k = 0`` — the midpoint of the band between the top
+      of the negatives and the lowest positive. Every cut in that band has
+      identical empirical error, so its top edge (the single lowest calibration
+      positive) is an arbitrary, high-variance choice; the midpoint is the
+      max-margin one and is what stops the threshold jumping vote-to-vote.
+
+    Every component is monotone non-increasing in ``k``, so the cut is monotone in
+    inclusion by construction. Returns ``0.5`` when the score list is empty or
+    single-class (no quantiles to take); never abstains otherwise.
+    """
+    if len(scores) == 0:
+        return 0.5
+
+    scores_arr = np.asarray(scores, dtype=np.float64)
+    labels_arr = np.asarray(labels, dtype=np.float64)
+    pos = scores_arr[labels_arr == 1.0]
+    neg = scores_arr[labels_arr != 1.0]
+    if len(pos) == 0 or len(neg) == 0:
+        return 0.5
+
+    def _threshold_at(k: int) -> float:
+        fn_cap = float(np.quantile(pos, min(1.0, CONFORMAL_BASE_BUDGET * 2.0**-k)))
+        if k > 0:
+            # The k=0 floor keeps the seam monotone: q_pos(alpha) can sit above
+            # the k=0 cut when the budget goes unspent there.
+            return min(fn_cap, _threshold_at(0))
+        fp_guard = float(np.quantile(neg, 1.0 - CONFORMAL_BASE_BUDGET * 2.0**k))
+        # Midpoint of the band the calibration data cannot resolve: the top of the
+        # negatives up to the lowest positive. Collapses to ``fp_guard`` under
+        # class overlap (no band), so the FPR-controlled regime is untouched.
+        gap_mid = (fp_guard + max(fp_guard, float(np.min(pos)))) / 2.0
+        # Walk from that midpoint at k=0 up to the QPOS_MAX positive quantile at
+        # k=-10, linearly in score space (evenly spaced stops even on few points).
+        top = float(np.quantile(pos, CONFORMAL_QPOS_MAX))
+        walk = gap_mid + (-k / 10.0) * max(0.0, top - gap_mid)
+        return min(fn_cap, max(fp_guard, walk))
+
+    return _threshold_at(inclusion_value)
+
+
+def stratified_fold_orderings(
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    trainer_fn: TrainerFn,
+    seed: int,
+    *,
+    calibrate_count: int = 2,
+    cal_fraction: float = 0.5,
+) -> list[tuple[list[float], list[float]]]:
+    """Held-out ``(scores, labels)`` per fold under **class-stratified** splits.
+
+    The conformal analogue of the fold loop in
+    :func:`vtscore.eval.xcal.cross_calibrated_threshold`, differing in two ways
+    that matter for the study:
+
+    * splits are **stratified** — each class is permuted and cut at its own
+      ``cal_fraction`` boundary, so a fold can never land single-class (the
+      unstratified argmin path skips those folds, concentrating variance at low /
+      imbalanced vote counts — plan suspect S4);
+    * it returns the raw held-out orderings rather than a per-fold threshold, so
+      the caller pools them and takes **one** conformal cut over the union
+      (production's ``threshold_from_fold_orderings`` behaviour: the knob's
+      resolution is bounded by how many calibration scores the quantile sees, so
+      pooling beats averaging per-fold quantiles on a handful of votes each).
+
+    Returns ``[]`` when the labels are too few or single-class to split — the
+    caller then falls back to ``0.5`` exactly as the argmin path does.
+    """
+    y = np.asarray(y_train)
+    n = int(y.size)
+    if n < 4 or len({int(v) for v in y}) < 2:
+        return []
+
+    pos_idx = np.flatnonzero(y == 1.0)
+    neg_idx = np.flatnonzero(y != 1.0)
+    if len(pos_idx) < 2 or len(neg_idx) < 2:
+        return []
+
+    rng = np.random.default_rng(seed)
+    orderings: list[tuple[list[float], list[float]]] = []
+    for k in range(max(1, calibrate_count)):
+        tr_idx, cal_idx = _stratified_split(pos_idx, neg_idx, cal_fraction, rng)
+        if tr_idx is None or cal_idx is None:
+            continue
+        if len({int(v) for v in y[tr_idx]}) < 2 or len({int(v) for v in y[cal_idx]}) < 2:
+            continue
+        try:
+            predict = trainer_fn(X_train[tr_idx], y_train[tr_idx], seed + k)
+        except ValueError:
+            continue
+        cal_scores = np.asarray(predict(X_train[cal_idx]), dtype=np.float64).tolist()
+        cal_labels = [float(v) for v in y[cal_idx]]
+        orderings.append((cal_scores, cal_labels))
+    return orderings
+
+
+def _stratified_split(
+    pos_idx: np.ndarray,
+    neg_idx: np.ndarray,
+    cal_fraction: float,
+    rng: np.random.Generator,
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    """One class-balanced Train/Calibrate split; ``(None, None)`` if unsplittable.
+
+    Each class contributes ``round(class_n * cal_fraction)`` rows to Calibrate
+    (clamped so both Train and Calibrate keep at least one of each class), so
+    neither side is ever single-class — the guard the unstratified path lacks.
+    """
+
+    def _per_class(idx: np.ndarray) -> tuple[np.ndarray, np.ndarray] | None:
+        perm = rng.permutation(idx)
+        n_cal = int(round(len(idx) * cal_fraction))
+        n_cal = max(1, min(len(idx) - 1, n_cal))
+        return perm[n_cal:], perm[:n_cal]  # (train, cal)
+
+    p = _per_class(pos_idx)
+    q = _per_class(neg_idx)
+    if p is None or q is None:
+        return None, None
+    tr = np.concatenate([p[0], q[0]])
+    cal = np.concatenate([p[1], q[1]])
+    return tr, cal
+
+
+def calibrated_threshold(
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    trainer_fn: TrainerFn,
+    seed: int,
+    *,
+    rule: str = "argmin",
+    inclusion_value: int = 0,
+    calibrate_count: int = 2,
+    cal_fraction: float = 0.5,
+) -> float:
+    """Decision threshold under the named *rule*.
+
+    ``"argmin"`` delegates unchanged to
+    :func:`vtscore.eval.xcal.cross_calibrated_threshold` (the sweep's current
+    behaviour — byte-identical). ``"conformal"`` and ``"rank-transfer"`` build
+    stratified fold orderings, pool them, and apply :func:`conformal_threshold`;
+    ``"rank-transfer"`` returns the same conformal cut here (the rank re-mapping
+    needs the final model's scores and is applied later via
+    :func:`rank_transfer_cut`). Falls back to ``0.5`` when the votes cannot form a
+    valid split, matching the argmin path's fallback.
+    """
+    if rule == "argmin":
+        return cross_calibrated_threshold(
+            X_train,
+            y_train,
+            trainer_fn,
+            seed,
+            inclusion_value=inclusion_value,
+            calibrate_count=calibrate_count,
+            cal_fraction=cal_fraction,
+        )
+    if rule in ("conformal", "rank-transfer"):
+        orderings = stratified_fold_orderings(
+            X_train,
+            y_train,
+            trainer_fn,
+            seed,
+            calibrate_count=calibrate_count,
+            cal_fraction=cal_fraction,
+        )
+        if not orderings:
+            return 0.5
+        pooled_scores = [s for scores, _ in orderings for s in scores]
+        pooled_labels = [lb for _, labels in orderings for lb in labels]
+        return conformal_threshold(pooled_scores, pooled_labels, inclusion_value)
+    raise ValueError(f"unknown threshold rule {rule!r}; expected one of {RULES}")
+
+
+def rank_transfer_cut(
+    conformal_cut: float,
+    pooled_fold_scores: Sequence[float],
+    final_pool_scores: Sequence[float],
+) -> float:
+    """Re-express a *conformal_cut* as a rank and read it back on the final scores.
+
+    The conformal cut is chosen on the **fold** models' score scale (they train on
+    half the votes and saturate differently), then applied to the **final** model's
+    scores — the fold→final scale mismatch (plan suspect S3). This maps the cut to
+    its quantile position among the pooled fold scores and returns the score at
+    that same quantile of the final model's own pool distribution, so a cut that is
+    stable in rank space stays stable in score space.
+
+    Degenerates gracefully: with no fold scores or no final scores it returns
+    *conformal_cut* unchanged.
+    """
+    fold = np.asarray(pooled_fold_scores, dtype=np.float64)
+    final = np.asarray(final_pool_scores, dtype=np.float64)
+    if fold.size == 0 or final.size == 0:
+        return float(conformal_cut)
+    # Fraction of fold scores at or below the cut = the cut's quantile position.
+    q = float(np.mean(fold <= conformal_cut))
+    return float(np.quantile(final, min(1.0, max(0.0, q))))
+
+
+def median_smooth(threshold_history: Sequence[float], window: int = 3) -> float:
+    """Median of the last *window* raw thresholds (the ``med3`` temporal fix).
+
+    ``threshold_history`` is the sequence of raw (pre-smoothing) thresholds up to
+    and including the current step; the smoothed threshold is the median of its
+    last ``window`` entries (fewer early on). A cheap hysteresis that kills a
+    single-step spike without lagging a genuine level shift by more than one step.
+    Non-finite entries (a degenerate fallback) are dropped before the median; if
+    none remain the last raw value is returned.
+    """
+    if not threshold_history:
+        raise ValueError("threshold_history must be non-empty")
+    tail = [float(t) for t in list(threshold_history)[-window:]]
+    finite = [t for t in tail if np.isfinite(t)]
+    if not finite:
+        return float(threshold_history[-1])
+    return float(np.median(finite))
+
+
+# Re-exported for callers that build a trainer_fn and want the type names local.
+__all__ = [
+    "CONFORMAL_BASE_BUDGET",
+    "CONFORMAL_QPOS_MAX",
+    "RULES",
+    "PredictFn",
+    "TrainerFn",
+    "calibrated_threshold",
+    "conformal_threshold",
+    "median_smooth",
+    "rank_transfer_cut",
+    "stratified_fold_orderings",
+]


### PR DESCRIPTION
Harness for the pre-registered threshold-stability study (`docs/plans/threshold-stability-experiment.md` on `dev`), issue #2790. Real Grid runs are owner-gated; the code + offline tests + CPU Grid runner are here.

## Headline: plan vs. this branch
The plan assumes the sod region-voting path "already uses the production conformal rule." **It doesn't** — `evaluation-framework` predates #2784, so *both* threshold paths reduce to min-cost **argmin**. Per the owner's steering ("match a simulation of Autopilot over the plan"), `argmin` = the current infidelity, `conformal` = fidelity-correct (what production Autopilot runs). Reframe confirmed by the owner.

## What's here (all tested; default byte-identical)
- **`vtscore/eval/threshold_rules.py`** — selectable, head-agnostic rules: verbatim `conformal_threshold` port (#2784), `stratified_fold_orderings`, `calibrated_threshold(rule=)` (`argmin`≡`xcal` byte-identical), `rank_transfer_cut` (S3), `median_smooth` (med3). — 16 tests.
- **`scripts/sod/replay_thresholds.py`** — Stage-A frozen-trace replay: cache-free tested core (vote reconstruction, per-step × rule × seed matrix, variance decomposition) + `CacheVectorLoader` (VALIDATE-ON-GRID). — 5 tests.
- **Stage B live-loop wiring** — `sweep.py` `--threshold-rule` / `--threshold-smooth`, threaded through `evaluate_realistic_curve` → `_train_pool_head` (whole path dispatches `calibrated_threshold`); med3 + diagnostic trace columns (`delta_threshold`, `spike`, `regret`). — 42 `test_region_curve.py` pass (byte-identical default).
- **CPU Grid runner** `scripts/experiments/threshold_stability/` — 6 arms × 5 classes × 10 seeds; Stage B sweep-per-arm + Stage A replay; CPU SLURM scripts; reuses the #2790 SigLIP2/whole cache.
- `scripts/sod/THRESHOLD_STABILITY_STATUS.md` — status, the reframe, and the remaining owner-gated work (validate `CacheVectorLoader` on one cell; region-voting-path conformal; run + report).

63 targeted tests pass; 172/172 `tests_lib/sorting`; ruff/codespell clean. Note: `sweep.py` carries pre-existing pyright PIL-monkeypatch warnings (lines ~179-192), not introduced here.

Refs #2790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)