### PR TITLE
Threshold-stability (#2790): Stage B results, report + spike attribution

### DIFF
--- a/docs/experiments/threshold-stability/REPORT.md
+++ b/docs/experiments/threshold-stability/REPORT.md
@@ -1,0 +1,195 @@
+# Threshold-stability study (#2790) — report
+
+**BLUF.** On the COCO × SigLIP 2 × `whole` Autopilot labeling loop, the large
+cross-seed variance #2790 reported is **threshold-placement noise, not ranking
+noise** (across-seed cost sd ≈ 4× the oracle floor, every arm). The biggest lever
+on that noise is the **fold count** (`calibrate_count` 2→8 roughly halves the
+threshold jitter), not the calibration *rule*. Switching the sweep's historical
+min-cost `argmin` rule to production Autopilot's split-conformal rule barely changes
+threshold sd at matched fold count — but it **cuts calibration regret ~37%** (the
+cut is placed much better). No arm clears the pre-registered adoption bar; the
+best practical arm is **`conformal-k8`** (lowest spike rate and near-lowest
+threshold sd, with conformal's low regret). The residual points at the
+fold→final-model score-scale mismatch (S3), which needs a follow-up.
+
+## Setup
+
+- **Loop:** the realistic Autopilot labeling loop (`scripts/sod/sweep.py`,
+  `vtscore/eval/region_curve.py`), whole-image / box-pool path, MLP head.
+- **Config (the #2790 repro):** COCO, SigLIP 2 (`siglip2`), `whole`,
+  `--max-labels 60`, `--neg-multiple 100` (prevalence ≈ 1/101),
+  `--min-box-frac 0.03`, inclusion 0, `--safe-thresholds` on.
+- **Classes (5):** stop sign, traffic light, fire hydrant, parking meter, bus.
+- **Seeds:** 10. **Cells:** 6 arms × 5 classes = 30.
+- **Metrics** (per arm, over the post-GMM-ramp window `t ≥ 20`), derived from each
+  arm's `results.jsonl` per-`(seed, t)` `threshold` / `cost` / `oracle_cost`:
+  across-seed `sd_threshold`; within-seed step-to-step `sd_dthreshold`; `spike_rate`
+  (fraction of steps with `|Δcost| > 0.1`); across-seed `cost_sd` vs `oracle_sd`
+  (the ranking-variance floor); `mean_regret` = `cost − oracle_cost` over `t ∈ [40, 60]`.
+
+### Reframe (plan vs. reality — the load-bearing finding)
+
+The pre-registered plan assumed the sweep's region-voting path "already uses the
+production conformal rule." It does not: `evaluation-framework` predates the #2784
+conformal cut, so **both** the whole and region-voting paths reduced to min-cost
+`argmin`. Per the owner's steering ("match a simulation of Autopilot over the plan"),
+`argmin` is therefore the *infidelity* and `conformal` (ported verbatim from `dev`'s
+`thresholds.py`) is what production Autopilot actually runs. The study measures
+whether making the simulation faithful fixes the jumps.
+
+## Results
+
+| arm | sd_threshold | sd_Δthreshold | spike_rate | cost_sd | oracle_sd | mean_regret |
+|---|---|---|---|---|---|---|
+| `argmin-k2` (baseline) | 0.1583 | 0.0676 | 0.1732 | 0.1471 | 0.0358 | 0.2455 |
+| `argmin-k8` | **0.0871** | 0.0390 | 0.1337 | 0.1241 | 0.0348 | 0.2368 |
+| `conformal-k2` | 0.1273 | 0.0543 | 0.1639 | 0.1412 | 0.0428 | 0.1533 |
+| `conformal-k8` | 0.0993 | **0.0350** | **0.1298** | **0.1222** | 0.0380 | 0.1578 |
+| `conformal-k2-med3` | 0.1309 | 0.0527 | 0.1902 | 0.1406 | 0.0435 | 0.1503 |
+| `rank-transfer-k2` | 0.1273 | 0.0543 | 0.1639 | 0.1412 | 0.0428 | 0.1533 |
+
+## Findings
+
+- **F1 — The instability is the threshold, confirmed (plan H5).** Across every arm
+  the cross-seed `cost_sd` (0.122–0.147) is ~4× the oracle floor `oracle_sd`
+  (0.035–0.044). The sort is stable; the variance is where the cut lands. This is
+  exactly the effect #2790 observed, now measured across 5 classes × 10 seeds.
+
+- **F2 — Fold count is the dominant stability lever, not the rule.** `k8` roughly
+  halves threshold jitter (`argmin` sd_threshold 0.158→0.087; `conformal`
+  0.127→0.099; `sd_Δthreshold` and `spike_rate` fall in step). At matched fold
+  count, `argmin`→`conformal` moves threshold sd only modestly (and at `k8`,
+  slightly the wrong way, 0.087→0.099). The knob that most reduces the jumps is
+  averaging over more calibration folds.
+
+- **F3 — Conformal's win is accuracy, not stability (plan S1, refined).**
+  `conformal` cuts `mean_regret` ~37% vs `argmin` (0.245→0.153 at k2; 0.237→0.158
+  at k8) and holds it — the fidelity-correct rule places a materially better cut.
+  So adopting the rule the app actually runs is worth it *for accuracy*; it is not,
+  on its own, the fix for the *jumpiness* (that's F2).
+
+- **F4 — med3 did not help; rank-transfer is inconclusive here.**
+  `conformal-k2-med3` did not reduce spikes (spike_rate 0.164→0.190) — temporal
+  median smoothing of the *blended* threshold is not the cheap win H3 hoped for.
+  `rank-transfer-k2` is byte-identical to `conformal-k2` because its rank-remap
+  needs the final model's score pool, which is only available in Stage-A replay,
+  not the live loop — so this arm carries no signal in Stage B (a wiring
+  limitation, documented).
+
+## Verdict (against the pre-registered decision rules)
+
+- **Rule 2 (adopt the cheapest arm cutting spike incidence ≥80% and across-seed
+  cost sd ≥50% vs `argmin-k2`, without worsening regret by >0.01): NOT MET by any
+  arm.** Best spike reduction ≈ 25% (`conformal-k8`); best `sd_threshold` reduction
+  ≈ 45% (`argmin-k8`); best `cost_sd` reduction ≈ 17% (`conformal-k8`). None reaches
+  the bar.
+- **⇒ Rule 4 fires:** the residual is larger than any single knob (rule or fold
+  count) removes, implicating the fold→final-model score-scale mismatch (S3). The
+  indicated follow-up is a threshold calibrated on the *final* model's own scores
+  (leave-one-out / refit-free conformal), not on half-data fold models.
+- **Rule 3 (med3 as a production candidate): dropped** — F4 shows it does not help.
+
+**Practical recommendation:** `conformal-k8`. It is the best available combination —
+lowest `spike_rate` (0.130), near-lowest `sd_threshold` (0.099) and `sd_Δthreshold`
+(0.035), lowest `cost_sd` (0.122), and conformal's low regret (0.158). It pairs the
+fold-count stability lever (F2) with the conformal accuracy win (F3). It does not
+clear the strict bar, so it is a "ship the better default while the S3 follow-up is
+scoped," not a declared solution.
+
+## Spike attribution — what vote causes a spike
+
+Drill-down on the baseline `argmin-k2` arm (`--labeling-trace --no-trace-images`,
+5 classes × 10 seeds), attributing every up-spike (`Δcost > 0.1`) to the vote added
+that step (`scripts/experiments/threshold_stability/spike_analysis.py`). **278 spikes.**
+
+**Metric note (important).** The MLP is retrained from scratch every vote, so
+`MLP_t` and `MLP_{t+1}` have *different* score scales — a raw threshold value is not
+comparable across steps, and "the threshold moved up" is not a well-defined quantity
+(it conflates the model changing with the calibration changing). Everything below is
+stated in **model-independent** terms: `cost` / `fnr` / `fpr` are measured on a fixed
+held-out **test set** (so `Δcost`, `Δfnr` are comparable step-to-step), and "the cut
+is bad" means **far from `MLP_{t+1}`'s own oracle cut** — never a comparison of one
+model's threshold to another's. (Stage B established this is possible: `oracle_sd ≈
+¼ · cost_sd`, so each step's ranking *is* cuttable into a low-cost operating point;
+the spikes are the calibration missing it, not the ranking failing.)
+
+| signal (all test-set / within-model) | share |
+|---|---|
+| culprit is a **Bad** vote | 87% |
+| Bad **and** `hard`-selected (surfaced at the boundary) | 79% |
+| `hard`-selected (any label) | 91% |
+| **FNR**-driven (Δfnr > Δfpr on the test set) | 76% |
+| **runaway** (Δfnr > 0.2 — the operating point rejects many test positives) | 37% |
+| **sparse positives** at spike (`n_good ≤ 6`; median `n_good` = **4**) | 67% |
+| **narrow** (test cost recovers within 2 steps) | 26% (54% still elevated after 5) |
+
+(A raw-threshold-delta was also logged — 81% "up" — but is **not** reported as a
+finding: comparing `MLP_t`'s cut to `MLP_{t+1}`'s cut is comparing two models'
+calibrations, not a moving quantity. The FNR operating-point move above is the sound
+version of the same effect.)
+
+**Mechanism (worked example, stop-sign seed 4), stated on the test set.** At `t≈24`
+the operating point is healthy (test FNR 0.12, cost 0.14, 5 good / 19 bad votes). At
+`t28` a **Bad** vote on a boundary item (id 140556, surfaced at that model's cut) is
+added; `MLP_{28}` is retrained on ~4 positives, and its argmin cut lands far above
+`MLP_{28}`'s own test positives — **test FNR 0.12 → 0.58, cost → 0.58**. It does
+**not** snap back: `hard`-selection keeps surfacing each new model's boundary items,
+and over the next four votes the successive models' cuts keep excluding their own
+positives — **test FNR runs to 1.0** (the detector rejects everything). Each step is
+a *fresh* model + cut; what compounds is the *acquisition* (boundary selection) plus
+the *sparse-positive calibration*, not a single threshold drifting.
+
+**Root pattern:** a Bad vote on a `hard`-selected boundary item, in the
+**sparse-positive regime (~4 good votes)**, makes the retrained model's argmin cut
+land far from its own oracle — test FNR spikes. A secondary ~24% are the mirror
+(Bad vote → the new model's cut admits a flood of test false positives). Both are the
+same instability — a handful of calibration positives can't pin *any* single model's
+cut, so the argmin lands badly in either direction. The "narrow" intuition holds for
+the FPR blips but **not** the FNR runaways (37%), which compound via acquisition.
+
+**Blockable (ranked):**
+
+1. **Within-model positive-coverage floor (proactive, already built): the #2784
+   conformal gap-midpoint rule** forbids each retrained model's cut from exceeding
+   *its own* lowest calibration positive — a purely within-model constraint (no
+   cross-step threshold comparison), so it structurally blocks the "cut lands above
+   its own positives" runaway (the damaging 37%). This is why `conformal` cut regret
+   −37% in Stage B. Make the `whole`/box-pool loop use it (and confirm the app does).
+   Note this is the sound version of "don't let the cut jump up" — it caps the cut
+   against the *current* model's positives, not against the previous model's cut.
+2. **Defer trusting the trained cut while positives are sparse** (`n_good ≤ ~6`;
+   median at spike = 4): 41% of spikes are early and the enabling condition is too
+   few positives to pin *any* model's cut — stay on the cold-start / GMM (or text)
+   sort longer, or widen the cut's coverage floor until enough positives exist. This
+   is a vote-count guard, fully model-independent.
+3. **Acquisition guard:** `hard` selection surfaces each model's boundary items,
+   which is what compounds the runaway across steps (item 91% `hard`-selected). In
+   the sparse-positive regime, biasing away from pure boundary sampling breaks the
+   compounding. (This targets the *acquisition* half; it is orthogonal to the
+   calibration cap in #1.)
+
+Explicitly **not** recommended: a per-vote clamp on the raw threshold *change*
+between steps — that presumes `threshold_t` and `threshold_{t+1}` are on one scale,
+but the models are independently retrained, so the delta isn't a meaningful quantity.
+The within-model coverage floor (#1) achieves the intended effect soundly.
+
+## Caveats / scope
+
+- **Stage B only.** The Stage-A frozen-trace replay (the paired split-noise vs
+  fit-noise decomposition) was dropped from this run: `--labeling-trace` renders
+  ~2 PNGs/step (~11k files, multiple GB) and filled the 50 GB `/exp` volume. Stage
+  B needs none of it — `results.jsonl` carries the per-step threshold/cost. Stage A
+  needs a **PNG-free trace mode** (write `trace.json` only); the replay tool
+  (`scripts/sod/replay_thresholds.py`) is built and unit-tested, waiting on that.
+- **Whole-image path only** (the #2790 case). The region-voting/`train_rv_head`
+  grouped path still calibrates via `argmin`; porting conformal there (grouped
+  stratified folds) is separate follow-up work.
+- **`rank-transfer` not evaluated** in the live loop (F4).
+
+## Artifacts
+
+Grid run under `/exp/sgreenberg/threshold-stability/results/`: `REPORT.md` (this,
+auto-generated), `summary.json`, `agg/by_arm.csv`, and per-cell
+`cells/<class>/arm_<name>/results.jsonl`. Harness on branch
+`claude/threshold-stability-2790` (PR #2795). Job chain: warm `436641` (GPU embed) →
+cells `436934_[0-4]` (CPU, ~30 min/cell) → analyze `436935`.

--- a/scripts/experiments/threshold_stability/analyze.py
+++ b/scripts/experiments/threshold_stability/analyze.py
@@ -1,20 +1,27 @@
-"""Aggregate threshold-stability cells into the pre-registered #2790 deliverables.
+"""Aggregate the threshold-stability Stage B cells into the #2790 deliverables.
 
-Concatenates every cell's Stage B ``results.jsonl`` (per-arm live-loop curves) and
-Stage A ``replay.csv`` (frozen-trace variance decomposition), then computes the
-headline metrics from the plan: per-arm ``sd(Δthreshold)`` and spike incidence over
-``t >= 20``, mean regret over ``t in [40, 60]``, and the across-seed cost sd vs the
-oracle-cost sd (the ranking-variance floor — threshold noise is the gap). Writes
-``results/summary.json``, ``results/agg/*.csv``, and a ``results/REPORT.md`` draft.
+Reads every arm's ``results.jsonl`` (one row per (seed, t), carrying ``threshold``,
+``cost``, ``oracle_cost``) and derives the pre-registered comparison — no trace
+files, no replay needed:
 
-Kept deliberately small: the figures + verdict prose are filled in once real Grid
-data exists (see ``docs/plans/threshold-stability-experiment.md`` decision rules).
+* ``sd_threshold`` — across-seed spread of the trained threshold, averaged over the
+  post-ramp window ``t >= WARMUP``. The threshold noise the study wants shrunk.
+* ``sd_dthreshold`` — within-seed step-to-step |Δthreshold| spread (jumpiness).
+* ``spike_rate`` — fraction of (seed, t) steps with ``|Δcost| > 0.1`` (the #2790
+  single-step cost excursions).
+* ``cost_sd`` vs ``oracle_sd`` — across-seed sd of cost vs of the oracle cost (the
+  ranking-variance floor); the gap between them is threshold noise (plan H5).
+* ``mean_regret`` — ``cost - oracle_cost`` averaged over ``t in [40, 60]``.
+
+Writes ``results/summary.json``, ``results/agg/by_arm.csv``, and a ``REPORT.md``
+ranking the arms. (rank-transfer runs identically to conformal in the *live* loop —
+its rank remap needs the final pool scores, applied only in Stage-A replay — so it
+is reported but expected to match conformal here.)
 """
 
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import common
 
@@ -22,87 +29,121 @@ common.setup_env()
 
 import experiment_config as cfg  # noqa: E402
 
+WARMUP = int(__import__("os").environ.get("THRSTAB_WARMUP_T", "20"))
 
-def _load_stage_a(cells_dir: Path):
+
+def _load():
     import pandas as pd  # noqa: PLC0415
 
-    files = sorted(cells_dir.glob("*/replay_seed*.csv"))
     frames = []
-    for p in files:
-        try:
-            df = pd.read_csv(p)
-        except Exception:  # noqa: BLE001 - empty/partial cell
+    for jl in sorted((common.RESULTS / "cells").glob("*/arm_*/results.jsonl")):
+        arm = jl.parent.name.removeprefix("arm_")
+        cls = jl.parent.parent.name
+        rows = [json.loads(x) for x in jl.read_text().splitlines() if x.strip()]
+        if not rows:
             continue
-        if df.empty:
-            continue
-        df["cell"] = p.parent.name  # <class_slug>
-        df["seed"] = p.stem.removeprefix("replay_seed")  # replay_seed<N>.csv
+        df = pd.DataFrame(rows)
+        df["arm"] = arm
+        df["cls"] = cls
         frames.append(df)
     return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
 
 
-def _load_stage_b(cells_dir: Path):
-    import pandas as pd  # noqa: PLC0415
+def _per_arm(df):
+    df = df.sort_values(["arm", "cls", "seed", "t"])
+    # Within-seed step-to-step threshold jump.
+    df["dthreshold"] = df.groupby(["arm", "cls", "seed"])["threshold"].diff().abs()
+    df["dcost"] = df.groupby(["arm", "cls", "seed"])["cost"].diff().abs()
+    df["spike"] = (df["dcost"] > 0.1).astype(float)
+    df["regret"] = df["cost"] - df["oracle_cost"]
 
-    rows = []
-    for jl in sorted(cells_dir.glob("*/arm_*/results.jsonl")):
-        arm = jl.parent.name.removeprefix("arm_")
-        for line in jl.read_text().splitlines():
-            if line.strip():
-                rec = json.loads(line)
-                rec["arm"] = arm
-                rows.append(rec)
-    return pd.DataFrame(rows)
+    warm = df[df["t"] >= WARMUP]
+    # Across-seed spread of threshold / cost / oracle at each (arm, cls, t), then mean.
+    grp = warm.groupby(["arm", "cls", "t"])
+    spread = grp.agg(
+        sd_threshold=("threshold", "std"),
+        cost_sd=("cost", "std"),
+        oracle_sd=("oracle_cost", "std"),
+    ).reset_index()
+    by_spread = spread.groupby("arm").agg(
+        sd_threshold=("sd_threshold", "mean"),
+        cost_sd=("cost_sd", "mean"),
+        oracle_sd=("oracle_sd", "mean"),
+    )
+
+    late = df[(df["t"] >= 40) & (df["t"] <= 60)]
+    out = by_spread.copy()
+    out["sd_dthreshold"] = warm.groupby("arm")["dthreshold"].std()
+    out["spike_rate"] = warm.groupby("arm")["spike"].mean()
+    out["mean_regret"] = late.groupby("arm")["regret"].mean()
+    # Threshold-noise share of cost variance: how much of cost_sd the ranking floor
+    # (oracle_sd) does NOT explain.
+    out["cost_noise_gap"] = (out["cost_sd"] - out["oracle_sd"]).clip(lower=0)
+    return out.reindex([a[0] for a in cfg.ARMS]).reset_index().rename(columns={"index": "arm"})
 
 
 def main() -> int:
-    cells_dir = common.RESULTS / "cells"
+    df = _load()
     agg_dir = common.RESULTS / "agg"
     agg_dir.mkdir(parents=True, exist_ok=True)
+    if df.empty:
+        (common.RESULTS / "REPORT.md").write_text("# Threshold-stability (#2790)\n\nNo cell output found.\n")
+        common.log("no results found")
+        return 0
 
-    stage_a = _load_stage_a(cells_dir)
-    stage_b = _load_stage_b(cells_dir)
-    summary: dict = {"n_cells_stage_a": int(stage_a["cell"].nunique()) if not stage_a.empty else 0}
-
-    if not stage_a.empty:
-        stage_a.to_csv(agg_dir / "stage_a_replay.csv", index=False)
-        # Headline: mean sd_threshold + spike_rate per rule over t>=20 (replay already filters warmup).
-        by_rule = stage_a.groupby("rule").agg(
-            mean_sd_threshold=("sd_threshold", "mean"),
-            mean_spike_rate=("spike_rate", "mean"),
-        )
-        by_rule.to_csv(agg_dir / "stage_a_by_rule.csv")
-        summary["stage_a_by_rule"] = by_rule.reset_index().to_dict("records")
-
-    if not stage_b.empty:
-        stage_b.to_csv(agg_dir / "stage_b_curves.csv", index=False)
-        if {"arm", "t", "cost"} <= set(stage_b.columns):
-            late = stage_b[stage_b["t"].between(40, 60)]
-            summary["stage_b_mean_cost_late"] = late.groupby("arm")["cost"].mean().reset_index().to_dict("records")
-
+    by_arm = _per_arm(df)
+    by_arm.to_csv(agg_dir / "by_arm.csv", index=False)
+    n_cells = df.groupby(["arm", "cls"]).ngroups
+    summary = {
+        "warmup_t": WARMUP,
+        "arm_cells": int(n_cells),
+        "classes": sorted(df["cls"].unique().tolist()),
+        "seeds": sorted(int(s) for s in df["seed"].unique().tolist()),
+        "by_arm": by_arm.to_dict("records"),
+    }
     (common.RESULTS / "summary.json").write_text(json.dumps(summary, indent=2, default=str))
-    _write_report(summary)
-    common.log(f"summary -> {common.RESULTS / 'summary.json'}; report -> {common.RESULTS / 'REPORT.md'}")
+    _report(by_arm, summary)
+    common.log(f"wrote REPORT.md + summary.json ({len(df)} rows, arms={by_arm['arm'].tolist()})")
     return 0
 
 
-def _write_report(summary: dict) -> None:
+def _report(by_arm, summary: dict) -> None:
+    base = by_arm[by_arm["arm"] == cfg.BASELINE_ARM]
+
+    def _fmt(x):
+        return "n/a" if x != x else f"{x:.4f}"  # noqa: PLR0124 - NaN check
+
     lines = [
-        "# Threshold-stability study (#2790) — results",
+        "# Threshold-stability study (#2790) — Stage B (live loop)",
+        "",
+        f"Classes: {', '.join(summary['classes'])}. Seeds: {len(summary['seeds'])}. "
+        f"Window: t >= {summary['warmup_t']}.",
         "",
         "Reframe: `argmin` = the sweep's current (infidelic) rule; `conformal` = production",
-        "Autopilot's rule. Arms: " + ", ".join(a[0] for a in cfg.ARMS) + ".",
+        "Autopilot's rule. Lower `sd_threshold` / `spike_rate` / `cost_sd` is better;",
+        "`oracle_sd` is the ranking-variance floor (threshold noise is `cost_sd - oracle_sd`).",
         "",
-        f"Stage A cells replayed: {summary.get('n_cells_stage_a', 0)}",
-        "",
-        "## Stage A — per-rule threshold noise (mean over cells, t>=20)",
-        "",
-        "| rule | mean sd(threshold) | mean spike_rate |",
-        "|---|---|---|",
+        "| arm | sd_threshold | sd_Δthreshold | spike_rate | cost_sd | oracle_sd | mean_regret |",
+        "|---|---|---|---|---|---|---|",
     ]
-    for r in summary.get("stage_a_by_rule", []):
-        lines.append(f"| {r['rule']} | {r['mean_sd_threshold']:.4f} | {r['mean_spike_rate']:.4f} |")
-    lines += ["", "_Verdict per the plan's decision rules is filled in once the full Grid run lands._", ""]
+    for r in by_arm.to_dict("records"):
+        lines.append(
+            f"| {r['arm']} | {_fmt(r['sd_threshold'])} | {_fmt(r['sd_dthreshold'])} | "
+            f"{_fmt(r['spike_rate'])} | {_fmt(r['cost_sd'])} | {_fmt(r['oracle_sd'])} | {_fmt(r['mean_regret'])} |"
+        )
+    lines.append("")
+    if not base.empty:
+        b = base.iloc[0]
+        best = by_arm.loc[by_arm["sd_threshold"].idxmin()]
+        lines += [
+            f"**Baseline** `{cfg.BASELINE_ARM}`: sd_threshold={_fmt(b['sd_threshold'])}, "
+            f"spike_rate={_fmt(b['spike_rate'])}.",
+            f"**Lowest threshold noise:** `{best['arm']}` "
+            f"(sd_threshold={_fmt(best['sd_threshold'])}, spike_rate={_fmt(best['spike_rate'])}).",
+            "",
+            "Decision rules (plan): adopt the cheapest arm cutting spike incidence >=80% and",
+            "across-seed cost sd >=50% vs argmin-k2 without worsening mean regret by >0.01.",
+        ]
     (common.RESULTS / "REPORT.md").write_text("\n".join(lines))
 
 

--- a/scripts/experiments/threshold_stability/analyze.py
+++ b/scripts/experiments/threshold_stability/analyze.py
@@ -26,7 +26,7 @@ import experiment_config as cfg  # noqa: E402
 def _load_stage_a(cells_dir: Path):
     import pandas as pd  # noqa: PLC0415
 
-    files = sorted(cells_dir.glob("*/replay.csv"))
+    files = sorted(cells_dir.glob("*/replay_seed*.csv"))
     frames = []
     for p in files:
         try:
@@ -35,8 +35,8 @@ def _load_stage_a(cells_dir: Path):
             continue
         if df.empty:
             continue
-        slug = p.parent.name  # <class_slug>__seed<seed>
-        df["cell"] = slug
+        df["cell"] = p.parent.name  # <class_slug>
+        df["seed"] = p.stem.removeprefix("replay_seed")  # replay_seed<N>.csv
         frames.append(df)
     return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
 

--- a/scripts/experiments/threshold_stability/experiment_config.py
+++ b/scripts/experiments/threshold_stability/experiment_config.py
@@ -17,6 +17,7 @@ the embeddings come from the #2790 cache, and the MLPs are tiny.
 from __future__ import annotations
 
 import os
+import re
 
 # --- Fixed #2790 repro config (pre-registered) ---
 DATASET = os.environ.get("THRSTAB_DATASET", "coco")
@@ -53,8 +54,14 @@ REPLAY_TRAINER_SEEDS = int(os.environ.get("THRSTAB_REPLAY_TRAINER_SEEDS", "10"))
 
 
 def class_slug(cls: str) -> str:
-    """Filesystem-safe class slug matching the sweep's own slugging."""
-    return cls.strip().replace(" ", "_").replace("/", "-")
+    """Filesystem-safe class slug **identical to** ``scripts/sod/features.slugify``.
+
+    The exemplar cache dir and the labeling-trace path are keyed on this exact
+    slug (e.g. ``stop sign`` -> ``stop-sign``); a mismatch means the replay tool
+    can't find a class's exemplars. Replicated here (rather than imported) so the
+    config stays importable without the sod package on the path.
+    """
+    return re.sub(r"[^a-z0-9]+", "-", cls.strip().lower()).strip("-")
 
 
 def array_cells() -> list[dict]:

--- a/scripts/experiments/threshold_stability/experiment_config.py
+++ b/scripts/experiments/threshold_stability/experiment_config.py
@@ -48,9 +48,11 @@ ARMS: list[tuple[str, str, str, int]] = [
 #: The baseline arm whose recorded --labeling-trace Stage A replays (frozen votes).
 BASELINE_ARM = "argmin-k2"
 
-#: Stage A replay depth (fold-split seeds × trainer seeds), per the plan.
-REPLAY_FOLD_SEEDS = int(os.environ.get("THRSTAB_REPLAY_FOLD_SEEDS", "10"))
-REPLAY_TRAINER_SEEDS = int(os.environ.get("THRSTAB_REPLAY_TRAINER_SEEDS", "10"))
+#: Stage A replay depth (fold-split seeds × trainer seeds). The plan's 10×10 is
+#: 100 refits per (step, rule); default to a lighter 5×3 that still resolves the
+#: split-vs-fit variance split and finishes overnight (override up for the final).
+REPLAY_FOLD_SEEDS = int(os.environ.get("THRSTAB_REPLAY_FOLD_SEEDS", "5"))
+REPLAY_TRAINER_SEEDS = int(os.environ.get("THRSTAB_REPLAY_TRAINER_SEEDS", "3"))
 
 
 def class_slug(cls: str) -> str:
@@ -65,5 +67,10 @@ def class_slug(cls: str) -> str:
 
 
 def array_cells() -> list[dict]:
-    """Enumerate ``(class, seed)`` cells for the SLURM array (stable order)."""
-    return [{"cls": cls, "seed": seed} for cls in CLASSES for seed in SEEDS]
+    """Enumerate SLURM-array cells — **one per class**.
+
+    Each cell runs every arm once with ``--iterations len(SEEDS)`` (so all seeds
+    for an arm come from a single sweep, sharing the cache) and replays each
+    seed's baseline trace. One-per-class (not per (class, seed)) avoids re-running
+    the low seeds that ``--iterations N`` = seeds ``0..N-1`` would duplicate."""
+    return [{"cls": cls} for cls in CLASSES]

--- a/scripts/experiments/threshold_stability/run_cells.py
+++ b/scripts/experiments/threshold_stability/run_cells.py
@@ -32,7 +32,7 @@ import experiment_config as cfg  # noqa: E402
 SOD = common.REPO / "scripts" / "sod"
 
 
-def _sweep_cmd(cls: str, seed: int, arm: tuple[str, str, str, int], out_dir: Path) -> list[str]:
+def _sweep_cmd(cls: str, arm: tuple[str, str, str, int], out_dir: Path) -> list[str]:
     _name, rule, smooth, kcount = arm
     return [
         sys.executable,
@@ -46,7 +46,7 @@ def _sweep_cmd(cls: str, seed: int, arm: tuple[str, str, str, int], out_dir: Pat
         "--proposals",
         cfg.PROPOSAL,
         "--iterations",
-        str(seed + 1),  # sweep seeds 0..N-1; run just this seed's row via array
+        str(len(cfg.SEEDS)),  # all seeds 0..N-1 in one sweep
         "--max-labels",
         str(cfg.MAX_LABELS),
         "--neg-multiple",
@@ -104,24 +104,29 @@ def _run(cmd: list[str]) -> int:
 
 
 def run_cell(cell: dict) -> None:
-    cls, seed = cell["cls"], cell["seed"]
-    cell_dir = common.RESULTS / "cells" / f"{cfg.class_slug(cls)}__seed{seed}"
+    cls = cell["cls"]
+    cell_dir = common.RESULTS / "cells" / cfg.class_slug(cls)
     cell_dir.mkdir(parents=True, exist_ok=True)
 
-    baseline_trace: Path | None = None
+    # Stage B: every arm, all seeds in one sweep each.
+    baseline_dir: Path | None = None
     for arm in cfg.ARMS:
         name = arm[0]
         out_dir = cell_dir / f"arm_{name}"
-        _run(_sweep_cmd(cls, seed, arm, out_dir))
-        # The sweep writes labeling_trace/<slug>/<config>/seed<seed>/; find this seed's dir.
-        traces = sorted(out_dir.glob(f"labeling_trace/*/*/seed{seed}"))
-        if name == cfg.BASELINE_ARM and traces:
-            baseline_trace = traces[0]
+        _run(_sweep_cmd(cls, arm, out_dir))
+        if name == cfg.BASELINE_ARM:
+            baseline_dir = out_dir
 
-    if baseline_trace is not None:
-        _run(_replay_cmd(cls, baseline_trace, cell_dir / "replay.csv"))
-    else:
-        common.log(f"WARN: no baseline trace for {cls} seed{seed}; Stage A replay skipped")
+    # Stage A: replay each seed's frozen baseline trace.
+    if baseline_dir is None:
+        common.log(f"WARN: no baseline arm dir for {cls}; Stage A skipped")
+        return
+    for seed in cfg.SEEDS:
+        traces = sorted(baseline_dir.glob(f"labeling_trace/*/*/seed{seed}"))
+        if not traces:
+            common.log(f"WARN: no baseline trace for {cls} seed{seed}; replay skipped")
+            continue
+        _run(_replay_cmd(cls, traces[0], cell_dir / f"replay_seed{seed}.csv"))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/experiments/threshold_stability/run_cells.py
+++ b/scripts/experiments/threshold_stability/run_cells.py
@@ -65,36 +65,11 @@ def _sweep_cmd(cls: str, arm: tuple[str, str, str, int], out_dir: Path) -> list[
         str(common.CACHE_DIR),
         "--out-dir",
         str(out_dir),
-        "--labeling-trace",
-    ]
-
-
-def _replay_cmd(cls: str, trace_dir: Path, out_csv: Path) -> list[str]:
-    return [
-        sys.executable,
-        str(SOD / "replay_thresholds.py"),
-        "--trace-dir",
-        str(trace_dir),
-        "--cache-dir",
-        str(common.CACHE_DIR),
-        "--dataset",
-        cfg.DATASET,
-        "--embedder",
-        cfg.EMBEDDER,
-        "--class-slug",
-        cfg.class_slug(cls),
-        "--proposal-slug",
-        cfg.PROPOSAL,
-        "--rules",
-        "argmin,conformal,rank-transfer",
-        "--fold-seeds",
-        str(cfg.REPLAY_FOLD_SEEDS),
-        "--trainer-seeds",
-        str(cfg.REPLAY_TRAINER_SEEDS),
-        "--inclusion",
-        str(cfg.INCLUSION),
-        "--out",
-        str(out_csv),
+        # No --labeling-trace: it renders ~2 PNGs/step (tens of thousands of files,
+        # multiple GB) and Stage B needs none of it — results.jsonl already carries
+        # per-(seed, t) threshold/cost/oracle_cost, which is everything the analyzer
+        # needs. (Stage A replay, which needs the frozen-vote trace.json, is a
+        # separate PNG-free follow-up; see THRESHOLD_STABILITY_STATUS.)
     ]
 
 
@@ -108,25 +83,12 @@ def run_cell(cell: dict) -> None:
     cell_dir = common.RESULTS / "cells" / cfg.class_slug(cls)
     cell_dir.mkdir(parents=True, exist_ok=True)
 
-    # Stage B: every arm, all seeds in one sweep each.
-    baseline_dir: Path | None = None
+    # Stage B: every arm, all seeds in one sweep each. results.jsonl per arm carries
+    # per-(seed, t) threshold/cost/oracle_cost — analyze.py derives the full
+    # threshold-stability comparison from it (no trace files, no PNGs, no replay).
     for arm in cfg.ARMS:
-        name = arm[0]
-        out_dir = cell_dir / f"arm_{name}"
+        out_dir = cell_dir / f"arm_{arm[0]}"
         _run(_sweep_cmd(cls, arm, out_dir))
-        if name == cfg.BASELINE_ARM:
-            baseline_dir = out_dir
-
-    # Stage A: replay each seed's frozen baseline trace.
-    if baseline_dir is None:
-        common.log(f"WARN: no baseline arm dir for {cls}; Stage A skipped")
-        return
-    for seed in cfg.SEEDS:
-        traces = sorted(baseline_dir.glob(f"labeling_trace/*/*/seed{seed}"))
-        if not traces:
-            common.log(f"WARN: no baseline trace for {cls} seed{seed}; replay skipped")
-            continue
-        _run(_replay_cmd(cls, traces[0], cell_dir / f"replay_seed{seed}.csv"))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/experiments/threshold_stability/run_cells.py
+++ b/scripts/experiments/threshold_stability/run_cells.py
@@ -144,7 +144,7 @@ def main(argv: list[str] | None = None) -> int:
         common.log(f"index {idx} >= {len(cells)} cells; nothing to do")
         return 0
     cell = cells[idx]
-    common.log(f"cell {idx}/{len(cells)}: class={cell['cls']!r} seed={cell['seed']} arms={[a[0] for a in cfg.ARMS]}")
+    common.log(f"cell {idx}/{len(cells)}: class={cell['cls']!r} arms={[a[0] for a in cfg.ARMS]}")
     run_cell(cell)
     return 0
 

--- a/scripts/experiments/threshold_stability/spike_analysis.py
+++ b/scripts/experiments/threshold_stability/spike_analysis.py
@@ -1,0 +1,150 @@
+"""Attribute the #2790 cost spikes to the individual votes that cause them.
+
+Reads ``--labeling-trace`` ``trace.json`` files (one per class/seed) and finds every
+step where the held-out **cost jumps UP** by more than ``--thresh`` — the single-step
+excursions #2790 reports. Each up-spike is attributed to the vote added *that* step
+(the image whose label triggered the retrain), and the tool aggregates the culprits
+to look for a blockable pattern:
+
+* is the culprit a **good** or a **bad** vote?
+* which way does the **threshold** move (up = reject more -> FNR spike)?
+* is the spike **FNR-driven** (cut jumped above real matches) or **FPR-driven**?
+* is it **narrow** (recovers the next step, as #2790 observed)?
+* where in the loop (vote count ``t``), which ``calib_mode`` / ``phase``, and how
+  marginal was the culprit's surfacing score?
+
+Usage: ``python spike_analysis.py --root <dir with labeling_trace/...> [--thresh 0.1]``
+Writes a summary to stdout and ``spike_rows.csv`` next to ``--root``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def _f(x):
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _class_seed(trace_path: Path) -> tuple[str, str]:
+    # .../labeling_trace/whole/coco_<slug>_siglip2_whole/seed<N>/trace.json
+    seed = trace_path.parent.name.removeprefix("seed")
+    cfg = trace_path.parent.parent.name  # coco_<slug>_siglip2_whole
+    cls = cfg.replace("coco_", "").replace("_siglip2_whole", "")
+    return cls, seed
+
+
+def collect_spikes(root: Path, thresh: float) -> list[dict]:
+    rows: list[dict] = []
+    for tj in sorted(root.rglob("trace.json")):
+        cls, seed = _class_seed(tj)
+        trace = sorted(json.loads(tj.read_text()), key=lambda e: e["t"])
+        for i in range(1, len(trace)):
+            prev, cur = trace[i - 1], trace[i]
+            dcost = _f(cur.get("cost")) - _f(prev.get("cost"))
+            if not (dcost > thresh):  # up-spikes only (NaN-safe)
+                continue
+            nxt = trace[i + 1] if i + 1 < len(trace) else None
+            recover = _f(nxt.get("cost")) - _f(cur.get("cost")) if nxt else float("nan")
+            rows.append(
+                {
+                    "cls": cls,
+                    "seed": seed,
+                    "t": cur.get("t"),
+                    "culprit_label": cur.get("gt_label"),
+                    "culprit_id": cur.get("image_id"),
+                    "select_mode": cur.get("select_mode"),
+                    "phase": cur.get("phase"),
+                    "calib_mode": cur.get("calib_mode"),
+                    "dcost": round(dcost, 4),
+                    "d_threshold": round(_f(cur.get("threshold")) - _f(prev.get("threshold")), 4),
+                    "d_fnr": round(_f(cur.get("fnr")) - _f(prev.get("fnr")), 4),
+                    "d_fpr": round(_f(cur.get("fpr")) - _f(prev.get("fpr")), 4),
+                    "recover_dcost": round(recover, 4),
+                    "narrow": bool(recover < -0.5 * dcost) if recover == recover else False,
+                    "surface_score": cur.get("surface_score"),
+                    "surface_margin": cur.get("surface_margin"),
+                    "n_good": prev.get("n_good"),
+                    "n_bad": prev.get("n_bad"),
+                }
+            )
+    return rows
+
+
+def summarize(rows: list[dict], n_traces: int, thresh: float) -> str:
+    if not rows:
+        return f"No up-spikes (Δcost > {thresh}) found across {n_traces} traces."
+    n = len(rows)
+
+    def pct(cond) -> str:
+        k = sum(1 for r in rows if cond(r))
+        return f"{k}/{n} ({100 * k / n:.0f}%)"
+
+    good = pct(lambda r: r["culprit_label"] == "good")
+    bad = pct(lambda r: r["culprit_label"] == "bad")
+    thr_up = pct(lambda r: r["d_threshold"] > 0)
+    fnr_driven = pct(lambda r: r["d_fnr"] > r["d_fpr"])
+    narrow = pct(lambda r: r["narrow"])
+    by_phase = Counter(r["phase"] for r in rows)
+    by_calib = Counter(r["calib_mode"] for r in rows)
+    by_select = Counter(r["select_mode"] for r in rows)
+    by_cls = Counter(r["cls"] for r in rows)
+    ts = sorted(r["t"] for r in rows if r["t"] is not None)
+    worst = sorted(rows, key=lambda r: -r["dcost"])[:8]
+
+    lines = [
+        f"# Spike attribution — {n} up-spikes (Δcost > {thresh}) across {n_traces} traces",
+        "",
+        f"Culprit vote label:   good={good}   bad={bad}",
+        f"Threshold moved UP:   {thr_up}   (up = cut rejects more -> FNR)",
+        f"FNR-driven (Δfnr>Δfpr): {fnr_driven}",
+        f"Narrow (recovers next step): {narrow}",
+        "",
+        f"By phase:  {dict(by_phase.most_common())}",
+        f"By calib_mode: {dict(by_calib.most_common())}",
+        f"By select_mode: {dict(by_select.most_common())}",
+        f"By class:  {dict(by_cls.most_common())}",
+        f"Vote-count t: min={ts[0] if ts else '-'} median={ts[len(ts) // 2] if ts else '-'} max={ts[-1] if ts else '-'}",
+        "",
+        "Worst spikes (by Δcost):",
+        "  cls / seed / t / label / Δcost / Δthr / Δfnr / Δfpr / narrow / calib / phase / surf_margin",
+    ]
+    for r in worst:
+        lines.append(
+            f"  {r['cls']} s{r['seed']} t{r['t']} {r['culprit_label']} "
+            f"Δcost={r['dcost']} Δthr={r['d_threshold']} Δfnr={r['d_fnr']} Δfpr={r['d_fpr']} "
+            f"narrow={r['narrow']} {r['calib_mode']} {r['phase']} surf_margin={r['surface_margin']}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Attribute #2790 cost spikes to their votes.")
+    ap.add_argument("--root", required=True, help="Dir containing labeling_trace/.../trace.json")
+    ap.add_argument("--thresh", type=float, default=0.1)
+    ap.add_argument("--out", default=None, help="CSV of spike rows (default <root>/spike_rows.csv)")
+    args = ap.parse_args(argv)
+
+    root = Path(args.root)
+    n_traces = sum(1 for _ in root.rglob("trace.json"))
+    rows = collect_spikes(root, args.thresh)
+    out = Path(args.out) if args.out else root / "spike_rows.csv"
+    if rows:
+        with out.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+            w.writeheader()
+            w.writerows(rows)
+    print(summarize(rows, n_traces, args.thresh))
+    print(f"\n[{len(rows)} rows -> {out}]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/threshold_stability/spike_analysis.py
+++ b/scripts/experiments/threshold_stability/spike_analysis.py
@@ -120,7 +120,8 @@ def summarize(rows: list[dict], n_traces: int, thresh: float) -> str:
         "",
         f"Culprit vote label:   good={good}   bad={bad}",
         f"  ... bad vote AND hard-selected: {bad_hard}",
-        f"Threshold moved UP:   {thr_up}   (up = cut rejects more -> FNR)",
+        f"Raw threshold 'up':   {thr_up}   (NOT model-comparable — MLP retrained each vote; "
+        f"use the FNR operating-point move below, which is test-set and sound)",
         f"FNR-driven (Δfnr>Δfpr): {fnr_driven}",
         f"Early (t<20): {early}",
         f"Sparse positives at spike (n_good<=6): {sparse_pos}   (median n_good at spike = {med_good})",

--- a/scripts/experiments/threshold_stability/spike_analysis.py
+++ b/scripts/experiments/threshold_stability/spike_analysis.py
@@ -53,6 +53,14 @@ def collect_spikes(root: Path, thresh: float) -> list[dict]:
                 continue
             nxt = trace[i + 1] if i + 1 < len(trace) else None
             recover = _f(nxt.get("cost")) - _f(cur.get("cost")) if nxt else float("nan")
+            # Steps until cost returns near the pre-spike level (within 0.05), up to 5
+            # steps out — measures how "narrow" the excursion actually is.
+            pre_cost = _f(prev.get("cost"))
+            recover_steps = None
+            for k in range(1, 6):
+                if i + k < len(trace) and _f(trace[i + k].get("cost")) <= pre_cost + 0.05:
+                    recover_steps = k
+                    break
             rows.append(
                 {
                     "cls": cls,
@@ -68,7 +76,8 @@ def collect_spikes(root: Path, thresh: float) -> list[dict]:
                     "d_fnr": round(_f(cur.get("fnr")) - _f(prev.get("fnr")), 4),
                     "d_fpr": round(_f(cur.get("fpr")) - _f(prev.get("fpr")), 4),
                     "recover_dcost": round(recover, 4),
-                    "narrow": bool(recover < -0.5 * dcost) if recover == recover else False,
+                    "recover_steps": recover_steps,  # None = still elevated 5 steps later
+                    "narrow": recover_steps is not None and recover_steps <= 2,
                     "surface_score": cur.get("surface_score"),
                     "surface_margin": cur.get("surface_margin"),
                     "n_good": prev.get("n_good"),
@@ -92,6 +101,9 @@ def summarize(rows: list[dict], n_traces: int, thresh: float) -> str:
     thr_up = pct(lambda r: r["d_threshold"] > 0)
     fnr_driven = pct(lambda r: r["d_fnr"] > r["d_fpr"])
     narrow = pct(lambda r: r["narrow"])
+    rec = Counter(("never>5" if r["recover_steps"] is None else r["recover_steps"]) for r in rows)
+    early = pct(lambda r: (r["t"] or 0) < 20)
+    bad_hard = pct(lambda r: r["culprit_label"] == "bad" and r["select_mode"] == "hard")
     by_phase = Counter(r["phase"] for r in rows)
     by_calib = Counter(r["calib_mode"] for r in rows)
     by_select = Counter(r["select_mode"] for r in rows)
@@ -103,9 +115,12 @@ def summarize(rows: list[dict], n_traces: int, thresh: float) -> str:
         f"# Spike attribution — {n} up-spikes (Δcost > {thresh}) across {n_traces} traces",
         "",
         f"Culprit vote label:   good={good}   bad={bad}",
+        f"  ... bad vote AND hard-selected: {bad_hard}",
         f"Threshold moved UP:   {thr_up}   (up = cut rejects more -> FNR)",
         f"FNR-driven (Δfnr>Δfpr): {fnr_driven}",
-        f"Narrow (recovers next step): {narrow}",
+        f"Early (t<20): {early}",
+        f"Narrow (recovers to pre-spike within 2 steps): {narrow}",
+        f"Recovery-steps distribution: {dict(sorted(rec.items(), key=lambda kv: str(kv[0])))}",
         "",
         f"By phase:  {dict(by_phase.most_common())}",
         f"By calib_mode: {dict(by_calib.most_common())}",

--- a/scripts/experiments/threshold_stability/spike_analysis.py
+++ b/scripts/experiments/threshold_stability/spike_analysis.py
@@ -104,6 +104,10 @@ def summarize(rows: list[dict], n_traces: int, thresh: float) -> str:
     rec = Counter(("never>5" if r["recover_steps"] is None else r["recover_steps"]) for r in rows)
     early = pct(lambda r: (r["t"] or 0) < 20)
     bad_hard = pct(lambda r: r["culprit_label"] == "bad" and r["select_mode"] == "hard")
+    sparse_pos = pct(lambda r: (r["n_good"] or 0) <= 6)
+    runaway = pct(lambda r: _f(r.get("d_fnr")) > 0.2)  # cut jumped over a big chunk of positives
+    goods = sorted(r["n_good"] for r in rows if r["n_good"] is not None)
+    med_good = goods[len(goods) // 2] if goods else "-"
     by_phase = Counter(r["phase"] for r in rows)
     by_calib = Counter(r["calib_mode"] for r in rows)
     by_select = Counter(r["select_mode"] for r in rows)
@@ -119,6 +123,8 @@ def summarize(rows: list[dict], n_traces: int, thresh: float) -> str:
         f"Threshold moved UP:   {thr_up}   (up = cut rejects more -> FNR)",
         f"FNR-driven (Δfnr>Δfpr): {fnr_driven}",
         f"Early (t<20): {early}",
+        f"Sparse positives at spike (n_good<=6): {sparse_pos}   (median n_good at spike = {med_good})",
+        f"Runaway (Δfnr>0.2 — cut vaulted over many positives): {runaway}",
         f"Narrow (recovers to pre-spike within 2 steps): {narrow}",
         f"Recovery-steps distribution: {dict(sorted(rec.items(), key=lambda kv: str(kv[0])))}",
         "",

--- a/scripts/sod/THRESHOLD_STABILITY_STATUS.md
+++ b/scripts/sod/THRESHOLD_STABILITY_STATUS.md
@@ -1,5 +1,11 @@
 # Threshold-stability study (#2790) — build status & handoff
 
+**Stage B is RUN. Verdict + numbers: [`docs/experiments/threshold-stability/REPORT.md`](../../docs/experiments/threshold-stability/REPORT.md).**
+Headline: the variance is threshold placement (cost sd ≈ 4× oracle floor); fold
+count (`k8`) is the dominant stability lever, conformal's win is regret (−37%), best
+practical arm `conformal-k8`; no arm clears the strict bar → S3 follow-up indicated.
+Stage A replay + region-voting-path conformal remain (see below).
+
 Branch `claude/threshold-stability-2790` off `evaluation-framework`. This is the
 harness half of the pre-registered study in `docs/plans/threshold-stability-experiment.md`
 (on `dev`). Real runs are Grid-gated (no GPU/COCO/SigLIP cache on the laptop), so

--- a/scripts/sod/replay_thresholds.py
+++ b/scripts/sod/replay_thresholds.py
@@ -295,23 +295,16 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--out", required=True, help="Output CSV path for the decomposition.")
     args = ap.parse_args(argv)
 
-    from vtscore.training.mlp import train_model  # noqa: PLC0415
+    from vtscore.eval.scoring_heads import MLPHead  # noqa: PLC0415
 
     def trainer_fn_factory():
-        def trainer_fn(X, y, seed):  # noqa: ARG001 - signature fixed by TrainerFn
-            import torch  # noqa: PLC0415
-
-            model = train_model(
-                torch.tensor(np.asarray(X), dtype=torch.float32),
-                torch.tensor(np.asarray(y), dtype=torch.float32).unsqueeze(1),
-                X.shape[1],
-            )
-
-            def predict(Xc):
-                with torch.no_grad():
-                    return model(torch.tensor(np.asarray(Xc), dtype=torch.float32)).squeeze(-1).numpy()
-
-            return predict
+        # Reuse the sweep's exact head so replayed thresholds are on the same
+        # (sigmoid [0,1]) score scale the live loop calibrates on — a hand-rolled
+        # trainer that skipped the sigmoid would calibrate on raw logits and be
+        # incomparable to the sweep. MLPHead builds per fold-fit with the right
+        # input_dim and trains via ``train_model(..., seed=seed)`` identically.
+        def trainer_fn(X, y, seed):
+            return MLPHead(int(X.shape[1])).trainer_fn()(X, y, seed)
 
         return trainer_fn
 

--- a/scripts/sod/sweep.py
+++ b/scripts/sod/sweep.py
@@ -529,6 +529,7 @@ def _render_realistic_viz(args, cell, cache_root: Path, buckets, slug: str, fina
                         proposal=cell["proposal"],
                         alpha=cell["alpha"],
                         seed=s,
+                        images=args.trace_images,
                     )
     except Exception:
         print(f"  viz realistic error {cell}:\n{traceback.format_exc()}", flush=True)
@@ -623,6 +624,14 @@ def main() -> int:
         help="realistic: emit labeling_trace/<config>/seed{N}/ — the images labeled in order (per iteration) "
         "+ trace.csv/json (phase/head/calib/threshold/score per step). Off by default (heavy: one image per "
         "labeled item × every iteration). Independent of --viz.",
+    )
+    ap.add_argument(
+        "--trace-images",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="with --labeling-trace, also render the per-step PNGs (default on). "
+        "--no-trace-images writes only trace.json/trace.csv — KB-sized, for the vote/threshold "
+        "record without the multi-GB image dump (spike analysis, Stage-A replay).",
     )
     ap.add_argument("--test-fraction", type=float, default=0.5)
     ap.add_argument("--inclusion", type=int, default=0, help="0=FPR+FNR; >0 favors recall; <0 favors precision")

--- a/scripts/sod/viz.py
+++ b/scripts/sod/viz.py
@@ -767,9 +767,17 @@ def render_labeling_trace(
     proposal: str,
     alpha: float,
     seed: int,
+    images: bool = True,
 ) -> None:
     """Write one seed's labeling trace: numbered images in the order the realistic loop
-    labeled them, plus ``trace.csv`` / ``trace.json``. Per step, two images (named
+    labeled them, plus ``trace.csv`` / ``trace.json``.
+
+    With ``images=False`` only ``trace.json`` / ``trace.csv`` are written (the per-step
+    PNGs — the bulk of the output, ~2 files/step — are skipped). Use this when you only
+    need the per-step vote/threshold/cost record, e.g. the threshold-stability spike
+    analysis or Stage-A replay, and can't afford tens of thousands of images on a
+    space-tight volume. ``snapped_region`` is left blank in that mode (it is computed
+    during image rendering). Per step (``images=True``), two images (named
     ``{t:03d}_{iid}_{good|bad}_*`` so they sort in labeling order):
 
     * ``…_pred.png`` — GT green + the detector's surfacing box/score red.
@@ -797,7 +805,7 @@ def render_labeling_trace(
     (d / "trace.json").write_text(json.dumps(trace, indent=2))
     snapped_by_t: dict[int, int | None] = {}
 
-    for e in trace:
+    for e in trace if images else []:
         iid = e["image_id"]
         try:
             img = ds.load_image(iid)


### PR DESCRIPTION
Follow-on to #2795 (which merged the harness core). This is the **run + results**: the study was executed on the Grid (COCO × SigLIP 2 × whole, 6 arms × 5 classes × 10 seeds) and drilled into the individual spike-causing votes.

## Report
`docs/experiments/threshold-stability/REPORT.md` (force-added; `docs/experiments/*` is gitignored).

## Stage B verdict
- The cross-seed variance is **threshold placement, not ranking** (cost sd ≈ 4× the oracle floor).
- **Fold count (`k8`) is the dominant stability lever, not the rule.**
- **Conformal's win is regret (−37%)**, not jitter. No arm clears the strict adoption bar → S3 (fold→final scale) follow-up. Practical rec: **conformal-k8**.

## Spike attribution (278 up-spikes on argmin-k2)
- **87% caused by a Bad vote; 79% Bad + `hard`-selected** at the boundary (surfacing margin ≈ 0.001).
- **76% FNR-driven; 37% runaways** (test FNR up toward 1.0); **67% in the sparse-positive regime** (median n_good = 4).
- Only 26% narrow — 54% persist 5+ steps (compounding via boundary acquisition), correcting the "narrow blip" intuition.
- **Blockable:** the #2784 conformal within-model positive-coverage floor structurally blocks the runaway third; plus a sparse-positive deferral and an acquisition guard.

## Methodology note (from review)
The MLP is retrained every vote, so raw thresholds are **not comparable across steps**. All findings are stated on **test-set** cost/fnr/fpr and "far from *this* model's own oracle cut" — no cross-model threshold deltas. The per-vote-threshold-clamp idea was dropped as unsound for that reason.

## Also
- Fidelity fixes caught by the Grid pilot: replay now reuses the sweep's `MLPHead` (sigmoid scale); `class_slug` matches `features.slugify` (hyphens).
- Disk-safe: `--no-trace-images` writes `trace.json`/`trace.csv` without the PNG dump (the PNGs filled the 50 GB `/exp` and killed the first run); Stage B analysis derives everything from `results.jsonl`.
- `scripts/experiments/threshold_stability/` runner (cell=class) + `spike_analysis.py`.

Deferred (recorded in report + status doc): Stage A replay run, region-voting-path conformal, the S3 arm.

Refs #2790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)