### PR TITLE
Fit the safe-threshold GMM on inference-geometry scores

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -13807,6 +13807,7 @@
     },
     "/api/label-file-sort": {
       "post": {
+        "description": "On a patch dataset each result also carries the ``best_region`` box of the\nregion that drove its score, matching the cosine- and learned-sort paths.",
         "operationId": "label_file_sort",
         "responses": {
           "200": {

--- a/tests_lib/detectors/test_safe_threshold_region_geometry.py
+++ b/tests_lib/detectors/test_safe_threshold_region_geometry.py
@@ -1,0 +1,147 @@
+"""``train_and_threshold``'s safe-threshold GMM must be fitted on inference geometry.
+
+The blended threshold this function returns is later compared against the
+per-media scores ``score_media_with_model`` produces - which, on a patch
+dataset, are **region max-pooled** (~24 region rows collapsed to their max).
+Fitting the GMM on the one image-level vector per media instead put the fitted
+component means systematically below the distribution the cut is applied to
+(the region max is >= the whole-image region's own score), biasing the midpoint
+low and over-including on region-voting detectors.
+
+These tests pin that the GMM sees exactly the scores inference computes: the
+pooled distribution on a region dataset, and the unchanged embedding-matrix
+distribution on a plain single-vector dataset.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+import vtscore.state as core_state
+import vtscore.training as training_pkg
+from vtscore.detectors.training import _score_all_media, train_and_threshold
+from vtscore.embedding.matrix import get_embedding_matrix_for_snap
+from vtscore.media.patch_embed import RegionVector
+
+DIM = 8
+N_MEDIA = 20
+
+
+def _unit(vec: np.ndarray) -> np.ndarray:
+    return (vec / (np.linalg.norm(vec) + 1e-8)).astype(np.float32)
+
+
+@pytest.fixture
+def captured_gmm_scores(monkeypatch):
+    """Turn safe-thresholds on and record the scores the GMM blend is fitted on."""
+    monkeypatch.setattr(core_state, "get_safe_thresholds", lambda: True)
+
+    seen: list[list[float]] = []
+    real = training_pkg.calculate_safe_threshold
+
+    def _spy(xcal_threshold, all_scores, n_labels):
+        seen.append([float(s) for s in all_scores])
+        return real(xcal_threshold, all_scores, n_labels)
+
+    monkeypatch.setattr(training_pkg, "calculate_safe_threshold", _spy)
+    return seen
+
+
+def _labels(rng: np.random.Generator, good_proto: np.ndarray, bad_proto: np.ndarray):
+    """Eight labels (>= the ramp floor) clustered around two prototypes."""
+    X_list, y_list = [], []
+    for _ in range(4):
+        X_list.append(_unit(good_proto + 0.1 * rng.standard_normal(DIM)))
+        y_list.append(1.0)
+        X_list.append(_unit(bad_proto + 0.1 * rng.standard_normal(DIM)))
+        y_list.append(0.0)
+    return X_list, y_list
+
+
+def _image_level_scores(model, snap, embedder_name):
+    """Score one image-level vector per media - the pre-fix GMM input."""
+    all_ids, embs = get_embedding_matrix_for_snap(snap, embedder_name)
+    with torch.no_grad():
+        logits = model(torch.from_numpy(embs).to(next(model.parameters()).device))
+        return all_ids, torch.sigmoid(logits).squeeze(-1).cpu().numpy().astype(np.float64)
+
+
+class TestRegionDatasetFitsPooledScores:
+    def _snap(self, rng: np.random.Generator, good_proto: np.ndarray) -> dict[int, dict]:
+        """Media whose region tree is ``[whole-image root, a good-like sub-region]``.
+
+        The root region carries the media's own image-level vector, so the
+        pooled score is by construction >= the image-level score - exactly the
+        one-sided bias the old fit suffered from.
+        """
+        snap: dict[int, dict] = {}
+        for cid in range(1, N_MEDIA + 1):
+            image_vec = _unit(rng.standard_normal(DIM))
+            hot_vec = _unit(good_proto + 0.4 * rng.standard_normal(DIM))
+            snap[cid] = {
+                "id": cid,
+                "media_type": "image",
+                "embedder": "dinov3_patch",
+                "embeddings": {"dinov3_patch": image_vec},
+                "patch_regions": [
+                    RegionVector(box=(0.0, 0.0, 1.0, 1.0), vec=image_vec),
+                    RegionVector(box=(0.25, 0.25, 0.75, 0.75), vec=hot_vec),
+                ],
+            }
+        return snap
+
+    def test_gmm_sees_region_max_pooled_scores(self, captured_gmm_scores):
+        rng = np.random.default_rng(11)
+        good_proto = _unit(rng.standard_normal(DIM))
+        bad_proto = _unit(rng.standard_normal(DIM))
+        snap = self._snap(rng, good_proto)
+        X_list, y_list = _labels(rng, good_proto, bad_proto)
+
+        model, _threshold = train_and_threshold(
+            X_list, y_list, snap=snap, embedder_name="dinov3_patch"
+        )
+
+        assert len(captured_gmm_scores) == 1
+        fitted = np.asarray(captured_gmm_scores[0], dtype=np.float64)
+
+        # What inference will actually compare against the threshold.
+        pooled_ids, pooled, _best = _score_all_media(model, snap, "dinov3_patch")
+        np.testing.assert_allclose(fitted, np.asarray(pooled, dtype=np.float64), rtol=0, atol=0)
+
+        # ...and it is a genuinely different distribution from the image-level
+        # one the GMM used to be fitted on: never lower, sometimes higher.
+        image_ids, image_level = _image_level_scores(model, snap, "dinov3_patch")
+        assert image_ids == pooled_ids
+        assert np.all(fitted >= image_level - 1e-9)
+        assert np.any(fitted > image_level + 1e-6), (
+            "the region max-pool must lift at least one media's score above its "
+            "image-level score, otherwise this fixture proves nothing"
+        )
+
+
+class TestPlainDatasetUnchanged:
+    def test_gmm_still_sees_the_embedding_matrix_scores(self, captured_gmm_scores):
+        """A single-vector dataset takes ``_score_all_media``'s matrix fallback,
+        so the fitted distribution is byte-for-byte the pre-fix one."""
+        rng = np.random.default_rng(13)
+        good_proto = _unit(rng.standard_normal(DIM))
+        bad_proto = _unit(rng.standard_normal(DIM))
+        snap = {
+            cid: {
+                "id": cid,
+                "media_type": "audio",
+                "embedder": "test",
+                "embeddings": {"test": _unit(rng.standard_normal(DIM))},
+            }
+            for cid in range(1, N_MEDIA + 1)
+        }
+        X_list, y_list = _labels(rng, good_proto, bad_proto)
+
+        model, _threshold = train_and_threshold(X_list, y_list, snap=snap)
+
+        assert len(captured_gmm_scores) == 1
+        fitted = np.asarray(captured_gmm_scores[0], dtype=np.float64)
+        _ids, image_level = _image_level_scores(model, snap, None)
+        np.testing.assert_allclose(fitted, image_level, rtol=0, atol=1e-9)

--- a/tests_lib/detectors/test_safe_threshold_region_geometry.py
+++ b/tests_lib/detectors/test_safe_threshold_region_geometry.py
@@ -99,9 +99,7 @@ class TestRegionDatasetFitsPooledScores:
         snap = self._snap(rng, good_proto)
         X_list, y_list = _labels(rng, good_proto, bad_proto)
 
-        model, _threshold = train_and_threshold(
-            X_list, y_list, snap=snap, embedder_name="dinov3_patch"
-        )
+        model, _threshold = train_and_threshold(X_list, y_list, snap=snap, embedder_name="dinov3_patch")
 
         assert len(captured_gmm_scores) == 1
         fitted = np.asarray(captured_gmm_scores[0], dtype=np.float64)

--- a/tests_lib/detectors/test_safe_threshold_region_geometry.py
+++ b/tests_lib/detectors/test_safe_threshold_region_geometry.py
@@ -27,6 +27,10 @@ from vtscore.media.patch_embed import RegionVector
 
 DIM = 8
 N_MEDIA = 20
+# Media ids well clear of the active context's own ids: the embedding- and
+# region-matrix caches key on the sorted id list, so a snap that coincidentally
+# reuses the context's ids would be served the context's cached matrix.
+ID_BASE = 5000
 
 
 def _unit(vec: np.ndarray) -> np.ndarray:
@@ -77,7 +81,7 @@ class TestRegionDatasetFitsPooledScores:
         one-sided bias the old fit suffered from.
         """
         snap: dict[int, dict] = {}
-        for cid in range(1, N_MEDIA + 1):
+        for cid in range(ID_BASE + 1, ID_BASE + N_MEDIA + 1):
             image_vec = _unit(rng.standard_normal(DIM))
             hot_vec = _unit(good_proto + 0.4 * rng.standard_normal(DIM))
             snap[cid] = {
@@ -133,7 +137,7 @@ class TestPlainDatasetUnchanged:
                 "embedder": "test",
                 "embeddings": {"test": _unit(rng.standard_normal(DIM))},
             }
-            for cid in range(1, N_MEDIA + 1)
+            for cid in range(ID_BASE + 1, ID_BASE + N_MEDIA + 1)
         }
         X_list, y_list = _labels(rng, good_proto, bad_proto)
 

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from vtscore.utils.scores import sigmoid_to_finite_array, sigmoid_to_finite_scores
+from vtscore.utils.scores import sigmoid_to_finite_array
 
 if TYPE_CHECKING:
     import torch.nn as nn
@@ -177,7 +177,10 @@ def train_and_threshold(
        ``calibration_fraction`` settings).
     2. Full-data model training (respects ``inclusion`` setting).
     3. Optional safe-threshold blending when ``get_safe_thresholds()`` is
-       enabled and *snap* is provided.
+       enabled and *snap* is provided.  The GMM half of that blend is fitted
+       on the per-media scores :func:`_score_all_media` produces - region
+       max-pooled on a patch dataset - so it sees the distribution the
+       threshold will actually cut.
 
     ``inclusion`` is read from ``get_inclusion()``, which resolves to the
     *active detector context's* inclusion (seeded from the user's settings
@@ -288,17 +291,22 @@ def train_and_threshold(
         model = train_model(X, y, input_dim, hidden_dim=hidden_dim)
 
     if safe:
-        from vtscore.embedding.matrix import get_embedding_matrix_for_snap
-
         # `safe` is only True when `snap` is truthy (see assignment above),
         # so the narrowing is real even though pyright can't track it.
         assert snap is not None
-        score_emb = embedder_name if embedder_name is not None else _score_embedder_for_snap(snap)
-        _all_ids, all_embs = get_embedding_matrix_for_snap(snap, score_emb)
-        X_all = torch.from_numpy(all_embs)
-        with torch.no_grad():
-            X_all = X_all.to(next(model.parameters()).device)
-            all_scores = sigmoid_to_finite_scores(model(X_all))
+        # Fit the GMM on the *inference* score distribution.  `_score_all_media`
+        # is the same call scoring makes (`score_media_with_model`), so on a
+        # patch dataset the GMM sees the region max-pooled per-media scores the
+        # threshold will actually cut.  Scoring the image-level embedding matrix
+        # instead fitted the GMM on a systematically lower distribution (the
+        # region max is ≥ the single image-level row), biasing the midpoint cut
+        # low → over-inclusion on region-voting detectors.  Plain single-vector
+        # datasets take `_score_all_media`'s embedding-matrix fallback, so their
+        # behaviour is unchanged.  *embedder_name* is forwarded as-is (not
+        # pre-resolved) so the region-vs-plain gating matches inference exactly.
+        # Mirrors `_train_and_score_xy` and
+        # `eval.voting_iterations._blend_safe_threshold`.
+        _all_ids, all_scores, _best_region = _score_all_media(model, snap, embedder_name)
         # The GMM blend is applied only on a *fresh* retrain: the fold-ordering
         # cache above stores the raw cross-cal orderings, so a later inclusion
         # slide re-derives the unblended cutoff (intentional - see

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -918,28 +918,18 @@ def _train_and_score_dataset(
     """Train an MLP on (X, y), then score every media in the active dataset.
 
     *embedder_name* is the embedder the external labels in *X_list* were
-    embedded with; scoring sources the haystack matrix from the same embedder
+    embedded with; scoring sources the haystack vectors from the same embedder
     so the trained MLP and the scored vectors share one space.  ``None`` reads
-    each media's primary vector.
+    each media's primary vector.  The same name is handed to
+    :func:`train_and_threshold` so the safe-threshold GMM is fitted on exactly
+    the score distribution returned here - including the region max-pool on a
+    patch dataset, where results also gain a ``best_region`` box.
     """
-    import torch  # noqa: PLC0415
-
-    from vtscore.detectors.training import train_and_threshold
-    from vtscore.embedding.matrix import get_embedding_matrix_for_snap  # noqa: PLC0415
-    from vtscore.utils.scores import sigmoid_to_finite_scores  # noqa: PLC0415
+    from vtscore.detectors.training import score_media_with_model, train_and_threshold  # noqa: PLC0415
 
     snap = snapshot_medias()
-    model, threshold = train_and_threshold(X_list, y_list, snap=snap)
-
-    all_ids, all_embs = get_embedding_matrix_for_snap(snap, embedder_name)
-    X_all = torch.from_numpy(all_embs)
-    with torch.no_grad():
-        X_all = X_all.to(next(model.parameters()).device)
-        scores = sigmoid_to_finite_scores(model(X_all))
-
-    paired = sorted(zip(all_ids, scores, strict=True), key=lambda x: x[1], reverse=True)
-    results = [{"id": cid, "score": round(s, 4)} for cid, s in paired]
-    return results, threshold
+    model, threshold = train_and_threshold(X_list, y_list, snap=snap, embedder_name=embedder_name)
+    return score_media_with_model(model, snap, embedder_name), threshold
 
 
 @sorting_bp.route("/api/label-file-sort", methods=["POST"])
@@ -953,7 +943,11 @@ def _train_and_score_dataset(
 )
 @sorting_bp.alt_response(500, description="Label file sort failed (unexpected exception).")
 def label_file_sort():
-    """Train MLP on external media files from a label file, then sort all medias."""
+    """Train MLP on external media files from a label file, then sort all medias.
+
+    On a patch dataset each result also carries the ``best_region`` box of the
+    region that drove its score, matching the cosine- and learned-sort paths.
+    """
     if "file" not in request.files:
         abort(400, message="No file provided")
 


### PR DESCRIPTION
Closes #2797

## Problem

`train_and_threshold`'s safe-threshold blend fitted its GMM on `get_embedding_matrix_for_snap(snap, score_emb)` — one **image-level** vector per media. On a patch dataset the threshold it returns is applied at inference to **region max-pooled** scores (`score_media_with_model` → `_score_all_media` → `segmented_max_pool`). The region max is ≥ the whole-image region's own score, so the GMM was fitted on a distribution systematically below the one the cut is applied to → fitted component means (and the midpoint) biased low → systematic over-inclusion on region-voting detectors.

The other two GMM call sites already do this right (`_train_and_score_xy`, `eval.voting_iterations._blend_safe_threshold`).

## Change

- **`vtscore/detectors/training.py`** — the `if safe:` block now scores the snap through `_score_all_media(model, snap, embedder_name)`, the same call inference makes, so the GMM sees the distribution the threshold will actually cut. `embedder_name` is forwarded **unresolved** (rather than pre-resolved through `_score_embedder_for_snap`) so `_score_all_media`'s region-vs-plain gating matches inference exactly in both the explicit-primary and `None` cases. Plain single-vector datasets take `_score_all_media`'s embedding-matrix fallback and are unchanged.

- **`vtsearch/routes/sorting.py`** — companion alignment for `label-file-sort`, the one affected caller whose own scoring was *not* region-aware: `_train_and_score_dataset` scored the haystack with the image-level matrix, so making only the GMM region-aware would have introduced the mirror-image bias there. It now scores via `score_media_with_model` and forwards its embedder to `train_and_threshold`, so the threshold and the scores it is compared against share one geometry. This also fixes a pre-existing mismatch (the safe-threshold pass resolved its own embedder instead of using the caller's) and, on a patch dataset, results now carry `best_region` like the cosine- and learned-sort paths. **Backwards-compatibility note:** `POST /api/label-file-sort` ranking changes on patch datasets (region max-pool instead of image-level scores) and results gain a `best_region` field there.

## Tests

New `tests_lib/detectors/test_safe_threshold_region_geometry.py`:

- **region dataset** — the scores handed to `calculate_safe_threshold` are exactly `_score_all_media`'s pooled scores, and that distribution is provably distinct from the image-level one (never lower, sometimes higher). Verified to **fail** against the pre-fix code.
- **plain single-vector dataset** — the fitted distribution is still the embedding-matrix one, byte-for-byte. Passes both before and after, pinning the no-change guarantee.

Full `./run-tests.sh` green: 7398 passed, 1 skipped. OpenAPI snapshot regenerated for the updated `label_file_sort` docstring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaesKoWeZWUSjuqAnqA1i4)_