### PR TITLE
Cut the GMM threshold at the components' equal-density crossing

### DIFF
--- a/docs/ML.md
+++ b/docs/ML.md
@@ -71,7 +71,9 @@ The rule is **monotone in `k` by construction**: raising inclusion can only lowe
 
 Because the fold models are inclusion-independent, the pooled held-out scores can be cached once and re-thresholded at any inclusion (this powers the Find Stats sweep across all inclusion values).
 
-For semantic (text/example) sorts, a **GMM-based threshold** is used instead: a 2-component Gaussian Mixture Model is fitted to the score distribution and the midpoint between component means serves as the threshold.
+For semantic (text/example) sorts, a **GMM-based threshold** is used instead: a 2-component Gaussian Mixture Model is fitted to the score distribution and the cut is placed at the **equal-density crossing** of the two fitted components — the score at which an item stops being better explained by the low ("Bad") component than by the high ("Good") one. Solving `w_lo·N(x; μ_lo, σ²_lo) = w_hi·N(x; μ_hi, σ²_hi)` is a quadratic in `x`; the root between the two means is the Bayes boundary between them. When no root lies strictly between the means (degenerate fit, or an extreme weight ratio that pushes it outside), the threshold falls back to the midpoint between the means.
+
+The crossing and the midpoint coincide exactly when the two components are equal-weight and equal-variance. They diverge under **region voting**, where a media's score is the max over ~24 region-node scores: the Bad mode is then an extreme-value statistic — shifted up, right-skewed, wider, and much heavier than the Good mode, since even a thoroughly bad image gets ~24 draws at a false-positive region. A wider/heavier low component puts the crossing *above* the midpoint, so the midpoint rule cuts inside Bad mass and over-includes. This matters most below 6 votes, where the safe-threshold ramp uses the pure GMM value (see issue #2798).
 
 ## PyTorch Environment Settings
 

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -536,7 +536,7 @@ def train_model(
 
 ```python
 def calculate_gmm_threshold(scores: np.ndarray) -> float:
-    """Fit a 2-component GMM to scores; return the midpoint between component means."""
+    """Fit a 2-component GMM to scores; return the equal-density crossing of the two components."""
 
 def conformal_threshold(scores: np.ndarray, y: np.ndarray) -> float:
     """Split-conformal quantile rule mapping inclusion to a threshold over held-out (scores, y)."""

--- a/tests_lib/sorting/test_gmm_crossing.py
+++ b/tests_lib/sorting/test_gmm_crossing.py
@@ -1,0 +1,158 @@
+"""Tests for the equal-density cut rule in ``calculate_gmm_threshold`` (issue #2798).
+
+The threshold used to be the midpoint between the two fitted component means.
+That rule is only the Bayes boundary when the components are equal-weight and
+equal-variance; under region voting a media's score is the max over ~24 region
+nodes, so the Bad mode is an extreme-value statistic - wider, right-skewed, and
+far heavier than the Good mode - and the midpoint lands inside Bad mass.  These
+tests pin the crossing solver's algebra, its degenerate-case fallbacks, and the
+end-to-end behaviour change on a max-pooled distribution.
+"""
+
+import math
+from unittest import mock
+
+import numpy as np
+
+from vtscore.training.thresholds import (
+    _weighted_gaussian_crossing,
+    calculate_gmm_threshold,
+)
+
+
+def _log_density(w, mu, var, x):
+    """Log of ``w * N(x; mu, var)``, up to the shared ``-0.5*log(2*pi)`` constant."""
+    return math.log(w) - 0.5 * math.log(var) - (x - mu) ** 2 / (2.0 * var)
+
+
+class TestWeightedGaussianCrossing:
+    def test_equal_weight_equal_variance_is_the_midpoint(self):
+        """The historical rule is the special case the new one generalises."""
+        got = _weighted_gaussian_crossing(0.5, 0.2, 0.0025, 0.5, 0.8, 0.0025)
+        assert got is not None
+        assert abs(got - 0.5) < 1e-12
+
+    def test_equal_variance_matches_closed_form(self):
+        """With equal variances the crossing is ``mid + var*ln(w_lo/w_hi)/(mu_hi-mu_lo)``."""
+        w_lo, mu_lo, w_hi, mu_hi, var = 0.8, 0.2, 0.2, 0.8, 0.01
+        got = _weighted_gaussian_crossing(w_lo, mu_lo, var, w_hi, mu_hi, var)
+        expected = (mu_lo + mu_hi) / 2.0 + var * math.log(w_lo / w_hi) / (mu_hi - mu_lo)
+        assert got is not None
+        assert abs(got - expected) < 1e-12
+
+    def test_densities_are_equal_at_the_returned_score(self):
+        """The defining property, checked directly on unequal weights *and* variances."""
+        params = (0.9, 0.3, 0.02, 0.1, 0.8, 0.002)
+        got = _weighted_gaussian_crossing(*params)
+        assert got is not None
+        w_lo, mu_lo, var_lo, w_hi, mu_hi, var_hi = params
+        gap = _log_density(w_lo, mu_lo, var_lo, got) - _log_density(w_hi, mu_hi, var_hi, got)
+        assert abs(gap) < 1e-9
+
+    def test_wider_heavier_low_component_cuts_above_the_midpoint(self):
+        """The max-pool shape: a fat, heavy Bad mode pushes the cut up, not down."""
+        got = _weighted_gaussian_crossing(0.9, 0.3, 0.02, 0.1, 0.8, 0.002)
+        assert got is not None
+        assert got > (0.3 + 0.8) / 2.0
+
+    def test_narrow_heavy_low_component_cuts_below_the_midpoint(self):
+        """The rule is not a one-way ratchet - a tight Bad mode lets the cut fall."""
+        got = _weighted_gaussian_crossing(0.7, 0.1, 0.001, 0.3, 0.6, 0.05)
+        assert got is not None
+        assert got < (0.1 + 0.6) / 2.0
+
+    def test_crossing_lies_strictly_between_the_means(self):
+        rng = np.random.default_rng(11)
+        for _ in range(200):
+            w_lo = float(rng.uniform(0.05, 0.95))
+            mu_lo = float(rng.uniform(-1.0, 0.4))
+            mu_hi = mu_lo + float(rng.uniform(0.05, 1.5))
+            var_lo = float(rng.uniform(1e-4, 0.2))
+            var_hi = float(rng.uniform(1e-4, 0.2))
+            got = _weighted_gaussian_crossing(w_lo, mu_lo, var_lo, 1.0 - w_lo, mu_hi, var_hi)
+            if got is not None:
+                assert mu_lo < got < mu_hi
+
+    def test_extreme_weight_ratio_has_no_crossing_between_the_means(self):
+        """Equal variances plus a 999:1 weight ratio push the root past the Good mean."""
+        assert _weighted_gaussian_crossing(0.999, 0.0, 1.0, 0.001, 1.0, 1.0) is None
+
+    def test_degenerate_inputs_return_none(self):
+        """Non-ordered means, and non-positive weights/variances, all fall back."""
+        assert _weighted_gaussian_crossing(0.5, 0.5, 0.01, 0.5, 0.5, 0.01) is None  # equal means
+        assert _weighted_gaussian_crossing(0.5, 0.8, 0.01, 0.5, 0.2, 0.01) is None  # mis-ordered
+        assert _weighted_gaussian_crossing(0.0, 0.2, 0.01, 1.0, 0.8, 0.01) is None  # zero weight
+        assert _weighted_gaussian_crossing(0.5, 0.2, 0.0, 0.5, 0.8, 0.01) is None  # zero variance
+        assert _weighted_gaussian_crossing(0.5, float("nan"), 0.01, 0.5, 0.8, 0.01) is None
+
+    def test_near_equal_variances_converge_to_the_linear_root(self):
+        """``a -> 0`` must not blow up: the quadratic root tracks the linear one."""
+        w_lo, mu_lo, w_hi, mu_hi, var = 0.75, 0.2, 0.25, 0.8, 0.01
+        linear = (mu_lo + mu_hi) / 2.0 + var * math.log(w_lo / w_hi) / (mu_hi - mu_lo)
+        for eps in (1e-6, 1e-9, 1e-12, 1e-15):
+            got = _weighted_gaussian_crossing(w_lo, mu_lo, var, w_hi, mu_hi, var * (1.0 + eps))
+            assert got is not None
+            assert abs(got - linear) < 1e-6
+
+
+def _pooled_scores(n, mu, sd, rng, k=24):
+    """Region max-pooling: each media's score is the max over *k* region nodes."""
+    logits = rng.normal(mu, sd, size=(n, k))
+    return np.max(1.0 / (1.0 + np.exp(-logits)), axis=1)
+
+
+class TestGmmThresholdCutRule:
+    def test_symmetric_bimodal_still_cuts_at_the_midpoint(self):
+        """Equal-weight, equal-variance modes: the rule change is a no-op."""
+        rng = np.random.default_rng(1)
+        lo = rng.normal(0.2, 0.05, size=5000)
+        hi = rng.normal(0.8, 0.05, size=5000)
+        scores = np.clip(np.concatenate([lo, hi]), 0.0, 1.0).tolist()
+        assert abs(calculate_gmm_threshold(scores) - 0.5) < 0.02
+
+    def test_max_pooled_distribution_cuts_above_the_midpoint(self):
+        """On a region-voted score distribution the cut moves up off the midpoint."""
+        from sklearn.mixture import GaussianMixture
+
+        rng = np.random.default_rng(7)
+        bad = _pooled_scores(950, -2.0, 1.0, rng)
+        good = _pooled_scores(50, 1.5, 1.0, rng)
+        scores = np.concatenate([bad, good])
+
+        threshold = calculate_gmm_threshold(scores.tolist())
+        fitted = GaussianMixture(n_components=2, random_state=42).fit(scores.reshape(-1, 1))
+        assert fitted.means_ is not None
+        midpoint = float(np.ravel(fitted.means_).mean())
+
+        assert threshold > midpoint
+        # And it buys real precision: same recall, far fewer Bad medias admitted.
+        assert (good >= threshold).sum() == (good >= midpoint).sum()
+        assert (bad >= threshold).sum() < (bad >= midpoint).sum()
+
+    def test_falls_back_to_the_midpoint_when_no_crossing_exists(self):
+        """A ``None`` from the solver must land exactly on the old midpoint rule."""
+        from sklearn.mixture import GaussianMixture
+
+        rng = np.random.default_rng(2)
+        scores = np.clip(
+            np.concatenate([rng.normal(0.25, 0.04, size=800), rng.normal(0.75, 0.09, size=200)]),
+            0.0,
+            1.0,
+        )
+        fitted = GaussianMixture(n_components=2, random_state=42).fit(scores.reshape(-1, 1))
+        assert fitted.means_ is not None
+        midpoint = float(np.ravel(fitted.means_).mean())
+
+        with mock.patch("vtscore.training.thresholds._weighted_gaussian_crossing", return_value=None):
+            assert calculate_gmm_threshold(scores.tolist()) == midpoint
+
+    def test_threshold_stays_inside_the_score_range(self):
+        rng = np.random.default_rng(5)
+        scores = _pooled_scores(2000, -1.5, 1.2, rng)
+        threshold = calculate_gmm_threshold(scores.tolist())
+        assert float(scores.min()) <= threshold <= float(scores.max())
+
+    def test_deterministic_across_calls(self):
+        rng = np.random.default_rng(9)
+        scores = np.concatenate([_pooled_scores(900, -2.0, 1.0, rng), _pooled_scores(100, 1.0, 0.8, rng)]).tolist()
+        assert calculate_gmm_threshold(scores) == calculate_gmm_threshold(scores)

--- a/vtscore/docs/packages/training.md
+++ b/vtscore/docs/packages/training.md
@@ -179,14 +179,23 @@ lists from votes, caching on `DetectorContext`) sits one layer up.
 
 `vtscore/training/thresholds.py:17`. Fits a 2-component
 `sklearn.mixture.GaussianMixture` to the score list and returns the
-midpoint between the two component means. Used to produce a reasonable
-operating point even when only a few labels exist - the score
-distribution still tends to be bimodal because the embedder space
-already separates "kind of like X" from "kind of not like X".
+**equal-density crossing** of the two weighted components - the root of
+`w_lo·N(x; μ_lo, σ²_lo) = w_hi·N(x; μ_hi, σ²_hi)` lying between the two
+means. Used to produce a reasonable operating point even when only a few
+labels exist - the score distribution still tends to be bimodal because
+the embedder space already separates "kind of like X" from "kind of not
+like X".
 
-Falls back to `np.median(scores)` when GMM fitting raises (e.g.
-degenerate score distributions), and to `0.5` when fewer than 2 scores
-are provided.
+The crossing equals the midpoint between the means for equal-weight,
+equal-variance components, and departs from it when they differ - notably
+under region voting, where each media scores as the max over ~24 region
+nodes and the Bad component comes out wide, right-skewed and heavy, which
+pushes the crossing above the midpoint (issue #2798).
+
+Falls back to the midpoint between the means when no crossing lies
+strictly between them, to `np.median(scores)` when GMM fitting raises
+(e.g. degenerate score distributions), and to `0.5` when fewer than 2
+scores are provided.
 
 ### `conformal_threshold(scores, labels, inclusion_value=0)`
 

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -10,6 +10,7 @@ from votes, caching on ``DetectorContext``) lives in
 from __future__ import annotations
 
 import hashlib
+import math
 from typing import Any
 
 import numpy as np
@@ -62,12 +63,102 @@ def classify_threshold_provenance(fallback: float | None) -> str:
     return "unknown"
 
 
+def _quadratic_roots(a: float, b: float, c: float) -> list[float]:
+    """Real roots of ``a*x^2 + b*x + c``, degenerating gracefully to the linear case.
+
+    Uses the cancellation-free ("citardauq") pairing ``q = -(b + sign(b)*sqrt(D))/2``,
+    ``x = {q/a, c/q}`` rather than the textbook formula.  That matters here because
+    the near-equal-variance case drives ``a`` toward 0, where ``(-b + sqrt(D)) /
+    (2a)`` is catastrophic cancellation over a vanishing denominator while ``c/q``
+    stays accurate and converges smoothly to the linear root ``-c/b``.
+    """
+    if a == 0.0:
+        return [] if b == 0.0 else [-c / b]
+    disc = b * b - 4.0 * a * c
+    if disc < 0.0:
+        return []
+    q = -0.5 * (b + math.copysign(math.sqrt(disc), b))
+    if q == 0.0:
+        # Only reachable with b == 0 and disc == 0, i.e. ``a*x^2 = 0``.
+        return [0.0]
+    return [q / a, c / q]
+
+
+def _weighted_gaussian_crossing(
+    w_lo: float,
+    mu_lo: float,
+    var_lo: float,
+    w_hi: float,
+    mu_hi: float,
+    var_hi: float,
+) -> float | None:
+    """Score between the two means where the weighted component densities cross.
+
+    Solves ``w_lo * N(x; mu_lo, var_lo) == w_hi * N(x; mu_hi, var_hi)``.  Taking
+    logs makes the difference a quadratic ``f(x) = a x^2 + b x + c`` (``f > 0``
+    means the Bad component owns that score), so the crossing is a root of that
+    quadratic - the Bayes decision boundary between the two fitted components.
+
+    This is the cut the midpoint-between-means rule only approximates, and the
+    two agree **exactly** when the components are equal-weight and equal-variance.
+    They diverge precisely where region voting lives: a media's score is the max
+    over ~24 region nodes, so the Bad mode is an extreme-value statistic - wider,
+    right-skewed, and far heavier than the Good mode.  A wider/heavier low
+    component pushes the crossing *above* the midpoint (with equal variances the
+    offset is ``var * ln(w_lo/w_hi) / (mu_hi - mu_lo)``), so the midpoint sits
+    inside Bad mass and over-includes.
+
+    Returns ``None`` - meaning "the caller should fall back to the midpoint" -
+    whenever the crossing is not a well-defined boundary: non-positive weights or
+    variances, non-ordered/degenerate means, a complex-root fit, no root strictly
+    between the means (near-equal variances with an extreme weight ratio push the
+    linear root outside the interval), or a fit in which the Bad component still
+    out-densities the Good one at the Good mean.  When two roots land inside the
+    interval the larger one is taken: above it the Good component dominates all
+    the way to its own mean, which is the boundary a threshold wants.
+    """
+    if not (w_lo > 0.0 and w_hi > 0.0 and var_lo > 0.0 and var_hi > 0.0):
+        return None
+    if not (mu_hi > mu_lo):
+        return None
+
+    # Solve in ``u = x - mu_lo`` so the interval is ``(0, d)``.  Shifting keeps
+    # the roots exact while dropping the ``mu^2 / var`` terms that would dominate
+    # the coefficients (and their cancellation) for score scales far from zero.
+    d = mu_hi - mu_lo
+    offset = math.log(w_lo / w_hi) + 0.5 * math.log(var_hi / var_lo)
+    a = 0.5 / var_hi - 0.5 / var_lo
+    b = -d / var_hi
+    c = 0.5 * d * d / var_hi + offset
+
+    # The Good mode must actually be Good-dominated, else "the score above which
+    # Good wins" is not something this fit expresses.  Evaluated in closed form
+    # rather than as ``a d^2 + b d + c`` (the same value, without the cancellation).
+    if offset - 0.5 * d * d / var_lo >= 0.0:
+        return None
+
+    inside = [u for u in _quadratic_roots(a, b, c) if math.isfinite(u) and 0.0 < u < d]
+    if not inside:
+        return None
+    return mu_lo + max(inside)
+
+
 def calculate_gmm_threshold(scores: list[float]) -> float:
     """Use a Gaussian Mixture Model to find a threshold between two score distributions.
 
     Fits a 2-component GMM to the provided scores, assuming a bimodal distribution
-    representing Bad (low) and Good (high) classes. Returns the midpoint between the
-    two component means as the decision threshold.
+    representing Bad (low) and Good (high) classes.  Returns the **equal-density
+    crossing** of the two fitted components (see :func:`_weighted_gaussian_crossing`)
+    - the score at which a media stops being better explained by the Bad component
+    than by the Good one - falling back to the midpoint between the component means
+    when no crossing exists strictly between them.
+
+    The crossing and the midpoint coincide for equal-weight, equal-variance
+    components; they separate when the low component is wider or heavier, which is
+    the standing shape of a region-voted score distribution (every media's score is
+    a max over ~24 region nodes, so even a thoroughly Bad image gets ~24 draws at a
+    false positive).  Cutting at the midpoint there lands inside Bad mass and
+    over-includes.
 
     For score sets larger than :data:`_GMM_MAX_SAMPLES`, fits on a deterministic
     (seed-42) random subsample - the two-Gaussian fit is unchanged in practice
@@ -108,11 +199,27 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
         low_idx = 0 if means[0] < means[1] else 1
         high_idx = 1 - low_idx
 
-        # Threshold is at the intersection of the two Gaussians
-        # For simplicity, use the midpoint between means
-        threshold = (means[low_idx] + means[high_idx]) / 2.0
+        # Threshold is at the intersection of the two Gaussians; the midpoint
+        # between the means is the fallback when that intersection is not a
+        # usable boundary (degenerate fit, or root outside the two means).
+        midpoint = float((means[low_idx] + means[high_idx]) / 2.0)
 
-        return float(threshold)
+        # ``covariances_`` is (n_components, 1, 1) under the default "full"
+        # covariance type; ravel gives the two scalar variances.  Both attributes
+        # are stub-typed ``np.ndarray | None`` and always set after ``fit``.
+        assert gmm.covariances_ is not None
+        assert gmm.weights_ is not None
+        variances = np.ravel(gmm.covariances_)
+        weights = np.ravel(gmm.weights_)
+        crossing = _weighted_gaussian_crossing(
+            float(weights[low_idx]),
+            float(means[low_idx]),
+            float(variances[low_idx]),
+            float(weights[high_idx]),
+            float(means[high_idx]),
+            float(variances[high_idx]),
+        )
+        return midpoint if crossing is None else crossing
     except Exception:
         # If GMM fails, return median (of the subsample when one was taken -
         # representative of the full distribution and keeps this path bounded).
@@ -874,8 +981,6 @@ def calculate_safe_threshold(
         ``DetectorContext.threshold`` without breaking ``score >= threshold``
         comparisons.
     """
-    import math  # noqa: PLC0415
-
     gmm_threshold = calculate_gmm_threshold(all_scores)
 
     # Defend against non-finite inputs from either side: an upstream


### PR DESCRIPTION
Closes #2798

## Problem

`calculate_gmm_threshold` fit a 2-component GMM and returned **the midpoint between the two component means** ("For simplicity, use the midpoint between means"). That is the Bayes boundary only when the two components are equal-weight *and* equal-variance.

Region voting breaks both assumptions: a media's score is the **max over ~24 region-node scores**, so the low ("Bad") mode is an extreme-value statistic — shifted up, right-skewed, wider, and far heavier than the Good mode, because even a thoroughly bad image gets ~24 draws at a false-positive region. When the low component is wider/heavier the equal-density crossing sits **above** the midpoint, so the midpoint cut lands inside Bad mass and over-includes. This bites hardest below 6 votes, where the safe-threshold ramp uses the *pure* GMM value.

## Change

Solve `w_lo·N(x; μ_lo, σ²_lo) = w_hi·N(x; μ_hi, σ²_hi)` for `x`. In log space that is a quadratic; the root between the two means is the Bayes boundary.

- `_weighted_gaussian_crossing(...)` — solves in `μ_lo`-shifted coordinates (`u = x − μ_lo`), which drops the `μ²/σ²` terms that would dominate the coefficients and their cancellation at score scales far from zero.
- `_quadratic_roots(...)` — uses the cancellation-free root pairing (`q = −(b + sign(b)·√D)/2`, roots `{q/a, c/q}`) rather than the textbook formula. The near-equal-variance case drives `a → 0`, where `(−b + √D)/(2a)` is catastrophic cancellation over a vanishing denominator while `c/q` converges smoothly to the linear root `−c/b`.
- Takes the **largest** root strictly between the means: above it the Good component dominates all the way to its own mean.
- Guards the "Good mode is still Bad-dominated" fit (evaluated in closed form, not as `a·d² + b·d + c`) and rejects non-positive weights/variances and non-ordered means.

Everything else is byte-for-byte unchanged: the midpoint is the fallback whenever no usable crossing exists, `np.median` still catches fit failure, `0.5` still covers `< 2` scores, `_GMM_MAX_SAMPLES` subsampling and `random_state=42` determinism are untouched, and equal-weight/equal-variance components still yield exactly the midpoint.

This changes behavior for **all** GMM callers, including the text/cosine sort (`vtsearch/routes/sorting.py`) and the safe-threshold blend.

## Effect

On a simulated region-voted distribution (950 Bad + 50 Good medias, each scored as the max over 24 region nodes):

| cut | value | recall | false positives | precision |
|---|---|---|---|---|
| midpoint (old) | 0.582 | 1.000 | 189 | 0.209 |
| crossing (new) | 0.669 | 1.000 | 69 | **0.420** |

Same recall, 63% fewer Bad medias admitted.

## Tests

New `tests_lib/sorting/test_gmm_crossing.py`:

- the solver's algebra — equal-weight/equal-variance reduces to the midpoint; equal-variance matches the closed form `mid + σ²·ln(w_lo/w_hi)/(μ_hi − μ_lo)`; the weighted densities are equal at the returned score under unequal weights *and* variances (verified against a brute-force scan while developing);
- direction — a wide/heavy Bad mode cuts above the midpoint, a tight one cuts below (the rule is not a one-way ratchet);
- degenerate fallbacks — equal/mis-ordered means, zero weight, zero variance, NaN, and an extreme weight ratio that pushes the root past the Good mean;
- numerical stability — `σ²_hi/σ²_lo − 1` swept down to `1e-15` still tracks the linear root;
- a randomized property test that any returned crossing lies strictly between the means;
- end-to-end — symmetric bimodal is a no-op, a max-pooled distribution cuts above the midpoint with equal recall and strictly fewer false positives, the result stays inside the score range, and repeated calls are identical.

`./run-tests.sh` passes in full: **7412 passed, 1 skipped, 1 xfailed** (plus the `sorting` + `detectors` groups green on their own).

## Not done here

The issue's optional "evaluate fitting in logit space to undo sigmoid saturation" is deliberately left out — it is a measurement question, not a code change, and belongs with #2799's harness arm. Noted on that issue.

Docs updated: `docs/ML.md`, `docs/vtscore-api.md`, `vtscore/docs/packages/training.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018FDmSc8h9fYpaGE6qKhuAF)_