### PR TITLE
Add the safe-threshold GMM measurement harness (#2799 prep)

### DIFF
--- a/docs/plans/safe-threshold-gmm-experiment.md
+++ b/docs/plans/safe-threshold-gmm-experiment.md
@@ -1,0 +1,167 @@
+# Safe-threshold GMM study — measuring the blend under region voting (issue #2799)
+
+**Status: harness ready, awaiting a Grid run.** All code for this study is on
+`dev`: the eval harness emits the variant rows, the runner has a launch
+wrapper, and the analyzer computes every pre-registered deliverable below. The
+only open work is running it and writing the verdict.
+
+## Question
+
+The safe-threshold GMM blend (`calculate_safe_threshold`,
+`vtscore/training/thresholds.py`) has **full** authority over the decision
+threshold below 6 votes and majority authority up to ~13, yet the #2781
+calibration study (`docs/experiments/calibration/REPORT.md`) ran every arm with
+`safe_thresholds False` — the blend has never been measured under region
+voting. Two fixes shipped ahead of measurement, on geometry/theory alone:
+
+- **#2797** (PR #2800): production now fits the GMM on the region **max-pooled**
+  per-media scores (the distribution the threshold actually cuts) instead of the
+  image-level scores, whose distribution sits systematically lower.
+- **#2798** (PR #2801): `calculate_gmm_threshold` now cuts at the two fitted
+  components' **equal-density crossing** instead of the midpoint between their
+  means (midpoint over-includes when the Bad mode is a wide, heavy
+  extreme-value lump — the standing shape under max-pooling).
+
+This study measures what those fixes bought (and whether they cost anything),
+plus the one idea #2798 deliberately left unshipped: fitting the GMM in **logit
+space** to undo sigmoid saturation before the components are estimated.
+
+## Design
+
+One factorial sweep, computed *within* each simulated voting step so every
+variant is paired on the identical model, votes, and held-out test scores. At
+each trainable step the harness fits a GMM per (fit-geometry, fit-space) pair,
+derives both cut rules from each fit, blends each cut with the step's conformal
+threshold on the production label ramp, and scores every resulting threshold on
+the same max-pooled test distribution. Axes:
+
+- **Fit geometry** — `pooled` (sim-set scores through the style's inference
+  max-pool; production post-#2797) vs `image` (whole-image vector scores; the
+  historical geometry).
+- **Cut rule** — `cross` (equal-density crossing; production post-#2798) vs
+  `mid` (midpoint-of-means; historical).
+- **Fit space** — `sig` (sigmoid scores, production) vs `logit` (scores
+  logit-transformed before the fit, cut mapped back through the sigmoid).
+
+Emitted variants (`gmm_variant` column; `vtscore/eval/voting_iterations.py::_SAFE_GMM_VARIANTS`):
+
+| variant | fit | cut | space | reading |
+|---|---|---|---|---|
+| `xcal_only` | — | — | — | no-blend control: the raw conformal cut at the same step |
+| `image_mid` | image | mid | sig | **historical production** (pre-#2797/#2798) |
+| `image_cross` | image | cross | sig | cut-rule fix alone (counterfactual: #2798 without #2797) |
+| `pooled_mid` | pooled | mid | sig | geometry fix alone (#2797 without #2798) |
+| `pooled_cross` | pooled | cross | sig | **current production** — must equal the base row's blend |
+| `pooled_mid_logit` | pooled | mid | logit | logit-space fit, historical cut |
+| `pooled_cross_logit` | pooled | cross | logit | logit-space fit, production cut — the open #2798 idea |
+
+Each variant row records `threshold` (blended), `gmm_cut` (pre-blend),
+`xcal_threshold`, `blend_weight`, and the full FPR/FNR/cost + oracle/regret
+metric set against the shared test scores. The `pooled_cross` row doubles as a
+harness sanity check: the analyzer asserts it reproduces the production blend
+(base row) bit-for-bit.
+
+### Arms
+
+Visual Genome region voting only (the setup where the geometry/shape concerns
+live; Caltech binary voting is deliberately out of scope — single-vector GMM
+behaviour is partially covered by the control arm):
+
+| Dataset | Embedder | Style | Role |
+|---|---|---|---|
+| `visual_genome_m` | `dinov3_patch` | `max_patch` | the production region-vote strategy — the arm the decisions read |
+| `visual_genome_m` | `siglip` | `whole_image` | single-vector control: pooled ≡ image fit, isolates the pure cut-rule effect (#2798 changed *all* GMM callers, including the text/cosine sort) |
+
+### Fixed config
+
+`safe_thresholds=True` (the object of study), inclusion 0, `sim_fraction` 0.5,
+`calibrate_count` 2, `calibration_fraction` 0.5, MLP trainer,
+`autopilot_fidelity=True` (the runner default — vote counts must mean
+app-visible votes, since the ramp is keyed on them), **30 voting steps**
+(above ~20 votes the blend is pure cross-cal and #2781 already covers it),
+**8 seeds** (cells are ~5x cheaper than #2781's 150-step cells and the
+sub-20-vote regime is the noisy one), same scale-band VG category selection as
+the Max-Patch/#2781 studies (shared pickles).
+
+### Windows
+
+Vote count `n = n_good + n_bad` (votes, not flooded rows — the ramp's own
+unit): **2–5** (pure-GMM window, blend weight 0) and **6–20** (ramp window).
+The 6–20 cells are the primary ones (issue #2799); above 20 nothing the GMM
+does matters.
+
+## Pre-registered deliverables
+
+`analyze_safe.py` computes all of these; the report draft lands in
+`results/REPORT.md`:
+
+- **FPR / FNR / cost vs vote count per variant, per arm** (`variant_vs_votes.csv`,
+  `safe_{cost,fpr,fnr}_vs_votes.png`), plus per-window means
+  (`window_by_variant.csv`).
+- **Paired contrasts** (`contrasts.csv`), each as mean per-cell delta +
+  Wilcoxon over (category, seed) cells (t-axis collapsed first so cells are the
+  independent units):
+  - `pooled_mid − image_mid` — the size of the bias #2797 removed;
+  - `pooled_cross − pooled_mid` — what the #2798 cut rule buys under region
+    voting;
+  - `image_cross − image_mid` — same cut-rule contrast in single-vector
+    geometry (reads on the text/cosine-sort callers);
+  - `pooled_cross_logit − pooled_cross` — the logit-space question;
+  - `pooled_cross − xcal_only` — does the blend beat the raw conformal cut at
+    low votes at all?
+- **Threshold diagnostics**: mean `gmm_cut` / `threshold` vs `oracle_threshold`
+  per variant, degenerate rate per variant.
+- **Sanity**: max |`pooled_cross` − base threshold| (must be 0 to the CSV's
+  6-dp grain).
+
+## Pre-registered decision rules
+
+Read on the **`max_patch` arm, ramp window (6–20)** unless stated:
+
+- **Keep #2801 (equal-density crossing)** unless `pooled_cross` is
+  *significantly worse* than `pooled_mid` on cost (Wilcoxon p < 0.05 with a
+  positive mean Δcost). The revert is a one-line swap:
+  `_weighted_gaussian_crossing` returning `None` already falls back to the
+  midpoint, so reverting = cutting at `fit.midpoint()` unconditionally.
+- **Adopt the logit-space fit** only if `pooled_cross_logit` beats
+  `pooled_cross` by mean Δcost ≤ −0.02 at p < 0.05 (both windows agreeing in
+  sign). Otherwise record the number and close the idea.
+- **#2797 sizing** is reporting, not a decision (the fix is already justified
+  on geometry): expect `image_mid` to carry higher FPR than `pooled_mid`
+  (image-level fit → cut biased low → over-inclusion). If the measured Δ is
+  ~0, say so in the report — it bounds how much the geometry fix mattered in
+  practice.
+- **Cold-start plan note**: if `pooled_cross` is *worse* than `xcal_only` on
+  ramp-window cost, the "Cold-start calibration" item in
+  [`inclusion-calibration-bias.md`](inclusion-calibration-bias.md) absorbs a
+  GMM-specific note (the blend as shipped is then part of the cold-start
+  problem, not its mitigation); if better, that item's "hard GMM blend"
+  framing should cite this study as evidence the blend earns its keep.
+
+## Grid runbook
+
+```bash
+# worktree with this branch/dev at /exp/$USER/projects/vts-calib
+cd /exp/$USER/projects/vts-calib/scripts/experiments/calibration
+bash launch_safe.sh
+```
+
+`launch_safe.sh` chains the standard pipeline (`prepare` → cells array →
+`analyze_safe.py`) with `CALIB_SAFE_THRESHOLDS=1`, VG-only arms
+(`siglip,dinov3_patch` × `whole_image`/`max_patch`), 30 steps, 8 seeds, and
+results under `/exp/$USER/calibration-safe` (the #2781 outputs stay untouched;
+Max-Patch pickles/crops are reused in place). Expected size: 2 embedders × ~23
+scale-band categories × 8 seeds ≈ 368 cells, each ≪ the #2781 cells (30 steps,
+no 150-step tail, no re-pool arms). Knobs: `CALIB_N_SEEDS`, `CALIB_MAX_STEPS`,
+`CALIB_VG_EMBEDDERS`, `CALIB_PATCH_STYLES` — all overridable in the usual
+`CALIB_*` way.
+
+## After the run
+
+- Write `docs/experiments/safe-thresholds/REPORT.md` from the analyzer's draft
+  (numbers + verdicts on the decision rules above), mirroring the #2781 report's
+  shape.
+- Act on the decision rules (revert/keep #2801; file or close the logit idea;
+  add or don't add the cold-start note to `inclusion-calibration-bias.md`).
+- Close out issue #2799 per the repo's issue workflow, and prune this plan file
+  down to whatever follow-ups the data creates (delete it outright if none).

--- a/scripts/experiments/calibration/README.md
+++ b/scripts/experiments/calibration/README.md
@@ -1,4 +1,4 @@
-# Calibration study runner (issue #2781)
+# Calibration study runner (issues #2781, #2799)
 
 Measures **calibration regret** — the extra `FPR + FNR` cost the trained
 (cross-calibrated conformal) threshold pays versus the *oracle* threshold for the
@@ -50,3 +50,18 @@ alongside them harmlessly), and writes all study output under
 `inclusion=0` (cost = FPR + FNR), `sim_fraction=0.5`, `calibrate_count=2`,
 `calibration_fraction=0.5`, `safe_thresholds=False`, MLP trainer, 150 votes,
 4 seeds. Env knobs mirror the `MAXPATCH_*` set under the `CALIB_*` prefix.
+
+## Safe-threshold GMM study (issue #2799)
+
+```bash
+cd /exp/$USER/projects/vts-calib/scripts/experiments/calibration
+bash launch_safe.sh      # safe_thresholds ON, VG only, 30 votes, 8 seeds
+```
+
+`launch_safe.sh` re-drives the same pipeline with `CALIB_SAFE_THRESHOLDS=1`:
+every step then emits one extra row per safe-threshold GMM variant
+(`gmm_variant` column — fit geometry x cut rule x fit space, plus an
+`xcal_only` control), and the analyze stage runs `analyze_safe.py` instead of
+`analyze.py`. Results land under `/exp/$USER/calibration-safe`, reusing the
+shared Max-Patch pickles/crops in place. Design and pre-registered decision
+rules: `docs/plans/safe-threshold-gmm-experiment.md`.

--- a/scripts/experiments/calibration/analyze_safe.py
+++ b/scripts/experiments/calibration/analyze_safe.py
@@ -1,0 +1,325 @@
+"""Stage 2 (safe-threshold study, #2799): aggregate the GMM-variant cells.
+
+Consumes the same ``results/cells/task_*.csv`` files as ``analyze.py`` but from
+a run with ``CALIB_SAFE_THRESHOLDS=1``, where every step additionally emits one
+row per safe-threshold GMM variant (``gmm_variant`` column; see
+``vtscore.eval.voting_iterations._SAFE_GMM_VARIANTS``).  Computes the
+pre-registered #2799 deliverables (design + decision rules:
+``docs/plans/safe-threshold-gmm-experiment.md``):
+
+* FPR / FNR / cost vs vote count per variant, per arm - the 6-20-vote ramp
+  window (and the sub-6 pure-GMM window) are the cells that matter.
+* Paired contrasts on the same steps: ``pooled_mid - image_mid`` (the geometry
+  bias #2797 removed), ``pooled_cross - pooled_mid`` (the #2798 cut-rule
+  change), ``pooled_cross_logit - pooled_cross`` (the logit-space idea), and
+  ``pooled_cross - xcal_only`` (does the blend beat raw conformal at all?).
+* Threshold diagnostics: mean cut vs the oracle cut, degenerate rate.
+* A sanity check that the ``pooled_cross`` variant reproduces the production
+  blend (its threshold must equal the base row's).
+
+Writes ``results/summary.json``, ``results/agg/*.csv``,
+``results/figures/*.png``, and a ``results/REPORT.md`` draft.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import common
+
+common.setup_env()
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+#: Vote-count windows (inclusive) the deliverables aggregate over.  Below 6
+#: votes the blend is pure GMM; 6-20 is the ramp; above 20 the blend is pure
+#: cross-cal and the #2781 study already covers it.
+WINDOWS: dict[str, tuple[int, int]] = {"pure_gmm_2_5": (2, 5), "ramp_6_20": (6, 20)}
+
+#: Pre-registered paired contrasts: name -> (variant_a, variant_b); each is
+#: measured as mean(a - b) on identical (arm, category, seed, t) steps.
+CONTRASTS: dict[str, tuple[str, str]] = {
+    "pooled_fit_vs_image_fit": ("pooled_mid", "image_mid"),  # the #2797 geometry bias
+    "crossing_vs_midpoint": ("pooled_cross", "pooled_mid"),  # the #2798 cut rule
+    "logit_vs_sigmoid": ("pooled_cross_logit", "pooled_cross"),  # the open logit idea
+    "blend_vs_xcal_only": ("pooled_cross", "xcal_only"),  # does the blend help at all?
+    "crossing_vs_midpoint_image": ("image_cross", "image_mid"),  # cut rule, single-vector geometry
+}
+
+
+def _md(df: pd.DataFrame) -> str:
+    """Markdown table when ``tabulate`` is available, else a plain fixed-width dump."""
+    try:
+        return df.to_markdown(index=False, floatfmt=".4f")
+    except Exception:  # noqa: BLE001 - tabulate not installed
+        return "```\n" + df.to_string(index=False) + "\n```"
+
+
+def load_cells(cells_dir: Path) -> pd.DataFrame:
+    files = sorted(p for p in cells_dir.glob("task_*.csv") if "__sweep" not in p.name)
+    if not files:
+        return pd.DataFrame()
+    df = pd.concat([pd.read_csv(p) for p in files], ignore_index=True)
+    df["gmm_variant"] = df["gmm_variant"].fillna("")
+    df["arm"] = df["dataset"] + "/" + df["embedder"] + "/" + df["style"]
+    df["n_votes"] = df["n_good"] + df["n_bad"]
+    common.log(f"loaded {len(df)} rows from {len(files)} cells")
+    return df
+
+
+def production_blend_sanity(df: pd.DataFrame) -> dict:
+    """The ``pooled_cross`` variant must reproduce the production blended cut."""
+    keys = ["arm", "category", "seed", "t"]
+    base = df[(df["pool_variant"] == "max") & (df["gmm_variant"] == "")].set_index(keys)["threshold"]
+    pc = df[df["gmm_variant"] == "pooled_cross"].set_index(keys)["threshold"]
+    joined = base.to_frame("base").join(pc.to_frame("pooled_cross"), how="inner")
+    if joined.empty:
+        return {"n_steps": 0, "max_abs_diff": None, "ok": None}
+    diff = (joined["base"] - joined["pooled_cross"]).abs()
+    return {
+        "n_steps": int(len(joined)),
+        "max_abs_diff": float(diff.max()),
+        # thresholds are rounded to 6 dp on emit, so equality holds to that grain
+        "ok": bool(diff.max() <= 1e-6),
+    }
+
+
+def variant_curves(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
+    """Mean FPR/FNR/cost vs vote count, per (arm, variant)."""
+    v = df[df["gmm_variant"] != ""]
+    g = (
+        v.groupby(["arm", "gmm_variant", "n_votes"])
+        .agg(
+            cost=("cost", "mean"),
+            fpr=("fpr", "mean"),
+            fnr=("fnr", "mean"),
+            threshold=("threshold", "mean"),
+            gmm_cut=("gmm_cut", "mean"),
+            oracle_threshold=("oracle_threshold", "mean"),
+            degenerate_rate=("degenerate", "mean"),
+            n=("cost", "size"),
+        )
+        .reset_index()
+    )
+    g.to_csv(agg_dir / "variant_vs_votes.csv", index=False)
+    return g
+
+
+def window_table(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
+    """Per-window mean metrics per (arm, variant) - the headline table."""
+    v = df[df["gmm_variant"] != ""]
+    out = []
+    for wname, (lo, hi) in WINDOWS.items():
+        w = v[(v["n_votes"] >= lo) & (v["n_votes"] <= hi)]
+        g = (
+            w.groupby(["arm", "gmm_variant"])
+            .agg(
+                cost=("cost", "mean"),
+                fpr=("fpr", "mean"),
+                fnr=("fnr", "mean"),
+                regret=("regret", "mean"),
+                degenerate_rate=("degenerate", "mean"),
+                n_steps=("cost", "size"),
+            )
+            .reset_index()
+        )
+        g.insert(0, "window", wname)
+        out.append(g)
+    tbl = pd.concat(out, ignore_index=True) if out else pd.DataFrame()
+    tbl.to_csv(agg_dir / "window_by_variant.csv", index=False)
+    return tbl
+
+
+def _paired_cells(v: pd.DataFrame, a: str, b: str, lo: int, hi: int) -> pd.DataFrame:
+    """Per-(arm, category, seed) mean deltas of a-b on identical steps in [lo, hi]."""
+    keys = ["arm", "category", "seed", "t"]
+    w = v[(v["n_votes"] >= lo) & (v["n_votes"] <= hi)]
+    va = w[w["gmm_variant"] == a].set_index(keys)[["cost", "fpr", "fnr", "threshold"]]
+    vb = w[w["gmm_variant"] == b].set_index(keys)[["cost", "fpr", "fnr", "threshold"]]
+    j = va.join(vb, how="inner", lsuffix="_a", rsuffix="_b")
+    if j.empty:
+        return pd.DataFrame()
+    for col in ("cost", "fpr", "fnr", "threshold"):
+        j[f"d_{col}"] = j[f"{col}_a"] - j[f"{col}_b"]
+    j = j.reset_index()
+    # Collapse the t axis first: one delta per (arm, category, seed) cell, so
+    # the Wilcoxon's units are independent cells rather than autocorrelated steps.
+    return j.groupby(["arm", "category", "seed"])[["d_cost", "d_fpr", "d_fnr", "d_threshold"]].mean().reset_index()
+
+
+def contrast_tables(df: pd.DataFrame, agg_dir: Path) -> dict:
+    from scipy.stats import wilcoxon  # noqa: PLC0415
+
+    v = df[df["gmm_variant"] != ""]
+    out: dict = {}
+    rows = []
+    for wname, (lo, hi) in WINDOWS.items():
+        for cname, (a, b) in CONTRASTS.items():
+            for arm, sub in v.groupby("arm"):
+                cells = _paired_cells(sub, a, b, lo, hi)
+                if cells.empty:
+                    continue
+                entry: dict = {
+                    "window": wname,
+                    "contrast": cname,
+                    "variant_a": a,
+                    "variant_b": b,
+                    "arm": arm,
+                    "n_cells": int(len(cells)),
+                }
+                for col in ("d_cost", "d_fpr", "d_fnr", "d_threshold"):
+                    vals = cells[col].to_numpy()
+                    entry[f"mean_{col}"] = float(np.mean(vals))
+                    if len(vals) >= 3 and np.any(vals != 0):
+                        _stat, p = wilcoxon(vals)
+                        entry[f"p_{col}"] = float(p)
+                    else:
+                        entry[f"p_{col}"] = None
+                rows.append(entry)
+    tbl = pd.DataFrame(rows)
+    tbl.to_csv(agg_dir / "contrasts.csv", index=False)
+    out["rows"] = rows
+    return out
+
+
+def decision_rules(contrasts: dict) -> dict:
+    """Evaluate the pre-registered decisions on the ramp window's patch arm.
+
+    Rules (see docs/plans/safe-threshold-gmm-experiment.md):
+
+    * ``keep_crossing`` - #2801 stays unless the crossing cut is *significantly
+      worse* than the midpoint on cost (p < 0.05 with a positive delta); the
+      revert is a one-line fallback swap.
+    * ``adopt_logit`` - the logit-space fit ships only if it beats the sigmoid
+      crossing by >= 0.02 mean cost at p < 0.05.
+    * ``blend_helps_cold_start`` - if the production blend is *worse* than the
+      raw conformal cut on the ramp, the cold-start item in
+      inclusion-calibration-bias.md absorbs a GMM-specific note.
+    """
+
+    def _find(contrast: str, window: str = "ramp_6_20") -> dict | None:
+        matches = [
+            r
+            for r in contrasts.get("rows", [])
+            if r["contrast"] == contrast and r["window"] == window and "whole_image" not in r["arm"]
+        ]
+        return matches[0] if matches else None
+
+    out: dict = {}
+    cross = _find("crossing_vs_midpoint")
+    out["keep_crossing"] = (
+        None
+        if cross is None
+        else not (cross["p_d_cost"] is not None and cross["p_d_cost"] < 0.05 and cross["mean_d_cost"] > 0)
+    )
+    logit = _find("logit_vs_sigmoid")
+    out["adopt_logit"] = (
+        None
+        if logit is None
+        else bool(logit["p_d_cost"] is not None and logit["p_d_cost"] < 0.05 and logit["mean_d_cost"] <= -0.02)
+    )
+    blend = _find("blend_vs_xcal_only")
+    out["blend_helps_cold_start"] = None if blend is None else bool(blend["mean_d_cost"] < 0)
+    out["evidence"] = {"crossing_vs_midpoint": cross, "logit_vs_sigmoid": logit, "blend_vs_xcal_only": blend}
+    return out
+
+
+def make_figures(curves: pd.DataFrame, fig_dir: Path) -> list[str]:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception as e:  # noqa: BLE001
+        common.log(f"matplotlib unavailable ({e}); skipping figures")
+        return []
+    saved = []
+    for metric in ("cost", "fpr", "fnr"):
+        fig, axes = plt.subplots(1, max(1, curves["arm"].nunique()), figsize=(13, 4.5), sharey=True, squeeze=False)
+        for ax, (arm, sub) in zip(axes[0], curves.groupby("arm"), strict=False):
+            for variant, vs in sub.groupby("gmm_variant"):
+                ax.plot(vs["n_votes"], vs[metric], label=variant, lw=1.2)
+            ax.axvspan(6, 20, alpha=0.08, color="gray")
+            ax.set_title(arm, fontsize=8)
+            ax.set_xlabel("votes")
+            ax.grid(alpha=0.3)
+        axes[0][0].set_ylabel(f"mean {metric}")
+        axes[0][-1].legend(fontsize=6)
+        p = fig_dir / f"safe_{metric}_vs_votes.png"
+        fig.tight_layout()
+        fig.savefig(p, dpi=120)
+        plt.close(fig)
+        saved.append(p.name)
+    return saved
+
+
+def write_report(summary: dict, tables: dict, report_path: Path) -> None:
+    lines = ["# Safe-threshold GMM study — auto-generated summary (issue #2799)", ""]
+    lines.append(f"Rows: {summary.get('n_rows')} · variant rows: {summary.get('n_variant_rows')}")
+    lines.append("")
+    lines.append("## Production-blend sanity (pooled_cross == base threshold)")
+    lines.append("")
+    lines.append("```json")
+    lines.append(json.dumps(summary["sanity"], indent=2))
+    lines.append("```")
+    lines.append("")
+    lines.append("## Window means by (arm, variant)")
+    lines.append("")
+    lines.append(_md(tables["window"]))
+    lines.append("")
+    lines.append("## Pre-registered contrasts")
+    lines.append("")
+    lines.append(_md(pd.DataFrame(summary["contrasts"]["rows"])))
+    lines.append("")
+    lines.append("## Decision rules")
+    lines.append("")
+    lines.append("```json")
+    lines.append(json.dumps(summary["decisions"], indent=2))
+    lines.append("```")
+    lines.append("")
+    report_path.write_text("\n".join(lines))
+    common.log(f"wrote {report_path}")
+
+
+def main() -> int:
+    cells_dir = common.RESULTS / "cells"
+    agg_dir = common.RESULTS / "agg"
+    fig_dir = common.RESULTS / "figures"
+    agg_dir.mkdir(parents=True, exist_ok=True)
+    fig_dir.mkdir(parents=True, exist_ok=True)
+
+    df = load_cells(cells_dir)
+    if df.empty:
+        common.log("no cell CSVs found; nothing to analyze")
+        return 1
+    if (df["gmm_variant"] != "").sum() == 0:
+        common.log("no gmm_variant rows - was the run launched with CALIB_SAFE_THRESHOLDS=1?")
+        return 1
+
+    sanity = production_blend_sanity(df)
+    curves = variant_curves(df, agg_dir)
+    window = window_table(df, agg_dir)
+    contrasts = contrast_tables(df, agg_dir)
+    decisions = decision_rules(contrasts)
+    figs = make_figures(curves, fig_dir)
+
+    summary = {
+        "n_rows": int(len(df)),
+        "n_variant_rows": int((df["gmm_variant"] != "").sum()),
+        "n_cells": int(df[["dataset", "embedder", "category", "seed"]].drop_duplicates().shape[0]),
+        "windows": {k: list(v) for k, v in WINDOWS.items()},
+        "sanity": sanity,
+        "contrasts": contrasts,
+        "decisions": decisions,
+        "figures": figs,
+    }
+    (common.RESULTS / "summary.json").write_text(json.dumps(summary, indent=2, default=float))
+    write_report(summary, {"window": window}, common.RESULTS / "REPORT.md")
+    common.log("analysis complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -59,7 +59,10 @@ INCLUSION = 0
 SIM_FRACTION = 0.5
 CALIBRATE_COUNT = 2
 CALIBRATION_FRACTION = 0.5
-SAFE_THRESHOLDS = False
+#: The #2781 study pre-registered safe_thresholds OFF (conformal path only);
+#: the #2799 safe-threshold GMM study flips this on via CALIB_SAFE_THRESHOLDS=1
+#: (see docs/plans/safe-threshold-gmm-experiment.md).
+SAFE_THRESHOLDS = os.environ.get("CALIB_SAFE_THRESHOLDS", "0") == "1"
 MEDIA_TYPE = "image"
 
 # --- Category-selection parameters (copied from the Max-Patch runner) ---

--- a/scripts/experiments/calibration/launch_cells.sh
+++ b/scripts/experiments/calibration/launch_cells.sh
@@ -32,10 +32,13 @@ B=$(sbatch --parsable --job-name=cal-cells --array=0-$((N-1))%$CONC \
   --wrap="source $WT/gridenv.sh && $ENVX && cd $HERE && python run_cells.py")
 echo "cells array: $B"
 
+# Which analyzer runs after the cells: the #2781 study's analyze.py (default)
+# or the #2799 safe-threshold study's analyze_safe.py (set by launch_safe.sh).
+ANALYZE="${CALIB_ANALYZE:-analyze.py}"
 A=$(sbatch --parsable --dependency=afterany:$B --job-name=cal-analyze --mem=16G \
   --cpus-per-task=4 --time=0:40:00 --partition=cpu \
   --export=ALL --output="$LOGS/analyze-%j.out" \
-  --wrap="source $WT/gridenv.sh && $ENVX && cd $HERE && python analyze.py")
+  --wrap="source $WT/gridenv.sh && $ENVX && cd $HERE && python $ANALYZE")
 echo "analyze: $A"
 echo "$B" > "$LOGS/.cells_jobid"
 echo "Report -> $CALIB_RESULTS/REPORT.md"

--- a/scripts/experiments/calibration/launch_safe.sh
+++ b/scripts/experiments/calibration/launch_safe.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Safe-threshold GMM study (#2799) on the HLTCOE Grid.
+#
+# Thin wrapper over launch_all.sh that flips the pre-registered #2799 knobs:
+# safe_thresholds ON, Visual Genome region voting only, the production
+# `max_patch` patch style plus a `whole_image` single-vector control, 30 voting
+# steps (the GMM has authority only below ~20 votes), 8 seeds (cells are ~5x
+# cheaper than the 150-step #2781 cells, and the small-vote regime is noisy).
+# Results land under /exp/$USER/calibration-safe so the #2781 outputs are
+# untouched; the shared Max-Patch pickles/crops are reused in place.
+#
+# Design + pre-registered decision rules: docs/plans/safe-threshold-gmm-experiment.md
+#
+# Usage: bash launch_safe.sh
+set -uo pipefail
+
+export CALIB_EXP="${CALIB_EXP:-/exp/$USER/calibration-safe}"
+export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
+
+export CALIB_SAFE_THRESHOLDS=1
+export CALIB_ANALYZE=analyze_safe.py
+
+# Visual Genome region voting only; production patch arm + single-vector control.
+export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m}"
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
+# No raw-patch tree arm -> nothing to re-pool.
+export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"
+
+# The 6-20-vote ramp window is the object of study; beyond ~20 votes the blend
+# is pure cross-cal and the #2781 study already covers it.
+export CALIB_MAX_STEPS="${CALIB_MAX_STEPS:-30}"
+export CALIB_N_SEEDS="${CALIB_N_SEEDS:-8}"
+
+# Short trajectories -> short cells.
+export CALIB_TIME="${CALIB_TIME:-1:30:00}"
+
+exec bash "$(dirname "$0")/launch_all.sh"

--- a/tests_lib/detectors/test_safe_gmm_variant_rows.py
+++ b/tests_lib/detectors/test_safe_gmm_variant_rows.py
@@ -1,0 +1,131 @@
+"""Tests for the safe-threshold GMM variant rows in the eval harness (issue #2799).
+
+With ``safe_thresholds=True`` and ``emit_calibration_metrics=True`` the harness
+emits one extra metric row per GMM variant at every trainable step - the #2799
+measurement arms.  The load-bearing invariant is that the ``pooled_cross``
+variant (pooled fit, equal-density crossing, sigmoid space - i.e. exactly what
+production computes) reproduces the base row's blended threshold bit-for-bit,
+so the study measures the shipped code and every other variant differs from it
+along exactly one named axis.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.eval.voting_iterations import (
+    _CALIBRATION_COLUMNS,
+    _SAFE_GMM_VARIANTS,
+    simulate_voting_iterations,
+)
+
+# Reuse the synthetic planted-patch dataset builders from the Max-Patch tests.
+from .test_max_patch_style import _planted_dataset
+
+_VARIANT_NAMES = {name for name, _fit, _cut, _space in _SAFE_GMM_VARIANTS}
+
+
+def _run_safe(style, seed=0, max_steps=16):
+    medias, _ = _planted_dataset(n_per_cat=40, seed=seed)
+    return simulate_voting_iterations(
+        medias,
+        target_category="cat0",
+        seed=seed,
+        dataset_name="planted",
+        inclusion=0,
+        region_voting=True,
+        safe_thresholds=True,
+        max_steps=max_steps,
+        style=style,
+        emit_calibration_metrics=True,
+    )
+
+
+class TestSafeGmmVariantRows:
+    def test_every_step_emits_base_plus_all_variants(self):
+        rows = _run_safe("max_patch")
+        assert rows, "no rows produced"
+        by_step: dict[int, set[str]] = {}
+        for r in rows:
+            by_step.setdefault(r["t"], set()).add(r["gmm_variant"])
+        for variants_at_t in by_step.values():
+            assert variants_at_t == {"", *_VARIANT_NAMES}
+
+    def test_columns_and_tags(self):
+        rows = _run_safe("max_patch")
+        for r in rows:
+            assert set(_CALIBRATION_COLUMNS).issubset(r.keys())
+        base = [r for r in rows if r["gmm_variant"] == ""]
+        variant = [r for r in rows if r["gmm_variant"] != ""]
+        assert base and variant
+        # The production operating point is the base row; its provenance is the
+        # blend tag, and it records the pre-blend conformal cut alongside.
+        for r in base:
+            assert r["threshold_provenance"] == "gmm_blend"
+            assert np.isfinite(r["xcal_threshold"])
+        for r in variant:
+            assert r["pool_variant"] == "max"
+            assert 0.0 <= r["blend_weight"] <= 1.0 or np.isnan(r["blend_weight"])
+
+    def test_pooled_cross_reproduces_production_blend(self):
+        rows = _run_safe("max_patch")
+        base = {r["t"]: r for r in rows if r["gmm_variant"] == ""}
+        pc = {r["t"]: r for r in rows if r["gmm_variant"] == "pooled_cross"}
+        assert set(base) == set(pc)
+        for t, b in base.items():
+            assert pc[t]["threshold"] == b["threshold"], f"step {t}: variant diverged from production"
+
+    def test_xcal_only_is_the_unblended_cut(self):
+        rows = _run_safe("max_patch")
+        base = {r["t"]: r for r in rows if r["gmm_variant"] == ""}
+        xo = {r["t"]: r for r in rows if r["gmm_variant"] == "xcal_only"}
+        for t, b in base.items():
+            assert xo[t]["threshold"] == b["xcal_threshold"]
+            # The control row keeps the pre-blend provenance, not the blend tag.
+            assert xo[t]["threshold_provenance"] != "gmm_blend"
+
+    def test_pure_gmm_below_the_ramp(self):
+        """Below 6 votes the blend weight is 0, so blended == the GMM cut."""
+        rows = _run_safe("max_patch")
+        saw_pure = False
+        for r in rows:
+            if r["gmm_variant"] in ("", "xcal_only"):
+                continue
+            n_votes = r["n_good"] + r["n_bad"]
+            if n_votes <= 6:
+                assert r["blend_weight"] == 0.0
+                assert r["threshold"] == r["gmm_cut"]
+                saw_pure = True
+        assert saw_pure, "no sub-ramp step reached - raise max_steps"
+
+    def test_whole_image_collapses_fit_geometries(self):
+        """On a single-vector style the pooled and image-level scores coincide,
+        so the two fit geometries must produce identical cuts."""
+        rows = _run_safe("whole_image", max_steps=12)
+        by_step: dict[int, dict[str, dict]] = {}
+        for r in rows:
+            if r["gmm_variant"]:
+                by_step.setdefault(r["t"], {})[r["gmm_variant"]] = r
+        assert by_step
+        for variants in by_step.values():
+            assert variants["image_mid"]["gmm_cut"] == variants["pooled_mid"]["gmm_cut"]
+            assert variants["image_cross"]["gmm_cut"] == variants["pooled_cross"]["gmm_cut"]
+
+    def test_no_variant_rows_without_safe_thresholds(self):
+        medias, _ = _planted_dataset(n_per_cat=40, seed=0)
+        rows = simulate_voting_iterations(
+            medias,
+            target_category="cat0",
+            seed=0,
+            dataset_name="planted",
+            inclusion=0,
+            region_voting=True,
+            safe_thresholds=False,
+            max_steps=10,
+            style="max_patch",
+            emit_calibration_metrics=True,
+        )
+        assert rows
+        assert all(r["gmm_variant"] == "" for r in rows)
+        # Without the blend the recorded xcal threshold is the threshold itself.
+        assert all(r["xcal_threshold"] == r["threshold"] for r in rows)

--- a/tests_lib/sorting/test_gmm_fit_refactor.py
+++ b/tests_lib/sorting/test_gmm_fit_refactor.py
@@ -1,0 +1,110 @@
+"""Tests for the GMM fit/cut/blend decomposition in ``thresholds.py`` (issue #2799).
+
+The #2799 measurement harness re-cuts one fitted GMM under several rules and
+re-blends pre-computed cuts on the production label ramp, so the monolithic
+``calculate_gmm_threshold`` / ``calculate_safe_threshold`` pair was split into
+``gmm_fit_array`` + ``fit_score_gmm`` + ``GmmFit1D`` cuts and
+``safe_blend_weight`` + ``blend_gmm_threshold``.  These tests pin the split's
+contract: recomposing the pieces must reproduce the production functions
+exactly, so the study's ``pooled_cross`` variant is guaranteed to measure the
+threshold production actually ships.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from vtscore.training.thresholds import (
+    GmmFit1D,
+    _GMM_MAX_SAMPLES,
+    blend_gmm_threshold,
+    calculate_gmm_threshold,
+    calculate_safe_threshold,
+    fit_score_gmm,
+    gmm_fit_array,
+    safe_blend_weight,
+)
+
+
+def _bimodal(n=400, seed=7):
+    rng = np.random.default_rng(seed)
+    lo = rng.normal(0.2, 0.05, size=int(n * 0.8))
+    hi = rng.normal(0.8, 0.03, size=n - int(n * 0.8))
+    return np.clip(np.concatenate([lo, hi]), 0.0, 1.0).tolist()
+
+
+class TestFitScoreGmm:
+    def test_components_ordered_by_mean(self):
+        fit = fit_score_gmm(np.asarray(_bimodal()))
+        assert fit is not None
+        assert fit.mu_lo < fit.mu_hi
+        assert fit.w_lo > 0 and fit.w_hi > 0
+        assert fit.var_lo > 0 and fit.var_hi > 0
+        assert fit.w_lo + fit.w_hi == pytest.approx(1.0, abs=1e-9)
+
+    def test_fewer_than_two_scores_is_none(self):
+        assert fit_score_gmm(np.asarray([0.5])) is None
+        assert fit_score_gmm(np.empty(0)) is None
+
+    def test_midpoint_is_mean_of_means(self):
+        fit = GmmFit1D(w_lo=0.7, mu_lo=0.2, var_lo=0.01, w_hi=0.3, mu_hi=0.8, var_hi=0.01)
+        assert fit.midpoint() == pytest.approx(0.5)
+
+    def test_crossing_falls_back_to_midpoint(self):
+        # Equal variances + a 999:1 weight ratio push the crossing outside the
+        # means -> the cut method must fall back to the midpoint.
+        fit = GmmFit1D(w_lo=0.999, mu_lo=0.0, var_lo=1.0, w_hi=0.001, mu_hi=1.0, var_hi=1.0)
+        assert fit.crossing_or_midpoint() == pytest.approx(fit.midpoint())
+
+
+class TestGmmFitArray:
+    def test_small_input_unchanged(self):
+        scores = _bimodal(n=100)
+        assert np.array_equal(gmm_fit_array(scores), np.asarray(scores, dtype=np.float64))
+
+    def test_large_input_subsampled_deterministically(self):
+        rng = np.random.default_rng(3)
+        scores = rng.random(_GMM_MAX_SAMPLES + 1000)
+        a = gmm_fit_array(scores)
+        b = gmm_fit_array(scores)
+        assert a.shape[0] == _GMM_MAX_SAMPLES
+        assert np.array_equal(a, b)
+
+
+class TestRecomposition:
+    """The split pieces must recompose to the production functions exactly."""
+
+    def test_calculate_gmm_threshold_equals_fit_plus_cut(self):
+        scores = _bimodal()
+        fit = fit_score_gmm(gmm_fit_array(scores))
+        assert fit is not None
+        assert calculate_gmm_threshold(scores) == fit.crossing_or_midpoint()
+
+    @pytest.mark.parametrize("n_labels", [2, 5, 6, 7, 13, 19, 20, 40])
+    def test_calculate_safe_threshold_equals_blend_of_parts(self, n_labels):
+        scores = _bimodal()
+        expected = blend_gmm_threshold(0.9, calculate_gmm_threshold(scores), n_labels)
+        assert calculate_safe_threshold(0.9, scores, n_labels) == expected
+
+
+class TestBlend:
+    def test_ramp_endpoints(self):
+        assert safe_blend_weight(2) == 0.0
+        assert safe_blend_weight(6) == 0.0
+        assert safe_blend_weight(13) == pytest.approx(0.5)
+        assert safe_blend_weight(20) == 1.0
+        assert safe_blend_weight(100) == 1.0
+
+    def test_pure_gmm_below_ramp(self):
+        assert blend_gmm_threshold(0.9, 0.3, 4) == pytest.approx(0.3)
+
+    def test_pure_xcal_above_ramp(self):
+        assert blend_gmm_threshold(0.9, 0.3, 25) == pytest.approx(0.9)
+
+    def test_non_finite_guards(self):
+        nan = float("nan")
+        assert blend_gmm_threshold(nan, 0.3, 10) == 0.3
+        assert blend_gmm_threshold(0.9, nan, 10) == 0.9
+        assert blend_gmm_threshold(nan, nan, 10) == 0.5
+        assert math.isfinite(blend_gmm_threshold(float("inf"), 0.3, 10))

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -117,14 +117,20 @@ _VOTING_COLUMNS: tuple[str, ...] = (
 )
 
 #: Column order for the calibration study's main per-step frame (issue #2781),
-#: emitted only when ``emit_calibration_metrics``.  One row per ``pool_variant``.
+#: emitted only when ``emit_calibration_metrics``.  One row per ``pool_variant``;
+#: under ``safe_thresholds`` additionally one row per safe-threshold GMM variant
+#: (issue #2799), tagged in ``gmm_variant`` (``""`` on every other row).
 _CALIBRATION_COLUMNS: tuple[str, ...] = (
     *_IDENT_COLUMNS,
     "pool_variant",
+    "gmm_variant",
     "threshold",
     "threshold_provenance",
     "degenerate",
     "threshold_percentile",
+    "xcal_threshold",
+    "gmm_cut",
+    "blend_weight",
     "cost",
     "fpr",
     "fnr",
@@ -263,7 +269,7 @@ def _blend_safe_threshold(
     X_all_clips: Any,
     n_labels: int,
     style_obj: Any = None,
-) -> float:
+) -> tuple[float, list[float]]:
     """Blend *threshold* with a GMM threshold over the simulation set's scores.
 
     Region-aware datasets (MLP + patch embedder only) score the sim set via
@@ -274,21 +280,24 @@ def _blend_safe_threshold(
     With an explicit detection *style_obj* (see :mod:`vtscore.eval.patch_styles`)
     the sim set is scored through that style - the same scorer the test set
     uses - so the GMM sees the distribution the threshold will actually cut.
+
+    Returns ``(blended_threshold, sim_scores)`` - the scores the GMM was fitted
+    on ride along so the #2799 safe-threshold variant rows can re-cut the same
+    distribution without a second scoring pass.
     """
     import numpy as np  # noqa: PLC0415
 
     if style_obj is not None:
         assert sim_clips is not None and step.torch_model is not None
         all_scores = list(style_obj.score_media(step.torch_model, sim_clips).values())
-        return calculate_safe_threshold(threshold, all_scores, n_labels)
-    if region_aware:
+    elif region_aware:
         from vtscore.detectors.training import score_media_with_model  # noqa: PLC0415
 
         assert sim_clips is not None and step.torch_model is not None
         all_scores = [r["score"] for r in score_media_with_model(step.torch_model, sim_clips)]
     else:
         all_scores = np.asarray(step.predict(np.asarray(X_all_clips))).ravel().tolist()
-    return calculate_safe_threshold(threshold, all_scores, n_labels)
+    return calculate_safe_threshold(threshold, all_scores, n_labels), all_scores
 
 
 def _evaluate_on_test(
@@ -436,6 +445,12 @@ def _operating_metrics(
 
     return {
         "pool_variant": pool_variant,
+        # Safe-threshold study columns (issue #2799): defaults here; the base
+        # row and the per-variant rows overwrite them where they apply.
+        "gmm_variant": "",
+        "xcal_threshold": _r(float(threshold)),
+        "gmm_cut": nan,
+        "blend_weight": nan,
         "threshold": _r(float(threshold)),
         "threshold_provenance": provenance,
         "degenerate": 1 if is_degenerate(scores, threshold) else 0,
@@ -456,6 +471,127 @@ def _operating_metrics(
         "calibration_shift": _r(calibration_shift),
         "n_pool_rows": _r(float(n_pool_rows)),
     }
+
+
+#: Safe-threshold GMM variants (issue #2799): ``(name, fit_scores, cut, space)``.
+#: ``fit_scores`` picks which sim-set score distribution the GMM is fitted on
+#: ("pooled" = the style's inference max-pool, what production fits post-#2797;
+#: "image" = the whole-image vector scores, the historical pre-#2797 geometry).
+#: ``cut`` picks the rule ("cross" = equal-density crossing, production
+#: post-#2798; "mid" = midpoint-of-means, historical).  ``space`` fits the GMM
+#: on sigmoid scores ("sig") or their logits ("logit", the #2798 open idea).
+#: ``xcal_only`` is the no-blend control: the raw conformal threshold at the
+#: same step.  ``pooled_cross`` must reproduce the production blend exactly.
+_SAFE_GMM_VARIANTS: tuple[tuple[str, str, str, str], ...] = (
+    ("xcal_only", "", "", ""),
+    ("image_mid", "image", "mid", "sig"),
+    ("image_cross", "image", "cross", "sig"),
+    ("pooled_mid", "pooled", "mid", "sig"),
+    ("pooled_cross", "pooled", "cross", "sig"),
+    ("pooled_mid_logit", "pooled", "mid", "logit"),
+    ("pooled_cross_logit", "pooled", "cross", "logit"),
+)
+
+#: Sigmoid scores are clipped into ``[eps, 1-eps]`` before the logit transform
+#: so saturated scores stay finite.
+_LOGIT_EPS = 1e-6
+
+
+def _gmm_cuts(scores: list[float], space: str) -> dict[str, float]:
+    """Both GMM cut rules from one fit of *scores*, in sigmoid score space.
+
+    Mirrors :func:`vtscore.training.thresholds.calculate_gmm_threshold`'s
+    semantics per fallback (0.5 below 2 scores, median on fit failure) so the
+    ``("cross", "sig")`` cut blended on the pooled scores reproduces the
+    production safe threshold bit-for-bit.  With ``space="logit"`` the GMM is
+    fitted on the logit-transformed sample and the cut mapped back through the
+    sigmoid; the median fallback stays in the original space (the sigmoid is
+    monotone, so the two medians agree).
+    """
+    import numpy as np  # noqa: PLC0415
+
+    from vtscore.training.thresholds import fit_score_gmm, gmm_fit_array  # noqa: PLC0415
+
+    if len(scores) < 2:
+        return {"mid": 0.5, "cross": 0.5}
+    arr = gmm_fit_array(scores)
+    fit_arr = arr
+    if space == "logit":
+        p = np.clip(arr, _LOGIT_EPS, 1.0 - _LOGIT_EPS)
+        fit_arr = np.log(p) - np.log1p(-p)
+    fit = fit_score_gmm(fit_arr)
+    if fit is None:
+        med = float(np.median(arr))
+        return {"mid": med, "cross": med}
+    cuts = {"mid": fit.midpoint(), "cross": fit.crossing_or_midpoint()}
+    if space == "logit":
+        cuts = {name: float(1.0 / (1.0 + np.exp(-v))) for name, v in cuts.items()}
+    return cuts
+
+
+def _safe_gmm_variant_rows(
+    details: dict[str, Any],
+    base_scores: "np.ndarray",
+    base_labels: "np.ndarray",
+    sim_pooled_scores: list[float],
+    sim_image_scores: list[float],
+    inclusion: int,
+    n_pool_rows: float,
+) -> list[dict[str, Any]]:
+    """One metric row per safe-threshold GMM variant (issue #2799).
+
+    Every variant re-cuts the *same* per-step model: the two candidate sim-set
+    score distributions are fitted once per (fit, space) pair, each fit yields
+    both cut rules, and each cut is blended with the step's conformal threshold on
+    the production label ramp.  All variants are evaluated against the same
+    held-out test scores (*base_scores*, the inference max-pool), so the rows
+    are paired within a step by construction.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    from vtscore.training.thresholds import blend_gmm_threshold, safe_blend_weight  # noqa: PLC0415
+
+    xcal = float(details["xcal_threshold"])
+    n_votes = int(details["n_votes"])
+    pre_blend_provenance = str(details.get("pre_blend_provenance", "conformal"))
+    fold_orderings = details.get("fold_orderings") or []
+    cal_scores = np.array([s for scores, _ in fold_orderings for s in scores]) if fold_orderings else None
+    cal_labels = np.array([lb for _, labels_ in fold_orderings for lb in labels_]) if fold_orderings else None
+
+    fit_scores = {"pooled": sim_pooled_scores, "image": sim_image_scores}
+    cuts: dict[tuple[str, str], dict[str, float]] = {}
+    for name, _fit, _cut, _space in _SAFE_GMM_VARIANTS:
+        if _fit and (_fit, _space) not in cuts:
+            cuts[(_fit, _space)] = _gmm_cuts(fit_scores[_fit], _space)
+
+    weight = safe_blend_weight(n_votes)
+    rows: list[dict[str, Any]] = []
+    for name, _fit, _cut, _space in _SAFE_GMM_VARIANTS:
+        if name == "xcal_only":
+            threshold = xcal
+            gmm_cut = float("nan")
+            provenance = pre_blend_provenance
+        else:
+            gmm_cut = cuts[(_fit, _space)][_cut]
+            threshold = blend_gmm_threshold(xcal, gmm_cut, n_votes)
+            provenance = "gmm_blend"
+        row = _operating_metrics(
+            base_scores,
+            base_labels,
+            threshold,
+            inclusion,
+            cal_scores,
+            cal_labels,
+            pool_variant="max",
+            provenance=provenance,
+            n_pool_rows=n_pool_rows,
+        )
+        row["gmm_variant"] = name
+        row["xcal_threshold"] = _r(xcal)
+        row["gmm_cut"] = _r(gmm_cut)
+        row["blend_weight"] = _r(weight)
+        rows.append(row)
+    return rows
 
 
 def _calibration_metric_rows(
@@ -501,19 +637,22 @@ def _calibration_metric_rows(
     base_scores = cm.segment_max_pool(flat, seg)
     base_cal_scores = np.array([s for scores, _ in fold_orderings for s in scores]) if fold_orderings else None
     base_cal_labels = np.array([lb for _, labels_ in fold_orderings for lb in labels_]) if fold_orderings else None
-    rows.append(
-        _operating_metrics(
-            base_scores,
-            labels,
-            threshold,
-            inclusion,
-            base_cal_scores,
-            base_cal_labels,
-            pool_variant="max",
-            provenance=provenance,
-            n_pool_rows=n_pool_rows,
-        )
+    base = _operating_metrics(
+        base_scores,
+        labels,
+        threshold,
+        inclusion,
+        base_cal_scores,
+        base_cal_labels,
+        pool_variant="max",
+        provenance=provenance,
+        n_pool_rows=n_pool_rows,
     )
+    if "xcal_threshold" in details:
+        # Under safe_thresholds the base row's threshold is the blended one;
+        # record the pre-blend conformal cut alongside it (issue #2799).
+        base["xcal_threshold"] = _r(float(details["xcal_threshold"]))
+    rows.append(base)
 
     # --- Remedial re-pools: only where the same fold models exposed node data
     # (the raw-patch tree arm) and the base threshold was a real conformal cut. ---
@@ -1179,6 +1318,10 @@ def simulate_voting_iterations(  # noqa: C901
         sim_fraction: Fraction of medias used for simulated voting.
         safe_thresholds: When ``True``, blend the cross-calibration threshold
             with a GMM-based threshold for robustness with small label counts.
+            Under ``emit_calibration_metrics`` with a *style*, each step
+            additionally emits one metric row per safe-threshold GMM variant
+            (:data:`_SAFE_GMM_VARIANTS`, tagged in the ``gmm_variant`` column) -
+            the #2799 measurement arms.
         calibrate_count: Number of random Train/Calibrate splits for threshold
             calibration (default 2).
         calibration_fraction: Fraction of labelled data reserved for
@@ -1300,6 +1443,13 @@ def simulate_voting_iterations(  # noqa: C901
         gmm_clip_embs = np.array([media_embedding(clips_dict[cid]) for cid in sorted(sim_ids)])
         X_all_clips = torch.tensor(gmm_clip_embs, dtype=torch.float32)
 
+    # The #2799 safe-threshold variant rows additionally fit a GMM on the sim
+    # set's *whole-image* scores (the historical pre-#2797 fit geometry), so
+    # the whole-image matrix is pre-stacked once here.
+    X_sim_image: "np.ndarray | None" = None
+    if safe_thresholds and emit_calibration_metrics and style_obj is not None:
+        X_sim_image = np.stack([sim_embeddings[cid] for cid in sorted(sim_ids)])
+
     good_votes: dict[int, None] = {}
     bad_votes: dict[int, None] = {}
     labeled: dict[int, float] = {}
@@ -1395,12 +1545,17 @@ def simulate_voting_iterations(  # noqa: C901
         )
 
         # Apply safe threshold blending if enabled
+        sim_pooled_scores: list[float] | None = None
         if safe_thresholds:
-            threshold = _blend_safe_threshold(
+            xcal_threshold = threshold
+            threshold, sim_pooled_scores = _blend_safe_threshold(
                 threshold, step, region_aware, sim_clips, X_all_clips, n_labels, style_obj=style_obj
             )
             if emit_calibration_metrics:
+                details["pre_blend_provenance"] = details.get("provenance", "conformal")
                 details["provenance"] = "gmm_blend"
+                details["xcal_threshold"] = xcal_threshold
+                details["n_votes"] = n_labels
 
         # Evaluate on the held-out test set.  The calibration study (#2781)
         # emits one row per pooling (base + remedial) instead of the single
@@ -1485,6 +1640,21 @@ def simulate_voting_iterations(  # noqa: C901
 
         if calibration is not None:
             metric_rows, base_scores, base_labels = calibration
+            # One extra row per safe-threshold GMM variant (issue #2799), all
+            # evaluated against the same held-out max-pooled test scores.
+            if X_sim_image is not None and sim_pooled_scores is not None:
+                sim_image_scores = np.asarray(step.predict(X_sim_image)).ravel().tolist()
+                metric_rows.extend(
+                    _safe_gmm_variant_rows(
+                        details,
+                        base_scores,
+                        base_labels,
+                        sim_pooled_scores,
+                        sim_image_scores,
+                        inclusion,
+                        n_pool_rows=metric_rows[0]["n_pool_rows"],
+                    )
+                )
             for mr in metric_rows:
                 rows.append({**base_row, **mr, **timing_cols})
             # The near-free inclusion-budget sweep, into the side sink.

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import math
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -143,6 +144,89 @@ def _weighted_gaussian_crossing(
     return mu_lo + max(inside)
 
 
+@dataclass(frozen=True)
+class GmmFit1D:
+    """The two components of a fitted 1-D, 2-component GMM, ordered by mean.
+
+    Carries exactly the parameters the two candidate cut rules need, so one EM
+    fit can be re-cut under both rules (the safe-threshold measurement study,
+    issue #2799) instead of re-fitting per rule.  ``lo`` is the Bad (low-mean)
+    component, ``hi`` the Good one.
+    """
+
+    w_lo: float
+    mu_lo: float
+    var_lo: float
+    w_hi: float
+    mu_hi: float
+    var_hi: float
+
+    def midpoint(self) -> float:
+        """The historical cut: the midpoint between the two component means."""
+        return (self.mu_lo + self.mu_hi) / 2.0
+
+    def crossing_or_midpoint(self) -> float:
+        """The production cut: equal-density crossing, midpoint when none exists."""
+        crossing = _weighted_gaussian_crossing(self.w_lo, self.mu_lo, self.var_lo, self.w_hi, self.mu_hi, self.var_hi)
+        return self.midpoint() if crossing is None else crossing
+
+
+def gmm_fit_array(scores: "list[float] | np.ndarray") -> np.ndarray:
+    """The (possibly subsampled) float64 array a score-GMM is fitted on.
+
+    Above :data:`_GMM_MAX_SAMPLES` scores, takes a deterministic (seed-42)
+    random subsample; below, returns the scores unchanged.  Exposed separately
+    from :func:`fit_score_gmm` so a caller that needs the fit's *input* too
+    (e.g. for the median fallback, or to transform the same sample into logit
+    space) subsamples exactly once.
+    """
+    arr = np.asarray(scores, dtype=np.float64)
+    if arr.shape[0] > _GMM_MAX_SAMPLES:
+        rng = np.random.default_rng(42)
+        arr = rng.choice(arr, size=_GMM_MAX_SAMPLES, replace=False)
+    return arr
+
+
+def fit_score_gmm(arr: np.ndarray) -> GmmFit1D | None:
+    """Fit a deterministic 2-component GMM to a 1-D score array.
+
+    Returns ``None`` when the fit fails (fewer than 2 scores, or an EM
+    failure), leaving the fallback policy to the caller -
+    :func:`calculate_gmm_threshold` falls back to the median.
+    """
+    if arr.shape[0] < 2:
+        return None
+
+    from sklearn.mixture import GaussianMixture  # noqa: PLC0415
+
+    try:
+        gmm: GaussianMixture = GaussianMixture(n_components=2, random_state=42)
+        gmm.fit(arr.reshape(-1, 1))
+
+        # The stubs type these ``np.ndarray | None``; all are set after ``fit``.
+        assert gmm.means_ is not None
+        assert gmm.covariances_ is not None
+        assert gmm.weights_ is not None
+        means = np.ravel(gmm.means_)
+        # ``covariances_`` is (n_components, 1, 1) under the default "full"
+        # covariance type; ravel gives the two scalar variances.
+        variances = np.ravel(gmm.covariances_)
+        weights = np.ravel(gmm.weights_)
+
+        low_idx = 0 if means[0] < means[1] else 1
+        high_idx = 1 - low_idx
+        return GmmFit1D(
+            w_lo=float(weights[low_idx]),
+            mu_lo=float(means[low_idx]),
+            var_lo=float(variances[low_idx]),
+            w_hi=float(weights[high_idx]),
+            mu_hi=float(means[high_idx]),
+            var_hi=float(variances[high_idx]),
+        )
+    except Exception:
+        return None
+
+
 def calculate_gmm_threshold(scores: list[float]) -> float:
     """Use a Gaussian Mixture Model to find a threshold between two score distributions.
 
@@ -175,55 +259,13 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
     if len(scores) < 2:
         return 0.5
 
-    from sklearn.mixture import GaussianMixture  # noqa: PLC0415
-
-    arr = np.asarray(scores, dtype=np.float64)
-    if arr.shape[0] > _GMM_MAX_SAMPLES:
-        rng = np.random.default_rng(42)
-        arr = rng.choice(arr, size=_GMM_MAX_SAMPLES, replace=False)
-
-    # Reshape for sklearn
-    X = arr.reshape(-1, 1)
-
-    try:
-        # Fit a 2-component GMM
-        gmm: GaussianMixture = GaussianMixture(n_components=2, random_state=42)
-        gmm.fit(X)
-
-        # Get the means of the two components.  The stub types `means_`
-        # as `np.ndarray | None`; after `fit` it's always set.
-        assert gmm.means_ is not None
-        means = np.ravel(gmm.means_)
-
-        # Identify which component is "low" (Bad) and which is "high" (Good)
-        low_idx = 0 if means[0] < means[1] else 1
-        high_idx = 1 - low_idx
-
-        # Threshold is at the intersection of the two Gaussians; the midpoint
-        # between the means is the fallback when that intersection is not a
-        # usable boundary (degenerate fit, or root outside the two means).
-        midpoint = float((means[low_idx] + means[high_idx]) / 2.0)
-
-        # ``covariances_`` is (n_components, 1, 1) under the default "full"
-        # covariance type; ravel gives the two scalar variances.  Both attributes
-        # are stub-typed ``np.ndarray | None`` and always set after ``fit``.
-        assert gmm.covariances_ is not None
-        assert gmm.weights_ is not None
-        variances = np.ravel(gmm.covariances_)
-        weights = np.ravel(gmm.weights_)
-        crossing = _weighted_gaussian_crossing(
-            float(weights[low_idx]),
-            float(means[low_idx]),
-            float(variances[low_idx]),
-            float(weights[high_idx]),
-            float(means[high_idx]),
-            float(variances[high_idx]),
-        )
-        return midpoint if crossing is None else crossing
-    except Exception:
+    arr = gmm_fit_array(scores)
+    fit = fit_score_gmm(arr)
+    if fit is None:
         # If GMM fails, return median (of the subsample when one was taken -
         # representative of the full distribution and keeps this path bounded).
         return float(np.median(arr))
+    return fit.crossing_or_midpoint()
 
 
 def _score_rows_digest(score_rows_by_group: dict | None) -> bytes | None:
@@ -981,8 +1023,27 @@ def calculate_safe_threshold(
         ``DetectorContext.threshold`` without breaking ``score >= threshold``
         comparisons.
     """
-    gmm_threshold = calculate_gmm_threshold(all_scores)
+    return blend_gmm_threshold(xcal_threshold, calculate_gmm_threshold(all_scores), n_labels)
 
+
+def safe_blend_weight(n_labels: int) -> float:
+    """The x-cal weight of the safe-threshold blend at *n_labels* labels.
+
+    Linear ramp: 0 at 6 labels (pure GMM), 1 at 20 (pure x-cal).
+    """
+    MIN_LABELS = 6
+    MAX_LABELS = 20
+    return max(0.0, min(1.0, (n_labels - MIN_LABELS) / (MAX_LABELS - MIN_LABELS)))
+
+
+def blend_gmm_threshold(xcal_threshold: float, gmm_threshold: float, n_labels: int) -> float:
+    """Blend an x-cal and a GMM threshold on the safe-threshold label ramp.
+
+    The blending core of :func:`calculate_safe_threshold`, split out so a
+    caller with a pre-computed GMM cut (the #2799 measurement harness re-cuts
+    one fitted GMM under several rules) applies the identical ramp and
+    finite-guards without re-fitting.
+    """
     # Defend against non-finite inputs from either side: an upstream
     # ``calculate_cross_calibration_threshold`` can theoretically still
     # surface inf/NaN, and ``calculate_gmm_threshold`` returns NaN when
@@ -998,11 +1059,7 @@ def calculate_safe_threshold(
     if not gmm_finite:
         return xcal_threshold
 
-    # Linear ramp: 0 at 6 labels, 1 at 20 labels
-    MIN_LABELS = 6
-    MAX_LABELS = 20
-    label_weight = max(0.0, min(1.0, (n_labels - MIN_LABELS) / (MAX_LABELS - MIN_LABELS)))
-
+    label_weight = safe_blend_weight(n_labels)
     blended = label_weight * xcal_threshold + (1.0 - label_weight) * gmm_threshold
     if not math.isfinite(blended):
         return 0.5


### PR DESCRIPTION
Prep for the #2799 measurement: everything needed to run the safe-threshold GMM study on the Grid, without running it. Refs #2799, refs #2797, refs #2798.

## What's here

**Harness instrumentation** (`vtscore/eval/voting_iterations.py`): with `safe_thresholds=True` + `emit_calibration_metrics=True`, every trainable step now emits one metric row per safe-threshold GMM variant, tagged in a new `gmm_variant` column (plus `xcal_threshold`, `gmm_cut`, `blend_weight` columns). The variants factor over fit geometry (`pooled` region max-pool vs historical `image`-level), cut rule (`cross` equal-density crossing vs historical `mid`point), and fit space (`sig` vs `logit` — the idea #2798 left unshipped), plus an `xcal_only` no-blend control. All variants are paired within a step on the identical model, votes, and held-out test scores; the extra cost per step is two sim-set scoring passes and three small GMM fits.

**Threshold library split** (`vtscore/training/thresholds.py`): `calculate_gmm_threshold` / `calculate_safe_threshold` are decomposed into `gmm_fit_array` + `fit_score_gmm` + `GmmFit1D.{midpoint,crossing_or_midpoint}` and `safe_blend_weight` + `blend_gmm_threshold`. Behavior-preserving — the recomposition is pinned by tests, and the harness's `pooled_cross` variant reproduces the production blend bit-for-bit (asserted per-step in tests and across a whole run by the analyzer's sanity check).

**Runner** (`scripts/experiments/calibration/`): `CALIB_SAFE_THRESHOLDS` env knob, `launch_safe.sh` (VG-only arms — `dinov3_patch`×`max_patch` production arm + `siglip`×`whole_image` single-vector control — 30 steps, 8 seeds, results under `/exp/$USER/calibration-safe`), and `analyze_safe.py` computing the pre-registered deliverables: per-variant FPR/FNR/cost vs vote count, the paired contrasts (Wilcoxon over (category, seed) cells), threshold diagnostics, and the decision-rule verdicts.

**Plan file** (`docs/plans/safe-threshold-gmm-experiment.md`): the pre-registered design, windows (2–5 pure-GMM, 6–20 ramp), decision rules (keep/revert #2801, adopt-logit bar, cold-start note trigger), and the Grid runbook (`bash launch_safe.sh`).

## Validation

- `./run-tests.sh sorting detectors` and the full `./run-tests.sh`: **all 7438 tests pass** (new: `tests_lib/sorting/test_gmm_fit_refactor.py`, `tests_lib/detectors/test_safe_gmm_variant_rows.py`).
- `analyze_safe.py` smoke-tested end-to-end against real harness output (synthetic planted-patch cells in `run_cells.py`'s CSV format): report, figures, contrasts, and decision blocks all generate, and the `pooled_cross == production blend` sanity check holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3oTixDXYBSLtKLWSmD9fs

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3oTixDXYBSLtKLWSmD9fs)_