### PR TITLE
Threshold-stability #2790: crossing-GMM on region voting + spike-vector signature

### DIFF
--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -197,3 +197,30 @@ hard examples" are found **per embedder** — the SigLIP 2 mislabels/look-alikes
 DINO ones are different sets, both worth harvesting. (The sparse-positive fix
 `--defer-cut-goods` is embedder-agnostic — it stabilizes the cut regardless of which
 images are at the boundary.)
+
+---
+
+## New GMM (equal-density crossing, dev #2801) on the region-voting path
+
+Ported dev's crossing-based `calculate_gmm_threshold` (cuts at the components'
+equal-density crossing, not the midpoint of means — engineered for the region-voted
+max-over-~24-nodes score distribution, whose Bad mode is a wide right-skewed
+extreme-value statistic). Re-ran base vs defer6 (DINOv3/hac, 5 classes × 10 seeds).
+
+| GMM | arm | spike_rate | cost_sd | runaway% | cost_auc | final_cost | regret |
+|---|---|---|---|---|---|---|---|
+| old (midpoint) | base | 0.181 | 0.306 | 35% | 0.446 | 0.294 | 0.184 |
+| old (midpoint) | defer6 | 0.128 | 0.201 | 16% | 0.390 | 0.267 | 0.133 |
+| new (crossing) | base | 0.180 | 0.234 | 29% | 0.356 | 0.248 | **0.120** |
+| new (crossing) | defer6 | 0.180 | **0.190** | **15%** | **0.337** | **0.215** | 0.147 |
+
+- **The crossing GMM is a clear win for region voting** — it lowers the cost *level*
+  substantially on the base arm (regret 0.184→0.120, cost_auc 0.446→0.356, final_cost
+  0.294→0.248, runaways 35→29%) by cutting the skewed distribution correctly.
+- **It largely subsumes defer's benefit here:** new-GMM *base* already beats old-GMM
+  *defer6* on regret/cost_auc/final_cost. defer was a workaround for a bad GMM; a good
+  GMM does most of the job in the safe-threshold blend directly.
+- **Neither reduces the spike *rate*** (~0.18 across all four) — the step-to-step jumps
+  persist; the win is in the cost *level*, not jumpiness.
+- **Best combo = new-GMM + defer6** (lowest cost_sd/cost_auc/final_cost, runaways 15%),
+  though regret ticks up vs new-GMM base. Worth updating to the new GMM regardless.

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -224,3 +224,30 @@ extreme-value statistic). Re-ran base vs defer6 (DINOv3/hac, 5 classes × 10 see
   persist; the win is in the cost *level*, not jumpiness.
 - **Best combo = new-GMM + defer6** (lowest cost_sd/cost_auc/final_cost, runaways 15%),
   though regret ticks up vs new-GMM base. Worth updating to the new GMM regardless.
+
+---
+
+## What's special about the spiking *vectors*? (pure embedding, #2790)
+
+`spike_vectors.py` — no eval framework, just cached SigLIP 2 whole-image embeddings.
+For each class: G = positive vectors, B = negatives, S = spikers (bad, ≥5 seeds). For
+each spiker, its **percentile among all bads** on several geometric features; mean over
+71 classes (one strong spiker each):
+
+| feature | spiker pctile | reading |
+|---|---|---|
+| `margin` = cos_G − cos_B | **0.69** | the signature: spikers lean toward good on the good↔bad axis |
+| `proj_w` (Fisher axis) | 0.69 | identical (monotone with margin) |
+| `cos_G` (good centroid) | 0.62 | more class-like than typical bads |
+| `cos_B` (bad centroid) | 0.44 | *less* bad-like |
+| `max_cos_G` (nearest good) | 0.59 | mildly nearer one exemplar |
+| `knn_good` | 0.56 | slightly more good neighbors |
+| `b_outlier` | 0.53 | ~typical — **not** an outlier |
+
+**A spiker is a negative pulled toward the good cluster and away from the bad cluster
+— a boundary case near the model's cut, leaning good but not extreme, and NOT an
+isolated outlier.** That is why nothing stands out in the pixels: the signal is a soft
+position in embedding space, not a distinct visual feature. The effect is real but
+moderate and **class-dependent** (strong: oven/sink/zebra/elephant, margin pct 0.9+;
+weak/reversed: umbrella/vase/surfboard). Consistent with "vaguely hard negatives."
+Tool: `spike_vectors.py`.

--- a/scripts/experiments/threshold_stability/spike_vectors.py
+++ b/scripts/experiments/threshold_stability/spike_vectors.py
@@ -1,0 +1,161 @@
+"""What's geometrically special about the spiking vectors? (#2790, pure embedding)
+
+No eval framework — just the cached embeddings. For each class c (one embedder), take
+the positive image vectors ``G``, the negative image vectors ``B``, and the spikers
+``S`` (the negatives that repeatedly stressed the cut, from ``spike_items.json``), and
+ask whether ``S`` is distinguishable from ordinary bads ``B\\S`` by any of:
+
+* ``cos_G`` — cosine to the good centroid (how class-like);
+* ``proj_w`` — projection on the good↔bad axis ``mean(G)-mean(B)`` (Fisher direction);
+* ``max_cos_G`` — nearest single good (a look-alike to one exemplar);
+* ``knn_good`` — fraction of good among the k nearest neighbors in ``G∪B`` (does it sit
+  in mixed/boundary territory);
+* ``b_outlier`` — mean distance to the k nearest bads (is it an outlier among negatives);
+* ``margin`` — ``cos_G - cos_B``.
+
+For each spiker it computes the **percentile** of that feature among all bads, then
+aggregates the mean spiker percentile per feature across classes: a feature where
+spikers land at a consistently extreme percentile is the signature. All vectors are
+the whole-image embeddings from ``regions/<ds>/<embedder>/whole/<id>.npz`` (same space
+for good and bad), L2-normalized.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "sod"))
+from datasets import SodDataset  # noqa: E402
+
+
+def _load_vecs(regions_dir: Path, ids: list[int]) -> tuple[np.ndarray, list[int]]:
+    vs, keep = [], []
+    for i in ids:
+        p = regions_dir / f"{i}.npz"
+        if not p.exists():
+            continue
+        with np.load(p) as z:
+            if "whole_vec" in z:
+                vs.append(np.asarray(z["whole_vec"], dtype=np.float64))
+                keep.append(i)
+    if not vs:
+        return np.empty((0, 0)), []
+    X = np.vstack(vs)
+    X /= np.linalg.norm(X, axis=1, keepdims=True) + 1e-12
+    return X, keep
+
+
+def _features(V: np.ndarray, G: np.ndarray, gc: np.ndarray, bc: np.ndarray, w: np.ndarray) -> dict:
+    """Feature matrix for rows of V, given good set G and axes."""
+    cos_G = V @ gc
+    cos_B = V @ bc
+    proj_w = V @ w
+    max_cos_G = (V @ G.T).max(axis=1) if len(G) else np.full(len(V), np.nan)
+    return {"cos_G": cos_G, "cos_B": cos_B, "margin": cos_G - cos_B, "proj_w": proj_w, "max_cos_G": max_cos_G}
+
+
+def _knn_good_and_outlier(B: np.ndarray, G: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]:
+    """For each bad row: fraction of good among k NN in G∪B, and mean dist to k NN bads."""
+    allX = np.vstack([G, B]) if len(G) else B
+    is_good = np.concatenate([np.ones(len(G)), np.zeros(len(B))]) if len(G) else np.zeros(len(B))
+    knn_good, b_out = [], []
+    for i in range(len(B)):
+        v = B[i]
+        sims = allX @ v
+        order = np.argsort(-sims)
+        order = order[order != (len(G) + i)][:k]  # drop self
+        knn_good.append(float(is_good[order].mean()))
+        bsims = B @ v
+        b_order = np.argsort(-bsims)
+        b_order = b_order[b_order != i][:k]
+        b_out.append(float((1.0 - bsims[b_order]).mean()))
+    return np.array(knn_good), np.array(b_out)
+
+
+def _pctile(x: float, arr: np.ndarray) -> float:
+    return float((arr < x).mean())
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Embedding-space signature of spiking vectors (#2790).")
+    ap.add_argument("--items", required=True, help="spike_items.json")
+    ap.add_argument("--cache", required=True)
+    ap.add_argument("--dataset", default="coco")
+    ap.add_argument("--embedder", default="siglip2")
+    ap.add_argument("--min-spikes", type=int, default=5, help="an image is a spiker if it spiked in >= this many seeds")
+    ap.add_argument("--neg-sample", type=int, default=1200)
+    ap.add_argument("--k", type=int, default=15)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args(argv)
+
+    data = json.loads(Path(args.items).read_text())
+    by_class: dict[str, list[int]] = {}
+    for it in data["items"]:
+        if it["gt_label"] == "bad" and it["n_spikes"] >= args.min_spikes:
+            by_class.setdefault(it["cls"], []).append(int(it["image_id"]))
+
+    regions = Path(args.cache) / "regions" / args.dataset / args.embedder / "whole"
+    feats = ["cos_G", "cos_B", "margin", "proj_w", "max_cos_G", "knn_good", "b_outlier"]
+    per_class_pcts: dict[str, list[dict]] = {}
+    rng = np.random.default_rng(0)
+
+    with SodDataset(args.dataset) as ds:
+        for cls, spikers in sorted(by_class.items()):
+            name = cls.replace("-", " ")
+            try:
+                split = ds.class_split(name, min_box_frac=0.03, neg_multiple=1, seed=0)
+            except Exception:
+                continue
+            neg_pool = [i for i in split.negative_ids if i not in set(spikers)]
+            if len(neg_pool) > args.neg_sample:
+                neg_pool = list(rng.choice(neg_pool, size=args.neg_sample, replace=False))
+            G, _ = _load_vecs(regions, list(split.gt_boxes))  # positive whole-image vecs
+            B, bkeep = _load_vecs(regions, neg_pool + spikers)  # bads incl. spikers
+            if len(G) < 3 or len(B) < 20:
+                continue
+            gc = G.mean(0)
+            gc /= np.linalg.norm(gc) + 1e-12
+            bc = B[: len(neg_pool)].mean(0) if len(neg_pool) else B.mean(0)
+            bc /= np.linalg.norm(bc) + 1e-12
+            w = gc - bc
+            w /= np.linalg.norm(w) + 1e-12
+            fx = _features(B, G, gc, bc, w)
+            knn_good, b_out = _knn_good_and_outlier(B, G, args.k)
+            fx["knn_good"] = knn_good
+            fx["b_outlier"] = b_out
+            sp_idx = [bkeep.index(i) for i in spikers if i in bkeep]
+            if not sp_idx:
+                continue
+            recs = []
+            for si in sp_idx:
+                recs.append({f: _pctile(fx[f][si], fx[f]) for f in feats})
+            per_class_pcts[cls] = recs
+
+    # Aggregate: mean spiker percentile per feature, across all spikers of all classes.
+    allrecs = [r for recs in per_class_pcts.values() for r in recs]
+    summary = {f: round(statistics.fmean(r[f] for r in allrecs), 3) for f in feats} if allrecs else {}
+    out = {"n_classes": len(per_class_pcts), "n_spikers": len(allrecs), "mean_spiker_percentile": summary,
+           "per_class": {c: {f: round(statistics.fmean(r[f] for r in recs), 3) for f in feats}
+                         for c, recs in per_class_pcts.items()}}  # fmt: skip
+    if args.out:
+        Path(args.out).write_text(json.dumps(out, indent=2))
+
+    print(f"classes={out['n_classes']}  spikers={out['n_spikers']}")
+    print("\nMean spiker PERCENTILE among bads (0.5 = typical bad; >>0.5 or <<0.5 = signature):")
+    for f in feats:
+        print(f"  {f:<12} {summary.get(f, float('nan')):.3f}")
+    print("\nPer-class (mean spiker percentile):")
+    print(f"  {'class':<15} " + " ".join(f"{f:>9}" for f in feats))
+    for c, m in sorted(out["per_class"].items()):
+        print(f"  {c:<15} " + " ".join(f"{m[f]:>9.2f}" for f in feats))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -10,6 +10,8 @@ from votes, caching on ``DetectorContext``) lives in
 from __future__ import annotations
 
 import hashlib
+import math
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -39,12 +41,185 @@ CONFORMAL_QPOS_MAX = 0.75
 _GMM_MAX_SAMPLES = 50_000
 
 
+def _quadratic_roots(a: float, b: float, c: float) -> list[float]:
+    """Real roots of ``a*x^2 + b*x + c``, degenerating gracefully to the linear case.
+
+    Uses the cancellation-free ("citardauq") pairing ``q = -(b + sign(b)*sqrt(D))/2``,
+    ``x = {q/a, c/q}`` rather than the textbook formula.  That matters here because
+    the near-equal-variance case drives ``a`` toward 0, where ``(-b + sqrt(D)) /
+    (2a)`` is catastrophic cancellation over a vanishing denominator while ``c/q``
+    stays accurate and converges smoothly to the linear root ``-c/b``.
+    """
+    if a == 0.0:
+        return [] if b == 0.0 else [-c / b]
+    disc = b * b - 4.0 * a * c
+    if disc < 0.0:
+        return []
+    q = -0.5 * (b + math.copysign(math.sqrt(disc), b))
+    if q == 0.0:
+        # Only reachable with b == 0 and disc == 0, i.e. ``a*x^2 = 0``.
+        return [0.0]
+    return [q / a, c / q]
+
+
+def _weighted_gaussian_crossing(
+    w_lo: float,
+    mu_lo: float,
+    var_lo: float,
+    w_hi: float,
+    mu_hi: float,
+    var_hi: float,
+) -> float | None:
+    """Score between the two means where the weighted component densities cross.
+
+    Solves ``w_lo * N(x; mu_lo, var_lo) == w_hi * N(x; mu_hi, var_hi)``.  Taking
+    logs makes the difference a quadratic ``f(x) = a x^2 + b x + c`` (``f > 0``
+    means the Bad component owns that score), so the crossing is a root of that
+    quadratic - the Bayes decision boundary between the two fitted components.
+
+    This is the cut the midpoint-between-means rule only approximates, and the
+    two agree **exactly** when the components are equal-weight and equal-variance.
+    They diverge precisely where region voting lives: a media's score is the max
+    over ~24 region nodes, so the Bad mode is an extreme-value statistic - wider,
+    right-skewed, and far heavier than the Good mode.  A wider/heavier low
+    component pushes the crossing *above* the midpoint (with equal variances the
+    offset is ``var * ln(w_lo/w_hi) / (mu_hi - mu_lo)``), so the midpoint sits
+    inside Bad mass and over-includes.
+
+    Returns ``None`` - meaning "the caller should fall back to the midpoint" -
+    whenever the crossing is not a well-defined boundary: non-positive weights or
+    variances, non-ordered/degenerate means, a complex-root fit, no root strictly
+    between the means (near-equal variances with an extreme weight ratio push the
+    linear root outside the interval), or a fit in which the Bad component still
+    out-densities the Good one at the Good mean.  When two roots land inside the
+    interval the larger one is taken: above it the Good component dominates all
+    the way to its own mean, which is the boundary a threshold wants.
+    """
+    if not (w_lo > 0.0 and w_hi > 0.0 and var_lo > 0.0 and var_hi > 0.0):
+        return None
+    if not (mu_hi > mu_lo):
+        return None
+
+    # Solve in ``u = x - mu_lo`` so the interval is ``(0, d)``.  Shifting keeps
+    # the roots exact while dropping the ``mu^2 / var`` terms that would dominate
+    # the coefficients (and their cancellation) for score scales far from zero.
+    d = mu_hi - mu_lo
+    offset = math.log(w_lo / w_hi) + 0.5 * math.log(var_hi / var_lo)
+    a = 0.5 / var_hi - 0.5 / var_lo
+    b = -d / var_hi
+    c = 0.5 * d * d / var_hi + offset
+
+    # The Good mode must actually be Good-dominated, else "the score above which
+    # Good wins" is not something this fit expresses.  Evaluated in closed form
+    # rather than as ``a d^2 + b d + c`` (the same value, without the cancellation).
+    if offset - 0.5 * d * d / var_lo >= 0.0:
+        return None
+
+    inside = [u for u in _quadratic_roots(a, b, c) if math.isfinite(u) and 0.0 < u < d]
+    if not inside:
+        return None
+    return mu_lo + max(inside)
+
+
+@dataclass(frozen=True)
+class GmmFit1D:
+    """The two components of a fitted 1-D, 2-component GMM, ordered by mean.
+
+    Carries exactly the parameters the two candidate cut rules need, so one EM
+    fit can be re-cut under both rules (the safe-threshold measurement study,
+    issue #2799) instead of re-fitting per rule.  ``lo`` is the Bad (low-mean)
+    component, ``hi`` the Good one.
+    """
+
+    w_lo: float
+    mu_lo: float
+    var_lo: float
+    w_hi: float
+    mu_hi: float
+    var_hi: float
+
+    def midpoint(self) -> float:
+        """The historical cut: the midpoint between the two component means."""
+        return (self.mu_lo + self.mu_hi) / 2.0
+
+    def crossing_or_midpoint(self) -> float:
+        """The production cut: equal-density crossing, midpoint when none exists."""
+        crossing = _weighted_gaussian_crossing(self.w_lo, self.mu_lo, self.var_lo, self.w_hi, self.mu_hi, self.var_hi)
+        return self.midpoint() if crossing is None else crossing
+
+
+def gmm_fit_array(scores: "list[float] | np.ndarray") -> np.ndarray:
+    """The (possibly subsampled) float64 array a score-GMM is fitted on.
+
+    Above :data:`_GMM_MAX_SAMPLES` scores, takes a deterministic (seed-42)
+    random subsample; below, returns the scores unchanged.  Exposed separately
+    from :func:`fit_score_gmm` so a caller that needs the fit's *input* too
+    (e.g. for the median fallback, or to transform the same sample into logit
+    space) subsamples exactly once.
+    """
+    arr = np.asarray(scores, dtype=np.float64)
+    if arr.shape[0] > _GMM_MAX_SAMPLES:
+        rng = np.random.default_rng(42)
+        arr = rng.choice(arr, size=_GMM_MAX_SAMPLES, replace=False)
+    return arr
+
+
+def fit_score_gmm(arr: np.ndarray) -> GmmFit1D | None:
+    """Fit a deterministic 2-component GMM to a 1-D score array.
+
+    Returns ``None`` when the fit fails (fewer than 2 scores, or an EM
+    failure), leaving the fallback policy to the caller -
+    :func:`calculate_gmm_threshold` falls back to the median.
+    """
+    if arr.shape[0] < 2:
+        return None
+
+    from sklearn.mixture import GaussianMixture  # noqa: PLC0415
+
+    try:
+        gmm: GaussianMixture = GaussianMixture(n_components=2, random_state=42)
+        gmm.fit(arr.reshape(-1, 1))
+
+        # The stubs type these ``np.ndarray | None``; all are set after ``fit``.
+        assert gmm.means_ is not None
+        assert gmm.covariances_ is not None
+        assert gmm.weights_ is not None
+        means = np.ravel(gmm.means_)
+        # ``covariances_`` is (n_components, 1, 1) under the default "full"
+        # covariance type; ravel gives the two scalar variances.
+        variances = np.ravel(gmm.covariances_)
+        weights = np.ravel(gmm.weights_)
+
+        low_idx = 0 if means[0] < means[1] else 1
+        high_idx = 1 - low_idx
+        return GmmFit1D(
+            w_lo=float(weights[low_idx]),
+            mu_lo=float(means[low_idx]),
+            var_lo=float(variances[low_idx]),
+            w_hi=float(weights[high_idx]),
+            mu_hi=float(means[high_idx]),
+            var_hi=float(variances[high_idx]),
+        )
+    except Exception:
+        return None
+
+
 def calculate_gmm_threshold(scores: list[float]) -> float:
     """Use a Gaussian Mixture Model to find a threshold between two score distributions.
 
     Fits a 2-component GMM to the provided scores, assuming a bimodal distribution
-    representing Bad (low) and Good (high) classes. Returns the midpoint between the
-    two component means as the decision threshold.
+    representing Bad (low) and Good (high) classes.  Returns the **equal-density
+    crossing** of the two fitted components (see :func:`_weighted_gaussian_crossing`)
+    - the score at which a media stops being better explained by the Bad component
+    than by the Good one - falling back to the midpoint between the component means
+    when no crossing exists strictly between them.
+
+    The crossing and the midpoint coincide for equal-weight, equal-variance
+    components; they separate when the low component is wider or heavier, which is
+    the standing shape of a region-voted score distribution (every media's score is
+    a max over ~24 region nodes, so even a thoroughly Bad image gets ~24 draws at a
+    false positive).  Cutting at the midpoint there lands inside Bad mass and
+    over-includes.
 
     For score sets larger than :data:`_GMM_MAX_SAMPLES`, fits on a deterministic
     (seed-42) random subsample - the two-Gaussian fit is unchanged in practice
@@ -61,39 +236,13 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
     if len(scores) < 2:
         return 0.5
 
-    from sklearn.mixture import GaussianMixture  # noqa: PLC0415
-
-    arr = np.asarray(scores, dtype=np.float64)
-    if arr.shape[0] > _GMM_MAX_SAMPLES:
-        rng = np.random.default_rng(42)
-        arr = rng.choice(arr, size=_GMM_MAX_SAMPLES, replace=False)
-
-    # Reshape for sklearn
-    X = arr.reshape(-1, 1)
-
-    try:
-        # Fit a 2-component GMM
-        gmm: GaussianMixture = GaussianMixture(n_components=2, random_state=42)
-        gmm.fit(X)
-
-        # Get the means of the two components.  The stub types `means_`
-        # as `np.ndarray | None`; after `fit` it's always set.
-        assert gmm.means_ is not None
-        means = np.ravel(gmm.means_)
-
-        # Identify which component is "low" (Bad) and which is "high" (Good)
-        low_idx = 0 if means[0] < means[1] else 1
-        high_idx = 1 - low_idx
-
-        # Threshold is at the intersection of the two Gaussians
-        # For simplicity, use the midpoint between means
-        threshold = (means[low_idx] + means[high_idx]) / 2.0
-
-        return float(threshold)
-    except Exception:
+    arr = gmm_fit_array(scores)
+    fit = fit_score_gmm(arr)
+    if fit is None:
         # If GMM fails, return median (of the subsample when one was taken -
         # representative of the full distribution and keeps this path bounded).
         return float(np.median(arr))
+    return fit.crossing_or_midpoint()
 
 
 def _calibration_cache_key(


### PR DESCRIPTION
Follow-on to #2802 (merged). Two investigations.

## New crossing-GMM (#2801) ported to the region-voting path
Ported dev's equal-density-crossing `calculate_gmm_threshold` (cuts at the components' density crossing, engineered for the region-voted max-over-~24-nodes distribution) to `evaluation-framework`. Re-ran base vs defer6 (DINOv3/hac):
- **Clear win on cost level** — base regret 0.184→0.120, cost_auc 0.446→0.356, final_cost 0.294→0.248, runaways 35→29%.
- **Largely subsumes defer** here: new-GMM base already beats old-GMM defer6 on regret/cost_auc/final_cost.
- **Neither cuts the spike *rate*** (~0.18) — the win is in the cost level, not jumpiness. Best combo = new-GMM + defer6 (runaways 15%, lowest cost_sd/final_cost).
- 265 GMM/safe-threshold/region-curve tests pass.

## Embedding-space signature of the spiking vectors
`spike_vectors.py` (no eval framework — cached SigLIP 2 embeddings). For each class, each spiker's percentile among all bads on geometric features, mean over 71 classes:
- **`margin` (cos_G − cos_B) = 0.69** — the signature: a spiker is a negative pulled toward the good cluster and away from the bad cluster (cos_G 0.62, cos_B 0.44), sitting near the model's decision cut.
- **`b_outlier` = 0.53** — *not* an outlier; not a weird isolated point.
- Real but moderate and class-dependent (strong: oven/sink/zebra/elephant; weak: umbrella/vase/surfboard). Explains "nothing obvious in the pixels" — it's a soft embedding position, not a visual feature.

Tools: `spike_vectors.py`; the crossing-GMM machinery (`_weighted_gaussian_crossing`, `GmmFit1D`, `fit_score_gmm`) in `vtscore/training/thresholds.py`. Findings in `docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md`.

Refs #2790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)