### PR TITLE
Threshold-stability #2790: SigLIP-1 replication + predictive test of spike-vector signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,7 @@ model_cache/*
 # Spike / experiment scratch (codebook fits, ROxford caches, logs)
 scratch/
 
-docs/experiments/*
+# Generated sweep output (results.jsonl, viz PNGs, npz caches) — but keep hand-written *.md writeups
+docs/experiments/**
+!docs/experiments/**/
+!docs/experiments/**/*.md

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -290,3 +290,74 @@ position only weakly tilts. **The app simulation is irreplaceable for identifyin
 hard negatives actually spike.** Tool: `spike_vectors.py --embedder siglip`; artifacts
 `/exp/sgreenberg/threshold-stability/broad_sig1/spike_vectors_sig1.json`,
 `broad/spike_vectors_sig2_v2.json`.
+
+## When does a Bad vote spike? (per-EVENT, #2790)
+
+If the vector position only weakly tilts the odds, *what* sets them? The unit that
+answers this is the **vote event**, not the item: `spike_events.py` rebuilds every
+Bad-vote event from the traces (~77k per embedder) with the **state at vote time**
+(`n_good`, `n_bad`, `t`, `surface_margin` = item score − cut, `select_mode`, `head`,
+`calib_mode`) plus context geometry vs the labeled-so-far sets, and whether it spiked
+(Δcost > 0.1). No re-run — it's all in the `--labeling-trace` output.
+
+**First, the mechanism (two distinct phenomena, don't conflate them).** The trace's
+`head`/`calib_mode` fields show the loop runs a **cosine cold-start** (no MLP) through the
+all-Goods phase: cost is *frozen* (flat across every `n_bad`=0 step in 1519/1580 traces).
+The **first Bad vote is where the MLP switches on** — `head` flips `cosine → mlp` in all
+1580 traces the instant both classes exist (3 goods + 1 bad). So the big cost jump at the
+first bad is a **one-time cosine→MLP handoff**, not a retrain destabilizing: the frozen
+cold-start cost is replaced by the first MLP's calibrated cost (worse 79% of the time,
+median Δ +0.14). 931/1580 of these cross the Δcost>0.1 bar, which is what inflated an
+earlier "first bad = 59–71%" reading — real, but a model *switch*, not the recurring
+instability. The `margin`≥0.5 "confident FP ⇒ 62–77%" pattern lives almost entirely here
+too (only the cold-start cut ever surfaces items that far above it).
+
+**Recurring MLP-retrain spikes** are the phenomenon of interest: every Bad vote once the
+MLP is already on (`n_bad`≥1). 4947 (S1) / 5122 (S2) of them. Both embedders agree to
+within a few points on every cut (S1 = SigLIP 1, S2 = SigLIP 2):
+
+| condition (recurring, `n_bad`≥1) | spike rate S1 / S2 |
+|---|---|
+| **base** (recurring Bad vote) | 6.6% / 6.8% |
+| item **below** cut (`margin`<0) | **0.6% / 0.6%** |
+| item **at/above** cut (`margin`≥0) | 15.3% / 15.7% |
+| &nbsp;&nbsp;└ `margin` just above, [0, 0.1) | 15.5% / 15.9% |
+| &nbsp;&nbsp;└ `margin` just below, [−0.1, 0) | 0.3% / 0.3% |
+| sparse pos `n_good`≤3 → ≥15 | 10→2% / 10→2% |
+| `margin`≥0 ∧ `n_good`≤4 (best profile) | 16.3% / 17.1% |
+
+**The necessary condition is "the item is a live false-positive," not "hard-ish Bad far
+from other bads."** A recurring spike essentially requires the voted item to currently
+score **at/above the cut** (`margin`≥0) — the crossing at `margin`=0 is nearly a hard
+boundary (0.3% just below vs 15.5% just above). Voting Bad on something the MLP already
+scores as bad can't move the operating point. `margin≥0` is the (near-)necessary gate.
+
+**Amplifier:** **sparse positives** — `n_good`≤3 ⇒ ~10%, decaying monotonically to ~2%
+by `n_good`≥15 (fewer positives pin the cut, so one boundary Bad shoves it further). The
+logistic ranks `surface_margin` (+0.77) then `n_good` (−0.28/−0.35) on both; all else minor.
+
+**"Far from other bads" is NOT a driver.** Distance to the labeled-bad set (`nb_cos_max`)
+and the context good↔bad margin are flat-to-slightly-*rising* in spike rate on both
+embedders. The intuition was really tracking the *count* — few bads yet — not geometric
+distance. (Consistent with the vector study: spikers aren't outliers.)
+
+**Not sufficient.** Even the best profile (`margin`≥0 ∧ `n_good`≤4) spikes only ~1 in 6.
+The residual is the exact cut arithmetic on that retrain — whether this one Bad tips the
+operating point across a real match — which isn't a function of the vote's own features.
+
+**Why the same item spikes only sometimes (when a spiker does NOT spike).** 100/114 (S1)
+and 104/126 (S2) robust spikers **also** have no-spike occurrences — the same item does
+both. Holding the item fixed, the spike occurrences differ from the no-spike ones by
+**trajectory timing, not geometry**: Δ`t` −2.1/−1.4, Δ`n_bad` −1.6/−1.0, Δ`n_good`
+−0.5/−0.4, Δ`surface_margin` +0.03/+0.02; every geometry delta ≈ 0. So a spiker spikes
+when caught **early — few positives, while it still scores above the cut**; the *same*
+item voted later, after the negative set has grown and its score has fallen below the
+stabilized cut, lands in the 0.6% floor and does nothing. Spiking is a property of *when*
+the item is met, not of the item.
+
+Tool: `spike_events.py`, `inspect_mech.py`; artifacts `broad_sig1/spike_events_sig1.json`,
+`broad/spike_events_sig2.json`. Two guards fall out: (1) the cosine→MLP handoff cost step
+is one-time and could be smoothed (warm-start the MLP cut toward the cold-start operating
+point); (2) recurring spikes need a live FP at the cut with sparse positives — most are
+narrow/self-correcting, but damping the cut move while `n_good` is small (the shipped
+crossing-GMM / `defer-cut-goods` levers) is the mitigation.

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -296,45 +296,57 @@ hard negatives actually spike.** Tool: `spike_vectors.py --embedder siglip`; art
 If the vector position only weakly tilts the odds, *what* sets them? The unit that
 answers this is the **vote event**, not the item: `spike_events.py` rebuilds every
 Bad-vote event from the traces (~77k per embedder) with the **state at vote time**
-(`n_good`, `n_bad`, `t`, `surface_margin` = item score − cut, `select_mode`, `head`,
-`calib_mode`) plus context geometry vs the labeled-so-far sets, and whether it spiked
-(Δcost > 0.1). No re-run — it's all in the `--labeling-trace` output.
+(`n_good`, `n_bad`, `t`, `surface_margin` = item score − cut, `select_mode`, `head`)
+plus context geometry vs the labeled-so-far sets, and whether it spiked (Δcost > 0.1).
 
-**First, the mechanism (two distinct phenomena, don't conflate them).** The trace's
-`head`/`calib_mode` fields show the loop runs a **cosine cold-start** (no MLP) through the
-all-Goods phase: cost is *frozen* (flat across every `n_bad`=0 step in 1519/1580 traces).
-The **first Bad vote is where the MLP switches on** — `head` flips `cosine → mlp` in all
-1580 traces the instant both classes exist (3 goods + 1 bad). So the big cost jump at the
-first bad is a **one-time cosine→MLP handoff**, not a retrain destabilizing: the frozen
-cold-start cost is replaced by the first MLP's calibrated cost (worse 79% of the time,
-median Δ +0.14). 931/1580 of these cross the Δcost>0.1 bar, which is what inflated an
-earlier "first bad = 59–71%" reading — real, but a model *switch*, not the recurring
-instability. The `margin`≥0.5 "confident FP ⇒ 62–77%" pattern lives almost entirely here
-too (only the cold-start cut ever surfaces items that far above it).
+### Harness-fidelity fix (this changed the mechanism story)
 
-**Recurring MLP-retrain spikes** are the phenomenon of interest: every Bad vote once the
-MLP is already on (`n_bad`≥1). 4947 (S1) / 5122 (S2) of them. Both embedders agree to
-within a few points on every cut (S1 = SigLIP 1, S2 = SigLIP 2):
+The app's autopilot (cold-start, `retrainMode=false`) surfaces the **good and bad phases
+with text/example (cosine) sort** and only switches to the learned **MLP at the `hard`
+phase** — once `n_good ≥ good_to_start` (3) **and** `n_bad ≥ bad_to_start` (4)
+(`label-view.component.ts` phase dispatch / `AutopilotPhaseMachine.next_phase`). The
+realistic harness (`_resolve_step_head`) instead switched to the MLP the instant *both*
+classes existed (the **first bad**, `n_bad`=1), so it was scoring *and selecting* with a
+1–3-bad MLP the app would never use. Fixed: gate MLP training on
+`mlp_eligible = n_good ≥ good_to_start ∧ n_bad ≥ bad_to_start`, holding the cosine
+cold-start head through the whole good+bad phase. Verified end-to-end (`head` stays
+`cosine` at `n_bad` 0→3, flips to `mlp` at `n_bad`=4) and 42 region_curve tests pass.
+**All numbers below are the post-fix re-run** (`broad_sig1_v2`, `broad_v2`); the pre-fix
+`n_bad<4` "spikes" were harness artifacts and are now exactly **0.000**.
 
-| condition (recurring, `n_bad`≥1) | spike rate S1 / S2 |
+### The three regimes
+
+1. **Cosine phase (`n_bad` 0–3, good+bad phases):** no MLP; cost is *frozen* (flat across
+   every `n_bad`=0 step in 1519/1580 traces). Spike rate at `n_bad` 0 and 1 is **0.000** —
+   the old "first bad = 59–71%" was entirely the too-early MLP switch.
+2. **Hard-phase handoff (`n_bad` 3→4):** the app fires learned sort entering the `hard`
+   phase, replacing the frozen cosine cost with the first MLP's calibrated cost. This
+   crosses the Δcost>0.1 bar **~41% (S1) / 53% (S2)** of the time — a real, app-faced,
+   *one-time* model switch (smaller than the old bogus 1-bad handoff because the MLP now
+   has 4 bads). Not a retrain instability.
+3. **Recurring MLP-retrain spikes (`n_bad` ≥ 4):** the phenomenon of interest. Both
+   embedders agree to within a few points (S1 = SigLIP 1, S2 = SigLIP 2):
+
+| condition | spike rate S1 / S2 |
 |---|---|
-| **base** (recurring Bad vote) | 6.6% / 6.8% |
-| item **below** cut (`margin`<0) | **0.6% / 0.6%** |
-| item **at/above** cut (`margin`≥0) | 15.3% / 15.7% |
-| &nbsp;&nbsp;└ `margin` just above, [0, 0.1) | 15.5% / 15.9% |
-| &nbsp;&nbsp;└ `margin` just below, [−0.1, 0) | 0.3% / 0.3% |
-| sparse pos `n_good`≤3 → ≥15 | 10→2% / 10→2% |
-| `margin`≥0 ∧ `n_good`≤4 (best profile) | 16.3% / 17.1% |
+| **base** (all Bad votes) | 6.7% / 7.5% |
+| `n_bad` 0 / 1 (cosine phase) | **0.000 / 0.000** |
+| item **below** cut (`margin`<0) | **0.7% / 0.9%** |
+| item **at/above** cut (`margin`≥0) | 15.5% / 17.3% |
+| &nbsp;&nbsp;└ just above [0, 0.1) | 15.9% / 17.7% |
+| &nbsp;&nbsp;└ just below [−0.1, 0) | 0.5% / 0.7% |
+| sparse pos `n_good` 3 → ≥15 | 8→2% / 10→3% |
+| `margin`≥0 ∧ `n_good`≤4 (best profile) | 16.7% / — |
 
 **The necessary condition is "the item is a live false-positive," not "hard-ish Bad far
 from other bads."** A recurring spike essentially requires the voted item to currently
 score **at/above the cut** (`margin`≥0) — the crossing at `margin`=0 is nearly a hard
-boundary (0.3% just below vs 15.5% just above). Voting Bad on something the MLP already
+boundary (0.5% just below vs 15.9% just above). Voting Bad on something the MLP already
 scores as bad can't move the operating point. `margin≥0` is the (near-)necessary gate.
 
-**Amplifier:** **sparse positives** — `n_good`≤3 ⇒ ~10%, decaying monotonically to ~2%
-by `n_good`≥15 (fewer positives pin the cut, so one boundary Bad shoves it further). The
-logistic ranks `surface_margin` (+0.77) then `n_good` (−0.28/−0.35) on both; all else minor.
+**Amplifier:** **sparse positives** — `n_good`=3 ⇒ ~8–10%, decaying monotonically to ~2%
+by `n_good`≥15. The logistic ranks `surface_margin` (+0.64) then `n_good` (−0.28) on both;
+all else minor.
 
 **"Far from other bads" is NOT a driver.** Distance to the labeled-bad set (`nb_cos_max`)
 and the context good↔bad margin are flat-to-slightly-*rising* in spike rate on both
@@ -345,19 +357,19 @@ distance. (Consistent with the vector study: spikers aren't outliers.)
 The residual is the exact cut arithmetic on that retrain — whether this one Bad tips the
 operating point across a real match — which isn't a function of the vote's own features.
 
-**Why the same item spikes only sometimes (when a spiker does NOT spike).** 100/114 (S1)
-and 104/126 (S2) robust spikers **also** have no-spike occurrences — the same item does
-both. Holding the item fixed, the spike occurrences differ from the no-spike ones by
-**trajectory timing, not geometry**: Δ`t` −2.1/−1.4, Δ`n_bad` −1.6/−1.0, Δ`n_good`
-−0.5/−0.4, Δ`surface_margin` +0.03/+0.02; every geometry delta ≈ 0. So a spiker spikes
-when caught **early — few positives, while it still scores above the cut**; the *same*
-item voted later, after the negative set has grown and its score has fallen below the
-stabilized cut, lands in the 0.6% floor and does nothing. Spiking is a property of *when*
+**Why the same item spikes only sometimes (when a spiker does NOT spike).** 78/95 (S1)
+robust spikers **also** have no-spike occurrences — the same item does both. Holding the
+item fixed, the spike occurrences differ from the no-spike ones by **trajectory timing,
+not geometry**: Δ`t` −1.9, Δ`n_bad` −1.4, Δ`n_good` −0.5, Δ`surface_margin` +0.01; every
+geometry delta ≈ 0. So a spiker spikes when caught **early — few positives, while it still
+scores above the cut**; the *same* item voted later, after its score has fallen below the
+stabilized cut, lands in the 0.7% floor and does nothing. Spiking is a property of *when*
 the item is met, not of the item.
 
-Tool: `spike_events.py`, `inspect_mech.py`; artifacts `broad_sig1/spike_events_sig1.json`,
-`broad/spike_events_sig2.json`. Two guards fall out: (1) the cosine→MLP handoff cost step
-is one-time and could be smoothed (warm-start the MLP cut toward the cold-start operating
-point); (2) recurring spikes need a live FP at the cut with sparse positives — most are
-narrow/self-correcting, but damping the cut move while `n_good` is small (the shipped
-crossing-GMM / `defer-cut-goods` levers) is the mitigation.
+Tool: `spike_events.py`, `inspect_mech.py`; harness fix in `region_curve.py`
+(`_resolve_step_head`); artifacts `broad_sig1_v2/spike_events.json`,
+`broad_v2/spike_events.json`. Two guards fall out: (1) the hard-phase cosine→MLP handoff
+is one-time and app-faced — could be smoothed by warm-starting the first MLP cut toward
+the cold-start operating point; (2) recurring spikes need a live FP at the cut with sparse
+positives — damp the cut move while `n_good` is small (the shipped crossing-GMM /
+`defer-cut-goods` levers).

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -251,3 +251,42 @@ position in embedding space, not a distinct visual feature. The effect is real b
 moderate and **class-dependent** (strong: oven/sink/zebra/elephant, margin pct 0.9+;
 weak/reversed: umbrella/vase/surfboard). Consistent with "vaguely hard negatives."
 Tool: `spike_vectors.py`.
+
+### Does the signature hold on a second embedder, and is it *predictive*? (SigLIP 1)
+
+Re-ran the whole pipeline on **SigLIP 1** (fresh embed of all 4,952 val2017 whole
+vectors → 79-class × 20-seed labeling simulation → `spike_items` → `spike_vectors`).
+Two questions: does the *descriptive* signature replicate across embedders, and is it
+*predictive* (would picking the vector-hard negatives actually find the spikers, letting
+us skip the simulation)? Added **precision@N / lift** to `spike_vectors.py`: rank all
+bads by a feature, take the top-N (N = #spikers, base rate ~1%), count how many spike.
+
+| feature | pctile S1 / S2 | lift S1 / S2 |
+|---|---|---|
+| `margin` = cos_G − cos_B | 0.68 / 0.69 | **0.0× / 2.5×** |
+| `proj_w` (Fisher axis) | 0.68 / 0.69 | 0.0× / 2.5× |
+| `cos_G` (good centroid) | 0.65 / 0.61 | 5.4× / 2.2× |
+| `cos_B` | 0.46 / 0.44 | 1.8× / 0.0× |
+| `max_cos_G` | 0.61 / 0.59 | 1.5× / 3.3× |
+| `knn_good` | 0.56 / 0.56 | 0.0× / 2.6× |
+| `b_outlier` | 0.52 / 0.53 | 0.0× / 0.9× |
+
+**The descriptive signature is embedder-invariant.** Every percentile matches SigLIP 2
+to ±0.04 — margin 0.68 vs 0.69, knn_good 0.56 vs 0.56, b_outlier 0.52 vs 0.53. So even
+though the *specific* spiking items don't transfer across embedders (0 overlap, above),
+the geometric *type* does: a spiker is a good-leaning boundary negative, not an outlier,
+in **both** representations. The "vaguely hard negative" picture is real and general.
+
+**But the signature is descriptively real and predictively near-useless.** The
+mean-percentile (≈ each feature's AUC as a spike predictor) is a soft central tendency
+at ~0.68 — which carries almost no mass into the top-1% tail where the precision@N cut
+falls. So precision@N is tiny everywhere (best case `cos_G` on SigLIP 1: 5.4× lift but
+still only 5% precision), it's **near-zero for the margin signature itself** (0.0× on
+SigLIP 1), and *which* feature has any lift isn't even stable across embedders (margin
+0.0× vs 2.5×; cos_B 1.8× vs 0.0×). **You cannot pre-screen spikers from the embedding
+geometry** — the top vector-hard negatives are ~95%+ non-spikers. Spiking is set by the
+per-step training dynamics (which model, which prior labels), which the static vector
+position only weakly tilts. **The app simulation is irreplaceable for identifying which
+hard negatives actually spike.** Tool: `spike_vectors.py --embedder siglip`; artifacts
+`/exp/sgreenberg/threshold-stability/broad_sig1/spike_vectors_sig1.json`,
+`broad/spike_vectors_sig2_v2.json`.

--- a/scripts/experiments/threshold_stability/inspect_mech.py
+++ b/scripts/experiments/threshold_stability/inspect_mech.py
@@ -1,0 +1,81 @@
+"""What is the model actually doing at the first Bad vote vs later? (#2790 mechanism check)"""
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+root = Path(sys.argv[1])
+traces = sorted(root.rglob("trace.json"))
+
+# 1) example: full step table for a few traces
+print("===== EXAMPLE TRACES (t | phase | select | calib_mode | head | n_good | n_bad | threshold | cost | Δcost) =====")
+for tj in traces[:3]:
+    t = sorted(json.loads(tj.read_text()), key=lambda e: e["t"])
+    print(f"\n--- {tj.parent.parent.name} / {tj.parent.name} ---")
+    prev = None
+    for e in t[:10]:
+        dc = "" if prev is None else f"{e.get('cost', 0) - prev.get('cost', 0):+.3f}"
+        mark = "  <-- FIRST BAD" if (prev and prev.get("n_bad") == 0 and e.get("gt_label") == "bad") else ""
+        print(
+            f"  t{e.get('t'):>2} {str(e.get('phase')):<5} {str(e.get('select_mode')):<5} "
+            f"{str(e.get('calib_mode')):<16} {str(e.get('head')):<8} g{e.get('n_good')} b{e.get('n_bad')} "
+            f"thr={e.get('threshold')} cost={e.get('cost')} d={dc}{mark}"
+        )
+
+# 2) aggregate mechanism stats
+cost_flat_before_first_bad = 0
+n_traces_with_bad = 0
+first_bad_calib = Counter()
+first_bad_head = Counter()
+first_bad_costjump = []  # Δcost at the first bad
+head_by_nbad0 = Counter()  # head during all-good phase
+recurring_spike_calib = Counter()  # calib_mode at spikes that are NOT the first bad
+recurring_spike_head = Counter()
+n_first_bad_spikes = 0
+n_recurring_spikes = 0
+
+for tj in traces:
+    t = sorted(json.loads(tj.read_text()), key=lambda e: e["t"])
+    # cost during n_bad==0 steps
+    good_costs = [e.get("cost") for e in t if (e.get("n_bad") or 0) == 0 and e.get("cost") is not None]
+    if len(good_costs) >= 2 and max(good_costs) - min(good_costs) < 1e-6:
+        cost_flat_before_first_bad += 1
+    for e in t:
+        if (e.get("n_bad") or 0) == 0:
+            head_by_nbad0[str(e.get("head"))] += 1
+    for i in range(1, len(t)):
+        prev, cur = t[i - 1], t[i]
+        if cur.get("gt_label") != "bad":
+            continue
+        dcost = (cur.get("cost") or 0) - (prev.get("cost") or 0)
+        is_first_bad = (prev.get("n_bad") or 0) == 0
+        is_spike = dcost > 0.1
+        if is_first_bad:
+            n_traces_with_bad += 1
+            first_bad_calib[str(cur.get("calib_mode"))] += 1
+            first_bad_head[str(cur.get("head"))] += 1
+            first_bad_costjump.append(dcost)
+            if is_spike:
+                n_first_bad_spikes += 1
+        elif is_spike:
+            n_recurring_spikes += 1
+            recurring_spike_calib[str(cur.get("calib_mode"))] += 1
+            recurring_spike_head[str(cur.get("head"))] += 1
+
+print("\n\n===== MECHANISM AGGREGATE =====")
+print(f"traces: {len(traces)}")
+print(f"cost is FLAT across all n_bad==0 steps in: {cost_flat_before_first_bad}/{len(traces)} traces")
+print(f"head during all-good (n_bad==0) steps: {dict(head_by_nbad0.most_common())}")
+print(f"\nAt the FIRST bad vote (n={n_traces_with_bad}):")
+print(f"  calib_mode: {dict(first_bad_calib.most_common())}")
+print(f"  head:       {dict(first_bad_head.most_common())}")
+if first_bad_costjump:
+    js = sorted(first_bad_costjump)
+    print(
+        f"  Δcost at first bad: min={js[0]:+.3f} median={js[len(js) // 2]:+.3f} max={js[-1]:+.3f} "
+        f"mean={sum(js) / len(js):+.3f}; fraction Δcost>0 (cost got WORSE): {sum(1 for x in js if x > 0) / len(js):.2f}"
+    )
+print(f"\nSpikes (Δcost>0.1): first-bad={n_first_bad_spikes}, recurring(n_bad>=1)={n_recurring_spikes}")
+print(f"  recurring-spike calib_mode: {dict(recurring_spike_calib.most_common())}")
+print(f"  recurring-spike head:       {dict(recurring_spike_head.most_common())}")

--- a/scripts/experiments/threshold_stability/spike_events.py
+++ b/scripts/experiments/threshold_stability/spike_events.py
@@ -1,0 +1,266 @@
+"""Per-EVENT spike analysis (#2790): when does a Bad vote spike, and when does a spiker NOT?
+
+Earlier analysis treated spikers as *items*. But a spike is really a **(class, seed, step)
+VOTE EVENT**: the same item is voted Bad in many trajectories and spikes in only some of
+them. This tool rebuilds every Bad-vote event from the ``--labeling-trace`` ``trace.json``
+files and records the **state at vote time** — no re-run needed, it's all in the traces:
+
+* loop position: ``n_good``, ``n_bad``, ``t``, ``phase``, ``select_mode``;
+* the surfaced item's ``surface_score`` and ``surface_margin`` (score minus the cut);
+* **context geometry** against the *labeled-so-far* sets (what the model has actually
+  seen): nearest labeled bad (``nb_cos_max``), context good/bad centroids and margin.
+  The static "distance to all bads" said spikers aren't outliers; the *context* distance
+  to the handful of already-labeled bads is the quantity the intuition is really about.
+
+and whether the vote **spiked** (``Δcost > thresh``). Then three analyses:
+
+  A. conditional spike rates -> which conditions are *necessary* (spike rate ~0 when
+     violated) and how far short of *sufficient* they fall (max spike rate when all hold);
+  B. within-item -> for items that spike in >=K seeds, compare the occurrences where the
+     SAME item spiked vs didn't (holds the item fixed, isolates the context);
+  C. logistic fit on standardized features -> coefficients ranking the drivers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sod"))  # noqa: E402
+from spike_analysis import _class_seed, _f  # type: ignore  # noqa: E402
+
+
+def _load_vec(regions: Path, iid) -> np.ndarray | None:
+    p = regions / f"{iid}.npz"
+    if not p.exists():
+        return None
+    with np.load(p) as z:
+        if "whole_vec" not in z:
+            return None
+        v = np.asarray(z["whole_vec"], dtype=np.float64)
+    n = np.linalg.norm(v)
+    return v / (n + 1e-12) if n else v
+
+
+def build_events(root: Path, regions: Path, thresh: float) -> list[dict]:
+    """One row per Bad-vote event across all traces, with state-at-vote-time + geometry."""
+    events: list[dict] = []
+    for tj in sorted(root.rglob("trace.json")):
+        cls, seed = _class_seed(tj)
+        trace = sorted(json.loads(tj.read_text()), key=lambda e: e["t"])
+        # cache vectors for the (<=60) voted ids in this trace
+        vcache: dict = {}
+        for e in trace:
+            iid = e.get("image_id")
+            if iid is not None and iid not in vcache:
+                vcache[iid] = _load_vec(regions, iid)
+        good_ids: list = []  # labeled BEFORE the current step (running)
+        bad_ids: list = []
+        for i, cur in enumerate(trace):
+            label = cur.get("gt_label")
+            iid = cur.get("image_id")
+            if i >= 1 and label == "bad":
+                prev = trace[i - 1]
+                dcost = _f(cur.get("cost")) - _f(prev.get("cost"))
+                v = vcache.get(iid)
+                # context geometry vs the sets labeled BEFORE this vote
+                gv = [vcache[g] for g in good_ids if vcache.get(g) is not None]
+                bv = [vcache[b] for b in bad_ids if vcache.get(b) is not None]
+                nb_cos_max = nb_cos_mean = ng_cos_max = ctx_cos_G = ctx_cos_B = ctx_margin = float("nan")
+                if v is not None:
+                    if bv:
+                        bsim = np.array([float(v @ b) for b in bv])
+                        nb_cos_max, nb_cos_mean = float(bsim.max()), float(bsim.mean())
+                        bc = np.mean(bv, axis=0)
+                        ctx_cos_B = float(v @ (bc / (np.linalg.norm(bc) + 1e-12)))
+                    if gv:
+                        gsim = np.array([float(v @ g) for g in gv])
+                        ng_cos_max = float(gsim.max())
+                        gc = np.mean(gv, axis=0)
+                        ctx_cos_G = float(v @ (gc / (np.linalg.norm(gc) + 1e-12)))
+                    if gv and bv:
+                        ctx_margin = ctx_cos_G - ctx_cos_B
+                events.append(
+                    {
+                        "cls": cls,
+                        "seed": seed,
+                        "t": cur.get("t"),
+                        "image_id": iid,
+                        "is_spike": int(dcost > thresh),
+                        "dcost": round(dcost, 4),
+                        "d_fnr": round(_f(cur.get("fnr")) - _f(prev.get("fnr")), 4),
+                        "d_fpr": round(_f(cur.get("fpr")) - _f(prev.get("fpr")), 4),
+                        "n_good": prev.get("n_good"),
+                        "n_bad": prev.get("n_bad"),
+                        "phase": cur.get("phase"),
+                        "select_mode": cur.get("select_mode"),
+                        "calib_mode": cur.get("calib_mode"),
+                        "surface_score": _f(cur.get("surface_score")),
+                        "surface_margin": _f(cur.get("surface_margin")),
+                        "nb_cos_max": nb_cos_max,
+                        "nb_cos_mean": nb_cos_mean,
+                        "ng_cos_max": ng_cos_max,
+                        "ctx_cos_G": ctx_cos_G,
+                        "ctx_cos_B": ctx_cos_B,
+                        "ctx_margin": ctx_margin,
+                    }
+                )
+            # advance the labeled sets to include this vote
+            if label == "good":
+                good_ids.append(iid)
+            elif label == "bad":
+                bad_ids.append(iid)
+    return events
+
+
+def _rate(rows: list[dict], cond) -> tuple[int, int, float]:
+    sub = [r for r in rows if cond(r)]
+    k = sum(r["is_spike"] for r in sub)
+    return k, len(sub), (k / len(sub) if sub else float("nan"))
+
+
+def _bin_table(rows: list[dict], key: str, edges: list[float]) -> str:
+    lines = [f"  spike rate by {key}:"]
+    labels = [f"<{edges[0]}"] + [f"[{edges[j]},{edges[j + 1]})" for j in range(len(edges) - 1)] + [f">={edges[-1]}"]
+    bins: list = [[] for _ in labels]
+    for r in rows:
+        x = r.get(key)
+        if x is None or (isinstance(x, float) and np.isnan(x)):
+            continue
+        b = 0
+        while b < len(edges) and x >= edges[b]:
+            b += 1
+        bins[b].append(r)
+    for lab, b in zip(labels, bins):
+        if b:
+            k = sum(rr["is_spike"] for rr in b)
+            lines.append(f"    {lab:<12} {k:>4}/{len(b):<5} = {k / len(b):.3f}")
+    return "\n".join(lines)
+
+
+def within_item(events: list[dict], min_seeds: int) -> tuple[list[dict], str]:
+    """For items that spike in >=min_seeds seeds, compare spike vs no-spike occurrences."""
+    by_item: dict = defaultdict(list)
+    for e in events:
+        by_item[(e["cls"], e["image_id"])].append(e)
+    feats = ["n_good", "n_bad", "t", "surface_margin", "nb_cos_max", "ng_cos_max", "ctx_margin", "ctx_cos_B"]
+    diffs: dict = defaultdict(list)
+    kept = 0
+    ambivalent = 0  # items that both spike AND don't-spike across their occurrences
+    for _, occ in by_item.items():
+        n_sp = sum(o["is_spike"] for o in occ)
+        if n_sp < min_seeds:
+            continue
+        kept += 1
+        sp = [o for o in occ if o["is_spike"]]
+        no = [o for o in occ if not o["is_spike"]]
+        if sp and no:
+            ambivalent += 1
+            for f in feats:
+                a = [o[f] for o in sp if o[f] is not None and not (isinstance(o[f], float) and np.isnan(o[f]))]
+                b = [o[f] for o in no if o[f] is not None and not (isinstance(o[f], float) and np.isnan(o[f]))]
+                if a and b:
+                    diffs[f].append(statistics.fmean(a) - statistics.fmean(b))
+    lines = [
+        f"  robust spiker items (>={min_seeds} spike-seeds): {kept}; of those, "
+        f"{ambivalent} ALSO have no-spike occurrences (same item, both outcomes).",
+        "  mean(spike) - mean(no-spike) within the same item, averaged over ambivalent items:",
+    ]
+    for f in feats:
+        if diffs[f]:
+            lines.append(f"    Δ{f:<15} {statistics.fmean(diffs[f]):+.4f}   (n_items={len(diffs[f])})")
+    return [], "\n".join(lines)
+
+
+def logistic(events: list[dict]) -> str:
+    try:
+        from sklearn.linear_model import LogisticRegression  # noqa: PLC0415
+        from sklearn.preprocessing import StandardScaler  # noqa: PLC0415
+    except ImportError:
+        return "  (sklearn unavailable — skipping logistic fit)"
+    feats = ["n_good", "n_bad", "t", "surface_score", "surface_margin", "nb_cos_max", "ng_cos_max", "ctx_margin"]
+    X, y = [], []
+    for e in events:
+        row = [e.get(f) for f in feats]
+        vals = [float(v) if v is not None else np.nan for v in row]
+        # impute "no labeled bad yet" (nb_cos_max NaN) as -1 (maximally far) + flag
+        no_bad = 1.0 if np.isnan(vals[feats.index("nb_cos_max")]) else 0.0
+        vals = [(-1.0 if (i == feats.index("nb_cos_max") and np.isnan(v)) else v) for i, v in enumerate(vals)]
+        if any(np.isnan(v) for v in vals):
+            continue
+        X.append(vals + [no_bad])
+        y.append(e["is_spike"])
+    if len(set(y)) < 2:
+        return "  (only one class present — skipping logistic fit)"
+    names = feats + ["no_prior_bad"]
+    Xs = StandardScaler().fit_transform(np.array(X))
+    clf = LogisticRegression(max_iter=1000, class_weight="balanced").fit(Xs, y)
+    coefs = sorted(zip(names, clf.coef_[0]), key=lambda kv: -abs(kv[1]))
+    lines = [f"  logistic (standardized, class-balanced) on n={len(y)} events, {sum(y)} spikes:",
+             "  coef>0 => raises spike odds:"]  # fmt: skip
+    for nm, c in coefs:
+        lines.append(f"    {nm:<15} {c:+.3f}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Per-event spike analysis (#2790).")
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--cache", required=True, help="cache dir (for regions/<ds>/<embedder>/whole)")
+    ap.add_argument("--dataset", default="coco")
+    ap.add_argument("--embedder", default="siglip")
+    ap.add_argument("--thresh", type=float, default=0.1)
+    ap.add_argument("--min-seeds", type=int, default=3)
+    ap.add_argument("--out", default=None, help="write events as JSON")
+    args = ap.parse_args(argv)
+
+    regions = Path(args.cache) / "regions" / args.dataset / args.embedder / "whole"
+    events = build_events(Path(args.root), regions, args.thresh)
+    if args.out:
+        Path(args.out).write_text(json.dumps(events))
+
+    n = len(events)
+    n_sp = sum(e["is_spike"] for e in events)
+    print(f"Bad-vote events: {n}   spikes: {n_sp}   base spike rate: {n_sp / n:.3f}\n")
+
+    print("== A. Conditional spike rates ==")
+    print(_bin_table(events, "n_good", [3, 4, 6, 9, 15]))
+    print(_bin_table(events, "n_bad", [1, 2, 4, 8]))
+    print(_bin_table(events, "surface_margin", [-0.5, -0.1, 0.0, 0.1, 0.5]))
+    print(_bin_table(events, "nb_cos_max", [0.2, 0.4, 0.5, 0.6, 0.7]))
+    print(_bin_table(events, "ctx_margin", [-0.1, 0.0, 0.1, 0.2]))
+    for name, cond in [
+        ("select_mode == hard", lambda r: r["select_mode"] == "hard"),
+        ("select_mode != hard", lambda r: r["select_mode"] != "hard"),
+        ("surface_margin >= 0 (item AT/ABOVE cut)", lambda r: _f(r["surface_margin"]) >= 0),
+        ("surface_margin < 0 (item below cut)", lambda r: _f(r["surface_margin"]) < 0),
+        ("first bad (n_bad==0)", lambda r: (r["n_bad"] or 0) == 0),
+        ("first bad AND margin>=0", lambda r: (r["n_bad"] or 0) == 0 and _f(r["surface_margin"]) >= 0),
+        ("sparse pos (n_good<=4)", lambda r: (r["n_good"] or 0) <= 4),
+        ("margin>=0 AND n_good<=4", lambda r: _f(r["surface_margin"]) >= 0 and (r["n_good"] or 0) <= 4),
+        (
+            "margin>=0 AND n_good<=4 AND hard",
+            lambda r: _f(r["surface_margin"]) >= 0 and (r["n_good"] or 0) <= 4 and r["select_mode"] == "hard",
+        ),  # noqa: E501
+        ("margin<0 AND NOT first-bad (safe?)", lambda r: _f(r["surface_margin"]) < 0 and (r["n_bad"] or 0) > 0),
+    ]:
+        k, tot, rate = _rate(events, cond)
+        print(f"  {name:<38} {k:>4}/{tot:<6} = {rate:.3f}")
+
+    print("\n== B. Within-item: when does the SAME item spike vs not ==")
+    _, wtxt = within_item(events, args.min_seeds)
+    print(wtxt)
+
+    print("\n== C. Logistic drivers ==")
+    print(logistic(events))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -801,17 +801,27 @@ def _resolve_step_head(
     calibrate_count,
     cal_fraction,
     threshold_rule="conformal",
+    good_to_start=3,
+    bad_to_start=4,
 ):
     """Return ``(cached, steps_since_train)`` for one step.
 
     ``cached`` is ``(predict, raw_thr, n_votes, calib, blend)``. Trains a fresh
-    head when both classes exist and a retrain is due (no model yet, cadence
-    elapsed, or the current model is a cold-start); otherwise reuses the cache, or
-    falls back to the cosine cold-start while only one class is labeled.
+    MLP head only once the autopilot would actually *use* one — the app surfaces
+    the initial good/bad phases with text/example (cosine) sort and switches to the
+    learned MLP only at the ``hard`` phase, i.e. once ``good >= good_to_start`` AND
+    ``bad >= bad_to_start`` (``label-view.component.ts`` phase dispatch /
+    :meth:`AutopilotPhaseMachine.next_phase`). Until then — including the whole
+    ``bad`` phase, where only 1..3 bads exist — we hold the cosine cold-start head
+    so we never score or *select* with an MLP the app wouldn't be using yet. Once
+    eligible, trains a fresh head when a retrain is due (no model yet, cadence
+    elapsed, or the current model is still a cold-start).
     """
     both = bool(good_ids) and bool(bad_ids)
+    # Mirror the app's text-sort → learned-sort handoff at the hard-phase boundary.
+    mlp_eligible = len(good_ids) >= good_to_start and len(bad_ids) >= bad_to_start
     due = cached is None or steps_since_train >= retrain_cadence or not cached[4]
-    if both and due:
+    if both and mlp_eligible and due:
         res = _train_pool_head(
             inputs,
             good_ids,
@@ -828,7 +838,7 @@ def _resolve_step_head(
         if res is not None:
             predict, raw_thr, n_votes, calib = res
             return (predict, raw_thr, n_votes, calib, True), 0
-    if cached is None or not both:
+    if cached is None or not both or not mlp_eligible:
         predict, thr0 = _cosine_coldstart(inputs, cold_query)
         return (predict, thr0, len(good_ids) + len(bad_ids), "cosine_coldstart", False), 0
     return cached, steps_since_train + 1
@@ -981,6 +991,8 @@ def _realistic_one_seed(
             calibrate_count=calibrate_count,
             cal_fraction=cal_fraction,
             threshold_rule=threshold_rule,
+            good_to_start=good_to_start,
+            bad_to_start=bad_to_start,
         )
         predict, raw_thr, n_votes, calib, blend = cached
 


### PR DESCRIPTION
Threshold-stability #2790: **understanding the hidden calibration catastrophe** (necessary+sufficient), plus the harness-fidelity fix and the metric correction.

## The mechanism (headline)
Instrumented the calibration (`_calib_diag`: `poolpos_recall` = *true* recall over all pool positives, which the sim knows but labeled data hides). **Two hypotheses refuted** — it's *not* a training-recall collapse (99.6% of *labeled* positives stay above the cut at spikes) and the trigger is *not* a vote scored high (a Bad above the prev top bad spikes 2.0% vs 12.4% below it).

**What it is:** acquisition surfaces *easy* (high-scoring) positives → the ~3 labeled positives are unrepresentatively high → the cut lives in the **gap** between labeled bads and those positives, where the *unlabeled* positives densely live. Each vote retrains the MLP; the cut is **under-determined** in that gap and wobbles every refit. A spike = the operating point wobbles **up** through the hidden positives → true recall collapses (Δpoolpos_recall −0.093 vs +0.004; Δthreshold +0.031) while **labeled recall stays ~1** — invisible to the labeled data, hence *hidden*.
- **Necessary:** sparse unrepresentatively-high labeled positives (under-determined cut) + a retrain wobble up (cut ~60% / scores ~40%, a 2nd mode) + unlabeled positives in the path.
- **Sufficient: none observable** — the hidden positives and the stochastic retrain wobble aren't visible from labels; best predictor is the symptom "cut moved up" (60% recall / 18% precision). The unobservability *is* the catastrophe.

Explains why the fixes work (reduce the cut's freedom: defer/GMM/recall-anchor) and why more positives barely moved FNR (mode-2 + ranking floor remain).

## Also in this PR
- **Harness fidelity fix**: the loop now uses cosine/text sort through good+bad phases, MLP only at the hard phase (matching the app); pre-hard-phase "spikes" were artifacts. 42 tests pass.
- **Metric correction**: evaluate on **FNR+FPR / recall@budget**, not F1 (which collapses to precision under 100× imbalance and under-weights recall); on that metric defer6 is a genuine recall win.
- **Negative results, recorded**: positive-seeking `soft` acquisition fails (GMM can't ID positives in a sparse pool, 5% yield); positive *count* barely moves FNR; per-event/vector analyses.

## Update: is it the cross-calibration folds? (~15-25%, not the driver)
Tested whether the Train/Calibrate fold structure explains the residual: the conformal cut is anchored to `min(calibration-positive)`, and the split reshuffles every step, so with ~3 positives (1-train/2-cal) which positive is held out jerks the cut. Two tests: **`--stable-folds`** (freeze the split) cut deep spikes only ~13%; **`calibrate_count` 2→16** cut them ~16-19%. So cross-calibration variance is a real but **secondary (~15-25%)** contributor. The **dominant (~75-85%)** driver is **MLP-retrain score variance** — freezing *which* positive is in Calibrate doesn't freeze its *score*, and the under-determined 3-positive model changes on every retrain. That's why no observable sufficient condition exists (the retrain is a complex fn of the whole label set) and why the cut-side fixes only blunt the consequence. (`--stable-folds` also improved the customer metric: FNR 0.32→0.26.)

Tools in `scripts/experiments/threshold_stability/`: `calib_conditions`, `deep_spikes`, `handoff_quality`, `soft_eval`, `spike_events`, `spike_vectors`, `inspect_mech`. Harness knobs: `--defer-cut-goods`, `--soft-seek`, `--recall-target`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



> **Correction (2026-08-02):** the cross-calibration figure above was refined by *direct* measurement — the deep-spike recall collapse decomposes as **56% MLP-retrain score variance / 44% cut movement** (800 traces / 3002 spikes), not the by-exclusion 75-85/15-25. The cut/calibration side is a substantial ~44% contributor (~13-19 pts of it removable via `--stable-folds` / `calibrate_count`; the rest tracks the under-determined MLP). See `SPARSE_POSITIVE_PLAN.md`.
