### PR TITLE
Threshold-stability #2790: understanding the deep-spike calibration catastrophe (mechanism + necessary/sufficient)

### DIFF
--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -328,6 +328,32 @@ work by *reducing the cut's freedom* (defer/GMM/recall-anchor pin it to the scor
 or the positives), and why more positives barely moved FNR (mode-2 + the ranking floor remain).
 Tools: `calib_conditions.py`, `_calib_diag`; artifacts `broad_v2_diag3/`.
 
+### The "unobservable" residual IS the cross-calibration fold reshuffle (2026-08-02)
+
+Owner's insight: the threshold is set by **cross-calibration** (split labels Train/Calibrate,
+sub-model on Train, cut on Calibrate, ×`calibrate_count` folds pooled) — so *which fold the
+labels land in* should matter, and might explain the "hidden" residual. Reading the code, it
+does — precisely:
+
+- The conformal cut at `inclusion=0` is the **gap midpoint between the top negatives and
+  `min(pos)` — the *lowest calibration positive*** (`conformal_threshold`). So the cut is
+  pinned by the single lowest positive that landed in the Calibrate fold.
+- The split is `rng.permutation` of the positive/negative index arrays with a **fixed run
+  seed** (`stratified_fold_orderings`). With `cal_fraction=0.5` and ~3 positives, that's a
+  **1-train / 2-cal** split. When a vote arrives the arrays grow, so the permutation
+  **reshuffles which positive is held out to Train every step** — jerking `min(cal-positive)`
+  and hence the cut. It's not random noise: it's a *deterministic, chaotic* function of the
+  fold assignment, invisible from the vote's own score (which is why my earlier "stochastic /
+  unobservable" framing was incomplete — it's observable in fold space, just not vote space).
+- This also predicts the old Stage-B result that **`calibrate_count`=k8 is the dominant
+  stability lever, not the rule**: more folds pool more Calibrate positives, so the pooled
+  `min(cal-positive)` stabilizes to the true lowest → the cut stops jumping.
+
+**Tests in flight (2026-08-02 ~01:45 EDT, siglip2):** (a) `calibrate_count` sweep {2,4,8,16}
+— predict deep-spike rate ↓ monotonically; (b) `--stable-folds` (freeze the split to append
+position, no per-step reshuffle) as the causal clincher — predict spikes largely vanish.
+[RESULTS PENDING — fill in.]
+
 ## The actual #2790 spikes: deep-run transient excursions (`deep_spikes.py`)
 
 The per-event work above characterizes *all* MLP-regime Bad votes; the #2790 complaint is

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -315,10 +315,50 @@ depth `t`, on the faithful v2 traces. Both embedders identical.
   cost_sd ≈ 4× oracle floor).
 - **Implication for mitigation:** staying in HardText longer (more *bads* before learned
   sort) does **not** help — `n_good` stays ~5 regardless of bad count. The lever is the
-  *positive* side: hold a distribution cut while positives are sparse (`--defer-cut-goods`,
-  already a Pareto win at K=6 — and since `n_good` stays low all run, it applies throughout,
-  exactly where the deep spikes live), the crossing-GMM cut, or acquire more positives
-  (diversify away from pure boundary sampling). Tool: `deep_spikes.py`.
+  *positive* side (see the mitigation experiments below). Tool: `deep_spikes.py`.
+
+## Mitigation experiments: it's the positives, and threshold tricks trade F1
+
+Tested the two candidate levers on the faithful harness (79 classes × 20 seeds); both land
+on one conclusion: **the bottleneck is positives, not the cut rule or the negatives.**
+
+**defer6 (crossing-GMM cut while sparse) crushes the deep cost-spikes ~8× — but trades
+F1.** Deep-spike rate t[20,30) 0.10 → 0.012 (both embedders); the distribution-based GMM
+cut doesn't lurch when one boundary Bad is added. BUT it does so by moving the operating
+point, not by being a better cut: SigLIP 2 @t60 FNR 0.32→0.18, FPR 0.02→0.09, **F1
+0.625→0.323**, weighted cost 0.343→0.268. The permissive GMM cut catches more positives
+but, under `neg_multiple`=100, the extra FPs wreck precision. So an earlier "defer6 is a
+Pareto win" (5-class, cost-only) is **wrong once F1 is included** — it suppresses transient
+cost-spikes by adopting a permanently worse-F1 cut. Cost and F1 only diverge for such
+threshold tricks; they agree everywhere else.
+
+**Handoff-quality arms (`handoff_quality.py`, SigLIP 2) — staying in TextHard longer buys
+nothing; more positives is the only lever:**
+
+| arm | switch t | handoff jump | @t60 cost | @t60 F1 |
+|---|---|---|---|---|
+| g3/b4 baseline | 7.1 | +0.125 | 0.343 | 0.625 |
+| g3/b8 more bads | 11.1 | +0.065 | 0.345 | 0.621 |
+| g3/b12 more bads | 15.2 | +0.096 | 0.347 | 0.622 |
+| g6/b4 more goods | 10.4 | +0.054 | 0.334 | **0.677** |
+
+More bads (the *free* lever — the haystack is all hay) softens the one-time handoff jump
+but leaves the learned detector **flat** at matched budget. More *goods* is the only thing
+that moves quality (F1 0.625→**0.677**). But "require more goods" is **begging the
+question** — finding needles is the task VTSearch exists for; you can't demand them.
+Confirmed in the data: g6/b4 ran only 1540/1580 traces because **40 seeds couldn't reach 6
+goods** (the hard classes can't supply them).
+
+**Unified root cause = positive starvation.** The deep threshold spikes (cut pinned by ~3
+positives all run), the horrible Text→Learned scores (3-positive MLP never catches text),
+and the F1 ceiling all dissolve only when `n_good` grows. The one lever that is both
+**shippable and helps everything** (spikes *and* F1, no threshold trickery, no demanding
+goods) is **positive-*seeking* acquisition**: have the autopilot spend some picks surfacing
+its best *guesses* at positives for the user to confirm (interleave exploit/"top" picks
+through the `hard` phase) — the system doing the hard task, not begging for it. **Not yet
+built**; the g6/b4 arm is the "if goods were free" ceiling it should chase. Metric note:
+track **F1/recall alongside cost** — cost alone rewards precision-wrecking permissive cuts
+under the 100× imbalance. Tools: `handoff_quality.py`, `deep_spikes.py`.
 
 ## When does a Bad vote spike? (per-EVENT, #2790)
 

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -363,13 +363,13 @@ more stable cut and `min(cal-pos)`, but the effect is diminishing and modest.
 **Decomposition of the deep spikes — DIRECT measurement (corrects the by-exclusion estimate).**
 Instrumenting `poolpos_recall` at the *previous* cut with the *current* scores splits each
 spike's recall collapse into a score-driven term (MLP retrain, cut held) and a cut-driven term
-(cut moved, scores held). Result: **~57% score-driven / ~43% cut-driven** (partial 67-trace
-sample; 40-class re-run pending). So — correcting my earlier by-exclusion claim of "75–85 /
-15–25" — the **cut/calibration side is a larger contributor (~43%)** than the behavioral tests
-implied:
-- **MLP-retrain score variance (~57%)** — the under-determined 3-positive MLP gives different
+(cut moved, scores held). Result: **56% score-driven / 44% cut-driven** (confirmed on 800
+traces / 3002 spikes; the partial 67-trace read was 57/43). So — correcting my earlier
+by-exclusion claim of "75–85 / 15–25" — the **cut/calibration side is a larger contributor
+(~44%)** than the behavioral tests implied:
+- **MLP-retrain score variance (~56%)** — the under-determined 3-positive MLP gives different
   scores each retrain; test positives wobble vs a fixed cut. Only more positives fix it (hard).
-- **Cut movement (~43%)** — but only ~13 points of this is the *removable* fold reshuffle
+- **Cut movement (~44%)** — but only ~13 points of this is the *removable* fold reshuffle
   (`--stable-folds`) / ~16–19 via `calibrate_count`↑; the rest is the conformal cut faithfully
   recomputing on the wildly-varying retrained scores. So the behavioral tests (which only
   remove the fold-reshuffle slice) undercounted the cut's role — the owner's cross-calibration

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -291,6 +291,43 @@ hard negatives actually spike.** Tool: `spike_vectors.py --embedder siglip`; art
 `/exp/sgreenberg/threshold-stability/broad_sig1/spike_vectors_sig1.json`,
 `broad/spike_vectors_sig2_v2.json`.
 
+## MECHANISM: what the hidden calibration catastrophe actually is (`calib_conditions.py`)
+
+Necessary+sufficient conditions, established by instrumenting the calibration (`_calib_diag`
+records, per MLP step: where the cut sits in the bad→positive gap, and `poolpos_recall` = the
+**true** recall over *all* pool positives, which the sim knows but the labeled data hides).
+Two hypotheses were **refuted** on the way, which is the crux of the answer:
+
+1. *Refuted:* a spike is **not** a training-recall collapse — at spikes 99.6% of labeled
+   positives stay **above** the cut. The cut does not jump above the labeled positives.
+2. *Refuted:* the trigger is **not** a vote scored high. Bads essentially never outscore a
+   labeled positive; and a Bad above the *previous top bad* spikes only 2.0% vs 12.4% for a
+   Bad *below* it. The vote's score position does not predict the spike.
+
+**What it is.** Acquisition surfaces *easy* (high-scoring) positives, so the ~3 labeled
+positives are unrepresentatively high and sit well above the cut. The conformal cut lives in
+the **gap** between the labeled bads and those high positives — and the *unlabeled/test*
+positives live densely in that gap, near the cut. Each vote **retrains** the MLP; with almost
+nothing pinning the cut in the gap, the cut (and/or the scores) **wobbles** on every refit. A
+spike is a step where the operating point wobbles **up** through that dense band of unlabeled
+positives → true recall collapses (`Δpoolpos_recall` −0.093 at spikes vs +0.004 otherwise;
+`Δcut_in_gap` +0.218, `Δthreshold` +0.031) — while labeled recall stays ~1, so it's invisible
+to the labeled data. **That divergence is why it's "hidden."**
+
+**Necessary** (all three): (1) sparse, unrepresentatively-high labeled positives → an
+under-determined cut in a wide gap; (2) a retrain wobble that moves the operating point up —
+the **cut** (~60% of spikes, `Δthreshold`>0) or the **scores** under a stable cut (~40%, a
+second mode); (3) unlabeled positives densely in that path.
+
+**Sufficient: none observable.** (2)∧(3) is sufficient, but (3) is *hidden* (unlabeled) and
+(2) is a *stochastic retrain outcome* not determined by the vote's features. The tightest
+labeled-observable predictor is the symptom "the cut moved up" — **60% recall, 18%
+precision**. No vote-level trigger exists. The unobservability of a sufficient condition is
+not a gap in the analysis; it **is** the nature of the catastrophe. This is also why the fixes
+work by *reducing the cut's freedom* (defer/GMM/recall-anchor pin it to the score distribution
+or the positives), and why more positives barely moved FNR (mode-2 + the ranking floor remain).
+Tools: `calib_conditions.py`, `_calib_diag`; artifacts `broad_v2_diag3/`.
+
 ## The actual #2790 spikes: deep-run transient excursions (`deep_spikes.py`)
 
 The per-event work above characterizes *all* MLP-regime Bad votes; the #2790 complaint is

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -349,10 +349,33 @@ does — precisely:
   stability lever, not the rule**: more folds pool more Calibrate positives, so the pooled
   `min(cal-positive)` stabilizes to the true lowest → the cut stops jumping.
 
-**Tests in flight (2026-08-02 ~01:45 EDT, siglip2):** (a) `calibrate_count` sweep {2,4,8,16}
-— predict deep-spike rate ↓ monotonically; (b) `--stable-folds` (freeze the split to append
-position, no per-step reshuffle) as the causal clincher — predict spikes largely vanish.
-[RESULTS PENDING — fill in.]
+**Result — the reshuffle is real but MINOR (hypothesis mostly refuted in magnitude).**
+`--stable-folds` (freeze the split → no per-step reshuffle) cut the deep-spike rate only
+~10–15% (t[20,30) 0.108→0.094; overall 0.080→0.072), **not** the ~60% predicted. Reason:
+freezing the fold *identity* doesn't freeze the *scores* — the MLP retrains every vote, so
+`min(cal-positive)`'s **score** still moves even when *which* positive it is stays fixed. So
+the dominant wobble is the **MLP retrain itself** (scores shift), with the fold reshuffle a
+~13% add-on. (Side effect: stable folds gave a better operating point — FNR 0.321→0.263, cost
+0.343→0.310.) The `calibrate_count` sweep agrees: deep-spike t[20,30) 0.108→0.100→0.097→0.088
+for k=2/4/8/16 (overall 0.080→0.067; deepest band t[45+) 0.039→0.025, −36%). More folds pool a
+more stable cut and `min(cal-pos)`, but the effect is diminishing and modest.
+
+**Definitive decomposition of the deep spikes:**
+- **MLP-retrain score variance — dominant (~75–85%).** The under-determined 3-positive MLP
+  produces substantially different *scores* on every retrain; the test positives' scores
+  wobble relative to a fixed cut → FNR spike. No calibration change fixes this; only more
+  positives (a better-determined model) would — and that's hard (soft/g6b4 above).
+- **Cross-calibration variance — real but secondary (~15–25% combined).** Fold reshuffle
+  (~13%, `--stable-folds`) + few calibration points (~16–19%, `calibrate_count`↑). The
+  owner's hunch is a genuine contributor, just not the driver.
+
+Both are rooted in **sparse positives**. This is *why* no observable sufficient condition
+exists — the dominant term is the MLP retrain's score shift, a complex nonlinear function of
+the whole label set, unpredictable from the vote. And it's *why the shipped fixes work*:
+defer/GMM/recall-anchor cut the *cut's* sensitivity (the ~15–25% calibration term) **and**
+park the operating point where a wobble crosses fewer test positives — they don't touch the
+MLP variance but blunt its consequence. Tools: `--stable-folds`, `--calibrate-count`;
+artifacts `broad_v2_stable/`, `broad_cc{4,8,16}/`.
 
 ## The actual #2790 spikes: deep-run transient excursions (`deep_spikes.py`)
 

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -291,6 +291,35 @@ hard negatives actually spike.** Tool: `spike_vectors.py --embedder siglip`; art
 `/exp/sgreenberg/threshold-stability/broad_sig1/spike_vectors_sig1.json`,
 `broad/spike_vectors_sig2_v2.json`.
 
+## The actual #2790 spikes: deep-run transient excursions (`deep_spikes.py`)
+
+The per-event work above characterizes *all* MLP-regime Bad votes; the #2790 complaint is
+specifically the violent jumps **deep in the run, while the MLP is already trained and
+improving** (issue: seed0 t~24, cost 0.088→0.424 then recovers). `deep_spikes.py` isolates
+these — tracking each spike's **up-jump and recovery** ("jump back to good"), sliced by
+depth `t`, on the faithful v2 traces. Both embedders identical.
+
+- **They persist deep and don't fade with learning.** Spike rate by `t`: t[20,30) ≈ 10%,
+  t[30,45) ≈ 6.6%, t[45+) ≈ 4%. A well-trained MLP at t=20–45 still spikes ~7–10% of Bad
+  votes.
+- **They are violent and self-correcting.** Median up-jump +0.17–0.19, but the tail is
+  catastrophic: e.g. `kite` s10 t27 **cost 0.009 → 0.993**; `baseball-glove` s3 t51 **0.037
+  → 1.000** — the cut lurches over *all* the positives (FNR→1), then **~37% snap back within
+  2 steps** (median recovery 2 steps); the other ~40–45% run away longer.
+- **Root cause = sparse POSITIVES that never resolve, not the handoff.** `n_good` median at
+  a deep spike is **5** (min 3) even at t=25–51 — the boundary/`hard` acquisition surfaces
+  mostly negatives, so the MLP is pinned by ~3–5 positives *for the whole run*. **93% of
+  deep spikes are live false-positives** (`surface_margin`≥0): one boundary Bad added to ~3
+  positives shoves the cut across the real matches → cost→1.0 → next retrain re-fits →
+  snap back. Pure threshold-*placement* instability (ranking/oracle barely moves, Stage B
+  cost_sd ≈ 4× oracle floor).
+- **Implication for mitigation:** staying in HardText longer (more *bads* before learned
+  sort) does **not** help — `n_good` stays ~5 regardless of bad count. The lever is the
+  *positive* side: hold a distribution cut while positives are sparse (`--defer-cut-goods`,
+  already a Pareto win at K=6 — and since `n_good` stays low all run, it applies throughout,
+  exactly where the deep spikes live), the crossing-GMM cut, or acquire more positives
+  (diversify away from pure boundary sampling). Tool: `deep_spikes.py`.
+
 ## When does a Bad vote spike? (per-EVENT, #2790)
 
 If the vector position only weakly tilts the odds, *what* sets them? The unit that

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -323,14 +323,17 @@ Tested the two candidate levers on the faithful harness (79 classes × 20 seeds)
 on one conclusion: **the bottleneck is positives, not the cut rule or the negatives.**
 
 **defer6 (crossing-GMM cut while sparse) crushes the deep cost-spikes ~8× — but trades
-F1.** Deep-spike rate t[20,30) 0.10 → 0.012 (both embedders); the distribution-based GMM
-cut doesn't lurch when one boundary Bad is added. BUT it does so by moving the operating
-point, not by being a better cut: SigLIP 2 @t60 FNR 0.32→0.18, FPR 0.02→0.09, **F1
-0.625→0.323**, weighted cost 0.343→0.268. The permissive GMM cut catches more positives
-but, under `neg_multiple`=100, the extra FPs wreck precision. So an earlier "defer6 is a
-Pareto win" (5-class, cost-only) is **wrong once F1 is included** — it suppresses transient
-cost-spikes by adopting a permanently worse-F1 cut. Cost and F1 only diverge for such
-threshold tricks; they agree everywhere else.
+the deep spikes.** Deep-spike rate t[20,30) 0.10 → 0.012 (both embedders); the
+distribution-based GMM cut doesn't lurch when one boundary Bad is added. It also **catches
+more needles**: SigLIP 2 @t60 FNR 0.32→**0.18** (misses 18% vs 32%), FPR 0.02→0.09, cost
+(=FNR+FPR) 0.343→**0.268**. (**Metric correction**, owner 2026-08-01: an intermediate write-up
+called this a regression on **F1** — that was wrong. Under `neg_multiple`=100, F1 collapses
+to precision ≈ 2·TP/(TP+FP) and *under-weights* FNR, so it penalises the extra FPs and hides
+the recall win. For a rare-needle, don't-miss-any customer the right metric is **FNR+FPR**
+(prevalence-independent, recall-inclusive) — which is what `cost` already is — and by it
+defer6 is a genuine **improvement**, catching 82% of needles vs 68% for a review set of 9%
+vs 2% of the hay. So the original cost-based "defer6 helps" stands; only the F1 detour was
+the error.)
 
 **Handoff-quality arms (`handoff_quality.py`, SigLIP 2) — staying in TextHard longer buys
 nothing; more positives is the only lever:**
@@ -351,14 +354,18 @@ goods** (the hard classes can't supply them).
 
 **Unified root cause = positive starvation.** The deep threshold spikes (cut pinned by ~3
 positives all run), the horrible Text→Learned scores (3-positive MLP never catches text),
-and the F1 ceiling all dissolve only when `n_good` grows. The one lever that is both
-**shippable and helps everything** (spikes *and* F1, no threshold trickery, no demanding
+and the recall/FNR ceiling all dissolve only when `n_good` grows. The one lever that is both
+**shippable and helps everything** (spikes *and* recall, no threshold trickery, no demanding
 goods) is **positive-*seeking* acquisition**: have the autopilot spend some picks surfacing
-its best *guesses* at positives for the user to confirm (interleave exploit/"top" picks
-through the `hard` phase) — the system doing the hard task, not begging for it. **Not yet
-built**; the g6/b4 arm is the "if goods were free" ceiling it should chase. Metric note:
-track **F1/recall alongside cost** — cost alone rewards precision-wrecking permissive cuts
-under the 100× imbalance. Tools: `handoff_quality.py`, `deep_spikes.py`.
+its best *guesses* at positives for the user to confirm — the `soft` select mode
+(`--soft-seek`), which picks the item with calibrated P(good)~0.7 (the ~50–76%-good band vs
+`hard`'s ~17%) — the system doing the hard task, not begging for it. **Built + under test**; the g6/b4 arm is the "if goods were free" ceiling it should chase. **Metric (owner
+2026-08-01):** evaluate on **FNR+FPR** (= `cost`) and **recall-at-review-budget**, *not* F1.
+Customers hunt rare needles (~0.1%) and can't miss any; F1 collapses to precision under that
+imbalance and under-weights FNR — the opposite of the goal. Since #2790 shows the *ranking*
+is the stable/good part and only the *threshold* is unstable, a threshold-independent
+recall@budget is the cleanest "customer value" metric. Tools: `handoff_quality.py`,
+`deep_spikes.py`, `soft_eval.py` (reports n_good / FNR / FPR / cost, not F1).
 
 ## When does a Bad vote spike? (per-EVENT, #2790)
 

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -360,14 +360,21 @@ the dominant wobble is the **MLP retrain itself** (scores shift), with the fold 
 for k=2/4/8/16 (overall 0.080→0.067; deepest band t[45+) 0.039→0.025, −36%). More folds pool a
 more stable cut and `min(cal-pos)`, but the effect is diminishing and modest.
 
-**Definitive decomposition of the deep spikes:**
-- **MLP-retrain score variance — dominant (~75–85%).** The under-determined 3-positive MLP
-  produces substantially different *scores* on every retrain; the test positives' scores
-  wobble relative to a fixed cut → FNR spike. No calibration change fixes this; only more
-  positives (a better-determined model) would — and that's hard (soft/g6b4 above).
-- **Cross-calibration variance — real but secondary (~15–25% combined).** Fold reshuffle
-  (~13%, `--stable-folds`) + few calibration points (~16–19%, `calibrate_count`↑). The
-  owner's hunch is a genuine contributor, just not the driver.
+**Decomposition of the deep spikes — DIRECT measurement (corrects the by-exclusion estimate).**
+Instrumenting `poolpos_recall` at the *previous* cut with the *current* scores splits each
+spike's recall collapse into a score-driven term (MLP retrain, cut held) and a cut-driven term
+(cut moved, scores held). Result: **~57% score-driven / ~43% cut-driven** (partial 67-trace
+sample; 40-class re-run pending). So — correcting my earlier by-exclusion claim of "75–85 /
+15–25" — the **cut/calibration side is a larger contributor (~43%)** than the behavioral tests
+implied:
+- **MLP-retrain score variance (~57%)** — the under-determined 3-positive MLP gives different
+  scores each retrain; test positives wobble vs a fixed cut. Only more positives fix it (hard).
+- **Cut movement (~43%)** — but only ~13 points of this is the *removable* fold reshuffle
+  (`--stable-folds`) / ~16–19 via `calibrate_count`↑; the rest is the conformal cut faithfully
+  recomputing on the wildly-varying retrained scores. So the behavioral tests (which only
+  remove the fold-reshuffle slice) undercounted the cut's role — the owner's cross-calibration
+  hunch is more right than my first read said, though most of the cut movement is downstream of
+  the MLP variance, not independent of it.
 
 Both are rooted in **sparse positives**. This is *why* no observable sufficient condition
 exists — the dominant term is the MLP retrain's score shift, a complex nonlinear function of

--- a/scripts/experiments/threshold_stability/calib_conditions.py
+++ b/scripts/experiments/threshold_stability/calib_conditions.py
@@ -1,0 +1,116 @@
+"""Necessary + sufficient conditions for the #2790 calibration catastrophe.
+
+Hypothesis: a deep spike is a **training-recall collapse** — the conformal cut jumping ABOVE
+the sparse labeled positives — triggered by a vote scored among/above them. The instrumented
+trace (region_curve `_calib_diag`) records, per MLP-regime step:
+  ``n_pos_above_cut`` (labeled positives still ≥ cut), ``n_pos_lab``, ``vote_beats_pos``
+  (positives the just-voted item outscored), ``gt_label``.
+This script tests:
+  (A) does a spike ⟺ training-recall collapse (n_pos_above_cut/n_pos_lab → 0)?
+  (B) the trigger: spike rate by (vote label, vote_beats_pos) — is "a Bad that outscores ≥1
+      positive" necessary (spike~0 otherwise) and sufficient (spike~1 when it holds)?
+  (C) precision/recall of candidate necessary+sufficient rules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sod"))  # noqa: E402
+from spike_analysis import _f  # type: ignore  # noqa: E402
+
+
+def collect(root: Path, thresh: float):
+    ev = []
+    for tj in sorted(root.rglob("trace.json")):
+        tr = sorted(json.loads(tj.read_text()), key=lambda e: e["t"])
+        costs = [_f(e.get("cost")) for e in tr]
+        for i in range(1, len(tr)):
+            cur = tr[i]
+            if cur.get("head") != "mlp":
+                continue
+            up = costs[i] - costs[i - 1]
+            npl = cur.get("n_pos_lab") or 0
+            nab = cur.get("n_pos_above_cut")
+            ev.append(
+                {
+                    "is_spike": int(up > thresh),
+                    "label": cur.get("gt_label"),
+                    "vote_beats_pos": cur.get("vote_beats_pos"),
+                    "n_pos_lab": npl,
+                    "recall_frac": (nab / npl if npl and nab is not None else None),
+                    "fnr": _f(cur.get("fnr")),
+                }
+            )
+    return ev
+
+
+def _rate(ev, cond):
+    s = [e for e in ev if cond(e)]
+    k = sum(e["is_spike"] for e in s)
+    return k, len(s), (k / len(s) if s else float("nan"))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Necessary+sufficient conditions for #2790 spikes.")
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--thresh", type=float, default=0.1)
+    args = ap.parse_args(argv)
+    ev = collect(Path(args.root), args.thresh)
+    n = len(ev)
+    sp = [e for e in ev if e["is_spike"]]
+    print(f"MLP-regime steps: {n}   up-spikes: {len(sp)} ({len(sp) / n:.3f})\n")
+
+    def m(x):
+        v = [a for a in x if a is not None and a == a]
+        return statistics.fmean(v) if v else float("nan")
+
+    print("== (A) training-recall at the step: frac of labeled positives still >= cut ==")
+    print(f"  spikes    : recall_frac mean {m([e['recall_frac'] for e in sp]):.3f}  (→0 = cut above the positives)")
+    print(f"  non-spikes: recall_frac mean {m([e['recall_frac'] for e in ev if not e['is_spike']]):.3f}")
+    print(f"  spikes with ALL positives below cut (recall_frac==0): "
+          f"{sum(1 for e in sp if e['recall_frac'] == 0)}/{len(sp)}")  # fmt: skip
+
+    print("\n== (B) trigger: spike rate by vote label × how many positives it outscored ==")
+    for lab in ("bad", "good"):
+        print(f"  {lab} votes:")
+        for bp in ("0", "1", "2", ">=3"):
+
+            def c(e, lab=lab, bp=bp):
+                if e["label"] != lab or e["vote_beats_pos"] is None:
+                    return False
+                v = e["vote_beats_pos"]
+                return {"0": v == 0, "1": v == 1, "2": v == 2, ">=3": v >= 3}[bp]
+
+            k, tot, r = _rate(ev, c)
+            if tot:
+                print(f"    beats {bp:<3} positives: {k:>4}/{tot:<6} = {r:.3f}")
+
+    print("\n== (C) candidate necessary+sufficient rules (precision = spike rate | rule; recall = spikes caught) ==")
+    rules = [
+        ("Bad AND beats >=1 pos", lambda e: e["label"] == "bad" and (e["vote_beats_pos"] or 0) >= 1),
+        ("beats >=1 pos (any label)", lambda e: (e["vote_beats_pos"] or 0) >= 1),
+        (
+            "Bad AND beats >=1 AND n_pos_lab<=5",
+            lambda e: e["label"] == "bad" and (e["vote_beats_pos"] or 0) >= 1 and (e["n_pos_lab"] or 0) <= 5,
+        ),  # noqa: E501
+        (
+            "Bad AND beats ALL pos",
+            lambda e: e["label"] == "bad" and e["n_pos_lab"] and e["vote_beats_pos"] == e["n_pos_lab"],
+        ),
+    ]
+    tot_sp = len(sp)
+    print(f"  {'rule':<38} {'precision':>10} {'recall':>8} {'n':>7}")
+    for name, rule in rules:
+        k, tot, prec = _rate(ev, rule)
+        rec = k / tot_sp if tot_sp else float("nan")
+        print(f"  {name:<38} {prec:>10.3f} {rec:>8.3f} {tot:>7}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/threshold_stability/calib_conditions.py
+++ b/scripts/experiments/threshold_stability/calib_conditions.py
@@ -1,15 +1,12 @@
-"""Necessary + sufficient conditions for the #2790 calibration catastrophe.
+"""Necessary + sufficient conditions for the #2790 calibration catastrophe (v2: the gap).
 
-Hypothesis: a deep spike is a **training-recall collapse** — the conformal cut jumping ABOVE
-the sparse labeled positives — triggered by a vote scored among/above them. The instrumented
-trace (region_curve `_calib_diag`) records, per MLP-regime step:
-  ``n_pos_above_cut`` (labeled positives still ≥ cut), ``n_pos_lab``, ``vote_beats_pos``
-  (positives the just-voted item outscored), ``gt_label``.
-This script tests:
-  (A) does a spike ⟺ training-recall collapse (n_pos_above_cut/n_pos_lab → 0)?
-  (B) the trigger: spike rate by (vote label, vote_beats_pos) — is "a Bad that outscores ≥1
-      positive" necessary (spike~0 otherwise) and sufficient (spike~1 when it holds)?
-  (C) precision/recall of candidate necessary+sufficient rules.
+v1 refuted the training-recall-collapse hypothesis: at spikes the labeled positives stay
+ABOVE the cut (recall_frac 0.996), and Bad votes essentially never outscore a labeled
+positive. The labeled positives are unrepresentatively high-scoring; the cut lives in the
+GAP between the top labeled bad and the bottom labeled positive, and the *test* positives
+live in that gap. Refined hypothesis: a spike is the cut being pushed UP within that gap
+(``cut_in_gap`` ↑), triggered by a Bad scored high in the gap (``vote_above_badmax`` — it
+raises the conformal gap floor). This tests it on the instrumented trace.
 """
 
 from __future__ import annotations
@@ -30,20 +27,20 @@ def collect(root: Path, thresh: float):
         tr = sorted(json.loads(tj.read_text()), key=lambda e: e["t"])
         costs = [_f(e.get("cost")) for e in tr]
         for i in range(1, len(tr)):
-            cur = tr[i]
+            cur, prev = tr[i], tr[i - 1]
             if cur.get("head") != "mlp":
                 continue
-            up = costs[i] - costs[i - 1]
-            npl = cur.get("n_pos_lab") or 0
-            nab = cur.get("n_pos_above_cut")
+            cig, pcig = cur.get("cut_in_gap"), prev.get("cut_in_gap")
             ev.append(
                 {
-                    "is_spike": int(up > thresh),
+                    "is_spike": int(costs[i] - costs[i - 1] > thresh),
                     "label": cur.get("gt_label"),
-                    "vote_beats_pos": cur.get("vote_beats_pos"),
-                    "n_pos_lab": npl,
-                    "recall_frac": (nab / npl if npl and nab is not None else None),
-                    "fnr": _f(cur.get("fnr")),
+                    "vote_above_badmax": cur.get("vote_above_badmax"),
+                    "vote_beats_bad": cur.get("vote_beats_bad"),
+                    "n_bad_lab": (prev.get("n_bad") or 0),
+                    "cut_in_gap": cig,
+                    "d_cut_in_gap": (cig - pcig if cig is not None and pcig is not None else None),
+                    "d_thr": cur.get("delta_threshold"),
                 }
             )
     return ev
@@ -56,59 +53,53 @@ def _rate(ev, cond):
 
 
 def main(argv=None):
-    ap = argparse.ArgumentParser(description="Necessary+sufficient conditions for #2790 spikes.")
+    ap = argparse.ArgumentParser(description="#2790 spike conditions (gap hypothesis).")
     ap.add_argument("--root", required=True)
     ap.add_argument("--thresh", type=float, default=0.1)
     args = ap.parse_args(argv)
     ev = collect(Path(args.root), args.thresh)
     n = len(ev)
     sp = [e for e in ev if e["is_spike"]]
+    ns = [e for e in ev if not e["is_spike"]]
     print(f"MLP-regime steps: {n}   up-spikes: {len(sp)} ({len(sp) / n:.3f})\n")
 
     def m(x):
         v = [a for a in x if a is not None and a == a]
         return statistics.fmean(v) if v else float("nan")
 
-    print("== (A) training-recall at the step: frac of labeled positives still >= cut ==")
-    print(f"  spikes    : recall_frac mean {m([e['recall_frac'] for e in sp]):.3f}  (→0 = cut above the positives)")
-    print(f"  non-spikes: recall_frac mean {m([e['recall_frac'] for e in ev if not e['is_spike']]):.3f}")
-    print(f"  spikes with ALL positives below cut (recall_frac==0): "
-          f"{sum(1 for e in sp if e['recall_frac'] == 0)}/{len(sp)}")  # fmt: skip
+    print("== (A) where the cut sits in the bad→positive gap (0=top bad, 1=bottom positive) ==")
+    print(
+        f"  cut_in_gap    spikes {m([e['cut_in_gap'] for e in sp]):.3f}   non-spikes {m([e['cut_in_gap'] for e in ns]):.3f}"
+    )
+    print(
+        f"  Δcut_in_gap   spikes {m([e['d_cut_in_gap'] for e in sp]):+.3f}   non-spikes {m([e['d_cut_in_gap'] for e in ns]):+.3f}"
+    )
+    print(f"  Δthreshold    spikes {m([e['d_thr'] for e in sp]):+.4f}   non-spikes {m([e['d_thr'] for e in ns]):+.4f}")
 
-    print("\n== (B) trigger: spike rate by vote label × how many positives it outscored ==")
+    print("\n== (B) trigger: spike rate by vote-above-topbad (raises the gap floor) ==")
     for lab in ("bad", "good"):
-        print(f"  {lab} votes:")
-        for bp in ("0", "1", "2", ">=3"):
-
-            def c(e, lab=lab, bp=bp):
-                if e["label"] != lab or e["vote_beats_pos"] is None:
-                    return False
-                v = e["vote_beats_pos"]
-                return {"0": v == 0, "1": v == 1, "2": v == 2, ">=3": v >= 3}[bp]
-
-            k, tot, r = _rate(ev, c)
+        for name, cond in [
+            (f"{lab} above top bad", lambda e, lab=lab: e["label"] == lab and e["vote_above_badmax"] == 1),
+            (f"{lab} below top bad", lambda e, lab=lab: e["label"] == lab and e["vote_above_badmax"] == 0),
+        ]:
+            k, tot, r = _rate(ev, cond)
             if tot:
-                print(f"    beats {bp:<3} positives: {k:>4}/{tot:<6} = {r:.3f}")
+                print(f"    {name:<20} {k:>4}/{tot:<6} = {r:.3f}")
 
-    print("\n== (C) candidate necessary+sufficient rules (precision = spike rate | rule; recall = spikes caught) ==")
-    rules = [
-        ("Bad AND beats >=1 pos", lambda e: e["label"] == "bad" and (e["vote_beats_pos"] or 0) >= 1),
-        ("beats >=1 pos (any label)", lambda e: (e["vote_beats_pos"] or 0) >= 1),
-        (
-            "Bad AND beats >=1 AND n_pos_lab<=5",
-            lambda e: e["label"] == "bad" and (e["vote_beats_pos"] or 0) >= 1 and (e["n_pos_lab"] or 0) <= 5,
-        ),  # noqa: E501
-        (
-            "Bad AND beats ALL pos",
-            lambda e: e["label"] == "bad" and e["n_pos_lab"] and e["vote_beats_pos"] == e["n_pos_lab"],
-        ),
-    ]
+    print("\n== (C) candidate rules (precision = P(spike|rule); recall = spikes caught) ==")
     tot_sp = len(sp)
-    print(f"  {'rule':<38} {'precision':>10} {'recall':>8} {'n':>7}")
-    for name, rule in rules:
+    rules = [
+        ("vote above top bad (any)", lambda e: e["vote_above_badmax"] == 1),
+        ("Bad above top bad", lambda e: e["label"] == "bad" and e["vote_above_badmax"] == 1),
+        ("Δcut_in_gap > 0.1 (cut pushed up)", lambda e: (e["d_cut_in_gap"] or 0) > 0.1),
+        ("Δthreshold > 0 (cut moved up)", lambda e: (e["d_thr"] or 0) > 0),
+        ("above-topbad AND Δthr>0", lambda e: e["vote_above_badmax"] == 1 and (e["d_thr"] or 0) > 0),
+    ]
+    print(f"  {'rule':<38} {'precision':>10} {'recall':>8} {'n':>8}")
+    for nm, rule in rules:
         k, tot, prec = _rate(ev, rule)
         rec = k / tot_sp if tot_sp else float("nan")
-        print(f"  {name:<38} {prec:>10.3f} {rec:>8.3f} {tot:>7}")
+        print(f"  {nm:<38} {prec:>10.3f} {rec:>8.3f} {tot:>8}")
     return 0
 
 

--- a/scripts/experiments/threshold_stability/calib_conditions.py
+++ b/scripts/experiments/threshold_stability/calib_conditions.py
@@ -31,7 +31,10 @@ def collect(root: Path, thresh: float):
             if cur.get("head") != "mlp":
                 continue
             cig, pcig = cur.get("cut_in_gap"), prev.get("cut_in_gap")
-            pr, ppr = cur.get("poolpos_recall"), prev.get("poolpos_recall")
+            pr, ppr, prc = cur.get("poolpos_recall"), prev.get("poolpos_recall"), cur.get("poolpos_recall_prevcut")
+            # decompose the recall change into score-driven (cut held at prev) vs cut-driven
+            d_score = (prc - ppr) if (prc is not None and ppr is not None) else None
+            d_cut = (pr - prc) if (pr is not None and prc is not None) else None
             ev.append(
                 {
                     "is_spike": int(costs[i] - costs[i - 1] > thresh),
@@ -42,6 +45,8 @@ def collect(root: Path, thresh: float):
                     "d_thr": cur.get("delta_threshold"),
                     "poolpos_recall": pr,
                     "d_poolpos_recall": (pr - ppr if pr is not None and ppr is not None else None),
+                    "d_score": d_score,
+                    "d_cut": d_cut,
                 }
             )
     return ev
@@ -68,7 +73,16 @@ def main(argv=None):
         v = [a for a in x if a is not None and a == a]
         return statistics.fmean(v) if v else float("nan")
 
-    print("== (A) the catastrophe = TRUE (pool) recall collapse, vs cut movement ==")
+    print("== (A0) DECOMPOSE the recall collapse at spikes: score-driven (MLP retrain) vs cut-driven ==")
+    print(f"  Δrecall_total  spikes {m([e['d_poolpos_recall'] for e in sp]):+.4f}")
+    print(f"    ├ score-driven (cut held at prev)  {m([e['d_score'] for e in sp]):+.4f}")
+    print(f"    └ cut-driven   (scores held)       {m([e['d_cut'] for e in sp]):+.4f}")
+    ds = [abs(e["d_score"]) for e in sp if e["d_score"] is not None]
+    dc = [abs(e["d_cut"]) for e in sp if e["d_cut"] is not None]
+    tot = (statistics.fmean(ds) + statistics.fmean(dc)) if ds and dc else float("nan")
+    print(f"  share of |Δ| at spikes: score {statistics.fmean(ds) / tot:.0%}  cut {statistics.fmean(dc) / tot:.0%}")
+
+    print("\n== (A) the catastrophe = TRUE (pool) recall collapse, vs cut movement ==")
     print(
         f"  poolpos_recall   spikes {m([e['poolpos_recall'] for e in sp]):.3f}   non-spikes {m([e['poolpos_recall'] for e in ns]):.3f}"
     )

--- a/scripts/experiments/threshold_stability/calib_conditions.py
+++ b/scripts/experiments/threshold_stability/calib_conditions.py
@@ -31,16 +31,17 @@ def collect(root: Path, thresh: float):
             if cur.get("head") != "mlp":
                 continue
             cig, pcig = cur.get("cut_in_gap"), prev.get("cut_in_gap")
+            pr, ppr = cur.get("poolpos_recall"), prev.get("poolpos_recall")
             ev.append(
                 {
                     "is_spike": int(costs[i] - costs[i - 1] > thresh),
                     "label": cur.get("gt_label"),
-                    "vote_above_badmax": cur.get("vote_above_badmax"),
-                    "vote_beats_bad": cur.get("vote_beats_bad"),
-                    "n_bad_lab": (prev.get("n_bad") or 0),
+                    "vote_above_prev_badmax": cur.get("vote_above_prev_badmax"),
                     "cut_in_gap": cig,
                     "d_cut_in_gap": (cig - pcig if cig is not None and pcig is not None else None),
                     "d_thr": cur.get("delta_threshold"),
+                    "poolpos_recall": pr,
+                    "d_poolpos_recall": (pr - ppr if pr is not None and ppr is not None else None),
                 }
             )
     return ev
@@ -67,33 +68,41 @@ def main(argv=None):
         v = [a for a in x if a is not None and a == a]
         return statistics.fmean(v) if v else float("nan")
 
-    print("== (A) where the cut sits in the bad→positive gap (0=top bad, 1=bottom positive) ==")
+    print("== (A) the catastrophe = TRUE (pool) recall collapse, vs cut movement ==")
     print(
-        f"  cut_in_gap    spikes {m([e['cut_in_gap'] for e in sp]):.3f}   non-spikes {m([e['cut_in_gap'] for e in ns]):.3f}"
+        f"  poolpos_recall   spikes {m([e['poolpos_recall'] for e in sp]):.3f}   non-spikes {m([e['poolpos_recall'] for e in ns]):.3f}"
     )
     print(
-        f"  Δcut_in_gap   spikes {m([e['d_cut_in_gap'] for e in sp]):+.3f}   non-spikes {m([e['d_cut_in_gap'] for e in ns]):+.3f}"
+        f"  Δpoolpos_recall  spikes {m([e['d_poolpos_recall'] for e in sp]):+.3f}   non-spikes {m([e['d_poolpos_recall'] for e in ns]):+.3f}"
     )
-    print(f"  Δthreshold    spikes {m([e['d_thr'] for e in sp]):+.4f}   non-spikes {m([e['d_thr'] for e in ns]):+.4f}")
+    print(
+        f"  cut_in_gap       spikes {m([e['cut_in_gap'] for e in sp]):.3f}   non-spikes {m([e['cut_in_gap'] for e in ns]):.3f}"
+    )
+    print(
+        f"  Δcut_in_gap      spikes {m([e['d_cut_in_gap'] for e in sp]):+.3f}   non-spikes {m([e['d_cut_in_gap'] for e in ns]):+.3f}"
+    )
+    print(
+        f"  Δthreshold       spikes {m([e['d_thr'] for e in sp]):+.4f}   non-spikes {m([e['d_thr'] for e in ns]):+.4f}"
+    )
 
-    print("\n== (B) trigger: spike rate by vote-above-topbad (raises the gap floor) ==")
+    print("\n== (B) trigger: spike rate by vote-above-PREVIOUS-top-bad (raises the gap floor) ==")
     for lab in ("bad", "good"):
         for name, cond in [
-            (f"{lab} above top bad", lambda e, lab=lab: e["label"] == lab and e["vote_above_badmax"] == 1),
-            (f"{lab} below top bad", lambda e, lab=lab: e["label"] == lab and e["vote_above_badmax"] == 0),
+            (f"{lab} above prev top bad", lambda e, lab=lab: e["label"] == lab and e["vote_above_prev_badmax"] == 1),
+            (f"{lab} below prev top bad", lambda e, lab=lab: e["label"] == lab and e["vote_above_prev_badmax"] == 0),
         ]:
             k, tot, r = _rate(ev, cond)
             if tot:
-                print(f"    {name:<20} {k:>4}/{tot:<6} = {r:.3f}")
+                print(f"    {name:<22} {k:>4}/{tot:<6} = {r:.3f}")
 
     print("\n== (C) candidate rules (precision = P(spike|rule); recall = spikes caught) ==")
     tot_sp = len(sp)
     rules = [
-        ("vote above top bad (any)", lambda e: e["vote_above_badmax"] == 1),
-        ("Bad above top bad", lambda e: e["label"] == "bad" and e["vote_above_badmax"] == 1),
-        ("Δcut_in_gap > 0.1 (cut pushed up)", lambda e: (e["d_cut_in_gap"] or 0) > 0.1),
+        ("Bad above prev top bad", lambda e: e["label"] == "bad" and e["vote_above_prev_badmax"] == 1),
+        ("vote above prev top bad (any)", lambda e: e["vote_above_prev_badmax"] == 1),
         ("Δthreshold > 0 (cut moved up)", lambda e: (e["d_thr"] or 0) > 0),
-        ("above-topbad AND Δthr>0", lambda e: e["vote_above_badmax"] == 1 and (e["d_thr"] or 0) > 0),
+        ("Δcut_in_gap > 0.1", lambda e: (e["d_cut_in_gap"] or 0) > 0.1),
+        ("above-prev-topbad AND Δthr>0", lambda e: e["vote_above_prev_badmax"] == 1 and (e["d_thr"] or 0) > 0),
     ]
     print(f"  {'rule':<38} {'precision':>10} {'recall':>8} {'n':>8}")
     for nm, rule in rules:

--- a/scripts/experiments/threshold_stability/deep_spikes.py
+++ b/scripts/experiments/threshold_stability/deep_spikes.py
@@ -1,0 +1,121 @@
+"""The ACTUAL #2790 spikes: deep-run transient excursions (converged MLP jumps up, snaps back).
+
+Not the start-up cosine->MLP handoff — the violent single-step jumps *while the MLP is
+already trained and improving* (the issue's t~24: cost 0.088 -> 0.424 in one retrain, then
+recovers). For every Bad vote once the MLP is on (``n_bad >= bad_to_start``, default 4),
+tracks the **up-jump** (Δcost > thresh) AND its **recovery** — does cost snap back near the
+pre-spike level within a few steps ("jump back to good") or run away? Sliced by depth ``t``
+and reported with the state at the spike (n_good, n_bad, surface_margin), plus a few full
+before→spike→after cost trajectories.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sod"))  # noqa: E402
+from spike_analysis import _class_seed, _f  # type: ignore  # noqa: E402
+
+
+def collect(root: Path, thresh: float, bad_to_start: int):
+    events = []  # every MLP-regime bad vote
+    for tj in sorted(root.rglob("trace.json")):
+        cls, seed = _class_seed(tj)
+        tr = sorted(json.loads(tj.read_text()), key=lambda e: e["t"])
+        costs = [_f(e.get("cost")) for e in tr]
+        for i in range(1, len(tr)):
+            cur = tr[i]
+            if cur.get("gt_label") != "bad":
+                continue
+            if (cur.get("n_bad") or 0) < bad_to_start:  # MLP not on yet (cosine phase)
+                continue
+            up = costs[i] - costs[i - 1]
+            is_spike = up > thresh
+            rec_steps = None  # steps until cost returns within 0.05 of pre-spike level
+            down = float("nan")
+            if is_spike:
+                pre = costs[i - 1]
+                for k in range(1, 6):
+                    if i + k < len(tr) and costs[i + k] <= pre + 0.05:
+                        rec_steps = k
+                        break
+                if i + 1 < len(tr):
+                    down = costs[i + 1] - costs[i]
+            events.append(
+                {
+                    "cls": cls,
+                    "seed": seed,
+                    "t": cur.get("t"),
+                    "n_good": tr[i - 1].get("n_good"),
+                    "n_bad": tr[i - 1].get("n_bad"),
+                    "surface_margin": _f(cur.get("surface_margin")),
+                    "pre_cost": round(costs[i - 1], 3),
+                    "spike_cost": round(costs[i], 3),
+                    "up": up,
+                    "down": down,
+                    "is_spike": is_spike,
+                    "rec_steps": rec_steps,
+                }  # fmt: skip
+            )
+    return events
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Deep-run transient spike dynamics (#2790).")
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--thresh", type=float, default=0.1)
+    ap.add_argument("--bad-to-start", type=int, default=4)
+    ap.add_argument("--deep-t", type=int, default=20)
+    args = ap.parse_args(argv)
+
+    ev = collect(Path(args.root), args.thresh, args.bad_to_start)
+    spikes = [e for e in ev if e["is_spike"]]
+    print(f"MLP-regime bad votes: {len(ev)}   up-spikes (Δcost>{args.thresh}): {len(spikes)} "
+          f"({len(spikes) / max(1, len(ev)):.3f})\n")  # fmt: skip
+
+    print("== spike rate & recovery by depth t ==")
+    print(
+        f"  {'t band':<10} {'votes':>7} {'spikes':>7} {'rate':>6} {'transient':>10} {'runaway':>8} {'med_up':>7} {'med_rec_steps':>14}"
+    )
+    bands = [(4, 10), (10, 20), (20, 30), (30, 45), (45, 999)]
+    for lo, hi in bands:
+        vv = [e for e in ev if lo <= (e["t"] or 0) < hi]
+        ss = [e for e in vv if e["is_spike"]]
+        if not vv:
+            continue
+        trans = [e for e in ss if e["rec_steps"] is not None and e["rec_steps"] <= 2]
+        runaway = [e for e in ss if e["rec_steps"] is None]
+        med_up = statistics.median(e["up"] for e in ss) if ss else float("nan")
+        rec_vals = [e["rec_steps"] for e in ss if e["rec_steps"] is not None]
+        med_rec = statistics.median(rec_vals) if rec_vals else float("nan")
+        tp = f"{len(trans)}({len(trans) / len(ss):.0%})" if ss else "-"
+        rp = f"{len(runaway)}({len(runaway) / len(ss):.0%})" if ss else "-"
+        print(
+            f"  t[{lo:>2},{hi if hi < 999 else '+':>3}) {len(vv):>7} {len(ss):>7} {len(ss) / len(vv):>6.3f} {tp:>10} {rp:>8} {med_up:>7.3f} {med_rec:>14.1f}"
+        )
+
+    deep = [e for e in spikes if (e["t"] or 0) >= args.deep_t]
+    if deep:
+        print(f"\n== DEEP spikes (t>={args.deep_t}): n={len(deep)} ==")
+        trans = [e for e in deep if e["rec_steps"] is not None and e["rec_steps"] <= 2]
+        print(f"  transient (snap back <=2 steps): {len(trans)}/{len(deep)} = {len(trans) / len(deep):.0%}")
+        print(f"  median up-jump Δcost   : +{statistics.median(e['up'] for e in deep):.3f}")
+        downs = [e["down"] for e in deep if e["down"] == e["down"]]
+        print(f"  median next-step recover: {statistics.median(downs):+.3f}" if downs else "  (no recover data)")
+        print(f"  n_good at deep spike   : median {statistics.median(e['n_good'] for e in deep):.0f} "
+              f"(min {min(e['n_good'] for e in deep)}, max {max(e['n_good'] for e in deep)})")  # fmt: skip
+        print(f"  surface_margin>=0 share: {sum(1 for e in deep if e['surface_margin'] >= 0) / len(deep):.0%}")
+        print("\n  example deep transient spikes (pre → spike → recovery):")
+        exs = sorted((e for e in trans), key=lambda e: -e["up"])[:6]
+        for e in exs:
+            print(f"    {e['cls']:<14} s{e['seed']} t{e['t']:>2}  g{e['n_good']} b{e['n_bad']}  "
+                  f"cost {e['pre_cost']:.3f} → {e['spike_cost']:.3f} (Δ+{e['up']:.3f}) → back {e['down']:+.3f} in {e['rec_steps']} step(s)")  # fmt: skip
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/threshold_stability/handoff_quality.py
+++ b/scripts/experiments/threshold_stability/handoff_quality.py
@@ -1,0 +1,87 @@
+"""Learned-detector QUALITY at/after the Text→Learned switch, vs how long we stay in TextHard.
+
+"It seemed like we had horrible scores when we switched from Text to Learned." Does
+collecting more bads (higher ``bad_to_start``) — or more goods — before the MLP switches on
+make the *first* learned detector less garbage, and/or the detector better at a matched
+annotation budget? For each trace this finds the switch step (first ``head==mlp``) and reports:
+
+* the **handoff jump** = cost at the first MLP step − cost at the last cosine step (the
+  "horrible switch"), and the absolute cost at the switch;
+* cost/F1 a few steps **after** the switch (does the young MLP recover fast?);
+* cost/F1 at fixed **total-vote budgets** t ∈ {20,40,60} so arms whose switch lands at
+  different t are compared at equal annotation cost.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sod"))  # noqa: E402
+from spike_analysis import _f  # type: ignore  # noqa: E402
+
+
+def _at_budget(tr, t):
+    best = None
+    for e in tr:
+        if (e.get("t") or 0) <= t:
+            best = e
+        else:
+            break
+    return best
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Text→Learned handoff quality (#2790).")
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--label", default="")
+    args = ap.parse_args(argv)
+
+    budgets = [20, 40, 60]
+    after = [0, 3, 6]  # steps after the switch
+    jumps, at_switch, switch_ts = [], [], []
+    cost_after = {k: [] for k in after}
+    cost_at = {b: [] for b in budgets}
+    f1_at = {b: [] for b in budgets}
+    final_c, final_f = [], []
+    n = 0
+    for tj in sorted(Path(args.root).rglob("trace.json")):
+        tr = sorted(json.loads(tj.read_text()), key=lambda e: e["t"])
+        sw = next((i for i, e in enumerate(tr) if e.get("head") == "mlp"), None)
+        if sw is None or sw == 0:
+            continue
+        n += 1
+        cb, ca = _f(tr[sw - 1].get("cost")), _f(tr[sw].get("cost"))
+        jumps.append(ca - cb)
+        at_switch.append(ca)
+        switch_ts.append(tr[sw].get("t"))
+        for k in after:
+            if sw + k < len(tr):
+                cost_after[k].append(_f(tr[sw + k].get("cost")))
+        for b in budgets:
+            e = _at_budget(tr, b)
+            if e:
+                cost_at[b].append(_f(e.get("cost")))
+                f1_at[b].append(_f(e.get("f1")))
+        final_c.append(_f(tr[-1].get("cost")))
+        final_f.append(_f(tr[-1].get("f1")))
+
+    def m(x):
+        vals = [v for v in x if v == v]
+        return statistics.fmean(vals) if vals else float("nan")
+
+    print(f"{args.label or args.root}: n_traces={n}")
+    print(f"  switch_t (first MLP)      : {m(switch_ts):.1f}")
+    print(f"  cost AT switch (1st MLP)  : {m(at_switch):.3f}   handoff jump Δ {m(jumps):+.3f}")
+    print(f"  cost after switch  +0/+3/+6: {m(cost_after[0]):.3f} / {m(cost_after[3]):.3f} / {m(cost_after[6]):.3f}")
+    for b in budgets:
+        print(f"  @ t={b:<3} (equal budget) cost {m(cost_at[b]):.3f}   f1 {m(f1_at[b]):.3f}")
+    print(f"  final (t=60)              cost {m(final_c):.3f}   f1 {m(final_f):.3f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/threshold_stability/soft_eval.py
+++ b/scripts/experiments/threshold_stability/soft_eval.py
@@ -1,0 +1,76 @@
+"""Evaluate positive-seeking 'soft' acquisition on the metrics that matter for rare needles.
+
+Per the rare-needle, don't-miss-any use case: report **n_good growth** (does soft break past
+the ~3-5 starvation?), **FNR** (needles missed = 1-recall), **FPR**, and **cost = FNR+FPR**
+(prevalence-independent, recall-inclusive) at matched vote budgets — NOT F1 (which, under the
+100x imbalance, collapses to precision and under-weights FNR). Also the realized **soft-pick
+good-rate** (did soft actually surface positives?). Compare baseline / soft / g6b4-ceiling.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sod"))  # noqa: E402
+from spike_analysis import _f  # type: ignore  # noqa: E402
+
+
+def _at(tr, t):
+    best = None
+    for e in tr:
+        if (e.get("t") or 0) <= t:
+            best = e
+        else:
+            break
+    return best
+
+
+def evaluate(root: Path, label: str):
+    budgets = [20, 40, 60]
+    ng = {b: [] for b in budgets}
+    fnr = {b: [] for b in budgets}
+    fpr = {b: [] for b in budgets}
+    cost = {b: [] for b in budgets}
+    soft_good = soft_tot = 0
+    n = 0
+    for tj in root.rglob("trace.json"):
+        tr = sorted(json.loads(tj.read_text()), key=lambda e: e["t"])
+        n += 1
+        for e in tr:
+            if e.get("select_mode") == "soft":
+                soft_tot += 1
+                soft_good += 1 if e.get("gt_label") == "good" else 0
+        for b in budgets:
+            e = _at(tr, b)
+            if e:
+                ng[b].append(e.get("n_good"))
+                fnr[b].append(_f(e.get("fnr")))
+                fpr[b].append(_f(e.get("fpr")))
+                cost[b].append(_f(e.get("cost")))
+
+    def m(x):
+        v = [a for a in x if a is not None and a == a]
+        return statistics.fmean(v) if v else float("nan")
+
+    print(
+        f"{label}: n_traces={n}"
+        + (f"  soft-pick good-rate {soft_good}/{soft_tot}={soft_good / soft_tot:.3f}" if soft_tot else "")
+    )
+    print(f"  {'budget':<8}{'n_good':>8}{'FNR':>8}{'FPR':>8}{'cost':>8}   (cost=FNR+FPR; FNR=needles missed)")
+    for b in budgets:
+        print(f"  t={b:<6}{m(ng[b]):>8.1f}{m(fnr[b]):>8.3f}{m(fpr[b]):>8.3f}{m(cost[b]):>8.3f}")
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+    for i in range(0, len(argv), 2):
+        evaluate(Path(argv[i]), argv[i + 1])
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sod/sweep.py
+++ b/scripts/sod/sweep.py
@@ -460,6 +460,7 @@ def _run_cell(cell: dict, args, cache_root: Path) -> list[dict]:
         defer_cut_goods=args.defer_cut_goods,
         soft_seek=args.soft_seek,
         recall_target=args.recall_target,
+        stable_folds=args.stable_folds,
     )
     rows: list[dict] = []
     if args.viz or args.labeling_trace:
@@ -667,6 +668,13 @@ def main() -> int:
         help="recall-tuned cut (#2790): anchor the threshold to catch this fraction of the "
         "labeled positives (the (1-R) quantile of their scores). Directly tunes FNR for "
         "rare-needle customers + resists FNR->1 spikes. 0 = off; e.g. 0.9 = catch 90%%.",
+    )
+    ap.add_argument(
+        "--stable-folds",
+        action="store_true",
+        help="causal #2790 test: freeze the cross-calibration Train/Calibrate split (fold by "
+        "append position, no per-step permutation) so an item's fold doesn't reshuffle when "
+        "later votes arrive. Isolates whether the fold reshuffle drives the spikes.",
     )
     ap.add_argument("--cal-fraction", type=float, default=0.5)
     ap.add_argument("--scales", type=_floats, default=(1.0, 0.75, 0.5, 0.3))

--- a/scripts/sod/sweep.py
+++ b/scripts/sod/sweep.py
@@ -459,6 +459,7 @@ def _run_cell(cell: dict, args, cache_root: Path) -> list[dict]:
         threshold_smooth=args.threshold_smooth,
         defer_cut_goods=args.defer_cut_goods,
         soft_seek=args.soft_seek,
+        recall_target=args.recall_target,
     )
     rows: list[dict] = []
     if args.viz or args.labeling_trace:
@@ -658,6 +659,14 @@ def main() -> int:
         help="positive-seeking acquisition (#2790): in the learned 'hard' phase, every "
         "Nth pick is a 'soft' pick (calibrated P(good)~0.7) to grow n_good instead of "
         "only boundary hay. 0 = off, 2 = alternate hard/soft.",
+    )
+    ap.add_argument(
+        "--recall-target",
+        type=float,
+        default=0.0,
+        help="recall-tuned cut (#2790): anchor the threshold to catch this fraction of the "
+        "labeled positives (the (1-R) quantile of their scores). Directly tunes FNR for "
+        "rare-needle customers + resists FNR->1 spikes. 0 = off; e.g. 0.9 = catch 90%%.",
     )
     ap.add_argument("--cal-fraction", type=float, default=0.5)
     ap.add_argument("--scales", type=_floats, default=(1.0, 0.75, 0.5, 0.3))

--- a/scripts/sod/sweep.py
+++ b/scripts/sod/sweep.py
@@ -458,6 +458,7 @@ def _run_cell(cell: dict, args, cache_root: Path) -> list[dict]:
         threshold_rule=args.threshold_rule,
         threshold_smooth=args.threshold_smooth,
         defer_cut_goods=args.defer_cut_goods,
+        soft_seek=args.soft_seek,
     )
     rows: list[dict] = []
     if args.viz or args.labeling_trace:
@@ -649,6 +650,14 @@ def main() -> int:
         default=0,
         help="sparse-positive fix (#2790): while n_good < this, don't trust the trained "
         "conformal cut — use a GMM cut on the model's pool scores. 0 = off.",
+    )
+    ap.add_argument(
+        "--soft-seek",
+        type=int,
+        default=0,
+        help="positive-seeking acquisition (#2790): in the learned 'hard' phase, every "
+        "Nth pick is a 'soft' pick (calibrated P(good)~0.7) to grow n_good instead of "
+        "only boundary hay. 0 = off, 2 = alternate hard/soft.",
     )
     ap.add_argument("--cal-fraction", type=float, default=0.5)
     ap.add_argument("--scales", type=_floats, default=(1.0, 0.75, 0.5, 0.3))

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -695,38 +695,41 @@ def _resolve_select_mode(phase: str, soft_seek: int, hard_pick: int) -> tuple[st
     return select_mode, hard_pick
 
 
-def _calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id) -> dict:
-    """Calibration-catastrophe diagnostics (#2790). The training-recall-collapse hypothesis was
-    refuted (labeled positives stay above the cut at spikes), so this now measures the **bad
-    side / the gap** too: labeled positives are unrepresentatively high-scoring, the cut lives in
-    the gap between the top labeled bad and the bottom labeled positive, and the *test* positives
-    live in that gap. Suspected trigger: a Bad scored high *in the gap* (``vote_beats_bad`` near
-    the top of the bads / ``vote_above_badmax``) raises the conformal gap floor and pushes the cut
-    up through the test positives. ``cut_in_gap`` = 0 at the top bad, 1 at the bottom positive."""
+def _calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id, pool_pos_pos) -> dict:
+    """Calibration-catastrophe diagnostics (#2790). ``cut_in_gap`` (0=top bad, 1=bottom labeled
+    positive) locates the cut; ``poolpos_recall`` is the **true** recall over ALL pool positives
+    (the test-like distribution the sim knows) — vs labeled recall which stays ~1 because the
+    labeled positives are unrepresentatively high-scoring. A spike is the cut wobbling up through
+    the pool positives in the gap. ``vote_above_prev_badmax`` (fixed: compares the vote to the top
+    bad *before* this vote) tests whether a Bad raising the gap floor is the trigger."""
 
     def _sc(ids):
         return sorted(float(pool_scores[idx[i]]) for i in ids if i in idx and np.isfinite(pool_scores[idx[i]]))
 
     pos, bad = _sc(good_ids), _sc(bad_ids)
+    prev_bad = _sc([b for b in bad_ids if b != labeled_id])  # bads BEFORE this vote
     vote = float("nan")
     if labeled_id in idx and np.isfinite(pool_scores[idx[labeled_id]]):
         vote = float(pool_scores[idx[labeled_id]])
-    bad_max = bad[-1] if bad else None
-    pos_min = pos[0] if pos else None
+    bad_max, prev_bad_max, pos_min = (
+        (bad[-1] if bad else None),
+        (prev_bad[-1] if prev_bad else None),
+        (pos[0] if pos else None),
+    )
     cut_in_gap = None
     if bad_max is not None and pos_min is not None and pos_min > bad_max:
         cut_in_gap = round((threshold - bad_max) / (pos_min - bad_max), 4)
+    ppos_above = sum(1 for p in pool_pos_pos if np.isfinite(pool_scores[p]) and pool_scores[p] >= threshold)
+    n_ppos = len(pool_pos_pos)
     return {
         "n_pos_above_cut": sum(1 for s in pos if s >= threshold),
         "n_pos_lab": len(pos),
-        "n_bad_above_cut": sum(1 for s in bad if s >= threshold),
-        "pos_min": round(pos_min, 4) if pos_min is not None else None,
-        "bad_max": round(bad_max, 4) if bad_max is not None else None,
         "cut_in_gap": cut_in_gap,
-        "vote_score_now": round(vote, 4) if vote == vote else None,
+        "poolpos_above_cut": ppos_above,
+        "n_poolpos": n_ppos,
+        "poolpos_recall": round(ppos_above / n_ppos, 4) if n_ppos else None,
         "vote_beats_pos": (sum(1 for s in pos if vote > s) if vote == vote else None),
-        "vote_beats_bad": (sum(1 for s in bad if vote > s) if vote == vote else None),
-        "vote_above_badmax": (int(bad_max is not None and vote > bad_max) if vote == vote else None),
+        "vote_above_prev_badmax": (int(prev_bad_max is not None and vote > prev_bad_max) if vote == vote else None),
     }
 
 
@@ -1049,6 +1052,7 @@ def _realistic_one_seed(
     if setup is None:
         return [], None
     pool_ids, idx, pool_label, seed_id, cold_query, tree = setup
+    pool_pos_pos = [i for i, pid in enumerate(pool_ids) if pool_label[pid] == 1]  # positions of pool positives
     test_labels = [int(v) for v in inputs.test_labels]
 
     machine = AutopilotPhaseMachine(good_to_start=good_to_start, bad_to_start=bad_to_start)
@@ -1200,7 +1204,7 @@ def _realistic_one_seed(
                 "spike": int(len(cost_history) > 1 and abs(cost_history[-1] - cost_history[-2]) > 0.1),
                 "regret": round(float(err["cost"]) - float(oracle), 6),
                 "threshold_rule": threshold_rule,
-                **_calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id),
+                **_calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id, pool_pos_pos),
             }
         )
         prev_threshold = float(threshold)

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -695,6 +695,50 @@ def _resolve_select_mode(phase: str, soft_seek: int, hard_pick: int) -> tuple[st
     return select_mode, hard_pick
 
 
+def _calib_diag(pool_scores, good_ids, idx, threshold, labeled_id) -> dict:
+    """Calibration-catastrophe diagnostics (#2790): where the trained cut sits **relative to
+    the labeled positives**, and where the just-voted item falls among them. A deep spike is
+    hypothesised to be a training-recall collapse — the cut jumping above the sparse positives
+    — so ``n_pos_above_cut`` (labeled positives still scored ≥ cut) is the key signal, and
+    ``vote_beats_pos`` (positives the just-voted item outscores) the suspected trigger."""
+    pos = sorted(float(pool_scores[idx[g]]) for g in good_ids if g in idx and np.isfinite(pool_scores[idx[g]]))
+    vote = float("nan")
+    if labeled_id in idx and np.isfinite(pool_scores[idx[labeled_id]]):
+        vote = float(pool_scores[idx[labeled_id]])
+    return {
+        "n_pos_above_cut": sum(1 for s in pos if s >= threshold),
+        "n_pos_lab": len(pos),
+        "pos_min": round(pos[0], 4) if pos else None,
+        "pos_max": round(pos[-1], 4) if pos else None,
+        "vote_score_now": round(vote, 4) if vote == vote else None,
+        "vote_beats_pos": (sum(1 for s in pos if vote > s) if vote == vote else None),
+    }
+
+
+def _override_cut(threshold, calib, pool_scores, good_ids, idx, defer_cut_goods, recall_target):
+    """Post-calibration cut overrides (#2790). A no-op on the cosine cold-start.
+
+    ``recall_target`` R (0<R<1) **anchors the cut to the labeled positives** — the (1−R)
+    quantile of their pooled scores, i.e. catch R of them — which directly tunes FNR for
+    rare-needle customers and, being positive-anchored, structurally can't lurch above ALL
+    positives (resists the FNR→1 deep spikes). Falls back to ``defer_cut_goods`` K (GMM cut
+    on pool scores while n_good<K), else leaves the trained cut. Returns ``(threshold, calib)``.
+    """
+    if calib == "cosine_coldstart":
+        return threshold, calib
+    if recall_target:
+        pos = [float(pool_scores[idx[g]]) for g in good_ids if g in idx and np.isfinite(pool_scores[idx[g]])]
+        if len(pos) >= 2:
+            return float(np.quantile(pos, 1.0 - recall_target)), "recall_target"
+    if defer_cut_goods and len(good_ids) < defer_cut_goods:
+        from vtscore.training.thresholds import calculate_gmm_threshold  # noqa: PLC0415
+
+        finite = [float(s) for s in pool_scores if np.isfinite(s)]
+        if finite:
+            return calculate_gmm_threshold(finite), "defer_gmm"
+    return threshold, calib
+
+
 def _select_next(select_mode, tree, pool_ids, pool_scores, threshold, labeled, idx):
     if select_mode == "top":
         return _select_top(pool_ids, pool_scores, labeled, idx)
@@ -979,11 +1023,12 @@ def _realistic_one_seed(
     threshold_smooth: str = "none",
     defer_cut_goods: int = 0,
     soft_seek: int = 0,
+    recall_target: float = 0.0,
 ) -> tuple[list[dict], dict | None]:
     """Run one seed's labeling loop. Returns ``(rows, final)`` where ``final`` is a dict
     ``{predict, threshold, n_good, n_bad, t, trace}`` for the last step (head + blended
     threshold the final row measured, plus the per-step trace), or ``None`` when no step ran."""
-    from vtscore.training.thresholds import calculate_gmm_threshold, calculate_safe_threshold  # noqa: PLC0415
+    from vtscore.training.thresholds import calculate_safe_threshold  # noqa: PLC0415
 
     setup = _realistic_setup(inputs, seed, query_vec)
     if setup is None:
@@ -1067,11 +1112,7 @@ def _realistic_one_seed(
         # the model's pool scores instead (independent of the sparse calibration
         # positives). Off when ``defer_cut_goods == 0``; skips the cosine cold-start
         # step, which already has no trained cut.
-        if defer_cut_goods and len(good_ids) < defer_cut_goods and calib != "cosine_coldstart":
-            finite = [float(s) for s in pool_scores if np.isfinite(s)]
-            if finite:
-                threshold = calculate_gmm_threshold(finite)
-                calib = "defer_gmm"
+        threshold, calib = _override_cut(threshold, calib, pool_scores, good_ids, idx, defer_cut_goods, recall_target)
 
         err = weighted_error(test_scores, [float(v) for v in test_labels], threshold, inclusion)
         oracle = min_weighted_cost(test_scores, [float(v) for v in test_labels], inclusion)
@@ -1144,6 +1185,7 @@ def _realistic_one_seed(
                 "spike": int(len(cost_history) > 1 and abs(cost_history[-1] - cost_history[-2]) > 0.1),
                 "regret": round(float(err["cost"]) - float(oracle), 6),
                 "threshold_rule": threshold_rule,
+                **_calib_diag(pool_scores, good_ids, idx, threshold, labeled_id),
             }
         )
         prev_threshold = float(threshold)
@@ -1187,6 +1229,7 @@ def evaluate_realistic_curve(
     threshold_smooth: str = "none",
     defer_cut_goods: int = 0,
     soft_seek: int = 0,
+    recall_target: float = 0.0,
 ) -> list[dict] | tuple[list[dict], dict[int, dict]]:
     """Realistic active-learning labeling curve: cost/fpr/fnr/F1/IoU vs ``t`` (total
     annotations), one row per ``(seed, t)``.
@@ -1231,6 +1274,7 @@ def evaluate_realistic_curve(
             threshold_smooth=threshold_smooth,
             defer_cut_goods=defer_cut_goods,
             soft_seek=soft_seek,
+            recall_target=recall_target,
         )
         # Amortize the seed's wall-clock over its rows (per-step retrain dominates).
         per = round((time.perf_counter() - t0) * 1000.0 / max(len(seed_rows), 1), 3)

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -780,6 +780,7 @@ def _train_pool_head(
     calibrate_count: int,
     cal_fraction: float,
     threshold_rule: str = "conformal",
+    stable_folds: bool = False,
 ):
     """Train a head on the current good/bad votes; returns
     ``(predict_fn, raw_threshold, n_votes, calib_mode)`` or ``None`` on a
@@ -842,6 +843,7 @@ def _train_pool_head(
         inclusion_value=inclusion,
         calibrate_count=calibrate_count,
         cal_fraction=cal_fraction,
+        stable_folds=stable_folds,
     )
     if not np.isfinite(raw_thr):
         raw_thr = 0.5
@@ -917,6 +919,7 @@ def _resolve_step_head(
     threshold_rule="conformal",
     good_to_start=3,
     bad_to_start=4,
+    stable_folds=False,
 ):
     """Return ``(cached, steps_since_train)`` for one step.
 
@@ -948,6 +951,7 @@ def _resolve_step_head(
             calibrate_count=calibrate_count,
             cal_fraction=cal_fraction,
             threshold_rule=threshold_rule,
+            stable_folds=stable_folds,
         )
         if res is not None:
             predict, raw_thr, n_votes, calib = res
@@ -1042,6 +1046,7 @@ def _realistic_one_seed(
     defer_cut_goods: int = 0,
     soft_seek: int = 0,
     recall_target: float = 0.0,
+    stable_folds: bool = False,
 ) -> tuple[list[dict], dict | None]:
     """Run one seed's labeling loop. Returns ``(rows, final)`` where ``final`` is a dict
     ``{predict, threshold, n_good, n_bad, t, trace}`` for the last step (head + blended
@@ -1111,6 +1116,7 @@ def _realistic_one_seed(
             threshold_rule=threshold_rule,
             good_to_start=good_to_start,
             bad_to_start=bad_to_start,
+            stable_folds=stable_folds,
         )
         predict, raw_thr, n_votes, calib, blend = cached
 
@@ -1249,6 +1255,7 @@ def evaluate_realistic_curve(
     defer_cut_goods: int = 0,
     soft_seek: int = 0,
     recall_target: float = 0.0,
+    stable_folds: bool = False,
 ) -> list[dict] | tuple[list[dict], dict[int, dict]]:
     """Realistic active-learning labeling curve: cost/fpr/fnr/F1/IoU vs ``t`` (total
     annotations), one row per ``(seed, t)``.
@@ -1294,6 +1301,7 @@ def evaluate_realistic_curve(
             defer_cut_goods=defer_cut_goods,
             soft_seek=soft_seek,
             recall_target=recall_target,
+            stable_folds=stable_folds,
         )
         # Amortize the seed's wall-clock over its rows (per-step retrain dominates).
         per = round((time.perf_counter() - t0) * 1000.0 / max(len(seed_rows), 1), 3)

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -695,23 +695,38 @@ def _resolve_select_mode(phase: str, soft_seek: int, hard_pick: int) -> tuple[st
     return select_mode, hard_pick
 
 
-def _calib_diag(pool_scores, good_ids, idx, threshold, labeled_id) -> dict:
-    """Calibration-catastrophe diagnostics (#2790): where the trained cut sits **relative to
-    the labeled positives**, and where the just-voted item falls among them. A deep spike is
-    hypothesised to be a training-recall collapse — the cut jumping above the sparse positives
-    — so ``n_pos_above_cut`` (labeled positives still scored ≥ cut) is the key signal, and
-    ``vote_beats_pos`` (positives the just-voted item outscores) the suspected trigger."""
-    pos = sorted(float(pool_scores[idx[g]]) for g in good_ids if g in idx and np.isfinite(pool_scores[idx[g]]))
+def _calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id) -> dict:
+    """Calibration-catastrophe diagnostics (#2790). The training-recall-collapse hypothesis was
+    refuted (labeled positives stay above the cut at spikes), so this now measures the **bad
+    side / the gap** too: labeled positives are unrepresentatively high-scoring, the cut lives in
+    the gap between the top labeled bad and the bottom labeled positive, and the *test* positives
+    live in that gap. Suspected trigger: a Bad scored high *in the gap* (``vote_beats_bad`` near
+    the top of the bads / ``vote_above_badmax``) raises the conformal gap floor and pushes the cut
+    up through the test positives. ``cut_in_gap`` = 0 at the top bad, 1 at the bottom positive."""
+
+    def _sc(ids):
+        return sorted(float(pool_scores[idx[i]]) for i in ids if i in idx and np.isfinite(pool_scores[idx[i]]))
+
+    pos, bad = _sc(good_ids), _sc(bad_ids)
     vote = float("nan")
     if labeled_id in idx and np.isfinite(pool_scores[idx[labeled_id]]):
         vote = float(pool_scores[idx[labeled_id]])
+    bad_max = bad[-1] if bad else None
+    pos_min = pos[0] if pos else None
+    cut_in_gap = None
+    if bad_max is not None and pos_min is not None and pos_min > bad_max:
+        cut_in_gap = round((threshold - bad_max) / (pos_min - bad_max), 4)
     return {
         "n_pos_above_cut": sum(1 for s in pos if s >= threshold),
         "n_pos_lab": len(pos),
-        "pos_min": round(pos[0], 4) if pos else None,
-        "pos_max": round(pos[-1], 4) if pos else None,
+        "n_bad_above_cut": sum(1 for s in bad if s >= threshold),
+        "pos_min": round(pos_min, 4) if pos_min is not None else None,
+        "bad_max": round(bad_max, 4) if bad_max is not None else None,
+        "cut_in_gap": cut_in_gap,
         "vote_score_now": round(vote, 4) if vote == vote else None,
         "vote_beats_pos": (sum(1 for s in pos if vote > s) if vote == vote else None),
+        "vote_beats_bad": (sum(1 for s in bad if vote > s) if vote == vote else None),
+        "vote_above_badmax": (int(bad_max is not None and vote > bad_max) if vote == vote else None),
     }
 
 
@@ -1185,7 +1200,7 @@ def _realistic_one_seed(
                 "spike": int(len(cost_history) > 1 and abs(cost_history[-1] - cost_history[-2]) > 0.1),
                 "regret": round(float(err["cost"]) - float(oracle), 6),
                 "threshold_rule": threshold_rule,
-                **_calib_diag(pool_scores, good_ids, idx, threshold, labeled_id),
+                **_calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id),
             }
         )
         prev_threshold = float(threshold)

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -26,6 +26,7 @@ text-capable embedders (baseline). ``K == 0`` is the zero-shot cosine point
 
 from __future__ import annotations
 
+import math
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -645,11 +646,62 @@ def _select_new(tree, pool_ids, pool_scores, threshold, labeled, idx):
     return _select_hard(pool_ids, pool_scores, threshold, labeled)
 
 
+def _gmm_p_good(fit, s: float) -> float:
+    """Posterior P(good) = P(high-mean component) for score ``s`` under the fitted GMM."""
+
+    def _npdf(x, mu, var):
+        return math.exp(-0.5 * (x - mu) ** 2 / var) / math.sqrt(2.0 * math.pi * var)
+
+    hi = fit.w_hi * _npdf(s, fit.mu_hi, fit.var_hi)
+    lo = fit.w_lo * _npdf(s, fit.mu_lo, fit.var_lo)
+    tot = hi + lo
+    return hi / tot if tot > 0 else 0.0
+
+
+def _select_soft(pool_ids, pool_scores, threshold, labeled, target_p: float = 0.7):
+    """Positive-*seeking* pick: the unlabeled item whose calibrated ``P(good|score)`` is
+    closest to ``target_p`` (~0.7). Targets *likely-but-not-certain* positives — the score
+    band that surfaces new positives (grows ``n_good``) while staying informative, unlike
+    ``top`` (P≈1, redundant/baby-easy) or ``hard`` (at the cut, negative-dominated in this
+    all-hay regime; measured ~17% good vs the soft band's ~50-76%). Fits a 2-component GMM
+    to the pool scores for the posterior; falls back to ``hard`` when the fit is unusable."""
+    from vtscore.training.thresholds import fit_score_gmm  # noqa: PLC0415
+
+    fit = fit_score_gmm(np.asarray(pool_scores, dtype=np.float64))
+    if fit is None or fit.var_hi <= 0.0 or fit.var_lo <= 0.0:
+        return _select_hard(pool_ids, pool_scores, threshold, labeled)
+    best, best_d = None, float("inf")
+    for i, pid in enumerate(pool_ids):
+        if pid in labeled:
+            continue
+        d = abs(_gmm_p_good(fit, float(pool_scores[i])) - target_p)
+        if d < best_d:
+            best_d, best = d, pid
+    return best if best is not None else _select_hard(pool_ids, pool_scores, threshold, labeled)
+
+
+def _resolve_select_mode(phase: str, soft_seek: int, hard_pick: int) -> tuple[str, int]:
+    """The phase's select mode, with positive-seeking ``soft`` interleaved (#2790).
+
+    In the learned phases (``hard``/``new``) every ``soft_seek``-th pick becomes ``soft``
+    (calibrated P(good)~0.7) to grow ``n_good`` instead of only boundary ``hard`` hay
+    (~17% good). Returns ``(select_mode, updated_hard_pick)``. ``soft_seek == 0`` is off.
+    """
+    select_mode = _PHASE_TO_SELECT[phase]
+    if soft_seek and phase in ("hard", "new"):
+        hard_pick += 1
+        if hard_pick % soft_seek == 0:
+            select_mode = "soft"
+    return select_mode, hard_pick
+
+
 def _select_next(select_mode, tree, pool_ids, pool_scores, threshold, labeled, idx):
     if select_mode == "top":
         return _select_top(pool_ids, pool_scores, labeled, idx)
     if select_mode == "new":
         return _select_new(tree, pool_ids, pool_scores, threshold, labeled, idx)
+    if select_mode == "soft":
+        return _select_soft(pool_ids, pool_scores, threshold, labeled)
     return _select_hard(pool_ids, pool_scores, threshold, labeled)  # "hard" (and any fallback)
 
 
@@ -926,6 +978,7 @@ def _realistic_one_seed(
     threshold_rule: str = "conformal",
     threshold_smooth: str = "none",
     defer_cut_goods: int = 0,
+    soft_seek: int = 0,
 ) -> tuple[list[dict], dict | None]:
     """Run one seed's labeling loop. Returns ``(rows, final)`` where ``final`` is a dict
     ``{predict, threshold, n_good, n_bad, t, trace}`` for the last step (head + blended
@@ -965,6 +1018,7 @@ def _realistic_one_seed(
     prev_threshold: float | None = None  # previous step's threshold, for delta/spike diagnostics
     trace: list[dict] = []  # per-step labeling record (order, id, phase, head, threshold, …)
     final: dict | None = None  # {predict, threshold, n_good, n_bad, t, trace} of the last step
+    hard_pick = 0  # counts learned-phase picks, for soft-seek interleaving
 
     for t in range(1, max_labels + 1):
         if pending is None:
@@ -1031,7 +1085,7 @@ def _realistic_one_seed(
         smart, stable, span = _step_indicators(cost_history, flip_history, prev_pred, cur_pred, tree, good, bad)
         prev_pred = cur_pred
         phase = machine.next_phase(good, bad, smart, stable, span)
-        select_mode = _PHASE_TO_SELECT[phase]
+        select_mode, hard_pick = _resolve_select_mode(phase, soft_seek, hard_pick)
         stop_recommended = phase == "done"
 
         rows.append(
@@ -1132,6 +1186,7 @@ def evaluate_realistic_curve(
     threshold_rule: str = "conformal",
     threshold_smooth: str = "none",
     defer_cut_goods: int = 0,
+    soft_seek: int = 0,
 ) -> list[dict] | tuple[list[dict], dict[int, dict]]:
     """Realistic active-learning labeling curve: cost/fpr/fnr/F1/IoU vs ``t`` (total
     annotations), one row per ``(seed, t)``.
@@ -1175,6 +1230,7 @@ def evaluate_realistic_curve(
             threshold_rule=threshold_rule,
             threshold_smooth=threshold_smooth,
             defer_cut_goods=defer_cut_goods,
+            soft_seek=soft_seek,
         )
         # Amortize the seed's wall-clock over its rows (per-step retrain dominates).
         per = round((time.perf_counter() - t0) * 1000.0 / max(len(seed_rows), 1), 3)

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -695,7 +695,7 @@ def _resolve_select_mode(phase: str, soft_seek: int, hard_pick: int) -> tuple[st
     return select_mode, hard_pick
 
 
-def _calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id, pool_pos_pos) -> dict:
+def _calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id, pool_pos_pos, prev_threshold=None) -> dict:
     """Calibration-catastrophe diagnostics (#2790). ``cut_in_gap`` (0=top bad, 1=bottom labeled
     positive) locates the cut; ``poolpos_recall`` is the **true** recall over ALL pool positives
     (the test-like distribution the sim knows) — vs labeled recall which stays ~1 because the
@@ -721,6 +721,13 @@ def _calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id, pool
         cut_in_gap = round((threshold - bad_max) / (pos_min - bad_max), 4)
     ppos_above = sum(1 for p in pool_pos_pos if np.isfinite(pool_scores[p]) and pool_scores[p] >= threshold)
     n_ppos = len(pool_pos_pos)
+    # Recall at the PREVIOUS cut but with the CURRENT (retrained) scores: holds the cut fixed
+    # so it isolates the pure MLP-retrain SCORE effect from the cut-movement effect (#2790
+    # dominant-mode confirmation). recall@prevcut − recall[t−1] = score-driven Δ; recall[t] −
+    # recall@prevcut = cut-driven Δ; the two sum to the total recall change.
+    ppos_prevcut = None
+    if prev_threshold is not None:
+        ppos_prevcut = sum(1 for p in pool_pos_pos if np.isfinite(pool_scores[p]) and pool_scores[p] >= prev_threshold)
     return {
         "n_pos_above_cut": sum(1 for s in pos if s >= threshold),
         "n_pos_lab": len(pos),
@@ -728,6 +735,7 @@ def _calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id, pool
         "poolpos_above_cut": ppos_above,
         "n_poolpos": n_ppos,
         "poolpos_recall": round(ppos_above / n_ppos, 4) if n_ppos else None,
+        "poolpos_recall_prevcut": (round(ppos_prevcut / n_ppos, 4) if (ppos_prevcut is not None and n_ppos) else None),
         "vote_beats_pos": (sum(1 for s in pos if vote > s) if vote == vote else None),
         "vote_above_prev_badmax": (int(prev_bad_max is not None and vote > prev_bad_max) if vote == vote else None),
     }
@@ -1210,7 +1218,7 @@ def _realistic_one_seed(
                 "spike": int(len(cost_history) > 1 and abs(cost_history[-1] - cost_history[-2]) > 0.1),
                 "regret": round(float(err["cost"]) - float(oracle), 6),
                 "threshold_rule": threshold_rule,
-                **_calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id, pool_pos_pos),
+                **_calib_diag(pool_scores, good_ids, bad_ids, idx, threshold, labeled_id, pool_pos_pos, prev_threshold),
             }
         )
         prev_threshold = float(threshold)

--- a/vtscore/eval/threshold_rules.py
+++ b/vtscore/eval/threshold_rules.py
@@ -66,6 +66,7 @@ def stratified_fold_orderings(
     *,
     calibrate_count: int = 2,
     cal_fraction: float = 0.5,
+    stable_folds: bool = False,
 ) -> list[tuple[list[float], list[float]]]:
     """Held-out ``(scores, labels)`` per fold under **class-stratified** splits.
 
@@ -99,7 +100,7 @@ def stratified_fold_orderings(
     rng = np.random.default_rng(seed)
     orderings: list[tuple[list[float], list[float]]] = []
     for k in range(max(1, calibrate_count)):
-        tr_idx, cal_idx = _stratified_split(pos_idx, neg_idx, cal_fraction, rng)
+        tr_idx, cal_idx = _stratified_split(pos_idx, neg_idx, cal_fraction, rng, stable=stable_folds)
         if tr_idx is None or cal_idx is None:
             continue
         if len({int(v) for v in y[tr_idx]}) < 2 or len({int(v) for v in y[cal_idx]}) < 2:
@@ -119,16 +120,23 @@ def _stratified_split(
     neg_idx: np.ndarray,
     cal_fraction: float,
     rng: np.random.Generator,
+    stable: bool = False,
 ) -> tuple[np.ndarray | None, np.ndarray | None]:
     """One class-balanced Train/Calibrate split; ``(None, None)`` if unsplittable.
 
     Each class contributes ``round(class_n * cal_fraction)`` rows to Calibrate
     (clamped so both Train and Calibrate keep at least one of each class), so
     neither side is ever single-class — the guard the unstratified path lacks.
+
+    ``stable=True`` (#2790 causal test) **skips the permutation** — the fold is by
+    append position, so an item's Train/Calibrate membership does not reshuffle when
+    later votes arrive. Isolates whether the per-step fold reshuffle (which, with ~3
+    positives split 1-train/2-cal, jerks ``min(cal-positive)`` and hence the cut) is
+    what drives the spikes.
     """
 
     def _per_class(idx: np.ndarray) -> tuple[np.ndarray, np.ndarray] | None:
-        perm = rng.permutation(idx)
+        perm = np.asarray(idx) if stable else rng.permutation(idx)
         n_cal = int(round(len(idx) * cal_fraction))
         n_cal = max(1, min(len(idx) - 1, n_cal))
         return perm[n_cal:], perm[:n_cal]  # (train, cal)
@@ -152,6 +160,7 @@ def calibrated_threshold(
     inclusion_value: int = 0,
     calibrate_count: int = 2,
     cal_fraction: float = 0.5,
+    stable_folds: bool = False,
 ) -> float:
     """Decision threshold under the named *rule*.
 
@@ -182,6 +191,7 @@ def calibrated_threshold(
             seed,
             calibrate_count=calibrate_count,
             cal_fraction=cal_fraction,
+            stable_folds=stable_folds,
         )
         if not orderings:
             return 0.5


### PR DESCRIPTION
Continues #2790 (prior work merged in #2805). This PR is the **understanding** arc — what the deep-run spikes actually are, and the necessary/sufficient conditions — plus the tools and knobs built to establish it.

## The mechanism (headline)
The #2790 spikes are the **deep transient excursions** (t≈20–45, ~10% of Bad votes): a converged MLP pinned by ~3 *unrepresentatively-high* labeled positives, whose cut floats in a **gap** where the *unlabeled* positives densely live. Every vote retrains the under-determined model → the operating point wobbles up through those hidden positives → true recall collapses (FNR→1) while **labeled recall stays ~1** — invisible to the labeled data, hence "hidden."

**Direct decomposition** of the recall collapse (recall at the previous cut with current scores): **56% MLP-retrain score variance / 44% cut movement** (800 traces / 3002 spikes). Of the 44% cut, only ~13–19 pts is *removable* (fold reshuffle via `--stable-folds`; `calibrate_count`↑) — the rest is the conformal cut tracking the unstable MLP. **No observable sufficient condition** exists (the retrain is a complex fn of the whole label set); the irreducible core is sparse positives, fixable only by more positives (hard).

Two hypotheses were **refuted** on the way (training-recall-collapse; a high-scoring-vote trigger), which is what pinned the real mechanism.

## What's in it
- **Analysis tools** (`scripts/experiments/threshold_stability/`): `deep_spikes`, `handoff_quality`, `soft_eval`, `calib_conditions`, plus the `_calib_diag` calibration instrumentation.
- **Causal/experimental knobs** (default off, byte-identical; 58 tests pass): `--soft-seek` (positive-seeking acquisition — tested, fails: GMM can't ID positives in a sparse pool), `--recall-target` (recall-anchored cut), `--stable-folds` (freeze the cross-calibration split — causal test; also improves the customer metric FNR 0.32→0.26), `--calibrate-count` sweep.
- **Findings, recorded in `docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md`:** harness-fidelity fix (MLP gated to the hard phase); metric correction (FNR+FPR/recall, not F1); positive starvation as root cause (more-bads useless, more-goods helps but can't be demanded); defer/GMM as cut-side mitigations.

Refs #2790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)