### PR TITLE
Threshold-stability #2790: FIX — a linear head stops the deep spikes (+ decomposition clarification)

### DIFF
--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -362,19 +362,25 @@ more stable cut and `min(cal-pos)`, but the effect is diminishing and modest.
 
 **Decomposition of the deep spikes — DIRECT measurement (corrects the by-exclusion estimate).**
 Instrumenting `poolpos_recall` at the *previous* cut with the *current* scores splits each
-spike's recall collapse into a score-driven term (MLP retrain, cut held) and a cut-driven term
-(cut moved, scores held). Result: **56% score-driven / 44% cut-driven** (confirmed on 800
-traces / 3002 spikes; the partial 67-trace read was 57/43). So — correcting my earlier
-by-exclusion claim of "75–85 / 15–25" — the **cut/calibration side is a larger contributor
-(~44%)** than the behavioral tests implied:
-- **MLP-retrain score variance (~56%)** — the under-determined 3-positive MLP gives different
-  scores each retrain; test positives wobble vs a fixed cut. Only more positives fix it (hard).
-- **Cut movement (~44%)** — but only ~13 points of this is the *removable* fold reshuffle
-  (`--stable-folds`) / ~16–19 via `calibrate_count`↑; the rest is the conformal cut faithfully
-  recomputing on the wildly-varying retrained scores. So the behavioral tests (which only
-  remove the fold-reshuffle slice) undercounted the cut's role — the owner's cross-calibration
-  hunch is more right than my first read said, though most of the cut movement is downstream of
-  the MLP variance, not independent of it.
+spike's recall drop into two **additive** credit terms (hold one fixed, move the other):
+`Δrecall = Δscore (retrained scores, cut held) + Δcut (cut moved, scores held)`. Averaged over
+the 3002 spikes (800 traces): total −0.094 = score −0.063 + cut −0.030 — i.e. **credit for the
+lost recall ≈ 67% under-determined-model / 33% moving-cut** (signed). (An earlier note said
+"56/44"; that was `mean(|score|)`/`mean(|cut|)` — the share of absolute *movement*, which
+over-credits the cut by counting recall-*helping* moves; **67/33 is the credit for the loss**.)
+This *is* a credit-attribution, **not** a partition of spikes ("X% of spikes are score-caused")
+— essentially every spike has both terms. Two caveats: (a) it's a first-order attribution, so
+decomposition order shifts it a few points; (b) the two aren't independent causes — **the cut
+moves *because* the scores moved** (the conformal cut recomputes on the retrained scores), so
+most of the 33% cut credit is *downstream* of the model variance. The genuinely independent,
+*removable* cut slice (the cross-calibration fold reshuffle) is only ~13% (`--stable-folds`;
+~16–19 via `calibrate_count`↑). So, correcting the earlier by-exclusion "75–85 / 15–25":
+- **Model score variance ≈ ⅔** — the under-determined 3-positive MLP gives different scores
+  each retrain; test positives wobble vs a fixed cut. Only more positives fix it (hard).
+- **Cut movement ≈ ⅓, but mostly downstream of the model** — only ~13 pts is the removable
+  fold reshuffle; the rest is the cut faithfully tracking the unstable MLP. The owner's
+  cross-calibration hunch is a real contributor (I first *under*counted it), but the removable
+  part is small.
 
 Both are rooted in **sparse positives**. This is *why* no observable sufficient condition
 exists — the dominant term is the MLP retrain's score shift, a complex nonlinear function of

--- a/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
+++ b/docs/experiments/threshold-stability/SPARSE_POSITIVE_PLAN.md
@@ -291,6 +291,36 @@ hard negatives actually spike.** Tool: `spike_vectors.py --embedder siglip`; art
 `/exp/sgreenberg/threshold-stability/broad_sig1/spike_vectors_sig1.json`,
 `broad/spike_vectors_sig2_v2.json`.
 
+## FIX: a low-variance (linear) head stops the spikes (`--head-strategy`, `results_eval.py`)
+
+The deep spikes are ~85% under-determined-MLP score variance, so the direct fix is a
+lower-variance model while positives are sparse. Head-strategy sweep (20 COCO classes × 15
+seeds, SigLIP 2, MLP-regime, t≥20; trace-free via `results_eval.py` on `results.jsonl`):
+
+| head | deep-spike rate | spike size | @t60 cost | @t60 FNR | @t60 FPR |
+|---|---|---|---|---|---|
+| `mlp` (baseline) | 0.055 | 0.167 | 0.386 | 0.365 | 0.020 |
+| **`linear`** (logistic) | **0.025** | 0.140 | **0.352** | **0.299** | 0.052 |
+| **`svm`** (linear) | **0.023** | 0.134 | 0.356 | 0.308 | 0.049 |
+| `reg-mlp` (small hidden) | 0.042 | 0.152 | 0.381 | 0.310 | 0.071 |
+| `anneal-svm` | 0.026 | 0.139 | 0.364 | 0.319 | 0.044 |
+
+**A linear head (logistic / linear SVM) cuts the deep-spike rate ~55–58% AND improves the
+customer metric** (cost 0.386→0.352, FNR 0.365→**0.299** — catches more needles), for a modest
+FPR rise (0.02→0.05) — the trade a rare-needle customer wants. Not a trade: a Pareto win. The
+gap is largest early (t=20 cost 0.508→0.396), exactly the sparse regime the spikes live in.
+`reg-mlp` (shrinking the hidden layer) helps far less — the MLP's nonlinearity still injects
+variance; you must go fully linear. `anneal-svm ≈ svm` because `n_good` rarely clears the K=8
+switch (positives stay sparse), so it's SVM almost throughout. All arms are **uniform within
+cross-calibration** (`make_head` keyed on the full labelset's `n_good`, reused for M0 + the fold
+sub-models) and use conformal on raw `decision_function` scores (no Platt).
+
+**Recommendation:** for the #2790 spike regime (sparse positives, few dozen votes) replace the
+MLP with a **linear head**. Caveat: validated to t≤60; the earlier MLP-vs-SVM study found the
+MLP overtakes by ~t=200 with abundant labels, so the full production answer is an **anneal keyed
+on `n_good`** (linear/SVM while sparse → MLP once rich) — only the sparse end is tested here.
+Tools: `--head-strategy {linear,svm,reg-mlp,anneal-*}`, `results_eval.py`.
+
 ## MECHANISM: what the hidden calibration catastrophe actually is (`calib_conditions.py`)
 
 Necessary+sufficient conditions, established by instrumenting the calibration (`_calib_diag`

--- a/scripts/experiments/threshold_stability/results_eval.py
+++ b/scripts/experiments/threshold_stability/results_eval.py
@@ -1,0 +1,82 @@
+"""Head-strategy (or any-arm) comparison straight from results.jsonl — trace-free.
+
+Avoids the /exp ENOSPC + the same-out-dir results.jsonl clobber (run each class to its own
+out-dir, no ``--labeling-trace``). Computes, per arm dir (globs all results.jsonl under it):
+the **deep-spike rate** (Δcost>0.1 between consecutive ``t`` within a (class,seed), MLP-regime
+only = ``calib_mode != cosine_coldstart``, ``t >= deep_t``), the median spike magnitude, and
+**cost=FNR+FPR / FNR / FPR** at fixed vote budgets. Usage: ``results_eval.py DIR LABEL [...]``.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def _load(root: Path):
+    g = defaultdict(list)
+    for f in root.rglob("results.jsonl"):
+        for line in f.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            g[(r.get("class"), r.get("seed"))].append(r)
+    return g
+
+
+def analyze(root: Path, label: str, deep_t: int = 20, thresh: float = 0.1):
+    g = _load(root)
+    mlp_steps = deep_steps = deep_spikes = 0
+    ups = []
+    budgets = [20, 40, 60]
+    cost = {b: [] for b in budgets}
+    fnr = {b: [] for b in budgets}
+    fpr = {b: [] for b in budgets}
+    for seq in g.values():
+        seq.sort(key=lambda r: r["t"])
+        for i in range(1, len(seq)):
+            if seq[i].get("calib_mode") == "cosine_coldstart":
+                continue
+            dc = seq[i]["cost"] - seq[i - 1]["cost"]
+            mlp_steps += 1
+            if (seq[i].get("t") or 0) >= deep_t:
+                deep_steps += 1
+                if dc > thresh:
+                    deep_spikes += 1
+                    ups.append(dc)
+        for b in budgets:
+            row = None
+            for r in seq:
+                if (r.get("t") or 0) <= b:
+                    row = r
+                else:
+                    break
+            if row is not None:
+                cost[b].append(row["cost"])
+                fnr[b].append(row["fnr"])
+                fpr[b].append(row["fpr"])
+
+    def m(x):
+        v = [a for a in x if a is not None]
+        return statistics.fmean(v) if v else float("nan")
+
+    dr = deep_spikes / deep_steps if deep_steps else float("nan")
+    print(f"{label:<11} cells={len(g):<4} deep-spike rate(t>={deep_t}) {dr:.3f}  "
+          f"med-up {statistics.median(ups) if ups else float('nan'):.3f}  ({deep_spikes}/{deep_steps})")  # fmt: skip
+    for b in budgets:
+        print(f"    @t={b:<3} cost {m(cost[b]):.3f}  FNR {m(fnr[b]):.3f}  FPR {m(fpr[b]):.3f}")
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+    for i in range(0, len(argv), 2):
+        analyze(Path(argv[i]), argv[i + 1])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sod/sweep.py
+++ b/scripts/sod/sweep.py
@@ -461,6 +461,7 @@ def _run_cell(cell: dict, args, cache_root: Path) -> list[dict]:
         soft_seek=args.soft_seek,
         recall_target=args.recall_target,
         stable_folds=args.stable_folds,
+        head_strategy=args.head_strategy,
     )
     rows: list[dict] = []
     if args.viz or args.labeling_trace:
@@ -675,6 +676,14 @@ def main() -> int:
         help="causal #2790 test: freeze the cross-calibration Train/Calibrate split (fold by "
         "append position, no per-step permutation) so an item's fold doesn't reshuffle when "
         "later votes arrive. Isolates whether the fold reshuffle drives the spikes.",
+    )
+    ap.add_argument(
+        "--head-strategy",
+        default="mlp",
+        choices=["mlp", "linear", "svm", "reg-mlp", "anneal-svm", "anneal-linear", "anneal-reg"],
+        help="anti-spike #2790 arm: model class for the calibration head, keyed on n_good and "
+        "uniform across M0 and the fold sub-models. linear/svm = low-variance throughout; "
+        "reg-mlp = capacity annealed within MLP; anneal-* = low-variance while n_good<8 then MLP.",
     )
     ap.add_argument("--cal-fraction", type=float, default=0.5)
     ap.add_argument("--scales", type=_floats, default=(1.0, 0.75, 0.5, 0.3))

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from vtscore.eval.error_metrics import f1_at, max_f1, min_weighted_cost, weighted_error
-from vtscore.eval.scoring_heads import CosineHead, MLPHead, max_pool_over_images, max_pool_with_argmax
+from vtscore.eval.scoring_heads import CosineHead, MLPHead, make_head, max_pool_over_images, max_pool_with_argmax
 from vtscore.eval.threshold_rules import calibrated_threshold, median_smooth
 from vtscore.eval.xcal import cross_calibrated_threshold
 
@@ -789,6 +789,7 @@ def _train_pool_head(
     cal_fraction: float,
     threshold_rule: str = "conformal",
     stable_folds: bool = False,
+    head_strategy: str = "mlp",
 ):
     """Train a head on the current good/bad votes; returns
     ``(predict_fn, raw_threshold, n_votes, calib_mode)`` or ``None`` on a
@@ -841,7 +842,10 @@ def _train_pool_head(
     neg = np.vstack([inputs.pool_whole_vecs[idx[i]][None, :] for i in bad]).astype(np.float32)
     x = np.vstack([pos, neg]).astype(np.float32)
     y = np.array([1.0] * pos.shape[0] + [0.0] * neg.shape[0], dtype=np.float32)
-    head = MLPHead(inputs.input_dim)
+    # #2790 anti-spike arms: pick the head by strategy, keyed on the FULL labelset's n_good
+    # (len(good)) — decided once and reused for M0 (fit) AND every fold sub-model (trainer_fn),
+    # so the cross-calibration stays uniform (never averages an SVM threshold for an MLP).
+    head = make_head(head_strategy, inputs.input_dim, len(good))
     raw_thr = calibrated_threshold(
         x,
         y,
@@ -928,6 +932,7 @@ def _resolve_step_head(
     good_to_start=3,
     bad_to_start=4,
     stable_folds=False,
+    head_strategy="mlp",
 ):
     """Return ``(cached, steps_since_train)`` for one step.
 
@@ -960,6 +965,7 @@ def _resolve_step_head(
             cal_fraction=cal_fraction,
             threshold_rule=threshold_rule,
             stable_folds=stable_folds,
+            head_strategy=head_strategy,
         )
         if res is not None:
             predict, raw_thr, n_votes, calib = res
@@ -1055,6 +1061,7 @@ def _realistic_one_seed(
     soft_seek: int = 0,
     recall_target: float = 0.0,
     stable_folds: bool = False,
+    head_strategy: str = "mlp",
 ) -> tuple[list[dict], dict | None]:
     """Run one seed's labeling loop. Returns ``(rows, final)`` where ``final`` is a dict
     ``{predict, threshold, n_good, n_bad, t, trace}`` for the last step (head + blended
@@ -1125,6 +1132,7 @@ def _realistic_one_seed(
             good_to_start=good_to_start,
             bad_to_start=bad_to_start,
             stable_folds=stable_folds,
+            head_strategy=head_strategy,
         )
         predict, raw_thr, n_votes, calib, blend = cached
 
@@ -1264,6 +1272,7 @@ def evaluate_realistic_curve(
     soft_seek: int = 0,
     recall_target: float = 0.0,
     stable_folds: bool = False,
+    head_strategy: str = "mlp",
 ) -> list[dict] | tuple[list[dict], dict[int, dict]]:
     """Realistic active-learning labeling curve: cost/fpr/fnr/F1/IoU vs ``t`` (total
     annotations), one row per ``(seed, t)``.
@@ -1310,6 +1319,7 @@ def evaluate_realistic_curve(
             soft_seek=soft_seek,
             recall_target=recall_target,
             stable_folds=stable_folds,
+            head_strategy=head_strategy,
         )
         # Amortize the seed's wall-clock over its rows (per-step retrain dominates).
         per = round((time.perf_counter() - t0) * 1000.0 / max(len(seed_rows), 1), 3)

--- a/vtscore/eval/scoring_heads.py
+++ b/vtscore/eval/scoring_heads.py
@@ -120,6 +120,116 @@ class MLPHead:
         return self._predict(region_matrix)
 
 
+class _SklearnHead:
+    """Base for low-variance sklearn heads (#2790 anti-spike arms). Scores by
+    ``decision_function`` — a monotone real score, which is all ``conformal_threshold``
+    (quantile-based) needs; no probability calibration. Raises ``ValueError`` on a
+    single-class fold, matching :class:`MLPHead` so the fold loop skips it identically."""
+
+    name = "sklearn"
+
+    def __init__(self, input_dim: int) -> None:
+        self.input_dim = int(input_dim)
+        self._predict: PredictFn | None = None
+
+    def _make(self, seed: int):  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def _train(self, x: np.ndarray, y: np.ndarray, seed: int) -> PredictFn:
+        ya = np.asarray(y)
+        if len({int(v) for v in ya}) < 2:
+            raise ValueError("single-class fold")
+        clf = self._make(seed).fit(np.asarray(x, dtype=np.float64), ya)
+
+        def predict(z: np.ndarray) -> np.ndarray:
+            return np.asarray(clf.decision_function(np.asarray(z, dtype=np.float64)), dtype=np.float64)
+
+        return predict
+
+    def trainer_fn(self) -> "TrainerFn":
+        return self._train
+
+    def fit(self, x: np.ndarray, y: np.ndarray, seed: int) -> None:
+        self._predict = self._train(x, y, seed)
+
+    def score_rows(self, region_matrix: np.ndarray) -> np.ndarray:
+        if self._predict is None:
+            raise RuntimeError(f"{type(self).__name__}.fit must be called before scoring")
+        return self._predict(region_matrix)
+
+
+class LinearHead(_SklearnHead):
+    """L2-regularized logistic regression — max-bias/min-variance reference (#2790)."""
+
+    name = "linear"
+
+    def _make(self, seed: int):
+        from sklearn.linear_model import LogisticRegression  # noqa: PLC0415
+
+        return LogisticRegression(max_iter=1000, C=1.0, class_weight="balanced")
+
+
+class SVMHead(_SklearnHead):
+    """Linear SVM (max-margin, low variance) — better than the MLP when positives are sparse
+    (our MLP-vs-SVM study: SVM wins early). #2790 anti-spike arm."""
+
+    name = "svm"
+
+    def _make(self, seed: int):
+        from sklearn.svm import SVC  # noqa: PLC0415
+
+        return SVC(kernel="linear", C=1.0, class_weight="balanced", random_state=seed)
+
+
+class RegMLPHead(MLPHead):
+    """MLP with capacity annealed on the FULL labelset's ``n_good`` — tiny hidden dim + dropout
+    while positives are sparse, relaxing as they accumulate (#2790). Stays one model class
+    (no SVM→MLP score-scale handoff), so it's uniform across M0 and the fold sub-models."""
+
+    name = "reg-mlp"
+
+    def __init__(self, input_dim: int, n_good: int) -> None:
+        super().__init__(input_dim)
+        # Tiny hidden layer while positives are sparse (fewer params → lower variance),
+        # relaxing toward the default (64) as they accumulate. hidden_dim is the capacity knob
+        # train_model exposes (dropout is internal/fixed).
+        self.hidden_dim = max(4, min(64, 4 * max(1, int(n_good))))
+
+    def _train(self, x: np.ndarray, y: np.ndarray, seed: int) -> PredictFn:
+        import torch  # noqa: PLC0415
+
+        from vtscore.training.mlp import train_model  # noqa: PLC0415
+
+        xt = torch.tensor(np.asarray(x, dtype=np.float32))
+        yt = torch.tensor(np.asarray(y, dtype=np.float32)).unsqueeze(1)
+        model = train_model(xt, yt, self.input_dim, seed=seed, hidden_dim=self.hidden_dim)
+        return _mlp_predict_factory(model)
+
+
+def make_head(strategy: str, input_dim: int, n_good: int, *, anneal_k: int = 8):
+    """Build the calibration head for a step, keyed on the FULL labelset's ``n_good`` (#2790).
+
+    Decided ONCE here and reused for both M0 (``fit``) and every fold sub-model (via
+    ``trainer_fn``), so the cross-calibration stays **uniform** — we never average an SVM
+    threshold to calibrate an MLP. Anneal arms switch class at ``n_good == anneal_k``.
+    """
+    if strategy == "mlp":
+        return MLPHead(input_dim)
+    if strategy == "linear":
+        return LinearHead(input_dim)
+    if strategy == "svm":
+        return SVMHead(input_dim)
+    if strategy == "reg-mlp":
+        return RegMLPHead(input_dim, n_good)
+    if strategy == "anneal-svm":
+        return SVMHead(input_dim) if n_good < anneal_k else MLPHead(input_dim)
+    if strategy == "anneal-linear":
+        return LinearHead(input_dim) if n_good < anneal_k else MLPHead(input_dim)
+    if strategy == "anneal-reg":
+        return RegMLPHead(input_dim, n_good) if n_good < anneal_k else MLPHead(input_dim)
+    raise ValueError(f"unknown head strategy {strategy!r}")
+
+
 class CosineHead:
     """Zero-shot head: cosine to a fixed (L2-normalized) query vector."""
 


### PR DESCRIPTION
Follow-up to #2806 (merged). Delivers a **fix** for the #2790 deep-spike catastrophe, plus the earlier score/cut decomposition clarification.

## The fix: a low-variance (linear) head
The deep spikes are ~85% under-determined-MLP score variance (see #2806 / the MECHANISM section). So the direct fix is a lower-variance model while positives are sparse. Head-strategy sweep (20 COCO classes × 15 seeds, SigLIP 2, MLP-regime, t≥20):

| head | deep-spike rate | @t60 cost (FNR+FPR) | @t60 FNR |
|---|---|---|---|
| `mlp` (baseline) | 0.055 | 0.386 | 0.365 |
| **`linear`** (logistic) | **0.025** | **0.352** | **0.299** |
| **`svm`** (linear) | **0.023** | 0.356 | 0.308 |
| `reg-mlp` | 0.042 | 0.381 | 0.310 |
| `anneal-svm` | 0.026 | 0.364 | 0.319 |

A **linear head cuts the deep-spike rate ~55–58% AND improves the customer metric** (cost ↓, FNR ↓ — catches *more* needles) for a modest FPR rise. Not a trade — a **Pareto win**, confirming the spikes are MLP over-flexibility. `reg-mlp` (small hidden layer) helps far less — must go fully linear. `anneal-svm ≈ svm` (n_good rarely clears the K=8 switch).

**New knobs/tools** (default `mlp` byte-identical; 42+16 tests pass): `--head-strategy {linear,svm,reg-mlp,anneal-{svm,linear,reg}}` with `make_head` (uniform across M0 + fold sub-models per the cross-calibration requirement; conformal on raw `decision_function`, no Platt); `results_eval.py` (trace-free arm comparison from `results.jsonl`).

**Recommendation:** linear head in the #2790 sparse regime; full production answer is an anneal keyed on `n_good` (linear/SVM while sparse → MLP once rich; MLP overtakes ~t=200 per the earlier study — only t≤60 tested here).

## Also: decomposition clarification
The score/cut spike split is a **credit-attribution** (not a partition of spikes): credit for the recall *loss* is **~67% under-determined model / ~33% moving cut** (signed), and most of that cut third is *downstream* of the model variance (only ~13% is the removable fold reshuffle).

Refs #2790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)