### PR TITLE
Wait out the Find → Browse map build in Find, behind a progress bar

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5187,6 +5187,12 @@
             "nullable": true,
             "type": "string"
           },
+          "overall": {
+            "default": null,
+            "description": "Whole-job completion fraction (0..1) stitched from the current phase and its within-phase counts, so one bar fills across the entire build instead of restarting at each phase.",
+            "nullable": true,
+            "type": "number"
+          },
           "point_count": {
             "default": null,
             "nullable": true,
@@ -5201,6 +5207,12 @@
             "description": "idle | building | ready | error",
             "type": "string"
           },
+          "step": {
+            "default": null,
+            "description": "Which coarse build phase is running (1-based).",
+            "nullable": true,
+            "type": "integer"
+          },
           "tile_span": {
             "default": null,
             "nullable": true,
@@ -5208,6 +5220,12 @@
           },
           "total": {
             "default": null,
+            "nullable": true,
+            "type": "integer"
+          },
+          "total_steps": {
+            "default": null,
+            "description": "How many coarse phases the whole build has.",
             "nullable": true,
             "type": "integer"
           }

--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -10,9 +10,11 @@
       <div class="browse-status">
         <p class="browse-status-message">Building the map…</p>
         <vt-progress-bar
-          [indeterminate]="buildTotal() <= 0"
-          [value]="buildProgress()"
-          [max]="buildTotal()"
+          [indeterminate]="buildBar().indeterminate"
+          [pulsing]="!!buildBar().pulsing"
+          [smooth]="true"
+          [value]="buildBar().value"
+          [max]="buildBar().max"
         />
         <!-- Reserved-height lines so the count/detail appearing or disappearing
              doesn't re-center the column and shift the bar above it. -->
@@ -21,7 +23,7 @@
             {{ buildProgress() }} / {{ buildTotal() }}
           }
         </span>
-        <span class="browse-status-detail">{{ buildMessage() }}</span>
+        <span class="browse-status-detail">{{ buildDetail() }}</span>
       </div>
     }
     @case ('error') {

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -38,6 +38,7 @@ import {
 } from '../browse-canvas/hex-render.util';
 import type { ProjectionMeta, RegionLabelPayload } from '../../models/projection.models';
 import { snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
+import { progressBarState } from '../../utils/format-progress';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
@@ -130,6 +131,31 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   readonly buildProgress = signal(0);
   readonly buildTotal = signal(0);
   readonly buildMessage = signal('');
+  /** Whole-job build position: which coarse phase (arranging → tiling →
+   *  naming regions) is running, and the stitched 0..1 fraction across all of
+   *  them, both reported by the projection meta. */
+  readonly buildStep = signal<number | null>(null);
+  readonly buildTotalSteps = signal<number | null>(null);
+  readonly buildOverall = signal<number | null>(null);
+
+  /** `<vt-progress-bar>` inputs for the build state, preferring the whole-job
+   *  ``overall`` fraction so the bar fills once across the build rather than
+   *  restarting at each phase. */
+  readonly buildBar = computed(() =>
+    progressBarState({
+      current: this.buildProgress(),
+      total: this.buildTotal(),
+      overall: this.buildOverall(),
+    }),
+  );
+
+  /** Phase line under the bar: `"Step 2 of 3 · building pyramid"`. */
+  readonly buildDetail = computed(() => {
+    const step = this.buildStep();
+    const totalSteps = this.buildTotalSteps();
+    const phase = step != null && totalSteps != null && totalSteps > 1 ? `Step ${step} of ${totalSteps}` : '';
+    return [phase, this.buildMessage()].filter(Boolean).join(' · ');
+  });
 
   /**
    * Discrete thumbnail-size multipliers, one per named icon size (XS…XL),
@@ -1186,10 +1212,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       );
       return;
     }
-    this.status.set('building');
-    this.buildProgress.set(0);
-    this.buildTotal.set(0);
-    this.buildMessage.set('');
+    this.enterBuilding();
     this.buildRequest()
       .pipe(takeUntil(this.destroy$))
       .subscribe({
@@ -1226,10 +1249,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     // arm the one-shot survive mark so the canvas keeps it when the fresh
     // projection id lands, instead of treating the re-fit as a new projection.
     this.selection.markSurviveProjectionChange();
-    this.status.set('building');
-    this.buildProgress.set(0);
-    this.buildTotal.set(0);
-    this.buildMessage.set('');
+    this.enterBuilding();
     const request$ = this.subset
       ? this.projectionApi.reprojectSubset(this.subsetIds)
       : this.projectionApi.reproject();
@@ -1382,6 +1402,22 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     return this.mediaTypeCaps.usesThumbnails(this.mediaType()) ? 'Loading thumbnails…' : 'Loading map…';
   }
 
+  /** Enter the building state with a cleared bar (a fresh build starts at 0). */
+  private enterBuilding(): void {
+    this.status.set('building');
+    this.applyBuildProgress(null);
+  }
+
+  /** Mirror a meta's build progress onto the bar's signals. */
+  private applyBuildProgress(meta: ProjectionMeta | null): void {
+    this.buildProgress.set(meta?.current ?? 0);
+    this.buildTotal.set(meta?.total ?? 0);
+    this.buildMessage.set(meta?.message ?? '');
+    this.buildStep.set(meta?.step ?? null);
+    this.buildTotalSteps.set(meta?.total_steps ?? null);
+    this.buildOverall.set(meta?.overall ?? null);
+  }
+
   private loadProjection(): void {
     this.status.set('loading');
     this.polling = false;
@@ -1430,9 +1466,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     if (meta.status === 'building') {
       // A build is already in flight (e.g. started at ingest); track it.
       this.status.set('building');
-      this.buildProgress.set(meta.current ?? 0);
-      this.buildTotal.set(meta.total ?? 0);
-      this.buildMessage.set(meta.message ?? '');
+      this.applyBuildProgress(meta);
       this.pollBuildStatus();
       return;
     }
@@ -1469,9 +1503,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
               this.errorMessage.set(meta.error || 'Failed to build the map');
               return;
             }
-            this.buildProgress.set(meta.current ?? 0);
-            this.buildTotal.set(meta.total ?? 0);
-            this.buildMessage.set(meta.message ?? '');
+            this.applyBuildProgress(meta);
             this.pollTimer = setTimeout(poll, 1000);
           },
           error: () => {

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -23,7 +23,7 @@
       [textQuery]="sortState.textQuery"
       [datasetName]="datasetName()"
       [panelMode]="'find'"
-      [disabled]="sortState.sortBusy"
+      [disabled]="waiting"
       [autopilotCollapsed]="false"
       [autopilotEnabled]="false"
       (mediaSelect)="onMediaSelect($event)"
@@ -62,10 +62,37 @@
           <button class="btn btn--secondary btn--sm" (click)="onSortCancel()">Cancel</button>
         </div>
       </div>
+    } @else if (browsePrep.preparing()) {
+      <!-- Browse builds its map here, in Find, rather than dropping the user
+           into an empty browse view to watch it fit (issue: the black screen). -->
+      <div class="find-wait-overlay" role="status" aria-live="polite">
+        <div class="find-wait-content">
+          <p class="find-wait-message">Please wait: building the map to browse…</p>
+          <vt-progress-bar
+            [indeterminate]="browsePrep.bar().indeterminate"
+            [pulsing]="!!browsePrep.bar().pulsing"
+            [smooth]="true"
+            [value]="browsePrep.bar().value"
+            [max]="browsePrep.bar().max"
+          />
+          <!-- Reserved-height lines so the count/phase appearing or disappearing
+               doesn't re-center the column and shift the bar above it. -->
+          <span class="find-wait-count">
+            @if (browsePrep.count()) {
+              {{ browsePrep.count() }}
+            }
+            @if (browsePrep.eta()) {
+              <span class="find-wait-eta">{{ browsePrep.eta() }}</span>
+            }
+          </span>
+          <span class="find-wait-detail">{{ browsePrep.detail() }}</span>
+          <button class="btn btn--secondary btn--sm" (click)="browsePrep.cancel()">Cancel</button>
+        </div>
+      </div>
     }
     <vt-center-panel
       [media]="mediaState.selectedMedia"
-      [disabled]="sortState.sortBusy"
+      [disabled]="waiting"
       (mediaVoted)="onMediaVoted($event)"
     />
   </div>
@@ -77,7 +104,7 @@
     <vt-right-panel
       [medias]="mediaState.mediasSignal()"
       [focusMode]="focusModeRight()"
-      [disabled]="sortState.sortBusy"
+      [disabled]="waiting"
       mode="find"
       (mediaSelected)="onMediaSelect($event)"
       (mediaVoted)="onHoverVote($event)"

--- a/frontend/src/app/components/find-view/find-view.component.scss
+++ b/frontend/src/app/components/find-view/find-view.component.scss
@@ -77,3 +77,13 @@
 .find-wait-eta {
   color: var(--text-muted);
 }
+
+// Phase line under the bar ("Step 2 of 3 · building pyramid"). Reserves its
+// height like the count above it so phase changes never re-center the column.
+.find-wait-detail {
+  font-size: var(--font-sm);
+  color: var(--text-muted);
+  text-align: center;
+  line-height: 1.4;
+  min-height: 1.4em;
+}

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, NgZone, OnDestroy, OnInit, signal, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Router } from '@angular/router';
 import { Subject, Subscription } from 'rxjs';
 import { finalize, takeUntil } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
@@ -72,7 +71,6 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private browseSubset = inject(BrowseSubsetService);
   /** Public: the wait overlay binds this service's progress signals directly. */
   browsePrep = inject(BrowseSubsetPrepService);
-  private router = inject(Router);
 
   readonly layoutRef = viewChild.required<ElementRef<HTMLElement>>('layout');
   readonly centerPanel = viewChild(CenterPanelComponent);

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -26,6 +26,7 @@ import { SortingApiService } from '../../services/sorting-api.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { ProgressEventsService } from '../../services/progress-events.service';
 import { BrowseSubsetService } from '../../services/browse-subset.service';
+import { BrowseSubsetPrepService } from '../../services/browse-subset-prep.service';
 import { ProgressEvent } from '../../models/api.models';
 import {
   ProgressBarState,
@@ -69,6 +70,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private settingsState = inject(SettingsStateService);
   private progressEvents = inject(ProgressEventsService);
   private browseSubset = inject(BrowseSubsetService);
+  /** Public: the wait overlay binds this service's progress signals directly. */
+  browsePrep = inject(BrowseSubsetPrepService);
   private router = inject(Router);
 
   readonly layoutRef = viewChild.required<ElementRef<HTMLElement>>('layout');
@@ -288,6 +291,11 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.destroy$.complete();
     this.voteState.setFindMode(false);
     this.voteState.stopPolling();
+    // Stop waiting on a map build if the user left Find some other way (the
+    // top bar, a context switch) — nothing should yank them into the browse
+    // view from a screen they already walked away from. A no-op on the
+    // handoff itself, which clears the wait before it navigates.
+    this.browsePrep.cancel();
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
     document.removeEventListener('mousemove', this.boundRightMouseMove);
@@ -297,6 +305,15 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   // --- Find-label scoring ---
 
   private progressPollSub: Subscription | null = null;
+
+  /**
+   * Whether Find is parked behind a wait overlay — either the detector scoring
+   * run or a Browse map build. Both block the three panels the same way, so
+   * every `[disabled]` binding reads this rather than one specific wait.
+   */
+  get waiting(): boolean {
+    return this.sortState.sortBusy || this.browsePrep.preparing();
+  }
 
   /** Unified bar state for the scoring overlay: prefers the whole-job
    *  ``overall`` fraction so the bar fills once across all Find phases. */
@@ -726,17 +743,14 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   /**
-   * Stash *ids* for the browse view and navigate to
-   * `/browse/:datasetId?subset=1`, where they're UMAP'd on their own.
+   * Build the map for *ids* — a UMAP fit over just those items — behind Find's
+   * wait overlay, and hand off to `/browse/:datasetId?subset=1` only once it's
+   * ready. The fit can run for minutes on a large positive set, so it happens
+   * *here*, where the user has a progress bar and a Cancel, rather than in the
+   * browse view, which has nothing to draw until the layout lands.
    */
   private browseIds(ids: number[]): void {
-    const datasetId = this.activeContext.datasetId;
-    if (!datasetId || ids.length === 0) return;
-    this.browseSubset.set({
-      datasetId,
-      ids,
-    });
-    this.router.navigate(['/browse', datasetId], { queryParams: { subset: 1 } });
+    this.browsePrep.start(this.activeContext.datasetId, ids);
   }
 
   /**

--- a/frontend/src/app/models/projection.models.ts
+++ b/frontend/src/app/models/projection.models.ts
@@ -106,6 +106,20 @@ export interface ProjectionMeta {
   current?: number;
   total?: number;
   message?: string;
+  /**
+   * Which coarse build phase is running, and how many the build has in total
+   * (arranging → tiling → naming regions). The UMAP fit reports no fraction of
+   * its own, so phase position is the only honest "how far along" signal for
+   * the longest stretch of the build.
+   */
+  step?: number | null;
+  total_steps?: number | null;
+  /**
+   * Whole-job completion fraction (0..1) stitched from {@link step} and the
+   * within-phase counts, so one bar fills across the entire build instead of
+   * restarting at each phase. Mirrors ``ProgressEvent.overall``.
+   */
+  overall?: number | null;
   error?: string;
 }
 

--- a/frontend/src/app/services/browse-prep.service.ts
+++ b/frontend/src/app/services/browse-prep.service.ts
@@ -20,6 +20,13 @@ interface BrowsePrepState {
   current: number;
   total: number;
   message: string;
+  /** Whole-job build position reported by the projection meta: which coarse
+   *  phase (arranging → tiling → naming regions) is running, and the stitched
+   *  0..1 fraction across all of them. Carried onto the synthetic row so the
+   *  dashboard bar fills once across the build instead of restarting per phase. */
+  step: number | null;
+  totalSteps: number | null;
+  overall: number | null;
   error: string;
 }
 
@@ -78,6 +85,9 @@ export class BrowsePrepService {
       current: 0,
       total: 0,
       message: 'Loading dataset…',
+      step: null,
+      totalSteps: null,
+      overall: null,
       error: '',
     });
 
@@ -156,13 +166,26 @@ export class BrowsePrepService {
     if (s.phase === 'error') {
       return this.synthTask(datasetId, 'idle', '', 0, 0, s.error);
     }
-    return this.synthTask(datasetId, 'building', s.message, s.current, s.total, '');
+    return {
+      ...this.synthTask(datasetId, 'building', s.message, s.current, s.total, ''),
+      step: s.step,
+      total_steps: s.totalSteps,
+      overall: s.overall,
+    };
   }
 
   // --- projection phase ---
 
   private startProjection(datasetId: string): void {
-    this.patch({ phase: 'projecting', current: 0, total: 0, message: 'Building the map…' });
+    this.patch({
+      phase: 'projecting',
+      current: 0,
+      total: 0,
+      message: 'Building the map…',
+      step: null,
+      totalSteps: null,
+      overall: null,
+    });
     this.pollErrors = 0;
     this.projectionApi
       .getMeta()
@@ -189,6 +212,9 @@ export class BrowsePrepService {
         current: meta.current ?? 0,
         total: meta.total ?? 0,
         message: meta.message || 'Building the map…',
+        step: meta.step ?? null,
+        totalSteps: meta.total_steps ?? null,
+        overall: meta.overall ?? null,
       });
       this.schedulePoll(datasetId);
       return;

--- a/frontend/src/app/services/browse-subset-prep.service.spec.ts
+++ b/frontend/src/app/services/browse-subset-prep.service.spec.ts
@@ -1,0 +1,216 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { BrowseSubsetPrepService } from './browse-subset-prep.service';
+import { BrowseSubsetService } from './browse-subset.service';
+import { ProjectionApiService } from './projection-api.service';
+import { ToastService } from './toast.service';
+import { configureZoneless } from '../testing/zoneless-testbed';
+import type { ProjectionBuildResponse, ProjectionMeta } from '../models/projection.models';
+
+/**
+ * The Find view's Browse button must build its map **in Find**, behind a
+ * progress bar, and only then hand off to the browse view — never drop the user
+ * into an empty browse window to watch a multi-minute UMAP fit. These tests pin
+ * that contract: no navigation until the layout is ready, a live whole-job bar
+ * while it builds, and failures that leave the user in Find.
+ */
+describe('BrowseSubsetPrepService', () => {
+  let service: BrowseSubsetPrepService;
+  let router: Router;
+  let subsetHandoff: BrowseSubsetService;
+  let toastErrors: string[];
+
+  // Reassigned per test to script the build/meta responses.
+  let metaProvider: () => Observable<ProjectionMeta>;
+  let buildProvider: () => Observable<ProjectionBuildResponse>;
+  let buildIds: number[][];
+
+  const DS = 'ds1';
+  const IDS = [3, 1, 4];
+
+  function meta(overrides: Partial<ProjectionMeta>): ProjectionMeta {
+    return {
+      projection_id: 'p',
+      bounds: [0, 0, 1, 1],
+      base_radius: 1,
+      tile_span: 1,
+      point_count: 0,
+      levels: [],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    metaProvider = () => of(meta({ status: 'building' }));
+    buildProvider = () => of({ status: 'building' });
+    buildIds = [];
+    toastErrors = [];
+
+    const projectionApiStub = {
+      getMeta: (): Observable<ProjectionMeta> => metaProvider(),
+      buildSubset: (ids: number[]): Observable<ProjectionBuildResponse> => {
+        buildIds.push(ids);
+        return buildProvider();
+      },
+    };
+    const toastStub = {
+      error: (opts: { message: string }) => {
+        toastErrors.push(opts.message);
+        return 0;
+      },
+    };
+
+    configureZoneless({
+      providers: [
+        provideRouter([]),
+        { provide: ProjectionApiService, useValue: projectionApiStub },
+        { provide: ToastService, useValue: toastStub },
+      ],
+    });
+
+    service = TestBed.inject(BrowseSubsetPrepService);
+    subsetHandoff = TestBed.inject(BrowseSubsetService);
+    router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  });
+
+  it('navigates straight through when the layout is already fit', () => {
+    buildProvider = () => of({ status: 'ready' });
+
+    service.start(DS, IDS);
+
+    expect(buildIds).toEqual([IDS]);
+    expect(router.navigate).toHaveBeenCalledWith(['/browse', DS], {
+      queryParams: { subset: 1 },
+    });
+    expect(subsetHandoff.take()).toEqual({ datasetId: DS, ids: IDS });
+    expect(service.preparing()).toBe(false);
+  });
+
+  it('holds the user in Find with a whole-job bar until the build lands', async () => {
+    vi.useFakeTimers();
+    try {
+      service.start(DS, IDS);
+
+      // Still in Find: the wait is up and nothing has navigated.
+      expect(service.preparing()).toBe(true);
+      expect(router.navigate).not.toHaveBeenCalled();
+
+      // Mid-build: the bar reads the whole-job fraction, and the phase line
+      // names which of the build's steps is running.
+      metaProvider = () =>
+        of(
+          meta({
+            status: 'building',
+            current: 1,
+            total: 2,
+            message: 'building pyramid',
+            step: 2,
+            total_steps: 3,
+            overall: 0.5,
+          }),
+        );
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(service.bar()).toMatchObject({ value: 0.5, max: 1, indeterminate: false });
+      expect(service.count()).toBe('1 / 2');
+      expect(service.detail()).toBe('Step 2 of 3 · building pyramid');
+      expect(router.navigate).not.toHaveBeenCalled();
+
+      // The layout lands → hand off to the browse view.
+      metaProvider = () => of(meta({ status: 'ready', point_count: 3 }));
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(router.navigate).toHaveBeenCalledWith(['/browse', DS], {
+        queryParams: { subset: 1 },
+      });
+      expect(service.preparing()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('pulses in place while a phase reports no counts of its own', async () => {
+    vi.useFakeTimers();
+    try {
+      service.start(DS, IDS);
+      metaProvider = () =>
+        of(
+          meta({
+            status: 'building',
+            message: 'UMAP fit (900 points) — 12s elapsed',
+            step: 1,
+            total_steps: 3,
+            overall: 0,
+          }),
+        );
+      await vi.advanceTimersByTimeAsync(1000);
+
+      // The UMAP fit has no fraction to report, so the bar keeps its earned
+      // fill and shimmers rather than pretending to advance.
+      expect(service.bar().pulsing).toBe(true);
+      expect(service.count()).toBe('');
+      expect(service.detail()).toBe('Step 1 of 3 · UMAP fit (900 points) — 12s elapsed');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('leaves the user in Find when the build fails', async () => {
+    vi.useFakeTimers();
+    try {
+      service.start(DS, IDS);
+      metaProvider = () => of(meta({ status: 'error', error: 'no embeddings' }));
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(toastErrors).toEqual(['no embeddings']);
+      expect(router.navigate).not.toHaveBeenCalled();
+      expect(service.preparing()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('drops the wait when the build request itself is rejected', () => {
+    buildProvider = () =>
+      throwError(() => new HttpErrorResponse({ status: 409, error: { message: 'nope' } }));
+
+    service.start(DS, IDS);
+
+    // The global error interceptor already toasted the rejection; all this
+    // service owes the user is releasing the Find view.
+    expect(service.preparing()).toBe(false);
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('cancelling stops the poll and leaves no stale handoff behind', async () => {
+    vi.useFakeTimers();
+    try {
+      service.start(DS, IDS);
+      service.cancel();
+      expect(service.preparing()).toBe(false);
+
+      // A late "ready" must not yank a user who walked away into the browser.
+      metaProvider = () => of(meta({ status: 'ready', point_count: 3 }));
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(router.navigate).not.toHaveBeenCalled();
+      expect(subsetHandoff.take()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores an empty selection and a second start while preparing', () => {
+    service.start(DS, []);
+    expect(buildIds).toEqual([]);
+    expect(service.preparing()).toBe(false);
+
+    service.start(DS, IDS);
+    service.start(DS, [9, 9]);
+    expect(buildIds).toEqual([IDS]);
+  });
+});

--- a/frontend/src/app/services/browse-subset-prep.service.ts
+++ b/frontend/src/app/services/browse-subset-prep.service.ts
@@ -1,0 +1,203 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { take } from 'rxjs/operators';
+import { BrowseSubsetService } from './browse-subset.service';
+import { ProjectionApiService } from './projection-api.service';
+import { ToastService } from './toast.service';
+import { formatEta, progressBarState } from '../utils/format-progress';
+import type { ProgressEvent } from '../models/api.models';
+import type { ProjectionMeta } from '../models/projection.models';
+
+/** How often the in-flight subset build is polled for progress. */
+const POLL_MS = 1000;
+/** Consecutive poll failures tolerated before giving up on the build. */
+const MAX_POLL_ERRORS = 5;
+
+/**
+ * Orchestrates the Find view's **Browse** buttons: build the ephemeral subset
+ * projection (a UMAP fit over just this run's positives) *while the user is
+ * still in Find*, showing progress there, and navigate to the browse view only
+ * once the map is ready.
+ *
+ * This exists because a Find-positives browse can take minutes to fit, and the
+ * browse view has nothing to render until it lands — navigating first stranded
+ * the user on an empty canvas watching a status line, which is not how any
+ * other wait in the app behaves. Every long operation in Find (detector
+ * scoring, dataset loads) keeps the user where they are behind a progress bar,
+ * and this makes Browse do the same. It is the Find-side sibling of
+ * {@link BrowsePrepService}, which does the equivalent job for the dashboard's
+ * full-dataset Browse button.
+ *
+ * Progress rides ``GET /api/projection/meta?subset=1``, which reports the
+ * build's coarse phase (arranging → tiling → naming regions) plus a whole-job
+ * ``overall`` fraction, so the bar fills once across the build rather than
+ * restarting per phase.
+ */
+@Injectable({ providedIn: 'root' })
+export class BrowseSubsetPrepService {
+  private router = inject(Router);
+  private projectionApi = inject(ProjectionApiService);
+  private browseSubset = inject(BrowseSubsetService);
+  private toast = inject(ToastService);
+
+  /** True while a build is in flight, i.e. while Find shows the wait overlay. */
+  readonly preparing = signal(false);
+  /**
+   * The latest build progress, shaped as a {@link ProgressEvent} so it feeds
+   * the same `progressBarState` / `formatEta` helpers every other progress
+   * surface in the app uses.
+   */
+  readonly progress = signal<ProgressEvent | null>(null);
+
+  /** Resolved `<vt-progress-bar>` inputs for the current build. */
+  readonly bar = computed(() => progressBarState(this.progress()));
+
+  /** `"12 / 345"` for the phase's own counts, or `''` when it has none. */
+  readonly count = computed(() => {
+    const p = this.progress();
+    const total = p?.total ?? 0;
+    if (total <= 0) return '';
+    return `${(p?.current ?? 0).toLocaleString()} / ${total.toLocaleString()}`;
+  });
+
+  /**
+   * The phase line under the bar: `"Step 2 of 3 · building pyramid"`. The step
+   * counter is what makes the wait legible — the UMAP fit is one opaque call
+   * that reports no fraction of its own (it ticks elapsed seconds into the
+   * message instead), so knowing which of three phases is running is the only
+   * honest sense of how much work is left.
+   */
+  readonly detail = computed(() => {
+    const p = this.progress();
+    const step = p?.step;
+    const totalSteps = p?.total_steps;
+    const phase = step != null && totalSteps != null && totalSteps > 1 ? `Step ${step} of ${totalSteps}` : '';
+    return [phase, p?.message].filter(Boolean).join(' · ');
+  });
+
+  readonly eta = computed(() => formatEta(this.progress()?.eta_seconds));
+
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private pollErrors = 0;
+  private datasetId = '';
+  private ids: number[] = [];
+
+  /**
+   * Build the subset projection over *ids* and, when it's ready, hand off to
+   * `/browse/:datasetId?subset=1`. No-ops on an empty selection or while a
+   * previous preparation is still running.
+   */
+  start(datasetId: string, ids: number[]): void {
+    if (this.preparing() || !datasetId || ids.length === 0) return;
+    this.datasetId = datasetId;
+    this.ids = ids;
+    this.pollErrors = 0;
+    this.preparing.set(true);
+    this.progress.set({ message: 'Arranging the items…' });
+
+    this.projectionApi
+      .buildSubset(ids)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          if (!this.preparing()) return;
+          if (resp.status === 'ready') {
+            // Already fit (an unchanged subset re-binned from the cached
+            // layout) — go straight through with no visible wait.
+            this.finish();
+            return;
+          }
+          this.schedulePoll();
+        },
+        // The build POST raises the global error toast on its own, so there's
+        // nothing to say here beyond dropping the overlay and staying in Find.
+        error: () => this.clear(),
+      });
+  }
+
+  /**
+   * Abandon the wait and stay in Find. The background fit keeps running
+   * server-side (it has no cancellation hook, and its result is cached by
+   * signature), so pressing Browse again picks the same job back up rather
+   * than starting a second fit.
+   */
+  cancel(): void {
+    this.clear();
+  }
+
+  // --- polling ------------------------------------------------------------
+
+  private schedulePoll(): void {
+    this.clearTimer();
+    this.pollTimer = setTimeout(() => {
+      if (!this.preparing()) return;
+      this.projectionApi
+        .getMeta(true)
+        .pipe(take(1))
+        .subscribe({
+          next: (meta) => {
+            this.pollErrors = 0;
+            this.handleMeta(meta);
+          },
+          error: () => {
+            this.pollErrors += 1;
+            if (this.pollErrors >= MAX_POLL_ERRORS) {
+              this.fail('Lost contact with the server while building the map.');
+              return;
+            }
+            this.schedulePoll();
+          },
+        });
+    }, POLL_MS);
+  }
+
+  private handleMeta(meta: ProjectionMeta): void {
+    if (!this.preparing()) return;
+    if (meta.point_count > 0) {
+      this.finish();
+      return;
+    }
+    if (meta.status === 'error') {
+      this.fail(meta.error || 'Failed to build the map');
+      return;
+    }
+    this.progress.set({
+      message: meta.message ?? '',
+      current: meta.current ?? 0,
+      total: meta.total ?? 0,
+      step: meta.step ?? null,
+      total_steps: meta.total_steps ?? null,
+      overall: meta.overall ?? null,
+    });
+    this.schedulePoll();
+  }
+
+  /** The map is ready: hand the ids to the browse view and navigate. */
+  private finish(): void {
+    const datasetId = this.datasetId;
+    const ids = this.ids;
+    this.clear();
+    // Set the handoff only now, so a cancelled preparation never leaves a
+    // stale pending subset behind for the next browse to pick up.
+    this.browseSubset.set({ datasetId, ids });
+    this.router.navigate(['/browse', datasetId], { queryParams: { subset: 1 } });
+  }
+
+  private fail(message: string): void {
+    this.clear();
+    this.toast.error({ message, dedupKey: 'find-browse-build-error' });
+  }
+
+  private clear(): void {
+    this.clearTimer();
+    this.preparing.set(false);
+    this.progress.set(null);
+  }
+
+  private clearTimer(): void {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+}

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -148,6 +148,58 @@ class TestProjectionMeta:
         assert meta["status"] == "ready"
         assert meta["point_count"] > 0
 
+    @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
+    def test_building_reports_phase_and_overall(self, _mock_fit, client):
+        """A build in flight reports which phase it's in and a whole-job fraction.
+
+        The Find view now waits out a Browse map build *in Find*, behind a
+        progress bar, instead of dropping the user into an empty browse view.
+        That bar needs to show total work and position, and the UMAP fit itself
+        reports no fraction of its own — so the meta carries the coarse phase
+        (``step``/``total_steps``) plus an ``overall`` fraction stitched from the
+        phase and its within-phase counts.
+        """
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _blocker(job):
+            started.set()
+            release.wait(timeout=30)
+
+        # Park the build in the pending slot so its job is inspectable and
+        # nothing races with the phase we stamp on it below.
+        projection_jobs.start(("blocker",), _blocker, dataset_id="__other__")
+        assert started.wait(timeout=5)
+
+        try:
+            build_body = client.post("/api/projection/build").get_json()
+            assert build_body["status"] == "building"
+            job = projection_jobs.get(build_body["job_id"])
+            assert job is not None
+
+            # Phase 1 of 3, no within-phase counts (the UMAP fit's shape).
+            job.set_phase(1, 3, "arranging items")
+            meta = client.get("/api/projection/meta").get_json()
+            assert meta["status"] == "building"
+            assert (meta["step"], meta["total_steps"]) == (1, 3)
+            assert meta["message"] == "arranging items"
+            assert meta["overall"] == pytest.approx(0.0)
+
+            # Halfway through phase 2 of 3 → one third plus half of a third.
+            job.set_phase(2, 3, "building pyramid")
+            job.update_progress(1, 2, "building pyramid")
+            meta = client.get("/api/projection/meta").get_json()
+            assert (meta["step"], meta["total_steps"]) == (2, 3)
+            assert meta["overall"] == pytest.approx(0.5)
+        finally:
+            release.set()
+
+        build_job = projection_jobs.get(build_body["job_id"])
+        assert build_job is not None
+        assert build_job.done_event.wait(timeout=30)
+
 
 class TestProjectionBuild:
     """``POST /api/projection/build`` background job lifecycle."""

--- a/tests_lib/integration/test_async_jobs.py
+++ b/tests_lib/integration/test_async_jobs.py
@@ -605,3 +605,33 @@ class TestRunningJobCancellation:
         assert pending.status == "done"
         assert pending.result == {"signature": "sig-B"}
         assert marker == ["start", "sig-B"]
+
+
+class TestPhaseProgress:
+    """``AsyncJob.set_phase`` — the multi-phase progress structure."""
+
+    def test_phase_defaults_to_single_phase(self):
+        job = AsyncJob(job_id="j1")
+        assert (job.step, job.total_steps) == (0, 0)
+
+    def test_set_phase_records_position_and_clears_within_phase_counts(self):
+        """Entering a phase zeroes the counts left over from the previous one.
+
+        The within-phase ``current``/``total`` describe the phase being *left*;
+        carrying them into the next phase would make a poller draw a bar that
+        is momentarily complete for work that hasn't started.
+        """
+        job = AsyncJob(job_id="j1")
+        job.update_progress(7, 7, "arranging items")
+
+        job.set_phase(2, 3, "building pyramid")
+
+        assert (job.step, job.total_steps) == (2, 3)
+        assert (job.current, job.total) == (0, 0)
+        assert job.message == "building pyramid"
+
+    def test_set_phase_keeps_the_previous_message_when_given_none(self):
+        job = AsyncJob(job_id="j1")
+        job.update_progress(1, 2, "arranging items")
+        job.set_phase(2, 3)
+        assert job.message == "arranging items"

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -53,6 +53,11 @@ class AsyncJob:
     current: int = 0
     total: int = 0
     message: str = ""
+    #: Optional multi-phase structure for jobs that walk a fixed sequence of
+    #: steps (see :meth:`set_phase`).  ``0`` means "single-phase job"; pollers
+    #: that render a whole-job bar skip the step decoration then.
+    step: int = 0
+    total_steps: int = 0
     started_at: float = 0.0
     cancel_event: threading.Event = field(default_factory=threading.Event)
     done_event: threading.Event = field(default_factory=threading.Event)
@@ -76,6 +81,22 @@ class AsyncJob:
         """Update progress counters atomically (single writer per job)."""
         self.current = current
         self.total = total
+        if message:
+            self.message = message
+
+    def set_phase(self, step: int, total_steps: int, message: str = "") -> None:
+        """Enter phase *step* of *total_steps*, resetting the within-phase counts.
+
+        A job made of several coarse phases (e.g. the projection build's fit →
+        tile → name-regions) calls this at each boundary so a poller can render
+        **one** whole-job bar instead of three bars that each restart at zero.
+        The within-phase ``current``/``total`` are zeroed because they belong to
+        the phase being left, not the one being entered.
+        """
+        self.step = step
+        self.total_steps = total_steps
+        self.current = 0
+        self.total = 0
         if message:
             self.message = message
 

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -41,6 +41,44 @@ projection_bp = Blueprint(
 #: projection package on the request path.
 _VALID_SHAPES = ("hex", "square")
 
+#: The coarse phases every projection build walks through, in order:
+#: 1. arranging the items (the UMAP fit), 2. tiling the layout into the pyramid,
+#: 3. naming the regions (signposts).  Reported as ``step``/``total_steps`` on
+#: the build meta so the client draws **one** whole-job bar that fills across the
+#: build instead of three bars that each restart at zero.  The UMAP fit itself is
+#: a single opaque call with no fraction to report (see
+#: :mod:`vtscore.projection.umap_projection`), so phase position is the only
+#: honest "how far along" signal for the longest part of the build.
+_BUILD_STEPS = 3
+
+
+def _build_progress(job) -> dict:
+    """The ``status: building`` meta payload for an in-flight build *job*.
+
+    Carries the within-phase counts **and** the whole-job structure: which of
+    the :data:`_BUILD_STEPS` phases is running, plus an ``overall`` completion
+    fraction stitched from the two so the client's bar advances monotonically
+    across the whole build.  A phase with no countable total (the UMAP fit)
+    contributes its slice only when it ends — the bar parks and pulses inside it
+    rather than pretending to a fraction the fit cannot report.
+    """
+    total_steps = job.total_steps or 0
+    step = job.step or 0
+    within = job.current / job.total if job.total > 0 else 0.0
+    overall = None
+    if total_steps > 0 and step > 0:
+        overall = min(1.0, max(0.0, (step - 1 + within) / total_steps))
+    return {
+        "status": "building",
+        "job_id": job.job_id,
+        "current": job.current,
+        "total": job.total,
+        "message": job.message,
+        "step": step or None,
+        "total_steps": total_steps or None,
+        "overall": overall,
+    }
+
 
 def _shape_for(ctx) -> str:
     """The bin shape this dataset is tiled with, fixed by its media type.
@@ -78,13 +116,7 @@ def _subset_meta(ctx, bin_shape: str) -> dict:
         job = projection_jobs.get(ctx._subset_job_id)
         if job is not None:
             if job.status in ("running", "pending"):
-                return {
-                    "status": "building",
-                    "job_id": job.job_id,
-                    "current": job.current,
-                    "total": job.total,
-                    "message": job.message,
-                }
+                return _build_progress(job)
             if job.status == "error":
                 return {"status": "error", "error": job.error or "projection build failed"}
 
@@ -478,6 +510,7 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, for
             def _on_progress(status, message, current, total):
                 job.update_progress(current, total, message)
 
+            job.set_phase(1, _BUILD_STEPS, "arranging items")
             proj = fit_projection(
                 mat_copy,
                 ids_copy,
@@ -486,8 +519,9 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, for
                 compact=compact,
                 on_progress=_on_progress,
             )
-            job.update_progress(0, 1, "building pyramid")
+            job.set_phase(2, _BUILD_STEPS, "building pyramid")
             pyr = build_pyramid(proj, bin_shape=bin_shape)
+            job.set_phase(3, _BUILD_STEPS, "naming regions")
             _prep_signposts_best_effort(ctx, proj, job, subset=False)
             job.update_progress(1, 1, "done")
 
@@ -602,6 +636,7 @@ def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str,
             def _on_progress(status, message, current, total):
                 job.update_progress(current, total, message)
 
+            job.set_phase(1, _BUILD_STEPS, "arranging items")
             proj = fit_projection(
                 mat_copy,
                 ids_copy,
@@ -610,12 +645,13 @@ def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str,
                 compact=compact,
                 on_progress=_on_progress,
             )
-            job.update_progress(0, 1, "building pyramid")
+            job.set_phase(2, _BUILD_STEPS, "building pyramid")
             pyr = build_pyramid(proj, bin_shape=bin_shape)
             # Fresh signs over just this subset: the contrastive keyphrases
             # recompute against the subset's own siblings (better than any
             # filtered dataset-level signs), and the per-media texts were
             # cached at ingest, so this is the cheap half of the pipeline.
+            job.set_phase(3, _BUILD_STEPS, "naming regions")
             _prep_signposts_best_effort(ctx, proj, job, subset=True)
             job.update_progress(1, 1, "done")
 
@@ -776,13 +812,7 @@ def projection_meta():
         job = projection_jobs.get(ctx._full_job_id)
         if job is not None:
             if job.status in ("running", "pending"):
-                return {
-                    "status": "building",
-                    "job_id": job.job_id,
-                    "current": job.current,
-                    "total": job.total,
-                    "message": job.message,
-                }
+                return _build_progress(job)
             if job.status == "error":
                 return {"status": "error", "error": job.error or "projection build failed"}
 

--- a/vtsearch/schemas/projection.py
+++ b/vtsearch/schemas/projection.py
@@ -50,6 +50,24 @@ class ProjectionMetaSchema(Schema):
     current = fields.Integer(load_default=None)
     total = fields.Integer(load_default=None)
     message = fields.String(load_default=None)
+    step = fields.Integer(
+        load_default=None,
+        metadata={"description": "Which coarse build phase is running (1-based)."},
+    )
+    total_steps = fields.Integer(
+        load_default=None,
+        metadata={"description": "How many coarse phases the whole build has."},
+    )
+    overall = fields.Float(
+        load_default=None,
+        metadata={
+            "description": (
+                "Whole-job completion fraction (0..1) stitched from the current "
+                "phase and its within-phase counts, so one bar fills across the "
+                "entire build instead of restarting at each phase."
+            ),
+        },
+    )
     error = fields.String(load_default=None)
 
 


### PR DESCRIPTION
## The problem

Clicking **Browse** in Find navigated to the browse view immediately and then parked the user on an empty canvas with a bare status line while the subset UMAP fit ran — which on a large positive set is minutes. Every other long wait in the app (detector scoring, dataset loads, the dashboard's own Browse button) keeps the user where they are behind a progress bar. This makes Find's Browse do the same: **the map is built in Find, and we only navigate once there is a browser to show.**

## What changed

**Find waits in Find.** A new `BrowseSubsetPrepService` kicks the subset build (`POST /api/projection/build` with `ids`), polls `GET /api/projection/meta?subset=1`, and navigates to `/browse/:datasetId?subset=1` only once the layout is ready. The Find view renders it with the *same* wait overlay the scoring run already uses — bar, counts, ETA, Cancel — and disables the three panels behind it. Both Browse entry points (the left panel's unverified-positives Browse and the right panel's full-positives Browse) route through it. A build failure toasts and leaves the user in Find; Cancel drops the wait and stays put. The subset handoff is now set at navigation time rather than at click time, so a cancelled wait can't leave a stale pending subset for the next browse to pick up.

**The bar shows total work.** The projection build now reports its coarse phase as `step`/`total_steps` — arranging (UMAP fit) → tiling (pyramid) → naming regions (signposts) — plus a stitched whole-job `overall` fraction, so one bar fills across the build instead of three bars that each restart at zero. `AsyncJob` grows a `set_phase()` that records the position and clears the previous phase's within-phase counts. The UMAP fit is a single opaque call with no fraction of its own (it ticks elapsed seconds into the message), so the bar parks and *pulses* inside that phase rather than faking movement; the "Step 1 of 3" line is the honest signal for the longest stretch of the build.

**Same bar everywhere the build shows up.** The browse view's own `building` state (reachable via Rebuild Map / a full-dataset build) and the dashboard's Browse-prep row both render the whole-job bar now instead of a per-phase one.

## Notes

- `Cancel` stops the wait client-side; the background fit keeps running server-side (it has no cancellation hook, and its result is cached by signature), so pressing Browse again picks the same job back up rather than starting a second fit. This is documented on `cancel()`.
- API change: `GET /api/projection/meta` gains `step`, `total_steps`, and `overall` on the `building` payload. OpenAPI snapshot regenerated.
- No screenshot reshoots needed — the manifest's `find-view` / `browse-view` shots frame the ready states, which are unchanged.

## Testing

`./run-tests.sh` — **ALL 7455 TESTS PASSED** (1 skipped), including 1896 frontend Vitest tests. New coverage:

- `tests/api/test_projection.py` — a build in flight reports its phase and a whole-job `overall` fraction.
- `tests_lib/integration/test_async_jobs.py` — `AsyncJob.set_phase` records the position and clears the previous phase's counts.
- `frontend/.../browse-subset-prep.service.spec.ts` — no navigation until the layout is ready, live whole-job bar, pulsing on a count-less phase, failures/cancel leave the user in Find, no stale handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2kmPxpqMqCvwzznq716W6

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2kmPxpqMqCvwzznq716W6)_