### PR TITLE
Fix dataset-load progress reporting: dropped callback + event flood

### DIFF
--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1092,7 +1092,7 @@ class TestDemoCacheEmbedderMismatch:
 
         medias: dict = {}
 
-        def fake_load(path, m):
+        def fake_load(path, m, **kwargs):
             m[1] = {"embedding": np.array([0.1, 0.2]), "file": "/fake/file.png"}
 
         with (
@@ -1131,7 +1131,7 @@ class TestDemoCacheEmbedderMismatch:
 
         medias: dict = {}
 
-        def fake_load(path, m):
+        def fake_load(path, m, **kwargs):
             m[1] = {"embedding": np.array([0.1]), "file": "/fake/file.png"}
 
         with (
@@ -1308,7 +1308,7 @@ class TestDemoCacheClipperMismatch:
         demo_name = "fake_audio_demo"
         self._write_cache(embeddings_dir, demo_name, "sound_tiling", {"duration": 2.0})
 
-        def fake_load(path, m):
+        def fake_load(path, m, **kwargs):
             m[1] = {"embedding": np.array([0.1]), "media_type": "audio"}
 
         with (

--- a/tests_lib/datasets/test_cached_load_progress.py
+++ b/tests_lib/datasets/test_cached_load_progress.py
@@ -1,0 +1,153 @@
+"""Library-tier tests: loading a dataset out of a ``.pkl`` reports progress.
+
+Reading the cached container is the *whole* job for the two import paths
+covered here — a demo the picker shows as "Ready", and a user-uploaded
+``.pkl`` — and on a large dataset it is the slowest thing in the load.  Both
+call sites used to invoke ``load_dataset_from_pickle`` without forwarding a
+progress callback, so the dashboard row parked on a single static message
+with no counter and no bar movement until the entire read finished.  These
+tests pin the callback wiring so the row keeps ticking.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from vtscore.datasets import loader as _loader
+from vtscore.datasets.config import DEMO_DATASETS
+from vtscore.datasets.loader import export_dataset_to_file, load_demo_dataset
+
+#: A real image-typed demo id, so ``_try_load_cached`` takes the cached branch
+#: for a media type whose pickled medias round-trip without external files.
+DEMO_ID = "caltech101_s"
+
+
+def _png_bytes(color: tuple[int, int, int]) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _image_medias(n: int) -> dict[int, dict]:
+    """Build *n* image medias with inline bytes and deterministic embeddings."""
+    rng = np.random.default_rng(7)
+    medias: dict[int, dict] = {}
+    for i in range(n):
+        src = _png_bytes((i % 255, (3 * i) % 255, (7 * i) % 255))
+        medias[i] = {
+            "id": i,
+            "media_type": "image",
+            "duration": 0,
+            "file_size": len(src),
+            "md5": f"md5-{i}",
+            "embedder": "siglip",
+            "embeddings": {"siglip": rng.standard_normal(32).astype(np.float32)},
+            "filename": f"{i}.png",
+            "category": "test",
+            "media_bytes": src,
+            "width": 8,
+            "height": 8,
+        }
+    return medias
+
+
+def _write_cached_demo(tmp_path: Path, monkeypatch, n: int = 120) -> dict[int, dict]:
+    """Plant a cached demo container in a redirected ``EMBEDDINGS_DIR``."""
+    medias = _image_medias(n)
+    container = export_dataset_to_file(medias, embedder="siglip", media_type="image")
+    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)
+    (tmp_path / f"{DEMO_ID}.pkl").write_bytes(container)
+    return medias
+
+
+class _Recorder:
+    """Collect ``(status, message, current, total)`` progress calls."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, int, int]] = []
+
+    def __call__(self, status: str, message: str = "", current: int = 0, total: int = 0, **_: object) -> None:
+        self.events.append((status, message, current, total))
+
+    @property
+    def counted(self) -> list[tuple[str, str, int, int]]:
+        """Events that carry a real denominator, i.e. move a determinate bar."""
+        return [e for e in self.events if e[3] > 0]
+
+
+def test_cached_demo_load_reports_per_item_progress(tmp_path: Path, monkeypatch):
+    """A "Ready" demo ticks per-item progress, not one static message."""
+    assert DEMO_ID in DEMO_DATASETS, "test fixture must name a real demo id"
+    medias = _write_cached_demo(tmp_path, monkeypatch)
+
+    loaded: dict = {}
+    progress = _Recorder()
+    load_demo_dataset(DEMO_ID, loaded, on_progress=progress)
+
+    assert loaded.keys() == medias.keys()
+    counted = progress.counted
+    assert counted, "cached demo load must report progress with a real total"
+    assert all(total == len(medias) for _, _, _, total in counted)
+    # More than the single opening tick, so the bar actually advances mid-read.
+    assert max(current for _, _, current, _ in counted) > 0
+
+
+def test_cached_demo_load_still_finishes_idle(tmp_path: Path, monkeypatch):
+    """Forwarding the callback must not disturb the terminal ``idle`` event."""
+    _write_cached_demo(tmp_path, monkeypatch, n=20)
+
+    loaded: dict = {}
+    progress = _Recorder()
+    load_demo_dataset(DEMO_ID, loaded, on_progress=progress)
+
+    assert progress.events[-1][0] == "idle"
+
+
+def test_pickle_importer_reports_per_item_progress(tmp_path: Path):
+    """The uploaded-``.pkl`` importer reports through the per-task callback."""
+    from vtscore.concurrency.progress import clear_thread_progress, set_thread_progress
+    from vtscore.datasets import get_importer
+    from vtscore.plugins.uploads import BytesIOUploadedFile
+
+    medias = _image_medias(120)
+    container = export_dataset_to_file(medias, embedder="siglip", media_type="image")
+
+    importer = get_importer("pickle")
+    assert importer is not None
+
+    progress = _Recorder()
+    loaded: dict = {}
+    set_thread_progress(progress)
+    try:
+        importer.run({"file": BytesIOUploadedFile(container, "ds.pkl")}, loaded)
+    finally:
+        clear_thread_progress()
+
+    assert loaded.keys() == medias.keys()
+    counted = progress.counted
+    assert counted, "pickle import must report progress with a real total"
+    assert all(total == len(medias) for _, _, _, total in counted)
+
+
+@pytest.mark.parametrize("n", [2, 51, 120])
+def test_progress_totals_match_item_count(tmp_path: Path, monkeypatch, n: int):
+    """The reported denominator is the item count at every dataset size.
+
+    ``load_dataset_from_pickle`` derives its tick interval from the item
+    count, so a size that lands on an interval boundary must not silently
+    drop every tick.
+    """
+    _write_cached_demo(tmp_path, monkeypatch, n=n)
+
+    loaded: dict = {}
+    progress = _Recorder()
+    load_demo_dataset(DEMO_ID, loaded, on_progress=progress)
+
+    assert len(loaded) == n
+    assert progress.counted, f"no counted progress for n={n}"
+    assert all(total == n for _, _, _, total in progress.counted)

--- a/vtscore/datasets/importers/pickle/__init__.py
+++ b/vtscore/datasets/importers/pickle/__init__.py
@@ -16,9 +16,19 @@ from vtscore.datasets.loader import load_dataset_from_pickle, load_dataset_from_
 
 
 def _get_progress():
-    from vtscore.concurrency.progress import update_progress
+    """Resolve the progress sink, preferring the per-task thread callback.
 
-    return update_progress
+    ``_run_importer`` installs the load's own stepped tracker as the thread
+    progress before calling ``run()``, so preferring it routes this importer's
+    messages to the dashboard row for *this* import.  Reporting straight to the
+    global ``update_progress`` singleton (the previous behaviour) published on
+    the ``dataset`` channel instead, where the row never reads it.  Mirrors
+    ``vtscore.datasets.loader._default_progress``.
+    """
+    from vtscore.concurrency.progress import get_thread_progress, update_progress
+
+    cb = get_thread_progress()
+    return cb if cb is not None else update_progress
 
 
 class PickleDatasetImporter(ImporterBase):
@@ -59,7 +69,10 @@ class PickleDatasetImporter(ImporterBase):
             # UploadedFile.save() persists to disk; FileStorage, CliUploadedFile,
             # and BytesIOUploadedFile all implement it.
             file_obj.save(temp_path)
-            load_dataset_from_pickle(temp_path, medias, thin=thin)
+            # Same reason as the cached-demo path in ``loader_demo``: reading
+            # the pickle is the whole import, so without the callback the
+            # dashboard row shows one static message until it finishes.
+            load_dataset_from_pickle(temp_path, medias, thin=thin, on_progress=progress)
         finally:
             temp_path.unlink(missing_ok=True)
         progress("idle", f"Loaded {len(medias)} medias from file")

--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -139,7 +139,14 @@ def _try_load_cached(
         return False
 
     on_progress("loading", f"Loading {dataset_name} dataset...", 0, 0)
-    _loader.load_dataset_from_pickle(pkl_file, medias)
+    # Forward the callback: for a demo the picker shows as "Ready", reading this
+    # pickle *is* the whole import, and it is the slowest thing in the job (tens
+    # of seconds on the larger demos).  Without the callback the dashboard row
+    # sat on this one static message with no counter and no bar movement for the
+    # entire load, which reads as "nothing is happening" right after the user
+    # clicks Import.  ``load_dataset_from_pickle`` emits "Reading <file>…" and
+    # then a per-item "Processing i of N items…" tick.
+    _loader.load_dataset_from_pickle(pkl_file, medias, on_progress=on_progress)
 
     # Check if any medias were actually loaded
     if len(medias) == 0:

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -426,7 +426,13 @@ def load_dataset_from_pickle(
     missing_media = 0
     loaded_count = 0
     total_count = len(medias_data)
-    _progress_interval = max(1, min(50, total_count // 50)) if total_count > 0 else 1
+    # ~50 updates for the whole loop, whatever the item count.  The old
+    # ``min(50, total // 50)`` capped the *interval* at 50 instead of the
+    # update count, so it inverted above 2500 items: a 300k-item dataset
+    # emitted 6,000 progress events, each one a full re-serialisation of the
+    # task list pushed to every open SSE stream (enough to back up the
+    # per-client 1024-deep queue and start dropping frames).
+    _progress_interval = max(1, total_count // 50) if total_count > 0 else 1
     if on_progress is not None:
         on_progress("loading", f"Processing 0 of {total_count} items…", 0, total_count)
 


### PR DESCRIPTION
## Dropped progress callback

Importing a demo the picker shows as **Ready** goes entirely through the cached `.pkl` — `_try_load_cached` in `vtscore/datasets/loader_demo.py`. That path emitted one static message and then called `load_dataset_from_pickle` **without forwarding the progress callback**, so for the whole read the dashboard row sat on `Loading <demo> dataset...` with no counter and no bar movement.

The uploaded-`.pkl` importer had the same dropped callback, plus its `_get_progress()` returned the global `update_progress` singleton, which publishes on the `dataset` SSE channel — the one the per-task loading row never reads. So its messages went nowhere visible either.

## Progress-event flood

`_progress_interval = max(1, min(50, total // 50))` capped the *interval* at 50 items instead of the update count, so it inverted above 2500 items:

| items | before | after |
|---|---|---|
| 1,000 | 50 events | 50 events |
| 36,500 | 730 events | 50 events |
| 300,000 | **6,000 events** | 50 events |

Each event re-serialises the whole task list onto every open SSE stream. Measured against a planted 300k-item demo container, the run emitted **7,043 `loading-tasks` frames** and visibly backed up the per-client 1024-deep queue (`vtscore/concurrency/events.py`), which drops frames when full. Now ~50 updates at any size.

## Changes

- `vtscore/datasets/loader_demo.py`, `vtscore/datasets/importers/pickle/__init__.py` — forward `on_progress`; resolve the pickle importer's sink from the per-task thread callback.
- `vtscore/datasets/loader_pickle.py` — cap the event count, not the tick interval.
- `tests_lib/datasets/test_cached_load_progress.py` — new coverage; verified failing (5 of 6) with the fix reverted.
- `tests/datasets/test_datasets.py` — three `fake_load` stubs accept the forwarded kwarg.

## Not fixed here

Neither of these is the cause of a row that never appears at all — that one is SSE-side, traced in the session and not yet filed:

- The container decompress + unpickle that precedes the item loop still reports no counter (#2811). It scales with item count, not file size: **4.1 s of a 4.4 s load** on a 300k-item container.

`./run-tests.sh` — ALL 7461 TESTS PASSED (1 skipped).

Refs #2811
