### PR TITLE
Fix SSE cap lockout: classify stream errors via /healthz, fast slot release, uncap dev server

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -158,8 +158,12 @@ A few VTSearch-specific points matter when configuring the proxy:
   connections at `VTSEARCH_THREADS - 2` (override with
   `VTSEARCH_SSE_MAX_CONNECTIONS`) and returns `503` once saturated instead of
   starving the pool that serves ordinary requests; the frontend's `EventSource`
-  wrapper retries on a timer when that happens. Raising `VTSEARCH_THREADS` raises
-  the SSE cap along with it.
+  wrapper retries on a timer when that happens (a cap rejection proves the
+  backend is alive, so it never counts toward the client's offline circuit
+  breaker). Raising `VTSEARCH_THREADS` raises the SSE cap along with it. The
+  cap only applies under gunicorn: the dev server (`python app.py`) spawns a
+  thread per connection and runs uncapped unless `VTSEARCH_SSE_MAX_CONNECTIONS`
+  is set explicitly.
 - **Forwarded headers.** Pass `X-Forwarded-For`, `X-Forwarded-Proto`, and
   `X-Forwarded-Host` (and `Host`) so the app sees the real client and external
   scheme. For SSE/WebSocket-style streams also forward `Connection`/`Upgrade` if

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -101,6 +101,13 @@ also re-emits the `loading-tasks` and `detector-loading-tasks` channels so
 finished tasks vanish from the UI once they pass their stale-prune window
 without a server-side timer.
 
+Between heartbeats an idle stream also writes a bare SSE comment (`: ka`)
+roughly every second. It is deliberately a comment — invisible to
+`EventSource`, so it does not feed the client's liveness signal — and exists
+only to probe the socket: a client that vanished abruptly (page reload) is
+detected on the first failed write, releasing its connection slot in ~1s
+instead of a full heartbeat period.
+
 ## Example
 
 ```ts

--- a/frontend/src/app/services/connection-state.service.spec.ts
+++ b/frontend/src/app/services/connection-state.service.spec.ts
@@ -79,4 +79,50 @@ describe('ConnectionStateService', () => {
     expect(reqs.length).toBe(1);
     reqs[0].flush('ok');
   });
+
+  // --- recordStreamFailure(): classifying ambiguous SSE errors (#2816) ---
+
+  it('recordStreamFailure() probes /healthz instead of counting a failure', () => {
+    // Three SSE errors in a row used to trip the breaker even though the
+    // backend was answering (503 slot-cap rejections). Now each error only
+    // fires a probe; a healthy answer keeps the app online.
+    service.recordStreamFailure();
+    const req = httpMock.expectOne('/healthz');
+    req.flush('ok');
+    service.recordStreamFailure();
+    httpMock.expectOne('/healthz').flush('ok');
+    service.recordStreamFailure();
+    httpMock.expectOne('/healthz').flush('ok');
+    expect(service.isOffline).toBe(false);
+  });
+
+  it('recordStreamFailure() sends one probe at a time', () => {
+    service.recordStreamFailure();
+    service.recordStreamFailure();
+    const reqs = httpMock.match('/healthz');
+    expect(reqs.length).toBe(1);
+    reqs[0].flush('ok');
+    // Once the probe settles, a new stream error may probe again.
+    service.recordStreamFailure();
+    httpMock.expectOne('/healthz').flush('ok');
+  });
+
+  it('recordStreamFailure() does not probe while offline', () => {
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    service.recordNetworkFailure();
+    expect(service.isOffline).toBe(true);
+    // Recovery stays manual: no automatic probing once the breaker tripped.
+    service.recordStreamFailure();
+    httpMock.expectNone('/healthz');
+  });
+
+  it('recordStreamFailure() probes again after a failed probe settles', () => {
+    // A network-level probe failure (backend really gone) must not wedge the
+    // in-flight flag; the next stream error probes again.
+    service.recordStreamFailure();
+    httpMock.expectOne('/healthz').error(new ProgressEvent('error'));
+    service.recordStreamFailure();
+    httpMock.expectOne('/healthz').flush('ok');
+  });
 });

--- a/frontend/src/app/services/connection-state.service.ts
+++ b/frontend/src/app/services/connection-state.service.ts
@@ -76,6 +76,8 @@ export class ConnectionStateService {
   readonly retrying = this._retrying.asReadonly();
 
   private consecutiveFailures = 0;
+  /** True while a stream-failure classification probe is in flight. */
+  private streamProbeInFlight = false;
 
   constructor() {
     // A browser-level `offline` event (the OS lost its network interface) is
@@ -113,6 +115,36 @@ export class ConnectionStateService {
     if (this.consecutiveFailures >= ConnectionStateService.OFFLINE_THRESHOLD) {
       this.goOffline();
     }
+  }
+
+  /**
+   * Record an error reported by the SSE stream ({@link ProgressEventsService}).
+   *
+   * `EventSource` hides HTTP status codes, so a stream error is ambiguous:
+   * the backend may be unreachable — or it answered the connect with an error
+   * such as the `/api/events` 503 slot-cap rejection, which *proves* it is
+   * alive. Counting the ambiguous error as a network failure used to lock the
+   * whole app offline when three cap rejections landed inside the slot-release
+   * window (#2816). Instead, send a single `/healthz` probe and let the
+   * interceptor classify the outcome: any HTTP response resets the failure
+   * tally (so the stream keeps retrying on its 2s timer until a slot frees),
+   * while a status-0 failure counts toward tripping the breaker exactly like
+   * any other request's.
+   */
+  recordStreamFailure(): void {
+    if (this.isOffline || this.streamProbeInFlight) return;
+    this.streamProbeInFlight = true;
+    this.http
+      .get('/healthz', {
+        context: new HttpContext().set(CONNECTION_PROBE, true),
+        responseType: 'text',
+      })
+      .subscribe({
+        // The interceptor already recorded the outcome (success or network
+        // failure); this subscription only tracks that the probe finished.
+        next: () => (this.streamProbeInFlight = false),
+        error: () => (this.streamProbeInFlight = false),
+      });
   }
 
   private goOffline(): void {

--- a/frontend/src/app/services/progress-events.service.spec.ts
+++ b/frontend/src/app/services/progress-events.service.spec.ts
@@ -43,6 +43,8 @@ class FakeEventSource {
 
 describe('ProgressEventsService liveness wiring', () => {
   let recordSuccess: ReturnType<typeof vi.fn>;
+  let recordNetworkFailure: ReturnType<typeof vi.fn>;
+  let recordStreamFailure: ReturnType<typeof vi.fn>;
   let status: WritableSignal<ConnectionStatus>;
   let originalEventSource: typeof EventSource;
 
@@ -52,11 +54,14 @@ describe('ProgressEventsService liveness wiring', () => {
     globalThis.EventSource = FakeEventSource as unknown as typeof EventSource;
 
     recordSuccess = vi.fn();
+    recordNetworkFailure = vi.fn();
+    recordStreamFailure = vi.fn();
     status = signal<ConnectionStatus>('online');
     const connectionStub = {
       status,
       recordSuccess,
-      recordNetworkFailure: vi.fn(),
+      recordNetworkFailure,
+      recordStreamFailure,
       get isOffline() {
         return status() === 'offline';
       },
@@ -98,6 +103,21 @@ describe('ProgressEventsService liveness wiring', () => {
     recordSuccess.mockClear();
     es.emit('dataset', { status: 'loading', current: 5, total: 10 });
     expect(recordSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks the connection service to classify an SSE error, never counting it as a network failure outright (#2816)', () => {
+    // EventSource hides HTTP statuses: the error may be a 503 slot-cap
+    // rejection from a live backend. recordStreamFailure() probes /healthz
+    // to tell; a direct recordNetworkFailure() here is exactly the bug that
+    // locked the app offline behind a manual Retry.
+    const es = connectedSource();
+    es.readyState = FakeEventSource.CLOSED;
+    es.onerror!();
+    expect(recordStreamFailure).toHaveBeenCalledTimes(1);
+    expect(recordNetworkFailure).not.toHaveBeenCalled();
+    // Tear down the 2s reconnect timer the error handler scheduled.
+    status.set('offline');
+    TestBed.tick();
   });
 
   // --- detectorTaskUntilDone$: awaiting one task's terminal frame (#2703) ---
@@ -205,6 +225,7 @@ describe('ProgressEventsService (zoneless view canary)', () => {
       status,
       recordSuccess: vi.fn(),
       recordNetworkFailure: vi.fn(),
+      recordStreamFailure: vi.fn(),
       get isOffline() {
         return status() === 'offline';
       },

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -174,9 +174,13 @@ export class ProgressEventsService implements OnDestroy {
     es.onopen = () => this.connection.recordSuccess();
 
     es.onerror = () => {
-      // Feed the circuit breaker: an SSE error is a connectivity signal too,
-      // so a dashboard sitting on only the stream still trips offline.
-      this.connection.recordNetworkFailure();
+      // Feed the circuit breaker indirectly: EventSource hides the HTTP
+      // status, so this error may be a dead backend or a 503 slot-cap
+      // rejection from a perfectly healthy one. recordStreamFailure()
+      // probes /healthz to tell the two apart — a dashboard sitting on only
+      // the stream still trips offline (via failed probes) when the backend
+      // is really gone, but a cap rejection no longer locks the app (#2816).
+      this.connection.recordStreamFailure();
       // EventSource reconnects on its own for transient failures, but
       // schedules an extra reconnect in case the server closed the stream
       // permanently. Idempotent: if `source` is already non-null the next

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -321,6 +321,38 @@ class TestEventsRoute:
         finally:
             gen.close()
 
+    def test_idle_stream_emits_keepalive_comment_between_heartbeats(self):
+        """An idle stream probes the socket with an SSE comment well before
+        the next heartbeat, so a dead client's slot is released in ~1s
+        instead of a full heartbeat period (#2816). The probe must be a
+        comment (invisible to EventSource), never a named event."""
+        gen = stream_progress_events(heartbeat_seconds=60.0, keepalive_seconds=0.01)
+        try:
+            assert next(gen).startswith(": connected")
+            for _ in initial_snapshot():
+                next(gen)
+            # The next idle wakeup is the socket-probe comment, not a heartbeat.
+            chunk = next(gen)
+            assert chunk.startswith(": ")
+            assert "event:" not in chunk
+        finally:
+            gen.close()
+
+    def test_heartbeat_still_fires_with_keepalive_enabled(self):
+        """Keepalive probes must not starve the named heartbeat the client's
+        liveness breaker depends on."""
+        gen = stream_progress_events(heartbeat_seconds=0.05, keepalive_seconds=0.01)
+        try:
+            heartbeat = None
+            deadline = time.monotonic() + 2.0
+            while heartbeat is None and time.monotonic() < deadline:
+                chunk = next(gen)
+                if chunk.startswith("event: heartbeat\n"):
+                    heartbeat = chunk
+            assert heartbeat is not None, "no heartbeat frame arrived"
+        finally:
+            gen.close()
+
     def test_initial_dataset_snapshot_reflects_current_state(self):
         dataset_progress.update("loading", "snap", 7, 8)
         try:
@@ -428,6 +460,24 @@ class TestSseConnectionCapPrimitive:
     def test_default_max_connections_floors_at_one(self, monkeypatch):
         monkeypatch.setenv("VTSEARCH_THREADS", "1")
         assert events_mod._default_max_connections() == 1
+
+    def test_uncap_removes_the_cap(self, monkeypatch):
+        """The dev server (`app.run(threaded=True)`) has no thread pool to
+        protect, so `_run_server` uncaps SSE connections (#2816)."""
+        monkeypatch.delenv("VTSEARCH_SSE_MAX_CONNECTIONS", raising=False)
+        monkeypatch.setattr(events_mod, "MAX_SSE_CONNECTIONS", 2)
+        events_mod.uncap_sse_connections()
+        assert events_mod.MAX_SSE_CONNECTIONS > 10**6
+        for _ in range(10):
+            assert acquire_sse_slot() is True
+        for _ in range(10):
+            release_sse_slot()
+
+    def test_uncap_respects_explicit_env_override(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_SSE_MAX_CONNECTIONS", "4")
+        monkeypatch.setattr(events_mod, "MAX_SSE_CONNECTIONS", 4)
+        events_mod.uncap_sse_connections()
+        assert events_mod.MAX_SSE_CONNECTIONS == 4
 
 
 class TestSseConnectionCapRoute:

--- a/vtscore/concurrency/events.py
+++ b/vtscore/concurrency/events.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import os
 import queue
+import sys
 import threading
 import time
 import uuid
@@ -42,6 +43,18 @@ from vtscore.concurrency.progress import (
 #: must stay comfortably below the breaker's tolerance for consecutive poller
 #: misses; 5s is well under that.
 HEARTBEAT_SECONDS = 5.0
+
+#: Idle socket-probe cadence. With ``stream_with_context`` a client that
+#: vanished abruptly (page reload, killed tab) is only detected when a write
+#: to the dead socket fails — and the slot it holds via
+#: :func:`acquire_sse_slot` is only released then. If the only idle write
+#: were the heartbeat, a reloading page could collide with its *own*
+#: previous connection's slot for a full heartbeat period (#2816). So when
+#: no frame has been written for this long, the stream emits a bare SSE
+#: comment: invisible to the browser's ``EventSource`` (it must NOT reset
+#: the client's liveness breaker — only real events do), but enough to make
+#: the write fail fast and free the slot.
+KEEPALIVE_SECONDS = 1.0
 
 #: Per-process identifier emitted as the first SSE frame on every new
 #: connection. Clients compare it against the last value they saw; when
@@ -89,6 +102,22 @@ MAX_SSE_CONNECTIONS = int(os.environ.get("VTSEARCH_SSE_MAX_CONNECTIONS", str(_de
 
 _connection_lock = threading.Lock()
 _active_connections = 0
+
+
+def uncap_sse_connections() -> None:
+    """Remove the SSE connection cap for servers without a bounded thread pool.
+
+    The cap exists to keep long-lived streams from starving gunicorn's
+    ``gthread`` worker pool. The Flask dev server (``app.run(threaded=True)``,
+    see ``vtsearch/cli_main.py``) spawns a thread per connection and has no
+    pool to protect, so there the cap is pure downside: extra tabs get 503s
+    while the server has capacity to spare (#2816). An explicit
+    ``VTSEARCH_SSE_MAX_CONNECTIONS`` override still wins.
+    """
+    global MAX_SSE_CONNECTIONS
+    if "VTSEARCH_SSE_MAX_CONNECTIONS" in os.environ:
+        return
+    MAX_SSE_CONNECTIONS = sys.maxsize
 
 
 def acquire_sse_slot() -> bool:
@@ -141,7 +170,10 @@ def initial_snapshot() -> list[str]:
 
 
 def stream_progress_events(  # noqa: C901
-    *, heartbeat_seconds: float = HEARTBEAT_SECONDS, max_queue: int = 1024
+    *,
+    heartbeat_seconds: float = HEARTBEAT_SECONDS,
+    keepalive_seconds: float = KEEPALIVE_SECONDS,
+    max_queue: int = 1024,
 ) -> Generator[str, None, None]:
     """Yield SSE-formatted strings for every progress channel until disconnect.
 
@@ -191,25 +223,35 @@ def stream_progress_events(  # noqa: C901
             yield frame
 
         last_heartbeat = time.monotonic()
+        last_write = time.monotonic()
         while True:
-            timeout = max(0.0, heartbeat_seconds - (time.monotonic() - last_heartbeat))
+            deadline = min(last_heartbeat + heartbeat_seconds, last_write + keepalive_seconds)
             try:
-                name, snapshot = q.get(timeout=timeout)
+                name, snapshot = q.get(timeout=max(0.0, deadline - time.monotonic()))
                 yield _format_sse(name, snapshot)
             except queue.Empty:
-                # Emit the heartbeat as a real, named ``heartbeat`` event
-                # rather than an SSE comment (``: heartbeat``). Comments are
-                # invisible to the browser's EventSource API, so the client
-                # could not use them as a liveness signal; a named event fires
-                # a listener, letting the frontend treat every heartbeat as
-                # proof the backend is still alive (and keeping idle proxies
-                # open just as a comment would).
-                yield _format_sse("heartbeat", {"ts": time.time()})
-                # Re-emit task channels so clients see finished tasks
-                # disappear once their stale-prune window elapses.
-                for name, tasks_tracker in _TASK_CHANNELS.items():
-                    yield _format_sse(name, tasks_tracker.list_tasks())
-                last_heartbeat = time.monotonic()
+                if time.monotonic() - last_heartbeat >= heartbeat_seconds:
+                    # Emit the heartbeat as a real, named ``heartbeat`` event
+                    # rather than an SSE comment (``: heartbeat``). Comments are
+                    # invisible to the browser's EventSource API, so the client
+                    # could not use them as a liveness signal; a named event fires
+                    # a listener, letting the frontend treat every heartbeat as
+                    # proof the backend is still alive (and keeping idle proxies
+                    # open just as a comment would).
+                    yield _format_sse("heartbeat", {"ts": time.time()})
+                    # Re-emit task channels so clients see finished tasks
+                    # disappear once their stale-prune window elapses.
+                    for name, tasks_tracker in _TASK_CHANNELS.items():
+                        yield _format_sse(name, tasks_tracker.list_tasks())
+                    last_heartbeat = time.monotonic()
+                else:
+                    # Socket probe only (see KEEPALIVE_SECONDS): a comment is
+                    # invisible to EventSource, so it deliberately does not
+                    # feed the client's liveness breaker — its sole job is to
+                    # make a write happen so a dead connection raises and
+                    # releases its slot promptly.
+                    yield ": ka\n\n"
+            last_write = time.monotonic()
     finally:
         for subject, handler in subscriptions:
             subject.unsubscribe(handler)

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -823,6 +823,12 @@ def _run_server(args, app, initialize_server) -> None:
     _preflight_port(port)
     initialize_server(mode_label="LOCAL" if args.local else "PRODUCTION")
     print(f"\U0001f310 Open http://localhost:{port} in your browser", flush=True)
+    # The dev server spawns a thread per connection (threaded=True): there is
+    # no bounded worker pool for long-lived SSE streams to starve, so the
+    # gunicorn-oriented connection cap is pure downside here (#2816).
+    from vtscore.concurrency.events import uncap_sse_connections
+
+    uncap_sse_connections()
     app.run(host="0.0.0.0", port=port, debug=False, threaded=True)
 
 

--- a/vtsearch/routes/events.py
+++ b/vtsearch/routes/events.py
@@ -31,7 +31,11 @@ def progress_events() -> Response:
     ordinary requests; once the cap is hit new connects get a 503 instead of
     starving the pool. ``EventSource`` treats a non-2xx response as a fatal
     error and stops auto-reconnecting, so the frontend's own ``onerror``
-    handler schedules a manual reconnect (see ``progress-events.service.ts``).
+    handler schedules a manual reconnect (see ``progress-events.service.ts``);
+    it also probes ``/healthz`` to classify the error, so a cap rejection —
+    proof the backend is alive — never counts toward the offline circuit
+    breaker (#2816). The dev server (``app.run(threaded=True)``) has no
+    thread pool to protect and runs uncapped (``uncap_sse_connections``).
     """
     if not acquire_sse_slot():
         response = jsonify({"message": "Too many live event streams open; retry shortly."})


### PR DESCRIPTION
Closes #2816

Three individually-reasonable behaviours composed into "the whole app stops talking to a healthy backend until a manual Retry": the SSE connection cap 503s new connects, the frontend counted every `EventSource` error as a *network* failure, and three of those inside the ~5s slot-release window tripped the manual-recovery offline breaker. This PR breaks the chain at all three layers.

## Frontend: classify SSE errors instead of counting them (the essential fix)

`EventSource` hides HTTP status codes, so an `onerror` is ambiguous: dead backend, or a 503 slot-cap rejection that *proves* the backend is alive. New `ConnectionStateService.recordStreamFailure()` sends a single `/healthz` probe (one in flight at a time, no-op while offline) and lets the existing interceptor classify the outcome:

- any HTTP response → `recordSuccess()`, breaker stays online, the 2s reconnect loop keeps running until a slot frees;
- status-0 network failure → counts toward the offline threshold exactly as before, so a dashboard sitting on only the stream still trips offline when the backend is really gone.

`progress-events.service.ts`'s `onerror` now calls `recordStreamFailure()` instead of `recordNetworkFailure()`. Manual-recovery semantics while offline are unchanged.

## Backend: release a dead connection's slot in ~1s, not ~5s

With `stream_with_context`, a vanished client (page reload) is only detected when a write fails — previously the next write was the 5s heartbeat, so a reload collided with its *own* previous connection's slot. An idle stream now writes a bare SSE comment (`: ka`) every ~1s (`KEEPALIVE_SECONDS`). It's deliberately a comment — invisible to `EventSource`, so it does not feed the client's liveness breaker — and exists purely to make a write happen so the dead socket raises and `release_sse_slot()` runs. The named 5s heartbeat and its task-channel re-emits are unchanged.

## Backend: no cap on the dev server

`python app.py` serves via `app.run(threaded=True)` — a thread per connection, no bounded pool for streams to starve — so the gunicorn-derived cap was pure downside there. `_run_server` now calls `uncap_sse_connections()`, which is a no-op when `VTSEARCH_SSE_MAX_CONNECTIONS` is set explicitly. Gunicorn deployments keep the derived `VTSEARCH_THREADS - 2` cap.

## Tests

- Backend: idle stream emits the keepalive comment between heartbeats; heartbeats still fire with keepalive enabled; `uncap_sse_connections()` lifts the cap and respects the explicit env override.
- Frontend: SSE `onerror` calls `recordStreamFailure()` (never `recordNetworkFailure()` directly); `recordStreamFailure()` probes `/healthz`, sends one probe at a time, stays quiet while offline, and recovers its in-flight flag after a failed probe.
- `./run-tests.sh` full suite: **ALL 7465 TESTS PASSED** (1 skipped); frontend gate: build OK, audit OK, 1906 Vitest tests passed.

Docs updated: `docs/api/events.md` (keepalive comment semantics) and `docs/DEPLOYMENT.md` (cap is gunicorn-only; cap rejections don't trip the client breaker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfQ5VkpQ311iSTB3aWXcAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfQ5VkpQ311iSTB3aWXcAt)_