### PR TITLE
Let importers name the datasets they import

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -369,6 +369,7 @@ to the framework.
 | `_fetch_records_bulk_impl()` | `(records: list, field_values: dict, thin: bool) -> list[dict | None]` | Batched fetch hook. Default loops `fetch_record`. Override to issue concurrent / batched I/O |
 | `run_cli()` | `(field_values: dict, medias: dict, thin: bool = False) -> None` | CLI variant; default delegates to `run()`. Override when `run()` expects FileStorage objects |
 | `get_field_options()` | `(field_key: str, current_values: dict) -> Sequence[FieldOption]` | Compute dropdown options for fields declared with `dynamic_options=True`; each option is a plain string or a `(value, label)` tuple. See [Dynamic field options](#dynamic-field-options) |
+| `default_display_name()` | `(field_values: dict) -> str` | Name the datasets this importer produces. Shown live in the form's Dataset Name box and used verbatim when the user leaves it blank. Default derives a name from your URL / path / upload fields. See [Naming the imported dataset](#naming-the-imported-dataset) |
 | `run_chunked()` | `(field_values, chunk_size, thin) -> Iterator[dict]` | Yield chunks of medias for piecewise processing. Set `supports_chunked = True` |
 | `run_chunked_cli()` | `(field_values, chunk_size, thin) -> Iterator[dict]` | CLI variant of `run_chunked()` |
 | `build_origin()` | `(field_values: dict) -> dict` | Build an origin dict for provenance tracking. Default uses importer name + string field values |
@@ -608,6 +609,63 @@ string and `(value, label)` shapes are coerced to `{value, label}` before
 serialisation. Any exception your `get_field_options()` raises is returned
 as a 502 with the exception message; perfect for surfacing remote-service
 errors directly to the user.
+
+### Naming the imported dataset
+
+Every importer's form carries a **Dataset Name** field that you never
+declare: the base class appends it to your `fields` when the form is
+serialised (`ImporterBase.to_dict`). Whatever the user types there wins.
+When they leave it blank, the name comes from your importer's
+`default_display_name(field_values)`.
+
+That method is also what the form *shows*. As the user fills the form in,
+the modal asks your importer what it would name the result and prefills
+the Dataset Name box with the answer, so the box is never a mystery: what
+it shows is what the import will use, and the user can still overwrite it.
+
+The base implementation walks your own declared fields and derives a name
+from the first one holding a usable value: a `url` field's tail, a
+`server_path` / `folder` leaf, an uploaded file's stem (archive extensions
+like `.tar.gz` are stripped). Field declaration order decides precedence.
+So an importer whose form is "a URL" or "a path" needs no naming code at
+all.
+
+Override it when the form holds something opaque — an id, a saved-query
+key, a bucket handle — and only your importer can turn it into words:
+
+```python
+class ReCallerImporter(DatasetImporter):
+    name = "recaller"
+    fields = [
+        PluginField("media_type", "Media Type", "select", options=all_folder_names()),
+        PluginField("query_id", "Query ID", "select", dynamic_options=True,
+                    depends_on=["media_type"]),
+    ]
+
+    def default_display_name(self, field_values):
+        query = _lookup_query(field_values.get("query_id", ""))
+        # Fall back to the base derivation when there is nothing to resolve.
+        return query.title if query else super().default_display_name(field_values)
+```
+
+Now picking *Q1 Field Survey* in the dropdown fills the Dataset Name box
+with `Q1 Field Survey` instead of leaving the user staring at `q-8f31`.
+
+Two constraints worth knowing:
+
+- **Keep it cheap.** It runs on every form change (debounced), not once
+  per import, so cache any remote lookup it needs. It should have no side
+  effects.
+- **Don't read `dataset_name` inside it.** The user's own answer is
+  stripped before your method is called — `resolve_display_name()` already
+  gives it priority — so `field_values` holds only the form fields you
+  declared.
+
+API contract: `POST /api/dataset/import/<name>/suggested-name` with body
+`{"values": {...}}` returns `{"dataset_name": "..."}`. An exception from
+your `default_display_name()` comes back as a 502; the form treats any
+failure as "no suggestion" and leaves the box untouched, since a name hint
+is never worth blocking an import over.
 
 ### How it gets invoked
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -131,6 +131,7 @@ See [EXTENDING-plugins.md § Adding a Data Importer](EXTENDING-plugins.md#adding
 - [ ] Subclass `DatasetImporter`, set `name`, `display_name`, `description`, `fields`
 - [ ] Implement `run(self, field_values, medias, thin=False)`: populate `medias` in-place
 - [ ] Expose `IMPORTER = YourImporter()` at module level
+- [ ] If your form holds opaque values (ids, query keys), override `default_display_name(field_values)` so the Dataset Name box shows a readable name — see [Naming the imported dataset](EXTENDING-plugins.md#naming-the-imported-dataset)
 - [ ] If the plugin needs extra packages, add them to `[project.dependencies]` in `pyproject.toml` and re-run your editable install
 - [ ] Test: start the app and check `GET /api/dataset/all-importers` includes your importer
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -255,6 +255,28 @@ coincide for plain-string options and differ for `(value, label)` tuples).
 400 (unknown / non-dynamic field), 404 (unknown importer), 501 (not
 implemented), 502 (remote error).
 
+### Importer suggested dataset name
+
+```
+POST /api/dataset/import/{importer_name}/suggested-name
+```
+
+**Body:** `{"values": {...}}` (the current form snapshot, optional).
+
+Calls the importer's `default_display_name(values)` and returns the name it
+would give a dataset built from those values, so the import modal can
+prefill its Dataset Name box — including a label the importer resolved from
+an opaque selection. See
+[Naming the imported dataset](../EXTENDING-plugins.md#naming-the-imported-dataset).
+
+Any `dataset_name` in `values` is dropped before the importer sees it: the
+route reports what the importer *would* pick, and the caller decides
+whether to overwrite what the user typed.
+
+→ `{"dataset_name": "Q1 Field Survey"}`
+
+404 (unknown importer), 502 (the importer raised).
+
 ### Detect media type
 
 ```

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4109,6 +4109,28 @@
         ],
         "type": "object"
       },
+      "ImporterSuggestedNameRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "values": {
+            "additionalProperties": {},
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ImporterSuggestedNameResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "dataset_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "dataset_name"
+        ],
+        "type": "object"
+      },
       "InclusionRequest": {
         "additionalProperties": false,
         "properties": {
@@ -10096,6 +10118,61 @@
           }
         },
         "summary": "Return dropdown options for a dynamic-options field.",
+        "tags": [
+          "datasets_staging"
+        ]
+      }
+    },
+    "/api/dataset/import/{importer_name}/suggested-name": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "importer_name",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Calls the importer's ``default_display_name(field_values)`` with a\nsnapshot of the current form, so the Add-Dataset form can prefill its\nDataset Name box with something human-readable -- including a label a\nplugin resolved from an opaque internal selection, which no\nclient-side derivation could produce.  The user's own ``dataset_name``\nis deliberately ignored here: the caller only asks for the suggestion,\nand decides for itself whether to overwrite what the user typed.\n\nErrors from the plugin are surfaced as a 502 with the original\nmessage; the frontend treats any failure as \"no suggestion\" and leaves\nthe box alone, since a name hint is never worth blocking an import.",
+        "operationId": "importer_suggested_name",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImporterSuggestedNameRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImporterSuggestedNameResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "description": "Unknown importer name."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "502": {
+            "description": "default_display_name raised an error."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return the name the importer would give a dataset built from these values.",
         "tags": [
           "datasets_staging"
         ]

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
@@ -120,6 +120,88 @@ describe('GenericFormPickerComponent', () => {
     expect(component.formValues['q']).toBe('');
   });
 
+  describe('importer-suggested dataset name', () => {
+    // The suggestion round trip is debounced, so every assertion here has to
+    // step past SUGGESTED_NAME_DEBOUNCE_MS before the request exists.
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('prefills the Dataset Name box with the name the importer would use', () => {
+      openAndFlush();
+      component.formValues['path'] = '/data/field-recordings';
+      component.onFieldChanged('path');
+      vi.advanceTimersByTime(300);
+
+      const req = httpMock.expectOne('/api/dataset/import/generic_form/suggested-name');
+      expect(req.request.body.values['path']).toBe('/data/field-recordings');
+      // The importer is asked what it would pick, not handed the answer.
+      expect(req.request.body.values['dataset_name']).toBeUndefined();
+      req.flush({ dataset_name: 'Field Recordings' });
+
+      expect(component.formValues['dataset_name']).toBe('Field Recordings');
+    });
+
+    it('re-asks once a dynamic select resolves, so an opaque id can become a label', () => {
+      const field = { key: 'query_id', field_type: 'select', dynamic_options: true, required: true } as any;
+      component.selectedImporter.set({ name: 'imp', fields: [field] } as any);
+      (component as any).refreshDynamicFieldOptions(field);
+      httpMock
+        .expectOne((req) => req.url.endsWith('/api/dataset/import/imp/options'))
+        .flush({ options: [{ value: 'q-8f31', label: 'Q1 Field Survey' }] });
+      expect(component.formValues['query_id']).toBe('q-8f31');
+
+      vi.advanceTimersByTime(300);
+      const req = httpMock.expectOne('/api/dataset/import/imp/suggested-name');
+      expect(req.request.body.values['query_id']).toBe('q-8f31');
+      req.flush({ dataset_name: 'Q1 Field Survey' });
+
+      expect(component.formValues['dataset_name']).toBe('Q1 Field Survey');
+    });
+
+    it('stops asking once the user names the dataset themselves', () => {
+      openAndFlush();
+      component.onDatasetNameInput('My Corpus');
+      component.formValues['path'] = '/data/sounds';
+      component.onFieldChanged('path');
+      vi.advanceTimersByTime(300);
+
+      httpMock.expectNone((req) => req.url.endsWith('/suggested-name'));
+      expect(component.formValues['dataset_name']).toBe('My Corpus');
+    });
+
+    it('keeps the current name and stays silent when the importer errors', () => {
+      openAndFlush();
+      component.formValues['dataset_name'] = 'Earlier Suggestion';
+      component.formValues['path'] = '/data/sounds';
+      component.onFieldChanged('path');
+      vi.advanceTimersByTime(300);
+
+      httpMock
+        .expectOne('/api/dataset/import/generic_form/suggested-name')
+        .flush({ message: 'upstream down' }, { status: 502, statusText: 'Bad Gateway' });
+
+      expect(component.formValues['dataset_name']).toBe('Earlier Suggestion');
+      expect(component.error()).toBe('');
+    });
+
+    it('keeps suggesting after a failed request', () => {
+      openAndFlush();
+      component.formValues['path'] = '/data/one';
+      component.onFieldChanged('path');
+      vi.advanceTimersByTime(300);
+      httpMock
+        .expectOne('/api/dataset/import/generic_form/suggested-name')
+        .flush({ message: 'upstream down' }, { status: 502, statusText: 'Bad Gateway' });
+
+      component.formValues['path'] = '/data/two';
+      component.onFieldChanged('path');
+      vi.advanceTimersByTime(300);
+      httpMock.expectOne('/api/dataset/import/generic_form/suggested-name').flush({ dataset_name: 'Two' });
+
+      expect(component.formValues['dataset_name']).toBe('Two');
+    });
+  });
+
   it('surfaces a server error without emitting importStarted', () => {
     openAndFlush();
     component.formValues['path'] = '/data/sounds';

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
@@ -1,4 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, signal, input, output } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { EMPTY, Subject, catchError, debounceTime, filter, switchMap } from 'rxjs';
 
 import { FormsModule } from '@angular/forms';
 import { ClipperChooserComponent, ClipperSelection } from '../../../clipper-chooser/clipper-chooser.component';
@@ -24,6 +26,11 @@ import {
 } from '../../../../../models/api.models';
 import { ImportDefaultsService } from '../shared/import-defaults.service';
 import { availableConvertersFor, composeEmbedders, mediaTypeLabels, mediaTypeOptionIcons, mediaTypeOptionLabels, toFolderName, toTypeId } from '../shared/media-type.util';
+
+/** How long the form settles before asking the importer to name the dataset.
+ *  ``default_display_name`` may resolve a label from a remote service, so
+ *  keystrokes must not each cost a round trip. */
+const SUGGESTED_NAME_DEBOUNCE_MS = 250;
 
 /** Generic importer form: renders whatever fields an importer declares
  *  (``server_files``, ``pickle``, or any extension importer whose
@@ -71,8 +78,11 @@ export class GenericFormPickerComponent {
   readonly submitting = signal(false);
   readonly error = signal('');
   /** Whether the user has manually edited the generic-form dataset_name
-   *  input (so we stop auto-deriving it from path/url/file fields). */
+   *  input (so we stop asking the importer to name the dataset for them). */
   private datasetNameDirty = false;
+  /** Debounces the ``suggested-name`` round trip; ``switchMap`` drops the
+   *  reply to any request the user has already typed past. */
+  private readonly suggestedNameRequests = new Subject<void>();
 
   readonly availableClippers = signal<ClipperInfo[]>([]);
   /** Cleanup gates available for the current media type, and the subset the
@@ -95,6 +105,48 @@ export class GenericFormPickerComponent {
 
   clipperChooserOpen = false;
   clipperChooserClippers: ClipperInfo[] = [];
+
+  constructor() {
+    this.suggestedNameRequests
+      .pipe(
+        debounceTime(SUGGESTED_NAME_DEBOUNCE_MS),
+        // The user may have named the dataset since this request was armed,
+        // in which case there is nothing left to suggest.
+        filter(() => !this.datasetNameDirty),
+        switchMap(() => {
+          const importer = this.selectedImporter();
+          if (!importer) return EMPTY;
+          return this.datasetsCrudApi
+            .getImporterSuggestedName(importer.name, this.suggestedNameValues())
+            // A name hint is never worth an error banner: on failure the box
+            // just keeps whatever it already showed.
+            .pipe(catchError(() => EMPTY));
+        }),
+        takeUntilDestroyed(),
+      )
+      .subscribe((res) => {
+        // The user may have started typing while the request was in flight.
+        if (this.datasetNameDirty) return;
+        const suggested = (res.dataset_name || '').trim();
+        if (!suggested) return;
+        this.formValues['dataset_name'] = suggested;
+        this.cdr.markForCheck();
+      });
+  }
+
+  /** The form snapshot sent to ``suggested-name``: declared field values
+   *  only, minus ``dataset_name`` itself (the importer is being asked what
+   *  it would pick, not handed the answer). */
+  private suggestedNameValues(): Record<string, unknown> {
+    const values: Record<string, unknown> = {};
+    for (const field of this.selectedImporter()?.fields || []) {
+      if (field.key === 'dataset_name') continue;
+      const raw = this.formValues[field.key];
+      if (raw === undefined || raw === null || raw === '') continue;
+      values[field.key] = raw;
+    }
+    return values;
+  }
 
   get effectiveSoloMediaType(): string | null {
     return this.importDefaults.effectiveSoloMediaType;
@@ -181,6 +233,11 @@ export class GenericFormPickerComponent {
       }
     }
 
+    // Importers whose defaults already describe a dataset (a preselected
+    // select, a remembered path) get named before the user touches
+    // anything; the rest just get their display name back.
+    this.requestSuggestedDatasetName();
+
     // `open()` is invoked imperatively from the parent's importer-selection
     // handler (a listener bound on a sibling `<vt-source-picker>`), so this
     // component's own OnPush view is not on the ancestor-marked dirty path
@@ -212,7 +269,7 @@ export class GenericFormPickerComponent {
       this.refreshDynamicFieldOptions(field);
     }
     if (changedKey !== 'dataset_name') {
-      this.maybeApplyDerivedDatasetName();
+      this.requestSuggestedDatasetName();
     }
   }
 
@@ -226,39 +283,17 @@ export class GenericFormPickerComponent {
     this.onFieldChanged(key);
   }
 
-  private maybeApplyDerivedDatasetName(): void {
+  /** Ask the importer to name the dataset these form values describe.
+   *
+   *  The suggestion is computed server-side by the importer's
+   *  ``default_display_name``, so it is exactly the name the import would
+   *  fall back to if the box were left blank -- and an importer that maps
+   *  an opaque selection (an id, a saved-query key) onto a human-readable
+   *  label can surface that label here, which no client-side derivation
+   *  could work out.  No-ops once the user has typed a name of their own. */
+  private requestSuggestedDatasetName(): void {
     if (this.datasetNameDirty) return;
-    const derived = this.derivedDatasetName();
-    if (derived) {
-      this.formValues['dataset_name'] = derived;
-    }
-  }
-
-  private derivedDatasetName(): string {
-    const fields = this.selectedImporter()?.fields || [];
-    for (const f of fields) {
-      if (f.key === 'dataset_name') continue;
-      const raw = this.formValues[f.key];
-      if (typeof raw !== 'string' || !raw) continue;
-      if (f.field_type === 'url') {
-        const cleaned = raw.split('?')[0].replace(/\/+$/, '');
-        const tail = cleaned.split('/').pop() || '';
-        if (!tail) continue;
-        const stripped = tail.replace(/\.(?:tar\.gz|tar\.bz2|tar\.xz|tar|zip|rar)$/i, '');
-        return stripped || tail;
-      }
-      if (f.field_type === 'server_path' || f.field_type === 'file') {
-        const basename = raw.split(/[\\/]/).pop() || '';
-        if (!basename) continue;
-        const dot = basename.lastIndexOf('.');
-        return dot > 0 ? basename.slice(0, dot) : basename;
-      }
-      if (f.key === 'path') {
-        const parts = raw.split(/[\\/]/).filter(Boolean);
-        if (parts.length > 0) return parts[parts.length - 1];
-      }
-    }
-    return '';
+    this.suggestedNameRequests.next();
   }
 
   private refreshDynamicFieldOptions(field: ImporterField): void {
@@ -282,6 +317,10 @@ export class GenericFormPickerComponent {
         if (!this.formValues[key] && field.required && !field.allow_free_text && options.length > 0) {
           this.formValues[key] = options[0].value;
         }
+        // Auto-selecting an option is a form change like any other, and it
+        // is exactly the case the importer's own naming exists for: only it
+        // can turn the opaque option value back into a readable label.
+        this.requestSuggestedDatasetName();
       },
       error: (err) => {
         this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
@@ -376,7 +415,7 @@ export class GenericFormPickerComponent {
     if (input.files && input.files.length > 0) {
       this.selectedFile = input.files[0];
       this.formValues[fieldName] = input.files[0].name;
-      this.maybeApplyDerivedDatasetName();
+      this.requestSuggestedDatasetName();
     }
   }
 

--- a/frontend/src/app/services/datasets-crud-api.service.ts
+++ b/frontend/src/app/services/datasets-crud-api.service.ts
@@ -18,6 +18,7 @@ import type { DatasetStageFileResponse } from '../generated/api-client/models/da
 import type { DatasetStagingStartedResponse } from '../generated/api-client/models/dataset-staging-started-response';
 import type { DetectMediaTypeResponse } from '../generated/api-client/models/detect-media-type-response';
 import type { ImporterFieldOptionsResponse } from '../generated/api-client/models/importer-field-options-response';
+import type { ImporterSuggestedNameResponse } from '../generated/api-client/models/importer-suggested-name-response';
 import type {
   CleanerSelection,
   ImporterInfo,
@@ -32,6 +33,7 @@ import { datasetAllImporters } from '../generated/api-client/fn/datasets-listing
 import { datasetImporters } from '../generated/api-client/fn/datasets-listings/dataset-importers';
 import { detectMediaType } from '../generated/api-client/fn/datasets-ui/detect-media-type';
 import { importerFieldOptions } from '../generated/api-client/fn/datasets-staging/importer-field-options';
+import { importerSuggestedName } from '../generated/api-client/fn/datasets-staging/importer-suggested-name';
 import { loadDatasetFromSource } from '../generated/api-client/fn/datasets-load/load-dataset-from-source';
 import { loadDemoDatasetRoute } from '../generated/api-client/fn/datasets-load/load-demo-dataset-route';
 import { stageDemo } from '../generated/api-client/fn/datasets-staging/stage-demo';
@@ -97,6 +99,23 @@ export class DatasetsCrudApiService {
     return importerFieldOptions(this.http, this.config.rootUrl, {
       importer_name: importerName,
       body: { field_key: fieldKey, values },
+    }).pipe(map((r) => r.body));
+  }
+
+  /**
+   * Ask the importer what it would name a dataset built from *values*.
+   *
+   * Backed by the plugin's ``default_display_name``, so an importer can
+   * turn an opaque selection (an id, a saved-query key) into a
+   * human-readable name for the Dataset Name box.
+   */
+  getImporterSuggestedName(
+    importerName: string,
+    values: Record<string, unknown>,
+  ): Observable<ImporterSuggestedNameResponse> {
+    return importerSuggestedName(this.http, this.config.rootUrl, {
+      importer_name: importerName,
+      body: { values },
     }).pipe(map((r) => r.body));
   }
 

--- a/tests/io/test_suggested_dataset_name.py
+++ b/tests/io/test_suggested_dataset_name.py
@@ -1,0 +1,163 @@
+"""Tests for ``POST /api/dataset/import/<name>/suggested-name``.
+
+The route surfaces an importer's ``default_display_name`` live, so the
+Add-Dataset form can prefill its Dataset Name box with the same name the
+import would fall back to.  Its reason for existing is the case no
+client-side derivation can handle: an importer that maps an opaque
+internal selection (an id, a saved-query key) onto a human-readable label.
+
+Covers:
+
+- The route returns the importer's suggestion for the supplied form values.
+- A plugin that resolves an id to a label is reflected verbatim.
+- The user's own ``dataset_name`` is excluded from what the plugin sees.
+- Unknown importer → 404; a raising plugin → 502 carrying its message.
+- Importers that override nothing fall back to the generic derivation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.datasets.importers.base import DatasetImporter
+from vtscore.plugins import PluginField
+
+_QUERY_LABELS = {"q-8f31": "Q1 Field Survey", "q-2b07": "Q2 Coastal Sweep"}
+
+
+class _LabelResolvingImporter(DatasetImporter):
+    """The issue's shape: the form holds an id, only the plugin knows its name."""
+
+    name = "_stub_suggested_name"
+    display_name = "Stub Suggested Name"
+    description = "Test importer that names datasets after a selected query."
+    fields = [
+        PluginField("query_id", "Query", "select", options=sorted(_QUERY_LABELS)),
+    ]
+
+    def __init__(self, fail_with: Exception | None = None) -> None:
+        super().__init__()
+        self._fail_with = fail_with
+        self.seen_values: dict | None = None
+
+    def default_display_name(self, field_values):
+        if self._fail_with is not None:
+            raise self._fail_with
+        self.seen_values = dict(field_values)
+        return _QUERY_LABELS.get(field_values.get("query_id", ""), self.display_name)
+
+    def run(self, field_values, medias, thin=False):  # pragma: no cover; unused here
+        return None
+
+
+class _DerivingImporter(DatasetImporter):
+    """Overrides no naming code; relies on the base derivation."""
+
+    name = "_stub_derived_name"
+    display_name = "Stub Derived Name"
+    description = "Test importer with a URL field and no naming code."
+    fields = [PluginField("url", "URL", "url")]
+
+    def run(self, field_values, medias, thin=False):  # pragma: no cover; unused here
+        return None
+
+
+@pytest.fixture
+def register_importer():
+    """Register importers in the live registry for the duration of a test."""
+    from vtscore.datasets.importers import get_importer
+
+    registry = get_importer.__self__
+    registry._ensure_discovered()
+    registered: list[str] = []
+
+    def _register(importer):
+        registry._items[importer.name] = importer
+        registered.append(importer.name)
+        return importer
+
+    try:
+        yield _register
+    finally:
+        for name in registered:
+            registry._items.pop(name, None)
+
+
+def _post(client, importer_name, values):
+    return client.post(f"/api/dataset/import/{importer_name}/suggested-name", json={"values": values})
+
+
+class TestSuggestedNameRoute:
+    def test_resolves_an_opaque_id_to_a_label(self, client, register_importer):
+        stub = register_importer(_LabelResolvingImporter())
+        resp = _post(client, stub.name, {"query_id": "q-8f31"})
+        assert resp.status_code == 200
+        assert resp.get_json()["dataset_name"] == "Q1 Field Survey"
+
+    def test_tracks_the_current_selection(self, client, register_importer):
+        stub = register_importer(_LabelResolvingImporter())
+        assert _post(client, stub.name, {"query_id": "q-2b07"}).get_json()["dataset_name"] == "Q2 Coastal Sweep"
+
+    def test_unrecognised_selection_falls_back_to_the_importer_name(self, client, register_importer):
+        stub = register_importer(_LabelResolvingImporter())
+        assert _post(client, stub.name, {"query_id": "nope"}).get_json()["dataset_name"] == stub.display_name
+
+    def test_user_typed_name_is_hidden_from_the_plugin(self, client, register_importer):
+        """The plugin is asked what it *would* pick, not handed the answer."""
+        stub = register_importer(_LabelResolvingImporter())
+        resp = _post(client, stub.name, {"query_id": "q-8f31", "dataset_name": "My Corpus"})
+        assert resp.get_json()["dataset_name"] == "Q1 Field Survey"
+        assert stub.seen_values is not None
+        assert "dataset_name" not in stub.seen_values
+
+    def test_missing_values_key_is_allowed(self, client, register_importer):
+        stub = register_importer(_LabelResolvingImporter())
+        resp = client.post(f"/api/dataset/import/{stub.name}/suggested-name", json={})
+        assert resp.status_code == 200
+        assert resp.get_json()["dataset_name"] == stub.display_name
+
+    def test_suggestion_is_whitespace_stripped(self, client, register_importer):
+        class _Padded(_LabelResolvingImporter):
+            name = "_stub_padded_name"
+
+            def default_display_name(self, field_values):
+                return "  Padded  "
+
+        stub = register_importer(_Padded())
+        assert _post(client, stub.name, {}).get_json()["dataset_name"] == "Padded"
+
+    def test_unknown_importer_is_404(self, client):
+        assert _post(client, "_no_such_importer", {}).status_code == 404
+
+    def test_plugin_error_is_502_with_its_message(self, client, register_importer):
+        stub = register_importer(_LabelResolvingImporter(fail_with=RuntimeError("query service down")))
+        resp = _post(client, stub.name, {"query_id": "q-8f31"})
+        assert resp.status_code == 502
+        assert "query service down" in resp.get_data(as_text=True)
+
+    def test_falls_back_to_the_generic_derivation(self, client, register_importer):
+        """An importer that overrides nothing still suggests something useful."""
+        stub = register_importer(_DerivingImporter())
+        resp = _post(client, stub.name, {"url": "https://example.org/sets/genres.tar.gz"})
+        assert resp.get_json()["dataset_name"] == "genres"
+
+    def test_suggestion_matches_the_name_the_import_would_use(self, client, register_importer):
+        """The whole point: what the box shows is what a blank box would produce."""
+        stub = register_importer(_LabelResolvingImporter())
+        values = {"query_id": "q-8f31"}
+        suggested = _post(client, stub.name, values).get_json()["dataset_name"]
+        assert suggested == stub.resolve_display_name({**values, "dataset_name": ""})
+
+
+class TestBuiltinImporterSuggestions:
+    """Spot-check that the route works against real registered importers."""
+
+    def test_server_folder_suggests_the_leaf_directory(self, client):
+        resp = _post(client, "server_folder", {"path": "/data/sounds/sirens"})
+        assert resp.status_code == 200
+        assert resp.get_json()["dataset_name"] == "sirens"
+
+    def test_http_archive_strips_the_archive_extension(self, client):
+        resp = _post(client, "http_archive", {"url": "https://example.org/data/genres.tar.gz"})
+        assert resp.status_code == 200
+        assert resp.get_json()["dataset_name"] == "genres"

--- a/tests_lib/io/test_importers.py
+++ b/tests_lib/io/test_importers.py
@@ -482,6 +482,122 @@ class TestImporterDefaultDisplayName:
         assert "dataset_name" not in origin["params"]
 
 
+class TestBaseDefaultDisplayName:
+    """An importer that overrides nothing still gets a readable default name.
+
+    ``ImporterBase.default_display_name`` derives one from the importer's own
+    declared URL / path / upload fields, so a plugin only overrides it when it
+    knows something the fields do not (e.g. the label behind an opaque id).
+    """
+
+    def _importer(self, *fields):
+        from vtscore.datasets.importers.base import DatasetImporter
+
+        class Imp(DatasetImporter):
+            name = "derived"
+            display_name = "Derived Importer"
+            description = "Declares fields but no naming code."
+
+            def run(self, field_values, medias):
+                pass
+
+        Imp.fields = list(fields)
+        return Imp()
+
+    def test_url_field_uses_tail(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(PluginField("url", "URL", "url"))
+        assert imp.default_display_name({"url": "https://example.org/sets/sirens"}) == "sirens"
+
+    def test_url_field_ignores_query_fragment_and_trailing_slash(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(PluginField("url", "URL", "url"))
+        assert imp.default_display_name({"url": "https://example.org/sets/sirens/?token=abc"}) == "sirens"
+        assert imp.default_display_name({"url": "https://example.org/sets/sirens#part2"}) == "sirens"
+
+    def test_url_field_strips_compound_archive_suffix(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(PluginField("url", "URL", "url"))
+        assert imp.default_display_name({"url": "https://example.org/genres.tar.gz"}) == "genres"
+
+    def test_server_path_keeps_a_dotted_directory_name(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        # A path may name a directory, so only archive suffixes come off --
+        # ``2024.raw`` is a folder, not a file with an extension.
+        imp = self._importer(PluginField("root", "Root", "server_path"))
+        assert imp.default_display_name({"root": "/data/2024.raw"}) == "2024.raw"
+        assert imp.default_display_name({"root": "/data/photos.zip"}) == "photos"
+
+    def test_file_field_takes_the_stem(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(PluginField("file", "File", "file"))
+        assert imp.default_display_name({"file": "/tmp/uploads/genres.pkl"}) == "genres"
+
+    def test_file_field_reads_an_upload_filename(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        class Upload:
+            filename = "Field Recordings.zip"
+
+        imp = self._importer(PluginField("file", "File", "file"))
+        assert imp.default_display_name({"file": Upload()}) == "Field Recordings"
+
+    def test_text_field_named_path_is_treated_as_a_path(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(PluginField("path", "Path", "text"))
+        assert imp.default_display_name({"path": "/data/sounds/sirens/"}) == "sirens"
+
+    def test_windows_separators(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(PluginField("root", "Root", "server_path"))
+        assert imp.default_display_name({"root": r"C:\datasets\sirens"}) == "sirens"
+
+    def test_field_declaration_order_decides_precedence(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(
+            PluginField("url", "URL", "url"),
+            PluginField("root", "Root", "server_path"),
+        )
+        values = {"url": "https://example.org/from-url", "root": "/data/from-path"}
+        assert imp.default_display_name(values) == "from-url"
+
+    def test_opaque_field_types_contribute_nothing(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(
+            PluginField("query_id", "Query", "select", options=["q-8f31"]),
+            PluginField("token", "Token", "password"),
+            PluginField("limit", "Limit", "number"),
+        )
+        # Nothing derivable: this is exactly the case an importer overrides
+        # ``default_display_name`` to handle.
+        assert imp.default_display_name({"query_id": "q-8f31", "token": "s3cret", "limit": "10"}) == "Derived Importer"
+
+    def test_no_values_falls_back_to_display_name(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(PluginField("url", "URL", "url"))
+        assert imp.default_display_name({}) == "Derived Importer"
+        assert imp.default_display_name({"url": "   "}) == "Derived Importer"
+
+    def test_user_typed_name_is_not_used_as_its_own_default(self):
+        from vtscore.datasets.importers.base import PluginField
+
+        imp = self._importer(PluginField("url", "URL", "url"))
+        # ``resolve_display_name`` owns that precedence; the derivation skips
+        # the synthetic field entirely.
+        assert imp.default_display_name({"dataset_name": "Typed"}) == "Derived Importer"
+        assert imp.resolve_display_name({"dataset_name": "Typed"}) == "Typed"
+
+
 # ---------------------------------------------------------------------------
 # Folder importer not in builtin names
 # ---------------------------------------------------------------------------

--- a/vtscore/datasets/importers/base/__init__.py
+++ b/vtscore/datasets/importers/base/__init__.py
@@ -31,6 +31,8 @@ The base is split across submodules:
   spec-parsing / converter-ingestion helpers.
 - :mod:`~vtscore.datasets.importers.base.origin` — origin-serialisation policy
   helpers and the synthetic dataset-name field.
+- :mod:`~vtscore.datasets.importers.base.naming` — the generic dataset-name
+  derivation behind :meth:`~ImporterBase.default_display_name`.
 
 Example – a minimal SFTP importer skeleton::
 
@@ -74,6 +76,7 @@ from vtscore.plugins import PluginField
 
 from .core import ImporterBase
 from .dataset_importer import DatasetImporter
+from .naming import derive_display_name, strip_archive_suffix
 from .origin import DATASET_NAME_FIELD_KEY
 from .specs import MissingMediaTypeError, PickerView, SourceSpec
 
@@ -85,4 +88,6 @@ __all__ = [
     "PickerView",
     "PluginField",
     "SourceSpec",
+    "derive_display_name",
+    "strip_archive_suffix",
 ]

--- a/vtscore/datasets/importers/base/core.py
+++ b/vtscore/datasets/importers/base/core.py
@@ -21,6 +21,7 @@ from typing import Any, Iterator
 
 from vtscore.plugins import FieldOption, PluginBase, PluginField
 
+from .naming import derive_display_name
 from .origin import _dataset_name_field, _field_in_origin, _serialise_origin_value
 
 
@@ -204,13 +205,26 @@ class ImporterBase(PluginBase):
     def default_display_name(self, field_values: dict[str, Any]) -> str:
         """Return the importer-computed default name for a dataset.
 
-        Subclasses override this to derive a sensible default from
-        *field_values* (e.g. the demo importer reads the demo entry's
-        label).  The base implementation just returns :attr:`display_name`.
+        Subclasses override this to derive a name from *field_values* that
+        the generic derivation cannot reach -- most usefully, to turn an
+        opaque internal selection (an id, a saved-query key, a bucket
+        handle) into something human-readable.  The base implementation
+        walks the importer's own :attr:`fields` and derives a name from the
+        first URL / path / upload field that holds a value (see
+        :func:`~vtscore.datasets.importers.base.naming.derive_display_name`),
+        falling back to :attr:`display_name`.
+
+        This runs live while the user fills in the Add-Dataset form: the
+        frontend calls it through ``POST /api/dataset/import/<name>/
+        suggested-name`` on every field change and prefills the Dataset
+        Name box with the result.  Keep it cheap and side-effect free; if
+        it must reach a remote service to resolve a label, cache the
+        lookup, because it is called far more often than :meth:`run`.
+
         The user-typed ``dataset_name`` (when present) takes priority over
         whatever this method returns (see :meth:`resolve_display_name`).
         """
-        return self.display_name
+        return derive_display_name(self.fields, field_values) or self.display_name
 
     def resolve_display_name(self, field_values: dict[str, Any] | None) -> str:
         """Return the human-readable name to use for a dataset loaded with *field_values*.

--- a/vtscore/datasets/importers/base/naming.py
+++ b/vtscore/datasets/importers/base/naming.py
@@ -1,0 +1,126 @@
+"""Default dataset-name derivation shared by every importer.
+
+:meth:`ImporterBase.default_display_name` is the single hook an importer
+overrides to name the datasets it produces.  Its base implementation lives
+here: a generic derivation over the importer's own declared fields (URL
+tail, path leaf, uploaded filename), so a plugin that declares a ``url`` or
+``server_path`` field gets a sensible human-readable default without
+writing any naming code at all.
+
+This is also what the Add-Dataset form shows: ``POST /api/dataset/import/
+<name>/suggested-name`` calls ``default_display_name`` live as the user
+edits the form and prefills the Dataset Name box with the result.  The
+derivation therefore exists in exactly one place -- what the box shows is
+what the import will use.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from vtscore.plugins import PluginField
+
+from .origin import DATASET_NAME_FIELD_KEY
+
+#: Compound and plain archive extensions stripped from a derived name, so a
+#: ``photos.tar.gz`` download becomes ``photos`` rather than ``photos.tar``.
+#: Longest-first so the compound forms win over the bare ``.tar``.
+_ARCHIVE_SUFFIXES = (
+    ".tar.gz",
+    ".tar.bz2",
+    ".tar.xz",
+    ".tgz",
+    ".tbz2",
+    ".txz",
+    ".tar",
+    ".zip",
+    ".rar",
+)
+
+#: Field types whose value names a filesystem location the derivation can
+#: read a leaf out of.  ``file`` is handled separately (its value is an
+#: upload object, and files always carry an extension worth stripping).
+_PATH_FIELD_TYPES = frozenset({"server_path", "folder"})
+
+
+def strip_archive_suffix(name: str) -> str:
+    """Return *name* without a trailing archive extension.
+
+    Falls back to *name* unchanged when stripping would leave nothing
+    (e.g. a file literally called ``.zip``).
+    """
+    lowered = name.lower()
+    for suffix in _ARCHIVE_SUFFIXES:
+        if lowered.endswith(suffix):
+            return name[: -len(suffix)] or name
+    return name
+
+
+def _basename(raw: str) -> str:
+    """Return the last path segment of *raw*, tolerating either separator."""
+    return next((part for part in reversed(raw.replace("\\", "/").split("/")) if part), "")
+
+
+def _upload_filename(value: Any) -> str:
+    """Return the client-supplied filename behind a ``file`` field value.
+
+    Handles the three shapes a file field arrives as: a Werkzeug upload
+    (``.filename``), a file-like object opened from disk (``.name``), or a
+    plain path string (CLI runs).
+    """
+    if value is None:
+        return ""
+    for attr in ("filename", "name"):
+        candidate = getattr(value, attr, None)
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return value if isinstance(value, str) else ""
+
+
+def _candidate_from(field: PluginField, raw: Any) -> str:
+    """Return the name *field* suggests given its current *raw* value, or ``""``."""
+    if field.field_type == "file":
+        basename = _basename(_upload_filename(raw))
+        if not basename:
+            return ""
+        stripped = strip_archive_suffix(basename)
+        if stripped != basename:
+            return stripped
+        # A file always has an extension worth dropping; a directory (below)
+        # does not, which is why only this branch takes the stem.
+        dot = stripped.rfind(".")
+        return stripped[:dot] if dot > 0 else stripped
+
+    if not isinstance(raw, str) or not raw.strip():
+        return ""
+    raw = raw.strip()
+
+    if field.field_type == "url":
+        tail = _basename(raw.split("?")[0].split("#")[0])
+        return strip_archive_suffix(tail) if tail else ""
+
+    # A path field may name a directory, so only archive suffixes come off:
+    # a folder called ``2024.raw`` keeps its dotted name.
+    if field.field_type in _PATH_FIELD_TYPES or field.key == "path":
+        leaf = _basename(raw)
+        return strip_archive_suffix(leaf) if leaf else ""
+
+    return ""
+
+
+def derive_display_name(fields: Iterable[PluginField], field_values: dict[str, Any]) -> str:
+    """Return a dataset name derived from *field_values*, or ``""``.
+
+    Walks *fields* in declaration order and returns the first name any of
+    them yields, so an importer controls precedence by field ordering.  The
+    synthetic ``dataset_name`` field is skipped: it holds the user's own
+    answer, which :meth:`ImporterBase.resolve_display_name` already
+    prefers over anything derived here.
+    """
+    for field in fields:
+        if field.key == DATASET_NAME_FIELD_KEY:
+            continue
+        candidate = _candidate_from(field, field_values.get(field.key))
+        if candidate:
+            return candidate
+    return ""

--- a/vtscore/docs/packages/plugins.md
+++ b/vtscore/docs/packages/plugins.md
@@ -149,7 +149,7 @@ frontend handles its result-display directly.
 
 | Method | Description |
 |--------|-------------|
-| `resolve_display_name(field_values) -> str` | Override to return a dataset-specific label (e.g. the demo importer returns the demo name). Default returns `display_name`. |
+| `resolve_display_name(field_values) -> str` | Returns the label for the thing these `field_values` describe: the user-typed `dataset_name` when non-empty, else `default_display_name(field_values)`. Importers override `default_display_name`, not this. Default returns `display_name`. |
 | `add_cli_arguments(parser)` | Walks `fields` and adds an `argparse` argument per field. `"checkbox"` fields use `BooleanOptionalAction` (`--<key>` / `--no-<key>`). `"select"` fields get a `choices` constraint. `"number"` fields get `type=int` or `type=float` per `is_integer_number()`. |
 | `validate_cli_field_values(field_values)` | Raises `ValueError("Missing required argument: --<flag>")` if any non-checkbox required field is empty. Checkboxes are skipped because argparse always populates them. |
 | `to_dict()` | Returns the JSON-serialisable plugin metadata used by listing endpoints: `{name, display_name, description, icon, fields, ui_mode, hidden_from_picker}`. |

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -4,8 +4,9 @@ Migrated to ``flask_smorest`` so these routes appear in
 ``/api/openapi.json``. See ``docs/plans/openapi-schema.md``.
 
 JSON-shaped routes (available-files, combine, stage-demo, clear-staging,
-importer-field-options) use the standard ``@arguments`` + ``@response``
-decorators; schema-level validation failures surface as 422.
+importer-field-options, importer-suggested-name) use the standard
+``@arguments`` + ``@response`` decorators; schema-level validation
+failures surface as 422.
 Multipart-upload routes (``stage-file``) and plugin-field routes
 (``stage-import/<importer>``, ``import/<importer>``) keep ``@arguments``
 omitted; the latter pair's body shape depends on the importer plugin
@@ -32,6 +33,7 @@ from vtscore.concurrency.progress import CancelledError, loading_tasks
 from vtscore.config import EMBEDDINGS_DIR
 from vtscore.datasets import DEMO_DATASETS, export_dataset_to_file, get_importer, list_importers
 from vtscore.datasets.file_types import count_file_types
+from vtscore.datasets.importers.base import DATASET_NAME_FIELD_KEY
 from vtscore.datasets.load_pipeline import (
     STAGING_DIR,
     _run_importer_in_background,
@@ -63,6 +65,8 @@ from vtsearch.schemas.datasets import (
     DatasetStagingStartedResponseSchema,
     ImporterFieldOptionsRequestSchema,
     ImporterFieldOptionsResponseSchema,
+    ImporterSuggestedNameRequestSchema,
+    ImporterSuggestedNameResponseSchema,
 )
 from vtsearch.state import get_active_context, snapshot_medias
 from vtscore.security.pickle import peek_pickle_dataset_summary
@@ -628,6 +632,41 @@ def importer_field_options(body: dict, importer_name: str):
     if not isinstance(options, list):
         abort(500, message="get_field_options must return a list")
     return {"options": [_normalise_option(o) for o in options]}
+
+
+@datasets_staging_bp.route("/api/dataset/import/<importer_name>/suggested-name", methods=["POST"])
+@datasets_staging_bp.arguments(ImporterSuggestedNameRequestSchema)
+@datasets_staging_bp.response(200, ImporterSuggestedNameResponseSchema)
+@datasets_staging_bp.alt_response(404, description="Unknown importer name.")
+@datasets_staging_bp.alt_response(502, description="default_display_name raised an error.")
+def importer_suggested_name(body: dict, importer_name: str):
+    """Return the name the importer would give a dataset built from these values.
+
+    Calls the importer's ``default_display_name(field_values)`` with a
+    snapshot of the current form, so the Add-Dataset form can prefill its
+    Dataset Name box with something human-readable -- including a label a
+    plugin resolved from an opaque internal selection, which no
+    client-side derivation could produce.  The user's own ``dataset_name``
+    is deliberately ignored here: the caller only asks for the suggestion,
+    and decides for itself whether to overwrite what the user typed.
+
+    Errors from the plugin are surfaced as a 502 with the original
+    message; the frontend treats any failure as "no suggestion" and leaves
+    the box alone, since a name hint is never worth blocking an import.
+    """
+    importer, err = get_plugin_or_404(get_importer, list_importers, importer_name, "importer")
+    if err:
+        return err
+    assert importer is not None  # narrowed by err check
+
+    values = {k: v for k, v in (body.get("values") or {}).items() if k != DATASET_NAME_FIELD_KEY}
+
+    try:
+        suggested = importer.default_display_name(values)
+    except Exception as exc:  # noqa: BLE001 (surface remote-service errors verbatim)
+        abort(502, message=str(exc) or type(exc).__name__)
+
+    return {"dataset_name": str(suggested or "").strip()}
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -1000,6 +1000,23 @@ class ImporterFieldOptionsResponseSchema(Schema):
     options = fields.List(fields.Nested(FieldOptionsSchema), required=True)
 
 
+class ImporterSuggestedNameRequestSchema(Schema):
+    """Body for ``POST /api/dataset/import/<importer_name>/suggested-name``."""
+
+    values = fields.Dict(load_default=dict)
+
+
+class ImporterSuggestedNameResponseSchema(Schema):
+    """Response for ``POST /api/dataset/import/<importer_name>/suggested-name``.
+
+    ``dataset_name`` is what the importer would name a dataset built from
+    the supplied form values, i.e. the value the Dataset Name box is
+    prefilled with while the user is still typing.
+    """
+
+    dataset_name = fields.String(required=True)
+
+
 # ---------------------------------------------------------------------------
 # Registry routes (vtsearch/routes/datasets/registry.py)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2818

## The problem

An importer plugin whose form holds an **opaque selection** — a saved-query id, a bucket handle, an internal key — had no way to put a human-readable name in the Add-Dataset form's **Dataset Name** box.

The box was filled by a TypeScript heuristic in `generic-form-picker.component.ts` that only understood `url` / `server_path` / `file` fields. A plugin that selects by id matched none of them, so the user was left staring at `q-8f31` — or an empty box — unless the plugin worked around it by making the *name itself* the selectable value, which is exactly what the issue describes.

Meanwhile the plugin already knew the answer: `default_display_name(field_values)` is what the backend falls back to when the box is left blank. It just never reached the UI.

## The change

Surface that existing hook live, rather than adding a new one.

**New endpoint** — `POST /api/dataset/import/<name>/suggested-name`, body `{"values": {...}}` → `{"dataset_name": "..."}`. Calls the importer's `default_display_name()` with the current form snapshot. The user's own `dataset_name` is stripped before the plugin sees it: the route asks what the importer *would* pick, and the caller decides whether to use it.

**Generic importer form** — asks for a suggestion on every field change (debounced 250 ms, `switchMap` so a stale reply can't land) and prefills the box, until the user types a name of their own. Crucially it re-asks after a `dynamic_options` select resolves, which is the issue's exact scenario: pick *Q1 Field Survey* in the dropdown and the box fills with `Q1 Field Survey`, not `q-8f31`. A failed suggestion is silent — the box keeps what it had, since a name hint is never worth blocking an import over.

Because the box is now filled by the same method the import falls back to, **what the form shows is exactly what the import will use.**

## Consolidating the derivation

The TS heuristic moves into `ImporterBase.default_display_name` (new `vtscore/datasets/importers/base/naming.py`): URL tail, path leaf, upload stem, archive suffixes stripped, first field in declaration order wins. It previously existed in two languages with nothing binding them together; now there is one implementation, and a plugin that overrides nothing still gets a sensible name.

One deliberate divergence from the old TS version: a `server_path` keeps a dotted directory name (`2024.raw` stays `2024.raw`) since a path may name a folder, while a `file` field still takes the stem. This matches what `server_folder` already did in Python.

**In-tree importers are unaffected.** The eight that override naming keep their override; the three that don't (`local_folder`, `local_files`, `recaller`) declare no path-shaped field, so they fall back to `display_name` as before.

## Behavior change worth flagging

A third-party importer that declares a `url` or path field and overrides nothing now gets a *derived* dataset name where it previously got the plain importer display name. That is the intended improvement, but it does change persisted dataset names for such plugins.

## Tests

- `tests/io/test_suggested_dataset_name.py` (new, 12 tests) — id→label resolution, `dataset_name` hidden from the plugin, 404 / 502 handling, fallback to the generic derivation, and that the suggestion equals what a blank box would produce.
- `tests_lib/io/test_importers.py` — 12 tests for the base derivation (query strings, compound archive suffixes, Windows separators, upload objects, field precedence, opaque field types contributing nothing).
- `generic-form-picker.component.spec.ts` — 5 tests covering prefill, the dynamic-select re-ask, user-typed values winning, and silent recovery from a failing suggestion.

`./run-tests.sh` green: **7489 passed**, 1 skipped. `./run-tests.sh vtscore-clean` green (3371). Frontend gate green (build + audit + 1911 Vitest).

## Docs

New **Naming the imported dataset** section in `docs/EXTENDING-plugins.md` (this was previously undocumented for importers, including the synthetic `dataset_name` field the base class injects), the endpoint in `docs/api/datasets.md`, an optional-override row, a checklist bullet in `docs/EXTENDING.md`, and a correction to `vtscore/docs/packages/plugins.md`, which told plugin authors to override `resolve_display_name` rather than `default_display_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122JYuWXZ6NbrYpN9Q9jBqm

---
_Generated by [Claude Code](https://claude.ai/code/session_0122JYuWXZ6NbrYpN9Q9jBqm)_