### PR TITLE
Roll out the linear head to the region-voting / uncached calibration path

### DIFF
--- a/tests_lib/detectors/test_linear_head_fidelity.py
+++ b/tests_lib/detectors/test_linear_head_fidelity.py
@@ -173,6 +173,102 @@ class TestProductionPathTrainsTheLinearHead:
         assert [type(layer) for layer in model] == [torch.nn.Linear]
         assert set(serialize_weights(model)) == {"0.weight", "0.bias"}
 
+    def _region_labels(self, seed: int = 5, rows_per_bad_bag: int = 3):
+        """Flooded region label set: 4 Good rows (one bag each), 4 Bad bags of N rows.
+
+        Mirrors what region flooding hands ``train_and_threshold``: a Good vote
+        contributes its one snapped-box row, a Bad vote floods its leaf set.
+        """
+        rng = np.random.default_rng(seed)
+
+        def _unit(vec: np.ndarray) -> np.ndarray:
+            return (vec / (np.linalg.norm(vec) + 1e-8)).astype(np.float32)
+
+        good_proto = _unit(rng.standard_normal(DIM))
+        bad_proto = _unit(rng.standard_normal(DIM))
+        X_list: list[np.ndarray] = []
+        y_list: list[float] = []
+        groups: list = []
+        for i in range(4):
+            X_list.append(_unit(good_proto + 0.1 * rng.standard_normal(DIM)))
+            y_list.append(1.0)
+            groups.append(("g", i))
+        for i in range(4):
+            for _ in range(rows_per_bad_bag):
+                X_list.append(_unit(bad_proto + 0.1 * rng.standard_normal(DIM)))
+                y_list.append(0.0)
+                groups.append(("b", i))
+        return X_list, y_list, groups
+
+    def _spy_hidden_dims(self, monkeypatch) -> list:
+        """Record the ``hidden_dim`` of every ``train_model`` call (folds + final).
+
+        Patches both the defining module and the package re-export: the
+        calibration folds resolve ``train_model`` from ``vtscore.training.mlp``
+        at call time, while ``train_and_threshold``'s final fit resolves it from
+        the ``vtscore.training`` package namespace.
+        """
+        import vtscore.training as training_pkg  # noqa: PLC0415
+        import vtscore.training.mlp as mlp_module  # noqa: PLC0415
+
+        seen: list = []
+        real = mlp_module.train_model
+
+        def spy(*args, **kwargs):
+            seen.append(kwargs.get("hidden_dim", "MISSING"))
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(mlp_module, "train_model", spy)
+        monkeypatch.setattr(training_pkg, "train_model", spy)
+        return seen
+
+    def test_uncached_calibration_folds_use_the_linear_head(self, monkeypatch):
+        """The ``det_ctx is None`` branch calibrates on the linear head too (#2824).
+
+        Before the fix this branch omitted ``hidden_dim`` from
+        ``calculate_cross_calibration_threshold``, so the fold models auto-sized
+        to the MLP while the final model was linear - the threshold was measured
+        on an architecture the detector never ships.
+        """
+        from vtscore.detectors.training import train_and_threshold  # noqa: PLC0415
+
+        seen = self._spy_hidden_dims(monkeypatch)
+        _snap, X_list, y_list = self._snap_and_labels()
+        train_and_threshold(X_list, y_list)
+
+        # At least the calibration folds plus the final fit.
+        assert len(seen) >= 2
+        assert all(h == LINEAR_HEAD for h in seen), f"non-linear train_model calls: {seen}"
+
+    def test_region_bag_uncached_path_uses_the_linear_head(self, monkeypatch):
+        """A flooded region label set calibrates + trains linear end-to-end (#2824)."""
+        from vtscore.detectors.training import train_and_threshold  # noqa: PLC0415
+
+        seen = self._spy_hidden_dims(monkeypatch)
+        X_list, y_list, groups = self._region_labels()
+        model, _threshold = train_and_threshold(X_list, y_list, groups=groups)
+
+        assert len(seen) >= 2
+        assert all(h == LINEAR_HEAD for h in seen), f"non-linear train_model calls: {seen}"
+        assert [type(layer) for layer in model] == [torch.nn.Linear]
+
+    def test_region_bag_cached_path_uses_the_linear_head(self, monkeypatch):
+        """The det_ctx (cached grouped-calibration) path is linear end-to-end too."""
+        from types import SimpleNamespace  # noqa: PLC0415
+
+        from vtscore.detectors.training import train_and_threshold  # noqa: PLC0415
+
+        seen = self._spy_hidden_dims(monkeypatch)
+        X_list, y_list, groups = self._region_labels()
+        det_ctx = SimpleNamespace(calibration_cache=None)
+        model, _threshold = train_and_threshold(X_list, y_list, det_ctx=det_ctx, groups=groups)
+
+        assert len(seen) >= 2
+        assert all(h == LINEAR_HEAD for h in seen), f"non-linear train_model calls: {seen}"
+        assert [type(layer) for layer in model] == [torch.nn.Linear]
+        # The fold orderings were cached for a later no-retrain Inclusion slide.
+        assert det_ctx.calibration_cache is not None
+
 
 class TestLinearHeadStructure:
     def test_single_linear_layer(self):

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -240,9 +240,10 @@ def train_and_threshold(
 
     # The production detector head is linear (logistic regression): stable under
     # sparse positives where a small MLP's per-retrain score wobble drove the
-    # threshold-stability #2790 spikes.  The same head sizes both the final model
-    # and the cached fold sub-models below, so the cached re-thresholding stays
-    # consistent with this run's threshold.
+    # threshold-stability #2790 spikes.  The same head sizes the final model and
+    # the calibration fold models on *both* branches below (cached and uncached),
+    # so the calibrated threshold is always measured on the architecture the
+    # final model actually has.
     hidden_dim = LINEAR_HEAD
 
     safe = bool(get_safe_thresholds() and snap)
@@ -282,6 +283,7 @@ def train_and_threshold(
             get_inclusion(),
             calibrate_count=get_calibrate_count(),
             calibration_fraction=get_calibration_fraction(),
+            hidden_dim=hidden_dim,
             groups=cal_groups,
             score_rows_by_group=cal_score_rows,
         )


### PR DESCRIPTION
Closes #2824

## What

Completes the linear-head rollout (Part A of #2824): the `det_ctx is None` branch of `train_and_threshold` — reached by Find verification (`vtsearch/routes/detectors/find.py`) and label-file sort (`vtsearch/routes/sorting.py`) — called `calculate_cross_calibration_threshold` **without** `hidden_dim`, so its calibration folds auto-sized to the MLP (`_auto_hidden_dim`) while the final model trained the linear head. The threshold was being measured on fold models with an architecture the shipped detector doesn't have.

The fix passes `hidden_dim=LINEAR_HEAD` on that branch, making every production path — cached and uncached, row-wise and region/bag grouped — calibrate on the same head it trains.

## Why now

The region-voting head experiment ({DINOv2, DINOv3} × MaxPatch on VG, `mlp` vs `linear` arms) is still running, but the results are already strong enough to start the rollout, matching the boolean-path findings from #2790 (deep-spike rate roughly halved, lower FNR and cost).

## Audit

Per the issue, audited the other production calibration sites:

- `_train_and_score_xy` (vote/labelset path): already threads `hidden_dim=LINEAR_HEAD` through `cross_calibration_threshold_cached` — clean.
- `train_detector_from_origins` (`training.py:947`): already passes `hidden_dim=LINEAR_HEAD` — clean.
- The eval-harness arms in `vtscore/eval/voting_iterations.py` (`_mlp_train_and_calibrate`, `_style_train_and_calibrate`) intentionally measure the MLP candidate head and are left unchanged; the trainer-seam threading for region-voting head arms (Part B) lives on the `evaluation-framework` branch.

## Tests

Three new regression tests in `tests_lib/detectors/test_linear_head_fidelity.py` spy on every `train_model` call (calibration folds + final fit) and assert `hidden_dim == LINEAR_HEAD` end-to-end on:

- the uncached row-wise path (`det_ctx=None` — the fixed branch),
- the uncached region-bag path (flooded Bad bags via `groups`),
- the cached region-bag path (`det_ctx` provided; also asserts the fold orderings are cached for a no-retrain Inclusion slide).

`./run-tests.sh` full suite: **ALL 7497 TESTS PASSED** (1 skipped), plus frontend build/audit/Vitest (1925 passed), ruff, codespell, deptry, pip-audit, pyright all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnP8PR4UZXjHjX6UsY1fMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnP8PR4UZXjHjX6UsY1fMM)_