### PR TITLE
Light up the container read on the dataset loading bar

### DIFF
--- a/tests_lib/datasets/test_cached_load_progress.py
+++ b/tests_lib/datasets/test_cached_load_progress.py
@@ -79,6 +79,38 @@ class _Recorder:
         """Events that carry a real denominator, i.e. move a determinate bar."""
         return [e for e in self.events if e[3] > 0]
 
+    @property
+    def fractions(self) -> list[float]:
+        """The bar fraction each counted event puts on screen."""
+        return [current / total for _, _, current, total in self.counted]
+
+    def phase(self, prefix: str) -> list[float]:
+        """Fractions reported by counted events whose message starts *prefix*."""
+        return [c / t for _, message, c, t in self.counted if message.startswith(prefix)]
+
+
+def assert_one_monotone_bar(progress: _Recorder) -> None:
+    """Pin the invariant that makes the read reportable without stalling the loop.
+
+    The load's two sub-phases measure different things (bytes consumed, then
+    items built), so they must still share one denominator and one
+    non-decreasing fraction.  Were they each given their native scale, the
+    handover would rewind the fraction to zero — and because every consumer
+    clamps monotonically (``ProgressTracker._compute_overall`` pins
+    ``overall``, ``AdaptiveLoadPacer.update`` pins ``_frac``), that rewind
+    surfaces as the bar *freezing* for the whole item loop rather than
+    visibly retreating.
+    """
+    counted = progress.counted
+    assert counted, "load must report progress with a real denominator"
+    assert len({total for _, _, _, total in counted}) == 1, (
+        "both sub-phases must report against one shared denominator"
+    )
+    fractions = progress.fractions
+    assert all(b >= a for a, b in zip(fractions, fractions[1:])), (
+        f"bar fraction must never retreat, got {fractions}"
+    )
+
 
 def test_cached_demo_load_reports_per_item_progress(tmp_path: Path, monkeypatch):
     """A "Ready" demo ticks per-item progress, not one static message."""
@@ -90,11 +122,9 @@ def test_cached_demo_load_reports_per_item_progress(tmp_path: Path, monkeypatch)
     load_demo_dataset(DEMO_ID, loaded, on_progress=progress)
 
     assert loaded.keys() == medias.keys()
-    counted = progress.counted
-    assert counted, "cached demo load must report progress with a real total"
-    assert all(total == len(medias) for _, _, _, total in counted)
+    assert_one_monotone_bar(progress)
     # More than the single opening tick, so the bar actually advances mid-read.
-    assert max(current for _, _, current, _ in counted) > 0
+    assert max(current for _, _, current, _ in progress.counted) > 0
 
 
 def test_cached_demo_load_still_finishes_idle(tmp_path: Path, monkeypatch):
@@ -129,14 +159,12 @@ def test_pickle_importer_reports_per_item_progress(tmp_path: Path):
         clear_thread_progress()
 
     assert loaded.keys() == medias.keys()
-    counted = progress.counted
-    assert counted, "pickle import must report progress with a real total"
-    assert all(total == len(medias) for _, _, _, total in counted)
+    assert_one_monotone_bar(progress)
 
 
 @pytest.mark.parametrize("n", [2, 51, 120])
-def test_progress_totals_match_item_count(tmp_path: Path, monkeypatch, n: int):
-    """The reported denominator is the item count at every dataset size.
+def test_progress_stays_one_monotone_bar_at_every_size(tmp_path: Path, monkeypatch, n: int):
+    """The bar stays single-denominator and monotone at every dataset size.
 
     ``load_dataset_from_pickle`` derives its tick interval from the item
     count, so a size that lands on an interval boundary must not silently
@@ -149,5 +177,45 @@ def test_progress_totals_match_item_count(tmp_path: Path, monkeypatch, n: int):
     load_demo_dataset(DEMO_ID, loaded, on_progress=progress)
 
     assert len(loaded) == n
-    assert progress.counted, f"no counted progress for n={n}"
-    assert all(total == n for _, _, _, total in progress.counted)
+    assert_one_monotone_bar(progress)
+
+
+def test_container_read_advances_the_bar(tmp_path: Path, monkeypatch):
+    """The container read reports real movement instead of a dark window.
+
+    Reading the container — streaming ``medias.pkl`` and deserialising it —
+    used to report ``total == 0`` for its whole duration, which renders as an
+    indeterminate bar that never advances.  On the large demos that is tens of
+    seconds of dead bar right after the user clicks Import.
+    """
+    _write_cached_demo(tmp_path, monkeypatch, n=120)
+
+    loaded: dict = {}
+    progress = _Recorder()
+    load_demo_dataset(DEMO_ID, loaded, on_progress=progress)
+
+    read_fractions = progress.phase("Reading")
+    assert read_fractions, "the container read must report counted progress"
+    assert max(read_fractions) > 0, "the read must advance the bar, not park it at zero"
+
+
+def test_read_and_item_phases_partition_the_bar(tmp_path: Path, monkeypatch):
+    """The read hands the bar to the item loop; neither replays the other's span.
+
+    The read owns ``[0, _READ_SHARE]`` and the item loop ``[_READ_SHARE, 1]``,
+    so the two together sweep the bar exactly once.
+    """
+    from vtscore.datasets.loader_pickle import _READ_SHARE
+
+    _write_cached_demo(tmp_path, monkeypatch, n=120)
+
+    loaded: dict = {}
+    progress = _Recorder()
+    load_demo_dataset(DEMO_ID, loaded, on_progress=progress)
+
+    read_fractions = progress.phase("Reading")
+    item_fractions = progress.phase("Processing")
+    assert max(read_fractions) <= _READ_SHARE + 1e-9
+    assert min(item_fractions) >= _READ_SHARE - 1e-9
+    # The item loop finishes the bar rather than stopping short of it.
+    assert max(item_fractions) == pytest.approx(1.0, abs=1e-3)

--- a/tests_lib/datasets/test_cached_load_progress.py
+++ b/tests_lib/datasets/test_cached_load_progress.py
@@ -103,13 +103,9 @@ def assert_one_monotone_bar(progress: _Recorder) -> None:
     """
     counted = progress.counted
     assert counted, "load must report progress with a real denominator"
-    assert len({total for _, _, _, total in counted}) == 1, (
-        "both sub-phases must report against one shared denominator"
-    )
+    assert len({total for _, _, _, total in counted}) == 1, "both sub-phases must report against one shared denominator"
     fractions = progress.fractions
-    assert all(b >= a for a, b in zip(fractions, fractions[1:])), (
-        f"bar fraction must never retreat, got {fractions}"
-    )
+    assert all(b >= a for a, b in zip(fractions, fractions[1:])), f"bar fraction must never retreat, got {fractions}"
 
 
 def test_cached_demo_load_reports_per_item_progress(tmp_path: Path, monkeypatch):

--- a/tests_lib/datasets/test_container.py
+++ b/tests_lib/datasets/test_container.py
@@ -6,6 +6,7 @@ import pickle
 import zipfile
 
 import numpy as np
+import pytest
 
 from vtscore.datasets.container import (
     append_projection,
@@ -65,6 +66,65 @@ class TestContainerFormat:
         assert meta["embedder"] == "test_embedder"
         assert meta["clipper"] == "test_clipper"
         assert meta["name"] == "Test Dataset"
+
+    def test_read_reports_byte_progress(self, tmp_path):
+        """``on_progress`` tracks the read against the entry's byte size.
+
+        The counter wraps the stream the *unpickler* pulls from, so it spans
+        deserialisation too — not just the transfer.  That is the whole point:
+        on a text-shaped container the raw transfer is a small minority of the
+        phase, so counting transfer alone would leave most of it dark.
+        """
+        path = tmp_path / "dataset.pkl"
+        write_container(path, _medias_pkl_bytes(200), _meta())
+        with zipfile.ZipFile(str(path), "r") as zf:
+            entry_size = zf.getinfo("medias.pkl").file_size
+
+        seen: list[tuple[int, int]] = []
+        data, _meta_out = read_container(path, on_progress=lambda c, t: seen.append((c, t)))
+
+        assert len(data["medias"]) == 200, "streaming must not disturb the payload"
+        assert seen, "a read with a callback must report progress"
+        assert all(total == entry_size for _, total in seen)
+        assert [c for c, _ in seen] == sorted(c for c, _ in seen), "counter must not retreat"
+        assert all(current <= entry_size for current, _ in seen)
+
+    def test_read_publishes_denominator_before_streaming(self, tmp_path):
+        """The first tick carries the total, even when the read fits in one gulp.
+
+        Callers scale their whole phase against this denominator, so a
+        container small enough to finish inside a single tick must still
+        announce it rather than leaving the caller with no scale.
+        """
+        path = tmp_path / "dataset.pkl"
+        write_container(path, _medias_pkl_bytes(1), _meta())
+
+        seen: list[tuple[int, int]] = []
+        read_container(path, on_progress=lambda c, t: seen.append((c, t)))
+
+        assert seen[0][0] == 0
+        assert seen[0][1] > 0
+
+    def test_read_without_progress_still_round_trips(self, tmp_path):
+        """The no-callback path stays the plain streamed read."""
+        path = tmp_path / "dataset.pkl"
+        write_container(path, _medias_pkl_bytes(20), _meta())
+        data, meta = read_container(path)
+        assert len(data["medias"]) == 20
+        assert meta["embedder"] == "test_embedder"
+
+    def test_streamed_read_still_rejects_forbidden_classes(self, tmp_path):
+        """Streaming must not weaken the restricted unpickler's allowlist."""
+        import pickle as _pickle
+
+        path = tmp_path / "evil.pkl"
+        payload = b"c__builtin__\neval\n(S'1+1'\ntR."
+        with zipfile.ZipFile(str(path), "w") as zf:
+            zf.writestr("medias.pkl", payload)
+            zf.writestr("meta.json", "{}")
+
+        with pytest.raises(_pickle.UnpicklingError):
+            read_container(path, on_progress=lambda c, t: None)
 
     def test_payload_stored_uncompressed(self, tmp_path):
         """medias.pkl must be stored (ZIP_STORED), not DEFLATE-compressed.

--- a/vtscore/datasets/container.py
+++ b/vtscore/datasets/container.py
@@ -23,9 +23,15 @@ from typing import Any
 
 import numpy as np
 
-from vtscore.security.pickle import safe_pickle_load
+from vtscore.security.pickle import RestrictedUnpickler, safe_pickle_load
 
 logger = logging.getLogger(__name__)
+
+#: Report at most this many byte-progress ticks while streaming ``medias.pkl``.
+#: Matches the ~50-update budget the per-item load loop uses: every tick is a
+#: full re-serialisation of the task list pushed to every open SSE stream, so
+#: the cost is per-*event*, not per-byte.
+_READ_PROGRESS_TICKS = 50
 
 
 # ---------------------------------------------------------------------------
@@ -101,13 +107,88 @@ def write_container(
 # ---------------------------------------------------------------------------
 
 
-def read_container(path: str | Path) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Read a container, returning ``(data_dict, meta)``."""
+class _CountingReader(io.BufferedIOBase):
+    """Byte-counting passthrough that feeds the unpickler and reports progress.
+
+    Wrapping the raw ``medias.pkl`` stream — rather than the old
+    ``zf.read()``-then-unpickle pair — is what makes the read reportable at
+    all.  The unpickler pulls bytes through here as it materialises objects,
+    so the counter advances across the *whole* phase (stream + deserialise)
+    instead of only the transfer half.  That distinction is the point: on the
+    text demos the raw read is ~14% of the phase and the deserialise is the
+    rest, so counting only the transfer would leave most of the window as dark
+    as it was before.
+
+    Streaming also drops peak allocation by ~45% (no full serialised blob
+    held alongside the objects being built from it), which is the difference
+    between loading and :class:`MemoryError` on the multi-GB demos.
+
+    ``peek`` is deliberately *not* exposed: the C unpickler would use it for
+    framing lookahead, and peeked bytes are not consumed, so counting them
+    would double-count and run the fraction past 1.0.
+    """
+
+    def __init__(self, raw: Any, total: int, on_progress: Any) -> None:
+        self._raw = raw
+        self._total = total
+        self._on_progress = on_progress
+        self._read = 0
+        self._step = max(1, total // _READ_PROGRESS_TICKS) if total > 0 else 0
+        self._next_tick = self._step
+
+    def _advance(self, n: int) -> None:
+        self._read += n
+        if self._step and self._read >= self._next_tick:
+            # Snap to the tick grid so a single huge read (a multi-MB inline
+            # blob) skips the ticks it flew past instead of emitting one event
+            # per grid line it crossed.
+            self._next_tick = ((self._read // self._step) + 1) * self._step
+            self._on_progress(min(self._read, self._total), self._total)
+
+    def read(self, size: int | None = -1) -> bytes:
+        chunk = self._raw.read(size)
+        self._advance(len(chunk))
+        return chunk
+
+    def readline(self, size: int | None = -1) -> bytes:  # type: ignore[override]
+        line = self._raw.readline(size)
+        self._advance(len(line))
+        return line
+
+    def readinto(self, buf: Any) -> int:
+        n = self._raw.readinto(buf) or 0
+        self._advance(n)
+        return n
+
+    def readable(self) -> bool:
+        return True
+
+
+def read_container(
+    path: str | Path,
+    on_progress: Any = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Read a container, returning ``(data_dict, meta)``.
+
+    *on_progress*, when given, is called as ``on_progress(bytes_read,
+    total_bytes)`` while the ``medias.pkl`` entry streams into the unpickler,
+    at most :data:`_READ_PROGRESS_TICKS` times.  Callers that drive a progress
+    bar use it to keep the read reportable; everything else omits it and pays
+    nothing.
+    """
     p = Path(path)
 
     with zipfile.ZipFile(str(p), "r") as zf:
-        pkl_bytes = zf.read("medias.pkl")
-        data = safe_pickle_load(io.BytesIO(pkl_bytes))
+        info = zf.getinfo("medias.pkl")
+        with zf.open("medias.pkl") as raw:
+            if on_progress is None:
+                data = safe_pickle_load(raw)
+            else:
+                # Publish the denominator before the first byte moves, so the
+                # caller can scale its whole phase against it even on a
+                # container small enough to finish inside one tick.
+                on_progress(0, info.file_size)
+                data = RestrictedUnpickler(_CountingReader(raw, info.file_size, on_progress)).load()
         if not isinstance(data, dict) or "medias" not in data:
             raise ValueError(f"Invalid container {p.name}: pickle missing 'medias' key.")
 

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -46,17 +46,29 @@ def _load_embeddings_dict(media_info: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
-def _read_pickle_dataset(file_path: Path) -> dict[str, Any]:
+#: Share of the pickle load's wall clock spent streaming + deserialising the
+#: container, before the per-item conversion loop starts.  Measured across two
+#: dataset shapes (a 243 MB / 20k-item image container and a 328 MB / 105k-item
+#: text container): the read phase ran 56% and 43% of the total respectively,
+#: so half is the honest split.  It only sets where the read hands the bar over
+#: to the item loop; both sub-phases advance the same fraction either way, so a
+#: drift of a few points costs pacing smoothness, never correctness.
+_READ_SHARE = 0.5
+
+
+def _read_pickle_dataset(file_path: Path, on_progress: Any = None) -> dict[str, Any]:
     """Load a dataset ZIP container and assert the ``"medias"`` envelope.
 
     Translates :class:`MemoryError` into a contextual message and raises
     :class:`ValueError` when the file does not contain a dict with a
-    ``"medias"`` key.
+    ``"medias"`` key.  *on_progress* is forwarded to
+    :func:`~vtscore.datasets.container.read_container` as
+    ``on_progress(bytes_read, total_bytes)``.
     """
     from vtscore.datasets.container import read_container
 
     try:
-        data, _meta = read_container(file_path)
+        data, _meta = read_container(file_path, on_progress=on_progress)
     except MemoryError:
         gc.collect()
         raise MemoryError(
@@ -414,10 +426,30 @@ def load_dataset_from_pickle(
         :func:`vtscore.state.coverage.restore_coverage_atlas_from_cache` to
         skip rebuilding the coverage atlas.
     """
+    # Both sub-phases of this load — streaming/deserialising the container, then
+    # converting each media — report against one denominator: the container's
+    # ``medias.pkl`` byte size.  They measure different things (bytes consumed
+    # vs items built), so giving each its native scale would rewind the fraction
+    # to zero at the handover, and every consumer clamps monotonically:
+    # ``ProgressTracker._compute_overall`` pins ``overall`` and
+    # ``AdaptiveLoadPacer.update`` pins ``_frac``.  A rewind therefore does not
+    # show as a rewind, it shows as a *freeze* for the whole item loop — which
+    # is how lighting up the read would have bought a lit read at the cost of a
+    # dead conversion.  One shared scale keeps the fraction monotone across the
+    # handover; the human-readable counts stay in the message.
+    read_total = 0
+
+    def _read_progress(read_bytes: int, total_bytes: int) -> None:
+        nonlocal read_total
+        read_total = total_bytes
+        if total_bytes > 0:
+            assert on_progress is not None
+            on_progress("loading", f"Reading {file_path.name}…", int(_READ_SHARE * read_bytes), total_bytes)
+
     if on_progress is not None:
         on_progress("loading", f"Reading {file_path.name}…", 0, 0)
 
-    data = _read_pickle_dataset(file_path)
+    data = _read_pickle_dataset(file_path, _read_progress if on_progress is not None else None)
     medias.clear()
     cached_coverage_atlas = data.get("coverage_atlas")
     medias_data = data["medias"]
@@ -433,8 +465,21 @@ def load_dataset_from_pickle(
     # task list pushed to every open SSE stream (enough to back up the
     # per-client 1024-deep queue and start dropping frames).
     _progress_interval = max(1, total_count // 50) if total_count > 0 else 1
+
+    def _item_progress(loaded: int) -> None:
+        """Report the item loop on the shared byte scale set by the read."""
+        assert on_progress is not None
+        message = f"Processing {loaded} of {total_count} items…"
+        if read_total <= 0 or total_count <= 0:
+            # No denominator to continue from (an unreadable entry size, or an
+            # empty dataset): fall back to the item scale on its own.
+            on_progress("loading", message, loaded, total_count)
+            return
+        done = _READ_SHARE + (1.0 - _READ_SHARE) * (loaded / total_count)
+        on_progress("loading", message, int(read_total * done), read_total)
+
     if on_progress is not None:
-        on_progress("loading", f"Processing 0 of {total_count} items…", 0, total_count)
+        _item_progress(0)
 
     try:
         for media_id, media_info in medias_data.items():
@@ -453,7 +498,7 @@ def load_dataset_from_pickle(
             medias[media_id] = media_data
             loaded_count += 1
             if on_progress is not None and loaded_count % _progress_interval == 0:
-                on_progress("loading", f"Processing {loaded_count} of {total_count} items…", loaded_count, total_count)
+                _item_progress(loaded_count)
     except MemoryError:
         medias.clear()
         del data

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -56,6 +56,45 @@ def _load_embeddings_dict(media_info: dict[str, Any]) -> dict[str, Any] | None:
 _READ_SHARE = 0.5
 
 
+class _PickleLoadProgress:
+    """Composites a pickle load's two sub-phases onto one monotone bar.
+
+    Streaming/deserialising the container and converting each media measure
+    different things — bytes consumed, then items built — so reporting each on
+    its native scale would rewind the fraction to zero at the handover.  Every
+    consumer clamps monotonically (``ProgressTracker._compute_overall`` pins
+    ``overall``, ``AdaptiveLoadPacer.update`` pins ``_frac``), so that rewind
+    never shows as a retreat; it shows as the bar *freezing* for the whole item
+    loop.  Lighting up the read at the cost of deadening the conversion is not
+    a trade worth making, so both report against one denominator — the
+    ``medias.pkl`` byte size — with the read owning ``[0, _READ_SHARE]`` and
+    the item loop the rest.  The human-readable byte and item counts stay in
+    the message, where they are not load-bearing for the bar.
+    """
+
+    def __init__(self, on_progress: ProgressCallback, name: str) -> None:
+        self._on_progress = on_progress
+        self._name = name
+        self._total = 0
+
+    def on_read(self, read_bytes: int, total_bytes: int) -> None:
+        """Report the streaming read, and latch its denominator for the loop."""
+        self._total = total_bytes
+        if total_bytes > 0:
+            self._on_progress("loading", f"Reading {self._name}…", int(_READ_SHARE * read_bytes), total_bytes)
+
+    def on_item(self, loaded: int, total_count: int) -> None:
+        """Report the conversion loop, continuing the read's scale."""
+        message = f"Processing {loaded} of {total_count} items…"
+        if self._total <= 0 or total_count <= 0:
+            # Nothing to continue from (an unreadable entry size, or an empty
+            # dataset): fall back to the item scale on its own.
+            self._on_progress("loading", message, loaded, total_count)
+            return
+        done = _READ_SHARE + (1.0 - _READ_SHARE) * (loaded / total_count)
+        self._on_progress("loading", message, int(self._total * done), self._total)
+
+
 def _read_pickle_dataset(file_path: Path, on_progress: Any = None) -> dict[str, Any]:
     """Load a dataset ZIP container and assert the ``"medias"`` envelope.
 
@@ -426,30 +465,11 @@ def load_dataset_from_pickle(
         :func:`vtscore.state.coverage.restore_coverage_atlas_from_cache` to
         skip rebuilding the coverage atlas.
     """
-    # Both sub-phases of this load — streaming/deserialising the container, then
-    # converting each media — report against one denominator: the container's
-    # ``medias.pkl`` byte size.  They measure different things (bytes consumed
-    # vs items built), so giving each its native scale would rewind the fraction
-    # to zero at the handover, and every consumer clamps monotonically:
-    # ``ProgressTracker._compute_overall`` pins ``overall`` and
-    # ``AdaptiveLoadPacer.update`` pins ``_frac``.  A rewind therefore does not
-    # show as a rewind, it shows as a *freeze* for the whole item loop — which
-    # is how lighting up the read would have bought a lit read at the cost of a
-    # dead conversion.  One shared scale keeps the fraction monotone across the
-    # handover; the human-readable counts stay in the message.
-    read_total = 0
-
-    def _read_progress(read_bytes: int, total_bytes: int) -> None:
-        nonlocal read_total
-        read_total = total_bytes
-        if total_bytes > 0:
-            assert on_progress is not None
-            on_progress("loading", f"Reading {file_path.name}…", int(_READ_SHARE * read_bytes), total_bytes)
-
+    reporter = _PickleLoadProgress(on_progress, file_path.name) if on_progress is not None else None
     if on_progress is not None:
         on_progress("loading", f"Reading {file_path.name}…", 0, 0)
 
-    data = _read_pickle_dataset(file_path, _read_progress if on_progress is not None else None)
+    data = _read_pickle_dataset(file_path, reporter.on_read if reporter is not None else None)
     medias.clear()
     cached_coverage_atlas = data.get("coverage_atlas")
     medias_data = data["medias"]
@@ -466,20 +486,8 @@ def load_dataset_from_pickle(
     # per-client 1024-deep queue and start dropping frames).
     _progress_interval = max(1, total_count // 50) if total_count > 0 else 1
 
-    def _item_progress(loaded: int) -> None:
-        """Report the item loop on the shared byte scale set by the read."""
-        assert on_progress is not None
-        message = f"Processing {loaded} of {total_count} items…"
-        if read_total <= 0 or total_count <= 0:
-            # No denominator to continue from (an unreadable entry size, or an
-            # empty dataset): fall back to the item scale on its own.
-            on_progress("loading", message, loaded, total_count)
-            return
-        done = _READ_SHARE + (1.0 - _READ_SHARE) * (loaded / total_count)
-        on_progress("loading", message, int(read_total * done), read_total)
-
-    if on_progress is not None:
-        _item_progress(0)
+    if reporter is not None:
+        reporter.on_item(0, total_count)
 
     try:
         for media_id, media_info in medias_data.items():
@@ -497,8 +505,8 @@ def load_dataset_from_pickle(
                 continue
             medias[media_id] = media_data
             loaded_count += 1
-            if on_progress is not None and loaded_count % _progress_interval == 0:
-                _item_progress(loaded_count)
+            if reporter is not None and loaded_count % _progress_interval == 0:
+                reporter.on_item(loaded_count, total_count)
     except MemoryError:
         medias.clear()
         del data

--- a/vtscore/security/pickle.py
+++ b/vtscore/security/pickle.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import io
 import pickle
 import struct
-from typing import TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any
 
 
 # Allowlist of (module, name) pairs that may be instantiated during unpickling.
@@ -101,12 +101,17 @@ class RestrictedUnpickler(pickle.Unpickler):
         )
 
 
-def safe_pickle_load(f: io.BufferedIOBase, **kwargs: Any) -> Any:
+def safe_pickle_load(f: io.BufferedIOBase | IO[bytes], **kwargs: Any) -> Any:
     """Deserialise a pickle stream using the restricted unpickler.
 
     Drop-in replacement for ``pickle.load(f)`` that blocks arbitrary code
     execution.  Any extra keyword arguments (e.g. ``encoding``) are
     forwarded to the underlying ``Unpickler``.
+
+    *f* is any readable binary stream, not just an in-memory buffer: the
+    container reader hands this the live ``ZipExtFile`` for ``medias.pkl`` so
+    the entry deserialises as it streams, instead of being materialised in
+    full first.
     """
     return RestrictedUnpickler(f, **kwargs).load()
 


### PR DESCRIPTION
Reading a dataset container — streaming `medias.pkl` and deserialising it — reported `total == 0` for its whole duration, so the row rendered an indeterminate bar that never advanced.

## Is it worth fixing?

This started as a check on whether #2811 was a real bug or an artifact of a Claude session hunting an unrelated problem. It's real, and the measurement in the issue was low. Two synthetic containers, timed end to end:

| Container | stream | deserialise | item loop | **dark window** |
|---|---|---|---|---|
| 243 MB image-shaped, 20k items | 23% | 33% | 45% | **56%** |
| 328 MB text-shaped, 105k items | 6% | 37% | 57% | **43%** |

The issue estimated ~⅓. The demos it names are genuinely large — `wikipedia_topics_a` is 630k items, `speech_commands_v2_a` is 106k — so "tens of seconds of dead bar right after clicking Import" holds.

## Where the issue's suggested fix falls short

#2811 proposed streaming `zf.read` in chunks and reporting bytes against `ZipInfo.file_size`. But on the text shape — which is what the largest named demo is — the raw transfer is only **14% of the dark window**; the rest is `safe_pickle_load`, which that fix leaves exactly as dark as it is today.

So the counter here wraps the stream the *unpickler itself* pulls from, rather than a separate read-then-deserialise pair. The fraction then advances across the whole phase.

## The trap: lighting up the read can deaden the item loop

The two sub-phases measure different things — bytes consumed, then items built — so giving each its native scale rewinds the fraction to zero at the handover. That rewind never *shows* as a rewind, because every consumer clamps monotonically (`ProgressTracker._compute_overall` pins `overall`, `AdaptiveLoadPacer.update` pins `_frac`). It shows as the bar **freezing for the entire item loop** — trading a dark read for a dead conversion, which on the import path would have been a net regression.

Both sub-phases therefore report against one denominator (the entry's byte size), with the read owning `[0, 0.5]` and the item loop `[0.5, 1]`. The 0.5 split is the measured average of the two shapes above. Human-readable byte and item counts stay in the message, where they aren't load-bearing for the bar.

## Bonus: peak memory

Streaming means the serialised blob is no longer held alongside the objects being built from it — which is precisely what the `MemoryError` handler in `_read_pickle_dataset` exists for:

| Container | peak alloc before | after |
|---|---|---|
| 243 MB | 515 MB | 271 MB (**47% lower**) |
| 328 MB | 804 MB | 476 MB (**41% lower**) |

Wall-clock is also slightly better (0.36→0.27s, 1.01→0.88s). Callers that pass no `on_progress` get the memory win too.

## Breaking change

`load_dataset_from_pickle`'s progress denominator is now the container's byte size, not the item count. Anything asserting `total == len(medias)` needs updating — the two tests that did now pin the invariant that actually matters (one shared denominator, non-decreasing fraction) instead of the old incidental one.

## Testing

`./run-tests.sh` — 7500 passed, 1 skipped. `./run-tests.sh vtscore-clean` — 3382 passed. New coverage: byte-progress contract and denominator publication in `test_container.py` (including that streaming doesn't weaken the restricted unpickler's allowlist), and read-phase/item-phase partitioning plus the monotonicity invariant in `test_cached_load_progress.py`.

Closes #2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2mPiusdA3iB1oCsAeYdt9