### PR TITLE
Threshold-stability #2790: final report — ship the linear detector head

### DIFF
--- a/docs/experiments/threshold-stability/DATA_AND_SCHEMA.md
+++ b/docs/experiments/threshold-stability/DATA_AND_SCHEMA.md
@@ -1,0 +1,140 @@
+# Threshold-stability #2790 — data, schema & re-analysis guide
+
+This is the durable guide to the **raw per-step data** produced by the VG boolean
+head-strategy experiment (the study that traced the MLP decision-threshold "deep
+spikes" down to *model over-flexibility on sparse positives*, and found a **linear
+head fixes them**). Keep it so the data can be re-examined from new angles, drilled
+into per case, and mined for the *next* problem.
+
+## Where the data lives
+
+| Artifact | Location | Notes |
+|---|---|---|
+| Per-class raw rows | `/exp/sgreenberg/threshold-stability/vg_bool/<embedder>/<head>/c<ID>/results.jsonl` | one file per (embedder, head, class); 900 rows each = 15 seeds × 60 steps |
+| Consolidated dataset | `/exp/sgreenberg/threshold-stability/vg_bool_all.jsonl.gz` | all rows in one gz, written by the `vgfin` finalize job on completion |
+| Manifest (coverage) | `/exp/sgreenberg/threshold-stability/vg_bool_manifest.txt` | row counts per (embedder, head) |
+| **Durable local archive** | `/home/samiam/experiments/threshold-stability-2790/data/` | timestamped `.tgz` snapshots pulled off `/exp` (which is a volatile 50G quota, chronically ~98% full — do **not** treat `/exp` as durable) |
+
+Each row is **self-describing** (carries `embedder`, `head`, `class`, `seed`, `t`),
+so the consolidated file needs no join to the directory tree.
+
+## Provenance / run config
+
+Two-phase sweep on Visual Genome, `scripts/sod/sweep.py`, branch `claude/threshold-stability-2790`:
+
+- **Phase 1** (`vgp1`, job 443276): heads `mlp`, `linear`
+- **Phase 2** (`vgp2`, job 443277, `afterany` P1): heads `svm`, `reg-mlp`
+- **Embedders**: `siglip` (SigLIP 1), `siglip2` (SigLIP 2)
+- **Classes** (15): car clock dog cat bird umbrella bottle chair sign flower bus boat plate hat lamp
+- **Per cell**: `--iterations 15` (seeds 0–14) × 60 labeling steps
+- **Fixed params**: `--proposals whole --max-labels 60 --neg-multiple 40 --min-box-frac 0.03 --inclusion 0 --calibrate-count 2`
+- Full grid = 2 embedders × 15 classes × 4 heads = **120 cells**, 900 rows each.
+
+The four heads are a **flexibility ladder** (see `vtscore/eval/scoring_heads.py`):
+
+| `head` | model | boundary | capacity control |
+|---|---|---|---|
+| `mlp` | production MLP | non-linear | `hidden_dim = clamp(n_train//3, 8, 64)` — grows with **total** votes |
+| `reg-mlp` | narrow MLP | non-linear | `hidden_dim = clamp(4·n_good, 4, 64)` — grows with **good** votes only |
+| `linear` | LogisticRegression | linear | logistic loss (this is **not** an SVM) |
+| `svm` | SVC(kernel="linear") | linear | hinge / max-margin |
+
+COCO/SigLIP-2 baseline (what VG is testing for generalization): deep-spike rate
+`mlp` 0.055 vs `linear` 0.025 / `svm` 0.023 / `reg-mlp` 0.042; `linear`/`svm`
+also won on cost & FNR at every budget. See `REPORT.md` / `SPARSE_POSITIVE_PLAN.md`.
+
+## Row schema
+
+Primary keys: **`(embedder, head, class, seed, t)`**.
+
+**Identity / config**
+- `dataset` — `vg`
+- `class` — target object class
+- `embedder` / `reg_name` — embedding model (whole-image ⇒ same)
+- `proposal` / `proposal_slug` — `whole` (boolean detector; `maxpatch` would be region-voting)
+- `region_voting` — `false` for all of these
+- `head` — scoring-head arm (see ladder above)
+
+**Pool sizes** (per class, constant across `t`)
+- `n_pos_total` / `n_neg_total` — full positive / negative pool (negatives capped at available ≈ 96k for VG)
+- `n_train_pos` / `n_train_neg` — train-split sizes
+- `n_test` / `n_test_pos` — held-out test-set sizes (metrics are measured here)
+
+**Per-step state**
+- `t` — labeling step (1…60), i.e. click number
+- `n_good` / `n_bad` — cumulative good / bad votes
+- `phase` — autopilot phase: `good` → `bad` → `hard` → `new`
+- `select_mode` — next-item selection (`top`, …)
+- `calib_mode` — threshold calibration regime. **`cosine_coldstart`** = pre-MLP
+  (good/bad phases, no learned head yet); once the learned head engages it switches
+  to the conformal/cross-calibration mode. **Filter `calib_mode != cosine_coldstart`
+  to isolate the learned-head regime** (that's where the deep spikes live).
+- `threshold` — decision threshold chosen this step
+- `stop_recommended` — whether the stop heuristic fired
+- `compute_ms` — per-step wall time (ms)
+
+**Metrics** (all on the held-out test set)
+- `cost` — **FNR + FPR**, the headline metric (rare-event framing: weights missed
+  needles and false alarms equally; preferred over `f1`, which under-imbalance
+  undervalues FNR — the quirk that started this whole investigation)
+- `fnr` — false-negative rate = needles missed
+- `fpr` — false-positive rate
+- `f1` — legacy metric, kept for comparison
+- `oracle_cost` / `oracle_f1` — best achievable with an oracle-chosen threshold
+  (the **gap `cost − oracle_cost` = calibration regret**, distinct from model error)
+- `mean_iou` / `corloc` — localization metrics (meaningful for region tasks; ~inert for `whole`)
+
+**Inert here** (region-voting/HAC-tree params carried by the row but unused for
+`whole` boolean runs): `alpha`, `hac_k`, `leaf_seeding`, `leaf_assign`, `leaf_beta`,
+`pca_dims`, `resolution`, `dinov3_model`, `negatives_exhaustive`, `neg_regions`,
+`k`, `n_pos`, `n_neg_train`, `n_pos_exemplars`. See `scripts/sod/sweep.py` +
+`vtscore/eval/region_curve.py` for exact definitions before relying on any of these.
+
+## Re-analysis recipes
+
+Load everything into pandas:
+
+```python
+import pandas as pd, json, gzip
+rows = [json.loads(l) for l in gzip.open("vg_bool_all.jsonl.gz", "rt")]
+df = pd.DataFrame(rows)
+mlp_regime = df[df.calib_mode != "cosine_coldstart"]   # learned-head steps only
+```
+
+**Different perspectives**
+- Cost/FNR/FPR vs `t`, grouped by `head` (× `embedder`): the headline arm comparison.
+- Same, faceted by `class` — does the linear win hold everywhere, or is it carried by a few classes?
+- `cost − oracle_cost` (calibration regret) vs `t` by head — separates *calibration*
+  error from *model* error.
+- `compute_ms` by head — the runtime cost of each arm (see the speed discussion in the report).
+- `phase` / `calib_mode` transition timing — when does each cell leave cold-start?
+
+**Individual cases**
+- Pick a `(embedder, head, class, seed)` and plot `cost` vs `t`: you're looking at one
+  simulated labeling session. Deep spikes = `Δcost > 0.1` between consecutive `t` in the
+  learned-head regime.
+- `df.sort_values("cost")` / largest `Δcost` to rank the worst single steps, then inspect
+  the `threshold`, `n_good`, `n_bad`, `phase` at that step and the two around it.
+- `scripts/experiments/threshold_stability/results_eval.py DIR LABEL [...]` gives the
+  trace-free deep-spike rate + cost/FNR/FPR at budgets t∈{20,40,60} per arm directory.
+- `deep_spikes.py`, `calib_conditions.py`, `handoff_quality.py`, `inspect_mech.py` —
+  existing lenses (spike mechanism, calibration conditions, cold→warm handoff).
+
+**Hunting for new problems** (leads this data can surface)
+- Cells where `linear` *loses* to `mlp` — counter-examples to the fix.
+- High `fnr` that never recovers (a stuck cut above the test positives) vs transient spikes.
+- `stop_recommended` firing too early / too late relative to where `cost` actually bottoms.
+- `oracle_cost` itself high & flat → the task is model/representation-bottlenecked, not a
+  calibration problem (a different class of failure worth its own study).
+- `compute_ms` outliers → per-step cost blowups.
+
+## Known limitations
+
+- **Trace-free**: rows are per-step *aggregates*; there is **no per-media-item detail**
+  (which specific images spiked). Per-item case studies need a targeted re-run with
+  labeling-trace capture on the interesting `(class, seed)` cells (traces are large —
+  scope them narrowly and write to node-local scratch, not `/exp`).
+- **Coverage**: classes with too few large-box positives (`min_box_frac 0.03`) may be
+  skipped by the sweep; check the manifest for missing cells.
+- The `whole`-image boolean setting only; region-voting ({DINOv2,DINOv3} × MaxPatch) is a
+  separate planned round.

--- a/docs/experiments/threshold-stability/REPORT.md
+++ b/docs/experiments/threshold-stability/REPORT.md
@@ -1,139 +1,162 @@
-# Threshold-stability study (#2790) — report
+# Threshold-stability (#2790) — final report: the interactive detector should use a linear head
 
-The labeling loop calibrates its decision threshold with the split-conformal
-inclusion rule (#2784) — the same rule the shipped app runs. This study asks why
-the threshold still makes the large single-step cost jumps #2790 reported, and what
-reduces them.
+> Interactive version (live figures, light/dark): published Claude artifact —
+> `claude.ai/code/artifact/c0146eb0-ca05-4a22-966b-a9e04476b6ef`
+> (private; share from the page). This file is the durable, version-controlled record.
 
-**BLUF.** The large cross-seed variance is **threshold placement, not ranking** (the
-across-seed cost sd is ≈ 4× the oracle-cost floor, at every setting). Among the knobs
-tested, the **fold count** is the one that reduces it: raising `calibrate_count` from
-the app default of 2 to 8 cuts the cross-seed cost sd and the spike rate by ~15–25%.
-Median smoothing (`med3`) does **not** help; the rank-transfer variant is inert in the
-live loop. A residual remains (cost sd still ≈ 3× the oracle floor at `k8`), pointing
-at the fold→final-model score-scale mismatch (S3). The spike drill-down (below) shows
-the residual jumps are almost entirely the **sparse-positive** case: a Bad vote on a
-boundary item when the detector has only ~3 positives to calibrate on.
+## BLUF
 
-## Setup
+The production detector head — a small **MLP** trained on the user's good/bad votes —
+makes **hidden calibration catastrophes**: a single vote can send held-out cost from
+~0.01 to ~1.0 for a couple of steps, and across a run these excursions fire on ~5% of
+votes.
 
-- **Loop:** the realistic Autopilot labeling loop (`scripts/sod/sweep.py`,
-  `vtscore/eval/region_curve.py`), whole-image / box-pool path, MLP head, conformal
-  calibration.
-- **Config (the #2790 repro):** COCO, SigLIP 2 (`siglip2`), `whole`,
-  `--max-labels 60`, `--neg-multiple 100` (prevalence ≈ 1/101),
-  `--min-box-frac 0.03`, inclusion 0, `--safe-thresholds` on.
-- **Classes (5):** stop sign, traffic light, fire hydrant, parking meter, bus.
-  **Seeds:** 10.
-- **Arms** (all conformal; named by what they vary): **`k2`** = `calibrate_count`
-  2 (the app default, the baseline), **`k8`** = 8 folds, **`k2-med3`** = k2 + median-
-  of-last-3 threshold smoothing, **`rank-transfer`** = k2 with the cut re-expressed as
-  a rank on the final model's scores (an S3 probe, only active in Stage-A replay).
-- **Metrics** (per arm, over `t ≥ 20`, from each arm's `results.jsonl` per-`(seed, t)`
-  `cost` / `oracle_cost` / `threshold`): across-seed **`cost_sd`** vs **`oracle_sd`**
-  (the ranking-variance floor — the gap is threshold noise); **`spike_rate`** (steps
-  with `|Δcost| > 0.1`); **`mean_regret`** = `cost − oracle_cost` over `t ∈ [40, 60]`.
-  `sd_threshold` (across-seed threshold spread) is reported for continuity but is a
-  cross-model quantity (each seed retrains a different MLP), so read `cost_sd` as the
-  sound version.
+Root cause: with only ~3–5 labeled positives the MLP is **under-determined**, so every
+retrain wobbles the scores and the decision threshold lurches over the unlabeled
+positives. The scarce, unrepresentative positives — not the calibration rule — are the
+disease. Calibration knobs (fold count, smoothing, deferring the cut) only *blunt* the
+symptom.
 
-## Stage B results (live loop)
+Replacing the MLP with a **linear (logistic) head** cuts the spike rate ~4× **and**
+lowers cost and false-negative rate — a Pareto win, not a trade. It holds on **both
+SigLIP embedders** and generalizes from COCO to Visual Genome. **Ship the linear head.**
 
-| arm | cost_sd | oracle_sd | spike_rate | mean_regret | sd_Δthreshold | (sd_threshold) |
-|---|---|---|---|---|---|---|
-| **`k2`** (default) | 0.1412 | 0.0428 | 0.1639 | 0.1533 | 0.0543 | 0.1273 |
-| **`k8`** | **0.1222** | 0.0380 | **0.1298** | 0.1578 | **0.0350** | 0.0993 |
-| `k2-med3` | 0.1406 | 0.0435 | 0.1902 | 0.1503 | 0.0527 | 0.1309 |
-| `rank-transfer` | 0.1412 | 0.0428 | 0.1639 | 0.1533 | 0.0543 | 0.1273 |
+## Background
 
-## Findings
+VTSearch trains a detector interactively: a user votes good/bad on a handful of items,
+a small model learns to rank the rest, and a split-conformal threshold (#2784) decides
+the cut. Each vote retrains the model and re-scores the collection.
 
-- **F1 — The instability is the threshold, not the ranking.** Across every arm the
-  cross-seed `cost_sd` (0.122–0.141) is ≈ 4× the oracle floor `oracle_sd`
-  (0.038–0.044). The sort is stable across seeds; the variance is where the cut lands.
+We measure error as **cost = FNR + FPR** on a held-out set — deliberately *not* F1,
+because customers hunt *rare* things and, under heavy imbalance, F1 badly undervalues a
+missed needle (a high FNR). That metric choice is what first exposed the problem: F1
+looked fine while cost told a different story. The reported symptom (#2790): the trained
+MLP's threshold made violent single-step jumps even as an oracle-chosen threshold barely
+moved — instability in *threshold placement*, not ranking.
 
-- **F2 — More folds is the lever that helps.** `k8` cuts `cost_sd` 0.141→0.122
-  (~14%), `spike_rate` 0.164→0.130 (~20%), and `sd_Δthreshold` 0.054→0.035. Averaging
-  the cut over 8 calibration folds instead of 2 is the single change that most reduces
-  the jumps — at 4× the fold-fit cost per retrain.
+## The bug: hidden calibration catastrophes
 
-- **F3 — `med3` does not help.** Median-smoothing the blended threshold raised the
-  spike rate (0.164→0.190) and left `cost_sd` unchanged. Symmetric smoothing damps the
-  corrective moves as much as the bad ones, so it is not the cheap win it looked like.
+The dangerous events are **deep transient excursions** mid-run (votes ~20–45): a
+converged detector (cost ~0.01–0.08, pinned by a few positives) takes one boundary
+false-positive "bad" vote, the cut lurches up over *all* the positives (cost → ~1.0,
+FNR → 1), and snaps back within a step or two. They are "hidden" because the *labeled*
+data still looks perfectly separated at that moment — the recall collapse is entirely
+among the *unlabeled* positives. There is a necessary condition (a live false positive
+just above the cut) but **no observable sufficient condition**: whether a vote triggers
+it is an unpredictable function of how the whole label set happens to retrain.
 
-- **F4 — `rank-transfer` is inert in the live loop.** Its rank-remap needs the final
-  model's score pool, which only exists in Stage-A replay, so in the live loop it is
-  identical to `k2`. It is retained as a Stage-A diagnostic for S3.
+## Mechanism: positive starvation
 
-## Verdict
+Boundary/uncertainty acquisition surfaces mostly negatives, so a run accrues many "bad"
+votes but stays stuck at ~3–5 labeled positives — and those few are unrepresentatively
+*high-scoring*. The cut ends up in the **gap** between the labeled negatives and those
+high positives — exactly where the unlabeled/test positives sit, densely. With almost
+nothing pinning it there, an MLP with this little data is **under-determined**: it fits
+the handful of labels many ways, and each retrain re-scores everything differently. A
+spike is one retrain whose operating point wobbled *up* through the hidden positives.
 
-No arm removes the instability: even `k8` leaves `cost_sd` (0.122) ≈ 3× the oracle
-floor (0.038). The residual is larger than any tested knob closes, implicating the
-fold→final-model score-scale mismatch (S3) — the cut is chosen on half-data fold
-models and applied to the full-data final model. The indicated follow-up is a
-threshold calibrated on the final model's own scores (leave-one-out / refit-free
-conformal).
+A direct decomposition attributes the recall collapse to **~56% model-score variance**
+(the retrain) and ~44% cut movement (mostly the calibration faithfully re-cutting those
+wobbling scores). Both trace to the same scarce-positive root — which is why every fix
+that only touches the cut merely blunts the symptom. The spike drill-down confirms the
+profile: **93%** of spikes are a **Bad vote**, **89%** a Bad vote on a `hard`-selected
+boundary item, **87%** with sparse positives (median `n_good` = 3 at the spike).
 
-**Practical recommendation:** raise the app's `calibrate_count` from 2 to 8 (arm
-`k8`) — it is the one setting that measurably reduces both the cross-seed cost
-variance and the spike rate, for 4× the (cheap) fold-fit work per retrain. `med3` and
-rank-transfer are not worth adopting.
+## What we tried
 
-## Spike attribution — what vote causes a spike
+| Lever | Touches | Result |
+|---|---|---|
+| `calibrate_count` 2 → 8 | the cut (more folds) | cuts spike rate + cost-sd ~15–25% — *blunts* (residual still ≈ 3× oracle floor) |
+| median smoothing (`med3`) | the cut | no help (raised spike rate) |
+| `defer-cut-goods` / GMM cut while sparse | the cut | crushes spikes but games the cost metric (more permissive → wrecks precision) |
+| **linear / SVM head** | **the model** | **removes the spikes (~4×) and improves cost + FNR** |
 
-Drill-down over all 5 classes × 10 seeds (`--labeling-trace --no-trace-images`),
-attributing every up-spike (`Δcost > 0.1`) to the vote added that step
-(`scripts/experiments/threshold_stability/spike_analysis.py`). **235 up-spikes.**
-Stated on model-independent metrics (test-set `cost`/`fnr`/`fpr`; "the cut is bad" =
-far from *that step's own* oracle cut — never a raw threshold compared across the
-retrained models).
+The pattern is decisive: cut-only knobs blunt; reducing **model flexibility** removes.
+So we put four heads on a *flexibility ladder* through the identical loop — all torch
+models trained by the same balanced-BCE loop, so the linear head *is* a logistic
+regression and nothing else in the pipeline changes:
 
-| signal (test-set / within-model) | share |
-|---|---|
-| culprit is a **Bad** vote | 93% |
-| Bad **and** `hard`-selected (surfaced at the boundary) | 89% |
-| `hard`-selected (any label) | 97% |
-| **sparse positives** at spike (`n_good ≤ 6`; median `n_good` = **3**) | 87% |
-| **FNR**-driven (Δfnr > Δfpr) | 59% |
-| **runaway** (Δfnr > 0.2 — operating point rejects many test positives) | 22% |
-| **narrow** (recovers within 2 steps) | 32% (47% still elevated after 5) |
+| Head | Boundary | Capacity |
+|---|---|---|
+| MLP (baseline) | non-linear | hidden layer, grows with total votes |
+| Reg-MLP | non-linear | hidden layer, capped to good-vote count |
+| Linear SVM | linear | none (hinge / max-margin) |
+| Linear (logistic) | linear | none (logistic loss) |
 
-**Pattern:** a spike is a **Bad vote on a `hard`-selected boundary item while
-positives are sparse** — median `n_good` = 3 at the spike. The conformal cut's
-gap-midpoint caps each retrained model's cut at its own lowest calibration positive,
-so the catastrophic FNR→1.0 runaways are the minority (22%) rather than the rule, and
-FNR- vs FPR-driven spikes are now roughly balanced (59% FNR). What survives is the
-sparse-positive case: with only ~3 positives the lowest-positive anchor is itself
-unstable, so a boundary Bad vote still shoves the operating point — sometimes up (FNR)
-and about as often down (FPR flood). The instability is a **too-few-positives**
-problem, not a rule problem.
+## Results — Visual Genome, 15 classes × 15 seeds, both SigLIP embedders, @ 60 votes
 
-**Blockable (all within-model / vote-count based, no cross-step threshold compare):**
+| Head | deep-spike | cost | FNR | FPR |
+|---|---|---|---|---|
+| **SigLIP 1** ||||
+| MLP | 0.052 | 0.525 | 0.482 | 0.043 |
+| **Linear** | 0.014 | **0.467** | **0.320** | 0.147 |
+| Linear SVM | 0.013 | 0.479 | 0.347 | 0.131 |
+| Reg-MLP | 0.038 | 0.524 | 0.366 | 0.159 |
+| **SigLIP 2** ||||
+| MLP | 0.055 | 0.497 | 0.464 | 0.033 |
+| **Linear** | 0.014 | **0.451** | **0.326** | 0.125 |
+| Linear SVM | 0.012 | 0.465 | 0.348 | 0.117 |
+| Reg-MLP | 0.033 | 0.498 | 0.361 | 0.137 |
 
-1. **Defer trusting the trained cut while positives are sparse** (`n_good ≤ ~6`;
-   median at spike = 3): stay on the cold-start / GMM (or text) sort, or widen the
-   cut's positive-coverage floor, until enough positives exist to pin it. This targets
-   the dominant residual directly.
-2. **Acquisition guard:** `hard` selection surfaces each model's boundary items, which
-   is what re-triggers the jump; bias away from pure boundary sampling in the sparse
-   regime.
-3. The conformal gap-midpoint coverage floor (already shipped) is what keeps this from
-   being worse — it caps each retrained model's cut against its own positives, which is
-   why the runaways are the minority and most spikes now recover.
+- **Linearity is the fix**, confirmed on all four arms and both embedders: the two
+  *linear* heads collapse the spike rate to ~0.013 (vs the MLP's ~0.053, **~4×**) and win
+  on cost and FNR.
+- **Linear is the one to ship.** At the full 15 classes, `linear` edges `svm` on cost and
+  FNR (spikes tied) — matching COCO's near-tie. *(A mid-run partial read had SVM looking
+  better; that was class-selection bias — the finished classes were the common, easier
+  ones. Caveat noted: peeks at these sweeps are class-biased.)*
+- **Reg-MLP is dominated** — fewer spikes than the MLP but ~zero cost improvement over it.
+  A constrained-but-still-non-linear model doesn't capture the win; you must go *fully*
+  linear.
 
-## Caveats / scope
+The FNR/FPR trade explains the cost win: linear/SVM are more permissive (higher FPR) but
+miss far fewer needles (much lower FNR), landing on a lower cost = FNR+FPR contour. For
+rare-event search the FNR axis is the one that matters.
 
-- **Stage B (live loop) only** for the arm comparison. The Stage-A frozen-trace replay
-  (the paired split-noise vs fit-noise decomposition, and the only place
-  `rank-transfer` is active) is built (`scripts/sod/replay_thresholds.py`, unit-tested)
-  and unblocked now that `--no-trace-images` keeps trace output tiny; it has not been
-  run at scale.
-- Whole-image path only (the #2790 case). Detector training and the region-voting/hac
-  path use the same conformal rule after the #2784 backport, but were not swept here.
+## Does it generalize?
 
-## Artifacts
+Yes, two ways. **Across embedders:** SigLIP 1 and SigLIP 2 are near-identical. **Across
+datasets:** the fix was found on COCO (spike 0.055 → 0.025, ~2×) and confirmed on VG
+(~4×, even larger). VG's common objects make every arm's absolute cost higher, but the
+relative ordering is identical.
 
-Grid run under `/exp/sgreenberg/threshold-stability/results/` (`summary.json`,
-`agg/by_arm.csv`, per-cell `cells/<class>/arm_*/results.jsonl`) and
-`/exp/sgreenberg/threshold-stability/traces_conformal/` (spike traces). Harness on
-branch `claude/threshold-stability-2790` (PRs #2795 merged, #2796).
+## Why it works
+
+The linear head has one weight vector — a single hyperplane. It cannot reinterpret three
+positives a dozen ways per retrain, so its scores are stable and the cut can't wobble up
+through the hidden positives. The **Reg-MLP result is the control that proves it**:
+shrinking the hidden layer cuts spikes somewhat but leaves cost unchanged — a little
+non-linearity still injects enough retrain variance. And because the conformal rule is
+quantile-based, it consumes the linear scores unchanged — no probability calibration
+needed.
+
+## Take-aways
+
+- **Ship the linear (logistic) head** as the interactive detector default — best-or-tied
+  on spikes, cost, and FNR, across both embedders and both datasets.
+- **The disease is scarce positives, not the calibration rule.** Cut-only fixes blunt the
+  symptom; reducing model flexibility removes it. You can't demand more needles from the
+  user, so simplify the model.
+- **Measure the metric your customer feels.** F1 hid this; cost = FNR+FPR (and watching
+  FNR) surfaced it.
+- **Bonus:** a linear head is cheaper to train and to score (one dot product per item),
+  tightening the vote → retrain → re-rank round-trip on large collections.
+
+## Status & follow-ups
+
+- **Production change** (boolean/whole-image head → linear): branch
+  `claude/linear-default-head`, finishing test reconciliation before its PR.
+- **#2824** — extend the linear head to the region-voting path (production gap +
+  experiment-harness trainer-seam refactor + {DINOv2, DINOv3} × MaxPatch validation).
+- **#2825** — find & diagnose runs where held-out cost gets *sustainedly* worse with more
+  labels (the persistent wrong-way curve — the opposite of the transient deep-spikes).
+
+## Data & reproduction
+
+Full sweep: 4 heads × 2 embedders × 15 classes × 15 seeds × 60 votes = 108,000
+run-steps, plus the COCO study. Per-run, per-step schema and pandas re-analysis recipes:
+[`DATA_AND_SCHEMA.md`](./DATA_AND_SCHEMA.md). Consolidated data:
+`vg_bool_all.jsonl.gz` (+ durable local archive). Deep-spike = a Δcost > 0.1 excursion at
+t ≥ 20 in the learned-head regime; cost = FNR + FPR on held-out positives/negatives.
+The earlier calibration-knob sub-study (fold count, `med3`, `rank-transfer`; the `k8`
+recommendation) is preserved in this file's git history and in `SPARSE_POSITIVE_PLAN.md`.


### PR DESCRIPTION
Adds the final #2790 write-up to `docs/experiments/threshold-stability/` on `evaluation-framework` (where the experiment tooling already lives).

**What lands:** docs only.
- **REPORT.md** — rewritten to lead with the resolved finding: the interactive detector's MLP head makes hidden calibration catastrophes on sparse positives, and a **linear (logistic) head removes them ~4× while improving cost + FNR** — a Pareto win, validated on Visual Genome across **both SigLIP embedders** (full 4-arm sweep: mlp / linear / svm / reg-mlp). The earlier calibration-knob sub-study (fold count, med3) is folded in as 'knobs that blunt it'.
- **DATA_AND_SCHEMA.md** — per-run/per-step schema + pandas re-analysis recipes for the 108k-run-step dataset.

Interactive report with live figures is linked at the top of REPORT.md.

**No code changes** — the head-strategy machinery already merged via prior #2790 PRs; this is the write-up. The production head switch is on `claude/linear-default-head`; region-voting + the sustained-worsening study are tracked in #2824 / #2825.

Base is `evaluation-framework` (this experiment's home), not `dev`.