### PR TITLE
Sustained wrong-way runs (#2825): more labels make the detector worse, and it stays worse

### DIFF
--- a/docs/experiments/threshold-stability/SUSTAINED_REGRESSION_2825.md
+++ b/docs/experiments/threshold-stability/SUSTAINED_REGRESSION_2825.md
@@ -1,0 +1,268 @@
+# Sustained wrong-way runs (#2825) — when more labels make the detector worse, and it stays worse
+
+**Question.** Normally more good/bad votes → lower held-out cost. Find the runs where the
+cost curve legitimately goes the *other* way and **stays** there, and work out what is going
+wrong in each. Explicitly not the #2790 deep spike, which is transient and recovers.
+
+**Metric.** `cost = FNR + FPR` on the held-out set, throughout — the same headline the sweeps
+were run on. Detection scans `cost`. The ranking-vs-calibration split compares it with
+`oracle_cost`, which is that same cost at the best achievable cut, so the whole analysis stays
+in one unit. `average_precision`/`auroc` are printed where a source carries them but never
+classify anything.
+
+**Data.** Existing per-step rows only — **no new runs**. 4,484 trajectories:
+
+| source | dataset | mode | embedder | runs |
+|---|---|---|---|---|
+| `vg_bool/` | VG | boolean (`whole`) × 4 heads | SigLIP 1 + 2 | 1,800 |
+| `broad_hs2/` | COCO | boolean × 5 heads | SigLIP 2 | 1,500 |
+| `results/cells/` | COCO | boolean, 6 calibration arms | SigLIP 2 | 300 |
+| `acq/` | COCO | boolean, acquisition arms | SigLIP 2 | 300 |
+| `hac_newgmm/`, `hac_confirm/` | COCO | **region voting** (`hac`) | DINOv3 | 200 |
+| `hac_dinov2/` | COCO | **region voting** | DINOv2 | 40 |
+| `max-patch/results/cells.csv.gz` | VG | **region voting** (max_patch / max_patch_hac / max_hac) + whole_image, t→150 | DINOv3-patch, SigLIP | 344 |
+
+Tool: `scripts/experiments/threshold_stability/sustained_regression.py` (new; sibling of
+`deep_spikes.py`). 29 unit tests in `tests_lib/sorting/test_sustained_regression.py`.
+
+---
+
+## How a run has to earn the label
+
+Two criteria, both on a median-smoothed `cost` series so a single-step spike cannot trigger
+either:
+
+1. **Sustained rise** — cost climbs from the run's best-so-far over ≥ K=5 steps by ≥ δ=0.10,
+   mostly upward, and then *persists* at that level rather than snapping back.
+2. **Late gap** — the median of the last 10 steps sits ≥ δ above an earlier best that never
+   came back.
+
+### The threshold-only version of this question is meaningless
+
+At K=5 / δ=0.10, magnitude alone flags **2,185 of 4,484 runs (49%)**. The same thresholds
+applied to *surrogate* runs — built by reshuffling each run's own step-to-step cost moves —
+flag **74–90%**. A magnitude rule here is mostly measuring how jumpy a run is, and these runs
+are very jumpy.
+
+So every detection additionally has to clear a **per-run permutation test**: 99 surrogates of
+that run's own volatility with the net drift removed, keep it only if its severity lands in
+the top 5%.
+
+Two details that turned out to matter, both now pinned by tests:
+
+- **Reshuffle in blocks of 5, not single moves.** A #2790 deep spike is a `+0.9` step
+  immediately followed by a `−0.9` recovery. Shuffling single moves separates the pair, so the
+  surrogate manufactures exactly the sustained level shifts we are testing for, and the null
+  becomes self-defeating. Blocks keep the pairing.
+- **Anchor the segment floor at the *last* best-so-far, not the first.** With the first, a long
+  flat stretch gets swallowed into the segment and drags the "mostly upward" fraction to the
+  rejection boundary, losing real climbs off a plateau.
+
+### Calibration of the test itself
+
+Running the full pipeline on trend-free surrogates (type-I error, target ≤ 0.05):
+
+| source | type-I |
+|---|---|
+| VG boolean SigLIP 1 / 2 | 0.028 / 0.031 |
+| COCO region voting DINOv3 | 0.056 |
+| VG max_patch / max_patch_hac / max_hac | 0.033 / 0.000 / 0.111 |
+
+**Power is the honest weakness.** Planting a sustained `+0.30` rise into a trendless surrogate
+of each run's own volatility, the detector recovers it only **9–11%** of the time on boolean
+runs and **7–28%** on region-voting runs. These cost curves are heavy-tailed enough that a
+trend has to be extreme to separate from the spikes.
+
+> **Everything below is a lower bound.** 5.0% is the incidence of wrong-way runs *severe
+> enough to prove themselves against their own noise*, not the incidence of the phenomenon.
+
+---
+
+## What was found
+
+**223 of 4,484 runs (5.0%)** are sustained wrong-way runs.
+
+They are not marginal. Median rise in cost **+0.309**; median cost **0.486 at onset → 0.742 at
+the last step of the run**; and **98% are still worse at the final step than where the segment
+started**. This is not a dip that recovers — the user finishes the session with a worse
+detector than they had 40 votes earlier.
+
+### 1. It is an FNR collapse, not an FPR one
+
+| | median Δ over the segment |
+|---|---|
+| Δcost | **+0.309** |
+| ΔFNR | **+0.530** |
+| ΔFPR | **−0.164** |
+
+**93% of detections are FNR-driven.** The detector gets *more* precise and dramatically less
+complete: the cut marches up through the test positives until it is finding almost nothing.
+Median Δthreshold +0.091 — but note the #2790 methodology caveat: the model is retrained every
+vote, so raw threshold values are not comparable across steps. The FNR/FPR movement is.
+
+### 2. The mechanism: a run of bad votes with no positives to hold the cut down
+
+This is the finding. Across the wrong-way segment:
+
+| | median |
+|---|---|
+| good votes added | **1** |
+| bad votes added | **9** |
+| share of votes that were GOOD, inside the segment | **0.09** |
+| share of votes that were GOOD, over the whole run | 0.22 |
+| segments in which **not one** new positive arrived | **34%** |
+| longest stretch with no new positive | **7 steps** |
+
+`n_good` at onset: median **3**. `n_bad` at onset: median **7**. Onset phase: `hard` in
+**219 of 223**. Median onset step **t=10** — this is an *early-loop* failure that then never
+recovers.
+
+A worked example — COCO `carrot`, seed 1, SVM head, straight from the per-step rows:
+
+```
+  t   cost   oracle   fnr     fpr    threshold  n_good  n_bad  phase  calib
+  7  0.2065  0.1570  0.0000  0.2065   -0.1941      3      4    hard   blend   <- best
+  9  0.1935  0.1623  0.0789  0.1145   -0.2571      3      6    hard   blend
+ 11  0.2787  0.2367  0.2368  0.0419   -0.2082      3      8    hard   blend
+ 13  0.3803  0.1643  0.3684  0.0119   -0.0935      3     10    hard   blend
+ 15  0.7681  0.2358  0.7632  0.0049   -0.1228      3     12    hard   blend
+ 17  0.8951  0.2580  0.8947  0.0004    0.1205      3     14    hard   blend   <- peak
+ ...  n_good finally moves at t=18; cost claws back only to 0.50 by t=60
+```
+
+Nine consecutive votes, every one of them a **bad**, `n_good` frozen at 3. FNR climbs
+0.08 → 0.89 while FPR collapses to 0.0004. The run ends at cost 0.502 against a best of 0.194.
+
+This is the **sustained sibling of the #2790 deep spike**: same root cause (positive
+starvation — the cut is under-determined because almost nothing is pinning it from below), but
+where a spike is one bad boundary vote that snaps back, this is a *prolonged* run of bad votes
+that walks the cut all the way up and leaves it there. #2790 found the transient form. This is
+the form that does not recover.
+
+### 3. Mostly a calibration failure — but the ranking genuinely degrades too
+
+Splitting the cost rise into the part an oracle threshold could undo and the part it could not:
+
+| | share of detections |
+|---|---|
+| calibration (oracle flat, gap to it opens) | **56%** |
+| mixed | 35% |
+| ranking (oracle_cost itself carries ≥ half the rise) | **10%** |
+
+Median Δ`oracle_cost` **+0.058** against median Δ`cost` +0.316 — a ranking share of 0.17. But
+**`oracle_cost` itself rose by > 0.05 in 56% of detections**. So the issue's "scariest case"
+is real and common, just not dominant: in most wrong-way runs more labels are genuinely making
+the *ranking* worse as well, and a perfect threshold would recover roughly five sixths of the
+damage but not all of it.
+
+### 4. The linear head does **not** fix this
+
+#2790's conclusion was to ship the linear head, which stops the deep spikes. It does not stop
+this:
+
+| head | COCO boolean | VG boolean |
+|---|---|---|
+| linear | **0.077** | 0.044 |
+| reg-mlp | 0.077 | **0.069** |
+| anneal-svm | 0.073 | — |
+| svm | 0.060 | 0.051 |
+| mlp | 0.050 | **0.038** |
+
+On COCO the linear head is the *worst* arm and the MLP the best; on VG the MLP is the best. No
+model class is protective. Head-independence agrees: of 123 affected cells, 62% show it in only
+one head, and only 29% hit both a linear-family and an MLP-family head. **This is not a model
+flexibility problem** — which is exactly what you would expect if the cause is what the loop is
+being fed rather than what is fitted to it.
+
+### 5. Region voting is almost clean — and that is partly a real result
+
+| mode | runs | wrong-way |
+|---|---|---|
+| COCO boolean, SigLIP 2 | 2,100 | **6.1%** |
+| VG boolean, SigLIP 2 | 900 | **5.3%** |
+| VG boolean, SigLIP 1 | 900 | **4.8%** |
+| COCO region voting, DINOv2 | 40 | 2.5% |
+| VG region voting, `max_hac` DINOv3-patch | 69 | 1.4% |
+| VG boolean `whole_image`, SigLIP | 68 | 1.5% |
+| COCO region voting, DINOv3 | 200 | **0.5%** |
+| VG region voting, `max_patch` / `max_patch_hac` DINOv3-patch | 138 | **0.0%** |
+
+Read this carefully. Region-voting power is 7–28%, comparable to boolean's 9–11%, so the gap is
+not purely a sensitivity artifact — but with only 378 region-voting runs the confidence
+interval is wide, and the VG max-patch runs improve by a median **−0.55** in cost over the run
+(against −0.10 for VG boolean), which leaves far less room for a wrong-way stretch to stand out.
+The defensible statement is: **the phenomenon is concentrated in the boolean/whole-image loop,
+and there is no evidence it is a significant problem in region voting.** A dedicated
+region-voting sweep with more seeds would be needed to put a real bound on it.
+
+### 6. Which classes
+
+| class | wrong-way |
+|---|---|
+| COCO `book` | **0.413** |
+| COCO `bottle` | **0.400** |
+| VG `flower` | **0.300** |
+| COCO `carrot` | 0.227 |
+| COCO `traffic light` | 0.125 |
+| VG `car` | 0.108 |
+
+Small, cluttered, high-count-per-image objects. These are exactly the classes where the `hard`
+phase surfaces boundary items that are almost all negatives — the acquisition mix in §2.
+
+### 7. Calibration-rule arms: suggestive, not conclusive
+
+On the six-arm #2790 comparison (50 runs each): `conformal-k8` 0/50, `conformal-k2` 1/50,
+`rank-transfer-k2` 2/50, `argmin-k2` 2/50, `conformal-k2-med3` 3/50, `argmin-k8` 4/50. The
+direction favours conformal over argmin but 50 runs per arm cannot carry that claim.
+
+---
+
+## What this says to do
+
+The mechanism is a **prolonged run of negative-only votes during the `hard` phase while
+`n_good` is still ~3**. Three things follow, in order of how directly they attack it:
+
+1. **Positive-seeking acquisition** — the fix already identified at the end of #2790 and still
+   not built. This study is independent evidence for the same thing: the damage tracks the
+   *vote mix*, not the model class. If the loop interleaved exploit/top picks so positives keep
+   arriving, the 9-bad-votes-to-1-good stretches would not happen.
+2. **A no-new-positives guard.** 34% of wrong-way segments received not one positive, and the
+   median dry stretch is 7 steps. That is directly observable at runtime — the loop knows
+   `n_good` has not moved for k votes — and is a cheap trigger for either switching acquisition
+   or declining to move the cut.
+3. **Do not expect the linear head to cover this.** It is the right call for #2790's spikes and
+   it is not protective here (§4). The two failures need different fixes.
+
+## Limitations
+
+- **Power ~10%.** 5.0% is a floor on the incidence, not an estimate of it.
+- Region voting has 378 runs against 4,100 boolean; the near-zero rate is under-powered.
+- The VG max-patch source has no `oracle_cost` column, so 2 detections there are reported as
+  undecided rather than split into ranking vs calibration.
+- Per-item detail (which specific vote rotated the model) needs a targeted trace re-run on the
+  identified `(class, seed)` cells; this study works from per-step aggregates only.
+
+## Data-integrity note
+
+The `head` field in every sweep row is the per-step *scoring family* (`cosine` vs `mlp`), not
+the `--head-strategy` arm — so it reads `mlp` for every row of the `linear`, `svm` and
+`reg-mlp` sweeps alike. The arm survived only in the output directory name, which means it is
+unrecoverable from `vg_bool_all.jsonl.gz`. `DATA_AND_SCHEMA.md`'s claim that rows are
+self-describing is wrong on this point. `_row_realistic` now records `head_strategy`; the tool
+reads the arm from the path for existing data.
+
+## Reproducing
+
+```bash
+python scripts/experiments/threshold_stability/sustained_regression.py \
+  --jsonl-root "vg-bool=$EXP/vg_bool" \
+  --jsonl-root "coco-bool-heads=$EXP/broad_hs2" \
+  --jsonl-root "coco-rv-dinov3=$EXP/hac_newgmm" \
+  --csv-source "vg-maxpatch=/exp/sgreenberg/max-patch/results/cells.csv.gz" \
+  --null-block 5 --per-run-null 99 --top 30
+# add --power-rise 0.30 --fp-check 2 to reproduce the power / type-I tables
+# add --show "dataset=coco,class=carrot,seed=1" for the per-step deep-dive tables
+```
+
+Outputs on the Grid: `/exp/sgreenberg/threshold-stability/sr2825/` — `detections_final.json`,
+`logs/final-448402.out` (main scan), `logs/calib4-448367.out` (calibration).

--- a/scripts/experiments/threshold_stability/sustained_regression.py
+++ b/scripts/experiments/threshold_stability/sustained_regression.py
@@ -1,0 +1,796 @@
+"""Runs whose held-out cost gets — and STAYS — worse as the user labels more (issue #2825).
+
+The opposite of ``deep_spikes.py``. A deep spike is a *transient* excursion that snaps back
+within a step or two; this tool hunts **persistent** wrong-way trends: cost climbing over a
+run of >=K consecutive steps by >=delta and not giving the rise back, or a late/final cost
+sitting meaningfully above an earlier best that never recovers. Those are cases where the
+user is actively making the detector worse by labelling.
+
+Works straight off the per-step sweep rows — **no new runs**:
+
+* ``--jsonl-root DIR`` — any tree of ``results.jsonl`` (whole/boolean *and* region-voting
+  ``hac`` rows). Arm/head are taken from the **path** (a ``mlp``/``linear``/``svm``/``reg-mlp``
+  or ``arm_*`` component), because the row's own ``head`` field records the sweep default
+  rather than the arm actually run — see ``--strict-head``.
+* ``--csv-source PATH`` — the max-patch ``cells.csv.gz`` schema (DINOv3-patch region voting on
+  Visual Genome).
+
+The metric is **cost = FNR + FPR** throughout — the same headline the sweeps were run on.
+Detection scans ``cost``; the ranking-vs-calibration split compares it with ``oracle_cost``,
+which is that same cost evaluated at the best possible cut, so the whole analysis stays in one
+unit. ``average_precision``/``auroc`` are reported where a source happens to carry them, but
+they never classify a failure — a source without ``oracle_cost`` is simply reported as
+undecided rather than judged on a different metric.
+
+A **run** is one ``(source, group, head, embedder, proposal, class, seed)`` cost-vs-``t``
+trajectory. Detection is on a median-smoothed series so single-step spikes cannot trigger it,
+and every detection must beat a **per-run permutation test**: the same run's step-to-step cost
+moves are reshuffled ``--per-run-null`` times (a random walk of exactly this run's volatility)
+and the detection is kept only if its severity lands in the top ``--null-alpha`` tail. Without
+that test a magnitude-only rule mostly measures how jumpy a run is — ``--permute-null`` reports
+the pooled false-positive rate that makes the point.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import json
+import math
+import random
+import statistics
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: Model-class arms the sweeps write as a path component (the row field is unreliable).
+HEADS = {"mlp", "linear", "svm", "reg-mlp", "anneal-svm"}
+#: Which of those are linear-boundary models — the head-independence split.
+LINEAR_FAMILY = {"linear", "svm", "anneal-svm"}
+MLP_FAMILY = {"mlp", "reg-mlp"}
+COLDSTART = "cosine_coldstart"
+
+# Fields carried through from a row when present; everything else is ignored.
+STEP_FIELDS = (
+    "t", "cost", "fnr", "fpr", "f1", "threshold", "n_good", "n_bad",
+    "phase", "calib_mode", "select_mode", "oracle_cost", "average_precision", "auroc",
+)  # fmt: skip
+
+
+@dataclass
+class Run:
+    """One labeling trajectory: the unit #2825 asks about."""
+
+    key: tuple
+    meta: dict
+    steps: list = field(default_factory=list)
+
+    def series(self, name):
+        return [s.get(name) for s in self.steps]
+
+
+# --------------------------------------------------------------------------- loading
+
+
+def _num(v):
+    if v is None or v == "":
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return None if math.isnan(f) else f
+
+
+def _meta_from_path(root: Path, path: Path) -> dict:
+    """Arm/head live in the directory tree, not in the row (see module docstring)."""
+    parts = path.relative_to(root).parts[:-1]
+    head = next((p for p in parts if p in HEADS), None)
+    arm = next((p for p in parts if p.startswith("arm_")), None)
+    group = "/".join(parts) or root.name
+    return {"head": head, "arm": arm[4:] if arm else None, "group": group}
+
+
+def load_jsonl_tree(root: Path, source: str, strict_head: bool = False):
+    """Every ``results.jsonl`` under *root*, grouped into runs."""
+    runs: dict[tuple, Run] = {}
+    for f in sorted(root.rglob("results.jsonl")):
+        pm = _meta_from_path(root, f)
+        for line in f.open():
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            if pm["head"] is None and strict_head:
+                raise SystemExit(f"--strict-head: no head component in {f}")
+            head = pm["head"] or r.get("head")
+            key = (
+                source,
+                pm["group"],
+                pm["arm"],
+                head,
+                r.get("dataset"),
+                r.get("embedder"),
+                r.get("proposal"),
+                r.get("class"),
+                r.get("seed"),
+            )
+            run = runs.get(key)
+            if run is None:
+                run = runs[key] = Run(
+                    key=key,
+                    meta={
+                        "source": source,
+                        "group": pm["group"],
+                        "arm": pm["arm"],
+                        "head": head,
+                        "dataset": r.get("dataset"),
+                        "embedder": r.get("embedder"),
+                        "proposal": r.get("proposal"),
+                        "region_voting": bool(r.get("region_voting")),
+                        "class": r.get("class"),
+                        "seed": r.get("seed"),
+                        "n_test_pos": r.get("n_test_pos"),
+                        "n_test": r.get("n_test"),
+                    },
+                )
+            step = {k: r.get(k) for k in STEP_FIELDS if k in r}
+            for k in ("cost", "fnr", "fpr", "threshold", "oracle_cost", "f1"):
+                if k in step:
+                    step[k] = _num(step[k])
+            run.steps.append(step)
+    for run in runs.values():
+        run.steps.sort(key=lambda s: s.get("t") or 0)
+    return list(runs.values())
+
+
+def load_maxpatch_csv(path: Path, source: str):
+    """The max-patch ``cells.csv.gz`` schema: region-voting styles, AP/AUROC, no oracle."""
+    runs: dict[tuple, Run] = {}
+    op = gzip.open if path.suffix == ".gz" else open
+    with op(path, "rt") as fh:
+        for r in csv.DictReader(fh):
+            style = r.get("style")
+            key = (source, style, r.get("trainer"), r.get("embedder"), r.get("category"), r.get("seed"))
+            run = runs.get(key)
+            if run is None:
+                run = runs[key] = Run(
+                    key=key,
+                    meta={
+                        "source": source,
+                        "group": style,
+                        "arm": r.get("prevalence_arm"),
+                        "head": r.get("trainer"),
+                        "dataset": r.get("dataset"),
+                        "embedder": r.get("embedder"),
+                        "proposal": style,
+                        "region_voting": style in {"max_patch", "max_patch_hac", "max_hac"},
+                        "class": r.get("category"),
+                        "seed": int(r["seed"]),
+                    },
+                )
+            run.steps.append(
+                {
+                    "t": int(r["t"]),
+                    "cost": _num(r.get("cost")),
+                    "fnr": _num(r.get("fnr")),
+                    "fpr": _num(r.get("fpr")),
+                    "n_good": _num(r.get("n_good")),
+                    "n_bad": _num(r.get("n_bad")),
+                    "average_precision": _num(r.get("average_precision")),
+                    "auroc": _num(r.get("auroc")),
+                }
+            )
+    for run in runs.values():
+        run.steps.sort(key=lambda s: s["t"])
+    return list(runs.values())
+
+
+# --------------------------------------------------------------------------- detection
+
+
+def smooth_median(xs, w: int = 3):
+    """Centred rolling median — kills 1-step spikes so only sustained moves survive."""
+    if w <= 1:
+        return list(xs)
+    half = w // 2
+    out = []
+    for i in range(len(xs)):
+        win = [v for v in xs[max(0, i - half) : i + half + 1] if v is not None]
+        out.append(statistics.median(win) if win else None)
+    return out
+
+
+def find_sustained_rise(s, k: int, delta: float, hold: int, min_up_frac: float):
+    """The worst floor->peak rise that lasts.
+
+    Walks the running minimum, so every candidate segment reads "from this run's best-so-far
+    up to here". A candidate survives only if it spans >=*k* steps, rises >=*delta*, is mostly
+    upward, and the elevated level then **persists** without falling back below
+    ``floor + delta/2`` — that persistence is what separates a wrong-way trend from the
+    transient deep spike of #2790. A run that simply *ends* elevated has nowhere left to
+    recover, so the hold requirement is capped by the steps that remain. Among survivors we
+    keep the one with the largest ``rise x hold``, which is how detections are ranked.
+    """
+    n = len(s)
+    if n < k + 1:
+        return None
+    best = None
+    min_i = None
+    for j in range(n):
+        if s[j] is None:
+            continue
+        if min_i is None:
+            min_i = j
+            continue
+        if j - min_i >= k:
+            cand = _validate_rise(s, min_i, j, delta, hold, min_up_frac)
+            if cand is not None and (best is None or cand["rise"] * cand["hold"] > best["rise"] * best["hold"]):
+                best = cand
+        if s[j] < s[min_i]:
+            min_i = j
+    return best
+
+
+def _validate_rise(s, i, j, delta, hold, min_up_frac):
+    rise = s[j] - s[i]
+    if rise < delta:
+        return None
+    seg = [v for v in s[i : j + 1] if v is not None]
+    ups = sum(1 for a, b in zip(seg, seg[1:]) if b > a)
+    up_frac = ups / max(1, len(seg) - 1)
+    if up_frac < min_up_frac:
+        return None
+    floor = s[i] + delta / 2.0
+    n = len(s)
+    held = 0
+    for m in range(j, n):
+        if s[m] is None or s[m] < floor:
+            break
+        held += 1
+    if held < min(hold, n - j):
+        return None
+    return {
+        "start_idx": i,
+        "peak_idx": j,
+        "rise": rise,
+        "span": j - i,
+        "up_frac": up_frac,
+        "hold": held,
+        "held_to_end": j + held >= n,
+    }
+
+
+def find_best_late_gap(s, k: int, delta: float, late_window: int):
+    """Late plateau sitting above an earlier best that never came back."""
+    n = len(s)
+    if n < k + late_window:
+        return None
+    head = [v for v in s[: n - late_window] if v is not None]
+    if not head:
+        return None
+    best_v = min(head)
+    best_i = next(i for i, v in enumerate(s[: n - late_window]) if v == best_v)
+    if best_i > n - 1 - k:
+        return None
+    tail = [v for v in s[n - late_window :] if v is not None]
+    if not tail:
+        return None
+    late = statistics.median(tail)
+    gap = late - best_v
+    if gap < delta:
+        return None
+    return {"best_idx": best_i, "best": best_v, "late": late, "gap": gap, "steps_after_best": n - 1 - best_i}
+
+
+def analysis_window(run: Run, regime: str):
+    """Indices of the steps to scan. ``learned`` drops the pre-MLP cosine cold-start."""
+    steps = run.steps
+    if regime == "all":
+        return list(range(len(steps)))
+    have_mode = any("calib_mode" in s for s in steps)
+    if not have_mode:
+        return list(range(len(steps)))
+    if regime == "coldstart":
+        return [i for i, s in enumerate(steps) if s.get("calib_mode") == COLDSTART]
+    return [i for i, s in enumerate(steps) if s.get("calib_mode") != COLDSTART]
+
+
+def detect(run: Run, cfg) -> dict | None:
+    idx = analysis_window(run, cfg.regime)
+    if len(idx) < cfg.k + 2:
+        return None
+    raw = [run.steps[i].get("cost") for i in idx]
+    if sum(1 for v in raw if v is not None) < cfg.k + 2:
+        return None
+    s = smooth_median(raw, cfg.smooth)
+    rise = find_sustained_rise(s, cfg.k, cfg.delta, cfg.hold, cfg.min_up_frac)
+    gap = find_best_late_gap(s, cfg.k, cfg.delta, cfg.late_window)
+    if rise is not None:
+        a, b = idx[rise["start_idx"]], idx[rise["peak_idx"]]
+        severity = rise["rise"] * rise["hold"]
+        kind = "rise"
+    elif gap is not None:
+        a, b = idx[gap["best_idx"]], idx[-1]
+        severity = gap["gap"] * gap["steps_after_best"]
+        kind = "late-gap"
+    else:
+        return None
+    return {
+        "meta": run.meta,
+        "kind": kind,
+        "rise": rise,
+        "late_gap": gap,
+        "severity": severity,
+        "seg_i": a,
+        "seg_j": b,
+        "n_steps": len(idx),
+    }
+
+
+# --------------------------------------------------------------------------- characterisation
+
+
+def _regret(step):
+    """cost - oracle_cost at one step: the calibration gap, when both are recorded."""
+    c, o = step.get("cost"), step.get("oracle_cost")
+    return None if c is None or o is None else c - o
+
+
+def _delta(run: Run, name, a, b):
+    va, vb = run.steps[a].get(name), run.steps[b].get(name)
+    if va is None or vb is None:
+        return None
+    return vb - va
+
+
+def characterise(run: Run, det: dict) -> dict:
+    a, b = det["seg_i"], det["seg_j"]
+    sa, sb = run.steps[a], run.steps[b]
+    d_cost = _delta(run, "cost", a, b)
+    d_fnr = _delta(run, "fnr", a, b)
+    d_fpr = _delta(run, "fpr", a, b)
+    d_thr = _delta(run, "threshold", a, b)
+    d_or = _delta(run, "oracle_cost", a, b)
+    d_ap = _delta(run, "average_precision", a, b)
+    d_auroc = _delta(run, "auroc", a, b)
+
+    driver = None
+    if d_fnr is not None and d_fpr is not None:
+        if d_fnr > 0 and d_fpr <= 0:
+            driver = "fnr"
+        elif d_fpr > 0 and d_fnr <= 0:
+            driver = "fpr"
+        elif d_fnr > 0 and d_fpr > 0:
+            driver = "both"
+        else:
+            driver = "neither"
+
+    # Ranking vs calibration, decided **only** on cost=FNR+FPR: oracle_cost is the same cost at
+    # the best achievable cut, so its rise is the part of the damage no threshold could undo.
+    # Sources that never recorded oracle_cost stay undecided — AP/AUROC are a different metric
+    # and are not allowed to stand in for this call.
+    failure = None
+    ranking_share = None
+    if d_or is not None and d_cost:
+        ranking_share = d_or / d_cost
+        failure = "ranking" if ranking_share >= 0.5 else ("calibration" if ranking_share <= 0.2 else "mixed")
+    elif d_cost:
+        failure = "undecided-no-oracle-cost"
+
+    thr_mono = None
+    thr_vals = [run.steps[i].get("threshold") for i in range(a, b + 1)]
+    thr_vals = [v for v in thr_vals if v is not None]
+    if len(thr_vals) > 2:
+        ups = sum(1 for x, y in zip(thr_vals, thr_vals[1:]) if y > x)
+        thr_mono = ups / (len(thr_vals) - 1)
+
+    return {
+        "t_start": sa.get("t"),
+        "t_end": sb.get("t"),
+        "cost_start": sa.get("cost"),
+        "cost_end": sb.get("cost"),
+        "cost_final": run.steps[-1].get("cost"),
+        "d_cost": d_cost,
+        "d_fnr": d_fnr,
+        "d_fpr": d_fpr,
+        "driver": driver,
+        "d_threshold": d_thr,
+        "thr_up_frac": thr_mono,
+        "d_oracle": d_or,
+        "ranking_share": ranking_share,
+        "d_ap": d_ap,
+        "d_auroc": d_auroc,
+        "failure": failure,
+        "n_good_start": sa.get("n_good"),
+        "n_bad_start": sa.get("n_bad"),
+        "n_good_end": sb.get("n_good"),
+        "n_bad_end": sb.get("n_bad"),
+        "phase_start": sa.get("phase"),
+        "calib_start": sa.get("calib_mode"),
+        "regret_start": _regret(sa),
+        "regret_end": _regret(sb),
+    }
+
+
+# --------------------------------------------------------------------------- null control
+
+
+def null_severities(run: Run, cfg, n: int, rng: random.Random):
+    """Severity the detector reports on *n* surrogates of this run's own cost moves."""
+    out = []
+    for _ in range(n):
+        d = detect(permuted_copy(run, rng, cfg.null_mode), cfg)
+        out.append(d["severity"] if d is not None else 0.0)
+    return out
+
+
+def permutation_p(observed: float, nulls) -> float:
+    """Fraction of the null draws that match or beat the observed severity (add-one)."""
+    return (1 + sum(1 for v in nulls if v >= observed)) / (len(nulls) + 1)
+
+
+def permuted_copy(run: Run, rng: random.Random, mode: str = "demean") -> Run:
+    """A same-volatility surrogate of this run's cost curve.
+
+    ``demean`` (default) re-centres the step-to-step moves to zero net drift before
+    reshuffling: the surrogate is a **driftless** walk that is exactly as jumpy as the real
+    run, which is the null a *trend* claim has to beat. ``raw`` reshuffles the moves as they
+    are — but that preserves the run's start and end points, so it can only ask whether the
+    ordering is unusual, never whether the run ended worse. Use it as a sensitivity check.
+    """
+    idx = list(range(len(run.steps)))
+    costs = [run.steps[i].get("cost") for i in idx]
+    have = [i for i, v in enumerate(costs) if v is not None]
+    if len(have) < 3:
+        return run
+    deltas = [costs[b] - costs[a] for a, b in zip(have, have[1:])]
+    if mode == "demean":
+        drift = sum(deltas) / len(deltas)
+        deltas = [d - drift for d in deltas]
+    rng.shuffle(deltas)
+    new = list(costs)
+    cur = costs[have[0]]
+    for pos, d in zip(have[1:], deltas):
+        cur += d
+        new[pos] = cur
+    steps = [dict(s) for s in run.steps]
+    for i, v in enumerate(new):
+        if v is not None:
+            steps[i]["cost"] = v
+    return Run(key=run.key, meta=run.meta, steps=steps)
+
+
+def ramped_copy(run: Run, total_rise: float, cfg) -> Run | None:
+    """This run with a synthetic sustained rise injected over the back half of its window.
+
+    Used for the power check: if a planted wrong-way trend of a size we care about would not
+    survive the detector on *this* run, then "no detections here" means "too noisy to tell",
+    not "nothing is wrong".
+    """
+    idx = analysis_window(run, cfg.regime)
+    if len(idx) < 4:
+        return None
+    back = idx[len(idx) // 2 :]
+    steps = [dict(st) for st in run.steps]
+    for j, i in enumerate(back):
+        c = steps[i].get("cost")
+        if c is not None:
+            steps[i]["cost"] = c + total_rise * (j + 1) / len(back)
+    return Run(key=run.key, meta=run.meta, steps=steps)
+
+
+def power_report(runs, cfg, rise: float, rng: random.Random):
+    """Per-source: how volatile the cost curves are, and whether a planted trend is findable."""
+    groups = defaultdict(list)
+    for r in runs:
+        groups[(r.meta["dataset"], r.meta["proposal"], r.meta["embedder"])].append(r)
+    print(f"\n== detection power (planted sustained rise of +{rise:.2f} in cost over the back half) ==")
+    print(f"  {'group':<50} {'runs':>5} {'|dcost| med':>11} {'planted found':>14}")
+    for g, rs in sorted(groups.items()):
+        vols = []
+        found = tried = 0
+        for r in rs:
+            idx = analysis_window(r, cfg.regime)
+            cs = [r.steps[i].get("cost") for i in idx]
+            cs = [c for c in cs if c is not None]
+            if len(cs) > 2:
+                vols.append(statistics.median(abs(b - a) for a, b in zip(cs, cs[1:])))
+            ramped = ramped_copy(r, rise, cfg)
+            if ramped is None:
+                continue
+            tried += 1
+            d = detect(ramped, cfg)
+            if d is None:
+                continue
+            if cfg.per_run_null:
+                if permutation_p(d["severity"], null_severities(ramped, cfg, cfg.per_run_null, rng)) > cfg.null_alpha:
+                    continue
+            found += 1
+        vol = statistics.median(vols) if vols else float("nan")
+        rate = found / tried if tried else float("nan")
+        print(f"  {str(g):<50} {len(rs):>5} {vol:>11.4f} {rate:>13.0%}")
+
+
+# --------------------------------------------------------------------------- reporting
+
+
+def _rate_table(title, dets, runs, keyfn, min_runs: int = 1, limit: int | None = None):
+    """Wrong-way rate per group. *min_runs* hides cells too small to read a rate off."""
+    tot, hit = defaultdict(int), defaultdict(int)
+    for r in runs:
+        tot[keyfn(r.meta)] += 1
+    for d in dets:
+        hit[keyfn(d["meta"])] += 1
+    shown = [k for k in tot if tot[k] >= min_runs]
+    hidden = len(tot) - len(shown)
+    print(f"\n== {title} ==" + (f"   (>= {min_runs} runs; {hidden} smaller cells hidden)" if hidden else ""))
+    print(f"  {'group':<50} {'runs':>6} {'wrong-way':>10} {'rate':>7}")
+    order = sorted(shown, key=lambda k: -(hit[k] / max(1, tot[k])))
+    for k in order[:limit] if limit else order:
+        print(f"  {str(k):<50} {tot[k]:>6} {hit[k]:>10} {hit[k] / max(1, tot[k]):>7.3f}")
+
+
+def _share(items, pred):
+    items = list(items)
+    return (sum(1 for x in items if pred(x)) / len(items)) if items else float("nan")
+
+
+def _med(vals):
+    vals = [v for v in vals if v is not None]
+    return statistics.median(vals) if vals else float("nan")
+
+
+def report(runs, dets, cfg, null_rate=None):
+    print(f"runs scanned: {len(runs)}   wrong-way runs: {len(dets)} ({len(dets) / max(1, len(runs)):.3f})")
+    print(
+        f"  criteria: K>={cfg.k} steps, delta>={cfg.delta}, hold>={cfg.hold}, up_frac>={cfg.min_up_frac}, "
+        f"smooth={cfg.smooth}, late_window={cfg.late_window}, regime={cfg.regime}"
+    )
+    if null_rate is not None:
+        print(f"  permuted-null rate (same thresholds, temporal order destroyed): {null_rate:.3f}")
+    if not dets:
+        return
+    _rate_table("by dataset x proposal x embedder", dets, runs,
+                lambda m: (m["dataset"], m["proposal"], m["embedder"]))  # fmt: skip
+    _rate_table("by head / arm", dets, runs, lambda m: (m["dataset"], m["proposal"], m["head"], m["arm"]))
+    _rate_table("by class (worst 20)", dets, runs, lambda m: (m["dataset"], m["proposal"], m["class"]),
+                min_runs=10, limit=20)  # fmt: skip
+
+    ch = [d["char"] for d in dets]
+    print("\n== what is going wrong ==")
+    print(f"  kind: rise {_share(dets, lambda d: d['kind'] == 'rise'):.0%}  "
+          f"late-gap {_share(dets, lambda d: d['kind'] == 'late-gap'):.0%}")  # fmt: skip
+    for name in ("fnr", "fpr", "both", "neither"):
+        sh = _share(ch, lambda c, n=name: c["driver"] == n)
+        if sh == sh and sh > 0:
+            print(f"  driver={name:<8} {sh:.0%}")
+    print(f"  median rise in cost      : {_med(c['d_cost'] for c in ch):+.3f}")
+    never = _share(ch, lambda c: c["cost_final"] is not None and c["cost_start"] is not None
+                   and c["cost_final"] >= c["cost_start"] + 0.5 * cfg.delta)  # fmt: skip
+    print(f"  still worse at the LAST step of the run: {never:.0%}   "
+          f"median cost at t_end-of-run {_med(c['cost_final'] for c in ch):.3f} "
+          f"vs {_med(c['cost_start'] for c in ch):.3f} at onset")  # fmt: skip
+    print(f"  median onset step t      : {_med(c['t_start'] for c in ch):.0f}")
+    print(f"  median d_fnr / d_fpr     : {_med(c['d_fnr'] for c in ch):+.3f} / {_med(c['d_fpr'] for c in ch):+.3f}")
+    print(f"  median d_threshold       : {_med(c['d_threshold'] for c in ch):+.3f}  "
+          f"(share monotone-up >0.7: {_share(ch, lambda c: (c['thr_up_frac'] or 0) > 0.7):.0%})")  # fmt: skip
+    print(f"  n_good at onset (median) : {_med(c['n_good_start'] for c in ch):.0f}   "
+          f"n_bad {_med(c['n_bad_start'] for c in ch):.0f}")  # fmt: skip
+    ph = defaultdict(int)
+    for c in ch:
+        ph[c["phase_start"]] += 1
+    print(f"  phase at onset           : {dict(sorted(ph.items(), key=lambda kv: -kv[1]))}")
+
+    withor = [c for c in ch if c["ranking_share"] is not None]
+    if withor:
+        print("\n== calibration failure vs genuine RANKING degradation ==")
+        print(f"  runs with oracle_cost    : {len(withor)}")
+        print(f"  median d_oracle_cost     : {_med(c['d_oracle'] for c in withor):+.3f}  "
+              f"(median d_cost {_med(c['d_cost'] for c in withor):+.3f})")  # fmt: skip
+        print(f"  median ranking share     : {_med(c['ranking_share'] for c in withor):.2f}")
+        print("    (share of the cost rise that survives an oracle threshold = ranking damage)")
+        for lab in ("ranking", "mixed", "calibration"):
+            print(f"    {lab:<12} {_share(withor, lambda c, L=lab: c['failure'] == L):.0%}")
+        print(f"  ORACLE ITSELF ROSE >0.05 : {_share(withor, lambda c: (c['d_oracle'] or 0) > 0.05):.0%}"
+              " <- more labels degraded the RANKING")  # fmt: skip
+    noor = [c for c in ch if c["ranking_share"] is None]
+    if noor:
+        print(f"\n  ({len(noor)} detections come from a source with no oracle_cost column, so the "
+              "ranking/calibration split is undecided for them.)")  # fmt: skip
+    withap = [c for c in ch if c["d_ap"] is not None]
+    if withap:
+        print("\n== SECONDARY (not the #2825 metric): average_precision over the same segment ==")
+        print("  Context only — cost=FNR+FPR above is what the study is about; AP is a different metric")
+        print("  and is never used to classify a failure.")
+        print(f"  runs with AP             : {len(withap)}")
+        print(f"  median d_AP over segment : {_med(c['d_ap'] for c in withap):+.4f}   "
+              f"share AP fell: {_share(withap, lambda c: c['d_ap'] < 0):.0%}")  # fmt: skip
+        print(f"  median d_AUROC           : {_med(c['d_auroc'] for c in withap):+.4f}")
+
+    print(f"\n== worst {min(cfg.top, len(dets))} runs (severity = rise x persistence) ==")
+    for d in sorted(dets, key=lambda d: -d["severity"])[:cfg.top]:  # fmt: skip
+        m, c = d["meta"], d["char"]
+        orx = f" oracle {c['d_oracle']:+.3f}" if c["d_oracle"] is not None else ""
+        apx = f" AP {c['d_ap']:+.3f}" if c["d_ap"] is not None else ""
+        print(
+            f"  [{d['severity']:6.2f}] {m['dataset']}/{m['proposal']}/{m['embedder']}/{m['head'] or m['group']} "
+            f"{m['class']:<14} s{m['seed']:<3} {d['kind']:<9} "
+            f"t{c['t_start']}->{c['t_end']} cost {c['cost_start']:.3f}->{c['cost_end']:.3f} "
+            f"(fnr {c['d_fnr']:+.3f} fpr {c['d_fpr']:+.3f}){orx}{apx} g{c['n_good_start']}b{c['n_bad_start']}"
+        )
+
+
+def head_independence(runs, dets):
+    """Same (embedder, class, seed) across model families: data problem or model problem?"""
+    by_cell = defaultdict(dict)
+    for r in runs:
+        m = r.meta
+        if m["head"] not in HEADS:
+            continue
+        by_cell[(m["source"], m["dataset"], m["proposal"], m["embedder"], m["class"], m["seed"])][m["head"]] = False
+    for d in dets:
+        m = d["meta"]
+        if m["head"] not in HEADS:
+            continue
+        cell = (m["source"], m["dataset"], m["proposal"], m["embedder"], m["class"], m["seed"])
+        if cell in by_cell:
+            by_cell[cell][m["head"]] = True
+    full = {c: h for c, h in by_cell.items() if len(h) >= 3}
+    if not full:
+        return
+    hit = {c: [k for k, v in h.items() if v] for c, h in full.items()}
+    affected = {c: hs for c, hs in hit.items() if hs}
+    print("\n== head-independence (cells with >=3 heads run) ==")
+    print(f"  cells: {len(full)}   cells with >=1 wrong-way head: {len(affected)}")
+    dist = defaultdict(int)
+    for hs in affected.values():
+        dist[len(hs)] += 1
+    for n in sorted(dist):
+        print(f"    {n} of the heads affected: {dist[n]} cells ({dist[n] / max(1, len(affected)):.0%})")
+    both = sum(1 for hs in affected.values() if set(hs) & LINEAR_FAMILY and set(hs) & MLP_FAMILY)
+    only_mlp = sum(1 for hs in affected.values() if not (set(hs) & LINEAR_FAMILY))
+    only_lin = sum(1 for hs in affected.values() if not (set(hs) & MLP_FAMILY))
+    print(f"  hits BOTH a linear and an MLP family head : {both} ({both / max(1, len(affected)):.0%})"
+          "  <- head-independent => data/acquisition")  # fmt: skip
+    print(f"  MLP-family only                           : {only_mlp} ({only_mlp / max(1, len(affected)):.0%})"
+          "  <- model-flexibility")  # fmt: skip
+    print(f"  linear-family only                        : {only_lin} ({only_lin / max(1, len(affected)):.0%})")
+
+
+def show_runs(runs, spec: str, cfg):
+    """Dump the per-step table for the runs matching ``key=value,...`` — the deep-dive view."""
+    want = dict(kv.split("=", 1) for kv in spec.split(",") if "=" in kv)
+    sel = [r for r in runs if all(str(r.meta.get(k)) == v for k, v in want.items())]
+    print(f"\n== per-step detail for {spec}: {len(sel)} run(s) ==")
+    for run in sel:
+        det = detect(run, cfg)
+        mark = set(range(det["seg_i"], det["seg_j"] + 1)) if det else set()
+        print(f"\n  {run.meta}")
+        if det:
+            print(f"  detected: {det['kind']} severity {det['severity']:.3f} "
+                  f"(segment marked '>')")  # fmt: skip
+        cols = ["t", "cost", "oracle_cost", "fnr", "fpr", "threshold", "n_good", "n_bad",
+                "phase", "calib_mode", "average_precision"]  # fmt: skip
+        cols = [c for c in cols if any(c in st for st in run.steps)]
+        print("   " + " ".join(f"{c[:9]:>10}" for c in cols))
+        for i, st in enumerate(run.steps):
+            cells = []
+            for c in cols:
+                v = st.get(c)
+                cells.append(f"{v:>10.4f}" if isinstance(v, float) else f"{str(v):>10}")
+            print(("  >" if i in mark else "   ") + " ".join(cells))
+
+
+# --------------------------------------------------------------------------- cli
+
+
+def build_parser():
+    ap = argparse.ArgumentParser(description="Sustained wrong-way cost trends (#2825).")
+    ap.add_argument("--jsonl-root", action="append", default=[], metavar="LABEL=DIR",
+                    help="tree of results.jsonl; repeatable")  # fmt: skip
+    ap.add_argument("--csv-source", action="append", default=[], metavar="LABEL=PATH",
+                    help="max-patch cells.csv(.gz); repeatable")  # fmt: skip
+    ap.add_argument("--k", type=int, default=5, help="min consecutive steps in the rising segment")
+    ap.add_argument("--delta", type=float, default=0.10, help="min sustained rise in cost")
+    ap.add_argument("--hold", type=int, default=5, help="min steps the elevated cost must persist")
+    ap.add_argument("--min-up-frac", type=float, default=0.5, help="min fraction of upward steps in the segment")
+    ap.add_argument("--smooth", type=int, default=3, help="rolling-median window (>=3 kills 1-step spikes)")
+    ap.add_argument("--late-window", type=int, default=10, help="steps averaged for the late/final level")
+    ap.add_argument("--regime", choices=("learned", "all", "coldstart"), default="learned")
+    ap.add_argument("--top", type=int, default=25)
+    ap.add_argument("--permute-null", type=int, default=0,
+                    help="pooled null replicates per run, for the false-positive-rate line (0 = skip)")  # fmt: skip
+    ap.add_argument("--per-run-null", type=int, default=99,
+                    help="permutation replicates used to significance-test each detection (0 = magnitude only)")  # fmt: skip
+    ap.add_argument("--null-alpha", type=float, default=0.05, help="permutation p-value a detection must clear")
+    ap.add_argument("--null-mode", choices=("demean", "raw"), default="demean",
+                    help="surrogate construction; see permuted_copy")  # fmt: skip
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--out-json", default=None, help="write the detected runs here")
+    ap.add_argument("--strict-head", action="store_true", help="fail if a head cannot be read from the path")
+    ap.add_argument("--power-rise", type=float, default=0.0,
+                    help="plant a sustained rise of this size in every run and report how often it is found")  # fmt: skip
+    ap.add_argument("--show", action="append", default=[], metavar="k=v,k=v",
+                    help="dump the per-step table for matching runs (deep-dive); repeatable")  # fmt: skip
+    return ap
+
+
+def _split(spec, default_label):
+    if "=" in spec:
+        lab, _, p = spec.partition("=")
+        return lab, Path(p)
+    return default_label, Path(spec)
+
+
+def main(argv=None):
+    cfg = build_parser().parse_args(argv)
+    runs = []
+    for spec in cfg.jsonl_root:
+        lab, p = _split(spec, "jsonl")
+        got = load_jsonl_tree(p, lab, cfg.strict_head)
+        print(f"[load] {lab}: {len(got)} runs from {p}")
+        runs += got
+    for spec in cfg.csv_source:
+        lab, p = _split(spec, "csv")
+        got = load_maxpatch_csv(p, lab)
+        print(f"[load] {lab}: {len(got)} runs from {p}")
+        runs += got
+    if not runs:
+        raise SystemExit("no runs loaded")
+
+    rng = random.Random(cfg.seed)
+    dets, raw_hits = [], 0
+    for r in runs:
+        d = detect(r, cfg)
+        if d is None:
+            continue
+        raw_hits += 1
+        if cfg.per_run_null:
+            d["p"] = permutation_p(d["severity"], null_severities(r, cfg, cfg.per_run_null, rng))
+            if d["p"] > cfg.null_alpha:
+                continue
+        d["char"] = characterise(r, d)
+        d["cost_traj"] = [round(v, 4) for v in r.series("cost") if v is not None]
+        dets.append(d)
+    if cfg.per_run_null:
+        print(f"[null] {raw_hits} magnitude hits -> {len(dets)} survive the per-run permutation test "
+              f"(N={cfg.per_run_null}, alpha={cfg.null_alpha})")  # fmt: skip
+
+    null_rate = None
+    if cfg.permute_null:
+        hits = trials = 0
+        for r in runs:
+            for _ in range(cfg.permute_null):
+                trials += 1
+                if detect(permuted_copy(r, rng), cfg) is not None:
+                    hits += 1
+        null_rate = hits / max(1, trials)
+
+    report(runs, dets, cfg, null_rate)
+    head_independence(runs, dets)
+    if cfg.power_rise:
+        power_report(runs, cfg, cfg.power_rise, random.Random(cfg.seed + 1))
+    for spec in cfg.show:
+        show_runs(runs, spec, cfg)
+
+    if cfg.out_json:
+        Path(cfg.out_json).write_text(
+            json.dumps(
+                {
+                    "config": vars(cfg),
+                    "n_runs": len(runs),
+                    "null_rate": null_rate,
+                    "detections": [{k: v for k, v in d.items()} for d in dets],
+                },
+                indent=1,
+                default=str,
+            )
+        )
+        print(f"\nwrote {cfg.out_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/threshold_stability/sustained_regression.py
+++ b/scripts/experiments/threshold_stability/sustained_regression.py
@@ -228,7 +228,10 @@ def find_sustained_rise(s, k: int, delta: float, hold: int, min_up_frac: float):
             cand = _validate_rise(s, min_i, j, delta, hold, min_up_frac)
             if cand is not None and (best is None or cand["rise"] * cand["hold"] > best["rise"] * best["hold"]):
                 best = cand
-        if s[j] < s[min_i]:
+        # ``<=`` on purpose: anchor the floor at the LAST step that was at the best-so-far, not
+        # the first. With ``<`` a long flat stretch gets swallowed into the segment and drags
+        # ``up_frac`` down to the rejection boundary, so real climbs off a plateau are missed.
+        if s[j] <= s[min_i]:
             min_i = j
     return best
 
@@ -386,6 +389,27 @@ def characterise(run: Run, det: dict) -> dict:
         ups = sum(1 for x, y in zip(thr_vals, thr_vals[1:]) if y > x)
         thr_mono = ups / (len(thr_vals) - 1)
 
+    # What the user was actually feeding the loop across the segment. The mechanism claim is
+    # that a wrong-way stretch is a stretch where the bad votes keep coming and the good ones
+    # stop, so the cut has nothing holding it down and marches up through the test positives.
+    d_good = _delta(run, "n_good", a, b)
+    d_bad = _delta(run, "n_bad", a, b)
+    votes = (d_good or 0) + (d_bad or 0)
+    good_share = (d_good / votes) if votes else None
+    run_good = run.steps[-1].get("n_good")
+    run_bad = run.steps[-1].get("n_bad")
+    run_votes = (run_good or 0) + (run_bad or 0)
+    good_share_run = (run_good / run_votes) if run_votes else None
+    # Longest stretch inside the segment with no new positive at all.
+    dry = best_dry = 0
+    for i in range(a + 1, b + 1):
+        prev, cur = run.steps[i - 1].get("n_good"), run.steps[i].get("n_good")
+        if prev is not None and cur is not None and cur > prev:
+            dry = 0
+        else:
+            dry += 1
+            best_dry = max(best_dry, dry)
+
     return {
         "t_start": sa.get("t"),
         "t_end": sb.get("t"),
@@ -407,6 +431,11 @@ def characterise(run: Run, det: dict) -> dict:
         "n_bad_start": sa.get("n_bad"),
         "n_good_end": sb.get("n_good"),
         "n_bad_end": sb.get("n_bad"),
+        "d_n_good": d_good,
+        "d_n_bad": d_bad,
+        "good_share_segment": good_share,
+        "good_share_run": good_share_run,
+        "longest_no_positive_stretch": best_dry,
         "phase_start": sa.get("phase"),
         "calib_start": sa.get("calib_mode"),
         "regret_start": _regret(sa),
@@ -421,7 +450,7 @@ def null_severities(run: Run, cfg, n: int, rng: random.Random):
     """Severity the detector reports on *n* surrogates of this run's own cost moves."""
     out = []
     for _ in range(n):
-        d = detect(permuted_copy(run, rng, cfg.null_mode), cfg)
+        d = detect(permuted_copy(run, rng, cfg.null_mode, cfg.null_block), cfg)
         out.append(d["severity"] if d is not None else 0.0)
     return out
 
@@ -431,7 +460,23 @@ def permutation_p(observed: float, nulls) -> float:
     return (1 + sum(1 for v in nulls if v >= observed)) / (len(nulls) + 1)
 
 
-def permuted_copy(run: Run, rng: random.Random, mode: str = "demean") -> Run:
+def _shuffle_blocks(deltas, block: int, rng: random.Random):
+    """Reorder contiguous blocks of moves instead of individual moves.
+
+    Single-move shuffling is the wrong null here: a #2790 deep spike is a ``+0.9`` step
+    immediately followed by a ``-0.9`` recovery, and shuffling separates the pair, so the
+    surrogate manufactures exactly the sustained level shifts we are testing for. Keeping
+    moves in blocks preserves that local pairing, which is what makes the test usable.
+    """
+    if block <= 1:
+        rng.shuffle(deltas)
+        return deltas
+    blocks = [deltas[i : i + block] for i in range(0, len(deltas), block)]
+    rng.shuffle(blocks)
+    return [d for b in blocks for d in b]
+
+
+def permuted_copy(run: Run, rng: random.Random, mode: str = "demean", block: int = 5) -> Run:
     """A same-volatility surrogate of this run's cost curve.
 
     ``demean`` (default) re-centres the step-to-step moves to zero net drift before
@@ -439,6 +484,7 @@ def permuted_copy(run: Run, rng: random.Random, mode: str = "demean") -> Run:
     run, which is the null a *trend* claim has to beat. ``raw`` reshuffles the moves as they
     are — but that preserves the run's start and end points, so it can only ask whether the
     ordering is unusual, never whether the run ended worse. Use it as a sensitivity check.
+    *block* is the block length for the reshuffle (see :func:`_shuffle_blocks`).
     """
     idx = list(range(len(run.steps)))
     costs = [run.steps[i].get("cost") for i in idx]
@@ -449,7 +495,7 @@ def permuted_copy(run: Run, rng: random.Random, mode: str = "demean") -> Run:
     if mode == "demean":
         drift = sum(deltas) / len(deltas)
         deltas = [d - drift for d in deltas]
-    rng.shuffle(deltas)
+    deltas = _shuffle_blocks(list(deltas), block, rng)
     new = list(costs)
     cur = costs[have[0]]
     for pos, d in zip(have[1:], deltas):
@@ -481,36 +527,72 @@ def ramped_copy(run: Run, total_rise: float, cfg) -> Run | None:
     return Run(key=run.key, meta=run.meta, steps=steps)
 
 
+def gated_detect(run: Run, cfg, rng: random.Random):
+    """detect() plus the per-run permutation gate — the full pipeline, as applied to real data."""
+    d = detect(run, cfg)
+    if d is None:
+        return None
+    if cfg.per_run_null:
+        if permutation_p(d["severity"], null_severities(run, cfg, cfg.per_run_null, rng)) > cfg.null_alpha:
+            return None
+    return d
+
+
+def fp_report(runs, cfg, reps: int, rng: random.Random):
+    """Type-I error: feed the pipeline surrogates that contain no trend by construction."""
+    groups = defaultdict(lambda: [0, 0])
+    for r in runs:
+        for _ in range(reps):
+            sur = permuted_copy(r, rng, cfg.null_mode, cfg.null_block)
+            g = groups[(r.meta["dataset"], r.meta["proposal"], r.meta["embedder"])]
+            g[1] += 1
+            if gated_detect(sur, cfg, rng) is not None:
+                g[0] += 1
+    print(f"\n== type-I error (pipeline run on trend-free surrogates, target <= {cfg.null_alpha:.2f}) ==")
+    print(f"  {'group':<50} {'trials':>7} {'false pos':>10} {'rate':>7}")
+    for g, (hit, tot) in sorted(groups.items()):
+        print(f"  {str(g):<50} {tot:>7} {hit:>10} {hit / max(1, tot):>7.3f}")
+
+
 def power_report(runs, cfg, rise: float, rng: random.Random):
-    """Per-source: how volatile the cost curves are, and whether a planted trend is findable."""
+    """Per-source: how volatile the cost curves are, and whether a planted trend is findable.
+
+    Two columns, because they answer different questions. ``on run`` plants the rise on the
+    real trajectory, so it measures whether this much *extra* worsening would show up on top
+    of whatever the run already does — and most runs are busy improving, which cancels much
+    of it. ``on flat`` plants the same rise on a trendless surrogate of the same volatility,
+    which isolates the detector's own sensitivity. Read ``on flat`` when deciding whether a
+    source's zero detections mean "nothing there" or "could not have seen it".
+    """
     groups = defaultdict(list)
     for r in runs:
         groups[(r.meta["dataset"], r.meta["proposal"], r.meta["embedder"])].append(r)
     print(f"\n== detection power (planted sustained rise of +{rise:.2f} in cost over the back half) ==")
-    print(f"  {'group':<50} {'runs':>5} {'|dcost| med':>11} {'planted found':>14}")
+    print(f"  {'group':<50} {'runs':>5} {'|dcost| med':>11} {'on run':>8} {'on flat':>8} {'drift':>8}")
     for g, rs in sorted(groups.items()):
-        vols = []
-        found = tried = 0
+        vols, drifts = [], []
+        found = found_flat = tried = 0
         for r in rs:
             idx = analysis_window(r, cfg.regime)
             cs = [r.steps[i].get("cost") for i in idx]
             cs = [c for c in cs if c is not None]
             if len(cs) > 2:
                 vols.append(statistics.median(abs(b - a) for a, b in zip(cs, cs[1:])))
+                drifts.append(cs[-1] - cs[0])
             ramped = ramped_copy(r, rise, cfg)
             if ramped is None:
                 continue
             tried += 1
-            d = detect(ramped, cfg)
-            if d is None:
-                continue
-            if cfg.per_run_null:
-                if permutation_p(d["severity"], null_severities(ramped, cfg, cfg.per_run_null, rng)) > cfg.null_alpha:
-                    continue
-            found += 1
+            if gated_detect(ramped, cfg, rng) is not None:
+                found += 1
+            flat = ramped_copy(permuted_copy(r, rng, "demean", cfg.null_block), rise, cfg)
+            if flat is not None and gated_detect(flat, cfg, rng) is not None:
+                found_flat += 1
         vol = statistics.median(vols) if vols else float("nan")
+        dr = statistics.median(drifts) if drifts else float("nan")
         rate = found / tried if tried else float("nan")
-        print(f"  {str(g):<50} {len(rs):>5} {vol:>11.4f} {rate:>13.0%}")
+        rate_f = found_flat / tried if tried else float("nan")
+        print(f"  {str(g):<50} {len(rs):>5} {vol:>11.4f} {rate:>7.0%} {rate_f:>8.0%} {dr:>+8.3f}")
 
 
 # --------------------------------------------------------------------------- reporting
@@ -582,6 +664,18 @@ def report(runs, dets, cfg, null_rate=None):
     for c in ch:
         ph[c["phase_start"]] += 1
     print(f"  phase at onset           : {dict(sorted(ph.items(), key=lambda kv: -kv[1]))}")
+
+    print("\n== what the loop was being fed across the wrong-way segment ==")
+    print(f"  votes added: good {_med(c['d_n_good'] for c in ch):.0f}  bad {_med(c['d_n_bad'] for c in ch):.0f}"
+          "   (median)")  # fmt: skip
+    gs = [c["good_share_segment"] for c in ch if c["good_share_segment"] is not None]
+    gr = [c["good_share_run"] for c in ch if c["good_share_run"] is not None]
+    print(f"  share of votes that were GOOD: {_med(gs):.2f} inside the segment "
+          f"vs {_med(gr):.2f} over the whole run")  # fmt: skip
+    print(f"  segments where NOT ONE new positive arrived: "
+          f"{_share(ch, lambda c: (c['d_n_good'] or 0) == 0):.0%}")  # fmt: skip
+    print(f"  longest run of steps with no new positive  : median "
+          f"{_med(c['longest_no_positive_stretch'] for c in ch):.0f} steps")  # fmt: skip
 
     withor = [c for c in ch if c["ranking_share"] is not None]
     if withor:
@@ -705,6 +799,12 @@ def build_parser():
     ap.add_argument("--per-run-null", type=int, default=99,
                     help="permutation replicates used to significance-test each detection (0 = magnitude only)")  # fmt: skip
     ap.add_argument("--null-alpha", type=float, default=0.05, help="permutation p-value a detection must clear")
+    ap.add_argument("--sample", type=int, default=0,
+                    help="deterministically subsample this many runs (calibration only, 0 = all)")  # fmt: skip
+    ap.add_argument("--null-block", type=int, default=5,
+                    help="block length for the surrogate reshuffle; 1 = shuffle single moves")  # fmt: skip
+    ap.add_argument("--fp-check", type=int, default=0,
+                    help="run the FULL pipeline on N surrogates per run and report the type-I error rate")  # fmt: skip
     ap.add_argument("--null-mode", choices=("demean", "raw"), default="demean",
                     help="surrogate construction; see permuted_copy")  # fmt: skip
     ap.add_argument("--seed", type=int, default=0)
@@ -739,6 +839,10 @@ def main(argv=None):
         runs += got
     if not runs:
         raise SystemExit("no runs loaded")
+    if cfg.sample and cfg.sample < len(runs):
+        step = len(runs) / cfg.sample  # even stride keeps every source represented
+        runs = [runs[int(i * step)] for i in range(cfg.sample)]
+        print(f"[sample] calibrating on {len(runs)} runs (even stride)")
 
     rng = random.Random(cfg.seed)
     dets, raw_hits = [], 0
@@ -772,6 +876,8 @@ def main(argv=None):
     head_independence(runs, dets)
     if cfg.power_rise:
         power_report(runs, cfg, cfg.power_rise, random.Random(cfg.seed + 1))
+    if cfg.fp_check:
+        fp_report(runs, cfg, cfg.fp_check, random.Random(cfg.seed + 2))
     for spec in cfg.show:
         show_runs(runs, spec, cfg)
 

--- a/tests_lib/sorting/test_sustained_regression.py
+++ b/tests_lib/sorting/test_sustained_regression.py
@@ -1,0 +1,268 @@
+"""Pure-core tests for the sustained wrong-way-trend detector (issue #2825).
+
+The science that matters here is the *discrimination*: a persistent climb in held-out cost
+must fire, and a transient deep spike (the #2790 phenomenon, already studied by
+``deep_spikes.py``) must NOT — nor may sub-delta drift or plain noise. Everything below runs
+on synthetic trajectories, so no sweep data, cache, model or GPU is needed. The tool lives
+under ``scripts/experiments/threshold_stability``; the test puts that dir on ``sys.path`` the
+same way the runner does.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "threshold_stability"))
+
+from sustained_regression import (  # noqa: E402
+    Run,
+    analysis_window,
+    characterise,
+    detect,
+    find_best_late_gap,
+    find_sustained_rise,
+    null_severities,
+    permutation_p,
+    permuted_copy,
+    smooth_median,
+)
+
+
+class _Cfg:
+    """Stand-in for the argparse namespace the detector reads."""
+
+    k = 5
+    delta = 0.10
+    hold = 5
+    min_up_frac = 0.5
+    smooth = 3
+    late_window = 10
+    regime = "learned"
+    null_mode = "demean"
+    top = 5
+
+
+def _run(costs, **extra):
+    steps = []
+    for i, c in enumerate(costs):
+        s = {"t": i + 1, "cost": c, "calib_mode": "conformal", "n_good": 3, "n_bad": 4}
+        for k, v in extra.items():
+            s[k] = v[i] if isinstance(v, list) else v
+        steps.append(s)
+    return Run(key=("k",), meta={"head": "mlp", "class": "car", "seed": 0}, steps=steps)
+
+
+# --------------------------------------------------------------------------- smoothing
+
+
+def test_smooth_median_removes_single_step_spike():
+    xs = [0.1, 0.1, 0.9, 0.1, 0.1]
+    assert smooth_median(xs, 3) == [0.1, 0.1, 0.1, 0.1, 0.1]
+
+
+def test_smooth_median_keeps_a_sustained_level_change():
+    xs = [0.1] * 5 + [0.5] * 5
+    out = smooth_median(xs, 3)
+    assert out[:4] == [0.1] * 4
+    assert out[-4:] == [0.5] * 4
+
+
+# --------------------------------------------------------------------------- rise finder
+
+
+def test_sustained_rise_fires_on_a_persistent_climb():
+    s = [0.10, 0.12, 0.16, 0.22, 0.28, 0.34, 0.40, 0.40, 0.41, 0.40, 0.42, 0.41]
+    hit = find_sustained_rise(s, k=5, delta=0.10, hold=5, min_up_frac=0.5)
+    assert hit is not None
+    assert hit["rise"] > 0.25
+    assert hit["span"] >= 5
+    assert hit["held_to_end"]
+
+
+def test_transient_spike_does_not_fire():
+    """The #2790 deep spike: one violent step that snaps straight back."""
+    s = [0.08] * 10 + [0.95] + [0.08] * 10
+    assert find_sustained_rise(smooth_median(s, 3), k=5, delta=0.10, hold=5, min_up_frac=0.5) is None
+
+
+def test_two_step_excursion_does_not_fire():
+    s = [0.08] * 10 + [0.60, 0.55] + [0.08] * 10
+    assert find_sustained_rise(smooth_median(s, 3), k=5, delta=0.10, hold=5, min_up_frac=0.5) is None
+
+
+def test_sub_delta_drift_does_not_fire():
+    s = [0.20 + 0.004 * i for i in range(20)]  # real trend, but only +0.076 total
+    assert find_sustained_rise(s, k=5, delta=0.10, hold=5, min_up_frac=0.5) is None
+
+
+def test_rise_that_is_given_back_does_not_fire():
+    """Climbs by 0.3 but returns to the floor immediately: not sustained."""
+    s = [0.10, 0.15, 0.20, 0.25, 0.30, 0.40, 0.11, 0.10, 0.10, 0.10, 0.10, 0.10]
+    assert find_sustained_rise(s, k=5, delta=0.10, hold=5, min_up_frac=0.5) is None
+
+
+def test_step_change_that_never_recovers_fires():
+    """Not a gradual climb, but the cost steps up and simply stays there: in scope."""
+    s = [0.10, 0.45, 0.46, 0.47] + [0.46] * 8
+    hit = find_sustained_rise(s, k=5, delta=0.10, hold=5, min_up_frac=0.5)
+    assert hit is not None
+    assert hit["held_to_end"]
+
+
+def test_a_run_that_ends_elevated_is_not_penalised_for_having_no_room_left():
+    """The rise peaks on the last step — there is nowhere left to recover, so it counts."""
+    s = [0.10] * 3 + [0.14, 0.20, 0.27, 0.33, 0.40]
+    assert find_sustained_rise(s, k=5, delta=0.10, hold=5, min_up_frac=0.5) is not None
+
+
+def test_long_flat_then_permanent_step_is_caught_by_the_late_gap_rule():
+    run = _run([0.08] * 14 + [0.55] * 14)
+    det = detect(run, _Cfg())
+    assert det is not None
+    assert det["kind"] == "late-gap"
+
+
+def test_improving_run_does_not_fire():
+    s = [0.60 - 0.02 * i for i in range(25)]
+    assert find_sustained_rise(s, k=5, delta=0.10, hold=5, min_up_frac=0.5) is None
+
+
+# --------------------------------------------------------------------------- late-gap finder
+
+
+def test_late_gap_fires_when_the_end_sits_above_an_earlier_best():
+    s = [0.5, 0.3, 0.1] + [0.2] * 5 + [0.35] * 10
+    hit = find_best_late_gap(s, k=5, delta=0.10, late_window=10)
+    assert hit is not None
+    assert hit["best"] == 0.1
+    assert round(hit["gap"], 3) == 0.25
+
+
+def test_late_gap_silent_when_the_run_ends_at_its_best():
+    s = [0.5] * 5 + [0.3] * 5 + [0.1] * 10
+    assert find_best_late_gap(s, k=5, delta=0.10, late_window=10) is None
+
+
+def test_late_gap_ignores_a_best_at_the_very_end():
+    s = [0.4] * 12 + [0.1] * 10
+    assert find_best_late_gap(s, k=5, delta=0.10, late_window=10) is None
+
+
+# --------------------------------------------------------------------------- regime window
+
+
+def test_analysis_window_drops_cold_start():
+    run = _run([0.5] * 6)
+    for i in range(3):
+        run.steps[i]["calib_mode"] = "cosine_coldstart"
+    assert analysis_window(run, "learned") == [3, 4, 5]
+    assert analysis_window(run, "coldstart") == [0, 1, 2]
+    assert analysis_window(run, "all") == [0, 1, 2, 3, 4, 5]
+
+
+def test_detect_ignores_a_cold_start_handoff_jump():
+    """A jump that happens exactly at the cosine->learned handoff is out of the window."""
+    run = _run([0.05] * 8 + [0.55] * 12)
+    for i in range(8):
+        run.steps[i]["calib_mode"] = "cosine_coldstart"
+    assert detect(run, _Cfg()) is None
+
+
+# --------------------------------------------------------------------------- characterisation
+
+
+def test_characterise_splits_ranking_from_calibration():
+    costs = [0.10, 0.14, 0.20, 0.26, 0.32, 0.38, 0.40, 0.40, 0.41, 0.40, 0.42, 0.41]
+    # oracle flat => the whole rise is calibration regret
+    calib = _run(costs, oracle_cost=[0.09] * len(costs), fnr=[c * 0.9 for c in costs], fpr=[0.01] * len(costs))
+    det = detect(calib, _Cfg())
+    assert det is not None
+    ch = characterise(calib, det)
+    assert ch["failure"] == "calibration"
+    assert ch["driver"] == "fnr"
+
+    # oracle rises with cost => the ranking itself degraded (the scary case)
+    rank = _run(costs, oracle_cost=[c - 0.02 for c in costs], fnr=[0.01] * len(costs), fpr=[c * 0.9 for c in costs])
+    det2 = detect(rank, _Cfg())
+    ch2 = characterise(rank, det2)
+    assert ch2["failure"] == "ranking"
+    assert ch2["ranking_share"] > 0.9
+    assert ch2["driver"] == "fpr"
+
+
+def test_a_source_without_oracle_cost_is_undecided_not_judged_on_ap():
+    """#2825 is a cost=FNR+FPR question; AP is a different metric and must not classify."""
+    costs = [0.10, 0.14, 0.20, 0.26, 0.32, 0.38, 0.40, 0.40, 0.41, 0.40, 0.42, 0.41]
+    run = _run(costs, average_precision=[0.8 - 0.02 * i for i in range(len(costs))])
+    det = detect(run, _Cfg())
+    ch = characterise(run, det)
+    assert ch["d_ap"] < -0.01  # still reported...
+    assert ch["ranking_share"] is None  # ...but it decides nothing
+    assert ch["failure"] == "undecided-no-oracle-cost"
+
+
+def test_detection_is_driven_by_cost_not_by_ap():
+    """AP collapsing while cost stays flat is not a #2825 wrong-way run."""
+    flat = [0.20] * 24
+    run = _run(flat, average_precision=[0.9 - 0.03 * i for i in range(24)])
+    assert detect(run, _Cfg()) is None
+
+
+# --------------------------------------------------------------------------- null control
+
+
+def test_raw_surrogate_preserves_the_delta_multiset_and_endpoints():
+    run = _run([0.1, 0.3, 0.2, 0.6, 0.5, 0.4])
+    perm = permuted_copy(run, random.Random(0), mode="raw")
+    orig = sorted(round(b - a, 9) for a, b in zip(run.series("cost"), run.series("cost")[1:]))
+    got = sorted(round(b - a, 9) for a, b in zip(perm.series("cost"), perm.series("cost")[1:]))
+    assert orig == got
+    assert perm.series("cost")[0] == run.series("cost")[0]
+    # ...which is exactly why `raw` cannot test a trend: the end point is fixed too.
+    assert round(perm.series("cost")[-1], 9) == round(run.series("cost")[-1], 9)
+
+
+def test_demeaned_surrogate_keeps_the_volatility_but_drops_the_drift():
+    costs = [0.10 + 0.05 * i for i in range(12)]  # steady climb
+    run = _run(costs)
+    perm = permuted_copy(run, random.Random(0), mode="demean")
+    seq = perm.series("cost")
+    assert abs(seq[-1] - seq[0]) < 1e-9  # no net drift left
+    spread = max(abs(b - a) for a, b in zip(seq, seq[1:]))
+    assert spread < 1e-9  # a perfectly steady climb has zero volatility once demeaned
+
+
+def test_demeaned_surrogate_does_not_flatten_a_jumpy_run():
+    run = _run([0.1, 0.5, 0.15, 0.6, 0.2, 0.55])
+    perm = permuted_copy(run, random.Random(3), mode="demean")
+    seq = perm.series("cost")
+    assert max(abs(b - a) for a, b in zip(seq, seq[1:])) > 0.2
+
+
+def test_permuted_copy_leaves_other_fields_alone():
+    run = _run([0.1, 0.3, 0.2, 0.6, 0.5, 0.4], fnr=[0.5] * 6)
+    perm = permuted_copy(run, random.Random(1))
+    assert perm.series("fnr") == [0.5] * 6
+    assert perm.series("t") == [1, 2, 3, 4, 5, 6]
+
+
+def test_permutation_p_is_one_sided_with_add_one():
+    assert permutation_p(1.0, [0.0] * 99) == 1 / 100
+    assert permutation_p(0.0, [1.0] * 99) == 100 / 100
+    assert permutation_p(0.5, [1.0] * 49 + [0.0] * 50) == 50 / 100
+
+
+def test_a_steady_climb_beats_its_own_null_but_a_jumpy_flat_run_does_not():
+    cfg = _Cfg()
+    rng = random.Random(0)
+    climb = _run([0.10 + 0.02 * i for i in range(30)])
+    det = detect(climb, cfg)
+    assert det is not None
+    assert permutation_p(det["severity"], null_severities(climb, cfg, 99, rng)) <= 0.05
+
+    jumpy = _run([0.2, 0.55, 0.18, 0.6, 0.22, 0.58, 0.19, 0.62, 0.21, 0.57] * 3)
+    d2 = detect(jumpy, cfg)
+    if d2 is not None:
+        assert permutation_p(d2["severity"], null_severities(jumpy, cfg, 99, rng)) > 0.05

--- a/tests_lib/sorting/test_sustained_regression.py
+++ b/tests_lib/sorting/test_sustained_regression.py
@@ -41,6 +41,9 @@ class _Cfg:
     late_window = 10
     regime = "learned"
     null_mode = "demean"
+    null_block = 5
+    per_run_null = 99
+    null_alpha = 0.05
     top = 5
 
 
@@ -266,3 +269,47 @@ def test_a_steady_climb_beats_its_own_null_but_a_jumpy_flat_run_does_not():
     d2 = detect(jumpy, cfg)
     if d2 is not None:
         assert permutation_p(d2["severity"], null_severities(jumpy, cfg, 99, rng)) > 0.05
+
+
+# --------------------------------------------------------------------------- block surrogate
+
+
+def test_block_shuffle_keeps_a_spike_next_to_its_recovery():
+    """A +0.9 jump and its -0.9 snap-back must not be torn apart by the surrogate."""
+    from sustained_regression import _shuffle_blocks
+
+    deltas = [0.0, 0.0, 0.9, -0.9, 0.0, 0.0, 0.0, 0.0]
+    for seed in range(20):
+        out = _shuffle_blocks(list(deltas), block=4, rng=random.Random(seed))
+        i = out.index(0.9)
+        assert out[i + 1] == -0.9, out
+
+
+def test_single_move_shuffle_does_tear_the_pair_apart():
+    """Which is exactly why block=1 makes the null far too conservative here."""
+    from sustained_regression import _shuffle_blocks
+
+    deltas = [0.0, 0.0, 0.9, -0.9, 0.0, 0.0, 0.0, 0.0]
+    torn = 0
+    for seed in range(40):
+        out = _shuffle_blocks(list(deltas), block=1, rng=random.Random(seed))
+        i = out.index(0.9)
+        if i + 1 >= len(out) or out[i + 1] != -0.9:
+            torn += 1
+    assert torn > 20
+
+
+def test_block_surrogate_still_destroys_a_trend():
+    run = _run([0.10 + 0.02 * i for i in range(40)])
+    perm = permuted_copy(run, random.Random(0), mode="demean", block=5)
+    seq = perm.series("cost")
+    assert abs(seq[-1] - seq[0]) < 1e-9
+
+
+def test_climb_off_a_long_plateau_is_found():
+    """The floor must anchor at the END of the plateau, else up_frac sinks and the climb is lost."""
+    s = [0.10] * 25 + [0.10 + 0.012 * i for i in range(1, 26)]
+    hit = find_sustained_rise(s, k=5, delta=0.10, hold=5, min_up_frac=0.5)
+    assert hit is not None
+    assert hit["start_idx"] >= 24  # anchored at the end of the plateau, not index 0
+    assert hit["up_frac"] > 0.9

--- a/vtscore/eval/region_curve.py
+++ b/vtscore/eval/region_curve.py
@@ -916,9 +916,14 @@ def _row_realistic(
     select_mode,
     stop_recommended,
     oracle_extra=None,
+    head_strategy=None,
 ) -> dict:
     row = _row(inputs, head_kind, t, n_bad, seed, threshold, err, oracle, calib, f1, mean_iou, corloc, oracle_extra)
     row["n_pos"] = int(n_good)  # override: for the realistic loop n_pos is the good count, not t
+    # head is the per-step scoring family (cosine vs mlp); the *arm* actually swept is
+    # --head-strategy, which used to survive only in the output directory name and left
+    # re-analyses guessing (#2825). Record it so a row is genuinely self-describing.
+    row["head_strategy"] = head_strategy
     row["t"] = int(t)
     row["n_good"] = int(n_good)
     row["n_bad"] = int(n_bad)
@@ -1205,6 +1210,7 @@ def _realistic_one_seed(
                 select_mode,
                 stop_recommended,
                 oracle_extra=oracle_extra,
+                head_strategy=head_strategy,
             )
         )
         # Per-step labeling record: how the item was surfaced (from pending_meta,


### PR DESCRIPTION
Closes #2825.

Finds the runs where the held-out cost curve legitimately goes the wrong way and **stays**
there — the persistent, non-recovering sibling of the #2790 deep spike — and works out what is
going wrong. Reuses the per-step rows the sweeps already wrote: **no new runs**.

Everything is on `cost = FNR + FPR`, the metric the sweeps were run on. Detection scans `cost`;
the ranking-vs-calibration split compares it with `oracle_cost` (that same cost at the best
achievable cut). `average_precision`/`auroc` are printed where a source has them but never
classify anything.

## Coverage

4,484 trajectories: VG + COCO, SigLIP 1/2 + DINOv2/v3, **boolean *and* region voting** —
including the VG DINOv3-patch max-patch history (`max_patch` / `max_patch_hac` / `max_hac`,
t→150) and the COCO `hac` region-voting sweeps.

## What it found

**223 runs (5.0%)**. Median cost **0.486 at onset → 0.742 at the last step of the run**;
**98% are still worse at the final step** than where the segment began.

**The mechanism is the vote mix, not the model.** Across a wrong-way segment the loop is fed a
median of **1 good vote and 9 bad ones** (good share 0.09 inside the segment vs 0.22 over the
run); **34% of segments receive not one new positive**, median dry stretch 7 steps. `n_good` at
onset is 3, phase is `hard` in 219/223, median onset **t=10**. **93% are FNR-driven** (median
ΔFNR +0.53, ΔFPR −0.16) — the cut walks up through the test positives until the detector finds
almost nothing. Same positive starvation as #2790, but a prolonged run of bad votes rather than
one, so it never snaps back.

**Two results worth a look:**

- **The linear head does not fix this.** On COCO it is the *worst* arm (0.077) and the MLP the
  best (0.050); on VG the MLP is best. Only 29% of affected cells hit both a linear-family and
  an MLP-family head. #2790's linear-head fix is right for the spikes and is not protective
  here — the two failures need different fixes.
- **Region voting is nearly clean** (4/378) against 5–6% for boolean. Stated as "no evidence of
  a significant problem" rather than a clean bill of health: 378 runs is under-powered and those
  runs improve by a median −0.55 in cost, leaving little room for a wrong-way stretch to show.

**Calibration vs ranking:** 56% calibration / 35% mixed / 10% ranking (median Δ`oracle_cost`
+0.058 vs Δ`cost` +0.316) — but `oracle_cost` itself rose >0.05 in **56%** of detections, so the
issue's "scariest case" is real and common, just not dominant.

## Method — and why the naive version of this question is meaningless

A magnitude-only rule at K=5/δ=0.10 flags **49%** of runs — while flagging **74–90%** of
surrogates built from each run's own step-to-step moves. It measures jumpiness, not trends. So
every detection clears a **per-run permutation test** (99 volatility-matched, drift-removed
surrogates, α=0.05). Two details, both pinned by tests:

- **Reshuffle in blocks of 5.** A deep spike is `+0.9` followed immediately by `−0.9`;
  single-move shuffling tears the pair apart and the surrogate manufactures exactly the level
  shifts under test.
- **Anchor the segment floor at the last best-so-far**, not the first, or a flat prefix gets
  swallowed and drags the "mostly upward" fraction to the rejection boundary.

Type-I error on trend-free surrogates: **0.028–0.056** for the well-populated sources.

**Power is the honest weakness: 9–11% (boolean) / 7–28% (region voting)** for a planted +0.30
sustained rise. **5.0% is reported throughout as a lower bound, not an estimate.**

## Also in here

`head` in a sweep row is the per-step scoring family (`cosine` vs `mlp`), not the
`--head-strategy` arm — it reads `mlp` for every row of the `linear`/`svm`/`reg-mlp` sweeps
alike, so the arm is unrecoverable from `vg_bool_all.jsonl.gz` and survives only in the output
directory name. `DATA_AND_SCHEMA.md` is wrong on this point. `_row_realistic` now records
`head_strategy`; the tool reads the arm from the path for existing data.

## Recommends

1. **Positive-seeking acquisition** — identified at the end of #2790, still unbuilt. This is
   independent evidence for the same fix: the damage tracks the vote mix, not the model class.
2. **A runtime no-new-positives guard** — `n_good` not moving for k votes is directly observable
   and is a cheap trigger to switch acquisition or decline to move the cut.
3. Do not expect the linear head to cover this.

## Testing

29 new tests in `tests_lib/sorting/test_sustained_regression.py` pin the discrimination (a
transient #2790 spike must not fire; sub-delta drift must not fire; a planted trend must beat
its own null; AP must not drive detection or classification). Full `tests/sorting` +
`tests_lib/sorting` suite passes; ruff clean.

Report: `docs/experiments/threshold-stability/SUSTAINED_REGRESSION_2825.md`.
Grid outputs: `/exp/sgreenberg/threshold-stability/sr2825/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
