### PR TITLE
Bust the archive index cache on same-tick, same-padded-size rewrites

### DIFF
--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -1023,10 +1023,15 @@ class TestSyncFromSourceFreshness:
         first_load_in_flight = threading.Event()
         release_first_load = threading.Event()
 
+        # Generous waits: a loaded machine can stall the main thread for
+        # seconds, and a wait that expires early would let A finish before B
+        # ever races it -- testing nothing instead of failing.
+        wait_s = 30
+
         def slow_load(field_values):
             if not first_load_in_flight.is_set():
                 first_load_in_flight.set()
-                release_first_load.wait(timeout=5)
+                release_first_load.wait(timeout=wait_s)
             return real_load(field_values)
 
         src.load = slow_load  # type: ignore[assignment]
@@ -1039,13 +1044,15 @@ class TestSyncFromSourceFreshness:
         try:
             t_a = threading.Thread(target=reader, args=("a",))
             t_a.start()
-            assert first_load_in_flight.wait(timeout=5), "first load never started"
+            assert first_load_in_flight.wait(timeout=wait_s), "first load never started"
             t_b = threading.Thread(target=reader, args=("b",))
             t_b.start()
             # Let A's sync complete.
             release_first_load.set()
-            t_a.join(timeout=5)
-            t_b.join(timeout=5)
+            t_a.join(timeout=wait_s)
+            t_b.join(timeout=wait_s)
+            assert not t_a.is_alive(), "reader A never finished"
+            assert not t_b.is_alive(), "reader B never finished"
         finally:
             src.load = real_load  # type: ignore[assignment]
 

--- a/tests_lib/datasets/test_archive_stream.py
+++ b/tests_lib/datasets/test_archive_stream.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import os
 import tarfile
 import threading
 import zipfile
@@ -33,6 +34,14 @@ def _make_tar(tmp_path: Path) -> Path:
             info.size = len(payload)
             tf.addfile(info, io.BytesIO(payload))
     return archive
+
+
+def _make_one_member_tar(path: Path, payload: bytes = MEMBER_A, name: str = "m.bin") -> Path:
+    with tarfile.open(path, "w") as tf:
+        info = tarfile.TarInfo(name)
+        info.size = len(payload)
+        tf.addfile(info, io.BytesIO(payload))
+    return path
 
 
 def _make_zip(tmp_path: Path) -> Path:
@@ -89,19 +98,45 @@ class TestReadMember:
         # Rewrite the archive with a differently-sized member; the cache key
         # folds in size+mtime, so the new index must be picked up.
         new_payload = MEMBER_A + b"EXTRA"
-        with tarfile.open(archive, "w") as tf:
-            info = tarfile.TarInfo("chunk_a.mp4")
-            info.size = len(new_payload)
-            tf.addfile(info, io.BytesIO(new_payload))
+        _make_one_member_tar(archive, new_payload, "chunk_a.mp4")
+        # Stamp a distinct mtime rather than trusting the filesystem's timestamp
+        # resolution: this asserts the cache-key contract, not the clock.
+        bumped = archive.stat().st_mtime_ns + 10**9
+        os.utime(archive, ns=(bumped, bumped))
         assert read_member(archive, "chunk_a.mp4") == new_payload
 
+    def test_index_cache_busts_on_same_tick_rewrite(self, tmp_path):
+        """A rewrite that leaves (size, mtime) untouched must still be noticed.
 
-def _make_one_member_tar(path: Path, payload: bytes = MEMBER_A, name: str = "m.bin") -> Path:
-    with tarfile.open(path, "w") as tf:
-        info = tarfile.TarInfo(name)
-        info.size = len(payload)
-        tf.addfile(info, io.BytesIO(payload))
-    return path
+        tar pads members to 512-byte blocks, so a member that grows by a few
+        bytes can leave the archive's size unchanged; on a filesystem with
+        coarse mtime the rewrite can also land in the same tick as the write we
+        indexed.  Both are forced here so the stat key is *identical* and only
+        the header-block probe can catch the change.
+        """
+        archive = _make_one_member_tar(tmp_path / "shard.tar", MEMBER_A, "chunk_a.mp4")
+        stamp = archive.stat().st_mtime_ns
+        size_before = archive.stat().st_size
+        assert member_size(archive, "chunk_a.mp4") == len(MEMBER_A)
+
+        new_payload = MEMBER_A + b"EXTRA"
+        _make_one_member_tar(archive, new_payload, "chunk_a.mp4")
+        os.utime(archive, ns=(stamp, stamp))  # same mtime tick as the indexed write
+        assert archive.stat().st_size == size_before  # same 512-block padding
+        assert archive.stat().st_mtime_ns == stamp
+
+        assert read_member(archive, "chunk_a.mp4") == new_payload
+
+    def test_settled_index_stops_probing(self, tmp_path):
+        """Past the settle window a hit is served without re-reading the head."""
+        archive = _make_tar(tmp_path)
+        assert member_size(archive, "chunk_a.mp4") == len(MEMBER_A)
+        entry = archive_stream._index_cache[archive_stream._cache_key(archive)]
+        assert not entry.settled
+        # Age the entry past the window; the next lookup settles it for good.
+        entry.first_seen_ns -= archive_stream._SETTLE_NS + 1
+        assert member_size(archive, "chunk_a.mp4") == len(MEMBER_A)
+        assert entry.settled
 
 
 class TestHandlePool:

--- a/vtscore/datasets/archive_stream.py
+++ b/vtscore/datasets/archive_stream.py
@@ -3,9 +3,9 @@
 This is the no-extraction counterpart to :mod:`vtscore.datasets.archive`,
 which extracts a whole archive to :data:`~vtscore.config.DATA_DIR`.  Here we
 serve **one member on demand**: a ``{member_name: info}`` index is built once
-per archive (cached, keyed by path/size/mtime) and a byte range of a single
-member is read by seeking within that member's file object.  So playback of a
-media stored inside a multi-GB tar shard never materialises the member on disk
+per archive (cached, keyed by path/inode/size/mtime) and a byte range of a
+single member is read by seeking within that member's file object.  So playback
+of a media stored inside a multi-GB tar shard never materialises the member on disk
 and, paired with HTTP Range, downloads only the bytes the browser actually
 plays.
 
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import tarfile
 import threading
+import time
 import zipfile
 from collections import OrderedDict
 from pathlib import Path
@@ -49,16 +50,58 @@ class ArchiveMemberError(Exception):
     """Raised when an archive or one of its members cannot be read."""
 
 
-# Process-scoped index cache.  Keyed by (resolved path, size, mtime_ns) so a
-# replaced archive busts the cache; the value is a {member_name: info} map of
-# tarfile.TarInfo / zipfile.ZipInfo objects (metadata only -- never bytes).
-_index_cache: dict[tuple[str, int, int], dict[str, Any]] = {}
-_index_lock = threading.Lock()
-
-
-def _cache_key(path: Path) -> tuple[str, int, int]:
+def _cache_key(path: Path) -> tuple[str, int, int, int]:
     st = path.stat()
-    return (str(path), st.st_size, st.st_mtime_ns)
+    return (str(path), st.st_ino, st.st_size, st.st_mtime_ns)
+
+
+#: How long a cached index stays *unsettled* after it is built, measured on a
+#: monotonic clock (so wall-clock or NFS server skew cannot affect it).
+#:
+#: Filesystems advance ``st_mtime`` only once per tick -- coarse enough on some
+#: (HLTCOE's ``/scratch``, ext3, FAT) that two back-to-back writes share one
+#: ``st_mtime_ns``.  An archive rewritten within one tick of the write we
+#: indexed, to the same 512-block-padded size, therefore keeps an identical
+#: cache key, and we would serve its stale index forever.  So while an entry is
+#: younger than this window we re-verify it on every lookup against the
+#: archive's first header block (cheap: one 512-byte read).  Once the window has
+#: passed, any later rewrite necessarily stamps an mtime the cached key cannot
+#: reproduce, so the stat key alone is authoritative and the probe stops --
+#: steady-state reads pay nothing.
+_SETTLE_NS = 2_000_000_000
+
+#: Bytes of the archive head folded into the freshness probe: exactly one tar
+#: header block (member name, size, checksum) or a zip local file header.
+_PROBE_BYTES = 512
+
+
+class _IndexEntry:
+    """A cached member index plus what we need to re-verify its freshness."""
+
+    __slots__ = ("first_seen_ns", "index", "probe", "settled")
+
+    def __init__(self, index: dict[str, Any], probe: bytes) -> None:
+        self.index = index
+        self.probe = probe
+        self.first_seen_ns = time.monotonic_ns()
+        self.settled = False
+
+
+def _read_probe(path: Path) -> bytes:
+    """Return the archive's first :data:`_PROBE_BYTES` bytes (``b""`` on error)."""
+    try:
+        with path.open("rb") as f:
+            return f.read(_PROBE_BYTES)
+    except OSError:
+        return b""
+
+
+# Process-scoped index cache.  Keyed by (resolved path, inode, size, mtime_ns)
+# so a replaced archive busts the cache; the value is an _IndexEntry wrapping a
+# {member_name: info} map of tarfile.TarInfo / zipfile.ZipInfo objects
+# (metadata only -- never bytes).
+_index_cache: dict[tuple[str, int, int, int], _IndexEntry] = {}
+_index_lock = threading.Lock()
 
 
 #: Upper bound on simultaneously-open archive handles.  Reads seek within a
@@ -110,7 +153,7 @@ class _PooledArchive:
 
 # Process-scoped pool of open archive handles, keyed like ``_index_cache`` and
 # ordered least-recently-used first for eviction.
-_handle_cache: OrderedDict[tuple[str, int, int], _PooledArchive] = OrderedDict()
+_handle_cache: OrderedDict[tuple[str, int, int, int], _PooledArchive] = OrderedDict()
 _handle_lock = threading.Lock()
 
 
@@ -203,16 +246,46 @@ def _build_index(path: Path) -> dict[str, Any]:
         raise ArchiveMemberError(f"Not a readable tar/zip archive: {path} ({exc})") from exc
 
 
+def _invalidate(key: tuple[str, int, int, int]) -> None:
+    """Drop the cached index *and* the pooled handle for *key* (archive changed).
+
+    The two locks are taken one after the other, never nested, and the evicted
+    handle is closed outside both (``close`` waits on its own read lock).
+    """
+    with _index_lock:
+        _index_cache.pop(key, None)
+    with _handle_lock:
+        pooled = _handle_cache.pop(key, None)
+    if pooled is not None:
+        pooled.close()
+
+
 def _index(path: Path) -> dict[str, Any]:
-    """Return the cached member index for *path*, building it on first use."""
+    """Return the cached member index for *path*, building it on first use.
+
+    A hit is trusted outright once the entry has settled (see
+    :data:`_SETTLE_NS`); before that it is re-verified against the archive's
+    first header block, so an archive rewritten within one mtime tick to the
+    same padded size -- which leaves the stat key untouched -- is still noticed.
+    """
     key = _cache_key(path)
     with _index_lock:
-        cached = _index_cache.get(key)
-    if cached is not None:
-        return cached
+        entry = _index_cache.get(key)
+    if entry is not None:
+        if entry.settled:
+            return entry.index
+        if _read_probe(path) == entry.probe:
+            # Past the coarse-mtime window the stat key can no longer be
+            # reproduced by a later rewrite, so stop probing this entry.
+            entry.settled = time.monotonic_ns() - entry.first_seen_ns > _SETTLE_NS
+            return entry.index
+        _invalidate(key)
+    # Probe *before* building so an archive rewritten mid-build leaves a probe
+    # that no longer matches, and the next lookup rebuilds rather than trusting.
+    probe = _read_probe(path)
     index = _build_index(path)
     with _index_lock:
-        _index_cache[key] = index
+        _index_cache[key] = _IndexEntry(index, probe)
     return index
 
 


### PR DESCRIPTION
Closes #2834

Took both calls the issue asked for: fixed the product window **and** made the test independent of the filesystem's clock.

## The window

`_index_cache` was keyed on `(path, st_size, st_mtime_ns)`. tar pads members to 512-byte blocks, so a member that grows by a few bytes can leave the archive's size unchanged — which makes `st_mtime_ns` the only thing that can bust the key. On filesystems with coarse mtime (the Grid's `/scratch`, ext3, FAT) two back-to-back writes share a tick, the key doesn't move, and `read_member` serves the stale index silently and forever.

## The fix

A cached entry is now re-verified on every lookup against the archive's first 512 bytes — one tar header block (member name, size, checksum) or a zip local file header — until the entry **settles**. An entry settles once it is older than 2s on a `time.monotonic_ns()` clock: past that window any later rewrite necessarily stamps an mtime the cached key cannot reproduce, so the stat key alone is authoritative and the probe stops. Steady-state reads on a stable shard corpus therefore pay nothing extra; only the first couple of seconds after an index is built cost one 512-byte read per lookup.

Using a monotonic clock rather than comparing `st_mtime` against wall time is deliberate: NFS/server clock skew can't push an archive into a permanent "always probe" state, and can't shorten the window either.

Two smaller hardenings that fall out of the same key:

- `st_ino` joins the cache key. Without it an atomic replace (rename over the path) with a matching size and same-tick mtime would reuse the pooled fd pointing at the *old, unlinked* inode — genuinely wrong bytes, not just a stale index.
- Invalidating a key now also drops and closes that key's pooled archive handle, so the handle pool can't outlive the index it was opened alongside. The two locks are taken sequentially, never nested, and the evicted handle is closed outside both.

## Tests

- `test_index_cache_busts_on_mtime` stamps a distinct mtime with `os.utime` after the rewrite, so it asserts the cache-key contract instead of the filesystem's timestamp resolution.
- `test_index_cache_busts_on_same_tick_rewrite` (new) forces the exact bad case: a one-member tar rewritten 5 bytes longer (same 512-block padding → same size) with the original mtime stamped back, then asserts both that the stat key really is unchanged and that the fresh bytes are served. Verified it reads `STALE` with the probe stubbed out and `fresh` with it in place.
- `test_settled_index_stops_probing` (new) covers the settle transition.

Also widened the thread waits in `tests/io/test_sync_sources.py::TestSyncFromSourceFreshness::test_concurrent_readers_observe_post_sync_cache` (5s → 30s, plus `is_alive` assertions on the joins) — the issue flagged it in the same load-sensitivity class. Its 5s `release_first_load.wait` was the risky one: expiring early lets thread A finish before B ever races it, so the test would silently stop testing the race rather than fail.

Full suite green: 7510 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_0176ghiA64pjpPzuCXw1RFA5)_