### PR TITLE
Add umap-learn to the standalone Docker requirements files

### DIFF
--- a/docker/Dockerfile.labbench
+++ b/docker/Dockerfile.labbench
@@ -104,7 +104,7 @@ RUN if [ -n "$VTSEARCH_VERSION" ]; then echo "$VTSEARCH_VERSION" > vtsearch/_ver
 #
 # * ``hidden_plugins`` drops the Aud2Img (spectrogram) converter and the
 #   Downloaded Demo Media importer from every picker / listing API
-#   response. The Aud2Img converter is useless without librosa/matplotlib
+#   response. The Aud2Img converter is useless without librosa
 #   (omitted from ``requirements/labbench.txt``) and the demo importer
 #   needs outbound network access this container doesn't expect to have.
 #   Hidden plugins remain importable by name for any backend code that

--- a/requirements/image-embedders-gpu.txt
+++ b/requirements/image-embedders-gpu.txt
@@ -26,6 +26,14 @@ pandas
 matplotlib
 scipy
 
+# ── VTSBrowse projection ─────────────────────────────────────────────
+# The Browse canvas fits UMAP on the embedding matrix (vtscore.gpu_backends
+# .umap_fit_transform, imported lazily). Needed by every deployment
+# regardless of media type: nothing else pulls umap-learn in transitively,
+# so omitting it leaves Browse broken at runtime rather than at build time.
+# This image ships no cuML, so the CPU umap-learn path is the only one.
+umap-learn
+
 # ── PyTorch (GPU; CUDA version set via --extra-index-url at install time)
 torch>=2.0.0
 

--- a/requirements/image-embedders.txt
+++ b/requirements/image-embedders.txt
@@ -34,6 +34,13 @@ pandas
 matplotlib
 scipy
 
+# ── VTSBrowse projection ─────────────────────────────────────────────
+# The Browse canvas fits UMAP on the embedding matrix (vtscore.gpu_backends
+# .umap_fit_transform, imported lazily). Needed by every deployment
+# regardless of media type: nothing else pulls umap-learn in transitively,
+# so omitting it leaves Browse broken at runtime rather than at build time.
+umap-learn
+
 # ── PyTorch (CPU) ────────────────────────────────────────────────────
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.0.0

--- a/requirements/labbench.txt
+++ b/requirements/labbench.txt
@@ -24,6 +24,13 @@ pandas
 matplotlib
 scipy
 
+# ── VTSBrowse projection ─────────────────────────────────────────────
+# The Browse canvas fits UMAP on the embedding matrix (vtscore.gpu_backends
+# .umap_fit_transform, imported lazily). Needed by every deployment
+# regardless of media type: nothing else pulls umap-learn in transitively,
+# so omitting it leaves Browse broken at runtime rather than at build time.
+umap-learn
+
 # ── PyTorch (CPU) ────────────────────────────────────────────────────
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.0.0

--- a/tests/core/test_requirements.py
+++ b/tests/core/test_requirements.py
@@ -15,8 +15,17 @@ import pytest
 
 _REPO_ROOT = Path(__file__).parent.parent.parent
 
-# Packages that every VTSearch deployment requires regardless of variant.
-# These are imported at app startup before any plugin-specific code runs.
+# Packages that every VTSearch deployment requires regardless of variant:
+# the web/app framework, the numeric + model stack every embedder and the
+# ranker sit on, and umap-learn for the Browse projection. A slim file may
+# drop media-type-specific deps (librosa, PyMuPDF, ultralytics, ...) but
+# never these.
+#
+# Only list packages nothing else pulls in transitively. threadpoolctl and
+# huggingface_hub are imported directly by vtscore but arrive with
+# scikit-learn / transformers, so a slim file that omits them still works;
+# umap-learn has no such carrier, which is how issue #2843 (LabBench image
+# built without umap-learn) happened.
 _ALWAYS_REQUIRED: frozenset[str] = frozenset(
     {
         "flask",
@@ -24,6 +33,16 @@ _ALWAYS_REQUIRED: frozenset[str] = frozenset(
         "marshmallow",
         "pydantic",
         "werkzeug",
+        "gunicorn",
+        "numpy",
+        "requests",
+        "tqdm",
+        "scikit-learn",
+        "torch",
+        # Browse canvas: vtscore.gpu_backends.umap_fit_transform falls back to
+        # the CPU umap-learn reducer whenever cuML is absent (always, in the
+        # slim images).
+        "umap-learn",
     }
 )
 
@@ -58,6 +77,7 @@ def test_slim_requirements_include_core_deps(req_file: Path) -> None:
     declared = _parse_packages(req_file)
     missing = {_normalise(p) for p in _ALWAYS_REQUIRED} - declared
     assert not missing, (
-        f"{req_file.name} is missing core framework deps: {sorted(missing)}\n"
-        "Add them to the '── Core framework ──' section of that file."
+        f"{req_file.name} is missing deps every deployment needs: {sorted(missing)}\n"
+        "Add them to that file (core framework / numeric stack entries near the top; "
+        "umap-learn under the '── VTSBrowse projection ──' heading)."
     )


### PR DESCRIPTION
Closes #2843

## The bug

`requirements/labbench.txt`, `requirements/image-embedders.txt`, and `requirements/image-embedders-gpu.txt` are curated flat lists that deliberately do **not** forward to `pyproject.toml` via `-e .`. All three omitted `umap-learn`, which `pyproject.toml` has declared since Browse landed.

Nothing pulls `umap-learn` in transitively, so those images build clean and then fail at runtime the first time a user opens the Browse canvas: `vtscore.gpu_backends.umap_fit_transform` imports `umap` lazily, and none of these images ship cuML, so the CPU reducer is the only path.

## The fix

- Add `umap-learn` to all three standalone requirements files, under a new `── VTSBrowse projection ──` heading with a note on why it can't be dropped.
- Widen `tests/core/test_requirements.py` — which already existed to catch exactly this drift — from the five framework packages to everything a deployment needs regardless of media type: the web stack plus `numpy`, `requests`, `tqdm`, `scikit-learn`, `torch`, `umap-learn`. Media-type-specific deps (`librosa`, `PyMuPDF`, `ultralytics`, …) stay omissible; these don't. The list intentionally excludes `threadpoolctl` and `huggingface_hub`: vtscore imports both directly, but they arrive with `scikit-learn` / `transformers`, so a slim file that omits them still works. `umap-learn` has no such carrier, which is how this slipped through.
- Drop a stale mention of `matplotlib` from a `Dockerfile.labbench` comment — it claimed matplotlib was omitted from `labbench.txt`, but only `librosa` is.

## Testing

`./run-tests.sh` — all 7518 tests pass. Verified the widened test fails on the pre-fix files (each slim file reported `umap-learn` missing) and passes after.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTNXBHayqpUeLSCAhQFbgD)_