### PR TITLE
Add anchored-mixture threshold estimators and paired eval arms (#2852)

### DIFF
--- a/scripts/experiments/calibration/README.md
+++ b/scripts/experiments/calibration/README.md
@@ -51,6 +51,7 @@ cd /exp/$USER/projects/vts-calib/scripts/experiments/calibration
 bash launch_all.sh          # reuse-symlink -> prepare (GPU) -> cells -> analyze
 bash launch_safe.sh         # the #2799 safe-threshold sizing, analyze_safe.py
 bash launch_cut.sh          # the #2836 cut-rule study: theory bench + analyze_cut.py
+bash launch_anchored.sh     # the #2852 anchored-mixture study, analyze_anchored.py
 ```
 
 Both study launchers are thin wrappers over `launch_all.sh` that flip the
@@ -86,3 +87,29 @@ every step then emits one extra row per safe-threshold GMM variant
 `analyze.py`. Results land under `/exp/$USER/calibration-safe`, reusing the
 shared Max-Patch pickles/crops in place. Design and pre-registered decision
 rules: `docs/plans/safe-threshold-gmm-experiment.md`.
+
+## Anchored-mixture study (issue #2852)
+
+```bash
+cd /exp/$USER/projects/vts-calib/scripts/experiments/calibration
+bash launch_anchored.sh  # safe+anchored ON, VG only, 300 votes (deep regime), 4 seeds
+```
+
+`launch_anchored.sh` additionally sets `CALIB_ANCHORED=1`: every step then
+emits one row per anchored-mixture arm — the label-anchored family
+(`anchored_w{W}_{rule}`: anchored EM on the final model's haystack scores with
+the voted items' scores clamped to their labelled component), the fold-anchored
+"cross-LabeledGMM" family (`fold_anchored_w{W}_{rule}_{combine}`: per-fold
+anchored fits on honest held-out anchors, rank-transferred back to the final
+scale), and the `rank_transfer` attribution arm — all step-paired against the
+`pooled_mid` (shipped blend) and `xcal_only` controls. The sweep grid is
+`CALIB_ANCHORED_WEIGHTS` × `CALIB_ANCHORED_RULES` ×
+`CALIB_ANCHORED_FOLD_COMBINES` (see `experiment_config.py`). Analyzer:
+`analyze_anchored.py` (H1–H4 verdicts + paired tables); self-test:
+`python selftest_analyze_anchored.py`. Results land under
+`/exp/$USER/calibration-anchored`. Design and pre-registered decision rules:
+`docs/plans/population-anchored-calibration.md`.
+
+Cost note: the fold-anchored arms score the sim set once per calibration fold
+per step (`calibrate_count=2` → two extra scoring passes); disable them with
+`CALIB_ANCHORED_FOLD_ARMS=0` for a cheap label-anchored-only run.

--- a/scripts/experiments/calibration/analyze_anchored.py
+++ b/scripts/experiments/calibration/analyze_anchored.py
@@ -1,0 +1,278 @@
+"""Stage 2 (anchored-mixture study, #2852): aggregate the anchored-arm cells.
+
+Consumes the ``results/cells/task_*.csv`` files from a run with
+``CALIB_SAFE_THRESHOLDS=1 CALIB_ANCHORED=1``, where every step emits - besides
+the base blended row and the #2799 variant rows - one row per anchored arm:
+``anchored_w{W}_{rule}`` (label-anchored mixture on the final model's haystack
+scores), ``fold_anchored_w{W}_{rule}_{combine}`` (the cross-LabeledGMM repair:
+per-fold anchored fits on honest held-out anchors, rank-transferred back), and
+``rank_transfer`` (the scale-transfer-only attribution arm).  Controls ride in
+the same frame: ``xcal_only`` (pure cross-cal) and ``pooled_mid`` (the shipped
+safe-blend).
+
+Computes the pre-registered deliverables of
+``docs/plans/population-anchored-calibration.md``:
+
+* Per-window (the plan's {20,50,100,200,300}-vote checkpoints) mean cost /
+  regret / FPR / FNR per arm, and **paired** contrasts vs ``xcal_only`` (H1)
+  and vs ``pooled_mid`` (H2) on identical (arm, category, seed, t) steps.
+* Step-to-step threshold delta per arm (H3 - stability comes along free).
+* FNR vs the conformal budget (0.25 at inclusion 0) per window (H4).
+* Estimator-path tallies from ``threshold_provenance`` (how often the anchored
+  EM ran vs fell back, and the fold-anchored per-fold tallies).
+
+Writes ``results/summary.json``, ``results/agg/*.csv``, and a
+``results/REPORT.md`` draft.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import common
+
+common.setup_env()
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+import experiment_config as cfg  # noqa: E402
+
+#: Conformal FN budget at inclusion 0 - the H4 envelope.
+FN_BUDGET = 0.25
+
+#: Arms whose H1/H2 verdicts the decision rules read (regexes over
+#: ``gmm_variant``).  ``pooled_mid`` and ``xcal_only`` are the controls.
+FUSION_ARM_RE = re.compile(r"^(anchored_|fold_anchored_|rank_transfer$)")
+
+#: The deep-regime windows the plan keys its decisions on (votes > 100).
+DEEP_WINDOWS_MIN = 100
+
+
+def _md(df: pd.DataFrame) -> str:
+    """Markdown table when ``tabulate`` is available, else a fixed-width dump."""
+    try:
+        return df.to_markdown(index=False, floatfmt=".4f")
+    except Exception:  # noqa: BLE001 - tabulate not installed
+        return "```\n" + df.to_string(index=False) + "\n```"
+
+
+def load_cells(cells_dir: Path) -> pd.DataFrame:
+    files = sorted(p for p in cells_dir.glob("task_*.csv") if "__sweep" not in p.name and "__cutdiag" not in p.name)
+    if not files:
+        return pd.DataFrame()
+    df = pd.concat([pd.read_csv(p) for p in files], ignore_index=True)
+    df["gmm_variant"] = df["gmm_variant"].fillna("")
+    df["arm"] = df["dataset"] + "/" + df["embedder"] + "/" + df["style"]
+    df["n_votes"] = df["n_good"] + df["n_bad"]
+    common.log(f"loaded {len(df)} rows from {len(files)} cells")
+    return df
+
+
+def assign_window(df: pd.DataFrame, checkpoints: list[int]) -> pd.DataFrame:
+    """Label each row with its checkpoint window ``(prev, c]`` -> ``"le_{c}"``."""
+    edges = [1, *sorted(checkpoints)]
+    labels = [f"le_{c}" for c in sorted(checkpoints)]
+    df = df.copy()
+    df["window"] = pd.cut(df["n_votes"], bins=edges, labels=labels)
+    df["window_hi"] = pd.cut(df["n_votes"], bins=edges, labels=sorted(checkpoints)).astype("Int64")
+    return df[df["window"].notna()]
+
+
+def variant_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """The comparison arms: fusion variants + the two controls."""
+    v = df[df["gmm_variant"] != ""].copy()
+    keep = v["gmm_variant"].str.match(FUSION_ARM_RE) | v["gmm_variant"].isin(["xcal_only", "pooled_mid"])
+    return v[keep]
+
+
+def window_table(v: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
+    g = (
+        v.groupby(["arm", "gmm_variant", "window"], observed=True)
+        .agg(
+            cost=("cost", "mean"),
+            regret=("regret", "mean"),
+            fpr=("fpr", "mean"),
+            fnr=("fnr", "mean"),
+            threshold=("threshold", "mean"),
+            oracle_threshold=("oracle_threshold", "mean"),
+            degenerate_rate=("degenerate", "mean"),
+            n=("cost", "size"),
+        )
+        .reset_index()
+    )
+    g.to_csv(agg_dir / "anchored_window_table.csv", index=False)
+    return g
+
+
+def paired_contrasts(v: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
+    """Per-window mean paired difference of each fusion arm vs each control.
+
+    Pairing unit: identical (arm, category, seed, t) steps - every variant of a
+    step re-cuts the same model against the same test scores, so the difference
+    isolates the threshold rule.
+    """
+    keys = ["arm", "category", "seed", "t", "window"]
+    rows = []
+    fusion_names = sorted(n for n in v["gmm_variant"].unique() if FUSION_ARM_RE.match(n))
+    for control in ("xcal_only", "pooled_mid"):
+        c = v[v["gmm_variant"] == control].set_index(keys)[["cost", "regret", "fnr"]]
+        for name in fusion_names:
+            a = v[v["gmm_variant"] == name].set_index(keys)[["cost", "regret", "fnr"]]
+            j = a.join(c, how="inner", lsuffix="_a", rsuffix="_c")
+            if j.empty:
+                continue
+            j = j.reset_index()
+            for window, w in j.groupby("window", observed=True):
+                rows.append(
+                    {
+                        "variant": name,
+                        "control": control,
+                        "window": window,
+                        "n_steps": int(len(w)),
+                        "d_cost": float((w["cost_a"] - w["cost_c"]).mean()),
+                        "d_regret": float((w["regret_a"] - w["regret_c"]).mean()),
+                        "d_fnr": float((w["fnr_a"] - w["fnr_c"]).mean()),
+                        # Sign test share: fraction of steps the fusion arm wins.
+                        "win_rate_cost": float((w["cost_a"] < w["cost_c"]).mean()),
+                    }
+                )
+    out = pd.DataFrame(rows)
+    out.to_csv(agg_dir / "anchored_paired_contrasts.csv", index=False)
+    return out
+
+
+def stability_table(v: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
+    """H3: per-arm step-to-step threshold delta, past the safe-blend ramp."""
+    keys = ["arm", "category", "seed", "gmm_variant"]
+    w = v[v["n_votes"] > 20].sort_values([*keys, "t"])
+    w = w.assign(d_thr=w.groupby(keys, observed=True)["threshold"].diff().abs())
+    g = (
+        w.dropna(subset=["d_thr"])
+        .groupby("gmm_variant", observed=True)
+        .agg(mean_abs_dthr=("d_thr", "mean"), sd_dthr=("d_thr", "std"), n=("d_thr", "size"))
+        .reset_index()
+    )
+    g.to_csv(agg_dir / "anchored_stability.csv", index=False)
+    return g
+
+
+def provenance_table(v: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
+    """Which estimator path each arm actually took, per window."""
+    g = (
+        v[v["gmm_variant"].str.match(FUSION_ARM_RE)]
+        .groupby(["gmm_variant", "window", "threshold_provenance"], observed=True)
+        .size()
+        .reset_index()
+        .rename(columns={0: "n"})
+    )
+    g.to_csv(agg_dir / "anchored_provenance.csv", index=False)
+    return g
+
+
+def hypothesis_verdicts(contrasts: pd.DataFrame, windows: pd.DataFrame, stability: pd.DataFrame) -> dict:
+    """The plan's H1-H4, mechanically evaluated (the report still gets read)."""
+    deep = contrasts[contrasts["window"].astype(str).str.replace("le_", "").astype(int) >= DEEP_WINDOWS_MIN]
+    out: dict = {}
+
+    # H1: at 100-300 votes at least one fusion arm beats pure x-cal on regret.
+    h1 = deep[(deep["control"] == "xcal_only")]
+    h1_best = h1.groupby("variant")["d_regret"].mean().sort_values() if not h1.empty else pd.Series(dtype=float)
+    out["h1_deep_regret_vs_xcal"] = {k: float(v_) for k, v_ in h1_best.items()}
+    out["h1_supported"] = bool((h1_best < 0).any()) if not h1_best.empty else None
+    out["h1_best_arm"] = str(h1_best.index[0]) if not h1_best.empty else None
+
+    # Attribution: rank-transfer absorbing the win names deficit 2; an anchored
+    # arm winning where rank-transfer doesn't names deficit 1; fold_anchored
+    # beating anchored names the train-anchor bias.
+    if not h1_best.empty:
+        rt = h1_best.get("rank_transfer", np.nan)
+        anch = h1_best[h1_best.index.str.startswith("anchored_")].min() if len(h1_best) else np.nan
+        fold = h1_best[h1_best.index.str.startswith("fold_anchored_")].min() if len(h1_best) else np.nan
+        out["h1_attribution"] = {
+            "rank_transfer_d_regret": None if pd.isna(rt) else float(rt),
+            "best_anchored_d_regret": None if pd.isna(anch) else float(anch),
+            "best_fold_anchored_d_regret": None if pd.isna(fold) else float(fold),
+            "fold_beats_label_anchored": None if (pd.isna(fold) or pd.isna(anch)) else bool(fold < anch),
+        }
+
+    # H2: the winning fusion arm beats the shipped blend at matched steps.
+    if out.get("h1_best_arm"):
+        h2 = deep[(deep["control"] == "pooled_mid") & (deep["variant"] == out["h1_best_arm"])]
+        out["h2_supported"] = bool((h2["d_regret"].mean() < 0)) if not h2.empty else None
+
+    # H3: the winning arm cuts step-to-step threshold delta vs pure x-cal.
+    if out.get("h1_best_arm") and not stability.empty:
+        s = stability.set_index("gmm_variant")["mean_abs_dthr"]
+        if out["h1_best_arm"] in s.index and "xcal_only" in s.index:
+            out["h3_supported"] = bool(s[out["h1_best_arm"]] < s["xcal_only"])
+            out["h3_mean_abs_dthr"] = {"winner": float(s[out["h1_best_arm"]]), "xcal_only": float(s["xcal_only"])}
+
+    # H4: winner's FNR stays within the conformal budget at every checkpoint.
+    if out.get("h1_best_arm") and not windows.empty:
+        w = windows[windows["gmm_variant"] == out["h1_best_arm"]]
+        out["h4_max_window_fnr"] = float(w["fnr"].max()) if not w.empty else None
+        out["h4_supported"] = bool(w["fnr"].max() <= FN_BUDGET) if not w.empty else None
+
+    return out
+
+
+def write_report(
+    results: Path, windows: pd.DataFrame, contrasts: pd.DataFrame, stability: pd.DataFrame, verdicts: dict
+) -> None:
+    lines = [
+        "# Anchored-mixture calibration study (#2852) - draft report",
+        "",
+        "Auto-generated by `analyze_anchored.py`; numbers are means over paired",
+        "within-step variants (identical models, votes, and test scores per step).",
+        "Design + decision rules: `docs/plans/population-anchored-calibration.md`.",
+        "",
+        "## Hypothesis verdicts (mechanical; read the tables before believing them)",
+        "",
+        "```json",
+        json.dumps(verdicts, indent=2),
+        "```",
+        "",
+        "## Per-window means",
+        "",
+        _md(windows),
+        "",
+        "## Paired contrasts (fusion - control)",
+        "",
+        _md(contrasts),
+        "",
+        "## Threshold stability (|delta threshold| per step, votes > 20)",
+        "",
+        _md(stability),
+        "",
+    ]
+    (results / "REPORT.md").write_text("\n".join(lines))
+
+
+def main() -> int:
+    results = common.RESULTS
+    agg = results / "agg"
+    agg.mkdir(parents=True, exist_ok=True)
+    df = load_cells(results / "cells")
+    if df.empty:
+        common.log("no cells found; nothing to analyze")
+        return 1
+    df = assign_window(df, cfg.ANCHORED_CHECKPOINTS)
+    v = variant_frame(df)
+
+    windows = window_table(v, agg)
+    contrasts = paired_contrasts(v, agg)
+    stability = stability_table(v, agg)
+    provenance_table(v, agg)
+    verdicts = hypothesis_verdicts(contrasts, windows, stability)
+
+    (results / "summary.json").write_text(json.dumps(verdicts, indent=2))
+    write_report(results, windows, contrasts, stability, verdicts)
+    common.log(f"wrote {results / 'summary.json'} and {results / 'REPORT.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -65,6 +65,31 @@ CALIBRATION_FRACTION = 0.5
 SAFE_THRESHOLDS = os.environ.get("CALIB_SAFE_THRESHOLDS", "0") == "1"
 MEDIA_TYPE = "image"
 
+#: The #2852 anchored-mixture study (design + pre-registered decision rules:
+#: ``docs/plans/population-anchored-calibration.md``) flips this on via
+#: ``CALIB_ANCHORED=1``; every step then additionally emits the label-anchored,
+#: fold-anchored ("cross-LabeledGMM"), and rank-transfer arm rows.  Requires
+#: ``CALIB_SAFE_THRESHOLDS=1`` (the anchored arms ride the variant-row path).
+ANCHORED = os.environ.get("CALIB_ANCHORED", "0") == "1"
+#: Anchor-weight grid: each labelled score counts as this many haystack scores
+#: in the anchored EM.  Log-spaced from "one label = one haystack point" to
+#: "labels dominate the fit" - the fusion knob the sweep exists to place.
+ANCHORED_WEIGHTS = [float(w) for w in os.environ.get("CALIB_ANCHORED_WEIGHTS", "1,3,10,30,100").split(",") if w]
+#: Cut rules re-cutting each anchored fit: production midpoint, and the
+#: rate-optimal crossing (well-founded on an anchored fit, where the
+#: components *are* the classes - the #2836 identification term is gone).
+ANCHORED_RULES = [r for r in os.environ.get("CALIB_ANCHORED_RULES", "mid,rate").split(",") if r]
+#: Fold-anchored + rank-transfer arms cost one sim-set scoring pass per
+#: calibration fold per step; disable to keep only the cheap final-model arms.
+ANCHORED_FOLD_ARMS = os.environ.get("CALIB_ANCHORED_FOLD_ARMS", "1") == "1"
+#: How the fold arms combine per-fold cuts in quantile space.
+ANCHORED_FOLD_COMBINES = [c for c in os.environ.get("CALIB_ANCHORED_FOLD_COMBINES", "qmean,qmedian").split(",") if c]
+#: Vote-count checkpoints the anchored analyzer windows on (the plan's deep
+#: regime; each window is (previous checkpoint, checkpoint]).
+ANCHORED_CHECKPOINTS = [
+    int(c) for c in os.environ.get("CALIB_ANCHORED_CHECKPOINTS", "20,50,100,200,300").split(",") if c
+]
+
 #: Which torch head each step trains (``vtscore.eval.voting_iterations.HEADS``).
 #: #2781 ran the harness's historical auto-sized MLP; the #2799 safe-threshold
 #: study runs ``linear`` — the head the live detector actually trains since

--- a/scripts/experiments/calibration/launch_anchored.sh
+++ b/scripts/experiments/calibration/launch_anchored.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Anchored-mixture calibration study (#2852) on the HLTCOE Grid.
+#
+# Thin wrapper over launch_all.sh that flips the pre-registered knobs for the
+# population-anchored-calibration experiment (design + decision rules:
+# docs/plans/population-anchored-calibration.md): safe_thresholds ON (the
+# anchored arms ride the variant-row path and need the shipped blend +
+# xcal_only controls emitted alongside), CALIB_ANCHORED=1, the production
+# linear head, Visual Genome region voting with the production max_patch arm
+# plus a whole_image single-vector control, and 300 voting steps - the deep
+# regime where the ongoing owner-side experiment found the naive GMM still
+# competitive with x-cal.  Results land under /exp/$USER/calibration-anchored
+# so the #2781/#2799 outputs are untouched; the shared Max-Patch pickles/crops
+# are reused in place.
+#
+# The sweep grid (anchor weights x cut rules x fold combines) comes from
+# CALIB_ANCHORED_WEIGHTS / CALIB_ANCHORED_RULES / CALIB_ANCHORED_FOLD_COMBINES
+# (see experiment_config.py for the registered defaults).
+#
+# Usage: bash launch_anchored.sh
+set -uo pipefail
+
+export CALIB_EXP="${CALIB_EXP:-/exp/$USER/calibration-anchored}"
+export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
+
+export CALIB_SAFE_THRESHOLDS=1
+export CALIB_ANCHORED=1
+export CALIB_ANALYZE=analyze_anchored.py
+# The head the live detector ships since #2790/#2809 - the estimator is only
+# worth measuring on the model users actually get.
+export CALIB_HEAD="${CALIB_HEAD:-linear}"
+
+# Visual Genome region voting; production patch arm + single-vector control.
+export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m}"
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
+# No raw-patch tree arm -> nothing to re-pool.
+export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"
+
+# The deep-vote regime is the object of study: checkpoints to 300 votes, so
+# every window of the plan's {20,50,100,200,300} grid is populated.
+export CALIB_MAX_STEPS="${CALIB_MAX_STEPS:-300}"
+export CALIB_N_SEEDS="${CALIB_N_SEEDS:-4}"
+
+# 300-step trajectories + one sim-set scoring pass per calibration fold per
+# step (the fold-anchored arms) -> long cells.
+export CALIB_TIME="${CALIB_TIME:-8:00:00}"
+
+exec bash "$(dirname "$0")/launch_all.sh"

--- a/scripts/experiments/calibration/run_cells.py
+++ b/scripts/experiments/calibration/run_cells.py
@@ -135,6 +135,11 @@ def main(argv: list[str] | None = None) -> int:
             inclusion_sweep_ks=cfg.INCLUSION_SWEEP_KS,
             sweep_sink=sweep_local,
             cut_diag_sink=cutdiag_local,
+            anchored_thresholds=cfg.ANCHORED,
+            anchored_weights=cfg.ANCHORED_WEIGHTS,
+            anchored_rules=cfg.ANCHORED_RULES,
+            anchored_fold_arms=cfg.ANCHORED_FOLD_ARMS,
+            anchored_fold_combines=cfg.ANCHORED_FOLD_COMBINES,
         )
         for r in rows:
             r["embedder"] = emb

--- a/scripts/experiments/calibration/selftest_analyze_anchored.py
+++ b/scripts/experiments/calibration/selftest_analyze_anchored.py
@@ -1,0 +1,155 @@
+"""Self-test for :mod:`analyze_anchored` on fabricated cells (no cluster data).
+
+Plants a known deep-regime ordering - ``fold_anchored`` best, ``anchored`` next,
+``rank_transfer`` a small win, all null below 50 votes - plus a stability gap
+and an in-budget FNR, then checks the analyzer's mechanical H1-H4 verdicts
+recover exactly that: right winner, right attribution (fold beats
+label-anchored), right sign in every window, H3 from the threshold jitter, H4
+from the FNR ceiling.  A sign error here would otherwise surface only after an
+overnight GRID run.
+
+Usage::
+
+    python selftest_analyze_anchored.py     # exits non-zero on failure
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+CATEGORIES = ["cat_a", "cat_b", "cat_c"]
+SEEDS = [0, 1]
+MAX_T = 300
+#: Deep-regime (votes >= 51, i.e. windows le_100/le_200/le_300) regret edge vs
+#: xcal_only, per arm.  fold_anchored planted best; below 51 votes all null.
+DEEP_EDGE = {
+    "anchored_w10_mid": -0.02,
+    "fold_anchored_w10_mid_qmean": -0.04,
+    "rank_transfer": -0.01,
+    "pooled_mid": 0.0,
+    "xcal_only": 0.0,
+}
+#: Step-to-step threshold jitter scale per arm (H3: the winner must be calmer).
+JITTER = {
+    "anchored_w10_mid": 0.01,
+    "fold_anchored_w10_mid_qmean": 0.005,
+    "rank_transfer": 0.01,
+    "pooled_mid": 0.03,
+    "xcal_only": 0.05,
+}
+
+
+def _fabricate(results: Path, rng: np.random.Generator) -> None:
+    cells = results / "cells"
+    cells.mkdir(parents=True, exist_ok=True)
+    idx = 0
+    for cat in CATEGORIES:
+        for seed in SEEDS:
+            rows = []
+            walk = {name: 0.5 for name in DEEP_EDGE}
+            for t in range(2, MAX_T + 1):
+                n_votes = t
+                base_regret = 0.10 + 0.002 * rng.standard_normal()
+                base = {
+                    "seed": seed,
+                    "dataset": "visual_genome_m",
+                    "category": cat,
+                    "strategy": "autopilot",
+                    "trainer": "mlp",
+                    "head": "linear",
+                    "style": "max_patch",
+                    "prevalence_arm": "natural",
+                    "realized_prevalence": 0.05,
+                    "t": t,
+                    "n_good": n_votes // 2,
+                    "n_bad": n_votes - n_votes // 2,
+                    "phase": "hard",
+                    "app_trained": 1,
+                    "pool_variant": "max",
+                    "oracle_threshold": 0.5,
+                    "degenerate": 0,
+                    "auroc": 0.9,
+                    "average_precision": 0.5,
+                    "embedder": "dinov3_patch",
+                }
+                # Base blended row (gmm_variant "") - the analyzer must ignore it.
+                rows.append(
+                    {
+                        **base,
+                        "gmm_variant": "",
+                        "threshold": 0.5,
+                        "cost": 0.99,
+                        "regret": 0.99,
+                        "fpr": 0.5,
+                        "fnr": 0.5,
+                        "threshold_provenance": "gmm_blend",
+                    }
+                )
+                for name, edge in DEEP_EDGE.items():
+                    effect = edge if n_votes >= 51 else 0.0
+                    walk[name] += JITTER[name] * rng.standard_normal()
+                    regret = base_regret + effect
+                    rows.append(
+                        {
+                            **base,
+                            "gmm_variant": name,
+                            "threshold": walk[name],
+                            "cost": 0.2 + regret,
+                            "regret": regret,
+                            "fpr": 0.05,
+                            "fnr": 0.12 + effect,  # well inside the 0.25 budget
+                            "threshold_provenance": "anchored" if name.startswith("anchored") else name,
+                        }
+                    )
+            pd.DataFrame(rows).to_csv(cells / f"task_{idx:04d}.csv", index=False)
+            idx += 1
+
+
+def main() -> int:
+    rng = np.random.default_rng(0)
+    with tempfile.TemporaryDirectory() as tmp:
+        results = Path(tmp) / "results"
+        _fabricate(results, rng)
+
+        os.environ["CALIB_EXP"] = tmp
+        os.environ["CALIB_RESULTS"] = str(results)
+        sys.path.insert(0, str(Path(__file__).parent))
+
+        import analyze_anchored  # noqa: PLC0415
+
+        rc = analyze_anchored.main()
+        assert rc == 0, f"analyze_anchored returned {rc}"
+
+        verdicts = json.loads((results / "summary.json").read_text())
+        assert verdicts["h1_supported"] is True, verdicts
+        assert verdicts["h1_best_arm"] == "fold_anchored_w10_mid_qmean", verdicts
+        att = verdicts["h1_attribution"]
+        assert att["fold_beats_label_anchored"] is True, att
+        assert abs(att["best_fold_anchored_d_regret"] - (-0.04)) < 0.005, att
+        assert abs(att["rank_transfer_d_regret"] - (-0.01)) < 0.005, att
+        assert verdicts["h2_supported"] is True, verdicts  # also beats the shipped blend
+        assert verdicts["h3_supported"] is True, verdicts  # calmer than xcal_only
+        assert verdicts["h4_supported"] is True, verdicts  # FNR inside the budget
+
+        # The shallow windows must not leak the planted deep effect.
+        contrasts = pd.read_csv(results / "agg" / "anchored_paired_contrasts.csv")
+        shallow = contrasts[
+            (contrasts["window"].isin(["le_20", "le_50"]))
+            & (contrasts["control"] == "xcal_only")
+            & (contrasts["variant"] == "fold_anchored_w10_mid_qmean")
+        ]
+        assert not shallow.empty and shallow["d_regret"].abs().max() < 0.005, shallow
+
+    print("selftest_analyze_anchored: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_lib/detectors/test_anchored_variant_rows.py
+++ b/tests_lib/detectors/test_anchored_variant_rows.py
@@ -1,0 +1,123 @@
+"""Tests for the anchored-mixture eval variant rows (issue #2852).
+
+With ``safe_thresholds=True``, ``emit_calibration_metrics=True``, a style, and
+``anchored_thresholds=True`` the harness emits one extra metric row per
+anchored arm at every trainable step: the label-anchored family
+(``anchored_w{W}_{rule}``), the fold-anchored "cross-LabeledGMM" family
+(``fold_anchored_w{W}_{rule}_{combine}``), and the ``rank_transfer``
+attribution arm.  The load-bearing invariants: the rows are step-paired with
+the existing ``pooled_mid`` / ``xcal_only`` controls (same test scores, same
+columns), the anchored thresholds are raw (no blend), the estimator path taken
+is surfaced in ``threshold_provenance``, and everything is deterministic.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.eval.voting_iterations import _CALIBRATION_COLUMNS, simulate_voting_iterations
+
+# Reuse the synthetic planted-patch dataset builders from the Max-Patch tests.
+from .test_max_patch_style import _planted_dataset
+
+_ANCHORED = "anchored_w10_mid"
+_FOLD = "fold_anchored_w10_mid_qmean"
+_RANK = "rank_transfer"
+
+
+def _run(seed=0, max_steps=12, fold_arms=True):
+    medias, _ = _planted_dataset(n_per_cat=40, seed=seed)
+    return simulate_voting_iterations(
+        medias,
+        target_category="cat0",
+        seed=seed,
+        dataset_name="planted",
+        inclusion=0,
+        region_voting=True,
+        safe_thresholds=True,
+        max_steps=max_steps,
+        style="max_patch",
+        emit_calibration_metrics=True,
+        anchored_thresholds=True,
+        anchored_weights=[10.0],
+        anchored_rules=["mid"],
+        anchored_fold_combines=["qmean"],
+        anchored_fold_arms=fold_arms,
+    )
+
+
+class TestAnchoredVariantRows:
+    def test_anchored_arms_emitted_and_paired_per_step(self):
+        rows = _run()
+        assert rows, "no rows produced"
+        by_step: dict[int, set[str]] = {}
+        calibratable: dict[int, bool] = {}
+        for r in rows:
+            by_step.setdefault(r["t"], set()).add(r["gmm_variant"])
+            # The fold arms need real calibration folds, which the grouped
+            # calibrator only trains with >= 2 votes of each class.
+            calibratable[r["t"]] = r["n_good"] >= 2 and r["n_bad"] >= 2
+        assert any(calibratable.values()), "run never reached a calibratable step"
+        for t, variants_at_t in by_step.items():
+            # Paired within the step against the shipped blend and pure x-cal.
+            assert {_ANCHORED, "pooled_mid", "xcal_only"} <= variants_at_t
+            if calibratable[t]:
+                assert {_FOLD, _RANK} <= variants_at_t
+
+    def test_columns_provenance_and_no_blend(self):
+        rows = _run()
+        anchored = [r for r in rows if r["gmm_variant"] == _ANCHORED]
+        fold = [r for r in rows if r["gmm_variant"] == _FOLD]
+        rank = [r for r in rows if r["gmm_variant"] == _RANK]
+        assert anchored and fold and rank
+        for r in (*anchored, *fold, *rank):
+            assert set(_CALIBRATION_COLUMNS).issubset(r.keys())
+            assert np.isfinite(r["threshold"])
+            # The estimator replaces the blend: raw threshold, no ramp weight.
+            assert np.isnan(r["blend_weight"])
+            assert r["gmm_cut"] == r["threshold"]
+            assert r["raw_cut_cost"] == r["cost"]
+        for r in anchored:
+            assert r["threshold_provenance"] == "anchored" or r["threshold_provenance"].startswith(
+                ("unanchored:", "gmm_failed:")
+            )
+        for r in fold:
+            assert r["threshold_provenance"].startswith(("fold_anchored[", "fold_fallback"))
+        for r in rank:
+            assert r["threshold_provenance"] == "rank_transfer"
+
+    def test_fold_arms_can_be_disabled(self):
+        rows = _run(fold_arms=False)
+        variants = {r["gmm_variant"] for r in rows}
+        assert _ANCHORED in variants
+        assert _FOLD not in variants
+        assert _RANK not in variants
+
+    def test_deterministic(self):
+        thr_a = [
+            (r["t"], r["gmm_variant"], r["threshold"])
+            for r in _run()
+            if r["gmm_variant"].startswith(("anchored", "fold_anchored", "rank"))
+        ]
+        thr_b = [
+            (r["t"], r["gmm_variant"], r["threshold"])
+            for r in _run()
+            if r["gmm_variant"].startswith(("anchored", "fold_anchored", "rank"))
+        ]
+        assert thr_a == thr_b
+
+    def test_off_by_default(self):
+        medias, _ = _planted_dataset(n_per_cat=40, seed=0)
+        rows = simulate_voting_iterations(
+            medias,
+            target_category="cat0",
+            seed=0,
+            dataset_name="planted",
+            inclusion=0,
+            region_voting=True,
+            safe_thresholds=True,
+            max_steps=8,
+            style="max_patch",
+            emit_calibration_metrics=True,
+        )
+        assert not any(r["gmm_variant"].startswith(("anchored", "fold_anchored", "rank")) for r in rows)

--- a/tests_lib/sorting/test_anchored_gmm.py
+++ b/tests_lib/sorting/test_anchored_gmm.py
@@ -1,0 +1,241 @@
+"""Tests for the label-anchored mixture estimators (issue #2852).
+
+Covers the anchored EM itself (seeded synthetic bimodal / unimodal /
+anchors-contradict-modes cases, determinism, degeneracy fallbacks), the
+rank-transfer scale carrier, and the fold-anchored ("cross-LabeledGMM")
+combiner.  Library tier: pure ``vtscore.training.thresholds``, no app imports.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.training.thresholds import (
+    GmmFit1D,
+    anchored_gmm_fit,
+    fit_anchored_score_gmm,
+    fit_score_gmm,
+    fold_anchored_gmm_threshold,
+    gmm_cut_from_fit,
+    gmm_fit_array,
+    rank_transfer,
+)
+
+
+def _bimodal(
+    rng: np.random.Generator, n: int = 2000, mu_lo: float = 0.2, mu_hi: float = 0.8, sd: float = 0.05, w_hi: float = 0.3
+) -> np.ndarray:
+    n_hi = int(n * w_hi)
+    return np.concatenate([rng.normal(mu_lo, sd, n - n_hi), rng.normal(mu_hi, sd, n_hi)])
+
+
+def _anchors_from_modes(rng: np.random.Generator, n_each: int = 10) -> tuple[np.ndarray, np.ndarray]:
+    scores = np.concatenate([rng.normal(0.2, 0.05, n_each), rng.normal(0.8, 0.05, n_each)])
+    labels = np.concatenate([np.zeros(n_each), np.ones(n_each)])
+    return scores, labels
+
+
+class TestAnchoredEm:
+    def test_bimodal_with_agreeing_anchors_recovers_modes(self):
+        rng = np.random.default_rng(42)
+        arr = _bimodal(rng)
+        a_scores, a_labels = _anchors_from_modes(rng)
+        fit, provenance = fit_anchored_score_gmm(arr, a_scores, a_labels)
+        assert provenance == "anchored"
+        assert fit is not None
+        assert abs(fit.mu_lo - 0.2) < 0.03
+        assert abs(fit.mu_hi - 0.8) < 0.03
+        assert 0.3 < fit.midpoint() < 0.7
+
+    def test_deterministic(self):
+        rng = np.random.default_rng(7)
+        arr = _bimodal(rng)
+        a_scores, a_labels = _anchors_from_modes(rng)
+        fit1, p1 = fit_anchored_score_gmm(arr, a_scores, a_labels)
+        fit2, p2 = fit_anchored_score_gmm(arr, a_scores, a_labels)
+        assert p1 == p2 == "anchored"
+        assert fit1 == fit2  # frozen dataclass: bit-for-bit parameter equality
+
+    def test_unimodal_anchors_identify_the_split(self):
+        # A single broad mode gives the unanchored EM no class information;
+        # strong anchors must place the components on the labelled sides.
+        rng = np.random.default_rng(3)
+        arr = rng.normal(0.5, 0.15, 3000)
+        a_scores = np.concatenate([rng.normal(0.25, 0.03, 15), rng.normal(0.75, 0.03, 15)])
+        a_labels = np.concatenate([np.zeros(15), np.ones(15)])
+        fit, provenance = fit_anchored_score_gmm(arr, a_scores, a_labels, anchor_weight=100.0)
+        assert provenance == "anchored"
+        assert fit is not None
+        assert fit.mu_lo < 0.5 < fit.mu_hi
+        assert 0.3 < fit.midpoint() < 0.7
+
+    def test_anchors_contradicting_modes_fall_back_to_unanchored(self):
+        # Good anchors planted in the LOW population mode: the anchored means
+        # invert, the anchored path must report the degeneracy, and the
+        # production-shaped wrapper must fall back to the unanchored fit -
+        # never to 0.5.
+        rng = np.random.default_rng(11)
+        arr = _bimodal(rng)
+        a_scores = np.concatenate([rng.normal(0.2, 0.05, 20), rng.normal(0.8, 0.05, 20)])
+        a_labels = np.concatenate([np.ones(20), np.zeros(20)])  # deliberately inverted
+        fit, provenance = fit_anchored_score_gmm(arr, a_scores, a_labels, anchor_weight=1000.0)
+        assert fit is None
+        assert provenance == "inverted_means"
+
+        wrapped, wrapped_prov = anchored_gmm_fit(arr, a_scores, a_labels, anchor_weight=1000.0)
+        assert wrapped_prov == "unanchored:inverted_means"
+        assert wrapped == fit_score_gmm(gmm_fit_array(arr))
+
+    def test_huge_weight_converges_to_anchor_class_means(self):
+        rng = np.random.default_rng(5)
+        arr = _bimodal(rng)
+        a_scores = np.concatenate([rng.normal(0.3, 0.02, 25), rng.normal(0.7, 0.02, 25)])
+        a_labels = np.concatenate([np.zeros(25), np.ones(25)])
+        fit, provenance = fit_anchored_score_gmm(arr, a_scores, a_labels, anchor_weight=1e6)
+        assert provenance == "anchored"
+        assert fit is not None
+        assert abs(fit.mu_lo - float(a_scores[:25].mean())) < 0.02
+        assert abs(fit.mu_hi - float(a_scores[25:].mean())) < 0.02
+
+    def test_tiny_weight_stays_close_to_unanchored(self):
+        rng = np.random.default_rng(9)
+        arr = _bimodal(rng)
+        a_scores, a_labels = _anchors_from_modes(rng, n_each=5)
+        anchored, provenance = fit_anchored_score_gmm(arr, a_scores, a_labels, anchor_weight=1e-3)
+        plain = fit_score_gmm(arr)
+        assert provenance == "anchored"
+        assert anchored is not None and plain is not None
+        assert abs(anchored.mu_lo - plain.mu_lo) < 0.02
+        assert abs(anchored.mu_hi - plain.mu_hi) < 0.02
+
+    def test_no_anchor_edge_cases(self):
+        rng = np.random.default_rng(1)
+        arr = _bimodal(rng)
+        assert fit_anchored_score_gmm(arr, [], []) == (None, "no_anchors")
+        assert fit_anchored_score_gmm(arr, [0.5], [1.0], anchor_weight=0.0) == (None, "no_anchors")
+        assert fit_anchored_score_gmm(np.array([0.5]), [0.5], [1.0]) == (None, "too_few_scores")
+
+    def test_one_sided_anchors_are_allowed(self):
+        rng = np.random.default_rng(13)
+        arr = _bimodal(rng)
+        fit, provenance = fit_anchored_score_gmm(arr, rng.normal(0.8, 0.05, 10), np.ones(10))
+        assert provenance == "anchored"
+        assert fit is not None
+        assert fit.mu_hi > fit.mu_lo
+
+
+class TestCutFromFit:
+    _FIT = GmmFit1D(w_lo=0.7, mu_lo=0.2, var_lo=0.01, w_hi=0.3, mu_hi=0.8, var_hi=0.01)
+
+    def test_mid(self):
+        cut, fell_back = gmm_cut_from_fit(self._FIT, "mid")
+        assert cut == self._FIT.midpoint()
+        assert fell_back == 0
+
+    def test_rate_root_between_means(self):
+        cut, fell_back = gmm_cut_from_fit(self._FIT, "rate", 1.0, 1.0)
+        assert fell_back == 0
+        assert self._FIT.mu_lo < cut < self._FIT.mu_hi
+        # Equal variances at equal cost weights: the prior-free crossing IS the
+        # midpoint (see GmmFit1D.rate_crossing).
+        assert abs(cut - self._FIT.midpoint()) < 1e-9
+
+    def test_rate_without_root_falls_back_flagged(self):
+        # The rate rule divides the mixture weights back out, so only extreme
+        # COST weights can push the root outside (mu_lo, mu_hi): with a huge
+        # FPR weight and wide components no cut between the means is
+        # rate-optimal, and the rule must fall back to the midpoint and say so.
+        fit = GmmFit1D(w_lo=0.7, mu_lo=0.2, var_lo=0.04, w_hi=0.3, mu_hi=0.8, var_hi=0.04)
+        cut, fell_back = gmm_cut_from_fit(fit, "rate", 1e6, 1.0)
+        assert fell_back == 1
+        assert cut == fit.midpoint()
+
+    def test_unknown_rule_raises(self):
+        with pytest.raises(ValueError, match="unknown cut rule"):
+            gmm_cut_from_fit(self._FIT, "bogus")
+
+
+class TestRankTransfer:
+    def test_identity_when_scales_match(self):
+        rng = np.random.default_rng(21)
+        scores = rng.normal(0.5, 0.1, 5000)
+        assert abs(rank_transfer(0.5, scores, scores) - 0.5) < 0.005
+
+    def test_recovers_affine_scale_change(self):
+        rng = np.random.default_rng(22)
+        src = rng.normal(0.5, 0.1, 5000)
+        tgt = 2.0 * src + 1.0
+        assert abs(rank_transfer(0.55, src, tgt) - (2.0 * 0.55 + 1.0)) < 0.01
+
+    def test_empty_inputs_pass_through(self):
+        assert rank_transfer(0.42, [], [1.0, 2.0]) == 0.42
+        assert rank_transfer(0.42, [1.0, 2.0], []) == 0.42
+
+
+class TestFoldAnchored:
+    def test_transfers_fold_cuts_across_scales(self):
+        # Fold 2 sees the same haystack squashed to half scale; the combined
+        # quantile must land the cut between the FINAL distribution's modes.
+        rng = np.random.default_rng(31)
+        final = _bimodal(rng)
+        fold1 = _bimodal(np.random.default_rng(32))
+        fold2 = 0.5 * _bimodal(np.random.default_rng(33))
+        a1, l1 = _anchors_from_modes(np.random.default_rng(34))
+        a2, l2 = _anchors_from_modes(np.random.default_rng(35))
+        threshold, provenance = fold_anchored_gmm_threshold(
+            [fold1, fold2],
+            [(list(a1), list(l1)), (list(0.5 * a2), list(l2))],
+            final,
+        )
+        assert provenance == "fold_anchored[2/2]"
+        assert 0.3 < threshold < 0.7
+
+    def test_deterministic(self):
+        rng = np.random.default_rng(41)
+        final = _bimodal(rng)
+        fold = _bimodal(np.random.default_rng(42))
+        a, lbl = _anchors_from_modes(np.random.default_rng(43))
+        args = ([fold], [(list(a), list(lbl))], final)
+        assert fold_anchored_gmm_threshold(*args) == fold_anchored_gmm_threshold(*args)
+
+    def test_qmedian_combine(self):
+        rng = np.random.default_rng(51)
+        final = _bimodal(rng)
+        folds = [_bimodal(np.random.default_rng(52 + i)) for i in range(3)]
+        anchors = [_anchors_from_modes(np.random.default_rng(60 + i)) for i in range(3)]
+        threshold, provenance = fold_anchored_gmm_threshold(
+            folds, [(list(a), list(lbl)) for a, lbl in anchors], final, combine="qmedian"
+        )
+        assert provenance == "fold_anchored[3/3]"
+        assert 0.3 < threshold < 0.7
+
+    def test_degenerate_fold_falls_back_to_unanchored_fold_fit(self):
+        # One fold's anchors are inverted -> that fold falls back to its own
+        # unanchored fit but still contributes a quantile.
+        rng = np.random.default_rng(71)
+        final = _bimodal(rng)
+        fold = _bimodal(np.random.default_rng(72))
+        a, lbl = _anchors_from_modes(np.random.default_rng(73))
+        threshold, provenance = fold_anchored_gmm_threshold(
+            [fold], [(list(a), list(1.0 - lbl))], final, anchor_weight=1000.0
+        )
+        assert provenance == "fold_anchored[0/1]"
+        assert np.isfinite(threshold)
+
+    def test_all_folds_unusable_falls_back_to_final_unanchored(self):
+        rng = np.random.default_rng(81)
+        final = _bimodal(rng)
+        threshold, provenance = fold_anchored_gmm_threshold([np.array([0.5])], [([0.5], [1.0])], final)
+        assert provenance == "fold_fallback_final_unanchored"
+        plain = fit_score_gmm(gmm_fit_array(final))
+        assert plain is not None
+        assert threshold == plain.midpoint()
+
+    def test_unknown_combine_raises(self):
+        rng = np.random.default_rng(91)
+        final = _bimodal(rng)
+        fold = _bimodal(np.random.default_rng(92))
+        a, lbl = _anchors_from_modes(np.random.default_rng(93))
+        with pytest.raises(ValueError, match="unknown fold combine"):
+            fold_anchored_gmm_threshold([fold], [(list(a), list(lbl))], final, combine="bogus")

--- a/tests_lib/sorting/test_anchored_gmm.py
+++ b/tests_lib/sorting/test_anchored_gmm.py
@@ -87,6 +87,37 @@ class TestAnchoredEm:
         assert wrapped_prov == "unanchored:inverted_means"
         assert wrapped == fit_score_gmm(gmm_fit_array(arr))
 
+    def test_interleaved_anchors_are_not_degenerate(self):
+        # Ranking errors among the anchors are the NORMAL regime, not a
+        # degeneracy: the estimator is moment-based, so a Bad scoring above a
+        # Good (or a 24%-pairwise-inverted heavy overlap) just widens the
+        # components.  The fallback must trigger only on *mean* inversion of
+        # the anchor classes - the model ranking the labelset worse than
+        # chance - never on individual crossing pairs.  (An order-statistic
+        # sensitivity here would rebuild exactly the conformal rule's
+        # small-sample noise this estimator exists to escape.)
+        rng = np.random.default_rng(17)
+        arr = _bimodal(rng)
+
+        # One fully inverted pair on top of clean mode anchors.
+        a_scores = np.concatenate([rng.normal(0.2, 0.05, 10), rng.normal(0.8, 0.05, 10), [0.95, 0.05]])
+        a_labels = np.concatenate([np.zeros(10), np.ones(10), [0.0, 1.0]])
+        for weight in (1.0, 100.0, 1000.0):
+            fit, provenance = fit_anchored_score_gmm(arr, a_scores, a_labels, anchor_weight=weight)
+            assert provenance == "anchored", (weight, provenance)
+            assert fit is not None and 0.3 < fit.midpoint() < 0.7
+
+        # Heavily overlapping anchor classes: many crossing pairs, ordered means.
+        a_bad = rng.normal(0.45, 0.12, 20)
+        a_good = rng.normal(0.55, 0.12, 20)
+        assert any(b > g for b in a_bad for g in a_good)  # the overlap is real
+        a_scores2 = np.concatenate([a_bad, a_good])
+        a_labels2 = np.concatenate([np.zeros(20), np.ones(20)])
+        for weight in (1.0, 100.0, 1000.0):
+            fit, provenance = fit_anchored_score_gmm(arr, a_scores2, a_labels2, anchor_weight=weight)
+            assert provenance == "anchored", (weight, provenance)
+            assert fit is not None and fit.mu_hi > fit.mu_lo
+
     def test_huge_weight_converges_to_anchor_class_means(self):
         rng = np.random.default_rng(5)
         arr = _bimodal(rng)

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -49,11 +49,15 @@ from vtscore.eval.labels import media_is_positive, region_box_for_category
 from vtscore.eval.trainers import _cross_calibrated_threshold, _parse_trainer_spec
 from vtscore.training.mlp import LINEAR_HEAD, _auto_hidden_dim, train_model
 from vtscore.training.thresholds import (
+    anchored_gmm_fit,
     calculate_cross_calibration_threshold,
     calculate_safe_threshold,
     classify_threshold_provenance,
     compute_fold_orderings,
     compute_grouped_fold_node_scores,
+    fold_anchored_gmm_threshold,
+    gmm_cut_from_fit,
+    rank_transfer,
     threshold_from_fold_orderings,
 )
 
@@ -728,6 +732,186 @@ def _safe_gmm_variant_rows(
     return rows, diag_rows
 
 
+#: Default sweep grid for the anchored-mixture eval arms (issue #2852).  Each
+#: (anchor_weight, cut rule[, fold combine]) combination is one paired
+#: within-step variant; the GRID run overrides these via
+#: ``simulate_voting_iterations``'s ``anchored_*`` parameters to exhaust the
+#: grid registered in ``docs/plans/population-anchored-calibration.md``.
+_ANCHORED_WEIGHTS: tuple[float, ...] = (1.0, 10.0, 100.0)
+_ANCHORED_RULES: tuple[str, ...] = ("mid", "rate")
+_ANCHORED_FOLD_COMBINES: tuple[str, ...] = ("qmean",)
+
+
+def _anchored_variant_rows(
+    details: dict[str, Any],
+    base_scores: "np.ndarray",
+    base_labels: "np.ndarray",
+    sim_scores: list[float],
+    sim_ids: list[int],
+    good_ids: list[int],
+    bad_ids: list[int],
+    fold_models: list,
+    style_obj: Any,
+    sim_clips: dict[int, dict[str, Any]] | None,
+    inclusion: int,
+    n_pool_rows: float,
+    weights: list[float],
+    rules: list[str],
+    fold_combines: list[str],
+    fold_anchored: bool,
+) -> list[dict[str, Any]]:
+    """Metric rows for the anchored-mixture threshold arms (issue #2852).
+
+    Three families, all evaluated against the same held-out test scores as the
+    #2799 variants so every row is step-paired with the shipped blend
+    (``pooled_mid``) and pure x-cal (``xcal_only``):
+
+    * ``anchored_w{W}_{rule}`` - the **label-anchored** mixture: anchored EM on
+      the final model's sim-set (haystack) scores with the voted items' own
+      final-model scores clamped to their labelled component.  One EM per
+      anchor weight; each cut rule re-cuts the same fit.
+    * ``fold_anchored_w{W}_{rule}_{combine}`` - the **fold-anchored**
+      ("cross-LabeledGMM") repair: per calibration fold, anchored EM on that
+      fold model's haystack scores with that fold's held-out labelled scores
+      as anchors (honest anchors, one shared scale), each fold's cut carried
+      to the final model by rank transfer and combined in quantile space.
+    * ``rank_transfer`` - the conformal x-cal cut carried from the pooled fold
+      haystack distribution to the final model's as a quantile: the
+      scale-transfer-only arm that attributes H1 (see the plan).
+
+    Anchored thresholds are used **raw** - the estimator replaces the blend
+    rather than feeding it - so ``blend_weight`` is NaN and ``raw_cut_*``
+    equals the headline cost columns.  The estimator path actually taken
+    (anchored / unanchored fallback / fold tally) is recorded in
+    ``threshold_provenance``.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    from vtscore.eval.calibration_metrics import inclusion_weights, operating_cost  # noqa: PLC0415
+
+    xcal = float(details["xcal_threshold"])
+    fold_orderings = details.get("fold_orderings") or []
+    cal_scores = np.array([s for scores, _ in fold_orderings for s in scores]) if fold_orderings else None
+    cal_labels = np.array([lb for _, labels_ in fold_orderings for lb in labels_]) if fold_orderings else None
+    wf, wn = inclusion_weights(inclusion)
+    nan = float("nan")
+
+    score_by_id = dict(zip(sim_ids, sim_scores, strict=True))
+    anchor_scores = [score_by_id[cid] for cid in (*good_ids, *bad_ids) if cid in score_by_id]
+    anchor_labels = [1.0] * sum(1 for cid in good_ids if cid in score_by_id) + [0.0] * sum(
+        1 for cid in bad_ids if cid in score_by_id
+    )
+    final_scores = np.asarray(sim_scores, dtype=np.float64)
+
+    rows: list[dict[str, Any]] = []
+
+    def emit(name: str, threshold: float, provenance: str, cut_fallback: int) -> None:
+        if not np.isfinite(threshold):
+            return
+        row = _operating_metrics(
+            base_scores,
+            base_labels,
+            threshold,
+            inclusion,
+            cal_scores,
+            cal_labels,
+            pool_variant="max",
+            provenance=provenance,
+            n_pool_rows=n_pool_rows,
+        )
+        row["gmm_variant"] = name
+        row["xcal_threshold"] = _r(xcal)
+        row["gmm_cut"] = _r(threshold)
+        row["blend_weight"] = nan
+        row["cut_fallback"] = cut_fallback
+        raw_cost, raw_fpr, raw_fnr = operating_cost(base_scores, base_labels, threshold, wf, wn)
+        row["raw_cut_cost"] = _r(raw_cost)
+        row["raw_cut_fpr"] = _r(raw_fpr)
+        row["raw_cut_fnr"] = _r(raw_fnr)
+        rows.append(row)
+
+    # --- Label-anchored family: one anchored EM per weight, re-cut per rule. ---
+    for weight in weights:
+        fit, provenance = anchored_gmm_fit(final_scores, anchor_scores, anchor_labels, anchor_weight=weight)
+        if fit is None:
+            continue
+        for rule in rules:
+            cut, fell_back = gmm_cut_from_fit(fit, rule, wf, wn)
+            emit(f"anchored_w{weight:g}_{rule}", cut, provenance, fell_back)
+
+    # --- Fold-anchored family + the rank-transfer attribution arm. ---
+    if fold_anchored and fold_models and fold_orderings and sim_clips is not None and style_obj is not None:
+        _emit_fold_anchored_rows(
+            emit,
+            xcal,
+            fold_models,
+            fold_orderings,
+            final_scores,
+            style_obj,
+            sim_clips,
+            wf,
+            wn,
+            weights,
+            rules,
+            fold_combines,
+        )
+
+    return rows
+
+
+def _emit_fold_anchored_rows(
+    emit: Callable[[str, float, str, int], None],
+    xcal: float,
+    fold_models: list,
+    fold_orderings: list[tuple[list[float], list[float]]],
+    final_scores: "np.ndarray",
+    style_obj: Any,
+    sim_clips: dict[int, dict[str, Any]],
+    wf: float,
+    wn: float,
+    weights: list[float],
+    rules: list[str],
+    fold_combines: list[str],
+) -> None:
+    """Score the sim set per fold model and emit the fold-family arm rows.
+
+    The scoring pass per fold model is the fold arms' whole marginal cost, so
+    it happens exactly once here regardless of how many (weight, rule, combine)
+    grid points re-cut it.  ``rank_transfer`` reuses the same fold scores: the
+    conformal cut carried from the pooled fold haystack distribution to the
+    final model's - the scale-transfer-only attribution arm of the plan.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    fold_hay: list[np.ndarray] = []
+    for model in fold_models:
+        score_map = style_obj.score_media(model, sim_clips)
+        fold_hay.append(np.asarray(list(score_map.values()), dtype=np.float64))
+    n_folds = min(len(fold_hay), len(fold_orderings))
+    fold_hay, orderings = fold_hay[:n_folds], fold_orderings[:n_folds]
+
+    emit(
+        "rank_transfer",
+        rank_transfer(xcal, np.concatenate(fold_hay), final_scores),
+        "rank_transfer",
+        0,
+    )
+    for weight in weights:
+        for rule in rules:
+            for combine in fold_combines:
+                threshold, provenance = fold_anchored_gmm_threshold(
+                    fold_hay,
+                    orderings,
+                    final_scores,
+                    anchor_weight=weight,
+                    cut_rule=rule,
+                    combine=combine,
+                    fpr_weight=wf,
+                    fnr_weight=wn,
+                )
+                emit(f"fold_anchored_w{weight:g}_{rule}_{combine}", threshold, provenance, 0)
+
+
 def _calibration_metric_rows(
     step: _StepModel,
     threshold: float,
@@ -1284,6 +1468,10 @@ def _calibrate_with_details(
     """
     import numpy as np  # noqa: PLC0415
 
+    # The trained fold models ride along in details["fold_models"] so the
+    # #2852 fold-anchored arm can score the haystack on each fold's own scale
+    # without retraining; production callers never see them.
+    fold_models: list = []
     if cal_groups is not None:
         fold_node_data, fallback = compute_grouped_fold_node_scores(
             X_list,
@@ -1295,12 +1483,14 @@ def _calibrate_with_details(
             calibration_fraction=calibration_fraction,
             hidden_dim=hidden_dim,
             score_rows_by_group=score_rows_by_group,
+            model_sink=fold_models,
         )
         if fallback is not None:
             return fallback, {
                 "provenance": classify_threshold_provenance(fallback),
                 "fold_orderings": [],
                 "fold_node_data": None,
+                "fold_models": [],
             }
         # Base (max) orderings from the same fold node data -> identical to
         # production's grouped calibration for this arm.
@@ -1310,6 +1500,7 @@ def _calibrate_with_details(
             "provenance": classify_threshold_provenance(None),
             "fold_orderings": fold_orderings,
             "fold_node_data": fold_node_data,
+            "fold_models": fold_models,
         }
 
     # Row-wise path (whole-image styles): no bag flooding, no node re-pooling.
@@ -1321,18 +1512,21 @@ def _calibrate_with_details(
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
         hidden_dim=hidden_dim,
+        model_sink=fold_models,
     )
     if fallback is not None:
         return fallback, {
             "provenance": classify_threshold_provenance(fallback),
             "fold_orderings": [],
             "fold_node_data": None,
+            "fold_models": [],
         }
     threshold = threshold_from_fold_orderings(fold_orderings, inclusion)
     return threshold, {
         "provenance": classify_threshold_provenance(None),
         "fold_orderings": fold_orderings,
         "fold_node_data": None,
+        "fold_models": fold_models,
     }
 
 
@@ -1432,6 +1626,11 @@ def simulate_voting_iterations(  # noqa: C901
     sweep_sink: Optional[list[dict[str, Any]]] = None,
     cut_diag_sink: Optional[list[dict[str, Any]]] = None,
     autopilot_fidelity: bool = True,
+    anchored_thresholds: bool = False,
+    anchored_weights: Optional[list[float]] = None,
+    anchored_rules: Optional[list[str]] = None,
+    anchored_fold_arms: bool = True,
+    anchored_fold_combines: Optional[list[str]] = None,
 ) -> list[dict[str, Any]]:
     """Simulate voting on *clips_dict* and evaluate at every step.
 
@@ -1513,6 +1712,27 @@ def simulate_voting_iterations(  # noqa: C901
             follows the text sort (top items for the initial goods, the sort's
             cutoff for the initial bads); ``None`` (default) means the dataset
             has no text sort, so autopilot seeds from random known-good examples.
+        anchored_thresholds: When ``True`` (requires ``safe_thresholds``,
+            ``emit_calibration_metrics``, and a *style*), each step additionally
+            emits one metric row per anchored-mixture arm (issue #2852): the
+            label-anchored family (``anchored_w{W}_{rule}``), the fold-anchored
+            "cross-LabeledGMM" family (``fold_anchored_w{W}_{rule}_{combine}``),
+            and the ``rank_transfer`` attribution arm - see
+            :func:`_anchored_variant_rows`.  The fold arms score the sim set
+            once per calibration fold model per step, so they cost roughly one
+            extra scoring pass per fold.
+        anchored_weights: Anchor-weight grid for the anchored arms (default
+            :data:`_ANCHORED_WEIGHTS`).  Each labelled score counts as this
+            many haystack scores in the anchored EM's M-step.
+        anchored_rules: Cut rules applied to each anchored fit (default
+            :data:`_ANCHORED_RULES`): ``"mid"`` (production midpoint) and/or
+            ``"rate"`` (rate-optimal crossing at the live inclusion weights).
+        anchored_fold_arms: Include the fold-anchored + rank-transfer arms
+            (default ``True``); ``False`` keeps only the cheap label-anchored
+            family (no per-fold scoring passes).
+        anchored_fold_combines: How the fold arms combine per-fold cuts in
+            quantile space (default :data:`_ANCHORED_FOLD_COMBINES`):
+            ``"qmean"`` and/or ``"qmedian"``.
         autopilot_fidelity: When ``True`` (default) the simulated user follows
             the app's own phase machine
             (:class:`vtscore.eval.autopilot_flow.AutopilotFlow`): no detector is
@@ -1832,6 +2052,33 @@ def simulate_voting_iterations(  # noqa: C901
                 if cut_diag_sink is not None:
                     for dr in diag_rows:
                         cut_diag_sink.append({**base_row, **dr})
+            # The #2852 anchored-mixture arms, paired against the same test
+            # scores (and against pooled_mid / xcal_only above).
+            if anchored_thresholds and sim_pooled_scores is not None:
+                metric_rows.extend(
+                    _anchored_variant_rows(
+                        details,
+                        base_scores,
+                        base_labels,
+                        sim_pooled_scores,
+                        sim_pooled_ids,
+                        list(good_votes),
+                        list(bad_votes),
+                        details.get("fold_models") or [],
+                        style_obj,
+                        sim_clips,
+                        inclusion,
+                        n_pool_rows=metric_rows[0]["n_pool_rows"],
+                        weights=anchored_weights if anchored_weights is not None else list(_ANCHORED_WEIGHTS),
+                        rules=anchored_rules if anchored_rules is not None else list(_ANCHORED_RULES),
+                        fold_combines=(
+                            anchored_fold_combines
+                            if anchored_fold_combines is not None
+                            else list(_ANCHORED_FOLD_COMBINES)
+                        ),
+                        fold_anchored=anchored_fold_arms,
+                    )
+                )
             for mr in metric_rows:
                 rows.append({**base_row, **mr, **timing_cols})
             # The near-free inclusion-budget sweep, into the side sink.

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -291,6 +291,314 @@ def fit_score_gmm(arr: np.ndarray) -> GmmFit1D | None:
         return None
 
 
+# --- Anchored (semi-supervised) mixture estimation: issue #2852 ---------------
+#
+# The label-anchored mixture fits the same 2-component 1-D Gaussian mixture as
+# ``fit_score_gmm`` but on a *partially labelled* sample: the haystack scores
+# are free, while each voted item's score has its component membership fixed by
+# its label (Good -> high component, Bad -> low component).  This is classical
+# semi-supervised ML estimation for a mixture: EM where the E-step clamps the
+# labelled points' responsibilities to one-hot and the M-step counts each
+# labelled point ``anchor_weight`` times.  ``anchor_weight`` is therefore the
+# single fusion knob: the anchors' M-step mass is ``anchor_weight * n_labels``
+# against the haystack's ``N``, so with few labels the population dominates
+# (the GMM regime) and as labels accumulate the labelled class-conditionals
+# take over smoothly - the schedule the safe-blend hand-tunes, derived instead
+# from relative likelihood mass.
+
+#: Default per-anchor multiplicity for the anchored EM: each labelled score
+#: counts as this many haystack scores in the M-step.  Chosen so a handful of
+#: votes is already visible against the ``_GMM_MAX_SAMPLES``-sized haystack
+#: sample without drowning it; the #2852 experiment sweeps this.
+ANCHOR_WEIGHT_DEFAULT = 10.0
+
+#: Relative variance floor for the anchored EM, as a fraction of the total
+#: sample variance.  A component pinned to (near-)duplicate anchor scores would
+#: otherwise collapse its variance to 0 and take the likelihood to infinity.
+_ANCHOR_VAR_FLOOR_FRAC = 1e-6
+
+#: Minimum mixture weight either anchored component may end with; below this
+#: the fit has effectively deleted a component and the anchored path must fall
+#: back to the unanchored fit.
+_ANCHOR_MIN_WEIGHT = 1e-6
+
+
+def _anchored_em(
+    x: np.ndarray,
+    a_lo: np.ndarray,
+    a_hi: np.ndarray,
+    init: GmmFit1D,
+    anchor_weight: float,
+    max_iter: int,
+    tol: float,
+) -> GmmFit1D | None:
+    """Run the anchored EM iterations; ``None`` on numerical failure.
+
+    *x* is the free (unlabelled) sample, *a_lo* / *a_hi* the anchor scores
+    clamped to the low / high component.  Pure numpy, log-domain E-step, fixed
+    iteration order - deterministic for fixed inputs by construction.  Only
+    numerical failure (non-finite parameters) returns ``None`` here; semantic
+    degeneracy (inverted means, collapsed component) is judged by the caller so
+    it can name the reason.
+    """
+    lam = float(anchor_weight)
+    n = float(x.size)
+    n_lo, n_hi = float(a_lo.size), float(a_hi.size)
+    total_mass = n + lam * (n_lo + n_hi)
+
+    w = np.array([init.w_lo, init.w_hi], dtype=np.float64)
+    mu = np.array([init.mu_lo, init.mu_hi], dtype=np.float64)
+    var = np.array([init.var_lo, init.var_hi], dtype=np.float64)
+
+    pooled = np.concatenate([x, a_lo, a_hi])
+    var_floor = max(1e-12, _ANCHOR_VAR_FLOOR_FRAC * float(np.var(pooled)))
+    var = np.maximum(var, var_floor)
+
+    sum_a_lo, sum_a_hi = float(a_lo.sum()), float(a_hi.sum())
+
+    for _ in range(max_iter):
+        # E-step over the free sample only (anchors are clamped one-hot).
+        # Log-domain: log w_c - 0.5*log(2*pi*var_c) - (x-mu_c)^2 / (2*var_c).
+        log_p = (
+            np.log(np.maximum(w, 1e-300))[None, :]
+            - 0.5 * np.log(2.0 * math.pi * var)[None, :]
+            - (x[:, None] - mu[None, :]) ** 2 / (2.0 * var[None, :])
+        )
+        log_p -= log_p.max(axis=1, keepdims=True)
+        r = np.exp(log_p)
+        r /= r.sum(axis=1, keepdims=True)
+
+        # M-step with the anchors folded in at weight ``lam`` each.
+        m_lo = float(r[:, 0].sum()) + lam * n_lo
+        m_hi = float(r[:, 1].sum()) + lam * n_hi
+        if not (m_lo > 0.0 and m_hi > 0.0):
+            return None
+        mu_new = np.array(
+            [
+                (float(r[:, 0] @ x) + lam * sum_a_lo) / m_lo,
+                (float(r[:, 1] @ x) + lam * sum_a_hi) / m_hi,
+            ]
+        )
+        var_new = np.array(
+            [
+                (float(r[:, 0] @ (x - mu_new[0]) ** 2) + lam * float(((a_lo - mu_new[0]) ** 2).sum())) / m_lo,
+                (float(r[:, 1] @ (x - mu_new[1]) ** 2) + lam * float(((a_hi - mu_new[1]) ** 2).sum())) / m_hi,
+            ]
+        )
+        var_new = np.maximum(var_new, var_floor)
+        w_new = np.array([m_lo, m_hi]) / total_mass
+
+        if not (np.all(np.isfinite(mu_new)) and np.all(np.isfinite(var_new)) and np.all(np.isfinite(w_new))):
+            return None
+        delta = max(
+            float(np.max(np.abs(mu_new - mu))),
+            float(np.max(np.abs(var_new - var))),
+            float(np.max(np.abs(w_new - w))),
+        )
+        mu, var, w = mu_new, var_new, w_new
+        if delta < tol:
+            break
+
+    return GmmFit1D(
+        w_lo=float(w[0]),
+        mu_lo=float(mu[0]),
+        var_lo=float(var[0]),
+        w_hi=float(w[1]),
+        mu_hi=float(mu[1]),
+        var_hi=float(var[1]),
+    )
+
+
+def fit_anchored_score_gmm(
+    arr: np.ndarray,
+    anchor_scores: "list[float] | np.ndarray",
+    anchor_labels: "list[float] | np.ndarray",
+    *,
+    anchor_weight: float = ANCHOR_WEIGHT_DEFAULT,
+    max_iter: int = 200,
+    tol: float = 1e-8,
+) -> tuple[GmmFit1D | None, str]:
+    """Fit the label-anchored 2-component mixture (issue #2852).
+
+    *arr* is the (possibly :func:`gmm_fit_array`-subsampled) haystack score
+    sample; *anchor_scores* / *anchor_labels* are the voted items' scores and
+    binary labels (1.0 Good -> high component, else low).  Initialised from the
+    **unanchored** :func:`fit_score_gmm` fit (deterministic, seed-42 EM), then
+    refined by anchored EM (see :func:`_anchored_em`).
+
+    Returns ``(fit, provenance)``.  On success the provenance is ``"anchored"``
+    and the fit's components are class-identified by construction (``hi`` is
+    the Good-anchored component).  On failure the fit is ``None`` and the
+    provenance names the reason (``"no_anchors"``, ``"too_few_scores"``,
+    ``"unanchored_init_failed"``, ``"em_failed"``, ``"inverted_means"``,
+    ``"component_collapse"``) - the caller decides the fallback policy
+    (:func:`anchored_gmm_fit` falls back to the unanchored fit, never to 0.5).
+
+    Anchors force a component ordering rather than inherit one: if the labelled
+    scores contradict the population modes (Good votes living in the low mode),
+    the anchored means invert or a component collapses, and that is reported as
+    a degeneracy instead of silently shipping a backwards cut.
+    """
+    x = np.asarray(arr, dtype=np.float64).ravel()
+    a = np.asarray(anchor_scores, dtype=np.float64).ravel()
+    z = np.asarray(anchor_labels, dtype=np.float64).ravel()
+    if x.size < 2:
+        return None, "too_few_scores"
+    if a.size == 0 or a.size != z.size:
+        return None, "no_anchors"
+    if not (anchor_weight > 0.0):
+        return None, "no_anchors"
+
+    init = fit_score_gmm(x)
+    if init is None:
+        return None, "unanchored_init_failed"
+
+    a_hi = a[z == 1.0]
+    a_lo = a[z != 1.0]
+    fit = _anchored_em(x, a_lo, a_hi, init, anchor_weight, max_iter, tol)
+    if fit is None:
+        return None, "em_failed"
+    if not (fit.mu_hi > fit.mu_lo):
+        return None, "inverted_means"
+    if fit.w_lo < _ANCHOR_MIN_WEIGHT or fit.w_hi < _ANCHOR_MIN_WEIGHT:
+        return None, "component_collapse"
+    return fit, "anchored"
+
+
+def anchored_gmm_fit(
+    all_scores: "list[float] | np.ndarray",
+    anchor_scores: "list[float] | np.ndarray",
+    anchor_labels: "list[float] | np.ndarray",
+    *,
+    anchor_weight: float = ANCHOR_WEIGHT_DEFAULT,
+) -> tuple[GmmFit1D | None, str]:
+    """Production-shaped anchored fit with the #2852 fallback policy applied.
+
+    Subsamples via :func:`gmm_fit_array`, attempts the anchored fit, and on any
+    anchored degeneracy falls back to the **unanchored** GMM fit of the same
+    sample - never to 0.5.  Returns ``(fit, provenance)`` where provenance is
+    ``"anchored"`` or ``"unanchored:<reason>"``; the fit is ``None`` only when
+    the unanchored fit fails too (provenance ``"gmm_failed:<reason>"``, caller
+    falls back to its median rule).
+    """
+    arr = gmm_fit_array(all_scores)
+    fit, provenance = fit_anchored_score_gmm(arr, anchor_scores, anchor_labels, anchor_weight=anchor_weight)
+    if fit is not None:
+        return fit, provenance
+    fallback = fit_score_gmm(arr)
+    if fallback is not None:
+        return fallback, f"unanchored:{provenance}"
+    return None, f"gmm_failed:{provenance}"
+
+
+def gmm_cut_from_fit(fit: GmmFit1D, rule: str, fpr_weight: float = 1.0, fnr_weight: float = 1.0) -> tuple[float, int]:
+    """Apply a named cut *rule* to *fit*; ``(cut, fell_back_to_midpoint)``.
+
+    ``"mid"`` is the production midpoint; ``"rate"`` is the rate-optimal
+    crossing at the given cost weights (see :meth:`GmmFit1D.rate_crossing`),
+    falling back to the midpoint - flagged - when the crossing has no root on
+    this fit.  Shared by the anchored-threshold eval variants so every arm
+    falls back exactly the way production would.
+    """
+    if rule == "mid":
+        return fit.midpoint(), 0
+    if rule == "rate":
+        cut = fit.rate_crossing(fpr_weight, fnr_weight)
+        if cut is None or not math.isfinite(cut):
+            return fit.midpoint(), 1
+        return cut, 0
+    raise ValueError(f"unknown cut rule {rule!r}; expected 'mid' or 'rate'")
+
+
+def rank_transfer(
+    cut: float, source_scores: "list[float] | np.ndarray", target_scores: "list[float] | np.ndarray"
+) -> float:
+    """Carry *cut* from one score distribution to another as a quantile.
+
+    Reads the empirical quantile of *cut* in *source_scores* (the fraction of
+    source scores strictly below it) and realizes that quantile on
+    *target_scores* via linear interpolation.  A cut is a point on a score
+    *scale*; two models scoring the same haystack are related by an
+    approximately monotone map, and a quantile is invariant under any monotone
+    map - so this is the scale-transfer step that lets a cut measured on a fold
+    model's distribution be applied to the final model's (deficit 2 of
+    ``docs/plans/population-anchored-calibration.md``).
+    """
+    src = np.sort(np.asarray(source_scores, dtype=np.float64).ravel())
+    tgt = np.asarray(target_scores, dtype=np.float64).ravel()
+    if src.size == 0 or tgt.size == 0:
+        return float(cut)
+    q = float(np.searchsorted(src, cut, side="left")) / float(src.size)
+    return float(np.quantile(tgt, min(1.0, max(0.0, q))))
+
+
+def fold_anchored_gmm_threshold(
+    fold_haystack_scores: "list[np.ndarray]",
+    fold_anchor_orderings: list[tuple[list[float], list[float]]],
+    final_scores: "list[float] | np.ndarray",
+    *,
+    anchor_weight: float = ANCHOR_WEIGHT_DEFAULT,
+    cut_rule: str = "mid",
+    combine: str = "qmean",
+    fpr_weight: float = 1.0,
+    fnr_weight: float = 1.0,
+) -> tuple[float, str]:
+    """The fold-anchored ("cross-LabeledGMM") mixture threshold (#2852 comment).
+
+    Per calibration fold *k*: fit the anchored mixture on the **fold model's**
+    haystack scores (``fold_haystack_scores[k]``) with anchors from that fold's
+    *held-out* labelled scores (``fold_anchor_orderings[k]``, the same
+    ``(scores, labels)`` orderings the conformal rule pools).  Anchors and
+    population then share one scale and the anchors are honest - the labelled
+    items were not in that fold model's training set, so their scores carry no
+    train-set optimism.  Each fold's cut is carried to the final model by
+    :func:`rank_transfer` (as a quantile of the fold's haystack distribution,
+    realized on *final_scores*), and the folds are combined in **quantile**
+    space (``combine="qmean"`` / ``"qmedian"``) so no cross-scale averaging of
+    raw cuts ever happens.
+
+    Degeneracy policy per the issue: a fold whose anchored fit degenerates
+    falls back to that fold's unanchored GMM fit; if every fold fails both
+    fits, the final model's own unanchored GMM midpoint is returned (and its
+    median if even that fails) - never 0.5.  Returns ``(threshold,
+    provenance)`` with provenance ``"fold_anchored[a/k]"`` (*a* folds anchored
+    of *k* used) or ``"fold_fallback_final_unanchored"`` /
+    ``"fold_fallback_final_median"`` on the terminal fallbacks.
+    """
+    final_arr = gmm_fit_array(final_scores)
+    quantiles: list[float] = []
+    n_anchored = 0
+    for hay, (a_scores, a_labels) in zip(fold_haystack_scores, fold_anchor_orderings, strict=True):
+        arr = gmm_fit_array(hay)
+        fit, provenance = fit_anchored_score_gmm(arr, a_scores, a_labels, anchor_weight=anchor_weight)
+        if fit is None:
+            fit = fit_score_gmm(arr)
+            if fit is None:
+                continue
+        elif provenance == "anchored":
+            n_anchored += 1
+        cut, _fell_back = gmm_cut_from_fit(fit, cut_rule, fpr_weight, fnr_weight)
+        src = np.sort(arr)
+        quantiles.append(float(np.searchsorted(src, cut, side="left")) / float(src.size))
+
+    if not quantiles or final_arr.size == 0:
+        fallback_fit = fit_score_gmm(final_arr) if final_arr.size >= 2 else None
+        if fallback_fit is not None:
+            return fallback_fit.midpoint(), "fold_fallback_final_unanchored"
+        if final_arr.size:
+            return float(np.median(final_arr)), "fold_fallback_final_median"
+        return 0.5, "fold_fallback_final_median"
+
+    if combine == "qmean":
+        q = float(np.mean(quantiles))
+    elif combine == "qmedian":
+        q = float(np.median(quantiles))
+    else:
+        raise ValueError(f"unknown fold combine {combine!r}; expected 'qmean' or 'qmedian'")
+    threshold = float(np.quantile(final_arr, min(1.0, max(0.0, q))))
+    return threshold, f"fold_anchored[{n_anchored}/{len(quantiles)}]"
+
+
 def calculate_gmm_threshold(scores: list[float]) -> float:
     """Use a Gaussian Mixture Model to find a threshold between two score distributions.
 
@@ -761,6 +1069,7 @@ def _compute_fold_orderings_grouped(
     calibration_fraction: float,
     hidden_dim: int | None,
     score_rows_by_group: dict | None = None,
+    model_sink: list | None = None,
 ) -> tuple[list[tuple[list[float], list[float]]], float | None]:
     """Bag-aware variant of :func:`compute_fold_orderings`.
 
@@ -778,6 +1087,8 @@ def _compute_fold_orderings_grouped(
     )
     if fallback is not None:
         return [], fallback
+    if model_sink is not None:
+        model_sink.extend(model for model, _cal in folds)
 
     orderings: list[tuple[list[float], list[float]]] = []
     for model, cal_groups in folds:
@@ -800,6 +1111,7 @@ def compute_grouped_fold_node_scores(
     calibration_fraction: float = 0.5,
     hidden_dim: int | None = None,
     score_rows_by_group: dict | None = None,
+    model_sink: list | None = None,
 ) -> tuple[list[tuple[list[np.ndarray], list[float]]], float | None]:
     """Bag-aware calibration folds, returning each held-out group's node scores.
 
@@ -813,12 +1125,19 @@ def compute_grouped_fold_node_scores(
     Returns ``(fold_node_data, fallback)`` where *fold_node_data* is a list, one
     entry per fold, of ``(group_node_scores, group_labels)`` - *group_node_scores*
     being a list of 1-D float arrays (one per held-out calibration group).
+
+    *model_sink*, when given, receives each trained fold model in fold order -
+    the #2852 fold-anchored eval arm scores the haystack with the same fold
+    models the orderings came from, so the anchors and the population it fits
+    share one score scale without a retrain.
     """
     folds, fallback, X_np, rows_by_group, label_by_group = _grouped_folds(
         X_list, y_list, input_dim, groups, rng, calibrate_count, calibration_fraction, hidden_dim
     )
     if fallback is not None:
         return [], fallback
+    if model_sink is not None:
+        model_sink.extend(model for model, _cal in folds)
 
     fold_node_data: list[tuple[list[np.ndarray], list[float]]] = []
     for model, cal_groups in folds:
@@ -838,6 +1157,7 @@ def compute_fold_orderings(
     hidden_dim: int | None = None,
     groups: list | None = None,
     score_rows_by_group: dict | None = None,
+    model_sink: list | None = None,
 ) -> tuple[list[tuple[list[float], list[float]]], float | None]:
     """Train the K calibration folds and return their held-out orderings.
 
@@ -877,6 +1197,10 @@ def compute_fold_orderings(
     (:func:`vtscore.detectors.training.inference_score_rows`); ``None`` keeps
     the "collapse over the training rows" behaviour for callers that have no
     inference geometry to offer.
+
+    *model_sink*, when given, receives each trained fold model in fold order
+    (see :func:`compute_grouped_fold_node_scores`); production callers pass
+    nothing and the models stay fold-local as before.
     """
     if groups is not None:
         return _compute_fold_orderings_grouped(
@@ -889,6 +1213,7 @@ def compute_fold_orderings(
             calibration_fraction=calibration_fraction,
             hidden_dim=hidden_dim,
             score_rows_by_group=score_rows_by_group,
+            model_sink=model_sink,
         )
     n = len(X_list)
     if n < 4:
@@ -933,6 +1258,8 @@ def compute_fold_orderings(
         X_cal = torch.tensor(X_np[cal_idx], dtype=torch.float32)
 
         model = train_model(X_train, y_train, input_dim, hidden_dim=hidden_dim)
+        if model_sink is not None:
+            model_sink.append(model)
 
         with torch.no_grad():
             from vtscore.utils.scores import sigmoid_to_finite_scores  # noqa: PLC0415


### PR DESCRIPTION
Closes #2852.

Implements the label-anchored mixture threshold and its fold-anchored ("cross-LabeledGMM") refinement from the issue comment, wires both as within-step paired eval variants, and adds the GRID experiment (launcher + analyzer + self-test) so the pre-registered measurement in `docs/plans/population-anchored-calibration.md` can run on a fresh worktree from `dev`.

## Estimators (`vtscore/training/thresholds.py`)

- **`fit_anchored_score_gmm` / `anchored_gmm_fit`** — semi-supervised anchored EM: the 2-component 1-D mixture is fitted on `gmm_fit_array(all_scores)` with the labelled items' component responsibilities clamped one-hot (Good → high, Bad → low), each anchor counting `anchor_weight` times in the M-step. Deterministic: init from the existing seed-42 unanchored fit, fixed iteration order, pure numpy. Degeneracies (inverted means, component/variance collapse, EM failure) fall back to the **unanchored** fit — never to 0.5 — and the path taken is surfaced as a provenance string (`"anchored"` / `"unanchored:<reason>"` / `"gmm_failed:<reason>"`), mirroring `classify_threshold_provenance`'s style.
- **`rank_transfer`** — carries a cut between score scales as an empirical quantile (monotone-map invariant), the scale-transfer step for deficit 2.
- **`fold_anchored_gmm_threshold`** — per calibration fold: anchored fit on the *fold model's* haystack scores with that fold's *held-out* labelled scores as anchors (honest anchors, one shared scale), each fold's cut rank-transferred to the final model and combined in quantile space (`qmean` / `qmedian`).
- **`gmm_cut_from_fit`** — shared `mid` / `rate` cut rules with production's midpoint fallback, flagged.
- `compute_fold_orderings` / `compute_grouped_fold_node_scores` grew an optional `model_sink` so the harness can reuse the trained fold models for the haystack scoring pass (production callers unchanged).

## Eval harness (`vtscore/eval/voting_iterations.py`)

`anchored_thresholds=True` (with `safe_thresholds`, `emit_calibration_metrics`, and a style) emits per step, step-paired against the existing `pooled_mid` (shipped blend) and `xcal_only` controls:

- `anchored_w{W}_{rule}` — label-anchored mixture on the final model's sim-set scores, anchors = the voted items' own final-model scores (the issue's first implementation; reuses scores that already exist).
- `fold_anchored_w{W}_{rule}_{combine}` — the cross-LabeledGMM repair (kills the train-anchor bias and the fold→final scale mismatch in one move; costs one sim-set scoring pass per fold per step).
- `rank_transfer` — the conformal cut carried from the pooled fold haystack distribution to the final model's: the scale-transfer-only arm that attributes H1.

Anchored thresholds are used **raw** (the estimator replaces the blend), `blend_weight` is NaN, and the estimator path lands in `threshold_provenance`. Columns are unchanged, so existing cell CSVs/analyzers are unaffected.

## GRID study (`scripts/experiments/calibration/`)

- `launch_anchored.sh` — thin wrapper over `launch_all.sh`: safe+anchored ON, linear head, VG (`siglip` + `dinov3_patch`/`max_patch`), 300 voting steps (the deep regime), 4 seeds, results under `/exp/$USER/calibration-anchored`.
- Sweep knobs in `experiment_config.py`: `CALIB_ANCHORED_WEIGHTS` (default `1,3,10,30,100`), `CALIB_ANCHORED_RULES` (`mid,rate`), `CALIB_ANCHORED_FOLD_COMBINES` (`qmean,qmedian`), `CALIB_ANCHORED_FOLD_ARMS`, `CALIB_ANCHORED_CHECKPOINTS` (`20,50,100,200,300`).
- `analyze_anchored.py` — per-checkpoint-window paired contrasts vs both controls, threshold-stability table, provenance tallies, and mechanical H1–H4 verdicts per the plan; `selftest_analyze_anchored.py` recovers a planted deep-regime winner (right arm, right attribution, right signs) before any overnight run.

## Tests

`tests_lib/sorting/test_anchored_gmm.py` (seeded bimodal / unimodal / anchors-contradict-modes, determinism, weight extremes, fallbacks, rank transfer, fold combining) and `tests_lib/detectors/test_anchored_variant_rows.py` (arms emitted and paired per step, no-blend invariants, provenance, determinism, off-by-default). `./run-tests.sh`: **ALL 7589 TESTS PASSED** (1 skipped, 1 xfailed).

Out of scope (per the issue): any production threshold change — adoption stays gated on the plan's decision rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mg2Rk3WjPGfPfGTLDdYtjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mg2Rk3WjPGfPfGTLDdYtjA)_