### PR TITLE
Restore ActiveDetectorService, lost to a stale-branch conflict resolution

### DIFF
--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -17,7 +17,7 @@ import { DashboardLoadingTasksService } from '../../services/dashboard-loading-t
 import { ToastService } from '../../services/toast.service';
 import { VtDialogService } from '../../services/dialog.service';
 import { ActiveContextService } from '../../services/active-context.service';
-import { DatasetStateService } from '../../services/dataset-state.service';
+import { ActiveDetectorService } from '../../services/active-detector.service';
 import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService, SortedItem } from '../../services/sort-state.service';
@@ -61,7 +61,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private dialog = inject(VtDialogService);
   private ngZone = inject(NgZone);
   private activeContext = inject(ActiveContextService);
-  private datasetState = inject(DatasetStateService);
+  private activeDetector = inject(ActiveDetectorService);
   mediaState = inject(MediaStateService);
   voteState = inject(VoteStateService);
   sortState = inject(SortStateService);
@@ -365,8 +365,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // Start polling for progress concurrently
     this.startProgressPolling();
 
-    const modelName =
-      this.datasetState.detectors.find((d) => d.id === modelId)?.name || 'Detector';
+    const modelName = this.activeDetector.detectorName() || 'Detector';
     this.detectorsFindApi.findLabel({ detector_id: modelId })
       .pipe(
         takeUntil(this.destroy$),
@@ -779,9 +778,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   private toDatasetFromIds(ids: number[]): void {
     if (ids.length === 0) return;
-    const modelId = this.activeContext.modelId;
-    const detectorName =
-      this.datasetState.detectors.find((d) => d.id === modelId)?.name || 'Detector';
+    const detectorName = this.activeDetector.detectorName() || 'Detector';
     const base = [this.datasetName(), detectorName, 'Results'].filter((s) => !!s).join(' ');
 
     this.dialog.prompt('Name the new dataset', base).then((name) => {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HttpTestingController } from '@angular/common/http/testing';
 import { ExportModalComponent } from './export-modal.component';
+import { ActiveContextService } from '../../../services/active-context.service';
+import { DatasetStateService } from '../../../services/dataset-state.service';
 import { ToastService } from '../../../services/toast.service';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
 import { settleResource } from '../../../testing/settle-resource';
@@ -293,6 +295,57 @@ describe('ExportModalComponent', () => {
     };
     component.startExporter(exporter as never);
     expect(component.formValues['q']).toBe('');
+  });
+
+  describe('default filename', () => {
+    /** An exporter whose `filepath` field gets the generated default. */
+    const fileExporter = {
+      name: 'server_json_file',
+      display_name: 'Server JSON',
+      fields: [{ key: 'filepath', field_type: 'text', default: 'data/labels.json' }],
+    };
+
+    /** Land a detector registry naming `d1`, as the app-level refresh would. */
+    function flushRegistry(): void {
+      TestBed.inject(DatasetStateService).refresh();
+      httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+      httpMock
+        .expectOne('/api/detectors/registry')
+        .flush({ detectors: [{ id: 'd1', name: 'Birdsong' }] });
+    }
+
+    it('names the parent-supplied detector', async () => {
+      fixture.componentRef.setInput('detectorName', 'Sirens');
+      await flushInit();
+      component.selectExporterTab(fileExporter as never);
+      expect(component.formValues['filepath']).toBe('data/Good-Sirens-My Dataset.json');
+    });
+
+    // The lifecycle gap behind issue #2819: the filename is built once, at
+    // exporter-select time, so a detector registry that resolves afterwards
+    // used to leave the detector out of it permanently.
+    it('backfills the detector name when the registry resolves late', async () => {
+      await flushInit();
+      TestBed.inject(ActiveContextService).setActivePair('ds1', 'd1');
+      component.selectExporterTab(fileExporter as never);
+      expect(component.formValues['filepath']).toBe('data/Good-My Dataset.json');
+
+      flushRegistry();
+      TestBed.tick();
+      expect(component.effectiveDetectorName()).toBe('Birdsong');
+      expect(component.formValues['filepath']).toBe('data/Good-Birdsong-My Dataset.json');
+    });
+
+    it('leaves a user-edited filename alone when the name arrives late', async () => {
+      await flushInit();
+      TestBed.inject(ActiveContextService).setActivePair('ds1', 'd1');
+      component.selectExporterTab(fileExporter as never);
+      component.formValues['filepath'] = 'data/mine.json';
+
+      flushRegistry();
+      TestBed.tick();
+      expect(component.formValues['filepath']).toBe('data/mine.json');
+    });
   });
 
   it('emits closed on close', async () => {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -20,9 +20,8 @@ import {
   ClipboardColumn,
   ClipboardCopyComponent,
 } from '../../clipboard-copy/clipboard-copy.component';
-import { ActiveContextService } from '../../../services/active-context.service';
+import { ActiveDetectorService } from '../../../services/active-detector.service';
 import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
-import { DatasetStateService } from '../../../services/dataset-state.service';
 import { ExportersApiService } from '../../../services/exporters-api.service';
 import { LabelSessionService } from '../../../services/label-session.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
@@ -70,8 +69,7 @@ export class ExportModalComponent implements OnInit {
   private readonly exportersApi = inject(ExportersApiService);
   private readonly labelSession = inject(LabelSessionService);
   private readonly sortingApi = inject(SortingApiService);
-  private readonly activeContext = inject(ActiveContextService);
-  private readonly datasetState = inject(DatasetStateService);
+  private readonly activeDetector = inject(ActiveDetectorService);
   private readonly toast = inject(ToastService);
 
   // Two eager reads (dataset status + exporter list) load on creation; the
@@ -164,6 +162,16 @@ export class ExportModalComponent implements OnInit {
    */
   private static readonly ALWAYS_EXPORT_KEYS = ['origin', 'origin_name'];
 
+  /** Detector/model name from any available source: the parent-supplied name
+   *  (a Dashboard row action exports *that* row's detector, which need not be
+   *  the active one), else the selected detector resolved through the registry
+   *  (typical when this modal opens from the Find view), else the last name
+   *  the label session carried. A signal, not a getter, so a name that lands
+   *  after the modal opened still reaches the default filename below. */
+  readonly effectiveDetectorName = computed(
+    () => this.detectorName() || this.activeDetector.detectorName() || this.labelSession.modelName,
+  );
+
   constructor() {
     // Rebuild the column set when the labels read settles. The checkbox
     // `enabled` state lives on `columns`, so it stays a mutable field rather
@@ -176,19 +184,23 @@ export class ExportModalComponent implements OnInit {
         this.buildColumns();
       }
     });
-  }
 
-  /** Detector/model name from any available source. Falls back to the
-   *  registry entry for the active detector id when the
-   *  parent-supplied name and `labelSession.modelName` are both
-   *  empty (typical when this modal opens from the Find view). */
-  private get effectiveDetectorName(): string {
-    const detectorName = this.detectorName();
-    if (detectorName) return detectorName;
-    if (this.labelSession.modelName) return this.labelSession.modelName;
-    const modelId = this.activeContext.modelId;
-    if (!modelId) return '';
-    return this.datasetState.detectors.find((d) => d.id === modelId)?.name || '';
+    // Re-apply the default filename when a name it is built from arrives late.
+    // `applyDefaultFilename` runs once, at exporter-select time; the detector
+    // registry and the dataset-status read can both settle after that, which
+    // used to leave the filename permanently missing the piece that wasn't
+    // loaded yet (issue #2819). Both sources are signals, so this effect
+    // re-runs when either resolves — and only rewrites the field while it
+    // still holds the value we generated, so a user edit is never clobbered.
+    effect(() => {
+      const detectorName = this.effectiveDetectorName();
+      const datasetName = this.datasetName();
+      const exporter = this.selectedExporter ?? this.activeTabExporter;
+      if (!exporter) return;
+      if (!detectorName && !datasetName) return;
+      if (this.formValues['filepath'] !== this.lastAutoFilename) return;
+      this.applyDefaultFilename(exporter);
+    });
   }
 
   ngOnInit(): void {
@@ -422,7 +434,7 @@ export class ExportModalComponent implements OnInit {
     if (this.labelFilter === 'good') parts.push('Good');
     else if (this.labelFilter === 'bad') parts.push('Bad');
     else if (this.labelFilter === 'corrections') parts.push('Corrections');
-    const detName = this.effectiveDetectorName;
+    const detName = this.effectiveDetectorName();
     if (detName) parts.push(detName);
     const datasetName = this.datasetName();
     if (datasetName) parts.push(datasetName);
@@ -455,6 +467,11 @@ export class ExportModalComponent implements OnInit {
     return '';
   }
 
+  /** The filename this component last auto-filled into `filepath`. Compared
+   *  against the live field value to tell "still ours" from "user-edited"
+   *  before the constructor effect regenerates it. */
+  private lastAutoFilename = '';
+
   /** Apply the dynamic default filename to the filepath form field if present. */
   private applyDefaultFilename(exporter: ExporterEntry): void {
     const filepathField = this.exporterFieldsOf(exporter).find((f) => f.key === 'filepath');
@@ -463,7 +480,9 @@ export class ExportModalComponent implements OnInit {
       // Derive extension from the static default (e.g. ".json", ".csv") or fall back
       const extMatch = staticDefault.match(/\.(\w+)$/);
       const ext = extMatch ? extMatch[1] : 'json';
-      this.formValues['filepath'] = `data/${this.buildDefaultFilename(ext)}`;
+      const filename = `data/${this.buildDefaultFilename(ext)}`;
+      this.formValues['filepath'] = filename;
+      this.lastAutoFilename = filename;
     }
   }
 

--- a/frontend/src/app/services/active-detector.service.spec.ts
+++ b/frontend/src/app/services/active-detector.service.spec.ts
@@ -1,0 +1,98 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+
+import { ActiveContextService } from './active-context.service';
+import { ActiveDetectorService } from './active-detector.service';
+import { DatasetStateService } from './dataset-state.service';
+import { provideHttpTesting } from '../testing/test-providers';
+
+describe('ActiveDetectorService', () => {
+  let service: ActiveDetectorService;
+  let activeContext: ActiveContextService;
+  let datasetState: DatasetStateService;
+  let httpMock: HttpTestingController;
+
+  /** Land a detector registry payload, as the app-level refresh would. */
+  function flushRegistry(detectors: { id: string; name: string }[]): void {
+    datasetState.refresh();
+    httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+    httpMock.expectOne('/api/detectors/registry').flush({ detectors });
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [...provideHttpTesting()],
+    });
+    service = TestBed.inject(ActiveDetectorService);
+    activeContext = TestBed.inject(ActiveContextService);
+    datasetState = TestBed.inject(DatasetStateService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('reports no detector before anything is selected', () => {
+    expect(service.detectorId()).toBe('');
+    expect(service.detector()).toBeNull();
+    expect(service.detectorName()).toBe('');
+  });
+
+  it('resolves the active id to its registry name', () => {
+    flushRegistry([
+      { id: 'd1', name: 'Birdsong' },
+      { id: 'd2', name: 'Sirens' },
+    ]);
+    activeContext.setActivePair('ds1', 'd2');
+    expect(service.detectorId()).toBe('d2');
+    expect(service.detector()?.name).toBe('Sirens');
+    expect(service.detectorName()).toBe('Sirens');
+  });
+
+  // The lifecycle gap behind issue #2819: a consumer reading the name before
+  // the registry lands used to latch '' forever. As a signal it fills in.
+  it('fills in the name when the registry lands after the selection', () => {
+    activeContext.setActivePair('ds1', 'd1');
+    expect(service.detectorName()).toBe('');
+
+    flushRegistry([{ id: 'd1', name: 'Birdsong' }]);
+    expect(service.detectorName()).toBe('Birdsong');
+  });
+
+  it('names the user pick while the switch is still loading', () => {
+    flushRegistry([{ id: 'd1', name: 'Birdsong' }]);
+    // Intent leads active for the duration of the dataset/detector load.
+    activeContext.setIntent('ds1', 'd1');
+    expect(service.activeId()).toBe('');
+    expect(service.intentId()).toBe('d1');
+    expect(service.detectorName()).toBe('Birdsong');
+  });
+
+  it('prefers the active detector over an in-flight switch to another one', () => {
+    flushRegistry([
+      { id: 'd1', name: 'Birdsong' },
+      { id: 'd2', name: 'Sirens' },
+    ]);
+    activeContext.setActivePair('ds1', 'd1');
+    activeContext.setIntent('ds1', 'd2');
+    // Until the load promotes d2, the loaded detector is still d1.
+    expect(service.detectorName()).toBe('Birdsong');
+
+    activeContext.setActive('ds1', 'd2');
+    expect(service.detectorName()).toBe('Sirens');
+  });
+
+  it('clears the name when the selection is cleared', () => {
+    flushRegistry([{ id: 'd1', name: 'Birdsong' }]);
+    activeContext.setActivePair('ds1', 'd1');
+    activeContext.clear();
+    expect(service.detectorId()).toBe('');
+    expect(service.detectorName()).toBe('');
+  });
+
+  it('reports an empty name for an id the registry does not know', () => {
+    flushRegistry([{ id: 'd1', name: 'Birdsong' }]);
+    activeContext.setActivePair('ds1', 'gone');
+    expect(service.detector()).toBeNull();
+    expect(service.detectorName()).toBe('');
+  });
+});

--- a/frontend/src/app/services/active-detector.service.ts
+++ b/frontend/src/app/services/active-detector.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { DetectorRegistryEntry } from '../generated/api-client/models/detector-registry-entry';
+import { ActiveContextService } from './active-context.service';
+import { DatasetStateService } from './dataset-state.service';
+
+/**
+ * Signal view of *which detector the user is working with*, resolved from the
+ * active-context id to the registry entry (and therefore to a display name).
+ *
+ * `ActiveContextService` carries ids only, on an RxJS layer that a `computed`
+ * can't track, so every consumer that wanted a name re-did the same
+ * `detectors.find(...)` lookup imperatively. That reads whatever happens to be
+ * loaded at call time and never updates when the registry lands a moment
+ * later: the lifecycle gap that leaves an export filename detector-less when
+ * the modal opens before the detector registry resolves (issue #2819).
+ *
+ * Exposing the name as a signal closes both halves: it is one source of truth,
+ * and it repopulates on its own once the registry (or an in-flight context
+ * switch) settles, so `computed`s, `effect`s and templates downstream follow
+ * along instead of latching a stale first read.
+ *
+ * Deliberately a separate service rather than fields on `ActiveContextService`:
+ * that one is injected by the HTTP interceptor, and pulling the registry state
+ * (which itself depends on `HttpClient`) into it would make the interceptor's
+ * dependency graph cyclic.
+ */
+@Injectable({ providedIn: 'root' })
+export class ActiveDetectorService {
+  private readonly activeContext = inject(ActiveContextService);
+  private readonly datasetState = inject(DatasetStateService);
+
+  /** Detector id currently loaded into the backend (`''` when none). */
+  readonly activeId = toSignal(this.activeContext.modelId$, { initialValue: '' });
+
+  /** Detector id the user picked, which leads {@link activeId} for as long as
+   *  a context switch is still loading. */
+  readonly intentId = toSignal(this.activeContext.intentModelId$, { initialValue: '' });
+
+  /**
+   * The id to describe: the active detector, or — when nothing is active yet —
+   * the one being switched to, so the UI can name the user's pick immediately
+   * instead of blanking for the duration of the load.
+   */
+  readonly detectorId = computed(() => this.activeId() || this.intentId());
+
+  /** Registry entry for {@link detectorId}: null when nothing is selected, and
+   *  also while the registry fetch is still in flight. */
+  readonly detector = computed<DetectorRegistryEntry | null>(() => {
+    const id = this.detectorId();
+    if (!id) return null;
+    return this.datasetState.detectors.find((d) => d.id === id) ?? null;
+  });
+
+  /** Display name of the selected detector; `''` when unknown (nothing
+   *  selected, or the registry hasn't resolved the id yet). */
+  readonly detectorName = computed(() => this.detector()?.name ?? '');
+}


### PR DESCRIPTION
Fixes the regression @CarHorseBatteryStaple spotted on #2819: the fix shipped in #2820 was silently undone before it ever reached users.

## What happened

Not a merge-driver bug in the `dev` → `main` release (#2839) — that merge faithfully carried what `dev` already had. The loss happened on `dev`, 45 minutes after #2820 landed:

| | |
|---|---|
| `4c32669d` | **18:15** — *Expose the selected detector name as a signal (issue #2819)* — adds `ActiveDetectorService` + spec, moves export modal and Find view onto it |
| `57212b53` | **19:00** — *Progress bar: bounded shimmer zone for count-less phases* — deletes both service files, reverts both consumers to the old `detectors.find(...)` lookups |

`57212b53` was cut from a base predating `4c32669d`. When it was brought up to date, the conflicts in the three overlapping files were resolved by keeping the stale side wholesale, so a progress-bar commit quietly carried a full revert of an unrelated feature (`-250` lines it never mentions in its message). Nothing flagged it: the tests for the reverted behavior were deleted in the same motion, so the suite stayed green.

## The fix

- **Restored verbatim**: `active-detector.service.ts` and `active-detector.service.spec.ts` (byte-identical to #2820).
- **`export-modal.component.ts`**: `effectiveDetectorName` is a `computed` signal again, plus the constructor effect that re-applies the default filename when the detector name lands after the modal opened, guarded by `lastAutoFilename` so a user edit is never clobbered.
- **`find-view.component.ts`**: both call sites read `activeDetector.detectorName()`.
- **`export-modal.component.spec.ts`**: restored the three deleted default-filename tests.

Work that landed on these files *after* the revert is preserved — the `open_url` handling from #2855 in the export modal, and the `overall_step_end` threading from `57212b53` itself in the Find view. Verified by diffing each restored file against its #2820 version: the only differences are those later additions.

## Testing

`./run-tests.sh` — **ALL 7808 TESTS PASSED** (1 skipped, 2 xfailed). Frontend gate green: `build:prod` clean, `npm audit` 0 vulnerabilities, 1942 Vitest tests pass.

Refs #2819

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEX7s1dDgSe19rqp5CfASj

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEX7s1dDgSe19rqp5CfASj)_