### PR TITLE
Why region and binary voting want different κ: the curvature hypothesis, plus a runnable bench

### DIFF
--- a/docs/plans/region-vs-binary-kappa-mechanism.md
+++ b/docs/plans/region-vs-binary-kappa-mechanism.md
@@ -1,0 +1,213 @@
+# Why region voting and binary voting want different anchor masses
+
+**Open question behind #2864 · proposed experiments · a runnable synthetic
+bench (`scripts/experiments/calibration/theory_kappa_bench.py`) with
+preliminary results**
+
+## Background — the observation that has no explanation yet
+
+PR #2864's anchor-mass sweep established two things empirically and explained
+neither:
+
+- **Fusion pays on region voting and does not on binary voting.** Against the
+  blend that ships, `fold_anchored κ=0.3 mid` is −0.026 on region voting and
+  −0.0004 (n.s.) on binary; the shipped `κ=1 rate` is *+0.0063 worse* than
+  `cap50` on binary.
+- **The cut rule flips with κ, and κ\* differs by mode.** `mid` peaks near
+  κ=0.3 and `rate` near κ=1, the curves crossing at κ≈1–2.
+
+The report attributes the *rule* flip to mixture weights (`mid` ignores them,
+`rate` reads them, and anchor mass lets acquisition-biased prevalence into
+them) and attributes the *mode* split to positive counts (24 → −0.093, 8 →
+−0.019, 3 → −0.002). The positive-count story is a good predictor but it is
+not a mechanism: it says *when* fusion pays, not *why max over a set per image
+changes what the estimator wants*. That is the open question.
+
+Note also that #2864's design **confounds pooling with class separation**: its
+region environments (Visual Genome) are also its overlap-heavy ones, and its
+binary environments (COCO, caltech101) are its near-separable ones — binary
+x-cal FNR runs 0.04–0.06 against region's 0.18–0.28. Nothing in that design
+can say which of the two axes drives the split.
+
+## The hypothesis: max-pooling is an overlap generator, and overlap is curvature
+
+An image's score is `max` over its `m` region scores. Against the whole-image
+(`m=1`) geometry that operator does three things at once:
+
+- **Translates and compresses the negative bulk.** The max of `m` background
+  regions concentrates near `sqrt(2 ln m)` with shrinking spread (at `m=24`,
+  1.95 ± 0.51 against 0.00 ± 1.00). Negatives move *toward* the positives.
+- **Censors the positive lower tail.** A positive image's score is
+  `max(object, background)`, so a weak object is replaced by its own
+  background max. The positive class inherits the negative class's upper tail.
+- **Amplifies FPR `m`-fold.** `FPR(t) = 1 − Φ(t)^m`: every region gets an
+  independent chance to fire, so the same per-region threshold error costs `m`
+  times as much.
+
+All three push the same quantity up — the **curvature of the rate loss at its
+optimum**, `L''(τ*)`. In the closed-form model, `L''` goes 0.39 → 0.74 → 1.00
+across `m` = 1 → 6 → 24 at separation 3.
+
+Curvature is the bridge to κ, because regret is locally quadratic in threshold
+error:
+
+> **regret ≈ ½ · L''(τ*) · (τ̂ − τ*)²**
+
+So curvature is the exchange rate that converts threshold *imprecision* into
+cost. Where it is high, the estimator's **variance** dominates its bias, and
+the right move is to lean on the low-variance estimate — the 2000-sample
+haystack — and admit only a whisper of the high-variance, acquisition-biased
+label evidence. That is a **small κ**. Where curvature is low (`m=1`,
+separable), the valley floor is flat, threshold precision is nearly free, and
+the labels' *identification* value — knowing which component is which, and
+which quantile matters — is worth more than their variance costs. That is a
+**large κ**.
+
+This reframes the mode split as not really about voting mode at all. Voting
+mode is a *proxy* for where the task sits on the curvature axis, and #2864's
+design happens to have both of its axes (pooling, separation) pointing the
+same way.
+
+## Preliminary evidence — the synthetic bench, run 1
+
+`theory_kappa_bench.py` sweeps the **production estimators**
+(`fold_anchored_gmm_threshold`, `anchored_gmm_fit`,
+`threshold_from_fold_orderings`, `rank_transfer`, `blend_gmm_threshold`) over
+the #2836 closed-form generative model, so every cut is scored against the
+*exact* optimum rather than a held-out sample. Each replicate trains a 1-D
+logistic head on the votes plus one per calibration fold, so all three
+cross-calibration deficits (#2790/#2799: conformal sample size, fold→final
+scale transfer, per-retrain redraw) are present and priced.
+
+**Run 1: 96 configurations × 25 reps = 2400 replicates**, `m` ∈ {1, 6, 24} ×
+separation ∈ {2, 3} × prevalence ∈ {0.02, 0.05} × votes ∈ {20, 50, 100, 300} ×
+{random, hard} acquisition. Results in
+`scripts/experiments/calibration/` output dirs; the headline table is κ\* (fold
+family, `mid` rule, random votes):
+
+| κ\* by vote count | 20 | 50 | 100 | 300 |
+|---|---:|---:|---:|---:|
+| **m = 24** (region-like) | 0.1 | **0.01** | **0.01** | **0.01** |
+| **m = 1** (binary-like) | 10 | 1 | 0.3 | 0.03 |
+
+**At every vote count, the pooled geometry wants an anchor mass one to two
+decades smaller than the whole-image geometry.** That is the qualitative
+answer to "why does max over a set suggest a different κ setup": pooling
+raises curvature, curvature punishes variance, and κ is exactly the knob that
+buys label information at the price of variance. It also reproduces #2864's
+finding 3 (κ\* falls as votes accumulate) independently, in a model with no
+acquisition feedback and no real data.
+
+Broken out by separation, with curvature alongside (random votes, pooled):
+
+| config | curvature | κ\* | x-cal excess |
+|---|---:|---:|---:|
+| m=1, sep=3 | 0.388 | **1** | 0.043 |
+| m=1, sep=2 | 0.484 | 0.01 | 0.028 |
+| m=6, sep=2 / 3 | 0.739 / 0.740 | 0.01 / 0.03 | 0.031 / 0.040 |
+| m=24, sep=2 | 0.787 | 0.01 | 0.028 |
+| m=24, sep=3 | 1.003 | 0.01 | 0.035 |
+
+The lone configuration wanting a large κ is the one with the **lowest
+curvature**, and it is the most binary-like cell in the design (unpooled,
+separable). Consistent with the hypothesis — but see the caveats.
+
+**Three things run 1 did *not* confirm, stated plainly:**
+
+- **The fusion *advantage* did not grow with `m`** (0.032 / 0.034 / 0.030 for
+  m = 1 / 6 / 24). The naive form of the prediction — "pooling is what makes
+  fusion pay" — is **false** in this model. Fusion beats x-cal everywhere by a
+  similar margin; what changes with `m` is *which κ* you must use to get it.
+  So `m` moves κ\*, not the size of the prize. Any theory claiming pooling
+  explains #2864's *mode split in effect size* has to answer this.
+- **κ\* is censored at the grid bottom** for five of six cells (0.01 was the
+  lowest κ tested), so the curvature ordering is only partially observable and
+  the correlation of curvature with advantage is weak (r = 0.17).
+- **Hard acquisition inverted the prediction**: threshold-adjacent votes moved
+  κ\* *up* (to 3–10), not down, at every `m`. Under the `mid` rule that is
+  coherent — labels near the boundary are highly informative about *where the
+  boundary is*, and `mid` never reads the corrupted mixture weights — which
+  suggests #2864's acquisition-bias mechanism is specific to the weight-reading
+  `rate` rule. Worth testing directly rather than assuming.
+
+**Status: preliminary and not to be cited as a result.** Run 2 (extending κ
+down to 0.001 to uncensor the argmin, adding separations 4–5 to break the
+pooling/separation confound, adding the `cap50`/`slow_cap50` blend arms that
+fusion actually loses to, and a mixed rather than all-hard acquisition mode)
+completed 74 of 192 cells before the container running it was recycled. The
+bench checkpoints per configuration, so a rerun resumes.
+
+## Open work
+
+<!-- item-sep -->
+
+- **Run 2 of the synthetic bench to completion.** `python
+  theory_kappa_bench.py --reps 25 --procs <n>` — 192 configurations, single-
+  threaded per cell, ~30 CPU-minutes at 4 procs, no GPU, no dataset, no
+  prepare stage. Cells checkpoint to `cells/cfg_NNNN.csv` and resume, so it
+  can be chunked or restarted freely. The three questions it settles:
+  **(a)** where κ\* actually lands once the grid extends to 0.001, i.e.
+  whether the m=24 argmin is interior or the model genuinely wants
+  vanishing anchor mass; **(b)** whether **separation or pooling** is the
+  real driver, which #2864's design cannot separate and this one can, since
+  it crosses `m` ∈ {1, 6, 24} with separation ∈ {2, 3, 4, 5} — the decisive
+  contrast is `m=24, sep=5` (pooled but separable) against `m=1, sep=2`
+  (unpooled but overlapping); **(c)** whether fusion loses to `cap50` in the
+  near-separable cells, which is the real-data result the mechanism has to
+  reproduce to be believed at all. Falsifier: if κ\* tracks separation and
+  ignores `m`, the max-pooling story is wrong and "curvature" reduces to
+  "class overlap", which is a simpler and more useful statement.
+
+<!-- item-sep -->
+
+- **Curvature as the shipped gate, if it survives.** The practical payoff of
+  the mechanism is a gate that is *measurable at run time*. `L''(τ*)` is not
+  observable, but the fitted mixture is: the two components' separation and
+  the density at the cut are both available from `GmmFit1D` at zero extra
+  cost, and either is a candidate proxy. This would replace #2864's
+  recommendation 3 ("gate on positives") with a gate on the quantity the
+  positives were standing in for — and unlike the positive count, it does not
+  need labels to evaluate. Only worth designing after run 2 says whether
+  curvature is the right axis.
+
+<!-- item-sep -->
+
+- **The causal test on real data.** The synthetic bench can only show the
+  mechanism is *sufficient* in a model. To show it operates in production,
+  vary `m` while holding the dataset, embedder and votes fixed: re-pool an
+  existing patch-embedder region environment at `m` ∈ {1, 4, 24} (top-1 vs
+  top-k vs all regions — the harness already has `segment_topk_mean_pool` and
+  the `_repool_variants` machinery from #2781) and re-run the κ sweep on each.
+  A real-data κ\* that falls with `m` on the *same* images is the causal claim;
+  #2864's cross-dataset comparison cannot make it. This is the expensive one
+  (GPU prepare + a full cell array) and should wait on run 2.
+
+<!-- item-sep -->
+
+- **Separate the acquisition-bias mechanism from the cut rule.** Run 1's hard
+  mode moved κ\* the *opposite* way #2864's mechanism predicts, but only the
+  `mid` rule was examined closely. Compare `mid` and `rate` under matched
+  acquisition: if the corrupted-weights story is right, `rate` should degrade
+  under hard acquisition while `mid` improves, and the κ\* crossover should
+  move with it. Cheap — it is a re-analysis of run 2's existing rows, since
+  both rules are already emitted per cell.
+
+## Reproduction
+
+The bench is self-contained: no dataset, no embedder, no models, no
+`prepare` stage. It needs `numpy`, `scipy`, `scikit-learn`, `pandas` and the
+`vtscore` import path that `common.setup_env()` sets up.
+
+```bash
+cd scripts/experiments/calibration
+VTS_REPO=<worktree> CALIB_EXP=<scratch> \
+  python theory_kappa_bench.py --reps 25 --procs 16 --out <results>
+```
+
+`--smoke` runs six configurations for sizing. `--no-resume` re-runs cells that
+already exist. The self-check (`selfcheck()`, run before every sweep) asserts
+the sampled scores reproduce the closed-form `FPR`/`FNR` at three thresholds,
+so a broken generative model fails loudly rather than producing a plausible
+wrong curve. Outputs: `kappa_raw.csv` (one row per replicate),
+`kappa_by_config.csv`, `kappa_curve_{fold,label}_mid.csv`, and
+`kappa_summary.json` (the P1–P4 verdicts).

--- a/scripts/experiments/calibration/theory_kappa_bench.py
+++ b/scripts/experiments/calibration/theory_kappa_bench.py
@@ -1,0 +1,495 @@
+"""Anchored-κ estimator study on the known-truth region model (#2864 follow-up).
+
+The #2864 anchor-mass sweep found, empirically, that the fused threshold is a
+clear win on **region voting** and a wash-to-loss on **binary voting**, with a
+small interior κ* on region environments and a flat, meaningless κ curve on
+binary ones.  This bench tests the proposed *mechanism* on the closed-form
+generative model :mod:`theory_bench` built for #2836, where the truth is exact:
+
+    An image's score is the max over its ``m`` regions.  The max operator is an
+    **overlap generator**: it translates the negative bulk up by ~sqrt(2 ln m)
+    and compresses it, censors the positive lower tail at the background max,
+    and amplifies FPR sensitivity m-fold.  All three raise the curvature
+    ``L''(tau*)`` of the rate loss at the optimum.  Since regret ~
+    0.5 * L'' * (tau_hat - tau*)^2, curvature converts threshold *imprecision*
+    into cost: at m = 1 the optimum sits in a flat valley and every estimator
+    ties; at m = 24 precise cut *location* dominates, so the low-variance
+    population estimator wins and the labels' biased, high-variance authority
+    must be kept small - hence a small κ*.
+
+Where :mod:`theory_bench` swept cut *rules* on a fixed fit, this bench sweeps
+the *estimators*, reproducing the production stack in 1-D miniature.  Each
+replicate trains a regularized 1-D logistic head on the votes (the trained
+score *scale* production fits its mixtures on) plus one head per calibration
+fold, so the three structural deficits of cross-calibration (#2790/#2799:
+conformal sample size, fold-to-final scale transfer, per-retrain redraw) all
+exist here and can be priced against the exact optimum.  A first cut of this
+bench skipped the trained heads and scored a conformal quantile of honest
+votes on the *raw* score scale - and that arm beat every mixture even at
+m = 24, which is itself a finding: the conformal rule's real-data losses are
+not a bare sample-size effect but come from the scale deficits the fold
+machinery exists to repair, amplified by the max operator's curvature.  The
+``conformal_true_scale`` arm keeps that decomposition measurable.
+
+Arms (all production code paths from :mod:`vtscore.training.thresholds`):
+
+* ``xcal_only`` - :func:`threshold_from_fold_orderings` on the fold heads'
+  held-out vote scores: the pure cross-calibration estimator, fold-scale
+  deficit included.
+* ``conformal_true_scale`` - the same conformal rule on the *final* head's
+  vote scores: sample-size deficit only (not shippable - a diagnostic bound).
+* ``rank_transfer`` - the x-cal cut carried to the final scale as a quantile:
+  repairs scale transfer only.
+* ``unanchored_{mid,rate}`` - :func:`fit_score_gmm` on the final head's sim
+  scores: the κ -> 0 population-only limit.
+* ``fold_w{κ}_{mid,rate}`` - :func:`fold_anchored_gmm_threshold`, the shipped
+  fusion estimator, per anchor mass κ.
+* ``label_w{κ}_{mid,rate}`` - :func:`anchored_gmm_fit` anchoring on the final
+  head's scores of the voted items (train-set anchors, the #2852 label family).
+
+Every cut is inverted through the final head and scored on the **closed-form
+true loss**, so excess is measured against the exact optimum with no held-out
+sample noise.
+
+Pre-registered predictions (checked and printed by :func:`check_predictions`):
+
+* **P1** - the fusion advantage (``xcal_only`` excess minus best fold-anchored
+  excess) grows with ``m`` and is smallest at ``m = 1``.
+* **P2** - the κ curve is flat at ``m = 1``; at ``m >= 6`` it has an interior
+  optimum whose argmin falls as the vote count grows.
+* **P3** - across configurations, the fusion advantage tracks the true-loss
+  curvature ``L''(tau*)`` (curvature as the mediating variable, also ordering
+  configurations *within* each ``m``).
+* **P4** - threshold-adjacent ("hard") vote acquisition shifts κ* down
+  relative to random votes at high ``m``.
+
+Usage: ``python theory_kappa_bench.py [--reps 25] [--procs 4] [--smoke]``
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+from multiprocessing import Pool
+from pathlib import Path
+
+import common
+
+common.setup_env()
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from vtscore.training.thresholds import (  # noqa: E402
+    anchored_gmm_fit,
+    conformal_threshold,
+    fit_score_gmm,
+    fold_anchored_gmm_threshold,
+    gmm_cut_from_fit,
+    rank_transfer,
+    threshold_from_fold_orderings,
+)
+
+#: Region counts. 1 = the whole-image (binary-voting) control; 24 ~ the
+#: production patch grid's usable region count (matches theory_bench).
+M_VALUES: tuple[int, ...] = (1, 6, 24)
+#: Class separation in per-region logit units.
+SEPARATIONS: tuple[float, ...] = (2.0, 3.0)
+#: Positive-class prevalence of the sim population.
+PREVALENCES: tuple[float, ...] = (0.02, 0.05)
+#: Sim-set (haystack) size - the real fit populations were 419-2476.
+SIM_N: int = 2000
+#: Vote counts, spanning the #2864 windows.
+VOTE_COUNTS: tuple[int, ...] = (20, 50, 100, 300)
+#: Fraction of votes that are positive (~ the deep-regime environments'
+#: 7-24 positives per ~176 votes).
+POS_VOTE_FRAC: float = 0.1
+#: Vote acquisition modes: iid class samples vs threshold-adjacent picks
+#: (Autopilot's Hard phase, modelled as nearest-to-tau* from a 5x pool).
+VOTE_MODES: tuple[str, ...] = ("random", "hard")
+HARD_POOL_FACTOR: int = 5
+#: Anchor masses. Spans #2864's grid and extends one decade up to keep the
+#: label-anchored trap visible.
+KAPPAS: tuple[float, ...] = (0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0)
+RULES: tuple[str, ...] = ("mid", "rate")
+#: Calibration folds, matching production's ``calibrate_count``.
+N_FOLDS: int = 2
+
+MU_BAD = 0.0
+SD_BAD = 1.0
+SD_GOOD = 1.0
+#: Inclusion 0 cost weights - the setting every #2864 arm was scored at.
+FPR_WEIGHT = 1.0
+FNR_WEIGHT = 1.0
+INCLUSION = 0
+
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def _logit(p: float) -> float:
+    p = min(max(p, 1e-12), 1.0 - 1e-12)
+    return float(np.log(p) - np.log1p(-p))
+
+
+def _normal_cdf(x: np.ndarray, mu: float, sd: float) -> np.ndarray:
+    from scipy.special import ndtr  # noqa: PLC0415
+
+    return ndtr((x - mu) / sd)
+
+
+def true_loss(t_logit: np.ndarray, m: int, mu_good: float) -> np.ndarray:
+    """Exact rate loss at each raw-logit threshold (theory_bench's model)."""
+    phi_bad = _normal_cdf(t_logit, MU_BAD, SD_BAD)
+    phi_good = _normal_cdf(t_logit, mu_good, SD_GOOD)
+    fpr = 1.0 - phi_bad**m
+    fnr = phi_good * phi_bad ** (m - 1)
+    return FPR_WEIGHT * fpr + FNR_WEIGHT * fnr
+
+
+def population_optimum(m: int, mu_good: float) -> tuple[float, float, float]:
+    """``(tau*_logit, min_loss, curvature L'')`` on a fine grid."""
+    grid = np.linspace(MU_BAD - 6.0 * SD_BAD, mu_good + 6.0 * SD_GOOD, 20_001)
+    loss = true_loss(grid, m, mu_good)
+    i = int(np.argmin(loss))
+    tau, lmin = float(grid[i]), float(loss[i])
+    h = 0.05
+    lpp = float(
+        (true_loss(np.array([tau + h]), m, mu_good)[0] - 2.0 * lmin + true_loss(np.array([tau - h]), m, mu_good)[0])
+        / h**2
+    )
+    return tau, lmin, lpp
+
+
+def _class_logits(rng: np.random.Generator, n: int, m: int, mu_good: float, positive: bool) -> np.ndarray:
+    """*n* raw image logits (max over regions) drawn from one class."""
+    bad = rng.normal(MU_BAD, SD_BAD, size=(n, m))
+    logits = bad.max(axis=1)
+    if positive:
+        obj = rng.normal(mu_good, SD_GOOD, size=n)
+        others = bad[:, 1:].max(axis=1) if m > 1 else np.full(n, -np.inf)
+        logits = np.maximum(obj, others)
+    return logits
+
+
+def sample_population(
+    rng: np.random.Generator, n: int, m: int, prevalence: float, mu_good: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """``(raw logits, labels)`` for a mixed-population sample of *n* images."""
+    labels = (rng.random(n) < prevalence).astype(np.float64)
+    n_pos = int(labels.sum())
+    logits = _class_logits(rng, n, m, mu_good, positive=False)
+    if n_pos:
+        logits[labels == 1.0] = _class_logits(rng, n_pos, m, mu_good, positive=True)
+    return logits, labels
+
+
+def sample_votes(
+    rng: np.random.Generator, n_votes: int, m: int, mu_good: float, tau_star_logit: float, mode: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """``(raw vote logits, labels)`` under an acquisition *mode*.
+
+    ``random`` draws each class iid.  ``hard`` draws a :data:`HARD_POOL_FACTOR`
+    times larger pool per class and keeps the votes nearest the true optimum -
+    a stateless stand-in for Autopilot's Hard phase, which samples items
+    adjacent to the current threshold.
+    """
+    n_pos = max(2, round(POS_VOTE_FRAC * n_votes))
+    n_neg = n_votes - n_pos
+    pos = _class_logits(rng, n_pos * (HARD_POOL_FACTOR if mode == "hard" else 1), m, mu_good, positive=True)
+    neg = _class_logits(rng, n_neg * (HARD_POOL_FACTOR if mode == "hard" else 1), m, mu_good, positive=False)
+    if mode == "hard":
+        pos = pos[np.argsort(np.abs(pos - tau_star_logit))[:n_pos]]
+        neg = neg[np.argsort(np.abs(neg - tau_star_logit))[:n_neg]]
+    elif mode != "random":
+        raise ValueError(f"unknown vote mode {mode!r}")
+    return np.concatenate([pos, neg]), np.concatenate([np.ones(n_pos), np.zeros(n_neg)])
+
+
+def _fit_head(x: np.ndarray, y: np.ndarray) -> tuple[float, float] | None:
+    """Regularized 1-D logistic head ``score = sigmoid(a*x + c)``; ``None`` if degenerate.
+
+    The miniature of production's trained head: it cannot change the ranking
+    (1-D, monotone for ``a > 0``) but it *learns the score scale* the mixture
+    estimators fit on and the conformal rule cuts on - which is exactly the
+    part of the system the threshold estimators are sensitive to.  ``a <= 0``
+    (possible under heavy overlap with few votes) is reported as degenerate
+    rather than silently flipping the ranking.
+    """
+    from sklearn.linear_model import LogisticRegression  # noqa: PLC0415
+
+    if len(np.unique(y)) < 2:
+        return None
+    clf = LogisticRegression(C=1.0)
+    clf.fit(x.reshape(-1, 1), y)
+    a = float(clf.coef_[0][0])
+    c = float(clf.intercept_[0])
+    if not (np.isfinite(a) and np.isfinite(c)) or a <= 0.0:
+        return None
+    return a, c
+
+
+def _head_scores(head: tuple[float, float], x: np.ndarray) -> np.ndarray:
+    a, c = head
+    return _sigmoid(a * x + c)
+
+
+def _fold_split(labels: np.ndarray) -> list[np.ndarray]:
+    """Deterministic 2-fold split, both classes represented in each fold."""
+    folds: list[list[int]] = [[] for _ in range(N_FOLDS)]
+    for cls in (1.0, 0.0):
+        for j, idx in enumerate(np.flatnonzero(labels == cls)):
+            folds[j % N_FOLDS].append(int(idx))
+    return [np.asarray(f, dtype=np.int64) for f in folds]
+
+
+def evaluate_config(
+    rng: np.random.Generator, m: int, separation: float, prevalence: float, n_votes: int, vote_mode: str
+) -> dict:
+    """One replicate: every estimator on one (sim sample, vote set, trained heads)."""
+    mu_good = MU_BAD + separation
+    tau_star, best_loss, curvature = population_optimum(m, mu_good)
+
+    sim_logits, _sim_labels = sample_population(rng, SIM_N, m, prevalence, mu_good)
+    vote_logits, vote_labels = sample_votes(rng, n_votes, m, mu_good, tau_star, vote_mode)
+
+    row: dict = {
+        "m": m,
+        "separation": separation,
+        "prevalence": prevalence,
+        "n_votes": n_votes,
+        "n_pos": int(vote_labels.sum()),
+        "vote_mode": vote_mode,
+        "tau_star_logit": tau_star,
+        "best_loss": best_loss,
+        "curvature": curvature,
+        "degenerate_head": 0,
+    }
+
+    final = _fit_head(vote_logits, vote_labels)
+    fold_idx = _fold_split(vote_labels)
+    fold_heads = []
+    for k in range(N_FOLDS):
+        train = np.concatenate([fold_idx[j] for j in range(N_FOLDS) if j != k])
+        fold_heads.append(_fit_head(vote_logits[train], vote_labels[train]))
+    if final is None or any(h is None for h in fold_heads):
+        row["degenerate_head"] = 1
+        return row
+
+    a, c = final
+    sim_final = _head_scores(final, sim_logits)
+    fold_haystacks = [np.asarray(_head_scores(h, sim_logits), dtype=np.float64) for h in fold_heads]
+    fold_orderings = [
+        (_head_scores(h, vote_logits[fold_idx[k]]).tolist(), vote_labels[fold_idx[k]].tolist())
+        for k, h in enumerate(fold_heads)
+    ]
+
+    def score(name: str, threshold_sigmoid: float) -> None:
+        """Excess true loss of cutting the *final* head's scores at this threshold."""
+        if not np.isfinite(threshold_sigmoid) or not 0.0 < threshold_sigmoid < 1.0:
+            row[f"excess_{name}"] = float("nan")
+            return
+        t_raw = (_logit(float(threshold_sigmoid)) - c) / a
+        row[f"excess_{name}"] = float(true_loss(np.array([t_raw]), m, mu_good)[0] - best_loss)
+
+    xcal = threshold_from_fold_orderings(fold_orderings, INCLUSION)
+    score("xcal_only", xcal)
+    score("rank_transfer", rank_transfer(xcal, np.concatenate(fold_haystacks), sim_final))
+    score(
+        "conformal_true_scale",
+        conformal_threshold(_head_scores(final, vote_logits).tolist(), vote_labels.tolist(), INCLUSION),
+    )
+
+    fit = fit_score_gmm(sim_final)
+    for rule in RULES:
+        score(f"unanchored_{rule}", gmm_cut_from_fit(fit, rule, FPR_WEIGHT, FNR_WEIGHT)[0] if fit else float("nan"))
+
+    anchor_scores = _head_scores(final, vote_logits).tolist()
+    for kappa in KAPPAS:
+        for rule in RULES:
+            thr, provenance = fold_anchored_gmm_threshold(
+                fold_haystacks, fold_orderings, sim_final, INCLUSION, anchor_weight=kappa, cut_rule=rule
+            )
+            if rule == RULES[0]:
+                row[f"fold_fallback_w{kappa:g}"] = 0 if provenance.startswith("fold_anchored") else 1
+            score(f"fold_w{kappa:g}_{rule}", thr)
+        lfit, lprov = anchored_gmm_fit(sim_final, anchor_scores, vote_labels.tolist(), anchor_weight=kappa)
+        for rule in RULES:
+            score(
+                f"label_w{kappa:g}_{rule}",
+                gmm_cut_from_fit(lfit, rule, FPR_WEIGHT, FNR_WEIGHT)[0] if lfit else float("nan"),
+            )
+    return row
+
+
+def selfcheck() -> None:
+    """The sampled scores must reproduce the closed-form rates (planted truth)."""
+    rng = np.random.default_rng(7)
+    m, sep = 6, 3.0
+    n = 200_000
+    pos = _class_logits(rng, n, m, sep, positive=True)
+    neg = _class_logits(rng, n, m, sep, positive=False)
+    for t in (1.0, 2.0, 2.5):
+        fpr_emp, fnr_emp = float((neg >= t).mean()), float((pos < t).mean())
+        phi_bad = _normal_cdf(np.array([t]), MU_BAD, SD_BAD)[0]
+        phi_good = _normal_cdf(np.array([t]), sep, SD_GOOD)[0]
+        fpr_true, fnr_true = 1.0 - phi_bad**m, phi_good * phi_bad ** (m - 1)
+        if abs(fpr_emp - fpr_true) > 0.01 or abs(fnr_emp - fnr_true) > 0.01:
+            raise AssertionError(
+                f"selfcheck failed at t={t}: empirical ({fpr_emp:.4f}, {fnr_emp:.4f}) "
+                f"vs closed-form ({fpr_true:.4f}, {fnr_true:.4f})"
+            )
+    common.log("selfcheck passed: sampled rates match the closed form")
+
+
+def _run_one_config(task: tuple[int, tuple[int, float, float, int, str], int]) -> list[dict]:
+    """All reps for one configuration (one worker task)."""
+    cfg_i, (m, sep, prev, n_votes, mode), reps = task
+    rng = np.random.default_rng(np.random.SeedSequence(entropy=22864, spawn_key=(cfg_i,)))
+    return [evaluate_config(rng, m, sep, prev, n_votes, mode) for _ in range(reps)]
+
+
+def run_sweep(reps: int, procs: int, smoke: bool = False) -> pd.DataFrame:
+    grid = list(itertools.product(M_VALUES, SEPARATIONS, PREVALENCES, VOTE_COUNTS, VOTE_MODES))
+    if smoke:
+        grid = [g for g in grid if g[1] == 3.0 and g[2] == 0.02 and g[3] == 100]
+    tasks = [(i, cfg, reps) for i, cfg in enumerate(grid)]
+    common.log(f"kappa bench: {len(grid)} configurations x {reps} reps = {len(grid) * reps} replicates, {procs} procs")
+    rows: list[dict] = []
+    if procs <= 1:
+        for i, task in enumerate(tasks):
+            rows.extend(_run_one_config(task))
+            common.log(f"  {i + 1}/{len(tasks)} configurations")
+    else:
+        with Pool(procs) as pool:
+            for i, config_rows in enumerate(pool.imap_unordered(_run_one_config, tasks)):
+                rows.extend(config_rows)
+                if (i + 1) % 8 == 0:
+                    common.log(f"  {i + 1}/{len(tasks)} configurations")
+    return pd.DataFrame(rows)
+
+
+def _kappa_curve(df: pd.DataFrame, family: str, rule: str) -> pd.DataFrame:
+    """Mean excess per (m, n_votes, vote_mode, κ) for one estimator family+rule."""
+    records = []
+    for (m, n_votes, mode), sub in df.groupby(["m", "n_votes", "vote_mode"]):
+        for kappa in KAPPAS:
+            records.append(
+                {
+                    "m": m,
+                    "n_votes": n_votes,
+                    "vote_mode": mode,
+                    "kappa": kappa,
+                    "excess": float(sub[f"excess_{family}_w{kappa:g}_{rule}"].mean()),
+                }
+            )
+    return pd.DataFrame(records)
+
+
+def check_predictions(df: pd.DataFrame, outdir: Path) -> dict:
+    """Evaluate P1-P4 and write the tidy aggregates they are read from."""
+    n_total = len(df)
+    df = df[df["degenerate_head"] == 0].copy()
+    dropped = n_total - len(df)
+
+    fold_cols = [f"excess_fold_w{k:g}_{r}" for k in KAPPAS for r in RULES]
+    base_cols = [
+        "excess_xcal_only",
+        "excess_rank_transfer",
+        "excess_conformal_true_scale",
+        "excess_unanchored_mid",
+        "excess_unanchored_rate",
+    ]
+    label_cols = [f"excess_label_w{k:g}_{r}" for k in KAPPAS for r in RULES]
+
+    keys = ["m", "separation", "prevalence", "n_votes", "vote_mode"]
+    by_config = df.groupby(keys)[[*base_cols, *fold_cols, *label_cols, "curvature"]].mean().reset_index()
+    by_config["best_fold"] = by_config[fold_cols].min(axis=1)
+    by_config["advantage"] = by_config["excess_xcal_only"] - by_config["best_fold"]
+    by_config.to_csv(outdir / "kappa_by_config.csv", index=False)
+
+    curve = _kappa_curve(df, "fold", "mid")
+    curve.to_csv(outdir / "kappa_curve_fold_mid.csv", index=False)
+    _kappa_curve(df, "label", "mid").to_csv(outdir / "kappa_curve_label_mid.csv", index=False)
+
+    # P1: advantage vs m (random votes).
+    rnd_cfg = by_config[by_config["vote_mode"] == "random"]
+    p1 = {str(int(m)): float(rnd_cfg[rnd_cfg["m"] == m]["advantage"].mean()) for m in M_VALUES}
+
+    # P2: κ-curve spread by m, and argmin κ by n at the largest m (fold mid,
+    # random votes - the recommended family).
+    rnd = curve[curve["vote_mode"] == "random"]
+    p2_spread = {}
+    for m in M_VALUES:
+        sub = rnd[rnd["m"] == m].groupby("kappa")["excess"].mean()
+        p2_spread[str(int(m))] = float(sub.max() - sub.min())
+    p2_argmin = {}
+    for n_votes, sub in rnd[rnd["m"] == max(M_VALUES)].groupby("n_votes"):
+        p2_argmin[str(int(n_votes))] = float(sub.set_index("kappa")["excess"].idxmin())
+
+    # P3: does curvature explain the advantage across all configs, and within m?
+    finite = by_config.dropna(subset=["advantage", "curvature"])
+    p3_corr = float(np.corrcoef(finite["curvature"], finite["advantage"])[0, 1]) if len(finite) > 2 else float("nan")
+    p3_within = {}
+    for m in M_VALUES:
+        sub = finite[finite["m"] == m]
+        if len(sub) > 2 and sub["curvature"].std() > 0:
+            p3_within[str(int(m))] = float(np.corrcoef(sub["curvature"].rank(), sub["advantage"].rank())[0, 1])
+
+    # P4: argmin κ under hard vs random votes at each m (fold mid, pooled n).
+    p4 = {}
+    for m in M_VALUES:
+        entry = {}
+        for mode in VOTE_MODES:
+            s = curve[(curve["m"] == m) & (curve["vote_mode"] == mode)].groupby("kappa")["excess"].mean()
+            entry[mode] = float(s.idxmin())
+        p4[str(int(m))] = entry
+
+    # Deficit decomposition at the biggest m (random votes): what each repair buys.
+    big = rnd_cfg[rnd_cfg["m"] == max(M_VALUES)]
+    decomposition = {
+        col.removeprefix("excess_"): float(big[col].mean())
+        for col in [*base_cols, "excess_fold_w0.3_mid", "best_fold"]
+        if col in big
+    }
+
+    fallback_rate = {f"{k:g}": float(df[f"fold_fallback_w{k:g}"].mean()) for k in KAPPAS}
+    return {
+        "n_replicates": int(n_total),
+        "n_degenerate_heads_dropped": int(dropped),
+        "p1_advantage_by_m": p1,
+        "p2_kappa_spread_by_m": p2_spread,
+        "p2_argmin_kappa_by_n_at_max_m": p2_argmin,
+        "p3_curvature_advantage_corr": p3_corr,
+        "p3_within_m_rank_corr": p3_within,
+        "p4_argmin_kappa_by_mode": p4,
+        "decomposition_at_max_m_random": decomposition,
+        "fold_fallback_rate_by_kappa": fallback_rate,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reps", type=int, default=25, help="replicates per configuration")
+    parser.add_argument("--procs", type=int, default=4, help="worker processes")
+    parser.add_argument("--smoke", action="store_true", help="tiny grid, for sizing")
+    parser.add_argument("--out", default=str(common.RESULTS / "theory_kappa"))
+    args = parser.parse_args(argv)
+
+    outdir = Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    selfcheck()
+    df = run_sweep(args.reps, args.procs, smoke=args.smoke)
+    df.to_csv(outdir / "kappa_raw.csv", index=False)
+    summary = check_predictions(df, outdir)
+    (outdir / "kappa_summary.json").write_text(json.dumps(summary, indent=2, default=float))
+    common.log(f"kappa bench complete -> {outdir}")
+    common.log(json.dumps(summary, indent=2, default=float))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/calibration/theory_kappa_bench.py
+++ b/scripts/experiments/calibration/theory_kappa_bench.py
@@ -376,31 +376,66 @@ def selfcheck() -> None:
     common.log("selfcheck passed: sampled rates match the closed form")
 
 
-def _run_one_config(task: tuple[int, tuple[int, float, float, int, str], int]) -> list[dict]:
-    """All reps for one configuration (one worker task)."""
-    cfg_i, (m, sep, prev, n_votes, mode), reps = task
+def _cell_path(outdir: Path, cfg_i: int) -> Path:
+    return outdir / "cells" / f"cfg_{cfg_i:04d}.csv"
+
+
+def _run_one_config(task: tuple[int, tuple[int, float, float, int, str], int, str]) -> str:
+    """All reps for one configuration, written to its own cell file.
+
+    Each configuration checkpoints itself so a killed run resumes instead of
+    losing everything: the sweep is ~30 minutes and a mid-run interruption used
+    to discard 184 of 192 completed configurations.  The cell is written to a
+    temp path and renamed, so a kill during the write cannot leave a truncated
+    file that resume would count as done.
+    """
+    cfg_i, (m, sep, prev, n_votes, mode), reps, out = task
+    path = _cell_path(Path(out), cfg_i)
     rng = np.random.default_rng(np.random.SeedSequence(entropy=22864, spawn_key=(cfg_i,)))
-    return [evaluate_config(rng, m, sep, prev, n_votes, mode) for _ in range(reps)]
+    rows = [evaluate_config(rng, m, sep, prev, n_votes, mode) for _ in range(reps)]
+    tmp = path.with_suffix(".csv.tmp")
+    pd.DataFrame(rows).to_csv(tmp, index=False)
+    tmp.rename(path)
+    return str(path)
 
 
-def run_sweep(reps: int, procs: int, smoke: bool = False) -> pd.DataFrame:
+def run_sweep(reps: int, procs: int, outdir: Path, smoke: bool = False, resume: bool = True) -> pd.DataFrame:
     grid = list(itertools.product(M_VALUES, SEPARATIONS, PREVALENCES, VOTE_COUNTS, VOTE_MODES))
     if smoke:
         grid = [g for g in grid if g[1] == 3.0 and g[2] == 0.02 and g[3] == 100]
-    tasks = [(i, cfg, reps) for i, cfg in enumerate(grid)]
-    common.log(f"kappa bench: {len(grid)} configurations x {reps} reps = {len(grid) * reps} replicates, {procs} procs")
-    rows: list[dict] = []
+    (outdir / "cells").mkdir(parents=True, exist_ok=True)
+
+    # A zero-byte cell is debris from a kill mid-write, not a completed cell.
+    done = {
+        i
+        for i in range(len(grid))
+        if resume and _cell_path(outdir, i).exists() and _cell_path(outdir, i).stat().st_size > 0
+    }
+    for i in range(len(grid)):
+        p = _cell_path(outdir, i)
+        if p.exists() and i not in done:
+            p.unlink()
+    tasks = [(i, cfg, reps, str(outdir)) for i, cfg in enumerate(grid) if i not in done]
+    common.log(
+        f"kappa bench: {len(grid)} configurations x {reps} reps = {len(grid) * reps} replicates, "
+        f"{procs} procs ({len(done)} cells already done, {len(tasks)} to run)"
+    )
+
     if procs <= 1:
         for i, task in enumerate(tasks):
-            rows.extend(_run_one_config(task))
+            _run_one_config(task)
             common.log(f"  {i + 1}/{len(tasks)} configurations")
     else:
         with Pool(procs) as pool:
-            for i, config_rows in enumerate(pool.imap_unordered(_run_one_config, tasks)):
-                rows.extend(config_rows)
+            for i, _ in enumerate(pool.imap_unordered(_run_one_config, tasks)):
                 if (i + 1) % 8 == 0:
                     common.log(f"  {i + 1}/{len(tasks)} configurations")
-    return pd.DataFrame(rows)
+
+    cells = sorted((outdir / "cells").glob("cfg_*.csv"))
+    missing = len(grid) - len(cells)
+    if missing:
+        common.log(f"WARNING: {missing} of {len(grid)} cells missing; analysing the {len(cells)} present")
+    return pd.concat([pd.read_csv(c) for c in cells], ignore_index=True)
 
 
 def _kappa_curve(df: pd.DataFrame, family: str, rule: str) -> pd.DataFrame:
@@ -524,6 +559,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--reps", type=int, default=25, help="replicates per configuration")
     parser.add_argument("--procs", type=int, default=4, help="worker processes")
     parser.add_argument("--smoke", action="store_true", help="tiny grid, for sizing")
+    parser.add_argument("--no-resume", action="store_true", help="re-run every cell instead of reusing cells/")
     parser.add_argument("--out", default=str(common.RESULTS / "theory_kappa"))
     args = parser.parse_args(argv)
 
@@ -531,7 +567,7 @@ def main(argv: list[str] | None = None) -> int:
     outdir.mkdir(parents=True, exist_ok=True)
 
     selfcheck()
-    df = run_sweep(args.reps, args.procs, smoke=args.smoke)
+    df = run_sweep(args.reps, args.procs, outdir, smoke=args.smoke, resume=not args.no_resume)
     df.to_csv(outdir / "kappa_raw.csv", index=False)
     summary = check_predictions(df, outdir)
     (outdir / "kappa_summary.json").write_text(json.dumps(summary, indent=2, default=float))

--- a/scripts/experiments/calibration/theory_kappa_bench.py
+++ b/scripts/experiments/calibration/theory_kappa_bench.py
@@ -54,17 +54,32 @@ Every cut is inverted through the final head and scored on the **closed-form
 true loss**, so excess is measured against the exact optimum with no held-out
 sample noise.
 
-Pre-registered predictions (checked and printed by :func:`check_predictions`):
+Pre-registered predictions (checked and printed by :func:`check_predictions`).
+Run 1 (2400 replicates, m x {2,3} separation) already **refuted P1 and P4**;
+they are kept unchanged so the second run scores the same stated predictions
+rather than ones retrofitted to the first run's answer:
 
 * **P1** - the fusion advantage (``xcal_only`` excess minus best fold-anchored
   excess) grows with ``m`` and is smallest at ``m = 1``.
+  *Run 1: REFUTED* - flat in ``m`` (0.032 / 0.034 / 0.030).  Pooling moves
+  which κ wins, not the size of the prize.
 * **P2** - the κ curve is flat at ``m = 1``; at ``m >= 6`` it has an interior
   optimum whose argmin falls as the vote count grows.
+  *Run 1: PARTIAL* - argmin falls with votes at both ``m`` (reproducing
+  #2864's finding 3 with no acquisition feedback), and is 1-2 decades lower
+  at ``m = 24`` than at ``m = 1`` at every vote count - but it is censored at
+  the grid's bottom edge, which is why :data:`KAPPAS` now reaches 0.001.
 * **P3** - across configurations, the fusion advantage tracks the true-loss
   curvature ``L''(tau*)`` (curvature as the mediating variable, also ordering
   configurations *within* each ``m``).
+  *Run 1: WEAK* (r = 0.17), unreadable while the argmin is censored.
 * **P4** - threshold-adjacent ("hard") vote acquisition shifts κ* down
   relative to random votes at high ``m``.
+  *Run 1: REFUTED, and inverted* - hard votes moved κ* **up** (to 3-10) at
+  every ``m``.  Coherent under the ``mid`` rule, which never reads the
+  mixture weights that acquisition bias corrupts: boundary-adjacent labels
+  are highly informative about where the boundary is.  This suggests #2864's
+  acquisition-bias mechanism is specific to the weight-reading ``rate`` rule.
 
 Usage: ``python theory_kappa_bench.py [--reps 25] [--procs 4] [--smoke]``
 """

--- a/scripts/experiments/calibration/theory_kappa_bench.py
+++ b/scripts/experiments/calibration/theory_kappa_bench.py
@@ -42,6 +42,9 @@ Arms (all production code paths from :mod:`vtscore.training.thresholds`):
   repairs scale transfer only.
 * ``unanchored_{mid,rate}`` - :func:`fit_score_gmm` on the final head's sim
   scores: the κ -> 0 population-only limit.
+* ``blend_{cap50,slow_cap50}`` - :func:`blend_gmm_threshold` on the shipped
+  per-mode schedules: the pre-#2861 production blends the real data ranks
+  fusion against (``cap50`` beats fusion on binary voting there).
 * ``fold_w{κ}_{mid,rate}`` - :func:`fold_anchored_gmm_threshold`, the shipped
   fusion estimator, per anchor mass κ.
 * ``label_w{κ}_{mid,rate}`` - :func:`anchored_gmm_fit` anchoring on the final
@@ -81,8 +84,10 @@ common.setup_env()
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
 
+from vtscore.training.blend_schedules import BlendContext  # noqa: E402
 from vtscore.training.thresholds import (  # noqa: E402
     anchored_gmm_fit,
+    blend_gmm_threshold,
     conformal_threshold,
     fit_score_gmm,
     fold_anchored_gmm_threshold,
@@ -94,8 +99,13 @@ from vtscore.training.thresholds import (  # noqa: E402
 #: Region counts. 1 = the whole-image (binary-voting) control; 24 ~ the
 #: production patch grid's usable region count (matches theory_bench).
 M_VALUES: tuple[int, ...] = (1, 6, 24)
-#: Class separation in per-region logit units.
-SEPARATIONS: tuple[float, ...] = (2.0, 3.0)
+#: Class separation in per-region logit units.  2-3 are overlap-heavy (the
+#: region-voting regime); 4-5 are near-separable - the analog of the real
+#: *binary* environments, whose x-cal FNR runs 0.04-0.06.  The real #2864
+#: design confounds pooling with achieved separation (its region environments
+#: are also its overlappy ones); crossing m with separation is what lets this
+#: bench split them.
+SEPARATIONS: tuple[float, ...] = (2.0, 3.0, 4.0, 5.0)
 #: Positive-class prevalence of the sim population.
 PREVALENCES: tuple[float, ...] = (0.02, 0.05)
 #: Sim-set (haystack) size - the real fit populations were 419-2476.
@@ -105,13 +115,17 @@ VOTE_COUNTS: tuple[int, ...] = (20, 50, 100, 300)
 #: Fraction of votes that are positive (~ the deep-regime environments'
 #: 7-24 positives per ~176 votes).
 POS_VOTE_FRAC: float = 0.1
-#: Vote acquisition modes: iid class samples vs threshold-adjacent picks
-#: (Autopilot's Hard phase, modelled as nearest-to-tau* from a 5x pool).
+#: Vote acquisition modes: iid class samples vs Autopilot-like mixed
+#: acquisition (half iid, half nearest-tau* from a 5x pool - the Hard phase is
+#: only one of Autopilot's phases; an all-hard vote set makes ~half the 1-D
+#: heads degenerate at 20 votes, a selection bias run 1 of this bench hit).
 VOTE_MODES: tuple[str, ...] = ("random", "hard")
 HARD_POOL_FACTOR: int = 5
-#: Anchor masses. Spans #2864's grid and extends one decade up to keep the
-#: label-anchored trap visible.
-KAPPAS: tuple[float, ...] = (0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0)
+HARD_FRACTION: float = 0.5
+#: Anchor masses. Spans #2864's grid, extended one decade up (the
+#: label-anchored trap) and one down (at 300 votes the argmin fell to run 1's
+#: bottom edge).
+KAPPAS: tuple[float, ...] = (0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0)
 RULES: tuple[str, ...] = ("mid", "rate")
 #: Calibration folds, matching production's ``calibrate_count``.
 N_FOLDS: int = 2
@@ -191,20 +205,25 @@ def sample_votes(
 ) -> tuple[np.ndarray, np.ndarray]:
     """``(raw vote logits, labels)`` under an acquisition *mode*.
 
-    ``random`` draws each class iid.  ``hard`` draws a :data:`HARD_POOL_FACTOR`
-    times larger pool per class and keeps the votes nearest the true optimum -
-    a stateless stand-in for Autopilot's Hard phase, which samples items
-    adjacent to the current threshold.
+    ``random`` draws each class iid.  ``hard`` draws :data:`HARD_FRACTION` of
+    each class as the nearest-to-tau* picks from a :data:`HARD_POOL_FACTOR`
+    times larger pool (Autopilot's Hard phase) and the rest iid (its other
+    phases) - a stateless stand-in for threshold-adjacent acquisition.
     """
     n_pos = max(2, round(POS_VOTE_FRAC * n_votes))
     n_neg = n_votes - n_pos
-    pos = _class_logits(rng, n_pos * (HARD_POOL_FACTOR if mode == "hard" else 1), m, mu_good, positive=True)
-    neg = _class_logits(rng, n_neg * (HARD_POOL_FACTOR if mode == "hard" else 1), m, mu_good, positive=False)
-    if mode == "hard":
-        pos = pos[np.argsort(np.abs(pos - tau_star_logit))[:n_pos]]
-        neg = neg[np.argsort(np.abs(neg - tau_star_logit))[:n_neg]]
-    elif mode != "random":
-        raise ValueError(f"unknown vote mode {mode!r}")
+
+    def draw(n: int, positive: bool) -> np.ndarray:
+        if mode == "random":
+            return _class_logits(rng, n, m, mu_good, positive)
+        if mode != "hard":
+            raise ValueError(f"unknown vote mode {mode!r}")
+        n_hard = round(HARD_FRACTION * n)
+        pool = _class_logits(rng, max(n_hard, 1) * HARD_POOL_FACTOR, m, mu_good, positive)
+        hard = pool[np.argsort(np.abs(pool - tau_star_logit))[:n_hard]]
+        return np.concatenate([hard, _class_logits(rng, n - n_hard, m, mu_good, positive)])
+
+    pos, neg = draw(n_pos, positive=True), draw(n_neg, positive=False)
     return np.concatenate([pos, neg]), np.concatenate([np.ones(n_pos), np.zeros(n_neg)])
 
 
@@ -306,6 +325,19 @@ def evaluate_config(
     for rule in RULES:
         score(f"unanchored_{rule}", gmm_cut_from_fit(fit, rule, FPR_WEIGHT, FNR_WEIGHT)[0] if fit else float("nan"))
 
+    # The shipped pre-fusion blends (#2841/#2849): conformal x-cal averaged
+    # with the unanchored mid cut on the per-mode schedule.  ``cap50`` is what
+    # binary voting had before #2861 - the arm the real data says fusion loses
+    # to there - and ``slow_cap50`` its region counterpart.
+    if fit is not None:
+        ctx = BlendContext(n_labels=n_votes, n_good=int(vote_labels.sum()), n_bad=int((1.0 - vote_labels).sum()))
+        mid_cut = gmm_cut_from_fit(fit, "mid", FPR_WEIGHT, FNR_WEIGHT)[0]
+        for schedule in ("cap50", "slow_cap50"):
+            score(f"blend_{schedule}", blend_gmm_threshold(xcal, mid_cut, ctx, schedule=schedule))
+    else:
+        row["excess_blend_cap50"] = float("nan")
+        row["excess_blend_slow_cap50"] = float("nan")
+
     anchor_scores = _head_scores(final, vote_logits).tolist()
     for kappa in KAPPAS:
         for rule in RULES:
@@ -401,6 +433,8 @@ def check_predictions(df: pd.DataFrame, outdir: Path) -> dict:
         "excess_conformal_true_scale",
         "excess_unanchored_mid",
         "excess_unanchored_rate",
+        "excess_blend_cap50",
+        "excess_blend_slow_cap50",
     ]
     label_cols = [f"excess_label_w{k:g}_{r}" for k in KAPPAS for r in RULES]
 
@@ -455,6 +489,20 @@ def check_predictions(df: pd.DataFrame, outdir: Path) -> dict:
         if col in big
     }
 
+    # The real-data mode split, reproduced or not: fusion-vs-blend by
+    # separation (random votes, pooled m/prev/n).  The #2864 ranking to match:
+    # blend ahead of fusion on near-separable ("binary") configs, fusion ahead
+    # where classes overlap ("region").
+    ranking_by_separation = {}
+    for sep in SEPARATIONS:
+        sub = rnd_cfg[rnd_cfg["separation"] == sep]
+        ranking_by_separation[f"{sep:g}"] = {
+            "xcal_only": float(sub["excess_xcal_only"].mean()),
+            "blend_cap50": float(sub["excess_blend_cap50"].mean()),
+            "fold_w0.3_mid": float(sub["excess_fold_w0.3_mid"].mean()),
+            "best_fold": float(sub["best_fold"].mean()),
+        }
+
     fallback_rate = {f"{k:g}": float(df[f"fold_fallback_w{k:g}"].mean()) for k in KAPPAS}
     return {
         "n_replicates": int(n_total),
@@ -465,6 +513,7 @@ def check_predictions(df: pd.DataFrame, outdir: Path) -> dict:
         "p3_curvature_advantage_corr": p3_corr,
         "p3_within_m_rank_corr": p3_within,
         "p4_argmin_kappa_by_mode": p4,
+        "ranking_by_separation": ranking_by_separation,
         "decomposition_at_max_m_random": decomposition,
         "fold_fallback_rate_by_kappa": fallback_rate,
     }


### PR DESCRIPTION
#2864 established the region/binary split empirically and explained neither half. This proposes a mechanism, ships a bench that tests it against a *known* optimum, and reports what its first run already refutes.

## The hypothesis

`max` over `m` regions is an **overlap generator**. It translates the negative bulk up by ~`sqrt(2 ln m)` and compresses it, censors the positive lower tail at the background max, and amplifies FPR `m`-fold. All three raise **`L''(τ*)`, the curvature of the rate loss at its optimum** (0.39 → 0.74 → 1.00 across m = 1 → 6 → 24 at separation 3).

Curvature is the bridge to κ, because `regret ≈ ½·L''(τ*)·(τ̂ − τ*)²`. It is the exchange rate converting threshold *imprecision* into cost. Where it is high, estimator **variance** dominates bias: lean on the 2000-sample haystack, admit only a whisper of high-variance label evidence → **small κ**. Where it is low, the valley floor is flat, precision is nearly free, and the labels' *identification* value outweighs their variance → **large κ**.

Under this reading the mode split is not about voting mode. Voting mode is a proxy for position on the curvature axis — and #2864's design has both of its axes pointing the same way, since its region environments are also its overlap-heavy ones (binary x-cal FNR 0.04–0.06 vs region 0.18–0.28). No cross-dataset comparison can separate them.

## Preliminary evidence (2400 replicates)

`theory_kappa_bench.py` sweeps the **production** estimators over #2836's closed-form model, scoring every cut against the exact optimum. Each replicate trains a 1-D logistic head plus one per fold, so all three cross-calibration deficits are present and priced.

κ\* (fold family, `mid`, random votes):

| κ\* by vote count | 20 | 50 | 100 | 300 |
|---|---:|---:|---:|---:|
| **m = 24** (region-like) | 0.1 | **0.01** | **0.01** | **0.01** |
| **m = 1** (binary-like) | 10 | 1 | 0.3 | 0.03 |

**At every vote count the pooled geometry wants an anchor mass one to two decades smaller.** It also reproduces #2864's finding 3 (κ\* falls with votes) in a model with no acquisition feedback and no real data. The one configuration wanting large κ is the lowest-curvature, most binary-like cell (m=1, sep=3).

## What run 1 refuted

- **P1 is false.** The fusion *advantage* is flat in `m` (0.032 / 0.034 / 0.030). Pooling moves *which κ wins*, not the size of the prize — so pooling alone cannot explain #2864's mode split in effect size.
- **P4 is inverted.** Hard acquisition moved κ\* *up* (3–10), not down. Coherent under `mid`, which never reads the weights acquisition bias corrupts — suggesting #2864's acquisition-bias mechanism is specific to the weight-reading `rate` rule.
- κ\* is **censored** at the grid's bottom edge in 5 of 6 cells, so the curvature correlation (r = 0.17) is not yet readable.

These are recorded unchanged in the bench docstring so a second run scores the same stated predictions rather than ones retrofitted to the first run's answer.

## Why this is a plan and not a result

Run 2 — κ down to 0.001, separations 4–5 to break the pooling/separation confound, the `cap50` blend arms fusion actually loses to — completed 74 of 192 cells before the container running it was recycled. Cloud containers are the wrong place for this. The bench now checkpoints per configuration and resumes, and needs no dataset, embedder, GPU or prepare stage: ~30 CPU-minutes at 4 procs.

The decisive contrast it can make and #2864 cannot: **`m=24, sep=5` (pooled but separable) against `m=1, sep=2` (unpooled but overlapping)**. If κ\* tracks separation and ignores `m`, the max-pooling story is wrong and "curvature" reduces to "class overlap" — a simpler and more useful statement.

Remaining open work (in the plan): finishing run 2; curvature as a *runtime-measurable* gate, replacing #2864's "gate on positives" with the quantity the positives were standing in for; the causal real-data test that re-pools one environment at m ∈ {1, 4, 24} rather than comparing datasets; and separating the acquisition-bias mechanism from the cut rule.

## Testing

`./run-tests.sh` — **ALL 7808 TESTS PASSED** (1 skipped, 1 xfailed). No production code touched: one new experiment script, one new plan.

Refs #2864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRRszCtWbrG5miHe4L5dAk)_