### PR TITLE
Make autopilot's post-training return to the Dashboard idle-only

### DIFF
--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.spec.ts
@@ -352,7 +352,7 @@ describe('AutopilotPanelComponent', () => {
       expect(t.message).toContain('Done!');
       expect(t.countdown).toBeTruthy();
       expect(t.countdown!.label).toContain('Dashboard');
-      expect(t.countdown!.remaining).toBe(5);
+      expect(t.countdown!.remaining).toBe(10);
       expect(t.action!.label).toBe('Stay here');
     });
 
@@ -361,7 +361,7 @@ describe('AutopilotPanelComponent', () => {
       reachDone();
 
       await vi.advanceTimersByTimeAsync(2000);
-      expect(toasts.toasts[0].countdown!.remaining).toBe(3);
+      expect(toasts.toasts[0].countdown!.remaining).toBe(8);
     });
 
     it('navigates to the Dashboard when the countdown runs out', async () => {
@@ -370,13 +370,117 @@ describe('AutopilotPanelComponent', () => {
       const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
       reachDone();
 
-      await vi.advanceTimersByTimeAsync(4000);
+      await vi.advanceTimersByTimeAsync(9000);
       expect(navigate).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(1000);
       expect(navigate).toHaveBeenCalledWith(['/dashboard']);
       // The toast is gone by the time the view changes.
+      expect(navigate).toHaveBeenCalledTimes(1);
       expect(toasts.toasts.length).toBe(0);
+    });
+
+    it('calls off the return as soon as the user clicks anything', async () => {
+      vi.useFakeTimers();
+      const router = TestBed.inject(Router);
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      reachDone();
+
+      // The reported bug: the user goes straight on to export their detector
+      // and the redirect fires mid-click, looking like a broken export.
+      document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('calls off the return on a keystroke too', async () => {
+      vi.useFakeTimers();
+      const router = TestBed.inject(Router);
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      reachDone();
+
+      document.body.dispatchEvent(new Event('keydown', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('keeps the news on screen when interaction cancels the return', async () => {
+      vi.useFakeTimers();
+      reachDone();
+
+      document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+      // The "Done!" headline survives — just without the countdown, the escape
+      // button, and any suggestion the user is about to be moved.
+      const [t] = toasts.toasts;
+      expect(t.message).toContain('Done!');
+      expect(t.countdown).toBeUndefined();
+      expect(t.action).toBeUndefined();
+      expect(t.detail).toContain('Staying here');
+
+      // ...and it then clears itself on the ordinary success timer.
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(toasts.toasts.length).toBe(0);
+    });
+
+    it('leaves the toast alone when the interaction is with the toast itself', async () => {
+      vi.useFakeTimers();
+      reachDone();
+
+      // The toast stack lives outside this fixture, so stand in for it with an
+      // element carrying the class the guard looks for.
+      const stack = document.createElement('div');
+      stack.className = 'toast-stack';
+      const btn = document.createElement('button');
+      stack.appendChild(btn);
+      document.body.appendChild(stack);
+      try {
+        btn.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+        expect(toasts.toasts[0].countdown).toBeTruthy();
+      } finally {
+        document.body.removeChild(stack);
+      }
+    });
+
+    it('does not re-arm the countdown when the user returns to the Train window', async () => {
+      vi.useFakeTimers();
+      const router = TestBed.inject(Router);
+      const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      reachDone();
+      expect(toasts.toasts.length).toBe(1);
+
+      // Leaving drops the toast; the autopilot run itself keeps going.
+      fixture.destroy();
+      expect(toasts.toasts.length).toBe(0);
+
+      // Coming back rebuilds the panel. The hand-off was already offered once,
+      // so it must not start counting down again — that is what made the
+      // redirect feel like it was chasing the user around.
+      const revisit = TestBed.createComponent(AutopilotPanelComponent);
+      revisit.componentRef.setInput('goodVotes', new Set([1, 2, 3, 4, 5]));
+      revisit.componentRef.setInput('badVotes', new Set([11, 12, 13, 14, 15]));
+      revisit.componentRef.setInput('labelingStatus', ALL_GREEN);
+      TestBed.tick();
+
+      expect(toasts.toasts.length).toBe(0);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('offers the hand-off again on a genuinely new autopilot run', async () => {
+      vi.useFakeTimers();
+      reachDone();
+      expect(toasts.toasts.length).toBe(1);
+      toasts.dismissAll();
+
+      // Stopping and restarting autopilot is a new run, not a return visit.
+      component.deactivate();
+      component.activate();
+      reachDone();
+
+      expect(toasts.toasts[0].countdown!.remaining).toBe(10);
     });
 
     it('stays in the Train window when the escape button is used', async () => {
@@ -390,7 +494,7 @@ describe('AutopilotPanelComponent', () => {
       t.action!.onClick();
       toasts.dismiss(t.id);
 
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(30_000);
       expect(navigate).not.toHaveBeenCalled();
     });
 
@@ -419,9 +523,9 @@ describe('AutopilotPanelComponent', () => {
       TestBed.tick();
       expect(component.state.phase).toBe('exhausted');
       expect(toasts.toasts[0].message).toContain('Done!');
-      expect(toasts.toasts[0].countdown!.remaining).toBe(5);
+      expect(toasts.toasts[0].countdown!.remaining).toBe(10);
 
-      await vi.advanceTimersByTimeAsync(5000);
+      await vi.advanceTimersByTimeAsync(10_000);
       expect(navigate).toHaveBeenCalledWith(['/dashboard']);
     });
   });

--- a/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
+++ b/frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts
@@ -41,11 +41,24 @@ export interface StepDisplay {
 }
 
 /**
- * Seconds the completion toast counts down before returning the user to the
- * Dashboard. Long enough to read the headline and reach the "Stay here"
- * button, short enough that a user who is done doesn't sit waiting.
+ * Seconds the completion toast counts down before returning an *idle* user to
+ * the Dashboard. Long enough to notice the toast, read it, and reach the "Stay
+ * here" button while looking somewhere else on the page; short enough that a
+ * user who is genuinely finished doesn't sit waiting.
+ *
+ * The countdown only ever runs while the user is idle (see
+ * ``armInteractionCancel``), so erring long costs nothing: the moment they do
+ * anything, the return is called off regardless of how much time was left.
  */
-const RETURN_COUNTDOWN_SECONDS = 5;
+const RETURN_COUNTDOWN_SECONDS = 10;
+
+/**
+ * Replaces the toast's detail line once user interaction calls off the pending
+ * auto-return, so the toast the user is looking at states plainly that it is no
+ * longer going to move them.
+ */
+const RETURN_CANCELLED_NOTE =
+  'Staying here — export your detector or keep labeling. Head back to the Dashboard whenever you like.';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -85,10 +98,12 @@ export class AutopilotPanelComponent implements OnInit, OnDestroy {
   readonly toggleCollapse = output<void>();
   readonly refocus = output<void>();
 
-  private completionAlerted = false;
   /** Id of the live completion toast, or ``null`` when none is showing. Kept
    *  so leaving the Train window cancels the pending auto-return. */
   private completionToastId: number | null = null;
+  /** Tears down the document-level interaction listeners that call off a
+   *  pending auto-return, or ``null`` when none are armed. */
+  private disarmInteraction: (() => void) | null = null;
 
   constructor() {
     // Signal inputs don't fire ``ngOnChanges``; this effect replaces the old
@@ -110,7 +125,7 @@ export class AutopilotPanelComponent implements OnInit, OnDestroy {
       const prevPhase = this.autopilotState.state.phase;
       this.autopilotState.checkPhaseTransition(goodVotes.size, badVotes.size, datasetSize);
       const phase = this.autopilotState.state.phase;
-      if (prevPhase !== phase && !this.completionAlerted) {
+      if (prevPhase !== phase && !this.autopilotState.completionAlreadyAnnounced) {
         if (phase === 'done') {
           this.announceCompletion('Done! Your detector is trained.');
         } else if (phase === 'exhausted') {
@@ -199,10 +214,15 @@ export class AutopilotPanelComponent implements OnInit, OnDestroy {
    * A bare "Done!" leaves the user parked in the Train window with no next
    * step, so the toast says where they are being taken and when — and carries
    * a "Stay here" button for the user who wants to keep labeling instead.
-   * Dismissing the toast by any means cancels the return.
+   * Dismissing the toast by any means cancels the return, as does touching
+   * anything else on the page (see ``armInteractionCancel``).
+   *
+   * The offer is made once per autopilot run: the "already announced" flag
+   * lives on ``AutopilotStateService``, so returning to the Train window does
+   * not re-arm a countdown the user has already escaped.
    */
   private announceCompletion(message: string, detail?: string): void {
-    this.completionAlerted = true;
+    this.autopilotState.markCompletionAnnounced();
     this.completionToastId = this.toastService.success({
       message,
       detail,
@@ -215,20 +235,71 @@ export class AutopilotPanelComponent implements OnInit, OnDestroy {
         label: 'Stay here',
         title: 'Stay in the Train window and keep labeling',
         onClick: () => {
+          this.disarmInteractionCancel();
           this.completionToastId = null;
         },
       },
     });
+    this.armInteractionCancel();
+  }
+
+  /**
+   * Make the pending auto-return conditional on the user staying idle.
+   *
+   * Training finishing is not the same thing as the *user* being finished:
+   * someone who goes straight on to export their detector is mid-task, and
+   * navigating out from under them reads as the export being broken rather
+   * than as a redirect they missed. So the countdown only survives while
+   * nothing else is happening — the first click or keystroke anywhere outside
+   * the toast itself calls the return off for good.
+   *
+   * Events from inside the toast stack are excluded so the toast's own "Stay
+   * here" and dismiss buttons keep working normally: cancelling on their
+   * ``pointerdown`` would pull them out of the DOM before the click landed.
+   */
+  private armInteractionCancel(): void {
+    this.disarmInteractionCancel();
+    const onInteract = (ev: Event): void => {
+      const target = ev.target;
+      if (target instanceof Element && target.closest('.toast-stack')) return;
+      this.cancelReturnOnInteraction();
+    };
+    document.addEventListener('pointerdown', onInteract, true);
+    document.addEventListener('keydown', onInteract, true);
+    this.disarmInteraction = () => {
+      document.removeEventListener('pointerdown', onInteract, true);
+      document.removeEventListener('keydown', onInteract, true);
+    };
+  }
+
+  private disarmInteractionCancel(): void {
+    this.disarmInteraction?.();
+    this.disarmInteraction = null;
+  }
+
+  /**
+   * Drop the pending return but keep the toast: the user who just clicked
+   * something may never have read the "Done!" headline, and silently removing
+   * it would lose the one piece of news worth telling them.
+   */
+  private cancelReturnOnInteraction(): void {
+    const id = this.completionToastId;
+    this.disarmInteractionCancel();
+    this.completionToastId = null;
+    if (id === null) return;
+    this.toastService.cancelCountdown(id, RETURN_CANCELLED_NOTE);
   }
 
   private returnToDashboard(): void {
     // Cleared first so the ``ngOnDestroy`` that the navigation triggers does
     // not try to dismiss an already-dismissed toast.
     this.completionToastId = null;
+    this.disarmInteractionCancel();
     void this.router.navigate(['/dashboard']);
   }
 
   private cancelCompletionToast(): void {
+    this.disarmInteractionCancel();
     if (this.completionToastId === null) return;
     this.toastService.dismiss(this.completionToastId);
     this.completionToastId = null;
@@ -236,7 +307,6 @@ export class AutopilotPanelComponent implements OnInit, OnDestroy {
 
   activate(): void {
     if (this.running) return;
-    this.completionAlerted = false;
     this.cancelCompletionToast();
     // Retrain mode: the detector already has good+bad labels (carried over
     // from a previous dataset), so learned sort is available immediately and

--- a/frontend/src/app/components/toast-container/toast-container.component.html
+++ b/frontend/src/app/components/toast-container/toast-container.component.html
@@ -14,7 +14,12 @@
       </div>
     }
     @for (t of toasts; track trackById($index, t)) {
-    <div class="toast" [class.toast--success]="t.level === 'success'" role="alert">
+    <div
+      class="toast"
+      [class.toast--success]="t.level === 'success'"
+      [class.toast--countdown]="!!t.countdown"
+      role="alert"
+    >
       <div class="toast__main">
         @if (t.level === 'success') {
           <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -37,6 +42,12 @@
                  screen reader; the toast's role="alert" already read the line once. -->
             <div class="toast__countdown" aria-live="off">
               {{ cd.label }} <span class="toast__countdown-seconds">{{ cd.remaining }}</span>&hellip;
+            </div>
+            <!-- Draining bar: the countdown's second-by-second text is easy to
+                 miss when the user's attention is elsewhere on the page, so the
+                 same information is also carried by a moving shape. -->
+            <div class="toast__countdown-track" aria-hidden="true">
+              <div class="toast__countdown-bar" [style.width.%]="(cd.remaining / cd.total) * 100"></div>
             </div>
           }
         </div>

--- a/frontend/src/app/components/toast-container/toast-container.component.scss
+++ b/frontend/src/app/components/toast-container/toast-container.component.scss
@@ -61,6 +61,14 @@
       border-color: var(--color-good);
     }
   }
+
+  // A toast that is about to *do* something (navigate, discard) is not the same
+  // class of message as "here is some news", so it carries more weight: a wider
+  // accent edge and a deeper shadow lift it off the page behind it.
+  &.toast--countdown {
+    border-left-width: 6px;
+    box-shadow: var(--shadow-lg);
+  }
 }
 
 @keyframes toast-slide-in {
@@ -104,15 +112,37 @@
 // Live "this is about to happen" line, e.g. "Taking you back to the Dashboard
 // in 3…". Ticks once a second, so the seconds sit in a tabular-numeral span to
 // stop the trailing ellipsis jittering as the digit changes.
+//
+// Set at body size rather than the --font-xs used by .toast__detail: a line
+// that announces the page is about to navigate out from under the user has to
+// out-shout the message it sits below, or it reads as decoration and the
+// navigation lands as a bug.
 .toast__countdown {
-  margin-top: var(--space-2xs);
+  margin-top: var(--space-xs);
   color: var(--text-primary);
-  font-size: var(--font-xs);
+  font-size: var(--font-md);
+  font-weight: var(--weight-medium);
 }
 
 .toast__countdown-seconds {
   font-variant-numeric: tabular-nums;
   font-weight: var(--weight-semibold);
+}
+
+.toast__countdown-track {
+  margin-top: var(--space-2xs);
+  height: 4px;
+  border-radius: var(--radius-sm);
+  background: var(--border-subtle);
+  overflow: hidden;
+}
+
+.toast__countdown-bar {
+  height: 100%;
+  background: var(--color-good);
+  // Matches the one-second tick, so the bar slides continuously instead of
+  // stepping — motion in the corner of the eye is what gets noticed.
+  transition: width 1s linear;
 }
 
 .toast__actions {

--- a/frontend/src/app/components/toast-container/toast-container.component.spec.ts
+++ b/frontend/src/app/components/toast-container/toast-container.component.spec.ts
@@ -96,6 +96,70 @@ describe('ToastContainerComponent', () => {
       expect(line().textContent).toContain('4');
     });
 
+    it('drains a progress bar alongside the seconds', async () => {
+      vi.useFakeTimers();
+      toast.success({
+        message: 'Done!',
+        countdown: { label: 'Leaving in', seconds: 4, onExpire: () => {} },
+      });
+      TestBed.tick();
+
+      const bar = () => fixture.nativeElement.querySelector('.toast__countdown-bar');
+      expect(bar().style.width).toBe('100%');
+
+      await vi.advanceTimersByTimeAsync(1000);
+      TestBed.tick();
+      expect(bar().style.width).toBe('75%');
+    });
+
+    it('marks a countdown toast so it can be styled more loudly', async () => {
+      vi.useFakeTimers();
+      toast.success({ message: 'Just news' });
+      toast.success({
+        message: 'Done!',
+        countdown: { label: 'Leaving in', seconds: 4, onExpire: () => {} },
+      });
+      TestBed.tick();
+
+      const toastEls = fixture.nativeElement.querySelectorAll('.toast');
+      expect(toastEls[0].classList).not.toContain('toast--countdown');
+      expect(toastEls[1].classList).toContain('toast--countdown');
+    });
+
+    it('cancelCountdown keeps the message but drops the timer and the escape', async () => {
+      vi.useFakeTimers();
+      const onExpire = vi.fn();
+      const id = toast.success({
+        message: 'Done!',
+        detail: 'original detail',
+        countdown: { label: 'Leaving in', seconds: 5, onExpire },
+        action: { label: 'Stay here', onClick: () => {} },
+      });
+      TestBed.tick();
+
+      toast.cancelCountdown(id, 'Staying put.');
+      TestBed.tick();
+
+      expect(fixture.nativeElement.querySelector('.toast__countdown')).toBeNull();
+      expect(fixture.nativeElement.querySelector('.toast__btn--primary')).toBeNull();
+      expect(fixture.nativeElement.querySelector('.toast__title').textContent).toContain('Done!');
+      expect(fixture.nativeElement.querySelector('.toast__detail').textContent).toContain('Staying put.');
+
+      // The pending action never runs, and the toast falls back to the normal
+      // success auto-dismiss rather than lingering forever.
+      await vi.advanceTimersByTimeAsync(10_000);
+      TestBed.tick();
+      expect(onExpire).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.querySelector('.toast')).toBeNull();
+    });
+
+    it('cancelCountdown is a no-op for a toast that has no countdown', () => {
+      vi.useFakeTimers();
+      const id = toast.success({ message: 'Just news' });
+      toast.cancelCountdown(id, 'ignored');
+      expect(toast.toasts[0].detail).toBeUndefined();
+    });
+
     it('runs the expiry handler once the countdown empties, then drops the toast', async () => {
       vi.useFakeTimers();
       const onExpire = vi.fn();

--- a/frontend/src/app/services/autopilot-state.service.ts
+++ b/frontend/src/app/services/autopilot-state.service.ts
@@ -39,6 +39,19 @@ export class AutopilotStateService {
 
   readonly state$ = this.stateSubject.asObservable();
 
+  /**
+   * Whether the terminal-phase hand-off (the "Done!" toast and its auto-return
+   * countdown) has already fired for the current autopilot run.
+   *
+   * This lives on the service rather than on the panel component on purpose:
+   * the panel is destroyed and rebuilt every time the user leaves and re-enters
+   * the Train window, so a component-scoped flag re-arms the countdown on each
+   * return and keeps yanking a user who has come back precisely because they
+   * wanted to stay. The hand-off is offered once per run; declining it (or
+   * simply coming back) is final.
+   */
+  private completionAnnounced = false;
+
   get state(): AutopilotState {
     return this.stateSubject.value;
   }
@@ -47,8 +60,19 @@ export class AutopilotStateService {
     return this.stateSubject.value.phase !== 'idle';
   }
 
+  /** See {@link completionAnnounced}. */
+  get completionAlreadyAnnounced(): boolean {
+    return this.completionAnnounced;
+  }
+
+  /** Record that the completion hand-off has been offered for this run. */
+  markCompletionAnnounced(): void {
+    this.completionAnnounced = true;
+  }
+
   activate(retrainMode = false): void {
     if (this.running) return;
+    this.completionAnnounced = false;
     this.stateSubject.next({
       ...this.stateSubject.value,
       phase: 'good',
@@ -142,6 +166,7 @@ export class AutopilotStateService {
   }
 
   clear(): void {
+    this.completionAnnounced = false;
     this.stateSubject.next({ ...INITIAL_STATE });
   }
 }

--- a/frontend/src/app/services/toast.service.ts
+++ b/frontend/src/app/services/toast.service.ts
@@ -218,6 +218,40 @@ export class ToastService {
   }
 
   /**
+   * Call off a toast's pending countdown *without* dismissing the toast.
+   *
+   * The countdown line and the escape action disappear and ``onExpire`` never
+   * runs; what stays is an ordinary notification carrying the original
+   * headline, which then auto-dismisses on the usual timer. Pass ``note`` to
+   * replace the detail line with an explanation of why the pending action was
+   * called off.
+   *
+   * This is the hook for cancelling from *outside* the toast: the countdown's
+   * own buttons already cancel by dismissing, but a caller that watches the
+   * page behind the toast (e.g. "the user started clicking things, so don't
+   * navigate away from under them") wants to drop the timer while leaving the
+   * message the user may not have read yet.
+   */
+  cancelCountdown(id: number, note?: string): void {
+    const list = this.toastsSubject.value;
+    const idx = list.findIndex((t) => t.id === id);
+    if (idx < 0 || !list[idx].countdown) return;
+    this.clearTimer(id);
+    const next = list.slice();
+    next[idx] = {
+      ...list[idx],
+      countdown: undefined,
+      action: undefined,
+      detail: note ?? list[idx].detail,
+    };
+    this.toastsSubject.next(next);
+    this.autoDismissTimers.set(
+      id,
+      setTimeout(() => this.dismiss(id), SUCCESS_AUTO_DISMISS_MS),
+    );
+  }
+
+  /**
    * Advance one countdown by a second. Emits a replacement toast object each
    * tick so ``OnPush`` renderers repaint the remaining seconds. At zero the
    * toast is dismissed *before* ``onExpire`` runs, so a handler that navigates


### PR DESCRIPTION
Finishing autopilot training fired a 5-second countdown toast that navigated to the Dashboard whether or not the user was still working. A user who went straight on to export their detector got moved mid-click, several times over — the export looked broken when it was really the redirect — and coming back to the Train window re-armed the countdown.

Three changes, one per failure mode in the report ("too subtle, too fast, too persistent"):

**Idle-only.** The countdown now survives only while the user is idle. The first `pointerdown` or `keydown` outside the toast calls the return off for good. Training finishing is not the same as the *user* being finished; if they're clicking things, they're mid-task. This is the part that actually fixes the reported symptom — the export can no longer be interrupted, regardless of how long the timer is.

The toast itself stays, minus its countdown and its "Stay here" button, with a note saying it is no longer going to move them. The "Done!" headline is the one piece of news worth keeping on screen, and the user who just clicked something may never have read it. Events originating inside `.toast-stack` are excluded so the toast's own buttons keep working — cancelling on their `pointerdown` would pull them out of the DOM before the click landed.

**Offered once per run.** The "already announced" flag moves from `AutopilotPanelComponent` to `AutopilotStateService`. The panel is destroyed and rebuilt every time the user leaves and re-enters the Train window, so a component-scoped flag re-armed the countdown on each return — chasing a user who had come back precisely because they wanted to stay. A genuinely new autopilot run (stop → start) offers it again.

**Harder to miss.** 10 seconds instead of 5; the countdown line at body size (`--font-md`) rather than the `--font-xs` used for supporting detail; a draining progress bar beneath it, so the information is carried by motion and not only by a digit; and a wider accent edge plus `--shadow-lg` on any toast carrying a pending action.

Adds `ToastService.cancelCountdown(id, note?)`: cancels a countdown from *outside* the toast while leaving the message in place, and hands the toast back to the ordinary success auto-dismiss timer. The countdown's own buttons already cancel by dismissing; this is for a caller watching the page behind the toast.

### Files

- `frontend/src/app/services/toast.service.ts` — `cancelCountdown`
- `frontend/src/app/services/autopilot-state.service.ts` — run-scoped `completionAnnounced` flag
- `frontend/src/app/components/left-panel/autopilot-panel/autopilot-panel.component.ts` — 10s, interaction listeners, one-shot hand-off
- `frontend/src/app/components/toast-container/` — draining bar, louder countdown line, `.toast--countdown`

### Testing

`./run-tests.sh` — ALL 7808 TESTS PASSED (1 skipped, 1 xfailed); frontend gate 1952 passed, no build warnings.

New frontend tests cover: cancellation on click and on keystroke, the surviving message and its note, the toast-stack exclusion, no re-arm on returning to the Train window, re-arm on a new run, the draining bar, the `.toast--countdown` marker, and `cancelCountdown` (both the live-countdown and no-op paths).

No screenshot reshoot needed — no manifest shot frames a completion toast, and the autopilot panel's own markup is unchanged.

Closes #2870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rqFtcDQRcWbK9uVwPjKGp