### PR TITLE
REMEASURE-2846: point the surviving tail-alpha thread at its issue (#2881)

### DIFF
--- a/docs/experiments/gmm-cut/REMEASURE-2846.md
+++ b/docs/experiments/gmm-cut/REMEASURE-2846.md
@@ -195,7 +195,8 @@ numbers excluded the ~14 % of fits #2836 discarded. Those fits are now kept and
 "cut the Bad tail at α ≈ 0.16" is still a coherent one-constant rule that needs
 no crossing at all — which is now the only part of the EVT work with a future,
 given that the crossing rules do not clear the plain Gaussian `priorfree`, let
-alone production.
+alone production. Tracked as #2881 — nobody has measured it *as a rule*;
+`oracle_lo_sf_evt` is recorded only diagnostically, at the oracle cut.
 
 > A reading trap: `summary_cut.json`'s `decisions.tail_alpha_stable: false`
 > refers to the **Gaussian** row (`analyze_cut.py` keys it off


### PR DESCRIPTION
Docs-only, one paragraph edited.

#2879 closed the Gumbel **crossing** work, but it also discharged `REPORT.md`'s pre-registered recomputation and the tail-level finding survived it — the EVT tail level is the stable one (IQR ratio 2.38 against a bar of 3, where the Gaussian is 5.54), and the report calls `"cut the Bad tail at α ≈ 0.16"` *"the only part of the EVT work with a future"*.

That thread had no issue and no plan file (`docs/plans/gmm-cut-theory-experiment.md` was correctly pruned when the study shipped), so the one live piece of this line existed only as two paragraphs inside a report that opens with "close the Gumbel line of work". Easy to lose.

Filed as #2881 and pointed at from the report. The pointer also states the thing that is easy to miss on a skim: `oracle_lo_sf_evt` is recorded only *diagnostically*, evaluated at the oracle cut (`vtscore/eval/cut_rules.py:383`) — the rule itself has never been measured, so "the finding survives" is not the same claim as "the rule works".

No body duplicated into the report: the issue carries the work (closed-form inverse, the logit-space and swapped-orientation traps, the α sweep, and the correct incumbent to pair against), the report carries one line and the number.

Verification: `codespell --toml pyproject.toml` clean. No code paths touched, so the rest of `./run-tests.sh` has nothing to exercise here — calling that out explicitly rather than implying a full-suite run.

Refs #2846, refs #2836, refs #2881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QYTTwHrty1Arqhvip9u1L

---
_Generated by [Claude Code](https://claude.ai/code/session_016QYTTwHrty1Arqhvip9u1L)_