### PR TITLE
Follow through on #2879: pair against the run's own base row, and check what `import vtscore` resolves to

### DIFF
--- a/docs/experiments/gmm-cut/REMEASURE-2846.md
+++ b/docs/experiments/gmm-cut/REMEASURE-2846.md
@@ -123,10 +123,12 @@ on this table. #2875's bench estimate of the recovery ("5 of the ~32 missing
 points") was right in spirit: the ordering guard was rejecting sound fits, but
 most of those fits have no root either way.
 
-> `agg/cut_fallback_reasons.csv` is written over **all 30 steps**, not the ramp
+> `agg/cut_fallback_reasons.csv` was written over **all 30 steps**, not the ramp
 > window — there the same split is 946 `modes_swapped` → 391 crossings + 555
-> `lo_owns_hi_mode` (1 795 → 1 404 fallbacks of 7 365 steps). Don't mix its
-> counts with the ramp-window rates above.
+> `lo_owns_hi_mode` (1 795 → 1 404 fallbacks of 7 365 steps). Don't mix those
+> counts with the ramp-window rates above. *(Fixed since: the table now carries a
+> `window` column and is emitted per window as well as `all_steps`, so a later
+> run cannot make that mistake by reading the file the obvious way.)*
 
 `gumbel_any_cross` is worth noting as the one place the repair makes a variant's
 fallback rate *worse-behaved*: it fires on 2.0 % more steps and loses on them.
@@ -197,9 +199,11 @@ no crossing at all — which is now the only part of the EVT work with a future,
 given that the crossing rules do not clear the plain Gaussian `priorfree`, let
 alone production.
 
-> A reading trap: `summary_cut.json`'s `decisions.tail_alpha_stable: false`
-> refers to the **Gaussian** row (`analyze_cut.py` keys it off
-> `oracle_lo_sf_gauss`). It is not saying the EVT rule is unstable.
+> A reading trap in this run's `summary_cut.json`: `decisions.tail_alpha_stable:
+> false` refers to the **Gaussian** row (`analyze_cut.py` keyed it off
+> `oracle_lo_sf_gauss`). It is not saying the EVT rule is unstable. *(Fixed
+> since: the key is gone, replaced by `tail_alpha_stable_gauss` and
+> `tail_alpha_stable_evt`, each named after the model it judges.)*
 
 ## The decomposition replicates
 

--- a/scripts/experiments/LESSONS.md
+++ b/scripts/experiments/LESSONS.md
@@ -153,9 +153,11 @@ a worktree pins *that* worktree at `sys.path[0]`. `preflight.sh` already checked
 that VTS_REPO was set and clean — it just could not check the one thing that was
 wrong, which was that nobody had set it at all.
 
-**Still advice:** after sourcing `gridenv.sh` in a new worktree, print
-`python -c "import vtscore; print(vtscore.__file__)"` once. It is one line and it
-is the only direct evidence that the run measures your branch.
+**Also prevented (code):** `preflight.sh` now resolves `import vtscore` the way a
+job does — through `common.setup_env()` — and fails if the file it lands on is
+not inside `VTS_REPO`. That is the direct evidence the run measures your branch,
+and it is checked rather than remembered. Setting `VTS_REPO` correctly is not the
+same thing: this run had it right and still imported the other checkout.
 
 <!-- entry-sep -->
 
@@ -188,12 +190,20 @@ X beats what we ship". A re-measure that had not looked at the provenance column
 would have republished that claim in good faith. On this cluster a study's
 baseline is a moving target, because studies here ship things.
 
-**Now prevented (code):** `analyze_cut.py`'s `production_blend_sanity` no longer
-just reports `ok: false` — on failure it breaks the mismatch down by
-`threshold_provenance`, so "the harness is broken" and "the incumbent moved" are
-distinguishable at a glance instead of by investigation.
+**Now prevented (code), twice over:**
 
-**Still advice:** when a study's baseline arm is *defined* as "what production
-does", re-read that definition against `git log` on the threshold path before
-trusting any "beats production" line. And prefer pairing against the run's own
-base row, which cannot go stale, over a variant that reconstructs it.
+1. `analyze_cut.py`'s `production_blend_sanity` no longer just reports
+   `ok: false` — on failure it breaks the mismatch down by
+   `threshold_provenance`, so "the harness is broken" and "the incumbent moved"
+   are distinguishable at a glance instead of by investigation.
+2. The ship decision no longer depends on a reconstruction at all.
+   `base_row_contrasts` pairs every rule against **the run's own base row** —
+   the threshold production actually used on that step, whatever it was — and
+   `decisions.beats_production` / `ship_candidate` are computed from that.
+   `beats_midpoint` survives as the historical #2836 contrast and gates nothing.
+   A baseline that is read rather than reconstructed cannot go stale, so the
+   next incumbent can ship without expiring anyone's conclusions.
+
+**Still advice:** when a study defines *any* arm as "what production does",
+re-read that definition against `git log` on the path it names. The base row
+covers the threshold; the next study will name something else.

--- a/scripts/experiments/calibration/analyze_cut.py
+++ b/scripts/experiments/calibration/analyze_cut.py
@@ -7,7 +7,9 @@ geometry, carrying the fitted mixture parameters and the whole decomposition
 chain).  Produces two independent things:
 
 **Which cut wins** — paired within-step contrasts between every shippable rule
-and the production midpoint, on the blended threshold (what a user gets) *and*
+and (a) the run's own production row, which is what "beats what we ship" means
+and cannot go stale, and (b) the production midpoint, which is #2836's baseline
+and did go stale (#2846).  Both on the blended threshold (what a user gets) *and*
 on the raw cut (what the rule is worth before the conformal blend damps it).
 
 **Why** — the four-term decomposition of today's error, per step:
@@ -66,8 +68,31 @@ SHIPPABLE: tuple[str, ...] = (
 #: Label-reading diagnostics — bounds and decomposition anchors, never candidates.
 ORACLE_VARIANTS: tuple[str, ...] = ("pooled_supervised", "pooled_sim_oracle")
 
-#: The incumbent every candidate is measured against (production since #2833).
+#: Deliberately not ship candidates: ``xcal_only`` is the no-blend control, and
+#: the ``image_*`` family is the single-vector geometry arm, measured for
+#: comparison rather than to ship.  Anything in the cells that is in *none* of
+#: these three sets is a rule someone added to ``_SAFE_GMM_VARIANTS`` without
+#: telling the analyzer, and :func:`unclassified_variants` says so — see there
+#: for why that has to be loud rather than silent.
+NON_CANDIDATES: tuple[str, ...] = ("xcal_only",)
+NON_CANDIDATE_PREFIXES: tuple[str, ...] = ("image_",)
+
+#: The variant that *reconstructs* the production rule of #2836's era.  Kept as
+#: the historical contrast, but it is a reconstruction and reconstructions go
+#: stale: by #2846's re-measure production had moved to the fold-anchored
+#: threshold and this rule reproduced it on 16 % of steps.  See ``BASE_ROW``.
 INCUMBENT = "pooled_mid"
+
+#: The run's *own* production row — no cut variant, the pooled max geometry the
+#: app ships — identified by ``(pool_variant, gmm_variant)``.  Pairing against
+#: this is what "does the rule beat what we ship" actually means, and unlike
+#: ``INCUMBENT`` it cannot expire when the app changes its threshold (#2846).
+BASE_ROW: tuple[str, str] = ("max", "")
+
+#: Metrics the base row shares with a cut variant.  It has no ``gmm_cut`` and no
+#: raw (unblended) cut of its own, so the rule-quality columns are meaningless
+#: here; the blended cost *is* the ship number.
+BASE_METRICS: tuple[str, ...] = ("cost", "fpr", "fnr")
 
 #: Decomposition terms: name -> (tau_a, tau_b); each is ``tau_a - tau_b``, and
 #: consecutive terms telescope to ``tau_cross - tau_test_oracle``.
@@ -123,6 +148,26 @@ def load_cutdiag(cells_dir: Path) -> pd.DataFrame:
     return df
 
 
+def unclassified_variants(df: pd.DataFrame) -> list[str]:
+    """Cut variants present in the cells that this analyzer does not classify.
+
+    ``SHIPPABLE`` is an allowlist, and the ship decision, both contrast tables
+    and the oracle-distance tie-break all read through it.  So a rule added to
+    ``_SAFE_GMM_VARIANTS`` but not added here does not fail — it is *silently
+    omitted from the verdict* while still appearing in the window means, which
+    is the exact shape of wrong table this study line keeps producing.  #2881
+    will add a ``tail_alpha`` rule; this makes forgetting it a visible event
+    rather than a missing row nobody counts.
+    """
+    known = {*SHIPPABLE, *ORACLE_VARIANTS, *NON_CANDIDATES}
+    present = {str(v) for v in df["gmm_variant"].unique() if str(v) != ""}
+    unknown = sorted(v for v in present - known if not any(v.startswith(p) for p in NON_CANDIDATE_PREFIXES))
+    if unknown:
+        common.log(f"WARNING: {len(unknown)} variant(s) not classified by this analyzer: {', '.join(unknown)}")
+        common.log("         -> add them to SHIPPABLE (or NON_CANDIDATES); until then they cannot win or ship")
+    return unknown
+
+
 def production_blend_sanity(df: pd.DataFrame) -> dict:
     """``pooled_mid`` must reproduce the production blended cut bit-for-bit.
 
@@ -171,16 +216,12 @@ def production_blend_sanity(df: pd.DataFrame) -> dict:
 # ------------------------------------------------------------------
 
 
-def _paired_cells(v: pd.DataFrame, a: str, b: str, lo: int, hi: int, metric_cols: list[str]) -> pd.DataFrame:
-    """Per-(arm, category, seed) mean deltas of ``a - b`` on identical steps in [lo, hi].
+def _pair_frames(va: pd.DataFrame, vb: pd.DataFrame, metric_cols: list[str]) -> pd.DataFrame:
+    """Per-(arm, category, seed) mean deltas of ``va - vb`` on identical steps.
 
     The t axis is collapsed first so the test's units are independent cells
     rather than autocorrelated steps within one trajectory.
     """
-    keys = ["arm", "category", "seed", "t"]
-    w = v[(v["n_votes"] >= lo) & (v["n_votes"] <= hi)]
-    va = w[w["gmm_variant"] == a].set_index(keys)[metric_cols]
-    vb = w[w["gmm_variant"] == b].set_index(keys)[metric_cols]
     j = va.join(vb, how="inner", lsuffix="_a", rsuffix="_b")
     if j.empty:
         return pd.DataFrame()
@@ -188,6 +229,29 @@ def _paired_cells(v: pd.DataFrame, a: str, b: str, lo: int, hi: int, metric_cols
         j[f"d_{col}"] = j[f"{col}_a"] - j[f"{col}_b"]
     j = j.reset_index()
     return j.groupby(["arm", "category", "seed"])[[f"d_{c}" for c in metric_cols]].mean().reset_index()
+
+
+def _window(v: pd.DataFrame, lo: int, hi: int) -> pd.DataFrame:
+    return v[(v["n_votes"] >= lo) & (v["n_votes"] <= hi)]
+
+
+def _paired_cells(v: pd.DataFrame, a: str, b: str, lo: int, hi: int, metric_cols: list[str]) -> pd.DataFrame:
+    """:func:`_pair_frames` between two cut variants over the window [lo, hi]."""
+    keys = ["arm", "category", "seed", "t"]
+    w = _window(v, lo, hi)
+    va = w[w["gmm_variant"] == a].set_index(keys)[metric_cols]
+    vb = w[w["gmm_variant"] == b].set_index(keys)[metric_cols]
+    return _pair_frames(va, vb, metric_cols)
+
+
+def _paired_cells_vs_base(v: pd.DataFrame, a: str, lo: int, hi: int, metric_cols: list[str]) -> pd.DataFrame:
+    """:func:`_pair_frames` between a cut variant and the run's own base row."""
+    keys = ["arm", "category", "seed", "t"]
+    w = _window(v, lo, hi)
+    pool, gmm = BASE_ROW
+    va = w[w["gmm_variant"] == a].set_index(keys)[metric_cols]
+    vb = w[(w["pool_variant"] == pool) & (w["gmm_variant"] == gmm)].set_index(keys)[metric_cols]
+    return _pair_frames(va, vb, metric_cols)
 
 
 def window_table(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
@@ -257,6 +321,55 @@ def rule_contrasts(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
                 rows.append(entry)
     tbl = pd.DataFrame(rows)
     tbl.to_csv(agg_dir / "cut_contrasts.csv", index=False)
+    return tbl
+
+
+def base_row_contrasts(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
+    """Every rule against **the threshold the run actually used**, per window per arm.
+
+    :func:`rule_contrasts` answers "does this rule beat the midpoint".  That was
+    the same question as "does it beat what we ship" only for as long as the app
+    computed the midpoint, and #2846 found out the hard way that it had stopped:
+    ``pooled_mid`` was still bit-for-bit correct, production had simply moved to
+    the fold-anchored threshold, and every "beats the shipped midpoint" line in
+    the study silently stopped meaning what it said.
+
+    The base row cannot go stale, because it is not a reconstruction — it is the
+    step's own outcome under whatever production did that day.  ``base_provenance``
+    records which path that was, so a contrast is never read without knowing what
+    it was against.
+    """
+    metrics = list(BASE_METRICS)
+    pool, gmm = BASE_ROW
+    has_prov = "threshold_provenance" in df
+    rows = []
+    for wname, (lo, hi) in WINDOWS.items():
+        for cand in (*SHIPPABLE, *ORACLE_VARIANTS):
+            for arm, sub in df.groupby("arm"):
+                cells = _paired_cells_vs_base(sub, cand, lo, hi, metrics)
+                if cells.empty:
+                    continue
+                base = _window(sub, lo, hi)
+                base = base[(base["pool_variant"] == pool) & (base["gmm_variant"] == gmm)]
+                prov = base["threshold_provenance"].fillna("").astype(str) if has_prov else pd.Series(dtype=str)
+                entry: dict = {
+                    "window": wname,
+                    "variant": cand,
+                    "vs": "base_row",
+                    "arm": arm,
+                    "n_cells": int(len(cells)),
+                    "base_provenance": "|".join(sorted(prov.unique())) if len(prov) else "",
+                }
+                for col in metrics:
+                    vals = cells[f"d_{col}"].to_numpy(dtype=float)
+                    vals = vals[np.isfinite(vals)]
+                    entry[f"mean_d_{col}"] = float(np.mean(vals)) if vals.size else float("nan")
+                    entry[f"p_d_{col}"] = _wilcoxon(vals) if vals.size else None
+                    if col == "cost":
+                        entry["frac_cells_improved"] = float(np.mean(vals < 0)) if vals.size else float("nan")
+                rows.append(entry)
+    tbl = pd.DataFrame(rows)
+    tbl.to_csv(agg_dir / "cut_contrasts_vs_base.csv", index=False)
     return tbl
 
 
@@ -470,23 +583,38 @@ def fallback_reasons(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
     sound but oriented the other way" (repairable, and what ``gumbel_any_*``
     repairs) and "the two components collapsed onto each other" (a statement
     about that step's score distribution, which no solver can fix).
+
+    Emitted **per window**, plus an ``all_steps`` row set.  Every other table
+    here is windowed, so a bare all-steps count invited exactly the mistake
+    #2846's report had to warn about in prose: reading these counts next to a
+    ramp-window fallback *rate* and treating them as the same population.
     """
     if "cut_fail_reason" not in df:
         return pd.DataFrame()
     fell = df[(df["cut_fallback"] == 1) & (df["cut_fail_reason"].astype(str) != "")]
     if fell.empty:
         return pd.DataFrame()
-    g = (
-        fell.groupby(["arm", "gmm_variant", "cut_fail_reason"])
-        .size()
-        .reset_index(name="n_steps")
-        .sort_values(["arm", "gmm_variant", "n_steps"], ascending=[True, True, False])
-    )
-    # Share within each (arm, variant), so a reason is readable without joining
-    # back to that variant's own step count.
-    g["share_of_fallbacks"] = g["n_steps"] / g.groupby(["arm", "gmm_variant"])["n_steps"].transform("sum")
-    g.to_csv(agg_dir / "cut_fallback_reasons.csv", index=False)
-    return g
+    out = []
+    for wname, sub in (
+        ("all_steps", fell),
+        *((wname, _window(fell, lo, hi)) for wname, (lo, hi) in WINDOWS.items()),
+    ):
+        if sub.empty:
+            continue
+        g = (
+            sub.groupby(["arm", "gmm_variant", "cut_fail_reason"])
+            .size()
+            .reset_index(name="n_steps")
+            .sort_values(["arm", "gmm_variant", "n_steps"], ascending=[True, True, False])
+        )
+        # Share within each (arm, variant), so a reason is readable without joining
+        # back to that variant's own step count.
+        g["share_of_fallbacks"] = g["n_steps"] / g.groupby(["arm", "gmm_variant"])["n_steps"].transform("sum")
+        g.insert(0, "window", wname)
+        out.append(g)
+    tbl = pd.concat(out, ignore_index=True) if out else pd.DataFrame()
+    tbl.to_csv(agg_dir / "cut_fallback_reasons.csv", index=False)
+    return tbl
 
 
 def tail_alpha_stability(diag: pd.DataFrame, agg_dir: Path) -> dict:
@@ -556,22 +684,48 @@ def estimator_variance(diag: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
 # ------------------------------------------------------------------
 
 
-def decisions(contrasts: pd.DataFrame, gaps: pd.DataFrame, costs: pd.DataFrame, alpha: dict) -> dict:
+def _wins(row: pd.Series | None) -> bool:
+    """Significantly cheaper, on the pre-registered two-sided 5 % bar."""
+    if row is None:
+        return False
+    p = row["p_d_cost"]
+    return bool(p is not None and np.isfinite(float(p)) and float(p) < 0.05 and float(row["mean_d_cost"]) < 0)
+
+
+def _ramp_prod(tbl: pd.DataFrame, variants: tuple[str, ...] | None = None) -> pd.DataFrame:
+    """The production arm's ramp window, optionally restricted to *variants*."""
+    if tbl.empty:
+        return tbl
+    sel = (tbl["window"] == "ramp_6_20") & (tbl["arm"].str.contains(PRODUCTION_ARM_SUBSTR))
+    if variants is not None:
+        sel &= tbl["variant"].isin(variants)
+    return tbl[sel]
+
+
+def decisions(
+    contrasts: pd.DataFrame,
+    base_contrasts: pd.DataFrame,
+    gaps: pd.DataFrame,
+    costs: pd.DataFrame,
+    alpha: dict,
+) -> dict:
     """The issue's pre-registered decision rules, evaluated.
 
     Ship the rule that is closest to the oracle cut **and** wins on cost on the
     production arm's ramp window, provided it does not regress the single-vector
     arm.  Anything else is a negative result with a named cause.
+
+    "Wins on cost" is judged against the **run's own base row**, not against
+    ``pooled_mid``: #2846 shipped a new production threshold mid-study and the
+    midpoint contrast quietly became a comparison with a rule nobody runs.
+    ``beats_midpoint`` is still reported, as the historical #2836 contrast, but
+    it no longer gates the ship decision.
     """
     out: dict = {}
     if contrasts.empty:
         return {"error": "no contrasts"}
 
-    prod = contrasts[
-        (contrasts["window"] == "ramp_6_20")
-        & (contrasts["arm"].str.contains(PRODUCTION_ARM_SUBSTR))
-        & (contrasts["variant"].isin(SHIPPABLE))
-    ]
+    prod = _ramp_prod(contrasts, SHIPPABLE)
     if prod.empty:
         return {"error": "no production-arm contrasts"}
 
@@ -584,9 +738,43 @@ def decisions(contrasts: pd.DataFrame, gaps: pd.DataFrame, costs: pd.DataFrame, 
         "p_raw": None if best["p_d_raw_cut_cost"] is None else float(best["p_d_raw_cut_cost"]),
         "frac_cells_improved": float(best["frac_cells_improved"]),
     }
-    out["beats_midpoint"] = bool(
-        best["p_d_cost"] is not None and float(best["p_d_cost"]) < 0.05 and float(best["mean_d_cost"]) < 0
-    )
+    out["beats_midpoint"] = _wins(best)
+
+    # --- Against what production actually did -------------------------------
+    prod_base = _ramp_prod(base_contrasts, SHIPPABLE)
+    cand = None
+    out["best_vs_production"] = None
+    out["beats_production"] = False
+    if not prod_base.empty:
+        cand = prod_base.sort_values("mean_d_cost").iloc[0]
+        out["best_vs_production"] = {
+            "variant": str(cand["variant"]),
+            "mean_d_cost": float(cand["mean_d_cost"]),
+            "p": None if cand["p_d_cost"] is None else float(cand["p_d_cost"]),
+            "frac_cells_improved": float(cand["frac_cells_improved"]),
+            "base_provenance": str(cand["base_provenance"]),
+        }
+        out["beats_production"] = _wins(cand)
+
+    # Is there anything left on this axis at all?  `pooled_sim_oracle` is the
+    # empirical rate-loss minimiser over the sim scores *read with true labels*,
+    # with no parametric form at all, so it bounds every rule that picks a
+    # threshold from that sim set - Gaussian crossing, Gumbel crossing, and the
+    # one-constant tail quantile of #2881 alike.  If *it* cannot beat production,
+    # no unsupervised member of that set will, and the next study belongs on the
+    # fit rather than the cut (#2846's closing finding, mechanised here so a
+    # later run is told rather than having to rediscover it by hand).
+    oracle_row = _ramp_prod(base_contrasts)
+    oracle_row = oracle_row[oracle_row["variant"] == "pooled_sim_oracle"]
+    out["family_headroom"] = None
+    out["family_headroom_exhausted"] = None
+    if not oracle_row.empty:
+        o = oracle_row.iloc[0]
+        out["family_headroom"] = {
+            "mean_d_cost": float(o["mean_d_cost"]),
+            "p": None if o["p_d_cost"] is None else float(o["p_d_cost"]),
+        }
+        out["family_headroom_exhausted"] = not _wins(o)
 
     # Closest to the oracle cut, among shippable rules, same arm and window.
     gp = gaps[
@@ -608,11 +796,18 @@ def decisions(contrasts: pd.DataFrame, gaps: pd.DataFrame, costs: pd.DataFrame, 
         out["closest_to_oracle_tied"] = tied
         out["closest_to_oracle"] = tied[0]
 
-    # Does the winner regress the single-vector arm the cosine/text sort uses?
-    ctrl = contrasts[
-        (contrasts["window"] == "ramp_6_20")
-        & (contrasts["arm"].str.contains(CONTROL_ARM_SUBSTR))
-        & (contrasts["variant"] == best["variant"])
+    # The ship candidate is the one that beats *production*; the midpoint winner
+    # is only the candidate when there is no base row to pair against.
+    ship_candidate = str((cand if cand is not None else best)["variant"])
+    out["ship_candidate"] = ship_candidate
+
+    # Does the candidate regress the single-vector arm the cosine/text sort uses?
+    # Measured against the same baseline as the ship test, for the same reason.
+    ctrl_tbl = base_contrasts if cand is not None else contrasts
+    ctrl = ctrl_tbl[
+        (ctrl_tbl["window"] == "ramp_6_20")
+        & (ctrl_tbl["arm"].str.contains(CONTROL_ARM_SUBSTR))
+        & (ctrl_tbl["variant"] == ship_candidate)
     ]
     out["control_arm_delta"] = None if ctrl.empty else float(ctrl.iloc[0]["mean_d_cost"])
     out["regresses_control"] = bool(
@@ -622,8 +817,8 @@ def decisions(contrasts: pd.DataFrame, gaps: pd.DataFrame, costs: pd.DataFrame, 
         and float(ctrl.iloc[0]["p_d_cost"]) < 0.05
     )
     out["ship"] = bool(
-        out["beats_midpoint"]
-        and out["best_by_cost"]["variant"] in out["closest_to_oracle_tied"]
+        (out["beats_production"] if cand is not None else out["beats_midpoint"])
+        and ship_candidate in out["closest_to_oracle_tied"]
         and not out["regresses_control"]
     )
 
@@ -642,7 +837,12 @@ def decisions(contrasts: pd.DataFrame, gaps: pd.DataFrame, costs: pd.DataFrame, 
                 out["error_terms_cost"] = terms
     # The leading hypothesis is confirmed only if the prior/loss term dominates.
     out["leading_hypothesis_confirmed"] = out["dominant_error_term"] == "prior_loss"
-    out["tail_alpha_stable"] = bool(alpha.get("oracle_lo_sf_gauss", {}).get("stable", False))
+    # One key per tail model, named after it.  The old single `tail_alpha_stable`
+    # was keyed off the Gaussian row alone, so a reader who found it `false` next
+    # to a passing EVT row concluded the EVT rule was unstable - which is the
+    # opposite of what that table says (#2846 had to spend a paragraph on it).
+    out["tail_alpha_stable_gauss"] = bool(alpha.get("oracle_lo_sf_gauss", {}).get("stable", False))
+    out["tail_alpha_stable_evt"] = bool(alpha.get("oracle_lo_sf_evt", {}).get("stable", False))
     return out
 
 
@@ -726,7 +926,8 @@ def write_report(summary: dict, tables: dict, report_path: Path) -> None:
     lines.append("```")
     for title, key in (
         ("Window means by (arm, variant)", "window"),
-        ("Rule contrasts vs the midpoint", "contrasts"),
+        ("Rule contrasts vs the run's own production row", "base_contrasts"),
+        ("Rule contrasts vs the midpoint (the #2836 baseline)", "contrasts"),
         ("Distance to the oracle cut", "gaps"),
         ("Decomposition (threshold units)", "decomposition"),
         ("Decomposition (excess-cost units)", "cost_decomposition"),
@@ -776,9 +977,11 @@ def main() -> int:
     if diag.empty:
         common.log("WARNING: no __cutdiag frames; the decomposition half will be empty")
 
+    unknown = unclassified_variants(df)
     sanity = production_blend_sanity(df)
     window = window_table(df, agg_dir)
     contrasts = rule_contrasts(df, agg_dir)
+    base_contrasts = base_row_contrasts(df, agg_dir)
     gaps = oracle_distance(df, agg_dir)
     decomp = decomposition_table(diag, agg_dir) if not diag.empty else pd.DataFrame()
     costs = cost_decomposition(df, agg_dir)
@@ -787,7 +990,11 @@ def main() -> int:
     why = fallback_reasons(df, agg_dir)
     alpha = tail_alpha_stability(diag, agg_dir) if not diag.empty else {}
     est_var = estimator_variance(diag, agg_dir) if not diag.empty else pd.DataFrame()
-    dec = decisions(contrasts, gaps, costs, alpha)
+    dec = decisions(contrasts, base_contrasts, gaps, costs, alpha)
+    # Carried in the decisions block, not only in the log: this is the one place
+    # a reader checks before believing a verdict, and the verdict is exactly what
+    # an unclassified rule is missing from.
+    dec["unclassified_variants"] = unknown
     figs = make_figures(df, diag, fig_dir) if not diag.empty else []
 
     summary = {
@@ -795,6 +1002,7 @@ def main() -> int:
         "n_diag_rows": int(len(diag)),
         "n_cells": int(df[["dataset", "embedder", "category", "seed"]].drop_duplicates().shape[0]),
         "windows": {k: list(v) for k, v in WINDOWS.items()},
+        "unclassified_variants": unknown,
         "sanity": sanity,
         "decisions": dec,
         "offsets": offsets,
@@ -806,6 +1014,7 @@ def main() -> int:
         summary,
         {
             "window": window,
+            "base_contrasts": base_contrasts,
             "contrasts": contrasts,
             "gaps": gaps,
             "decomposition": decomp,

--- a/scripts/experiments/calibration/selftest_analyze_cut.py
+++ b/scripts/experiments/calibration/selftest_analyze_cut.py
@@ -13,7 +13,12 @@ they come back out:
 * the decomposition telescopes and names the term that was actually planted as
   dominant;
 * a rule whose *blended* cost wins while its *raw cut* does not is reported as
-  such, since that is the trap the plan pre-registers.
+  such, since that is the trap the plan pre-registers;
+* the ship test is decided against the run's **own base row**, not against the
+  ``pooled_mid`` reconstruction of it — the two are planted apart here, exactly
+  as #2846 found them in the field, and the ship gate must follow the base row;
+* fallback reasons are windowed, so an out-of-ramp fallback cannot be read as a
+  ramp-window one.
 
 Usage::
 
@@ -52,6 +57,25 @@ ARMS = [("dinov3_patch", "max_patch"), ("siglip", "whole_image")]
 WINNER = "pooled_priorfree"
 INCUMBENT = "pooled_mid"
 
+#: #2846's field condition, planted: on half the cells production no longer takes
+#: the blended-GMM path that ``pooled_mid`` reconstructs, and the path it takes
+#: instead is *cheaper* than the planted winner.  So the midpoint contrast says
+#: ship and the base-row contrast says do not, and the analyzer has to follow the
+#: base row.  Keyed on seed parity, which also gives the fidelity check the exact
+#: 1:1 provenance partition the re-measure found.
+ANCHORED_SEEDS = {2, 3}
+PROD_EDGE = -0.10
+#: A fallback planted **outside** the ramp window: the windowed reasons table
+#: must not report it inside one.
+FALLBACK_VARIANT = "pooled_gumbel_priorfree"
+FALLBACK_REASON = "modes_swapped"
+FALLBACK_STEPS = [t for t in range(2, 31) if t >= 21]
+#: A rule present in the cells that the analyzer's ``SHIPPABLE`` allowlist does
+#: not know about.  Planted deliberately: the allowlist gates the ship decision,
+#: so an unlisted rule is omitted from the verdict while still showing up in the
+#: window means, and that omission has to be loud.
+UNKNOWN_VARIANT = "pooled_not_a_known_rule"
+
 
 def _ident(cat: str, seed: int, t: int, embedder: str, style: str) -> dict:
     n_votes = t
@@ -80,6 +104,11 @@ def _fabricate(root: Path, rng: np.random.Generator) -> None:
     cells = root / "cells"
     cells.mkdir(parents=True, exist_ok=True)
     variants = [name for name, _f, _r in _SAFE_GMM_VARIANTS]
+    # A rule the analyzer has never heard of, standing in for the next one added
+    # to `_SAFE_GMM_VARIANTS` without a matching `SHIPPABLE` entry (#2881's
+    # `tail_alpha` is the one actually coming).  It must not be able to slip
+    # through unnoticed.
+    variants.append(UNKNOWN_VARIANT)
 
     idx = 0
     for embedder, style in ARMS:
@@ -97,30 +126,40 @@ def _fabricate(root: Path, rng: np.random.Generator) -> None:
                     # the correlation the analyzer reports is still computable.
                     jitter = 0.01 * rng.standard_normal()
 
-                    # The base (production) row, and the variant that must match it.
+                    # The base (production) row, and the variant that reconstructs
+                    # it - which on the anchored cells it no longer does.
+                    anchored = seed in ANCHORED_SEEDS
                     threshold = 0.55
                     for variant in ["", *variants]:
+                        is_base = variant == ""
                         effect = RAMP_EFFECT if (variant == WINNER and in_ramp) else 0.0
+                        if is_base and anchored:
+                            effect = PROD_EDGE
                         # The blended and raw columns move together here except
                         # for the decoy, which wins only after blending.
                         decoy = variant == "pooled_gumbel_cross" and in_ramp
                         raw_cost = _CHAIN_RAW_COST.get(variant, base_cost) + (0.02 if decoy else 0.0)
+                        fell = variant == FALLBACK_VARIANT and t in FALLBACK_STEPS
                         row = dict(ident)
                         row.update(
                             pool_variant="max",
                             gmm_variant=variant,
-                            threshold=threshold,
-                            threshold_provenance="gmm_blend",
+                            threshold=threshold - (0.02 if (is_base and anchored) else 0.0),
+                            threshold_provenance="fold_anchored[k0.3]" if anchored else "gmm_blend",
                             degenerate=0,
                             threshold_percentile=0.9,
                             xcal_threshold=0.52,
                             gmm_cut=oracle_threshold + (0.0 if variant == WINNER else 0.05),
                             blend_weight=0.5,
-                            cut_fallback=0,
+                            cut_fallback=1 if fell else 0,
+                            cut_fail_reason=FALLBACK_REASON if fell else "",
                             raw_cut_cost=raw_cost,
                             raw_cut_fpr=0.1,
                             raw_cut_fnr=0.2,
-                            cost=base_cost + effect + (RAMP_EFFECT if decoy else 0.0),
+                            # Half the winner's edge: enough to win on the blended
+                            # column, small enough that no argmin is a tie (which
+                            # a tie-break would then have to resolve arbitrarily).
+                            cost=base_cost + effect + (RAMP_EFFECT / 2 if decoy else 0.0),
                             fpr=0.1,
                             fnr=0.2,
                             auroc=0.9,
@@ -269,6 +308,83 @@ def main() -> int:
         ok &= _check("winner chosen", dec["best_by_cost"]["variant"] == WINNER, str(dec["best_by_cost"]["variant"]))
         ok &= _check("beats the incumbent", bool(dec["beats_midpoint"]))
         ok &= _check("closest to the oracle cut", dec["closest_to_oracle"] == WINNER, str(dec["closest_to_oracle"]))
+
+        # --- The baseline that cannot go stale (#2846) ------------------------
+        base = pd.read_csv(root / "agg" / "cut_contrasts_vs_base.csv")
+        bprod = base[
+            (base["arm"].str.contains("dinov3_patch/max_patch"))
+            & (base["window"] == "ramp_6_20")
+            & (base["variant"] == WINNER)
+        ]
+        # Half the cells are anchored (production PROD_EDGE cheaper than the
+        # midpoint), half are not, so the winner's edge over production is the
+        # average of RAMP_EFFECT and RAMP_EFFECT - PROD_EDGE.
+        expected = RAMP_EFFECT - PROD_EDGE * len(ANCHORED_SEEDS) / len(SEEDS)
+        ok &= _check("winner paired against the run's own base row", len(bprod) == 1)
+        if len(bprod) == 1:
+            ok &= _check(
+                "base-row delta reflects the shipped threshold, not the midpoint",
+                abs(float(bprod.iloc[0]["mean_d_cost"]) - expected) < 1e-6,
+                f"{float(bprod.iloc[0]['mean_d_cost']):.5f} vs {expected}",
+            )
+            ok &= _check(
+                "base row records which production path it was",
+                "fold_anchored[k0.3]" in str(bprod.iloc[0]["base_provenance"]),
+                str(bprod.iloc[0]["base_provenance"]),
+            )
+        ok &= _check("ship candidate is chosen vs production", dec["ship_candidate"] == WINNER)
+        ok &= _check("does not beat what production actually ships", not dec["beats_production"])
+        ok &= _check(
+            "a stale-baseline win alone does not ship",
+            dec["beats_midpoint"] and not dec["ship"],
+        )
+        ok &= _check("family headroom reported", dec["family_headroom"] is not None)
+        ok &= _check("no headroom left on this axis", bool(dec["family_headroom_exhausted"]))
+
+        # A rule the allowlist does not know about is named, not dropped in silence.
+        ok &= _check(
+            "an unclassified rule is reported in the verdict",
+            dec["unclassified_variants"] == [UNKNOWN_VARIANT],
+            str(dec["unclassified_variants"]),
+        )
+        ok &= _check(
+            "the image geometry arm and the no-blend control are not flagged",
+            not [v for v in dec["unclassified_variants"] if v.startswith("image_") or v == "xcal_only"],
+        )
+
+        # A failed fidelity check must say *why*: harness bug or shipped incumbent.
+        sanity = summary["sanity"]
+        prov = sanity.get("by_provenance", {})
+        ok &= _check(
+            "fidelity failure is broken down by production path",
+            not sanity["ok"]
+            and prov.get("gmm_blend", {}).get("n_mismatched") == 0
+            and prov.get("fold_anchored[k0.3]", {}).get("n_mismatched", 0) > 0,
+            str(prov),
+        )
+
+        # Both tail models named, so neither can be read as the other.
+        ok &= _check(
+            "tail stability is reported per tail model",
+            "tail_alpha_stable" not in dec and {"tail_alpha_stable_gauss", "tail_alpha_stable_evt"} <= set(dec),
+        )
+
+        # Fallback reasons are windowed: the planted fallback sits outside the ramp.
+        reasons = pd.read_csv(root / "agg" / "cut_fallback_reasons.csv")
+        planted = reasons[
+            (reasons["arm"].str.contains("dinov3_patch/max_patch")) & (reasons["gmm_variant"] == FALLBACK_VARIANT)
+        ]
+        n_expected = len(FALLBACK_STEPS) * len(CATEGORIES) * len(SEEDS)
+        all_steps = planted[planted["window"] == "all_steps"]
+        ok &= _check(
+            "fallbacks counted over all steps",
+            len(all_steps) == 1 and int(all_steps.iloc[0]["n_steps"]) == n_expected,
+            f"{None if all_steps.empty else int(all_steps.iloc[0]['n_steps'])} vs {n_expected}",
+        )
+        ok &= _check(
+            "an out-of-ramp fallback is not reported inside the ramp",
+            planted[planted["window"] == "ramp_6_20"].empty,
+        )
 
         # The decoy wins on the blended column but not on the raw cut; the
         # analyzer must expose both so it cannot be shipped on the wrong one.

--- a/scripts/experiments/preflight.sh
+++ b/scripts/experiments/preflight.sh
@@ -128,6 +128,40 @@ else
   fi
 fi
 
+# --- 5. …and the checkout `import vtscore` ACTUALLY resolves to --------------
+# VTS_REPO being right is not the same as the import being right.  #2846 launched
+# from a fresh worktree with a correct VTS_REPO and correct PYTHONPATH and still
+# imported the shared vts-calib checkout, via the venv's editable-install finder
+# (the `.shadow` shim that neutralises it is untracked, so a new worktree has
+# none).  That run only noticed because the branch had *added* a symbol; a branch
+# that merely changes behaviour would have produced a clean, plausible, wrong
+# table.  So resolve the import the way a job does - through common.setup_env() -
+# and check where it landed.
+if [[ -n "$REPO" && -d "$REPO/vtscore" ]]; then
+  RESOLVED=$(CALIB_EXP="$EXP" python - "$REPO" <<'PY' 2>/dev/null
+import pathlib, sys
+sys.path.insert(0, str(pathlib.Path(sys.argv[1]) / "scripts" / "experiments" / "calibration"))
+import common
+common.setup_env()
+import vtscore
+print(pathlib.Path(vtscore.__file__).resolve())
+PY
+)
+  if [[ -z "$RESOLVED" ]]; then
+    say_fail "could not resolve 'import vtscore' - is the venv active (source gridenv.sh)?"
+  else
+    REPO_REAL=$(cd "$REPO" && pwd -P)
+    case "$RESOLVED" in
+      "$REPO_REAL"/*) say_ok "import vtscore -> $RESOLVED" ;;
+      *)
+        say_fail "import vtscore resolves to $RESOLVED"
+        echo "        -> that is NOT $REPO_REAL; the jobs would measure another checkout"
+        echo "        -> source this worktree's gridenv.sh (it creates .shadow and pins VTS_REPO)"
+        ;;
+    esac
+  fi
+fi
+
 echo
 if [[ "$FAILED" == "1" ]]; then
   echo "PREFLIGHT FAILED - fix the above before launching (or --warn-only if deliberate)"


### PR DESCRIPTION
#2879 answered #2846 (the Gumbel repair is worth −0.0004, n.s. — do not promote) and, along the way, turned up something bigger: the study's baseline had shipped out from under it. `pooled_mid` *reconstructs* the production rule of #2836's era, and by the time of the re-measure production had moved to the fold-anchored κ=0.3 threshold, so "beats the shipped midpoint" quietly stopped meaning "beats what we ship" on 84 % of steps.

That PR's recommendations left four things undone: two mechanically checkable failures written down in `LESSONS.md` as **"Still advice"**, and two reading traps documented in prose in `REMEASURE-2846.md`. Per the repo's own rule — a mechanically checkable failure gets a check, not a paragraph — all four are now code. Its remaining recommendations (close #2846, annotate `REPORT.md`) are discharged too.

## A baseline that cannot go stale

`analyze_cut.py` gains `base_row_contrasts`: every shippable rule and both oracles paired **within-step against the run's own base row** — the threshold production actually used on that step, whatever path it took — written to `agg/cut_contrasts_vs_base.csv` with the base row's `threshold_provenance` recorded alongside, so a contrast is never read without knowing what it was against.

`decisions` follows it. The ship gate is now `beats_production` (plus the unchanged oracle-distance and control-arm conditions), and `ship_candidate` names the rule chosen against production. `beats_midpoint` survives as the historical #2836 contrast and gates nothing. A baseline that is *read* rather than *reconstructed* cannot expire, so the next incumbent can ship without invalidating anyone's conclusions.

`decisions.family_headroom_exhausted` mechanises #2879's closing finding. `pooled_sim_oracle` is the empirical rate-loss minimiser over the sim scores read with true labels, with no parametric form at all, so it bounds every rule that picks a threshold from that sim set; when *it* cannot beat production (−0.0059, p = 0.22 in that run), no unsupervised member of that set will. A later run is told that, instead of having to rediscover it by hand.

## A rule cannot be added and then silently ignored

`SHIPPABLE` is an allowlist, and the ship decision plus both contrast tables read through it — so a rule added to `_SAFE_GMM_VARIANTS` without a matching entry is not an error, it is *omitted from the verdict* while still appearing in the window means. That is the same shape of quietly-wrong table this line keeps producing, and #2881 is about to add a `tail_alpha` rule. `decisions.unclassified_variants` now names any unclassified variant and the analyzer logs a warning; the `image_*` geometry arm and `xcal_only` are classified as deliberate non-candidates so it does not cry wolf.

## The import that lands somewhere else

`preflight.sh` gains a check: resolve `import vtscore` the way a job does — through `common.setup_env()` — and fail if the file it lands on is outside `VTS_REPO`, naming both paths. #2846 launched from a fresh worktree with a correct `VTS_REPO` and a correct `PYTHONPATH` and still imported the shared `vts-calib` checkout; it was only visible because the branch had *added* a symbol. A branch that merely changes behaviour would have produced a clean, plausible, wrong table.

## The two reading traps

- `agg/cut_fallback_reasons.csv` is windowed — `all_steps` plus one row set per window — instead of an all-steps count sitting next to ramp-window fallback *rates*, which is the confusion the report had to warn about in prose.
- `decisions.tail_alpha_stable` is replaced by `tail_alpha_stable_gauss` and `tail_alpha_stable_evt`, each named after the model it judges. The old single key was the Gaussian row, and a reader finding it `false` next to a passing EVT row drew the opposite conclusion from what the table says.

## Alignment with #2881

#2881 (the one-constant EVT tail-α run) was filed eleven minutes after #2879 merged and lands on the same surfaces. It is not in conflict, and three of its lines are affected:

- its **item 3** ("pair against the base row, not `pooled_mid`") is built here, so that run consumes the table rather than building one;
- its **item 4** (report the fallback rate against the 24.9 % / 19.6 % figures) now compares like with like, because those are ramp-window rates and the file used to be all-steps;
- its **"Reading trap"** pointer — `decisions.tail_alpha_stable` at `analyze_cut.py:645` — is superseded by the split keys, and its stale line reference is called out on the issue.

Details posted as a comment on #2881, and #2883 (which carries #2879's "aim at the fit, not the cut" recommendation) now states explicitly that it does **not** supersede #2881, so nobody closes one as covered by the other.

## Testing

`selftest_analyze_cut.py` now plants #2846's field condition: production is anchored and *cheaper* than the planted winner on half the cells, so the midpoint contrast says ship and the base row says no. The suite asserts the analyzer follows the base row (`ship_candidate`, `beats_production`, `ship == false` despite `beats_midpoint == true`), that the fidelity failure is broken down 1:1 by production path, that both tail keys are present and the old one is gone, that a fallback planted outside the ramp is not reported inside it, and that a planted unknown rule is named rather than dropped. **32/32 pass** (was 18/18).

Full `./run-tests.sh`: **7849 passed, 1 skipped, 2 xpassed** — including `ruff check` / `ruff format` / `codespell` / `deptry` / `pyright` / the frontend build. `preflight.sh` was exercised on both paths (a worktree whose import resolves inside it, and one whose import escapes).

## Issue admin from #2879's recommendation

- **#2846 closed** as `not_planned`, with a comment carrying the verdict and a pointer to `REMEASURE-2846.md`. No plan file referenced it, so there was no pointer to prune.
- **#2883 filed** for the successor question — aim the next study at the *fit*, where `transfer` is +0.041 and two thirds of the total — with the base-row pre-registration and the "do not trust the theory bench on this family" constraint written into it.

No `vtscore/` or app-path code changed: this is the experiment harness, the analyzer, and its docs.

Refs #2879, refs #2846, refs #2881, refs #2883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVc6U42eBkacHUK2V8bHcV