### PR TITLE
Record staging imports under a dataset_stage task family

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -569,8 +569,9 @@ python scripts/profiling/tune_timing_profile.py --drive \
 By default `--drive` runs only the read-only families (opening a dataset, text
 search, Find). The others mutate state — loading a detector seeds example votes,
 **train-and-score overwrites the active dataset's labels**, promote creates a
-dataset, an import writes one — so they require `--allow-mutating` and should be
-pointed at a scratch `--data-dir`, never at live user data.
+dataset, an import writes one, a staging import leaves a pkl behind — so they
+require `--allow-mutating` and should be pointed at a scratch `--data-dir`, never
+at live user data.
 
 Either way the script ends by printing a coverage report naming which task
 families got measured and which fell back to the defaults, so a thin sweep is

--- a/scripts/profiling/tune_timing_profile.py
+++ b/scripts/profiling/tune_timing_profile.py
@@ -31,8 +31,9 @@ against datasets and detectors you name::
 By default ``--drive`` runs only the **read-only** families: opening a dataset,
 text search, and Find. The rest mutate state — loading a detector seeds example
 votes, train-and-score *overwrites the active dataset's labels*, promote creates
-a dataset, and an import writes one — so they need ``--allow-mutating`` and
-should be pointed at a scratch ``--data-dir``, never at live user data.
+a dataset, an import writes one, and a staging import leaves a pkl behind — so
+they need ``--allow-mutating`` and should be pointed at a scratch ``--data-dir``,
+never at live user data.
 
 Both modes end the same way: the fit runs, the profile is written, and a coverage
 report says exactly which task families got measured and which fell back to the
@@ -73,7 +74,12 @@ _MUTATING_TASKS = {
     "train_and_score": "OVERWRITES every label in the active dataset (replace_all)",
     "dataset_promote": "creates new datasets in the registry",
     "dataset_load": "imports demo datasets, downloading and writing them",
+    "dataset_stage": "imports demo datasets into staging pkls (no registry entry)",
 }
+
+#: Families driven from ``--demo`` ids rather than from registry datasets, so a
+#: sweep of only these needs no ``--datasets``.
+_DEMO_DRIVEN_TASKS = frozenset({"dataset_load", "dataset_stage"})
 
 #: How long to wait for one background task before giving up on the cell.
 _TASK_TIMEOUT_S = 3600
@@ -113,7 +119,7 @@ def _parse_args() -> argparse.Namespace:
     )
     ap.add_argument("--datasets", default="", help="comma list of registry dataset ids or names")
     ap.add_argument("--detectors", default="", help="comma list of registry detector ids or names")
-    ap.add_argument("--demo", default="", help="comma list of demo dataset ids for dataset_load")
+    ap.add_argument("--demo", default="", help="comma list of demo dataset ids for dataset_load / dataset_stage")
     ap.add_argument(
         "--queries",
         default="a person,an outdoor scene,music",
@@ -355,6 +361,32 @@ def drive_dataset_load(demo_ids: list[str], reps: int) -> None:
             _wait_for_task(loading_tasks, task_id, f"demo {demo_id}")
 
 
+def drive_dataset_stage(demo_ids: list[str], reps: int) -> None:
+    """Measure staging demo datasets (acquire, embed, serialize; no registry)."""
+    from vtscore.concurrency.progress import loading_tasks  # noqa: PLC0415
+    from vtscore.datasets.config import DEMO_DATASETS  # noqa: PLC0415
+    from vtscore.datasets.importers import get_importer  # noqa: PLC0415
+    from vtscore.datasets.load_pipeline import STAGING_DIR, _stage_importer_in_background  # noqa: PLC0415
+
+    if not demo_ids:
+        _log("SKIPPED dataset_stage: no --demo ids given")
+        return
+    importer = get_importer("demo")
+    for demo_id in demo_ids:
+        info = DEMO_DATASETS.get(demo_id)
+        if info is None:
+            _log(f"SKIPPED demo {demo_id}: unknown demo dataset")
+            continue
+        for rep in range(reps):
+            _log(f"dataset_stage {demo_id} rep {rep + 1}/{reps}")
+            task_id = _stage_importer_in_background(
+                importer,
+                {"name": demo_id, "media_type": info.get("media_type", ""), "embedder": ""},
+            )
+            _wait_for_task(loading_tasks, task_id, f"staging demo {demo_id}")
+    _log(f"NOTE: dataset_stage left staged pkls in {STAGING_DIR}; delete them when done.")
+
+
 def run_drivers(args: argparse.Namespace, tasks: list[str]) -> None:
     """Dispatch each requested family's driver against the resolved inputs."""
     import app as app_module  # noqa: PLC0415 - wires Flask + every plugin registry
@@ -362,7 +394,7 @@ def run_drivers(args: argparse.Namespace, tasks: list[str]) -> None:
     app_module.app.config["TESTING"] = True
     datasets = _resolve_datasets(_split(args.datasets))
     detectors = _resolve_detectors(_split(args.detectors))
-    if not datasets and tasks != ["dataset_load"]:
+    if not datasets and not set(tasks) <= _DEMO_DRIVEN_TASKS:
         _log("nothing to drive: no datasets matched. Load or name at least one registry dataset.")
     with app_module.app.test_client() as client:
         if "dataset_open" in tasks:
@@ -379,6 +411,8 @@ def run_drivers(args: argparse.Namespace, tasks: list[str]) -> None:
             drive_dataset_promote(client, datasets, args.reps)
     if "dataset_load" in tasks:
         drive_dataset_load(_split(args.demo), args.reps)
+    if "dataset_stage" in tasks:
+        drive_dataset_stage(_split(args.demo), args.reps)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/datasets/test_dataset_load_timing_rows.py
+++ b/tests/datasets/test_dataset_load_timing_rows.py
@@ -10,6 +10,11 @@ These tests drive a real load through ``_run_origin_load_in_background`` on the
 calling thread and assert the rows land — and that they land in a shape the
 fitter accepts, since rows the fitter rejects are as useless as rows never
 written.
+
+Staging imports (``_stage_importer_in_background``, the combine flow's half of
+an import) are covered too, under their own ``dataset_stage`` family: they stop
+before dedup, the coverage atlas, and the registry write, so recording them as
+``dataset_load`` would teach the fit that finalize is free.
 """
 
 from __future__ import annotations
@@ -148,5 +153,96 @@ class TestDatasetLoadRecordsTimingRows:
         monkeypatch.delenv(RECORD_ENV_VAR, raising=False)
 
         _run_load(tmp_path)
+
+        assert not sink.exists()
+
+
+class _StubImporter:
+    """The smallest thing ``_stage_importer_in_background`` will accept."""
+
+    fields: list = []
+
+    def __init__(self, run=None):
+        self._run = run or _fake_load
+
+    def run(self, field_values, target_medias, **kwargs):
+        self._run(target_medias)
+
+    def resolve_display_name(self, field_values):
+        return "stub staging import"
+
+
+def _run_staging(tmp_path, monkeypatch, run=None) -> str:
+    """Stage one import synchronously, leaving its pkl under *tmp_path*."""
+    from vtscore.datasets import load_pipeline
+    from vtscore.datasets.load_pipeline import _stage_importer_in_background
+
+    monkeypatch.setattr(load_pipeline, "STAGING_DIR", tmp_path / "staging")
+    with mock.patch(
+        "vtscore.datasets.load_pipeline.threading.Thread",
+        side_effect=_sync_thread_factory(),
+    ):
+        return _stage_importer_in_background(
+            _StubImporter(run),
+            {"media_type": "audio", "embedder": "clap"},
+        )
+
+
+class TestStagingImportRecordsTimingRows:
+    """The staging half of an import records under its own task family."""
+
+    def test_staging_import_appends_rows(self, isolated_settings, tmp_path, monkeypatch):
+        sink = tmp_path / "timings.jsonl"
+        monkeypatch.setenv(RECORD_ENV_VAR, str(sink))
+
+        _run_staging(tmp_path, monkeypatch)
+
+        assert sink.exists(), "a staging import with the recorder armed must write rows"
+        rows = load_rows([str(sink)])
+        assert rows
+        assert {r["task"] for r in rows} == {"dataset_stage"}
+
+    def test_rows_cover_the_staging_steps_and_survive_the_fitter(self, isolated_settings, tmp_path, monkeypatch):
+        sink = tmp_path / "timings.jsonl"
+        monkeypatch.setenv(RECORD_ENV_VAR, str(sink))
+
+        _run_staging(tmp_path, monkeypatch)
+
+        rows = load_rows([str(sink)])
+        assert {r["step"] for r in rows} == {"acquire", "embed", "serialize"}
+        assert all(r["ok"] and r["complete"] for r in rows)
+        assert all(r["n"] == 1 for r in rows), "the staged item count must ride along as the scale variable"
+        assert all(r["media_type"] == "audio" and r["embedder"] == "clap" for r in rows)
+        assert all(normalize_row(r) is not None for r in rows)
+
+    def test_staging_is_not_recorded_as_a_dataset_load(self, isolated_settings, tmp_path, monkeypatch):
+        """Staging skips dedup, the atlas, and the registry write, so folding it
+        into ``dataset_load`` would fit a finalize phase that never ran."""
+        sink = tmp_path / "timings.jsonl"
+        monkeypatch.setenv(RECORD_ENV_VAR, str(sink))
+
+        _run_staging(tmp_path, monkeypatch)
+
+        assert "dataset_load" not in {r["task"] for r in load_rows([str(sink)])}
+
+    def test_failed_staging_is_marked_not_ok(self, isolated_settings, tmp_path, monkeypatch):
+        sink = tmp_path / "timings.jsonl"
+        monkeypatch.setenv(RECORD_ENV_VAR, str(sink))
+
+        def _boom(target_medias):
+            raise RuntimeError("importer exploded")
+
+        _run_staging(tmp_path, monkeypatch, run=_boom)
+
+        rows = load_rows([str(sink)])
+        assert rows, "even a failed staging run should record what it measured"
+        assert all(not r["ok"] for r in rows)
+        assert all(normalize_row(r) is None for r in rows)
+
+    def test_disarmed_recorder_writes_nothing(self, isolated_settings, tmp_path, monkeypatch):
+        sink = tmp_path / "timings.jsonl"
+        monkeypatch.delenv(RECORD_ENV_VAR, raising=False)
+
+        _run_staging(tmp_path, monkeypatch)
 
         assert not sink.exists()

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -57,7 +57,7 @@ from vtscore.datasets.stages.finalize import (
 from vtscore.datasets.stages.projection import _build_projection_stage, _maybe_signpost_texts_stage
 from vtscore.datasets.stages.registry import _register_and_migrate
 from vtscore.datasets.thumbnail_warm import start_archive_thumbnail_warm
-from vtscore.timing import record_task
+from vtscore.timing import record_task, step_weights
 
 
 # Two independent gates control how many dataset loads can run concurrently
@@ -773,6 +773,10 @@ def _demo_load_hints(importer, field_values: dict) -> tuple[str, int | None, flo
 
 STAGING_DIR = DATA_DIR / "staging"
 
+#: Task family and step count for a staging import (see vtscore.timing.tasks).
+_STAGE_TASK = "dataset_stage"
+_TOTAL_STAGE_STEPS = 3  # acquire, embed, serialize
+
 
 def _stage_importer_in_background(importer, field_values: dict, label: str = "") -> str:
     """Run *importer*.run() in a daemon thread, saving the result to a staging pkl.
@@ -801,14 +805,25 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
 
     task_id = f"_staging_{uuid4().hex[:8]}"
     display_name = label or importer.resolve_display_name(field_values)
+    staged_media_type = _normalize_media_type(field_values.get("media_type", ""))
+    staged_embedder = field_values.get("embedder", "") or ""
     tracker = loading_tasks.create_task(
         task_id,
         display_name,
-        media_type=_normalize_media_type(field_values.get("media_type", "")),
-        embedder=field_values.get("embedder", "") or "",
+        media_type=staged_media_type,
+        embedder=staged_embedder,
         extra_fields={"staging_result": None},
+        step_weights=step_weights(_STAGE_TASK, media_type=staged_media_type, embedder=staged_embedder),
     )
-    tracker.update("loading", "Preparing dataset…", 0, 0)
+    # Staging reports the same step structure every other long-running family
+    # does, which is what earns it a whole-job bar and an ETA — and what lets the
+    # timing recorder below label each measured duration with the phase it
+    # belongs to. The importer's own progress calls come through stepless, and
+    # the tracker keeps the last step it was told, so stamping the boundaries
+    # here is enough.
+    timing_recorder = record_task(tracker, _STAGE_TASK, media_type=staged_media_type, embedder=staged_embedder)
+    timing_recorder.start()
+    tracker.update("loading", "Preparing dataset…", 0, 0, step=1, total_steps=_TOTAL_STAGE_STEPS)
 
     def stage_task():
         from vtsearch.auth import thread_user  # noqa: PLC0415
@@ -821,6 +836,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                 temp_medias: dict = {}
                 importer.run(field_values, temp_medias)
                 apply_custom_metadata_md5(temp_medias)
+                tracker.update("embedding", "Embedding…", 0, 0, step=2, total_steps=_TOTAL_STAGE_STEPS)
                 embed_missing(temp_medias, field_values.get("embedder", "") or "", on_progress=tracker.update)
                 from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
 
@@ -833,8 +849,10 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                 first = next(iter(temp_medias.values()))
                 media_type = first.get("media_type", "audio")
                 count = len(temp_medias)
+                timing_recorder.set_scale(n=count)
                 name = label or importer.resolve_display_name(field_values)
 
+                tracker.update("loading", "Writing staged file…", 0, 0, step=3, total_steps=_TOTAL_STAGE_STEPS)
                 data_bytes = export_dataset_to_file(temp_medias)
                 del temp_medias
                 gc.collect()
@@ -850,6 +868,8 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                     f"Staged: {name} ({count} medias)",
                     100,
                     100,
+                    step=_TOTAL_STAGE_STEPS,
+                    total_steps=_TOTAL_STAGE_STEPS,
                     staging_result={"path": str(staging_path), "name": name, "count": count, "media_type": media_type},
                 )
             except ImportError as e:
@@ -876,6 +896,10 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                 error_msg = str(e) or repr(e) or "Unknown error during staging"
                 tracker.update("idle", "", 0, 0, error=error_msg)
             finally:
+                # Every branch above parks the tracker at "idle", setting
+                # ``error`` when it failed — which is what says whether these
+                # phase timings describe a staging run worth fitting.
+                timing_recorder.finish(ok=not tracker.get().get("error"))
                 clear_thread_progress()
                 loading_tasks.mark_finished(task_id)
 

--- a/vtscore/timing/tasks.py
+++ b/vtscore/timing/tasks.py
@@ -126,6 +126,19 @@ TASKS: dict[str, TaskSpec] = {
         "media items in the promoted subset",
         (6.0, 3.5, 0.5),
     ),
+    # Staging an import: run the importer, embed what it produced, serialize the
+    # result to a staging pkl. Deliberately *not* modelled as a ``dataset_load``:
+    # staging stops before dedup, the coverage atlas, and the registry write (a
+    # later promote pays those), so folding its runs into the load fit would
+    # teach that finalize is free. No byte-scaled phases here — the staging path
+    # is never told an archive size, so a per-MB rate would have nothing to
+    # divide by.
+    "dataset_stage": _linear(
+        "dataset_stage",
+        ("acquire", "embed", "serialize"),
+        "media items staged",
+        (0.30, 0.60, 0.10),
+    ),
     # Loading a saved detector: read its labelset, pull the label examples back
     # into the active dataset, retrain the MLP. Training dominates; the other
     # two are quick I/O.


### PR DESCRIPTION
Closes #2889

## What this fixes

#2845 reported that no rows reached `VTSEARCH_TIMING_RECORD` for dataset imports. PR #2848 fixed the **direct** import path and the issue was closed — but `_stage_importer_in_background`, the combine flow's half of an import, was never covered. It still drove a stepless progress bar and never subscribed the timing recorder, so a staged import produced zero rows and no ETA.

## What changed

- **New `dataset_stage` task family** (`vtscore/timing/tasks.py`): steps `acquire` / `embed` / `serialize`, weights `0.30 / 0.60 / 0.10`.

  Modelled as its own family rather than folded into `dataset_load` because staging stops before dedup, the coverage atlas, and the registry write — recording it as a load would fit a finalize phase that never ran. No byte-scaled phases either: the staging path is never told an archive size, so a per-MB rate would have nothing to divide by.

- **`load_pipeline.py`**: threads `step_weights(...)` into `loading_tasks.create_task`, stamps the three step boundaries, and wraps the run in `record_task(...)` with `start()` / `set_scale(n=count)` / `finish(ok=...)`. The `finish` call sits in the existing `finally` and reads the tracker's `error` field, so a failed staging run is marked not-ok and the fitter drops it.

  Side effect of having steps: the staging bar now gets a whole-job overall fraction and an ETA like every other long-running task.

- **`scripts/profiling/tune_timing_profile.py`**: adds the `--drive` driver for the new family, and fixes the "nothing to drive" guard that only exempted `dataset_load` from requiring `--datasets`.

- **`docs/DEPLOYMENT.md`**: documents the new family.

## Provenance

This is commit `f1ed2ff9`, cherry-picked from the stale branch `claude/issue-2845-43q89m`. It was pushed there after PR #2848 merged, but no PR was ever opened, so the work sat unlanded for two days. It applied cleanly to current `dev` and every API it uses (`step_weights`, `record_task`, `create_task(step_weights=...)`) is unchanged. Original authorship is preserved in the commit.

## Testing

`./run-tests.sh` — **7854 passed, 1 skipped, 2 xpassed**; no failures or diagnostics, including ruff, `ruff format --check`, codespell, deptry, pip-audit, pyright, the OpenAPI snapshot, the Angular `build:prod`, and the Vitest suite.

Includes 96 lines of new tests in `tests/datasets/test_dataset_load_timing_rows.py` covering the staging path end-to-end: an armed recorder must write rows the fitter accepts, and a failed staging run must be marked not-ok.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsLZgUjr3QtEwn2MnNuccq)_