### PR TITLE
Build the one-constant EVT tail-α cut rule, its α sweep, and the run's pre-registration

### DIFF
--- a/docs/experiments/gmm-cut/PREREG-2881.md
+++ b/docs/experiments/gmm-cut/PREREG-2881.md
@@ -1,0 +1,154 @@
+# Pre-registration: the one-constant EVT tail-α cut (issue #2881)
+
+**Written before the run.** Nothing below may be edited after the cells array is
+submitted; the run's findings go in a separate `REPORT-2881.md`. The point of
+writing it down is that this family has now been mis-sized twice by the theory
+bench in the same direction (#2836, #2846), and a prediction recorded afterwards
+is not a prediction.
+
+## BLUF — the prediction
+
+**The tail rule will not beat production, and the EVT line closes with it.**
+
+Concretely, at the pre-registered α = 0.158, against the run's own base row on
+the production arm's ramp window: `mean_d_cost` **inside ±0.005 with p > 0.05**.
+That is the honest prior, and it is the outcome this run is expected to produce.
+
+The reasoning is not about this rule specifically. `pooled_sim_oracle` is the
+empirical rate-loss minimiser over the sim scores *read with true labels*, with
+no parametric form at all, so it upper-bounds every rule that picks a threshold
+from that sim set — a Gumbel tail quantile included. #2846 measured it at
+−0.0059 against production, p = 0.22: **the whole unanchored cut family already
+has no measurable headroom left.** A tail-α rule is still a cut of the same
+unanchored fit.
+
+What makes it worth one run anyway: it is cheap (closed form, no extra fit, it
+rides along in the existing cells array), it is the only EVT variant whose
+fallback rate is not the thing killing it, and it is the one piece of the family
+the data has twice declined to refute.
+
+## The rule
+
+`tail_a<α>` cuts where the fitted **Bad** component still has α of its mass above
+the cut — the inverse of the `oracle_lo_sf_evt` diagnostic that #2836 and #2846
+both recorded but neither measured *as a rule*. One constant. No `lam`, no tilt,
+no crossing, and no orientation question.
+
+Solved on the **logit axis**, where the EVT fit lives, then squashed back
+(`vtscore/eval/cut_rules.py`, `tail_cuts`). Closed form in both orientations
+(`GumbelNormalFit1D.lo_quantile`):
+
+| the low component is | cut |
+|---|---|
+| the Gumbel | `loc − scale·ln(−ln(1−α))` — at α = 0.158, `loc + 1.761·scale` |
+| the Normal (swapped fit) | `mu + sd·Φ⁻¹(1−α)` |
+
+It branches exactly as `lo_survival` does, so a swapped fit reports the Normal's
+tail rather than a plausible number read off the wrong component.
+
+## Why the fallback rate should collapse
+
+Every `hi_owns_lo_mode` / `lo_owns_hi_mode` decline in #2846's fallback table
+exists because a *crossing* may not exist between the modes. A tail quantile
+always exists for a non-degenerate fit. **Prediction: the tail rules' fallback
+rate goes to the EVT fit-failure rate alone (1.3–3.0 %)**, against the 24.9 % /
+19.6 % the crossing rules carried.
+
+Read this off `agg/cut_fallback_reasons.csv`, **`window == "ramp_6_20"` rows** —
+those 24.9 % / 19.6 % figures are ramp-window rates, and the file also carries an
+`all_steps` row set that is a different population.
+
+If the tail rules' fallback rate is *not* near-zero, the implementation is wrong,
+not the hypothesis. That is a harness failure, not a finding.
+
+## The α sweep, and what it is for
+
+Seven levels: **0.04, 0.08, 0.11, 0.158, 0.22, 0.30, 0.40**, spaced so the *cut*
+moves in near-even steps (`loc + {3.20, 2.48, 2.15, 1.76, 1.39, 1.03, 0.67}·scale`)
+rather than α, which is logarithmic in the cut.
+
+The stability finding says the oracle cut sits at a stable *level* (median 0.158,
+IQR ratio 2.38 over 511 cells). That is a claim about where the optimum **is**,
+not about what it costs to aim there, and the two come apart if the cost curve is
+steep. So the claim actually being tested is **flatness**:
+
+> **Pre-registered bar.** The α levels whose cost is within one standard error of
+> the best level's must span a factor of **≥ 2** in α. A constant that can be
+> wrong by 2× and still land inside the noise will transfer to another dataset;
+> one that cannot is a number fitted to this run.
+
+Reported as `decisions.tail_curve_is_flat`, with the curve in
+`agg/cut_tail_alpha_curve.csv`. Its sibling
+`decisions.tail_preregistered_alpha_in_flat_band` says whether 0.158 is still
+*inside* that band — membership, not equality with the argmin, because demanding
+the exact argmin would fail on noise alone. If 0.158 falls outside the band, the
+constant does not carry across runs, which is the same conclusion as a steep
+curve by another route.
+
+## The sweep does not get seven shots at the ship gate
+
+**Only α = 0.158 is a ship candidate.** The other six levels are measured and
+reported but are excluded from `best_by_cost`, `best_vs_production`,
+`closest_to_oracle` and the ship gate (`analyze_cut.SWEEP_ONLY`, named in
+`decisions.sweep_only_variants`).
+
+A sweep varies a free parameter. Handing all seven levels to a two-sided 5 % bar
+buys roughly a 30 % chance of a "winner" from noise alone, and this study line has
+already paid twice for a wrong-but-plausible read. If the curve's minimum lands
+somewhere other than 0.158, that is a finding for the *next* pre-registration —
+evidence that the constant does not transfer — not a rule to ship off this run.
+
+## The baseline
+
+Paired **within-step against the run's own base row** — the threshold production
+actually used on that step, whatever path it took — from
+`agg/cut_contrasts_vs_base.csv`, with `base_provenance` recorded alongside.
+`pooled_priorfree` and `pooled_sim_oracle` come out of the same table for
+continuity with the two prior reports.
+
+Not `pooled_mid`. That variant *reconstructs* the production rule of #2836's era
+and by #2846 it reproduced the shipped threshold on only 16 % of steps; the
+`beats_midpoint` column survives as the historical #2836 contrast and gates
+nothing.
+
+## What would count as a positive
+
+All four, on the production arm's ramp window:
+
+1. α = 0.158 beats the base row: `mean_d_cost < 0` at p < 0.05.
+2. The curve is flat by the bar above — otherwise the constant is this run's, not
+   a constant.
+3. `pooled_tail_a158` is in `closest_to_oracle_tied`. A rule that is right on
+   average and wrong step by step is not a rule.
+4. No significant regression on the `whole_image` control arm, which
+   `calculate_gmm_threshold` also serves through the cosine/text sort.
+
+Anything less is the negative result predicted above.
+
+## What closes the line
+
+If α = 0.158 lands inside the noise — **close #2881, and close the EVT cut line
+with it.** Not "try another α", not "try another tail model": the bound in the
+BLUF says the axis is exhausted, and #2883 already carries the successor
+question (aim at the *fit*, where `transfer` is +0.041 and two thirds of the
+total). Keep the `tail_a*` rules as measured variants, as `gumbel_any_*` was
+kept; do not promote them.
+
+The one result that would reopen it is a flat curve with a *negative* mean that
+misses significance — that is an underpowered measurement rather than a null, and
+it would justify one larger run at α = 0.158 alone.
+
+## Scope
+
+- Rides along inside the existing `CALIB_SAFE_THRESHOLDS=1` cells array
+  (`launch_tail_2881.sh`): same arms, sizing and seeds as #2836/#2846, so the
+  contrasts stay comparable to the numbers those reports produced. No extra fit
+  per step — the tail rules read the EVT fit that is already computed.
+- The theory bench is **not** run. Its `CANDIDATE_RULES` list does not include
+  the tail family, deliberately: the bench mis-sized this family twice in the
+  same direction, and #2846's recommendation was to stop trusting it here.
+- At inclusion 0 the cost weights are (1, 1), so `rate` and `priorfree` are the
+  same rule in the comparison tables — as in both prior reports. The tail rules
+  have no cost-weight dependence at all, which is a difference worth remembering
+  when reading them next to the tilted ones.
+- Every contrast is within-step, so none of it sees acquisition feedback.

--- a/docs/experiments/gmm-cut/REMEASURE-2846.md
+++ b/docs/experiments/gmm-cut/REMEASURE-2846.md
@@ -198,7 +198,9 @@ numbers excluded the ~14 % of fits #2836 discarded. Those fits are now kept and
 no crossing at all — which is now the only part of the EVT work with a future,
 given that the crossing rules do not clear the plain Gaussian `priorfree`, let
 alone production. Tracked as #2881 — nobody has measured it *as a rule*;
-`oracle_lo_sf_evt` is recorded only diagnostically, at the oracle cut.
+`oracle_lo_sf_evt` is recorded only diagnostically, at the oracle cut. *(The rule
+and its α sweep now exist, and the run is pre-registered in `PREREG-2881.md` —
+including the prediction that it lands inside the noise and closes this line.)*
 
 > A reading trap in this run's `summary_cut.json`: `decisions.tail_alpha_stable:
 > false` refers to the **Gaussian** row (`analyze_cut.py` keyed it off

--- a/scripts/experiments/calibration/analyze_cut.py
+++ b/scripts/experiments/calibration/analyze_cut.py
@@ -25,6 +25,11 @@ three falsifiable predictions the issue pre-registers: that the realised
 ``cross - mid`` offset matches its closed form, that the per-step cost penalty
 scales with that offset, and that the prior-free crossing beats both incumbents.
 
+**The tail sweep** (#2881) rides along in both halves: ``tail_alpha_stability``
+says where the oracle cut sits in the fitted Bad tail, and ``tail_alpha_curve``
+says what it costs to aim there, as a function of the one constant.  Its
+pre-registration is ``docs/experiments/gmm-cut/PREREG-2881.md``.
+
 Writes ``results/summary_cut.json``, ``results/agg/cut_*.csv``,
 ``results/figures/cut_*.png`` and a ``results/REPORT_CUT.md`` draft.
 """
@@ -32,6 +37,7 @@ Writes ``results/summary_cut.json``, ``results/agg/cut_*.csv``,
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import common
@@ -40,6 +46,8 @@ common.setup_env()
 
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
+
+from vtscore.eval.cut_rules import TAIL_ALPHA_PREREGISTERED, TAIL_RULES  # noqa: E402
 
 #: Vote-count windows (inclusive).  Below 6 votes the blend is pure GMM (total
 #: authority, but #2799 showed the app shows no trained detector before 7 votes);
@@ -51,6 +59,13 @@ PRODUCTION_ARM_SUBSTR = "dinov3_patch/max_patch"
 #: The single-vector arm a winner must not regress (``calculate_gmm_threshold``
 #: also backs the cosine/text sort, which has no region max-pool).
 CONTROL_ARM_SUBSTR = "whole_image"
+
+#: #2881's tail-quantile sweep, as cell-variant names.  Imported rather than
+#: respelled: the analyzer's allowlist going out of step with the rule table is
+#: the exact failure ``unclassified_variants`` exists to shout about, and a rule
+#: family that arrives seven at a time is where a hand-maintained list would
+#: first lose one.
+TAIL_VARIANTS: tuple[str, ...] = tuple(f"pooled_{r}" for r in TAIL_RULES)
 
 #: Rules that could actually ship: unsupervised, computable from the sim scores.
 SHIPPABLE: tuple[str, ...] = (
@@ -64,9 +79,39 @@ SHIPPABLE: tuple[str, ...] = (
     "pooled_gumbel_any_cross",
     "pooled_gumbel_any_priorfree",
     "pooled_gumbel_any_rate",
+    *TAIL_VARIANTS,
 )
+
+#: Measured and reported, but **not eligible to be the ship candidate**.
+#:
+#: The tail sweep varies one free parameter, so handing all seven levels to a
+#: 5 %-bar ship gate would be seven shots at it — and the sweep would then
+#: "win" on this run at whatever alpha the noise favoured, which is precisely the
+#: wrong-but-plausible result that has cost this study line two runs already.
+#: The pre-registered constant (0.158, #2846's median over 511 cells) is the only
+#: tail level that can ship; the other six exist to show the *shape* of the cost
+#: curve in alpha, which is the actual claim the stability finding makes.  If the
+#: curve turns out to peak somewhere else entirely, that is a finding for the
+#: next pre-registration, not a rule to ship off this run.
+SWEEP_ONLY: tuple[str, ...] = tuple(
+    v for v in TAIL_VARIANTS if v != f"pooled_tail_a{round(TAIL_ALPHA_PREREGISTERED * 1000):03d}"
+)
+#: What the ship decision, the oracle-distance tie-break and ``best_by_cost`` read.
+SHIP_ELIGIBLE: tuple[str, ...] = tuple(v for v in SHIPPABLE if v not in SWEEP_ONLY)
+
 #: Label-reading diagnostics — bounds and decomposition anchors, never candidates.
 ORACLE_VARIANTS: tuple[str, ...] = ("pooled_supervised", "pooled_sim_oracle")
+
+#: ``pooled_tail_a158`` -> ``0.158``.  Parsed from the *data's* variant names
+#: rather than read off the imported grid, so re-analyzing an older run whose
+#: sweep used different levels still labels its own curve correctly.
+_TAIL_RE = re.compile(r"^pooled_tail_a(\d{3})$")
+
+
+def tail_alpha_of(variant: str) -> float | None:
+    m = _TAIL_RE.match(str(variant))
+    return int(m.group(1)) / 1000.0 if m else None
+
 
 #: Deliberately not ship candidates: ``xcal_only`` is the no-blend control, and
 #: the ``image_*`` family is the single-vector geometry arm, measured for
@@ -155,9 +200,10 @@ def unclassified_variants(df: pd.DataFrame) -> list[str]:
     and the oracle-distance tie-break all read through it.  So a rule added to
     ``_SAFE_GMM_VARIANTS`` but not added here does not fail — it is *silently
     omitted from the verdict* while still appearing in the window means, which
-    is the exact shape of wrong table this study line keeps producing.  #2881
-    will add a ``tail_alpha`` rule; this makes forgetting it a visible event
-    rather than a missing row nobody counts.
+    is the exact shape of wrong table this study line keeps producing.  #2881's
+    ``tail_a*`` family was the seven-at-a-time case this was built for; it now
+    imports its own names from the rule table, which is stronger than a warning,
+    but the warning stays for the next rule added by hand.
     """
     known = {*SHIPPABLE, *ORACLE_VARIANTS, *NON_CANDIDATES}
     present = {str(v) for v in df["gmm_variant"].unique() if str(v) != ""}
@@ -233,6 +279,23 @@ def _pair_frames(va: pd.DataFrame, vb: pd.DataFrame, metric_cols: list[str]) -> 
 
 def _window(v: pd.DataFrame, lo: int, hi: int) -> pd.DataFrame:
     return v[(v["n_votes"] >= lo) & (v["n_votes"] <= hi)]
+
+
+def _fill_metric(entry: dict, col: str, series: pd.Series) -> None:
+    """Write one metric's mean / SEM / p (and cost's improved-cell share) into *entry*.
+
+    The SEM is over **cells**, matching the pairing unit, and is what makes "these
+    two rules are indistinguishable" a statement rather than an impression - the
+    alpha sweep in :func:`tail_alpha_curve` needs exactly that to say whether its
+    cost curve is flat near the optimum or a knife-edge.
+    """
+    vals = series.to_numpy(dtype=float)
+    vals = vals[np.isfinite(vals)]
+    entry[f"mean_d_{col}"] = float(np.mean(vals)) if vals.size else float("nan")
+    entry[f"sem_d_{col}"] = float(np.std(vals, ddof=1) / np.sqrt(vals.size)) if vals.size > 1 else float("nan")
+    entry[f"p_d_{col}"] = _wilcoxon(vals) if vals.size else None
+    if col == "cost":
+        entry["frac_cells_improved"] = float(np.mean(vals < 0)) if vals.size else float("nan")
 
 
 def _paired_cells(v: pd.DataFrame, a: str, b: str, lo: int, hi: int, metric_cols: list[str]) -> pd.DataFrame:
@@ -312,12 +375,7 @@ def rule_contrasts(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
                     "n_cells": int(len(cells)),
                 }
                 for col in metrics:
-                    vals = cells[f"d_{col}"].to_numpy(dtype=float)
-                    vals = vals[np.isfinite(vals)]
-                    entry[f"mean_d_{col}"] = float(np.mean(vals)) if vals.size else float("nan")
-                    entry[f"p_d_{col}"] = _wilcoxon(vals) if vals.size else None
-                    if col == "cost":
-                        entry["frac_cells_improved"] = float(np.mean(vals < 0)) if vals.size else float("nan")
+                    _fill_metric(entry, col, cells[f"d_{col}"])
                 rows.append(entry)
     tbl = pd.DataFrame(rows)
     tbl.to_csv(agg_dir / "cut_contrasts.csv", index=False)
@@ -361,12 +419,7 @@ def base_row_contrasts(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
                     "base_provenance": "|".join(sorted(prov.unique())) if len(prov) else "",
                 }
                 for col in metrics:
-                    vals = cells[f"d_{col}"].to_numpy(dtype=float)
-                    vals = vals[np.isfinite(vals)]
-                    entry[f"mean_d_{col}"] = float(np.mean(vals)) if vals.size else float("nan")
-                    entry[f"p_d_{col}"] = _wilcoxon(vals) if vals.size else None
-                    if col == "cost":
-                        entry["frac_cells_improved"] = float(np.mean(vals < 0)) if vals.size else float("nan")
+                    _fill_metric(entry, col, cells[f"d_{col}"])
                 rows.append(entry)
     tbl = pd.DataFrame(rows)
     tbl.to_csv(agg_dir / "cut_contrasts_vs_base.csv", index=False)
@@ -658,6 +711,84 @@ def tail_alpha_stability(diag: pd.DataFrame, agg_dir: Path) -> dict:
     return out
 
 
+def tail_alpha_curve(base_contrasts: pd.DataFrame, agg_dir: Path) -> dict:
+    """#2881's sweep: the cost of "cut the Bad tail at alpha", as a function of alpha.
+
+    :func:`tail_alpha_stability` says the *oracle* cut sits at a stable survival
+    level of the fitted Gumbel low component (median 0.158, IQR ratio 2.38 over
+    511 cells).  That is a statement about where the optimum *is*, not about what
+    it costs to aim there, and the two come apart if the cost curve is steep:
+    a constant calibrated on a median is only transferable if being off by a
+    factor of ~1.5 in alpha is cheap.  So the claim being tested here is
+    **flatness**, and it needs the curve, not the argmin.
+
+    Read against the run's own base row (production), production arm, ramp
+    window — the only baseline that means "beats what we ship" (#2846).
+
+    ``flat_alphas`` are the levels whose cost is within one standard error of the
+    best level's; ``flat_alpha_ratio`` is how wide a band in alpha that spans.
+    The pre-registered bar is a factor of 2: a constant that can be wrong by 2x
+    and still land inside the noise will transfer to another dataset, and one
+    that cannot is a number fitted to this run.
+    """
+    out: dict = {"n_levels": 0, "preregistered_alpha": TAIL_ALPHA_PREREGISTERED}
+    if base_contrasts.empty:
+        return out
+    prod = _ramp_prod(base_contrasts)
+    rows = []
+    for _i, r in prod.iterrows():
+        alpha = tail_alpha_of(r["variant"])
+        if alpha is None:
+            continue
+        rows.append(
+            {
+                "alpha": alpha,
+                "variant": str(r["variant"]),
+                "ship_eligible": str(r["variant"]) not in SWEEP_ONLY,
+                "mean_d_cost": float(r["mean_d_cost"]),
+                "sem_d_cost": float(r["sem_d_cost"]),
+                "p_d_cost": None if r["p_d_cost"] is None else float(r["p_d_cost"]),
+                "frac_cells_improved": float(r["frac_cells_improved"]),
+                "n_cells": int(r["n_cells"]),
+                "base_provenance": str(r["base_provenance"]),
+            }
+        )
+    if not rows:
+        return out
+    curve = pd.DataFrame(rows).sort_values("alpha").reset_index(drop=True)
+    curve.to_csv(agg_dir / "cut_tail_alpha_curve.csv", index=False)
+
+    best = curve.loc[curve["mean_d_cost"].idxmin()]
+    # One SEM of the *best* level: the band inside which another level is not
+    # distinguishable from it.  A NaN SEM (one cell) leaves the band empty rather
+    # than swallowing the whole curve.
+    band = float(best["sem_d_cost"])
+    flat = curve[curve["mean_d_cost"] <= float(best["mean_d_cost"]) + band] if np.isfinite(band) else curve.iloc[[]]
+    prereg = curve[np.isclose(curve["alpha"], TAIL_ALPHA_PREREGISTERED)]
+
+    out.update(
+        n_levels=int(len(curve)),
+        curve=curve.to_dict("records"),
+        best_alpha=float(best["alpha"]),
+        best_mean_d_cost=float(best["mean_d_cost"]),
+        flat_alphas=[float(a) for a in flat["alpha"]],
+        flat_alpha_ratio=(float(flat["alpha"].max() / flat["alpha"].min()) if len(flat) else float("nan")),
+        preregistered=None if prereg.empty else prereg.iloc[0].to_dict(),
+    )
+    # The transferability claim, pre-registered at 2x.
+    out["curve_is_flat"] = bool(np.isfinite(out["flat_alpha_ratio"]) and out["flat_alpha_ratio"] >= 2.0)
+    # Is #2846's median still where this run's optimum is?  Membership in the
+    # flat band, not equality with the argmin: "0.158 is indistinguishable from
+    # the best level here" is the transferability claim, and demanding it be the
+    # exact argmin would fail on noise alone.  If it falls *outside* the band that
+    # is a real finding - the constant does not carry across runs - which is the
+    # same conclusion as a steep curve, by another route.
+    out["preregistered_in_flat_band"] = bool(
+        not prereg.empty and float(prereg.iloc[0]["alpha"]) in set(out["flat_alphas"])
+    )
+    return out
+
+
 def estimator_variance(diag: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
     """Step-to-step jitter of each cut within a cell — rule vs *estimator* quality.
 
@@ -715,6 +846,7 @@ def decisions(
     gaps: pd.DataFrame,
     costs: pd.DataFrame,
     alpha: dict,
+    tail_curve: dict,
 ) -> dict:
     """The issue's pre-registered decision rules, evaluated.
 
@@ -727,12 +859,17 @@ def decisions(
     midpoint contrast quietly became a comparison with a rule nobody runs.
     ``beats_midpoint`` is still reported, as the historical #2836 contrast, but
     it no longer gates the ship decision.
+
+    Every candidate here is drawn from ``SHIP_ELIGIBLE``, not ``SHIPPABLE``: the
+    swept tail levels are measured but cannot win the gate, because a sweep over
+    a free parameter would otherwise get one shot per level at a 5 % bar.  See
+    ``SWEEP_ONLY``.
     """
     out: dict = {}
     if contrasts.empty:
         return {"error": "no contrasts"}
 
-    prod = _ramp_prod(contrasts, SHIPPABLE)
+    prod = _ramp_prod(contrasts, SHIP_ELIGIBLE)
     if prod.empty:
         return {"error": "no production-arm contrasts"}
 
@@ -748,7 +885,7 @@ def decisions(
     out["beats_midpoint"] = _wins(best)
 
     # --- Against what production actually did -------------------------------
-    prod_base = _ramp_prod(base_contrasts, SHIPPABLE)
+    prod_base = _ramp_prod(base_contrasts, SHIP_ELIGIBLE)
     cand = None
     out["best_vs_production"] = None
     out["beats_production"] = False
@@ -787,7 +924,7 @@ def decisions(
     gp = gaps[
         (gaps["window"] == "ramp_6_20")
         & (gaps["arm"].str.contains(PRODUCTION_ARM_SUBSTR))
-        & (gaps["gmm_variant"].isin(SHIPPABLE))
+        & (gaps["gmm_variant"].isin(SHIP_ELIGIBLE))
     ]
     # Several rules in this family are *aliases* rather than competitors - at
     # inclusion 0 the cost weights are (1, 1), so `rate` reduces to `priorfree`
@@ -850,6 +987,17 @@ def decisions(
     # opposite of what that table says (#2846 had to spend a paragraph on it).
     out["tail_alpha_stable_gauss"] = bool(alpha.get("oracle_lo_sf_gauss", {}).get("stable", False))
     out["tail_alpha_stable_evt"] = bool(alpha.get("oracle_lo_sf_evt", {}).get("stable", False))
+
+    # #2881: the tail rule *as a rule*, plus what its sweep says about whether the
+    # one constant transfers.  Named separately from the ship gate above because
+    # only one level is eligible for it - a flat curve is evidence for the rule's
+    # premise, not a licence to ship whichever level came out lowest.
+    out["sweep_only_variants"] = list(SWEEP_ONLY)
+    out["tail_alpha_curve"] = {
+        k: tail_curve.get(k) for k in ("n_levels", "best_alpha", "best_mean_d_cost", "flat_alphas", "flat_alpha_ratio")
+    }
+    out["tail_curve_is_flat"] = tail_curve.get("curve_is_flat")
+    out["tail_preregistered_alpha_in_flat_band"] = tail_curve.get("preregistered_in_flat_band")
     return out
 
 
@@ -864,7 +1012,11 @@ def make_figures(df: pd.DataFrame, diag: pd.DataFrame, fig_dir: Path) -> list[st
         return []
     saved = []
 
-    v = df[df["gmm_variant"].isin((*SHIPPABLE, *ORACLE_VARIANTS))]
+    # The swept tail levels are left off these line plots: seven near-identical
+    # curves would cost the legend its legibility and say nothing the alpha curve
+    # in `cut_tail_alpha_curve.csv` does not say better.  The pre-registered level
+    # is a ship candidate and stays.
+    v = df[df["gmm_variant"].isin((*SHIP_ELIGIBLE, *ORACLE_VARIANTS))]
     for metric in ("cost", "raw_cut_cost"):
         curves = v.groupby(["arm", "gmm_variant", "n_votes"])[metric].mean().reset_index()
         n_arms = max(1, curves["arm"].nunique())
@@ -962,6 +1114,19 @@ def write_report(summary: dict, tables: dict, report_path: Path) -> None:
     lines.append(json.dumps(summary["tail_alpha"], indent=2, default=float))
     lines.append("```")
     lines.append("")
+    curve = summary.get("tail_alpha_curve") or {}
+    if curve.get("curve"):
+        lines.append("## The tail rule as a rule: cost vs alpha (issue #2881)")
+        lines.append("")
+        lines.append("Production arm, ramp 6-20, paired against the run's own base row.")
+        lines.append("Only the pre-registered level is a ship candidate; the rest show the curve's shape.")
+        lines.append("")
+        lines.append(_md(pd.DataFrame(curve["curve"])))
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps({k: v for k, v in curve.items() if k != "curve"}, indent=2, default=float))
+        lines.append("```")
+        lines.append("")
     report_path.write_text("\n".join(lines))
     common.log(f"wrote {report_path}")
 
@@ -996,8 +1161,9 @@ def main() -> int:
     evt = evt_evidence(diag, agg_dir) if not diag.empty else pd.DataFrame()
     why = fallback_reasons(df, agg_dir)
     alpha = tail_alpha_stability(diag, agg_dir) if not diag.empty else {}
+    tail_curve = tail_alpha_curve(base_contrasts, agg_dir)
     est_var = estimator_variance(diag, agg_dir) if not diag.empty else pd.DataFrame()
-    dec = decisions(contrasts, base_contrasts, gaps, costs, alpha)
+    dec = decisions(contrasts, base_contrasts, gaps, costs, alpha, tail_curve)
     # Carried in the decisions block, not only in the log: this is the one place
     # a reader checks before believing a verdict, and the verdict is exactly what
     # an unclassified rule is missing from.
@@ -1014,6 +1180,7 @@ def main() -> int:
         "decisions": dec,
         "offsets": offsets,
         "tail_alpha": alpha,
+        "tail_alpha_curve": tail_curve,
         "figures": figs,
     }
     (common.RESULTS / "summary_cut.json").write_text(json.dumps(summary, indent=2, default=float))

--- a/scripts/experiments/calibration/launch_tail_2881.sh
+++ b/scripts/experiments/calibration/launch_tail_2881.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# One-constant EVT tail-alpha cut (#2881) on the HLTCOE Grid.
+#
+# The tail rules ride along inside the ordinary cut-study cells array: they read
+# the EVT fit that every step already computes, and their cuts are closed form,
+# so this run costs the same as `launch_cut.sh` and produces seven more variant
+# rows per step.  Same arms, sizing and seeds as #2836/#2846 -- the contrasts are
+# paired within a step, so reusing the sizing keeps them directly comparable to
+# the numbers those two reports produced.
+#
+# **Its own CALIB_EXP.** The grid differs from #2846's (seven new variants per
+# step), which makes it a different study; sharing a results dir is how two grids
+# get analysed as one.
+#
+# Pre-registration -- read it before reading the output:
+#   docs/experiments/gmm-cut/PREREG-2881.md
+#
+# The theory bench is deliberately not launched.  Its CANDIDATE_RULES list does
+# not carry the tail family, and #2846's recommendation was to stop trusting the
+# bench on this family after it mis-sized it twice in the same direction.  Set
+# TAIL_WITH_THEORY=1 to launch it anyway (it will measure the crossing rules).
+#
+# Usage: bash launch_tail_2881.sh
+set -uo pipefail
+
+WT="${VTS_REPO:-/exp/$USER/projects/vts-calib}"
+HERE="$WT/scripts/experiments/calibration"
+
+export CALIB_EXP="${CALIB_EXP:-/exp/$USER/calibration-tail2881}"
+export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
+
+export CALIB_SAFE_THRESHOLDS=1
+export CALIB_ANALYZE=analyze_cut.py
+export CALIB_HEAD="${CALIB_HEAD:-linear}"
+
+# Visual Genome region voting; production patch arm + the single-vector control.
+# The control is the ship gate's other half: `calculate_gmm_threshold` also backs
+# the cosine/text sort, which has no max-pool and so no extreme-value tail at all.
+export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m}"
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
+export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"
+export CALIB_SWEEP_KS="${CALIB_SWEEP_KS:-0}"
+
+export CALIB_MAX_STEPS="${CALIB_MAX_STEPS:-30}"
+export CALIB_N_SEEDS="${CALIB_N_SEEDS:-12}"
+
+export CALIB_PARTITION="${CALIB_PARTITION:-cpu}"
+export CALIB_GRES="${CALIB_GRES:-none}"
+export CALIB_MEM="${CALIB_MEM:-24G}"
+export CALIB_CPUS="${CALIB_CPUS:-4}"
+export CALIB_CONC="${CALIB_CONC:-40}"
+export CALIB_TIME="${CALIB_TIME:-1:30:00}"
+
+MAXPATCH="/exp/$USER/max-patch"
+export VTSEARCH_DATA_DIR="${VTSEARCH_DATA_DIR:-$MAXPATCH/datadir}"
+export VTSEARCH_MODELS_DIR="${VTSEARCH_MODELS_DIR:-$MAXPATCH/models}"
+export HF_HOME="${HF_HOME:-/exp/$USER/.cache/huggingface}"
+
+LOGS="$CALIB_EXP/logs"
+mkdir -p "$LOGS"
+
+# The gate, not a reminder.  It also resolves `import vtscore` the way a job does
+# and fails if it lands outside VTS_REPO -- which is exactly how #2846 ran a
+# fresh worktree against the shared checkout with a correct PYTHONPATH.  A branch
+# that only *changes* behaviour (this one adds seven rules, so it would in fact
+# have been caught by the missing-symbol crash, but the next one may not) would
+# otherwise produce a clean, plausible, wrong table.
+bash "$WT/scripts/experiments/preflight.sh" --exp "$CALIB_EXP" --arms siglip,dinov3_patch || exit 1
+
+if [[ -n "${TAIL_WITH_THEORY:-}" ]]; then
+  T=$(sbatch --parsable --job-name=tail-theory --mem=8G --cpus-per-task=4 \
+    --time="${TAIL_THEORY_TIME:-3:00:00}" --partition=cpu --export=ALL --output="$LOGS/theory-%j.out" \
+    --wrap="source $WT/gridenv.sh && export CALIB_EXP=$CALIB_EXP CALIB_RESULTS=$CALIB_RESULTS && cd $HERE && python theory_bench.py --reps ${TAIL_THEORY_REPS:-40}")
+  echo "theory bench job: $T   -> $CALIB_RESULTS/theory/"
+fi
+
+# The arms are identical to #2799's, so its prepare output (category counts in
+# prepare_info.json, exemplar-crop symlinks into the Max-Patch results) is
+# reusable verbatim -- there is no new embedding to do, and seeding from it skips
+# a GPU stage that would otherwise queue behind the 4-GPU QOS cap for nothing.
+REUSE="${TAIL_REUSE_PREPARE:-/exp/$USER/calibration-safe-linear/results}"
+if [[ -f "$REUSE/prepare_info.json" ]]; then
+  mkdir -p "$CALIB_RESULTS/cells" "$CALIB_RESULTS/crops"
+  cp "$REUSE/prepare_info.json" "$CALIB_RESULTS/prepare_info.json"
+  for f in "$REUSE"/crops/*; do
+    dst="$CALIB_RESULTS/crops/$(basename "$f")"
+    # cp -P would copy the symlink itself, whose relative target would not
+    # resolve from here; resolve it to the real file instead.
+    [[ -e "$dst" ]] || ln -s "$(readlink -f "$f")" "$dst"
+  done
+  echo "reused prepare from $REUSE"
+  exec bash "$HERE/launch_cells.sh"
+fi
+
+echo "no reusable prepare at $REUSE; running the full chain"
+exec bash "$HERE/launch_all.sh"

--- a/scripts/experiments/calibration/selftest_analyze_cut.py
+++ b/scripts/experiments/calibration/selftest_analyze_cut.py
@@ -18,7 +18,11 @@ they come back out:
   ``pooled_mid`` reconstruction of it — the two are planted apart here, exactly
   as #2846 found them in the field, and the ship gate must follow the base row;
 * fallback reasons are windowed, so an out-of-ramp fallback cannot be read as a
-  ramp-window one.
+  ramp-window one;
+* the #2881 tail sweep is classified, its cost-vs-alpha curve is recovered, and a
+  swept level that beats production **cannot** become the ship candidate — the
+  sweep varies a free parameter, so letting all seven levels at a 5 % bar would
+  buy a winner out of noise.
 
 Usage::
 
@@ -75,6 +79,32 @@ FALLBACK_STEPS = [t for t in range(2, 31) if t >= 21]
 #: so an unlisted rule is omitted from the verdict while still showing up in the
 #: window means, and that omission has to be loud.
 UNKNOWN_VARIANT = "pooled_not_a_known_rule"
+
+#: #2881's tail sweep, planted as a **knife-edge** curve whose minimum sits at a
+#: level that is not the pre-registered one — and which is cheaper than both
+#: production and the planted winner.  Two things have to come out of this:
+#: the curve's argmin is found (0.30) and reported as *not* flat, and that argmin
+#: is nonetheless **not** the ship candidate, because a sweep over one free
+#: parameter does not get seven shots at the 5 % bar (``analyze_cut.SWEEP_ONLY``).
+#: Per-cell ramp effect, relative to the incumbent midpoint.
+TAIL_EFFECTS: dict[float, float] = {
+    0.04: 0.01,
+    0.08: 0.00,
+    0.11: -0.01,
+    0.158: -0.02,
+    0.22: -0.03,
+    0.30: -0.08,
+    0.40: -0.01,
+}
+TAIL_BEST_ALPHA = 0.30
+TAIL_PREREGISTERED_ALPHA = 0.158
+
+
+def _tail_variant(alpha: float) -> str:
+    return f"pooled_tail_a{round(alpha * 1000):03d}"
+
+
+_TAIL_EFFECT_BY_VARIANT: dict[str, float] = {_tail_variant(a): e for a, e in TAIL_EFFECTS.items()}
 
 
 def _ident(cat: str, seed: int, t: int, embedder: str, style: str) -> dict:
@@ -133,6 +163,8 @@ def _fabricate(root: Path, rng: np.random.Generator) -> None:
                     for variant in ["", *variants]:
                         is_base = variant == ""
                         effect = RAMP_EFFECT if (variant == WINNER and in_ramp) else 0.0
+                        if in_ramp and variant in _TAIL_EFFECT_BY_VARIANT:
+                            effect = _TAIL_EFFECT_BY_VARIANT[variant]
                         if is_base and anchored:
                             effect = PROD_EDGE
                         # The blended and raw columns move together here except
@@ -241,6 +273,12 @@ def _fabricate(root: Path, rng: np.random.Generator) -> None:
                             tau_test_oracle=tau_test_oracle,
                             oracle_lo_sf_gauss=0.02,
                             oracle_lo_sf_evt=0.02,
+                        )
+                        # The tail sweep's cuts descend with alpha, as the rule's
+                        # closed form requires; nothing here reads their values,
+                        # but a frame missing them is not the frame a run emits.
+                        d.update(
+                            {f"tau_tail_a{round(a * 1000):03d}": tau_sim_oracle + 0.10 - 0.2 * a for a in TAIL_EFFECTS}
                         )
                         diag.append(d)
 
@@ -367,6 +405,64 @@ def main() -> int:
         ok &= _check(
             "tail stability is reported per tail model",
             "tail_alpha_stable" not in dec and {"tail_alpha_stable_gauss", "tail_alpha_stable_evt"} <= set(dec),
+        )
+
+        # --- #2881's tail sweep -----------------------------------------------
+        ok &= _check(
+            "the tail sweep is classified, not flagged as unknown",
+            not [v for v in dec["unclassified_variants"] if v.startswith("pooled_tail_")],
+            str(dec["unclassified_variants"]),
+        )
+        curve = summary["tail_alpha_curve"]
+        ok &= _check(
+            "every swept alpha appears on the curve",
+            curve.get("n_levels") == len(TAIL_EFFECTS),
+            f"{curve.get('n_levels')} vs {len(TAIL_EFFECTS)}",
+        )
+        ok &= _check(
+            "the planted curve minimum is found",
+            curve.get("best_alpha") == TAIL_BEST_ALPHA,
+            str(curve.get("best_alpha")),
+        )
+        curve_rows = {round(float(r["alpha"]), 3): r for r in curve.get("curve", [])}
+        # Base row is PROD_EDGE cheaper on half the cells, so the contrast against
+        # production is the planted effect plus half of that edge.
+        expected_prereg = TAIL_EFFECTS[TAIL_PREREGISTERED_ALPHA] - PROD_EDGE * len(ANCHORED_SEEDS) / len(SEEDS)
+        got = curve_rows.get(TAIL_PREREGISTERED_ALPHA, {}).get("mean_d_cost")
+        ok &= _check(
+            "the pre-registered level is paired against production",
+            got is not None and abs(float(got) - expected_prereg) < 1e-6,
+            f"{got} vs {expected_prereg}",
+        )
+        ok &= _check(
+            "only the pre-registered level is ship-eligible",
+            [a for a, r in curve_rows.items() if r["ship_eligible"]] == [TAIL_PREREGISTERED_ALPHA],
+            str([a for a, r in curve_rows.items() if r["ship_eligible"]]),
+        )
+        # The trap: the swept minimum is the cheapest rule in the whole table, and
+        # must still not be what the run proposes to ship.
+        cheapest = base[
+            (base["arm"].str.contains("dinov3_patch/max_patch")) & (base["window"] == "ramp_6_20")
+        ].sort_values("mean_d_cost")
+        ok &= _check(
+            "the swept minimum really is the cheapest rule measured",
+            str(cheapest.iloc[0]["variant"]) == _tail_variant(TAIL_BEST_ALPHA),
+            str(cheapest.iloc[0]["variant"]),
+        )
+        ok &= _check(
+            "a sweep-only level cannot become the ship candidate",
+            dec["ship_candidate"] != _tail_variant(TAIL_BEST_ALPHA),
+            str(dec["ship_candidate"]),
+        )
+        ok &= _check(
+            "sweep-only levels are named in the verdict",
+            _tail_variant(TAIL_BEST_ALPHA) in dec["sweep_only_variants"]
+            and _tail_variant(TAIL_PREREGISTERED_ALPHA) not in dec["sweep_only_variants"],
+        )
+        ok &= _check(
+            "a knife-edge curve is not reported as flat",
+            dec["tail_curve_is_flat"] is False,
+            str(dec["tail_curve_is_flat"]),
         )
 
         # Fallback reasons are windowed: the planted fallback sits outside the ramp.

--- a/tests_lib/detectors/test_cut_rules.py
+++ b/tests_lib/detectors/test_cut_rules.py
@@ -17,12 +17,19 @@ import pytest
 from vtscore.eval.calibration_metrics import inclusion_weights, operating_cost
 from vtscore.eval.cut_rules import (
     ALL_RULES,
+    EVT_FIT_RULES,
     EVT_RULES,
+    TAIL_ALPHA_GRID,
+    TAIL_ALPHA_PREREGISTERED,
+    TAIL_RULES,
     decomposition_cuts,
     gaussian_cuts,
     sim_oracle_cut,
     supervised_cut,
+    tail_alpha_rule,
+    tail_cuts,
 )
+from vtscore.training.evt_mixture import GumbelNormalFit1D
 from vtscore.training.thresholds import GmmFit1D, _weighted_gaussian_crossing
 
 
@@ -247,7 +254,7 @@ class TestDecomposition:
         rng = np.random.default_rng(11)
         scores, labels = self._sample(rng)
         _cuts, _params, reasons = decomposition_cuts(scores, labels, 1.0, 1.0)
-        assert set(reasons) == set(EVT_RULES)
+        assert set(reasons) == set(EVT_FIT_RULES)
         assert all(r for r in reasons.values()), reasons
 
     def test_an_unfittable_sample_reports_a_fit_reason_not_a_crossing_one(self):
@@ -267,3 +274,124 @@ class TestDecomposition:
         """
         assert {"gumbel_priorfree", "gumbel_any_priorfree"} <= set(EVT_RULES)
         assert set(EVT_RULES) <= set(ALL_RULES)
+
+
+class TestTailAlphaRule:
+    """#2881's one-constant rule: the fitted Bad component's own upper quantile.
+
+    Closed form in both orientations, so these check the arithmetic against the
+    definition (``lo_survival`` at the returned cut must be ``alpha``) rather than
+    against a golden number - which also means the two directions cannot drift
+    apart without a failure here.
+    """
+
+    def _evt(self, *, swapped=False) -> GumbelNormalFit1D:
+        """A well-separated fit, with the Gumbel on the low or the high mode."""
+        if swapped:
+            # Normal below, Gumbel above -> `lo_quantile` must read the Normal.
+            return GumbelNormalFit1D(w_gumbel=0.1, loc=2.0, scale=0.4, w_normal=0.9, mu=-2.0, var=0.5, mean_loglik=0.0)
+        return GumbelNormalFit1D(w_gumbel=0.9, loc=-2.0, scale=0.4, w_normal=0.1, mu=2.0, var=0.5, mean_loglik=0.0)
+
+    @pytest.mark.parametrize("swapped", [False, True])
+    @pytest.mark.parametrize("alpha", [0.01, 0.04, 0.158, 0.4, 0.9])
+    def test_quantile_inverts_the_survival_function(self, alpha, swapped):
+        fit = self._evt(swapped=swapped)
+        x = fit.lo_quantile(alpha)
+        assert x is not None
+        assert fit.lo_survival(x) == pytest.approx(alpha, abs=1e-12)
+
+    def test_gumbel_branch_matches_the_closed_form(self):
+        """``x = loc - scale*ln(-ln(1-alpha))``; at 0.158 that is ``loc + 1.761*scale``."""
+        fit = self._evt()
+        x = fit.lo_quantile(TAIL_ALPHA_PREREGISTERED)
+        assert x is not None
+        offset = (x - fit.loc) / fit.scale
+        assert offset == pytest.approx(-math.log(-math.log1p(-TAIL_ALPHA_PREREGISTERED)), rel=1e-12)
+        assert offset == pytest.approx(1.7604, abs=1e-4)
+
+    def test_swapped_fit_reads_the_normal_not_the_gumbel(self):
+        """The one thing this rule can still get wrong, and the reason it branches.
+
+        A quantile taken off the Gumbel when the Normal is the low component
+        would be a plausible number from the wrong component - silent, and on the
+        wrong end of the axis.
+        """
+        fit = self._evt(swapped=True)
+        x = fit.lo_quantile(TAIL_ALPHA_PREREGISTERED)
+        assert x is not None
+        assert fit.mu < x < fit.loc  # the Normal's upper tail, below the Gumbel's mode
+        # A Normal's median is its mean, which the Gumbel branch would miss by
+        # ``loc + 0.3665*scale`` - a plausible number from the wrong component.
+        assert fit.lo_quantile(0.5) == pytest.approx(fit.mu, abs=1e-12)
+
+    def test_higher_alpha_cuts_lower(self):
+        """More Bad mass left above the cut means a cut further down the axis."""
+        fit = self._evt()
+        raw = [fit.lo_quantile(a) for a in TAIL_ALPHA_GRID]
+        assert all(c is not None for c in raw)
+        cuts = [c for c in raw if c is not None]
+        assert cuts == sorted(cuts, reverse=True)
+
+    def test_alpha_outside_the_unit_interval_is_declined(self):
+        fit = self._evt()
+        assert fit.lo_quantile(0.0) is None
+        assert fit.lo_quantile(1.0) is None
+        assert fit.lo_quantile(-0.1) is None
+
+    def test_the_rule_needs_no_crossing_to_exist(self):
+        """The whole reason this family is worth a run after #2846.
+
+        On a fit whose modes have collapsed onto each other every crossing rule
+        declines, and the crossing family degrades to the midpoint.  A tail
+        quantile is still perfectly well defined there.
+        """
+        fit = GumbelNormalFit1D(w_gumbel=0.9, loc=0.0, scale=0.4, w_normal=0.1, mu=0.02, var=4.0, mean_loglik=0.0)
+        assert fit.crossing_state(allow_swapped=True)[0] != "ok"
+        cuts, reasons = tail_cuts(fit)
+        assert set(reasons.values()) == {"ok"}
+        assert all(math.isfinite(c) for c in cuts.values()), cuts
+
+    def test_rule_names_are_stable_and_sorted_by_alpha(self):
+        assert tail_alpha_rule(0.158) == "tail_a158"
+        assert tail_alpha_rule(0.04) == "tail_a040"
+        assert TAIL_RULES == tuple(tail_alpha_rule(a) for a in TAIL_ALPHA_GRID)
+        assert list(TAIL_ALPHA_GRID) == sorted(TAIL_ALPHA_GRID)
+        assert TAIL_ALPHA_PREREGISTERED in TAIL_ALPHA_GRID
+
+    def test_tail_cuts_are_reported_in_score_space(self):
+        """The fit is on the logit axis; the cuts a rule ships are scores."""
+        fit = self._evt()
+        cuts, _reasons = tail_cuts(fit)
+        assert all(0.0 < c < 1.0 for c in cuts.values()), cuts
+
+
+class TestRuleWiring:
+    """A rule that exists but is never emitted produces a missing row, not an error.
+
+    #2884 made an *unclassified* variant loud in the analyzer.  This is the other
+    half, one layer down: a rule defined in :mod:`vtscore.eval.cut_rules` but not
+    wired into the harness never reaches the analyzer at all, so there is nothing
+    for it to classify.  Both lists are spelled out by hand in
+    ``voting_iterations`` (which is deliberately import-light), so these
+    assertions are what keeps the duplication honest.
+    """
+
+    def test_every_rule_is_emitted_as_a_pooled_variant(self):
+        from vtscore.eval.voting_iterations import _SAFE_GMM_VARIANTS
+
+        names = {name for name, _f, _r in _SAFE_GMM_VARIANTS}
+        missing = sorted(f"pooled_{r}" for r in ALL_RULES if f"pooled_{r}" not in names)
+        assert not missing, f"defined in cut_rules but never emitted by the harness: {missing}"
+
+    def test_every_rule_has_a_diagnostic_column(self):
+        from vtscore.eval.voting_iterations import _CUT_DIAGNOSTIC_COLUMNS
+
+        missing = sorted(f"tau_{r}" for r in ALL_RULES if f"tau_{r}" not in _CUT_DIAGNOSTIC_COLUMNS)
+        assert not missing, f"cut emitted with no column to write it to: {missing}"
+
+    def test_pooled_variant_rules_all_exist(self):
+        """And the converse: a variant naming a rule that was renamed or removed."""
+        from vtscore.eval.voting_iterations import _SAFE_GMM_VARIANTS
+
+        unknown = sorted({rule for _n, _f, rule in _SAFE_GMM_VARIANTS if rule and rule not in ALL_RULES})
+        assert not unknown, f"harness emits variants for rules that do not exist: {unknown}"

--- a/vtscore/eval/cut_rules.py
+++ b/vtscore/eval/cut_rules.py
@@ -29,6 +29,12 @@ again without #2836's assumption that the Gumbel is necessarily the *low*
 component; that assumption is what the Gumbel arm's fallback rate turned out to
 be made of (issue #2846).
 
+The ``tail_a*`` rules are a different animal from all of the above: not a
+crossing at any tilt, but the fitted **Bad** component's own upper quantile -
+"cut where alpha of the Bad mass is still above the cut" (issue #2881).  There is
+no ``lam``, no orientation question, and no boundary that might not exist; it is
+one constant against one fitted tail.
+
 **The decomposition.**  A simulation knows the sim set's true labels, so the gap
 between what a rule cuts and where the rate loss is actually minimised can be
 split into named terms rather than reported as one number
@@ -107,12 +113,56 @@ EVT_RULES: tuple[str, ...] = (
     "gumbel_any_priorfree",
     "gumbel_any_rate",
 )
+#: The pre-registered constant for the one-constant tail rule (issue #2881): the
+#: median survival level at which the *true* rate optimum sat in the fitted Gumbel
+#: low component, over #2846's 511 cells.  It is a median over one dataset and one
+#: geometry, which is why the grid below sweeps around it rather than trusting it.
+TAIL_ALPHA_PREREGISTERED: float = 0.158
+#: Tail levels measured, in increasing alpha (so in *decreasing* cut).  Chosen so
+#: the cut moves in near-even steps rather than alpha: for a Gumbel the cut is
+#: ``loc - scale*ln(-ln(1-alpha))``, i.e. logarithmic in alpha, so an evenly
+#: spaced alpha grid would bunch every point on one side of the optimum.  These
+#: seven sit at ``loc + {3.20, 2.48, 2.15, 1.76, 1.39, 1.03, 0.67}*scale`` - even
+#: 0.36-wide steps except the bottom rung, which reaches twice as far to bracket
+#: a genuinely conservative cut without spending two levels down there.
+#:
+#: The grid exists because "the cost curve is flat near 0.158" is the actual
+#: claim the stability finding makes, and a single hardcoded constant cannot test
+#: it.  Only :data:`TAIL_ALPHA_PREREGISTERED` is a ship candidate; the rest are
+#: measured to show the *shape* of the curve.  See ``analyze_cut.SWEEP_ONLY``.
+TAIL_ALPHA_GRID: tuple[float, ...] = (0.04, 0.08, 0.11, TAIL_ALPHA_PREREGISTERED, 0.22, 0.30, 0.40)
+
+
+def tail_alpha_rule(alpha: float) -> str:
+    """Rule name for a tail level, e.g. ``0.158 -> "tail_a158"`` (units: milli-alpha).
+
+    Three digits rather than a decimal point because these names become CSV
+    column values and variant ids, and a ``.`` in either reads as a path
+    separator to half the tooling that touches them.
+    """
+    return f"tail_a{round(alpha * 1000):03d}"
+
+
+#: One rule per swept tail level.  Backed by the same EVT fit as
+#: :data:`EVT_RULES`, but **not** a crossing: it inverts the fitted low
+#: component's survival function instead of looking for a boundary between the
+#: modes.  That is what makes the family worth another run after #2846 - a
+#: quantile exists for every non-degenerate fit, so the 20-25 % midpoint-fallback
+#: rate that diluted every crossing contrast to nothing should collapse to the
+#: EVT fit-failure rate alone.
+TAIL_RULES: tuple[str, ...] = tuple(tail_alpha_rule(a) for a in TAIL_ALPHA_GRID)
+
+#: Every rule read off the EVT fit, so a failed fit can be attributed to all of
+#: them at once.  ``EVT_RULES`` and ``TAIL_RULES`` stay separate above because
+#: they answer different questions and only one of them declines for orientation.
+EVT_FIT_RULES: tuple[str, ...] = (*EVT_RULES, *TAIL_RULES)
+
 #: Label-reading diagnostics.  **Not rules** - they read the sim set's true
 #: labels, so they are upper bounds on what an unsupervised cut could achieve,
 #: reported to locate the error rather than to be shipped.
 ORACLE_RULES: tuple[str, ...] = ("supervised", "sim_oracle")
 
-ALL_RULES: tuple[str, ...] = (*GAUSSIAN_RULES, *EVT_RULES, *ORACLE_RULES)
+ALL_RULES: tuple[str, ...] = (*GAUSSIAN_RULES, *EVT_RULES, *TAIL_RULES, *ORACLE_RULES)
 
 
 def _finite(x: float | None) -> float:
@@ -173,6 +223,38 @@ def evt_cuts(fit: GumbelNormalFit1D, fpr_weight: float, fnr_weight: float) -> tu
     ):
         cuts[name] = float("nan") if cut is None else _from_logit(cut)
         reasons[name] = reason
+    return cuts, reasons
+
+
+def tail_cuts(
+    fit: GumbelNormalFit1D,
+    alphas: tuple[float, ...] = TAIL_ALPHA_GRID,
+) -> tuple[dict[str, float], dict[str, str]]:
+    """``(cuts, reasons)`` for every tail-alpha rule, mapped back to score space.
+
+    Each rule cuts where the fitted **Bad** component still has *alpha* of its
+    mass above the cut - "cut the Bad tail at alpha", one constant, no crossing
+    and no ``lam``.  Solved on the logit axis, where the fit lives, and squashed
+    back, which is sound for a different reason than :func:`evt_cuts`': a crossing
+    survives the change of variable because both sides pick up the same Jacobian
+    and it cancels, whereas a quantile survives because the sigmoid is *monotone*,
+    so it carries a tail probability through unchanged.  Either way the answer is
+    the point solving in score space would have given.
+
+    Nothing here consults the orientation: :meth:`GumbelNormalFit1D.lo_quantile`
+    reads whichever component came out low, so the ``modes_swapped`` axis that
+    #2836 and #2846 spent themselves on simply does not arise.  A rule declines
+    only for a degenerate fit, which is why the reason vocabulary is a two-element
+    subset of :data:`~vtscore.training.evt_mixture.CROSSING_REASONS` rather than
+    the full set.
+    """
+    cuts: dict[str, float] = {}
+    reasons: dict[str, str] = {}
+    for alpha in alphas:
+        cut = fit.lo_quantile(alpha)
+        name = tail_alpha_rule(alpha)
+        cuts[name] = float("nan") if cut is None else _from_logit(cut)
+        reasons[name] = "degenerate_params" if cut is None else "ok"
     return cuts, reasons
 
 
@@ -355,7 +437,7 @@ def decomposition_cuts(
     # A rule whose fit never existed still needs a reason; "the fit failed" is a
     # different diagnosis from "the fit had no crossing" and the two must not be
     # pooled into one fallback count.
-    reasons: dict[str, str] = dict.fromkeys(EVT_RULES, f"fit_{params['evt_fit_fail']}")
+    reasons: dict[str, str] = dict.fromkeys(EVT_FIT_RULES, f"fit_{params['evt_fit_fail']}")
 
     if gmm is not None:
         cuts.update(gaussian_cuts(gmm, fpr_weight, fnr_weight))
@@ -365,8 +447,12 @@ def decomposition_cuts(
         # so it stays a usable fallback for the rules that have no root.
         cuts["mid"] = params["fallback_median"]
     if evt is not None:
-        evt_cut_map, reasons = evt_cuts(evt, fpr_weight, fnr_weight)
+        evt_cut_map, evt_reasons = evt_cuts(evt, fpr_weight, fnr_weight)
         cuts.update(evt_cut_map)
+        reasons.update(evt_reasons)
+        tail_cut_map, tail_reasons = tail_cuts(evt)
+        cuts.update(tail_cut_map)
+        reasons.update(tail_reasons)
 
     sup, sup_stats = supervised_cut(scores, sim_labels, fpr_weight, fnr_weight)
     params.update(sup_stats)

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -266,6 +266,14 @@ _CUT_DIAGNOSTIC_COLUMNS: tuple[str, ...] = (
     "tau_gumbel_any_cross",
     "tau_gumbel_any_priorfree",
     "tau_gumbel_any_rate",
+    # #2881's tail-quantile sweep, one column per swept alpha (in milli-alpha).
+    "tau_tail_a040",
+    "tau_tail_a080",
+    "tau_tail_a110",
+    "tau_tail_a158",
+    "tau_tail_a220",
+    "tau_tail_a300",
+    "tau_tail_a400",
     "tau_supervised",
     "tau_sim_oracle",
     "tau_test_oracle",
@@ -702,6 +710,16 @@ def _operating_metrics(
 #: ("supervised", "sim_oracle") that locate the error rather than compete to
 #: ship.  ``xcal_only`` is the no-blend control: the raw conformal threshold at
 #: the same step.  ``pooled_mid`` must reproduce the production blend exactly.
+#: The ``tail_a*`` sweep is #2881's one-constant rule at seven tail levels - the
+#: fitted Bad component's own quantile rather than a crossing of any kind.
+#:
+#: **The rule names here are the ones in :mod:`vtscore.eval.cut_rules`**, spelled
+#: out rather than derived, because this module is deliberately import-light (no
+#: numpy at import time) and importing the rule tables to build the list would
+#: undo that.  ``test_cut_rules`` asserts the two agree, so the duplication
+#: cannot drift silently - which matters more than usual here, since a rule that
+#: is defined but never emitted produces a table with a missing row rather than
+#: an error.
 #:
 #: The #2798 logit-space variants are gone: #2799 measured them at +0.0006 cost
 #: (dead) and each extra fit costs a step's CPU that the #2836 arms need.
@@ -721,6 +739,13 @@ _SAFE_GMM_VARIANTS: tuple[tuple[str, str, str], ...] = (
     ("pooled_gumbel_any_cross", "pooled", "gumbel_any_cross"),
     ("pooled_gumbel_any_priorfree", "pooled", "gumbel_any_priorfree"),
     ("pooled_gumbel_any_rate", "pooled", "gumbel_any_rate"),
+    ("pooled_tail_a040", "pooled", "tail_a040"),
+    ("pooled_tail_a080", "pooled", "tail_a080"),
+    ("pooled_tail_a110", "pooled", "tail_a110"),
+    ("pooled_tail_a158", "pooled", "tail_a158"),
+    ("pooled_tail_a220", "pooled", "tail_a220"),
+    ("pooled_tail_a300", "pooled", "tail_a300"),
+    ("pooled_tail_a400", "pooled", "tail_a400"),
     ("pooled_supervised", "pooled", "supervised"),
     ("pooled_sim_oracle", "pooled", "sim_oracle"),
 )

--- a/vtscore/training/evt_mixture.py
+++ b/vtscore/training/evt_mixture.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from statistics import NormalDist
 
 import numpy as np
 
@@ -321,6 +322,41 @@ class GumbelNormalFit1D:
         if self.var <= 0.0:
             return float("nan")
         return float(0.5 * math.erfc((x - self.mu) / math.sqrt(2.0 * self.var)))
+
+    def lo_quantile(self, alpha: float) -> float | None:
+        """The ``x`` where :meth:`lo_survival` equals *alpha*; ``None`` if there is none.
+
+        The exact inverse of :meth:`lo_survival`, and deliberately its immediate
+        neighbour: the two branch on ``gumbel_is_low`` the same way, and a
+        quantile that read the Gumbel's tail off a fit whose low component is the
+        *Normal* would be wrong in the silent, plausible way this study line keeps
+        producing.  Both branches are closed form, so there is no bracket to get
+        wrong and no bisection to converge:
+
+        * Gumbel low — ``S(x) = 1 - exp(-exp(-z))``, ``z = (x - loc)/scale``, so
+          ``x = loc - scale*ln(-ln(1 - alpha))``.  At ``alpha = 0.158`` that is
+          ``loc + 1.761*scale``.
+        * Normal low (the swapped fit) — ``S(x) = Phi((mu - x)/sd)``, so
+          ``x = mu + sd*Phi^-1(1 - alpha)``.
+
+        Unlike a crossing, this always exists for a non-degenerate fit: a tail
+        quantile needs no Bad-then-Good boundary between the modes, which is the
+        entire reason the one-constant rule is worth measuring after the crossing
+        family's fallback rate sank it (issues #2846, #2881).  The units are the
+        fit's own — logit space, wherever the caller fitted it — so the caller
+        maps back exactly as it does for a crossing.
+        """
+        if not (0.0 < alpha < 1.0):
+            return None
+        if self.gumbel_is_low:
+            if not (self.scale > 0.0 and math.isfinite(self.loc)):
+                return None
+            x = self.loc - self.scale * math.log(-math.log1p(-alpha))
+        else:
+            if not (self.var > 0.0 and math.isfinite(self.mu)):
+                return None
+            x = self.mu + math.sqrt(self.var) * NormalDist().inv_cdf(1.0 - alpha)
+        return x if math.isfinite(x) else None
 
 
 #: Why the EM fit produced nothing.  ``"ok"`` means it produced a fit.


### PR DESCRIPTION
#2884 built the scaffolding around #2881 — the base-row contrast table, the windowed fallback file, the split `tail_alpha_stable_*` keys — but the rule itself was never written. `EVT_RULES` still held only the six crossing rules, and the only `tail_alpha` in the tree was the diagnostic in `analyze_cut.py` that #2881 asks to **invert**. This builds it.

## The rule

`tail_a<α>` cuts where the fitted **Bad** component still has α of its mass above the cut. One constant: no `lam`, no tilt, no crossing, and no orientation question.

`GumbelNormalFit1D.lo_quantile` is the exact inverse of `lo_survival` and deliberately its immediate neighbour, branching on `gumbel_is_low` the same way — a quantile read off the Gumbel's tail when the low component is the *Normal* would be wrong in the silent, plausible way this study line keeps producing. Closed form in both orientations, so no bracket and no bisection:

| the low component is | cut |
|---|---|
| the Gumbel | `loc − scale·ln(−ln(1−α))` — at α = 0.158, `loc + 1.7604·scale` |
| the Normal (swapped) | `mu + sd·Φ⁻¹(1−α)` (stdlib `NormalDist.inv_cdf`, no new dependency) |

Solved on the **logit axis**, where the fit lives, then squashed back. That is sound for a different reason than `evt_cuts`, and the docstring says which: a crossing survives the change of variable because both sides pick up the same Jacobian and it cancels; a quantile survives because the sigmoid is monotone and carries a tail probability through unchanged.

Unlike every crossing in the family it needs no boundary between the modes — `test_the_rule_needs_no_crossing_to_exist` plants a collapsed fit where every crossing declines and the quantile is still perfectly well defined. That is the whole reason the family is worth another run after #2846's fallback table.

## The sweep, and why it does not get seven shots at the ship gate

Seven levels (0.04 … 0.40), spaced so the *cut* moves in even 0.36-scale steps rather than α — for a Gumbel the cut is logarithmic in α, so an evenly spaced α grid would bunch every point on one side of the optimum. The bottom rung reaches twice as far, to bracket a genuinely conservative cut without spending two levels down there.

`analyze_cut.tail_alpha_curve` emits `agg/cut_tail_alpha_curve.csv`: cost vs α paired within-step against the run's own base row, with a flatness verdict. The stability finding says where the optimum *is*; it does not say what it costs to aim there, and the two come apart if the curve is steep. **Flatness is the claim**, so the pre-registered bar is that the levels within one SEM of the best span a factor of ≥ 2 in α — a constant that can be wrong by 2× and still land inside the noise transfers; one that cannot is a number fitted to this run. Both contrast tables gained `sem_d_cost` to support it.

**`SWEEP_ONLY`**: only α = 0.158 can be the ship candidate. `best_by_cost`, `best_vs_production`, `closest_to_oracle` and the ship gate all read `SHIP_ELIGIBLE`. A sweep over one free parameter handed to a two-sided 5 % bar is ~30 % chance of a "winner" from noise alone, and #2881 is explicit that this family has been mis-sized twice in the same direction. If the curve's minimum lands elsewhere, that is a finding for the next pre-registration — evidence the constant does not transfer — not a rule to ship off this run.

## A rule cannot be defined and then never emitted

#2884 made an *unclassified* variant loud in the analyzer. That check cannot fire for a rule that never reaches the analyzer at all. Two wiring tests close the other half: every rule in `ALL_RULES` must appear as a `pooled_*` variant and must have a `tau_*` diagnostic column, and every variant must name a rule that exists. The variant/column lists stay spelled out by hand in `voting_iterations` (it is deliberately import-light — no numpy at import time), so these are what keep the duplication honest. `analyze_cut` goes further and imports its `TAIL_VARIANTS` straight from the rule table.

## Pre-registration

`docs/experiments/gmm-cut/PREREG-2881.md`, written before the run as #2881 requires. **The prediction is negative**: α = 0.158 lands inside ±0.005 with p > 0.05. `pooled_sim_oracle` is the empirical rate-loss minimiser over the sim scores read with true labels, with no parametric form, so it bounds every rule that picks a threshold from that sim set — a Gumbel tail quantile included — and #2846 measured it at −0.0059 (p = 0.22) against production. The doc records what would count as a positive, and the commitment to close the EVT cut line if it lands inside the noise.

`launch_tail_2881.sh` gives the run its own `CALIB_EXP` (the grid differs from #2846's by seven variants per step, which makes it a different study) and gates on `preflight.sh`. The theory bench is deliberately not launched: its `CANDIDATE_RULES` does not carry the tail family, and #2846's recommendation was to stop trusting it here.

**The Grid run itself has not happened** — that needs the cluster. Everything up to `bash launch_tail_2881.sh` is in place.

## One correction to #2881's text

The issue quotes the α = 0.158 offset as `loc + 1.761·scale`. It is **1.7604** — I copied 1.761 into a test and it failed. The test now checks `−ln(−ln(1−α))` itself rather than any transcribed constant.

## Rebase note: a test fix dropped in favour of #2896's

An earlier revision of this branch also patched `test_the_offset_is_relative_to_inclusion_not_absolute`, which was failing on `dev` when I started: it asserted the acquisition cut is *strictly* above the reporting cut at every inclusion, which the estimator could not satisfy once the per-fold rate cut clamped at the fitted interval's edge. #2896 has since landed on `dev` and fixes the **root cause** — the rate cut now continues past the mode edges, so the Inclusion tilt never flattens — and rebuilds that test on a hand-built, order-independent estimator that restores the strict `>`. That is strictly the better fix, so this branch now carries `dev`'s version of the file verbatim and none of mine.

## Testing

`selftest_analyze_cut.py`: **41/41 pass** (was 32). It plants the sweep as a knife-edge curve whose minimum sits at a sweep-only level that is cheaper than both production *and* the planted winner, and asserts the argmin is found (0.30), reported as not flat, confirmed to be the cheapest rule in the whole table — and still not the ship candidate.

Full `./run-tests.sh` green on this branch — ruff check / format, codespell, deptry, pip-audit, pyright, screenshot wiring-check, frontend build + audit, the Vitest suite, and pytest. Re-run after rebasing onto `dev` at `39bc9845` (which brought MaxPatch adoption and the #2896 rate-cut change).

No behaviour change to any app path: `_SAFE_GMM_VARIANTS` and the cut-rule tables are read only by the calibration harness, which runs under `CALIB_SAFE_THRESHOLDS=1`.

Refs #2881, refs #2846, refs #2884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmZvWe2Ru9sTWDBWYv7pjt