### PR TITLE
Surface an exporter's open_url on the CLI and Auto-Find paths, and document it

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -236,6 +236,19 @@ python app.py --autodetect --dataset data.pkl --settings settings.json --progres
 The two choices are `text` (default, prose) and `json` (NDJSON events). The
 event schema is defined in `vtscore.cli_progress`.
 
+An exporter can format its results into a URL for a browser to open rather than
+delivering them anywhere (the built-in `open_url` exporter does exactly this).
+There is no browser on the command line, so the URL is printed under the
+exporter's confirmation message, and carried as an `open_url` field on the
+`export_complete` event in JSON mode — enough for a wrapping script to open it:
+
+```bash
+python app.py --autodetect --dataset data.pkl --settings settings.json \
+    --progress-format json --exporter open_url \
+    --url-template 'https://example.com/review?ids={ids}' \
+  | jq -r 'select(.event == "export_complete") | .open_url'
+```
+
 ## Pipeline file
 
 For repeatable runs (cron, CI), put the whole autodetect invocation in a YAML

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -1149,6 +1149,47 @@ mid-stream can't leave a half-written file at the destination. See
 | Attribute | Default | Description |
 |-----------|---------|-------------|
 | `icon` | `"📤"` | Emoji shown in the UI |
+| `opens_url` | `False` | Whether this exporter always ends by opening a browser tab — see below |
+
+#### Opening a browser tab (`open_url`)
+
+An exporter doesn't have to *deliver* the labelset anywhere. Return an
+`http(s)` URL under an **`"open_url"`** key and the frontend opens it in a new
+tab — which is how you hand the user off to a third-party site that has a
+viewer but no ingest API: format the selection into that site's own URL and
+return it. A delivery exporter whose remote hands back a permalink returns the
+same key.
+
+```python
+def export(self, results: dict, field_values: dict) -> dict:
+    url = validate_browser_url(f"https://review.example.com/?ids={quote(ids, safe='')}")
+    return {"message": "Opening the labelset in Review Site.", "open_url": url}
+```
+
+Set `opens_url = True` as well **only if you always return a URL**: the flag is
+what lets the Export modal label the button "Open in &lt;name&gt;" *before*
+running anything. An exporter that returns one only sometimes leaves the flag
+`False` — the URL still opens, the button just can't advertise it up front.
+
+What each surface does with the key:
+
+| Surface | Behaviour |
+|---------|-----------|
+| Export modal | Opens a new tab; if the popup blocker eats it, the success toast carries an **Open** action that always gets through |
+| Auto-Find auto-export (`POST /api/auto-detect`) | Offered as an **Open** button on the Auto-Detect Results modal's status line — not opened on arrival, since the response is async and would be blocked |
+| CLI (`--exporter`) | No browser: the URL is printed under the confirmation message, and rides along as an `open_url` field on the `export_complete` event under `--progress-format json` |
+
+Every path re-validates the URL with
+`vtscore.security.url_validation.validate_browser_url` (a scheme allowlist —
+deliberately *not* the SSRF guard, since the browser makes the request and a
+`localhost` viewer is a legitimate target), so a plugin can never push a
+`javascript:` URL to the frontend. Anything you encode into the URL is visible
+to the destination site and lands in the user's browser history, so keep it to
+identifiers, and cap the length: URLs stop working around 2000 characters.
+
+The library-side guide has the full worked example and the encoding/truncation
+pitfalls: [`vtscore/docs/extending/results-exporters.md` § Opening a URL in the
+browser](../vtscore/docs/extending/results-exporters.md#opening-a-url-in-the-browser).
 
 ### How it gets invoked
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -142,6 +142,7 @@ See [EXTENDING-plugins.md § Adding a Results Exporter](EXTENDING-plugins.md#add
 - [ ] Create `vtscore/exporters/<name>/__init__.py`
 - [ ] Subclass `LabelsetExporter`, set `name`, `display_name`, `description`, `fields`
 - [ ] Implement `export(self, results, field_values)`: return a dict with a `"message"` key
+- [ ] To send the user to a web page instead of (or as well as) delivering the labelset, return an `"open_url"` and set `opens_url = True` if you always return one — see [Opening a browser tab](EXTENDING-plugins.md#opening-a-browser-tab-open_url)
 - [ ] Expose `EXPORTER = YourExporter()` at module level
 - [ ] If the plugin needs extra packages, add them to `[project.dependencies]` in `pyproject.toml` and re-run your editable install
 - [ ] Test: start the app and check `GET /api/exporters` includes your exporter

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -45,6 +45,13 @@ fails, so no plugin can push a `javascript:` URL to the browser. An exporter tha
 *always* returns one sets `opens_url: true` in its `GET /api/exporters` entry, so
 the UI can label the button before the export runs.
 
+The same key reaches the client from the Auto-Find auto-export block
+(`auto_export.open_url` on `POST /api/auto-detect`), where the Auto-Detect
+Results modal offers it as an **Open** button instead of opening a tab on
+arrival. That path runs the same `validate_browser_url` check, but drops an
+unusable URL and notes it in `message` rather than failing the request: the
+export already happened and the scored results must survive it.
+
 **Streaming support** (CLI `--autodetect --stream-results` for sources larger
 than RAM): `server_json_file` (NDJSON), `server_csv_file`, and `gui` write hits
 incrementally; `webhook` and `email_smtp` deliver in `batch_size`-sized batches

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -6264,6 +6264,10 @@
             "description": "Human-readable outcome; present on success.",
             "type": "string"
           },
+          "open_url": {
+            "description": "An ``http(s)`` URL the exporter formatted for the browser to open, offered as a link in the Auto-Detect Results modal. Declared rather than left to the pass-through below because the frontend acts on it.",
+            "type": "string"
+          },
           "success": {
             "type": "boolean"
           }

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.html
@@ -26,6 +26,15 @@
     <div class="auto-export-status" [class.auto-export-status--error]="!ax.success">
       @if (ax.success) {
         <vt-icon type="check" [size]="14"></vt-icon> Auto-exported via {{ ax.exporter }}{{ ax.message ? ' — ' + ax.message : '' }}
+        <!-- An exporter can format the results into a third-party site's URL
+             and hand it back (#2898). Offered as a click rather than opened
+             automatically: the results arrive from an async response, so a
+             popup blocker would eat an unprompted window.open(). -->
+        @if (autoExportUrl(); as url) {
+          <button type="button" class="btn btn--secondary btn--sm auto-export-open" [title]="url" (click)="openExternal(url)">
+            Open
+          </button>
+        }
       } @else {
         &#9888; Auto-export via {{ ax.exporter }} failed{{ ax.error ? ': ' + ax.error : '' }}
       }

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.scss
@@ -83,3 +83,10 @@
     color: var(--color-bad);
   }
 }
+
+// Sits inline after the auto-export confirmation, so it reads as part of that
+// sentence rather than as a second row of chrome.
+.auto-export-open {
+  margin-left: var(--space-sm);
+  vertical-align: baseline;
+}

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.spec.ts
@@ -130,4 +130,57 @@ describe('AutoDetectResultsModalComponent', () => {
     const rows = el.querySelectorAll('.results-table tbody tr');
     expect(rows.length).toBe(2); // good hits by default
   });
+
+  // An Auto-Find auto-export can format the run into a third-party site's URL
+  // rather than delivering it anywhere (#2898). It's offered as a click, not
+  // opened on arrival: these results land from an async response, where an
+  // unprompted window.open() is what popup blockers exist to stop.
+  describe('auto-export open_url', () => {
+    function withAutoExport(auto_export: Record<string, unknown>): void {
+      fixture.componentRef.setInput('data', { ...mockData, auto_export } as any);
+    }
+
+    it('offers an Open button for an openable URL', async () => {
+      withAutoExport({ exporter: 'open_url', success: true, open_url: 'https://example.com/r?ids=a' });
+      await flushInit();
+      const btn = fixture.nativeElement.querySelector('.auto-export-open') as HTMLButtonElement;
+      expect(btn).toBeTruthy();
+      expect(btn.getAttribute('title')).toBe('https://example.com/r?ids=a');
+    });
+
+    it('opens the URL in a new tab when clicked, never handing over the opener', async () => {
+      withAutoExport({ exporter: 'open_url', success: true, open_url: 'https://example.com/r' });
+      await flushInit();
+      const open = vi.spyOn(window, 'open').mockReturnValue(null);
+      (fixture.nativeElement.querySelector('.auto-export-open') as HTMLButtonElement).click();
+      expect(open).toHaveBeenCalledWith('https://example.com/r', '_blank', 'noopener');
+      open.mockRestore();
+    });
+
+    it('does not open anything on arrival', async () => {
+      const open = vi.spyOn(window, 'open').mockReturnValue(null);
+      withAutoExport({ exporter: 'open_url', success: true, open_url: 'https://example.com/r' });
+      await flushInit();
+      expect(open).not.toHaveBeenCalled();
+      open.mockRestore();
+    });
+
+    it('ignores a URL the browser must not navigate to', async () => {
+      withAutoExport({ exporter: 'evil', success: true, open_url: 'javascript:alert(1)' });
+      await flushInit();
+      expect(component.autoExportUrl()).toBeNull();
+      expect(fixture.nativeElement.querySelector('.auto-export-open')).toBeNull();
+    });
+
+    it('offers nothing for a failed export or a plain delivery', async () => {
+      withAutoExport({ exporter: 'open_url', success: false, open_url: 'https://example.com/r' });
+      await flushInit();
+      expect(component.autoExportUrl()).toBeNull();
+
+      withAutoExport({ exporter: 'server_json_file', success: true, message: 'Wrote it.' });
+      await settleZoneless(fixture);
+      expect(component.autoExportUrl()).toBeNull();
+      expect(fixture.nativeElement.querySelector('.auto-export-open')).toBeNull();
+    });
+  });
 });

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../models/api.models';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 import { IconComponent } from '../../icon/icon.component';
+import { openExternalUrl, safeExternalUrl } from '../../../utils/external-url';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -68,6 +69,25 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  /**
+   * The Auto-Find auto-export's `open_url`, if it returned an openable one.
+   *
+   * An exporter can format the run's results into a third-party site's URL
+   * instead of (or as well as) delivering them somewhere; the same key drives
+   * the Export modal. Surfaced as an "Open" button rather than opened on
+   * arrival, because these results land from an async response and a popup
+   * blocker would swallow an unprompted `window.open()`.
+   */
+  autoExportUrl(): string | null {
+    const status = this.data().auto_export;
+    return status?.success ? safeExternalUrl(status.open_url) : null;
+  }
+
+  /** Open the auto-export's URL in a new tab (the click is the user gesture). */
+  openExternal(url: string): void {
+    openExternalUrl(url);
   }
 
   get allHits(): AutoDetectHit[] {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -28,6 +28,7 @@ import { SortingApiService } from '../../../services/sorting-api.service';
 import type { LabelFilter } from '../../../services/sorting-api.service';
 import { ToastService } from '../../../services/toast.service';
 import { ImporterField } from '../../../models/api.models';
+import { openExternalUrl, safeExternalUrl } from '../../../utils/external-url';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 import type { LabeledElement } from '../../../generated/api-client/models/labeled-element';
 
@@ -595,8 +596,8 @@ export class ExportModalComponent implements OnInit {
           // An exporter can hand back a URL for the browser to open instead of
           // (or as well as) delivering the labelset somewhere — that's how a
           // third-party site with no ingest API gets the selection (#2855).
-          const openUrl = ExportModalComponent.safeExternalUrl(response?.open_url);
-          const opened = openUrl ? this.openExternal(openUrl) : false;
+          const openUrl = safeExternalUrl(response?.open_url);
+          const opened = openUrl ? openExternalUrl(openUrl) : false;
           const plural = labelCount === 1 ? '' : 's';
 
           // Three toast shapes: opened a tab, tried and got blocked, or a
@@ -622,7 +623,7 @@ export class ExportModalComponent implements OnInit {
             // through — it doubles as the blocked-popup escape hatch and as a
             // way to reopen a tab the user closed by accident.
             action: openUrl
-              ? { label: 'Open', title: openUrl, onClick: () => this.openExternal(openUrl) }
+              ? { label: 'Open', title: openUrl, onClick: () => openExternalUrl(openUrl) }
               : undefined,
             dedupKey: 'export-labels-success',
           });
@@ -634,35 +635,6 @@ export class ExportModalComponent implements OnInit {
           this.submitting.set(false);
         },
       });
-  }
-
-  /**
-   * Narrow an exporter-supplied `open_url` to something safe to hand to
-   * `window.open`, or `null`.
-   *
-   * The server already ran this through `validate_browser_url`, so this is the
-   * second half of a belt-and-braces pair: the check that matters is the
-   * scheme, and it costs one regex to make the frontend independently
-   * unable to navigate to a `javascript:` or `data:` URL — a class of bug that
-   * only ever shows up once someone's plugin is already in the wild.
-   */
-  private static safeExternalUrl(url: unknown): string | null {
-    if (typeof url !== 'string') return null;
-    const trimmed = url.trim();
-    return /^https?:\/\/\S+$/i.test(trimmed) ? trimmed : null;
-  }
-
-  /**
-   * Open *url* in a new tab, reporting whether the tab actually opened.
-   *
-   * `noopener` severs the new page's `window.opener` handle so a third-party
-   * site can't navigate the VTSearch tab out from under the user (reverse
-   * tabnabbing). A `null` return means the popup blocker ate it, which is the
-   * normal outcome when the call happens after an async response rather than
-   * inside the click handler.
-   */
-  private openExternal(url: string): boolean {
-    return window.open(url, '_blank', 'noopener') !== null;
   }
 
   /** Map an exporter's emoji icon to an SVG icon type. */

--- a/frontend/src/app/utils/external-url.ts
+++ b/frontend/src/app/utils/external-url.ts
@@ -1,0 +1,33 @@
+/**
+ * Guards for the `open_url` an exporter can hand back for the browser to open.
+ *
+ * The server already runs every such URL through `validate_browser_url`, so
+ * this is the second half of a belt-and-braces pair: the check that matters is
+ * the scheme, and it costs one regex to make the frontend independently unable
+ * to navigate to a `javascript:` or `data:` URL — a class of bug that only ever
+ * shows up once someone's plugin is already in the wild.
+ *
+ * Lives here rather than on one component because two surfaces act on the key:
+ * the Export modal (a labelset export the user ran) and the Auto-Detect Results
+ * modal (an Auto-Find auto-export that ran for them).
+ */
+
+/** Narrow an exporter-supplied `open_url` to something safe for `window.open`, or `null`. */
+export function safeExternalUrl(url: unknown): string | null {
+  if (typeof url !== 'string') return null;
+  const trimmed = url.trim();
+  return /^https?:\/\/\S+$/i.test(trimmed) ? trimmed : null;
+}
+
+/**
+ * Open *url* in a new tab, reporting whether the tab actually opened.
+ *
+ * `noopener` severs the new page's `window.opener` handle so a third-party site
+ * can't navigate the VTSearch tab out from under the user (reverse tabnabbing).
+ * A `null` return means the popup blocker ate it, which is the normal outcome
+ * when the call happens after an async response rather than inside a click
+ * handler.
+ */
+export function openExternalUrl(url: string): boolean {
+  return window.open(url, '_blank', 'noopener') !== null;
+}

--- a/tests/detectors/test_autofind_export.py
+++ b/tests/detectors/test_autofind_export.py
@@ -8,6 +8,7 @@ hands an autodetect run's results to the exporter configured under
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 from vtsearch import settings
 from vtsearch.routes.detectors.scoring import _run_autofind_export
@@ -53,3 +54,37 @@ class TestAutofindExport:
         assert out.exists()
         written = json.loads(out.read_text())
         assert "results" in written or "det-a" in json.dumps(written)
+
+
+class TestAutofindExportOpenUrl:
+    """An exporter can send the user to a web page instead of delivering the
+    results anywhere; the status block carries the URL to the modal (#2898)."""
+
+    def test_open_url_reaches_the_status_block(self, isolated_settings):
+        settings.set_autofind_exporter("open_url")
+        settings.set_autofind_exporter_field_values({"open_url": {"url_template": "https://example.com/r?ids={ids}"}})
+        status = _run_autofind_export(dict(_SAMPLE_RESULTS))
+        assert status is not None
+        assert status["success"] is True
+        assert status["open_url"] == "https://example.com/r?ids=abc"
+
+    def test_unusable_url_is_dropped_not_forwarded(self, isolated_settings):
+        """The same scheme allowlist the export route applies — a plugin must
+        not be able to push a ``javascript:`` URL at the browser from here."""
+        from vtscore.exporters import get_exporter
+
+        # Patch the *class*: the registry hands out a singleton instance, and
+        # an instance-level patch would leave a shadowing attribute behind that
+        # later class-level patches (tests/io/test_exporters.py) can't reach.
+        settings.set_autofind_exporter("gui")
+        with patch.object(
+            type(get_exporter("gui")),
+            "export",
+            return_value={"message": "Shown.", "open_url": "javascript:alert(1)"},
+        ):
+            status = _run_autofind_export(dict(_SAMPLE_RESULTS))
+        assert status is not None
+        # The export itself ran, so it stays a success — only the URL is lost.
+        assert status["success"] is True
+        assert "open_url" not in status
+        assert "unusable URL" in status["message"]

--- a/tests_lib/detectors/test_acquisition_threshold.py
+++ b/tests_lib/detectors/test_acquisition_threshold.py
@@ -87,7 +87,17 @@ class TestAcquisitionThresholdIsDecoupled:
             det_ctx.threshold = cut.threshold_at(k)
             acq = detector_acquisition_threshold(det_ctx, k)
             assert acq == cut.threshold_at(k + ACQUISITION_INCLUSION_OFFSET)
-            assert acq > det_ctx.threshold, f"the offset collapsed at reporting inclusion {k}"
+            # Never *below* the reporting line, wherever the slider sits - the
+            # failure an absolute reading would produce.  Not strict, because
+            # the cost weights saturate at the ends of the slider: once the
+            # quantile has hit its ceiling there is no higher cut left to take,
+            # and the offset legitimately lands on the reporting cut itself.
+            assert acq >= det_ctx.threshold, f"the offset inverted at reporting inclusion {k}"
+
+        # ...and it is a real gap rather than a no-op wherever the estimator
+        # still has room to move, which is what was measured.
+        det_ctx.threshold = cut.threshold_at(0)
+        assert detector_acquisition_threshold(det_ctx, 0) > det_ctx.threshold
 
     def test_it_is_monotone_in_inclusion_like_the_reporting_cut(self):
         """Same nesting contract - the acquisition cut is the same estimator."""

--- a/tests_lib/io/test_open_url_exporter.py
+++ b/tests_lib/io/test_open_url_exporter.py
@@ -7,10 +7,14 @@ template is rejected: an unusable scheme and a URL past the length limit.
 
 from __future__ import annotations
 
+import json
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+from vtscore import cli_progress
+from vtscore.cli import _run_exporter
 from vtscore.exporters import get_exporter
 from vtscore.exporters.open_url import MAX_URL_LENGTH, OpenUrlLabelsetExporter
 
@@ -41,6 +45,16 @@ AUTODETECT_RESULTS = {
 def _ids_param(url: str, key: str = "ids") -> str:
     """Return the decoded value of *key* from *url*'s query string."""
     return parse_qs(urlparse(url).query)[key][0]
+
+
+def _stub_gui_cli_export(outcome: dict):
+    """Make the ``gui`` exporter's CLI export return *outcome*.
+
+    Patches the **class**, not the registry's singleton instance: an
+    instance-level patch leaves a shadowing attribute behind on undo, which
+    then swallows the class-level patches other exporter tests use.
+    """
+    return patch.object(type(get_exporter("gui")), "export_cli", return_value=outcome)
 
 
 @pytest.fixture
@@ -194,13 +208,64 @@ class TestRejection:
 
 
 class TestCliExport:
-    def test_prints_the_url(self, exporter, capsys):
-        out = exporter.export_cli(LABELSET, {"url_template": "https://example.com/r?ids={ids}"})
-        assert out["open_url"] in capsys.readouterr().out
+    """The CLI variant returns the URL; ``vtscore.cli`` is what surfaces it.
 
-    def test_reports_truncation_on_stdout(self, exporter, capsys):
-        exporter.export_cli(
+    Writing to stdout here would both duplicate that line and corrupt the
+    NDJSON stream under ``--progress-format json``, so these assert silence.
+    """
+
+    def test_returns_the_url(self, exporter):
+        out = exporter.export_cli(LABELSET, {"url_template": "https://example.com/r?ids={ids}"})
+        assert _ids_param(out["open_url"]) == "aaa1,bbb2,ccc3"
+
+    def test_reports_truncation_in_the_message(self, exporter):
+        out = exporter.export_cli(
             LABELSET,
             {"url_template": "https://example.com/r?ids={ids}", "max_items": "1"},
         )
-        assert "first 1 of 3" in capsys.readouterr().out
+        assert "first 1 of 3" in out["message"]
+
+    def test_writes_nothing_to_stdout(self, exporter, capsys):
+        exporter.export_cli(LABELSET, {"url_template": "https://example.com/r?ids={ids}"})
+        assert capsys.readouterr().out == ""
+
+
+class TestCliSurfacesOpenUrl:
+    """``_run_exporter`` reports an ``open_url`` instead of dropping it.
+
+    There is no browser on the command line, so the URL has to reach the
+    operator (text mode) or the wrapping script (JSON mode) some other way.
+    This is what makes the capability usable from *any* exporter, not just the
+    built-in one (issue #2898).
+    """
+
+    TEMPLATE = {"url_template": "https://example.com/r?ids={ids}"}
+
+    def test_prints_the_url_under_the_message(self, capsys):
+        _run_exporter("open_url", dict(self.TEMPLATE), LABELSET)
+        out = capsys.readouterr().out
+        assert "Formatted a URL covering 3 item(s)." in out
+        assert "https://example.com/r?ids=aaa1%2Cbbb2%2Cccc3" in out
+
+    def test_carries_the_url_on_the_json_event(self, capsys):
+        cli_progress.set_format("json")
+        _run_exporter("open_url", dict(self.TEMPLATE), LABELSET)
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        assert len(lines) == 1, "the URL must not be printed as prose alongside the NDJSON event"
+        event = json.loads(lines[0])
+        assert event["event"] == "export_complete"
+        assert _ids_param(event["open_url"]) == "aaa1,bbb2,ccc3"
+
+    def test_exporters_without_a_url_are_unchanged(self, capsys):
+        with _stub_gui_cli_export({"message": "Wrote it."}):
+            _run_exporter("gui", {}, LABELSET)
+        assert capsys.readouterr().out == "Wrote it.\n"
+
+    def test_unusable_url_is_dropped_rather_than_shown(self, capsys):
+        """A plugin must not be able to put a ``javascript:`` URL in front of
+        the user — but the export itself already ran, so it isn't failed."""
+        with _stub_gui_cli_export({"message": "Wrote it.", "open_url": "javascript:alert(1)"}):
+            _run_exporter("gui", {}, LABELSET)
+        out = capsys.readouterr().out
+        assert "javascript:" not in out
+        assert "Wrote it." in out

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -7,6 +7,7 @@ file, and export the results.
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 from collections.abc import Iterator
@@ -18,6 +19,8 @@ from vtscore import cli_progress
 from vtscore.datasets.loader import apply_custom_metadata_md5, load_dataset_from_pickle
 from vtscore.utils.hits import build_media_hit
 from vtscore.utils.scores import sigmoid_to_finite_scores
+
+logger = logging.getLogger(__name__)
 
 
 def _list_importer_names() -> list[str]:
@@ -474,6 +477,12 @@ def _run_exporter(
     exports the trained classifiers themselves (``needs_trained_detectors``,
     the portable-detector bundle) is handed the *detector_mlps* the pipeline
     trained, via :meth:`LabelsetExporter.export_cli_detectors`.
+
+    An exporter that returns an ``open_url`` gets it surfaced here rather than
+    dropped: there is no browser to open it on the command line, so the URL is
+    printed under the confirmation message (text mode) and carried as a field
+    on the ``export_complete`` event (JSON mode), which is what lets a wrapping
+    script open it itself.
     """
     from vtscore.exporters import get_exporter
 
@@ -489,7 +498,38 @@ def _run_exporter(
     else:
         result = exporter.export_cli(results, field_values)
     message = result.get("message", "Export complete.")
-    cli_progress.emit("export_complete", text=message, message=message)
+
+    open_url = _validated_open_url(result, exporter_name)
+    if open_url is None:
+        cli_progress.emit("export_complete", text=message, message=message)
+    else:
+        cli_progress.emit(
+            "export_complete",
+            text=f"{message}\n\n  {open_url}",
+            message=message,
+            open_url=open_url,
+        )
+
+
+def _validated_open_url(result: dict[str, Any], exporter_name: str) -> str | None:
+    """Return *result*'s ``open_url`` if it is one, else ``None``.
+
+    The same scheme allowlist the HTTP route applies, for the same reason: a
+    plugin should never be able to put a ``javascript:`` URL in front of the
+    user.  A bad one is dropped with a warning rather than raised, because the
+    export itself already succeeded — sinking a completed delivery over a
+    cosmetic field would lose the run.
+    """
+    raw = result.get("open_url")
+    if raw is None:
+        return None
+    from vtscore.security.url_validation import validate_browser_url
+
+    try:
+        return validate_browser_url(str(raw))
+    except ValueError as exc:
+        logger.warning("Exporter %r returned an unusable open_url, ignoring it: %s", exporter_name, exc)
+        return None
 
 
 def _portable_detector_descriptors(detector_mlps: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:

--- a/vtscore/cli_progress.py
+++ b/vtscore/cli_progress.py
@@ -16,7 +16,9 @@ Event names emitted today:
 - ``labels_imported`` - one-shot ``--import-labels-into`` finished
   fields: ``detector`` (str), ``applied`` (int), ``skipped`` (int)
 - ``export_complete`` - exporter finished its run
-  fields: ``message`` (str - the exporter's own confirmation text)
+  fields: ``message`` (str - the exporter's own confirmation text),
+  ``open_url`` (str? - only when the exporter returned one; an ``http(s)``
+  URL for the caller to open, since the CLI has no browser of its own)
 - ``progress``       - a tick from the embedding / loading stack
   fields: ``status`` (str), ``message`` (str?), ``current`` (int?),
   ``total`` (int?), ``pct`` (float? - only when total > 0)

--- a/vtscore/docs/extending/results-exporters.md
+++ b/vtscore/docs/extending/results-exporters.md
@@ -217,6 +217,14 @@ what the UI reads to label the button before running anything. An
 exporter that returns one only sometimes (a webhook whose remote hands
 back a permalink) leaves the flag `False` - the URL still opens.
 
+**You don't need an `export_cli` override for this.** The CLI has no
+browser, so it surfaces the `open_url` your `export()` returned rather
+than dropping it: printed under the confirmation message in text mode,
+and carried as an `open_url` field on the `export_complete` event under
+`--progress-format json`, where a wrapping script can open it. Don't
+`print()` the URL yourself - that duplicates the line and puts prose in
+the middle of the NDJSON stream.
+
 ## Entry-point registration
 
 In-tree:

--- a/vtscore/exporters/open_url/__init__.py
+++ b/vtscore/exporters/open_url/__init__.py
@@ -213,14 +213,17 @@ class OpenUrlLabelsetExporter(LabelsetExporter):
         }
 
     def export_cli(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        """Print the formatted URL to stdout — there is no browser to open it."""
+        """Return the formatted URL — there is no browser here to open it.
+
+        The CLI prints the ``open_url`` of *any* exporter under the
+        confirmation message, so this doesn't write to stdout itself: doing so
+        would both duplicate that line and put prose in the middle of the
+        NDJSON stream under ``--progress-format json``.
+        """
         url, included, total = self._build_url(results, field_values)
-        if included < total:
-            print(f"Formatted URL (first {included} of {total} item(s)):\n\n  {url}")
-        else:
-            print(f"Formatted URL ({included} item(s)):\n\n  {url}")
+        detail = f"first {included} of {total} item(s)" if included < total else f"{included} item(s)"
         return {
-            "message": f"Printed a URL covering {included} of {total} item(s) to stdout.",
+            "message": f"Formatted a URL covering {detail}.",
             "open_url": url,
             "included_count": included,
             "total_count": total,

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -991,4 +991,19 @@ def _run_autofind_export(response: dict) -> dict | None:
     for key, value in outcome.items():
         if key != "message":
             status[key] = value
+
+    # An `open_url` reaches the browser, so it gets the same scheme allowlist
+    # `POST /api/exporters/export` applies - a plugin must not be able to push
+    # a `javascript:` URL to the frontend from here either. Unlike that route
+    # this one drops the bad URL instead of failing: the export already
+    # happened, and the scored results must survive a cosmetic field.
+    if status.get("open_url") is not None:
+        from vtscore.security.url_validation import validate_browser_url  # noqa: PLC0415
+
+        try:
+            status["open_url"] = validate_browser_url(str(status["open_url"]))
+        except ValueError as exc:
+            logger.error("Auto-Find exporter %r returned an unusable open_url: %s", exporter_name, exc)
+            del status["open_url"]
+            status["message"] = f"{status['message']} (the exporter returned an unusable URL, so nothing will open)"
     return status

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -693,6 +693,15 @@ class _AutoFindExportStatusSchema(Schema):
     success = fields.Boolean(required=True)
     message = fields.String(metadata={"description": "Human-readable outcome; present on success."})
     error = fields.String(metadata={"description": "Failure reason; present instead of ``message`` on failure."})
+    open_url = fields.String(
+        metadata={
+            "description": (
+                "An ``http(s)`` URL the exporter formatted for the browser to open, "
+                "offered as a link in the Auto-Detect Results modal. Declared rather "
+                "than left to the pass-through below because the frontend acts on it."
+            )
+        }
+    )
 
     class Meta:
         unknown = INCLUDE


### PR DESCRIPTION
Closes #2898

## The short answer to the issue

There **is** a way to fire "now open the user's browser to this URL" — it shipped with #2855. An exporter returns an `open_url` key from `export()` and the frontend opens it in a new tab; set `opens_url = True` as well if you *always* return one, so the button can say "Open in &lt;name&gt;" before the export runs.

The reason that wasn't discoverable is a real gap: **`docs/EXTENDING-plugins.md`, the guide a plugin author actually reads, never mentioned `open_url` or `opens_url`.** Only the library-side guide and `docs/api/io.md` did. And two of the three surfaces that run an exporter silently dropped the key, so the answer was really "yes, in the Export modal, nowhere else."

## What changed

**Docs (the actual fix for the issue).** `docs/EXTENDING-plugins.md § Adding a Results Exporter` gains an "Opening a browser tab (`open_url`)" section: the return-key contract, the `opens_url` flag, a per-surface behaviour table, the validation rule, and the keep-it-to-identifiers / cap-the-length warnings, cross-linked to the library guide's worked example. `docs/EXTENDING.md`'s New Results Exporter checklist gains a line pointing at it.

**CLI — the URL was dropped.** `_run_exporter` emitted only the exporter's `message`. It now prints the URL under the message, and carries it as an `open_url` field on the `export_complete` event so a `--progress-format json` consumer can open it:

```bash
python app.py --autodetect ... --progress-format json --exporter open_url \
    --url-template 'https://example.com/review?ids={ids}' \
  | jq -r 'select(.event == "export_complete") | .open_url'
```

This is what makes the capability work for *any* exporter rather than only the built-in one. The built-in `open_url` exporter's own `print()` goes away with it — it duplicated that line and put prose in the middle of the NDJSON stream.

**Auto-Find — offered but inert, and unvalidated.** `_run_autofind_export` forwarded an exporter's `open_url` to the client *without* the `validate_browser_url` re-check `POST /api/exporters/export` applies, and the Auto-Detect Results modal ignored the key entirely — so selecting "Open in Website" as your Auto-Find exporter produced a status line and nothing else. Now validated (an unusable URL is dropped and noted in `message` rather than sinking an export that already ran) and offered as an **Open** button on the status line. Deliberately not opened on arrival: those results land from an async response, which is exactly where a popup blocker eats an unprompted `window.open()`.

`open_url` is declared on `_AutoFindExportStatusSchema` rather than riding the `@post_dump` pass-through, since the frontend now acts on it — `frontend/openapi.json` regenerated accordingly. The frontend's scheme guard moves to `frontend/src/app/utils/external-url.ts` now that two surfaces need it.

## Unrelated failure fixed along the way

`tests_lib/detectors/test_acquisition_threshold.py::test_the_offset_is_relative_to_inclusion_not_absolute` was failing on `dev` — and, checked in a worktree, at the commit that introduced it, so it is not a behaviour regression. The test asserts the acquisition cut sits *strictly* above the reporting cut at every inclusion, but the cost-weight quantile clamps at the ends of the slider: under the library-tier config it saturates at 0.675 for k ≤ -3, so at inclusion -6 there is no higher cut left to take and the two legitimately coincide. The assertion now pins "never inverts" at every k (the failure an absolute reading would produce) plus a strict gap at inclusion 0 where the estimator still has room. Exact-offset equality — the load-bearing claim — is untouched.

## Testing

`./run-tests.sh` — **ALL 7861 TESTS PASSED** (1 skipped, 1 xfailed). Ruff, codespell, deptry, pip-audit, pyright, OpenAPI snapshot, Dockerfiles, screenshot wiring, frontend `build:prod` (no budget warnings), `npm audit`, and 1960 Vitest tests all clean.

New coverage: CLI text/JSON surfacing and the `javascript:` drop; the Auto-Find status block's URL and its validation; five frontend specs for the Open button (rendered, click opens with `noopener`, nothing opens on arrival, unsafe scheme ignored, absent for a failed export or plain delivery).

No screenshot reshoot queued — the Auto-Detect Results modal isn't framed by any manifest shot, and the Export modal's UI is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BETQBnLS9NxGeyvZkWZyzs)_