### PR TITLE
Gate the eval framework against drifting from the app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,25 @@ The single exception is **dataset pickle files**, which are by design a snapshot
 
 If a feature seems to require persisting a vector or MLP, push back: either re-derive on demand, or change the design.
 
+## The Eval Default Arm IS the App (CRITICAL)
+
+`vtscore.eval` exists to measure **deviations** from the shipped algorithm. That only means something if its **default arm** *is* the shipped algorithm. When the app's algorithm moves and the harness doesn't, every experiment run after that point is measuring a detector nobody uses — and the damage is silent and retroactive, because the numbers still look fine. So: **an app-side algorithm change is not finished until the eval framework has caught up.**
+
+Most of the harness is safe by construction because it **delegates** — `MaxPatchStyle` calls `pool_box_from_media` / `bad_negative_vecs` / `media_score_rows` rather than re-deriving them, so it cannot drift. Prefer delegation over copying every time; it is the only fix that can't rot. Two kinds of code can't delegate, and those are the ones that bite:
+
+- **Ported** — app logic re-implemented in the harness because the original is unreachable (it lives in TypeScript) or unusable (wrapped in interactive, lock-guarded, single-detector caches). `vtscore/eval/autopilot_flow.py` is the whole of this category today.
+- **Default resolution** — where the harness resolves "no explicit arm" to whatever the app currently defaults to (`style=None` → `max_patch` on a patch dataset; `blend_schedule=None` → `production_schedule_for(...)`). When the app's default changes, the harness keeps handing out the old one *under the name "default"*.
+
+**The gate:** `scripts/check-eval-app-sync.py` pins a digest of every mirrored app surface (Python and TypeScript), and `./run-tests.sh` fails when one moves. It tells you which harness code to reconcile. After reconciling — or after confirming nothing is owed — re-pin:
+
+```
+python scripts/check-eval-app-sync.py --update
+```
+
+Digests ignore comments, docstrings, and formatting, so only real logic changes trip it. **Re-pinning without looking at the harness defeats the entire gate**; the digest is a prompt to check, not a checkbox.
+
+**When you add a new mirror** (any new place the harness copies app logic or tracks an app default), add a `Mirror(...)` entry to `MIRRORS` in that script and run `--update`. If the harness *intentionally* differs from the app at that point, put the reason in `divergence=` — the text is printed whenever that mirror trips, so the next person reconciling it knows which differences are deliberate. Named experiment arms (`whole_image`, `max_patch_hac`, …) are supposed to differ and are out of scope; this rule is about the **default** arm only.
+
 ## Fix All Errors (CRITICAL)
 
 When you run a build, typecheck, linter, or test suite, **fix every error and failure you see; not only the ones you introduced**. Do not dismiss errors as "pre-existing", "unrelated to my change", or "not my fault" and move on. Do not announce them and ask the user to triage. The user does not want to scan your output for problems you decided to ignore.
@@ -210,6 +229,7 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 - **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json>`
 - **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter server_json_file --filepath results.json`
 - **CLI autodetect + importer**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --importer server_folder --path /data/sounds --media-type audio --settings <settings.json>`
+- **Check eval/app sync**: `python scripts/check-eval-app-sync.py` (also a `./run-tests.sh` gate; re-pin with `--update` after reconciling the harness)
 - **Install deps**: `bash scripts/install.sh` (auto-detects CPU vs GPU; pass `cpu`/`gpu` to force, or a `cuXYZ` tag to override the GPU wheel, e.g. `bash scripts/install.sh cu121`)
 - **Build frontend**: `cd frontend && npm install && npm run build:prod` (builds Angular app to `static/`)
 - **Frontend dev server**: `cd frontend && npm start` (proxies `/api/*` to Flask at localhost:5000)

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -2,6 +2,8 @@
 
 VTSearch includes a built-in evaluation framework that measures how well its sorting methods work on demo datasets. This guide covers how to run evaluations, write custom eval scripts, and interpret the results.
 
+> **The default arm is the shipped algorithm.** Every experiment here is a measured *deviation* from what the app does, which only means something if the un-deviated arm matches the app. Where the harness can't call app code directly it copies it, and those copies are pinned by `scripts/check-eval-app-sync.py` — a `./run-tests.sh` gate that fails when an app-side surface moves. See [The Eval Default Arm IS the App](#the-eval-default-arm-is-the-app) below.
+
 ## Quick start
 
 Run the full evaluation across all demo datasets:
@@ -372,3 +374,44 @@ Both functions:
 - Create the output directory if it doesn't exist.
 - Return a list of `Path` objects pointing to the generated PNGs.
 - Skip chart types that don't apply (e.g., no learned-sort plots if only text-sort was run).
+
+## The Eval Default Arm IS the App
+
+Every experiment in this framework is a *deviation* from the shipped algorithm — a different Good-vote geometry, a different blend schedule, a different acquisition cut. A deviation is only interpretable against a baseline that is the real thing, so the framework's default arm has to be exactly what the app ships. When the app moves and the harness doesn't, the studies don't fail loudly; they keep producing plausible numbers about a detector nobody uses, and everything measured after the drift is quietly devalued.
+
+Three ways the harness relates to the app, in descending order of safety:
+
+| | How | Can it drift? |
+|---|---|---|
+| **Delegated** | The harness calls the app's function. `MaxPatchStyle.good_vec` / `.bad_vecs` / `._rows_for_media` are thin wrappers over `pool_box_from_media`, `bad_negative_vecs`, and `media_score_rows`. | No — by construction. |
+| **Ported** | The app's logic is re-implemented, because the original is unreachable or unusable. `vtscore/eval/autopilot_flow.py` ports the phase machine from `AutopilotStateService.checkPhaseTransition` (TypeScript — nothing to import) and the three indicators from `vtscore.detectors.labeling_progress` (wrapped in an interactive, lock-guarded single-detector cache a simulation can't use). | Yes — a copy goes stale the moment the original moves. |
+| **Default resolution** | The harness resolves "no explicit arm" to whatever the app currently defaults to: `style=None` → `max_patch` on a patch dataset, `blend_schedule=None` → `production_schedule_for(...)`. | Yes — the app changes its default and the harness keeps serving the old one *under the name "default"*. |
+
+Prefer delegation whenever it's possible; it's the only fix that can't rot.
+
+### The drift gate
+
+`scripts/check-eval-app-sync.py` pins a digest of each mirrored app surface — Python symbols by parsing the module, TypeScript blocks by brace-matching an anchor — and `./run-tests.sh` fails when one changes. It parses rather than imports, so it's dependency-free and takes ~0.3s. A failure names the mirror, both sides of it, and what to re-check:
+
+```
+  * autopilot.phase_machine  [ported, changed]
+      app:     frontend/src/app/services/autopilot-state.service.ts::checkPhaseTransition(
+      harness: vtscore/eval/autopilot_flow.py::next_phase
+      The phase ordering and every transition trigger of the simulated Autopilot user. ...
+```
+
+Reconcile the harness side, then re-pin:
+
+```bash
+python scripts/check-eval-app-sync.py --update
+```
+
+Digests ignore comments, docstrings, and formatting (including the magic trailing comma `ruff format` adds when it wraps a line), so only real logic changes trip the gate. Re-pinning without reading the harness defeats the whole thing — the digest is a prompt to check, not a checkbox.
+
+### Adding and diverging
+
+A new mirror is a new `Mirror(...)` entry in `MIRRORS`, plus `--update`. Give it a `note` that says what to re-check when the app moves, not just what the code is.
+
+When the harness *intentionally* differs from the app at a mirror, record why in `divergence=`. That doesn't exempt it from the digest — you still re-pin — but the text prints whenever the mirror trips, so whoever reconciles it next knows which differences are deliberate. The ported indicators use this: they take their histories as arguments rather than reading the app's `_cached_steps`, which is plumbing, not a rule change.
+
+Named experiment arms (`whole_image`, `max_patch_hac`, `max_patch_pca_hac`) are *supposed* to differ from the app — that's what makes them arms. This gate is about the default arm only.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -215,6 +215,20 @@ if ! python scripts/screenshots/wiring-check.py ; then
     exit 1
 fi
 
+# Eval/app sync: the eval framework reproduces a handful of app surfaces it
+# cannot call (the TypeScript autopilot phase machine, the app's default
+# resolution). This gate notices when one of those app surfaces changes, so the
+# eval default arm can't quietly stop being the shipped algorithm. Parses
+# source, imports nothing, ~0.3s.
+echo "Checking eval/app sync..."
+if ! python scripts/check-eval-app-sync.py ; then
+    echo ""
+    echo "============================================================"
+    echo "TESTS BLOCKED: eval framework is out of sync with the app"
+    echo "============================================================"
+    exit 1
+fi
+
 # Split arguments into groups and extra pytest args
 TEST_GROUPS=()
 EXTRA_ARGS=()

--- a/scripts/check-eval-app-sync.py
+++ b/scripts/check-eval-app-sync.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Drift gate: the eval framework's default arm vs. the app it is meant to model.
+
+`vtscore.eval` exists to measure *deviations* from the shipped algorithm.  That
+only means something if the framework's **default arm** is the shipped
+algorithm.  When it isn't, every experiment run against it is measuring a
+detector nobody uses, and the damage is silent and retroactive - the numbers
+still look fine.
+
+Most of the harness is safe by construction because it *delegates*: the
+`max_patch` style calls `pool_box_from_media` / `bad_negative_vecs` /
+`media_score_rows` rather than re-deriving them, so it cannot drift.  This gate
+covers the parts that can't delegate:
+
+* **ported** - app logic re-implemented in the harness, because the original is
+  unreachable (it lives in TypeScript) or unusable (it is wrapped in
+  interactive, lock-guarded, single-detector caches).  A copy goes stale the
+  moment the original moves.
+* **default** - places where the harness resolves "no explicit arm" to whatever
+  the app currently defaults to.  When the app's default changes, the harness
+  keeps handing out the old one under the name "default".
+
+Each mirror pins a digest of the app-side source.  Changing the app trips the
+gate, which tells you which harness code to reconcile.  Once reconciled (or once
+you have confirmed nothing is owed), re-pin:
+
+    python scripts/check-eval-app-sync.py --update
+
+Digests ignore comments, docstrings and formatting, so only real logic changes
+trip the gate.
+
+Adding a mirror: append a `Mirror(...)` to `MIRRORS` and run `--update`.  If the
+harness *intentionally* differs from the app at that point, say so in
+`divergence=` - the text is printed whenever the mirror trips, so the next
+person reconciling it knows which differences are deliberate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import io
+import json
+import re
+import sys
+import textwrap
+import tokenize
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PINS_PATH = REPO_ROOT / "scripts" / "eval-app-sync.pins.json"
+
+AUTOPILOT_TS = "frontend/src/app/services/autopilot-state.service.ts"
+
+
+@dataclass(frozen=True)
+class Mirror:
+    """One app-side surface the eval harness reproduces rather than calls.
+
+    Attributes:
+        id: Stable key into the pins file.  Renaming one re-pins from scratch.
+        app: The app-side source. ``py:<dotted.path.to.symbol>`` for Python,
+            ``ts:<repo-relative file>::<anchor>`` for a TypeScript block (the
+            anchor is matched literally, then brace-matched from the first
+            ``{`` after it).
+        harness: Where the reproduction lives, as ``<repo-relative file>::<symbol>``.
+            Checked for existence, so deleting or renaming the harness side
+            trips the gate too.
+        kind: ``ported`` or ``default`` - see the module docstring.
+        note: What is reproduced, and what to re-check when the app moves.
+        divergence: A *declared, intentional* difference from the app.  Not an
+            exemption - the digest is still pinned - but it tells whoever
+            reconciles this mirror which differences are on purpose.
+    """
+
+    id: str
+    app: str
+    harness: str
+    kind: str
+    note: str
+    divergence: str | None = None
+
+
+MIRRORS: list[Mirror] = [
+    # ------------------------------------------------------------------ ported
+    Mirror(
+        id="autopilot.phase_machine",
+        app=f"ts:{AUTOPILOT_TS}::checkPhaseTransition(",
+        harness="vtscore/eval/autopilot_flow.py::next_phase",
+        kind="ported",
+        note=(
+            "The phase ordering and every transition trigger of the simulated Autopilot user. "
+            "Lives in TypeScript, so there is nothing to import - it is a hand copy. If you "
+            "add, remove or reorder a phase, or change what gates one, port the same change."
+        ),
+    ),
+    Mirror(
+        id="autopilot.vote_targets",
+        app=f"ts:{AUTOPILOT_TS}::const INITIAL_STATE",
+        harness="vtscore/eval/autopilot_flow.py::GOOD_TARGET",
+        kind="ported",
+        note=(
+            "goodToStart / badToStart are copied as GOOD_TARGET / BAD_TARGET, which decide how "
+            "many votes the simulation spends before its first learned sort. Pinned literally "
+            "by tests_lib/detectors/test_autopilot_flow.py::TestPortedConstants."
+        ),
+    ),
+    Mirror(
+        id="progress.smart_status",
+        app="py:vtscore.detectors.labeling_progress._compute_smart_status",
+        harness="vtscore/eval/autopilot_flow.py::smart_status",
+        kind="ported",
+        note=(
+            "The Smart indicator - error-cost flatness - one of the three gates the phase "
+            "machine reads. Re-check the per-class minimum and the flatness threshold."
+        ),
+        divergence=(
+            "The harness takes the error-cost history as an argument instead of reading the "
+            "module-level `_cached_steps` MLP cache, which is built for one interactive "
+            "detector advancing a vote at a time. The *rules* are copied; only the input "
+            "plumbing differs."
+        ),
+    ),
+    Mirror(
+        id="progress.stable_status",
+        app="py:vtscore.detectors.labeling_progress._compute_stable_status",
+        harness="vtscore/eval/autopilot_flow.py::stable_status",
+        kind="ported",
+        note=(
+            "The Stable indicator - prediction-flip rate. Re-check the per-class minimum, the "
+            "minimum history length, and both the rate and max flip thresholds."
+        ),
+        divergence=(
+            "Same input plumbing divergence as progress.smart_status: flip counts are passed "
+            "in rather than read from `_cached_steps`."
+        ),
+    ),
+    Mirror(
+        id="progress.span_status",
+        app="py:vtscore.detectors.labeling_progress._compute_span_status",
+        harness="vtscore/eval/autopilot_flow.py::span_status",
+        kind="ported",
+        note=(
+            "The Span indicator - coverage-atlas breadth - which drives the new -> done "
+            "transition. Re-check the green target and the yellow cutoff."
+        ),
+        divergence=(
+            "The app reads its green target from `CoreConfig.autopilot_goal_diversity`; the "
+            "harness takes it per-run so a sweep can vary it, defaulting to the same value."
+        ),
+    ),
+    # ----------------------------------------------------------------- default
+    Mirror(
+        id="training.train_and_threshold",
+        app="py:vtscore.detectors.training.train_and_threshold",
+        harness="vtscore/eval/voting_iterations.py::_style_train_and_calibrate",
+        kind="default",
+        note=(
+            "The app's canonical train + calibrate pipeline, which the harness reproduces step "
+            "for step (fold calibration, full-data fit, fold-anchored threshold). A new stage "
+            "here - or a changed head, fold rule or ordering - has to reach the harness or its "
+            "default arm trains a detector the app no longer ships. Note "
+            "_mlp_train_and_calibrate is the single-vector path and reproduces the same shape."
+        ),
+    ),
+    Mirror(
+        id="training.fused_threshold",
+        app="py:vtscore.detectors.training._fused_threshold",
+        harness="vtscore/eval/voting_iterations.py::_safe_threshold_for_step",
+        kind="default",
+        note=(
+            "How the cross-calibration cut and the population estimate are fused into the "
+            "shipped threshold. The harness's reported operating point is only comparable to "
+            "the app's if this rule matches."
+        ),
+    ),
+    Mirror(
+        id="training.calibration_score_rows",
+        app="py:vtscore.detectors.training._calibration_score_rows",
+        harness="vtscore/eval/voting_iterations.py::_safe_threshold_for_step",
+        kind="default",
+        note=(
+            "Calibrating in *inference* geometry: each voted bag collapses over the rows the "
+            "scorer will max-pool, not the rows the fold model trained on. Changing which rows "
+            "the app calibrates over silently moves every threshold the harness reports."
+        ),
+    ),
+    Mirror(
+        id="training.blend_schedule_default",
+        app="py:vtscore.detectors.training._blend_schedule_for_snap",
+        harness="vtscore/eval/voting_iterations.py::simulate_voting_iterations",
+        kind="default",
+        note=(
+            "How the app picks a safe-threshold blend schedule when none is named (per voting "
+            "mode). simulate_voting_iterations resolves blend_schedule=None through "
+            "production_schedule_for to match; if the app's choice becomes conditional on "
+            "something else, that condition has to reach the harness too."
+        ),
+    ),
+]
+
+
+class MirrorError(Exception):
+    """A mirror could not be resolved at all - the app or harness side moved."""
+
+
+# --------------------------------------------------------------------- digests
+
+
+def _normalize_python(source: str) -> str:
+    """Source text stripped of comments, docstrings and formatting.
+
+    Token-based rather than AST-based on purpose: `ast.unparse` output is not
+    guaranteed stable across the Python versions this repo supports (>=3.10),
+    which would make the pins fail for whoever is not on the pinning machine's
+    interpreter.  Token text is.
+
+    Magic trailing commas are dropped as well, so that `ruff format` wrapping a
+    call across lines - which it will do for a change as innocent as a longer
+    variable name - doesn't read as a logic change.
+    """
+    skip = (tokenize.COMMENT, tokenize.NL, tokenize.ENCODING, tokenize.ENDMARKER)
+    out: list[str] = []
+    prev_meaningful: int | None = None
+    tokens = list(tokenize.generate_tokens(io.StringIO(textwrap.dedent(source) + "\n").readline))
+    for i, tok in enumerate(tokens):
+        if tok.type in skip:
+            continue
+        nxt = next((t for t in tokens[i + 1 :] if t.type not in skip), None)
+        if tok.type == tokenize.STRING and prev_meaningful in (None, tokenize.NEWLINE, tokenize.INDENT):
+            # A string that is an entire statement: a docstring.
+            if nxt is not None and nxt.type == tokenize.NEWLINE:
+                continue
+        if tok.string == "," and nxt is not None and nxt.string in (")", "]", "}"):
+            continue
+        out.append(tok.string.strip() if tok.type == tokenize.NEWLINE else tok.string)
+        prev_meaningful = tok.type
+    return "\n".join(s for s in out if s)
+
+
+_TS_LINE_COMMENT = re.compile(r"//[^\n]*")
+_TS_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _normalize_typescript(source: str) -> str:
+    """TypeScript block stripped of comments and collapsed whitespace."""
+    stripped = _TS_BLOCK_COMMENT.sub(" ", source)
+    stripped = _TS_LINE_COMMENT.sub(" ", stripped)
+    return re.sub(r"\s+", " ", stripped).strip()
+
+
+def _ts_block(path: Path, anchor: str) -> str:
+    """The brace-delimited block introduced by *anchor* in *path*.
+
+    Comments are removed before brace-matching so a brace inside a comment
+    cannot unbalance the scan.
+    """
+    text = _TS_BLOCK_COMMENT.sub(" ", path.read_text(encoding="utf-8"))
+    text = _TS_LINE_COMMENT.sub(" ", text)
+    start = text.find(anchor)
+    if start < 0:
+        raise MirrorError(f"anchor {anchor!r} not found in {path.relative_to(REPO_ROOT)}")
+    if text.find(anchor, start + len(anchor)) >= 0:
+        raise MirrorError(f"anchor {anchor!r} is ambiguous in {path.relative_to(REPO_ROOT)} (matches more than once)")
+    open_idx = text.find("{", start)
+    if open_idx < 0:
+        raise MirrorError(f"no block follows anchor {anchor!r} in {path.relative_to(REPO_ROOT)}")
+    depth = 0
+    for i in range(open_idx, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    raise MirrorError(f"unbalanced block for anchor {anchor!r} in {path.relative_to(REPO_ROOT)}")
+
+
+def _py_symbol_source(path: Path, symbol: str) -> str:
+    """The source of top-level *symbol* in *path*, found by parsing not importing.
+
+    Parsing keeps the gate fast and dependency-free: it runs before the test
+    suite has installed torch, and reading a module for its text should never
+    execute it.
+    """
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    lines = text.splitlines()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name == symbol:
+            start = min([node.lineno, *[d.lineno for d in node.decorator_list]]) - 1
+            return "\n".join(lines[start : node.end_lineno])
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if any(isinstance(t, ast.Name) and t.id == symbol for t in targets):
+                return "\n".join(lines[node.lineno - 1 : node.end_lineno])
+    raise MirrorError(f"{path.relative_to(REPO_ROOT)} has no top-level {symbol!r} - did it move or get renamed?")
+
+
+def _app_source(mirror: Mirror) -> str:
+    """The normalized app-side source *mirror* is pinned against."""
+    kind, _, ref = mirror.app.partition(":")
+    if kind == "py":
+        module_path, _, symbol = ref.rpartition(".")
+        path = REPO_ROOT / (module_path.replace(".", "/") + ".py")
+        if not path.exists():
+            raise MirrorError(f"module {module_path} ({path.relative_to(REPO_ROOT)}) does not exist")
+        return _normalize_python(_py_symbol_source(path, symbol))
+    if kind == "ts":
+        rel, _, anchor = ref.partition("::")
+        path = REPO_ROOT / rel
+        if not path.exists():
+            raise MirrorError(f"{rel} does not exist")
+        return _normalize_typescript(_ts_block(path, anchor))
+    raise MirrorError(f"unknown app source kind {kind!r} in {mirror.app!r}")
+
+
+def _digest(mirror: Mirror) -> str:
+    return hashlib.sha256(_app_source(mirror).encode("utf-8")).hexdigest()
+
+
+def _check_harness_side(mirror: Mirror) -> None:
+    """The harness counterpart still exists under the name the manifest claims."""
+    rel, _, symbol = mirror.harness.partition("::")
+    path = REPO_ROOT / rel
+    if not path.exists():
+        raise MirrorError(f"harness file {rel} does not exist")
+    if symbol and symbol not in path.read_text(encoding="utf-8"):
+        raise MirrorError(f"harness symbol {symbol!r} not found in {rel} - was it renamed or removed?")
+
+
+# ----------------------------------------------------------------------- pins
+
+
+def _load_pins() -> dict[str, str]:
+    if not PINS_PATH.exists():
+        return {}
+    return json.loads(PINS_PATH.read_text(encoding="utf-8"))
+
+
+def _write_pins(pins: dict[str, str]) -> None:
+    PINS_PATH.write_text(json.dumps(pins, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+@dataclass
+class Drift:
+    mirror: Mirror
+    reason: str
+    detail: str = ""
+    extras: list[str] = field(default_factory=list)
+
+
+def check() -> list[Drift]:
+    """Every mirror whose app side moved, or whose two sides no longer resolve."""
+    pins = _load_pins()
+    drifts: list[Drift] = []
+    seen: set[str] = set()
+    for mirror in MIRRORS:
+        if mirror.id in seen:
+            raise SystemExit(f"duplicate mirror id {mirror.id!r} in MIRRORS")
+        seen.add(mirror.id)
+        try:
+            _check_harness_side(mirror)
+            digest = _digest(mirror)
+        except MirrorError as exc:
+            drifts.append(Drift(mirror, "unresolvable", str(exc)))
+            continue
+        pinned = pins.get(mirror.id)
+        if pinned is None:
+            drifts.append(Drift(mirror, "unpinned", "no digest recorded yet"))
+        elif pinned != digest:
+            drifts.append(Drift(mirror, "changed", f"pinned {pinned[:12]}, now {digest[:12]}"))
+    stale = sorted(set(pins) - {m.id for m in MIRRORS})
+    if stale:
+        drifts.append(
+            Drift(
+                MIRRORS[0],
+                "stale-pins",
+                "pins recorded for mirrors that no longer exist: " + ", ".join(stale),
+                extras=stale,
+            )
+        )
+    return drifts
+
+
+def update() -> int:
+    pins: dict[str, str] = {}
+    for mirror in MIRRORS:
+        _check_harness_side(mirror)
+        pins[mirror.id] = _digest(mirror)
+    _write_pins(pins)
+    print(f"Pinned {len(pins)} eval/app mirrors to {PINS_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+def _report(drifts: list[Drift]) -> None:
+    print("The eval framework mirrors app code that has since changed.")
+    print("")
+    print("The eval default arm has to BE the app's algorithm - that is the only")
+    print("thing that makes a deviation arm meaningful. Reconcile each mirror below,")
+    print("then re-pin with:  python scripts/check-eval-app-sync.py --update")
+    for drift in drifts:
+        mirror = drift.mirror
+        print("")
+        if drift.reason == "stale-pins":
+            print(f"  * {drift.detail}")
+            print("    Run --update to drop them.")
+            continue
+        print(f"  * {mirror.id}  [{mirror.kind}, {drift.reason}]")
+        print(f"      app:     {mirror.app.partition(':')[2]}")
+        print(f"      harness: {mirror.harness}")
+        print(f"      {mirror.note}")
+        if mirror.divergence:
+            print(f"      DECLARED DIVERGENCE: {mirror.divergence}")
+        if drift.detail and drift.reason != "changed":
+            print(f"      {drift.detail}")
+    print("")
+    print("If the harness already tracks the change (or is unaffected), --update alone")
+    print("is the right answer. If the harness now *intentionally* differs, record why")
+    print("in the mirror's divergence= field in scripts/check-eval-app-sync.py.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="re-pin every mirror to the current app source, after reconciling the harness",
+    )
+    args = parser.parse_args(argv)
+    if args.update:
+        return update()
+    drifts = check()
+    if drifts:
+        _report(drifts)
+        return 1
+    print(f"Eval/app sync: {len(MIRRORS)} mirrors up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval-app-sync.pins.json
+++ b/scripts/eval-app-sync.pins.json
@@ -1,0 +1,11 @@
+{
+  "autopilot.phase_machine": "8ad8a0c2a72103a3ca0061201f57977869225a458894d79efd41a18e5e342fc7",
+  "autopilot.vote_targets": "6b15d45162cc406b8924e37a23286950d5e5dde551cbcd0d9d4c2500cec044f9",
+  "progress.smart_status": "89b7600be625c7de64c21b54bfcf96e20bcee6229d28dc4f879386cdb3a67e24",
+  "progress.span_status": "7da887d32d0559066dd3d51ad1045e5b9322f2e295aa6bc8e5ca62e6f81ba3a3",
+  "progress.stable_status": "ae6894ad77dfbc5cbec37a71faa39f0fd90df74fecb464cb9d4f4fdf53ed2057",
+  "training.blend_schedule_default": "3737e6185aeb219673cbf8126a5306d6e435eba67e73c24cc1975a896bbab7e1",
+  "training.calibration_score_rows": "1110937c8efc4198ff299328966afaa2a150ed856868033d701914995beadae1",
+  "training.fused_threshold": "e9ab7076808a11dda013a48d750efb9af43b15f22a57009fa8d66e378aae2a36",
+  "training.train_and_threshold": "ae01e49abe5abab28cc1d30961e029d78d4b87aaf52475aa9f9fc4b9f14d683a"
+}

--- a/tests_lib/detectors/test_eval_app_sync.py
+++ b/tests_lib/detectors/test_eval_app_sync.py
@@ -1,0 +1,137 @@
+"""The eval/app drift gate itself: `scripts/check-eval-app-sync.py`.
+
+The gate's whole job is to notice when app code that `vtscore.eval` reproduces
+has moved.  If it stops noticing - or starts crying wolf over a reworded
+comment - it gets ignored, and then the eval default arm drifts from the app
+exactly the way it did before the gate existed.  So pin both halves: it fires on
+a logic change, and it stays quiet for everything else.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check-eval-app-sync.py"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("_eval_app_sync_gate", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # `@dataclass` resolves annotations through sys.modules, so register first.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate()
+
+
+class TestManifestIsLive:
+    """Every mirror resolves on both sides, and its pin is current."""
+
+    def test_no_drift(self):
+        drifts = gate.check()
+        assert not drifts, "\n".join(f"{d.mirror.id}: {d.reason} ({d.detail})" for d in drifts)
+
+    def test_every_mirror_names_both_sides(self):
+        for mirror in gate.MIRRORS:
+            assert mirror.app.split(":", 1)[0] in ("py", "ts"), mirror.id
+            assert "::" in mirror.harness, mirror.id
+            assert mirror.kind in ("ported", "default"), mirror.id
+            assert mirror.note.strip(), mirror.id
+
+    def test_the_manifest_is_not_empty(self):
+        """A gate with nothing pinned passes vacuously and fools everyone."""
+        assert len(gate.MIRRORS) >= 5
+        assert {m.kind for m in gate.MIRRORS} == {"ported", "default"}
+
+
+class TestDigestSensitivity:
+    """What trips the gate, and what must not."""
+
+    BASE = '''
+def f(a, b):
+    """A docstring."""
+    # A comment.
+    if a < 5:
+        return "red"
+    return b
+'''
+
+    def test_logic_change_trips(self):
+        changed = self.BASE.replace("a < 5", "a < 7")
+        assert gate._normalize_python(changed) != gate._normalize_python(self.BASE)
+
+    def test_comment_change_does_not_trip(self):
+        changed = self.BASE.replace("# A comment.", "# A completely different comment.")
+        assert gate._normalize_python(changed) == gate._normalize_python(self.BASE)
+
+    def test_docstring_change_does_not_trip(self):
+        changed = self.BASE.replace('"""A docstring."""', '"""Rewritten, at length.\n\n    More prose.\n    """')
+        assert gate._normalize_python(changed) == gate._normalize_python(self.BASE)
+
+    def test_reformatting_does_not_trip(self):
+        """Including the magic trailing comma `ruff format` adds when it wraps."""
+        changed = self.BASE.replace("def f(a, b):", "def f(\n    a,\n    b,\n):")
+        assert gate._normalize_python(changed) == gate._normalize_python(self.BASE)
+
+    def test_a_meaningful_trailing_comma_still_trips(self):
+        """Only the comma immediately before a closer is dropped, not tuple-ness."""
+        base = "x = (1, 2)\n"
+        assert gate._normalize_python(base.replace("(1, 2)", "(1, 2, 3)")) != gate._normalize_python(base)
+
+    def test_a_returned_string_is_not_mistaken_for_a_docstring(self):
+        """Only a string in *statement* position is a docstring."""
+        changed = self.BASE.replace('return "red"', 'return "green"')
+        assert gate._normalize_python(changed) != gate._normalize_python(self.BASE)
+
+    def test_typescript_comment_change_does_not_trip(self):
+        base = "checkPhaseTransition() {\n  // why\n  if (a < 5) { return 'good'; }\n}"
+        changed = base.replace("// why", "// a different why")
+        assert gate._normalize_typescript(changed) == gate._normalize_typescript(base)
+
+    def test_typescript_logic_change_trips(self):
+        base = "checkPhaseTransition() {\n  if (a < 5) { return 'good'; }\n}"
+        changed = base.replace("a < 5", "a < 7")
+        assert gate._normalize_typescript(changed) != gate._normalize_typescript(base)
+
+
+class TestResolutionFailures:
+    """A moved or renamed side is drift too, not a silent pass."""
+
+    def _mirror(self, **kwargs):
+        base = dict(
+            id="probe",
+            app="py:vtscore.detectors.training.train_and_threshold",
+            harness="vtscore/eval/voting_iterations.py::simulate_voting_iterations",
+            kind="default",
+            note="probe",
+        )
+        base.update(kwargs)
+        return gate.Mirror(**base)
+
+    def test_missing_app_symbol_is_an_error(self):
+        with pytest.raises(gate.MirrorError, match="no top-level"):
+            gate._app_source(self._mirror(app="py:vtscore.detectors.training.no_such_function"))
+
+    def test_missing_app_module_is_an_error(self):
+        with pytest.raises(gate.MirrorError, match="does not exist"):
+            gate._app_source(self._mirror(app="py:vtscore.detectors.no_such_module.thing"))
+
+    def test_missing_typescript_anchor_is_an_error(self):
+        with pytest.raises(gate.MirrorError, match="not found"):
+            gate._app_source(self._mirror(app=f"ts:{gate.AUTOPILOT_TS}::noSuchMethod("))
+
+    def test_renamed_harness_symbol_is_an_error(self):
+        with pytest.raises(gate.MirrorError, match="not found"):
+            gate._check_harness_side(self._mirror(harness="vtscore/eval/voting_iterations.py::no_such_symbol"))
+
+    def test_deleted_harness_file_is_an_error(self):
+        with pytest.raises(gate.MirrorError, match="does not exist"):
+            gate._check_harness_side(self._mirror(harness="vtscore/eval/no_such_file.py::thing"))

--- a/vtscore/eval/autopilot_flow.py
+++ b/vtscore/eval/autopilot_flow.py
@@ -22,6 +22,12 @@ per-step model it needs, so it feeds those inputs in directly.  The rules —
 every threshold and constant below — are copied verbatim, and
 ``tests_lib/detectors/test_autopilot_flow.py`` pins them against the sources.
 
+Because this is a copy, it can go stale silently: change a phase trigger in the
+app and the simulated user keeps taking the old route, so every study run after
+that measures a flow nobody takes.  ``scripts/check-eval-app-sync.py`` — a
+``./run-tests.sh`` gate — digests both sources and fails when either moves; see
+"The Eval Default Arm IS the App" in ``docs/EVAL.md``.
+
 The phase ordering the app implements, and the harness therefore reproduces:
 
 1. ``good`` until ``good_target`` positives exist (text sort, take the top).


### PR DESCRIPTION
## Why

`vtscore.eval` exists to measure **deviations** from the shipped algorithm. That only means something if its **default arm** *is* the shipped algorithm. When the app moved and the harness didn't, nothing failed — the studies kept producing plausible numbers about a detector nobody uses, and the damage was silent and retroactive.

`61ceb263` is the most recent instance: a style-less `simulate_voting_iterations` run trained a Bad vote on one image-level row while scoring max-pooled over the whole ~197-row stack. Every patch-dataset study before that fix under-suppressed relative to the live detector. The divergence *was* documented in a code comment at the time, and the comment went stale anyway — which is why this PR adds a mechanical gate rather than another paragraph of prose.

## What drifts, and what can't

Most of the harness is safe by construction because it **delegates** — `MaxPatchStyle.good_vec` / `.bad_vecs` / `._rows_for_media` are thin wrappers over `pool_box_from_media`, `bad_negative_vecs`, and `media_score_rows`. Two categories can't delegate:

- **Ported** — app logic re-implemented because the original is unreachable or unusable. `vtscore/eval/autopilot_flow.py` is the whole of this category: it ports the phase machine from `AutopilotStateService.checkPhaseTransition` (TypeScript — nothing to import, no typecheck) and the three indicators from `vtscore.detectors.labeling_progress` (wrapped in an interactive, lock-guarded single-detector cache a simulation can't use).
- **Default resolution** — where the harness resolves "no explicit arm" to whatever the app currently defaults to (`style=None` → `max_patch`, `blend_schedule=None` → `production_schedule_for(...)`). When the app's default changes, the harness keeps serving the old one *under the name "default"*.

## The gate

`scripts/check-eval-app-sync.py` holds a manifest of 9 mirrors (5 ported, 4 default-tracking), each pinning a digest of the app-side source alongside a pointer to its harness counterpart and a note on what to re-check. `run-tests.sh` fails when one moves:

```
  * autopilot.phase_machine  [ported, changed]
      app:     frontend/src/app/services/autopilot-state.service.ts::checkPhaseTransition(
      harness: vtscore/eval/autopilot_flow.py::next_phase
      The phase ordering and every transition trigger of the simulated Autopilot user. ...
```

Reconcile, then `python scripts/check-eval-app-sync.py --update`.

Implementation notes:

- **Parses, never imports.** Python symbols are located via `ast` against the file path; the gate runs before torch is installed and takes ~0.3s. TypeScript blocks are found by brace-matching a literal anchor, with comments stripped first so a brace in a comment can't unbalance the scan.
- **Token-based normalization**, not `ast.unparse` — unparse output isn't guaranteed stable across the Python versions this repo supports (>=3.10), which would fail the pins for anyone not on the pinning machine's interpreter. Comments, docstrings, formatting, and the magic trailing comma `ruff format` adds when it wraps are all ignored, so only logic changes trip the gate.
- **Both sides are checked.** A renamed or deleted *harness* symbol is drift too, not a silent pass.
- **Declared divergences.** A mirror that intentionally differs records why in `divergence=`; the text prints whenever it trips, so whoever reconciles it knows which differences are deliberate. Used today for the ported indicators, which take their histories as arguments rather than reading the app's `_cached_steps` — plumbing, not a rule change. Named experiment arms (`whole_image`, `max_patch_hac`) are supposed to differ and are out of scope; this is about the default arm only.

## Changes

- `scripts/check-eval-app-sync.py` — manifest + checker + `--update`.
- `scripts/eval-app-sync.pins.json` — machine-managed digests.
- `run-tests.sh` — gate, alongside the OpenAPI and screenshot-wiring checks.
- `tests_lib/detectors/test_eval_app_sync.py` — 16 tests covering both halves of the gate's job: it fires on Python and TypeScript logic changes and on unresolvable mirrors, and stays quiet for comments, docstrings, reformatting, and wrap-induced trailing commas. A gate that cries wolf gets ignored, which puts us back where we started.
- `CLAUDE.md` — new **The Eval Default Arm IS the App (CRITICAL)** section, plus a Commands entry.
- `docs/EVAL.md` — delegated/ported/default table, the gate's workflow, and how to add or diverge a mirror.
- `vtscore/eval/autopilot_flow.py` — docstring pointer to the gate (docstring only, no logic change).

## Testing

`./run-tests.sh` — 7817 passed, 1 skipped, 1 xfailed, 1 xpassed.

Verified by hand that the gate fires on a real logic edit to `_compute_stable_status`, on a `goodToStart` change in the TypeScript, and stays silent for a comment-only edit to `_blend_schedule_for_snap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jNo7cSx3hXK38FG2gjxGU

---
_Generated by [Claude Code](https://claude.ai/code/session_011jNo7cSx3hXK38FG2gjxGU)_