### PR TITLE
Expose the eval cut-fallback policy in the data, not only in prose (#2900)

### DIFF
--- a/docs/experiments/gmm-cut/PREREG-2881.md
+++ b/docs/experiments/gmm-cut/PREREG-2881.md
@@ -150,5 +150,9 @@ it would justify one larger run at α = 0.158 alone.
 - At inclusion 0 the cost weights are (1, 1), so `rate` and `priorfree` are the
   same rule in the comparison tables — as in both prior reports. The tail rules
   have no cost-weight dependence at all, which is a difference worth remembering
-  when reading them next to the tilted ones.
+  when reading them next to the tilted ones. It also means the `*_rate` arms'
+  midpoint substitution (#2900) is not in play: at inclusion 0 those rows are
+  `priorfree` rows, and `priorfree` has no shipped continuation to diverge from.
+  Read `cut_fallback_kind` before carrying any `*_rate` contrast to a non-zero
+  Inclusion run.
 - Every contrast is within-step, so none of it sees acquisition feedback.

--- a/docs/experiments/gmm-cut/REMEASURE-2846.md
+++ b/docs/experiments/gmm-cut/REMEASURE-2846.md
@@ -240,7 +240,12 @@ run rules out is one particular way of trying to claim it.
   0 failures, 0 zero-byte outputs; nothing was dropped from the analysis.
 - At inclusion 0 the cost weights are (1, 1), so `rate` and `priorfree` are the
   **same rule** here — every `*_rate` row in the tables above is identical to its
-  `*_priorfree` sibling by construction, not by coincidence.
+  `*_priorfree` sibling by construction, not by coincidence. This is also why
+  the `_SAFE_GMM_VARIANTS` midpoint substitution (#2900), which diverges from
+  the shipped `rate` rule's continuation past the component mean, cannot have
+  moved any number here: these `*_rate` rows are `priorfree` rows, and
+  `priorfree` has no shipped counterpart. It would bite a run at non-zero
+  Inclusion, where `cut_fallback_kind` now separates the substituted steps.
 - Every contrast is within-step, so none of it sees acquisition feedback.
 - **The one result that could flip with more data** is finding 2's `priorfree`
   conditional effect: it is genuine (p = 8e−4 pooled) but it fires on 5 % of

--- a/docs/experiments/gmm-cut/REPORT.md
+++ b/docs/experiments/gmm-cut/REPORT.md
@@ -371,3 +371,16 @@ pre-vote and deterministic). At inclusion 0 the cost weights are (1, 1), so
 untested at non-zero Inclusion and needs its own trajectory arm. Every contrast
 is within-step, so none of this can see selection feedback; #2799 showed that
 effect is real and worth ~0.02 on its own, so the shipped gain is a lower bound.
+
+The `pooled_*` / `image_*` arms substitute the fit's own **midpoint** for a rule
+with no root, where the shipped `rate` rule continues past the component mean
+instead. That divergence is deliberate (#2900) — a rule-independent stand-in is
+what makes the tilts comparable to each other — and it does not touch any number
+above: at inclusion 0 these `*_rate` rows *are* the `*_priorfree` rows, and
+`priorfree` has no shipped counterpart to diverge from in the first place. It
+would matter to a future run at non-zero Inclusion, where a `*_rate` arm read as
+"what the app would have done" is wrong on the fallen-back steps. Runs from
+2026-08-08 onward carry `cut_fallback_kind` per row (`midpoint` here vs
+`continued` / `degenerate_midpoint` on the anchored arms) so those steps can be
+excluded; on this run's frames the column is absent and the family name is the
+only signal.

--- a/scripts/check-eval-app-sync.py
+++ b/scripts/check-eval-app-sync.py
@@ -199,6 +199,35 @@ MIRRORS: list[Mirror] = [
             "something else, that condition has to reach the harness too."
         ),
     ),
+    Mirror(
+        id="thresholds.rate_cut_no_root",
+        app="py:vtscore.training.thresholds._rate_cut",
+        harness="vtscore/eval/cut_rules.py::gaussian_cuts",
+        kind="default",
+        note=(
+            "What the 'rate' rule does on a fit whose density crossing has no root between the "
+            "component means. This has moved twice already - midpoint (pre-2026-08-06), bare "
+            "edge, then continued past the edge at the rule's first-order slope (#2896) - and "
+            "each move silently changed what the harness's *_rate arms mean relative to the "
+            "app. Pinned so the next move prompts a decision instead of going unnoticed for "
+            "days, which is exactly how #2900 happened."
+        ),
+        divergence=(
+            "INTENTIONAL, decided in #2900: gaussian_cuts reports NaN and _safe_gmm_variant_rows "
+            "substitutes that fit's MIDPOINT, where production continues past the component "
+            "mean. The decomposition family compares cut rules against each other on one fit, so "
+            "it wants a neutral, rule-independent stand-in - production's continuation exists "
+            "only for 'rate' and would make it incomparable to its cross/priorfree siblings (at "
+            "inclusion 0 it would break the rate == priorfree identity every report in "
+            "docs/experiments/gmm-cut/ relies on). The divergence is recorded per row in "
+            "cut_fallback_kind ('midpoint' vs 'continued'/'degenerate_midpoint'), so an analysis "
+            "that needs the shipped path filters on it. The fold-anchored family calls "
+            "gmm_cut_from_fit directly and is the faithful stand-in for the app. When re-pinning "
+            "this mirror, re-check that the divergence is still the one you want AND that "
+            "cut_fallback still fires on the same fits in both families - the flag being "
+            "comparable is what keeps fallback_rate aggregates joinable across them."
+        ),
+    ),
 ]
 
 

--- a/scripts/eval-app-sync.pins.json
+++ b/scripts/eval-app-sync.pins.json
@@ -4,6 +4,7 @@
   "progress.smart_status": "89b7600be625c7de64c21b54bfcf96e20bcee6229d28dc4f879386cdb3a67e24",
   "progress.span_status": "7da887d32d0559066dd3d51ad1045e5b9322f2e295aa6bc8e5ca62e6f81ba3a3",
   "progress.stable_status": "ae6894ad77dfbc5cbec37a71faa39f0fd90df74fecb464cb9d4f4fdf53ed2057",
+  "thresholds.rate_cut_no_root": "b167612751767183a0416f22e643d9d4a79c67e7d041d9b9a1ae4d20725db084",
   "training.blend_schedule_default": "3737e6185aeb219673cbf8126a5306d6e435eba67e73c24cc1975a896bbab7e1",
   "training.calibration_score_rows": "1110937c8efc4198ff299328966afaa2a150ed856868033d701914995beadae1",
   "training.fused_threshold": "e9ab7076808a11dda013a48d750efb9af43b15f22a57009fa8d66e378aae2a36",

--- a/scripts/experiments/calibration/analyze_cut.py
+++ b/scripts/experiments/calibration/analyze_cut.py
@@ -629,29 +629,48 @@ def evt_evidence(diag: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
 
 
 def fallback_reasons(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
-    """Why each rule declined to fire, per arm per variant (issue #2846).
+    """Why each rule declined to fire and what it cut instead, per arm per variant.
 
-    ``cut_fallback`` says a rule declined to fire on that fit; this says *which*
-    guard sent it there, which is the whole difference between "the fit was
-    sound but oriented the other way" (repairable, and what ``gumbel_any_*``
-    repairs) and "the two components collapsed onto each other" (a statement
-    about that step's score distribution, which no solver can fix).
+    Two columns, answering two different questions about the same event
+    (issues #2846, #2900):
 
-    What the flag means depends on which family emitted the row: for the
-    ``_SAFE_GMM_VARIANTS`` arms it is "degraded to that fit's midpoint", while
-    for the label-anchored arms it is the production rule's own "no interior
-    stationary point" flag, where the cut is continued past the component mean
-    rather than replaced.  The flag fires on the same fits either way, so rates
-    and filters are comparable; the substituted *value* is not.
+    ``cut_fail_reason`` is *which guard sent it there* - the whole difference
+    between "the fit was sound but oriented the other way" (repairable, and what
+    ``gumbel_any_*`` repairs) and "the two components collapsed onto each other"
+    (a statement about that step's score distribution, which no solver can fix).
+    Only the EVT rules have a reason vocabulary; the Gaussian ones report ``""``.
+
+    ``cut_fallback_kind`` is *what was substituted*, which is not the same
+    question and does not have the same answer in both families.  For the
+    ``_SAFE_GMM_VARIANTS`` arms it is ``midpoint``: that family compares tilts
+    against each other on one fit, so a rule with no root gets a neutral,
+    rule-independent stand-in.  For the label-anchored arms it is the production
+    rule's own branch - ``continued`` (the cut carried past the component mean
+    at the rule's first-order slope, still moving with the cost tilt) or
+    ``degenerate_midpoint`` (a fit too degenerate to express a boundary at all).
+    The flag fires on the same fits in both families, so ``fallback_rate``
+    aggregates and ``cut_fallback == 0/1`` filters stay comparable across them;
+    the substituted *value* does not, which is what this column exposes.  **A
+    contrast that reads a ``*_rate`` arm as "what the app would have done" must
+    exclude the ``midpoint`` rows**, since on those steps the arm is scoring a
+    stand-in the app never cuts at.
 
     Emitted **per window**, plus an ``all_steps`` row set.  Every other table
     here is windowed, so a bare all-steps count invited exactly the mistake
     #2846's report had to warn about in prose: reading these counts next to a
     ramp-window fallback *rate* and treating them as the same population.
     """
-    if "cut_fail_reason" not in df:
+    has_reason = "cut_fail_reason" in df
+    has_kind = "cut_fallback_kind" in df
+    if not (has_reason or has_kind):
         return pd.DataFrame()
-    fell = df[(df["cut_fallback"] == 1) & (df["cut_fail_reason"].astype(str) != "")]
+    df = df.copy()
+    # A frame emitted before either column existed is still analyzable - this
+    # study's whole point is comparing against those numbers - so fill the
+    # missing side rather than dropping the table.
+    for col in ("cut_fail_reason", "cut_fallback_kind"):
+        df[col] = df[col].fillna("").astype(str) if col in df else ""
+    fell = df[df["cut_fallback"] == 1]
     if fell.empty:
         return pd.DataFrame()
     out = []
@@ -662,7 +681,7 @@ def fallback_reasons(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
         if sub.empty:
             continue
         g = (
-            sub.groupby(["arm", "gmm_variant", "cut_fail_reason"])
+            sub.groupby(["arm", "gmm_variant", "cut_fallback_kind", "cut_fail_reason"])
             .size()
             .reset_index(name="n_steps")
             .sort_values(["arm", "gmm_variant", "n_steps"], ascending=[True, True, False])
@@ -1091,7 +1110,7 @@ def write_report(summary: dict, tables: dict, report_path: Path) -> None:
         ("Decomposition (threshold units)", "decomposition"),
         ("Decomposition (excess-cost units)", "cost_decomposition"),
         ("Extreme-value evidence", "evt"),
-        ("Why each rule fell back (issue #2846)", "fallback_reasons"),
+        ("Why each rule fell back, and to what (issues #2846, #2900)", "fallback_reasons"),
         ("Estimator variance (within-cell)", "estimator_variance"),
     ):
         tbl = tables.get(key)

--- a/tests_lib/detectors/test_anchored_variant_rows.py
+++ b/tests_lib/detectors/test_anchored_variant_rows.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import numpy as np
 
+from vtscore.eval.cut_rules import CUT_KIND_MIDPOINT
 from vtscore.eval.voting_iterations import _CALIBRATION_COLUMNS, simulate_voting_iterations
+from vtscore.training.thresholds import CUT_KIND_CONTINUED, CUT_KIND_DEGENERATE_MIDPOINT, CUT_KIND_INTERIOR
 
 # Reuse the synthetic planted-patch dataset builders from the Max-Patch tests.
 from .test_max_patch_style import _planted_dataset
@@ -85,6 +87,25 @@ class TestAnchoredVariantRows:
             assert r["threshold_provenance"].startswith(("fold_anchored[", "fold_fallback"))
         for r in rank:
             assert r["threshold_provenance"] == "rank_transfer"
+
+    def test_the_fallback_kind_is_productions_own_never_the_decomposition_stand_in(self):
+        """These arms call the shipped rule, so their fallbacks are production's.
+
+        The ``_SAFE_GMM_VARIANTS`` family substitutes that fit's *midpoint* for a
+        rule with no root; production instead continues past the component mean.
+        Both set ``cut_fallback``, which is why the flag alone cannot tell an
+        analysis which of the two it is looking at (issue #2900) - so no
+        production-path row may ever claim the decomposition family's kind.
+        """
+        rows = [r for r in _run() if r["gmm_variant"].startswith(("anchored", "fold_anchored", "rank"))]
+        assert rows
+        for r in rows:
+            kind = r["cut_fallback_kind"]
+            assert kind in (CUT_KIND_INTERIOR, CUT_KIND_CONTINUED, CUT_KIND_DEGENERATE_MIDPOINT), kind
+            assert kind != CUT_KIND_MIDPOINT
+            # ``bool(kind)`` must stay exactly the flag, or fallback *rates*
+            # computed across the two families stop being comparable.
+            assert r["cut_fallback"] == int(bool(kind))
 
     def test_fold_arms_can_be_disabled(self):
         rows = _run(fold_arms=False)

--- a/tests_lib/detectors/test_safe_gmm_variant_rows.py
+++ b/tests_lib/detectors/test_safe_gmm_variant_rows.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from vtscore.eval.cut_rules import CUT_KIND_MIDPOINT
 from vtscore.eval.voting_iterations import (
     _CALIBRATION_COLUMNS,
     _CUT_DIAGNOSTIC_COLUMNS,
@@ -24,7 +25,12 @@ from vtscore.eval.voting_iterations import (
     _SAFE_GMM_VARIANTS,
     simulate_voting_iterations,
 )
-from vtscore.training.thresholds import FOLD_ANCHOR_COMBINE, FOLD_ANCHOR_CUT_RULE, FOLD_ANCHOR_WEIGHT
+from vtscore.training.thresholds import (
+    CUT_KIND_INTERIOR,
+    FOLD_ANCHOR_COMBINE,
+    FOLD_ANCHOR_CUT_RULE,
+    FOLD_ANCHOR_WEIGHT,
+)
 
 # Reuse the synthetic planted-patch dataset builders from the Max-Patch tests.
 from .test_max_patch_style import _planted_dataset
@@ -195,6 +201,40 @@ class TestCutDiagnosticFrame:
             if r["cut_fallback"]:
                 continue  # the row reports the midpoint it fell back to
             assert r["gmm_cut"] == pooled[r["t"]][f"tau_{rule}"]
+
+    def test_a_fallen_back_row_names_the_midpoint_it_substituted(self):
+        """The divergence from production is kept, but it is no longer invisible.
+
+        This family substitutes the fit's own midpoint - a neutral,
+        rule-independent stand-in, which is what keeps ``rate`` commensurable
+        with the ``cross``/``priorfree`` siblings it is differenced against.
+        Production's ``rate`` continues past the component mean instead, so on
+        exactly these steps the arm is *not* a stand-in for the app.  The row
+        has to say which of the two it is, or an analysis that reads a
+        ``*_rate`` arm as "what the app would have done" is silently wrong on
+        them (issue #2900).
+        """
+        diag: list[dict] = []
+        rows = _run_safe("max_patch", diag_sink=diag)
+        pooled = {d["t"]: d for d in diag if d["geometry"] == "pooled"}
+        seen_fallback = 0
+        for r in rows:
+            if r["gmm_variant"] in ("xcal_only", *_ORACLE_VARIANTS) or not r["gmm_variant"].startswith(
+                ("pooled_", "image_")
+            ):
+                continue
+            kind = r["cut_fallback_kind"]
+            # This family has exactly two outcomes: the rule's own cut, or the
+            # midpoint.  It never continues, and it never reports production's
+            # degenerate branch.
+            assert kind in (CUT_KIND_INTERIOR, CUT_KIND_MIDPOINT), (r["gmm_variant"], kind)
+            assert r["cut_fallback"] == int(bool(kind))
+            if kind == CUT_KIND_MIDPOINT and r["gmm_variant"].startswith("pooled_"):
+                seen_fallback += 1
+                # The substituted value really is that fit's midpoint, not the
+                # rule's own extrapolation.
+                assert r["gmm_cut"] == pooled[r["t"]]["tau_mid"]
+        assert seen_fallback, "no rule fell back; the substitution path went unexercised"
 
     def test_prevalence_is_a_fraction(self):
         diag: list[dict] = []

--- a/tests_lib/sorting/test_anchored_gmm.py
+++ b/tests_lib/sorting/test_anchored_gmm.py
@@ -17,6 +17,9 @@ from vtscore.training.thresholds import (
     FOLD_ANCHOR_COMBINE,
     FOLD_ANCHOR_CUT_RULE,
     FOLD_ANCHOR_WEIGHT,
+    CUT_KIND_CONTINUED,
+    CUT_KIND_DEGENERATE_MIDPOINT,
+    CUT_KIND_INTERIOR,
     FoldAnchoredCut,
     GmmFit1D,
     anchored_gmm_fit,
@@ -168,13 +171,13 @@ class TestCutFromFit:
     _FIT = GmmFit1D(w_lo=0.7, mu_lo=0.2, var_lo=0.01, w_hi=0.3, mu_hi=0.8, var_hi=0.01)
 
     def test_mid(self):
-        cut, fell_back = gmm_cut_from_fit(self._FIT, "mid")
+        cut, kind = gmm_cut_from_fit(self._FIT, "mid")
         assert cut == self._FIT.midpoint()
-        assert fell_back == 0
+        assert kind == CUT_KIND_INTERIOR
 
     def test_rate_root_between_means(self):
-        cut, fell_back = gmm_cut_from_fit(self._FIT, "rate", 1.0, 1.0)
-        assert fell_back == 0
+        cut, kind = gmm_cut_from_fit(self._FIT, "rate", 1.0, 1.0)
+        assert kind == CUT_KIND_INTERIOR
         assert self._FIT.mu_lo < cut < self._FIT.mu_hi
         # Equal variances at equal cost weights: the prior-free crossing IS the
         # midpoint (see GmmFit1D.rate_crossing).
@@ -196,13 +199,13 @@ class TestCutFromFit:
         def line(wf: float, wn: float) -> float:
             return fit.midpoint() + 0.04 * math.log(wf / wn) / 0.6
 
-        cut, no_root = gmm_cut_from_fit(fit, "rate", 1e6, 1.0)
-        assert no_root == 1
+        cut, kind = gmm_cut_from_fit(fit, "rate", 1e6, 1.0)
+        assert kind == CUT_KIND_CONTINUED
         assert cut > fit.mu_hi
         assert cut == pytest.approx(line(1e6, 1.0), rel=1e-12)
 
-        cut, no_root = gmm_cut_from_fit(fit, "rate", 1.0, 1e6)
-        assert no_root == 1
+        cut, kind = gmm_cut_from_fit(fit, "rate", 1.0, 1e6)
+        assert kind == CUT_KIND_CONTINUED
         assert cut < fit.mu_lo
         assert cut == pytest.approx(line(1.0, 1e6), rel=1e-12)
 
@@ -254,13 +257,56 @@ class TestCutFromFit:
             for k in (-3, 0, 3):
                 wf, wn = inclusion_cost_weights(k)
                 root = fit.rate_crossing(wf, wn)
-                cut, clamped = gmm_cut_from_fit(fit, "rate", wf, wn)
+                cut, kind = gmm_cut_from_fit(fit, "rate", wf, wn)
                 if root is None:
                     continue
                 seen += 1
-                assert clamped == 0
+                assert kind == CUT_KIND_INTERIOR
                 assert cut == pytest.approx(root, abs=1e-12)
         assert seen > 100, "the sweep never produced an interior crossing"
+
+    def test_a_degenerate_fit_reports_a_midpoint_not_a_continuation(self):
+        """Both branches set the fallback flag; only one still answers the knob.
+
+        A continued cut keeps moving with the cost tilt, so it is still the rate
+        rule; a degenerate fit's midpoint is *constant* in the tilt and is not.
+        Reporting both as one flag is what made a fallback unattributable, so
+        the kind has to tell them apart (issue #2900).
+        """
+        no_gap = GmmFit1D(w_lo=0.7, mu_lo=0.5, var_lo=0.01, w_hi=0.3, mu_hi=0.5, var_hi=0.01)
+        cut, kind = gmm_cut_from_fit(no_gap, "rate", 1.0, 1.0)
+        assert kind == CUT_KIND_DEGENERATE_MIDPOINT
+        assert cut == no_gap.midpoint()
+        assert gmm_cut_from_fit(no_gap, "rate", 1e6, 1.0)[0] == cut, "a degenerate cut must not move with the tilt"
+
+        empty_hi = GmmFit1D(w_lo=1.0, mu_lo=0.2, var_lo=0.01, w_hi=0.0, mu_hi=0.8, var_hi=0.01)
+        assert gmm_cut_from_fit(empty_hi, "rate", 1.0, 1.0)[1] == CUT_KIND_DEGENERATE_MIDPOINT
+
+    def test_the_kind_is_exactly_the_no_interior_stationary_point_flag(self):
+        """``bool(kind)`` has to keep meaning what ``cut_fallback`` meant, or the
+        fallback *rates* in every existing analysis silently change meaning."""
+        rng = np.random.default_rng(2900)
+        seen = {CUT_KIND_INTERIOR: 0, CUT_KIND_CONTINUED: 0}
+        for _ in range(500):
+            w_lo = float(rng.uniform(0.05, 0.95))
+            mu_lo = float(rng.uniform(0.0, 0.4))
+            fit = GmmFit1D(
+                w_lo=w_lo,
+                mu_lo=mu_lo,
+                var_lo=float(rng.uniform(1e-4, 0.05)),
+                w_hi=1.0 - w_lo,
+                mu_hi=mu_lo + float(rng.uniform(0.05, 0.5)),
+                var_hi=float(rng.uniform(1e-4, 0.05)),
+            )
+            for k in (-6, 0, 6):
+                cut, kind = gmm_cut_from_fit(fit, "rate", *inclusion_cost_weights(k))
+                assert kind in (CUT_KIND_INTERIOR, CUT_KIND_CONTINUED, CUT_KIND_DEGENERATE_MIDPOINT)
+                # An interior kind is exactly a genuine root; anything else is not.
+                assert (kind == CUT_KIND_INTERIOR) == (fit.rate_crossing(*inclusion_cost_weights(k)) is not None)
+                if kind == CUT_KIND_CONTINUED:
+                    assert not (fit.mu_lo < cut < fit.mu_hi)
+                seen[kind] = seen.get(kind, 0) + 1
+        assert seen[CUT_KIND_INTERIOR] > 50 and seen[CUT_KIND_CONTINUED] > 50, seen
 
     def test_unknown_rule_raises(self):
         with pytest.raises(ValueError, match="unknown cut rule"):

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -44,6 +44,16 @@ instead, since every commit on `dev` is effectively a new app release.)
   is the no-fusion control arm. `eval_learned_sort` / `run_eval` lost the
   parameter entirely - they delegate to the production trainer, which has no
   such mode.
+- **`gmm_cut_from_fit` returns `(cut, kind)` instead of `(cut, flag)`**, where
+  *kind* is one of `CUT_KIND_INTERIOR` (`""`), `CUT_KIND_CONTINUED` or
+  `CUT_KIND_DEGENERATE_MIDPOINT`. It is empty exactly when the old flag was 0,
+  so `bool(kind)` is the previous "no interior stationary point" boolean; the
+  non-empty values distinguish a cut *continued* past a component mean (still
+  moving with the cost tilt, still the rate rule) from a fit too degenerate to
+  express a boundary at all (a midpoint, constant in the tilt). Those two were
+  indistinguishable before, which made a fallback countable but not
+  attributable. **Breaking:** a caller comparing the second element to `0`/`1`
+  should compare to `""` or wrap in `bool()`.
 
 ### Removed
 

--- a/vtscore/eval/cut_rules.py
+++ b/vtscore/eval/cut_rules.py
@@ -66,7 +66,53 @@ from vtscore.training.evt_mixture import (
     fit_gumbel_normal_mixture_state,
     gaussian_mixture_mean_loglik,
 )
-from vtscore.training.thresholds import GmmFit1D, fit_score_gmm, gmm_fit_array
+from vtscore.training.thresholds import (
+    CUT_KIND_CONTINUED,
+    CUT_KIND_DEGENERATE_MIDPOINT,
+    CUT_KIND_INTERIOR,
+    GmmFit1D,
+    fit_score_gmm,
+    gmm_fit_array,
+)
+
+#: ``cut_fallback_kind`` when *this* module's decomposition family substituted
+#: the fit's own midpoint for a rule that has no root (issue #2900).  The
+#: substitution is deliberately **rule-independent**: the family's job is to
+#: compare tilts against each other on one fit, so every rule that misses gets
+#: the same neutral stand-in rather than each rule's own extrapolation.  That is
+#: what keeps ``rate`` comparable to its ``cross``/``priorfree`` siblings - and
+#: at inclusion 0, where the cost weights are ``(1, 1)``, it is what keeps
+#: ``rate`` *identical* to ``priorfree`` by construction, an identity every
+#: report in ``docs/experiments/gmm-cut/`` reads its ``*_rate`` rows through.
+#:
+#: Production does not do this.  It is not a bug on either side; the two answer
+#: different questions, and this value in the emitted rows is what lets an
+#: analyzer tell them apart instead of pooling both under ``cut_fallback == 1``.
+CUT_KIND_MIDPOINT: str = "midpoint"
+
+#: The whole ``cut_fallback_kind`` vocabulary, across both families.  Empty
+#: means the rule found an interior stationary point and nothing was
+#: substituted; the rest name which path produced the cut:
+#:
+#: ================================  =====================  ====================
+#: value                             emitted by             cut is
+#: ================================  =====================  ====================
+#: ``""``                            both                   the rule's own root
+#: ``"midpoint"``                    decomposition family   that fit's midpoint
+#: ``"continued"``                   production rule        continued past an
+#:                                                          inter-mean edge
+#: ``"degenerate_midpoint"``         production rule        that fit's midpoint
+#: ================================  =====================  ====================
+#:
+#: ``"midpoint"`` and ``"degenerate_midpoint"`` are both midpoints but are not
+#: the same event: the first is a measurement policy applied to a sound fit, the
+#: second is a fit too degenerate for any rule to cut.
+CUT_FALLBACK_KINDS: tuple[str, ...] = (
+    CUT_KIND_INTERIOR,
+    CUT_KIND_MIDPOINT,
+    CUT_KIND_CONTINUED,
+    CUT_KIND_DEGENERATE_MIDPOINT,
+)
 
 #: Sigmoid scores are clipped into ``[eps, 1-eps]`` before the logit transform so
 #: saturated scores stay finite.
@@ -185,7 +231,10 @@ def gaussian_cuts(fit: GmmFit1D, fpr_weight: float, fnr_weight: float) -> dict[s
     interval at the rule's own first-order slope, so it never stops moving with
     the cost tilt.  This function keeps reporting NaN because the decomposition
     is measuring *where the stationary point sits*, and "there is none" is the
-    honest answer to that question.
+    honest answer to that question.  The divergence is deliberate and is
+    recorded per row in ``cut_fallback_kind`` (:data:`CUT_KIND_MIDPOINT` vs
+    :data:`CUT_KIND_CONTINUED`), so an analysis that needs the shipped path can
+    exclude the substituted steps rather than mistake them for it (#2900).
     """
     return {
         "mid": _finite(fit.midpoint()),

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -53,6 +53,7 @@ from vtscore.training.blend_schedules import BlendContext
 from vtscore.training.mlp import LINEAR_HEAD, _auto_hidden_dim, train_model
 from vtscore.training.thresholds import (
     ACQUISITION_INCLUSION_OFFSET,
+    CUT_KIND_INTERIOR,
     acquisition_inclusion,
     anchored_gmm_fit,
     calculate_safe_threshold,
@@ -179,6 +180,7 @@ _CALIBRATION_COLUMNS: tuple[str, ...] = (
     "gmm_cut",
     "blend_weight",
     "cut_fallback",
+    "cut_fallback_kind",
     "cut_fail_reason",
     "raw_cut_cost",
     "raw_cut_fpr",
@@ -681,7 +683,11 @@ def _operating_metrics(
         "fold_seconds": nan,
         "n_cal_scores": nan,
         # Cut-rule study columns (issue #2836); only the variant rows set them.
+        # ``cut_fallback_kind`` says *what was substituted* where ``cut_fallback``
+        # only says *that* something was, which the two emitting families answer
+        # differently on the same fits (issue #2900).
         "cut_fallback": 0,
+        "cut_fallback_kind": CUT_KIND_INTERIOR,
         "cut_fail_reason": "",
         "raw_cut_cost": nan,
         "raw_cut_fpr": nan,
@@ -800,8 +806,19 @@ def _safe_gmm_variant_rows(
     (:func:`~vtscore.training.thresholds.gmm_cut_from_fit`) continues past the
     inter-mean interval at its own first-order slope instead, so on the fits
     where this flag fires these arms are measuring a different rule than the
-    app runs.  The fold-anchored family below calls the production function
-    directly and so does not have that gap.  For the EVT rules
+    app runs.  That divergence is **kept on purpose** (issue #2900): this family
+    compares tilts against each other on one fit, and a rule-independent
+    stand-in is what keeps ``rate`` commensurable with the ``cross`` and
+    ``priorfree`` siblings it is differenced against - at inclusion 0 it is what
+    keeps ``rate`` bit-identical to ``priorfree``, which is how every report in
+    ``docs/experiments/gmm-cut/`` reads those rows.  It is no longer *invisible*
+    though: ``cut_fallback_kind`` carries
+    :data:`~vtscore.eval.cut_rules.CUT_KIND_MIDPOINT` on exactly these steps,
+    against the production family's ``continued`` / ``degenerate_midpoint``, so
+    an analysis that wants the shipped path can filter for it instead of reading
+    a substituted midpoint as "what the app would have done".  The fold-anchored
+    family below calls the production function directly and so does not have
+    that gap at all.  For the EVT rules
     ``cut_fail_reason`` additionally names *which* guard declined, because the
     repairs those guards want are different and the counts alone cannot tell them
     apart (issue #2846).  The oracle variants do not fall back; they emit NaN cuts
@@ -814,7 +831,7 @@ def _safe_gmm_variant_rows(
     import numpy as np  # noqa: PLC0415
 
     from vtscore.eval.calibration_metrics import inclusion_weights, operating_cost  # noqa: PLC0415
-    from vtscore.eval.cut_rules import decomposition_cuts  # noqa: PLC0415
+    from vtscore.eval.cut_rules import CUT_KIND_MIDPOINT, decomposition_cuts  # noqa: PLC0415
     from vtscore.training.thresholds import blend_gmm_threshold, safe_blend_weight  # noqa: PLC0415
 
     xcal = float(details["xcal_threshold"])
@@ -859,6 +876,7 @@ def _safe_gmm_variant_rows(
     rows: list[dict[str, Any]] = []
     for name, geometry, rule in _SAFE_GMM_VARIANTS:
         fallback = 0
+        fallback_kind = CUT_KIND_INTERIOR
         fail_reason = ""
         if name == "xcal_only":
             threshold = xcal
@@ -869,6 +887,7 @@ def _safe_gmm_variant_rows(
             if not np.isfinite(gmm_cut) and name not in _ORACLE_VARIANTS:
                 gmm_cut = cuts_by_geometry[geometry].get("mid", nan)
                 fallback = 1
+                fallback_kind = CUT_KIND_MIDPOINT
                 # Empty for the Gaussian rules, which have no reason vocabulary;
                 # the EVT rules name the guard that declined so a fallback can be
                 # attributed rather than merely counted (issue #2846).
@@ -894,6 +913,7 @@ def _safe_gmm_variant_rows(
         row["gmm_cut"] = _r(gmm_cut)
         row["blend_weight"] = _r(weight)
         row["cut_fallback"] = fallback
+        row["cut_fallback_kind"] = fallback_kind
         row["cut_fail_reason"] = fail_reason
         if np.isfinite(gmm_cut):
             raw_cost, raw_fpr, raw_fnr = operating_cost(base_scores, base_labels, gmm_cut, wf, wn)
@@ -1174,7 +1194,13 @@ def _anchored_variant_rows(
 
     rows: list[dict[str, Any]] = []
 
-    def emit(name: str, threshold: float, provenance: str, cut_fallback: int) -> None:
+    def emit(name: str, threshold: float, provenance: str, cut_kind: str) -> None:
+        """Record one anchored arm.  *cut_kind* is the production rule's own
+        ``cut_fallback_kind`` (:func:`~vtscore.training.thresholds.gmm_cut_from_fit`),
+        so these rows say ``continued`` / ``degenerate_midpoint`` where the
+        decomposition family says ``midpoint`` - the two substitute different
+        values on the same fits (issue #2900).
+        """
         if not np.isfinite(threshold):
             return
         row = _operating_metrics(
@@ -1192,7 +1218,8 @@ def _anchored_variant_rows(
         row["xcal_threshold"] = _r(xcal)
         row["gmm_cut"] = _r(threshold)
         row["blend_weight"] = nan
-        row["cut_fallback"] = cut_fallback
+        row["cut_fallback"] = int(bool(cut_kind))
+        row["cut_fallback_kind"] = cut_kind
         raw_cost, raw_fpr, raw_fnr = operating_cost(base_scores, base_labels, threshold, wf, wn)
         row["raw_cut_cost"] = _r(raw_cost)
         row["raw_cut_fpr"] = _r(raw_fpr)
@@ -1211,8 +1238,8 @@ def _anchored_variant_rows(
                 # family below sweeps it; here it is skipped rather than fed to
                 # gmm_cut_from_fit, which (correctly) rejects it.
                 continue
-            cut, fell_back = gmm_cut_from_fit(fit, rule, wf, wn)
-            emit(f"anchored_w{weight:g}_{rule}", cut, provenance, fell_back)
+            cut, cut_kind = gmm_cut_from_fit(fit, rule, wf, wn)
+            emit(f"anchored_w{weight:g}_{rule}", cut, provenance, cut_kind)
 
     # --- Fold-anchored family + the rank-transfer attribution arm. ---
     if fold_anchored and fold_haystacks and fold_orderings:
@@ -1232,7 +1259,7 @@ def _anchored_variant_rows(
 
 
 def _emit_fold_anchored_rows(
-    emit: Callable[[str, float, str, int], None],
+    emit: Callable[[str, float, str, str], None],
     xcal: float,
     fold_haystacks: list,
     fold_orderings: list[tuple[list[float], list[float]]],
@@ -1255,6 +1282,14 @@ def _emit_fold_anchored_rows(
     :func:`~vtscore.training.thresholds.fold_anchored_gmm_threshold` the app
     ships; the grid *is* the deviation under test, so the arm at the production
     (κ, rule, combine) reproduces the shipped cut exactly.
+
+    These rows carry no ``cut_fallback_kind``: a fold-anchored threshold is
+    composed from one per-fit cut *per fold* in quantile space, so there is no
+    single fit whose fallback branch the row could name.  A per-fold breakdown
+    would be a different column with a different unit of observation, and the
+    ``mid_tilt`` rule the app ships already degrades a rate-less fold to plain
+    ``mid`` rather than to a substituted value (see
+    :meth:`~vtscore.training.thresholds.FoldAnchoredCut._quantile_at`).
     """
     import numpy as np  # noqa: PLC0415
 
@@ -1265,7 +1300,7 @@ def _emit_fold_anchored_rows(
         "rank_transfer",
         rank_transfer(xcal, np.concatenate(fold_hay), final_scores),
         "rank_transfer",
-        0,
+        CUT_KIND_INTERIOR,
     )
     for weight in weights:
         for rule in rules:
@@ -1279,7 +1314,7 @@ def _emit_fold_anchored_rows(
                     cut_rule=rule,
                     combine=combine,
                 )
-                emit(f"fold_anchored_w{weight:g}_{rule}_{combine}", threshold, provenance, 0)
+                emit(f"fold_anchored_w{weight:g}_{rule}_{combine}", threshold, provenance, CUT_KIND_INTERIOR)
 
 
 def _calibration_metric_rows(

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -241,6 +241,22 @@ def _weighted_gaussian_crossing(
     return mu_lo + max(inside)
 
 
+#: ``cut_fallback_kind`` when the rule found an interior stationary point, i.e.
+#: nothing was substituted or continued and the cut *is* the root.
+CUT_KIND_INTERIOR: str = ""
+#: ``cut_fallback_kind`` when the crossing ran off the inter-mean interval and
+#: the cut was continued past that edge at the rule's own first-order slope.
+#: The cut still moves with the cost tilt; it is simply no longer a stationary
+#: point of the rate loss.
+CUT_KIND_CONTINUED: str = "continued"
+#: ``cut_fallback_kind`` when the fit is too degenerate to express a boundary at
+#: all (non-positive weights/variances, non-ordered means) and the rule returned
+#: the plain midpoint.  Distinct from :data:`CUT_KIND_CONTINUED` because the cut
+#: is then *constant* in the cost tilt - the failure mode issue #2896 removed
+#: everywhere it could be removed.
+CUT_KIND_DEGENERATE_MIDPOINT: str = "degenerate_midpoint"
+
+
 def _rate_cut(
     w_lo: float,
     mu_lo: float,
@@ -250,12 +266,18 @@ def _rate_cut(
     var_hi: float,
     *,
     lam: float,
-) -> tuple[float, int]:
+) -> tuple[float, str]:
     """The rate-optimal cut: a **sup** over the inter-mean interval, continued
     past the edges at the rule's own first-order slope so it is **strictly**
     monotone in *lam* everywhere.
 
-    ``(cut, no_interior_stationary_point)``.  Inside the interval the cut is
+    ``(cut, kind)``, where *kind* is one of :data:`CUT_KIND_INTERIOR`,
+    :data:`CUT_KIND_CONTINUED` or :data:`CUT_KIND_DEGENERATE_MIDPOINT` - empty
+    exactly when an interior stationary point existed, so ``bool(kind)`` is the
+    "no interior stationary point" flag, and the non-empty values say *how* the
+    cut was produced instead.  The distinction matters to anything auditing the
+    rule: a continued cut still answers the Inclusion knob, a degenerate
+    midpoint does not (issue #2900).  Inside the interval the cut is
 
         ``sup { x in [mu_lo, mu_hi] : w_lo*N_lo(x) >= lam*w_hi*N_hi(x) }``
 
@@ -298,9 +320,9 @@ def _rate_cut(
     """
     mid = (mu_lo + mu_hi) / 2.0
     if not (w_lo > 0.0 and w_hi > 0.0 and var_lo > 0.0 and var_hi > 0.0 and lam > 0.0):
-        return mid, 1
+        return mid, CUT_KIND_DEGENERATE_MIDPOINT
     if not (mu_hi > mu_lo):
-        return mid, 1
+        return mid, CUT_KIND_DEGENERATE_MIDPOINT
 
     # Same shifted quadratic as ``_weighted_gaussian_crossing`` (u = x - mu_lo,
     # interval (0, d)): ``g(u) > 0`` means the Bad component owns that score.
@@ -322,7 +344,7 @@ def _rate_cut(
     # as ``lam`` falls - so the continuation leaves the edge without a step.
     excess = offset - 0.5 * d * d / var_lo
     if excess >= 0.0:
-        return mu_hi + slope * excess, 1
+        return mu_hi + slope * excess, CUT_KIND_CONTINUED
 
     inside = [u for u in _quadratic_roots(a, b, c) if math.isfinite(u) and 0.0 <= u < d]
     if not inside:
@@ -330,8 +352,8 @@ def _rate_cut(
         # ``c = g(0) <= 0`` (a positive g(0) with g(d) < 0 forces a root
         # inside), and ``-c`` is the log-cost margin by which Good is ahead at
         # the Bad mean - the mirror-image continuation below ``mu_lo``.
-        return mu_lo - slope * max(0.0, -c), 1
-    return mu_lo + max(inside), 0
+        return mu_lo - slope * max(0.0, -c), CUT_KIND_CONTINUED
+    return mu_lo + max(inside), CUT_KIND_INTERIOR
 
 
 @dataclass(frozen=True)
@@ -660,8 +682,13 @@ def anchored_gmm_fit(
     return None, f"gmm_failed:{provenance}"
 
 
-def gmm_cut_from_fit(fit: GmmFit1D, rule: str, fpr_weight: float = 1.0, fnr_weight: float = 1.0) -> tuple[float, int]:
-    """Apply a named cut *rule* to *fit*; ``(cut, no_interior_stationary_point)``.
+def gmm_cut_from_fit(fit: GmmFit1D, rule: str, fpr_weight: float = 1.0, fnr_weight: float = 1.0) -> tuple[float, str]:
+    """Apply a named cut *rule* to *fit*; ``(cut, kind)``.
+
+    *kind* is the ``cut_fallback_kind`` vocabulary above - empty exactly when
+    the rule found an interior stationary point, so ``bool(kind)`` is the "no
+    interior stationary point" flag and the value names *how* the cut was
+    produced otherwise.
 
     ``"mid"`` is the historical midpoint; ``"rate"`` is the rate-optimal
     crossing at the given cost weights (see :meth:`GmmFit1D.rate_crossing`).
@@ -670,9 +697,12 @@ def gmm_cut_from_fit(fit: GmmFit1D, rule: str, fpr_weight: float = 1.0, fnr_weig
     **sup** rather than a bare root so it stays monotone in the cost ratio
     even on fits where the root enters and leaves the inter-mean interval, and
     continues past the interval edges at the rule's first-order slope so it
-    never flattens (issue #2896); the flag marks the cases with no interior
+    never flattens (issue #2896); the kind marks the cases with no interior
     stationary point.  The value is the stationary point wherever one exists,
     so this is the rule the #2836 / #2852 measurements scored.
+
+    ``"mid"`` never reports a kind: the midpoint of two means is defined for
+    every fit, so it has no fallback branch to distinguish.
 
     ``"mid_tilt"`` (the shipped fold-level rule, :data:`FOLD_ANCHOR_CUT_RULE`)
     is deliberately *not* accepted here: it is defined in fold-quantile space
@@ -681,10 +711,10 @@ def gmm_cut_from_fit(fit: GmmFit1D, rule: str, fpr_weight: float = 1.0, fnr_weig
     form for this function to apply.
     """
     if rule == "mid":
-        return fit.midpoint(), 0
+        return fit.midpoint(), CUT_KIND_INTERIOR
     if rule == "rate":
         if not (fpr_weight > 0.0 and fnr_weight > 0.0 and fit.w_hi > 0.0):
-            return fit.midpoint(), 1
+            return fit.midpoint(), CUT_KIND_DEGENERATE_MIDPOINT
         lam = (fnr_weight / fpr_weight) * (fit.w_lo / fit.w_hi)
         return _rate_cut(fit.w_lo, fit.mu_lo, fit.var_lo, fit.w_hi, fit.mu_hi, fit.var_hi, lam=lam)
     raise ValueError(f"unknown cut rule {rule!r}; expected 'mid' or 'rate'")
@@ -790,7 +820,7 @@ class FoldAnchoredCut:
         """Combined fold quantile of *rule*'s per-fold cuts at these cost weights."""
         quantiles = []
         for fit, src in zip(self.fits, self.fold_haystacks, strict=True):
-            cut, _fell_back = gmm_cut_from_fit(fit, rule, fpr_weight, fnr_weight)
+            cut, _kind = gmm_cut_from_fit(fit, rule, fpr_weight, fnr_weight)
             quantiles.append(float(np.searchsorted(src, cut, side="left")) / float(src.size))
         if self.combine == "qmean":
             return float(np.mean(quantiles))


### PR DESCRIPTION
Resolves the decision #2900 asked for: **keep the divergence, make it visible in the emitted rows.**

Refs #2900

## The decision, and why

`_SAFE_GMM_VARIANTS` substitutes a fit's own **midpoint** for a rule with no root; production's `rate` rule **continues past the component mean** at the rule's first-order slope. Both set `cut_fallback == 1`, so an analysis reading a `*_rate` arm as "what the app would have done" was wrong on those steps with nothing in the data to say so.

Option 1 (adopt production's continuation) is worse than the issue anticipated. The continuation exists only for `rate`, so giving it to `rate` alone would:

- put **two** differences (tilt *and* fallback policy) into the `priorfree → rate` step of a chain whose whole design is "each consecutive pair differs in exactly one assumption"; and
- **break the `rate ≡ priorfree` identity at inclusion 0**. `inclusion_cost_weights(0) == (1.0, 1.0)`, so `rate`'s `lam = (wn/wf)·(w_lo/w_hi)` collapses to `priorfree`'s `lam = w_lo/w_hi`. All three reports in `docs/experiments/gmm-cut/` state this explicitly and read their `*_rate` rows through it. Option 1 would turn that structural equality into a silent difference on the ~20–25 % of steps where the flag fires.

So the divergence stays, and the rows now say which one they are.

## Item 3: does any shipped conclusion depend on it?

**No.** Every run in `docs/experiments/gmm-cut/` (REPORT, REMEASURE-2846, PREREG-2881) is at **inclusion 0**, where those `*_rate` rows *are* the `*_priorfree` rows — and `priorfree` has no shipped continuation to diverge from in the first place. Nobody could have read those arms as the shipped path even in principle. The exposure is for future runs at non-zero Inclusion, which is where it would actually bite. A short note to that effect is added to the scope section of each of the three reports.

## What changed

- **`gmm_cut_from_fit` / `_rate_cut` return a `kind`, not a bare flag.** `""` / `"continued"` / `"degenerate_midpoint"`. This splits two outcomes that were indistinguishable: a cut *continued* past the edge still moves with the cost tilt and is still the rate rule, while a degenerate fit's midpoint is *constant* in it. Without the split, a `cut_fallback_kind` column would have had to label production's degenerate rows as "continued", which is false. `bool(kind)` is exactly the old flag, so `fallback_rate` aggregates and `== 0`/`== 1` filters keep their meaning and stay comparable across the two families.
- **Both eval families emit `cut_fallback_kind`** (`"midpoint"` for the decomposition family, production's own kind for the anchored family), added to `_CALIBRATION_COLUMNS` with a neutral default on every other row.
- **`analyze_cut.fallback_reasons` groups on it** and no longer filters on a non-empty `cut_fail_reason` — that filter silently excluded *every* Gaussian rule from the table, since only the EVT rules have a reason vocabulary. Frames emitted before this change still analyze.
- **`thresholds._rate_cut` is now a pinned eval/app mirror** with the divergence declared in `divergence=`. This surface has moved twice (midpoint → bare edge → continued), and each move silently changed what the harness's `*_rate` arms mean; the second one is what left the docstring stale for two days with nothing noticing. The gate now makes the next move prompt a decision.
- Prose corrected at the sites #2899 touched, plus a `vtscore` CHANGELOG entry for the breaking return-signature change.

## Testing

`./run-tests.sh` — **ALL 7860 TESTS PASSED** (1 skipped). New coverage:

- `test_anchored_gmm.py` — degenerate fits report a midpoint, not a continuation, and the midpoint really is constant in the tilt; `bool(kind)` is exactly "no interior stationary point" over a 500-fit sweep that exercises both branches.
- `test_safe_gmm_variant_rows.py` — a fallen-back row names `midpoint` and the substituted value really is that fit's `tau_mid`.
- `test_anchored_variant_rows.py` — production-path rows never claim the decomposition family's kind.

`analyze_cut.fallback_reasons` was smoke-tested directly (not covered by `run-tests.sh`) on both a current frame and a pre-change one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WswahPCb95B33EsVb1STym

---
_Generated by [Claude Code](https://claude.ai/code/session_01WswahPCb95B33EsVb1STym)_