### PR TITLE
Fix image2face producing zero faces for path-only (thin) media

### DIFF
--- a/tests_lib/detectors/test_face.py
+++ b/tests_lib/detectors/test_face.py
@@ -308,3 +308,31 @@ class TestImage2FaceConverter:
         with patch.object(conv, "_make_detector", return_value=detector):
             out = conv.convert_normalized(media, {"threshold": "0.5", "padding": "0", "min_size": "1"})
         assert len(out) == 1
+
+    def test_path_only_media_is_read_from_disk(self, tmp_path):
+        """Reference (*thin*) mode passes only ``{filename, media_path}``.
+
+        The runner's thin path hands the converter no ``media_bytes`` at all,
+        so the converter has to read the file itself; otherwise every image in
+        a thin folder import yields zero faces with no error.
+        """
+        from vtscore.converters.image2face import Image2FaceMediaConverter
+
+        src = tmp_path / "group.png"
+        src.write_bytes(_png_bytes())
+
+        conv = Image2FaceMediaConverter()
+        detector = _fake_mtcnn(boxes=[[10, 10, 40, 40]], probs=[0.9])
+        media = {"filename": "group.png", "media_path": str(src)}
+        with patch.object(conv, "_make_detector", return_value=detector):
+            out = conv.convert_normalized(media, {"padding": "0", "min_size": "1"})
+        assert len(out) == 1
+        assert out[0]["media_bytes"]
+
+    def test_missing_path_yields_no_output(self, tmp_path):
+        from vtscore.converters.image2face import Image2FaceMediaConverter
+
+        conv = Image2FaceMediaConverter()
+        media = {"filename": "gone.png", "media_path": str(tmp_path / "gone.png")}
+        out = conv.convert_normalized(media, {})
+        assert out == []

--- a/vtscore/converters/audio2image.py
+++ b/vtscore/converters/audio2image.py
@@ -6,21 +6,8 @@ import io
 from pathlib import Path
 from typing import Any
 
-from vtscore.converters.base import MediaConverter
+from vtscore.converters.base import MediaConverter, resolve_media_bytes
 from vtscore.plugins import PluginField
-
-
-def _resolve_media_bytes(media: dict[str, Any]) -> bytes | None:
-    """Read raw bytes from ``media_bytes`` or, failing that, ``media_path``."""
-    media_bytes = media.get("media_bytes")
-    if media_bytes is not None:
-        return media_bytes
-    media_path = media.get("media_path")
-    if media_path:
-        path = Path(media_path)
-        if path.exists():
-            return path.read_bytes()
-    return None
 
 
 def _load_audio_array(media_bytes: bytes, filename: str, duration: float | None) -> tuple[Any, int] | None:
@@ -216,7 +203,7 @@ class Audio2ImageMediaConverter(MediaConverter):
 
         filename = media.get("filename", "audio.wav")
         stem = Path(filename).stem
-        media_bytes = _resolve_media_bytes(media)
+        media_bytes = resolve_media_bytes(media)
         if not media_bytes:
             return []
 

--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -4,9 +4,31 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 from vtscore.plugins import PluginBase, PluginField
+
+
+def resolve_media_bytes(media: dict[str, Any]) -> bytes | None:
+    """Read raw bytes from ``media_bytes`` or, failing that, ``media_path``.
+
+    Every binary-input converter needs this: the source media dict carries
+    inline ``media_bytes`` in full-import mode, but reference (*thin*) mode
+    hands the converter only ``{filename, media_path}`` (see
+    :func:`vtscore.converters.runner._run_converter_on_source`), so a
+    converter that reads ``media_bytes`` alone silently produces nothing for
+    every thin import.  Returns ``None`` when neither source yields bytes.
+    """
+    media_bytes = media.get("media_bytes")
+    if media_bytes is not None:
+        return media_bytes
+    media_path = media.get("media_path")
+    if media_path:
+        path = Path(media_path)
+        if path.exists():
+            return path.read_bytes()
+    return None
 
 
 class MediaConverter(PluginBase, ABC):

--- a/vtscore/converters/document2image.py
+++ b/vtscore/converters/document2image.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 
-from vtscore.converters.base import MediaConverter
+from vtscore.converters.base import MediaConverter, resolve_media_bytes
 
 
 class Document2ImageMediaConverter(MediaConverter):
@@ -43,17 +43,10 @@ class Document2ImageMediaConverter(MediaConverter):
         return "image"
 
     def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
-        media_bytes = media.get("media_bytes")
-        media_path = media.get("media_path")
         filename = media.get("filename", "document")
         stem = Path(filename).stem
 
-        if media_bytes is None and media_path:
-            path = Path(media_path)
-            if path.exists():
-                with open(path, "rb") as f:
-                    media_bytes = f.read()
-
+        media_bytes = resolve_media_bytes(media)
         if not media_bytes:
             return []
 

--- a/vtscore/converters/document2text.py
+++ b/vtscore/converters/document2text.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, cast
 
-from vtscore.converters.base import MediaConverter
+from vtscore.converters.base import MediaConverter, resolve_media_bytes
 
 
 class Document2TextMediaConverter(MediaConverter):
@@ -37,17 +37,10 @@ class Document2TextMediaConverter(MediaConverter):
         return "text"
 
     def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
-        media_bytes = media.get("media_bytes")
-        media_path = media.get("media_path")
         filename = media.get("filename", "document")
         stem = Path(filename).stem
 
-        if media_bytes is None and media_path:
-            path = Path(media_path)
-            if path.exists():
-                with open(path, "rb") as f:
-                    media_bytes = f.read()
-
+        media_bytes = resolve_media_bytes(media)
         if not media_bytes:
             return []
 

--- a/vtscore/converters/image2face.py
+++ b/vtscore/converters/image2face.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import io
 from typing import Any, Optional
 
-from vtscore.converters.base import MediaConverter
+from vtscore.converters.base import MediaConverter, resolve_media_bytes
 from vtscore.plugins import PluginField
 
 
@@ -177,16 +177,11 @@ class Image2FaceMediaConverter(MediaConverter):
     # ------------------------------------------------------------------
 
     def convert(self, media: dict[str, Any], params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
-        from vtscore.media.embedder import media_from_path  # noqa: PLC0415
         from vtscore.media.image.decode import decode_bounded_rgb  # noqa: PLC0415
 
         threshold, padding, min_size = self._resolve_params(params)
 
-        media_bytes = media.get("media_bytes")
-        if media_bytes is None:
-            media_path = media.get("media_path")
-            if media_path:
-                media_bytes = media_from_path(media_path).get("media_bytes")
+        media_bytes = resolve_media_bytes(media)
         if not media_bytes:
             return []
         try:

--- a/vtscore/converters/image2text.py
+++ b/vtscore/converters/image2text.py
@@ -5,21 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from vtscore.converters.base import MediaConverter
+from vtscore.converters.base import MediaConverter, resolve_media_bytes
 from vtscore.plugins import PluginField
-
-
-def _resolve_media_bytes(media: dict[str, Any]) -> bytes | None:
-    """Read raw bytes from ``media_bytes`` or, failing that, ``media_path``."""
-    media_bytes = media.get("media_bytes")
-    if media_bytes is not None:
-        return media_bytes
-    media_path = media.get("media_path")
-    if media_path:
-        path = Path(media_path)
-        if path.exists():
-            return path.read_bytes()
-    return None
 
 
 def _run_paddleocr(media_bytes: bytes, filename: str, language: str) -> list | None:
@@ -176,7 +163,7 @@ class Image2TextMediaConverter(MediaConverter):
 
         filename = media.get("filename", "image.png")
         stem = Path(filename).stem
-        media_bytes = _resolve_media_bytes(media)
+        media_bytes = resolve_media_bytes(media)
         if not media_bytes:
             return []
 


### PR DESCRIPTION
Closes #2915

## The bug

`Image2FaceMediaConverter.convert()` resolved a path-only source with:

```python
media_bytes = media_from_path(media_path).get("media_bytes")
```

`media_from_path` (`vtscore/media/embedder.py`) builds only `{media_path, origin, origin_name, filename, custom_metadata}` — it never reads the file and never sets `media_bytes`, so that lookup always returned `None` and the next `if not media_bytes: return []` bailed.

The concrete failure is reference (*thin*) folder import: `_run_converter_on_source` (`vtscore/converters/runner.py`) hands the converter only `{filename, media_path}` when `thin=True`, so every image routed through Images → Faces silently produced zero faces and the face dataset came out empty with no error — empty output is the documented "no faces detected" semantic, so nothing flagged it.

## The fix

The read-bytes-or-read-path fallback was already duplicated as a private `_resolve_media_bytes` in `image2text.py` and `audio2image.py`, and inlined a third and fourth time in `document2image.py` / `document2text.py`. Rather than adding a fifth copy, this hoists it into a shared `resolve_media_bytes()` in `vtscore/converters/base.py` and routes all five converters through it, so a new converter can't reintroduce the same broken variant.

Behavior is unchanged for the four converters that already had a working fallback; only `image2face` changes.

## Tests

Two regression tests in `tests_lib/detectors/test_face.py`:

- `test_path_only_media_is_read_from_disk` — a `{filename, media_path}` media dict (the exact shape thin mode passes) now yields a face crop.
- `test_missing_path_yields_no_output` — a nonexistent path still returns `[]` rather than raising.

Full `./run-tests.sh` passes: 7862 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Wjcq4mgsDwhyhCmpHPMHi)_