### PR TITLE
Key the labeling-progress cache by (dataset, detector)

### DIFF
--- a/tests/detectors/test_multi_detector.py
+++ b/tests/detectors/test_multi_detector.py
@@ -530,3 +530,144 @@ class TestLabelingStatusResetOnDetectorSwitch:
         # With 0 good and 0 bad votes the indicators must NOT be green
         assert data["smart"]["status"] == "red", f"smart should be red with 0 votes, got {data['smart']['status']}"
         assert data["stable"]["status"] == "red", f"stable should be red with 0 votes, got {data['stable']['status']}"
+
+
+# ---------------------------------------------------------------------------
+# Progress-cache identity across *already loaded* detectors (issue #2914)
+# ---------------------------------------------------------------------------
+
+
+class TestProgressCacheKeyedByDetector:
+    """The per-step progress cache is a single module-global slot, but every
+    input it is built from resolves per-(dataset, detector).
+
+    Switching the UI between two detectors that are *both already loaded* goes
+    through neither ``register_detector_context`` nor
+    ``unregister_detector_context``, so those clears do not cover it.  Without
+    an identity stamp the length-only freshness gates replay one detector's
+    history on top of another's accumulated label sets, or serve one detector's
+    models as another's Smart / Stable indicators.
+    """
+
+    @staticmethod
+    def _load(*det_ids: str) -> None:
+        """Register every named detector, leaving them all loaded.
+
+        Done up front so the later switches go through neither register nor
+        unregister - i.e. exactly the path whose cache clears are missing.
+        """
+        from vtscore.state.core import DetectorContext, register_detector_context
+
+        for det_id in det_ids:
+            register_detector_context(DetectorContext(det_id, name=det_id, media_type="audio"))
+
+    @staticmethod
+    def _activate(det_id: str) -> None:
+        """Make an already-loaded detector the active one (no register/unregister)."""
+        from vtscore.state.core import get_detector_context, set_thread_detector_context
+
+        ctx = get_detector_context(det_id)
+        assert ctx is not None
+        set_thread_detector_context(ctx)
+
+    def test_switch_between_loaded_detectors_does_not_merge_label_sets(self, client):
+        """Re-selecting an already-loaded detector must rebuild its own cache,
+        not append its remaining history onto the other detector's ID sets."""
+        from vtsearch.state import apply_label, label_history, medias
+        from vtscore.detectors.labeling_progress import (
+            _cache_bad_ids,
+            _cache_good_ids,
+            _cached_steps,
+            _ensure_cache,
+            _progress_lock,
+        )
+
+        a_good, a_bad = [1, 2, 3, 4, 5], [16, 17, 18, 19, 20]
+        b_good, b_bad = [6, 7], [14, 15]
+
+        self._load("det_key_a", "det_key_b")
+
+        # --- Detector A: 10 votes, cache advanced to 10 steps ---
+        self._activate("det_key_a")
+        for mid in a_good:
+            apply_label(mid, "good")
+        for mid in a_bad:
+            apply_label(mid, "bad")
+        with _progress_lock:
+            _ensure_cache(medias, label_history, 0)
+            assert len(_cached_steps) == 10
+
+        # --- Detector B: 4 votes.  Its shorter history must not be read as
+        # "the cache is ahead"; the cache belongs to A and has to be dropped. ---
+        self._activate("det_key_b")
+        for mid in b_good:
+            apply_label(mid, "good")
+        for mid in b_bad:
+            apply_label(mid, "bad")
+        with _progress_lock:
+            _ensure_cache(medias, label_history, 0)
+            assert len(_cached_steps) == 4, "cache must be rebuilt for B, not reused from A"
+            assert _cache_good_ids == set(b_good)
+            assert _cache_bad_ids == set(b_bad)
+
+        # --- Back to A: replaying steps 4..9 on top of B's ID sets would train
+        # the appended steps on a merged A+B labelset. ---
+        self._activate("det_key_a")
+        with _progress_lock:
+            _ensure_cache(medias, label_history, 0)
+            assert len(_cached_steps) == 10
+            assert _cache_good_ids == set(a_good), "A's cache must not carry B's good votes"
+            assert _cache_bad_ids == set(a_bad), "A's cache must not carry B's bad votes"
+            for step in _cached_steps:
+                assert not (set(step["good_ids"]) & set(b_good)), "B's votes leaked into A's steps"
+                assert not (set(step["bad_ids"]) & set(b_bad)), "B's votes leaked into A's steps"
+
+    def test_status_cache_not_fresh_for_a_different_detector(self, client):
+        """A cache built for A must never be reported fresh for B, whose own
+        (shorter) history it has never seen."""
+        from vtsearch.state import apply_label, label_history, medias
+        from vtscore.detectors.labeling_progress import (
+            _ensure_cache,
+            _progress_lock,
+            is_status_cache_fresh,
+        )
+
+        self._load("det_fresh_a", "det_fresh_b")
+        self._activate("det_fresh_a")
+        for mid in [1, 2, 3, 4, 5]:
+            apply_label(mid, "good")
+        for mid in [16, 17, 18, 19, 20]:
+            apply_label(mid, "bad")
+        with _progress_lock:
+            _ensure_cache(medias, label_history, 0)
+        assert is_status_cache_fresh(label_history, 0)
+
+        # B has a strictly shorter history, so a length-only gate would call
+        # A's 10-step cache "fresh" for B and serve A's models as B's status.
+        self._activate("det_fresh_b")
+        apply_label(6, "good")
+        apply_label(15, "bad")
+        assert not is_status_cache_fresh(label_history, 0)
+
+    def test_status_snapshot_not_served_across_detectors(self, client):
+        """``stale_labeling_status`` must not hand B the Smart / Stable
+        indicators computed for A."""
+        from vtsearch.state import apply_label, bad_votes, good_votes, label_history, medias
+        from vtscore.detectors.labeling_progress import compute_labeling_status, stale_labeling_status
+
+        self._load("det_snap_a", "det_snap_b")
+        self._activate("det_snap_a")
+        for mid in [1, 2, 3, 4, 5]:
+            apply_label(mid, "good")
+        for mid in [16, 17, 18, 19, 20]:
+            apply_label(mid, "bad")
+        status_a = compute_labeling_status(medias, label_history, good_votes, bad_votes, 0)
+        assert status_a["smart"]["status"] != "red", "A should have a real (non-placeholder) Smart status"
+
+        # B has no votes at all: its stale poll must fall back to the transient
+        # "computing" placeholder rather than reusing A's snapshot.
+        self._activate("det_snap_b")
+        assert len(good_votes) == 0 and len(bad_votes) == 0
+        stale = stale_labeling_status(good_votes, bad_votes, None)
+        assert stale["smart"]["reason"] == "Computing indicators..."
+        assert stale["stable"]["reason"] == "Computing indicators..."

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -46,6 +46,9 @@ if TYPE_CHECKING:
 # and stores the model, threshold, label sets, and stability result for that
 # step.  ``_cache_good_ids`` / ``_cache_bad_ids`` track the running label sets
 # so the next step only needs to apply a single delta.
+#
+# The cache holds exactly one ``(dataset, detector)`` pair at a time, stamped in
+# ``_cache_key``; switching to another pair drops it (see that variable's note).
 
 _cache_inclusion: Optional[int] = None
 _cached_steps: list[dict[str, Any]] = []
@@ -71,6 +74,24 @@ _cache_monitored_set: Optional[set[int]] = None
 # status is never shown after a detector switch / vote clear.
 _status_snapshot: Optional[dict[str, Any]] = None
 
+# Identity of the ``(dataset_id, detector_id)`` pair every cache variable above
+# belongs to, or ``None`` when the cache is empty and belongs to nobody.
+#
+# Every input the cache is built from is resolved *per request* from the
+# ``X-Dataset-Id`` / ``X-Detector-Id`` headers (``label_history``,
+# ``good_votes`` / ``bad_votes`` via the detector context; ``clips_dict`` and
+# the coverage atlas via the dataset context), while the cache itself is a
+# single module-global slot.  Multiple detectors stay loaded at once and the UI
+# switches between them freely - re-selecting an *already loaded* detector never
+# goes through ``register_detector_context`` / ``unregister_detector_context``,
+# so those clears do not cover the switch.  Without an identity stamp the
+# freshness gates (which compare only ``len(_cached_steps)`` to
+# ``len(label_history)``) would replay one detector's history on top of
+# another's accumulated label sets, or serve one detector's models as another's
+# Smart / Stable indicators.  :func:`_bind_cache_identity` stamps this key and
+# drops the cache whenever the active pair changes.
+_cache_key: Optional[tuple[str, str]] = None
+
 # Live models injected by `train_and_score` during sorting.  Keyed by
 # ``(frozenset(good_ids), frozenset(bad_ids))`` so that ``_ensure_cache``
 # can look up the actual model that was used at each label step instead
@@ -79,7 +100,8 @@ _live_models: dict[tuple[frozenset[int], frozenset[int]], tuple[Any, float]] = {
 
 # Reentrant lock protecting all module-level cache variables.
 # RLock is used because public functions call _ensure_cache which may
-# call clear_progress_cache internally when the inclusion value changes.
+# call _clear_cache_data internally (inclusion change, or a rebind onto a
+# different dataset/detector) while already holding the lock.
 _progress_lock = threading.RLock()
 
 # Upper bound on the number of items the per-step stability forward pass
@@ -102,11 +124,36 @@ _STABILITY_MAX_SAMPLES = 50_000
 _CACHE_READ_LOCK_TIMEOUT = 0.25
 
 
-def clear_progress_cache() -> None:
-    """Clear all cached progress data.
+def _active_cache_key() -> tuple[str, str]:
+    """Return ``(dataset_id, detector_id)`` for the current execution context.
 
-    Must be called whenever votes are cleared, medias change, or inclusion
-    is altered so that stale models are not reused.
+    Read *without* acquiring ``_state_lock``: this runs under ``_progress_lock``
+    (see the lock-ordering note at module top), which forbids taking
+    ``_state_lock`` while held.  Neither ``get_active_context()`` nor
+    ``get_active_detector_context()`` takes a lock - both resolve from the
+    request-scoped resolver or a thread-local - so the read is safe.  In the
+    ``/api/labeling-status`` background worker both contexts are bound
+    thread-locally by ``JobManager``, so the worker resolves the same key the
+    request thread did.
+
+    Falls back to ``("", "")`` when resolution fails (e.g. a request naming an
+    unloaded detector, whose resolver raises); such a caller cannot reach a
+    usable ``label_history`` anyway.
+    """
+    try:
+        from vtscore.state.core import get_active_context, get_active_detector_context  # noqa: PLC0415
+
+        return (get_active_context().dataset_id, get_active_detector_context().detector_id)
+    except Exception:
+        return ("", "")
+
+
+def _clear_cache_data() -> None:
+    """Clear every cache variable *except* the identity stamp.
+
+    Used by the in-place rebuilds (an inclusion change) that keep the cache
+    bound to the same ``(dataset, detector)`` pair.  Callers that hand the
+    cache back to nobody should use :func:`clear_progress_cache`.
     """
     global _cache_inclusion, _cache_prev_predictions, _cache_coverage_atlas, _status_snapshot
     global _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set
@@ -129,6 +176,32 @@ def clear_progress_cache() -> None:
         _status_snapshot = None
 
 
+def _bind_cache_identity() -> None:
+    """Drop the cache when the active ``(dataset, detector)`` pair has changed.
+
+    Must be called with ``_progress_lock`` held, at the top of every entry
+    point that reads or writes the module cache, so a poll for detector A can
+    never see state accumulated for detector B (issue #2914).
+    """
+    global _cache_key
+    key = _active_cache_key()
+    if _cache_key is not None and _cache_key != key:
+        _clear_cache_data()
+    _cache_key = key
+
+
+def clear_progress_cache() -> None:
+    """Clear all cached progress data and unbind it from any detector.
+
+    Must be called whenever votes are cleared, medias change, or inclusion
+    is altered so that stale models are not reused.
+    """
+    global _cache_key
+    with _progress_lock:
+        _clear_cache_data()
+        _cache_key = None
+
+
 def invalidate_progress_cache_from(media_id: int) -> None:
     """Truncate the progress cache to just before *media_id* first appeared.
 
@@ -140,6 +213,10 @@ def invalidate_progress_cache_from(media_id: int) -> None:
     """
     global _cache_prev_predictions, _status_snapshot
     with _progress_lock:
+        # A polarity flip on one detector must not truncate another's cache;
+        # rebinding drops a foreign cache outright, leaving nothing to trim.
+        _bind_cache_identity()
+
         # Find the first cached step that includes media_id in its training data.
         truncate_at = None
         for i, step in enumerate(_cached_steps):
@@ -204,6 +281,9 @@ def inject_live_model(
     """
     key = (frozenset(good_votes), frozenset(bad_votes))
     with _progress_lock:
+        # Live models are looked up by labelset alone, so they must not outlive
+        # the detector they were trained for.
+        _bind_cache_identity()
         _live_models[key] = (model, threshold)
 
 
@@ -332,8 +412,9 @@ def _monitored_pool(
     Built once per cache lifetime and memoised.  It used to be rebuilt inside
     every step - an O(N x D) numpy materialisation per label-history step,
     which dominated the cost of advancing the cache.  The pool depends only on
-    *clips_dict*, which cannot change without a ``clear_progress_cache()``,
-    so one build per cache lifetime is sound.
+    *clips_dict*, which cannot change without a ``clear_progress_cache()`` (in
+    place) or a ``_cache_key`` change (a different dataset), so one build per
+    cache lifetime is sound.
     """
     global _cache_monitored_ids, _cache_monitored_X, _cache_monitored_set
 
@@ -519,8 +600,14 @@ def _ensure_cache(
     """
     global _cache_inclusion, _cache_coverage_atlas
 
+    # Drop anything accumulated for a different (dataset, detector) pair before
+    # comparing lengths below: the ``start >= len(label_history)`` gate has no
+    # idea whose history it is looking at (issue #2914).
+    _bind_cache_identity()
+
     if _cache_inclusion is not None and _cache_inclusion != inclusion_value:
-        clear_progress_cache()
+        # Same pair, different inclusion: rebuild in place and keep the stamp.
+        _clear_cache_data()
 
     if _cache_inclusion is None:
         _cache_inclusion = inclusion_value
@@ -939,6 +1026,7 @@ def compute_labeling_status(
 
     with _progress_lock:
         _ensure_cache(clips_dict, label_history, inclusion_value)
+        computed_for = _cache_key
 
         smart = _compute_smart_status(
             clips_dict, label_history, current_good_votes, current_bad_votes, inclusion_value, good, bad, total
@@ -958,9 +1046,14 @@ def compute_labeling_status(
     }
     # Refresh the snapshot the poll route hands back while the cache is behind.
     # Store a copy so a caller that mutates the returned dict (e.g. adding the
-    # ``stale`` flag) doesn't retroactively corrupt the snapshot.
+    # ``stale`` flag) doesn't retroactively corrupt the snapshot.  The lock was
+    # released for the (settings-reading) Span computation above, so another
+    # thread may have rebound the cache to a different detector meanwhile;
+    # publishing this result under that detector's key is exactly the bleed
+    # this cache-keying exists to prevent, so drop it instead.
     with _progress_lock:
-        _status_snapshot = dict(result)
+        if _cache_key == computed_for:
+            _status_snapshot = dict(result)
     return result
 
 
@@ -1019,9 +1112,12 @@ def is_status_cache_fresh(label_history: list[tuple[int, str, float]], inclusion
     A fresh cache means ``compute_labeling_status`` will not retrain any model,
     so the route can compute the status inline instead of deferring to a
     background worker.  A mismatched ``inclusion_value`` counts as not-fresh
-    because :func:`_ensure_cache` would rebuild the cache from scratch.
+    because :func:`_ensure_cache` would rebuild the cache from scratch.  So
+    does a cache belonging to a different ``(dataset, detector)`` pair, which is
+    dropped here rather than length-compared against a history it never saw.
     """
     with _progress_lock:
+        _bind_cache_identity()
         if _cache_inclusion is not None and _cache_inclusion != inclusion_value:
             return False
         return len(_cached_steps) >= len(label_history)
@@ -1067,6 +1163,9 @@ def stale_labeling_status(
     """
     status = _pending_labeling_status(current_good_votes, current_bad_votes, span_info)
     with _progress_lock:
+        # Never hand another detector's last snapshot to this one; rebinding
+        # drops it so the "computing" placeholder shows instead.
+        _bind_cache_identity()
         if _status_snapshot is not None:
             status["smart"] = dict(_status_snapshot["smart"])
             status["stable"] = dict(_status_snapshot["stable"])


### PR DESCRIPTION
## Problem

The per-step cache in `vtscore/detectors/labeling_progress.py` (`_cached_steps`, `_cache_good_ids` / `_cache_bad_ids`, `_cache_prev_predictions`, `_cache_monitored_*`, `_cache_coverage_atlas`, `_status_snapshot`, `_live_models`) is a single module-global slot with no identity, while every input fed into it resolves *per request* from the `X-Dataset-Id` / `X-Detector-Id` headers.

Its clears only covered `register_detector_context` / `unregister_detector_context`, vote-clear, media-clear, and inclusion change. Re-selecting a detector that is **already loaded** goes through none of those, and both freshness gates (`_ensure_cache`, `is_status_cache_fresh`) validate only by comparing `len(_cached_steps)` to `len(label_history)`. So:

- **Cache shorter than history** — a poll for detector A replays A's remaining label events on top of B's accumulated `_cache_good_ids` / `_cache_bad_ids`, training the appended steps on a merged A+B labelset and computing stability flips against B's `_cache_prev_predictions`.
- **Cache longer than history** — `is_status_cache_fresh` returns `True` for B and `compute_labeling_status` serves A's cached models and stability entries as B's Smart / Stable indicators.
- The same bleed applies across **datasets**: the monitored pool and the coverage atlas are memoised from the first dataset's `clips_dict` and reused for another.

All silent: no crash, just wrong indicator curves and wrong `recreate_model_at_time` results.

## Fix

Stamp the cache with the active `(dataset_id, detector_id)` pair in a new `_cache_key`, and drop it whenever that pair changes.

- `_active_cache_key()` resolves the pair from `get_active_context()` / `get_active_detector_context()` — neither takes `_state_lock`, so it is safe to call under `_progress_lock` (the module's lock-ordering rule). Background workers bind both contexts thread-locally via `JobManager`, so a worker resolves the same key its request thread did.
- `_bind_cache_identity()` clears a foreign cache and re-stamps the key. It is called under `_progress_lock` at the top of every entry point that reads or writes the cache: `_ensure_cache`, `is_status_cache_fresh` (and therefore `cached_indicator_history`), `stale_labeling_status`, `invalidate_progress_cache_from`, and `inject_live_model`.
- `clear_progress_cache()` is split into `_clear_cache_data()` (wipe everything, keep the stamp — used by the in-place inclusion-change rebuild) and the public `clear_progress_cache()` (wipe and unbind). External callers are unchanged.
- `compute_labeling_status` releases the lock for the settings-reading Span computation, so it now records the key it computed under and only publishes `_status_snapshot` if the cache is still bound to that key.

The cache still holds one pair at a time — switching back to a detector rebuilds its cache, exactly as the existing register/unregister clears already did — rather than retaining a per-detector cache of trained MLPs and device-resident tensors.

## Tests

New `TestProgressCacheKeyedByDetector` in `tests/detectors/test_multi_detector.py` registers both detectors up front so the switches go through neither register nor unregister:

- switching A → B → A must not merge label sets into either detector's cached steps;
- a cache built for A must not be reported fresh for B's shorter history;
- `stale_labeling_status` must not serve A's snapshot as B's indicators.

All three fail on `dev` and pass with this change. Full `./run-tests.sh` green (7863 passed, 1 skipped).

Closes #2914

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfGGc1p2Q8rfz5iq3KKAok

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfGGc1p2Q8rfz5iq3KKAok)_