### PR TITLE
Fix /api/auto-detect KeyError when no detector keys to the score embedder

### DIFF
--- a/tests/detectors/test_auto_detect_multi_embedder.py
+++ b/tests/detectors/test_auto_detect_multi_embedder.py
@@ -1,0 +1,103 @@
+"""``POST /api/auto-detect`` on a dataset whose score precedence nobody keys to.
+
+Regression for the ``KeyError`` at the top of ``auto_detect``: the route built
+one embedding matrix per *distinct keying embedder* of the Auto-Find detectors,
+then unconditionally read ``matrices[default_score]`` to size the worker cap and
+the achievement count.  On a multi-embedder dataset the score precedence
+(structural ▸ patch ▸ text) can name an embedder no detector keys to - the
+normal case when every Auto-Find detector is type-locked to ``semantic`` while
+the dataset also binds a patch embedder - so that key was never built and the
+whole request 500'd even though every per-detector scoring path would have
+succeeded.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import numpy as np
+import pytest
+
+import app as app_module  # noqa: F401  (ensures routes are registered)
+from vtsearch.settings import get_detectors_dir
+
+DIM = 4
+
+
+@pytest.fixture(autouse=True)
+def clean_detectors_dir():
+    d = get_detectors_dir()
+    if d.is_dir():
+        shutil.rmtree(d)
+    yield
+    d = get_detectors_dir()
+    if d.is_dir():
+        shutil.rmtree(d)
+
+
+def _basis(i: int) -> np.ndarray:
+    return np.eye(DIM, dtype=np.float32)[i]
+
+
+def _trio_medias() -> dict[int, dict]:
+    """Four image medias bound to siglip (text slot) + dinov3_patch (patch slot).
+
+    The score precedence therefore resolves to ``dinov3_patch``, while a
+    ``semantic`` detector keys to ``siglip``.
+    """
+    medias = {}
+    for i in range(1, 5):
+        on = i <= 2
+        medias[i] = {
+            "id": i,
+            "media_type": "image",
+            "embedder": "siglip",
+            "embeddings": {
+                "siglip": _basis(0) if on else _basis(1),
+                "dinov3_patch": _basis(1) if on else _basis(0),
+            },
+            "filename": f"m{i}.png",
+            "md5": f"m{i}",
+            "origin_name": f"m{i}.png",
+            "origin": {"importer": "test", "params": {}},
+        }
+    return medias
+
+
+def _activate_trio_dataset():
+    from vtscore.state.core import DatasetContext, register_context, set_thread_dataset_context
+
+    ctx = DatasetContext("ds-auto-detect-trio")
+    ctx.medias.update(_trio_medias())
+    register_context(ctx)
+    set_thread_dataset_context(ctx)
+    return ctx
+
+
+class TestAutoDetectOnMultiEmbedderDataset:
+    def test_semantic_only_autofind_does_not_500(self, client):
+        """No detector keys to the score-precedence embedder → must still run."""
+        from helpers import setup_trainable_model_in_registry
+        from vtsearch.settings import add_autofind_detector
+
+        ctx = _activate_trio_dataset()
+        assert ctx.routed_embedder("score") == "dinov3_patch"
+
+        snap = dict(ctx.medias)
+        setup_trainable_model_in_registry(
+            "semantic-autofind",
+            good_ids=[1, 2],
+            bad_ids=[3, 4],
+            snap=snap,
+            media_type="image",
+            embedder_type="semantic",
+        )
+        add_autofind_detector("semantic-autofind")
+
+        resp = client.post("/api/auto-detect", json={})
+        assert resp.status_code == 200, resp.get_json()
+        data = resp.get_json()
+        assert data["media_type"] == "image"
+        assert data["detectors_run"] == 1, data
+        result = data["results"]["semantic-autofind"]
+        assert len(result["hits"]) + len(result["negative_hits"]) == len(snap)

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -913,11 +913,17 @@ def auto_detect(body: dict):
         ids, embs = get_embedding_matrix_for_snap(snap, emb)
         matrices[emb] = (ids, torch.from_numpy(embs))
 
-    default_ids, default_X = matrices[default_score]
-    embed_dim = int(default_X.shape[1]) if default_X.ndim > 1 else 0
+    # Size the worker cap off the biggest matrix actually built.  Indexing by
+    # ``default_score`` would KeyError whenever no detector keys to it - the
+    # normal case on a multi-embedder dataset where every Auto-Find detector is
+    # type-locked to a semantic embedder while the score precedence picks the
+    # patch/structural one.  ``matrices`` is never empty here because
+    # ``_compatible_detectors`` aborts 400 when the type gate leaves nothing.
+    cap_rows = max(len(ids) for ids, _X in matrices.values())
+    cap_dim = max(int(X.shape[1]) if X.ndim > 1 else 0 for _ids, X in matrices.values())
     worker_cap = cap_workers_by_memory(
-        len(default_ids),
-        embed_dim,
+        cap_rows,
+        cap_dim,
         max_workers=min(len(detectors_to_run), 8),
     )
     results: dict[str, dict] = {}
@@ -939,7 +945,9 @@ def auto_detect(body: dict):
     if results:
         from vtsearch.achievements import record_find  # noqa: PLC0415
 
-        record_find(len(default_ids) * len(results))
+        # Each detector scored the medias in its own embedder's matrix, so count
+        # them per detector rather than multiplying one matrix's row count out.
+        record_find(sum(len(matrices[det_embedders[name]][0]) for name in results))
 
     response = {
         "media_type": media_type,


### PR DESCRIPTION
`auto_detect` builds one embedding matrix per **distinct keying embedder** of the Auto-Find detectors, then read `matrices[default_score]` — where `default_score = routed_embedder("score")` — to size the worker cap and the achievement count.

Nothing guarantees the score-precedence embedder is among the keys. On a multi-embedder dataset (e.g. siglip + dinov3_patch) the score precedence resolves structural ▸ patch ▸ text = `dinov3_patch`, while a `semantic`-locked Auto-Find detector keys to `siglip` via `keying_embedder_for_snap` → `embedder_of_type` (truthy, so the `or default_score` fallback never fires). If every compatible detector is type-locked away from the score embedder — the normal case for semantic detectors on a patch+semantic dataset — that key was never built and line 916 raised an uncaught `KeyError`, turning the request into a generic 500 even though every per-detector scoring path would have succeeded. The same shape hits slot-less datasets where `default_score` is `None` but the marker is the concrete primary name.

## Changes

- **`vtsearch/routes/detectors/scoring.py`** — size the worker cap off the largest matrix actually built (`max` row count and `max` embed dim across `matrices`) instead of indexing by `default_score`. `matrices` is never empty at that point because `_compatible_detectors` aborts 400 when the type gate leaves nothing to run.
- Count the achievement per detector — `sum(len(matrices[det_embedders[name]][0]) for name in results)` — rather than multiplying one matrix's row count by the detector count. With per-embedder matrices that can hold different id sets, this is also the more accurate number.
- **`tests/detectors/test_auto_detect_multi_embedder.py`** (new) — activates a siglip + dinov3_patch image dataset (score precedence = `dinov3_patch`), registers a `semantic`-locked Auto-Find detector, and asserts `POST /api/auto-detect` returns 200 with the detector run and every media scored. Confirmed to fail against the pre-fix code with exactly `KeyError: 'dinov3_patch'` → 500.

Taking the cap dimensions from the biggest built matrix rather than an arbitrary one keeps the memory cap conservative when the per-embedder matrices differ in width.

`./run-tests.sh`: **ALL 7861 TESTS PASSED** (1 skipped, 1 xfailed).

Closes #2924

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWueQmpWnqng5haQMe2Tp9)_