### PR TITLE
Install the ApiKey provider for CLI `--autodetect --user` runs

### DIFF
--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -443,6 +443,8 @@ class TestCliUserAuth:
         import vtsearch.auth as auth_mod
 
         class _FakeProvider:
+            name = "api_key"
+
             def __init__(self, keys_file=None):
                 pass
 
@@ -453,12 +455,53 @@ class TestCliUserAuth:
                 return "alice"
 
         set_users = []
+        provs = []
         monkeypatch.setattr(auth_mod, "ApiKeyLoginProvider", _FakeProvider)
         monkeypatch.setattr(auth_mod, "set_thread_user", lambda u: set_users.append(u))
+        monkeypatch.setattr(auth_mod, "set_login_provider", lambda p: provs.append(p))
 
         parser = cli_main._build_parser()
         cli_main._authenticate_cli_user(argparse.Namespace(user="alice", api_key="key"), parser)
         assert set_users == ["alice"]
+        # The authenticated provider must be installed process-wide, not merely
+        # used for the key check: get_user_data_dir() consults it to resolve
+        # data/<user>/user_settings.json.
+        assert [type(p) for p in provs] == [_FakeProvider]
+
+    def test_authenticate_installs_provider_so_user_dir_resolves(self, monkeypatch):
+        """After --user auth, get_user_data_dir() resolves per-user paths."""
+        import argparse
+
+        import vtsearch.auth as auth_mod
+
+        class _FakeProvider(auth_mod.LoginProvider):
+            name = "api_key"
+
+            def __init__(self, keys_file=None):
+                pass
+
+            def is_authenticated(self, req):
+                return True
+
+            def get_user(self, req):
+                return "alice"
+
+            def get_user_data_dir(self, username, base_dir):
+                return base_dir / username
+
+        monkeypatch.setattr(auth_mod, "ApiKeyLoginProvider", _FakeProvider)
+        from vtscore.config import DATA_DIR
+
+        original = auth_mod.get_login_provider()
+        try:
+            parser = cli_main._build_parser()
+            cli_main._authenticate_cli_user(argparse.Namespace(user="alice", api_key="key"), parser)
+            assert auth_mod.get_user_data_dir("alice") == DATA_DIR / "alice"
+            # Resolution also works off the thread-local user set by the CLI.
+            assert auth_mod.get_user_data_dir() == DATA_DIR / "alice"
+        finally:
+            auth_mod.set_login_provider(original)
+            auth_mod.set_thread_user(None)
 
     def test_authenticate_wrong_user_errors(self, monkeypatch, capsys):
         import argparse

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -588,7 +588,7 @@ def _authenticate_cli_user(args, parser) -> None:
     if args.user:
         from vtscore.config import DATA_DIR
 
-        from vtsearch.auth import ApiKeyLoginProvider, set_thread_user
+        from vtsearch.auth import ApiKeyLoginProvider, set_login_provider, set_thread_user
 
         if not args.api_key:
             parser.error("--user requires --api-key <key> to authenticate against data/api_keys.json")
@@ -603,6 +603,14 @@ def _authenticate_cli_user(args, parser) -> None:
         _authed = _provider.get_user(_req)
         if _authed != args.user:
             parser.error(f"--api-key authenticates as {_authed!r}, not --user {args.user!r}")
+        # Activate the provider process-wide, not just for the auth check: it is
+        # what get_user_data_dir() consults to resolve per-user paths. Without
+        # this the default provider stays installed and ignores the username, so
+        # data/<user>/user_settings.json would silently read (and write) through
+        # to the default user's flat file -- i.e. the wrong Auto-Find list and
+        # exporter config, under the right username. Mirrors _run_server's
+        # --login api_key setup so a CLI run resolves paths identically.
+        set_login_provider(_provider)
         set_thread_user(args.user)
         cli_progress.emit(
             "authenticated_user",


### PR DESCRIPTION
Closes #2925

## The bug

`_authenticate_cli_user` (`vtsearch/cli_main.py`) constructed an `ApiKeyLoginProvider` purely to verify the bearer key, then dropped it — it called `set_thread_user(args.user)` but never `set_login_provider(...)`, leaving the process on `DefaultLoginProvider`.

Per-user settings paths resolve through the *active* provider: `get_user_data_dir(username)` → `_login_provider.get_user_data_dir(username, DATA_DIR)`, and `DefaultLoginProvider` ignores the username and returns `DATA_DIR` unchanged. So a run started as `python app.py --autodetect --user alice --api-key ...` read `data/user_settings.json` (the *default* user's flat file) instead of `data/alice/user_settings.json` — the file an api_key server writes. The run silently applied the wrong user's Auto-Find list (`autofind_detectors`) and results-exporter config, and any settings writes during the run landed in the default user's file while attributed to alice.

## The fix

Call `set_login_provider(_provider)` on the already-authenticated provider before `set_thread_user`, so a CLI run resolves user paths identically to a server started with `--login api_key`.

## Tests

- Extended `test_authenticate_user_happy_path` to assert the provider is installed process-wide, not merely used for the key check.
- Added `test_authenticate_installs_provider_so_user_dir_resolves`, which drives `_authenticate_cli_user` with a multi-user provider and asserts `get_user_data_dir()` then resolves to `DATA_DIR/alice` — both by explicit username and via the thread-local user the CLI sets. This is the assertion the existing per-user CLI tests could not make: the autouse `isolated_settings` fixture installs `set_user_data_dir_override`, which bypasses `get_user_data_dir` entirely and so masked the production mismatch.

`./run-tests.sh` passes in full (7861 passed, 1 skipped, 1 xfailed).

---
_Generated by [Claude Code](https://claude.ai/code/session_013sJYcf9nqKCUV5brFLTiSo)_