### PR TITLE
Validate every origin param, not just separator-bearing ones

### DIFF
--- a/tests/api/test_path_validation.py
+++ b/tests/api/test_path_validation.py
@@ -450,3 +450,29 @@ class TestExampleSortOriginConfinement:
             assert resp.status_code == 404, resp.get_json()
         finally:
             set_login_provider(original)
+
+    @pytest.mark.parametrize("token", ["..", ".", "~"])
+    def test_separator_free_traversal_token_rejected_multi_user(self, client, tmp_path, token):
+        """Issue #2918: the confinement check used to validate a param only
+        when it contained a path separator, so ``..`` / ``.`` / ``~`` slipped
+        through and built a ``LocalFolderSource`` rooted at (the parent of)
+        the process CWD."""
+        from vtsearch.auth import get_login_provider, set_login_provider
+
+        user_dir = tmp_path / "alice"
+        user_dir.mkdir()
+
+        original = get_login_provider()
+        try:
+            set_login_provider(self._multi_user_provider(user_dir))
+            resp = client.post(
+                "/api/example-sort-origin",
+                json={
+                    "origin": {"importer": "server_folder", "params": {"path": token}},
+                    "key": "app.py",
+                },
+            )
+            assert resp.status_code == 400, resp.get_json()
+            assert "must be within" in resp.get_json()["message"]
+        finally:
+            set_login_provider(original)

--- a/tests_lib/core/test_origin_validation.py
+++ b/tests_lib/core/test_origin_validation.py
@@ -30,6 +30,7 @@ class TestSingleUserMode:
 
         monkeypatch.setattr(paths_mod, "get_file_access_base_dir", lambda: None)
         check_origin_param_confinement({"importer": "server_file", "params": {"path": "/etc/passwd"}})
+        check_origin_param_confinement({"importer": "server_folder", "params": {"path": ".."}})
 
 
 class TestMultiUserConfinement:
@@ -48,8 +49,36 @@ class TestMultiUserConfinement:
             {"importer": "url_download", "params": {"url": "https://media.example.test/a.wav"}}
         )
 
-    def test_pathless_params_ignored(self, confined_base):
+    def test_plain_relative_params_pass(self, confined_base):
+        # Opaque params (a cache filename, a media type, an archive member
+        # key) resolve inside the user's own dir, so validating them is
+        # harmless — the check errs towards validating too much.
         check_origin_param_confinement({"importer": "example_media", "params": {"filename": "abc.wav"}})
+        check_origin_param_confinement(
+            {
+                "importer": "local_archive_member",
+                "params": {"member": "sounds/clip.wav", "media_type": "audio"},
+            }
+        )
+
+    @pytest.mark.parametrize("token", ["..", ".", "~", "~/secrets", "../..", "..\\..", "./data", "a/../.."])
+    def test_separator_free_and_dot_tokens_are_rejected(self, confined_base, token):
+        """Issue #2918: ``..`` / ``.`` / ``~`` carry no path separator, so the
+        old heuristic skipped them entirely and ``LocalFolderSource("..")``
+        got built against the process CWD's parent."""
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            check_origin_param_confinement({"importer": "server_folder", "params": {"path": token}})
+
+    def test_non_string_params_are_ignored(self, confined_base):
+        check_origin_param_confinement(
+            {"importer": "local_archive_member", "params": {"clip_start": 1.5, "thin": True, "n": None}}
+        )
+
+    def test_nested_container_params_are_recursed(self, confined_base):
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            check_origin_param_confinement({"importer": "server_files", "params": {"paths": ["ok.wav", ".."]}})
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            check_origin_param_confinement({"importer": "custom", "params": {"nested": {"path": "/etc/passwd"}}})
 
     def test_dupe_set_members_are_recursed(self, confined_base):
         origin = {

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -49,9 +49,8 @@ def _real_example_origin(ex: dict[str, Any]) -> dict[str, Any] | None:
     ``origin`` key and fall back to the sentinel.
 
     Security: the origin comes from a detector JSON / request body, so its
-    path-like params must pass the same per-user confinement the ingress
-    applies; an origin that fails the check is discarded (sentinel
-    fallback).  URL params are re-validated by the url_download source at
+    params must pass the same per-user confinement the ingress applies; an
+    origin that fails the check is discarded (sentinel fallback).  URL params are re-validated by the url_download source at
     fetch time (``validate_url`` plus per-redirect-hop checks in the
     downloader).
     """

--- a/vtscore/security/origin_validation.py
+++ b/vtscore/security/origin_validation.py
@@ -6,8 +6,16 @@ accept a full origin from a request body or a detector JSON file (the
 ``POST /api/example-sort-origin`` route, a detector's saved media examples),
 and resolving such an origin re-runs filesystem or network access from
 originally user-supplied parameters.  Before an externally-supplied origin
-is used, its path-like params must pass the same per-user confinement the
-ingress applies.
+is used, its params must pass the same per-user confinement the ingress
+applies.
+
+Every string param is checked, not just the ones that *look* like paths:
+an origin's params are untyped, so there is no reliable way to tell a
+filesystem path from an opaque key, and the tokens that matter most
+(``..``, ``.``, ``~``) carry no path separator to key off.  A value that is
+not a path at all is harmless to check — a plain relative name resolves
+inside the user's own directory and passes — so the check errs towards
+validating too much rather than too little.
 
 URL-valued params are deliberately *not* path-checked here: they are
 re-validated with :func:`~vtscore.security.url_validation.validate_url` at
@@ -18,11 +26,21 @@ reject them in multi-user mode.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
+
+#: Path components that make a *relative* value unconfinable.  ``.`` and
+#: ``..`` are resolved against the process CWD by the sources that consume
+#: an origin (``LocalFolderSource(params["path"])`` and friends), not
+#: against the user's data dir, so they escape the per-user boundary even
+#: when they look inert against it (``base_dir/.`` *is* ``base_dir``).
+#: ``~`` is the shell's home-directory token and never names a real
+#: directory inside a user's data dir.
+_UNCONFINABLE_COMPONENTS = frozenset({".", "..", "~"})
 
 
 def check_origin_param_confinement(origin: Any) -> None:
-    """Raise :class:`ValueError` if a path-like origin param escapes the user's allowed dir.
+    """Raise :class:`ValueError` if an origin param escapes the user's allowed dir.
 
     Recurses into ``dupe_set``-style ``members`` so a nested member origin
     cannot smuggle an unvalidated path.  A no-op in single-user mode, where
@@ -31,26 +49,57 @@ def check_origin_param_confinement(origin: Any) -> None:
     """
     from vtscore.security.path_validation import get_file_access_base_dir
 
-    _check(origin, get_file_access_base_dir())
+    base_dir = get_file_access_base_dir()
+    if base_dir is None:
+        return  # single-user / no-auth: every server-readable path is allowed
+    _check(origin, base_dir)
 
 
-def _check(origin: Any, base_dir: Any) -> None:
+def _check(origin: Any, base_dir: Path) -> None:
     if not isinstance(origin, dict):
         return
 
-    from vtscore.security.path_validation import validate_server_filepath
-
     params = origin.get("params")
     if isinstance(params, dict):
-        for val in params.values():
-            if not isinstance(val, str) or ("/" not in val and "\\" not in val):
-                continue
-            if val.startswith(("http://", "https://")):
-                continue  # re-validated by validate_url at fetch time
-            validate_server_filepath(val, base_dir=base_dir)
+        for key, val in params.items():
+            _check_param(str(key), val, base_dir)
 
     members = origin.get("members")
     if isinstance(members, list):
         for member in members:
             if isinstance(member, dict):
                 _check(member.get("origin"), base_dir)
+
+
+def _check_param(key: str, val: Any, base_dir: Path) -> None:
+    """Validate one param value, recursing into nested containers."""
+    if isinstance(val, str):
+        _check_value(key, val, base_dir)
+    elif isinstance(val, dict):
+        for sub_key, sub_val in val.items():
+            _check_param(f"{key}.{sub_key}", sub_val, base_dir)
+    elif isinstance(val, (list, tuple)):
+        for sub_val in val:
+            _check_param(key, sub_val, base_dir)
+
+
+def _check_value(key: str, val: str, base_dir: Path) -> None:
+    """Validate a single string param against the user's allowed dir."""
+    from vtscore.security.path_validation import validate_server_filepath
+
+    if val.startswith(("http://", "https://")):
+        return  # re-validated by validate_url at fetch time
+
+    if not Path(val).is_absolute():
+        # A relative value is only safe if it is a plain forward path: the
+        # consuming source joins it verbatim, so a ``.`` / ``..`` / ``~``
+        # component is resolved somewhere other than the user's data dir.
+        tokens = val.replace("\\", "/").split("/")
+        if any(token in _UNCONFINABLE_COMPONENTS for token in tokens):
+            raise ValueError(
+                f"The origin param '{key}' resolves outside the allowed directory: "
+                f"a relative path must not contain '.', '..' or '~' components. "
+                f"Paths must be within '{base_dir.resolve()}'."
+            )
+
+    validate_server_filepath(val, base_dir=base_dir)

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -288,11 +288,11 @@ def example_sort_server(body: dict):
 
 
 def _validate_origin_param_confinement(origin: dict) -> None:
-    """Abort 400 if a path-like origin param escapes the user's allowed dir.
+    """Abort 400 if an origin param escapes the user's allowed dir.
 
-    The origin dict comes verbatim from the request body, so any path-like
-    param must pass the same confinement check ``_load_from_origin`` applies
-    before it can point a filesystem-backed source (server_folder,
+    The origin dict comes verbatim from the request body, so its params
+    must pass the same confinement check ``_load_from_origin`` applies
+    before they can point a filesystem-backed source (server_folder,
     server_files) outside the user's allowed directory.  A no-op in
     single-user mode, where the base dir is unrestricted.  URL params are
     exempt from the path check: the URL-backed sources re-run


### PR DESCRIPTION
Closes #2918

## The hole

`check_origin_param_confinement` only ran `validate_server_filepath` on a param value that contained `/` or `\`:

```python
if not isinstance(val, str) or ("/" not in val and "\\" not in val):
    continue
```

The path tokens `..`, `.` and `~` carry no separator, so they were skipped entirely. In multi-user mode a request body of `{"importer": "server_folder", "params": {"path": ".."}}` passed the check, `get_source_for_origin` built `LocalFolderSource("..")` — the parent of the process CWD — and `fetch_item` then confined `key` only within *that* directory, so any file under the app root's parent could be fetched, embedded and similarity-ranked.

## The fix

`vtscore/security/origin_validation.py`:

- **Drop the separator heuristic.** Every string param is validated now. Origin params are untyped, so there is no reliable way to tell a filesystem path from an opaque key — and validating too much is harmless, because an opaque relative value (a cache filename, an archive member key like `sounds/clip.wav`, a media type) resolves inside the user's own dir and passes. URL params stay exempt: they're re-checked by `validate_url` at fetch time, and running them through the path validator would spuriously reject them.
- **Reject `.` / `..` / `~` components in relative values.** Dropping the heuristic alone fixes `..` but *not* `.`: `base_dir/.` is `base_dir`, so `validate_server_filepath` would happily pass it — while the consuming source joins the raw value verbatim and resolves it against the process CWD, pointing `LocalFolderSource(".")` at the app root. A relative param must therefore be a plain forward path with no `.`, `..` or `~` component. `./data` and `a/../..` are rejected for the same reason.
- **Recurse into nested dicts/lists** inside `params`, so a path can't hide one level down.
- **Short-circuit single-user mode** (`base_dir is None`), where the base dir is unrestricted — the check is now a genuine no-op there instead of calling the validator per param.

Error messages keep the existing `Paths must be within '<base>'` phrasing, so the route's 400 body is unchanged in shape.

## Tests

- `tests_lib/core/test_origin_validation.py` — parametrised rejection of `..`, `.`, `~`, `~/secrets`, `../..`, `..\..`, `./data`, `a/../..`; plain relative params (cache filename, archive member key) still pass; non-string params ignored; nested list/dict params recursed; single-user mode still lets `..` through.
- `tests/api/test_path_validation.py` — route-level: `POST /api/example-sort-origin` with `path` of `..` / `.` / `~` now 400s in multi-user mode.

Full suite green: `ALL 7873 TESTS PASSED (1 skipped)`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WTg94np2UuWuYFTbZ4wMoL)_