### PR TITLE
Fix Find-mode undo/redo capturing the detector's presumption as a human vote

### DIFF
--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -561,6 +561,103 @@ describe('VoteStateService', () => {
     });
   });
 
+  describe('undo / redo under Find mode', () => {
+    /** Flood-fill the piles with a detector presumption and enter Find. */
+    const enterFind = (good: number[], bad: number[], verified: number[]) => {
+      service.loadVotes();
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good, bad, verified, click_times: {}, learned_scores: {} });
+      service.setFindMode(true);
+    };
+
+    /** What find-view does after a vote lands: mirror the server's verify. */
+    const verifyLikeFindView = (id: number) => {
+      service.setOptimisticVerified(
+        id,
+        service.goodVotes.has(id) || service.badVotes.has(id),
+      );
+    };
+
+    it('undo of a verify-as-bad returns a flood-filled-good item to unverified', () => {
+      // Item 5 is the detector's presumed good, but the human hasn't ruled.
+      enterFind([5], [], []);
+
+      // User clicks Bad: verify-as-bad (not a toggle off the presumption).
+      service.submitToggleVoteAndRecord(5, 'bad', 'foo.wav').subscribe();
+      httpMock
+        .expectOne('/api/medias/5/vote')
+        .flush({ ok: true, state: 'bad', click_time: 1 });
+      verifyLikeFindView(5);
+      expect(service.verifiedIds.has(5)).toBe(true);
+
+      // Cmd-Z must return the item to *unverified*, not record the detector's
+      // flood-filled 'good' as a human label (issue #2922).
+      service.undo();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ target: 'none' });
+      req.flush({ ok: true, state: 'none', click_time: null });
+
+      // ...and the left/right split follows immediately, without a poll.
+      expect(service.verifiedIds.has(5)).toBe(false);
+    });
+
+    it('redo of a verify-good on a flood-filled-good item re-verifies it', () => {
+      enterFind([5], [], []);
+
+      // User clicks Good on the presumed-good item: verifies it as good.
+      service.submitToggleVoteAndRecord(5, 'good', 'foo.wav').subscribe();
+      httpMock
+        .expectOne('/api/medias/5/vote')
+        .flush({ ok: true, state: 'good', click_time: 1 });
+      verifyLikeFindView(5);
+
+      service.undo();
+      httpMock
+        .expectOne('/api/medias/5/vote')
+        .flush({ ok: true, state: 'none', click_time: null });
+      expect(service.verifiedIds.has(5)).toBe(false);
+
+      // Redo must re-apply the click (verify good), not compute 'none' from a
+      // previousPolarity that was really the detector's presumption.
+      service.redo();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ target: 'good' });
+      req.flush({ ok: true, state: 'good', click_time: 2 });
+      expect(service.verifiedIds.has(5)).toBe(true);
+    });
+
+    it('undo restores (and re-verifies) a human vote the user toggled off', () => {
+      // Item 5 is a *verified* good: its membership IS a human decision.
+      enterFind([5], [], [5]);
+
+      // Clicking Good again un-votes it, which un-verifies it too.
+      service.submitToggleVoteAndRecord(5, 'good', 'foo.wav').subscribe();
+      const off = httpMock.expectOne('/api/medias/5/vote');
+      expect(off.request.body).toEqual({ target: 'none' });
+      off.flush({ ok: true, state: 'none', click_time: null });
+      verifyLikeFindView(5);
+      expect(service.verifiedIds.has(5)).toBe(false);
+
+      service.undo();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body).toEqual({ target: 'good' });
+      req.flush({ ok: true, state: 'good', click_time: 2 });
+      expect(service.verifiedIds.has(5)).toBe(true);
+    });
+
+    it('leaves the verified set alone outside Find mode', () => {
+      service.recordVote(5, 'good', 'foo.wav');
+      service.applyOptimisticState(5, 'good');
+
+      service.undo();
+      httpMock
+        .expectOne('/api/medias/5/vote')
+        .flush({ ok: true, state: 'none', click_time: null });
+      expect(service.verifiedIds.size).toBe(0);
+    });
+  });
+
   describe('submitToggleVoteAndRecord (the H26 fix surface)', () => {
     it('records the undo entry only after the POST succeeds', () => {
       service.submitToggleVoteAndRecord(5, 'good', 'foo.wav').subscribe();

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -10,7 +10,10 @@ import { SortingApiService } from './sorting-api.service';
 /**
  * One vote captured for Cmd/Ctrl-Z undo.  `previousPolarity` is the polarity
  * the media had *before* the click that produced this entry, so undo can
- * restore it with a single inverse POST to /api/medias/<id>/vote.
+ * restore it with a single inverse POST to /api/medias/<id>/vote.  It is the
+ * *human* polarity (see {@link VoteStateService.currentState}): in Find mode
+ * an unverified item's flood-filled good/bad membership is the detector's
+ * presumption, not a decision, so it snapshots as `null`.
  */
 export interface UndoEntry {
   mediaId: number;
@@ -251,6 +254,33 @@ export class VoteStateService implements OnDestroy {
   }
 
   /**
+   * Snapshot the polarity and good-vote crop *id* carries before a click, for
+   * the undo stack.  Must be read before the optimistic flip overwrites them.
+   *
+   * The polarity comes from the find-aware {@link currentState}, **not** raw
+   * ``goodVotes`` / ``badVotes`` membership: in Find every item is flood-filled
+   * with the detector's presumption, so an unverified item's membership is not
+   * a human decision.  Snapshotting it as one is what made undo POST the
+   * presumption back as an explicit vote — which the server marks *verified*,
+   * silently writing a label the human never gave — and inverted redo whenever
+   * the clicked direction happened to match the presumption (redo computed
+   * ``'none'`` and un-verified the item the user had just re-verified).
+   * Outside Find this is identical to the raw membership it replaced.
+   */
+  private capturePrevious(id: number): {
+    previousPolarity: 'good' | 'bad' | null;
+    previousRegionBox: number[] | null;
+  } {
+    const state = this.currentState(id);
+    const previousPolarity = state === 'none' ? null : state;
+    const prevBox = this._goodRegionBoxes()[String(id)];
+    return {
+      previousPolarity,
+      previousRegionBox: previousPolarity === 'good' && prevBox ? [...prevBox] : null,
+    };
+  }
+
+  /**
    * Submit a click on a media with the local-view toggle rule.
    *
    * Computes the target from current local state, optimistically applies
@@ -317,16 +347,7 @@ export class VoteStateService implements OnDestroy {
     mediaName: string,
     regionBox?: readonly number[] | null,
   ): Observable<MediaVoteResponse> {
-    const previousPolarity: 'good' | 'bad' | null = this._goodVotes().has(id)
-      ? 'good'
-      : this._badVotes().has(id)
-        ? 'bad'
-        : null;
-    // Snapshot the crop the good vote carried before the click (for undo) and
-    // the crop this click applies (for redo).  Both captured synchronously,
-    // before the optimistic flip clears/overwrites the region-box map.
-    const prevBox = this._goodRegionBoxes()[String(id)];
-    const previousRegionBox = previousPolarity === 'good' && prevBox ? [...prevBox] : null;
+    const { previousPolarity, previousRegionBox } = this.capturePrevious(id);
     const target = this.toggleTargetFor(id, clickedDirection);
     const clickedRegionBox =
       target === 'good' && regionBox && regionBox.length === 4 ? [...regionBox] : null;
@@ -511,13 +532,7 @@ export class VoteStateService implements OnDestroy {
    * are dropped, matching standard editor undo semantics.
    */
   recordVote(mediaId: number, clickedDirection: 'good' | 'bad', mediaName: string): void {
-    const previousPolarity: 'good' | 'bad' | null = this._goodVotes().has(mediaId)
-      ? 'good'
-      : this._badVotes().has(mediaId)
-        ? 'bad'
-        : null;
-    const prevBox = this._goodRegionBoxes()[String(mediaId)];
-    const previousRegionBox = previousPolarity === 'good' && prevBox ? [...prevBox] : null;
+    const { previousPolarity, previousRegionBox } = this.capturePrevious(mediaId);
     this.past.push({
       mediaId,
       clickedDirection,
@@ -531,6 +546,18 @@ export class VoteStateService implements OnDestroy {
     });
     if (this.past.length > UNDO_STACK_MAX) this.past.shift();
     this.future = [];
+  }
+
+  /**
+   * Mirror the verified transition an undo/redo POST triggers server-side, so
+   * the Find left/right split moves with the keystroke instead of lagging a
+   * poll behind.  A vote/redo to good|bad verifies the item; a target of
+   * ``'none'`` un-verifies it (``_mark_verified_if_find_mode``, votes.py).
+   * A no-op outside Find, where nothing is verification-gated.
+   */
+  private mirrorVerified(id: number, target: VoteState): void {
+    if (!this.findMode) return;
+    this.setOptimisticVerified(id, target !== 'none');
   }
 
   canUndo(): boolean {
@@ -559,6 +586,7 @@ export class VoteStateService implements OnDestroy {
     const box = target === 'good' ? entry.previousRegionBox : null;
     this.applyOptimisticState(entry.mediaId, target);
     this.applyOptimisticRegionBox(entry.mediaId, box);
+    this.mirrorVerified(entry.mediaId, target);
     this.mediasApi.vote(entry.mediaId, target, box).subscribe({
       next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
       // rollbackOptimistic (not a bare loadVotes): the pending entries set
@@ -583,6 +611,7 @@ export class VoteStateService implements OnDestroy {
     const box = target === 'good' ? entry.clickedRegionBox : null;
     this.applyOptimisticState(entry.mediaId, target);
     this.applyOptimisticRegionBox(entry.mediaId, box);
+    this.mirrorVerified(entry.mediaId, target);
     this.mediasApi.vote(entry.mediaId, target, box).subscribe({
       next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
       // See undo(): drop the pending entries before reloading server state.


### PR DESCRIPTION
Closes #2922

## The bug

In Find mode the detector flood-fills **every** item into `goodVotes` / `badVotes` with its presumption at the cutoff, so raw set membership is not a human decision — only `verifiedIds` is. That is exactly why `currentState()` treats an *unverified* item as `'none'` under `findMode`.

But `submitToggleVoteAndRecord()` and `recordVote()` snapshotted `previousPolarity` straight off `_goodVotes()` / `_badVotes()`, while the toggle target on the very next line went through the find-aware `currentState()`. The two state models disagreed on any unverified item:

- **Undo mislabeled.** Item 5 is flood-filled good but unverified; the user clicks Bad to verify-as-bad (target `'bad'`, correct). Cmd-Z then used `previousPolarity = 'good'` — the detector's presumption, not a human vote — and POSTed `'good'`, which the server records as an explicit label *and* marks verified (`_mark_verified_if_find_mode`, `vtscore/state/votes.py`). The item ended up VERIFIED GOOD instead of returning to unverified, silently writing a label the human never gave into the detector's labelset.
- **Redo inverted.** For a verify-good click on a flood-filled-good item, `redo()` computed `previousPolarity ('good') === clickedDirection ('good')` → target `'none'`, so "redo" *un-verified* the item the user had just re-verified.

Separately, `undo()` / `redo()` never mirrored the verified transition their POST triggers server-side, so the Find left/right split stayed stale until the next 2s poll.

Undo/redo are reachable in Find via Cmd-Z / Cmd-Shift-Z (`center-panel.component.ts`), and the spec never exercised undo under `findMode`.

## The fix

- Both captures now go through the find-aware `currentState()`, via a new shared `capturePrevious()` helper that returns `{ previousPolarity, previousRegionBox }`. Outside Find this is byte-for-byte the same behaviour as the raw membership check it replaces; inside Find an unverified item correctly snapshots as `null`, so undo un-votes it back to unverified and redo replays the click.
- `undo()` / `redo()` call a new `mirrorVerified(id, target)`, which under `findMode` does `setOptimisticVerified(id, target !== 'none')` — matching the server's `_mark_verified_if_find_mode` rule, so the left→right move follows the keystroke instead of a poll. No-op outside Find.
- The region-box snapshot rides along on the same `currentState()` fix: an unverified flood-filled-good item no longer replays a crop as if it were a human good vote.

## Tests

New `undo / redo under Find mode` block in `vote-state.service.spec.ts` covering the two failure modes from the issue plus the cases that must keep working:

- undo of a verify-as-bad on a flood-filled-good item POSTs `target: 'none'` and drops the item from `verifiedIds`;
- redo of a verify-good on a flood-filled-good item POSTs `target: 'good'` and re-verifies (previously `'none'`);
- undo of a genuine un-vote on a *verified* good restores `'good'` and re-verifies it;
- outside Find, undo leaves `verifiedIds` untouched.

`./run-tests.sh` is green: 7860 passed / 1 skipped, frontend build + audit + 1964 Vitest tests OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNyTmphHS4sWxsg2NtiSjb)_