### PR TITLE
Drop late tile responses from a superseded projection

### DIFF
--- a/frontend/src/app/services/tile-cache.service.spec.ts
+++ b/frontend/src/app/services/tile-cache.service.spec.ts
@@ -98,6 +98,55 @@ describe('TileCacheService', () => {
     expect(service.getCached(2, 1, 1)).toBeNull();
   });
 
+  it('drops a tile that arrives after the projection switched', () => {
+    const pending = new Subject<TilePayload>();
+    getTile.mockReturnValueOnce(pending.asObservable());
+    service.setProjectionId('p1');
+    // Fire-and-forget subscriber, exactly like the canvas/minimap draw paths.
+    service.getTile(2, 1, 3)?.subscribe();
+
+    service.setProjectionId('p2');
+    const loaded: TilePayload[] = [];
+    service.tileLoaded$.subscribe((t) => loaded.push(t));
+    // p1's response finally lands, after the switch cleared the cache.
+    pending.next({
+      level: 2,
+      tx: 1,
+      ty: 3,
+      cells: [{ q: 9, r: 9, cx: 1, cy: 1, count: 1, rep_id: 42 }],
+    });
+
+    // p2 must not see p1's cells, and must not be told to redraw for them.
+    expect(service.getCached(2, 1, 3)).toBeNull();
+    expect(loaded).toEqual([]);
+    // The tile is still fetchable for p2 (the stale put did not block it).
+    let fresh: TilePayload | undefined;
+    service.getTile(2, 1, 3)?.subscribe((t) => (fresh = t));
+    expect(fresh).toEqual(payload(2, 1, 3));
+  });
+
+  it('drops a tile that arrives after clear()', () => {
+    const pending = new Subject<TilePayload>();
+    getTile.mockReturnValueOnce(pending.asObservable());
+    service.setProjectionId('p1');
+    service.getTile(1, 0, 0)?.subscribe();
+
+    service.clear();
+    pending.next(payload(1, 0, 0));
+
+    service.setProjectionId('p1');
+    expect(service.getCached(1, 0, 0)).toBeNull();
+  });
+
+  it('keys tiles by subset so the full and subset projections cannot collide', () => {
+    service.setProjectionId('p1');
+    service.getTile(2, 1, 1)?.subscribe();
+    expect(service.getCached(2, 1, 1)).not.toBeNull();
+
+    service.setSubset(true);
+    expect(service.getCached(2, 1, 1)).toBeNull();
+  });
+
   it('getCached returns null for an uncached tile and the tile once cached', () => {
     service.setProjectionId('p1');
     expect(service.getCached(4, 0, 0)).toBeNull();

--- a/frontend/src/app/services/tile-cache.service.ts
+++ b/frontend/src/app/services/tile-cache.service.ts
@@ -73,9 +73,15 @@ export class TileCacheService {
 
     if (!this.projectionId) return null;
 
+    // Identity of the view this request belongs to, captured now. Subscribers
+    // are fire-and-forget (the canvas and minimap never unsubscribe), so a
+    // response can land long after a projection switch cleared the cache; the
+    // guard below drops it instead of caching another projection's cells.
+    const token = this.viewToken();
     const req$ = this.projectionApi.getTile(level, tx, ty, this.subset, this.cacheToken()).pipe(
       tap((tile) => {
         this.inflight.delete(key);
+        if (this.viewToken() !== token) return;
         this.put(key, tile);
         this.tileLoaded$.next(tile);
       }),
@@ -113,7 +119,19 @@ export class TileCacheService {
   }
 
   private key(level: number, tx: number, ty: number): string {
-    return `${this.contentVersion}:${level}:${tx}:${ty}`;
+    return `${this.viewToken()}:${level}:${tx}:${ty}`;
+  }
+
+  /**
+   * Full identity of what a tile's cells depict: layout (``projectionId``),
+   * membership (``contentVersion``) and which projection the tiles come from
+   * (``subset``). Keying on all three means a tile fetched under one view can
+   * never be read back under another, even if a stale ``put`` slips through —
+   * ``setProjectionId`` resets ``contentVersion`` to 0, so the version alone
+   * collides across projections.
+   */
+  private viewToken(): string {
+    return `${this.projectionId}:${this.contentVersion}:${this.subset ? 's' : 'f'}`;
   }
 
   /** Cache-bust token for the tile URL: ``<projection_id>:<content_version>``. */


### PR DESCRIPTION
Closes #2927

## The bug

`TileCacheService` keyed cache entries by `contentVersion` only:

```ts
return `${this.contentVersion}:${level}:${tx}:${ty}`;
```

but `setProjectionId` resets `contentVersion` to 0 on every switch, so projections A and B almost always shared the same key namespace. Meanwhile the canvas (`browse-canvas.component.ts:1389`) and minimap (`browse-minimap.component.ts:265`) subscribe fire-and-forget, so nothing cancels an in-flight tile request when the user switches datasets or moves between Find-subset and full browse.

The result: A's response lands after `setProjectionId(B)` cleared the cache, and `tap` runs `put("0:2:1:3", tileA)` — caching A's cells under exactly the key B reads for that coordinate. The canvas then paints A's bins (wrong positions, wrong rep/member ids) inside B, and because `getCached` hits, the real B tile is never fetched. The poison is sticky: levels 0–2 are exempt from eviction entirely. The same race fires across unmount/remount, since the service is a root singleton and `ngOnDestroy`'s `clear()` can be followed by a late `put`.

## The fix

- Capture the full **view token** (`projectionId` + `contentVersion` + `subset`) when the request is created, and drop the response in `tap` if it no longer matches. A superseded tile is neither cached nor pushed onto `tileLoaded$` (so it can't trigger a redraw either). `inflight.delete` still runs unconditionally.
- Use that same token as the cache-key prefix, so even a stale `put` that somehow slipped through would land in a dead namespace instead of colliding with the live projection. Folding `subset` in also closes the (narrower) full-vs-subset collision.

`cacheToken()` — the `v=` URL cache-bust param — is unchanged.

## Tests

Three new cases in `tile-cache.service.spec.ts`: a late response after a projection switch (asserts no poisoned entry, no `tileLoaded$` emission, and that the correct tile is still fetchable afterwards), a late response after `clear()`, and subset/full key isolation.

`./run-tests.sh` — 7860 passed, 1 skipped. Frontend gate green (build, audit, 1963 Vitest tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_018cMBXV1gkxk1mxbFe6Jmsm)_