### PR TITLE
Fix AB-BA deadlock: settings getters no longer hold _settings_lock across ensure-loaded

### DIFF
--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -549,6 +549,196 @@ class TestSlowSettingsIODoesNotBlockOthers:
         assert not errors, f"Threads raised: {errors!r}"
 
 
+def _settings_lock_free_for_other_threads(timeout: float = 3.0) -> bool:
+    """Report whether a *different* thread can take ``_settings_lock`` right now.
+
+    ``_settings_lock`` is an ``RLock``, so the calling thread can always
+    re-acquire it and can't tell whether it already owns it.  Probing from a
+    fresh thread is what makes "is this lock held across the call?"
+    observable.
+    """
+    result: list[bool] = []
+
+    def probe():
+        got = _settings_mod._settings_lock.acquire(timeout=timeout)
+        result.append(got)
+        if got:
+            _settings_mod._settings_lock.release()
+
+    t = threading.Thread(target=probe, daemon=True)
+    t.start()
+    t.join(timeout + 2)
+    return bool(result) and result[0]
+
+
+class TestGettersDoNotHoldSettingsLockAcrossFileIO:
+    """Regression for the AB-BA deadlock in issue #2913.
+
+    The canonical lock order is **file lock -> settings lock**.  Every
+    settings *getter* used to do the reverse: ``with _settings_lock:
+    _read_value(key)``, and ``_read_value`` calls ``_ensure_server_loaded`` /
+    ``_ensure_user_loaded``, which on a cold cache take the cross-process
+    ``file_lock`` (and on a due sync the per-user sync lock plus, via the
+    setters ``_apply_settings`` invokes, ``file_lock`` again).  A concurrent
+    writer taking ``file_lock`` then ``settings_lock`` deadlocked against it,
+    permanently freezing the single-worker gunicorn deployment.
+
+    The tests below assert the invariant directly: while a settings read is
+    inside ``file_lock`` (or inside a settings source's ``load()``), an
+    unrelated thread must still be able to take ``_settings_lock``.
+    """
+
+    def _record_lock_state_inside_file_lock(self, monkeypatch) -> list[bool]:
+        """Instrument ``file_lock`` to probe ``_settings_lock`` on every entry."""
+        import contextlib
+
+        observations: list[bool] = []
+        real_file_lock = _settings_store_mod.file_lock
+
+        @contextlib.contextmanager
+        def probing_file_lock(path):
+            with real_file_lock(path):
+                observations.append(_settings_lock_free_for_other_threads())
+                yield
+
+        monkeypatch.setattr(_settings_store_mod, "file_lock", probing_file_lock)
+        return observations
+
+    def test_cold_scalar_getter_does_not_hold_settings_lock(self, monkeypatch, isolated_settings, tmp_path):
+        """A user-tier getter on a cold cache must not hold the lock across file I/O."""
+        _settings_mod.set_user_data_dir_override(tmp_path)
+        try:
+            _settings_mod.reset()  # cold server + user caches
+            observations = self._record_lock_state_inside_file_lock(monkeypatch)
+
+            _settings_mod.get_volume()
+
+            assert observations, "the cold read never entered file_lock; the test no longer exercises the path"
+            assert all(observations), "a getter held _settings_lock inside file_lock; issue #2913 has regressed"
+        finally:
+            _settings_mod.set_user_data_dir_override(None)
+
+    def test_cold_per_side_getter_does_not_hold_settings_lock(self, monkeypatch, isolated_settings, tmp_path):
+        """``_get_dict`` (the per-media-type per-side getters) has the same shape."""
+        _settings_mod.set_user_data_dir_override(tmp_path)
+        try:
+            _settings_mod.reset()
+            observations = self._record_lock_state_inside_file_lock(monkeypatch)
+
+            _settings_mod.get_grid_icon_size_left()
+
+            assert observations, "the cold read never entered file_lock"
+            assert all(observations), "_get_dict held _settings_lock inside file_lock; issue #2913 has regressed"
+        finally:
+            _settings_mod.set_user_data_dir_override(None)
+
+    def test_cold_dir_getter_does_not_hold_settings_lock(self, monkeypatch, isolated_settings, tmp_path):
+        """``_get_dir`` (server-tier directory settings) has the same shape."""
+        _settings_mod.set_user_data_dir_override(tmp_path)
+        try:
+            _settings_mod.reset()
+            observations = self._record_lock_state_inside_file_lock(monkeypatch)
+
+            _settings_mod.get_saved_datasets_dir()
+
+            assert observations, "the cold read never entered file_lock"
+            assert all(observations), "_get_dir held _settings_lock inside file_lock; issue #2913 has regressed"
+        finally:
+            _settings_mod.set_user_data_dir_override(None)
+
+    def test_getter_does_not_hold_settings_lock_across_source_load(
+        self, monkeypatch, isolated_settings, tmp_path
+    ):
+        """With a settings source configured, the sync fires *inside* a getter.
+
+        The source's ``load()`` is network/file I/O of unbounded duration, and
+        the setters it feeds re-enter ``file_lock``.  Holding the global
+        settings lock across it both deadlocks (issue #2913) and stalls every
+        other user's settings reads.
+        """
+        import json
+
+        from vtsearch.settings_io.sources.server_json_file import ServerFileSettingsSource
+
+        _settings_mod.set_user_data_dir_override(tmp_path)
+        try:
+            source_file = tmp_path / "source.settings.json"
+            source_file.write_text(json.dumps({"volume": 0.25}))
+            _settings_mod.set_settings_source_config(
+                {"source_name": "server_json_file", "field_values": {"filepath": str(source_file)}}
+            )
+
+            observations: list[bool] = []
+            real_do_load = ServerFileSettingsSource._do_load
+
+            def probing_do_load(self, field_values):
+                observations.append(_settings_lock_free_for_other_threads())
+                return real_do_load(self, field_values)
+
+            monkeypatch.setattr(ServerFileSettingsSource, "_do_load", probing_do_load)
+
+            # Force a real sync-from-source pass on the next read: drop the
+            # in-memory sync state *and* the on-disk dedup marker (which would
+            # otherwise let ``_adopt_sync_marker_if_current`` skip the load).
+            _settings_mod._sync_state.pop("default", None)
+            _settings_store_mod._sync_marker_path(_settings_mod._user_settings_path("default")).unlink(
+                missing_ok=True
+            )
+
+            _settings_mod.get_theme()
+
+            assert observations, "the getter never ran a sync-from-source load"
+            assert all(observations), "a getter held _settings_lock across source.load(); issue #2913 has regressed"
+        finally:
+            _settings_mod.set_user_data_dir_override(None)
+
+    def test_concurrent_cold_readers_and_writers_do_not_deadlock(self, isolated_settings, tmp_path):
+        """The end-to-end shape from the issue: cold readers racing writers.
+
+        Threads are daemons and joined with a timeout so a regression fails
+        the test instead of hanging the suite forever.
+        """
+        _settings_mod.set_user_data_dir_override(tmp_path)
+        try:
+            _settings_mod.reset()
+            errors: list[BaseException] = []
+            start = threading.Barrier(8)
+
+            def reader():
+                try:
+                    start.wait(timeout=10)
+                    for _ in range(20):
+                        _settings_mod.get_volume()
+                        _settings_mod.get_saved_datasets_dir()
+                except BaseException as exc:  # pragma: no cover - surfaced via errors
+                    errors.append(exc)
+
+            def writer(value):
+                try:
+                    start.wait(timeout=10)
+                    for _ in range(20):
+                        _settings_mod.set_theme(value)
+                except BaseException as exc:  # pragma: no cover - surfaced via errors
+                    errors.append(exc)
+
+            themes = ["light", "dark"]
+            threads = []
+            for i in range(8):
+                if i % 2 == 0:
+                    threads.append(threading.Thread(target=reader, daemon=True))
+                else:
+                    threads.append(threading.Thread(target=writer, args=(themes[i % len(themes)],), daemon=True))
+            for th in threads:
+                th.start()
+            for th in threads:
+                th.join(timeout=30)
+            alive = [th for th in threads if th.is_alive()]
+            assert not alive, f"{len(alive)} thread(s) deadlocked; issue #2913 has regressed"
+            assert not errors, f"Threads raised: {errors!r}"
+        finally:
+            _settings_mod.set_user_data_dir_override(None)
+
+
 class TestProgressLock:
     """Verify that _progress_lock exists and is an RLock."""
 

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -646,9 +646,7 @@ class TestGettersDoNotHoldSettingsLockAcrossFileIO:
         finally:
             _settings_mod.set_user_data_dir_override(None)
 
-    def test_getter_does_not_hold_settings_lock_across_source_load(
-        self, monkeypatch, isolated_settings, tmp_path
-    ):
+    def test_getter_does_not_hold_settings_lock_across_source_load(self, monkeypatch, isolated_settings, tmp_path):
         """With a settings source configured, the sync fires *inside* a getter.
 
         The source's ``load()`` is network/file I/O of unbounded duration, and
@@ -681,9 +679,7 @@ class TestGettersDoNotHoldSettingsLockAcrossFileIO:
             # in-memory sync state *and* the on-disk dedup marker (which would
             # otherwise let ``_adopt_sync_marker_if_current`` skip the load).
             _settings_mod._sync_state.pop("default", None)
-            _settings_store_mod._sync_marker_path(_settings_mod._user_settings_path("default")).unlink(
-                missing_ok=True
-            )
+            _settings_store_mod._sync_marker_path(_settings_mod._user_settings_path("default")).unlink(missing_ok=True)
 
             _settings_mod.get_theme()
 
@@ -692,51 +688,14 @@ class TestGettersDoNotHoldSettingsLockAcrossFileIO:
         finally:
             _settings_mod.set_user_data_dir_override(None)
 
-    def test_concurrent_cold_readers_and_writers_do_not_deadlock(self, isolated_settings, tmp_path):
-        """The end-to-end shape from the issue: cold readers racing writers.
-
-        Threads are daemons and joined with a timeout so a regression fails
-        the test instead of hanging the suite forever.
-        """
-        _settings_mod.set_user_data_dir_override(tmp_path)
-        try:
-            _settings_mod.reset()
-            errors: list[BaseException] = []
-            start = threading.Barrier(8)
-
-            def reader():
-                try:
-                    start.wait(timeout=10)
-                    for _ in range(20):
-                        _settings_mod.get_volume()
-                        _settings_mod.get_saved_datasets_dir()
-                except BaseException as exc:  # pragma: no cover - surfaced via errors
-                    errors.append(exc)
-
-            def writer(value):
-                try:
-                    start.wait(timeout=10)
-                    for _ in range(20):
-                        _settings_mod.set_theme(value)
-                except BaseException as exc:  # pragma: no cover - surfaced via errors
-                    errors.append(exc)
-
-            themes = ["light", "dark"]
-            threads = []
-            for i in range(8):
-                if i % 2 == 0:
-                    threads.append(threading.Thread(target=reader, daemon=True))
-                else:
-                    threads.append(threading.Thread(target=writer, args=(themes[i % len(themes)],), daemon=True))
-            for th in threads:
-                th.start()
-            for th in threads:
-                th.join(timeout=30)
-            alive = [th for th in threads if th.is_alive()]
-            assert not alive, f"{len(alive)} thread(s) deadlocked; issue #2913 has regressed"
-            assert not errors, f"Threads raised: {errors!r}"
-        finally:
-            _settings_mod.set_user_data_dir_override(None)
+    # Deliberately no end-to-end "race cold readers against writers" test here.
+    # The regression it would catch is a real deadlock, which wedges
+    # ``_settings_lock`` for the rest of the process: the racing threads can
+    # never be unwedged, so every later test that touches settings (and the
+    # ``reset_state`` fixture itself) hangs too. That turns a regression into a
+    # suite-wide hang instead of a failure. The probing tests above assert the
+    # same invariant deterministically, fail in milliseconds, and leave no
+    # poisoned lock behind.
 
 
 class TestProgressLock:

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -436,23 +436,52 @@ def _read_value(key: str) -> Any:
 
     Routes to the server tier or the current user's tier based on *key*.
     The caller is responsible for casting/coercion.
+
+    Takes ``_settings_lock`` itself, and *only* around the cache-dict
+    reads. The ``_ensure_*_loaded`` calls run outside it because they take
+    the cross-process ``file_lock`` on a cold cache (and the per-user sync
+    RLock plus, via ``_apply_settings``'s setters, ``file_lock`` again on a
+    due sync), and the canonical order is file_lock → settings_lock.
+    Callers must therefore **not** hold ``_settings_lock`` when calling
+    this - doing so inverts the order and deadlocks against any concurrent
+    writer (see ``ensure_server_loaded``'s docstring). Keeping the lock out
+    of the ensure calls also means a slow ``source.load()`` no longer
+    stalls every other settings read.
+
+    The caches are re-read from the store *after* the ensure calls rather
+    than using their return values, because a concurrent writer replaces
+    the cache dict wholesale (``mutate_*_locked``) - the returned dict can
+    be the pre-write one.
     """
     if key in _SERVER_KEYS:
-        return _ensure_server_loaded().get(key, _server_defaults()[key])
+        _ensure_server_loaded()
+        with _settings_lock:
+            server_cache = _store.server_cache or {}
+            if key in server_cache:
+                return server_cache[key]
+        return _server_defaults()[key]
     from vtsearch.auth import get_current_user
 
     username = get_current_user()
-    user_cache = _ensure_user_loaded(username)
-    if key in user_cache:
-        return user_cache[key]
+    _ensure_user_loaded(username)
     # Default-user read-through: the single-user GUI and the CLI ``--settings``
     # flat file carry these Auto-Find keys in the server settings file. Honor
     # them for the built-in "default" user when not set in its own file, so
     # those workflows keep working without making the setting truly server-wide.
-    if username == "default" and key in _DEFAULT_USER_FALLBACK_KEYS:
-        server_cache = _ensure_server_loaded()
-        if key in server_cache:
-            return server_cache[key]
+    # ``_ensure_user_loaded`` already loaded the server tier, so this is a
+    # cache hit - it stays outside the lock anyway so the cold path can never
+    # invert the order.
+    fallback_to_server = username == "default" and key in _DEFAULT_USER_FALLBACK_KEYS
+    if fallback_to_server:
+        _ensure_server_loaded()
+    with _settings_lock:
+        user_cache = _user_caches.get(username, {})
+        if key in user_cache:
+            return user_cache[key]
+        if fallback_to_server:
+            server_cache = _store.server_cache or {}
+            if key in server_cache:
+                return server_cache[key]
     return _user_defaults().get(key)
 
 
@@ -657,8 +686,11 @@ def _validate_field(model: type, key: str, value: Any) -> Any:
 
 def _make_scalar_accessors(model: type, key: str):
     def getter():
-        with _settings_lock:
-            raw = _read_value(key)
+        # ``_read_value`` takes ``_settings_lock`` itself, around the cache
+        # read only. Wrapping the call in the lock here would put the
+        # ensure-loaded file/sync locks underneath it and invert the
+        # canonical file_lock → settings_lock order.
+        raw = _read_value(key)
         try:
             return _validate_field(model, key, raw)
         except ValueError:
@@ -773,8 +805,9 @@ def _make_per_side_setting(  # noqa: C901
     def _get_dict(key: str) -> dict[str, Any]:
         side = key[len(key_base) + 1 :]
         default_val = defaults.get(side, next(iter(defaults.values())))
-        with _settings_lock:
-            raw = _read_value(key)
+        # Unlocked: ``_read_value`` locks its own cache read (see
+        # ``_make_scalar_accessors.getter``).
+        raw = _read_value(key)
         types = _valid_media_types()
         if not isinstance(raw, dict):
             return {tid: default_val for tid in types}
@@ -1342,9 +1375,15 @@ def filter_semantic_only_embedder_dicts(embedder_dicts: Iterable[dict[str, Any]]
 
 
 def _get_dir(key: str) -> Path:
-    """Return a server-tier directory path setting as a :class:`~pathlib.Path`."""
+    """Return a server-tier directory path setting as a :class:`~pathlib.Path`.
+
+    ``_ensure_server_loaded`` runs outside ``_settings_lock`` (it takes the
+    server ``file_lock`` on a cold cache); only the cache read is locked.
+    """
+    _ensure_server_loaded()
     with _settings_lock:
-        raw = _ensure_server_loaded().get(key, _server_defaults()[key])
+        server_cache = _store.server_cache or {}
+        raw = server_cache.get(key, _server_defaults()[key])
     return Path(raw)
 
 

--- a/vtsearch/settings_store.py
+++ b/vtsearch/settings_store.py
@@ -343,9 +343,16 @@ class UserSettingsStore:
         from the deployment default rather than the user's own key.
 
         Reads the user cache under ``settings_lock``; the caller is
-        responsible for having loaded it (every sync path does). Safe to call
-        while already holding ``settings_lock`` (it is reentrant) and while
-        holding the per-user sync lock.
+        responsible for having loaded it (every sync path does).
+
+        **Must not be called while holding ``settings_lock``.** The
+        deployment-default read goes through a server-tier settings
+        accessor, which calls :meth:`ensure_server_loaded` and so may take
+        the server ``file_lock`` on a cold cache - holding ``settings_lock``
+        across that inverts the canonical file_lock -> settings_lock order.
+        The lock is reentrant, so the inversion would not be caught locally;
+        it would deadlock against a concurrent writer. Holding the per-user
+        sync lock is fine.
         """
         with self._lock:
             user_cfg = self._user_caches.get(username, {}).get("settings_source")
@@ -432,9 +439,20 @@ class UserSettingsStore:
             # Re-entrance guard: a setter inside ``_apply_settings`` re-enters
             # this function while the outer call holds the sync lock.  Skip
             # the sync path so we don't recurse or fire another peek probe.
+            # This is a same-thread guard (the thread running the import is
+            # the one that set the flag), so checking it here - before the
+            # lock is dropped below - still catches every re-entry.
             if username in self._syncing:
                 return cache
-            cfg, _inherited = self.resolve_settings_source(username)
+
+        # ``resolve_settings_source`` reads the deployment default through a
+        # server-tier accessor, so it runs *outside* ``settings_lock`` to keep
+        # the canonical file_lock -> settings_lock order.
+        cfg, _inherited = self.resolve_settings_source(username)
+        with self._lock:
+            # Re-read: a concurrent writer may have swapped the cache dict
+            # while the lock was released.
+            cache = self._user_caches.get(username, cache)
             if cfg is None:
                 return cache
             state = self._sync_state.get(username)
@@ -470,11 +488,14 @@ class UserSettingsStore:
         Refreshes ``last_check_monotonic`` on the no-sync paths so the
         freshness probe is rate-limited even when state is being mutated.
         """
-        with self._lock:
-            state = self._sync_state.get(username)
-            cache_cfg, _inherited = self.resolve_settings_source(username)
+        # Resolved outside ``settings_lock``: the resolver reads the
+        # deployment default through a server-tier accessor (file lock on a
+        # cold cache).
+        cache_cfg, _inherited = self.resolve_settings_source(username)
         if cache_cfg is None:
             return False
+        with self._lock:
+            state = self._sync_state.get(username)
 
         now = time.monotonic()
 
@@ -588,12 +609,14 @@ class UserSettingsStore:
         (``last_sync_succeeded`` stays ``False``) so the slow path retries
         once the rate-limit window elapses.
         """
-        with self._lock:
-            cache_cfg, _inherited = self.resolve_settings_source(username)
-            state = self._sync_state.setdefault(username, UserSyncState())
-            dirty_snapshot = set(state.dirty_keys)
+        # Resolved outside ``settings_lock`` (see
+        # :meth:`resolve_settings_source`).
+        cache_cfg, _inherited = self.resolve_settings_source(username)
         if cache_cfg is None:
             return
+        with self._lock:
+            state = self._sync_state.setdefault(username, UserSyncState())
+            dirty_snapshot = set(state.dirty_keys)
 
         from vtsearch.settings_io.sources import get_settings_source
 


### PR DESCRIPTION
Closes #2913

## The bug

The canonical lock order is **file lock → settings lock**, documented in `vtsearch/settings_store.py`'s module docstring and enforced by every writer. `ensure_server_loaded`'s own docstring says it "must never be called while already holding `settings_lock`".

Every autogenerated settings getter did exactly that:

```python
def getter():
    with _settings_lock:
        raw = _read_value(key)
```

`_read_value` calls `_ensure_server_loaded()` / `_ensure_user_loaded(username)`, which on a cold cache take the cross-process `file_lock`, and on a due sync take the per-user sync RLock and run `_run_sync_from_source` → `_apply_settings` → setters → `_mutate_user_locked` → `file_lock`. `_get_dict` (per-side settings) and `_get_dir` had the same shape.

Concrete hang, no settings source needed: on a fresh process, thread A calls `get_volume()` → holds `_settings_lock`, enters cold `ensure_server_loaded` → blocks acquiring the server path's non-reentrant in-process lock; thread B calls `set_theme(...)` → `_ensure_user_loaded` (no settings lock) → cold `_load_and_migrate_server` acquires the file lock, then blocks on `settings_lock` that A holds. Both hang forever, and gunicorn runs a single worker with `timeout=0`, so the app freezes permanently. With a source configured the window recurs on every source version change.

## The fix

`_read_value` now owns its locking and does it in the canonical order: the `_ensure_*_loaded` calls run **outside** `_settings_lock`, and the lock is taken only around the cache-dict reads — the same shape `get_user_settings`, `get_all`, and `achievements.get_full_state` already used. The three call sites (autogenerated getters, `_get_dict`, `_get_dir`) no longer wrap it in the lock.

The caches are re-read from the store *after* the ensure calls rather than using their return values, because a concurrent `mutate_*_locked` replaces the cache dict wholesale — the returned dict can be the pre-write one.

Also fixed the same inversion in the store: `resolve_settings_source` reads the deployment-wide default through a server-tier accessor (so it can reach `file_lock` on a cold cache), but three of its call sites — `ensure_user_loaded`, `_needs_sync_from_source`, `_run_sync_from_source` — held `settings_lock` across it. `settings_lock` is reentrant, so the inversion was invisible locally. These were safe only by the accident that `ensure_user_loaded` warms the server cache first; now they resolve outside the lock, and the docstring states the requirement instead of claiming the call is lock-safe.

Beyond the deadlock, this also stops a getter from holding the *global* settings lock across a source's `load()` network/file I/O, which stalled every settings read for every user.

## Tests

Four deterministic probes in `tests/integration/test_thread_safety.py` assert the invariant directly: while a settings read is inside `file_lock` (or inside a source's `load()`), an unrelated thread must still be able to take `_settings_lock`. The probe runs on a fresh thread because an `RLock` can't report whether the calling thread already owns it. Coverage: the autogenerated scalar getter, `_get_dict`, and `_get_dir` on a cold cache, plus a source-configured read whose sync pass fires inside the getter.

All four fail with the fix reverted (checked). There is deliberately no end-to-end "race cold readers against writers" test — that regression is a real deadlock, which wedges `_settings_lock` for the rest of the process and turns a failure into a suite-wide hang; a note in the file records why.

`./run-tests.sh`: **7864 passed, 1 skipped**.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133cHwAhfAsMhBwQf3Sh8Kz)_