### PR TITLE
Signalize plain-field state in four zoneless-broken components

### DIFF
--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.html
@@ -38,15 +38,15 @@
       Labels that disagree across sources are dropped.
     </p>
 
-    @if (error) {
-      <p class="error-text">{{ error }}</p>
+    @if (error()) {
+      <p class="error-text">{{ error() }}</p>
     }
   </form>
 
   <div modal-footer>
-    <button type="button" class="btn btn--secondary" [disabled]="submitting" (click)="close()" title="Discard and close the dialog">Cancel</button>
+    <button type="button" class="btn btn--secondary" [disabled]="submitting()" (click)="close()" title="Discard and close the dialog">Cancel</button>
     <button type="button" class="btn btn--primary" [disabled]="!canSubmit" (click)="submit()" title="Combine the selected detectors into a new one">
-      {{ submitting ? 'Combining…' : 'Combine' }}
+      {{ submitting() ? 'Combining…' : 'Combine' }}
     </button>
   </div>
 </vt-modal>

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.spec.ts
@@ -1,0 +1,122 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+
+import { CombineDetectorsModalComponent } from './combine-detectors-modal.component';
+import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
+import type { DetectorCombineResponse } from '../../../generated/api-client/models/detector-combine-response';
+import { DetectorRegistryEntry } from '../../../generated/api-client/models/detector-registry-entry';
+import { configureZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
+
+describe('CombineDetectorsModalComponent', () => {
+  let component: CombineDetectorsModalComponent;
+  let fixture: ComponentFixture<CombineDetectorsModalComponent>;
+  /** Controllable stand-in for the combine request. */
+  let combine$: Subject<DetectorCombineResponse>;
+
+  const source = (name: string, numTraining: number): DetectorRegistryEntry =>
+    ({ name, num_training: numTraining, media_type: 'audio' }) as DetectorRegistryEntry;
+
+  beforeEach(async () => {
+    combine$ = new Subject<DetectorCombineResponse>();
+
+    await configureZoneless({
+      imports: [CombineDetectorsModalComponent],
+      providers: [
+        {
+          provide: DetectorsCrudApiService,
+          useValue: { combine: () => combine$.asObservable() },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CombineDetectorsModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('sources', [source('Barks', 3), source('Yips', 5)]);
+    fixture.componentRef.setInput('existingNames', ['Barks', 'Yips']);
+  });
+
+  const nameInput = () =>
+    fixture.nativeElement.querySelector('#combine-new-name') as HTMLInputElement;
+  const combineBtn = () =>
+    fixture.nativeElement.querySelector('.btn--primary') as HTMLButtonElement;
+  const cancelBtn = () =>
+    fixture.nativeElement.querySelector('.btn--secondary') as HTMLButtonElement;
+  const errorText = () => fixture.nativeElement.querySelector('.error-text') as HTMLElement | null;
+
+  /** Type a name through ngModel and press Combine. */
+  async function submitAs(name: string): Promise<void> {
+    const el = nameInput();
+    el.value = name;
+    el.dispatchEvent(new Event('input'));
+    await settleZoneless(fixture);
+    combineBtn().click();
+    await settleZoneless(fixture);
+  }
+
+  it('summarises the selected sources', async () => {
+    await fixture.whenStable();
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Barks');
+    expect(text).toContain('Yips');
+    expect(text).toContain('2 detectors · 8 total labels');
+  });
+
+  it('blocks a name that collides with an existing detector', async () => {
+    await fixture.whenStable();
+    await submitAs('Barks');
+
+    expect(errorText()?.textContent).toContain('already exists');
+    expect(combineBtn().disabled).toBe(true);
+  });
+
+  it('disables both buttons while the combine is in flight', async () => {
+    await fixture.whenStable();
+    await submitAs('All Dog Sounds');
+
+    expect(combineBtn().textContent).toContain('Combining…');
+    expect(combineBtn().disabled).toBe(true);
+    expect(cancelBtn().disabled).toBe(true);
+  });
+
+  // Zoneless staleness canary: the failure state is written from the combine
+  // subscribe's error callback, and the success-only `created` output is the
+  // component's sole other CD trigger. With plain fields the modal stayed on
+  // "Combining…" with both buttons disabled and the server's message hidden
+  // until an unrelated in-modal event happened to mark the view dirty.
+  it('surfaces a rejected combine and re-enables the buttons (zoneless canary)', async () => {
+    await fixture.whenStable();
+    await submitAs('All Dog Sounds');
+
+    combine$.error({ status: 409, error: { message: 'Name taken on disk.' } });
+    await settleZoneless(fixture);
+
+    expect(errorText()?.textContent).toContain('Name taken on disk.');
+    expect(combineBtn().textContent).toContain('Combine');
+    expect(combineBtn().disabled).toBe(false);
+    expect(cancelBtn().disabled).toBe(false);
+  });
+
+  it('falls back to a status-specific message when the server sends no body', async () => {
+    await fixture.whenStable();
+    await submitAs('All Dog Sounds');
+
+    combine$.error({ status: 422 });
+    await settleZoneless(fixture);
+
+    expect(errorText()?.textContent).toContain('Every label was a conflict');
+  });
+
+  it('emits the created name on success', async () => {
+    await fixture.whenStable();
+    let created = '';
+    component.created.subscribe((n) => (created = n));
+    await submitAs('All Dog Sounds');
+
+    combine$.next({ name: 'All Dog Sounds' } as DetectorCombineResponse);
+    await settleZoneless(fixture);
+
+    expect(created).toBe('All Dog Sounds');
+    expect(component.submitting()).toBe(false);
+  });
+});

--- a/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
+++ b/frontend/src/app/components/dashboard/combine-detectors-modal/combine-detectors-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, input, OnInit, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnInit, output, signal } from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
 
 import { FormsModule } from '@angular/forms';
@@ -35,8 +35,12 @@ export class CombineDetectorsModalComponent implements OnInit {
 
   newName = '';
   conflictPolicy: 'drop' = 'drop';
-  submitting = false;
-  error = '';
+  // Signals, mirroring the sibling combine-datasets-modal: written from the
+  // async combine subscribe, which under zoneless + OnPush schedules no
+  // repaint of its own. Plain fields left the modal stuck on "Combining…"
+  // with both buttons disabled and the server error hidden.
+  readonly submitting = signal(false);
+  readonly error = signal('');
 
   rows: SourceRow[] = [];
   totalLabels = 0;
@@ -72,7 +76,7 @@ export class CombineDetectorsModalComponent implements OnInit {
 
   get canSubmit(): boolean {
     return (
-      !this.submitting &&
+      !this.submitting() &&
       this.rows.length >= 2 &&
       !!this.newName.trim() &&
       !this.nameCollision
@@ -83,37 +87,38 @@ export class CombineDetectorsModalComponent implements OnInit {
     if (!this.canSubmit) return;
     const trimmed = this.newName.trim();
     const names = this.rows.map((r) => r.name);
-    this.submitting = true;
-    this.error = '';
+    this.submitting.set(true);
+    this.error.set('');
 
     this.detectorsCrudApi.combine(names, trimmed, this.conflictPolicy).subscribe({
       next: (resp: DetectorCombineResponse) => {
-        this.submitting = false;
+        this.submitting.set(false);
         this.created.emit(resp?.name || trimmed);
       },
       error: (err) => {
-        this.submitting = false;
+        this.submitting.set(false);
         const status = err?.status;
         const serverMsg = apiErrorMessage(err, '');
         if (status === 422) {
-          this.error =
+          this.error.set(
             serverMsg ||
-            'Every label was a conflict; no detector was created. Try fewer or more aligned sources.';
+              'Every label was a conflict; no detector was created. Try fewer or more aligned sources.',
+          );
         } else if (status === 409) {
-          this.error = serverMsg || `A detector named "${trimmed}" already exists.`;
+          this.error.set(serverMsg || `A detector named "${trimmed}" already exists.`);
         } else if (status === 404) {
-          this.error = serverMsg || 'A source detector was not found.';
+          this.error.set(serverMsg || 'A source detector was not found.');
         } else if (status === 400) {
-          this.error = serverMsg || 'Invalid combine request.';
+          this.error.set(serverMsg || 'Invalid combine request.');
         } else {
-          this.error = serverMsg || 'Failed to combine detectors.';
+          this.error.set(serverMsg || 'Failed to combine detectors.');
         }
       },
     });
   }
 
   close(): void {
-    if (this.submitting) return;
+    if (this.submitting()) return;
     this.closed.emit();
   }
 }

--- a/frontend/src/app/components/folder-browser/folder-browser.component.html
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.html
@@ -3,7 +3,7 @@
     <button
       type="button"
       class="vfb-crumb"
-      [class.active]="!currentPath"
+      [class.active]="!currentPath()"
       (click)="navigateRoot()"
     >{{ rootLabel() }}</button>
     @for (crumb of breadcrumbs; track $index) {
@@ -22,7 +22,7 @@
     class="vfb-list"
     tabindex="0"
     role="listbox"
-    [class.vfb-list--loading]="loading"
+    [class.vfb-list--loading]="loading()"
   >
     <div class="vfb-header" role="row">
       <button
@@ -49,12 +49,12 @@
       }
     </div>
 
-    @if (loading) {
+    @if (loading()) {
       <p class="vfb-empty">Loading…</p>
-    } @else if (error) {
-      <p class="vfb-error">{{ error }}</p>
+    } @else if (error()) {
+      <p class="vfb-error">{{ error() }}</p>
     } @else {
-      @if (currentPath) {
+      @if (currentPath()) {
         <button
           type="button"
           class="vfb-row vfb-row--up"
@@ -65,16 +65,16 @@
           <span class="vfb-name">..</span>
         </button>
       }
-      @if (rows.length === 0) {
+      @if (rows().length === 0) {
         <p class="vfb-empty">{{ emptyMessage() || (showFiles() ? 'Empty folder.' : 'No subdirectories.') }}</p>
       }
-      @for (row of rows; track trackRow($index, row); let i = $index) {
+      @for (row of rows(); track trackRow($index, row); let i = $index) {
         <button
           type="button"
           class="vfb-row"
           [class.vfb-row--dir]="row.kind === 'dir'"
           [class.vfb-row--file]="row.kind === 'file'"
-          [class.vfb-row--selected]="i === selectedIndex"
+          [class.vfb-row--selected]="i === selectedIndex()"
           [disabled]="busy() && row.kind === 'file'"
           (click)="selectRow(i)"
           (dblclick)="onRowDblClick(row)"
@@ -99,7 +99,7 @@
     }
   </div>
 
-  @if (showPathFooter() && rootPath) {
+  @if (showPathFooter() && rootPath()) {
     <div class="vfb-path-footer">
       <span class="vfb-path-label">Path:</span>
       <code class="vfb-path-value">{{ absolutePath }}</code>

--- a/frontend/src/app/components/folder-browser/folder-browser.component.spec.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.spec.ts
@@ -8,6 +8,7 @@ import {
   FolderBrowserListing,
 } from './folder-browser.component';
 import { provideZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
 
 /** Build a listing, defaulting the arrays to empty. */
 function listing(overrides: Partial<FolderBrowserListing> = {}): FolderBrowserListing {
@@ -79,28 +80,28 @@ describe('FolderBrowserComponent', () => {
 
     expect(requestedPaths).toEqual(['']);
     // Directories come first (sorted), then files (sorted).
-    expect(component.rows.map(r => r.name)).toEqual(['alpha', 'beta', 'a.txt', 'z.txt']);
-    expect(component.rows.map(r => r.kind)).toEqual(['dir', 'dir', 'file', 'file']);
-    expect(component.loading).toBe(false);
-    expect(component.rootPath).toBe('/srv');
+    expect(component.rows().map(r => r.name)).toEqual(['alpha', 'beta', 'a.txt', 'z.txt']);
+    expect(component.rows().map(r => r.kind)).toEqual(['dir', 'dir', 'file', 'file']);
+    expect(component.loading()).toBe(false);
+    expect(component.rootPath()).toBe('/srv');
   });
 
   it('honours a non-empty initialPath input', () => {
     init({ initialPath: 'music/rock' });
     expect(requestedPaths).toEqual(['music/rock']);
-    expect(component.currentPath).toBe('music/rock');
+    expect(component.currentPath()).toBe('music/rock');
   });
 
   it('omits files when showFiles is false', () => {
     defaultListing = listing({ directories: [dir('d')], files: [file('f.txt')] });
     init({ showFiles: false });
-    expect(component.rows.map(r => r.kind)).toEqual(['dir']);
+    expect(component.rows().map(r => r.kind)).toEqual(['dir']);
   });
 
   it('falls back to the requested path when the listing omits currentPath', () => {
     listings['deep/dir'] = listing({ directories: [] });
     init({ initialPath: 'deep/dir' });
-    expect(component.currentPath).toBe('deep/dir');
+    expect(component.currentPath()).toBe('deep/dir');
   });
 
   it('emits pathChange with the resolved path and rootPath', () => {
@@ -129,6 +130,48 @@ describe('FolderBrowserComponent', () => {
   });
 
   // ------------------------------------------------------------------
+  // Zoneless repaint canaries
+  // ------------------------------------------------------------------
+  //
+  // The listings above resolve synchronously (`of(...)`), so their callbacks
+  // run inside an existing CD pass and cannot detect staleness. These two
+  // drive an *asynchronous* browse and assert on the rendered DOM without a
+  // manual `detectChanges()` — the state must repaint on its own, since the
+  // only usage-independent trigger (`pathChange`) is not bound by every parent
+  // and `loadError` is bound by none.
+
+  it('repaints the listing after an async browse resolves (zoneless canary)', async () => {
+    const subject = new Subject<FolderBrowserListing>();
+    fixture.componentRef.setInput('browse', () => subject.asObservable());
+    fixture.componentRef.setInput('autoFocus', false);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.textContent).toContain('Loading…');
+
+    subject.next(listing({ directories: [dir('alpha')], files: [file('a.txt')] }));
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.textContent).not.toContain('Loading…');
+    const names = Array.from(
+      fixture.nativeElement.querySelectorAll('.vfb-row .vfb-name') as NodeListOf<HTMLElement>,
+    ).map((el) => el.textContent?.trim());
+    expect(names).toEqual(['alpha', 'a.txt']);
+  });
+
+  it('repaints the inline error after an async browse fails (zoneless canary)', async () => {
+    const subject = new Subject<FolderBrowserListing>();
+    fixture.componentRef.setInput('browse', () => subject.asObservable());
+    fixture.componentRef.setInput('autoFocus', false);
+    await fixture.whenStable();
+
+    subject.error({ error: { message: 'boom' } });
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.vfb-error') as HTMLElement | null;
+    expect(err?.textContent?.trim()).toBe('boom');
+    expect(fixture.nativeElement.textContent).not.toContain('Loading…');
+  });
+
+  // ------------------------------------------------------------------
   // Errors
   // ------------------------------------------------------------------
 
@@ -140,9 +183,9 @@ describe('FolderBrowserComponent', () => {
     component.loadError.subscribe(e => (emitted = e));
     fixture.detectChanges();
 
-    expect(component.error).toBe('boom');
-    expect(component.rows).toEqual([]);
-    expect(component.loading).toBe(false);
+    expect(component.error()).toBe('boom');
+    expect(component.rows()).toEqual([]);
+    expect(component.loading()).toBe(false);
     expect(emitted).toBe(err);
   });
 
@@ -157,7 +200,7 @@ describe('FolderBrowserComponent', () => {
       fixture.componentRef.setInput('browse', () => throwError(() => err));
       fixture.componentRef.setInput('autoFocus', false);
       component.reload();
-      expect(component.error).toBe(expected);
+      expect(component.error()).toBe(expected);
     }
   });
 
@@ -281,27 +324,27 @@ describe('FolderBrowserComponent', () => {
       files: [file('a.txt'), file('b.txt')],
     });
     init();
-    expect(component.sortDir).toBe('asc');
+    expect(component.sortDir()).toBe('asc');
 
     component.setSort('name'); // same key -> flip to desc
-    expect(component.sortDir).toBe('desc');
+    expect(component.sortDir()).toBe('desc');
     // Dirs stay grouped above files even when descending.
-    expect(component.rows.map(r => r.name)).toEqual(['beta', 'alpha', 'b.txt', 'a.txt']);
+    expect(component.rows().map(r => r.name)).toEqual(['beta', 'alpha', 'b.txt', 'a.txt']);
   });
 
   it('setSort switching keys resets direction to asc', () => {
     init();
     component.setSort('name');
-    expect(component.sortDir).toBe('desc');
+    expect(component.sortDir()).toBe('desc');
     component.setSort('modified');
-    expect(component.sortKey).toBe('modified');
-    expect(component.sortDir).toBe('asc');
+    expect(component.sortKey()).toBe('modified');
+    expect(component.sortDir()).toBe('asc');
   });
 
   it('sorts names numerically (natural order)', () => {
     defaultListing = listing({ directories: [dir('item10'), dir('item2'), dir('item1')] });
     init();
-    expect(component.rows.map(r => r.name)).toEqual(['item1', 'item2', 'item10']);
+    expect(component.rows().map(r => r.name)).toEqual(['item1', 'item2', 'item10']);
   });
 
   it('sorts files by size', () => {
@@ -310,7 +353,7 @@ describe('FolderBrowserComponent', () => {
     });
     init();
     component.setSort('size');
-    expect(component.rows.map(r => r.name)).toEqual(['small', 'big']);
+    expect(component.rows().map(r => r.name)).toEqual(['small', 'big']);
   });
 
   it('sorts by modified date', () => {
@@ -322,7 +365,7 @@ describe('FolderBrowserComponent', () => {
     });
     init();
     component.setSort('modified');
-    expect(component.rows.map(r => r.name)).toEqual(['older', 'newer']);
+    expect(component.rows().map(r => r.name)).toEqual(['older', 'newer']);
   });
 
   it('sortIndicator shows an arrow only for the active key', () => {
@@ -341,11 +384,11 @@ describe('FolderBrowserComponent', () => {
     defaultListing = listing({ directories: [dir('a'), dir('b')] });
     init();
     component.selectRow(-1);
-    expect(component.selectedIndex).toBe(-1);
+    expect(component.selectedIndex()).toBe(-1);
     component.selectRow(5);
-    expect(component.selectedIndex).toBe(-1);
+    expect(component.selectedIndex()).toBe(-1);
     component.selectRow(1);
-    expect(component.selectedIndex).toBe(1);
+    expect(component.selectedIndex()).toBe(1);
   });
 
   it('resets the selection after a sort', () => {
@@ -353,7 +396,7 @@ describe('FolderBrowserComponent', () => {
     init();
     component.selectRow(1);
     component.setSort('name');
-    expect(component.selectedIndex).toBe(-1);
+    expect(component.selectedIndex()).toBe(-1);
   });
 
   // ------------------------------------------------------------------
@@ -370,24 +413,24 @@ describe('FolderBrowserComponent', () => {
     defaultListing = listing({ directories: [dir('a'), dir('b'), dir('c')] });
     init();
     press('ArrowDown');
-    expect(component.selectedIndex).toBe(0);
+    expect(component.selectedIndex()).toBe(0);
     press('ArrowDown');
-    expect(component.selectedIndex).toBe(1);
+    expect(component.selectedIndex()).toBe(1);
     press('ArrowUp');
-    expect(component.selectedIndex).toBe(0);
+    expect(component.selectedIndex()).toBe(0);
     // From no selection, ArrowUp lands on the last row.
-    component.selectedIndex = -1;
+    component.selectedIndex.set(-1);
     press('ArrowUp');
-    expect(component.selectedIndex).toBe(2);
+    expect(component.selectedIndex()).toBe(2);
   });
 
   it('Home and End jump to the first and last rows', () => {
     defaultListing = listing({ directories: [dir('a'), dir('b'), dir('c')] });
     init();
     press('End');
-    expect(component.selectedIndex).toBe(2);
+    expect(component.selectedIndex()).toBe(2);
     press('Home');
-    expect(component.selectedIndex).toBe(0);
+    expect(component.selectedIndex()).toBe(0);
   });
 
   it('Enter activates the selected row', () => {
@@ -417,17 +460,17 @@ describe('FolderBrowserComponent', () => {
   it('ignores keys while loading', () => {
     defaultListing = listing({ directories: [dir('a')] });
     init();
-    component.loading = true;
-    component.selectedIndex = -1;
+    component.loading.set(true);
+    component.selectedIndex.set(-1);
     press('ArrowDown');
-    expect(component.selectedIndex).toBe(-1);
+    expect(component.selectedIndex()).toBe(-1);
   });
 
   it('type-ahead jumps to the first row matching the typed prefix', () => {
     defaultListing = listing({ directories: [dir('apple'), dir('banana'), dir('cherry')] });
     init();
     press('b');
-    expect(component.rows[component.selectedIndex].name).toBe('banana');
+    expect(component.rows()[component.selectedIndex()].name).toBe('banana');
   });
 
   it('type-ahead cycles through rows sharing a prefix once the buffer resets', () => {
@@ -438,13 +481,13 @@ describe('FolderBrowserComponent', () => {
       defaultListing = listing({ directories: [dir('ball'), dir('bat'), dir('bell')] });
       init();
       press('b');
-      const first = component.selectedIndex;
+      const first = component.selectedIndex();
       vi.advanceTimersByTime(900); // clear the type-ahead buffer
       press('b');
-      const second = component.selectedIndex;
+      const second = component.selectedIndex();
       expect(second).not.toBe(first);
-      expect(component.rows[first].name.startsWith('b')).toBe(true);
-      expect(component.rows[second].name.startsWith('b')).toBe(true);
+      expect(component.rows()[first].name.startsWith('b')).toBe(true);
+      expect(component.rows()[second].name.startsWith('b')).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/src/app/components/folder-browser/folder-browser.component.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.ts
@@ -9,6 +9,7 @@ import {
   input,
   OnDestroy,
   output,
+  signal,
   untracked,
   viewChild,
 } from '@angular/core';
@@ -130,14 +131,21 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
    *  way.  The component also shows an inline error message. */
   readonly loadError = output<unknown>();
 
-  rows: Row[] = [];
-  currentPath = '';
-  rootPath = '';
-  loading = false;
-  error = '';
-  selectedIndex = -1;
-  sortKey: SortKey = 'name';
-  sortDir: SortDir = 'asc';
+  // Signals, not plain fields: the app is zoneless and this component is
+  // OnPush, so every one of these is written from the async `browse()`
+  // subscribe callbacks — nothing else would schedule a repaint. (The success
+  // path used to limp along on `pathChange.emit()`, which only marks the view
+  // dirty when the parent actually binds that output; `vt-file-browser` binds
+  // only `(confirm)`, so it stalled on "Loading…". The error path had no
+  // trigger at all.)
+  readonly rows = signal<Row[]>([]);
+  readonly currentPath = signal('');
+  readonly rootPath = signal('');
+  readonly loading = signal(false);
+  readonly error = signal('');
+  readonly selectedIndex = signal(-1);
+  readonly sortKey = signal<SortKey>('name');
+  readonly sortDir = signal<SortDir>('asc');
 
   private typeaheadBuf = '';
   private typeaheadTimer: ReturnType<typeof setTimeout> | null = null;
@@ -174,8 +182,8 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   // ------------------------------------------------------------------
 
   private loadDirectory(path: string): void {
-    this.loading = true;
-    this.error = '';
+    this.loading.set(true);
+    this.error.set('');
     this.currentSub?.unsubscribe();
     this.currentSub = this.browse()(path).subscribe({
       next: (res) => {
@@ -194,18 +202,18 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
             size_bytes: f.size_bytes,
           });
         }
-        this.rows = this.sortRows(rows, this.sortKey, this.sortDir);
-        this.currentPath = res.currentPath ?? path;
-        this.rootPath = res.rootPath ?? '';
-        this.selectedIndex = -1;
-        this.loading = false;
-        this.pathChange.emit({ path: this.currentPath, rootPath: this.rootPath });
+        this.rows.set(this.sortRows(rows, this.sortKey(), this.sortDir()));
+        this.currentPath.set(res.currentPath ?? path);
+        this.rootPath.set(res.rootPath ?? '');
+        this.selectedIndex.set(-1);
+        this.loading.set(false);
+        this.pathChange.emit({ path: this.currentPath(), rootPath: this.rootPath() });
       },
       error: (err) => {
         const msg = (err && err.error && err.error.message) || (err && err.error && err.error.error) || 'Could not browse this folder.';
-        this.error = typeof msg === 'string' ? msg : 'Could not browse this folder.';
-        this.loading = false;
-        this.rows = [];
+        this.error.set(typeof msg === 'string' ? msg : 'Could not browse this folder.');
+        this.loading.set(false);
+        this.rows.set([]);
         this.loadError.emit(err);
       },
     });
@@ -214,7 +222,7 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   /** Re-load the current directory (e.g. after the caller changed a
    *  filter that affects the listing). */
   reload(): void {
-    this.loadDirectory(this.currentPath);
+    this.loadDirectory(this.currentPath());
   }
 
   // ------------------------------------------------------------------
@@ -222,7 +230,8 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   // ------------------------------------------------------------------
 
   get breadcrumbs(): string[] {
-    return this.currentPath ? this.currentPath.split('/').filter(Boolean) : [];
+    const path = this.currentPath();
+    return path ? path.split('/').filter(Boolean) : [];
   }
 
   navigateRoot(): void {
@@ -230,7 +239,7 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   }
 
   navigateBreadcrumb(index: number): void {
-    const parts = this.currentPath.split('/').filter(Boolean);
+    const parts = this.currentPath().split('/').filter(Boolean);
     this.loadDirectory(parts.slice(0, index + 1).join('/'));
   }
 
@@ -249,20 +258,22 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   }
 
   goUp(): void {
-    if (!this.currentPath) return;
-    const parts = this.currentPath.split('/').filter(Boolean);
+    if (!this.currentPath()) return;
+    const parts = this.currentPath().split('/').filter(Boolean);
     parts.pop();
     this.loadDirectory(parts.join('/'));
   }
 
   get absolutePath(): string {
-    if (!this.rootPath) return '';
-    if (!this.currentPath) return this.rootPath;
+    const root = this.rootPath();
+    const current = this.currentPath();
+    if (!root) return '';
+    if (!current) return root;
     // When the root is the filesystem root ("/"), joining with "/" would
     // produce a leading "//". Treat "/" as a special case so the absolute
     // path stays well-formed.
-    if (this.rootPath === '/') return '/' + this.currentPath;
-    return this.rootPath + '/' + this.currentPath;
+    if (root === '/') return '/' + current;
+    return root + '/' + current;
   }
 
   // ------------------------------------------------------------------
@@ -270,8 +281,8 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   // ------------------------------------------------------------------
 
   selectRow(index: number): void {
-    if (index < 0 || index >= this.rows.length) return;
-    this.selectedIndex = index;
+    if (index < 0 || index >= this.rows().length) return;
+    this.selectedIndex.set(index);
   }
 
   onRowDblClick(row: Row): void {
@@ -283,14 +294,14 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   // ------------------------------------------------------------------
 
   setSort(key: SortKey): void {
-    if (this.sortKey === key) {
-      this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
+    if (this.sortKey() === key) {
+      this.sortDir.set(this.sortDir() === 'asc' ? 'desc' : 'asc');
     } else {
-      this.sortKey = key;
-      this.sortDir = 'asc';
+      this.sortKey.set(key);
+      this.sortDir.set('asc');
     }
-    this.rows = this.sortRows(this.rows, this.sortKey, this.sortDir);
-    this.selectedIndex = -1;
+    this.rows.set(this.sortRows(this.rows(), this.sortKey(), this.sortDir()));
+    this.selectedIndex.set(-1);
   }
 
   private sortRows(rows: Row[], key: SortKey, dir: SortDir): Row[] {
@@ -317,8 +328,8 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   }
 
   sortIndicator(key: SortKey): string {
-    if (this.sortKey !== key) return '';
-    return this.sortDir === 'asc' ? '▲' : '▼';
+    if (this.sortKey() !== key) return '';
+    return this.sortDir() === 'asc' ? '▲' : '▼';
   }
 
   // ------------------------------------------------------------------
@@ -327,7 +338,7 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
 
   @HostListener('keydown', ['$event'])
   onKeyDown(e: KeyboardEvent): void {
-    if (this.loading) return;
+    if (this.loading()) return;
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       this.moveSelection(1);
@@ -340,17 +351,17 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
     }
     if (e.key === 'Home') {
       e.preventDefault();
-      if (this.rows.length > 0) this.selectRow(0);
+      if (this.rows().length > 0) this.selectRow(0);
       return;
     }
     if (e.key === 'End') {
       e.preventDefault();
-      if (this.rows.length > 0) this.selectRow(this.rows.length - 1);
+      if (this.rows().length > 0) this.selectRow(this.rows().length - 1);
       return;
     }
     if (e.key === 'Enter') {
       e.preventDefault();
-      if (this.selectedIndex >= 0) this.enter(this.rows[this.selectedIndex]);
+      if (this.selectedIndex() >= 0) this.enter(this.rows()[this.selectedIndex()]);
       return;
     }
     if (e.key === 'Backspace' || (e.key === 'ArrowUp' && e.altKey)) {
@@ -367,11 +378,12 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   }
 
   private moveSelection(delta: number): void {
-    if (this.rows.length === 0) return;
-    let i = this.selectedIndex + delta;
-    if (this.selectedIndex < 0) i = delta > 0 ? 0 : this.rows.length - 1;
+    const rows = this.rows();
+    if (rows.length === 0) return;
+    let i = this.selectedIndex() + delta;
+    if (this.selectedIndex() < 0) i = delta > 0 ? 0 : rows.length - 1;
     if (i < 0) i = 0;
-    if (i >= this.rows.length) i = this.rows.length - 1;
+    if (i >= rows.length) i = rows.length - 1;
     this.selectRow(i);
     this.scrollSelectionIntoView();
   }
@@ -379,7 +391,7 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   private scrollSelectionIntoView(): void {
     const list = this.listEl()?.nativeElement;
     if (!list) return;
-    const row = list.querySelectorAll('.vfb-row')[this.selectedIndex] as HTMLElement | undefined;
+    const row = list.querySelectorAll('.vfb-row')[this.selectedIndex()] as HTMLElement | undefined;
     row?.scrollIntoView({ block: 'nearest' });
   }
 
@@ -391,12 +403,13 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
       this.typeaheadTimer = null;
     }, TYPEAHEAD_RESET_MS);
     const needle = this.typeaheadBuf;
+    const rows = this.rows();
     // Search starting from the row after the current selection so
     // repeated presses cycle through matches.
-    const start = this.selectedIndex >= 0 ? this.selectedIndex : 0;
-    for (let off = 0; off < this.rows.length; off++) {
-      const idx = (start + off + (needle.length === 1 ? 1 : 0)) % this.rows.length;
-      if (this.rows[idx].name.toLowerCase().startsWith(needle)) {
+    const start = this.selectedIndex() >= 0 ? this.selectedIndex() : 0;
+    for (let off = 0; off < rows.length; off++) {
+      const idx = (start + off + (needle.length === 1 ? 1 : 0)) % rows.length;
+      if (rows[idx].name.toLowerCase().startsWith(needle)) {
         this.selectRow(idx);
         this.scrollSelectionIntoView();
         return;

--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -17,13 +17,13 @@
         autofocus
         autocomplete="username"
         maxlength="64"
-        [disabled]="busy"
+        [disabled]="busy()"
       >
-      @if (error) {
-        <p class="login-error">{{ error }}</p>
+      @if (error()) {
+        <p class="login-error">{{ error() }}</p>
       }
-      <button type="submit" [disabled]="busy" title="Log in to VTSearch">
-        {{ busy ? 'Logging in…' : 'Log in' }}
+      <button type="submit" [disabled]="busy()" title="Log in to VTSearch">
+        {{ busy() ? 'Logging in…' : 'Log in' }}
       </button>
     </form>
   </div>

--- a/frontend/src/app/components/login/login.component.spec.ts
+++ b/frontend/src/app/components/login/login.component.spec.ts
@@ -1,0 +1,119 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+
+import { LoginComponent } from './login.component';
+import { AuthService } from '../../services/auth.service';
+import type { AuthStatus } from '../../generated/api-client/models/auth-status';
+import { configureZoneless } from '../../testing/zoneless-testbed';
+import { settleZoneless } from '../../testing/settle-resource';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+  /** Controllable stand-in for the login request. */
+  let login$: Subject<AuthStatus>;
+  let requestedNames: string[];
+
+  beforeEach(async () => {
+    login$ = new Subject<AuthStatus>();
+    requestedNames = [];
+
+    await configureZoneless({
+      imports: [LoginComponent],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            login: (name: string) => {
+              requestedNames.push(name);
+              return login$.asObservable();
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+  });
+
+  const input = () => fixture.nativeElement.querySelector('#login-username') as HTMLInputElement;
+  const submitBtn = () =>
+    fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+  const errorEl = () => fixture.nativeElement.querySelector('.login-error') as HTMLElement | null;
+
+  /** Type a username through ngModel and submit the form. */
+  async function submitAs(name: string): Promise<void> {
+    const el = input();
+    el.value = name;
+    el.dispatchEvent(new Event('input'));
+    await settleZoneless(fixture);
+    fixture.nativeElement.querySelector('form')!.dispatchEvent(new Event('submit'));
+    await settleZoneless(fixture);
+  }
+
+  it('rejects an empty username without calling the service', async () => {
+    await fixture.whenStable();
+    await submitAs('   ');
+
+    expect(requestedNames).toEqual([]);
+    expect(errorEl()?.textContent).toContain('Please enter a username.');
+  });
+
+  it('disables the form while the login request is in flight', async () => {
+    await fixture.whenStable();
+    await submitAs('alice');
+
+    expect(requestedNames).toEqual(['alice']);
+    expect(submitBtn().textContent).toContain('Logging in…');
+    expect(submitBtn().disabled).toBe(true);
+    expect(input().disabled).toBe(true);
+  });
+
+  // Zoneless staleness canary: the failure state is written from the login
+  // subscribe's error callback, and the success-only `loggedIn` output is the
+  // component's sole other CD trigger. With plain fields the form stayed
+  // rendered as "Logging in…" with the input AND button disabled — leaving no
+  // element that could fire an event to un-stick it, so the login screen was
+  // bricked until a page reload.
+  it('re-enables the form and shows the message when login fails (zoneless canary)', async () => {
+    await fixture.whenStable();
+    await submitAs('alice');
+
+    login$.error({ status: 401, error: { message: 'Unknown user.' } });
+    await settleZoneless(fixture);
+
+    expect(errorEl()?.textContent).toContain('Unknown user.');
+    expect(submitBtn().textContent).toContain('Log in');
+    expect(submitBtn().disabled).toBe(false);
+    expect(input().disabled).toBe(false);
+  });
+
+  it('falls back to a generic message when the server sends no body', async () => {
+    await fixture.whenStable();
+    await submitAs('alice');
+
+    login$.error({ status: 0 });
+    await settleZoneless(fixture);
+
+    expect(errorEl()?.textContent).toContain('Login failed.');
+  });
+
+  it('emits loggedIn on success', async () => {
+    await fixture.whenStable();
+    let emitted = false;
+    component.loggedIn.subscribe(() => (emitted = true));
+    await submitAs('alice');
+
+    login$.next({
+      provider: 'default',
+      user: 'alice',
+      authenticated: true,
+      login_required: true,
+    });
+    await settleZoneless(fixture);
+
+    expect(emitted).toBe(true);
+    expect(component.busy()).toBe(false);
+  });
+});

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, output, signal } from '@angular/core';
 
 import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../services/auth.service';
@@ -18,25 +18,30 @@ export class LoginComponent {
   readonly loggedIn = output<void>();
 
   username = '';
-  error = '';
-  busy = false;
+  // Signals, not plain fields: the app is zoneless and this component is
+  // OnPush, so the async login callbacks are the only writers and nothing else
+  // would schedule a repaint. On a failed login that left the form bricked —
+  // the input and the submit button stayed `[disabled]="busy"` with no
+  // remaining listener to mark the view dirty.
+  readonly error = signal('');
+  readonly busy = signal(false);
 
   submit(): void {
     const name = this.username.trim();
     if (!name) {
-      this.error = 'Please enter a username.';
+      this.error.set('Please enter a username.');
       return;
     }
-    this.busy = true;
-    this.error = '';
+    this.busy.set(true);
+    this.error.set('');
     this.auth.login(name).subscribe({
       next: () => {
-        this.busy = false;
+        this.busy.set(false);
         this.loggedIn.emit();
       },
       error: (err) => {
-        this.busy = false;
-        this.error = apiErrorMessage(err, 'Login failed.');
+        this.busy.set(false);
+        this.error.set(apiErrorMessage(err, 'Login failed.'));
       },
     });
   }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.html
@@ -1,20 +1,20 @@
 <vt-modal [title]="title" [open]="true" (closed)="onCancel()">
-  @if (analyzing) {
+  @if (analyzing()) {
     <div class="analysis-loading">
-      @if (!runningJob) {
+      @if (!runningJob()) {
         <p aria-live="polite">Loading indicator history…</p>
       } @else {
         <vt-job-progress
           aria-live="polite"
           header="Training detectors over label history"
-          [eta]="analysisProgress + '%'"
-          [bar]="{ value: analysisProgress, max: 100, indeterminate: false }"
+          [eta]="analysisProgress() + '%'"
+          [bar]="{ value: analysisProgress(), max: 100, indeterminate: false }"
           cancelTitle="Cancel the running analysis"
           (cancel)="onCancel()"
         />
       }
     </div>
-  } @else if (emptyHistory) {
+  } @else if (emptyHistory()) {
     <div class="analysis-loading">
       <p>No score history available yet. Label more items to build up history.</p>
     </div>

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -7,6 +7,7 @@ import { ProgressModalComponent } from './progress-modal.component';
 import { ProgressEventsService } from '../../../services/progress-events.service';
 import { VotingIterationsResponse } from '../../../models/api.models';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
+import { settleZoneless } from '../../../testing/settle-resource';
 import { provideHttpTesting } from '../../../testing/test-providers';
 
 describe('ProgressModalComponent', () => {
@@ -68,7 +69,7 @@ describe('ProgressModalComponent', () => {
       fixture.componentRef.setInput('metric', 'smart');
       // TestBed.tick() runs ngOnInit (the cached read) under zoneless.
       TestBed.tick();
-      expect(component.analyzing).toBe(true);
+      expect(component.analyzing()).toBe(true);
       missCachedHistory('smart');
 
       // Progress now arrives over the `eval` SSE channel, not via HTTP polling.
@@ -84,8 +85,8 @@ describe('ProgressModalComponent', () => {
       });
 
       await vi.advanceTimersByTimeAsync(50);
-      expect(component.analyzing).toBe(false);
-      expect(component.chartData.length).toBe(1);
+      expect(component.analyzing()).toBe(false);
+      expect(component.chartData().length).toBe(1);
     } finally {
       vi.useRealTimers();
     }
@@ -114,7 +115,7 @@ describe('ProgressModalComponent', () => {
         current: 0,
         total: 5,
       });
-      expect(component.analyzing).toBe(true);
+      expect(component.analyzing()).toBe(true);
 
       // SSE says done *before* the result endpoint flips. This used to kill
       // the poller; it must only stop the progress watcher now.
@@ -123,7 +124,7 @@ describe('ProgressModalComponent', () => {
       // First poll still sees `running`.
       await vi.advanceTimersByTimeAsync(200);
       httpMock.expectOne(isResult).flush({ job_id: 'j1', status: 'running', current: 5, total: 5 });
-      expect(component.analyzing).toBe(true);
+      expect(component.analyzing()).toBe(true);
 
       // Next poll observes completion and applies the data.
       await vi.advanceTimersByTimeAsync(500);
@@ -135,8 +136,8 @@ describe('ProgressModalComponent', () => {
       });
 
       await vi.advanceTimersByTimeAsync(50);
-      expect(component.analyzing).toBe(false);
-      expect(component.chartData.length).toBe(1);
+      expect(component.analyzing()).toBe(false);
+      expect(component.chartData().length).toBe(1);
     } finally {
       vi.useRealTimers();
     }
@@ -164,7 +165,7 @@ describe('ProgressModalComponent', () => {
 
       httpMock.expectOne('/api/eval/train-and-score/cancel/j2').flush({ ok: true });
       expect(component.closed.emit).toHaveBeenCalled();
-      expect(component.analyzing).toBe(false);
+      expect(component.analyzing()).toBe(false);
     } finally {
       vi.useRealTimers();
     }
@@ -211,9 +212,9 @@ describe('ProgressModalComponent', () => {
       });
 
       await vi.advanceTimersByTimeAsync(50);
-      expect(component.analyzing).toBe(false);
-      expect(component.runningJob).toBe(false);
-      expect(component.chartData.length).toBe(1);
+      expect(component.analyzing()).toBe(false);
+      expect(component.runningJob()).toBe(false);
+      expect(component.chartData().length).toBe(1);
       httpMock.expectNone('/api/eval/train-and-score');
     } finally {
       vi.useRealTimers();
@@ -229,10 +230,10 @@ describe('ProgressModalComponent', () => {
       fixture.componentRef.setInput('metric', 'stable');
       TestBed.tick();
 
-      expect(component.runningJob).toBe(false);
+      expect(component.runningJob()).toBe(false);
       missCachedHistory('stable');
-      expect(component.runningJob).toBe(true);
-      expect(component.analyzing).toBe(true);
+      expect(component.runningJob()).toBe(true);
+      expect(component.analyzing()).toBe(true);
 
       httpMock.expectOne('/api/eval/train-and-score').flush({
         job_id: 'j3',
@@ -242,8 +243,8 @@ describe('ProgressModalComponent', () => {
       });
 
       await vi.advanceTimersByTimeAsync(50);
-      expect(component.analyzing).toBe(false);
-      expect(component.chartData.length).toBe(1);
+      expect(component.analyzing()).toBe(false);
+      expect(component.chartData().length).toBe(1);
     } finally {
       vi.useRealTimers();
     }
@@ -261,8 +262,8 @@ describe('ProgressModalComponent', () => {
         { message: 'Score history computation failed' },
         { status: 500, statusText: 'Server Error' },
       );
-      expect(component.runningJob).toBe(true);
-      expect(component.emptyHistory).toBe(false);
+      expect(component.runningJob()).toBe(true);
+      expect(component.emptyHistory()).toBe(false);
 
       httpMock.expectOne('/api/eval/train-and-score').flush({
         job_id: 'j4',
@@ -272,11 +273,56 @@ describe('ProgressModalComponent', () => {
       });
 
       await vi.advanceTimersByTimeAsync(50);
-      expect(component.analyzing).toBe(false);
-      expect(component.chartData.length).toBe(1);
+      expect(component.analyzing()).toBe(false);
+      expect(component.chartData().length).toBe(1);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // Zoneless staleness canary: the history lands in an HTTP subscribe (not a
+  // CD trigger) and this component emits no output on the data path, so the
+  // loading→chart transition repaints only because the state is signals. No
+  // manual `detectChanges()` — a missing notification shows up as stale DOM.
+  it('repaints from the loading line to the chart canvas (zoneless canary)', async () => {
+    fixture.componentRef.setInput('metric', 'smart');
+    await fixture.whenStable();
+    expect(fixture.nativeElement.textContent).toContain('Loading indicator history…');
+
+    httpMock.expectOne(isHistory).flush({
+      metric: 'smart',
+      history: [{ num_labels: 5, error_cost: 0.5 }],
+      complete: true,
+    });
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.textContent).not.toContain('Loading indicator history…');
+    // The canvas only exists in the results branch; the render effect draws
+    // into it as soon as the viewChild query resolves.
+    expect(fixture.nativeElement.querySelector('canvas')).toBeTruthy();
+  });
+
+  // The job path's progress bar is written from the SSE subscribe, which is
+  // likewise not a CD trigger.
+  it('repaints the job progress bar from SSE frames (zoneless canary)', async () => {
+    fixture.componentRef.setInput('metric', 'smart');
+    await fixture.whenStable();
+    missCachedHistory('smart');
+    await settleZoneless(fixture);
+
+    httpMock.expectOne('/api/eval/train-and-score').flush({
+      job_id: 'j6',
+      status: 'running',
+      current: 0,
+      total: 4,
+    });
+    votingIterations$.next({ progress: 1, total: 4, done: false });
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.textContent).toContain('25%');
+
+    // Drain the poller so `httpMock.verify()` sees no outstanding request.
+    component.ngOnDestroy();
   });
 
   it('shows the empty state when a finished job yields no points', async () => {
@@ -294,8 +340,8 @@ describe('ProgressModalComponent', () => {
       });
 
       await vi.advanceTimersByTimeAsync(50);
-      expect(component.analyzing).toBe(false);
-      expect(component.emptyHistory).toBe(true);
+      expect(component.analyzing()).toBe(false);
+      expect(component.emptyHistory()).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -5,6 +5,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { Subject } from 'rxjs';
 import { ProgressModalComponent } from './progress-modal.component';
 import { ProgressEventsService } from '../../../services/progress-events.service';
+import { ChartsService } from '../../../services/charts.service';
 import { VotingIterationsResponse } from '../../../models/api.models';
 import { provideZoneless } from '../../../testing/zoneless-testbed';
 import { settleZoneless } from '../../../testing/settle-resource';
@@ -17,15 +18,28 @@ describe('ProgressModalComponent', () => {
   // Controllable stand-in for the `eval` SSE channel so a test can push a
   // "done" progress frame at will.
   let votingIterations$: Subject<VotingIterationsResponse>;
+  // Records every chart the component asks to draw, so a spec can assert the
+  // canvas was actually painted (not merely instantiated).
+  let rendered: { chart: string; canvas: HTMLCanvasElement; points: unknown[] }[];
 
   beforeEach(async () => {
     votingIterations$ = new Subject<VotingIterationsResponse>();
+    rendered = [];
+    const chartsStub = {
+      renderErrorCostChart: (canvas: HTMLCanvasElement, points: unknown[]) =>
+        rendered.push({ chart: 'error-cost', canvas, points }),
+      renderStabilityChart: (canvas: HTMLCanvasElement, points: unknown[]) =>
+        rendered.push({ chart: 'stability', canvas, points }),
+      renderDiversityChart: (canvas: HTMLCanvasElement, points: unknown[]) =>
+        rendered.push({ chart: 'diversity', canvas, points }),
+    };
     await TestBed.configureTestingModule({
       imports: [ProgressModalComponent],
       providers: [
         ...provideZoneless(),
         ...provideHttpTesting(),
         { provide: ProgressEventsService, useValue: { votingIterations$ } },
+        { provide: ChartsService, useValue: chartsStub },
       ],
     }).compileComponents();
 
@@ -299,7 +313,11 @@ describe('ProgressModalComponent', () => {
     expect(fixture.nativeElement.textContent).not.toContain('Loading indicator history…');
     // The canvas only exists in the results branch; the render effect draws
     // into it as soon as the viewChild query resolves.
-    expect(fixture.nativeElement.querySelector('canvas')).toBeTruthy();
+    const canvas = fixture.nativeElement.querySelector('canvas') as HTMLCanvasElement;
+    expect(canvas).toBeTruthy();
+    expect(rendered).toEqual([
+      { chart: 'error-cost', canvas, points: [{ num_labels: 5, error_cost: 0.5 }] },
+    ]);
   });
 
   // The job path's progress bar is written from the SSE subscribe, which is

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, inject, input, OnDestroy, OnInit, output, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, OnDestroy, OnInit, output, signal, viewChild } from '@angular/core';
 
 import { Subject, takeUntil, timer, switchMap, filter, take } from 'rxjs';
 import { ModalComponent } from '../../modal/modal.component';
@@ -36,18 +36,35 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   // Optional query: the canvas only renders in the results `@else` branch.
   readonly chartCanvas = viewChild<ElementRef<HTMLCanvasElement>>('chartCanvas');
 
-  analyzing = true;
-  analysisProgress = 0;
-  chartData: ErrorCostPoint[] | StabilityPoint[] | DiversityPoint[] = [];
-  emptyHistory = false;
+  // Signals, not plain fields: the app is zoneless and this component is
+  // OnPush, and every one of these is written from an HTTP/SSE subscribe
+  // callback. This component emits no output on the data path either, so
+  // plain fields froze the modal on "Loading indicator history…" forever.
+  readonly analyzing = signal(true);
+  readonly analysisProgress = signal(0);
+  readonly chartData = signal<ErrorCostPoint[] | StabilityPoint[] | DiversityPoint[]>([]);
+  readonly emptyHistory = signal(false);
   /** True once we've fallen back to the async train-and-score job, which
    *  swaps the brief "loading" line for a real progress bar + Cancel. */
-  runningJob = false;
+  readonly runningJob = signal(false);
   /** Job id of the in-flight eval train-and-score run. Set once the
    *  backend hands back a job envelope; consumed by ``onCancel``. */
   private currentJobId: string | null = null;
 
   private destroy$ = new Subject<void>();
+
+  constructor() {
+    // The canvas lives in the results `@else` branch, so it only exists one
+    // render pass after `chartData` lands. Keying the draw on the viewChild
+    // signal *and* the data means the chart paints exactly when the canvas
+    // materialises, rather than racing it on a fixed timeout.
+    effect(() => {
+      const canvas = this.chartCanvas()?.nativeElement;
+      const data = this.chartData();
+      if (!canvas || data.length === 0) return;
+      this.renderChart(canvas, data);
+    });
+  }
 
   get title(): string {
     switch (this.metric()) {
@@ -75,7 +92,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   }
 
   private loadCachedHistory(): void {
-    this.analyzing = true;
+    this.analyzing.set(true);
     this.sortingApi
       .getIndicatorScoreHistory(this.metric())
       .pipe(takeUntil(this.destroy$))
@@ -89,12 +106,11 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
             this.runAnalysis();
             return;
           }
-          this.analyzing = false;
-          this.chartData = (res.history || []) as ErrorCostPoint[] | StabilityPoint[] | DiversityPoint[];
-          this.emptyHistory = this.chartData.length === 0;
-          if (!this.emptyHistory) {
-            setTimeout(() => this.renderChart(), 50);
-          }
+          this.analyzing.set(false);
+          this.chartData.set(
+            (res.history || []) as ErrorCostPoint[] | StabilityPoint[] | DiversityPoint[],
+          );
+          this.emptyHistory.set(this.chartData().length === 0);
         },
         // A failed cached read is not fatal: the job path recomputes the
         // series from scratch, so fall back rather than showing "no history".
@@ -103,9 +119,9 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   }
 
   private runAnalysis(): void {
-    this.analyzing = true;
-    this.runningJob = true;
-    this.analysisProgress = 0;
+    this.analyzing.set(true);
+    this.runningJob.set(true);
+    this.analysisProgress.set(0);
 
     // Progress comes from the `eval` SSE channel on /api/events. Use a
     // dedicated notifier to stop watching once the bar reaches 100%: the
@@ -120,7 +136,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (res) => {
           if (res.total > 0) {
-            this.analysisProgress = Math.round((res.progress / res.total) * 100);
+            this.analysisProgress.set(Math.round((res.progress / res.total) * 100));
           }
           if (res.done) {
             stopWatchingProgress$.next();
@@ -145,11 +161,11 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
             this.currentJobId = res.job_id;
             this.pollEvalJob(res.job_id);
           } else {
-            this.analyzing = false;
+            this.analyzing.set(false);
           }
         },
         error: () => {
-          this.analyzing = false;
+          this.analyzing.set(false);
         },
       });
   }
@@ -168,12 +184,12 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
           if (res.status === 'done') {
             this.applyEvalResult(res);
           } else {
-            this.analyzing = false;
+            this.analyzing.set(false);
           }
         },
         error: () => {
           this.currentJobId = null;
-          this.analyzing = false;
+          this.analyzing.set(false);
         },
       });
   }
@@ -192,44 +208,41 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     if (jobId) {
       this.sortingApi.cancelEvalTrainAndScore(jobId).pipe(takeUntil(this.destroy$)).subscribe();
     }
-    this.analyzing = false;
+    this.analyzing.set(false);
     this.close();
   }
 
   private applyEvalResult(res: EvalTrainAndScoreResponse): void {
-    this.analyzing = false;
-    this.runningJob = false;
+    this.analyzing.set(false);
+    this.runningJob.set(false);
     if (this.metric() === 'smart') {
-      this.chartData = (res.error_cost || []) as ErrorCostPoint[];
+      this.chartData.set((res.error_cost || []) as ErrorCostPoint[]);
     } else if (this.metric() === 'stable') {
-      this.chartData = (res.stability || []) as StabilityPoint[];
+      this.chartData.set((res.stability || []) as StabilityPoint[]);
     } else {
-      this.chartData = (res.diversity || []) as DiversityPoint[];
+      this.chartData.set((res.diversity || []) as DiversityPoint[]);
     }
     // Same empty-state handling as the cached path: a job that legitimately
     // produces no points (too little history) shows the explanatory message
     // rather than an empty set of axes.
-    this.emptyHistory = this.chartData.length === 0;
-    if (!this.emptyHistory) {
-      setTimeout(() => this.renderChart(), 50);
-    }
+    this.emptyHistory.set(this.chartData().length === 0);
   }
 
-  private renderChart(): void {
-    const chartCanvas = this.chartCanvas();
-    if (!chartCanvas) return;
-    const canvas = chartCanvas.nativeElement;
+  private renderChart(
+    canvas: HTMLCanvasElement,
+    data: ErrorCostPoint[] | StabilityPoint[] | DiversityPoint[],
+  ): void {
     switch (this.metric()) {
       case 'smart':
-        this.chartsService.renderErrorCostChart(canvas, this.chartData as ErrorCostPoint[]);
+        this.chartsService.renderErrorCostChart(canvas, data as ErrorCostPoint[]);
         break;
       case 'stable':
-        this.chartsService.renderStabilityChart(canvas, this.chartData as StabilityPoint[]);
+        this.chartsService.renderStabilityChart(canvas, data as StabilityPoint[]);
         break;
       case 'diverse':
         this.chartsService.renderDiversityChart(
           canvas,
-          this.chartData as DiversityPoint[],
+          data as DiversityPoint[],
           this.settingsState.settingsSignal()?.autopilot_goal_diversity ?? 40,
         );
         break;


### PR DESCRIPTION
Closes #2919

The app runs `provideZonelessChangeDetection()`, so a plain field written from an async subscribe callback schedules no repaint on an OnPush component. Four components still did that, each with a different user-visible failure. All four are converted to signals (the convention used everywhere else in the codebase), plus one behavioural fix in the progress modal.

## What was broken, and what changed

**`folder-browser.component.ts`** — `rows`, `loading`, `error`, `currentPath`, `rootPath`, `selectedIndex`, `sortKey`, `sortDir` → signals.

The success path was limping along on `pathChange.emit()`, which marks the child view dirty only when the parent actually binds that output. `server-folder-picker.component.html` binds `(pathChange)`; `file-browser.component.html` binds only `(confirm)` — so every `vt-file-browser` usage (the New Detector "Server file" example picker, Add Dataset generic importer forms) sat on "Loading…" after each directory load until the user happened to click inside the panel. The error path had no trigger at all in *any* usage, since nothing in the codebase binds `(loadError)`: the inline "Could not browse this folder." message never rendered anywhere.

**`login.component.ts`** — `busy`, `error` → signals.

On a failed login the DOM stayed on "Logging in…" with both the username input and the submit button `[disabled]="busy"`. Disabled elements fire no events and the login screen has no other listeners, so nothing was left to mark the view dirty — the form was unrecoverable until a page reload.

**`progress-modal.component.ts`** — `analyzing`, `runningJob`, `analysisProgress`, `chartData`, `emptyHistory` → signals, and the chart now draws from an `effect` keyed on the `chartCanvas` viewChild signal plus `chartData`.

This component emits no output on the data path, so it never left "Loading indicator history…": the `@else` branch (and its `#chartCanvas`) never materialised, and the `setTimeout(renderChart, 50)` found `chartCanvas()` undefined and silently no-opped. Keying the draw on the viewChild signal means it fires exactly when the canvas appears, rather than racing it on a fixed timeout. The async-job progress bar and its Cancel affordance never painted either.

**`combine-detectors-modal.component.ts`** — `submitting`, `error` → signals, mirroring the sibling `combine-datasets-modal.component.ts`, which already signalized the same two fields with a comment about zoneless repaint.

A rejected combine (409 duplicate, 422 all-conflicts, …) left the modal on "Combining…" with both the Combine *and* Cancel buttons disabled and the server's message hidden.

## Tests

The existing specs concealed all four regressions — they asserted on instance fields rather than the DOM, and the folder-browser spec's fake `browse` returned a synchronous `of(...)` whose callback runs inside an existing CD pass. Added DOM-level zoneless canaries for each component (new spec files for login and combine-detectors-modal; new cases in the folder-browser and progress-modal specs), driving state through the production channel and asserting on rendered DOM after `settleZoneless()` with no manual `detectChanges()`. The progress-modal canary stubs `ChartsService` so it asserts the chart is actually drawn into the canvas, not just that the canvas exists.

I verified the canaries are real oracles rather than vacuous: reverting `login.component.ts` to its plain-field shape fails exactly the two failure-path canaries (the "disabled while in flight" case still passes, as expected — that state renders inside the click's own CD pass).

`./run-tests.sh` is green: 7860 passed, 1 skipped, 1 xfailed; frontend 1975 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVZvMhZfHu4UNL5m37Mk7k

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVZvMhZfHu4UNL5m37Mk7k)_