### PR TITLE
Route media_url fetches through the SSRF guard

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -749,7 +749,7 @@ Each clip dict includes two provenance fields:
 |-------|------|-------------|
 | `origin` | `dict \| None` | Serialised `Origin` (e.g. `{"importer": "server_folder", "params": {"path": "/data"}}`) |
 | `origin_name` | `str` | Unique name within the origin (typically the filename) |
-| `media_url` | `str \| None` | Remote URL for lazy-fetching media bytes (e.g. PullWrest URL). Used as fallback when `media_bytes` and `media_path` are both absent |
+| `media_url` | `str \| None` | Remote URL for lazy-fetching media bytes (e.g. PullWrest URL). Used as fallback when `media_bytes` and `media_path` are both absent. Fetched only through the SSRF guard (`fetch_validated_url`): publicly routable `http(s)` only, every redirect hop re-checked |
 
 ### Origin class (`vtscore/datasets/origin.py`)
 

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -424,6 +424,13 @@ in this priority order:
 2. `media_path`; local file on disk (thin mode with local files).
 3. `media_url`; remote URL (fetched on demand).
 
+The `media_url` fetch goes through the project's SSRF guard
+(`vtscore.security.url_validation.fetch_validated_url`), so it must be a
+publicly routable `http(s)` URL and every redirect hop is re-checked.  A
+`file://` or private-network URL fetches nothing and resolves to `None` /
+`""`; a URL-backed importer that needs a local file should set
+`media_path` instead.
+
 In thin mode, URL-backed importers can skip downloading entirely: set
 `media_bytes=None`, `media_path=None`, and `media_url="https://..."`.
 Embeddings and MD5 can come from external services, so sorting and scoring

--- a/docs/plans/codebase-audit-2026-08.md
+++ b/docs/plans/codebase-audit-2026-08.md
@@ -117,6 +117,7 @@ carries pointers only.
 ### Security
 
 - [ ] #2926 — SSRF + arbitrary local file disclosure via unvalidated media_url (file:// / internal http fetched with urllib.urlopen) (high, Opus 4.8)
+- [ ] #3003 — Arbitrary local file disclosure via unconfined media_path from an externally-supplied pickle (medium, Opus 4.8)
 - [ ] #2946 — No server-side authentication enforcement: is_authenticated / login_required are never checked, so every endpoint is reachable unauthenticated (medium, Opus 4.8)
 - [ ] #2950 — SSRF DNS-rebinding window: validate_url resolves-and-checks, then the fetch re-resolves the hostname (medium, Opus 4.8)
 

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -1127,6 +1127,22 @@ def validate_url(url: str) -> str:
     """SSRF guard for outbound HTTP. Rejects private IPs, link-local, and metadata
     endpoints. Returns the validated URL."""
 
+def open_validated_stream(
+    session: requests.Session,
+    url: str,
+    *,
+    headers_for_url: Callable[[str], dict] | None = None,
+    timeout: tuple[float, float] = (10, 60),
+) -> requests.Response:
+    """Stream an *already-validated* URL with allow_redirects=False, re-running
+    validate_url on every hop so a public URL can't 302 to an internal host.
+    `headers_for_url` is recomputed per hop so host-scoped credentials aren't
+    replayed to a redirect target. Caller closes the returned response."""
+
+def fetch_validated_url(url: str, *, timeout: tuple[float, float] = (10, 30)) -> bytes:
+    """validate_url + open_validated_stream + raise_for_status, returning the whole
+    body. The fetch primitive for byte-wanting callers (e.g. a media's media_url)."""
+
 def validate_browser_url(url: str) -> str:
     """Scheme allowlist for URLs the *user's browser* opens (an exporter's
     `open_url`). Rejects non-HTTP(S) schemes, whitespace/control characters, and

--- a/tests_lib/core/test_ssrf_validation.py
+++ b/tests_lib/core/test_ssrf_validation.py
@@ -1,16 +1,19 @@
 """Tests for SSRF URL validation.
 
 Verifies that :func:`vtscore.security.url_validation.validate_url` blocks
-requests to private/internal network addresses while allowing public URLs.
-Also verifies that the HTTP archive importer and webhook exporter both
-call the validator.
+requests to private/internal network addresses while allowing public URLs,
+that :func:`~vtscore.security.url_validation.open_validated_stream` re-checks
+every redirect hop, and that the HTTP archive importer, the webhook exporter,
+and the ``media_url`` media fetch all go through the guard.
 """
 
 from __future__ import annotations
 
+from typing import cast
 from unittest import mock
 
 import pytest
+import requests
 
 from vtscore.security.url_validation import validate_url
 
@@ -144,6 +147,274 @@ class TestValidateUrlPrivateIPs:
         ):
             with pytest.raises(ValueError, match="private/internal"):
                 validate_url("http://dual-homed.example/")
+
+
+# ---------------------------------------------------------------------------
+# open_validated_stream – per-hop redirect revalidation
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for a streamed ``requests.Response``."""
+
+    def __init__(self, status_code: int, location: str | None = None, body: bytes = b""):
+        self.status_code = status_code
+        self.headers = {"Location": location} if location else {}
+        self.content = body
+        self.closed = False
+
+    @property
+    def is_redirect(self) -> bool:
+        return 300 <= self.status_code < 400 and "Location" in self.headers
+
+    @property
+    def is_permanent_redirect(self) -> bool:
+        return self.status_code in (301, 308) and "Location" in self.headers
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+
+class _FakeSession:
+    """Session that replays a scripted chain of responses and records hops."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.hops: list[tuple[str, dict]] = []
+
+    def get(self, url, **kwargs):
+        self.hops.append((url, kwargs.get("headers") or {}))
+        if self._responses:
+            return self._responses.pop(0)
+        return _FakeResponse(200, body=b"end")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def as_session(self) -> requests.Session:
+        """Typed view for the duck-typed ``session`` parameter.
+
+        ``open_validated_stream`` only ever calls ``.get()``, but its signature
+        names the real class; this keeps the fake usable without widening the
+        production annotation to a bespoke protocol.
+        """
+        return cast(requests.Session, self)
+
+
+class TestOpenValidatedStream:
+    """A one-time up-front check is not enough: each hop is re-resolved."""
+
+    def _resolve(self, ip):
+        return mock.patch(
+            "vtscore.security.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", (ip, 0))],
+        )
+
+    def test_redirect_to_internal_host_is_rejected(self):
+        from vtscore.security.url_validation import open_validated_stream
+
+        session = _FakeSession([_FakeResponse(302, location="http://169.254.169.254/latest/meta-data/")])
+        with self._resolve("169.254.169.254"):
+            with pytest.raises(ValueError, match="private/internal"):
+                open_validated_stream(session.as_session(), "https://public.example/media.wav")
+        # Only the first hop was ever issued; the internal target was not fetched.
+        assert [hop for hop, _ in session.hops] == ["https://public.example/media.wav"]
+
+    def test_redirect_to_non_http_scheme_is_rejected(self):
+        from vtscore.security.url_validation import open_validated_stream
+
+        session = _FakeSession([_FakeResponse(302, location="file:///etc/passwd")])
+        with pytest.raises(ValueError, match="http or https"):
+            open_validated_stream(session.as_session(), "https://public.example/media.wav")
+
+    def test_follows_a_public_redirect_chain(self):
+        from vtscore.security.url_validation import open_validated_stream
+
+        session = _FakeSession(
+            [
+                _FakeResponse(302, location="https://cdn.example/final.wav"),
+                _FakeResponse(200, body=b"payload"),
+            ]
+        )
+        with self._resolve("93.184.216.34"):
+            response = open_validated_stream(session.as_session(), "https://public.example/media.wav")
+        assert response.content == b"payload"
+        assert [hop for hop, _ in session.hops] == [
+            "https://public.example/media.wav",
+            "https://cdn.example/final.wav",
+        ]
+
+    def test_relative_location_is_resolved_against_the_current_hop(self):
+        from vtscore.security.url_validation import open_validated_stream
+
+        session = _FakeSession([_FakeResponse(302, location="/elsewhere.wav"), _FakeResponse(200, body=b"ok")])
+        with self._resolve("93.184.216.34"):
+            open_validated_stream(session.as_session(), "https://public.example/a/media.wav")
+        assert session.hops[1][0] == "https://public.example/elsewhere.wav"
+
+    def test_headers_are_recomputed_per_hop(self):
+        """Credentials scoped to one host must not be replayed to the next."""
+        from vtscore.security.url_validation import open_validated_stream
+
+        session = _FakeSession([_FakeResponse(302, location="https://cdn.example/final.wav"), _FakeResponse(200)])
+        with self._resolve("93.184.216.34"):
+            open_validated_stream(
+                session.as_session(),
+                "https://public.example/media.wav",
+                headers_for_url=lambda u: {"Authorization": "secret"} if "public.example" in u else {},
+            )
+        assert session.hops[0][1] == {"Authorization": "secret"}
+        assert session.hops[1][1] == {}
+
+    def test_gives_up_past_the_redirect_cap(self):
+        from vtscore.security.url_validation import MAX_REDIRECTS, open_validated_stream
+
+        session = _FakeSession(
+            [_FakeResponse(302, location=f"https://h{i}.example/x") for i in range(MAX_REDIRECTS + 2)]
+        )
+        with self._resolve("93.184.216.34"):
+            with pytest.raises(requests.TooManyRedirects):
+                open_validated_stream(session.as_session(), "https://public.example/media.wav")
+
+    def test_does_not_validate_the_first_url(self):
+        """The caller owns the up-front check; this covers only the hops after it."""
+        from vtscore.security.url_validation import open_validated_stream
+
+        session = _FakeSession([_FakeResponse(200, body=b"ok")])
+        with mock.patch("vtscore.security.url_validation.socket.getaddrinfo") as mock_gai:
+            open_validated_stream(session.as_session(), "https://public.example/media.wav")
+        mock_gai.assert_not_called()
+
+
+class TestFetchValidatedUrl:
+    def test_rejects_file_scheme_before_any_request(self):
+        from vtscore.security.url_validation import fetch_validated_url
+
+        with mock.patch("vtscore.security.url_validation.requests.Session") as mock_session:
+            with pytest.raises(ValueError, match="http or https"):
+                fetch_validated_url("file:///etc/passwd")
+        mock_session.assert_not_called()
+
+    def test_rejects_internal_host_before_any_request(self):
+        from vtscore.security.url_validation import fetch_validated_url
+
+        with mock.patch(
+            "vtscore.security.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", ("127.0.0.1", 0))],
+        ):
+            with mock.patch("vtscore.security.url_validation.requests.Session") as mock_session:
+                with pytest.raises(ValueError, match="private/internal"):
+                    fetch_validated_url("http://localhost:5000/api/settings")
+        mock_session.assert_not_called()
+
+    def test_returns_body_for_a_public_url(self):
+        from vtscore.security.url_validation import fetch_validated_url
+
+        session = _FakeSession([_FakeResponse(200, body=b"media-bytes")])
+        with mock.patch(
+            "vtscore.security.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
+        ):
+            with mock.patch("vtscore.security.url_validation.requests.Session", return_value=session):
+                assert fetch_validated_url("https://public.example/m.wav") == b"media-bytes"
+
+    def test_raises_on_error_status(self):
+        from vtscore.security.url_validation import fetch_validated_url
+
+        session = _FakeSession([_FakeResponse(404)])
+        with mock.patch(
+            "vtscore.security.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
+        ):
+            with mock.patch("vtscore.security.url_validation.requests.Session", return_value=session):
+                with pytest.raises(requests.HTTPError):
+                    fetch_validated_url("https://public.example/missing.wav")
+
+
+# ---------------------------------------------------------------------------
+# media_url – SSRF protection integration
+# ---------------------------------------------------------------------------
+
+
+class TestMediaUrlSSRF:
+    """``media_url`` rides along on a media dict that can come from a loaded
+    pickle, and whatever it fetches is served straight back to the requester.
+    It must not be able to name a local file or an internal service.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "file://localhost/etc/shadow",
+            "ftp://evil.example/creds",
+            "/etc/passwd",
+        ],
+    )
+    def test_non_http_media_url_fetches_nothing(self, url):
+        from vtscore.media.base import _fetch_media_url
+
+        with mock.patch("vtscore.security.url_validation.requests.Session") as mock_session:
+            assert _fetch_media_url(url) is None
+        mock_session.assert_not_called()
+
+    @pytest.mark.parametrize("ip", ["127.0.0.1", "169.254.169.254", "10.0.0.5", "192.168.1.1"])
+    def test_internal_media_url_fetches_nothing(self, ip):
+        from vtscore.media.base import _fetch_media_url
+
+        with mock.patch(
+            "vtscore.security.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", (ip, 0))],
+        ):
+            with mock.patch("vtscore.security.url_validation.requests.Session") as mock_session:
+                assert _fetch_media_url(f"http://{ip}/latest/meta-data/") is None
+        mock_session.assert_not_called()
+
+    def test_public_media_url_still_fetches(self):
+        from vtscore.media.base import _fetch_media_url
+
+        session = _FakeSession([_FakeResponse(200, body=b"remote-media")])
+        with mock.patch(
+            "vtscore.security.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
+        ):
+            with mock.patch("vtscore.security.url_validation.requests.Session", return_value=session):
+                assert _fetch_media_url("https://pullwrest.example/media/123") == b"remote-media"
+
+    def test_resolve_media_bytes_refuses_a_file_url(self, tmp_path):
+        """End-to-end: a pickled ``file://`` media_url must not read the disk."""
+        from vtscore.media.audio.media_type import AudioMediaType
+
+        secret = tmp_path / "secret.txt"
+        secret.write_bytes(b"top-secret")
+
+        mt = AudioMediaType()
+        media = {"media_bytes": None, "media_path": None, "media_url": secret.as_uri()}
+        assert mt._resolve_media_bytes(media) is None
+
+    def test_resolve_media_string_refuses_a_file_url(self, tmp_path):
+        from vtscore.media.text.media_type import TextMediaType
+
+        secret = tmp_path / "secret.txt"
+        secret.write_text("top-secret")
+
+        mt = TextMediaType()
+        media = {"media_string": None, "media_path": None, "media_url": secret.as_uri()}
+        assert mt._resolve_media_string(media) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -15,16 +15,14 @@ import uuid
 import zipfile
 from pathlib import Path
 from typing import Callable, Literal, Optional
-from urllib.parse import urljoin
 
 import requests
 
 from vtscore.config import DATA_DIR
 from vtscore.security.archive import safe_tar_extract
 from vtscore.security.hf_auth import GatedResourceError, auth_header_for_url
-from vtscore.security.url_validation import validate_url
+from vtscore.security.url_validation import open_validated_stream, validate_url
 
-_MAX_REDIRECTS = 10
 # Statuses that mean "this resource is gated / needs credentials we don't have".
 # These are surfaced as a short, actionable GatedResourceError rather than a
 # raw HTTPError, and are never retried (retrying without auth can't succeed).
@@ -274,45 +272,21 @@ def _request_headers(url: str, headers: Optional[dict]) -> dict:
 
 
 def _open_validated_stream(session: requests.Session, url: str, headers: Optional[dict] = None) -> requests.Response:
-    """GET *url* as a stream, following redirects manually so every hop is
-    re-checked by :func:`validate_url`.
+    """GET *url* as a stream with every redirect hop re-checked for SSRF.
 
-    We follow redirects by hand (``allow_redirects=False``) so a public URL
-    cannot redirect to an internal host (SSRF), bypassing the up-front check
-    callers performed. The ``(connect, read)`` timeout fails fast on an
-    unresponsive host and aborts if the server stalls for 60s mid-stream.
+    A thin binding of :func:`~vtscore.security.url_validation.open_validated_stream`
+    to the downloader's needs: caller *headers* merged with a HuggingFace bearer
+    token recomputed per hop, so the token follows a redirect only to another
+    Hub host and never to a presigned CDN / Xet target.  Callers validate *url*
+    itself up front; this covers the hops after it.
 
     Returns the final, non-redirect response; the caller owns closing it.
     """
-    current_url = url
-    response = session.get(
-        current_url,
-        stream=True,
-        timeout=(10, 60),
-        allow_redirects=False,
-        headers=_request_headers(current_url, headers),
+    return open_validated_stream(
+        session,
+        url,
+        headers_for_url=lambda hop: _request_headers(hop, headers),
     )
-    redirects = 0
-    while response.is_redirect or response.is_permanent_redirect:
-        if redirects >= _MAX_REDIRECTS:
-            response.close()
-            raise requests.TooManyRedirects(f"Exceeded {_MAX_REDIRECTS} redirects following {url}")
-        location = response.headers.get("Location")
-        if not location:
-            break
-        next_url = urljoin(current_url, location)
-        validate_url(next_url)
-        response.close()
-        current_url = next_url
-        response = session.get(
-            current_url,
-            stream=True,
-            timeout=(10, 60),
-            allow_redirects=False,
-            headers=_request_headers(current_url, headers),
-        )
-        redirects += 1
-    return response
 
 
 def _total_size_from_headers(response: requests.Response, downloaded: int, expected_size: int) -> int:

--- a/vtscore/docs/packages/security.md
+++ b/vtscore/docs/packages/security.md
@@ -17,6 +17,7 @@ the load pipeline that calls these helpers during dataset import.
 - [Path validation](#path-validation)
 - [URL validation](#url-validation)
   - [`validate_url` (SSRF guard)](#validate_url-ssrf-guard)
+  - [Fetching: `open_validated_stream` / `fetch_validated_url`](#fetching-open_validated_stream--fetch_validated_url)
   - [Browser-URL validation](#browser-url-validation)
 - [Pickle safety](#pickle-safety)
 - [Why no `find_class` shim is needed](#why-no-find_class-shim-is-needed)
@@ -108,6 +109,12 @@ similar and defend against different things, so pick by **who makes the
 request**: `validate_url` for URLs *the server* fetches, and
 `validate_browser_url` for URLs *the user's browser* opens.
 
+Alongside them sit the two fetch primitives every server-side fetch is
+meant to go through, `open_validated_stream` and `fetch_validated_url`.
+A single up-front `validate_url` is not enough on its own - a public URL
+can `302` to an internal host - so the redirect chain has to be walked by
+hand with each hop re-checked.
+
 ### `validate_url` (SSRF guard)
 
 For SSRF protection on outbound HTTP requests:
@@ -145,6 +152,41 @@ validate_url("http://169.254.169.254/latest/meta-data/") # raises ValueError
 validate_url("file:///etc/passwd")                       # raises ValueError
 validate_url("https://10.0.0.1/")                        # raises ValueError
 ```
+
+### Fetching: `open_validated_stream` / `fetch_validated_url`
+
+```python
+def open_validated_stream(session, url, *, headers_for_url=None,
+                          timeout=(10, 60)) -> requests.Response:
+    """GET an already-validated url with allow_redirects=False, re-running
+    validate_url on every hop.  Returns the final response; caller closes."""
+
+def fetch_validated_url(url: str, *, timeout=(10, 30)) -> bytes:
+    """validate_url + open_validated_stream + raise_for_status, returning
+    the whole body."""
+```
+
+`open_validated_stream` deliberately does **not** validate its first URL:
+the caller owns that check, and this covers only the hops the caller
+cannot see. That split is what lets the resuming downloader validate once
+and then retry a partial transfer without paying a fresh DNS resolve per
+attempt (and without a transient resolver failure turning a retryable
+connection error into a hard `ValueError`). `headers_for_url` is
+recomputed per hop, so a credential scoped to one host - the HuggingFace
+bearer token, say - is never replayed to a redirect target on another.
+
+`fetch_validated_url` is the whole-body convenience wrapper for fetch
+sites that want bytes rather than a stream to spool to disk. It is what
+`vtscore.media.base._fetch_media_url` calls, so a media's `media_url` -
+which can arrive verbatim from a loaded pickle and whose bytes are served
+straight back to the requester - cannot name `file:///etc/passwd` or an
+internal service. (It previously used `urllib.request.urlopen`, whose
+default opener services `file://` and `ftp://` and obliged.)
+
+Users of these primitives: the dataset downloader
+(`vtscore/datasets/downloader/core.py`) and the `media_url` fallback in
+`vtscore/media/base.py`. A new outbound fetch belongs here too rather
+than reaching for `requests.get` / `urlopen` directly.
 
 ### Browser-URL validation
 

--- a/vtscore/media/base.py
+++ b/vtscore/media/base.py
@@ -43,18 +43,30 @@ __all__ = [
 
 
 def _fetch_media_url(url: str) -> bytes | None:
-    """Fetch binary content from a ``media_url``.
+    """Fetch binary content from a ``media_url``, or ``None`` if it can't be had.
 
     Used by :meth:`MediaType._resolve_media_bytes` and
     :meth:`MediaType._resolve_media_string` as a last-resort fallback when
     neither ``media_bytes`` nor ``media_path`` are available (e.g. for
     URL-backed media from PullWrest).
+
+    A ``media_url`` is **not** trusted input.  It rides along on a media dict
+    that can arrive from a loaded pickle
+    (``vtscore.datasets.loader_pickle._restore_media_url``), and whatever this
+    returns is served straight back to the requester by the media routes.  It
+    therefore goes through
+    :func:`~vtscore.security.url_validation.fetch_validated_url`, the same SSRF
+    guard the URL-backed dataset sources and the downloader use: only publicly
+    routable ``http(s)`` URLs, with every redirect hop re-checked.  That is what
+    keeps a ``file:///etc/passwd`` or ``http://169.254.169.254/…`` media_url
+    from turning a media fetch into an arbitrary file read or an internal
+    network probe — ``urllib.request.urlopen``, which this used to call, services
+    ``file://`` and ``ftp://`` out of the box and would have obliged.
     """
-    import urllib.request
+    from vtscore.security.url_validation import fetch_validated_url  # noqa: PLC0415
 
     try:
-        with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310
-            return resp.read()
+        return fetch_validated_url(url)
     except Exception:
         logger = logging.getLogger(__name__)
         logger.warning("Failed to fetch media_url: %s", url, exc_info=True)
@@ -596,7 +608,8 @@ class MediaType(ABC):
            sliced/cropped from the source on demand (see
            :mod:`vtscore.media.lazy_clip`).
         3. ``media_path`` - local file on disk (thin mode).
-        4. ``media_url`` - remote URL (URL-backed media, e.g. PullWrest).
+        4. ``media_url`` - remote URL (URL-backed media, e.g. PullWrest),
+           fetched only through the SSRF guard in :func:`_fetch_media_url`.
         """
         media_bytes = media.get("media_bytes")
         if media_bytes is not None:

--- a/vtscore/security/url_validation.py
+++ b/vtscore/security/url_validation.py
@@ -12,13 +12,26 @@ Two guards live here, and they defend against different things:
   when a URL is handed to the frontend to open.
 
 Pick by *who makes the request*, not by where the string came from.
+
+Alongside them sits :func:`open_validated_stream`, the one fetch primitive
+every server-side URL fetch is meant to go through.  A single up-front
+:func:`validate_url` is not enough on its own: a public URL can 302 to an
+internal host, so the redirect chain has to be walked by hand with each hop
+re-checked.  Keeping that loop here rather than in one caller is what stops
+the next fetch site from quietly re-introducing a bypass.
 """
 
 from __future__ import annotations
 
 import ipaddress
 import socket
-from urllib.parse import urlparse
+from typing import Callable, Optional
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+#: Redirect hops :func:`open_validated_stream` will follow before giving up.
+MAX_REDIRECTS = 10
 
 
 def _is_private_ip(ip_str: str) -> bool:
@@ -64,6 +77,100 @@ def validate_url(url: str) -> str:
             )
 
     return url
+
+
+def open_validated_stream(
+    session: requests.Session,
+    url: str,
+    *,
+    headers_for_url: Optional[Callable[[str], dict]] = None,
+    timeout: tuple[float, float] = (10, 60),
+) -> requests.Response:
+    """GET *url* as a stream, following redirects manually so every hop is
+    re-checked by :func:`validate_url`.
+
+    We follow redirects by hand (``allow_redirects=False``) so a public URL
+    cannot redirect to an internal host (SSRF), bypassing the up-front check.
+    The ``(connect, read)`` timeout fails fast on an unresponsive host and
+    aborts if the server stalls mid-stream.
+
+    The **caller** validates the first URL — pass a *url* that has already been
+    through :func:`validate_url`.  This function owns only the hops after it,
+    which the caller has no chance to see.  (Keeping the initial check outside
+    means a caller that already validated, like the resuming downloader, does
+    not pay a fresh DNS resolve on every retry, and a transient resolver
+    failure surfaces as a retryable connection error rather than a hard
+    ``ValueError``.)
+
+    Args:
+        session: The :class:`requests.Session` to issue each hop on.
+        url: An already-validated HTTP(S) URL.
+        headers_for_url: Optional callable returning the headers to send for a
+            given hop's URL.  Recomputed per hop so credentials scoped to one
+            host are not replayed to a redirect target on another.
+        timeout: ``(connect, read)`` timeout passed to each request.
+
+    Returns:
+        The final, non-redirect response; the caller owns closing it.
+
+    Raises:
+        ValueError: If a redirect hop fails :func:`validate_url`.
+        requests.TooManyRedirects: If the chain exceeds :data:`MAX_REDIRECTS`.
+    """
+
+    def _headers(target: str) -> dict:
+        return headers_for_url(target) if headers_for_url is not None else {}
+
+    current_url = url
+    response = session.get(
+        current_url,
+        stream=True,
+        timeout=timeout,
+        allow_redirects=False,
+        headers=_headers(current_url),
+    )
+    redirects = 0
+    while response.is_redirect or response.is_permanent_redirect:
+        if redirects >= MAX_REDIRECTS:
+            response.close()
+            raise requests.TooManyRedirects(f"Exceeded {MAX_REDIRECTS} redirects following {url}")
+        location = response.headers.get("Location")
+        if not location:
+            break
+        next_url = urljoin(current_url, location)
+        validate_url(next_url)
+        response.close()
+        current_url = next_url
+        response = session.get(
+            current_url,
+            stream=True,
+            timeout=timeout,
+            allow_redirects=False,
+            headers=_headers(current_url),
+        )
+        redirects += 1
+    return response
+
+
+def fetch_validated_url(url: str, *, timeout: tuple[float, float] = (10, 30)) -> bytes:
+    """Fetch *url* into memory through the full SSRF guard and return its body.
+
+    The whole-body counterpart to :func:`open_validated_stream`, for the fetch
+    sites that want bytes rather than a stream to spool to disk (see
+    :func:`vtscore.media.base._fetch_media_url`).  Validates *url* up front,
+    re-validates every redirect hop, and raises for a non-2xx status.
+
+    Raises:
+        ValueError: If *url* — or any redirect hop — is not a publicly
+            routable ``http(s)`` URL.
+        requests.RequestException: On any transport or HTTP error.
+    """
+    validate_url(url)
+    with requests.Session() as session:
+        response = open_validated_stream(session, url, timeout=timeout)
+        with response:
+            response.raise_for_status()
+            return response.content
 
 
 def validate_browser_url(url: str) -> str:


### PR DESCRIPTION
Closes #2920, closes #2926. (The two are the same finding filed twice by the August audit.)

## The hole

`vtscore/media/base.py:_fetch_media_url` fetched a media's `media_url` with `urllib.request.urlopen(url, timeout=30)` — no scheme restriction, no SSRF check. The `# noqa: S310` on that line silenced exactly bandit's audit of `urlopen` for non-http schemes.

`media_url` is not trusted input. `loader_pickle._restore_media_url` copies it verbatim off a loaded pickle (`RestrictedUnpickler` happily permits a plain string field), and whatever the fetch returns is handed straight back to the requester by the media routes (`_resolve_media_bytes` → `GET /api/medias/<id>/media`). Since urllib's default opener services `file://` and `ftp://` alongside `http(s)`:

- a pickled `media_url` of `file:///etc/passwd` read and served any server-readable file;
- `http://169.254.169.254/latest/meta-data/` or `http://127.0.0.1:PORT/...` probed and exfiltrated internal services.

The sibling `url_download` source already called `validate_url` before fetching, and the downloader already re-checked every redirect hop — this was the one fetch site that bypassed the project's own SSRF policy.

## The fix

`_fetch_media_url` now calls a new `vtscore.security.url_validation.fetch_validated_url`, which validates up front and re-checks every redirect hop. A failed URL logs and returns `None`, exactly as before, so the resolution chain's contract is unchanged.

Rather than add a second copy of the redirect loop, the policy is consolidated in the security module:

- `open_validated_stream(session, url, *, headers_for_url=None, timeout=...)` — the downloader's private `_open_validated_stream`, moved. Per-hop headers now come from a callback so the HuggingFace bearer token still follows a redirect only to another Hub host, never to a presigned CDN target. The downloader keeps a thin binding that supplies that callback; its behavior is byte-for-byte what it was.
- `fetch_validated_url(url, *, timeout=...)` — `validate_url` + `open_validated_stream` + `raise_for_status`, returning the whole body. For callers that want bytes rather than a stream to spool to disk.

`open_validated_stream` deliberately does **not** validate its first URL — the caller owns that check, and this covers only the hops the caller cannot see. That split is what lets the resuming downloader validate once and then retry a partial transfer without a fresh DNS resolve per attempt, and keeps a transient resolver failure a retryable `ConnectionError` instead of a hard `ValueError` that aborts the download.

## Deliberately out of scope

The `media_path` branch next door is the same class of issue for an externally-supplied pickle (`media_path: "/etc/shadow"` is read and served with no per-user confinement). Confining it is *not* the one-liner the issue suggests: `validate_server_filepath(..., base_dir=get_file_access_base_dir())` is a no-op in single-user mode but, in multi-user mode, would reject the shared demo-dataset roots under `DATA_DIR` that every demo references by absolute path. That needs an allowed-roots policy decision, so it is filed as #3003 rather than guessed at here.

## Verification

- New coverage in `tests_lib/core/test_ssrf_validation.py`: `file://` / `ftp://` / schemeless / private-IP `media_url`s fetch nothing and never construct a session; a public one still returns its bytes; end-to-end, `_resolve_media_bytes` returns `None` and `_resolve_media_string` returns `""` for a `file://` URL pointing at a real on-disk file. Plus `open_validated_stream` itself: a public URL that 302s to `169.254.169.254` or to `file://` is rejected before the second hop is issued, relative `Location`s resolve against the current hop, headers are recomputed per hop, and the chain gives up past `MAX_REDIRECTS`.
- `./run-tests.sh` — 7882 passed, 1 skipped, 2 xpassed.
- `./run-tests.sh vtscore-clean` — 3815 passed.
- `python scripts/check-eval-app-sync.py` — 10 mirrors up to date, nothing owed.

## Docs

`vtscore/docs/packages/security.md` gains a section on the two fetch primitives and why the first-URL check sits with the caller; `docs/vtscore-api.md`, `docs/ARCHITECTURE.md`, and `docs/EXTENDING-plugins.md` note that a `media_url` must now be a publicly routable `http(s)` URL.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QwYqy3Y2xpUUkmzi44tzoz)_