### PR TITLE
Scope Find/Train sort work to the active pair so stale responses can't land

### DIFF
--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -126,6 +126,23 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly CENTER_MIN = 100;
   private readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
   private destroy$ = new Subject<void>();
+  /**
+   * Fires whenever the active (dataset, detector) pair changes — and on
+   * destroy. Every request whose response writes *pair-scoped* state (the
+   * ranking, the threshold, the inclusion slider, the dataset name, the vote
+   * cache) is piped through `takeUntil(this.pairScope$)` rather than
+   * `destroy$`, so the work started for the pair we're leaving is torn down
+   * the instant the pair switches.
+   *
+   * Without it, a scoring run — minutes long on a large dataset — outlives the
+   * switch: whichever response lands last wins, so the *old* pair's ranking and
+   * threshold get installed into the new context, and `advanceToBoundary()`
+   * selects a media id that may not exist in the new dataset (broken viewer,
+   * image 404s). Even when the old response lands *first*, its `finalize()`
+   * drops the wait overlay and re-enables voting while the new run is still
+   * going. `takeUntil` here also aborts the stale XHR client-side.
+   */
+  private pairScope$ = new Subject<void>();
   private dragging = false;
   private draggingRight = false;
   private boundMouseMove = this.onMouseMove.bind(this);
@@ -218,7 +235,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // The left work queue (ranking minus verified items) is the
     // `unverifiedSortOrder` computed, which tracks sortOrder + verifiedIds.
     this.loadSettings();
-    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
+    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
       next: (status) => { this.datasetName.set(status.display_name || ''); },
     });
 
@@ -258,13 +275,20 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private reloadForNewPair(): void {
+    // Supersede the pair we're leaving *first*: every in-flight request scoped
+    // to it dies here, before any of the new pair's state is installed, so no
+    // late response can write the old ranking/threshold into the new context.
+    // The old scoring run's `finalize()` runs as part of this teardown, which
+    // is why it can't clobber the fresh run started at the bottom of this
+    // method — that run begins after the teardown has already settled.
+    this.pairScope$.next();
     this.sortState.setSortResults([], 0);
     this.sortState.setSortStatus('');
     this.sortState.setSortProgress(0, 0);
     this.voteState.clear();
     this.mediaState.loadMedias();
     this.voteState.loadVotes();
-    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
+    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
       next: (status) => { this.datasetName.set(status.display_name || ''); },
     });
     this.seedInclusion();
@@ -275,7 +299,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private seedInclusion(): void {
     this.sortingApi
       .getInclusion()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this.pairScope$))
       .subscribe({ next: (resp) => this.sortState.setInclusion(resp.inclusion) });
   }
 
@@ -285,6 +309,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.stopProgressPolling();
+    this.pairScope$.next();
+    this.pairScope$.complete();
     this.destroy$.next();
     this.destroy$.complete();
     this.voteState.setFindMode(false);
@@ -368,7 +394,10 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const modelName = this.activeDetector.detectorName() || 'Detector';
     this.detectorsFindApi.findLabel({ detector_id: modelId })
       .pipe(
-        takeUntil(this.destroy$),
+        // Pair-scoped, NOT lifetime-scoped: scoring runs for minutes, so a pair
+        // switch mid-run must kill this subscription before its response can
+        // rank the new pair with the old pair's scores (see `pairScope$`).
+        takeUntil(this.pairScope$),
         finalize(() => {
           this.stopProgressPolling();
           this.sortState.setSortBusy(false);
@@ -509,7 +538,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.sortState.setInclusion(value);
     this.sortingApi
       .setInclusion(value)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this.pairScope$))
       .subscribe({
         next: (resp) => {
           if (resp.threshold != null && this.sortState.sortOrder) {
@@ -528,7 +557,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const name = m?.filename || m?.origin_name || `#${event.id}`;
     this.voteState
       .submitToggleVoteAndRecord(event.id, event.vote, name)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this.pairScope$))
       .subscribe({
         next: () => {
           this.onMediaVoted(event);

--- a/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
+++ b/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
@@ -4,6 +4,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 
 import { FindViewComponent } from './find-view.component';
+import { ActiveContextService } from '../../services/active-context.service';
 import { SortStateService } from '../../services/sort-state.service';
 import { BrowseSubsetService } from '../../services/browse-subset.service';
 import { configureZoneless } from '../../testing/zoneless-testbed';
@@ -167,5 +168,98 @@ describe('FindViewComponent (zoneless canary)', () => {
     await settleZoneless(fixture);
 
     expect(sortState.sortOrder?.map((s) => s.id)).toEqual([999]);
+  });
+});
+
+/**
+ * Issue #2921: a find-label scoring run outlives the pair it was started for.
+ * Scoring takes minutes on a large dataset, so switching the active
+ * (dataset, detector) pair mid-run used to leave two live subscriptions racing:
+ * whichever landed last installed its ranking + threshold into the *active*
+ * context, and `advanceToBoundary()` then selected a media id that need not
+ * exist in the new dataset. Even the old response landing first was harmful —
+ * its `finalize()` dropped the wait overlay while the new run was still going.
+ * The run is now scoped to the pair (`pairScope$`), so a switch tears it down.
+ */
+describe('FindViewComponent (pair-switch supersession)', () => {
+  let fixture: ComponentFixture<FindViewComponent>;
+  let httpMock: HttpTestingController;
+  let activeContext: ActiveContextService;
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [FindViewComponent],
+      providers: [...provideHttpTesting(), provideRouter([])],
+    }).compileComponents();
+
+    activeContext = TestBed.inject(ActiveContextService);
+    // A detector must be active before ngOnInit or `runFindLabel` no-ops. Set
+    // it *before* creating the component so the pair$ replay this seeds is the
+    // subscription's skipped first emission, not a spurious reload.
+    activeContext.setActivePair('ds1', 'det1');
+
+    fixture = TestBed.createComponent(FindViewComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    fixture.componentInstance.ngOnDestroy();
+    httpMock.match(() => true).forEach((req) => {
+      if (!req.cancelled) req.flush([]);
+    });
+    fixture.destroy();
+  });
+
+  // Same drain as the canary above, plus the dataset-status read (no assertion
+  // rides it here). The dataset is *images*: this spec is the only find-view
+  // one that installs a ranking, which auto-selects the top item into the
+  // centre viewer — and the audio player's waveform-decode path needs Web Audio,
+  // which jsdom does not implement.
+  async function flushInit(): Promise<void> {
+    TestBed.tick();
+    for (let i = 0; i < 3; i++) {
+      await settleResource();
+      httpMock.match('/api/medias/ids').forEach((req) =>
+        req.flush([{ id: 1, media_type: 'image' }]),
+      );
+      httpMock.match('/api/votes').forEach((req) =>
+        req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
+      );
+      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 80 }));
+      httpMock.match('/api/inclusion').forEach((req) => req.flush({ inclusion: 0 }));
+      httpMock.match('/api/media-types').forEach((req) => req.flush({ media_types: [] }));
+      httpMock.match('/api/embedders').forEach((req) => req.flush([]));
+      httpMock.match('/api/dataset/status').forEach((req) => req.flush({ display_name: 'ds' }));
+    }
+  }
+
+  it('cancels the previous pair\'s scoring run and keeps the overlay on the new one', async () => {
+    const sortState = TestBed.inject(SortStateService);
+    await flushInit();
+    await settleZoneless(fixture);
+
+    // Pair one's scoring run is in flight behind the wait overlay.
+    const staleScore = httpMock.expectOne('/api/find-label');
+    expect(staleScore.cancelled).toBe(false);
+    expect(sortState.sortBusy).toBe(true);
+
+    // The user switches pair while that run is still going.
+    activeContext.setActivePair('ds2', 'det2');
+
+    // The stale run is aborted client-side, so its ranking can never land in
+    // the new context — and its finalize() did not drop the overlay, because
+    // the fresh run re-armed it.
+    expect(staleScore.cancelled).toBe(true);
+    expect(sortState.sortBusy).toBe(true);
+
+    // Only the new pair's ranking is installed.
+    const freshScore = httpMock.expectOne('/api/find-label');
+    freshScore.flush({ results: [{ id: 1, score: 0.9 }], threshold: 0.5 });
+    await flushInit();
+    await settleZoneless(fixture);
+
+    expect(sortState.sortOrder?.map((s) => s.id)).toEqual([1]);
+    expect(sortState.threshold).toBe(0.5);
+    expect(sortState.sortBusy).toBe(false);
   });
 });

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -156,6 +156,24 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly CENTER_MIN = 100;
   readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
   private destroy$ = new Subject<void>();
+  /**
+   * Fires whenever the active (dataset, detector) pair changes — and on
+   * destroy. Every request whose response writes *pair-scoped* state (the sort
+   * window, the inclusion slider, the dataset name, the selected media) is
+   * piped through `takeUntil(this.pairScope$)` rather than `destroy$`, so the
+   * work started for the pair we're leaving is torn down the instant the pair
+   * switches.
+   *
+   * Without it, a detector-scoring POST or a learned-sort job poll outlives the
+   * switch and calls `applySortWindow` into whatever pair happens to be active
+   * when it finally settles — installing the previous pair's ranking and
+   * threshold, then auto-selecting an id that may not exist in the new dataset.
+   * `takeUntil` also aborts the stale request client-side. NOTE: subscriptions
+   * started from `modelId$` (which emits *before* `pair$`) must stay on
+   * `destroy$`, or `reloadForNewPair`'s teardown would kill the request they
+   * just issued for the new pair.
+   */
+  private pairScope$ = new Subject<void>();
   private statusPolling$: Subscription | null = null;
   private scoringProgressPoll$: Subscription | null = null;
   private learnedSortPending = false;
@@ -283,7 +301,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.voteState.loadVotes();
     this.loadSettings();
     this.startStatusPolling();
-    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
+    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
       next: (status) => { this.datasetName.set(status.display_name || ''); },
     });
 
@@ -351,6 +369,15 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
    *  and starts a fresh job otherwise; either way the user lands on
    *  learned-sorted content without a manual mode toggle. */
   private reloadForNewPair(): void {
+    // Supersede the pair we're leaving *first*: every in-flight request scoped
+    // to it dies here, before any of the new pair's state is installed, so no
+    // late scoring/learned-sort response can `applySortWindow` into the new
+    // context. Those subscriptions carry no `finalize`, so the busy flag and
+    // the scoring progress feed they own are reset explicitly below.
+    this.pairScope$.next();
+    this.stopScoringProgressPoll();
+    this.currentLearnedSortJobId = null;
+    this.sortState.setSortBusy(false);
     this.pendingRehydrateLearned = false;
     this.sortState.setSortResults([], 0);
     this.sortState.setSortStatus('');
@@ -359,7 +386,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.pendingSnapOnLoad = true;
     this.mediaState.loadMedias();
     this.voteState.loadVotes();
-    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.destroy$)).subscribe({
+    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
       next: (status) => { this.datasetName.set(status.display_name || ''); },
     });
     // Re-seed the slider for the detector we just switched to.
@@ -376,6 +403,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.cancelAutoPop('right');
     this.cancelSnapOnLoad();
     if (this.animatePopTimer) clearTimeout(this.animatePopTimer);
+    this.pairScope$.next();
+    this.pairScope$.complete();
     this.destroy$.next();
     this.destroy$.complete();
     this.voteState.stopPolling();
@@ -631,7 +660,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const offset = this.sortState.sortOrder?.length ?? 0;
     this.sortingApi
       .getSortPage(token, offset, 200)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this.pairScope$))
       .subscribe({
         next: (page) => {
           const items = (page.results ?? []).map((r) => ({
@@ -650,7 +679,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.sortState.setTextQuery(text);
     this.sortState.setSortBusy(true);
     this.sortState.setSortStatus('Sorting…');
-    this.sortingApi.sort({ text }).pipe(takeUntil(this.destroy$)).subscribe({
+    this.sortingApi.sort({ text }).pipe(takeUntil(this.pairScope$)).subscribe({
       next: (response) => {
         this.applySortWindow(response);
         this.sortState.setSortBusy(false);
@@ -668,7 +697,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!this.voteState.learnedSortAvailable) return;
     this.sortState.setSortBusy(true);
     this.sortState.setSortStatus('Training…');
-    this.sortingApi.learnedSort().pipe(takeUntil(this.destroy$)).subscribe({
+    this.sortingApi.learnedSort().pipe(takeUntil(this.pairScope$)).subscribe({
       next: (response) => {
         if (response.status === 'done') {
           this.applyLearnedSortResult(response, autoSelect);
@@ -690,7 +719,10 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private pollLearnedSortJob(jobId: string, autoSelect: boolean): void {
     timer(200, 500)
       .pipe(
-        takeUntil(this.destroy$),
+        // Pair-scoped: a training job can outlive the pair it was started for,
+        // and its result must not be applied to whatever pair is active when it
+        // finally settles (see `pairScope$`).
+        takeUntil(this.pairScope$),
         switchMap(() => this.sortingApi.getLearnedSortResult(jobId)),
         filter((res) => res.status !== 'running'),
         take(1),
@@ -785,7 +817,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.startScoringProgressPoll();
 
-    this.detectorsFindApi.findLabel({ detector_id: modelId }).pipe(takeUntil(this.destroy$)).subscribe({
+    // Pair-scoped: scoring runs for minutes on a large dataset, so a pair switch
+    // mid-run must kill this before it ranks the new pair with old scores.
+    this.detectorsFindApi.findLabel({ detector_id: modelId }).pipe(takeUntil(this.pairScope$)).subscribe({
       next: (raw) => {
         const response = raw as {
           results: { id: number; score: number; best_region?: number[] }[];
@@ -839,7 +873,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       // the atlas probe by a node's median score), so it takes the acquisition
       // cut alongside the Hard pick.
       .getCoverageAtlasNext(scores, this.sortState.acqThreshold ?? undefined)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this.pairScope$))
       .subscribe({
         next: (response) => {
           if (response.id !== null) {
@@ -863,13 +897,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private seedInclusion(): void {
     this.sortingApi
       .getInclusion()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this.pairScope$))
       .subscribe({ next: (resp) => this.sortState.setInclusion(resp.inclusion) });
   }
 
   onInclusionChange(value: number): void {
     this.sortState.setInclusion(value);
-    this.sortingApi.setInclusion(value).pipe(takeUntil(this.destroy$)).subscribe();
+    this.sortingApi.setInclusion(value).pipe(takeUntil(this.pairScope$)).subscribe();
     this.autoSelectNext();
     if (this.sortState.sortMode === 'learned' && this.voteState.learnedSortAvailable) {
       this.scheduleLearnedSort(false);
@@ -942,7 +976,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.sortState.setSortStatus('Sorting by example…');
     this.sortingApi
       .exampleSortById({ media_id: mediaId, crop_params: cropParams })
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this.pairScope$))
       .subscribe({
         next: (response) => {
           this.sortState.setSortMode('load');
@@ -1035,7 +1069,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
     this.voteState
       .submitToggleVoteAndRecord(event.id, event.vote, this.mediaDisplayName(event.id))
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this.pairScope$))
       .subscribe({
         next: () => {
           this.onMediaVoted(event);
@@ -1180,7 +1214,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     if (filenames.length > 0) {
       this.sortState.setSortBusy(true);
       this.sortState.setSortStatus(filenames.length > 1 ? 'Sorting by examples…' : 'Sorting by example…');
-      this.sortingApi.exampleSortServer({ filenames }).pipe(takeUntil(this.destroy$)).subscribe({
+      this.sortingApi.exampleSortServer({ filenames }).pipe(takeUntil(this.pairScope$)).subscribe({
         next: (response) => {
           this.applySortWindow(response);
           this.sortState.setSortBusy(false);

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -9,6 +9,7 @@ import { LabelSessionService } from '../../services/label-session.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService } from '../../services/sort-state.service';
 import { AutopilotStateService } from '../../services/autopilot-state.service';
+import { ActiveContextService } from '../../services/active-context.service';
 import { configureZoneless } from '../../testing/zoneless-testbed';
 import { settleResource, settleZoneless } from '../../testing/settle-resource';
 import { provideHttpTesting } from '../../testing/test-providers';
@@ -847,5 +848,94 @@ describe('LabelViewComponent', () => {
     freshFixture.componentInstance.ngOnDestroy();
     httpMock.match(() => true);
     freshFixture.destroy();
+  });
+
+  // Issue #2921: sort work started for one (dataset, detector) pair must not
+  // apply its results into whatever pair is active when it finally settles.
+  // Detector scoring and learned-sort training both run for minutes, so a
+  // context switch mid-run used to leave the old subscription live, calling
+  // `applySortWindow` — and then auto-selecting an id that need not exist in
+  // the new dataset — against the new pair.
+  describe('pair-switch supersession', () => {
+    /** Seed an active pair *before* ngOnInit so the `pair$` replay is the
+     *  subscription's skipped first emission rather than a spurious reload. */
+    function seedPair(): ActiveContextService {
+      const activeContext = TestBed.inject(ActiveContextService);
+      activeContext.setActivePair('ds1', 'det1');
+      return activeContext;
+    }
+
+    /** The detector-registry read the switch fires off `modelId$` needs its
+     *  real shape; the catch-all `[]` drain elsewhere would break its handler. */
+    function flushDetectorRegistry(): void {
+      httpMock
+        .match((req) => req.url.startsWith('/api/detectors'))
+        .forEach((req) => req.flush({ detectors: [] }));
+    }
+
+    it('cancels an in-flight detector scoring run when the active pair changes', () => {
+      const activeContext = seedPair();
+      flushInitialRequests();
+      flushDetectorRegistry();
+
+      component.onModelSelected('det1');
+      const staleScore = httpMock.expectOne('/api/find-label');
+      expect(component.sortState.sortBusy).toBe(true);
+
+      activeContext.setActivePair('ds2', 'det2');
+      flushDetectorRegistry();
+
+      // Aborted client-side, so the old pair's ranking can never be installed.
+      expect(staleScore.cancelled).toBe(true);
+      // That subscription carries no `finalize`, so `reloadForNewPair` resets
+      // the busy flag itself — otherwise the overlay would hang forever.
+      expect(component.sortState.sortBusy).toBe(false);
+      expect(component.sortState.sortOrder ?? []).toEqual([]);
+    });
+
+    it('stops polling a learned-sort job when the active pair changes', async () => {
+      const activeContext = seedPair();
+      flushInitialRequests();
+      flushDetectorRegistry();
+
+      component.voteState.loadVotes();
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [1], bad: [2], click_times: {}, learned_scores: {} });
+
+      component.onLearnedSort();
+      httpMock.expectOne('/api/learned-sort').flush({ status: 'running', job_id: 'job-1' });
+
+      // Positive control: the job poll (timer(200, 500)) is genuinely running.
+      await new Promise<void>((resolve) => setTimeout(resolve, 300));
+      const firstPoll = httpMock.match((req) => req.url.startsWith('/api/learned-sort/result'));
+      expect(firstPoll.length).toBe(1);
+      firstPoll[0].flush({ status: 'running' });
+
+      activeContext.setActivePair('ds2', 'det2');
+      // Drain the reload's own requests so they can't be mistaken for a poll.
+      // The two whose handlers read into the body need their real shape; a
+      // bare `[]` from the catch-all would throw inside them.
+      flushDetectorRegistry();
+      httpMock.match('/api/labeling-status').forEach((req) =>
+        req.flush({
+          good_count: 0,
+          bad_count: 0,
+          total_count: 0,
+          smart: { status: 'green' },
+          stable: { status: 'green' },
+          span: { status: 'green' },
+        }),
+      );
+      httpMock.match(() => true).forEach((req) => {
+        if (!req.cancelled) req.flush([]);
+      });
+
+      // The poll is torn down with the pair it belonged to: no further result
+      // reads, so the finished job can never rank the new pair.
+      await new Promise<void>((resolve) => setTimeout(resolve, 800));
+      httpMock.expectNone((req) => req.url.startsWith('/api/learned-sort/result'));
+      expect(component.sortState.sortBusy).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Closes #2921

## The bug

Find's `runFindLabel()` POST and Train's `onModelSelected()` / `pollLearnedSortJob()` continuations were guarded only by `takeUntil(this.destroy$)`. Both components survive an active-pair switch (single route config, no custom `RouteReuseStrategy` — the `pair$`/`reloadForNewPair` subscription proves the instance is reused), and detector scoring runs for minutes on a large dataset. So `reloadForNewPair()` left the previous pair's subscription live alongside the new one, with nothing on either side superseding it — `ContextSwitchService`'s `nextRequestId` guard covers only dataset/detector *loads*, and the backend's `find_label` even calls `find_progress.reset_cancel()` on each new request.

Two ways that bites:

- **Old response lands last** → its handler installs the *old* pair's ranking and threshold into the new context. Find then walks `advanceToBoundary()` onto a media id that need not exist in the new dataset (broken viewer, image 404s) and reloads votes against the wrong pair; Train calls `applySortWindow` and auto-selects the same way.
- **Old response lands first** → Find's `finalize()` tears down the *new* run's progress subscription and clears `sortBusy`, lifting the wait overlay and re-enabling voting while scoring is still going.

## The fix

Both views now carry a `pairScope$` Subject, fired at the top of `reloadForNewPair()` (and on destroy). Every request whose response writes pair-scoped state — the ranking, the threshold, the inclusion slider, the dataset name, the vote cache, the selected media — pipes through `takeUntil(this.pairScope$)` instead of `destroy$`. Firing it *first*, before any of the new pair's state is installed, means the leaving pair's teardown (including Find's `finalize()`) has fully settled before the fresh run starts, so it cannot clobber it. `takeUntil` also aborts the stale request client-side rather than merely ignoring its result.

Two details worth calling out:

- **label-view's sort subscriptions carry no `finalize`**, so tearing them down would strand the wait overlay. `reloadForNewPair()` now resets `sortBusy`, stops the scoring progress feed, and clears the tracked learned-sort job id explicitly.
- **The detector-registry read stays on `destroy$` on purpose.** It is fired from `modelId$`, which emits *before* `pair$` on a switch, so a pair-scoped teardown would kill the request it had just issued for the *new* pair. Noted in the `pairScope$` doc comment so the next reader doesn't "fix" it.

Nothing about the shipped algorithm or any server contract changes; this is purely subscription scoping in two components.

## Tests

- `find-view.zoneless.spec.ts` — new `pair-switch supersession` block: with a scoring run in flight, switching the active pair cancels the stale request, leaves `sortBusy` set (the new run owns the overlay), and installs only the new pair's ranking/threshold.
- `label-view.zoneless.spec.ts` — new `pair-switch supersession` block: a switch cancels an in-flight `/api/find-label` and resets the busy flag; and it tears down a running learned-sort job poll (with a positive control asserting the poll was genuinely live first, so the absence assertion means something).

Each of the three tests was confirmed to fail with the guard reverted.

`./run-tests.sh` green: **ALL 7860 TESTS PASSED** (1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvKpe2NvhgyWawj11j1akQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvKpe2NvhgyWawj11j1akQ)_