### PR TITLE
Validate usernames before they become path components

### DIFF
--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -57,6 +57,23 @@ class MyProvider(LoginProvider):
         return base_data_dir / username
 ```
 
+**Validate any username you didn't construct yourself.** A username returned
+by `get_user()` becomes a path component (`data/<username>/`) *and* the
+confinement root for server-file path validation, which resolves `..` away
+instead of rejecting it. Screen client-supplied values with
+`vtsearch.auth.is_safe_username()` and fall back to `"anonymous"`:
+
+```python
+from vtsearch.auth import is_safe_username
+
+def get_user(self, request) -> str:
+    username = request.headers.get("X-User", "anonymous")
+    return username if is_safe_username(username) else "anonymous"
+```
+
+This applies regardless of how strong your authentication is — it is a
+filesystem-hygiene check, not an authentication one.
+
 ### How it works
 
 1. `set_login_provider(provider)` is called once at startup (in `app.py`).

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -30,6 +30,28 @@ determines what `/api/auth/*` does and whether the SPA shows a login screen.
 The SPA switches on `login_required` from `GET /api/auth/status`: when `true`
 it shows a login screen at startup, otherwise it goes straight to the app.
 
+### Usernames are path components
+
+Any provider that returns a per-user data dir puts the username on the
+filesystem twice: `data/<username>/` is where per-user settings are written,
+**and** it is the confinement root passed to `validate_server_filepath()` for
+server-file importers and exporters. That check calls `base_dir.resolve()`,
+which *collapses* `..` rather than rejecting it — so an unvalidated username
+would silently widen the sandbox rather than trip it.
+
+Every username is therefore screened by `vtsearch.auth.is_safe_username()`
+(`[A-Za-z0-9._-]+`, and not a bare `.` / `..` segment) at the point it enters
+the app: `ApiKeyLoginProvider` screens `api_keys.json` at load time, and
+`TrivialLoginProvider` re-screens the session cookie on every read — the
+cookie is only integrity-protected by `app.secret_key`, so a client that
+knows the key can put an arbitrary string in it regardless of what
+`POST /api/auth/login` accepted. An unsafe name resolves to `"anonymous"`
+with `authenticated: false`.
+
+This is *not* an impersonation defence. In `trivial` mode anyone may claim
+any username by design; the check only keeps a username from becoming a
+path escape.
+
 ### Auth status
 
 ```

--- a/tests/api/test_multi_user_security.py
+++ b/tests/api/test_multi_user_security.py
@@ -22,6 +22,7 @@ from vtsearch.auth import (
     get_current_user,
     get_login_provider,
     get_user_data_dir,
+    is_safe_username,
     set_login_provider,
 )
 
@@ -406,6 +407,22 @@ class TestApiKeyLoginProvider:
         assert provider.get_user(_FakeRequest({"Authorization": "Bearer evil"})) == "anonymous"
         assert any("invalid username" in rec.message for rec in caplog.records)
 
+    @pytest.mark.parametrize("bare_dots", ["..", ".", "..."])
+    def test_bare_dot_username_skipped(self, tmp_path, caplog, bare_dots):
+        """A username of bare dots is a traversal segment with no separator.
+
+        These slip past a ``[A-Za-z0-9._-]+`` character class — ``.`` is in
+        the class — so they need an explicit check.
+        """
+        keys_file = tmp_path / "api_keys.json"
+        _write_keys(keys_file, {_hash_key("good"): "alice", _hash_key("evil"): bare_dots})
+        with caplog.at_level("ERROR"):
+            provider = ApiKeyLoginProvider(keys_file=keys_file)
+
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer good"})) == "alice"
+        assert provider.get_user(_FakeRequest({"Authorization": "Bearer evil"})) == "anonymous"
+        assert any("invalid username" in rec.message for rec in caplog.records)
+
     def test_malformed_json_keeps_existing_keys(self, tmp_path, caplog):
         keys_file = tmp_path / "api_keys.json"
         _write_keys(keys_file, {_hash_key("good"): "alice"})
@@ -593,6 +610,116 @@ class TestTrivialLoginProvider:
         assert status["user"] == "anonymous"
         assert status["authenticated"] is False
         assert status["login_required"] is True
+
+
+# ---------------------------------------------------------------------------
+# Username-as-path-component validation (issue #2930)
+# ---------------------------------------------------------------------------
+
+
+class TestIsSafeUsername:
+    """``is_safe_username`` gates any username that reaches the filesystem."""
+
+    @pytest.mark.parametrize("name", ["alice", "Bob_123", "user-1", "A", "sam.greenberg"])
+    def test_accepts_ordinary_names(self, name):
+        assert is_safe_username(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "..",  # the traversal segment the old regex admitted
+            ".",  # resolves to the parent dir itself
+            "...",
+            "../etc",
+            "../../home/user/.ssh",
+            "a/b",
+            "/absolute",
+            "back\\slash",
+            "",
+            "has space",
+        ],
+    )
+    def test_rejects_path_unsafe_names(self, name):
+        assert is_safe_username(name) is False
+
+    @pytest.mark.parametrize("value", [None, 42, ["alice"], {"user": "alice"}])
+    def test_rejects_non_strings(self, value):
+        """A forged cookie can carry any JSON type, not just a string."""
+        assert is_safe_username(value) is False
+
+
+class TestTrivialProviderRejectsForgedUsernames:
+    """A forged session cookie must not turn a username into a path escape.
+
+    The login route's schema blocks traversal names on the way *in*, so
+    these tests write the session directly (``session_transaction``) to
+    model a cookie signed with a known ``app.secret_key`` — the only way
+    an unsafe name can reach ``get_user``.
+    """
+
+    @pytest.fixture
+    def trivial_client(self, client):
+        original = get_login_provider()
+        set_login_provider(TrivialLoginProvider())
+        try:
+            yield client
+        finally:
+            set_login_provider(original)
+
+    def _forge(self, client, username):
+        with client.session_transaction() as sess:
+            sess[TrivialLoginProvider._COOKIE_KEY] = username
+
+    @pytest.mark.parametrize("forged", ["../../home/user/.ssh", "..", ".", "../etc"])
+    def test_forged_traversal_resolves_to_anonymous(self, trivial_client, forged):
+        self._forge(trivial_client, forged)
+
+        data = trivial_client.get("/api/auth/status").get_json()
+        assert data["user"] == "anonymous"
+        # We refused to honour the name, so don't claim an authenticated session.
+        assert data["authenticated"] is False
+
+    def test_forged_traversal_cannot_escape_data_dir(self, trivial_client):
+        """The confinement root itself must stay inside DATA_DIR.
+
+        ``get_user_data_dir()`` is not only where per-user settings are
+        written — it is the ``base_dir`` handed to
+        ``validate_server_filepath``, which calls ``base_dir.resolve()``.
+        That collapses ``..`` instead of rejecting it, so an unvalidated
+        username would silently widen the sandbox for every server-file
+        importer and exporter.
+        """
+        from vtscore.config import DATA_DIR
+        from vtscore.security.path_validation import get_file_access_base_dir
+
+        forged = "../../../.."
+        self._forge(trivial_client, forged)
+
+        # The ``client`` fixture already enters the test client as a context
+        # manager, so the request context (and thus ``g.user``) stays alive
+        # after the request returns: the resolution below runs exactly as it
+        # would inside a handler.
+        trivial_client.get("/api/auth/status")
+        base = get_file_access_base_dir()
+
+        assert base is not None
+        assert base.resolve().is_relative_to(DATA_DIR.resolve())
+
+        # Guard against a vacuous assertion: the forged name really would
+        # have escaped had it been used verbatim.
+        escaped = (DATA_DIR / forged).resolve()
+        assert not escaped.is_relative_to(DATA_DIR.resolve())
+
+    def test_valid_forged_username_still_honoured(self, trivial_client):
+        """Impersonation is a *feature* of the trivial provider, not a bug.
+
+        Only path-unsafe names are refused; a well-formed name set directly
+        in the session works exactly as if it had come from the login route.
+        """
+        self._forge(trivial_client, "alice")
+        data = trivial_client.get("/api/auth/status").get_json()
+        assert data["user"] == "alice"
+        assert data["authenticated"] is True
 
 
 class TestTrivialLoginEndpoints:

--- a/vtsearch/auth/__init__.py
+++ b/vtsearch/auth/__init__.py
@@ -122,6 +122,38 @@ class DefaultLoginProvider(LoginProvider):
 
 
 # ---------------------------------------------------------------------------
+# Username validation
+# ---------------------------------------------------------------------------
+
+
+# Usernames are used as data-directory names (data/<user>/...) so they must
+# not contain path separators or traversal segments.  Note that the character
+# class alone is not sufficient: it admits "." and "..", which *are* traversal
+# segments, so :func:`is_safe_username` rejects those explicitly.
+_VALID_USERNAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def is_safe_username(username: Any) -> bool:
+    """Return ``True`` if *username* is safe to use as a path component.
+
+    A username reaches the filesystem in two places, so a bad one is not
+    merely a mislabelled request:
+
+    * ``get_user_data_dir()`` builds ``DATA_DIR / username`` for per-user
+      settings, which are written with ``mkdir(parents=True)``.
+    * The same directory is the confinement root handed to
+      :func:`~vtscore.security.path_validation.validate_server_filepath`,
+      which compares against ``base_dir.resolve()`` — so ``..`` segments in
+      the root are *collapsed* rather than rejected, silently widening the
+      sandbox for every server-file importer and exporter.
+
+    Providers must therefore validate any username they did not construct
+    themselves, whatever their authentication strength.
+    """
+    return isinstance(username, str) and bool(_VALID_USERNAME.match(username)) and username.strip(".") != ""
+
+
+# ---------------------------------------------------------------------------
 # TrivialLoginProvider - cookie-based, no password
 # ---------------------------------------------------------------------------
 
@@ -133,6 +165,14 @@ class TrivialLoginProvider(LoginProvider):
     ``POST /api/auth/login``.  The server stores the name in a
     signed Flask session cookie.  Completely insecure; useful only
     for testing multi-user features locally.
+
+    "Insecure" here means **no isolation between users**: anyone may claim
+    any username, and impersonating another user is a feature, not a bug.
+    It does *not* mean the username escapes ``DATA_DIR``.  The cookie is
+    only integrity-protected by ``app.secret_key``, so a client that knows
+    the key can put an arbitrary string in it — hence :meth:`get_user`
+    re-validates on the way out, even though the login route already
+    validates on the way in.  See :func:`is_safe_username`.
     """
 
     name = "trivial"
@@ -143,17 +183,29 @@ class TrivialLoginProvider(LoginProvider):
         try:
             from flask import session
 
-            return session.get(self._COOKIE_KEY, "anonymous")
+            username = session.get(self._COOKIE_KEY, "anonymous")
         except RuntimeError:
             return "anonymous"
+        if not is_safe_username(username):
+            logger.warning(
+                "TrivialLoginProvider: ignoring unsafe username %r in session cookie; treating request as anonymous",
+                username,
+            )
+            return "anonymous"
+        return username
 
     def is_authenticated(self, request: Any) -> bool:
         try:
             from flask import session
 
-            return self._COOKIE_KEY in session
+            if self._COOKIE_KEY not in session:
+                return False
         except RuntimeError:
             return False
+        # A cookie carrying an unsafe name resolves to "anonymous" above, so
+        # report it as unauthenticated rather than letting ``status_dict``
+        # claim an authenticated session for a user we refused to honour.
+        return is_safe_username(session.get(self._COOKIE_KEY))
 
     def login_required(self) -> bool:
         return True
@@ -165,11 +217,6 @@ class TrivialLoginProvider(LoginProvider):
 # ---------------------------------------------------------------------------
 # ApiKeyLoginProvider - bearer-token, for headless integrations
 # ---------------------------------------------------------------------------
-
-
-# Usernames are used as data-directory names (data/<user>/...) so they must
-# not contain path separators or traversal segments.
-_VALID_USERNAME = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 class ApiKeyLoginProvider(LoginProvider):
@@ -258,9 +305,10 @@ class ApiKeyLoginProvider(LoginProvider):
                     username,
                 )
                 continue
-            if not _VALID_USERNAME.match(username):
+            if not is_safe_username(username):
                 logger.error(
-                    "ApiKeyLoginProvider: skipping key for invalid username %r in %s (must match [A-Za-z0-9._-]+)",
+                    "ApiKeyLoginProvider: skipping key for invalid username %r in %s "
+                    "(must match [A-Za-z0-9._-]+ and not be a '.'/'..' path segment)",
                     username,
                     self._keys_file,
                 )


### PR DESCRIPTION
Refs #2930

`TrivialLoginProvider.get_user` returned the session cookie's username unchecked. The login route's schema (`^[A-Za-z0-9_-]{1,64}$`) blocks traversal names on the way *in*, but the cookie is only integrity-protected by `app.secret_key`, so a client that knows the key can put an arbitrary string in it.

**This is not an impersonation fix.** In trivial mode anyone may claim any username by design, and forging a cookie for `alice` gains nothing over `POST /api/auth/login {"username": "alice"}`. Issue #2930 originally framed this as an auth bypass; that framing was wrong and the issue has been rescoped. What's actually broken is narrower: a username reaches the filesystem without being screened as a path component.

## Why the username matters

It lands on the filesystem twice:

- `DATA_DIR / username / user_settings.json`, written via `_atomic_write` → `mkdir(parents=True)`.
- The `base_dir` handed to `validate_server_filepath()`, which compares against `base_dir.resolve()` — **collapsing** `..` rather than rejecting it. A traversal username therefore silently *widens* the sandbox for every server-file importer and exporter instead of tripping the check. This is the larger of the two impacts and the original report missed it.

## Changes

- **`is_safe_username()`** in `vtsearch/auth/__init__.py`, documenting both filesystem paths so the next provider author knows why the check exists.
- **`TrivialLoginProvider.get_user`** screens the cookie on every read, logs a warning, and falls back to `"anonymous"`. `is_authenticated` now reports `False` for a name we refused to honour, so `status_dict` can't claim an authenticated session for a user that resolved to anonymous.
- **Closed a gap in the shared regex** that `ApiKeyLoginProvider` already relied on: `^[A-Za-z0-9._-]+$` matches `..` and `.` (since `.` is in the class) — exactly the traversal segments its comment claimed to exclude. `is_safe_username` rejects bare-dot names explicitly, and both providers now go through it.
- Docs: a "usernames are path components" section in `docs/api/auth.md`, and guidance in `docs/EXTENDING.md` for custom providers, both stating this is filesystem hygiene rather than an authentication control.

## Scope note

The issue's other suggestion — refuse to boot a multi-user provider on the default `secret_key` — is deliberately **not** here. It's already tracked in `docs/plans/codebase-audit-2026-08.md` and stays there as its single home; it's been stripped from #2930 to avoid a duplicate body.

## Tests

New coverage in `tests/api/test_multi_user_security.py`: an `is_safe_username` accept/reject table (including non-string cookie payloads), forged-cookie tests via `session_transaction()` asserting the confinement root stays inside `DATA_DIR` (with a guard proving the assertion isn't vacuous), a test that a *valid* forged name is still honoured — impersonation remains a feature — and bare-dot rejection in `api_keys.json`.

Full suite green: `ALL 7890 TESTS PASSED (1 skipped, total: 7891)`.

## Backwards compatibility

A `trivial`-mode session cookie carrying a name outside `[A-Za-z0-9._-]+` now resolves to `"anonymous"` instead of that name. Such a cookie could not have been produced by the login route, so this should affect no real session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RUX6UeZZN4HMJbRKwmshDs)_