### PR TITLE
Default the eval harness to the shipped linear head

### DIFF
--- a/scripts/check-eval-app-sync.py
+++ b/scripts/check-eval-app-sync.py
@@ -164,9 +164,13 @@ MIRRORS: list[Mirror] = [
         note=(
             "The app's canonical train + calibrate pipeline, which the harness reproduces step "
             "for step (fold calibration, full-data fit, fold-anchored threshold). A new stage "
-            "here - or a changed head, fold rule or ordering - has to reach the harness or its "
+            "here - or a changed fold rule or ordering - has to reach the harness or its "
             "default arm trains a detector the app no longer ships. Note "
-            "_mlp_train_and_calibrate is the single-vector path and reproduces the same shape."
+            "_mlp_train_and_calibrate is the single-vector path and reproduces the same shape. "
+            "The head is the one knob mirrored by name: this function's `hidden_dim` must equal "
+            "`_resolve_hidden_dim(voting_iterations.PRODUCTION_HEAD, ...)`, which "
+            "tests_lib/detectors/test_harness_linear_head.py pins by training this pipeline for "
+            "real - so a head change fails the suite as well as tripping this digest."
         ),
     ),
     Mirror(

--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -136,11 +136,13 @@ ANCHORED_CHECKPOINTS = [
 FOLD_COUNTS = [int(k) for k in os.environ.get("CALIB_FOLD_COUNTS", "").split(",") if k.strip()]
 
 #: Which torch head each step trains (``vtscore.eval.voting_iterations.HEADS``).
-#: #2781 ran the harness's historical auto-sized MLP; the #2799 safe-threshold
-#: study runs ``linear`` — the head the live detector actually trains since
-#: #2790/#2809 — because its question ("should safe_thresholds be forced on for
-#: every VTSearch user?") is only answerable on the shipped head.
-HEAD = os.environ.get("CALIB_HEAD", "mlp")
+#: Unset (the default) hands ``head=None`` to the harness, which resolves it to
+#: the head the live detector actually trains — ``linear`` since #2790/#2809.
+#: That is the only setting a study's headline numbers can be read off, because
+#: questions like #2799's ("should safe_thresholds be forced on for every
+#: VTSearch user?") are answerable only on the shipped head.  Set
+#: ``CALIB_HEAD=mlp`` to reproduce the historical auto-sized-MLP arm (#2781).
+HEAD = os.environ.get("CALIB_HEAD") or None
 
 #: Which safe-threshold mix-in schedule the run *lives* under (issue #2841).
 #: This steers the trajectory - the blended threshold feeds Autopilot's Hard

--- a/scripts/experiments/calibration/run_cells.py
+++ b/scripts/experiments/calibration/run_cells.py
@@ -78,7 +78,7 @@ def main(argv: list[str] | None = None) -> int:
     region_voting = cfg.REGION_VOTING_BY_DATASET.get(ds, False)
     common.log(
         f"cell {idx}/{len(cells)}: dataset={ds} embedder={emb} category={cat} seed={seed} "
-        f"styles={styles} head={cfg.HEAD} safe_thresholds={cfg.SAFE_THRESHOLDS} "
+        f"styles={styles} head={cfg.HEAD or 'default (production)'} safe_thresholds={cfg.SAFE_THRESHOLDS} "
         f"calibrate_count={cfg.CALIBRATE_COUNT} fold_counts={cfg.FOLD_COUNTS or 'off'} "
         f"acq_inclusion_offset={cfg.ACQ_INCLUSION_OFFSET} acq_rank_percentile={cfg.ACQ_RANK_PERCENTILE}"
     )

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -406,9 +406,10 @@ class TestProductionCalibrationFidelity:
     per-seed simulation RNG or letting folds auto-size can't silently
     reintroduce a production mismatch.
 
-    The *head* itself is where the eval's MLP arm and production part ways:
-    production trains the linear head (#2790), while this arm keeps the MLP as a
-    sweep candidate, so the width asserted below is the arm's own auto-sizing.
+    The *head* is threaded the same way whichever arm runs: the default arm
+    trains production's linear head (#2790/#2916) and ``head="mlp"`` the legacy
+    auto-sized one, and in both cases the folds must take the final model's
+    width rather than sizing themselves from their own smaller split.
     """
 
     def _spy_calibration(self, monkeypatch):
@@ -432,18 +433,20 @@ class TestProductionCalibrationFidelity:
         monkeypatch.setattr(voting_iterations, "calibration_folds", spy)
         return captured
 
-    def test_folds_forced_to_full_data_hidden_dim(self, monkeypatch):
-        from vtscore.training.mlp import _auto_hidden_dim
+    @pytest.mark.parametrize("head", [None, "mlp"])
+    def test_folds_forced_to_full_data_hidden_dim(self, head, monkeypatch):
+        from vtscore.eval.voting_iterations import PRODUCTION_HEAD, _resolve_hidden_dim
 
         captured = self._spy_calibration(monkeypatch)
         medias = _make_separable_clips(n_per_cat=10)
-        simulate_voting_iterations(medias, "alpha", seed=42)
+        simulate_voting_iterations(medias, "alpha", seed=42, head=head)
 
         assert captured  # at least one calibrated step
         for c in captured:
             # The fold models must be sized from the full label count for the
-            # step, not auto-sized per fold (hidden_dim=None).
-            assert c["hidden_dim"] == _auto_hidden_dim(c["n"])
+            # step, not auto-sized per fold (hidden_dim=None) - on the default
+            # (production) arm and on the legacy MLP arm alike.
+            assert c["hidden_dim"] == _resolve_hidden_dim(head or PRODUCTION_HEAD, c["n"])
 
     def test_folds_calibrate_with_fixed_random_state_42(self, monkeypatch):
         captured = self._spy_calibration(monkeypatch)

--- a/tests_lib/detectors/test_harness_linear_head.py
+++ b/tests_lib/detectors/test_harness_linear_head.py
@@ -1,12 +1,17 @@
-"""The harness can run the **production** head (#2799 needs it; torch tests).
+"""The harness's **default** head is the production head (#2799, #2916).
 
 The calibration/voting harness historically trained a small auto-sized MLP,
 while the live detector has trained a linear (logistic) head since #2790/#2809.
 Measuring a shipped default like ``safe_thresholds`` on the wrong head measures
-the wrong product, so ``simulate_voting_iterations(head=...)`` selects it.
+the wrong product, so an unspecified ``head`` resolves to
+:data:`~vtscore.eval.voting_iterations.PRODUCTION_HEAD` and ``head="mlp"`` is
+the explicitly-named legacy arm.
 
-These tests pin the two things that make a ``head="linear"`` run faithful:
+These tests pin the three things that make a default run faithful:
 
+* the resolved default really is the head the *app* trains — pinned against
+  ``train_and_threshold`` itself, so flipping the shipped head fails the suite
+  instead of silently leaving the harness behind;
 * the width reaches **both** the final model and the calibration folds (the
   folds must share the final model's architecture — production threads one
   width through ``_train_and_score_xy`` for exactly this reason);
@@ -38,6 +43,37 @@ def test_resolve_hidden_dim_maps_heads_to_widths():
     assert vi._resolve_hidden_dim("mlp", 40) == _auto_hidden_dim(40)
     with pytest.raises(ValueError, match="unknown head"):
         vi._resolve_hidden_dim("logreg", 40)
+
+
+def test_the_default_head_is_the_head_the_app_trains(monkeypatch):
+    """#2916: ``PRODUCTION_HEAD`` must track ``train_and_threshold``'s own width.
+
+    Pinned by *running* the app's pipeline rather than by restating its
+    constant: if the shipped detector ever changes head, this fails and the
+    harness default has to move with it, instead of the default arm quietly
+    measuring a detector nobody ships.
+    """
+    import vtscore.training as app_training_pkg
+    from vtscore.detectors.training import train_and_threshold
+
+    seen: list = []
+    real_train = app_training_pkg.train_model
+
+    def spy_train(X, y, input_dim, **kw):
+        seen.append(kw.get("hidden_dim"))
+        return real_train(X, y, input_dim, **kw)
+
+    # ``train_and_threshold`` imports ``train_model`` from the package at call
+    # time, so the package attribute is the binding it will actually use.
+    monkeypatch.setattr(app_training_pkg, "train_model", spy_train)
+
+    rng = np.random.default_rng(0)
+    X_list = [rng.standard_normal(8).astype(np.float32) for _ in range(8)]
+    y_list = [1.0] * 4 + [0.0] * 4
+    train_and_threshold(X_list, y_list)
+
+    assert seen, "the app never trained a model"
+    assert set(seen) == {vi._resolve_hidden_dim(vi.PRODUCTION_HEAD, len(y_list))}
 
 
 def test_unknown_head_is_rejected_early():
@@ -107,8 +143,35 @@ def test_linear_head_reaches_the_final_model_and_the_calibration_folds(style, mo
     assert np.isfinite(threshold)
 
 
-def test_mlp_head_is_still_the_default_and_keeps_a_hidden_layer():
-    """Default runs stay byte-comparable to the published #2781 numbers."""
+def _default_arm_step(medias):
+    good_votes, bad_votes = _votes(medias)
+    return vi._train_and_calibrate(
+        "mlp",
+        good_votes,
+        bad_votes,
+        medias,
+        "cat0",
+        region_voting=True,
+        input_dim=DIM,
+        inclusion=0,
+        calibrate_count=2,
+        calibration_fraction=0.5,
+    )
+
+
+def test_the_default_arm_trains_the_production_head():
+    """#2916: no explicit head == the shipped head, not the retired MLP."""
+    medias, _ = _planted_dataset(n_per_cat=10, seed=0)
+
+    step, _threshold, _n_labels, _t, _d = _default_arm_step(medias)
+    assert step.torch_model is not None
+    layers = [m for m in step.torch_model if isinstance(m, nn.Linear)]
+    assert len(layers) == 1
+    assert not any(isinstance(m, nn.ReLU) for m in step.torch_model)
+
+
+def test_the_mlp_arm_is_still_reachable_by_name():
+    """The legacy #2781 head stays available — just not as the default."""
     medias, _ = _planted_dataset(n_per_cat=10, seed=0)
     good_votes, bad_votes = _votes(medias)
 
@@ -123,11 +186,20 @@ def test_mlp_head_is_still_the_default_and_keeps_a_hidden_layer():
         inclusion=0,
         calibrate_count=2,
         calibration_fraction=0.5,
+        head="mlp",
     )
     assert step.torch_model is not None
     layers = [m for m in step.torch_model if isinstance(m, nn.Linear)]
     assert len(layers) == 2
     assert layers[0].out_features == _auto_hidden_dim(n_labels)
+
+
+def test_default_runs_record_the_production_head():
+    """A run that names no head must report — and train — the shipped one."""
+    medias, _ = _planted_dataset(n_per_cat=20, seed=0)
+    rows = vi.simulate_voting_iterations(medias, target_category="cat0", seed=0, max_steps=8)
+    assert rows, "no rows produced"
+    assert {r["head"] for r in rows} == {vi.PRODUCTION_HEAD}
 
 
 def test_rows_record_the_head_and_linear_runs_end_to_end():
@@ -148,6 +220,7 @@ def test_rows_record_the_head_and_linear_runs_end_to_end():
     assert rows, "no rows produced"
     assert {r["head"] for r in rows} == {"linear"}
     assert "head" in vi._IDENT_COLUMNS
+    assert vi.PRODUCTION_HEAD == "linear"
     # The #2799 variant rows still ride along under safe_thresholds.
     assert {r["gmm_variant"] for r in rows} >= {"", "xcal_only", "pooled_cross"}
     for r in rows:

--- a/tests_lib/detectors/test_max_patch_style.py
+++ b/tests_lib/detectors/test_max_patch_style.py
@@ -458,7 +458,11 @@ class TestMaxPatchPcaHacStyle:
             seed_scores=seed_scores,
         )
         assert rows
-        assert rows[-1]["average_precision"] > 0.7
+        # Well above chance (prevalence 0.5) is the claim.  The bar is loose
+        # because the run now trains the production linear head (#2916), which
+        # on this 12-step toy lands near 0.68 rather than the legacy MLP arm's
+        # ~0.81 - and because the run is mildly sensitive to ambient state.
+        assert rows[-1]["average_precision"] > 0.6
 
 
 # ---------------------------------------------------------------------------
@@ -670,11 +674,12 @@ class TestStyleVotingSimulation:
         )
         # The planted patch is a separable signal: the ranking must sit far
         # above chance (prevalence 0.5) throughout the back half of the run.
-        # The exact values are deterministic (~0.79-0.80) but left slack for
+        # The exact values are deterministic (~0.65-0.77 on the production
+        # linear head this run now defaults to, #2916) but left slack for
         # cross-platform torch numerics.  No monotone-improvement assertion:
         # exemplar seeding makes even the first trainable step strong, and AP
         # wobbles a few points between retrains.
-        assert all(r["average_precision"] > 0.7 for r in rows[len(rows) // 2 :])
+        assert all(r["average_precision"] > 0.6 for r in rows[len(rows) // 2 :])
 
     def test_style_rejects_svm_trainer(self):
         medias, _ = _planted_dataset(n_per_cat=10, seed=10)

--- a/tests_lib/detectors/test_mlp_vs_svm_experiment.py
+++ b/tests_lib/detectors/test_mlp_vs_svm_experiment.py
@@ -167,6 +167,9 @@ class TestTrainerPluggableVoting:
             assert key in row
         assert row["trainer"] == "svm_linear"
         assert row["backend"] == "sklearn-cpu"
+        # #2916: the SVM trainers fit no torch head, so naming one on their rows
+        # would attribute them to an architecture they never trained.
+        assert row["head"] == ""
         assert row["prevalence_arm"] == "natural"
 
     def test_svm_trajectory_learns(self):

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -99,6 +99,17 @@ class _StepModel:
 #: threads one width through ``_train_and_score_xy``.
 HEADS: tuple[str, ...] = ("mlp", "linear")
 
+#: The head the **app** trains, and therefore the harness's default arm:
+#: ``vtscore.detectors.training.train_and_threshold`` pins ``hidden_dim =
+#: LINEAR_HEAD`` on every production fit.  ``head=None`` resolves to this, the
+#: way ``style=None`` and ``blend_schedule=None`` resolve to the app's geometry
+#: and blend schedule — an eval default that isn't the app default measures a
+#: detector nobody ships (see the "Eval Default Arm IS the App" rule).  If the
+#: shipped head ever changes, move this with it: ``test_harness_linear_head``
+#: pins the two against each other by training the real app pipeline, so the
+#: suite fails rather than letting the default arm drift silently.
+PRODUCTION_HEAD: str = "linear"
+
 
 def _resolve_hidden_dim(head: str, n_votes: int) -> int:
     """Hidden width for *head* at *n_votes* votes (0 = the linear head)."""
@@ -1582,7 +1593,7 @@ def _train_and_calibrate(
     inclusion: int,
     calibrate_count: int,
     calibration_fraction: float,
-    head: str = "mlp",
+    head: str = PRODUCTION_HEAD,
     style_obj: Any = None,
     emit_calibration_metrics: bool = False,
     fold_count_variants: list[int] | None = None,
@@ -1590,9 +1601,9 @@ def _train_and_calibrate(
     """Train the step's ranker and calibrate its threshold from the current votes.
 
     *head* selects the torch head on both torch paths (see :data:`HEADS`):
-    ``"mlp"`` keeps the auto-sized hidden layer, ``"linear"`` trains the
-    production linear head.  It is ignored by the SVM path, which has no torch
-    head at all.
+    ``"linear"`` (the default, :data:`PRODUCTION_HEAD`) trains the head the live
+    detector has, ``"mlp"`` the legacy auto-sized hidden layer.  It is ignored by
+    the SVM path, which has no torch head at all.
 
     Dispatches on *trainer*: ``"mlp"`` runs the production MLP path unchanged
     (see :func:`_mlp_train_and_calibrate`); any ``svm_*`` name runs the SVM path
@@ -1658,15 +1669,16 @@ def _mlp_train_and_calibrate(
     inclusion: int,
     calibrate_count: int,
     calibration_fraction: float,
-    head: str = "mlp",
+    head: str = PRODUCTION_HEAD,
 ) -> tuple[_StepModel, float, int, dict[str, float], dict[str, Any]]:
     """The torch arm — numerically identical to the pre-trainer harness at ``head="mlp"``.
 
-    At ``head="mlp"`` (the default) this is the harness's small-MLP candidate,
-    not the live detector's head: production trains the linear (logistic) head
-    instead (the #2790 finding, see ``vtscore.training.mlp.LINEAR_HEAD``).
-    ``head="linear"`` selects that production head, so the reported cost is the
-    shipped detector's.  Everything *around* the head mirrors the production
+    At ``head="linear"`` (the default, :data:`PRODUCTION_HEAD`) this trains the
+    live detector's head: production pins the linear (logistic) head on every
+    fit (the #2790 finding, see ``vtscore.training.mlp.LINEAR_HEAD``), so the
+    reported thresholds and costs are the shipped detector's.  ``head="mlp"`` is
+    the legacy arm — the harness's small-MLP candidate #2781 measured, which the
+    app no longer ships.  Everything *around* the head mirrors the production
     ``_train_and_score_xy`` / ``train_and_threshold`` pipeline either way:
 
     Good votes region-pool their ground-truth box when *region_voting* is on
@@ -1762,7 +1774,7 @@ def _style_train_and_calibrate(
     inclusion: int,
     calibrate_count: int,
     calibration_fraction: float,
-    head: str = "mlp",
+    head: str = PRODUCTION_HEAD,
     emit_calibration_metrics: bool = False,
     fold_count_variants: list[int] | None = None,
 ) -> tuple[_StepModel, float, int, dict[str, float], dict[str, Any]]:
@@ -2103,7 +2115,7 @@ def simulate_voting_iterations(  # noqa: C901
     atlas_min_node_size: int = 20,
     seed_scores: Optional[dict[int, float]] = None,
     trainer: str = "mlp",
-    head: str = "mlp",
+    head: Optional[str] = None,
     target_prevalence: Optional[float] = None,
     style: Optional[str] = None,
     emit_calibration_metrics: bool = False,
@@ -2141,14 +2153,17 @@ def simulate_voting_iterations(  # noqa: C901
             which model makes *VTSearch* better, and VTSearch's vote order
             depends on the model).
         head: Which torch head the ``"mlp"`` trainer fits at each step (see
-            :data:`HEADS`): ``"mlp"`` (default) keeps the harness's historical
-            auto-sized hidden layer, ``"linear"`` trains the production linear
-            (logistic) head shipped in #2790/#2809 — the head a live VTSearch
-            detector actually has, so a ``"linear"`` run's thresholds and costs
-            are the ones users see.  The head is threaded into the calibration
-            folds as well, mirroring how production threads one width through
-            ``_train_and_score_xy``.  Ignored on the SVM trainers (no torch
-            head); recorded in the ``head`` result column.
+            :data:`HEADS`).  ``None`` (default) resolves to the **app's** head,
+            :data:`PRODUCTION_HEAD` — the linear (logistic) head shipped in
+            #2790/#2809, which a live VTSearch detector actually has, so a
+            default run's thresholds and costs are the ones users see.
+            ``"mlp"`` is the explicitly-named legacy arm: the harness's
+            historical auto-sized hidden layer (#2781), which the app no longer
+            ships.  The head is threaded into the calibration folds as well,
+            mirroring how production threads one width through
+            ``_train_and_score_xy``.  Rejected on the SVM trainers, which have
+            no torch head; the *resolved* name is recorded in the ``head``
+            result column (blank on the SVM trainers).
         style: Optional detection-style name (see
             :mod:`vtscore.eval.patch_styles`): ``"whole_image"``,
             ``"max_patch"`` (the production geometry), or one of the
@@ -2312,10 +2327,21 @@ def simulate_voting_iterations(  # noqa: C901
         if not 0.0 <= acq_rank_percentile <= 1.0:
             raise ValueError(f"acq_rank_percentile must be in [0, 1], got {acq_rank_percentile}")
 
-    if head not in HEADS:
-        raise ValueError(f"unknown head {head!r}; expected one of {HEADS}")
-    if head != "mlp" and trainer != "mlp":
-        raise ValueError(f"head={head!r} only applies to the torch trainer; got trainer={trainer!r}")
+    if head is not None:
+        if head not in HEADS:
+            raise ValueError(f"unknown head {head!r}; expected one of {HEADS}")
+        if trainer != "mlp":
+            raise ValueError(f"head={head!r} only applies to the torch trainer; got trainer={trainer!r}")
+    # **The default arm must be the app's default.**  Production pins the linear
+    # (logistic) head on every fit (``hidden_dim = LINEAR_HEAD`` in
+    # ``vtscore.detectors.training.train_and_threshold``), so an unspecified head
+    # resolves to it — the same way *style* and *blend_schedule* resolve to the
+    # app's geometry and schedule below.  The head sizes the final model *and*
+    # the calibration folds, so it moves the thresholds and, through the vote
+    # order, the whole trajectory: defaulting to the retired auto-sized MLP would
+    # make every unqualified run measure a detector nobody ships.  ``head="mlp"``
+    # stays available as the explicitly-named legacy arm.
+    head = head or PRODUCTION_HEAD
 
     if style is not None and trainer != "mlp":
         raise ValueError(f"detection styles only support the MLP trainer; got trainer={trainer!r}")
@@ -2662,7 +2688,9 @@ def simulate_voting_iterations(  # noqa: C901
             "category": target_category,
             "strategy": strategy,
             "trainer": trainer,
-            "head": head,
+            # Blank on the SVM trainers: they fit no torch head, so naming one
+            # here would attribute the row to an architecture it never trained.
+            "head": head if trainer == "mlp" else "",
             "style": style or "",
             "prevalence_arm": prevalence_arm,
             "realized_prevalence": realized_prevalence,


### PR DESCRIPTION
The eval framework only measures *deviations* from the shipped algorithm if its default arm **is** the shipped algorithm. Production pins `hidden_dim = LINEAR_HEAD` on every fit (`vtscore/detectors/training.py:333`), but `simulate_voting_iterations` defaulted `head="mlp"` — the auto-sized hidden layer retired in #2790/#2809. Any run that didn't explicitly name a head trained a detector nobody ships, and the head sizes the final model *and* the calibration fold models, so it moves the thresholds and, through the vote order, the entire trajectory.

## What changed

- **`head` resolves to the app's head.** `simulate_voting_iterations(head=...)` is now `Optional[str]`; `None` resolves to the new `PRODUCTION_HEAD` constant (`"linear"`), exactly the way `style=None` and `blend_schedule=None` already resolve to the app's geometry and blend schedule. `head="mlp"` stays available as the explicitly-named legacy arm (#2781's candidate).
- **No internal default can drift either.** `_train_and_calibrate`, `_mlp_train_and_calibrate` and `_style_train_and_calibrate` default to `PRODUCTION_HEAD` rather than `"mlp"`.
- **GRID config follows.** `CALIB_HEAD` defaults to unset (→ production head) instead of `"mlp"`, so a cell that doesn't set it measures the shipped detector. The launch scripts that already exported `CALIB_HEAD=linear` are unaffected.
- **Explicit head on an SVM trainer is rejected** (it was previously accepted whenever it happened to equal `"mlp"`), and the `head` result column is blank on the SVM trainers, which fit no torch head to name.
- **Sync-gate note updated** to point at `PRODUCTION_HEAD` as the one knob mirrored by name. No re-pin: no app-side source moved.

## Pinning it against the app

`tests_lib/detectors/test_harness_linear_head.py` gains a cross-tier pin that *runs* `train_and_threshold` with a spy on `train_model` and asserts the width it trains equals `_resolve_hidden_dim(PRODUCTION_HEAD, ...)`. If the shipped head ever changes, the suite fails and the harness default has to move with it, rather than the default arm silently measuring a retired architecture.

## Test fallout

Three synthetic assertions were calibrated on the MLP arm and had to be re-cut to the claim they actually make (ranking well above chance at prevalence 0.5) now that the default run trains the linear head:

- `test_max_patch_learns_planted_signal` — back-half AP `> 0.7` → `> 0.6` (measured 0.65–0.77).
- `TestMaxPatchPcaHacStyle::test_learns_planted_signal` — final AP `> 0.7` → `> 0.6` (measured 0.685).
- `test_folds_forced_to_full_data_hidden_dim` — parametrized over `[None, "mlp"]` so it keeps proving "folds take the final model's width, not their own auto-size" on both arms instead of only the MLP one.

`./run-tests.sh` full suite: 7916 passed, 1 skipped.

Closes #2916


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gf1CH2rJ6eYEBgjxFFjrV6)_