### PR TITLE
Keep human-verified votes through a Find re-score

### DIFF
--- a/docs/api/find.md
+++ b/docs/api/find.md
@@ -135,6 +135,14 @@ Find verification workflow. If no trained MLP is cached in the detector
 context, it trains on the fly from the detector's labelset (resolving label
 origins as needed).
 
+Items the human has **verified** (see `verified` on [`GET
+/api/votes`](medias.md)) keep their existing vote and click-time: re-scoring is
+the normal fold-corrections → retrain → re-score loop, and it must not invert a
+recorded human decision. Their machine call still seeds `find_initial_labels`,
+so a disagreement surfaces as a correction in Find stats. `good_count` /
+`bad_count` therefore count the labels actually *adopted* — the threshold split
+everywhere except those held votes.
+
 → ```json
 {
   "ok": true,

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -545,7 +545,10 @@ The verification view's action buttons let you act on the result:
   into its own new dataset.
 - **Add Corrections to Detector** - fold the items you changed from the
   detector's call back into the detector's examples and retrain it, so
-  the detector gets better at the cases it got wrong.
+  the detector gets better at the cases it got wrong. Running Find again
+  re-scores the dataset with the improved detector; every item you have
+  already verified keeps the call *you* made, so re-scoring never undoes
+  your work.
 - **Stats** - open the results modal: a breakdown of the detector's
   calls plus a chart of how wrong matches and missed matches change as
   you adjust inclusion - the clearest way to see the trade-off the

--- a/tests/detectors/test_find_verification.py
+++ b/tests/detectors/test_find_verification.py
@@ -5,6 +5,7 @@ Covers:
 - the ``verified`` array on ``GET /api/votes``
 - ``label_filter=unverified`` / ``verified`` export partitioning
 - ``GET /api/find/stats`` (2x2 confusion + FP/FN inclusion sweep)
+- verified votes surviving a re-score (issue #2928)
 - a live Find session surviving a detector-file write (issue #2786)
 
 See docs/plans/find-verification-workflow.md.
@@ -346,6 +347,99 @@ class TestCorrectionsToDetector:
         assert resp.status_code == 200, resp.get_json()
         assert get_active_detector_context().find_eval_stale is False
         assert client.get("/api/find/stats").get_json()["stale"] is False
+
+
+class TestReScoreKeepsVerifiedVotes:
+    """Re-scoring must not overwrite a human-verified vote (#2928).
+
+    ``POST /api/find-label`` re-applies the detector's call to every item, and
+    the fold-corrections -> retrain -> re-score loop re-runs it on purpose.  The
+    bulk apply used to reassign *every* vote from the new threshold split while
+    nothing cleared ``verified_ids``, so an item the human had ruled on came
+    back carrying the machine's opposite label - excluded from the work queue,
+    counted in ``verified_count``, and pinned there by the Inclusion
+    re-threshold - i.e. the human's decision silently inverted while still
+    presented as human-verified.
+    """
+
+    DETECTOR = "rescore-verified"
+
+    def _setup_find(self, client):
+        detector_id = setup_trainable_model_in_registry(
+            self.DETECTOR,
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        load_detector_and_wait(client, detector_id)
+        resp = client.post("/api/find-label", json={"detector_id": detector_id})
+        assert resp.status_code == 200, resp.get_json()
+        return detector_id, resp.get_json()
+
+    def _rescue_lowest_scored(self, client, data):
+        """Verify the detector's most confident Bad as Good; return its id.
+
+        The lowest-scored item stays below the cutoff on any re-score, so the
+        machine's call on the next pass reliably disagrees with the human's.
+        """
+        lowest = min(data["results"], key=lambda r: r["score"])
+        assert lowest["score"] < data["threshold"]
+        cid = lowest["id"]
+        assert client.post(f"/api/medias/{cid}/vote", json={"target": "good"}).status_code == 200
+        ctx = get_active_detector_context()
+        assert cid in ctx.verified_ids and cid in ctx.good_votes
+        return cid
+
+    def test_verified_vote_survives_a_re_score(self, client):
+        detector_id, data = self._setup_find(client)
+        cid = self._rescue_lowest_scored(client, data)
+        click_before = get_active_detector_context().vote_click_times[cid]
+
+        assert client.post("/api/find-label", json={"detector_id": detector_id}).status_code == 200
+
+        ctx = get_active_detector_context()
+        assert cid in ctx.good_votes, "the re-score overwrote the human's vote"
+        assert cid not in ctx.bad_votes
+        assert cid in ctx.verified_ids, "the item lost its verified marker"
+        assert ctx.vote_click_times[cid] == click_before, "the human's click-time was re-stamped"
+
+    def test_re_score_still_relabels_unverified_items(self, client):
+        """The guard is narrow: everything unverified adopts the new pass."""
+        detector_id, data = self._setup_find(client)
+        self._rescue_lowest_scored(client, data)
+
+        resp = client.post("/api/find-label", json={"detector_id": detector_id})
+        assert resp.status_code == 200, resp.get_json()
+        fresh = resp.get_json()
+        ctx = get_active_detector_context()
+        for entry in fresh["results"]:
+            if entry["id"] in ctx.verified_ids:
+                continue
+            assert (entry["id"] in ctx.good_votes) == (entry["score"] >= fresh["threshold"])
+
+    def test_re_score_reports_the_adopted_counts(self, client):
+        """``good_count`` / ``bad_count`` describe the labels actually applied."""
+        detector_id, data = self._setup_find(client)
+        self._rescue_lowest_scored(client, data)
+
+        body = client.post("/api/find-label", json={"detector_id": detector_id}).get_json()
+        ctx = get_active_detector_context()
+        assert body["good_count"] == len(ctx.good_votes)
+        assert body["bad_count"] == len(ctx.bad_votes)
+
+    def test_disagreement_reads_as_a_correction_in_stats(self, client):
+        """The machine's call still seeds the eval baseline, so a held human
+        vote the re-scored detector disagrees with shows up as a correction
+        rather than quietly agreeing with itself."""
+        detector_id, data = self._setup_find(client)
+        cid = self._rescue_lowest_scored(client, data)
+
+        assert client.post("/api/find-label", json={"detector_id": detector_id}).status_code == 200
+
+        assert get_active_detector_context().find_initial_labels[cid] == "bad"
+        stats = client.get("/api/find/stats").get_json()
+        assert stats["rescued_false_neg"] >= 1
+        assert stats["corrections"] >= 1
 
 
 class TestFindSessionSurvivesDetectorFileWrite:

--- a/tests_lib/detectors/test_find_rescore_verified.py
+++ b/tests_lib/detectors/test_find_rescore_verified.py
@@ -36,9 +36,7 @@ class TestPreserveVerified:
     def test_verified_vote_is_not_overwritten(self):
         # 1 verified-good, 2 unverified-good; the new pass calls both bad.
         _seed_find_session(good={1, 2}, bad=set(), verified={1})
-        apply_labels_bulk_with_click_time(
-            [(1, "bad"), (2, "bad")], replace_all=True, preserve_verified=True
-        )
+        apply_labels_bulk_with_click_time([(1, "bad"), (2, "bad")], replace_all=True, preserve_verified=True)
         ctx = get_active_detector_context()
         assert 1 in ctx.good_votes and 1 not in ctx.bad_votes  # human's call held
         assert 2 in ctx.bad_votes and 2 not in ctx.good_votes  # machine's call adopted
@@ -46,9 +44,7 @@ class TestPreserveVerified:
 
     def test_verified_click_time_is_preserved(self):
         _seed_find_session(good={1, 2}, bad=set(), verified={1})
-        apply_labels_bulk_with_click_time(
-            [(1, "bad"), (2, "bad")], replace_all=True, preserve_verified=True
-        )
+        apply_labels_bulk_with_click_time([(1, "bad"), (2, "bad")], replace_all=True, preserve_verified=True)
         ctx = get_active_detector_context()
         assert ctx.vote_click_times[1] == 101  # untouched
         assert ctx.vote_click_times[2] != 102  # re-stamped by this pass

--- a/tests_lib/detectors/test_find_rescore_verified.py
+++ b/tests_lib/detectors/test_find_rescore_verified.py
@@ -1,0 +1,87 @@
+"""Unit tests for the verified-vote guard in the Find bulk label apply.
+
+``/api/find-label`` re-applies the detector's machine call to every item on
+every run, and the fold-corrections -> retrain -> re-score loop re-runs it on
+purpose.  Items the human already verified must keep their vote through that,
+or a recorded human decision gets silently inverted while still being counted
+as human-verified (issue #2928).
+
+Library tier: ``apply_labels_bulk_with_click_time`` is a pure ``vtscore``
+mutation of the active detector context.
+"""
+
+from __future__ import annotations
+
+from vtscore.state import apply_labels_bulk_with_click_time, get_active_detector_context
+
+
+def _seed_find_session(good: set[int], bad: set[int], verified: set[int]) -> None:
+    """Put the active detector context into a voted, partly-verified Find state."""
+    ctx = get_active_detector_context()
+    ctx.find_mode = True
+    ctx.good_votes.clear()
+    ctx.bad_votes.clear()
+    ctx.good_votes.update({mid: None for mid in good})
+    ctx.bad_votes.update({mid: None for mid in bad})
+    ctx.vote_click_times.clear()
+    ctx.vote_click_times.update({mid: 100 + mid for mid in (good | bad)})
+    ctx.click_counter = 200
+    ctx.verified_ids.clear()
+    ctx.verified_ids.update({mid: None for mid in verified})
+
+
+class TestPreserveVerified:
+    """``preserve_verified=True`` leaves verified items exactly as they were."""
+
+    def test_verified_vote_is_not_overwritten(self):
+        # 1 verified-good, 2 unverified-good; the new pass calls both bad.
+        _seed_find_session(good={1, 2}, bad=set(), verified={1})
+        apply_labels_bulk_with_click_time(
+            [(1, "bad"), (2, "bad")], replace_all=True, preserve_verified=True
+        )
+        ctx = get_active_detector_context()
+        assert 1 in ctx.good_votes and 1 not in ctx.bad_votes  # human's call held
+        assert 2 in ctx.bad_votes and 2 not in ctx.good_votes  # machine's call adopted
+        assert 1 in ctx.verified_ids
+
+    def test_verified_click_time_is_preserved(self):
+        _seed_find_session(good={1, 2}, bad=set(), verified={1})
+        apply_labels_bulk_with_click_time(
+            [(1, "bad"), (2, "bad")], replace_all=True, preserve_verified=True
+        )
+        ctx = get_active_detector_context()
+        assert ctx.vote_click_times[1] == 101  # untouched
+        assert ctx.vote_click_times[2] != 102  # re-stamped by this pass
+
+    def test_returns_the_preserved_ids(self):
+        _seed_find_session(good={1, 2}, bad={3}, verified={1, 3})
+        preserved = apply_labels_bulk_with_click_time(
+            [(1, "bad"), (2, "bad"), (3, "good")], replace_all=True, preserve_verified=True
+        )
+        assert preserved == {1, 3}
+
+    def test_verified_bad_holds_against_a_good_call(self):
+        # The mirror case: a human-culled false positive the new pass promotes.
+        _seed_find_session(good=set(), bad={1}, verified={1})
+        apply_labels_bulk_with_click_time([(1, "good")], replace_all=True, preserve_verified=True)
+        ctx = get_active_detector_context()
+        assert 1 in ctx.bad_votes and 1 not in ctx.good_votes
+
+    def test_off_by_default(self):
+        """The guard is opt-in; the plain bulk apply still reassigns everything."""
+        _seed_find_session(good={1}, bad=set(), verified={1})
+        preserved = apply_labels_bulk_with_click_time([(1, "bad")], replace_all=True)
+        assert preserved == set()
+        assert 1 in get_active_detector_context().bad_votes
+
+
+class TestReplaceAllPrunesVerified:
+    """``replace_all`` drops verified markers whose vote it just cleared."""
+
+    def test_verified_id_outside_the_new_label_set_is_dropped(self):
+        _seed_find_session(good={1, 2}, bad=set(), verified={1, 2})
+        apply_labels_bulk_with_click_time([(1, "good")], replace_all=True, preserve_verified=True)
+        ctx = get_active_detector_context()
+        assert 2 not in ctx.good_votes  # vote cleared (not in the new label set)
+        assert 2 not in ctx.verified_ids  # ...so the verified marker goes too
+        assert 1 in ctx.verified_ids

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -633,6 +633,28 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
         _record_vote_locked(count_streak=False)
 
 
+def _purge_vote_state_outside(ctx: Any, kept: set[int]) -> None:
+    """Drop every vote / click-time / region box / verified marker outside *kept*.
+
+    The ``replace_all`` half of :func:`apply_labels_bulk_with_click_time`.  The
+    verified markers go with the votes they described: a marker whose vote was
+    just cleared would keep inflating ``verified_count`` and the verified
+    export partitions for an item the new label set no longer covers.  Caller
+    must hold ``_state_lock``.
+    """
+    for cid in [c for c in ctx.good_votes if c not in kept]:
+        ctx.good_votes.pop(cid, None)
+    for cid in [c for c in ctx.bad_votes if c not in kept]:
+        ctx.bad_votes.pop(cid, None)
+    for cid in [c for c in ctx.vote_click_times if c not in kept]:
+        ctx.vote_click_times.pop(cid, None)
+    for cid in [c for c in ctx.vote_region_boxes if c not in kept]:
+        ctx.vote_region_boxes.pop(cid, None)
+    for cid in [c for c in ctx.verified_ids if c not in kept]:
+        ctx.verified_ids.pop(cid, None)
+    ctx.find_initial_labels.clear()
+
+
 def apply_labels_bulk_with_click_time(
     labels: list[tuple[int, str]],
     replace_all: bool = False,
@@ -689,18 +711,7 @@ def apply_labels_bulk_with_click_time(
         label_history = ctx.label_history
         atlas = get_active_context().coverage_atlas
         if replace_all:
-            kept = {mid for mid, _ in labels}
-            for cid in [c for c in good_votes if c not in kept]:
-                good_votes.pop(cid, None)
-            for cid in [c for c in bad_votes if c not in kept]:
-                bad_votes.pop(cid, None)
-            for cid in [c for c in vote_click_times if c not in kept]:
-                vote_click_times.pop(cid, None)
-            for cid in [c for c in vote_region_boxes if c not in kept]:
-                vote_region_boxes.pop(cid, None)
-            for cid in [c for c in verified_ids if c not in kept]:
-                verified_ids.pop(cid, None)
-            ctx.find_initial_labels.clear()
+            _purge_vote_state_outside(ctx, {mid for mid, _ in labels})
         preserved: set[int] = set()
         for media_id, label in labels:
             if preserve_verified and media_id in verified_ids:

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -638,7 +638,8 @@ def apply_labels_bulk_with_click_time(
     replace_all: bool = False,
     *,
     record_achievement: bool = True,
-) -> None:
+    preserve_verified: bool = False,
+) -> set[int]:
     """Apply many labels in a single lock acquisition (for find-label scoring).
 
     Each entry is ``(media_id, label)`` where *label* is ``"good"`` or
@@ -656,7 +657,25 @@ def apply_labels_bulk_with_click_time(
     outside *labels* are cleared first.  This is what ``/api/find-label``
     wants: a detector trained on Dataset A holds Dataset A's media IDs in
     its DetectorContext, and switching to Dataset B must not leak those
-    stale IDs into Dataset B's right-scroll Goods/Bads.
+    stale IDs into Dataset B's right-scroll Goods/Bads.  Any ``verified_ids``
+    entry outside *labels* goes with them: a verified marker whose vote was
+    just dropped would keep inflating ``verified_count`` and the verified
+    partitions for an item this label set no longer covers.
+
+    Set *preserve_verified* to ``True`` when the labels are a detector's
+    machine calls over a live Find session (``/api/find-label``).  Ids in
+    ``verified_ids`` are then left exactly as they are - vote, click-time,
+    region box, history - and returned instead of being overwritten, because
+    the human already ruled on them and a re-score must not silently invert a
+    recorded decision while still presenting it as human-verified (issue
+    #2928).  The fold-corrections -> retrain -> re-score loop re-runs this path
+    on purpose, so without the guard every verified item the retrained detector
+    now scores on the other side of the cutoff would flip to the machine's call
+    and stay marked verified.
+
+    Returns:
+        The ids skipped because they were verified (empty unless
+        *preserve_verified* is set).
     """
     import time as _time
 
@@ -666,6 +685,7 @@ def apply_labels_bulk_with_click_time(
         bad_votes = ctx.bad_votes
         vote_click_times = ctx.vote_click_times
         vote_region_boxes = ctx.vote_region_boxes
+        verified_ids = ctx.verified_ids
         label_history = ctx.label_history
         atlas = get_active_context().coverage_atlas
         if replace_all:
@@ -678,8 +698,17 @@ def apply_labels_bulk_with_click_time(
                 vote_click_times.pop(cid, None)
             for cid in [c for c in vote_region_boxes if c not in kept]:
                 vote_region_boxes.pop(cid, None)
+            for cid in [c for c in verified_ids if c not in kept]:
+                verified_ids.pop(cid, None)
             ctx.find_initial_labels.clear()
+        preserved: set[int] = set()
         for media_id, label in labels:
+            if preserve_verified and media_id in verified_ids:
+                # The human's call stands, click-time and all.  Its machine
+                # label still reaches ``find_initial_labels`` via the caller,
+                # so a disagreement shows up as a correction in Stats.
+                preserved.add(media_id)
+                continue
             if label == "good":
                 already = media_id in good_votes
                 bad_votes.pop(media_id, None)
@@ -699,3 +728,4 @@ def apply_labels_bulk_with_click_time(
             if not already and record_achievement:
                 # Bulk batch: never contributes to the individual-effort streak.
                 _record_vote_locked(count_streak=False)
+        return preserved

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -336,9 +336,7 @@ def find_label(body: dict):
     # fold-corrections -> retrain -> re-score loop) must not silently invert a
     # recorded human decision while still counting it as verified (issue #2928).
     # Everything else adopts this pass's call.
-    apply_labels_bulk_with_click_time(
-        label_pairs, replace_all=True, record_achievement=False, preserve_verified=True
-    )
+    apply_labels_bulk_with_click_time(label_pairs, replace_all=True, record_achievement=False, preserve_verified=True)
 
     # The detector's own call for *every* item, verified ones included: this is
     # the evaluation baseline Stats crosses the adopted labels against, so a

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -330,17 +330,20 @@ def find_label(body: dict):
         total_steps=_FIND_LABEL_STEPS,
     )
     label_pairs = []
-    good_count = 0
-    bad_count = 0
     for entry in results:
-        if entry["score"] >= threshold:
-            label_pairs.append((entry["id"], "good"))
-            good_count += 1
-        else:
-            label_pairs.append((entry["id"], "bad"))
-            bad_count += 1
-    apply_labels_bulk_with_click_time(label_pairs, replace_all=True, record_achievement=False)
+        label_pairs.append((entry["id"], "good" if entry["score"] >= threshold else "bad"))
+    # Items the human already verified keep their vote: a re-score (the normal
+    # fold-corrections -> retrain -> re-score loop) must not silently invert a
+    # recorded human decision while still counting it as verified (issue #2928).
+    # Everything else adopts this pass's call.
+    apply_labels_bulk_with_click_time(
+        label_pairs, replace_all=True, record_achievement=False, preserve_verified=True
+    )
 
+    # The detector's own call for *every* item, verified ones included: this is
+    # the evaluation baseline Stats crosses the adopted labels against, so a
+    # verified item the retrained detector now disagrees with reads as a
+    # correction rather than vanishing.
     set_find_initial_labels({mid: lbl for mid, lbl in label_pairs})
     # Freeze the single-pass scores so the cutoff (Inclusion) re-thresholds
     # without re-scoring, and the Stats FP/FN sweep can read them.
@@ -350,11 +353,16 @@ def find_label(body: dict):
 
     set_find_mode(True)
 
+    det_ctx = get_active_detector_context()
     # A fresh scoring pass IS the current evaluation, so any "stale" flag left by
     # a prior corrections-to-detector fold no longer applies.
-    from vtscore.state.core import get_active_detector_context
-
-    get_active_detector_context().find_eval_stale = False
+    det_ctx.find_eval_stale = False
+    # The counts the client shows are the labels this pass *adopted*, which is
+    # the threshold split everywhere except the verified items that held their
+    # human vote.  ``replace_all`` left exactly this label set behind, so the
+    # vote dicts are the count.
+    good_count = len(det_ctx.good_votes)
+    bad_count = len(det_ctx.bad_votes)
 
     from vtscore.labels.sync import sync_to_labelset_source
 


### PR DESCRIPTION
## The bug

`POST /api/find-label` re-applies the detector's machine call to every item via `apply_labels_bulk_with_click_time(..., replace_all=True)`, and the fold-corrections → retrain → re-score loop re-runs it on purpose. The bulk apply reassigned **every** vote from the new threshold split, and nothing in that path cleared `verified_ids` (only `clear_votes` and a dataset switch do).

So: a human verifies item 17 as Good; corrections are folded and the detector retrained; the user re-runs Find; the new model scores 17 below the cutoff, so the bulk apply writes it into `bad_votes` — while 17 stays in `verified_ids`. It is then excluded from the unverified work queue (`find_queue_ids`), counted in `verified_count`, and pinned there by `rethreshold_unverified_find_items` as if a human had called it Bad. The recorded human decision was silently inverted while still being presented as human-verified.

This also contradicted the surrounding design: `dataset_sync` deliberately preserves `verified_ids` across detector-file writes on the same dataset (#2786, where un-verifying what the human confirmed is named as the failure mode), `_mark_verified_if_find_mode`'s contract is that detector-assigned labels "stay unverified by construction", and `rethreshold_unverified_find_items` lets verified items hold wherever their score lands.

## The fix

Preserve the human's vote — the option that keeps the verify → correct → retrain → re-score loop from throwing away the work it just collected.

- **`apply_labels_bulk_with_click_time` gains `preserve_verified`** (`vtscore/state/votes.py`). With it set, ids in `verified_ids` are skipped entirely — vote, click-time, region box and history all untouched — and returned to the caller instead of overwritten. Skipping (rather than re-applying the human's own label) is what keeps the click-time stable, so the right-scroll ordering doesn't churn on a re-score, matching what an Inclusion slide already does.
- **`replace_all` now also prunes `verified_ids`** outside the new label set, via an extracted `_purge_vote_state_outside` helper. A verified marker whose vote was just cleared would otherwise keep inflating `verified_count` and the verified export partitions for an item the label set no longer covers.
- **The find-label route opts in** (`vtsearch/routes/detectors/scoring.py`). It still seeds `find_initial_labels` from the *machine* call for every item, so a held human vote that the retrained detector now disagrees with reads as a correction in `GET /api/find/stats` rather than quietly agreeing with itself. `good_count` / `bad_count` now report the labels actually **adopted** (the threshold split everywhere except those held votes).

No frontend change is needed: the Find view re-fetches votes (including the authoritative `verified` set) after each scoring run, so it picks up the server's truth.

## Tests

- `tests_lib/detectors/test_find_rescore_verified.py` (new, library tier) — the unit contract: verified good/bad hold against an opposite machine call, click-times are preserved, the preserved ids are returned, `replace_all` prunes orphaned verified markers, and the guard stays opt-in.
- `tests/detectors/test_find_verification.py::TestReScoreKeepsVerifiedVotes` (new) — the route-level regression: rescue the detector's lowest-scored item as Good, re-run `/api/find-label`, and assert the vote, the verified marker and the click-time all survive; that unverified items still adopt the new pass; that the reported counts match the adopted labels; and that the disagreement shows up as a correction in Stats.

`./run-tests.sh` full suite: **7922 passed, 1 skipped** (ruff / format / codespell / deptry / pip-audit / pyright / OpenAPI snapshot / eval-app-sync / frontend build + Vitest gates all green).

## Docs

`docs/api/find.md` documents the held votes and the adopted-count semantics; `docs/user/USER_GUIDE.md` notes that re-running Find never undoes verification work. No GUI surface changed, so no screenshot reshoots are queued.

Closes #2928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5gBV6PsbfHWZSEQuFhncP)_