### PR TITLE
Guard detector-registry create and rename against name collisions

### DIFF
--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -255,6 +255,11 @@ all of them.
 
 → `{"ok": true, "detector": {...}}` (201)
 
+409 if the name is already taken — by another registry entry, or by a
+detector file created through `POST /api/detectors`. Names are compared by the
+labelset *slug* (lowercased, punctuation collapsed), so "My Cat" and "my cat"
+collide.
+
 ### Register detector from a label importer
 
 ```
@@ -368,6 +373,10 @@ PUT /api/detectors/registry/{detector_id}/rename
 **Body:** `{"name": "New Name"}`
 
 → `{"ok": true, "name": "New Name"}`
+
+409 if the new name is already taken. Names are compared by the labelset
+*slug* (lowercased, punctuation collapsed), so "My Cat" and "my cat" collide;
+re-spelling a detector's own name that way is allowed.
 
 ### Set detector readers
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -11676,6 +11676,9 @@
           "400": {
             "description": "Empty name after stripping, or media_type is 'any'."
           },
+          "409": {
+            "description": "A detector with this name already exists."
+          },
           "422": {
             "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
           },
@@ -12176,6 +12179,9 @@
           },
           "404": {
             "description": "Detector not found."
+          },
+          "409": {
+            "description": "A detector with the new name already exists."
           },
           "422": {
             "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -937,13 +937,9 @@ class TestAddToPile:
         assert inserted_id in app_module.good_votes
 
     def _setup_loaded_detector(self, client, name="H33Detector"):
-        """Create a detector, register it, load it, and return its registry id."""
+        """Register a detector, load it, and return its registry id."""
         from tests import load_detector_and_wait
 
-        client.post(
-            "/api/detectors",
-            json={"name": name, "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": name, "media_type": "audio", "text_query": "test"},

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -295,11 +295,7 @@ class TestRenameDetector:
         """Renaming a detector should update registry references."""
         from vtscore.detectors.registry import find_by_name, get_detector
 
-        # Create a detector and register it in the model registry
-        client.post(
-            "/api/detectors",
-            json={"name": "Original", "media_type": "audio", "text_query": "test"},
-        )
+        # Register a detector in the model registry
         res = client.post(
             "/api/detectors/registry",
             json={"name": "Original", "media_type": "audio", "text_query": "test"},
@@ -341,15 +337,148 @@ class TestRenameDetector:
         assert res.status_code == 409
 
 
+class TestRegistryNameCollisions:
+    """Two registry entries must never share one labelset file.
+
+    ``_slug`` maps every name onto ``data/detectors/<slug>.json``, so a
+    duplicate name means both detectors read and write the same labels:
+    whichever syncs last wins, and deleting either unlinks the file out
+    from under the survivor.  Both create routes and the rename route
+    refuse the collision up front.
+    """
+
+    def _register(self, client, name, **extra):
+        return client.post(
+            "/api/detectors/registry",
+            json={"name": name, "media_type": "audio", "text_query": "x", **extra},
+        )
+
+    def _labels_of(self, name):
+        from vtscore.detectors.store import _detector_path, _read_detector
+
+        data = _read_detector(_detector_path(name)) or {}
+        return data.get("labelset", {}).get("labels", [])
+
+    def _write_labels(self, name, labels):
+        from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
+
+        path = _detector_path(name)
+        data = _read_detector(path)
+        assert data is not None
+        data["labelset"] = {"labels": labels}
+        _write_detector(path, data)
+
+    def test_register_duplicate_name_conflicts(self, client):
+        from vtscore.detectors.registry import list_detectors
+
+        assert self._register(client, "Dupe").status_code == 201
+        res = self._register(client, "Dupe")
+        assert res.status_code == 409
+        assert "already exists" in res.get_json()["message"]
+        assert [e["name"] for e in list_detectors()] == ["Dupe"]
+
+    def test_register_duplicate_name_preserves_existing_labelset(self, client):
+        """The rejected create must not blank the incumbent's labels."""
+        assert self._register(client, "Keeper").status_code == 201
+        self._write_labels("Keeper", [{"md5": "a" * 32, "label": "good"}])
+
+        assert self._register(client, "Keeper").status_code == 409
+        assert self._labels_of("Keeper") == [{"md5": "a" * 32, "label": "good"}]
+
+    def test_register_slug_collision_conflicts(self, client):
+        """'My Cat' and 'my cat' slug onto the same file, so they collide."""
+        assert self._register(client, "My Cat").status_code == 201
+        assert self._register(client, "my cat").status_code == 409
+
+    def test_register_conflicts_with_unregistered_detector_file(self, client):
+        """A detector file created off-registry still owns its name."""
+        client.post(
+            "/api/detectors",
+            json={"name": "OnDisk", "media_type": "audio", "text_query": "x"},
+        )
+        assert self._register(client, "OnDisk").status_code == 409
+
+    def test_register_conflicts_when_entry_outlives_its_file(self, client):
+        """A registry entry whose file vanished still owns its name."""
+        from vtscore.detectors.store import _detector_path
+
+        assert self._register(client, "Ghost").status_code == 201
+        _detector_path("Ghost").unlink()
+
+        assert self._register(client, "Ghost").status_code == 409
+
+    def test_rename_to_taken_name_conflicts_and_preserves_labelsets(self, client):
+        from vtscore.detectors.registry import get_detector
+
+        a_id = self._register(client, "Det A").get_json()["detector"]["id"]
+        assert self._register(client, "Det B").status_code == 201
+        self._write_labels("Det A", [{"md5": "a" * 32, "label": "good"}])
+        self._write_labels("Det B", [{"md5": "b" * 32, "label": "bad"}])
+
+        res = client.put(f"/api/detectors/registry/{a_id}/rename", json={"name": "Det B"})
+        assert res.status_code == 409
+        assert "already exists" in res.get_json()["message"]
+
+        # Neither detector moved, and neither labelset was overwritten.
+        entry_a = get_detector(a_id)
+        assert entry_a is not None and entry_a["name"] == "Det A"
+        assert self._labels_of("Det A") == [{"md5": "a" * 32, "label": "good"}]
+        assert self._labels_of("Det B") == [{"md5": "b" * 32, "label": "bad"}]
+
+    def test_rename_slug_collision_conflicts(self, client):
+        a_id = self._register(client, "Alpha One").get_json()["detector"]["id"]
+        assert self._register(client, "Beta Two").status_code == 201
+
+        res = client.put(f"/api/detectors/registry/{a_id}/rename", json={"name": "beta two"})
+        assert res.status_code == 409
+
+    def test_rename_conflicts_with_unregistered_detector_file(self, client):
+        detector_id = self._register(client, "Reg Only").get_json()["detector"]["id"]
+        client.post(
+            "/api/detectors",
+            json={"name": "Squatter", "media_type": "audio", "text_query": "x"},
+        )
+
+        res = client.put(f"/api/detectors/registry/{detector_id}/rename", json={"name": "Squatter"})
+        assert res.status_code == 409
+
+    def test_rename_respelling_own_name_allowed(self, client):
+        """A rename that lands on the detector's own file is not a collision."""
+        from vtscore.detectors.registry import get_detector
+
+        detector_id = self._register(client, "Same Slug").get_json()["detector"]["id"]
+        self._write_labels("Same Slug", [{"md5": "c" * 32, "label": "good"}])
+
+        res = client.put(f"/api/detectors/registry/{detector_id}/rename", json={"name": "same slug"})
+        assert res.status_code == 200
+        entry = get_detector(detector_id)
+        assert entry is not None and entry["name"] == "same slug"
+        assert self._labels_of("same slug") == [{"md5": "c" * 32, "label": "good"}]
+
+    def test_rename_to_unchanged_name_allowed(self, client):
+        detector_id = self._register(client, "NoOp").get_json()["detector"]["id"]
+
+        res = client.put(f"/api/detectors/registry/{detector_id}/rename", json={"name": "NoOp"})
+        assert res.status_code == 200
+
+    def test_rename_to_free_name_still_works(self, client):
+        from vtscore.detectors.registry import get_detector
+
+        detector_id = self._register(client, "Before").get_json()["detector"]["id"]
+        self._write_labels("Before", [{"md5": "d" * 32, "label": "bad"}])
+
+        res = client.put(f"/api/detectors/registry/{detector_id}/rename", json={"name": "After"})
+        assert res.status_code == 200
+        entry = get_detector(detector_id)
+        assert entry is not None and entry["name"] == "After"
+        assert self._labels_of("After") == [{"md5": "d" * 32, "label": "bad"}]
+
+
 class TestRenameLabelsetSourceCleanup:
     """Renaming a detector with a {detector_name} labelset source should
     surface the orphaned file path so the user can move it."""
 
     def _create_registered_detector(self, client):
-        client.post(
-            "/api/detectors",
-            json={"name": "Old Name", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "Old Name", "media_type": "audio", "text_query": "test"},
@@ -852,10 +981,6 @@ class TestDeleteRegisteredModel:
         """Deleting a loaded model should also unload it."""
         from vtscore.detectors.registry import get_detector, is_detector_loaded
 
-        client.post(
-            "/api/detectors",
-            json={"name": "LoadDel", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "LoadDel", "media_type": "audio", "text_query": "test"},
@@ -1037,12 +1162,7 @@ class TestLoadModelEndpoint:
 
         ids = list(medias.keys())
 
-        # Create two detectors + registry entries.
-        for name in ("ModelA", "ModelB"):
-            client.post(
-                "/api/detectors",
-                json={"name": name, "media_type": "audio", "text_query": "test"},
-            )
+        # Register two detectors.
         res_a = client.post(
             "/api/detectors/registry",
             json={"name": "ModelA", "media_type": "audio", "text_query": "test"},
@@ -1078,11 +1198,7 @@ class TestLoadModelEndpoint:
 
         ids = list(medias.keys())
 
-        # Create model, load it, vote, then save labels.
-        client.post(
-            "/api/detectors",
-            json={"name": "Persist", "media_type": "audio", "text_query": "test"},
-        )
+        # Register a model, load it, vote, then save labels.
         res = client.post(
             "/api/detectors/registry",
             json={"name": "Persist", "media_type": "audio", "text_query": "test"},
@@ -1130,10 +1246,6 @@ class TestLoadModelEndpoint:
         a_bad = a_ids[1]
 
         # Create + load a detector while dataset A is active.
-        client.post(
-            "/api/detectors",
-            json={"name": "CrossDS", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "CrossDS", "media_type": "audio", "text_query": "test"},
@@ -1203,10 +1315,6 @@ class TestLoadModelEndpoint:
         a_ids = list(medias.keys())
         a_good = a_ids[0]
 
-        client.post(
-            "/api/detectors",
-            json={"name": "StaleFlagDS", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "StaleFlagDS", "media_type": "audio", "text_query": "test"},
@@ -1349,10 +1457,6 @@ class TestEmbedderMismatchInvalidatesStaleModel:
             pytest.skip("Need at least 2 medias")
 
         # Create and load a detector against dataset A.
-        client.post(
-            "/api/detectors",
-            json={"name": "H5Det", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "H5Det", "media_type": "audio", "text_query": "test"},
@@ -1431,10 +1535,6 @@ class TestValidatedVoteSnapshot:
             pytest.skip("Need at least 2 medias")
         good_cid, bad_cid = ids[0], ids[1]
 
-        client.post(
-            "/api/detectors",
-            json={"name": "SnapshotTest", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "SnapshotTest", "media_type": "audio", "text_query": "test"},
@@ -1592,10 +1692,6 @@ class TestRequestMissingDatasetPreservesDetectorState:
         ids = list(medias.keys())
         good_cid, bad_cid = ids[0], ids[1]
 
-        client.post(
-            "/api/detectors",
-            json={"name": "NoDatasetHeaderTest", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "NoDatasetHeaderTest", "media_type": "audio", "text_query": "test"},
@@ -1641,10 +1737,6 @@ class TestVoteSyncsToLoadedModel:
             pytest.skip("No medias loaded")
 
         # Create and register a detector
-        client.post(
-            "/api/detectors",
-            json={"name": "AutoSync", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "AutoSync", "media_type": "audio", "text_query": "test"},
@@ -1677,10 +1769,6 @@ class TestVoteSyncsToLoadedModel:
         if not medias:
             pytest.skip("No medias loaded")
 
-        client.post(
-            "/api/detectors",
-            json={"name": "ToggleSync", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "ToggleSync", "media_type": "audio", "text_query": "test"},
@@ -1726,10 +1814,6 @@ class TestVoteSyncsToLoadedModel:
         if not medias:
             pytest.skip("No medias loaded")
 
-        client.post(
-            "/api/detectors",
-            json={"name": "ImportSync", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "ImportSync", "media_type": "audio", "text_query": "test"},
@@ -2173,16 +2257,7 @@ class TestSeedVotesFromExamples:
         media = medias[first_id]
         fname = self._create_example_file(media["media_bytes"], "autoload.wav")
 
-        # Create model with a media example
-        client.post(
-            "/api/detectors",
-            json={
-                "name": "AutoSeed",
-                "media_type": "audio",
-                "examples": [{"type": "media", "value": fname}],
-            },
-        )
-        # Register in model registry
+        # Register a model with a media example
         res = client.post(
             "/api/detectors/registry",
             json={
@@ -2207,10 +2282,6 @@ class TestSeedVotesFromExamples:
         """Loading a text-only model should seed 0 examples."""
         from vtsearch.state import good_votes
 
-        client.post(
-            "/api/detectors",
-            json={"name": "TextOnly", "media_type": "audio", "text_query": "dogs"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={
@@ -2247,17 +2318,13 @@ class TestSeedVotesFromExamples:
             fname = self._create_example_file(medias[cid]["media_bytes"], f"skip_{i}.wav")
             fnames.append(fname)
 
-        examples = [{"type": "media", "value": fn} for fn in fnames]
-        client.post(
-            "/api/detectors",
-            json={"name": "SkipGood", "media_type": "audio", "examples": examples},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={
                 "name": "SkipGood",
                 "media_type": "audio",
                 "text_query": "",
+                "examples": [{"type": "media", "value": fn} for fn in fnames],
             },
         )
         detector_id = res.get_json()["detector"]["id"]
@@ -2278,20 +2345,13 @@ class TestSeedVotesFromExamples:
         original_count = len(medias)
         fname = self._create_example_file(b"novel-load-bytes", "novel_load.wav")
 
-        client.post(
-            "/api/detectors",
-            json={
-                "name": "NovelSeed",
-                "media_type": "audio",
-                "examples": [{"type": "media", "value": fname}],
-            },
-        )
         res = client.post(
             "/api/detectors/registry",
             json={
                 "name": "NovelSeed",
                 "media_type": "audio",
                 "text_query": "",
+                "examples": [{"type": "media", "value": fname}],
             },
         )
         detector_id = res.get_json()["detector"]["id"]

--- a/tests/detectors/test_multi_detector.py
+++ b/tests/detectors/test_multi_detector.py
@@ -281,11 +281,7 @@ class TestModelLoadEndpoints:
     """Test the multi-loaded model API endpoints."""
 
     def _register_trainable_model(self, client, name):
-        """Helper: create detector + register in model registry."""
-        client.post(
-            "/api/detectors",
-            json={"name": name, "media_type": "audio", "text_query": "test"},
-        )
+        """Helper: register a detector in the model registry."""
         res = client.post(
             "/api/detectors/registry",
             json={

--- a/tests/io/test_labels.py
+++ b/tests/io/test_labels.py
@@ -286,10 +286,6 @@ class TestExportOriginOnlyFallback:
         ids = list(medias.keys())
         good_cid, bad_cid = ids[0], ids[1]
 
-        client.post(
-            "/api/detectors",
-            json={"name": "OriginOnlyExport", "media_type": "audio", "text_query": "test"},
-        )
         res = client.post(
             "/api/detectors/registry",
             json={"name": "OriginOnlyExport", "media_type": "audio", "text_query": "test"},

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import logging
 import time
+from pathlib import Path
 
 from flask import jsonify
 from flask_smorest import Blueprint, abort
@@ -73,6 +74,39 @@ detectors_registry_bp = Blueprint(
     __name__,
     description="Register, load, unload, rename, and toggle Auto-Find on detectors.",
 )
+
+
+def _abort_if_name_taken(name: str, *, own_path: Path | None = None, exclude_id: str = "") -> None:
+    """Abort 409 when *name* would collide with an existing detector.
+
+    Two detectors collide as soon as their names resolve to the same labelset
+    file: ``_slug`` lowercases and strips punctuation, so "My Cat" and "my cat"
+    share one ``data/detectors/*.json``.  Sharing a file is never benign —
+    whichever detector writes last destroys the other's labelset, and deleting
+    either one unlinks the file out from under the survivor.
+
+    Both halves are checked because either can outlive the other: the on-disk
+    labelset file (a detector created through the non-registry ``/api/detectors``
+    route has a file but no registry entry) and the registry entries (an entry
+    whose file was deleted still owns the name).
+
+    Args:
+        name: The proposed detector name.
+        own_path: The labelset path the caller already owns, if any.  A rename
+            that only re-spells its own name ("My Cat" -> "my cat") resolves to
+            this same path and is allowed through.
+        exclude_id: Registry id to skip, so a rename doesn't collide with itself.
+    """
+    from vtscore.detectors.registry import list_detectors
+
+    new_path = _detector_path(name)
+    if own_path is not None and new_path == own_path:
+        return
+    if new_path.exists() or any(
+        entry.get("id") != exclude_id and _detector_path(entry.get("name", "")) == new_path
+        for entry in list_detectors()
+    ):
+        abort(409, message=f"A detector named '{name}' already exists")
 
 
 # ---------------------------------------------------------------------------
@@ -145,6 +179,7 @@ def list_registered_detectors():
 @detectors_registry_bp.arguments(DetectorRegistryCreateRequestSchema)
 @detectors_registry_bp.response(201, DetectorRegistryCreateResponseSchema)
 @detectors_registry_bp.alt_response(400, description="Empty name after stripping, or media_type is 'any'.")
+@detectors_registry_bp.alt_response(409, description="A detector with this name already exists.")
 def register_detector_route(body: dict):
     """Register a new detector in the detector registry."""
     from vtscore.detectors.registry import register_detector
@@ -167,6 +202,11 @@ def register_detector_route(body: dict):
         abort(400, message=type_err)
     abort_if_semantic_only_type(embedder_type)
 
+    # Two registry entries sharing one labelset file silently overwrite each
+    # other's labels, so a name that is already taken is a hard 409 (matching
+    # the sibling create routes) rather than a reuse of the existing file.
+    _abort_if_name_taken(name)
+
     examples = body.get("examples") or []
     if not examples and text_query:
         examples = [{"type": "text", "value": text_query}]
@@ -177,19 +217,17 @@ def register_detector_route(body: dict):
         # display, Autopilot fallback) see the first media example.
         media_example = next((ex.get("value", "") for ex in examples if ex.get("type") == "media"), "")
 
-    det_path = _detector_path(name)
-    if not det_path.exists():
-        detector_data = {
-            "name": name,
-            "text_query": text_query,
-            "media_example": media_example,
-            "media_type": media_type,
-            "examples": examples,
-            "created_at": time.time(),
-            "embedder_type": embedder_type,
-            "labelset": {"labels": []},
-        }
-        _write_detector(det_path, detector_data)
+    detector_data = {
+        "name": name,
+        "text_query": text_query,
+        "media_example": media_example,
+        "media_type": media_type,
+        "examples": examples,
+        "created_at": time.time(),
+        "embedder_type": embedder_type,
+        "labelset": {"labels": []},
+    }
+    _write_detector(_detector_path(name), detector_data)
 
     entry = register_detector(
         name=name,
@@ -315,9 +353,8 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
         abort(400, message=type_err)
     abort_if_semantic_only_type(embedder_type_val)
 
+    _abort_if_name_taken(name)
     det_path = _detector_path(name)
-    if det_path.exists():
-        abort(409, message=f"A detector named '{name}' already exists")
 
     label_entries, err = run_plugin_or_error(importer, "run", field_values)
     if err:
@@ -840,6 +877,7 @@ def cancel_detector_loading_task(task_id: str):
 @detectors_registry_bp.alt_response(400, description="Empty name after stripping.")
 @detectors_registry_bp.alt_response(403, description="Only the detector creator can rename it.")
 @detectors_registry_bp.alt_response(404, description="Detector not found.")
+@detectors_registry_bp.alt_response(409, description="A detector with the new name already exists.")
 def rename_registered_detector(body: dict, detector_id: str):
     """Rename a registered detector and its on-disk labelset file."""
     from vtscore.detectors.labelset_ops import detect_pending_labelset_move
@@ -856,8 +894,13 @@ def rename_registered_detector(body: dict, detector_id: str):
     if not is_detector_owner(detector_id, get_current_user()):
         abort(403, message="Only the detector creator can rename it")
 
-    pending_move: dict[str, str] | None = None
     old_name = entry.get("name", "")
+    # Without this guard the write below would overwrite the target detector's
+    # labelset file and leave both registry entries resolving to it.  A rename
+    # that only re-spells its own name keeps its own file, so it is allowed.
+    _abort_if_name_taken(new_name, own_path=_detector_path(old_name), exclude_id=detector_id)
+
+    pending_move: dict[str, str] | None = None
     if old_name and old_name != new_name:
         old_path = _detector_path(old_name)
         det_data = _read_detector(old_path)


### PR DESCRIPTION
Closes #2912

## The bug

Every detector's labels live in `data/detectors/<slug>.json`, keyed by the slug of its name. Two detectors that share a name therefore share one file: the last write wins, and deleting either one unlinks the file out from under the survivor. `_slug` lowercases and collapses punctuation, so "My Cat" and "my cat" collide too.

Two registry routes let that happen:

- **`POST /api/detectors/registry`** skipped the file write when the path already existed (`if not det_path.exists()`) but still called `register_detector(...)` unconditionally, appending a fresh-uuid entry. A duplicate name produced two registry entries over one labelset — voting on either rewrote the other's persisted labels, and deleting either orphaned the survivor.
- **`PUT /api/detectors/registry/<id>/rename`** wrote the renamed detector straight to `_detector_path(new_name)` and then unlinked its own file. Renaming A onto B's name destroyed B's labelset with no error and left both entries resolving to a single file.

The sibling routes (`crud.py` `create_detector` / `rename_detector`, and `from-labelset`) already had these guards, so this was an omission rather than a design choice.

## The fix

Both routes now go through a shared `_abort_if_name_taken` helper in `vtsearch/routes/detectors/registry.py`, which aborts 409 when the proposed name resolves to a labelset path that is already claimed by:

- an **on-disk labelset file** (a detector created through `POST /api/detectors` has a file but no registry entry), or
- a **registry entry** (an entry whose file was deleted still owns the name).

Either half can outlive the other, so both are checked. A rename that only re-spells its own name ("My Cat" → "my cat") resolves to the detector's own path and is still allowed; `own_path`/`exclude_id` carry that exemption.

Follow-on changes:

- The create route's file write is now unconditional — a pre-existing file can no longer reach it.
- The `from-labelset` route's existing file-only check moves to the same helper, so it also catches a registry entry whose file is gone.
- `alt_response(409, ...)` added to both routes; `frontend/openapi.json` regenerated.
- `docs/api/detectors.md` documents the two new 409s, including the slug-collision rule.

## Backwards compatibility

**Breaking:** `POST /api/detectors/registry` used to *adopt* an existing labelset file when the name matched, silently seeding the new registry entry with that file's labels. It now returns 409 instead. No frontend flow used the adoption path (the frontend never calls `POST /api/detectors`), but a direct API client relying on it will now get a conflict.

## Tests

New `TestRegistryNameCollisions` in `tests/detectors/test_detectors.py` covers: duplicate create, slug-collision create, create against an unregistered detector file, create when a registry entry outlives its file, rename onto a taken name (asserting *both* labelsets survive intact), rename slug collision, rename onto an unregistered file, own-name re-spelling, no-op rename, and a plain rename to a free name.

Existing tests that created a detector via `POST /api/detectors` purely so the registry create would adopt the file now register directly — that adoption path is exactly what the guard removes.

`./run-tests.sh` is green: 7871 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAARjduWqRrwPJTa94nv5J)_