### PR TITLE
Treat a framerate-0 WAV header as a decode failure, not a load abort

### DIFF
--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -320,6 +320,61 @@ class TestUndecodableAudio:
         assert result == [media]
 
 
+def _zero_rate_wav() -> bytes:
+    """Return a WAV whose fmt chunk declares a sample rate of 0.
+
+    stdlib ``wave`` opens these without complaint, so ``getnframes() /
+    getframerate()`` used to raise ``ZeroDivisionError`` straight through the
+    clippers and abort the whole dataset load.
+    """
+    wav = bytearray(generate_wav(440, 3.0))
+    fmt_offset = wav.find(b"fmt ")
+    assert fmt_offset != -1
+    struct.pack_into("<I", wav, fmt_offset + 12, 0)  # sample rate
+    struct.pack_into("<I", wav, fmt_offset + 16, 0)  # byte rate
+    return bytes(wav)
+
+
+class TestZeroSampleRateWav:
+    """A framerate-0 header is a decode failure, not a load-aborting crash."""
+
+    def test_fixture_opens_with_zero_framerate(self):
+        # Guards the regression tests below: stdlib wave really does accept
+        # this header, so the clippers are the only line of defence.
+        with wave.open(io.BytesIO(_zero_rate_wav()), "rb") as wf:
+            assert wf.getframerate() == 0
+
+    def test_wav_duration_raises_audio_decode_error(self):
+        from vtscore.media.audio.clipper import AudioDecodeError, _wav_duration
+
+        with pytest.raises(AudioDecodeError):
+            _wav_duration(_zero_rate_wav())
+
+    def test_wav_slice_raises_audio_decode_error(self):
+        from vtscore.media.audio.clipper import AudioDecodeError, _wav_slice
+
+        with pytest.raises(AudioDecodeError):
+            _wav_slice(_zero_rate_wav(), 0.0, 1.0)
+
+    def test_tiling_clipper_returns_media_unchanged(self):
+        from vtscore.media.audio.clipper import SoundTilingClipper
+
+        media = {"id": 1, "media_type": "audio", "media_bytes": _zero_rate_wav()}
+        assert SoundTilingClipper(2.0).clip(media) == [media]
+
+    def test_clip_clipper_returns_media_unchanged(self):
+        from vtscore.media.audio.clipper import SoundClipClipper
+
+        media = {"id": 1, "media_type": "audio", "media_bytes": _zero_rate_wav()}
+        assert SoundClipClipper(1.0, 3.0).clip(media) == [media]
+
+    def test_silence_trim_cleaner_returns_media_unchanged(self):
+        from vtscore.media.audio.cleaner import AudioSilenceTrimCleaner
+
+        media = {"id": 1, "media_type": "audio", "media_bytes": _zero_rate_wav()}
+        assert AudioSilenceTrimCleaner().clean(media) == media
+
+
 # ---------------------------------------------------------------------------
 # SoundClipClipper
 # ---------------------------------------------------------------------------

--- a/vtscore/media/audio/clipper.py
+++ b/vtscore/media/audio/clipper.py
@@ -37,20 +37,37 @@ def _to_pcm_wav(wav_bytes: bytes) -> bytes:
     return buf.getvalue()
 
 
+def _checked_wav(wf: wave.Wave_read) -> wave.Wave_read:
+    """Return *wf* if its header is usable, else close it and raise.
+
+    stdlib ``wave`` happily accepts a fmt chunk declaring a sample rate of 0,
+    so a corrupt or truncated header can open cleanly and then blow up with a
+    ``ZeroDivisionError`` in :func:`_wav_duration` (or a ``wave.Error`` from
+    ``setframerate`` in :func:`_wav_slice`).  Reject it up front as a decode
+    failure so callers hit the same graceful-degradation path as any other
+    undecodable payload.
+    """
+    if wf.getframerate() <= 0:
+        wf.close()
+        raise AudioDecodeError("WAV header declares a non-positive sample rate")
+    return wf
+
+
 def _open_wav(wav_bytes: bytes) -> wave.Wave_read:
     """Open WAV bytes for reading, tolerating non-PCM formats.
 
     Falls back to re-encoding via :func:`_to_pcm_wav` when stdlib ``wave``
-    can't parse the container (e.g. ``WAVE_FORMAT_EXTENSIBLE``).  Raises
-    :class:`AudioDecodeError` when neither path can decode the bytes (corrupt
-    or unsupported payload) so callers can degrade gracefully.
+    can't parse the container (e.g. ``WAVE_FORMAT_EXTENSIBLE``) or parses it
+    into an unusable header.  Raises :class:`AudioDecodeError` when neither
+    path can decode the bytes (corrupt or unsupported payload) so callers can
+    degrade gracefully.
     """
     try:
-        return wave.open(io.BytesIO(wav_bytes), "rb")
-    except (wave.Error, EOFError):
+        return _checked_wav(wave.open(io.BytesIO(wav_bytes), "rb"))
+    except (wave.Error, EOFError, AudioDecodeError):
         pass
     try:
-        return wave.open(io.BytesIO(_to_pcm_wav(wav_bytes)), "rb")
+        return _checked_wav(wave.open(io.BytesIO(_to_pcm_wav(wav_bytes)), "rb"))
     except Exception as exc:  # soundfile LibsndfileError, wave.Error, EOFError, ...
         raise AudioDecodeError("could not decode audio bytes") from exc
 


### PR DESCRIPTION
Closes #2939

## Problem

Python's stdlib `wave` accepts a fmt chunk declaring a sample rate of 0 (verified here on 3.11.15: `wave.open` returns a reader with `getframerate() == 0`). `_wav_duration` then computed `getnframes() / getframerate()` and raised `ZeroDivisionError`.

Both `SoundTilingClipper.clip` and `SoundClipClipper.clip` wrap that call in `except AudioDecodeError` only, so the `ZeroDivisionError` escaped the clipper, propagated through `apply_chain_to_clips` uncaught, and hit the load pipeline's top-level `_handle_load_failure` — killing the whole import. That contradicts the module docstring's contract that a corrupt payload (GTZAN's `jazz.00054.wav` being the motivating case) falls back to returning the media unchanged.

## Fix

Validate the header once, in `_open_wav`, via a new `_checked_wav` helper. A non-positive framerate is treated the same as an unparseable container: it falls through to the `soundfile` re-encode path and, when that also fails, raises `AudioDecodeError`. The existing handlers then degrade to "return the media unclipped".

Putting the check in `_open_wav` rather than `_wav_duration` also covers `_wav_slice`, which would otherwise have failed later with `wave.Error` from `setframerate(0)` — that path is reachable from `AudioSilenceTrimCleaner`.

## Tests

New `TestZeroSampleRateWav` in `tests/detectors/test_clippers.py`, built on a real `generate_wav` output with its fmt-chunk sample-rate and byte-rate fields zeroed:

- a guard test asserting stdlib `wave` really does open the fixture with `getframerate() == 0`, so the clippers are the only line of defence
- `_wav_duration` and `_wav_slice` raise `AudioDecodeError`
- both clippers and the silence-trim cleaner return the media unchanged

Full suite: 7918 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CcwhuxnKpGpaUPMszwBfV)_