### PR TITLE
Rebuild request-missing sentinels from their real contexts

### DIFF
--- a/tests/datasets/test_request_context.py
+++ b/tests/datasets/test_request_context.py
@@ -500,6 +500,41 @@ class TestRequestMissingSentinel:
             with pytest.raises(RequestMissingContextError):
                 ctx.click_counter = 5
 
+    def test_projection_meta_reads_sentinel_as_idle(self, client):
+        """``GET /api/projection/meta`` with no ``X-Dataset-Id`` reads
+        ``ctx._pyramids`` on the dataset sentinel.
+
+        Those slots were missing from the sentinel's hand-maintained slot
+        list, so the read raised ``AttributeError`` → 500 on exactly the
+        dropped-header path the sentinel exists to serve (issue #2933).
+        The documented behaviour is an empty-context read.
+        """
+        from vtscore.state.core import set_thread_dataset_context
+
+        set_thread_dataset_context(None)
+
+        resp = client.get("/api/projection/meta")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "idle"
+
+        resp = client.get("/api/projection/meta?subset=1")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "idle"
+
+    def test_projection_labels_reads_sentinel_as_idle(self, client):
+        """Same for ``GET /api/projection/labels``, which reads
+        ``ctx._pyramids`` / ``ctx._subset_pyramids``."""
+        from vtscore.state.core import set_thread_dataset_context
+
+        set_thread_dataset_context(None)
+
+        for url in ("/api/projection/labels", "/api/projection/labels?subset=1"):
+            resp = client.get(url)
+            assert resp.status_code == 200
+            body = resp.get_json()
+            assert body["status"] == "idle"
+            assert body["labels"] == []
+
     def test_vote_endpoint_returns_4xx_without_dataset_header(self, client):
         """``POST /api/medias/<id>/vote`` does not silently 200 when the
         request didn't identify a dataset/detector and nothing's pinned

--- a/tests_lib/core/test_request_missing_sentinel_slots.py
+++ b/tests_lib/core/test_request_missing_sentinel_slots.py
@@ -1,0 +1,129 @@
+"""The request-missing sentinels must expose the *full* slot set of the
+contexts they stand in for.
+
+The sentinels are documented (and relied on) to read as empty contexts so
+non-mutating endpoints keep working when a request didn't identify a
+dataset/detector.  Both subclasses declare ``__slots__ = ()`` and define no
+``__getattr__``, so any slot the sentinel fails to initialise is not "empty"
+— it's an ``AttributeError`` (a 500 on the exact dropped-header path the
+sentinel exists to serve).  The hand-maintained slot lists drifted twice
+(issue #2933); these tests pin the parity so they can't drift again.
+"""
+
+import pytest
+
+from vtscore.state.core import (
+    DatasetContext,
+    DetectorContext,
+    RequestMissingContextError,
+    _iter_slots,
+    _request_missing_dataset_context,
+    _request_missing_detector_context,
+    is_request_missing_dataset_context,
+    is_request_missing_detector_context,
+)
+
+
+class TestSentinelSlotParity:
+    """Every slot a real context initialises exists on the sentinel too."""
+
+    @pytest.mark.parametrize(
+        ("sentinel", "cls"),
+        [
+            (_request_missing_dataset_context, DatasetContext),
+            (_request_missing_detector_context, DetectorContext),
+        ],
+    )
+    def test_sentinel_exposes_every_slot(self, sentinel, cls):
+        real = cls("")
+        missing = [name for name in _iter_slots(cls) if hasattr(real, name) and not hasattr(sentinel, name)]
+        assert missing == [], f"{type(sentinel).__name__} is missing slots: {missing}"
+
+    def test_dataset_sentinel_reads_projection_slots_as_empty(self):
+        """The concrete #2933 crash path: ``GET /api/projection/meta`` with no
+        ``X-Dataset-Id`` reads these and must see empty, not AttributeError."""
+        ctx = _request_missing_dataset_context
+        assert ctx._pyramids == {}
+        assert ctx._subset_pyramids == {}
+        assert ctx._projection is None
+        assert ctx._subset_projection is None
+        assert ctx._full_job_id is None
+        assert ctx._subset_job_id is None
+        assert ctx._subset_ids is None
+        assert ctx._subset_content_version == 0
+        assert ctx._region_labels is None
+        assert ctx._subset_region_labels is None
+        assert ctx._relabel_job_id is None
+        assert ctx._emb_sidecar_disabled is False
+
+    def test_detector_sentinel_reads_find_mode_as_false(self):
+        """``is_find_mode()`` reads this on the sentinel; it must be False."""
+        assert _request_missing_detector_context.find_mode is False
+
+    def test_identity_predicates_still_hold(self):
+        assert is_request_missing_dataset_context(_request_missing_dataset_context)
+        assert is_request_missing_detector_context(_request_missing_detector_context)
+        assert not is_request_missing_dataset_context(DatasetContext(""))
+        assert not is_request_missing_detector_context(DetectorContext(""))
+
+
+class TestSentinelStaysFrozen:
+    """Copying the slots across must not soften the mutation guard."""
+
+    def test_dataset_containers_are_frozen(self):
+        ctx = _request_missing_dataset_context
+        with pytest.raises(RequestMissingContextError):
+            ctx.medias[1] = {}
+        with pytest.raises(RequestMissingContextError):
+            ctx._pyramids["hex"] = object()
+        with pytest.raises(RequestMissingContextError):
+            ctx._subset_pyramids["square"] = object()
+        with pytest.raises(RequestMissingContextError):
+            ctx.bump_media_revision()
+
+    def test_dataset_attribute_writes_raise(self):
+        ctx = _request_missing_dataset_context
+        with pytest.raises(RequestMissingContextError):
+            ctx._projection = object()
+        with pytest.raises(RequestMissingContextError):
+            ctx._subset_content_version = 7
+
+    def test_detector_containers_are_frozen(self):
+        ctx = _request_missing_detector_context
+        with pytest.raises(RequestMissingContextError):
+            ctx.good_votes[1] = None
+        with pytest.raises(RequestMissingContextError):
+            ctx.label_history.append((1, "good", 0.0))
+        with pytest.raises(RequestMissingContextError):
+            ctx.textsort_suggestions.append("x")
+        with pytest.raises(RequestMissingContextError):
+            ctx.find_mode = True
+
+    def test_sentinel_ids_are_the_placeholders(self):
+        assert _request_missing_dataset_context.dataset_id == "__request_missing__"
+        assert _request_missing_detector_context.detector_id == "__request_missing__"
+
+
+class TestSetFindModeIgnoresSentinel:
+    """``set_find_mode`` documents itself as a no-op for the sentinel; its
+    ``if det_ctx.detector_id:`` guard treated the truthy placeholder id as a
+    real detector (issue #2933)."""
+
+    def test_set_find_mode_is_a_noop_on_the_sentinel(self):
+        import vtscore.state.core as core
+        from vtscore.detectors.registry import set_find_mode
+
+        prev_detector = getattr(core._thread_local, "detector_context", None)
+        prev_forced = getattr(core._thread_local, "forced_detector_context", None)
+        prev_predicate = core._request_context_predicate
+        core._thread_local.detector_context = None
+        core._thread_local.forced_detector_context = None
+        core.register_request_context_predicate(lambda: True)
+        try:
+            assert core.get_active_detector_context() is _request_missing_detector_context
+            set_find_mode(True)  # must not raise, must not stick
+            assert _request_missing_detector_context.find_mode is False
+        finally:
+            core.register_request_context_predicate(prev_predicate)
+            core._thread_local.detector_context = prev_detector
+            core._thread_local.forced_detector_context = prev_forced

--- a/vtscore/detectors/registry.py
+++ b/vtscore/detectors/registry.py
@@ -398,10 +398,20 @@ def set_find_mode(enabled: bool = True) -> None:
     No-op when no real detector is active (the empty / request-missing
     sentinel contexts have no labelset to protect).
     """
-    from vtscore.state.core import _state_lock, get_active_detector_context
+    from vtscore.state.core import (
+        _state_lock,
+        get_active_detector_context,
+        is_request_missing_detector_context,
+    )
 
     with _state_lock:
         det_ctx = get_active_detector_context()
+        # The request-missing sentinel carries a truthy placeholder id
+        # ("__request_missing__"), so identify it explicitly rather than
+        # leaning on ``detector_id`` truthiness (which only screens the
+        # empty fallback context).
+        if is_request_missing_detector_context(det_ctx):
+            return
         if det_ctx.detector_id:
             det_ctx.find_mode = enabled
 

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -177,6 +177,49 @@ class _FrozenList(list):  # type: ignore[type-arg]
         raise _frozen_mutation_error(self._kind)
 
 
+def _iter_slots(cls: type) -> Iterator[str]:
+    """Yield every ``__slots__`` name declared anywhere in *cls*'s MRO, once."""
+    seen: set[str] = set()
+    for klass in cls.__mro__:
+        for name in getattr(klass, "__slots__", ()):
+            if name not in seen:
+                seen.add(name)
+                yield name
+
+
+def _freeze_into(sentinel: Any, template: Any, kind: str) -> None:
+    """Copy every slot of *template* onto *sentinel*, freezing its containers.
+
+    The request-missing sentinels are documented to read as *empty*
+    contexts, so they must carry the full slot set of the class they
+    subclass - a subclass with ``__slots__ = ()`` and no ``__getattr__``
+    turns any missed slot into an ``AttributeError`` (a 500 on the exact
+    dropped-header path the sentinel exists to serve).  Hand-maintaining
+    that list drifted twice; instead we build a fresh real context and copy
+    it across, so a newly added slot can never be missed (issue #2933).
+
+    Every ``dict`` / ``list`` value is replaced by a :class:`_FrozenDict` /
+    :class:`_FrozenList` so container mutations raise
+    :class:`RequestMissingContextError` instead of silently landing on the
+    sentinel.  Scalar / ``None`` slots are copied verbatim; the whole
+    sentinel refuses attribute assignment anyway (``__setattr__``), so a
+    write to one of those raises too.
+    """
+    for name in _iter_slots(type(template)):
+        try:
+            value = getattr(template, name)
+        except AttributeError:
+            # A slot the class declares but never initialises: leave it
+            # unset here too, so the sentinel reads exactly like a real
+            # freshly-constructed context.
+            continue
+        if isinstance(value, dict):
+            value = _FrozenDict(kind)
+        elif isinstance(value, list):
+            value = _FrozenList(kind)
+        object.__setattr__(sentinel, name, value)
+
+
 # ---------------------------------------------------------------------------
 # Flask-request predicate hook
 # ---------------------------------------------------------------------------
@@ -919,34 +962,16 @@ class _RequestMissingDatasetContext(DatasetContext):
     __slots__ = ()
 
     def __init__(self) -> None:
-        # Use object.__setattr__ to bypass our own write guard while
-        # initialising the slot values.
-        object.__setattr__(self, "dataset_id", "__request_missing__")
-        # ``medias`` is a property on the base class; write its backing slot
-        # directly with a frozen dict so every mutation raises.  The revision
+        # Copy every slot from a fresh, real ``DatasetContext`` (containers
+        # frozen on the way in) rather than hand-listing them, so a slot added
+        # to ``DatasetContext`` can never go missing here.  ``medias`` is a
+        # property on the base class; ``_freeze_into`` writes its backing slot
+        # directly with a frozen dict, so every mutation raises.  The revision
         # counter is inert here (a frozen dict never mutates), but the slot
         # must exist for the property / bump machinery not to AttributeError.
-        object.__setattr__(self, "_medias", _FrozenDict("dataset"))
-        object.__setattr__(self, "_media_revision", 0)
-        object.__setattr__(self, "coverage_atlas", None)
-        object.__setattr__(self, "dataset_display_name", None)
-        object.__setattr__(self, "_emb_matrix_ids", None)
-        object.__setattr__(self, "_emb_matrix", None)
-        object.__setattr__(self, "_emb_matrix_revision", None)
-        object.__setattr__(self, "_region_matrix_ids", None)
-        object.__setattr__(self, "_region_matrix", None)
-        object.__setattr__(self, "_region_matrix_revision", None)
-        object.__setattr__(self, "_region_media_index", None)
-        object.__setattr__(self, "_region_index_per_row", None)
-        object.__setattr__(self, "_origin_key_index", None)
-        object.__setattr__(self, "_md5_index", None)
-        object.__setattr__(self, "_name_index", None)
-        object.__setattr__(self, "_lookup_index_revision", None)
-        object.__setattr__(self, "_text_embedder", None)
-        object.__setattr__(self, "_patch_embedder", None)
-        object.__setattr__(self, "_structural_embedder", None)
-        object.__setattr__(self, "_binding_explicit", False)
-        object.__setattr__(self, "merge_near_duplicates", False)
+        _freeze_into(self, DatasetContext(""), "dataset")
+        # Use object.__setattr__ to bypass our own write guard.
+        object.__setattr__(self, "dataset_id", "__request_missing__")
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise _frozen_mutation_error("dataset")
@@ -1092,42 +1117,12 @@ class _RequestMissingDetectorContext(DetectorContext):
     __slots__ = ()
 
     def __init__(self) -> None:
+        # Copy every slot from a fresh, real ``DetectorContext`` (containers
+        # frozen on the way in) rather than hand-listing them, so a slot added
+        # to ``DetectorContext`` can never go missing here.
+        _freeze_into(self, DetectorContext(""), "detector")
+        # Use object.__setattr__ to bypass our own write guard.
         object.__setattr__(self, "detector_id", "__request_missing__")
-        object.__setattr__(self, "name", "")
-        object.__setattr__(self, "media_type", "")
-        object.__setattr__(self, "embedder", "")
-        object.__setattr__(self, "embedder_type", "")
-        object.__setattr__(self, "good_votes", _FrozenDict("detector"))
-        object.__setattr__(self, "bad_votes", _FrozenDict("detector"))
-        object.__setattr__(self, "label_history", _FrozenList("detector"))
-        object.__setattr__(self, "vote_click_times", _FrozenDict("detector"))
-        object.__setattr__(self, "vote_region_boxes", _FrozenDict("detector"))
-        object.__setattr__(self, "click_counter", 0)
-        object.__setattr__(self, "last_learned_scores", _FrozenDict("detector"))
-        object.__setattr__(self, "textsort_suggestions", _FrozenList("detector"))
-        object.__setattr__(self, "find_initial_labels", _FrozenDict("detector"))
-        object.__setattr__(self, "verified_ids", _FrozenDict("detector"))
-        object.__setattr__(self, "find_scores", _FrozenDict("detector"))
-        object.__setattr__(self, "find_eval_stale", False)
-        object.__setattr__(self, "inclusion", None)
-        object.__setattr__(self, "training_medias", _FrozenDict("detector"))
-        object.__setattr__(self, "label_embeddings", _FrozenDict("detector"))
-        object.__setattr__(self, "label_embedding_regions", _FrozenDict("detector"))
-        object.__setattr__(self, "label_local_features", _FrozenDict("detector"))
-        object.__setattr__(self, "label_negative_regions", _FrozenDict("detector"))
-        object.__setattr__(self, "label_score_regions", _FrozenDict("detector"))
-        object.__setattr__(self, "model", None)
-        object.__setattr__(self, "verification_classifier", None)
-        object.__setattr__(self, "threshold", 0.5)
-        object.__setattr__(self, "labelset_good_count", 0)
-        object.__setattr__(self, "labelset_bad_count", 0)
-        object.__setattr__(self, "votes_dataset_id", "")
-        object.__setattr__(self, "cached_labelset", None)
-        object.__setattr__(self, "cached_labelset_mtime", 0.0)
-        object.__setattr__(self, "cached_labelset_media_type", "")
-        object.__setattr__(self, "labelset_source", None)
-        object.__setattr__(self, "calibration_cache", None)
-        object.__setattr__(self, "anchored_cut_cache", None)
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise _frozen_mutation_error("detector")

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -172,10 +172,7 @@ def rethreshold_unverified_find_items() -> None:
     """
     with _state_lock:
         ctx = get_active_detector_context()
-        # The request-missing sentinel (no detector identified) exposes none of
-        # these fields; guard with getattr so an Inclusion/settings write with
-        # no detector context is a clean no-op rather than an AttributeError.
-        if not getattr(ctx, "find_mode", False) or not getattr(ctx, "find_scores", None):
+        if not ctx.find_mode or not ctx.find_scores:
             return
         threshold = ctx.threshold
         good_votes = ctx.good_votes
@@ -230,7 +227,7 @@ def find_queue_ids(label_filter: str) -> list[int]:
     """
     with _state_lock:
         ctx = get_active_detector_context()
-        if not getattr(ctx, "find_mode", False) or not getattr(ctx, "find_scores", None):
+        if not ctx.find_mode or not ctx.find_scores:
             return []
         threshold = ctx.threshold
         if threshold is None:
@@ -267,7 +264,7 @@ def find_boundary_next(side: str, exclude: int | None = None) -> dict:
     """
     with _state_lock:
         ctx = get_active_detector_context()
-        if not getattr(ctx, "find_mode", False) or not getattr(ctx, "find_scores", None):
+        if not ctx.find_mode or not ctx.find_scores:
             return {"id": None, "side": None}
         threshold = ctx.threshold
         if threshold is None:
@@ -425,7 +422,7 @@ def _mark_verified_if_find_mode(ctx: Any, media_id: int, new_label: str) -> None
     path does *not* go through here, so detector-assigned labels stay
     unverified by construction.  See docs/plans/find-verification-workflow.md.
     """
-    if not getattr(ctx, "find_mode", False):
+    if not ctx.find_mode:
         return
     if new_label in ("good", "bad"):
         ctx.verified_ids[media_id] = None

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -113,7 +113,7 @@ def _subset_meta(ctx, bin_shape: str) -> dict:
         meta["status"] = "ready"
         meta["media_type"] = _media_type_for(ctx)
         meta["method"] = ctx._subset_projection.method if ctx._subset_projection else None
-        meta["content_version"] = getattr(ctx, "_subset_content_version", 0)
+        meta["content_version"] = ctx._subset_content_version
         label_set = _label_set_for(ctx, pyr, subset=True)
         meta["has_labels"] = bool(label_set and label_set.labels)
         return meta
@@ -774,7 +774,7 @@ def remove_from_subset(body: dict):
     ctx._subset_projection = new_proj
     ctx._subset_ids = list(new_proj.ids)
     ctx._subset_job_id = None
-    ctx._subset_content_version = getattr(ctx, "_subset_content_version", 0) + 1
+    ctx._subset_content_version += 1
     # Re-bin every shape that was already built, each on its own preserved grid,
     # then stamp the survivors' extent over rebin_like's kept template bounds.
     ctx._subset_pyramids = {


### PR DESCRIPTION
Closes #2933

## Problem

`_RequestMissingDatasetContext` / `_RequestMissingDetectorContext` are documented to read as **empty** contexts so non-mutating endpoints keep working when a Flask request didn't identify a dataset/detector. Both declare `__slots__ = ()` and define no `__getattr__`, so any slot their hand-maintained `__init__` missed wasn't "empty" — it raised `AttributeError`.

Those lists had drifted: the dataset sentinel was missing 12 slots (`_emb_sidecar_disabled`, `_projection`, `_pyramids`, `_full_job_id`, `_region_labels`, `_relabel_job_id`, `_subset_projection`, `_subset_pyramids`, `_subset_ids`, `_subset_job_id`, `_subset_content_version`, `_subset_region_labels`) and the detector sentinel was missing `find_mode`. `GET /api/projection/meta` with no `X-Dataset-Id` — the exact dropped-header case the sentinel exists for — reached `ctx._pyramids.get(shape)` and 500'd instead of answering `{"status": "idle"}`; same for `/api/projection/labels`.

## Fix

- **Stop hand-maintaining the slot lists.** Each sentinel `__init__` now builds a fresh real `DatasetContext("")` / `DetectorContext("")` and copies every slot across via `object.__setattr__` (new `_freeze_into` / `_iter_slots` helpers), replacing each `dict`/`list` with a `_FrozenDict`/`_FrozenList` and stamping the `"__request_missing__"` id last. A newly added slot can never be missed again. The mutation guard is unchanged: containers stay frozen and `__setattr__` still raises `RequestMissingContextError`.
- **`set_find_mode`** (`vtscore/detectors/registry.py`): its `if det_ctx.detector_id:` guard treated the sentinel's truthy `"__request_missing__"` id as a real detector, contradicting its "no-op for the request-missing sentinel" docstring. It now tests identity via `is_request_missing_detector_context()`.
- **Removed the now-dead point-patches** that worked around the gap one crash site at a time: `getattr(ctx, "find_mode", False)` / `getattr(ctx, "find_scores", None)` in `vtscore/state/votes.py` (4 sites) and `getattr(ctx, "_subset_content_version", 0)` in `vtsearch/routes/projection.py` (2 sites) are back to plain attribute reads.

## Tests

- `tests_lib/core/test_request_missing_sentinel_slots.py` (new): slot-parity check against `DatasetContext` / `DetectorContext` (the durable anti-drift guard), empty-read assertions for the projection/subset/signpost slots and `find_mode`, freeze assertions so the copy didn't soften the mutation guard, and a `set_find_mode` no-op-on-sentinel test.
- `tests/datasets/test_request_context.py`: `GET /api/projection/meta` and `/api/projection/labels` (both plain and `?subset=1`) return 200 `"idle"` with no `X-Dataset-Id` instead of 500.

`./run-tests.sh` — ALL 7924 TESTS PASSED (1 skipped). `./run-tests.sh vtscore-clean` — 3843 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtBrBt2A67CePTAYtmwm5g)_