### PR TITLE
Guard New Detector submits against Enter-key double submit

### DIFF
--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -575,6 +575,47 @@ describe('NewDetectorModalComponent', () => {
     httpMock.expectOne('/api/detectors/registry/load').flush({ ok: true });
     expect(component.created.emit).toHaveBeenCalledWith('d0');
   });
+
+  // --- Double-submit guards (#2941) ---
+
+  it('ignores a second submit while the register POST is in flight', () => {
+    component.name.set('Dog Barks');
+    component.mediaType.set('audio');
+    component.pendingText.set('dog barking sounds');
+
+    // Enter in the text field, then Enter again (or in the name field) before
+    // the first POST resolves.
+    component.submit();
+    component.submit();
+
+    // One detector, not two.
+    const req = httpMock.expectOne('/api/detectors/registry');
+    req.flush({ ok: true, detector: { id: '123' } });
+  });
+
+  it('ignores a second Trained submit while the from-labelset POST is in flight', () => {
+    submitTrained();
+    component.submit();
+
+    const req = httpMock.expectOne('/api/detectors/registry/from-labelset/server_json_file');
+    req.flush({ ok: true, detector: { id: 'd1' }, ingest_task_id: '' });
+    httpMock.expectOne('/api/detectors/registry/load').flush({ ok: true });
+  });
+
+  it('ignores a second demo-path load while the select POST is in flight', () => {
+    component.mediaType.set('audio');
+    component.demoFileBrowseSource = 'demo:gtzan';
+    component.demoTypedPath = 'blues/blues.00000.wav';
+
+    component.submitDemoTypedPath();
+    component.submitDemoTypedPath();
+
+    // One materialisation, so one example row — a duplicate would collide the
+    // @for track key on example.value.
+    const req = httpMock.expectOne('/api/browse-media-files/select');
+    req.flush({ ok: true, filename: 'ex.wav', original_name: 'blues.00000.wav' });
+    expect(component.mediaExamples().length).toBe(1);
+  });
 });
 
 describe('NewDetectorModalComponent with defaultMediaType', () => {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -839,6 +839,11 @@ export class NewDetectorModalComponent implements OnInit {
   /** Submit the typed demo-relative path. Server validates and returns
    *  the materialised filename for the example sort. */
   submitDemoTypedPath(): void {
+    // The path input stays enabled during the request, so Enter can re-fire
+    // this and materialise the same example twice (duplicate rows collide the
+    // @for track key). The Load button's [disabled] alone isn't enough.
+    if (this.demoFileLoading()) return;
+
     const raw = (this.demoTypedPath || '').trim();
     if (!raw) return;
     this.demoFileLoading.set(true);
@@ -1097,6 +1102,8 @@ export class NewDetectorModalComponent implements OnInit {
   }
 
   submitTrained(): void {
+    if (this.submitting()) return;
+
     const trimmedName = this.name().trim();
     if (!trimmedName) {
       this.error.set('Name is required');
@@ -1185,6 +1192,11 @@ export class NewDetectorModalComponent implements OnInit {
   // --- Submit ---
 
   submit(): void {
+    // The footer button's [disabled] isn't the only way in: the text-example
+    // and name inputs fire this on Enter while a POST is in flight, and a
+    // second registerDetector would create a duplicate detector.
+    if (this.submitting()) return;
+
     if (this.tab === 'trained') {
       this.submitTrained();
       return;


### PR DESCRIPTION
Closes #2941

`submit()`, `submitTrained()` and `submitDemoTypedPath()` in the New Detector modal relied solely on their footer buttons' `[disabled]` to prevent re-entry. But the text-example input, the name field (via the form's `(ngSubmit)`) and the demo path input all invoke them from `(keydown.enter)` while the input stays enabled and visible during the in-flight POST. Pressing Enter twice quickly fired two `registerDetector` POSTs — and since the register route has no duplicate-name check, two identical detectors landed on the dashboard. The demo-path variant materialised the same example twice, producing stacked rows with identical `value` that also collide the `@for (track example.value)` key.

## Changes

- `submit()` returns early when `submitting()` is set.
- `submitTrained()` gets the same guard (it's the `tab === 'trained'` branch of `submit()`, and its own entry point).
- `submitDemoTypedPath()` returns early when `demoFileLoading()` is set.

## Tests

Three new specs in `new-detector-modal.component.spec.ts` assert that a second call while a request is in flight issues no second HTTP request (and, for the demo path, leaves exactly one example row).

`./run-tests.sh` — ALL 7954 TESTS PASSED (1 skipped), frontend build + Vitest (1988 passed) green.

---
_Generated by [Claude Code](https://claude.ai/code/session_011hKDyVHTciFNBRj3mBZKoR)_