### PR TITLE
Make the vtscore-clean gate actually block Flask (and fix what it caught)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -713,7 +713,14 @@ OAuth, LDAP, or any auth scheme without modifying route code.
 The `before_request` middleware in `app.py` populates `g.user` on every
 request via the active provider's `get_user()`. Routes access the current
 user via `get_current_user()`. Outside a Flask request context (CLI,
-background threads) it falls back to `"default"`.
+background threads) it falls back to the thread-local set by
+`thread_user(...)`, then to `"default"`.
+
+The resolution itself lives in `vtscore.state.current_user` so library
+code can ask "who is this for?" without Flask; `vtsearch/auth/` registers
+the `g.user` reader through `register_request_user_resolver()` at import
+time and re-exports `get_current_user` / `thread_user` / `set_thread_user`
+/ `get_thread_user` unchanged.
 
 ### Ownership tracking
 

--- a/scripts/check-vtscore-clean.py
+++ b/scripts/check-vtscore-clean.py
@@ -13,6 +13,14 @@ any other Flask-shaped module) before pytest collection starts.  If any
 library-candidate module imports Flask, the test session crashes with a
 clear error pointing at the offending import.
 
+The hook itself lives in :mod:`tests_lib.flask_blocker`, because it has
+to be installed in *every* process that imports library code: this
+controller runs pytest with ``-n auto``, and the xdist workers doing the
+actual importing are fresh subprocesses with their own ``sys.meta_path``.
+We therefore export ``VTSEARCH_BLOCK_FLASK=1`` (workers inherit the
+environment) and ``tests_lib/conftest.py`` re-installs the hook on the
+way in.
+
 Run this script with the same CLI arguments you would pass to pytest:
 
     python scripts/check-vtscore-clean.py
@@ -25,56 +33,31 @@ in a mode that bans Flask.
 
 from __future__ import annotations
 
-import importlib.abc
-import importlib.machinery
+import os
 import sys
 from pathlib import Path
 
 
-_BLOCKED_TOP_LEVEL = {"flask", "werkzeug", "flask_smorest"}
-
-
-class _FlaskBlocker(importlib.abc.MetaPathFinder):
-    """Refuse to load Flask-shaped modules.
-
-    Raises :class:`ImportError` with a directive pointing to the
-    library-clean rule in ``../vtscore/docs/architecture.md``.
-    """
-
-    def find_spec(self, fullname, path=None, target=None):  # noqa: ARG002
-        root = fullname.partition(".")[0]
-        if root in _BLOCKED_TOP_LEVEL:
-            # Returning a spec whose loader raises makes the import look
-            # like a real failure, which is what we want - pytest will
-            # surface the importing module's path in the traceback.
-            return importlib.machinery.ModuleSpec(fullname, _FlaskBlockerLoader(fullname))
-        return None
-
-
-class _FlaskBlockerLoader(importlib.abc.Loader):
-    def __init__(self, fullname: str) -> None:
-        self._fullname = fullname
-
-    def create_module(self, spec):  # noqa: ARG002
-        return None
-
-    def exec_module(self, module):  # noqa: ARG002
-        raise ImportError(
-            f"Import of {self._fullname!r} is blocked in vtscore-clean test mode. "
-            "Library-candidate code (tests_lib/ targets) must not import Flask. "
-            "See ../vtscore/docs/architecture.md Phase 1/Phase 7 for the seam policy."
-        )
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def main() -> int:
-    sys.meta_path.insert(0, _FlaskBlocker())
+    sys.path.insert(0, str(REPO_ROOT))
+    from tests_lib.flask_blocker import BLOCK_ENV_VAR, install  # noqa: PLC0415
+
+    # Block Flask here (covers this controller process) *and* tell every
+    # xdist worker to do the same on its way in - workers inherit the
+    # environment but not ``sys.meta_path``, and they are what import the
+    # test modules and the library code under test.
+    os.environ[BLOCK_ENV_VAR] = "1"
+    install()
 
     # Defer pytest import until after the blocker is in place - pytest
     # itself does NOT import Flask, but pulling it in early reduces the
     # window for accidental Flask imports.
     import pytest  # noqa: PLC0415
 
-    repo_root = Path(__file__).resolve().parent.parent
+    repo_root = REPO_ROOT
     args = [
         str(repo_root / "tests_lib"),
         "-q",

--- a/tests/io/test_csv_webhook_exporters.py
+++ b/tests/io/test_csv_webhook_exporters.py
@@ -894,26 +894,28 @@ class TestFilepathTemplateExpansion:
 
     def test_username_template_expands(self, tmp_path):
         """The {username} template substitutes get_current_user(), sanitised."""
+        from vtsearch.auth import thread_user
         from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
         from vtscore.plugins.normalize import normalize_field_values
 
         exp = ServerJsonLabelsetExporter()
         template = str(tmp_path / "{username}.json")
 
-        with mock.patch("vtsearch.auth.get_current_user", return_value="alice"):
+        with thread_user("alice"):
             exp.export(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
 
         assert (tmp_path / "alice.json").exists()
 
     def test_username_template_sanitises_path_separators(self, tmp_path):
         """A malicious username with ``/`` cannot escape the parent directory."""
+        from vtsearch.auth import thread_user
         from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
         from vtscore.plugins.normalize import normalize_field_values
 
         exp = ServerJsonLabelsetExporter()
         template = str(tmp_path / "{username}.json")
 
-        with mock.patch("vtsearch.auth.get_current_user", return_value="../evil"):
+        with thread_user("../evil"):
             exp.export(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
 
         # ``/`` and ``..`` are replaced with ``_``, so the result stays inside tmp_path.

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -295,13 +295,13 @@ class TestServerFileSettingsSource:
         with pytest.raises(ValueError, match="is required"):
             src.load({"filepath": ""})
 
-    def test_username_template_resolution(self, tmp_path, monkeypatch):
+    def test_username_template_resolution(self, tmp_path):
+        from vtsearch.auth import thread_user
         from vtsearch.settings_io.sources import get_settings_source
 
-        monkeypatch.setattr("vtsearch.auth.get_current_user", lambda: "alice")
-
         src = get_settings_source("server_json_file")
-        result = src._normalize({"filepath": str(tmp_path / "{username}.settings.json")})["filepath"]
+        with thread_user("alice"):
+            result = src._normalize({"filepath": str(tmp_path / "{username}.settings.json")})["filepath"]
         assert "alice.settings.json" in result
         assert "{username}" not in result
 

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -12,15 +12,27 @@ Phase 7 of ``../vtscore/docs/architecture.md``.
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import patch
+# Must run before ANY other import in this file: under ``-n auto`` the xdist
+# workers are separate processes that inherit the environment but not the
+# controller's ``sys.meta_path``, and this conftest is the first thing a
+# worker imports.  Installing the Flask blocker here is what makes
+# ``./run-tests.sh vtscore-clean`` actually cover the library code (the
+# controller-side install in ``scripts/check-vtscore-clean.py`` would
+# otherwise only see this file's own imports).  No-op unless the gate set
+# ``VTSEARCH_BLOCK_FLASK``.
+from tests_lib.flask_blocker import install_if_requested as _install_flask_blocker
 
-import numpy as np
-import os
-import pytest
+_install_flask_blocker()
 
-import vtscore.config as config
-from vtscore.utils.hashing import content_md5
+from pathlib import Path  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+import numpy as np  # noqa: E402
+import os  # noqa: E402
+import pytest  # noqa: E402
+
+import vtscore.config as config  # noqa: E402
+from vtscore.utils.hashing import content_md5  # noqa: E402
 
 
 _NON_GROUP_DIRS = {"tests_lib", "fixtures", "__pycache__"}

--- a/tests_lib/core/test_flask_blocker.py
+++ b/tests_lib/core/test_flask_blocker.py
@@ -1,0 +1,183 @@
+"""Guards for the ``./run-tests.sh vtscore-clean`` gate itself.
+
+The gate's whole value is the claim "the library tier is import-clean of
+Flask".  That claim was silently false for a while: the meta-path hook
+was installed only in the controller process, while ``-n auto`` handed
+every real import to xdist workers that never saw it.  A ``tests_lib``
+module could have grown ``import flask`` and the gate would have stayed
+green.
+
+So these tests guard the *gate*, in three links that together can't rot:
+
+* Under the gate (``VTSEARCH_BLOCK_FLASK`` set) the canary below proves
+  Flask is genuinely unimportable **inside the worker**, both at
+  test-module import time and at test-call time - the exact windows the
+  controller-only hook missed.
+* Always, :func:`test_conftest_installs_blocker_first` pins the
+  install call to the top of ``tests_lib/conftest.py`` (the only place
+  that runs early enough in a worker), and
+  :func:`test_gate_script_exports_env_var` pins the controller side of
+  the handshake.  Without those, the canary would skip silently and the
+  gate would go vacuous again.
+* Always, the mechanism tests check the hook actually raises.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests_lib import flask_blocker
+from tests_lib.flask_blocker import BLOCK_ENV_VAR, BLOCKED_TOP_LEVEL
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GATE_ACTIVE = bool(os.environ.get(BLOCK_ENV_VAR))
+
+# Canary: this runs at test-module import time, inside whichever process
+# collects the module (an xdist worker under the gate).  That is precisely
+# the window a controller-only blocker leaves open.
+_MODULE_IMPORT_BLOCKED: bool | None = None
+if _GATE_ACTIVE:
+    try:
+        import flask  # noqa: F401
+    except ImportError:
+        _MODULE_IMPORT_BLOCKED = True
+    else:
+        _MODULE_IMPORT_BLOCKED = False
+
+
+_gate_only = pytest.mark.skipif(not _GATE_ACTIVE, reason=f"only meaningful when {BLOCK_ENV_VAR} is set")
+
+
+@_gate_only
+def test_flask_blocked_at_module_import_time():
+    assert _MODULE_IMPORT_BLOCKED is True, (
+        "vtscore-clean gate is not blocking Flask when test modules are imported - "
+        "the blocker is missing from this process (an xdist worker?)."
+    )
+
+
+@_gate_only
+@pytest.mark.parametrize("name", sorted(BLOCKED_TOP_LEVEL))
+def test_blocked_modules_unimportable_at_test_time(name):
+    with pytest.raises(ImportError):
+        importlib.import_module(name)
+
+
+@_gate_only
+def test_blocker_is_on_this_processes_meta_path():
+    assert flask_blocker.is_installed()
+
+
+def test_conftest_installs_blocker_first():
+    """``tests_lib/conftest.py`` must import+install the blocker before anything else.
+
+    A worker imports this conftest before any test module, so it is the
+    only hook point early enough to cover library imports.  Anything
+    imported ahead of it is outside the gate.
+    """
+    source = (_REPO_ROOT / "tests_lib" / "conftest.py").read_text()
+    tree = ast.parse(source)
+
+    imports = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom)) and getattr(node, "module", None) != "__future__"
+    ]
+    assert imports, "conftest.py has no imports?"
+    first = imports[0]
+    assert isinstance(first, ast.ImportFrom) and first.module == "tests_lib.flask_blocker", (
+        f"tests_lib/conftest.py must import tests_lib.flask_blocker first; found {ast.dump(first)[:120]} instead."
+    )
+
+    calls = [node.value.func for node in tree.body if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)]
+    assert any(isinstance(func, ast.Name) and "flask_blocker" in func.id for func in calls), (
+        "tests_lib/conftest.py imports the blocker but never installs it."
+    )
+
+
+def test_gate_script_exports_env_var():
+    """The gate must hand the blocker to its xdist workers via the environment.
+
+    ``sys.meta_path`` is per-process and execnet workers start clean, so
+    the env var is the only channel; if this assignment disappears the
+    gate-only tests above would skip and the gate would pass vacuously.
+    """
+    source = (_REPO_ROOT / "scripts" / "check-vtscore-clean.py").read_text()
+    assert "os.environ[BLOCK_ENV_VAR]" in source or f'os.environ["{BLOCK_ENV_VAR}"]' in source, (
+        f"scripts/check-vtscore-clean.py no longer sets {BLOCK_ENV_VAR} for xdist workers."
+    )
+
+
+def test_install_blocks_flask_then_restores():
+    """The hook raises a directive-bearing ImportError while installed."""
+    saved_meta_path = list(sys.meta_path)
+    saved_modules = {k: v for k, v in sys.modules.items() if k.partition(".")[0] in BLOCKED_TOP_LEVEL}
+    try:
+        flask_blocker.install()
+        assert flask_blocker.is_installed()
+        with pytest.raises(ImportError, match="blocked in vtscore-clean test mode"):
+            importlib.import_module("flask")
+    finally:
+        sys.meta_path[:] = saved_meta_path
+        sys.modules.update(saved_modules)
+
+
+def test_install_evicts_already_imported_modules():
+    """A cached module never consults ``sys.meta_path``, so install() must evict it."""
+    saved_meta_path = list(sys.meta_path)
+    saved_modules = {k: v for k, v in sys.modules.items() if k.partition(".")[0] in BLOCKED_TOP_LEVEL}
+    sentinel = object()
+    sys.modules["flask"] = sentinel  # type: ignore[assignment]
+    try:
+        flask_blocker.install()
+        assert sys.modules.get("flask") is not sentinel
+    finally:
+        sys.meta_path[:] = saved_meta_path
+        sys.modules.pop("flask", None)
+        sys.modules.update(saved_modules)
+
+
+@pytest.mark.parametrize("env_value, expect_blocked", [("1", True), ("", False)])
+def test_env_var_handshake_in_a_fresh_process(env_value, expect_blocked):
+    """End-to-end check of the controller→worker handshake.
+
+    Mirrors what an xdist worker does on start-up: fresh interpreter,
+    inherited environment, ``install_if_requested()`` at the top of the
+    conftest.  With the var set Flask must be unimportable; without it
+    the blocker must stay out of the way.
+    """
+    env = dict(os.environ)
+    if env_value:
+        env[BLOCK_ENV_VAR] = env_value
+    else:
+        env.pop(BLOCK_ENV_VAR, None)
+
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            "from tests_lib.flask_blocker import install_if_requested\n"
+            "install_if_requested()\n"
+            "try:\n"
+            "    import flask\n"
+            "except ImportError:\n"
+            "    print('BLOCKED')\n"
+            "else:\n"
+            "    print('IMPORTED')\n",
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ("BLOCKED" if expect_blocked else "IMPORTED")

--- a/tests_lib/flask_blocker.py
+++ b/tests_lib/flask_blocker.py
@@ -1,0 +1,96 @@
+"""Meta-path import hook that bans Flask from the library-tier test run.
+
+The ``vtscore`` library (Phase 8 of ``../vtscore/docs/architecture.md``)
+must be importable without Flask installed.  Because the library code
+still ships inside the ``vtsearch`` distribution, we can't simulate
+"Flask uninstalled" with a Flask-less virtualenv; instead
+``scripts/check-vtscore-clean.py`` installs the hook below, which makes
+``import flask`` (and friends) raise :class:`ImportError`.
+
+**Why this lives here and not in the script.**  The gate runs pytest
+with ``-n auto``: xdist workers are fresh ``execnet`` subprocesses that
+inherit the parent's *environment* but not its ``sys.meta_path``, and
+the workers are what import every test module and all the library code
+underneath.  A blocker installed only in the controller process
+therefore covers almost nothing.  ``tests_lib/conftest.py`` is imported
+inside every worker before any test module, so it calls
+:func:`install_if_requested` at the very top of the file and the
+controller merely sets :data:`BLOCK_ENV_VAR` for the workers to see.
+"""
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.machinery
+import os
+import sys
+
+
+#: Environment variable the gate sets so xdist workers re-install the hook.
+BLOCK_ENV_VAR = "VTSEARCH_BLOCK_FLASK"
+
+BLOCKED_TOP_LEVEL = frozenset({"flask", "werkzeug", "flask_smorest"})
+
+
+class FlaskBlocker(importlib.abc.MetaPathFinder):
+    """Refuse to load Flask-shaped modules.
+
+    Raises :class:`ImportError` with a directive pointing to the
+    library-clean rule in ``../vtscore/docs/architecture.md``.
+    """
+
+    def find_spec(self, fullname, path=None, target=None):  # noqa: ARG002
+        root = fullname.partition(".")[0]
+        if root in BLOCKED_TOP_LEVEL:
+            # Returning a spec whose loader raises makes the import look
+            # like a real failure, which is what we want - pytest will
+            # surface the importing module's path in the traceback.
+            return importlib.machinery.ModuleSpec(fullname, _FlaskBlockerLoader(fullname))
+        return None
+
+
+class _FlaskBlockerLoader(importlib.abc.Loader):
+    def __init__(self, fullname: str) -> None:
+        self._fullname = fullname
+
+    def create_module(self, spec):  # noqa: ARG002
+        return None
+
+    def exec_module(self, module):  # noqa: ARG002
+        raise ImportError(
+            f"Import of {self._fullname!r} is blocked in vtscore-clean test mode. "
+            "Library-candidate code (tests_lib/ targets) must not import Flask. "
+            "See ../vtscore/docs/architecture.md Phase 1/Phase 7 for the seam policy."
+        )
+
+
+def is_installed() -> bool:
+    """True when a :class:`FlaskBlocker` is already on ``sys.meta_path``."""
+    return any(isinstance(finder, FlaskBlocker) for finder in sys.meta_path)
+
+
+def install() -> None:
+    """Put the blocker at the front of ``sys.meta_path`` (idempotent).
+
+    Any Flask-shaped module that slipped into ``sys.modules`` before the
+    hook went up is evicted: a cached module is served straight out of
+    ``sys.modules`` without consulting ``sys.meta_path``, so leaving it
+    there would punch a silent hole in the gate.
+    """
+    for name in list(sys.modules):
+        if name.partition(".")[0] in BLOCKED_TOP_LEVEL:
+            del sys.modules[name]
+    if not is_installed():
+        sys.meta_path.insert(0, FlaskBlocker())
+
+
+def install_if_requested() -> bool:
+    """Install the blocker iff :data:`BLOCK_ENV_VAR` is set in the environment.
+
+    Returns whether the blocker is active, so callers (conftest, tests)
+    can branch on it.
+    """
+    if os.environ.get(BLOCK_ENV_VAR):
+        install()
+        return True
+    return False

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -73,6 +73,16 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **`vtscore.state.current_user`** - Flask-free resolution of "who is this
+  work for": a pluggable request-user resolver
+  (`register_request_user_resolver`), the `thread_user` thread-local scope
+  background jobs use to inherit a requester's identity, and the `"default"`
+  fallback. Library code that needs a username now calls
+  `vtscore.state.current_user.get_current_user()` instead of importing
+  `vtsearch.auth`, which made `JobManager.start()` (and label sync, dataset
+  loading, exporters, plugin templating) hard-require Flask at call time.
+  `vtsearch.auth` re-exports every name, so there is still exactly one
+  thread-local behind the app.
 - **`FoldAnchoredCut`** / **`fit_fold_anchored_cut`** - the fitted estimator,
   split from the cut so a new Inclusion value can be re-cut arithmetically
   without refitting or re-scoring.

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -236,7 +236,7 @@ class JobManager:
         """
         # Capture the user that triggered this start() so background work
         # touching per-user settings resolves to the right user.
-        from vtsearch.auth import get_current_user
+        from vtscore.state.current_user import get_current_user
 
         current_user = get_current_user()
 
@@ -313,7 +313,7 @@ class JobManager:
     def _run(self, job: AsyncJob, target: Callable[[AsyncJob], Any]) -> None:
         from contextlib import ExitStack
 
-        from vtsearch.auth import thread_user
+        from vtscore.state.current_user import thread_user
         from vtscore.state.core import (
             get_context,
             get_detector_context,

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -452,12 +452,12 @@ def _run_origin_load_in_background(
 
     # Snapshot the user that triggered the load so background per-user
     # state (settings writes, settings_source sync) resolves correctly.
-    from vtsearch.auth import get_current_user  # noqa: PLC0415
+    from vtscore.state.current_user import get_current_user  # noqa: PLC0415
 
     request_user = created_by or get_current_user()
 
     def task():
-        from vtsearch.auth import thread_user  # noqa: PLC0415
+        from vtscore.state.current_user import thread_user  # noqa: PLC0415
         from vtscore.state.core import thread_dataset_context  # noqa: PLC0415
 
         ctx = DatasetContext(task_id)
@@ -664,7 +664,7 @@ def _run_importer_in_background(importer, field_values: dict) -> str:
     # the reload-from-origin path supplies a server path string that
     # needs CliUploadedFile wrapping so ``run()`` doesn't have to
     # branch on the input shape.
-    from vtsearch.auth import get_current_user  # noqa: PLC0415
+    from vtscore.state.current_user import get_current_user  # noqa: PLC0415
 
     field_values = wrap_cli_file_fields(importer.fields, field_values)
     created_by = get_current_user()
@@ -797,7 +797,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
     Returns the ``task_id`` a caller can poll (via the ``loading-tasks`` SSE
     channel) for progress and the final ``staging_result``.
     """
-    from vtsearch.auth import get_current_user  # noqa: PLC0415
+    from vtscore.state.current_user import get_current_user  # noqa: PLC0415
     from vtscore.plugins.uploads import wrap_cli_file_fields  # noqa: PLC0415
 
     field_values = wrap_cli_file_fields(importer.fields, field_values)
@@ -826,7 +826,7 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
     tracker.update("loading", "Preparing dataset…", 0, 0, step=1, total_steps=_TOTAL_STAGE_STEPS)
 
     def stage_task():
-        from vtsearch.auth import thread_user  # noqa: PLC0415
+        from vtscore.state.current_user import thread_user  # noqa: PLC0415
 
         with thread_user(_request_user):
             # Route the importer's own progress calls (and embedding progress)

--- a/vtscore/docs/architecture.md
+++ b/vtscore/docs/architecture.md
@@ -58,13 +58,13 @@ they define the library's interface boundary.
 
 | # | Seam | What used to leak | How the library decouples it |
 |---|------|-------------------|-----|
-| 1 | **Flask** | `flask.g` reads in `state.core` and `detectors.workflow` | Pluggable context resolvers (`register_dataset_context_resolver`, `register_detector_context_resolver`); the Flask wiring lives in `vtsearch/shim/`. |
+| 1 | **Flask** | `flask.g` reads in `state.core` and `detectors.workflow` | Pluggable context resolvers (`register_dataset_context_resolver`, `register_detector_context_resolver`) plus the current-user resolver (`register_request_user_resolver`, backing `vtscore.state.current_user.get_current_user`); the Flask wiring lives in `vtsearch/shim/` and `vtsearch/auth/`. |
 | 2 | **Settings** | Library code read `vtsearch.settings.get_*` directly | `CoreConfig` dataclass carries every knob library code consumes; `CoreConfig.from_settings()` is the bridge the app installs via `register_core_config_builder()`. |
 | 3 | **Global state** | Library code imported the `medias`, `good_votes`, … proxies | `DatasetContext` / `DetectorContext` are the library primitives; the proxies stayed app-side in `vtsearch/state_proxies.py`. |
 | 4 | **Filesystem** | Hardcoded `"data/"` paths scattered around | Every path routes through `vtscore.config.DATA_DIR` (honouring `$VTSEARCH_DATA_DIR`), snapshotted into `CoreConfig.data_dir`. |
 | 5 | **Plugin discovery** | Module scan over `vtsearch.<family>` package paths | Generic `PluginRegistry[T]` walks any package by name + sentinel; library families register under `vtscore.<family>` entry-point groups, app families stay `vtsearch.<family>`. |
 | 6 | **Pickle compatibility** | Risk that old pickles referenced `vtsearch.*` classes | Audit confirmed `safe_pickle_load`'s allowlist already prevents app-class references in any saved artefact. No shim needed. |
-| 7 | **Test suite** | `tests/` reached into Flask, settings, auth | `tests_lib/` mirrors the tree with Flask-free fixtures; `./run-tests.sh vtscore-clean` runs them under a meta-path hook that refuses `flask` / `werkzeug` / `flask_smorest`. |
+| 7 | **Test suite** | `tests/` reached into Flask, settings, auth | `tests_lib/` mirrors the tree with Flask-free fixtures; `./run-tests.sh vtscore-clean` runs them under a meta-path hook that refuses `flask` / `werkzeug` / `flask_smorest`. The hook (`tests_lib/flask_blocker.py`) is re-installed at the top of `tests_lib/conftest.py` in every xdist worker, since `sys.meta_path` is per-process and the workers are what import the code under test. |
 
 If you find code in `vtscore/` that violates one of these seams, it's a bug.
 The grep commands that enforce each seam live in the git history under the
@@ -328,7 +328,7 @@ never the reverse.
 └─────────────────────────────────────────────┘
 ```
 
-The app uses three categories of hooks to inject app-side behaviour into
+The app uses four categories of hooks to inject app-side behaviour into
 the library without the library knowing:
 
 1. **Context resolvers** - `register_dataset_context_resolver`,
@@ -339,8 +339,14 @@ the library without the library knowing:
    the app contribute `settings_importers`, `settings_exporters`,
    `settings_sources` to the registry that library tools (like
    `python app.py --list-plugins`) enumerate. Wired in `vtsearch/shim/`.
+4. **Current-user resolver** - `register_request_user_resolver`. Tells
+   `vtscore.state.current_user.get_current_user()` how to read the
+   *request-scoped* user; `vtsearch/auth/` wires it to `flask.g.user` at
+   import time. Below it sit the thread-local (`thread_user`) and the
+   `"default"` fallback, both Flask-free.
 
 If you're embedding `vtscore` in your own application, you'll typically
-install your own variants of these three hooks. None of them is required -
-the library has working defaults for all three (no context, no
-`from_settings()` builder, no app-side plugin families).
+install your own variants of these hooks. None of them is required -
+the library has working defaults for all four (no context, no
+`from_settings()` builder, no app-side plugin families, every user is
+`"default"`).

--- a/vtscore/exporters/_template.py
+++ b/vtscore/exporters/_template.py
@@ -45,7 +45,7 @@ def resolve_export_filepath(filepath: str) -> str:
         filepath = filepath.replace("{detector_name}", sanitize_template_value(ctx.name))
 
     if "{username}" in filepath:
-        from vtsearch.auth import get_current_user
+        from vtscore.state.current_user import get_current_user
         from vtscore.security.path_validation import sanitize_template_value
 
         filepath = filepath.replace("{username}", sanitize_template_value(get_current_user() or "default"))

--- a/vtscore/labels/sync.py
+++ b/vtscore/labels/sync.py
@@ -82,7 +82,7 @@ def sync_to_labelset_source() -> None:
     detector, if no detector is active, or if a ``sync_from`` import is
     currently in progress (re-checked at execution time, not here).
     """
-    from vtsearch.auth import get_current_user
+    from vtscore.state.current_user import get_current_user
     from vtscore.state.core import get_active_context, get_active_detector_context
 
     detector_ctx = get_active_detector_context()
@@ -127,7 +127,7 @@ def _run_pending_sync(detector_id: str) -> None:
 
 def _push_with_thread_context(entry: _PendingSync) -> None:
     """Scope thread-local user / dataset / detector context, run the push, restore."""
-    from vtsearch.auth import thread_user
+    from vtscore.state.current_user import thread_user
     from vtscore.state.core import thread_dataset_context, thread_detector_context
 
     with (

--- a/vtscore/plugins/normalize.py
+++ b/vtscore/plugins/normalize.py
@@ -78,8 +78,8 @@ def _resolve_template_var(name: str) -> str:
         return ctx.name if name == "detector_name" else ctx.detector_id
 
     if name == "username":
-        # Lazy import: ``vtscore.plugins`` is library-tier and must not
-        # take a hard dependency on ``vtsearch.auth`` at import time.
+        # Lazy import: keeps ``vtscore.plugins`` from pulling in the whole
+        # ``vtscore.state`` package (contexts, votes, coverage) at import time.
         from vtscore.state.current_user import get_current_user  # noqa: PLC0415
 
         return get_current_user() or "default"

--- a/vtscore/plugins/normalize.py
+++ b/vtscore/plugins/normalize.py
@@ -80,7 +80,7 @@ def _resolve_template_var(name: str) -> str:
     if name == "username":
         # Lazy import: ``vtscore.plugins`` is library-tier and must not
         # take a hard dependency on ``vtsearch.auth`` at import time.
-        from vtsearch.auth import get_current_user  # noqa: PLC0415
+        from vtscore.state.current_user import get_current_user  # noqa: PLC0415
 
         return get_current_user() or "default"
 

--- a/vtscore/state/current_user.py
+++ b/vtscore/state/current_user.py
@@ -1,0 +1,121 @@
+"""Who is this work being done for? - the Flask-free half of user identity.
+
+Library code needs a username in a handful of places (per-user settings
+writes, label-sync attribution, background jobs that must run "as" the
+user who triggered them).  In the Flask app that identity comes off
+``g.user``; on the CLI or in a plain library embedding there is no
+request at all.
+
+So identity resolves in three steps, none of which import Flask:
+
+1. A pluggable **request-user resolver**.  Default returns ``None``;
+   :mod:`vtsearch.auth` registers a Flask-aware one at import time, so an
+   app process reads ``g.user`` and a library process doesn't.
+2. The **thread-local** user, scoped by :func:`thread_user`.  Background
+   threads spawned from a request use this to inherit the requester's
+   identity.
+3. ``"default"`` - the single-user / CLI / test answer.
+
+``vtsearch.auth`` re-exports every name here, so there is exactly one
+thread-local backing the whole app; importing either module gets you the
+same storage.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Callable, Optional
+
+
+#: Fallback username when nothing else identifies the caller.
+DEFAULT_USER = "default"
+
+_thread_local = threading.local()
+
+
+def _default_request_user_resolver() -> str | None:
+    """No request framework installed - nobody to ask."""
+    return None
+
+
+_request_user_resolver: Callable[[], Optional[str]] = _default_request_user_resolver
+
+
+def register_request_user_resolver(fn: Callable[[], Optional[str]]) -> None:
+    """Install the hook that reads the *request-scoped* user, if any.
+
+    The resolver must return ``None`` (not raise) when there is no
+    request in flight.  :mod:`vtsearch.auth` wires this to Flask's
+    ``g.user`` at import time; the library default leaves it unset so
+    :func:`get_current_user` falls through to the thread-local.
+    """
+    global _request_user_resolver
+    _request_user_resolver = fn
+
+
+def reset_request_user_resolver() -> None:
+    """Restore the Flask-free default resolver (tests)."""
+    global _request_user_resolver
+    _request_user_resolver = _default_request_user_resolver
+
+
+def get_current_user() -> str:
+    """Return the username the current work belongs to.
+
+    Resolution order: registered request-user resolver (``g.user`` under
+    Flask) → thread-local (see :func:`thread_user`) → ``"default"``.
+    """
+    request_user = _request_user_resolver()
+    if request_user:
+        return request_user
+    tl_user = getattr(_thread_local, "user", None)
+    if tl_user:
+        return tl_user
+    return DEFAULT_USER
+
+
+def set_thread_user(username: str | None) -> None:
+    """Set the thread-local user for the current thread.
+
+    Prefer :func:`thread_user` (a context manager) for new code, as it saves
+    and restores the prior value automatically, removing the need for a
+    manual ``try/finally`` discipline that is easy to get wrong (and would
+    leak across requests if these threads were ever pooled).
+
+    Pass ``None`` to clear.
+    """
+    _thread_local.user = username
+
+
+def get_thread_user() -> str | None:
+    """Return the thread-local user, or ``None`` if unset."""
+    return getattr(_thread_local, "user", None)
+
+
+@contextmanager
+def thread_user(username: str | None) -> Iterator[None]:
+    """Scope the thread-local user to *username* for the ``with``-block.
+
+    On entry, snapshots the prior thread-local user (if any) and sets it
+    to *username*.  On exit, restores the snapshot, so nested scopes
+    compose correctly and a pooled / reused thread cannot leak identity
+    across jobs even if the inner body raises.
+
+    Use this from background threads (or anywhere outside a request
+    context) that need :func:`get_current_user` to resolve to a specific
+    user::
+
+        request_user = get_current_user()
+
+        def task():
+            with thread_user(request_user):
+                ...  # per-user settings writes resolve correctly here
+    """
+    prev = getattr(_thread_local, "user", None)
+    _thread_local.user = username
+    try:
+        yield
+    finally:
+        _thread_local.user = prev

--- a/vtsearch/auth/__init__.py
+++ b/vtsearch/auth/__init__.py
@@ -14,20 +14,18 @@ import logging
 import re
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from vtscore.state.current_user import (
+    get_current_user as get_current_user,
+    get_thread_user as get_thread_user,
+    register_request_user_resolver,
+    set_thread_user as set_thread_user,
+    thread_user as thread_user,
+)
 
-# Thread-local fallback used when no Flask request context is available.
-# Background threads spawned by request handlers should use the
-# :func:`thread_user` context manager to propagate the user that triggered
-# them (it snapshots and restores the prior value automatically); tests
-# can use the bare :func:`set_thread_user` setter to pin or clear a user
-# without a request context.
-_thread_local = threading.local()
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -326,73 +324,38 @@ def get_login_provider() -> LoginProvider:
     return _login_provider
 
 
-def get_current_user() -> str:
-    """Return the username for the current request.
+# ---------------------------------------------------------------------------
+# Current-user resolution
+# ---------------------------------------------------------------------------
+# The mechanics (thread-local storage, the ``"default"`` fallback) live in
+# ``vtscore.state.current_user`` so library code can resolve a user without
+# importing Flask - see ``../../vtscore/docs/architecture.md`` Phase 2.  All
+# this module adds is the Flask half: read ``g.user`` when a request is in
+# flight.  Registering the resolver at *import* time (rather than from the
+# shim's startup wiring) means any process that has the app tier loaded at
+# all resolves request users correctly, including CLI and test paths that
+# never call ``register_flask_context_resolvers()``.
 
-    Resolution order:
 
-    1. ``g.user`` (set by the ``before_request`` middleware in ``app.py``).
-    2. Thread-local fallback (scoped by the :func:`thread_user` context
-       manager; background threads spawned from a request handler use
-       this).
-    3. ``"default"`` (CLI, tests, threads with no explicit user).
+def _flask_request_user() -> str | None:
+    """Return ``g.user`` when inside a Flask request, else ``None``.
+
+    ``ImportError`` is part of the contract, not defensive padding: the
+    ``vtscore-clean`` gate makes ``flask`` unimportable to prove the
+    library tier runs without it, and this resolver is reachable from
+    library code through :func:`vtscore.state.current_user.get_current_user`.
     """
     try:
         from flask import g
 
         return g.user  # type: ignore[attr-defined]
-    except (AttributeError, RuntimeError):
-        # No Flask request context (CLI mode, background thread, etc.)
-        pass
-    tl_user = getattr(_thread_local, "user", None)
-    if tl_user:
-        return tl_user
-    return "default"
+    except (AttributeError, RuntimeError, ImportError):
+        # No Flask request context (CLI mode, background thread, etc.),
+        # or no Flask at all (library-tier test run).
+        return None
 
 
-def set_thread_user(username: str | None) -> None:
-    """Set the thread-local user for the current thread.
-
-    Prefer :func:`thread_user` (a context manager) for new code, as it saves
-    and restores the prior value automatically, removing the need for a
-    manual ``try/finally`` discipline that is easy to get wrong (and would
-    leak across requests if these threads were ever pooled).
-
-    Pass ``None`` to clear.
-    """
-    _thread_local.user = username
-
-
-def get_thread_user() -> str | None:
-    """Return the thread-local user, or ``None`` if unset."""
-    return getattr(_thread_local, "user", None)
-
-
-@contextmanager
-def thread_user(username: str | None) -> Iterator[None]:
-    """Scope the thread-local user to *username* for the ``with``-block.
-
-    On entry, snapshots the prior thread-local user (if any) and sets it
-    to *username*.  On exit, restores the snapshot, so nested scopes
-    compose correctly and a pooled / reused thread cannot leak identity
-    across jobs even if the inner body raises.
-
-    Use this from background threads (or anywhere outside a Flask request
-    context) that need :func:`get_current_user` to resolve to a specific
-    user::
-
-        request_user = get_current_user()
-
-        def task():
-            with thread_user(request_user):
-                ...  # per-user settings writes resolve correctly here
-    """
-    prev = getattr(_thread_local, "user", None)
-    _thread_local.user = username
-    try:
-        yield
-    finally:
-        _thread_local.user = prev
+register_request_user_resolver(_flask_request_user)
 
 
 def get_user_data_dir(username: str | None = None) -> Path:


### PR DESCRIPTION
## The hole

`scripts/check-vtscore-clean.py` installed the `_FlaskBlocker` meta-path hook in the controller process and then ran pytest with `-n auto`. xdist workers are fresh `execnet` subprocesses: they inherit the environment but not `sys.meta_path`, and the workers are what import every test module and all the library code underneath. So the gate covered essentially nothing — a canary `tests_lib` module with a top-level `import flask` reported `1 passed`.

## The fix

The hook moves to `tests_lib/flask_blocker.py`. The gate exports `VTSEARCH_BLOCK_FLASK=1` (workers inherit it) and `tests_lib/conftest.py` re-installs the hook on its first line — conftest is imported inside every worker before any test module, so that is the earliest hook point that covers the code under test. `install()` also evicts any already-cached blocked module, since a `sys.modules` hit never consults `sys.meta_path`.

Verified with the issue's own canary: a `tests_lib` module with top-level `import flask` now **errors** the gate (it passed before).

## What the working gate caught

Turning the gate on made 17 `tests_lib` tests fail for real: `JobManager.start()` called `vtsearch.auth.get_current_user()`, which does `from flask import g` and caught only `(AttributeError, RuntimeError)` — so the library tier hard-required Flask at call time. That is #2931's core defect, and the gate can't ship green without it.

New `vtscore/state/current_user.py` owns the resolution — pluggable request-user resolver → `thread_user` thread-local → `"default"` — with no Flask anywhere. `vtsearch/auth/` registers the `g.user` reader at import time and re-exports every name, so there is still exactly one thread-local behind the app and no caller changes. The `vtscore` call sites in `async_jobs`, `labels/sync`, `datasets/load_pipeline`, `exporters/_template` and `plugins/normalize` now import from `vtscore`.

## Guards so it can't rot again

`tests_lib/core/test_flask_blocker.py` chains three checks: under the gate, a canary proves Flask is unimportable **inside the worker** at both module-import and test-call time; always, the conftest's install is pinned to the top of the file by AST and the script's env-var export is pinned by inspection, so the gate can't quietly go vacuous and let the canary skip.

## Notes

- Three app-tier tests patched `vtsearch.auth.get_current_user` to drive the `{username}` template; they now use `thread_user(...)`, which exercises the real resolution path instead of a patch target.
- Still owed on #2931 and deliberately out of scope here: the `vtsearch.achievements` inversion (`vtscore/state/votes.py`, `vtscore/cli.py`, `labels/sync.py`, `load_pipeline.py`). It needs a recorder hook whose default is a no-op, which risks silently dropping achievements if the wiring is missed — worth its own change now that the gate can prove the result.
- `./run-tests.sh` and `./run-tests.sh vtscore-clean` both pass. One unrelated wall-clock assertion (`test_reported_xcal_seconds_is_billed_for_the_live_count`) flaked once under parallel load and passed on rerun and in isolation; filed as #3025.

Closes #2929
Refs #2931