### PR TITLE
Blend NO_GOOD_THRESHOLD on calibration-fallback steps in the eval harness

### DIFF
--- a/tests_lib/detectors/test_fallback_blend_parity.py
+++ b/tests_lib/detectors/test_fallback_blend_parity.py
@@ -1,0 +1,182 @@
+"""The harness's fallback blend must feed the x-cal side what the app feeds it (#2936).
+
+When calibration cannot form folds at all, the shipped threshold falls back to
+the schedule blend — and the app's ``_fused_threshold`` substitutes
+``NO_GOOD_THRESHOLD`` ("we never computed a cut, so admit nothing") for the
+blend's x-cal input whenever ``folds.fallback is not None``, *whichever*
+sentinel the fold rule returned.  The harness used to blend the sentinel itself,
+which is ``0.5`` on the too-few / fewer-than-two-per-class paths.
+
+The two only coincide at blend weight 0.  The production schedules ramp from
+``lo=6`` labels, so the rare-class-starvation regime (7 good / 1 bad, reachable
+under the faithful autopilot flow) carries real weight on the x-cal side and the
+two sides disagree by ``weight * (2.0 - 0.5)`` — silently moving the recorded
+operating point *and* the acquisition cut in exactly the cold-start steps the
+calibration studies examine.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.detectors.training import _fused_threshold
+from vtscore.eval.voting_iterations import (
+    _blend_xcal_input,
+    _resolve_hidden_dim,
+    _safe_threshold_for_step,
+    _train_and_calibrate,
+)
+from vtscore.training.blend_schedules import BlendContext
+from vtscore.training.thresholds import NO_GOOD_THRESHOLD, calculate_safe_threshold, calibration_folds
+
+DIM = 8
+SCHEDULE = "cap50"
+
+
+def _unit(vec: np.ndarray) -> np.ndarray:
+    return (vec / (np.linalg.norm(vec) + 1e-8)).astype(np.float32)
+
+
+def _starved_votes(rng: np.random.Generator, n_good: int = 7, n_bad: int = 1):
+    """A vote set past the schedule's ramp with one class still under 2 votes.
+
+    ``n_good + n_bad > 6`` puts real weight on the x-cal side of the blend, while
+    the single Bad vote is what makes ``compute_fold_orderings`` bail to its
+    ``0.5`` sentinel instead of calibrating.
+    """
+    good = _unit(rng.standard_normal(DIM))
+    bad = _unit(rng.standard_normal(DIM))
+    clips: dict[int, dict] = {}
+    good_votes: dict[int, None] = {}
+    bad_votes: dict[int, None] = {}
+    for i in range(n_good):
+        cid = 100 + i
+        clips[cid] = _media(cid, _unit(good + 0.05 * rng.standard_normal(DIM)), "cat0")
+        good_votes[cid] = None
+    for i in range(n_bad):
+        cid = 200 + i
+        clips[cid] = _media(cid, _unit(bad + 0.05 * rng.standard_normal(DIM)), "cat1")
+        bad_votes[cid] = None
+    # Unvoted media: the simulation set the blend fits its mixture on.
+    for i in range(20):
+        cid = 300 + i
+        base = good if i % 2 == 0 else bad
+        clips[cid] = _media(cid, _unit(base + 0.3 * rng.standard_normal(DIM)), "cat0" if i % 2 == 0 else "cat1")
+    return clips, good_votes, bad_votes
+
+
+def _media(cid: int, vec: np.ndarray, category: str) -> dict:
+    return {
+        "id": cid,
+        "media_type": "image",
+        "embedder": "siglip",
+        "category": category,
+        "embeddings": {"siglip": vec},
+    }
+
+
+def _calibrate_and_blend(clips, good_votes, bad_votes):
+    """Train one starved step and return everything both sides of the mirror need."""
+    sim_ids = sorted(cid for cid in clips if cid not in good_votes and cid not in bad_votes)
+    X_all = np.array([clips[cid]["embeddings"]["siglip"] for cid in sim_ids], dtype=np.float32)
+
+    step, threshold, n_labels, _timings, details = _train_and_calibrate(
+        "mlp",
+        good_votes,
+        bad_votes,
+        clips,
+        "cat0",
+        region_voting=False,
+        input_dim=DIM,
+        inclusion=0,
+        calibrate_count=2,
+        calibration_fraction=0.5,
+    )
+    ctx = BlendContext(n_labels=n_labels, n_good=len(good_votes), n_bad=len(bad_votes))
+    blended, sim_scores, _ids, _hay, provenance, cut = _safe_threshold_for_step(
+        threshold,
+        step,
+        details,
+        False,
+        None,
+        X_all,
+        ctx,
+        sim_ids,
+        0,
+        schedule=SCHEDULE,
+    )
+    return threshold, details, ctx, blended, sim_scores, provenance, cut
+
+
+class TestFallbackBlendParity:
+    def test_starved_step_blends_the_app_sentinel(self):
+        rng = np.random.default_rng(2936)
+        clips, good_votes, bad_votes = _starved_votes(rng)
+        threshold, details, ctx, blended, sim_scores, provenance, cut = _calibrate_and_blend(
+            clips, good_votes, bad_votes
+        )
+
+        # The regime is the one the issue describes: folds bailed to the 0.5
+        # sentinel, so there is no anchored cut and the blend is what ships.
+        assert details["fold_fallback"] == 0.5
+        assert threshold == 0.5
+        assert cut is None
+        assert provenance == "gmm_blend"
+
+        expected = _fused_threshold(
+            threshold,
+            calibration_folds(
+                [clips[cid]["embeddings"]["siglip"] for cid in [*good_votes, *bad_votes]],
+                [1.0] * len(good_votes) + [0.0] * len(bad_votes),
+                DIM,
+                calibrate_count=2,
+                calibration_fraction=0.5,
+                hidden_dim=_resolve_hidden_dim("mlp", len(good_votes) + len(bad_votes)),
+                rng=np.random.RandomState(42),
+            ),
+            {},
+            None,
+            sim_scores,
+            0,
+            ctx,
+            SCHEDULE,
+        )
+        assert blended == pytest.approx(expected), (
+            "the harness's shipped-threshold arm blended a different x-cal input than the app"
+        )
+
+    def test_the_two_sentinels_would_have_differed(self):
+        """Guard the guard: at this vote count the substitution is observable."""
+        rng = np.random.default_rng(2936)
+        clips, good_votes, bad_votes = _starved_votes(rng)
+        _threshold, _details, ctx, blended, sim_scores, _prov, _cut = _calibrate_and_blend(clips, good_votes, bad_votes)
+
+        as_sentinel = calculate_safe_threshold(0.5, sim_scores, ctx, schedule=SCHEDULE)
+        as_no_good = calculate_safe_threshold(NO_GOOD_THRESHOLD, sim_scores, ctx, schedule=SCHEDULE)
+        assert as_sentinel != pytest.approx(as_no_good), (
+            "blend weight is 0 here, so this dataset cannot tell the two rules apart"
+        )
+        assert blended == pytest.approx(as_no_good)
+
+    def test_real_folds_blend_the_computed_cut(self):
+        """The substitution is confined to the fallback: real folds blend their cut."""
+        rng = np.random.default_rng(2937)
+        clips, good_votes, bad_votes = _starved_votes(rng, n_good=5, n_bad=5)
+        threshold, details, _ctx, _blended, _scores, _prov, _cut = _calibrate_and_blend(clips, good_votes, bad_votes)
+
+        assert details["fold_fallback"] is None
+        assert _blend_xcal_input(threshold, details) == threshold
+
+
+class TestBlendXcalInput:
+    @pytest.mark.parametrize("sentinel", [0.5, NO_GOOD_THRESHOLD])
+    def test_any_sentinel_becomes_no_good(self, sentinel):
+        assert _blend_xcal_input(sentinel, {"fold_fallback": sentinel}) == NO_GOOD_THRESHOLD
+
+    def test_real_calibration_passes_through(self):
+        assert _blend_xcal_input(0.31, {"fold_fallback": None}) == 0.31
+
+    def test_trainers_without_fold_provenance_pass_through(self):
+        """The SVM arms carry no ``fold_fallback``; they blend their own value."""
+        assert _blend_xcal_input(0.5, {}) == 0.5

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -54,6 +54,7 @@ from vtscore.training.mlp import LINEAR_HEAD, _auto_hidden_dim, train_model
 from vtscore.training.thresholds import (
     ACQUISITION_INCLUSION_OFFSET,
     CUT_KIND_INTERIOR,
+    NO_GOOD_THRESHOLD,
     acquisition_inclusion,
     anchored_gmm_fit,
     calculate_safe_threshold,
@@ -451,6 +452,35 @@ def _pool_percentile(pool_scores: dict[int, float], threshold: float) -> float:
     return round(float((arr < threshold).mean()), 6)
 
 
+def _blend_xcal_input(threshold: float, details: dict[str, Any]) -> float:
+    """The x-cal side of the schedule blend, with the app's sentinel substitution.
+
+    When the fold computation could not calibrate at all it returns a *sentinel*
+    rather than a cut - ``0.5`` on the too-few-labels / fewer-than-two-per-class
+    paths, :data:`~vtscore.training.thresholds.NO_GOOD_THRESHOLD` when the split
+    itself is degenerate (see
+    :func:`~vtscore.training.thresholds.compute_fold_orderings`).  Production
+    does **not** blend whichever sentinel came back: ``_fused_threshold`` feeds
+    the blend ``NO_GOOD_THRESHOLD`` ("we never computed a cut, so admit
+    nothing") whenever ``folds.fallback is not None``, regardless of the
+    sentinel's value.  This applies that same substitution, so the harness's
+    shipped-threshold arm blends what the app blends.
+
+    It matters exactly in the cold start: the production schedules ramp from
+    ``lo=6`` labels, so a step past that with one class still under two votes -
+    the rare-class starvation the autopilot flow reaches whenever the Bad phase
+    keeps surfacing positives - carries real weight on the x-cal side, and
+    ``2.0`` vs ``0.5`` moves both the recorded operating point and the
+    acquisition cut.
+
+    *details* carries ``fold_fallback`` on every torch path (``None`` when the
+    folds are real).  The SVM arms carry no fold fallback at all - their
+    threshold comes from the trainer-agnostic port, which has no production
+    counterpart to mirror - so they blend their own returned value unchanged.
+    """
+    return NO_GOOD_THRESHOLD if details.get("fold_fallback") is not None else threshold
+
+
 def _safe_threshold_for_step(
     threshold: float,
     step: _StepModel,
@@ -477,9 +507,12 @@ def _safe_threshold_for_step(
 
     Falls back to the schedule blend
     (:func:`~vtscore.training.thresholds.calculate_safe_threshold`) exactly
-    where production does: no usable calibration folds.  The SVM arms always
-    land there - their fold models are sklearn estimators, not the torch heads
-    the app trains, so there is no production path for them to match.
+    where production does: no usable calibration folds.  The blend's x-cal side
+    carries production's sentinel substitution (see :func:`_blend_xcal_input`) -
+    a step whose folds fell back blends ``NO_GOOD_THRESHOLD``, not whichever
+    sentinel the fold rule returned.  The SVM arms always land on the blend -
+    their fold models are sklearn estimators, not the torch heads the app
+    trains, so there is no production path for them to match.
 
     Returns ``(threshold, sim_scores, sim_ids, fold_haystacks, provenance, cut)``.
     The fitted :class:`~vtscore.training.thresholds.FoldAnchoredCut` rides along
@@ -520,7 +553,7 @@ def _safe_threshold_for_step(
         anchored = cut.threshold_at(inclusion)
         if np.isfinite(anchored):
             return anchored, all_scores, ids, fold_haystacks, cut.provenance, cut
-    blended = calculate_safe_threshold(threshold, all_scores, ctx, schedule=schedule)
+    blended = calculate_safe_threshold(_blend_xcal_input(threshold, details), all_scores, ctx, schedule=schedule)
     return blended, all_scores, ids, fold_haystacks, "gmm_blend", None
 
 
@@ -725,8 +758,11 @@ def _operating_metrics(
 #: over one whose Gumbel may land on either mode ("gumbel_any_*", #2846's repair
 #: to the first family's fallback rate), and the two label-reading diagnostics
 #: ("supervised", "sim_oracle") that locate the error rather than compete to
-#: ship.  ``xcal_only`` is the no-blend control: the raw conformal threshold at
-#: the same step.  ``pooled_mid`` must reproduce the production blend exactly.
+#: ship.  ``xcal_only`` is the no-blend control: the conformal threshold at the
+#: same step, or - on a step whose folds fell back - the same sentinel the
+#: shipped blend feeds its x-cal side (:func:`_blend_xcal_input`), so the
+#: control is the blend's own input with the mix-in removed rather than a cut
+#: nobody computed.  ``pooled_mid`` must reproduce the production blend exactly.
 #: The ``tail_a*`` sweep is #2881's one-constant rule at seven tail levels - the
 #: fitted Bad component's own quantile rather than a crossing of any kind.
 #:
@@ -1746,7 +1782,14 @@ def _mlp_train_and_calibrate(
         backend="torch-cuda" if device.startswith("cuda") else "torch-cpu",
         device=device,
     )
-    details = {"fold_orderings": folds.orderings, "fold_models": folds.models}
+    details = {
+        "fold_orderings": folds.orderings,
+        "fold_models": folds.models,
+        # Which sentinel (if any) the fold rule returned: the blend's x-cal side
+        # is NO_GOOD_THRESHOLD whenever this is set, as production's does
+        # (see :func:`_blend_xcal_input`).
+        "fold_fallback": folds.fallback,
+    }
     return step, threshold, n_labels, {"train_seconds": train_seconds, "xcal_seconds": xcal_seconds}, details
 
 
@@ -1850,7 +1893,11 @@ def _style_train_and_calibrate(
             score_rows_by_group=score_rows_by_group if cal_groups is not None else None,
         )
         threshold = threshold_from_folds(folds, inclusion)
-        details = {"fold_orderings": folds.orderings, "fold_models": folds.models}
+        details = {
+            "fold_orderings": folds.orderings,
+            "fold_models": folds.models,
+            "fold_fallback": folds.fallback,
+        }
     xcal_seconds = time.monotonic() - t_xcal
     # Under the #2897 screen this step trained Kmax folds, not ``calibrate_count``
     # of them.  Bill the reported wall clock for the live count only, so the
@@ -1909,6 +1956,10 @@ def _calibrate_with_details(
     * ``fold_node_data`` — per-fold, per-group **node** scores (grouped path
       only), so a remedial pooling variant can recalibrate off the same fold
       models without retraining; ``None`` on the row-wise (whole-image) path.
+    * ``fold_fallback`` — the sentinel the fold rule returned, or ``None`` when
+      the folds are real.  The shipped blend substitutes ``NO_GOOD_THRESHOLD``
+      for the x-cal side whenever this is set, as production does (see
+      :func:`_blend_xcal_input`).
     * ``fold_count_data`` — only under *fold_count_variants* (issue #2897): the
       **full** Kmax fold orderings, their per-fold seconds, and the
       count-independent overhead, for :func:`_fold_count_variant_rows`.
@@ -1969,6 +2020,7 @@ def _calibrate_with_details(
                 "fold_orderings": [],
                 "fold_node_data": None,
                 "fold_models": [],
+                "fold_fallback": fallback,
             }
         # Base (max) orderings from the same fold node data -> identical to
         # production's grouped calibration for this arm.
@@ -1981,6 +2033,7 @@ def _calibrate_with_details(
                 "fold_orderings": fold_orderings,
                 "fold_node_data": fold_node_data[:calibrate_count],
                 "fold_models": fold_models[:calibrate_count],
+                "fold_fallback": None,
             },
             all_orderings,
         )
@@ -2003,6 +2056,7 @@ def _calibrate_with_details(
             "fold_orderings": [],
             "fold_node_data": None,
             "fold_models": [],
+            "fold_fallback": fallback,
         }
     fold_orderings = all_orderings[:calibrate_count]
     threshold = threshold_from_fold_orderings(fold_orderings, inclusion)
@@ -2012,6 +2066,7 @@ def _calibrate_with_details(
             "fold_orderings": fold_orderings,
             "fold_node_data": None,
             "fold_models": fold_models[:calibrate_count],
+            "fold_fallback": None,
         },
         all_orderings,
     )
@@ -2549,7 +2604,11 @@ def simulate_voting_iterations(  # noqa: C901
         sim_pooled_ids: list[int] = []
         sim_fold_haystacks: list[Any] = []
         if safe_thresholds:
-            xcal_threshold = threshold
+            # The x-cal side of the blend, not the raw fold return: a step whose
+            # folds fell back blends NO_GOOD_THRESHOLD (see _blend_xcal_input),
+            # and the variant families below re-blend this same input, so their
+            # rows stay paired with the shipped one.
+            xcal_threshold = _blend_xcal_input(threshold, details)
             # Vote-level class counts, so the fallback blend's schedule can ramp
             # on the rarer class (#2841).  The harness votes one media at a
             # time, so bags and votes coincide here and the counts are the two


### PR DESCRIPTION
Closes #2936

## The drift

The app's `_fused_threshold` (`vtscore/detectors/training.py:207`) feeds the schedule blend's x-cal side `NO_GOOD_THRESHOLD` (2.0) — "we never computed a cut, so admit nothing" — whenever `folds.fallback is not None`, regardless of which sentinel the fold computation returned. The harness's `_safe_threshold_for_step` blended whatever `threshold_from_folds` handed back, which is the **0.5** sentinel on the too-few-labels and fewer-than-two-per-class paths (`thresholds.py:1703`, `1717`, grouped: `1492-1494`).

The two only coincide at blend weight 0. The production schedules (`cap50`, `slow_cap50`) ramp from `lo=6`, so any step past that with one class still under two votes — the rare-class starvation #2790 documented, reachable under the faithful autopilot flow whenever the Bad phase keeps surfacing positives — carried real weight on the x-cal side. At 8g/1b the weight is ≈0.14 and the two thresholds differ by ≈0.21, moving both the recorded `cost`/`fpr`/`fnr` rows and the acquisition trajectory, concentrated in exactly the cold-start steps the #2788/#2799 studies examine. The `training.fused_threshold` mirror declared no divergence here, so this was undocumented drift in the shipped-threshold baseline arm.

## The fix

- Every torch calibration path now carries `fold_fallback` in its `details` (`_mlp_train_and_calibrate`, `_style_train_and_calibrate`, and all four returns of `_calibrate_with_details`) — the sentinel the fold rule returned, or `None` when the folds are real.
- New `_blend_xcal_input(threshold, details)` applies the app's substitution, and `_safe_threshold_for_step` blends through it. That is the whole behavioural change to the default arm.
- The recorded `xcal_threshold` is now the blend's *actual* x-cal input, so the variant families that re-blend it (`_safe_gmm_variant_rows`, `_schedule_variant_rows`, `_anchored_variant_rows`) stay paired with the shipped row on fallback steps instead of blending a cut nobody computed. The `xcal_only` control's doc-comment says so.
- The SVM arms are unchanged: they carry no `fold_fallback` and blend their own returned value. Their threshold comes from the trainer-agnostic port, which has no production counterpart to mirror, and they are named experiment arms rather than the default.

`scripts/check-eval-app-sync.py` pins the app-side digest only, so nothing needed re-pinning; the app side did not move.

## Tests

New `tests_lib/detectors/test_fallback_blend_parity.py` (7 tests):

- A 7-good/1-bad starved step (past the `cap50` ramp, one class under two votes) trains through `_train_and_calibrate`, lands on the 0.5 sentinel with no anchored cut, and its blended threshold now equals what the app's `_fused_threshold` returns for the same folds, sim scores and blend context.
- A guard-the-guard test asserts the two sentinels *would* have produced different thresholds at this vote count, so the parity test cannot pass vacuously at blend weight 0.
- A real-folds step confirms the substitution is confined to the fallback, plus unit coverage of `_blend_xcal_input` for both sentinels, real calibration, and the no-`fold_fallback` (SVM) case.

Full suite green: 7919 passed, 1 skipped, 2 xpassed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPRAmwyBqDZYo3Hy9fRbdk)_