### PR TITLE
Cap folder-loader progress updates at ~50, not the interval

### DIFF
--- a/tests_lib/datasets/test_folder_progress_cadence.py
+++ b/tests_lib/datasets/test_folder_progress_cadence.py
@@ -65,9 +65,7 @@ class TestFolderProgressCadence:
         # No override map: files stream lazily, so the total is unknown and the
         # loader falls back to a fixed 200-file interval.
         def run(cb):
-            for _chunk in load_dataset_from_folder_chunked(
-                big_text_folder, "text", 500, on_progress=cb, thin=True
-            ):
+            for _chunk in load_dataset_from_folder_chunked(big_text_folder, "text", 500, on_progress=cb, thin=True):
                 pass
 
         count = _count_progress_calls(run)

--- a/tests_lib/datasets/test_folder_progress_cadence.py
+++ b/tests_lib/datasets/test_folder_progress_cadence.py
@@ -1,0 +1,74 @@
+"""Progress-event cadence for the folder loaders.
+
+Regression guard: the loaders must cap the *update count* at ~50 for the whole
+walk, not cap the *interval* at 50 files.  The old ``min(50, total // 50)``
+form inverted above 2500 files — a 300k-file import emitted ~6,000 progress
+events, each a full task-list re-serialisation pushed to every open SSE stream.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vtscore.datasets.loader import (
+    load_dataset_from_folder,
+    load_dataset_from_folder_chunked,
+)
+
+# Well above the 2500-file point where the old formula inverted: with the
+# correct formula this folder yields ~50 events, with the old one ~120.
+_FILE_COUNT = 6000
+
+
+@pytest.fixture(scope="module")
+def big_text_folder(tmp_path_factory) -> Path:
+    folder = tmp_path_factory.mktemp("big_text_folder")
+    for i in range(_FILE_COUNT):
+        (folder / f"f{i}.txt").write_text("hello")
+    return folder
+
+
+def _count_progress_calls(fn) -> int:
+    calls: list[tuple] = []
+    fn(lambda *args: calls.append(args))
+    return len(calls)
+
+
+class TestFolderProgressCadence:
+    def test_monolithic_loader_emits_about_fifty_updates(self, big_text_folder):
+        medias: dict[int, dict[str, Any]] = {}
+        count = _count_progress_calls(
+            lambda cb: load_dataset_from_folder(big_text_folder, "text", medias, thin=True, on_progress=cb)
+        )
+        assert len(medias) == _FILE_COUNT
+        # ~50 per-file ticks plus the scan/finish bookends — never total // 50.
+        assert 40 <= count <= 60, f"expected ~50 progress events for {_FILE_COUNT} files, got {count}"
+
+    def test_chunked_loader_emits_about_fifty_updates_when_total_known(self, big_text_folder):
+        # An override map forces the eager (known-total) branch of the chunked loader.
+        def run(cb):
+            for _chunk in load_dataset_from_folder_chunked(
+                big_text_folder,
+                "text",
+                500,
+                custom_metadata_map={"f0.txt": {"note": "x"}},
+                on_progress=cb,
+                thin=True,
+            ):
+                pass
+
+        count = _count_progress_calls(run)
+        assert 40 <= count <= 60, f"expected ~50 progress events for {_FILE_COUNT} files, got {count}"
+
+    def test_chunked_loader_uses_fixed_interval_when_total_unknown(self, big_text_folder):
+        # No override map: files stream lazily, so the total is unknown and the
+        # loader falls back to a fixed 200-file interval.
+        def run(cb):
+            for _chunk in load_dataset_from_folder_chunked(
+                big_text_folder, "text", 500, on_progress=cb, thin=True
+            ):
+                pass
+
+        count = _count_progress_calls(run)
+        assert 20 <= count <= 40, f"expected ~30 progress events for {_FILE_COUNT} files, got {count}"

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -682,7 +682,12 @@ def load_dataset_from_folder(
     )
 
     medias.clear()
-    _progress_interval = max(1, min(50, total_files // 50)) if total_files > 0 else 1
+    # ~50 updates for the whole loop, whatever the file count.  ``min(50, ...)``
+    # would cap the *interval* at 50 instead of the update count, inverting above
+    # 2500 files: a 300k-file folder would emit 6,000 progress events, each a full
+    # re-serialisation of the task list pushed to every open SSE stream (enough to
+    # back up the per-client 1024-deep queue and start dropping frames).
+    _progress_interval = max(1, total_files // 50) if total_files > 0 else 1
 
     build_specs = [
         (media_id, file_path, file_path.relative_to(folder_path).as_posix())
@@ -803,9 +808,11 @@ def load_dataset_from_folder_chunked(
         total_files = 0  # unknown up front when streaming
         file_iter = _iter_media_files(folder_path, mt, recursive)
 
-    # When the total is known, report progress at ~50 evenly spaced ticks;
-    # when streaming (total unknown) fall back to a fixed file interval.
-    _progress_interval = max(1, min(50, total_files // 50)) if total_files > 0 else 200
+    # When the total is known, report progress at ~50 evenly spaced ticks — cap the
+    # update count, not the interval (see the monolithic loader above for why the
+    # inverted ``min(50, ...)`` form floods SSE streams on large folders); when
+    # streaming (total unknown) fall back to a fixed file interval.
+    _progress_interval = max(1, total_files // 50) if total_files > 0 else 200
 
     media_id = 1
     chunk_index = 0


### PR DESCRIPTION
Closes #2942

## What

`load_dataset_from_folder` (`loader_folder.py:685`) and `load_dataset_from_folder_chunked` (`:808`) both computed:

```python
_progress_interval = max(1, min(50, total_files // 50))
```

The `min(50, ...)` caps the *interval* at 50 files rather than capping the *update count* at ~50, so above 2,500 files the event count grows linearly with the folder size — a 300k-file import emits ~6,000 progress events, each a full task-list re-serialisation pushed to every open SSE stream (per-client queues are bounded at 1024, so frames start dropping).

This is the same bug `loader_pickle.py:481-487` already documents as fixed on the pickle side. Both folder occurrences now use `max(1, total_files // 50)`, matching it. The chunked loader's streaming fallback of `200` for the unknown-total case is unchanged.

## Tests

New `tests_lib/datasets/test_folder_progress_cadence.py` builds a 6,000-file text folder (well past the 2,500-file inversion point, ~1s to create and load in thin mode) and asserts:

- the monolithic loader emits ~50 progress events (the old formula gave ~120);
- the chunked loader emits ~50 when the total is known (forced via an override map);
- the chunked loader still falls back to the fixed 200-file interval when the total is unknown.

Full `./run-tests.sh` is green: 7957 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jw3ZtFm1YjN5DFeHAKK86p)_