### PR TITLE
Serialise global monkey-patch install/restore; seed uncached calibration fold splits

### DIFF
--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -1223,3 +1223,81 @@ class TestTimedProgress:
         assert "Importing thing…" in out
         # Bar climbs (8 modules clamped to 3/4 = 75%) but never completes here.
         assert "100%" not in out
+
+
+class TestConcurrentWeightInterception:
+    """Two embedders can load weights at once; the patches must survive that."""
+
+    def test_interleaved_sessions_keep_counts_separate_and_restore(self):
+        """Overlapping sessions must not leave torch permanently wrapped.
+
+        Model loading is serialised per embedder *class*, so two embedders can
+        be inside ``intercept_weight_loading_progress`` at the same time.  With
+        naive save/patch/restore the second entrant saves the *patched*
+        functions as its originals, and the ordering below (A enters, B enters,
+        A exits, B exits) leaves ``nn.Module.load_state_dict`` permanently
+        wrapped in A's dead counting closure.
+        """
+        import threading
+
+        orig_lsd = nn.Module.load_state_dict
+
+        a_calls: list[tuple] = []
+        b_calls: list[tuple] = []
+        errors: list[BaseException] = []
+
+        a_entered = threading.Event()
+        b_entered = threading.Event()
+        a_load_done = threading.Event()
+        b_load_done = threading.Event()
+        a_exited = threading.Event()
+
+        small = nn.Linear(4, 2)  # 2 tensors
+        big = nn.Sequential(nn.Linear(4, 8), nn.Linear(8, 2))  # 4 tensors
+
+        def thread_a() -> None:
+            try:
+                with intercept_weight_loading_progress(lambda *c: a_calls.append(c), "A"):
+                    a_entered.set()
+                    assert b_entered.wait(timeout=10)
+                    nn.Linear(4, 2).load_state_dict(small.state_dict())
+                    a_load_done.set()
+                    assert b_load_done.wait(timeout=10)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                a_entered.set()
+                a_load_done.set()
+                a_exited.set()
+
+        def thread_b() -> None:
+            try:
+                assert a_entered.wait(timeout=10)
+                with intercept_weight_loading_progress(lambda *c: b_calls.append(c), "B"):
+                    b_entered.set()
+                    nn.Sequential(nn.Linear(4, 8), nn.Linear(8, 2)).load_state_dict(big.state_dict())
+                    b_load_done.set()
+                    assert a_exited.wait(timeout=10)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                b_entered.set()
+                b_load_done.set()
+
+        threads = [threading.Thread(target=thread_a), threading.Thread(target=thread_b)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+            assert not t.is_alive()
+        assert errors == []
+
+        # Each session counted only its own tensors, not the other thread's.
+        assert a_calls and all(c[1] == "A" and c[3] == 2 for c in a_calls)
+        assert b_calls and all(c[1] == "B" and c[3] == 4 for c in b_calls)
+
+        # Both sessions are gone: torch must be fully unwrapped again.
+        assert nn.Module.load_state_dict is orig_lsd
+        before = (len(a_calls), len(b_calls))
+        nn.Linear(4, 2).load_state_dict(small.state_dict())
+        assert (len(a_calls), len(b_calls)) == before

--- a/tests_lib/cli/test_tqdm_progress.py
+++ b/tests_lib/cli/test_tqdm_progress.py
@@ -5,6 +5,9 @@ callback during model loading, and that tqdm behaviour is fully restored
 after the context manager exits.
 """
 
+import io
+import threading
+
 import pytest
 import tqdm.auto
 import tqdm.std
@@ -188,6 +191,84 @@ class TestInterceptTqdmProgress:
             bar.close()
 
         assert all(s == "loading" for s in calls)
+
+
+class TestConcurrentTqdmInterception:
+    """Two embedders can load at once; interception must survive that."""
+
+    def test_interleaved_sessions_keep_progress_separate_and_restore(self):
+        """Overlapping sessions must not corrupt tqdm for the rest of the process.
+
+        Model loading is serialised per embedder *class*, so two embedders can
+        be inside ``intercept_tqdm_progress`` simultaneously.  With naive
+        save/patch/restore the second entrant saves the *patched* functions as
+        its originals, and the ordering below (A enters, B enters, A exits, B
+        exits) leaves ``tqdm.std.tqdm.__init__`` permanently bound to A's dead
+        closure — so every later bar in the process is forwarded to A's stale
+        callback.
+        """
+        a_calls: list[tuple] = []
+        b_calls: list[tuple] = []
+        errors: list[BaseException] = []
+
+        a_entered = threading.Event()
+        b_entered = threading.Event()
+        a_bar_done = threading.Event()
+        b_bar_done = threading.Event()
+        a_exited = threading.Event()
+
+        def run_bar(desc: str, total: int) -> None:
+            bar = tqdm.auto.tqdm(total=total, desc=desc)
+            bar.update(total)
+            bar.close()
+
+        def thread_a() -> None:
+            try:
+                with intercept_tqdm_progress(lambda *c: a_calls.append(c)):
+                    a_entered.set()
+                    assert b_entered.wait(timeout=10)
+                    run_bar("A", 100)
+                    a_bar_done.set()
+                    assert b_bar_done.wait(timeout=10)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                a_entered.set()
+                a_bar_done.set()
+                a_exited.set()
+
+        def thread_b() -> None:
+            try:
+                assert a_entered.wait(timeout=10)
+                with intercept_tqdm_progress(lambda *c: b_calls.append(c)):
+                    b_entered.set()
+                    run_bar("B", 200)
+                    b_bar_done.set()
+                    assert a_exited.wait(timeout=10)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                b_entered.set()
+                b_bar_done.set()
+
+        threads = [threading.Thread(target=thread_a), threading.Thread(target=thread_b)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+            assert not t.is_alive()
+        assert errors == []
+
+        # Each session saw only its own bar, not the other thread's.
+        assert a_calls and all(c[1] == "A" and c[3] == 100 for c in a_calls)
+        assert b_calls and all(c[1] == "B" and c[3] == 200 for c in b_calls)
+
+        # Both sessions are gone: a fresh bar must reach neither callback.
+        before = (len(a_calls), len(b_calls))
+        bar = tqdm.auto.tqdm(total=7, desc="After", file=io.StringIO())
+        bar.update(7)
+        bar.close()
+        assert (len(a_calls), len(b_calls)) == before
 
 
 class TestProgressTrackerUpdate:

--- a/tests_lib/sorting/test_conformal_threshold.py
+++ b/tests_lib/sorting/test_conformal_threshold.py
@@ -364,11 +364,10 @@ class TestUnseededFoldSplitsAreDeterministic:
         """Calibration must not read or advance shared global RNG state."""
         X, y = self._votes()
         np.random.seed(1234)
-        before = np.random.get_state()
+        expected = np.random.random(8)
+        np.random.seed(1234)
         self._orderings(X, y)
-        after = np.random.get_state()
-        assert np.array_equal(before[1], after[1])
-        assert before[2:] == after[2:]
+        assert np.array_equal(np.random.random(8), expected)
 
     def test_grouped_path_is_deterministic_too(self):
         """The bag-aware split (``groups=...``) takes the same seeded default."""

--- a/tests_lib/sorting/test_conformal_threshold.py
+++ b/tests_lib/sorting/test_conformal_threshold.py
@@ -314,3 +314,69 @@ class TestEndToEndAcceptance:
             assert hi >= lo
         # ...and strictly more items at +10 than -10 (the knob moves).
         assert sizes[-1] > sizes[0]
+
+
+class TestUnseededFoldSplitsAreDeterministic:
+    """Issue #2934: fold splits must not be drawn from global ``np.random``.
+
+    Several production paths call the calibration trainer with no ``rng``: the
+    uncached ``calibration_folds`` branch of ``train_and_threshold``
+    (``det_ctx is None``, reached from the Find multi-detector check and the
+    label-file sort) and ``train_detector_from_origins``.  If the ``rng is
+    None`` fallback were the global ``np.random``, the same labelset would take
+    different Train/Calibrate splits on every run - different fold models,
+    different conformal threshold, different Good/Bad verdicts near the cut -
+    and would advance shared RNG state from request threads besides.
+    """
+
+    DIM = 16
+
+    def _votes(self, n: int = 16) -> tuple[list[np.ndarray], list[float]]:
+        rng = np.random.default_rng(7)
+        X = [(rng.standard_normal(self.DIM) + (0.6 if i < n // 2 else -0.6)).astype(np.float32) for i in range(n)]
+        y = [1.0 if i < n // 2 else 0.0 for i in range(n)]
+        return X, y
+
+    def _orderings(self, X, y, **kwargs):
+        orderings, fallback = compute_fold_orderings(
+            X, y, self.DIM, calibrate_count=2, calibration_fraction=0.5, **kwargs
+        )
+        assert fallback is None
+        return orderings
+
+    def test_repeated_calls_without_rng_agree(self):
+        """Two rng-free runs over one labelset must produce identical folds."""
+        X, y = self._votes()
+        first = self._orderings(X, y)
+        # Perturb the global RNG between runs: if the splits were drawn from it,
+        # the second run would land on different folds.
+        np.random.seed(99)
+        np.random.random(1000)
+        second = self._orderings(X, y)
+        assert first == second
+
+    def test_matches_an_explicit_seed_42_rng(self):
+        """The rng-free default is the same seed the cached path uses."""
+        X, y = self._votes()
+        assert self._orderings(X, y) == self._orderings(X, y, rng=np.random.RandomState(42))
+
+    def test_global_numpy_random_state_is_untouched(self):
+        """Calibration must not read or advance shared global RNG state."""
+        X, y = self._votes()
+        np.random.seed(1234)
+        before = np.random.get_state()
+        self._orderings(X, y)
+        after = np.random.get_state()
+        assert np.array_equal(before[1], after[1])
+        assert before[2:] == after[2:]
+
+    def test_grouped_path_is_deterministic_too(self):
+        """The bag-aware split (``groups=...``) takes the same seeded default."""
+        X, y = self._votes(20)
+        groups = [f"g{i // 2}" for i in range(len(X))]
+        y = [y[(i // 2) * 2] for i in range(len(X))]  # one label per bag
+        first = self._orderings(X, y, groups=groups)
+        np.random.seed(7)
+        np.random.random(500)
+        second = self._orderings(X, y, groups=groups)
+        assert first == second

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -366,8 +366,184 @@ def _hub_metadata_preflight(args: tuple, kwargs: dict) -> None:
         pass
 
 
+# ----------------------------------------------------------------------
+# Global monkey-patch interception (thread-safe)
+# ----------------------------------------------------------------------
+#
+# Both interception context managers below patch *process-wide* globals: tqdm's
+# class methods, ``torch.load``, ``nn.Module.load_state_dict``, and friends.
+# Model loading is only serialised per embedder *class* (``_model_load_lock`` is
+# created per subclass in ``MediaEmbedder.__init_subclass__``), so two different
+# embedders can be inside these context managers at the same time — a background
+# preload plus a user-triggered embed, say.
+#
+# Naive save/patch/restore corrupts the process in that case: the second entrant
+# saves the *patched* functions as its "originals", and restoring them on exit
+# leaves the globals permanently bound to the first entrant's dead closures, so
+# every later tqdm bar in the process is forwarded to a stale progress callback.
+#
+# ``_InterceptRegistry`` fixes that with reference counting: each patch is
+# installed exactly once (when the first session enters) and removed exactly once
+# (when the last session leaves), all under one re-entrant module-level lock.
+# Patched code then resolves *which* session to report to from the calling
+# thread, so concurrent loads keep their progress separate instead of sharing a
+# single set of counters.
+
+_patch_lock = threading.RLock()
+
+
+class _InterceptRegistry:
+    """Reference-counted, thread-attributed registry of interception sessions.
+
+    :meth:`enter` and :meth:`exit` return whether the caller is responsible for
+    installing / removing the global patches.  :meth:`current` maps the calling
+    thread to a session: its own if it has one (nested sessions resolve
+    innermost-first), otherwise the sole active session when exactly one is
+    active — which keeps events raised on helper threads (e.g. huggingface_hub's
+    parallel download workers) attributed the way they always were.  With
+    several sessions active such events are genuinely ambiguous, so they are
+    dropped rather than misreported into an unrelated load's progress bar.
+    """
+
+    def __init__(self) -> None:
+        self._by_thread: dict[int, list[Any]] = {}
+        self._active: list[Any] = []
+
+    def enter(self, session: Any) -> bool:
+        """Register *session*; return ``True`` if patches must be installed."""
+        with _patch_lock:
+            self._by_thread.setdefault(threading.get_ident(), []).append(session)
+            self._active.append(session)
+            return len(self._active) == 1
+
+    def exit(self, session: Any) -> bool:
+        """Unregister *session*; return ``True`` if patches must be removed."""
+        with _patch_lock:
+            ident = threading.get_ident()
+            stack = self._by_thread.get(ident)
+            if stack is not None:
+                for i, entry in enumerate(stack):
+                    if entry is session:
+                        del stack[i]
+                        break
+                if not stack:
+                    del self._by_thread[ident]
+            for i, entry in enumerate(self._active):
+                if entry is session:
+                    del self._active[i]
+                    break
+            return not self._active
+
+    def current(self) -> Any | None:
+        """Session the calling thread's events belong to, if unambiguous."""
+        with _patch_lock:
+            stack = self._by_thread.get(threading.get_ident())
+            if stack:
+                return stack[-1]
+            if len(self._active) == 1:
+                return self._active[0]
+            return None
+
+
+def _remove_patches(patches: list[tuple]) -> None:
+    """Restore every ``(obj, attr, original)`` triple and empty *patches*."""
+    for obj, attr, orig in patches:
+        setattr(obj, attr, orig)
+    patches.clear()
+
+
+class _DiscardingSink(io.StringIO):
+    """A :class:`io.StringIO` that throws writes away.
+
+    Intercepted bars are redirected here so they never reach the console.  The
+    sink is process-wide and lives for the lifetime of the process, so unlike a
+    per-context buffer it must not accumulate the text written to it.
+    """
+
+    def write(self, s: str) -> int:  # type: ignore[override]
+        return len(s)
+
+
+_tqdm_sink = _DiscardingSink()
+_tqdm_registry = _InterceptRegistry()
+_tqdm_patches: list[tuple] = []
+
+
+class _TqdmSession:
+    """One active :func:`intercept_tqdm_progress` block."""
+
+    def __init__(self, callback: ProgressCallback) -> None:
+        self.callback = callback
+        self.bars: list[Any] = []
+
+    def primary_bar(self) -> Any | None:
+        if not self.bars:
+            return None
+        return max(self.bars, key=lambda b: getattr(b, "total", 0) or 0)
+
+    def report(self, bar: Any) -> None:
+        total = getattr(bar, "total", None)
+        if not total or total <= 0:
+            return
+        current = int(getattr(bar, "n", 0))
+        desc = (getattr(bar, "desc", "") or "Loading…").rstrip(": ")
+        self.callback("loading", desc, current, int(total))
+
+
+def _install_tqdm_patches() -> None:  # noqa: C901
+    """Patch ``tqdm.std.tqdm`` so bars report to the active session."""
+    import tqdm.std  # noqa: PLC0415
+
+    orig_init = tqdm.std.tqdm.__init__
+    orig_update = tqdm.std.tqdm.update
+    orig_close = tqdm.std.tqdm.close
+
+    def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        # Redirect every bar created while interception is live, even one we
+        # cannot attribute, so nothing leaks onto the console.
+        session = _tqdm_registry.current()
+        kwargs["file"] = _tqdm_sink
+        orig_init(self, *args, **kwargs)
+        if session is None:
+            return
+        total = getattr(self, "total", None)
+        if total and total > 0 and not getattr(self, "disable", False):
+            self._vt_session = session
+            session.bars.append(self)
+            if session.primary_bar() is self:
+                session.report(self)
+
+    def _patched_update(self: Any, n: int = 1) -> None:
+        orig_update(self, n)
+        session = getattr(self, "_vt_session", None)
+        if session is not None and session.primary_bar() is self:
+            session.report(self)
+
+    def _patched_close(self: Any) -> None:
+        orig_close(self)
+        session = getattr(self, "_vt_session", None)
+        if session is None:
+            return
+        self._vt_session = None
+        for i, bar in enumerate(session.bars):
+            if bar is self:
+                del session.bars[i]
+                break
+
+    tqdm.std.tqdm.__init__ = _patched_init  # type: ignore[assignment]
+    tqdm.std.tqdm.update = _patched_update  # type: ignore[assignment]
+    tqdm.std.tqdm.close = _patched_close  # type: ignore[assignment]
+    _tqdm_patches.extend(
+        [
+            (tqdm.std.tqdm, "__init__", orig_init),
+            (tqdm.std.tqdm, "update", orig_update),
+            (tqdm.std.tqdm, "close", orig_close),
+        ]
+    )
+
+
 @contextlib.contextmanager
-def intercept_tqdm_progress(callback: ProgressCallback) -> Any:  # noqa: C901
+def intercept_tqdm_progress(callback: ProgressCallback) -> Any:
     """Temporarily hook tqdm progress bars to forward updates to *callback*.
 
     HuggingFace ``transformers`` and ``huggingface_hub`` use :mod:`tqdm` for
@@ -382,61 +558,64 @@ def intercept_tqdm_progress(callback: ProgressCallback) -> Any:  # noqa: C901
 
     Only bars with a known *total* are forwarded; indeterminate spinners are
     silently ignored.
+
+    Nesting and concurrent use are safe: the patch is installed once and removed
+    once (see :class:`_InterceptRegistry`), and each bar reports to the session
+    that was active on its creating thread.
     """
-    import tqdm.std
-
-    _orig_init = tqdm.std.tqdm.__init__
-    _orig_update = tqdm.std.tqdm.update
-    _orig_close = tqdm.std.tqdm.close
-
-    _bars: list[tqdm.std.tqdm] = []
-
-    def _primary_bar() -> tqdm.std.tqdm | None:
-        if not _bars:
-            return None
-        return max(_bars, key=lambda b: getattr(b, "total", 0) or 0)
-
-    def _report(bar: tqdm.std.tqdm) -> None:
-        total = getattr(bar, "total", None)
-        if not total or total <= 0:
-            return
-        current = int(getattr(bar, "n", 0))
-        desc = (getattr(bar, "desc", "") or "Loading…").rstrip(": ")
-        callback("loading", desc, current, int(total))
-
-    _sink = io.StringIO()
-
-    def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
-        kwargs["file"] = _sink
-        _orig_init(self, *args, **kwargs)
-        total = getattr(self, "total", None)
-        if total and total > 0 and not getattr(self, "disable", False):
-            _bars.append(self)
-            if _primary_bar() is self:
-                _report(self)
-
-    def _patched_update(self: Any, n: int = 1) -> None:
-        _orig_update(self, n)
-        if _primary_bar() is self:
-            _report(self)
-
-    def _patched_close(self: Any) -> None:
-        _orig_close(self)
-        if self in _bars:
-            _bars.remove(self)
-
-    tqdm.std.tqdm.__init__ = _patched_init  # type: ignore[assignment]
-    tqdm.std.tqdm.update = _patched_update  # type: ignore[assignment]
-    tqdm.std.tqdm.close = _patched_close  # type: ignore[assignment]
+    session = _TqdmSession(callback)
+    with _patch_lock:
+        if _tqdm_registry.enter(session):
+            _install_tqdm_patches()
     try:
         yield
     finally:
-        tqdm.std.tqdm.__init__ = _orig_init  # type: ignore[assignment]
-        tqdm.std.tqdm.update = _orig_update  # type: ignore[assignment]
-        tqdm.std.tqdm.close = _orig_close  # type: ignore[assignment]
+        with _patch_lock:
+            for bar in session.bars:
+                with contextlib.suppress(Exception):
+                    bar._vt_session = None
+            session.bars.clear()
+            if _tqdm_registry.exit(session):
+                _remove_patches(_tqdm_patches)
 
 
-def _patch_safetensors_load_file(counter: list[int], total: list[int], report) -> tuple | None:
+_weight_registry = _InterceptRegistry()
+_weight_patches: list[tuple] = []
+
+
+class _WeightSession:
+    """One active :func:`intercept_weight_loading_progress` block."""
+
+    def __init__(self, callback: ProgressCallback, label: str) -> None:
+        self.callback = callback
+        self.label = label
+        self.counter = 0
+        self.total = 0
+        self.active = True
+
+    def report(self) -> None:
+        if self.active and self.total > 0:
+            self.callback("loading", self.label, min(self.counter, self.total), self.total)
+
+
+class _CountingStateDict(dict):
+    """Dict wrapper that counts unique key accesses for a weight session."""
+
+    def __init__(self, source: dict, session: _WeightSession) -> None:
+        super().__init__(source)
+        self._session = session
+        self._seen: set = set()
+
+    def __getitem__(self, key: Any) -> Any:
+        val = super().__getitem__(key)
+        if key not in self._seen:
+            self._seen.add(key)
+            self._session.counter += 1
+            self._session.report()
+        return val
+
+
+def _patch_safetensors_load_file() -> tuple | None:
     """Wrap ``safetensors.torch.load_file`` to count returned tensors."""
     try:
         import safetensors.torch as _st  # noqa: PLC0415
@@ -446,14 +625,16 @@ def _patch_safetensors_load_file(counter: list[int], total: list[int], report) -
 
     def tracked(*a: Any, **kw: Any) -> Any:
         r = orig(*a, **kw)
-        total[0] += len(r)
+        session = _weight_registry.current()
+        if session is not None:
+            session.total += len(r)
         return r
 
     _st.load_file = tracked
     return (_st, "load_file", orig)
 
 
-def _patch_torch_load(counter: list[int], total: list[int], report) -> tuple | None:
+def _patch_torch_load() -> tuple | None:
     """Wrap ``torch.load`` to count tensors in returned state dicts (.bin weights)."""
     try:
         import torch as _torch  # noqa: PLC0415
@@ -463,17 +644,18 @@ def _patch_torch_load(counter: list[int], total: list[int], report) -> tuple | N
 
     def tracked(*a: Any, **kw: Any) -> Any:
         r = orig(*a, **kw)
-        if isinstance(r, dict) and r:
+        session = _weight_registry.current()
+        if session is not None and isinstance(r, dict) and r:
             sample = next(iter(r.values()))
             if isinstance(sample, _torch.Tensor):
-                total[0] += len(r)
+                session.total += len(r)
         return r
 
     _torch.load = tracked
     return (_torch, "load", orig)
 
 
-def _patch_set_module_tensor_to_device(counter: list[int], total: list[int], report) -> tuple | None:
+def _patch_set_module_tensor_to_device() -> tuple | None:
     """Wrap ``set_module_tensor_to_device`` (HF low_cpu_mem_usage path)."""
     try:
         import transformers.modeling_utils as _tm  # noqa: PLC0415
@@ -487,15 +669,17 @@ def _patch_set_module_tensor_to_device(counter: list[int], total: list[int], rep
 
     def tracked(*a: Any, **kw: Any) -> Any:
         r = orig(*a, **kw)
-        counter[0] += 1
-        report()
+        session = _weight_registry.current()
+        if session is not None:
+            session.counter += 1
+            session.report()
         return r
 
     _tm.set_module_tensor_to_device = tracked  # pyright: ignore[reportAttributeAccessIssue]
     return (_tm, "set_module_tensor_to_device", orig)
 
 
-def _patch_load_state_dict(counter: list[int], total: list[int], report) -> tuple | None:
+def _patch_load_state_dict() -> tuple | None:
     """Wrap ``nn.Module.load_state_dict`` (PyTorch / SentenceTransformers path)."""
     try:
         import torch.nn as _nn  # noqa: PLC0415
@@ -503,26 +687,12 @@ def _patch_load_state_dict(counter: list[int], total: list[int], report) -> tupl
         return None
     orig = _nn.Module.load_state_dict
 
-    class _CountingStateDict(dict):
-        """Dict wrapper that counts unique key accesses for progress."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            super().__init__(*args, **kwargs)
-            self._seen: set = set()
-
-        def __getitem__(self, key: Any) -> Any:
-            val = super().__getitem__(key)
-            if key not in self._seen:
-                self._seen.add(key)
-                counter[0] += 1
-                report()
-            return val
-
     def tracked(self_model: Any, state_dict: Any, *a: Any, **kw: Any) -> Any:
-        if isinstance(state_dict, dict) and not isinstance(state_dict, _CountingStateDict):
-            if total[0] == 0:
-                total[0] = len(state_dict)
-            state_dict = _CountingStateDict(state_dict)
+        session = _weight_registry.current()
+        if session is not None and isinstance(state_dict, dict) and not isinstance(state_dict, _CountingStateDict):
+            if session.total == 0:
+                session.total = len(state_dict)
+            state_dict = _CountingStateDict(state_dict, session)
         return orig(self_model, state_dict, *a, **kw)
 
     _nn.Module.load_state_dict = tracked  # type: ignore[assignment]
@@ -542,30 +712,30 @@ def intercept_weight_loading_progress(callback: ProgressCallback, label: str = "
     and report ``(current, total)`` progress via *callback*.  The total is
     discovered by also intercepting ``safetensors.torch.load_file`` and
     ``torch.load`` to count keys in loaded state dicts.
+
+    Nesting and concurrent use are safe: the patches are installed once and
+    removed once (see :class:`_InterceptRegistry`), and each counted tensor is
+    charged to the session active on the calling thread.
     """
-    counter = [0]
-    total = [0]
-
-    def report() -> None:
-        if total[0] > 0:
-            callback("loading", label, min(counter[0], total[0]), total[0])
-
-    patches: list[tuple] = []
-    for installer in (
-        _patch_safetensors_load_file,
-        _patch_torch_load,
-        _patch_set_module_tensor_to_device,
-        _patch_load_state_dict,
-    ):
-        result = installer(counter, total, report)
-        if result is not None:
-            patches.append(result)
-
+    session = _WeightSession(callback, label)
+    with _patch_lock:
+        if _weight_registry.enter(session):
+            for installer in (
+                _patch_safetensors_load_file,
+                _patch_torch_load,
+                _patch_set_module_tensor_to_device,
+                _patch_load_state_dict,
+            ):
+                result = installer()
+                if result is not None:
+                    _weight_patches.append(result)
     try:
         yield
     finally:
-        for obj, attr, orig in patches:
-            setattr(obj, attr, orig)
+        with _patch_lock:
+            session.active = False
+            if _weight_registry.exit(session):
+                _remove_patches(_weight_patches)
 
 
 class MediaEmbedder(ABC):

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -26,6 +26,15 @@ from vtscore.training.blend_schedules import BlendContext, BlendSchedule, get_sc
 # stored on ``DetectorContext.threshold`` and break every comparison.
 NO_GOOD_THRESHOLD = 2.0
 
+# Seed of the Train/Calibrate fold splits when a caller passes no ``rng``.
+# The splits must be reproducible: the same labelset has to yield the same fold
+# models, hence the same conformal threshold, hence the same Good/Bad verdicts
+# on every run and every reload of a detector.  Falling back to the *global*
+# ``np.random`` would break that twice over - the splits would differ run to
+# run, and the request/background threads that run Find scoring would mutate
+# shared global RNG state, making results order-dependent under concurrency.
+CALIBRATION_SPLIT_SEED = 42
+
 # False-negative budget of the conformal inclusion rule at inclusion 0; each
 # +1 step of inclusion halves it (see :func:`conformal_threshold`).  0.25 means
 # the default cutoff may sacrifice at most ~25% of true matches to the
@@ -1079,7 +1088,8 @@ def _calibration_cache_key(
     """Build a deterministic cache key for the calibration **fold orderings**.
 
     The orderings (per-fold held-out scores + labels) are a deterministic
-    function of these inputs (RNG seeded with 42 at every cached call site)
+    function of these inputs (the split RNG is seeded with
+    :data:`CALIBRATION_SPLIT_SEED` whether or not the caller supplies one)
     and are **inclusion-independent** - ``inclusion`` is deliberately *not* in
     the key, so an Inclusion change hits the cache and only re-runs the cheap
     conformal quantile rule.  The key encodes a hash of the raw training vectors (not
@@ -1138,7 +1148,13 @@ def calibration_folds(
     groups: list | None = None,
     score_rows_by_group: dict | None = None,
 ) -> CalibrationFolds:
-    """Train the K calibration folds, keeping their models (uncached)."""
+    """Train the K calibration folds, keeping their models (uncached).
+
+    Deterministic without a caller-supplied *rng*: the splits then come from a
+    fresh ``RandomState(CALIBRATION_SPLIT_SEED)``, matching
+    :func:`calibration_folds_cached`, so an uncached call (``det_ctx is None``)
+    and a cached one produce the same folds for the same labelset.
+    """
     models: list = []
     orderings, fallback = compute_fold_orderings(
         X_list,
@@ -1209,7 +1225,7 @@ def calibration_folds_cached(
         calibrate_count=calibrate_count,
         calibration_fraction=calibration_fraction,
         hidden_dim=hidden_dim,
-        rng=np.random.RandomState(42),
+        rng=np.random.RandomState(CALIBRATION_SPLIT_SEED),
         groups=groups,
         score_rows_by_group=score_rows_by_group,
     )
@@ -1469,7 +1485,7 @@ def _grouped_folds(
 
     from vtscore.training.mlp import train_model  # noqa: PLC0415
 
-    _rng = rng if rng is not None else np.random
+    _rng = rng if rng is not None else np.random.RandomState(CALIBRATION_SPLIT_SEED)
     X_np = np.array(X_list)
     y_np = np.array(y_list)
     grp = list(groups)
@@ -1702,7 +1718,7 @@ def compute_fold_orderings(
     if n < 4:
         return [], 0.5
 
-    _rng = rng if rng is not None else np.random
+    _rng = rng if rng is not None else np.random.RandomState(CALIBRATION_SPLIT_SEED)
     X_np = np.array(X_list)
     y_np = np.array(y_list)
 
@@ -1828,8 +1844,10 @@ def calculate_cross_calibration_threshold(
             are inclusion-independent), so the same fold scores can be
             re-thresholded at any inclusion - see
             docs/plans/find-verification-workflow.md.
-        rng: Optional seeded RandomState for reproducible splits. Falls back
-            to the global ``np.random`` state when ``None``.
+        rng: Optional RandomState for the Train/Calibrate splits.  When
+            ``None`` a fresh ``RandomState(CALIBRATION_SPLIT_SEED)`` is used,
+            so the splits are reproducible and the global ``np.random`` state
+            is never read or advanced.
         calibrate_count: Number of random Train/Calibrate splits (default 2).
         calibration_fraction: Fraction of data used for calibration in each
             split (default 0.5).  For example, 0.2 means 80% Train / 20%


### PR DESCRIPTION
Closes #2932, closes #2934.

Two independent determinism/thread-safety fixes from the August 2026 audit.

## #2932 — unsynchronised global monkey-patching during concurrent model loads

`intercept_tqdm_progress` and `intercept_weight_loading_progress` (`vtscore/media/embedder.py`) patch *process-wide* globals — `tqdm.std.tqdm.__init__/update/close`, `torch.load`, `safetensors.torch.load_file`, `nn.Module.load_state_dict`, `set_module_tensor_to_device` — with an unlocked save/patch/restore. Model loading is only serialised per embedder *class* (`_model_load_lock` is created per subclass in `__init_subclass__`), so two different embedders can be inside these context managers at once: a dashboard-triggered `preload_embedder_for_dataset`, a `smart_preload_in_background`, and a lazy load on embed can all overlap.

In that case the second entrant saved the *patched* functions as its `_orig_*`, so an A-in / B-in / A-out / B-out interleaving left `tqdm.std.tqdm.__init__` permanently bound to A's dead closure — forcing every later bar in the process into a stale sink and forwarding it to a dead progress callback. The weight-loading variant left `torch.load` and `Module.load_state_dict` permanently wrapped in dead counting closures. The damage lasted for the process lifetime.

Both context managers now share a reference-counted `_InterceptRegistry` under one module-level re-entrant lock:

- Each patch is **installed once** (first session in) and **removed once** (last session out), so no entrant can ever capture another's patched function as its "original".
- Patched code resolves *which* session an event belongs to from the calling thread — its own session if it has one (nested sessions resolve innermost-first), otherwise the sole active session when exactly one is active. That last fallback preserves today's behaviour for bars raised on huggingface_hub's parallel download workers. With several sessions active such events are genuinely ambiguous, so they are dropped rather than charged to an unrelated load's progress bar.
- Per-session state replaces the shared closure state: each `_TqdmSession` owns its own bar list, and each `_WeightSession` its own `counter`/`total`, so concurrent loads no longer share one set of counters.
- The console sink is now a process-wide `_DiscardingSink` (a `StringIO` that throws writes away) rather than a per-context buffer, so it cannot accumulate text over the process lifetime.

The four `_patch_*` installers lost their `(counter, total, report)` parameters and resolve the active session at call time instead; `_CountingStateDict` moved to module scope and binds its session at construction.

## #2934 — uncached threshold paths drew fold splits from unseeded global `np.random`

`compute_fold_orderings` and `_grouped_folds` (`vtscore/training/thresholds.py`) fell back to `_rng = np.random` when given no `rng`. Three production chains never pass one: `train_and_threshold`'s uncached `calibration_folds` branch (`det_ctx is None`, reached from the Find multi-detector check and the label-file sort) and `train_detector_from_origins` via `calculate_cross_calibration_threshold`. So the same labelset took different Train/Calibrate splits on every run — different fold models, different conformal threshold, different Good/Bad verdicts near the cut — and reloading a detector persisted a different threshold each time. It also read and advanced shared global RNG state from the request/background threads that run Find scoring, making results order-dependent under concurrency.

The `rng is None` fallback is now a fresh `RandomState(CALIBRATION_SPLIT_SEED)` (42), matching what `calibration_folds_cached` already passed explicitly. Fixing it at the fallback rather than at each call site covers both the row-wise and bag-aware paths and any future caller. `calibration_folds_cached` now uses the same named constant, and the docstrings that promised the global-`np.random` fallback (and `_calibration_cache_key`'s "seeded with 42 at every *cached* call site" premise) were corrected.

## Tests

- `tests_lib/cli/test_tqdm_progress.py::TestConcurrentTqdmInterception` and `tests_lib/cli/test_preload_progress.py::TestConcurrentWeightInterception` — drive the exact A-in/B-in/A-out/B-out interleaving with `threading.Event` handoffs, assert each session sees only its own bars/tensors, and assert a bar (resp. `load_state_dict`) after both sessions exit reaches neither callback. Both fail on the pre-fix code.
- `tests_lib/sorting/test_conformal_threshold.py::TestUnseededFoldSplitsAreDeterministic` — four tests: rng-free runs agree across a perturbed global RNG, the rng-free default equals an explicit `RandomState(42)`, global `np.random` is neither read nor advanced, and the grouped (`groups=...`) path is deterministic too. All four fail on the pre-fix code.

`./run-tests.sh` is green: 7918 passed, 1 skipped.

## Notes

- `python scripts/check-eval-app-sync.py` reports all 10 mirrors up to date — neither change touches a mirrored surface, so no re-pin was needed.
- Behaviour change worth knowing: with **two or more** interceptions live at once, a tqdm bar created on a thread that owns neither is no longer forwarded to a progress callback (it is still kept off the console). Previously it would have been forwarded to whichever session patched last, which is what the corruption was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrMe9fcWJgWMGPnrenpf2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrMe9fcWJgWMGPnrenpf2c)_