### PR TITLE
Gate patch-space training on the space the detector actually scores in

### DIFF
--- a/tests/detectors/test_patch_embedder.py
+++ b/tests/detectors/test_patch_embedder.py
@@ -910,6 +910,14 @@ class TestRegionAwareTraining:
 
         Each cell is a distinct axis-aligned unit vector, so it's easy to
         check which cells got pooled by inspecting the resulting vector.
+
+        Bound to ``dinov3_patch`` because that is what a grid-bearing media
+        actually looks like: the grid lives in the *patch-slot* embedder's
+        space, and every patch behaviour - scoring
+        (:func:`~vtscore.detectors.training._score_all_media`), the Bad-vote
+        flood, the Good-vote pool - is gated on the detector scoring in that
+        slot.  A grid hung off a semantic embedder is a shape no loader
+        produces, and would (correctly) be scored image-level.
         """
         h, w, d = 4, 4, 16
         n = h * w
@@ -926,8 +934,8 @@ class TestRegionAwareTraining:
             "id": cid,
             "md5": f"md5-{cid:04x}",
             "media_type": "image",
-            "embedder": "siglip",
-            "embeddings": {"siglip": cls},
+            "embedder": "dinov3_patch",
+            "embeddings": {"dinov3_patch": cls},
             "patch_grid": grid,
         }
 
@@ -953,7 +961,7 @@ class TestRegionAwareTraining:
         from vtscore.embedding.matrix import media_score_rows
 
         media = self._media_with_patch_grid(0.99, cid=7)
-        rows = media_score_rows(media, "siglip")
+        rows = media_score_rows(media, "dinov3_patch")
         assert rows is not None
         for box in [(0.02, 0.02, 0.48, 0.48), (0.5, 0.5, 1.0, 1.0), (0.0, 0.0, 1.0, 1.0), None]:
             vec = _training_vec_for_vote(media, box)

--- a/tests_lib/detectors/test_per_detector_embedder_type.py
+++ b/tests_lib/detectors/test_per_detector_embedder_type.py
@@ -14,6 +14,10 @@ These cover the pure resolvers that route training/scoring through that choice:
   layer (delegates to keying).
 * ``_score_all_media`` region gating - region max-pool only when the detector
   scores in the dataset's *patch* slot.
+* ``_build_vote_xy`` / ``populate_label_embeddings`` **training** gating - the
+  Bad-vote flood and the Good-vote region pool are gated the same way, so a
+  detector scoring in a non-patch space never trains on rows it will never be
+  scored over (#2935).
 * ``resolve_detector_embedder_type`` - create-time resolution: an explicit type
   (the user's declared intent) is accepted regardless of the active dataset's
   bound embedders; an empty request auto-resolves a single-type dataset and is
@@ -29,7 +33,11 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from vtscore.detectors.training import _score_all_media, detector_score_embedder
+from vtscore.detectors.training import (
+    _build_vote_xy,
+    _score_all_media,
+    detector_score_embedder,
+)
 from vtscore.embedding.binding import (
     dataset_supplied_types,
     detector_dataset_compatible,
@@ -65,6 +73,31 @@ def _dual_snap() -> dict[int, dict]:
 
 def _det(embedder_type: str = "") -> SimpleNamespace:
     return SimpleNamespace(embedder_type=embedder_type, embedder="")
+
+
+def _ragged_snap() -> dict[int, dict]:
+    """A dual-embedder snap whose two spaces have **different** dimensions.
+
+    siglip is 4-d, the dinov3 patch slot (and its grid) 6-d, so mixing rows
+    from the two spaces into one ``X_list`` cannot be papered over - it raises
+    at ``np.stack``.  Both medias carry an md5 so the labelset path can resolve
+    them in-dataset.
+    """
+    snap: dict[int, dict] = {}
+    for cid in (1, 2):
+        semantic = np.zeros(DIM, dtype=np.float32)
+        semantic[cid] = 1.0
+        patch = np.zeros(6, dtype=np.float32)
+        patch[cid] = 1.0
+        snap[cid] = {
+            "id": cid,
+            "md5": f"md5-{cid}",
+            "media_type": "image",
+            "embedder": "dinov3_patch",
+            "embeddings": {"siglip": semantic, "dinov3_patch": patch},
+            "patch_grid": np.zeros((1, 2, 6), dtype=np.float16),
+        }
+    return snap
 
 
 class TestEmbedderTypeTaxonomy:
@@ -185,6 +218,106 @@ class TestRegionGating:
         all_ids, scores, _best = _score_all_media(model, snap)
         assert set(all_ids) == {1, 2}
         assert abs(scores[0] - scores[1]) < 1e-6
+
+
+class TestVoteTrainingGating:
+    """``_build_vote_xy`` trains under the gate ``_score_all_media`` scores under.
+
+    Regression for #2935: the training side used to flood every Bad vote with
+    the media's patch stack (and pool a boxed Good vote out of the grid)
+    regardless of which space the detector actually scores in, so a
+    semantic-locked detector on a text+patch dataset trained on patch-space
+    vectors it would never be scored over.
+    """
+
+    def test_semantic_detector_gets_one_negative_row_per_bad_vote(self):
+        snap = _dual_snap()
+        X, y, groups, score_rows = _build_vote_xy(snap, {1: None}, {2: None}, {}, "siglip")
+        # No flood: one row per vote, each a siglip image-level vector.
+        assert y == [1.0, 0.0]
+        assert groups == [("g", 1), ("b", 2)]
+        np.testing.assert_allclose(X[0], _basis(1))
+        np.testing.assert_allclose(X[1], _basis(2))
+        # The recorded calibration stacks are the rows the scorer pools for a
+        # siglip detector: the single full-image row, not the patch grid.
+        assert set(score_rows) == {("g", 1), ("b", 2)}
+        for rows in score_rows.values():
+            assert rows.shape == (1, DIM)
+
+    def test_patch_detector_still_floods(self):
+        snap = _dual_snap()
+        X, y, groups, score_rows = _build_vote_xy(snap, {1: None}, {2: None}, {}, "dinov3_patch")
+        # Image-level row + the grid's single cell = 2 negative rows, one bag.
+        assert y == [1.0, 0.0, 0.0]
+        assert groups == [("g", 1), ("b", 2), ("b", 2)]
+        assert len(X) == 3
+        assert score_rows[("b", 2)].shape == (2, DIM)
+
+    def test_none_embedder_keeps_dataset_precedence(self):
+        # The pre-per-detector path: any media with a grid floods, matching
+        # ``_score_all_media(model, snap)`` with no explicit primary.
+        snap = _dual_snap()
+        _X, y, groups, _rows = _build_vote_xy(snap, {1: None}, {2: None}, {}, None)
+        assert y == [1.0, 0.0, 0.0]
+        assert groups == [("g", 1), ("b", 2), ("b", 2)]
+
+    def test_semantic_detector_ignores_a_region_box(self):
+        # The box designates a patch of the *patch* embedder's grid; a siglip
+        # detector has no such row, so it trains on its own image-level vector.
+        snap = _dual_snap()
+        X, _y, _groups, _rows = _build_vote_xy(snap, {1: None}, {2: None}, {1: (0.0, 0.0, 0.5, 0.5)}, "siglip")
+        np.testing.assert_allclose(X[0], _basis(1))
+
+    def test_ragged_spaces_no_longer_blow_up_at_stack(self):
+        # Pre-fix this mixed 4-d Good row with 6-d flooded Bad rows, so the
+        # trainer's ``np.stack`` raised ValueError and every learned sort 500'd.
+        snap = _ragged_snap()
+        X, y, groups, _rows = _build_vote_xy(snap, {1: None}, {2: None}, {1: (0.0, 0.0, 0.5, 0.5)}, "siglip")
+        assert y == [1.0, 0.0]
+        assert groups == [("g", 1), ("b", 2)]
+        assert np.stack(X).shape == (2, DIM)
+
+
+class TestLabelsetTrainingGating:
+    """The labelset (load-time / cross-dataset) path is gated identically.
+
+    ``populate_label_embeddings`` resolves each element in-dataset when it can;
+    without the gate a semantic detector's Bad element read the media's stored
+    ``patch_grid`` - the patch embedder's space - into its negative cache.
+    """
+
+    def _labelset(self):
+        from vtscore.datasets.labelset import LabeledElement, LabelSet
+
+        good = LabeledElement(md5="md5-1", label="good")
+        bad = LabeledElement(md5="md5-2", label="bad")
+        return LabelSet([good, bad]), good, bad
+
+    def _populate(self, embedder_type: str):
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.labelset_training import populate_label_embeddings
+        from vtscore.state.core import DetectorContext
+
+        snap = _ragged_snap()
+        labelset, good, bad = self._labelset()
+        det_ctx = DetectorContext("d-2935")
+        det_ctx.embedder_type = embedder_type
+        populate_label_embeddings(det_ctx, labelset, media_type="image", snap=snap)
+        return det_ctx, stable_element_id(good), stable_element_id(bad)
+
+    def test_semantic_detector_caches_no_patch_rows(self):
+        det_ctx, gid, bid = self._populate("semantic")
+        assert det_ctx.label_negative_regions == {}
+        assert det_ctx.label_score_regions == {}
+        # Both labels are the dataset's siglip vectors, so training stacks.
+        assert det_ctx.label_embeddings[gid].shape == (DIM,)
+        assert det_ctx.label_embeddings[bid].shape == (DIM,)
+
+    def test_patch_detector_still_caches_the_flood(self):
+        det_ctx, _gid, bid = self._populate("patch_semantic")
+        # Image-level row + the grid's 2 cells, in the 6-d patch space.
+        assert len(det_ctx.label_negative_regions[bid]) == 3
+        assert det_ctx.label_negative_regions[bid][0].shape == (6,)
 
 
 class TestResolveDetectorEmbedderType:

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -129,9 +129,25 @@ def _patch_output_from_file(
 def _embedder_supports_patch_regions(embedder_name: str) -> bool:
     """Whether *embedder_name* produces a patch grid at all.
 
-    Gates the score-row resolution below: on a legacy single-vector detector
-    there is no grid to re-derive, so probing every element's origin file would
-    be pure I/O for a guaranteed ``None``.
+    This is the labelset tier's patch gate - the counterpart of
+    :func:`~vtscore.detectors.training._scores_in_patch_space`, phrased against
+    the detector's own embedder because the cross-dataset branch has no snap to
+    resolve a patch slot from.  It answers "does this detector score in a patch
+    space?", and *every* patch behaviour on this path hangs off it: the raw-patch
+    pool under a Good element's ``region_box``, a Bad element's flooded
+    negatives, and the calibration score-row stacks.
+
+    Two things it buys:
+
+    * On a legacy single-vector detector there is no grid to re-derive, so
+      probing every element's origin file would be pure I/O for a guaranteed
+      ``None``.
+    * On a **multi-embedder** dataset it keeps a detector locked to the text or
+      structural space off the patch grid entirely.  That detector is scored
+      against its own space's full-image vectors
+      (:func:`~vtscore.detectors.training._score_all_media`), so reading the
+      media's stored ``patch_grid`` - which lives in the *patch* embedder's
+      space - would train it on vectors from an unrelated space.
     """
     if not embedder_name:
         return False
@@ -255,6 +271,7 @@ def _resolve_uncached_embedding(
     *,
     media_type: str,
     embedder_name: str,
+    patch_capable: bool,
     lookups: tuple[dict[str, list[int]], dict[str, list[int]], dict[str, list[int]]] | None = None,
 ) -> np.ndarray | None:
     """Produce a training vector for *elem*, not consulting the cache.
@@ -264,6 +281,13 @@ def _resolve_uncached_embedding(
     ``region_box`` when the element carries one).
     Falls back to the cross-dataset path - resolve via the importer and embed
     freshly.  Returns ``None`` when neither path produces a vector.
+
+    *patch_capable* (:func:`_embedder_supports_patch_regions`) gates the
+    raw-patch pool: a detector that doesn't score in a patch space trains on the
+    image-level vector of its own space even when the media carries a grid,
+    because the grid's vectors belong to the dataset's *patch* embedder.  The
+    cross-dataset branch is already gated the same way inside
+    :func:`_patch_output_from_file`.
 
     *lookups* is the pre-built ``build_media_lookup`` triple for *snap*; loop
     callers pass it so the cid resolution doesn't rebuild the tables per element.
@@ -275,7 +299,7 @@ def _resolve_uncached_embedding(
         cid = resolve_current_dataset_cid(elem, lookups)
         if cid is not None and cid in snap:
             media = snap[cid]
-            pooled = pool_box_from_media(media, elem.region_box)
+            pooled = pool_box_from_media(media, elem.region_box) if patch_capable else None
             # Read the in-dataset vector from the detector's primary space (the
             # same space the cross-dataset path embeds into), not the media's
             # generic primary - they diverge on a multi-embedder dataset.
@@ -372,12 +396,21 @@ def _cache_region_vectors(
     rows, so the two caches are fed from one resolution, cached so re-sorts
     don't re-resolve.
 
-    The resolution is skipped entirely on a legacy single-vector detector
-    (*patch_capable* is ``False``, where it would return ``None`` anyway), so no
-    origin file is probed for a grid that cannot exist.
+    The resolution is skipped entirely unless the detector scores in a patch
+    space (*patch_capable*; see :func:`_embedder_supports_patch_regions`).  On a
+    legacy single-vector detector it would return ``None`` anyway, so no origin
+    file is probed for a grid that cannot exist.  On a multi-embedder dataset
+    the skip is load-bearing: a semantic- or structural-locked detector is
+    scored against its own space's full-image vectors, so flooding it with the
+    dataset's patch grid would train it on a different embedding space (and
+    blow up at ``np.stack`` outright when the two dimensions differ).  Both
+    caches stay empty, and :func:`build_xy_from_labelset` falls back to the
+    single image-level vector per element.
     """
+    if not patch_capable:
+        return
     wants_negatives = elem.label == "bad" and eid not in neg_cache
-    wants_score_rows = patch_capable and elem.label in ("good", "bad") and eid not in score_cache
+    wants_score_rows = elem.label in ("good", "bad") and eid not in score_cache
     if not (wants_negatives or wants_score_rows):
         return
     rows = _resolve_score_rows(elem, snap, media_type=media_type, embedder_name=embedder_name, lookups=lookups)
@@ -458,7 +491,12 @@ def populate_label_embeddings(
             continue
 
         emb = _resolve_uncached_embedding(
-            elem, snap, media_type=media_type, embedder_name=embedder_name, lookups=lookups
+            elem,
+            snap,
+            media_type=media_type,
+            embedder_name=embedder_name,
+            patch_capable=patch_capable,
+            lookups=lookups,
         )
         if emb is not None:
             cache[eid] = emb

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -76,6 +76,33 @@ def _patch_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> str | No
     return patch
 
 
+def _scores_in_patch_space(snap: dict[int, dict[str, Any]] | None, embedder_name: str | None) -> bool:
+    """Whether a detector whose primary is *embedder_name* lives in *snap*'s patch space.
+
+    **The single definition of the patch gate**, so training and scoring cannot
+    disagree about which geometry a detector is in:
+
+    * An explicit primary (the per-detector embedder) is in the patch space
+      **only** when it *is* the snap's patch-slot embedder.  A detector locked to
+      the text or structural space of a multi-embedder dataset scores against
+      that space's full-image vectors (:func:`_score_all_media`), so it must
+      train on those vectors too - flooding it with patch rows would mix two
+      unrelated embedding spaces into one model (or, when their dimensions
+      differ, fail outright at ``np.stack``).
+    * ``None`` (no per-detector primary) keeps the dataset-level score
+      precedence, where any media carrying a ``patch_grid`` takes the patch
+      path - the pre-per-detector behaviour.
+
+    Callers pair this with "does any media actually carry a grid?"; on a
+    grid-less dataset both sides collapse to the single image-level vector
+    regardless.
+    """
+    if embedder_name is None:
+        return True
+    patch = _patch_embedder_for_snap(snap)
+    return patch is not None and embedder_name == patch
+
+
 def validate_good_bad_split(y_list: list[float]) -> tuple[int, int]:
     """Check that *y_list* contains at least one good and one bad label.
 
@@ -539,6 +566,49 @@ def inference_score_rows(
     return media_score_rows(media, embedder_name)
 
 
+def _vote_score_rows(
+    media: dict[str, Any],
+    embedder_name: str | None,
+    row_embedder: str | None,
+    *,
+    patch_rows: bool,
+) -> np.ndarray | None:
+    """The rows the scorer max-pools *media* over, in the detector's own space.
+
+    The patch stack (:func:`inference_score_rows`) when the detector scores in
+    the patch space, else the single image-level row of *embedder_name* - which
+    is exactly what :func:`_score_all_media`'s embedding-matrix fallback scores
+    that media by.  See :func:`_scores_in_patch_space`.
+    """
+    if patch_rows:
+        return inference_score_rows(media, row_embedder)
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
+    vec = media_embedding(media, embedder_name)
+    return None if vec is None else np.asarray(vec, dtype=np.float32).reshape(1, -1)
+
+
+def _vote_negative_vecs(
+    media: dict[str, Any],
+    embedder_name: str | None,
+    row_embedder: str | None,
+    *,
+    patch_rows: bool,
+) -> list[np.ndarray]:
+    """The rows one Bad vote on *media* trains down - the rows the scorer pools.
+
+    The flood (:func:`bad_negative_vecs`) when the detector scores in the patch
+    space, else the one image-level vector of *embedder_name*.  A non-patch
+    detector never max-pools the grid, so flooding it would train the model on
+    rows from another embedding space that nothing ever scores.
+    """
+    if patch_rows:
+        return bad_negative_vecs(media, row_embedder)
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
+    return [media_embedding(media, embedder_name)]
+
+
 def _build_vote_xy(
     clips_dict: dict[int, dict[str, Any]],
     good_votes: dict[int, None],
@@ -573,7 +643,19 @@ def _build_vote_xy(
     dataset score precedence for *clips_dict* is used (the pre-per-detector
     behaviour).  Either way the MLP trains in the same space
     :func:`_score_all_media` scores against.
+
+    All three patch behaviours above - the Good vote's region pool, the Bad
+    vote's flood, and the recorded calibration stack - are gated by
+    :func:`_scores_in_patch_space`, the same gate :func:`_score_all_media`
+    pools under.  A detector locked to the text or structural space of a
+    multi-embedder dataset therefore trains on that space's **full-image**
+    vectors, exactly the rows it will be scored over; without the gate its Bad
+    votes flooded patch-space rows (and its boxed Good votes pooled one) into a
+    model scored in a different space entirely - a ``np.stack`` ValueError when
+    the two dimensions differ, silent garbage negatives when they happen to
+    match.
     """
+    patch_rows = _scores_in_patch_space(clips_dict, embedder_name)
     if embedder_name is None:
         embedder_name = _score_embedder_for_snap(clips_dict)
     # The image-level row of a patch stack belongs to the *patch-slot* embedder
@@ -581,26 +663,27 @@ def _build_vote_xy(
     # see ``matrix._patch_embedder_for_region_snap``.  On a single-embedder
     # patch dataset this is the score embedder anyway; on a text+patch dataset
     # it keeps the flooded / calibrated rows out of the text space.
-    row_embedder = _patch_embedder_for_snap(clips_dict) or embedder_name
+    row_embedder = (_patch_embedder_for_snap(clips_dict) or embedder_name) if patch_rows else embedder_name
     X_list: list[np.ndarray] = []
     y_list: list[float] = []
     groups: list = []
     score_rows: dict = {}
 
     def _record_score_rows(group: tuple, cid: int) -> None:
-        rows = inference_score_rows(clips_dict[cid], row_embedder)
+        rows = _vote_score_rows(clips_dict[cid], embedder_name, row_embedder, patch_rows=patch_rows)
         if rows is not None:
             score_rows[group] = rows
 
     for cid in good_votes:
         if cid in clips_dict:
-            X_list.append(_training_vec_for_vote(clips_dict[cid], region_boxes.get(cid), embedder_name))
+            box = region_boxes.get(cid) if patch_rows else None
+            X_list.append(_training_vec_for_vote(clips_dict[cid], box, embedder_name))
             y_list.append(1.0)
             groups.append(("g", cid))
             _record_score_rows(("g", cid), cid)
     for cid in bad_votes:
         if cid in clips_dict:
-            for vec in bad_negative_vecs(clips_dict[cid], row_embedder):
+            for vec in _vote_negative_vecs(clips_dict[cid], embedder_name, row_embedder, patch_rows=patch_rows):
                 X_list.append(vec)
                 y_list.append(0.0)
                 groups.append(("b", cid))
@@ -669,12 +752,12 @@ def _score_all_media(
     )
 
     resolved = embedder_name if embedder_name is not None else _score_embedder_for_snap(clips_dict)
-    has_regions = any(clips_dict[cid].get("patch_grid") is not None for cid in clips_dict)
-    if has_regions and embedder_name is not None:
-        # Explicit per-detector primary: patch-pool only when scoring in the
-        # patch space (the grid lives in the patch embedder's vectors).
-        patch = _patch_embedder_for_snap(clips_dict)
-        has_regions = patch is not None and resolved == patch
+    # Explicit per-detector primary: patch-pool only when scoring in the patch
+    # space (the grid lives in the patch embedder's vectors).  Same gate
+    # ``_build_vote_xy`` trains under - see :func:`_scores_in_patch_space`.
+    has_regions = any(clips_dict[cid].get("patch_grid") is not None for cid in clips_dict) and _scores_in_patch_space(
+        clips_dict, embedder_name
+    )
     if has_regions:
         # One row per (media, score row) pair, built once and cached on the
         # dataset context (the patch vectors never change between votes -


### PR DESCRIPTION
## The bug

`_score_all_media` already refused to max-pool a dataset's patch grid for a detector whose primary is that dataset's *text* or *structural* embedder — such a detector must score against its own space's full-image vectors. The **training** side had no such gate.

`_build_vote_xy` set `row_embedder = _patch_embedder_for_snap(clips_dict) or embedder_name` unconditionally, so for a `semantic`-locked detector pointed at a trio (text + patch + structural) dataset:

- every **Bad** vote flooded the full ~197-row patch stack (`bad_negative_vecs` → `media_score_rows`, which only checks for a `patch_grid`),
- a boxed **Good** vote pooled a raw patch (`pool_box_from_media` ignores `embedder_name`),
- while boxless Good votes and the scoring pass both ran in the semantic space.

If the two embedders' dimensions differ, `np.stack` in `_train_and_score_xy` raises `ValueError` and every learned sort / vote 500s. If they happen to match, the model silently trains on negatives from an unrelated embedding space that nothing ever scores — breaking the module's own invariant (*"every vector a vote can train on must also be a row that is scored"*).

The scenario is reachable: a semantic-locked detector is deliberately compatible with a trio dataset (`detector_dataset_compatible` / `keying_embedder_for_snap`), and both `learned_sort.py` and `workflow.py` thread `det_ctx` through `detector_score_embedder` into `_build_vote_xy`.

## The fix

- **`_scores_in_patch_space(snap, embedder_name)`** — the gate extracted into one function. `_score_all_media` and `_build_vote_xy` now both read it, so training and scoring cannot disagree about which geometry a detector is in. `None` (no per-detector primary) still means the pre-per-detector dataset precedence.
- A non-patch-space detector trains on the **single image-level vector of its own space** — exactly the row the scorer pools it over — for Good votes (the region box is ignored, since it designates a row of *another* space's grid), for Bad votes, and for the recorded calibration stacks alike. `_vote_score_rows` / `_vote_negative_vecs` hold that branch.
- Patch-space detectors and every single-embedder dataset are byte-for-byte unchanged; `_score_all_media`'s behaviour is unchanged (pure refactor of an equivalent condition).

### Labelset path (same defect)

`_cache_region_vectors` gated only `wants_score_rows` on `patch_capable`, so a Bad element on a non-patch detector still cached mixed-space flooded negatives, and the in-dataset branch of `_resolve_uncached_embedding` pooled the stored grid regardless of the detector's space. Both now hang off `patch_capable`, which additionally stops the wasted per-sort `resolve_file_context` I/O its docstring already claimed to avoid.

### Test fixture correction

`TestRegionAwareTraining._media_with_patch_grid` bound a patch grid to `siglip` — a shape no loader produces, since a grid lives in the patch-slot embedder's space (and which the *existing* scoring gate already scored image-level). Rebound to `dinov3_patch` so it exercises the path it means to.

## Tests

New `TestVoteTrainingGating` / `TestLabelsetTrainingGating` in `tests_lib/detectors/test_per_detector_embedder_type.py`, alongside the existing `_score_all_media` gating tests:

- a semantic detector on a dual-bound snap gets **one** negative row per Bad vote, in siglip space, with single-row calibration stacks;
- a patch detector still floods, and `embedder_name=None` still takes the dataset precedence;
- a region box is ignored for a semantic detector;
- a **ragged** snap (siglip 4-d vs. a 6-d patch slot) now stacks cleanly instead of raising at `np.stack`;
- the labelset path caches no patch rows for a semantic detector, and still caches the full flood for a patch one.

Verified these fail against the un-gated code.

`./run-tests.sh`: **ALL 7919 TESTS PASSED** (1 skipped). `scripts/check-eval-app-sync.py`: 10 mirrors up to date — the eval harness reaches this logic by delegation, so nothing was owed there.

Closes #2935
Closes #2938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwdzLJsGD5iG5jYSteQ8Ka

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwdzLJsGD5iG5jYSteQ8Ka)_