### PR TITLE
Restart the media-ids fetch on reload instead of dropping it

### DIFF
--- a/frontend/src/app/services/media-state.service.spec.ts
+++ b/frontend/src/app/services/media-state.service.spec.ts
@@ -77,6 +77,25 @@ describe('MediaStateService', () => {
     expect(service.selectedId()).toBeNull();
   });
 
+  it('loadMedias should restart an in-flight fetch instead of dropping the reload', async () => {
+    // Pair switch A->B issues the first fetch (stamped with B's X-Dataset-Id)...
+    service.loadMedias();
+    TestBed.tick();
+    const stale = httpMock.expectOne('/api/medias/ids');
+
+    // ...and a rapid B->C switch reloads while it is still in flight. The
+    // reload must not be swallowed: the in-flight response carries the *old*
+    // pair's id list, and nothing else would ever re-fetch (issue #2944).
+    service.loadMedias();
+    TestBed.tick();
+
+    expect(stale.cancelled).toBe(true);
+    const fresh = httpMock.expectOne('/api/medias/ids');
+    fresh.flush(mockMedias);
+    await settleResource();
+    expect(service.mediasSignal()).toEqual(mockMedias);
+  });
+
   it('mediasSignal should reflect the loaded medias', async () => {
     expect(service.mediasSignal()).toEqual([]);
     load();

--- a/frontend/src/app/services/media-state.service.ts
+++ b/frontend/src/app/services/media-state.service.ts
@@ -73,9 +73,19 @@ export class MediaStateService {
     this.metadataCache.ensureLoaded([id]);
   }
 
-  /** Fetch (or refetch) the dataset media stubs. No-op while a fetch is in flight. */
+  /**
+   * Fetch (or refetch) the dataset media stubs.
+   *
+   * Always restarts the loader, even mid-flight. An in-flight request carries
+   * the `X-Dataset-Id` header of the pair that was active when it was
+   * dispatched, so on a rapid A->B->C pair switch its response is the *wrong*
+   * dataset's id list; skipping the refetch would leave that stale list
+   * rendered against the new pair forever (nothing else re-fetches). Bumping
+   * `loadCount` changes the resource request, which makes `rxResource`
+   * unsubscribe from the stale stream (cancelling the request) and re-run the
+   * loader with the current headers.
+   */
   loadMedias(): void {
-    if (this.resource.isLoading()) return;
     this.loadCount.update((n) => n + 1);
   }
 


### PR DESCRIPTION
Closes #2944

## The bug

`MediaStateService.loadMedias()` no-opped while `resource.isLoading()` was true. An in-flight `/api/medias/ids` request carries the `X-Dataset-Id` header of the pair that was active when it was *dispatched*, so its response is that pair's id list — not the current one.

On a rapid A→B→C pair switch (B's fetch still in flight, C already loaded so `ContextSwitchService.flipAndLoad` takes the synchronous fast path and emits `pair$` immediately), the `reloadForNewPair()` calls in label-view and find-view hit the guard and were silently skipped. B's response then landed as `resource.value`, and nothing ever re-fetched: the view permanently rendered dataset B's media ids against active pair C — mismatched votes/sort, wrong thumbnails, 404 media URLs — until the user switched pairs again. Neither view calls `mediaState.clear()` on a pair switch, so no path recovered.

## The fix

Drop the guard: `loadMedias()` always bumps `loadCount`. That changes the resource request, so `rxResource` unsubscribes from the stale stream (cancelling the request) and re-runs the loader with the current headers — the issue's first suggested fix. No caller loops on `loadMedias()`, so there's nothing for the guard to protect against; both views call it exactly once per mount and once per pair switch.

## Testing

- New spec in `media-state.service.spec.ts` drives the exact sequence: load, then load again while the first request is open, and asserts the first `TestRequest` is `cancelled` and the second one's response is what lands in `mediasSignal()`.
- `./run-tests.sh` full suite green: 7954 passed, frontend build + audit + 1986 Vitest tests OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_017d3Lu1PZVhE2zzkoqZjjcL)_