### PR TITLE
Resolve every separable cell before stopping adaptive pyramid descent

### DIFF
--- a/tests_lib/projection/test_pyramid.py
+++ b/tests_lib/projection/test_pyramid.py
@@ -276,6 +276,26 @@ def test_auto_depth_terminates_on_coincident_points():
         assert cells[0].count == 10
 
 
+@pytest.mark.parametrize("bin_shape", BIN_SHAPES)
+def test_auto_depth_resolves_tight_cluster_beside_coincident_pile(bin_shape):
+    # A dominant pile of exact duplicates must not mask a smaller-but-separable
+    # cluster: the halving that fails to split the pile leaves both the cell
+    # count and the max count unchanged, and the co-location guard used to read
+    # that stagnation off the densest cell alone.  Every multi-point cell has to
+    # be coincident before the descent may stop.
+    coords = np.array(
+        [[0.0, 0.0]] * 5 + [[100.0, 0.0], [103.0, 0.0], [106.0, 0.0]],
+        dtype=np.float32,
+    )
+    pyr = build_pyramid(_projection(coords), bin_shape=bin_shape)
+    deepest = max(lm.level for lm in pyr.levels)
+    counts = sorted(c.count for (lvl, _, _), t in pyr.tiles.items() if lvl == deepest for c in t.cells)
+    # The three spread-out points land in their own cells; only the 5 exact
+    # duplicates stay merged (no radius can ever separate those).
+    assert counts == [1, 1, 1, 5]
+    assert len(pyr.levels) <= max_useful_levels(coords.shape[0])
+
+
 # --- Bin shape (hex vs square) -------------------------------------------------
 
 

--- a/vtscore/projection/pyramid.py
+++ b/vtscore/projection/pyramid.py
@@ -373,7 +373,7 @@ def _descent_resolved(
     - **Fully resolved:** every cell holds a single clip (``max_count <= 1``), so
       deeper levels would only reproduce this one at finer (wasted) radii.
     - **Co-located:** no progress across a radius halving — neither the cell count
-      nor the densest cell improved — *and* the densest cell's members are
+      nor the densest cell improved — *and* **every** multi-point cell is
       genuinely coincident (zero spatial extent), so a finer radius can never
       separate them.  The coincidence check matters because "no cell split" alone
       does **not** imply co-location: a corner-anchored square cell wider than the
@@ -381,12 +381,21 @@ def _descent_resolved(
       between them.  Only the spread test distinguishes "can't separate" from
       "haven't separated yet"; without it the descent would stop short on tight
       clouds under the square (quadtree) lattice.
+
+      Testing every multi-point cell (rather than only the densest) is what keeps
+      a dominant duplicate pile from masking smaller, still-separable clusters: a
+      halving that neither grows the cell count nor thins the coincident pile
+      leaves both statistics unchanged, and stopping there would strand a merely
+      *tight* secondary cluster above one-clip-per-cell.
     """
     if max_count <= 1:
         return True
     if n_cells == prev_n_cells and max_count == prev_max_count:
-        pile = coords[lc.members[int(np.argmax(lc.counts))]]
-        return float(np.max(pile.max(axis=0) - pile.min(axis=0))) == 0.0
+        for h in np.flatnonzero(lc.counts > 1):
+            pile = coords[lc.members[int(h)]]
+            if float(np.max(pile.max(axis=0) - pile.min(axis=0))) != 0.0:
+                return False
+        return True
     return False
 
 


### PR DESCRIPTION
Closes #2945

## Problem

`_descent_resolved`'s co-location guard inspected only the single densest cell:

```python
pile = coords[lc.members[int(np.argmax(lc.counts))]]
return float(np.max(pile.max(axis=0) - pile.min(axis=0))) == 0.0
```

A dominant pile of exact duplicates therefore masked smaller clusters that a finer radius could still split. A radius halving that neither grows the cell count nor thins the coincident pile leaves both stagnation statistics unchanged, so the descent stopped with separable cells still merged — violating the documented one-clip-per-cell contract that hover-to-hear relies on.

Reproduced before the fix: 5 exactly-coincident points at the origin plus 3 points at x=100/103/106 stopped at 3 levels with deepest counts `[1, 2, 5]`, while the `max_useful_levels` cap allowed 4 levels and level 3 resolves to `[1, 1, 1, 5]`.

## Fix

Require zero spatial extent across **every** multi-point cell before declaring the descent resolved, with an early exit on the first cell that still has spread (so the scan costs nothing on the common fully-coincident case). The guard only runs on a stagnated halving, which is already rare.

After the fix the repro yields 4 levels with deepest counts `[1, 1, 1, 5]` under both the hex and square lattices — the 5 duplicates stay merged (no radius can ever separate them), the 3 spread-out points each get their own cell.

## Tests

Added `test_auto_depth_resolves_tight_cluster_beside_coincident_pile`, parametrized over both bin shapes, in `tests_lib/projection/test_pyramid.py`. Full `./run-tests.sh` passes (7956 passed, 1 skipped).

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7yAxj3NmPYTE1T8Y34NJo)_