### PR TITLE
Clear active context when bulk dataset delete removes the active dataset

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -637,6 +637,65 @@ describe('DashboardComponent', () => {
     httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
   });
 
+  it('clears the active context when the bulk delete removes the active dataset', async () => {
+    const datasets = [
+      { id: 'd1', name: 'Active', media_type: 'audio' },
+      { id: 'd2', name: 'Other', media_type: 'audio' },
+    ];
+    flushInitialRequests(datasets);
+
+    const activeCtx = TestBed.inject(ActiveContextService);
+    activeCtx.setActivePair('d1', '');
+    component.selectedDatasetIds.add('d1');
+    component.selectedDatasetIds.add('d2');
+
+    vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(true));
+
+    await component.deleteSelectedDatasets();
+
+    for (const req of httpMock.match((r) => r.method === 'DELETE')) {
+      req.flush({});
+    }
+
+    // The deleted dataset must not linger as the interceptor's X-Dataset-Id.
+    expect(activeCtx.datasetId).toBe('');
+    expect(activeCtx.intentDatasetId).toBe('');
+    expect(component.selectedDatasetIds.size).toBe(0);
+
+    // Each delete triggers a registry refresh; drain them.
+    for (const req of httpMock.match('/api/datasets/registry')) {
+      if (!req.cancelled) req.flush({ datasets: [] });
+    }
+    for (const req of httpMock.match('/api/detectors/registry')) {
+      if (!req.cancelled) req.flush({ detectors: [] });
+    }
+  });
+
+  it('leaves the active context alone when the bulk delete spares the active dataset', async () => {
+    const datasets = [
+      { id: 'd1', name: 'Active', media_type: 'audio' },
+      { id: 'd2', name: 'Other', media_type: 'audio' },
+    ];
+    flushInitialRequests(datasets);
+
+    const activeCtx = TestBed.inject(ActiveContextService);
+    activeCtx.setActivePair('d1', 'm1');
+    component.selectedDatasetIds.clear();
+    component.selectedDatasetIds.add('d2');
+
+    vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(true));
+
+    await component.deleteSelectedDatasets();
+
+    httpMock.expectOne('/api/datasets/registry/d2').flush({});
+
+    expect(activeCtx.datasetId).toBe('d1');
+    expect(activeCtx.modelId).toBe('m1');
+
+    httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+    httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
+  });
+
   it('should open and close importer modal via NewThingFlowsService', () => {
     flushInitialRequests();
     const flows = TestBed.inject(NewThingFlowsService);

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -691,6 +691,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.datasetsRegistryApi.deleteRegistered(dataset.id).subscribe({
         next: () => {
           this.selectedDatasetIds.delete(dataset.id);
+          if (this.activeContext.datasetId === dataset.id || this.activeContext.intentDatasetId === dataset.id) {
+            this.activeContext.setActivePair('', '');
+          }
           this.datasetState.refresh();
         },
       });


### PR DESCRIPTION
Closes #2947

## Problem

`deleteSelectedDatasets()` in `dashboard.component.ts` only removed the deleted id from `selectedDatasetIds` and refreshed the registry. It never reconciled `ActiveContextService`, unlike the three sibling delete paths — single-row `deleteDataset()`, `deleteDetector()`, and bulk `deleteSelectedDetectors()` — which all clear the active/intent halves when the deleted item is the active one.

So deleting the currently-loaded dataset via the bulk trash action left `ActiveContextService` holding an id the backend had already unregistered: the HTTP interceptor kept stamping `X-Dataset-Id: <dead id>` on subsequent requests, the off-dashboard top-bar pulldown kept naming the deleted dataset, and context-dependent calls 404'd until the user manually loaded something else.

## Fix

Mirror `deleteDataset`'s cleanup in the bulk path's per-dataset `next` callback: if the deleted id matches `activeContext.datasetId` or `activeContext.intentDatasetId`, call `setActivePair('', '')`.

`ActiveContextWatcherService` would eventually notice the vanished id, but only after the registry refresh lands and only while detectors exist — and it recovers by way of a "Dataset 'X' was removed." error toast, which is the wrong story for a deletion the user just performed themselves. Clearing at the delete site keeps the bulk path behaving exactly like the other three.

## Tests

Two new cases in `dashboard.component.spec.ts`:

- bulk-deleting the active dataset clears both the active and intent halves,
- bulk-deleting a dataset that isn't active leaves the active pair untouched.

`./run-tests.sh` passes in full: 7954 passed, 1 skipped, 2 xpassed; frontend gate green (build, audit, 1987 Vitest tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4444aXcAdf7WUNvdWjEDh)_