### PR TITLE
Migrate the learned-sort result poll off the freeze-prone timer+switchMap pattern

### DIFF
--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,7 +1,8 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, OnDestroy, OnInit, signal, untracked, viewChild } from '@angular/core';
 
-import { Subject, timer, Subscription, pairwise } from 'rxjs';
-import { takeUntil, switchMap, filter, take } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Subject, Subscription, of, pairwise, throwError } from 'rxjs';
+import { takeUntil, catchError, filter, take, tap } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
@@ -182,6 +183,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
    *  ``applyLearnedSortResult`` / the error/cancel paths. Used by the
    *  Cancel button on the sort progress bar to target the right job. */
   private currentLearnedSortJobId: string | null = null;
+  /** Consecutive *transient* learned-sort result-poll failures tolerated before
+   *  the run is declared failed. Roughly 10s–40s of unbroken failures at the
+   *  poll's 500ms–2000ms cadence: long enough to ride out a backend blip,
+   *  short enough that a genuinely unreachable server does not leave the panel
+   *  spinning on 'Training…'. Terminal statuses (404/500) end the run at once
+   *  and never consume this budget. */
+  private readonly POLL_ERROR_LIMIT = 20;
   /** Set by `reloadForNewPair` when the user was in `learned` sort mode at the
    *  time of a pair switch: a constructor effect watches the labelset counts and
    *  re-fires `onLearnedSort` once, after the reloaded votes make both classes
@@ -716,36 +724,76 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   }
 
+  /**
+   * Poll a running learned-sort job until it settles.
+   *
+   * Uses {@link adaptivePoll}, not the `timer(200, 500)` + `switchMap` pattern
+   * this once had: `switchMap` aborted the in-flight result GET on every tick,
+   * so a backend that needed longer than the interval to answer — exactly the
+   * situation while an MLP training job is hogging the process — had *every*
+   * read cancelled, never saw a non-running status, and left the panel stuck
+   * on 'Training…' with `sortBusy` true forever. That is the pathology
+   * documented in `adaptive-poll.ts` (issue #2572) that the labeling-status
+   * poll above was already migrated off; this poll was left behind.
+   *
+   * Poll failures are no longer fatal either. The result endpoint reports two
+   * genuine terminal states by HTTP status code — 404 (job evicted or unknown)
+   * and 500 (the job itself errored) — so those still end the run, but any
+   * other failure (a network blip, a proxy 502/503) is transient and costs
+   * only that tick, until {@link POLL_ERROR_LIMIT} consecutive failures say
+   * the backend is really gone. Previously a single transient error tore the
+   * poll down and reported 'Training failed' for a job still running
+   * server-side.
+   */
   private pollLearnedSortJob(jobId: string, autoSelect: boolean): void {
-    timer(200, 500)
+    let consecutiveErrors = 0;
+    const settledWith = (error: string): LearnedSortResponse => ({
+      job_id: jobId,
+      status: 'error',
+      error,
+    });
+
+    adaptivePoll<LearnedSortResponse>(
+      () =>
+        this.sortingApi.getLearnedSortResult(jobId).pipe(
+          tap(() => (consecutiveErrors = 0)),
+          catchError((err: unknown) => {
+            const status = err instanceof HttpErrorResponse ? err.status : 0;
+            if (status === 404) return of(settledWith('Training job expired'));
+            if (status === 500) return of(settledWith('Training failed'));
+            consecutiveErrors += 1;
+            if (consecutiveErrors >= this.POLL_ERROR_LIMIT) {
+              return of(settledWith('Training failed'));
+            }
+            // Re-throw so adaptivePoll absorbs it: this tick is skipped and the
+            // next one scheduled as usual, rather than the poll tearing down.
+            return throwError(() => err);
+          }),
+        ),
+      { fastMs: 500, slowMs: 2000 },
+    )
       .pipe(
         // Pair-scoped: a training job can outlive the pair it was started for,
         // and its result must not be applied to whatever pair is active when it
         // finally settles (see `pairScope$`).
         takeUntil(this.pairScope$),
-        switchMap(() => this.sortingApi.getLearnedSortResult(jobId)),
         filter((res) => res.status !== 'running'),
         take(1),
       )
-      .subscribe({
-        next: (res) => {
-          if (res.status === 'done') {
-            this.applyLearnedSortResult(res, autoSelect);
-          } else if (res.status === 'cancelled') {
-            this.currentLearnedSortJobId = null;
-            this.sortState.setSortBusy(false);
-            this.sortState.setSortStatus('Cancelled');
-          } else {
-            this.currentLearnedSortJobId = null;
-            this.sortState.setSortBusy(false);
-            this.sortState.setSortStatus(res.error || 'Training failed');
-          }
-        },
-        error: () => {
+      // No `error` handler: adaptivePoll never errors — a request failure is
+      // either absorbed above or converted into a terminal `error` status.
+      .subscribe((res) => {
+        if (res.status === 'done') {
+          this.applyLearnedSortResult(res, autoSelect);
+        } else if (res.status === 'cancelled') {
           this.currentLearnedSortJobId = null;
           this.sortState.setSortBusy(false);
-          this.sortState.setSortStatus('Training failed');
-        },
+          this.sortState.setSortStatus('Cancelled');
+        } else {
+          this.currentLearnedSortJobId = null;
+          this.sortState.setSortBusy(false);
+          this.sortState.setSortStatus(res.error || 'Training failed');
+        }
       });
   }
 

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, TestRequest } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 
 import { LabelViewComponent } from './label-view.component';
@@ -906,7 +906,7 @@ describe('LabelViewComponent', () => {
       component.onLearnedSort();
       httpMock.expectOne('/api/learned-sort').flush({ status: 'running', job_id: 'job-1' });
 
-      // Positive control: the job poll (timer(200, 500)) is genuinely running.
+      // Positive control: the adaptivePoll job poll is genuinely running.
       await new Promise<void>((resolve) => setTimeout(resolve, 300));
       const firstPoll = httpMock.match((req) => req.url.startsWith('/api/learned-sort/result'));
       expect(firstPoll.length).toBe(1);
@@ -936,6 +936,106 @@ describe('LabelViewComponent', () => {
       await new Promise<void>((resolve) => setTimeout(resolve, 800));
       httpMock.expectNone((req) => req.url.startsWith('/api/learned-sort/result'));
       expect(component.sortState.sortBusy).toBe(false);
+    });
+  });
+
+  // Issue #2948: the learned-sort result poll used `timer(200, 500)` +
+  // `switchMap`, so every 500ms tick aborted the in-flight GET. A backend
+  // slower than the interval — exactly the case while an MLP training job is
+  // hogging the process — had every read cancelled, never saw a non-running
+  // status, and left the panel on 'Training…' with `sortBusy` stuck true. One
+  // transient HTTP error was also fatal, reporting 'Training failed' for a job
+  // still running server-side.
+  describe('learned-sort job polling', () => {
+    /** Kick a learned-sort run off and leave it `running`, with the result poll
+     *  live and its first read in flight. */
+    function startRunningJob(): void {
+      flushInitialRequests();
+      component.voteState.loadVotes();
+      httpMock
+        .expectOne('/api/votes')
+        .flush({ good: [1], bad: [2], click_times: {}, learned_scores: {} });
+
+      component.onLearnedSort();
+      httpMock.expectOne('/api/learned-sort').flush({ status: 'running', job_id: 'job-1' });
+    }
+
+    /** Result-poll reads issued since the last call (matching consumes them,
+     *  so an empty result means "no *new* read was issued"). */
+    function resultPolls(): TestRequest[] {
+      return httpMock.match((req) => req.url.startsWith('/api/learned-sort/result'));
+    }
+
+    it('never cancels a result read that outlives the poll interval', async () => {
+      startRunningJob();
+      const first = resultPolls();
+      expect(first.length).toBe(1);
+
+      // Well past the 500ms fast cadence. The read is still alive (nothing
+      // aborted it) and no second read piled up behind it: adaptivePoll waits
+      // for each poll to finish before scheduling the next.
+      await new Promise<void>((resolve) => setTimeout(resolve, 1500));
+      expect(first[0].cancelled).toBe(false);
+      expect(resultPolls().length).toBe(0);
+
+      // The slow answer lands and ranks normally — under the old poll it never
+      // could, because it was cancelled a second into its life.
+      first[0].flush({
+        status: 'done',
+        results: [{ id: 1, score: 0.8 }, { id: 2, score: 0.2 }],
+        threshold: 0.5,
+      });
+      expect(component.sortState.sortBusy).toBe(false);
+      expect(component.sortState.sortStatus).toBe('');
+      expect(component.sortState.sortOrder!.length).toBe(2);
+    });
+
+    it('rides out a transient poll failure instead of failing the run', async () => {
+      startRunningJob();
+      const first = resultPolls();
+      expect(first.length).toBe(1);
+
+      // A network-level failure: the job is untouched server-side, so the run
+      // must stay busy rather than report failure.
+      first[0].error(new ProgressEvent('error'));
+      expect(component.sortState.sortBusy).toBe(true);
+      expect(component.sortState.sortStatus).toBe('Training…');
+
+      // The poll keeps ticking and the run completes on the next read.
+      await new Promise<void>((resolve) => setTimeout(resolve, 700));
+      const second = resultPolls();
+      expect(second.length).toBe(1);
+      second[0].flush({ status: 'done', results: [{ id: 1, score: 0.8 }], threshold: 0.5 });
+      expect(component.sortState.sortBusy).toBe(false);
+      expect(component.sortState.sortStatus).toBe('');
+    });
+
+    it('ends the run when the result endpoint reports the job errored', () => {
+      startRunningJob();
+      // 500 is how the endpoint reports a failed job (there is no `error`
+      // status in a 200 body), so it is terminal, not a blip to ride out.
+      resultPolls()[0].flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+
+      expect(component.sortState.sortBusy).toBe(false);
+      expect(component.sortState.sortStatus).toBe('Training failed');
+    });
+
+    it('ends the run when the job is no longer known to the backend', () => {
+      startRunningJob();
+      // 404 means the job was evicted or never existed; polling it forever
+      // would just spin the panel.
+      resultPolls()[0].flush({ error: 'Not Found' }, { status: 404, statusText: 'Not Found' });
+
+      expect(component.sortState.sortBusy).toBe(false);
+      expect(component.sortState.sortStatus).toBe('Training job expired');
+    });
+
+    it('reports a cancelled job', () => {
+      startRunningJob();
+      resultPolls()[0].flush({ status: 'cancelled' });
+
+      expect(component.sortState.sortBusy).toBe(false);
+      expect(component.sortState.sortStatus).toBe('Cancelled');
     });
   });
 });


### PR DESCRIPTION
Closes #2948

## The bug

`pollLearnedSortJob` (`label-view.component.ts`) polled `/api/learned-sort/result` with `timer(200, 500)` piped through `switchMap`. `switchMap` aborts the in-flight GET on every tick, so on a backend that consistently takes >500ms to answer — exactly the situation while an MLP training job is hogging the process — **every** read was cancelled before completing, `filter(res => res.status !== 'running')` never passed, and the panel sat on `Training…` with `sortBusy` stuck true even after the job finished.

This is the pathology `adaptive-poll.ts` documents ("a backend slower than the interval had *every* request cancelled … and the panel froze permanently", issue #2572). Vote / labelset / labeling-status polling were all migrated off it — including this same component's status poll — but this one was left behind.

Secondary: a single transient HTTP error reached the subscribe error handler and declared `Training failed` for a job that was still running server-side.

## The fix

- Replaced the timer+`switchMap` poll with `adaptivePoll(() => getLearnedSortResult(jobId), {fastMs: 500, slowMs: 2000})`, still piped through the existing `takeUntil(pairScope$)` + non-running `filter` + `take(1)`. Each read runs to completion before the next is scheduled, the cadence eases to a heartbeat once the job stops reporting progress, and polling pauses while the tab is hidden.
- Poll failures are no longer fatal. The two states the result endpoint reports by HTTP status code stay terminal — **404** (job evicted/unknown → `Training job expired`) and **500** (the job itself errored → `Training failed`) — while anything else (network blip, proxy 502/503) is re-thrown for `adaptivePoll` to absorb, costing only that tick. A bounded budget of consecutive transient failures (`POLL_ERROR_LIMIT`) still ends the run, so a permanently unreachable backend can't leave the panel spinning either — trading one permanent freeze for another would have been a weak fix.
- The subscribe `error` handler is gone, since `adaptivePoll` never errors; every failure is either absorbed or converted into a terminal `error` status.

## Tests

Five new cases in `label-view.zoneless.spec.ts` under `learned-sort job polling`:

- a result read that outlives the poll interval is neither cancelled nor doubled-up, and still ranks when it finally lands (the regression the issue describes);
- a transient network failure keeps the run busy on `Training…` and the next tick completes it;
- a 500 ends the run as `Training failed`;
- a 404 ends the run as `Training job expired`;
- a `cancelled` status still reports `Cancelled`.

The existing pair-switch supersession test keeps passing (its stale `timer(200, 500)` comment is updated).

`./run-tests.sh` is green: **7954 passed** (1 skipped, 1 xfailed), frontend gate clean (build, audit, 1990 Vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqwkCbnx7ch8Zy79vHnZrb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqwkCbnx7ch8Zy79vHnZrb)_