### PR TITLE
Park find_progress at idle when a scoring route crashes unexpectedly

### DIFF
--- a/tests/detectors/test_find_progress_reset.py
+++ b/tests/detectors/test_find_progress_reset.py
@@ -1,0 +1,194 @@
+"""Regression tests: an *unexpected* exception still parks ``find_progress``.
+
+Issue #2949.  The scoring routes park the shared ``find_progress`` singleton at
+``"idle"`` on every anticipated exit (success, ``abort()``, cancel), but an
+unhandled exception used to skip all of them: the request 500'd through the
+global handler while the tracker stayed at ``"running"`` on whatever step it
+died on — broadcast to every SSE client until the next Find reset it, with the
+``auto_finish`` timing recorder still subscribed to the singleton.
+
+``vtsearch.routes._shared.find_idle_on_crash`` now guards the post-resolve body
+of ``/api/find``, ``/api/find-label``, and ``/api/auto-detect``, mirroring
+``sort_clips``' exception branch.  ``/api/auto-detect`` additionally never
+parked the tracker on its *success* path (a cold detector's train writes
+"running" from inside the workers), which is covered here too.
+"""
+
+from __future__ import annotations
+
+import pytest
+from helpers import setup_trainable_model_in_registry
+from vtscore.concurrency.progress import find_progress, get_find_progress
+from vtsearch.state import snapshot_medias
+
+import app as app_module  # noqa: F401  (ensures routes are registered)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cancel_flag():
+    """Never leak a set cancel flag into (or out of) a test."""
+    find_progress.reset_cancel()
+    yield
+    find_progress.reset_cancel()
+
+
+class _Boom(RuntimeError):
+    """Stands in for e.g. an embedding-dimension mismatch raised mid-scoring."""
+
+
+class TestGuardUnit:
+    """``find_idle_on_crash`` itself."""
+
+    def test_parks_idle_and_reraises(self):
+        from vtsearch.routes._shared import find_idle_on_crash
+
+        find_progress.update("running", "Scoring…", step=3, total_steps=4)
+        with pytest.raises(_Boom), find_idle_on_crash():
+            raise _Boom("dimension mismatch")
+
+        snap = get_find_progress()
+        assert snap["status"] == "idle"
+        # The whole-job step frame is cleared too, so the next job's bar starts
+        # from scratch instead of inheriting a half-finished one.
+        assert snap["step"] is None
+        assert snap["total_steps"] is None
+
+    def test_closes_the_recorder_as_a_failed_run(self):
+        """The idle update's ``auto_finish`` hook would otherwise bank a crashed
+        run's partial phase timings as a good cost sample."""
+        from vtsearch.routes._shared import find_idle_on_crash
+
+        calls: list[bool] = []
+
+        class _Recorder:
+            def finish(self, n=None, size_mb=None, ok=True):
+                calls.append(ok)
+
+        with pytest.raises(_Boom), find_idle_on_crash(_Recorder()):
+            raise _Boom("dimension mismatch")
+
+        assert calls == [False]
+        assert get_find_progress()["status"] == "idle"
+
+    def test_abort_passes_through_untouched(self):
+        """``abort()`` already parked the tracker; the guard must not re-push an
+        idle frame or re-render flask-smorest's envelope."""
+        from werkzeug.exceptions import HTTPException
+
+        from vtsearch.routes._shared import find_idle_on_crash
+
+        calls: list[bool] = []
+
+        class _Recorder:
+            def finish(self, n=None, size_mb=None, ok=True):
+                calls.append(ok)
+
+        with app_module.app.test_request_context("/api/find-label"):
+            with pytest.raises(HTTPException) as excinfo:
+                with find_idle_on_crash(_Recorder()):
+                    from flask_smorest import abort
+
+                    abort(409, message="Find cancelled")
+        assert excinfo.value.code == 409
+        assert calls == []
+
+
+class TestFindLabelCrash:
+    def test_scoring_failure_returns_500_and_resets_progress(self, client, monkeypatch):
+        import vtscore.detectors.training as training_mod
+
+        detector_id = setup_trainable_model_in_registry(
+            "crash-find-label",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+
+        def boom(*args, **kwargs):
+            raise _Boom("mat1 and mat2 shapes cannot be multiplied")
+
+        # Patched on the defining module: find_label imports it inside the body.
+        monkeypatch.setattr(training_mod, "score_media_with_model", boom)
+
+        resp = client.post("/api/find-label", json={"detector_id": detector_id})
+        assert resp.status_code == 500, resp.get_json()
+        assert get_find_progress()["status"] == "idle"
+
+
+class TestMultiFindCrash:
+    def test_dataset_scoring_failure_returns_500_and_resets_progress(self, client, monkeypatch):
+        import vtsearch.routes.detectors.find as find_mod
+
+        detector_id = setup_trainable_model_in_registry(
+            "crash-multi-find",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+
+        monkeypatch.setattr(
+            find_mod,
+            "_resolve_find_datasets",
+            lambda dataset_ids: [{"name": "phantom", "pkl_path": "/nonexistent.pkl", "num_items": 1}],
+        )
+
+        def boom(*args, **kwargs):
+            raise _Boom("mat1 and mat2 shapes cannot be multiplied")
+
+        monkeypatch.setattr(find_mod, "_score_dataset", boom)
+
+        resp = client.post(
+            "/api/find",
+            json={"dataset_ids": ["anything"], "detector_ids": [detector_id]},
+        )
+        assert resp.status_code == 500, resp.get_json()
+        assert get_find_progress()["status"] == "idle"
+
+    def test_detector_prep_failure_resets_progress(self, client, monkeypatch):
+        """The guard starts *before* detector resolution, which reports step 1."""
+        import vtsearch.routes.detectors.find as find_mod
+
+        detector_id = setup_trainable_model_in_registry(
+            "crash-multi-find-prep",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+
+        monkeypatch.setattr(
+            find_mod,
+            "_resolve_find_datasets",
+            lambda dataset_ids: [{"name": "phantom", "pkl_path": "/nonexistent.pkl", "num_items": 1}],
+        )
+
+        def boom(_detectors):
+            raise _Boom("unreadable detector JSON")
+
+        monkeypatch.setattr(find_mod, "_build_detector_configs", boom)
+
+        resp = client.post(
+            "/api/find",
+            json={"dataset_ids": ["anything"], "detector_ids": [detector_id]},
+        )
+        assert resp.status_code == 500, resp.get_json()
+        assert get_find_progress()["status"] == "idle"
+
+
+class TestAutoDetectParksTracker:
+    def test_success_parks_tracker_at_idle(self, client):
+        """A cold detector's train leaves the tracker at "running"; the route
+        owns parking it again once the workers are drained."""
+        from vtsearch.settings import set_autofind_detectors
+
+        name = "autodetect-idle"
+        setup_trainable_model_in_registry(
+            name,
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        set_autofind_detectors([name])
+
+        resp = client.post("/api/auto-detect", json={})
+        assert resp.status_code == 200, resp.get_json()
+        assert get_find_progress()["status"] == "idle"

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import io
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
 from flask import g, jsonify, make_response, request, send_file
 from flask_smorest import abort
 from marshmallow import ValidationError
+from werkzeug.exceptions import HTTPException
 
+from vtscore.concurrency.progress import update_find_progress
 from vtscore.utils.hashing import content_md5, new_md5
 
 if TYPE_CHECKING:
@@ -167,6 +171,47 @@ def require_dataset_header(fn: Callable) -> Callable:
         return fn(*args, **kwargs)
 
     return wrapper
+
+
+def find_idle() -> None:
+    """Park the shared ``find_progress`` tracker at idle, clearing the step frame.
+
+    The find-side sibling of ``vtsearch.routes.sorting._sort_idle``. Every
+    scoring route (``/api/find``, ``/api/find-label``, ``/api/auto-detect``)
+    reports through the one process-wide ``find_progress`` singleton and pushes
+    it to every SSE client, so whichever route ran last owns leaving it parked
+    at ``"idle"``.
+    """
+    update_find_progress("idle", "", step=None, total_steps=None)
+
+
+@contextmanager
+def find_idle_on_crash(recorder: Any = None) -> Iterator[None]:
+    """Park ``find_progress`` at idle when the wrapped body dies unexpectedly.
+
+    Every *anticipated* exit from a scoring route resets the tracker itself:
+    ``_abort_find``, ``_abort_if_find_cancelled``, and the success path all end
+    with an idle update. An unhandled exception (say an embedding-dimension
+    mismatch raising ``RuntimeError`` mid-scoring) takes none of those paths, so
+    without this guard the request 500s through the global error handler while
+    the shared singleton stays at ``"running"`` on whatever step it died on —
+    broadcast to every SSE client, and only cleared by the next Find.
+
+    *recorder* (a :func:`vtscore.timing.record_task` handle, when the route runs
+    one) is closed first, as a failed run: the idle update would otherwise trip
+    its ``auto_finish`` hook and bank a crashed run's partial phase timings as a
+    good cost sample.  ``abort()`` is left alone — it already parked the tracker
+    and closed the recorder, and flask-smorest renders its envelope unchanged.
+    """
+    try:
+        yield
+    except HTTPException:
+        raise
+    except Exception:
+        if recorder is not None:
+            recorder.finish(ok=False)
+        find_idle()
+        raise
 
 
 def error_response(error: str, status: int, detail: Any | None = None, **extra: Any):

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -21,7 +21,7 @@ from vtscore.concurrency.progress import CancelledError, find_progress, update_f
 from vtscore.detectors.training import train_and_threshold
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.utils.scores import sigmoid_to_finite_scores
-from vtsearch.routes._shared import require_detector_header
+from vtsearch.routes._shared import find_idle, find_idle_on_crash, require_detector_header
 from vtsearch.schemas.detectors import (
     FindBoundaryNextQuerySchema,
     FindBoundaryNextResponseSchema,
@@ -164,7 +164,7 @@ def find_check_labels(body: dict):
 
 def _abort_find(code: int, message: str) -> NoReturn:
     """Reset find_progress to idle and abort with *code* / *message*."""
-    update_find_progress("idle", "", step=None, total_steps=None)
+    find_idle()
     abort(code, message=message)
     raise RuntimeError("unreachable (abort() raises)")  # for type narrowing
 
@@ -641,69 +641,68 @@ def multi_find(body: dict):
     find_progress.set_step_weights(
         timing.step_weights(_FIND_TASK, media_type=find_media_type, embedder=find_embedder, n=n_scored)
     )
-    # Every exit below — success, cancel, and abort alike — parks the tracker at
-    # "idle", which is what closes the recorder.
+    # Every exit below — success, cancel, abort, and unexpected crash alike —
+    # parks the tracker at "idle", which is what closes the recorder.  The
+    # crash case is the guard's job (see :func:`find_idle_on_crash`).
     recorder = timing.record_task(
         find_progress, _FIND_TASK, media_type=find_media_type, embedder=find_embedder, auto_finish=True
     )
     recorder.start()
     recorder.set_scale(n=n_scored)
 
-    detectors = _resolve_find_detectors(detector_ids)
-    detector_configs = _build_detector_configs(detectors)
-    detector_names = [dc["name"] for dc in detector_configs]
+    with find_idle_on_crash(recorder):
+        detectors = _resolve_find_detectors(detector_ids)
+        detector_configs = _build_detector_configs(detectors)
+        detector_names = [dc["name"] for dc in detector_configs]
 
-    all_results: list[dict] = []
-    all_negative_results: list[dict] = []
-    detected_media_type = ""
-    total_scoring_units = 0
-    scored_units = 0
+        all_results: list[dict] = []
+        all_negative_results: list[dict] = []
+        detected_media_type = ""
+        total_scoring_units = 0
+        scored_units = 0
 
-    try:
-        for di, ds in enumerate(datasets):
-            find_progress.check_cancelled()
-            ds_label = f'Loading dataset "{ds["name"]}"…'
-            update_find_progress(
-                "running",
-                ds_label,
-                current=di,
-                total=len(datasets),
-                step=2,
-                total_steps=_FIND_STEPS,
-            )
+        try:
+            for di, ds in enumerate(datasets):
+                find_progress.check_cancelled()
+                ds_label = f'Loading dataset "{ds["name"]}"…'
+                update_find_progress(
+                    "running",
+                    ds_label,
+                    current=di,
+                    total=len(datasets),
+                    step=2,
+                    total_steps=_FIND_STEPS,
+                )
 
-            positives, negatives, scored_units, added_units, ds_media_type = _score_dataset(
-                ds,
-                detector_configs,
-                scored_units,
-                total_scoring_units,
-            )
-            all_results.extend(positives)
-            all_negative_results.extend(negatives)
-            total_scoring_units += added_units
-            if not detected_media_type and ds_media_type:
-                detected_media_type = ds_media_type
-    except CancelledError:
-        # A cancelled run's phase timings describe a partial job, so they are
-        # recorded as not-ok and the fit drops them.
-        recorder.finish(ok=False)
-        _abort_find(409, "Find cancelled")
-    except Exception:
-        recorder.finish(ok=False)
-        raise
+                positives, negatives, scored_units, added_units, ds_media_type = _score_dataset(
+                    ds,
+                    detector_configs,
+                    scored_units,
+                    total_scoring_units,
+                )
+                all_results.extend(positives)
+                all_negative_results.extend(negatives)
+                total_scoring_units += added_units
+                if not detected_media_type and ds_media_type:
+                    detected_media_type = ds_media_type
+        except CancelledError:
+            # A cancelled run's phase timings describe a partial job, so they are
+            # recorded as not-ok and the fit drops them.
+            recorder.finish(ok=False)
+            _abort_find(409, "Find cancelled")
 
-    update_find_progress("idle", "", step=None, total_steps=None)
+        find_idle()
 
-    return {
-        "results": all_results,
-        "negative_results": all_negative_results,
-        "datasets": [ds["name"] for ds in datasets],
-        "detectors": detector_names,
-        "media_type": detected_media_type,
-        "multiple_datasets": len(datasets) > 1,
-        "multiple_detectors": len(detector_configs) > 1,
-        "total_hits": len(all_results),
-    }
+        return {
+            "results": all_results,
+            "negative_results": all_negative_results,
+            "datasets": [ds["name"] for ds in datasets],
+            "detectors": detector_names,
+            "media_type": detected_media_type,
+            "multiple_datasets": len(datasets) > 1,
+            "multiple_detectors": len(detector_configs) > 1,
+            "total_hits": len(all_results),
+        }
 
 
 @detector_find_bp.route("/api/find/cancel", methods=["POST"])

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -20,7 +20,12 @@ from vtscore.concurrency.memory_budget import cap_workers_by_memory
 from vtscore.concurrency.progress import CancelledError, find_progress, update_find_progress
 from vtscore.detectors.model_loading import resolve_or_train_detector
 from vtscore.embedding.media_vectors import EMBEDDINGS_KEY
-from vtsearch.routes._shared import require_dataset_header, require_detector_header
+from vtsearch.routes._shared import (
+    find_idle,
+    find_idle_on_crash,
+    require_dataset_header,
+    require_detector_header,
+)
 from vtsearch.schemas.detectors import (
     AutoDetectRequestSchema,
     AutoDetectResponseSchema,
@@ -124,7 +129,7 @@ def _abort_if_find_cancelled() -> None:
     a cancel takes effect at the next stage boundary.
     """
     if find_progress.is_cancelled:
-        update_find_progress("idle", "", step=None, total_steps=None)
+        find_idle()
         abort(409, message="Find cancelled")
 
 
@@ -179,20 +184,21 @@ def find_label(body: dict):
 
     d = reg_get_detector(detector_id)
     if d is None:
-        update_find_progress("idle", "")
+        find_idle()
         abort(404, message=f"Detector '{detector_id}' not found")
 
     snap = snapshot_medias()
     if not snap:
-        update_find_progress("idle", "")
+        find_idle()
         abort(400, message="No medias loaded")
 
     media_type = d.get("media_type", "") or next(iter(snap.values())).get("media_type", "image")
 
     # Both the train and score steps scale with the active dataset, so the bar
     # can be paced against its real size instead of a fixed guess. Every exit
-    # below — success and abort alike — parks the tracker at "idle", which is
-    # what closes the recorder.
+    # below — success, abort, and unexpected crash alike — parks the tracker at
+    # "idle", which is what closes the recorder. The crash case is the guard's
+    # job (see :func:`find_idle_on_crash`).
     from vtscore import timing  # noqa: PLC0415
 
     score_embedder = next(iter(snap.values())).get("embedder", "")
@@ -208,192 +214,195 @@ def find_label(body: dict):
     )
     recorder.start()
     recorder.set_scale(n=len(snap))
-    det_path = _detector_path(d["name"])
-    det_data = _read_detector(det_path)
+    with find_idle_on_crash(recorder):
+        det_path = _detector_path(d["name"])
+        det_data = _read_detector(det_path)
 
-    # Type gate: the active dataset must bind an embedder of the detector's
-    # locked type before we spend a train/score in the wrong space.
-    if not _dataset_supplies_detector_type(det_data, snap):
-        update_find_progress("idle", "")
-        abort(409, message=_type_incompatible_message(det_data))
+        # Type gate: the active dataset must bind an embedder of the detector's
+        # locked type before we spend a train/score in the wrong space.
+        if not _dataset_supplies_detector_type(det_data, snap):
+            find_idle()
+            abort(409, message=_type_incompatible_message(det_data))
 
-    _abort_if_find_cancelled()
-    mlp, threshold, diagnostic = resolve_or_train_detector(
-        detector_id,
-        det_data,
-        media_type,
-        snap,
-        progress_step=2,
-        progress_total_steps=_FIND_LABEL_STEPS,
-    )
-    if mlp is None:
-        update_find_progress("idle", "")
-        if diagnostic is not None:
-            error_msg = (
-                f"Detector '{d['name']}' could not be trained: "
-                f"{diagnostic['total_labels']} training labels found, "
-                f"{diagnostic['md5_matched']} matched current dataset by MD5, "
-                f"{diagnostic['needed_resolution']} needed origin resolution, "
-                f"{diagnostic['resolved_from_origin']} resolved successfully, "
-                f"{diagnostic['failed_resolution']} failed to resolve. "
-                f"Has good={diagnostic['has_good']}, has bad={diagnostic['has_bad']}."
-            )
-            if diagnostic.get("sample_failures"):
-                first = diagnostic["sample_failures"][0]
-                error_msg += (
-                    f" First failure: importer={first['origin'].get('importer', '?') if first['origin'] else 'None'}, "
-                    f"origin_name={first['origin_name']!r}, "
-                    f"params={first['origin'].get('params', {}) if first['origin'] else '{}'}"
+        _abort_if_find_cancelled()
+        mlp, threshold, diagnostic = resolve_or_train_detector(
+            detector_id,
+            det_data,
+            media_type,
+            snap,
+            progress_step=2,
+            progress_total_steps=_FIND_LABEL_STEPS,
+        )
+        if mlp is None:
+            find_idle()
+            if diagnostic is not None:
+                error_msg = (
+                    f"Detector '{d['name']}' could not be trained: "
+                    f"{diagnostic['total_labels']} training labels found, "
+                    f"{diagnostic['md5_matched']} matched current dataset by MD5, "
+                    f"{diagnostic['needed_resolution']} needed origin resolution, "
+                    f"{diagnostic['resolved_from_origin']} resolved successfully, "
+                    f"{diagnostic['failed_resolution']} failed to resolve. "
+                    f"Has good={diagnostic['has_good']}, has bad={diagnostic['has_bad']}."
                 )
-            if diagnostic.get("hint"):
-                error_msg += f" Hint: {diagnostic['hint']}"
-            failed = diagnostic["failed_resolution"]
-            total = diagnostic["total_labels"]
-            mt = diagnostic.get("media_type", "items")
-            mt_plural = mt + "s" if mt and not mt.endswith("s") else mt
-            abort(
-                400,
-                message=error_msg,
-                resolution_diagnostic=diagnostic,
-                warning=(f"{failed} of your {total} {mt_plural} could not be resolved from their original files."),
-            )
-        abort(400, message=f"Detector '{d['name']}' has no labels for scoring")
+                if diagnostic.get("sample_failures"):
+                    first = diagnostic["sample_failures"][0]
+                    error_msg += (
+                        f" First failure: importer={first['origin'].get('importer', '?') if first['origin'] else 'None'}, "
+                        f"origin_name={first['origin_name']!r}, "
+                        f"params={first['origin'].get('params', {}) if first['origin'] else '{}'}"
+                    )
+                if diagnostic.get("hint"):
+                    error_msg += f" Hint: {diagnostic['hint']}"
+                failed = diagnostic["failed_resolution"]
+                total = diagnostic["total_labels"]
+                mt = diagnostic.get("media_type", "items")
+                mt_plural = mt + "s" if mt and not mt.endswith("s") else mt
+                abort(
+                    400,
+                    message=error_msg,
+                    resolution_diagnostic=diagnostic,
+                    warning=(f"{failed} of your {total} {mt_plural} could not be resolved from their original files."),
+                )
+            abort(400, message=f"Detector '{d['name']}' has no labels for scoring")
 
-    n_total = len(snap)
-    update_find_progress(
-        "running",
-        f"Scoring {n_total} items…",
-        current=0,
-        total=n_total,
-        step=3,
-        total_steps=_FIND_LABEL_STEPS,
-    )
+        n_total = len(snap)
+        update_find_progress(
+            "running",
+            f"Scoring {n_total} items…",
+            current=0,
+            total=n_total,
+            step=3,
+            total_steps=_FIND_LABEL_STEPS,
+        )
 
-    # Region-aware scoring: for patch datasets (DINOv2/v3, EUPE) this
-    # max-pools over each media's region vectors and surfaces the winning
-    # region's box as ``best_region`` so the gallery thumbnails and focus-view
-    # Highlight overlay can outline it - matching the learned-sort path.  Plain
-    # single-vector datasets take the cached embedding-matrix path inside and
-    # gain no ``best_region`` field.
-    from types import SimpleNamespace
+        # Region-aware scoring: for patch datasets (DINOv2/v3, EUPE) this
+        # max-pools over each media's region vectors and surfaces the winning
+        # region's box as ``best_region`` so the gallery thumbnails and focus-view
+        # Highlight overlay can outline it - matching the learned-sort path.  Plain
+        # single-vector datasets take the cached embedding-matrix path inside and
+        # gain no ``best_region`` field.
+        from types import SimpleNamespace
 
-    from vtscore.detectors.training import score_media_with_model
-    from vtscore.embedding.binding import keying_embedder_for_snap
+        from vtscore.detectors.training import score_media_with_model
+        from vtscore.embedding.binding import keying_embedder_for_snap
 
-    # Score in the same space the MLP was trained in: the concrete embedder of
-    # the detector's locked type this dataset supplies, else the dataset score
-    # precedence (keying_embedder_for_snap) - matching resolve_or_train_detector's
-    # cold path and the learned-sort cache-space marker.
-    _abort_if_find_cancelled()
-    score_emb = keying_embedder_for_snap(SimpleNamespace(embedder_type=_detector_type(det_data)), snap)
-    results = score_media_with_model(mlp, snap, embedder_name=score_emb or None)
-    update_find_progress(
-        "running",
-        f"Scoring {n_total} items…",
-        current=n_total,
-        total=n_total,
-        step=3,
-        total_steps=_FIND_LABEL_STEPS,
-    )
+        # Score in the same space the MLP was trained in: the concrete embedder of
+        # the detector's locked type this dataset supplies, else the dataset score
+        # precedence (keying_embedder_for_snap) - matching resolve_or_train_detector's
+        # cold path and the learned-sort cache-space marker.
+        _abort_if_find_cancelled()
+        score_emb = keying_embedder_for_snap(SimpleNamespace(embedder_type=_detector_type(det_data)), snap)
+        results = score_media_with_model(mlp, snap, embedder_name=score_emb or None)
+        update_find_progress(
+            "running",
+            f"Scoring {n_total} items…",
+            current=n_total,
+            total=n_total,
+            step=3,
+            total_steps=_FIND_LABEL_STEPS,
+        )
 
-    # Stage-2 structural re-rank for a saved structural (SIFT/VLAD) detector:
-    # geometrically verify the VLAD shortlist against the detector's RegionYes
-    # templates and re-rank by the match-statistic verification classifier.
-    # This is the Find counterpart to the re-rank already wired into the
-    # vote-driven (``train_and_score``) and learned-sort (``labelset_train_and_score``)
-    # paths, so a pre-trained structural detector verifies in Find too instead of
-    # stopping at the coarse VLAD retrieval.  A no-op for every non-structural
-    # detector (gated on the active snapshot carrying ``local_features``).  See
-    # docs/plans/structural-embedder.md.
-    from vtscore.datasets.labelset import LabelSet
-    from vtscore.detectors.labelset_training import maybe_labelset_structural_rerank
-    from vtscore.state.core import get_active_detector_context
+        # Stage-2 structural re-rank for a saved structural (SIFT/VLAD) detector:
+        # geometrically verify the VLAD shortlist against the detector's RegionYes
+        # templates and re-rank by the match-statistic verification classifier.
+        # This is the Find counterpart to the re-rank already wired into the
+        # vote-driven (``train_and_score``) and learned-sort (``labelset_train_and_score``)
+        # paths, so a pre-trained structural detector verifies in Find too instead of
+        # stopping at the coarse VLAD retrieval.  A no-op for every non-structural
+        # detector (gated on the active snapshot carrying ``local_features``).  See
+        # docs/plans/structural-embedder.md.
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.labelset_training import maybe_labelset_structural_rerank
+        from vtscore.state.core import get_active_detector_context
 
-    labelset = LabelSet.from_dict((det_data or {}).get("labelset") or {})
-    results, threshold = maybe_labelset_structural_rerank(
-        get_active_detector_context(), labelset, results, threshold, snap
-    )
-    # Store the final (post-rerank) cutoff on the context so server-side reads of
-    # the Find cutoff — the work-queue / boundary-walk endpoints, Inclusion
-    # re-thresholding — agree with the labels this pass just applied. A no-op for
-    # the non-structural path (threshold unchanged), authoritative for the
-    # structural one.
-    get_active_detector_context().threshold = threshold
+        labelset = LabelSet.from_dict((det_data or {}).get("labelset") or {})
+        results, threshold = maybe_labelset_structural_rerank(
+            get_active_detector_context(), labelset, results, threshold, snap
+        )
+        # Store the final (post-rerank) cutoff on the context so server-side reads of
+        # the Find cutoff — the work-queue / boundary-walk endpoints, Inclusion
+        # re-thresholding — agree with the labels this pass just applied. A no-op for
+        # the non-structural path (threshold unchanged), authoritative for the
+        # structural one.
+        get_active_detector_context().threshold = threshold
 
-    _abort_if_find_cancelled()
-    update_find_progress(
-        "running",
-        f"Applying labels to {n_total} items…",
-        current=0,
-        total=n_total,
-        step=4,
-        total_steps=_FIND_LABEL_STEPS,
-    )
-    label_pairs = []
-    for entry in results:
-        label_pairs.append((entry["id"], "good" if entry["score"] >= threshold else "bad"))
-    # Items the human already verified keep their vote: a re-score (the normal
-    # fold-corrections -> retrain -> re-score loop) must not silently invert a
-    # recorded human decision while still counting it as verified (issue #2928).
-    # Everything else adopts this pass's call.
-    apply_labels_bulk_with_click_time(label_pairs, replace_all=True, record_achievement=False, preserve_verified=True)
+        _abort_if_find_cancelled()
+        update_find_progress(
+            "running",
+            f"Applying labels to {n_total} items…",
+            current=0,
+            total=n_total,
+            step=4,
+            total_steps=_FIND_LABEL_STEPS,
+        )
+        label_pairs = []
+        for entry in results:
+            label_pairs.append((entry["id"], "good" if entry["score"] >= threshold else "bad"))
+        # Items the human already verified keep their vote: a re-score (the normal
+        # fold-corrections -> retrain -> re-score loop) must not silently invert a
+        # recorded human decision while still counting it as verified (issue #2928).
+        # Everything else adopts this pass's call.
+        apply_labels_bulk_with_click_time(
+            label_pairs, replace_all=True, record_achievement=False, preserve_verified=True
+        )
 
-    # The detector's own call for *every* item, verified ones included: this is
-    # the evaluation baseline Stats crosses the adopted labels against, so a
-    # verified item the retrained detector now disagrees with reads as a
-    # correction rather than vanishing.
-    set_find_initial_labels({mid: lbl for mid, lbl in label_pairs})
-    # Freeze the single-pass scores so the cutoff (Inclusion) re-thresholds
-    # without re-scoring, and the Stats FP/FN sweep can read them.
-    set_find_scores({entry["id"]: entry["score"] for entry in results})
+        # The detector's own call for *every* item, verified ones included: this is
+        # the evaluation baseline Stats crosses the adopted labels against, so a
+        # verified item the retrained detector now disagrees with reads as a
+        # correction rather than vanishing.
+        set_find_initial_labels({mid: lbl for mid, lbl in label_pairs})
+        # Freeze the single-pass scores so the cutoff (Inclusion) re-thresholds
+        # without re-scoring, and the Stats FP/FN sweep can read them.
+        set_find_scores({entry["id"]: entry["score"] for entry in results})
 
-    from vtscore.detectors.registry import set_find_mode
+        from vtscore.detectors.registry import set_find_mode
 
-    set_find_mode(True)
+        set_find_mode(True)
 
-    det_ctx = get_active_detector_context()
-    # A fresh scoring pass IS the current evaluation, so any "stale" flag left by
-    # a prior corrections-to-detector fold no longer applies.
-    det_ctx.find_eval_stale = False
-    # The counts the client shows are the labels this pass *adopted*, which is
-    # the threshold split everywhere except the verified items that held their
-    # human vote.  ``replace_all`` left exactly this label set behind, so the
-    # vote dicts are the count.
-    good_count = len(det_ctx.good_votes)
-    bad_count = len(det_ctx.bad_votes)
+        det_ctx = get_active_detector_context()
+        # A fresh scoring pass IS the current evaluation, so any "stale" flag left by
+        # a prior corrections-to-detector fold no longer applies.
+        det_ctx.find_eval_stale = False
+        # The counts the client shows are the labels this pass *adopted*, which is
+        # the threshold split everywhere except the verified items that held their
+        # human vote.  ``replace_all`` left exactly this label set behind, so the
+        # vote dicts are the count.
+        good_count = len(det_ctx.good_votes)
+        bad_count = len(det_ctx.bad_votes)
 
-    from vtscore.labels.sync import sync_to_labelset_source
+        from vtscore.labels.sync import sync_to_labelset_source
 
-    sync_to_labelset_source()
+        sync_to_labelset_source()
 
-    update_find_progress(
-        "idle",
-        "Done",
-        current=n_total,
-        total=n_total,
-        step=_FIND_LABEL_STEPS,
-        total_steps=_FIND_LABEL_STEPS,
-    )
+        update_find_progress(
+            "idle",
+            "Done",
+            current=n_total,
+            total=n_total,
+            step=_FIND_LABEL_STEPS,
+            total_steps=_FIND_LABEL_STEPS,
+        )
 
-    from vtsearch.achievements import record_find
+        from vtsearch.achievements import record_find
 
-    record_find(n_total)
+        record_find(n_total)
 
-    # Find is not yet windowed: its "just sit and vote" boundary walk and the
-    # Browse / To Dataset / Export bulk actions still read the full client-side
-    # ranking, so find-label returns the whole ``results`` list. The server-side
-    # replacements those flows will switch to already exist
-    # (``/api/find/queue-ids``, ``/api/find/boundary-next``); wiring the Find
-    # frontend onto them + windowing this response is the remaining slice (see
-    # docs/plans/scalability.md S3/S17/S19).
-    return {
-        "ok": True,
-        "results": results,
-        "threshold": round(threshold, 4),
-        "good_count": good_count,
-        "bad_count": bad_count,
-        "detector_name": d.get("name", ""),
-    }
+        # Find is not yet windowed: its "just sit and vote" boundary walk and the
+        # Browse / To Dataset / Export bulk actions still read the full client-side
+        # ranking, so find-label returns the whole ``results`` list. The server-side
+        # replacements those flows will switch to already exist
+        # (``/api/find/queue-ids``, ``/api/find/boundary-next``); wiring the Find
+        # frontend onto them + windowing this response is the remaining slice (see
+        # docs/plans/scalability.md S3/S17/S19).
+        return {
+            "ok": True,
+            "results": results,
+            "threshold": round(threshold, 4),
+            "good_count": good_count,
+            "bad_count": bad_count,
+            "detector_name": d.get("name", ""),
+        }
 
 
 def _resolve_autofind_names(body: dict, media_type: str) -> list[str]:
@@ -523,7 +532,7 @@ def _collect_auto_detect_results(futures: list, results: dict[str, dict]) -> Non
     except CancelledError:
         for f in futures:
             f.cancel()
-        update_find_progress("idle", "", step=None, total_steps=None)
+        find_idle()
         abort(409, message="Find cancelled")
 
 
@@ -933,20 +942,26 @@ def auto_detect(body: dict):
         max_workers=min(len(detectors_to_run), 8),
     )
     results: dict[str, dict] = {}
-    with ThreadPoolExecutor(max_workers=worker_cap) as pool:
-        futures = [
-            pool.submit(
-                _score_detector_for_auto_detect,
-                name,
-                data,
-                entry,
-                media_type,
-                snap,
-                *matrices[det_embedders[name]],
-            )
-            for name, data, entry in detectors_to_run
-        ]
-        _collect_auto_detect_results(futures, results)
+    # A cold detector's train writes "running" to the shared tracker from inside
+    # the workers (``resolve_or_train_detector``), so this route owns parking it
+    # again — on the way out of a crash via the guard, and on the ordinary path
+    # below.  Cancellation parks it in ``_collect_auto_detect_results``.
+    with find_idle_on_crash():
+        with ThreadPoolExecutor(max_workers=worker_cap) as pool:
+            futures = [
+                pool.submit(
+                    _score_detector_for_auto_detect,
+                    name,
+                    data,
+                    entry,
+                    media_type,
+                    snap,
+                    *matrices[det_embedders[name]],
+                )
+                for name, data, entry in detectors_to_run
+            ]
+            _collect_auto_detect_results(futures, results)
+        find_idle()
 
     if results:
         from vtsearch.achievements import record_find  # noqa: PLC0415


### PR DESCRIPTION
Closes #2949

## The bug

The scoring routes reset the shared `find_progress` singleton on every *anticipated* exit — success, `abort()`, cancel — but an unhandled exception took none of those paths. The request 500s through the global handler in `vtsearch/errors.py` (which never touches progress state) while the tracker stays at `"running"` on whatever step it died on, pushed to every client over `/api/events` until the next Find resets it, with the `auto_finish` timing recorder still subscribed to the process-wide singleton.

- `multi_find`'s catch-all closed the recorder but never parked the tracker, contradicting its own "every exit parks the tracker at idle" comment.
- `find_label` had no catch-all at all: an `RuntimeError` out of `score_media_with_model`, `maybe_labelset_structural_rerank`, or `apply_labels_bulk_with_click_time` left the tracker running.

`sort_clips` (`vtsearch/routes/sorting.py`) already gets this right via `_sort_idle()` in its exception branch; this brings the find side into line.

## The fix

Adds two helpers to `vtsearch/routes/_shared.py`:

- `find_idle()` — the find-side sibling of `_sort_idle()`; parks the tracker and clears the whole-job step frame.
- `find_idle_on_crash(recorder=None)` — a context manager that parks the tracker if the wrapped body dies unexpectedly, then re-raises. It closes the timing recorder as a **failed** run *first*, so the idle update's `auto_finish` hook can't bank a crashed run's partial phase timings as a good cost sample. `HTTPException` passes through untouched — `abort()` already parked the tracker and closed the recorder, and flask-smorest renders its envelope unchanged.

The guard wraps the post-resolve body of `/api/find` and `/api/find-label`. On `/api/find` it starts *before* detector resolution, so a crash in `_build_detector_configs` (step 1) is covered too, not just the dataset loop.

Every `update_find_progress("idle", …)` call in the two route modules now goes through `find_idle()`, which also fixes a small inconsistency: `find_label`'s abort paths used to park at idle while leaving `step`/`total_steps` set from the phase they died in.

## Also fixed: `/api/auto-detect` never parked the tracker at all

Not in the issue, but the same defect one function over, and worse: `auto_detect` writes `"running"` to the shared tracker from inside its workers (via `resolve_or_train_detector`'s cold-train path) and had no idle update on **any** path except cancel — including success. It now parks once the workers are drained, and is guarded the same way on the crash path.

## Tests

New `tests/detectors/test_find_progress_reset.py` (7 tests): unit coverage of the guard (parks idle + clears the step frame, closes the recorder with `ok=False`, passes `abort()` through), plus route-level regressions that make `score_media_with_model` / `_score_dataset` / `_build_detector_configs` raise and assert 500 + `status == "idle"`, and one asserting `/api/auto-detect` parks the tracker on success. Verified they fail against the unguarded code (5 of the 7 fail; the two that don't are the `abort()` passthrough and the auto-detect success path, which is fixed in the route body rather than the guard).

`./run-tests.sh`: **ALL 7961 TESTS PASSED** (1 skipped, 1 xfailed).

## Backwards compatibility

No API surface change: the same status codes and response bodies come back. The only observable difference is that the SSE progress channel now sees an `idle` frame after a failed scoring run instead of a stuck `running` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135YmR7x6k9pEM873jE2EES

---
_Generated by [Claude Code](https://claude.ai/code/session_0135YmR7x6k9pEM873jE2EES)_