### PR TITLE
Scope embedder progress callbacks per thread

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -444,9 +444,18 @@ No Flask, no global state, no progress dependency (silent no-op by
 default).  To get progress reporting, set a callback before loading:
 
 ```python
-embedder._on_progress = lambda status, msg, cur, tot: print(f"{msg} ({cur}/{tot})")
-embedder.load_models()
+with embedder.progress_scope(lambda status, msg, cur, tot: print(f"{msg} ({cur}/{tot})")):
+    embedder.load_models()
 ```
+
+Embedders are process-wide singletons, so `_on_progress` is **thread-scoped**:
+`progress_scope()` (and a bare `embedder._on_progress = cb` assignment) only
+redirects progress for calls made on the *calling* thread, and a thread that set
+nothing reads the process-wide default wired in by
+`vtscore.media.set_progress_callback()`.  That is what lets two concurrent
+dataset loads share one embedder without their trackers crossing — a mis-routed
+callback would not merely mis-draw a bar, since trackers call `check_cancelled()`
+and would abort the wrong load.
 
 ### The plugin systems
 

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -543,7 +543,7 @@ loaded via `spec_from_file_location` so discovery still works.
 
 | Attribute       | Type               | Description                         |
 |-----------------|--------------------|-------------------------------------|
-| `_on_progress`  | `ProgressCallback` | Progress callback (default: no-op). Set via `set_progress_callback()` |
+| `_on_progress`  | `ProgressCallback` | Progress callback (default: no-op). Process-wide default set via `set_progress_callback()`; **reads and writes are per-thread**, so wrap a temporary redirect in `with emb.progress_scope(cb):` rather than saving/restoring by hand. Embedders are singletons — a process-wide swap would cross concurrent loads' progress bars and cancellations. |
 
 ### Built-in embedders
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -203,3 +203,36 @@ def setup_trainable_model_in_registry(name, good_ids, bad_ids, snap, media_type=
 
     entry = register_detector(name=name, media_type=media_type, num_training=len(labelset))
     return entry["id"]
+
+
+# ---------------------------------------------------------------------------
+# Mock embedder helpers
+# ---------------------------------------------------------------------------
+
+
+def wire_mock_progress_scope(emb):
+    """Give a ``MagicMock`` embedder a working ``progress_scope``.
+
+    Production code redirects an embedder's progress through
+    :meth:`~vtscore.media.embedder.MediaEmbedder.progress_scope` (thread-scoped,
+    so concurrent dataset loads sharing the singleton embedder can't cross
+    wires).  A bare ``MagicMock`` answers that call with another mock that
+    enters and exits without ever touching ``_on_progress``, so a mock whose
+    bulk/load hook reads ``self._on_progress`` would see its own stub instead of
+    the caller's tracker.  This installs the real set-then-restore contract.
+
+    Returns *emb* so it can wrap a factory call.
+    """
+    import contextlib  # noqa: PLC0415
+
+    @contextlib.contextmanager
+    def _scope(callback):
+        prev = emb._on_progress
+        emb._on_progress = callback
+        try:
+            yield
+        finally:
+            emb._on_progress = prev
+
+    emb.progress_scope = _scope
+    return emb

--- a/tests_lib/cli/test_preload_progress.py
+++ b/tests_lib/cli/test_preload_progress.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import torch
 import torch.nn as nn
 
+from helpers import wire_mock_progress_scope
 from vtscore.media.embedder import (
     _hub_metadata_preflight,
     hf_token,
@@ -290,6 +291,7 @@ class TestPreloadConsoleOutput:
         mock_emb = MagicMock()
         mock_emb.name = "clap"
         mock_emb._on_progress = lambda *a, **kw: None
+        wire_mock_progress_scope(mock_emb)
 
         def fake_load_models():
             mock_emb._on_progress("loading", "Loading CLAP model weights...", 0, 0)

--- a/tests_lib/datasets/test_embed_progress_isolation.py
+++ b/tests_lib/datasets/test_embed_progress_isolation.py
@@ -1,0 +1,248 @@
+"""Concurrent dataset loads must not trample each other's embed progress.
+
+Embedders are process-wide singletons (``vtscore.media._embedder_registry``),
+so the embed stage's ``_on_progress`` save-and-restore used to be shared
+mutable state: with two loads inside ``embed_missing`` on the same embedder
+(the CPU embed gate allows several, and the staging path bypasses it
+entirely), load B's assignment re-routed load A's still-running bulk embed
+into B's tracker — mis-drawing B's bar, letting a cancel of B raise inside A,
+and finally silencing B when A's ``finally`` restored a stale callback.
+
+``MediaEmbedder._on_progress`` is now per-thread over a process-wide default,
+so each load keeps its own tracker for the whole pass.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+
+from vtscore.concurrency.progress import CancelledError
+from vtscore.datasets.stages.embedding import embed_missing
+from vtscore.media.embedder import MediaEmbedder
+
+
+class _FakeEmbedder(MediaEmbedder):
+    """Minimal single-vector embedder whose bulk pass emits two progress calls."""
+
+    _NAME = "fake_test_embedder"
+
+    @property
+    def name(self) -> str:
+        return self._NAME
+
+    @property
+    def media_type_id(self) -> str:
+        return "audio"
+
+    def __init__(self) -> None:
+        self._model = True
+
+    def _load_models_impl(self) -> None:  # pragma: no cover - model is pre-set
+        self._model = True
+
+    def _embed_media_impl(self, media: dict) -> np.ndarray:
+        return np.ones(3, dtype=np.float32)
+
+    def _embed_media_bulk_impl(self, medias: list[dict]) -> list[np.ndarray]:
+        total = len(medias)
+        self._on_progress("embedding", "start", 0, total)
+        self._park()
+        self._on_progress("embedding", "end", total, total)
+        return [np.ones(3, dtype=np.float32) for _ in medias]
+
+    def _park(self) -> None:
+        """Hook: block mid-bulk.  The plain embedder never parks."""
+
+
+class _Gate:
+    """One bulk pass's park: ``entered`` fires on arrival, ``release`` resumes it."""
+
+    def __init__(self) -> None:
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+
+class _GatedEmbedder(_FakeEmbedder):
+    """Embedder that parks mid-bulk on a per-call gate, in call-arrival order.
+
+    Parking lets a second thread enter its own ``embed_missing`` (installing its
+    own callback) while the first is still mid-bulk, and lets the test resume
+    the two passes one at a time — the exact interleaving that used to cross the
+    two loads' progress wires.
+    """
+
+    _NAME = "gated_test_embedder"
+
+    def __init__(self, gates: list[_Gate]) -> None:
+        super().__init__()
+        self._gates = list(gates)
+        self._gate_lock = threading.Lock()
+
+    def _park(self) -> None:
+        with self._gate_lock:
+            gate = self._gates.pop(0)
+        gate.entered.set()
+        assert gate.release.wait(timeout=10)
+
+
+def _medias(n: int) -> dict[int, dict]:
+    return {i: {"media_type": "audio", "embeddings": {}} for i in range(n)}
+
+
+class _Recorder:
+    """Progress callback that records every message it is handed."""
+
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+        self.messages: list[str] = []
+
+    def __call__(self, status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+        self.messages.append(message)
+
+
+class _registered:
+    """Context manager registering *emb* in the process embedder registry."""
+
+    def __init__(self, emb: MediaEmbedder) -> None:
+        self._emb = emb
+
+    def __enter__(self):
+        from vtscore.media import _embedder_registry, register_embedder
+
+        self._registry = _embedder_registry
+        self._prev = _embedder_registry.get(self._emb.name)
+        register_embedder(self._emb)
+        return self._emb
+
+    def __exit__(self, *exc):
+        if self._prev is None:
+            self._registry.pop(self._emb.name, None)
+        else:
+            self._registry[self._emb.name] = self._prev
+        return False
+
+
+def _overlapped_embed(emb: _GatedEmbedder, gates: list[_Gate], calls) -> None:
+    """Run *calls* (``(medias, on_progress)`` pairs) overlapped inside the bulk pass.
+
+    Every pass parks; the first is then resumed and joined **while the second is
+    still parked**, so the second's callback is the most recently installed one
+    when the first emits its remaining progress.  That ordering is what a shared
+    ``_on_progress`` would mis-route, and it is deterministic — no reliance on
+    which released thread happens to run first.
+    """
+    threads = []
+    for medias, on_progress in calls:
+        t = threading.Thread(target=embed_missing, args=(medias, emb.name), kwargs={"on_progress": on_progress})
+        t.start()
+        assert gates[len(threads)].entered.wait(timeout=10), "bulk pass never reached its park"
+        threads.append(t)
+    for gate, t in zip(gates, threads):
+        gate.release.set()
+        t.join(timeout=10)
+        assert not t.is_alive()
+
+
+class TestConcurrentEmbedProgressIsolation:
+    def test_each_load_keeps_its_own_callback(self):
+        """Two overlapping ``embed_missing`` calls report into their own trackers."""
+        gates = [_Gate(), _Gate()]
+        emb = _GatedEmbedder(gates)
+        a, b = _Recorder("a"), _Recorder("b")
+        medias_a, medias_b = _medias(2), _medias(3)
+
+        with _registered(emb):
+            _overlapped_embed(emb, gates, [(medias_a, a), (medias_b, b)])
+
+        # Each recorder saw its own pass's announce plus both of its bulk
+        # updates, and nothing from the other load.  Before the fix, A's "end"
+        # landed in B's recorder because B had overwritten the shared slot.
+        assert a.messages == ["Embedding 2 item(s)…", "start", "end"]
+        assert b.messages == ["Embedding 3 item(s)…", "start", "end"]
+
+    def test_cancel_of_one_load_does_not_abort_the_other(self):
+        """A cancelling tracker raises only inside its own load's embed pass.
+
+        Progress callbacks call ``check_cancelled()``, so a mis-routed callback
+        does more than mis-draw a bar: it aborts whichever embed pass calls it.
+        """
+        gates = [_Gate(), _Gate()]
+        emb = _GatedEmbedder(gates)
+        survivor = _Recorder("survivor")
+        medias_a, medias_b = _medias(2), _medias(2)
+
+        def cancelling(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+            if message == "end":
+                raise CancelledError("cancelled")
+
+        with _registered(emb):
+            _overlapped_embed(emb, gates, [(medias_a, survivor), (medias_b, cancelling)])
+
+        # A ran to completion with its own progress intact…
+        assert survivor.messages == ["Embedding 2 item(s)…", "start", "end"]
+        assert all(m["embeddings"] for m in medias_a.values())
+        # …while the cancel landed in B's own pass, which embedded nothing.
+        assert not any(m["embeddings"] for m in medias_b.values())
+
+
+class TestProgressScope:
+    def test_scope_is_thread_local_over_a_shared_default(self):
+        emb = _FakeEmbedder()
+        default = _Recorder("default")
+        emb.set_default_progress_callback(default)
+
+        scoped = _Recorder("scoped")
+        seen_in_thread: list[object] = []
+        with emb.progress_scope(scoped):
+            # Another thread never sees this thread's override.
+            t = threading.Thread(target=lambda: seen_in_thread.append(emb._on_progress))
+            t.start()
+            t.join(timeout=10)
+            assert emb._on_progress is scoped
+
+        assert seen_in_thread == [default]
+        # Restored to the process-wide default, not pinned to the scoped one.
+        assert emb._on_progress is default
+
+    def test_scope_restores_on_exception(self):
+        emb = _FakeEmbedder()
+        default = _Recorder("default")
+        emb.set_default_progress_callback(default)
+
+        try:
+            with emb.progress_scope(_Recorder("scoped")):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        assert emb._on_progress is default
+
+    def test_scopes_nest(self):
+        emb = _FakeEmbedder()
+        outer, inner = _Recorder("outer"), _Recorder("inner")
+        with emb.progress_scope(outer):
+            with emb.progress_scope(inner):
+                assert emb._on_progress is inner
+            assert emb._on_progress is outer
+
+    def test_default_is_noop_until_wired(self):
+        emb = _FakeEmbedder()
+        # No callback anywhere: reads the no-op default rather than raising.
+        emb._on_progress("embedding", "ignored", 0, 1)
+
+    def test_plain_assignment_stays_thread_scoped(self):
+        """The legacy ``emb._on_progress = cb`` idiom is a per-thread override."""
+        emb = _FakeEmbedder()
+        default = _Recorder("default")
+        emb.set_default_progress_callback(default)
+
+        assigned = _Recorder("assigned")
+        emb._on_progress = assigned
+        seen_in_thread: list[object] = []
+        t = threading.Thread(target=lambda: seen_in_thread.append(emb._on_progress))
+        t.start()
+        t.join(timeout=10)
+
+        assert emb._on_progress is assigned
+        assert seen_in_thread == [default]

--- a/tests_lib/helpers.py
+++ b/tests_lib/helpers.py
@@ -199,3 +199,36 @@ def setup_trainable_model_in_registry(name, good_ids, bad_ids, snap, media_type=
 
     entry = register_detector(name=name, media_type=media_type, num_training=len(labelset))
     return entry["id"]
+
+
+# ---------------------------------------------------------------------------
+# Mock embedder helpers
+# ---------------------------------------------------------------------------
+
+
+def wire_mock_progress_scope(emb):
+    """Give a ``MagicMock`` embedder a working ``progress_scope``.
+
+    Production code redirects an embedder's progress through
+    :meth:`~vtscore.media.embedder.MediaEmbedder.progress_scope` (thread-scoped,
+    so concurrent dataset loads sharing the singleton embedder can't cross
+    wires).  A bare ``MagicMock`` answers that call with another mock that
+    enters and exits without ever touching ``_on_progress``, so a mock whose
+    bulk/load hook reads ``self._on_progress`` would see its own stub instead of
+    the caller's tracker.  This installs the real set-then-restore contract.
+
+    Returns *emb* so it can wrap a factory call.
+    """
+    import contextlib  # noqa: PLC0415
+
+    @contextlib.contextmanager
+    def _scope(callback):
+        prev = emb._on_progress
+        emb._on_progress = callback
+        try:
+            yield
+        finally:
+            emb._on_progress = prev
+
+    emb.progress_scope = _scope
+    return emb

--- a/tests_lib/io/test_bulk_embedding.py
+++ b/tests_lib/io/test_bulk_embedding.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import numpy as np
 
 from helpers import make_raw_wav_bytes as _make_wav_bytes
+from helpers import wire_mock_progress_scope
 from vtscore.embedding.media_vectors import media_embedding
 
 
@@ -37,7 +38,7 @@ def _make_bulk_embedder(embed_return_dim: int = 3):
         return [np.full(embed_return_dim, float(i), dtype=np.float32) for i, _ in enumerate(medias)]
 
     emb.embed_media_bulk.side_effect = _bulk
-    return emb
+    return wire_mock_progress_scope(emb)
 
 
 def _make_media_type_for_audio():

--- a/tests_lib/io/test_clip_reembed_bulk.py
+++ b/tests_lib/io/test_clip_reembed_bulk.py
@@ -17,6 +17,7 @@ import unittest.mock as mock
 import numpy as np
 import pytest
 
+from helpers import wire_mock_progress_scope
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.media.audio.audio_generator import generate_wav
 from vtscore.utils.hashing import content_md5
@@ -163,6 +164,7 @@ class TestClipReembedLoadingProgressPassthrough:
 
         emb = mock.MagicMock()
         emb._on_progress = lambda *a, **kw: None
+        wire_mock_progress_scope(emb)
 
         def _bulk(medias):
             # Simulate lazy load: descriptive "loading" progress (weight

--- a/vtscore/datasets/stages/clipper.py
+++ b/vtscore/datasets/stages/clipper.py
@@ -444,10 +444,12 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
         scaled = min(total_clips, int(current * len(embed_indices) / max(1, total)))
         on_progress(scaled, total_clips, "embedding")
 
-    original_cb = embedder._on_progress
-    embedder._on_progress = _clip_progress
     try:
-        vectors = embedder.embed_media_bulk(embed_inputs)
+        # Thread-scoped so a concurrent dataset load sharing this singleton
+        # embedder keeps reporting into its own tracker (see
+        # ``MediaEmbedder.progress_scope``).
+        with embedder.progress_scope(_clip_progress):
+            vectors = embedder.embed_media_bulk(embed_inputs)
     except Exception:
         import logging as _logging
 
@@ -455,8 +457,6 @@ def _fixup_clip_md5_and_embeddings(  # noqa: C901
             "Bulk clip re-embed failed for media_type=%s (%d clips)", media_type, len(embed_indices)
         )
         return
-    finally:
-        embedder._on_progress = original_cb
 
     for slot, vec in zip(embed_indices, vectors):
         if vec is not None:

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -174,14 +174,16 @@ def _run_embed_pass(
     media_type: str,
     missing: list[tuple[int, dict[str, Any]]],
     on_progress: Callable[[str, str, int, int], None],
-    original_cb,
 ) -> None:
     """Bulk-embed the *missing* items and attach each non-``None`` vector.
 
     Announces progress, routes the embedder's callback through *on_progress*
-    (restoring *original_cb* afterward), and on a bulk-embed failure logs and
-    attaches nothing (items stay at ``None`` for the drop-none stage).  Items
-    whose media vanished from *medias* during the call are skipped.
+    for the duration of the call (via the thread-scoped
+    :meth:`~vtscore.media.embedder.MediaEmbedder.progress_scope`, so a
+    concurrent load on this singleton embedder keeps its own tracker), and on a
+    bulk-embed failure logs and attaches nothing (items stay at ``None`` for the
+    drop-none stage).  Items whose media vanished from *medias* during the call
+    are skipped.
     """
     if not missing:
         return
@@ -189,14 +191,12 @@ def _run_embed_pass(
     on_progress("embedding", f"Embedding {total} item(s)…", 0, total)
 
     inputs = [m for _, m in missing]
-    emb._on_progress = on_progress
     try:
-        vectors = emb.embed_media_bulk(inputs)
+        with emb.progress_scope(on_progress):
+            vectors = emb.embed_media_bulk(inputs)
     except Exception:
         logging.getLogger(__name__).exception("Bulk embed failed for media_type=%s (%d items)", media_type, total)
         vectors = None
-    finally:
-        emb._on_progress = original_cb
 
     if vectors is None:
         return
@@ -215,7 +215,6 @@ def _run_backfill_pass(
     medias: dict[int, dict[str, Any]],
     media_type: str,
     on_progress: Callable[[str, str, int, int], None],
-    original_cb,
     *,
     needs: Callable[[dict[str, Any]], bool],
     forward: Callable[[list[dict[str, Any]]], list],
@@ -225,23 +224,22 @@ def _run_backfill_pass(
     """Run one side-channel back-fill pass over every media still needing it.
 
     Filters *medias* by *needs*, bulk-forwards them through *forward* (routing
-    progress through *on_progress* and restoring *original_cb* afterward), and
-    attaches each non-``None`` output via *attach*.  On a *forward* failure the
-    pass logs *fail_message* and attaches nothing (every output is treated as
-    ``None``).  Runs over every matching media, including ones that arrived
+    progress through *on_progress* for the duration of the call, scoped to this
+    thread so a concurrent load keeps its own tracker), and attaches each
+    non-``None`` output via *attach*.  On a *forward* failure the pass logs
+    *fail_message* and attaches nothing (every output is treated as ``None``).
+    Runs over every matching media, including ones that arrived
     already-embedded — not only the items embedded in this load.
     """
     inputs = [m for m in medias.values() if needs(m)]
     if not inputs:
         return
-    emb._on_progress = on_progress
     try:
-        outputs = forward(inputs)
+        with emb.progress_scope(on_progress):
+            outputs = forward(inputs)
     except Exception:
         logging.getLogger(__name__).exception(fail_message, media_type, len(inputs))
         outputs = [None] * len(inputs)
-    finally:
-        emb._on_progress = original_cb
 
     for media, out in zip(inputs, outputs):
         if out is None:
@@ -333,9 +331,7 @@ def embed_missing(
 
     _ensure_model_loaded(emb, on_progress)
 
-    original_cb = emb._on_progress
-
-    _run_embed_pass(emb, medias, media_type, missing, on_progress, original_cb)
+    _run_embed_pass(emb, medias, media_type, missing, on_progress)
 
     # Patch-grid pass for embedders that support it (DINOv2/v3/EUPE).  Runs
     # over every patch-capable image still lacking a grid, including ones that
@@ -346,7 +342,6 @@ def embed_missing(
             medias,
             media_type,
             on_progress,
-            original_cb,
             needs=_needs_patch,
             forward=emb.patch_forward_bulk,
             attach=_attach_patch_grid_to_media,
@@ -362,7 +357,6 @@ def embed_missing(
             medias,
             media_type,
             on_progress,
-            original_cb,
             needs=_needs_local_features,
             forward=emb.local_features_forward_bulk,
             attach=lambda media, feats: media.__setitem__("local_features", feats.compact()),

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -518,14 +518,12 @@ def preload_predicted_embedders(
         try:
             emb = get_embedder(emb_name)
             print(f"  Preloading {emb_name} embedder...", flush=True)
-            original_cb = emb._on_progress
-            console_cb = _make_console_progress(original_cb)
-            emb._on_progress = console_cb
+            console_cb = _make_console_progress(emb._on_progress)
             try:
-                emb.load_models()
+                with emb.progress_scope(console_cb):
+                    emb.load_models()
             finally:
                 console_cb.flush()  # type: ignore[attr-defined]
-                emb._on_progress = original_cb
             preloaded.append(emb_name)
         except Exception as exc:
             print(f"  Warning: failed to preload {emb_name}: {exc}", flush=True)

--- a/vtscore/media/__init__.py
+++ b/vtscore/media/__init__.py
@@ -411,11 +411,17 @@ def set_progress_callback(callback: "ProgressCallback") -> None:
 
     Call this once at application startup to wire media types and embedders
     into whatever progress reporting mechanism the host application uses.
+
+    Embedders go through :meth:`~vtscore.media.embedder.MediaEmbedder.set_default_progress_callback`
+    rather than a plain ``_on_progress`` assignment: that attribute is
+    thread-scoped (so concurrent dataset loads can't trample each other's
+    tracker), whereas this startup wiring is a process-wide default every
+    thread must see.
     """
     for mt in _registry.values():
         mt._on_progress = callback
     for emb in _embedder_registry.values():
-        emb._on_progress = callback
+        emb.set_default_progress_callback(callback)
 
 
 __all__ = [

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -981,12 +981,8 @@ class AudioMediaType(MediaType):
         # skip_embedding in load_demo_dataset).
         if not skip_embedding and getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading audio embedding model…", 0, 0)
-            original_cb = embedder._on_progress
-            embedder._on_progress = on_progress
-            try:
+            with embedder.progress_scope(on_progress):
                 embedder.load_models()
-            finally:
-                embedder._on_progress = original_cb
 
         clip_id = max(clips.keys(), default=0) + 1
         total = len(audio_files)

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -568,6 +568,76 @@ def intercept_weight_loading_progress(callback: ProgressCallback, label: str = "
             setattr(obj, attr, orig)
 
 
+#: Key under which an embedder instance stashes its :class:`_ProgressSlot`.
+_PROGRESS_SLOT_KEY = "_progress_slot"
+
+
+class _ProgressSlot:
+    """Per-embedder progress state: a process-wide default + a per-thread override.
+
+    *default* is what :func:`vtscore.media.set_progress_callback` wires in once
+    at startup (the host application's progress sink); every thread sees it.
+    *local* carries the per-thread override installed by
+    :meth:`MediaEmbedder.progress_scope` (or a plain ``emb._on_progress = cb``
+    assignment) for the duration of one embed / model-load pass.
+    """
+
+    __slots__ = ("default", "local")
+
+    def __init__(self, default: ProgressCallback) -> None:
+        self.default = default
+        self.local = threading.local()
+
+
+def _progress_slot(emb: "MediaEmbedder") -> _ProgressSlot:
+    """Return *emb*'s :class:`_ProgressSlot`, creating it on first use.
+
+    Created lazily (rather than in ``__init__``) so an embedder subclass that
+    never calls ``super().__init__()`` still gets one.  ``dict.setdefault`` is
+    atomic under the GIL, so two threads racing to create the slot agree on a
+    single winner instead of one silently discarding the other's callback.
+    """
+    state = vars(emb)
+    slot = state.get(_PROGRESS_SLOT_KEY)
+    if slot is None:
+        slot = state.setdefault(_PROGRESS_SLOT_KEY, _ProgressSlot(_noop_progress))
+    return slot
+
+
+class _ThreadLocalProgress:
+    """Data descriptor backing :attr:`MediaEmbedder._on_progress`.
+
+    Embedders are process-wide singletons (``vtscore.media._embedder_registry``),
+    so a plain instance attribute made the progress callback shared mutable
+    state: two concurrent dataset loads on the same embedder would each assign
+    their own tracker callback, and the second assignment re-routed the *first*
+    load's still-running ``embed_media_bulk`` into the second load's tracker.
+    That mis-drew the progress bar and — because tracker callbacks call
+    ``check_cancelled()`` — let cancelling one load raise ``CancelledError``
+    inside the other's embed pass, aborting the wrong dataset.  Each pass's
+    ``finally`` then restored a callback captured before the other's assignment,
+    silencing whichever load was still running.
+
+    Reads and writes are therefore scoped to the calling thread: a write only
+    ever redirects the progress of embed / model-load calls made *by that
+    thread*, which is exactly what every save-and-restore call site wants.  A
+    thread that never assigned anything reads the process-wide default
+    (:meth:`MediaEmbedder.set_default_progress_callback`), so background work
+    with no explicit callback — the smart-preload thread, say — still reports
+    into the host application's progress sink.
+    """
+
+    def __get__(self, obj: "MediaEmbedder | None", objtype: type | None = None) -> Any:
+        if obj is None:
+            return self
+        slot = _progress_slot(obj)
+        cb = getattr(slot.local, "cb", None)
+        return slot.default if cb is None else cb
+
+    def __set__(self, obj: "MediaEmbedder", value: ProgressCallback | None) -> None:
+        _progress_slot(obj).local.cb = value
+
+
 class MediaEmbedder(ABC):
     """Abstract base class for media embedders.
 
@@ -592,12 +662,44 @@ class MediaEmbedder(ABC):
     # embedder type.
     _embed_lock = threading.Lock()
 
+    #: Progress sink for this embedder's model loads and bulk passes.  Reads
+    #: and writes are **per-thread** over a process-wide default; see
+    #: :class:`_ThreadLocalProgress` for why, and prefer :meth:`progress_scope`
+    #: over assigning it directly.
+    _on_progress: ProgressCallback = _ThreadLocalProgress()  # type: ignore[assignment]
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         cls._model_load_lock = threading.Lock()
 
-    def __init__(self) -> None:
-        self._on_progress: ProgressCallback = _noop_progress
+    def set_default_progress_callback(self, callback: ProgressCallback) -> None:
+        """Set the process-wide fallback progress sink for this embedder.
+
+        This is the callback every thread sees when it has not installed a
+        :meth:`progress_scope` of its own; :func:`vtscore.media.set_progress_callback`
+        calls it once at application startup.  Unlike assigning
+        :attr:`_on_progress` (which is thread-scoped by design), this is
+        deliberately visible across threads.
+        """
+        _progress_slot(self).default = callback
+
+    @contextlib.contextmanager
+    def progress_scope(self, callback: ProgressCallback):
+        """Route this embedder's progress to *callback* for the calling thread.
+
+        Restores whatever the calling thread had installed before (usually
+        nothing, meaning the process-wide default) on exit, including on
+        exception.  Other threads are unaffected for the whole scope, so two
+        concurrent dataset loads sharing this singleton embedder each keep
+        their own tracker.
+        """
+        slot = _progress_slot(self)
+        prev = getattr(slot.local, "cb", None)
+        slot.local.cb = callback
+        try:
+            yield
+        finally:
+            slot.local.cb = prev
 
     # ------------------------------------------------------------------
     # Identity

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -1009,12 +1009,8 @@ def _collect_openlogo_files(categories, slice_args, on_progress) -> list:
 def _ensure_image_embedder_loaded(embedder, on_progress) -> None:
     if getattr(embedder, "_model", None) is None:
         on_progress("loading", "Loading image embedding model…", 0, 0)
-        original_cb = embedder._on_progress
-        embedder._on_progress = on_progress
-        try:
+        with embedder.progress_scope(on_progress):
             embedder.load_models()
-        finally:
-            embedder._on_progress = original_cb
 
 
 def _synthetic_tile_png(item) -> bytes:

--- a/vtscore/media/text/media_type.py
+++ b/vtscore/media/text/media_type.py
@@ -571,12 +571,8 @@ class TextMediaType(MediaType):
         # skip_embedding in load_demo_dataset).
         if not skip_embedding and getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading text embedding model…", 0, 0)
-            original_cb = embedder._on_progress
-            embedder._on_progress = on_progress
-            try:
+            with embedder.progress_scope(on_progress):
                 embedder.load_models()
-            finally:
-                embedder._on_progress = original_cb
 
         clip_id = max(clips.keys(), default=0) + 1
         total = len(selected_texts)

--- a/vtscore/media/video/media_type.py
+++ b/vtscore/media/video/media_type.py
@@ -678,12 +678,8 @@ class VideoMediaType(MediaType):
         # skip_embedding in load_demo_dataset).
         if not skip_embedding and getattr(embedder, "_model", None) is None:
             on_progress("loading", "Loading video embedding model\u2026", 0, 0)
-            original_cb = embedder._on_progress
-            embedder._on_progress = on_progress
-            try:
+            with embedder.progress_scope(on_progress):
                 embedder.load_models()
-            finally:
-                embedder._on_progress = original_cb
 
         clip_id = max(clips.keys(), default=0) + 1
         total = len(video_files)

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -182,11 +182,12 @@ def _load_embedder_with_progress(snap=None):
     """Load the embedding model, forwarding its load progress to step 1 of the bar.
 
     If the model is already loaded this is a no-op.  A lock serialises
-    concurrent callers so that only one request touches ``_on_progress``
-    at a time, preventing the save/restore from trampling another
-    request's callback.  The model-load ``cur``/``tot`` is reported as the
-    within-step progress of step 1, so the unified bar animates during the
-    load instead of parking at a step floor.
+    concurrent callers so only one request drives the load and the others
+    return early once it is warm (``_on_progress`` itself is thread-scoped —
+    see ``MediaEmbedder.progress_scope`` — so the save/restore below can no
+    longer trample another request's callback).  The model-load ``cur``/``tot``
+    is reported as the within-step progress of step 1, so the unified bar
+    animates during the load instead of parking at a step floor.
 
     *snap* threads in an already-taken medias snapshot to avoid re-copying the
     medias dict under ``_state_lock``; when ``None`` a fresh snapshot is taken.


### PR DESCRIPTION
Closes #2937

## The race

Embedders are process-wide singletons (`vtscore.media._embedder_registry`), so `MediaEmbedder._on_progress` was shared mutable state that every save-and-restore call site trampled.

Two dataset loads can be inside `embed_missing` on the same embedder at once — `default_concurrent_embeddings()` is >1 on CPU hosts, and the staging path (`_stage_importer_in_background` → `embed_missing`) bypasses the embed gate entirely. So load B's `emb._on_progress = B_cb` re-routed load A's *still-running* `embed_media_bulk` into B's tracker. Because tracker callbacks call `check_cancelled()`, that did more than mis-draw a bar: cancelling B raised `CancelledError` inside A's embed pass, aborting the wrong dataset load. A's `finally` then restored a callback captured before B's assignment, silencing B for the rest of its pass.

## The fix

`MediaEmbedder._on_progress` is now a data descriptor over a per-embedder slot holding a **process-wide default** plus a **`threading.local` override**:

- A write (`emb._on_progress = cb`, or the new `progress_scope()`) only redirects progress for calls made on the *writing* thread — which is exactly what every save-and-restore call site wanted.
- A thread that set nothing reads the process-wide default, so background work with no explicit callback (the smart-preload thread, say) still reports into the host app's sink.
- `vtscore.media.set_progress_callback` now wires the startup sink through the new `MediaEmbedder.set_default_progress_callback` rather than a plain assignment, so it stays visible on every thread instead of becoming the startup thread's override.

The slot is created lazily via an atomic `dict.setdefault`, so a subclass that never calls `super().__init__()` still gets one and two threads racing to create it agree on one winner.

Call sites that temporarily redirect progress now use the `progress_scope()` context manager instead of hand-rolled `original_cb` / `try:` / `finally:` triples: the embed + patch/structural back-fill passes, the clipper re-embed, the three demo-dataset model loads (audio/text/video), the image demo source, and the CLI preloader.

`vtsearch/routes/sorting.py` keeps `_embedder_load_lock` (it also stops two requests both driving a model load); only its docstring changed, since the callback trample it was guarding against is now impossible.

## Tests

New `tests_lib/datasets/test_embed_progress_isolation.py`. Two `embed_missing` calls overlap deterministically — each parks mid-bulk on its own gate, and the first is resumed and joined *while the second is still parked*, so the second's callback is the most recently installed one when the first emits. Verified the new tests fail against the old shared-slot semantics and pass with the fix:

- each load's progress reaches only its own tracker;
- a cancelling tracker aborts only its own pass (the survivor's dataset is fully embedded, the cancelled one embedded nothing);
- `progress_scope` is thread-local over a shared default, nests, and restores on exception;
- a bare `_on_progress` assignment is likewise thread-scoped.

Three existing tests used `MagicMock` embedders and asserted the routing contract; a mock's auto-generated `progress_scope` enters and exits without touching `_on_progress`, so they now wire a real one via the new `wire_mock_progress_scope()` helper (added to both `tests/helpers.py` and `tests_lib/helpers.py`, which are intentional duplicates).

`./run-tests.sh` (7919 passed, 1 skipped) and `./run-tests.sh vtscore-clean` (3840 passed) both green.

## Docs

`docs/ARCHITECTURE.md` and `docs/EXTENDING-media.md` now describe `_on_progress` as thread-scoped and point plugin authors at `progress_scope()`.

## Backwards compatibility

`MediaEmbedder.__init__` is gone (the attribute is now class-level), and any out-of-tree code that set `emb._on_progress` on one thread expecting another thread to observe it must call `set_default_progress_callback` instead. No in-tree caller did.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4qhHh2owEXdjT2pM7gKpx)_