### PR TITLE
Close the SSRF DNS-rebinding window with a peer-address recheck

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -876,7 +876,16 @@ DATASOURCE_IMPORTER = PastebinDataSourceImporter()
 `fetch()` receives the validated + normalized form values (text stripped;
 `url` / `server_path` fields already passed the shared SSRF /
 path-traversal validators — see `vtscore/plugins/normalize.py`). `file`
-fields arrive as `UploadedFile` objects. Raise `ValueError` for bad user
+fields arrive as `UploadedFile` objects.
+
+That up-front `url` check vets a *hostname*, so it is only half the guard:
+issue the actual fetch on a
+`vtscore.security.url_validation.guarded_session()` (or go through
+`fetch_validated_url` / `download_file_with_progress`, which already do).
+A bare `requests.get` resolves the hostname a second time at connect time,
+and a DNS server the attacker controls gets to answer that lookup with
+`127.0.0.1`; the guarded session rejects the connection by peer address, so
+the name it was validated under stops mattering. Raise `ValueError` for bad user
 input (surfaced as a 400); any other exception is reported as an upstream
 failure (502). The returned `FetchedMediaItem.filename` should keep the
 source's real extension — it drives media-type inference downstream.

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -1125,7 +1125,18 @@ def glob_top_level(root: Path, pattern: str) -> list[Path]: ...
 
 def validate_url(url: str) -> str:
     """SSRF guard for outbound HTTP. Rejects private IPs, link-local, and metadata
-    endpoints. Returns the validated URL."""
+    endpoints. Returns the validated URL. A name-level check only — pair it with
+    `guarded_session` so the address the socket reaches is checked too."""
+
+class BlockedAddressError(ValueError):
+    """Raised when a connection's peer turns out to be a private/internal address."""
+
+def guarded_session() -> requests.Session:
+    """A Session whose every new socket has its peer address re-checked against the
+    private/internal blocklist (raising `BlockedAddressError`), closing the
+    DNS-rebinding window where the connect-time lookup returns a different address
+    than the one `validate_url` vetted. Proxied requests are exempt (the peer is the
+    proxy). Every server-side fetch of a user-influenced URL must run on one."""
 
 def open_validated_stream(
     session: requests.Session,
@@ -1136,12 +1147,14 @@ def open_validated_stream(
 ) -> requests.Response:
     """Stream an *already-validated* URL with allow_redirects=False, re-running
     validate_url on every hop so a public URL can't 302 to an internal host.
-    `headers_for_url` is recomputed per hop so host-scoped credentials aren't
-    replayed to a redirect target. Caller closes the returned response."""
+    Pass a `guarded_session`. `headers_for_url` is recomputed per hop so
+    host-scoped credentials aren't replayed to a redirect target. Caller closes
+    the returned response."""
 
 def fetch_validated_url(url: str, *, timeout: tuple[float, float] = (10, 30)) -> bytes:
-    """validate_url + open_validated_stream + raise_for_status, returning the whole
-    body. The fetch primitive for byte-wanting callers (e.g. a media's media_url)."""
+    """validate_url + guarded_session + open_validated_stream + raise_for_status,
+    returning the whole body. The fetch primitive for byte-wanting callers (e.g. a
+    media's media_url)."""
 
 def validate_browser_url(url: str) -> str:
     """Scheme allowlist for URLs the *user's browser* opens (an exporter's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,12 @@ dependencies = [
     "werkzeug",
     "numpy",
     "requests",
+    # requests' own transport layer, imported directly by
+    # vtscore.security.url_validation to subclass the connection/pool classes
+    # its SSRF-guarded session mounts (the peer-address recheck that closes the
+    # DNS-rebinding window). The floor is also a CVE pin (CVE-2026-44431,
+    # CVE-2026-44432).
+    "urllib3>=2.7.0",
     "tqdm",
     "scikit-learn",
     # Imported directly by vtscore.embedding.loader for the startup

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,5 +14,6 @@
 # Transitive-dep security pin (not imported directly; required to keep
 # `pip-audit` clean in `run-tests.sh`). Drop the line if the version
 # pulled by requests/huggingface-hub already satisfies the constraint.
-urllib3>=2.7.0  # CVE-2026-44431, CVE-2026-44432
+# (urllib3's own pin lives in `[project.dependencies]` — we import it
+# directly for the SSRF guard's peer-checking transport adapter.)
 idna>=3.15  # CVE-2026-45409

--- a/tests/io/test_csv_webhook_exporters.py
+++ b/tests/io/test_csv_webhook_exporters.py
@@ -690,7 +690,7 @@ class TestWebhookExporterExport:
         mock_resp.raise_for_status.return_value = None
 
         with (
-            mock.patch("vtscore.exporters.webhook.requests.post", return_value=mock_resp) as mock_post,
+            mock.patch("requests.Session.post", return_value=mock_resp) as mock_post,
         ):
             result = exp.export(results, {"url": "https://example.com/hook"})
 
@@ -711,7 +711,7 @@ class TestWebhookExporterExport:
         mock_resp.raise_for_status.return_value = None
 
         with (
-            mock.patch("vtscore.exporters.webhook.requests.post", return_value=mock_resp) as mock_post,
+            mock.patch("requests.Session.post", return_value=mock_resp) as mock_post,
         ):
             exp.export(results, {"url": "https://example.com/hook", "auth_header": "Bearer my-token"})
 
@@ -729,7 +729,7 @@ class TestWebhookExporterExport:
         mock_resp.raise_for_status.return_value = None
 
         with (
-            mock.patch("vtscore.exporters.webhook.requests.post", return_value=mock_resp) as mock_post,
+            mock.patch("requests.Session.post", return_value=mock_resp) as mock_post,
         ):
             exp.export(results, {"url": "https://example.com/hook", "auth_header": ""})
 
@@ -745,7 +745,7 @@ class TestWebhookExporterExport:
         mock_resp = mock.MagicMock()
         mock_resp.raise_for_status.side_effect = Exception("500 Server Error")
 
-        with mock.patch("vtscore.exporters.webhook.requests.post", return_value=mock_resp):
+        with mock.patch("requests.Session.post", return_value=mock_resp):
             with pytest.raises(Exception, match="500 Server Error"):
                 exp.export(results, {"url": "https://example.com/hook"})
 
@@ -759,7 +759,7 @@ class TestWebhookExporterExport:
         mock_resp.status_code = 200
         mock_resp.raise_for_status.return_value = None
 
-        with mock.patch("vtscore.exporters.webhook.requests.post", return_value=mock_resp):
+        with mock.patch("requests.Session.post", return_value=mock_resp):
             result = exp.export(results, {"url": "https://example.com/hook"})
 
         assert "3 hit(s)" in result["message"]
@@ -775,7 +775,7 @@ class TestWebhookExporterExport:
         mock_resp.status_code = 201
         mock_resp.raise_for_status.return_value = None
 
-        with mock.patch("vtscore.exporters.webhook.requests.post", return_value=mock_resp):
+        with mock.patch("requests.Session.post", return_value=mock_resp):
             result = exp.export(results, {"url": "https://example.com/hook"})
 
         assert result["status_code"] == 201
@@ -793,7 +793,7 @@ class TestWebhookExporterIntegration:
 
         with (
             mock.patch("vtscore.security.url_validation.validate_url"),
-            mock.patch("vtscore.exporters.webhook.requests.post", return_value=mock_resp),
+            mock.patch("requests.Session.post", return_value=mock_resp),
         ):
             _run_exporter("webhook", {"url": "https://example.com/hook"}, results)
 

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -1199,7 +1199,7 @@ class TestWebhookStreaming:
     def test_batches_hits_into_separate_posts(self):
         from vtscore.exporters import get_exporter
 
-        with patch("vtscore.exporters.webhook.requests.post", return_value=self._mock_post()) as mock_post:
+        with patch("requests.Session.post", return_value=self._mock_post()) as mock_post:
             res = get_exporter("webhook").export_cli_streaming(
                 _STREAM_HEADER, _stream_records(), {"url": "https://ex.com/hook", "batch_size": 2}
             )
@@ -1220,7 +1220,7 @@ class TestWebhookStreaming:
     def test_auth_header_forwarded(self):
         from vtscore.exporters import get_exporter
 
-        with patch("vtscore.exporters.webhook.requests.post", return_value=self._mock_post()) as mock_post:
+        with patch("requests.Session.post", return_value=self._mock_post()) as mock_post:
             get_exporter("webhook").export_cli_streaming(
                 _STREAM_HEADER,
                 _stream_records(),
@@ -1232,7 +1232,7 @@ class TestWebhookStreaming:
     def test_empty_run_still_posts_once(self):
         from vtscore.exporters import get_exporter
 
-        with patch("vtscore.exporters.webhook.requests.post", return_value=self._mock_post()) as mock_post:
+        with patch("requests.Session.post", return_value=self._mock_post()) as mock_post:
             res = get_exporter("webhook").export_cli_streaming(_STREAM_HEADER, iter([]), {"url": "https://ex.com/hook"})
 
         assert mock_post.call_count == 1
@@ -1243,7 +1243,7 @@ class TestWebhookStreaming:
     def test_default_batch_size_sends_single_post(self):
         from vtscore.exporters import get_exporter
 
-        with patch("vtscore.exporters.webhook.requests.post", return_value=self._mock_post()) as mock_post:
+        with patch("requests.Session.post", return_value=self._mock_post()) as mock_post:
             get_exporter("webhook").export_cli_streaming(
                 _STREAM_HEADER, _stream_records(), {"url": "https://ex.com/hook"}
             )

--- a/tests_lib/core/test_ssrf_validation.py
+++ b/tests_lib/core/test_ssrf_validation.py
@@ -2,14 +2,18 @@
 
 Verifies that :func:`vtscore.security.url_validation.validate_url` blocks
 requests to private/internal network addresses while allowing public URLs,
-that :func:`~vtscore.security.url_validation.open_validated_stream` re-checks
-every redirect hop, and that the HTTP archive importer, the webhook exporter,
-and the ``media_url`` media fetch all go through the guard.
+that :func:`~vtscore.security.url_validation.guarded_session` re-checks the
+peer address each socket actually reaches (so a rebinding DNS answer cannot
+slip past the name check), that
+:func:`~vtscore.security.url_validation.open_validated_stream` re-checks every
+redirect hop, and that the HTTP archive importer, the webhook exporter, and the
+``media_url`` media fetch all go through the guard.
 """
 
 from __future__ import annotations
 
-from typing import cast
+import socket as socket_mod
+from typing import Any, cast
 from unittest import mock
 
 import pytest
@@ -147,6 +151,209 @@ class TestValidateUrlPrivateIPs:
         ):
             with pytest.raises(ValueError, match="private/internal"):
                 validate_url("http://dual-homed.example/")
+
+
+# ---------------------------------------------------------------------------
+# guarded_session – peer-address recheck (DNS rebinding)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def loopback_listener():
+    """A real listening socket on ``127.0.0.1``; yields its port.
+
+    Nothing ever accepts on it - a TCP connect still completes through the
+    listen backlog, which is all the peer check needs to observe an address.
+    """
+    srv = socket_mod.socket()
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    try:
+        yield srv.getsockname()[1]
+    finally:
+        srv.close()
+
+
+class TestGuardedSessionPeerCheck:
+    """``validate_url`` vets a *name*; the socket connects to an *address*.
+
+    Between the two lookups an attacker who runs DNS for their own hostname can
+    swap the answer (DNS rebinding), so the name check alone proves nothing.
+    These tests drive the real socket path: the address is never mocked, only
+    the DNS answer ``validate_url`` sees.
+    """
+
+    def _public_dns_answer(self):
+        """Make ``validate_url`` believe any hostname is publicly routable."""
+        return mock.patch(
+            "vtscore.security.url_validation.socket.getaddrinfo",
+            return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
+        )
+
+    def _session(self):
+        from vtscore.security.url_validation import guarded_session
+
+        session = guarded_session()
+        # Ignore any ambient HTTP(S)_PROXY: a proxied request is peer-checked at
+        # the proxy, which is exactly the case this test must not exercise.
+        session.trust_env = False
+        return session
+
+    def test_rebinding_to_loopback_is_blocked_at_connect(self, loopback_listener):
+        from vtscore.security.url_validation import BlockedAddressError
+
+        url = f"http://localhost:{loopback_listener}/admin"
+        with self._public_dns_answer():
+            # The name check is fooled by the attacker's first DNS answer...
+            assert validate_url(url) == url
+        # ...but the socket lands on 127.0.0.1, and that is what gets checked.
+        with self._session() as session:
+            with pytest.raises(BlockedAddressError, match="private/internal"):
+                session.get(url, timeout=5)
+
+    def test_https_is_blocked_before_the_tls_handshake(self, loopback_listener):
+        """The hook is on the bare socket, so no SNI or request byte is sent."""
+        from vtscore.security.url_validation import BlockedAddressError
+
+        with self._session() as session:
+            with pytest.raises(BlockedAddressError, match="private/internal"):
+                session.get(f"https://localhost:{loopback_listener}/admin", timeout=5)
+
+    def test_a_plain_session_is_not_guarded(self, loopback_listener):
+        """Pins why the guard has to be mounted: a bare session has no check.
+
+        The connect succeeds and the request goes out (there is no server, so it
+        stalls on the read) - the point is that nothing rejects the address.
+        """
+        from vtscore.security.url_validation import BlockedAddressError
+
+        session = requests.Session()
+        session.trust_env = False
+        with session:
+            with pytest.raises(requests.RequestException) as excinfo:
+                session.get(f"http://localhost:{loopback_listener}/admin", timeout=(5, 0.5))
+        assert not isinstance(excinfo.value, BlockedAddressError)
+
+    def test_blocked_error_is_a_value_error(self):
+        """Callers already treat a failed guard as ``ValueError``; keep it so."""
+        from vtscore.security.url_validation import BlockedAddressError
+
+        assert issubclass(BlockedAddressError, ValueError)
+
+
+class _FakeSocket:
+    """Just enough socket for the peer check: an address and a close flag."""
+
+    def __init__(self, peer):
+        self._peer = peer
+        self.closed = False
+
+    def getpeername(self):
+        if self._peer is None:
+            raise OSError("not connected")
+        return self._peer
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeConn:
+    def __init__(self, proxy=None):
+        self.proxy = proxy
+
+
+def _check_peer(peer, proxy=None) -> tuple[_FakeSocket, object]:
+    """Run the peer check over a stubbed socket; return the socket and result."""
+    from vtscore.security.url_validation import _reject_internal_peer
+
+    sock = _FakeSocket(peer)
+    returned = _reject_internal_peer(cast(Any, _FakeConn(proxy)), cast(Any, sock))
+    return sock, returned
+
+
+class TestRejectInternalPeer:
+    """Unit coverage for the peer check itself, socket layer stubbed out."""
+
+    def test_public_peer_passes_through(self):
+        sock, returned = _check_peer(("93.184.216.34", 443))
+        assert returned is sock
+        assert not sock.closed
+
+    @pytest.mark.parametrize(
+        "ip",
+        ["127.0.0.1", "169.254.169.254", "10.0.0.5", "192.168.1.1", "172.16.0.1", "0.0.0.0", "::1"],
+    )
+    def test_internal_peer_is_rejected(self, ip):
+        from vtscore.security.url_validation import BlockedAddressError
+
+        with pytest.raises(BlockedAddressError, match="private/internal"):
+            _check_peer((ip, 80))
+
+    def test_rejected_socket_is_closed(self):
+        """Nothing is left half-open for the caller to accidentally write to."""
+        from vtscore.security.url_validation import BlockedAddressError, _reject_internal_peer
+
+        sock = _FakeSocket(("127.0.0.1", 80))
+        with pytest.raises(BlockedAddressError):
+            _reject_internal_peer(cast(Any, _FakeConn()), cast(Any, sock))
+        assert sock.closed
+
+    def test_unreadable_peer_fails_closed(self):
+        """A socket we cannot read the peer of is a socket we cannot vouch for."""
+        from vtscore.security.url_validation import BlockedAddressError
+
+        with pytest.raises(BlockedAddressError, match="unknown"):
+            _check_peer(None)
+
+    def test_proxied_connection_is_exempt(self):
+        """Through a proxy the peer *is* the proxy, often legitimately private."""
+        sock, returned = _check_peer(("127.0.0.1", 3128), proxy="http://127.0.0.1:3128")
+        assert returned is sock
+        assert not sock.closed
+
+
+class TestGuardedSessionWiring:
+    """The guard is only worth anything if it is actually mounted."""
+
+    def test_both_schemes_get_the_guarded_adapter(self):
+        from vtscore.security.url_validation import _GuardedHTTPAdapter, guarded_session
+
+        with guarded_session() as session:
+            for prefix in ("http://x/", "https://x/"):
+                assert isinstance(session.get_adapter(prefix), _GuardedHTTPAdapter)
+
+    def test_pool_manager_hands_out_guarded_connections(self):
+        from vtscore.security.url_validation import (
+            _GuardedHTTPConnection,
+            _GuardedHTTPSConnection,
+            guarded_session,
+        )
+
+        with guarded_session() as session:
+            manager = session.get_adapter("https://x/").poolmanager  # type: ignore[attr-defined]
+            assert manager.pool_classes_by_scheme["http"].ConnectionCls is _GuardedHTTPConnection
+            assert manager.pool_classes_by_scheme["https"].ConnectionCls is _GuardedHTTPSConnection
+
+    def test_the_downloader_fetches_on_a_guarded_session(self):
+        """A validated URL handed to a bare session is the rebinding hole."""
+        from vtscore.security.url_validation import _GuardedHTTPAdapter
+
+        captured: list[requests.Session] = []
+
+        def fake_stream(session, url, headers=None):
+            captured.append(session)
+            raise requests.ConnectionError("stop here")
+
+        with mock.patch("vtscore.datasets.downloader.core._open_validated_stream", fake_stream):
+            from vtscore.datasets.downloader.core import fetch_remote_signature
+
+            with mock.patch(
+                "vtscore.security.url_validation.socket.getaddrinfo",
+                return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
+            ):
+                assert fetch_remote_signature("https://public.example/a.zip") is None
+        assert captured, "the downloader never opened a stream"
+        assert isinstance(captured[0].get_adapter("https://x/"), _GuardedHTTPAdapter)
 
 
 # ---------------------------------------------------------------------------
@@ -304,7 +511,7 @@ class TestFetchValidatedUrl:
     def test_rejects_file_scheme_before_any_request(self):
         from vtscore.security.url_validation import fetch_validated_url
 
-        with mock.patch("vtscore.security.url_validation.requests.Session") as mock_session:
+        with mock.patch("vtscore.security.url_validation.guarded_session") as mock_session:
             with pytest.raises(ValueError, match="http or https"):
                 fetch_validated_url("file:///etc/passwd")
         mock_session.assert_not_called()
@@ -316,7 +523,7 @@ class TestFetchValidatedUrl:
             "vtscore.security.url_validation.socket.getaddrinfo",
             return_value=[(2, 1, 0, "", ("127.0.0.1", 0))],
         ):
-            with mock.patch("vtscore.security.url_validation.requests.Session") as mock_session:
+            with mock.patch("vtscore.security.url_validation.guarded_session") as mock_session:
                 with pytest.raises(ValueError, match="private/internal"):
                     fetch_validated_url("http://localhost:5000/api/settings")
         mock_session.assert_not_called()
@@ -329,7 +536,7 @@ class TestFetchValidatedUrl:
             "vtscore.security.url_validation.socket.getaddrinfo",
             return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
         ):
-            with mock.patch("vtscore.security.url_validation.requests.Session", return_value=session):
+            with mock.patch("vtscore.security.url_validation.guarded_session", return_value=session):
                 assert fetch_validated_url("https://public.example/m.wav") == b"media-bytes"
 
     def test_raises_on_error_status(self):
@@ -340,7 +547,7 @@ class TestFetchValidatedUrl:
             "vtscore.security.url_validation.socket.getaddrinfo",
             return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
         ):
-            with mock.patch("vtscore.security.url_validation.requests.Session", return_value=session):
+            with mock.patch("vtscore.security.url_validation.guarded_session", return_value=session):
                 with pytest.raises(requests.HTTPError):
                     fetch_validated_url("https://public.example/missing.wav")
 
@@ -368,7 +575,7 @@ class TestMediaUrlSSRF:
     def test_non_http_media_url_fetches_nothing(self, url):
         from vtscore.media.base import _fetch_media_url
 
-        with mock.patch("vtscore.security.url_validation.requests.Session") as mock_session:
+        with mock.patch("vtscore.security.url_validation.guarded_session") as mock_session:
             assert _fetch_media_url(url) is None
         mock_session.assert_not_called()
 
@@ -380,7 +587,7 @@ class TestMediaUrlSSRF:
             "vtscore.security.url_validation.socket.getaddrinfo",
             return_value=[(2, 1, 0, "", (ip, 0))],
         ):
-            with mock.patch("vtscore.security.url_validation.requests.Session") as mock_session:
+            with mock.patch("vtscore.security.url_validation.guarded_session") as mock_session:
                 assert _fetch_media_url(f"http://{ip}/latest/meta-data/") is None
         mock_session.assert_not_called()
 
@@ -392,7 +599,7 @@ class TestMediaUrlSSRF:
             "vtscore.security.url_validation.socket.getaddrinfo",
             return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
         ):
-            with mock.patch("vtscore.security.url_validation.requests.Session", return_value=session):
+            with mock.patch("vtscore.security.url_validation.guarded_session", return_value=session):
                 assert _fetch_media_url("https://pullwrest.example/media/123") == b"remote-media"
 
     def test_resolve_media_bytes_refuses_a_file_url(self, tmp_path):
@@ -492,7 +699,7 @@ class TestWebhookExporterSSRF:
             "vtscore.security.url_validation.socket.getaddrinfo",
             return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
         ):
-            with mock.patch("vtscore.exporters.webhook.requests.post", return_value=mock_resp):
+            with mock.patch("requests.Session.post", return_value=mock_resp):
                 result = exp.export(
                     {"detectors_run": 0, "results": {}},
                     {"url": "https://example.com/hook"},

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -21,7 +21,7 @@ import requests
 from vtscore.config import DATA_DIR
 from vtscore.security.archive import safe_tar_extract
 from vtscore.security.hf_auth import GatedResourceError, auth_header_for_url
-from vtscore.security.url_validation import open_validated_stream, validate_url
+from vtscore.security.url_validation import guarded_session, open_validated_stream, validate_url
 
 # Statuses that mean "this resource is gated / needs credentials we don't have".
 # These are surfaced as a short, actionable GatedResourceError rather than a
@@ -388,7 +388,7 @@ def download_file_with_progress(  # noqa: C901
     if on_progress is None:
         on_progress = _default_progress()
 
-    session = requests.Session()
+    session = guarded_session()
     downloaded = 0  # bytes already on disk at dest_path
     total_size = 0  # full size of the file once known
     # Resume relies on the server honoring Range requests on the *raw* body.
@@ -469,7 +469,7 @@ def fetch_remote_signature(url: str) -> Optional[str]:
     """
     try:
         validate_url(url)
-        session = requests.Session()
+        session = guarded_session()
         response = _open_validated_stream(session, url, headers={"Range": "bytes=0-0"})
     except Exception:
         return None

--- a/vtscore/exporters/webhook/__init__.py
+++ b/vtscore/exporters/webhook/__init__.py
@@ -1,15 +1,20 @@
 """Webhook exporter – POSTs auto-detect results to an arbitrary URL.
 
 Requires only ``requests``, which is already a core dependency.
+
+The target URL is user-supplied, so every POST goes out on a
+:func:`~vtscore.security.url_validation.guarded_session`: the framework's
+``field_type="url"`` normalize pass rejects internal hosts up front, and the
+guarded session re-checks the peer address each socket actually reaches so a
+rebinding DNS answer cannot redirect the payload at an internal service.
 """
 
 from __future__ import annotations
 
 from typing import Any, Iterator
 
-import requests
-
 from vtscore.exporters.base import PluginField, LabelsetExporter, resolve_stream_batch_size
+from vtscore.security.url_validation import guarded_session
 
 
 class WebhookLabelsetExporter(LabelsetExporter):
@@ -65,8 +70,9 @@ class WebhookLabelsetExporter(LabelsetExporter):
         url = field_values["url"]
         headers = self._headers(field_values)
 
-        resp = requests.post(url, json=results, headers=headers, timeout=30, allow_redirects=False)
-        resp.raise_for_status()
+        with guarded_session() as session:
+            resp = session.post(url, json=results, headers=headers, timeout=30, allow_redirects=False)
+            resp.raise_for_status()
 
         if "labels" in results:
             total_items = len(results.get("labels", []))
@@ -116,24 +122,28 @@ class WebhookLabelsetExporter(LabelsetExporter):
         total_hits = 0
         batches = 0
 
-        def _post(hits: list[dict[str, Any]]) -> None:
-            nonlocal batches
-            payload = {**meta, "batch_index": batches, "hits": hits}
-            resp = requests.post(url, json=payload, headers=headers, timeout=30, allow_redirects=False)
-            resp.raise_for_status()
-            batches += 1
+        # One session for the whole run so connections are reused across
+        # batches; each new socket it opens is still peer-checked.
+        with guarded_session() as session:
 
-        batch: list[dict[str, Any]] = []
-        for detector_name, hit in records:
-            batch.append({"detector": detector_name, **hit})
-            total_hits += 1
-            if len(batch) >= batch_size:
+            def _post(hits: list[dict[str, Any]]) -> None:
+                nonlocal batches
+                payload = {**meta, "batch_index": batches, "hits": hits}
+                resp = session.post(url, json=payload, headers=headers, timeout=30, allow_redirects=False)
+                resp.raise_for_status()
+                batches += 1
+
+            batch: list[dict[str, Any]] = []
+            for detector_name, hit in records:
+                batch.append({"detector": detector_name, **hit})
+                total_hits += 1
+                if len(batch) >= batch_size:
+                    _post(batch)
+                    batch = []
+            # Flush the trailing partial batch; also fire once for an empty run
+            # so the receiver always gets at least one POST.
+            if batch or batches == 0:
                 _post(batch)
-                batch = []
-        # Flush the trailing partial batch; also fire once for an empty run so
-        # the receiver always gets at least one POST.
-        if batch or batches == 0:
-            _post(batch)
 
         return {
             "message": (f"Streamed {total_hits} hit(s) to {url} in {batches} batch(es)."),

--- a/vtscore/security/url_validation.py
+++ b/vtscore/security/url_validation.py
@@ -19,19 +19,43 @@ every server-side URL fetch is meant to go through.  A single up-front
 internal host, so the redirect chain has to be walked by hand with each hop
 re-checked.  Keeping that loop here rather than in one caller is what stops
 the next fetch site from quietly re-introducing a bypass.
+
+Name-based checks have a second, subtler hole: :func:`validate_url` vets the
+addresses a *hostname* resolved to, but the fetch that follows resolves that
+name **again** inside urllib3.  An attacker who runs the authoritative DNS for
+their own hostname can answer the validation lookup with a public IP and the
+connect-time lookup with ``127.0.0.1`` / ``169.254.169.254`` (classic DNS
+rebinding), so passing the name check proves nothing about where the socket
+lands.  :func:`guarded_session` closes that window by re-checking the *peer
+address* of every freshly connected socket, before TLS or any request bytes.
+Server-side fetches must issue their requests on such a session — validating
+the URL and then handing it to a bare :class:`requests.Session` is the hole.
 """
 
 from __future__ import annotations
 
 import ipaddress
 import socket
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 from urllib.parse import urljoin, urlparse
 
 import requests
+from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.poolmanager import PoolManager
 
 #: Redirect hops :func:`open_validated_stream` will follow before giving up.
 MAX_REDIRECTS = 10
+
+
+class BlockedAddressError(ValueError):
+    """A socket connected to a private/internal peer address and was dropped.
+
+    Subclasses :class:`ValueError` so every caller that already treats a
+    rejected :func:`validate_url` as a ``ValueError`` handles a rebinding block
+    the same way, without a new except clause.
+    """
 
 
 def _is_private_ip(ip_str: str) -> bool:
@@ -79,6 +103,124 @@ def validate_url(url: str) -> str:
     return url
 
 
+def _reject_internal_peer(conn: HTTPConnection, sock: socket.socket) -> socket.socket:
+    """Return *sock* unless its peer is an internal address, in which case close
+    it and raise :class:`BlockedAddressError`.
+
+    This is the anti-rebinding half of the SSRF guard.  ``validate_url`` vets a
+    *name*; this vets the *address* the kernel actually connected to, which is
+    the only thing an attacker's second DNS answer cannot lie about.
+
+    Failing closed matters here: a socket whose peer we cannot read is a socket
+    we cannot vouch for, so an unreadable ``getpeername`` is treated as a block
+    rather than waved through.
+    """
+    if getattr(conn, "proxy", None) is not None:
+        # Through a proxy the peer *is* the proxy — routinely a private or
+        # loopback address, legitimately so — and the origin hostname is
+        # resolved at the far end where we cannot see it.  Blocking on the
+        # proxy's address would break every proxied deployment while buying
+        # nothing, so the peer check does not apply.
+        return sock
+    try:
+        peer = sock.getpeername()
+        ip_str = str(peer[0]) if peer else ""
+    except OSError:
+        ip_str = ""
+    if not ip_str or _is_private_ip(ip_str):
+        sock.close()
+        raise BlockedAddressError(
+            f"URL points to a private/internal network address ({ip_str or 'unknown'}). "
+            "Only publicly routable URLs are allowed."
+        )
+    return sock
+
+
+class _GuardedHTTPConnection(HTTPConnection):
+    """An ``http://`` connection that vets its peer address once connected.
+
+    The hook is ``_new_conn`` rather than ``connect`` so the check sees the bare
+    TCP socket: for HTTPS that is *before* the handshake leaks the hostname via
+    SNI, and for both schemes before a single request byte is written.
+    """
+
+    def _new_conn(self) -> socket.socket:
+        return _reject_internal_peer(self, super()._new_conn())
+
+
+class _GuardedHTTPSConnection(HTTPSConnection):
+    """The ``https://`` counterpart of :class:`_GuardedHTTPConnection`."""
+
+    def _new_conn(self) -> socket.socket:
+        return _reject_internal_peer(self, super()._new_conn())
+
+
+# ``ConnectionCls`` is annotated as urllib3's ``BaseHTTP[S]Connection``
+# *protocol*, which its own concrete ``HTTP[S]Connection`` does not structurally
+# satisfy (mutable ``host``/``assert_hostname`` are invariant), so assigning any
+# subclass of the concrete class trips reportAssignmentType. urllib3 makes the
+# identical assignment internally; the subclasses below only override
+# ``_new_conn``.
+class _GuardedHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = _GuardedHTTPConnection  # pyright: ignore[reportAssignmentType]
+
+
+class _GuardedHTTPSConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = _GuardedHTTPSConnection  # pyright: ignore[reportAssignmentType]
+
+
+class _GuardedPoolManager(PoolManager):
+    """A pool manager that hands out peer-checking connection pools."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.pool_classes_by_scheme = {
+            "http": _GuardedHTTPConnectionPool,
+            "https": _GuardedHTTPSConnectionPool,
+        }
+
+
+class _GuardedHTTPAdapter(HTTPAdapter):
+    """A ``requests`` transport adapter whose sockets re-check their peer IP."""
+
+    def init_poolmanager(
+        self, connections: int, maxsize: int, block: bool = DEFAULT_POOLBLOCK, **pool_kwargs: Any
+    ) -> None:
+        # Mirrors HTTPAdapter.init_poolmanager, swapping in the guarded manager.
+        # The three attributes it sets are what makes an adapter picklable.
+        self._pool_connections = connections
+        self._pool_maxsize = maxsize
+        self._pool_block = block
+        self.poolmanager = _GuardedPoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            **pool_kwargs,
+        )
+
+
+def guarded_session() -> requests.Session:
+    """Return a :class:`requests.Session` whose every connection is peer-checked.
+
+    The session behaves exactly like a plain one except that each freshly
+    opened socket has its peer address checked against the private/internal
+    blocklist and is dropped — with :class:`BlockedAddressError` — if it landed
+    somewhere internal.  That is what makes the up-front :func:`validate_url`
+    binding: without it, the hostname is resolved a second time at connect
+    time and a rebinding DNS server gets to pick the address that lookup
+    returns.
+
+    Every server-side fetch of a URL the user had any hand in should run on one
+    of these.  Requests routed through an HTTP proxy are exempt (see
+    :func:`_reject_internal_peer`).
+    """
+    session = requests.Session()
+    adapter = _GuardedHTTPAdapter()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
 def open_validated_stream(
     session: requests.Session,
     url: str,
@@ -103,7 +245,10 @@ def open_validated_stream(
     ``ValueError``.)
 
     Args:
-        session: The :class:`requests.Session` to issue each hop on.
+        session: The :class:`requests.Session` to issue each hop on.  Pass a
+            :func:`guarded_session`; a bare session re-resolves each hostname
+            at connect time, which is the DNS-rebinding hole the per-hop
+            :func:`validate_url` calls here cannot see.
         url: An already-validated HTTP(S) URL.
         headers_for_url: Optional callable returning the headers to send for a
             given hop's URL.  Recomputed per hop so credentials scoped to one
@@ -114,7 +259,9 @@ def open_validated_stream(
         The final, non-redirect response; the caller owns closing it.
 
     Raises:
-        ValueError: If a redirect hop fails :func:`validate_url`.
+        ValueError: If a redirect hop fails :func:`validate_url`, or (as
+            :class:`BlockedAddressError`) if a hop's socket lands on an
+            internal peer address.
         requests.TooManyRedirects: If the chain exceeds :data:`MAX_REDIRECTS`.
     """
 
@@ -158,15 +305,16 @@ def fetch_validated_url(url: str, *, timeout: tuple[float, float] = (10, 30)) ->
     The whole-body counterpart to :func:`open_validated_stream`, for the fetch
     sites that want bytes rather than a stream to spool to disk (see
     :func:`vtscore.media.base._fetch_media_url`).  Validates *url* up front,
-    re-validates every redirect hop, and raises for a non-2xx status.
+    re-validates every redirect hop, fetches on a :func:`guarded_session` so no
+    hop can rebind onto an internal address, and raises for a non-2xx status.
 
     Raises:
         ValueError: If *url* — or any redirect hop — is not a publicly
-            routable ``http(s)`` URL.
+            routable ``http(s)`` URL, or lands on an internal peer address.
         requests.RequestException: On any transport or HTTP error.
     """
     validate_url(url)
-    with requests.Session() as session:
+    with guarded_session() as session:
         response = open_validated_stream(session, url, timeout=timeout)
         with response:
             response.raise_for_status()


### PR DESCRIPTION
Closes #2950

## The hole

`validate_url` resolved the hostname, checked every returned IP against the private/loopback/reserved blocklist, and then returned the original URL **string**. Callers fetched by hostname again, so urllib3 resolved the name a *second* time at connect time. An attacker running authoritative DNS for their own hostname could answer the validation lookup with a public IP and the connect-time lookup with `127.0.0.1` / `169.254.169.254` — classic DNS rebinding — defeating the guard on the very first hop, even though every redirect hop after it was carefully re-checked.

## The fix

`vtscore.security.url_validation.guarded_session()` returns a `requests.Session` whose transport adapter mounts peer-checking urllib3 connection classes. Every freshly opened socket has its **peer address** checked against the same blocklist and is closed — raising `BlockedAddressError` — if it landed somewhere internal. An address is the one thing an attacker's second DNS answer cannot lie about, so the name it was validated under stops mattering.

Details worth knowing:

- **The hook is `_new_conn`, not `connect`**, so the check sees the bare TCP socket: for HTTPS that is *before* the handshake leaks the hostname via SNI, and for both schemes before a single request byte is written.
- **`BlockedAddressError` subclasses `ValueError`**, so every caller that already treats a rejected `validate_url` as a `ValueError` handles a rebinding block identically, with no new `except` clause.
- **It fails closed:** a socket whose `getpeername()` we cannot read is a socket we cannot vouch for, so that is a block too.
- **Proxied connections are exempt.** Through a proxy the peer *is* the proxy — routinely on a private or loopback address, legitimately — and the origin hostname is resolved at the far end where we cannot see it. Blocking on the proxy's address would break every proxied deployment while buying nothing.
- `validate_url` is unchanged and still runs up front: it fails fast, with a clear message, before a socket is opened at all.

## Fetch sites routed onto it

Every server-side fetch of a URL the user had a hand in:

- `fetch_validated_url` — the `media_url` lazy fetch.
- `download_file_with_progress` and `fetch_remote_signature` in `vtscore/datasets/downloader/core.py` — reached by the `url_download` importer, `UrlDownloadSource`, and `http_archive`.
- The webhook exporter's POSTs (one session reused across streaming batches, so connection reuse survives).

The arXiv / UCSF / HuggingFace-auth fetches are left on plain `requests`: their URLs are hardcoded constants, with no user-supplied host to rebind.

`urllib3` is now imported directly, so its CVE pin moves from `requirements/base.txt` into `[project.dependencies]` (deptry's source of truth) with a note on why we import it.

## Tests

New coverage in `tests_lib/core/test_ssrf_validation.py`:

- **The real rebinding scenario, end to end, with a real socket.** A loopback listener stands in for the internal service; only the DNS answer `validate_url` sees is mocked (public). `validate_url` passes — it is fooled, exactly as it would be in the attack — and then the guarded session's connect is rejected on `127.0.0.1`. The same test for `https://` proves the block lands before the TLS handshake.
- A companion test asserting a **plain** `requests.Session` is *not* guarded, pinning why the adapter has to be mounted rather than assumed.
- Unit coverage of the peer check across `127.0.0.1`, `169.254.169.254`, `10.x`, `192.168.x`, `172.16.x`, `0.0.0.0`, `::1`; that the rejected socket is closed; that an unreadable peer fails closed; and that a proxied connection is exempt.
- Wiring tests that the guarded adapter is mounted for both schemes, that its pool manager really hands out the guarded connection classes (so a future urllib3 refactor of the private `_new_conn` hook fails loudly instead of silently disarming the guard), and that the downloader opens its stream on a guarded session.

Existing webhook tests move from patching `vtscore.exporters.webhook.requests.post` to `requests.Session.post` — a name swap; call assertions are unchanged.

`./run-tests.sh` green (7983 passed, 1 skipped), as is `./run-tests.sh vtscore-clean` (3861 passed).

## Backwards compatibility

A fetch that lands on an internal address now raises where it previously succeeded. That is the point of the change, and no such fetch was ever intended to work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WpsS278ugtEz21o5tb1SkY)_