### PR TITLE
Add Apache-2.0 license, NOTICE, and packaging license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Sam Greenberg
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,51 @@
+VTSearch
+Copyright 2026 Sam Greenberg
+
+This product includes software developed as part of the VTSearch project
+(https://github.com/samggreenberg/VTSearch), licensed under the Apache
+License, Version 2.0. See the LICENSE file for the full terms.
+
+The Apache-2.0 grant in LICENSE covers the source code in this repository
+(the `vtsearch` application and the `vtscore` library). It does NOT cover
+third-party dependencies or machine-learning model weights, which carry
+their own separate terms.
+
+
+Machine-learning model weights
+------------------------------
+
+VTSearch downloads embedding-model weights at runtime; it does not vendor
+them. Each model is licensed by its own publisher, and some carry usage
+restrictions that are more limiting than this project's license. Notably:
+
+  * EUPE (Perception Encoder, facebookresearch) is released under the FAIR
+    Noncommercial Research License and may not be used commercially.
+  * DINOv3 (Meta) is gated on Hugging Face and requires accepting its
+    license before the weights can be downloaded.
+
+Embedders that carry such a restriction advertise it through the
+`license_notice` field on their descriptor, which the UI surfaces as a
+warning on the embedder picker. Review the terms of any model you enable
+before deploying VTSearch.
+
+
+Third-party dependencies
+------------------------
+
+Most of VTSearch's runtime dependencies are permissively licensed (BSD,
+MIT, Apache-2.0, ISC). Two are copyleft and are worth calling out for
+anyone redistributing VTSearch or building a product on top of `vtscore`:
+
+  * ultralytics (YOLO object detection) - AGPL-3.0-or-later.
+    Used by the image extractor and the image clipper.
+  * PyMuPDF - AGPL-3.0-or-later (or a commercial license from Artifex).
+    Used by the PDF importer and the document converters.
+
+Both are imported lazily but are declared as install-time dependencies, so
+a default install pulls them in. VTSearch's own Apache-2.0 grant is
+unaffected, but the AGPL terms may attach to a combined work you
+distribute or operate as a network service. Uninstall these packages (and
+forgo the features that use them), or obtain suitable commercial terms, if
+that is incompatible with your deployment.
+
+  * soxr (audio resampling) - LGPL-2.1-or-later.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ VTSearch has a plugin architecture for media types, data importers, results expo
 - **[docs/EXTENDING-media.md](docs/EXTENDING-media.md)**: media types, embedders, clippers, converters, media sources.
 - **[docs/EXTENDING-processors.md](docs/EXTENDING-processors.md)**: detectors, localizers, extractors.
 
+## License
+
+VTSearch is licensed under the [Apache License 2.0](LICENSE). That covers the source code in this repository: both the `vtsearch` application and the `vtscore` library.
+
+Two things it does **not** cover:
+
+- **Model weights are separately licensed.** VTSearch downloads embedding models at runtime rather than vendoring them, and each publisher sets its own terms; some are more restrictive than this project's license. EUPE (Perception Encoder) is released under the FAIR Noncommercial Research License and cannot be used commercially; DINOv3 is gated on Hugging Face and requires accepting its license before download. Embedders with a usage restriction advertise it via their descriptor's `license_notice` field, which the UI shows as a warning on the embedder picker. Check the terms of any model you enable before deploying.
+- **Two dependencies are copyleft.** `ultralytics` (used by the image extractor and clipper) and `PyMuPDF` (used by the PDF importer and document converters) are both AGPL-3.0. They are imported lazily but declared as install-time dependencies, so a default install pulls them in. VTSearch's own Apache-2.0 grant is unaffected, but the AGPL terms may attach to a combined work you redistribute or run as a network service. Uninstall those packages, or obtain commercial terms for them, if that doesn't suit your deployment.
+
+See [NOTICE](NOTICE) for the full attribution and dependency-licensing statement.
+
 ---
 
 *Readme Reader code phrase:* `all aboard the embedding express`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+# >= 77 for PEP 639 support (the SPDX `license` string + `license-files`
+# below); older setuptools only understands the deprecated table/classifier
+# form and errors on the expression.
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,6 +10,25 @@ name = "vtsearch"
 version = "0.1.0"
 requires-python = ">=3.10"
 description = "Media explorer for browsing and voting on audio, images, text, video, or documents"
+# Apache-2.0 covers this repository's source only. Embedding-model weights are
+# downloaded at runtime under their publishers' own terms (some noncommercial),
+# and two dependencies are AGPL-3.0 (ultralytics, PyMuPDF). See NOTICE.
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Web Environment",
+    "Framework :: Flask",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Multimedia",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Image Recognition",
+]
 
 # Runtime dependencies. These mirror requirements/base.txt + the per-plugin
 # requirements.txt files so deptry can verify that every imported package is

--- a/vtscore/README.md
+++ b/vtscore/README.md
@@ -133,4 +133,20 @@ for per-release notes.
 
 ## License
 
-Same as the parent `vtsearch` project - see the repository's `LICENSE` file.
+Apache License 2.0, same as the parent `vtsearch` project - see the
+repository's [`LICENSE`](../LICENSE) file.
+
+Two carve-outs matter if you are embedding `vtscore` in your own product:
+
+- **Model weights carry their own terms.** `vtscore` downloads embedding
+  models at runtime rather than vendoring them, and each publisher licenses
+  its own weights. Some are noncommercial (EUPE, under the FAIR
+  Noncommercial Research License) or gated (DINOv3). Embedders with a
+  restriction expose it through their descriptor's `license_notice` field.
+- **Two dependencies are AGPL-3.0**: `ultralytics` (image extractor and
+  clipper) and `PyMuPDF` (PDF importer and document converters). Both are
+  lazily imported but declared as install-time dependencies. The Apache-2.0
+  grant on `vtscore` itself is unaffected, but AGPL terms may attach to a
+  combined work you distribute or operate as a service.
+
+See [`NOTICE`](../NOTICE) for the full statement.


### PR DESCRIPTION
The repository had no `LICENSE` or `COPYING` file and no license metadata in `pyproject.toml`, so external consumers of `vtscore` had no grant of rights at all — default copyright applied. `vtscore/README.md` already pointed at a `LICENSE` file that did not exist.

Apache-2.0 was chosen over MIT/BSD for the explicit patent grant (this ships ML scoring code and an ONNX exporter, aimed at external consumers) and for the `NOTICE` mechanism, which gives the model-weight and dependency carve-outs a formal home.

## What's in here

- **`LICENSE`** — the canonical Apache-2.0 text, copyright placeholder filled in as `Copyright 2026 Sam Greenberg`.
- **`NOTICE`** — attribution plus the two carve-outs the Apache grant cannot cover (below).
- **`pyproject.toml`** — PEP 639 metadata: `license = "Apache-2.0"` (SPDX expression), `license-files = ["LICENSE", "NOTICE"]`, and trove classifiers. The build requirement moves from `setuptools>=61.0` to `>=77.0`, which is the floor for PEP 639 support; older setuptools errors on the expression form. Both install scripts already pin `setuptools<82` and upgrade, and nothing builds with `--no-build-isolation`, so this is satisfied. No `License ::` classifier is added — setuptools ≥77 rejects combining one with an SPDX expression.
- **`README.md` / `vtscore/README.md`** — License sections stating the carve-outs and linking to `NOTICE`.

## Carve-outs documented

- **Model weights are separately licensed.** Embedding models are downloaded at runtime, not vendored, and each publisher sets its own terms. EUPE is under the FAIR Noncommercial Research License; DINOv3 is gated on Hugging Face. Embedders with a restriction already expose it via their descriptor's `license_notice` field.
- **Two declared runtime dependencies are AGPL-3.0**: `ultralytics` (image extractor and clipper) and `PyMuPDF` (PDF importer and document converters). Both are lazily imported but declared in `[project.dependencies]`, so a default install pulls them in. The Apache-2.0 grant on this repo's own source is unaffected, but AGPL terms may attach to a combined work a downstream user distributes or runs as a network service. `soxr` is LGPL-2.1-or-later and is noted alongside them.

This PR documents that constraint rather than fixing it. Moving the two AGPL packages into optional extras so a default install is permissive-clean is filed separately as #3048, since it needs graceful-degradation paths, test-harness changes, and a deliberate decision about what the Docker images install.

## Testing

`./run-tests.sh` — `ALL 8129 TESTS PASSED (6 skipped, total: 8135)`. Includes ruff, `ruff format --check`, codespell, deptry, pip-audit, pyright, the eval/app sync gate, and the frontend build.

Closes #2977

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUZJp53rDswhcSb7fx6zAY
