### PR TITLE
Fix run-tests.sh timeout re-exec breaking `bash run-tests.sh` invocation

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,6 +21,13 @@
 
 set -euo pipefail
 cd "$(dirname "$0")"
+# Absolute, slash-containing path to this script. `$0` alone can be a bare
+# filename (e.g. `run-tests.sh` when invoked as `bash run-tests.sh`), which
+# makes `timeout`'s execvp do a PATH-only lookup below and fail with "No
+# such file or directory". We've already cd'd into dirname("$0"), so pwd
+# joined with basename("$0") is always absolute regardless of how we were
+# invoked.
+_self="$(pwd)/$(basename "$0")"
 
 # Wall-clock cap on the whole run.
 #
@@ -43,7 +50,7 @@ if [[ -z "${_VT_TIMEOUT_WRAPPED:-}" && "$VTSEARCH_TEST_TIMEOUT" != "0" ]] \
     # TERM first so pytest can print what it was doing; KILL 30s later for a
     # process too wedged to answer (exactly the defunct-worker case).
     set +e
-    timeout --signal=TERM --kill-after=30 "$VTSEARCH_TEST_TIMEOUT" "$0" "$@"
+    timeout --signal=TERM --kill-after=30 "$VTSEARCH_TEST_TIMEOUT" "$_self" "$@"
     _timeout_status=$?
     set -e
     if [[ $_timeout_status -eq 124 || $_timeout_status -eq 137 ]]; then


### PR DESCRIPTION
## Problem

`run-tests.sh` re-executes itself under `timeout` as a wall-clock cap, using `"$0"` as the re-exec target. When the script is invoked as `bash run-tests.sh` from the repo root, `$0` is the bare string `run-tests.sh` (no slash), so `timeout`'s `execvp` does a PATH-only lookup and fails:

```
timeout: failed to run command 'run-tests.sh': No such file or directory
```

This exits with status 127, which the existing 124/137 timeout-status check doesn't recognize either — so the failure surfaces as a confusing raw `timeout` error rather than a clear message. The documented `./run-tests.sh` form works only because `$0` then contains a slash.

## Fix

Resolve the script to an absolute, slash-containing path before re-exec'ing. Since the script already does `cd "$(dirname "$0")"` at startup, `pwd` at that point is exactly `dirname("$0")` — so `"$(pwd)/$(basename "$0")"` gives an absolute path regardless of how the script was invoked. Use that (`_self`) as the `timeout` re-exec target instead of the raw `"$0"`.

## Verification

- Reproduced the bug in isolation with a minimal test harness mirroring the same `cd`/re-exec structure: before the fix, `bash test_self.sh` invoked with a bare filename fails the same way `timeout` fails on `run-tests.sh`; after the fix, it resolves and re-execs correctly.
- Ran `bash run-tests.sh core -- -x` (the exact reproduction shape from the issue: bare `bash run-tests.sh` invocation) from the repo root — this now runs to completion instead of failing with the `timeout` PATH-lookup error, and all tests pass: `ALL 1504 TESTS PASSED (5 skipped, total: 1509)`.

Closes #2971

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014AZu3YLDhw5LpatneA3CpT)_