### PR TITLE
Add the SigLIP2-L (SO400M/384) image embedder

### DIFF
--- a/docker/Dockerfile.image-embedders
+++ b/docker/Dockerfile.image-embedders
@@ -19,6 +19,12 @@
 #                                                          *outputs*, not on
 #                                                          download access)
 #
+# The two SO400M/384 embedders — SigLIP2-L (google/siglip2-so400m-patch14-384)
+# and SigLIP-L (open_clip ViT-SO400M-14-SigLIP-384) — are installed and
+# selectable but deliberately NOT baked: their weights would add several GB
+# to the image, so they download lazily into the persistent /app/data volume
+# the first time a user picks one.
+#
 # SigLIP / SigLIP 2 / CLIP / DINOv2 are ungated on Hugging Face and
 # download during the build with no credentials.
 #

--- a/docker/Dockerfile.image-embedders.gpu
+++ b/docker/Dockerfile.image-embedders.gpu
@@ -19,6 +19,12 @@
 #                                                          *outputs*, not on
 #                                                          download access)
 #
+# The two SO400M/384 embedders — SigLIP2-L (google/siglip2-so400m-patch14-384)
+# and SigLIP-L (open_clip ViT-SO400M-14-SigLIP-384) — are installed and
+# selectable but deliberately NOT baked: their weights would add several GB
+# to the image, so they download lazily into the persistent /app/data volume
+# the first time a user picks one.
+#
 # Gated weights (DINOv3, optionally EUPE's GitHub clone) are sourced
 # from the host's ./model_cache/; populate it with
 # scripts/cache_gated_models.sh BEFORE building. See the comments in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,8 +71,8 @@ VTSearch/
 │   │   ├── clipper.py              Shared clipper logic
 │   │   ├── audio/                  Audio media type, embedders (CLAP, CLAP-Music, CLAP-General,
 │   │   │                           ParaSpeechCLAP, AST, Whisper), clippers, SpeechExtractor
-│   │   ├── image/                  Image media type, embedders (SigLIP default; SigLIP2, CLIP,
-│   │   │                           SIFT-VLAD single-vector; DINOv2, DINOv3, EUPE each with
+│   │   ├── image/                  Image media type, embedders (SigLIP default; SigLIP2, SigLIP2-L,
+│   │   │                           SigLIP-L, CLIP, SIFT-VLAD single-vector; DINOv2, DINOv3, EUPE each with
 │   │   │                           single + patch variants), clippers, ImageClassExtractor,
 │   │   │                           FaceLocalizer, OCRExtractor
 │   │   ├── text/                   Text media type, embedders (E5 default, BGE), clippers

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -302,6 +302,7 @@ embedder per media type should override the `is_default` property to return
 | `audio/embedder_whisper.py` | `AudioWhisperEncoderEmbedder` | audio | |
 | `image/embedder_siglip.py` | `ImageSiglipEmbedder` | image | ✅ |
 | `image/embedder_siglip2.py` | `ImageSiglip2Embedder` | image | |
+| `image/embedder_siglip2_l.py` | `ImageSiglip2LEmbedder` | image | |
 | `image/embedder_clip.py` | `ImageClipEmbedder` | image | |
 | `image/embedder_dinov2_single.py` / `_patch.py` | `ImageDinov2SingleEmbedder` / `ImageDinov2PatchEmbedder` | image | |
 | `image/embedder_dinov3_single.py` / `_patch.py` | `ImageDinov3SingleEmbedder` / `ImageDinov3PatchEmbedder` | image | |
@@ -557,6 +558,7 @@ loaded via `spec_from_file_location` so discovery still works.
 | `AudioWhisperEncoderEmbedder` | `whisper_encoder` | `audio` | Whisper-base encoder (openai/whisper-base), audio-only | 512 |
 | `ImageSiglipEmbedder` | `siglip` | `image` | SigLIP (google/siglip-base-patch16-224) | 768 |
 | `ImageSiglip2Embedder` | `siglip2` | `image` | SigLIP 2 (google/siglip2-base-patch16-224) | 768 |
+| `ImageSiglip2LEmbedder` | `siglip2_l` | `image` | SigLIP2-L (google/siglip2-so400m-patch14-384) | 1152 |
 | `ImageClipEmbedder` | `clip` | `image` | CLIP (openai/clip-vit-base-patch32) | 512 |
 | `ImageDinov2SingleEmbedder` / `ImageDinov2PatchEmbedder` | `dinov2_single` / `dinov2_patch` | `image` | DINOv2 ViT-B/14 (facebook/dinov2-base), ungated | 768 |
 | `ImageDinov3SingleEmbedder` / `ImageDinov3PatchEmbedder` | `dinov3_single` / `dinov3_patch` | `image` | DINOv3 ViT-B/16 (facebook/dinov3-vitb16-pretrain-lvd1689m), HF-gated | 768 |

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -135,6 +135,7 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 | Audio (`audio`) | `whisper_encoder` | Whisper-base encoder (`openai/whisper-base`, audio-only) | 512 |
 | Image (`image`) | `siglip` (default) | SigLIP (`google/siglip-base-patch16-224`) | 768 |
 | Image (`image`) | `siglip2` | SigLIP 2 (`google/siglip2-base-patch16-224`) | 768 |
+| Image (`image`) | `siglip2_l` | SigLIP2-L (`google/siglip2-so400m-patch14-384`) | 1152 |
 | Image (`image`) | `clip` | CLIP (`openai/clip-vit-base-patch32`) | 512 |
 | Image (`image`) | `dinov2_single` / `dinov2_patch` | DINOv2 ViT-B/14 (`facebook/dinov2-base`) | 768 |
 | Image (`image`) | `dinov3_single` / `dinov3_patch` | DINOv3 ViT-B/16 (`facebook/dinov3-vitb16-pretrain-lvd1689m`, gated) | 768 |

--- a/docs/vtscore-api.md
+++ b/docs/vtscore-api.md
@@ -112,6 +112,7 @@ E5_MODEL_ID: str             # Multilingual E5 text embedder
 BGE_MODEL_ID: str            # BGE text embedder variant
 SIGLIP_MODEL_ID: str
 SIGLIP2_MODEL_ID: str
+SIGLIP2_L_MODEL_ID: str
 CLIP_MODEL_ID: str
 DINOV2_MODEL_ID: str
 DINOV3_MODEL_ID: str

--- a/requirements/image-embedders.txt
+++ b/requirements/image-embedders.txt
@@ -3,6 +3,7 @@
 # Image-only deployment that ships every supported image embedder:
 #   * SigLIP   (google/siglip-base-patch16-224)         - default, text-capable, ungated
 #   * SigLIP 2 (google/siglip2-base-patch16-224)        - text-capable, ungated
+#   * SigLIP2-L (google/siglip2-so400m-patch14-384)     - text-capable, ungated, 1152-d
 #   * SigLIP-L (open_clip ViT-SO400M-14-SigLIP-384)     - text-capable, ungated, 1152-d
 
 #   * CLIP     (openai/clip-vit-base-patch32)           - text-capable, ungated

--- a/tests/detectors/test_image_embedders.py
+++ b/tests/detectors/test_image_embedders.py
@@ -506,14 +506,15 @@ class TestApiEmbeddersResponseShape:
         assert resp.status_code == 200
         body = resp.get_json()
         entries = {e["name"]: e for e in body["embedders"]}
-        # All image embedders must be present; four CLIP-family bimodal
-        # models (siglip, siglip2, siglip_l, clip), single/patch pairs for
+        # All image embedders must be present; five CLIP-family bimodal
+        # models (siglip, siglip2, siglip2_l, siglip_l, clip), single/patch pairs for
         # DINOv2/DINOv3/EUPE, and the SIFT/VLAD structural embedder.  The
         # FaceNet face-identity embedder is *not* here — it belongs to the
         # separate ``face`` media type now.
         assert set(entries) == {
             "siglip",
             "siglip2",
+            "siglip2_l",
             "siglip_l",
             "clip",
             "dinov2_single",
@@ -534,6 +535,7 @@ class TestApiEmbeddersResponseShape:
         # Specific expectations.
         assert entries["siglip"]["supports_text"] is True
         assert entries["siglip_l"]["supports_text"] is True
+        assert entries["siglip2_l"]["supports_text"] is True
         for name in (
             "dinov2_single",
             "dinov2_patch",
@@ -550,6 +552,7 @@ class TestApiEmbeddersResponseShape:
         for name in (
             "siglip",
             "siglip2",
+            "siglip2_l",
             "siglip_l",
             "clip",
             "dinov2_single",
@@ -562,6 +565,7 @@ class TestApiEmbeddersResponseShape:
         for name in (
             "siglip",
             "siglip2",
+            "siglip2_l",
             "siglip_l",
             "clip",
             "dinov2_single",

--- a/tests_lib/detectors/test_embedder_wrappers.py
+++ b/tests_lib/detectors/test_embedder_wrappers.py
@@ -379,6 +379,56 @@ class TestSiglip2Wrapper:
 
 
 # ===========================================================================
+# SigLIP2-L (embedder_siglip2_l.py)
+# ===========================================================================
+
+
+class TestSiglip2LWrapper:
+    """Same shared cross-modal base as SigLIP 2, but at the SO400M width.
+
+    The point of these is the **1152** in every shape assertion: the two
+    SigLIP 2 entries are separate embedders precisely because their vectors
+    are not interchangeable, so a change that collapsed SigLIP2-L onto the
+    base checkpoint's width would fail here.
+    """
+
+    def _make(self, dim=1152):
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        emb = ImageSiglip2LEmbedder()
+        emb._model = _FakeVisionTextModel(dim)
+        emb._processor = _FakeProcessor(keys=("pixel_values",))
+        return emb
+
+    def test_embed_pil_image(self):
+        from PIL import Image
+
+        emb = self._make()
+        vec = emb.embed_pil_image(Image.new("RGB", (16, 16)))
+        assert vec is not None
+        assert vec.shape == (1152,)
+
+    def test_embed_media_from_bytes(self):
+        emb = self._make()
+        vec = emb.embed_media({"media_bytes": _png_bytes()})
+        assert vec is not None
+        assert vec.shape == (1152,)
+        np.testing.assert_allclose(np.linalg.norm(vec), 1.0, atol=1e-5)
+
+    def test_embed_media_bad_source(self):
+        assert self._make().embed_media({}) is None
+
+    def test_embed_text_uses_padding_and_truncation(self):
+        emb = self._make()
+        vec = emb.embed_text("a photo of a cat")
+        assert vec is not None
+        assert vec.shape == (1152,)
+        _args, kwargs = emb._processor.calls[0]
+        assert kwargs["padding"] == "max_length"
+        assert kwargs["truncation"] is True
+
+
+# ===========================================================================
 # DINOv2 / DINOv3 (shared CLS-extraction path)
 # ===========================================================================
 

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -226,6 +226,124 @@ class TestImageSiglipLEmbedderProperties:
         assert embedder_siglip_l.EMBEDDER.name == "siglip_l"
 
 
+class TestImageSiglip2LEmbedderProperties:
+    """Verify ImageSiglip2LEmbedder class properties and registration.
+
+    Offline-safe like its SigLIP-L neighbour: nothing here imports
+    ``transformers`` or downloads the SO400M checkpoint, because
+    ``_load_models_impl`` defers both.
+    """
+
+    def test_name(self):
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        assert ImageSiglip2LEmbedder().name == "siglip2_l"
+
+    def test_media_type_id(self):
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        assert ImageSiglip2LEmbedder().media_type_id == "image"
+
+    def test_is_not_default(self):
+        """SigLIP (base) stays the default image embedder; SigLIP2-L is opt-in."""
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        assert ImageSiglip2LEmbedder().is_default is False
+
+    def test_supports_text(self):
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        assert ImageSiglip2LEmbedder().supports_text is True
+
+    def test_description_wrappers_non_empty(self):
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        wrappers = ImageSiglip2LEmbedder().description_wrappers
+        assert len(wrappers) > 0
+        assert all("{text}" in w for w in wrappers)
+
+    def test_registered_in_registry(self):
+        from vtscore.media import get_embedder
+
+        emb = get_embedder("siglip2_l")
+        assert emb.name == "siglip2_l"
+        assert emb.media_type_id == "image"
+
+    def test_listed_in_embedders_for_type(self):
+        from vtscore.media import embedders_for_type
+
+        names = [e.name for e in embedders_for_type("image")]
+        assert "siglip2_l" in names
+
+    def test_to_dict(self):
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        d = ImageSiglip2LEmbedder().to_dict()
+        assert d == {
+            "name": "siglip2_l",
+            "display_name": "SigLIP2-L (SO400M/384)",
+            "model_id": "google/siglip2-so400m-patch14-384",
+            "media_type_id": "image",
+            "is_default": False,
+            "supports_text": True,
+            "supports_patch_regions": False,
+            "supports_geometric_verification": False,
+            "license_notice": None,
+        }
+
+    def test_load_models_idempotent(self):
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        emb = ImageSiglip2LEmbedder()
+        # Simulate already-loaded model: a second load must be a no-op and must
+        # not attempt to import transformers or download weights.
+        emb._model = MagicMock()
+        emb._processor = MagicMock()
+        emb.load_models()
+        assert isinstance(emb._model, MagicMock)
+
+    def test_embed_media_returns_none_when_not_loaded(self):
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        emb = ImageSiglip2LEmbedder()
+        with patch.object(emb, "load_models"):
+            result = emb.embed_media({"media_path": "/nonexistent.jpg"})
+        assert result is None
+
+    def test_embed_text_returns_none_when_not_loaded(self):
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        emb = ImageSiglip2LEmbedder()
+        with patch.object(emb, "load_models"):
+            result = emb.embed_text("a cat")
+        assert result is None
+
+    def test_uses_correct_model_id(self):
+        from vtscore.config import SIGLIP2_L_MODEL_ID
+
+        assert SIGLIP2_L_MODEL_ID == "google/siglip2-so400m-patch14-384"
+
+    def test_distinct_checkpoint_from_base_siglip2(self):
+        """The two SigLIP 2 entries must not collapse onto the same weights:
+        they emit different dimensions (768 vs 1152) and are not gallery-compatible."""
+        from vtscore.config import SIGLIP2_L_MODEL_ID, SIGLIP2_MODEL_ID
+
+        assert SIGLIP2_L_MODEL_ID != SIGLIP2_MODEL_ID
+
+    def test_is_media_embedder(self):
+        from vtscore.media.embedder import MediaEmbedder
+        from vtscore.media.image.embedder_siglip2_l import ImageSiglip2LEmbedder
+
+        assert issubclass(ImageSiglip2LEmbedder, MediaEmbedder)
+
+    def test_module_exposes_embedder_sentinel(self):
+        from vtscore.media.embedder import MediaEmbedder
+        from vtscore.media.image import embedder_siglip2_l
+
+        assert isinstance(embedder_siglip2_l.EMBEDDER, MediaEmbedder)
+        assert embedder_siglip2_l.EMBEDDER.name == "siglip2_l"
+
+
 class TestAudioClapMusicEmbedderProperties:
     """Verify AudioClapMusicEmbedder class properties and registration."""
 
@@ -990,12 +1108,12 @@ class TestAllEmbeddersRegistration:
         from vtscore.media import all_embedders
 
         embedders = all_embedders()
-        # 7 original + 9 image embedders (clip, siglip2, siglip_l, plus
-        # single/patch variants for dinov2, dinov3, eupe) + 1 face embedder
+        # 7 original + 10 image embedders (clip, siglip2, siglip2_l, siglip_l,
+        # plus single/patch variants for dinov2, dinov3, eupe) + 1 face embedder
         # + 1 structural image embedder (sift_vlad)
         # + 1 vision-only video embedder (videomae)
         # + 4 audio embedders (ast, clap_general, whisper_encoder, paraspeechclap).
-        assert len(embedders) == 23
+        assert len(embedders) == 24
 
     def test_all_embedders_dict_includes_supports_text(self):
         """The new ``supports_text`` flag must round-trip through ``to_dict``
@@ -1005,7 +1123,17 @@ class TestAllEmbeddersRegistration:
         dicts = all_embedders_dict()
         by_name = {d["name"]: d for d in dicts}
         # Cross-modal embedders advertise text support.
-        for name in ("siglip", "siglip2", "siglip_l", "clip", "clap", "clap_general", "paraspeechclap", "xclip"):
+        for name in (
+            "siglip",
+            "siglip2",
+            "siglip2_l",
+            "siglip_l",
+            "clip",
+            "clap",
+            "clap_general",
+            "paraspeechclap",
+            "xclip",
+        ):
             assert by_name[name]["supports_text"] is True, name
         # Vision-only / patch-based and speech-only embedders do not.
         for name in (
@@ -1035,6 +1163,7 @@ class TestAllEmbeddersRegistration:
             "paraspeechclap",
             "siglip",
             "siglip2",
+            "siglip2_l",
             "siglip_l",
             "clip",
             "dinov2_single",
@@ -1066,6 +1195,7 @@ class TestAllEmbeddersRegistration:
         assert names == {
             "siglip",
             "siglip2",
+            "siglip2_l",
             "siglip_l",
             "clip",
             "dinov2_single",
@@ -1110,12 +1240,12 @@ class TestAllEmbeddersRegistration:
         from vtscore.media import all_embedders_dict
 
         dicts = all_embedders_dict()
-        # 7 original + 9 image embedders (clip, siglip2, siglip_l, plus
-        # single/patch variants for dinov2, dinov3, eupe) + 1 face embedder
+        # 7 original + 10 image embedders (clip, siglip2, siglip2_l, siglip_l,
+        # plus single/patch variants for dinov2, dinov3, eupe) + 1 face embedder
         # + 1 structural image embedder (sift_vlad)
         # + 1 vision-only video embedder (videomae)
         # + 4 audio embedders (ast, clap_general, whisper_encoder, paraspeechclap).
-        assert len(dicts) == 23
+        assert len(dicts) == 24
         for d in dicts:
             assert "name" in d
             assert "media_type_id" in d

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -261,6 +261,13 @@ XCLIP_MODEL_ID = "microsoft/xclip-base-patch32"
 E5_MODEL_ID = "intfloat/e5-base-v2"
 SIGLIP_MODEL_ID = "google/siglip-base-patch16-224"
 SIGLIP2_MODEL_ID = "google/siglip2-base-patch16-224"
+# SigLIP2-L: the SigLIP 2 SO400M/384 checkpoint, loaded through ``transformers``
+# like its base sibling (SigLIP 2 has a first-party HF port, so there is no
+# reason to route it through open_clip the way ``SIGLIP_L_MODEL_ID`` is).  The
+# fixed-resolution ``patch14-384`` variant, not the NaFlex one, so the standard
+# ``AutoProcessor`` image pipeline applies.  Emits 1152-d vectors, so its
+# galleries are *not* interchangeable with the 768-d base SigLIP 2.
+SIGLIP2_L_MODEL_ID = "google/siglip2-so400m-patch14-384"
 # SigLIP-L: the SO400M/384 checkpoint, loaded via ``open_clip`` (not
 # transformers) so its 1152-d vectors match galleries produced by open_clip's
 # own ``ViT-SO400M-14-SigLIP-384`` model.  The arch name is the open_clip

--- a/vtscore/docs/packages/config.md
+++ b/vtscore/docs/packages/config.md
@@ -225,6 +225,7 @@ time. The actual download + load is lazy, driven by
 | `LANGUAGEBIND_VIDEO_MODEL_ID`  | `"LanguageBind/LanguageBind_Video_V1.5_FT"`                                            | Alternative video embedder with text-aligned latent.                                   |
 | `SIGLIP_MODEL_ID`              | `"google/siglip-base-patch16-224"`                                                     | Default image embedder.                                                                |
 | `SIGLIP2_MODEL_ID`             | `"google/siglip2-base-patch16-224"`                                                    | SigLIP v2.                                                                             |
+| `SIGLIP2_L_MODEL_ID`           | `"google/siglip2-so400m-patch14-384"`                                                  | SigLIP v2, SO400M/384 (1152-d).                                                        |
 | `CLIP_MODEL_ID`                | `"openai/clip-vit-base-patch32"`                                                       | OpenAI CLIP.                                                                           |
 | `DINOV2_MODEL_ID`              | `"facebook/dinov2-base"`                                                               | Self-supervised image encoder.                                                         |
 | `DINOV3_MODEL_ID`              | `"facebook/dinov3-vitb16-pretrain-lvd1689m"`                                           | DINO v3.                                                                               |

--- a/vtscore/docs/packages/media.md
+++ b/vtscore/docs/packages/media.md
@@ -312,7 +312,7 @@ Each lives under `vtscore/media/<type>/` and self-registers:
 | Type     | Folder                       | Default embedder                | Other embedders ship in-tree                            |
 |----------|------------------------------|---------------------------------|---------------------------------------------------------|
 | audio    | `vtscore/media/audio/`       | `clap` (`laion/clap-htsat-unfused`) | `clap_general`, `clap_music`, `ast`, `whisper_encoder`, `paraspeechclap` |
-| image    | `vtscore/media/image/`       | `siglip` (`google/siglip-base-patch16-224`) | `clip`, `siglip2`, `dinov2_single`, `dinov2_patch`, `dinov3_single`, `dinov3_patch`, `eupe_single`, `eupe_patch`, `face` |
+| image    | `vtscore/media/image/`       | `siglip` (`google/siglip-base-patch16-224`) | `clip`, `siglip2`, `siglip2_l`, `siglip_l`, `dinov2_single`, `dinov2_patch`, `dinov3_single`, `dinov3_patch`, `eupe_single`, `eupe_patch`, `face` |
 | text     | `vtscore/media/text/`        | `e5` (`intfloat/multilingual-e5-base`) | `bge`                                            |
 | video    | `vtscore/media/video/`       | `xclip` (`microsoft/xclip-base-patch32`) | `videomae`, `languagebind`                       |
 | document | `vtscore/media/document/`    | - (uses converters; see below)  | -                                                       |

--- a/vtscore/media/image/_cross_modal_shared.py
+++ b/vtscore/media/image/_cross_modal_shared.py
@@ -1,6 +1,6 @@
-"""Shared base for the HF cross-modal image embedders (SigLIP, SigLIP 2, CLIP).
+"""Shared base for the HF cross-modal image embedders (SigLIP, SigLIP 2, SigLIP2-L, CLIP).
 
-All three embedders wrap a Hugging Face model/processor pair that exposes
+All of them wrap a Hugging Face model/processor pair that exposes
 ``get_image_features`` / ``get_text_features``, so the full cross-modal
 surface (single/bulk image embedding, PIL embedding, text-query embedding)
 lives here.  Subclasses provide the identity properties, their own

--- a/vtscore/media/image/embedder_siglip2_l.py
+++ b/vtscore/media/image/embedder_siglip2_l.py
@@ -1,0 +1,91 @@
+"""Image embedder - SigLIP2-L (google/siglip2-so400m-patch14-384).
+
+The SO400M/384 member of the SigLIP 2 family.  Unlike
+:mod:`vtscore.media.image.embedder_siglip_l` - which reaches the *v1* SO400M
+checkpoint through ``open_clip`` because that is where its canonical weights
+live - SigLIP 2 ships a first-party Hugging Face port, so this embedder loads
+through :class:`~transformers.AutoModel` / :class:`~transformers.AutoProcessor`
+exactly like :mod:`vtscore.media.image.embedder_siglip2` and shares the whole
+cross-modal surface with it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vtscore.config import SIGLIP2_L_MODEL_ID
+from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
+    embedder_load_setup,
+    hf_token,
+    intercept_tqdm_progress,
+    intercept_weight_loading_progress,
+    load_pretrained_local_first,
+    timed_progress,
+    to_compute_device,
+)
+from vtscore.media.image._cross_modal_shared import _CrossModalHFEmbedder
+
+
+class ImageSiglip2LEmbedder(_CrossModalHFEmbedder):
+    """Embeds images using SigLIP2-L (google/siglip2-so400m-patch14-384).
+
+    The large sibling of :class:`ImageSiglip2Embedder`: same vision-encoder /
+    text-encoder split and same tokenization contract, but a 400M-parameter
+    shape-optimised backbone at 384px producing **1152-dimensional** vectors
+    instead of 768.  A detector trained on one is not usable on the other -
+    the dimensions differ - so the two are separate registry entries rather
+    than a size knob on one.
+    """
+
+    _label = "SigLIP2-L"
+    _text_processor_kwargs: dict[str, Any] = {"padding": "max_length", "truncation": True}
+
+    @property
+    def name(self) -> str:
+        return "siglip2_l"
+
+    @property
+    def display_name(self) -> str:
+        return "SigLIP2-L (SO400M/384)"
+
+    @property
+    def model_id(self) -> str:
+        return SIGLIP2_L_MODEL_ID
+
+    def _load_models_impl(self) -> None:
+        if self._model is not None:
+            return
+
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
+            import torch  # noqa: F401, PLC0415
+
+        with timed_progress(
+            self._on_progress, "loading", "Importing transformers…", est_modules=IMPORT_MODULE_ESTIMATES["transformers"]
+        ):
+            from transformers import AutoModel, AutoProcessor  # noqa: PLC0415
+
+        cache_dir = embedder_load_setup(self._on_progress, "Loading SigLIP2-L model weights…")
+        with (
+            intercept_tqdm_progress(self._on_progress),
+            intercept_weight_loading_progress(self._on_progress, "Loading SigLIP2-L model weights…"),
+        ):
+            self._model = load_pretrained_local_first(
+                AutoModel.from_pretrained,
+                SIGLIP2_L_MODEL_ID,
+                low_cpu_mem_usage=True,
+                cache_dir=cache_dir,
+                token=hf_token(),
+                on_progress=self._on_progress,
+            )
+        self._model = to_compute_device(self._model)
+        self._on_progress("loading", "Loading SigLIP2-L processor…", 0, 0)
+        with intercept_tqdm_progress(self._on_progress):
+            self._processor = load_pretrained_local_first(
+                AutoProcessor.from_pretrained, SIGLIP2_L_MODEL_ID, cache_dir=cache_dir, token=hf_token()
+            )
+
+
+EMBEDDER = ImageSiglip2LEmbedder()


### PR DESCRIPTION
Adds `google/siglip2-so400m-patch14-384` as a second SigLIP 2 entry, alongside the existing base checkpoint. Before this, `siglip2` was the only SigLIP 2 model in the app; the only SO400M-sized option was `siglip_l`, which is on SigLIP **v1**.

## What landed

- **`SIGLIP2_L_MODEL_ID`** in `vtscore/config.py`, pinned to `google/siglip2-so400m-patch14-384` — the fixed-resolution `patch14-384` variant, not NaFlex, so the standard `AutoProcessor` image pipeline applies.
- **`vtscore/media/image/embedder_siglip2_l.py`** — `ImageSiglip2LEmbedder`, slug `siglip2_l`, display name "SigLIP2-L (SO400M/384)". Auto-discovered via the module-level `EMBEDDER` sentinel; no `__init__.py` edits.
- Tests, and the doc tables that enumerate embedders.

A note on the naming: the request named the constant `SIGLIP2_L_MODEL`, but every model-id constant in `vtscore/config.py` ends in `_MODEL_ID` (`SIGLIP_MODEL_ID`, `SIGLIP2_MODEL_ID`, `SIGLIP_L_MODEL_ID`, …), so this follows the file's convention. Easy to rename if the shorter form was deliberate.

## Two things worth knowing

**It loads through transformers, not open_clip.** `ImageSiglipLEmbedder` deliberately routes the v1 SO400M checkpoint through `open_clip` so its vectors match galleries embedded by open_clip's own model bit-for-bit. That reasoning doesn't carry over: SigLIP 2 has a first-party Hugging Face port, so this embedder goes through `AutoModel` / `AutoProcessor` like its base sibling and subclasses `_CrossModalHFEmbedder` wholesale — identity properties plus a loader are the entire module. No new dependencies.

**It emits 1152-d vectors, not 768.** That is why this is a separate registry entry rather than a size knob on `siglip2`: a detector trained against one is not usable against the other. `TestSiglip2LWrapper` pins the width end-to-end through the shared base so a change that collapsed the two onto one checkpoint fails loudly.

## Deliberately not done

The SO400M weights are **not** baked into `Dockerfile.image-embedders{,.gpu}`. That matches how the equally large `siglip_l` is already handled — it ships installed and selectable, but its weights download lazily into the persistent `/app/data` volume on first use rather than adding several GB to every image. I added a header comment to both Dockerfiles recording that, since the file claims to bake "every supported image embedder" and there are now two exceptions to that.

No row was added to `_load_cost_model.py`: that table is machine-fit from measured GRID timings and explicitly must not be hand-tuned. Unmeasured cells fall back to the static per-`(device, media)` profiles, which is the correct behaviour for a new embedder until someone re-runs the calibration harness. Same for `PROJECTION_DEFAULTS_BY_EMBEDDER`, which only carries empirically swept embedders.

No screenshot reshoot is owed — the embedder picker is a collapsed `<select>`, so a new option changes no framed surface.

## Testing

`./run-tests.sh` — **8148 passed, 6 skipped**, including ruff, codespell, deptry, pyright, the frontend build and Vitest suite, and the eval/app-sync gate (untouched; no embedder mirrors exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bp4pBTtSg1RW1FLyLuXegC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp4pBTtSg1RW1FLyLuXegC)_