### PR TITLE
Fall back to latin-1 for non-UTF-8 text_dir companion files in pickle loader

### DIFF
--- a/tests_lib/datasets/test_thin_loading.py
+++ b/tests_lib/datasets/test_thin_loading.py
@@ -744,3 +744,64 @@ class TestClipResponseLazyLoading:
         media = {"id": 1, "media_bytes": None, "media_path": None, "filename": "test.wav"}
         resp = mt.media_response(media)
         assert resp.data == b""
+
+
+class TestFullModeTextCompanionEncoding:
+    """Regression for #2961: a non-UTF-8 ``text_dir`` companion must not abort the load.
+
+    ``_load_pickle_media_payload`` used to open ``.txt``/``.md`` companion
+    files with strict ``encoding="utf-8"``, so one latin-1/cp1252 file in a
+    scraped text corpus raised ``UnicodeDecodeError`` and failed the entire
+    load. It now falls back to latin-1, mirroring the CSV label importer.
+    """
+
+    def _write_pickle(self, tmp_path: Path, text_dir: Path, filename: str) -> Path:
+        media: dict[str, Any] = {
+            "id": 1,
+            "media_type": "text",
+            "embedding": np.zeros(512).tolist(),
+            "embedder": "e5",
+            "filename": filename,
+            "category": "test",
+            "media_bytes": None,
+            "media_string": None,
+            "media_path": None,
+        }
+        pkl_path = tmp_path / "text.pkl"
+        from vtscore.datasets.container import write_container
+
+        write_container(
+            pkl_path,
+            pickle.dumps({"medias": {1: media}, "text_dir": str(text_dir)}),
+            {"format_version": 1},
+        )
+        return pkl_path
+
+    def test_full_mode_falls_back_to_latin1_on_bad_utf8(self, tmp_path, caplog):
+        text_dir = tmp_path / "texts"
+        text_dir.mkdir()
+        # "café" encoded as latin-1/cp1252, not valid UTF-8.
+        raw = "café scraped corpus entry".encode("latin-1")
+        (text_dir / "bad.txt").write_bytes(raw)
+
+        pkl_path = self._write_pickle(tmp_path, text_dir, "bad.txt")
+        medias: dict[int, dict[str, Any]] = {}
+        with caplog.at_level("WARNING"):
+            load_dataset_from_pickle(pkl_path, medias, thin=False)
+
+        assert len(medias) == 1
+        assert medias[1]["media_string"] == raw.decode("latin-1")
+        assert "falling back to latin-1" in caplog.text
+
+    def test_full_mode_still_reads_valid_utf8(self, tmp_path):
+        text_dir = tmp_path / "texts"
+        text_dir.mkdir()
+        content = "plain ascii/utf-8 entry"
+        (text_dir / "good.txt").write_text(content, encoding="utf-8")
+
+        pkl_path = self._write_pickle(tmp_path, text_dir, "good.txt")
+        medias: dict[int, dict[str, Any]] = {}
+        load_dataset_from_pickle(pkl_path, medias, thin=False)
+
+        assert len(medias) == 1
+        assert medias[1]["media_string"] == content

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -197,8 +197,15 @@ def _load_pickle_media_payload(
     if not ext_path.exists():
         return None, None, None, True
     if ext_path.suffix in (".txt", ".md"):
-        with open(ext_path, "r", encoding="utf-8") as f:
-            txt = f.read()
+        raw = ext_path.read_bytes()
+        try:
+            txt = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            logger.warning(
+                "%s is not valid UTF-8; falling back to latin-1 encoding. Non-Latin characters may be corrupted.",
+                ext_path,
+            )
+            txt = raw.decode("latin-1")
         return txt.encode("utf-8"), txt, str(ext_path.resolve()), False
     with open(ext_path, "rb") as f:
         return f.read(), None, str(ext_path.resolve()), False


### PR DESCRIPTION
## Summary

`_load_pickle_media_payload` (`vtscore/datasets/loader_pickle.py`) read companion-dir `.txt`/`.md` files with strict `encoding="utf-8"` and no error handling. A `UnicodeDecodeError` from one bad file propagated all the way up through `_convert_one_pickle_media` / `load_dataset_from_pickle`, and `_handle_load_failure` aborted the *entire* dataset load instead of skipping just that item — inconsistent with the loader's contract for other per-item problems (a missing external file is counted in `missing_media` and skipped) and with the CSV label importer, which already falls back to latin-1 for the same class of input.

## Fix

The companion-file read now tries UTF-8 first and falls back to latin-1 (which always succeeds, since every byte value is a valid latin-1 code point) on `UnicodeDecodeError`, logging a warning — mirroring `vtscore/labels/importers/server_csv_file/__init__.py`'s existing `_parse_csv_bytes` fallback.

## Testing

- Added `TestFullModeTextCompanionEncoding` to `tests_lib/datasets/test_thin_loading.py`: a latin-1-encoded `.txt` companion now loads successfully (with a warning logged) instead of aborting the load, and a regular UTF-8 companion still reads unchanged.
- `./run-tests.sh` — full suite passes (8131 passed, 6 skipped).

Closes #2961

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyjwJopUFkv5fii5W3dQUq)_