### PR TITLE
Close the append handle before rewriting a dataset container

### DIFF
--- a/tests_lib/datasets/test_container.py
+++ b/tests_lib/datasets/test_container.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import pickle
 import zipfile
 
@@ -228,6 +229,84 @@ class TestContainerProjection:
         loaded = read_projection(path)
         assert loaded is not None
         assert loaded[0].projection_id == "second-pid"
+
+
+def _forbid_replace_under_open_handle(monkeypatch, path) -> None:
+    """Make ``os.replace`` on *path* fail while a write handle is open on it.
+
+    That is exactly Windows' behaviour, and the reason the append helpers must
+    close their probe before rewriting the container.  On POSIX the same
+    overlap is silently tolerated, so without this shim the regression is
+    invisible here.
+    """
+    open_writers: list = []
+    real_zipfile = zipfile.ZipFile
+    real_replace = os.replace
+
+    class TrackingZipFile(real_zipfile):  # type: ignore[misc,valid-type]
+        def __init__(self, file, mode="r", *args, **kwargs):
+            super().__init__(file, mode, *args, **kwargs)
+            self._tracked = mode in ("a", "w") and str(file) == str(path)
+            if self._tracked:
+                open_writers.append(self)
+
+        def close(self):
+            if getattr(self, "_tracked", False):
+                self._tracked = False
+                open_writers.remove(self)
+            super().close()
+
+    def guarded_replace(src, dst):
+        if open_writers and str(dst) == str(path):
+            raise PermissionError(f"cannot replace {dst}: a write handle is still open on it")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(zipfile, "ZipFile", TrackingZipFile)
+    monkeypatch.setattr(os, "replace", guarded_replace)
+
+
+class TestContainerAppendHandleSafety:
+    """Replacing an existing entry must not rewrite the container under an open handle."""
+
+    def test_append_projection_replaces_without_open_handle(self, tmp_path, monkeypatch):
+        path = tmp_path / "dataset.pkl"
+        write_container(path, _medias_pkl_bytes(20), _meta())
+
+        rng = np.random.default_rng(7)
+        coords = rng.standard_normal((20, 2)).astype(np.float32)
+        proj = Projection("first-pid", list(range(20)), coords, "test")
+        append_projection(path, proj, build_pyramid(proj, n_levels=2))
+
+        _forbid_replace_under_open_handle(monkeypatch, path)
+
+        proj2 = Projection("second-pid", list(range(20)), coords, "test")
+        append_projection(path, proj2, build_pyramid(proj2, n_levels=2))
+
+        loaded = read_projection(path)
+        assert loaded is not None
+        assert loaded[0].projection_id == "second-pid"
+
+    def test_append_region_labels_replaces_without_open_handle(self, tmp_path, monkeypatch):
+        from vtscore.datasets.container import append_region_labels, read_region_labels
+        from vtscore.projection.labels import RegionLabel, make_label_set
+
+        path = tmp_path / "dataset.pkl"
+        write_container(path, _medias_pkl_bytes(), _meta())
+
+        def labels(text: str):
+            return make_label_set("pid", [RegionLabel(level=0.0, x=0.0, y=0.0, text=text)])
+
+        append_region_labels(path, labels("old"), "sig-old")
+
+        _forbid_replace_under_open_handle(monkeypatch, path)
+
+        append_region_labels(path, labels("new"), "sig-new")
+
+        result = read_region_labels(path)
+        assert result is not None
+        label_set, signature = result
+        assert [lab.text for lab in label_set.labels] == ["new"]
+        assert signature == "sig-new"
 
 
 class TestContainerMetaReaders:

--- a/tests_lib/datasets/test_container.py
+++ b/tests_lib/datasets/test_container.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import pickle
 import zipfile
+from typing import Any
 
 import numpy as np
 import pytest
@@ -244,7 +245,7 @@ def _forbid_replace_under_open_handle(monkeypatch, path) -> None:
     real_replace = os.replace
 
     class TrackingZipFile(real_zipfile):  # type: ignore[misc,valid-type]
-        def __init__(self, file, mode="r", *args, **kwargs):
+        def __init__(self, file, mode: Any = "r", *args, **kwargs):
             super().__init__(file, mode, *args, **kwargs)
             self._tracked = mode in ("a", "w") and str(file) == str(path)
             if self._tracked:

--- a/vtscore/datasets/container.py
+++ b/vtscore/datasets/container.py
@@ -241,13 +241,7 @@ def append_projection(
     entry_name = _projection_entry_name(pyramid.bin_shape)
     npz_bytes = _serialize_projection(projection, pyramid)
 
-    with zipfile.ZipFile(str(p), "a") as zf:
-        if entry_name in zf.namelist():
-            _rewrite_without(p, entry_name)
-            with zipfile.ZipFile(str(p), "a") as zf2:
-                zf2.writestr(entry_name, npz_bytes)
-        else:
-            zf.writestr(entry_name, npz_bytes)
+    _replace_entry(p, entry_name, npz_bytes)
 
     logger.info("Appended %s projection to container: %s", pyramid.bin_shape, p)
 
@@ -316,13 +310,7 @@ def append_region_labels(path: str | Path, label_set: Any, labeler_signature: st
     }
     body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
 
-    with zipfile.ZipFile(str(p), "a") as zf:
-        if _REGION_LABELS_ENTRY in zf.namelist():
-            _rewrite_without(p, _REGION_LABELS_ENTRY)
-            with zipfile.ZipFile(str(p), "a") as zf2:
-                zf2.writestr(_REGION_LABELS_ENTRY, body)
-        else:
-            zf.writestr(_REGION_LABELS_ENTRY, body)
+    _replace_entry(p, _REGION_LABELS_ENTRY, body)
 
     logger.info("Appended region labels (%d signs) to container: %s", len(label_set.labels), p)
 
@@ -389,6 +377,34 @@ def _deserialize_projection(npz_bytes: bytes) -> tuple[Any, Any] | None:
     except Exception:
         logger.warning("Failed to deserialize projection from container", exc_info=True)
         return None
+
+
+def _replace_entry(path: Path, entry_name: str, body: bytes) -> None:
+    """Store *body* at *entry_name*, replacing any copy already in the container.
+
+    ZIP has no in-place entry replacement, so an existing entry has to be dropped
+    by rewriting the whole archive — and :func:`_rewrite_without` publishes that
+    rewrite with :func:`os.replace`.  That rename must not run while an
+    append-mode handle is open on the same path: Windows refuses to replace a
+    file that has an open handle (``PermissionError``, losing the update), and on
+    POSIX the now-orphaned handle's ``close()`` writes a fresh central directory
+    into the unlinked inode.  So the presence probe gets its own short-lived
+    read-only open, and the append handle is taken only after the rewrite lands.
+    """
+    exists = False
+    try:
+        with zipfile.ZipFile(str(path), "r") as zf:
+            exists = entry_name in zf.namelist()
+    except (OSError, zipfile.BadZipFile):
+        # No container at this path yet (or an unreadable one) — the append
+        # below creates/repairs it, matching what mode "a" did before.
+        exists = False
+
+    if exists:
+        _rewrite_without(path, entry_name)
+
+    with zipfile.ZipFile(str(path), "a") as zf:
+        zf.writestr(entry_name, body)
 
 
 def _rewrite_without(path: Path, entry_name: str) -> None:


### PR DESCRIPTION
Closes #2963

## The bug

`append_projection` and `append_region_labels` (`vtscore/datasets/container.py`) replaced an already-present entry by calling `_rewrite_without(...)` — which `os.replace()`s the container — from *inside* an open `zipfile.ZipFile(p, "a")` handle on the same path, then opened a second append handle on the freshly renamed file.

- **Windows** (a platform the codebase explicitly accommodates): `os.replace` onto a file with an open handle raises `PermissionError`, so re-projecting or re-labeling a dataset that already has a stored projection — the common re-fit path — fails and the update is lost.
- **POSIX**: harmless but wasteful — the outer handle now points at the unlinked old inode, and its `close()` writes a central directory into it.

## The fix

Both functions now go through a single `_replace_entry(path, entry_name, body)` helper that:

1. probes for the entry with a short-lived **read-only** open, and closes it;
2. calls `_rewrite_without` only if the entry is present, with no handle held;
3. takes the append handle **after** the rewrite has landed, and writes the entry.

A missing/unreadable container still falls through to the append (mode `"a"` creates it), matching the previous behavior. `remove_projections` / `remove_region_labels` already probed-then-closed and are unchanged.

## Tests

New `TestContainerAppendHandleSafety` in `tests_lib/datasets/test_container.py` covers both append functions. Since POSIX tolerates the overlap silently, the test installs a shim that reproduces Windows' rule — `os.replace` on the container raises while any write handle is open on it — so the regression is actually observable here. Both tests fail against the old implementation and pass against the new one.

Full suite: `ALL 8131 TESTS PASSED (6 skipped, 2 xfailed)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbTRsBJTw1Wx8V5LWq1tX5)_