### PR TITLE
Fix hexbin edge correction to compare distances isotropically

### DIFF
--- a/tests_lib/projection/test_hexbin.py
+++ b/tests_lib/projection/test_hexbin.py
@@ -56,6 +56,34 @@ def test_smaller_radius_yields_more_distinct_cells():
     assert n_fine > n_coarse
 
 
+@pytest.mark.parametrize("radius", [0.37, 1.0, 2.5])
+def test_assignment_is_the_exact_nearest_center_partition(radius):
+    """Every point must land in the hexagon that actually contains it.
+
+    Pins the deliberate divergence from d3-hexbin: d3 compares the
+    near-boundary tie-break in per-axis-normalized units (no 0.75 y-weight),
+    which misassigns ~2% of boundary points to a neighbor whose center is
+    farther away.  Assignment must equal nearest-center over the lattice.
+    """
+    rng = np.random.default_rng(0)
+    pts = rng.uniform(-10.0, 10.0, size=(20_000, 2))
+    q, r = hexbin_assign(pts, radius)
+
+    cx, cy = hex_center(q, r, radius)
+    assigned_dist = np.hypot(pts[:, 0] - cx, pts[:, 1] - cy)
+
+    # Brute-force nearest center over the neighborhood of the assigned cell.
+    # Only even ``q`` are real lattice columns (``hex_center`` folds the odd-row
+    # half-column offset in itself), so step the column index by two.
+    nearest_dist = np.full(len(pts), np.inf)
+    for d_row in (-2, -1, 0, 1, 2):
+        for d_col in (-4, -2, 0, 2, 4):
+            ncx, ncy = hex_center(q + d_col, r + d_row, radius)
+            nearest_dist = np.minimum(nearest_dist, np.hypot(pts[:, 0] - ncx, pts[:, 1] - ncy))
+
+    assert np.all(assigned_dist <= nearest_dist + 1e-9)
+
+
 def test_invalid_radius_raises():
     with pytest.raises(ValueError):
         hexbin_assign(np.zeros((3, 2)), radius=0.0)

--- a/tests_lib/projection/test_rep_persistence.py
+++ b/tests_lib/projection/test_rep_persistence.py
@@ -57,12 +57,18 @@ def _a_dense_level0_cell(pyr):
     return next(c for (lvl, _, _), t in pyr.tiles.items() if lvl == 0 for c in t.cells if c.count > 1)
 
 
-def _nearest_member(proj, members: list[int]) -> int:
-    """The member id nearest the members' centroid (the deepest-level / fallback rule)."""
+def _is_centroid_nearest(proj, members: list[int], rep: int) -> bool:
+    """Whether *rep* is a member at minimal distance to the members' centroid.
+
+    "A" and not "the": equidistant members are common (any two-member cell ties
+    exactly, its centroid being the midpoint), and which one wins is an
+    arbitrary argmin tie-break, so the contract is only that the rep is one of
+    the centroid-nearest members.
+    """
     id_to_idx = {int(m): i for i, m in enumerate(proj.ids)}
     pts = np.asarray(proj.coords, dtype=np.float64)[[id_to_idx[m] for m in members]]
-    centroid = pts.mean(axis=0)
-    return members[int(np.argmin(np.sum((pts - centroid) ** 2, axis=1)))]
+    d2 = np.sum((pts - pts.mean(axis=0)) ** 2, axis=1)
+    return bool(d2[members.index(rep)] <= d2.min() + 1e-9)
 
 
 def _assert_reps_well_formed(pyr, proj):
@@ -82,7 +88,7 @@ def _assert_reps_well_formed(pyr, proj):
                 assert cell.rep_id in members, f"rep {cell.rep_id} not a member of its bin"
                 if finer is not None and cell.rep_id not in finer:
                     # Not inherited -> must be the centroid-nearest fallback.
-                    assert cell.rep_id == _nearest_member(proj, members)
+                    assert _is_centroid_nearest(proj, members, cell.rep_id)
 
 
 def _persistence_fractions(pyr) -> list[float]:

--- a/vtscore/projection/hexbin.py
+++ b/vtscore/projection/hexbin.py
@@ -29,6 +29,10 @@ import numpy as np
 # 2·sin(π/3): the column spacing of a pointy-top hex lattice is ``radius · SQRT3``.
 SQRT3 = math.sqrt(3.0)
 
+# ``(dy/dx)² = (1.5·r / (√3·r))² = 0.75``: the factor that makes a squared
+# distance in the per-axis-normalized (x/dx, y/dy) frame isotropic again.
+Y_WEIGHT = 0.75
+
 
 def hexbin_assign(points: np.ndarray, radius: float) -> tuple[np.ndarray, np.ndarray]:
     """Assign each point in *points* to a hex cell of the given *radius*.
@@ -43,6 +47,15 @@ def hexbin_assign(points: np.ndarray, radius: float) -> tuple[np.ndarray, np.nda
     then the nearest (row-offset) column, and where the point lands in the outer
     third of a row, compare against the staggered neighbor and snap to whichever
     center is closer.
+
+    One deliberate divergence from upstream d3-hexbin: the near-boundary
+    tie-break compares distances in *isotropic* units.  The working coordinates
+    are normalized per axis (x by ``dx = r·√3``, y by ``dy = 1.5·r``), so a raw
+    ``px² + py²`` — what d3 computes — is not a Euclidean distance and picks the
+    wrong center for ~2% of near-boundary points.  Weighting the y-terms by
+    ``(dy/dx)² = 0.75`` restores the true metric at zero extra cost, making the
+    result an exact point-in-hexagon partition that matches the hexagons the
+    renderer draws.
     """
     if radius <= 0:
         raise ValueError(f"hex radius must be positive, got {radius!r}")
@@ -70,7 +83,9 @@ def hexbin_assign(points: np.ndarray, radius: float) -> tuple[np.ndarray, np.nda
     pj2 = pj + np.where(py0 < pj, -1.0, 1.0)
     px2 = px - pi2
     py2 = py0 - pj2
-    closer_to_neighbor = (px1 * px1 + py1 * py1) > (px2 * px2 + py2 * py2)
+    # ``Y_WEIGHT`` converts the per-axis-normalized coordinates back to a true
+    # Euclidean comparison; see the docstring's note on diverging from d3.
+    closer_to_neighbor = (px1 * px1 + Y_WEIGHT * py1 * py1) > (px2 * px2 + Y_WEIGHT * py2 * py2)
     swap = needs_check & closer_to_neighbor
 
     # When we snap to the neighbor the column shifts by ±0.5 depending on the


### PR DESCRIPTION
Closes #2964

`hexbin_assign`'s near-boundary tie-break compared `px² + py²` in coordinates that are normalized *per axis* (x by `dx = r·√3`, y by `dy = 1.5·r`). Since `dx ≠ dy` that is not a Euclidean distance, so ~2% of near-boundary points were snapped to a staggered neighbor whose center is actually farther away — i.e. counted in a hexagon that does not contain them, contradicting the docstring's "snap to whichever center is closer" and the exact hexagons the renderer draws.

## Change

Weight the y-terms by `(dy/dx)² = 0.75` (new `Y_WEIGHT` constant), restoring the true metric at zero extra cost. This is a deliberate divergence from upstream d3-hexbin (which has the same quirk); the docstring now says so.

## Verification

Brute-forcing nearest-center over the lattice for 20k uniform points, at radii 0.37 / 1.0 / 2.5:

| radius | misassigned (d3 metric) | max excess distance | misassigned (0.75 weight) |
|---|---|---|---|
| 0.37 | 405 | 9.1% of r | 0 |
| 1.0 | 431 | 9.0% of r | 0 |
| 2.5 | 459 | 9.3% of r | 0 |

New test `test_assignment_is_the_exact_nearest_center_partition` pins this as an exact point-in-hexagon partition (parameterized over those three radii), which also pins the intended divergence from d3.

Persisted pyramids rebuild from origins, so no migration is needed.

## Test-helper fix

The shifted assignment moved a boundary point into a two-member cell, which tripped `test_rep_persistence.py`'s rep-fallback assertion. A two-member cell's centroid is the midpoint, so both members are *exactly* equidistant and which one wins the argmin is arbitrary — the helper had pinned one arbitrary pick (first in member-list order) while `_assign_reps` breaks the tie by ascending point position. The helper now asserts the rep is *a* centroid-nearest member. No behavior change in `pyramid.py`.

Full `./run-tests.sh`: 8132 passed, 6 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqjmK8F1URgeov3fHhogiP)_