### PR TITLE
Undo CSV formula-injection escaping when importing labels

### DIFF
--- a/tests_lib/io/test_csv_label_roundtrip.py
+++ b/tests_lib/io/test_csv_label_roundtrip.py
@@ -66,7 +66,8 @@ class TestCsvLabelRoundTrip:
         )
         with open(filepath, newline="", encoding="utf-8") as f:
             rows = list(csv.reader(f))
-        assert rows[1] == ["good", "abc123", "'-take2.wav"]
+        # ``origin`` is always appended as the last column (empty here).
+        assert rows[1] == ["good", "abc123", "'-take2.wav", ""]
 
     def test_ordinary_names_are_unchanged(self, tmp_path):
         labels = [{"label": "bad", "md5": "abc123", "origin_name": "clip.wav", "filename": "sub/clip.wav"}]

--- a/tests_lib/io/test_csv_label_roundtrip.py
+++ b/tests_lib/io/test_csv_label_roundtrip.py
@@ -1,0 +1,103 @@
+"""Export → import round-trip for the CSV labelset exporter / label importer.
+
+The exporter escapes any cell starting with a spreadsheet formula prefix
+(``=``, ``+``, ``-``, ``@``, tab, CR) by prefixing an apostrophe.  Its
+docstring promises "the CSV can be re-imported without data loss", which
+only holds if the importer undoes that escaping — otherwise a media file
+named ``-take2.wav`` comes back as ``'-take2.wav`` and the origin_name /
+filename resolution used by the missing-media re-ingest paths fails to
+find it.
+"""
+
+from __future__ import annotations
+
+import csv
+
+from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+from vtscore.labels.importers.server_csv_file import _parse_csv_bytes
+
+# Names that begin with each formula prefix the exporter escapes.  Tab and
+# CR are excluded: leading whitespace does not survive either side's
+# ``strip()``, escaped or not.
+_TRICKY_NAMES = ["-take2.wav", "@handle_post.txt", "=mc2.wav", "+1_more.wav"]
+
+
+def _export_then_import(labels, tmp_path, columns=None):
+    filepath = tmp_path / "labels.csv"
+    ServerCsvLabelsetExporter().export(
+        {"labels": labels, "selected_columns": columns or ["label", "md5", "origin_name", "filename", "category"]},
+        {"filepath": str(filepath)},
+    )
+    return _parse_csv_bytes(filepath.read_bytes())
+
+
+class TestCsvLabelRoundTrip:
+    def test_formula_prefixed_names_survive_round_trip(self, tmp_path):
+        labels = [
+            {
+                "label": "good",
+                "md5": f"{i:032x}",
+                "origin_name": name,
+                "filename": name,
+                "category": name,
+            }
+            for i, name in enumerate(_TRICKY_NAMES)
+        ]
+
+        imported = _export_then_import(labels, tmp_path)
+
+        assert len(imported) == len(labels)
+        for original, entry in zip(labels, imported):
+            assert entry["origin_name"] == original["origin_name"]
+            assert entry["filename"] == original["filename"]
+            assert entry["category"] == original["category"]
+            assert entry["md5"] == original["md5"]
+            assert entry["label"] == "good"
+
+    def test_written_csv_still_escapes_for_spreadsheets(self, tmp_path):
+        """De-sanitizing on read must not weaken the on-disk escaping."""
+        filepath = tmp_path / "labels.csv"
+        ServerCsvLabelsetExporter().export(
+            {
+                "labels": [{"label": "good", "md5": "abc123", "filename": "-take2.wav"}],
+                "selected_columns": ["label", "md5", "filename"],
+            },
+            {"filepath": str(filepath)},
+        )
+        with open(filepath, newline="", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        assert rows[1] == ["good", "abc123", "'-take2.wav"]
+
+    def test_ordinary_names_are_unchanged(self, tmp_path):
+        labels = [{"label": "bad", "md5": "abc123", "origin_name": "clip.wav", "filename": "sub/clip.wav"}]
+
+        imported = _export_then_import(labels, tmp_path, columns=["label", "md5", "origin_name", "filename"])
+
+        assert imported == [{"label": "bad", "md5": "abc123", "origin_name": "clip.wav", "filename": "sub/clip.wav"}]
+
+    def test_origin_dict_survives_round_trip(self, tmp_path):
+        origin = {"importer": "server_folder", "params": {"path": "/data/-odd"}}
+        labels = [{"label": "good", "md5": "abc123", "origin_name": "-odd.wav", "origin": origin}]
+
+        imported = _export_then_import(labels, tmp_path, columns=["label", "md5", "origin_name", "origin"])
+
+        assert imported[0]["origin"] == origin
+        assert imported[0]["origin_name"] == "-odd.wav"
+
+    def test_literal_apostrophe_name_is_not_over_stripped(self, tmp_path):
+        """Only an apostrophe followed by a formula prefix is escaping."""
+        labels = [{"label": "good", "md5": "abc123", "filename": "'quoted.wav"}]
+
+        imported = _export_then_import(labels, tmp_path, columns=["label", "md5", "filename"])
+
+        assert imported[0]["filename"] == "'quoted.wav"
+
+
+class TestCsvImporterRaggedRows:
+    def test_short_row_does_not_crash(self):
+        """``csv.DictReader`` fills missing trailing cells with ``None``."""
+        csv_text = "md5,label,origin_name,filename\nabc123,good\n"
+
+        result = _parse_csv_bytes(csv_text.encode())
+
+        assert result == [{"md5": "abc123", "label": "good"}]

--- a/tests_lib/io/test_io_helpers.py
+++ b/tests_lib/io/test_io_helpers.py
@@ -195,9 +195,12 @@ class TestCsvCellSanitization:
     def test_desanitize_leaves_unescaped_values_alone(self, value):
         assert desanitize_csv_cell(value) == value
 
-    def test_desanitize_strips_only_one_apostrophe(self):
-        # ``''-x`` is the sanitized form of ``'-x``, which is itself literal.
-        assert desanitize_csv_cell("''-x") == "'-x"
+    def test_literal_apostrophe_prefix_is_ambiguous(self):
+        # ``'-x`` is both the sanitized form of ``-x`` and a literal value
+        # the sanitizer would pass through untouched.  The reader resolves
+        # it as the escaped form; nothing in the CSV can tell them apart.
+        assert sanitize_csv_cell("'-x") == "'-x"
+        assert desanitize_csv_cell("'-x") == "-x"
 
     def test_sanitize_round_trips_the_desanitized_form(self):
         # Every value the reader produces re-encodes to what it was read from.

--- a/tests_lib/io/test_io_helpers.py
+++ b/tests_lib/io/test_io_helpers.py
@@ -1,4 +1,4 @@
-"""Tests for ``vtscore.io``: the shared JSON read / atomic-write helpers."""
+"""Tests for ``vtscore.io``: the shared JSON read / atomic-write / CSV-cell helpers."""
 
 from __future__ import annotations
 
@@ -8,7 +8,13 @@ import threading
 
 import pytest
 
-from vtscore.io import atomic_write_json, atomic_write_text, read_server_json
+from vtscore.io import (
+    atomic_write_json,
+    atomic_write_text,
+    desanitize_csv_cell,
+    read_server_json,
+    sanitize_csv_cell,
+)
 
 
 class TestReadServerJson:
@@ -169,3 +175,31 @@ class TestConcurrentAtomicWrites:
         # ``os.replace`` swaps inodes on POSIX, proving the rename was
         # atomic rather than an in-place truncate.
         assert first_inode != second_inode
+
+
+class TestCsvCellSanitization:
+    @pytest.mark.parametrize("prefix", ["=", "+", "-", "@", "\t", "\r"])
+    def test_formula_prefix_is_escaped(self, prefix):
+        assert sanitize_csv_cell(f"{prefix}take2.wav") == f"'{prefix}take2.wav"
+
+    @pytest.mark.parametrize("value", ["take2.wav", "", "a-b", "'quoted", "0.5"])
+    def test_safe_value_is_untouched(self, value):
+        assert sanitize_csv_cell(value) == value
+
+    @pytest.mark.parametrize("prefix", ["=", "+", "-", "@", "\t", "\r"])
+    def test_desanitize_inverts_sanitize(self, prefix):
+        original = f"{prefix}handle_post.txt"
+        assert desanitize_csv_cell(sanitize_csv_cell(original)) == original
+
+    @pytest.mark.parametrize("value", ["take2.wav", "", "'", "'quoted", "a-b", "-"])
+    def test_desanitize_leaves_unescaped_values_alone(self, value):
+        assert desanitize_csv_cell(value) == value
+
+    def test_desanitize_strips_only_one_apostrophe(self):
+        # ``''-x`` is the sanitized form of ``'-x``, which is itself literal.
+        assert desanitize_csv_cell("''-x") == "'-x"
+
+    def test_sanitize_round_trips_the_desanitized_form(self):
+        # Every value the reader produces re-encodes to what it was read from.
+        for written in ["'-take2.wav", "'@handle.txt", "plain.wav"]:
+            assert sanitize_csv_cell(desanitize_csv_cell(written)) == written

--- a/vtscore/exporters/server_csv_file/__init__.py
+++ b/vtscore/exporters/server_csv_file/__init__.py
@@ -20,7 +20,7 @@ from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
 from vtscore.exporters.base import PluginField, LabelsetExporter
-from vtscore.io import atomic_write_text
+from vtscore.io import atomic_write_text, sanitize_csv_cell as _sanitize_csv_cell
 
 _DEFAULT_CSV_PATH = f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.csv"
 
@@ -37,17 +37,6 @@ def _atomic_write_csv(path: Path, write_rows) -> None:
     writer = csv.writer(buf)
     write_rows(writer)
     atomic_write_text(path, buf.getvalue())
-
-
-# Characters that trigger formula execution in spreadsheet applications.
-_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
-
-
-def _sanitize_csv_cell(value: str) -> str:
-    """Prefix formula-like cell values with a single quote to prevent injection."""
-    if value and value[0] in _FORMULA_PREFIXES:
-        return "'" + value
-    return value
 
 
 class ServerCsvLabelsetExporter(LabelsetExporter):

--- a/vtscore/io.py
+++ b/vtscore/io.py
@@ -40,9 +40,42 @@ __all__ = [
     "atomic_write_bytes",
     "atomic_write_json",
     "atomic_write_text",
+    "desanitize_csv_cell",
     "file_lock",
     "read_server_json",
+    "sanitize_csv_cell",
 ]
+
+#: Characters that trigger formula execution in spreadsheet applications.
+_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def sanitize_csv_cell(value: str) -> str:
+    """Prefix formula-like cell values with a single quote to prevent injection.
+
+    Spreadsheet applications execute a cell whose text starts with ``=``,
+    ``+``, ``-``, ``@``, tab, or CR.  A leading apostrophe forces the cell
+    to be read as literal text instead.
+    """
+    if value and value[0] in _FORMULA_PREFIXES:
+        return "'" + value
+    return value
+
+
+def desanitize_csv_cell(value: str) -> str:
+    """Undo :func:`sanitize_csv_cell` so a written CSV can be re-read losslessly.
+
+    This is the exact inverse of the sanitizer: it strips a leading
+    apostrophe only when the *next* character is one the sanitizer would
+    have escaped, which is precisely the shape the sanitizer emits.  A
+    value that genuinely starts with ``'`` followed by a formula prefix
+    (``'-foo``) is indistinguishable from the sanitized form of ``-foo``
+    and loses its apostrophe — an ambiguity inherent to the escaping
+    scheme, not something the reader can resolve.
+    """
+    if len(value) >= 2 and value[0] == "'" and value[1] in _FORMULA_PREFIXES:
+        return value[1:]
+    return value
 
 
 def read_server_json(path: Path | str, *, missing_ok: bool = False) -> Any:

--- a/vtscore/labels/importers/server_csv_file/__init__.py
+++ b/vtscore/labels/importers/server_csv_file/__init__.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from vtscore.config import DATA_DIR
+from vtscore.io import desanitize_csv_cell
 from vtscore.labels.importers.base import LabelImporter, PluginField
 
 
@@ -79,6 +80,19 @@ class ServerCsvLabelImporter(LabelImporter):
 _OPTIONAL_COLS = ("origin_name", "filename", "category")
 
 
+def _cell(row: dict[str, Any], field: str) -> str:
+    """Read one cell, undoing the exporter's formula-injection escaping.
+
+    The CSV exporter prefixes any cell starting with ``=``/``+``/``-``/
+    ``@``/tab/CR with an apostrophe so spreadsheets treat it as text.
+    Reading it back without :func:`desanitize_csv_cell` would hand
+    ``'-take2.wav`` to origin_name/filename resolution, which then fails
+    to find the real media.  A short row yields ``None`` from
+    :class:`csv.DictReader`, so coerce that to an empty string.
+    """
+    return desanitize_csv_cell(str(row.get(field) or "").strip()).strip()
+
+
 def _row_to_entry(row: dict[str, Any], normalised: dict[str, str]) -> dict[str, Any] | None:
     """Build a label entry from one CSV *row*, or ``None`` to skip it.
 
@@ -88,19 +102,19 @@ def _row_to_entry(row: dict[str, Any], normalised: dict[str, str]) -> dict[str, 
     and an ``origin`` cell is parsed as JSON (a non-object or invalid value
     is ignored).
     """
-    md5 = row.get(normalised["md5"], "").strip()
-    label = row.get(normalised["label"], "").strip().lower()
+    md5 = _cell(row, normalised["md5"])
+    label = _cell(row, normalised["label"]).lower()
     if not (md5 and label):
         return None
     entry: dict[str, Any] = {"md5": md5, "label": label}
     for col in _OPTIONAL_COLS:
         if col in normalised:
-            val = row.get(normalised[col], "").strip()
+            val = _cell(row, normalised[col])
             if val:
                 entry[col] = val
     # Parse origin dict from JSON if present
     if "origin" in normalised:
-        origin_raw = row.get(normalised["origin"], "").strip()
+        origin_raw = _cell(row, normalised["origin"])
         if origin_raw:
             try:
                 origin = json.loads(origin_raw)


### PR DESCRIPTION
Closes #2959

## The bug

The CSV labelset exporter prefixes any cell starting with `=`, `+`, `-`, `@`, tab, or CR with a literal apostrophe so spreadsheets treat it as text rather than a formula. The CSV label importer copied those columns back with only `.strip()` — no de-sanitizer existed anywhere in `vtscore`, so `_export_labels`' promise that "the CSV can be re-imported without data loss" did not hold.

A media file named `-take2.wav` or `@handle_post.txt` exported as `'-take2.wav` and re-imported as `'-take2.wav`. Label application to media already in the dataset was unaffected (`resolve_media_ids` also matches by md5), but the missing-media re-ingest paths in `vtscore/datasets/ingest.py` (`_ingest_via_source` / `_ingest_via_resolver`) resolve files by origin_name/filename, so they failed to find the file, silently skipped it, and returned `>= 0` — meaning the md5-robust fallback never ran. The corrupted `filename` / `category` were also stamped onto anything that did get ingested.

## The fix

- Moved `_sanitize_csv_cell` out of the exporter plugin into `vtscore/io.py` as `sanitize_csv_cell`, next to a new `desanitize_csv_cell` inverse, so the escaping rule and its reverse live in one place instead of one plugin depending on another.
- `desanitize_csv_cell` strips a leading apostrophe **only** when the next character is one the sanitizer would have escaped — precisely the shape the sanitizer emits. A value that genuinely starts with `'` followed by a formula prefix is indistinguishable from the escaped form and loses its apostrophe; that ambiguity is inherent to the escaping scheme and is documented in the docstring and pinned by a test.
- The CSV label importer now reads every cell through a `_cell` helper that strips, de-sanitizes, then strips again — so escaped and unescaped values behave identically. Applied to `md5`, `label`, the optional columns, and the `origin` JSON cell.
- `_cell` also coerces `None` to `""`, which `csv.DictReader` fills short rows with; previously a ragged CSV raised `AttributeError` on `.strip()`.

The on-disk output is unchanged — the CSV is still escaped for spreadsheets, and a test asserts that de-sanitizing on read did not weaken it.

## Tests

- `tests_lib/io/test_io_helpers.py` — unit tests for `sanitize_csv_cell` / `desanitize_csv_cell`, including the inverse property over every formula prefix and the literal-apostrophe ambiguity.
- `tests_lib/io/test_csv_label_roundtrip.py` — new file: real export → import round-trips through both plugins for formula-prefixed names, ordinary names, origin dicts, literal apostrophes, and ragged rows.

`./run-tests.sh` passes in full (8160 passed, 6 skipped), as does `./run-tests.sh vtscore-clean`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014VBwyehfvKvobtLAinA3WC)_