### PR TITLE
docs(api): fix non-rendering → ```json response fences

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -58,7 +58,8 @@ path escape.
 GET /api/auth/status
 ```
 
-→ ```json
+→
+```json
 {
   "provider": "default",
   "user": "default",
@@ -123,7 +124,8 @@ OpenAPI surface.
 GET /api/auth/huggingface/status
 ```
 
-→ ```json
+→
+```json
 {"configured": true, "authenticated": false, "username": "", "scopes": ""}
 ```
 

--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -16,7 +16,8 @@ GET /api/dashboard/dataset-info
 
 Metadata about the currently loaded dataset.
 
-→ ```json
+→
+```json
 {
   "name": "ESC-50 Animals",
   "num_medias": 500,

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -16,7 +16,8 @@
 GET /api/media-types
 ```
 
-→ ```json
+→
+```json
 {
   "media_types": [
     {
@@ -289,7 +290,8 @@ GET /api/dataset/detect-media-type
 Samples a folder's files by extension to pre-fill the import modal's
 media-type dropdown.
 
-→ ```json
+→
+```json
 {
   "sample_size": 50,
   "counts_by_type": {"audio": 48, "image": 2},
@@ -401,7 +403,8 @@ All load endpoints are async; subscribe to the `dataset` and
 GET /api/dataset/demo-list
 ```
 
-→ ```json
+→
+```json
 {
   "datasets": [
     {
@@ -450,7 +453,8 @@ GET /api/browse-media-files
 Lists files and subdirectories within an allowed root, filtered to only
 media files with recognized extensions.
 
-→ ```json
+→
+```json
 {
   "directories": [{"name": "dog", "path": "dog", "modified_at": "2025-03-31T10:15:00"}],
   "files": [{"name": "bark.wav", "path": "dog/bark.wav", "size_bytes": 12345, "modified_at": "2025-03-31T10:15:00"}],
@@ -561,7 +565,8 @@ POST /api/dataset/clear
 GET /api/datasets/registry
 ```
 
-→ ```json
+→
+```json
 {
   "datasets": [
     {
@@ -623,7 +628,8 @@ response is a superset of the Dashboard grid's row (`name`, `media_type`,
 `num_items`, `created_at`, `expires_at`, `created_by`, `readers`), so the
 Stats window can show everything the grid does while it covers the grid up.
 
-→ ```json
+→
+```json
 {
   "name": "Field recordings",
   "media_type": "audio",
@@ -669,7 +675,8 @@ together and where each one came from. Each set corresponds to one
 `dupe_set` representative in the dataset's in-memory context; exact-dupe
 members share the representative's MD5, near-dupe members keep their own.
 
-→ ```json
+→
+```json
 {
   "duplicate_sets": [
     {

--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -133,7 +133,8 @@ Returns the detector's saved labelset split into good/bad lists with right-pane
 render data. Not gated on a loaded dataset (but when one is loaded, each item's
 `cid` / `time` / `score` resolve against it).
 
-→ ```json
+→
+```json
 {
   "media_type": "audio",
   "good": [
@@ -193,7 +194,8 @@ manifest + README).
 GET /api/detectors/registry
 ```
 
-→ ```json
+→
+```json
 {
   "detectors": [
     {
@@ -273,7 +275,8 @@ Runs the label importer and creates a detector seeded with the labels it
 returns. The media type is inferred from the labels' origins; labels spanning
 more than one media type are rejected (400).
 
-→ ```json
+→
+```json
 {
   "ok": true,
   "detector": {...},
@@ -405,7 +408,8 @@ Counts and metadata only — never embeddings or MLP weights.
 detector's positive labels currently resolve into the loaded dataset (the
 set the dashboard's Browse button projects).
 
-→ ```json
+→
+```json
 {
   "name": "cat-sounds",
   "media_type": "audio",
@@ -441,7 +445,8 @@ mixed-source detectors work and no dataset need be loaded. The resulting
 throwaway context (vectors + preview bytes, never persisted) is registered
 under a synthetic `dataset_id` the browse view opens.
 
-→ ```json
+→
+```json
 {
   "ok": true,
   "dataset_id": "__detpos__<detector_id>",

--- a/docs/api/file-browser.md
+++ b/docs/api/file-browser.md
@@ -22,7 +22,8 @@ directory. In single-user mode the root is the current working directory;
 in multi-user mode it is the current user's data directory. Hidden files
 (names starting with `.`) are excluded.
 
-→ ```json
+→
+```json
 {
   "directories": [
     {"name": "subdir", "path": "subdir", "modified_at": "2025-03-31T10:15:00"}

--- a/docs/api/find.md
+++ b/docs/api/find.md
@@ -30,7 +30,8 @@ Reports, per detector, how many labels can be resolved against the chosen
 datasets so the UI can warn before an expensive Find. Call before `POST
 /api/find`.
 
-→ ```json
+→
+```json
 {
   "warnings": [
     {
@@ -54,7 +55,8 @@ POST /api/find
 
 **Body:** `{"dataset_ids": ["id1", "id2"], "detector_ids": ["m1"]}`
 
-→ ```json
+→
+```json
 {
   "results": [
     {
@@ -143,7 +145,8 @@ so a disagreement surfaces as a correction in Find stats. `good_count` /
 `bad_count` therefore count the labels actually *adopted* — the threshold split
 everywhere except those held votes.
 
-→ ```json
+→
+```json
 {
   "ok": true,
   "results": [{"id": 0, "score": 0.9812}, ...],
@@ -171,7 +174,8 @@ flagged for Auto-Find on the active dataset's media type, or name a single one.
 Scores the active dataset with each Auto-Find detector, training each MLP on
 demand, and returns one result column per detector.
 
-→ ```json
+→
+```json
 {
   "media_type": "audio",
   "detectors_run": 2,
@@ -203,7 +207,8 @@ Pure-read detector-evaluation stats over the adopted Find label set: a 2×2
 confusion of the adopted label vs. the detector's original call, plus an FP/FN
 threshold sweep.
 
-→ ```json
+→
+```json
 {
   "total_good": 42, "total_bad": 458,
   "verified_count": 30,

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -99,7 +99,8 @@ POST /api/label-importers/import/{importer_name}
 
 **Form or Body:** importer-specific fields.
 
-→ ```json
+→
+```json
 {
   "applied": 8,
   "skipped": 2,

--- a/docs/api/labeling.md
+++ b/docs/api/labeling.md
@@ -48,7 +48,8 @@ implementation).
 GET /api/labeling-status
 ```
 
-→ ```json
+→
+```json
 {
   "smart": {"status": "green"},
   "stable": {"status": "yellow"},

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -492,7 +492,8 @@ Trains an MLP on the labeled files, then scores all loaded medias.
 GET /api/votes
 ```
 
-→ ```json
+→
+```json
 {
   "good": [0, 3, 7],
   "bad": [1, 5],

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -10,7 +10,8 @@
 GET /api/settings
 ```
 
-→ ```json
+→
+```json
 {
   "volume": 1.0,
   "theme": "dark",


### PR DESCRIPTION
## Problem

25 JSON response examples across 10 API doc pages were written as a single line beginning `→ ```json`. A CommonMark/GFM fence must *begin* the line (at most 3 spaces of indent); these began with `→ ` (U+2192 plus a space), so the backticks parsed as inline code instead of a fence opener — the JSON rendered as one collapsed inline-code run instead of a formatted, syntax-highlighted block.

## Fix

Moved the `→` response-body marker (per `docs/API.md`'s conventions table) onto its own line, so the fence itself starts at column 0 on the following line:

```diff
-→ ```json
+→
+```json
 {
   ...
 }
 ```
```

Fenced code blocks are allowed to interrupt a paragraph in CommonMark/GFM, so the standalone `→` line renders correctly above each JSON block without needing a blank line in between.

## Files changed

| File | Occurrences fixed |
|---|---|
| `docs/api/datasets.md` | 7 |
| `docs/api/detectors.md` | 5 |
| `docs/api/find.md` | 5 |
| `docs/api/auth.md` | 2 |
| `docs/api/dashboard.md` | 1 |
| `docs/api/file-browser.md` | 1 |
| `docs/api/io.md` | 1 |
| `docs/api/labeling.md` | 1 |
| `docs/api/medias.md` | 1 |
| `docs/api/settings.md` | 1 |

Verified all fences are balanced (`grep -c '```json'` matches, no unclosed fences) and no `^→ ```` lines remain anywhere in `docs/`.

Closes #2979


---
_Generated by [Claude Code](https://claude.ai/code/session_01SrZtRcNTNrSecxUzQm62Z4)_