### PR TITLE
Fix run-tests.sh comment: --cov flag was never implemented

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -381,9 +381,9 @@ else
     done
 fi
 
-# Coverage is opt-in via VTSEARCH_COVERAGE=1 (or `--cov` as first arg).
-# Default off because tests already run in ~35s; coverage adds ~10-20%
-# overhead and the coverage report is most useful when explicitly asked for.
+# Coverage is opt-in via VTSEARCH_COVERAGE=1. Default off because tests
+# already run in ~35s; coverage adds ~10-20% overhead and the coverage
+# report is most useful when explicitly asked for.
 COV_ARGS=()
 if [[ "${VTSEARCH_COVERAGE:-}" == "1" ]]; then
     COV_ARGS=(--cov=vtsearch --cov-report=term-missing)


### PR DESCRIPTION
## Summary

`run-tests.sh` documented coverage as opt-in via `VTSEARCH_COVERAGE=1` **or `--cov` as first arg**, but the argument parser never implements `--cov` handling — a leading `--cov` falls through into `TEST_GROUPS` and ends up as `pytest -m "--cov"`, an invalid marker expression. That failure only surfaces after the ~5-minute lint/frontend preamble has already run, which is a confusing experience for anyone following the script's own comment.

## Fix

Removed the false `--cov` claim from the comment above `COV_ARGS`, leaving only the behavior that actually exists: `VTSEARCH_COVERAGE=1`.

Closes #2975

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NRjSCaESL7ui3DQPj4YgJM)_