### PR TITLE
Reset the acquisition cut in SortStateService.clear()

### DIFF
--- a/frontend/src/app/services/sort-state.service.spec.ts
+++ b/frontend/src/app/services/sort-state.service.spec.ts
@@ -188,6 +188,25 @@ describe('SortStateService', () => {
     expect(service.aboveThreshold).toBe(0);
   });
 
+  it('clear should reset the acquisition cut', () => {
+    // Seeded via setSortWindow, the only path that sets an acquisition cut:
+    // setSortResults nulls it, so it cannot catch a missing reset in clear().
+    service.setSortWindow({
+      items: [{ id: 1, score: 0.9 }],
+      threshold: 0.5,
+      acqThreshold: 0.8,
+      total: 1,
+      hasMore: false,
+      token: null,
+      aboveThreshold: 1,
+    });
+    expect(service.acqThreshold).toBe(0.8);
+
+    service.clear();
+
+    expect(service.acqThreshold).toBeNull();
+  });
+
   it('sortMode getter is reactive (drives a computed that reads it)', () => {
     // The state is signal-backed and exposed via value getters; a computed that
     // reads the getter must recompute when the setter writes the backing signal.

--- a/frontend/src/app/services/sort-state.service.ts
+++ b/frontend/src/app/services/sort-state.service.ts
@@ -249,6 +249,7 @@ export class SortStateService {
     this._selectMode.set('top');
     this._sortOrder.set(null);
     this._threshold.set(null);
+    this._acqThreshold.set(null);
     this._sortBusy.set(false);
     this._sortStatus.set('');
     this._sortProgress.set(0);


### PR DESCRIPTION
`SortStateService.clear()` reset every sort signal except `_acqThreshold`. After a `clear()` following a `setSortWindow()` that carried an acquisition cut, the `acqThreshold` getter (`_acqThreshold() ?? _threshold()`) kept returning the previous detector's cut instead of falling back to the now-null reporting threshold — which label-view's `autoSelectNext` 'hard' branch would then sample around.

No production code calls `clear()` today (the views reset via `setSortResults([], 0)`, which does null the field), so there is no reachable failure — but that made `clear()` an incomplete API that would silently misbehave for its first caller. Kept the method and completed it rather than deleting it: every sibling state service exposes the same `clear()` shape.

Also adds a regression test seeded via `setSortWindow`. The existing "clear should reset all state" test seeds via `setSortResults`, which nulls `_acqThreshold` itself, so it structurally could not catch this omission.

Verified with `./run-tests.sh frontend` — build, audit, and 1997 Vitest tests pass.

Closes #2970

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDu8QtEJt6F17PGzZ2BKxE)_