### PR TITLE
Add role="listbox" to virtual-scroll media list viewport

### DIFF
--- a/frontend/src/app/components/left-panel/media-list/media-list.component.html
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.html
@@ -14,7 +14,7 @@
 } @else if (useGridVirtual) {
   <!-- Virtual scrolling for large galleries: cards are chunked into rows so
        only the visible rows are mounted, instead of every thumbnail at once. -->
-  <cdk-virtual-scroll-viewport [itemSize]="gridRowHeight" class="media-list virtual-scroll-viewport grid-virtual" [style.--grid-goal-width]="gridGoalWidth() + 'px'">
+  <cdk-virtual-scroll-viewport [itemSize]="gridRowHeight" class="media-list virtual-scroll-viewport grid-virtual" [style.--grid-goal-width]="gridGoalWidth() + 'px'" role="listbox" aria-label="Media items">
     <div
       class="grid-virtual-row"
       *cdkVirtualFor="let row of gridRows; trackBy: trackByGridRow"


### PR DESCRIPTION
## Summary

The `cdk-virtual-scroll-viewport` branch of `vt-media-list` (used for large galleries, over `GRID_VIRTUAL_THRESHOLD` items) renders `vt-media-item` children carrying `role="option"` / `aria-selected` (from `media-item.component.html`), but the viewport itself had no owning `role="listbox"` ancestor. The plain-DOM branch (small galleries) already had `role="listbox" aria-label="Media items"` on its container.

This left orphaned `option` roles with no owning `listbox` on any large gallery — invalid ARIA, and it breaks screen-reader announcement of the list exactly where it matters most (bigger datasets).

## Fix

Added `role="listbox" aria-label="Media items"` to the `cdk-virtual-scroll-viewport` element, matching the plain-DOM branch's container.

## Testing

- `./run-tests.sh frontend` — frontend TypeScript build OK, frontend audit OK (0 vulnerabilities), Vitest unit suite OK (1996 passed)

Closes #2969


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ybq7Q2faC4KC7zba1MqR87)_