### PR TITLE
ingest: give each re-ingested media its own origin dict

### DIFF
--- a/tests/datasets/test_origin_isolation.py
+++ b/tests/datasets/test_origin_isolation.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import app as app_module  # noqa: F401  (sets up Flask test infra via conftest)
 from vtscore.datasets.importers.server_files import ServerFilesDatasetImporter
+from vtscore.datasets.ingest import _build_media_data
 from vtscore.datasets.load_pipeline import _tag_origins
 from vtscore.datasets.loader_folder import _build_folder_media_data
 
@@ -130,6 +131,58 @@ class TestBuildFolderMediaDataIsolation:
     def test_none_origin_passes_through(self):
         media = self._build(1, "a.wav", None)
         assert media["origin"] is None
+
+
+class TestBuildIngestMediaDataIsolation:
+    """``_build_media_data`` is called once per re-ingested entry with the
+    *group-shared* origin dict from ``_group_by_origin``; each media must
+    still end up with its own copy.
+    """
+
+    def _build(self, name: str, origin: dict[str, Any]) -> dict[str, Any]:
+        return _build_media_data(
+            origin_dict=origin,
+            entry={"filename": name},
+            media_type_id="audio",
+            origin_name=name,
+            file_path=Path(name),
+            file_bytes=b"data",
+            md5="deadbeef",
+            embedding=None,
+            embedder_name="test_embedder",
+        )
+
+    def test_two_calls_share_no_origin_state(self):
+        origin = {"importer": "server_folder", "params": {"path": "/data"}}
+        a = self._build("a.wav", origin)
+        b = self._build("b.wav", origin)
+        _assert_isolated(a, b)
+        assert a["origin"] is not origin
+        assert a["origin"] == origin
+
+    def test_mutating_one_origin_does_not_leak(self):
+        origin = {"importer": "server_folder", "params": {"path": "/data"}}
+        a = self._build("a.wav", origin)
+        b = self._build("b.wav", origin)
+        a["origin"]["params"]["clip_start"] = 1.5
+        a["origin"]["importer"] = "mutated"
+        assert "clip_start" not in b["origin"]["params"]
+        assert b["origin"]["importer"] == "server_folder"
+        # Caller-provided origin is also untouched.
+        assert "clip_start" not in origin["params"]
+        assert origin["importer"] == "server_folder"
+
+    def test_isolation_survives_pickle_roundtrip(self):
+        origin = {"importer": "server_folder", "params": {"path": "/data"}}
+        medias = {1: self._build("a.wav", origin), 2: self._build("b.wav", origin)}
+        revived = pickle.loads(pickle.dumps(medias))
+        _assert_isolated(revived[1], revived[2])
+        revived[1]["origin"]["params"]["extra"] = "only-on-1"
+        assert "extra" not in revived[2]["origin"]["params"]
+
+    def test_missing_origin_fields_default_empty(self):
+        media = self._build("a.wav", {})
+        assert media["origin"] == {"importer": "", "params": {}}
 
 
 class TestRewriteOriginsIsolation:

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -124,6 +124,11 @@ def _build_media_data(
     their media ``type`` (without it the frontend falls back to audio)
     and any ``custom_metadata`` supplied by the label entry (via
     :class:`~vtscore.datasets.labelset.LabeledElement.metadata`).
+
+    The ``origin`` is a fresh copy per media (``origin_dict`` is shared by
+    every entry in the origin group), so a later mutation of one media's
+    ``origin.params`` cannot leak across siblings — or survive into the next
+    dataset pickle as a backreference.
     """
     name = origin_name or file_path.name
     media_data: dict[str, Any] = {
@@ -134,7 +139,10 @@ def _build_media_data(
         "embedder": embedder_name,
         "filename": entry.get("filename") or name,
         "category": entry.get("category", ""),
-        "origin": origin_dict,
+        "origin": {
+            "importer": origin_dict.get("importer", ""),
+            "params": dict(origin_dict.get("params", {})),
+        },
         "origin_name": name,
         "media_bytes": file_bytes,
         "media_string": None,


### PR DESCRIPTION
Closes #2962

## Problem

`_build_media_data` (`vtscore/datasets/ingest.py`) stamped `"origin": origin_dict` — the group-shared dict produced by `_group_by_origin` — onto every media it built. So every media re-ingested for one origin group by `_ingest_via_source` or `_ingest_via_resolver` aliased a single `origin` dict *and* a single nested `params` dict.

A later per-media mutation of `media["origin"]["params"]` (clip stamping in `stages/clipper.py`, `clipper_chain.py`, dupe-set rewriting, or a caller normalizing one media's origin) would silently rewrite the provenance of every sibling — and the aliasing survives into the next dataset pickle as backreferences.

The codebase already treats exactly this as a corruption hazard and copies per media everywhere else: `_tag_origins` (`load_pipeline.py`), `_build_folder_media_data` (`loader_folder.py`), `ServerFilesDatasetImporter._rewrite_origins`, and `_normalize_temp_origins` in this very file.

## Change

`_build_media_data` now builds a fresh origin per media, matching the shape used by the other three sites:

```python
"origin": {
    "importer": origin_dict.get("importer", ""),
    "params": dict(origin_dict.get("params", {})),
},
```

## Tests

Added `TestBuildIngestMediaDataIsolation` to the existing `tests/datasets/test_origin_isolation.py` suite (the file that already pins this invariant for the other three sites): distinct `origin`/`params` per call, mutation of one media not leaking to siblings or back to the caller's dict, isolation surviving a pickle round-trip, and empty-field defaults.

Full `./run-tests.sh` passes: 8197 passed, 6 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_013EF4375aLeF66QZvEnjrf9)_