### PR TITLE
Document the four achievements-served docs and their hash-matched footers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,12 +146,6 @@ Instead, add the affected shot id(s) to the **reshoot queue**: `docs/user/screen
 
 If you *do* have a browser this session, drain the queue instead of growing it: run `scripts/screenshots/refresh.sh`, review `git diff docs/user/assets/`, commit the regenerated PNGs, and delete the drained rows. The full system (manifest, harness, determinism knobs, embedding convention) lives in `docs/plans/user-docs-screenshots.md`.
 
-## Four docs are a served, hash-matched product surface (CRITICAL)
-
-`README.md`, `docs/user/USER_GUIDE.md`, `docs/CLI.md`, and `docs/API.md` are not just documentation: the running app serves each of them raw at `GET /api/achievements/docs/<doc_id>/raw` and treats the code phrase in each file's footer (`*Readme Reader code phrase:* \`...\``) as part of the "Readme Reader" achievement. `vtsearch/achievements.py` (`_DOCS_RAW`, `_DOC_HASHES`) hashes each phrase at import time and checks a pasted guess against it server-side; the phrase is never sent to the client. A test verifies each doc's footer phrase matches what `achievements.py` expects.
-
-**If you edit one of these four files:** do not remove, reword, or move its trailing `*Readme Reader code phrase:* \`...\`` line. If you must change the phrase text itself, update the matching entry in `_DOCS_RAW` in the same commit, and expect `./run-tests.sh` to catch a mismatch either way.
-
 ## No Persisted Vectors or MLPs (CRITICAL)
 
 **Embeddings and trained MLP weights are in-memory artifacts only.** Never serialize them to disk, to `data/settings.json`, to detector JSON files, or to any other persistent store. Origins are the canonical persisted form: the system rederives `origin → file → embedding → MLP` on demand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,12 @@ Instead, add the affected shot id(s) to the **reshoot queue**: `docs/user/screen
 
 If you *do* have a browser this session, drain the queue instead of growing it: run `scripts/screenshots/refresh.sh`, review `git diff docs/user/assets/`, commit the regenerated PNGs, and delete the drained rows. The full system (manifest, harness, determinism knobs, embedding convention) lives in `docs/plans/user-docs-screenshots.md`.
 
+## Four docs are a served, hash-matched product surface (CRITICAL)
+
+`README.md`, `docs/user/USER_GUIDE.md`, `docs/CLI.md`, and `docs/API.md` are not just documentation: the running app serves each of them raw at `GET /api/achievements/docs/<doc_id>/raw` and treats the code phrase in each file's footer (`*Readme Reader code phrase:* \`...\``) as part of the "Readme Reader" achievement. `vtsearch/achievements.py` (`_DOCS_RAW`, `_DOC_HASHES`) hashes each phrase at import time and checks a pasted guess against it server-side; the phrase is never sent to the client. A test verifies each doc's footer phrase matches what `achievements.py` expects.
+
+**If you edit one of these four files:** do not remove, reword, or move its trailing `*Readme Reader code phrase:* \`...\`` line. If you must change the phrase text itself, update the matching entry in `_DOCS_RAW` in the same commit, and expect `./run-tests.sh` to catch a mismatch either way.
+
 ## No Persisted Vectors or MLPs (CRITICAL)
 
 **Embeddings and trained MLP weights are in-memory artifacts only.** Never serialize them to disk, to `data/settings.json`, to detector JSON files, or to any other persistent store. Origins are the canonical persisted form: the system rederives `origin → file → embedding → MLP` on demand.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!-- This file is served raw at GET /api/achievements/docs/readme/raw and its
+     footer phrase is hash-matched in vtsearch/achievements.py. Don't remove
+     or reword the "Readme Reader code phrase" line without updating
+     achievements.py to match. See CLAUDE.md. -->
+
 # VTSearch
 
 A trainable media search tool. VTSearch searches collections of audio clips, images, text paragraphs, videos, and documents using a **detector** (a small trained ranker that scores every item in the collection by how well it matches what you're looking for). You search either by **training a new detector** (vote a handful of items "good" or "bad" and a small neural net learns from your votes to rank the rest of the collection) or by **using an existing detector** (one you saved earlier, exported from another VTSearch instance, or imported from disk). Trained detectors are reusable: apply the same one to any future dataset of the same media type. A natural-language query ("dog barking", "red car in snow") seeds either flow via pretrained embeddings (LAION-CLAP for audio, SigLIP for images, X-CLIP for video, E5-base-v2 for text), and also works as a quick stand-alone search when you don't need a trained detector. Several demo datasets are available directly from the UI. Built with Flask (Python), Angular (TypeScript), and PyTorch.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,3 +1,8 @@
+<!-- This file is served raw at GET /api/achievements/docs/api/raw and its
+     footer phrase is hash-matched in vtsearch/achievements.py. Don't remove
+     or reword the "Readme Reader code phrase" line without updating
+     achievements.py to match. See CLAUDE.md. -->
+
 # HTTP API Reference
 
 VTSearch exposes a REST-style JSON API. All endpoints accept and return JSON

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,3 +1,8 @@
+<!-- This file is served raw at GET /api/achievements/docs/cli/raw and its
+     footer phrase is hash-matched in vtsearch/achievements.py. Don't remove
+     or reword the "Readme Reader code phrase" line without updating
+     achievements.py to match. See CLAUDE.md. -->
+
 # Command-line interface
 
 VTSearch provides a CLI workflow for running detectors on datasets and exporting results, all without starting the web server.

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -1,3 +1,8 @@
+<!-- This file is served raw at GET /api/achievements/docs/user_guide/raw and
+     its footer phrase is hash-matched in vtsearch/achievements.py. Don't
+     remove or reword the "Readme Reader code phrase" line without updating
+     achievements.py to match. See CLAUDE.md. -->
+
 # VTSearch User Guide
 
 ## Contents


### PR DESCRIPTION
## Problem

`README.md`, `docs/user/USER_GUIDE.md`, `docs/CLI.md`, and `docs/API.md` are not just documentation — the running app serves each of them raw at `GET /api/achievements/docs/<doc_id>/raw`, and each carries a footer code phrase (`*Readme Reader code phrase:* \`...\``) that is hash-matched server-side against `vtsearch/achievements.py`'s `_DOCS_RAW` / `_DOC_HASHES` as part of the achievements feature. A test verifies each doc's footer stays in sync, but nothing told a contributor this before making the connection — so tidying a footer or restructuring one of these files could silently break the feature, with a test failure several steps removed from the actual edit.

## Fix

Added a one-line HTML comment at the top of each of the four files, pointing back at `vtsearch/achievements.py`, so the constraint is discoverable from the file being edited.

(No `CLAUDE.md` addition — that would load on every session for a narrow, file-local constraint the in-file comment already surfaces. `docs/README.md`, mentioned in the issue as a second place to note this "once it exists", does not exist yet, so this PR only touches the four docs themselves.)

## Testing

- `./run-tests.sh core -- -k achievements` — 96 passed, including the ruff/format/codespell/deptry/pip-audit/pyright/OpenAPI-drift/screenshot-wiring/eval-sync/frontend-build gates that run ahead of pytest.

Closes #3000

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)