### PR TITLE
Identify browse-canvas bins by (level, q, r), not (q, r) alone

### DIFF
--- a/frontend/src/app/components/browse-canvas/bin-geometry.spec.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.spec.ts
@@ -5,6 +5,7 @@ import {
   hoverThumbHalfExtents,
   imageTileFitDimensions,
   pickCell,
+  sameBin,
   SQRT3,
   type BinGeometry,
 } from './bin-geometry';
@@ -261,6 +262,39 @@ describe('bin-geometry', () => {
       const big = imageTileFitDimensions(300, 100, 10, 'balanced');
       expect(big.dw).toBeCloseTo(2 * small.dw);
       expect(big.dh).toBeCloseTo(2 * small.dh);
+    });
+  });
+
+  describe('sameBin', () => {
+    it('matches the same (q, r) at the same level', () => {
+      expect(sameBin(2, { q: 3, r: -1 }, 2, { q: 3, r: -1 })).toBe(true);
+    });
+
+    it('does not match the same (q, r) across levels (issue #2967)', () => {
+      // The lattice origin exists at every level, so (0, 0) is the guaranteed
+      // collision — the pinned/hovered cell from level 1 is a different bin from
+      // level 2's (0, 0) even though the axial coords are identical.
+      expect(sameBin(1, { q: 0, r: 0 }, 2, { q: 0, r: 0 })).toBe(false);
+      expect(sameBin(0, { q: 4, r: 7 }, 1, { q: 4, r: 7 })).toBe(false);
+    });
+
+    it('does not match different cells within a level', () => {
+      expect(sameBin(1, { q: 0, r: 0 }, 1, { q: 0, r: 1 })).toBe(false);
+      expect(sameBin(1, { q: 0, r: 0 }, 1, { q: 1, r: 0 })).toBe(false);
+    });
+
+    it('treats an absent cell as never matching, including another absent one', () => {
+      expect(sameBin(1, null, 1, { q: 0, r: 0 })).toBe(false);
+      expect(sameBin(1, { q: 0, r: 0 }, 1, undefined)).toBe(false);
+      expect(sameBin(-1, null, -1, null)).toBe(false);
+    });
+
+    it('ignores fields beyond (level, q, r)', () => {
+      // Cells are re-fetched into fresh objects when a tile is evicted and
+      // reloaded, so identity must not depend on object reference or payload.
+      const a = { q: 1, r: 2, cx: 10, cy: 20, count: 5, rep_id: 7 };
+      const b = { q: 1, r: 2, cx: 10, cy: 20, count: 6, rep_id: 9 };
+      expect(sameBin(3, a, 3, b)).toBe(true);
     });
   });
 

--- a/frontend/src/app/components/browse-canvas/bin-geometry.ts
+++ b/frontend/src/app/components/browse-canvas/bin-geometry.ts
@@ -179,6 +179,35 @@ export function pickCell<T extends CellCentre>(
   return null;
 }
 
+/** The minimum an identity check needs of a cell: its axial coordinates. */
+export interface CellAxial {
+  q: number;
+  r: number;
+}
+
+/**
+ * Whether two cells are the *same bin*. Axial `(q, r)` repeats across pyramid
+ * levels — every level has its own `(0, 0)` at the lattice origin, and finer
+ * levels reuse the coarse coordinates generally — so a bin is identified by the
+ * pair **plus** the level it was resolved at, never by `(q, r)` alone. Comparing
+ * on `(q, r)` alone lets a level-crossing zoom silently swap in a different,
+ * finer cell that happens to share the coordinates (issue #2967).
+ *
+ * Takes the levels alongside the cells (rather than a `{level, q, r}` object) so
+ * callers in per-cell render loops can compare without allocating. A `null`
+ * cell on either side is never the same bin as anything, including another
+ * `null`.
+ */
+export function sameBin(
+  aLevel: number,
+  a: CellAxial | null | undefined,
+  bLevel: number,
+  b: CellAxial | null | undefined,
+): boolean {
+  if (!a || !b) return false;
+  return aLevel === bLevel && a.q === b.q && a.r === b.r;
+}
+
 /**
  * Half-extents (screen px) of a hovered break-out thumbnail with the given
  * `aspect` (image width / height), centred on a cell of screen `radius` and

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -19,6 +19,7 @@ import {
   hoverThumbHalfExtents,
   imageTileFitDimensions,
   pickCell,
+  sameBin,
   type TileFit,
 } from './bin-geometry';
 import {
@@ -429,6 +430,15 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
 
   private hoveredCell: HexCellPayload | null = null;
   /**
+   * Pyramid level {@link hoveredCell} was resolved at, or -1 when nothing is
+   * hovered. A cell's axial ``(q, r)`` is only unique *within* a level, so the
+   * level travels alongside the payload (which carries no level of its own) and
+   * every identity check goes through {@link sameBin}. Without it a zoom that
+   * crosses a level boundary matches the stale hover against a different,
+   * finer same-``(q, r)`` cell — see issue #2967.
+   */
+  private hoveredLevel = -1;
+  /**
    * A bin "pinned" enlarged because its detail popup (right-click) is open.
    * Independent of the live hover: it stays enlarged as long as the popup is up,
    * so the user can tell which bin the details belong to. While a cell is pinned,
@@ -438,6 +448,12 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
    * path as a hover; see the ``pinnedCell ?? hoveredCell`` pick in {@link draw}.
    */
   private pinnedCell: HexCellPayload | null = null;
+  /** Pyramid level {@link pinnedCell} was pinned at, or -1 when nothing is
+   *  pinned. Same role as {@link hoveredLevel}: the pin survives wheel zooms, so
+   *  after a level-crossing zoom the pinned bin no longer exists among the drawn
+   *  cells and nothing is enlarged — rather than the wrong bin being enlarged
+   *  while the details panel still describes the original. */
+  private pinnedLevel = -1;
   private hoverDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   // Last known cursor position over the canvas (canvas-relative mx/my plus the
   // viewport clientX/clientY) and whether the pointer is currently inside.
@@ -1417,14 +1433,17 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     // so the read-out is a size bump rather than a border — leaving the border
     // free to encode selection state. A pinned cell (its detail popup is open)
     // wins over the live hover, so the bin whose details are showing stays
-    // enlarged even as the cursor moves off it.
+    // enlarged even as the cursor moves off it. Matched by (level, q, r) via
+    // `sameBin`: the pin outlives a wheel zoom, and axial coords alone would
+    // match some unrelated finer cell once the zoom crosses a level.
     const enlargedCell = this.pinnedCell ?? this.hoveredCell;
+    const enlargedLevel = this.pinnedCell ? this.pinnedLevel : this.hoveredLevel;
     let hovered: { cell: HexCellPayload; sx: number; sy: number } | null = null;
     for (const cell of allCells) {
       const [sx, sy] = this.projToScreen(cell.cx, cell.cy);
       if (sx < -screenRadius * 2 || sx > this.width + screenRadius * 2) continue;
       if (sy < -screenRadius * 2 || sy > this.height + screenRadius * 2) continue;
-      if (enlargedCell && enlargedCell.q === cell.q && enlargedCell.r === cell.r) {
+      if (sameBin(enlargedLevel, enlargedCell, level, cell)) {
         hovered = { cell, sx, sy };
         continue;
       }
@@ -2430,7 +2449,11 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     // its true hex, so a raw hit-test at the cursor can land outside the true
     // silhouette and find nothing — which used to shrink the bin and take a
     // second click. The hovered cell is unambiguously what the user is aiming at.
-    const cell = this.hoveredCell ?? this.hitTest(mx, my);
+    const hovered = this.hoveredCell;
+    const cell = hovered ?? this.hitTest(mx, my);
+    // The level the pinned cell belongs to: the hover's own level when we reuse
+    // it, otherwise the level the fresh hit-test just resolved against.
+    const cellLevel = hovered ? this.hoveredLevel : this.activeLevel;
     // Stop the transient hover audition and drop the hover highlight; from here
     // the pinned cell drives the enlarge and the popup drives the audio.
     this.clearHover();
@@ -2454,6 +2477,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     // clicking another bin re-pins to it; dismissing the popup unpins via the
     // view calling {@link unpinCell}). Blank space clears any pin.
     this.pinnedCell = cell;
+    this.pinnedLevel = cell ? cellLevel : -1;
     this.requestRedraw();
     this.contextMenu.emit({
       clientX: event.clientX,
@@ -2473,6 +2497,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
   unpinCell(): void {
     if (!this.pinnedCell) return;
     this.pinnedCell = null;
+    this.pinnedLevel = -1;
     this.requestRedraw();
     if (this.pointerInside) {
       this.emitHoverHit(this.lastMouseX, this.lastMouseY, this.lastClientX, this.lastClientY);
@@ -2905,15 +2930,20 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     // post-zoom refresh path, which calls this directly).
     if (this.pinnedCell) return;
     const hit = this.hitTest(mx, my);
-    const prevQ = this.hoveredCell?.q;
-    const prevR = this.hoveredCell?.r;
+    const level = this.activeLevel;
+    const prev = this.hoveredCell;
+    const prevLevel = this.hoveredLevel;
     this.hoveredCell = hit;
+    this.hoveredLevel = hit ? level : -1;
     if (hit) {
-      if (hit.q !== prevQ || hit.r !== prevR) {
+      // Compared with the level included: a post-zoom refresh that lands on a
+      // finer cell sharing the old (q, r) is a *different* bin, so it must
+      // re-emit — otherwise the preview keeps describing the coarser bin.
+      if (!sameBin(level, hit, prevLevel, prev)) {
         this.hexHover.emit({ cell: hit, screenX: clientX, screenY: clientY });
         this.requestRedraw();
       }
-    } else if (prevQ != null) {
+    } else if (prev) {
       this.hexHover.emit(null);
       this.requestRedraw();
     }
@@ -2931,6 +2961,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
       this.emitHoverHit(this.lastMouseX, this.lastMouseY, this.lastClientX, this.lastClientY);
     } else if (this.hoveredCell) {
       this.hoveredCell = null;
+      this.hoveredLevel = -1;
       this.hexHover.emit(null);
       this.requestRedraw();
     }
@@ -2947,6 +2978,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     if (this.hoverDebounceTimer) clearTimeout(this.hoverDebounceTimer);
     if (this.hoveredCell) {
       this.hoveredCell = null;
+      this.hoveredLevel = -1;
       this.hexHover.emit(null);
       this.requestRedraw();
     }


### PR DESCRIPTION
Closes #2967

Axial `(q, r)` is only unique *within* one pyramid level, but two places in `browse-canvas.component.ts` compared cells by `(q, r)` alone:

1. **`draw()`** matched the enlarged cell (`pinnedCell ?? hoveredCell`) against the current level's cells. A pin survives a wheel zoom (`zoomBy` never clears it, and the docked details panel — the default — leaves the canvas wheel live), so a level-crossing zoom could enlarge a different, finer cell that happened to share `(q, r)` while the details panel still described the original bin. Guaranteed for `(0, 0)` at the lattice origin.
2. **`emitHoverHit()`** skipped re-emitting `hexHover` when the new hit shared `(q, r)` with the previous one. After `refreshHoverAfterZoom` re-resolved the hover at a new level, a same-`(q, r)` finer cell replaced `hoveredCell` with no event, leaving the browse view's hover preview (popup content/count, audio audition target) describing the old coarser bin.

## Changes

- **`bin-geometry.ts`**: new pure `sameBin(aLevel, a, bLevel, b)` helper. Takes levels alongside the cells rather than `{level, q, r}` objects so the per-cell render loop compares without allocating; a `null` cell never matches anything, including another `null`. Comparing on `(level, q, r)` rather than object reference keeps identity stable when a tile is evicted and re-fetched into fresh objects.
- **`browse-canvas.component.ts`**: `HexCellPayload` carries no level, so the resolving level is stamped alongside the state as `hoveredLevel` / `pinnedLevel` (`-1` when nothing is hovered/pinned) and cleared wherever the cell is cleared. Both comparison sites now go through `sameBin`. `onContextMenu` pins at the hover's own level when it reuses the hovered cell, otherwise at the level the fresh hit-test resolved against.

After a level-crossing zoom the pinned bin no longer exists among the drawn cells, so nothing is enlarged — rather than the wrong bin being enlarged. The pin itself is left intact (the details panel keeps showing what the user opened).

## Testing

- New `sameBin` cases in `bin-geometry.spec.ts`: same level matches, cross-level `(0, 0)` and `(4, 7)` do not, different cells within a level do not, absent cells never match, and identity ignores payload fields beyond `(level, q, r)`.
- `./run-tests.sh frontend` — build, audit, 2001 Vitest tests pass.
- `./run-tests.sh` — all 8193 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqdzAH2WGGF4SGzpnX91i

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYqdzAH2WGGF4SGzpnX91i)_