### PR TITLE
Snapshot ctx.medias under _state_lock before background iteration

### DIFF
--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -1006,6 +1006,53 @@ class TestBuildCoverageAtlasForContext:
         build_coverage_atlas_for_context(ctx)
         assert ctx.coverage_atlas is None
 
+    def test_survives_concurrent_media_inserts(self):
+        """Regression for #2958: this used to iterate ``ctx.medias.items()``
+
+        directly, with no lock, from the atlas route's spawned thread --
+        unlike every other cross-thread reader.  A writer inserting under
+        ``_state_lock`` (e.g. add-to-pile) while this iterates raised
+        ``RuntimeError: dictionary changed size during iteration``.  It now
+        snapshots under ``_state_lock`` first, so hammering inserts alongside
+        repeated builds must never raise.
+        """
+        import threading
+
+        from vtscore.state.core import DatasetContext, _state_lock
+        from vtscore.state.coverage import build_coverage_atlas_for_context
+
+        rng = np.random.default_rng(42)
+        ctx = DatasetContext("test_coverage_concurrent")
+        for i in range(10):
+            ctx.medias[i] = {
+                "id": i,
+                "embeddings": {"e5": rng.standard_normal(128).astype(np.float32)},
+            }
+
+        stop = threading.Event()
+        counter = {"next_id": 10_000}
+
+        def writer() -> None:
+            while not stop.is_set():
+                with _state_lock:
+                    media_id = counter["next_id"]
+                    counter["next_id"] += 1
+                    ctx.medias[media_id] = {
+                        "id": media_id,
+                        "embeddings": {"e5": rng.standard_normal(128).astype(np.float32)},
+                    }
+
+        thread = threading.Thread(target=writer, daemon=True)
+        thread.start()
+        try:
+            for _ in range(50):
+                build_coverage_atlas_for_context(ctx)
+        finally:
+            stop.set()
+            thread.join(timeout=5)
+
+        assert ctx.coverage_atlas is not None
+
 
 class TestBackgroundLoadThreadContext:
     """Regression for C3: background load tasks must pin the in-flight

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -1015,8 +1015,13 @@ class TestBuildCoverageAtlasForContext:
         ``RuntimeError: dictionary changed size during iteration``.  It now
         snapshots under ``_state_lock`` first, so hammering inserts alongside
         repeated builds must never raise.
+
+        The writer is bounded and paced: a tight unbounded loop would balloon
+        the vector set (and the k-means cost of every rebuild) without adding
+        anything to the race coverage.
         """
         import threading
+        import time
 
         from vtscore.state.core import DatasetContext, _state_lock
         from vtscore.state.coverage import build_coverage_atlas_for_context
@@ -1030,22 +1035,24 @@ class TestBuildCoverageAtlasForContext:
             }
 
         stop = threading.Event()
-        counter = {"next_id": 10_000}
 
         def writer() -> None:
-            while not stop.is_set():
+            next_id = 10_000
+            for _ in range(60):
+                if stop.is_set():
+                    return
                 with _state_lock:
-                    media_id = counter["next_id"]
-                    counter["next_id"] += 1
-                    ctx.medias[media_id] = {
-                        "id": media_id,
+                    ctx.medias[next_id] = {
+                        "id": next_id,
                         "embeddings": {"e5": rng.standard_normal(128).astype(np.float32)},
                     }
+                next_id += 1
+                time.sleep(0.001)
 
         thread = threading.Thread(target=writer, daemon=True)
         thread.start()
         try:
-            for _ in range(50):
+            for _ in range(15):
                 build_coverage_atlas_for_context(ctx)
         finally:
             stop.set()

--- a/tests_lib/datasets/test_archive_thumbnail_warm.py
+++ b/tests_lib/datasets/test_archive_thumbnail_warm.py
@@ -412,3 +412,69 @@ class TestKick:
             assert all(m["thumbnail_bytes"] for m in ctx.medias.values())
         finally:
             unregister_context(ctx.dataset_id)
+
+
+class TestConcurrentMutation:
+    """Regression tests for issue #2958.
+
+    ``pending_archive_thumbnail_ids`` used to be handed the live ``ctx.medias``
+    dict and iterate it directly from both ``warm_archive_thumbnails`` and
+    ``start_archive_thumbnail_warm`` -- with no lock, unlike every other
+    cross-thread reader.  A concurrent writer (e.g. add-to-pile, which inserts
+    under ``_state_lock``) racing that iteration raised ``RuntimeError:
+    dictionary changed size during iteration`` and aborted the pass.  Both
+    call sites now take a locked snapshot first; hammering inserts alongside
+    repeated calls must never raise.
+    """
+
+    @staticmethod
+    def _start_writer(ctx: DatasetContext) -> tuple[threading.Thread, threading.Event]:
+        from vtscore.state.core import _state_lock
+
+        stop = threading.Event()
+        counter = {"next_id": 10_000}
+
+        def writer() -> None:
+            while not stop.is_set():
+                with _state_lock:
+                    media_id = counter["next_id"]
+                    counter["next_id"] += 1
+                    ctx.medias[media_id] = {
+                        "id": media_id,
+                        "media_type": "image",
+                        "media_bytes": _jpeg_bytes(),
+                        "origin": {"importer": "server_folder", "params": {}},
+                    }
+
+        thread = threading.Thread(target=writer, daemon=True)
+        thread.start()
+        return thread, stop
+
+    def test_warm_pass_survives_concurrent_media_inserts(self, tmp_path: Path):
+        _archive, _payloads, medias = _image_corpus(tmp_path, n=10)
+        ctx = _ctx_with(medias, dataset_id="_warm_concurrent")
+        writer, stop = self._start_writer(ctx)
+        try:
+            for _ in range(50):
+                warm_archive_thumbnails(ctx, max_workers=2)
+        finally:
+            stop.set()
+            writer.join(timeout=5)
+            unregister_context(ctx.dataset_id)
+
+        assert all(m.get("thumbnail_bytes") for m in ctx.medias.values() if m.get("archive_member"))
+
+    def test_kick_survives_concurrent_media_inserts(self, tmp_path: Path):
+        _archive, _payloads, medias = _image_corpus(tmp_path, n=10)
+        ctx = _ctx_with(medias, dataset_id="_warm_kick_concurrent")
+        writer, stop = self._start_writer(ctx)
+        try:
+            for _ in range(50):
+                # A call this makes directly on the caller's thread (the
+                # pending check ahead of the JobManager kick) -- this is
+                # where the unlocked live iteration used to raise.
+                start_archive_thumbnail_warm(ctx)
+        finally:
+            stop.set()
+            writer.join(timeout=5)
+            unregister_context(ctx.dataset_id)

--- a/tests_lib/datasets/test_archive_thumbnail_warm.py
+++ b/tests_lib/datasets/test_archive_thumbnail_warm.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import io
 import tarfile
 import threading
+import time
 from pathlib import Path
 
 import numpy as np
@@ -428,23 +429,31 @@ class TestConcurrentMutation:
     """
 
     @staticmethod
-    def _start_writer(ctx: DatasetContext) -> tuple[threading.Thread, threading.Event]:
+    def _start_writer(ctx: DatasetContext, *, max_inserts: int = 300) -> tuple[threading.Thread, threading.Event]:
+        """A bounded, paced writer -- enough contention to race the snapshot,
+
+        capped so it can't balloon ``ctx.medias`` into the hundreds of
+        thousands and drag the surrounding test (or a shared xdist worker)
+        into a real hang.
+        """
         from vtscore.state.core import _state_lock
 
         stop = threading.Event()
-        counter = {"next_id": 10_000}
 
         def writer() -> None:
-            while not stop.is_set():
+            next_id = 10_000
+            for _ in range(max_inserts):
+                if stop.is_set():
+                    return
                 with _state_lock:
-                    media_id = counter["next_id"]
-                    counter["next_id"] += 1
-                    ctx.medias[media_id] = {
-                        "id": media_id,
+                    ctx.medias[next_id] = {
+                        "id": next_id,
                         "media_type": "image",
                         "media_bytes": _jpeg_bytes(),
                         "origin": {"importer": "server_folder", "params": {}},
                     }
+                next_id += 1
+                time.sleep(0.001)
 
         thread = threading.Thread(target=writer, daemon=True)
         thread.start()
@@ -455,7 +464,7 @@ class TestConcurrentMutation:
         ctx = _ctx_with(medias, dataset_id="_warm_concurrent")
         writer, stop = self._start_writer(ctx)
         try:
-            for _ in range(50):
+            for _ in range(20):
                 warm_archive_thumbnails(ctx, max_workers=2)
         finally:
             stop.set()
@@ -469,12 +478,18 @@ class TestConcurrentMutation:
         ctx = _ctx_with(medias, dataset_id="_warm_kick_concurrent")
         writer, stop = self._start_writer(ctx)
         try:
-            for _ in range(50):
-                # A call this makes directly on the caller's thread (the
-                # pending check ahead of the JobManager kick) -- this is
-                # where the unlocked live iteration used to raise.
-                start_archive_thumbnail_warm(ctx)
+            # This runs directly on the caller's thread (the pending check
+            # ahead of the JobManager kick) -- exactly where the unlocked
+            # live iteration used to raise.
+            job_id = start_archive_thumbnail_warm(ctx)
         finally:
             stop.set()
             writer.join(timeout=5)
-            unregister_context(ctx.dataset_id)
+
+        if job_id is not None:
+            from vtscore.concurrency.async_jobs import archive_thumbnail_jobs
+
+            job = archive_thumbnail_jobs.get(job_id)
+            if job is not None:
+                job.done_event.wait(timeout=30)
+        unregister_context(ctx.dataset_id)

--- a/vtscore/datasets/thumbnail_warm.py
+++ b/vtscore/datasets/thumbnail_warm.py
@@ -275,7 +275,11 @@ def warm_archive_thumbnails(
     number warmed so far -- a partial pass is a perfectly good outcome, since
     every un-warmed tile still resolves through the request path.
     """
-    pending = pending_archive_thumbnail_ids(ctx.medias)
+    from vtscore.state.core import _state_lock  # noqa: PLC0415
+
+    with _state_lock:
+        medias_snapshot = dict(ctx.medias)
+    pending = pending_archive_thumbnail_ids(medias_snapshot)
     if not pending:
         return 0
     total = len(pending)
@@ -368,7 +372,11 @@ def start_archive_thumbnail_warm(ctx: Any) -> str | None:
     requiring an explicit re-save, and costs nothing when the thumbnails did
     ride along.
     """
-    if not pending_archive_thumbnail_ids(ctx.medias):
+    from vtscore.state.core import _state_lock  # noqa: PLC0415
+
+    with _state_lock:
+        medias_snapshot = dict(ctx.medias)
+    if not pending_archive_thumbnail_ids(medias_snapshot):
         return None
     job = archive_thumbnail_jobs.start(
         ("archive-thumbnail-warm", ctx.dataset_id),

--- a/vtscore/state/coverage.py
+++ b/vtscore/state/coverage.py
@@ -123,8 +123,11 @@ def build_coverage_atlas_for_context(
 
     from vtscore.state.coverage_atlas import CoverageAtlas, auto_max_depth
 
+    with _state_lock:
+        medias_snapshot = dict(ctx.medias)
+
     vectors: dict[int, np.ndarray] = {}
-    for cid, media in ctx.medias.items():
+    for cid, media in medias_snapshot.items():
         emb = media_embedding(media)
         if emb is not None:
             vectors[cid] = np.asarray(emb, dtype=np.float32)


### PR DESCRIPTION
## Summary

`pending_archive_thumbnail_ids` was handed the live `ctx.medias` dict and iterated it directly from both `warm_archive_thumbnails` and `start_archive_thumbnail_warm` (`vtscore/datasets/thumbnail_warm.py`), and `build_coverage_atlas_for_context` (`vtscore/state/coverage.py`) iterated `ctx.medias.items()` directly from the coverage-atlas route's spawned thread. Neither took `_state_lock` or snapshotted first, unlike every other cross-thread reader (`snapshot_medias`, `cached_media_lookups`, `get_embedding_matrix`).

**Failure scenario:** while the archive-thumbnail warm-up sweep (or a coverage-atlas build) runs on a loaded dataset, a request thread adds a media (add-to-pile writes under `_state_lock`) → `RuntimeError: dictionary changed size during iteration` in the background thread → the warm pass for that dataset aborts (swallowed and logged by `_sweep`'s broad except, leaving the dataset cold) or the coverage-atlas build errors out.

## Fix

Both call sites now take a `dict(ctx.medias)` snapshot under `_state_lock` before iterating, matching the existing `snapshot_medias` pattern:

- `warm_archive_thumbnails` and `start_archive_thumbnail_warm` snapshot before calling `pending_archive_thumbnail_ids`.
- `build_coverage_atlas_for_context` snapshots before its vector-collection loop.

## Tests

Added regression tests that run a bounded, paced writer thread inserting into `ctx.medias` under `_state_lock` concurrently with repeated calls to the fixed functions, asserting no `RuntimeError` is raised:

- `tests_lib/datasets/test_archive_thumbnail_warm.py::TestConcurrentMutation`
- `tests/datasets/test_parallel_loading.py::TestBuildCoverageAtlasForContext::test_survives_concurrent_media_inserts`

Ran `./run-tests.sh` (full suite): `ALL 8132 TESTS PASSED (6 skipped, total: 8138)`.

Closes #2958

---

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TXsZBuhydPcLYY7rWDZcg5)_