### PR TITLE
Remove dead always-false guard in tests_lib pytest_unconfigure

### DIFF
--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -361,10 +361,6 @@ def pytest_unconfigure(config):
     """
     import sys
 
-    # If the app-tier conftest is loaded (i.e. pytest is collecting both
-    # trees, skip; its ``pytest_unconfigure`` already does the work.
-    if any("tests/conftest" in str(p) for p in getattr(config, "_inifile", None) and [config._inifile] or []):
-        return
     # Heuristic: only one of the two confests should print the summary.
     # When this conftest is loaded standalone (pytest tests_lib/), the
     # app conftest never gets imported.  Check by looking at registered


### PR DESCRIPTION
## Summary

`tests_lib/conftest.py`'s `pytest_unconfigure` had a guard that compared the string `"tests/conftest"` against `config._inifile`, which is `pyproject.toml` — it can never match, so the branch was unreachable dead code. `pytest.Config` doesn't even have an `_inifile` attribute (only `inipath`), so `getattr(config, "_inifile", None)` always returned `None`, and the convoluted `x and [y] or []` idiom silently reduced to `[]`.

The actually-working guard is the plugin-name check right below it, which checks whether the app-tier conftest (`tests.conftest`) is loaded as a plugin. That check is unaffected and remains in place.

## Changes

- Deleted the dead `_inifile`-based guard in `tests_lib/conftest.py:pytest_unconfigure`.
- Kept the plugin-name check, which is the guard that actually does the work.

## Testing

- `ruff check` / `ruff format --check` on the changed file: clean.
- `./run-tests.sh vtscore-clean`: **4024 passed, 2 xpassed** (0 failed).

Closes #2974

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XWHev2iDuu92SxMHfFLQK)_