### PR TITLE
Add an install-time opt-out for the two AGPL-3.0 dependencies

### DIFF
--- a/.claude/hooks/ensure-test-deps.sh
+++ b/.claude/hooks/ensure-test-deps.sh
@@ -60,7 +60,9 @@ SETUPTOOLS_USE_DISTUTILS=stdlib pip install apricot-select -q
 pip install --no-deps "toponymy==0.5.2" -q
 
 # Install all dependencies + editable install via pyproject.toml
-# (requirements/base.txt is just `-e .[dev]`).
+# (requirements/base.txt is just `-e .[dev,agpl]`; the `agpl` extra keeps
+# ultralytics + PyMuPDF installed so the YOLO/PDF tests still exercise the
+# real code paths rather than skipping).
 pip install --prefer-binary \
   -r "$REPO_DIR/requirements/base.txt" \
   -q

--- a/NOTICE
+++ b/NOTICE
@@ -41,11 +41,25 @@ anyone redistributing VTSearch or building a product on top of `vtscore`:
   * PyMuPDF - AGPL-3.0-or-later (or a commercial license from Artifex).
     Used by the PDF importer and the document converters.
 
-Both are imported lazily but are declared as install-time dependencies, so
-a default install pulls them in. VTSearch's own Apache-2.0 grant is
-unaffected, but the AGPL terms may attach to a combined work you
-distribute or operate as a network service. Uninstall these packages (and
-forgo the features that use them), or obtain suitable commercial terms, if
-that is incompatible with your deployment.
+A default install pulls both in, so the features that use them work out of
+the box. VTSearch's own Apache-2.0 grant is unaffected, but the AGPL terms
+may attach to a combined work you distribute or operate as a network
+service. If that is incompatible with your deployment, you can install
+without them:
+
+  * scripts/install.sh    VTSEARCH_NO_AGPL=1 bash scripts/install.sh
+  * pip                   pip install -r requirements/base-no-agpl.txt
+                          (or requirements/gpu-no-agpl.txt on CUDA hosts)
+  * docker                docker build --build-arg REQUIREMENTS=base-no-agpl.txt
+                          (or gpu-no-agpl.txt with docker/Dockerfile.gpu)
+
+Both packages sit in the `agpl` extra in pyproject.toml, which every
+default install path requests; the files and flags above are the same
+install with that extra dropped. The result is a permissively licensed
+install in which the YOLO image extractor and clipper, the PDF importer,
+and the document converters are unavailable and report themselves as such
+(vtscore/utils/optional_deps.py); everything else is unaffected. Obtaining
+commercial terms for these packages is the other option if you need the
+features.
 
   * soxr (audio resampling) - LGPL-2.1-or-later.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,14 @@ VTSearch is licensed under the [Apache License 2.0](LICENSE). That covers the so
 Two things it does **not** cover:
 
 - **Model weights are separately licensed.** VTSearch downloads embedding models at runtime rather than vendoring them, and each publisher sets its own terms; some are more restrictive than this project's license. EUPE (Perception Encoder) is released under the FAIR Noncommercial Research License and cannot be used commercially; DINOv3 is gated on Hugging Face and requires accepting its license before download. Embedders with a usage restriction advertise it via their descriptor's `license_notice` field, which the UI shows as a warning on the embedder picker. Check the terms of any model you enable before deploying.
-- **Two dependencies are copyleft.** `ultralytics` (used by the image extractor and clipper) and `PyMuPDF` (used by the PDF importer and document converters) are both AGPL-3.0. They are imported lazily but declared as install-time dependencies, so a default install pulls them in. VTSearch's own Apache-2.0 grant is unaffected, but the AGPL terms may attach to a combined work you redistribute or run as a network service. Uninstall those packages, or obtain commercial terms for them, if that doesn't suit your deployment.
+- **Two dependencies are copyleft, and can be skipped.** `ultralytics` (used by the image extractor and clipper) and `PyMuPDF` (used by the PDF importer and document converters) are both AGPL-3.0. A default install pulls them in, so those features work out of the box. VTSearch's own Apache-2.0 grant is unaffected, but the AGPL terms may attach to a combined work you redistribute or run as a network service. If that doesn't suit your deployment, install without them:
+
+  ```bash
+  VTSEARCH_NO_AGPL=1 bash scripts/install.sh      # or: pip install -r requirements/base-no-agpl.txt
+  docker build --build-arg REQUIREMENTS=base-no-agpl.txt -f docker/Dockerfile .
+  ```
+
+  Both packages live in the `agpl` extra in `pyproject.toml`, which every default install path requests; the commands above are the same install with that extra dropped. The result is permissively licensed, and the four features listed above report themselves as unavailable with an actionable message rather than half-working. Obtaining commercial terms for the packages is the other way to keep the features.
 
 See [NOTICE](NOTICE) for the full attribution and dependency-licensing statement.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,17 +33,27 @@ RUN apt-get update && \
 WORKDIR /app
 
 # ---------- dependency layer ----------
-# requirements/base.txt forwards to pyproject.toml via `-e .[dev]`, so the
+# requirements/base.txt forwards to pyproject.toml via `-e .[dev,agpl]`, so the
 # package source needs to be present when this layer builds. That means
 # any Python source change busts this layer; full source copy happens here.
 COPY requirements/ requirements/
 COPY pyproject.toml ./
 COPY vtsearch/ vtsearch/
 
+# The image includes the two AGPL-3.0 dependencies (ultralytics, PyMuPDF) by
+# default, so the YOLO and PDF/document features work out of the box in a
+# turnkey deployment. To build an image without them -- forgoing those
+# features -- point this at the opt-out mirror:
+#
+#   docker build --build-arg REQUIREMENTS=base-no-agpl.txt ...
+#
+# See NOTICE and docs/DEPLOYMENT.md.
+ARG REQUIREMENTS=base.txt
+
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
     pip install --no-cache-dir \
         --prefer-binary \
-        -r requirements/base.txt
+        -r "requirements/$REQUIREMENTS"
 
 # ---------- application layer ----------
 COPY . .

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -43,12 +43,22 @@ RUN apt-get update && \
 WORKDIR /app
 
 # ---------- dependency layer ----------
-# requirements/gpu.txt forwards to pyproject.toml via `-e .[dev]`, so the
+# requirements/gpu.txt forwards to pyproject.toml via `-e .[dev,agpl]`, so the
 # package source needs to be present when this layer builds. That means
 # any Python source change busts this layer; full source copy happens here.
 COPY requirements/ requirements/
 COPY pyproject.toml ./
 COPY vtsearch/ vtsearch/
+
+# The image includes the two AGPL-3.0 dependencies (ultralytics, PyMuPDF) by
+# default, so the YOLO and PDF/document features work out of the box in a
+# turnkey deployment. To build an image without them -- forgoing those
+# features -- point this at the opt-out mirror:
+#
+#   docker build --build-arg REQUIREMENTS=gpu-no-agpl.txt ...
+#
+# See NOTICE and docs/DEPLOYMENT.md.
+ARG REQUIREMENTS=gpu.txt
 
 # Pre-install numpy/scipy as binary-only wheels so the PyTorch extra-index
 # cannot pull in source tarballs that require g++. Then pin torch from the CUDA
@@ -64,7 +74,7 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
     pip install --no-cache-dir \
         --extra-index-url https://download.pytorch.org/whl/cu121 \
         --prefer-binary \
-        -r requirements/gpu.txt
+        -r "requirements/$REQUIREMENTS"
 
 # ---------- cuML / RAPIDS layer (GPU UMAP + k-means) ----------
 # cuML accelerates the VTSBrowse UMAP projection and the diversity-tree k-means

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -741,9 +741,10 @@ Add `--no-cache` after dependency changes to force a full rebuild.
 ## Dependency structure
 
 Runtime + dev dependencies are declared in `pyproject.toml` (under
-`[project.dependencies]` and `[project.optional-dependencies].dev`).
+`[project.dependencies]` and `[project.optional-dependencies]`, whose
+`dev` and `agpl` extras hold the dev tools and the two AGPL-3.0 packages).
 The top-level `requirements/base.txt` and `requirements/gpu.txt` just
-forward to it via `-e .[dev]`, so pyproject is the single source of
+forward to it via `-e .[dev,agpl]`, so pyproject is the single source of
 truth and deptry verifies every imported package is declared there.
 
 The labbench / image-embedders requirements files are deliberately
@@ -751,9 +752,11 @@ standalone (curated minimal subsets pinned for size-constrained Docker
 images) and do **not** flow through pyproject.
 
 ```
-pyproject.toml                       ← [project.dependencies] + [project.optional-dependencies].dev
-requirements/base.txt                ← --extra-index-url <cpu wheel index> + `-e .[dev]`
-requirements/gpu.txt                 ← `-e .[dev]` (install.sh / Dockerfile.gpu set --extra-index-url)
+pyproject.toml                       ← [project.dependencies] + [project.optional-dependencies] (dev, agpl)
+requirements/base.txt                ← --extra-index-url <cpu wheel index> + `-e .[dev,agpl]`
+requirements/gpu.txt                 ← `-e .[dev,agpl]` (install.sh / Dockerfile.gpu set --extra-index-url)
+requirements/base-no-agpl.txt        ← base.txt without the `agpl` extra (see below)
+requirements/gpu-no-agpl.txt         ← gpu.txt without the `agpl` extra (see below)
 requirements/labbench.txt            ← LabBench (SigLIP-only) image deps (standalone)
 requirements/image-embedders.txt     ← All-image-embedders image deps (CPU, standalone)
 requirements/image-embedders-gpu.txt ← All-image-embedders image deps (GPU, standalone)
@@ -770,6 +773,40 @@ bash scripts/install.sh cpu
 bash scripts/install.sh gpu
 ```
 
+### Installing without the AGPL dependencies
+
+Two runtime dependencies are AGPL-3.0-or-later: **`ultralytics`** (YOLO)
+and **`PyMuPDF`**. Every default install path includes them — the install
+scripts, both `requirements/{base,gpu}.txt`, and both Docker images — so
+the features that need them work out of the box. That is a deliberate
+choice for turnkey deployments, not an accident of the requirements
+fan-out: VTSearch's own Apache-2.0 grant is unaffected either way, but
+AGPL terms may attach to a combined work you redistribute or operate as a
+network service, and a service you host publicly is exactly the case
+AGPL's network clause is about.
+
+If your deployment cannot take copyleft code, install without them:
+
+```bash
+# Install script (CPU or GPU; picks the matching *-no-agpl.txt file)
+VTSEARCH_NO_AGPL=1 bash scripts/install.sh
+
+# pip, directly
+pip install -r requirements/base-no-agpl.txt      # CPU
+pip install -r requirements/gpu-no-agpl.txt       # CUDA hosts
+
+# Docker (same for Dockerfile.gpu with gpu-no-agpl.txt)
+docker build --build-arg REQUIREMENTS=base-no-agpl.txt -f docker/Dockerfile -t vtsearch .
+```
+
+What you give up: the YOLO image extractor and the YOLO image clipper,
+PDF import, and the document → image / document → text converters. Those
+fail with a message naming the missing package and how to get it
+(`vtscore/utils/optional_deps.py`) rather than erroring opaquely.
+Everything else — every embedder, every other media type, training,
+scoring, Browse — is unaffected. See [`NOTICE`](../NOTICE) for the full
+licensing statement.
+
 ### Key dependencies
 
 | Package | Version constraint | Purpose |
@@ -780,12 +817,12 @@ bash scripts/install.sh gpu
 | `numpy` | latest | Numeric arrays |
 | `flask` | latest | Web server |
 | `opencv-python-headless` | latest | Image processing (structural embedder, YOLO). **Not** used for video decoding — see [FIPS](#video-import-crashes-with-fatal-fips-selftest-failure) |
-| `ultralytics` | latest | YOLO-based image processing |
+| `ultralytics` | latest | YOLO-based image processing. AGPL-3.0; in the `agpl` extra, installed by default — see [Installing without the AGPL dependencies](#installing-without-the-agpl-dependencies) |
 | `laion_clap` | latest | Audio embedding preprocessing |
 | `librosa` | latest | Audio analysis (spectrograms, silence splitting) |
 | `soundfile` / `soxr` | latest | Audio decoding and resampling (`vtscore.media.audio.decode`) |
 | `imageio-ffmpeg` | latest | Bundled ffmpeg binary; audio codecs libsndfile can't read (AAC/M4A/MP4), and all video frame decoding (`vtscore.media.video.decode`) |
-| `PyMuPDF` | latest | Document (PDF/DOC/PPT) rendering and text extraction |
+| `PyMuPDF` | latest | Document (PDF/DOC/PPT) rendering and text extraction. AGPL-3.0; in the `agpl` extra, installed by default — see [Installing without the AGPL dependencies](#installing-without-the-agpl-dependencies) |
 
 ---
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -111,12 +111,17 @@ Runtime dependencies are declared in **`pyproject.toml`** under
 `[project.dependencies]`: that's the single source of truth, and deptry
 (wired into `lint.yml` and the pre-commit hook) verifies that every
 imported package is declared there. Dev tools (pytest, ruff,
-pre-commit, etc.) live under `[project.optional-dependencies].dev`.
+pre-commit, etc.) live under `[project.optional-dependencies].dev`, and
+the two AGPL-3.0 packages (`ultralytics`, `PyMuPDF`) under
+`[project.optional-dependencies].agpl` — an extra every default install
+path requests, so it is opt-*out*, not opt-in (see
+[DEPLOYMENT.md](DEPLOYMENT.md#installing-without-the-agpl-dependencies)).
 
 ```
-pyproject.toml                       # [project.dependencies] + [project.optional-dependencies].dev
-requirements/base.txt                # `--extra-index-url <cpu wheel index>` + `-e .[dev]`
-requirements/gpu.txt                 # `-e .[dev]` (install.sh / Dockerfile.gpu set --extra-index-url)
+pyproject.toml                       # [project.dependencies] + [project.optional-dependencies] (dev, agpl)
+requirements/base.txt                # `--extra-index-url <cpu wheel index>` + `-e .[dev,agpl]`
+requirements/gpu.txt                 # `-e .[dev,agpl]` (install.sh / Dockerfile.gpu set --extra-index-url)
+requirements/*-no-agpl.txt           # The same two files without the `agpl` extra (VTSEARCH_NO_AGPL=1)
 requirements/labbench.txt            # Standalone curated list for Dockerfile.labbench (image+SigLIP only)
 requirements/image-embedders*.txt    # Standalone curated lists for Dockerfile.image-embedders[.gpu]
 ```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -176,12 +176,21 @@ When activated, you'll see `(venv)` at the start of your terminal prompt.
 ## Installing dependencies
 
 Runtime + dev dependencies are declared in `pyproject.toml` (under
-`[project.dependencies]` and `[project.optional-dependencies].dev`).
+`[project.dependencies]` and `[project.optional-dependencies]`, whose
+`dev` and `agpl` extras hold the dev tools and the two AGPL-3.0 packages).
 `requirements/base.txt` and `requirements/gpu.txt` just forward to it via
-`-e .[dev]`, so pyproject is the single source of truth and deptry
+`-e .[dev,agpl]`, so pyproject is the single source of truth and deptry
 catches any drift. The labbench / image-embedders requirements files
 under `requirements/` are deliberately standalone; they pin a minimal
 subset for size-constrained Docker images.
+
+Two dependencies are AGPL-3.0-or-later — `ultralytics` (YOLO) and
+`PyMuPDF` — and a default install includes them. To install without them,
+set `VTSEARCH_NO_AGPL=1` on the install command below (or install
+`requirements/base-no-agpl.txt` directly); the YOLO extractor/clipper, PDF
+import, and the document converters then report themselves as unavailable
+and everything else works unchanged. See
+[DEPLOYMENT.md](DEPLOYMENT.md#installing-without-the-agpl-dependencies).
 
 One script handles both CPU and GPU. With no argument it **auto-detects**
 whether this host has an NVIDIA GPU and installs the matching dependency set,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ dependencies = [
     # Plugin deps that are imported from the codebase
     "sentence-transformers",
     "dnspython>=2.0.0",
-    "PyMuPDF",
     "librosa",
     "soundfile",
     # Resampler behind ``vtscore.media.audio.decode``. It arrives with librosa
@@ -92,7 +91,6 @@ dependencies = [
     "open_clip_torch",
     "timm",
     "ftfy",
-    "ultralytics",
     "opencv-python-headless",
     "imageio-ffmpeg",
     # Portable detector export: build a standalone ONNX scorer from a trained
@@ -120,6 +118,24 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# The AGPL-3.0-or-later runtime dependencies, split out so a deployment that
+# cannot take copyleft code has a way to say no. THIS EXTRA IS PART OF THE
+# DEFAULT INSTALL: every documented install path requests it
+# (`requirements/base.txt` and `requirements/gpu.txt` are `-e .[dev,agpl]`,
+# and both Dockerfiles install those files), so a normal install pulls these
+# in exactly as it did when they were hard dependencies. Opting out means
+# using the `*-no-agpl.txt` mirrors -- `VTSEARCH_NO_AGPL=1 bash
+# scripts/install.sh` -- and forgoing the features listed below, which then
+# fail with an actionable message from `vtscore.utils.optional_deps`.
+# See NOTICE and the License section of README.md.
+agpl = [
+    # PDF page rendering + document text extraction: vtscore.datasets.pdf,
+    # vtscore.converters.document2image / document2text.
+    "PyMuPDF",
+    # YOLO object detection: the image extractor (vtscore.media.image.extractor)
+    # and the image clipper (vtscore.media.image.clipper).
+    "ultralytics",
+]
 dev = [
     "pytest",
     "pytest-xdist",

--- a/requirements/base-no-agpl.txt
+++ b/requirements/base-no-agpl.txt
@@ -1,0 +1,26 @@
+# VTSearch: core dependencies for local development (CPU), minus the
+# AGPL-3.0 packages.
+#
+# Install:  pip install -r requirements/base-no-agpl.txt
+#
+# Identical to `requirements/base.txt` except that it does NOT request the
+# `agpl` extra, so `ultralytics` (YOLO) and `PyMuPDF` are never installed.
+# Use this when AGPL-3.0-or-later code cannot ship in your deployment: the
+# resulting install is permissively licensed, and the features that need
+# those packages -- the YOLO image extractor and clipper, the PDF importer,
+# and the document converters -- fail with an actionable message instead of
+# working. Everything else is unaffected.
+#
+# `requirements/base.txt` remains the default; this file is the opt-out.
+# `tests/core/test_requirements.py` enforces that the two stay in sync
+# apart from the requested extras.
+
+--extra-index-url https://download.pytorch.org/whl/cpu
+-e .[dev]
+
+# Transitive-dep security pin (not imported directly; required to keep
+# `pip-audit` clean in `run-tests.sh`). Drop the line if the version
+# pulled by requests/huggingface-hub already satisfies the constraint.
+# (urllib3's own pin lives in `[project.dependencies]` — we import it
+# directly for the SSRF guard's peer-checking transport adapter.)
+idna>=3.15  # CVE-2026-45409

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,9 +7,16 @@
 # in pyproject.toml. That makes pyproject.toml the single source of truth and
 # lets deptry catch drift from either side. The --extra-index-url pulls the
 # CPU-only torch wheel (~200 MB) instead of the default CUDA build (~2 GB).
+#
+# The `agpl` extra (ultralytics, PyMuPDF) is requested here so this file
+# installs exactly what it always has. To skip those two AGPL-3.0 packages,
+# install `requirements/base-no-agpl.txt` instead (or run the installer as
+# `VTSEARCH_NO_AGPL=1 bash scripts/install.sh`); see NOTICE. Keep the two
+# files in sync -- `tests/core/test_requirements.py` enforces that they
+# differ only in the extras.
 
 --extra-index-url https://download.pytorch.org/whl/cpu
--e .[dev]
+-e .[dev,agpl]
 
 # Transitive-dep security pin (not imported directly; required to keep
 # `pip-audit` clean in `run-tests.sh`). Drop the line if the version

--- a/requirements/gpu-no-agpl.txt
+++ b/requirements/gpu-no-agpl.txt
@@ -1,0 +1,15 @@
+# VTSearch: GPU dependencies (CUDA), minus the AGPL-3.0 packages.
+#
+# Identical to `requirements/gpu.txt` except that it does NOT request the
+# `agpl` extra, so `ultralytics` (YOLO) and `PyMuPDF` are never installed.
+# Use it wherever `gpu.txt` would be used (same --index-url / --extra-index-url
+# sequence for torch; see the header of that file) when AGPL-3.0-or-later code
+# cannot ship in your deployment. The features that need those packages -- the
+# YOLO image extractor and clipper, the PDF importer, the document converters
+# -- then fail with an actionable message instead of working.
+#
+# `requirements/gpu.txt` remains the default; this file is the opt-out.
+# `tests/core/test_requirements.py` enforces that the two stay in sync apart
+# from the requested extras.
+
+-e .[dev]

--- a/requirements/gpu.txt
+++ b/requirements/gpu.txt
@@ -5,9 +5,14 @@
 # from the chosen CUDA tag's index with --index-url (so PyPI can't override
 # the build with a mismatched-arch wheel), then install the rest of this file
 # with --extra-index-url. Like requirements/base.txt this forwards to
-# pyproject.toml; `[project.dependencies]` plus the `dev` extra.
+# pyproject.toml; `[project.dependencies]` plus the `dev` and `agpl` extras.
+#
+# `agpl` (ultralytics, PyMuPDF) is requested so this file installs exactly
+# what it always has. To skip those two AGPL-3.0 packages, install
+# `requirements/gpu-no-agpl.txt` instead (or run the installer as
+# `VTSEARCH_NO_AGPL=1 bash scripts/install.sh`); see NOTICE.
 
--e .[dev]
+-e .[dev,agpl]
 
 # --- GPU UMAP + k-means via cuML / RAPIDS ------------------------------------
 # cuML accelerates the VTSBrowse UMAP projection and the diversity-tree k-means

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,6 +64,18 @@ set -euo pipefail
 # the next approach" instead of a wall of red, and the raw output only surfaces if
 # a step actually fails. Set VTSEARCH_VERBOSE=1 to stream every command's raw
 # output live (no capture, no spinner) when debugging a genuinely stuck install.
+#
+# SKIPPING THE AGPL DEPENDENCIES: two runtime deps are AGPL-3.0-or-later --
+# ultralytics (YOLO) and PyMuPDF -- and a default install includes them, as it
+# always has. Set VTSEARCH_NO_AGPL=1 to install neither, for deployments that
+# cannot take copyleft code:
+#
+#   VTSEARCH_NO_AGPL=1 bash scripts/install.sh
+#
+# That installs requirements/{base,gpu}-no-agpl.txt instead of the default
+# requirements/{base,gpu}.txt. The YOLO image extractor and clipper, the PDF
+# importer, and the document converters then fail with a message naming the
+# missing package instead of working; nothing else changes. See NOTICE.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -815,6 +827,24 @@ vts_resolve_cuda_tag() {
     fi
 }
 
+# --- requirements-file choice (shared) ---------------------------------------
+# Echo the requirements file for the given flavour ("base" or "gpu"), honouring
+# the VTSEARCH_NO_AGPL opt-out. The default (unset/0) keeps the AGPL packages,
+# which is what every install has always done; VTSEARCH_NO_AGPL=1 swaps in the
+# `*-no-agpl.txt` mirror, which forwards to pyproject.toml without the `agpl`
+# extra. Also announces the choice, since a silently AGPL-free install would be
+# confusing when the YOLO/PDF features later report themselves missing.
+vts_requirements_file() {
+    local flavour="$1"
+    if [ "${VTSEARCH_NO_AGPL:-0}" = "1" ]; then
+        echo "  (VTSEARCH_NO_AGPL=1 -> skipping ultralytics + PyMuPDF; the YOLO" >&2
+        echo "   extractor/clipper, PDF import, and document converters stay unavailable)" >&2
+        echo "$REPO_ROOT/requirements/${flavour}-no-agpl.txt"
+    else
+        echo "$REPO_ROOT/requirements/${flavour}.txt"
+    fi
+}
+
 # --- pre-commit wiring (shared) ----------------------------------------------
 vts_install_precommit() {
     if [ -d "$REPO_ROOT/.git" ] && [ -f "$REPO_ROOT/.pre-commit-config.yaml" ]; then
@@ -828,7 +858,8 @@ vts_install_precommit() {
 # --- CPU install -------------------------------------------------------------
 # Installs runtime + dev dependencies and the vtsearch package itself (editable)
 # by forwarding to pyproject.toml via requirements/base.txt, which is just
-# `--extra-index-url <cpu wheel index>` + `-e .[dev]`.
+# `--extra-index-url <cpu wheel index>` + `-e .[dev,agpl]` (or the
+# `base-no-agpl.txt` mirror under VTSEARCH_NO_AGPL=1).
 # --- toponymy (VTSBrowse signpost naming) ------------------------------------
 # Two quirks force a dedicated step (see docs/plans/vtsbrowse-toponymy.md):
 #   - apricot-select (a real toponymy dep, declared in pyproject.toml) ships a
@@ -884,7 +915,7 @@ vts_install_cpu() {
     vts_install_toponymy
 
     vts_progress_step "Installing runtime + dev dependencies (this may take several minutes)"
-    pip install -r "$REPO_ROOT/requirements/base.txt" --progress-bar on
+    pip install -r "$(vts_requirements_file base)" --progress-bar on
 
     vts_progress_step "Installing FaceNet face embedder (facenet-pytorch, --no-deps)"
     vts_install_face_deps
@@ -1104,7 +1135,7 @@ vts_install_gpu() {
     vts_progress_step "Installing remaining dependencies via ${extra_index} (this may take several minutes)"
     pip install --extra-index-url "$extra_index" \
       --prefer-binary \
-      -r "$REPO_ROOT/requirements/gpu.txt" \
+      -r "$(vts_requirements_file gpu)" \
       --progress-bar on
 
     vts_progress_step "Installing FaceNet face embedder (facenet-pytorch, --no-deps)"

--- a/tests_lib/core/test_agpl_optional_extra.py
+++ b/tests_lib/core/test_agpl_optional_extra.py
@@ -1,0 +1,197 @@
+"""The AGPL-3.0 packages are an opt-*out* extra, not an opt-in one.
+
+``ultralytics`` and ``PyMuPDF`` are AGPL-3.0-or-later, so they live in the
+``agpl`` extra rather than in ``[project.dependencies]`` — but every default
+install path requests that extra, so a normal install is unchanged. Two things
+can silently break that arrangement, and both are cheap to pin down:
+
+* a default install path quietly *losing* the extra (users stop getting the
+  YOLO/PDF features, and the test suite stops covering those code paths), or
+* the ``*-no-agpl.txt`` mirrors drifting from the files they mirror, so the
+  opt-out install differs from the default in ways nobody intended.
+
+The rest of the file checks that opting out degrades with an actionable
+message instead of a bare ``ImportError``.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vtscore.utils.optional_deps import agpl_import_error, agpl_unavailable_message
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REQUIREMENTS = REPO_ROOT / "requirements"
+
+AGPL_PACKAGES = ("PyMuPDF", "ultralytics")
+
+
+def _pyproject() -> dict[str, Any]:
+    return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+
+
+def _requirement_lines(path: Path) -> list[str]:
+    """Requirement/option lines of a pip requirements file (comments dropped)."""
+    lines: list[str] = []
+    for raw in path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            lines.append(line)
+    return lines
+
+
+def _normalise(name: str) -> str:
+    return name.replace("_", "-").lower()
+
+
+# ---------------------------------------------------------------------------
+# Packaging: where the two packages are declared
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("package", AGPL_PACKAGES)
+def test_agpl_package_lives_in_the_agpl_extra(package: str) -> None:
+    project = _pyproject()["project"]
+    hard = {_normalise(d) for d in project["dependencies"]}
+    extra = {_normalise(d) for d in project["optional-dependencies"]["agpl"]}
+
+    assert _normalise(package) not in hard, (
+        f"{package} is AGPL-3.0-or-later and must stay in the `agpl` extra, not in "
+        "[project.dependencies] — otherwise there is no way to install without it."
+    )
+    assert _normalise(package) in extra, f"{package} is missing from [project.optional-dependencies].agpl"
+
+
+# ---------------------------------------------------------------------------
+# The default install paths keep requesting the extra
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["base", "gpu"])
+def test_default_requirements_request_the_agpl_extra(name: str) -> None:
+    """The default install is unchanged by the split: it still gets both packages."""
+    editable = [line for line in _requirement_lines(REQUIREMENTS / f"{name}.txt") if line.startswith("-e")]
+    assert editable == ["-e .[dev,agpl]"], (
+        f"requirements/{name}.txt must forward to `-e .[dev,agpl]` so a default install still installs the AGPL deps"
+    )
+
+
+@pytest.mark.parametrize("name", ["base", "gpu"])
+def test_no_agpl_mirror_matches_its_default_except_for_the_extra(name: str) -> None:
+    """The opt-out file differs from the default only in the requested extras."""
+    default = _requirement_lines(REQUIREMENTS / f"{name}.txt")
+    opt_out = _requirement_lines(REQUIREMENTS / f"{name}-no-agpl.txt")
+
+    assert "-e .[dev]" in opt_out, f"requirements/{name}-no-agpl.txt must forward to `-e .[dev]` (no `agpl` extra)"
+    assert [line for line in default if not line.startswith("-e")] == [
+        line for line in opt_out if not line.startswith("-e")
+    ], (
+        f"requirements/{name}.txt and requirements/{name}-no-agpl.txt have drifted apart. They must stay "
+        "identical apart from the requested extras, so opting out of AGPL changes nothing else."
+    )
+
+
+@pytest.mark.parametrize(
+    ("dockerfile", "expected"),
+    [("Dockerfile", "base.txt"), ("Dockerfile.gpu", "gpu.txt")],
+)
+def test_dockerfiles_default_to_the_agpl_requirements(dockerfile: str, expected: str) -> None:
+    """Images are turnkey deployments: they include the AGPL deps unless told otherwise."""
+    text = (REPO_ROOT / "docker" / dockerfile).read_text()
+    assert f"ARG REQUIREMENTS={expected}" in text, (
+        f"docker/{dockerfile} must default its REQUIREMENTS build arg to {expected}; the "
+        f"{expected.replace('.txt', '')}-no-agpl.txt file is the opt-in-to-opting-out path."
+    )
+    assert "requirements/$REQUIREMENTS" in text, f"docker/{dockerfile} must install the file named by $REQUIREMENTS"
+
+
+# ---------------------------------------------------------------------------
+# Degrading without the extra
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("package", AGPL_PACKAGES)
+def test_message_names_the_package_the_feature_and_the_fix(package: str) -> None:
+    message = agpl_unavailable_message(package, "Doing the thing")
+    assert "Doing the thing" in message
+    assert package in message
+    assert "VTSEARCH_NO_AGPL=1" in message
+    assert f"pip install {package}" in message
+
+
+def test_import_error_carries_the_message() -> None:
+    exc = agpl_import_error("PyMuPDF", "Rendering PDF pages")
+    assert isinstance(exc, ImportError)
+    assert "PyMuPDF" in str(exc)
+
+
+@pytest.fixture
+def without_module(monkeypatch: pytest.MonkeyPatch):
+    """Make ``import <name>`` fail, as it does on a VTSEARCH_NO_AGPL install."""
+
+    def _hide(name: str) -> None:
+        # A None entry in sys.modules makes the import machinery raise
+        # ImportError, without needing the package to be genuinely absent.
+        monkeypatch.setitem(sys.modules, name, None)  # pyright: ignore[reportArgumentType]
+
+    return _hide
+
+
+def test_pdf_render_reports_the_missing_package(without_module, tmp_path: Path) -> None:
+    from vtscore.datasets import pdf
+
+    without_module("fitz")
+    with pytest.raises(ImportError, match="PyMuPDF"):
+        pdf.render_pdf_pages(tmp_path / "nonexistent.pdf")
+
+
+def test_pdf_preview_reports_the_missing_package(without_module) -> None:
+    from vtscore.datasets import pdf
+
+    without_module("fitz")
+    with pytest.raises(ImportError, match="PyMuPDF"):
+        pdf.render_pdf_page_png(b"%PDF-1.4 not really a pdf")
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        ("vtscore.converters.document2image", "Document2ImageMediaConverter"),
+        ("vtscore.converters.document2text", "Document2TextMediaConverter"),
+    ],
+)
+def test_document_converters_report_the_missing_package(
+    without_module,
+    capsys: pytest.CaptureFixture[str],
+    module_path: str,
+    class_name: str,
+) -> None:
+    """Converters return no clips (their existing contract) but say why."""
+    import importlib
+
+    converter = getattr(importlib.import_module(module_path), class_name)()
+    without_module("fitz")
+
+    assert converter.convert({"filename": "doc.pdf", "media_bytes": b"%PDF-1.4"}) == []
+    assert "PyMuPDF" in capsys.readouterr().out
+
+
+def test_yolo_extractor_reports_the_missing_package(without_module) -> None:
+    from vtscore.media.image.extractor import ImageClassExtractor
+
+    without_module("ultralytics")
+    with pytest.raises(ImportError, match="ultralytics"):
+        ImageClassExtractor("people", "person").load_model()
+
+
+def test_yolo_clipper_reports_the_missing_package(without_module) -> None:
+    from vtscore.media.image.clipper import ImageObjectClipper
+
+    without_module("ultralytics")
+    with pytest.raises(ImportError, match="ultralytics"):
+        ImageObjectClipper()._load_model()

--- a/vtscore/README.md
+++ b/vtscore/README.md
@@ -143,10 +143,17 @@ Two carve-outs matter if you are embedding `vtscore` in your own product:
   its own weights. Some are noncommercial (EUPE, under the FAIR
   Noncommercial Research License) or gated (DINOv3). Embedders with a
   restriction expose it through their descriptor's `license_notice` field.
-- **Two dependencies are AGPL-3.0**: `ultralytics` (image extractor and
-  clipper) and `PyMuPDF` (PDF importer and document converters). Both are
-  lazily imported but declared as install-time dependencies. The Apache-2.0
-  grant on `vtscore` itself is unaffected, but AGPL terms may attach to a
-  combined work you distribute or operate as a service.
+- **Two dependencies are AGPL-3.0, and are skippable**: `ultralytics` (image
+  extractor and clipper) and `PyMuPDF` (PDF importer and document
+  converters). A default install includes both. The Apache-2.0 grant on
+  `vtscore` itself is unaffected, but AGPL terms may attach to a combined
+  work you distribute or operate as a service — so if you are shipping a
+  closed product on top of `vtscore`, install without them:
+  `VTSEARCH_NO_AGPL=1 bash scripts/install.sh`, or
+  `pip install -r requirements/base-no-agpl.txt`. Both packages live in the
+  `agpl` extra, which every default install path requests; dropping it
+  leaves a permissively licensed install in which those four features raise
+  an actionable error instead of running (see
+  `vtscore/utils/optional_deps.py`).
 
 See [`NOTICE`](../NOTICE) for the full statement.

--- a/vtscore/converters/document2image.py
+++ b/vtscore/converters/document2image.py
@@ -8,6 +8,7 @@ from typing import Any
 
 
 from vtscore.converters.base import MediaConverter, resolve_media_bytes
+from vtscore.utils.optional_deps import agpl_unavailable_message
 
 
 class Document2ImageMediaConverter(MediaConverter):
@@ -53,7 +54,7 @@ class Document2ImageMediaConverter(MediaConverter):
         try:
             import fitz  # noqa: PLC0415 - PyMuPDF
         except ImportError:
-            print("Document2ImageMediaConverter requires PyMuPDF: pip install PyMuPDF")
+            print(agpl_unavailable_message("PyMuPDF", "Converting documents to images"))
             return []
 
         results: list[dict[str, Any]] = []

--- a/vtscore/converters/document2text.py
+++ b/vtscore/converters/document2text.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from vtscore.converters.base import MediaConverter, resolve_media_bytes
+from vtscore.utils.optional_deps import agpl_unavailable_message
 
 
 class Document2TextMediaConverter(MediaConverter):
@@ -47,7 +48,7 @@ class Document2TextMediaConverter(MediaConverter):
         try:
             import fitz  # noqa: PLC0415 - PyMuPDF
         except ImportError:
-            print("Document2TextMediaConverter requires PyMuPDF: pip install PyMuPDF")
+            print(agpl_unavailable_message("PyMuPDF", "Extracting text from documents"))
             return []
 
         try:

--- a/vtscore/datasets/pdf.py
+++ b/vtscore/datasets/pdf.py
@@ -1,7 +1,8 @@
 """PDF page rendering utility.
 
 Converts each page of a PDF document into a PIL Image at a specified DPI.
-Requires the ``pymupdf`` package (``pip install pymupdf``).
+Requires ``PyMuPDF``, which a default install provides but the AGPL opt-out
+(``VTSEARCH_NO_AGPL=1``) leaves out - see :mod:`vtscore.utils.optional_deps`.
 
 Also provides :func:`load_pdf_images_into`, the shared folder-scan helper that
 expands every PDF in a directory into per-page image medias (used by the
@@ -14,6 +15,7 @@ import io
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from vtscore.utils.hashing import content_md5
+from vtscore.utils.optional_deps import agpl_import_error
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -31,7 +33,10 @@ def render_pdf_pages(pdf_path: Path, dpi: int = 150) -> list[tuple[str, "Image.I
         List of ``(page_name, pil_image)`` tuples.  ``page_name`` follows the
         pattern ``"filename.pdf-1"``, ``"filename.pdf-2"``, etc. (1-indexed).
     """
-    import fitz  # noqa: PLC0415  (pymupdf)
+    try:
+        import fitz  # noqa: PLC0415  (pymupdf)
+    except ImportError as exc:
+        raise agpl_import_error("PyMuPDF", "Rendering PDF pages") from exc
     from PIL import Image as PILImage  # noqa: PLC0415
 
     doc = fitz.open(str(pdf_path))
@@ -66,7 +71,10 @@ def render_pdf_page_png(pdf_bytes: bytes, page_index: int = 0, dpi: int = 150) -
         page_index: 0-indexed page to render (default the first page).
         dpi: Render resolution.
     """
-    import fitz  # noqa: PLC0415  (pymupdf)
+    try:
+        import fitz  # noqa: PLC0415  (pymupdf)
+    except ImportError as exc:
+        raise agpl_import_error("PyMuPDF", "Rendering a PDF page preview") from exc
     from PIL import Image as PILImage  # noqa: PLC0415
 
     try:

--- a/vtscore/docs/packages/converters.md
+++ b/vtscore/docs/packages/converters.md
@@ -430,7 +430,11 @@ CONVERTER = Text2EmojiMediaConverter()
   `document2*`, `openai-whisper` for `audio2text`). Each does the
   import inside `convert` and returns `[]` on `ImportError` rather
   than crashing - install the relevant extras before relying on a
-  converter.
+  converter. `pymupdf` is the one a *default* install still has but
+  can be deliberately left out (it is AGPL-3.0, so it sits in the
+  opt-out `agpl` extra); the `document2*` converters print the
+  message from `vtscore/utils/optional_deps.py` in that case, naming
+  the package and how to install it.
 - **Temporary files.** Converters that need a file path (e.g.
   `audio2image` decoding via librosa) write `media_bytes` to a
   `tempfile.NamedTemporaryFile`, run the operation, and `unlink` the

--- a/vtscore/media/image/clipper.py
+++ b/vtscore/media/image/clipper.py
@@ -7,6 +7,7 @@ import math
 from typing import Any, Optional
 
 from vtscore.media.clipper import MediaClipper
+from vtscore.utils.optional_deps import agpl_import_error
 
 
 class ImageDefaultClipper(MediaClipper):
@@ -286,7 +287,10 @@ class ImageObjectClipper(MediaClipper):
     def _load_model(self) -> None:
         if self._model is not None:
             return
-        from ultralytics import YOLO  # pyright: ignore[reportPrivateImportUsage] # noqa: PLC0415
+        try:
+            from ultralytics import YOLO  # pyright: ignore[reportPrivateImportUsage] # noqa: PLC0415
+        except ImportError as exc:
+            raise agpl_import_error("ultralytics", "The YOLO object clipper") from exc
 
         self._model = YOLO(self._model_id)
 

--- a/vtscore/media/image/extractor.py
+++ b/vtscore/media/image/extractor.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 
 from vtscore.media.image.decode import decode_bounded_rgb
 from vtscore.media.processors import Extractor
+from vtscore.utils.optional_deps import agpl_import_error
 
 
 class ImageClassExtractor(Extractor):
@@ -70,7 +71,10 @@ class ImageClassExtractor(Extractor):
     def load_model(self) -> None:
         if self._model is not None:
             return
-        from ultralytics import YOLO  # pyright: ignore[reportPrivateImportUsage]
+        try:
+            from ultralytics import YOLO  # pyright: ignore[reportPrivateImportUsage]
+        except ImportError as exc:
+            raise agpl_import_error("ultralytics", "The YOLO object extractor") from exc
 
         self._model = YOLO(self._model_id)
 

--- a/vtscore/utils/__init__.py
+++ b/vtscore/utils/__init__.py
@@ -11,6 +11,9 @@ Remaining here:
   non-security declaration stays in one place (keeps MD5 working on
   FIPS-enabled hosts).
 - :mod:`vtscore.utils.hits` - ``build_media_hit`` helper for scoring/route hit dicts.
+- :mod:`vtscore.utils.optional_deps` - actionable messages for the opt-out AGPL
+  packages (``ultralytics``, ``PyMuPDF``), which a default install has but an
+  ``VTSEARCH_NO_AGPL=1`` install deliberately lacks.
 - :mod:`vtscore.utils.scores` - ``sigmoid_to_finite_scores``/``finite_or`` for
   JSON-safe MLP scoring (no NaN/Infinity leaks to strict clients).
 - :mod:`vtscore.utils.synthetic` - Synthetic media generators for the offline demo importer.

--- a/vtscore/utils/optional_deps.py
+++ b/vtscore/utils/optional_deps.py
@@ -1,0 +1,68 @@
+"""Actionable errors for the opt-out (AGPL-3.0) dependencies.
+
+Two runtime dependencies are AGPL-3.0-or-later: ``ultralytics`` (YOLO) and
+``PyMuPDF``.  They live in the ``agpl`` extra in ``pyproject.toml`` rather than
+in ``[project.dependencies]``, but **every documented install path requests
+that extra** (``requirements/base.txt`` and ``requirements/gpu.txt`` are
+``-e .[dev,agpl]``, and both Dockerfiles install those files), so a normal
+install has them exactly as it always did.
+
+The split exists so a deployment that cannot take copyleft code can say no:
+``VTSEARCH_NO_AGPL=1 bash scripts/install.sh``, or installing the
+``requirements/*-no-agpl.txt`` mirrors directly.  On such an install the
+features backed by these packages are simply unavailable, and the bare
+``ImportError`` a lazy import would raise says nothing about why.  These
+helpers turn it into a message that names the package, the feature, and the
+way back.
+
+Every call site keeps its plain ``import`` inside a ``try`` (rather than going
+through :func:`importlib.import_module` here) so static analysis still sees the
+real module and its stubs::
+
+    try:
+        import fitz
+    except ImportError as exc:
+        raise agpl_import_error("PyMuPDF", "Rendering PDF pages") from exc
+"""
+
+from __future__ import annotations
+
+# Package name -> the pip install target and a one-line note on what it is.
+# Keyed by the distribution name as it appears in the ``agpl`` extra.
+_AGPL_PACKAGES: dict[str, str] = {
+    "PyMuPDF": "PDF rendering and document text extraction",
+    "ultralytics": "YOLO object detection",
+}
+
+
+def agpl_unavailable_message(package: str, feature: str) -> str:
+    """Explain that *feature* needs the opt-out AGPL package *package*.
+
+    Args:
+        package: Distribution name, e.g. ``"PyMuPDF"`` or ``"ultralytics"``.
+        feature: What the caller was trying to do, phrased as a sentence
+            subject, e.g. ``"Rendering PDF pages"``.
+
+    Returns:
+        A single-line message naming the package, why it may be missing, and
+        the two ways to get it back.
+    """
+    what = _AGPL_PACKAGES.get(package, "")
+    what = f" ({what})" if what else ""
+    return (
+        f"{feature} needs the '{package}' package{what}, which is not installed. "
+        f"It is AGPL-3.0-or-later, so it lives in VTSearch's optional 'agpl' extra: a default "
+        f"install includes it, but an install made with VTSEARCH_NO_AGPL=1 (or from a "
+        f"requirements/*-no-agpl.txt file) leaves it out on purpose. Install it with "
+        f"'pip install {package}', or reinstall with the extra: 'pip install -e .[agpl]'. "
+        f"See NOTICE for the licensing implications."
+    )
+
+
+def agpl_import_error(package: str, feature: str) -> ImportError:
+    """Build the :class:`ImportError` to raise from a failed AGPL-package import.
+
+    Raise it ``from`` the original ``ImportError`` so the underlying failure
+    (a genuinely broken install, rather than a missing one) stays visible.
+    """
+    return ImportError(agpl_unavailable_message(package, feature))


### PR DESCRIPTION
`ultralytics` (YOLO) and `PyMuPDF` are AGPL-3.0-or-later, and being hard entries in `[project.dependencies]` meant every install pulled copyleft code in with no way to say no.

Per the direction on #3048 ("Don't change the default. Instead, simply add an option to NOT install these. And add a note in the License section"), **the default is unchanged** — this adds the way out, not a new default.

## How the default stays the default

Both packages move into a new `agpl` extra, and every default install path requests it:

| Path | Before | After |
|---|---|---|
| `requirements/base.txt` | `-e .[dev]` + hard deps | `-e .[dev,agpl]` |
| `requirements/gpu.txt` | `-e .[dev]` + hard deps | `-e .[dev,agpl]` |
| `docker/Dockerfile{,.gpu}` | installs those files | unchanged (new `REQUIREMENTS` build arg defaults to them) |
| `scripts/install.sh`, `ensure-test-deps.sh` | installs those files | unchanged |

So a normal install, a Docker build, and the test suite all get exactly what they got before — the YOLO and PDF/document tests still exercise the real code paths rather than skipping.

## The opt-out

```bash
VTSEARCH_NO_AGPL=1 bash scripts/install.sh          # CPU or GPU; picks the matching file
pip install -r requirements/base-no-agpl.txt        # or gpu-no-agpl.txt
docker build --build-arg REQUIREMENTS=base-no-agpl.txt -f docker/Dockerfile .
```

The `*-no-agpl.txt` files are their default counterparts minus the extra. A test pins each pair together (identical apart from the requested extras), so the opt-out install can never quietly differ in anything else, and further tests pin the defaults to keep requesting `agpl` — a silent loss there would drop the features for everyone *and* stop the suite covering those paths, which is exactly the failure this split could otherwise introduce.

## Degrading when you opt out

The five lazy import sites — PDF page rendering and preview, both document converters, the YOLO extractor and the YOLO clipper — now report the missing package, why it may be absent, and how to get it back, via a new `vtscore/utils/optional_deps.py`:

```
Rendering PDF pages needs the 'PyMuPDF' package (PDF rendering and document text
extraction), which is not installed. It is AGPL-3.0-or-later, so it lives in
VTSearch's optional 'agpl' extra: a default install includes it, but an install made
with VTSEARCH_NO_AGPL=1 (or from a requirements/*-no-agpl.txt file) leaves it out on
purpose. Install it with 'pip install PyMuPDF', or reinstall with the extra:
'pip install -e .[agpl]'. See NOTICE for the licensing implications.
```

Each site keeps its plain `import` inside a `try` (rather than routing through `importlib`) so pyright still sees the real module and its stubs. The converters keep their existing "return `[]`" contract and print the message; the extractor/clipper/PDF paths raise `ImportError`, as they already did — just legibly now.

Per the answered scope question, this stops at actionable errors; making the plugins advertise themselves as unavailable so the UI hides them was the larger option and is not included.

## License notes

`README.md` and `vtscore/README.md` License sections, the dependency section of `NOTICE`, and a new **Installing without the AGPL dependencies** section in `docs/DEPLOYMENT.md` all now say the two packages ship by default and how to skip them, plus what you give up. `docs/SETUP.md`, `docs/EXTENDING.md`, and the converters package doc pick up the same pointer. The Docker images including the packages is now a stated choice rather than an accident of the requirements fan-out.

## Testing

`./run-tests.sh` — `ALL 8166 TESTS PASSED (6 skipped, 1 xfailed, total: 8172)`, including ruff, `ruff format --check`, codespell, deptry, pip-audit, pyright, the eval/app sync gate, and the frontend build. deptry is clean with the packages in an extra (it reads optional-dependencies as declared).

The opt-out path was also exercised end to end in this container: `VTSEARCH_NO_AGPL=1` resolved to `requirements/base-no-agpl.txt` and pip installed it cleanly, and the default `base.txt` install (via `ensure-test-deps.sh`) still lands `fitz` and `ultralytics`.

Unrelated observation, not touched here: `scripts/install.sh` pins `setuptools<82`, and setuptools 81 carries PYSEC-2026-3447, which trips the `pip-audit` gate on a box installed that way.

Closes #3048

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxZkZcN7eJsH5oPHNvCWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxZkZcN7eJsH5oPHNvCWyW)_