### PR TITLE
docs: replace the retired MLP head with the linear/logistic head

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # VTSearch
 
-Trainable media search tool. Searches collections of audio, images, text, video, and documents using a **detector**: a small trained ranker that scores each item by how well it matches. Two ways to search: **train a new detector** (vote good/bad on a handful of items; a small MLP learns to rank the rest) or **use an existing detector** (saved or imported). Trained detectors are reusable across compatible datasets. Text queries (LAION-CLAP, SigLIP, X-CLIP, E5 embeddings) seed either flow or work as a quick stand-alone search. Flask + Angular + PyTorch.
+Trainable media search tool. Searches collections of audio, images, text, video, and documents using a **detector**: a small trained ranker that scores each item by how well it matches. Two ways to search: **train a new detector** (vote good/bad on a handful of items; a linear (logistic) head learns to rank the rest) or **use an existing detector** (saved or imported). Trained detectors are reusable across compatible datasets. Text queries (LAION-CLAP, SigLIP, X-CLIP, E5 embeddings) seed either flow or work as a quick stand-alone search. Flask + Angular + PyTorch.
 
 Architecture, state model, plugin systems, auth, and the directory map all live in **`docs/ARCHITECTURE.md`**. This file holds the testing rules and the policy/gotchas that must be in context every turn.
 
@@ -148,18 +148,18 @@ If you *do* have a browser this session, drain the queue instead of growing it: 
 
 ## No Persisted Vectors or MLPs (CRITICAL)
 
-**Embeddings and trained MLP weights are in-memory artifacts only.** Never serialize them to disk, to `data/settings.json`, to detector JSON files, or to any other persistent store. Origins are the canonical persisted form: the system rederives `origin → file → embedding → MLP` on demand.
+**Embeddings and trained model weights are in-memory artifacts only.** Never serialize them to disk, to `data/settings.json`, to detector JSON files, or to any other persistent store. Origins are the canonical persisted form: the system rederives `origin → file → embedding → detector head` on demand.
 
 This rule applies to all detector code:
 
-- Detector JSON files store `LabeledElement`s with origin info, never embeddings or MLP weights.
+- Detector JSON files store `LabeledElement`s with origin info, never embeddings or model weights.
 - In-memory caches are fine and encouraged: `DetectorContext.label_embeddings`, `DetectorContext.model`, etc.: they live for the lifetime of the process and are repopulated from origins on the next start.
 - New features that cache vectors must use a process-scoped data structure (e.g. a field on `DetectorContext`), not a file or settings key.
 - Embedder version drift is impossible by construction because every load resolves+re-embeds against the active embedder.
 
 The single exception is **dataset pickle files**, which are by design a snapshot of media + their embeddings; they ARE the dataset, not a cache.
 
-If a feature seems to require persisting a vector or MLP, push back: either re-derive on demand, or change the design.
+If a feature seems to require persisting a vector or a trained head, push back: either re-derive on demand, or change the design.
 
 ## The Eval Default Arm IS the App (CRITICAL)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ VTSearch provides several CLI workflows for applying detectors to datasets, impo
 VTSearch is split into two Python packages along an **app tier / library tier** line:
 
 - **`vtsearch/`** — the app tier: Flask routes, authentication, settings, the achievements state machine, and the CLI entry point (`vtsearch/cli_main.py`). Anything that depends on Flask/Werkzeug lives here.
-- **`vtscore/`** — the library tier: the ML (training, MLP, thresholds), embedding runtime, media-type plugins (audio, image, text, video, document), converters, datasets/importers, exporters, labels, evaluation, projection (VTSBrowse), concurrency, security, and the plugin/sync machinery. It is import-clean of Flask so it can be reused as a standalone library. The CLI orchestration (`vtscore/cli.py`, `cli_pipeline.py`, `cli_progress.py`) lives here too.
+- **`vtscore/`** — the library tier: the ML (training, classifier head, thresholds), embedding runtime, media-type plugins (audio, image, text, video, document), converters, datasets/importers, exporters, labels, evaluation, projection (VTSBrowse), concurrency, security, and the plugin/sync machinery. It is import-clean of Flask so it can be reused as a standalone library. The CLI orchestration (`vtscore/cli.py`, `cli_pipeline.py`, `cli_progress.py`) lives here too.
 
 The remaining top level:
 
@@ -110,7 +110,7 @@ New to the project? Start with [docs/HANDOFF.md](docs/HANDOFF.md) for a full ori
 
 ## Machine learning
 
-VTSearch trains a small MLP neural network on user votes to learn a binary classifier over pretrained embeddings. See [docs/ML.md](docs/ML.md) for full details on the model architecture, training configuration, PyTorch settings, embedding models, and the Coverage Atlas that drives diversity sampling and domain-shift detection.
+VTSearch trains a **linear (logistic) head** — a single `Linear(input_dim, 1)` fitted with balanced binary cross-entropy — on user votes to learn a binary classifier over pretrained embeddings. See [docs/ML.md](docs/ML.md) for full details on the model architecture (including why the head is linear and where the older MLP path survives), training configuration, PyTorch settings, embedding models, and the Coverage Atlas that drives diversity sampling and domain-shift detection.
 
 ## Evaluation
 

--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -12,7 +12,7 @@
 ## Detectors
 
 A detector is a named labelset plus a text-sort query, persisted as a
-JSON file at `data/detectors/<name>.json`. The MLP is trained on demand
+JSON file at `data/detectors/<name>.json`. The head is trained on demand
 from the labelset and lives only in `DetectorContext` once the user
 loads the detector into memory.
 
@@ -99,12 +99,12 @@ regular label import).
 
 When the detector context **is** loaded, the new labels are also resolved
 against the loaded dataset's medias, applied to the detector's votes, and
-a fresh MLP is trained with a cross-validated threshold.
+a fresh head is trained with a cross-validated threshold.
 
 → `{"applied": 12, "skipped": 3, "resolved": 12, "trained": true, "num_labels": 62, "message": "..."}`
 
 `resolved` counts labels resolved into the loaded detector context (0 when no
-context is loaded); `trained` is `true` when a fresh MLP was retrained.
+context is loaded); `trained` is `true` when a fresh head was retrained.
 
 404 if detector or importer not found. 400 on validation errors.
 
@@ -214,7 +214,7 @@ GET /api/detectors/registry
 ```
 
 `name` is the slug used to look up the on-disk labelset file at
-`data/detectors/<name>.json`. The MLP is trained on demand from the
+`data/detectors/<name>.json`. The head is trained on demand from the
 labelset and lives only in RAM. `autofind` mirrors whether the
 detector's name appears in `autofind_detectors` settings (toggle it with
 the route below).
@@ -403,7 +403,7 @@ GET /api/detectors/registry/{detector_id}/stats
 ```
 
 Returns labelset composition and provenance for a registered detector.
-Counts and metadata only — never embeddings or MLP weights.
+Counts and metadata only — never embeddings or model weights.
 `num_positive_resolved` / `active_dataset_name` report how many of the
 detector's positive labels currently resolve into the loaded dataset (the
 set the dashboard's Browse button projects).

--- a/docs/api/find.md
+++ b/docs/api/find.md
@@ -133,7 +133,7 @@ POST /api/find-label
 
 Scores every loaded media with the given detector and applies Good/Bad labels
 to **all** elements by threshold, freezing scores and initial labels for the
-Find verification workflow. If no trained MLP is cached in the detector
+Find verification workflow. If no trained head is cached in the detector
 context, it trains on the fly from the detector's labelset (resolving label
 origins as needed).
 
@@ -171,7 +171,7 @@ POST /api/auto-detect
 **Body:** `{"detector_name": ""}` — omit / empty to run **every** detector
 flagged for Auto-Find on the active dataset's media type, or name a single one.
 
-Scores the active dataset with each Auto-Find detector, training each MLP on
+Scores the active dataset with each Auto-Find detector, training each head on
 demand, and returns one result column per detector.
 
 →

--- a/docs/api/labeling.md
+++ b/docs/api/labeling.md
@@ -99,7 +99,7 @@ POST /api/eval/train-and-score
 
 **Body:** `{"metric": "smart"}` (or `"stable"` / `"diverse"`; optional `"wait": true`)
 
-The work retrains a small MLP at every step of the label history, so it runs
+The work retrains the detector head at every step of the label history, so it runs
 on a background daemon thread. The route returns immediately with a `job_id`;
 poll `GET /api/eval/train-and-score/result` for the metric data and subscribe
 to the `eval` SSE channel for live progress. A signature cache short-circuits

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -188,7 +188,7 @@ opposite direction switches sides.
 `[x0, y0, x1, y1]` in normalised image coordinates (`0..1`,
 pre-rotation) that annotates *which region of the image* the user
 is voting good on. Persisted alongside the vote and consumed by
-region-aware MLP training (the trainer pools the box's patch-grid
+region-aware head training (the trainer pools the box's patch-grid
 cells on the fly). The box is dropped when the vote is toggled off
 or switched good → bad.
 
@@ -284,7 +284,7 @@ Status is `"idle"` or `"sorting"`.
 POST /api/learned-sort
 ```
 
-Trains an MLP on the current good/bad votes and scores all medias. Requires at
+Trains the detector head on the current good/bad votes and scores all medias. Requires at
 least one good and one bad vote.
 
 **Asynchronous by default.** Training is GIL-bound, so the endpoint hands the
@@ -340,7 +340,7 @@ Sets the cancel flag on the job; the training loop polls it cooperatively.
 Returns `{"ok": true}` (HTTP 200) even when the job has already finished — the
 contract is "make sure it's no longer running". Unknown `job_id`: HTTP 404.
 
-On patch datasets the MLP is max-pooled over each image's score-row
+On patch datasets the head is max-pooled over each image's score-row
 stack (the image-level vector plus every raw patch of its
 `patch_grid`), and each result carries `"best_region": [x0, y0, x1,
 y1]` for the row whose score won - the whole image when the
@@ -478,7 +478,7 @@ POST /api/label-file-sort
 **Form:** `file`: JSON file with a `labels` array. Each entry has `label`
 (`"good"` / `"bad"`) and a `path`/`file`/`filename` pointing to an audio file.
 
-Trains an MLP on the labeled files, then scores all loaded medias.
+Trains the detector head on the labeled files, then scores all loaded medias.
 
 → `{"results": [...], "threshold": 0.5123, "loaded": 10, "skipped": 2}`
 

--- a/vtscore/README.md
+++ b/vtscore/README.md
@@ -2,7 +2,7 @@
 
 The Flask-free, app-free core of [VTSearch](https://github.com/samggreenberg/vtsearch).
 A reusable Python library for trainable media search: dataset origins,
-MediaSources, clippers, embedders, MLP / detector training and scoring,
+MediaSources, clippers, embedders, detector training and scoring,
 and evaluation. The companion `vtsearch` Flask + Angular application wraps
 this library with the HTTP / SPA / settings layer; everything described
 here works without it.
@@ -13,7 +13,7 @@ Comprehensive developer documentation lives under [`docs/`](docs/):
 
 - **[Quickstart](docs/quickstart.md)** - load a folder, train a detector, score new media. Start here.
 - **[Architecture](docs/architecture.md)** - system overview, the seven seams between vtscore and vtsearch, the resolution chain for "active context".
-- **[Concepts](docs/concepts.md)** - `Media`, `Origin`, `LabelSet`, `Embedding`, `Context`, the MLP detector. The vocabulary every other doc assumes.
+- **[Concepts](docs/concepts.md)** - `Media`, `Origin`, `LabelSet`, `Embedding`, `Context`, the linear-head detector. The vocabulary every other doc assumes.
 - **[Package reference](docs/README.md#package-reference)** - one deep-dive guide per subpackage.
 - **[Extending vtscore](docs/extending/README.md)** - eleven plugin families with authoring guides for each.
 
@@ -80,7 +80,7 @@ The 17 subpackages and what they do:
 | `vtscore.media` | `MediaType` plugins (audio, image, text, video, document) + embedders + clippers |
 | `vtscore.embedding` | Embedder façade, torch runtime, cached `(N, D)` matrix |
 | `vtscore.datasets` | Origins, labelsets, loaders, importers, media sources |
-| `vtscore.training` | MLP / threshold / SVM / region-similarity primitives |
+| `vtscore.training` | Head (linear / MLP) / threshold / SVM / region-similarity primitives |
 | `vtscore.detectors` | Detector lifecycle: train, store, score, labelset sync |
 | `vtscore.eval` | Offline evaluation (text-sort, learned-sort, voting iterations) |
 | `vtscore.converters` | Cross-format converters (audio→spectrogram, ASR, OCR, …) |
@@ -111,9 +111,9 @@ See [docs/extending/](docs/extending/) for per-family authoring guides.
 
 ## Conventions
 
-- **No persisted vectors or MLP weights.** Embeddings and trained models
+- **No persisted vectors or model weights.** Embeddings and trained models
   live in-memory only. Origins are the canonical persisted form; the
-  library re-derives `origin → file → embedding → MLP` on demand. The
+  library re-derives `origin → file → embedding → head` on demand. The
   single exception is dataset pickle files, which are by design a
   snapshot of media + their embeddings.
 - **No hardcoded `data/` paths.** Every reference routes through

--- a/vtscore/docs/README.md
+++ b/vtscore/docs/README.md
@@ -2,7 +2,7 @@
 
 The `vtscore` library is the Flask-free, reusable core of
 [VTSearch](https://github.com/samggreenberg/vtsearch). It provides everything
-needed to load a dataset, embed media, train an MLP detector from labels,
+needed to load a dataset, embed media, train a detector from labels,
 score new media, and evaluate results - without any web framework, settings
 system, or UI dependency. The companion `vtsearch` Flask + Angular app wraps
 this library with the HTTP / SPA / settings layer.
@@ -16,7 +16,7 @@ For end users of the VTSearch web app, see the
 
 - [Quickstart](quickstart.md) - load a folder, train a detector, score new media. ~15 minute read.
 - [Architecture](architecture.md) - system overview, the seven seams between vtscore and vtsearch, the resolution chain for "active context".
-- [Concepts](concepts.md) - `Media`, `Origin`, `LabelSet`, `Embedding`, `Context`, the MLP detector. The vocabulary every other doc assumes.
+- [Concepts](concepts.md) - `Media`, `Origin`, `LabelSet`, `Embedding`, `Context`, the linear-head detector. The vocabulary every other doc assumes.
 
 ## Package reference
 
@@ -29,7 +29,7 @@ surface, worked examples, and gotchas.
 | `vtscore.media` | `MediaType`, embedder + clipper ABCs, processor ABCs | [packages/media.md](packages/media.md) |
 | `vtscore.embedding` | Embedder loaders, torch runtime, cached `(N, D)` matrix | [packages/embedding.md](packages/embedding.md) |
 | `vtscore.datasets` | Origins, labelsets, loaders, importers, media sources | [packages/datasets.md](packages/datasets.md) |
-| `vtscore.training` | MLP / threshold / SVM / region-similarity primitives | [packages/training.md](packages/training.md) |
+| `vtscore.training` | Head (linear / MLP) / threshold / SVM / region-similarity primitives | [packages/training.md](packages/training.md) |
 | `vtscore.detectors` | Detector lifecycle: train, store, score, labelset sync | [packages/detectors.md](packages/detectors.md) |
 | `vtscore.eval` | Offline evaluation: text-sort, learned-sort, voting iterations | [packages/eval.md](packages/eval.md) |
 | `vtscore.converters` | Cross-format converters (spectrogram, OCR, ASR, keyframes) | [packages/converters.md](packages/converters.md) |
@@ -65,10 +65,10 @@ library discovers it automatically. See:
 These rules hold across every package - internalise them once and the rest of
 the docs make sense:
 
-- **No persisted vectors or MLP weights.** Embeddings and trained models are
+- **No persisted vectors or model weights.** Embeddings and trained models are
   in-memory artefacts only. The on-disk persistence is `Origin` records
   inside `LabeledElement`s inside a detector's `LabelSet` JSON. On every load,
-  the library re-derives `origin → file → embedding → MLP` from those
+  the library re-derives `origin → file → embedding → head` from those
   origins. The single sanctioned exception is dataset pickle files, which
   are by design a snapshot of media plus their embeddings.
 - **No hardcoded `data/` paths.** Every filesystem reference goes through

--- a/vtscore/docs/architecture.md
+++ b/vtscore/docs/architecture.md
@@ -27,9 +27,10 @@ or *Context* are unfamiliar - this doc assumes them.
 1. **Turn media into embeddings.** Audio, images, text, video, documents go
    in via a `MediaEmbedder`; fixed-dimensional `(D,)` numpy vectors come
    out.
-2. **Train a small MLP on user-labelled embeddings.** Voted-good and
-   voted-bad media become `(X, y)`; an MLP plus a calibrated threshold
-   comes out.
+2. **Train a linear (logistic) head on user-labelled embeddings.** Voted-good
+   and voted-bad media become `(X, y)`; a `Linear(D, 1)` head plus a calibrated
+   threshold comes out. See [`docs/ML.md`](../../docs/ML.md) for why the head is
+   linear and where the older MLP path survives.
 3. **Score new media against a trained detector.** A new dataset is loaded,
    embedded, and ranked by the detector; the top results are exported.
 
@@ -39,7 +40,7 @@ extensible, and reproducible:
 - `vtscore.datasets` holds the data formats and loaders.
 - `vtscore.embedding` and `vtscore.media` hold the per-format embedder
   implementations.
-- `vtscore.training` holds the MLP / threshold primitives.
+- `vtscore.training` holds the classifier-head / threshold primitives.
 - `vtscore.detectors` orchestrates the full train→score→persist cycle.
 - `vtscore.plugins` plus the per-family registries make every component
   swappable and third-party-extensible.
@@ -207,7 +208,7 @@ ground rules:
   `set_thread_detector_context()` are how background threads tell the
   library which context they're operating on. The dataset-load and
   learned-sort job managers do this automatically when they spawn workers.
-- **Deterministic MLP training.** `train_model` uses a local
+- **Deterministic training.** `train_model` uses a local
   `torch.Generator` seeded with the caller-supplied seed (default 42) and
   wraps `nn.Dropout` initialisation in `torch.random.fork_rng()`, so
   parallel training calls don't race on the global RNG.
@@ -220,7 +221,7 @@ you allocate the threads and supply the contexts.
 
 Read this once and the persistence story makes sense.
 
-**Trained MLP weights and embeddings live in memory only.** They are never
+**Trained model weights and embeddings live in memory only.** They are never
 serialised to disk, never written to `data/settings.json`, never embedded
 inside a detector JSON file, never persisted anywhere.
 
@@ -280,7 +281,7 @@ vtscore/
 │   ├── video/
 │   └── document/
 ├── embedding/                          # embedder façade + cached matrix
-├── training/                           # MLP / thresholds / SVM / region-similarity
+├── training/                           # classifier head / thresholds / SVM / region-similarity
 ├── detectors/                          # full detector lifecycle
 │   ├── registry.py                     # in-memory detector registry
 │   ├── store.py                        # JSON labelset persistence
@@ -289,7 +290,7 @@ vtscore/
 │   ├── resolver.py                     # origin → file → embedding
 │   ├── label_sync.py / label_restoration.py / dataset_sync.py / media_seeding.py
 │   ├── labelset_elements.py / labelset_training.py
-│   └── labeling_progress.py            # per-step MLP cache + stopping conditions
+│   └── labeling_progress.py            # per-step model cache + stopping conditions
 ├── eval/                               # offline evaluation runner + metrics
 ├── converters/                         # audio↔image/text, video→audio/image, etc.
 ├── exporters/                          # EXPORTER-sentinel auto-discovery

--- a/vtscore/docs/concepts.md
+++ b/vtscore/docs/concepts.md
@@ -8,7 +8,7 @@ package docs read smoothly.
 3. [Origin](#3-origin) - provenance: how to find a media item again.
 4. [LabelSet / LabeledElement](#4-labelset--labeledelement) - voted labels with provenance.
 5. [Embedder](#5-embedder) - the model that turns a file into an embedding.
-6. [Detector](#6-detector) - the MLP + threshold that scores embeddings.
+6. [Detector](#6-detector) - the linear head + threshold that scores embeddings.
 7. [Context](#7-context) - per-dataset / per-detector mutable state holder.
 8. [Plugin](#8-plugin) - auto-discovered, swappable component of any family.
 
@@ -72,7 +72,7 @@ the embedder:
 The library also maintains a **cached embedding matrix** per
 `DatasetContext`: a contiguous `(N, D)` float32 array built lazily by
 `vtscore.embedding.matrix.get_embedding_matrix(ctx)` and reused across
-cosine sort, MLP scoring, and diversity-tree construction. The cache lives
+cosine sort, detector scoring, and diversity-tree construction. The cache lives
 in process memory only - it's never persisted - and is invalidated when
 the underlying `medias` dict changes.
 
@@ -186,19 +186,23 @@ and [extending/embedders.md](extending/embedders.md) to write your own.
 
 ## 6. Detector
 
-A **detector** in `vtscore` is a small MLP classifier plus a calibrated
-decision threshold, both derived from a `LabelSet`.
+A **detector** in `vtscore` is a **linear (logistic) classifier head** plus a
+calibrated decision threshold, both derived from a `LabelSet`.
 
 Architecture (`vtscore/training/mlp.py`):
 
 ```
 input  (D,)
-  → Linear(D, H)        # H auto-sized from training-set count
-  → ReLU
-  → Dropout(p)          # default 0.3
-  → Linear(H, 1)
+  → Linear(D, 1)        # hidden_dim=LINEAR_HEAD (0): no hidden layer
   → (no activation; train with BCEWithLogitsLoss)
 ```
+
+`build_model(input_dim, hidden_dim=N)` with `N > 0` still builds the older MLP
+(`Linear(D, H) → ReLU → Dropout(p) → Linear(H, 1)`, width from
+`_auto_hidden_dim`), but that path survives only for the eval harness's sweep
+arm and unit tests - production always passes `LINEAR_HEAD`. See
+[`docs/ML.md`](../../docs/ML.md#why-linear-and-where-the-mlp-survives) for why
+the head is linear.
 
 Training (`vtscore.training.train_model`):
 
@@ -208,7 +212,8 @@ Training (`vtscore.training.train_model`):
 - Local `torch.Generator` seeded with the caller-supplied seed
   (default 42) for deterministic weight init.
 - `torch.random.fork_rng()` around `nn.Dropout` so concurrent training
-  calls don't race on the global RNG.
+  calls don't race on the global RNG (the linear head has no dropout, so
+  this only bites the MLP arm).
 
 Thresholding (`vtscore/training/thresholds.py`):
 

--- a/vtscore/docs/extending/README.md
+++ b/vtscore/docs/extending/README.md
@@ -87,7 +87,7 @@ for the full dataclass and the [plugins package doc](../packages/plugins.md#plug
 for the field-type matrix.
 
 **Never persist vectors or trained model weights.** Embeddings are
-re-derived from origins on demand. MLP weights are retrained from the
+re-derived from origins on demand. The detector head is retrained from the
 linked labelset on each detector load. Plugins must not write either
 to disk, to `data/settings.json`, to detector JSON files, or to any
 other store. If your plugin appears to need a cache for vectors, put

--- a/vtscore/docs/extending/dataset-importers.md
+++ b/vtscore/docs/extending/dataset-importers.md
@@ -149,7 +149,7 @@ in the folder (e.g. `class_a/foo.wav` and `class_b/foo.wav` with a
 single `"foo.wav"` key) without an explicit relative-path entry for
 every match, the loader raises `ValueError`; supply the full
 relative path for each file to disambiguate. Don't persist vectors
-or MLP weights to disk on your own; the library re-derives them
+or model weights to disk on your own; the library re-derives them
 from origins.
 
 ## Multi-media imports

--- a/vtscore/docs/extending/labelset-sources.md
+++ b/vtscore/docs/extending/labelset-sources.md
@@ -79,7 +79,7 @@ metadata you want the receiving detector to adopt - input spec
 via `apply_detector_meta`
 ([`vtscore/detectors/input_spec.py`](../../detectors/input_spec.py))
 on import. Threshold is intentionally **not** persisted from
-`detector_meta` - the receiving detector retrains its MLP from the
+`detector_meta` - the receiving detector retrains its head from the
 imported labels and computes its own threshold; remember the
 [no-persisted-vectors-or-MLPs invariant](README.md#shared-rules-for-every-plugin).
 

--- a/vtscore/docs/faq.md
+++ b/vtscore/docs/faq.md
@@ -23,7 +23,7 @@ the architecture overview in [architecture.md](architecture.md).
 
 ### How is `vtscore` different from `vtsearch`?
 
-`vtscore` is the **library**: dataset loaders, embedders, MLP training,
+`vtscore` is the **library**: dataset loaders, embedders, detector training,
 detector lifecycle, evaluation. It has no Flask, no Angular, no settings
 JSON. `vtsearch` is the **application** that wraps `vtscore` with a
 Flask + Angular UI, a per-user settings system, and authentication.
@@ -174,10 +174,12 @@ fetching at runtime.
 
 ### How many labels do I need?
 
-The MLP works from about 4 labels (2 good, 2 bad) and improves through
-about 50. Above 100 the gains are mostly noise. The MLP hidden layer
-auto-sizes from the training-set count (see `_auto_hidden_dim` in
-`vtscore/training/mlp.py`).
+The detector works from about 4 labels (2 good, 2 bad) and improves through
+about 50. Above 100 the gains are mostly noise. The production head is linear
+(a single `Linear(D, 1)`, i.e. logistic regression), which is what makes it
+usable that low: with 3-5 positives an MLP is under-determined and its scores
+wobble from retrain to retrain. See
+[docs/ML.md](../../docs/ML.md#why-linear-and-where-the-mlp-survives).
 
 ### Is training deterministic?
 
@@ -227,7 +229,7 @@ contains:
 - Nothing else - **no embeddings, no model weights**.
 
 On load, the library re-derives every embedding from the origin and
-re-trains the MLP. This is by design - see
+re-trains the head. This is by design - see
 [architecture.md §The no-persisted-vectors rule](architecture.md#the-no-persisted-vectors-rule).
 
 ### Doesn't re-deriving embeddings on every load take forever?
@@ -269,7 +271,7 @@ the route layer handles this.)
 
 `DatasetContext` holds dataset-intrinsic state: the medias dict, the
 diversity tree, the cached embedding matrix. `DetectorContext` holds
-detector-intrinsic state: votes, the trained MLP, the threshold, the
+detector-intrinsic state: votes, the trained head, the threshold, the
 labelset source. One dataset can be open with multiple detectors active
 against it simultaneously; both contexts are independently registered.
 
@@ -363,7 +365,7 @@ process loads from disk (~5s) and subsequent uses are instant.
 dimensions × 4 bytes = ~200 MB. The cached matrix on `DatasetContext`
 lives only in process memory; clearing it is `invalidate_embedding_matrix(ctx)`.
 
-### My MLP training is using only one CPU core. Why?
+### My detector training is using only one CPU core. Why?
 
 `OMP_NUM_THREADS=1` and `MKL_NUM_THREADS=1` are set at import time as a
 memory-optimisation default (the project runs in many low-memory

--- a/vtscore/docs/integration.md
+++ b/vtscore/docs/integration.md
@@ -274,7 +274,7 @@ from vtscore.detectors.training import train_detector_from_origins
 def score_one(dataset_ctx: DatasetContext, detector_ctx: DetectorContext) -> dict:
     set_thread_dataset_context(dataset_ctx)
     set_thread_detector_context(detector_ctx)
-    # Re-derive the detector's MLP from its saved origins. Pass
+    # Re-derive the detector's head from its saved origins. Pass
     # detector_ctx.embedder so the re-embedded vectors match the embedder
     # the detector was originally trained with - never the media type's
     # default, which may have changed since save.

--- a/vtscore/docs/packages/concurrency.md
+++ b/vtscore/docs/packages/concurrency.md
@@ -34,7 +34,7 @@ The word "progress" shows up in two unrelated parts of `vtscore`:
 | Layer | Module | What it tracks |
 |-------|--------|----------------|
 | Long-running operation progress | `vtscore.concurrency.progress` | Dataset load / sort / eval / find - coarse-grained `(current, total, status, message)` for UI bars and cancel buttons |
-| Labeling-session analyzer | `vtscore.detectors.labeling_progress` | Per-step trained MLP cache + stopping-condition metrics |
+| Labeling-session analyzer | `vtscore.detectors.labeling_progress` | Per-step trained model cache + stopping-condition metrics |
 
 The labeling-session analyzer is **not** in this package. If you see
 `clear_progress_cache()` or `recreate_model_at_time()` referenced

--- a/vtscore/docs/packages/config.md
+++ b/vtscore/docs/packages/config.md
@@ -145,12 +145,12 @@ when one is in scope). Tests rely on this: they override
 | `TORCH_THREADS`          | `1`     | `VTSEARCH_TORCH_THREADS`      | Native thread count for OpenMP / MKL / `torch.set_num_threads`. Default 1 keeps RSS low in constrained envs.     |
 | `DEVICE`                 | `"auto"`| `VTSEARCH_DEVICE`             | Preferred compute device. `"auto"` resolves at call time; explicit `"cuda"`, `"cuda:0"`, `"cpu"`, `"mps"` are honoured, but a CUDA device the installed torch wheel can't actually run on falls back to `"cpu"`. |
 | `MAX_UPLOAD_MB`          | `2048`  | `VTSEARCH_MAX_UPLOAD_MB`      | HTTP body cap in megabytes (default 2 GiB). Oversized requests get HTTP 413. Set to `0` for unlimited (Flask's out-of-the-box behaviour). |
-| `TRAIN_EPOCHS`           | `200`   | `VTSEARCH_TRAIN_EPOCHS`       | Upper bound on MLP training epochs. `vtscore.training.mlp.train_model` may early-stop sooner.                    |
+| `TRAIN_EPOCHS`           | `200`   | `VTSEARCH_TRAIN_EPOCHS`       | Upper bound on head training epochs. `vtscore.training.mlp.train_model` may early-stop sooner.                   |
 | `TRAIN_PATIENCE`         | `10`    | `VTSEARCH_TRAIN_PATIENCE`     | Epochs the training loss must fail to improve before early-stop fires. `0` disables early-stop.                  |
 | `DEFAULT_CALIBRATE_COUNT`| `1`     | `VTSEARCH_CALIBRATE_COUNT`    | First-run default for `CoreConfig.calibrate_count`. Min 1.                                                       |
-| `MLP_HIDDEN_MIN`         | `8`     | -                             | Auto-sizing floor for MLP hidden width.                                                                          |
-| `MLP_HIDDEN_MAX`         | `32`    | -                             | Auto-sizing ceiling for MLP hidden width.                                                                        |
-| `MLP_DROPOUT`            | `0.5`   | -                             | Dropout rate for trained MLPs.                                                                                   |
+| `MLP_HIDDEN_MIN`         | `8`     | -                             | Auto-sizing floor for MLP hidden width. Legacy MLP head only - the production linear head has none.              |
+| `MLP_HIDDEN_MAX`         | `32`    | -                             | Auto-sizing ceiling for MLP hidden width. Legacy MLP head only.                                                  |
+| `MLP_DROPOUT`            | `0.5`   | -                             | Dropout rate for trained MLPs. Ignored by the production linear head.                                            |
 
 ### `resolve_device()`
 
@@ -249,7 +249,7 @@ Every env var consulted by `vtscore.config`, in one place:
 | `VTSEARCH_TORCH_THREADS`    | Set `TORCH_THREADS` (and therefore OMP / MKL caps). Floor of 1.                                 |
 | `VTSEARCH_DEVICE`           | Set `DEVICE`. `"auto"` is the default; pin to `"cuda"`, `"cuda:0"`, `"cpu"`, or `"mps"`.        |
 | `VTSEARCH_MAX_UPLOAD_MB`    | Set `MAX_UPLOAD_MB` (default 2048 MB). `0` = unlimited.                                         |
-| `VTSEARCH_TRAIN_EPOCHS`     | Set `TRAIN_EPOCHS` (MLP training upper bound).                                                  |
+| `VTSEARCH_TRAIN_EPOCHS`     | Set `TRAIN_EPOCHS` (head training upper bound).                                                 |
 | `VTSEARCH_TRAIN_PATIENCE`   | Set `TRAIN_PATIENCE` (early-stop patience). `0` disables.                                       |
 | `VTSEARCH_CALIBRATE_COUNT`  | Set `DEFAULT_CALIBRATE_COUNT` (first-run default; later writes go to per-user settings).        |
 
@@ -291,5 +291,5 @@ care which path produced the config.
 - `CoreConfig` is `frozen=True`. Background threads can safely hold
   a reference; in-flight reconfiguration requires building a new
   `CoreConfig` and routing it explicitly.
-- No persisted embeddings, no persisted MLP weights. This config
+- No persisted embeddings, no persisted model weights. This config
   module does not introduce a place to cache them.

--- a/vtscore/docs/packages/detectors.md
+++ b/vtscore/docs/packages/detectors.md
@@ -1,12 +1,12 @@
 # `vtscore.detectors` - Detector lifecycle, training, and labelset materialisation
 
 A **detector** in vtscore is the trained classifier you search with: a
-small MLP plus a calibrated threshold plus a `LabelSet`. This package
+linear (logistic) head plus a calibrated threshold plus a `LabelSet`. This package
 owns the resolve → embed → train pipeline that turns origin trails into
 a trained model, the on-disk JSON store that persists the labelset
 (never weights), the registry that tracks every detector the user has
 created, and a separate labeling-session analyzer that caches per-step
-MLPs so the stopping-condition UI can answer "should I keep voting?"
+models so the stopping-condition UI can answer "should I keep voting?"
 without retraining.
 
 The generic ML primitives this package builds on live in
@@ -20,7 +20,7 @@ origins into vectors live in `vtscore.embedding`.
 | `vtscore/detectors/registry.py`              | Persistent registry of detector entries (one JSON manifest)         |
 | `vtscore/detectors/store.py`                 | Per-detector on-disk JSON labelset file I/O                         |
 | `vtscore/detectors/training.py`              | `train_and_threshold`, `train_and_score`, `train_detector_from_origins` |
-| `vtscore/detectors/workflow.py`              | `apply_and_retrain` - combined "apply labels + retrain MLP" entry   |
+| `vtscore/detectors/workflow.py`              | `apply_and_retrain` - combined "apply labels + retrain" entry        |
 | `vtscore/detectors/resolver.py`              | Origin → file → embedding pipeline + pluggable resolvers            |
 | `vtscore/detectors/labelset_training.py`     | Train from the saved labelset (cross-dataset)                       |
 | `vtscore/detectors/labelset_elements.py`     | Stable element IDs, per-element views                               |
@@ -66,7 +66,7 @@ It contains **no weights, no embeddings, no scores**. On every load,
 weights are re-derived: each `LabeledElement.origin` is resolved to a
 file via an importer or media source, embedded with the active media
 type's embedder, and the resulting `(X_list, y_list)` is fed into
-`train_and_threshold`. The trained MLP + threshold live in
+`train_and_threshold`. The trained head + threshold live in
 `DetectorContext.model` / `.threshold` until the process ends or the
 labelset changes. This is the invariant the
 [CLAUDE.md "No Persisted Vectors or MLPs"](../../../CLAUDE.md) rule
@@ -233,7 +233,7 @@ sync flow:
    the UI like the user just cast them.
 3. Calls `sync_labels_to_loaded_detector()` so the on-disk labelset
    captures the new votes.
-4. Retrains the MLP via `train_and_score` when both polarities have
+4. Retrains the head via `train_and_score` when both polarities have
    labels, stores the model and threshold on `det_ctx`, and snapshots
    the voted medias into `det_ctx.training_medias`.
 
@@ -327,7 +327,7 @@ embedding.
 
 The detector's saved labelset is dataset-agnostic - every element is
 keyed by origin / md5. At load time, the labelset has to be resolved
-into a concrete embedding cache so the MLP can train. This is what
+into a concrete embedding cache so the head can train. This is what
 `labelset_training.py` does, and it's why one labelset trained on
 dataset A can score dataset B.
 
@@ -349,7 +349,7 @@ populated:
 
 If the active dataset's embedder name differs from
 `det_ctx.embedder`, the cache is cleared first - mixing vectors from
-two embedders into one MLP produces garbage.
+two embedders into one head produces garbage.
 
 ### `build_xy_from_labelset(det_ctx, labelset)`
 
@@ -453,7 +453,7 @@ obvious.
 - **`vtscore.concurrency.progress`** - long-running-operation
   progress and cancellation (`ProgressTracker`, `dataset_progress`,
   `sort_progress`, etc.).
-- **`vtscore.detectors.labeling_progress`** - per-step MLP cache and
+- **`vtscore.detectors.labeling_progress`** - per-step model cache and
   stopping-condition metrics. Used by the labeling-progress UI to
   answer "should I keep voting?" without retraining.
 
@@ -523,7 +523,7 @@ training clipper without reading the detector JSON.
 
 - **Labelset is the only persisted form.** Detector JSON files store
   `LabeledElement` lists; never weights, never embeddings, never
-  scores. Every load re-derives the MLP from origins.
+  scores. Every load re-derives the head from origins.
 - **Origins are stable across datasets.** `stable_element_id` is
   computed from origin / md5 fields, so the same training label
   identifies the same source file no matter which dataset is loaded.

--- a/vtscore/docs/packages/eval.md
+++ b/vtscore/docs/packages/eval.md
@@ -225,7 +225,7 @@ through `json.dumps(indent=2)`.
 `vtscore/eval/voting_iterations.py` simulates an interactive labelling
 session - votes are cast one at a time in the order the app's
 **Autopilot** would present them, and at each step (once both
-polarities have at least one vote) a fresh MLP is trained, a threshold
+polarities have at least one vote) a fresh head is trained, a threshold
 is computed, the held-out test set is scored, and the inclusion-weighted
 cost is recorded. This is how the team answers "how does cost drop as
 the user labels?" without spinning up a UI session.
@@ -247,8 +247,9 @@ by `sim_fraction`, then iterates:
 1. Pick the next vote with the autopilot selector (seed → Good → Bad →
    Hard → New) and apply it; mirror it onto the coverage atlas that
    drives the New phase.
-2. When both polarities have at least one vote, train an MLP
-   (`train_model`) and pick a threshold
+2. When both polarities have at least one vote, train the head
+   (`train_model`; the default arm passes `LINEAR_HEAD`, matching the app)
+   and pick a threshold
    (`calculate_cross_calibration_threshold`, with optional
    `calculate_safe_threshold` blend).
 3. Score `D_test`, compute FPR / FNR, weight by inclusion, record the
@@ -410,7 +411,7 @@ matplotlib is not in the library's core dependencies - installing
 ## Invariants worth restating
 
 - **No persisted weights.** `eval_learned_sort` and
-  `simulate_voting_iterations` train MLPs in memory and discard them
+  `simulate_voting_iterations` train heads in memory and discard them
   after scoring; no detector files are written.
 - **Deterministic.** Every function that produces randomness takes a
   `seed` argument; `np.random.RandomState(seed)` controls splits and

--- a/vtscore/docs/packages/labels.md
+++ b/vtscore/docs/packages/labels.md
@@ -228,9 +228,9 @@ block. When `sync_from_labelset_source` sees one, it folds the
 source's `input_spec` (and `media_type`, when the receiving detector
 is missing one) into the receiving detector's on-disk JSON. The
 source's `threshold` is intentionally **not** applied - the receiver
-retrains its MLP from the imported labels and recomputes its own
+retrains its head from the imported labels and recomputes its own
 threshold (`vtscore/labels/sync.py:296`). The detector files
-themselves only ever store origins and meta, never embeddings or MLP
+themselves only ever store origins and meta, never embeddings or model
 weights (CLAUDE.md "No Persisted Vectors").
 
 ### Configuration

--- a/vtscore/docs/packages/media.md
+++ b/vtscore/docs/packages/media.md
@@ -392,7 +392,7 @@ out-of-tree implementations.
   carry the old callback; prefer re-registering or calling
   `set_progress_callback` again.
 - **Embedders do not own a `to_disk` / `from_disk`.** Vectors and
-  trained MLP weights are in-memory artefacts only. Re-derive on
+  trained model weights are in-memory artefacts only. Re-derive on
   demand from origins (`Origin → file → embedding`). The single
   exception is dataset pickles, which snapshot media + embeddings as
   one unit (see [datasets](datasets.md)).
@@ -414,7 +414,7 @@ out-of-tree implementations.
   (`vtscore/media/torch_setup.py:16`) reads `vtscore.config.TORCH_THREADS`
   (env `$VTSEARCH_TORCH_THREADS`, default `1`) and calls
   `torch.set_num_threads` the first time torch is imported. Every
-  code path that touches torch (embedders, MLP training, scoring)
+  code path that touches torch (embedders, head training, scoring)
   must call this first. `embedder_load_setup` does it for you.
 
 ---

--- a/vtscore/docs/packages/state.md
+++ b/vtscore/docs/packages/state.md
@@ -3,7 +3,7 @@
 The runtime state package. Every loaded dataset and every loaded detector
 gets its own context object that bundles the mutable data structures
 operating on it - votes, label history, click times, the cached embedding
-matrix, the diversity tree, the trained MLP, the calibrated threshold.
+matrix, the diversity tree, the trained head, the calibrated threshold.
 The package also owns the resolution chain that picks which context is
 "active" for the current call (Flask request, background thread, or test
 harness), the helpers that operate on the active context, and the
@@ -36,7 +36,7 @@ infrastructure that drives long-running operations on these contexts.
 and `vtscore/state/core.py:122`. Both use `__slots__` so accidentally
 shadowing an attribute raises immediately. Every field is in-memory
 only; datasets persist via pickle, detectors via labelset JSON (origins
-+ labels only, never MLP weights - see the "No Persisted Vectors or
++ labels only, never model weights - see the "No Persisted Vectors or
 MLPs" rule in `CLAUDE.md`).
 
 ### `DatasetContext`
@@ -56,7 +56,7 @@ Per-dataset mutable state. One context per loaded dataset.
 
 The cached matrix is rebuilt lazily by
 `vtscore.embedding.matrix.get_embedding_matrix` and reused across
-cosine sort, MLP scoring, and diversity-tree construction so the library
+cosine sort, detector scoring, and diversity-tree construction so the library
 doesn't rebuild an `(N, D)` matrix per call. Cache validity is a single
 `media_revision` compare, so a mutation that changes vectors without
 changing the id set still invalidates it (root-cause Pattern #4). An
@@ -67,7 +67,7 @@ drops both the matrix and the diversity tree.
 ### `DetectorContext`
 
 Per-detector mutable state. Vote state, training artefacts, and the
-trained MLP live here - never on `DatasetContext`. One detector can be
+trained head live here - never on `DatasetContext`. One detector can be
 trained on labels collected against many datasets; the labelset is the
 canonical persisted form.
 
@@ -85,7 +85,7 @@ canonical persisted form.
 | `inclusion` | `int \| None` | Per-detector inclusion fraction override |
 | `training_medias` | `dict[int, dict[str, Any]]` | Voted medias with embeddings |
 | `label_embeddings` | `dict[str, np.ndarray]` | `stable_element_id -> embedding`, built from origins |
-| `model` | `torch.nn.Sequential \| None` | Trained MLP (process-lifetime only) |
+| `model` | `torch.nn.Sequential \| None` | Trained head (process-lifetime only) |
 | `threshold` | `float` | Calibrated decision threshold |
 | `labelset_good_count` / `labelset_bad_count` | `int` | Counts from the on-disk labelset (cross-dataset) |
 | `votes_dataset_id` | `str` | Dataset ID the cid-keyed dicts are valid against |

--- a/vtscore/docs/packages/sync.md
+++ b/vtscore/docs/packages/sync.md
@@ -148,7 +148,7 @@ pick it up.
   `vtscore/labels/sync.py` and `vtsearch/settings.py`, not here.
 - **It does not persist anything.** `SyncSource` is a contract;
   storage is whatever the subclass implements. The standard caveats
-  about persistence still apply - embeddings and trained MLP weights
+  about persistence still apply - embeddings and trained model weights
   are in-memory artefacts, not labels. See `CLAUDE.md` "No Persisted
   Vectors or MLPs" if you're tempted to round-trip more than label
   identifiers + their `good`/`bad` flag.

--- a/vtscore/docs/packages/training.md
+++ b/vtscore/docs/packages/training.md
@@ -5,8 +5,8 @@ the detector pipeline. Everything in this package operates on raw numpy
 arrays and PyTorch tensors - there are no media-type, embedder, vote,
 or context dependencies. Library consumers can use it as a stand-alone
 learned-sort toolkit: feed in `(N, D)` feature matrices and binary
-labels, get back a trained MLP, a calibrated threshold, and (optionally)
-patch-level cosine scoring against a query vector.
+labels, get back a trained classifier head, a calibrated threshold, and
+(optionally) patch-level cosine scoring against a query vector.
 
 The detector-specific glue that resolves votes → origins → embeddings →
 training data lives one layer up in [`vtscore.detectors`](detectors.md);
@@ -21,7 +21,7 @@ this package is the underlying ML core.
 | `vtscore/training/svm.py`                                             | `SVMClassifier` + `train_svm` prototype                         |
 | `vtscore/training/region_similarity.py`                               | Patch-level cosine scoring with bounding boxes                  |
 
-The package `__init__.py` re-exports the MLP and threshold names; SVM
+The package `__init__.py` re-exports the head-building and threshold names; SVM
 and region-similarity helpers are imported from their submodules.
 
 ```python
@@ -39,12 +39,32 @@ from vtscore.training.region_similarity import (
 
 ---
 
-## MLP trainer
+## Classifier-head trainer
 
-A small `Linear → ReLU → Dropout → Linear` classifier that emits raw
-logits. Built and trained from feature matrices and binary labels.
+A classifier that emits raw logits, built and trained from feature
+matrices and binary labels. The `hidden_dim` argument selects the head:
 
 ### Architecture
+
+**Linear (logistic) head - the production head.** Selected by the
+`hidden_dim=LINEAR_HEAD` (`0`) sentinel at `vtscore/training/mlp.py:34`:
+
+```python
+nn.Sequential(
+    nn.Linear(input_dim, 1),
+)
+```
+
+Trained through `train_model`'s balanced BCE-with-logits loop this *is*
+logistic regression. `dropout` is ignored (a bare linear map has nothing to
+regularise with dropout). Every production fit passes `LINEAR_HEAD`:
+`vtscore/detectors/training.py` does it for both the final model and the
+calibration fold models (so the threshold is always calibrated on the
+architecture the final model has), `labeling_progress.py` does it for the
+per-step stopping-condition models, and `labelset_training.py` inherits it by
+going through `train_and_threshold`.
+
+**MLP head - eval harness and tests only.** Any `hidden_dim > 0`:
 
 ```python
 nn.Sequential(
@@ -55,15 +75,29 @@ nn.Sequential(
 )
 ```
 
-Built by `build_model(input_dim, hidden_dim=64, dropout=0.0, generator=None)`
-at `vtscore/training/mlp.py:35`. Pass a seeded `torch.Generator` to
+This was the production head until the threshold-stability work (#2790): with
+only ~3-5 labelled positives the MLP is under-determined, each retrain wobbles
+the scores, and the calibrated cut lurches. It survives for the eval harness's
+head-sweep arm (see [eval.md](eval.md)) and unit tests, and is not reachable
+from the app. See [`docs/ML.md`](../../../docs/ML.md#why-linear-and-where-the-mlp-survives)
+for the measurements.
+
+Both are built by
+`build_model(input_dim, hidden_dim=64, dropout=0.0, generator=None)` at
+`vtscore/training/mlp.py:51`. Pass a seeded `torch.Generator` to
 deterministically re-initialise the `Linear` weights (Kaiming uniform
 on the weight matrix, uniform on the bias with the standard PyTorch
 fan-in bound).
 
-### Auto-sizing the hidden layer
+> Note the mismatch between the two defaults: `build_model`'s own
+> `hidden_dim=64` builds an MLP, and `train_model`'s `hidden_dim=None`
+> auto-sizes one. Neither default is the production head - callers that want
+> it must pass `LINEAR_HEAD` explicitly.
 
-`_auto_hidden_dim(n_train)` at `vtscore/training/mlp.py:25` chooses the
+### Auto-sizing the MLP hidden layer
+
+Only the MLP head uses this; the linear head has no hidden layer.
+`_auto_hidden_dim(n_train)` at `vtscore/training/mlp.py:37` chooses the
 hidden width from the number of training examples:
 
 ```python
@@ -72,26 +106,28 @@ return max(MLP_HIDDEN_MIN, min(MLP_HIDDEN_MAX, n_train // 3))
 
 With the default `MLP_HIDDEN_MIN=8` and `MLP_HIDDEN_MAX=32` (from
 `vtscore.config`), the heuristic keeps the model small when only a
-handful of labels exist - n_train=10 picks 4, n_train=60 picks 20,
-n_train=120 picks 32 (capped). The function is private but stable; the
-detector code in `vtscore/detectors/training.py:182` and
-`vtscore/detectors/labelset_training.py:277` use it to ensure
-cross-calibration fold models share the same architecture as the final
-full-data model, so fold thresholds are directly comparable.
+handful of labels exist - n_train=10 picks 8 (floored), n_train=60 picks 20,
+n_train=120 picks 32 (capped). The function is private but stable; the eval
+harness's `_resolve_hidden_dim` (`vtscore/eval/voting_iterations.py`) calls it
+for the `"mlp"` arm. The detector code no longer does - it passes `LINEAR_HEAD`
+for both the final model and the cross-calibration fold models, so fold
+thresholds stay directly comparable to the full-data model.
 
 ### Training
 
-`train_model(X_train, y_train, input_dim, inclusion_value=0, seed=42, hidden_dim=None)`
-at `vtscore/training/mlp.py:110` is the workhorse:
+`train_model(X_train, y_train, input_dim, seed=42, hidden_dim=None, sample_weights=None)`
+at `vtscore/training/mlp.py:139` is the workhorse:
 
 ```python
 import numpy as np, torch
 from vtscore.training import train_model
+from vtscore.training.mlp import LINEAR_HEAD
 
 X = torch.from_numpy(np.random.RandomState(0).standard_normal((60, 512)).astype(np.float32))
 y = torch.tensor([1.0] * 30 + [0.0] * 30).unsqueeze(1)
 
-model = train_model(X, y, input_dim=512, inclusion_value=0)
+# hidden_dim=LINEAR_HEAD is what production passes; omitting it auto-sizes an MLP.
+model = train_model(X, y, input_dim=512, hidden_dim=LINEAR_HEAD)
 with torch.no_grad():
     scores = torch.sigmoid(model(X)).squeeze(1).cpu().numpy()
 ```
@@ -100,13 +136,16 @@ Key behaviour:
 
 - **Loss:** weighted `BCEWithLogitsLoss(reduction="none")`. Per-sample
   weights are precomputed from `y_train` so the loss balances class
-  frequencies (`weight_true = num_false / num_true`, `weight_false = 1.0`)
-  even before the inclusion bias is applied.
-- **Inclusion bias** (`inclusion_value ∈ [-10, 10]`): multiplies the
-  per-class weight by `2 ** abs(inclusion_value)`. Positive values
-  inflate the True-class weight so the classifier prefers recall
-  (include more); negative values inflate the False-class weight so it
-  prefers precision (include fewer). See `vtscore/training/mlp.py:193`.
+  frequencies (`weight_true = num_false / num_true`, `weight_false = 1.0`).
+  Pass `sample_weights` to replace them entirely - that is how the
+  region-flooding path expresses per-bag balancing.
+- **Inclusion does not enter training.** It is a pure threshold knob applied
+  later in `vtscore.training.thresholds.conformal_threshold`, so the trained
+  model - and therefore every item's score - is independent of inclusion.
+- **Label smoothing:** targets are smoothed by `MLP_LABEL_SMOOTHING` after the
+  class weights are derived from the hard labels, so a strongly-fit model
+  can't saturate every score to an exact 0.0/1.0 sigmoid and collapse the
+  conformal rule's quantiles into a single tie.
 - **Optimiser:** `Adam(lr=0.001, weight_decay=1e-4)`.
 - **Early stop:** trains up to `config.TRAIN_EPOCHS` (default 200) and
   stops after `config.TRAIN_PATIENCE` consecutive epochs with no
@@ -135,7 +174,8 @@ with torch.random.fork_rng(), torch.enable_grad():
 ```
 
 The local `torch.Generator` seeds weight initialisation; `fork_rng`
-isolates the dropout RNG inside the training loop. Two concurrent
+isolates the dropout RNG inside the training loop (the linear head has no
+dropout, so that half matters only for the MLP arm). Two concurrent
 `train_model` calls in different threads do not interfere with each
 other's seed, and either call produces the same model given the same
 `(X, y, seed)`. This matters because cross-calibration trains *k* fold
@@ -144,16 +184,17 @@ parallel.
 
 ### Reloading from saved weights
 
-`build_model_from_weights(weights)` at `vtscore/training/mlp.py:78`
+`build_model_from_weights(weights)` at `vtscore/training/mlp.py:101`
 reconstructs a model from a dict of lists (the output of
-`tensor.tolist()` per state-dict entry). It accepts the current 4-layer
-format (`0.weight`, `0.bias`, `3.weight`, `3.bias`) and silently
-remaps the legacy 3-layer format (`0.*`, `2.*`) to the current keys, so
-old detector files don't have to be migrated.
+`tensor.tolist()` per state-dict entry). It infers the head from the keys
+present: `0.*` alone means the linear head, while a `3.weight` means an MLP
+whose hidden width is the length of `0.bias`. It also silently remaps the
+legacy 3-layer MLP format (`0.*`, `2.*`) to the current keys, so old detector
+files don't have to be migrated.
 
-> **Invariant - no persisted MLP weights.** In VTSearch proper, detector
+> **Invariant - no persisted model weights.** In VTSearch proper, detector
 > JSON files store labelsets (origin info + per-element labels) only;
-> MLP weights are re-derived from those origins on every load. See
+> the head is re-derived from those origins on every load. See
 > [`detectors.md`](detectors.md) for the detector storage contract.
 > `build_model_from_weights` exists for callers (eval harnesses, third-
 > party tooling) that have their own reason to ship weights around - the
@@ -226,7 +267,8 @@ For each of `calibrate_count` rounds:
 
 1. Randomly split `(X_list, y_list)` into Train (`1 - calibration_fraction`)
    and Calibrate (`calibration_fraction`).
-2. Train an MLP on Train via `train_model`.
+2. Train a head on Train via `train_model` (the caller passes `hidden_dim`;
+   the detector pipeline passes `LINEAR_HEAD`).
 3. Score the held-out Calibrate portion.
 
 Pools every round's held-out (score, label) pairs and applies
@@ -306,8 +348,8 @@ back entirely to the GMM threshold.
 `vtscore/training/svm.py` ships a parallel trainer with the same call
 shape as `train_model`. It is **not** wired into the detector pipeline;
 its purpose is to let
-[`vtscore.eval.label_curve`](eval.md#label-curve-sweep) sweep MLP vs.
-SVM head-to-head so the team can decide whether to add a trainer-
+[`vtscore.eval.label_curve`](eval.md#label-curve-sweep) sweep the neural head
+vs. SVM head-to-head so the team can decide whether to add a trainer-
 selection field on detectors.
 
 ### `SVMClassifier` (`vtscore/training/svm.py:26`)
@@ -334,8 +376,8 @@ VTSearch picks its operating threshold via cross-calibration, not
 from the model's raw probability, so burning training data on k-fold
 CV calibration would shrink the final-fit data while inverting
 `inclusion_value`. Raises `ValueError` for fewer than 2 samples or
-single-class inputs (the MLP path returns `None` instead; here the
-eval harness wants the error to record a skip).
+single-class inputs, matching `train_model`, which refuses single-class data
+up front for the same reason: BCE has no discriminative signal there.
 
 ---
 
@@ -363,7 +405,7 @@ top_ten = results[:10]
 
 ## Invariants worth restating
 
-- **No persisted MLP weights.** Library callers that load a model from
+- **No persisted model weights.** Library callers that load a model from
   disk are expected to re-derive it from a labelset's origins (see
   [`detectors.md`](detectors.md)). `build_model_from_weights` is a
   utility, not a contract.

--- a/vtscore/docs/quickstart.md
+++ b/vtscore/docs/quickstart.md
@@ -116,6 +116,7 @@ import numpy as np
 import torch
 
 from vtscore.training import train_model, calculate_cross_calibration_threshold
+from vtscore.training.mlp import LINEAR_HEAD
 
 # Map filenames to labels.
 labels = {
@@ -139,17 +140,21 @@ for m in medias.values():
 X = torch.from_numpy(np.stack(X_list).astype(np.float32))
 y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
 
-model = train_model(X, y, input_dim=X.shape[1])
+# LINEAR_HEAD is the production head: a single Linear(D, 1), i.e. logistic
+# regression. Omitting hidden_dim auto-sizes an MLP instead - see docs/ML.md.
+model = train_model(X, y, input_dim=X.shape[1], hidden_dim=LINEAR_HEAD)
 threshold = calculate_cross_calibration_threshold(
     X_list, y_list, input_dim=X.shape[1], inclusion_value=0,
+    hidden_dim=LINEAR_HEAD,
 )
-print(f"Trained MLP; calibrated threshold = {threshold:.3f}")
-# Trained MLP; calibrated threshold = 0.412
+print(f"Trained detector; calibrated threshold = {threshold:.3f}")
+# Trained detector; calibrated threshold = 0.412
 ```
 
 `train_model` is deterministic given the default seed (42). Six labels is
-enough for the MLP to converge - the model is small (auto-sized to ~16
-hidden units for this corpus) and the dropout regularises it.
+enough for the linear head to converge - it has `D + 1` parameters and no
+hidden layer, which is exactly why it is the production head when positives
+are sparse.
 
 For a more idiomatic detector lifecycle (with persistence), see
 [example 5](#5-persist-and-reload-a-detector) below.
@@ -196,7 +201,7 @@ For larger datasets, build the embedding matrix once on the
 
 Detectors persist as JSON labelsets - never as model weights. On reload,
 the library re-derives embeddings from the labelset's origins and
-retrains the MLP.
+retrains the head.
 
 ```python
 from vtscore.datasets.labelset import LabeledElement, LabelSet
@@ -234,7 +239,7 @@ register_detector_context(ctx)
 # Build (good_origins, bad_origins) from the saved labelset's elements,
 # then re-derive embeddings + retrain. Pass the same embedder the detector
 # was trained with so the re-embedded vectors line up with the saved ones -
-# otherwise the MLP trains on a mix of embedder outputs.
+# otherwise the head trains on a mix of embedder outputs.
 good_origins = [
     {"origin": e.origin, "origin_name": e.origin_name,
      "filename": e.filename, "md5": e.md5}

--- a/vtscore/docs/tutorials/train-and-score.md
+++ b/vtscore/docs/tutorials/train-and-score.md
@@ -6,7 +6,7 @@ will have:
 1. Loaded a folder of audio files into `vtscore`.
 2. Inspected the resulting media items and their embeddings.
 3. Cast labels on a handful of items.
-4. Trained an MLP detector with a calibrated threshold.
+4. Trained a linear-head detector with a calibrated threshold.
 5. Saved the detector to disk as a `LabelSet` JSON.
 6. Reloaded it in a fresh Python process and re-derived its weights.
 7. Scored a held-out folder against the detector.
@@ -14,7 +14,7 @@ will have:
 
 The scenario: you have a corpus of mixed audio - barks, music, speech,
 environmental sound - and you want a binary detector for "is this a
-dog bark?". Six labels is enough to get the MLP off the ground; a few
+dog bark?". Six labels is enough to get the detector off the ground; a few
 dozen will make it good.
 
 You'll need `vtscore` installed (`bash scripts/install.sh` from the
@@ -134,12 +134,13 @@ print(f"Labelled {len(labelled)} items.")
 
 ESC-50 uses `<fold>-<clip_id>-A-<category_id>.wav`; category 0 is "dog",
 category 7 is "rooster", etc. Replace these filenames with whatever you
-actually have. Six labels is enough - the MLP is small.
+actually have. Six labels is enough - the linear head is small.
 
-## Step 3: Train the MLP
+## Step 3: Train the detector
 
 ```python
 from vtscore.training import train_model, calculate_cross_calibration_threshold
+from vtscore.training.mlp import LINEAR_HEAD
 
 # Build (X, y) tensors.
 X_list = [m["embedding"] for m, _ in labelled]
@@ -148,21 +149,27 @@ y_list = [1.0 if label == "good" else 0.0 for _, label in labelled]
 X = torch.from_numpy(np.stack(X_list).astype(np.float32))
 y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
 
-# Train.
-model = train_model(X, y, input_dim=X.shape[1])
+# Train. LINEAR_HEAD is what the app passes on every production fit.
+model = train_model(X, y, input_dim=X.shape[1], hidden_dim=LINEAR_HEAD)
 
-# Calibrate the decision threshold via 2-fold cross-validation.
+# Calibrate the decision threshold via 2-fold cross-validation, on the same
+# head - otherwise the threshold is measured on a different architecture.
 threshold = calculate_cross_calibration_threshold(
     X_list, y_list, input_dim=X.shape[1], inclusion_value=0,
+    hidden_dim=LINEAR_HEAD,
 )
 
-print(f"Trained MLP; threshold = {threshold:.3f}")
+print(f"Trained detector; threshold = {threshold:.3f}")
 ```
 
-The MLP architecture is `Linear(512, H) → ReLU → Dropout → Linear(H, 1)`
-where `H` is auto-sized from the training-set count (`_auto_hidden_dim`
-in `vtscore/training/mlp.py`). With 6 examples, `H ≈ 16`. The default
-seed makes training deterministic.
+The production architecture is a single `Linear(512, 1)` - the
+`hidden_dim=LINEAR_HEAD` (`0`) sentinel in `vtscore/training/mlp.py` - trained
+with balanced BCE-with-logits, i.e. logistic regression. A positive
+`hidden_dim` builds the older MLP
+(`Linear(512, H) → ReLU → Dropout → Linear(H, 1)`, `H` auto-sized by
+`_auto_hidden_dim`), which now survives only for the eval harness and tests;
+see [docs/ML.md](../../../docs/ML.md#why-linear-and-where-the-mlp-survives).
+The default seed makes training deterministic.
 
 ## Step 4: Score all loaded items
 
@@ -354,7 +361,7 @@ for i, metrics in enumerate(metrics_list):
 ```
 
 `eval_learned_sort` is in `vtscore/eval/runner.py`; it splits the data
-into `n_folds` folds, trains a fresh MLP per fold, and computes
+into `n_folds` folds, trains a fresh head per fold, and computes
 classification + ranking metrics. See
 [packages/eval.md](../packages/eval.md) for the full evaluation API.
 
@@ -366,7 +373,7 @@ By the end of the tutorial:
   six origins, no weights. ~1 KB.
 - **`/tmp/vtscore-tutorial/models/`** - cached LAION-CLAP weights. Reused
   by every future detector with `embedder="audio_clap"`. ~600 MB.
-- **`ctx.model`** + **`ctx.threshold`** - in-memory trained MLP, ready
+- **`ctx.model`** + **`ctx.threshold`** - in-memory trained head, ready
   to score anything.
 
 The same shape generalises to:


### PR DESCRIPTION
The production detector head became a linear (logistic) head during the threshold-stability work (#2790), but only `docs/ML.md` was updated. Every other description of what the product is still taught the MLP — including `CLAUDE.md:3`, which is loaded into every agent session's context on every turn, so the stale claim was being continuously re-taught.

Closes #2981

## The four surfaces named in the issue

| Surface | Now says |
|---|---|
| `README.md` | trains a **linear (logistic) head** — a single `Linear(input_dim, 1)` fitted with balanced BCE |
| `CLAUDE.md:3` | "a linear (logistic) head learns to rank the rest" |
| `vtscore/docs/concepts.md` §6 | linear head in the prose, **and the architecture diagram is now `Linear(D, 1)`** |
| the wider `vtscore/docs` set | see below |

Each is one clause, worded to match `ML.md:3` so the set can be diffed later, and links to `docs/ML.md#why-linear-and-where-the-mlp-survives` for the rationale rather than restating it. (The old diagram also claimed `Dropout(p) # default 0.3`; `MLP_DROPOUT` is `0.5`.)

## The rest of the sweep

Same one-clause treatment across `vtscore/docs/` (`README.md`, `architecture.md`, `quickstart.md`, `faq.md`, `integration.md`, `tutorials/train-and-score.md`, `packages/{detectors,state,labels,media,config,concurrency,sync,eval}.md`, `extending/*`), `vtscore/README.md`, and `docs/api/{detectors,find,labeling,medias}.md`, which were describing production endpoints as "trains an MLP".

`vtscore/docs/packages/training.md` gets more than a clause: it documented the MLP as *the* architecture. It now covers both heads, says which one production passes and where, and flags that **neither** `build_model`'s `hidden_dim=64` nor `train_model`'s `hidden_dim=None` is the production head — a caller who omits the argument silently gets an auto-sized MLP.

The `quickstart.md` and `train-and-score.md` snippets now pass `hidden_dim=LINEAR_HEAD` to both `train_model` and `calculate_cross_calibration_threshold`, so what they teach is what the app runs (and the threshold is calibrated on the same architecture as the final model).

## Accuracy fixes found in the rewritten sections

Not in the issue, but they were inside the prose being rewritten:

- **`train_model` has no `inclusion_value` parameter.** Inclusion is a pure threshold knob applied later in `conformal_threshold`. The documented signature and the runnable snippet both raised `TypeError`. Replaced with the real signature, plus a note that inclusion does not enter training and a bullet on `MLP_LABEL_SMOOTHING`.
- **`_auto_hidden_dim(10)` returns 8, not 4** — `MLP_HIDDEN_MIN` floors it. Also: the detector code no longer calls it at all (the doc cited `detectors/training.py:182` and `labelset_training.py:277`); only the eval harness's `"mlp"` arm does.
- **`train_svm`'s `ValueError` note** claimed the neural path "returns `None` instead" on single-class input. `train_model` raises `ValueError` too, for the same reason.
- **`build_model_from_weights`** now documents how it infers the head from the state-dict keys (`0.*` alone → linear; `3.weight` → MLP).
- Stale `vtscore/training/mlp.py` line references (`:25`, `:35`, `:78`, `:110`, `:193`).

## Left alone deliberately

All still real, so changing them would make the docs *less* accurate:

- The `CLAUDE.md` **"No Persisted Vectors or MLPs"** heading — a rule name cited by six `vtscore` docs. Its body is updated to "model weights" / `origin → file → embedding → detector head`, but the heading stays so the cross-references keep resolving.
- The `MLP_*` config constants, `vtscore/training/mlp.py`'s module name, and the eval harness's MLP sweep arm. `config.md` now marks the hidden-width/dropout knobs as MLP-head-only.

## Rebase note

Rebased onto `dev` after #3071. Two consequences worth flagging:

- `dev` retired `docs/vtscore-api.md` in e617e08d (#2986), so this branch's edits to that file are gone — resolved by accepting the deletion. Only its import-path table was salvaged into `vtscore/docs/architecture.md`, and that table carries no MLP prose, so nothing was owed there.
- The rebase surfaced a surface the first pass missed: `vtscore/README.md`, the library package's own README, carried the same four stale claims. Swept in the second commit.

The `docs/api/*.md` overlap with #2979's JSON-fence rewrite auto-merged; verified both sides survived (no `→ ```json` fences remain, and every head/MLP clause is present).

## Verification

- `./run-tests.sh` on the rebased branch → **`ALL 8217 TESTS PASSED (6 skipped, 2 xfailed, total: 8223)`**, exit 0 (ruff, `ruff format --check`, codespell, deptry, pip-audit, pyright, the OpenAPI snapshot, `check-eval-app-sync.py`, the Angular `build:prod` and the Vitest suite all clean).
- Every new relative link, the `#why-linear-and-where-the-mlp-survives` anchor, and the absence of any surviving link to the retired `docs/vtscore-api.md` all checked.

Docs-only; no code changes, so nothing to break at runtime.