### PR TITLE
Pin mediaVoted's id to the item that was actually voted

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -280,7 +280,7 @@ stub_extractor_factory  # noqa: F821
 stub_localizer_factory  # noqa: F821
 stubbed_resolver  # noqa: F821
 reset_state  # noqa: F821
-example_media_cleanup  # noqa: F821 - tests/io/test_datasource_importer_routes.py cleans SERVER_MEDIA_DIR via yield
+example_media_dir  # noqa: F821 - tests/io/test_datasource_importer_routes.py redirects SERVER_MEDIA_DIR to tmp_path
 
 # ---------------------------------------------------------------------------
 # Mock function signatures that must match a real API but whose body

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -389,6 +389,11 @@ export class CenterPanelComponent implements OnDestroy {
     }
 
     const regionBox = vote === 'good' ? this.currentRegionBox : null;
+    // The vote belongs to the item that was selected when the key was pressed.
+    // Selection can move while the request is in flight (or during the 180ms
+    // swipe animation below), so pin the id here rather than re-reading the
+    // input later; otherwise the emit carries a new item's id with this vote.
+    const votedId = media.id;
     this.pendingBadConfirm.set(false);
     this.isVoting.set(true);
 
@@ -403,11 +408,11 @@ export class CenterPanelComponent implements OnDestroy {
             if (this.spinTimer) clearTimeout(this.spinTimer);
             this.spinTimer = setTimeout(() => this.spinningVote.set(null), 300);
             setTimeout(() => {
-              this.mediaVoted.emit({ id: this.media()!.id, vote });
+              this.mediaVoted.emit({ id: votedId, vote });
               this.isVoting.set(false);
             }, 180);
           } else {
-            this.mediaVoted.emit({ id: this.media()!.id, vote });
+            this.mediaVoted.emit({ id: votedId, vote });
             this.isVoting.set(false);
           }
         },

--- a/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
@@ -5,7 +5,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CenterPanelComponent } from './center-panel.component';
 import { EmbedderInfo, Media } from '../../models/api.models';
 import { RegionBox } from './image-viewer/image-viewer.component';
-import { ANIMATIONS_OFF_CLASS } from '../../utils/reduced-motion';
+import { ANIMATIONS_OFF_CLASS, ANIMATIONS_ON_CLASS } from '../../utils/reduced-motion';
 import { configureZoneless } from '../../testing/zoneless-testbed';
 import { settleZoneless } from '../../testing/settle-resource';
 import { provideHttpTesting } from '../../testing/test-providers';
@@ -240,6 +240,72 @@ describe('CenterPanelComponent', () => {
 
     expect(emitted).toEqual({ id: 1, vote: 'good' });
     expect(component.voteState.goodVotes.has(1)).toBe(true);
+  });
+
+  /**
+   * The vote belongs to the item that was selected when the key was pressed.
+   * Selection can move while the POST is in flight or during the 180ms swipe
+   * animation (a click in the left list, hover-focus, a concurrent auto-advance),
+   * so `mediaVoted` must carry the id captured at castVote() time. Emitting the
+   * *current* selection's id pairs a new item with the old vote direction, which
+   * makes find-view mark the wrong row optimistically verified and makes
+   * label-view's auto-advance exclude the wrong id.
+   */
+  describe('mediaVoted id is pinned to the voted item', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+      document.documentElement.classList.remove(ANIMATIONS_ON_CLASS);
+    });
+
+    it('emits the voted id when selection moves while the vote is in flight', () => {
+      fixture.componentRef.setInput('media', mockMedia);
+      component.showAnimations.set(false);
+      TestBed.tick();
+
+      let emitted: { id: number; vote: string } | undefined;
+      component.mediaVoted.subscribe((e: { id: number; vote: string }) => (emitted = e));
+
+      component.castVote('good');
+      const voteReq = httpMock.expectOne('/api/medias/1/vote');
+
+      // The user clicks a different card before the server answers.
+      fixture.componentRef.setInput('media', { ...mockMedia, id: 2, filename: 'other.pdf' });
+      TestBed.tick();
+
+      voteReq.flush({ state: 'good', click_time: 1 });
+
+      expect(emitted).toEqual({ id: 1, vote: 'good' });
+    });
+
+    it('emits the voted id when selection moves during the swipe animation', async () => {
+      vi.useFakeTimers();
+      // The settings mirror put `animations-off` on <html> in beforeEach; swap it
+      // for `animations-on` so prefersReducedMotion() reports false and castVote()
+      // takes the animated (deferred-emit) branch.
+      document.documentElement.classList.remove(ANIMATIONS_OFF_CLASS);
+      document.documentElement.classList.add(ANIMATIONS_ON_CLASS);
+
+      fixture.componentRef.setInput('media', mockMedia);
+      component.showAnimations.set(true);
+      TestBed.tick();
+
+      let emitted: { id: number; vote: string } | undefined;
+      component.mediaVoted.subscribe((e: { id: number; vote: string }) => (emitted = e));
+
+      component.castVote('bad');
+      httpMock.expectOne('/api/medias/1/vote').flush({ state: 'bad', click_time: 1 });
+      // The deferred emit has not fired yet; selection moves inside the window.
+      expect(emitted).toBeUndefined();
+
+      fixture.componentRef.setInput('media', { ...mockMedia, id: 2, filename: 'other.pdf' });
+      TestBed.tick();
+
+      // Drain both the 180ms emit timer and the 300ms spin timer.
+      await vi.advanceTimersByTimeAsync(300);
+      TestBed.tick();
+
+      expect(emitted).toEqual({ id: 1, vote: 'bad' });
+    });
   });
 
   it('should prevent double voting', () => {

--- a/tests/io/test_datasource_importer_routes.py
+++ b/tests/io/test_datasource_importer_routes.py
@@ -7,17 +7,22 @@ import pytest
 from vtscore.datasource_importers import get_datasource_importer
 from vtscore.datasource_importers.base import DataSourceImporter, FetchedMediaItem
 from vtscore.plugins import PluginField
-from vtsearch.routes.media.server import SERVER_MEDIA_DIR
+from vtsearch.routes.media import server as media_server_module
 
 
 @pytest.fixture
-def example_media_cleanup():
-    """Track and remove files this test adds to ``example_media/``."""
-    before = set(SERVER_MEDIA_DIR.glob("*")) if SERVER_MEDIA_DIR.exists() else set()
-    yield
-    if SERVER_MEDIA_DIR.exists():
-        for f in set(SERVER_MEDIA_DIR.glob("*")) - before:
-            f.unlink(missing_ok=True)
+def example_media_dir(tmp_path, monkeypatch):
+    """Redirect ``example_media/`` to a per-test directory and return it.
+
+    ``data/example_media/`` is a real shared directory, so pointing the route
+    at a private one keeps the suite from writing to disk. It also removes a
+    cross-worker race: the previous fixture deleted every file that appeared in
+    the shared directory during the test, which under ``pytest -n auto`` could
+    unlink a file another worker had just written and not yet read.
+    """
+    media_dir = tmp_path / "example_media"
+    monkeypatch.setattr(media_server_module, "SERVER_MEDIA_DIR", media_dir)
+    return media_dir
 
 
 class TestDatasourceImportersList:
@@ -43,7 +48,7 @@ class TestDatasourceImportersList:
 
 
 class TestDatasourceImportRun:
-    def test_server_file_fetches_into_example_media(self, client, tmp_path, example_media_cleanup):
+    def test_server_file_fetches_into_example_media(self, client, tmp_path, example_media_dir):
         src = tmp_path / "bark.wav"
         src.write_bytes(b"RIFFxxxxWAVE")
 
@@ -57,10 +62,10 @@ class TestDatasourceImportRun:
         assert data["origin"]["importer"] == "server_file"
         assert data["origin"]["params"]["path"] == str(src.resolve())
 
-        saved = SERVER_MEDIA_DIR / data["filename"]
+        saved = example_media_dir / data["filename"]
         assert saved.read_bytes() == b"RIFFxxxxWAVE"
 
-    def test_origin_null_when_importer_reports_none(self, client, monkeypatch, example_media_cleanup):
+    def test_origin_null_when_importer_reports_none(self, client, monkeypatch, example_media_dir):
         """Importers whose items have no re-derivable source return origin: null."""
 
         def _fetch(field_values):
@@ -107,7 +112,7 @@ class TestDatasourceImportRun:
         assert resp.status_code == 502
         assert "upstream fell over" in resp.get_json()["message"]
 
-    def test_file_field_importer_accepts_multipart(self, client, monkeypatch, example_media_cleanup):
+    def test_file_field_importer_accepts_multipart(self, client, monkeypatch, example_media_dir):
         class UploadThingDataSourceImporter(DataSourceImporter):
             """Test-only importer with a file field."""
 
@@ -131,7 +136,7 @@ class TestDatasourceImportRun:
         assert resp.status_code == 201
         data = resp.get_json()
         assert data["original_name"] == "pick.png"
-        assert (SERVER_MEDIA_DIR / data["filename"]).read_bytes() == b"\x01\x02"
+        assert (example_media_dir / data["filename"]).read_bytes() == b"\x01\x02"
 
 
 class TestDatasourceImportFieldOptions:


### PR DESCRIPTION
`castVote()`'s success handler re-read `this.media()` when emitting `mediaVoted`, in both the animated (180ms deferred) branch and the immediate one. If the selection moved while the vote was in flight or during the swipe window — a click in the left list, hover-focus, a concurrent auto-advance — the event paired the **new** item's id with the **old** vote direction. Downstream, `find-view.onMediaVoted()` marked the wrong row optimistically verified and `label-view.autoSelectNext(excludeId)` excluded the wrong id. The animated branch's `this.media()!` non-null assertion would also have thrown inside the timer if any path nulled the selection mid-window.

Fix: capture the id from the media resolved at the top of `castVote()` and emit that from both branches.

## Changes

- `frontend/src/app/components/center-panel/center-panel.component.ts` — pin `votedId` before submitting; emit it in both branches (drops the non-null assertion).
- `frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts` — regression coverage for both branches: selection moved while the POST is in flight, and selection moved inside the 180ms animation window (fake timers).

## Unrelated fix (full-suite failure)

`tests/io/test_datasource_importer_routes.py`'s `example_media_cleanup` fixture snapshotted the real, process-shared `data/example_media/` and on teardown unlinked every file that had appeared since. Under `pytest -n auto` one worker's teardown could delete a file another worker had just written and not yet read, which failed `test_server_file_fetches_into_example_media` on a full run while it passed in isolation. The fixture now redirects `SERVER_MEDIA_DIR` to a per-test tmp dir (`example_media_dir`), so those tests neither touch the shared directory nor need snapshot-diff cleanup. `.vulture-whitelist.py` updated for the rename.

## Testing

`./run-tests.sh` — all 8200 tests pass (6 skipped); frontend gate green (build, audit, 2004 Vitest tests).

Closes #2968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8Wwx8sZe8e4kKfzbdyHq9

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Wwx8sZe8e4kKfzbdyHq9)_