### PR TITLE
Add BEATs audio embedder; fix eval text-sort scoring queries in the wrong embedder's space

### DIFF
--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -298,6 +298,7 @@ embedder per media type should override the `is_default` property to return
 | `audio/embedder_clap_music.py` | `AudioClapMusicEmbedder` | audio | |
 | `audio/embedder_clap_general.py` | `AudioClapGeneralEmbedder` | audio | |
 | `audio/embedder_paraspeechclap.py` | `AudioParaSpeechClapEmbedder` | audio | |
+| `audio/embedder_beats.py` | `AudioBEATsEmbedder` | audio | |
 | `audio/embedder_ast.py` | `AudioASTEmbedder` | audio | |
 | `audio/embedder_whisper.py` | `AudioWhisperEncoderEmbedder` | audio | |
 | `image/embedder_siglip.py` | `ImageSiglipEmbedder` | image | ✅ |
@@ -554,6 +555,7 @@ loaded via `spec_from_file_location` so discovery still works.
 | `AudioClapMusicEmbedder` | `clap_music` | `audio` | CLAP Music & Speech (laion/larger_clap_music_and_speech) | 512 |
 | `AudioClapGeneralEmbedder` | `clap_general` | `audio` | CLAP General 2024 (laion/larger_clap_general) | 512 |
 | `AudioParaSpeechClapEmbedder` | `paraspeechclap` | `audio` | ParaSpeechCLAP speech-style (WavLM-Large + Granite, ajd12342/paraspeechclap-combined) | 768 |
+| `AudioBEATsEmbedder` | `beats` | `audio` | BEATs iter3+ AS2M self-supervised encoder (lpepino/beats_ckpts), audio-only | 768 |
 | `AudioASTEmbedder` | `ast` | `audio` | AST audio spectrogram (MIT/ast-finetuned-audioset-10-10-0.4593), audio-only | 768 |
 | `AudioWhisperEncoderEmbedder` | `whisper_encoder` | `audio` | Whisper-base encoder (openai/whisper-base), audio-only | 512 |
 | `ImageSiglipEmbedder` | `siglip` | `image` | SigLIP (google/siglip-base-patch16-224) | 768 |

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -131,7 +131,7 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 | Audio (`audio`) | `clap_music` | CLAP Music & Speech (`laion/larger_clap_music_and_speech`) | 512 |
 | Audio (`audio`) | `clap_general` | CLAP General 2024 (`laion/larger_clap_general`) | 512 |
 | Audio (`audio`) | `paraspeechclap` | ParaSpeechCLAP speech-style (WavLM + Granite, `ajd12342/paraspeechclap-combined`) | 768 |
-| Audio (`audio`) | `beats` | BEATs iter3+ AS2M (`lpepino/beats_ckpts`, audio-only) | 768 |
+| Audio (`audio`) | `beats` | BEATs iter3+ AS2M self-supervised encoder (`lpepino/beats_ckpts`, audio-only) | 768 |
 | Audio (`audio`) | `ast` | AST audio spectrogram (`MIT/ast-finetuned-audioset-10-10-0.4593`, audio-only) | 768 |
 | Audio (`audio`) | `whisper_encoder` | Whisper-base encoder (`openai/whisper-base`, audio-only) | 512 |
 | Image (`image`) | `siglip` (default) | SigLIP (`google/siglip-base-patch16-224`) | 768 |

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -131,6 +131,7 @@ Each media type uses a different pretrained model to produce fixed-size embeddin
 | Audio (`audio`) | `clap_music` | CLAP Music & Speech (`laion/larger_clap_music_and_speech`) | 512 |
 | Audio (`audio`) | `clap_general` | CLAP General 2024 (`laion/larger_clap_general`) | 512 |
 | Audio (`audio`) | `paraspeechclap` | ParaSpeechCLAP speech-style (WavLM + Granite, `ajd12342/paraspeechclap-combined`) | 768 |
+| Audio (`audio`) | `beats` | BEATs iter3+ AS2M (`lpepino/beats_ckpts`, audio-only) | 768 |
 | Audio (`audio`) | `ast` | AST audio spectrogram (`MIT/ast-finetuned-audioset-10-10-0.4593`, audio-only) | 768 |
 | Audio (`audio`) | `whisper_encoder` | Whisper-base encoder (`openai/whisper-base`, audio-only) | 512 |
 | Image (`image`) | `siglip` (default) | SigLIP (`google/siglip-base-patch16-224`) | 768 |

--- a/frontend/src/app/services/embedder-capability.service.ts
+++ b/frontend/src/app/services/embedder-capability.service.ts
@@ -26,7 +26,7 @@ export const EMBEDDER_TYPE_ORDER: EmbedderType[] = ['semantic', 'patch_semantic'
  * registry), so callers can answer "can this dataset's embedder search by
  * text?" without each reimplementing the `supports_text` lookup.
  *
- * Vision-only / speech-only encoders (DINOv3, EUPE, AST, Whisper, VideoMAE)
+ * Vision-only / audio-only encoders (DINOv3, EUPE, BEATs, AST, Whisper, VideoMAE)
  * report `supports_text === false`; CLIP/SigLIP/CLAP/E5/X-CLIP report `true`.
  * Text sort and Autopilot's text-seed phase only work on the latter.
  *

--- a/tests/sorting/test_enrich_descriptions.py
+++ b/tests/sorting/test_enrich_descriptions.py
@@ -355,8 +355,8 @@ class TestEvalTextSortEnrich:
 
         call_kwargs = []
 
-        def mock_embed(text, media_type, enrich=False):
-            call_kwargs.append({"enrich": enrich})
+        def mock_embed(text, media_type, enrich=False, embedder_name=""):
+            call_kwargs.append({"enrich": enrich, "embedder_name": embedder_name})
             if "cat" in text:
                 return cat_dir.copy()
             return dog_dir.copy()
@@ -366,6 +366,10 @@ class TestEvalTextSortEnrich:
 
         assert len(results) == 1
         assert all(kw["enrich"] is True for kw in call_kwargs)
+        # Called directly with no embedder_name, so it forwards the empty
+        # default. run_eval is what fills it in; that is covered by
+        # tests_lib/detectors/test_eval.py.
+        assert all(kw["embedder_name"] == "" for kw in call_kwargs)
 
     def test_eval_text_sort_without_enrich(self):
         """eval_text_sort with enrich=False should pass enrich=False."""
@@ -374,8 +378,8 @@ class TestEvalTextSortEnrich:
 
         call_kwargs = []
 
-        def mock_embed(text, media_type, enrich=False):
-            call_kwargs.append({"enrich": enrich})
+        def mock_embed(text, media_type, enrich=False, embedder_name=""):
+            call_kwargs.append({"enrich": enrich, "embedder_name": embedder_name})
             return cat_dir.copy()
 
         with patch("vtscore.embedding.helpers.embed_text_query", side_effect=mock_embed):

--- a/tests_lib/detectors/test_beats_embedder.py
+++ b/tests_lib/detectors/test_beats_embedder.py
@@ -31,6 +31,9 @@ TINY_CFG = {
     "relative_position_embedding": True,
     "num_buckets": 32,
     "max_distance": 80,
+    "gru_rel_pos": True,
+    "deep_norm": True,
+    "layer_norm_first": False,
     "conv_bias": False,
     "input_patch_size": 16,
     "embed_dim": 16,
@@ -128,6 +131,26 @@ class TestVendoredEncoder:
         for i in range(TINY_CFG["encoder_layers"]):
             assert f"encoder.layers.{i}.self_attn.relative_attention_bias.weight" in keys
             assert f"encoder.layers.{i}.self_attn.grep_a" in keys
+
+    def test_pre_layer_norm_configs_are_refused(self):
+        """Only the post-LN graph is ported; a pre-LN config must not load quietly."""
+        from vtscore.media.audio._beats_model import BEATs
+
+        with pytest.raises(ValueError, match="layer_norm_first"):
+            BEATs(dict(TINY_CFG, layer_norm_first=True))
+
+    def test_ungated_config_has_no_gate_tensors(self):
+        """``gru_rel_pos=False`` checkpoints carry no ``grep_*``; neither should we."""
+        from vtscore.media.audio._beats_model import BEATs
+
+        keys = set(BEATs(dict(TINY_CFG, gru_rel_pos=False)).state_dict())
+        assert not [k for k in keys if "grep_" in k]
+
+    def test_deep_norm_can_be_disabled(self):
+        from vtscore.media.audio._beats_model import BEATs
+
+        model = BEATs(dict(TINY_CFG, deep_norm=False))
+        assert model.encoder.layers[0].deep_norm_alpha == 1.0
 
     def test_deep_norm_alpha(self):
         from vtscore.media.audio._beats_model import BEATs

--- a/tests_lib/detectors/test_beats_embedder.py
+++ b/tests_lib/detectors/test_beats_embedder.py
@@ -1,0 +1,316 @@
+"""Tests for the BEATs audio embedder and its vendored architecture.
+
+Covers three layers, none of which downloads the released weights:
+
+- the Kaldi fbank front-end ported from torchaudio,
+- the vendored encoder's structure (built from a miniature config),
+- the embedder's own audio handling (windowing, padding, pooling).
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+# A miniature BEATs config: same shape as the released one, small enough to
+# build in a test. Mirrors the ``cfg`` dict stored in the checkpoint.
+TINY_CFG = {
+    "encoder_layers": 2,
+    "encoder_embed_dim": 32,
+    "encoder_ffn_embed_dim": 64,
+    "encoder_attention_heads": 4,
+    "dropout": 0.0,
+    "attention_dropout": 0.0,
+    "activation_dropout": 0.0,
+    "dropout_input": 0.0,
+    "conv_pos": 16,
+    "conv_pos_groups": 4,
+    "relative_position_embedding": True,
+    "num_buckets": 32,
+    "max_distance": 80,
+    "conv_bias": False,
+    "input_patch_size": 16,
+    "embed_dim": 16,
+}
+
+
+def _tone(freq: float, n: int = 4000, sr: int = 16000) -> "torch.Tensor":
+    """A deterministic pure tone — no RNG, so goldens are version-stable."""
+    t = torch.arange(n, dtype=torch.float32) / sr
+    return torch.sin(2 * math.pi * freq * t)
+
+
+class TestKaldiFbank:
+    """The fbank front-end must match Kaldi's ``compute-fbank-feats``."""
+
+    def test_framing_matches_kaldi_snip_edges(self):
+        from vtscore.media.audio._beats_model import kaldi_fbank
+
+        # 25 ms window (400 samples), 10 ms hop (160): only whole frames count,
+        # so m = 1 + (n - 400) // 160.
+        for n in (4000, 16000, 12345):
+            fb = kaldi_fbank(_tone(440.0, n) * 2**15)
+            assert fb.shape == (1 + (n - 400) // 160, 128)
+
+    def test_signal_shorter_than_one_window_is_empty(self):
+        from vtscore.media.audio._beats_model import kaldi_fbank
+
+        assert kaldi_fbank(_tone(440.0, 399) * 2**15).shape == (0, 128)
+
+    @pytest.mark.parametrize(
+        ("freq", "expected_bin"),
+        [(250.0, 13), (1000.0, 43), (4000.0, 96)],
+    )
+    def test_pure_tone_peaks_in_the_right_mel_bin(self, freq, expected_bin):
+        """A tone's energy must land in the mel bin covering its frequency.
+
+        This pins the mel scale, the FFT and the triangular filterbank
+        together, independently of the golden values below.
+        """
+        from vtscore.media.audio._beats_model import kaldi_fbank
+
+        fb = kaldi_fbank(_tone(freq) * 2**15)
+        assert int(fb[5].argmax()) == expected_bin
+
+    def test_golden_values(self):
+        """Values captured from the run verified bit-exact against torchaudio.
+
+        ``torchaudio.compliance.kaldi.fbank(waveform * 2**15, num_mel_bins=128,
+        sample_frequency=16000, frame_length=25, frame_shift=10)`` returned
+        exactly these numbers for this input.
+        """
+        from vtscore.media.audio._beats_model import kaldi_fbank
+
+        t = torch.arange(4000, dtype=torch.float32) / 16000
+        waveform = 0.6 * torch.sin(2 * math.pi * 440 * t) + 0.3 * torch.sin(2 * math.pi * 3000 * t)
+        fb = kaldi_fbank(waveform * 2**15)
+
+        assert fb.shape == (23, 128)
+        np.testing.assert_allclose(fb[0, :4].numpy(), [9.7353, 6.9038, 10.3472, -15.9424], rtol=0, atol=1e-3)
+        np.testing.assert_allclose(fb[0, 60:64].numpy(), [6.1935, 5.4065, 6.0111, 7.0570], rtol=0, atol=1e-3)
+        assert float(fb.sum()) == pytest.approx(30299.383, abs=0.05)
+
+    def test_is_deterministic(self):
+        """No dithering: re-running must give bit-identical features."""
+        from vtscore.media.audio._beats_model import kaldi_fbank
+
+        w = _tone(440.0) * 2**15
+        assert torch.equal(kaldi_fbank(w), kaldi_fbank(w))
+
+
+class TestVendoredEncoder:
+    """Structure of the vendored BEATs module."""
+
+    def test_relative_attention_bias_is_shared_across_layers(self):
+        from vtscore.media.audio._beats_model import BEATs
+
+        model = BEATs(TINY_CFG)
+        first = model.encoder.layers[0].self_attn.relative_attention_bias
+        for layer in model.encoder.layers[1:]:
+            assert layer.self_attn.relative_attention_bias is first
+
+    def test_state_dict_keys_match_the_released_layout(self):
+        """The checkpoint stores one bias table per layer; so must we.
+
+        Upstream ties the tables rather than deduplicating them, so the
+        released ``state_dict`` carries a byte-identical copy under every
+        layer. Losing the tie (or dropping the tables) would break a strict
+        load of the real checkpoint.
+        """
+        from vtscore.media.audio._beats_model import BEATs
+
+        keys = set(BEATs(TINY_CFG).state_dict())
+        assert {"patch_embedding.weight", "layer_norm.weight", "post_extract_proj.weight"} <= keys
+        assert {"encoder.pos_conv.0.weight_g", "encoder.pos_conv.0.weight_v"} <= keys
+        for i in range(TINY_CFG["encoder_layers"]):
+            assert f"encoder.layers.{i}.self_attn.relative_attention_bias.weight" in keys
+            assert f"encoder.layers.{i}.self_attn.grep_a" in keys
+
+    def test_deep_norm_alpha(self):
+        from vtscore.media.audio._beats_model import BEATs
+
+        model = BEATs(dict(TINY_CFG, encoder_layers=12))
+        assert model.encoder.layers[0].deep_norm_alpha == pytest.approx(24**0.25)
+
+    def test_extract_features_shape(self):
+        """One token per 16x16 patch: (frames // 16) rows x (128 // 16) columns."""
+        from vtscore.media.audio._beats_model import BEATs
+
+        model = BEATs(TINY_CFG).eval()
+        with torch.no_grad():
+            out = model.extract_features(_tone(440.0, 16000), 15.41663, 6.55582)
+        frames = 1 + (16000 - 400) // 160  # 98
+        assert out.shape == (1, (frames // 16) * (128 // 16), TINY_CFG["encoder_embed_dim"])
+
+    def test_weight_norm_conv_reparameterisation(self):
+        """``weight_g``/``weight_v`` must reconstruct the same conv weight.
+
+        We reparameterise by hand rather than using ``nn.utils.weight_norm``
+        (deprecated) or ``nn.utils.parametrizations.weight_norm`` (different
+        key names), so the maths is worth pinning.
+        """
+        from vtscore.media.audio._beats_model import _WeightNormConv1d
+
+        conv = _WeightNormConv1d(8, kernel_size=4, groups=2)
+        with torch.no_grad():
+            conv.weight_v.normal_(generator=torch.Generator().manual_seed(0))
+            conv.weight_g.fill_(2.0)
+        norm = conv.weight_v.norm(2, dim=(0, 1), keepdim=True)
+        expected = conv.weight_v * (conv.weight_g / norm)
+        # Every kernel slice ends up with L2 norm equal to weight_g.
+        np.testing.assert_allclose(expected.norm(2, dim=(0, 1)).detach().numpy(), np.full(4, 2.0), rtol=1e-5, atol=1e-5)
+
+
+class TestBEATsEmbedderProperties:
+    """Identity and registration — no weights are downloaded."""
+
+    def test_name_and_media_type(self):
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        emb = AudioBEATsEmbedder()
+        assert emb.name == "beats"
+        assert emb.media_type_id == "audio"
+
+    def test_does_not_support_text(self):
+        """BEATs has no text tower, so text search must be hidden for it."""
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        emb = AudioBEATsEmbedder()
+        assert emb.supports_text is False
+        assert emb.embed_text("a dog barking") is None
+
+    def test_is_not_the_default_audio_embedder(self):
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        assert AudioBEATsEmbedder().is_default is False
+
+    def test_registered_in_registry(self):
+        from vtscore.media import get_embedder
+
+        assert get_embedder("beats").name == "beats"
+
+    def test_to_dict(self):
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        assert AudioBEATsEmbedder().to_dict() == {
+            "name": "beats",
+            "display_name": "BEATs (audio events)",
+            "model_id": "lpepino/beats_ckpts",
+            "media_type_id": "audio",
+            "is_default": False,
+            "supports_text": False,
+            "supports_patch_regions": False,
+            "supports_geometric_verification": False,
+            "license_notice": None,
+        }
+
+    def test_config_constants(self):
+        from vtscore.config import (
+            BEATS_CHECKPOINT_FILE,
+            BEATS_CHECKPOINT_REPO,
+            BEATS_FBANK_MEAN,
+            BEATS_FBANK_STD,
+            BEATS_MAX_SAMPLES,
+            BEATS_SAMPLE_RATE,
+        )
+
+        assert BEATS_CHECKPOINT_REPO == "lpepino/beats_ckpts"
+        # The self-supervised encoder, not an AudioSet-finetuned classifier.
+        assert BEATS_CHECKPOINT_FILE == "BEATs_iter3_plus_AS2M.pt"
+        assert BEATS_SAMPLE_RATE == 16000
+        assert BEATS_MAX_SAMPLES == 160000
+        assert (BEATS_FBANK_MEAN, BEATS_FBANK_STD) == (15.41663, 6.55582)
+
+
+class TestBEATsEmbedderAudioHandling:
+    """Windowing / padding / pooling, exercised against a stub encoder."""
+
+    @staticmethod
+    def _stub(emb):
+        """Swap in a fake encoder that records the waveform it was handed."""
+        seen = {}
+
+        class _Fake(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.marker = torch.nn.Parameter(torch.zeros(1))
+
+            def extract_features(self, waveform, fbank_mean, fbank_std):
+                seen["n"] = int(waveform.shape[0])
+                seen["norm"] = (fbank_mean, fbank_std)
+                return torch.arange(2 * 4, dtype=torch.float32).reshape(1, 2, 4)
+
+        emb._model = _Fake()
+        return seen
+
+    def _wav_bytes(self, seconds: float, sr: int = 16000) -> bytes:
+        import io
+
+        import soundfile as sf
+
+        buf = io.BytesIO()
+        sf.write(buf, np.zeros(int(sr * seconds), dtype=np.float32), sr, format="WAV")
+        return buf.getvalue()
+
+    def test_long_audio_is_truncated_to_the_leading_window(self):
+        """Deterministic first window — a random crop would break rederivation."""
+        from vtscore.config import BEATS_MAX_SAMPLES
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        emb = AudioBEATsEmbedder()
+        seen = self._stub(emb)
+        emb._embed_media_impl({"media_bytes": self._wav_bytes(30.0)})
+        assert seen["n"] == BEATS_MAX_SAMPLES
+
+    def test_short_audio_is_padded_to_the_floor(self):
+        """Too-short clips must still produce a patch row instead of failing."""
+        from vtscore.config import BEATS_MIN_SAMPLES
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        emb = AudioBEATsEmbedder()
+        seen = self._stub(emb)
+        emb._embed_media_impl({"media_bytes": self._wav_bytes(0.05)})
+        assert seen["n"] == BEATS_MIN_SAMPLES
+
+    def test_mid_length_audio_is_passed_through_untouched(self):
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        emb = AudioBEATsEmbedder()
+        seen = self._stub(emb)
+        emb._embed_media_impl({"media_bytes": self._wav_bytes(5.0)})
+        assert seen["n"] == 5 * 16000
+
+    def test_tokens_are_mean_pooled(self):
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        emb = AudioBEATsEmbedder()
+        self._stub(emb)
+        vec = emb._embed_media_impl({"media_bytes": self._wav_bytes(5.0)})
+        # Stub returns tokens [[0,1,2,3],[4,5,6,7]] -> mean over dim 1.
+        np.testing.assert_allclose(vec, [2.0, 3.0, 4.0, 5.0])
+
+    def test_uses_the_checkpoint_fbank_normalisation(self):
+        from vtscore.config import BEATS_FBANK_MEAN, BEATS_FBANK_STD
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        emb = AudioBEATsEmbedder()
+        seen = self._stub(emb)
+        emb._embed_media_impl({"media_bytes": self._wav_bytes(5.0)})
+        assert seen["norm"] == (BEATS_FBANK_MEAN, BEATS_FBANK_STD)
+
+    def test_missing_source_returns_none(self):
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        emb = AudioBEATsEmbedder()
+        self._stub(emb)
+        assert emb._embed_media_impl({}) is None
+
+    def test_undecodable_bytes_return_none(self):
+        from vtscore.media.audio.embedder_beats import AudioBEATsEmbedder
+
+        emb = AudioBEATsEmbedder()
+        self._stub(emb)
+        assert emb._embed_media_impl({"media_bytes": b"not audio"}) is None

--- a/tests_lib/detectors/test_beats_embedder.py
+++ b/tests_lib/detectors/test_beats_embedder.py
@@ -8,11 +8,24 @@ Covers three layers, none of which downloads the released weights:
 """
 
 import math
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pytest
+import torch
 
-torch = pytest.importorskip("torch")
+if TYPE_CHECKING:
+    from vtscore.media.audio._beats_model import BEATs, _EncoderLayer
+
+
+def _layers(model: "BEATs") -> list["_EncoderLayer"]:
+    """The encoder's layers, typed.
+
+    ``nn.ModuleList`` indexing widens to ``Module``, whose ``__getattr__``
+    returns ``Tensor | Module``, so reaching into a layer's submodules needs
+    the concrete type back.
+    """
+    return cast(list["_EncoderLayer"], list(model.encoder.layers))
 
 
 # A miniature BEATs config: same shape as the released one, small enough to
@@ -40,7 +53,7 @@ TINY_CFG = {
 }
 
 
-def _tone(freq: float, n: int = 4000, sr: int = 16000) -> "torch.Tensor":
+def _tone(freq: float, n: int = 4000, sr: int = 16000) -> torch.Tensor:
     """A deterministic pure tone — no RNG, so goldens are version-stable."""
     t = torch.arange(n, dtype=torch.float32) / sr
     return torch.sin(2 * math.pi * freq * t)
@@ -110,9 +123,9 @@ class TestVendoredEncoder:
     def test_relative_attention_bias_is_shared_across_layers(self):
         from vtscore.media.audio._beats_model import BEATs
 
-        model = BEATs(TINY_CFG)
-        first = model.encoder.layers[0].self_attn.relative_attention_bias
-        for layer in model.encoder.layers[1:]:
+        layers = _layers(BEATs(TINY_CFG))
+        first = layers[0].self_attn.relative_attention_bias
+        for layer in layers[1:]:
             assert layer.self_attn.relative_attention_bias is first
 
     def test_state_dict_keys_match_the_released_layout(self):
@@ -150,13 +163,13 @@ class TestVendoredEncoder:
         from vtscore.media.audio._beats_model import BEATs
 
         model = BEATs(dict(TINY_CFG, deep_norm=False))
-        assert model.encoder.layers[0].deep_norm_alpha == 1.0
+        assert _layers(model)[0].deep_norm_alpha == 1.0
 
     def test_deep_norm_alpha(self):
         from vtscore.media.audio._beats_model import BEATs
 
         model = BEATs(dict(TINY_CFG, encoder_layers=12))
-        assert model.encoder.layers[0].deep_norm_alpha == pytest.approx(24**0.25)
+        assert _layers(model)[0].deep_norm_alpha == pytest.approx(24**0.25)
 
     def test_extract_features_shape(self):
         """One token per 16x16 patch: (frames // 16) rows x (128 // 16) columns."""
@@ -312,6 +325,7 @@ class TestBEATsEmbedderAudioHandling:
         emb = AudioBEATsEmbedder()
         self._stub(emb)
         vec = emb._embed_media_impl({"media_bytes": self._wav_bytes(5.0)})
+        assert vec is not None
         # Stub returns tokens [[0,1,2,3],[4,5,6,7]] -> mean over dim 1.
         np.testing.assert_allclose(vec, [2.0, 3.0, 4.0, 5.0])
 

--- a/tests_lib/detectors/test_eval.py
+++ b/tests_lib/detectors/test_eval.py
@@ -345,7 +345,7 @@ class TestEvalTextSort:
         ]
 
         # Mock embed_text_query to return the cluster centre
-        def mock_embed(text, media_type, enrich=False):
+        def mock_embed(text, media_type, enrich=False, embedder_name=""):
             if "cat" in text:
                 return cat_dir.copy()
             return dog_dir.copy()
@@ -388,7 +388,7 @@ class TestEvalTextSort:
         medias, cat_dir, _ = self._make_synthetic_clips()
         queries = [EvalQuery("a cat", "cat"), EvalQuery("a dog", "dog")]
 
-        def mock_embed(text, media_type, enrich=False):
+        def mock_embed(text, media_type, enrich=False, embedder_name=""):
             return cat_dir.copy()
 
         start = time.monotonic()
@@ -398,6 +398,37 @@ class TestEvalTextSort:
             assert qm.elapsed_seconds >= 0.0
         # Second query should have equal or later timestamp
         assert results[1].elapsed_seconds >= results[0].elapsed_seconds
+
+    def test_query_is_embedded_with_the_datasets_embedder(self):
+        """The query must land in the *dataset's* space, not the default one.
+
+        Without this the harness embedded queries with the media type's
+        default embedder while the medias carried vectors from whatever
+        ``--embedder`` asked for. Cosine between two unrelated 512-d spaces
+        is noise, so every non-default arm silently reported near-chance mAP
+        while looking like a real measurement.
+        """
+        medias, cat_dir, _ = self._make_synthetic_clips()
+        queries = [EvalQuery("a cat", "cat")]
+        seen = []
+
+        def mock_embed(text, media_type, enrich=False, embedder_name=""):
+            seen.append(embedder_name)
+            return cat_dir.copy()
+
+        with patch("vtscore.embedding.helpers.embed_text_query", side_effect=mock_embed):
+            eval_text_sort(medias, queries, "image", k_values=[5], embedder_name="clap_general")
+        assert seen == ["clap_general"]
+
+    def test_loaded_embedder_name_is_read_off_the_medias(self):
+        """Resolved from the medias, not the flag, which is empty by default."""
+        from vtscore.eval.runner import _loaded_embedder_name
+
+        medias = {
+            1: {"embedder": "clap_general", "embeddings": {"clap_general": np.zeros(4, dtype=np.float32)}},
+        }
+        assert _loaded_embedder_name(medias) == "clap_general"
+        assert _loaded_embedder_name({}) == ""
 
 
 # =====================================================================

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -1112,8 +1112,8 @@ class TestAllEmbeddersRegistration:
         # plus single/patch variants for dinov2, dinov3, eupe) + 1 face embedder
         # + 1 structural image embedder (sift_vlad)
         # + 1 vision-only video embedder (videomae)
-        # + 4 audio embedders (ast, clap_general, whisper_encoder, paraspeechclap).
-        assert len(embedders) == 24
+        # + 5 audio embedders (ast, beats, clap_general, whisper_encoder, paraspeechclap).
+        assert len(embedders) == 25
 
     def test_all_embedders_dict_includes_supports_text(self):
         """The new ``supports_text`` flag must round-trip through ``to_dict``
@@ -1146,6 +1146,7 @@ class TestAllEmbeddersRegistration:
             "sift_vlad",
             "videomae",
             "ast",
+            "beats",
             "whisper_encoder",
         ):
             assert by_name[name]["supports_text"] is False, name
@@ -1159,6 +1160,7 @@ class TestAllEmbeddersRegistration:
             "clap_music",
             "clap_general",
             "ast",
+            "beats",
             "whisper_encoder",
             "paraspeechclap",
             "siglip",
@@ -1186,7 +1188,7 @@ class TestAllEmbeddersRegistration:
         from vtscore.media import embedders_for_type
 
         names = {e.name for e in embedders_for_type("audio")}
-        assert names == {"clap", "clap_music", "clap_general", "ast", "whisper_encoder", "paraspeechclap"}
+        assert names == {"clap", "clap_music", "clap_general", "ast", "beats", "whisper_encoder", "paraspeechclap"}
 
     def test_embedders_for_image(self):
         from vtscore.media import embedders_for_type
@@ -1244,8 +1246,8 @@ class TestAllEmbeddersRegistration:
         # plus single/patch variants for dinov2, dinov3, eupe) + 1 face embedder
         # + 1 structural image embedder (sift_vlad)
         # + 1 vision-only video embedder (videomae)
-        # + 4 audio embedders (ast, clap_general, whisper_encoder, paraspeechclap).
-        assert len(dicts) == 24
+        # + 5 audio embedders (ast, beats, clap_general, whisper_encoder, paraspeechclap).
+        assert len(dicts) == 25
         for d in dicts:
             assert "name" in d
             assert "media_type_id" in d

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -10,6 +10,18 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ## [Unreleased]
 
+### Added
+
+- **`beats` audio embedder** - Microsoft's BEATs iter3+ AudioSet-2M
+  self-supervised encoder, exposed as a 768-d audio-only embedder
+  (`supports_text=False`). There is no `transformers` implementation, so the
+  architecture is vendored in `vtscore.media.audio._beats_model` (DeepNorm
+  residuals, a shared gated relative position bias, a weight-normalised
+  convolutional position embedding) and the released MIT-licensed checkpoint
+  is loaded onto it. Its Kaldi `compute-fbank-feats` front-end is ported from
+  torchaudio's pure-PyTorch implementation rather than taken as a dependency,
+  since torchaudio's wheels are built against a pinned torch.
+
 ### Changed
 
 - **`fold_anchored_gmm_threshold` is the shipped decision threshold.** Per

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -295,6 +295,22 @@ CLAP_MUSIC_MODEL_ID = "laion/larger_clap_music_and_speech"
 CLAP_GENERAL_MODEL_ID = "laion/larger_clap_general"
 AST_MODEL_ID = "MIT/ast-finetuned-audioset-10-10-0.4593"
 AST_SAMPLE_RATE = 16000  # AST expects 16 kHz mono
+# BEATs: Microsoft's self-supervised audio encoder (MIT, part of ``microsoft/unilm``).
+# The official weights are published as loose ``.pt`` files on Azure blob storage
+# rather than on the Hub, so we pull the ``iter3+`` AudioSet-2M checkpoint from an
+# MIT-licensed Hub mirror of that release. ``iter3_plus_AS2M`` is the
+# self-supervised encoder, *not* one of the AudioSet-finetuned classifier
+# variants: it has no prediction head, which is what we want for embeddings.
+BEATS_CHECKPOINT_REPO = "lpepino/beats_ckpts"
+BEATS_CHECKPOINT_FILE = "BEATs_iter3_plus_AS2M.pt"
+BEATS_SAMPLE_RATE = 16000  # BEATs expects 16 kHz mono
+BEATS_EMBED_DIM = 768
+BEATS_MAX_SAMPLES = 16000 * 10  # cap clips at the 10 s AudioSet window BEATs was trained on
+BEATS_MIN_SAMPLES = 16000  # zero-pad anything shorter, so short clips still yield patches
+# Global fbank normalisation constants baked into the released BEATs
+# checkpoints; the encoder expects ``(fbank - mean) / (2 * std)``.
+BEATS_FBANK_MEAN = 15.41663
+BEATS_FBANK_STD = 6.55582
 WHISPER_MODEL_ID = "openai/whisper-base"
 WHISPER_SAMPLE_RATE = 16000  # Whisper expects 16 kHz mono
 # ParaSpeechCLAP: dual-encoder speech↔text "style" CLAP (MIT-licensed).

--- a/vtscore/docs/packages/config.md
+++ b/vtscore/docs/packages/config.md
@@ -219,6 +219,9 @@ time. The actual download + load is lazy, driven by
 | `CLAP_GENERAL_MODEL_ID`        | `"laion/larger_clap_general"`                                                          | Larger general-purpose CLAP.                                                           |
 | `AST_MODEL_ID`                 | `"MIT/ast-finetuned-audioset-10-10-0.4593"`                                            | Audio Spectrogram Transformer. 16 kHz mono via `AST_SAMPLE_RATE`.                      |
 | `AST_SAMPLE_RATE`              | `16000`                                                                                |                                                                                        |
+| `BEATS_CHECKPOINT_REPO`        | `"lpepino/beats_ckpts"`                                                                | Hub mirror of the MIT-licensed BEATs release (no `transformers` implementation).       |
+| `BEATS_CHECKPOINT_FILE`        | `"BEATs_iter3_plus_AS2M.pt"`                                                           | Self-supervised encoder, not an AudioSet-finetuned classifier variant.                 |
+| `BEATS_SAMPLE_RATE`            | `16000`                                                                                | 16 kHz mono; features are Kaldi fbanks, not waveforms.                                 |
 | `WHISPER_MODEL_ID`             | `"openai/whisper-base"`                                                                | Used by the audio→text converter (ASR).                                                |
 | `WHISPER_SAMPLE_RATE`          | `16000`                                                                                |                                                                                        |
 | `XCLIP_MODEL_ID`               | `"microsoft/xclip-base-patch32"`                                                       | Default video embedder.                                                                |

--- a/vtscore/docs/packages/media.md
+++ b/vtscore/docs/packages/media.md
@@ -311,7 +311,7 @@ Each lives under `vtscore/media/<type>/` and self-registers:
 
 | Type     | Folder                       | Default embedder                | Other embedders ship in-tree                            |
 |----------|------------------------------|---------------------------------|---------------------------------------------------------|
-| audio    | `vtscore/media/audio/`       | `clap` (`laion/clap-htsat-unfused`) | `clap_general`, `clap_music`, `ast`, `whisper_encoder`, `paraspeechclap` |
+| audio    | `vtscore/media/audio/`       | `clap` (`laion/clap-htsat-unfused`) | `clap_general`, `clap_music`, `beats`, `ast`, `whisper_encoder`, `paraspeechclap` |
 | image    | `vtscore/media/image/`       | `siglip` (`google/siglip-base-patch16-224`) | `clip`, `siglip2`, `siglip2_l`, `siglip_l`, `dinov2_single`, `dinov2_patch`, `dinov3_single`, `dinov3_patch`, `eupe_single`, `eupe_patch`, `face` |
 | text     | `vtscore/media/text/`        | `e5` (`intfloat/multilingual-e5-base`) | `bge`                                            |
 | video    | `vtscore/media/video/`       | `xclip` (`microsoft/xclip-base-patch32`) | `videomae`, `languagebind`                       |

--- a/vtscore/eval/runner.py
+++ b/vtscore/eval/runner.py
@@ -39,19 +39,42 @@ def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
     return float(np.dot(a, b) / norm)
 
 
+def _loaded_embedder_name(medias: dict[int, dict[str, Any]]) -> str:
+    """The embedder the loaded *medias* actually carry vectors for.
+
+    Read back off the medias rather than taken from the ``--embedder`` flag,
+    because the flag is empty for a default-embedder run while the medias
+    always name the concrete embedder that produced them.
+    """
+    from vtscore.embedding.media_vectors import media_embedder_names
+
+    first = next(iter(medias.values()), {})
+    names = media_embedder_names(first)
+    return names[0] if names else ""
+
+
 def _run_text_sort_query(
     query: EvalQuery,
     medias: dict[int, dict[str, Any]],
     media_type: str,
     enrich: bool = False,
+    embedder_name: str = "",
 ) -> list[dict[str, Any]]:
     """Embed the query text and rank medias by cosine similarity.
+
+    *embedder_name* must be the embedder the medias were embedded with: the
+    query has to land in the same vector space as the media vectors it is
+    compared against.  Omitting it falls back to the media type's *default*
+    embedder, which silently scores a non-default ``--embedder`` run across
+    two unrelated spaces and reports near-chance mAP.  The app threads the
+    dataset's bound embedder through the same argument
+    (``vtsearch/routes/sorting.py``).
 
     Returns a list of ``{"id": int, "similarity": float}`` sorted descending.
     """
     from vtscore.embedding.helpers import embed_text_query
 
-    text_vec = embed_text_query(query.text, media_type, enrich=enrich)
+    text_vec = embed_text_query(query.text, media_type, enrich=enrich, embedder_name=embedder_name)
     if text_vec is None:
         raise RuntimeError(f"Could not embed query {query.text!r} for media type {media_type}")
 
@@ -71,6 +94,7 @@ def eval_text_sort(
     k_values: list[int] | None = None,
     enrich: bool = False,
     start_time: float | None = None,
+    embedder_name: str = "",
 ) -> list:
     """Run text-sort evaluation for a list of queries.
 
@@ -85,6 +109,8 @@ def eval_text_sort(
         enrich: If ``True``, use enriched (wrapper-averaged) text embeddings.
         start_time: Monotonic timestamp from the start of the eval run.
             When provided, each result records ``elapsed_seconds``.
+        embedder_name: The embedder *medias* were embedded with, so the query
+            lands in the same space. Empty means the media type's default.
 
     Returns:
         List of :class:`~vtscore.eval.metrics.QueryMetrics`.
@@ -93,7 +119,7 @@ def eval_text_sort(
 
     results: list[QueryMetrics] = []
     for query in queries:
-        ranked = _run_text_sort_query(query, medias, media_type, enrich=enrich)
+        ranked = _run_text_sort_query(query, medias, media_type, enrich=enrich, embedder_name=embedder_name)
         ranked_ids = [r["id"] for r in ranked]
         relevant_ids = {cid for cid, c in medias.items() if media_is_positive(c, query.target_category)}
 
@@ -317,7 +343,17 @@ def run_eval(
         # --- Text sort ---
         if mode in ("text", "both"):
             print(f"\n--- Text Sort Evaluation ({len(queries)} queries) ---")
-            text_results = eval_text_sort(medias, queries, media_type, k_values, enrich=enrich, start_time=start_time)
+            # Score the query in the *dataset's* space, not the media type's
+            # default — see _run_text_sort_query.
+            text_results = eval_text_sort(
+                medias,
+                queries,
+                media_type,
+                k_values,
+                enrich=enrich,
+                start_time=start_time,
+                embedder_name=_loaded_embedder_name(medias),
+            )
             ds_result.text_sort = text_results
 
             for qm in text_results:

--- a/vtscore/media/audio/_beats_model.py
+++ b/vtscore/media/audio/_beats_model.py
@@ -389,32 +389,32 @@ class _TransformerEncoder(nn.Module):
             _SamePad(cfg["conv_pos"]),
             nn.GELU(),
         )
-        self.layers = nn.ModuleList(
-            [
-                _EncoderLayer(
-                    embedding_dim=embed_dim,
-                    ffn_embedding_dim=cfg["encoder_ffn_embed_dim"],
-                    num_attention_heads=cfg["encoder_attention_heads"],
-                    dropout=self.dropout,
-                    attention_dropout=cfg["attention_dropout"],
-                    activation_dropout=cfg["activation_dropout"],
-                    has_relative_attention_bias=cfg["relative_position_embedding"],
-                    num_buckets=cfg["num_buckets"],
-                    max_distance=cfg["max_distance"],
-                    gru_rel_pos=cfg["gru_rel_pos"],
-                    deep_norm=cfg["deep_norm"],
-                    encoder_layers=layers,
-                )
-                for _ in range(layers)
-            ]
-        )
+        stack = [
+            _EncoderLayer(
+                embedding_dim=embed_dim,
+                ffn_embedding_dim=cfg["encoder_ffn_embed_dim"],
+                num_attention_heads=cfg["encoder_attention_heads"],
+                dropout=self.dropout,
+                attention_dropout=cfg["attention_dropout"],
+                activation_dropout=cfg["activation_dropout"],
+                has_relative_attention_bias=cfg["relative_position_embedding"],
+                num_buckets=cfg["num_buckets"],
+                max_distance=cfg["max_distance"],
+                gru_rel_pos=cfg["gru_rel_pos"],
+                deep_norm=cfg["deep_norm"],
+                encoder_layers=layers,
+            )
+            for _ in range(layers)
+        ]
         if cfg["relative_position_embedding"]:
             # Tie every layer's table to layer 0's, as upstream does. Only
             # layer 0 actually evaluates it (the bias is computed once and
             # passed up the stack), but the tie is what makes the checkpoint's
-            # twelve identical copies load.
-            for i in range(1, layers):
-                self.layers[i].self_attn.relative_attention_bias = self.layers[0].self_attn.relative_attention_bias
+            # twelve identical copies load. Tied here, before the ModuleList
+            # wraps them, so the concrete layer type is still in hand.
+            for layer in stack[1:]:
+                layer.self_attn.relative_attention_bias = stack[0].self_attn.relative_attention_bias
+        self.layers = nn.ModuleList(stack)
         self.layer_norm = nn.LayerNorm(embed_dim)
 
     def forward(self, x: Tensor) -> Tensor:

--- a/vtscore/media/audio/_beats_model.py
+++ b/vtscore/media/audio/_beats_model.py
@@ -1,0 +1,449 @@
+"""Vendored BEATs architecture + Kaldi-compatible fbank front-end.
+
+BEATs ("Audio Pre-Training with Acoustic Tokenizers", Chen et al. 2022) has no
+``transformers`` implementation, so - exactly as with
+:mod:`vtscore.media.audio._paraspeechclap_model` - the architecture is
+reconstructed here and the released checkpoint is overlaid onto it.  The
+underscore-prefixed filename keeps this module out of the embedder
+auto-discovery scan in :mod:`vtscore.media` (only ``embedder*.py`` files are
+imported as plugins); :mod:`vtscore.media.audio.embedder_beats` imports from
+here.
+
+Two things are vendored:
+
+**The encoder** (:class:`BEATs`) - a ported subset of ``microsoft/unilm``'s
+``BEATs.py`` / ``backbone.py`` (MIT).  A 16x16 patch embedding over the
+log-mel fbank feeds a 12-layer, 768-d Transformer that differs from a stock
+Transformer in three ways, all of which the released weights depend on:
+
+- **DeepNorm** residual scaling (``x = residual * alpha + f(x)`` with
+  ``alpha = (2 * layers) ** 0.25``) and post-layer-norm ordering.
+- **Gated relative position bias** - a T5-style bucketed bias, computed once
+  in layer 0 and shared by every layer, gated per-layer by ``grep_linear`` /
+  ``grep_a`` from the query.
+- A grouped **convolutional position embedding** (``pos_conv``) applied before
+  the stack, stored weight-normalised as ``weight_g`` / ``weight_v``.
+
+Only the inference path is ported.  Training-only machinery (layer-drop,
+gradient scaling, the masked-prediction head, the acoustic tokenizer) is
+omitted, and the fine-tuned classifier variants are not supported - the
+embedder loads the self-supervised checkpoint and mean-pools the encoder
+output.
+
+**The front-end** (:func:`kaldi_fbank`) - BEATs consumes Kaldi
+``compute-fbank-feats`` features, which upstream obtains from
+``torchaudio.compliance.kaldi.fbank``.  We do not depend on torchaudio (its
+wheels are built against a pinned torch and would constrain ours), so the
+fbank is ported here from torchaudio's own pure-PyTorch implementation
+(BSD-2), specialised to the settings BEATs uses.  The port was checked against
+torchaudio's output and agrees bit-for-bit at every signal length tried;
+``tests_lib/detectors/test_beats_embedder.py`` pins values captured from that
+verified run so later refactors cannot drift away from it.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+from torch import Tensor, nn
+
+# ----------------------------------------------------------------------
+# Kaldi-compatible log-mel filterbank
+#
+# Ported from ``torchaudio.compliance.kaldi`` (BSD-2), fixed to the options
+# BEATs uses: 128 mel bins, 25 ms / 10 ms framing, Povey window, power
+# spectrum, log output, snip_edges, no dither, no energy column.  The
+# remaining Kaldi defaults are inlined as the constants below.
+# ----------------------------------------------------------------------
+
+_PREEMPHASIS = 0.97
+_LOW_FREQ = 20.0
+
+
+def _next_power_of_2(x: int) -> int:
+    return 1 if x == 0 else 2 ** (x - 1).bit_length()
+
+
+def _mel_scale(freq: Tensor) -> Tensor:
+    return 1127.0 * (1.0 + freq / 700.0).log()
+
+
+def _mel_scale_scalar(freq: float) -> float:
+    return 1127.0 * math.log(1.0 + freq / 700.0)
+
+
+def _mel_banks(num_bins: int, window_length_padded: int, sample_freq: float, low_freq: float) -> Tensor:
+    """Kaldi triangular mel filterbank, shape ``(num_bins, padded // 2)``."""
+    num_fft_bins = window_length_padded / 2
+    nyquist = 0.5 * sample_freq
+    high_freq = nyquist  # Kaldi's ``high_freq <= 0`` means "offset from Nyquist"
+
+    fft_bin_width = sample_freq / window_length_padded
+    mel_low_freq = _mel_scale_scalar(low_freq)
+    mel_high_freq = _mel_scale_scalar(high_freq)
+    # +1 because the end bins spread out past the edges.
+    mel_freq_delta = (mel_high_freq - mel_low_freq) / (num_bins + 1)
+
+    bin_idx = torch.arange(num_bins).unsqueeze(1)
+    left_mel = mel_low_freq + bin_idx * mel_freq_delta
+    center_mel = mel_low_freq + (bin_idx + 1.0) * mel_freq_delta
+    right_mel = mel_low_freq + (bin_idx + 2.0) * mel_freq_delta
+
+    mel = _mel_scale(fft_bin_width * torch.arange(num_fft_bins)).unsqueeze(0)
+    up_slope = (mel - left_mel) / (center_mel - left_mel)
+    down_slope = (right_mel - mel) / (right_mel - center_mel)
+    # left < center < right, so the min of the two slopes clamped at 0 is the triangle.
+    return torch.max(torch.zeros(1), torch.min(up_slope, down_slope))
+
+
+def kaldi_fbank(
+    waveform: Tensor,
+    *,
+    num_mel_bins: int = 128,
+    sample_frequency: float = 16000.0,
+    frame_length: float = 25.0,
+    frame_shift: float = 10.0,
+) -> Tensor:
+    """Log-mel filterbank matching Kaldi's ``compute-fbank-feats``.
+
+    Args:
+        waveform: 1-D tensor of samples, already scaled to Kaldi's int16-ish
+            range (BEATs multiplies its ``[-1, 1]`` float audio by ``2 ** 15``).
+        num_mel_bins: Number of triangular mel bins.
+        sample_frequency: Sample rate of *waveform*, in Hz.
+        frame_length: Window length in milliseconds.
+        frame_shift: Hop between windows in milliseconds.
+
+    Returns:
+        Tensor of shape ``(num_frames, num_mel_bins)``.
+    """
+    device, dtype = waveform.device, waveform.dtype
+    epsilon = torch.tensor(torch.finfo(torch.float).eps, device=device, dtype=dtype)
+
+    window_shift = int(sample_frequency * frame_shift * 0.001)
+    window_size = int(sample_frequency * frame_length * 0.001)
+    padded_window_size = _next_power_of_2(window_size)
+
+    # Frames that completely fit in the signal (Kaldi's snip_edges=True).
+    num_samples = waveform.size(0)
+    if num_samples < window_size:
+        return torch.empty((0, num_mel_bins), dtype=dtype, device=device)
+    m = 1 + (num_samples - window_size) // window_shift
+    strides = (window_shift * waveform.stride(0), waveform.stride(0))
+    strided = waveform.as_strided((m, window_size), strides)
+
+    # remove_dc_offset: subtract each frame's own mean.
+    strided = strided - torch.mean(strided, dim=1).unsqueeze(1)
+
+    # Pre-emphasis, with the first sample replicated so frame[0] keeps its edge.
+    offset = F.pad(strided.unsqueeze(0), (1, 0), mode="replicate").squeeze(0)
+    strided = strided - _PREEMPHASIS * offset[:, :-1]
+
+    # Povey window: a Hann window raised to 0.85 so it reaches zero at the edges.
+    window = torch.hann_window(window_size, periodic=False, device=device, dtype=dtype).pow(0.85)
+    strided = strided * window.unsqueeze(0)
+
+    if padded_window_size != window_size:
+        strided = F.pad(strided.unsqueeze(0), (0, padded_window_size - window_size), mode="constant", value=0).squeeze(
+            0
+        )
+
+    spectrum = torch.fft.rfft(strided).abs().pow(2.0)
+
+    banks = _mel_banks(num_mel_bins, padded_window_size, sample_frequency, _LOW_FREQ).to(device=device, dtype=dtype)
+    # The Nyquist column is not covered by any triangle; pad it with zeros.
+    banks = F.pad(banks, (0, 1), mode="constant", value=0)
+
+    return torch.max(torch.mm(spectrum, banks.T), epsilon).log()
+
+
+# ----------------------------------------------------------------------
+# Encoder
+# ----------------------------------------------------------------------
+
+
+class _SamePad(nn.Module):
+    """Trim the trailing column an even-width 'same' convolution adds."""
+
+    def __init__(self, kernel_size: int) -> None:
+        super().__init__()
+        self.remove = 1 if kernel_size % 2 == 0 else 0
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.remove > 0:
+            x = x[:, :, : -self.remove]
+        return x
+
+
+class _WeightNormConv1d(nn.Module):
+    """``Conv1d`` with the weight stored weight-normalised over ``dim=2``.
+
+    Upstream builds this with ``nn.utils.weight_norm(conv, dim=2)``, which is
+    deprecated in current torch and whose replacement
+    (``nn.utils.parametrizations.weight_norm``) renames the stored tensors to
+    ``parametrizations.weight.original{0,1}``.  The released checkpoint holds
+    the legacy ``weight_g`` / ``weight_v`` names, so the reparameterisation is
+    done explicitly here: it pins the key names and is version-proof.
+    """
+
+    def __init__(self, channels: int, kernel_size: int, groups: int) -> None:
+        super().__init__()
+        self.padding = kernel_size // 2
+        self.groups = groups
+        self.weight_g = nn.Parameter(torch.ones(1, 1, kernel_size))
+        self.weight_v = nn.Parameter(torch.zeros(channels, channels // groups, kernel_size))
+        self.bias = nn.Parameter(torch.zeros(channels))
+
+    def forward(self, x: Tensor) -> Tensor:
+        # weight_norm over dim=2: normalise across every dim except the last.
+        norm = self.weight_v.norm(2, dim=(0, 1), keepdim=True)
+        weight = self.weight_v * (self.weight_g / norm)
+        return F.conv1d(x, weight, self.bias, padding=self.padding, groups=self.groups)
+
+
+class _MultiheadAttention(nn.Module):
+    """Self-attention with a gated, bucketed relative position bias.
+
+    One relative-position table is shared by the whole stack: only layer 0 ever
+    computes the bias, and it threads the *raw* bias through to the layers
+    above, each of which applies its own gate (``grep_linear`` / ``grep_a``) to
+    it.  ``_TransformerEncoder`` ties the tables the way upstream does, which
+    is why the released checkpoint carries twelve byte-identical copies.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        dropout: float,
+        has_relative_attention_bias: bool,
+        num_buckets: int,
+        max_distance: int,
+    ) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.dropout_module = nn.Dropout(dropout)
+        self.has_relative_attention_bias = has_relative_attention_bias
+        self.num_buckets = num_buckets
+        self.max_distance = max_distance
+
+        if has_relative_attention_bias:
+            self.relative_attention_bias = nn.Embedding(num_buckets, num_heads)
+
+        self.k_proj = nn.Linear(embed_dim, embed_dim)
+        self.v_proj = nn.Linear(embed_dim, embed_dim)
+        self.q_proj = nn.Linear(embed_dim, embed_dim)
+        self.out_proj = nn.Linear(embed_dim, embed_dim)
+
+        self.grep_linear = nn.Linear(self.head_dim, 8)
+        self.grep_a = nn.Parameter(torch.ones(1, num_heads, 1, 1))
+
+    def _relative_positions_bucket(self, relative_positions: Tensor) -> Tensor:
+        """T5-style bidirectional bucketing: exact when near, log-spaced when far."""
+        num_buckets = self.num_buckets // 2
+        relative_buckets = (relative_positions > 0).to(torch.long) * num_buckets
+        relative_positions = torch.abs(relative_positions)
+
+        max_exact = num_buckets // 2
+        is_small = relative_positions < max_exact
+        if_large = max_exact + (
+            torch.log(relative_positions.float() / max_exact)
+            / math.log(self.max_distance / max_exact)
+            * (num_buckets - max_exact)
+        ).to(torch.long)
+        if_large = torch.min(if_large, torch.full_like(if_large, num_buckets - 1))
+        return relative_buckets + torch.where(is_small, relative_positions, if_large)
+
+    def compute_bias(self, query_length: int, key_length: int) -> Tensor:
+        context_position = torch.arange(query_length, dtype=torch.long)[:, None]
+        memory_position = torch.arange(key_length, dtype=torch.long)[None, :]
+        bucket = self._relative_positions_bucket(memory_position - context_position)
+        bucket = bucket.to(self.relative_attention_bias.weight.device)
+        return self.relative_attention_bias(bucket).permute([2, 0, 1])
+
+    def forward(self, x: Tensor, position_bias: Optional[Tensor]) -> tuple[Tensor, Optional[Tensor]]:
+        """Args: *x* is ``(T, B, C)``; returns ``(output, raw position bias)``."""
+        tgt_len, bsz, _ = x.size()
+
+        if self.has_relative_attention_bias and position_bias is None:
+            position_bias = self.compute_bias(tgt_len, tgt_len)
+            position_bias = position_bias.unsqueeze(0).repeat(bsz, 1, 1, 1).view(bsz * self.num_heads, tgt_len, tgt_len)
+
+        attn_mask = None
+        if position_bias is not None:
+            # Gate the shared bias on this layer's queries.
+            query_layer = x.transpose(0, 1).view(bsz, tgt_len, self.num_heads, -1).transpose(1, 2)
+            _b, _h, _l, _ = query_layer.size()
+            gate_a, gate_b = torch.sigmoid(
+                self.grep_linear(query_layer).view(_b, _h, _l, 2, 4).sum(-1, keepdim=False)
+            ).chunk(2, dim=-1)
+            gate = gate_a * (gate_b * self.grep_a - 1.0) + 2.0
+            attn_mask = gate.view(bsz * self.num_heads, tgt_len, 1) * position_bias
+            attn_mask = attn_mask.view((-1, tgt_len, tgt_len))
+
+        out, _ = F.multi_head_attention_forward(
+            x,
+            x,
+            x,
+            self.embed_dim,
+            self.num_heads,
+            torch.empty([0]),
+            torch.cat((self.q_proj.bias, self.k_proj.bias, self.v_proj.bias)),
+            None,
+            None,
+            False,
+            self.dropout_module.p,
+            self.out_proj.weight,
+            self.out_proj.bias,
+            self.training,
+            need_weights=False,
+            attn_mask=attn_mask,
+            use_separate_proj_weight=True,
+            q_proj_weight=self.q_proj.weight,
+            k_proj_weight=self.k_proj.weight,
+            v_proj_weight=self.v_proj.weight,
+        )
+        return out, position_bias
+
+
+class _EncoderLayer(nn.Module):
+    """Post-LN Transformer layer with DeepNorm residual scaling."""
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        ffn_embedding_dim: int,
+        num_attention_heads: int,
+        dropout: float,
+        attention_dropout: float,
+        activation_dropout: float,
+        has_relative_attention_bias: bool,
+        num_buckets: int,
+        max_distance: int,
+        encoder_layers: int,
+    ) -> None:
+        super().__init__()
+        self.self_attn = _MultiheadAttention(
+            embedding_dim,
+            num_attention_heads,
+            dropout=attention_dropout,
+            has_relative_attention_bias=has_relative_attention_bias,
+            num_buckets=num_buckets,
+            max_distance=max_distance,
+        )
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(activation_dropout)
+        self.dropout3 = nn.Dropout(dropout)
+        self.self_attn_layer_norm = nn.LayerNorm(embedding_dim)
+        self.fc1 = nn.Linear(embedding_dim, ffn_embedding_dim)
+        self.fc2 = nn.Linear(ffn_embedding_dim, embedding_dim)
+        self.final_layer_norm = nn.LayerNorm(embedding_dim)
+        self.deep_norm_alpha = math.pow(2 * encoder_layers, 1 / 4)
+
+    def forward(self, x: Tensor, pos_bias: Optional[Tensor]) -> tuple[Tensor, Optional[Tensor]]:
+        residual = x
+        x, pos_bias = self.self_attn(x, position_bias=pos_bias)
+        x = self.dropout1(x)
+        x = residual * self.deep_norm_alpha + x
+        x = self.self_attn_layer_norm(x)
+
+        residual = x
+        x = F.gelu(self.fc1(x).float()).type_as(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        x = self.dropout3(x)
+        x = residual * self.deep_norm_alpha + x
+        x = self.final_layer_norm(x)
+        return x, pos_bias
+
+
+class _TransformerEncoder(nn.Module):
+    def __init__(self, cfg: dict) -> None:
+        super().__init__()
+        embed_dim = cfg["encoder_embed_dim"]
+        layers = cfg["encoder_layers"]
+        self.dropout = cfg["dropout"]
+        self.pos_conv = nn.Sequential(
+            _WeightNormConv1d(embed_dim, cfg["conv_pos"], cfg["conv_pos_groups"]),
+            _SamePad(cfg["conv_pos"]),
+            nn.GELU(),
+        )
+        self.layers = nn.ModuleList(
+            [
+                _EncoderLayer(
+                    embedding_dim=embed_dim,
+                    ffn_embedding_dim=cfg["encoder_ffn_embed_dim"],
+                    num_attention_heads=cfg["encoder_attention_heads"],
+                    dropout=self.dropout,
+                    attention_dropout=cfg["attention_dropout"],
+                    activation_dropout=cfg["activation_dropout"],
+                    has_relative_attention_bias=cfg["relative_position_embedding"],
+                    num_buckets=cfg["num_buckets"],
+                    max_distance=cfg["max_distance"],
+                    encoder_layers=layers,
+                )
+                for _ in range(layers)
+            ]
+        )
+        if cfg["relative_position_embedding"]:
+            # Tie every layer's table to layer 0's, as upstream does. Only
+            # layer 0 actually evaluates it (the bias is computed once and
+            # passed up the stack), but the tie is what makes the checkpoint's
+            # twelve identical copies load.
+            for i in range(1, layers):
+                self.layers[i].self_attn.relative_attention_bias = self.layers[0].self_attn.relative_attention_bias
+        self.layer_norm = nn.LayerNorm(embed_dim)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = x + self.pos_conv(x.transpose(1, 2)).transpose(1, 2)
+        # layer_norm_first is False for every released BEATs config, so the
+        # norm sits before the stack and there is none after it.
+        x = self.layer_norm(x)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+
+        x = x.transpose(0, 1)  # B x T x C -> T x B x C
+        pos_bias = None
+        for layer in self.layers:
+            x, pos_bias = layer(x, pos_bias)
+        return x.transpose(0, 1)
+
+
+class BEATs(nn.Module):
+    """The self-supervised BEATs encoder, from fbank patches to token features.
+
+    Instantiate from the ``cfg`` dict stored alongside the weights in the
+    released ``.pt`` file, then load ``checkpoint["model"]`` into it.
+    """
+
+    def __init__(self, cfg: dict) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.embed = cfg["embed_dim"]
+        patch = cfg["input_patch_size"]
+        self.patch_embedding = nn.Conv2d(1, self.embed, kernel_size=patch, stride=patch, bias=cfg["conv_bias"])
+        self.layer_norm = nn.LayerNorm(self.embed)
+        self.post_extract_proj = (
+            nn.Linear(self.embed, cfg["encoder_embed_dim"]) if self.embed != cfg["encoder_embed_dim"] else None
+        )
+        self.dropout_input = nn.Dropout(cfg["dropout_input"])
+        self.encoder = _TransformerEncoder(cfg)
+
+    def preprocess(self, waveform: Tensor, fbank_mean: float, fbank_std: float) -> Tensor:
+        """Waveform in ``[-1, 1]`` -> normalised fbank of shape ``(T, 128)``."""
+        fbank = kaldi_fbank(waveform * 2**15, num_mel_bins=128, sample_frequency=16000)
+        return (fbank - fbank_mean) / (2 * fbank_std)
+
+    def extract_features(self, waveform: Tensor, fbank_mean: float, fbank_std: float) -> Tensor:
+        """Embed a single mono waveform into ``(1, num_tokens, encoder_embed_dim)``."""
+        fbank = self.preprocess(waveform, fbank_mean, fbank_std).unsqueeze(0).unsqueeze(1)
+        features = self.patch_embedding(fbank)
+        features = features.reshape(features.shape[0], features.shape[1], -1).transpose(1, 2)
+        features = self.layer_norm(features)
+        if self.post_extract_proj is not None:
+            features = self.post_extract_proj(features)
+        return self.encoder(self.dropout_input(features))

--- a/vtscore/media/audio/_beats_model.py
+++ b/vtscore/media/audio/_beats_model.py
@@ -222,6 +222,7 @@ class _MultiheadAttention(nn.Module):
         has_relative_attention_bias: bool,
         num_buckets: int,
         max_distance: int,
+        gru_rel_pos: bool,
     ) -> None:
         super().__init__()
         self.embed_dim = embed_dim
@@ -231,6 +232,7 @@ class _MultiheadAttention(nn.Module):
         self.has_relative_attention_bias = has_relative_attention_bias
         self.num_buckets = num_buckets
         self.max_distance = max_distance
+        self.gru_rel_pos = gru_rel_pos
 
         if has_relative_attention_bias:
             self.relative_attention_bias = nn.Embedding(num_buckets, num_heads)
@@ -240,8 +242,11 @@ class _MultiheadAttention(nn.Module):
         self.q_proj = nn.Linear(embed_dim, embed_dim)
         self.out_proj = nn.Linear(embed_dim, embed_dim)
 
-        self.grep_linear = nn.Linear(self.head_dim, 8)
-        self.grep_a = nn.Parameter(torch.ones(1, num_heads, 1, 1))
+        # The gate exists only when the config asks for it — otherwise the raw
+        # bias is used directly and the checkpoint carries no gate tensors.
+        if gru_rel_pos:
+            self.grep_linear = nn.Linear(self.head_dim, 8)
+            self.grep_a = nn.Parameter(torch.ones(1, num_heads, 1, 1))
 
     def _relative_positions_bucket(self, relative_positions: Tensor) -> Tensor:
         """T5-style bidirectional bucketing: exact when near, log-spaced when far."""
@@ -276,14 +281,16 @@ class _MultiheadAttention(nn.Module):
 
         attn_mask = None
         if position_bias is not None:
-            # Gate the shared bias on this layer's queries.
-            query_layer = x.transpose(0, 1).view(bsz, tgt_len, self.num_heads, -1).transpose(1, 2)
-            _b, _h, _l, _ = query_layer.size()
-            gate_a, gate_b = torch.sigmoid(
-                self.grep_linear(query_layer).view(_b, _h, _l, 2, 4).sum(-1, keepdim=False)
-            ).chunk(2, dim=-1)
-            gate = gate_a * (gate_b * self.grep_a - 1.0) + 2.0
-            attn_mask = gate.view(bsz * self.num_heads, tgt_len, 1) * position_bias
+            attn_mask = position_bias
+            if self.gru_rel_pos:
+                # Gate the shared bias on this layer's own queries.
+                query_layer = x.transpose(0, 1).view(bsz, tgt_len, self.num_heads, -1).transpose(1, 2)
+                _b, _h, _l, _ = query_layer.size()
+                gate_a, gate_b = torch.sigmoid(
+                    self.grep_linear(query_layer).view(_b, _h, _l, 2, 4).sum(-1, keepdim=False)
+                ).chunk(2, dim=-1)
+                gate = gate_a * (gate_b * self.grep_a - 1.0) + 2.0
+                attn_mask = gate.view(bsz * self.num_heads, tgt_len, 1) * position_bias
             attn_mask = attn_mask.view((-1, tgt_len, tgt_len))
 
         out, _ = F.multi_head_attention_forward(
@@ -325,6 +332,8 @@ class _EncoderLayer(nn.Module):
         has_relative_attention_bias: bool,
         num_buckets: int,
         max_distance: int,
+        gru_rel_pos: bool,
+        deep_norm: bool,
         encoder_layers: int,
     ) -> None:
         super().__init__()
@@ -335,6 +344,7 @@ class _EncoderLayer(nn.Module):
             has_relative_attention_bias=has_relative_attention_bias,
             num_buckets=num_buckets,
             max_distance=max_distance,
+            gru_rel_pos=gru_rel_pos,
         )
         self.dropout1 = nn.Dropout(dropout)
         self.dropout2 = nn.Dropout(activation_dropout)
@@ -343,7 +353,7 @@ class _EncoderLayer(nn.Module):
         self.fc1 = nn.Linear(embedding_dim, ffn_embedding_dim)
         self.fc2 = nn.Linear(ffn_embedding_dim, embedding_dim)
         self.final_layer_norm = nn.LayerNorm(embedding_dim)
-        self.deep_norm_alpha = math.pow(2 * encoder_layers, 1 / 4)
+        self.deep_norm_alpha = math.pow(2 * encoder_layers, 1 / 4) if deep_norm else 1.0
 
     def forward(self, x: Tensor, pos_bias: Optional[Tensor]) -> tuple[Tensor, Optional[Tensor]]:
         residual = x
@@ -368,6 +378,12 @@ class _TransformerEncoder(nn.Module):
         embed_dim = cfg["encoder_embed_dim"]
         layers = cfg["encoder_layers"]
         self.dropout = cfg["dropout"]
+        # Every released BEATs checkpoint is post-LN (``deep_norm`` and
+        # ``layer_norm_first`` are mutually exclusive upstream, and all of them
+        # pick deep_norm). Only the post-LN path is ported, so refuse a pre-LN
+        # config rather than silently producing features from the wrong graph.
+        if cfg.get("layer_norm_first"):
+            raise ValueError("layer_norm_first=True (pre-LN) BEATs configs are not supported")
         self.pos_conv = nn.Sequential(
             _WeightNormConv1d(embed_dim, cfg["conv_pos"], cfg["conv_pos_groups"]),
             _SamePad(cfg["conv_pos"]),
@@ -385,6 +401,8 @@ class _TransformerEncoder(nn.Module):
                     has_relative_attention_bias=cfg["relative_position_embedding"],
                     num_buckets=cfg["num_buckets"],
                     max_distance=cfg["max_distance"],
+                    gru_rel_pos=cfg["gru_rel_pos"],
+                    deep_norm=cfg["deep_norm"],
                     encoder_layers=layers,
                 )
                 for _ in range(layers)

--- a/vtscore/media/audio/embedder_beats.py
+++ b/vtscore/media/audio/embedder_beats.py
@@ -124,7 +124,7 @@ class AudioBEATsEmbedder(MediaEmbedder):
         # weights, so the encoder is built from the checkpoint's own ``cfg``
         # rather than from constants that could drift away from it.
         self._on_progress("loading", "Building BEATs encoder…", 0, 0)
-        checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+        checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
         model = BEATs(checkpoint["cfg"])
         model.load_state_dict(checkpoint["model"], strict=True)
         self._model = to_compute_device(model)

--- a/vtscore/media/audio/embedder_beats.py
+++ b/vtscore/media/audio/embedder_beats.py
@@ -8,13 +8,22 @@ Like :mod:`~vtscore.media.audio.embedder_ast` it has no paired text tower, so
 for datasets embedded with it; it is an option for collections searched by
 voted examples, not by a typed query.
 
-It is not a drop-in upgrade over the default ``clap``.  On the ESC-50 arm of
-:mod:`vtscore.eval` its learned-sort scores land in the same band as the CLAP
-embedders rather than above them, and unlike them it cannot answer a text
-query at all.  Its appeal is the different inductive bias: AST's features are
-shaped by its 527-label AudioSet head and CLAP's by text alignment, while
-BEATs' are shaped by neither, so it is worth trying on collections whose
-categories sit outside both.
+It is not a drop-in upgrade over the default ``clap`` - on ESC-50 it is the
+weakest of the four audio embedders measured.  Leave-one-out 1-NN accuracy
+over all 50 classes: ``clap_general`` 0.973, ``clap`` 0.958, ``ast`` 0.940,
+``beats`` 0.905; on the learned-sort arm of :mod:`vtscore.eval` it lands in
+the same band as the CLAP embedders rather than above them, and unlike them it
+cannot answer a text query at all.  The headline BEATs results in the
+literature are for *fine-tuned* models; what we use here is the frozen encoder
+mean-pooled over its patch tokens, which is a different and weaker setting.
+
+Its appeal is the different inductive bias, not raw ESC-50 quality: AST's
+features are shaped by its 527-label AudioSet head and CLAP's by text
+alignment, while BEATs' come from masked prediction over acoustic tokens and
+are shaped by neither.  That makes it worth trying on collections whose
+categories sit outside both - but ESC-50 is not such a collection, so treat
+these numbers as the expected-case baseline rather than a reason to reach for
+it by default.
 
 There is no ``transformers`` implementation, so the architecture is vendored
 in :mod:`vtscore.media.audio._beats_model` and the released checkpoint is

--- a/vtscore/media/audio/embedder_beats.py
+++ b/vtscore/media/audio/embedder_beats.py
@@ -1,19 +1,20 @@
 """Audio embedder - BEATs (self-supervised audio-event encoder).
 
 BEATs ("Audio Pre-Training with Acoustic Tokenizers", Chen et al. 2022) is
-Microsoft's iterative self-supervised audio encoder and the long-standing
-state of the art on AudioSet tagging.  It is the strongest *audio-only*
-representation VTSearch ships: like :mod:`~vtscore.media.audio.embedder_ast`
-it has no paired text tower, so :attr:`supports_text` is ``False`` and the UI
-hides text-search affordances for datasets embedded with it - but where AST is
-a supervised AudioSet classifier whose features are shaped by its 527-label
-head, BEATs' features come from masked-prediction pre-training over acoustic
-tokens, which transfers noticeably better to categories the label set never
-covered.
+Microsoft's iterative self-supervised audio encoder, trained by masked
+prediction over learned acoustic tokens rather than by supervised tagging.
+Like :mod:`~vtscore.media.audio.embedder_ast` it has no paired text tower, so
+:attr:`supports_text` is ``False`` and the UI hides text-search affordances
+for datasets embedded with it; it is an option for collections searched by
+voted examples, not by a typed query.
 
-Reach for it over ``clap`` when the search is driven by voted examples rather
-than a text query, and over ``ast`` whenever quality matters more than the
-extra ~90M-parameter forward pass.
+It is not a drop-in upgrade over the default ``clap``.  On the ESC-50 arm of
+:mod:`vtscore.eval` its learned-sort scores land in the same band as the CLAP
+embedders rather than above them, and unlike them it cannot answer a text
+query at all.  Its appeal is the different inductive bias: AST's features are
+shaped by its 527-label AudioSet head and CLAP's by text alignment, while
+BEATs' are shaped by neither, so it is worth trying on collections whose
+categories sit outside both.
 
 There is no ``transformers`` implementation, so the architecture is vendored
 in :mod:`vtscore.media.audio._beats_model` and the released checkpoint is

--- a/vtscore/media/audio/embedder_beats.py
+++ b/vtscore/media/audio/embedder_beats.py
@@ -1,0 +1,205 @@
+"""Audio embedder - BEATs (self-supervised audio-event encoder).
+
+BEATs ("Audio Pre-Training with Acoustic Tokenizers", Chen et al. 2022) is
+Microsoft's iterative self-supervised audio encoder and the long-standing
+state of the art on AudioSet tagging.  It is the strongest *audio-only*
+representation VTSearch ships: like :mod:`~vtscore.media.audio.embedder_ast`
+it has no paired text tower, so :attr:`supports_text` is ``False`` and the UI
+hides text-search affordances for datasets embedded with it - but where AST is
+a supervised AudioSet classifier whose features are shaped by its 527-label
+head, BEATs' features come from masked-prediction pre-training over acoustic
+tokens, which transfers noticeably better to categories the label set never
+covered.
+
+Reach for it over ``clap`` when the search is driven by voted examples rather
+than a text query, and over ``ast`` whenever quality matters more than the
+extra ~90M-parameter forward pass.
+
+There is no ``transformers`` implementation, so the architecture is vendored
+in :mod:`vtscore.media.audio._beats_model` and the released checkpoint is
+overlaid onto it.  Both the code and the weights are MIT-licensed, so there is
+no :attr:`license_notice`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from vtscore.config import (
+    BEATS_CHECKPOINT_FILE,
+    BEATS_CHECKPOINT_REPO,
+    BEATS_FBANK_MEAN,
+    BEATS_FBANK_STD,
+    BEATS_MAX_SAMPLES,
+    BEATS_MIN_SAMPLES,
+    BEATS_SAMPLE_RATE,
+)
+from vtscore.media.embedder import (
+    IMPORT_MODULE_ESTIMATES,
+    MediaEmbedder,
+    embedder_load_setup,
+    hf_token,
+    intercept_tqdm_progress,
+    load_pretrained_local_first,
+    timed_progress,
+    to_compute_device,
+)
+
+
+class AudioBEATsEmbedder(MediaEmbedder):
+    """Embeds audio files using the BEATs iter3+ AudioSet-2M encoder.
+
+    * Audio files → 768-dimensional vectors, mean-pooled over the encoder's
+      patch tokens.
+    * No text encoder; :meth:`embed_text` returns ``None``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Typed ``Any``: the vendored ``BEATs`` module has no stubs, and the
+        # runtime ``None`` checks below guard every call.
+        self._model: Any = None
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "beats"
+
+    @property
+    def display_name(self) -> str:
+        return "BEATs (audio events)"
+
+    @property
+    def model_id(self) -> str:
+        return BEATS_CHECKPOINT_REPO
+
+    @property
+    def media_type_id(self) -> str:
+        return "audio"
+
+    @property
+    def supports_text(self) -> bool:
+        return False
+
+    # ------------------------------------------------------------------
+    # Model lifecycle
+    # ------------------------------------------------------------------
+
+    def _load_models_impl(self) -> None:
+        if self._model is not None:
+            return
+
+        with timed_progress(
+            self._on_progress, "loading", "Importing torch…", est_modules=IMPORT_MODULE_ESTIMATES["torch"]
+        ):
+            import torch  # noqa: PLC0415
+
+        with timed_progress(
+            self._on_progress, "loading", "Importing soundfile…", est_modules=IMPORT_MODULE_ESTIMATES["soundfile"]
+        ):
+            import soundfile  # noqa: F401, PLC0415
+
+        from huggingface_hub import hf_hub_download  # noqa: PLC0415
+
+        from vtscore.media.audio._beats_model import BEATs  # noqa: PLC0415
+
+        cache_dir = embedder_load_setup(self._on_progress, "Loading BEATs checkpoint…")
+        with intercept_tqdm_progress(self._on_progress):
+            checkpoint_path = load_pretrained_local_first(
+                hf_hub_download,
+                repo_id=BEATS_CHECKPOINT_REPO,
+                filename=BEATS_CHECKPOINT_FILE,
+                cache_dir=cache_dir,
+                token=hf_token(),
+            )
+
+        # The released ``.pt`` carries the architecture config alongside the
+        # weights, so the encoder is built from the checkpoint's own ``cfg``
+        # rather than from constants that could drift away from it.
+        self._on_progress("loading", "Building BEATs encoder…", 0, 0)
+        checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+        model = BEATs(checkpoint["cfg"])
+        model.load_state_dict(checkpoint["model"], strict=True)
+        self._model = to_compute_device(model)
+        self._model.eval()
+
+        # Warmup: resampling JIT + one dummy forward, so the first real
+        # embed_media call runs at steady-state speed instead of appearing to
+        # stall the progress bar.
+        self._on_progress("loading", "Warming up BEATs: resampling JIT…", 1, 2)
+        import io  # noqa: PLC0415
+
+        import soundfile as sf  # noqa: PLC0415
+
+        from vtscore.media.audio.decode import decode_audio  # noqa: PLC0415
+
+        _warmup_sr = 22050  # intentionally different from BEATS_SAMPLE_RATE
+        _warmup_buf = io.BytesIO()
+        sf.write(_warmup_buf, np.zeros(_warmup_sr, dtype=np.float32), _warmup_sr, format="WAV")
+        _warmup_buf.seek(0)
+        decode_audio(_warmup_buf, sr=BEATS_SAMPLE_RATE, mono=True)
+
+        self._on_progress("loading", "Warming up BEATs: running model…", 2, 2)
+        dummy = torch.zeros(BEATS_SAMPLE_RATE, device=next(self._model.parameters()).device)
+        with torch.no_grad():
+            self._model.extract_features(dummy, BEATS_FBANK_MEAN, BEATS_FBANK_STD)
+
+    # ------------------------------------------------------------------
+    # Embedding
+    # ------------------------------------------------------------------
+
+    def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
+        if self._model is None:
+            self.load_models()
+        if self._model is None:
+            return None
+        # Prefer in-memory bytes (set by clip re-embed) over a disk path so the
+        # caller does not need to round-trip through a tempfile.
+        audio_bytes = media.get("media_bytes")
+        file_path: Optional[Path] = None
+        if not isinstance(audio_bytes, (bytes, bytearray)) or not audio_bytes:
+            audio_bytes = None
+            path_str = media.get("media_path")
+            if not path_str:
+                return None
+            file_path = Path(path_str)
+        source_repr = file_path if file_path is not None else "<bytes>"
+        try:
+            import torch  # noqa: PLC0415
+
+            from vtscore.media.audio.decode import decode_audio  # noqa: PLC0415
+
+            if audio_bytes is not None:
+                source: bytes | Path = bytes(audio_bytes)
+            else:
+                assert file_path is not None  # narrowed by the path_str check above
+                source = file_path
+            audio_data, _sr = decode_audio(source, sr=BEATS_SAMPLE_RATE, mono=True)
+            # Deterministic leading window, mirroring the CLAP embedders: a
+            # random crop would break the origin -> embedding rederivation
+            # contract that the no-persisted-vectors design relies on.
+            if audio_data.shape[0] > BEATS_MAX_SAMPLES:
+                audio_data = audio_data[:BEATS_MAX_SAMPLES]
+            # A clip shorter than one 16-frame patch row yields zero tokens, so
+            # pad up to a floor rather than failing on very short media.
+            if audio_data.shape[0] < BEATS_MIN_SAMPLES:
+                audio_data = np.pad(audio_data, (0, BEATS_MIN_SAMPLES - audio_data.shape[0]))
+            device = next(self._model.parameters()).device
+            waveform = torch.from_numpy(np.ascontiguousarray(audio_data, dtype=np.float32)).to(device)
+            with torch.no_grad():
+                features = self._model.extract_features(waveform, BEATS_FBANK_MEAN, BEATS_FBANK_STD)
+                embedding = features.mean(dim=1).detach().cpu().numpy()
+            return embedding[0]
+        except Exception:
+            logging.getLogger(__name__).exception("Error embedding %s", source_repr)
+            return None
+
+
+EMBEDDER = AudioBEATsEmbedder()


### PR DESCRIPTION
Adds `beats` as a new audio embedder, and fixes an eval-harness bug found while measuring `clap` against `clap_general`.

## `beats` — BEATs iter3+ AudioSet-2M

Microsoft's self-supervised audio encoder, as a 768-d audio-only embedder (`supports_text=False`, so text search stays hidden for datasets bound to it). Opt-in, not the default.

There is no `transformers` implementation, so the architecture is vendored in `vtscore/media/audio/_beats_model.py` — the same shape as the existing `_paraspeechclap_model.py` — and the released MIT-licensed checkpoint is loaded onto it with `strict=True` (90,311,792 params). Three details the weights depend on:

- **DeepNorm** residual scaling with post-layer-norm ordering.
- A **gated relative position bias**, computed once in layer 0 and shared up the stack, gated per layer from that layer's own queries. The checkpoint carries twelve byte-identical copies of the table because upstream ties rather than deduplicates them; the tie is reproduced so a strict load works.
- A **weight-normalised convolutional position embedding** stored as `weight_g`/`weight_v`, reparameterised by hand because `nn.utils.weight_norm` is deprecated and its replacement renames the keys.

All three are read from the `cfg` the checkpoint ships rather than hardcoded, and the unported pre-LN path raises instead of silently computing from the wrong graph.

### The fbank front-end

BEATs consumes Kaldi `compute-fbank-feats` features, which upstream gets from torchaudio. torchaudio is not viable here — its wheels are built against a pinned torch, and the current one is CUDA-linked and fails to load against this CPU torch. So the fbank is ported from torchaudio's own pure-PyTorch implementation, specialised to BEATs' settings.

The port was checked against torchaudio and agrees **bit-for-bit** at every signal length tried. Tests pin values captured from that verified run, plus a tone-localisation property (a pure tone must peak in the mel bin covering its frequency) that ties the mel scale, FFT and filterbank together independently of the goldens.

### How good is it

Not a drop-in upgrade, and the docstring says so. Leave-one-out 1-NN over all 50 ESC-50 classes (400 clips):

| embedder | dim | 1-NN acc |
|---|---|---|
| `clap_general` | 512 | 0.973 |
| `clap` | 512 | 0.958 |
| `ast` | 768 | 0.940 |
| `beats` | 768 | 0.905 |

The headline BEATs results in the literature are for *fine-tuned* models; this is the frozen encoder mean-pooled over its patch tokens, a weaker setting. Its case is the different inductive bias — neither a supervised label head like AST nor text alignment like CLAP — not ESC-50 quality.

## Eval fix: text queries were scored in the wrong vector space

`vtscore/eval/runner.py` called `embed_text_query(text, media_type)` with no `embedder_name`, so it always resolved to the media type's **default** embedder — while the medias carried vectors from whatever `--embedder` the run asked for. Cosine between two unrelated 512-d spaces is noise, so every non-default text-sort arm reported near-chance mAP that looked like a real measurement.

On the full ESC-50 this made `clap_general` report mAP 0.047–0.065 against `clap`'s 0.850–0.866, which reads as a broken text tower. It is not: checked directly against HuggingFace, `clap`, `clap_general` and `clap_music` each score 24/24 on a 4-way text→audio retrieval probe, via both VTSearch's embedding path and `ClapModel`'s own forward.

The app was already correct (`vtsearch/routes/sorting.py` passes the dataset's bound embedder), as was `vtscore/eval/seed_scores.py`; only this one call site diverged — exactly the drift the "eval default arm IS the app" rule exists to catch. The name is now resolved off the loaded medias rather than the flag, since the flag is empty for a default-embedder run while the medias always name the embedder that produced them.

With the fix, `clap_general` beats `clap` on every slice and both axes:

| | esc50_s | esc50_m | esc50_l |
|---|---|---|---|
| `clap` text mAP | 0.8634 | 0.8503 | 0.8661 |
| `clap_general` text mAP | **0.8950** | **0.8691** | **0.8842** |
| `clap` learned F1 | 0.5285 | 0.4572 | 0.5122 |
| `clap_general` learned F1 | **0.5641** | **0.5384** | **0.5230** |

That answers the question this branch started from, but changes no defaults — the consolidation decision is left open deliberately, and is filed as #3077.

Also worth noting for a future look: description enrichment **helps** `clap_general` (+0.012–0.016 mAP) and **hurts** `clap` (−0.005–0.014), and it is a single global setting.

## Testing

Rebased onto `dev` (currently `9043486e`); `./run-tests.sh` re-run after the rebase → **ALL 8245 TESTS PASSED** (8 skipped, of 8253).

28 new BEATs tests cover the fbank (framing, goldens, tone localisation, determinism), the vendored encoder (tied position-bias tables, state-dict layout, DeepNorm alpha, refused pre-LN configs, weight-norm reparameterisation) and the embedder's audio handling (truncation, padding, mean-pooling, error paths). Two regression tests cover the eval fix.

### Note on the rebase

Three conflicts against the newer `dev`, worth recording because one was silent:

- `vtscore/docs/packages/media.md` — `dev` added `siglip2_l`/`siglip_l` to the image row, this branch added `beats` to the audio row; took both.
- `docs/plans/progress-weight-calibration.md` — deleted on `dev` by the shipped-plans sweep (ce4ffd6c). This branch's only edit was a pointer line into it, so the deletion was accepted and that commit dropped. #3062 carries the work, and its body now points at `scripts/profiling/README.md`, where the runbook moved.
- `tests_lib/detectors/test_new_embedders.py` — **`dev` and this branch both bumped the embedder count 23→24**, for SigLIP2-L and BEATs respectively. Identical text on both sides, so git auto-merged the assertion to 24 with no conflict; only the adjacent comment conflicted. The real total with both is 25, confirmed by enumerating the registry rather than by arithmetic. Without the comment conflict this would have merged clean and failed the suite.

## Follow-ups

- #3077 — make `clap_general` the default and disambiguate the CLAP display names, with the measurements above as the evidence.
- #3062 — `beats` has no calibrated load-cost row; it falls back to the static audio profile. Needs the calibration host.
- #3075 — `test_stream_yields_update_after_subscribe` is flaky when a memory-heavy process shares the machine. Pre-existing, unrelated to this change; passes 8/8 alone and in clean full runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BUpKCd8SvefzccRZhQfir