### PR TITLE
Re-derive CLAUDE.md's operational reference from run-tests.sh

### DIFF
--- a/.claude/scripts/style-check.py
+++ b/.claude/scripts/style-check.py
@@ -249,7 +249,7 @@ def check_raw_zindex(files: list[Path]) -> Finding:
 
 
 # ---------------------------------------------------------------------------
-# §1.9 Raw decorative-dim opacity (should be var(--opacity-dim))
+# §1.10 Raw decorative-dim opacity (should be var(--opacity-dim))
 # ---------------------------------------------------------------------------
 # The canonical decorative-dim value. A raw `opacity: 0.7` on a decorative or
 # secondary element (dimmed icon, chevron, accent divider, hint/note text,
@@ -262,7 +262,7 @@ RAW_OPACITY_RE = re.compile(r"\bopacity\s*:\s*(0?\.\d+|1(?:\.0+)?|0)\b")
 
 def check_raw_dim_opacity(files: list[Path]) -> Finding:
     f = Finding(
-        rule="§1.9 Raw decorative-dim opacity",
+        rule="§1.10 Raw decorative-dim opacity",
         description=(
             f"A raw `opacity: {DIM_OPACITY_VALUE}` on a decorative/secondary "
             "element should use var(--opacity-dim). Legitimate exceptions: "

--- a/.claude/skills/style-check/SKILL.md
+++ b/.claude/skills/style-check/SKILL.md
@@ -33,6 +33,9 @@ your job is to review them and decide which to fix.
 | §4.6   | `font-weight: 700` / `bold` | Regex |
 | §4.7   | Heading tags (`h1`–`h6`) restyled in component SCSS | Top-level `hN {` rule blocks |
 | §4.10  | `transition: all <custom-duration>` | Regex, ignores tokenised durations |
+| §1.8   | Raw `z-index` integers that bypass the `--z-*` scale | Regex, skips lines already resolving through a `var(--…)` |
+| §1.10  | Raw `opacity: 0.7` where `var(--opacity-dim)` is the token | Regex on the canonical dim value only |
+| Bespoke accent tint | Hand-rolled `color-mix(in srgb, var(--accent) N%, transparent)` instead of `--accent-highlight-bg` | Regex on the bare `var(--accent)` form, so the fallback-carrying decorative tint isn't flagged |
 | §4.13  | `font: inherit` inside component SCSS (specificity trap) | Regex |
 | §4.14  | `flex-direction: column` blocks without an explicit `gap` | Brace-depth aware SCSS parser |
 | §4.15  | Shared utility classes redeclared locally | Top-level `.{class} {` outside shared files |
@@ -57,6 +60,15 @@ patterns alongside real bugs. Apply judgement before fixing:
   the redeclared `.info-text`/`.error-text` blocks across modals are
   near-identical copies. Worth consolidating, but a bulk rewrite
   touches many components; consider doing it as its own PR.
+- **§1.10 raw `opacity: 0.7`** has legitimate hits: animation keyframes
+  that fade `0`↔`1`, hover-brighten rest states, and the two-tier
+  done/future progression dims all carry their own values. Flag it when
+  the element is decorative or secondary *at rest*.
+- **§1.8 raw `z-index`** and the **bespoke accent tint** are, like the
+  two token-resolution checks, close to objective - both have a single
+  canonical token (`--z-*`, `--accent-highlight-bg`) and a hit means the
+  component reinvented it. Adding a new layer means adding a `--z-*`
+  token to `_variables.scss`, not a bare integer.
 - **§4.1-2 raw `px`/`rem`** is sometimes a deliberate off-scale value
   with an inline comment justifying it (e.g.
   `padding: var(--space-xs) 0.625rem; // 10px - off-scale horizontal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ This rule has **no exceptions for "quick" yes/no follow-ups.** Yes/no offers bel
 
 ## Branch Policy (CRITICAL)
 
-- **Always base work on `dev`.** The `.claude/hooks/session-start.sh` SessionStart hook runs `git fetch origin --prune && git rebase origin/dev` automatically in remote sessions, so a fresh container lands rebased onto `dev`. If the hook reports "skipping" (dirty tree, detached HEAD) or "rebase failed", run the fetch+rebase yourself before making any changes. The harness cuts the working branch off `main` (the GitHub default), so this rebase is required to pick up work already merged to `dev`. The GitHub default stays `main` so new users land on the stable branch: `dev` is Claude's starting point, not the public default.
+- **Always base work on `dev`.** The `.claude/hooks/session-start.sh` SessionStart hook fetches `origin --prune` and then lands the working branch on `origin/dev` automatically in remote sessions. The harness cuts the working branch off `main` (the GitHub default), so this is required to pick up work already merged to `dev`. The GitHub default stays `main` so new users land on the stable branch: `dev` is Claude's starting point, not the public default.
+  - **The hook can *hard-reset*, not only rebase — read its output.** It picks one of four outcomes and says which: `already includes origin/dev; nothing to do`; **hard-reset** to `origin/dev` (either because the branch has no `origin/<branch>` counterpart — a fresh branch the harness just cut off `main`, whose unique commits are all inherited `main`-only history carrying no Claude work — or because `git cherry` shows every unique commit is patch-equivalent to one already on `dev`); **rebase** onto `origin/dev` (the branch is in sync with its origin counterpart and carries genuinely new pushed commits); or a **skip**. A hard-reset discards the branch's prior commits by design; that is expected at session start and nothing of yours is lost, but do not assume commits you saw in `git log` before the hook ran are still there.
+  - If the hook prints `‼ session-start: DID NOT rebase onto origin/dev` (dirty tree, detached HEAD, fetch failed, a reset/rebase that failed, or a local branch that differs from its pushed origin counterpart), run `git fetch origin --prune && git rebase origin/dev` yourself before making any changes.
 - **All pull requests MUST target `dev`**, never `main`.
 - **Claude must NEVER open a PR that merges into `main`.** The `main` branch is protected and only updated by human maintainers.
 - When creating a PR, always use `--base dev` (e.g., `gh pr create --base dev ...` or the equivalent MCP tool parameter).
@@ -216,16 +218,17 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 
 ## Commands
 
-- **Run tests (CPU, fast)**: `./run-tests.sh` (also runs `ruff check`, `ruff format --check`, `codespell`, `deptry`, and the frontend TypeScript build)
-- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; every invocation runs ruff/codespell/deptry first; `core` additionally runs the frontend build check)
+- **Run tests (CPU, fast)**: `./run-tests.sh` (runs every gate listed under "What `run-tests.sh` gates" below, then pytest)
+- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; **every** invocation runs the full non-pytest gate chain first, so a group run is not a way to skip the linters; `core` and `frontend` additionally run the frontend build + `npm audit`, and `frontend` alone also runs the Vitest unit suite)
 - **Run tests with coverage**: `VTSEARCH_COVERAGE=1 ./run-tests.sh` (opt-in; adds ~10-20% overhead)
 - **Run multiple groups**: `./run-tests.sh core sorting api`
 - **Run tests with extra args**: `./run-tests.sh core -- -x --tb=long` (args after `--` go to pytest)
-- **Run library-tier tests only (Flask-blocked)**: `./run-tests.sh vtscore-clean` (runs `tests_lib/` via a meta-path import hook that refuses `flask`, `werkzeug`, `flask_smorest`; proves the library tier is import-clean)
+- **Run library-tier tests only (Flask-blocked)**: `./run-tests.sh vtscore-clean` (runs `tests_lib/` via a meta-path import hook that refuses `flask`, `werkzeug`, `flask_smorest`; proves the library tier is import-clean. This mode `exec`s straight into the checker, so it deliberately skips the linter and frontend gates)
 - **Run tests (CPU, full)**: `bash .claude/hooks/ensure-test-deps.sh && python -m pytest tests/ tests_lib/ -q --tb=short -m 'not gpu'`
-- **Run slow CLI subprocess tests only**: `python -m pytest tests/ -q --tb=short -m slow`
+- **Run slow tests only**: `python -m pytest tests/ tests_lib/ -q --tb=short -m slow` (both trees — the slow tests do not all live under `tests/`; see Test Markers)
 - **Run GPU tests**: `python -m pytest tests_lib/gpu/test_gpu.py -q --tb=short -m gpu` (requires CUDA GPU; downloads models on first run)
 - **Run all tests (CPU + GPU)**: `python -m pytest tests/ tests_lib/ -q --tb=short -m ''`
+- **Regenerate the OpenAPI snapshot** (after any route/schema change, to clear the drift gate): `cd frontend && npm run regenerate-openapi-snapshot` (equivalently `python scripts/dump_openapi.py > frontend/openapi.json`), then commit `frontend/openapi.json`
 - **Start app**: `bash .claude/hooks/ensure-test-deps.sh && python app.py` (or `python app.py --local` for dev)
 - **CLI autodetect**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json>`
 - **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter server_json_file --filepath results.json`
@@ -241,6 +244,29 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 - **Spell check**: `codespell --toml pyproject.toml`
 - **Dependency check**: `python -m deptry .`
 - **Dead code audit** (manual, pre-release): see `.vulture-whitelist.py` for the full invocation (60% confidence, with marshmallow/pydantic field directories excluded and pytest/Flask/dunder noise filtered). Run before each release; not a CI gate.
+
+## What `run-tests.sh` gates
+
+There is no CI: `./run-tests.sh` is the only gate, so it front-loads a long chain of checks and stops at the first failure with a `TESTS BLOCKED: ...` banner naming which one. **This list is derived from `run-tests.sh`; when you add or remove a gate there, update it here in the same commit.** In script order:
+
+| # | Gate | Command it runs | Notes |
+|---|------|-----------------|-------|
+| 0 | Wall-clock cap | re-`exec`s itself under `timeout` | `VTSEARCH_TEST_TIMEOUT` (default **1800s = 30 min**) bounds the *whole* run, every stage included. `VTSEARCH_TEST_TIMEOUT=0` opts out for a deliberately long run (GPU, coverage sweep). |
+| 1 | Dep install | `.claude/hooks/ensure-test-deps.sh` | ~1-2 min on a cold container, near-instant after. |
+| 2 | Lint | `ruff check .` | |
+| 3 | Format | `ruff format --check .` | Fix with `ruff format .`. |
+| 4 | Spelling | `codespell --toml pyproject.toml` | |
+| 5 | Dependencies | `python -m deptry .` | |
+| 6 | Known CVEs | `pip-audit` | Audits the resolved venv, not the requirements files. `PIP_AUDIT_IGNORE` in the script lists advisories with no upstream fix; re-audit and remove an entry once a patched release exists. |
+| 7 | Types | `pyright` (pinned via `PYRIGHT_PYTHON_FORCE_VERSION`) | Scope is `pyrightconfig.json`. |
+| 8 | OpenAPI snapshot drift | `scripts/dump_openapi.py` diffed against `frontend/openapi.json` | The generated TS client is built from this snapshot. Regenerate with `npm run regenerate-openapi-snapshot` and commit the result. |
+| 9 | Dockerfiles | `scripts/check-dockerfiles.py` | |
+| 10 | User-docs screenshot wiring | `scripts/screenshots/wiring-check.py` | Browser-free; the pixel-diff (`check.sh`) stays a manual chore. Also what makes the reshoot queue un-rottable. |
+| 11 | Eval/app sync | `scripts/check-eval-app-sync.py` | Re-pin with `--update` **after** reconciling the harness. |
+| 12 | Frontend build | `cd frontend && npm run build:prod` | Full run, or the `core` / `frontend` groups. Any `▲ [WARNING]` line is a hard failure. Skipped with a notice if `frontend/node_modules` is absent. |
+| 13 | Frontend audit | `cd frontend && npm audit --omit=dev` | Same trigger as the build. Prod deps only — dev-only advisories don't ship. |
+| 14 | Frontend unit tests | `cd frontend && npm run test:ci` | Full run or the `frontend` group **only** — deliberately off the fast `core` path. |
+| 15 | Python tests | `pytest tests/ tests_lib/ -n auto --dist loadgroup` | Skipped entirely when `frontend` is the only requested group. |
 
 ## Test Groups
 
@@ -268,17 +294,23 @@ Tests are grouped by folder under `tests/` and `tests_lib/`. Each folder is a py
 
 ## Test Markers
 
-- **Default** (`./run-tests.sh` or `pytest tests/`): Runs fast CPU tests only (~35s). Excludes `gpu` and `slow` markers.
-- **`slow`**: CLI subprocess tests that spawn `python app.py --autodetect` (2 tests in `tests/cli/test_cli_main_subprocess.py`, each ~16s). Run with `-m slow` or include with `-m 'not gpu'`.
-- **`gpu`**: CUDA-only tests. Run with `-m gpu`.
-- **All tests**: Use `-m ''` to run everything.
+The default filter lives in `pyproject.toml`'s `addopts`: `-m 'not gpu and not slow' --timeout=300 --timeout-method=thread`.
+
+- **Default** (`./run-tests.sh` with no group, or a bare `pytest`): fast CPU tests only (~35s). Excludes `gpu` and `slow`.
+- **`slow`**: 3 tests, in **two** trees — one CLI subprocess test that spawns `python app.py --autodetect` (`tests/cli/test_cli_main_subprocess.py`, ~16s) and two real-`toponymy` fit tests (`tests_lib/projection/test_toponymy_smoke.py`, module-level `pytestmark`, ~1 min each; `importorskip`ped when toponymy isn't installed). Run with `python -m pytest tests/ tests_lib/ -m slow` — passing only `tests/` silently misses two thirds of them.
+- **`gpu`**: CUDA-only tests (`tests_lib/gpu/test_gpu.py`). Run with `-m gpu`.
+- **All tests**: `-m ''`.
+- **Per-test timeout**: 300s, thread-based (signal-based interruption doesn't work on xdist workers). One hung test fails by name instead of stalling the run; the wall-clock cap in `run-tests.sh` is the backstop for a worker that dies outright and can no longer fire its own timeout.
+
+**Gotcha: naming a group re-opens `slow` and `gpu`.** `./run-tests.sh <group>` passes `-m "<group>"` on the command line, and a command-line `-m` *replaces* the one in `addopts` rather than combining with it. So `./run-tests.sh cli` does run the slow subprocess test, and `./run-tests.sh projection` does run the toponymy smoke tests — a group run is slower than the same tests in a default run. That is also why `./run-tests.sh gpu` works at all. To get the default exclusions back inside a group, spell the filter out after `--` (a later `-m` wins): `./run-tests.sh cli -- -m 'cli and not slow'`.
 
 ## Test Workflow (IMPORTANT)
 
 Testing can crash the session. To avoid losing work, follow this workflow:
 
 1. **Commit and push before running tests.** Before running `pytest` or any test command, commit all current changes and push to your working branch. Use a message like `"WIP: pre-test checkpoint"` if the work isn't finalized yet.
-2. **Run tests in the foreground (never in the background).** The test command has a slow startup phase: `ensure-test-deps.sh` installs dependencies (~1-2 min on first run), then `conftest.py` imports `app.py` and generates test media/embeddings before any tests execute. There may be no output for 1-3 minutes; this is normal. Do NOT run tests with `run_in_background` or assume output capture is broken because of the delay. Use a timeout of at least 300000ms (5 minutes).
+2. **Run tests in the foreground (never in the background).** The test command has a slow startup phase: `ensure-test-deps.sh` installs dependencies (~1-2 min on first run), then `conftest.py` imports `app.py` and generates test media/embeddings before any tests execute. There may be no output for 1-3 minutes; this is normal. Do NOT run tests with `run_in_background` or assume output capture is broken because of the delay.
+   **Give a full `./run-tests.sh` the Bash tool's maximum timeout, `600000` ms (10 minutes).** A healthy full run is several minutes — cold dep install, then pyright and pip-audit, then the frontend build + `npm audit` + Vitest gate (~3 min on its own), and only then the ~35s pytest — so the old "at least 5 minutes" suggestion cut healthy runs off mid-gate and produced spurious timeouts. If 10 minutes is genuinely not enough, run one group at a time rather than backgrounding the run; a group run skips the frontend gate unless it is `core` or `frontend`. The script has its own 30-minute wall-clock cap and prints a distinctive `TESTS TIMED OUT` banner when *it* fires, which is how you tell a wedged run from a harness cut-off.
 3. **If tests fail and fixes are needed**, make the fixes, then commit and push again before re-running tests.
 4. **Repeat** until tests pass. Every cycle of fixes should be committed and pushed before the next test run.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ There is no CI: `./run-tests.sh` is the only gate, so it front-loads a long chai
 | # | Gate | Command it runs | Notes |
 |---|------|-----------------|-------|
 | 0 | Wall-clock cap | re-`exec`s itself under `timeout` | `VTSEARCH_TEST_TIMEOUT` (default **1800s = 30 min**) bounds the *whole* run, every stage included. `VTSEARCH_TEST_TIMEOUT=0` opts out for a deliberately long run (GPU, coverage sweep). |
-| 1 | Dep install | `.claude/hooks/ensure-test-deps.sh` | ~1-2 min on a cold container, near-instant after. |
+| 1 | Dep install | `.claude/hooks/ensure-test-deps.sh` | Minutes on a cold container, near-instant after. |
 | 2 | Lint | `ruff check .` | |
 | 3 | Format | `ruff format --check .` | Fix with `ruff format .`. |
 | 4 | Spelling | `codespell --toml pyproject.toml` | |
@@ -309,8 +309,13 @@ The default filter lives in `pyproject.toml`'s `addopts`: `-m 'not gpu and not s
 Testing can crash the session. To avoid losing work, follow this workflow:
 
 1. **Commit and push before running tests.** Before running `pytest` or any test command, commit all current changes and push to your working branch. Use a message like `"WIP: pre-test checkpoint"` if the work isn't finalized yet.
-2. **Run tests in the foreground (never in the background).** The test command has a slow startup phase: `ensure-test-deps.sh` installs dependencies (~1-2 min on first run), then `conftest.py` imports `app.py` and generates test media/embeddings before any tests execute. There may be no output for 1-3 minutes; this is normal. Do NOT run tests with `run_in_background` or assume output capture is broken because of the delay.
-   **Give a full `./run-tests.sh` the Bash tool's maximum timeout, `600000` ms (10 minutes).** A healthy full run is several minutes — cold dep install, then pyright and pip-audit, then the frontend build + `npm audit` + Vitest gate (~3 min on its own), and only then the ~35s pytest — so the old "at least 5 minutes" suggestion cut healthy runs off mid-gate and produced spurious timeouts. If 10 minutes is genuinely not enough, run one group at a time rather than backgrounding the run; a group run skips the frontend gate unless it is `core` or `frontend`. The script has its own 30-minute wall-clock cap and prints a distinctive `TESTS TIMED OUT` banner when *it* fires, which is how you tell a wedged run from a harness cut-off.
+2. **Start the run in the foreground with the maximum timeout, and never *launch* it with `run_in_background`.** The test command has a slow startup phase: `ensure-test-deps.sh` installs dependencies (~1-2 min on first run), then `conftest.py` imports `app.py` and generates test media/embeddings before any tests execute. There may be no output for several minutes; this is normal, and is not a sign that output capture is broken.
+
+   **Pass `600000` ms (10 minutes) — the Bash tool's maximum — and expect a cold full run to exceed it anyway.** A measured cold `./run-tests.sh` is ~11 minutes: ~7 for dep install plus the linter/pyright/pip-audit/snapshot gates and the frontend build + `npm audit` + Vitest, then ~3.5 minutes of pytest. (The old "at least 5 minutes" suggestion cut healthy runs off mid-gate.) When the tool's cap is hit the harness moves the run to the background rather than killing it — that is fine; wait for the completion notification and read the output file it names. What matters is that you *started* it in the foreground so the harness tracks it.
+
+   Two consequences worth knowing before you run it:
+   - **Do not pipe the run through `tail`/`grep`.** If the harness backgrounds a pipeline, nothing flushes until the whole pipeline ends, so the output file sits empty and you can't watch progress. Run the script bare and read the tail of the output file afterwards.
+   - **A run that outlives the tool's cap is not a timeout.** The script has its own 30-minute wall-clock cap (`VTSEARCH_TEST_TIMEOUT`) and prints a distinctive `TESTS TIMED OUT` banner when *it* fires. Absent that banner, the run is still healthy. To stay inside 10 minutes, run one group at a time — a group run skips the frontend gates unless it is `core` or `frontend`.
 3. **If tests fail and fixes are needed**, make the fixes, then commit and push again before re-running tests.
 4. **Repeat** until tests pass. Every cycle of fixes should be committed and pushed before the next test run.
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -239,8 +239,9 @@ See `CLAUDE.md` for the complete group-to-file mapping.
 ### Test markers
 
 - Default (no marker flag): fast CPU tests only, excludes `gpu` and `slow`
-- `slow`: CLI subprocess tests that spawn `python app.py --autodetect`
-  (~16 seconds each)
+- `slow`: the CLI subprocess test that spawns `python app.py --autodetect`
+  (~16s) plus the two real-`toponymy` fit tests in `tests_lib/projection/`
+  (~1 min each). Run both trees: `pytest tests/ tests_lib/ -m slow`
 - `gpu`: CUDA-only tests
 
 ### Linting, formatting, and other quality tools
@@ -257,10 +258,13 @@ vulture vtsearch/ .vulture-whitelist.py --min-confidence 80   # dead code audit
 Configuration is in `pyproject.toml`. `pre-commit install` wires up
 ruff, codespell, and deptry as git hooks. There is **no CI**: VTSearch has
 no GitHub Actions workflows, so `./run-tests.sh` is the only gate — it runs
-ruff, `ruff format --check`, codespell, deptry, `pip-audit`, pyright, and the
-frontend build before pytest. Run it before pushing. See
-`docs/plans/python-quality-tools.md` for the rationale behind which security
-rules are enabled and which are ignored.
+ruff, `ruff format --check`, codespell, deptry, `pip-audit`, pyright, the
+OpenAPI snapshot diff, the Dockerfile check, the user-docs screenshot wiring
+check, the eval/app sync check, and the frontend build + `npm audit` + Vitest
+suite before pytest. Run it before pushing; CLAUDE.md's "What `run-tests.sh`
+gates" table is the authoritative list. The rationale for which flake8-bandit
+security rules are enabled and which are ignored lives inline in
+`pyproject.toml`'s `[tool.ruff.lint]` block, one comment per ignored rule.
 
 ---
 

--- a/docs/plans/documentation-accuracy.md
+++ b/docs/plans/documentation-accuracy.md
@@ -124,6 +124,17 @@ separately.
 
 <!-- item-sep -->
 
+- **The `run-tests.sh` gate list is still hand-maintained in three places.** CLAUDE.md's "What
+  `run-tests.sh` gates" table, `docs/HANDOFF.md`'s quality-tools paragraph and the script's own
+  usage header each restate the chain by hand; the first two were six gates stale before #2997.
+  This is the same inventory-drift shape as #2984, and it wants the same treatment — but note the
+  cheaper shape fits better here: rather than *generating* the table, an invariant check could
+  assert that the set of `echo "…"` stage banners in `run-tests.sh` matches the rows in CLAUDE.md's
+  table, which is a few lines inside whatever #2983's docs-drift gate becomes. Worth folding into
+  that gate rather than shipping its own script.
+
+<!-- item-sep -->
+
 - **README.md and SETUP.md — install-path drift.** `SETUP.md:205-207` describes GPU detection
   as "nvidia-smi absent → CPU wheel", but `scripts/install.sh:1137-1173` only falls back to CPU
   when no NVIDIA PCI hardware exists; with a card present and no driver it prompts for a sudo

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,12 +9,20 @@
 #   ./run-tests.sh vtscore-clean  # run tests_lib/ with Flask import blocked
 #
 # Available groups: core, api, sorting, datasets, io, detectors,
-#                   downloads, integration, cli, converters, projection
+#                   downloads, integration, cli, converters, projection,
+#                   frontend (build + audit + Vitest, no Python tests), gpu
 #
 # Each group is a folder under tests/ AND tests_lib/. Marker assignment is
 # automatic: any file at tests[_lib]/<group>/test_*.py gets marked <group>
 # by the respective conftest.  tests_lib/ holds Flask-free library tests
-# (Phase 7 of vtscore/docs/architecture.md).
+# (see vtscore/docs/architecture.md).
+#
+# NOTE: naming a group puts `-m <group>` on the pytest command line, which
+# REPLACES the `-m 'not gpu and not slow'` default in pyproject.toml's
+# addopts rather than combining with it. So a group run also picks up any
+# slow/gpu tests in that folder (that is how `./run-tests.sh gpu` works).
+# To keep the default exclusions, spell the filter out after `--`, e.g.
+#   ./run-tests.sh cli -- -m 'cli and not slow'
 #
 # Extra pytest args can follow a '--':
 #   ./run-tests.sh core -- -x --tb=short

--- a/scripts/experiments/GRID-PLAYBOOK.md
+++ b/scripts/experiments/GRID-PLAYBOOK.md
@@ -1,9 +1,13 @@
 # Running eval experiments on the GRID (SLURM) — playbook
 
-Practical, hard-won ops notes for running the `scripts/experiments/*` and
-`scripts/sod` sweeps on the JHU-HLTCOE GRID (a shared SLURM cluster). The
-patterns are general; HLTCOE-specific values are marked **[HLTCOE]**. Read this
-before launching a big sweep — most of it was learned by getting it wrong.
+Practical, hard-won ops notes for running the `scripts/experiments/*` sweeps on
+the JHU-HLTCOE GRID (a shared SLURM cluster) — and the older `scripts/sod`
+sweeps, which live **only on the `evaluation-framework` branch** and are not
+present on `dev` (see `LESSONS.md`, the 2026-08-07 entry, and
+`docs/experiments/spike-check-2847/REPORT.md` for why that harness can't be
+pointed at `dev`). The patterns are general; HLTCOE-specific values are marked
+**[HLTCOE]**. Read this before launching a big sweep — most of it was learned by
+getting it wrong.
 
 This file covers **SLURM resources**. Its companions cover the rest of running a
 study, and the `grid-experiments` skill ties all three together:


### PR DESCRIPTION
Closes #2997

`CLAUDE.md` is re-read by every agent on every turn, so its operational reference is the most expensive doc in the repo to have wrong. It had fallen six gates behind `run-tests.sh`. Everything below was re-derived from `run-tests.sh` and `pyproject.toml` rather than hand-edited.

## CLAUDE.md

- **New "What `run-tests.sh` gates" table**, in script order, with each gate's command, trigger and notes: the wall-clock cap, dep install, `ruff check` / `ruff format --check`, `codespell`, `deptry`, `pip-audit`, `pyright`, the OpenAPI snapshot diff, `check-dockerfiles.py`, `wiring-check.py`, `check-eval-app-sync.py`, the frontend build / `npm audit` / Vitest gates, and pytest. It carries an explicit "update this when you change the script" instruction, and the Commands bullets now point at it instead of restating a partial list.
- **The OpenAPI regeneration command is documented** (`npm run regenerate-openapi-snapshot`). The gate told you the snapshot was stale but CLAUDE.md never said how to fix it.
- **The `slow` marker was wrong in count, location and command.** It is 3 tests across *both* trees — one CLI subprocess test in `tests/cli/` plus two real-`toponymy` fit tests in `tests_lib/projection/` (module-level `pytestmark`, ~1 min each) — and the documented command passed only `tests/`, silently missing two thirds of them.
- **New gotcha, verified against pytest:** naming a group puts `-m <group>` on the command line, which *replaces* `addopts`' `-m 'not gpu and not slow'` rather than combining with it. So `./run-tests.sh cli` does run the slow subprocess test and `./run-tests.sh projection` does run the toponymy smoke tests — which is also why `./run-tests.sh gpu` works at all. The workaround (`./run-tests.sh cli -- -m 'cli and not slow'`) is spelled out.
- **The suggested test timeout is raised and grounded in a measurement.** A full run on this container took ~11 minutes (~7 for dep install + the linter/pyright/pip-audit/snapshot gates + the frontend build/audit/Vitest, then 3m35s of pytest), so the old 5-minute suggestion cut healthy runs off mid-gate. The guidance now says to pass the Bash tool's 600s maximum, expect the harness to background the run rather than kill it, avoid piping through `tail` (a backgrounded pipeline flushes nothing until it ends), and treat the script's own `TESTS TIMED OUT` banner as the only real timeout signal.
- **The session-start hook description covers its hard-reset paths.** The hook picks one of four outcomes and says which; it can hard-reset the working branch to `origin/dev` — as it did at the start of the session that produced this PR — and the doc described only fetch+rebase and "skipping".

## Same drift, elsewhere

- `docs/HANDOFF.md`: its gate list was stale in the same way, its `slow` description carried the same wrong count, and it pointed at `docs/plans/python-quality-tools.md`, pruned on ship. The flake8-bandit rationale now lives inline in `pyproject.toml`'s `[tool.ruff.lint]` block, so the pointer goes there.
- `scripts/experiments/GRID-PLAYBOOK.md`: referenced `scripts/sod` with no note that it exists only on the `evaluation-framework` branch, sending a reader on `dev` after a directory that isn't there.
- `.claude/skills/style-check/SKILL.md`: the rule table was three checks behind `.claude/scripts/style-check.py` (raw `z-index`, raw decorative-dim `opacity`, bespoke accent tint), with curation notes for each. Also corrects the script's own mislabelled section number — its decorative-dim check printed §1.9, but §1.9 is the disabled state and §1.10 is decorative-dim.
- `run-tests.sh`'s usage header omitted the `frontend` and `gpu` groups and now records the marker-override gotcha at the source.

## Follow-up recorded, not shipped

The issue asked whether the gate list could be generated. It's noted as an open finding in `docs/plans/documentation-accuracy.md`: the list is hand-maintained in three places, but the cheaper shape is an *invariant* — assert that the `echo` stage banners in `run-tests.sh` match the table's rows — which belongs inside #2983's docs-drift gate rather than in its own script.

## Testing

`./run-tests.sh` — all gates pass, **8247 passed, 6 skipped, 1 xfailed, 1 xpassed**. `codespell` and `ruff check` re-run after the follow-up markdown edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_0177gpikvJTfsaqZypFF1SDt)_