### PR TITLE
Document the default deployment's security posture; fix the browse root in file-browser.md

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,15 +6,97 @@ installation and getting started, see [SETUP.md](SETUP.md).
 
 ## Table of Contents
 
-1. [Environment variables](#environment-variables)
-2. [Running under gunicorn](#running-under-gunicorn)
-3. [Network dependencies](#network-dependencies)
-4. [Offline deployment](#offline-deployment)
-5. [Data directory layout](#data-directory-layout)
-6. [Progress-bar timing profile](#progress-bar-timing-profile)
-7. [Docker production notes](#docker-production-notes)
-8. [Dependency structure](#dependency-structure)
-9. [Troubleshooting](#troubleshooting)
+1. [Security](#security)
+2. [Environment variables](#environment-variables)
+3. [Running under gunicorn](#running-under-gunicorn)
+4. [Network dependencies](#network-dependencies)
+5. [Offline deployment](#offline-deployment)
+6. [Data directory layout](#data-directory-layout)
+7. [Progress-bar timing profile](#progress-bar-timing-profile)
+8. [Docker production notes](#docker-production-notes)
+9. [Dependency structure](#dependency-structure)
+10. [Troubleshooting](#troubleshooting)
+
+---
+
+## Security
+
+> **A default VTSearch deployment has no authentication and no filesystem
+> confinement. Anyone who can reach the port gets full use of the app and,
+> through it, read and write access to every path the server process can
+> reach. Do not put one on an untrusted network — including the public
+> internet — without the measures in [Before you expose
+> it](#before-you-expose-it) below.**
+
+This is a deliberate design for the deployment VTSearch is built around: one
+trusted user, on their own workstation or a private host. It is *not* a
+hardened multi-tenant server, and nothing in the app assumes it is.
+
+### What the default deployment grants
+
+With no `--login` flag the app runs `DefaultLoginProvider`: every request is
+treated as the single user `default`, always authenticated. There is no
+password, token, session, or login step to obtain — the request lifecycle
+identifies the caller but never challenges them. Concretely, an unauthenticated
+caller can:
+
+- **Read any server-readable path.** `GET /api/browse` roots at the filesystem
+  root (`/`) in single-user mode, and server-path importer fields accept any
+  absolute or relative path. `get_file_access_base_dir()`
+  (`vtscore/security/path_validation.py`) returns `None` for the default
+  provider, which tells `validate_server_filepath()` to apply **no**
+  containment check at all. Imported file contents are then served back
+  through the media routes.
+- **Write any server-writable path.** Server-file exporters
+  (`server_json_file`, `server_csv_file`, portable-detector export, the
+  server-JSON label source) take a destination path as a free-text field and
+  create parent directories as needed, under the same `None` confinement.
+- **Make the server issue outbound requests.** The HTTP-archive importer and
+  the webhook exporter fetch/post to a user-supplied URL (these go through the
+  SSRF guard in `vtscore/security/url_validation.py`, which rejects non-HTTP(S)
+  schemes and private/internal addresses).
+- **Read and change every setting and every dataset/detector on the instance.**
+  There is one shared `data/` tree with no per-user boundary.
+
+The bound host makes this reachable by default: `python app.py` listens on
+`0.0.0.0:5000`, and gunicorn's `VTSEARCH_BIND` defaults to `0.0.0.0:5000`. On a
+cloud or multi-homed host that is every interface, not just loopback.
+
+### Before you expose it
+
+- **Put an authenticating proxy in front, and bind VTSearch to loopback.** Set
+  `VTSEARCH_BIND=127.0.0.1:5000` (or publish only to a private Docker network)
+  and terminate authentication — mTLS, OIDC/SSO, or HTTP basic auth — in the
+  reverse proxy, which then forwards to gunicorn. **Today this is the only way
+  to actually require authentication**; see the next bullet for why the
+  built-in providers are not a substitute.
+- **Understand what `--login` does and does not do.** Selecting a non-default
+  provider (`--login trivial`, `--login api_key`) makes
+  `get_file_access_base_dir()` return `data/<username>/`, which *does* confine
+  the browse root and every server-path importer/exporter to that subtree — a
+  real and worthwhile change. It does **not** gate access: no `before_request`
+  hook or route calls `provider.is_authenticated()`, so a request with a
+  missing or invalid Bearer token is served as the `anonymous` user rather than
+  rejected, and `TrivialLoginProvider`'s login screen is enforced only in the
+  SPA ([#2946](https://github.com/samggreenberg/VTSearch/issues/2946)). Treat
+  provider choice as a **confinement** mechanism, not an authentication one,
+  until that issue is fixed.
+- **Set `VTSEARCH_SECRET_KEY` to a random value.** The default is a constant
+  visible in the source. `TrivialLoginProvider`'s session cookie is only
+  integrity-protected by that key, so with the default anyone can forge a
+  cookie naming any user — and the username is also a path component
+  ([#2930](https://github.com/samggreenberg/VTSearch/issues/2930)).
+- **Let the OS be the real boundary.** In single-user mode the only limit on
+  file access is what the process account can read and write, so run VTSearch
+  as an unprivileged, dedicated user (or in a container) whose only writable
+  mount is the data directory. Do not run it as root.
+- **Keep the media you import in mind.** Dataset pickles are loaded through a
+  restricted unpickler (`vtscore/security/pickle.py`) that permits only plain
+  types and numpy arrays, so a `.pkl` cannot execute code — but everything a
+  user can point an importer at is content the server will read and serve.
+
+Behaviour changes to close these gaps are tracked as open issues rather than
+documented workarounds; this section describes the code as it stands.
 
 ---
 
@@ -136,6 +218,13 @@ For public deployments, put nginx / Caddy / Traefik in front of gunicorn
 to handle TLS, gzip, and static-asset caching. Flask serves the Angular
 build from `static/` directly, but a dedicated reverse proxy is much
 more efficient for that traffic.
+
+> **Read [Security](#security) first.** VTSearch itself does not
+> authenticate anyone and, in the default single-user mode, does not confine
+> file access. A proxy that only terminates TLS publishes an unauthenticated
+> filesystem browser. The proxy is also where you add authentication — and
+> gunicorn should be bound to loopback (`VTSEARCH_BIND=127.0.0.1:5000`) so it
+> can't be reached around it.
 
 A few VTSearch-specific points matter when configuring the proxy:
 

--- a/docs/api/file-browser.md
+++ b/docs/api/file-browser.md
@@ -13,14 +13,37 @@ GET /api/browse
 ```
 
 **Query:**
-- `path` (optional): relative path within the allowed root (default `""`).
+- `path` (optional): path relative to the browse root (default `""`, the
+  root itself).
 - `extensions` (optional): comma-separated list of file extensions to show,
   e.g. `".csv,.json"`. When omitted, all files are listed.
 
-Lists directories and files at a relative path within the allowed root
-directory. In single-user mode the root is the current working directory;
-in multi-user mode it is the current user's data directory. Hidden files
-(names starting with `.`) are excluded.
+Lists directories and files at a path within the browse root. What that
+root is depends on the active login provider (see
+[Authentication](auth.md#login-providers)):
+
+- **Single-user mode** (`DefaultLoginProvider`, the default — no `--login`
+  flag): the root is the **filesystem root**, `/`. There is no confinement:
+  the lone trusted user may browse any directory the server process can
+  read, matching the unrestricted server-path validation applied to
+  importers and exporters (`get_file_access_base_dir()` returns `None`).
+  Paths in the response are absolute (`/data`, `/data/sounds`), so the value
+  can be handed straight to a server-path field.
+- **Multi-user mode** (any other provider): the root is the current user's
+  data directory, `data/<username>/`, and the browser is confined to that
+  subtree. Paths in the response are relative to it, so the server's
+  absolute layout never leaks.
+
+In both modes the server's own root path is omitted from the response, and
+`path` is interpreted relative to the root. Hidden files (names starting
+with `.`) are excluded, as are symlinks whose target resolves outside the
+root.
+
+> **Deploying this publicly?** In the default single-user mode this endpoint
+> exposes the whole server filesystem to anyone who can reach the port, and
+> nothing authenticates the caller. See
+> [Security](../DEPLOYMENT.md#security) before putting VTSearch on an
+> untrusted network.
 
 →
 ```json
@@ -35,8 +58,38 @@ in multi-user mode it is the current user's data directory. Hidden files
 }
 ```
 
-400 if the path escapes the allowed root (path traversal prevention).
-403 if permission is denied. 404 if the directory does not exist.
+(Shown with a confined root; in single-user mode the same listing carries
+absolute paths — `"path": "/data/labels/labels.csv"`,
+`"current_path": "/data/labels"`.)
+
+400 if the path escapes the browse root (path traversal prevention) and
+403 if permission is denied reading the directory; both use the standard
+`{"message": "..."}` envelope.
+
+404 if the directory does not exist. This one is intercepted by the
+app-level `NotFound` handler, so it keeps the legacy shape
+`{"error": "Not Found", "request_id": "..."}` rather than the `message`
+envelope.
+
+422 if a query parameter fails schema validation, with the standard
+per-field `errors` envelope:
+
+```json
+{
+  "code": 422,
+  "status": "Unprocessable Content",
+  "errors": {"query": {"path": ["Not a valid string."]}}
+}
+```
+
+(`status` is the HTTP reason phrase as the running interpreter spells it —
+`"Unprocessable Entity"` before Python 3.13, `"Unprocessable Content"` from
+3.13 on. Match on `code` / `errors`, not on that string.)
+
+Both query params are optional strings, so in practice this endpoint
+rarely produces a 422; it is declared (and appears in
+`/api/openapi.json`) because the route is schema-validated like every
+other `flask-smorest` endpoint.
 
 ---
 

--- a/tests_lib/detectors/test_acquisition_threshold.py
+++ b/tests_lib/detectors/test_acquisition_threshold.py
@@ -35,9 +35,23 @@ def _clips(rng: np.random.Generator, cids: range) -> dict[int, dict]:
     }
 
 
+#: Haystack size for the trained fixtures below.  A cut is realized as an
+#: empirical quantile of this haystack (:meth:`FoldAnchoredCut.threshold_at`),
+#: so the haystack's own spacing is the finest gap two cuts can be apart: with
+#: 20 items a quantile has to move a full 5% before the threshold moves at all.
+#: :data:`ACQUISITION_INCLUSION_OFFSET` is one inclusion step, whose tilt is
+#: routinely smaller than that, so on a 20-item haystack the acquisition cut
+#: lands on the *same* haystack element as the reporting cut and a strict ``>``
+#: holds or fails on numerical noise - which is how it varied with process
+#: ordering.  100 resolves a single step with room to spare (verified across
+#: seeds), keeping the direction pin about the offset rather than about
+#: discretization.
+HAYSTACK = 100
+
+
 def _trained(seed: int, detector_id: str, inclusion_value: int = 0):
     rng = np.random.default_rng(seed)
-    clips = _clips(rng, range(500, 520))
+    clips = _clips(rng, range(500, 500 + HAYSTACK))
     good = {cid: None for cid in range(500, 504)}
     bad = {cid: None for cid in range(504, 508)}
     det_ctx = DetectorContext(detector_id=detector_id, media_type="audio")


### PR DESCRIPTION
Closes #2980

## `docs/api/file-browser.md` — the browse root

The page said the single-user root is "the current working directory". It is the **filesystem root**: `get_file_access_base_dir()` returns `None` for `DefaultLoginProvider`, so `_get_browse_root()` (`vtsearch/routes/file_browser.py:40`) falls back to `Path("/")` and no confinement is applied.

- States the real root for both modes — `/` in single-user, `data/<username>/` in multi-user — and why (the `None` return, matching the unrestricted server-path validation).
- Notes that single-user responses carry **absolute** paths while confined ones are relative, and annotates the example listing, which was showing only the confined shape.
- Adds the 422 `errors` envelope the page omitted, and corrects the error list: 400/403 use the `message` envelope, but 404 is intercepted by the app-level `NotFound` handler (`vtsearch/errors.py:25`) and keeps the legacy `{"error": ..., "request_id": ...}` shape.
- Links to the new Security section for anyone deploying it.

The `status` string in the 422 example is annotated as version-dependent ("Unprocessable Entity" pre-3.13, "Unprocessable Content" from 3.13) — the OpenAPI postprocessor pins that spelling in the *spec*, not in the runtime body.

## `docs/DEPLOYMENT.md` — new Security section

The guide explained how to publish VTSearch behind nginx / Caddy / Traefik (TLS, timeouts, SSE buffering, forwarded headers) without ever saying that the default deployment is unauthenticated and grants unrestricted server-filesystem read/write. New `## Security` section, first in the document and in the TOC, covering:

- **What the default grants** — no password/token/session at all; read any server-readable path (`/api/browse` roots at `/`, importer path fields unconfined), write any server-writable path (the server-file exporters and label source), outbound requests via the URL-typed fields (which *do* go through `validate_url`), and one shared `data/` tree.
- **That it is reachable by default** — `python app.py` binds `0.0.0.0:5000` and `VTSEARCH_BIND` defaults to the same.
- **What to do before exposing it** — bind to loopback and authenticate at the proxy (currently the only way to actually require authentication); understand that `--login` buys per-user *confinement* but not *authentication*, since nothing calls `is_authenticated()` (#2946); set `VTSEARCH_SECRET_KEY`, since the trivial provider's cookie is only integrity-protected by it and the username is a path component (#2930); run unprivileged, because in single-user mode the process account is the only boundary.

Only the two still-open hardening issues are cross-linked; #2926 / #2920 (the `media_url` SSRF) are already fixed and closed, so citing them as open caveats would have been wrong. The reverse-proxy section now opens with a pointer back to Security — a proxy that only terminates TLS publishes an unauthenticated filesystem browser.

## Unrelated test fix (`./run-tests.sh` was red on `dev`)

`tests_lib/detectors/test_acquisition_threshold.py::test_it_sits_above_the_reporting_cut` failed in the parallel full-suite run (`acq == threshold`, strict `>` expected) while passing when the file ran alone — a pre-existing order-dependent failure on `dev`, unrelated to this change.

Cause: `FoldAnchoredCut.threshold_at` realizes a cut as an empirical quantile of the haystack, so the haystack's spacing bounds how close two cuts can be — on 20 items a quantile has to move a full 5% before the threshold moves at all. Since `ACQUISITION_INCLUSION_OFFSET` went `-3` → `-1` (#2909), one inclusion step's tilt is routinely smaller than that, so both cuts land on the same haystack element and the assertion turns on numerical noise that varies with process ordering. Widening the trained fixtures to a 100-item haystack resolves one step with room to spare across seeds, so the test pins the *direction of the offset* rather than pinning discretization. The sibling relative-offset test in the same file already carries this lesson (it swapped its trained fit for exact hand-built geometry for the same reason).

## Testing

`./run-tests.sh` — 8247 passed, 6 skipped, 1 xfailed, 1 xpassed. No source behavior changed; the app-side docs describe the code as it stands, and behavior fixes stay tracked in their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVoLHuBvw3X4jtY5Sa59Fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVoLHuBvw3X4jtY5Sa59Fk)_