### PR TITLE
docs: document the real processor registration path

### DIFF
--- a/docs/EXTENDING-processors.md
+++ b/docs/EXTENDING-processors.md
@@ -4,6 +4,11 @@ How to add new detectors, localizers, and extractors (the three kinds
 of **Processor** in VTSearch). All three subclass `Processor` from
 `vtscore/media/processors.py`.
 
+Subclassing is necessary but **not sufficient**: unlike the auto-discovered
+plugin families, a processor is only reachable once it is added to a hardcoded
+factory dict in the app. Read [Registering a Processor with the
+App](#registering-a-processor-with-the-app) alongside the recipes below.
+
 **Related docs:** [EXTENDING.md](EXTENDING.md) (index, checklists, auth,
 dependencies) · [EXTENDING-plugins.md](EXTENDING-plugins.md) (importers,
 exporters, sources) · [EXTENDING-media.md](EXTENDING-media.md) (media
@@ -16,6 +21,9 @@ types, embedders, clippers, converters).
 - [Adding a Localizer](#adding-a-localizer): "where inside this media?" → regions
 - [Adding an Extractor](#adding-an-extractor): "what structured data can
   we pull out?" → list of dicts
+- [Registering a Processor with the App](#registering-a-processor-with-the-app):
+  the `from_config` contract and the hardcoded factory dicts — **required**,
+  the class alone is not reachable
 
 ---
 
@@ -34,9 +42,27 @@ Processor (ABC)
 
 Each processor operates on exactly one media type.
 
+> **Processors are not auto-discovered.** Unlike the nine plugin families in
+> [EXTENDING-plugins.md](EXTENDING-plugins.md), there is no registry scan and
+> no module-level sentinel here: the app instantiates processors through two
+> **hardcoded factory dicts** in `vtsearch/routes/processors/crud.py`. Writing
+> the subclass below is only half the job — a class that isn't in a factory
+> dict cannot be built by any endpoint. See [Registering a Processor with the
+> App](#registering-a-processor-with-the-app) for the other half.
+
 ### Adding a Detector
 
 A Detector answers "is this media Good?" with a boolean.
+
+> **Detectors have no app wiring at all.** No concrete `Detector` subclass
+> ships in the tree, there is no detector factory dict, and no endpoint builds
+> or runs one — the ABC exists so the `Processor` hierarchy is complete, and a
+> subclass is usable only from code you call yourself. If you want an ML
+> classifier the app can actually run, you want a **detector in the VTSearch
+> sense** (a trained ranking head registered via `POST /api/detectors/registry`
+> — see [ML.md](ML.md) and [docs/api/detectors.md](api/detectors.md)), which is
+> an unrelated concept that happens to share the word. The two registrable processor kinds are `Localizer` and
+> `Extractor`.
 
 ```python
 from vtscore.media.processors import Detector
@@ -73,9 +99,13 @@ from typing import Any
 
 class FaceLocalizer(Localizer):
 
+    def __init__(self, name: str, threshold: float = 0.5) -> None:
+        self._name = name
+        self._threshold = threshold
+
     @property
     def name(self) -> str:
-        return "face_localizer"
+        return self._name
 
     @property
     def media_type(self) -> str:
@@ -95,6 +125,11 @@ class FaceLocalizer(Localizer):
         ]
 ```
 
+That covers the ABC. To make it reachable from the API it also needs a
+`from_config` classmethod and an entry in `_LOCALIZER_FACTORIES` — see
+[Registering a Processor with the App](#registering-a-processor-with-the-app).
+`vtscore/media/image/face_localizer.py` is the one in-tree example.
+
 ### Adding an Extractor
 
 An Extractor returns structured details for each occurrence found.
@@ -106,9 +141,13 @@ from typing import Any
 
 class ObjectExtractor(Extractor):
 
+    def __init__(self, name: str, threshold: float = 0.25) -> None:
+        self._name = name
+        self._threshold = threshold
+
     @property
     def name(self) -> str:
-        return "object_extractor"
+        return self._name
 
     @property
     def media_type(self) -> str:
@@ -126,6 +165,11 @@ class ObjectExtractor(Extractor):
             {"confidence": 0.87, "bbox": [400, 50, 600, 250], "label": "tree"},
         ]
 ```
+
+Note that `name` is an instance attribute, not a hardcoded string: the app
+names each processor from the API request, so the constructor must accept a
+`name`. The next section explains why, and what else this class still needs
+before any endpoint can build it.
 
 ### Processor abstract interface reference
 
@@ -147,6 +191,14 @@ subtype-specific method below — you do **not** override `process()`.
 | Member | Type | Description |
 |--------|------|-------------|
 | `load_model()` | `() -> None` | One-time model loading (default: no-op) |
+| `to_dict()` | `() -> dict` | Metadata for API responses (default: `name` + `media_type`) |
+
+**Not on the ABC, but required by the app** (see
+[Registering a Processor with the App](#registering-a-processor-with-the-app)):
+
+| Member | Signature | Description |
+|--------|-----------|-------------|
+| `from_config(name, config)` | `classmethod (str, dict) -> Self` | Build an instance from an API request body |
 
 **Detector:**
 
@@ -165,6 +217,149 @@ subtype-specific method below — you do **not** override `process()`.
 | Member | Signature | Description |
 |--------|-----------|-------------|
 | `extract(media)` | `(dict) -> list[dict]` | Return result dicts with `confidence` key |
+
+---
+
+## Registering a Processor with the App
+
+A `Localizer` or `Extractor` subclass is inert until the app can **build** it.
+The app never looks at your class hierarchy: it maps a `localizer_type` /
+`extractor_type` **string** from the request body to a factory callable, using
+two module-level dicts in `vtsearch/routes/processors/crud.py`. A type string
+that isn't a key in the relevant dict raises `ValueError` inside
+`_build_extractor` / `_build_localizer` — which surfaces as an HTTP 400
+(`Invalid extractor config: Unknown extractor_type: 'object_class'`) from a
+route far away from the class you wrote.
+
+So registration is two steps: give the class a `from_config` classmethod, then
+add it to the factory dict.
+
+### Step 1: the `from_config` classmethod
+
+`_build_extractor(name, extractor_type, config)` calls the factory as
+`factory(name, config)`. The convention every in-tree processor follows is a
+`from_config` classmethod paired with a `to_dict` that emits the same shape, so
+a processor round-trips through the API:
+
+```python
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()                 # {"name": ..., "media_type": ...}
+        d["extractor_type"] = "object_class"  # the factory-dict key
+        d["config"] = {"threshold": self._threshold}
+        return d
+
+    @classmethod
+    def from_config(cls, name: str, config: dict[str, Any]) -> "ObjectExtractor":
+        """Reconstruct an ``ObjectExtractor`` from a saved config dict."""
+        return cls(name=name, threshold=config.get("threshold", 0.25))
+```
+
+Rules that fall out of how it is called:
+
+- **`name` comes from the request, not the class.** Two autorun entries of the
+  same type with different configs are distinct processors distinguished only
+  by name, so never hardcode `name` in the class.
+- **`config` is unvalidated.** `AutorunExtractorCreateRequestSchema` declares it
+  as a bare `fields.Dict`, so whatever JSON the client sent arrives verbatim.
+  `from_config` *is* the validation layer: use `config.get(key, default)` for
+  optional keys and `config[key]` for required ones. A `KeyError` or
+  `ValueError` raised here is caught by the route and returned as a 400, which
+  is the intended failure mode — don't swallow it and return a half-built
+  processor.
+- **A localizer uses `localizer_type` in `to_dict`**, not `extractor_type`.
+- **`to_dict` is not what registers anything.** It is metadata for API
+  responses; the string it reports is only correct because you also added that
+  same string to the factory dict in step 2.
+
+Reference implementations: `vtscore/media/image/extractor.py` (`image_class`),
+`vtscore/media/image/ocr_extractor.py` (`ocr`),
+`vtscore/media/audio/speech_extractor.py` (`speech`),
+`vtscore/media/image/face_localizer.py` (`face`).
+
+### Step 2: add it to the factory dict
+
+Edit `vtsearch/routes/processors/crud.py`. Extractors go in
+`_ensure_extractor_factories`, localizers in `_ensure_localizer_factories`.
+Both populate their dict on first use and import inside the function body —
+that laziness is deliberate (it avoids import cycles and keeps heavyweight
+optional dependencies out of app startup), so keep your import inside the
+function too:
+
+```python
+def _ensure_extractor_factories():
+    """Populate the factory registry on first use (lazy to avoid import cycles)."""
+    if _EXTRACTOR_FACTORIES:
+        return
+    # ... existing image_class / ocr / speech entries ...
+
+    from vtscore.media.image.object_extractor import ObjectExtractor
+
+    _EXTRACTOR_FACTORIES["object_class"] = ObjectExtractor.from_config
+```
+
+The key you choose here *is* the public `extractor_type` / `localizer_type`
+value. It is duplicated in your `to_dict`, and nothing checks the two agree —
+a mismatch means the processor builds fine but reports a type string that
+cannot be rebuilt.
+
+**Yes, this means adding a processor requires editing app code**, and a
+third-party package cannot ship one. That is a real divergence from every other
+plugin family in this repo (importers, exporters, converters, media sources, …),
+which *are* auto-discovered from a module-level sentinel and can be contributed
+out-of-tree via entry points — see
+[EXTENDING-plugins.md § PluginRegistry](EXTENDING-plugins.md#pluginregistry-auto-discovery).
+Processors predate that mechanism and were never moved onto it. Don't assume
+the sentinel pattern works here; it does not.
+
+### Step 3 (optional): offer it as a pregen processor
+
+`_PREGEN_PROCESSORS` further down the same file is a hardcoded list of
+ready-to-use processor definitions (name, kind, type, media type, default
+config). `GET /api/pregen-processors` returns it, and
+`POST /api/pregen-processors/add` registers **all** of them as autorun entries
+in one call. Add an entry if your processor should be part of that
+one-click bundle; the `processor_type` you use must be a factory-dict key, and
+`kind` must be `"extractor"` or `"localizer"`.
+
+### Using the registered processor
+
+With steps 1 and 2 done, the endpoints documented in
+[docs/api/io.md](api/io.md#pregen-processors) work:
+
+| Endpoint | Effect |
+|----------|--------|
+| `POST /api/autorun-extractors` | Validates by building the processor once, then stores `{name, extractor_type, media_type, config}` |
+| `POST /api/autorun-localizers` | Same, for localizers |
+| `POST /api/extract` / `POST /api/localize` | Build one ad-hoc processor from a body and run it over every loaded media |
+| `POST /api/auto-extract` / `POST /api/auto-localize` | Build and run every stored processor whose `media_type` matches the loaded medias |
+
+Four behaviours of this layer are worth knowing before you debug it:
+
+- **Registration is validated, autorun is not.** The `POST /api/autorun-*`
+  routes build the processor once purely to reject a bad config with a 400, and
+  throw the instance away. `/api/auto-extract` and `/api/auto-localize` rebuild
+  each stored processor at request time and **silently skip** any that fails to
+  build (`_run_single` swallows the exception and returns `None`), so a
+  processor removed from a factory dict later just disappears from the results
+  rather than erroring.
+- **Instances are per-request.** Nothing caches a built processor, so
+  `load_model()` runs again on every call. Cache heavy resources on the
+  instance (`if self._model is not None: return`, as the in-tree processors do)
+  and expect the load cost once per request.
+- **The stored `media_type` is what routes it.** `POST /api/autorun-*` takes
+  `media_type` from the request body and never cross-checks it against your
+  class's `media_type` property; `/api/auto-extract` selects processors by that
+  stored string. (`/api/extract` and `/api/localize` *do* check, and 400 on a
+  mismatch.) Send the same value your class reports.
+- **The autorun store is in-memory and process-global.** It lives in
+  `vtsearch/autorun_processors.py` and is not written to `data/settings.json`
+  or anywhere else, so registrations are lost on restart. Nothing runs autorun
+  processors implicitly on media load either — despite the name, they run only
+  when `/api/auto-extract` or `/api/auto-localize` is called.
 
 ---
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -295,11 +295,25 @@ See [EXTENDING-media.md § Adding a Media Converter](EXTENDING-media.md#adding-a
 See [EXTENDING-processors.md](EXTENDING-processors.md).
 
 - [ ] Subclass `Localizer` or `Extractor` from `vtscore.media.processors`
-- [ ] Implement `name`, `media_type`, and the type-specific method
-      (`localize` or `extract`)
+- [ ] Implement `name` (from a constructor argument, **not** hardcoded),
+      `media_type`, and the type-specific method (`localize` or `extract`)
 - [ ] Optionally override `load_model()` for one-time resource loading
+- [ ] Add a `from_config(name, config)` classmethod, and a `to_dict()` that
+      reports the matching `extractor_type` / `localizer_type` + `config`
+- [ ] **Wire it into the hardcoded factory dict** in
+      `vtsearch/routes/processors/crud.py` (`_ensure_extractor_factories` or
+      `_ensure_localizer_factories`) — processors are *not* auto-discovered,
+      and an unregistered type is a 400 from every endpoint
+- [ ] Optionally add it to `_PREGEN_PROCESSORS` in the same file
 - [ ] Register as autorun via `POST /api/autorun-extractors` or
-      `POST /api/autorun-localizers`
+      `POST /api/autorun-localizers`, then run it with `POST /api/auto-extract`
+      / `POST /api/auto-localize`
+- [ ] Test: build it via `_build_extractor` / `_build_localizer` and assert a
+      bad config raises (see `tests/detectors/test_processors.py`)
+
+Note that `Detector` (the `Processor` subtype) has no factory dict and no
+endpoint; it is not registrable. The ML classifiers users actually train are
+detectors in a different sense, covered below.
 
 For ML classifiers, create a detector instead: register it via
 `POST /api/detectors/registry`, label items in the right pane, and toggle

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -152,8 +152,9 @@ Re-ingests medias from their recorded origins and applies labels.
 Pregen processors are the built-in autorun processors VTSearch ships with: an
 OCR extractor (PaddleOCR), a Speech extractor (Whisper Tiny), and a Face
 localizer (MTCNN). Adding them registers each into the autorun
-extractors / localizers stores so they run automatically after a dataset
-loads. They do **not** create detectors.
+extractors / localizers stores, from which `POST /api/auto-extract` and
+`POST /api/auto-localize` run them over the loaded medias. They do **not**
+create detectors.
 
 ### List pregen processors
 
@@ -178,8 +179,16 @@ Face localizer) into the autorun extractor / localizer stores.
 
 ## Autorun Extractors
 
-Autorun extractors run after a dataset loads and attach free-form metadata
-records to each media (e.g. OCR text, speech transcripts, image classes).
+Autorun extractors pull free-form metadata records out of each media (e.g. OCR
+text, speech transcripts, image classes). Registering one stores its type and
+config; `POST /api/auto-extract` is what builds and runs every stored extractor
+matching the loaded medias' type. The store is in-memory and does not survive
+a restart.
+
+Which extractor types exist is fixed in app code (`ocr`, `speech`,
+`image_class`); adding a new one means editing the factory dict in
+`vtsearch/routes/processors/crud.py` — see
+[EXTENDING-processors.md](../EXTENDING-processors.md#registering-a-processor-with-the-app).
 
 ### List autorun extractors
 
@@ -221,8 +230,10 @@ PUT /api/autorun-extractors/{name}/rename
 
 ## Autorun Localizers
 
-Autorun localizers run after a dataset loads and attach a list of
-`(box, confidence)` regions to each media (e.g. face detection).
+Autorun localizers find `(box, confidence)` regions inside each media (e.g.
+face detection). As with extractors, registering one only stores its type and
+config in an in-memory store; `POST /api/auto-localize` builds and runs them.
+`face` is the only localizer type in the factory dict.
 
 ### List autorun localizers
 


### PR DESCRIPTION
`docs/EXTENDING-processors.md` taught readers to subclass `Extractor` / `Localizer` and then `POST /api/autorun-extractors`. That cannot work for a new class: the app never discovers processors by subclassing — it maps an `extractor_type` / `localizer_type` **string** to a factory callable through two hardcoded dicts in `vtsearch/routes/processors/crud.py`, and each class must supply a `from_config(name, config)` classmethod. An unregistered type raises `ValueError` in `_build_extractor`, surfacing as an HTTP 400 far from the code the reader wrote.

Refs #2990

## What changed

**`docs/EXTENDING-processors.md`**

- New **Registering a Processor with the App** section: the `from_config` / `to_dict` pair (with the rules that fall out of `factory(name, config)` — `name` comes from the request, `config` arrives unvalidated as a bare `fields.Dict` so `from_config` *is* the validation layer), both factory dicts and why their imports are lazy, and the optional `_PREGEN_PROCESSORS` entry.
- Says plainly that processors are **not** auto-discovered and diverge from the sentinel-based plugin families, so a reader arriving from `EXTENDING-plugins.md` does not assume discovery works the same way. Also states the consequence: a third-party package cannot ship a processor.
- Documents four runtime behaviours of the layer that are easy to misdiagnose: instances are rebuilt per request (so `load_model()` runs every call), `/api/auto-*` **silently skips** processors that fail to build while `POST /api/autorun-*` returns a 400, the stored `media_type` is never cross-checked against the class's property, and the autorun store is in-memory only.
- Notes that the `Detector` subtype has **no** wiring at all — no concrete subclass ships, no factory dict, no endpoint — and distinguishes it from the trained detectors registered via `/api/detectors/registry`, which is an unrelated concept sharing the word.
- Recipes now take `name` as a constructor argument, matching how the factories actually call them.

**`docs/EXTENDING.md`** — the New Localizer / Extractor checklist had the same gap; it now includes `from_config`, the factory-dict edit, the pregen entry, and a test step.

**`docs/api/io.md`** — corrected three places claiming autorun processors "run automatically after a dataset loads". Nothing triggers them implicitly: `get_autorun_extractors_by_media` / `get_autorun_localizers_by_media` are read only by `/api/auto-extract` and `/api/auto-localize`. Also notes the store is not persisted and points at the new registration section.

## Note on the hardcoding

The doc describes what exists and calls the divergence out as a divergence, without promising a fix. Whether processors should be moved onto `PluginRegistry` is a design call; happy to file that as a follow-up issue if you want it tracked.

## Testing

`./run-tests.sh` — 8247 passed, 6 skipped, 2 xpassed.

An earlier run of the same commit failed one unrelated test, `tests_lib/detectors/test_acquisition_threshold.py::TestAcquisitionThresholdIsDecoupled::test_it_sits_above_the_reporting_cut` (`assert 0.5650910377502442 > 0.5650910377502442`), which passed on re-run and in isolation. It is a pre-existing scheduling-dependent flake, not touched by this docs-only diff; filed separately as #3084.