### PR TITLE
Resolve Browse projection params in one place; stamp compaction

### DIFF
--- a/docs/plans/vtsbrowse-empirical-tuning.md
+++ b/docs/plans/vtsbrowse-empirical-tuning.md
@@ -8,8 +8,9 @@ across 23 embedded (dataset × embedder) matrices, scored with a ceiling-normali
 taxonomy-separability metric and label-free structure guards, CPU-verified with
 `umap-learn`. The chosen per-embedder values live in
 `vtscore/config.py:PROJECTION_DEFAULTS_BY_EMBEDDER` (+
-`PROJECTION_COMPACT_DEFAULT`), consulted by
-`vtsearch/routes/projection.py:_umap_params`; the harness is
+`PROJECTION_COMPACT_DEFAULT`), resolved by
+`vtscore/projection/params.py:resolve_projection_params` (the one resolver every
+projection fit path calls); the harness is
 `scripts/experiments/umap_params/` and the write-up is
 [`docs/reports/2026-07-22-vtsbrowse-umap-tuning.html`](../reports/2026-07-22-vtsbrowse-umap-tuning.html).
 
@@ -64,11 +65,6 @@ the rework below exists.
 
 <!-- item-sep -->
 
-- [ ] #3056 — Ingest-time projection ignores the tuned UMAP defaults and still
-  compacts; `compact` is never stamped so the mismatch is undetectable (Sonnet 5)
-
-<!-- item-sep -->
-
 - **Rework `compact_layout` with a minimum inter-island margin.** Compaction is
   off by default because it consistently bled neighbours across cluster
   boundaries, and the cost grew with layout density (worst on 21k-image
@@ -116,9 +112,9 @@ the rework below exists.
 
 | Knob | Current default | Notes |
 |------|-----------------|-------|
-| `n_neighbors` | per-embedder (`PROJECTION_DEFAULTS_BY_EMBEDDER`): 10 for `clip`/`siglip`/`siglip_l`, 15 for `clap`; global fallback `15` | Clamped to `N-1`. A `ServerSettings` (`projection_n_neighbors`) still overrides. Resolved by `vtsearch/routes/projection.py:_umap_params`, which only the route path calls — see #3056. |
+| `n_neighbors` | per-embedder (`PROJECTION_DEFAULTS_BY_EMBEDDER`): 10 for `clip`/`siglip`/`siglip_l`, 15 for `clap`; global fallback `15` | Clamped to `N-1`. A `ServerSettings` (`projection_n_neighbors`) still overrides. Resolved by `vtscore/projection/params.py:resolve_projection_params`, which every fit path calls (route, ingest pre-build, positives map). |
 | `min_dist` | per-embedder: 0.05 image, 0.10 audio; global fallback `0.1` | A `ServerSettings` (`projection_min_dist`) still overrides. |
-| `compact` | `False` (`PROJECTION_COMPACT_DEFAULT`) on the route path; `fit_projection`'s own signature default is still `True` | Post-fit `compact_layout` rigid-body packing; off since the Part 1 sweep. The ingest-time build takes the signature default — see #3056. |
+| `compact` | `False` (`PROJECTION_COMPACT_DEFAULT`), including `fit_projection`'s own signature default | Post-fit `compact_layout` rigid-body packing; off since the Part 1 sweep. Stamped on the `Projection`, so a layout packed under the old default fails the freshness check and is refit. |
 | `min_n_for_umap` | `10` | Below this → PCA-2 fallback. Constant for now. |
 | `random_state` | `None` (unseeded) | Keep unseeded in prod. Seed only inside a sweep harness. |
 | `metric` | `"euclidean"` | Settled (ingest-normalized vectors); not a tuning target. |

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -843,28 +843,63 @@ def test_projection_params_match(monkeypatch):
     import numpy as np
 
     from vtsearch.routes import projection as proj_route
+    from vtscore.projection.params import ProjectionParams
     from vtscore.projection.umap_projection import Projection
 
     coords = np.zeros((3, 2), dtype=np.float32)
     ids = [0, 1, 2]
-    umap_default = Projection("p", ids, coords, "umap", 15, 0.1)
-    umap_changed = Projection("p", ids, coords, "umap", 30, 0.1)
-    pca = Projection("p", ids, coords, "pca", None, None)
-    legacy = Projection("p", ids, coords, "umap", None, None)
+    umap_default = Projection("p", ids, coords, "umap", 15, 0.1, False)
+    umap_changed = Projection("p", ids, coords, "umap", 30, 0.1, False)
+    pca = Projection("p", ids, coords, "pca", None, None, None)
+    legacy = Projection("p", ids, coords, "umap", None, None, None)
 
     # Active settings at the config defaults.
-    monkeypatch.setattr(proj_route, "_umap_params", lambda ctx=None: (15, 0.1))
+    monkeypatch.setattr(proj_route, "_projection_params", lambda ctx=None: ProjectionParams(15, 0.1, False))
     assert proj_route._projection_params_match(umap_default) is True
     assert proj_route._projection_params_match(umap_changed) is False
     assert proj_route._projection_params_match(pca) is True
-    # Legacy None params are assumed to be the config defaults.
-    assert proj_route._projection_params_match(legacy) is True
+    # Legacy None UMAP knobs are assumed to be the config defaults — but an
+    # unstamped ``compact`` means "compacted", which today's default is not.
+    assert proj_route._projection_params_match(legacy) is False
 
     # Operator tuned the setting away from the default -> stale layouts recompute.
-    monkeypatch.setattr(proj_route, "_umap_params", lambda ctx=None: (30, 0.1))
+    monkeypatch.setattr(proj_route, "_projection_params", lambda ctx=None: ProjectionParams(30, 0.1, False))
     assert proj_route._projection_params_match(legacy) is False
     assert proj_route._projection_params_match(umap_changed) is True
     assert proj_route._projection_params_match(pca) is True
+
+
+def test_projection_params_match_detects_compaction_mismatch(monkeypatch):
+    """A layout compacted under the old default is refit, not silently served.
+
+    ``compact`` used not to be stamped at all, so a compacted layout was
+    indistinguishable from an uncompacted one and the mismatch could never
+    force a recompute (issue #3056).
+    """
+    import numpy as np
+
+    from vtsearch.routes import projection as proj_route
+    from vtscore.projection.params import ProjectionParams
+    from vtscore.projection.umap_projection import Projection
+
+    coords = np.zeros((3, 2), dtype=np.float32)
+    ids = [0, 1, 2]
+    compacted = Projection("p", ids, coords, "umap", 15, 0.1, True)
+    uncompacted = Projection("p", ids, coords, "umap", 15, 0.1, False)
+    unstamped = Projection("p", ids, coords, "umap", 15, 0.1, None)
+
+    monkeypatch.setattr(proj_route, "_projection_params", lambda ctx=None: ProjectionParams(15, 0.1, False))
+    assert proj_route._projection_params_match(uncompacted) is True
+    assert proj_route._projection_params_match(compacted) is False
+    # Unstamped reads as compacted — what it was when nothing recorded it.
+    assert proj_route._projection_params_match(unstamped) is False
+
+    # ...and the guard is symmetric: with compaction back on, the uncompacted
+    # layout is the stale one.
+    monkeypatch.setattr(proj_route, "_projection_params", lambda ctx=None: ProjectionParams(15, 0.1, True))
+    assert proj_route._projection_params_match(compacted) is True
+    assert proj_route._projection_params_match(unstamped) is True
+    assert proj_route._projection_params_match(uncompacted) is False
 
 
 class TestProjectionLabels:

--- a/tests/datasets/test_load_projection_stage.py
+++ b/tests/datasets/test_load_projection_stage.py
@@ -27,7 +27,7 @@ def _make_tracker():
     return LoadingTasksTracker().create_task("proj_task", "test")
 
 
-def _fake_fit_projection(matrix, ids, on_progress=None):
+def _fake_fit_projection(matrix, ids, on_progress=None, **kwargs):
     """Cheap stand-in for UMAP: a seeded random 2-D layout.
 
     Calls ``on_progress`` once so the stage's progress wiring is exercised.
@@ -88,6 +88,103 @@ class TestBuildProjectionStage:
         assert args[0] == "ds-123"
         assert args[1] is ctx._projection
         assert args[2] is ctx._pyramids["square"]
+
+    def test_threads_the_resolved_params_into_the_fit(self):
+        """The ingest fit uses the same knobs the route would resolve (#3056).
+
+        Not ``fit_projection``'s signature defaults: a layout fit under
+        different params than the route resolves is discarded on the first
+        Browse open (so the opt-in pre-build bought nothing), or — when the
+        mismatch happens to be invisible — served under knobs nobody chose.
+        """
+        ctx = self._ctx_with_embeddings("proj_stage_params")
+        captured: dict = {}
+
+        def _capturing(matrix, ids, on_progress=None, **kwargs):
+            captured.update(kwargs)
+            return _fake_fit_projection(matrix, ids, on_progress=on_progress)
+
+        with (
+            patch("vtscore.projection.fit_projection", side_effect=_capturing),
+            patch("vtscore.datasets.stages.projection._persist_projection_to_container"),
+        ):
+            _build_projection_stage(ctx, _make_tracker(), "ds-params")
+
+        # The fixtures are CLAP-embedded, whose swept defaults are (15, 0.10).
+        assert captured["n_neighbors"] == 15
+        assert captured["min_dist"] == 0.10
+        # And compaction is off, matching PROJECTION_COMPACT_DEFAULT — the
+        # signature default used to be True here.
+        assert captured["compact"] is False
+
+    def test_tuned_embedder_params_reach_the_fit(self):
+        """A SigLIP dataset is fit under SigLIP's swept knobs, not the globals."""
+        ctx = DatasetContext("proj_stage_siglip")
+        rng = np.random.default_rng(3)
+        for cid in (1, 2, 3, 4):
+            ctx.medias[cid] = {
+                "id": cid,
+                "media_type": "image",
+                "embedder": "siglip",
+                "embeddings": {"siglip": rng.standard_normal(8).astype(np.float32)},
+            }
+        captured: dict = {}
+
+        def _capturing(matrix, ids, on_progress=None, **kwargs):
+            captured.update(kwargs)
+            return _fake_fit_projection(matrix, ids, on_progress=on_progress)
+
+        with (
+            patch("vtscore.projection.fit_projection", side_effect=_capturing),
+            patch("vtscore.datasets.stages.projection._persist_projection_to_container"),
+        ):
+            _build_projection_stage(ctx, _make_tracker(), "ds-siglip")
+
+        assert (captured["n_neighbors"], captured["min_dist"]) == (10, 0.05)
+
+    def test_pre_built_layout_survives_the_routes_freshness_check(self):
+        """An ingest-built layout is kept — and kept uncompacted — on first Browse.
+
+        The end-to-end shape of #3056: the ingest stage stamps what it fit
+        under, and the route's persisted-layout guard asks for exactly those
+        knobs.  An untuned embedder is the interesting case, because there the
+        old mismatch was *invisible* — the stale layout passed the guard and
+        the user silently got the compacted arrangement the sweep measured as
+        worse.
+        """
+        from vtsearch.routes.projection import _projection_params_match
+
+        ctx = DatasetContext("proj_stage_untuned")
+        rng = np.random.default_rng(11)
+        for cid in (1, 2, 3, 4):
+            ctx.medias[cid] = {
+                "id": cid,
+                "media_type": "text",
+                "embedder": "e5",
+                "embeddings": {"e5": rng.standard_normal(8).astype(np.float32)},
+            }
+
+        def _stamping(matrix, ids, on_progress=None, **kwargs):
+            """A fake fit that records its knobs the way the real one does."""
+            coords = np.random.default_rng(1).standard_normal((len(ids), 2)).astype(np.float32)
+            return Projection(
+                "untuned-pid",
+                list(ids),
+                coords,
+                "umap",
+                kwargs.get("n_neighbors"),
+                kwargs.get("min_dist"),
+                kwargs.get("compact"),
+            )
+
+        with (
+            patch("vtscore.projection.fit_projection", side_effect=_stamping),
+            patch("vtscore.datasets.stages.projection._persist_projection_to_container"),
+        ):
+            _build_projection_stage(ctx, _make_tracker(), "ds-untuned")
+
+        assert ctx._projection.compact is False
+        assert _projection_params_match(ctx._projection, ctx) is True
 
     def test_empty_dataset_is_noop(self):
         ctx = DatasetContext("proj_stage_empty")

--- a/tests_lib/projection/test_params.py
+++ b/tests_lib/projection/test_params.py
@@ -1,0 +1,101 @@
+"""Tests for the shared Browse-projection parameter resolver.
+
+Both fit paths — the on-demand ``POST /api/projection/build`` route and the
+opt-in ingest-time ``build_projection`` load stage — resolve their UMAP knobs
+here, so this is the single place the per-embedder tuned defaults, the operator
+override, and the compaction default are decided (issue #3056).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+from vtscore import config
+from vtscore.config import (
+    PROJECTION_COMPACT_DEFAULT,
+    PROJECTION_MIN_DIST,
+    PROJECTION_N_NEIGHBORS,
+)
+from vtscore.projection.params import projection_embedder_for, resolve_projection_params
+from vtscore.state.core import DatasetContext
+
+
+def _ctx(embedder: str) -> DatasetContext:
+    """A tiny context whose medias carry a single *embedder* vector."""
+    ctx = DatasetContext(f"params_{embedder}")
+    rng = np.random.default_rng(0)
+    for cid in (1, 2, 3):
+        ctx.medias[cid] = {
+            "id": cid,
+            "media_type": "audio",
+            "embedder": embedder,
+            "embeddings": {embedder: rng.standard_normal(8).astype(np.float32)},
+        }
+    return ctx
+
+
+@pytest.fixture
+def override_settings(monkeypatch):
+    """Install a ``CoreConfig`` builder with overridden projection knobs."""
+
+    def _apply(**fields):
+        base = config.CoreConfig.from_settings()
+        replaced = dataclasses.replace(base, **fields)
+        monkeypatch.setattr(config, "_core_config_builder", lambda _path=None: replaced)
+
+    return _apply
+
+
+class TestProjectionEmbedderFor:
+    def test_reads_the_medias_primary_embedder(self):
+        assert projection_embedder_for(_ctx("siglip")) == "siglip"
+
+    def test_no_context_or_no_medias_is_none(self):
+        assert projection_embedder_for(None) is None
+        assert projection_embedder_for(DatasetContext("params_empty")) is None
+
+
+class TestResolveProjectionParams:
+    def test_tuned_embedder_gets_its_swept_defaults(self):
+        params = resolve_projection_params(_ctx("siglip"))
+        assert (params.n_neighbors, params.min_dist) == (10, 0.05)
+
+    def test_audio_embedder_gets_its_own_tuned_pair(self):
+        params = resolve_projection_params(_ctx("clap"))
+        assert (params.n_neighbors, params.min_dist) == (15, 0.10)
+
+    def test_untuned_embedder_falls_back_to_the_globals(self):
+        params = resolve_projection_params(_ctx("siglip2"))
+        assert params.n_neighbors == PROJECTION_N_NEIGHBORS
+        assert params.min_dist == PROJECTION_MIN_DIST
+
+    def test_no_context_falls_back_to_the_globals(self):
+        params = resolve_projection_params()
+        assert params.n_neighbors == PROJECTION_N_NEIGHBORS
+        assert params.min_dist == PROJECTION_MIN_DIST
+
+    def test_compaction_follows_the_shipped_default(self):
+        assert resolve_projection_params(_ctx("clip")).compact is PROJECTION_COMPACT_DEFAULT
+
+    def test_explicit_override_beats_the_tuned_default(self, override_settings):
+        override_settings(projection_n_neighbors=42, projection_min_dist=0.33)
+        params = resolve_projection_params(_ctx("siglip"))
+        assert (params.n_neighbors, params.min_dist) == (42, 0.33)
+
+    def test_setting_left_at_the_global_default_is_not_an_override(self, override_settings):
+        # Only ``min_dist`` is genuinely overridden; ``n_neighbors`` sits at the
+        # global default, which means "unset" and lets the tuned value apply.
+        override_settings(projection_n_neighbors=PROJECTION_N_NEIGHBORS, projection_min_dist=0.33)
+        params = resolve_projection_params(_ctx("siglip"))
+        assert (params.n_neighbors, params.min_dist) == (10, 0.33)
+
+    def test_unavailable_core_config_falls_back_to_the_tuned_defaults(self, monkeypatch):
+        # A library-only process with no builder installed must still fit, not
+        # raise: no override is readable, so the tuned defaults stand.
+        monkeypatch.setattr(config, "_core_config_builder", None)
+        params = resolve_projection_params(_ctx("clip"))
+        assert (params.n_neighbors, params.min_dist) == (10, 0.05)
+        assert params.compact is PROJECTION_COMPACT_DEFAULT

--- a/tests_lib/projection/test_persistence.py
+++ b/tests_lib/projection/test_persistence.py
@@ -190,10 +190,10 @@ def test_remove_projections_no_entries_is_noop(tmp_path):
 
 
 def test_umap_params_round_trip(tmp_path):
-    """A UMAP projection's stamped n_neighbors / min_dist survive persistence."""
+    """A UMAP projection's stamped n_neighbors / min_dist / compact survive persistence."""
     path = _make_container(tmp_path)
     base = _make_projection()
-    proj = Projection(base.projection_id, base.ids, base.coords, "umap", 30, 0.25)
+    proj = Projection(base.projection_id, base.ids, base.coords, "umap", 30, 0.25, False)
     append_projection(path, proj, build_pyramid(proj, n_levels=3))
     loaded = read_projection(path)
     assert loaded is not None
@@ -201,14 +201,32 @@ def test_umap_params_round_trip(tmp_path):
     assert proj2.method == "umap"
     assert proj2.n_neighbors == 30
     assert proj2.min_dist == 0.25
+    assert proj2.compact is False
+
+
+def test_compact_true_round_trips_distinctly_from_unstamped(tmp_path):
+    """``compact=True`` persists as True, not as the unstamped ``None``.
+
+    The freshness check reads an unstamped ``compact`` as "compacted", so the
+    two are equivalent *there* — but they must stay distinguishable on disk,
+    or a deliberately compacted layout is indistinguishable from a legacy one.
+    """
+    path = _make_container(tmp_path)
+    base = _make_projection()
+    proj = Projection(base.projection_id, base.ids, base.coords, "umap", 15, 0.1, True)
+    append_projection(path, proj, build_pyramid(proj, n_levels=3))
+    loaded = read_projection(path)
+    assert loaded is not None
+    assert loaded[0].compact is True
 
 
 def test_projection_without_params_reads_back_none(tmp_path):
     """A layout stored with no stamped knobs (PCA fallback / legacy) reads None."""
     path = _make_container(tmp_path)
-    proj = _make_projection()  # n_neighbors / min_dist default to None
+    proj = _make_projection()  # n_neighbors / min_dist / compact default to None
     append_projection(path, proj, build_pyramid(proj, n_levels=3))
     loaded = read_projection(path)
     assert loaded is not None
     assert loaded[0].n_neighbors is None
     assert loaded[0].min_dist is None
+    assert loaded[0].compact is None

--- a/tests_lib/projection/test_umap_projection.py
+++ b/tests_lib/projection/test_umap_projection.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import vtscore.projection.umap_projection as up
+from vtscore.config import PROJECTION_COMPACT_DEFAULT
 from vtscore.projection.umap_projection import Projection, fit_projection
 
 # Several tests below run *real* umap-learn fits (tiny matrices, but the first
@@ -110,7 +111,7 @@ def _clustered_matrix(per: int = 40, d: int = 12, seed: int = 0) -> np.ndarray:
     return np.concatenate([c + rng.standard_normal((per, d)).astype(np.float32) for c in centres])
 
 
-def test_compaction_on_by_default_moves_clusters_together():
+def test_compaction_moves_clusters_together():
     mat = _clustered_matrix(seed=5)
     ids = list(range(mat.shape[0]))
     packed = fit_projection(mat, ids, n_neighbors=10, random_state=3, compact=True)
@@ -118,8 +119,8 @@ def test_compaction_on_by_default_moves_clusters_together():
     assert packed.method == "umap" and loose.method == "umap"
     assert packed.coords.shape == loose.coords.shape
 
-    # Default compaction must actually change the layout (close the oceans):
-    # the packed bbox is no larger than the raw UMAP bbox.
+    # Compaction must actually change the layout (close the oceans): the packed
+    # bbox is no larger than the raw UMAP bbox.
     def _area(c):
         span = c.max(axis=0) - c.min(axis=0)
         return float(span[0] * span[1])
@@ -128,9 +129,24 @@ def test_compaction_on_by_default_moves_clusters_together():
     assert _area(packed.coords) <= _area(loose.coords) + 1e-3
 
 
+def test_compaction_defaults_to_the_shipped_default():
+    """``fit_projection``'s own default is ``PROJECTION_COMPACT_DEFAULT``.
+
+    The signature used to hardcode ``True`` while the app shipped ``False``, so
+    a caller that passed nothing (the ingest-time pre-build) got a layout
+    nobody configured — see issue #3056.
+    """
+    mat = _clustered_matrix(seed=5)
+    ids = list(range(mat.shape[0]))
+    implicit = fit_projection(mat, ids, n_neighbors=10, random_state=3)
+    explicit = fit_projection(mat, ids, n_neighbors=10, random_state=3, compact=PROJECTION_COMPACT_DEFAULT)
+    assert implicit.compact is PROJECTION_COMPACT_DEFAULT
+    assert np.allclose(implicit.coords, explicit.coords)
+
+
 def test_compaction_preserves_finiteness_and_dtype():
     mat = _clustered_matrix(seed=6)
-    proj = fit_projection(mat, list(range(mat.shape[0])), n_neighbors=10, random_state=2)
+    proj = fit_projection(mat, list(range(mat.shape[0])), n_neighbors=10, random_state=2, compact=True)
     assert proj.coords.dtype == np.float32
     assert np.isfinite(proj.coords).all()
 
@@ -204,18 +220,24 @@ def test_umap_fit_emits_elapsed_heartbeats(monkeypatch):
 
 def test_umap_fit_stamps_params():
     """A UMAP fit records the knobs it used on the returned projection."""
-    proj = fit_projection(_matrix(30, 16, seed=5), list(range(30)), n_neighbors=12, min_dist=0.3, random_state=1)
+    proj = fit_projection(
+        _matrix(30, 16, seed=5), list(range(30)), n_neighbors=12, min_dist=0.3, random_state=1, compact=True
+    )
     assert proj.method == "umap"
     assert proj.n_neighbors == 12
     assert proj.min_dist == 0.3
+    # Compaction is stamped too, or a layout packed under an old default is
+    # indistinguishable from one fit under the current one (issue #3056).
+    assert proj.compact is True
 
 
 def test_pca_fallback_leaves_params_none():
-    """The small-N PCA fallback ignores the knobs, so it stamps neither."""
-    proj = fit_projection(_matrix(6, 8, seed=3), list(range(6)), min_n_for_umap=10)
+    """The small-N PCA fallback ignores the knobs, so it stamps none of them."""
+    proj = fit_projection(_matrix(6, 8, seed=3), list(range(6)), min_n_for_umap=10, compact=True)
     assert proj.method == "pca"
     assert proj.n_neighbors is None
     assert proj.min_dist is None
+    assert proj.compact is None
 
 
 def test_remove_ids_preserves_stamped_params():
@@ -223,8 +245,9 @@ def test_remove_ids_preserves_stamped_params():
     from vtscore.projection.umap_projection import remove_ids
 
     coords = _matrix(5, 2, seed=1)
-    proj = Projection("pid", [0, 1, 2, 3, 4], coords, "umap", 20, 0.2)
+    proj = Projection("pid", [0, 1, 2, 3, 4], coords, "umap", 20, 0.2, False)
     culled = remove_ids(proj, [1, 3])
     assert culled.n_neighbors == 20
     assert culled.min_dist == 0.2
+    assert culled.compact is False
     assert culled.ids == [0, 2, 4]

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -423,6 +423,18 @@ class CoreConfig:
     autofind_exporter: str = ""
     autofind_exporter_field_values: dict[str, dict[str, str]] = field(default_factory=dict)
 
+    # Operator overrides for the Browse projection's UMAP knobs (server-tier
+    # ``projection_n_neighbors`` / ``projection_min_dist``).  Mirrored onto the
+    # library tier because *both* fit paths — the on-demand route and the
+    # ingest-time pre-build, which cannot import ``vtsearch.settings`` — resolve
+    # their params through :func:`vtscore.projection.params.resolve_projection_params`.
+    # A value equal to the global constant above means "no override", which is
+    # what lets ``PROJECTION_DEFAULTS_BY_EMBEDDER`` apply.  Defaulted here so
+    # library-only ``CoreConfig(...)`` constructions without the app shim keep
+    # working unchanged.
+    projection_n_neighbors: int = PROJECTION_N_NEIGHBORS
+    projection_min_dist: float = PROJECTION_MIN_DIST
+
     # Per-media-type opt-in to the generative signpost captioner (image VLM /
     # audio captioner) instead of the default zero-shot tag texts.  ``{}`` (the
     # default) means tags for every type.  Read by

--- a/vtscore/datasets/stages/projection.py
+++ b/vtscore/datasets/stages/projection.py
@@ -98,6 +98,14 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
     frozen layout (see ``vtscore.projection.signpost_prep``), cache
     everything on the context, and persist it into the dataset container.
 
+    "Mirrors" includes the knobs: the fit goes through the same
+    :func:`~vtscore.projection.params.resolve_projection_params` the route
+    uses, never ``fit_projection``'s signature defaults.  A layout fit under
+    different params than the route would resolve is worse than no pre-build
+    at all — the first Browse open either throws it away (params mismatch, so
+    UMAP re-runs and the opt-in bought nothing) or keeps a layout nobody
+    configured.
+
     Best-effort by contract: the dataset is already registered and usable
     before this runs, so any failure here (including a cancellation during
     the fit) must leave the dataset intact and merely fall back to the lazy
@@ -109,6 +117,7 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
         bin_shape_for_media_type,
         build_pyramid,
         fit_projection,
+        resolve_projection_params,
     )
 
     def _progress(current: int, total: int, message: str) -> None:
@@ -135,7 +144,15 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
     def _on_fit_progress(status: str, message: str, current: int, total: int) -> None:
         _progress(current, total, message or "Building 2-D projection…")
 
-    proj = fit_projection(matrix, list(sorted_ids), on_progress=_on_fit_progress)
+    params = resolve_projection_params(ctx)
+    proj = fit_projection(
+        matrix,
+        list(sorted_ids),
+        n_neighbors=params.n_neighbors,
+        min_dist=params.min_dist,
+        compact=params.compact,
+        on_progress=_on_fit_progress,
+    )
     _progress(0, 1, "Building tile pyramid…")
     # The bin shape is a fixed property of the dataset's media type — squares
     # for browsable-thumbnail media (image/video/document), hexes otherwise —

--- a/vtscore/detectors/positives_browse.py
+++ b/vtscore/detectors/positives_browse.py
@@ -141,12 +141,27 @@ def build_positives_browse_context(
 
     # Project + tile up front so the browse view lands on a ready layout.
     from vtscore.embedding.matrix import get_embedding_matrix
-    from vtscore.projection import bin_shape_for_media_type, build_pyramid, fit_projection
+    from vtscore.projection import (
+        bin_shape_for_media_type,
+        build_pyramid,
+        fit_projection,
+        resolve_projection_params,
+    )
 
     if on_progress is not None:
         on_progress(total, total, "Building projection…")
     sorted_ids, matrix = get_embedding_matrix(ctx, ctx.routed_embedder("score"))
-    proj = fit_projection(matrix, sorted_ids)
+    # Same knobs as every other Browse layout — this map is ephemeral, but a
+    # positives map fit under different params than the dataset browse would
+    # read as a different arrangement of the same items.
+    params = resolve_projection_params(ctx)
+    proj = fit_projection(
+        matrix,
+        sorted_ids,
+        n_neighbors=params.n_neighbors,
+        min_dist=params.min_dist,
+        compact=params.compact,
+    )
     pyr = build_pyramid(proj, bin_shape=bin_shape_for_media_type(media_type))
     ctx._projection = proj
     ctx._pyramids[pyr.bin_shape] = pyr

--- a/vtscore/projection/__init__.py
+++ b/vtscore/projection/__init__.py
@@ -23,6 +23,11 @@ from __future__ import annotations
 from vtscore.projection.compaction import compact_layout
 from vtscore.projection.hexbin import hex_center, hexbin_assign
 from vtscore.projection.labels import RegionLabel, RegionLabelSet, make_label_set
+from vtscore.projection.params import (
+    ProjectionParams,
+    projection_embedder_for,
+    resolve_projection_params,
+)
 from vtscore.projection.pyramid import (
     BIN_SHAPES,
     DEFAULT_BIN_SHAPE,
@@ -41,11 +46,14 @@ from vtscore.projection.umap_projection import Projection, fit_projection, remov
 
 __all__ = [
     "Projection",
+    "ProjectionParams",
     "RegionLabel",
     "RegionLabelSet",
     "compact_layout",
     "fit_projection",
     "make_label_set",
+    "projection_embedder_for",
+    "resolve_projection_params",
     "Pyramid",
     "Tile",
     "HexCell",

--- a/vtscore/projection/params.py
+++ b/vtscore/projection/params.py
@@ -1,0 +1,133 @@
+"""The one resolver for the knobs a Browse projection is fit under.
+
+Two code paths fit the VTSBrowse projection — the on-demand
+``POST /api/projection/build`` route and the opt-in ingest-time
+``build_projection`` load stage — and they must agree.  When they don't, the
+ingest fit is either thrown away on the first Browse open (its stamped params
+fail the persisted-layout check, UMAP re-runs, and the whole point of the
+pre-build is lost) or silently kept under knobs nobody chose.  So neither path
+resolves anything itself; both call :func:`resolve_projection_params`.
+
+Resolution order for ``n_neighbors`` / ``min_dist``:
+
+1. an explicit ``ServerSettings`` override, read off the library-tier
+   :class:`~vtscore.config.CoreConfig` (the app populates its
+   ``projection_n_neighbors`` / ``projection_min_dist`` fields from the
+   settings file).  "Explicit" means a value that *differs* from the global
+   config default, so an operator who deliberately picks the global value
+   simply gets it;
+2. the per-embedder tuned default
+   (:data:`~vtscore.config.PROJECTION_DEFAULTS_BY_EMBEDDER`), keyed off the
+   embedder whose vectors the projection is actually fit on;
+3. the global config default.
+
+``compact`` is not a user-facing setting at all: it is always
+:data:`~vtscore.config.PROJECTION_COMPACT_DEFAULT` (off since the Part 1 sweep
+— see ``docs/plans/vtsbrowse-empirical-tuning.md``).  It is resolved here
+anyway so that "the params this layout was fit under" is a single value both
+paths thread into ``fit_projection`` and stamp onto the frozen
+:class:`~vtscore.projection.umap_projection.Projection`.
+
+Reading ``CoreConfig`` is best-effort: a library-only process with no app
+config builder installed falls back to the tuned/global defaults rather than
+failing a fit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from vtscore.config import (
+    PROJECTION_COMPACT_DEFAULT,
+    PROJECTION_DEFAULTS_BY_EMBEDDER,
+    PROJECTION_MIN_DIST,
+    PROJECTION_N_NEIGHBORS,
+)
+
+if TYPE_CHECKING:
+    from vtscore.state.core import DatasetContext
+
+
+@dataclass(frozen=True)
+class ProjectionParams:
+    """The resolved knobs one Browse projection is fit under.
+
+    Passed straight into :func:`~vtscore.projection.umap_projection.fit_projection`
+    and stamped onto the resulting layout, so a persisted projection can be
+    compared field-for-field against what the active configuration would
+    produce today.
+    """
+
+    n_neighbors: int
+    min_dist: float
+    compact: bool
+
+
+def projection_embedder_for(ctx: DatasetContext | None) -> str | None:
+    """The embedder whose vectors this dataset's projection is fit on.
+
+    The projection clusters in the score embedder's space (patch-else-text; the
+    v3 routing table), which for the common single-embedder dataset resolves to
+    the dataset's primary embedder.  This is the key
+    :data:`~vtscore.config.PROJECTION_DEFAULTS_BY_EMBEDDER` is looked up under,
+    so it must name the embedder that actually produced the matrix — not
+    whichever one happens to be listed first.
+    """
+    if ctx is None:
+        return None
+    try:
+        routed = ctx.routed_embedder("score")
+        if routed:
+            return routed
+        medias = getattr(ctx, "medias", None)
+        if not medias:
+            return None
+        from vtscore.embedding.media_vectors import primary_embedder_name  # noqa: PLC0415
+
+        return primary_embedder_name(next(iter(medias.values())))
+    except Exception:  # pragma: no cover - defensive; fall back to the globals
+        return None
+
+
+def _settings_overrides() -> tuple[int | None, float | None]:
+    """The operator's explicit ``(n_neighbors, min_dist)`` overrides, if any.
+
+    ``None`` in a slot means "left at the global default", i.e. no override —
+    which is what lets the per-embedder tuned value apply.  A missing or
+    un-built :class:`~vtscore.config.CoreConfig` reads as "no override".
+    """
+    try:
+        from vtscore.config import CoreConfig  # noqa: PLC0415
+
+        cfg = CoreConfig.from_settings()
+        n = int(cfg.projection_n_neighbors)
+        d = float(cfg.projection_min_dist)
+    except Exception:
+        return None, None
+    return (
+        n if n != PROJECTION_N_NEIGHBORS else None,
+        d if d != PROJECTION_MIN_DIST else None,
+    )
+
+
+def resolve_projection_params(ctx: DatasetContext | None = None) -> ProjectionParams:
+    """Resolve the UMAP knobs *ctx*'s Browse projection should be fit under.
+
+    See the module docstring for the resolution order.  Safe to call from
+    either tier and from a background worker thread; it only reads
+    configuration.
+    """
+    embedder = projection_embedder_for(ctx)
+    tuned_n, tuned_d = PROJECTION_DEFAULTS_BY_EMBEDDER.get(
+        embedder or "", (PROJECTION_N_NEIGHBORS, PROJECTION_MIN_DIST)
+    )
+    override_n, override_d = _settings_overrides()
+    return ProjectionParams(
+        n_neighbors=override_n if override_n is not None else tuned_n,
+        min_dist=override_d if override_d is not None else tuned_d,
+        compact=PROJECTION_COMPACT_DEFAULT,
+    )
+
+
+__all__ = ["ProjectionParams", "projection_embedder_for", "resolve_projection_params"]

--- a/vtscore/projection/persistence.py
+++ b/vtscore/projection/persistence.py
@@ -23,6 +23,7 @@ def _pyramid_to_meta(projection: Projection, pyramid: Pyramid) -> dict[str, Any]
         "method": projection.method,
         "n_neighbors": projection.n_neighbors,
         "min_dist": projection.min_dist,
+        "compact": projection.compact,
         "bin_shape": pyramid.bin_shape,
         "base_radius": pyramid.base_radius,
         "tile_span": pyramid.tile_span,
@@ -61,6 +62,10 @@ def _rebuild_from_npz_arrays(
         method=meta["method"],
         n_neighbors=meta.get("n_neighbors"),
         min_dist=meta.get("min_dist"),
+        # Containers written before compaction was stamped have no ``compact``
+        # key; ``None`` marks them as "unknown", which the freshness check reads
+        # as compacted (what the default was when they were written).
+        compact=meta.get("compact"),
     )
 
     levels = [LevelMeta(level=lm["level"], radius=lm["radius"], n_cells=lm["n_cells"]) for lm in meta["levels"]]

--- a/vtscore/projection/umap_projection.py
+++ b/vtscore/projection/umap_projection.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from vtscore.config import PROJECTION_MIN_DIST, PROJECTION_N_NEIGHBORS
+from vtscore.config import PROJECTION_COMPACT_DEFAULT, PROJECTION_MIN_DIST, PROJECTION_N_NEIGHBORS
 
 # Matches the ingest progress-callback shape (status, message, current, total).
 ProgressCallback = Callable[[str, str, int, int], None]
@@ -66,6 +66,13 @@ class Projection:
     #: containers written before the params were recorded.
     n_neighbors: int | None = None
     min_dist: float | None = None
+    #: Whether :func:`~vtscore.projection.compaction.compact_layout` was applied
+    #: after the fit.  Stamped for the same reason as the UMAP knobs: without it
+    #: a layout compacted under the old default is indistinguishable from one
+    #: fit under the current (off) default, so the mismatch can never force a
+    #: recompute.  ``None`` on the PCA / trivial fallbacks (never compacted) and
+    #: on legacy containers, which predate the stamp and were compacted.
+    compact: bool | None = None
 
     @property
     def bounds(self) -> tuple[float, float, float, float]:
@@ -98,7 +105,13 @@ def remove_ids(projection: Projection, remove: Iterable[int]) -> Projection:
     else:
         new_coords = projection.coords
     return Projection(
-        projection.projection_id, new_ids, new_coords, projection.method, projection.n_neighbors, projection.min_dist
+        projection.projection_id,
+        new_ids,
+        new_coords,
+        projection.method,
+        projection.n_neighbors,
+        projection.min_dist,
+        projection.compact,
     )
 
 
@@ -192,7 +205,7 @@ def fit_projection(
     min_dist: float = PROJECTION_MIN_DIST,
     min_n_for_umap: int = 10,
     random_state: int | None = None,
-    compact: bool = True,
+    compact: bool = PROJECTION_COMPACT_DEFAULT,
     on_progress: ProgressCallback | None = None,
 ) -> Projection:
     """Project the ``(N, d)`` embedding *matrix* to a frozen 2-D :class:`Projection`.
@@ -206,12 +219,23 @@ def fit_projection(
     path); pass an int for a reproducible fit.  ``on_progress`` receives coarse
     ``(status, message, current, total)`` milestones if provided.
 
-    ``compact`` (default ``True``) post-processes the UMAP layout with
+    ``compact`` post-processes the UMAP layout with
     :func:`~vtscore.projection.compaction.compact_layout`, sliding clusters
     together as rigid bodies to close the empty "oceans" UMAP leaves between
     islands so the canvas isn't mostly dead water after zoom-to-fit.  It only
     engages on the UMAP path (the PCA/trivial fallbacks are too small to pack)
-    and preserves each cluster's internal shape exactly.
+    and preserves each cluster's internal shape exactly.  It defaults to
+    :data:`~vtscore.config.PROJECTION_COMPACT_DEFAULT` (off — the Part 1 sweep
+    measured it as a consistent loss), so a caller that passes nothing gets the
+    shipped behaviour rather than a second, disagreeing default.
+
+    Every knob the layout was fit under is stamped onto the returned
+    :class:`Projection`, so a persisted layout can later be compared against
+    what the active configuration would produce.  Production callers should
+    resolve those knobs with
+    :func:`~vtscore.projection.params.resolve_projection_params` rather than
+    relying on these signature defaults, which know nothing about the dataset's
+    embedder or the operator's settings.
     """
     # Force an owned, writable copy (not just contiguity/dtype): *matrix* may
     # be a read-only mmap view (S1's embedding-matrix sidecar,
@@ -267,4 +291,4 @@ def fit_projection(
         _progress("projecting", "compacting layout", 0, 0)
         coords = compact_layout(coords)
 
-    return Projection(projection_id, list(ids), coords, "umap", n_neighbors, min_dist)
+    return Projection(projection_id, list(ids), coords, "umap", n_neighbors, min_dist, compact)

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -291,52 +291,32 @@ def _pkl_path_for(dataset_id: str) -> str | None:
     return entry.get("pkl_path") or None
 
 
-def _primary_embedder_for(ctx) -> str | None:
-    """The embedder that produced this dataset's projected matrix (its primary)."""
-    if ctx is None or not getattr(ctx, "medias", None):
-        return None
-    try:
-        from vtscore.embedding.media_vectors import primary_embedder_name
+def _projection_params(ctx=None):
+    """The knobs a projection for *ctx* should be fit under.
 
-        return primary_embedder_name(ctx.medias)
-    except Exception:  # pragma: no cover - defensive; fall back to globals
-        return None
-
-
-def _umap_params(ctx=None) -> tuple[int, float]:
-    """The active UMAP knobs (``n_neighbors``, ``min_dist``).
-
-    Resolution: an explicit ``ServerSettings`` override wins; otherwise the
-    per-embedder default (:data:`~vtscore.config.PROJECTION_DEFAULTS_BY_EMBEDDER`)
-    keyed off the dataset's primary embedder; otherwise the global config default.
-    An "explicit override" is a setting that differs from the global default, so an
-    operator who deliberately picks the global value simply gets it.
+    A thin pass-through to the shared resolver
+    (:func:`vtscore.projection.params.resolve_projection_params`), which the
+    ingest-time pre-build stage calls too — the two paths must agree or the
+    pre-built layout is discarded (or silently served) on the first Browse
+    open.  Kept as a named seam here so the freshness check and the build
+    entry points read the same way, and so tests can substitute it.
     """
-    from vtsearch import settings
-    from vtscore.config import (
-        PROJECTION_DEFAULTS_BY_EMBEDDER,
-        PROJECTION_MIN_DIST,
-        PROJECTION_N_NEIGHBORS,
-    )
+    from vtscore.projection.params import resolve_projection_params
 
-    s_n = settings.get_projection_n_neighbors()
-    s_d = settings.get_projection_min_dist()
-    emb = _primary_embedder_for(ctx)
-    default = (PROJECTION_N_NEIGHBORS, PROJECTION_MIN_DIST)
-    d_n, d_d = PROJECTION_DEFAULTS_BY_EMBEDDER.get(emb, default) if emb else default
-    n = s_n if s_n != PROJECTION_N_NEIGHBORS else d_n
-    d = s_d if s_d != PROJECTION_MIN_DIST else d_d
-    return n, d
+    return resolve_projection_params(ctx)
 
 
 def _projection_params_match(proj, ctx=None) -> bool:
-    """Whether a persisted projection was fit under the active UMAP params.
+    """Whether a persisted projection was fit under the active params.
 
     Non-UMAP layouts (the PCA / trivial fallbacks for tiny datasets) ignore
     these knobs, so they always match.  A legacy projection with no stamped
-    params is assumed to have used the config defaults, so it only mismatches
-    once an operator has changed a setting away from the default — exactly
-    when its layout must be recomputed.
+    UMAP params is assumed to have used the config defaults, so it only
+    mismatches once an operator has changed a setting away from the default —
+    exactly when its layout must be recomputed.  An unstamped ``compact``
+    reads as ``True``: compaction was on by default for every layout written
+    before it was recorded, so those layouts correctly fail against today's
+    ``compact=False`` and get refit.
     """
     import math
 
@@ -346,8 +326,14 @@ def _projection_params_match(proj, ctx=None) -> bool:
 
     stored_n = proj.n_neighbors if proj.n_neighbors is not None else PROJECTION_N_NEIGHBORS
     stored_d = proj.min_dist if proj.min_dist is not None else PROJECTION_MIN_DIST
-    want_n, want_d = _umap_params(ctx)
-    return stored_n == want_n and math.isclose(stored_d, want_d, abs_tol=1e-9)
+    stored_c = getattr(proj, "compact", None)
+    stored_c = True if stored_c is None else bool(stored_c)
+    want = _projection_params(ctx)
+    return (
+        stored_n == want.n_neighbors
+        and math.isclose(stored_d, want.min_dist, abs_tol=1e-9)
+        and stored_c == want.compact
+    )
 
 
 def _try_load_persisted(ctx, sorted_ids: list[int], bin_shape: str) -> dict | None:
@@ -505,10 +491,7 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, for
     mat_copy = matrix.copy()
     ids_copy = list(sorted_ids)
     dataset_id = ctx.dataset_id
-    from vtscore.config import PROJECTION_COMPACT_DEFAULT
-
-    compact = PROJECTION_COMPACT_DEFAULT
-    n_neighbors, min_dist = _umap_params(ctx)
+    params = _projection_params(ctx)
 
     def _run(job):
         with thread_dataset_context(ctx):
@@ -520,9 +503,9 @@ def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, for
             proj = fit_projection(
                 mat_copy,
                 ids_copy,
-                n_neighbors=n_neighbors,
-                min_dist=min_dist,
-                compact=compact,
+                n_neighbors=params.n_neighbors,
+                min_dist=params.min_dist,
+                compact=params.compact,
                 on_progress=_on_progress,
             )
             job.set_phase(2, _BUILD_STEPS, "building pyramid")
@@ -631,10 +614,7 @@ def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str,
 
     mat_copy = matrix.copy()
     ids_copy = list(sorted_ids)
-    from vtscore.config import PROJECTION_COMPACT_DEFAULT
-
-    compact = PROJECTION_COMPACT_DEFAULT
-    n_neighbors, min_dist = _umap_params(ctx)
+    params = _projection_params(ctx)
 
     def _run(job):
         with thread_dataset_context(ctx):
@@ -646,9 +626,9 @@ def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str,
             proj = fit_projection(
                 mat_copy,
                 ids_copy,
-                n_neighbors=n_neighbors,
-                min_dist=min_dist,
-                compact=compact,
+                n_neighbors=params.n_neighbors,
+                min_dist=params.min_dist,
+                compact=params.compact,
                 on_progress=_on_progress,
             )
             job.set_phase(2, _BUILD_STEPS, "building pyramid")

--- a/vtsearch/shim/__init__.py
+++ b/vtsearch/shim/__init__.py
@@ -218,6 +218,8 @@ def build_core_config(settings_path: str | Path | None = None) -> CoreConfig:
         autofind_exporter_field_values={
             name: dict(vals) for name, vals in _settings.get_autofind_exporter_field_values().items()
         },
+        projection_n_neighbors=_settings.get_projection_n_neighbors(),
+        projection_min_dist=_settings.get_projection_min_dist(),
         signpost_captioner=dict(_settings.get_browse_signpost_captioner()),
         signpost_vocab={mt: list(terms) for mt, terms in _settings.get_browse_signpost_vocab().items()},
     )


### PR DESCRIPTION
Closes #3056

## Problem

Two paths fit the Browse projection and they disagreed.

- **Route** (`POST /api/projection/build`) resolved the tuned per-embedder params and passed `compact=PROJECTION_COMPACT_DEFAULT` (`False`).
- **Ingest stage** (`vtscore/datasets/stages/projection.py`) called `fit_projection(matrix, ids, on_progress=…)` with no params at all, taking the signature defaults `(15, 0.1, compact=True)` — despite a docstring claiming it "mirrors the on-demand path".

So on a **tuned** embedder the pre-built layout failed the freshness check and was refit on the first Browse open (the opt-in paid for a fit nobody used), and on an **untuned** one it *matched* and was kept — compacted, contradicting the shipped default and giving the user the arrangement the Part 1 sweep measured as worse (−2.0% taxonomy separability, 5–6% on the structure guards). The second case was silent because `Projection` never stamped `compact`, so `_projection_params_match` structurally could not detect a compaction mismatch.

## Changes

**One resolver, called by every fit path.** New `vtscore/projection/params.py` exposes `resolve_projection_params(ctx) -> ProjectionParams`, owning the whole resolution order: an explicit `ServerSettings` override ▸ the per-embedder tuned default (`PROJECTION_DEFAULTS_BY_EMBEDDER`) ▸ the global config default; `compact` always follows `PROJECTION_COMPACT_DEFAULT`. It is now the only place any of that is decided — the route (full + subset builds), the ingest pre-build stage, and the detector positives-map browse all call it.

**The library tier can see the operator's override.** `projection_n_neighbors` / `projection_min_dist` are mirrored onto `CoreConfig` (the existing `signpost_vocab` / `signpost_captioner` pattern), so the ingest stage honours a `ServerSettings` override without importing `vtsearch.settings` — which it never did before, under either option the issue sketched.

**`compact` is stamped and checked.** `Projection` carries a `compact` field, persisted and round-tripped through the container, and `_projection_params_match` compares it. An unstamped legacy value reads as `True` (what it was), so a layout packed under the old default now fails the check and is refit instead of being served indefinitely.

**`fit_projection`'s own default is `PROJECTION_COMPACT_DEFAULT`**, so the function default and the shipped default no longer disagree; its docstring points production callers at the resolver rather than at its signature defaults.

## Also fixed on the way

The per-embedder lookup never worked *on any path*: `_primary_embedder_for` passed the whole `ctx.medias` dict to `primary_embedder_name`, which takes a **single** media — so it always returned `None` and `PROJECTION_DEFAULTS_BY_EMBEDDER` was dead code. The resolver keys off the embedder that actually produces the projected matrix (the routed `"score"` embedder, else the medias' primary).

## Compatibility

Existing persisted layouts change freshness verdict, by design:

- `clip` / `siglip` / `siglip_l` datasets: stamped `(15, 0.1)` now mismatches the tuned `(10, 0.05)` and refits once on the next Browse open.
- Any layout stamped `compact=True` or unstamped now mismatches `compact=False` and refits once.

Both are one-time recomputes that replace a layout with the one the config actually asks for.

## Tests

- `tests_lib/projection/test_params.py` (new) — tuned vs untuned embedder, no-context fallback, explicit override beats the tuned default, an override left *at* the global default is not an override, and a missing `CoreConfig` builder degrades to the defaults instead of failing a fit.
- `tests/datasets/test_load_projection_stage.py` — the ingest stage threads the resolved knobs into the fit (CLAP → `(15, 0.10)`, SigLIP → `(10, 0.05)`, `compact=False`), and an untuned-embedder pre-build passes the route's own freshness check.
- `tests/api/test_projection.py` — the guard detects a compaction mismatch in both directions, and reads unstamped as compacted.
- `tests_lib/projection/test_persistence.py` / `test_umap_projection.py` — `compact` round-trips (and stays distinct from unstamped), is stamped on the UMAP path and left `None` on the PCA fallback, survives `remove_ids`, and `fit_projection`'s implicit default now equals `PROJECTION_COMPACT_DEFAULT`.

`./run-tests.sh`: 8263 passed, 6 skipped, 2 xpassed.

## Docs

`docs/plans/vtsbrowse-empirical-tuning.md`: dropped the #3056 pointer and repointed the knob table at the shared resolver.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGXqHBa1naHEHnT7URgCys)_