### PR TITLE
Enforce server-side authentication for enforcing login providers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -713,6 +713,8 @@ The `LoginProvider` ABC defines the interface:
 | `get_user(request)` | Return the username for the current request |
 | `is_authenticated(request)` | Check if the request carries valid credentials |
 | `login_required()` | Whether the frontend should show a login screen |
+| `enforce_auth()` | Whether the server 401s unauthenticated `/api/*` requests (default `True`) |
+| `www_authenticate()` | Optional `WWW-Authenticate` challenge for those 401s |
 | `get_user_data_dir(username, base)` | Return per-user data directory |
 | `status_dict(request)` | JSON dict for `/api/auth/status` |
 
@@ -722,8 +724,15 @@ OAuth, LDAP, or any auth scheme without modifying route code.
 
 ### Per-request user context
 
-The `before_request` middleware in `app.py` populates `g.user` on every
-request via the active provider's `get_user()`. Routes access the current
+The `before_request` middleware (`vtsearch/hooks.py`) populates `g.user` on
+every request via the active provider's `get_user()`, then — when the
+provider's `enforce_auth()` is true — rejects unauthenticated `/api/*`
+requests with a JSON 401 (`code: "auth_required"`) before any route
+handler runs. Only `/api/auth/status`, `/api/auth/login`, and
+`/api/auth/logout` are exempt, so the SPA can always reach the login
+screen. `DefaultLoginProvider` authenticates every request (single-user
+deployments never see a 401); `TrivialLoginProvider` opts out of
+enforcement because it is passwordless by design. Routes access the current
 user via `get_current_user()`. Outside a Flask request context (CLI,
 background threads) it falls back to the thread-local set by
 `thread_user(...)`, then to `"default"`.

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -57,6 +57,17 @@ class MyProvider(LoginProvider):
         return base_data_dir / username
 ```
 
+**Enforcement is on by default.** The base class's `enforce_auth()` returns
+`True`, which makes the server reject any `/api/*` request for which your
+`is_authenticated()` returns false with a JSON 401 (only the
+`/api/auth/status|login|logout` allowlist is exempt). You get real gating
+without writing a decorator or touching routes — but it also means
+`is_authenticated()` must return `True` for every request you intend to
+serve. Override `enforce_auth()` to return `False` only if anonymous access
+is a deliberate mode (see `TrivialLoginProvider`). Optionally override
+`www_authenticate()` (e.g. return `"Bearer"`) to set the 401's
+`WWW-Authenticate` header.
+
 **Validate any username you didn't construct yourself.** A username returned
 by `get_user()` becomes a path component (`data/<username>/`) *and* the
 confinement root for server-file path validation, which resolves `..` away
@@ -312,6 +323,9 @@ See [Authentication Providers](#authentication-providers) above.
 - [ ] Create a new module (e.g. `vtsearch/auth/my_provider.py`)
 - [ ] Subclass `LoginProvider` from `vtsearch.auth`
 - [ ] Implement `get_user(request)` and `is_authenticated(request)`
+- [ ] Decide on `enforce_auth()`: the inherited `True` makes the server 401
+      unauthenticated API requests; override to `False` only if anonymous
+      access is intended
 - [ ] Override `login_required()` if the frontend should show a login screen
 - [ ] Override `get_user_data_dir(username, base_data_dir)` for per-user isolation
 - [ ] Call `set_login_provider(MyProvider())` at app startup (in `app.py`)

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -30,6 +30,36 @@ determines what `/api/auth/*` does and whether the SPA shows a login screen.
 The SPA switches on `login_required` from `GET /api/auth/status`: when `true`
 it shows a login screen at startup, otherwise it goes straight to the app.
 
+### Server-side enforcement
+
+Whether the server actually *rejects* unauthenticated requests is governed by
+the provider's `enforce_auth()`, checked by a `before_request` hook: when it
+is true and `is_authenticated(request)` is false, any `/api/*` request is
+refused with **401** `{"error": "Authentication required", "code":
+"auth_required"}` before reaching a route handler. Exactly three paths are
+exempt — `/api/auth/status`, `/api/auth/login`, `/api/auth/logout` — so a
+client can always discover the auth mode and log in; everything else,
+including `/api/auth/huggingface/*`, sits behind the gate. Non-API paths
+(the SPA shell, favicons) are never gated.
+
+Per provider:
+
+- **`default`** — `enforce_auth()` is `True` but every request is
+  authenticated, so single-user deployments never see a 401. No change from
+  historical behaviour.
+- **`trivial`** — `enforce_auth()` is **`False`**, deliberately: the provider
+  is passwordless, so a server-side gate would add no security (any caller
+  could simply log in as any name first). Requests without a session cookie
+  are served as `"anonymous"`; the login screen is an identity switcher, not
+  an access control.
+- **`api_key`** — enforced. Requests without a valid Bearer token get 401
+  with `WWW-Authenticate: Bearer`. This is the provider to use when access
+  must actually be gated.
+- **Custom providers** — enforced by default (`enforce_auth()` inherits
+  `True`); a provider whose `is_authenticated()` raises fails **closed**
+  (401). Override `enforce_auth()` to `False` only if anonymous access is a
+  legitimate mode for your deployment.
+
 ### Usernames are path components
 
 Any provider that returns a per-user data dir puts the username on the

--- a/tests/api/test_auth_enforcement.py
+++ b/tests/api/test_auth_enforcement.py
@@ -1,0 +1,155 @@
+"""Tests for server-side auth enforcement (issue #2946).
+
+The ``_enforce_auth`` before_request hook rejects unauthenticated
+``/api/*`` requests with 401 when the active provider's ``enforce_auth()``
+is true. Verifies:
+
+- DefaultLoginProvider (single-user) is completely unaffected.
+- TrivialLoginProvider deliberately opts out (anonymous fallback intact).
+- ApiKeyLoginProvider actually gates the API: no/invalid Bearer -> 401,
+  valid Bearer -> served as the mapped user.
+- The auth-status/login/logout allowlist and non-API paths pass through.
+- A custom provider inherits enforcement (secure by default) and fails
+  closed when its checks raise.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from vtsearch.auth import (
+    ApiKeyLoginProvider,
+    LoginProvider,
+    TrivialLoginProvider,
+    set_login_provider,
+)
+
+
+def _api_key_provider(tmp_path, key: str = "sekrit-key", username: str = "alice") -> ApiKeyLoginProvider:
+    keys_file = tmp_path / "api_keys.json"
+    keys_file.write_text(json.dumps({hashlib.sha256(key.encode()).hexdigest(): username}))
+    return ApiKeyLoginProvider(keys_file=keys_file)
+
+
+class TestDefaultProviderUnaffected:
+    """Single-user deployments (no --login flag) must see zero change."""
+
+    def test_api_served_without_credentials(self, client):
+        resp = client.get("/api/medias/ids")
+        assert resp.status_code == 200
+
+    def test_auth_status_reports_authenticated(self, client):
+        resp = client.get("/api/auth/status")
+        assert resp.status_code == 200
+        assert resp.get_json()["authenticated"] is True
+
+
+class TestTrivialProviderOptsOut:
+    """Trivial login is passwordless; its gate is UI-only by design."""
+
+    def test_enforce_auth_is_false(self):
+        assert TrivialLoginProvider().enforce_auth() is False
+
+    def test_anonymous_api_access_still_served(self, client):
+        set_login_provider(TrivialLoginProvider())
+        resp = client.get("/api/medias/ids")
+        assert resp.status_code == 200
+
+
+class TestApiKeyEnforcement:
+    """ApiKeyLoginProvider gates every /api/* path outside the allowlist."""
+
+    def test_no_token_is_401(self, client, tmp_path):
+        set_login_provider(_api_key_provider(tmp_path))
+        resp = client.get("/api/medias/ids")
+        assert resp.status_code == 401
+        data = resp.get_json()
+        assert data["error"] == "Authentication required"
+        assert data["code"] == "auth_required"
+        assert resp.headers["WWW-Authenticate"] == "Bearer"
+
+    def test_invalid_token_is_401(self, client, tmp_path):
+        set_login_provider(_api_key_provider(tmp_path))
+        resp = client.get("/api/medias/ids", headers={"Authorization": "Bearer wrong-key"})
+        assert resp.status_code == 401
+
+    def test_valid_token_is_served(self, client, tmp_path):
+        set_login_provider(_api_key_provider(tmp_path, key="k123", username="alice"))
+        resp = client.get("/api/medias/ids", headers={"Authorization": "Bearer k123"})
+        assert resp.status_code == 200
+
+    def test_auth_status_exempt(self, client, tmp_path):
+        set_login_provider(_api_key_provider(tmp_path))
+        resp = client.get("/api/auth/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["provider"] == "api_key"
+        assert data["authenticated"] is False
+
+    def test_login_logout_exempt(self, client, tmp_path):
+        # api_key doesn't support login/logout, but the endpoints must be
+        # reachable (they answer 400, not 401) so the SPA can probe them.
+        set_login_provider(_api_key_provider(tmp_path))
+        assert client.post("/api/auth/login", json={"username": "x"}).status_code == 400
+        assert client.post("/api/auth/logout").status_code == 400
+
+    def test_spa_shell_not_gated(self, client, tmp_path):
+        set_login_provider(_api_key_provider(tmp_path))
+        resp = client.get("/")
+        assert resp.status_code == 200
+
+    def test_huggingface_endpoints_are_gated(self, client, tmp_path):
+        # hf_auth_bp configures a server-wide HuggingFace token; it must sit
+        # behind the same gate as the rest of the API (issue #2946).
+        set_login_provider(_api_key_provider(tmp_path))
+        assert client.get("/api/auth/huggingface/status").status_code == 401
+
+    def test_unknown_api_path_is_401_not_404(self, client, tmp_path):
+        # The gate runs before routing, so unauthenticated probes can't map
+        # the API surface via 404-vs-405 differences.
+        set_login_provider(_api_key_provider(tmp_path))
+        assert client.get("/api/definitely/not/a/route").status_code == 401
+
+
+class TestCustomProviderDefaults:
+    """Custom providers are enforced by construction (fail closed)."""
+
+    def test_enforce_auth_defaults_to_true(self):
+        class HeaderProvider(LoginProvider):
+            name = "header"
+
+            def get_user(self, request):
+                return "anonymous"
+
+            def is_authenticated(self, request):
+                return False
+
+        assert HeaderProvider().enforce_auth() is True
+
+    def test_unauthenticated_custom_provider_is_401(self, client):
+        class HeaderProvider(LoginProvider):
+            name = "header"
+
+            def get_user(self, request):
+                return request.headers.get("X-User") or "anonymous"
+
+            def is_authenticated(self, request):
+                return "X-User" in request.headers
+
+        set_login_provider(HeaderProvider())
+        assert client.get("/api/medias/ids").status_code == 401
+        assert client.get("/api/medias/ids", headers={"X-User": "bob"}).status_code == 200
+
+    def test_raising_provider_fails_closed(self, client):
+        class BrokenProvider(LoginProvider):
+            name = "broken"
+
+            def get_user(self, request):
+                return "anonymous"
+
+            def is_authenticated(self, request):
+                raise RuntimeError("backend down")
+
+        set_login_provider(BrokenProvider())
+        assert client.get("/api/medias/ids").status_code == 401

--- a/tests/api/test_auth_enforcement.py
+++ b/tests/api/test_auth_enforcement.py
@@ -95,9 +95,12 @@ class TestApiKeyEnforcement:
         assert client.post("/api/auth/logout").status_code == 400
 
     def test_spa_shell_not_gated(self, client, tmp_path):
+        # The guard only covers /api/*. Whether "/" is 200 or 404 here
+        # depends on whether the Angular bundle is built (see
+        # tests/core/test_frontend.py); what matters is that it isn't 401.
         set_login_provider(_api_key_provider(tmp_path))
         resp = client.get("/")
-        assert resp.status_code == 200
+        assert resp.status_code != 401
 
     def test_huggingface_endpoints_are_gated(self, client, tmp_path):
         # hf_auth_bp configures a server-wide HuggingFace token; it must sit

--- a/vtsearch/auth/__init__.py
+++ b/vtsearch/auth/__init__.py
@@ -67,6 +67,31 @@ class LoginProvider(ABC):
         """Whether the frontend should show a login screen at startup."""
         return False
 
+    def enforce_auth(self) -> bool:
+        """Whether the server rejects unauthenticated ``/api/*`` requests.
+
+        When ``True``, the ``_enforce_auth`` before_request hook (see
+        ``vtsearch.hooks``) aborts with 401 whenever
+        :meth:`is_authenticated` is ``False``, except for the small
+        allowlist of auth endpoints the SPA needs to reach the login
+        screen. Defaults to ``True`` so a custom provider that implements
+        real credentials is gated by construction — forgetting to override
+        this must fail closed, not silently serve every request as
+        ``"anonymous"``. Providers for which anonymous access is a
+        legitimate mode (``TrivialLoginProvider``) override this to
+        ``False``; ``DefaultLoginProvider`` is unaffected either way since
+        it authenticates every request.
+        """
+        return True
+
+    def www_authenticate(self) -> str | None:
+        """Challenge value for the ``WWW-Authenticate`` header on 401s.
+
+        Return the auth scheme clients should use (e.g. ``"Bearer"``), or
+        ``None`` to omit the header (cookie/session providers).
+        """
+        return None
+
     def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
         """Return the data directory for *username*.
 
@@ -208,6 +233,15 @@ class TrivialLoginProvider(LoginProvider):
     def login_required(self) -> bool:
         return True
 
+    def enforce_auth(self) -> bool:
+        # Deliberately not enforced server-side: this provider has no
+        # password, so a 401 gate adds no security (any caller could just
+        # POST /api/auth/login first) — it would only break the SPA's
+        # pre-login boot requests and the documented anonymous fallback.
+        # The login screen is a UX affordance for switching identities,
+        # not an access control.
+        return False
+
     def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
         return base_data_dir / username
 
@@ -236,10 +270,11 @@ class ApiKeyLoginProvider(LoginProvider):
             print('key:', k); \\
             print('hash:', hashlib.sha256(k.encode()).hexdigest())"
 
-    Requests without a valid bearer token resolve to the username
-    ``"anonymous"`` and ``is_authenticated`` returns ``False``.  This
-    provider does not show a login UI (``login_required`` is ``False``);
-    it is meant for headless callers that send the header directly.
+    Requests without a valid bearer token are rejected with 401 by the
+    ``_enforce_auth`` hook (``enforce_auth()`` is inherited ``True``),
+    except for the auth-status/login allowlist.  This provider does not
+    show a login UI (``login_required`` is ``False``); it is meant for
+    headless callers that send the header directly.
     """
 
     name = "api_key"
@@ -348,6 +383,9 @@ class ApiKeyLoginProvider(LoginProvider):
 
     def login_required(self) -> bool:
         return False
+
+    def www_authenticate(self) -> str | None:
+        return "Bearer"
 
     def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
         return base_data_dir / username

--- a/vtsearch/hooks.py
+++ b/vtsearch/hooks.py
@@ -2,8 +2,9 @@
 
 Holds the ``before_request`` / ``after_request`` / ``teardown_request``
 handlers that used to live inline in ``app.py``: per-request id + user +
-dataset/detector context resolution, the in-handler marker, and the
-API-response ``Cache-Control`` / ``X-Request-Id`` shaping.
+dataset/detector context resolution, server-side auth enforcement, the
+in-handler marker, and the API-response ``Cache-Control`` /
+``X-Request-Id`` shaping.
 
 ``app.py`` calls :func:`register_hooks` to wire them onto its module-level
 ``app``. Registration is done explicitly (rather than via ``@app.before_request``
@@ -70,6 +71,67 @@ def _set_user_context():
     except Exception:
         logging.getLogger(__name__).exception("Login provider get_user failed")
         g.user = "default"
+
+
+# API paths reachable without credentials when the active provider enforces
+# auth. Exactly what the SPA needs to render the login screen and log in:
+# `/api/auth/status` tells it whether a login is required at all, and
+# login/logout are how credentials are established/cleared in the first
+# place. Deliberately exact-match (not a prefix): `/api/auth/huggingface/*`
+# configures a server-wide HuggingFace token and must stay behind the gate.
+_AUTH_EXEMPT_PATHS = frozenset(
+    {
+        "/api/auth/status",
+        "/api/auth/login",
+        "/api/auth/logout",
+    }
+)
+
+
+def _enforce_auth():
+    """Reject unauthenticated ``/api/*`` requests for enforcing providers.
+
+    ``_set_user_context`` above only *identifies* the caller; this hook is
+    the *authentication* step (see issue #2946): when the active provider's
+    ``enforce_auth()`` is true and ``is_authenticated(request)`` is false,
+    the request is aborted with a JSON 401 before any route handler (or the
+    lock-taking state sync below) runs. Non-API paths (the SPA shell,
+    favicons) and the ``_AUTH_EXEMPT_PATHS`` allowlist pass through.
+
+    ``DefaultLoginProvider`` authenticates every request, so single-user
+    deployments never hit the 401 branch. ``TrivialLoginProvider`` opts out
+    via ``enforce_auth() -> False``. A provider that raises from either
+    check fails **closed** (401): a broken enforcing provider must not
+    degrade to serving everyone as anonymous — which was the bug this hook
+    exists to fix. The built-in providers' checks cannot raise, so the
+    fail-closed path is unreachable for stock deployments.
+    """
+    from flask import request
+
+    from vtsearch.auth import get_login_provider
+
+    path = request.path
+    if not path.startswith("/api/") or path in _AUTH_EXEMPT_PATHS:
+        return None
+    provider = get_login_provider()
+    try:
+        if not provider.enforce_auth() or provider.is_authenticated(request):
+            return None
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "Login provider auth check failed; rejecting request (fail closed)"
+        )
+    from vtsearch.routes._shared import error_response
+
+    body, status = error_response("Authentication required", 401, code="auth_required")
+    body.status_code = status
+    try:
+        challenge = provider.www_authenticate()
+    except Exception:
+        challenge = None
+    if challenge:
+        body.headers["WWW-Authenticate"] = challenge
+    return body
 
 
 def _set_request_context():
@@ -209,6 +271,7 @@ def register_hooks(app) -> None:
     """
     app.before_request(_set_request_id)
     app.before_request(_set_user_context)
+    app.before_request(_enforce_auth)
     app.before_request(_set_request_context)
     app.teardown_request(_clear_in_request_handler_marker)
     app.after_request(_no_cache_api)

--- a/vtsearch/hooks.py
+++ b/vtsearch/hooks.py
@@ -118,9 +118,7 @@ def _enforce_auth():
         if not provider.enforce_auth() or provider.is_authenticated(request):
             return None
     except Exception:
-        logging.getLogger(__name__).exception(
-            "Login provider auth check failed; rejecting request (fail closed)"
-        )
+        logging.getLogger(__name__).exception("Login provider auth check failed; rejecting request (fail closed)")
     from vtsearch.routes._shared import error_response
 
     body, status = error_response("Authentication required", 401, code="auth_required")


### PR DESCRIPTION
Closes #2946

## Problem

The request lifecycle only *identified* the caller, never *authenticated* them: `is_authenticated()` / `login_required()` were advisory metadata for the UI. With `--login api_key`, a request with no (or an invalid) Bearer token was simply served as `"anonymous"` — an operator who set up API keys to gate access got no gating at all. The `hf_auth_bp` blueprint (server-wide HuggingFace token) was likewise ungated.

## Fix

A new `_enforce_auth` `before_request` hook (`vtsearch/hooks.py`) rejects unauthenticated `/api/*` requests with a JSON **401** (`code: "auth_required"`) whenever the active provider's new `enforce_auth()` is true, before any route handler (or the lock-taking state sync) runs. Only `/api/auth/status`, `/api/auth/login`, and `/api/auth/logout` are exempt — exactly what a client needs to discover the auth mode and log in. Non-API paths (SPA shell, favicons) are never gated.

Provider behavior:

- **`DefaultLoginProvider`** (what nearly everyone runs, no `--login` flag): **zero change.** `is_authenticated()` is always true, so the 401 branch is unreachable — single-user desktop use is completely unaffected.
- **`ApiKeyLoginProvider`**: now genuinely enforced. Missing/invalid Bearer → 401 with `WWW-Authenticate: Bearer` (via a new optional `www_authenticate()` provider method).
- **`TrivialLoginProvider`**: explicitly opts out (`enforce_auth() → False`). It is passwordless by design, so a server-side gate adds no security (any caller could just log in as any name first) and would only break the documented anonymous fallback and the SPA's pre-login boot requests. The rationale is recorded in the code and docs.
- **Custom providers**: `enforce_auth()` defaults to `True` on the ABC, so a provider that implements real credentials is gated by construction — the failure mode the issue describes (implementing `is_authenticated()` per EXTENDING.md and getting no enforcement) can no longer happen silently. A provider that raises from its checks fails **closed** (401), never open.

## Tests

New `tests/api/test_auth_enforcement.py` covers: default provider unaffected; trivial opt-out; api_key 401 on missing/invalid token, 200 on valid token, allowlist reachable, HuggingFace endpoints gated, unknown API paths 401 (no route-mapping via 404s); custom providers enforced by default and failing closed on exceptions.

`./run-tests.sh` full suite: **ALL 8262 TESTS PASSED** (6 skipped), including the frontend build, Vitest suite, and the eval/app sync gate.

## Docs

Updated `docs/api/auth.md` (new "Server-side enforcement" section), `docs/ARCHITECTURE.md` (provider method table + per-request middleware description), and `docs/EXTENDING.md` (provider guide + checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tavNfeCfmvL2Esf4BfEdf

---
_Generated by [Claude Code](https://claude.ai/code/session_017tavNfeCfmvL2Esf4BfEdf)_