### PR TITLE
Guard dynamic plugin-field option fetches against stale responses

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -608,6 +608,14 @@ The frontend wiring is fully automatic:
 3. While a fetch is in-flight the dropdown is disabled and shows
    `Loading…`.  Errors raised by `get_field_options()` are surfaced
    inline next to the field.
+4. Only the newest response for a field is applied.  Every form shares
+   `DynamicFieldOptions`
+   (`frontend/src/app/utils/dynamic-field-options.ts`), which stamps a
+   token per dispatch and drops any response a newer request — or a
+   switch to a different importer — has superseded.  A slow
+   `get_field_options()` is therefore safe: it can never repopulate a
+   dropdown the user has already navigated away from, and it can never
+   auto-select a value for an importer that is no longer on screen.
 
 API contract: `POST /api/dataset/import/<name>/options` with body
 `{"field_key": "...", "values": {...}}` returns

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.html
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.html
@@ -67,37 +67,37 @@
               class="form-input"
               [attr.list]="'field-' + field.key + '-list'"
               [(ngModel)]="formValues[field.key]"
-              [disabled]="!!dynamicFieldLoading()[field.key]"
-              [placeholder]="dynamicFieldLoading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+              [disabled]="!!fieldOptions.loading()[field.key]"
+              [placeholder]="fieldOptions.loading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
               (ngModelChange)="onFieldChanged(field.key)"
             />
             <datalist [id]="'field-' + field.key + '-list'">
-              @for (opt of optionsFor(field); track opt.value) {
+              @for (opt of fieldOptions.optionsFor(field); track opt.value) {
                 <option [value]="opt.value">{{ opt.label }}</option>
               }
             </datalist>
-            @if (field.dynamic_options && dynamicFieldError()[field.key]) {
-              <p class="error-text">{{ dynamicFieldError()[field.key] }}</p>
+            @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+              <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
             }
           } @else if (field.field_type === 'select') {
             <select
               [id]="'field-' + field.key"
               class="form-select"
               [(ngModel)]="formValues[field.key]"
-              [disabled]="!!dynamicFieldLoading()[field.key] || (!!field.dynamic_options && optionsFor(field).length === 0)"
+              [disabled]="!!fieldOptions.loading()[field.key] || (!!field.dynamic_options && fieldOptions.optionsFor(field).length === 0)"
               (ngModelChange)="onFieldChanged(field.key)"
             >
-              @if (field.dynamic_options && dynamicFieldLoading()[field.key]) {
+              @if (field.dynamic_options && fieldOptions.loading()[field.key]) {
                 <option [value]="''" disabled>Loading…</option>
-              } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicFieldError()[field.key]) {
+              } @else if (field.dynamic_options && fieldOptions.optionsFor(field).length === 0 && !fieldOptions.error()[field.key]) {
                 <option [value]="''" disabled>No options available</option>
               }
-              @for (opt of optionsFor(field); track opt.value) {
+              @for (opt of fieldOptions.optionsFor(field); track opt.value) {
                 <option [value]="opt.value">{{ opt.label }}</option>
               }
             </select>
-            @if (field.dynamic_options && dynamicFieldError()[field.key]) {
-              <p class="error-text">{{ dynamicFieldError()[field.key] }}</p>
+            @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+              <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
             }
           } @else if (field.key === 'dataset_name') {
             <input

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
@@ -67,7 +67,7 @@ describe('GenericFormPickerComponent', () => {
 
   it('coerces static string options into {value,label} pairs', () => {
     const staticSelect = { key: 's', field_type: 'select', options: ['x', 'y'] } as any;
-    expect(component.optionsFor(staticSelect)).toEqual([
+    expect(component.fieldOptions.optionsFor(staticSelect)).toEqual([
       { value: 'x', label: 'x' },
       { value: 'y', label: 'y' },
     ]);
@@ -91,7 +91,7 @@ describe('GenericFormPickerComponent', () => {
       allow_free_text: true,
     } as any;
     component.selectedImporter.set({ name: 'imp', fields: [field] } as any);
-    (component as any).refreshDynamicFieldOptions(field);
+    component.fieldOptions.refresh(field, component.formValues);
     httpMock
       .expectOne((req) => req.url.endsWith('/api/dataset/import/imp/options'))
       .flush({ options: [{ value: 'a', label: 'A' }] });
@@ -102,7 +102,7 @@ describe('GenericFormPickerComponent', () => {
     const field = { key: 'q', field_type: 'select', dynamic_options: true, allow_free_text: true } as any;
     component.selectedImporter.set({ name: 'imp', fields: [field] } as any);
     component.formValues['q'] = 'hand-typed';
-    (component as any).refreshDynamicFieldOptions(field);
+    component.fieldOptions.refresh(field, component.formValues);
     httpMock
       .expectOne((req) => req.url.endsWith('/api/dataset/import/imp/options'))
       .flush({ options: [{ value: 'a', label: 'A' }] });
@@ -113,7 +113,7 @@ describe('GenericFormPickerComponent', () => {
     const field = { key: 'q', field_type: 'select', dynamic_options: true } as any;
     component.selectedImporter.set({ name: 'imp', fields: [field] } as any);
     component.formValues['q'] = 'stale';
-    (component as any).refreshDynamicFieldOptions(field);
+    component.fieldOptions.refresh(field, component.formValues);
     httpMock
       .expectOne((req) => req.url.endsWith('/api/dataset/import/imp/options'))
       .flush({ options: [{ value: 'a', label: 'A' }] });
@@ -144,7 +144,7 @@ describe('GenericFormPickerComponent', () => {
     it('re-asks once a dynamic select resolves, so an opaque id can become a label', () => {
       const field = { key: 'query_id', field_type: 'select', dynamic_options: true, required: true } as any;
       component.selectedImporter.set({ name: 'imp', fields: [field] } as any);
-      (component as any).refreshDynamicFieldOptions(field);
+      component.fieldOptions.refresh(field, component.formValues);
       httpMock
         .expectOne((req) => req.url.endsWith('/api/dataset/import/imp/options'))
         .flush({ options: [{ value: 'q-8f31', label: 'Q1 Field Survey' }] });

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.ts
@@ -11,6 +11,7 @@ import { FileBrowserComponent } from '../../../../file-browser/file-browser.comp
 import { DatasetsCrudApiService } from '../../../../../services/datasets-crud-api.service';
 import { DatasetsListingsApiService } from '../../../../../services/datasets-listings-api.service';
 import { apiErrorMessage } from '../../../../../utils/api-error';
+import { DynamicFieldOptions } from '../../../../../utils/dynamic-field-options';
 import {
   CleanerInfo,
   CleanerSelection,
@@ -18,7 +19,6 @@ import {
   ClipperParameter,
   ConverterInfo,
   EmbedderInfo,
-  FieldOptions,
   ImporterField,
   ImporterInfo,
   MediaTypeInfo,
@@ -99,9 +99,14 @@ export class GenericFormPickerComponent {
 
   sourceSpecs: SourceSpec[] = [];
 
-  readonly dynamicFieldOptions = signal<Record<string, FieldOptions[]>>({});
-  readonly dynamicFieldLoading = signal<Record<string, boolean>>({});
-  readonly dynamicFieldError = signal<Record<string, string>>({});
+  /** Option lists for the selected importer's ``dynamic_options`` fields.
+   *  Auto-selecting an option is a form change like any other, and it is
+   *  exactly the case the importer's own naming exists for: only it can turn
+   *  the opaque option value back into a readable label. */
+  readonly fieldOptions = new DynamicFieldOptions(
+    (key, values) => this.datasetsCrudApi.getImporterFieldOptions(this.selectedImporter()!.name, key, values),
+    () => this.requestSuggestedDatasetName(),
+  );
 
   clipperChooserOpen = false;
   clipperChooserClippers: ClipperInfo[] = [];
@@ -183,9 +188,7 @@ export class GenericFormPickerComponent {
     this.clipperParamValues.set({});
     this.selectedEmbedder.set('');
     this.availableEmbedders.set([]);
-    this.dynamicFieldOptions.set({});
-    this.dynamicFieldLoading.set({});
-    this.dynamicFieldError.set({});
+    this.fieldOptions.reset();
     this.datasetNameDirty = false;
 
     if (importer.fields) {
@@ -227,11 +230,7 @@ export class GenericFormPickerComponent {
 
     this.resetSourceSpecs();
 
-    for (const field of importer.fields || []) {
-      if (field.dynamic_options) {
-        this.refreshDynamicFieldOptions(field);
-      }
-    }
+    this.fieldOptions.refreshAll(importer.fields || [], this.formValues);
 
     // Importers whose defaults already describe a dataset (a preselected
     // select, a remembered path) get named before the user touches
@@ -262,12 +261,7 @@ export class GenericFormPickerComponent {
   onFieldChanged(changedKey: string): void {
     const importer = this.selectedImporter();
     if (!importer?.fields) return;
-    for (const field of importer.fields) {
-      if (!field.dynamic_options) continue;
-      if (!(field.depends_on || []).includes(changedKey)) continue;
-      this.formValues[field.key] = '';
-      this.refreshDynamicFieldOptions(field);
-    }
+    this.fieldOptions.refreshDependentsOf(changedKey, importer.fields, this.formValues);
     if (changedKey !== 'dataset_name') {
       this.requestSuggestedDatasetName();
     }
@@ -294,48 +288,6 @@ export class GenericFormPickerComponent {
   private requestSuggestedDatasetName(): void {
     if (this.datasetNameDirty) return;
     this.suggestedNameRequests.next();
-  }
-
-  private refreshDynamicFieldOptions(field: ImporterField): void {
-    const importer = this.selectedImporter();
-    if (!importer) return;
-    const key = field.key;
-    this.dynamicFieldLoading.update((m) => ({ ...m, [key]: true }));
-    this.dynamicFieldError.update((m) => ({ ...m, [key]: '' }));
-    this.datasetsCrudApi.getImporterFieldOptions(importer.name, key, { ...this.formValues }).subscribe({
-      next: (res) => {
-        const options: FieldOptions[] = res.options || [];
-        this.dynamicFieldOptions.update((m) => ({ ...m, [key]: options }));
-        this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
-        const current = this.formValues[key];
-        const inList = options.some((o) => o.value === String(current));
-        // Strict selects clear a value the new list no longer offers; a
-        // free-text combobox keeps whatever the user typed.
-        if (current && !inList && !field.allow_free_text) {
-          this.formValues[key] = '';
-        }
-        if (!this.formValues[key] && field.required && !field.allow_free_text && options.length > 0) {
-          this.formValues[key] = options[0].value;
-        }
-        // Auto-selecting an option is a form change like any other, and it
-        // is exactly the case the importer's own naming exists for: only it
-        // can turn the opaque option value back into a readable label.
-        this.requestSuggestedDatasetName();
-      },
-      error: (err) => {
-        this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
-        this.dynamicFieldError.update((m) => ({ ...m, [key]: apiErrorMessage(err, 'Could not load options') }));
-        this.dynamicFieldOptions.update((m) => ({ ...m, [key]: [] }));
-      },
-    });
-  }
-
-  optionsFor(field: ImporterField): FieldOptions[] {
-    if (field.dynamic_options) {
-      return this.dynamicFieldOptions()[field.key] || [];
-    }
-    // Static options are plain strings; render each as its own label.
-    return (field.options || []).map((o) => ({ value: o, label: o }));
   }
 
   /** Fetch the cleanup gates registered for *mediaType* and seed the

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -251,18 +251,18 @@
                       [attr.list]="'nmm-' + field.key + '-list'"
                       [(ngModel)]="labelImporterValues[field.key]"
                       [name]="'nmm-' + field.key"
-                      [disabled]="!!labelImporterDynamicLoading()[field.key]"
-                      [placeholder]="labelImporterDynamicLoading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+                      [disabled]="!!labelImporterFieldOptions.loading()[field.key]"
+                      [placeholder]="labelImporterFieldOptions.loading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
                       [title]="field.description || field.label || field.key"
                       (ngModelChange)="onLabelImporterFieldChanged(field.key)"
                     />
                     <datalist [id]="'nmm-' + field.key + '-list'">
-                      @for (opt of labelImporterOptionsFor(field); track opt.value) {
+                      @for (opt of labelImporterFieldOptions.optionsFor(field); track opt.value) {
                         <option [value]="opt.value">{{ opt.label }}</option>
                       }
                     </datalist>
-                    @if (field.dynamic_options && labelImporterDynamicError()[field.key]) {
-                      <p class="error-text">{{ labelImporterDynamicError()[field.key] }}</p>
+                    @if (field.dynamic_options && labelImporterFieldOptions.error()[field.key]) {
+                      <p class="error-text">{{ labelImporterFieldOptions.error()[field.key] }}</p>
                     }
                   } @else if (field.field_type === 'select') {
                     <select
@@ -272,19 +272,19 @@
                       [name]="'nmm-' + field.key"
                       [title]="field.description || field.label || field.key"
                       (ngModelChange)="onLabelImporterFieldChanged(field.key)"
-                      [disabled]="!!labelImporterDynamicLoading()[field.key] || (!!field.dynamic_options && labelImporterOptionsFor(field).length === 0)"
+                      [disabled]="!!labelImporterFieldOptions.loading()[field.key] || (!!field.dynamic_options && labelImporterFieldOptions.optionsFor(field).length === 0)"
                     >
-                      @if (field.dynamic_options && labelImporterDynamicLoading()[field.key]) {
+                      @if (field.dynamic_options && labelImporterFieldOptions.loading()[field.key]) {
                         <option value="">Loading…</option>
-                      } @else if (field.dynamic_options && labelImporterOptionsFor(field).length === 0 && !labelImporterDynamicError()[field.key]) {
+                      } @else if (field.dynamic_options && labelImporterFieldOptions.optionsFor(field).length === 0 && !labelImporterFieldOptions.error()[field.key]) {
                         <option value="">No options available</option>
                       }
-                      @for (opt of labelImporterOptionsFor(field); track opt.value) {
+                      @for (opt of labelImporterFieldOptions.optionsFor(field); track opt.value) {
                         <option [value]="opt.value">{{ opt.label }}</option>
                       }
                     </select>
-                    @if (field.dynamic_options && labelImporterDynamicError()[field.key]) {
-                      <p class="error-text">{{ labelImporterDynamicError()[field.key] }}</p>
+                    @if (field.dynamic_options && labelImporterFieldOptions.error()[field.key]) {
+                      <p class="error-text">{{ labelImporterFieldOptions.error()[field.key] }}</p>
                     }
                   } @else if (field.field_type === 'number') {
                     <input

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -430,7 +430,7 @@ describe('NewDetectorModalComponent', () => {
     expect(req.request.body.field_key).toBe('sheet');
     req.flush({ options: [{ value: 's1', label: 'Sheet 1' }] });
 
-    expect(component.labelImporterOptionsFor(field)).toEqual([{ value: 's1', label: 'Sheet 1' }]);
+    expect(component.labelImporterFieldOptions.optionsFor(field)).toEqual([{ value: 's1', label: 'Sheet 1' }]);
     // A required dynamic select auto-selects the first option.
     expect(component.labelImporterValues['sheet']).toBe('s1');
   });
@@ -461,7 +461,7 @@ describe('NewDetectorModalComponent', () => {
 
   it('coerces static string options into {value,label} pairs on the Trained tab', () => {
     const staticSelect = { key: 's', field_type: 'select', options: ['x', 'y'] } as any;
-    expect(component.labelImporterOptionsFor(staticSelect)).toEqual([
+    expect(component.labelImporterFieldOptions.optionsFor(staticSelect)).toEqual([
       { value: 'x', label: 'x' },
       { value: 'y', label: 'y' },
     ]);
@@ -489,7 +489,7 @@ describe('NewDetectorModalComponent', () => {
     const field = { key: 'q', field_type: 'select', dynamic_options: true, allow_free_text: true } as any;
     component.selectedLabelImporter = { name: 'imp', fields: [field] } as any;
     component.labelImporterValues['q'] = 'hand-typed';
-    (component as any).refreshLabelImporterFieldOptions(field);
+    component.labelImporterFieldOptions.refresh(field, component.labelImporterValues);
     httpMock
       .expectOne('/api/label-importers/field-options/imp')
       .flush({ options: [{ value: 'a', label: 'A' }] });
@@ -500,7 +500,7 @@ describe('NewDetectorModalComponent', () => {
     const field = { key: 'q', field_type: 'select', dynamic_options: true } as any;
     component.selectedLabelImporter = { name: 'imp', fields: [field] } as any;
     component.labelImporterValues['q'] = 'stale';
-    (component as any).refreshLabelImporterFieldOptions(field);
+    component.labelImporterFieldOptions.refresh(field, component.labelImporterValues);
     httpMock
       .expectOne('/api/label-importers/field-options/imp')
       .flush({ options: [{ value: 'a', label: 'A' }] });
@@ -510,12 +510,12 @@ describe('NewDetectorModalComponent', () => {
   it('surfaces a dynamic-option fetch error on the Trained tab', () => {
     const field = { key: 'q', field_type: 'select', dynamic_options: true } as any;
     component.selectedLabelImporter = { name: 'imp', fields: [field] } as any;
-    (component as any).refreshLabelImporterFieldOptions(field);
+    component.labelImporterFieldOptions.refresh(field, component.labelImporterValues);
     httpMock
       .expectOne('/api/label-importers/field-options/imp')
       .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
-    expect(component.labelImporterDynamicError()['q']).toBe('boom');
-    expect(component.labelImporterOptionsFor(field)).toEqual([]);
+    expect(component.labelImporterFieldOptions.error()['q']).toBe('boom');
+    expect(component.labelImporterFieldOptions.optionsFor(field)).toEqual([]);
   });
 
   // --- Create & Import: the background labelset-media ingest (#2703) ---

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -20,7 +20,6 @@ import {
 } from '../../../services/embedder-capability.service';
 import { MediaStateService } from '../../../services/media-state.service';
 import {
-  FieldOptions,
   ImporterField,
   ImporterInfo,
   ImporterPickerTab,
@@ -45,6 +44,7 @@ import {
 } from '../../../services/datasource-importers-api.service';
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 import { apiErrorMessage } from '../../../utils/api-error';
+import { DynamicFieldOptions } from '../../../utils/dynamic-field-options';
 
 type ModalView = 'main' | 'media-picker';
 type ModalTab = 'blank' | 'trained';
@@ -236,14 +236,12 @@ export class NewDetectorModalComponent implements OnInit {
   labelImporterValues: Record<string, string> = {};
   labelImporterFile: File | null = null;
   labelImporterFileFieldKey: string | null = null;
-  // Dynamic-field-option state for the Trained tab's label-importer form,
-  // mirroring label-importer-modal so plugins with dynamic_options /
-  // depends_on / allow_free_text render with full parity here too. Keyed by
-  // field key; signalized so the unpatched HTTP callbacks schedule CD under
-  // zoneless.
-  readonly labelImporterDynamicOptions = signal<Record<string, FieldOptions[]>>({});
-  readonly labelImporterDynamicLoading = signal<Record<string, boolean>>({});
-  readonly labelImporterDynamicError = signal<Record<string, string>>({});
+  /** Option lists for the Trained tab's label-importer form, mirroring
+   *  label-importer-modal so plugins with dynamic_options / depends_on /
+   *  allow_free_text render with full parity here too. */
+  readonly labelImporterFieldOptions = new DynamicFieldOptions((key, values) =>
+    this.labelImportersApi.getFieldOptions(this.selectedLabelImporter!.name, key, values),
+  );
 
   /** Type_id of the server's solo-mediaType restriction, or ``null`` when
    *  off. When non-null, the mediaType form-group is hidden in the
@@ -1000,9 +998,7 @@ export class NewDetectorModalComponent implements OnInit {
     this.labelImporterFile = null;
     this.labelImporterFileFieldKey = null;
     this.error.set('');
-    this.labelImporterDynamicOptions.set({});
-    this.labelImporterDynamicLoading.set({});
-    this.labelImporterDynamicError.set({});
+    this.labelImporterFieldOptions.reset();
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -1016,80 +1012,24 @@ export class NewDetectorModalComponent implements OnInit {
         this.labelImporterValues[field.key] = field.options![0];
       }
     }
-    for (const field of fields) {
-      if (field.dynamic_options) {
-        this.refreshLabelImporterFieldOptions(field);
-      }
-    }
+    this.labelImporterFieldOptions.refreshAll(fields, this.labelImporterValues);
     this.trainedView = 'form';
   }
 
-  /** Re-fetch dynamic options for any field that depends on the one the user
-   *  just changed, blanking each dependent value first so a stale selection
-   *  can't survive into the new option set. */
   onLabelImporterFieldChanged(changedKey: string): void {
-    const importer = this.selectedLabelImporter;
-    if (!importer?.fields) return;
-    for (const field of importer.fields as ImporterField[]) {
-      if (!field.dynamic_options) continue;
-      if (!(field.depends_on || []).includes(changedKey)) continue;
-      this.labelImporterValues[field.key] = '';
-      this.refreshLabelImporterFieldOptions(field);
-    }
-  }
-
-  /** Options to render for a label-importer field: the dynamically-fetched
-   *  list for a ``dynamic_options`` field, else the static strings coerced
-   *  into ``{value,label}`` pairs. */
-  labelImporterOptionsFor(field: ImporterField): FieldOptions[] {
-    if (field.dynamic_options) {
-      return this.labelImporterDynamicOptions()[field.key] || [];
-    }
-    return (field.options || []).map((o) => ({ value: o, label: o }));
-  }
-
-  private refreshLabelImporterFieldOptions(field: ImporterField): void {
-    const importer = this.selectedLabelImporter;
-    if (!importer) return;
-    const key = field.key;
-    this.labelImporterDynamicLoading.update((m) => ({ ...m, [key]: true }));
-    this.labelImporterDynamicError.update((m) => ({ ...m, [key]: '' }));
-    this.labelImportersApi
-      .getFieldOptions(importer.name, key, { ...this.labelImporterValues })
-      .subscribe({
-        next: (res) => {
-          const options: FieldOptions[] = res.options || [];
-          this.labelImporterDynamicOptions.update((m) => ({ ...m, [key]: options }));
-          this.labelImporterDynamicLoading.update((m) => ({ ...m, [key]: false }));
-          const current = this.labelImporterValues[key];
-          const inList = options.some((o) => o.value === String(current));
-          // Strict selects clear a value the new list no longer offers; a
-          // free-text combobox keeps whatever the user typed.
-          if (current && !inList && !field.allow_free_text) {
-            this.labelImporterValues[key] = '';
-          }
-          if (!this.labelImporterValues[key] && field.required && !field.allow_free_text && options.length > 0) {
-            this.labelImporterValues[key] = options[0].value;
-          }
-        },
-        error: (err) => {
-          this.labelImporterDynamicLoading.update((m) => ({ ...m, [key]: false }));
-          this.labelImporterDynamicError.update((m) => ({
-            ...m,
-            [key]: apiErrorMessage(err, 'Could not load options'),
-          }));
-          this.labelImporterDynamicOptions.update((m) => ({ ...m, [key]: [] }));
-        },
-      });
+    if (!this.selectedLabelImporter?.fields) return;
+    this.labelImporterFieldOptions.refreshDependentsOf(
+      changedKey,
+      this.selectedLabelImporterFields,
+      this.labelImporterValues,
+    );
   }
 
   backToImporterPicker(): void {
     this.trainedView = 'picker';
     this.selectedLabelImporter = null;
     this.error.set('');
-    this.labelImporterDynamicOptions.set({});
-    this.labelImporterDynamicLoading.set({});
-    this.labelImporterDynamicError.set({});
+    this.labelImporterFieldOptions.reset();
   }
 
   onLabelImporterFileSelected(event: Event, fieldName: string): void {

--- a/frontend/src/app/components/datasource-import-form/datasource-import-form.component.html
+++ b/frontend/src/app/components/datasource-import-form/datasource-import-form.component.html
@@ -71,18 +71,18 @@
           [attr.list]="'dsi-' + field.key + '-list'"
           [(ngModel)]="values[field.key]"
           [name]="'dsi-' + field.key"
-          [disabled]="!!dynamicLoading()[field.key]"
-          [placeholder]="dynamicLoading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+          [disabled]="!!fieldOptions.loading()[field.key]"
+          [placeholder]="fieldOptions.loading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
           [title]="field.description || field.label || field.key"
           (ngModelChange)="onFieldChanged(field.key)"
         />
         <datalist [id]="'dsi-' + field.key + '-list'">
-          @for (opt of optionsFor(field); track opt.value) {
+          @for (opt of fieldOptions.optionsFor(field); track opt.value) {
             <option [value]="opt.value">{{ opt.label }}</option>
           }
         </datalist>
-        @if (field.dynamic_options && dynamicError()[field.key]) {
-          <p class="error-text">{{ dynamicError()[field.key] }}</p>
+        @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+          <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
         }
       } @else if (field.field_type === 'select') {
         <select
@@ -92,19 +92,19 @@
           [name]="'dsi-' + field.key"
           [title]="field.description || field.label || field.key"
           (ngModelChange)="onFieldChanged(field.key)"
-          [disabled]="!!dynamicLoading()[field.key] || (!!field.dynamic_options && optionsFor(field).length === 0)"
+          [disabled]="!!fieldOptions.loading()[field.key] || (!!field.dynamic_options && fieldOptions.optionsFor(field).length === 0)"
         >
-          @if (field.dynamic_options && dynamicLoading()[field.key]) {
+          @if (field.dynamic_options && fieldOptions.loading()[field.key]) {
             <option value="">Loading…</option>
-          } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicError()[field.key]) {
+          } @else if (field.dynamic_options && fieldOptions.optionsFor(field).length === 0 && !fieldOptions.error()[field.key]) {
             <option value="">No options available</option>
           }
-          @for (opt of optionsFor(field); track opt.value) {
+          @for (opt of fieldOptions.optionsFor(field); track opt.value) {
             <option [value]="opt.value">{{ opt.label }}</option>
           }
         </select>
-        @if (field.dynamic_options && dynamicError()[field.key]) {
-          <p class="error-text">{{ dynamicError()[field.key] }}</p>
+        @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+          <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
         }
       } @else if (field.field_type === 'number') {
         <input

--- a/frontend/src/app/components/datasource-import-form/datasource-import-form.component.spec.ts
+++ b/frontend/src/app/components/datasource-import-form/datasource-import-form.component.spec.ts
@@ -54,7 +54,7 @@ describe('DatasourceImportFormComponent', () => {
     expect(req.request.body.field_key).toBe('sheet');
     req.flush({ options: [{ value: 's1', label: 'Sheet 1' }] });
 
-    expect(component.optionsFor(field as never)).toEqual([{ value: 's1', label: 'Sheet 1' }]);
+    expect(component.fieldOptions.optionsFor(field as never)).toEqual([{ value: 's1', label: 'Sheet 1' }]);
     expect(component.values['sheet']).toBe('s1');
   });
 
@@ -80,8 +80,8 @@ describe('DatasourceImportFormComponent', () => {
       .expectOne('/api/datasource-import/svc/options')
       .flush({ message: 'boom' }, { status: 502, statusText: 'Bad Gateway' });
 
-    expect(component.dynamicError()['q']).toBe('boom');
-    expect(component.optionsFor(field as never)).toEqual([]);
+    expect(component.fieldOptions.error()['q']).toBe('boom');
+    expect(component.fieldOptions.optionsFor(field as never)).toEqual([]);
   });
 
   it('blocks submit until every required field is filled', () => {

--- a/frontend/src/app/components/datasource-import-form/datasource-import-form.component.ts
+++ b/frontend/src/app/components/datasource-import-form/datasource-import-form.component.ts
@@ -2,12 +2,13 @@ import { ChangeDetectionStrategy, Component, effect, inject, input, output, sign
 
 import { FormsModule } from '@angular/forms';
 
-import { FieldOptions, ImporterField, ImporterInfo } from '../../models/api.models';
+import { ImporterField, ImporterInfo } from '../../models/api.models';
 import {
   DatasourceImportersApiService,
   DatasourceImportResult,
 } from '../../services/datasource-importers-api.service';
 import { apiErrorMessage } from '../../utils/api-error';
+import { DynamicFieldOptions } from '../../utils/dynamic-field-options';
 import { FieldHintIconComponent } from '../field-hint-icon/field-hint-icon.component';
 import { FileBrowserComponent } from '../file-browser/file-browser.component';
 
@@ -43,11 +44,10 @@ export class DatasourceImportFormComponent {
   fileFieldKey: string | null = null;
   readonly submitting = signal(false);
   readonly error = signal('');
-  // Dynamic-field-option state, keyed by field key; signalized so the
-  // unpatched HTTP callbacks schedule CD under zoneless.
-  readonly dynamicOptions = signal<Record<string, FieldOptions[]>>({});
-  readonly dynamicLoading = signal<Record<string, boolean>>({});
-  readonly dynamicError = signal<Record<string, string>>({});
+  /** Option lists for the importer's ``dynamic_options`` fields. */
+  readonly fieldOptions = new DynamicFieldOptions((key, values) =>
+    this.api.getFieldOptions(this.importer().name, key, values),
+  );
 
   constructor() {
     // Re-seed the form whenever the parent selects a different importer.
@@ -67,9 +67,7 @@ export class DatasourceImportFormComponent {
     this.fileFieldKey = null;
     this.submitting.set(false);
     this.error.set('');
-    this.dynamicOptions.set({});
-    this.dynamicLoading.set({});
-    this.dynamicError.set({});
+    this.fieldOptions.reset();
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -83,64 +81,11 @@ export class DatasourceImportFormComponent {
         this.values[field.key] = field.options![0];
       }
     }
-    for (const field of fields) {
-      if (field.dynamic_options) {
-        this.refreshFieldOptions(field);
-      }
-    }
+    this.fieldOptions.refreshAll(fields, this.values);
   }
 
-  /** Re-fetch dynamic options for any field that depends on the one the
-   *  user just changed, blanking each dependent value first so a stale
-   *  selection can't survive into the new option set. */
   onFieldChanged(changedKey: string): void {
-    for (const field of this.importerFields) {
-      if (!field.dynamic_options) continue;
-      if (!(field.depends_on || []).includes(changedKey)) continue;
-      this.values[field.key] = '';
-      this.refreshFieldOptions(field);
-    }
-  }
-
-  /** Options to render for a field: the dynamically-fetched list for a
-   *  ``dynamic_options`` field, else the static strings coerced into
-   *  ``{value,label}`` pairs. */
-  optionsFor(field: ImporterField): FieldOptions[] {
-    if (field.dynamic_options) {
-      return this.dynamicOptions()[field.key] || [];
-    }
-    return (field.options || []).map((o) => ({ value: o, label: o }));
-  }
-
-  private refreshFieldOptions(field: ImporterField): void {
-    const key = field.key;
-    this.dynamicLoading.update((m) => ({ ...m, [key]: true }));
-    this.dynamicError.update((m) => ({ ...m, [key]: '' }));
-    this.api.getFieldOptions(this.importer().name, key, { ...this.values }).subscribe({
-      next: (res) => {
-        const options: FieldOptions[] = res.options || [];
-        this.dynamicOptions.update((m) => ({ ...m, [key]: options }));
-        this.dynamicLoading.update((m) => ({ ...m, [key]: false }));
-        const current = this.values[key];
-        const inList = options.some((o) => o.value === String(current));
-        // Strict selects clear a value the new list no longer offers; a
-        // free-text combobox keeps whatever the user typed.
-        if (current && !inList && !field.allow_free_text) {
-          this.values[key] = '';
-        }
-        if (!this.values[key] && field.required && !field.allow_free_text && options.length > 0) {
-          this.values[key] = options[0].value;
-        }
-      },
-      error: (err) => {
-        this.dynamicLoading.update((m) => ({ ...m, [key]: false }));
-        this.dynamicError.update((m) => ({
-          ...m,
-          [key]: apiErrorMessage(err, 'Could not load options'),
-        }));
-        this.dynamicOptions.update((m) => ({ ...m, [key]: [] }));
-      },
-    });
+    this.fieldOptions.refreshDependentsOf(changedKey, this.importerFields, this.values);
   }
 
   onFileSelected(event: Event, fieldKey: string): void {

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.html
@@ -126,17 +126,17 @@
                 class="form-input"
                 [attr.list]="'lif-' + field.key + '-list'"
                 [(ngModel)]="formValues[field.key]"
-                [disabled]="!!dynamicFieldLoading()[field.key]"
-                [placeholder]="dynamicFieldLoading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+                [disabled]="!!fieldOptions.loading()[field.key]"
+                [placeholder]="fieldOptions.loading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
                 (ngModelChange)="onFormFieldChanged(field.key)"
               />
               <datalist [id]="'lif-' + field.key + '-list'">
-                @for (opt of optionsFor(field); track opt.value) {
+                @for (opt of fieldOptions.optionsFor(field); track opt.value) {
                   <option [value]="opt.value">{{ opt.label }}</option>
                 }
               </datalist>
-              @if (field.dynamic_options && dynamicFieldError()[field.key]) {
-                <p class="error-text">{{ dynamicFieldError()[field.key] }}</p>
+              @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+                <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
               }
             } @else if (field.field_type === 'select') {
               <select
@@ -144,19 +144,19 @@
                 class="form-select"
                 [(ngModel)]="formValues[field.key]"
                 (ngModelChange)="onFormFieldChanged(field.key)"
-                [disabled]="!!dynamicFieldLoading()[field.key] || (!!field.dynamic_options && optionsFor(field).length === 0)"
+                [disabled]="!!fieldOptions.loading()[field.key] || (!!field.dynamic_options && fieldOptions.optionsFor(field).length === 0)"
               >
-                @if (field.dynamic_options && dynamicFieldLoading()[field.key]) {
+                @if (field.dynamic_options && fieldOptions.loading()[field.key]) {
                   <option value="">Loading…</option>
-                } @else if (field.dynamic_options && optionsFor(field).length === 0 && !dynamicFieldError()[field.key]) {
+                } @else if (field.dynamic_options && fieldOptions.optionsFor(field).length === 0 && !fieldOptions.error()[field.key]) {
                   <option value="">No options available</option>
                 }
-                @for (opt of optionsFor(field); track opt.value) {
+                @for (opt of fieldOptions.optionsFor(field); track opt.value) {
                   <option [value]="opt.value">{{ opt.label }}</option>
                 }
               </select>
-              @if (field.dynamic_options && dynamicFieldError()[field.key]) {
-                <p class="error-text">{{ dynamicFieldError()[field.key] }}</p>
+              @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+                <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
               }
             } @else if (field.field_type === 'number') {
               <input

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
@@ -125,7 +125,7 @@ describe('LabelImporterModalComponent', () => {
   it('coerces static string options into {value,label} pairs', async () => {
     await flushInit();
     const staticSelect = { key: 's', field_type: 'select', options: ['x', 'y'] } as any;
-    expect(component.optionsFor(staticSelect)).toEqual([
+    expect(component.fieldOptions.optionsFor(staticSelect)).toEqual([
       { value: 'x', label: 'x' },
       { value: 'y', label: 'y' },
     ]);
@@ -151,7 +151,7 @@ describe('LabelImporterModalComponent', () => {
       allow_free_text: true,
     } as any;
     component.selectedImporter = { name: 'imp', fields: [field] } as any;
-    (component as any).refreshDynamicFieldOptions(field);
+    component.fieldOptions.refresh(field, component.formValues);
     httpMock
       .expectOne((req) => req.url.endsWith('/api/label-importers/field-options/imp'))
       .flush({ options: [{ value: 'a', label: 'A' }] });
@@ -163,7 +163,7 @@ describe('LabelImporterModalComponent', () => {
     const field = { key: 'q', field_type: 'select', dynamic_options: true, allow_free_text: true } as any;
     component.selectedImporter = { name: 'imp', fields: [field] } as any;
     component.formValues['q'] = 'hand-typed';
-    (component as any).refreshDynamicFieldOptions(field);
+    component.fieldOptions.refresh(field, component.formValues);
     httpMock
       .expectOne((req) => req.url.endsWith('/api/label-importers/field-options/imp'))
       .flush({ options: [{ value: 'a', label: 'A' }] });
@@ -175,7 +175,7 @@ describe('LabelImporterModalComponent', () => {
     const field = { key: 'q', field_type: 'select', dynamic_options: true } as any;
     component.selectedImporter = { name: 'imp', fields: [field] } as any;
     component.formValues['q'] = 'stale';
-    (component as any).refreshDynamicFieldOptions(field);
+    component.fieldOptions.refresh(field, component.formValues);
     httpMock
       .expectOne((req) => req.url.endsWith('/api/label-importers/field-options/imp'))
       .flush({ options: [{ value: 'a', label: 'A' }] });

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.ts
@@ -21,9 +21,10 @@ import { LabelImportersApiService } from '../../../services/label-importers-api.
 import { MediasApiService } from '../../../services/medias-api.service';
 import { ProgressEventsService } from '../../../services/progress-events.service';
 import { VoteStateService } from '../../../services/vote-state.service';
-import { FieldOptions, ImporterField, LoadingTask } from '../../../models/api.models';
+import { ImporterField, LoadingTask } from '../../../models/api.models';
 import type { LabelImporterEntry } from '../../../generated/api-client/models/label-importer-entry';
 import { apiErrorMessage } from '../../../utils/api-error';
+import { DynamicFieldOptions } from '../../../utils/dynamic-field-options';
 import { ProgressBarComponent } from '../../progress-bar/progress-bar.component';
 import { formatProgressMessage, progressBarState, type ProgressBarState } from '../../../utils/format-progress';
 
@@ -95,9 +96,10 @@ export class LabelImporterModalComponent implements OnDestroy {
       (this.importersResource.error() ? 'Failed to load label importers' : ''),
   );
   readonly successMessage = signal('');
-  readonly dynamicFieldOptions = signal<Record<string, FieldOptions[]>>({});
-  readonly dynamicFieldLoading = signal<Record<string, boolean>>({});
-  readonly dynamicFieldError = signal<Record<string, string>>({});
+  /** Option lists for the selected importer's ``dynamic_options`` fields. */
+  readonly fieldOptions = new DynamicFieldOptions((key, values) =>
+    this.labelImportersApi.getFieldOptions(this.selectedImporter!.name, key, values),
+  );
   readonly addingGood = signal(false);
   readonly addingBad = signal(false);
 
@@ -129,9 +131,7 @@ export class LabelImporterModalComponent implements OnDestroy {
     this.selectedFileFieldKey = null;
     this.importError.set('');
     this.successMessage.set('');
-    this.dynamicFieldOptions.set({});
-    this.dynamicFieldLoading.set({});
-    this.dynamicFieldError.set({});
+    this.fieldOptions.reset();
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -145,66 +145,13 @@ export class LabelImporterModalComponent implements OnDestroy {
         this.formValues[field.key] = field.options![0];
       }
     }
-    for (const field of fields) {
-      if (field.dynamic_options) {
-        this.refreshDynamicFieldOptions(field);
-      }
-    }
+    this.fieldOptions.refreshAll(fields, this.formValues);
     this.view = 'form';
   }
 
   onFormFieldChanged(changedKey: string): void {
-    const importer = this.selectedImporter;
-    if (!importer?.fields) return;
-    for (const field of (importer.fields as ImporterField[])) {
-      if (!field.dynamic_options) continue;
-      if (!(field.depends_on || []).includes(changedKey)) continue;
-      this.formValues[field.key] = '';
-      this.refreshDynamicFieldOptions(field);
-    }
-  }
-
-  optionsFor(field: ImporterField): FieldOptions[] {
-    if (field.dynamic_options) {
-      return this.dynamicFieldOptions()[field.key] || [];
-    }
-    // Static options are plain strings; render each as its own label.
-    return (field.options || []).map((o) => ({ value: o, label: o }));
-  }
-
-  private refreshDynamicFieldOptions(field: ImporterField): void {
-    const importer = this.selectedImporter;
-    if (!importer) return;
-    const key = field.key;
-    this.dynamicFieldLoading.update((m) => ({ ...m, [key]: true }));
-    this.dynamicFieldError.update((m) => ({ ...m, [key]: '' }));
-    this.labelImportersApi
-      .getFieldOptions(importer.name, key, { ...this.formValues })
-      .subscribe({
-        next: (res) => {
-          const options: FieldOptions[] = res.options || [];
-          this.dynamicFieldOptions.update((m) => ({ ...m, [key]: options }));
-          this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
-          const current = this.formValues[key];
-          const inList = options.some((o) => o.value === String(current));
-          // Strict selects clear a value the new list no longer offers; a
-          // free-text combobox keeps whatever the user typed.
-          if (current && !inList && !field.allow_free_text) {
-            this.formValues[key] = '';
-          }
-          if (!this.formValues[key] && field.required && !field.allow_free_text && options.length > 0) {
-            this.formValues[key] = options[0].value;
-          }
-        },
-        error: (err) => {
-          this.dynamicFieldLoading.update((m) => ({ ...m, [key]: false }));
-          this.dynamicFieldError.update((m) => ({
-            ...m,
-            [key]: apiErrorMessage(err, 'Could not load options'),
-          }));
-          this.dynamicFieldOptions.update((m) => ({ ...m, [key]: [] }));
-        },
-      });
+    if (!this.selectedImporter?.fields) return;
+    this.fieldOptions.refreshDependentsOf(changedKey, this.selectedImporterFields, this.formValues);
   }
 
   back(): void {
@@ -212,6 +159,7 @@ export class LabelImporterModalComponent implements OnDestroy {
     this.selectedImporter = null;
     this.importError.set('');
     this.successMessage.set('');
+    this.fieldOptions.reset();
   }
 
   onFileSelected(event: Event, fieldName: string): void {

--- a/frontend/src/app/utils/dynamic-field-options.spec.ts
+++ b/frontend/src/app/utils/dynamic-field-options.spec.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import { Subject } from 'rxjs';
+
+import { DynamicFieldOptions } from './dynamic-field-options';
+import type { FieldOptions, ImporterField } from '../models/api.models';
+
+/**
+ * Coverage for the cancellation/ordering guard shared by every plugin-field
+ * form with ``dynamic_options`` selects (issue #2965). The four copies of this
+ * fetch used to write whatever landed last, so a slow response could repopulate
+ * a dropdown the user had already navigated away from — and silently
+ * auto-select a value invalid for the importer now on screen.
+ */
+describe('DynamicFieldOptions', () => {
+  function field(partial: Partial<ImporterField> & { key: string }): ImporterField {
+    return { field_type: 'select', dynamic_options: true, ...partial } as ImporterField;
+  }
+
+  /** A controller whose fetches resolve manually, newest response last. */
+  function harness() {
+    const pending: Subject<{ options: FieldOptions[] }>[] = [];
+    const requests: { key: string; values: Record<string, string> }[] = [];
+    const controller = new DynamicFieldOptions((key, values) => {
+      requests.push({ key, values });
+      const subject = new Subject<{ options: FieldOptions[] }>();
+      pending.push(subject);
+      return subject;
+    });
+    const resolve = (index: number, options: FieldOptions[]) => {
+      pending[index].next({ options });
+      pending[index].complete();
+    };
+    const fail = (index: number, err: unknown) => pending[index].error(err);
+    return { controller, requests, resolve, fail };
+  }
+
+  it('applies a response and auto-selects the first option for a required strict select', () => {
+    const { controller, resolve } = harness();
+    const values: Record<string, string> = {};
+    const f = field({ key: 'sheet', required: true });
+
+    controller.refresh(f, values);
+    expect(controller.loading()['sheet']).toBe(true);
+    resolve(0, [{ value: 's1', label: 'Sheet 1' }]);
+
+    expect(controller.optionsFor(f)).toEqual([{ value: 's1', label: 'Sheet 1' }]);
+    expect(controller.loading()['sheet']).toBe(false);
+    expect(values['sheet']).toBe('s1');
+  });
+
+  it('drops an out-of-order response for the same field key', () => {
+    const { controller, resolve } = harness();
+    const values: Record<string, string> = {};
+    const f = field({ key: 'q', required: true });
+
+    // Two keystrokes in flight for the same field.
+    controller.refresh(f, values);
+    controller.refresh(f, values);
+
+    // The newer request answers first, then the older one straggles in.
+    resolve(1, [{ value: 'new', label: 'New' }]);
+    resolve(0, [{ value: 'old', label: 'Old' }]);
+
+    expect(controller.optionsFor(f)).toEqual([{ value: 'new', label: 'New' }]);
+    expect(values['q']).toBe('new');
+  });
+
+  it('drops a late response after reset(), leaving the new form untouched', () => {
+    const { controller, resolve } = harness();
+    const importerAValues: Record<string, string> = {};
+    const f = field({ key: 'path', required: true });
+
+    // Importer A dispatches a slow fetch; the user goes Back and picks
+    // importer B, which shares the `path` field key.
+    controller.refresh(f, importerAValues);
+    controller.reset();
+    const importerBValues: Record<string, string> = {};
+
+    resolve(0, [{ value: '/a/only', label: 'A only' }]);
+
+    expect(controller.optionsFor(f)).toEqual([]);
+    expect(importerAValues['path']).toBeUndefined();
+    expect(importerBValues['path']).toBeUndefined();
+  });
+
+  it("drops a late response once another importer's fetch for the same key is in flight", () => {
+    const { controller, resolve } = harness();
+    const valuesA: Record<string, string> = {};
+    const f = field({ key: 'dataset', required: true });
+
+    controller.refresh(f, valuesA); // importer A
+    controller.reset();
+    const valuesB: Record<string, string> = {};
+    controller.refresh(f, valuesB); // importer B, same field key
+
+    resolve(1, [{ value: 'b1', label: 'B one' }]);
+    resolve(0, [{ value: 'a1', label: 'A one' }]); // A straggles in
+
+    expect(controller.optionsFor(f)).toEqual([{ value: 'b1', label: 'B one' }]);
+    expect(valuesB['dataset']).toBe('b1');
+    expect(valuesA['dataset']).toBeUndefined();
+  });
+
+  it('drops a superseded error response instead of clobbering fresh options', () => {
+    const { controller, resolve, fail } = harness();
+    const values: Record<string, string> = {};
+    const f = field({ key: 'q' });
+
+    controller.refresh(f, values);
+    controller.refresh(f, values);
+    resolve(1, [{ value: 'fresh', label: 'Fresh' }]);
+    fail(0, { error: { message: 'boom' } });
+
+    expect(controller.error()['q']).toBe('');
+    expect(controller.optionsFor(f)).toEqual([{ value: 'fresh', label: 'Fresh' }]);
+    expect(controller.loading()['q']).toBe(false);
+  });
+
+  it('surfaces a fetch failure inline and empties the option list', () => {
+    const { controller, fail } = harness();
+    const f = field({ key: 'q' });
+
+    controller.refresh(f, {});
+    fail(0, { error: { message: 'boom' } });
+
+    expect(controller.error()['q']).toBe('boom');
+    expect(controller.loading()['q']).toBe(false);
+    expect(controller.optionsFor(f)).toEqual([]);
+  });
+
+  it('keeps a typed free-text value the refreshed options omit', () => {
+    const { controller, resolve } = harness();
+    const values: Record<string, string> = { q: 'hand-typed' };
+    const f = field({ key: 'q', required: true, allow_free_text: true });
+
+    controller.refresh(f, values);
+    resolve(0, [{ value: 'a', label: 'A' }]);
+
+    expect(values['q']).toBe('hand-typed');
+  });
+
+  it('clears a strict-select value the refreshed options omit', () => {
+    const { controller, resolve } = harness();
+    const values: Record<string, string> = { q: 'stale' };
+    const f = field({ key: 'q' });
+
+    controller.refresh(f, values);
+    resolve(0, [{ value: 'a', label: 'A' }]);
+
+    expect(values['q']).toBe('');
+  });
+
+  it('coerces static string options into {value,label} pairs', () => {
+    const { controller } = harness();
+    const staticSelect = { key: 's', field_type: 'select', options: ['x', 'y'] } as ImporterField;
+
+    expect(controller.optionsFor(staticSelect)).toEqual([
+      { value: 'x', label: 'x' },
+      { value: 'y', label: 'y' },
+    ]);
+  });
+
+  it('refreshes only the fields that depend on the changed key, blanking them first', () => {
+    const { controller, requests } = harness();
+    const values: Record<string, string> = { doc: 'doc-1', tab: 'stale', other: 'keep' };
+    const fields = [
+      field({ key: 'doc' }),
+      field({ key: 'tab', depends_on: ['doc'] }),
+      field({ key: 'other', depends_on: ['something-else'] }),
+    ];
+
+    controller.refreshDependentsOf('doc', fields, values);
+
+    expect(requests.map((r) => r.key)).toEqual(['tab']);
+    expect(values['tab']).toBe('');
+    expect(values['other']).toBe('keep');
+    // The request carries a snapshot, so later edits can't mutate it in flight.
+    expect(requests[0].values).toEqual({ doc: 'doc-1', tab: '', other: 'keep' });
+  });
+
+  it('fetches every dynamic field of a freshly-selected importer', () => {
+    const { controller, requests } = harness();
+    const fields = [
+      field({ key: 'a' }),
+      { key: 'b', field_type: 'text' } as ImporterField,
+      field({ key: 'c' }),
+    ];
+
+    controller.refreshAll(fields, {});
+
+    expect(requests.map((r) => r.key)).toEqual(['a', 'c']);
+  });
+
+  it('runs the onApplied hook only for a response that is still current', () => {
+    const pending: Subject<{ options: FieldOptions[] }>[] = [];
+    let applied = 0;
+    const controller = new DynamicFieldOptions(
+      () => {
+        const subject = new Subject<{ options: FieldOptions[] }>();
+        pending.push(subject);
+        return subject;
+      },
+      () => {
+        applied += 1;
+      },
+    );
+    const f = field({ key: 'q' });
+
+    controller.refresh(f, {});
+    controller.refresh(f, {});
+    pending[1].next({ options: [] });
+    pending[0].next({ options: [] }); // superseded
+
+    expect(applied).toBe(1);
+  });
+});

--- a/frontend/src/app/utils/dynamic-field-options.ts
+++ b/frontend/src/app/utils/dynamic-field-options.ts
@@ -1,0 +1,135 @@
+import { signal } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { FieldOptions, ImporterField } from '../models/api.models';
+import { apiErrorMessage } from './api-error';
+
+/** Fetches the current option list for one ``dynamic_options`` plugin field.
+ *  Supplied by the owning component so this helper stays independent of which
+ *  importer API (label importers, datasource importers, …) backs the form. */
+export type FieldOptionsFetcher = (
+  fieldKey: string,
+  values: Record<string, string>,
+) => Observable<{ options: FieldOptions[] }>;
+
+/** Option-list state for a plugin-field form whose ``dynamic_options`` selects
+ *  are populated by a server round-trip.
+ *
+ *  Every dispatch stamps a monotonically-increasing token onto the field key
+ *  and the response handlers bail unless that stamp is still the newest one,
+ *  which is what makes a late response harmless in the two ways it can be
+ *  stale: a `depends_on` free-text field re-fires on every keystroke, so two
+ *  requests for the same key can resolve out of order; and switching to a
+ *  different importer that happens to share a field key (``path``,
+ *  ``dataset``, …) would otherwise let the previous importer's late response
+ *  populate the new form's dropdown and auto-select a value invalid for it.
+ *  :meth:`reset` drops the stamps outright, so everything in flight when the
+ *  form is re-seeded is discarded.
+ *
+ *  The three maps are signals so the unpatched HTTP callbacks schedule change
+ *  detection under zoneless. */
+export class DynamicFieldOptions {
+  /** Fetched options, keyed by field key. */
+  readonly options = signal<Record<string, FieldOptions[]>>({});
+  /** Whether a fetch is in flight, keyed by field key. */
+  readonly loading = signal<Record<string, boolean>>({});
+  /** Inline fetch-failure message, keyed by field key. */
+  readonly error = signal<Record<string, string>>({});
+
+  /** Token of the newest dispatched request per field key.  A response whose
+   *  token no longer matches has been superseded and is dropped. */
+  private tokens: Record<string, number> = {};
+  private nextToken = 0;
+
+  /** @param fetcher  Issues the options request for one field.
+   *  @param onApplied  Optional hook run after a fresh (non-superseded)
+   *    response has been applied, for owners that need to react to the
+   *    auto-selected value. */
+  constructor(
+    private readonly fetcher: FieldOptionsFetcher,
+    private readonly onApplied?: () => void,
+  ) {}
+
+  /** Clear all fetched state and invalidate every in-flight request.  Call
+   *  when the form is re-seeded for a different importer, or abandoned. */
+  reset(): void {
+    this.tokens = {};
+    this.options.set({});
+    this.loading.set({});
+    this.error.set({});
+  }
+
+  /** Options to render for a field: the dynamically-fetched list for a
+   *  ``dynamic_options`` field, else the static strings coerced into
+   *  ``{value,label}`` pairs. */
+  optionsFor(field: ImporterField): FieldOptions[] {
+    if (field.dynamic_options) {
+      return this.options()[field.key] || [];
+    }
+    return (field.options || []).map((o) => ({ value: o, label: o }));
+  }
+
+  /** Fetch options for every ``dynamic_options`` field of a freshly-selected
+   *  importer. */
+  refreshAll(fields: ImporterField[], values: Record<string, string>): void {
+    for (const field of fields) {
+      if (field.dynamic_options) {
+        this.refresh(field, values);
+      }
+    }
+  }
+
+  /** Re-fetch options for any field that depends on the one the user just
+   *  changed, blanking each dependent value first so a stale selection can't
+   *  survive into the new option set. */
+  refreshDependentsOf(
+    changedKey: string,
+    fields: ImporterField[],
+    values: Record<string, string>,
+  ): void {
+    for (const field of fields) {
+      if (!field.dynamic_options) continue;
+      if (!(field.depends_on || []).includes(changedKey)) continue;
+      values[field.key] = '';
+      this.refresh(field, values);
+    }
+  }
+
+  /** Fetch one field's options, applying the result only if no newer request
+   *  for the same key (and no :meth:`reset`) has intervened. */
+  refresh(field: ImporterField, values: Record<string, string>): void {
+    const key = field.key;
+    const token = ++this.nextToken;
+    this.tokens[key] = token;
+    this.loading.update((m) => ({ ...m, [key]: true }));
+    this.error.update((m) => ({ ...m, [key]: '' }));
+    this.fetcher(key, { ...values }).subscribe({
+      next: (res) => {
+        if (this.tokens[key] !== token) return;
+        const options: FieldOptions[] = res.options || [];
+        this.options.update((m) => ({ ...m, [key]: options }));
+        this.loading.update((m) => ({ ...m, [key]: false }));
+        const current = values[key];
+        const inList = options.some((o) => o.value === String(current));
+        // Strict selects clear a value the new list no longer offers; a
+        // free-text combobox keeps whatever the user typed.
+        if (current && !inList && !field.allow_free_text) {
+          values[key] = '';
+        }
+        if (!values[key] && field.required && !field.allow_free_text && options.length > 0) {
+          values[key] = options[0].value;
+        }
+        this.onApplied?.();
+      },
+      error: (err) => {
+        if (this.tokens[key] !== token) return;
+        this.loading.update((m) => ({ ...m, [key]: false }));
+        this.error.update((m) => ({
+          ...m,
+          [key]: apiErrorMessage(err, 'Could not load options'),
+        }));
+        this.options.update((m) => ({ ...m, [key]: [] }));
+      },
+    });
+  }
+}


### PR DESCRIPTION
Closes #2965

## The bug

Every plugin-field form with `dynamic_options` selects fired a `getFieldOptions` request per field and applied whatever came back, keyed only by field key — no request token, no `switchMap`, no unsubscribe. The `next` callback doesn't just render options, it also mutates the form's value record (auto-selecting `options[0]` for a required strict select), so a late response is not merely a cosmetic dropdown refresh — it can change what gets submitted.

Two reachable failures:

1. **Out-of-order responses for the same key.** A `depends_on` free-text field re-fires the fetch on every keystroke (`(ngModelChange)`), so two requests for the same key can be in flight; if the older one lands last, its option set *and* its auto-selected value win.
2. **Cross-importer clobber.** Select importer A (slow options fetch) → `← Back` → select importer B that shares a field key (`path`, `dataset`, …). A's late response populates B's dropdown and silently sets B's value to something invalid for B, which is then submitted.

## The fix

Extract the fetch into a shared `DynamicFieldOptions` helper (`frontend/src/app/utils/dynamic-field-options.ts`) that adopts the `detectionToken` pattern `server-folder-picker` already uses for exactly this problem: each dispatch stamps a monotonically-increasing token onto the field key, and both response handlers bail unless that stamp is still the newest. `reset()` drops the stamps outright, so everything in flight when the form is re-seeded — or abandoned via Back — is discarded.

The same unguarded block was copy-pasted in **four** components, so all four now share the helper rather than each growing its own token:

- `new-detector-modal.component.ts` (the issue's primary location)
- `label-importer-modal.component.ts`
- `datasource-import-form.component.ts`
- `generic-form-picker.component.ts` — the Add-Dataset importer form, not named in the issue but carrying the identical pattern (its extra "re-suggest the dataset name once options land" side effect is kept via the helper's optional `onApplied` hook, and now runs only for a response that is still current)

Behavior is otherwise unchanged: the same loading/error state, the same "strict selects clear a value the new list no longer offers, free-text comboboxes keep what the user typed", the same auto-select of the first option for a required strict select.

Two incidental fixes that fall out of the consolidation:

- `label-importer-modal`'s `back()` never cleared its dynamic-option state at all (the other three did) — it now does, via `reset()`.
- ~90 lines of duplication removed (14 files, +462/−326 including the new helper and its spec).

## Docs

`docs/EXTENDING-plugins.md`'s "the frontend wiring is fully automatic" list gains a fourth point stating the ordering guarantee, so a plugin author knows a slow `get_field_options()` is safe.

## Testing

- New `frontend/src/app/utils/dynamic-field-options.spec.ts` — 13 cases driving the controller through manually-resolved subjects, covering both failure scenarios directly (out-of-order same-key response, and the importer A → Back → importer B cross-clobber, both with and without a competing in-flight request for the new importer), a superseded *error* response not clobbering fresh options, plus the value-retention/auto-select/static-coercion behavior moved out of the components.
- `cd frontend && npm run test:ci` — 2016 passed (152 files).
- `cd frontend && npm run build:prod` — clean.
- `./run-tests.sh` — 8253 Python tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyxTLugtGPJYUvZw41dhqc)_