### PR TITLE
Guard Find's inclusion POST against out-of-order responses

### DIFF
--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, NgZone, OnDestroy, OnInit, signal, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { EMPTY, Subject, Subscription } from 'rxjs';
-import { catchError, debounceTime, finalize, switchMap, takeUntil } from 'rxjs/operators';
+import { EMPTY, Subject, Subscription, timer } from 'rxjs';
+import { catchError, finalize, switchMap, takeUntil } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
@@ -181,12 +181,18 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // {@link inclusionRequests$} for why the slider is funnelled through it.
     this.inclusionRequests$
       .pipe(
-        debounceTime(INCLUSION_POST_DEBOUNCE_MS),
+        // `timer` + `switchMap` rather than `debounceTime`: it debounces the
+        // same way (a newer value restarts the wait and cancels the request the
+        // user moved past) while putting the *whole* chain, settle window
+        // included, inside the pair scope below — so a slide followed straight
+        // away by a dataset/detector switch cannot fire its POST into the new
+        // pair's context.
         switchMap((value) =>
-          this.sortingApi.setInclusion(value).pipe(
+          timer(INCLUSION_POST_DEBOUNCE_MS).pipe(
+            switchMap(() => this.sortingApi.setInclusion(value)),
             // Pair-scoped like every other threshold write: a response landing
-            // after a dataset/detector switch must not install the old pair's
-            // cutoff into the new context (see `pairScope$`).
+            // after a switch must not install the old pair's cutoff into the
+            // new context (see `pairScope$`).
             takeUntil(this.pairScope$),
             // A failed POST just leaves the cutoff where it was. Swallow it
             // inside the inner observable so the error can't tear down the

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, NgZone, OnDestroy, OnInit, signal, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subject, Subscription } from 'rxjs';
-import { finalize, takeUntil } from 'rxjs/operators';
+import { EMPTY, Subject, Subscription } from 'rxjs';
+import { catchError, debounceTime, finalize, switchMap, takeUntil } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
@@ -34,6 +34,14 @@ import {
   progressBarState,
 } from '../../utils/format-progress';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
+
+/**
+ * How long the Inclusion slider has to settle before its `POST /api/inclusion`
+ * goes out.  Short enough to feel immediate, long enough that walking the
+ * cutoff a few steps with the arrow keys (the slider emits on every `input`
+ * event) coalesces into a single round trip instead of a burst of racing ones.
+ */
+const INCLUSION_POST_DEBOUNCE_MS = 150;
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -143,6 +151,24 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
    * going. `takeUntil` here also aborts the stale XHR client-side.
    */
   private pairScope$ = new Subject<void>();
+  /**
+   * Inclusion-slider values awaiting their `POST /api/inclusion`, funnelled
+   * through a single debounced `switchMap` pipeline (wired in the constructor).
+   *
+   * The slider emits on every `input` event, so a quick walk of the cutoff used
+   * to put several POSTs in flight at once, each installing its own threshold
+   * on arrival: a slow response for a value the user had already moved past
+   * landed *last* and overwrote the newer threshold, snapping the green/red line
+   * (and the left/right vote split) back to a cutoff that was no longer
+   * selected — and leaving it there, since nothing re-reconciles until the next
+   * slide.  This is the same out-of-order hazard `VoteStateService.votesSeq`
+   * closes for `/api/votes`.  Debouncing means only the value the user settled
+   * on is sent, and `switchMap` cancels any request they moved past, so the
+   * newest POST is both the last one the server sees (keeping the persisted
+   * per-detector inclusion in step with the slider) and the only response that
+   * can install a threshold.
+   */
+  private readonly inclusionRequests$ = new Subject<number>();
   private dragging = false;
   private draggingRight = false;
   private boundMouseMove = this.onMouseMove.bind(this);
@@ -151,6 +177,34 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private boundRightMouseUp = this.onRightMouseUp.bind(this);
 
   constructor() {
+    // The one place `POST /api/inclusion` is issued from — see
+    // {@link inclusionRequests$} for why the slider is funnelled through it.
+    this.inclusionRequests$
+      .pipe(
+        debounceTime(INCLUSION_POST_DEBOUNCE_MS),
+        switchMap((value) =>
+          this.sortingApi.setInclusion(value).pipe(
+            // Pair-scoped like every other threshold write: a response landing
+            // after a dataset/detector switch must not install the old pair's
+            // cutoff into the new context (see `pairScope$`).
+            takeUntil(this.pairScope$),
+            // A failed POST just leaves the cutoff where it was. Swallow it
+            // inside the inner observable so the error can't tear down the
+            // long-lived outer pipeline and silence every later slide.
+            catchError(() => EMPTY),
+          ),
+        ),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((resp) => {
+        if (resp.threshold != null && this.sortState.sortOrder) {
+          this.sortState.setSortResults(this.sortState.sortOrder, resp.threshold);
+        }
+        // The server re-thresholded the unverified items over the frozen
+        // scores; pull the new good/bad split back for the left/right panes.
+        this.voteState.loadVotes();
+      });
+
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       if (!settings) return;
@@ -313,6 +367,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.pairScope$.complete();
     this.destroy$.next();
     this.destroy$.complete();
+    this.inclusionRequests$.complete();
     this.voteState.setFindMode(false);
     this.voteState.stopPolling();
     // Stop waiting on a map build if the user left Find some other way (the
@@ -532,23 +587,15 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
    * re-splits the *unverified* items server-side (verified items hold). We
    * reconcile the new threshold (moves the line) and the re-split votes on the
    * cheap response — there is no scoring spinner.
+   *
+   * The slider box moves at once; the round trip is deferred to the debounced
+   * {@link inclusionRequests$} pipeline, which is what keeps a superseded
+   * response from installing a threshold the user has already moved past.
    */
   onInclusionChange(value: number): void {
     if (this.sortState.sortBusy) return;
     this.sortState.setInclusion(value);
-    this.sortingApi
-      .setInclusion(value)
-      .pipe(takeUntil(this.pairScope$))
-      .subscribe({
-        next: (resp) => {
-          if (resp.threshold != null && this.sortState.sortOrder) {
-            this.sortState.setSortResults(this.sortState.sortOrder, resp.threshold);
-          }
-          // The server re-thresholded the unverified items over the frozen
-          // scores; pull the new good/bad split back for the left/right panes.
-          this.voteState.loadVotes();
-        },
-      });
+    this.inclusionRequests$.next(value);
   }
 
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
@@ -719,8 +766,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
    *
    * Derived from the *frozen scores + current cutoff* (`sortOrder` + `threshold`)
    * rather than the `goodVotes` signal, because those two move **synchronously**
-   * when the Inclusion slider does (`onInclusionChange` sets them on the POST
-   * response), whereas `goodVotes` only catches up on the follow-up
+   * when the Inclusion slider does ({@link inclusionRequests$} sets them on the
+   * POST response), whereas `goodVotes` only catches up on the follow-up
    * `loadVotes()` GET. Reading `goodVotes` here let a Browse fired right after a
    * slide pick up the *previous* cutoff's positives (the stale-superset bug);
    * scoring against the live cutoff keeps Browse in lock-step with the green

--- a/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
+++ b/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
@@ -262,6 +262,33 @@ describe('FindViewComponent (pair-switch supersession)', () => {
     expect(sortState.threshold).toBe(0.5);
     expect(sortState.sortBusy).toBe(false);
   });
+
+  // The Inclusion POST is deferred until the slider settles (issue #2973), and
+  // that settle window is inside the pair scope too: a slide the user abandons
+  // by switching pair must never be written into the pair they switched *to*,
+  // whose own inclusion the reload has just re-seeded.
+  it('drops a pending inclusion POST when the pair switches first', async () => {
+    await flushInit();
+    // Land the first pair's ranking so the slider isn't disabled by sortBusy.
+    httpMock
+      .expectOne('/api/find-label')
+      .flush({ results: [{ id: 1, score: 0.9 }], threshold: 0.5 });
+    await flushInit();
+    await settleZoneless(fixture);
+
+    vi.useFakeTimers();
+    try {
+      fixture.componentInstance.onInclusionChange(5);
+      // Still inside the settle window when the user switches pair.
+      vi.advanceTimersByTime(50);
+      activeContext.setActivePair('ds2', 'det2');
+      vi.advanceTimersByTime(1000);
+
+      httpMock.expectNone((req) => req.url === '/api/inclusion' && req.method === 'POST');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 /**

--- a/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
+++ b/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
@@ -263,3 +263,137 @@ describe('FindViewComponent (pair-switch supersession)', () => {
     expect(sortState.sortBusy).toBe(false);
   });
 });
+
+/**
+ * Issue #2973: the Inclusion slider emits on every `input` event, so walking the
+ * cutoff a few steps used to leave several `POST /api/inclusion` requests in
+ * flight at once, each installing its own threshold on arrival. A slow response
+ * for a value the user had already moved past could land *last* and overwrite
+ * the newer threshold, snapping the green/red line (and the left/right split)
+ * back to a cutoff that was no longer selected — with nothing to re-reconcile it
+ * until the next slide. Slider changes now funnel through one debounced
+ * `switchMap` pipeline, so only the settled value is sent and only its response
+ * is applied.
+ */
+describe('FindViewComponent (inclusion supersession)', () => {
+  let fixture: ComponentFixture<FindViewComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await configureZoneless({
+      imports: [FindViewComponent],
+      providers: [...provideHttpTesting(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FindViewComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    fixture.componentInstance.ngOnDestroy();
+    httpMock.match(() => true).forEach((req) => {
+      if (!req.cancelled) req.flush([]);
+    });
+    fixture.destroy();
+  });
+
+  // Same drain as the canary above; no pair is active, so `runFindLabel` no-ops
+  // and the only /api/inclusion traffic afterwards is the slider's.
+  async function flushInit(): Promise<void> {
+    TestBed.tick();
+    for (let i = 0; i < 3; i++) {
+      await settleResource();
+      httpMock.match('/api/medias/ids').forEach((req) =>
+        req.flush([{ id: 1, media_type: 'audio' }]),
+      );
+      httpMock.match('/api/votes').forEach((req) =>
+        req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
+      );
+      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 80 }));
+      httpMock.match('/api/inclusion').forEach((req) => req.flush({ inclusion: 0 }));
+      httpMock.match('/api/media-types').forEach((req) => req.flush({ media_types: [] }));
+      httpMock.match('/api/embedders').forEach((req) => req.flush([]));
+      httpMock.match('/api/dataset/status').forEach((req) => req.flush({ display_name: 'ds' }));
+    }
+  }
+
+  /** Seed a ranking so a returned threshold has an order to be installed against. */
+  function seedRanking(): SortStateService {
+    const sortState = TestBed.inject(SortStateService);
+    sortState.setSortResults([{ id: 1, score: 0.9 }], 0.5);
+    return sortState;
+  }
+
+  it('coalesces a rapid walk of the slider into one POST for the settled value', async () => {
+    await flushInit();
+    await settleZoneless(fixture);
+    const sortState = seedRanking();
+    const component = fixture.componentInstance;
+
+    vi.useFakeTimers();
+    // Three steps up in quick succession: the box tracks every one of them...
+    component.onInclusionChange(1);
+    vi.advanceTimersByTime(40);
+    component.onInclusionChange(2);
+    vi.advanceTimersByTime(40);
+    component.onInclusionChange(3);
+    expect(sortState.inclusion).toBe(3);
+    // ...but nothing is sent until the slider settles.
+    httpMock.expectNone('/api/inclusion');
+
+    vi.advanceTimersByTime(200);
+    const req = httpMock.expectOne('/api/inclusion');
+    expect(req.request.body).toEqual({ inclusion: 3 });
+    req.flush({ inclusion: 3, threshold: 0.7 });
+    expect(sortState.threshold).toBe(0.7);
+  });
+
+  it('cancels a superseded POST so its stale threshold can never land', async () => {
+    await flushInit();
+    await settleZoneless(fixture);
+    const sortState = seedRanking();
+    const component = fixture.componentInstance;
+
+    vi.useFakeTimers();
+    component.onInclusionChange(3);
+    vi.advanceTimersByTime(200);
+    // The first POST is still in flight (a slow re-threshold server-side) when
+    // the user moves the cutoff again.
+    const stale = httpMock.expectOne('/api/inclusion');
+    expect(stale.cancelled).toBe(false);
+
+    component.onInclusionChange(7);
+    vi.advanceTimersByTime(200);
+
+    // switchMap aborted the superseded request, so its threshold (0.2) has no
+    // subscriber left to install it however late it resolves.
+    expect(stale.cancelled).toBe(true);
+    const fresh = httpMock.expectOne('/api/inclusion');
+    expect(fresh.request.body).toEqual({ inclusion: 7 });
+    fresh.flush({ inclusion: 7, threshold: 0.9 });
+    expect(sortState.threshold).toBe(0.9);
+  });
+
+  it('keeps posting after a failed slide', async () => {
+    await flushInit();
+    await settleZoneless(fixture);
+    const sortState = seedRanking();
+    const component = fixture.componentInstance;
+
+    vi.useFakeTimers();
+    component.onInclusionChange(2);
+    vi.advanceTimersByTime(200);
+    httpMock
+      .expectOne('/api/inclusion')
+      .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+
+    // The error is swallowed per-request, so the shared pipeline survives it.
+    component.onInclusionChange(4);
+    vi.advanceTimersByTime(200);
+    const retry = httpMock.expectOne('/api/inclusion');
+    expect(retry.request.body).toEqual({ inclusion: 4 });
+    retry.flush({ inclusion: 4, threshold: 0.6 });
+    expect(sortState.threshold).toBe(0.6);
+  });
+});


### PR DESCRIPTION
Closes #2973

## The bug

`find-view`'s `onInclusionChange()` fired `POST /api/inclusion` on every slider `input` event and installed `resp.threshold` on arrival, with no ordering guard. A quick walk of the cutoff left several POSTs in flight at once, so a slow response for a value the user had already moved past could land **last** and overwrite the newer threshold — snapping the green/red line and the left/right vote split back to a cutoff that was no longer selected, and leaving it there (nothing re-reconciles until the next slide). Server-side `set_inclusion` is arrival-order last-write-wins and persists per detector, so the stored value could also end up disagreeing with the slider.

This is the same out-of-order hazard `VoteStateService.votesSeq` was built to close for `/api/votes`.

## The fix

Slider changes now funnel through a single long-lived pipeline (`inclusionRequests$`, wired in the constructor) instead of a fresh subscription per change:

- **Settle window** (`timer(150)` + `switchMap`, i.e. a debounce): only the value the user settles on is sent, so a walk up the arrow keys is one round trip rather than a burst of racing ones — which is also what keeps the persisted per-detector inclusion in step with the slider.
- **`switchMap` supersession**: a request the user has moved past is cancelled client-side, so only the newest response can ever install a threshold.
- **Pair-scoped, settle window included**: `timer` + `switchMap` rather than `debounceTime` specifically so the whole chain sits inside `takeUntil(pairScope$)` — a slide abandoned by a dataset/detector switch cannot fire its POST into the pair the user switched *to*, whose inclusion the reload has just re-seeded.
- **`catchError` inside the inner observable**: a failed POST can't tear down the shared pipeline and silence every later slide.

The slider box itself still moves synchronously (`sortState.setInclusion(value)` is unchanged); only the round trip is deferred.

Behaviour change worth noting: the green/red line now moves ~150ms after the slider instead of on the first response of a burst.

## Tests

Four new cases in `find-view.zoneless.spec.ts`:

- a rapid walk of the slider coalesces into one POST carrying the settled value;
- a superseded POST is cancelled, so its stale threshold can never land, and the newest response's threshold is the one installed;
- the pipeline survives a failed slide and still posts the next one;
- a pending POST is dropped when the pair switches inside the settle window (in the existing pair-switch describe).

`./run-tests.sh` is green end-to-end (8278 passed, 6 skipped), including the frontend build, `npm audit`, and the full Vitest suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_0112Dpkxduxmyr7JaM2UDePA)_