### PR TITLE
Make --help resolve plugin flags; fix CLI.md's detector-path claims

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -14,7 +14,9 @@ Auto-Find and output the items each model predicts as "Good."
 
 Models are specified via a **settings file** (`--settings`) whose
 `autofind_detectors` list names registered models.  Each name
-maps to `data/detectors/<name>.json`; the CLI re-resolves the
+maps to a JSON file under `data/detectors/` named after a **slug** of the
+detector name, not the name itself (see [Detector file
+names](#detector-file-names) below); the CLI re-resolves the
 labelset's origins, embeds them with the dataset's embedder, trains an
 head, and applies it to the dataset.  See below for the exact format.
 
@@ -58,7 +60,7 @@ python app.py --autodetect --importer http_archive --url https://example.com/dat
 python app.py --autodetect --importer http_archive --url /data/sounds.tar.gz --media-type audio --settings settings.json
 ```
 
-Use `python app.py --list-importers` to see all available importers. The full set includes: `server_folder`, `server_files`, `local_folder`, `local_files`, `pickle`, `http_archive`, `combine_datasets`, `demo`, `synthetic`. Each importer adds its own flags; run `python app.py --autodetect --importer <name> --help` to see them.
+Use `python app.py --list-importers` to see all available importers. The full set includes: `server_folder`, `server_files`, `local_folder`, `local_files`, `pickle`, `http_archive`, `combine_datasets`, `demo`, `synthetic`. Each importer adds its own flags; run `python app.py --autodetect --importer <name> --help` to see them. `--help` resolves the named plugin first, so its flags are listed at the end of the usual help output (the same works for `--exporter <name> --help`).
 
 **Chunked loading**: for large datasets, use `--chunk-size N` to process in batches to limit memory:
 
@@ -155,7 +157,7 @@ with no `input_spec.clipper` scores whole media.
 **How to get the files:**
 
 - **Dataset file**: Export from the web UI via the dataset menu ("Export dataset"), or use a cached `.pkl` file from the `data/embeddings/` directory after loading a demo dataset.
-- **Settings file**: A JSON file listing the detector names that should run during `--autodetect`. Each name maps to a JSON labelset under `data/detectors/<name>.json`; the CLI re-resolves the labelset's origins, embeds them with the dataset's embedder, trains a fresh head, and scores the dataset.
+- **Settings file**: A JSON file listing the detector names that should run during `--autodetect`. Each name maps to a JSON labelset under `data/detectors/` (see [Detector file names](#detector-file-names) below); the CLI re-resolves the labelset's origins, embeds them with the dataset's embedder, trains a fresh head, and scores the dataset.
 
 ```json
 {
@@ -165,6 +167,23 @@ with no `input_spec.clipper` scores whole media.
 ```
 
 - **Detector file**: Created from the dashboard by labeling items in the right pane. The file stores origin info plus labels (no weights); the head is rebuilt from origins at scoring time.
+
+#### Detector file names
+
+Everything that names a detector — `autofind_detectors`, `--import-labels-into`,
+the pipeline file's `detectors:` list — uses the **human-readable name**, exactly
+as it appears in the UI (`Dog Barks`). The *filename* is a slug derived from that
+name, so the two don't match literally: the name is lowercased and every run of
+characters outside `[a-z0-9_-]` collapses to a single `_`, with leading and
+trailing `_` stripped. So `Dog Barks` lives at `data/detectors/dog_barks.json`,
+and `Bird calls (v2)` at `data/detectors/bird_calls_v2.json`. A name that slugs
+to nothing falls back to `detector.json`, and a name long enough to overrun the
+filesystem's limit is truncated with a short content hash appended so two long
+names sharing a prefix can't collide.
+
+Don't hand-construct these paths when you can avoid it: `--dry-run` (below)
+prints the resolved file for every detector it would run, which is the reliable
+way to check that a name in your settings file points where you think it does.
 
 **Example output:**
 
@@ -208,8 +227,8 @@ Source:
 
 Settings: settings.json
 Auto-Find detectors (2):
-  - Dog Barks  [media_type=audio, labels=12, file=data/detectors/Dog Barks.json]
-  - Cat Meows  [media_type=audio, labels=8, file=data/detectors/Cat Meows.json]
+  - Dog Barks  [media_type=audio, labels=12, file=data/detectors/dog_barks.json]
+  - Cat Meows  [media_type=audio, labels=8, file=data/detectors/cat_meows.json]
 
 Exporter: server_json_file
   filepath: out.json
@@ -226,6 +245,43 @@ typos in a cron-style invocation fail immediately instead of after a
 multi-minute embedding pass. `--import-labels-into ... --label-importer-file ...`
 is announced as part of the plan but skipped (no detector JSON is
 modified).
+
+### Importing labels into a detector
+
+`--import-labels-into` merges an external label file into a detector's labelset
+*before* the run trains and scores, so a batch of labels produced elsewhere
+(another VTSearch instance, an annotation tool, a script) can be folded in
+headlessly. Three flags work together:
+
+| Flag | Meaning |
+|------|---------|
+| `--import-labels-into NAME` | Detector to merge into, by its human-readable name (see [Detector file names](#detector-file-names)). |
+| `--label-importer-file PATH` | The label file to read. Required whenever `--import-labels-into` is given. |
+| `--label-importer NAME` | Which label importer parses the file. Defaults to `server_json_file`; `python app.py --list-label-importers` shows the rest. |
+
+```bash
+# Merge new labels, then run Auto-Find with the enlarged labelset.
+python app.py --autodetect --dataset data.pkl --settings settings.json \
+    --import-labels-into "Dog Barks" --label-importer-file new_labels.json
+
+# Same, from a CSV.
+python app.py --autodetect --dataset data.pkl --settings settings.json \
+    --import-labels-into "Dog Barks" \
+    --label-importer server_csv_file --label-importer-file new_labels.csv
+```
+
+The two server-side importers expect labels keyed by media MD5:
+`server_json_file` reads `{"labels": [{"md5": "...", "label": "good"}, ...]}`,
+and `server_csv_file` reads a header row of `md5,label`. Only `good` and `bad`
+labels are accepted; entries with any other label, and `(md5, label)` pairs the
+detector already holds, are skipped and reported in the count.
+
+The import is a **one-shot mutation of the detector JSON on disk**: the merged
+labelset persists after the run, which is why it happens before scoring rather
+than only for the run's duration. It is part of the `--autodetect` flow (or the
+pipeline file's `import_labels:` block) — there is no standalone import mode.
+Under `--dry-run` the import is announced but not performed, so no detector JSON
+is touched.
 
 ### Progress output format
 
@@ -303,7 +359,7 @@ keep_negatives: false
 # before scoring (same as --import-labels-into / --label-importer /
 # --label-importer-file).
 import_labels:
-  detector: dog-barks
+  detector: Dog Barks             # the detector's name, not its filename slug
   importer: server_json_file       # default: server_json_file
   file: new_labels.json
 

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -1333,7 +1333,8 @@ classifier:
 
 1. Use `POST /api/detectors` (or
    `POST /api/detectors/registry/from-labelset/<importer>`) to create a
-   detector file under `data/detectors/<name>.json`.
+   detector file under `data/detectors/` (named after a slug of the
+   detector name, e.g. `Dog Barks` → `dog_barks.json`).
 2. Toggle its Auto-Find flag with
    `PUT /api/detectors/registry/<id>/autofind` so it runs from
    `/api/auto-detect` and the CLI's `--autodetect` flow.

--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -12,7 +12,9 @@
 ## Detectors
 
 A detector is a named labelset plus a text-sort query, persisted as a
-JSON file at `data/detectors/<name>.json`. The head is trained on demand
+JSON file under `data/detectors/`, named after a slug of the detector name
+rather than the name itself (`Dog Barks` → `dog_barks.json`; see
+[CLI.md § Detector file names](../CLI.md#detector-file-names)). The head is trained on demand
 from the labelset and lives only in `DetectorContext` once the user
 loads the detector into memory.
 
@@ -213,8 +215,8 @@ GET /api/detectors/registry
 }
 ```
 
-`name` is the slug used to look up the on-disk labelset file at
-`data/detectors/<name>.json`. The head is trained on demand from the
+`name` is what the on-disk labelset file is looked up by; the file itself is
+`data/detectors/<slug-of-name>.json`. The head is trained on demand from the
 labelset and lives only in RAM. `autofind` mirrors whether the
 detector's name appears in `autofind_detectors` settings (toggle it with
 the route below).

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -142,6 +142,63 @@ class TestBuildParser:
 
 
 # ---------------------------------------------------------------------------
+# -h / --help (plugin-aware)
+# ---------------------------------------------------------------------------
+
+
+class TestHelp:
+    """``--help`` must list the selected plugin's flags.
+
+    argparse's built-in help action would fire during the *first* parse pass,
+    before ``_resolve_plugins`` registers the importer/exporter flags, so the
+    doc-advertised ``--importer <name> --help`` discovery path printed only the
+    base flags. ``cli_main`` registers help as a plain flag and prints it after
+    plugin resolution instead.
+    """
+
+    def test_bare_help_exits_zero(self, monkeypatch, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _run_main(monkeypatch, ["--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--autodetect" in out
+        # No plugin selected: the importer's own flags stay out of the way.
+        assert "--dig-archives" not in out
+
+    def test_short_h_exits_zero(self, monkeypatch, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _run_main(monkeypatch, ["-h"])
+        assert exc.value.code == 0
+        assert "usage:" in capsys.readouterr().out
+
+    def test_help_lists_importer_flags(self, monkeypatch, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _run_main(monkeypatch, ["--autodetect", "--importer", "server_folder", "--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        for flag in ("--path", "--media-type", "--recursive", "--dig-archives"):
+            assert flag in out, f"{flag} missing from --importer server_folder --help"
+
+    def test_help_lists_exporter_flags(self, monkeypatch, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _run_main(monkeypatch, ["--autodetect", "--exporter", "webhook", "--help"])
+        assert exc.value.code == 0
+        assert "--auth-header" in capsys.readouterr().out
+
+    def test_help_with_unknown_importer_errors(self, monkeypatch, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _run_main(monkeypatch, ["--autodetect", "--importer", "no_such_importer", "--help"])
+        assert exc.value.code == 2
+        assert "Unknown importer" in capsys.readouterr().err
+
+    def test_help_does_not_start_server(self, monkeypatch):
+        monkeypatch.setattr(cli_main, "_run_server", lambda *a, **k: pytest.fail("server started"))
+        with pytest.raises(SystemExit) as exc:
+            _run_main(monkeypatch, ["--help"])
+        assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
 # --list-plugins early exit
 # ---------------------------------------------------------------------------
 

--- a/tests_lib/detectors/test_store_atomic_write.py
+++ b/tests_lib/detectors/test_store_atomic_write.py
@@ -75,6 +75,17 @@ class TestDetectorAtomicWrite:
         """The truncation path is inert for ordinary names."""
         assert _slug("Mammals of North America") == "mammals_of_north_america"
 
+    def test_slug_matches_documented_examples(self):
+        """Pin the worked examples in ``docs/CLI.md`` § Detector file names.
+
+        The doc tells operators that a detector *name* and its *filename* are
+        not the same string; these are the two examples it spells out, so a
+        change to slugging shows up as a doc-drift failure here.
+        """
+        assert _slug("Dog Barks") == "dog_barks"
+        assert _slug("Bird calls (v2)") == "bird_calls_v2"
+        assert _slug("!!!") == "detector"
+
     def test_tmp_cleaned_up_on_replace_error(self, tmp_path, monkeypatch):
         """A failed ``os.replace`` must not leak the half-written tmp file."""
         path = tmp_path / "mammals.json"

--- a/vtscore/detectors/registry.py
+++ b/vtscore/detectors/registry.py
@@ -4,7 +4,9 @@ Maintains a JSON manifest at ``data/detector_registry.json`` that tracks every
 detector the user has created.  Each entry stores enough metadata to display
 the detector in the dashboard grid.
 
-Every entry is backed by a labelset file at ``data/detectors/<name>.json``.
+Every entry is backed by a labelset file under ``data/detectors/``, named
+after a slug of the detector name rather than the name itself (see
+:func:`vtscore.detectors.store._slug`).
 The MLP that scores the detector is trained on demand from the labelset and
 lives only in RAM (see :class:`~vtsearch.state.DetectorContext`).
 
@@ -132,8 +134,9 @@ def register_detector(
     """Add a new detector to the registry and persist.
 
     Args:
-        name: Display name for the dashboard.  Also the slug used to look
-            up the on-disk labelset file at ``data/detectors/<name>.json``.
+        name: Display name for the dashboard.  Also the key the on-disk
+            labelset file is looked up by; the file itself is
+            ``data/detectors/<slug-of-name>.json``.
         media_type: ``"audio"``, ``"image"``, ``"video"``, ``"text"``, etc.
         num_training: Number of training examples (label count).
         text_query: Text-sort query associated with the detector.

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -26,7 +26,20 @@ from vtsearch.port_preflight import _acquire_single_instance_lock, _preflight_po
 
 def _build_parser() -> argparse.ArgumentParser:
     """Construct the full ``python app.py`` argument parser."""
-    parser = argparse.ArgumentParser(description="VTSearch \u2014 media explorer web app")
+    parser = argparse.ArgumentParser(description="VTSearch \u2014 media explorer web app", add_help=False)
+    # Help is a plain flag, not argparse's built-in ``action="help"``. The
+    # built-in action fires and exits during the *first* parse pass, which
+    # happens before ``--importer``/``--exporter`` have had their plugin-specific
+    # flags registered -- so ``--importer server_folder --help`` would print help
+    # that omits the very flags the user asked about. ``main()`` registers the
+    # selected plugin's arguments first and prints help afterwards.
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="store_true",
+        dest="show_help",
+        help="show this help message and exit (lists the selected --importer/--exporter's flags too)",
+    )
     parser.add_argument("--local", action="store_true", help="Run in local development mode")
     parser.add_argument(
         "--port",
@@ -342,6 +355,23 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _maybe_print_help(args, parser) -> None:
+    """Handle ``-h``/``--help``, including plugin-specific flags, then exit.
+
+    Registers the flags of any ``--importer``/``--exporter`` named on the
+    command line before printing, so ``python app.py --autodetect --importer
+    server_folder --help`` lists ``--path``, ``--media-type``, and the rest of
+    that importer's fields rather than only the base flags. (argparse's default
+    help action can't do this: it fires during the first parse pass, before the
+    plugin flags exist.)
+    """
+    if not getattr(args, "show_help", False):
+        return
+    _register_plugin_cli_args(args, parser)
+    parser.print_help()
+    sys.exit(0)
+
+
 def _maybe_list_plugins(args, parser) -> None:
     """Handle ``--list-plugins`` (and family shortcuts), then exit."""
     # ---- Early-exit informational flags --------------------------------
@@ -399,16 +429,18 @@ def _maybe_run_pipeline(args, parser, remaining) -> None:
         sys.exit(0)
 
 
-def _resolve_plugins(args, parser, remaining):
-    """Two-pass resolution of ``--importer``/``--exporter`` and their plugin args.
+def _register_plugin_cli_args(args, parser):
+    """Look up ``--importer``/``--exporter`` and register their plugin flags.
 
-    Returns ``(args, importer, exporter)``; ``args`` is re-parsed once the
-    plugin-specific arguments have been registered.
+    Returns the ``(importer, exporter)`` plugin instances (``None`` when the
+    corresponding flag wasn't given). Called both by :func:`_resolve_plugins`
+    for the second parse pass and by the ``--help`` path in :func:`main`, so
+    ``--importer <name> --help`` prints that importer's flags.
     """
     importer = None
     exporter = None
 
-    if args.autodetect and args.importer:
+    if args.importer:
         from vtscore.datasets.importers import get_importer, list_importers
 
         importer = get_importer(args.importer)
@@ -418,7 +450,7 @@ def _resolve_plugins(args, parser, remaining):
 
         importer.add_cli_arguments(parser)
 
-    if args.autodetect and args.exporter:
+    if args.exporter:
         from vtscore.exporters import get_exporter, list_exporters
 
         exporter = get_exporter(args.exporter)
@@ -427,6 +459,21 @@ def _resolve_plugins(args, parser, remaining):
             parser.error(f"Unknown exporter: {args.exporter}. Available: {available}")
 
         exporter.add_cli_arguments(parser)
+
+    return importer, exporter
+
+
+def _resolve_plugins(args, parser, remaining):
+    """Two-pass resolution of ``--importer``/``--exporter`` and their plugin args.
+
+    Returns ``(args, importer, exporter)``; ``args`` is re-parsed once the
+    plugin-specific arguments have been registered.
+    """
+    importer = None
+    exporter = None
+
+    if args.autodetect:
+        importer, exporter = _register_plugin_cli_args(args, parser)
 
     if importer or exporter:
         args = parser.parse_args()
@@ -849,6 +896,7 @@ def main(app, initialize_server) -> None:
     # second pass adds their plugin-specific arguments and re-parses.
     args, remaining = parser.parse_known_args()
 
+    _maybe_print_help(args, parser)
     _maybe_list_plugins(args, parser)
     _maybe_run_pipeline(args, parser, remaining)
     args, importer, exporter = _resolve_plugins(args, parser, remaining)


### PR DESCRIPTION
Closes #2992

`docs/CLI.md` made two claims that actively misled a reader following it; both are fixed here, one by correcting the doc and one by making the code do what the doc said.

## 1. `--importer <name> --help` now shows the importer's flags

The doc offered `python app.py --autodetect --importer <name> --help` as the way to discover a plugin's flags, but argparse's built-in help action fires and exits during the **first** parse pass (`parse_known_args`), while plugin flags are only registered afterwards by `_resolve_plugins`. The reader got the base help and never saw the flags they were told to look for.

`_build_parser` now takes `add_help=False` and registers `-h`/`--help` as a plain `store_true` flag. `main()` handles it via a new `_maybe_print_help`, which registers the selected plugin's arguments *before* printing — so the documented discovery path works, for `--exporter` as well as `--importer`. The plugin lookup itself is factored out of `_resolve_plugins` into `_register_plugin_cli_args` so both callers share one implementation rather than duplicating the get-or-error dance.

Behavior preserved: bare `--help`/`-h` still exits 0 with the base help; an unknown importer name still errors with the available list; unrecognized flags still fail the second parse.

```
$ python app.py --autodetect --importer server_folder --help
...
  --media-type {audio,document,face,image,text,video}
                        Type of media files the dataset ends up holding.
  --path PATH           Absolute path to a directory containing media files,
                        or to a single archive file (.zip, .tar, ...).
  --recursive, --no-recursive
  --dig-archives, --no-dig-archives
  --reference-files, --no-reference-files
```

## 2. Detector file paths are slugged, not literal

The doc said a detector named `X` lives at `data/detectors/X.json`, and the dry-run example printed `file=data/detectors/Dog Barks.json`. `vtscore/detectors/store.py:_slug` lowercases the name and collapses everything outside `[a-z0-9_-]` to `_`, so it's really `data/detectors/dog_barks.json` — and the dry-run summary prints the real path, so the doc's own sample output was wrong.

- New **Detector file names** section in `docs/CLI.md` spelling out the name-vs-filename split (including the `detector.json` fallback and the hash-suffixed truncation for overlong names), with the two intro references pointing at it.
- Corrected the dry-run sample output.
- Same stale claim fixed in `docs/api/detectors.md` (×2), `docs/EXTENDING-plugins.md`, and the `vtscore/detectors/registry.py` docstrings.
- The pipeline YAML's `import_labels.detector: dog-barks` looked like a slug; it's a name, so it now reads `Dog Barks` with a clarifying comment.

## 3. Label-import flags documented

`--import-labels-into` / `--label-importer` / `--label-importer-file` had no section of their own despite the README advertising a label-import CLI workflow. Added one covering the flag trio, the two server-side importers' file formats, the good/bad + duplicate-skip semantics, that the merge **mutates the detector JSON on disk**, and that `--dry-run` announces it without performing it.

The remaining enumeration drift noted in the issue (missing `datasource_importers` family, `face` media type, incomplete importer/exporter lists) is deliberately left to the inventory-generation issue rather than hand-edited again.

## Tests

- `tests/cli/test_cli_main.py::TestHelp` — bare `--help`/`-h` exit 0 without plugin flags leaking in, `--importer`/`--exporter` help lists the plugin's flags, unknown importer still exits 2, help never starts the server.
- `tests_lib/detectors/test_store_atomic_write.py::test_slug_matches_documented_examples` — pins the worked examples the new doc section uses, so slugging changes surface as doc drift.

`./run-tests.sh` full run: 8285 passed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Mt8a8i2zf47YgvtqKvzYR

---
_Generated by [Claude Code](https://claude.ai/code/session_016Mt8a8i2zf47YgvtqKvzYR)_