### PR TITLE
Remove the sleep-based handshake from the SSE stream tests

### DIFF
--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -375,7 +375,11 @@ class TestEventsRoute:
             # regression this test exists to catch.
             deadline = time.monotonic() + 10.0
             chunk = next(gen)
-            while chunk.startswith("event: ") and not chunk.startswith("event: heartbeat\n") and time.monotonic() < deadline:
+            while (
+                chunk.startswith("event: ")
+                and not chunk.startswith("event: heartbeat\n")
+                and time.monotonic() < deadline
+            ):
                 chunk = next(gen)
             assert chunk.startswith(": "), f"idle wakeup should be an SSE comment, got {chunk!r}"
             assert "event:" not in chunk

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -229,6 +229,26 @@ class TestLoadingTasksTrackerSubscriptions:
 # ---------------------------------------------------------------------------
 
 
+def _drain_connect_and_snapshot(gen) -> None:
+    """Consume the connect comment + initial snapshot from a fresh stream.
+
+    The generator yields the handshake comment followed by exactly one frame
+    per channel before it ever blocks, so the count is fixed and this needs no
+    wall-clock deadline: pulling ``len(initial_snapshot())`` frames lands the
+    generator on its first ``queue.get()`` every time, loaded machine or not.
+    Asserting the channel *set* here (with the missing names in the message)
+    is what makes a short read legible instead of a bare set mismatch.
+    """
+    assert next(gen).startswith(": connected")
+    seen_channels: set[str] = set()
+    for _ in initial_snapshot():
+        chunk = next(gen)
+        if chunk.startswith("event: "):
+            seen_channels.add(chunk.split("\n", 1)[0].removeprefix("event: "))
+    expected = set(_TRACKER_CHANNELS.keys()) | set(_TASK_CHANNELS.keys()) | {"server"}
+    assert seen_channels == expected, f"snapshot missing channels: {sorted(expected - seen_channels)}"
+
+
 class TestEventsRoute:
     def test_initial_snapshot_includes_every_channel(self):
         frames = initial_snapshot()
@@ -257,42 +277,60 @@ class TestEventsRoute:
             resp.close()
 
     def test_stream_yields_update_after_subscribe(self):
-        """Pump the generator directly and assert a live update arrives."""
-        gen = stream_progress_events(heartbeat_seconds=60.0)
+        """Pump the generator directly and assert a live update arrives.
+
+        No thread and no sleep: the stream subscribes to every tracker when
+        its body first runs, and each subscriber pushes into a *buffered*
+        queue, so an update published while the generator is suspended is
+        waiting for it on the next ``next()``. The old version slept 0.05s in
+        a publisher thread to "make sure" the generator had parked in
+        ``queue.get()`` — a distinction the queue makes unobservable, and a
+        sleep that lost its race whenever a co-resident heavy process delayed
+        the thread past the 1s keepalive (#3075).
+
+        Idle wakeups are pushed out of reach so nothing but the real update
+        can be the next frame.
+        """
+        gen = stream_progress_events(heartbeat_seconds=60.0, keepalive_seconds=60.0)
         try:
-            # Drain initial connect comment + the snapshot frames so the
-            # generator is parked on the queue.get() call.
-            seen_channels: set[str] = set()
-            expected = set(_TRACKER_CHANNELS.keys()) | set(_TASK_CHANNELS.keys()) | {"server"}
-            deadline = time.monotonic() + 2.0
-            while seen_channels != expected and time.monotonic() < deadline:
-                chunk = next(gen)
-                if chunk.startswith("event: "):
-                    name = chunk.split("\n", 1)[0].removeprefix("event: ")
-                    seen_channels.add(name)
-            assert seen_channels == expected
+            _drain_connect_and_snapshot(gen)
 
-            # Now publish an update on a fresh tracker and read it back.
-            #
-            # The generator is blocked inside queue.get() in the SSE
-            # thread; we trigger an update from this thread, then pull
-            # the next frame.
-            def push_update():
-                # Small wait so we know the generator has parked on
-                # queue.get(). Without this, the publish can race the
-                # subscribe.
-                time.sleep(0.05)
-                sort_progress.update("running", "tick", 1, 10)
+            sort_progress.update("running", "tick", 1, 10)
 
-            t = threading.Thread(target=push_update, daemon=True)
-            t.start()
             frame = next(gen)
-            t.join(timeout=1.0)
-            assert frame.startswith("event: sort\n")
+            assert frame.startswith("event: sort\n"), f"expected the published sort update, got {frame!r}"
             data_line = [ln for ln in frame.splitlines() if ln.startswith("data: ")][0]
             payload = json.loads(data_line.removeprefix("data: "))
             assert payload["status"] == "running"
             assert payload["current"] == 1
+        finally:
+            gen.close()
+
+    def test_parked_reader_is_woken_by_an_update_from_another_thread(self):
+        """A reader blocked in ``queue.get()`` gets the frame a *foreign*
+        thread publishes — the real cross-thread path, since tracker
+        subscribers run on whichever thread called ``update()``.
+
+        Ordering between the publish and the park needs no handshake: if the
+        publish lands first the queue holds it, and if it lands second it
+        wakes the parked reader. Both interleavings produce the same frame,
+        which is exactly why the old fixed sleep bought nothing.
+        """
+        # Generous enough that no plausible scheduling delay reaches it, low
+        # enough that a genuine regression fails in seconds instead of hanging.
+        gen = stream_progress_events(heartbeat_seconds=10.0, keepalive_seconds=10.0)
+        try:
+            _drain_connect_and_snapshot(gen)
+
+            t = threading.Thread(target=lambda: sort_progress.update("running", "tick", 2, 10), daemon=True)
+            t.start()
+            try:
+                frame = next(gen)
+            finally:
+                t.join(timeout=10.0)
+            assert frame.startswith("event: sort\n"), f"parked reader was not woken by the update; got {frame!r}"
+            data_line = [ln for ln in frame.splitlines() if ln.startswith("data: ")][0]
+            assert json.loads(data_line.removeprefix("data: "))["current"] == 2
         finally:
             gen.close()
 
@@ -306,12 +344,12 @@ class TestEventsRoute:
             # until the idle branch fires a heartbeat (no updates published, so
             # the queue.get() times out almost immediately).
             heartbeat = None
-            deadline = time.monotonic() + 2.0
+            deadline = time.monotonic() + 10.0
             while heartbeat is None and time.monotonic() < deadline:
                 chunk = next(gen)
                 if chunk.startswith("event: heartbeat\n"):
                     heartbeat = chunk
-            assert heartbeat is not None, "no heartbeat frame arrived"
+            assert heartbeat is not None, "no heartbeat frame arrived within 10s"
             # It is a real event with a JSON data line, never a `: heartbeat`
             # comment.
             assert not heartbeat.startswith(": ")
@@ -328,12 +366,18 @@ class TestEventsRoute:
         comment (invisible to EventSource), never a named event."""
         gen = stream_progress_events(heartbeat_seconds=60.0, keepalive_seconds=0.01)
         try:
-            assert next(gen).startswith(": connected")
-            for _ in initial_snapshot():
-                next(gen)
-            # The next idle wakeup is the socket-probe comment, not a heartbeat.
+            _drain_connect_and_snapshot(gen)
+            # The next *idle* wakeup is the socket-probe comment, not a
+            # heartbeat. A stray progress frame (the global trackers are
+            # shared, and a background thread from elsewhere in the suite can
+            # publish onto one) is not an idle wakeup at all, so skip past it
+            # rather than failing — but never skip a heartbeat, which is the
+            # regression this test exists to catch.
+            deadline = time.monotonic() + 10.0
             chunk = next(gen)
-            assert chunk.startswith(": ")
+            while chunk.startswith("event: ") and not chunk.startswith("event: heartbeat\n") and time.monotonic() < deadline:
+                chunk = next(gen)
+            assert chunk.startswith(": "), f"idle wakeup should be an SSE comment, got {chunk!r}"
             assert "event:" not in chunk
         finally:
             gen.close()
@@ -344,12 +388,12 @@ class TestEventsRoute:
         gen = stream_progress_events(heartbeat_seconds=0.05, keepalive_seconds=0.01)
         try:
             heartbeat = None
-            deadline = time.monotonic() + 2.0
+            deadline = time.monotonic() + 10.0
             while heartbeat is None and time.monotonic() < deadline:
                 chunk = next(gen)
                 if chunk.startswith("event: heartbeat\n"):
                     heartbeat = chunk
-            assert heartbeat is not None, "no heartbeat frame arrived"
+            assert heartbeat is not None, "no heartbeat frame arrived within 10s"
         finally:
             gen.close()
 


### PR DESCRIPTION
Closes #3075

## The race

`test_stream_yields_update_after_subscribe` synchronised with a fixed `time.sleep(0.05)` in a publisher thread, standing in for "the generator has parked on `queue.get()`". Under a co-resident memory-heavy process the thread could miss that window entirely — and because the stream ran with `heartbeat_seconds=60.0` but the *default* `keepalive_seconds=1.0`, the frame the test then read back was the 1s socket-probe comment rather than the update.

Confirmed by widening the sleep past the keepalive on the pre-fix test, which reproduces the reported failure exactly:

```
assert ': ka\n\n'.startswith('event: sort\n')
```

A bare `assert frame.startswith(...)` is also why the original failure said nothing about what went wrong.

## The fix

The park is unobservable *and irrelevant*: subscribers push into a **buffered** queue, so an update published while the generator is suspended is simply waiting for it on the next `next()`. Whether the publish lands before or after the consumer enters `get()`, the frame is the same. So the sleep was guarding a distinction that does not exist — it only ever added a way to lose.

- `test_stream_yields_update_after_subscribe` now publishes inline and reads the frame back — no thread, no sleep — with both `heartbeat_seconds` and `keepalive_seconds` pushed out of reach so nothing but the real update can be the next frame.
- New `test_parked_reader_is_woken_by_an_update_from_another_thread` keeps the cross-thread publish path covered (tracker subscribers run on whichever thread called `update()`). It passes under either interleaving by construction, and caps its blocking read at 10s so a genuine regression fails in seconds with a message instead of hanging.
- The snapshot drain loop's wall-clock deadline is gone: the stream yields the connect comment plus exactly one frame per channel before it can ever block, so a `_drain_connect_and_snapshot` helper pulls that exact count. When the channel set falls short it now names the missing channels.
- The sibling `test_idle_stream_emits_keepalive_comment_between_heartbeats` skips past a stray progress frame (the trackers are process-global, so a background thread elsewhere in the suite can publish onto one) while still failing on a heartbeat — the regression it exists to catch. Its two heartbeat-hunting siblings get 10s deadlines and messages instead of 2s.

## Verification

- `tests/api/test_events_sse.py` — 36 passed, 16 consecutive runs, including 8 under six co-resident ~1.2 GB NumPy/BLAS churn processes on the 4-core box.
- `./run-tests.sh` — full gate chain plus `ALL 8279 TESTS PASSED`.

No product code changed; this is test-synchronisation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_014JZXbDzmfWCtJcjmdxjdFr)_