### PR TITLE
Re-emit tracker channel snapshots on every SSE heartbeat

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -97,9 +97,15 @@ Angular client treats every frame (heartbeat or real progress) as proof of
 life and only declares the backend offline when the stream goes silent. It is
 a real named event rather than an SSE comment (`: heartbeat`) precisely because
 comments are invisible to the browser's `EventSource` API. Each heartbeat tick
-also re-emits the `loading-tasks` and `detector-loading-tasks` channels so
-finished tasks vanish from the UI once they pass their stale-prune window
-without a server-side timer.
+also re-emits **every** channel's current snapshot. For `loading-tasks` and
+`detector-loading-tasks` that is what makes finished tasks vanish from the UI
+once they pass their stale-prune window, without a server-side timer. For the
+single-tracker channels (`dataset`, `sort`, `find`, `eval`) it is a self-heal:
+each client's queue is bounded and drops frames when the client stalls, so a
+channel's single terminal `idle`/`error` frame can be lost and would otherwise
+leave a progress bar stuck at its last percentage until the next operation
+fired that channel. Re-emitting the (tiny) snapshots makes every channel
+eventually consistent after any drop.
 
 Between heartbeats an idle stream also writes a bare SSE comment (`: ka`)
 roughly every second. It is deliberately a comment — invisible to

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -386,9 +386,7 @@ class TestEventsRoute:
             # The only queued frame is the stale `running` one.
             frame = next(gen)
             assert frame.startswith("event: sort\n")
-            payload = json.loads(
-                [ln for ln in frame.splitlines() if ln.startswith("data: ")][0].removeprefix("data: ")
-            )
+            payload = json.loads([ln for ln in frame.splitlines() if ln.startswith("data: ")][0].removeprefix("data: "))
             assert payload["status"] == "running"
 
             # The heartbeat repairs it without any further tracker update.

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -365,6 +365,71 @@ class TestEventsRoute:
         finally:
             dataset_progress.update("idle", "", 0, 0)
 
+    def test_heartbeat_reemits_tracker_channels(self):
+        """A client whose bounded queue overflowed can lose a tracker
+        channel's single terminal frame, which would leave its progress bar
+        stuck at the last percentage until some later operation happened to
+        fire that channel again. The heartbeat re-emits every tracker
+        snapshot, so the client self-heals within one heartbeat (#2960)."""
+        # max_queue=1 makes the overflow deterministic: the first update
+        # fills the queue, the terminal one is dropped just as it would be
+        # for a stalled client behind a burst of per-item frames.
+        gen = stream_progress_events(heartbeat_seconds=0.01, max_queue=1)
+        try:
+            assert next(gen).startswith(": connected")
+            for _ in initial_snapshot():
+                next(gen)
+
+            sort_progress.update("running", "Scoring", 97, 100)
+            sort_progress.update("idle", "Done", 100, 100)  # dropped: queue full
+
+            # The only queued frame is the stale `running` one.
+            frame = next(gen)
+            assert frame.startswith("event: sort\n")
+            payload = json.loads(
+                [ln for ln in frame.splitlines() if ln.startswith("data: ")][0].removeprefix("data: ")
+            )
+            assert payload["status"] == "running"
+
+            # The heartbeat repairs it without any further tracker update.
+            repaired = None
+            deadline = time.monotonic() + 2.0
+            while repaired is None and time.monotonic() < deadline:
+                chunk = next(gen)
+                if chunk.startswith("event: sort\n"):
+                    repaired = json.loads(
+                        [ln for ln in chunk.splitlines() if ln.startswith("data: ")][0].removeprefix("data: ")
+                    )
+            assert repaired is not None, "no re-emitted sort frame arrived"
+            assert repaired["status"] == "idle"
+            assert repaired["current"] == 100
+        finally:
+            gen.close()
+            sort_progress.update("idle", "", 0, 0)
+
+    def test_heartbeat_reemits_every_tracker_channel(self):
+        """The re-emit covers all of ``_TRACKER_CHANNELS``, not just the one
+        that happened to move last."""
+        gen = stream_progress_events(heartbeat_seconds=0.01)
+        try:
+            assert next(gen).startswith(": connected")
+            for _ in initial_snapshot():
+                next(gen)
+
+            seen: set[str] = set()
+            expected = set(_TRACKER_CHANNELS) | set(_TASK_CHANNELS)
+            saw_heartbeat = False
+            deadline = time.monotonic() + 2.0
+            while seen != expected and time.monotonic() < deadline:
+                chunk = next(gen)
+                if chunk.startswith("event: heartbeat\n"):
+                    saw_heartbeat = True
+                elif saw_heartbeat and chunk.startswith("event: "):
+                    seen.add(chunk.split("\n", 1)[0].removeprefix("event: "))
+            assert seen == expected
+        finally:
+            gen.close()
+
     def test_initial_loading_tasks_snapshot(self):
         loading_tasks.create_task("evt_test", name="Evt DS")
         try:

--- a/vtscore/concurrency/events.py
+++ b/vtscore/concurrency/events.py
@@ -30,10 +30,12 @@ from vtscore.concurrency.progress import (
     sort_progress,
 )
 
-#: SSE heartbeat cadence. Also drives the periodic re-emit of task
-#: channels so finished tasks vanish from clients once they pass the
-#: ``LoadingTasksTracker`` stale-prune window without us having to
-#: schedule a background timer for every finish.
+#: SSE heartbeat cadence. Also drives the periodic re-emit of every
+#: channel's snapshot: task channels so finished tasks vanish from clients
+#: once they pass the ``LoadingTasksTracker`` stale-prune window without us
+#: having to schedule a background timer for every finish, and tracker
+#: channels so a client that dropped a terminal frame on queue overflow
+#: recovers within one heartbeat (#2960).
 #:
 #: The heartbeat is the frontend's authoritative "backend is alive" signal
 #: (see ``ConnectionStateService``): as long as a frame — heartbeat or real
@@ -239,8 +241,19 @@ def stream_progress_events(  # noqa: C901
                     # proof the backend is still alive (and keeping idle proxies
                     # open just as a comment would).
                     yield _format_sse("heartbeat", {"ts": time.time()})
-                    # Re-emit task channels so clients see finished tasks
-                    # disappear once their stale-prune window elapses.
+                    # Re-emit every channel's current snapshot. For task
+                    # channels this is what makes finished tasks disappear
+                    # once their stale-prune window elapses. For tracker
+                    # channels it is a self-heal: a client whose bounded
+                    # queue overflowed (see the ``queue.Full`` drops above)
+                    # can lose a channel's single terminal ``idle``/``error``
+                    # frame, which would otherwise leave its progress bar
+                    # stuck at the last percentage until some later operation
+                    # happened to fire that channel again (#2960). Snapshots
+                    # are tiny, so re-emitting them makes every channel
+                    # eventually consistent after any drop.
+                    for name, tracker in _TRACKER_CHANNELS.items():
+                        yield _format_sse(name, tracker.get())
                     for name, tasks_tracker in _TASK_CHANNELS.items():
                         yield _format_sse(name, tasks_tracker.list_tasks())
                     last_heartbeat = time.monotonic()


### PR DESCRIPTION
Closes #2960

## Problem

Each `/api/events` client gets a bounded queue (`max_queue=1024`) whose frames are dropped silently on overflow (`q.put_nowait` → `queue.Full: pass`). Progress producers are chatty — per-item frames during embed/score loops can burst thousands of updates — so a client stalled for a few seconds can overflow and lose a tracker channel's **single terminal `idle`/`error` frame**.

The heartbeat branch re-emitted only `_TASK_CHANNELS`, never `_TRACKER_CHANNELS`, so that drop was never repaired: the client's sort/find/dataset/eval bar stuck at e.g. 97% "running" until some later operation happened to fire that channel again (the frontend derives bar state solely from SSE frames and has no polling fallback). Task channels already had exactly this self-heal for the same reason.

## Change

`vtscore/concurrency/events.py` — the heartbeat branch now also yields `_format_sse(name, tracker.get())` for each `_TRACKER_CHANNELS` entry alongside the task lists. Snapshots are tiny, so every channel becomes eventually consistent (within one 5s heartbeat) after any drop.

Docs: `docs/api/events.md` and the `HEARTBEAT_SECONDS` docstring now describe the re-emit as covering every channel, with the self-heal rationale.

## Frontend impact

Checked every tracker-channel consumer: `find$` (find-view, dashboard, label-view) acts only on `status === 'running'`, and `votingIterations$` (progress modal) stops watching on `done` — which it already receives from the initial per-connect snapshot, so the periodic re-emit adds no new behavior there. `dataset$`, `sort$` and `eval$` have no other direct subscribers.

## Tests

Two new tests in `tests/api/test_events_sse.py`:

- `test_heartbeat_reemits_tracker_channels` — with `max_queue=1` the terminal `idle` frame is deterministically dropped on overflow; the test asserts the client still sees the repaired `idle` snapshot on the next heartbeat with no further tracker update.
- `test_heartbeat_reemits_every_tracker_channel` — the re-emit covers all of `_TRACKER_CHANNELS`, not just the one that moved last.

`./run-tests.sh api` → 624 passed. Full `./run-tests.sh` → all gates green, 8280 passed / 6 skipped. One earlier full run hit `tests_lib/detectors/test_acquisition_threshold.py::test_it_sits_above_the_reporting_cut` (an exact-tie assertion failure); that is the known xdist-ordering flake tracked in #3084, unrelated to this change, and it did not reproduce on re-run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfCMQRctYecH7YNdnLd2ve)_