### PR TITLE
Add docs/FRONTEND.md: an architecture map for the Angular SPA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,10 +431,11 @@ def slow_load():
 ## More docs
 
 - `docs/ARCHITECTURE.md` — directory map, dependency graph, plugin systems, state management (multi-dataset / multi-detector contexts, proxies, `X-Dataset-Id` / `X-Detector-Id` headers), auth, origin tracking.
+- `docs/FRONTEND.md` — Angular SPA architecture: feature-area boundaries, the service layer, the **zoneless change-detection rules**, active dataset/detector propagation, the generated OpenAPI client, component/modal conventions. Read this before changing frontend state or reactivity.
 - `docs/API.md` and `docs/api/*.md` — REST API reference.
 - `docs/CLI.md` — CLI flags and autodetect workflow.
 - `docs/ML.md` — training/scoring details.
 - `docs/EXTENDING.md` + `docs/EXTENDING-plugins.md` + `docs/EXTENDING-media.md` + `docs/EXTENDING-processors.md` — how to add plugins.
 - `docs/plans/` — future-work design docs (open/proposed; shipped work is pruned out, not archived); check here before adding a "Phase N" feature.
 - `docs/RELEASE.md` — the `dev` → `main` release runbook (the procedure the Dev2Main Routine follows: vulture audit, release summary, punch-card refresh, release PR, issue close-out, plan-pointer prune).
-- `docs/style-guide.md` — frontend SCSS conventions.
+- `docs/style-guide.md` — frontend SCSS conventions (the styling half of `docs/FRONTEND.md`).

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The remaining top level:
 └── pyproject.toml    # Project metadata and dependencies
 ```
 
-For the complete directory map, dependency graph, and the app-tier/library-tier rules, see **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
+For the complete directory map, dependency graph, and the app-tier/library-tier rules, see **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**. For the Angular SPA — feature areas, service layer, zoneless change detection, and the generated API client — see **[docs/FRONTEND.md](docs/FRONTEND.md)**.
 
 ## HTTP API
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,6 +5,11 @@ selectively extract** components from VTSearch.  It maps the module
 structure, dependency graph, and public APIs so you can quickly identify
 which pieces you need and how to pull them out.
 
+It covers the **Python tiers**.  The Angular SPA in `frontend/` has its own
+map: **[FRONTEND.md](FRONTEND.md)** — change-detection model, service layer,
+active dataset/detector propagation, the generated API client, and the
+component conventions.
+
 ## Table of Contents
 
 1. [What VTSearch does](#what-vtsearch-does)
@@ -37,7 +42,8 @@ imported/loaded from disk and applied as-is. The architecture combines:
   embedding-based similarity search, with alternative embedders
   available (CLAP Music, BGE). Used to seed a detector during the
   training loop, or as a quick stand-alone search.
-- **Flask web UI**: Angular SPA frontend with a REST API.
+- **Flask web UI**: Angular SPA frontend with a REST API (see
+  [FRONTEND.md](FRONTEND.md)).
 - **Plugin systems**: nine auto-discovered plugin families: dataset
   importers, results exporters, label importers, settings importers/
   exporters/sources, labelset sources, media converters, and media
@@ -258,6 +264,7 @@ VTSearch/
 │
 ├── static/                         Angular build output (HTML + CSS + JS)
 ├── frontend/                       Angular SPA source (components, services, SCSS)
+│                                   -> see docs/FRONTEND.md for the SPA architecture
 ├── tests/                          App-tier test suite (uses Flask client, vtsearch.*)
 └── tests_lib/                      Library-tier test suite (Flask-import-clean, vtscore.*)
 ```
@@ -695,7 +702,11 @@ API endpoints: `POST /api/datasets/registry/<id>/load` (load from pkl),
 
 The Angular frontend's `ActiveContextService` tracks which dataset/model
 the user selected, and `activeContextInterceptor` attaches
-`X-Dataset-Id` / `X-Detector-Id` headers to every API request.
+`X-Dataset-Id` / `X-Detector-Id` headers to every API request.  The
+frontend deliberately splits *intent* (what the user picked) from
+*active* (what the backend has loaded) so the headers never name a
+not-yet-loaded id; see
+[FRONTEND.md § The active dataset/detector context](FRONTEND.md#6-the-active-datasetdetector-context).
 
 ---
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,0 +1,676 @@
+# VTSearch Frontend Architecture
+
+This document maps the Angular single-page app in `frontend/`. It is the
+front-end counterpart to [ARCHITECTURE.md](ARCHITECTURE.md), which covers the
+Python tiers.
+
+It is a **map, not an inventory.** The SPA holds roughly ninety components and
+sixty services; enumerating them here would be a list that rots on the next
+commit. Instead this document explains the handful of mechanisms everything
+else is built on — the change-detection model, the service layer, the
+active-dataset/detector context, the generated API client, and the component
+composition conventions — so that any given file can be placed by reading its
+neighbours.
+
+**What lives elsewhere:**
+
+| For | See |
+|-----|-----|
+| Build commands, dev server, Angular upgrade mechanics | [`frontend/README.md`](../frontend/README.md) |
+| SCSS tokens, shared classes, copy style | [style-guide.md](style-guide.md) |
+| REST endpoint reference | [API.md](API.md) and [api/](api/) |
+| Backend state model, per-dataset contexts, auth | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| Modal back-button rules, desktop-only scope, budget policy | [`CLAUDE.md`](../CLAUDE.md) |
+
+## Table of contents
+
+1. [Shape of the app](#1-shape-of-the-app)
+2. [Directory layout](#2-directory-layout)
+3. [Feature areas and their boundaries](#3-feature-areas-and-their-boundaries)
+4. [The service layer](#4-the-service-layer)
+5. [Reactivity: the zoneless change-detection model](#5-reactivity-the-zoneless-change-detection-model)
+6. [The active dataset/detector context](#6-the-active-datasetdetector-context)
+7. [Talking to the backend](#7-talking-to-the-backend)
+8. [Component composition conventions](#8-component-composition-conventions)
+9. [Styling](#9-styling)
+10. [Testing](#10-testing)
+11. [Build and serve](#11-build-and-serve)
+12. [Invariants](#12-invariants)
+
+---
+
+## 1. Shape of the app
+
+Angular 21, TypeScript 5.9, **standalone components** (no `NgModule`s),
+**zoneless change detection** (no `zone.js` anywhere — app, tests, or
+`package.json`), built by the esbuild-based `@angular/build:application`
+builder. Desktop-only: there are no responsive breakpoints and none should be
+added.
+
+Bootstrap is three files deep:
+
+```
+src/main.ts            bootstrapApplication(AppComponent, appConfig)
+src/app/app.config.ts  the entire provider graph (below)
+src/app/app.component.ts  persistent chrome + <router-outlet>
+```
+
+`app.config.ts` is the whole composition root:
+
+```ts
+providers: [
+  provideZonelessChangeDetection(),
+  provideRouter(routes),
+  provideHttpClient(withInterceptors([
+    timezoneInterceptor,        // X-Timezone-Offset
+    activeContextInterceptor,   // X-Dataset-Id / X-Detector-Id
+    achievementsRefreshInterceptor,
+    errorInterceptor,           // toasts + offline circuit breaker
+  ])),
+]
+```
+
+Every service is `@Injectable({ providedIn: 'root' })` unless it is
+deliberately component-scoped (see
+[§8](#8-component-composition-conventions)), so there is no other provider
+list to keep in sync.
+
+`AppComponent` owns everything that outlives a route: the header (burger menu
+of recent sessions, dataset/detector pulldowns, achievements/help/settings
+buttons), the toast container, the offline banner, the dialog host, the
+achievement-unlock host, and the app-level modals (Settings, Achievements,
+Keyboard help, Add Dataset, New Detector). Route content renders into
+`<router-outlet>` inside `.main-content`.
+
+**Routes** (`app.routes.ts`) are all lazy (`loadComponent`) and encode the
+active context in the URL:
+
+| Path | Guard | View |
+|------|-------|------|
+| `/dashboard` | — | Dataset & detector management |
+| `/label/:datasetId/:detectorId` | `activeContextGuard` | Labeling / training |
+| `/find/:datasetId/:detectorId` | `activeContextGuard` | Multi-dataset search |
+| `/browse/:datasetId` | `browseContextGuard` | VTSBrowse projection canvas |
+
+Bare `/label`, `/find`, `/browse` (and anything unmatched) redirect to
+`/dashboard`: a half-specified pair is not a representable state, so there is
+nothing to render.
+
+---
+
+## 2. Directory layout
+
+```
+frontend/
+├── angular.json            Builder wiring, production budgets, the dedicated `test` build config
+├── ng-openapi-gen.json     Generated-client config (output: src/app/generated/api-client)
+├── openapi.json            Committed snapshot of the Flask spec (see §7)
+├── proxy.conf.json         Dev server: /api and /static → localhost:5000
+├── vitest.config.ts        isolate: true (see §10)
+├── docs-assets/            Symlink to docs/user/ — the in-app user guide is served from here
+├── public/                 Favicons, logo (copied verbatim into the build output)
+├── scripts/
+│   └── openapi-gen-cached.mjs   Hash-stamped wrapper around ng-openapi-gen
+└── src/
+    ├── main.ts, index.html, test-setup.ts
+    ├── styles.scss         Global stylesheet entry; @use's the scss/ partials
+    ├── scss/               _variables (design tokens), _layout, _components,
+    │                       _data-table, _picker-shared — global, class-only rules
+    └── app/
+        ├── app.component.*, app.config.ts, app.routes.ts
+        ├── components/     One directory per component; feature areas nest (see §3)
+        ├── services/       API services, state services, coordination services (§4)
+        ├── guards/         Route guards that resolve the URL pair into context (§6)
+        ├── interceptors/   The four HTTP interceptors (§7)
+        ├── directives/     Cross-cutting DOM behaviour (`no-focus-steal`)
+        ├── models/         Hand-written types the OpenAPI spec cannot describe (§7)
+        ├── utils/          Pure functions — no Angular DI, trivially unit-testable
+        ├── testing/        Shared TestBed fragments and zoneless helpers (§10)
+        └── generated/      **gitignored**; regenerated from openapi.json on prebuild/pretest
+```
+
+Two rules keep this navigable:
+
+- **A component's directory holds its children.** `dashboard/` contains
+  `dataset-card/`, `new-detector-modal/`, `combine-datasets-modal/`, …
+  because nothing outside the Dashboard uses them. A component used by two
+  feature areas moves up to `components/`.
+- **`utils/` is Angular-free.** Anything in there is a pure function over
+  plain data (clip windows, progress formatting, grid-icon sizing, keyboard
+  shortcut matching). If it needs `inject()`, it is a service, not a util.
+
+---
+
+## 3. Feature areas and their boundaries
+
+Four routed views, plus the shared chrome. Their boundaries are worth knowing
+because they determine which service a new piece of state belongs to.
+
+### Dashboard (`components/dashboard/`)
+
+The largest area by code volume. Dataset and detector cards, the sortable
+managed-column tables behind them, per-row loading progress, and the entry
+points into every creation flow (Add Dataset, New Detector, Combine…). It is
+deliberately a **thin layout/wiring shell**: its state was lifted into
+singleton services so the top-bar pulldowns can mirror it without depending on
+the component —
+
+- `DashboardColumnsService` — the two `ManagedColumns` instances (sort/visibility).
+- `DashboardModalsService` — which row-action modal is open, for what target.
+- `DashboardLoadingTasksService` — per-task loading rows, and the
+  poll-until-settled-then-refresh bookkeeping.
+- `DashboardSelectionService` — the highlighted table rows (which drive
+  Train / Find / Combine / Delete), bridged to the top-bar pulldowns so they
+  show what is *selected* while the Dashboard is on screen, not merely what is
+  loaded.
+
+The Add-Dataset and New-Detector flows are *not* owned by the Dashboard at
+all: `NewThingFlowsService` is a singleton opener, and the modals are rendered
+by `AppComponent` inside `@defer` blocks, so any surface can start those flows.
+
+### Label view (`components/label-view/`)
+
+The training loop. A three-panel layout (`vt-left-panel`, `vt-center-panel`,
+`vt-right-panel`) with draggable dividers (`panel-resize.directive.ts`), plus
+`LabelViewPanelStateService` — a **component-provided** (not root) service
+holding per-media-type panel preferences.
+
+The three panels are shared with the Find view:
+
+- **Left** — media list (virtual scroller), sort bar, inclusion slider, stripe
+  overview, select mode, and the **Autopilot panel** that drives the automated
+  vote → train → re-sort loop.
+- **Center** — the media viewer, one child per media type (image, text, video,
+  audio, document) plus the voting overlay.
+- **Right** — labels, labelsets, vote grid, and the detector context bar.
+
+### Find view (`components/find-view/`)
+
+Multi-dataset × multi-detector search. Reuses the same three panels but drives
+them from find results rather than a single loaded dataset, and can hand a
+subset of result ids to Browse (`BrowseSubsetService`) so the positives of a
+Find run become their own projection.
+
+### Browse view (`components/browse-*`)
+
+VTSBrowse: a UMAP projection rendered on a canvas as a hex-tile pyramid. This
+area is unusual and mostly self-contained — `browse-canvas` is the single
+largest component in the app because it owns the render loop. Its state is
+split across small services rather than living in the canvas:
+`BrowseViewportService` (visible region, shared with the minimap),
+`BrowseSelectionService` (selection at *item* granularity, so it stays coherent
+as bins split and merge across zoom levels), `TileCacheService`,
+`BrowsePrepService` (load + project before navigating), and
+`ProjectionApiService`.
+
+### Shared chrome
+
+`AppComponent`'s header, `context-pulldown` (the dataset and detector
+pickers, plus the incompatible-pair explainer), `toast-container`,
+`dialog-host`, `offline-banner`, `achievement-*`. Anything here must work on
+every route.
+
+**Where does new code go?** If it is used by one view, nest it under that
+view's directory. If two views need it, promote it to `components/` and give
+its state a root service. If it is state two *services* need, it belongs in a
+service of its own — the pattern the Dashboard and Browse areas already
+follow.
+
+---
+
+## 4. The service layer
+
+`services/` holds three distinct kinds of file. The suffix tells you which.
+
+### `*-api.service.ts` — thin typed HTTP wrappers
+
+One method per endpoint, returning an `Observable` of a generated type. They
+hold **no state**. Each wraps a function from the generated client rather than
+hand-building a URL:
+
+```ts
+getMediaIds(): Observable<MediaIdsListResponse[]> {
+  return listMediaIds(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+}
+```
+
+They are split to roughly mirror the backend's route modules
+(`vtsearch/routes/datasets/{listings,registry,ui}.py` →
+`datasets-{listings,registry,ui}-api.service.ts`, and so on). The mirror is
+approximate and does not need to be exact; the split exists to keep any one
+file readable.
+
+### `*-state.service.ts` — client-side state
+
+The stores the views bind to: `MediaStateService` (the dataset-wide media stub
+list and current selection), `VoteStateService` (the per-pile vote sets, undo
+and redo), `SortStateService`, `SettingsStateService`, `DatasetStateService`
+(the registry listing), `LabelsetStateService`, `AutopilotStateService`.
+
+They own state and the reactive surface over it; they call API services for
+I/O. A component should almost never call an API service *and* keep the result
+in a field that another component also needs — that is a state service.
+
+### Coordination services — everything else
+
+The ones worth knowing before changing anything:
+
+| Service | Responsibility |
+|---------|----------------|
+| `ActiveContextService` | The active (dataset, detector) pair, split into intent/active layers ([§6](#6-the-active-datasetdetector-context)) |
+| `ContextSwitchService` | Drives a pair change end to end: intent → load → promote to active |
+| `ActiveContextWatcherService` | Reacts when an active id disappears from the registry (deleted elsewhere) |
+| `ProgressEventsService` | The single `EventSource` over `/api/events`, fanned out per channel |
+| `ConnectionStateService` | Online/offline, and the probe that reopens the circuit breaker |
+| `ToastService` | Toasts, including the structured `ErrorContext` from failed requests |
+| `VtDialogService` | `confirm()` / `prompt()` as promises, rendered by `dialog-host` |
+| `NewThingFlowsService` | Singleton openers for the Add-Dataset / New-Detector flows |
+| `MediaMetadataCacheService` | Lazy batched fetch of full metadata for whatever is in the viewport |
+| `KeyboardService`, `ThemeService`, `AchievementsService`, `AuthService` | App-wide concerns wired in `AppComponent` |
+
+`adaptive-poll.ts` is not a service but a shared operator; see
+[§7](#7-talking-to-the-backend).
+
+---
+
+## 5. Reactivity: the zoneless change-detection model
+
+**This is the section to read before touching any state.**
+
+The app runs `provideZonelessChangeDetection()` and `zone.js` is gone
+end-to-end. There is no monkey-patched `setTimeout`, no zone tick after an
+HTTP callback, no implicit "something happened, re-render everything". Angular
+refreshes a view only when it is *notified*, and the notifications are:
+
+1. A **signal** read during that view's template evaluation is written.
+2. A **template-bound event** fires (`(click)`, `(widthChange)`, …).
+3. `AsyncPipe` emits, or an `@Input`/signal input changes.
+4. Something explicitly calls `markForCheck()` / `ApplicationRef.tick()`.
+
+Anything else that mutates rendered state produces a **stale view** — the
+value changed, the DOM did not. That is the characteristic frontend bug in
+this codebase, and it is silent.
+
+### The rules
+
+- **State that a template reads must be a signal**, or must reach the template
+  through `AsyncPipe` / `toSignal`. Writing a plain field from an HTTP
+  continuation, a timer, an `EventSource` callback, or a promise `.then()`
+  notifies nobody.
+- **Getter-over-signal is the sanctioned migration shape.** Several state
+  services expose `get sortBusy() { return this._sortBusy(); }` over a private
+  signal, so existing `sortState.sortBusy` bindings stayed byte-identical while
+  becoming reactive. A signal read through a getter during template evaluation
+  *is* tracked as a dependency of that view —
+  `testing/getter-signal-zoneless.spec.ts` pins this.
+- **Consumers use `effect()`, not `subscribe()`.** A constructor `effect()`
+  reading a signal auto-disposes with the component, which is why the
+  `takeUntil(destroy$)` / `ngOnDestroy` plumbing has been dropped wherever it
+  was the last user.
+- **Reads go through `rxResource`.** The read path is being migrated onto
+  Angular's reactive resource primitives (`SettingsStateService`,
+  `MediaStateService`, several picker modals so far). `rxResource({ params,
+  stream })` wraps the *existing* generated-client method, so the typed client
+  and interceptor chain are untouched and the service's public surface becomes
+  `valueSignal()` / `isLoading()` / `error()`. Prefer it over raw
+  `httpResource`, which would bypass the generated client. The remaining
+  conversion recipe and the list of still-open call sites live in
+  [`docs/plans/httpresource-migration.md`](plans/httpresource-migration.md).
+- **Mutations, SSE and pollers stay imperative** — POST/PUT/DELETE remain
+  plain `HttpClient` calls; write the server's response back into the store.
+  This is a deliberate boundary, not an unfinished migration.
+- **Every component is `ChangeDetectionStrategy.OnPush`.** All of them, with
+  no exceptions today. A new component should be too.
+- **Callbacks from outside Angular must write a signal.** The SSE pump, canvas
+  RAF loops, and the drag handlers that deliberately run outside Angular
+  (`panel-resize.directive.ts`) all reach the UI either by writing a signal or
+  by emitting through a template-bound output. `NgZone.run()` is a no-op here
+  and is not the fix.
+- **A `BehaviorSubject` service is not wrong, but its bridge is load-bearing.**
+  Roughly a third of the services still hold RxJS subjects; each is
+  change-detected via its `toSignal`/`AsyncPipe` bridge. A missed bridge is a
+  stale-view bug, not merely a slow one.
+
+`AsyncPipe`, `toSignal`, and `toObservable` are all in use and all fine. What
+is never fine is a rendered value with no notification path.
+
+---
+
+## 6. The active dataset/detector context
+
+The backend resolves per-dataset and per-detector state from the
+`X-Dataset-Id` / `X-Detector-Id` request headers (see
+[ARCHITECTURE.md § Multi-dataset support](ARCHITECTURE.md#multi-dataset-support)).
+The frontend's job is to make sure those headers name a pair the backend has
+actually loaded. Four pieces cooperate.
+
+### `ActiveContextService` — two layers, not one
+
+```
+intent   what the user just picked (pulldown click, deep link)  → UI affordances
+active   what the backend has loaded                            → HTTP headers
+```
+
+The split exists to fix a real cascade: tagging requests with the new ids the
+instant a pulldown was clicked produced a storm of `409 dataset_not_loaded`
+until the load finished. `intent` updates immediately so the pulldown
+highlights; `active` lags until a load completes and is promoted explicitly.
+
+- Read the pair as a whole via `pair$` / `intentPair$` (subscribing to the two
+  halves separately fires twice for one atomic change).
+- `setActivePair()` writes both layers — for cleanup paths only (registry
+  watcher, `clear()`, tests).
+- `nextRequestId()` / `currentRequestId` implement **latest-caller-wins**: a
+  prep step captures the id at start and discards its result if the id has
+  moved. Cancelling in-flight work is best-effort; this check is the
+  correctness guarantee.
+
+### `ContextSwitchService` — the only way to *change* the pair
+
+`switchTo()` tags intent, kicks off whatever dataset/detector loads are
+needed, and promotes to active only once they settle. It has cancel-and-replace
+semantics and a `switching$` observable for loading UI. A failed load must not
+promote — that would re-open the 409 cascade.
+
+### `activeContextInterceptor` — the header attachment
+
+Reads the **active** layer only and sets each header when its id is non-empty.
+That is the whole interceptor; all the difficulty lives upstream in the
+intent/active split.
+
+**Native element requests bypass it entirely.** `<img src>`, `<audio src>`, and
+`<video src>` are browser requests, not `HttpClient` requests, so they carry no
+headers. Build those URLs with `ActiveContextService.mediaUrl(path, extra?)`,
+which appends `dataset_id` / `detector_id` query params from the active layer.
+
+### Routes and guards — the URL is the source of truth
+
+`/label/:datasetId/:detectorId` and `/find/:datasetId/:detectorId` carry the
+pair so reload, share links, and browser back/forward all work.
+`activeContextGuard` resolves the URL pair before the view renders: it awaits
+the registry fetch (a cold deep-link can arrive first), toasts and redirects to
+`/dashboard` for an unknown id, fast-paths when the pair already matches, and
+otherwise holds activation on `ContextSwitchService.applyActivePair(...)`. An
+*incompatible* pair (mismatched media types) is allowed through — the
+`vt-incompatible-pair-explainer` overlay is a legitimate UI state.
+
+`browseContextGuard` is the dataset-only variant, with one carve-out:
+ephemeral detector-positive contexts (`__detpos__<id>`) are built server-side,
+are deliberately absent from the registry, and skip the checks.
+
+Finally, `ActiveContextWatcherService` watches the registry against the active
+pair and, when an id disappears (deleted from another tab, the CLI, or another
+session), clears the affected half, toasts, and bounces off any now-broken
+view.
+
+---
+
+## 7. Talking to the backend
+
+### The generated OpenAPI client
+
+`frontend/openapi.json` is a **committed snapshot** of the Flask-smorest spec.
+`ng-openapi-gen` turns it into `src/app/generated/api-client/` — typed models
+plus one function per operation. The generated tree is **gitignored** and
+rebuilt automatically:
+
+```
+prebuild / prebuild:prod / pretest / pretest:ci
+    → node scripts/openapi-gen-cached.mjs
+```
+
+The wrapper hashes the spec, the generator config, and the generator's own
+version, and skips regeneration when nothing moved (`--force`, or
+`npm run generate-api-client`, regenerates unconditionally).
+
+The snapshot itself is gated: `./run-tests.sh` re-dumps the spec from the
+running Flask app and **fails if `frontend/openapi.json` is stale**. When you
+change a backend schema or route, run `npm run regenerate-openapi-snapshot`
+and commit the result. That gate is what makes a backend field rename a
+TypeScript compile error instead of a runtime surprise.
+
+The client is configured with `apiService: false` — there is no generated
+god-service. Hand-written `*-api.service.ts` files call the generated
+functions, which is what lets them stay thin while keeping the typed contract.
+
+### `models/api.models.ts` — what stays hand-written
+
+Everything the spec describes is **re-exported** from the generated tree, not
+mirrored. Only three categories are hand-written, because the spec cannot
+describe them:
+
+- **SSE payloads** (`ProgressEvent`, `LoadingTask`, …) — `/api/events` is a raw
+  streaming response flask-smorest does not model.
+- **Client-only shapes** that no endpoint returns.
+- **Request-side settings shapes** the frontend builds and posts.
+
+Adding a hand-written interface that duplicates a generated one is a
+regression: it can drift, and the compile-time guarantee is exactly what is
+lost.
+
+### The interceptor chain
+
+Order matters; it is fixed in `app.config.ts`.
+
+1. **`timezoneInterceptor`** — attaches `X-Timezone-Offset` so the backend can
+   bucket achievement milestones by the user's wall clock, not UTC.
+2. **`activeContextInterceptor`** — the context headers ([§6](#6-the-active-datasetdetector-context)).
+3. **`achievementsRefreshInterceptor`** — after a POST to any endpoint that
+   could unlock a tier (vote, find, label import, dataset load), schedules a
+   coalesced achievements refresh.
+4. **`errorInterceptor`** — the failure chokepoint. Turns every failed response
+   into a structured `ErrorContext` toast (endpoint, status, `request_id`, and
+   the active pair at the time), deduped by status + message so one backend
+   condition surfacing from several in-flight requests shows once. It also
+   implements the **offline circuit breaker**: while offline, requests
+   short-circuit to a synthetic network error without touching the wire, which
+   is what stops the console filling with `ERR_CONNECTION_REFUSED`.
+   `ConnectionStateService`'s probe (tagged with the `CONNECTION_PROBE` context
+   token) is the one request allowed through.
+
+Opt a single request out of the global toast with the `SKIP_ERROR_TOAST`
+`HttpContextToken` — for probes that expect a 404, retry loops, and forms that
+render their own inline validation. The error still propagates to
+`catchError`/`error:` handlers; only the toast is suppressed.
+
+### Server push, and polling when push won't do
+
+`ProgressEventsService` holds **one** `EventSource` on `/api/events` and fans
+it out to every consumer, replacing what used to be several REST polls.
+Channels: `server` (a per-connect `boot_id`, so a backend restart fires
+`serverReset$` and consumers can drop state keyed on dead `task_id`s),
+`dataset`, `loading-tasks`, `detector-loading-tasks`, `sort`, `find`, `eval`.
+Every channel carries the same `ProgressEvent` shape, so any of them can be
+rendered by `utils/format-progress.ts`. The channel state is held in signals —
+a signal write inside the SSE callback notifies Angular's scheduler directly,
+which is precisely what makes the pump work without zone.js.
+
+Where a real poll is still needed, use `adaptivePoll()` from
+`services/adaptive-poll.ts` rather than `timer(0, n)` + `switchMap`. It runs
+each request to completion before scheduling the next (a `switchMap` timer
+cancels in-flight requests, so a backend slower than the interval froze the
+panel permanently), eases from `fastMs` to `slowMs` after N unchanged
+responses, and suspends entirely while the tab is hidden. Callers own teardown
+via `takeUntil(stop$)`.
+
+---
+
+## 8. Component composition conventions
+
+- **Standalone, `OnPush`, `vt-` selector prefix.** (`AppComponent` is the sole
+  `app-` selector, as the bootstrap root.)
+- **Signal inputs and outputs** (`input()`, `output()`) for new components;
+  older decorators survive in places and are converted opportunistically.
+- **Presentational children, stateful parents.** The larger pickers are
+  explicit about this: `vt-source-picker` takes precomputed lists as inputs,
+  emits user actions as outputs, and lets the parent decide what they mean —
+  which is how the same widget serves both the Add-Dataset modal (run an
+  importer) and the New-Detector modal (materialise one example file). Layout
+  that differs between hosts is projected into named content slots rather than
+  branched on inside the child.
+
+### Modals
+
+`vt-modal` (`components/modal/`) is the shared shell: backdrop, CDK focus
+trap, close button, and a module-level **stack** of open instances so Escape
+dismisses only the topmost one. Modals genuinely nest here (New Detector →
+media crop, Settings → importer picker, anything → a confirm dialog), and
+without the stack one keypress closed them all and lost the outer form.
+
+- `dialog-host` + `VtDialogService` provide promise-returning `confirm()` /
+  `prompt()`, including the standardised `confirmDestructive()` phrasing.
+  Purely informational messages go to `ToastService`, never a modal.
+- **Back vs Cancel is a rule, not a preference.** An inner view that *replaces*
+  an outer one gets a left-aligned `← Back` chevron; `Cancel` in the footer
+  means "abandon the whole dialog". A picker whose tab bar stays visible has no
+  outer view to return to and correctly has no back button. The full rule,
+  including the canonical markup and the persistent-tab exception, is in
+  [`CLAUDE.md`](../CLAUDE.md) under "Nested-modal back buttons".
+
+### Lazy loading and the bundle budget
+
+Routes are lazy by construction. Beyond that, the heavy app-level modals are
+imported by `AppComponent` but used **only inside `@defer` blocks**, so Angular
+splits them into separate chunks — they drag in the file browser, the crop
+modal and `marked`, which together push the eager bundle over budget.
+
+The production `initial` budget is deliberately tight and the rationale is
+written into `angular.json` next to the number. `./run-tests.sh` treats **any**
+`▲ [WARNING]` from `build:prod` as a hard failure, including the 8 kB
+`anyComponentStyle` budget. Fix the bloat — split the component, extract shared
+styles, delete dead rules. Raising a budget needs the user's explicit approval.
+
+### Other primitives
+
+`components/icon/` maps names (and backend-supplied emoji) to sanitised inline
+SVG, cached per process. `components/context-menu/`, `drop-zone/`,
+`skeleton/`, `progress-bar/`, `job-progress/`, `clipboard-copy/` are the small
+shared widgets. `directives/no-focus-steal.directive.ts` stops toolbar buttons
+next to the Browse canvas from swallowing keyboard focus on mousedown.
+
+Services are root-provided by default; provide one on a component only when
+per-instance state is the point (`LabelViewPanelStateService` is the current
+example).
+
+---
+
+## 9. Styling
+
+[style-guide.md](style-guide.md) is authoritative for design tokens, shared
+classes, patterns, and copy style. The structural facts:
+
+- `src/styles.scss` is the global entry and `@use`s the partials in
+  `src/scss/`: `_variables` (the `--space-*` / `--font-*` / `--radius-*` /
+  color / z-index token set), `_layout`, `_components` (the shared `.btn`,
+  `.back-btn`, card, form and modal classes), `_data-table`, `_picker-shared`
+  (the `.tab-bar` / `.tab` primitive).
+- Everything global is **class-only**, so it applies everywhere without
+  bleeding through component encapsulation.
+- Component `.scss` files hold only what is genuinely local. A rule that two
+  components want belongs in `_components.scss` — that is also how the
+  8 kB per-component style budget stays satisfiable.
+- Themes (dark / light / high-viz / system) are token swaps driven by
+  `ThemeService`; components should read tokens, not hardcode colors.
+
+If your change alters a GUI surface framed by a screenshot in the user docs,
+add the shot id to `docs/user/screenshots-reshoot-queue.md` — the wiring check
+in `./run-tests.sh` keeps that queue honest.
+
+---
+
+## 10. Testing
+
+The suite runs on **Vitest + jsdom** via the `@angular/build:unit-test`
+builder. No browser is needed, which is why it works in the cloud container.
+
+```bash
+cd frontend && npm run test:ci     # headless, one shot
+cd frontend && npm test            # watch
+./run-tests.sh frontend            # build:prod + npm audit + Vitest
+```
+
+Shared fragments live in `src/app/testing/` and compose freely in a
+`providers` array:
+
+- `provideHttpTesting(...interceptors)` — the
+  `provideHttpClient` + `provideHttpClientTesting` pair, optionally with
+  interceptors under test.
+- `provideZoneless()` / `configureZoneless()` — put the `TestBed` under
+  zoneless change detection.
+- `mocks.ts` — shared service stubs.
+
+### The zoneless oracle
+
+A normal spec that pumps `fixture.detectChanges()` by hand **masks** exactly
+the staleness bug zoneless introduces: it force-renders regardless of whether
+anything was notified. So a spec auditing that property must (1) add
+`provideZonelessChangeDetection()`, (2) **remove** the manual pumps — a
+leftover pump both re-masks the bug and can race auto-detect into NG0100, (3)
+drive updates through the same channel the app uses (write the service
+signal, dispatch the bound event), (4) `await settleZoneless(fixture)`, and
+(5) assert on rendered DOM, not component fields. The `*.zoneless.spec.ts`
+files on the main views are the worked examples.
+
+### `rxResource` timing
+
+The loader is effect-scheduled and promise-based, which changes test timing
+even though runtime behaviour is unaffected:
+
+- `fixture.detectChanges()` does **not** issue the GET — call `TestBed.tick()`
+  before `httpMock.expectOne(...)`.
+- The value commits on a microtask — `await settleResource()` after
+  `flush()` (advancing fake timers alone does not commit it).
+
+### Other conventions
+
+`src/test-setup.ts` installs the inert jsdom stubs (`EventSource`,
+`ResizeObserver`, `scrollIntoView`, `CSS.escape`, media element methods,
+canvas `getContext`) and resets the `TestBed` before each test so a throwing
+teardown cannot cascade. `vitest.config.ts` sets `isolate: true` so a dirty
+singleton cannot poison later files. No spec uses `fakeAsync`/`tick`: time is
+driven with `vi.useFakeTimers()` plus real macrotask drains.
+
+---
+
+## 11. Build and serve
+
+```bash
+cd frontend
+npm install
+npm start          # dev server on :4200, proxying /api and /static to :5000
+npm run build:prod # → ../static/ (index.html, main.js, styles.css)
+```
+
+Flask serves the built output from `static/`, whose build artifacts are
+gitignored — every deployment builds them. `public/` is copied verbatim into
+the output alongside them (favicons, logo); `docs-assets/` is a
+symlink to `docs/user/`, so the in-app user guide (rendered with `marked` in
+the keyboard-help modal) is the same file the repo ships.
+
+`angular.json` pins the canonical `@angular/build:*` builders (not the
+`@angular-devkit/build-angular:*` aliases) and gives the test target its own
+`build:test` configuration, so spec polyfills stay decoupled from production.
+Both polyfill arrays are empty and must stay that way — reintroducing
+`zone.js` would invalidate every rule in [§5](#5-reactivity-the-zoneless-change-detection-model).
+The Angular upgrade runbook is in [`frontend/README.md`](../frontend/README.md).
+
+---
+
+## 12. Invariants
+
+The short list of things that break silently if violated:
+
+- **No `zone.js`.** Not in the app, not in the test build, not in
+  `package.json`.
+- **Rendered state has a notification path** — signal write, bound event, or
+  async-pipe emission. A plain field written from a callback is a stale view.
+- **Only `ContextSwitchService` changes the active pair.** Promoting a pair the
+  backend has not loaded reopens the 409 cascade.
+- **Native `src` URLs go through `mediaUrl()`.** Interceptors do not run for
+  `<img>` / `<audio>` / `<video>`.
+- **`openapi.json` is regenerated when the backend spec changes**, and the
+  generated client is never edited or committed.
+- **Hand-written types never duplicate generated ones** — re-export instead.
+- **New components are standalone + `OnPush`**, with a `vt-` selector.
+- **Build warnings are failures.** Fix the bloat rather than the budget.
+- **Desktop only.** No responsive breakpoints, no touch affordances.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -55,7 +55,8 @@ deployments. Runs locally or in Docker.
 | [SETUP.md](SETUP.md) | Installation, prerequisites, getting started, basic Docker usage |
 | [user/USER_GUIDE.md](user/USER_GUIDE.md) | End-user walkthrough: training a detector with Autopilot, manual mode, applying existing detectors, sort modes, dashboard, exporting |
 | [DEPLOYMENT.md](DEPLOYMENT.md) | Production deployment, offline mode, network deps, env vars, data directory, troubleshooting |
-| [ARCHITECTURE.md](ARCHITECTURE.md) | Module structure, dependency graph, extractability matrix, state management |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Module structure, dependency graph, extractability matrix, state management (Python tiers) |
+| [FRONTEND.md](FRONTEND.md) | Angular SPA architecture: feature areas, service layer, zoneless change detection, active dataset/detector context, generated API client, component conventions |
 | [API.md](API.md) | HTTP API reference (all REST endpoints, request/response formats) |
 | [CLI.md](CLI.md) | Command-line interface reference (autodetect, importers, exporters) |
 | [ML.md](ML.md) | Detector-head architecture, training config, embedding models, threshold calibration, Coverage Atlas |

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -512,5 +512,6 @@ When you add a new token:
 - `frontend/src/scss/_picker-shared.scss` - importer/exporter tabs, picker table, badges.
 - `frontend/src/scss/_data-table.scss` - dashboard table.
 - `frontend/src/scss/_layout.scss` - 3-panel grid.
+- `docs/FRONTEND.md` - SPA architecture: feature areas, service layer, zoneless change detection, component conventions.
 - `CLAUDE.md` - Back vs Cancel rules, desktop-only scope.
 - `.claude/scripts/style-check.py` - static SCSS audit (invoked via the `/style-check` skill).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,43 +26,17 @@ npm run build:prod
 
 This compiles the Angular app and outputs the build artifacts to `../static/` (the project root's `static/` directory), where Flask serves them. Output files: `index.html`, `main.js`, `polyfills.js`, `styles.css`.
 
-## Project structure
+## Architecture
 
-```
-src/app/
-├── app.component.ts          # Root component
-├── app.routes.ts              # Route definitions
-├── components/                # UI components
-│   ├── center-panel/          # Media viewer (image, text, video, audio, document)
-│   ├── left-panel/            # Media list, sort bar, inclusion slider, autopilot
-│   ├── right-panel/           # Labels and detector context
-│   ├── dashboard/             # Dataset and model management UI
-│   ├── label-view/            # Main labeling view (orchestrates left/center/right panels)
-│   ├── find-view/             # Multi-dataset search interface
-│   ├── login/                 # Authentication screen
-│   ├── modals/                # 17 modal dialogs (export, import, settings, progress, etc.)
-│   ├── dialog-host/           # Modal container
-│   ├── file-browser/          # Server file picker
-│   ├── progress-bar/          # Progress indicators
-│   └── icon/                  # Icon system
-├── services/                  # State management and API communication
-│   ├── *-api.service.ts       # API services (one per backend module)
-│   ├── *-state.service.ts     # Client-side state services
-│   ├── active-context.service.ts  # Tracks selected dataset/detector
-│   ├── dialog.service.ts      # Modal management
-│   ├── keyboard.service.ts    # Keyboard shortcuts
-│   └── theme.service.ts       # Theme (light/dark) switching
-├── interceptors/
-│   └── active-context.interceptor.ts  # Attaches X-Dataset-Id/X-Detector-Id headers
-└── models/
-    └── api.models.ts          # TypeScript interfaces for API responses
-```
+The SPA's architecture lives in **[`../docs/FRONTEND.md`](../docs/FRONTEND.md)**:
+directory layout and feature-area boundaries, the service layer, the
+**zoneless change-detection rules**, active dataset/detector propagation and
+the `X-Dataset-Id` / `X-Detector-Id` headers, the generated OpenAPI client, and
+the component/modal composition conventions. Styling conventions are in
+[`../docs/style-guide.md`](../docs/style-guide.md).
 
-### Key architecture patterns
-
-- **ActiveContextService** tracks which dataset and detector the user has selected. The `activeContextInterceptor` attaches `X-Dataset-Id` and `X-Detector-Id` headers to every API request so the backend resolves the correct per-dataset state.
-- **State services** (`media-state`, `dataset-state`, `vote-state`, `sort-state`, `settings-state`) hold client-side state and expose signals (or, for the not-yet-migrated services, observables) for reactive UI updates.
-- **API services** (`medias-api`, `datasets-api`, `detectors-api`, etc.) wrap HTTP calls to the Flask backend. Each maps to a backend route module.
+This file stays scoped to the build: commands, test wiring, and the Angular
+upgrade runbook.
 
 ## Running unit tests
 


### PR DESCRIPTION
Closes #2998

An entire tier of the codebase had one line of structural documentation
(`ARCHITECTURE.md`'s directory-map entry for `frontend/`) and no document
explaining how the SPA actually works. `docs/FRONTEND.md` fills that gap.

## Approach

**A map, not an inventory.** The issue is explicit that ~90 components should
not be enumerated by hand, for the same reason the registry tables shouldn't
be — a hand-maintained list is what the documentation audit found drifting
everywhere else. So the doc explains the *mechanisms* everything is built on,
and names individual files only where the file is load-bearing (the four
interceptors, the context services, the guards). Anything else can be placed by
reading its neighbours.

Where a mechanism is already documented accurately elsewhere, the doc points
rather than restates: the Back-vs-Cancel rule to `CLAUDE.md`, SCSS tokens to
`style-guide.md`, endpoints to `API.md`, the remaining `rxResource` conversion
recipe to `docs/plans/httpresource-migration.md`.

## What it covers

- **Shape of the app** — bootstrap chain, the whole provider graph in
  `app.config.ts`, what `AppComponent` owns, and the route table with its
  guards.
- **Directory layout** — annotated tree, plus the two rules that keep it
  navigable (children nest under their parent component; `utils/` is
  Angular-free).
- **Feature areas** — Dashboard, Label, Find, Browse: where their boundaries
  fall, which state got lifted out of the components into singletons and why,
  and a "where does new code go?" rule.
- **The service layer** — the three kinds (`*-api`, `*-state`, coordination),
  what distinguishes them, and a table of the coordination services worth
  knowing before changing anything.
- **Reactivity** — the zoneless change-detection model. The four things that
  count as a notification, and the rules that follow: signals or bridges for
  rendered state, the sanctioned getter-over-signal shape, `effect()` over
  `subscribe()`, `rxResource` for reads, mutations/SSE/pollers deliberately
  imperative, and callbacks from outside Angular writing signals rather than
  reaching for `NgZone.run()`.
- **The active dataset/detector context** — the intent/active split and the 409
  cascade it exists to prevent, `ContextSwitchService` as the only way to
  change the pair, the header interceptor, why native `<img src>` needs
  `mediaUrl()`, the URL-as-source-of-truth guards, and the registry watcher.
- **Talking to the backend** — the generated client, the committed
  `openapi.json` snapshot and its `run-tests.sh` drift gate, what stays
  hand-written in `api.models.ts` and why duplicating a generated type is a
  regression, the interceptor chain in order, the offline circuit breaker and
  `SKIP_ERROR_TOAST`, the single SSE fan-out, and `adaptivePoll`.
- **Component conventions** — standalone/`OnPush`/`vt-` prefix, presentational
  children with content projection, the `vt-modal` stack and why Escape needs
  it, and the `@defer` pattern that keeps the eager bundle under budget.
- **Styling, testing, build** — the SCSS partial structure; the zoneless test
  oracle (why removing the manual `detectChanges()` pumps is the point) and
  `rxResource` test timing; builder wiring and the empty polyfill arrays.
- **Invariants** — a closing checklist of what breaks silently.

## Also in this PR

- Linked from `ARCHITECTURE.md` (intro, directory map, and the multi-dataset
  section where `ActiveContextService` was already mentioned in passing),
  `HANDOFF.md`'s documentation map, the root `README.md`, `style-guide.md`'s
  references, and `CLAUDE.md`'s More docs. `docs/README.md` is #2987's to
  create and will pick this up.
- **`frontend/README.md`'s "Project structure" tree and "Key architecture
  patterns" bullets are replaced by a pointer.** They had already drifted —
  naming `datasets-api` / `detectors-api` services that don't exist, "17 modal
  dialogs", no Browse view — and keeping a second map would just re-create the
  drift. That file is now scoped to the build: commands, test wiring, and the
  Angular upgrade runbook.

## Testing

Documentation only; no code changes. `./run-tests.sh` passes in full
(8278 passed, 6 skipped).

One earlier run hit a single failure in
`tests_lib/detectors/test_acquisition_threshold.py::test_it_sits_above_the_reporting_cut`
(`assert 0.565… > 0.565…` — an exact tie). It reproduces intermittently on
`dev` as well, never in isolation or in its own group, and this diff is
markdown-only, so it cannot be the cause. It is already tracked as #3084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wax5Yxav5QiTb9vF8zjc1u

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wax5Yxav5QiTb9vF8zjc1u)_