### PR TITLE
Make a detector's media exemplars labels, not just hints

### DIFF
--- a/docs/api/detectors.md
+++ b/docs/api/detectors.md
@@ -36,6 +36,10 @@ Or with examples: `{"name": "Dog Barks", "examples": [{"type": "text", "value": 
 
 → `{"success": true, "name": "...", "text_query": "...", "media_type": "audio", "examples": [...], "num_labels": 0}` (201)
 
+`num_labels` counts the **media** examples, which are written into the new
+detector's labelset as `good` labels (see *Register detector* below); a
+text-only detector reports 0.
+
 409 if name already exists.
 
 ### Get detector
@@ -75,6 +79,11 @@ PUT /api/detectors/{name}/examples
 **Body:** `{"examples": [{"type": "text", "value": "dog barking"}]}`
 
 → `{"success": true, "name": "...", "examples": [...]}`
+
+Replaces the `examples` list (on the detector JSON and the registry entry) and
+**adds** a `good` label for each media example not already in the labelset.
+The labelset edit is additive only: no existing label is dropped, and an
+exemplar the user has since voted Bad keeps that label.
 
 ### Save labels
 
@@ -251,9 +260,18 @@ Or seeded with media examples (each `value` a filename previously saved in
 ```
 
 The full `examples` list is persisted on both the detector JSON and the
-registry entry. On detector load every media example is seeded as a Good
-vote, and Autopilot's Good phase sorts against the embedding centroid of
-all of them.
+registry entry. Every **media** example additionally becomes a `good`
+`LabeledElement` in the detector's labelset right away (so `num_training`
+is the example count, not 0): a supplied exemplar is a vote the user
+already cast. Each label carries the example's durable `origin` when it has
+one (`url_download`, `server_file`, …), else the `example_media` sentinel;
+because labels are origin-keyed and dataset-agnostic, an `https://` exemplar
+is kept verbatim even when the dataset it is used against holds only local
+files. Text examples are queries, not media, and produce no labels.
+
+On detector load every media example is *also* seeded as a Good vote against
+the active dataset (matched by MD5, or embedded and inserted when absent), and
+Autopilot's Good phase sorts against the embedding centroid of all of them.
 
 → `{"ok": true, "detector": {...}}` (201)
 

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -157,6 +157,226 @@ class TestRegisterDetectorExamples:
         assert listed[detector_id]["examples"] == self._EXAMPLES
 
 
+class TestExamplesBecomeLabels:
+    """Media exemplars supplied at create time are labels, not just hints (issue #3045)."""
+
+    _URL_ORIGIN = {"importer": "url_download", "params": {"url": "https://x.test/bark.wav"}}
+
+    @pytest.fixture(autouse=True)
+    def _restore_medias(self):
+        """Remove any media items inserted by example seeding after each test."""
+        from vtsearch.state import medias
+
+        saved = dict(medias)
+        yield
+        medias.clear()
+        medias.update(saved)
+
+    def _write_example_file(self, media_bytes: bytes, filename: str) -> str:
+        """Write *media_bytes* into ``data/example_media/<filename>``."""
+        from vtscore.config import DATA_DIR
+
+        example_dir = DATA_DIR / "example_media"
+        example_dir.mkdir(parents=True, exist_ok=True)
+        (example_dir / filename).write_bytes(media_bytes)
+        return filename
+
+    def _register(self, client, name, examples):
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": name, "media_type": "audio", "examples": examples},
+        )
+        assert res.status_code == 201
+        return res.get_json()["detector"]
+
+    def test_every_media_example_becomes_a_good_label(self, client):
+        entry = self._register(
+            client,
+            "ThreeSeeds",
+            [
+                {"type": "media", "value": "one.wav"},
+                {"type": "media", "value": "two.wav"},
+                {"type": "media", "value": "three.wav", "origin": self._URL_ORIGIN},
+            ],
+        )
+        labels = client.get("/api/detectors/ThreeSeeds").get_json()["labelset"]["labels"]
+        assert len(labels) == 3
+        assert {lbl["label"] for lbl in labels} == {"good"}
+        assert [lbl["filename"] for lbl in labels] == ["one.wav", "two.wav", "three.wav"]
+        # The label count is the detector's training count from the outset.
+        assert entry["num_training"] == 3
+
+    def test_foreign_url_origin_kept_verbatim(self, client):
+        """A http:// exemplar keeps its own origin - the dataset it will be
+        used against is irrelevant at create time."""
+        self._register(
+            client,
+            "UrlSeed",
+            [{"type": "media", "value": "bark.wav", "origin": self._URL_ORIGIN}],
+        )
+        labels = client.get("/api/detectors/UrlSeed").get_json()["labelset"]["labels"]
+        assert len(labels) == 1
+        assert labels[0]["origin"] == self._URL_ORIGIN
+        assert labels[0]["origin_name"] == "https://x.test/bark.wav"
+
+    def test_upload_without_origin_gets_example_media_sentinel(self, client):
+        self._register(client, "UploadSeed", [{"type": "media", "value": "upload.wav"}])
+        labels = client.get("/api/detectors/UploadSeed").get_json()["labelset"]["labels"]
+        assert labels[0]["origin"] == {"importer": "example_media", "params": {"filename": "upload.wav"}}
+        assert labels[0]["origin_name"] == "upload.wav"
+
+    def test_label_carries_md5_of_cached_example_file(self, client):
+        fname = self._write_example_file(b"exemplar-bytes", "hashed.wav")
+        self._register(client, "HashedSeed", [{"type": "media", "value": fname}])
+        labels = client.get("/api/detectors/HashedSeed").get_json()["labelset"]["labels"]
+        assert labels[0]["md5"] == content_md5(b"exemplar-bytes")
+
+    def test_missing_cache_file_still_yields_a_label(self, client):
+        """No bytes on disk yet is no reason to drop the exemplar; origin is
+        the identity, md5 is only the content fallback."""
+        self._register(client, "NoBytesSeed", [{"type": "media", "value": "absent.wav"}])
+        labels = client.get("/api/detectors/NoBytesSeed").get_json()["labelset"]["labels"]
+        assert len(labels) == 1
+        assert labels[0].get("md5", "") == ""
+
+    def test_text_example_produces_no_labels(self, client):
+        """A text description is a query, not a labeled media."""
+        entry = self._register(client, "TextSeed", [{"type": "text", "value": "dog barking"}])
+        data = client.get("/api/detectors/TextSeed").get_json()
+        assert data["labelset"]["labels"] == []
+        assert entry["num_training"] == 0
+
+    def test_legacy_media_example_scalar_becomes_a_label(self, client):
+        """The scalar-only payload (no ``examples`` list) is labeled too."""
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "ScalarSeed", "media_type": "audio", "media_example": "scalar.wav"},
+        )
+        assert res.status_code == 201
+        labels = client.get("/api/detectors/ScalarSeed").get_json()["labelset"]["labels"]
+        assert len(labels) == 1
+        assert labels[0]["filename"] == "scalar.wav"
+
+    def test_crud_create_labels_media_examples(self, client):
+        """POST /api/detectors mirrors the registry route."""
+        res = client.post(
+            "/api/detectors",
+            json={
+                "name": "CrudSeed",
+                "media_type": "audio",
+                "examples": [
+                    {"type": "media", "value": "a.wav"},
+                    {"type": "media", "value": "b.wav", "origin": self._URL_ORIGIN},
+                ],
+            },
+        )
+        assert res.status_code == 201
+        assert res.get_json()["num_labels"] == 2
+        labels = client.get("/api/detectors/CrudSeed").get_json()["labelset"]["labels"]
+        assert len(labels) == 2
+
+    def test_set_examples_adds_labels_without_duplicating(self, client):
+        """PUT .../examples is additive and idempotent."""
+        self._register(client, "SetSeed", [{"type": "media", "value": "first.wav"}])
+        res = client.put(
+            "/api/detectors/SetSeed/examples",
+            json={
+                "examples": [
+                    {"type": "media", "value": "first.wav"},
+                    {"type": "media", "value": "second.wav"},
+                ]
+            },
+        )
+        assert res.status_code == 200
+        labels = client.get("/api/detectors/SetSeed").get_json()["labelset"]["labels"]
+        assert [lbl["filename"] for lbl in labels] == ["first.wav", "second.wav"]
+
+        # Re-supplying the same examples must not grow the labelset.
+        client.put(
+            "/api/detectors/SetSeed/examples",
+            json={"examples": [{"type": "media", "value": "second.wav"}]},
+        )
+        labels = client.get("/api/detectors/SetSeed").get_json()["labelset"]["labels"]
+        assert len(labels) == 2
+
+    def test_set_examples_does_not_flip_an_existing_bad_label(self, client):
+        """An exemplar the user has since voted Bad keeps that label."""
+        from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
+
+        self._register(client, "BadSeed", [{"type": "media", "value": "oops.wav"}])
+        path = _detector_path("BadSeed")
+        data = _read_detector(path)
+        assert data is not None
+        data["labelset"]["labels"][0]["label"] = "bad"
+        _write_detector(path, data)
+
+        client.put(
+            "/api/detectors/BadSeed/examples",
+            json={"examples": [{"type": "media", "value": "oops.wav"}]},
+        )
+        labels = client.get("/api/detectors/BadSeed").get_json()["labelset"]["labels"]
+        assert len(labels) == 1
+        assert labels[0]["label"] == "bad"
+
+    def test_foreign_origin_label_survives_a_vote_against_a_local_dataset(self, client, monkeypatch):
+        """The issue's core guarantee: a http:// exemplar stays in the labelset
+        even while the loaded dataset is entirely local files and the user votes
+        in it (the vote sync must not reconcile the exemplar away)."""
+        import vtscore.datasets.downloader as downloader_mod
+        import vtscore.security.url_validation as url_mod
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        def _download(u, dest_path, expected_size=0, on_progress=None):
+            dest_path.write_bytes(b"foreign-exemplar-bytes")
+
+        monkeypatch.setattr(downloader_mod, "download_file_with_progress", _download)
+        monkeypatch.setattr(url_mod, "validate_url", lambda u: u)
+
+        detector_id = self._register(
+            client,
+            "ForeignSurvives",
+            [{"type": "media", "value": "never_cached.wav", "origin": self._URL_ORIGIN}],
+        )["id"]
+        _load_detector_and_wait(client, detector_id)
+
+        first_id = next(iter(medias))
+        client.post(f"/api/medias/{first_id}/vote", json={"target": "good"})
+
+        labels = client.get("/api/detectors/ForeignSurvives").get_json()["labelset"]["labels"]
+        url_labels = [lbl for lbl in labels if lbl.get("origin") == self._URL_ORIGIN]
+        assert len(url_labels) == 1
+        assert url_labels[0]["label"] == "good"
+
+    def test_sentinel_origin_resolves_to_the_example_media_cache(self):
+        """An upload exemplar's label resolves to its byte cache, so the Labels
+        pane and label export can reach it without a dataset."""
+        from vtscore.detectors.resolver import resolve_file_from_origin
+
+        fname = self._write_example_file(b"sentinel-bytes", "sentinel.wav")
+        origin = {"importer": "example_media", "params": {"filename": fname}}
+        resolved = resolve_file_from_origin(origin, fname, fname)
+        assert resolved is not None
+        assert resolved.read_bytes() == b"sentinel-bytes"
+
+    def test_sentinel_resolution_refuses_traversal(self):
+        from vtscore.config import DATA_DIR
+        from vtscore.detectors.resolver import resolve_file_from_origin
+
+        # A real, readable file just outside example_media/ - the check must
+        # refuse it on the path shape, not on it happening to be missing.
+        (DATA_DIR / "example_media").mkdir(parents=True, exist_ok=True)
+        outside = DATA_DIR / "traversal_target.txt"
+        outside.write_bytes(b"not-an-exemplar")
+        try:
+            origin = {"importer": "example_media", "params": {"filename": "../traversal_target.txt"}}
+            assert resolve_file_from_origin(origin, "", "") is None
+        finally:
+            outside.unlink(missing_ok=True)
+
+
 class TestListDetectors:
     def test_empty_list(self, client):
         res = client.get("/api/detectors")

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -1,16 +1,28 @@
-"""Seed good votes from a model's media examples.
+"""Turn a detector's media examples into labels and votes.
 
-Provides :func:`seed_good_votes_from_examples` which reads example media
-files, matches them to loaded dataset medias by MD5, and votes them good.
+Two entry points, both keyed off the same example → origin identity:
+
+* :func:`labeled_elements_from_examples` converts the media examples the
+  user supplied at create time into ``good`` :class:`LabeledElement`s, so
+  the detector's labelset carries them from the moment it exists - no
+  dataset, embedder, or vote required.  This is what makes an exemplar a
+  *label* rather than a transient hint.
+* :func:`seed_good_votes_from_examples` reads the example media files,
+  matches them to loaded dataset medias by MD5, and votes them good, so
+  the same exemplars are usable for training against whatever dataset is
+  active.
 """
 
 from __future__ import annotations
 
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from vtscore.utils.hashing import content_md5
+
+if TYPE_CHECKING:
+    from vtscore.datasets.labelset import LabeledElement, LabelSet
 
 
 def _ensure_embedder(embedder, dataset_embedder_name: str, dataset_media_type: str):
@@ -73,6 +85,18 @@ def _real_example_origin(ex: dict[str, Any]) -> dict[str, Any] | None:
         return None
 
 
+def _sentinel_origin(filename: str) -> dict[str, Any]:
+    """The dead-end ``example_media`` origin for an example with no real source.
+
+    Uploads and add-to-pile snapshots have no re-derivable origin: the bytes
+    only exist in the ``example_media/`` cache.  The sentinel still gives the
+    element a stable identity key (see
+    :func:`~vtscore.datasets.labelset.element_key`), so the label dedupes and
+    survives merges the same way a real origin does.
+    """
+    return {"importer": "example_media", "params": {"filename": filename}}
+
+
 def _example_origin_name(origin: dict[str, Any] | None, filename: str) -> str:
     """Human-meaningful origin name: the URL / path for a real origin, else the cache filename."""
     if origin is not None:
@@ -119,16 +143,92 @@ def _insert_example_media(
             "filename": filename,
             "file_size": len(file_bytes),
             "category": "",
-            "origin": origin
-            if origin is not None
-            else {
-                "importer": "example_media",
-                "params": {"filename": filename},
-            },
+            "origin": origin if origin is not None else _sentinel_origin(filename),
             "origin_name": origin_name,
         }
 
     apply_label(new_id, "good", record_achievement=False)
+
+
+def labeled_elements_from_examples(examples: list[dict]) -> list["LabeledElement"]:
+    """Build one ``good`` :class:`LabeledElement` per ``type: "media"`` example.
+
+    A user who supplies three Good exemplars instead of a Good text
+    description has cast three good votes, so those exemplars belong in the
+    detector's labelset - not merely in its ``examples`` list, which nothing
+    downstream of training reads.  This runs at create time, before any
+    dataset is involved: the element's identity is its **origin**, which is
+    dataset-agnostic by construction, so an ``https://`` exemplar is kept
+    verbatim even when the dataset it will be used against is entirely local
+    files (issue #3045).
+
+    Each element carries:
+
+    * the example's validated real origin (``url_download``, ``server_file``,
+      ...) when it has one, else the ``example_media`` sentinel for genuinely
+      un-re-derivable exemplars (uploads, add-to-pile snapshots);
+    * the MD5 of the ``example_media/`` cache file when it is still there, so
+      the label can also match dataset media by content hash.  A missing
+      cache file leaves ``md5`` empty and costs nothing: origin is the
+      preferred identity key either way.
+
+    Text examples are skipped - they are queries, not labeled media.  The
+    origin / origin_name derivation is shared with
+    :func:`seed_good_votes_from_examples`, so the label a create emits and
+    the media a later seed inserts collapse onto one identity key instead of
+    double-counting.
+    """
+    from vtscore.config import DATA_DIR
+    from vtscore.datasets.labelset import LabeledElement
+    from vtscore.utils.hashing import file_md5
+
+    server_media_dir = DATA_DIR / "example_media"
+    elements: list[LabeledElement] = []
+    for ex in examples:
+        if not isinstance(ex, dict) or ex.get("type") != "media":
+            continue
+        filename = (ex.get("value") or "").strip()
+        if not filename:
+            continue
+
+        origin = _real_example_origin(ex)
+        origin_name = _example_origin_name(origin, filename)
+
+        md5 = ""
+        file_path = _example_file_path(server_media_dir, filename)
+        if file_path is not None and file_path.is_file():
+            try:
+                md5 = file_md5(file_path)
+            except OSError:
+                md5 = ""
+
+        elements.append(
+            LabeledElement(
+                md5=md5,
+                label="good",
+                origin=origin if origin is not None else _sentinel_origin(filename),
+                origin_name=origin_name,
+                filename=filename,
+            )
+        )
+    return elements
+
+
+def merge_examples_into_labelset(existing: "LabelSet", examples: list[dict]) -> "LabelSet":
+    """Return *existing* plus a good label for each media example not already in it.
+
+    Purely additive: an exemplar whose identity key is already present keeps
+    whatever label it has (the user may have since voted it Bad, and a
+    re-supplied example must not silently flip that back), and no existing
+    element is dropped.
+    """
+    from vtscore.datasets.labelset import LabelSet, element_key
+
+    seen = {element_key(el) for el in existing.elements}
+    added = [el for el in labeled_elements_from_examples(examples) if element_key(el) not in seen]
+    if not added:
+        return existing
+    return LabelSet(list(existing.elements) + added, detector_meta=existing.detector_meta)
 
 
 def _seed_one_example(

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -290,6 +290,12 @@ def _resolve_with_stack(  # noqa: C901
             )
         return result
 
+    if importer_name == "example_media":
+        result = _resolve_example_media(params)
+        if result is None:
+            log.debug("resolve_file: example_media cache file %r is gone", params.get("filename", ""))
+        return result
+
     # -- Source-based dispatch (preferred) --
 
     _auto_wire_resolvers()
@@ -353,6 +359,33 @@ def _resolve_dupe_set(stack: ExitStack, origin: dict[str, Any]) -> Path | None:
         if result is not None:
             return result
     return None
+
+
+def _resolve_example_media(params: dict[str, Any]) -> Path | None:
+    """Resolve an ``example_media`` sentinel origin to its byte-cache file.
+
+    The sentinel is what a detector exemplar with no re-derivable source
+    (a local upload, an add-to-pile snapshot) carries, and its bytes live
+    only in ``data/example_media/``.  Resolving it there lets such an
+    exemplar's *label* be thumbnailed and exported before any dataset is
+    loaded - the cache file is the closest thing it has to an origin.  It is
+    still a dead end in the sense that #2774 meant: delete the cache file and
+    there is nowhere left to re-fetch from.
+    """
+    from vtscore.config import DATA_DIR
+
+    filename = params.get("filename", "")
+    if not isinstance(filename, str) or not filename:
+        return None
+    base = DATA_DIR / "example_media"
+    candidate = base / filename
+    try:
+        # ``filename`` comes from a detector JSON, so confine it the same way
+        # the seeding path does before touching the filesystem.
+        candidate.resolve().relative_to(base.resolve())
+    except ValueError:
+        return None
+    return candidate if candidate.is_file() else None
 
 
 def _resolve_converter(stack: ExitStack, params: dict[str, str]) -> Path | None:

--- a/vtscore/docs/packages/detectors.md
+++ b/vtscore/docs/packages/detectors.md
@@ -312,10 +312,12 @@ with resolve_file_context(origin, origin_name, filename) as path:
 `resolved_count`, `total_count`, `missing_entries` plus the
 `available_fraction` and `has_good_and_bad` properties.
 
-Two synthetic origin types are special-cased: `dupe_set` (tries each
-member origin in turn) and `converter` (reconstructs a parent origin
+Three synthetic origin types are special-cased: `dupe_set` (tries each
+member origin in turn), `converter` (reconstructs a parent origin
 from `parent_importer` / `parent_path` / `parent_url` params and
-recurses). Clipped origins - audio `clip_start`/`clip_end`, image
+recurses), and `example_media` (the detector-exemplar sentinel, resolved
+to its `DATA_DIR / "example_media"` byte-cache file under the same
+traversal confinement the seeding path applies). Clipped origins - audio `clip_start`/`clip_end`, image
 `clip_box`, text `clip_index`, and origin-stored clipper chains - are
 handled transparently: the chain is replayed on the resolved source
 file via `vtscore.datasets.clipper_chain.replay_chain_on_file` before
@@ -431,6 +433,17 @@ last saw it. When triggered, clears `good_votes` / `bad_votes` /
 `label_history` / etc., replays `restore_labels_from_detector`, and
 caches the parsed labelset + mtime so subsequent requests within the
 same `(dataset_id, file_mtime)` tuple are no-ops.
+
+### `media_seeding.labeled_elements_from_examples(examples)`
+
+Turn a detector's media examples into `good` `LabeledElement`s at create
+time, so a supplied exemplar is a *label* and not just a hint. Origin
+is the example's validated durable origin when it has one, else the
+`example_media` sentinel; `md5` is filled in from the byte cache when the
+file is still there. Being origin-keyed, the resulting labels are
+dataset-agnostic: an `https://` exemplar survives against an all-local
+dataset. `merge_examples_into_labelset(existing, examples)` is the additive
+variant used when examples are replaced on an existing detector.
 
 ### `media_seeding.seed_good_votes_from_examples(examples)` (line 10)
 

--- a/vtsearch/routes/detectors/crud.py
+++ b/vtsearch/routes/detectors/crud.py
@@ -156,6 +156,14 @@ def create_detector(body: dict):
     elif examples is None and media_example:
         examples = [{"type": "media", "value": media_example}]
 
+    # Media exemplars are good votes the user already cast: they go into the
+    # labelset now, origin-keyed, so they survive against any dataset (issue
+    # #3045).  Mirrors POST /api/detectors/registry.
+    from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.media_seeding import labeled_elements_from_examples
+
+    example_labels = labeled_elements_from_examples(examples or [])
+
     detector_data = {
         "name": name,
         "text_query": text_query,
@@ -164,7 +172,7 @@ def create_detector(body: dict):
         "examples": examples or [],
         "created_at": time.time(),
         "embedder_type": embedder_type,
-        "labelset": {"labels": []},
+        "labelset": LabelSet(example_labels).to_dict(),
     }
     _write_detector(path, detector_data)
 
@@ -175,7 +183,7 @@ def create_detector(body: dict):
         "media_example": media_example,
         "media_type": media_type,
         "examples": examples or [],
-        "num_labels": 0,
+        "num_labels": len(example_labels),
     }
 
 
@@ -307,7 +315,22 @@ def set_detector_examples(body: dict, name: str):
     text_examples = [e for e in examples if e.get("type") == "text" and e.get("value")]
     if text_examples:
         data["text_query"] = text_examples[0]["value"]
+
+    # Newly-supplied media exemplars become good labels (issue #3045).  The
+    # merge is additive - replacing the examples list must not delete labels
+    # the user voted, nor flip an exemplar the user has since voted Bad.
+    from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.media_seeding import merge_examples_into_labelset
+
+    merged = merge_examples_into_labelset(LabelSet.from_dict(data.get("labelset") or {}), examples)
+    data["labelset"] = merged.to_dict()
     _write_detector(path, data)
+
+    from vtscore.detectors.registry import find_by_name, update_detector
+
+    reg_entry = find_by_name(name)
+    if reg_entry:
+        update_detector(reg_entry["id"], num_training=len(merged), examples=examples)
 
     return {"success": True, "name": name, "examples": examples}
 

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -217,6 +217,15 @@ def register_detector_route(body: dict):
         # display, Autopilot fallback) see the first media example.
         media_example = next((ex.get("value", "") for ex in examples if ex.get("type") == "media"), "")
 
+    # Media exemplars are good votes the user already cast, so they land in
+    # the labelset immediately - origin-keyed and dataset-agnostic, which is
+    # what keeps an https:// exemplar alive against an all-local dataset
+    # (issue #3045).  Text examples are queries, not labels.
+    from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.media_seeding import labeled_elements_from_examples
+
+    example_labels = labeled_elements_from_examples(examples)
+
     detector_data = {
         "name": name,
         "text_query": text_query,
@@ -225,13 +234,14 @@ def register_detector_route(body: dict):
         "examples": examples,
         "created_at": time.time(),
         "embedder_type": embedder_type,
-        "labelset": {"labels": []},
+        "labelset": LabelSet(example_labels).to_dict(),
     }
     _write_detector(_detector_path(name), detector_data)
 
     entry = register_detector(
         name=name,
         media_type=media_type,
+        num_training=len(example_labels),
         text_query=text_query,
         media_example=media_example,
         examples=examples,


### PR DESCRIPTION
Closes #3045

## Answering the question in the issue

**No — they were not saved as labels.** A supplied exemplar was stored only in the detector's `examples` list; the labelset was written **empty** at create time (`"labelset": {"labels": []}`). The examples became labels only *incidentally*: the detector had to be loaded against a dataset (which seeds each example as a good vote in memory) **and** some later vote had to trigger `sync_labels_to_loaded_detector`. Until both happened, the detector reported `num_training: 0`, its Labels pane was empty, and a rehydrate in between (`ensure_votes_match_active_dataset` fires on any detector-file write) could drop the seeded votes outright — there was nothing on disk to restore them from.

The one path that did persist them was `POST /api/votes/seed-from-examples`, which calls the sync explicitly; the detector *load* path did not.

## What changed

Media examples now become `good` `LabeledElement`s the moment the detector exists. Labels are origin-keyed and dataset-agnostic by construction, so this needs no dataset, embedder, or vote — which is exactly what makes the issue's requirement fall out for free: **an `https://` exemplar is kept verbatim even when the dataset it will be used against holds only local files.** All N examples are labeled, not just the `media_example` scalar.

- **`vtscore/detectors/media_seeding.py`** — new `labeled_elements_from_examples(examples)` builds one good element per `type: "media"` example, carrying the example's validated durable origin when it has one (`url_download`, `server_file`, …) and the `example_media` sentinel otherwise, plus the byte cache's MD5 when the file is still there so the label can also match dataset media by content. Text examples are queries, not media, and produce nothing. `merge_examples_into_labelset` is the additive variant.
  The origin / `origin_name` derivation is **shared** with `seed_good_votes_from_examples`, so the label a create emits and the media a later seed inserts collapse onto one identity key rather than double-counting.
- **`POST /api/detectors/registry`** and **`POST /api/detectors`** — write those labels into the new detector's labelset; `num_training` / `num_labels` is the media-example count from the outset instead of 0.
- **`PUT /api/detectors/<name>/examples`** — merges new media examples in **additively**: no existing label is dropped, and an exemplar the user has since voted Bad keeps that label. It also syncs the registry entry's `examples` / `num_training`, which it previously left stale.
- **`vtscore/detectors/resolver.py`** — resolves the `example_media` sentinel to its byte-cache file, under the same traversal confinement the seeding path applies, so an upload exemplar's label can be thumbnailed and exported before any dataset is loaded instead of dead-ending. It is still a dead end in the #2774 sense: delete the cache file and there is nowhere to re-fetch from.

No backwards-compatibility shim: a detector created before this lands keeps its empty labelset until it is loaded and voted in, as today.

## How the foreign-origin guarantee holds end to end

`sync_labels_to_loaded_detector` reconciles only the entries the active dataset *owns* (matching origin keys) and preserves the rest verbatim, so a `url_download` exemplar's label survives voting inside an all-local dataset. `test_foreign_origin_label_survives_a_vote_against_a_local_dataset` pins that path: create with a URL exemplar → load against the local test dataset → vote a local media → the URL label is still there, still `good`.

## Tests

13 new tests in `tests/detectors/test_detectors.py::TestExamplesBecomeLabels` covering: all three of three examples labeled; URL origin kept verbatim; upload → sentinel origin; MD5 filled from the cache file and empty when it's absent; text-only → no labels; the legacy `media_example` scalar; the CRUD create mirror; `PUT .../examples` additive + idempotent + not flipping a Bad; the end-to-end foreign-origin survival; and sentinel resolution incl. a traversal refusal against a real file outside `example_media/`.

`./run-tests.sh detectors` → 2311 passed.

## Docs

`docs/api/detectors.md` and `vtscore/docs/packages/detectors.md` updated (create semantics, `num_labels`, the additive `PUT .../examples` behaviour, the third synthetic origin type).

## Pre-existing failure, not from this branch

The full `./run-tests.sh` is green except `tests_lib/detectors/test_acquisition_threshold.py::TestAcquisitionThresholdIsDecoupled::test_it_sits_above_the_reporting_cut`, which **fails identically on a clean `origin/dev` worktree**. It passes in isolation and fails only in the full `--dist loadgroup` run, i.e. it's an order/state dependence in the safe-threshold subsystem. Filed with the full bisect as #3101 rather than fixed here — it sits in the acquisition-cut code this PR doesn't touch, and guessing at it risks the very invariant the test exists to pin.

I also found, while sharing the seeding path's directory resolution, that example media is uploaded to the **per-user** directory in multi-user mode but read from the **global** one — filed as #3102. This PR mirrors the existing global-dir behaviour rather than changing it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLZuWACrZcvxLKtM7SfVZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLZuWACrZcvxLKtM7SfVZk)_