### PR TITLE
Move the LoginProvider abstraction into vtscore.security.login

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,7 +196,7 @@ VTSearch/
 │   │   └── fit.py                  Fits recorded rows into a profile document
 │   │
 │   ├── plugins/                    PluginBase, PluginField, PluginRegistry (shared plugin infra)
-│   ├── security/                   Path/URL/pickle safety (path_validation, url_validation, pickle)
+│   ├── security/                   Path/URL/pickle safety + the LoginProvider ABC (path_validation, url_validation, pickle, login)
 │   ├── sync/                       SyncSource[LoadT, SaveT] generic base class
 │   └── utils/                      Shared helpers: hits.py (build_media_hit), synthetic/
 │

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -29,8 +29,11 @@ discovery/registration works, and includes a complete example.
 
 ## Authentication Providers
 
-VTSearch uses a pluggable `LoginProvider` ABC (`vtsearch/auth/__init__.py`)
-so that multi-user deployments can be supported without modifying routes.
+VTSearch uses a pluggable `LoginProvider` ABC so that multi-user deployments
+can be supported without modifying routes. The ABC itself is library-tier
+(`vtscore/security/login.py`, because `vtscore`'s path-confinement checks
+consult the active provider); `vtsearch.auth` re-exports it alongside the
+Flask-backed providers, and is the import path app code should use.
 
 ### Interface
 

--- a/tests_lib/core/test_library_layering.py
+++ b/tests_lib/core/test_library_layering.py
@@ -24,20 +24,15 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _VTSCORE = _REPO_ROOT / "vtscore"
 
 #: Imports of ``vtsearch`` that are allowed to remain, with the reason.
-#: The first two are *optional* - wrapped in ``try``/``except`` so the
-#: library keeps working when the app package is absent, which is what
-#: makes them tolerable.  The third is a genuine remaining violation with
-#: its own issue.  Anything else fails this test.
+#: Both are *optional* - wrapped in ``try``/``except`` so the library
+#: keeps working when the app package is absent, which is what makes them
+#: tolerable.  Anything else fails this test.
 _ALLOWED: dict[str, str] = {
     "exporters/portable_detector/__init__.py": (
         "guarded `import vtsearch` used only to stamp the producing app's version "
         "into a bundle; falls back to a literal when the app package is absent"
     ),
     "embedding/loader.py": "optional transformers logging bridge, wrapped in try/except Exception",
-    "security/path_validation.py": (
-        "UNGUARDED, tracked in issue #3042: the whole LoginProvider abstraction "
-        "still lives in vtsearch.auth, so moving it is its own change, not a hook"
-    ),
 }
 
 

--- a/tests_lib/core/test_library_login_provider.py
+++ b/tests_lib/core/test_library_login_provider.py
@@ -1,0 +1,142 @@
+"""The login-provider abstraction is library-tier (issue #3042).
+
+:mod:`vtscore.security.path_validation` decides file-access confinement by
+asking :func:`vtscore.security.login.get_login_provider` whether a per-user
+boundary exists.  That used to reach into ``vtsearch.auth``, so the whole
+containment check raised ``ImportError`` in a process without the app
+package - and a library-only embedder had no way to *opt into* confinement
+at all.
+
+These tests pin both halves of the fix: the default stays "single user, no
+confinement" (what the app already did), and a plain
+:class:`~vtscore.security.login.LoginProvider` subclass registered from
+library code turns confinement on for every path check in the library.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vtscore.security.login import (
+    DefaultLoginProvider,
+    LoginProvider,
+    get_login_provider,
+    get_user_data_dir,
+    is_safe_username,
+    set_login_provider,
+)
+from vtscore.security.path_validation import (
+    get_file_access_base_dir,
+    media_file_read_roots,
+    validate_server_filepath,
+)
+from vtscore.state.current_user import get_current_user, thread_user
+
+
+class _EmbedderProvider(LoginProvider):
+    """What a Flask-free multi-user embedding would register."""
+
+    name = "embedder"
+
+    def get_user(self, request: Any) -> str:  # noqa: ARG002
+        return get_current_user()
+
+    def is_authenticated(self, request: Any) -> bool:  # noqa: ARG002
+        return True
+
+    def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
+        return base_data_dir / username
+
+
+@pytest.fixture
+def restore_provider():
+    """Leave the process-wide provider as we found it."""
+    original = get_login_provider()
+    yield
+    set_login_provider(original)
+
+
+@pytest.fixture
+def as_alice(restore_provider):
+    """Register a confining provider and run as user ``alice``.
+
+    Both halves are needed, and they are separate seams: the provider says
+    *where* a user's data lives, while :mod:`vtscore.state.current_user`
+    says *which* user this work is for.  ``get_user_data_dir()`` with no
+    argument reads the latter, so a library embedder scopes work to a user
+    with ``thread_user`` (or its own registered request-user resolver) —
+    not by baking the name into the provider.
+    """
+    set_login_provider(_EmbedderProvider())
+    with thread_user("alice"):
+        yield
+
+
+@pytest.fixture
+def data_dir(monkeypatch, tmp_path):
+    """Point ``DATA_DIR`` at *tmp_path* everywhere it is read.
+
+    ``get_user_data_dir`` imports it lazily (so patching the config module
+    is enough), while ``path_validation`` bound it at import time.
+    """
+    monkeypatch.setattr("vtscore.config.DATA_DIR", tmp_path)
+    monkeypatch.setattr("vtscore.security.path_validation.DATA_DIR", tmp_path)
+    return tmp_path
+
+
+class TestDefaultIsUnconfinedSingleUser:
+    def test_default_provider_is_active_out_of_the_box(self):
+        assert isinstance(get_login_provider(), DefaultLoginProvider)
+
+    def test_no_confinement_by_default(self):
+        assert get_file_access_base_dir() is None
+        assert media_file_read_roots() is None
+
+    def test_user_data_dir_is_the_shared_data_dir(self):
+        from vtscore.config import DATA_DIR
+
+        assert get_user_data_dir("anyone") == DATA_DIR
+
+
+class TestLibraryOnlyEmbedderCanOptIn:
+    """The registered provider must drive confinement without any app tier."""
+
+    def test_base_dir_follows_the_registered_provider(self, as_alice, data_dir):
+        assert get_file_access_base_dir() == data_dir / "alice"
+        assert media_file_read_roots() == [data_dir / "alice", data_dir]
+
+    def test_escape_from_the_registered_base_dir_raises(self, as_alice, data_dir):
+        base = get_file_access_base_dir()
+        assert base is not None
+        base.mkdir(parents=True)
+
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            validate_server_filepath("../bob/secret.txt", base_dir=base)
+
+        inside = validate_server_filepath("notes.txt", base_dir=base)
+        assert inside == (base / "notes.txt").resolve()
+
+    def test_current_user_resolves_through_the_library_seam(self, as_alice, data_dir):
+        """The two seams compose: a nested scope re-points the base dir."""
+        assert get_user_data_dir() == data_dir / "alice"
+        with thread_user("bob"):
+            assert get_user_data_dir() == data_dir / "bob"
+            assert get_file_access_base_dir() == data_dir / "bob"
+
+    def test_enforce_auth_defaults_to_fail_closed(self, as_alice):
+        """A provider that forgets to override must gate, not serve anonymously."""
+        assert get_login_provider().enforce_auth() is True
+        assert get_login_provider().www_authenticate() is None
+
+
+class TestSafeUsername:
+    @pytest.mark.parametrize("name", ["alice", "ci-bot", "a.b_c-1"])
+    def test_accepts_path_safe_names(self, name):
+        assert is_safe_username(name)
+
+    @pytest.mark.parametrize("name", ["", ".", "..", "...", "a/b", "a\\b", "a b", None, 7])
+    def test_rejects_traversal_and_non_strings(self, name):
+        assert not is_safe_username(name)

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -12,6 +12,17 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **`vtscore.security.login`** - the `LoginProvider` ABC,
+  `DefaultLoginProvider`, the process-wide `set_login_provider` /
+  `get_login_provider` registry, `get_user_data_dir()` and
+  `is_safe_username()`, moved down from the `vtsearch` app tier. Path
+  confinement (`vtscore.security.path_validation`) asks the active provider
+  where the current user's data lives, so the abstraction had to be reachable
+  in a process with no Flask in it — previously `get_file_access_base_dir()`
+  raised `ImportError` there. An embedder can now opt into per-user
+  confinement by registering a provider whose `get_user_data_dir()` returns a
+  per-user subtree; the default stays single-user and unconfined.
+
 - **`beats` audio embedder** - Microsoft's BEATs iter3+ AudioSet-2M
   self-supervised encoder, exposed as a 768-d audio-only embedder
   (`supports_text=False`). There is no `transformers` implementation, so the

--- a/vtscore/docs/architecture.md
+++ b/vtscore/docs/architecture.md
@@ -378,7 +378,12 @@ the library without the library knowing:
    `vtscore.state.current_user.get_current_user()` how to read the
    *request-scoped* user; `vtsearch/auth/` wires it to `flask.g.user` at
    import time. Below it sit the thread-local (`thread_user`) and the
-   `"default"` fallback, both Flask-free.
+   `"default"` fallback, both Flask-free. Its companion,
+   `vtscore.security.login.set_login_provider(provider)`, is not a hook so
+   much as a plain registry: it decides *where* that user's data lives and
+   therefore whether file access is confined at all (see
+   [`packages/security.md`](packages/security.md)). Only the providers that
+   read `flask.session` / request headers stay app-side in `vtsearch/auth/`.
 5. **Achievement recorders** -
    `vtscore.achievements_hooks.register_achievement_recorder(event, fn)`
    for the `vote` / `dataset_load` / `detector_import` / `find` events the
@@ -399,6 +404,6 @@ depth. Lazy function-level imports were how the rule kept breaking: the
 module still imported cleanly and the inverted dependency only bit at
 call time, in exactly the Flask-free deployment the tier exists for. A
 short allowlist there carries the remaining imports with their rationale
-(two optional `try`/`except`-guarded ones, plus `security/path_validation.py`,
-which still reaches for the `LoginProvider` abstraction); add a hook
-rather than a sixth category.
+(two optional `try`/`except`-guarded ones, both wrapped so the library
+still works when the app package is absent); add a hook rather than a
+sixth category.

--- a/vtscore/docs/integration.md
+++ b/vtscore/docs/integration.md
@@ -342,22 +342,32 @@ that resolves an `Origin` back to a file pulled from your storage layer
 
 ## Authentication and per-user data
 
-`vtscore` is **single-tenant by design.** It does not know about users,
-ACLs, or per-user data directories. If your app is multi-user, the
-`vtsearch` companion app's `vtsearch.auth` package is one reference
-implementation:
+`vtscore` is **single-tenant by default**, not by design: out of the box
+every caller is `"default"` and nothing is confined. Multi-tenancy is
+opt-in, and two library-tier pieces carry it:
 
-- A `LoginProvider` ABC plus a `DefaultLoginProvider` (single-user,
-  no-op).
-- A `get_current_user()` accessor that reads the resolved user from
-  `flask.g`.
-- A `get_user_data_dir(user)` helper that returns
-  `data/<username>/...`.
+- `vtscore.state.current_user` - *which* user this work belongs to. A
+  pluggable request-user resolver (`register_request_user_resolver`) on
+  top of a thread-local (`thread_user`) on top of `"default"`.
+- `vtscore.security.login` - *how* an identity is established and *where*
+  its data lives. A `LoginProvider` ABC plus a `DefaultLoginProvider`
+  (single-user, no-op), a process-wide registry (`set_login_provider` /
+  `get_login_provider`), and `get_user_data_dir(user)`. Registering a
+  provider whose `get_user_data_dir()` returns `data/<username>/` is what
+  switches on file-access confinement for every server-file importer,
+  exporter, and media read - see
+  [packages/security.md](packages/security.md).
 
-To port this idea to your own app:
+The `vtsearch` companion app is a reference implementation: it registers a
+resolver reading `flask.g.user` and providers reading `flask.session` /
+the `Authorization` header. To port the idea to your own app:
 
 - Replace `flask.g` with your request-local store (a `ContextVar`,
-  request-scoped dependency injection, etc.).
+  request-scoped dependency injection, etc.) and install it via
+  `register_request_user_resolver`.
+- Subclass `LoginProvider`, override `get_user_data_dir()`, and register
+  it with `set_login_provider()`. Screen client-supplied usernames with
+  `is_safe_username()` - they become path components.
 - Build a per-user `CoreConfig` in your `register_core_config_builder`
   callback - point `data_dir` / `saved_datasets_dir` / `detectors_dir`
   at the per-user paths.

--- a/vtscore/docs/packages/security.md
+++ b/vtscore/docs/packages/security.md
@@ -6,7 +6,8 @@ allowlist-based pickle unpickler so loading a `.pkl` dataset can't lead
 to arbitrary code execution. The three modules
 (`path_validation.py`, `url_validation.py`, `pickle.py`) have no app
 coupling - they take their inputs explicitly and operate on bytes and
-strings, not request objects or settings.
+strings, not request objects or settings. A fourth, `login.py`, carries
+the identity abstraction the path checks depend on.
 
 Related docs: [`state.md`](state.md) for the contexts that hold the
 deserialised dataset artefacts; [`concurrency.md`](concurrency.md) for
@@ -14,6 +15,7 @@ the load pipeline that calls these helpers during dataset import.
 
 ## Contents
 
+- [Login providers](#login-providers)
 - [Path validation](#path-validation)
   - [Media-carried file references](#media_file_read_roots-and-resolve_media_file_pathfilepath_str)
 - [URL validation](#url-validation)
@@ -24,6 +26,58 @@ the load pipeline that calls these helpers during dataset import.
 - [Why no `find_class` shim is needed](#why-no-find_class-shim-is-needed)
 
 ---
+
+## Login providers
+
+`vtscore/security/login.py` answers the two questions the path checks
+below are built on: **how** an identity is established, and **where** that
+identity's data lives. `vtscore.state.current_user` resolves *which*
+username the work belongs to; this module maps that username to a
+directory, and that directory is the confinement root.
+
+| Name | Description |
+|------|-------------|
+| `LoginProvider` | ABC. Subclasses implement `get_user(request)` and `is_authenticated(request)`; override `get_user_data_dir(username, base_data_dir)` to opt into per-user confinement, and `login_required()` / `status_dict(request)` for the app's auth UI |
+| `DefaultLoginProvider` | Single-user, no auth. Every caller is `"default"`; the data dir is `DATA_DIR` itself, so nothing is confined |
+| `set_login_provider(p)` / `get_login_provider()` | The process-wide active provider. `DefaultLoginProvider()` until something replaces it |
+| `get_user_data_dir(username=None)` | `provider.get_user_data_dir(username or get_current_user(), DATA_DIR)` |
+| `is_safe_username(name)` | `True` when *name* is safe as a path component: matches `[A-Za-z0-9._-]+` and is not an all-dots traversal segment |
+
+The `request` argument is typed `Any` and never introspected by the
+library - it is handed straight back to the provider that asked for it.
+That is what lets the abstraction be Flask-free while the app's own
+providers (`TrivialLoginProvider`, `ApiKeyLoginProvider` in
+`vtsearch/auth/`, which read `flask.session` and the `Authorization`
+header) build on it. `vtsearch.auth` re-exports every name in the table,
+so there is exactly one active provider per process however you reach it.
+
+Embedding `vtscore` without the app and want per-user confinement? Register
+a provider; every path check in the library starts enforcing it:
+
+```python
+from pathlib import Path
+from vtscore.security.login import LoginProvider, set_login_provider
+
+class MyProvider(LoginProvider):
+    name = "mine"
+
+    def get_user(self, request):
+        return "alice"
+
+    def is_authenticated(self, request):
+        return True
+
+    def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
+        return base_data_dir / username
+
+set_login_provider(MyProvider())
+```
+
+Validate any username you did not construct yourself with
+`is_safe_username()` before returning it from `get_user()`: the name
+becomes a path component, and `..` segments in a confinement root are
+*collapsed* by `Path.resolve()` rather than rejected - which silently
+widens the sandbox for every server-file importer and exporter.
 
 ## Path validation
 
@@ -48,8 +102,9 @@ which tells `validate_server_filepath` to apply **no** confinement: the
 lone trusted user may read from and write to any server-readable path.
 There is no per-user boundary to protect, so the app does not impose one.
 In multi-user mode it returns the current user's data directory so each
-user is confined to their own `data/<username>/` subtree. This is the only
-function in the package that imports `vtsearch.auth`.
+user is confined to their own `data/<username>/` subtree. Which of the two
+applies is decided entirely by the registered
+[login provider](#login-providers) - there is no separate switch.
 
 ### `validate_server_filepath(filepath_str, base_dir=None)`
 

--- a/vtscore/security/login.py
+++ b/vtscore/security/login.py
@@ -1,0 +1,229 @@
+"""Who may act, and which subtree they are confined to - the Flask-free half of auth.
+
+:mod:`vtscore.state.current_user` answers *"which username is this work
+being done for?"*.  This module answers the two questions that follow
+from it and that the security boundary actually depends on: **how** an
+identity is established (the :class:`LoginProvider` abstraction) and
+**where** that identity's data lives
+(:func:`get_user_data_dir`, the confinement root handed to
+:func:`~vtscore.security.path_validation.validate_server_filepath`).
+
+Both halves have to be library-tier, because the code that consumes them
+is: every server-file importer and exporter resolves its path through
+:mod:`vtscore.security.path_validation`, which asks
+:func:`get_login_provider` whether a per-user boundary exists at all.
+Keeping the ABC and the process-wide registry here means a library-only
+embedder can opt into confinement - register a provider whose
+:meth:`LoginProvider.get_user_data_dir` returns ``base_data_dir /
+username`` and every path check in the library starts enforcing it -
+without a Flask app anywhere in the process.
+
+What stays app-tier is only what genuinely needs a web framework: the
+providers that read ``flask.session`` or an HTTP header
+(:class:`~vtsearch.auth.TrivialLoginProvider`,
+:class:`~vtsearch.auth.ApiKeyLoginProvider`) and the resolver that reads
+``g.user``.  :mod:`vtsearch.auth` re-exports every name defined here, so
+there is exactly one active provider per process however you reach it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# LoginProvider ABC
+# ---------------------------------------------------------------------------
+
+
+class LoginProvider(ABC):
+    """Abstract base for authentication providers.
+
+    Subclasses must implement :meth:`get_user` and :meth:`is_authenticated`.
+    The default implementations of the other methods are suitable for
+    single-user deployments; multi-user providers should override them.
+    """
+
+    #: Short identifier for this provider (e.g. ``"default"``, ``"userpass"``).
+    name: str = ""
+
+    @abstractmethod
+    def get_user(self, request: Any) -> str:
+        """Return the username for the current request.
+
+        Args:
+            request: The request object, or ``None`` outside a request
+                (CLI, library embedding).  Typed loosely on purpose: the
+                library never introspects it, it only hands it back to
+                the provider that asked for it.
+
+        Returns:
+            A non-empty string identifying the user.
+        """
+
+    @abstractmethod
+    def is_authenticated(self, request: Any) -> bool:
+        """Return ``True`` if the request carries valid credentials.
+
+        For providers that don't require authentication (e.g.
+        :class:`DefaultLoginProvider`) this should always return ``True``.
+        """
+
+    def login_required(self) -> bool:
+        """Whether the frontend should show a login screen at startup."""
+        return False
+
+    def enforce_auth(self) -> bool:
+        """Whether the server rejects unauthenticated ``/api/*`` requests.
+
+        When ``True``, the ``_enforce_auth`` before_request hook (see
+        ``vtsearch.hooks``) aborts with 401 whenever
+        :meth:`is_authenticated` is ``False``, except for the small
+        allowlist of auth endpoints the SPA needs to reach the login
+        screen. Defaults to ``True`` so a custom provider that implements
+        real credentials is gated by construction — forgetting to override
+        this must fail closed, not silently serve every request as
+        ``"anonymous"``. Providers for which anonymous access is a
+        legitimate mode (``TrivialLoginProvider``) override this to
+        ``False``; :class:`DefaultLoginProvider` is unaffected either way
+        since it authenticates every request.
+
+        Like :meth:`get_user`'s *request* argument, this is a policy the
+        library only stores: it means nothing without a serving layer to
+        enforce it.
+        """
+        return True
+
+    def www_authenticate(self) -> str | None:
+        """Challenge value for the ``WWW-Authenticate`` header on 401s.
+
+        Return the auth scheme clients should use (e.g. ``"Bearer"``), or
+        ``None`` to omit the header (cookie/session providers).
+        """
+        return None
+
+    def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
+        """Return the data directory for *username*.
+
+        The default implementation returns *base_data_dir* unchanged, which
+        is correct for single-user deployments.  Multi-user providers should
+        return ``base_data_dir / username`` (or similar) so each user's
+        datasets, detectors, and settings are stored separately.
+        """
+        return base_data_dir
+
+    def status_dict(self, request: Any) -> dict[str, Any]:
+        """Return a JSON-serialisable dict describing the auth state.
+
+        Used by the ``/api/auth/status`` endpoint.
+        """
+        return {
+            "provider": self.name,
+            "user": self.get_user(request),
+            "authenticated": self.is_authenticated(request),
+            "login_required": self.login_required(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# DefaultLoginProvider - single-user, no authentication
+# ---------------------------------------------------------------------------
+
+
+class DefaultLoginProvider(LoginProvider):
+    """No-op provider for single-user deployments.
+
+    Every request is treated as coming from the ``"default"`` user.
+    No login screen is shown, and the data directory is used as-is
+    (no per-user subdirectory).
+    """
+
+    name = "default"
+
+    def get_user(self, request: Any) -> str:  # noqa: ARG002
+        return "default"
+
+    def is_authenticated(self, request: Any) -> bool:  # noqa: ARG002
+        return True
+
+    def login_required(self) -> bool:
+        return False
+
+    def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:  # noqa: ARG002
+        # Single-user: no subdirectory, use data/ directly.
+        return base_data_dir
+
+
+# ---------------------------------------------------------------------------
+# Username validation
+# ---------------------------------------------------------------------------
+
+
+# Usernames are used as data-directory names (data/<user>/...) so they must
+# not contain path separators or traversal segments.  Note that the character
+# class alone is not sufficient: it admits "." and "..", which *are* traversal
+# segments, so :func:`is_safe_username` rejects those explicitly.
+_VALID_USERNAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def is_safe_username(username: Any) -> bool:
+    """Return ``True`` if *username* is safe to use as a path component.
+
+    A username reaches the filesystem in two places, so a bad one is not
+    merely a mislabelled request:
+
+    * ``get_user_data_dir()`` builds ``DATA_DIR / username`` for per-user
+      settings, which are written with ``mkdir(parents=True)``.
+    * The same directory is the confinement root handed to
+      :func:`~vtscore.security.path_validation.validate_server_filepath`,
+      which compares against ``base_dir.resolve()`` — so ``..`` segments in
+      the root are *collapsed* rather than rejected, silently widening the
+      sandbox for every server-file importer and exporter.
+
+    Providers must therefore validate any username they did not construct
+    themselves, whatever their authentication strength.
+    """
+    return isinstance(username, str) and bool(_VALID_USERNAME.match(username)) and username.strip(".") != ""
+
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+_login_provider: LoginProvider = DefaultLoginProvider()
+
+
+def set_login_provider(provider: LoginProvider) -> None:
+    """Set the active login provider (called once at app startup)."""
+    global _login_provider
+    _login_provider = provider
+    logger.info("Login provider set to %r", provider.name)
+
+
+def get_login_provider() -> LoginProvider:
+    """Return the active login provider."""
+    return _login_provider
+
+
+def get_user_data_dir(username: str | None = None) -> Path:
+    """Return the data directory for a user.
+
+    If *username* is ``None``, the current request user is used.  For
+    :class:`DefaultLoginProvider` this always returns ``DATA_DIR``
+    unchanged.
+    """
+    # Imported lazily: :mod:`vtscore.state` pulls in the embedding stack
+    # (numpy, torch) at import time, and this module is on the import path
+    # of every path check in the library.
+    from vtscore.config import DATA_DIR
+    from vtscore.state.current_user import get_current_user
+
+    if username is None:
+        username = get_current_user()
+    return _login_provider.get_user_data_dir(username, DATA_DIR)

--- a/vtscore/security/path_validation.py
+++ b/vtscore/security/path_validation.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Iterator
 
 from vtscore.config import DATA_DIR
+from vtscore.security.login import DefaultLoginProvider, get_login_provider, get_user_data_dir
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 def get_file_access_base_dir() -> Path | None:
     """Return the base directory for file-access validation.
 
-    In single-user / no-auth mode (:class:`~vtsearch.auth.DefaultLoginProvider`)
+    In single-user / no-auth mode (:class:`~vtscore.security.login.DefaultLoginProvider`)
     this returns ``None``, which tells :func:`validate_server_filepath` to apply
     **no** confinement: the lone trusted user may read from and write to any
     server-readable path.  There is no per-user boundary to protect, so the app
@@ -31,8 +32,6 @@ def get_file_access_base_dir() -> Path | None:
     user's data directory so that each user is confined to their own
     ``data/<username>/`` subtree.
     """
-    from vtsearch.auth import DefaultLoginProvider, get_login_provider, get_user_data_dir
-
     provider = get_login_provider()
     if isinstance(provider, DefaultLoginProvider):
         return None  # single-user / no-auth: unrestricted file access

--- a/vtsearch/auth/__init__.py
+++ b/vtsearch/auth/__init__.py
@@ -1,22 +1,46 @@
-"""Authentication and user management for VTSearch.
+"""Authentication and user management for VTSearch - the Flask half.
 
-Provides a pluggable login-provider abstraction so VTSearch can run in
-single-user mode (DefaultLoginProvider) or multi-user mode (e.g.
-UserPassLoginProvider, PKILoginProvider) without changing route code.
+VTSearch runs in single-user mode (:class:`DefaultLoginProvider`) or
+multi-user mode (:class:`TrivialLoginProvider`,
+:class:`ApiKeyLoginProvider`, or your own subclass) without changing
+route code.  Routes call :func:`get_current_user` to learn who is making
+the request; the active provider is set once at startup via
+:func:`set_login_provider`.
 
-Routes call :func:`get_current_user` to learn who is making the request.
-The active provider is set once at startup via :func:`set_login_provider`.
+The abstraction itself is **library-tier**: the :class:`LoginProvider`
+ABC, the single-user default, the process-wide registry,
+:func:`is_safe_username` and :func:`get_user_data_dir` all live in
+:mod:`vtscore.security.login`, because
+:mod:`vtscore.security.path_validation` consults them on every server-file
+path check and must work in a process with no Flask in it (see
+``../../vtscore/docs/architecture.md``).  This module re-exports them
+verbatim - so ``from vtsearch.auth import LoginProvider`` keeps working
+and there is exactly one active provider per process - and adds only the
+parts that genuinely need the web framework:
+
+* :class:`TrivialLoginProvider` / :class:`ApiKeyLoginProvider`, which read
+  ``flask.session`` and the request headers;
+* the request-user resolver that reads ``g.user``.
+
+The same split already backs the current-user thread-local, whose
+mechanics live in :mod:`vtscore.state.current_user`.
 """
 
 from __future__ import annotations
 
 import logging
-import re
 import threading
-from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
+from vtscore.security.login import (
+    DefaultLoginProvider as DefaultLoginProvider,
+    LoginProvider as LoginProvider,
+    get_login_provider as get_login_provider,
+    get_user_data_dir as get_user_data_dir,
+    is_safe_username as is_safe_username,
+    set_login_provider as set_login_provider,
+)
 from vtscore.state.current_user import (
     get_current_user as get_current_user,
     get_thread_user as get_thread_user,
@@ -26,154 +50,6 @@ from vtscore.state.current_user import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# LoginProvider ABC
-# ---------------------------------------------------------------------------
-
-
-class LoginProvider(ABC):
-    """Abstract base for authentication providers.
-
-    Subclasses must implement :meth:`get_user` and :meth:`is_authenticated`.
-    The default implementations of the other methods are suitable for
-    single-user deployments; multi-user providers should override them.
-    """
-
-    #: Short identifier for this provider (e.g. ``"default"``, ``"userpass"``).
-    name: str = ""
-
-    @abstractmethod
-    def get_user(self, request: Any) -> str:
-        """Return the username for the current request.
-
-        Args:
-            request: The Flask request object.
-
-        Returns:
-            A non-empty string identifying the user.
-        """
-
-    @abstractmethod
-    def is_authenticated(self, request: Any) -> bool:
-        """Return ``True`` if the request carries valid credentials.
-
-        For providers that don't require authentication (e.g.
-        :class:`DefaultLoginProvider`) this should always return ``True``.
-        """
-
-    def login_required(self) -> bool:
-        """Whether the frontend should show a login screen at startup."""
-        return False
-
-    def enforce_auth(self) -> bool:
-        """Whether the server rejects unauthenticated ``/api/*`` requests.
-
-        When ``True``, the ``_enforce_auth`` before_request hook (see
-        ``vtsearch.hooks``) aborts with 401 whenever
-        :meth:`is_authenticated` is ``False``, except for the small
-        allowlist of auth endpoints the SPA needs to reach the login
-        screen. Defaults to ``True`` so a custom provider that implements
-        real credentials is gated by construction — forgetting to override
-        this must fail closed, not silently serve every request as
-        ``"anonymous"``. Providers for which anonymous access is a
-        legitimate mode (``TrivialLoginProvider``) override this to
-        ``False``; ``DefaultLoginProvider`` is unaffected either way since
-        it authenticates every request.
-        """
-        return True
-
-    def www_authenticate(self) -> str | None:
-        """Challenge value for the ``WWW-Authenticate`` header on 401s.
-
-        Return the auth scheme clients should use (e.g. ``"Bearer"``), or
-        ``None`` to omit the header (cookie/session providers).
-        """
-        return None
-
-    def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:
-        """Return the data directory for *username*.
-
-        The default implementation returns *base_data_dir* unchanged, which
-        is correct for single-user deployments.  Multi-user providers should
-        return ``base_data_dir / username`` (or similar) so each user's
-        datasets, detectors, and settings are stored separately.
-        """
-        return base_data_dir
-
-    def status_dict(self, request: Any) -> dict[str, Any]:
-        """Return a JSON-serialisable dict describing the auth state.
-
-        Used by the ``/api/auth/status`` endpoint.
-        """
-        return {
-            "provider": self.name,
-            "user": self.get_user(request),
-            "authenticated": self.is_authenticated(request),
-            "login_required": self.login_required(),
-        }
-
-
-# ---------------------------------------------------------------------------
-# DefaultLoginProvider - single-user, no authentication
-# ---------------------------------------------------------------------------
-
-
-class DefaultLoginProvider(LoginProvider):
-    """No-op provider for single-user deployments.
-
-    Every request is treated as coming from the ``"default"`` user.
-    No login screen is shown, and the data directory is used as-is
-    (no per-user subdirectory).
-    """
-
-    name = "default"
-
-    def get_user(self, request: Any) -> str:  # noqa: ARG002
-        return "default"
-
-    def is_authenticated(self, request: Any) -> bool:  # noqa: ARG002
-        return True
-
-    def login_required(self) -> bool:
-        return False
-
-    def get_user_data_dir(self, username: str, base_data_dir: Path) -> Path:  # noqa: ARG002
-        # Single-user: no subdirectory, use data/ directly.
-        return base_data_dir
-
-
-# ---------------------------------------------------------------------------
-# Username validation
-# ---------------------------------------------------------------------------
-
-
-# Usernames are used as data-directory names (data/<user>/...) so they must
-# not contain path separators or traversal segments.  Note that the character
-# class alone is not sufficient: it admits "." and "..", which *are* traversal
-# segments, so :func:`is_safe_username` rejects those explicitly.
-_VALID_USERNAME = re.compile(r"^[A-Za-z0-9._-]+$")
-
-
-def is_safe_username(username: Any) -> bool:
-    """Return ``True`` if *username* is safe to use as a path component.
-
-    A username reaches the filesystem in two places, so a bad one is not
-    merely a mislabelled request:
-
-    * ``get_user_data_dir()`` builds ``DATA_DIR / username`` for per-user
-      settings, which are written with ``mkdir(parents=True)``.
-    * The same directory is the confinement root handed to
-      :func:`~vtscore.security.path_validation.validate_server_filepath`,
-      which compares against ``base_dir.resolve()`` — so ``..`` segments in
-      the root are *collapsed* rather than rejected, silently widening the
-      sandbox for every server-file importer and exporter.
-
-    Providers must therefore validate any username they did not construct
-    themselves, whatever their authentication strength.
-    """
-    return isinstance(username, str) and bool(_VALID_USERNAME.match(username)) and username.strip(".") != ""
 
 
 # ---------------------------------------------------------------------------
@@ -392,25 +268,6 @@ class ApiKeyLoginProvider(LoginProvider):
 
 
 # ---------------------------------------------------------------------------
-# Module-level state
-# ---------------------------------------------------------------------------
-
-_login_provider: LoginProvider = DefaultLoginProvider()
-
-
-def set_login_provider(provider: LoginProvider) -> None:
-    """Set the active login provider (called once at app startup)."""
-    global _login_provider
-    _login_provider = provider
-    logger.info("Login provider set to %r", provider.name)
-
-
-def get_login_provider() -> LoginProvider:
-    """Return the active login provider."""
-    return _login_provider
-
-
-# ---------------------------------------------------------------------------
 # Current-user resolution
 # ---------------------------------------------------------------------------
 # The mechanics (thread-local storage, the ``"default"`` fallback) live in
@@ -442,17 +299,3 @@ def _flask_request_user() -> str | None:
 
 
 register_request_user_resolver(_flask_request_user)
-
-
-def get_user_data_dir(username: str | None = None) -> Path:
-    """Return the data directory for a user.
-
-    If *username* is ``None``, the current request user is used.  For
-    :class:`DefaultLoginProvider` this always returns ``DATA_DIR``
-    unchanged.
-    """
-    from vtscore.config import DATA_DIR
-
-    if username is None:
-        username = get_current_user()
-    return _login_provider.get_user_data_dir(username, DATA_DIR)


### PR DESCRIPTION
Closes #3042.

`vtscore/security/path_validation.get_file_access_base_dir()` did an unguarded lazy `from vtsearch.auth import DefaultLoginProvider, get_login_provider, get_user_data_dir` to decide whether server file access is confined to a per-user data dir. That was the last remaining *unguarded* inverted dependency in the library tier: without the `vtsearch` package installed, every path check in `vtscore` raised `ImportError` at call time — and a library-only embedder had no way to *opt into* confinement at all.

Took option 2 from the issue (move the ABC) rather than the narrow hook, so the seam is removed instead of papered over.

## What moved

New `vtscore/security/login.py` carries the Flask-free half of `vtsearch/auth/`:

- `LoginProvider` ABC (including `enforce_auth()` / `www_authenticate()`, which landed on `dev` while this was in flight)
- `DefaultLoginProvider`
- `is_safe_username()`
- the process-wide `set_login_provider` / `get_login_provider` registry
- `get_user_data_dir()`

It sits in `security/` rather than `state/` for two reasons: it *is* the confinement-root decision that `path_validation` consumes, and `vtscore.state` pulls in the embedding stack (numpy, torch) at import time, which the lightweight path checks must not drag in. `get_current_user()` is therefore imported lazily inside `get_user_data_dir()`.

`vtsearch/auth/` keeps only what genuinely needs a web framework — `TrivialLoginProvider` (reads `flask.session`), `ApiKeyLoginProvider` (reads the `Authorization` header), and the `g.user` request-user resolver — and re-exports every moved name, so `from vtsearch.auth import LoginProvider` keeps working and there is exactly one active provider per process. That mirrors how `vtsearch.auth` already re-exports `vtscore.state.current_user`.

No behaviour change: `get_file_access_base_dir()` still returns `None` (unconfined) under `DefaultLoginProvider` and the user's data dir otherwise.

## Tests

- `tests_lib/core/test_library_layering.py`: dropped the `security/path_validation.py` entry from `_ALLOWED`. The allowlist is now only the two `try`/`except`-guarded optional imports.
- New `tests_lib/core/test_library_login_provider.py` pins both halves the issue asked to double-check: the default stays single-user and unconfined, and a plain `LoginProvider` subclass registered from Flask-free code turns confinement on for `get_file_access_base_dir` / `media_file_read_roots` / `validate_server_filepath`. It also pins that the two seams are separate — the provider says *where* a user's data lives, `thread_user` says *which* user — since `get_user_data_dir()` with no argument reads the latter.

`./run-tests.sh` (8297 passed) and `./run-tests.sh vtscore-clean` (4104 passed) both green.

## Docs

`vtscore/docs/packages/security.md` gains a "Login providers" section with the embedder recipe; `vtscore/docs/integration.md`'s "single-tenant by design" claim is now "single-tenant by default" with the opt-in path spelled out; `vtscore/docs/architecture.md`, `docs/ARCHITECTURE.md` and `docs/EXTENDING.md` updated for the new home; `vtscore/CHANGELOG.md` gains an Unreleased/Added entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dPh68ydGNkFtKYkrTGeQn

---
_Generated by [Claude Code](https://claude.ai/code/session_013dPh68ydGNkFtKYkrTGeQn)_