### PR TITLE
Delete dead shared SCSS rules and correct the button taxonomy docs

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -46,7 +46,7 @@ at the default 16px root.
 
 There are no other font sizes. `0.78rem`, `0.83rem`, `0.95rem`, `12px`, `13px`, etc. are all violations - they collapse into the table above.
 
-**Monospace:** `--font-mono` is the one monospace stack (`ui-monospace, SFMono-Regular, Menlo, Consolas, monospace`). Reach for it whenever a face needs to be fixed-width (`.form-hint`, `.form-textarea`, code-ish values); never write a bare `monospace` or a hand-rolled font stack.
+**Monospace:** `--font-mono` is the one monospace stack (`ui-monospace, SFMono-Regular, Menlo, Consolas, monospace`). Reach for it whenever a face needs to be fixed-width (`.form-hint`, code-ish values); never write a bare `monospace` or a hand-rolled font stack.
 
 ### 1.3 Font weights - `--weight-*`
 
@@ -226,18 +226,15 @@ The full taxonomy is `.btn` plus optional variant + optional size. Always start 
 <button class="btn btn--toolbar">Import Labels</button>
 <button class="btn btn--sm">Compact</button>
 <button class="btn btn--primary btn--sm">Compact primary</button>
-<button class="btn btn--xs">Inline mini</button>
-<button class="btn btn--icon-square">+</button>
 ```
 
 Rules:
 
 - **Default size** for prominent actions (modal footers, top-of-panel actions).
 - **`.btn--sm`** for inline actions inside cards and rows.
-- **`.btn--xs`** for the densest tables / inline edit rows.
 - **`.btn--cancel`** for low-weight cancel/close affordances next to progress bars.
 - **`.btn--toolbar`** for compact outline buttons in toolbars and panel action rows (the right-panel Import Labels / Add Corrections / Export cluster, the image-view-controls strip): tighter padding, `--font-xs`, a muted resting color, `white-space: nowrap`, and a hover that promotes the border to `--accent`.
-- **`.btn--icon-square`** for square plus/icon buttons (28×28).
+- **This list is the whole taxonomy.** There is no `--xs`, `--ghost`, or `--icon-square`; if you need a size or treatment that isn't here, add it to `_components.scss` (and to this list) rather than inventing a class name that no rule matches.
 - **Do not write per-component `padding` / `font-size` / `border-radius` on a button.** Every "small button" implementation in component SCSS that bypassed this taxonomy has been removed.
 
 A borderless icon button inside a card row or action cluster is **not** a `.btn` variant - use `.card-icon-btn` (§2.11).
@@ -251,13 +248,11 @@ A borderless icon button inside a card row or action cluster is **not** a `.btn`
   <p class="form-hint">JSON, CSV, or NPZ accepted.</p>
 </div>
 <select class="form-select">...</select>
-<textarea class="form-textarea"></textarea>
 ```
 
 - `.form-group` is the label+control wrapper: a flex column with `gap: var(--space-xs)`. It owns the spacing *inside* one field; the surrounding form (`.importer-form`, §2.5) owns the spacing between fields. `.form-group--section` adds `margin-top: var(--space-xl)` above a grouped block inside an importer form (the Embedder/Clipper "Advanced" block).
 - `.form-input` and `.form-select` share padding, border, focus state. They sit on `--bg-subtle` so they read as "input wells."
 - `.form-select--compact` is the toolbar-sized select: sized to its content rather than full width, tighter padding, `--font-xs`, on `--bg-surface`. Use it in dense bars (label sort, browse selection panel), not in forms.
-- `.form-textarea` extends `.form-input` for multi-line entry: vertical resize only, a `5rem` floor, and `--font-mono` so long term lists line up.
 - `.form-label` is `--font-md`, `--weight-medium`, `--text-primary` - sized to match `.form-input` so the header is never visually smaller than the value the user types/picks underneath it. Custom `<button>`-based dropdown triggers that play the role of `.form-select` (e.g. icon-bearing media-type pickers) must set `font-size: var(--font-md)` explicitly: `<button>` doesn't inherit page font by default, and component-scoped overrides (`font: inherit`, etc.) silently win over the global `.form-select` because Angular view encapsulation raises their specificity. If the trigger text ever renders larger than the label above it, that rule is the regression.
 - `.form-hint` (used for plugin-field `hint` strings) is muted `--font-mono` at `--font-sm`, and preserves newlines (`white-space: pre-wrap`) so a multi-line schema hint keeps its shape.
 - `.required` marks required fields with `--color-bad`.
@@ -471,7 +466,6 @@ Global classes that any component can apply. All animations here are silenced by
 | `.drawer-enter-left` / `.drawer-leave-left` / `.drawer-enter-right` / `.drawer-leave-right` | Slide-from-edge transitions for side panels, bound via Angular's `animate.enter` / `animate.leave`. |
 | `.swipe-left` / `.swipe-right` | The vote fling that throws the current media off-screen (bad / good). |
 | `.icon-waggle` | 2s rotate-and-hold loop signalling "a slow job kicked off by this control is running" (Find/Train buttons, in-flight import/export submits). |
-| `.skeleton-bg` | Flat subtle placeholder painted behind a lazy-loaded `<img>` so it doesn't pop in against nothing. |
 | `.waveform-mask` | Paints `--accent` through an audio waveform's alpha mask so thumbnails tint per theme. The `mask-image` URL is set per instance via a style binding. |
 | `.sr-only` | Visually hidden, screen-reader-visible text. |
 

--- a/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/import-defaults/import-defaults-settings.component.html
@@ -69,7 +69,7 @@
       <div class="import-defaults-footer">
         <button
           type="button"
-          class="btn btn--ghost btn--sm"
+          class="btn btn--sm"
           [disabled]="!hasOverridesForActiveType"
           (click)="resetActiveType()"
           [title]="hasOverridesForActiveType

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -451,17 +451,6 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
   cursor: pointer;
 }
 
-// Multi-line text entry (e.g. a custom signpost tag vocabulary, one term per
-// line).  Shares `.form-input`'s framing but allows vertical resize and reads
-// in a monospace face so long term lists line up.
-.form-textarea {
-  @extend .form-input;
-  resize: vertical;
-  min-height: 5rem;
-  font-family: var(--font-mono, monospace);
-  line-height: 1.4;
-}
-
 // Compact variant for dense toolbars (the label-sort bar, the browse
 // selection panel).  Same visual treatment as `.form-select`, but sized to
 // its content rather than stretched full-width, with tighter padding and a
@@ -936,25 +925,6 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
-}
-
-// --- Skeleton shimmer background ---
-//
-// Static placeholder behind lazy-loaded <img>s: a flat subtle background
-// shows until the image paints, smoothing the "pop-in" from
-// loading="lazy" without any motion.
-.skeleton-bg {
-  position: relative;
-  isolation: isolate;
-
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: var(--bg-subtle);
-    border-radius: inherit;
-    z-index: -1;
-  }
 }
 
 // --- Accessibility ---

--- a/frontend/src/scss/_components.scss
+++ b/frontend/src/scss/_components.scss
@@ -54,8 +54,6 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
 //   .btn--cancel      subtle, link-weight cancel/close (no fill, small)
 //   .btn--toolbar     compact outline button for toolbars / panel action rows
 //   .btn--sm          compact size modifier
-//   .btn--xs          inline mini size modifier (used inside table rows etc.)
-//   .btn--icon-square square 28×28 plus/icon button
 //
 // Combine variant + size as needed: `class="btn btn--primary btn--sm"`.
 
@@ -132,16 +130,10 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
     }
   }
 
-  // Size modifiers: change padding + font, keep border/colors from the variant.
+  // Size modifier: changes padding + font, keeps border/colors from the variant.
   &--sm {
     padding: var(--space-2xs) var(--space-md);
     font-size: var(--font-sm);
-  }
-
-  &--xs {
-    padding: 0 var(--space-sm);
-    font-size: var(--font-xs);
-    line-height: 1.6;
   }
 
   // Compact outline button for toolbars and panel action rows: tighter
@@ -163,14 +155,6 @@ h4 { font-size: var(--font-lg); font-weight: var(--weight-medium); }
     }
   }
 
-  // Square 28×28 icon button (used for "+ add" in dashboard headers).
-  &--icon-square {
-    width: 28px;
-    height: 28px;
-    padding: 0;
-    font-size: var(--font-xl);
-    line-height: 1;
-  }
 }
 
 // --- Segmented toggle ---


### PR DESCRIPTION
Cleanup pass over the shared stylesheet, prompted by `.form-textarea` and `.skeleton-bg` having no template consumers.

## What changed

**Deleted, zero consumers anywhere** (no template, component TS, or `@extend`):

- `.form-textarea` — its comment cites "a custom signpost tag vocabulary" that was never built. Nothing in `docs/plans/vtsbrowse-toponymy.md` owes a custom-vocabulary UI, so there is no consumer coming.
- `.skeleton-bg` — the lazy-image placeholder role is served by the `vt-skeleton` component (`.skeleton`, `.media-skeleton-card`, `.dashboard-skeleton-row`), which is what the templates actually use.
- `.btn--xs` — `.btn--sm` (37 uses) already owns "compact". A second, unused size modifier is a coin-flip for the next author and a path to inconsistent density.
- `.btn--icon-square` — its own comment names a dashboard "+ add" consumer that no longer exists.

**Kept:** `.btn--danger`, also unused today. It is a semantic variant rather than a decorative one, and its absence is exactly what pushes someone into the ad-hoc red button that the style guide's own last rule in §2.2 forbids. Eight lines of insurance against a documented failure mode.

**Docs follow the code.** `docs/style-guide.md` §2.2 claimed to list "the full taxonomy" while documenting three variants nobody uses and omitting `.btn--toolbar`, which 12 templates do use. The §2.2 example block and rule list, the §2.3 form example and `.form-textarea` bullet, the `--font-mono` note in §1.2, and the `.skeleton-bg` row in the shared-animation table all now describe what actually ships, and §2.2 states explicitly that its list is exhaustive.

**One template fixed.** `import-defaults-settings.component.html` asked for `.btn--ghost`, a class no rule has ever matched — the intended treatment silently never applied. Dropped the token; the button already rendered as a plain `.btn btn--sm`, so there is no visual change.

## Verification

Every deletion was confirmed dead by searching templates, component TS, and SCSS for both literal and dynamically-composed class names (there is no `btn--${…}` construction in the codebase), and re-confirmed against `dev` after rebasing. No visual change is expected from any hunk: the deleted rules matched no element, and the `--ghost` token matched no rule.

`./run-tests.sh` green on the rebased branch — 8296 passed, 6 skipped; frontend `build:prod` warning-free, `npm audit` clean, Vitest suite passing.