### PR TITLE
Cover the config builder in the reload-isolation pair, not just the budget

### DIFF
--- a/tests_lib/core/test_training_budget_isolation.py
+++ b/tests_lib/core/test_training_budget_isolation.py
@@ -31,11 +31,21 @@ pytestmark = pytest.mark.xdist_group("training-budget-isolation")
 
 
 def test_a_reloading_config_resets_the_training_budget():
-    """The hazard itself: a reload silently reverts the budget to production."""
+    """The hazard itself: a reload silently reverts the budget to production.
+
+    The budget is the one that read as nondeterminism, but it is not the only
+    session-level value the reload drops - the registered ``CoreConfig``
+    builder goes with it, and its absence makes ``from_settings()`` raise.
+    """
     importlib.reload(config)
     assert config.TRAIN_EPOCHS == int(os.environ.get("VTSEARCH_TRAIN_EPOCHS", "200"))
+    assert config._core_config_builder is None
 
 
 def test_b_the_next_test_still_gets_the_session_budget():
     """...and the next test is handed the session's budget regardless."""
     assert config.TRAIN_EPOCHS == TEST_TRAIN_EPOCHS
+    # Restored, and *callable*: registration alone would still leave
+    # ``from_settings()`` raising if the builder came back unusable.
+    assert config._core_config_builder is not None
+    assert config.CoreConfig.from_settings().data_dir == config.DATA_DIR


### PR DESCRIPTION
Refs #3084, refs #3101.

## What happened to this PR

It originally carried a fix for #3084 (a `tests_lib` threshold fixture that collapsed to an exact tie under xdist). While it was open, #3101 — the same bug, filed separately — shipped to `dev` as #3108 with the same diagnosis (`importlib.reload(vtscore.config)` reverting the tier's `TRAIN_EPOCHS = 30` to the production 200 for the rest of the worker) and a broader fix: `test_torch_config.py` now snapshots and restores the whole module dict, so the repair covers `MAX_UPLOAD_MB` and friends too, not just the one constant that happened to be load-bearing.

So this branch has been rebased onto that fix and its duplicate work dropped. What remains is the one thing the shipped version does not have.

## The delta

`tests_lib/core/test_training_budget_isolation.py` pins that a mid-session reload cannot reach the next test — but it asserts that for `TRAIN_EPOCHS` only. The reload drops the registered `CoreConfig` builder too, and that half fails *loudly*: `from_settings()` raises without it. Both conftests have re-registered it per test for far longer than they have re-asserted the budget, and nothing pinned it.

This asserts both halves at both ends of the existing pair: the builder is `None` after the reload, and back — and *callable*, not merely non-`None` — in the following test.

Verified non-vacuous by deleting the conftest's `register_core_config_builder` call, which fails `test_b`.

## Note on #3084

Left open rather than closed: it is a duplicate of #3101, whose fix is on `dev` but not yet on `main`, and per the repo's convention issues close when the fix ships. It may be worth closing as a duplicate independently of this PR.

## Testing

`./run-tests.sh` — all gates green, **8396 passed**, 6 skipped, 2 xpassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1iyKxkQWv2tu1grvcXj9d