### PR TITLE
Stop a config reload from leaking the production training budget into tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,14 @@ def pytest_collection_modifyitems(items, config):
 
 
 # Reduce training epochs for faster tests (default is 200; 30 is sufficient
-# for the tiny MLP to converge on the small test dataset).
-config.TRAIN_EPOCHS = 30
+# for the tiny MLP to converge on the small test dataset).  Named rather than
+# inlined because it is re-asserted per test in ``reset_state`` below: the two
+# trees share a worker process in a full run, and
+# ``tests_lib/core/test_torch_config.py`` reloads ``vtscore.config``, which
+# resets every module-level constant to its import-time value (issue #3101).
+TEST_TRAIN_EPOCHS = 30
+
+config.TRAIN_EPOCHS = TEST_TRAIN_EPOCHS
 
 # ---------------------------------------------------------------------------
 # Stub out heavy embedding models BEFORE importing the app.
@@ -363,6 +369,12 @@ def reset_state():
 
     config.resolve_device.cache_clear()
     _emb_loader.resolve_device.cache_clear()
+
+    # Same reload hazard, for a value that doesn't crash when it leaks: a wiped
+    # ``TRAIN_EPOCHS`` falls back to the production 200 and silently retrains
+    # every later detector fixture on a different budget, which is what made a
+    # fully seeded threshold fixture order-dependent (issue #3101).
+    config.TRAIN_EPOCHS = TEST_TRAIN_EPOCHS
 
     _dataset_progress.reset_cancel()
     _find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -46,7 +46,16 @@ def pytest_collection_modifyitems(items, config):
             item.add_marker(getattr(pytest.mark, parent))
 
 
-config.TRAIN_EPOCHS = 30
+#: Training epochs for the whole test session (production default is 200; 30 is
+#: enough for the tiny heads to converge on the small test fixtures).  Named
+#: rather than inlined because it is re-asserted per test in ``reset_contexts``
+#: below - ``tests_lib/core/test_torch_config.py`` reloads ``vtscore.config``,
+#: which resets every module-level constant to its import-time value, and a
+#: leaked 200 silently retrains every later detector fixture against a different
+#: budget (issue #3101).
+TEST_TRAIN_EPOCHS = 30
+
+config.TRAIN_EPOCHS = TEST_TRAIN_EPOCHS
 
 
 # ---------------------------------------------------------------------------
@@ -339,10 +348,16 @@ def reset_contexts(tmp_path, monkeypatch):
     _reset_model_reg()
 
     # ``test_torch_config.py`` reloads ``vtscore.config`` to test env-var
-    # behaviour, which wipes the module-level builder installed at import
-    # time.  Re-register defensively so any later test that calls
-    # ``CoreConfig.from_settings()`` still has a backing implementation.
+    # behaviour, which wipes *every* module-level value this conftest installed
+    # at import time.  That file restores its own snapshot now (issue #3101),
+    # but re-assert the two that matter defensively, so any future reload - or
+    # any test that writes to ``vtscore.config`` and forgets to restore - cannot
+    # silently change what the rest of the session runs against: a missing
+    # builder makes ``CoreConfig.from_settings()`` raise, and a leaked training
+    # budget retrains every later detector fixture on a different number of
+    # epochs (which is how #3101 turned a seeded fixture order-dependent).
     config.register_core_config_builder(_lib_default_core_config)
+    config.TRAIN_EPOCHS = TEST_TRAIN_EPOCHS
 
 
 @pytest.hookimpl(trylast=True)

--- a/tests_lib/core/test_torch_config.py
+++ b/tests_lib/core/test_torch_config.py
@@ -20,6 +20,40 @@ import torch
 
 
 @pytest.fixture(autouse=True)
+def restore_reloaded_modules():
+    """Undo what ``importlib.reload`` does to the rest of the session.
+
+    Every test here reloads ``vtscore.config`` (and often
+    ``vtscore.embedding.loader``) to re-read an env var at import time.  A
+    reload re-executes the module *in place*, so it resets every module-level
+    value to its import-time default - including the ones the conftests install
+    for the whole session, none of which the reloading test wants to change.
+    Nothing restored them, so the wipe leaked into every later test sharing the
+    worker process.
+
+    That is issue #3101: ``TRAIN_EPOCHS`` reverted from the session's 30 to the
+    production 200, so a *fully seeded* threshold fixture trained a different
+    model depending on whether these tests happened to run before it on the
+    same xdist worker - which read as a nondeterministic failure in the safe
+    threshold subsystem rather than as test-state leakage.  Restoring the
+    module dicts fixes the whole class of leak rather than the one constant
+    that happened to be load-bearing; the conftests additionally re-assert the
+    two values with the worst blast radius.
+
+    Declared first so it tears down *last*, after the narrower fixtures below
+    have cleared the caches they own on the reloaded module.
+    """
+    import vtscore.config as config
+    import vtscore.embedding.loader as loader
+
+    snapshots = [(module, dict(module.__dict__)) for module in (config, loader)]
+    yield
+    for module, snapshot in snapshots:
+        module.__dict__.clear()
+        module.__dict__.update(snapshot)
+
+
+@pytest.fixture(autouse=True)
 def reset_torch_configured_flag():
     """Force ``ensure_torch_configured`` to re-run on each test."""
     import vtscore.media.torch_setup as torch_setup

--- a/tests_lib/core/test_training_budget_isolation.py
+++ b/tests_lib/core/test_training_budget_isolation.py
@@ -1,0 +1,41 @@
+"""The session's training budget survives a mid-session ``vtscore.config`` reload.
+
+``tests_lib/core/test_torch_config.py`` reloads ``vtscore.config`` to re-read
+env vars at import time, which resets every module-level constant - including
+the conftests' ``TRAIN_EPOCHS`` override - to its production default.  Nothing
+restored it, so a fully seeded detector fixture trained 200 epochs instead of 30
+whenever those tests happened to land earlier on the same xdist worker, and the
+resulting threshold divergence read as nondeterminism in the safe-threshold
+subsystem (issue #3101).
+
+The reloading file now restores its own module snapshot and the conftests
+re-assert the budget per test.  This pins the guarantee those two provide, in
+the order that actually exposes it: poison the budget in one test, check it is
+back in the next.  ``xdist_group`` keeps the pair on one worker under
+``--dist loadgroup``; without it they could be split across processes and the
+second test would pass without ever seeing the first one's damage.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+from vtscore import config
+
+from tests_lib.conftest import TEST_TRAIN_EPOCHS
+
+pytestmark = pytest.mark.xdist_group("training-budget-isolation")
+
+
+def test_a_reloading_config_resets_the_training_budget():
+    """The hazard itself: a reload silently reverts the budget to production."""
+    importlib.reload(config)
+    assert config.TRAIN_EPOCHS == int(os.environ.get("VTSEARCH_TRAIN_EPOCHS", "200"))
+
+
+def test_b_the_next_test_still_gets_the_session_budget():
+    """...and the next test is handed the session's budget regardless."""
+    assert config.TRAIN_EPOCHS == TEST_TRAIN_EPOCHS

--- a/tests_lib/detectors/test_acquisition_threshold.py
+++ b/tests_lib/detectors/test_acquisition_threshold.py
@@ -42,10 +42,21 @@ def _clips(rng: np.random.Generator, cids: range) -> dict[int, dict]:
 #: :data:`ACQUISITION_INCLUSION_OFFSET` is one inclusion step, whose tilt is
 #: routinely smaller than that, so on a 20-item haystack the acquisition cut
 #: lands on the *same* haystack element as the reporting cut and a strict ``>``
-#: holds or fails on numerical noise - which is how it varied with process
-#: ordering.  100 resolves a single step with room to spare (verified across
-#: seeds), keeping the direction pin about the offset rather than about
-#: discretization.
+#: degenerates into an equality.  100 resolves a single step with room to spare
+#: (verified across seeds), keeping the direction pin about the offset rather
+#: than about discretization.
+#:
+#: The 20-item version *looked* nondeterministic (issue #3101): it failed only
+#: in a full run, from a fully seeded fixture.  What varied with process
+#: ordering was the ambient training budget, not the estimator - a stray
+#: ``vtscore.config`` reload reverted ``TRAIN_EPOCHS`` to production, which
+#: moved the fit, which moved which side of a haystack gap the two cuts landed
+#: on.  The offset itself was never at risk: measured on the failing fixture,
+#: the per-fold rate cut moved 0.528 -> 0.551 between the two inclusions with
+#: an interior stationary point at both, i.e. exactly the tilt this file pins,
+#: too small to cross a 20-sample gap.  The leak is fixed at its source, but
+#: the fixture stays wide: a pin whose margin is one haystack spacing is a pin
+#: that reports unrelated drift as a falsified conclusion.
 HAYSTACK = 100
 
 


### PR DESCRIPTION
Closes #3101

## What was actually wrong

`tests_lib/core/test_torch_config.py` calls `importlib.reload(vtscore.config)` in almost every test, to re-read an env var at import time. A reload re-executes the module **in place**, resetting every module-level value to its import-time default — including the `TRAIN_EPOCHS = 30` both conftests install for the whole session. Nothing restored it, so every later test sharing that xdist worker trained the production **200** epochs instead of 30.

That is the whole mechanism behind the reported nondeterminism. A different training budget produces a different fit, and on the (then) 20-item haystack the acquisition and reporting cuts landed on the *same* haystack element, so the strict `>` degenerated into an equality. Reproduced deterministically outside pytest: at `TRAIN_EPOCHS=200`, `HAYSTACK=20`, `seed=7` the threshold is `0.5650910377502442` — bit-for-bit the value in the issue's traceback — with the combined fold quantile identical at both inclusions; at 30 epochs the same fixture has a healthy gap.

**The acquisition offset was never implicated.** Measured on the failing fixture, the per-fold rate cut still moves `0.5284 → 0.5508` (fold 0) and `0.5046 → 0.5210` (fold 1) across the one-step offset, with `cut_fallback_kind == ""` (an interior stationary point) at *both* inclusions — the tilt is exactly what the test claims, just smaller than one gap between adjacent samples of a 20-element haystack. So this was "the invariant is too strict for the fixture size", not "the shipped offset collapses"; the `acq_p2` conclusion stands. The `HAYSTACK = 100` widening already on `dev` is why the test passes today — this PR removes the coupling that made it fail in the first place.

## Changes

- **`tests_lib/core/test_torch_config.py`** — a first-declared autouse fixture snapshots and restores `vtscore.config.__dict__` and `vtscore.embedding.loader.__dict__` around each test. Declared first so it tears down last, after the narrower fixtures have cleared the caches they own on the reloaded module. This fixes the whole class of leak, not just the load-bearing constant: a reload was also leaving e.g. `MAX_UPLOAD_MB` at whatever the reloading test's env var said.
- **`tests/conftest.py`, `tests_lib/conftest.py`** — the training budget becomes a named `TEST_TRAIN_EPOCHS` and is re-asserted per test in the autouse reset fixture, alongside the existing defensive `register_core_config_builder`. A backstop for the two values with the worst blast radius: a missing builder raises, a leaked budget doesn't — it just silently retrains everything downstream.
- **`tests_lib/core/test_training_budget_isolation.py`** (new) — an order-pinned pair (`xdist_group`, so `--dist loadgroup` keeps them on one worker in order): the first test reloads `vtscore.config` and confirms the budget reverts to production, the second confirms the next test is handed the session budget anyway.
- **`tests_lib/detectors/test_acquisition_threshold.py`** — the `HAYSTACK` comment attributed the failure to "numerical noise" varying "with process ordering". Corrected to name the real coupling and to record the rate-cut measurement above, so the next reader doesn't go looking for phantom nondeterminism in the estimator. The fixture stays wide regardless: a pin whose margin is one haystack spacing reports unrelated drift as a falsified conclusion.

## Verification

- Leak reproduced and confirmed fixed: `pytest tests_lib/core/test_torch_config.py <probe>` — probe asserting `TRAIN_EPOCHS == 30` fails before, passes after; same for a `MAX_UPLOAD_MB` probe (which the conftest backstop alone does *not* cover, so it exercises the fixture specifically).
- Full `./run-tests.sh`: **8298 passed, 6 skipped, 2 xfailed** — all gates green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R66gzjBY1cBa61VTMZJKMv)_