### PR TITLE
Unblind the build-warning gate, and bring the initial bundle back under budget

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -59,8 +59,12 @@
                 // deferred chunk. The shared `vt-modal` adds CDK a11y's focus
                 // trap (`CdkTrapFocus`) for keyboard/screen-reader focus
                 // management across all ~24 dialogs; because the modal is eager,
-                // that ~7kB lands in the initial bundle, taking it to ~507kB. The
-                // warn limit sits just above the real size with a small headroom.
+                // that ~7kB lands in the initial bundle, taking it to ~507kB.
+                // Measured 515.63kB as of the eager-path audit that split
+                // `DashboardSortService` out of `DashboardColumnsService` (the
+                // eager context pulldowns were dragging `ManagedColumns` and the
+                // Dashboard column metadata onto first paint, ~6.5kB). The warn
+                // limit sits just above the real size with a small headroom.
                 // Do not raise without first auditing the eager path for genuine
                 // bloat.
                 {

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -9,10 +9,10 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { ContextSwitchService } from '../../services/context-switch.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 import { PulldownControlService } from '../../services/pulldown-control.service';
-import { DashboardColumnsService } from '../../services/dashboard-columns.service';
+import { DashboardSortService } from '../../services/dashboard-sort.service';
 import { DashboardSelectionService } from '../../services/dashboard-selection.service';
 import { RunningJobsService, pairKey } from '../../services/running-jobs.service';
-import { SortState, sortRowsByColumn } from '../../utils/managed-columns';
+import { SortState, sortRowsByColumn } from '../../utils/sort-rows';
 import { DatasetRegistryEntry } from '../../models/api.models';
 import { IconComponent } from '../icon/icon.component';
 import { DetectorRegistryEntry } from '../../generated/api-client/models/detector-registry-entry';
@@ -74,7 +74,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   private contextSwitch = inject(ContextSwitchService);
   private newThingFlows = inject(NewThingFlowsService);
   private pulldownControl = inject(PulldownControlService);
-  private dashboardColumns = inject(DashboardColumnsService);
+  private dashboardSort = inject(DashboardSortService);
   private dashSelection = inject(DashboardSelectionService);
   private runningJobs = inject(RunningJobsService);
   private cdr = inject(ChangeDetectorRef);
@@ -195,11 +195,11 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.openMenu());
 
-    // Erase the column-type union to a plain `SortState`; the pulldown
-    // doesn't care which specific column-type union the source carries.
-    const sortState$: Observable<SortState> = this.isDataset
-      ? this.dashboardColumns.datasetCols.sortState$
-      : this.dashboardColumns.detectorCols.sortState$;
+    // Mirror of the Dashboard table's sort. Read through
+    // `DashboardSortService` rather than the owning `DashboardColumnsService`
+    // so this eager component doesn't pull the column-management code onto
+    // the initial bundle.
+    const sortState$: Observable<SortState> = this.dashboardSort.sort$(this.kind());
     sortState$.pipe(takeUntil(this.destroy$)).subscribe((state) => {
       this.sortState = state;
       this.rebuildRows();
@@ -447,7 +447,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   }
 
   /** Sort registry entries the same way the Dashboard's tables sort them
-   *  (column + direction read from `DashboardColumnsService`). Mirrors
+   *  (column + direction read from `DashboardSortService`). Mirrors
    *  the comparator in `DashboardComponent.sortedDatasets` /
    *  `sortedDetectors`. */
   private applySort<T>(arr: T[]): T[] {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -33,7 +33,7 @@ import {
   formatProgressMessage,
   progressBarState,
 } from '../../utils/format-progress';
-import { sortRowsByColumn } from '../../utils/managed-columns';
+import { sortRowsByColumn } from '../../utils/sort-rows';
 import {
   DashboardColumnsService,
   DatasetColumn,

--- a/frontend/src/app/services/dashboard-columns.service.spec.ts
+++ b/frontend/src/app/services/dashboard-columns.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { DashboardColumnsService } from './dashboard-columns.service';
-import { SortState } from '../utils/managed-columns';
+import { SortState } from '../utils/sort-rows';
 
 describe('DashboardColumnsService', () => {
   let service: DashboardColumnsService;

--- a/frontend/src/app/services/dashboard-columns.service.ts
+++ b/frontend/src/app/services/dashboard-columns.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ColMeta, ManagedColumns } from '../utils/managed-columns';
+import { DashboardSortService } from './dashboard-sort.service';
 
 export type DatasetColumn =
   | 'name'
@@ -78,11 +79,20 @@ export const DETECTOR_COL_META: Record<string, ColMeta> = {
  * (datasets, detectors). Lifting them out of `DashboardComponent` lets
  * the top-bar context pulldowns mirror the Dashboard's column sort
  * without coupling to the Dashboard component.
+ *
+ * The pulldowns read that sort from `DashboardSortService`, which this
+ * service feeds, rather than injecting this one: this service reaches
+ * `ManagedColumns` and the column-metadata tables, all of which belong on
+ * the lazy `dashboard-component` chunk rather than the initial bundle.
+ * So this stays a Dashboard-side type — only lazily-loaded code may inject
+ * it.
  */
 @Injectable({ providedIn: 'root' })
 export class DashboardColumnsService {
   readonly datasetCols: ManagedColumns<DatasetColumn>;
   readonly detectorCols: ManagedColumns<DetectorColumn>;
+
+  private readonly sortMirror = inject(DashboardSortService);
 
   constructor() {
     this.datasetCols = new ManagedColumns<DatasetColumn>(
@@ -95,5 +105,10 @@ export class DashboardColumnsService {
       DETECTOR_COL_META,
       { initialSort: 'name', storageKey: DETECTOR_COL_ORDER_KEY },
     );
+    // Forward both tables' sort into the read-side mirror. Never
+    // unsubscribed, which is correct for a root singleton feeding another
+    // root singleton: both live for the lifetime of the app.
+    this.datasetCols.sortState$.subscribe((s) => this.sortMirror.publish('dataset', s));
+    this.detectorCols.sortState$.subscribe((s) => this.sortMirror.publish('detector', s));
   }
 }

--- a/frontend/src/app/services/dashboard-sort.service.spec.ts
+++ b/frontend/src/app/services/dashboard-sort.service.spec.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+
+import { DashboardSortService } from './dashboard-sort.service';
+import { DashboardColumnsService } from './dashboard-columns.service';
+import { SortState } from '../utils/sort-rows';
+
+describe('DashboardSortService', () => {
+  let mirror: DashboardSortService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    mirror = TestBed.inject(DashboardSortService);
+  });
+
+  it('reports name-ascending for both tables before the Dashboard is constructed', () => {
+    const seen: SortState[] = [];
+    mirror.sort$('dataset').subscribe((s) => seen.push(s));
+    mirror.sort$('detector').subscribe((s) => seen.push(s));
+
+    expect(seen.length).toBe(2);
+    for (const s of seen) {
+      expect(s.column).toBe('name');
+      expect(s.asc).toBe(true);
+    }
+  });
+
+  it('keeps the two tables independent', () => {
+    const columns = TestBed.inject(DashboardColumnsService);
+    const datasetSeen: SortState[] = [];
+    const detectorSeen: SortState[] = [];
+    mirror.sort$('dataset').subscribe((s) => datasetSeen.push(s));
+    mirror.sort$('detector').subscribe((s) => detectorSeen.push(s));
+
+    columns.datasetCols.sortBy('num_items');
+
+    expect(datasetSeen[datasetSeen.length - 1].column).toBe('num_items');
+    expect(detectorSeen.length).toBe(1);
+    expect(detectorSeen[0].column).toBe('name');
+  });
+
+  it('mirrors sortBy on the Dashboard tables, including the direction toggle', () => {
+    const columns = TestBed.inject(DashboardColumnsService);
+    const seen: SortState[] = [];
+    mirror.sort$('detector').subscribe((s) => seen.push(s));
+
+    // Replayed initial state from the freshly-constructed columns service.
+    expect(seen.length).toBe(1);
+    expect(seen[0]).toEqual({ column: 'name', asc: true });
+
+    columns.detectorCols.sortBy('num_training');
+    expect(seen[seen.length - 1]).toEqual({ column: 'num_training', asc: true });
+
+    // Same-column click flips direction, and that reaches the mirror too.
+    columns.detectorCols.sortBy('num_training');
+    expect(seen[seen.length - 1]).toEqual({ column: 'num_training', asc: false });
+  });
+});

--- a/frontend/src/app/services/dashboard-sort.service.ts
+++ b/frontend/src/app/services/dashboard-sort.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+import type { SortState } from '../utils/sort-rows';
+
+/** Which of the Dashboard's two tables a sort state belongs to. */
+export type DashboardTable = 'dataset' | 'detector';
+
+const INITIAL_SORT: SortState = { column: 'name', asc: true };
+
+/**
+ * Read-side mirror of the Dashboard tables' sort state.
+ *
+ * `DashboardColumnsService` owns the actual `ManagedColumns` instances and
+ * publishes into this service; consumers that only want to *read* the sort
+ * (the top-bar context pulldowns, which order their rows to match the
+ * table the user last sorted) inject this instead.
+ *
+ * The indirection is a bundle boundary, not decoration: the pulldowns are
+ * eager (they live in the app header) while `ManagedColumns` and the
+ * Dashboard's column metadata are only needed once the lazy
+ * `dashboard-component` chunk loads.  Injecting the owning service from an
+ * eager component pulled ~6 kB of column-management code onto the initial
+ * bundle for a feature first paint never uses.
+ *
+ * Until the Dashboard is first constructed nothing has published, so the
+ * mirror reports the same name-ascending default the tables start at.
+ */
+@Injectable({ providedIn: 'root' })
+export class DashboardSortService {
+  private readonly subjects: Record<DashboardTable, BehaviorSubject<SortState>> = {
+    dataset: new BehaviorSubject<SortState>(INITIAL_SORT),
+    detector: new BehaviorSubject<SortState>(INITIAL_SORT),
+  };
+
+  /** Current sort of the named table, replayed on subscribe. */
+  sort$(table: DashboardTable): Observable<SortState> {
+    return this.subjects[table].asObservable();
+  }
+
+  /** Publish a new sort state for the named table. Called by
+   *  `DashboardColumnsService`; nothing else should write here. */
+  publish(table: DashboardTable, state: SortState): void {
+    this.subjects[table].next(state);
+  }
+}

--- a/frontend/src/app/utils/managed-columns.spec.ts
+++ b/frontend/src/app/utils/managed-columns.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { ColMeta, ManagedColumns, SortState } from './managed-columns';
+import { ColMeta, ManagedColumns } from './managed-columns';
+import { SortState } from './sort-rows';
 
 /**
  * Unit coverage for the ManagedColumns table controller. The class is pure

--- a/frontend/src/app/utils/managed-columns.ts
+++ b/frontend/src/app/utils/managed-columns.ts
@@ -1,5 +1,7 @@
 import { BehaviorSubject, Observable } from 'rxjs';
 
+import type { SortState } from './sort-rows';
+
 /**
  * Shared controller for tables whose columns can be sorted, resized, and
  * drag-reordered.  Holds all the mutable state plus the event handlers; a
@@ -12,14 +14,11 @@ import { BehaviorSubject, Observable } from 'rxjs';
  * same amount; clicking (no drag) auto-fits the left column to its content.
  *
  * Sort state is also exposed as the `sortState$` observable so non-host
- * components (e.g. the top-bar context pulldowns) can mirror the host
- * table's sort without being coupled to the host component.
+ * components can mirror the host table's sort without being coupled to the
+ * host component.  The eager top-bar context pulldowns read it through
+ * `DashboardSortService` rather than reaching in here, so that this class
+ * stays off the initial bundle; see `sort-rows.ts`.
  */
-export interface SortState<TCol extends string = string> {
-  column: TCol;
-  asc: boolean;
-}
-
 export interface ColMeta {
   label: string;
   title: string;
@@ -357,28 +356,4 @@ export class ManagedColumns<TCol extends string = string> {
   isDragging(col: TCol): boolean {
     return this.dragCol === col;
   }
-}
-
-/**
- * Sort *rows* by the value of the column named `column`.
- *
- * A table column id is not necessarily a field on the row objects: purely
- * presentational columns (`actions`, `select`) have no value, and rows typed
- * against a generated OpenAPI model expose only the fields the backend
- * declares.  So the lookup is deliberately widened to a `Record` here rather
- * than each caller's row type carrying a catch-all index signature — the
- * index signature is what used to hide backend/frontend schema drift.
- *
- * Numbers compare numerically; everything else compares as a locale string,
- * with a missing value sorting as `''`.
- */
-export function sortRowsByColumn<T>(rows: readonly T[], column: string, asc: boolean): T[] {
-  const dir = asc ? 1 : -1;
-  const valueAt = (row: T): unknown => (row as Record<string, unknown>)[column];
-  return [...rows].sort((a, b) => {
-    const va = valueAt(a) ?? '';
-    const vb = valueAt(b) ?? '';
-    if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * dir;
-    return String(va).localeCompare(String(vb)) * dir;
-  });
 }

--- a/frontend/src/app/utils/sort-rows.ts
+++ b/frontend/src/app/utils/sort-rows.ts
@@ -1,0 +1,40 @@
+/**
+ * The sort half of the managed-table story, split out from
+ * `managed-columns.ts` so it can be imported without dragging the
+ * `ManagedColumns` class (resize tracking, drag-reorder, localStorage
+ * persistence) along with it.
+ *
+ * The split exists for bundle reasons: the eager top-bar context pulldowns
+ * mirror the Dashboard's sort, but they never resize or reorder a column,
+ * so the class belongs on the lazy `dashboard-component` chunk while these
+ * two tiny declarations stay reachable from the initial bundle.
+ */
+
+export interface SortState<TCol extends string = string> {
+  column: TCol;
+  asc: boolean;
+}
+
+/**
+ * Sort *rows* by the value of the column named `column`.
+ *
+ * A table column id is not necessarily a field on the row objects: purely
+ * presentational columns (`actions`, `select`) have no value, and rows typed
+ * against a generated OpenAPI model expose only the fields the backend
+ * declares.  So the lookup is deliberately widened to a `Record` here rather
+ * than each caller's row type carrying a catch-all index signature — the
+ * index signature is what used to hide backend/frontend schema drift.
+ *
+ * Numbers compare numerically; everything else compares as a locale string,
+ * with a missing value sorting as `''`.
+ */
+export function sortRowsByColumn<T>(rows: readonly T[], column: string, asc: boolean): T[] {
+  const dir = asc ? 1 : -1;
+  const valueAt = (row: T): unknown => (row as Record<string, unknown>)[column];
+  return [...rows].sort((a, b) => {
+    const va = valueAt(a) ?? '';
+    const vb = valueAt(b) ?? '';
+    if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * dir;
+    return String(va).localeCompare(String(vb)) * dir;
+  });
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -296,16 +296,25 @@ if $_run_frontend_check && [ -d "frontend/node_modules" ]; then
     echo "Checking frontend TypeScript build..."
     _fe_log=$(mktemp)
     if (cd frontend && npm run build:prod 2>&1) > "$_fe_log"; then
-        # Treat Angular compiler warnings (e.g. NG8107) as errors
-        if grep -q '▲ \[WARNING\]' "$_fe_log"; then
+        # Treat Angular compiler warnings (e.g. NG8107) and budget warnings as
+        # errors. Angular colourises its output even when stdout is a file, and
+        # it interleaves the escapes *inside* the marker
+        # (`ESC[33m▲ ESC[43;33m[ESC[43;30mWARNING…`), so the literal
+        # `▲ [WARNING]` never matches the raw log — that blindness let an
+        # over-budget initial bundle sail past this gate for months. Match
+        # against an ANSI-stripped copy instead.
+        _fe_plain=$(mktemp)
+        sed -r 's/\x1b\[[0-9;]*m//g' "$_fe_log" > "$_fe_plain"
+        if grep -q '▲ \[WARNING\]' "$_fe_plain"; then
             echo ""
             echo "============================================================"
             echo "TESTS BLOCKED: Frontend build has warnings (treated as errors)"
             echo "============================================================"
-            grep -A 10 '▲ \[WARNING\]' "$_fe_log"
-            rm -f "$_fe_log"
+            grep -A 10 '▲ \[WARNING\]' "$_fe_plain"
+            rm -f "$_fe_log" "$_fe_plain"
             exit 1
         fi
+        rm -f "$_fe_plain"
         echo "Frontend build OK"
     else
         echo ""


### PR DESCRIPTION
Closes #3100

Both halves land together, since fixing the gate without fixing the bundle would turn `./run-tests.sh` red for everyone.

## 1. The gate could not match the warning it grepped for

`run-tests.sh` grepped the captured `build:prod` log for a literal `▲ [WARNING]`. Angular colourises its output even when stdout is redirected to a file, and it interleaves the escapes *inside* the marker:

```
ESC[33m▲ ESC[43;33m[ESC[43;30mWARNINGESC[43;33m]ESC[0m ESC[1mbundle initial exceeded…
```

so the literal never matched and the gate printed `Frontend build OK` over real warnings. Confirmed on the log from a `dev` build: `grep -c '▲ \[WARNING\]'` → `0`.

The fix strips ANSI into a scratch copy and both matches and prints context from that, reusing the `sed -r 's/\x1b\[[0-9;]*m//g'` idiom already used a few lines below for the Vitest summary line.

Verified end-to-end against a build that genuinely warns, not just a clean one: with the budget temporarily lowered to 500 kB, `./run-tests.sh frontend` now stops with

```
TESTS BLOCKED: Frontend build has warnings (treated as errors)
▲ [WARNING] bundle initial exceeded maximum budget. Budget 500.00 kB was not met by 15.63 kB with a total of 515.63 kB.
```

## 2. What it had been hiding: 522.11 kB against a 520 kB budget

Per the audit-first policy in `CLAUDE.md` and in `angular.json`'s budget comment, this fixes the bloat rather than raising the number.

The lever the issue identified holds up. The context pulldowns are eager (they live in the app header) and injected `DashboardColumnsService`, which reaches `ManagedColumns` — resize tracking, drag-reorder, localStorage persistence — plus the Dashboard's column-metadata tables. None of that is used at first paint: the pulldowns only mirror the table's **sort**, so they can order their rows to match whichever column the user last sorted.

Split that one read path out of the owning service:

- **`utils/sort-rows.ts`** (new) holds `SortState` and `sortRowsByColumn` — the two declarations the pulldowns actually need, with no dependency on the class. `managed-columns.ts` now imports `SortState` from there.
- **`DashboardSortService`** (new, root-scoped) is a small read-side mirror of the two tables' sort state. `DashboardColumnsService` — which stays Dashboard-side, on the lazy `dashboard-component` chunk — forwards both `sortState$` streams into it on construction; `ContextPulldownComponent` reads from it.

**Initial bundle: 522.11 kB → 515.63 kB**, back under the 520 kB budget with ~4.4 kB of headroom. The budget number is unchanged; its comment now records the new measurement and why the split is load-bearing, so a future re-entangling shows up as a budget failure rather than silently.

### Behaviour is unchanged

The only observable difference is *when* `DashboardColumnsService` is constructed — on first Dashboard load rather than at app start. That is invisible:

- The mirror's default is `{ column: 'name', asc: true }`, exactly the state `ManagedColumns` initialises to, so a deep link to `/label` or `/find` that never visits the Dashboard sees what it saw before.
- Sort state was never persisted (only column *order* is, and that still loads in the `ManagedColumns` constructor as before), so there is nothing to restore early.
- The mirror's subjects are `BehaviorSubject`s, so a pulldown subscribed before the Dashboard exists receives the real state the moment it is published.

## Tests

- New `dashboard-sort.service.spec.ts` covers the pre-Dashboard default, the two tables staying independent, and `sortBy` forwarding through the mirror including the same-column direction toggle.
- Full `./run-tests.sh`: **8296 passed, 6 skipped** — including the frontend build (no warnings), `npm audit`, and 2018 Vitest specs across 153 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sat2ky8KenmkiT2mcJJn35

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sat2ky8KenmkiT2mcJJn35)_