### PR TITLE
Digest f-strings the same way on every supported interpreter

### DIFF
--- a/docs/experiments/calibration-fold-count/REPORT.md
+++ b/docs/experiments/calibration-fold-count/REPORT.md
@@ -1,7 +1,7 @@
 # Is 2 still the right number of cross-calibration folds?
 
-**Issue #2897 · design pre-registered in `docs/plans/calibration-fold-count-experiment.md`,
-removed by this report · harness PR #2902 · run + fixes PR #2906 · follow-ups #3115, #3116**
+**Issue #2897 · design pre-registered in a plan file, deleted by the PR that added this
+report · harness PR #2902 · run + fixes PR #2906 · follow-ups #3115, #3116**
 
 The decision rules below (`MARGIN`, `COST_CEILING_X`, the deep regime, H1–H4)
 were fixed before the run and live as module constants in

--- a/scripts/check-eval-app-sync.py
+++ b/scripts/check-eval-app-sync.py
@@ -246,13 +246,71 @@ class MirrorError(Exception):
 # --------------------------------------------------------------------- digests
 
 
+def _source_slice(lines: list[str], start: tuple[int, int], end: tuple[int, int]) -> str:
+    """The literal source text between two `(row, col)` token positions."""
+    (srow, scol), (erow, ecol) = start, end
+    if srow == erow:
+        return lines[srow - 1][scol:ecol]
+    parts = [lines[srow - 1][scol:]]
+    parts.extend(lines[row - 1] for row in range(srow + 1, erow))
+    parts.append(lines[erow - 1][:ecol])
+    return "".join(parts)
+
+
+def _collapse_fstrings(tokens: list[tokenize.TokenInfo], lines: list[str]) -> list[tokenize.TokenInfo]:
+    """Re-join PEP 701's split f-string tokens into the one token <=3.11 emits.
+
+    Python 3.12 stopped tokenizing an f-string as a single STRING and started
+    emitting `FSTRING_START` / `FSTRING_MIDDLE` / `FSTRING_END` around the real
+    tokens of each replacement field.  That is a pure tokenizer change - the
+    code means the same thing - but it changes the token *text*, so a digest
+    taken on 3.12+ disagreed with one taken on 3.10/3.11 for any mirrored
+    function containing an f-string, and `--update` just moved the failure to
+    the other half of the supported range instead of converging (issue #3117).
+
+    Splicing the original source back out by token position restores the older
+    single-token form on every interpreter, so a pin travels between them.
+    """
+    start_type = getattr(tokenize, "FSTRING_START", None)
+    if start_type is None:  # <=3.11 already emits one STRING token.
+        return tokens
+    end_type = tokenize.FSTRING_END
+    out: list[tokenize.TokenInfo] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.type != start_type:
+            out.append(tok)
+            i += 1
+            continue
+        # Nested f-strings are legal on 3.12+, so match by depth, not first END.
+        depth = 0
+        j = i
+        while j < len(tokens):
+            if tokens[j].type == start_type:
+                depth += 1
+            elif tokens[j].type == end_type:
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        else:  # pragma: no cover - tokenize raises on an unterminated string first.
+            raise MirrorError("unterminated f-string while normalizing source")
+        end = tokens[j]
+        text = _source_slice(lines, tok.start, end.end)
+        out.append(tokenize.TokenInfo(tokenize.STRING, text, tok.start, end.end, tok.line))
+        i = j + 1
+    return out
+
+
 def _normalize_python(source: str) -> str:
     """Source text stripped of comments, docstrings and formatting.
 
     Token-based rather than AST-based on purpose: `ast.unparse` output is not
     guaranteed stable across the Python versions this repo supports (>=3.10),
     which would make the pins fail for whoever is not on the pinning machine's
-    interpreter.  Token text is.
+    interpreter.  Token text is *nearly* stable - see `_collapse_fstrings` for
+    the one place it isn't, and how that is normalized away.
 
     Magic trailing commas are dropped as well, so that `ruff format` wrapping a
     call across lines - which it will do for a change as innocent as a longer
@@ -261,7 +319,11 @@ def _normalize_python(source: str) -> str:
     skip = (tokenize.COMMENT, tokenize.NL, tokenize.ENCODING, tokenize.ENDMARKER)
     out: list[str] = []
     prev_meaningful: int | None = None
-    tokens = list(tokenize.generate_tokens(io.StringIO(textwrap.dedent(source) + "\n").readline))
+    text = textwrap.dedent(source) + "\n"
+    tokens = _collapse_fstrings(
+        list(tokenize.generate_tokens(io.StringIO(text).readline)),
+        text.splitlines(keepends=True),
+    )
     for i, tok in enumerate(tokens):
         if tok.type in skip:
             continue

--- a/tests_lib/detectors/test_eval_app_sync.py
+++ b/tests_lib/detectors/test_eval_app_sync.py
@@ -102,6 +102,59 @@ def f(a, b):
         assert gate._normalize_typescript(changed) != gate._normalize_typescript(base)
 
 
+class TestFstringsDigestTheSameOnEveryInterpreter:
+    """A pin must travel between the Python versions the repo supports (>=3.10).
+
+    Python 3.12 (PEP 701) stopped emitting an f-string as one STRING token and
+    started splitting it into FSTRING_START / FSTRING_MIDDLE / FSTRING_END plus
+    the real tokens of each replacement field.  The normalizer is token-based
+    precisely so it would be version-stable, so this went unnoticed: the three
+    mirrored `labeling_progress._compute_*_status` functions all contain an
+    f-string, so the gate was red on 3.12+ and green on 3.10/3.11 for the same
+    tree, and `--update` only moved the failure to the other half of the range
+    (issue #3117).  These assert the collapsed, <=3.11-shaped form, so they fail
+    on an unfixed 3.12+ and pass everywhere once it is normalized away.
+    """
+
+    def test_a_simple_fstring_stays_one_token(self):
+        assert 'f"a{b}c"' in gate._normalize_python('x = f"a{b}c"\n').splitlines()
+
+    def test_a_nested_fstring_stays_one_token(self):
+        """Legal on 3.12+, so the run has to be matched by depth, not first END."""
+        source = "x = f\"{f'{y}'}\"\n"
+        assert "f\"{f'{y}'}\"" in gate._normalize_python(source).splitlines()
+
+    def test_a_multiline_fstring_stays_one_token(self):
+        """Exercises the multi-row branch of the source slice."""
+        source = 'x = f"""\nhello {name}\n"""\n'
+        assert 'f"""\nhello {name}\n"""' in gate._normalize_python(source)
+
+    def test_an_fstring_is_still_part_of_the_digest(self):
+        """Collapsing must not amount to dropping it - rewording is a real change."""
+        base = 'def f(good, bad):\n    return f"Currently {good}g, {bad}b."\n'
+        changed = base.replace("{good}g, {bad}b.", "{good}g and {bad}b.")
+        assert gate._normalize_python(changed) != gate._normalize_python(base)
+
+    def test_an_fstring_expression_change_trips(self):
+        base = 'def f(good, bad):\n    return f"{good}g, {bad}b"\n'
+        changed = base.replace("{good}g", "{bad}g")
+        assert gate._normalize_python(changed) != gate._normalize_python(base)
+
+    def test_logic_beside_an_fstring_still_trips(self):
+        """The real shape of the mirrored functions: a threshold, then a message."""
+        base = 'def f(good, bad):\n    if good < 5 or bad < 5:\n        return f"need {good}"\n    return None\n'
+        changed = base.replace("good < 5 or bad < 5", "good < 7 or bad < 7")
+        assert gate._normalize_python(changed) != gate._normalize_python(base)
+
+    def test_reformatting_around_an_fstring_does_not_trip(self):
+        base = 'def f(good):\n    return dict(reason=f"need {good}", status="red")\n'
+        changed = base.replace(
+            'dict(reason=f"need {good}", status="red")',
+            'dict(\n        reason=f"need {good}",\n        status="red",\n    )',
+        )
+        assert gate._normalize_python(changed) == gate._normalize_python(base)
+
+
 class TestResolutionFailures:
     """A moved or renamed side is drift too, not a silent pass."""
 


### PR DESCRIPTION
`scripts/check-eval-app-sync.py` was never drifting. It was disagreeing with itself across Python versions.

Closes #3117

## The finding

On a clean `dev` (`716476f1`), the gate's result depends entirely on which interpreter runs it:

| Interpreter | Before | After |
|---|---|---|
| 3.10 | pass | pass |
| 3.11 | pass | pass |
| **3.12** | **FAIL** — `progress.{smart,stable,span}_status` | pass |
| **3.13** | **FAIL** — same three | pass |

`run-tests.sh:280` invokes a bare `python`, so whether the whole suite was red came down to what was on `PATH`. One correction to the issue's framing: it was not red "for everyone", which is also why it looked green to anyone who went to check.

## Root cause

PEP 701 (Python 3.12) stopped tokenizing an f-string as a single `STRING` and started splitting it into `FSTRING_START` / `FSTRING_MIDDLE` / `FSTRING_END` around the real tokens of each replacement field:

```
py3.11:  ('STRING', 'f"a{b}c"')
py3.12:  ('FSTRING_START','f"') ('FSTRING_MIDDLE','a') ('OP','{') ('NAME','b')
         ('OP','}') ('FSTRING_MIDDLE','c') ('FSTRING_END','"')
```

`_normalize_python` is token-based *specifically* to be version-stable — its docstring rejects `ast.unparse` on exactly those grounds and asserts "Token text is." So this hid in the one place the design assumed was safe.

The three failing mirrors are precisely the three mirrored app functions containing an f-string (`labeling_progress._compute_{smart,stable,span}_status`). Diffing the normalized text of `_compute_smart_status` across 3.11 and 3.12 yields exactly one hunk — the f-string, exploded into 11 lines. The other seven mirrors digest identically on both.

## Why not just re-pin

The remedy the gate suggests would have made things worse. Re-pinning under 3.12 flips 3.10/3.11 to failing:

```
after --update on 3.12:   py3.11 -> FAIL   py3.12 -> PASS
```

`--update` ping-pongs between interpreters instead of converging, so the fix has to be in the normalizer, not the pins.

## The change

`_collapse_fstrings` splices the original source back out by token position, restoring the single `≤3.11`-shaped token on every interpreter. Nested f-strings (legal on 3.12+) are matched by depth rather than first `END`; multi-line f-strings go through a multi-row source slice. On `≤3.11` the pass is a no-op.

**`scripts/eval-app-sync.pins.json` is unchanged and still valid** — 3.12/3.13 now agree with what `dev` already had pinned. No judgment call about drift was needed, because nothing had drifted.

## Verification

- Digests for all 10 mirrors are byte-identical across 3.10, 3.11, 3.12 and 3.13 (1 distinct digest set, not 2).
- The gate still fires: a `good < 5` → `good < 7` threshold change inside `_compute_smart_status` trips on all four interpreters. Rewording the f-string's message text also trips on all four, so collapsing is not quietly dropping it.
- New `TestFstringsDigestTheSameOnEveryInterpreter` covers the gap that let this through — the existing digest tests never exercised an f-string. Confirmed these fail against the pre-fix gate on 3.12 and pass on 3.11, so they are real regression coverage rather than vacuous.
- `./run-tests.sh`: **ALL 8406 TESTS PASSED** (6 skipped), every gate green.

## Unrelated fix, included because it blocked the suite

`check-docs` was also red on a clean `dev`, at step 5 — ahead of the eval gate — because #3118 deleted `docs/plans/calibration-fold-count-experiment.md` while `docs/experiments/calibration-fold-count/REPORT.md` still cited it. That is exactly the dangling `docs/plans/` pointer the docs gate exists to catch. Kept the provenance sentence, dropped the path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNTQAfoQswqjAE2SFJ44eM)_