### PR TITLE
Add a shared pre-embedded pile of (dataset, embedder) cells

### DIFF
--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -10,6 +10,7 @@ source scripts/experiments/pile/pile_env.sh   # point a study at it
 python build_pile.py --list                   # what exists
 python build_pile.py                          # build whatever is missing
 python build_pile.py --verify                 # check every cell is usable
+python build_pile.py --bands                  # voted-box scale bands (boxed datasets)
 ```
 
 ## Why this exists
@@ -22,9 +23,18 @@ Embedders got re-run because the cache had no home of its own.
 
 ## The grid
 
-Three datasets x five embedders. `siglip`/`siglip2` emit 768-d vectors,
-`siglip_l`/`siglip2_l` emit 1152-d, so galleries are **not** interchangeable
-across that split.
+Three datasets x three embedders: `siglip` (the shipped default, 768-d),
+`siglip2_l` (the premium end, 1152-d) and `dinov3_patch` (768-d, the only
+patch-capable one). Differing dims mean galleries are **not** interchangeable
+between `siglip` and `siglip2_l`.
+
+The middle columns (`siglip_l`, `siglip2`) were deliberately dropped: a study
+learns little from interpolating between the endpoints, and the compute is
+better spent on more runs of the ones that matter. The cost is that
+`siglip` -> `siglip2_l` moves *generation* (1 -> 2) and *capacity* (base ->
+SO400M) together, so a difference between them cannot be attributed to either
+alone. `build_pile.py --embedders siglip2` rebuilds a middle column if a result
+ever needs that split.
 
 | dataset | medias | boxed | note |
 |---|---:|:--:|---|
@@ -51,6 +61,39 @@ separated from the environment it was measured in.
 COCO is built from the staged images rather than the #2790 vector cache, which
 stores HAC region vectors but not the raw patch grid and so can never carry a
 region arm.
+
+## Voted-box scale bands (`--bands`)
+
+Orthogonal to the `_s`/`_m`/`_l` suffix, which is a **dataset size tier** (a
+`slice_frac` window over the source), *not* a box-size subset — `caltech101_m`
+is boxless and still carries an `_m`.
+
+Box size enters as a **category-selection** axis: `select_categories_by_scale`
+in `../calibration/experiment_config.py` bins categories by the median area of
+the box a Good vote drags (`category_scale_stats` in `vtscore/eval/labels.py`)
+and takes 6 per band, preferring low `union_inflation` (categories that are one
+clean object per image rather than scattered instances whose union box is far
+bigger than anything a user would drag).
+
+Band edges are anchored to the patch embedder's geometry, which is the point:
+
+| band | range | meaning |
+|---|---|---|
+| `sub_patch` | 0 – 0.51% | below **one DINOv3 patch** (1/196) — unresolvable |
+| `patch_to_leaf` | 0.51 – 8.33% | patch to smallest **HAC leaf** (1/12) |
+| `leaf_to_4x` | 8.33 – 33.3% | a few leaves |
+| `above_4x` | 33.3 – 101% | most of the image |
+
+**`sub_patch` is under-populated and cannot be fixed by tuning.** It holds 5
+candidate categories on VG and 1 on COCO, and that is unchanged at every
+`min_count` from 5 to 30 — the filter is not the binding constraint, so
+lowering it recovers nothing. Objects below one patch are simply rare, and
+COCO is worse by construction: its vocabulary is object-level (80 classes)
+while VG annotates *parts* (`eye`, `nose`, `cap`, `hat`), which is what fills
+the band. Widening the edge would inflate the count with objects the grid can
+actually resolve, destroying what the band means. Treat sub-patch conclusions
+as resting on ~5 VG categories, and prefer pooling both datasets over
+re-cutting the band.
 
 ## Rebuilding
 

--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -1,0 +1,79 @@
+# The shared pre-embedded pile
+
+A grid of `(dataset, embedder)` cells that every study reads instead of
+embedding its own copy. One cell = one `<dataset>__<embedder>.pkl` of media
+dicts carrying vectors (and `patch_grid` for patch embedders) but **no pixels**,
+so the pile stays small relative to its sources.
+
+```bash
+source scripts/experiments/pile/pile_env.sh   # point a study at it
+python build_pile.py --list                   # what exists
+python build_pile.py                          # build whatever is missing
+python build_pile.py --verify                 # check every cell is usable
+```
+
+## Why this exists
+
+Before it, each study embedded its own datadir and then later studies
+symlinked back to whichever one happened to have the pair they needed — the
+chain rooted at `max-patch/datadir`, an artifact named after a finished
+experiment, split across two study dirs on a chronically full 50G mount.
+Embedders got re-run because the cache had no home of its own.
+
+## The grid
+
+Three datasets x five embedders. `siglip`/`siglip2` emit 768-d vectors,
+`siglip_l`/`siglip2_l` emit 1152-d, so galleries are **not** interchangeable
+across that split.
+
+| dataset | medias | boxed | note |
+|---|---:|:--:|---|
+| `visual_genome_m` | 4193 | yes | demo dataset; ground-truth regions |
+| `caltech101_m` | 838 | no | demo dataset; whole-image labels only |
+| `coco_val` | 4952 | yes | assembled from the staged val2017 zip |
+
+## Region voting needs both halves
+
+A region-voting arm drags a ground-truth box and pools it over a patch grid. It
+therefore needs a **boxed dataset** *and* a **patch embedder**. Pair a boxed
+dataset with a single-vector embedder and it does not error — it silently runs
+as binary voting, because there is no `patch_grid` to pool and no
+`patch_regions` to max-pool.
+
+That mis-specification has cost three studies (#2877, #2897, #2905), so
+capability is stated per *cell* (`pile_config.region_capable`) rather than per
+dataset, and `--verify` asserts the geometry is physically present instead of
+trusting the arm table. Only `dinov3_patch` is patch-capable, so the pile's
+region-voting cells are `visual_genome_m x dinov3_patch` and
+`coco_val x dinov3_patch` — deliberately two, so a region result can be
+separated from the environment it was measured in.
+
+COCO is built from the staged images rather than the #2790 vector cache, which
+stores HAC region vectors but not the raw patch grid and so can never carry a
+region arm.
+
+## Rebuilding
+
+Scratch is treated as purgeable, so every cell must rebuild from sources that
+are not on scratch: demo datasets from the shared demo cache, COCO from the
+staged zip plus flattened annotations. `build_pile.py` is idempotent — it skips
+cells that exist, so it doubles as the resume path for a partial SLURM run.
+
+**A demo cell will not build if its source is missing from the datadir.** The
+downloaders read a missing extraction dir as "not downloaded yet" and refetch,
+which once substituted a partial re-download and produced a healthy-looking
+`visual_genome_m` cell holding 1662 of 4193 medias. `require_demo_source`
+blocks that, and `--verify` cross-checks that a dataset's cells agree on media
+count.
+
+## Building on the GRID
+
+```bash
+bash launch_pile.sh              # prefetch weights (CPU), then one GPU job per dataset
+bash launch_pile.sh coco_val     # just one dataset
+```
+
+Weights are prefetched in a separate CPU stage because parallel GPU jobs would
+otherwise race on the shared HF cache, and because the embedders load with
+`cache_dir=<VTSEARCH_MODELS_DIR>` — prefetching to the HF default instead leaves
+weights the jobs cannot see.

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -163,6 +163,7 @@ def build_cell(dataset: str, embedder: str, force: bool = False) -> dict:
     if kind == "coco":
         _load_coco(medias, embedder)
     else:
+        pc.require_demo_source(dataset)
         _load_demo(dataset, medias, embedder)
     log(f"  loaded {len(medias)} medias in {time.time() - t0:.0f}s")
 
@@ -200,6 +201,7 @@ def verify() -> int:
     io = _cells_io()
     problems: list[str] = []
     rows = []
+    counts_by_dataset: dict[str, dict[str, int]] = defaultdict(dict)
     for ds, emb in pc.cells():
         path = pc.cell_path(ds, emb)
         if not path.exists():
@@ -207,6 +209,7 @@ def verify() -> int:
             continue
         medias = io.load_medias(path)
         n = len(medias)
+        counts_by_dataset[ds][emb] = n
         n_patch = sum(1 for m in medias.values() if m.get("patch_grid") is not None)
         first = next(iter(medias.values()), None)
         dim = ""
@@ -230,6 +233,20 @@ def verify() -> int:
             state = "UNEXPECTED-PATCH"
             problems.append(f"{ds} x {emb}: single-vector embedder carries patch grids")
         rows.append((ds, emb, state, str(n), f"{n_patch}/{n}", dim))
+
+    # A dataset's cells must all cover the same medias, or cross-embedder
+    # comparisons silently compare different populations. This is not
+    # hypothetical: a datadir missing its demo-source symlink sent the loader
+    # off to re-download the dataset, and it embedded a truncated 1662-media
+    # subset of a 4193-media dataset into a cell that otherwise looked healthy.
+    for ds, per_emb in counts_by_dataset.items():
+        if len(set(per_emb.values())) > 1:
+            majority = max(set(per_emb.values()), key=list(per_emb.values()).count)
+            odd = {e: n for e, n in per_emb.items() if n != majority}
+            problems.append(
+                f"{ds}: cells disagree on media count (most are {majority}); "
+                f"rebuild {', '.join(f'{e} ({n})' for e, n in sorted(odd.items()))}"
+            )
 
     log(f"{'dataset':18s} {'embedder':14s} {'state':16s} {'medias':>7s} {'patch':>12s} {'dim':>6s}")
     for ds, emb, state, n, patch, dim in rows:

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -44,14 +44,26 @@ def log(msg: str) -> None:
     print(f"[pile] {msg}", flush=True)
 
 
-def _cells_io():
-    """Import the calibration harness's pickle IO (drops bytes, keeps patch_grid)."""
+def _calibration_path() -> None:
     calib = Path(__file__).resolve().parent.parent / "calibration"
     if str(calib) not in sys.path:
         sys.path.insert(0, str(calib))
+
+
+def _cells_io():
+    """Import the calibration harness's pickle IO (drops bytes, keeps patch_grid)."""
+    _calibration_path()
     import _cells_io  # noqa: PLC0415
 
     return _cells_io
+
+
+def _experiment_config():
+    """Import the calibration harness's category-selection config."""
+    _calibration_path()
+    import experiment_config  # noqa: PLC0415
+
+    return experiment_config
 
 
 # --------------------------------------------------------------------------
@@ -261,6 +273,75 @@ def verify() -> int:
     return 0
 
 
+def report_bands() -> int:
+    """Report voted-box scale-band populations for each boxed dataset.
+
+    The bands are anchored to the patch embedder's geometry: ``sub_patch`` is
+    "smaller than one DINOv3 patch", i.e. below what the patch grid can resolve
+    at all. That anchoring is the band's whole meaning, so a thin ``sub_patch``
+    is a fact about the data, not a threshold to tune — widening the edge would
+    inflate the count with objects that *are* resolvable.
+
+    Reads the smallest available cell for each dataset: scale stats need only
+    ``regions``, which every cell carries, so there is no reason to page in the
+    multi-GB patch cell.
+    """
+    io = _cells_io()
+    cfg = _experiment_config()
+    from vtscore.eval.labels import category_scale_stats  # noqa: PLC0415
+
+    boxed = [ds for ds, info in pc.DATASETS.items() if info.get("boxed")]
+    if not boxed:
+        log("no boxed datasets in the pile; nothing to stratify")
+        return 0
+
+    for ds in boxed:
+        present = [(pc.cell_path(ds, e).stat().st_size, e) for e in pc.EMBEDDERS if pc.cell_path(ds, e).exists()]
+        if not present:
+            log(f"{ds}: no cells present")
+            continue
+        _, emb = min(present)
+        medias = io.load_medias(pc.cell_path(ds, emb))
+
+        counts: dict[str, int] = defaultdict(int)
+        for m in medias.values():
+            for c in m.get("categories") or [m.get("category")]:
+                if c:
+                    counts[c] += 1
+
+        selected, report = cfg.select_categories_by_scale(medias, dict(counts))
+        log("")
+        log(f"=== {ds}: {len(medias)} medias, {len(counts)} categories (via {emb}) ===")
+        dropped = report.get("dropped_above_max_voted_area") or []
+        log(f"  dropped above max_voted_area={report.get('max_voted_area')}: {len(dropped)}")
+        for name, info in (report.get("bands") or {}).items():
+            lo, hi = info["range"]
+            flag = "  ** UNDER-POPULATED **" if info["under_populated"] else ""
+            log(
+                f"  {name:14s} [{lo * 100:5.2f}%, {hi * 100:6.2f}%): "
+                f"{len(info['selected'])}/{info['target']} of {info['n_candidates']} candidates{flag}"
+            )
+            log(f"      {info['selected']}")
+
+        # When a band is starved, say whether the min-count filter is even the
+        # binding constraint. Measured on the first run it was not: the
+        # sub_patch pool held 5 categories (VG) and 1 (COCO) at every
+        # min_count from 5 to 30, so lowering it recovers nothing.
+        starved = [n for n, i in (report.get("bands") or {}).items() if i["under_populated"]]
+        if starved:
+            stats = {c: s for c in counts if (s := category_scale_stats(medias, c)) is not None}
+            for name in starved:
+                lo, hi = report["bands"][name]["range"]
+                pools = {
+                    mc: sum(1 for c, s in stats.items() if counts[c] >= mc and lo <= s["voted_area"] < hi)
+                    for mc in (5, 10, 20, 30)
+                }
+                spread = "same at every min_count" if len(set(pools.values())) == 1 else str(pools)
+                log(f"  {name}: candidate pool by min category count -> {spread}")
+        log(f"  -> selected {len(selected)} categories")
+    return 0
+
+
 def write_manifest() -> None:
     """Write MANIFEST.json + MANIFEST.md describing the pile and how to rebuild it."""
     io = _cells_io()
@@ -366,6 +447,7 @@ def main() -> int:
     ap.add_argument("--force", action="store_true", help="rebuild cells that already exist")
     ap.add_argument("--list", action="store_true", help="show cell status and exit")
     ap.add_argument("--verify", action="store_true", help="load every cell and check geometry")
+    ap.add_argument("--bands", action="store_true", help="report voted-box scale bands for boxed datasets")
     ap.add_argument("--manifest", action="store_true", help="(re)write the manifest and exit")
     args = ap.parse_args()
 
@@ -376,6 +458,8 @@ def main() -> int:
         return 0
     if args.verify:
         return verify()
+    if args.bands:
+        return report_bands()
     if args.manifest:
         write_manifest()
         return 0

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -44,6 +44,27 @@ def log(msg: str) -> None:
     print(f"[pile] {msg}", flush=True)
 
 
+def assert_vtscore_is_this_checkout() -> None:
+    """Refuse to run against a different checkout's ``vtscore``.
+
+    The venv's editable install points at the main checkout. If anything
+    resolves ``vtscore`` there instead of here, cells get embedded by whatever
+    code that tree happens to be on — silently, and possibly by a different
+    embedder implementation. Cheap to assert, expensive to discover later.
+    """
+    import vtscore  # noqa: PLC0415
+
+    want = Path(__file__).resolve().parents[3]
+    got = Path(vtscore.__file__).resolve().parent.parent
+    if got != want:
+        raise SystemExit(
+            f"vtscore resolved to {got}, not this checkout ({want}).\n"
+            f"  Something put another checkout ahead on sys.path — usually the venv's\n"
+            f"  editable install. Re-run with VTS_REPO={want} set for THIS command\n"
+            f"  (note `VAR=x cmd1 && cmd2` sets VAR for cmd1 only)."
+        )
+
+
 def _calibration_path() -> None:
     calib = Path(__file__).resolve().parent.parent / "calibration"
     if str(calib) not in sys.path:
@@ -452,6 +473,7 @@ def main() -> int:
     args = ap.parse_args()
 
     pc.EMBEDDINGS.mkdir(parents=True, exist_ok=True)
+    assert_vtscore_is_this_checkout()
 
     if args.list:
         list_cells()

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -1,0 +1,385 @@
+"""Build (and verify) the shared pre-embedded pile of ``(dataset, embedder)`` cells.
+
+One cell = one ``<dataset>__<embedder>.pkl`` of media dicts carrying vectors
+(and ``patch_grid`` for patch embedders) but no pixels. Studies point
+``VTSEARCH_DATA_DIR`` at the pile and load cells in place, so an embedder runs
+once per pair ever rather than once per study.
+
+Idempotent: a cell that already exists is skipped unless ``--force``. That makes
+this safe to re-run after a partial SLURM job, and makes it the rebuild path if
+scratch is ever purged.
+
+Usage::
+
+    python build_pile.py --list                      # what exists / what's missing
+    python build_pile.py                             # build every missing cell
+    python build_pile.py --datasets coco_val         # just COCO's cells
+    python build_pile.py --embedders siglip2,siglip2_l
+    python build_pile.py --verify                    # load every cell, check geometry
+    python build_pile.py --manifest                  # (re)write MANIFEST.{json,md}
+
+``--verify`` is the guard the region-voting studies needed: it asserts that
+every cell whose ``(dataset, embedder)`` pair claims region capability actually
+carries ``patch_grid`` on its medias, and that no cell silently holds zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+import time
+import zipfile
+from collections import defaultdict
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+
+def log(msg: str) -> None:
+    print(f"[pile] {msg}", flush=True)
+
+
+def _cells_io():
+    """Import the calibration harness's pickle IO (drops bytes, keeps patch_grid)."""
+    calib = Path(__file__).resolve().parent.parent / "calibration"
+    if str(calib) not in sys.path:
+        sys.path.insert(0, str(calib))
+    import _cells_io  # noqa: PLC0415
+
+    return _cells_io
+
+
+# --------------------------------------------------------------------------
+# COCO: not a demo dataset, so assemble medias from the staged zip + annotations
+# --------------------------------------------------------------------------
+
+
+def _coco_annotations() -> tuple[dict[int, list[dict]], dict[int, str]]:
+    """``({image_id: [{box, label}, ...]}, {image_id: file_name})``.
+
+    Mirrors ``calibration/build_coco_pickle.py``: boxes already normalised to
+    [0, 1], ``iscrowd`` regions kept (they are still true instances of the
+    category, and positives are defined by category presence).
+    """
+    regions: dict[int, list[dict]] = defaultdict(list)
+    filenames: dict[int, str] = {}
+    with gzip.open(pc.COCO_ANNOTATIONS, "rt") as fh:
+        for line in fh:
+            row = json.loads(line)
+            image_id = int(row["image_id"])
+            filenames[image_id] = row["file_name"]
+            regions[image_id].append(
+                {
+                    "box": [float(row["x0"]), float(row["y0"]), float(row["x1"]), float(row["y1"])],
+                    "label": row["name"],
+                }
+            )
+    return dict(regions), filenames
+
+
+def _load_coco(medias: dict[int, dict], embedder_name: str) -> None:
+    """Populate *medias* with COCO-val images (bytes read straight from the zip).
+
+    Only images the annotation file covers are kept: an image with no category
+    can be neither a positive nor a meaningful negative.
+    """
+    if not pc.COCO_ANNOTATIONS.exists():
+        raise SystemExit(f"missing COCO annotations: {pc.COCO_ANNOTATIONS}")
+    zip_path = pc.COCO_ROOT / "images" / "val2017.zip"
+    if not zip_path.exists():
+        raise SystemExit(f"missing COCO images zip: {zip_path}")
+
+    regions_by_image, filenames = _coco_annotations()
+    log(f"  coco: {len(regions_by_image)} annotated images")
+
+    with zipfile.ZipFile(zip_path) as zf:
+        members = {Path(n).name: n for n in zf.namelist() if n.endswith(".jpg")}
+        missing = 0
+        for image_id in sorted(regions_by_image):
+            regions = regions_by_image[image_id]
+            fname = Path(filenames[image_id]).name
+            member = members.get(fname)
+            if member is None:
+                missing += 1
+                continue
+            counts: dict[str, int] = defaultdict(int)
+            for r in regions:
+                counts[r["label"]] += 1
+            # Most-annotated first, so ``category`` is the dominant object.
+            ordered = [c for c, _ in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))]
+            medias[image_id] = {
+                "id": image_id,
+                "media_type": "image",
+                "embedder": embedder_name,
+                "duration": 0,
+                "file_size": 0,
+                "md5": "",
+                "embeddings": {},
+                "media_bytes": zf.read(member),
+                "media_string": None,
+                "filename": fname,
+                "category": ordered[0],
+                "categories": ordered,
+                "regions": regions,
+                "origin": {"importer": "staged_coco_val", "params": {"embedder": embedder_name}},
+                "origin_name": filenames[image_id],
+            }
+    if missing:
+        log(f"  coco: WARNING {missing} annotated images absent from the zip")
+
+
+def _load_demo(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
+    from vtscore.datasets.loader_demo import load_demo_dataset  # noqa: PLC0415
+
+    load_demo_dataset(dataset, medias, embedder_name=embedder_name)
+
+
+# --------------------------------------------------------------------------
+# Build
+# --------------------------------------------------------------------------
+
+
+def build_cell(dataset: str, embedder: str, force: bool = False) -> dict:
+    """Build one cell, returning a summary record."""
+    out = pc.cell_path(dataset, embedder)
+    if out.exists() and not force:
+        log(f"skip {dataset} x {embedder} (exists: {out.name})")
+        return {"dataset": dataset, "embedder": embedder, "status": "exists"}
+
+    if pc.EMBEDDERS.get(embedder, {}).get("gated") and not os.environ.get("HF_TOKEN"):
+        log(f"SKIP {dataset} x {embedder}: HF_TOKEN unset (weights are licence-gated)")
+        return {"dataset": dataset, "embedder": embedder, "status": "skipped_gated"}
+
+    kind = pc.DATASETS[dataset]["kind"]
+    log(f"=== build {dataset} x {embedder} ({kind}) ===")
+    t0 = time.time()
+
+    medias: dict[int, dict] = {}
+    if kind == "coco":
+        _load_coco(medias, embedder)
+    else:
+        _load_demo(dataset, medias, embedder)
+    log(f"  loaded {len(medias)} medias in {time.time() - t0:.0f}s")
+
+    from vtscore.datasets.stages.embedding import embed_missing  # noqa: PLC0415
+
+    t1 = time.time()
+    embed_missing(medias, embedder)
+    embed_s = time.time() - t1
+
+    n_patch = sum(1 for m in medias.values() if m.get("patch_grid") is not None)
+    nbytes = _cells_io().dump_medias(medias, out)
+    total_s = time.time() - t0
+    log(
+        f"  wrote {out.name}: {nbytes / 1e6:.0f} MB, {len(medias)} medias, "
+        f"patch grids {n_patch}/{len(medias)}, embed {embed_s:.0f}s, total {total_s:.0f}s"
+    )
+    return {
+        "dataset": dataset,
+        "embedder": embedder,
+        "status": "built",
+        "n_medias": len(medias),
+        "n_patch_grids": n_patch,
+        "megabytes": round(nbytes / 1e6, 1),
+        "embed_seconds": round(embed_s, 1),
+    }
+
+
+# --------------------------------------------------------------------------
+# Verify + manifest
+# --------------------------------------------------------------------------
+
+
+def verify() -> int:
+    """Load every present cell and check it is usable. Returns an exit code."""
+    io = _cells_io()
+    problems: list[str] = []
+    rows = []
+    for ds, emb in pc.cells():
+        path = pc.cell_path(ds, emb)
+        if not path.exists():
+            rows.append((ds, emb, "MISSING", "", "", ""))
+            continue
+        medias = io.load_medias(path)
+        n = len(medias)
+        n_patch = sum(1 for m in medias.values() if m.get("patch_grid") is not None)
+        first = next(iter(medias.values()), None)
+        dim = ""
+        if first is not None:
+            from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
+            vec = media_embedding(first)
+            dim = str(len(vec)) if vec is not None else "NO-VECTOR"
+        want_region = pc.region_capable(ds, emb)
+        state = "ok"
+        if n == 0:
+            state = "EMPTY"
+            problems.append(f"{ds} x {emb}: 0 medias")
+        elif dim in ("", "NO-VECTOR"):
+            state = "NO-VECTOR"
+            problems.append(f"{ds} x {emb}: medias carry no embedding")
+        elif want_region and n_patch < n:
+            state = "PATCH-GAP"
+            problems.append(f"{ds} x {emb}: region-capable but patch_grid on only {n_patch}/{n}")
+        elif not pc.is_patch_embedder(emb) and n_patch:
+            state = "UNEXPECTED-PATCH"
+            problems.append(f"{ds} x {emb}: single-vector embedder carries patch grids")
+        rows.append((ds, emb, state, str(n), f"{n_patch}/{n}", dim))
+
+    log(f"{'dataset':18s} {'embedder':14s} {'state':16s} {'medias':>7s} {'patch':>12s} {'dim':>6s}")
+    for ds, emb, state, n, patch, dim in rows:
+        log(f"{ds:18s} {emb:14s} {state:16s} {n:>7s} {patch:>12s} {dim:>6s}")
+
+    if problems:
+        log("")
+        for p in problems:
+            log(f"PROBLEM: {p}")
+        return 1
+    log("all present cells verified")
+    return 0
+
+
+def write_manifest() -> None:
+    """Write MANIFEST.json + MANIFEST.md describing the pile and how to rebuild it."""
+    io = _cells_io()
+    entries = []
+    for ds, emb in pc.cells():
+        path = pc.cell_path(ds, emb)
+        if not path.exists():
+            entries.append({"dataset": ds, "embedder": emb, "present": False})
+            continue
+        medias = io.load_medias(path)
+        n = len(medias)
+        entries.append(
+            {
+                "dataset": ds,
+                "embedder": emb,
+                "present": True,
+                "file": path.name,
+                "megabytes": round(path.stat().st_size / 1e6, 1),
+                "n_medias": n,
+                "n_patch_grids": sum(1 for m in medias.values() if m.get("patch_grid") is not None),
+                "region_capable": pc.region_capable(ds, emb),
+            }
+        )
+
+    doc = {
+        "pile": str(pc.PILE),
+        "sources": {
+            "demo_cache": str(pc.DEMO_CACHE),
+            "coco_root": str(pc.COCO_ROOT),
+        },
+        "datasets": pc.DATASETS,
+        "embedders": pc.EMBEDDERS,
+        "cells": entries,
+    }
+    (pc.PILE / "MANIFEST.json").write_text(json.dumps(doc, indent=2) + "\n")
+
+    present = [e for e in entries if e["present"]]
+    total_mb = sum(e["megabytes"] for e in present)
+    lines = [
+        "# Pre-embedded pile",
+        "",
+        f"`{pc.PILE}` — {len(present)}/{len(entries)} cells, {total_mb / 1000:.1f} GB of embeddings.",
+        "",
+        "Point a study at it with:",
+        "",
+        "```bash",
+        f'export VTSEARCH_DATA_DIR="{pc.DATADIR}"',
+        f'export VTSEARCH_MODELS_DIR="{pc.MODELS}"',
+        "```",
+        "",
+        "## Cells",
+        "",
+        "| dataset | embedder | medias | patch grids | region-voting | size |",
+        "|---|---|---:|---:|:--:|---:|",
+    ]
+    for e in entries:
+        if not e["present"]:
+            lines.append(f"| `{e['dataset']}` | `{e['embedder']}` | — | — | — | *missing* |")
+            continue
+        region = "**yes**" if e["region_capable"] else "no"
+        lines.append(
+            f"| `{e['dataset']}` | `{e['embedder']}` | {e['n_medias']} | "
+            f"{e['n_patch_grids']} | {region} | {e['megabytes']:.0f} MB |"
+        )
+    lines += [
+        "",
+        "**Region voting needs both halves**: ground-truth boxes (dataset) *and* a patch",
+        "grid (embedder). A boxed dataset on a single-vector embedder silently runs as",
+        "binary voting — the failure behind #2877, #2897 and #2905. `build_pile.py --verify`",
+        "asserts the geometry rather than trusting the arm table.",
+        "",
+        "## Rebuilding",
+        "",
+        "Scratch is treated as purgeable. Every cell rebuilds from staged, non-scratch",
+        "sources, so the pile is disposable:",
+        "",
+        "```bash",
+        "python build_pile.py            # rebuild whatever is missing (idempotent)",
+        "python build_pile.py --verify   # check geometry after a rebuild",
+        "```",
+        "",
+        f"Sources: demo datasets from `{pc.DEMO_CACHE}`, COCO from `{pc.COCO_ROOT}`.",
+        "",
+    ]
+    (pc.PILE / "MANIFEST.md").write_text("\n".join(lines))
+    log(f"wrote MANIFEST.json + MANIFEST.md ({len(present)}/{len(entries)} cells)")
+
+
+def list_cells() -> None:
+    log(f"pile: {pc.PILE}")
+    for ds, emb in pc.cells():
+        path = pc.cell_path(ds, emb)
+        mark = "present" if path.exists() else "MISSING"
+        size = f"{path.stat().st_size / 1e6:8.0f} MB" if path.exists() else " " * 11
+        region = " region-voting" if pc.region_capable(ds, emb) else ""
+        log(f"  {ds:18s} x {emb:14s} {mark:8s} {size}{region}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--datasets", help="comma-separated subset (default: all)")
+    ap.add_argument("--embedders", help="comma-separated subset (default: all)")
+    ap.add_argument("--force", action="store_true", help="rebuild cells that already exist")
+    ap.add_argument("--list", action="store_true", help="show cell status and exit")
+    ap.add_argument("--verify", action="store_true", help="load every cell and check geometry")
+    ap.add_argument("--manifest", action="store_true", help="(re)write the manifest and exit")
+    args = ap.parse_args()
+
+    pc.EMBEDDINGS.mkdir(parents=True, exist_ok=True)
+
+    if args.list:
+        list_cells()
+        return 0
+    if args.verify:
+        return verify()
+    if args.manifest:
+        write_manifest()
+        return 0
+
+    datasets = args.datasets.split(",") if args.datasets else list(pc.DATASETS)
+    embedders = args.embedders.split(",") if args.embedders else list(pc.EMBEDDERS)
+    for bad in [d for d in datasets if d not in pc.DATASETS]:
+        raise SystemExit(f"unknown dataset {bad!r}; known: {sorted(pc.DATASETS)}")
+    for bad in [e for e in embedders if e not in pc.EMBEDDERS]:
+        raise SystemExit(f"unknown embedder {bad!r}; known: {sorted(pc.EMBEDDERS)}")
+
+    summaries = []
+    for ds in datasets:
+        for emb in embedders:
+            summaries.append(build_cell(ds, emb, force=args.force))
+
+    built = [s for s in summaries if s["status"] == "built"]
+    log(f"done: {len(built)} built, {len(summaries) - len(built)} skipped")
+    write_manifest()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/launch_pile.sh
+++ b/scripts/experiments/pile/launch_pile.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Build the missing pile cells on the GRID: prefetch weights (CPU), then one
+# GPU job per dataset so the three run concurrently within the 4-GPU tier.
+#
+#   bash launch_pile.sh              # prefetch + submit all three dataset jobs
+#   bash launch_pile.sh coco_val     # just one dataset's job
+#
+# Weights are prefetched in a separate CPU step because parallel GPU jobs would
+# otherwise race to populate the same shared HF cache (see prefetch_models.py).
+set -euo pipefail
+
+USER="${USER:-sgreenberg}"
+REPO="${VTS_REPO:-/exp/$USER/projects/vts-pile}"
+PILE="${VTS_PILE:-/expscratch/$USER/vts-cache}"
+HERE="$REPO/scripts/experiments/pile"
+LOGS="${PILE}/logs"
+GPU_TYPE="${VTS_GPU:-v100}"
+# These sweeps peak well under 16G; a fatter request wedges the job off idle
+# GPUs whose RAM is already reserved (GRID-PLAYBOOK section 1).
+MEM="${VTS_MEM:-24G}"
+TIME="${VTS_TIME:-8:00:00}"
+
+mkdir -p "$LOGS"
+
+ENVSET="module load python/3.12.3 && source /exp/$USER/projects/VTSearch/.venv/bin/activate"
+ENVSET="$ENVSET && export VTS_REPO=$REPO VTS_PILE=$PILE"
+# Keep HF off /exp: one model download there fills the 50G quota.
+ENVSET="$ENVSET && export HF_HOME=$PILE/models VTSEARCH_MODELS_DIR=$PILE/models"
+ENVSET="$ENVSET && export VTSEARCH_DATA_DIR=$PILE/datadir && cd $HERE"
+
+# --- Stage 1: weights (CPU, blocking) -------------------------------------
+echo "=== prefetching weights (CPU) ==="
+srun --job-name=pile-prefetch --partition=cpu --cpus-per-task=4 --mem=8G --time=2:00:00 \
+  bash -lc "$ENVSET && python prefetch_models.py" 2>&1 | tail -20
+
+# --- Stage 2: one GPU job per dataset -------------------------------------
+DATASETS=("${@:-visual_genome_m caltech101_m coco_val}")
+read -r -a DATASETS <<< "${DATASETS[@]}"
+
+for ds in "${DATASETS[@]}"; do
+  jid=$(sbatch --parsable \
+    --job-name="pile-$ds" \
+    --partition=gpu \
+    --gres="gpu:${GPU_TYPE}:1" \
+    --cpus-per-task=8 \
+    --mem="$MEM" \
+    --time="$TIME" \
+    --output="$LOGS/pile-$ds-%j.out" \
+    --wrap "bash -lc '$ENVSET && python build_pile.py --datasets $ds'")
+  # An empty job id means sbatch silently refused the request -- treat it as a
+  # failure rather than reporting a launch that never happened (LESSONS.md).
+  if [[ -z "$jid" ]]; then
+    echo "FAILED to submit $ds (empty job id)" >&2
+    exit 1
+  fi
+  echo "submitted $ds -> job $jid  (log: $LOGS/pile-$ds-$jid.out)"
+done
+
+echo
+echo "watch:   squeue -u $USER"
+echo "verify:  cd $HERE && python build_pile.py --verify"

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -1,0 +1,116 @@
+"""The shared pre-embedded pile: which ``(dataset, embedder)`` cells exist and where.
+
+A *cell* is one ``<dataset>__<embedder>.pkl`` under the pile's
+``embeddings/`` dir — the per-pair artifact every study loads instead of
+re-embedding. Studies point ``VTSEARCH_DATA_DIR`` at the pile and read the
+cells in place; nothing here is study-specific.
+
+**Reproducibility.** The pile lives on scratch, which is treated as purgeable,
+so every cell must be rebuildable from sources that are *not* on scratch:
+
+* ``visual_genome_m`` / ``caltech101_m`` are VTSearch demo datasets, downloaded
+  into the shared demo cache (``DEMO_CACHE``) and loaded by ``load_demo_dataset``.
+* ``coco_val`` is not a demo dataset; it is assembled from the COCO-2017-val
+  images and the flattened annotations staged under ``COCO_ROOT``.
+
+Because ``_cells_io.dump_medias`` drops ``media_bytes``, a cell holds vectors
+(plus ``patch_grid`` for patch embedders) and no pixels — so the pile is small
+relative to its sources and a rebuild always re-reads the staged originals.
+
+**Region voting.** Only patch embedders emit ``patch_grid``; a boxed dataset
+paired with a single-vector embedder silently degrades to binary voting. That
+mis-specification has burned three studies (#2877, #2897, #2905), so
+:func:`region_capable` states it per *cell* rather than per dataset, and
+``build_pile.py --verify`` asserts the geometry is actually present.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+USER = os.environ.get("USER", "sgreenberg")
+
+#: Root of the shared pile. Everything below is derived from it.
+PILE = Path(os.environ.get("VTS_PILE", f"/expscratch/{USER}/vts-cache"))
+DATADIR = PILE / "datadir"
+EMBEDDINGS = DATADIR / "embeddings"
+MODELS = PILE / "models"
+
+#: Shared, non-scratch sources the pile is rebuilt from.
+DEMO_CACHE = Path(os.environ.get("VTS_DEMO_CACHE", "/exp/scale26/datasets/external/vtsearch-demos"))
+COCO_ROOT = Path(os.environ.get("VTS_COCO_ROOT", "/exp/scale26/datasets/external/COCO"))
+COCO_IMAGES = COCO_ROOT / "images" / "val2017"
+COCO_ANNOTATIONS = COCO_ROOT / "derived" / "objects_flat_val2017.jsonl.gz"
+
+#: Datasets in the pile. ``boxed`` means the medias carry ground-truth region
+#: boxes, which is what a region-voting arm drags — necessary but not
+#: sufficient (the embedder must also be patch-capable; see region_capable).
+DATASETS: dict[str, dict] = {
+    "visual_genome_m": {"boxed": True, "kind": "demo"},
+    "caltech101_m": {"boxed": False, "kind": "demo"},
+    "coco_val": {"boxed": True, "kind": "coco"},
+}
+
+#: Embedders in the pile. ``patch`` embedders attach ``patch_grid`` and are the
+#: only ones that can carry a region-voting arm.
+EMBEDDERS: dict[str, dict] = {
+    "siglip": {"patch": False},
+    "siglip2": {"patch": False},
+    "siglip_l": {"patch": False},
+    "siglip2_l": {"patch": False},
+    "dinov3_patch": {"patch": True, "gated": True},
+}
+
+
+def cells() -> list[tuple[str, str]]:
+    """Every ``(dataset, embedder)`` cell in the full grid."""
+    return [(ds, emb) for ds in DATASETS for emb in EMBEDDERS]
+
+
+def pickle_name(dataset: str, embedder: str) -> str:
+    return f"{dataset}__{embedder}.pkl"
+
+
+def cell_path(dataset: str, embedder: str) -> Path:
+    return EMBEDDINGS / pickle_name(dataset, embedder)
+
+
+def is_patch_embedder(embedder: str) -> bool:
+    return bool(EMBEDDERS.get(embedder, {}).get("patch"))
+
+
+def region_capable(dataset: str, embedder: str) -> bool:
+    """True when this *cell* can actually region-vote.
+
+    Both halves are required: ground-truth boxes to drag (dataset) and a patch
+    grid to pool them over (embedder). Stated per cell precisely because the
+    per-dataset flag alone reads as "this arm region-votes" and does not.
+    """
+    return bool(DATASETS.get(dataset, {}).get("boxed")) and is_patch_embedder(embedder)
+
+
+def setup_env() -> None:
+    """Point vtscore + HF at the pile. Call before importing anything vtscore."""
+    import sys
+
+    os.environ.setdefault("VTSEARCH_DATA_DIR", str(DATADIR))
+    os.environ.setdefault("VTSEARCH_MODELS_DIR", str(MODELS))
+    os.environ.setdefault("HF_HOME", str(MODELS))
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    for var in ("VTSEARCH_DATA_DIR", "VTSEARCH_MODELS_DIR", "HF_HOME"):
+        Path(os.environ[var]).mkdir(parents=True, exist_ok=True)
+
+    repo = os.environ.get("VTS_REPO")
+    if repo and repo not in sys.path:
+        sys.path.insert(0, repo)
+    # Drop the venv's editable-install finder so ``import vtscore`` resolves to
+    # this checkout rather than whichever clone the editable install points at.
+    keep = []
+    for finder in sys.meta_path:
+        mod = type(finder).__module__ or ""
+        name = f"{mod}.{type(finder).__name__}".lower()
+        if "editable" in name and ("vtsearch" in name or "vtscore" in name):
+            continue
+        keep.append(finder)
+    sys.meta_path[:] = keep

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -57,10 +57,17 @@ DATASETS: dict[str, dict] = {
 
 #: Embedders in the pile. ``patch`` embedders attach ``patch_grid`` and are the
 #: only ones that can carry a region-voting arm.
+#: Deliberately three, not five. ``siglip`` is the shipped default and
+#: ``siglip2_l`` the premium end; the middles (``siglip_l``, ``siglip2``) were
+#: dropped because a study learns little from interpolating between them, and
+#: the compute is better spent on more runs of the endpoints.
+#:
+#: The cost of that: ``siglip`` -> ``siglip2_l`` moves generation (1 -> 2) and
+#: capacity (base -> SO400M) at the same time, so a difference between them
+#: cannot be attributed to either alone. Rebuild a middle column if a result
+#: ever needs that split -- ``build_pile.py --embedders siglip2`` restores one.
 EMBEDDERS: dict[str, dict] = {
     "siglip": {"patch": False},
-    "siglip2": {"patch": False},
-    "siglip_l": {"patch": False},
     "siglip2_l": {"patch": False},
     "dinov3_patch": {"patch": True, "gated": True},
 }

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -134,9 +134,18 @@ def setup_env() -> None:
     for var in ("VTSEARCH_DATA_DIR", "VTSEARCH_MODELS_DIR", "HF_HOME"):
         Path(os.environ[var]).mkdir(parents=True, exist_ok=True)
 
-    repo = os.environ.get("VTS_REPO")
-    if repo and repo not in sys.path:
+    # Default to the checkout this file lives in, rather than requiring VTS_REPO.
+    # Depending on the env var is a live hazard: with it unset, ``import vtscore``
+    # falls through to the venv's editable install, which points at the *main*
+    # checkout -- 592 commits stale at the time of writing, and missing embedders
+    # this pile uses. A build that resolved there would embed against different
+    # code with no error. (This is how the shadow-module trap actually bites:
+    # `VAR=x cmd1 && cmd2` applies VAR to cmd1 only, so the second command
+    # silently ran against the wrong tree.)
+    repo = os.environ.get("VTS_REPO") or str(Path(__file__).resolve().parents[3])
+    if repo not in sys.path:
         sys.path.insert(0, repo)
+    os.environ["VTS_REPO"] = repo  # so calibration's common.py agrees with us
     # Drop the venv's editable-install finder so ``import vtscore`` resolves to
     # this checkout rather than whichever clone the editable install points at.
     keep = []

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -46,9 +46,12 @@ COCO_ANNOTATIONS = COCO_ROOT / "derived" / "objects_flat_val2017.jsonl.gz"
 #: Datasets in the pile. ``boxed`` means the medias carry ground-truth region
 #: boxes, which is what a region-voting arm drags — necessary but not
 #: sufficient (the embedder must also be patch-capable; see region_capable).
+#: ``source_dir`` is the demo extraction dir the loader treats as "already
+#: downloaded" (vtscore/datasets/downloader/*.py). It must be present in the
+#: datadir before a demo cell is built — see :func:`require_demo_source`.
 DATASETS: dict[str, dict] = {
-    "visual_genome_m": {"boxed": True, "kind": "demo"},
-    "caltech101_m": {"boxed": False, "kind": "demo"},
+    "visual_genome_m": {"boxed": True, "kind": "demo", "source_dir": "visual_genome"},
+    "caltech101_m": {"boxed": False, "kind": "demo", "source_dir": "caltech-101"},
     "coco_val": {"boxed": True, "kind": "coco"},
 }
 
@@ -88,6 +91,29 @@ def region_capable(dataset: str, embedder: str) -> bool:
     per-dataset flag alone reads as "this arm region-votes" and does not.
     """
     return bool(DATASETS.get(dataset, {}).get("boxed")) and is_patch_embedder(embedder)
+
+
+def require_demo_source(dataset: str) -> None:
+    """Fail loudly if a demo dataset's source is not staged in the datadir.
+
+    The demo downloaders treat a *missing* extraction dir as "not downloaded
+    yet" and go fetch it. On a datadir that lost its symlink into the shared
+    demo cache, that silently substitutes a partial re-download for the real
+    dataset: the build still succeeds, but the cell holds a truncated subset
+    and disagrees with its sibling cells. Cheaper to block than to detect.
+    """
+    name = DATASETS.get(dataset, {}).get("source_dir")
+    if not name:
+        return
+    src = DATADIR / name
+    if not src.exists():
+        raise SystemExit(
+            f"{dataset}: demo source {src} is missing, so the loader would re-download it.\n"
+            f"  Link the shared cache in first, e.g.\n"
+            f"    ln -s {DEMO_CACHE}/{name} {src}"
+        )
+    if not any(src.iterdir()):
+        raise SystemExit(f"{dataset}: demo source {src} is empty (an empty dir reads as 'download complete')")
 
 
 def setup_env() -> None:

--- a/scripts/experiments/pile/pile_env.sh
+++ b/scripts/experiments/pile/pile_env.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Source this to point a study at the shared pre-embedded pile.
+#
+#   source scripts/experiments/pile/pile_env.sh
+#
+# After this, load_demo_dataset / the calibration harness read the per-pair
+# pickles in place instead of re-embedding, and model weights resolve to the
+# pile's models dir rather than being re-downloaded per study.
+#
+# HF_HOME is pinned here on purpose: the grid shell points it at /exp, where a
+# single model download fills the 50G quota.
+
+VTS_PILE="${VTS_PILE:-/expscratch/${USER}/vts-cache}"
+export VTS_PILE
+export VTSEARCH_DATA_DIR="$VTS_PILE/datadir"
+export VTSEARCH_MODELS_DIR="$VTS_PILE/models"
+export HF_HOME="$VTS_PILE/models"
+
+if [[ ! -d "$VTSEARCH_DATA_DIR/embeddings" ]]; then
+  echo "warning: no pile at $VTS_PILE (build it with build_pile.py)" >&2
+fi

--- a/scripts/experiments/pile/prefetch_models.py
+++ b/scripts/experiments/pile/prefetch_models.py
@@ -1,0 +1,62 @@
+"""Download the pile's embedder weights into the pile's models dir.
+
+Run this once, on CPU, *before* the GPU build jobs. Two reasons it is its own
+stage rather than a side effect of the first build:
+
+* Parallel build jobs would otherwise race to populate the same shared HF cache.
+* A download stall (the cluster's shared egress NAT is rate-limited for
+  anonymous traffic) is much cheaper to hit on a CPU node than while holding a
+  GPU allocation.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pile_config as pc
+
+pc.setup_env()
+
+
+def main() -> int:
+    from huggingface_hub import snapshot_download  # noqa: PLC0415
+
+    from vtscore import config as vtc  # noqa: PLC0415
+
+    # HF-hub repo ids, resolvable by snapshot_download.  ``siglip_l`` is absent
+    # on purpose: it loads through open_clip's pretrained registry, whose key
+    # (``ViT-SO400M-14-SigLIP-384``) is an arch name, not a repo id -- passing it
+    # to snapshot_download raises. open_clip fetches it from ``timm/<arch>`` on
+    # first use and caches it under the same HF_HOME as the rest.
+    wanted = {
+        "siglip": vtc.SIGLIP_MODEL_ID,
+        "siglip2": vtc.SIGLIP2_MODEL_ID,
+        "siglip2_l": vtc.SIGLIP2_L_MODEL_ID,
+        "dinov3_patch": vtc.DINOV3_MODEL_ID,
+    }
+    names = sys.argv[1].split(",") if len(sys.argv) > 1 else list(wanted)
+
+    failed = []
+    for name in names:
+        model_id = wanted.get(name)
+        if model_id is None:
+            print(f"[prefetch] unknown embedder {name!r}", flush=True)
+            failed.append(name)
+            continue
+        print(f"[prefetch] {name}: {model_id}", flush=True)
+        try:
+            path = snapshot_download(model_id)
+            print(f"[prefetch]   -> {path}", flush=True)
+        except Exception as exc:  # noqa: BLE001 - report and continue to the next
+            print(f"[prefetch]   FAILED {name}: {exc}", flush=True)
+            failed.append(name)
+
+    if failed:
+        print(f"[prefetch] FAILED: {failed}", flush=True)
+        return 1
+    print("[prefetch] all weights present", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/prefetch_models.py
+++ b/scripts/experiments/pile/prefetch_models.py
@@ -45,7 +45,12 @@ def main() -> int:
             continue
         print(f"[prefetch] {name}: {model_id}", flush=True)
         try:
-            path = snapshot_download(model_id)
+            # cache_dir=MODELS, not the default HF_HOME/hub: the embedders load
+            # with ``cache_dir=<VTSEARCH_MODELS_DIR>`` (see embedder_siglip2.py),
+            # which puts ``models--*`` at the top of that dir. Prefetching to
+            # HF_HOME/hub instead leaves weights the jobs cannot see, so each one
+            # re-downloads -- and three parallel jobs race on the same dir.
+            path = snapshot_download(model_id, cache_dir=str(pc.MODELS))
             print(f"[prefetch]   -> {path}", flush=True)
         except Exception as exc:  # noqa: BLE001 - report and continue to the next
             print(f"[prefetch]   FAILED {name}: {exc}", flush=True)

--- a/scripts/experiments/pile/scan_vg_boxes.py
+++ b/scripts/experiments/pile/scan_vg_boxes.py
@@ -1,0 +1,197 @@
+"""Scan the FULL Visual Genome annotations to band object categories by box size.
+
+The pile's `visual_genome_m` cell is the demo pipeline's view of VG: a curated
+100-category vocabulary, capped at 1000 items each, over a 4% ``slice_frac``
+window (1/50 -> 3/50). That is the right dataset for "load something into the
+UI quickly" and the wrong one for "how does box scale behave", because the
+scale question is about *which categories exist at which size*, and the demo
+vocabulary was chosen for recognisability, not for spanning scales.
+
+This scans the original source instead -- all 108k images across VG_100K and
+VG_100K_2, with the full free-text object vocabulary from ``objects.json`` --
+and reports the per-category voted-box scale so banded datasets can be built
+from the whole pool.
+
+``objects.json`` stores boxes in **pixels** and carries no image dimensions, so
+areas are normalised against dims read from each JPEG header (PIL reads the
+header without decoding the image, which is what makes 108k files tractable).
+Dims are cached; the scan is re-runnable.
+
+Usage::
+
+    python scan_vg_boxes.py                 # scan, cache, report
+    python scan_vg_boxes.py --min-images 50 # require more support per category
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+VG_ROOT = pc.DEMO_CACHE / "visual_genome"
+IMAGE_DIRS = [VG_ROOT / "VG_100K", VG_ROOT / "VG_100K_2"]
+OBJECTS_JSON = VG_ROOT / "objects.json"
+DIMS_CACHE = pc.PILE / "vg_image_dims.json"
+
+
+def log(msg: str) -> None:
+    print(f"[vgscan] {msg}", flush=True)
+
+
+def _image_paths() -> dict[int, Path]:
+    """``{image_id: path}`` over both VG image dirs."""
+    out: dict[int, Path] = {}
+    for d in IMAGE_DIRS:
+        if not d.is_dir():
+            raise SystemExit(f"missing VG image dir: {d}")
+        for p in d.iterdir():
+            if p.suffix.lower() == ".jpg":
+                try:
+                    out[int(p.stem)] = p
+                except ValueError:
+                    continue
+    return out
+
+
+def _read_dims(paths: dict[int, Path], workers: int = 16) -> dict[int, tuple[int, int]]:
+    """``{image_id: (w, h)}``, cached to disk. Header-only reads, threaded."""
+    if DIMS_CACHE.exists():
+        cached = {int(k): tuple(v) for k, v in json.loads(DIMS_CACHE.read_text()).items()}
+        if len(cached) >= len(paths):
+            log(f"reusing cached dims for {len(cached)} images")
+            return cached  # type: ignore[return-value]
+
+    from PIL import Image  # noqa: PLC0415
+
+    def one(item):
+        iid, path = item
+        try:
+            with Image.open(path) as im:  # header only; no decode
+                return iid, im.size
+        except Exception:  # noqa: BLE001 - a corrupt file just drops out
+            return iid, None
+
+    t0 = time.time()
+    dims: dict[int, tuple[int, int]] = {}
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        for i, (iid, size) in enumerate(ex.map(one, paths.items(), chunksize=256), 1):
+            if size:
+                dims[iid] = size
+            if i % 20000 == 0:
+                log(f"  dims {i}/{len(paths)} ({time.time() - t0:.0f}s)")
+    log(f"read dims for {len(dims)}/{len(paths)} images in {time.time() - t0:.0f}s")
+    DIMS_CACHE.write_text(json.dumps({str(k): list(v) for k, v in dims.items()}))
+    return dims
+
+
+def _union(boxes: list[tuple[float, float, float, float]]) -> tuple[float, float, float, float]:
+    """The single box a Good vote drags: the union over a category's instances."""
+    x0 = min(b[0] for b in boxes)
+    y0 = min(b[1] for b in boxes)
+    x1 = max(b[2] for b in boxes)
+    y1 = max(b[3] for b in boxes)
+    return x0, y0, x1, y1
+
+
+def scan(min_images: int) -> dict:
+    """Per-category voted-box scale over the whole of VG."""
+    paths = _image_paths()
+    log(f"found {len(paths)} images across {len(IMAGE_DIRS)} dirs")
+    dims = _read_dims(paths)
+
+    log(f"loading {OBJECTS_JSON.name} ({OBJECTS_JSON.stat().st_size / 1e6:.0f} MB)...")
+    t0 = time.time()
+    with OBJECTS_JSON.open() as fh:
+        records = json.load(fh)
+    log(f"  parsed {len(records)} image records in {time.time() - t0:.0f}s")
+
+    # category -> list of per-image (voted_area, instance_area) fractions
+    voted: dict[str, list[float]] = defaultdict(list)
+    instance: dict[str, list[float]] = defaultdict(list)
+    n_images: dict[str, int] = defaultdict(int)
+
+    for rec in records:
+        iid = int(rec["image_id"])
+        wh = dims.get(iid)
+        if wh is None:
+            continue
+        W, H = wh
+        if W <= 0 or H <= 0:
+            continue
+        area = float(W * H)
+        by_name: dict[str, list[tuple[float, float, float, float]]] = defaultdict(list)
+        for obj in rec.get("objects") or []:
+            names = obj.get("names") or []
+            if not names:
+                continue
+            name = str(names[0]).strip().lower()
+            if not name:
+                continue
+            x, y = float(obj.get("x", 0)), float(obj.get("y", 0))
+            w, h = float(obj.get("w", 0)), float(obj.get("h", 0))
+            if w <= 0 or h <= 0:
+                continue
+            by_name[name].append((x, y, x + w, y + h))
+        for name, boxes in by_name.items():
+            ux0, uy0, ux1, uy1 = _union(boxes)
+            voted[name].append(max(0.0, (ux1 - ux0)) * max(0.0, (uy1 - uy0)) / area)
+            instance[name].extend((b[2] - b[0]) * (b[3] - b[1]) / area for b in boxes)
+            n_images[name] += 1
+
+    stats = {}
+    for name, areas in voted.items():
+        if n_images[name] < min_images:
+            continue
+        v = float(statistics.median(areas))
+        i = float(statistics.median(instance[name]))
+        stats[name] = {
+            "voted_area": v,
+            "instance_area": i,
+            "union_inflation": (v / i) if i > 0 else float("inf"),
+            "n_images": n_images[name],
+        }
+    log(f"{len(stats)} categories with >= {min_images} images (of {len(voted)} distinct names)")
+    return stats
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--min-images", type=int, default=20, help="minimum images per category (default 20)")
+    ap.add_argument("--out", default=str(pc.PILE / "vg_box_scale.json"), help="where to write the scan")
+    args = ap.parse_args()
+
+    stats = scan(args.min_images)
+    Path(args.out).write_text(json.dumps(stats, indent=2, sort_keys=True) + "\n")
+    log(f"wrote {args.out}")
+
+    # Report against the geometry-anchored bands the calibration harness uses.
+    PATCH, LEAF = 1 / 196, 1 / 12
+    bands = [
+        ("sub_patch", 0.0, PATCH),
+        ("patch_to_leaf", PATCH, LEAF),
+        ("leaf_to_4x", LEAF, 4 * LEAF),
+        ("above_4x", 4 * LEAF, 1.01),
+    ]
+    log("")
+    log("=== full-VG category counts per geometry band ===")
+    for name, lo, hi in bands:
+        pool = [c for c, s in stats.items() if lo <= s["voted_area"] < hi]
+        clean = [c for c in pool if stats[c]["union_inflation"] <= 1.5]
+        log(f"  {name:14s} [{lo * 100:5.2f}%, {hi * 100:6.2f}%): {len(pool):5d} categories "
+            f"({len(clean)} with union_inflation <= 1.5)")
+        example = sorted(pool, key=lambda c: -stats[c]["n_images"])[:8]
+        log(f"      most-supported: {example}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Every study since July has read its embeddings through a symlink chain rooted at
`max-patch/datadir` — an artifact named after a finished experiment, split
across two study dirs, on a 50G mount that sat at 92%. Embedders were re-run per
study because the cache had no home of its own, and model weights were
re-downloaded into per-study dirs.

This gives the cache a home and makes it reproducible.

## What

`scripts/experiments/pile/` builds and verifies a grid of `(dataset, embedder)`
cells. A cell holds vectors (plus `patch_grid` for patch embedders) and no
pixels. Studies `source pile_env.sh` and read cells in place, so a pair is
embedded once ever.

Now built and verified on the GRID — **3 datasets x 5 embedders, all 15 cells**:

| | siglip | siglip2 | siglip_l | siglip2_l | dinov3_patch |
|---|---|---|---|---|---|
| `visual_genome_m` (4193, boxed) | ✓ | ✓ | ✓ | ✓ | ✓ **region** |
| `caltech101_m` (838) | ✓ | ✓ | ✓ | ✓ | ✓ |
| `coco_val` (4952, boxed) | ✓ | ✓ | ✓ | ✓ | ✓ **region** |

## The region-voting fix

A region arm needs a boxed dataset **and** a patch embedder. Pair a boxed
dataset with a single-vector embedder and it does not error — it silently runs
as binary voting. That has cost three studies (#2877, #2897, #2905), and until
now `visual_genome_m x dinov3_patch` was the *only* region-voting arm in
existence, so no region result could be separated from its environment.

`coco_val x dinov3_patch` (patch grids on 4952/4952) is a genuine second region
environment. It is built from the staged val2017 images, not the #2790 vector
cache, which stores HAC region vectors but not the raw patch grid and so could
never carry a region arm.

Capability is stated per *cell* rather than per dataset, and `--verify` asserts
the geometry is physically present instead of trusting the arm table.

## Guards, both learned the hard way on the first real run

- **Missing demo source.** A datadir without its symlink into the shared demo
  cache does not fail: the downloader reads a missing extraction dir as "not
  downloaded yet" and refetches. That substituted a partial re-download and
  wrote a healthy-looking VG cell holding **1662 of 4193 medias**.
  `require_demo_source` now blocks it, and `--verify` cross-checks that a
  dataset's cells agree on media count.
- **Prefetch destination.** The embedders load with
  `cache_dir=<VTSEARCH_MODELS_DIR>`, but `snapshot_download` defaults to
  `HF_HOME/hub` — prefetching there left 7.6G of weights the jobs could not see,
  so each would re-download and three parallel jobs would race on the same cache.

## Verification

```
[pile] visual_genome_m  dinov3_patch  ok  4193  4193/4193   768
[pile] coco_val         dinov3_patch  ok  4952  4952/4952   768
[pile] all present cells verified
```

All 15 cells: consistent populations per dataset, expected dims (768 for
siglip/siglip2, 1152 for the -L pair), full patch coverage on both region cells.