### PR TITLE
Export modal: open the open_url tab on click, not on the response

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -1311,21 +1311,32 @@ return it. A delivery exporter whose remote hands back a permalink returns the
 same key.
 
 ```python
-def export(self, results: dict, field_values: dict) -> dict:
-    url = validate_browser_url(f"https://review.example.com/?ids={quote(ids, safe='')}")
-    return {"message": "Opening the labelset in Review Site.", "open_url": url}
+class ReviewSiteExporter(LabelsetExporter):
+    name = "review_site"
+    display_name = "Review Site"
+    description = "Open the labelset in Review Site."
+    opens_url = True
+    fields = []          # required, even when empty — there is no default
+
+    def export(self, results: dict, field_values: dict) -> dict:
+        ids = ",".join(e["md5"] for e in results.get("labels", []))
+        url = validate_browser_url(f"https://review.example.com/?ids={quote(ids, safe='')}")
+        return {"message": "Opening the labelset in Review Site.", "open_url": url}
 ```
 
 Set `opens_url = True` as well **only if you always return a URL**: the flag is
 what lets the Export modal label the button "Open in &lt;name&gt;" *before*
-running anything. An exporter that returns one only sometimes leaves the flag
-`False` — the URL still opens, the button just can't advertise it up front.
+running anything, and — more importantly — it is what tells the modal to claim
+the browser tab while the user's click is still in hand (see the table below).
+An exporter that returns one only sometimes leaves the flag `False`; the URL
+still opens on a best-effort basis, but it is the case a popup blocker is most
+likely to eat.
 
 What each surface does with the key:
 
 | Surface | Behaviour |
 |---------|-----------|
-| Export modal | Opens a new tab; if the popup blocker eats it, the success toast carries an **Open** action that always gets through |
+| Export modal | An `opens_url` exporter gets a blank tab opened inside the click handler, which is navigated when the export returns — a tab opened from the response instead is what popup blockers stop. If the blocker refuses even that, the success toast carries an **Open** action and stays up until dismissed |
 | Auto-Find auto-export (`POST /api/auto-detect`) | Offered as an **Open** button on the Auto-Detect Results modal's status line — not opened on arrival, since the response is async and would be blocked |
 | CLI (`--exporter`) | No browser: the URL is printed under the confirmation message, and rides along as an `open_url` field on the `export_complete` event under `--progress-format json` |
 

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.spec.ts
@@ -151,9 +151,13 @@ describe('AutoDetectResultsModalComponent', () => {
     it('opens the URL in a new tab when clicked, never handing over the opener', async () => {
       withAutoExport({ exporter: 'open_url', success: true, open_url: 'https://example.com/r' });
       await flushInit();
-      const open = vi.spyOn(window, 'open').mockReturnValue(null);
+      // `noopener` in the features string would make `window.open` return null
+      // even on success, so the opener is severed on the handle instead (#2898).
+      const win = { closed: false, opener: {}, location: { href: '' }, close: vi.fn() };
+      const open = vi.spyOn(window, 'open').mockReturnValue(win as unknown as Window);
       (fixture.nativeElement.querySelector('.auto-export-open') as HTMLButtonElement).click();
-      expect(open).toHaveBeenCalledWith('https://example.com/r', '_blank', 'noopener');
+      expect(open).toHaveBeenCalledWith('https://example.com/r', '_blank');
+      expect(win.opener).toBeNull();
       open.mockRestore();
     });
 

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -172,9 +172,14 @@ describe('ExportModalComponent', () => {
       fields: [],
     };
 
+    /** A stand-in for the `Window` handle `window.open` hands back. */
+    function fakeWindow() {
+      return { closed: false, opener: {}, location: { href: '' }, close: vi.fn() };
+    }
+
     /** Stub `window.open`, returning *handle* as the opened window. */
     function stubWindowOpen(handle: unknown) {
-      return vi.spyOn(window, 'open').mockReturnValue(handle as Window);
+      return vi.spyOn(window, 'open').mockReturnValue(handle as unknown as Window);
     }
 
     // `window` outlives the TestBed, so a spy left installed on it carries its
@@ -184,14 +189,28 @@ describe('ExportModalComponent', () => {
       vi.restoreAllMocks();
     });
 
-    it('opens the returned URL in a new tab, severing the opener handle', async () => {
+    // The tab is claimed inside the click handler and navigated when the
+    // response lands: a `window.open` deferred to the response callback is what
+    // popup blockers eat, which is why nothing opened in issue #2898.
+    it('claims the tab on click and navigates it when the URL arrives', async () => {
       await flushInit();
-      const openSpy = stubWindowOpen({});
+      const win = fakeWindow();
+      const openSpy = stubWindowOpen(win);
       component.startExporter(openUrlExporter as never);
+
+      // Opened before the response — with no URL yet to give it.
+      expect(openSpy).toHaveBeenCalledWith('', '_blank');
+      expect(win.location.href).toBe('');
+
       httpMock
         .expectOne('/api/exporters/export')
         .flush({ success: true, open_url: 'https://example.com/r?ids=a' });
-      expect(openSpy).toHaveBeenCalledWith('https://example.com/r?ids=a', '_blank', 'noopener');
+
+      expect(win.location.href).toBe('https://example.com/r?ids=a');
+      // `noopener` would make `window.open` return null even on success, so the
+      // opener is severed by hand instead (see `utils/external-url.ts`).
+      expect(openSpy).toHaveBeenCalledTimes(1);
+      expect(win.opener).toBeNull();
     });
 
     it('offers an Open action on the toast so a blocked popup is recoverable', async () => {
@@ -207,38 +226,78 @@ describe('ExportModalComponent', () => {
       const toast = successSpy.mock.calls[0][0];
       expect(toast.detail).toContain('blocked');
       expect(toast.action?.label).toBe('Open');
+      // That button is the only way left to reach the site, so the toast must
+      // not time out from under it.
+      expect(toast.autoDismissMs).toBe(0);
       // The action's click is a real user gesture, so this one gets through.
-      openSpy.mockReturnValue({} as Window);
+      const win = fakeWindow();
+      openSpy.mockReturnValue(win as unknown as Window);
       toast.action!.onClick();
-      expect(openSpy).toHaveBeenCalledTimes(2);
+      expect(openSpy).toHaveBeenLastCalledWith('https://example.com/r', '_blank');
     });
 
     it('reports an opened tab rather than an export in the toast message', async () => {
       await flushInit();
-      stubWindowOpen({});
+      stubWindowOpen(fakeWindow());
       const successSpy = vi.spyOn(TestBed.inject(ToastService), 'success');
       component.labelFilter = 'good'; // two matching labels in the fixture
       component.startExporter(openUrlExporter as never);
       httpMock
         .expectOne('/api/exporters/export')
         .flush({ success: true, open_url: 'https://example.com/r' });
-      expect(successSpy.mock.calls[0][0].message).toBe('Opened 2 labels in Open in Website');
+      const toast = successSpy.mock.calls[0][0];
+      expect(toast.message).toBe('Opened 2 labels in Open in Website');
+      // Nothing to escape from: the default auto-dismiss applies.
+      expect(toast.autoDismissMs).toBeUndefined();
+    });
+
+    // A user who closed the pre-opened tab while the export ran gets the same
+    // recoverable toast as a blocked one.
+    it('treats a closed pre-opened tab as a failure to open', async () => {
+      await flushInit();
+      const win = fakeWindow();
+      stubWindowOpen(win);
+      const successSpy = vi.spyOn(TestBed.inject(ToastService), 'success');
+      component.startExporter(openUrlExporter as never);
+      win.closed = true;
+      httpMock
+        .expectOne('/api/exporters/export')
+        .flush({ success: true, open_url: 'https://example.com/r' });
+
+      expect(win.location.href).toBe('');
+      expect(successSpy.mock.calls[0][0].action?.label).toBe('Open');
     });
 
     it.each(['javascript:alert(1)', 'data:text/html,x', 'file:///etc/passwd', '/relative'])(
       'refuses to open a %s URL even if the server sent one',
       async (url) => {
         await flushInit();
-        const openSpy = stubWindowOpen({});
+        const win = fakeWindow();
+        stubWindowOpen(win);
         component.startExporter(openUrlExporter as never);
         httpMock.expectOne('/api/exporters/export').flush({ success: true, open_url: url });
-        expect(openSpy).not.toHaveBeenCalled();
+        // The tab was claimed on click, but nothing unsafe is navigated to and
+        // the blank tab doesn't outlive the export.
+        expect(win.location.href).toBe('');
+        expect(win.close).toHaveBeenCalled();
       },
     );
 
+    it('closes the claimed tab when the export fails outright', async () => {
+      await flushInit();
+      const win = fakeWindow();
+      stubWindowOpen(win);
+      component.startExporter(openUrlExporter as never);
+      httpMock
+        .expectOne('/api/exporters/export')
+        .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+      expect(win.close).toHaveBeenCalled();
+    });
+
     it('leaves a response without an open_url alone', async () => {
       await flushInit();
-      const openSpy = stubWindowOpen({});
+      const openSpy = stubWindowOpen(fakeWindow());
+      // `mockExporters[0]` doesn't declare `opens_url`, so no tab is claimed.
       component.startExporter(mockExporters[0] as never);
       httpMock.expectOne('/api/exporters/export').flush({ success: true });
       expect(openSpy).not.toHaveBeenCalled();

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -28,7 +28,7 @@ import { SortingApiService } from '../../../services/sorting-api.service';
 import type { LabelFilter } from '../../../services/sorting-api.service';
 import { ToastService } from '../../../services/toast.service';
 import { ImporterField } from '../../../models/api.models';
-import { openExternalUrl, safeExternalUrl } from '../../../utils/external-url';
+import { openBlankTab, openExternalUrl, safeExternalUrl } from '../../../utils/external-url';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 import type { LabeledElement } from '../../../generated/api-client/models/labeled-element';
 
@@ -582,6 +582,15 @@ export class ExportModalComponent implements OnInit {
       labels: this.filteredLabels,
       selected_columns: this.exportColumns.map((c) => c.key),
     };
+
+    // Claim the tab *now*, while the click that got us here still counts as
+    // user activation. Opening it from the response callback instead is what a
+    // popup blocker exists to stop, and it gets swallowed silently (#2898).
+    // Only exporters that declare `opens_url` are known to be heading for a new
+    // tab; one that returns a URL without declaring it falls back to the
+    // best-effort open in the callback, and to the toast's Open action.
+    const pendingTab = exporter.opens_url ? openBlankTab() : null;
+
     this.exportersApi
       .runExport({
         exporter_name: exporter.name,
@@ -597,13 +606,21 @@ export class ExportModalComponent implements OnInit {
           // (or as well as) delivering the labelset somewhere — that's how a
           // third-party site with no ingest API gets the selection (#2855).
           const openUrl = safeExternalUrl(response?.open_url);
-          const opened = openUrl ? openExternalUrl(openUrl) : false;
+          let opened = false;
+          if (openUrl) {
+            opened = pendingTab ? pendingTab.navigate(openUrl) : openExternalUrl(openUrl);
+          } else {
+            // The exporter advertised a URL and didn't produce one; don't leave
+            // a blank tab sitting there.
+            pendingTab?.close();
+          }
           const plural = labelCount === 1 ? '' : 's';
 
           // Three toast shapes: opened a tab, tried and got blocked, or a
-          // plain delivery export. The popup blocker fires when the response
-          // lands outside the click's task, so say why nothing happened
-          // rather than leaving the user staring at an unchanged screen.
+          // plain delivery export. The blocked case survives the pre-opened
+          // tab above (a blocker can refuse even a gesture-time popup), so say
+          // why nothing happened rather than leaving the user staring at an
+          // unchanged screen.
           let message = `Exported ${labelCount.toLocaleString()} label${plural} to ${exporterLabel}`;
           let detail = fieldValues['filepath'] ? `Destination: ${fieldValues['filepath']}` : undefined;
           if (openUrl) {
@@ -625,11 +642,17 @@ export class ExportModalComponent implements OnInit {
             action: openUrl
               ? { label: 'Open', title: openUrl, onClick: () => openExternalUrl(openUrl) }
               : undefined,
+            // A blocked tab makes that button the only way to reach the site,
+            // so the toast has to outlive the 5s success default — otherwise
+            // the escape hatch is gone before the user finishes reading why
+            // nothing opened.
+            autoDismissMs: openUrl && !opened ? 0 : undefined,
             dedupKey: 'export-labels-success',
           });
           this.exported.emit();
         },
         error: () => {
+          pendingTab?.close();
           this.status.set('');
           this.actionError.set('Label export failed');
           this.submitting.set(false);

--- a/frontend/src/app/services/toast.service.ts
+++ b/frontend/src/app/services/toast.service.ts
@@ -89,6 +89,15 @@ interface ShowOptions {
    * the seconds the user sees are the seconds they actually have.
    */
   countdown?: { label: string; seconds: number; onExpire: () => void };
+  /**
+   * Override how long a success toast stays up, in milliseconds; ``0`` keeps
+   * it until the user dismisses it. Left unset, success toasts auto-dismiss
+   * after ``SUCCESS_AUTO_DISMISS_MS``. Set this when the toast's
+   * {@link ToastAction} is the user's only route to something they asked for
+   * (e.g. a browser tab the popup blocker refused), since a timed-out toast
+   * takes that route with it.
+   */
+  autoDismissMs?: number;
   dedupKey?: string;
 }
 
@@ -150,10 +159,12 @@ export class ToastService {
   /**
    * Non-blocking success notification. Auto-dismisses after
    * ``SUCCESS_AUTO_DISMISS_MS`` so the user is not forced to click
-   * through a modal for "X is done" style messages.
+   * through a modal for "X is done" style messages, unless the caller
+   * overrides that with ``autoDismissMs`` (``0`` = stays until dismissed).
    */
   success(opts: ShowOptions): number {
-    return this.push('success', opts, opts.countdown ? 0 : SUCCESS_AUTO_DISMISS_MS);
+    const autoDismissMs = opts.autoDismissMs ?? SUCCESS_AUTO_DISMISS_MS;
+    return this.push('success', opts, opts.countdown ? 0 : autoDismissMs);
   }
 
   private push(level: ToastLevel, opts: ShowOptions, autoDismissMs = 0): number {

--- a/frontend/src/app/utils/external-url.spec.ts
+++ b/frontend/src/app/utils/external-url.spec.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { openBlankTab, openExternalUrl, safeExternalUrl } from './external-url';
+
+describe('safeExternalUrl', () => {
+  it.each(['https://example.com/r?ids=a', 'http://localhost:9000/viewer', '  https://x.test  '])(
+    'passes %s through, trimmed',
+    (url) => {
+      expect(safeExternalUrl(url)).toBe(url.trim());
+    },
+  );
+
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,x',
+    'file:///etc/passwd',
+    '/relative',
+    'https://',
+    '',
+    null,
+    undefined,
+    42,
+  ])('rejects %s', (url) => {
+    expect(safeExternalUrl(url)).toBeNull();
+  });
+});
+
+/** A stand-in for the `Window` handle `window.open` hands back. */
+function fakeWindow() {
+  return { closed: false, opener: {}, location: { href: '' }, close: vi.fn() };
+}
+
+function stubWindowOpen(handle: unknown) {
+  return vi.spyOn(window, 'open').mockReturnValue(handle as unknown as Window);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('openExternalUrl', () => {
+  // `noopener` in the features string would make `window.open` return null even
+  // when the tab opened (HTML standard, window open steps), leaving the caller
+  // unable to tell success from a blocked popup — issue #2898.
+  it('opens the URL and severs the opener without asking for noopener', () => {
+    const win = fakeWindow();
+    const openSpy = stubWindowOpen(win);
+    expect(openExternalUrl('https://example.com/r')).toBe(true);
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/r', '_blank');
+    expect(win.opener).toBeNull();
+  });
+
+  it('reports a blocked popup', () => {
+    stubWindowOpen(null);
+    expect(openExternalUrl('https://example.com/r')).toBe(false);
+  });
+});
+
+describe('openBlankTab', () => {
+  it('claims an empty tab up front and navigates it later', () => {
+    const win = fakeWindow();
+    const openSpy = stubWindowOpen(win);
+
+    const tab = openBlankTab();
+    expect(openSpy).toHaveBeenCalledWith('', '_blank');
+    expect(win.opener).toBeNull();
+    expect(win.location.href).toBe('');
+
+    expect(tab!.navigate('https://example.com/r')).toBe(true);
+    expect(win.location.href).toBe('https://example.com/r');
+  });
+
+  it('returns null when even the gesture-time open is refused', () => {
+    stubWindowOpen(null);
+    expect(openBlankTab()).toBeNull();
+  });
+
+  it('refuses to navigate a tab the user already closed', () => {
+    const win = fakeWindow();
+    stubWindowOpen(win);
+    const tab = openBlankTab();
+    win.closed = true;
+    expect(tab!.navigate('https://example.com/r')).toBe(false);
+    expect(win.location.href).toBe('');
+  });
+
+  it('closes the tab when there is nothing to show in it', () => {
+    const win = fakeWindow();
+    stubWindowOpen(win);
+    openBlankTab()!.close();
+    expect(win.close).toHaveBeenCalled();
+  });
+
+  it('leaves an already-closed tab alone', () => {
+    const win = fakeWindow();
+    stubWindowOpen(win);
+    const tab = openBlankTab();
+    win.closed = true;
+    tab!.close();
+    expect(win.close).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/utils/external-url.ts
+++ b/frontend/src/app/utils/external-url.ts
@@ -2,14 +2,28 @@
  * Guards for the `open_url` an exporter can hand back for the browser to open.
  *
  * The server already runs every such URL through `validate_browser_url`, so
- * this is the second half of a belt-and-braces pair: the check that matters is
- * the scheme, and it costs one regex to make the frontend independently unable
- * to navigate to a `javascript:` or `data:` URL — a class of bug that only ever
- * shows up once someone's plugin is already in the wild.
+ * `safeExternalUrl` is the second half of a belt-and-braces pair: the check that
+ * matters is the scheme, and it costs one regex to make the frontend
+ * independently unable to navigate to a `javascript:` or `data:` URL — a class
+ * of bug that only ever shows up once someone's plugin is already in the wild.
  *
  * Lives here rather than on one component because two surfaces act on the key:
  * the Export modal (a labelset export the user ran) and the Auto-Detect Results
  * modal (an Auto-Find auto-export that ran for them).
+ *
+ * ## Why the opener is severed by hand, not by `noopener`
+ *
+ * The obvious spelling — `window.open(url, '_blank', 'noopener')` — is
+ * unusable here, because the HTML standard's window open steps end with "if
+ * noopener is true [...] then return null" regardless of whether the tab
+ * opened. That makes the return value carry no information: the caller cannot
+ * tell a popup the blocker ate from one sitting in front of the user, so it can
+ * neither report what happened nor decide whether to offer a fallback (issue
+ * #2898). Dropping `noopener` and assigning `opener = null` on the returned
+ * handle buys back that signal at no real cost: the assignment runs
+ * synchronously in the same task as the `open()` call, before the new document
+ * can run any script of its own, and it permanently disowns the opener, so
+ * reverse tabnabbing (`window.opener.location = evil`) stays impossible.
  */
 
 /** Narrow an exporter-supplied `open_url` to something safe for `window.open`, or `null`. */
@@ -19,15 +33,75 @@ export function safeExternalUrl(url: unknown): string | null {
   return /^https?:\/\/\S+$/i.test(trimmed) ? trimmed : null;
 }
 
+/** Disown *win* so the page it ends up showing has no handle on this one. */
+function severOpener(win: Window): void {
+  try {
+    win.opener = null;
+  } catch {
+    // `opener` is cross-origin-settable per spec, but a browser that refuses
+    // is not a reason to abandon a tab the user asked for.
+  }
+}
+
+/**
+ * A tab opened up front, waiting for a URL that an in-flight request will
+ * carry. See {@link openBlankTab} for why it exists.
+ */
+export interface PendingTab {
+  /** Point the tab at *url*. False if it is gone (the user closed it). */
+  navigate(url: string): boolean;
+  /** Close the tab — the request came back with no URL to show it. */
+  close(): void;
+}
+
+/**
+ * Open an empty tab *now*, to be navigated when a pending request resolves.
+ *
+ * A popup is allowed while the click that triggered it still counts as user
+ * activation; a `window.open()` deferred to an HTTP response callback is
+ * precisely the shape popup blockers exist to stop, and gets swallowed with no
+ * error (issue #2898). So a flow that knows a URL is coming — an exporter
+ * declaring `opens_url` — claims the tab inside the click handler and points it
+ * at the URL once the response lands.
+ *
+ * Returns `null` when even the gesture-time open was refused, which is a real
+ * answer rather than the ambiguity `noopener` leaves behind: the caller can
+ * fall back to an explicit "Open" button.
+ */
+export function openBlankTab(): PendingTab | null {
+  const win = window.open('', '_blank');
+  if (!win) return null;
+  severOpener(win);
+  return {
+    navigate(url: string): boolean {
+      try {
+        if (win.closed) return false;
+        win.location.href = url;
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    close(): void {
+      try {
+        if (!win.closed) win.close();
+      } catch {
+        // Already gone; nothing to clean up.
+      }
+    },
+  };
+}
+
 /**
  * Open *url* in a new tab, reporting whether the tab actually opened.
  *
- * `noopener` severs the new page's `window.opener` handle so a third-party site
- * can't navigate the VTSearch tab out from under the user (reverse tabnabbing).
- * A `null` return means the popup blocker ate it, which is the normal outcome
- * when the call happens after an async response rather than inside a click
- * handler.
+ * Use this from a real click handler (a toast's "Open" button, a link-shaped
+ * control). From an async callback, prefer {@link openBlankTab} at gesture time
+ * — a `false` here usually means the popup blocker ate it.
  */
 export function openExternalUrl(url: string): boolean {
-  return window.open(url, '_blank', 'noopener') !== null;
+  const win = window.open(url, '_blank');
+  if (!win) return false;
+  severOpener(win);
+  return true;
 }

--- a/scripts/experiments/pile/scan_vg_boxes.py
+++ b/scripts/experiments/pile/scan_vg_boxes.py
@@ -186,8 +186,10 @@ def main() -> int:
     for name, lo, hi in bands:
         pool = [c for c, s in stats.items() if lo <= s["voted_area"] < hi]
         clean = [c for c in pool if stats[c]["union_inflation"] <= 1.5]
-        log(f"  {name:14s} [{lo * 100:5.2f}%, {hi * 100:6.2f}%): {len(pool):5d} categories "
-            f"({len(clean)} with union_inflation <= 1.5)")
+        log(
+            f"  {name:14s} [{lo * 100:5.2f}%, {hi * 100:6.2f}%): {len(pool):5d} categories "
+            f"({len(clean)} with union_inflation <= 1.5)"
+        )
         example = sorted(pool, key=lambda c: -stats[c]["n_images"])[:8]
         log(f"      most-supported: {example}")
     return 0

--- a/vtscore/docs/extending/results-exporters.md
+++ b/vtscore/docs/extending/results-exporters.md
@@ -228,10 +228,15 @@ Four things this shape gets right, and that yours should too:
 - **Assume the URL is public.** It reaches the destination site's logs
   and the user's browser history. Identifiers, not content.
 
-Set `opens_url = True` only if you *always* return a URL; the flag is
-what the UI reads to label the button before running anything. An
-exporter that returns one only sometimes (a webhook whose remote hands
-back a permalink) leaves the flag `False` - the URL still opens.
+Set `opens_url = True` only if you *always* return a URL. The flag does
+two jobs: it labels the button before anything runs, and it tells the
+Export modal to claim the new tab *inside the click handler* and
+navigate it when your `export()` returns. That ordering is the whole
+game - a `window.open()` fired from the response instead is exactly what
+a popup blocker exists to stop, and it fails silently. An exporter that
+returns a URL only sometimes (a webhook whose remote hands back a
+permalink) leaves the flag `False`; the URL still opens on a best-effort
+basis, with the success toast's **Open** button as the fallback.
 
 **You don't need an `export_cli` override for this.** The CLI has no
 browser, so it surfaces the `open_url` your `export()` returned rather


### PR DESCRIPTION
An exporter's `open_url` reaches the browser fine — the route validates it and
`RunExportResponseSchema` carries it, which `tests/io/test_exporters.py::TestOpenUrlResponseKey`
already pins. What didn't work was the opening, reported on #2898 with a
hardcoded `https://google.com` that never appeared.

Two defects, both in the frontend.

**The tab was claimed too late.** `exportLabelsWith` called `window.open()` from
inside the HTTP response callback — precisely the shape a popup blocker
swallows, with no error to show for it. The Auto-Detect Results modal already
refuses to do this (`autodetect-results-modal.component.ts:74-86` says so in a
comment); the Export modal did it anyway.

**And it couldn't tell that it hadn't worked.** `openExternalUrl` passed
`noopener`, and the HTML standard's [window open steps](https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-open-steps)
end with *"if noopener is true [...] then return null"* whether or not the tab
opened. So `window.open(...) !== null` was `false` in every real browser: the
`Opened N labels in <name>` message was unreachable in production, and every
URL export claimed the popup had been blocked — including the ones that worked.
The Vitest specs missed it by stubbing a truthy handle, a value no browser
returns for that call.

## Changes

- **`utils/external-url.ts`** — new `openBlankTab()` claims a tab while the
  click is still user activation and returns a `PendingTab` the response
  callback navigates (or closes, if no URL came back). `openExternalUrl` drops
  `noopener` and assigns `opener = null` on the handle instead, so the return
  value carries information again. The assignment runs in the same task as
  `open()`, before the new document can run script, so reverse tabnabbing stays
  impossible.
- **`export-modal.component.ts`** — pre-opens the tab for exporters that declare
  `opens_url` (the only up-front signal a URL is coming); closes it if the
  export returns no URL or fails outright. Exporters that return a URL without
  declaring the flag keep the best-effort async open.
- **`toast.service.ts`** — new `ShowOptions.autoDismissMs`. A genuinely blocked
  tab leaves its toast up until dismissed: that **Open** button is the only
  route left to the site, and the 5s success default was taking it away.
- **Docs** — corrects the Export modal row in the per-surface behaviour table in
  `docs/EXTENDING-plugins.md`, explains in both guides why `opens_url` is
  load-bearing rather than cosmetic, and gives the app-side example the `fields`
  attribute it needs (`PluginBase.fields` has no default, so a copy-paste of the
  old snippet 500s on `GET /api/exporters`).
- **Tests** — new `utils/external-url.spec.ts`; the export-modal and
  autodetect-results specs now model a real `Window` handle (settable `opener`,
  `location.href`, `closed`, `close()`) instead of `{}`, and cover the
  claim-then-navigate ordering, a tab the user closed mid-export, an unsafe URL,
  and a failed export.

Also formats `scripts/experiments/pile/scan_vg_boxes.py` — unrelated drift that
was blocking the `ruff format --check` gate for everyone.

`./run-tests.sh`: 8406 passed, 6 skipped; frontend 2051 passed.

## Caveat

There's no browser in the cloud container, so this is verified by unit tests and
the spec, not by watching a tab open. The two defects above are both certain
from the code and the standard, and between them they cover the reported
symptom — but if @CarHorseBatteryStaple's toast never showed *"Your browser
blocked the new tab."* with an **Open** button, then their `open_url` wasn't
reaching the client at all and there's a third thing going on. I've asked on the
issue.

Closes #2898

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Y1WByrfoQf76qEhwwRzqh)_