### PR TITLE
Make `clap_general` the default audio embedder; disambiguate the two CLAP display names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ not list every commit. Use `git log` for the full history.
 
 ### Changed
 
+- **Audio now defaults to the larger CLAP checkpoint.** New audio datasets and
+  text queries use `clap_general` (`laion/larger_clap_general`, shown as "CLAP
+  (general, larger)") instead of `clap`. It wins every measured retrieval
+  comparison on ESC-50, at roughly 2.1x the embedding time. The old checkpoint
+  is still selectable as "CLAP (general, faster)" for large collections where
+  ingest speed matters more, and existing datasets and detectors built with it
+  keep working. Cached demo-dataset pickles built with `clap` are re-embedded
+  the next time they are loaded with the new default.
 - **Library extracted.** The reusable core of VTSearch was carved out into a
   separate `vtscore/` package. The user-facing application surface (the Flask
   app, the Angular SPA, the settings system, the auth layer) is unchanged.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,7 +85,7 @@ detector training and label export.
 
 | Media type | Default embedder | Model | Alternative embedders |
 |---|---|---|---|
-| `audio` | `clap` (CLAP (general audio)) | `laion/clap-htsat-unfused` | `ast`, `beats`, `clap_general`, `clap_music`, `paraspeechclap`, `whisper_encoder` |
+| `audio` | `clap_general` (CLAP (general, larger)) | `laion/larger_clap_general` | `ast`, `beats`, `clap`, `clap_music`, `paraspeechclap`, `whisper_encoder` |
 | `document` | — (convert first) | — | — |
 | `face` | `face` (FaceNet (face identity, 512d)) | — | — |
 | `image` | `siglip` (SigLIP (general images)) | `google/siglip-base-patch16-224` | `clip`, `dinov2_patch`, `dinov2_single`, `dinov3_patch`, `dinov3_single`, `eupe_patch`, `eupe_single`, `sift_vlad`, `siglip2`, `siglip2_l`, `siglip_l` |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -327,15 +327,18 @@ offline deployments:
 
 | Model | Media type | HuggingFace ID | Approx. size |
 |-------|-----------|----------------|-------------|
-| CLAP | Audio (default) | `laion/clap-htsat-unfused` | ~1.1 GB |
+| CLAP General | Audio (default) | `laion/larger_clap_general` | ~1.4 GB |
 | SigLIP | Image (default) | `google/siglip-base-patch16-224` | ~400 MB |
 | CLIP | Image (alternative) | `openai/clip-vit-base-patch32` | ~600 MB |
 | X-CLIP | Video (default) | `microsoft/xclip-base-patch32` | ~1.2 GB |
 | E5 | Text (default) | `intfloat/e5-base-v2` | ~440 MB |
 
-**Total: ~3.8 GB** for the five models `download_models.sh` fetches (four
+**Total: ~4.1 GB** for the five models `download_models.sh` fetches (four
 defaults plus CLIP, the image alternative). At runtime, only the embedders a
-dataset or detector actually uses are loaded.
+dataset or detector actually uses are loaded. The smaller
+`laion/clap-htsat-unfused` checkpoint (the `clap` embedder, ~1.1 GB) is *not*
+prefetched: it is an alternative now, so it downloads on first use like any
+other non-default embedder.
 
 #### Alternative embedders
 
@@ -430,7 +433,7 @@ Run the provided script on a machine with internet access:
 ./scripts/download_models.sh [CACHE_DIR]
 ```
 
-This downloads all five embedding models (CLAP, SigLIP, CLIP, X-CLIP, E5) to `CACHE_DIR` (defaults to
+This downloads all five embedding models (CLAP General, SigLIP, CLIP, X-CLIP, E5) to `CACHE_DIR` (defaults to
 `data/models`). The script prints instructions for offline use when
 finished.
 
@@ -509,8 +512,8 @@ automatically on first startup.
 
 ```
 data/
-├── models/                           # HuggingFace model cache (~3.8 GB total)
-│   ├── models--laion--clap-htsat-unfused/
+├── models/                           # HuggingFace model cache (~4.1 GB total)
+│   ├── models--laion--larger_clap_general/
 │   ├── models--google--siglip-base-patch16-224/
 │   ├── models--openai--clip-vit-base-patch32/
 │   ├── models--microsoft--xclip-base-patch32/

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -297,10 +297,10 @@ embedder per media type should override the `is_default` property to return
 
 | File (under `vtscore/media/`) | Class | Embedder | Media type | Default |
 |---|---|---|---|---|
-| `audio/embedder_clap.py` | `AudioClapEmbedder` | `clap` | `audio` | ✅ |
+| `audio/embedder_clap_general.py` | `AudioClapGeneralEmbedder` | `clap_general` | `audio` | ✅ |
 | `audio/embedder_ast.py` | `AudioASTEmbedder` | `ast` | `audio` |  |
 | `audio/embedder_beats.py` | `AudioBEATsEmbedder` | `beats` | `audio` |  |
-| `audio/embedder_clap_general.py` | `AudioClapGeneralEmbedder` | `clap_general` | `audio` |  |
+| `audio/embedder_clap.py` | `AudioClapEmbedder` | `clap` | `audio` |  |
 | `audio/embedder_clap_music.py` | `AudioClapMusicEmbedder` | `clap_music` | `audio` |  |
 | `audio/embedder_paraspeechclap.py` | `AudioParaSpeechClapEmbedder` | `paraspeechclap` | `audio` |  |
 | `audio/embedder_whisper.py` | `AudioWhisperEncoderEmbedder` | `whisper_encoder` | `audio` |  |

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -136,10 +136,10 @@ Each embedder produces fixed-size embedding vectors from a pretrained model. The
 
 | Media type | Embedder | Display name | Model | Dim | Notes |
 |---|---|---|---|---|---|
-| `audio` | `clap` | CLAP (general audio) | `laion/clap-htsat-unfused` | 512 | **default** for its media type |
+| `audio` | `clap_general` | CLAP (general, larger) | `laion/larger_clap_general` | 512 | **default** for its media type |
 | `audio` | `ast` | AST (audio spectrogram) | `MIT/ast-finetuned-audioset-10-10-0.4593` | 768 | no text queries |
 | `audio` | `beats` | BEATs (audio events) | `lpepino/beats_ckpts` | 768 | no text queries |
-| `audio` | `clap_general` | CLAP (general 2024) | `laion/larger_clap_general` | 512 | — |
+| `audio` | `clap` | CLAP (general, faster) | `laion/clap-htsat-unfused` | 512 | — |
 | `audio` | `clap_music` | CLAP (music) | `laion/larger_clap_music_and_speech` | 512 | — |
 | `audio` | `paraspeechclap` | ParaSpeechCLAP (speech style) | `ajd12342/paraspeechclap-combined` | 768 | — |
 | `audio` | `whisper_encoder` | Whisper encoder (speech) | `openai/whisper-base` | 512 | no text queries |

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -26,14 +26,14 @@ import sys
 cache_dir = sys.argv[1]
 
 # ------------------------------------------------------------------
-# 1. CLAP  (audio):  laion/clap-htsat-unfused
+# 1. CLAP General  (audio, default):  laion/larger_clap_general
 # ------------------------------------------------------------------
-print("\n[1/5] Downloading CLAP model (laion/clap-htsat-unfused) ...")
+print("\n[1/5] Downloading CLAP General model (laion/larger_clap_general) ...")
 from transformers import ClapModel, ClapProcessor
 
-ClapModel.from_pretrained("laion/clap-htsat-unfused", cache_dir=cache_dir)
-ClapProcessor.from_pretrained("laion/clap-htsat-unfused", cache_dir=cache_dir)
-print("  CLAP done.")
+ClapModel.from_pretrained("laion/larger_clap_general", cache_dir=cache_dir)
+ClapProcessor.from_pretrained("laion/larger_clap_general", cache_dir=cache_dir)
+print("  CLAP General done.")
 
 # ------------------------------------------------------------------
 # 2. SigLIP  (image, default):  google/siglip-base-patch16-224

--- a/scripts/experiments/pile/scan_vg_boxes.py
+++ b/scripts/experiments/pile/scan_vg_boxes.py
@@ -186,8 +186,10 @@ def main() -> int:
     for name, lo, hi in bands:
         pool = [c for c, s in stats.items() if lo <= s["voted_area"] < hi]
         clean = [c for c in pool if stats[c]["union_inflation"] <= 1.5]
-        log(f"  {name:14s} [{lo * 100:5.2f}%, {hi * 100:6.2f}%): {len(pool):5d} categories "
-            f"({len(clean)} with union_inflation <= 1.5)")
+        log(
+            f"  {name:14s} [{lo * 100:5.2f}%, {hi * 100:6.2f}%): {len(pool):5d} categories "
+            f"({len(clean)} with union_inflation <= 1.5)"
+        )
         example = sorted(pool, key=lambda c: -stats[c]["n_images"])[:8]
         log(f"      most-supported: {example}")
     return 0

--- a/tests/datasets/test_multi_dataset.py
+++ b/tests/datasets/test_multi_dataset.py
@@ -449,8 +449,8 @@ class TestMultiDatasetAPI:
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["ok"] is True
-        # The default audio embedder is registered in tests as "clap".
-        assert data["embedder"] == "clap"
+        # The default audio embedder is registered in tests as "clap_general".
+        assert data["embedder"] == "clap_general"
 
     def test_preload_embedder_unknown_dataset_returns_404(self, client):
         """Unknown dataset id is rejected with 404."""

--- a/tests/detectors/test_portable_export_route.py
+++ b/tests/detectors/test_portable_export_route.py
@@ -44,9 +44,9 @@ class TestPortableExport:
         assert manifest["format"] == "vtsearch-portable-detector"
         assert manifest["detector_name"] == "portable-export"
         # Audio test medias bind the default CLAP embedder (512-dim).
-        assert manifest["embedder"]["name"] == "clap"
+        assert manifest["embedder"]["name"] == "clap_general"
         # The exact HF checkpoint travels in the bundle so it's fully actionable.
-        assert manifest["embedder"]["model_id"] == "laion/clap-htsat-unfused"
+        assert manifest["embedder"]["model_id"] == "laion/larger_clap_general"
         assert manifest["embedder"]["embedding_dim"] == 512
         assert 0.0 <= manifest["scoring"]["threshold"] <= 1.0
         assert manifest["training_labels"] == {"good": 3, "bad": 3}

--- a/tests/detectors/test_portable_export_route.py
+++ b/tests/detectors/test_portable_export_route.py
@@ -13,6 +13,7 @@ import zipfile
 
 import app as app_module
 import pytest
+from tests.fixtures.medias import DEFAULT_AUDIO_EMBEDDER
 from tests.helpers import setup_trainable_model_in_registry
 from vtsearch.state import snapshot_medias
 
@@ -76,11 +77,14 @@ class TestPortableExport:
         det_data = _read_detector(_detector_path("portable-parity"))
         mlp, _threshold, _diag = resolve_or_train_detector(detector_id, det_data, "audio", snap)
         assert mlp is not None
-        live = {r["id"]: r["score"] for r in score_media_with_model(mlp, snap, embedder_name="clap")}
+        live = {
+            r["id"]: r["score"]
+            for r in score_media_with_model(mlp, snap, embedder_name=DEFAULT_AUDIO_EMBEDDER)
+        }
 
         # Re-embed the same medias and run them through the exported graph.
         ids = sorted(live)
-        x = np.stack([np.asarray(snap[i]["embeddings"]["clap"], dtype=np.float32) for i in ids])
+        x = np.stack([np.asarray(snap[i]["embeddings"][DEFAULT_AUDIO_EMBEDDER], dtype=np.float32) for i in ids])
         session = ort.InferenceSession(onnx_bytes)
         onnx_scores = session.run(["score"], {"embedding": x})[0].ravel()
         for i, s in zip(ids, onnx_scores, strict=True):
@@ -130,7 +134,7 @@ class TestPortableExport:
         import vtsearch.routes.detectors.scoring as scoring_mod
 
         monkeypatch.setattr(scoring_mod, "_dataset_supplies_detector_type", lambda *_a, **_kw: True)
-        monkeypatch.setattr(binding_mod, "keying_embedder_for_snap", lambda *_a, **_kw: "clap")
+        monkeypatch.setattr(binding_mod, "keying_embedder_for_snap", lambda *_a, **_kw: DEFAULT_AUDIO_EMBEDDER)
         detector_id = setup_trainable_model_in_registry(
             "portable-patch",
             good_ids=[1, 2, 3],

--- a/tests/detectors/test_portable_export_route.py
+++ b/tests/detectors/test_portable_export_route.py
@@ -77,10 +77,7 @@ class TestPortableExport:
         det_data = _read_detector(_detector_path("portable-parity"))
         mlp, _threshold, _diag = resolve_or_train_detector(detector_id, det_data, "audio", snap)
         assert mlp is not None
-        live = {
-            r["id"]: r["score"]
-            for r in score_media_with_model(mlp, snap, embedder_name=DEFAULT_AUDIO_EMBEDDER)
-        }
+        live = {r["id"]: r["score"] for r in score_media_with_model(mlp, snap, embedder_name=DEFAULT_AUDIO_EMBEDDER)}
 
         # Re-embed the same medias and run them through the exported graph.
         ids = sorted(live)

--- a/tests/detectors/test_workflow.py
+++ b/tests/detectors/test_workflow.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 
+from tests.fixtures.medias import DEFAULT_AUDIO_EMBEDDER
 from vtscore.detectors.workflow import apply_and_retrain
 from vtsearch.state import medias
 from vtscore.state.core import DetectorContext
@@ -112,7 +113,7 @@ class TestTraining:
         # training_medias cache should hold both voted media.
         assert set(det_ctx.training_medias) >= {1, 2}
         # embedder / media_type stamped from the snapshot.
-        assert det_ctx.embedder == "clap"
+        assert det_ctx.embedder == DEFAULT_AUDIO_EMBEDDER
         assert det_ctx.media_type == "audio"
 
 

--- a/tests/fixtures/medias.py
+++ b/tests/fixtures/medias.py
@@ -8,8 +8,15 @@ from vtscore.config import DATA_DIR
 
 NUM_MEDIAS = 20
 from vtscore.embedding import embed_audio_file
+from vtscore.media import embedders_for_type
 from vtsearch.state import medias
 from vtscore.utils.hashing import content_md5
+
+#: The audio media type's default embedder, resolved from the registry rather
+#: than hard-coded, so the generated medias stay bound to whatever the app
+#: would bind them to.  Tests that need the name read it from here (or from
+#: ``media["embedder"]``) instead of spelling a checkpoint slug out.
+DEFAULT_AUDIO_EMBEDDER = embedders_for_type("audio")[0].name
 
 
 def _worker_suffix():
@@ -62,12 +69,12 @@ def init_medias():
         medias[i] = {
             "id": i,
             "media_type": "audio",
-            "embedder": "clap",
+            "embedder": DEFAULT_AUDIO_EMBEDDER,
             "frequency": freq,
             "duration": duration,
             "file_size": len(wav_bytes),
             "md5": content_md5(wav_bytes),
-            "embeddings": {"clap": embedding},
+            "embeddings": {DEFAULT_AUDIO_EMBEDDER: embedding},
             "media_bytes": wav_bytes,
             "thumbnail_bytes": thumbnail,
             "filename": fname,

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -466,10 +466,10 @@ class TestAudioClapGeneralEmbedderProperties:
         d = emb.to_dict()
         assert d == {
             "name": "clap_general",
-            "display_name": "CLAP (general 2024)",
+            "display_name": "CLAP (general, larger)",
             "model_id": "laion/larger_clap_general",
             "media_type_id": "audio",
-            "is_default": False,
+            "is_default": True,
             "supports_text": True,
             "supports_patch_regions": False,
             "supports_geometric_verification": False,
@@ -624,7 +624,7 @@ class TestAudioParaSpeechClapEmbedderProperties:
         assert emb.supports_text is True
 
     def test_is_not_default(self):
-        """CLAP remains the default audio embedder; ParaSpeechCLAP is opt-in."""
+        """CLAP General is the default audio embedder; ParaSpeechCLAP is opt-in."""
         from vtscore.media.audio.embedder_paraspeechclap import AudioParaSpeechClapEmbedder
 
         emb = AudioParaSpeechClapEmbedder()
@@ -1225,6 +1225,40 @@ class TestAllEmbeddersRegistration:
         ordered = embedders_for_type("image")
         assert ordered[0].name == "siglip"
         assert ordered[0].is_default is True
+
+    def test_clap_general_is_the_default_audio_embedder(self):
+        """``clap_general`` beats ``clap`` on every measured ESC-50 metric, so
+        it is what ``embedders_for_type('audio')[0]`` hands back."""
+        from vtscore.media import embedders_for_type
+
+        ordered = embedders_for_type("audio")
+        assert ordered[0].name == "clap_general"
+        assert ordered[0].is_default is True
+
+    def test_clap_stays_available_as_the_cheap_tier(self):
+        """The smaller checkpoint is not the default any more but must keep
+        resolving: existing pickles and detector JSONs record ``embedder:
+        "clap"`` and would stop loading if it were dropped."""
+        from vtscore.media import get_embedder
+
+        emb = get_embedder("clap")
+        assert emb.name == "clap"
+        assert emb.is_default is False
+        assert emb.model_id == "laion/clap-htsat-unfused"
+
+    def test_the_two_general_clap_display_names_are_distinguishable(self):
+        """They used to read as "CLAP (general audio)" and "CLAP (general
+        2024)", which is not a choice a user can make in a picker."""
+        from vtscore.media import get_embedder
+
+        assert get_embedder("clap").display_name == "CLAP (general, faster)"
+        assert get_embedder("clap_general").display_name == "CLAP (general, larger)"
+
+    def test_exactly_one_default_audio_embedder(self):
+        from vtscore.media import embedders_for_type
+
+        defaults = [e.name for e in embedders_for_type("audio") if e.is_default]
+        assert defaults == ["clap_general"]
 
     def test_embedders_for_text(self):
         from vtscore.media import embedders_for_type

--- a/tests_lib/fixtures/medias.py
+++ b/tests_lib/fixtures/medias.py
@@ -8,8 +8,15 @@ from vtscore.config import DATA_DIR
 
 NUM_MEDIAS = 20
 from vtscore.embedding import embed_audio_file
+from vtscore.media import embedders_for_type
 from vtsearch.state import medias
 from vtscore.utils.hashing import content_md5
+
+#: The audio media type's default embedder, resolved from the registry rather
+#: than hard-coded, so the generated medias stay bound to whatever the app
+#: would bind them to.  Tests that need the name read it from here (or from
+#: ``media["embedder"]``) instead of spelling a checkpoint slug out.
+DEFAULT_AUDIO_EMBEDDER = embedders_for_type("audio")[0].name
 
 
 def _worker_suffix():
@@ -62,12 +69,12 @@ def init_medias():
         medias[i] = {
             "id": i,
             "media_type": "audio",
-            "embedder": "clap",
+            "embedder": DEFAULT_AUDIO_EMBEDDER,
             "frequency": freq,
             "duration": duration,
             "file_size": len(wav_bytes),
             "md5": content_md5(wav_bytes),
-            "embeddings": {"clap": embedding},
+            "embeddings": {DEFAULT_AUDIO_EMBEDDER: embedding},
             "media_bytes": wav_bytes,
             "thumbnail_bytes": thumbnail,
             "filename": fname,

--- a/tests_lib/projection/test_params.py
+++ b/tests_lib/projection/test_params.py
@@ -67,6 +67,10 @@ class TestResolveProjectionParams:
         params = resolve_projection_params(_ctx("clap"))
         assert (params.n_neighbors, params.min_dist) == (15, 0.10)
 
+    def test_default_audio_embedder_gets_the_same_tuned_pair(self):
+        params = resolve_projection_params(_ctx("clap_general"))
+        assert (params.n_neighbors, params.min_dist) == (15, 0.10)
+
     def test_untuned_embedder_falls_back_to_the_globals(self):
         params = resolve_projection_params(_ctx("siglip2"))
         assert params.n_neighbors == PROJECTION_N_NEIGHBORS

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -35,6 +35,21 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Changed
 
+- **`clap_general` is the default audio embedder**, replacing `clap`.
+  Measured on the full ESC-50 (2000 clips, all 50 categories),
+  `laion/larger_clap_general` wins every comparison against
+  `laion/clap-htsat-unfused`: text-sort mAP 0.869-0.895 vs 0.850-0.866,
+  learned-sort mean F1 0.523-0.564 vs 0.457-0.529, and leave-one-out 1-NN
+  accuracy 0.973 vs 0.958. `embedders_for_type("audio")[0]` and any caller
+  that passes `embedder=""`/`None` now resolve to `clap_general`.
+  `clap` is **not** removed - it stays a first-class explicit choice, ~2.1x
+  faster and ~20% smaller, and existing pickles and detector JSONs recording
+  `embedder: "clap"` keep resolving. Both are 512-d, so vectors from the two
+  are dimension-compatible but not interchangeable.
+- **The two general CLAP display names are now distinguishable.** `clap` reads
+  "CLAP (general, faster)" (was "CLAP (general audio)") and `clap_general`
+  reads "CLAP (general, larger)" (was "CLAP (general 2024)"); their progress
+  labels are "CLAP Fast" and "CLAP General".
 - **`fold_anchored_gmm_threshold` is the shipped decision threshold.** Per
   calibration fold, a semi-supervised 2-component mixture is fitted to that
   fold model's scores over the whole collection with the fold's *held-out*

--- a/vtscore/config.py
+++ b/vtscore/config.py
@@ -242,6 +242,7 @@ PROJECTION_MIN_DIST = 0.1
 # neighbourhood than the old global 15; large ``n_neighbors`` hurt every embedder.
 PROJECTION_DEFAULTS_BY_EMBEDDER: dict[str, tuple[int, float]] = {
     "clap": (15, 0.10),  # audio: flat separability peak across 10-30
+    "clap_general": (15, 0.10),  # same family, same flat audio peak
     "clip": (10, 0.05),  # image: the most n_neighbors-sensitive embedder
     "siglip": (10, 0.05),
     "siglip_l": (10, 0.05),

--- a/vtscore/docs/concepts.md
+++ b/vtscore/docs/concepts.md
@@ -84,10 +84,10 @@ declares it via its `embedding_dim` property):
 
 | Embedder | Media type | D |
 |---|---|---|
-| `clap` | `audio` (default) | 512 |
+| `clap_general` | `audio` (default) | 512 |
 | `ast` | `audio` | 768 |
 | `beats` | `audio` | 768 |
-| `clap_general` | `audio` | 512 |
+| `clap` | `audio` | 512 |
 | `clap_music` | `audio` | 512 |
 | `paraspeechclap` | `audio` | 768 |
 | `whisper_encoder` | `audio` | 512 |
@@ -222,8 +222,8 @@ embedding. Every concrete embedder subclasses `vtscore.media.MediaEmbedder`
 
 ```python
 class MediaEmbedder:
-    name: str                  # property - registry key, e.g. "clap"
-    display_name: str          # property - human label, e.g. "CLAP (general audio)"
+    name: str                  # property - registry key, e.g. "clap_general"
+    display_name: str          # property - human label, e.g. "CLAP (general, larger)"
     media_type_id: str         # property - "audio", "image", …
     supports_text: bool        # property - is there a text tower?
 

--- a/vtscore/docs/faq.md
+++ b/vtscore/docs/faq.md
@@ -178,10 +178,10 @@ Depends on the embedder — each one declares its dimensionality via the
 
 | Embedder | Media type | D |
 |---|---|---|
-| `clap` | `audio` (default) | 512 |
+| `clap_general` | `audio` (default) | 512 |
 | `ast` | `audio` | 768 |
 | `beats` | `audio` | 768 |
-| `clap_general` | `audio` | 512 |
+| `clap` | `audio` | 512 |
 | `clap_music` | `audio` | 512 |
 | `paraspeechclap` | `audio` | 768 |
 | `whisper_encoder` | `audio` | 512 |

--- a/vtscore/docs/packages/config.md
+++ b/vtscore/docs/packages/config.md
@@ -224,10 +224,10 @@ time. The actual download + load is lazy, driven by
 
 | Constant                       | Value                                                                                  | Notes                                                                                  |
 |--------------------------------|----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| `CLAP_MODEL_ID`                | `"laion/clap-htsat-unfused"`                                                           | Default audio embedder.                                                                |
+| `CLAP_MODEL_ID`                | `"laion/clap-htsat-unfused"`                                                           | Smaller/faster general CLAP; the `clap` embedder.                                      |
 | `CLAP_SAMPLE_RATE`             | `48000`                                                                                | Required input sample rate for the CLAP family.                                        |
 | `CLAP_MUSIC_MODEL_ID`          | `"laion/larger_clap_music_and_speech"`                                                 | CLAP variant for music + speech.                                                       |
-| `CLAP_GENERAL_MODEL_ID`        | `"laion/larger_clap_general"`                                                          | Larger general-purpose CLAP.                                                           |
+| `CLAP_GENERAL_MODEL_ID`        | `"laion/larger_clap_general"`                                                          | Larger general-purpose CLAP. **Default audio embedder.**                               |
 | `AST_MODEL_ID`                 | `"MIT/ast-finetuned-audioset-10-10-0.4593"`                                            | Audio Spectrogram Transformer. 16 kHz mono via `AST_SAMPLE_RATE`.                      |
 | `AST_SAMPLE_RATE`              | `16000`                                                                                |                                                                                        |
 | `BEATS_CHECKPOINT_REPO`        | `"lpepino/beats_ckpts"`                                                                | Hub mirror of the MIT-licensed BEATs release (no `transformers` implementation).       |

--- a/vtscore/docs/packages/media.md
+++ b/vtscore/docs/packages/media.md
@@ -349,7 +349,7 @@ Each lives under `vtscore/media/<type>/` and self-registers:
 
 | Type     | Folder                       | Default embedder                | Other embedders ship in-tree                            |
 |----------|------------------------------|---------------------------------|---------------------------------------------------------|
-| audio    | `vtscore/media/audio/`       | `clap` (`laion/clap-htsat-unfused`) | `clap_general`, `clap_music`, `beats`, `ast`, `whisper_encoder`, `paraspeechclap` |
+| audio    | `vtscore/media/audio/`       | `clap_general` (`laion/larger_clap_general`) | `clap`, `clap_music`, `beats`, `ast`, `whisper_encoder`, `paraspeechclap` |
 | image    | `vtscore/media/image/`       | `siglip` (`google/siglip-base-patch16-224`) | `clip`, `siglip2`, `siglip2_l`, `siglip_l`, `dinov2_single`, `dinov2_patch`, `dinov3_single`, `dinov3_patch`, `eupe_single`, `eupe_patch`, `face` |
 | text     | `vtscore/media/text/`        | `e5` (`intfloat/multilingual-e5-base`) | `bge`                                            |
 | video    | `vtscore/media/video/`       | `xclip` (`microsoft/xclip-base-patch32`) | `videomae`, `languagebind`                       |

--- a/vtscore/docs/quickstart.md
+++ b/vtscore/docs/quickstart.md
@@ -117,7 +117,7 @@ print(f"Loaded {len(medias)} audio items.")
 print(f"Embedder: {first['embedder']}")
 print(f"First embedding shape: {media_embedding(first).shape}")
 # Loaded 532 audio items.
-# Embedder: clap
+# Embedder: clap_general
 # First embedding shape: (512,)
 ```
 
@@ -136,9 +136,9 @@ medias[1]
 # {
 #   "id": 1,
 #   "media_type": "audio",
-#   "embedder": "clap",
+#   "embedder": "clap_general",
 #   "md5": "5d41402abc4b2a76b9719d911017c592",
-#   "embeddings": {"clap": np.ndarray(shape=(512,), dtype=float32)},
+#   "embeddings": {"clap_general": np.ndarray(shape=(512,), dtype=float32)},
 #   "filename": "bark/poodle.wav",
 #   "origin": {"importer": "server_folder",
 #              "params": {"path": "/data/audio-corpus", "media_type": "audio"}},
@@ -153,7 +153,7 @@ Note `embeddings` (plural): vectors live in a dict keyed by embedder name so
 several bound embedders can coexist on one media. There is no
 `media["embedding"]`. Always read through
 `media_embedding(media)` - it resolves the media's primary embedder - or
-`media_embedding(media, "clap")` for a specific one.
+`media_embedding(media, "clap_general")` for a specific one.
 
 ## 3. Train a detector from labels
 
@@ -287,7 +287,7 @@ save_detector("barks", labelset, media_type="audio")
 
 # Later, in a different process - reload and train.
 ctx = DetectorContext(detector_id="barks", name="barks",
-                      media_type="audio", embedder="clap")
+                      media_type="audio", embedder="clap_general")
 register_detector_context(ctx)
 
 # Build (good_origins, bad_origins) from the saved labelset's elements,

--- a/vtscore/docs/tutorials/train-and-score.md
+++ b/vtscore/docs/tutorials/train-and-score.md
@@ -101,11 +101,11 @@ What just happened:
 2. `load_dataset_from_folder` walked `AUDIO_FOLDER` and populated `medias`
    with one dict per file - md5, bytes/path, and the `origin` you passed -
    but **no vectors**. Loaders never call the embedder.
-3. `embed_missing` resolved the media type's default embedder (CLAP), ran
-   every item through it in one bulk call, and wrote the vectors into
-   `media["embeddings"]["clap"]`.
-4. CLAP downloaded its weights on first use to
-   `WORKDIR/models/` (about 600 MB; subsequent runs are instant).
+3. `embed_missing` resolved the media type's default embedder (CLAP
+   General), ran every item through it in one bulk call, and wrote the
+   vectors into `media["embeddings"]["clap_general"]`.
+4. CLAP General downloaded its weights on first use to
+   `WORKDIR/models/` (about 776 MB; subsequent runs are instant).
 
 The first call takes ~30s for model download and ~10s per 100 files
 for embedding. Once cached, the same call runs in seconds.
@@ -118,7 +118,7 @@ print({k: type(v).__name__ for k, v in sample.items()})
 # {'id': 'int', 'media_type': 'str', 'embedder': 'str', 'file_size': 'int',
 #  'md5': 'str', 'embeddings': 'dict', 'filename': 'str', ...}
 
-print(f"Embedder: {sample['embedder']}")                  # clap
+print(f"Embedder: {sample['embedder']}")                  # clap_general
 print(f"Embedding shape: {media_embedding(sample).shape}")  # (512,)
 print(f"Origin: {sample['origin']}")
 # {'importer': 'server_folder', 'params': {'path': '/data/esc50/audio', 'media_type': 'audio'}}
@@ -126,7 +126,7 @@ print(f"Origin: {sample['origin']}")
 
 The embedding is a 512-D float32 vector; LAION-CLAP's output
 dimensionality. It lives in the per-embedder `embeddings` dict (keyed
-`"clap"`), which is why every read goes through `media_embedding` - there
+`"clap_general"`), which is why every read goes through `media_embedding` - there
 is no `sample["embedding"]`.
 
 ## Step 2: Label a few items
@@ -299,7 +299,7 @@ ctx = DetectorContext(
     detector_id="dog-barks",
     name="dog-barks",
     media_type="audio",
-    embedder="clap",
+    embedder="clap_general",
 )
 register_detector_context(ctx)
 
@@ -310,7 +310,7 @@ saved_labelset = LabelSet.from_dict(load_detector("dog-barks")["labelset"])
 
 # Build (good_origins, bad_origins) from the saved labelset, then
 # resolve every origin to a file, embed each file *with the same embedder
-# the detector was trained with* (here: "clap"), and train. Passing
+# the detector was trained with* (here: "clap_general"), and train. Passing
 # ctx.embedder is critical - using "" would silently fall back to whatever
 # the media type's default embedder is, mixing model outputs.
 good_origins = [
@@ -430,8 +430,8 @@ By the end of the tutorial:
 
 - **`/tmp/vtscore-tutorial/detectors/dog-barks.json`** - your detector,
   six origins, no weights. ~1 KB.
-- **`/tmp/vtscore-tutorial/models/`** - cached LAION-CLAP weights. Reused
-  by every future detector with `embedder="clap"`. ~600 MB.
+- **`/tmp/vtscore-tutorial/models/`** - cached LAION-CLAP General weights.
+  Reused by every future detector with `embedder="clap_general"`. ~776 MB.
 - **`ctx.model`** + **`ctx.threshold`** - in-memory trained head, ready
   to score anything.
 

--- a/vtscore/media/audio/_clap_shared.py
+++ b/vtscore/media/audio/_clap_shared.py
@@ -4,15 +4,19 @@ VTSearch ships three CLAP audio embedders that share an identical
 architecture (LAION CLAP: a 512-dim audio encoder + a text encoder) and
 differ only in which pretrained checkpoint they load:
 
-- ``clap``          - ``laion/clap-htsat-unfused`` (the default baseline).
-- ``clap_general``  - ``laion/larger_clap_general`` (broader audio mix).
+- ``clap_general``  - ``laion/larger_clap_general`` (broader audio mix; the
+  default, and the stronger of the two general checkpoints on every measured
+  retrieval metric).
+- ``clap``          - ``laion/clap-htsat-unfused`` (the original baseline, kept
+  as the cheap tier: ~2.1x faster and ~20% smaller).
 - ``clap_music``    - ``laion/larger_clap_music_and_speech`` (music/speech).
 
 All three share this base; subclasses set :attr:`name`,
-:attr:`display_name`, :attr:`model_id`, and (for the baseline) override
-:attr:`is_default`.  The underscore-prefixed filename keeps it out of the
-auto-discovery scan in :mod:`vtscore.media` (only ``embedder*.py`` files
-are imported as plugins) - the variant modules import from here.
+:attr:`display_name`, :attr:`label`, :attr:`model_id`, and (for
+``clap_general``) override :attr:`is_default`.  The underscore-prefixed
+filename keeps it out of the auto-discovery scan in :mod:`vtscore.media`
+(only ``embedder*.py`` files are imported as plugins) - the variant modules
+import from here.
 """
 
 from __future__ import annotations

--- a/vtscore/media/audio/embedder_clap.py
+++ b/vtscore/media/audio/embedder_clap.py
@@ -1,4 +1,4 @@
-"""Audio embedder - CLAP (laion/clap-htsat-unfused)."""
+"""Audio embedder - CLAP (laion/clap-htsat-unfused), the cheap/fast tier."""
 
 from __future__ import annotations
 
@@ -11,6 +11,13 @@ class AudioClapEmbedder(_ClapBase):
 
     * Audio files → 512-dimensional vectors via CLAP's audio encoder.
     * Text queries → 512-dimensional vectors via CLAP's text encoder.
+
+    The smaller of the two general-purpose CLAP checkpoints (HTSAT 768-d
+    hidden, depths ``[2, 2, 6, 2]``, ~614 MB of weights).  It loses to
+    :class:`~vtscore.media.audio.embedder_clap_general.AudioClapGeneralEmbedder`
+    on every measured retrieval metric, but embeds roughly 2x faster for
+    ~20% less disk, which is why it stays available as the cheap tier
+    rather than being the default.
     """
 
     @property
@@ -19,19 +26,15 @@ class AudioClapEmbedder(_ClapBase):
 
     @property
     def display_name(self) -> str:
-        return "CLAP (general audio)"
+        return "CLAP (general, faster)"
 
     @property
     def label(self) -> str:
-        return "CLAP"
+        return "CLAP Fast"
 
     @property
     def model_id(self) -> str:
         return CLAP_MODEL_ID
-
-    @property
-    def is_default(self) -> bool:
-        return True
 
 
 EMBEDDER = AudioClapEmbedder()

--- a/vtscore/media/audio/embedder_clap_general.py
+++ b/vtscore/media/audio/embedder_clap_general.py
@@ -1,4 +1,4 @@
-"""Audio embedder - CLAP General 2024 (laion/larger_clap_general)."""
+"""Audio embedder - CLAP General (laion/larger_clap_general), the audio default."""
 
 from __future__ import annotations
 
@@ -12,9 +12,14 @@ class AudioClapGeneralEmbedder(_ClapBase):
     * Audio files → 512-dimensional vectors via CLAP's audio encoder.
     * Text queries → 512-dimensional vectors via CLAP's text encoder.
 
-    Compared to the original ``laion/clap-htsat-unfused`` baseline, this
-    larger general-purpose checkpoint is trained on a broader audio mix
-    and tends to give stronger zero-shot transfer for general sounds.
+    The default audio embedder.  Compared to the original
+    ``laion/clap-htsat-unfused`` baseline (still shipped as ``clap``), this
+    larger general-purpose checkpoint is trained on a broader audio mix and
+    wins every measured comparison on the full ESC-50: text-sort mAP 0.869-0.895
+    vs 0.850-0.866, learned-sort mean F1 0.523-0.564 vs 0.457-0.529, and
+    leave-one-out 1-NN accuracy 0.973 vs 0.958.  The cost is ~2.1x the embedding
+    time and ~776 MB of weights against ``clap``'s ~614 MB, so ``clap`` remains
+    the explicit cheap/fast choice.
     """
 
     @property
@@ -23,7 +28,7 @@ class AudioClapGeneralEmbedder(_ClapBase):
 
     @property
     def display_name(self) -> str:
-        return "CLAP (general 2024)"
+        return "CLAP (general, larger)"
 
     @property
     def label(self) -> str:
@@ -32,6 +37,10 @@ class AudioClapGeneralEmbedder(_ClapBase):
     @property
     def model_id(self) -> str:
         return CLAP_GENERAL_MODEL_ID
+
+    @property
+    def is_default(self) -> bool:
+        return True
 
 
 EMBEDDER = AudioClapGeneralEmbedder()

--- a/vtscore/media/audio/media_type.py
+++ b/vtscore/media/audio/media_type.py
@@ -293,7 +293,9 @@ def generate_waveform_thumbnail_from_file(file_path: Path, *, size: int = _THUMB
 class AudioMediaType(MediaType):
     """Handles audio medias - file import, HTTP serving, and demo datasets.
 
-    Embedding is handled by :class:`~vtscore.media.audio.embedder_clap.AudioClapEmbedder`.
+    Embedding is handled by
+    :class:`~vtscore.media.audio.embedder_clap_general.AudioClapGeneralEmbedder`
+    (the default) or any of the other registered audio embedders.
     """
 
     #: Audio renders a waveform PNG (``generate_waveform_thumbnail``), so it is


### PR DESCRIPTION
Closes #3077

## What

`is_default` moves from `clap` (`laion/clap-htsat-unfused`) to `clap_general` (`laion/larger_clap_general`). `clap` is **not** removed — it stays a first-class explicit choice, and both display names are rewritten so a user can tell them apart in the picker:

| Embedder | Display name (before → after) | Progress label |
|---|---|---|
| `clap_general` | "CLAP (general 2024)" → **"CLAP (general, larger)"** | `CLAP General` |
| `clap` | "CLAP (general audio)" → **"CLAP (general, faster)"** | `CLAP Fast` |

`clap` keeps resolving, so existing dataset pickles and detector JSONs that record `embedder: "clap"` load unchanged. Both checkpoints are 512-d.

## Why

Per the measurements in #3077 (full ESC-50, 2000 clips, all 50 categories), `clap_general` wins every comparison — text-sort mAP 0.869–0.895 vs 0.850–0.866, learned-sort mean F1 0.523–0.564 vs 0.457–0.529, leave-one-out 1-NN accuracy 0.973 vs 0.958. The cost is ~2.1× the embedding time and ~776 MB of weights against ~614 MB, which is exactly why `clap` stays available as the cheap tier rather than being deleted.

## Changes

- `vtscore/media/audio/embedder_clap.py` / `embedder_clap_general.py` — `is_default` moved, display names and labels rewritten, docstrings say which is which and why.
- `vtscore/config.py` — `PROJECTION_DEFAULTS_BY_EMBEDDER` gains a `clap_general` row copying the tuned audio pair `(15, 0.10)`. It is numerically the global default today, so this is behaviour-neutral; it exists so the sweep's audio finding travels with the *default* embedder if the globals ever move.
- `scripts/download_models.sh` — prefetches `laion/larger_clap_general` instead of `laion/clap-htsat-unfused` (it only pulls defaults).
- `tests/fixtures/medias.py` + `tests_lib/fixtures/medias.py` — the test medias hard-coded `embedder: "clap"`, which silently decoupled the fixture from the media-type default the moment the default moved. They now resolve it from the registry and expose it as `DEFAULT_AUDIO_EMBEDDER`; the handful of tests that need the slug read it from there. (Both copies stay byte-identical, per the tier-copy gate.)
- Tests — new assertions gating that `clap_general` is the sole audio default, that `clap` still resolves as a non-default, and that the two display names are distinguishable.
- Docs — generated inventories regenerated (`docs/ML.md`, `docs/ARCHITECTURE.md`, `docs/EXTENDING-media.md`, `vtscore/docs/concepts.md`, `vtscore/docs/faq.md`); hand-written `(default)` markers updated in `docs/DEPLOYMENT.md`, `vtscore/docs/packages/media.md`, `vtscore/docs/packages/config.md`, plus the quickstart/tutorial snippets that print the default-path embedder name.
- Changelogs — entries in both `CHANGELOG.md` and `vtscore/CHANGELOG.md`.

## Notes for reviewers

- **Cached demo pickles re-embed once.** `_try_load_cached` drops a cached demo pickle when the requested embedder differs from the cached one. The UI passes the resolved default explicitly, so every existing cached audio demo re-embeds on its next load — correct, but slower that one time, and ~2.1× slower per clip from then on. (A caller that passes `embedder=""` still accepts whatever is cached; only an explicit name triggers the mismatch.)
- **Offline prefetch size moves.** `download_models.sh` now pulls the larger checkpoint, so the pre-download total in `docs/DEPLOYMENT.md` goes from ~3.8 GB to ~4.1 GB. The smaller `clap` checkpoint is no longer prefetched — it downloads on first use like any other non-default embedder.
- **Enrichment follow-up filed as #3127.** Description enrichment helps `clap_general` (+0.012–0.016 mAP) and hurts `clap` (−0.005–0.014), and `enrich_descriptions` is a single global setting currently defaulting to `False`. Deciding whether to flip it needs its own measurement across every media type's default, so it is out of scope here.
- No screenshot reshoots are queued: the embedder picker is inside the collapsed Advanced block and no manifest shot expands it, so no captured PNG frames these display names.

## Testing

`./run-tests.sh` — all gates green, **8424 passed, 6 skipped**. `./run-tests.sh vtscore-clean` — **4206 passed** (the fixture's new import is library-tier). Also fixed a pre-existing `ruff format` drift in `scripts/experiments/pile/scan_vg_boxes.py` that was blocking the gate chain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3D29DAR1hRhThJ8NZ5yCx)_