### PR TITLE
Issue-label enforcement, and a `dev` label for fixed-but-not-yet-shipped

### DIFF
--- a/.claude/hooks/require-issue-labels.py
+++ b/.claude/hooks/require-issue-labels.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""PreToolUse gate: no Claude-filed GitHub issue lands without its labels.
+
+CLAUDE.md ("Label every issue you file") requires `claude` on every issue
+Claude creates, and `experiment` on any issue that cannot be closed without a
+measurement (a GRID/SLURM sweep, an eval arm, a calibration run).
+
+That rule used to be prose only, which made it unenforceable in two distinct
+ways -- and issue #3127 was filed unlabeled by hitting the first one:
+
+1. **Staleness.** The rule reached `dev` at 2026-08-12 19:29 UTC; #3127 was
+   filed at 17:17 UTC by a session whose checkout predated it by two hours.
+   Prose in CLAUDE.md can only bind a session that checked it out.
+2. **Attention.** CLAUDE.md is long, and a rule near the bottom competes with
+   everything else in the window on a session that has been running for hours.
+
+A hook is immune to both: it runs at tool-call time, from the checkout as of
+session start, and it does not need to be remembered.
+
+Contract: read the PreToolUse payload on stdin, exit 2 to block (stderr is fed
+back to Claude as the reason), exit 0 to allow. Anything unexpected -- a
+payload we cannot parse, a tool we do not police -- allows, because a hook that
+fails closed would wedge every unrelated GitHub call.
+
+Escape hatch for the `experiment` heuristic (see `_looks_like_an_experiment`):
+put `<!-- not-an-experiment: <reason> -->` in the issue body. It renders as
+nothing on GitHub, greps cleanly, and forces the reason to be stated rather
+than letting the check be dodged by rewording the body.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+TOOL_SUFFIX = "issue_write"
+
+OPT_OUT = re.compile(r"<!--\s*not-an-experiment\s*:", re.IGNORECASE)
+
+# One of these alone means the issue cannot be closed without machine time.
+# They are repo-specific enough that a false positive is a real surprise.
+STRONG_SIGNALS = [
+    r"vtscore\.eval",
+    r"scripts/experiments",
+    r"\bsbatch\b",
+    r"\bSLURM\b",
+    r"\bGRID\b",
+    r"\bCALIB_EXP\b",
+    r"\bmAP\b",
+    r"\bnDCG\b",
+    r"\beval arm\b",
+    r"\bsweeps?\b",
+    r"\bre-?measure",
+    r"\bre-?run the\b",
+]
+
+# Individually weak -- "measure" shows up in plenty of pure code changes -- so
+# two are required before the hook will block on them.
+WEAK_SIGNALS = [
+    r"\bcalibrat\w*",
+    r"\bmeasur\w*",
+    r"\bstud(?:y|ies)\b",
+    r"\bbaselines?\b",
+    r"\bbenchmarks?\b",
+    r"\bablations?\b",
+    r"\bexperiments?\b",
+    r"\barms?\b",
+    r"\brecall@",
+    r"\bprecision@",
+]
+
+
+def _read_payload() -> dict:
+    """Parse the PreToolUse payload, preferring stdin and falling back to env."""
+    raw = ""
+    if not sys.stdin.isatty():
+        raw = sys.stdin.read().strip()
+    if not raw:
+        raw = os.environ.get("TOOL_INPUT", "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _tool_input(payload: dict) -> dict | None:
+    """Return the issue_write arguments, or None if this is not our tool.
+
+    Handles both the nested envelope (`{"tool_name", "tool_input"}`) and a
+    bare arguments dict, since the two shapes have both been observed.
+    """
+    name = payload.get("tool_name") or payload.get("toolName") or ""
+    args = payload.get("tool_input") or payload.get("toolInput")
+    if isinstance(args, dict):
+        return args if name.endswith(TOOL_SUFFIX) else None
+    # Bare arguments: identify it by its own shape rather than by a tool name.
+    if "method" in payload and "repo" in payload:
+        return payload
+    return None
+
+
+def _looks_like_an_experiment(text: str) -> bool:
+    """Heuristic: does closing this issue require a run, not just an edit?"""
+    if any(re.search(p, text, re.IGNORECASE) for p in STRONG_SIGNALS):
+        return True
+    hits = sum(1 for p in WEAK_SIGNALS if re.search(p, text, re.IGNORECASE))
+    return hits >= 2
+
+
+def _problems(args: dict) -> list[str]:
+    labels = {str(item).strip().lower() for item in (args.get("labels") or [])}
+    body = str(args.get("body") or "")
+    found = []
+
+    if "claude" not in labels:
+        found.append(
+            "MISSING `claude`: you are filing this issue, so it is Claude-authored. "
+            "Claude and humans file through the same GitHub account, so this label is "
+            "the ONLY thing that keeps your issues out of the human-issue view "
+            "(`is:issue is:open -label:claude`). It is never optional."
+        )
+
+    if "experiment" not in labels and not OPT_OUT.search(body):
+        if _looks_like_an_experiment(f"{args.get('title') or ''}\n{body}"):
+            found.append(
+                "MISSING `experiment`: this reads like an issue nobody can close from a "
+                "laptop with the test suite -- it needs measured results first. Add the "
+                "label so it lands in the queue of work that needs machine time booked.\n"
+                "  If closing it genuinely needs no run, say so explicitly instead of "
+                "rewording the body: add `<!-- not-an-experiment: <reason> -->`."
+            )
+
+    return found
+
+
+def main() -> int:
+    args = _tool_input(_read_payload())
+    if args is None:
+        return 0
+    if str(args.get("method") or "").strip().lower() != "create":
+        return 0
+
+    found = _problems(args)
+    if not found:
+        return 0
+
+    print("BLOCKED: this issue is missing a required label (CLAUDE.md, 'Label every issue you file').", file=sys.stderr)
+    for problem in found:
+        print(f"\n  - {problem}", file=sys.stderr)
+    print(
+        "\nDecide BOTH labels now and re-issue the call, so this takes one round-trip:\n"
+        "  `claude`     -> always, on every issue you file.\n"
+        "  `experiment` -> only if it cannot be closed without a run (sweep, eval arm, calibration).",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/require-issue-labels.py
+++ b/.claude/hooks/require-issue-labels.py
@@ -139,7 +139,7 @@ def _close_problems(args: dict) -> list[str]:
 
     if DEV_LABEL in labels:
         return [
-            f"KEEPS `{DEV_LABEL}` ON A CLOSED ISSUE: `{DEV_LABEL}` means \"on `dev`, NOT on `main`\". "
+            f'KEEPS `{DEV_LABEL}` ON A CLOSED ISSUE: `{DEV_LABEL}` means "on `dev`, NOT on `main`". '
             "Closing this issue is the act of shipping it to `main`, so the label is now false. "
             "Drop it from the `labels` array."
         ]
@@ -147,7 +147,7 @@ def _close_problems(args: dict) -> list[str]:
     if raw is None and str(args.get("state_reason") or "").strip().lower() == "completed":
         return [
             f"CLOSE DOES NOT STRIP `{DEV_LABEL}`: a `completed` close ships the fix to `main`, so "
-            f"`{DEV_LABEL}` (\"on `dev`, NOT on `main`\") must come off in the same write.\n"
+            f'`{DEV_LABEL}` ("on `dev`, NOT on `main`") must come off in the same write.\n'
             "  Pass `labels` explicitly. NOTE: `labels` REPLACES the whole set, so list every label "
             f"the issue should keep (`claude`, `experiment`, ...) and simply omit `{DEV_LABEL}`. "
             "Read the issue first if you do not already know its labels -- passing `[]` would wipe them.\n"

--- a/.claude/hooks/require-issue-labels.py
+++ b/.claude/hooks/require-issue-labels.py
@@ -17,6 +17,10 @@ ways -- and issue #3127 was filed unlabeled by hitting the first one:
 A hook is immune to both: it runs at tool-call time, from the checkout as of
 session start, and it does not need to be remembered.
 
+The hook has a second job at the other end of an issue's life: the `dev` label
+(docs/RELEASE.md step 6) means "fixed on `dev`, NOT yet on `main`", so it must
+come off in the write that closes the issue. See `_close_problems`.
+
 Contract: read the PreToolUse payload on stdin, exit 2 to block (stderr is fed
 back to Claude as the reason), exit 0 to allow. Anything unexpected -- a
 payload we cannot parse, a tool we do not police -- allows, because a hook that
@@ -36,6 +40,8 @@ import re
 import sys
 
 TOOL_SUFFIX = "issue_write"
+
+DEV_LABEL = "dev"
 
 OPT_OUT = re.compile(r"<!--\s*not-an-experiment\s*:", re.IGNORECASE)
 
@@ -112,7 +118,46 @@ def _looks_like_an_experiment(text: str) -> bool:
     return hits >= 2
 
 
-def _problems(args: dict) -> list[str]:
+def _close_problems(args: dict) -> list[str]:
+    """Guard the `dev` label on a completing close (the docs/RELEASE.md step-6 sweep).
+
+    `dev` means "fixed on `dev`, NOT yet on `main`", so it must not survive the
+    close that ships the fix -- a closed issue still carrying it asserts
+    something false, and the awaiting-release view (`is:open label:dev`) is only
+    trustworthy if the strip is reliable.
+
+    The hook sees the call's arguments, never the issue's current state, so it
+    cannot check whether an issue *has* the label when `labels` is omitted.
+    What it can require is that a completing close states the label set
+    explicitly, which is the only form of the call that provably strips `dev`.
+    """
+    if str(args.get("state") or "").strip().lower() != "closed":
+        return []
+
+    raw = args.get("labels")
+    labels = {str(item).strip().lower() for item in (raw or [])}
+
+    if DEV_LABEL in labels:
+        return [
+            f"KEEPS `{DEV_LABEL}` ON A CLOSED ISSUE: `{DEV_LABEL}` means \"on `dev`, NOT on `main`\". "
+            "Closing this issue is the act of shipping it to `main`, so the label is now false. "
+            "Drop it from the `labels` array."
+        ]
+
+    if raw is None and str(args.get("state_reason") or "").strip().lower() == "completed":
+        return [
+            f"CLOSE DOES NOT STRIP `{DEV_LABEL}`: a `completed` close ships the fix to `main`, so "
+            f"`{DEV_LABEL}` (\"on `dev`, NOT on `main`\") must come off in the same write.\n"
+            "  Pass `labels` explicitly. NOTE: `labels` REPLACES the whole set, so list every label "
+            f"the issue should keep (`claude`, `experiment`, ...) and simply omit `{DEV_LABEL}`. "
+            "Read the issue first if you do not already know its labels -- passing `[]` would wipe them.\n"
+            f"  If the issue never had `{DEV_LABEL}`, passing its existing labels unchanged satisfies this."
+        ]
+
+    return []
+
+
+def _create_problems(args: dict) -> list[str]:
     labels = {str(item).strip().lower() for item in (args.get("labels") or [])}
     body = str(args.get("body") or "")
     found = []
@@ -138,26 +183,40 @@ def _problems(args: dict) -> list[str]:
     return found
 
 
+CREATE_FOOTER = (
+    "\nDecide BOTH labels now and re-issue the call, so this takes one round-trip:\n"
+    "  `claude`     -> always, on every issue you file.\n"
+    "  `experiment` -> only if it cannot be closed without a run (sweep, eval arm, calibration)."
+)
+
+CLOSE_FOOTER = (
+    "\nSee docs/RELEASE.md step 6. `dev` is a transient status, not a historical fact:\n"
+    "  it goes ON when the fix merges to `dev`, and comes OFF in the write that closes the issue."
+)
+
+
 def main() -> int:
     args = _tool_input(_read_payload())
     if args is None:
         return 0
-    if str(args.get("method") or "").strip().lower() != "create":
+
+    method = str(args.get("method") or "").strip().lower()
+    if method == "create":
+        found, footer = _create_problems(args), CREATE_FOOTER
+        headline = "BLOCKED: this issue is missing a required label (CLAUDE.md, 'Label every issue you file')."
+    elif method == "update":
+        found, footer = _close_problems(args), CLOSE_FOOTER
+        headline = f"BLOCKED: this close mishandles the `{DEV_LABEL}` label."
+    else:
         return 0
 
-    found = _problems(args)
     if not found:
         return 0
 
-    print("BLOCKED: this issue is missing a required label (CLAUDE.md, 'Label every issue you file').", file=sys.stderr)
+    print(headline, file=sys.stderr)
     for problem in found:
         print(f"\n  - {problem}", file=sys.stderr)
-    print(
-        "\nDecide BOTH labels now and re-issue the call, so this takes one round-trip:\n"
-        "  `claude`     -> always, on every issue you file.\n"
-        "  `experiment` -> only if it cannot be closed without a run (sweep, eval arm, calibration).",
-        file=sys.stderr,
-    )
+    print(footer, file=sys.stderr)
     return 2
 
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,15 @@
             "command": "if echo \"$TOOL_INPUT\" | grep -qE 'pytest|ng test|ng serve|npm run|npm test'; then bash ${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ensure-test-deps.sh; fi"
           }
         ]
+      },
+      {
+        "matcher": "mcp__github__issue_write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/require-issue-labels.py"
+          }
+        ]
       }
     ]
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ This is why closing an issue by hand didn't previously "trickle back": the item 
 
 **Every GitHub issue you create must carry the `claude` label**, and the `experiment` label when it applies. Apply them at creation time (`labels: ["claude", …]`), not as a follow-up edit. If a label is missing from the repo, applying it via the issues API creates it automatically — do not skip a label because it doesn't exist yet.
 
+A third label, **`dev`**, is a release *status* rather than something you choose when filing — it is applied and removed by the release machinery. Read its section below before closing any issue.
+
 ### `claude` — who filed it
 
 `claude` means **this issue was written by Claude, not by a human.** It is not a topic tag and has nothing to do with what the issue is about (nearly every issue here concerns Claude-adjacent work; that is never why the label goes on).
@@ -121,6 +123,27 @@ That asymmetry is the whole design. It only works if Claude is exhaustive: a Cla
 - It is orthogonal to `claude` — a human-filed research idea gets `experiment` alone; a Claude-filed sweep gets both.
 
 The point is scheduling: `label:experiment` is the queue of work that needs machine time booked, and `-label:experiment` is what can be picked up right now. See the `grid-experiments` skill for how those runs are actually launched.
+
+### `dev` — fixed on `dev`, not yet on `main`
+
+`dev` means **the fix has merged to `dev` but has not shipped to `main`.** Unlike `claude` and `experiment`, it is **not applied at creation time** and is never something you decide when filing — it is a *status* the release machinery maintains.
+
+It exists to make an otherwise invisible state visible. A fix PR targets `dev`, and GitHub only auto-closes a keyword-linked issue when the PR merges into the **default** branch (`main`), so a fixed issue stays open until the release sweep closes it. Without this label there is no way to tell "waiting for the next release" apart from "nobody has started it". The awaiting-release view is:
+
+```
+is:issue is:open label:dev
+```
+
+**The label is transient, not a historical fact.** It goes on when the fix merges to `dev`, and comes off in the same write that closes the issue (`docs/RELEASE.md` step 6). A closed issue must never carry it: by then the fix is on `main` too, so the label would assert something false, and a reopened issue would wrongly appear in the awaiting-release view. `is:open` already filters the closed pile for free, so letting it linger would buy nothing.
+
+Two rules bind you directly:
+
+- **Closing an issue strips `dev`.** Pass `labels` explicitly on a `completed` close. Note that `labels` *replaces* the whole set, so list every label the issue keeps (`claude`, `experiment`, …) and omit `dev` — passing `[]` would wipe the rest. A `PreToolUse` hook blocks a close that keeps the label or omits the array.
+- **Do not apply it by hand from a fix session.** When you open a fix PR the merge hasn't happened yet, so the issue is not on `dev` and labeling it would be a lie for as long as the PR sits unmerged. Applying it is `scripts/reconcile-dev-labels.py`'s job.
+
+That script encodes `docs/RELEASE.md` step 6's resolution logic — closing keywords vs. `Refs`, `Partially addressed in #M` vs. `Addressed in #M`, and the ambiguity of a comment posted *after* a fix pointer — and reconciles the label in both directions. It is a pure function from data to plan: the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but 403s, since GitHub access is intermediated by the MCP server), so gather the PR and issue data with the `github` MCP tools and pipe it in. See `docs/RELEASE.md` for the recipe.
+
+**A comment after the fix pointer is never guessed at.** If someone comments below an `Addressed in #M` pointer, the script reports the issue as needing review rather than tagging or skipping it. The later comment might be a maintainer saying "thanks" or the reporter saying the fix doesn't work; tagging would bury a dispute, and skipping would silently drop the issue out of the awaiting-release view. Ambiguity gets surfaced, not resolved by a coin flip.
 
 ## Recommend a Claude model in every issue you file
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -84,10 +84,39 @@ Anything else stays open — a genuinely partial `Refs` is doing its job.
 
 - Skip it if it is already closed. Never reopen or re-close.
 - Close it with `state_reason: completed`.
+- **Strip the `dev` label in the same write.** `dev` means "fixed on `dev`, NOT yet on `main`" (see CLAUDE.md), and this close is the moment that stops being true. Pass `labels` explicitly with every label the issue keeps (`claude`, `experiment`, …) minus `dev`; `labels` *replaces* the whole set, so passing `[]` would wipe the rest. A `PreToolUse` hook blocks a `completed` close that keeps `dev` or omits the array.
 - Add a one-line comment noting it shipped to `main` in today's release and linking the fix PR (e.g. `Shipped to main in the 2026-07-14 release — fixed
   in #M.`). When the PR used a non-closing keyword, say so in that comment, so the mislabel is visible on the issue rather than silently corrected.
 
 **Report the reconciliation in chat**, briefly: which issues came from the closing bucket, which were closed after reconciliation (and under which PR keyword), and which non-closing references were deliberately left open. This is the only place a crossed wire between a PR keyword and an issue comment becomes visible, so do not collapse it to a bare count. If no qualifying issues are found, state that and do nothing.
+
+## 6b. Refresh the `dev` label between releases
+
+Step 6 is what *removes* `dev`. What puts it on is `scripts/reconcile-dev-labels.py`, and that runs **between** releases, not only at one: the label's whole job is to make the awaiting-release view (`is:issue is:open label:dev`) correct while the release is still weeks away. Run it whenever you want that view refreshed, and once more right after step 6 to confirm nothing was left behind.
+
+The script is a pure function from data to plan — it does no network I/O, because the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but returns 403; GitHub access is intermediated by the MCP server). So gather the data first, then pipe it in:
+
+1. List the PRs merged into `dev` since the last release — the same `origin/main..origin/dev` window as step 3 — and read each one's **body**.
+2. List the repo's issues with their `labels` and `state`, and fetch each one's **comments** in chronological order (the API default).
+3. Assemble them into one JSON object and run the script:
+
+```json
+{
+  "release_prs": [{"number": 3128, "body": "... Closes #3077 ..."}],
+  "issues": [
+    {"number": 3077, "state": "open", "labels": ["claude"],
+     "comments": [{"body": "Addressed in #3128"}]}
+  ]
+}
+```
+
+```
+python scripts/reconcile-dev-labels.py --input plan-input.json
+```
+
+It prints four buckets. **Apply `ADD` and `REMOVE` directly** — they are unambiguous. **Do not apply `NEEDS REVIEW`**; read those issues yourself. An issue lands there when a fix pointer is not the newest comment, which is genuinely undecidable from the outside: the later comment may be a maintainer saying "thanks" or the reporter saying the fix does not work. Tagging would bury a dispute; skipping would silently drop the issue out of the awaiting-release view. That is the same "not silently skipped" principle step 6 applies to non-closing references.
+
+Add `--check` to make it exit non-zero when anything needs attention, and `--json` for machine-readable output.
 
 ## 7. Prune plan pointers for the closed issues
 

--- a/scripts/reconcile-dev-labels.py
+++ b/scripts/reconcile-dev-labels.py
@@ -72,6 +72,7 @@ COMMENT_POINTER = re.compile(
     re.IGNORECASE,
 )
 
+
 def _refs(pattern: re.Pattern[str], text: str) -> set[int]:
     return {int(m) for m in pattern.findall(text or "")}
 

--- a/scripts/reconcile-dev-labels.py
+++ b/scripts/reconcile-dev-labels.py
@@ -72,11 +72,6 @@ COMMENT_POINTER = re.compile(
     re.IGNORECASE,
 )
 
-# Any issue reference at all, used only to notice that a later comment is
-# talking about some other PR rather than re-pointing at the fix.
-ANY_REF = re.compile(r"#(\d+)")
-
-
 def _refs(pattern: re.Pattern[str], text: str) -> set[int]:
     return {int(m) for m in pattern.findall(text or "")}
 
@@ -123,8 +118,7 @@ def _pointer_verdict(issue: dict, release_numbers: set[int]) -> tuple[str, str] 
         return "resolved", f"newest comment points at #{pr_number}"
 
     return "review", (
-        f"pointer at #{pr_number} is followed by {len(trailing)} later comment(s); "
-        "check whether they dispute the fix"
+        f"pointer at #{pr_number} is followed by {len(trailing)} later comment(s); check whether they dispute the fix"
     )
 
 
@@ -147,7 +141,10 @@ def _classify(issue: dict, closers: dict[int, int], release_numbers: set[int]) -
     verdict = _pointer_verdict(issue, release_numbers)
     if verdict is None:
         if labelled:
-            return "review", "carries `dev` but no release PR or comment resolves it — stale, or fixed in an earlier release"
+            return (
+                "review",
+                "carries `dev` but no release PR or comment resolves it — stale, or fixed in an earlier release",
+            )
         return "none", "not resolved on dev"
 
     kind, detail = verdict

--- a/scripts/reconcile-dev-labels.py
+++ b/scripts/reconcile-dev-labels.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Decide which issues should carry the `dev` label, and which should lose it.
+
+`dev` means **fixed on `dev`, not yet on `main`** — the window between a fix
+merging and the release that ships it. Because a fix PR targets `dev`, GitHub
+never auto-closes its issue (that only happens on the default branch), so
+without this label there is no way to tell "waiting for release" apart from
+"nobody has started it". The awaiting-release view is:
+
+    is:issue is:open label:dev
+
+The label is **transient**: `docs/RELEASE.md` step 6 strips it in the same
+write that closes the issue. So it is a precise status at all times rather
+than a historical fact — a reopened issue is automatically clean, and a closed
+issue is not cluttered with a label that is true of every shipped fix.
+
+## Why this is a script and not a runbook paragraph
+
+The rule reuses step 6's own resolution logic, which is fiddly in exactly the
+ways prose hides: closing keywords must be told apart from `Refs`/`Part of`,
+`Partially addressed in #M` must not read as `Addressed in #M`, and a comment
+posted *after* a fix pointer may or may not dispute it. Getting any of those
+subtly wrong silently corrupts the awaiting-release view. Encoding it here
+makes it testable; see tests/core/test_reconcile_dev_labels.py.
+
+## Why it takes input instead of fetching
+
+The GitHub REST API is not reachable from a Claude session — `GITHUB_TOKEN` is
+present but unauthorized (403), because the session's GitHub access is
+intermediated by the MCP server. So this script is a pure function from data
+to plan, and whoever *does* hold credentials supplies the data:
+
+    # in a Claude session: gather via the github MCP tools, then
+    python scripts/reconcile-dev-labels.py --input plan-input.json
+
+    # on a machine with the gh CLI: see docs/RELEASE.md for the recipe
+    gh ... | python scripts/reconcile-dev-labels.py
+
+Input schema (unknown keys are ignored, so richer API payloads pipe in as-is):
+
+    {
+      "release_prs": [ {"number": 3128, "body": "... Closes #3077 ..."} ],
+      "issues": [
+        {"number": 3077, "state": "open", "labels": ["claude"],
+         "comments": [ {"body": "Addressed in #3128"} ]}
+      ]
+    }
+
+`release_prs` are the PRs merged into `dev` since the last release — the same
+`origin/main..origin/dev` window step 6 uses. `comments` must be in chronological
+order (oldest first), which is what the GitHub API returns by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+DEV_LABEL = "dev"
+
+# `Closes #12, closes #15` is the documented multi-issue form, so the keyword
+# is matched per-reference rather than once per line.
+CLOSING_REF = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]+#(\d+)", re.IGNORECASE)
+
+# A comment pointing at the fix PR, per CLAUDE.md's "Addressed in #M" rule.
+# `(?<!ly )` keeps "Partially addressed in #M" — the documented marker for
+# work that is NOT finished — from reading as a resolution.
+COMMENT_POINTER = re.compile(
+    r"(?<!ly )\b(?:addressed|fixed|resolved|shipped|handled)\s+(?:in|by)\s+#(\d+)",
+    re.IGNORECASE,
+)
+
+# Any issue reference at all, used only to notice that a later comment is
+# talking about some other PR rather than re-pointing at the fix.
+ANY_REF = re.compile(r"#(\d+)")
+
+
+def _refs(pattern: re.Pattern[str], text: str) -> set[int]:
+    return {int(m) for m in pattern.findall(text or "")}
+
+
+def closing_targets(release_prs: list[dict]) -> dict[int, int]:
+    """Map issue number -> PR number, for issues a release PR claims to close.
+
+    Only closing keywords count. `Refs #N` / `Part of #N` / a bare `#N` mean
+    work is still owed on that issue, so it is not resolved on `dev`.
+    """
+    targets: dict[int, int] = {}
+    for pr in release_prs:
+        for issue in _refs(CLOSING_REF, pr.get("body") or ""):
+            targets.setdefault(issue, pr.get("number"))
+    return targets
+
+
+def _pointer_verdict(issue: dict, release_numbers: set[int]) -> tuple[str, str] | None:
+    """Classify an issue's comments as a fix pointer, a disputed one, or neither.
+
+    Returns (verdict, detail) where verdict is "resolved" or "review", or None
+    when no comment points at a PR in this release at all.
+
+    The newest comment wins. A pointer that is *not* the newest comment is
+    ambiguous by construction: the later comment might be a maintainer saying
+    "thanks", or it might be the reporter saying the fix does not work. Guessing
+    either way is wrong -- silently tagging buries a dispute, silently skipping
+    drops the issue out of the awaiting-release view with no signal -- so the
+    ambiguous case is surfaced for a human instead.
+    """
+    comments = issue.get("comments") or []
+    hits = [
+        (i, pr)
+        for i, comment in enumerate(comments)
+        for pr in _refs(COMMENT_POINTER, comment.get("body") or "")
+        if pr in release_numbers
+    ]
+    if not hits:
+        return None
+
+    last_index, pr_number = hits[-1]
+    trailing = comments[last_index + 1 :]
+    if not trailing:
+        return "resolved", f"newest comment points at #{pr_number}"
+
+    return "review", (
+        f"pointer at #{pr_number} is followed by {len(trailing)} later comment(s); "
+        "check whether they dispute the fix"
+    )
+
+
+def _classify(issue: dict, closers: dict[int, int], release_numbers: set[int]) -> tuple[str, str]:
+    """Return (action, reason) for one issue. Action is add/remove/review/none."""
+    number = issue.get("number")
+    labelled = DEV_LABEL in {str(item).strip().lower() for item in (issue.get("labels") or [])}
+    is_open = str(issue.get("state") or "open").lower() == "open"
+
+    if not is_open:
+        if labelled:
+            return "remove", "issue is closed but still carries `dev` — the closing write did not strip it"
+        return "none", "closed, no label"
+
+    if number in closers:
+        if labelled:
+            return "none", f"already labelled; closed by #{closers[number]}"
+        return "add", f"#{closers[number]} claims `Closes #{number}`"
+
+    verdict = _pointer_verdict(issue, release_numbers)
+    if verdict is None:
+        if labelled:
+            return "review", "carries `dev` but no release PR or comment resolves it — stale, or fixed in an earlier release"
+        return "none", "not resolved on dev"
+
+    kind, detail = verdict
+    if kind == "review":
+        return "review", detail
+    return ("none", f"already labelled; {detail}") if labelled else ("add", detail)
+
+
+def reconcile(data: dict) -> dict[str, list[tuple[int, str]]]:
+    """Group every issue into add / remove / review / none, with a reason each."""
+    release_prs = data.get("release_prs") or []
+    closers = closing_targets(release_prs)
+    release_numbers = {pr.get("number") for pr in release_prs}
+
+    plan: dict[str, list[tuple[int, str]]] = {"add": [], "remove": [], "review": [], "none": []}
+    for issue in data.get("issues") or []:
+        action, reason = _classify(issue, closers, release_numbers)
+        plan[action].append((issue.get("number"), reason))
+    for bucket in plan.values():
+        bucket.sort()
+    return plan
+
+
+def render(plan: dict[str, list[tuple[int, str]]]) -> str:
+    headings = [
+        ("add", f"ADD `{DEV_LABEL}`"),
+        ("remove", f"REMOVE `{DEV_LABEL}`"),
+        ("review", "NEEDS REVIEW (ambiguous — do not guess)"),
+    ]
+    lines = ["", "dev-label reconciliation", "=" * 40]
+    for key, heading in headings:
+        entries = plan[key]
+        lines.append(f"\n{heading} ({len(entries)})")
+        if not entries:
+            lines.append("  (none)")
+        for number, reason in entries:
+            lines.append(f"  #{number}: {reason}")
+    lines.append(f"\nno change: {len(plan['none'])} issue(s)")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--input", help="JSON file to read (default: stdin)")
+    parser.add_argument("--json", action="store_true", help="emit the plan as JSON instead of text")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if any issue needs a label change or review (for use as a gate)",
+    )
+    args = parser.parse_args(argv)
+
+    raw = open(args.input, encoding="utf-8").read() if args.input else sys.stdin.read()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"error: input is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(data, dict):
+        print("error: input must be a JSON object with `release_prs` and `issues` keys", file=sys.stderr)
+        return 2
+
+    plan = reconcile(data)
+    if args.json:
+        print(json.dumps({k: [{"number": n, "reason": r} for n, r in v] for k, v in plan.items()}, indent=2))
+    else:
+        print(render(plan))
+
+    if args.check and (plan["add"] or plan["remove"] or plan["review"]):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/core/test_issue_label_hook.py
+++ b/tests/core/test_issue_label_hook.py
@@ -30,7 +30,7 @@ PLAIN_BODY = "The Back button in the importer modal is left-aligned but should u
 
 
 def run_hook(payload: dict) -> subprocess.CompletedProcess:
-    return subprocess.run(
+    return subprocess.run(  # noqa: S603  # interpreter + repo-local hook path, no shell
         [sys.executable, str(HOOK)],
         input=json.dumps(payload),
         capture_output=True,
@@ -131,7 +131,7 @@ class TestPassthrough:
         ids=["empty", "blank", "garbage", "list", "null", "string"],
     )
     def test_unparseable_payloads_allow(self, raw):
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603  # interpreter + repo-local hook path, no shell
             [sys.executable, str(HOOK)], input=raw, capture_output=True, text=True, timeout=30
         )
         assert result.returncode == ALLOW

--- a/tests/core/test_issue_label_hook.py
+++ b/tests/core/test_issue_label_hook.py
@@ -40,7 +40,7 @@ def run_hook(payload: dict) -> subprocess.CompletedProcess:
 
 
 def create(body: str = PLAIN_BODY, labels: list[str] | None = None, **overrides) -> dict:
-    args = {"method": "create", "owner": "samggreenberg", "repo": "vtsearch", "title": "A title", "body": body}
+    args: dict = {"method": "create", "owner": "samggreenberg", "repo": "vtsearch", "title": "A title", "body": body}
     if labels is not None:
         args["labels"] = labels
     args.update(overrides)

--- a/tests/core/test_issue_label_hook.py
+++ b/tests/core/test_issue_label_hook.py
@@ -164,7 +164,9 @@ class TestDevLabelOnClose:
 
     def test_create_path_rules_do_not_leak_onto_closes(self):
         """A close needs no `claude` label -- the issue may well be a human's."""
-        assert run_hook(self.close(state="closed", state_reason="completed", labels=["enhancement"])).returncode == ALLOW
+        assert (
+            run_hook(self.close(state="closed", state_reason="completed", labels=["enhancement"])).returncode == ALLOW
+        )
 
 
 class TestPassthrough:

--- a/tests/core/test_issue_label_hook.py
+++ b/tests/core/test_issue_label_hook.py
@@ -1,0 +1,156 @@
+"""Tests for the .claude/hooks/require-issue-labels.py PreToolUse gate.
+
+The hook enforces CLAUDE.md's "Label every issue you file" rule at tool-call
+time. It is the only mechanical check on that rule -- there is no CI, and
+`run-tests.sh` never sees a GitHub issue -- so its two failure directions both
+matter and are tested here:
+
+* a miss (allowing an unlabeled issue) silently contaminates the human-issue
+  view, which is the regression that produced issue #3127;
+* a false block (rejecting an unrelated GitHub call) would wedge ordinary work,
+  so every non-create, non-issue payload must pass straight through.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "require-issue-labels.py"
+
+ALLOW = 0
+BLOCK = 2
+
+# An experiment-shaped body: two weak signals ("calibration", "measure") and
+# no strong one, so it also covers the >=2-weak-signals branch.
+EXPERIMENT_BODY = "Re-run the calibration arm and measure mAP against the fold-anchored threshold."
+PLAIN_BODY = "The Back button in the importer modal is left-aligned but should use .back-btn."
+
+
+def run_hook(payload: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def create(body: str = PLAIN_BODY, labels: list[str] | None = None, **overrides) -> dict:
+    args = {"method": "create", "owner": "samggreenberg", "repo": "vtsearch", "title": "A title", "body": body}
+    if labels is not None:
+        args["labels"] = labels
+    args.update(overrides)
+    return {"tool_name": "mcp__github__issue_write", "tool_input": args}
+
+
+class TestClaudeLabel:
+    """`claude` is mechanically decidable: Claude is making the call."""
+
+    def test_create_without_any_labels_is_blocked(self):
+        result = run_hook(create())
+        assert result.returncode == BLOCK
+        assert "MISSING `claude`" in result.stderr
+
+    def test_create_with_unrelated_labels_is_blocked(self):
+        result = run_hook(create(labels=["bug", "enhancement"]))
+        assert result.returncode == BLOCK
+        assert "MISSING `claude`" in result.stderr
+
+    def test_create_with_claude_label_is_allowed(self):
+        assert run_hook(create(labels=["claude"])).returncode == ALLOW
+
+    def test_label_matching_is_case_and_whitespace_insensitive(self):
+        assert run_hook(create(labels=[" Claude "])).returncode == ALLOW
+
+
+class TestExperimentLabel:
+    """`experiment` is a judgment call, so the hook blocks heuristically."""
+
+    def test_experiment_shaped_body_without_the_label_is_blocked(self):
+        result = run_hook(create(body=EXPERIMENT_BODY, labels=["claude"]))
+        assert result.returncode == BLOCK
+        assert "MISSING `experiment`" in result.stderr
+        assert "MISSING `claude`" not in result.stderr
+
+    def test_a_single_strong_signal_is_enough(self):
+        body = "Add a new arm to `python -m vtscore.eval` for the region-voting path."
+        result = run_hook(create(body=body, labels=["claude"]))
+        assert result.returncode == BLOCK
+        assert "MISSING `experiment`" in result.stderr
+
+    def test_experiment_shaped_body_with_the_label_is_allowed(self):
+        assert run_hook(create(body=EXPERIMENT_BODY, labels=["claude", "experiment"])).returncode == ALLOW
+
+    def test_the_heuristic_reads_the_title_too(self):
+        result = run_hook(create(title="Re-run the GRID sweep", body=PLAIN_BODY, labels=["claude"]))
+        assert result.returncode == BLOCK
+        assert "MISSING `experiment`" in result.stderr
+
+    def test_a_single_weak_signal_does_not_block(self):
+        body = "The progress bar should measure elapsed time, not step count."
+        assert run_hook(create(body=body, labels=["claude"])).returncode == ALLOW
+
+    def test_opt_out_marker_releases_the_heuristic(self):
+        body = f"{EXPERIMENT_BODY}\n\n<!-- not-an-experiment: the numbers already exist in #3077 -->"
+        assert run_hook(create(body=body, labels=["claude"])).returncode == ALLOW
+
+    def test_opt_out_marker_does_not_release_the_claude_label(self):
+        body = f"{EXPERIMENT_BODY}\n\n<!-- not-an-experiment: already measured -->"
+        result = run_hook(create(body=body))
+        assert result.returncode == BLOCK
+        assert "MISSING `claude`" in result.stderr
+
+    def test_both_problems_are_reported_together(self):
+        """One round-trip must be enough to fix both labels."""
+        result = run_hook(create(body=EXPERIMENT_BODY))
+        assert result.returncode == BLOCK
+        assert "MISSING `claude`" in result.stderr
+        assert "MISSING `experiment`" in result.stderr
+
+
+class TestPassthrough:
+    """A hook that fails closed would wedge unrelated GitHub work."""
+
+    def test_updates_are_never_blocked(self):
+        """Relabeling an existing issue -- including a human's -- must pass."""
+        payload = create(body=EXPERIMENT_BODY, method="update", issue_number=3127)
+        payload["tool_input"].pop("labels", None)
+        assert run_hook(payload).returncode == ALLOW
+
+    def test_other_tools_are_ignored(self):
+        payload = {"tool_name": "mcp__github__create_pull_request", "tool_input": {"method": "create", "repo": "x"}}
+        assert run_hook(payload).returncode == ALLOW
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["", "   ", "not json at all", "[]", "null", '"a string"'],
+        ids=["empty", "blank", "garbage", "list", "null", "string"],
+    )
+    def test_unparseable_payloads_allow(self, raw):
+        result = subprocess.run(
+            [sys.executable, str(HOOK)], input=raw, capture_output=True, text=True, timeout=30
+        )
+        assert result.returncode == ALLOW
+
+    def test_bare_argument_payload_is_still_policed(self):
+        """Some harness versions pass the arguments dict without an envelope."""
+        result = run_hook({"method": "create", "owner": "samggreenberg", "repo": "vtsearch", "body": PLAIN_BODY})
+        assert result.returncode == BLOCK
+        assert "MISSING `claude`" in result.stderr
+
+
+class TestWiring:
+    """The hook is inert unless settings.json actually points at it."""
+
+    def test_hook_file_exists(self):
+        assert HOOK.is_file()
+
+    def test_registered_as_a_pretooluse_hook_for_issue_write(self):
+        settings = json.loads((HOOK.parents[1] / "settings.json").read_text())
+        matchers = settings["hooks"]["PreToolUse"]
+        entry = next(h for h in matchers if h["matcher"] == "mcp__github__issue_write")
+        assert any(HOOK.name in hook["command"] for hook in entry["hooks"])

--- a/tests/core/test_issue_label_hook.py
+++ b/tests/core/test_issue_label_hook.py
@@ -112,12 +112,77 @@ class TestExperimentLabel:
         assert "MISSING `experiment`" in result.stderr
 
 
+class TestDevLabelOnClose:
+    """`dev` means "on `dev`, NOT on `main`", so a close must strip it.
+
+    The hook only ever sees the call's arguments, never the issue's current
+    state, so the enforceable form is "a completing close must state its label
+    set explicitly" -- that being the only shape of the call that provably
+    strips the label.
+    """
+
+    @staticmethod
+    def close(**overrides) -> dict:
+        args = {"method": "update", "owner": "samggreenberg", "repo": "vtsearch", "issue_number": 3077}
+        args.update(overrides)
+        return {"tool_name": "mcp__github__issue_write", "tool_input": args}
+
+    def test_completed_close_carrying_dev_is_blocked(self):
+        result = run_hook(self.close(state="closed", state_reason="completed", labels=["claude", "dev"]))
+        assert result.returncode == BLOCK
+        assert "KEEPS `dev` ON A CLOSED ISSUE" in result.stderr
+
+    def test_completed_close_without_explicit_labels_is_blocked(self):
+        result = run_hook(self.close(state="closed", state_reason="completed"))
+        assert result.returncode == BLOCK
+        assert "CLOSE DOES NOT STRIP `dev`" in result.stderr
+
+    def test_the_denial_warns_that_labels_replaces_the_whole_set(self):
+        """Passing `[]` to satisfy the hook would silently wipe `claude`."""
+        result = run_hook(self.close(state="closed", state_reason="completed"))
+        assert "REPLACES the whole set" in result.stderr
+
+    def test_completed_close_with_labels_minus_dev_is_allowed(self):
+        assert run_hook(self.close(state="closed", state_reason="completed", labels=["claude"])).returncode == ALLOW
+
+    def test_an_issue_with_no_labels_left_can_still_be_closed(self):
+        assert run_hook(self.close(state="closed", state_reason="completed", labels=[])).returncode == ALLOW
+
+    def test_dev_is_blocked_on_any_close_not_just_completed(self):
+        """A not_planned close carrying `dev` is just as false a statement."""
+        result = run_hook(self.close(state="closed", state_reason="not_planned", labels=["claude", "dev"]))
+        assert result.returncode == BLOCK
+        assert "KEEPS `dev` ON A CLOSED ISSUE" in result.stderr
+
+    def test_non_completed_close_does_not_require_explicit_labels(self):
+        """Only the release sweep must strip; a not_planned close need not restate labels."""
+        assert run_hook(self.close(state="closed", state_reason="not_planned")).returncode == ALLOW
+
+    def test_dev_label_matching_is_case_insensitive(self):
+        result = run_hook(self.close(state="closed", state_reason="completed", labels=["claude", "DEV"]))
+        assert result.returncode == BLOCK
+
+    def test_create_path_rules_do_not_leak_onto_closes(self):
+        """A close needs no `claude` label -- the issue may well be a human's."""
+        assert run_hook(self.close(state="closed", state_reason="completed", labels=["enhancement"])).returncode == ALLOW
+
+
 class TestPassthrough:
     """A hook that fails closed would wedge unrelated GitHub work."""
 
-    def test_updates_are_never_blocked(self):
-        """Relabeling an existing issue -- including a human's -- must pass."""
+    def test_non_close_updates_are_never_blocked(self):
+        """Relabeling an existing issue -- including a human's -- must pass.
+
+        Only a *close* is policed on the update path; an edit that does not
+        touch `state` is none of the hook's business, and the create-path
+        label rules must not leak onto it.
+        """
         payload = create(body=EXPERIMENT_BODY, method="update", issue_number=3127)
+        payload["tool_input"].pop("labels", None)
+        assert run_hook(payload).returncode == ALLOW
+
+    def test_reopening_is_not_policed(self):
+        payload = create(method="update", issue_number=3127, state="open")
         payload["tool_input"].pop("labels", None)
         assert run_hook(payload).returncode == ALLOW
 

--- a/tests/core/test_reconcile_dev_labels.py
+++ b/tests/core/test_reconcile_dev_labels.py
@@ -1,0 +1,210 @@
+"""Tests for scripts/reconcile-dev-labels.py.
+
+The script decides which open issues are "fixed on `dev`, not yet on `main`"
+and therefore carry the `dev` label. It reuses docs/RELEASE.md step 6's
+resolution logic, whose sharp edges are the point of testing it:
+
+* a closing keyword means resolved; `Refs` / `Part of` / a bare `#N` do not;
+* `Partially addressed in #M` is the documented marker for work still owed,
+  and must not read as `Addressed in #M`;
+* a comment posted *after* a fix pointer is ambiguous -- it may be chatter or
+  a dispute -- and the script must surface it rather than guess either way.
+
+Getting any of these wrong corrupts the awaiting-release view silently, which
+is exactly the failure mode the script exists to prevent.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "reconcile-dev-labels.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("reconcile_dev_labels", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+
+def issue(number: int, *, state: str = "open", labels: list[str] | None = None, comments: list[str] | None = None):
+    return {
+        "number": number,
+        "state": state,
+        "labels": labels or [],
+        "comments": [{"body": body} for body in (comments or [])],
+    }
+
+
+def plan_for(prs: list[dict], issues: list[dict]) -> dict[str, dict[int, str]]:
+    """Reconcile, then flatten each bucket to {issue number: reason}."""
+    raw = mod.reconcile({"release_prs": prs, "issues": issues})
+    return {action: {number: reason for number, reason in entries} for action, entries in raw.items()}
+
+
+class TestClosingKeywords:
+    """Only a closing keyword means the issue is finished on `dev`."""
+
+    @pytest.mark.parametrize("keyword", ["Closes", "closes", "Fixes", "fixed", "Resolves", "RESOLVED"])
+    def test_closing_keywords_resolve(self, keyword):
+        prs = [{"number": 3128, "body": f"Some work.\n\n{keyword} #3077"}]
+        assert 3077 in plan_for(prs, [issue(3077)])["add"]
+
+    @pytest.mark.parametrize("keyword", ["Refs", "Part of", "See", "Related to"])
+    def test_non_closing_keywords_do_not_resolve(self, keyword):
+        """A genuine `Refs` is doing its job: work is still owed on that issue."""
+        prs = [{"number": 3128, "body": f"{keyword} #3077"}]
+        assert 3077 in plan_for(prs, [issue(3077)])["none"]
+
+    def test_bare_mention_does_not_resolve(self):
+        prs = [{"number": 3128, "body": "Follow-up to #3077 (its 'watch out for' note)."}]
+        assert 3077 in plan_for(prs, [issue(3077)])["none"]
+
+    def test_multiple_issues_in_one_body_each_resolve(self):
+        """CLAUDE.md mandates one keyword per issue, not a comma-list."""
+        prs = [{"number": 3128, "body": "Closes #12, closes #15"}]
+        result = plan_for(prs, [issue(12), issue(15)])
+        assert set(result["add"]) == {12, 15}
+
+    def test_already_labelled_issue_needs_no_change(self):
+        prs = [{"number": 3128, "body": "Closes #3077"}]
+        assert 3077 in plan_for(prs, [issue(3077, labels=["claude", "dev"])])["none"]
+
+    def test_the_reason_names_the_pr(self):
+        prs = [{"number": 3128, "body": "Closes #3077"}]
+        assert "#3128" in plan_for(prs, [issue(3077)])["add"][3077]
+
+
+class TestCommentPointers:
+    """The orphan backstop: a PR that under-claimed, caught via issue comments."""
+
+    PRS = [{"number": 3128, "body": "Refs #3077"}]
+
+    def test_addressed_in_pointer_resolves(self):
+        result = plan_for(self.PRS, [issue(3077, comments=["Addressed in #3128"])])
+        assert 3077 in result["add"]
+
+    def test_partially_addressed_does_not_resolve(self):
+        """CLAUDE.md's marker for work still owed must not read as resolution."""
+        comment = "Partially addressed in #3128 — still open: the video arm."
+        assert 3077 in plan_for(self.PRS, [issue(3077, comments=[comment])])["none"]
+
+    def test_pointer_at_a_pr_outside_the_release_does_not_resolve(self):
+        """A fix shipped in an earlier release is already on `main`."""
+        assert 3077 in plan_for(self.PRS, [issue(3077, comments=["Addressed in #2001"])])["none"]
+
+    def test_issue_with_no_comments_is_untouched(self):
+        assert 3077 in plan_for(self.PRS, [issue(3077)])["none"]
+
+
+class TestMostRecentCommentRule:
+    """A comment after the pointer is ambiguous, so it is surfaced, not guessed."""
+
+    PRS = [{"number": 3128, "body": "Refs #3077"}]
+
+    def test_pointer_as_newest_comment_resolves(self):
+        comments = ["I'll take a look.", "Addressed in #3128"]
+        assert 3077 in plan_for(self.PRS, [issue(3077, comments=comments)])["add"]
+
+    def test_a_comment_after_the_pointer_flags_for_review(self):
+        """The dispute case: the reporter says it is not actually fixed."""
+        comments = ["Addressed in #3128", "This didn't actually fix it — still repros on audio."]
+        result = plan_for(self.PRS, [issue(3077, comments=comments)])
+        assert 3077 in result["review"]
+        assert 3077 not in result["add"]
+
+    def test_harmless_chatter_also_flags_rather_than_vanishing_the_issue(self):
+        """The false-negative case a strict newest-comment rule would hide."""
+        result = plan_for(self.PRS, [issue(3077, comments=["Addressed in #3128", "Thanks!"])])
+        assert 3077 in result["review"]
+        assert 3077 not in result["none"]
+
+    def test_the_review_reason_says_how_many_comments_followed(self):
+        comments = ["Addressed in #3128", "Thanks!", "Confirmed."]
+        assert "2 later comment" in plan_for(self.PRS, [issue(3077, comments=comments)])["review"][3077]
+
+    def test_a_later_re_pointer_wins(self):
+        """Fixed, disputed, then fixed again: the newest pointer is the truth."""
+        comments = ["Addressed in #3128", "Reopening, still broken.", "Addressed in #3128 (take two)"]
+        assert 3077 in plan_for(self.PRS, [issue(3077, comments=comments)])["add"]
+
+    def test_a_closing_pr_body_beats_a_disputed_comment_thread(self):
+        """An explicit `Closes` in the PR is a stronger claim than comment order."""
+        prs = [{"number": 3128, "body": "Closes #3077"}]
+        comments = ["Addressed in #3128", "Thanks!"]
+        assert 3077 in plan_for(prs, [issue(3077, comments=comments)])["add"]
+
+
+class TestRemovalAndStaleness:
+    """The label is transient, so the script reconciles in both directions."""
+
+    def test_closed_issue_still_carrying_dev_is_flagged_for_removal(self):
+        prs = [{"number": 3128, "body": "Closes #3077"}]
+        result = plan_for(prs, [issue(3077, state="closed", labels=["claude", "dev"])])
+        assert 3077 in result["remove"]
+
+    def test_closed_issue_without_the_label_needs_no_change(self):
+        assert 3077 in plan_for([], [issue(3077, state="closed", labels=["claude"])])["none"]
+
+    def test_open_issue_labelled_but_unresolved_is_flagged_for_review(self):
+        """Stale from a prior release, or the label was applied by hand in error."""
+        assert 3077 in plan_for([], [issue(3077, labels=["dev"])])["review"]
+
+    def test_dev_label_matching_is_case_insensitive(self):
+        prs = [{"number": 3128, "body": "Closes #3077"}]
+        assert 3077 in plan_for(prs, [issue(3077, labels=["DEV"])])["none"]
+
+
+class TestCommandLine:
+    def run(self, data: dict, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(  # noqa: S603  # interpreter + repo-local script path, no shell
+            [sys.executable, str(SCRIPT), *args],
+            input=json.dumps(data),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    RESOLVED = {"release_prs": [{"number": 3128, "body": "Closes #3077"}], "issues": [issue(3077)]}
+
+    def test_reads_stdin_and_reports(self):
+        result = self.run(self.RESOLVED)
+        assert result.returncode == 0
+        assert "#3077" in result.stdout
+
+    def test_check_exits_nonzero_on_drift(self):
+        assert self.run(self.RESOLVED, "--check").returncode == 1
+
+    def test_check_exits_zero_when_settled(self):
+        settled = {"release_prs": [], "issues": [issue(3077, labels=["claude"])]}
+        assert self.run(settled, "--check").returncode == 0
+
+    def test_json_output_is_machine_readable(self):
+        payload = json.loads(self.run(self.RESOLVED, "--json").stdout)
+        assert payload["add"] == [{"number": 3077, "reason": payload["add"][0]["reason"]}]
+        assert "#3128" in payload["add"][0]["reason"]
+
+    def test_invalid_json_is_rejected_with_a_clear_error(self):
+        result = subprocess.run(  # noqa: S603  # interpreter + repo-local script path, no shell
+            [sys.executable, str(SCRIPT)], input="not json", capture_output=True, text=True, timeout=30
+        )
+        assert result.returncode == 2
+        assert "not valid JSON" in result.stderr
+
+    def test_non_object_input_is_rejected(self):
+        result = subprocess.run(  # noqa: S603  # interpreter + repo-local script path, no shell
+            [sys.executable, str(SCRIPT)], input="[]", capture_output=True, text=True, timeout=30
+        )
+        assert result.returncode == 2
+
+    def test_empty_input_is_not_an_error(self):
+        assert self.run({}).returncode == 0


### PR DESCRIPTION
Two related pieces of issue-label hygiene: a hook that stops labels being forgotten at issue *creation*, and a new `dev` label that makes the fixed-on-`dev`-but-not-yet-released state visible.

---

# Part 1 — Enforce the `claude` / `experiment` labels

## Why

Issue #3127 was filed by Claude carrying neither label. It is now relabeled with both (it re-measures `enrich_descriptions` via `vtscore.eval`, so it cannot be closed without a run).

**The cause was a staleness race, not negligence:**

| | UTC |
|---|---|
| Label rule authored (on branch `claude/issue-labels-tags-9zico9`) | 2026-08-12 16:35 |
| **#3127 filed** | **2026-08-12 17:17** |
| Rule merged to `dev` (#3126) | 2026-08-12 19:29 |

The session that filed #3127 was the #3077 follow-up work (later merged as #3128). Its checkout predated the labeling rule by more than two hours, so it could not have known the rule existed.

That race exposes the general problem. The rule lived only as prose in `CLAUDE.md`, which binds a session only if that session checked the rule out **and** still has it in view. Neither holds reliably, and no gate could catch the miss: `run-tests.sh` never sees a GitHub issue.

## What

A `PreToolUse` hook on `mcp__github__issue_write` that blocks `create` when labels are missing. It runs at tool-call time and needs no remembering, so it is immune to both the staleness and the attention failure modes.

- **`claude`** — mechanically decidable (Claude is the one making the call), so it is always required.
- **`experiment`** — a judgment call, so it is enforced heuristically: one strong repo-specific signal (`vtscore.eval`, `sbatch`, `SLURM`, `mAP`, `sweep`, …) or two weak ones (`measure`, `calibrat*`, `baseline`, …). A single weak signal does not block.

Because a heuristic can be wrong, the body may carry an explicit `<!-- not-an-experiment: <reason> -->` marker. That keeps the escape hatch honest — the reason gets stated and greps cleanly — rather than inviting the body to be reworded around the keywords.

Both problems are reported in a single denial, so one round-trip fixes both labels.

---

# Part 2 — The `dev` label

## Why

A fix PR targets `dev`, and GitHub only auto-closes a keyword-linked issue when the PR merges into the **default** branch (`main`). So a fixed issue stays open until the release sweep closes it, and nothing distinguished *"waiting for the next release"* from *"nobody has started it"*. Now:

```
is:issue is:open label:dev
```

## Transient, not a historical fact

The label goes on when the fix merges to `dev`, and comes off in the same write that closes the issue (`docs/RELEASE.md` step 6).

Sticky semantics ("is on dev", never removed) would have served the primary query equally well — `is:open` filters the closed pile for free — but would leave a **reopened** issue asserting something false, and would carry no information on a closed issue, where the fix is on both branches by then. The usual objection to transient (a removal is a write that can fail) is answered by the reconciler below, which repairs drift in both directions.

## `scripts/reconcile-dev-labels.py`

Encodes `docs/RELEASE.md` step 6's resolution logic and reconciles the label. It is a **pure function from data to plan**, deliberately: the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but 403s, since GitHub access is intermediated by the MCP server), so the caller supplies the PR and issue data. That also makes the fiddly parts testable:

- closing keywords vs. `Refs` / `Part of` / a bare `#N`;
- `Partially addressed in #M` — the documented marker for work still owed — must not read as `Addressed in #M`;
- the comment-ordering rule below.

Buckets: `ADD`, `REMOVE`, `NEEDS REVIEW`, and no-change. `--check` exits non-zero on drift; `--json` for machine output.

### A comment after the fix pointer is surfaced, never guessed at

Requiring the pointer to be the newest comment correctly suppresses re-tagging when someone disputes a fix. But a harmless "thanks!" would then displace the pointer and silently drop the issue out of the awaiting-release view. **Both failure directions are silent**, so the ambiguous case is reported for a human instead — the same "not silently skipped" principle step 6 already applies to non-closing references.

## Hook guard on the other end

The `PreToolUse` hook now also blocks a close that keeps `dev`, or a `completed` close that omits `labels` entirely. The hook only sees call arguments, never the issue's current state, so requiring an explicit label set is the only form of the call that *provably* strips the label. The denial spells out that `labels` **replaces** the whole set, since passing `[]` to satisfy it would wipe `claude`.

## Applied to the live repo

Ran the reconciler against the actual `origin/main..origin/dev` window (17 PRs × 24 open issues). It found 8 issues fixed on `dev` but still open, now labeled: #2881, #2897, #2898, #2987, #2991, #3077, #3117, #3132. No removals and no ambiguous cases. That run supplied PR bodies and issue labels but not comments, so the orphan-backstop path was exercised only by its unit tests.

---

## Files

| File | |
|---|---|
| `.claude/hooks/require-issue-labels.py` | the hook (create-path labels + close-path `dev` strip) |
| `.claude/settings.json` | registers it under `PreToolUse` |
| `scripts/reconcile-dev-labels.py` | the reconciler |
| `tests/core/test_issue_label_hook.py` | 29 tests — blocks *and* pass-throughs |
| `tests/core/test_reconcile_dev_labels.py` | 39 tests — keyword buckets, pointer rules, comment ordering, CLI |
| `CLAUDE.md` | documents `dev` alongside `claude` / `experiment` |
| `docs/RELEASE.md` | step 6 strips the label; new step 6b is the reconcile recipe |

## Testing

`./run-tests.sh` — **8492 passed, 6 skipped**; every gate clean (ruff, format, codespell, check-docs, deptry, pip-audit, pyright, OpenAPI snapshot, Dockerfiles, screenshot wiring, eval/app sync, frontend build + audit + Vitest).

## Note

No closing keyword: this PR does not do #3127's actual work (the `enrich_descriptions` re-measurement), which remains open and now correctly labeled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkoTmcMUYXnLJneJy4ds1M