### PR TITLE
Let server-side code raise a toast without failing the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@ not list every commit. Use `git log` for the full history.
 
 ### Added
 
+- **Server-side code can raise a toast.** A new `notify()`
+  (`vtscore/concurrency/notifications.py`) lets any backend code — most
+  usefully a plugin that hit a recoverable problem — tell the user something
+  happened *without* failing the operation: "skipped 3 unreadable files",
+  "the remote API rate-limited us, results are partial". The message is
+  broadcast over a new `notification` channel on `/api/events` and rendered
+  as a toast; toasts gained `warning` and `info` levels alongside the
+  existing `error` and `success`. Plugin subclasses get `self.notify(...)`
+  with their display name attached. Headless runs print the same messages
+  (stderr in text mode, `notification` NDJSON records under
+  `--progress-format json`). Delivery is live-only — there is no replay for
+  a client that connects afterwards. See
+  [`docs/EXTENDING-plugins.md`](docs/EXTENDING-plugins.md#notifying-the-user-toasts).
 - `vtscore` library distribution with its own [README](vtscore/README.md) and
   [CHANGELOG](vtscore/CHANGELOG.md). See the
   [package reference](vtscore/docs/README.md#package-reference) for the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -297,6 +297,22 @@ python app.py --autodetect --dataset data.pkl --settings settings.json --progres
 The two choices are `text` (default, prose) and `json` (NDJSON events). The
 event schema is defined in `vtscore.cli_progress`.
 
+A plugin can also raise a **notification** — a message it wants the user to
+see about something it decided not to fail on ("skipped 3 unreadable files").
+In the GUI those become toasts; on the command line they print as
+`Warning: [Server Folder] Skipped 3 unreadable files` on **stderr** in text
+mode, and as `notification` events on stdout in JSON mode:
+
+```bash
+python app.py --autodetect --dataset data.pkl --settings settings.json \
+    --progress-format json \
+  | jq -r 'select(.event == "notification") | "\(.level): \(.message)"'
+```
+
+A `notification` never ends the run, at any level — including
+`"level": "error"`, which reports something the code continued past. The
+fatal-error record is the separate `error` event.
+
 An exporter can format its results into a URL for a browser to open rather than
 delivering them anywhere (the built-in `open_url` exporter does exactly this).
 There is no browser on the command line, so the URL is printed under the

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -21,6 +21,8 @@ extractors).
     what the framework does to `field_values` before your plugin sees it
     (read this before writing any `.strip()` / `validate_url` /
     `validate_server_filepath` boilerplate)
+  - [Notifying the user (toasts)](#notifying-the-user-toasts): telling the
+    user something went sideways *without* failing the whole run
 - [Adding a Data Importer](#adding-a-data-importer)
 - [Adding a Datasource Importer](#adding-a-datasource-importer)
 - [Adding a Media Converter](#adding-a-media-converter)
@@ -229,6 +231,68 @@ first request, so a typo fails fast rather than shipping a literal
 placeholder into a filename. Every substituted value is run through
 `sanitize_template_value()`, so a detector named `../../etc/passwd`
 cannot escape the directory implied by an admin-configured template.
+
+### Notifying the user (toasts)
+
+Sometimes a plugin hits a problem that is worth *mentioning* but not worth
+*failing over*: an API that rate-limited you into partial results, a
+handful of files that would not decode, a field the remote schema no longer
+returns. Raising turns a mostly-successful run into a total failure and
+throws away the work that did succeed; logging alone means nobody finds
+out, because the user is looking at a browser and not at your server's
+stdout.
+
+`PluginBase.notify()` is the third option — keep going, and put a toast in
+front of the user:
+
+```python
+def run(self, field_values):
+    medias, skipped = self._load(field_values)
+    if skipped:
+        self.notify(
+            f"Skipped {len(skipped)} unreadable files",
+            level="warning",
+            detail=", ".join(skipped[:10]),
+        )
+    return medias
+```
+
+| Argument  | Description |
+|-----------|-------------|
+| `message` | Headline, one short sentence. Truncated at 300 characters |
+| `level`   | `"info"` (default), `"success"`, `"warning"`, or `"error"`. The first two fade after a few seconds; the last two stay until the user dismisses them |
+| `detail`  | Optional second line with the specifics — which files, which endpoint, how many. Truncated at 2000 characters |
+
+Your `display_name` is attached automatically as the notification's source,
+so the toast says which plugin spoke. Code that isn't a `PluginBase`
+subclass (an embedder, a processor, a route helper) calls the underlying
+function directly and passes its own label:
+
+```python
+from vtscore.concurrency.notifications import notify
+
+notify("Rate limited; returning partial results", level="warning", source="ACME API")
+```
+
+Four things to know before you rely on it:
+
+- **It cannot fail.** A bad `level` degrades to `"info"`, a long message is
+  truncated, and a broken listener is swallowed. Call it inside an `except`
+  block or a loop without wrapping it in its own `try`.
+- **It is not an error channel.** A problem that *does* invalidate the
+  result should still raise; the framework turns that into a proper error
+  the user cannot miss. `notify` is for the case where you chose to
+  continue.
+- **Delivery is live-only.** Every user with the app open when you call it
+  sees the toast; nobody who opens the app afterwards does. There is no
+  replay, so don't use it for anything that has to survive a page reload.
+- **Headless still works.** Under `python app.py --autodetect` the same
+  messages print (to stderr in text mode, as `notification` NDJSON records
+  in `--progress-format json`), so a CLI run does not silently lose them.
+
+See [`vtscore/docs/packages/concurrency.md`](../vtscore/docs/packages/concurrency.md)
+for the broker itself, and [`api/events.md`](api/events.md) for the SSE
+frame that carries it.
 
 ### PluginRegistry (Auto-Discovery)
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -262,7 +262,7 @@ The ones worth knowing before changing anything:
 | `ActiveContextWatcherService` | Reacts when an active id disappears from the registry (deleted elsewhere) |
 | `ProgressEventsService` | The single `EventSource` over `/api/events`, fanned out per channel |
 | `ConnectionStateService` | Online/offline, and the probe that reopens the circuit breaker |
-| `ToastService` | Toasts, including the structured `ErrorContext` from failed requests |
+| `ToastService` | Toasts: four levels, the structured `ErrorContext` from failed requests, and the backend's `notification` channel |
 | `VtDialogService` | `confirm()` / `prompt()` as promises, rendered by `dialog-host` |
 | `NewThingFlowsService` | Singleton openers for the Add-Dataset / New-Detector flows |
 | `MediaMetadataCacheService` | Lazy batched fetch of full metadata for whatever is in the viewport |
@@ -480,10 +480,20 @@ it out to every consumer, replacing what used to be several REST polls.
 Channels: `server` (a per-connect `boot_id`, so a backend restart fires
 `serverReset$` and consumers can drop state keyed on dead `task_id`s),
 `dataset`, `loading-tasks`, `detector-loading-tasks`, `sort`, `find`, `eval`.
-Every channel carries the same `ProgressEvent` shape, so any of them can be
-rendered by `utils/format-progress.ts`. The channel state is held in signals —
-a signal write inside the SSE callback notifies Angular's scheduler directly,
-which is precisely what makes the pump work without zone.js.
+Every one of those carries the same `ProgressEvent` shape, so any of them can
+be rendered by `utils/format-progress.ts`. The channel state is held in
+signals — a signal write inside the SSE callback notifies Angular's scheduler
+directly, which is precisely what makes the pump work without zone.js.
+
+One channel breaks that mould: **`notification`**, carrying one-off messages
+any server-side code (most usefully a plugin that hit a recoverable problem
+and carried on) pushes with `notify()`. Those are *events*, not state — there
+is no "current notification" to re-read and none is replayed to a late
+listener — so the service exposes them as `notifications$`, a `Subject`
+rather than a signal, and `ToastService` subscribes to turn each into a toast
+of the matching level. See [`api/events.md`](api/events.md) for the payload
+and [`EXTENDING-plugins.md`](EXTENDING-plugins.md#notifying-the-user-toasts)
+for the producing side.
 
 Where a real poll is still needed, use `adaptivePoll()` from
 `services/adaptive-poll.ts` rather than `timer(0, n)` + `switchMap`. It runs

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -28,7 +28,13 @@ tracker, so clients do not need a separate REST bootstrap call.
 | `sort` | progress object | `sort_progress` (text sort) |
 | `find` | progress object | `find_progress` (multi-dataset Find) |
 | `eval` | progress object | `eval_progress` (train-and-score) |
+| `notification` | notification object | `notify()` — one-off messages from server-side code; rendered as toasts |
 | `heartbeat` | `{ "ts": <unix seconds> }` | periodic liveness ping (every ~5s) |
+
+Every channel except `notification` carries **state**: a snapshot sent on
+connect and re-sent on every heartbeat, so a dropped frame heals itself.
+`notification` carries **events** — see [Notification object
+shape](#notification-object-shape) for what that costs.
 
 ### Progress object shape
 
@@ -83,6 +89,40 @@ ingest (see [detectors.md](detectors.md) and [io.md](io.md)) publishes
 `ingest_result` — `{"ingested", "applied", "unresolved", "failed"}`, with only
 `ingested` present on the detector-import path.
 
+### Notification object shape
+
+```json
+{
+  "id": "note_4eb45583_7",
+  "level": "warning",
+  "message": "Skipped 3 unreadable files",
+  "detail": "page_2.pdf, page_9.pdf, notes.pdf",
+  "source": "Server Folder",
+  "timestamp": 1731000000.123
+}
+```
+
+A one-off message from server-side code — typically a plugin that hit a
+recoverable problem and chose to carry on rather than fail the whole
+operation. Published with `notify()`
+(`vtscore/concurrency/notifications.py`); the Angular client turns each one
+into a toast via `ToastService`. `level` is one of `info`, `success`,
+`warning`, `error`; the first two auto-dismiss, the last two stay until the
+user closes them. `detail` and `source` may be `null`.
+
+Unlike every other channel this one has no snapshot, which has three
+consequences worth designing around:
+
+- **No bootstrap.** It is absent from the connect-time snapshot.
+- **No replay.** A notification published while nobody is connected is gone;
+  a client connecting a second later does not receive it.
+- **No heal.** Each client's queue is bounded, and a notification dropped
+  when that queue is full is not re-sent by the heartbeat the way a tracker
+  snapshot is. The backend logs the drop.
+
+Every open client receives every notification, including a second browser
+tab — there is no per-session routing.
+
 ## Frame format
 
 ```
@@ -124,6 +164,10 @@ es.addEventListener('dataset', (e) => {
 });
 es.addEventListener('loading-tasks', (e) => {
   setActiveTasks(JSON.parse(e.data));
+});
+es.addEventListener('notification', (e) => {
+  const { level, message, detail } = JSON.parse(e.data);
+  showToast(level, message, detail);
 });
 ```
 

--- a/frontend/src/app/components/toast-container/toast-container.component.html
+++ b/frontend/src/app/components/toast-container/toast-container.component.html
@@ -17,20 +17,41 @@
     <div
       class="toast"
       [class.toast--success]="t.level === 'success'"
+      [class.toast--warning]="t.level === 'warning'"
+      [class.toast--info]="t.level === 'info'"
       [class.toast--countdown]="!!t.countdown"
       role="alert"
     >
       <div class="toast__main">
-        @if (t.level === 'success') {
-          <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.4" />
-            <path d="M5 8.2l2.2 2.2L11 6.4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        } @else {
-          <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.4" />
-            <path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
-          </svg>
+        <!-- One glyph per level, so severity survives a colour-blind or
+             greyscale reading of the same stack: tick / bang / "i" / cross. -->
+        @switch (t.level) {
+          @case ('success') {
+            <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.4" />
+              <path d="M5 8.2l2.2 2.2L11 6.4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          }
+          @case ('warning') {
+            <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 1.8L15 14H1L8 1.8z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" />
+              <path d="M8 6v3.4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+              <circle cx="8" cy="11.8" r="0.85" fill="currentColor" />
+            </svg>
+          }
+          @case ('info') {
+            <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.4" />
+              <path d="M8 7.2v3.6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+              <circle cx="8" cy="4.9" r="0.85" fill="currentColor" />
+            </svg>
+          }
+          @default {
+            <svg class="toast__icon" aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="8" cy="8" r="6.4" stroke="currentColor" stroke-width="1.4" />
+              <path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+            </svg>
+          }
         }
         <div class="toast__text">
           <div class="toast__title">{{ t.message }}</div>

--- a/frontend/src/app/components/toast-container/toast-container.component.scss
+++ b/frontend/src/app/components/toast-container/toast-container.component.scss
@@ -50,6 +50,10 @@
   line-height: 1.4;
   animation: toast-slide-in 180ms ease-out;
 
+  // Level accents. The base .toast is styled for `error` (the level that
+  // existed first); each other level re-tints the same four surfaces — border,
+  // left edge, icon, title — rather than restyling the toast, so a new level
+  // is a colour swap and nothing else can drift between them.
   &.toast--success {
     border-color: var(--color-good);
     border-left-color: var(--color-good);
@@ -59,6 +63,30 @@
     .toast__btn:hover {
       background: var(--good-bg);
       border-color: var(--color-good);
+    }
+  }
+
+  &.toast--warning {
+    border-color: var(--warning-border);
+    border-left-color: var(--text-warning);
+
+    .toast__icon { color: var(--text-warning); }
+    .toast__title { color: var(--text-warning); }
+    .toast__btn:hover {
+      background: var(--warning-bg);
+      border-color: var(--warning-border);
+    }
+  }
+
+  &.toast--info {
+    border-color: var(--accent-highlight-border);
+    border-left-color: var(--accent);
+
+    .toast__icon { color: var(--accent); }
+    .toast__title { color: var(--text-primary); }
+    .toast__btn:hover {
+      background: var(--accent-highlight-bg);
+      border-color: var(--accent-highlight-border);
     }
   }
 

--- a/frontend/src/app/models/api.models.ts
+++ b/frontend/src/app/models/api.models.ts
@@ -112,6 +112,32 @@ export interface ProgressEvent {
   [key: string]: unknown;
 }
 
+/**
+ * A one-off message the backend wants shown to the user, delivered on the
+ * `notification` channel of `/api/events` and rendered as a toast by
+ * `ToastService`.
+ *
+ * Backend: `vtscore/concurrency/notifications.py`. Any server-side code —
+ * most usefully a plugin that hit a recoverable problem and chose to carry
+ * on — calls `notify(...)` and every connected client receives this shape.
+ *
+ * Unlike `ProgressEvent` this is an event, not a snapshot: it is broadcast
+ * once, is never re-sent on a heartbeat, and is not replayed to a client that
+ * connects afterwards.
+ */
+export interface ServerNotification {
+  /** Unique per backend process; used as the toast's dedup key. */
+  id: string;
+  /** `error`/`warning` toasts stay until dismissed; the rest auto-dismiss. */
+  level: 'info' | 'success' | 'warning' | 'error';
+  message: string;
+  detail?: string | null;
+  /** Who spoke — usually a plugin's `display_name`. */
+  source?: string | null;
+  /** Unix seconds. */
+  timestamp?: number;
+}
+
 // --- Datasets ---
 
 /**

--- a/frontend/src/app/services/progress-events.service.spec.ts
+++ b/frontend/src/app/services/progress-events.service.spec.ts
@@ -2,7 +2,7 @@ import { Component, WritableSignal, inject, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProgressEventsService } from './progress-events.service';
 import { ConnectionStateService, ConnectionStatus } from './connection-state.service';
-import type { LoadingTask } from '../models/api.models';
+import type { LoadingTask, ServerNotification } from '../models/api.models';
 import { configureZoneless } from '../testing/zoneless-testbed';
 import { settleZoneless } from '../testing/settle-resource';
 
@@ -174,6 +174,50 @@ describe('ProgressEventsService liveness wiring', () => {
     es.emit('detector-loading-tasks', []);
     TestBed.tick();
     expect(state.completed).toBe(true);
+  });
+
+  // --- notification channel: one-off backend messages (#3132) ---
+
+  it('re-emits a notification frame on notifications$', () => {
+    const es = connectedSource();
+    const seen: ServerNotification[] = [];
+    TestBed.inject(ProgressEventsService).notifications$.subscribe((n) => seen.push(n));
+
+    es.emit('notification', {
+      id: 'note_ab_1',
+      level: 'warning',
+      message: 'Skipped 3 files',
+      detail: 'a, b, c',
+      source: 'Server Folder',
+    });
+
+    expect(seen.length).toBe(1);
+    expect(seen[0].message).toBe('Skipped 3 files');
+    expect(seen[0].level).toBe('warning');
+    expect(seen[0].source).toBe('Server Folder');
+  });
+
+  it('drops a notification frame with no message', () => {
+    // An empty toast tells the user nothing and still has to be dismissed.
+    const es = connectedSource();
+    const seen: ServerNotification[] = [];
+    TestBed.inject(ProgressEventsService).notifications$.subscribe((n) => seen.push(n));
+
+    es.emit('notification', { id: 'note_ab_2', level: 'info', message: '' });
+
+    expect(seen).toEqual([]);
+  });
+
+  it('does not replay an earlier notification to a late subscriber', () => {
+    // These are events, not state: a subscriber that arrives after the frame
+    // must not be handed a stale message to toast.
+    const es = connectedSource();
+    es.emit('notification', { id: 'note_ab_3', level: 'info', message: 'Already gone' });
+
+    const seen: ServerNotification[] = [];
+    TestBed.inject(ProgressEventsService).notifications$.subscribe((n) => seen.push(n));
+
+    expect(seen).toEqual([]);
   });
 
   it('keeps waiting while the task has not appeared yet', () => {

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -5,6 +5,7 @@ import { filter, map, takeWhile } from 'rxjs/operators';
 import {
   LoadingTask,
   ProgressEvent,
+  ServerNotification,
   VotingIterationsResponse,
 } from '../models/api.models';
 import { ConnectionStateService } from './connection-state.service';
@@ -30,6 +31,15 @@ import { ConnectionStateService } from './connection-state.service';
  *  - `sort` -> ProgressEvent (text-sort)
  *  - `find` -> ProgressEvent (multi-dataset×detector /api/find)
  *  - `eval` -> ProgressEvent (train-and-score; consumers derive `done` themselves)
+ *  - `notification` -> ServerNotification (one-off message from server-side
+ *    code, typically a plugin reporting something it decided not to fail on;
+ *    surfaced as a toast by `ToastService`)
+ *
+ * Every channel above except `notification` carries *state*: a snapshot the
+ * backend re-sends on connect and on every heartbeat, so a dropped frame
+ * heals itself. `notification` carries *events*, so it is exposed as a
+ * `Subject` rather than a signal — there is no "current notification" to
+ * read, only ones that arrive while you are listening.
  */
 @Injectable({ providedIn: 'root' })
 export class ProgressEventsService implements OnDestroy {
@@ -73,6 +83,14 @@ export class ProgressEventsService implements OnDestroy {
    */
   private readonly serverResetSubject = new Subject<void>();
   readonly serverReset$ = this.serverResetSubject.asObservable();
+
+  /**
+   * One-off messages pushed by server-side code (see `ServerNotification`).
+   * A `Subject`, not a signal: these are events with no resting value, and a
+   * late subscriber must not be handed a stale one to re-toast.
+   */
+  private readonly notificationsSubject = new Subject<ServerNotification>();
+  readonly notifications$ = this.notificationsSubject.asObservable();
 
   private source: EventSource | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -165,6 +183,12 @@ export class ProgressEventsService implements OnDestroy {
     this.listen(es, 'sort', (e) => this._sort.set(this.parse<ProgressEvent>(e, {})));
     this.listen(es, 'find', (e) => this._find.set(this.parse<ProgressEvent>(e, {})));
     this.listen(es, 'eval', (e) => this._eval.set(this.parse<ProgressEvent>(e, {})));
+    this.listen(es, 'notification', (e) => {
+      const note = this.parse<ServerNotification | null>(e, null);
+      // A frame that failed to parse, or one with nothing to say, would render
+      // as an empty toast the user cannot act on — drop it instead.
+      if (note?.message) this.notificationsSubject.next(note);
+    });
     // The periodic `heartbeat` frame carries no payload we render; its sole
     // job is to keep the circuit breaker online (handled by `listen`'s
     // recordSuccess) during long, busy operations that aren't emitting

--- a/frontend/src/app/services/toast.service.spec.ts
+++ b/frontend/src/app/services/toast.service.spec.ts
@@ -2,12 +2,13 @@ import { TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { ErrorContext, Toast, ToastService } from './toast.service';
 import { ProgressEventsService } from './progress-events.service';
-import { LoadingTask } from '../models/api.models';
+import { LoadingTask, ServerNotification } from '../models/api.models';
 
 describe('ToastService', () => {
   let service: ToastService;
   let loadingTasks$: Subject<LoadingTask[]>;
   let detectorLoadingTasks$: Subject<LoadingTask[]>;
+  let notifications$: Subject<ServerNotification>;
 
   function task(overrides: Partial<LoadingTask>): LoadingTask {
     return {
@@ -25,10 +26,14 @@ describe('ToastService', () => {
   beforeEach(() => {
     loadingTasks$ = new Subject<LoadingTask[]>();
     detectorLoadingTasks$ = new Subject<LoadingTask[]>();
+    notifications$ = new Subject<ServerNotification>();
     TestBed.configureTestingModule({
       providers: [
         ToastService,
-        { provide: ProgressEventsService, useValue: { loadingTasks$, detectorLoadingTasks$ } },
+        {
+          provide: ProgressEventsService,
+          useValue: { loadingTasks$, detectorLoadingTasks$, notifications$ },
+        },
       ],
     });
     service = TestBed.inject(ToastService);
@@ -186,5 +191,94 @@ describe('ToastService', () => {
     expect(md).toContain('**Message:** plain');
     expect(md).not.toContain('**Status:**');
     expect(md).not.toContain('**Endpoint:**');
+  });
+
+  // --- levels ------------------------------------------------------------
+
+  it('warning() stays up until dismissed, like error()', async () => {
+    vi.useFakeTimers();
+    try {
+      service.warning({ message: 'partial results' });
+      expect(service.toasts[0].level).toBe('warning');
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(service.toasts.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('info() auto-dismisses on the success timer', async () => {
+    vi.useFakeTimers();
+    try {
+      service.info({ message: 'heads up' });
+      expect(service.toasts[0].level).toBe('info');
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(service.toasts).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('show() dispatches to the level it is handed', () => {
+    for (const level of ['error', 'warning', 'success', 'info'] as const) {
+      service.dismissAll();
+      service.show(level, { message: level });
+      expect(service.toasts[0].level).toBe(level);
+    }
+  });
+
+  // --- backend notifications (#3132) --------------------------------------
+
+  function notification(overrides: Partial<ServerNotification> = {}): ServerNotification {
+    return { id: 'note_ab_1', level: 'warning', message: 'Skipped 3 files', ...overrides };
+  }
+
+  it('renders a backend notification as a toast of the same level', () => {
+    notifications$.next(notification());
+
+    expect(service.toasts.length).toBe(1);
+    expect(service.toasts[0].level).toBe('warning');
+    expect(service.toasts[0].message).toBe('Skipped 3 files');
+  });
+
+  it('folds the source into the detail line, ahead of the detail', () => {
+    // The headline is the plugin's own sentence and reads as written; which
+    // part of the app spoke is context and belongs on the secondary line.
+    notifications$.next(notification({ source: 'Server Folder', detail: 'a, b, c' }));
+    expect(service.toasts[0].detail).toBe('Server Folder — a, b, c');
+  });
+
+  it('uses the source alone as the detail when there is no detail', () => {
+    notifications$.next(notification({ source: 'Server Folder' }));
+    expect(service.toasts[0].detail).toBe('Server Folder');
+  });
+
+  it('leaves the detail unset when neither source nor detail is given', () => {
+    notifications$.next(notification());
+    expect(service.toasts[0].detail).toBeUndefined();
+  });
+
+  it('dedups on the backend notification id, so a redelivered frame does not stack', () => {
+    notifications$.next(notification());
+    notifications$.next(notification());
+    expect(service.toasts.length).toBe(1);
+  });
+
+  it('stacks distinct notifications', () => {
+    notifications$.next(notification({ id: 'note_ab_1', message: 'first' }));
+    notifications$.next(notification({ id: 'note_ab_2', message: 'second' }));
+    expect(service.toasts.map((t) => t.message)).toEqual(['first', 'second']);
+  });
+
+  it('auto-dismisses an info notification but keeps an error one', async () => {
+    vi.useFakeTimers();
+    try {
+      notifications$.next(notification({ id: 'note_ab_1', level: 'info', message: 'fyi' }));
+      notifications$.next(notification({ id: 'note_ab_2', level: 'error', message: 'bad' }));
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(service.toasts.map((t) => t.message)).toEqual(['bad']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/app/services/toast.service.ts
+++ b/frontend/src/app/services/toast.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { LoadingTask } from '../models/api.models';
+import { LoadingTask, ServerNotification } from '../models/api.models';
 import { ProgressEventsService } from './progress-events.service';
 
 /**
@@ -23,7 +23,15 @@ export interface ErrorContext {
   timestamp: string;
 }
 
-export type ToastLevel = 'error' | 'success';
+/**
+ * Toast severities, in descending order of how hard they insist.
+ *
+ * `error` and `warning` stay on screen until the user dismisses them: both
+ * report that something did not go as asked, and a message the user missed is
+ * the same as a message never sent. `success` and `info` auto-dismiss — they
+ * confirm or narrate, and nothing is lost if they scroll past unread.
+ */
+export type ToastLevel = 'error' | 'warning' | 'success' | 'info';
 
 /**
  * Optional action button rendered next to the toast's dismiss. Used by
@@ -112,6 +120,9 @@ const SUCCESS_AUTO_DISMISS_MS = 5000;
  *    ``ErrorContext`` for the Details / Copy debug info actions.
  *  - SSE LoadingTask failures (via ``SseErrorRouterService``): emitted
  *    deduped per task_id.
+ *  - Backend notifications (the ``notification`` SSE channel): one-off
+ *    messages any server-side code — most often a plugin that hit a
+ *    recoverable problem and chose to continue — pushed with ``notify()``.
  *
  * Toasts stack (newest at the bottom) and stay until the user
  * dismisses them. Replaces the old single-banner ``ErrorService`` so a
@@ -132,6 +143,7 @@ export class ToastService {
 
     progressEvents.loadingTasks$.subscribe((tasks) => this.routeTaskErrors(tasks, 'dataset'));
     progressEvents.detectorLoadingTasks$.subscribe((tasks) => this.routeTaskErrors(tasks, 'detector'));
+    progressEvents.notifications$.subscribe((note) => this.routeServerNotification(note));
   }
 
   get toasts(): Toast[] {
@@ -152,8 +164,55 @@ export class ToastService {
     }
   }
 
+  /**
+   * Render a notification pushed by the backend (`notify()` in
+   * `vtscore/concurrency/notifications.py`), typically from a plugin that hit
+   * a recoverable problem and kept going.
+   *
+   * The `source` is folded into the detail line rather than the headline: the
+   * headline is the plugin's own sentence and should read as written, while
+   * "which part of the app is telling me this" is context.
+   */
+  private routeServerNotification(note: ServerNotification): void {
+    const detail = [note.source, note.detail].filter(Boolean).join(' — ') || undefined;
+    this.show(note.level, { message: note.message, detail, dedupKey: `server:${note.id}` });
+  }
+
   error(opts: ShowOptions): number {
     return this.push('error', opts);
+  }
+
+  /**
+   * Something went wrong but the operation carried on with a partial or
+   * degraded result. Stays up until dismissed, like {@link error}: the user
+   * is holding a result that is not quite what they asked for, and needs to
+   * know before they act on it.
+   */
+  warning(opts: ShowOptions): number {
+    return this.push('warning', opts);
+  }
+
+  /**
+   * Neutral news — "this happened, nothing is wrong". Auto-dismisses on the
+   * same timer as {@link success}.
+   */
+  info(opts: ShowOptions): number {
+    const autoDismissMs = opts.autoDismissMs ?? SUCCESS_AUTO_DISMISS_MS;
+    return this.push('info', opts, opts.countdown ? 0 : autoDismissMs);
+  }
+
+  /** Dispatch to the per-level method for a level only known at runtime. */
+  show(level: ToastLevel, opts: ShowOptions): number {
+    switch (level) {
+      case 'error':
+        return this.error(opts);
+      case 'warning':
+        return this.warning(opts);
+      case 'success':
+        return this.success(opts);
+      default:
+        return this.info(opts);
+    }
   }
 
   /**

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -9,12 +9,14 @@ from vtscore.concurrency.events import (
     _TASK_CHANNELS,
     _TRACKER_CHANNELS,
     BOOT_ID,
+    NOTIFICATION_CHANNEL,
     acquire_sse_slot,
     active_sse_connections,
     initial_snapshot,
     release_sse_slot,
     stream_progress_events,
 )
+from vtscore.concurrency.notifications import notifications, notify
 from vtscore.concurrency.progress import (
     LoadingTasksTracker,
     ProgressTracker,
@@ -632,3 +634,86 @@ class TestSseConnectionCapRoute:
             resp.close()
         # Closing the connection frees its slot.
         assert active_sse_connections() == 0
+
+
+class TestNotificationChannel:
+    """The ``notification`` channel: one-off messages, not a snapshot.
+
+    Everything else on the stream is state the client can re-read; these are
+    events that happen once. The tests below pin that difference, because the
+    two failure modes it guards against are silent: a notification that never
+    reaches a connected client, and one the heartbeat re-toasts forever.
+    """
+
+    def test_notifications_are_absent_from_the_initial_snapshot(self):
+        names = {f.split("\n", 1)[0].replace("event: ", "") for f in initial_snapshot()}
+        assert NOTIFICATION_CHANNEL not in names
+
+    def test_stream_yields_a_notification_published_while_connected(self):
+        gen = stream_progress_events(heartbeat_seconds=60.0, keepalive_seconds=60.0)
+        try:
+            _drain_connect_and_snapshot(gen)
+
+            notify("Skipped 3 files", level="warning", detail="a, b, c", source="Server Folder")
+
+            frame = next(gen)
+            assert frame.startswith(f"event: {NOTIFICATION_CHANNEL}\n"), f"unexpected frame {frame!r}"
+            payload = json.loads([ln for ln in frame.splitlines() if ln.startswith("data: ")][0].removeprefix("data: "))
+            assert payload["level"] == "warning"
+            assert payload["message"] == "Skipped 3 files"
+            assert payload["detail"] == "a, b, c"
+            assert payload["source"] == "Server Folder"
+            assert payload["id"]
+        finally:
+            gen.close()
+
+    def test_notification_is_not_replayed_on_heartbeat(self):
+        """A delivered notification must not come back on the next heartbeat.
+
+        The heartbeat re-emits every tracker snapshot so a client that dropped
+        a terminal frame heals (#2960). A notification has no snapshot to
+        re-emit, and re-sending one would pop the same toast every five
+        seconds forever.
+        """
+        gen = stream_progress_events(heartbeat_seconds=0.01, keepalive_seconds=60.0)
+        try:
+            _drain_connect_and_snapshot(gen)
+
+            notify("Told you once")
+            assert next(gen).startswith(f"event: {NOTIFICATION_CHANNEL}\n")
+
+            # One full heartbeat burst: the ping plus one snapshot per channel.
+            burst = [next(gen) for _ in range(1 + len(_TRACKER_CHANNELS) + len(_TASK_CHANNELS))]
+            assert burst[0].startswith("event: heartbeat\n")
+            assert not any(f.startswith(f"event: {NOTIFICATION_CHANNEL}\n") for f in burst)
+        finally:
+            gen.close()
+
+    def test_stream_unsubscribes_from_the_broker_on_close(self):
+        before = notifications.subscriber_count()
+        gen = stream_progress_events(heartbeat_seconds=60.0, keepalive_seconds=60.0)
+        try:
+            _drain_connect_and_snapshot(gen)
+            assert notifications.subscriber_count() == before + 1
+        finally:
+            gen.close()
+        assert notifications.subscriber_count() == before
+
+    def test_disconnected_client_misses_notifications_published_before_it_connects(self):
+        """No replay: a notification published with nobody listening is gone.
+
+        Pinned deliberately — it is the contract plugin authors have to design
+        against, not an accident to be "fixed" later by a replay buffer.
+        """
+        notify("Nobody heard this")
+
+        gen = stream_progress_events(heartbeat_seconds=60.0, keepalive_seconds=60.0)
+        try:
+            _drain_connect_and_snapshot(gen)
+            notify("But they hear this")
+
+            frame = next(gen)
+            payload = json.loads([ln for ln in frame.splitlines() if ln.startswith("data: ")][0].removeprefix("data: "))
+            assert payload["message"] == "But they hear this"
+        finally:
+            gen.close()

--- a/tests/cli/test_cli_progress.py
+++ b/tests/cli/test_cli_progress.py
@@ -159,6 +159,57 @@ class TestProgressCallback:
         assert "total" not in event
 
 
+class TestNotificationSubscriber:
+    """The headless sink for the notifications the GUI renders as toasts."""
+
+    def _note(self, **kwargs):
+        from vtscore.concurrency.notifications import Notification
+
+        defaults = {"id": "note_1", "level": "warning", "message": "Skipped 3 files"}
+        return Notification(**{**defaults, **kwargs})
+
+    def test_text_mode_writes_one_line_to_stderr(self, capsys):
+        cli_progress.notification_subscriber(self._note(detail="a, b, c", source="Server Folder"))
+        captured = capsys.readouterr()
+        # stdout stays clean: a caller may be piping an exporter's output.
+        assert captured.out == ""
+        assert captured.err == "Warning: [Server Folder] Skipped 3 files - a, b, c\n"
+
+    def test_text_mode_omits_absent_source_and_detail(self, capsys):
+        cli_progress.notification_subscriber(self._note(level="info", message="All good"))
+        assert capsys.readouterr().err == "Note: All good\n"
+
+    @pytest.mark.parametrize(
+        "level,label",
+        [("info", "Note"), ("success", "Done"), ("warning", "Warning"), ("error", "Error")],
+    )
+    def test_text_mode_labels_each_level(self, capsys, level, label):
+        cli_progress.notification_subscriber(self._note(level=level, message="Hi"))
+        assert capsys.readouterr().err == f"{label}: Hi\n"
+
+    def test_json_mode_emits_notification_event_on_stdout(self, capsys):
+        cli_progress.set_format("json")
+        cli_progress.notification_subscriber(self._note(detail="a, b, c", source="Server Folder"))
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        event = json.loads(captured.out.strip())
+        assert event["event"] == "notification"
+        assert event["level"] == "warning"
+        assert event["message"] == "Skipped 3 files"
+        assert event["detail"] == "a, b, c"
+        assert event["source"] == "Server Folder"
+
+    def test_notify_reaches_the_cli_once_subscribed(self, capsys):
+        from vtscore.concurrency.notifications import notifications, notify
+
+        notifications.subscribe(cli_progress.notification_subscriber)
+        try:
+            notify("Partial results", level="warning", source="Remote API")
+        finally:
+            notifications.unsubscribe(cli_progress.notification_subscriber)
+        assert capsys.readouterr().err == "Warning: [Remote API] Partial results\n"
+
+
 # ---------------------------------------------------------------------------
 # End-to-end tests; autodetect emits the documented events
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,6 +402,13 @@ def reset_state():
 
     cli_progress.set_format("text")
 
+    # Drop notification subscribers: they are process-global, so a test that
+    # subscribes a collector (or drives the CLI, which subscribes a printer)
+    # would otherwise keep receiving every later test's notifications.
+    from vtscore.concurrency.notifications import notifications as _notifications
+
+    _notifications.clear_subscribers()
+
     _set_login_provider(_DefaultLoginProvider())
 
     _reset_ds_reg()

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -337,6 +337,13 @@ def reset_contexts(tmp_path, monkeypatch):
 
     cli_progress.set_format("text")
 
+    # Drop notification subscribers: they are process-global, so a test that
+    # subscribes a collector (or drives the CLI, which subscribes a printer)
+    # would otherwise keep receiving every later test's notifications.
+    from vtscore.concurrency.notifications import notifications as _notifications
+
+    _notifications.clear_subscribers()
+
     # Redirect registry storage to tmp_path so tests can't pollute repo data/.
     from vtscore.datasets import registry as ds_reg_mod
     from vtscore.detectors import registry as det_reg_mod

--- a/tests_lib/core/test_notifications.py
+++ b/tests_lib/core/test_notifications.py
@@ -1,0 +1,215 @@
+"""Tests for the user-notification broker (``vtscore.concurrency.notifications``)."""
+
+import logging
+
+import pytest
+
+from vtscore.concurrency.notifications import (
+    DEFAULT_LEVEL,
+    LEVELS,
+    MAX_DETAIL_CHARS,
+    MAX_MESSAGE_CHARS,
+    Notification,
+    NotificationBroker,
+    notifications,
+    notify,
+)
+
+
+@pytest.fixture
+def collected():
+    """Subscribe a collector to the process-wide broker for one test."""
+    received: list[Notification] = []
+    notifications.subscribe(received.append)
+    try:
+        yield received
+    finally:
+        notifications.unsubscribe(received.append)
+
+
+class TestNotificationBroker:
+    def test_subscriber_receives_published_notification(self):
+        broker = NotificationBroker()
+        received: list[Notification] = []
+        broker.subscribe(received.append)
+
+        note = Notification(id="note_1", level="info", message="Hello")
+        broker.publish(note)
+
+        assert received == [note]
+
+    def test_unsubscribe_stops_delivery(self):
+        broker = NotificationBroker()
+        received: list[Notification] = []
+        broker.subscribe(received.append)
+        broker.unsubscribe(received.append)
+
+        broker.publish(Notification(id="note_1", level="info", message="Hello"))
+        assert received == []
+
+    def test_unsubscribe_missing_is_noop(self):
+        NotificationBroker().unsubscribe(lambda _n: None)  # never subscribed
+
+    def test_subscriber_exception_does_not_break_others(self):
+        broker = NotificationBroker()
+        seen: list[Notification] = []
+
+        def boom(_n: Notification) -> None:
+            raise RuntimeError("subscriber is broken")
+
+        broker.subscribe(boom)
+        broker.subscribe(seen.append)
+
+        broker.publish(Notification(id="note_1", level="warning", message="Hi"))
+        assert len(seen) == 1
+
+    def test_every_subscriber_receives_each_notification(self):
+        broker = NotificationBroker()
+        first: list[Notification] = []
+        second: list[Notification] = []
+        broker.subscribe(first.append)
+        broker.subscribe(second.append)
+
+        broker.publish(Notification(id="note_1", level="info", message="Broadcast"))
+
+        assert len(first) == 1 and len(second) == 1
+
+    def test_subscriber_count_and_clear(self):
+        broker = NotificationBroker()
+        assert broker.subscriber_count() == 0
+        broker.subscribe(lambda _n: None)
+        broker.subscribe(lambda _n: None)
+        assert broker.subscriber_count() == 2
+        broker.clear_subscribers()
+        assert broker.subscriber_count() == 0
+
+
+class TestNotify:
+    def test_publishes_to_subscribers(self, collected):
+        notify("Skipped 3 files", level="warning", detail="a, b, c", source="Server Folder")
+
+        assert len(collected) == 1
+        note = collected[0]
+        assert note.level == "warning"
+        assert note.message == "Skipped 3 files"
+        assert note.detail == "a, b, c"
+        assert note.source == "Server Folder"
+
+    def test_defaults_to_info(self, collected):
+        notify("Just so you know")
+        assert collected[0].level == DEFAULT_LEVEL == "info"
+
+    @pytest.mark.parametrize("level", LEVELS)
+    def test_every_declared_level_round_trips(self, collected, level):
+        notify("Message", level=level)
+        assert collected[-1].level == level
+
+    def test_unknown_level_falls_back_instead_of_raising(self, collected):
+        note = notify("Message", level="catastrophe")
+
+        assert note.level == DEFAULT_LEVEL
+        assert collected[0].level == DEFAULT_LEVEL
+
+    def test_ids_are_unique(self, collected):
+        notify("One")
+        notify("Two")
+        assert collected[0].id != collected[1].id
+
+    def test_blank_message_is_not_broadcast(self, collected):
+        note = notify("   ")
+
+        # Returned (callers may inspect it) but never shown: an empty toast is
+        # worse than no toast.
+        assert note.message == ""
+        assert collected == []
+
+    def test_message_is_truncated(self, collected):
+        notify("x" * (MAX_MESSAGE_CHARS + 500))
+
+        assert len(collected[0].message) == MAX_MESSAGE_CHARS
+        assert collected[0].message.endswith("…")
+
+    def test_detail_is_truncated(self, collected):
+        notify("Headline", detail="y" * (MAX_DETAIL_CHARS + 500))
+
+        assert len(collected[0].detail) == MAX_DETAIL_CHARS
+        assert collected[0].detail.endswith("…")
+
+    def test_short_message_is_not_truncated(self, collected):
+        notify("Short and sweet")
+        assert collected[0].message == "Short and sweet"
+
+    def test_empty_detail_and_source_become_none(self, collected):
+        notify("Headline", detail="   ", source="  ")
+
+        assert collected[0].detail is None
+        assert collected[0].source is None
+
+    def test_broken_subscriber_does_not_propagate_to_caller(self):
+        def boom(_n: Notification) -> None:
+            raise RuntimeError("subscriber is broken")
+
+        notifications.subscribe(boom)
+        try:
+            notify("Still fine")  # must not raise
+        finally:
+            notifications.unsubscribe(boom)
+
+    @pytest.mark.parametrize(
+        "level,expected",
+        [("info", logging.INFO), ("success", logging.INFO), ("warning", logging.WARNING), ("error", logging.ERROR)],
+    )
+    def test_logs_at_matching_severity(self, caplog, level, expected):
+        with caplog.at_level(logging.INFO, logger="vtscore.concurrency.notifications"):
+            notify("Something happened", level=level, source="Plugin")
+
+        records = [r for r in caplog.records if r.name == "vtscore.concurrency.notifications"]
+        assert records, "notify() must always log, even with no subscribers"
+        assert records[-1].levelno == expected
+        assert "Something happened" in records[-1].getMessage()
+        assert "Plugin" in records[-1].getMessage()
+
+    def test_logs_even_with_no_subscribers(self, caplog):
+        notifications.clear_subscribers()
+        with caplog.at_level(logging.INFO, logger="vtscore.concurrency.notifications"):
+            notify("Nobody is listening")
+
+        assert any("Nobody is listening" in r.getMessage() for r in caplog.records)
+
+    def test_to_dict_is_json_shaped(self, collected):
+        notify("Headline", level="error", detail="Because reasons", source="Exporter")
+
+        payload = collected[0].to_dict()
+        assert set(payload) == {"id", "level", "message", "detail", "source", "timestamp"}
+        assert payload["level"] == "error"
+        assert payload["message"] == "Headline"
+        assert payload["detail"] == "Because reasons"
+        assert payload["source"] == "Exporter"
+        assert isinstance(payload["timestamp"], float)
+
+
+class TestPluginBaseNotify:
+    def test_plugin_notify_attaches_display_name_as_source(self, collected):
+        from vtscore.plugins import PluginBase
+
+        class WidgetExporter(PluginBase):
+            display_name = "Widget Exporter"
+            fields = []
+
+        WidgetExporter().notify("Partial export", level="warning", detail="2 rows dropped")
+
+        assert len(collected) == 1
+        assert collected[0].source == "Widget Exporter"
+        assert collected[0].level == "warning"
+        assert collected[0].detail == "2 rows dropped"
+
+    def test_plugin_notify_defaults_to_info(self, collected):
+        from vtscore.plugins import PluginBase
+
+        class QuietImporter(PluginBase):
+            display_name = "Quiet Importer"
+            fields = []
+
+        QuietImporter().notify("Nothing to report")
+
+        assert collected[0].level == "info"

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -12,6 +12,17 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **`vtscore.concurrency.notifications`** - `notify()`, `Notification` and
+  `NotificationBroker`: a fan-out channel for one-off user-facing messages.
+  The progress trackers publish *state* and an exception ends the operation;
+  neither fits "we skipped 3 unreadable files but the other 900 imported
+  fine". `notify()` is the third option — keep going, and say so. Consumers
+  subscribe to the process-wide `notifications` broker (the app's SSE stream
+  and the CLI printer both do); with no subscriber the message is still
+  logged at a severity matching its level. `PluginBase.notify()` wraps it
+  with the plugin's `display_name` as the source. The call never raises: bad
+  levels degrade, long messages truncate, broken subscribers are swallowed.
+
 - **`vtscore.security.login`** - the `LoginProvider` ABC,
   `DefaultLoginProvider`, the process-wide `set_login_provider` /
   `get_login_provider` registry, `get_user_data_dir()` and

--- a/vtscore/cli_progress.py
+++ b/vtscore/cli_progress.py
@@ -22,6 +22,11 @@ Event names emitted today:
 - ``progress``       - a tick from the embedding / loading stack
   fields: ``status`` (str), ``message`` (str?), ``current`` (int?),
   ``total`` (int?), ``pct`` (float? - only when total > 0)
+- ``notification``   - a non-fatal message a plugin wanted the user to see
+  (see :mod:`vtscore.concurrency.notifications`; in the GUI these become
+  toasts). The run continues either way, including at ``level="error"``.
+  fields: ``level`` (str), ``message`` (str), ``detail`` (str?),
+  ``source`` (str?)
 - ``error``          - fatal error; the process will exit non-zero
   fields: ``message`` (str)
 
@@ -36,7 +41,10 @@ from __future__ import annotations
 import json
 import sys
 from datetime import datetime, timezone
-from typing import Any, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
+
+if TYPE_CHECKING:
+    from vtscore.concurrency.notifications import Notification
 
 #: Allowed values for ``--progress-format``.
 FORMATS = ("text", "json")
@@ -127,3 +135,45 @@ def progress_callback(status: str, message: str = "", current: int = 0, total: i
         fields["total"] = total
         fields["pct"] = round(current * 100 / total, 1)
     emit("progress", **fields)
+
+
+#: Prose label per notification level, for ``text`` mode. Mirrors the
+#: ``Error:`` prefix :func:`emit_error` already uses, so a reader does not have
+#: to learn a second vocabulary for the same severity ladder.
+_NOTIFICATION_LABEL = {
+    "info": "Note",
+    "success": "Done",
+    "warning": "Warning",
+    "error": "Error",
+}
+
+
+def notification_subscriber(notification: "Notification") -> None:
+    """Print a user notification, in whichever format the CLI is running.
+
+    Subscribed to :data:`vtscore.concurrency.notifications.notifications` for
+    the life of a CLI run so the messages plugins raise for the GUI's toasts
+    are not silently dropped in headless mode.
+
+    In ``text`` mode this writes one prose line to **stderr**, keeping stdout
+    reserved for the run's real output (an exporter's confirmation, a results
+    dump a caller may be piping). In ``json`` mode it writes a ``notification``
+    NDJSON record to **stdout** with the rest of the event stream, so one pipe
+    still captures everything.
+
+    Note that ``level="error"`` here is *not* :func:`emit_error`: a
+    notification never ends the run. It reports something the code decided to
+    continue past, which is the entire point of the notification channel.
+    """
+    label = _NOTIFICATION_LABEL.get(notification.level, "Note")
+    source = f" [{notification.source}]" if notification.source else ""
+    detail = f" - {notification.detail}" if notification.detail else ""
+    emit(
+        "notification",
+        text=f"{label}:{source} {notification.message}{detail}",
+        stream=None if _format == "json" else sys.stderr,
+        level=notification.level,
+        message=notification.message,
+        detail=notification.detail,
+        source=notification.source,
+    )

--- a/vtscore/concurrency/events.py
+++ b/vtscore/concurrency/events.py
@@ -6,11 +6,18 @@ event strings that ``/api/events`` streams to connected clients.
 
 Replaces the per-tracker REST polling endpoints (``/api/dataset/progress``,
 ``/api/sort/progress``, etc.) with a single push channel.
+
+The stream carries two kinds of channel. The tracker channels below are
+*state*: each has a current snapshot, sent on connect and re-sent on every
+heartbeat, so a dropped frame heals. The ``notification`` channel is
+*events* — one-off messages from :mod:`vtscore.concurrency.notifications`,
+with no snapshot to bootstrap or replay.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import os
 import queue
 import sys
@@ -19,6 +26,7 @@ import time
 import uuid
 from typing import Any, Callable, Generator
 
+from vtscore.concurrency.notifications import Notification, notifications
 from vtscore.concurrency.progress import (
     LoadingTasksTracker,
     ProgressTracker,
@@ -29,6 +37,8 @@ from vtscore.concurrency.progress import (
     loading_tasks,
     sort_progress,
 )
+
+logger = logging.getLogger(__name__)
 
 #: SSE heartbeat cadence. Also drives the periodic re-emit of every
 #: channel's snapshot: task channels so finished tasks vanish from clients
@@ -78,6 +88,12 @@ _TASK_CHANNELS: dict[str, LoadingTasksTracker] = {
     "loading-tasks": loading_tasks,
     "detector-loading-tasks": detector_loading_tasks,
 }
+
+#: SSE event name for one-off user notifications (toasts). Unlike the tracker
+#: channels it carries no snapshot: it is absent from :func:`initial_snapshot`
+#: and never re-emitted on a heartbeat, because a notification is a thing that
+#: happened once, not a state to converge on.
+NOTIFICATION_CHANNEL = "notification"
 
 
 def _default_max_connections() -> int:
@@ -180,9 +196,9 @@ def stream_progress_events(  # noqa: C901
     """Yield SSE-formatted strings for every progress channel until disconnect.
 
     Each connected client gets a private bounded queue; tracker subscriptions
-    push snapshots into the queue, and the generator drains it. On client
-    disconnect (the generator is closed by Flask/Werkzeug) the ``finally``
-    block unsubscribes so we don't leak callbacks.
+    and the notification broker push into the queue, and the generator drains
+    it. On client disconnect (the generator is closed by Flask/Werkzeug) the
+    ``finally`` block unsubscribes so we don't leak callbacks.
     """
     q: queue.Queue[tuple[str, Any]] = queue.Queue(maxsize=max_queue)
 
@@ -206,6 +222,16 @@ def stream_progress_events(  # noqa: C901
 
         return handler
 
+    def _notification_handler(notification: Notification) -> None:
+        try:
+            q.put_nowait((NOTIFICATION_CHANNEL, notification.to_dict()))
+        except queue.Full:
+            # Unlike a tracker snapshot, this frame has no later re-emit to
+            # heal the drop: the message is simply lost for this client. Say
+            # so in the log, which :func:`~vtscore.concurrency.notifications.notify`
+            # has already written the message to.
+            logger.warning("SSE queue full; dropped notification %s for one client", notification.id)
+
     for name, tracker in _TRACKER_CHANNELS.items():
         h = _make_tracker_handler(name)
         tracker.subscribe(h)
@@ -214,6 +240,8 @@ def stream_progress_events(  # noqa: C901
         h = _make_tasks_handler(name)
         tasks_tracker.subscribe(h)
         subscriptions.append((tasks_tracker, h))
+    notifications.subscribe(_notification_handler)
+    subscriptions.append((notifications, _notification_handler))
 
     try:
         # Send the SSE handshake comment immediately so the browser fires

--- a/vtscore/concurrency/notifications.py
+++ b/vtscore/concurrency/notifications.py
@@ -1,0 +1,244 @@
+"""User-facing notifications ("toasts") published from server-side code.
+
+The progress trackers in :mod:`vtscore.concurrency.progress` publish *state*:
+a channel has one current snapshot, clients re-read it whenever they like, and
+a lost frame heals on the next heartbeat. This module publishes the other kind
+of thing a backend has to say — a one-off **message**: "3 files had no readable
+text and were skipped", "the remote API rate-limited us, so results are
+partial". Those have no snapshot to re-read; they happen once and are shown
+once.
+
+The motivating case is plugin code that hits a recoverable problem mid-run.
+Raising turns a partial success into a total failure, and logging buries the
+news in a terminal the user is not looking at. :func:`notify` is the third
+option: keep going, and put a toast in front of the user.
+
+Usage from anywhere in the library or the app::
+
+    from vtscore.concurrency.notifications import notify
+
+    notify(
+        "Skipped 3 unreadable files",
+        level="warning",
+        detail="page_2.pdf, page_9.pdf, notes.pdf could not be decoded.",
+        source="Server Folder",
+    )
+
+Plugin subclasses get the same thing with the ``source`` filled in for them —
+see :meth:`vtscore.plugins.PluginBase.notify`.
+
+Delivery semantics — read these before relying on a notification:
+
+- **Live broadcast, no replay.** Every client with an open ``/api/events``
+  stream at the moment of the call gets the frame; a client that connects a
+  second later does not. Notifications are for narrating work the user is
+  currently watching, not for durable records. Anything that must survive a
+  page reload belongs in a task's terminal payload or in persisted state.
+- **Every open client sees it,** including a second browser tab. There is no
+  per-session routing: the backend has no notion of which request belongs to
+  which stream.
+- **Never raises.** A bad level is coerced to ``"info"``, an over-long message
+  is truncated, and a subscriber that blows up is swallowed — a call that is
+  supposed to *avoid* interrupting the caller must not become the interruption.
+- **Always logged**, at a severity matching the level, so a headless run (CLI,
+  SLURM, tests) still has a record when no browser is attached.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal, Optional, get_args
+
+logger = logging.getLogger(__name__)
+
+#: Severities a notification can carry. They map onto the frontend's toast
+#: levels one-for-one: ``error`` and ``warning`` stay up until the user
+#: dismisses them, ``success`` and ``info`` auto-dismiss.
+NotificationLevel = Literal["info", "success", "warning", "error"]
+
+#: Tuple form of :data:`NotificationLevel`, for validation and tests.
+LEVELS: tuple[str, ...] = get_args(NotificationLevel)
+
+#: Fallback for a level the caller got wrong (see the "never raises" contract).
+DEFAULT_LEVEL: NotificationLevel = "info"
+
+_LOG_LEVEL_FOR: dict[str, int] = {
+    "info": logging.INFO,
+    "success": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+}
+
+#: Caps on what one notification may push into every connected client's queue.
+#: A toast is a headline, not a log file; a plugin that hands us a stack trace
+#: or a 10k-entry filename list gets it cut off rather than wedging the stream.
+MAX_MESSAGE_CHARS = 300
+MAX_DETAIL_CHARS = 2000
+
+#: Per-process id prefix. Ids only need to be unique among the notifications a
+#: client can hold at once, but a restarted backend re-using ``note_1`` while a
+#: stale toast is still on screen would collide in the frontend's dedup map, so
+#: the counter is namespaced per process.
+_ID_PREFIX = uuid.uuid4().hex[:8]
+_id_counter = itertools.count(1)
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Clip *text* to *limit* characters, marking that something was cut."""
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+@dataclass(frozen=True)
+class Notification:
+    """One user-facing message, as broadcast to connected clients."""
+
+    #: Unique within this process; the frontend keys its toast on it.
+    id: str
+    level: NotificationLevel
+    message: str
+    #: Secondary line, shown smaller under the message.
+    detail: Optional[str] = None
+    #: Who is talking — a plugin's display name, a subsystem. Rendered next
+    #: to the detail so the user knows which part of the app spoke up.
+    source: Optional[str] = None
+    #: Unix seconds, filled in at construction.
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serialisable form; the SSE ``notification`` frame payload."""
+        return {
+            "id": self.id,
+            "level": self.level,
+            "message": self.message,
+            "detail": self.detail,
+            "source": self.source,
+            "timestamp": self.timestamp,
+        }
+
+
+class NotificationBroker:
+    """Fan-out point for :class:`Notification`\\ s.
+
+    Mirrors :meth:`~vtscore.concurrency.progress.ProgressTracker.subscribe` /
+    ``unsubscribe`` so the SSE stream registers for notifications exactly the
+    way it registers for progress. The difference is what is delivered: a
+    tracker replays its current snapshot to every new subscriber, this broker
+    has no snapshot to replay and delivers only what happens next.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: list[Callable[[Notification], None]] = []
+        self._lock = threading.Lock()
+
+    def subscribe(self, callback: Callable[[Notification], None]) -> None:
+        """Register *callback*, fired once per published notification.
+
+        The callback runs synchronously on the publishing thread, outside the
+        broker's lock. Subscribers must be non-blocking and exception-safe;
+        exceptions are swallowed so one bad subscriber cannot break a publish
+        for the others.
+        """
+        with self._lock:
+            self._subscribers.append(callback)
+
+    def unsubscribe(self, callback: Callable[[Notification], None]) -> None:
+        """Remove a previously-registered subscriber. No-op if not present."""
+        with self._lock:
+            try:
+                self._subscribers.remove(callback)
+            except ValueError:
+                pass
+
+    def subscriber_count(self) -> int:
+        """Number of live subscribers (roughly: connected clients)."""
+        with self._lock:
+            return len(self._subscribers)
+
+    def clear_subscribers(self) -> None:
+        """Drop every subscriber. For test isolation, not production use."""
+        with self._lock:
+            self._subscribers.clear()
+
+    def publish(self, notification: Notification) -> None:
+        """Deliver *notification* to every current subscriber."""
+        with self._lock:
+            subs = list(self._subscribers)
+        for callback in subs:
+            try:
+                callback(notification)
+            except Exception:
+                logger.exception("Notification subscriber raised; continuing")
+
+
+#: Process-wide broker. The SSE endpoint subscribes one handler per connected
+#: client; the CLI subscribes a printer (see ``vtsearch.cli_main``).
+notifications = NotificationBroker()
+
+
+def notify(
+    message: str,
+    *,
+    level: str = DEFAULT_LEVEL,
+    detail: Optional[str] = None,
+    source: Optional[str] = None,
+) -> Notification:
+    """Show *message* to every connected user, and log it.
+
+    This is the whole public API. It is deliberately impossible to make it
+    fail: it is called from paths that chose *not* to raise, so it must not
+    reintroduce the exception it was used to avoid.
+
+    Args:
+        message: Headline, one short sentence. Truncated at
+            :data:`MAX_MESSAGE_CHARS`.
+        level: One of :data:`LEVELS`. ``"warning"`` / ``"error"`` stay on
+            screen until dismissed; ``"info"`` / ``"success"`` fade on their
+            own. An unrecognised value is coerced to :data:`DEFAULT_LEVEL`
+            (and logged) rather than raising.
+        detail: Optional second line with the specifics — which files, which
+            endpoint, how many. Truncated at :data:`MAX_DETAIL_CHARS`.
+        source: Who is speaking, e.g. a plugin's ``display_name``. Plugin
+            subclasses should use :meth:`vtscore.plugins.PluginBase.notify`,
+            which fills this in.
+
+    Returns:
+        The :class:`Notification` that was published. A blank *message*
+        produces a notification that is returned but **not** broadcast (an
+        empty toast is worse than none), which is also the only case where
+        nothing reaches the user.
+    """
+    if level not in LEVELS:
+        logger.warning("Unknown notification level %r; falling back to %r", level, DEFAULT_LEVEL)
+        level = DEFAULT_LEVEL
+
+    text = _truncate(str(message).strip(), MAX_MESSAGE_CHARS)
+    detail_text = _truncate(str(detail).strip(), MAX_DETAIL_CHARS) if detail else None
+    source_text = str(source).strip() or None if source else None
+
+    notification = Notification(
+        id=f"note_{_ID_PREFIX}_{next(_id_counter)}",
+        level=level,  # type: ignore[arg-type]  # narrowed by the LEVELS check above
+        message=text,
+        detail=detail_text or None,
+        source=source_text,
+    )
+
+    prefix = f"[{source_text}] " if source_text else ""
+    logger.log(
+        _LOG_LEVEL_FOR[level],
+        "%s%s%s",
+        prefix,
+        text or "(empty notification)",
+        f" - {detail_text}" if detail_text else "",
+    )
+
+    if text:
+        notifications.publish(notification)
+    return notification

--- a/vtscore/docs/packages/concurrency.md
+++ b/vtscore/docs/packages/concurrency.md
@@ -23,6 +23,7 @@ true of `vtscore.security`.
 | `vtscore/concurrency/async_jobs.py` | Single-slot async job manager: coalescing background tasks with a result slot |
 | `vtscore/concurrency/progress.py` | `ProgressTracker`, `LoadingTasksTracker`, the module-level singletons, cooperative cancellation |
 | `vtscore/concurrency/events.py` | Server-Sent Events stream over the progress channels |
+| `vtscore/concurrency/notifications.py` | `notify()` - one-off user-facing messages, rendered as toasts by the app |
 | `vtscore/concurrency/gate.py` | `ConcurrencyGate` - a semaphore whose limit is re-read on every acquisition |
 | `vtscore/concurrency/memory_budget.py` | Cap fan-out so peak per-worker memory fits a fraction of available RAM |
 
@@ -36,6 +37,7 @@ true of `vtscore.security`.
 - [Memory budget](#memory-budget)
 - [`ConcurrencyGate`](#concurrencygate)
 - [`events.py`](#eventspy)
+- [User notifications](#user-notifications)
 
 ---
 
@@ -450,3 +452,57 @@ Heartbeats every 5 seconds keep the connection alive and re-emit the
 task channels so clients see finished tasks vanish once the stale-prune
 window elapses. This module is thin wiring - most library consumers
 don't need to touch it.
+
+It also carries one channel that is *not* a tracker: `NOTIFICATION_CHANNEL`
+(`"notification"`), fed by the broker below. It is absent from
+`initial_snapshot()` and never re-emitted on a heartbeat, because a
+notification is something that happened once rather than a state to
+converge on.
+
+---
+
+## User notifications
+
+`vtscore/concurrency/notifications.py` answers a question the trackers
+can't: how does code tell the user something *without stopping*?
+
+A tracker publishes state, and an exception ends the operation. Neither
+fits "we skipped 3 unreadable files but the other 900 imported fine" -
+raising throws away the 900, and a log line is written where nobody is
+looking. `notify()` is the third option: keep going, and put the message
+in front of the user (a toast in the app; a stderr line under the CLI).
+
+```python
+from vtscore.concurrency.notifications import notify
+
+notify(
+    "Skipped 3 unreadable files",
+    level="warning",                       # info | success | warning | error
+    detail="page_2.pdf, page_9.pdf, notes.pdf",
+    source="Server Folder",
+)
+```
+
+| Name | Description |
+|------|-------------|
+| `notify(message, *, level="info", detail=None, source=None) -> Notification` | Publish and log one message. Never raises |
+| `Notification` | Frozen dataclass: `id`, `level`, `message`, `detail`, `source`, `timestamp`, `.to_dict()` |
+| `NotificationBroker` | `subscribe` / `unsubscribe` / `publish` / `subscriber_count` / `clear_subscribers` |
+| `notifications` | The process-wide broker singleton |
+
+Plugin authors get the same thing with `source` prefilled - see
+[`plugins.md`](plugins.md) and `PluginBase.notify`.
+
+**Delivery is live-only.** Every client with an open `/api/events` stream
+at the moment of the call receives the frame; one that connects a moment
+later does not, and there is no replay buffer. Notifications narrate work
+the user is currently watching. Anything that has to survive a page reload
+belongs in a task's terminal payload or in persisted state instead.
+
+**It cannot fail.** An unknown `level` degrades to `"info"`, an over-long
+message is truncated, a blank message is logged but not shown, and a
+subscriber that raises is swallowed. A call whose whole purpose is to
+*avoid* interrupting the caller must not become the interruption.
+
+**It always logs**, at a severity matching the level, so a headless run
+still has a record when no browser is attached.

--- a/vtscore/docs/packages/plugins.md
+++ b/vtscore/docs/packages/plugins.md
@@ -216,6 +216,7 @@ frontend handles its result-display directly.
 | `add_cli_arguments(parser)` | Walks `fields` and adds an `argparse` argument per field. `"checkbox"` fields use `BooleanOptionalAction` (`--<key>` / `--no-<key>`). `"select"` fields get a `choices` constraint. `"number"` fields get `type=int` or `type=float` per `is_integer_number()`. |
 | `validate_cli_field_values(field_values)` | Raises `ValueError("Missing required argument: --<flag>")` if any non-checkbox required field is empty. Checkboxes are skipped because argparse always populates them. |
 | `to_dict()` | Returns the JSON-serialisable plugin metadata used by listing endpoints: `{name, display_name, description, icon, fields, ui_mode, hidden_from_picker}`. |
+| `notify(message, *, level="info", detail=None)` | Shows the user a one-off message (a toast in the app, a printed line under the CLI) with `display_name` as the source, and keeps going. For the recoverable problem that shouldn't fail the run - see [`concurrency.md`](concurrency.md#user-notifications). Never raises. |
 
 Subclasses normally only override `to_dict()` if they need to attach
 family-specific metadata (e.g. converters expose `source_type` /

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -41,6 +41,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Generic, Literal, TypeVar
 
+from vtscore.concurrency.notifications import Notification, notify
+
 FieldType = Literal[
     "file",
     "folder",
@@ -65,10 +67,12 @@ __all__ = [
     "EntryPointTombstone",
     "FieldOption",
     "FieldType",
+    "Notification",
     "PluginBase",
     "PluginField",
     "PluginRegistry",
     "make_plugin_registry",
+    "notify",
 ]
 
 
@@ -483,6 +487,47 @@ class PluginBase:
         importer) can override this to return a dataset-specific label.
         """
         return self.display_name
+
+    # -- User notifications -------------------------------------------------
+
+    def notify(
+        self,
+        message: str,
+        *,
+        level: str = "info",
+        detail: str | None = None,
+    ) -> Notification:
+        """Put a toast in front of every user currently watching the app.
+
+        The escape hatch for a problem that is worth telling the user about
+        but not worth failing over: a source that returned fewer rows than
+        asked for, a handful of files that would not decode, a remote API
+        that rate-limited us into partial results.  Raising would throw away
+        the work that *did* succeed; logging alone means nobody finds out.
+
+        The call cannot fail, so it is safe inside an ``except`` block or a
+        tight loop, and it never needs its own ``try``.  :attr:`display_name`
+        is attached as the notification's source, so the toast says which
+        plugin spoke.  See :mod:`vtscore.concurrency.notifications` for the
+        delivery semantics (live broadcast, no replay).
+
+        Args:
+            message: Headline, one short sentence.
+            level: ``"info"`` (default), ``"success"``, ``"warning"``, or
+                ``"error"``.  The first two fade on their own; the last two
+                stay until the user dismisses them.
+            detail: Optional second line carrying the specifics.
+
+        Example::
+
+            if skipped:
+                self.notify(
+                    f"Skipped {len(skipped)} unreadable files",
+                    level="warning",
+                    detail=", ".join(skipped[:10]),
+                )
+        """
+        return notify(message, level=level, detail=detail, source=self.display_name)
 
     # -- CLI support --------------------------------------------------------
 

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -801,10 +801,16 @@ def _run_autodetect(args, parser, importer, exporter) -> None:
     # progress callback from update_progress (which writes to a tracker
     # nothing reads in CLI mode) to an NDJSON emitter on stdout.
     from vtscore import cli_progress
+    from vtscore.concurrency.notifications import notifications
 
     cli_progress.set_format(args.progress_format)
     if args.progress_format == "json":
         set_progress_callback(cli_progress.progress_callback)
+    # Plugin notifications become toasts in the GUI; headless there is no
+    # browser to toast at, so print them instead. Without this the CLI is the
+    # one place where "keep going but tell the user" silently drops the second
+    # half of its promise.
+    notifications.subscribe(cli_progress.notification_subscriber)
 
     _authenticate_cli_user(args, parser)
 


### PR DESCRIPTION
Closes #3132

A plugin that hits a recoverable problem mid-run had two bad options: **raise**, which throws away the work that succeeded, or **log**, which writes to a terminal the user is not looking at. This adds the third — keep going, and tell them.

```python
if skipped:
    self.notify(
        f"Skipped {len(skipped)} unreadable files",
        level="warning",
        detail=", ".join(skipped[:10]),
    )
```

## What landed

**Backend** — `vtscore/concurrency/notifications.py`: a `NotificationBroker` plus the `notify()` entry point. It is deliberately unable to fail (an unknown level degrades to `info`, long messages truncate, a subscriber that raises is swallowed), because a call whose whole purpose is to *avoid* interrupting the caller must not become the interruption. It always logs at a matching severity, so a headless run keeps a record even with nobody connected.

**Transport** — a new `notification` channel on `/api/events`. Unlike every other channel it carries *events* rather than *state*, so it is absent from the connect-time snapshot and never re-emitted on a heartbeat — re-sending one would re-toast the same message every five seconds. The corollary, pinned by a test rather than left implicit: there is no replay for a client that connects afterwards.

**Frontend** — `ToastService` gained `warning` and `info` alongside `error` and `success`, and subscribes to the channel. Warnings stay up like errors (the user is holding a result that isn't what they asked for and needs to know before acting on it); info fades like success. Each level carries its own glyph so severity survives a greyscale or colour-blind reading of the stack. The notification's `source` folds into the detail line, leaving the plugin's own sentence as the headline.

**CLI** — the same messages print to stderr in text mode and as `notification` NDJSON records under `--progress-format json`, so the headless path doesn't silently drop half of what the GUI shows.

**Plugin ergonomics** — `PluginBase.notify()` fills in `display_name` as the source; non-plugin code imports `notify` directly.

## Notes

- `notify` is not an error channel. A problem that invalidates the result should still raise; this is for the case where you chose to continue.
- Every open client receives every notification, including a second browser tab — there is no per-session routing, since the backend has no notion of which request belongs to which stream.
- No existing call site was converted. The issue asked for the capability; changing which current failures become warnings is a separate judgment call per site.

## Testing

`./run-tests.sh` — all gates green, 8465 passed / 6 skipped, plus 2064 frontend unit tests. New coverage: broker fan-out and the never-raises contract (`tests_lib/core/test_notifications.py`), the SSE channel including the no-replay and no-heartbeat-replay invariants (`tests/api/test_events_sse.py`), the CLI sink in both formats (`tests/cli/test_cli_progress.py`), and the frontend routing and level behaviour (`toast.service.spec.ts`, `progress-events.service.spec.ts`).

## Docs

`docs/EXTENDING-plugins.md` (producing side), `docs/api/events.md` (frame shape + delivery semantics), `docs/FRONTEND.md`, `docs/CLI.md`, `vtscore/docs/packages/{concurrency,plugins}.md`, and both CHANGELOGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kq4roF17UDsyrPecKj3fW1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kq4roF17UDsyrPecKj3fW1)_