### PR TITLE
Cut the full test-suite wall clock ~40% without dropping a single test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 ## Commands
 
 - **Run tests (CPU, fast)**: `./run-tests.sh` (runs every gate listed under "What `run-tests.sh` gates" below, then pytest)
-- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; **every** invocation runs the full non-pytest gate chain first, so a group run is not a way to skip the linters; `core` and `frontend` additionally run the frontend build + `npm audit`, and `frontend` alone also runs the Vitest unit suite)
+- **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; every invocation runs the cheap serial gates — linters, doc checks, snapshot drift — first, but a group run **skips the heavy whole-repo gates** (pyright, pip-audit, and the frontend gates unless the group is `core`/`frontend`) to keep the inner loop fast; it says so in its output. `VTSEARCH_FULL_GATES=1` forces them. A **full** `./run-tests.sh` runs everything and is mandatory before pushing. `core` and `frontend` additionally run the frontend build + `npm audit`, and `frontend` alone also runs the Vitest unit suite)
 - **Run tests with coverage**: `VTSEARCH_COVERAGE=1 ./run-tests.sh` (opt-in; adds ~10-20% overhead)
 - **Run multiple groups**: `./run-tests.sh core sorting api`
 - **Run tests with extra args**: `./run-tests.sh core -- -x --tb=long` (args after `--` go to pytest)
@@ -287,27 +287,39 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 
 ## What `run-tests.sh` gates
 
-There is no CI: `./run-tests.sh` is the only gate, so it front-loads a long chain of checks and stops at the first failure with a `TESTS BLOCKED: ...` banner naming which one. **This list is derived from `run-tests.sh`; when you add or remove a gate there, update it here in the same commit.** In script order:
+There is no CI: a **full** `./run-tests.sh` is the only gate, and it still runs every check. **This list is derived from `run-tests.sh`; when you add or remove a gate there, update it here in the same commit.** The run is staged: cheap gates run serially and stop at the first failure with a `TESTS BLOCKED: ...` banner naming which one; the heavy, mutually independent gates then run **concurrently with pytest**, each runs to completion, and every failure is reported (so one pass surfaces every problem instead of one per rerun). A final `RUN PASSED` / `RUN FAILED: <gates>` banner closes the run.
 
-| # | Gate | Command it runs | Notes |
-|---|------|-----------------|-------|
-| 0 | Wall-clock cap | re-`exec`s itself under `timeout` | `VTSEARCH_TEST_TIMEOUT` (default **1800s = 30 min**) bounds the *whole* run, every stage included. `VTSEARCH_TEST_TIMEOUT=0` opts out for a deliberately long run (GPU, coverage sweep). |
-| 1 | Dep install | `.claude/hooks/ensure-test-deps.sh` | Minutes on a cold container, near-instant after. |
-| 2 | Lint | `ruff check .` | |
-| 3 | Format | `ruff format --check .` | Fix with `ruff format .`. |
-| 4 | Spelling | `codespell --toml pyproject.toml` | |
-| 5 | Documentation | `scripts/check-docs.py` | Pure invariants over every tracked markdown file: relative links, `#anchors` (GitHub slug rules), backticked repo paths, absolute-path leaks, `docs/plans/*.md` citations **anywhere in the tree**, and broken code fences. Nothing to re-pin; fix the doc, or add an allowlist entry with a reason. |
-| 6 | Dependencies | `python -m deptry .` | |
-| 7 | Known CVEs | `pip-audit` | Audits the resolved venv, not the requirements files. `PIP_AUDIT_IGNORE` in the script lists advisories with no upstream fix; re-audit and remove an entry once a patched release exists. |
-| 8 | Types | `pyright` (pinned via `PYRIGHT_PYTHON_FORCE_VERSION`) | Scope is `pyrightconfig.json`. |
-| 9 | OpenAPI snapshot drift | `scripts/dump_openapi.py` diffed against `frontend/openapi.json` | The generated TS client is built from this snapshot. Regenerate with `npm run regenerate-openapi-snapshot` and commit the result. |
-| 10 | Dockerfiles | `scripts/check-dockerfiles.py` | |
-| 11 | User-docs screenshot wiring | `scripts/screenshots/wiring-check.py` | Browser-free; the pixel-diff (`check.sh`) stays a manual chore. Also what makes the reshoot queue un-rottable. |
-| 12 | Eval/app sync | `scripts/check-eval-app-sync.py` | Re-pin with `--update` **after** reconciling the harness. |
-| 13 | Frontend build | `cd frontend && npm run build:prod` | Full run, or the `core` / `frontend` groups. Any `▲ [WARNING]` line is a hard failure. Skipped with a notice if `frontend/node_modules` is absent. |
-| 14 | Frontend audit | `cd frontend && npm audit --omit=dev` | Same trigger as the build. Prod deps only — dev-only advisories don't ship. |
-| 15 | Frontend unit tests | `cd frontend && npm run test:ci` | Full run or the `frontend` group **only** — deliberately off the fast `core` path. |
-| 16 | Python tests | `pytest tests/ tests_lib/ -n auto --dist loadgroup` | Skipped entirely when `frontend` is the only requested group. |
+Wrapping everything: a wall-clock cap (`VTSEARCH_TEST_TIMEOUT`, default **1800s = 30 min**, `0` opts out for a deliberately long run) and `.claude/hooks/ensure-test-deps.sh` (minutes on a cold container, near-instant after).
+
+**Stage 1 — cheap gates, serial, fail-fast (~10s total, every invocation):**
+
+| Gate | Command it runs | Notes |
+|------|-----------------|-------|
+| Lint | `ruff check .` | |
+| Format | `ruff format --check .` | Fix with `ruff format .`. |
+| Spelling | `codespell --toml pyproject.toml` | |
+| Documentation | `scripts/check-docs.py` | Pure invariants over every tracked markdown file: relative links, `#anchors` (GitHub slug rules), backticked repo paths, absolute-path leaks, `docs/plans/*.md` citations **anywhere in the tree**, and broken code fences. Nothing to re-pin; fix the doc, or add an allowlist entry with a reason. |
+| Dependencies | `python -m deptry .` | |
+| OpenAPI snapshot drift | `scripts/dump_openapi.py` diffed against `frontend/openapi.json` | The generated TS client is built from this snapshot. Regenerate with `npm run regenerate-openapi-snapshot` and commit the result. |
+| Doc inventories | `scripts/gen-docs-inventories.py --check` | Regenerate with `python scripts/gen-docs-inventories.py` and commit the result. |
+| Dockerfiles | `scripts/check-dockerfiles.py` | |
+| User-docs screenshot wiring | `scripts/screenshots/wiring-check.py` | Browser-free; the pixel-diff (`check.sh`) stays a manual chore. Also what makes the reshoot queue un-rottable. |
+| vtscore package docs | `scripts/check-vtscore-docs.py` | |
+| Eval/app sync | `scripts/check-eval-app-sync.py` | Re-pin with `--update` **after** reconciling the harness. |
+
+**Stage 2 — frontend production build, serial (full run and the `core` / `frontend` groups):** `cd frontend && npm run build:prod`. Any `▲ [WARNING]` line is a hard failure. Runs *before* pytest because some tests serve the built bundle out of `static/`. Skipped with a notice if `frontend/node_modules` is absent.
+
+**Stage 3 — heavy gates, concurrent with pytest (pytest streams in the foreground; lane results print after it):**
+
+| Gate | Command it runs | When | Notes |
+|------|-----------------|------|-------|
+| Types | `pyright` (pinned via `PYRIGHT_PYTHON_FORCE_VERSION`) | Full run only | Scope is `pyrightconfig.json`. |
+| Known CVEs | `pip-audit` | Full run only | Audits the resolved venv, not the requirements files. `PIP_AUDIT_IGNORE` in the script lists advisories with no upstream fix; re-audit and remove an entry once a patched release exists. |
+| Frontend audit | `cd frontend && npm audit --omit=dev` | Full run, `core`, `frontend` | Prod deps only — dev-only advisories don't ship. |
+| Frontend unit tests | `cd frontend && npm run test:ci` | Full run or `frontend` **only** — deliberately off the fast `core` path | Headless Vitest. |
+| Python tests | `pytest tests/ tests_lib/ -n auto --dist loadgroup` | Every run except a `frontend`-only group | |
+
+**Group runs skip the whole-repo stage-3 gates** (pyright, pip-audit, and the frontend gates unless the group asks for them) so the edit/test loop stays in the seconds — the skip is announced in the output, and `VTSEARCH_FULL_GATES=1` forces the complete chain on a group run. Stage 1 runs on every invocation. This is a deliberate trade: the fast inner loop may miss a type error or CVE, which is why **a full `./run-tests.sh` remains mandatory before pushing.**
 
 ## Test Groups
 
@@ -352,11 +364,11 @@ Testing can crash the session. To avoid losing work, follow this workflow:
 1. **Commit and push before running tests.** Before running `pytest` or any test command, commit all current changes and push to your working branch. Use a message like `"WIP: pre-test checkpoint"` if the work isn't finalized yet.
 2. **Start the run in the foreground with the maximum timeout, and never *launch* it with `run_in_background`.** The test command has a slow startup phase: `ensure-test-deps.sh` installs dependencies (~1-2 min on first run), then `conftest.py` imports `app.py` and generates test media/embeddings before any tests execute. There may be no output for several minutes; this is normal, and is not a sign that output capture is broken.
 
-   **Pass `600000` ms (10 minutes) — the Bash tool's maximum — and expect a cold full run to exceed it anyway.** A measured cold `./run-tests.sh` is ~11 minutes: ~7 for dep install plus the linter/pyright/pip-audit/snapshot gates and the frontend build + `npm audit` + Vitest, then ~3.5 minutes of pytest. (The old "at least 5 minutes" suggestion cut healthy runs off mid-gate.) When the tool's cap is hit the harness moves the run to the background rather than killing it — that is fine; wait for the completion notification and read the output file it names. What matters is that you *started* it in the foreground so the harness tracks it.
+   **Pass `600000` ms (10 minutes) — the Bash tool's maximum.** A measured warm full `./run-tests.sh` is ~3.5 minutes on a 4-vCPU box (the heavy gates — pyright, pip-audit, the Vitest suite — run concurrently with pytest, so the wall clock is close to pytest's own); a cold container adds ~3 minutes of dep install up front. A cold run can still brush the cap — that is fine: when the tool's cap is hit the harness moves the run to the background rather than killing it; wait for the completion notification and read the output file it names. What matters is that you *started* it in the foreground so the harness tracks it.
 
    Two consequences worth knowing before you run it:
    - **Do not pipe the run through `tail`/`grep`.** If the harness backgrounds a pipeline, nothing flushes until the whole pipeline ends, so the output file sits empty and you can't watch progress. Run the script bare and read the tail of the output file afterwards.
-   - **A run that outlives the tool's cap is not a timeout.** The script has its own 30-minute wall-clock cap (`VTSEARCH_TEST_TIMEOUT`) and prints a distinctive `TESTS TIMED OUT` banner when *it* fires. Absent that banner, the run is still healthy. To stay inside 10 minutes, run one group at a time — a group run skips the frontend gates unless it is `core` or `frontend`.
+   - **A run that outlives the tool's cap is not a timeout.** The script has its own 30-minute wall-clock cap (`VTSEARCH_TEST_TIMEOUT`) and prints a distinctive `TESTS TIMED OUT` banner when *it* fires. Absent that banner, the run is still healthy. To stay well inside 10 minutes, run one group at a time — a group run skips the heavy whole-repo gates (pyright, pip-audit, and the frontend gates unless the group is `core`/`frontend`) and typically finishes in well under a minute warm.
 3. **If tests fail and fixes are needed**, make the fixes, then commit and push again before re-running tests.
 4. **Repeat** until tests pass. Every cycle of fixes should be committed and pushed before the next test run.
 
@@ -364,11 +376,13 @@ This ensures work is recoverable if the session crashes during a test run.
 
 ## Reading Test Results (IMPORTANT)
 
-The test suite prints a clear summary as its very last output:
-- `ALL 1600 TESTS PASSED (3 skipped, total: 1603)` → all good
-- `TESTS FAILED: 2 failed, 0 errors, 1598 passed, 3 skipped (total: 1603)` → 2 failures
+A `./run-tests.sh` run prints its verdict as its very last output, in a `====`-bordered block:
+- `RUN PASSED (all gates green; pytest summary above)` → all good
+- `RUN FAILED: pytest, pyright` → those gates failed; each failing gate's `TESTS BLOCKED` banner and log tail were printed above
 
-**ONLY look at this final summary block** (bordered by `====` lines) to determine pass/fail. Many test names contain the word "error" (e.g., `test_memory_errors.py`, `TestErrorResponseFormat`). These test **error-handling behavior**; they are not failures.
+Because the heavy gates run concurrently with pytest and report after it, pytest's own summary block (`ALL 1600 TESTS PASSED (3 skipped, total: 1603)` / `TESTS FAILED: 2 failed, ...`) sits *above* the lane report in a full run — it is still the place to read pytest's counts, and it is the last output of a bare `pytest` invocation.
+
+**ONLY look at these summary blocks** (bordered by `====` lines) to determine pass/fail. Many test names contain the word "error" (e.g., `test_memory_errors.py`, `TestErrorResponseFormat`). These test **error-handling behavior**; they are not failures.
 
 **Do NOT scan test names or output for the word "error" to detect failures.** A line like:
 ```

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,17 +5,35 @@ import { defineConfig } from 'vitest/config';
  * `runnerConfig` in angular.json). The builder merges this on top of its own
  * defaults.
  *
- * We override the builder's default `isolate: false` (which it picks to mimic
- * the old Karma/Jasmine single-context run). The Angular `TestBed` is a
- * module-level singleton; with isolation off, every spec file shares one
- * instance, so a single spec that leaves the TestBed instantiated (e.g. a
- * component whose teardown throws, or an unverified HttpTestingController)
- * cascades "test module already instantiated" into every file that runs after
- * it. Per-file isolation gives each spec a fresh module graph — and thus a
- * fresh TestBed — so failures stay contained to the spec that caused them.
+ * `isolate` is left at the builder's default (`false`): all 155 spec files
+ * share one module graph per worker rather than each getting a fresh one.
+ *
+ * This file previously forced `isolate: true`, to stop a spec that leaves the
+ * `TestBed` instantiated (a component whose teardown throws, an unverified
+ * `HttpTestingController`) from cascading "test module already instantiated"
+ * into every file that ran after it. That cascade is now handled directly, and
+ * far more cheaply, by the defensive `getTestBed().resetTestingModule()` that
+ * `src/test-setup.ts` runs in a `beforeEach` — it fires before each spec's own
+ * `beforeEach`, so a dirty TestBed is cleared at the start of the next test
+ * instead of being prevented by rebuilding the whole module graph 155 times.
+ *
+ * Per-file isolation was costing more than the entire rest of the suite: it
+ * turned ~89s of actual test execution into ~155s of jsdom environment
+ * construction plus ~92s of setup-file re-evaluation. Dropping it takes the
+ * unit run from ~88s wall / ~258 CPU-seconds to ~33s / ~68 — the single
+ * largest saving in the whole test pipeline.
+ *
+ * The trade-off worth knowing: with isolation off, spec files also share
+ * *application* module-level state (service singletons, module-scoped caches),
+ * so a spec that mutates such state can in principle leak into a later file.
+ * Nothing in the suite does today — the change was validated with three
+ * consecutive shuffled-order runs (`sequence.shuffle`), all 155 files and 2051
+ * tests passing. If a file-order-dependent failure ever does appear, fix the
+ * leaking spec rather than re-enabling isolation for all 155; setting
+ * `isolate: true` here again would buy back correctness at 3-4x the runtime.
  */
 export default defineConfig({
   test: {
-    isolate: true,
+    isolate: false,
   },
 });

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -521,13 +521,31 @@ for _log in ${_lane_logs[@]+"${_lane_logs[@]}"}; do
     rm -f "$_log"
 done
 
-if [[ ${#_failed_lanes[@]} -gt 0 ]]; then
+# Final verdict banner. With lanes reporting after pytest, pytest's own
+# summary is no longer the last thing printed — this banner is, so "read the
+# last ====-bordered block" stays the way to read a run's outcome.
+echo ""
+echo "============================================================"
+if [[ ${#_failed_lanes[@]} -gt 0 || $_pytest_status -ne 0 ]]; then
+    _verdict_parts=()
+    if [[ $_pytest_status -ne 0 ]]; then
+        _verdict_parts+=("pytest")
+    fi
+    for _i in ${_failed_lanes[@]+"${_failed_lanes[@]}"}; do
+        _verdict_parts+=("${_lane_names[$_i]}")
+    done
+    _joined=$(IFS=", "; echo "${_verdict_parts[*]}")
+    echo "RUN FAILED: $_joined"
+    echo "============================================================"
+    if [[ $_pytest_status -ne 0 ]]; then
+        exit $_pytest_status
+    fi
     exit 1
 fi
-if [[ $_pytest_status -ne 0 ]]; then
-    exit $_pytest_status
+if $_run_pytest; then
+    echo "RUN PASSED (all gates green; pytest summary above)"
+else
+    echo "RUN PASSED (frontend-only; no Python tests in the 'frontend' group)"
 fi
-if ! $_run_pytest; then
-    echo "Frontend-only run complete (no Python tests in the 'frontend' group)."
-fi
+echo "============================================================"
 exit 0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,10 +2,10 @@
 # Run tests with minimal output and a clear PASS/FAIL summary.
 #
 # Usage:
-#   ./run-tests.sh              # run all fast tests (default) + frontend build check
-#   ./run-tests.sh core         # run only core group + frontend build check
-#   ./run-tests.sh sorting      # run only sorting group
-#   ./run-tests.sh core sorting # run core + sorting groups + frontend build check
+#   ./run-tests.sh              # full gate: every check + all fast tests
+#   ./run-tests.sh core         # core group + the cheap gates (see below)
+#   ./run-tests.sh sorting      # sorting group + the cheap gates
+#   ./run-tests.sh core sorting # core + sorting groups
 #   ./run-tests.sh vtscore-clean  # run tests_lib/ with Flask import blocked
 #
 # Available groups: core, api, sorting, datasets, io, detectors,
@@ -26,6 +26,38 @@
 #
 # Extra pytest args can follow a '--':
 #   ./run-tests.sh core -- -x --tb=short
+#
+# ---------------------------------------------------------------------------
+# How the run is staged
+#
+# There is no CI, so a *full* `./run-tests.sh` remains the only real gate and
+# still runs every check. What changed is the shape of the run, because the
+# stages are independent of each other and the box has more than one core:
+#
+#   1. Cheap gates, serial, fail-fast (~8s total). Linters, doc invariants,
+#      snapshot drift. These are quick enough that stopping at the first
+#      failure costs nothing and saves you reading past it.
+#   2. The frontend production build, serial. It has to precede pytest because
+#      a handful of tests serve the built bundle out of `static/`, and it is
+#      also the frontend failure people hit most, so it is worth failing on
+#      before spending minutes elsewhere.
+#   3. The heavy, mutually independent stages *concurrently*: pyright,
+#      pip-audit, the frontend unit suite, and pytest. Sequentially these were
+#      ~338s on a 4-vCPU box; overlapped they land at ~250s, within a few
+#      percent of what the machine's cores can physically do.
+#
+# Stage 3 deliberately does NOT stop at the first failure: every lane runs to
+# completion and all failures are reported together. A serial chain that dies
+# on the first bad gate makes you pay the whole runtime again per fix.
+#
+# Group runs (`./run-tests.sh <group>`) run stage 1 and their own tests, and
+# skip the stage-3 gates that are not about the code you just changed —
+# pyright, pip-audit, and the frontend suite. That keeps the edit/test loop in
+# the seconds it should be instead of paying ~105s of whole-repo checks to run
+# a five-second group. The skip is announced on every group run, because the
+# full run is what actually gates a push. Set VTSEARCH_FULL_GATES=1 to force
+# the complete chain on a group run.
+# ---------------------------------------------------------------------------
 
 set -euo pipefail
 cd "$(dirname "$0")"
@@ -39,14 +71,14 @@ _self="$(pwd)/$(basename "$0")"
 
 # Wall-clock cap on the whole run.
 #
-# A healthy full run is single-digit minutes (frontend gate ~3min, pytest ~35s,
-# plus first-run dep install), so 30 minutes is ~5x the worst legitimate run and
-# will not misfire — but it bounds the failure mode where the run wedges and
-# nobody notices. That is not hypothetical: an xdist run once sat for 2h12m with
-# three of its four workers `<defunct>` and the master idle, because *nothing*
-# in this script had an upper bound. A per-test timeout does not cover that case
-# (a dead worker can't fire its own timeout), which is why the cap lives out
-# here, wrapping every stage — dep install, linters, npm, pytest alike.
+# A healthy full run is a few minutes (see the staging note above), so 30
+# minutes is many times the worst legitimate run and will not misfire — but it
+# bounds the failure mode where the run wedges and nobody notices. That is not
+# hypothetical: an xdist run once sat for 2h12m with three of its four workers
+# `<defunct>` and the master idle, because *nothing* in this script had an
+# upper bound. A per-test timeout does not cover that case (a dead worker can't
+# fire its own timeout), which is why the cap lives out here, wrapping every
+# stage — dep install, linters, npm, pytest alike.
 #
 # Implemented as a one-shot re-exec under `timeout`: the guard variable stops
 # the child from re-wrapping itself. Set VTSEARCH_TEST_TIMEOUT=0 to opt out (for
@@ -87,56 +119,242 @@ if [[ "${1:-}" == "vtscore-clean" ]]; then
     exec python scripts/check-vtscore-clean.py "$@"
 fi
 
+# ---------------------------------------------------------------------------
+# Argument parsing
+#
+# Done up front (it used to sit after the gate chain) because which gates run
+# now depends on whether this is a full run or a group run.
+# ---------------------------------------------------------------------------
+TEST_GROUPS=()
+EXTRA_ARGS=()
+PAST_SEPARATOR=false
+
+for arg in "$@"; do
+    if [[ "$arg" == "--" ]]; then
+        PAST_SEPARATOR=true
+        continue
+    fi
+    if $PAST_SEPARATOR; then
+        EXTRA_ARGS+=("$arg")
+    else
+        TEST_GROUPS+=("$arg")
+    fi
+done
+
+_is_full_run=false
+if [[ ${#TEST_GROUPS[@]} -eq 0 ]]; then
+    _is_full_run=true
+fi
+
+# A group run can be promoted back to the complete chain on demand.
+_run_whole_repo_gates=false
+if $_is_full_run || [[ "${VTSEARCH_FULL_GATES:-}" == "1" ]]; then
+    _run_whole_repo_gates=true
+fi
+
+_group_named() {
+    local want="$1" g
+    for g in ${TEST_GROUPS[@]+"${TEST_GROUPS[@]}"}; do
+        [[ "$g" == "$want" ]] && return 0
+    done
+    return 1
+}
+
+# The frontend production build runs for the full suite and for the core /
+# frontend groups. Catches compilation errors without needing a browser.
+_run_frontend_check=false
+if $_is_full_run || _group_named core || _group_named frontend; then
+    _run_frontend_check=true
+fi
+
+# The frontend Vitest unit suite runs for the full run or an explicit
+# `frontend` group, but NOT for `core`: it is heavier than the compile-only
+# build check, so it stays off the fast `core` path.
+_run_frontend_unit=false
+if $_is_full_run || _group_named frontend; then
+    _run_frontend_unit=true
+fi
+
+# `frontend` is a frontend-only gate; it has no Python tests. If it's the only
+# requested group, skip pytest entirely so it doesn't error on an empty
+# `-m frontend` selection.
+_run_pytest=true
+if [[ ${#TEST_GROUPS[@]} -eq 1 && "${TEST_GROUPS[0]}" == "frontend" ]]; then
+    _run_pytest=false
+fi
+
+_blocked() {
+    echo ""
+    echo "============================================================"
+    echo "TESTS BLOCKED: $1"
+    echo "============================================================"
+}
+
+# ---------------------------------------------------------------------------
+# Stage 1: cheap gates. Serial and fail-fast — the whole set is ~8s, so
+# stopping at the first failure costs nothing.
+# ---------------------------------------------------------------------------
+
 # Ruff lint + format check.
-# Runs early because it's fast (~1s) and catches mistakes the pytest /
+# Runs first because it's fast (~0.5s) and catches mistakes the pytest /
 # frontend stages can't see, e.g. F401 unused-import on TYPE_CHECKING
 # imports whose only "use" is inside a string-form forward reference.
 echo "Running ruff check..."
 if ! ruff check . ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: ruff check failed"
-    echo "============================================================"
+    _blocked "ruff check failed"
     exit 1
 fi
 echo "Running ruff format --check..."
 if ! ruff format --check . ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: ruff format --check failed (run 'ruff format .')"
-    echo "============================================================"
+    _blocked "ruff format --check failed (run 'ruff format .')"
     exit 1
 fi
 
 echo "Running codespell..."
 if ! codespell --toml pyproject.toml ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: codespell found typos"
-    echo "============================================================"
+    _blocked "codespell found typos"
     exit 1
 fi
+
 # Documentation drift: relative links, in-page anchors, backticked repo paths,
 # leaked absolute machine paths, plan-file citations anywhere in the tree, and
 # broken code fences. Pure invariants against the current tree — nothing to
 # re-pin — and it imports nothing, so it costs ~0.4s and sits with the linters.
 echo "Checking documentation..."
 if ! python scripts/check-docs.py ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: documentation check found drift"
-    echo "============================================================"
+    _blocked "documentation check found drift"
     exit 1
 fi
 
 echo "Running deptry..."
 if ! python -m deptry . ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: deptry found dependency issues"
-    echo "============================================================"
+    _blocked "deptry found dependency issues"
     exit 1
 fi
+
+# OpenAPI snapshot drift check: regenerate the flask-smorest spec from
+# the live app and diff against the checked-in snapshot at
+# frontend/openapi.json. The frontend's generated TS client is built
+# from this snapshot, so a stale file means the generated client lags
+# the real API. Cheap (~2s) and runs every invocation.
+echo "Checking OpenAPI snapshot drift..."
+_openapi_regen=$(mktemp)
+_openapi_dump_log=$(mktemp)
+if ! python scripts/dump_openapi.py > "$_openapi_regen" 2> "$_openapi_dump_log"; then
+    _blocked "OpenAPI spec dump failed"
+    cat "$_openapi_dump_log"
+    rm -f "$_openapi_regen" "$_openapi_dump_log"
+    exit 1
+fi
+if ! diff -u frontend/openapi.json "$_openapi_regen" > /dev/null; then
+    _blocked "OpenAPI snapshot is stale"
+    echo "Run 'npm run regenerate-openapi-snapshot' (or"
+    echo "'python scripts/dump_openapi.py > frontend/openapi.json') and"
+    echo "commit the result."
+    diff -u frontend/openapi.json "$_openapi_regen" | head -80
+    rm -f "$_openapi_regen" "$_openapi_dump_log"
+    exit 1
+fi
+rm -f "$_openapi_regen" "$_openapi_dump_log"
+
+# Generated doc-inventory drift check: regenerate the registry-backed
+# tables embedded in the docs (embedders, plugin families, demo datasets,
+# ...) and fail if any committed region is stale. Same shape as the
+# OpenAPI snapshot gate above; see scripts/gen-docs-inventories.py.
+echo "Checking generated doc inventories..."
+if ! python scripts/gen-docs-inventories.py --check ; then
+    _blocked "generated doc inventories are stale"
+    echo "Run 'python scripts/gen-docs-inventories.py' and commit the"
+    echo "result."
+    exit 1
+fi
+
+echo "Checking Dockerfiles..."
+if ! python scripts/check-dockerfiles.py ; then
+    _blocked "Dockerfile check failed"
+    exit 1
+fi
+
+# User-docs screenshot wiring: every manifest shot id has both theme PNGs on
+# disk, and every screenshot the user docs embed maps to a manifest id. Cheap,
+# browser-free (see docs/plans/user-docs-screenshots.md); the pixel-diff
+# (check.sh) needs chromium and stays a manual chore.
+echo "Checking user-docs screenshot wiring..."
+if ! python scripts/screenshots/wiring-check.py ; then
+    _blocked "user-docs screenshot wiring check failed"
+    exit 1
+fi
+
+# vtscore package docs: every top-level module / sub-package of vtscore/ is
+# covered by a packages/ doc, and no doc cites a file.py:NNN line anchor (they
+# rot on the next edit; cite module-and-symbol instead). Regex sweep, imports
+# nothing, ~0.1s. See scripts/check-vtscore-docs.py for the policy.
+echo "Checking vtscore package docs..."
+if ! python scripts/check-vtscore-docs.py ; then
+    _blocked "vtscore package docs check failed"
+    exit 1
+fi
+
+# Eval/app sync: the eval framework reproduces a handful of app surfaces it
+# cannot call (the TypeScript autopilot phase machine, the app's default
+# resolution). This gate notices when one of those app surfaces changes, so the
+# eval default arm can't quietly stop being the shipped algorithm. Parses
+# source, imports nothing, ~0.3s.
+echo "Checking eval/app sync..."
+if ! python scripts/check-eval-app-sync.py ; then
+    _blocked "eval framework is out of sync with the app"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 2: frontend production build (serial).
+#
+# Ahead of the parallel stage on purpose. `tests/core/test_frontend.py` and
+# parts of `tests/api/test_dashboard.py` serve the built bundle out of
+# `static/`, so building it *while* pytest reads it would race; and a broken
+# build is the frontend failure that actually happens, so it is worth learning
+# about before the long stage starts.
+# ---------------------------------------------------------------------------
+if $_run_frontend_check && [ -d "frontend/node_modules" ]; then
+    echo "Checking frontend TypeScript build..."
+    _fe_log=$(mktemp)
+    if (cd frontend && npm run build:prod 2>&1) > "$_fe_log"; then
+        # Treat Angular compiler warnings (e.g. NG8107) and budget warnings as
+        # errors. Angular colourises its output even when stdout is a file, and
+        # it interleaves the escapes *inside* the marker
+        # (`ESC[33m▲ ESC[43;33m[ESC[43;30mWARNING…`), so the literal
+        # `▲ [WARNING]` never matches the raw log — that blindness let an
+        # over-budget initial bundle sail past this gate for months. Match
+        # against an ANSI-stripped copy instead.
+        _fe_plain=$(mktemp)
+        sed -r 's/\x1b\[[0-9;]*m//g' "$_fe_log" > "$_fe_plain"
+        if grep -q '▲ \[WARNING\]' "$_fe_plain"; then
+            _blocked "Frontend build has warnings (treated as errors)"
+            grep -A 10 '▲ \[WARNING\]' "$_fe_plain"
+            rm -f "$_fe_log" "$_fe_plain"
+            exit 1
+        fi
+        rm -f "$_fe_plain"
+        echo "Frontend build OK"
+    else
+        _blocked "Frontend build failed"
+        cat "$_fe_log"
+        rm -f "$_fe_log"
+        exit 1
+    fi
+    rm -f "$_fe_log"
+elif $_run_frontend_check && [ ! -d "frontend/node_modules" ]; then
+    echo "Skipping frontend build check (node_modules not installed; run: cd frontend && npm install)"
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 3: the heavy, mutually independent stages, run concurrently.
+#
+# pytest runs in the foreground so its progress still streams live (it is the
+# output people actually watch); everything else runs as a background lane
+# writing to its own log, reported after pytest returns. Every lane runs to
+# completion even if another fails, so one pass surfaces every problem.
+# ---------------------------------------------------------------------------
 
 # pip-audit: scans installed Python packages against the PyPI advisory
 # database. Auditing the resolved venv (not requirements files) catches
@@ -168,301 +386,148 @@ PIP_AUDIT_IGNORE=(
     --ignore-vuln PYSEC-2025-218
     --ignore-vuln PYSEC-2026-3444
 )
-echo "Running pip-audit..."
-if ! pip-audit "${PIP_AUDIT_IGNORE[@]}" ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: pip-audit found known vulnerabilities"
-    echo "============================================================"
-    exit 1
-fi
+
+_lane_names=()
+_lane_pids=()
+_lane_logs=()
+
+_start_lane() {
+    local name="$1"; shift
+    local log
+    log=$(mktemp)
+    "$@" > "$log" 2>&1 &
+    _lane_pids+=("$!")
+    _lane_names+=("$name")
+    _lane_logs+=("$log")
+}
 
 # Pyright: full static type check across vtsearch/ and tests/
 # (see `pyrightconfig.json` for the gated scope). The PYRIGHT_PYTHON_FORCE_VERSION
 # pin keeps everyone on the same underlying pyright binary regardless of
 # what the `pyright` PyPI wrapper would otherwise pull.
-echo "Running pyright..."
-if ! PYRIGHT_PYTHON_FORCE_VERSION=1.1.408 pyright ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: pyright found type errors"
-    echo "============================================================"
-    exit 1
+_lane_pyright() { PYRIGHT_PYTHON_FORCE_VERSION=1.1.408 pyright; }
+_lane_pip_audit() { pip-audit "${PIP_AUDIT_IGNORE[@]}"; }
+# --omit=dev: only audit production deps. Dev-only deps (e.g.
+# @angular-devkit/build-angular → webpack-dev-server) regularly carry
+# advisories with "no fix available" upstream because Angular hasn't
+# cut a release yet. Those affect `ng serve` on a developer's machine,
+# not anything that ships to users. Auditing prod deps is the actual
+# security gate worth blocking tests on.
+_lane_npm_audit() { (cd frontend && npm audit --omit=dev); }
+# `npm run test:ci` regenerates the API client (pretest:ci) then runs
+# `ng test --no-watch`, which exits non-zero on any spec failure.
+_lane_frontend_unit() { (cd frontend && npm run test:ci); }
+
+if $_run_whole_repo_gates; then
+    _start_lane "pyright" _lane_pyright
+    _start_lane "pip-audit" _lane_pip_audit
 fi
-
-# OpenAPI snapshot drift check: regenerate the flask-smorest spec from
-# the live app and diff against the checked-in snapshot at
-# frontend/openapi.json. The frontend's generated TS client is built
-# from this snapshot, so a stale file means the generated client lags
-# the real API. Cheap (~2s) and runs every invocation.
-echo "Checking OpenAPI snapshot drift..."
-_openapi_regen=$(mktemp)
-_openapi_dump_log=$(mktemp)
-if ! python scripts/dump_openapi.py > "$_openapi_regen" 2> "$_openapi_dump_log"; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: OpenAPI spec dump failed"
-    echo "============================================================"
-    cat "$_openapi_dump_log"
-    rm -f "$_openapi_regen" "$_openapi_dump_log"
-    exit 1
-fi
-if ! diff -u frontend/openapi.json "$_openapi_regen" > /dev/null; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: OpenAPI snapshot is stale"
-    echo "============================================================"
-    echo "Run 'npm run regenerate-openapi-snapshot' (or"
-    echo "'python scripts/dump_openapi.py > frontend/openapi.json') and"
-    echo "commit the result."
-    diff -u frontend/openapi.json "$_openapi_regen" | head -80
-    rm -f "$_openapi_regen" "$_openapi_dump_log"
-    exit 1
-fi
-rm -f "$_openapi_regen" "$_openapi_dump_log"
-
-# Generated doc-inventory drift check: regenerate the registry-backed
-# tables embedded in the docs (embedders, plugin families, demo datasets,
-# ...) and fail if any committed region is stale. Same shape as the
-# OpenAPI snapshot gate above; see scripts/gen-docs-inventories.py.
-echo "Checking generated doc inventories..."
-if ! python scripts/gen-docs-inventories.py --check ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: generated doc inventories are stale"
-    echo "============================================================"
-    echo "Run 'python scripts/gen-docs-inventories.py' and commit the"
-    echo "result."
-    exit 1
-fi
-
-echo "Checking Dockerfiles..."
-if ! python scripts/check-dockerfiles.py ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: Dockerfile check failed"
-    echo "============================================================"
-    exit 1
-fi
-
-# User-docs screenshot wiring: every manifest shot id has both theme PNGs on
-# disk, and every screenshot the user docs embed maps to a manifest id. Cheap,
-# browser-free (see docs/plans/user-docs-screenshots.md); the pixel-diff
-# (check.sh) needs chromium and stays a manual chore.
-echo "Checking user-docs screenshot wiring..."
-if ! python scripts/screenshots/wiring-check.py ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: user-docs screenshot wiring check failed"
-    echo "============================================================"
-    exit 1
-fi
-
-# vtscore package docs: every top-level module / sub-package of vtscore/ is
-# covered by a packages/ doc, and no doc cites a file.py:NNN line anchor (they
-# rot on the next edit; cite module-and-symbol instead). Regex sweep, imports
-# nothing, ~0.1s. See scripts/check-vtscore-docs.py for the policy.
-echo "Checking vtscore package docs..."
-if ! python scripts/check-vtscore-docs.py ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: vtscore package docs check failed"
-    echo "============================================================"
-    exit 1
-fi
-
-# Eval/app sync: the eval framework reproduces a handful of app surfaces it
-# cannot call (the TypeScript autopilot phase machine, the app's default
-# resolution). This gate notices when one of those app surfaces changes, so the
-# eval default arm can't quietly stop being the shipped algorithm. Parses
-# source, imports nothing, ~0.3s.
-echo "Checking eval/app sync..."
-if ! python scripts/check-eval-app-sync.py ; then
-    echo ""
-    echo "============================================================"
-    echo "TESTS BLOCKED: eval framework is out of sync with the app"
-    echo "============================================================"
-    exit 1
-fi
-
-# Split arguments into groups and extra pytest args
-TEST_GROUPS=()
-EXTRA_ARGS=()
-PAST_SEPARATOR=false
-
-for arg in "$@"; do
-    if [[ "$arg" == "--" ]]; then
-        PAST_SEPARATOR=true
-        continue
-    fi
-    if $PAST_SEPARATOR; then
-        EXTRA_ARGS+=("$arg")
-    else
-        TEST_GROUPS+=("$arg")
-    fi
-done
-
-# Run frontend TypeScript build check for full suite or when core/frontend groups are requested.
-# Catches compilation errors without needing a browser (build:prod is headless).
-_run_frontend_check=false
-if [[ ${#TEST_GROUPS[@]} -eq 0 ]]; then
-    _run_frontend_check=true
-else
-    for _g in "${TEST_GROUPS[@]}"; do
-        if [[ "$_g" == "core" || "$_g" == "frontend" ]]; then
-            _run_frontend_check=true
-            break
-        fi
-    done
-fi
-
-# Run the frontend Vitest unit suite for the full run or an explicit `frontend`
-# group, but NOT for `core`. The unit run (a full app build + headless Vitest)
-# is heavier than the compile-only build check, so it stays off the fast `core`
-# path; the full `./run-tests.sh` (the real gate, since there's no CI) and
-# `./run-tests.sh frontend` are where it runs.
-_run_frontend_unit=false
-if [[ ${#TEST_GROUPS[@]} -eq 0 ]]; then
-    _run_frontend_unit=true
-else
-    for _g in "${TEST_GROUPS[@]}"; do
-        if [[ "$_g" == "frontend" ]]; then
-            _run_frontend_unit=true
-            break
-        fi
-    done
-fi
-
 if $_run_frontend_check && [ -d "frontend/node_modules" ]; then
-    echo "Checking frontend TypeScript build..."
-    _fe_log=$(mktemp)
-    if (cd frontend && npm run build:prod 2>&1) > "$_fe_log"; then
-        # Treat Angular compiler warnings (e.g. NG8107) and budget warnings as
-        # errors. Angular colourises its output even when stdout is a file, and
-        # it interleaves the escapes *inside* the marker
-        # (`ESC[33m▲ ESC[43;33m[ESC[43;30mWARNING…`), so the literal
-        # `▲ [WARNING]` never matches the raw log — that blindness let an
-        # over-budget initial bundle sail past this gate for months. Match
-        # against an ANSI-stripped copy instead.
-        _fe_plain=$(mktemp)
-        sed -r 's/\x1b\[[0-9;]*m//g' "$_fe_log" > "$_fe_plain"
-        if grep -q '▲ \[WARNING\]' "$_fe_plain"; then
-            echo ""
-            echo "============================================================"
-            echo "TESTS BLOCKED: Frontend build has warnings (treated as errors)"
-            echo "============================================================"
-            grep -A 10 '▲ \[WARNING\]' "$_fe_plain"
-            rm -f "$_fe_log" "$_fe_plain"
-            exit 1
-        fi
-        rm -f "$_fe_plain"
-        echo "Frontend build OK"
-    else
-        echo ""
-        echo "============================================================"
-        echo "TESTS BLOCKED: Frontend build failed"
-        echo "============================================================"
-        cat "$_fe_log"
-        rm -f "$_fe_log"
-        exit 1
-    fi
-    rm -f "$_fe_log"
-
-    echo "Checking frontend dependencies for vulnerabilities..."
-    # --omit=dev: only audit production deps. Dev-only deps (e.g.
-    # @angular-devkit/build-angular → webpack-dev-server) regularly carry
-    # advisories with "no fix available" upstream because Angular hasn't
-    # cut a release yet. Those affect `ng serve` on a developer's machine,
-    # not anything that ships to users. Auditing prod deps is the actual
-    # security gate worth blocking tests on.
-    _audit_log=$(mktemp)
-    if (cd frontend && npm audit --omit=dev 2>&1) > "$_audit_log"; then
-        echo "Frontend audit OK (0 vulnerabilities in production deps)"
-    else
-        echo ""
-        echo "============================================================"
-        echo "TESTS BLOCKED: npm audit found known vulnerabilities"
-        echo "============================================================"
-        cat "$_audit_log"
-        rm -f "$_audit_log"
-        exit 1
-    fi
-    rm -f "$_audit_log"
-elif $_run_frontend_check && [ ! -d "frontend/node_modules" ]; then
-    echo "Skipping frontend build check (node_modules not installed; run: cd frontend && npm install)"
+    _start_lane "npm audit" _lane_npm_audit
 fi
-
-# Frontend unit tests (Vitest, headless via jsdom). `npm run test:ci` regenerates
-# the API client (pretest:ci) then runs `ng test --no-watch`, which exits
-# non-zero on any spec failure.
 if $_run_frontend_unit && [ -d "frontend/node_modules" ]; then
-    echo "Running frontend unit tests (Vitest)..."
-    _vt_log=$(mktemp)
-    if (cd frontend && npm run test:ci 2>&1) > "$_vt_log"; then
-        _vt_count=$(sed -r 's/\x1b\[[0-9;]*m//g' "$_vt_log" | grep -oE 'Tests +[0-9]+ passed' | tail -1)
-        echo "Frontend unit tests OK${_vt_count:+ ($_vt_count)}"
-    else
-        echo ""
-        echo "============================================================"
-        echo "TESTS BLOCKED: Frontend unit tests failed"
-        echo "============================================================"
-        tail -80 "$_vt_log"
-        rm -f "$_vt_log"
-        exit 1
-    fi
-    rm -f "$_vt_log"
+    _start_lane "frontend unit tests (Vitest)" _lane_frontend_unit
 elif $_run_frontend_unit && [ ! -d "frontend/node_modules" ]; then
     echo "Skipping frontend unit tests (node_modules not installed; run: cd frontend && npm install)"
 fi
 
-# `frontend` is a frontend-only gate (build + audit + Vitest above); it has no
-# Python tests. If it's the only requested group, skip pytest entirely so it
-# doesn't error on an empty `-m frontend` selection.
-if [[ ${#TEST_GROUPS[@]} -eq 1 && "${TEST_GROUPS[0]}" == "frontend" ]]; then
-    echo "Frontend-only run complete (no Python tests in the 'frontend' group)."
-    exit 0
+if [[ ${#_lane_names[@]} -gt 0 ]]; then
+    echo "Running in parallel with the tests: ${_lane_names[*]}"
+fi
+if ! $_run_whole_repo_gates; then
+    echo "Group run: skipping pyright and pip-audit. A full './run-tests.sh' is"
+    echo "the gate before pushing (or set VTSEARCH_FULL_GATES=1 to force them)."
 fi
 
-# Build the pytest marker expression
-if [[ ${#TEST_GROUPS[@]} -eq 0 ]]; then
-    # Default: run all fast tests
-    MARKER_EXPR=""
-else
-    # Combine groups with OR: -m "core or sorting"
-    MARKER_EXPR=""
-    for g in "${TEST_GROUPS[@]}"; do
-        if [[ -n "$MARKER_EXPR" ]]; then
-            MARKER_EXPR="$MARKER_EXPR or $g"
+# --- pytest, in the foreground ---------------------------------------------
+_pytest_status=0
+if $_run_pytest; then
+    # Build the pytest marker expression
+    if $_is_full_run; then
+        # Default: run all fast tests
+        MARKER_EXPR=""
+    else
+        # Combine groups with OR: -m "core or sorting"
+        MARKER_EXPR=""
+        for g in "${TEST_GROUPS[@]}"; do
+            if [[ -n "$MARKER_EXPR" ]]; then
+                MARKER_EXPR="$MARKER_EXPR or $g"
+            else
+                MARKER_EXPR="$g"
+            fi
+        done
+    fi
+
+    # Coverage is opt-in via VTSEARCH_COVERAGE=1. Default off because it adds
+    # ~10-20% overhead and the report is most useful when explicitly asked for.
+    COV_ARGS=()
+    if [[ "${VTSEARCH_COVERAGE:-}" == "1" ]]; then
+        COV_ARGS=(--cov=vtsearch --cov-report=term-missing)
+    fi
+
+    # Run pytest with:
+    #   --tb=short: brief tracebacks (enough to diagnose, not overwhelming)
+    #   --no-header: skip the platform/plugin header noise
+    #   -q:         quiet mode (dots instead of full test names)
+    #   -n auto:    parallel execution via pytest-xdist (one worker per CPU)
+    #   --dist loadgroup: like the default load scheduling, except tests marked
+    #       @pytest.mark.xdist_group run together on one worker. Used to pin all
+    #       real-UMAP-fit tests to a single worker so the ~30s numba JIT compile
+    #       of umap-learn's kernels is paid once per run rather than once per
+    #       worker (tests_lib/projection/test_umap_projection.py), and to keep
+    #       each eval-sweep module together so its memoized sweeps hit the cache
+    #       instead of being recomputed on every worker that draws one
+    #       (tests_lib/detectors/sweep_cache.py).
+    #
+    # Both tests/ (app tier) and tests_lib/ (library tier) are passed in.
+    # The two trees have independent conftests; pytest's auto-merge picks
+    # the right autouse fixtures per test based on file location.
+    set +e
+    if [[ -n "$MARKER_EXPR" ]]; then
+        python -m pytest tests/ tests_lib/ -q --tb=short --no-header -n auto --dist loadgroup -m "$MARKER_EXPR" ${COV_ARGS[@]+"${COV_ARGS[@]}"} ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
+    else
+        python -m pytest tests/ tests_lib/ -q --tb=short --no-header -n auto --dist loadgroup ${COV_ARGS[@]+"${COV_ARGS[@]}"} ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
+    fi
+    _pytest_status=$?
+    set -e
+fi
+
+# --- collect the background lanes ------------------------------------------
+_failed_lanes=()
+if [[ ${#_lane_names[@]} -gt 0 ]]; then
+    echo ""
+    echo "Waiting for: ${_lane_names[*]}"
+    for _i in "${!_lane_pids[@]}"; do
+        set +e
+        wait "${_lane_pids[$_i]}"
+        _st=$?
+        set -e
+        if [[ $_st -eq 0 ]]; then
+            echo "  ${_lane_names[$_i]}: OK"
         else
-            MARKER_EXPR="$g"
+            echo "  ${_lane_names[$_i]}: FAILED"
+            _failed_lanes+=("$_i")
         fi
     done
 fi
 
-# Coverage is opt-in via VTSEARCH_COVERAGE=1. Default off because tests
-# already run in ~35s; coverage adds ~10-20% overhead and the coverage
-# report is most useful when explicitly asked for.
-COV_ARGS=()
-if [[ "${VTSEARCH_COVERAGE:-}" == "1" ]]; then
-    COV_ARGS=(--cov=vtsearch --cov-report=term-missing)
-fi
+# Report every failing lane, not just the first: the point of running them
+# concurrently is that one pass tells you everything that is broken.
+for _i in ${_failed_lanes[@]+"${_failed_lanes[@]}"}; do
+    _blocked "${_lane_names[$_i]} failed"
+    tail -80 "${_lane_logs[$_i]}"
+done
+for _log in ${_lane_logs[@]+"${_lane_logs[@]}"}; do
+    rm -f "$_log"
+done
 
-# Run pytest with:
-#   --tb=short: brief tracebacks (enough to diagnose, not overwhelming)
-#   --no-header: skip the platform/plugin header noise
-#   -q:         quiet mode (dots instead of full test names)
-#   -n auto:    parallel execution via pytest-xdist (one worker per CPU)
-#   --dist loadgroup: like the default load scheduling, except tests marked
-#       @pytest.mark.xdist_group run together on one worker.  Used to pin all
-#       real-UMAP-fit tests to a single worker so the ~30s numba JIT compile
-#       of umap-learn's kernels is paid once per run, not once per worker
-#       (see tests_lib/projection/test_umap_projection.py).
-#
-# Both tests/ (app tier) and tests_lib/ (library tier) are passed in.
-# The two trees have independent conftests; pytest's auto-merge picks
-# the right autouse fixtures per test based on file location.
-if [[ -n "$MARKER_EXPR" ]]; then
-    python -m pytest tests/ tests_lib/ -q --tb=short --no-header -n auto --dist loadgroup -m "$MARKER_EXPR" "${COV_ARGS[@]}" "${EXTRA_ARGS[@]}"
-else
-    python -m pytest tests/ tests_lib/ -q --tb=short --no-header -n auto --dist loadgroup "${COV_ARGS[@]}" "${EXTRA_ARGS[@]}"
+if [[ ${#_failed_lanes[@]} -gt 0 ]]; then
+    exit 1
 fi
+if [[ $_pytest_status -ne 0 ]]; then
+    exit $_pytest_status
+fi
+if ! $_run_pytest; then
+    echo "Frontend-only run complete (no Python tests in the 'frontend' group)."
+fi
+exit 0

--- a/scripts/check-vtscore-clean.py
+++ b/scripts/check-vtscore-clean.py
@@ -65,6 +65,14 @@ def main() -> int:
         "--no-header",
         "-n",
         "auto",
+        # Must match run-tests.sh's scheduler. Plain `load` scattering ignores
+        # `@pytest.mark.xdist_group`, which several modules here depend on for
+        # speed: the real-UMAP fits pay umap-learn's ~30s numba JIT compile once
+        # per worker that draws one instead of once per run, and the eval-sweep
+        # modules recompute their memoized sweeps on every worker they land on
+        # (tests_lib/detectors/sweep_cache.py) rather than simulating once.
+        "--dist",
+        "loadgroup",
         "-m",
         "not gpu and not slow",
         *sys.argv[1:],

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -133,6 +133,7 @@ def is_object_category(name: str) -> bool:
         return False
     return tokens[-1] not in NON_OBJECT_CATEGORIES and name not in NON_OBJECT_CATEGORIES
 
+
 #: Embedders in the pile. ``patch`` embedders attach ``patch_grid`` and are the
 #: only ones that can carry a region-voting arm.
 #: Deliberately three, not five. ``siglip`` is the shipped default and

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -24,11 +24,25 @@ from tests_lib.flask_blocker import install_if_requested as _install_flask_block
 
 _install_flask_blocker()
 
+# Cap native math threads BEFORE numpy/torch are imported, mirroring the top of
+# ``app.py``.  The app tier gets this for free (``tests/conftest.py`` imports
+# ``app``), but a ``tests_lib``-only run never does, and the fallback
+# (``ensure_torch_configured``) only fires from embedder paths the suite stubs
+# out — so torch fell back to one intra-op thread *per core*.  Under ``-n auto``
+# that is workers x cores native threads fighting over the same cores, and it
+# is not a small effect: ``pytest tests_lib/detectors`` alone went 130s -> 51s
+# on a 4-vCPU box when these were set.  Resolved the same way ``app.py`` does
+# so an explicit ``VTSEARCH_TORCH_THREADS`` override still wins.
+import os  # noqa: E402
+
+_torch_threads = str(max(1, int(os.environ.get("VTSEARCH_TORCH_THREADS", "1"))))
+os.environ.setdefault("OMP_NUM_THREADS", _torch_threads)
+os.environ.setdefault("MKL_NUM_THREADS", _torch_threads)
+
 from pathlib import Path  # noqa: E402
 from unittest.mock import patch  # noqa: E402
 
 import numpy as np  # noqa: E402
-import os  # noqa: E402
 import pytest  # noqa: E402
 
 import vtscore.config as config  # noqa: E402

--- a/tests_lib/detectors/sweep_cache.py
+++ b/tests_lib/detectors/sweep_cache.py
@@ -1,0 +1,67 @@
+"""Process-local memoization for the eval-harness sweeps.
+
+``simulate_voting_iterations`` is by far the most expensive thing the Python
+suite does: a single call trains a head and fits the safe-threshold mixtures
+once per simulated voting step, so one sweep costs seconds.  The threshold /
+variant-frame tests are written as one assertion per behaviour, and most of
+them assert on *different columns of the same frame* — so the same sweep, with
+byte-identical arguments, was being recomputed once per test.  Across
+``tests_lib/detectors`` that duplication was roughly a quarter of the whole
+pytest runtime.
+
+:func:`memoize_sweep` wraps such a helper so identical argument sets are
+computed once per worker process and replayed thereafter.  Two properties make
+this sound:
+
+* **The sweeps are deterministic.** Every call site passes an explicit
+  ``seed``, and the planted fixtures are built from a seeded ``default_rng``,
+  so a repeat call cannot produce different rows.
+* **The call still happens inside the test body**, not in a module- or
+  session-scoped fixture. That matters: higher-scoped fixtures are set up
+  *before* the function-scoped autouse ``reset_contexts``, which would let a
+  previous test's leaked ``config.TRAIN_EPOCHS`` (issue #3101) decide the
+  training budget for a cached sweep. Memoizing the plain helper keeps the
+  first, cache-filling call in exactly the state it runs in today.
+
+**Cached results are shared, so treat them as read-only.** A test that mutates
+returned rows would corrupt every later test that gets the same cached object.
+Tests that genuinely need a fresh computation — determinism checks that compare
+two independent runs, or anything passing a mutable output sink — must call the
+underlying helper directly rather than the memoized wrapper.
+
+For the cache to actually hit, the tests sharing it have to land on the same
+xdist worker: a module that relies on this carries a
+``pytestmark = pytest.mark.xdist_group(...)`` so ``--dist loadgroup`` keeps it
+together. Without that, a 4-worker run scatters the calls and recomputes the
+sweep on each worker that sees one.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable, TypeVar
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def memoize_sweep(fn: _F) -> _F:
+    """Memoize *fn* on its arguments for the life of the worker process.
+
+    Unlike :func:`functools.lru_cache` this accepts keyword arguments whose
+    values are unhashable (the sweeps take lists of rules / inclusion ks), by
+    keying on a ``repr`` of the bound arguments instead of the values
+    themselves. The keys are small, fully-determined literals at every call
+    site, so ``repr`` is an exact identity here rather than an approximation.
+    """
+    cache: dict[str, Any] = {}
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        key = repr((args, sorted(kwargs.items())))
+        if key not in cache:
+            cache[key] = fn(*args, **kwargs)
+        return cache[key]
+
+    wrapper.cache_clear = cache.clear  # type: ignore[attr-defined]
+    wrapper.__wrapped__ = fn  # type: ignore[attr-defined]
+    return wrapper  # type: ignore[return-value]

--- a/tests_lib/detectors/test_acq_inclusion.py
+++ b/tests_lib/detectors/test_acq_inclusion.py
@@ -20,7 +20,14 @@ from vtscore.training.thresholds import (
     fit_fold_anchored_cut,
 )
 
+from .sweep_cache import memoize_sweep
 from .test_max_patch_style import _planted_dataset
+
+# The offsets this file sweeps repeat across tests (``-2`` alone is asserted on
+# by three of them), so each distinct argument set is simulated once per worker
+# and this module is pinned to one worker for the cache to hit.  Rows are
+# shared and must stay read-only.  See sweep_cache.py.
+pytestmark = pytest.mark.xdist_group("acq-inclusion")
 
 
 def _base(rows):
@@ -40,6 +47,7 @@ def _base(rows):
     ]
 
 
+@memoize_sweep
 def _run(**kw):
     """A run on the established planted fixture, at a size that reaches the
     fold-anchored path (which needs enough votes to form calibration folds)."""

--- a/tests_lib/detectors/test_anchored_variant_rows.py
+++ b/tests_lib/detectors/test_anchored_variant_rows.py
@@ -14,20 +14,27 @@ is surfaced in ``threshold_provenance``, and everything is deterministic.
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from vtscore.eval.cut_rules import CUT_KIND_MIDPOINT
 from vtscore.eval.voting_iterations import _CALIBRATION_COLUMNS, simulate_voting_iterations
 from vtscore.training.thresholds import CUT_KIND_CONTINUED, CUT_KIND_DEGENERATE_MIDPOINT, CUT_KIND_INTERIOR
 
 # Reuse the synthetic planted-patch dataset builders from the Max-Patch tests.
+from .sweep_cache import memoize_sweep
 from .test_max_patch_style import _planted_dataset
+
+# Three tests below read different columns of the identical default sweep, so
+# it is computed once per worker and this module is pinned to one worker for
+# that cache to hit.  Shared rows are read-only.  See sweep_cache.py.
+pytestmark = pytest.mark.xdist_group("anchored-variant-rows")
 
 _ANCHORED = "anchored_w10_mid"
 _FOLD = "fold_anchored_w10_mid_qmean"
 _RANK = "rank_transfer"
 
 
-def _run(seed=0, max_steps=12, fold_arms=True):
+def _run_uncached(seed=0, max_steps=12, fold_arms=True):
     medias, _ = _planted_dataset(n_per_cat=40, seed=seed)
     return simulate_voting_iterations(
         medias,
@@ -46,6 +53,11 @@ def _run(seed=0, max_steps=12, fold_arms=True):
         anchored_fold_combines=["qmean"],
         anchored_fold_arms=fold_arms,
     )
+
+
+#: Memoized view of :func:`_run_uncached`.  Every test that only *reads* the
+#: frame goes through this; ``test_deterministic`` deliberately does not.
+_run = memoize_sweep(_run_uncached)
 
 
 class TestAnchoredVariantRows:
@@ -115,14 +127,20 @@ class TestAnchoredVariantRows:
         assert _RANK not in variants
 
     def test_deterministic(self):
+        """Two *independent* sweeps must agree.
+
+        This deliberately bypasses the memoized ``_run``: the cache would hand
+        back the very same list twice and the assertion would hold no matter
+        how non-deterministic the harness became.
+        """
         thr_a = [
             (r["t"], r["gmm_variant"], r["threshold"])
-            for r in _run()
+            for r in _run_uncached()
             if r["gmm_variant"].startswith(("anchored", "fold_anchored", "rank"))
         ]
         thr_b = [
             (r["t"], r["gmm_variant"], r["threshold"])
-            for r in _run()
+            for r in _run_uncached()
             if r["gmm_variant"].startswith(("anchored", "fold_anchored", "rank"))
         ]
         assert thr_a == thr_b

--- a/tests_lib/detectors/test_cut_inclusion_sweep.py
+++ b/tests_lib/detectors/test_cut_inclusion_sweep.py
@@ -24,12 +24,20 @@ from vtscore.eval.calibration_metrics import inclusion_weights, operating_cost
 from vtscore.eval.voting_iterations import _CUT_INCLUSION_COLUMNS, simulate_voting_iterations
 
 # Reuse the synthetic planted-patch dataset builders from the Max-Patch tests.
+from .sweep_cache import memoize_sweep
 from .test_max_patch_style import _planted_dataset
+
+# Six of the tests below sweep the identical default frame and assert on
+# different columns of it, so the sweep is memoized per worker and this module
+# is pinned to one worker for the cache to hit.  Rows handed back are shared:
+# read them, never mutate them.  See sweep_cache.py.
+pytestmark = pytest.mark.xdist_group("cut-inclusion-sweep")
 
 _KS = [-4, -2, 0, 2, 4]
 _RULES = ["mid", "mid_tilt", "rate", "cross_tilt", "q_tilt"]
 
 
+@memoize_sweep
 def _run(seed=0, max_steps=12, ks=None, rules=None, qtilt_steps=None):
     medias, _ = _planted_dataset(n_per_cat=40, seed=seed)
     sink: list[dict] = []

--- a/tests_lib/detectors/test_fold_count_variant_rows.py
+++ b/tests_lib/detectors/test_fold_count_variant_rows.py
@@ -29,7 +29,12 @@ from vtscore.eval.voting_iterations import _CALIBRATION_COLUMNS, simulate_voting
 from vtscore.training import thresholds as _thresholds
 
 # Reuse the synthetic planted-patch dataset builder from the Max-Patch tests.
+from .sweep_cache import memoize_sweep
 from .test_max_patch_style import _planted_dataset
+
+# Pinned to one worker so the memoized sweeps below actually hit the cache
+# under ``--dist loadgroup``.  See sweep_cache.py.
+pytestmark = pytest.mark.xdist_group("fold-count-variant-rows")
 
 _COUNTS = [1, 2, 4]
 
@@ -59,7 +64,7 @@ class _StubClock:
         return self._now
 
 
-def _run(
+def _run_uncached(
     *, fold_counts=None, calibrate_count=2, safe=False, seed=0, max_steps=10, region_voting=True, style="max_patch"
 ):
     medias, _ = _planted_dataset(n_per_cat=40, seed=seed)
@@ -77,6 +82,14 @@ def _run(
         emit_calibration_metrics=True,
         fold_count_variants=fold_counts,
     )
+
+
+#: Memoized view of :func:`_run_uncached`.  Six tests sweep the identical
+#: ``fold_counts=_COUNTS`` frame and read different columns of it.  Two callers
+#: deliberately stay on the uncached function: the determinism test (a cache hit
+#: would compare a list against itself) and the stub-clock test (whose rows are
+#: computed under a monkeypatched clock and must never enter a shared cache).
+_run = memoize_sweep(_run_uncached)
 
 
 def _base_rows(rows):
@@ -158,7 +171,9 @@ class TestFoldCountArms:
         grouped calibrator and the row-wise one.
         """
         monkeypatch.setattr(_thresholds, "time", _StubClock(_STUB_FOLD_SECONDS))
-        rows = _run(fold_counts=[1, 2, 8], calibrate_count=2, region_voting=region_voting, style=style)
+        # Uncached on purpose: these rows are billed by a stubbed clock, so they
+        # must not be memoized where a later test could pick them up.
+        rows = _run_uncached(fold_counts=[1, 2, 8], calibrate_count=2, region_voting=region_voting, style=style)
         base = _base_rows(rows)
         live = _arm_rows(rows, "folds_k2_xcal")
         screened = _arm_rows(rows, "folds_k8_xcal")
@@ -252,8 +267,10 @@ class TestFoldCountBinaryVoting:
 
 class TestFoldCountDeterminism:
     def test_two_runs_agree(self):
-        a = _run(fold_counts=_COUNTS)
-        b = _run(fold_counts=_COUNTS)
+        """Two *independent* sweeps must agree, so this bypasses the memoized
+        ``_run`` — a cache hit would compare one list against itself."""
+        a = _run_uncached(fold_counts=_COUNTS)
+        b = _run_uncached(fold_counts=_COUNTS)
         assert len(a) == len(b)
         for ra, rb in zip(a, b, strict=True):
             assert ra["gmm_variant"] == rb["gmm_variant"]

--- a/tests_lib/detectors/test_safe_gmm_variant_rows.py
+++ b/tests_lib/detectors/test_safe_gmm_variant_rows.py
@@ -16,6 +16,7 @@ measures the retired schedule blend.
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from vtscore.eval.cut_rules import CUT_KIND_MIDPOINT
 from vtscore.eval.voting_iterations import (
@@ -33,7 +34,15 @@ from vtscore.training.thresholds import (
 )
 
 # Reuse the synthetic planted-patch dataset builders from the Max-Patch tests.
+from .sweep_cache import memoize_sweep
 from .test_max_patch_style import _planted_dataset
+
+# Nine of the tests below sweep ``max_patch`` at identical settings — five
+# reading only the metric rows, four also reading the decomposition frame — so
+# each of those two shapes is simulated once per worker and this module is
+# pinned to one worker for the cache to hit.  Shared rows are read-only.
+# See sweep_cache.py.
+pytestmark = pytest.mark.xdist_group("safe-gmm-variant-rows")
 
 _VARIANT_NAMES = {name for name, _fit, _rule in _SAFE_GMM_VARIANTS}
 #: Variants that must appear at every trainable step.  The label-reading
@@ -42,7 +51,7 @@ _VARIANT_NAMES = {name for name, _fit, _rule in _SAFE_GMM_VARIANTS}
 _ALWAYS_EMITTED = _VARIANT_NAMES - set(_ORACLE_VARIANTS)
 
 
-def _run_safe(style, seed=0, max_steps=16, diag_sink=None, **kw):
+def _run_safe_uncached(style, seed=0, max_steps=16, diag_sink=None, **kw):
     medias, _ = _planted_dataset(n_per_cat=40, seed=seed)
     return simulate_voting_iterations(
         medias,
@@ -58,6 +67,38 @@ def _run_safe(style, seed=0, max_steps=16, diag_sink=None, **kw):
         cut_diag_sink=diag_sink,
         **kw,
     )
+
+
+_run_safe_no_sink = memoize_sweep(_run_safe_uncached)
+
+
+@memoize_sweep
+def _run_safe_with_diag(style, **kw):
+    """A sweep that also collects the decomposition frame, as a cacheable pair.
+
+    The frame is delivered through a caller-owned list, which cannot be part of
+    a cache key — every caller passes a fresh empty one. Running the sweep with
+    a sink this wrapper owns, and returning ``(rows, diagnostics)``, makes the
+    whole result cacheable; :func:`_run_safe` replays the diagnostics into
+    whichever list the test handed in.
+    """
+    sink: list[dict] = []
+    rows = _run_safe_uncached(style, diag_sink=sink, **kw)
+    return rows, sink
+
+
+def _run_safe(style, seed=0, max_steps=16, diag_sink=None, **kw):
+    """Memoized sweep, with or without the decomposition frame.
+
+    Passing a sink is not a different simulation, only a different *view* of
+    one, so both shapes are cached; see :mod:`.sweep_cache` for why the results
+    must be treated as read-only.
+    """
+    if diag_sink is None:
+        return _run_safe_no_sink(style, seed=seed, max_steps=max_steps, **kw)
+    rows, diagnostics = _run_safe_with_diag(style, seed=seed, max_steps=max_steps, **kw)
+    diag_sink.extend(diagnostics)
+    return rows
 
 
 class TestSafeGmmVariantRows:


### PR DESCRIPTION
## What

The suite's runtime was the complaint, not its size — so nothing is deleted, skipped, or weakened. Four independent fixes, each measured on a warm 4-vCPU container:

| Run | Before | After |
|---|---|---|
| Full `./run-tests.sh` | ~338s | **~195-200s** |
| `./run-tests.sh vtscore-clean` | ~278s | **~84s** |
| Group run (e.g. `converters`) | ~125s | **~35s** |
| Frontend Vitest suite alone | ~88s (258 core-s) | **~33s (68 core-s)** |

All 8,424 Python tests and 2,051 frontend tests still run and pass.

## The four fixes

**1. Stage `run-tests.sh` instead of running everything serially.** pyright (~85s), pip-audit, the Vitest suite (~88s), and pytest (~170s) are mutually independent but ran back-to-back. Now the ~10s of cheap linters stay serial and fail-fast, the frontend build stays serial ahead of pytest (some tests serve the bundle out of `static/`), and the heavy gates run concurrently with pytest — every lane runs to completion and **all** failures are reported in one pass (verified by injecting a pyright error and a test failure simultaneously; both surfaced). A closing `RUN PASSED` / `RUN FAILED: <gates>` banner keeps the last `====` block the verdict.

**2. Drop `isolate: true` from the Vitest config.** Per-file isolation cost ~155s of jsdom environment construction + ~92s of setup re-evaluation against ~89s of actual tests. The TestBed-cascade problem it guarded against is already handled by the defensive `resetTestingModule()` in `src/test-setup.ts`. Validated with three consecutive shuffled-order runs — 155 files, 2051 tests, all green each time.

**3. Memoize the duplicated eval-harness sweeps.** `tests_lib/detectors` was 190s of the 383s of pytest call time, mostly identical `simulate_voting_iterations` runs recomputed once per test (the same default frame 6× in one file, 9× in another). A small `sweep_cache.memoize_sweep` shares each distinct sweep per worker, with `xdist_group` pins so `--dist loadgroup` lets the cache hit. The two determinism tests and the stub-clock test deliberately stay uncached (a cache hit would make the determinism assertions vacuous, and stub-clock rows must not leak into the shared cache). Those five files: 137s → 79s.

**4. Cap native math threads in `tests_lib`-only runs.** The oddest finding: `pytest tests_lib/` alone took 283s — *slower than the entire combined suite*. The app tier caps `OMP_NUM_THREADS=1` at the top of `app.py`, which `tests/conftest.py` imports; a `tests_lib`-only run never does, and the library fallback only fires from embedder paths the suite stubs. Result: 4 xdist workers × 4 torch intra-op threads thrashing 4 cores. A/B on `tests_lib/detectors`: 130s → 51s. Fixed by mirroring `app.py`'s env cap at the top of `tests_lib/conftest.py` (an explicit `VTSEARCH_TORCH_THREADS` still wins). Also gave `check-vtscore-clean.py` the same `--dist loadgroup` scheduler as `run-tests.sh` so the `xdist_group` pins apply there too.

## Policy change (explicitly approved)

Group runs now skip the heavy whole-repo gates (pyright, pip-audit, frontend gates outside `core`/`frontend`) — reversing the old "every invocation runs the full gate chain" rule — so the inner loop is seconds, not minutes. The skip is announced in the run's output, `VTSEARCH_FULL_GATES=1` forces the full chain, and a full `./run-tests.sh` remains mandatory before pushing. CLAUDE.md's gates section is rewritten to match (and now includes two gates the old table had drifted from: doc inventories and vtscore package docs).

## What was evaluated and deliberately left alone

- **Per-test fixture overhead**: total setup across 8,432 tests is 17s (~2ms each) — already well tuned, nothing to win.
- **Test count/coverage**: untouched. The savings come from not doing the same work twice (sweeps, jsdom envs) and not idling cores, not from testing less.

Also fixes pre-existing `ruff format` drift in `scripts/experiments/pile/pile_config.py` that was blocking the format gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZgMmMjTWRDDjZn1BRHVTp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZgMmMjTWRDDjZn1BRHVTp)_