### PR TITLE
Stop losing issues whose fix shipped under another number

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ When your change resolves a GitHub issue, **link the PR back to that issue** so 
 
 - Put a closing keyword in the **PR body**: `Closes #N` (or `Fixes #N` / `Resolves #N`). This populates GitHub's "Linked issues" sidebar and the issue timeline. Reference every issue the PR resolves; use one keyword per issue (`Closes #12, closes #15`), not a comma-list after a single `Closes`.
 - If the PR only *partly* addresses an issue, use a non-closing reference instead — `Refs #N` / `Part of #N` — so it links without implying the issue is done.
-- Also drop a one-line comment on the issue pointing at the PR (e.g. "Addressed in #M"), so someone reading the issue sees the fix even before it merges.
+- Also drop a one-line comment on the issue pointing at the PR (e.g. "Addressed in #M"), so someone reading the issue sees the fix even before it merges. **Name the PR number, never a bare commit SHA.** "Fixed on `dev` by `de9ae81ac`" reads fine to a human and is invisible to the machinery: `scripts/reconcile-dev-labels.py` matches `#M`, so a SHA-only pointer used to report as "not resolved on dev" — indistinguishable from an issue nobody had started. The script now surfaces SHA pointers as `NEEDS REVIEW` rather than swallowing them, but that is a backstop that costs a human a lookup; write `#M` and it costs nothing. A SHA is a fine *addition* ("Addressed in #3051 (`de9ae81ac`)"), never the only pointer.
 
 **The PR keyword is the load-bearing signal, and the issue comment must agree with it.** The `dev`→`main` sweep (step 6 of `docs/RELEASE.md`) decides what to close by reading **PR bodies**, not issue comments — so the keyword you pick is what determines whether the issue ever gets closed. `Refs #N` on a PR that actually finishes the issue is not a harmless understatement: the sweep reads it as "still partial", skips the issue, and *nothing revisits it in a later release*. The issue stays open forever while its fix is live in `main`.
 
@@ -73,6 +73,20 @@ Use `Refs` only when you can name the work that remains on **that issue**. Resco
 If you catch yourself writing "Addressed in #M" on the issue while the PR body says `Refs`, one of the two is wrong — fix it before merging.
 
 **Do not close the issue yourself.** The closing keyword will **not** auto-close the issue on merge, because GitHub only auto-closes keyword-linked issues when the PR merges into the **default branch** (`main`), and our PRs target **`dev`**. That is intentional: an issue stays open while its fix lives only on `dev`, and is closed only once the fix reaches `main` (i.e. is actually shipped to users). The `dev`→`main` merge Routine is what sweeps the now-shipped issues closed (with `state_reason: completed`); a per-fix Claude session must not close the issue early. So: link and comment, but leave the issue open.
+
+## Duplicate issues: search before filing, link the moment you find one
+
+**Search the tracker before opening an issue.** Use `search_issues` on the symptom — a failing test's name, an error string, the file path — not on your own phrasing of the diagnosis. Two sessions hitting the same bug a day apart will describe it differently (one calls it flaky, the other calls it systematically wrong) while naming the identical test, so the symptom is what actually matches and the diagnosis is what actually diverges.
+
+**A duplicate that is never linked is worse than a noisy tracker**, because the `dev`→`main` sweep resolves issues through PR bodies and issue comments. When the fix PR names only one of the pair, the other has *nothing* pointing at it: no closing keyword, no `Refs`, no comment. All three of `docs/RELEASE.md` step 6's buckets are blind to it by construction, and no later release re-examines an already-merged PR. It stays open forever while its fix is live in `main`. That is exactly how #2911 sat open for six days after shipping, and the only reason it was caught is that someone asked about it directly.
+
+So when you find that two issues are the same bug:
+
+- **Fixing both at once** — put a closing keyword for **each** in the PR body (`Closes #12, closes #15`), and comment `Addressed in #M` on both. One PR legitimately closes N issues; the sweep handles that fine.
+- **Discovering the duplicate before any fix** — close the *newer* one with `state_reason: "duplicate"` and `duplicate_of: <older number>`, and keep the older one as the survivor. GitHub renders the link natively, and it is the survivor that the fix PR then references. Do not close the older one as duplicate of the newer just because the newer has a better write-up; fold the better write-up into the survivor's body instead.
+- **Discovering it after the fix already shipped** — comment `Addressed in #M` on the orphan naming the fix PR, and close it `completed` (stripping `dev` if present, per the label rules below). This is the one case where a per-fix session closes an issue itself rather than leaving it to the sweep: the sweep's window is `origin/main..origin/dev`, and a fix already on `main` has fallen out the far end of it, so nothing will ever pick the issue up again.
+
+The general shape: an issue is only ever resolved by something that *names its number*. If you know a number is resolved and nothing on GitHub says so, write the pointer yourself.
 
 ## Issues vs `docs/plans/`: one item, one home (CRITICAL)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -69,9 +69,11 @@ Now that the release PR is open, close the GitHub issues whose fixes are include
 - For each such PR, read its body and collect **every** issue it references, keeping track of which keyword introduced each reference. Sort them into two buckets:
   - **Closing** — `Closes #N`, `Fixes #N`, `Resolves #N` (case-insensitive).
   - **Non-closing** — `Refs #N`, `Part of #N`, or a bare `#N` mention.
-- Then add a third bucket, the **orphan backstop**: list the repo's still-open issues and check each one's comments for a pointer at a PR in this release range (`Addressed in #M`, `Fixed in #M`, and similar). Collect any whose pointer names a PR in the range that never referenced it back. (To keep this cheap, it's enough to check issues updated since the previous release.)
+- Then add a third bucket, the **orphan backstop**: list the repo's still-open issues and check each one's comments for a pointer at a PR in this release range (`Addressed in #M`, `Fixed in #M`, and similar). Collect any whose pointer names a PR in the range that never referenced it back. (To keep this cheap, it's enough to check issues updated since the previous release.) A pointer naming a **commit** rather than a PR (`Fixed on dev by <sha>`) belongs in this bucket too — resolve the SHA to its merge commit to find the PR, then reconcile it like any other orphan.
 
 Non-closing references are **not** silently skipped. A PR that finishes an issue but writes `Refs #N` would otherwise orphan it permanently: this step skips it, and because no later release re-examines an already-merged PR, nothing ever revisits it — the issue stays open forever while its fix is live in `main`. Real incident: #2940, #2930 and #2951 each shipped in the 2026-08-12 release under `Refs`, with an "Addressed in #M" comment on the issue, and all three stayed open. So the non-closing and orphan buckets get **reconciled** rather than dropped.
+
+**The hardest orphan is a duplicate.** #2911 shipped to `main` in the 2026-08-11 release and stayed open until 2026-08-17. It was a duplicate of #3025, the fix PR wrote `Closes #3025` only, and at release time #2911 had no comments and no PR references at all — so all three buckets were blind to it by construction, not by a keyword slip. No sweep rule recovers an issue that nothing on GitHub links to; that one is prevented upstream, by CLAUDE.md's duplicate rule. What this step *can* do is catch the late pointer: the resolving comment landed a day after the release, so an issue whose newest comment claims a fix by a PR or commit from **any earlier** release deserves a look, not just this one's.
 
 **Reconcile each issue in the non-closing and orphan buckets.** Read the issue (body *and* comments) alongside the PR, then close it only when **both** hold:
 
@@ -114,7 +116,13 @@ The script is a pure function from data to plan — it does no network I/O, beca
 python scripts/reconcile-dev-labels.py --input plan-input.json
 ```
 
-It prints four buckets. **Apply `ADD` and `REMOVE` directly** — they are unambiguous. **Do not apply `NEEDS REVIEW`**; read those issues yourself. An issue lands there when a fix pointer is not the newest comment, which is genuinely undecidable from the outside: the later comment may be a maintainer saying "thanks" or the reporter saying the fix does not work. Tagging would bury a dispute; skipping would silently drop the issue out of the awaiting-release view. That is the same "not silently skipped" principle step 6 applies to non-closing references.
+It prints four buckets. **Apply `ADD` and `REMOVE` directly** — they are unambiguous. **Do not apply `NEEDS REVIEW`**; read those issues yourself. An issue lands there for one of three reasons, all genuinely undecidable from the outside:
+
+- **A fix pointer is not the newest comment.** The later comment may be a maintainer saying "thanks" or the reporter saying the fix does not work. Tagging would bury a dispute; skipping would silently drop the issue out of the awaiting-release view.
+- **A comment claims a fix by commit SHA** instead of `Addressed in #M`. The script has only the JSON you piped in, so it cannot map a commit to its PR — but the claim is real, so it is surfaced. Resolve it with `git log --ancestry-path <sha>..origin/dev --merges --oneline | tail -1` to find the merge that carried it, then re-run with a corrected pointer.
+- **The issue carries `dev` but nothing resolves it** — stale, or fixed in an earlier release.
+
+That is the same "not silently skipped" principle step 6 applies to non-closing references.
 
 Add `--check` to make it exit non-zero when anything needs attention, and `--json` for machine-readable output.
 

--- a/scripts/reconcile-dev-labels.py
+++ b/scripts/reconcile-dev-labels.py
@@ -18,8 +18,9 @@ issue is not cluttered with a label that is true of every shipped fix.
 
 The rule reuses step 6's own resolution logic, which is fiddly in exactly the
 ways prose hides: closing keywords must be told apart from `Refs`/`Part of`,
-`Partially addressed in #M` must not read as `Addressed in #M`, and a comment
-posted *after* a fix pointer may or may not dispute it. Getting any of those
+`Partially addressed in #M` must not read as `Addressed in #M`, a comment
+posted *after* a fix pointer may or may not dispute it, and a pointer naming a
+commit instead of a PR cannot be resolved here at all. Getting any of those
 subtly wrong silently corrupts the awaiting-release view. Encoding it here
 makes it testable; see tests/core/test_reconcile_dev_labels.py.
 
@@ -69,6 +70,18 @@ CLOSING_REF = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]+#(
 # work that is NOT finished — from reading as a resolution.
 COMMENT_POINTER = re.compile(
     r"(?<!ly )\b(?:addressed|fixed|resolved|shipped|handled)\s+(?:in|by)\s+#(\d+)",
+    re.IGNORECASE,
+)
+
+# The same claim, but naming a commit instead of a PR ("Fixed on `dev` by
+# `de9ae81ac`"). A SHA cannot be mapped to a release PR from this input, so
+# such a comment is surfaced for review rather than resolved -- see
+# `_sha_pointer`. The gap between the verb and the SHA absorbs interjections
+# like "on `dev`", and excludes `#` so a well-formed `#M` pointer can never
+# land here instead.
+SHA_POINTER = re.compile(
+    r"(?<!ly )\b(?:addressed|fixed|resolved|shipped|handled)\b[^.\n#]{0,40}?"
+    r"\b(?:in|by)\s+(?:commit\s+)?`?([0-9a-f]{7,40})`?\b",
     re.IGNORECASE,
 )
 
@@ -123,6 +136,25 @@ def _pointer_verdict(issue: dict, release_numbers: set[int]) -> tuple[str, str] 
     )
 
 
+def _sha_pointer(issue: dict) -> str | None:
+    """Return the commit named by the newest SHA-form fix claim, if any.
+
+    CLAUDE.md prescribes `Addressed in #M` -- a *PR number* -- precisely because
+    a bare commit SHA cannot be mapped back to a release PR from this input.
+    But a comment saying "Fixed on `dev` by `de9ae81ac`" plainly claims a fix,
+    and reporting it as "not resolved on dev" is the script guessing, in the
+    one direction it is meant never to guess: silently. #2911 sat open through
+    a release exactly this way -- its fix was on `main` while the awaiting-
+    release view showed nothing at all. So the claim is surfaced and a human
+    maps the commit to its PR.
+    """
+    for comment in reversed(issue.get("comments") or []):
+        found = SHA_POINTER.findall(comment.get("body") or "")
+        if found:
+            return found[-1]
+    return None
+
+
 def _classify(issue: dict, closers: dict[int, int], release_numbers: set[int]) -> tuple[str, str]:
     """Return (action, reason) for one issue. Action is add/remove/review/none."""
     number = issue.get("number")
@@ -141,6 +173,12 @@ def _classify(issue: dict, closers: dict[int, int], release_numbers: set[int]) -
 
     verdict = _pointer_verdict(issue, release_numbers)
     if verdict is None:
+        sha = _sha_pointer(issue)
+        if sha:
+            return "review", (
+                f"a comment claims a fix by commit `{sha}` rather than `Addressed in #M`; "
+                "map the commit to its PR by hand, then re-run"
+            )
         if labelled:
             return (
                 "review",

--- a/tests/core/test_reconcile_dev_labels.py
+++ b/tests/core/test_reconcile_dev_labels.py
@@ -8,7 +8,9 @@ resolution logic, whose sharp edges are the point of testing it:
 * `Partially addressed in #M` is the documented marker for work still owed,
   and must not read as `Addressed in #M`;
 * a comment posted *after* a fix pointer is ambiguous -- it may be chatter or
-  a dispute -- and the script must surface it rather than guess either way.
+  a dispute -- and the script must surface it rather than guess either way;
+* a pointer naming a *commit* rather than a PR cannot be resolved from this
+  input, and must be surfaced rather than reported as settled.
 
 Getting any of these wrong corrupts the awaiting-release view silently, which
 is exactly the failure mode the script exists to prevent.
@@ -142,6 +144,70 @@ class TestMostRecentCommentRule:
         prs = [{"number": 3128, "body": "Closes #3077"}]
         comments = ["Addressed in #3128", "Thanks!"]
         assert 3077 in plan_for(prs, [issue(3077, comments=comments)])["add"]
+
+
+class TestCommitShaPointers:
+    """A fix claimed by commit SHA is surfaced, never reported as settled.
+
+    Regression cover for #2911, which shipped to `main` with its only pointer
+    reading "Fixed on `dev` by `de9ae81ac`". That matched no pattern, so the
+    script reported "not resolved on dev" -- indistinguishable from an issue
+    nobody had started -- and the release sweep had nothing to go on.
+    """
+
+    PRS = [{"number": 3128, "body": "Refs #3077"}]
+
+    @pytest.mark.parametrize(
+        "comment",
+        [
+            "Fixed on `dev` by `de9ae81ac`",
+            "Fixed in de9ae81ac",
+            "Addressed by commit `de9ae81acaafb9e267996e6096ff9b59c140b8e8`",
+            "Resolved on dev by de9ae81a",
+        ],
+    )
+    def test_sha_pointer_is_flagged_for_review(self, comment):
+        result = plan_for(self.PRS, [issue(3077, comments=[comment])])
+        assert 3077 in result["review"]
+        assert 3077 not in result["none"]
+
+    def test_the_review_reason_names_the_commit(self):
+        result = plan_for(self.PRS, [issue(3077, comments=["Fixed on `dev` by `de9ae81ac`"])])
+        assert "de9ae81ac" in result["review"][3077]
+
+    def test_a_proper_pr_pointer_still_resolves_and_is_not_downgraded(self):
+        """The `#M` form is the documented one; it must not be dragged into review."""
+        assert 3077 in plan_for(self.PRS, [issue(3077, comments=["Addressed in #3128"])])["add"]
+
+    def test_partially_addressed_by_commit_does_not_resolve_either(self):
+        """The `(?<!ly )` guard applies to the SHA form too."""
+        comment = "Partially addressed by `de9ae81ac` — still open: the video arm."
+        assert 3077 in plan_for(self.PRS, [issue(3077, comments=[comment])])["none"]
+
+    def test_prose_mentioning_a_commit_without_a_fix_claim_is_ignored(self):
+        """Not every SHA in a comment is a resolution."""
+        comment = "This regressed somewhere around de9ae81ac, still bisecting."
+        assert 3077 in plan_for(self.PRS, [issue(3077, comments=[comment])])["none"]
+
+    def test_a_newer_pr_pointer_beats_an_older_sha_pointer(self):
+        comments = ["Fixed on `dev` by `de9ae81ac`", "Addressed in #3128"]
+        assert 3077 in plan_for(self.PRS, [issue(3077, comments=comments)])["add"]
+
+    def test_a_closed_issue_with_a_sha_pointer_is_not_flagged(self):
+        """Closed is closed; the backstop only guards the open pile."""
+        result = plan_for(self.PRS, [issue(3077, state="closed", comments=["Fixed by `de9ae81ac`"])])
+        assert 3077 in result["none"]
+
+    def test_check_exits_nonzero_so_the_claim_cannot_pass_silently(self):
+        data = {"release_prs": self.PRS, "issues": [issue(3077, comments=["Fixed on `dev` by `de9ae81ac`"])]}
+        result = subprocess.run(  # noqa: S603  # interpreter + repo-local script path, no shell
+            [sys.executable, str(SCRIPT), "--check"],
+            input=json.dumps(data),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 1
 
 
 class TestRemovalAndStaleness:


### PR DESCRIPTION
#2911 shipped to `main` in the 2026-08-11 release and stayed open until 2026-08-17, when it was noticed by hand. Closed it, then fixed the two things that let it happen.

## What actually went wrong

It was a duplicate of #3025. The fix — PR #3051, commit `de9ae81ac` — wrote `Closes #3025` only, so at release time #2911 had **no closing keyword, no `Refs`, and no comments**. All three of `docs/RELEASE.md` step 6's buckets were blind to it by construction, not by a keyword slip, and no later release re-examines an already-merged PR.

The resolving comment landed a day *after* the release and read `Fixed on dev by de9ae81ac` — a commit SHA. `scripts/reconcile-dev-labels.py` matches `#M`, so that comment matched nothing and the issue reported as `none: not resolved on dev`: identical to an issue nobody had started. A script whose stated principle is *"ambiguity gets surfaced, not resolved by a coin flip"* was quietly resolving one.

Worth noting what was **not** broken: step 6's orphan backstop is sound, and PR #3118's body carries a bare `#2911` that would likely have caught it at the next release. But that depended on an unrelated docs PR happening to mention it, and on the reconciler reasoning "#3118 doesn't fix this, it points at the commit that does". Thin thread.

## Changes

**`scripts/reconcile-dev-labels.py`** — a new `SHA_POINTER` pattern recognises a fix claim naming a commit instead of a PR, and `_sha_pointer` routes it to **NEEDS REVIEW**. The script still cannot map a SHA to a release PR from its input — that is exactly why this is review and not `add` — but silence on a real claim is the one behaviour it exists to prevent. The pattern absorbs interjections (`Fixed on `dev` by `abc1234``, `Addressed by commit `abc1234``) and excludes `#`, so a well-formed `#M` pointer can never be downgraded into review. A false positive costs a human one lookup; the silence cost a release.

**`CLAUDE.md`** — a new "Duplicate issues" section, the only change that could have prevented the original loss:
- Search the tracker on the **symptom** (failing test name, error string, file path), not your own phrasing of the diagnosis. Two sessions hitting one bug describe it differently — #2911 called it systematically wrong, #3025 called it flaky — while naming the identical test.
- Link the pair on discovery: closing keywords for both, or `state_reason: "duplicate"` + `duplicate_of` (both already in the `issue_write` schema, previously unused by policy).
- Names the one case where a per-fix session *should* close an issue itself rather than deferring to the sweep: when the fix is already on `main` it has fallen out of the `origin/main..origin/dev` window, so nothing will ever pick it up again.

Plus a line in the linking section: point at `#M`, never a bare SHA. A SHA is a fine addition, never the only pointer.

**`docs/RELEASE.md`** — the orphan backstop now covers commit-SHA pointers, with the `git log --ancestry-path <sha>..origin/dev --merges` recipe for resolving one; step 6 records the duplicate incident and the late-pointer lesson (a pointer naming a PR from *any earlier* release deserves a look); and 6b's NEEDS REVIEW paragraph is split into the three distinct reasons an issue can land there.

## Testing

- `tests/core/test_reconcile_dev_labels.py` — **46 passed**, up from 27. New `TestCommitShaPointers` covers the four SHA phrasings, that `Partially addressed by <sha>` still does not resolve (the `(?<!ly )` guard applies to the SHA form too), that prose merely mentioning a commit is not a fix claim, that a newer `#M` pointer beats an older SHA one, that closed issues are untouched, and that `--check` exits non-zero so the claim cannot pass silently.
- `./run-tests.sh` — **ALL 8544 TESTS PASSED (6 skipped)**, every gate green.

Refs #2911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012WtomnZRdSx7D2VTddFHbR)_