### PR TITLE
Fix detector load hanging forever at "Preparing" when setup fails after reservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ not list every commit. Use `git log` for the full history.
 
 ## Unreleased
 
+### Fixed
+
+- **Detector load can no longer hang forever at "Preparing".** Loading a
+  detector while the selected dataset was not yet (re)loaded — typical right
+  after an app restart, while the dataset was still being read from its
+  pickle — left the dashboard row stuck at "Loading detector · Step 1 of 3 ·
+  Preparing" indefinitely: Cancel did nothing, every retry reported "Detector
+  load already in progress", voting returned 409, and only a restart
+  recovered. The load now fails fast with a clean 409 (`dataset_not_loaded`)
+  in that case, any other failure before the background worker starts
+  releases the load reservation and surfaces an error on the row, and load
+  failures are written to the server log. (#3139)
+
 ### Changed
 
 - **Audio now defaults to the larger CLAP checkpoint.** New audio datasets and

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1370,6 +1370,79 @@ class TestLoadModelEndpoint:
         res = client.post("/api/detectors/registry/load", json={"detector_id": "nope"})
         assert res.status_code == 404
 
+    def test_load_with_unloaded_dataset_header_409s_cleanly(self, client):
+        """An ``X-Dataset-Id`` naming an unloaded dataset must 409, not hang.
+
+        Regression test for issue #3139: the route resolved the dataset
+        context *after* reserving the load and creating the task row, so the
+        ``DatasetNotLoadedError`` → 409 leaked both — the row sat at
+        "Preparing" forever and every retry returned "already in progress"
+        until the app was restarted.
+        """
+        from vtscore.concurrency.progress import detector_loading_tasks
+
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "StallRepro", "media_type": "audio", "text_query": "test"},
+        )
+        detector_id = res.get_json()["detector"]["id"]
+
+        res = client.post(
+            "/api/detectors/registry/load",
+            json={"detector_id": detector_id},
+            headers={"X-Dataset-Id": "not_a_loaded_dataset"},
+        )
+        assert res.status_code == 409
+        assert res.get_json().get("code") == "dataset_not_loaded"
+        # No task row was created, so the dashboard shows no stuck spinner.
+        assert detector_loading_tasks.get_tracker(f"_detload_{detector_id}") is None
+
+        # The reservation was not leaked: a retry against a loaded dataset
+        # must start a real load (previously: "already in progress" forever).
+        res = _load_detector_and_wait(client, detector_id)
+        assert res.status_code == 200
+        assert res.get_json().get("message") == "Loading started"
+        from vtscore.detectors.registry import is_detector_loaded
+
+        assert is_detector_loaded(detector_id)
+
+    def test_load_setup_failure_releases_reservation(self, client, monkeypatch):
+        """A failure between reserving the load and spawning the worker must
+        release the reservation and retire the task row with an error.
+
+        Regression test for issue #3139's defensive half: until ``spawn``
+        succeeds there is no worker to run ``end_detector_load``, so the route
+        itself must clean up or the detector is stuck "in progress" forever.
+        """
+        import vtsearch.threading as vts_threading
+        from vtscore.concurrency.progress import detector_loading_tasks
+        from vtscore.detectors.registry import begin_detector_load, end_detector_load
+
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "SpawnBoom", "media_type": "audio", "text_query": "test"},
+        )
+        detector_id = res.get_json()["detector"]["id"]
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("thread pool exhausted")
+
+        monkeypatch.setattr(vts_threading, "spawn", _boom)
+        res = client.post("/api/detectors/registry/load", json={"detector_id": detector_id})
+        assert res.status_code == 500
+
+        # The reservation was released, so a retry owns the load again.
+        assert begin_detector_load(detector_id) == "reserved"
+        end_detector_load(detector_id)
+
+        # The task row is finished and carries an error, so the dashboard
+        # briefly shows the failure instead of a stuck "Preparing" spinner.
+        task_id = f"_detload_{detector_id}"
+        assert detector_loading_tasks.is_finished(task_id)
+        tracker = detector_loading_tasks.get_tracker(task_id)
+        assert tracker is not None
+        assert tracker.get().get("error")
+
     def test_load_clears_previous_labels(self, client):
         """Loading model B must not carry over labels from model A."""
         from vtsearch.state import (

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -598,9 +598,7 @@ def _run_detector_load_task(
                 remove_loaded_detector_id(detector_id)
                 tracker.update("idle", "", 0, 0, error="Cancelled", step=None, total_steps=None)
             except Exception as e:
-                import traceback as _tb
-
-                _tb.print_exc()
+                logger.exception("Detector load for %s failed", detector_id)
                 from vtsearch.state import unregister_detector_context as _unreg
 
                 _unreg(detector_id)
@@ -657,6 +655,94 @@ def _reembed_or_ack_loaded_detector(detector_id: str, entry: dict) -> dict:
     return {"ok": True, "labels_restored": 0, "examples_seeded": 0}
 
 
+def _start_detector_load(detector_id: str, entry: dict, thread_ds_ctx) -> dict:
+    """Spawn the background load for a freshly-reserved detector.
+
+    Called by :func:`load_detector_route` after ``begin_detector_load``
+    returned ``"reserved"``: the caller owns the load reservation, and this
+    helper hands it off to the worker thread.  Until ``spawn`` succeeds, only
+    this request can release the reservation and retire the task row, so any
+    failure here must do that cleanup itself — skipping it left the detector
+    stuck "in progress" forever: every retry attached to a worker that didn't
+    exist, Cancel had nothing to cancel, and only an app restart recovered
+    (issue #3139).
+    """
+    from vtscore import timing
+    from vtscore.concurrency.progress import detector_loading_tasks
+    from vtscore.detectors.registry import end_detector_load
+    from vtsearch.state import DetectorContext
+
+    task_id = f"_detload_{detector_id}"
+    timing_recorder = None
+    try:
+        # Build the context but do NOT register it yet: the worker publishes it
+        # into the global store only after labels/embeddings/MLP are populated,
+        # so no concurrent request can observe a torn, empty-then-filling
+        # detector.
+        det_ctx = DetectorContext(
+            detector_id,
+            name=entry.get("name", ""),
+            media_type=entry.get("media_type", ""),
+        )
+
+        det_media_type = entry.get("media_type", "")
+        det_embedder = entry.get("embedder", "") or ""
+        n_labels = int(entry.get("num_training") or 0)
+
+        tracker = detector_loading_tasks.create_task(
+            task_id,
+            entry.get("name", detector_id),
+            detector_id=detector_id,
+            media_type=det_media_type,
+            step_weights=timing.step_weights(
+                _DETECTOR_LOAD_TASK, media_type=det_media_type, embedder=det_embedder, n=n_labels
+            ),
+        )
+        timing_recorder = timing.record_task(
+            tracker, _DETECTOR_LOAD_TASK, media_type=det_media_type, embedder=det_embedder
+        )
+        timing_recorder.start()
+        timing_recorder.set_scale(n=n_labels)
+        tracker.update("loading", "Preparing…", 0, 0, step=1, total_steps=_LOAD_STEPS)
+
+        det_name = entry.get("name", "")
+
+        def load_task():
+            try:
+                _run_detector_load_task(
+                    detector_id=detector_id,
+                    det_ctx=det_ctx,
+                    thread_ds_ctx=thread_ds_ctx,
+                    det_name=det_name,
+                    tracker=tracker,
+                    task_id=task_id,
+                )
+            finally:
+                # The worker reports failures on the tracker rather than
+                # raising, so the tracker — not an exception — is what says
+                # whether these timings describe a real load or an aborted one.
+                timing_recorder.finish(ok=not tracker.get().get("error"))
+
+        from vtsearch.threading import spawn
+
+        spawn(load_task, name=f"det-load-{detector_id[:8]}")
+    except Exception:
+        logger.exception("Detector load for %s failed before the worker started", detector_id)
+        end_detector_load(detector_id)
+        if timing_recorder is not None:
+            timing_recorder.finish(ok=False)
+        leaked_tracker = detector_loading_tasks.get_tracker(task_id)
+        if leaked_tracker is not None:
+            leaked_tracker.update("idle", "", 0, 0, error="Detector load failed to start", step=None, total_steps=None)
+            detector_loading_tasks.mark_finished(task_id)
+        raise
+    return {
+        "ok": True,
+        "message": "Loading started",
+        "task_id": str(task_id),
+    }
+
+
 @detectors_registry_bp.route("/api/detectors/registry/load", methods=["POST"])
 @detectors_registry_bp.arguments(DetectorRegistryLoadRequestSchema)
 @detectors_registry_bp.response(200, DetectorRegistryLoadResponseSchema)
@@ -674,7 +760,6 @@ def load_detector_route(body: dict):
         get_detector,
     )
     from vtsearch.state import (
-        DetectorContext,
         bad_votes,
         good_votes,
     )
@@ -694,6 +779,17 @@ def load_detector_route(body: dict):
     if detector_id is None:
         return _unload_active_detector()
 
+    from vtsearch.state import get_active_context
+
+    # Snapshot the dataset context BEFORE reserving the load.  When the
+    # request's ``X-Dataset-Id`` names a registered-but-unloaded dataset
+    # (typical right after an app restart, while the dataset is still being
+    # re-loaded from its pickle), ``get_active_context`` raises
+    # ``DatasetNotLoadedError`` → a clean 409.  Resolving it after
+    # ``begin_detector_load`` leaked the reservation and a forever-"Preparing"
+    # task row that only an app restart could clear (issue #3139).
+    thread_ds_ctx = get_active_context()
+
     # Atomically decide our role, closing the check-then-act race where two
     # concurrent loads both saw the detector unloaded (the loaded flag is only
     # set at the end of the loader) and spawned twin loaders.
@@ -708,68 +804,7 @@ def load_detector_route(body: dict):
     if load_role == "loaded":
         return _reembed_or_ack_loaded_detector(detector_id, entry)
 
-    from vtscore.concurrency.progress import detector_loading_tasks
-
-    # Build the context but do NOT register it yet: the worker publishes it into
-    # the global store only after labels/embeddings/MLP are populated, so no
-    # concurrent request can observe a torn, empty-then-filling detector.
-    det_ctx = DetectorContext(
-        detector_id,
-        name=entry.get("name", ""),
-        media_type=entry.get("media_type", ""),
-    )
-
-    from vtscore import timing
-
-    det_media_type = entry.get("media_type", "")
-    det_embedder = entry.get("embedder", "") or ""
-    n_labels = int(entry.get("num_training") or 0)
-
-    task_id = f"_detload_{detector_id}"
-    tracker = detector_loading_tasks.create_task(
-        task_id,
-        entry.get("name", detector_id),
-        detector_id=detector_id,
-        media_type=det_media_type,
-        step_weights=timing.step_weights(
-            _DETECTOR_LOAD_TASK, media_type=det_media_type, embedder=det_embedder, n=n_labels
-        ),
-    )
-    timing_recorder = timing.record_task(tracker, _DETECTOR_LOAD_TASK, media_type=det_media_type, embedder=det_embedder)
-    timing_recorder.start()
-    timing_recorder.set_scale(n=n_labels)
-    tracker.update("loading", "Preparing…", 0, 0, step=1, total_steps=_LOAD_STEPS)
-
-    det_name = entry.get("name", "")
-
-    from vtsearch.state import get_active_context
-
-    _thread_ds_ctx = get_active_context()
-
-    def load_task():
-        try:
-            _run_detector_load_task(
-                detector_id=detector_id,
-                det_ctx=det_ctx,
-                thread_ds_ctx=_thread_ds_ctx,
-                det_name=det_name,
-                tracker=tracker,
-                task_id=task_id,
-            )
-        finally:
-            # The worker reports failures on the tracker rather than raising,
-            # so the tracker — not an exception — is what says whether these
-            # timings describe a real load or an aborted one.
-            timing_recorder.finish(ok=not tracker.get().get("error"))
-
-    from vtsearch.threading import spawn
-
-    spawn(load_task, name=f"det-load-{detector_id[:8]}")
-    return {
-        "ok": True,
-        "message": "Loading started",
-        "task_id": str(task_id),
-    }
+    return _start_detector_load(detector_id, entry, thread_ds_ctx)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3139

## Root cause

`POST /api/detectors/registry/load` resolved the active dataset context (`get_active_context()`) **after** `begin_detector_load()` had reserved the load and the "Preparing" task row already existed. When the request's `X-Dataset-Id` names a registered-but-unloaded dataset — exactly the after-restart scenario in the issue, where the dataset is still being re-loaded from its pickle — `get_active_context()` raises `DatasetNotLoadedError`, which the global error handler turns into a *deliberately quiet* 409 (no log line, by design of the H16 handlers). The request died between the reservation and `spawn()`, so:

- the `_loading_ids` reservation leaked forever → every retry returned `"Detector load already in progress"`;
- the tracker row leaked at "Loading detector · Step 1 of 3 · Preparing" → the bar never advanced and `mark_finished` never ran;
- Cancel no-oped, because cancellation is cooperative and no worker ever existed to check the flag;
- nothing was logged, because the not-loaded → 409 mapping is intentionally silent.

Only a restart cleared the in-memory reservation — and the same race then re-stalled the next attempt, matching the reported repro pattern (fresh dataset + fresh detector fine; pickle-loaded dataset after restart stalls).

## Fix

- **Fail fast, leak nothing:** the dataset-context snapshot now happens *before* `begin_detector_load()`. The unloaded-dataset case returns a clean 409 (`code="dataset_not_loaded"`, which the frontend already understands) with no reservation taken and no task row created.
- **Guard the reservation window:** the whole reserved-path setup (context build, tracker creation, timing recorder, `spawn`) moved into `_start_detector_load()`, wrapped so that *any* failure before the worker owns the reservation releases it, retires the task row with an error (so the dashboard shows a failure instead of a stuck spinner), logs a traceback, and re-raises. This covers the issue's "a load that can't proceed should fail, not hang" ask for every setup-time failure, not just the diagnosed one.
- **Log worker failures:** the load worker's generic exception path now logs through the app logger (`logger.exception`) instead of bare `traceback.print_exc()` to stderr, so a failed load is visible in the Flask log.

Extracting `_start_detector_load()` also keeps `load_detector_route` under the ruff C901 complexity limit.

## Tests

Two regression tests in `tests/detectors/test_detectors.py::TestLoadModelEndpoint`:

- `test_load_with_unloaded_dataset_header_409s_cleanly` — load with an `X-Dataset-Id` naming an unloaded dataset 409s with `dataset_not_loaded`, creates no task row, and a subsequent load actually starts and completes (previously: "already in progress" forever).
- `test_load_setup_failure_releases_reservation` — a failure at `spawn()` releases the reservation and leaves the task row finished with an error.

Full `./run-tests.sh` passes: 8546 Python tests + pyright, pip-audit, npm audit, frontend build, and the Vitest suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8tgtqL6EyAZ7hjRbcMqbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8tgtqL6EyAZ7hjRbcMqbW)_