### PR TITLE
Reject mismatched pre-computed vectors at ingestion, not at score time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ not list every commit. Use `git log` for the full history.
 
 ### Changed
 
+- **Bad pre-computed vectors are now rejected at import, with an error that says
+  what is wrong.** Importing an `.npz` manifest of pre-computed embeddings used
+  to accept anything: vectors of the wrong width for the embedder the manifest
+  named, `NaN`/infinite rows from a failed embed, ragged archives, `float64` or
+  half-precision exports. None of those failed at import. A wrong-width row
+  surfaced later as `could not broadcast input array from shape (768,) into
+  shape (1152,)` on an unrelated search, naming neither the file nor the
+  manifest; a non-finite row never raised at all and silently corrupted every
+  score and threshold it touched. Manifests are now checked as they are read —
+  including against the declared embedder's own dimension, so an archive that
+  says `siglip2_l` while shipping 768-dim rows is caught immediately — and
+  vectors are widened to `float32`, so a half-precision or double-precision
+  export imports cleanly instead of leaving the dataset mixed. If a dataset
+  still ends up holding two widths, sorting and training now name the offending
+  item and both dimensions instead of failing with a bare numpy shape error.
 - **Audio now defaults to the larger CLAP checkpoint.** New audio datasets and
   text queries use `clap_general` (`laion/larger_clap_general`, shown as "CLAP
   (general, larger)") instead of `clap`. It wins every measured retrieval

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -673,6 +673,35 @@ If the source ships pre-computed vectors, prefer
 `self.custom_metadata_map[filename] = {"embedding": vec}`; the framework
 treats those as already-embedded and skips them.
 
+#### Pre-computed vectors are validated
+
+Whatever you put in `content_vectors` / `custom_metadata_map` is checked
+before it becomes a media's stored vector, by
+`vtscore.embedding.precomputed.normalize_vector`.  A vector must be a flat,
+finite, numeric row; it is coerced to `float32`, so a `float64` export or a
+half-precision embed is widened for you rather than leaving the dataset
+holding mixed dtypes.  Anything else — a ragged array, a `(3, 4)` block where
+a single row was expected, a `NaN` from a failed forward pass — raises
+`MismatchedVectorError` (a `ValueError` subclass) naming your file.
+
+This is stricter than it looks like it needs to be, for a reason: a bad
+vector does not fail where you introduced it.  A wrong-width row resurfaces
+much later as a bare `could not broadcast input array from shape (768,) into
+shape (1152,)` from inside the matrix builder, on an unrelated request that
+names neither your importer nor the file; and a non-finite row never raises at
+all, it silently poisons every score, threshold comparison and sort it reaches.
+
+Two related checks you will hit:
+
+- **Width vs. the embedder you name.** If you set `embedder="<name>"` (or ship
+  an `.npz` whose `embedder_name` says so), the vectors must match that
+  embedder's declared `embedding_dim`.  Declaring `siglip2_l` while shipping
+  768-dim rows is a self-contradiction, and it is rejected at import.
+- **Nameless vectors.** A vector supplied with no embedder name is stored under
+  a sentinel key and re-keyed to the embedder the load actually picked.  That
+  re-keying asserts the vector lives in that embedder's space, so it is
+  width-checked too — supply the name yourself if you know it.
+
 When building dicts directly, the importer should also override
 `build_origin()` to return an empty origin (since the default
 implementation captures dataset-level field values like query IDs that

--- a/scripts/eval-app-sync.pins.json
+++ b/scripts/eval-app-sync.pins.json
@@ -9,5 +9,5 @@
   "training.blend_schedule_default": "3737e6185aeb219673cbf8126a5306d6e435eba67e73c24cc1975a896bbab7e1",
   "training.calibration_score_rows": "1110937c8efc4198ff299328966afaa2a150ed856868033d701914995beadae1",
   "training.fused_threshold": "e9ab7076808a11dda013a48d750efb9af43b15f22a57009fa8d66e378aae2a36",
-  "training.train_and_threshold": "ae01e49abe5abab28cc1d30961e029d78d4b87aaf52475aa9f9fc4b9f14d683a"
+  "training.train_and_threshold": "3cf6fdc346fe852b2d76a3518e0107052acaa954ff969017ae5aba222993fb40"
 }

--- a/tests/io/test_npz_dataset_import.py
+++ b/tests/io/test_npz_dataset_import.py
@@ -28,6 +28,7 @@ from vtscore.datasets.importers._npz_vectors import (
     read_npz_multi_vectors,
     write_npz_multi_vectors,
 )
+from vtscore.embedding.binding import expected_dim_for_embedder
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.datasets.importers.server_files import (
     ServerFilesDatasetImporter,
@@ -157,6 +158,19 @@ class TestReadNpzEmbedderName:
 # ---------------------------------------------------------------------------
 
 
+def _col(embedder_name: str, n_rows: int, offset: float = 0.0) -> np.ndarray:
+    """A ``vectors_<name>`` column of the width *embedder_name* actually declares.
+
+    Manifest reads reject a column whose width contradicts the embedder its key
+    names - that combination is the mislabelled-archive case the guard exists to
+    catch (see ``tests_lib/io/test_precomputed_vector_validation.py``).  So a
+    fixture that wants a *valid* trio archive has to use the real width; *offset*
+    keeps each column's values distinguishable.
+    """
+    dim = expected_dim_for_embedder(embedder_name) or 4
+    return np.arange(n_rows * dim, dtype=np.float32).reshape(n_rows, dim) + offset
+
+
 # ---------------------------------------------------------------------------
 # read_npz_multi_vectors / write_npz_multi_vectors (per-embedder trio layout)
 # ---------------------------------------------------------------------------
@@ -171,8 +185,8 @@ class TestReadNpzMultiVectors:
         assert read_npz_multi_vectors(npz) is None
 
     def test_reads_per_embedder_columns(self, tmp_path):
-        siglip = np.arange(6, dtype=np.float32).reshape(2, 3)
-        patch = (np.arange(8, dtype=np.float32) + 100).reshape(2, 4)
+        siglip = _col("siglip", 2)
+        patch = _col("dinov3_patch", 2, offset=100.0)
         npz = tmp_path / "multi.npz"
         np.savez(
             npz,
@@ -193,8 +207,8 @@ class TestReadNpzMultiVectors:
         np.savez(
             npz,
             filenames=np.array(["a.jpg"]),
-            vectors_siglip=np.zeros((1, 3), dtype=np.float32),
-            vectors_dinov3_patch=np.zeros((1, 4), dtype=np.float32),
+            vectors_siglip=_col("siglip", 1),
+            vectors_dinov3_patch=_col("dinov3_patch", 1),
             embedder_name=np.array("dinov3_patch"),
         )
         _mapping, primary = _read_multi(npz)
@@ -207,7 +221,7 @@ class TestReadNpzMultiVectors:
         np.savez(
             npz,
             filenames=np.array(["a.jpg"]),
-            vectors_siglip=np.zeros((1, 3), dtype=np.float32),
+            vectors_siglip=_col("siglip", 1),
             embedder_name=np.array("clip"),
         )
         _mapping, primary = _read_multi(npz)
@@ -220,7 +234,7 @@ class TestReadNpzMultiVectors:
         np.savez(
             npz,
             filenames=np.array(["a.jpg"]),
-            vectors_dinov3_patch=np.zeros((1, 4), dtype=np.float32),
+            vectors_dinov3_patch=_col("dinov3_patch", 1),
         )
         mapping, _primary = _read_multi(npz)
         assert set(mapping["a.jpg"]) == {"dinov3_patch"}
@@ -230,14 +244,14 @@ class TestReadNpzMultiVectors:
         np.savez(
             npz,
             filenames=np.array(["a.jpg", "b.jpg"]),
-            vectors_siglip=np.zeros((1, 3), dtype=np.float32),  # only 1 row for 2 files
+            vectors_siglip=_col("siglip", 1),  # only 1 row for 2 files
         )
         with pytest.raises(ValueError, match="mismatched lengths"):
             read_npz_multi_vectors(npz)
 
     def test_missing_filenames_raises(self, tmp_path):
         npz = tmp_path / "multi.npz"
-        np.savez(npz, vectors_siglip=np.zeros((2, 3), dtype=np.float32))
+        np.savez(npz, vectors_siglip=_col("siglip", 2))
         with pytest.raises(ValueError, match="filenames"):
             read_npz_multi_vectors(npz)
 
@@ -249,14 +263,16 @@ class TestReadNpzMultiVectors:
 class TestWriteNpzMultiVectors:
     def test_round_trips_through_reader(self, tmp_path):
         rng = np.random.default_rng(7)
+        siglip_dim = expected_dim_for_embedder("siglip") or 3
+        patch_dim = expected_dim_for_embedder("dinov3_patch") or 4
         mapping = {
             "a.jpg": {
-                "siglip": rng.standard_normal(3).astype(np.float32),
-                "dinov3_patch": rng.standard_normal(4).astype(np.float32),
+                "siglip": rng.standard_normal(siglip_dim).astype(np.float32),
+                "dinov3_patch": rng.standard_normal(patch_dim).astype(np.float32),
             },
             "b.jpg": {
-                "siglip": rng.standard_normal(3).astype(np.float32),
-                "dinov3_patch": rng.standard_normal(4).astype(np.float32),
+                "siglip": rng.standard_normal(siglip_dim).astype(np.float32),
+                "dinov3_patch": rng.standard_normal(patch_dim).astype(np.float32),
             },
         }
         npz = tmp_path / "out.npz"
@@ -270,11 +286,12 @@ class TestWriteNpzMultiVectors:
                 np.testing.assert_array_equal(read_back[fname][emb], vec)
 
     def test_compressed_round_trips(self, tmp_path):
-        mapping = {"a.jpg": {"siglip": np.ones(3, dtype=np.float32)}}
+        dim = expected_dim_for_embedder("siglip") or 3
+        mapping = {"a.jpg": {"siglip": np.ones(dim, dtype=np.float32)}}
         npz = tmp_path / "out.npz"
         write_npz_multi_vectors(npz, mapping, compressed=True)
         read_back, _primary = _read_multi(npz)
-        np.testing.assert_array_equal(read_back["a.jpg"]["siglip"], np.ones(3, dtype=np.float32))
+        np.testing.assert_array_equal(read_back["a.jpg"]["siglip"], np.ones(dim, dtype=np.float32))
 
     def test_empty_mapping_raises(self, tmp_path):
         with pytest.raises(ValueError, match="empty"):
@@ -531,8 +548,8 @@ class TestServerFilesMultiVectorsEndToEnd:
         np.savez(
             npz,
             filenames=np.array([str(src_a), str(src_b)]),
-            vectors_clap=np.arange(8, dtype=np.float32).reshape(2, 4),
-            vectors_ast=(np.arange(8, dtype=np.float32) + 50).reshape(2, 4),
+            vectors_clap=_col("clap", 2),
+            vectors_ast=_col("ast", 2, offset=50.0),
             embedder_name=np.array("clap"),
         )
         paths, path_to_vector, embedder_name = _read_npz_paths_file(npz)
@@ -546,8 +563,8 @@ class TestServerFilesMultiVectorsEndToEnd:
         media['embeddings'], with the scalar embedder_name as the primary."""
         src_a, src_b = self._write_wavs(tmp_path)
         rng = np.random.default_rng(3)
-        clap = rng.standard_normal((2, 512)).astype(np.float32)
-        ast = rng.standard_normal((2, 512)).astype(np.float32)
+        clap = rng.standard_normal((2, expected_dim_for_embedder("clap") or 512)).astype(np.float32)
+        ast = rng.standard_normal((2, expected_dim_for_embedder("ast") or 512)).astype(np.float32)
         npz = tmp_path / "multi.npz"
         np.savez(
             npz,

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -20,7 +20,9 @@ from vtscore.embedding.matrix import (
     get_embedding_matrix_for_snap,
     get_embedding_submatrix,
     invalidate_embedding_matrix,
+    media_score_rows,
 )
+from vtscore.embedding.precomputed import MismatchedVectorError
 from vtscore.state.core import DatasetContext, _state_lock, set_thread_dataset_context
 
 
@@ -531,3 +533,103 @@ class TestEmbeddingMatrixSidecar:
         # still mmap the stale pre-rewrite values.
         _, mat_path = matrix_mod._emb_sidecar_paths(self._pkl_path(dataset_id))
         assert np.load(mat_path)[0, 0] == 42.0
+
+
+class TestMixedDimensionsRaiseALocatableError:
+    """A dataset holding vectors of two widths must fail with a message that names them.
+
+    Ingestion validation (:mod:`vtscore.embedding.precomputed`) is supposed to
+    make this state unreachable, but a dataset can still arrive at it by another
+    route - a pickle written before that validation existed, or a third-party
+    importer writing ``media["embeddings"]`` directly.  When it does, the raw
+    numpy failure is ``could not broadcast input array from shape (768,) into
+    shape (1152,)``: no cid, no filename, no embedder, on whatever request
+    happened to rebuild the matrix.  These tests pin the replacement.
+    """
+
+    @staticmethod
+    def _mixed_ctx(name: str) -> DatasetContext:
+        ctx = DatasetContext(name)
+        ctx.medias[1] = {
+            "id": 1,
+            "embedder": "e5",
+            "filename": "first.txt",
+            "embeddings": {"e5": np.ones(4, dtype=np.float32)},
+        }
+        ctx.medias[2] = {
+            "id": 2,
+            "embedder": "e5",
+            "filename": "odd-one-out.txt",
+            "embeddings": {"e5": np.ones(7, dtype=np.float32)},
+        }
+        return ctx
+
+    def test_matrix_build_names_the_offending_media_and_both_widths(self):
+        ctx = self._mixed_ctx("test_mixed_dims_matrix")
+        with pytest.raises(MismatchedVectorError) as exc:
+            get_embedding_matrix(ctx)
+        msg = str(exc.value)
+        assert "media 2" in msg
+        assert "odd-one-out.txt" in msg
+        assert "7" in msg and "4" in msg
+
+    def test_submatrix_build_raises_too(self):
+        ctx = self._mixed_ctx("test_mixed_dims_submatrix")
+        with pytest.raises(MismatchedVectorError, match="odd-one-out.txt"):
+            get_embedding_submatrix(ctx, [1, 2])
+
+    def test_prefers_origin_name_over_filename(self):
+        ctx = self._mixed_ctx("test_mixed_dims_origin_name")
+        ctx.medias[2]["origin_name"] = "shards.tar::odd.jpg"
+        with pytest.raises(MismatchedVectorError, match=r"shards\.tar::odd\.jpg"):
+            get_embedding_matrix(ctx)
+
+    def test_uniform_widths_still_build_normally(self):
+        ctx = DatasetContext("test_uniform_dims")
+        ctx.medias[1] = {"id": 1, "embedder": "e5", "embeddings": {"e5": np.ones(4, dtype=np.float32)}}
+        ctx.medias[2] = {"id": 2, "embedder": "e5", "embeddings": {"e5": np.zeros(4, dtype=np.float32)}}
+        ids, mat = get_embedding_matrix(ctx)
+        assert ids == [1, 2]
+        assert mat.shape == (2, 4)
+
+    def test_float16_stored_vector_is_still_accepted(self):
+        """Width is what must match; a half-precision row is widened, not refused.
+
+        This is the shape issue #3143's fp16 work would produce, and it must
+        remain a non-event: the matrix is float32 and numpy widens on assignment.
+        """
+        ctx = DatasetContext("test_fp16_rows")
+        ctx.medias[1] = {"id": 1, "embedder": "e5", "embeddings": {"e5": np.ones(4, dtype=np.float16)}}
+        ctx.medias[2] = {"id": 2, "embedder": "e5", "embeddings": {"e5": np.zeros(4, dtype=np.float32)}}
+        _ids, mat = get_embedding_matrix(ctx)
+        assert mat.dtype == np.float32
+        assert mat[0, 0] == 1.0
+
+
+class TestPatchGridWidthMismatch:
+    def test_cls_vector_and_patch_grid_must_share_a_space(self):
+        """``media_score_rows`` max-pools the two together, so they must agree."""
+        media = {
+            "id": 5,
+            "filename": "mixed.jpg",
+            "embedder": "dinov3_patch",
+            "embeddings": {"dinov3_patch": np.ones(4, dtype=np.float32)},
+            "patch_grid": np.ones((2, 2, 9), dtype=np.float16),
+        }
+        with pytest.raises(MismatchedVectorError) as exc:
+            media_score_rows(media, "dinov3_patch")
+        msg = str(exc.value)
+        assert "mixed.jpg" in msg
+        assert "4" in msg and "9" in msg
+
+    def test_matching_widths_stack_cls_row_then_patches(self):
+        media = {
+            "id": 5,
+            "embedder": "dinov3_patch",
+            "embeddings": {"dinov3_patch": np.ones(3, dtype=np.float32)},
+            "patch_grid": np.zeros((2, 2, 3), dtype=np.float16),
+        }
+        rows = media_score_rows(media, "dinov3_patch")
+        assert rows is not None
+        assert rows.shape == (5, 3)  # 1 CLS row + 2x2 patches
+        assert rows[0, 0] == 1.0

--- a/tests_lib/datasets/test_local_archive_member_source.py
+++ b/tests_lib/datasets/test_local_archive_member_source.py
@@ -21,8 +21,20 @@ from vtscore.datasets.sources.local_archive_member import (
     SOURCE,
     LocalArchiveMemberSource,
 )
+from vtscore.embedding.binding import expected_dim_for_embedder
 
+#: Width used when a manifest declares no embedder (nothing to agree with).
 DIM = 8
+
+
+def _dim_for(embedder_name: str | None) -> int:
+    """Width a manifest naming *embedder_name* must use to be self-consistent.
+
+    Manifest reads reject an archive whose vectors contradict the embedder it
+    names, so a fixture cannot pair a real name with an arbitrary toy width.
+    Deriving the width keeps every fixture a *valid* manifest.
+    """
+    return expected_dim_for_embedder(embedder_name) or DIM
 
 
 def _make_manifest(
@@ -34,7 +46,7 @@ def _make_manifest(
     filenames=None,
 ) -> Path:
     rng = np.random.default_rng(3)
-    vectors = rng.standard_normal((len(members), DIM)).astype(np.float32)
+    vectors = rng.standard_normal((len(members), _dim_for(embedder_name))).astype(np.float32)
     archive = tmp_path / "shard.tar"
     arrays = {
         "vectors": vectors,
@@ -102,7 +114,7 @@ class TestFetchItem:
         fetched = src.fetch_item("a.mp4")
         assert fetched.path is None
         assert fetched.embedding is not None
-        assert fetched.embedding.shape == (DIM,)
+        assert fetched.embedding.shape == (_dim_for("xclip"),)
         assert fetched.embedder_name == "xclip"
 
     def test_unknown_key_returns_empty_fetch(self, tmp_path):

--- a/tests_lib/io/test_archive_member_import.py
+++ b/tests_lib/io/test_archive_member_import.py
@@ -14,12 +14,26 @@ import pytest
 from vtscore.datasets.archive_stream import archive_member_ref, read_member
 from vtscore.datasets.importers._npz_vectors import read_npz_archive_member_rows
 from vtscore.datasets.importers.local_archive_member import IMPORTER
+from vtscore.embedding.binding import expected_dim_for_embedder
 
 MEMBERS = {
     "chunk_a.mp4": b"AAAA-payload-a" * 16,
     "sub/chunk_b.mp4": b"BBBB-payload-b" * 16,
 }
+#: Width used when a manifest declares no embedder (nothing to agree with).
 DIM = 512
+
+
+def _dim_for(embedder_name: str | None) -> int:
+    """Width a manifest naming *embedder_name* must use to be self-consistent.
+
+    Manifest reads reject an archive whose vectors contradict the embedder it
+    names, so a fixture cannot pair a real name with an arbitrary toy width -
+    that combination is precisely the mislabelled manifest the guard exists to
+    catch. Deriving the width here keeps every fixture a *valid* manifest, so
+    these tests exercise the behaviour they are about rather than the guard.
+    """
+    return expected_dim_for_embedder(embedder_name) or DIM
 
 
 def _make_tar(tmp_path: Path) -> Path:
@@ -42,7 +56,7 @@ def _make_manifest(
 ) -> Path:
     members = members if members is not None else list(MEMBERS)
     rng = np.random.default_rng(7)
-    vectors = rng.standard_normal((len(members), DIM)).astype(np.float32)
+    vectors = rng.standard_normal((len(members), _dim_for(embedder_name))).astype(np.float32)
     manifest = tmp_path / "manifest.npz"
     archives = np.array(str(archive)) if scalar_archive else np.array([str(archive)] * len(members))
     arrays = {"vectors": vectors, "members": np.array(members), "archives": archives}
@@ -63,7 +77,7 @@ def _make_windowed_manifest(tmp_path: Path, archive: Path) -> Path:
     clip_starts = [s for _, s, _ in rows] + [float("nan")]  # NaN: whole-member row, no window
     clip_ends = [e for _, _, e in rows] + [float("nan")]
     rng = np.random.default_rng(11)
-    vectors = rng.standard_normal((len(members), DIM)).astype(np.float32)
+    vectors = rng.standard_normal((len(members), _dim_for("xclip"))).astype(np.float32)
     manifest = tmp_path / "windowed.npz"
     np.savez(
         manifest,
@@ -86,7 +100,7 @@ class TestManifestReader:
         assert {r["member"] for r in rows} == set(MEMBERS)
         for r in rows:
             assert Path(r["archive"]).name == "shard_000000.tar"
-            assert r["vector"].shape == (DIM,)
+            assert r["vector"].shape == (_dim_for("xclip"),)
         # filename defaults to the member basename.
         by_member = {r["member"]: r for r in rows}
         assert by_member["sub/chunk_b.mp4"]["filename"] == "chunk_b.mp4"
@@ -120,7 +134,7 @@ class TestImporter:
             assert "media_path" not in media or media["media_path"] is None
             # Precomputed embedding is carried, under the manifest's embedder.
             assert media["embedder"] == "xclip"
-            assert media["embeddings"]["xclip"].shape == (DIM,)
+            assert media["embeddings"]["xclip"].shape == (_dim_for("xclip"),)
             assert len(media["md5"]) == 32
             ref = media["archive_member"]
             assert Path(ref["path"]).name == "shard_000000.tar"
@@ -263,7 +277,7 @@ class TestWindowedManifest:
         manifest = tmp_path / "wid.npz"
         np.savez(
             manifest,
-            vectors=rng.standard_normal((2, DIM)).astype(np.float32),
+            vectors=rng.standard_normal((2, _dim_for("xclip"))).astype(np.float32),
             members=np.array(["chunk_a.mp4", "chunk_a.mp4"]),
             archives=np.array(str(archive)),
             window_id=np.array(["w0", "w1"]),
@@ -323,7 +337,7 @@ class TestLocalArchiveMemberSource:
         fetched = source.fetch_item("chunk_a.mp4")
         assert fetched.path is None
         assert fetched.embedding is not None
-        assert fetched.embedding.shape == (DIM,)
+        assert fetched.embedding.shape == (_dim_for("xclip"),)
         assert fetched.embedder_name == "xclip"
         # Re-supplied vector matches the in-memory embedding from import.
         np.testing.assert_array_equal(fetched.embedding, media["embeddings"]["xclip"])

--- a/tests_lib/io/test_precomputed_vector_validation.py
+++ b/tests_lib/io/test_precomputed_vector_validation.py
@@ -1,0 +1,411 @@
+"""Tests for the pre-computed vector guard (:mod:`vtscore.embedding.precomputed`).
+
+Vectors that arrive from outside VTSearch - an ``.npz`` manifest of
+pre-computed embeddings, an importer's ``content_vectors`` entry, a re-ingest
+source - carry no guarantee about their width, dtype or finiteness.  Adopted
+unchecked, none of those defects fail where they were introduced: a wrong-width
+row resurfaces as a bare numpy broadcast error inside the matrix builder on an
+unrelated request, and a non-finite row never raises at all.
+
+These tests pin the door shut at ingestion, and pin the scoring-path backstop
+that catches whatever slips past it by some other route.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.datasets.importers._npz_vectors import (
+    read_npz_archive_member_rows,
+    read_npz_filenames_and_vectors,
+    read_npz_multi_vectors,
+    write_npz_multi_vectors,
+)
+from vtscore.datasets.loader_folder import _resolve_file_embedding
+from vtscore.datasets.stages.embedding import _stamp_requested_embedder
+from vtscore.embedding.binding import expected_dim_for_embedder
+from vtscore.embedding.media_vectors import UNKNOWN_EMBEDDER_KEY
+from vtscore.embedding.precomputed import (
+    MismatchedVectorError,
+    normalize_vector,
+    normalize_vector_block,
+    require_dim,
+    stack_vectors,
+    vector_dim,
+)
+
+
+def _write(path, **arrays):
+    """Write an ``.npz`` and return its path."""
+    np.savez(path, **arrays)
+    return path
+
+
+class TestNormalizeVector:
+    def test_pins_dtype_to_float32(self):
+        """A float64 research export must not leave the dataset mixed-dtype."""
+        out = normalize_vector(np.arange(4, dtype=np.float64), label="v")
+        assert out.dtype == np.float32
+        assert out.flags["C_CONTIGUOUS"]
+
+    def test_accepts_float16_input(self):
+        """Half-precision vectors are legal input; they are widened, not refused."""
+        out = normalize_vector(np.ones(4, dtype=np.float16), label="v")
+        assert out.dtype == np.float32
+        assert np.array_equal(out, np.ones(4, dtype=np.float32))
+
+    def test_accepts_plain_python_list(self):
+        assert np.array_equal(normalize_vector([1.0, 2.0], label="v"), np.array([1.0, 2.0], dtype=np.float32))
+
+    def test_flattens_single_row_2d(self):
+        """A script that kept the leading axis produced (1, D); accept it."""
+        assert normalize_vector(np.ones((1, 5)), label="v").shape == (5,)
+
+    def test_rejects_none(self):
+        with pytest.raises(MismatchedVectorError, match="no vector supplied"):
+            normalize_vector(None, label="v")
+
+    def test_rejects_multi_row_2d(self):
+        with pytest.raises(MismatchedVectorError, match="expected a 1-D vector"):
+            normalize_vector(np.ones((3, 4)), label="v")
+
+    def test_rejects_empty(self):
+        with pytest.raises(MismatchedVectorError, match="zero-length"):
+            normalize_vector(np.zeros(0), label="v")
+
+    def test_rejects_nan(self):
+        with pytest.raises(MismatchedVectorError, match="non-finite"):
+            normalize_vector(np.array([1.0, np.nan]), label="v")
+
+    def test_rejects_inf(self):
+        with pytest.raises(MismatchedVectorError, match="non-finite"):
+            normalize_vector(np.array([1.0, np.inf]), label="v")
+
+    def test_rejects_float64_magnitude_that_overflows_float32(self):
+        """The finiteness check runs after the cast, so narrowing overflow is caught."""
+        with pytest.raises(MismatchedVectorError, match="non-finite"):
+            normalize_vector(np.array([1e300, 2.0], dtype=np.float64), label="v")
+
+    def test_rejects_non_numeric(self):
+        with pytest.raises(MismatchedVectorError, match="non-numeric"):
+            normalize_vector(np.array(["a", "b"]), label="v")
+
+    def test_rejects_wrong_expected_dim_and_names_both_widths(self):
+        with pytest.raises(MismatchedVectorError) as exc:
+            normalize_vector(np.ones(768), label="row 3", expected_dim=1152, expected_source="embedder 'siglip2_l'")
+        msg = str(exc.value)
+        assert "768" in msg and "1152" in msg
+        assert "row 3" in msg
+        assert "siglip2_l" in msg
+
+    def test_is_a_value_error(self):
+        """Existing ``except ValueError`` handlers must keep working."""
+        assert issubclass(MismatchedVectorError, ValueError)
+
+
+class TestNormalizeVectorBlock:
+    def test_pins_dtype_and_keeps_shape(self):
+        out = normalize_vector_block(np.arange(6, dtype=np.float64).reshape(3, 2), label="b")
+        assert out.dtype == np.float32
+        assert out.shape == (3, 2)
+
+    def test_rejects_1d_block(self):
+        """A manifest that lost its row axis is a bug, not a one-row archive."""
+        with pytest.raises(MismatchedVectorError, match=r"expected a 2-D \(N, D\) array"):
+            normalize_vector_block(np.ones(4), label="b")
+
+    def test_rejects_zero_width(self):
+        with pytest.raises(MismatchedVectorError, match="zero-width"):
+            normalize_vector_block(np.zeros((3, 0)), label="b")
+
+    def test_names_first_offending_row(self):
+        block = np.ones((5, 3))
+        block[3, 1] = np.nan
+        with pytest.raises(MismatchedVectorError, match="row: index 3"):
+            normalize_vector_block(block, label="b")
+
+    def test_rejects_wrong_expected_dim(self):
+        with pytest.raises(MismatchedVectorError, match="768-dimensional but 1152"):
+            normalize_vector_block(np.ones((2, 768)), label="b", expected_dim=1152)
+
+
+class TestRequireDimAndStackVectors:
+    def test_require_dim_passes_on_match(self):
+        require_dim(np.ones(4, dtype=np.float32), 4, label="m")
+
+    def test_require_dim_names_both_widths(self):
+        with pytest.raises(MismatchedVectorError, match="5-dimensional but 4 was expected"):
+            require_dim(np.ones(5), 4, label="media 7 (cat.jpg)")
+
+    def test_require_dim_rejects_non_1d(self):
+        with pytest.raises(MismatchedVectorError, match="expected a 1-D"):
+            require_dim(np.ones((2, 4)), 4, label="m")
+
+    def test_vector_dim_reads_trailing_axis(self):
+        assert vector_dim(np.ones((3, 7))) == 7
+        assert vector_dim([1.0, 2.0]) == 2
+
+    def test_stack_vectors_names_the_odd_row(self):
+        with pytest.raises(MismatchedVectorError, match=r"row 1 \(b\.jpg\)"):
+            stack_vectors(
+                [np.ones(4), np.ones(5)],
+                label="training vector",
+                row_labels=["a.jpg", "b.jpg"],
+            )
+
+    def test_stack_vectors_happy_path_is_float32(self):
+        out = stack_vectors([np.ones(3, dtype=np.float64), np.zeros(3)], label="v")
+        assert out.shape == (2, 3)
+        assert out.dtype == np.float32
+
+    def test_stack_vectors_rejects_empty(self):
+        with pytest.raises(MismatchedVectorError, match="no vectors to stack"):
+            stack_vectors([], label="v")
+
+
+class TestNpzFilenamesAndVectorsValidation:
+    def test_float64_manifest_is_widened_to_float32(self, tmp_path):
+        p = _write(
+            tmp_path / "m.npz",
+            filenames=np.array(["a.jpg", "b.jpg"]),
+            vectors=np.arange(8, dtype=np.float64).reshape(2, 4),
+        )
+        mapping = read_npz_filenames_and_vectors(p)
+        assert {v.dtype for v in mapping.values()} == {np.dtype(np.float32)}
+
+    def test_float16_manifest_is_widened_to_float32(self, tmp_path):
+        """A half-precision embed can ship its vectors; they are widened at the door."""
+        p = _write(tmp_path / "m.npz", filenames=np.array(["a.jpg"]), vectors=np.ones((1, 4), dtype=np.float16))
+        assert read_npz_filenames_and_vectors(p)["a.jpg"].dtype == np.float32
+
+    def test_non_finite_manifest_is_rejected(self, tmp_path):
+        p = _write(
+            tmp_path / "m.npz",
+            filenames=np.array(["a.jpg", "b.jpg"]),
+            vectors=np.array([[1.0, 2.0], [np.nan, 3.0]]),
+        )
+        with pytest.raises(MismatchedVectorError, match="non-finite"):
+            read_npz_filenames_and_vectors(p)
+
+    def test_declared_embedder_width_mismatch_is_rejected(self, tmp_path):
+        """The manifest contradicts itself: siglip2_l is 1152-dim, these rows are 768."""
+        assert expected_dim_for_embedder("siglip2_l") == 1152
+        p = _write(
+            tmp_path / "m.npz",
+            filenames=np.array(["a.jpg"]),
+            vectors=np.ones((1, 768), dtype=np.float32),
+            embedder_name=np.array("siglip2_l"),
+        )
+        with pytest.raises(MismatchedVectorError) as exc:
+            read_npz_filenames_and_vectors(p)
+        assert "siglip2_l" in str(exc.value)
+        assert "768" in str(exc.value) and "1152" in str(exc.value)
+
+    def test_matching_declared_embedder_width_is_accepted(self, tmp_path):
+        p = _write(
+            tmp_path / "m.npz",
+            filenames=np.array(["a.jpg"]),
+            vectors=np.ones((1, 1152), dtype=np.float32),
+            embedder_name=np.array("siglip2_l"),
+        )
+        assert read_npz_filenames_and_vectors(p)["a.jpg"].shape == (1152,)
+
+    def test_unregistered_embedder_name_skips_the_width_check(self, tmp_path):
+        """An unknown name means "nothing to check against", not an error here.
+
+        ``validate_manifest_embedder_name`` is what rejects an unroutable name,
+        and it runs in the importer with the media type in hand.
+        """
+        p = _write(
+            tmp_path / "m.npz",
+            filenames=np.array(["a.jpg"]),
+            vectors=np.ones((1, 7), dtype=np.float32),
+            embedder_name=np.array("not_a_real_embedder"),
+        )
+        assert read_npz_filenames_and_vectors(p)["a.jpg"].shape == (7,)
+
+
+class TestNpzPerKeyLayoutValidation:
+    def test_ragged_per_key_archive_names_the_offending_key(self, tmp_path):
+        """The per-key layout has no structural guarantee that rows agree."""
+        p = _write(tmp_path / "m.npz", a=np.ones(4), b=np.ones(5))
+        with pytest.raises(MismatchedVectorError) as exc:
+            read_npz_filenames_and_vectors(p)
+        assert "'b'" in str(exc.value)
+        assert "5-dimensional but 4" in str(exc.value)
+
+    def test_consistent_per_key_archive_is_accepted_and_widened(self, tmp_path):
+        p = _write(tmp_path / "m.npz", a=np.ones(4, dtype=np.float64), b=np.zeros(4, dtype=np.float64))
+        mapping = read_npz_filenames_and_vectors(p)
+        assert set(mapping) == {"a", "b"}
+        assert {v.dtype for v in mapping.values()} == {np.dtype(np.float32)}
+
+    def test_per_key_non_finite_is_rejected(self, tmp_path):
+        p = _write(tmp_path / "m.npz", a=np.array([1.0, np.inf]))
+        with pytest.raises(MismatchedVectorError, match="non-finite"):
+            read_npz_filenames_and_vectors(p)
+
+
+class TestNpzMultiVectorValidation:
+    def test_columns_may_differ_in_width_from_each_other(self, tmp_path):
+        """A trio archive's columns are *meant* to differ; only per-column checks apply.
+
+        ``siglip2_l`` really is 1152-dim while ``dinov3_patch`` really is 768-dim,
+        so a correct trio archive would trip any cross-column consistency check.
+        """
+        p = _write(
+            tmp_path / "m.npz",
+            filenames=np.array(["a.jpg"]),
+            vectors_siglip2_l=np.ones((1, 1152), dtype=np.float32),
+            vectors_dinov3_patch=np.ones((1, 768), dtype=np.float32),
+        )
+        result = read_npz_multi_vectors(p)
+        assert result is not None
+        mapping, _primary = result
+        assert mapping["a.jpg"]["siglip2_l"].shape == (1152,)
+        assert mapping["a.jpg"]["dinov3_patch"].shape == (768,)
+
+    def test_column_checked_against_its_own_embedder_width(self, tmp_path):
+        """``vectors_siglip2_l`` holding 768-dim rows is the mislabelled-column case."""
+        p = _write(
+            tmp_path / "m.npz",
+            filenames=np.array(["a.jpg"]),
+            vectors_siglip2_l=np.ones((1, 768), dtype=np.float32),
+        )
+        with pytest.raises(MismatchedVectorError, match="siglip2_l"):
+            read_npz_multi_vectors(p)
+
+    def test_non_finite_column_is_rejected(self, tmp_path):
+        p = _write(
+            tmp_path / "m.npz",
+            filenames=np.array(["a.jpg"]),
+            vectors_mystery=np.array([[1.0, np.nan]]),
+        )
+        with pytest.raises(MismatchedVectorError, match="non-finite"):
+            read_npz_multi_vectors(p)
+
+    def test_writer_names_the_offending_file_on_a_width_mismatch(self, tmp_path):
+        """``write_npz_multi_vectors`` used a bare ``np.stack``, which named nothing."""
+        mapping = {"a.jpg": {"e": np.ones(4)}, "b.jpg": {"e": np.ones(5)}}
+        with pytest.raises(MismatchedVectorError, match="b.jpg"):
+            write_npz_multi_vectors(tmp_path / "out.npz", mapping)
+
+    def test_multi_vector_round_trip(self, tmp_path):
+        mapping = {
+            "a.jpg": {"siglip": np.ones(768, dtype=np.float32)},
+            "b.jpg": {"siglip": np.zeros(768, dtype=np.float32)},
+        }
+        out = tmp_path / "out.npz"
+        write_npz_multi_vectors(out, mapping, "siglip")
+        result = read_npz_multi_vectors(out)
+        assert result is not None
+        read_back, primary = result
+        assert primary == "siglip"
+        assert np.array_equal(read_back["a.jpg"]["siglip"], np.ones(768, dtype=np.float32))
+
+
+class TestArchiveMemberManifestValidation:
+    def _manifest(self, tmp_path, vectors, **extra):
+        return _write(
+            tmp_path / "manifest.npz",
+            vectors=vectors,
+            members=np.array(["x.jpg", "y.jpg"][: len(vectors)]),
+            archives=np.array("shards.tar"),
+            **extra,
+        )
+
+    def test_float64_rows_are_widened(self, tmp_path):
+        p = self._manifest(tmp_path, np.arange(8, dtype=np.float64).reshape(2, 4))
+        rows = read_npz_archive_member_rows(p)
+        assert all(r["vector"].dtype == np.float32 for r in rows)
+
+    def test_non_finite_rows_are_rejected(self, tmp_path):
+        p = self._manifest(tmp_path, np.array([[1.0, 2.0], [3.0, np.nan]]))
+        with pytest.raises(MismatchedVectorError, match="non-finite"):
+            read_npz_archive_member_rows(p)
+
+    def test_declared_embedder_width_mismatch_is_rejected(self, tmp_path):
+        p = self._manifest(tmp_path, np.ones((2, 768), dtype=np.float32), embedder_name=np.array("siglip2_l"))
+        with pytest.raises(MismatchedVectorError, match="siglip2_l"):
+            read_npz_archive_member_rows(p)
+
+
+class TestContentVectorAdoption:
+    """``content_vectors`` / ``custom_metadata_map`` are the plugin-importer channel."""
+
+    def test_content_vector_is_widened_to_float32(self):
+        vec, name = _resolve_file_embedding("a.jpg", "a.jpg", None, {"a.jpg": np.ones(4, dtype=np.float64)}, "siglip")
+        assert vec.dtype == np.float32
+        assert name == "siglip"
+
+    def test_non_finite_content_vector_is_rejected(self):
+        with pytest.raises(MismatchedVectorError, match="non-finite"):
+            _resolve_file_embedding("a.jpg", "a.jpg", None, {"a.jpg": np.array([1.0, np.nan])}, "")
+
+    def test_non_finite_custom_metadata_vector_is_rejected(self):
+        with pytest.raises(MismatchedVectorError, match="non-finite"):
+            _resolve_file_embedding("a.jpg", "a.jpg", {"embedding": np.array([np.inf])}, None, "")
+
+    def test_per_embedder_dict_is_validated_column_by_column(self):
+        """A trio import supplies a ready-made ``{embedder: vector}`` dict."""
+        value = {"siglip": np.ones(4, dtype=np.float64), "dinov3_patch": np.ones(8, dtype=np.float64)}
+        vec, _name = _resolve_file_embedding("a.jpg", "a.jpg", None, {"a.jpg": value}, "siglip")
+        assert set(vec) == {"siglip", "dinov3_patch"}
+        assert vec["siglip"].shape == (4,) and vec["dinov3_patch"].shape == (8,)
+        assert all(v.dtype == np.float32 for v in vec.values())
+
+    def test_bad_column_in_a_per_embedder_dict_is_rejected(self):
+        value = {"siglip": np.ones(4), "dinov3_patch": np.array([np.nan, 1.0])}
+        with pytest.raises(MismatchedVectorError, match="dinov3_patch"):
+            _resolve_file_embedding("a.jpg", "a.jpg", None, {"a.jpg": value}, "siglip")
+
+    def test_absent_vector_still_returns_none(self):
+        assert _resolve_file_embedding("a.jpg", "a.jpg", None, {}, "") == (None, "")
+
+
+class TestStampRequestedEmbedder:
+    """Re-keying a nameless vector under a named embedder is an assertion, not a rename.
+
+    A manifest that ships vectors but no ``embedder_name`` stores them under the
+    blank sentinel key.  When the load names an embedder, the stage re-keys them
+    under that name - which claims the vectors live in that embedder's space.  A
+    manifest whose vectors came from a different model makes the claim false, and
+    the media then looks identical to a correctly-labelled one.
+    """
+
+    @staticmethod
+    def _nameless(dim: int) -> dict:
+        return {1: {"id": 1, "filename": "a.jpg", "embeddings": {UNKNOWN_EMBEDDER_KEY: np.ones(dim, np.float32)}}}
+
+    def test_matching_width_is_stamped(self):
+        medias = self._nameless(1152)
+        _stamp_requested_embedder(medias, "siglip2_l")
+        assert medias[1]["embedder"] == "siglip2_l"
+        assert set(medias[1]["embeddings"]) == {"siglip2_l"}
+
+    def test_wrong_width_is_rejected_and_names_both_widths(self):
+        medias = self._nameless(768)
+        with pytest.raises(MismatchedVectorError) as exc:
+            _stamp_requested_embedder(medias, "siglip2_l")
+        msg = str(exc.value)
+        assert "a.jpg" in msg
+        assert "768" in msg and "1152" in msg
+
+    def test_wrong_width_leaves_the_media_untouched(self):
+        """A rejected stamp must not half-apply: the sentinel key stays put."""
+        medias = self._nameless(768)
+        with pytest.raises(MismatchedVectorError):
+            _stamp_requested_embedder(medias, "siglip2_l")
+        assert set(medias[1]["embeddings"]) == {UNKNOWN_EMBEDDER_KEY}
+        assert "embedder" not in medias[1]
+
+    def test_unknown_embedder_width_skips_the_check(self):
+        medias = self._nameless(7)
+        _stamp_requested_embedder(medias, "not_a_real_embedder")
+        assert medias[1]["embedder"] == "not_a_real_embedder"
+
+    def test_importer_set_name_is_never_overwritten(self):
+        medias = {1: {"id": 1, "embedder": "clip", "embeddings": {"clip": np.ones(512, np.float32)}}}
+        _stamp_requested_embedder(medias, "siglip2_l")
+        assert medias[1]["embedder"] == "clip"

--- a/tests_lib/io/test_server_files_importer.py
+++ b/tests_lib/io/test_server_files_importer.py
@@ -19,6 +19,7 @@ from vtscore.datasets.importers.server_files import (
     _read_paths_file,
     _symlink_paths,
 )
+from vtscore.embedding.binding import expected_dim_for_embedder
 from vtscore.embedding.media_vectors import media_embedding
 
 
@@ -192,7 +193,9 @@ def _make_archive_manifest(tmp_path: Path):
             tf.addfile(info, io.BytesIO(payload))
 
     rng = np.random.default_rng(11)
-    vectors = rng.standard_normal((len(members), 512)).astype(np.float32)
+    # A manifest naming ``xclip`` must ship xclip-width rows: the reader rejects
+    # an archive whose vectors contradict the embedder it declares.
+    vectors = rng.standard_normal((len(members), expected_dim_for_embedder("xclip") or 512)).astype(np.float32)
     manifest = tmp_path / "manifest.npz"
     np.savez(
         manifest,

--- a/vtscore/datasets/importers/_npz_vectors.py
+++ b/vtscore/datasets/importers/_npz_vectors.py
@@ -36,6 +36,18 @@ Layout 3 (per-embedder) is detected first (any ``vectors_<name>`` key), then
 the standard ``filenames`` + ``vectors`` layout, and finally the per-key
 layout.  ``allow_pickle`` is disabled to avoid loading arbitrary Python
 objects from untrusted archives.
+
+**Every vector these readers return has been validated** (see
+:mod:`vtscore.embedding.precomputed`): it is a finite, contiguous, 1-D
+``float32`` row, and - when the archive names an embedder whose width VTSearch
+knows - its width matches that embedder's
+:attr:`~vtscore.media.embedder.MediaEmbedder.embedding_dim`.  This is the door
+an outside vector comes through, and it is the only cheap place to check: a
+manifest is read once, whereas the width mismatch it would otherwise introduce
+resurfaces on *every* subsequent scoring request as a bare numpy broadcast error
+that names neither the media nor the manifest.  Rejecting here also pins the
+dtype, so a ``float64`` research export or a half-precision embed cannot leave a
+dataset holding mixed-dtype vectors.
 """
 
 from __future__ import annotations
@@ -45,6 +57,9 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+
+from vtscore.embedding.binding import expected_dim_for_embedder
+from vtscore.embedding.precomputed import normalize_vector, normalize_vector_block, stack_vectors
 
 
 _FILENAMES_KEYS = ("filenames", "names", "paths", "filename")
@@ -122,6 +137,45 @@ def validate_manifest_embedder_name(
     )
 
 
+def _validated_vector_block(
+    arr: Any,
+    *,
+    npz_path: Path,
+    vectors_key: str,
+    embedder_name: str = "",
+) -> np.ndarray:
+    """Validate an ``(N, D)`` manifest vectors array, checking width against its embedder.
+
+    One vectorised pass rejects a ragged / non-2-D / zero-width / non-finite
+    block and pins the dtype to ``float32``, so a ``float64`` research export or
+    a half-precision embed can never reach ``media["embeddings"]`` in its
+    original dtype.  When the archive names an embedder whose width we know, a
+    disagreement is caught here - at the door, naming the manifest - rather than
+    surfacing later as a broadcast error inside the matrix builder.
+    """
+    return normalize_vector_block(
+        arr,
+        label=f"NPZ manifest {npz_path} array {vectors_key!r}",
+        expected_dim=expected_dim_for_embedder(embedder_name),
+        expected_source=f"the width declared by embedder {embedder_name!r}" if embedder_name else "",
+    )
+
+
+def _archive_embedder_name(data) -> str:
+    """Return the scalar ``embedder_name`` / ``embedder`` value in *data*, or ``""``.
+
+    The in-archive counterpart of :func:`read_npz_embedder_name` (which opens the
+    file itself); used by the readers that already hold an open handle so a
+    manifest is not read twice just to learn the name its vectors must match.
+    """
+    key_set = set(data.files)
+    for key in _EMBEDDER_NAME_KEYS:
+        if key in key_set:
+            val = data[key]
+            return (str(val) if val.ndim == 0 else str(val.flat[0])).strip()
+    return ""
+
+
 def is_archive_member_manifest(npz_path: Path) -> bool:
     """Return ``True`` if *npz_path* is a no-extraction **archive-member** manifest.
 
@@ -176,23 +230,56 @@ def read_npz_filenames_and_vectors(npz_path: Path) -> dict[str, np.ndarray]:
                     f"NPZ '{filenames_key}' and '{vectors_key}' have mismatched lengths "
                     f"({len(names_arr)} vs {len(vecs_arr)})"
                 )
+            vecs_arr = _validated_vector_block(
+                vecs_arr, npz_path=p, vectors_key=vectors_key, embedder_name=_archive_embedder_name(data)
+            )
             mapping: dict[str, np.ndarray] = {}
             for i, raw_name in enumerate(names_arr):
                 name = str(raw_name).strip()
                 if not name:
                     continue
-                mapping[name] = np.asarray(vecs_arr[i])
+                mapping[name] = vecs_arr[i]
             if not mapping:
                 raise ValueError(f"NPZ '{filenames_key}' array is empty")
             return mapping
 
-        # Per-key layout: every archive key is a filename.
-        if not keys:
-            raise ValueError(f"NPZ archive {p} is empty")
-        mapping = {}
-        for k in keys:
-            mapping[k] = np.asarray(data[k])
-        return mapping
+        return _read_per_key_vectors(data, keys, p)
+
+
+def _read_per_key_vectors(data, keys: list[str], p: Path) -> dict[str, np.ndarray]:
+    """Read the per-key layout, where every archive key is a filename.
+
+    Unlike the ``filenames`` + ``vectors`` block layout there is no single array
+    to validate in one pass, and nothing structural forces the entries to agree
+    on a width - so each is validated individually and checked against the
+    archive's declared embedder (or, failing that, the first entry).  That is
+    what turns "one row in this archive is 768-dim" into a message naming the
+    offending key instead of a broadcast failure several requests later.
+    """
+    if not keys:
+        raise ValueError(f"NPZ archive {p} is empty")
+    embedder_name = _archive_embedder_name(data)
+    expected_dim = expected_dim_for_embedder(embedder_name)
+    # Name where the width we compare against came from, so the message points at
+    # the thing the user can change: a declared embedder if the archive names one,
+    # otherwise simply "whatever the first entry was".
+    expected_source = (
+        f"the width declared by embedder {embedder_name!r}"
+        if expected_dim is not None
+        else f"matching the first entry {keys[0]!r}"
+    )
+    mapping: dict[str, np.ndarray] = {}
+    for k in keys:
+        vec = normalize_vector(
+            data[k],
+            label=f"NPZ archive {p} entry {k!r}",
+            expected_dim=expected_dim,
+            expected_source=expected_source,
+        )
+        if expected_dim is None:
+            expected_dim = int(vec.shape[0])
+        mapping[k] = vec
+    return mapping
 
 
 def _multi_vectors_embedder_name(key: str) -> str:
@@ -241,7 +328,12 @@ def _multi_vector_columns(data, p: Path) -> tuple[dict[str, np.ndarray], np.ndar
         arr = data[key]
         if len(arr) != n:
             raise ValueError(f"NPZ '{key}' and '{filenames_key}' have mismatched lengths ({len(arr)} vs {n})")
-        columns[emb_name] = arr
+        # Each column is validated against *its own* embedder's declared width.
+        # Columns legitimately differ from one another (siglip is 1152-dim while
+        # dinov3_patch is 768-dim), so the only meaningful width check here is
+        # per-column - which is exactly the check that catches a trio archive
+        # whose columns were written under the wrong keys.
+        columns[emb_name] = _validated_vector_block(arr, npz_path=p, vectors_key=key, embedder_name=emb_name)
     return columns, names_arr
 
 
@@ -341,7 +433,14 @@ def write_npz_multi_vectors(
 
     arrays: dict[str, np.ndarray] = {"filenames": np.array(filenames)}
     for emb_name in embedder_names:
-        arrays[f"vectors_{emb_name}"] = np.stack([np.asarray(mapping[f][emb_name]) for f in filenames])
+        # stack_vectors rather than np.stack: a dataset whose media disagree on
+        # width would otherwise be written out as "all input arrays must have the
+        # same shape", which names neither the embedder nor the offending file.
+        arrays[f"vectors_{emb_name}"] = stack_vectors(
+            [mapping[f][emb_name] for f in filenames],
+            label=f"write_npz_multi_vectors column {emb_name!r}",
+            row_labels=filenames,
+        )
     if primary_embedder:
         arrays["embedder_name"] = np.array(primary_embedder)
 
@@ -427,6 +526,9 @@ def _manifest_columns(data, p: Path) -> dict[str, Any]:
         raise ValueError(f"NPZ '{members_key}' and '{vectors_key}' have mismatched lengths ({n} vs {len(vecs_arr)})")
     if archives_key is None:
         raise ValueError(f"NPZ manifest {p} must contain an archives array (one of {_ARCHIVES_KEYS})")
+    vecs_arr = _validated_vector_block(
+        vecs_arr, npz_path=p, vectors_key=vectors_key, embedder_name=_archive_embedder_name(data)
+    )
 
     return {
         "vectors": vecs_arr,

--- a/vtscore/datasets/importers/recaller/__init__.py
+++ b/vtscore/datasets/importers/recaller/__init__.py
@@ -67,6 +67,8 @@ from collections.abc import Sequence
 from typing import Any, Iterator
 
 from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
+from vtscore.embedding.binding import expected_dim_for_embedder
+from vtscore.embedding.precomputed import normalize_vector
 from vtscore.plugins import FieldOption
 from vtscore.media import all_folder_names
 
@@ -138,6 +140,17 @@ def _build_media(
     content_id = record["contentID"]
     media_id = record["mediaID"]
     media_url = record["media_url"]
+    # DataWrest's vector is external input: validate it (shape, dtype,
+    # finiteness, and width against the embedder it names) before it becomes a
+    # stored embedding, so a bad row fails on the record that produced it rather
+    # than as a broadcast error inside the matrix builder later.
+    embedder_name = embedding_info["embedder"]
+    embedding = normalize_vector(
+        embedding_info["embedding"],
+        label=f"ReCaller embedding for content id {content_id!r}",
+        expected_dim=expected_dim_for_embedder(embedder_name),
+        expected_source=f"the width declared by embedder {embedder_name!r}",
+    )
     origin = {
         "importer": importer_name,
         "params": {
@@ -151,8 +164,8 @@ def _build_media(
         "media_type": media_type,
         "filename": content_id,
         "md5": record["md5"],
-        "embeddings": {embedding_info["embedder"]: embedding_info["embedding"]},
-        "embedder": embedding_info["embedder"],
+        "embeddings": {embedder_name: embedding},
+        "embedder": embedder_name,
         "media_bytes": media_bytes,
         "media_path": None,
         "media_url": media_url,

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -28,6 +28,7 @@ from vtscore.datasets.loader import (
     _pop_md5_key,
 )
 from vtscore.embedding.media_vectors import init_embeddings
+from vtscore.embedding.precomputed import normalize_vector
 from vtscore.security.path_validation import (
     glob_top_level,
     iter_glob_top_level,
@@ -314,15 +315,42 @@ def _resolve_file_embedding(
     is recorded on the media; ``""`` is returned when the caller doesn't
     know the embedder (the framework embed stage will stamp its own name
     when embedding is ``None``).
+
+    Whatever a hit yields is validated by
+    :func:`~vtscore.embedding.precomputed.normalize_vector` before it is
+    returned.  ``content_vectors`` and ``custom_metadata_map`` are the
+    documented channels for a *third-party* importer plugin to ship vectors it
+    computed elsewhere (see
+    :meth:`~vtscore.datasets.importers.base.core.DatasetImporter.yield_precomputed`),
+    so unlike an internally-produced embedding nothing guarantees their shape,
+    dtype or finiteness.  Validating here - once per file, at the only point
+    those dicts become a media's stored vector - keeps a plugin's bad row from
+    becoming a numpy broadcast error inside the matrix builder on some later
+    request.
     """
     cm_embedding = _get_embedding_value(file_cm) if file_cm else None
     if cm_embedding is not None:
-        return cm_embedding, ""
-    if content_vectors and rel_path in content_vectors:
-        return content_vectors[rel_path], content_embedder_name
-    if content_vectors and file_name in content_vectors:
-        return content_vectors[file_name], content_embedder_name
+        return _validated_precomputed(cm_embedding, f"custom_metadata embedding for {rel_path!r}"), ""
+    for key in (rel_path, file_name):
+        if content_vectors and key in content_vectors:
+            vec = _validated_precomputed(content_vectors[key], f"pre-computed vector for {key!r}")
+            return vec, content_embedder_name
     return None, ""
+
+
+def _validated_precomputed(value: Any, label: str) -> Any:
+    """Validate a pre-computed entry, which may be a vector *or* a per-embedder dict.
+
+    A per-embedder ``vectors_<name>`` NPZ import supplies one vector per bound
+    embedder as a ready-made ``{embedder_name: vector}`` dict (see
+    :func:`~vtscore.embedding.media_vectors.init_embeddings`), so both shapes
+    reach this point.  Each column is validated on its own: a trio archive's
+    columns are *meant* to differ in width (siglip is 1152-dim, dinov3_patch is
+    768-dim), so the only sound check is per-embedder, never across the dict.
+    """
+    if isinstance(value, dict):
+        return {name: normalize_vector(vec, label=f"{label} [embedder {name!r}]") for name, vec in value.items()}
+    return normalize_vector(value, label=label)
 
 
 def _resolve_file_md5(

--- a/vtscore/datasets/sources/pullwrest.py
+++ b/vtscore/datasets/sources/pullwrest.py
@@ -174,7 +174,8 @@ class PullWrestSource(MediaSource):
         Falls back to the single-item path for keys that are not
         ``self._content_id``.
         """
-        import numpy as np
+        from vtscore.embedding.binding import expected_dim_for_embedder  # noqa: PLC0415
+        from vtscore.embedding.precomputed import normalize_vector  # noqa: PLC0415
 
         # Collect items this source actually owns.
         owned = [k for k in keys if k == self._content_id]
@@ -190,8 +191,22 @@ class PullWrestSource(MediaSource):
                     cached = tmpdir / cid
                     cached.write_bytes(resp["data"])
 
+                    # A remote service's vector is as untrusted as a manifest's:
+                    # validate it here rather than letting a wrong-width or
+                    # non-finite row become a stored embedding.  This runs inside
+                    # the try, so a bad row degrades to the single-item fallback
+                    # below instead of aborting the whole batch.
                     raw_emb = resp.get("embedding")
-                    embedding = np.array(raw_emb, dtype=np.float32) if raw_emb else None
+                    embedding = (
+                        normalize_vector(
+                            raw_emb,
+                            label=f"PullWrest embedding for content id {cid!r}",
+                            expected_dim=expected_dim_for_embedder(resp.get("embedder_name", "")),
+                            expected_source=f"the width declared by embedder {resp.get('embedder_name', '')!r}",
+                        )
+                        if raw_emb
+                        else None
+                    )
 
                     extra: dict[str, Any] = {}
                     for field in ("file_size", "duration", "created_at"):

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -13,6 +13,7 @@ import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable
 
+from vtscore.embedding.binding import expected_dim_for_embedder
 from vtscore.embedding.matrix import invalidate_embedding_matrix
 from vtscore.embedding.media_vectors import (
     EMBEDDINGS_KEY,
@@ -22,6 +23,7 @@ from vtscore.embedding.media_vectors import (
     media_embedding,
     set_media_embedding,
 )
+from vtscore.embedding.precomputed import require_dim
 
 from vtscore.datasets.stages._common import _STATUS_TO_STEP, _TOTAL_LOAD_STEPS
 
@@ -109,16 +111,33 @@ def _stamp_requested_embedder(medias: dict[int, dict[str, Any]], embedder_name: 
 
     Only media whose embedder name is blank are touched; an importer-set name is
     never overwritten.  A no-op when *embedder_name* is blank (no pick to stamp).
+
+    **The stamp is checked, not assumed.**  Re-keying is an assertion that the
+    nameless vector belongs to *embedder_name*'s space, and a manifest whose
+    vectors came from a different model would make that assertion false - after
+    which the media is indistinguishable from a correctly-labelled one, and the
+    mismatch only surfaces as a broadcast error deep in the matrix builder.  So
+    when the embedder declares a width, a vector that disagrees with it is
+    rejected here, naming both widths.
     """
     if not embedder_name:
         return
-    for m in medias.values():
+    expected_dim = expected_dim_for_embedder(embedder_name)
+    for mid, m in medias.items():
         if m.get("embedder"):
             continue
         embs = m.get(EMBEDDINGS_KEY)
         if not isinstance(embs, dict) or UNKNOWN_EMBEDDER_KEY not in embs:
             continue
-        vec = embs.pop(UNKNOWN_EMBEDDER_KEY)
+        vec = embs[UNKNOWN_EMBEDDER_KEY]
+        if expected_dim is not None:
+            require_dim(
+                vec,
+                expected_dim,
+                label=f"pre-computed vector for media {mid} ({m.get('origin_name') or m.get('filename') or '?'})",
+                expected_source=f"the width declared by embedder {embedder_name!r}",
+            )
+        embs.pop(UNKNOWN_EMBEDDER_KEY)
         embs.setdefault(embedder_name, vec)
         m["embedder"] = embedder_name
 

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -403,7 +403,8 @@ def _cache_region_vectors(
     the skip is load-bearing: a semantic- or structural-locked detector is
     scored against its own space's full-image vectors, so flooding it with the
     dataset's patch grid would train it on a different embedding space (and
-    blow up at ``np.stack`` outright when the two dimensions differ).  Both
+    raise :class:`~vtscore.embedding.precomputed.MismatchedVectorError` outright
+    when the two dimensions differ).  Both
     caches stay empty, and :func:`build_xy_from_labelset` falls back to the
     single image-level vector per element.
     """

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from vtscore.embedding.precomputed import stack_vectors
 from vtscore.utils.scores import sigmoid_to_finite_array
 
 if TYPE_CHECKING:
@@ -88,7 +89,8 @@ def _scores_in_patch_space(snap: dict[int, dict[str, Any]] | None, embedder_name
       that space's full-image vectors (:func:`_score_all_media`), so it must
       train on those vectors too - flooding it with patch rows would mix two
       unrelated embedding spaces into one model (or, when their dimensions
-      differ, fail outright at ``np.stack``).
+      differ, fail outright with a
+      :class:`~vtscore.embedding.precomputed.MismatchedVectorError`).
     * ``None`` (no per-detector primary) keeps the dataset-level score
       precedence, where any media carrying a ``patch_grid`` takes the patch
       path - the pre-per-detector behaviour.
@@ -341,7 +343,7 @@ def train_and_threshold(
     from vtscore.training.blend_schedules import BlendContext
     from vtscore.training.mlp import LINEAR_HEAD
 
-    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
+    X = torch.from_numpy(stack_vectors(X_list, label="training vector"))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
 
@@ -651,9 +653,9 @@ def _build_vote_xy(
     multi-embedder dataset therefore trains on that space's **full-image**
     vectors, exactly the rows it will be scored over; without the gate its Bad
     votes flooded patch-space rows (and its boxed Good votes pooled one) into a
-    model scored in a different space entirely - a ``np.stack`` ValueError when
-    the two dimensions differ, silent garbage negatives when they happen to
-    match.
+    model scored in a different space entirely - a
+    :class:`~vtscore.embedding.precomputed.MismatchedVectorError` when the two
+    dimensions differ, silent garbage negatives when they happen to match.
     """
     patch_rows = _scores_in_patch_space(clips_dict, embedder_name)
     if embedder_name is None:
@@ -885,7 +887,7 @@ def _train_and_score_xy(
     # reads vectors from this same space the X_list were assembled in.
     score_emb = detector_score_embedder(det_ctx, clips_dict)
 
-    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
+    X = torch.from_numpy(stack_vectors(X_list, label="training vector"))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
 
@@ -1138,7 +1140,7 @@ def train_detector_from_origins(
     if len(X_list) < 2 or num_good == 0 or num_bad == 0:
         return None, 0.5
 
-    X = torch.from_numpy(np.stack(X_list).astype(np.float32, copy=False))
+    X = torch.from_numpy(stack_vectors(X_list, label="training vector"))
     y = torch.tensor(y_list, dtype=torch.float32).unsqueeze(1)
     input_dim = X.shape[1]
 

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -95,6 +95,13 @@ def expected_dim_for_embedder(embedder_name: str | None) -> int | None:
     that says ``embedder_name="siglip2_l"`` but ships 768-dim rows is
     contradicting itself, and the contradiction is visible without loading a
     single model.
+
+    Anything that is not a positive ``int`` collapses to ``None``.
+    ``embedding_dim`` is part of the *plugin* surface, so a third-party embedder
+    may return whatever it likes, and a test double standing in for the registry
+    returns a mock.  The value's only use is a width comparison, so a
+    non-integer has to read as "unknown" rather than as a width that nothing can
+    ever match.
     """
     name = (embedder_name or "").strip()
     if not name:
@@ -103,9 +110,13 @@ def expected_dim_for_embedder(embedder_name: str | None) -> int | None:
     from vtscore.media import get_embedder  # noqa: PLC0415 - avoid import cycle
 
     try:
-        return get_embedder(name).embedding_dim
+        dim = get_embedder(name).embedding_dim
     except KeyError:
         return None
+    # ``bool`` is an int subclass; True would otherwise read as a width of 1.
+    if isinstance(dim, bool) or not isinstance(dim, int) or dim <= 0:
+        return None
+    return dim
 
 
 def embedder_type(embedder_name: str | None) -> str:

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -81,6 +81,33 @@ def _capabilities(embedder_name: str) -> tuple[bool, bool, bool]:
     )
 
 
+def expected_dim_for_embedder(embedder_name: str | None) -> int | None:
+    """Return the declared output width of *embedder_name*, or ``None`` if unknown.
+
+    Reads :attr:`~vtscore.media.embedder.MediaEmbedder.embedding_dim`, which is
+    descriptor metadata - no weights are downloaded and no model is loaded, so
+    this is cheap enough to call on every manifest read.  ``None`` for a blank
+    or unregistered name, or an embedder that declares no fixed width; callers
+    treat that as "nothing to check against" rather than an error, since a
+    manifest of pre-computed vectors is allowed not to name its embedder at all.
+
+    This is what lets a mislabelled manifest be caught at the door: a ``.npz``
+    that says ``embedder_name="siglip2_l"`` but ships 768-dim rows is
+    contradicting itself, and the contradiction is visible without loading a
+    single model.
+    """
+    name = (embedder_name or "").strip()
+    if not name:
+        return None
+
+    from vtscore.media import get_embedder  # noqa: PLC0415 - avoid import cycle
+
+    try:
+        return get_embedder(name).embedding_dim
+    except KeyError:
+        return None
+
+
 def embedder_type(embedder_name: str | None) -> str:
     """Classify *embedder_name* into one of the three detector embedder types.
 

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from vtscore.embedding.media_vectors import media_embedder_names, media_embedding, primary_embedder_name
+from vtscore.embedding.precomputed import MismatchedVectorError, require_dim
 from vtscore.state.core import _state_lock
 
 if TYPE_CHECKING:
@@ -82,6 +83,18 @@ def _require_embedding(cid: int, media: dict[str, Any], embedder_name: str | Non
     return emb
 
 
+def _vector_label(cid: int, media: dict[str, Any], embedder_name: str | None) -> str:
+    """Human-locatable name for one media's vector, for a mismatch message.
+
+    Prefers the media's origin name / filename over the bare content id: the id
+    is an internal integer the user has no way to look up, whereas the filename
+    is the row they can go and find in the manifest that supplied it.
+    """
+    who = media.get("origin_name") or media.get("filename") or "?"
+    suffix = f" under embedder {embedder_name!r}" if embedder_name else ""
+    return f"media {cid} ({who}){suffix}"
+
+
 def _stack_embeddings(
     sorted_ids: list[int],
     source: dict[int, dict[str, Any]],
@@ -92,12 +105,33 @@ def _stack_embeddings(
     Rows follow *sorted_ids* order, pulling each media's vector via
     :func:`_require_embedding` (which routes through the dict-keyed accessor).
     Raises ``ValueError`` naming the first media that lacks a vector.
+
+    Each row's width is checked against the first row's before it is assigned.
+    Ingestion is supposed to make a mixed-width dataset impossible (see
+    :mod:`vtscore.embedding.precomputed`), but a dataset can still acquire one
+    by other routes - a pickle written before that validation existed, or a
+    third-party importer that writes ``media["embeddings"]`` directly - and
+    without the check numpy reports only
+
+        could not broadcast input array from shape (768,) into shape (1152,)
+
+    which names neither the media nor the embedder, on a request that has
+    nothing to do with where the bad vector came from.  The check is one
+    attribute read per media against an ``(N, D)`` allocation and a full copy,
+    so it costs nothing measurable on the hot path.
     """
     first_emb = np.asarray(_require_embedding(sorted_ids[0], source[sorted_ids[0]], embedder_name), dtype=np.float32)
     dim = int(first_emb.shape[-1])
     matrix = np.empty((len(sorted_ids), dim), dtype=np.float32)
     for i, cid in enumerate(sorted_ids):
-        matrix[i] = _require_embedding(cid, source[cid], embedder_name)
+        vec = _require_embedding(cid, source[cid], embedder_name)
+        require_dim(
+            vec,
+            dim,
+            label=_vector_label(cid, source[cid], embedder_name),
+            expected_source=f"matching {_vector_label(sorted_ids[0], source[sorted_ids[0]], embedder_name)}",
+        )
+        matrix[i] = vec
     return matrix
 
 
@@ -441,7 +475,20 @@ def media_score_rows(
     flat = arr.reshape(-1, arr.shape[-1])
     if emb is None:
         return flat
-    return np.concatenate([np.asarray(emb, dtype=dtype).reshape(1, -1), flat], axis=0)
+    cls_row = np.asarray(emb, dtype=dtype).reshape(1, -1)
+    if cls_row.shape[1] != flat.shape[1]:
+        # The image-level vector and the patch grid must live in the same space
+        # for a max-pool over them to mean anything.  np.concatenate would report
+        # only an axis-1 dimension mismatch, so say which two things disagree.
+        raise MismatchedVectorError(
+            f"media {media.get('id', '?')} ({media.get('origin_name') or media.get('filename') or '?'}): "
+            f"its image-level vector is {cls_row.shape[1]}-dimensional but its patch grid is "
+            f"{flat.shape[1]}-dimensional. MaxPatch scoring max-pools the two together, so they must come "
+            f"from the same embedder"
+            + (f" (expected {embedder_name!r})" if embedder_name else "")
+            + ". Re-embed this dataset so the image-level and patch vectors are produced by one model."
+        )
+    return np.concatenate([cls_row, flat], axis=0)
 
 
 def media_row_box(media: dict[str, Any], row_index: int) -> list[float] | None:
@@ -531,14 +578,26 @@ def _build_region_arrays(
     np.cumsum(counts[:-1], out=starts[1:])
     total = int(counts.sum())
 
-    # Pass 2: allocate once and fill each media's slice in place.
+    # Pass 2: allocate once and fill each media's slice in place.  Each media's
+    # rows are width-checked against the first media's before assignment, for
+    # the same reason as in ``_stack_embeddings``: the raw failure here is a
+    # bare numpy broadcast error naming neither the media nor the embedder.
     first = media_score_rows(snap[sorted_ids[0]], patch_embedder_name, dtype=np.float16)
     assert first is not None  # guaranteed by the _require_embedding pass above
-    region_matrix = np.empty((total, int(first.shape[1])), dtype=np.float16)
+    dim = int(first.shape[1])
+    region_matrix = np.empty((total, dim), dtype=np.float16)
     region_matrix[: first.shape[0]] = first
     for mi, cid in enumerate(sorted_ids[1:], start=1):
         rows = media_score_rows(snap[cid], patch_embedder_name, dtype=np.float16)
         assert rows is not None
+        if int(rows.shape[1]) != dim:
+            raise MismatchedVectorError(
+                f"{_vector_label(cid, snap[cid], patch_embedder_name)}: contributes "
+                f"{int(rows.shape[1])}-dimensional score rows, but "
+                f"{_vector_label(sorted_ids[0], snap[sorted_ids[0]], patch_embedder_name)} is {dim}-dimensional. "
+                "Every media in a dataset must be scored in one embedding space; this dataset mixes two. "
+                "Re-import the odd media with vectors from the same embedder, or rebuild the dataset."
+            )
         start = int(starts[mi])
         region_matrix[start : start + rows.shape[0]] = rows
 

--- a/vtscore/embedding/precomputed.py
+++ b/vtscore/embedding/precomputed.py
@@ -1,0 +1,274 @@
+"""Validation of externally-supplied ("pre-computed") embedding vectors.
+
+Most vectors in VTSearch are produced by an embedder we control, so their
+width, dtype and finiteness are guaranteed by construction.  A second class of
+vector arrives from *outside*: an ``.npz`` manifest of pre-computed embeddings,
+an importer's ``content_vectors`` / ``custom_metadata_map`` entry, or a re-ingest
+source that re-supplies a stored vector.  Nothing about those is guaranteed -
+they can be the wrong width (produced by a different model), the wrong dtype
+(``float64`` from a research script, ``float16`` from a half-precision embed),
+non-finite (a failed forward pass serialized verbatim), or not even rectangular
+(a ragged per-key archive that numpy loads as ``dtype=object``).
+
+Adopted unchecked, none of those fail where they are introduced.  They fail much
+later and much worse: the matrix builder allocates ``(N, D)`` from the *first*
+media's width and then raises a bare
+
+    ValueError: could not broadcast input array from shape (768,) into shape (1152,)
+
+on some unrelated request, naming neither the media, nor the embedder, nor the
+manifest that supplied it.  A non-finite vector is worse still - it never raises
+at all, it silently poisons every score, threshold compare and sort that touches
+it.
+
+This module is the one place that turns such a vector into either a clean
+``float32`` array or a :class:`MismatchedVectorError` that says exactly what is
+wrong and what to do about it.  Two tiers, because they have very different cost
+profiles:
+
+* :func:`normalize_vector` / :func:`normalize_vector_block` - **full**
+  validation (shape, dtype, finiteness, width).  Run once per vector at
+  *ingestion*, where an O(D) scan is free next to the file I/O that produced it.
+* :func:`require_dim` / :func:`stack_vectors` - **shape-only** checks for the
+  hot scoring path, where a per-request finiteness scan over the whole dataset
+  would be a real cost.  These exist to convert a numpy broadcast failure into a
+  locatable message, not to re-derive what ingestion already guaranteed.
+
+Imports only :mod:`numpy`, so it stays a leaf alongside
+:mod:`vtscore.embedding.normalize` with no risk of an import cycle through the
+embedding package façade.  In particular it does **not** reach into the embedder
+registry: callers that know an embedder's declared width pass it in as
+*expected_dim* (see
+:func:`vtscore.datasets.importers._npz_vectors.expected_dim_for_embedder`).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+
+
+class MismatchedVectorError(ValueError):
+    """An embedding vector cannot be used as-is.
+
+    Subclasses :class:`ValueError` deliberately: every existing ``except
+    ValueError`` around the import and scoring paths (including the route layer's
+    400-mapping) keeps working unchanged, while code that wants to single out a
+    vector-shape problem can catch this specific type.
+    """
+
+
+#: Appended to every dimension-mismatch message.  Split out so the wording of
+#: the fix stays identical whether the mismatch is caught at import (where the
+#: manifest is still nameable) or at score time (where it isn't).
+_DIM_ADVICE = (
+    "Vectors of different widths cannot be compared, so they cannot share a dataset. "
+    "This normally means the pre-computed vectors were produced by a different embedder "
+    "than the one this dataset uses: re-export them from the matching embedder, or build "
+    "the dataset with the embedder that produced them."
+)
+
+
+def _dim_mismatch_message(label: str, actual: int, expected: int, expected_source: str = "") -> str:
+    """Compose the shared "wrong width" message.
+
+    *expected_source* names where *expected* came from (an embedder name, "the
+    dataset", a sibling column) so the reader can tell which of the two numbers
+    is the one they control.
+    """
+    source = f" ({expected_source})" if expected_source else ""
+    return f"{label}: vector is {actual}-dimensional but {expected} was expected{source}. {_DIM_ADVICE}"
+
+
+def _as_numeric_array(vec: Any, label: str) -> np.ndarray:
+    """Return *vec* as a numeric ndarray, or raise :class:`MismatchedVectorError`.
+
+    Catches the two ways a non-rectangular or non-numeric payload reaches us: a
+    ragged nested sequence (numpy 2.x refuses it outright; older shapes land as
+    ``dtype=object``) and a string / structured array from a mis-keyed archive.
+    """
+    if vec is None:
+        raise MismatchedVectorError(f"{label}: no vector supplied (None).")
+    try:
+        arr = np.asarray(vec)
+    except Exception as exc:  # ragged nested sequences raise on numpy >= 1.24
+        raise MismatchedVectorError(
+            f"{label}: not convertible to a numeric array ({exc}). "
+            "Each vector must be a flat, equal-length sequence of numbers."
+        ) from exc
+    if arr.dtype == object:
+        raise MismatchedVectorError(
+            f"{label}: loaded as a ragged / non-numeric array (numpy dtype 'object'). "
+            "Each vector must be a flat, equal-length sequence of numbers."
+        )
+    if not np.issubdtype(arr.dtype, np.number):
+        raise MismatchedVectorError(
+            f"{label}: has non-numeric dtype {arr.dtype!r}; expected a float (or integer) array."
+        )
+    return arr
+
+
+def _reject_non_finite(arr: np.ndarray, label: str, *, row_axis: bool = False) -> None:
+    """Raise unless every entry of the already-``float32`` *arr* is finite.
+
+    Checked *after* the cast to ``float32`` so it also catches a ``float64``
+    value whose magnitude overflows to ``inf`` on narrowing - a real hazard for
+    vectors written by a script that never intended them to be stored at single
+    precision.  With *row_axis* set the message names the first offending row,
+    which is what makes a 100k-row manifest debuggable.
+    """
+    finite = np.isfinite(arr)
+    if bool(finite.all()):
+        return
+    detail = ""
+    if row_axis and arr.ndim == 2:
+        bad_rows = np.flatnonzero(~finite.all(axis=1))
+        detail = f" First offending row: index {int(bad_rows[0])} (of {len(bad_rows)} affected)."
+    raise MismatchedVectorError(
+        f"{label}: holds non-finite values - NaN, infinity, or a magnitude that overflows "
+        f"float32.{detail} Non-finite entries silently poison every score, threshold "
+        "comparison and sort they reach, so they are rejected at the door rather than stored."
+    )
+
+
+def normalize_vector(
+    vec: Any,
+    *,
+    label: str,
+    expected_dim: int | None = None,
+    expected_source: str = "",
+) -> np.ndarray:
+    """Return *vec* as a validated, contiguous 1-D ``float32`` array.
+
+    Rejects (with :class:`MismatchedVectorError`) a vector that is ``None``,
+    ragged, non-numeric, not 1-D, empty, non-finite, or - when *expected_dim* is
+    given - the wrong width.  A ``(1, D)`` or ``(D, 1)`` array is accepted and
+    flattened, since a research script that saved one row per file very commonly
+    keeps the leading axis.
+
+    *label* identifies the vector in the error message; make it something the
+    user can act on ("manifest row 41 ('cat.jpg')"), not an internal id.
+    *expected_source* names the origin of *expected_dim* for the same reason.
+    """
+    arr = _as_numeric_array(vec, label)
+    if arr.ndim == 2 and 1 in arr.shape:
+        arr = arr.reshape(-1)
+    if arr.ndim != 1:
+        raise MismatchedVectorError(
+            f"{label}: expected a 1-D vector, got shape {arr.shape}. "
+            "A pre-computed embedding is a single flat row per media."
+        )
+    if arr.size == 0:
+        raise MismatchedVectorError(f"{label}: vector is empty (zero-length), so it carries no embedding.")
+    out = np.ascontiguousarray(arr, dtype=np.float32)
+    _reject_non_finite(out, label)
+    if expected_dim is not None and int(out.shape[0]) != expected_dim:
+        raise MismatchedVectorError(_dim_mismatch_message(label, int(out.shape[0]), expected_dim, expected_source))
+    return out
+
+
+def normalize_vector_block(
+    block: Any,
+    *,
+    label: str,
+    expected_dim: int | None = None,
+    expected_source: str = "",
+) -> np.ndarray:
+    """Return an ``(N, D)`` block of vectors as a validated ``float32`` array.
+
+    The bulk counterpart of :func:`normalize_vector`, for the ``vectors`` array
+    of an ``.npz`` manifest: one vectorised pass validates the whole archive, so
+    a 100k-row manifest costs a single numpy scan rather than 100k Python calls.
+    Rejects a block that is ragged, non-numeric, not 2-D, zero-width, non-finite,
+    or the wrong width; a ``(D,)`` array is **not** silently promoted to one row,
+    because a manifest that lost its row axis is far more likely to be a bug than
+    a deliberate one-row archive.
+    """
+    arr = _as_numeric_array(block, label)
+    if arr.ndim != 2:
+        raise MismatchedVectorError(
+            f"{label}: expected a 2-D (N, D) array of vectors, got shape {arr.shape}. "
+            "Each row is one media's embedding."
+        )
+    if arr.shape[1] == 0:
+        raise MismatchedVectorError(f"{label}: vectors are zero-width (shape {arr.shape}), so they carry no embedding.")
+    out = np.ascontiguousarray(arr, dtype=np.float32)
+    _reject_non_finite(out, label, row_axis=True)
+    if expected_dim is not None and int(out.shape[1]) != expected_dim:
+        raise MismatchedVectorError(_dim_mismatch_message(label, int(out.shape[1]), expected_dim, expected_source))
+    return out
+
+
+def vector_dim(vec: Any) -> int | None:
+    """Return the trailing dimension of *vec*, or ``None`` if it has no shape.
+
+    Deliberately cheap: reads ``.shape`` off an ndarray without copying or
+    re-validating, so the hot scoring path can compare widths per media without
+    paying for :func:`normalize_vector`.
+    """
+    shape = getattr(vec, "shape", None)
+    if shape is None:
+        try:
+            shape = np.shape(vec)
+        except Exception:
+            return None
+    return int(shape[-1]) if shape else None
+
+
+def require_dim(vec: Any, expected_dim: int, *, label: str, expected_source: str = "") -> None:
+    """Raise :class:`MismatchedVectorError` unless *vec* is a 1-D row of *expected_dim*.
+
+    The scoring-path backstop.  Ingestion is supposed to have made this
+    impossible, but a dataset can also acquire mixed widths by other routes (a
+    pickle written before a validation rule existed, a plugin importer that
+    writes ``media["embeddings"]`` directly), and when it does, the alternative
+    is numpy's shape-only broadcast error from inside the matrix builder.  This
+    costs one attribute read per media and yields a message that names the media
+    and both widths.
+    """
+    shape = getattr(vec, "shape", None)
+    if shape is None:
+        shape = np.shape(vec)
+    if len(shape) == 1 and int(shape[0]) == expected_dim:
+        return
+    if len(shape) != 1:
+        raise MismatchedVectorError(
+            f"{label}: expected a 1-D {expected_dim}-dimensional vector, got shape {tuple(shape)}."
+        )
+    raise MismatchedVectorError(_dim_mismatch_message(label, int(shape[0]), expected_dim, expected_source))
+
+
+def stack_vectors(
+    vecs: Iterable[Any],
+    *,
+    label: str,
+    row_labels: Sequence[str] | None = None,
+    dtype: Any = np.float32,
+) -> np.ndarray:
+    """``np.stack`` over per-item vectors, naming the first row whose width differs.
+
+    ``np.stack`` reports only "all input arrays must have the same shape", which
+    on a training set of hundreds of votes says nothing about *which* vote is the
+    odd one out.  This walks the rows once, compares each width against the
+    first, and raises a message naming the offending row - using *row_labels*
+    (e.g. a filename or content id per row) when the caller can supply them.
+
+    Raises :class:`MismatchedVectorError` for an empty *vecs*: every caller here
+    is building a training or scoring matrix that is meaningless with no rows.
+    """
+    rows = list(vecs)
+    if not rows:
+        raise MismatchedVectorError(f"{label}: no vectors to stack.")
+
+    def _row_label(i: int) -> str:
+        if row_labels is not None and i < len(row_labels):
+            return f"{label} row {i} ({row_labels[i]})"
+        return f"{label} row {i}"
+
+    dim = vector_dim(rows[0])
+    if dim is None:
+        raise MismatchedVectorError(f"{_row_label(0)}: not an array-like vector.")
+    for i, vec in enumerate(rows):
+        require_dim(vec, dim, label=_row_label(i), expected_source=f"matching {_row_label(0)}")
+    return np.stack([np.asarray(v, dtype=dtype) for v in rows])

--- a/vtscore/embedding/precomputed.py
+++ b/vtscore/embedding/precomputed.py
@@ -109,6 +109,18 @@ def _as_numeric_array(vec: Any, label: str) -> np.ndarray:
     return arr
 
 
+def _to_float32(arr: np.ndarray) -> np.ndarray:
+    """Narrow *arr* to contiguous ``float32``, letting overflow become ``inf`` quietly.
+
+    A ``float64`` value too large for single precision casts to ``inf``, which
+    numpy reports as a ``RuntimeWarning``.  That warning is noise here: the very
+    next step is :func:`_reject_non_finite`, which turns the ``inf`` into a
+    message that actually explains what went wrong and what to do about it.
+    """
+    with np.errstate(over="ignore", invalid="ignore"):
+        return np.ascontiguousarray(arr, dtype=np.float32)
+
+
 def _reject_non_finite(arr: np.ndarray, label: str, *, row_axis: bool = False) -> None:
     """Raise unless every entry of the already-``float32`` *arr* is finite.
 
@@ -161,7 +173,7 @@ def normalize_vector(
         )
     if arr.size == 0:
         raise MismatchedVectorError(f"{label}: vector is empty (zero-length), so it carries no embedding.")
-    out = np.ascontiguousarray(arr, dtype=np.float32)
+    out = _to_float32(arr)
     _reject_non_finite(out, label)
     if expected_dim is not None and int(out.shape[0]) != expected_dim:
         raise MismatchedVectorError(_dim_mismatch_message(label, int(out.shape[0]), expected_dim, expected_source))
@@ -193,7 +205,7 @@ def normalize_vector_block(
         )
     if arr.shape[1] == 0:
         raise MismatchedVectorError(f"{label}: vectors are zero-width (shape {arr.shape}), so they carry no embedding.")
-    out = np.ascontiguousarray(arr, dtype=np.float32)
+    out = _to_float32(arr)
     _reject_non_finite(out, label, row_axis=True)
     if expected_dim is not None and int(out.shape[1]) != expected_dim:
         raise MismatchedVectorError(_dim_mismatch_message(label, int(out.shape[1]), expected_dim, expected_source))


### PR DESCRIPTION
Vectors supplied from outside VTSearch — an `.npz` manifest of pre-computed embeddings, an importer's `content_vectors` / `custom_metadata_map` entry, a re-ingest source — were adopted onto media dicts with no validation at all. The only import-time check was `validate_manifest_embedder_name`, which checks the embedder *name* and never the vectors it implies.

Adopted unchecked, a bad vector does not fail where it was introduced:

- A **wrong-width** row surfaced much later as a bare `could not broadcast input array from shape (768,) into shape (1152,)` from inside the matrix builder, on an unrelated request, naming neither the media nor the manifest.
- A **non-finite** row never raised at all. It silently poisoned every score, threshold comparison and sort it reached.
- A **`float64` or half-precision** export left the dataset holding mixed dtypes.

Refs #3143 — this is the derisking half of that issue, not the fix. fp16 embedding is exactly the change that makes a mixed-precision dataset a live possibility, and it should not be able to crash anything. #3143 itself still owes the fp16/autocast change and the calibration experiment gating it.

## What changed

**A single validation chokepoint.** New `vtscore/embedding/precomputed.py` turns an external vector into either a clean `float32` array or a `MismatchedVectorError` that names both widths and what to do about it. It subclasses `ValueError`, so every existing handler is unaffected. Two tiers, matched to cost:

- `normalize_vector` / `normalize_vector_block` — full validation (shape, dtype, finiteness, width), once per vector at ingestion, where an O(D) scan is free next to the file I/O that produced it.
- `require_dim` / `stack_vectors` — shape-only checks for the hot scoring path, where a per-request finiteness scan over the whole dataset would be a real cost. These exist to convert a numpy broadcast failure into a locatable message, not to re-derive what ingestion already guaranteed.

**Ingestion.** Every vector the NPZ readers return is now a finite, contiguous, 1-D `float32` row, width-checked against the `embedding_dim` declared by the embedder the archive names — so an archive saying `siglip2_l` while shipping 768-dim rows is caught at the door. All three layouts are covered, including the ragged per-key archive that previously passed through unexamined. The same validation runs where `content_vectors` / `custom_metadata_map` become a media's stored vector, on the ReCaller and PullWrest source paths, and in `_stamp_requested_embedder` — which asserts a nameless vector belongs to a named embedder's space, and now checks that claim instead of assuming it.

**Scoring.** `_stack_embeddings`, `_build_region_arrays`, `media_score_rows` and the three training `np.stack` sites now report which media is the odd one out and in which embedding space.

**Precision is not width.** A half-precision manifest is widened, not refused, and a `float16` stored vector still builds a `float32` matrix. Both are pinned by tests.

## Two things this surfaced

- `expected_dim_for_embedder` returned whatever `embedding_dim` gave it. That property is part of the plugin surface, and a test double standing in for the registry returns a mock — which then read as a width nothing could ever match. Anything that is not a positive `int` now reads as "unknown" and skips the check.
- The manifest fixtures paired a real embedder name with a toy width (a manifest declaring `xclip` while shipping 512-dim rows) — precisely the mislabelled archive the guard exists to reject, so they were no longer valid manifests. Each now derives its width from the embedder it names, so those tests exercise the behaviour they are about rather than the guard.

## Notes

- **Behaviour change:** a manifest that was previously imported and silently produced a broken dataset now fails at import with an explicit message. That is the intent, but it is a break for anyone who had such a manifest.
- The eval/app sync digest was re-pinned. `train_and_threshold`'s `np.stack` → `stack_vectors` swap is byte-identical for every input dtype (verified `float16`/`32`/`64`), so the harness mirror tracks it unchanged.

## Testing

Full `./run-tests.sh`: **8604 passed, 6 skipped**, all gates green (pyright, pip-audit, npm audit, Vitest, and every stage-1 gate).

New coverage in `tests_lib/io/test_precomputed_vector_validation.py` (48 tests) and `tests_lib/core/test_embedding_matrix.py`: every manifest layout, the `content_vectors` adoption point, the `_stamp_requested_embedder` claim check, the matrix and patch-grid backstops, and the fp16/`float64` widening cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016T5CCYMY4jCnb4vq7jtQBD

---
_Generated by [Claude Code](https://claude.ai/code/session_016T5CCYMY4jCnb4vq7jtQBD)_