### PR TITLE
Replace the `dev` label with `solved`: development done, applied at fix-PR time

### DIFF
--- a/.claude/hooks/require-issue-labels.py
+++ b/.claude/hooks/require-issue-labels.py
@@ -18,8 +18,9 @@ A hook is immune to both: it runs at tool-call time, from the checkout as of
 session start, and it does not need to be remembered.
 
 The hook has a second job at the other end of an issue's life: the `dev` label
-(docs/RELEASE.md step 6) means "fixed on `dev`, NOT yet on `main`", so it must
-come off in the write that closes the issue. See `_close_problems`.
+(docs/RELEASE.md step 6) means "the development is done; only merges remain",
+so it must come off in the write that closes the issue -- that close *is* the
+last merge landing. See `_close_problems`.
 
 Contract: read the PreToolUse payload on stdin, exit 2 to block (stderr is fed
 back to Claude as the reason), exit 0 to allow. Anything unexpected -- a
@@ -121,9 +122,10 @@ def _looks_like_an_experiment(text: str) -> bool:
 def _close_problems(args: dict) -> list[str]:
     """Guard the `dev` label on a completing close (the docs/RELEASE.md step-6 sweep).
 
-    `dev` means "fixed on `dev`, NOT yet on `main`", so it must not survive the
-    close that ships the fix -- a closed issue still carrying it asserts
-    something false, and the awaiting-release view (`is:open label:dev`) is only
+    `dev` means "the development is done; only merges remain", so it must not
+    survive the close that lands the last of those merges -- a closed issue
+    still carrying it asserts something false, and the views it powers
+    (`is:open -label:dev`, what a human should work on next) are only
     trustworthy if the strip is reliable.
 
     The hook sees the call's arguments, never the issue's current state, so it
@@ -139,15 +141,15 @@ def _close_problems(args: dict) -> list[str]:
 
     if DEV_LABEL in labels:
         return [
-            f'KEEPS `{DEV_LABEL}` ON A CLOSED ISSUE: `{DEV_LABEL}` means "on `dev`, NOT on `main`". '
-            "Closing this issue is the act of shipping it to `main`, so the label is now false. "
+            f'KEEPS `{DEV_LABEL}` ON A CLOSED ISSUE: `{DEV_LABEL}` means "solved, waiting only on merges". '
+            "Closing this issue is the act of landing the last merge, so the label is now false. "
             "Drop it from the `labels` array."
         ]
 
     if raw is None and str(args.get("state_reason") or "").strip().lower() == "completed":
         return [
             f"CLOSE DOES NOT STRIP `{DEV_LABEL}`: a `completed` close ships the fix to `main`, so "
-            f'`{DEV_LABEL}` ("on `dev`, NOT on `main`") must come off in the same write.\n'
+            f'`{DEV_LABEL}` ("solved, waiting only on merges") must come off in the same write.\n'
             "  Pass `labels` explicitly. NOTE: `labels` REPLACES the whole set, so list every label "
             f"the issue should keep (`claude`, `experiment`, ...) and simply omit `{DEV_LABEL}`. "
             "Read the issue first if you do not already know its labels -- passing `[]` would wipe them.\n"
@@ -191,7 +193,7 @@ CREATE_FOOTER = (
 
 CLOSE_FOOTER = (
     "\nSee docs/RELEASE.md step 6. `dev` is a transient status, not a historical fact:\n"
-    "  it goes ON when the fix merges to `dev`, and comes OFF in the write that closes the issue."
+    "  it goes ON when the fix PR is opened, and comes OFF in the write that closes the issue."
 )
 
 

--- a/.claude/hooks/require-issue-labels.py
+++ b/.claude/hooks/require-issue-labels.py
@@ -17,7 +17,7 @@ ways -- and issue #3127 was filed unlabeled by hitting the first one:
 A hook is immune to both: it runs at tool-call time, from the checkout as of
 session start, and it does not need to be remembered.
 
-The hook has a second job at the other end of an issue's life: the `dev` label
+The hook has a second job at the other end of an issue's life: the `solved` label
 (docs/RELEASE.md step 6) means "the development is done; only merges remain",
 so it must come off in the write that closes the issue -- that close *is* the
 last merge landing. See `_close_problems`.
@@ -42,7 +42,7 @@ import sys
 
 TOOL_SUFFIX = "issue_write"
 
-DEV_LABEL = "dev"
+SOLVED_LABEL = "solved"
 
 OPT_OUT = re.compile(r"<!--\s*not-an-experiment\s*:", re.IGNORECASE)
 
@@ -120,12 +120,12 @@ def _looks_like_an_experiment(text: str) -> bool:
 
 
 def _close_problems(args: dict) -> list[str]:
-    """Guard the `dev` label on a completing close (the docs/RELEASE.md step-6 sweep).
+    """Guard the `solved` label on a completing close (the docs/RELEASE.md step-6 sweep).
 
-    `dev` means "the development is done; only merges remain", so it must not
+    `solved` means "the development is done; only merges remain", so it must not
     survive the close that lands the last of those merges -- a closed issue
     still carrying it asserts something false, and the views it powers
-    (`is:open -label:dev`, what a human should work on next) are only
+    (`is:open -label:solved`, what a human should work on next) are only
     trustworthy if the strip is reliable.
 
     The hook sees the call's arguments, never the issue's current state, so it
@@ -139,21 +139,21 @@ def _close_problems(args: dict) -> list[str]:
     raw = args.get("labels")
     labels = {str(item).strip().lower() for item in (raw or [])}
 
-    if DEV_LABEL in labels:
+    if SOLVED_LABEL in labels:
         return [
-            f'KEEPS `{DEV_LABEL}` ON A CLOSED ISSUE: `{DEV_LABEL}` means "solved, waiting only on merges". '
+            f'KEEPS `{SOLVED_LABEL}` ON A CLOSED ISSUE: `{SOLVED_LABEL}` means "solved, waiting only on merges". '
             "Closing this issue is the act of landing the last merge, so the label is now false. "
             "Drop it from the `labels` array."
         ]
 
     if raw is None and str(args.get("state_reason") or "").strip().lower() == "completed":
         return [
-            f"CLOSE DOES NOT STRIP `{DEV_LABEL}`: a `completed` close ships the fix to `main`, so "
-            f'`{DEV_LABEL}` ("solved, waiting only on merges") must come off in the same write.\n'
+            f"CLOSE DOES NOT STRIP `{SOLVED_LABEL}`: a `completed` close ships the fix to `main`, so "
+            f'`{SOLVED_LABEL}` ("solved, waiting only on merges") must come off in the same write.\n'
             "  Pass `labels` explicitly. NOTE: `labels` REPLACES the whole set, so list every label "
-            f"the issue should keep (`claude`, `experiment`, ...) and simply omit `{DEV_LABEL}`. "
+            f"the issue should keep (`claude`, `experiment`, ...) and simply omit `{SOLVED_LABEL}`. "
             "Read the issue first if you do not already know its labels -- passing `[]` would wipe them.\n"
-            f"  If the issue never had `{DEV_LABEL}`, passing its existing labels unchanged satisfies this."
+            f"  If the issue never had `{SOLVED_LABEL}`, passing its existing labels unchanged satisfies this."
         ]
 
     return []
@@ -192,7 +192,7 @@ CREATE_FOOTER = (
 )
 
 CLOSE_FOOTER = (
-    "\nSee docs/RELEASE.md step 6. `dev` is a transient status, not a historical fact:\n"
+    "\nSee docs/RELEASE.md step 6. `solved` is a transient status, not a historical fact:\n"
     "  it goes ON when the fix PR is opened, and comes OFF in the write that closes the issue."
 )
 
@@ -208,7 +208,7 @@ def main() -> int:
         headline = "BLOCKED: this issue is missing a required label (CLAUDE.md, 'Label every issue you file')."
     elif method == "update":
         found, footer = _close_problems(args), CLOSE_FOOTER
-        headline = f"BLOCKED: this close mishandles the `{DEV_LABEL}` label."
+        headline = f"BLOCKED: this close mishandles the `{SOLVED_LABEL}` label."
     else:
         return 0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,22 +57,23 @@ When your change resolves a GitHub issue, **link the PR back to that issue** so 
 
 - Put a closing keyword in the **PR body**: `Closes #N` (or `Fixes #N` / `Resolves #N`). This populates GitHub's "Linked issues" sidebar and the issue timeline. Reference every issue the PR resolves; use one keyword per issue (`Closes #12, closes #15`), not a comma-list after a single `Closes`.
 - If the PR only *partly* addresses an issue, use a non-closing reference instead — `Refs #N` / `Part of #N` — so it links without implying the issue is done.
-- Also drop a one-line comment on the issue pointing at the PR (e.g. "Addressed in #M"), so someone reading the issue sees the fix even before it merges. **Name the PR number, never a bare commit SHA.** "Fixed on `dev` by `de9ae81ac`" reads fine to a human and is invisible to the machinery: `scripts/reconcile-dev-labels.py` matches `#M`, so a SHA-only pointer used to report as "not resolved on dev" — indistinguishable from an issue nobody had started. The script now surfaces SHA pointers as `NEEDS REVIEW` rather than swallowing them, but that is a backstop that costs a human a lookup; write `#M` and it costs nothing. A SHA is a fine *addition* ("Addressed in #3051 (`de9ae81ac`)"), never the only pointer.
+- Also drop a one-line comment on the issue pointing at the PR (e.g. "Addressed in #M"), so someone reading the issue sees the fix even before it merges. **Name the PR number, never a bare commit SHA.** "Fixed on `dev` by `de9ae81ac`" reads fine to a human and is invisible to the machinery: `scripts/reconcile-dev-labels.py` matches `#M`, so a SHA-only pointer used to report as unresolved — indistinguishable from an issue nobody had started. The script now surfaces SHA pointers as `NEEDS REVIEW` rather than swallowing them, but that is a backstop that costs a human a lookup; write `#M` and it costs nothing. A SHA is a fine *addition* ("Addressed in #3051 (`de9ae81ac`)"), never the only pointer.
+- **Add the `dev` label** to every issue the PR fully resolves, in the same motion. It means "no problem-solving left here" and is what keeps the issue out of the human work queue from the moment the fix exists — see the `dev` section below.
 
 **The PR keyword is the load-bearing signal, and the issue comment must agree with it.** The `dev`→`main` sweep (step 6 of `docs/RELEASE.md`) decides what to close by reading **PR bodies**, not issue comments — so the keyword you pick is what determines whether the issue ever gets closed. `Refs #N` on a PR that actually finishes the issue is not a harmless understatement: the sweep reads it as "still partial", skips the issue, and *nothing revisits it in a later release*. The issue stays open forever while its fix is live in `main`.
 
 So make the two statements match, and default to `Closes` whenever the PR finishes the issue:
 
-| The PR… | PR body | Issue comment |
-|---|---|---|
-| fully resolves the issue | `Closes #N` | `Addressed in #M` |
-| does part of it, more is still owed | `Refs #N` / `Part of #N` | `Partially addressed in #M — still open: <what's left>` |
+| The PR… | PR body | Issue comment | `dev` label |
+|---|---|---|---|
+| fully resolves the issue | `Closes #N` | `Addressed in #M` | **add it** |
+| does part of it, more is still owed | `Refs #N` / `Part of #N` | `Partially addressed in #M — still open: <what's left>` | leave it off |
 
 Use `Refs` only when you can name the work that remains on **that issue**. Rescoping counts as finishing: if you narrowed the issue's body and the PR does all of what's left, that's `Closes`. Deferred scope that has been moved into a plan file or a separate issue is no longer owed by this issue, so it doesn't make the PR partial either.
 
 If you catch yourself writing "Addressed in #M" on the issue while the PR body says `Refs`, one of the two is wrong — fix it before merging.
 
-**Do not close the issue yourself.** The closing keyword will **not** auto-close the issue on merge, because GitHub only auto-closes keyword-linked issues when the PR merges into the **default branch** (`main`), and our PRs target **`dev`**. That is intentional: an issue stays open while its fix lives only on `dev`, and is closed only once the fix reaches `main` (i.e. is actually shipped to users). The `dev`→`main` merge Routine is what sweeps the now-shipped issues closed (with `state_reason: completed`); a per-fix Claude session must not close the issue early. So: link and comment, but leave the issue open.
+**Do not close the issue yourself.** The closing keyword will **not** auto-close the issue on merge, because GitHub only auto-closes keyword-linked issues when the PR merges into the **default branch** (`main`), and our PRs target **`dev`**. That is intentional: an issue stays open while its fix lives only on `dev`, and is closed only once the fix reaches `main` (i.e. is actually shipped to users). The `dev`→`main` merge Routine is what sweeps the now-shipped issues closed (with `state_reason: completed`); a per-fix Claude session must not close the issue early. So: link, comment, and label — but leave the issue open. The `dev` label is what stops that still-open issue from being offered to the next person looking for work.
 
 ## Duplicate issues: search before filing, link the moment you find one
 
@@ -138,26 +139,30 @@ That asymmetry is the whole design. It only works if Claude is exhaustive: a Cla
 
 The point is scheduling: `label:experiment` is the queue of work that needs machine time booked, and `-label:experiment` is what can be picked up right now. See the `grid-experiments` skill for how those runs are actually launched.
 
-### `dev` — fixed on `dev`, not yet on `main`
+### `dev` — the development is done; only merges remain
 
-`dev` means **the fix has merged to `dev` but has not shipped to `main`.** Unlike `claude` and `experiment`, it is **not applied at creation time** and is never something you decide when filing — it is a *status* the release machinery maintains.
+`dev` means **there is no problem-solving left on this issue.** It has been figured out, a fix PR carries it, and everything still owed is a git merge — into `dev`, and then into `main` at the next release. Unlike `claude` and `experiment`, it is **not applied at creation time** and is never something you decide when filing — it is a *status*.
 
-It exists to make an otherwise invisible state visible. A fix PR targets `dev`, and GitHub only auto-closes a keyword-linked issue when the PR merges into the **default** branch (`main`), so a fixed issue stays open until the release sweep closes it. Without this label there is no way to tell "waiting for the next release" apart from "nobody has started it". The awaiting-release view is:
+Its job is to keep solved work out of the queue a human picks from. That queue is the primary view:
 
 ```
-is:issue is:open label:dev
+is:issue is:open -label:dev    # what a human should work on next
+is:issue is:open label:dev     # solved; waiting only on merges
 ```
 
-**The label is transient, not a historical fact.** It goes on when the fix merges to `dev`, and comes off in the same write that closes the issue (`docs/RELEASE.md` step 6). A closed issue must never carry it: by then the fix is on `main` too, so the label would assert something false, and a reopened issue would wrongly appear in the awaiting-release view. `is:open` already filters the closed pile for free, so letting it linger would buy nothing.
+**Solved-in-an-open-PR counts as done.** The label deliberately does *not* wait for the merge. "Fixed in a branch, PR open" and "merged into `dev`" are different facts about git but the same fact about people: neither has any thinking left in it, so neither should be offered to someone asking what to work on. Waiting for the merge would also make the label untriggerable in practice — no session is around to observe a merge happening, which is exactly why the label used to go unapplied for weeks at a time.
 
-Two rules bind you directly:
+**The label is transient, not a historical fact.** It goes on when the fix PR is opened and comes off whenever that stops being true — in the write that closes the issue (`docs/RELEASE.md` step 6), or if the fix falls through. A closed issue must never carry it: the label would assert something false, and a reopened issue would wrongly read as solved.
 
-- **Closing an issue strips `dev`.** Pass `labels` explicitly on a `completed` close. Note that `labels` *replaces* the whole set, so list every label the issue keeps (`claude`, `experiment`, …) and omit `dev` — passing `[]` would wipe the rest. A `PreToolUse` hook blocks a close that keeps the label or omits the array.
-- **Do not apply it by hand from a fix session.** When you open a fix PR the merge hasn't happened yet, so the issue is not on `dev` and labeling it would be a lie for as long as the PR sits unmerged. Applying it is `scripts/reconcile-dev-labels.py`'s job.
+Three rules bind you directly:
 
-That script encodes `docs/RELEASE.md` step 6's resolution logic — closing keywords vs. `Refs`, `Partially addressed in #M` vs. `Addressed in #M`, and the ambiguity of a comment posted *after* a fix pointer — and reconciles the label in both directions. It is a pure function from data to plan: the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but 403s, since GitHub access is intermediated by the MCP server), so gather the PR and issue data with the `github` MCP tools and pipe it in. See `docs/RELEASE.md` for the recipe.
+- **Apply it when you open the fix PR**, in the same motion as the `Addressed in #M` comment (see "Linking a fix PR to its GitHub issue" above). Pass `labels` explicitly with the issue's existing labels plus `dev` — `labels` *replaces* the whole set, so read the issue first if you don't already know them.
+- **Take it back off if the fix falls through.** If your PR is closed without merging, or review concludes the fix is wrong and the issue needs solving again, strip `dev` — the issue belongs back in the human queue. This is the one removal a fix session does itself.
+- **Closing an issue strips `dev`.** Pass `labels` explicitly on a `completed` close, listing every label the issue keeps (`claude`, `experiment`, …) and omitting `dev`; passing `[]` would wipe the rest. A `PreToolUse` hook blocks a close that keeps the label or omits the array.
 
-**A comment after the fix pointer is never guessed at.** If someone comments below an `Addressed in #M` pointer, the script reports the issue as needing review rather than tagging or skipping it. The later comment might be a maintainer saying "thanks" or the reporter saying the fix doesn't work; tagging would bury a dispute, and skipping would silently drop the issue out of the awaiting-release view. Ambiguity gets surfaced, not resolved by a coin flip.
+`scripts/reconcile-dev-labels.py` is the backstop for all three — it catches issues a session forgot to label, issues whose fix PR was abandoned, and stale labels left behind by a close. It encodes `docs/RELEASE.md` step 6's resolution logic — closing keywords vs. `Refs`, `Partially addressed in #M` vs. `Addressed in #M`, and the ambiguity of a comment posted *after* a fix pointer. It is a pure function from data to plan: the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but 403s, since GitHub access is intermediated by the MCP server), so gather the PR and issue data with the `github` MCP tools and pipe it in. See `docs/RELEASE.md` for the recipe.
+
+**A comment after the fix pointer is never guessed at.** If someone comments below an `Addressed in #M` pointer, the script reports the issue as needing review rather than tagging or skipping it. The later comment might be a maintainer saying "thanks" or the reporter saying the fix doesn't work; tagging would bury a dispute (hiding an issue that still needs solving), and skipping would leave solved work in the human queue. Ambiguity gets surfaced, not resolved by a coin flip.
 
 ## Recommend a Claude model in every issue you file
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,14 +57,14 @@ When your change resolves a GitHub issue, **link the PR back to that issue** so 
 
 - Put a closing keyword in the **PR body**: `Closes #N` (or `Fixes #N` / `Resolves #N`). This populates GitHub's "Linked issues" sidebar and the issue timeline. Reference every issue the PR resolves; use one keyword per issue (`Closes #12, closes #15`), not a comma-list after a single `Closes`.
 - If the PR only *partly* addresses an issue, use a non-closing reference instead — `Refs #N` / `Part of #N` — so it links without implying the issue is done.
-- Also drop a one-line comment on the issue pointing at the PR (e.g. "Addressed in #M"), so someone reading the issue sees the fix even before it merges. **Name the PR number, never a bare commit SHA.** "Fixed on `dev` by `de9ae81ac`" reads fine to a human and is invisible to the machinery: `scripts/reconcile-dev-labels.py` matches `#M`, so a SHA-only pointer used to report as unresolved — indistinguishable from an issue nobody had started. The script now surfaces SHA pointers as `NEEDS REVIEW` rather than swallowing them, but that is a backstop that costs a human a lookup; write `#M` and it costs nothing. A SHA is a fine *addition* ("Addressed in #3051 (`de9ae81ac`)"), never the only pointer.
-- **Add the `dev` label** to every issue the PR fully resolves, in the same motion. It means "no problem-solving left here" and is what keeps the issue out of the human work queue from the moment the fix exists — see the `dev` section below.
+- Also drop a one-line comment on the issue pointing at the PR (e.g. "Addressed in #M"), so someone reading the issue sees the fix even before it merges. **Name the PR number, never a bare commit SHA.** "Fixed on `dev` by `de9ae81ac`" reads fine to a human and is invisible to the machinery: `scripts/reconcile-solved-labels.py` matches `#M`, so a SHA-only pointer used to report as unresolved — indistinguishable from an issue nobody had started. The script now surfaces SHA pointers as `NEEDS REVIEW` rather than swallowing them, but that is a backstop that costs a human a lookup; write `#M` and it costs nothing. A SHA is a fine *addition* ("Addressed in #3051 (`de9ae81ac`)"), never the only pointer.
+- **Add the `solved` label** to every issue the PR fully resolves, in the same motion. It means "no problem-solving left here" and is what keeps the issue out of the human work queue from the moment the fix exists — see the `solved` section below.
 
 **The PR keyword is the load-bearing signal, and the issue comment must agree with it.** The `dev`→`main` sweep (step 6 of `docs/RELEASE.md`) decides what to close by reading **PR bodies**, not issue comments — so the keyword you pick is what determines whether the issue ever gets closed. `Refs #N` on a PR that actually finishes the issue is not a harmless understatement: the sweep reads it as "still partial", skips the issue, and *nothing revisits it in a later release*. The issue stays open forever while its fix is live in `main`.
 
 So make the two statements match, and default to `Closes` whenever the PR finishes the issue:
 
-| The PR… | PR body | Issue comment | `dev` label |
+| The PR… | PR body | Issue comment | `solved` label |
 |---|---|---|---|
 | fully resolves the issue | `Closes #N` | `Addressed in #M` | **add it** |
 | does part of it, more is still owed | `Refs #N` / `Part of #N` | `Partially addressed in #M — still open: <what's left>` | leave it off |
@@ -73,7 +73,7 @@ Use `Refs` only when you can name the work that remains on **that issue**. Resco
 
 If you catch yourself writing "Addressed in #M" on the issue while the PR body says `Refs`, one of the two is wrong — fix it before merging.
 
-**Do not close the issue yourself.** The closing keyword will **not** auto-close the issue on merge, because GitHub only auto-closes keyword-linked issues when the PR merges into the **default branch** (`main`), and our PRs target **`dev`**. That is intentional: an issue stays open while its fix lives only on `dev`, and is closed only once the fix reaches `main` (i.e. is actually shipped to users). The `dev`→`main` merge Routine is what sweeps the now-shipped issues closed (with `state_reason: completed`); a per-fix Claude session must not close the issue early. So: link, comment, and label — but leave the issue open. The `dev` label is what stops that still-open issue from being offered to the next person looking for work.
+**Do not close the issue yourself.** The closing keyword will **not** auto-close the issue on merge, because GitHub only auto-closes keyword-linked issues when the PR merges into the **default branch** (`main`), and our PRs target **`dev`**. That is intentional: an issue stays open while its fix lives only on `dev`, and is closed only once the fix reaches `main` (i.e. is actually shipped to users). The `dev`→`main` merge Routine is what sweeps the now-shipped issues closed (with `state_reason: completed`); a per-fix Claude session must not close the issue early. So: link, comment, and label — but leave the issue open. The `solved` label is what stops that still-open issue from being offered to the next person looking for work.
 
 ## Duplicate issues: search before filing, link the moment you find one
 
@@ -116,7 +116,7 @@ This is why closing an issue by hand didn't previously "trickle back": the item 
 
 **Every GitHub issue you create must carry the `claude` label**, and the `experiment` label when it applies. Apply them at creation time (`labels: ["claude", …]`), not as a follow-up edit. If a label is missing from the repo, applying it via the issues API creates it automatically — do not skip a label because it doesn't exist yet.
 
-A third label, **`dev`**, is a release *status* rather than something you choose when filing — it is applied and removed by the release machinery. Read its section below before closing any issue.
+A third label, **`solved`**, is a *status* rather than something you choose when filing — it goes on when a fix PR exists. Read its section below before closing any issue.
 
 ### `claude` — who filed it
 
@@ -139,15 +139,15 @@ That asymmetry is the whole design. It only works if Claude is exhaustive: a Cla
 
 The point is scheduling: `label:experiment` is the queue of work that needs machine time booked, and `-label:experiment` is what can be picked up right now. See the `grid-experiments` skill for how those runs are actually launched.
 
-### `dev` — the development is done; only merges remain
+### `solved` — the development is done; only merges remain
 
-`dev` means **there is no problem-solving left on this issue.** It has been figured out, a fix PR carries it, and everything still owed is a git merge — into `dev`, and then into `main` at the next release. Unlike `claude` and `experiment`, it is **not applied at creation time** and is never something you decide when filing — it is a *status*.
+`solved` means **there is no problem-solving left on this issue.** It has been figured out, a fix PR carries it, and everything still owed is a git merge — into `dev`, and then into `main` at the next release. Unlike `claude` and `experiment`, it is **not applied at creation time** and is never something you decide when filing — it is a *status*.
 
 Its job is to keep solved work out of the queue a human picks from. That queue is the primary view:
 
 ```
-is:issue is:open -label:dev    # what a human should work on next
-is:issue is:open label:dev     # solved; waiting only on merges
+is:issue is:open -label:solved    # what a human should work on next
+is:issue is:open label:solved     # solved; waiting only on merges
 ```
 
 **Solved-in-an-open-PR counts as done.** The label deliberately does *not* wait for the merge. "Fixed in a branch, PR open" and "merged into `dev`" are different facts about git but the same fact about people: neither has any thinking left in it, so neither should be offered to someone asking what to work on. Waiting for the merge would also make the label untriggerable in practice — no session is around to observe a merge happening, which is exactly why the label used to go unapplied for weeks at a time.
@@ -156,11 +156,11 @@ is:issue is:open label:dev     # solved; waiting only on merges
 
 Three rules bind you directly:
 
-- **Apply it when you open the fix PR**, in the same motion as the `Addressed in #M` comment (see "Linking a fix PR to its GitHub issue" above). Pass `labels` explicitly with the issue's existing labels plus `dev` — `labels` *replaces* the whole set, so read the issue first if you don't already know them.
-- **Take it back off if the fix falls through.** If your PR is closed without merging, or review concludes the fix is wrong and the issue needs solving again, strip `dev` — the issue belongs back in the human queue. This is the one removal a fix session does itself.
-- **Closing an issue strips `dev`.** Pass `labels` explicitly on a `completed` close, listing every label the issue keeps (`claude`, `experiment`, …) and omitting `dev`; passing `[]` would wipe the rest. A `PreToolUse` hook blocks a close that keeps the label or omits the array.
+- **Apply it when you open the fix PR**, in the same motion as the `Addressed in #M` comment (see "Linking a fix PR to its GitHub issue" above). Pass `labels` explicitly with the issue's existing labels plus `solved` — `labels` *replaces* the whole set, so read the issue first if you don't already know them.
+- **Take it back off if the fix falls through.** If your PR is closed without merging, or review concludes the fix is wrong and the issue needs solving again, strip `solved` — the issue belongs back in the human queue. This is the one removal a fix session does itself.
+- **Closing an issue strips `solved`.** Pass `labels` explicitly on a `completed` close, listing every label the issue keeps (`claude`, `experiment`, …) and omitting `solved`; passing `[]` would wipe the rest. A `PreToolUse` hook blocks a close that keeps the label or omits the array.
 
-`scripts/reconcile-dev-labels.py` is the backstop for all three — it catches issues a session forgot to label, issues whose fix PR was abandoned, and stale labels left behind by a close. It encodes `docs/RELEASE.md` step 6's resolution logic — closing keywords vs. `Refs`, `Partially addressed in #M` vs. `Addressed in #M`, and the ambiguity of a comment posted *after* a fix pointer. It is a pure function from data to plan: the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but 403s, since GitHub access is intermediated by the MCP server), so gather the PR and issue data with the `github` MCP tools and pipe it in. See `docs/RELEASE.md` for the recipe.
+`scripts/reconcile-solved-labels.py` is the backstop for all three — it catches issues a session forgot to label, issues whose fix PR was abandoned, and stale labels left behind by a close. It encodes `docs/RELEASE.md` step 6's resolution logic — closing keywords vs. `Refs`, `Partially addressed in #M` vs. `Addressed in #M`, and the ambiguity of a comment posted *after* a fix pointer. It is a pure function from data to plan: the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but 403s, since GitHub access is intermediated by the MCP server), so gather the PR and issue data with the `github` MCP tools and pipe it in. See `docs/RELEASE.md` for the recipe.
 
 **A comment after the fix pointer is never guessed at.** If someone comments below an `Addressed in #M` pointer, the script reports the issue as needing review rather than tagging or skipping it. The later comment might be a maintainer saying "thanks" or the reporter saying the fix doesn't work; tagging would bury a dispute (hiding an issue that still needs solving), and skipping would leave solved work in the human queue. Ambiguity gets surfaced, not resolved by a coin flip.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -86,17 +86,17 @@ Anything else stays open — a genuinely partial `Refs` is doing its job.
 
 - Skip it if it is already closed. Never reopen or re-close.
 - Close it with `state_reason: completed`.
-- **Strip the `dev` label in the same write.** `dev` means "the development is done; only merges remain" (see CLAUDE.md), and this close is the moment the last merge lands — so the label has nothing left to say. Pass `labels` explicitly with every label the issue keeps (`claude`, `experiment`, …) minus `dev`; `labels` *replaces* the whole set, so passing `[]` would wipe the rest. A `PreToolUse` hook blocks a `completed` close that keeps `dev` or omits the array.
+- **Strip the `solved` label in the same write.** `solved` means "the development is done; only merges remain" (see CLAUDE.md), and this close is the moment the last merge lands — so the label has nothing left to say. Pass `labels` explicitly with every label the issue keeps (`claude`, `experiment`, …) minus `solved`; `labels` *replaces* the whole set, so passing `[]` would wipe the rest. A `PreToolUse` hook blocks a `completed` close that keeps `solved` or omits the array.
 - Add a one-line comment noting it shipped to `main` in today's release and linking the fix PR (e.g. `Shipped to main in the 2026-07-14 release — fixed
   in #M.`). When the PR used a non-closing keyword, say so in that comment, so the mislabel is visible on the issue rather than silently corrected.
 
 **Report the reconciliation in chat**, briefly: which issues came from the closing bucket, which were closed after reconciliation (and under which PR keyword), and which non-closing references were deliberately left open. This is the only place a crossed wire between a PR keyword and an issue comment becomes visible, so do not collapse it to a bare count. If no qualifying issues are found, state that and do nothing.
 
-## 6b. Audit the `dev` label
+## 6b. Audit the `solved` label
 
-`dev` means "the development is done; only merges remain", and the fix session applies it when it opens the PR (CLAUDE.md). So by the time you get here the label should already be right, and this step is an **audit**: `scripts/reconcile-dev-labels.py` catches issues a session forgot to label, issues whose fix PR was later abandoned, and stale labels left behind by step 6's closes.
+`solved` means "the development is done; only merges remain", and the fix session applies it when it opens the PR (CLAUDE.md). So by the time you get here the label should already be right, and this step is an **audit**: `scripts/reconcile-solved-labels.py` catches issues a session forgot to label, issues whose fix PR was later abandoned, and stale labels left behind by step 6's closes.
 
-Run it right after step 6 to confirm nothing was left behind. It is also worth running **between** releases — the views it keeps honest (`is:issue is:open -label:dev`, what a human should pick up next) matter most while the release is still weeks away.
+Run it right after step 6 to confirm nothing was left behind. It is also worth running **between** releases — the views it keeps honest (`is:issue is:open -label:solved`, what a human should pick up next) matter most while the release is still weeks away.
 
 The script is a pure function from data to plan — it does no network I/O, because the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but returns 403; GitHub access is intermediated by the MCP server). So gather the data first, then pipe it in:
 
@@ -118,14 +118,14 @@ The script is a pure function from data to plan — it does no network I/O, beca
 ```
 
 ```
-python scripts/reconcile-dev-labels.py --input plan-input.json
+python scripts/reconcile-solved-labels.py --input plan-input.json
 ```
 
 It prints four buckets. **Apply `ADD` and `REMOVE` directly** — they are unambiguous. **Do not apply `NEEDS REVIEW`**; read those issues yourself. An issue lands there for one of three reasons, all genuinely undecidable from the outside:
 
 - **A fix pointer is not the newest comment.** The later comment may be a maintainer saying "thanks" or the reporter saying the fix does not work. Tagging would bury a dispute — hiding an issue that still needs solving — while skipping would leave solved work in the human queue.
 - **A comment claims a fix by commit SHA** instead of `Addressed in #M`. The script has only the JSON you piped in, so it cannot map a commit to its PR — but the claim is real, so it is surfaced. Resolve it with `git log --ancestry-path <sha>..origin/dev --merges --oneline | tail -1` to find the merge that carried it, then re-run with a corrected pointer.
-- **The issue carries `dev` but nothing resolves it** — stale, or fixed in an earlier release.
+- **The issue carries `solved` but nothing resolves it** — stale, or fixed in an earlier release.
 
 That is the same "not silently skipped" principle step 6 applies to non-closing references.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -86,25 +86,30 @@ Anything else stays open — a genuinely partial `Refs` is doing its job.
 
 - Skip it if it is already closed. Never reopen or re-close.
 - Close it with `state_reason: completed`.
-- **Strip the `dev` label in the same write.** `dev` means "fixed on `dev`, NOT yet on `main`" (see CLAUDE.md), and this close is the moment that stops being true. Pass `labels` explicitly with every label the issue keeps (`claude`, `experiment`, …) minus `dev`; `labels` *replaces* the whole set, so passing `[]` would wipe the rest. A `PreToolUse` hook blocks a `completed` close that keeps `dev` or omits the array.
+- **Strip the `dev` label in the same write.** `dev` means "the development is done; only merges remain" (see CLAUDE.md), and this close is the moment the last merge lands — so the label has nothing left to say. Pass `labels` explicitly with every label the issue keeps (`claude`, `experiment`, …) minus `dev`; `labels` *replaces* the whole set, so passing `[]` would wipe the rest. A `PreToolUse` hook blocks a `completed` close that keeps `dev` or omits the array.
 - Add a one-line comment noting it shipped to `main` in today's release and linking the fix PR (e.g. `Shipped to main in the 2026-07-14 release — fixed
   in #M.`). When the PR used a non-closing keyword, say so in that comment, so the mislabel is visible on the issue rather than silently corrected.
 
 **Report the reconciliation in chat**, briefly: which issues came from the closing bucket, which were closed after reconciliation (and under which PR keyword), and which non-closing references were deliberately left open. This is the only place a crossed wire between a PR keyword and an issue comment becomes visible, so do not collapse it to a bare count. If no qualifying issues are found, state that and do nothing.
 
-## 6b. Refresh the `dev` label between releases
+## 6b. Audit the `dev` label
 
-Step 6 is what *removes* `dev`. What puts it on is `scripts/reconcile-dev-labels.py`, and that runs **between** releases, not only at one: the label's whole job is to make the awaiting-release view (`is:issue is:open label:dev`) correct while the release is still weeks away. Run it whenever you want that view refreshed, and once more right after step 6 to confirm nothing was left behind.
+`dev` means "the development is done; only merges remain", and the fix session applies it when it opens the PR (CLAUDE.md). So by the time you get here the label should already be right, and this step is an **audit**: `scripts/reconcile-dev-labels.py` catches issues a session forgot to label, issues whose fix PR was later abandoned, and stale labels left behind by step 6's closes.
+
+Run it right after step 6 to confirm nothing was left behind. It is also worth running **between** releases — the views it keeps honest (`is:issue is:open -label:dev`, what a human should pick up next) matter most while the release is still weeks away.
 
 The script is a pure function from data to plan — it does no network I/O, because the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but returns 403; GitHub access is intermediated by the MCP server). So gather the data first, then pipe it in:
 
-1. List the PRs merged into `dev` since the last release — the same `origin/main..origin/dev` window as step 3 — and read each one's **body**.
-2. List the repo's issues with their `labels` and `state`, and fetch each one's **comments** in chronological order (the API default).
-3. Assemble them into one JSON object and run the script:
+1. List the PRs merged into `dev` since the last release — the same `origin/main..origin/dev` window as step 3 — and read each one's **body**. These are `release_prs`.
+2. List the PRs currently **open** against `dev` (`open_prs`) and those **closed without merging** since the last release (`abandoned_prs`), with their bodies. The open ones are why an issue can be labelled before any merge; the abandoned ones are the only way a label comes off outside a close.
+3. List the repo's issues with their `labels` and `state`, and fetch each one's **comments** in chronological order (the API default).
+4. Assemble them into one JSON object and run the script:
 
 ```json
 {
   "release_prs": [{"number": 3128, "body": "... Closes #3077 ..."}],
+  "open_prs": [{"number": 3160, "body": "... Closes #3081 ..."}],
+  "abandoned_prs": [{"number": 3155, "body": "... Closes #3090 ..."}],
   "issues": [
     {"number": 3077, "state": "open", "labels": ["claude"],
      "comments": [{"body": "Addressed in #3128"}]}
@@ -118,7 +123,7 @@ python scripts/reconcile-dev-labels.py --input plan-input.json
 
 It prints four buckets. **Apply `ADD` and `REMOVE` directly** — they are unambiguous. **Do not apply `NEEDS REVIEW`**; read those issues yourself. An issue lands there for one of three reasons, all genuinely undecidable from the outside:
 
-- **A fix pointer is not the newest comment.** The later comment may be a maintainer saying "thanks" or the reporter saying the fix does not work. Tagging would bury a dispute; skipping would silently drop the issue out of the awaiting-release view.
+- **A fix pointer is not the newest comment.** The later comment may be a maintainer saying "thanks" or the reporter saying the fix does not work. Tagging would bury a dispute — hiding an issue that still needs solving — while skipping would leave solved work in the human queue.
 - **A comment claims a fix by commit SHA** instead of `Addressed in #M`. The script has only the JSON you piped in, so it cannot map a commit to its PR — but the claim is real, so it is surfaced. Resolve it with `git log --ancestry-path <sha>..origin/dev --merges --oneline | tail -1` to find the merge that carried it, then re-run with a corrected pointer.
 - **The issue carries `dev` but nothing resolves it** — stale, or fixed in an earlier release.
 

--- a/scripts/reconcile-dev-labels.py
+++ b/scripts/reconcile-dev-labels.py
@@ -113,11 +113,7 @@ def _refs(pattern: re.Pattern[str], text: str) -> set[int]:
 
 def pull_requests(data: dict) -> list[tuple[int, str, str]]:
     """Flatten the PR lists into (number, body, kind) triples."""
-    return [
-        (pr.get("number"), pr.get("body") or "", kind)
-        for key, kind in PR_SOURCES
-        for pr in (data.get(key) or [])
-    ]
+    return [(pr.get("number"), pr.get("body") or "", kind) for key, kind in PR_SOURCES for pr in (data.get(key) or [])]
 
 
 def closing_targets(prs: list[tuple[int, str, str]]) -> dict[int, tuple[int, str]]:

--- a/scripts/reconcile-dev-labels.py
+++ b/scripts/reconcile-dev-labels.py
@@ -1,28 +1,40 @@
 #!/usr/bin/env python3
 """Decide which issues should carry the `dev` label, and which should lose it.
 
-`dev` means **fixed on `dev`, not yet on `main`** — the window between a fix
-merging and the release that ships it. Because a fix PR targets `dev`, GitHub
-never auto-closes its issue (that only happens on the default branch), so
-without this label there is no way to tell "waiting for release" apart from
-"nobody has started it". The awaiting-release view is:
+`dev` means **the development on this issue is done** — the problem has been
+solved, a fix PR carries it, and nothing remains but git merges (into `dev`,
+and then into `main` at the next release). Its job is to keep a solved issue
+out of the queue a human picks from:
 
-    is:issue is:open label:dev
+    is:issue is:open -label:dev    # what someone should pick up next
+    is:issue is:open label:dev     # solved; waiting only on merges
 
-The label is **transient**: `docs/RELEASE.md` step 6 strips it in the same
-write that closes the issue. So it is a precise status at all times rather
-than a historical fact — a reopened issue is automatically clean, and a closed
-issue is not cluttered with a label that is true of every shipped fix.
+## Why the label goes on at fix-PR time, not at merge time
+
+`dev` used to mean the narrower "merged into `dev`, not yet on `main`", which
+made the label's only honest trigger a merge — an event no session observes,
+so in practice nothing ever applied it. The wider meaning is both truer to
+what the label is *for* and self-triggering: from a planning perspective
+"solved in an open PR" and "merged to `dev`" are the same state, because
+neither has any problem-solving left in it. So the fix session applies the
+label when it opens the PR, in the same motion as its `Addressed in #M`
+comment (see CLAUDE.md), and this script is the backstop that catches what a
+session forgot and reconciles the other direction.
+
+Widening the front edge adds a removal case the narrow meaning could not
+have: a fix PR that is **closed without merging** un-solves its issue, and the
+label has to come off so the issue returns to the human queue. That is why
+`abandoned_prs` is part of the input.
 
 ## Why this is a script and not a runbook paragraph
 
-The rule reuses step 6's own resolution logic, which is fiddly in exactly the
-ways prose hides: closing keywords must be told apart from `Refs`/`Part of`,
-`Partially addressed in #M` must not read as `Addressed in #M`, a comment
-posted *after* a fix pointer may or may not dispute it, and a pointer naming a
-commit instead of a PR cannot be resolved here at all. Getting any of those
-subtly wrong silently corrupts the awaiting-release view. Encoding it here
-makes it testable; see tests/core/test_reconcile_dev_labels.py.
+The rule reuses docs/RELEASE.md step 6's own resolution logic, which is fiddly
+in exactly the ways prose hides: closing keywords must be told apart from
+`Refs`/`Part of`, `Partially addressed in #M` must not read as `Addressed in
+#M`, a comment posted *after* a fix pointer may or may not dispute it, and a
+pointer naming a commit instead of a PR cannot be resolved here at all.
+Getting any of those subtly wrong silently corrupts both views above.
+Encoding it here makes it testable; see tests/core/test_reconcile_dev_labels.py.
 
 ## Why it takes input instead of fetching
 
@@ -40,7 +52,9 @@ to plan, and whoever *does* hold credentials supplies the data:
 Input schema (unknown keys are ignored, so richer API payloads pipe in as-is):
 
     {
-      "release_prs": [ {"number": 3128, "body": "... Closes #3077 ..."} ],
+      "release_prs":   [ {"number": 3128, "body": "... Closes #3077 ..."} ],
+      "open_prs":      [ {"number": 3160, "body": "... Closes #3081 ..."} ],
+      "abandoned_prs": [ {"number": 3155, "body": "... Closes #3090 ..."} ],
       "issues": [
         {"number": 3077, "state": "open", "labels": ["claude"],
          "comments": [ {"body": "Addressed in #3128"} ]}
@@ -48,8 +62,11 @@ Input schema (unknown keys are ignored, so richer API payloads pipe in as-is):
     }
 
 `release_prs` are the PRs merged into `dev` since the last release — the same
-`origin/main..origin/dev` window step 6 uses. `comments` must be in chronological
-order (oldest first), which is what the GitHub API returns by default.
+`origin/main..origin/dev` window step 6 uses. `open_prs` are the PRs currently
+open against `dev`; `abandoned_prs` are those closed without merging. Only
+`issues` and at least one PR list need be present. `comments` must be in
+chronological order (oldest first), which is what the GitHub API returns by
+default.
 """
 
 from __future__ import annotations
@@ -60,6 +77,11 @@ import re
 import sys
 
 DEV_LABEL = "dev"
+
+# Where each PR list sits on the live/dead axis. A "live" claim means a fix
+# exists and is still on its way in; a "dead" one means it fell through.
+PR_SOURCES = (("release_prs", "merged"), ("open_prs", "open"), ("abandoned_prs", "abandoned"))
+DEAD_KIND = "abandoned"
 
 # `Closes #12, closes #15` is the documented multi-issue form, so the keyword
 # is matched per-reference rather than once per line.
@@ -74,11 +96,10 @@ COMMENT_POINTER = re.compile(
 )
 
 # The same claim, but naming a commit instead of a PR ("Fixed on `dev` by
-# `de9ae81ac`"). A SHA cannot be mapped to a release PR from this input, so
-# such a comment is surfaced for review rather than resolved -- see
-# `_sha_pointer`. The gap between the verb and the SHA absorbs interjections
-# like "on `dev`", and excludes `#` so a well-formed `#M` pointer can never
-# land here instead.
+# `de9ae81ac`"). A SHA cannot be mapped to a PR from this input, so such a
+# comment is surfaced for review rather than resolved -- see `_sha_pointer`.
+# The gap between the verb and the SHA absorbs interjections like "on `dev`",
+# and excludes `#` so a well-formed `#M` pointer can never land here instead.
 SHA_POINTER = re.compile(
     r"(?<!ly )\b(?:addressed|fixed|resolved|shipped|handled)\b[^.\n#]{0,40}?"
     r"\b(?:in|by)\s+(?:commit\s+)?`?([0-9a-f]{7,40})`?\b",
@@ -90,38 +111,48 @@ def _refs(pattern: re.Pattern[str], text: str) -> set[int]:
     return {int(m) for m in pattern.findall(text or "")}
 
 
-def closing_targets(release_prs: list[dict]) -> dict[int, int]:
-    """Map issue number -> PR number, for issues a release PR claims to close.
+def pull_requests(data: dict) -> list[tuple[int, str, str]]:
+    """Flatten the PR lists into (number, body, kind) triples."""
+    return [
+        (pr.get("number"), pr.get("body") or "", kind)
+        for key, kind in PR_SOURCES
+        for pr in (data.get(key) or [])
+    ]
+
+
+def closing_targets(prs: list[tuple[int, str, str]]) -> dict[int, tuple[int, str]]:
+    """Map issue number -> (PR number, kind), for issues a PR claims to close.
 
     Only closing keywords count. `Refs #N` / `Part of #N` / a bare `#N` mean
-    work is still owed on that issue, so it is not resolved on `dev`.
+    work is still owed on that issue, so its development is not done.
     """
-    targets: dict[int, int] = {}
-    for pr in release_prs:
-        for issue in _refs(CLOSING_REF, pr.get("body") or ""):
-            targets.setdefault(issue, pr.get("number"))
+    targets: dict[int, tuple[int, str]] = {}
+    for number, body, kind in prs:
+        for issue in _refs(CLOSING_REF, body):
+            targets.setdefault(issue, (number, kind))
     return targets
 
 
-def _pointer_verdict(issue: dict, release_numbers: set[int]) -> tuple[str, str] | None:
+def _pointer_verdict(issue: dict, live_numbers: set[int]) -> tuple[str, str] | None:
     """Classify an issue's comments as a fix pointer, a disputed one, or neither.
 
     Returns (verdict, detail) where verdict is "resolved" or "review", or None
-    when no comment points at a PR in this release at all.
+    when no comment points at a live PR at all.
 
     The newest comment wins. A pointer that is *not* the newest comment is
     ambiguous by construction: the later comment might be a maintainer saying
     "thanks", or it might be the reporter saying the fix does not work. Guessing
-    either way is wrong -- silently tagging buries a dispute, silently skipping
-    drops the issue out of the awaiting-release view with no signal -- so the
-    ambiguous case is surfaced for a human instead.
+    either way is wrong -- silently tagging buries a dispute (and hides an issue
+    that still needs solving from the human queue), while silently skipping
+    leaves solved work in that queue -- so the ambiguous case is surfaced for a
+    human instead.
     """
     comments = issue.get("comments") or []
     hits = [
         (i, pr)
         for i, comment in enumerate(comments)
         for pr in _refs(COMMENT_POINTER, comment.get("body") or "")
-        if pr in release_numbers
+        if pr in live_numbers
     ]
     if not hits:
         return None
@@ -136,17 +167,25 @@ def _pointer_verdict(issue: dict, release_numbers: set[int]) -> tuple[str, str] 
     )
 
 
+def _dead_pointer(issue: dict, dead_numbers: set[int]) -> int | None:
+    """Return a PR that a comment claims fixed this issue but which never merged."""
+    for comment in issue.get("comments") or []:
+        for pr in _refs(COMMENT_POINTER, comment.get("body") or ""):
+            if pr in dead_numbers:
+                return pr
+    return None
+
+
 def _sha_pointer(issue: dict) -> str | None:
     """Return the commit named by the newest SHA-form fix claim, if any.
 
     CLAUDE.md prescribes `Addressed in #M` -- a *PR number* -- precisely because
-    a bare commit SHA cannot be mapped back to a release PR from this input.
-    But a comment saying "Fixed on `dev` by `de9ae81ac`" plainly claims a fix,
-    and reporting it as "not resolved on dev" is the script guessing, in the
-    one direction it is meant never to guess: silently. #2911 sat open through
-    a release exactly this way -- its fix was on `main` while the awaiting-
-    release view showed nothing at all. So the claim is surfaced and a human
-    maps the commit to its PR.
+    a bare commit SHA cannot be mapped back to a PR from this input. But a
+    comment saying "Fixed on `dev` by `de9ae81ac`" plainly claims a fix, and
+    reporting it as unsolved is the script guessing, in the one direction it is
+    meant never to guess: silently. #2911 sat open through a release exactly
+    this way -- its fix was on `main` while no view showed it anywhere. So the
+    claim is surfaced and a human maps the commit to its PR.
     """
     for comment in reversed(issue.get("comments") or []):
         found = SHA_POINTER.findall(comment.get("body") or "")
@@ -155,7 +194,17 @@ def _sha_pointer(issue: dict) -> str | None:
     return None
 
 
-def _classify(issue: dict, closers: dict[int, int], release_numbers: set[int]) -> tuple[str, str]:
+def _describe(pr_number: int, kind: str, issue_number: int) -> str:
+    article = "open PR" if kind == "open" else "merged PR"
+    return f"{article} #{pr_number} claims `Closes #{issue_number}`"
+
+
+def _classify(
+    issue: dict,
+    closers: dict[int, tuple[int, str]],
+    live_numbers: set[int],
+    dead_numbers: set[int],
+) -> tuple[str, str]:
     """Return (action, reason) for one issue. Action is add/remove/review/none."""
     number = issue.get("number")
     labelled = DEV_LABEL in {str(item).strip().lower() for item in (issue.get("labels") or [])}
@@ -166,13 +215,23 @@ def _classify(issue: dict, closers: dict[int, int], release_numbers: set[int]) -
             return "remove", "issue is closed but still carries `dev` — the closing write did not strip it"
         return "none", "closed, no label"
 
-    if number in closers:
-        if labelled:
-            return "none", f"already labelled; closed by #{closers[number]}"
-        return "add", f"#{closers[number]} claims `Closes #{number}`"
+    claim = closers.get(number)
+    if claim and claim[1] != DEAD_KIND:
+        detail = _describe(claim[0], claim[1], number)
+        return ("none", f"already labelled; {detail}") if labelled else ("add", detail)
 
-    verdict = _pointer_verdict(issue, release_numbers)
+    verdict = _pointer_verdict(issue, live_numbers)
     if verdict is None:
+        # Nothing live claims this issue. Did something dead claim it?
+        dead_pr = claim[0] if claim else _dead_pointer(issue, dead_numbers)
+        if dead_pr is not None:
+            if labelled:
+                return "remove", (
+                    f"its fix PR #{dead_pr} was closed without merging — the development is owed again, "
+                    "so the issue belongs back in the human queue"
+                )
+            return "none", f"claimed only by #{dead_pr}, which was closed without merging"
+
         sha = _sha_pointer(issue)
         if sha:
             return "review", (
@@ -182,9 +241,9 @@ def _classify(issue: dict, closers: dict[int, int], release_numbers: set[int]) -
         if labelled:
             return (
                 "review",
-                "carries `dev` but no release PR or comment resolves it — stale, or fixed in an earlier release",
+                "carries `dev` but no PR or comment resolves it — stale, or fixed in an earlier release",
             )
-        return "none", "not resolved on dev"
+        return "none", "no fix PR claims it"
 
     kind, detail = verdict
     if kind == "review":
@@ -194,13 +253,14 @@ def _classify(issue: dict, closers: dict[int, int], release_numbers: set[int]) -
 
 def reconcile(data: dict) -> dict[str, list[tuple[int, str]]]:
     """Group every issue into add / remove / review / none, with a reason each."""
-    release_prs = data.get("release_prs") or []
-    closers = closing_targets(release_prs)
-    release_numbers = {pr.get("number") for pr in release_prs}
+    prs = pull_requests(data)
+    closers = closing_targets(prs)
+    live_numbers = {number for number, _, kind in prs if kind != DEAD_KIND}
+    dead_numbers = {number for number, _, kind in prs if kind == DEAD_KIND}
 
     plan: dict[str, list[tuple[int, str]]] = {"add": [], "remove": [], "review": [], "none": []}
     for issue in data.get("issues") or []:
-        action, reason = _classify(issue, closers, release_numbers)
+        action, reason = _classify(issue, closers, live_numbers, dead_numbers)
         plan[action].append((issue.get("number"), reason))
     for bucket in plan.values():
         bucket.sort()
@@ -243,7 +303,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: input is not valid JSON: {exc}", file=sys.stderr)
         return 2
     if not isinstance(data, dict):
-        print("error: input must be a JSON object with `release_prs` and `issues` keys", file=sys.stderr)
+        print("error: input must be a JSON object with PR list(s) and an `issues` key", file=sys.stderr)
         return 2
 
     plan = reconcile(data)

--- a/scripts/reconcile-solved-labels.py
+++ b/scripts/reconcile-solved-labels.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
-"""Decide which issues should carry the `dev` label, and which should lose it.
+"""Decide which issues should carry the `solved` label, and which should lose it.
 
-`dev` means **the development on this issue is done** — the problem has been
+`solved` means **the development on this issue is done** — the problem has been
 solved, a fix PR carries it, and nothing remains but git merges (into `dev`,
 and then into `main` at the next release). Its job is to keep a solved issue
 out of the queue a human picks from:
 
-    is:issue is:open -label:dev    # what someone should pick up next
-    is:issue is:open label:dev     # solved; waiting only on merges
+    is:issue is:open -label:solved    # what someone should pick up next
+    is:issue is:open label:solved     # solved; waiting only on merges
 
 ## Why the label goes on at fix-PR time, not at merge time
 
-`dev` used to mean the narrower "merged into `dev`, not yet on `main`", which
-made the label's only honest trigger a merge — an event no session observes,
-so in practice nothing ever applied it. The wider meaning is both truer to
-what the label is *for* and self-triggering: from a planning perspective
+The label used to be called `dev` and to mean the narrower "merged into the
+`dev` branch, not yet on `main`", which made its only honest trigger a merge —
+an event no session observes, so in practice nothing ever applied it. The
+wider meaning is both truer to what the label is *for* and self-triggering:
+from a planning perspective
 "solved in an open PR" and "merged to `dev`" are the same state, because
 neither has any problem-solving left in it. So the fix session applies the
 label when it opens the PR, in the same motion as its `Addressed in #M`
@@ -34,7 +35,7 @@ in exactly the ways prose hides: closing keywords must be told apart from
 #M`, a comment posted *after* a fix pointer may or may not dispute it, and a
 pointer naming a commit instead of a PR cannot be resolved here at all.
 Getting any of those subtly wrong silently corrupts both views above.
-Encoding it here makes it testable; see tests/core/test_reconcile_dev_labels.py.
+Encoding it here makes it testable; see tests/core/test_reconcile_solved_labels.py.
 
 ## Why it takes input instead of fetching
 
@@ -44,10 +45,10 @@ intermediated by the MCP server. So this script is a pure function from data
 to plan, and whoever *does* hold credentials supplies the data:
 
     # in a Claude session: gather via the github MCP tools, then
-    python scripts/reconcile-dev-labels.py --input plan-input.json
+    python scripts/reconcile-solved-labels.py --input plan-input.json
 
     # on a machine with the gh CLI: see docs/RELEASE.md for the recipe
-    gh ... | python scripts/reconcile-dev-labels.py
+    gh ... | python scripts/reconcile-solved-labels.py
 
 Input schema (unknown keys are ignored, so richer API payloads pipe in as-is):
 
@@ -76,7 +77,7 @@ import json
 import re
 import sys
 
-DEV_LABEL = "dev"
+SOLVED_LABEL = "solved"
 
 # Where each PR list sits on the live/dead axis. A "live" claim means a fix
 # exists and is still on its way in; a "dead" one means it fell through.
@@ -203,12 +204,12 @@ def _classify(
 ) -> tuple[str, str]:
     """Return (action, reason) for one issue. Action is add/remove/review/none."""
     number = issue.get("number")
-    labelled = DEV_LABEL in {str(item).strip().lower() for item in (issue.get("labels") or [])}
+    labelled = SOLVED_LABEL in {str(item).strip().lower() for item in (issue.get("labels") or [])}
     is_open = str(issue.get("state") or "open").lower() == "open"
 
     if not is_open:
         if labelled:
-            return "remove", "issue is closed but still carries `dev` — the closing write did not strip it"
+            return "remove", "issue is closed but still carries `solved` — the closing write did not strip it"
         return "none", "closed, no label"
 
     claim = closers.get(number)
@@ -237,7 +238,7 @@ def _classify(
         if labelled:
             return (
                 "review",
-                "carries `dev` but no PR or comment resolves it — stale, or fixed in an earlier release",
+                "carries `solved` but no PR or comment resolves it — stale, or fixed in an earlier release",
             )
         return "none", "no fix PR claims it"
 
@@ -265,11 +266,11 @@ def reconcile(data: dict) -> dict[str, list[tuple[int, str]]]:
 
 def render(plan: dict[str, list[tuple[int, str]]]) -> str:
     headings = [
-        ("add", f"ADD `{DEV_LABEL}`"),
-        ("remove", f"REMOVE `{DEV_LABEL}`"),
+        ("add", f"ADD `{SOLVED_LABEL}`"),
+        ("remove", f"REMOVE `{SOLVED_LABEL}`"),
         ("review", "NEEDS REVIEW (ambiguous — do not guess)"),
     ]
-    lines = ["", "dev-label reconciliation", "=" * 40]
+    lines = ["", "solved-label reconciliation", "=" * 40]
     for key, heading in headings:
         entries = plan[key]
         lines.append(f"\n{heading} ({len(entries)})")

--- a/tests/core/test_issue_label_hook.py
+++ b/tests/core/test_issue_label_hook.py
@@ -112,8 +112,8 @@ class TestExperimentLabel:
         assert "MISSING `experiment`" in result.stderr
 
 
-class TestDevLabelOnClose:
-    """`dev` means "on `dev`, NOT on `main`", so a close must strip it.
+class TestSolvedLabelOnClose:
+    """`solved` means "development done, only merges remain", so a close must strip it.
 
     The hook only ever sees the call's arguments, never the issue's current
     state, so the enforceable form is "a completing close must state its label
@@ -127,39 +127,39 @@ class TestDevLabelOnClose:
         args.update(overrides)
         return {"tool_name": "mcp__github__issue_write", "tool_input": args}
 
-    def test_completed_close_carrying_dev_is_blocked(self):
-        result = run_hook(self.close(state="closed", state_reason="completed", labels=["claude", "dev"]))
+    def test_completed_close_carrying_solved_is_blocked(self):
+        result = run_hook(self.close(state="closed", state_reason="completed", labels=["claude", "solved"]))
         assert result.returncode == BLOCK
-        assert "KEEPS `dev` ON A CLOSED ISSUE" in result.stderr
+        assert "KEEPS `solved` ON A CLOSED ISSUE" in result.stderr
 
     def test_completed_close_without_explicit_labels_is_blocked(self):
         result = run_hook(self.close(state="closed", state_reason="completed"))
         assert result.returncode == BLOCK
-        assert "CLOSE DOES NOT STRIP `dev`" in result.stderr
+        assert "CLOSE DOES NOT STRIP `solved`" in result.stderr
 
     def test_the_denial_warns_that_labels_replaces_the_whole_set(self):
         """Passing `[]` to satisfy the hook would silently wipe `claude`."""
         result = run_hook(self.close(state="closed", state_reason="completed"))
         assert "REPLACES the whole set" in result.stderr
 
-    def test_completed_close_with_labels_minus_dev_is_allowed(self):
+    def test_completed_close_with_labels_minus_solved_is_allowed(self):
         assert run_hook(self.close(state="closed", state_reason="completed", labels=["claude"])).returncode == ALLOW
 
     def test_an_issue_with_no_labels_left_can_still_be_closed(self):
         assert run_hook(self.close(state="closed", state_reason="completed", labels=[])).returncode == ALLOW
 
-    def test_dev_is_blocked_on_any_close_not_just_completed(self):
-        """A not_planned close carrying `dev` is just as false a statement."""
-        result = run_hook(self.close(state="closed", state_reason="not_planned", labels=["claude", "dev"]))
+    def test_solved_is_blocked_on_any_close_not_just_completed(self):
+        """A not_planned close carrying `solved` is just as false a statement."""
+        result = run_hook(self.close(state="closed", state_reason="not_planned", labels=["claude", "solved"]))
         assert result.returncode == BLOCK
-        assert "KEEPS `dev` ON A CLOSED ISSUE" in result.stderr
+        assert "KEEPS `solved` ON A CLOSED ISSUE" in result.stderr
 
     def test_non_completed_close_does_not_require_explicit_labels(self):
         """Only the release sweep must strip; a not_planned close need not restate labels."""
         assert run_hook(self.close(state="closed", state_reason="not_planned")).returncode == ALLOW
 
-    def test_dev_label_matching_is_case_insensitive(self):
-        result = run_hook(self.close(state="closed", state_reason="completed", labels=["claude", "DEV"]))
+    def test_solved_label_matching_is_case_insensitive(self):
+        result = run_hook(self.close(state="closed", state_reason="completed", labels=["claude", "SOLVED"]))
         assert result.returncode == BLOCK
 
     def test_create_path_rules_do_not_leak_onto_closes(self):

--- a/tests/core/test_reconcile_dev_labels.py
+++ b/tests/core/test_reconcile_dev_labels.py
@@ -1,8 +1,9 @@
 """Tests for scripts/reconcile-dev-labels.py.
 
-The script decides which open issues are "fixed on `dev`, not yet on `main`"
-and therefore carry the `dev` label. It reuses docs/RELEASE.md step 6's
-resolution logic, whose sharp edges are the point of testing it:
+The script decides which open issues have no development left in them -- the
+problem is solved and only git merges remain -- and therefore carry the `dev`
+label. It reuses docs/RELEASE.md step 6's resolution logic, whose sharp edges
+are the point of testing it:
 
 * a closing keyword means resolved; `Refs` / `Part of` / a bare `#N` do not;
 * `Partially addressed in #M` is the documented marker for work still owed,
@@ -10,10 +11,14 @@ resolution logic, whose sharp edges are the point of testing it:
 * a comment posted *after* a fix pointer is ambiguous -- it may be chatter or
   a dispute -- and the script must surface it rather than guess either way;
 * a pointer naming a *commit* rather than a PR cannot be resolved from this
-  input, and must be surfaced rather than reported as settled.
+  input, and must be surfaced rather than reported as settled;
+* an *open* fix PR resolves an issue just as a merged one does (the label
+  tracks "solved", not "merged"), while a PR closed *without* merging un-solves
+  it and must take the label back off.
 
-Getting any of these wrong corrupts the awaiting-release view silently, which
-is exactly the failure mode the script exists to prevent.
+Getting any of these wrong silently corrupts both views the label powers:
+`-label:dev` (what a human should pick up next) and `label:dev` (solved,
+waiting only on merges).
 """
 
 import importlib.util
@@ -47,9 +52,22 @@ def issue(number: int, *, state: str = "open", labels: list[str] | None = None, 
     }
 
 
-def plan_for(prs: list[dict], issues: list[dict]) -> dict[str, dict[int, str]]:
+def plan_for(
+    prs: list[dict],
+    issues: list[dict],
+    *,
+    open_prs: list[dict] | None = None,
+    abandoned_prs: list[dict] | None = None,
+) -> dict[str, dict[int, str]]:
     """Reconcile, then flatten each bucket to {issue number: reason}."""
-    raw = mod.reconcile({"release_prs": prs, "issues": issues})
+    raw = mod.reconcile(
+        {
+            "release_prs": prs,
+            "open_prs": open_prs or [],
+            "abandoned_prs": abandoned_prs or [],
+            "issues": issues,
+        }
+    )
     return {action: {number: reason for number, reason in entries} for action, entries in raw.items()}
 
 
@@ -208,6 +226,98 @@ class TestCommitShaPointers:
             timeout=30,
         )
         assert result.returncode == 1
+
+
+class TestOpenFixPrs:
+    """The label tracks "solved", not "merged", so an open fix PR resolves an issue.
+
+    This is the widened front edge: `dev` used to require a merge into `dev`,
+    which no session ever observes, so nothing applied the label in practice.
+    From a planning perspective an issue solved in an open PR has exactly as
+    little left to think about as one already merged.
+    """
+
+    def test_an_open_pr_closing_an_issue_resolves_it(self):
+        result = plan_for([], [issue(3081)], open_prs=[{"number": 3160, "body": "Closes #3081"}])
+        assert 3081 in result["add"]
+
+    def test_the_reason_distinguishes_an_open_pr_from_a_merged_one(self):
+        result = plan_for([], [issue(3081)], open_prs=[{"number": 3160, "body": "Closes #3081"}])
+        assert "open PR #3160" in result["add"][3081]
+
+    def test_a_comment_pointing_at_an_open_pr_resolves_it(self):
+        """The `Addressed in #M` comment lands before the merge, and counts."""
+        result = plan_for(
+            [],
+            [issue(3081, comments=["Addressed in #3160"])],
+            open_prs=[{"number": 3160, "body": "Refs #3081"}],
+        )
+        assert 3081 in result["add"]
+
+    def test_a_non_closing_open_pr_still_does_not_resolve(self):
+        """Widening which PRs count does not weaken which keywords count."""
+        result = plan_for([], [issue(3081)], open_prs=[{"number": 3160, "body": "Refs #3081"}])
+        assert 3081 in result["none"]
+
+
+class TestAbandonedFixPrs:
+    """A fix PR closed without merging un-solves its issue, so the label comes off.
+
+    This removal case only exists because the label goes on before the merge:
+    under the old "merged into `dev`" meaning there was no window in which a
+    labelled issue could lose its fix.
+    """
+
+    ABANDONED = [{"number": 3155, "body": "Closes #3090"}]
+
+    def test_labelled_issue_whose_fix_pr_was_abandoned_loses_the_label(self):
+        result = plan_for([], [issue(3090, labels=["claude", "dev"])], abandoned_prs=self.ABANDONED)
+        assert 3090 in result["remove"]
+
+    def test_the_removal_reason_names_the_abandoned_pr(self):
+        result = plan_for([], [issue(3090, labels=["claude", "dev"])], abandoned_prs=self.ABANDONED)
+        assert "#3155" in result["remove"][3090]
+
+    def test_an_unlabelled_issue_with_an_abandoned_fix_needs_no_change(self):
+        """It is already in the human queue, which is where it belongs."""
+        result = plan_for([], [issue(3090, labels=["claude"])], abandoned_prs=self.ABANDONED)
+        assert 3090 in result["none"]
+
+    def test_an_abandoned_comment_pointer_also_removes(self):
+        result = plan_for(
+            [],
+            [issue(3090, labels=["dev"], comments=["Addressed in #3155"])],
+            abandoned_prs=[{"number": 3155, "body": "Refs #3090"}],
+        )
+        assert 3090 in result["remove"]
+
+    def test_a_superseding_open_pr_beats_the_abandoned_one(self):
+        """Take two of a fix keeps the issue solved; the dead claim must not win."""
+        result = plan_for(
+            [],
+            [issue(3090, labels=["claude", "dev"])],
+            open_prs=[{"number": 3170, "body": "Closes #3090"}],
+            abandoned_prs=self.ABANDONED,
+        )
+        assert 3090 in result["none"]
+        assert 3090 not in result["remove"]
+
+    def test_a_superseding_merged_pr_beats_the_abandoned_one(self):
+        result = plan_for(
+            [{"number": 3180, "body": "Closes #3090"}],
+            [issue(3090)],
+            abandoned_prs=self.ABANDONED,
+        )
+        assert 3090 in result["add"]
+
+    def test_an_abandoned_pr_does_not_flag_an_unrelated_labelled_issue_for_review(self):
+        """Only the issue the dead PR claimed is affected."""
+        result = plan_for(
+            [{"number": 3180, "body": "Closes #3077"}],
+            [issue(3077, labels=["dev"])],
+            abandoned_prs=self.ABANDONED,
+        )
+        assert 3077 in result["none"]
 
 
 class TestRemovalAndStaleness:

--- a/tests/core/test_reconcile_solved_labels.py
+++ b/tests/core/test_reconcile_solved_labels.py
@@ -1,8 +1,8 @@
-"""Tests for scripts/reconcile-dev-labels.py.
+"""Tests for scripts/reconcile-solved-labels.py.
 
 The script decides which open issues have no development left in them -- the
-problem is solved and only git merges remain -- and therefore carry the `dev`
-label. It reuses docs/RELEASE.md step 6's resolution logic, whose sharp edges
+problem is solved and only git merges remain -- and therefore carry the
+`solved` label. It reuses docs/RELEASE.md step 6's resolution logic, whose sharp edges
 are the point of testing it:
 
 * a closing keyword means resolved; `Refs` / `Part of` / a bare `#N` do not;
@@ -17,8 +17,8 @@ are the point of testing it:
   it and must take the label back off.
 
 Getting any of these wrong silently corrupts both views the label powers:
-`-label:dev` (what a human should pick up next) and `label:dev` (solved,
-waiting only on merges).
+`-label:solved` (what a human should pick up next) and `label:solved`
+(solved, waiting only on merges).
 """
 
 import importlib.util
@@ -29,11 +29,11 @@ from pathlib import Path
 
 import pytest
 
-SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "reconcile-dev-labels.py"
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "reconcile-solved-labels.py"
 
 
 def _load():
-    spec = importlib.util.spec_from_file_location("reconcile_dev_labels", SCRIPT)
+    spec = importlib.util.spec_from_file_location("reconcile_solved_labels", SCRIPT)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -72,7 +72,7 @@ def plan_for(
 
 
 class TestClosingKeywords:
-    """Only a closing keyword means the issue is finished on `dev`."""
+    """Only a closing keyword means the issue's development is finished."""
 
     @pytest.mark.parametrize("keyword", ["Closes", "closes", "Fixes", "fixed", "Resolves", "RESOLVED"])
     def test_closing_keywords_resolve(self, keyword):
@@ -97,7 +97,7 @@ class TestClosingKeywords:
 
     def test_already_labelled_issue_needs_no_change(self):
         prs = [{"number": 3128, "body": "Closes #3077"}]
-        assert 3077 in plan_for(prs, [issue(3077, labels=["claude", "dev"])])["none"]
+        assert 3077 in plan_for(prs, [issue(3077, labels=["claude", "solved"])])["none"]
 
     def test_the_reason_names_the_pr(self):
         prs = [{"number": 3128, "body": "Closes #3077"}]
@@ -169,7 +169,7 @@ class TestCommitShaPointers:
 
     Regression cover for #2911, which shipped to `main` with its only pointer
     reading "Fixed on `dev` by `de9ae81ac`". That matched no pattern, so the
-    script reported "not resolved on dev" -- indistinguishable from an issue
+    script reported it as unresolved -- indistinguishable from an issue
     nobody had started -- and the release sweep had nothing to go on.
     """
 
@@ -231,7 +231,7 @@ class TestCommitShaPointers:
 class TestOpenFixPrs:
     """The label tracks "solved", not "merged", so an open fix PR resolves an issue.
 
-    This is the widened front edge: `dev` used to require a merge into `dev`,
+    This is the widened front edge: the label used to require a merge into `dev`,
     which no session ever observes, so nothing applied the label in practice.
     From a planning perspective an issue solved in an open PR has exactly as
     little left to think about as one already merged.
@@ -271,11 +271,11 @@ class TestAbandonedFixPrs:
     ABANDONED = [{"number": 3155, "body": "Closes #3090"}]
 
     def test_labelled_issue_whose_fix_pr_was_abandoned_loses_the_label(self):
-        result = plan_for([], [issue(3090, labels=["claude", "dev"])], abandoned_prs=self.ABANDONED)
+        result = plan_for([], [issue(3090, labels=["claude", "solved"])], abandoned_prs=self.ABANDONED)
         assert 3090 in result["remove"]
 
     def test_the_removal_reason_names_the_abandoned_pr(self):
-        result = plan_for([], [issue(3090, labels=["claude", "dev"])], abandoned_prs=self.ABANDONED)
+        result = plan_for([], [issue(3090, labels=["claude", "solved"])], abandoned_prs=self.ABANDONED)
         assert "#3155" in result["remove"][3090]
 
     def test_an_unlabelled_issue_with_an_abandoned_fix_needs_no_change(self):
@@ -286,7 +286,7 @@ class TestAbandonedFixPrs:
     def test_an_abandoned_comment_pointer_also_removes(self):
         result = plan_for(
             [],
-            [issue(3090, labels=["dev"], comments=["Addressed in #3155"])],
+            [issue(3090, labels=["solved"], comments=["Addressed in #3155"])],
             abandoned_prs=[{"number": 3155, "body": "Refs #3090"}],
         )
         assert 3090 in result["remove"]
@@ -295,7 +295,7 @@ class TestAbandonedFixPrs:
         """Take two of a fix keeps the issue solved; the dead claim must not win."""
         result = plan_for(
             [],
-            [issue(3090, labels=["claude", "dev"])],
+            [issue(3090, labels=["claude", "solved"])],
             open_prs=[{"number": 3170, "body": "Closes #3090"}],
             abandoned_prs=self.ABANDONED,
         )
@@ -314,7 +314,7 @@ class TestAbandonedFixPrs:
         """Only the issue the dead PR claimed is affected."""
         result = plan_for(
             [{"number": 3180, "body": "Closes #3077"}],
-            [issue(3077, labels=["dev"])],
+            [issue(3077, labels=["solved"])],
             abandoned_prs=self.ABANDONED,
         )
         assert 3077 in result["none"]
@@ -323,9 +323,9 @@ class TestAbandonedFixPrs:
 class TestRemovalAndStaleness:
     """The label is transient, so the script reconciles in both directions."""
 
-    def test_closed_issue_still_carrying_dev_is_flagged_for_removal(self):
+    def test_closed_issue_still_carrying_solved_is_flagged_for_removal(self):
         prs = [{"number": 3128, "body": "Closes #3077"}]
-        result = plan_for(prs, [issue(3077, state="closed", labels=["claude", "dev"])])
+        result = plan_for(prs, [issue(3077, state="closed", labels=["claude", "solved"])])
         assert 3077 in result["remove"]
 
     def test_closed_issue_without_the_label_needs_no_change(self):
@@ -333,11 +333,11 @@ class TestRemovalAndStaleness:
 
     def test_open_issue_labelled_but_unresolved_is_flagged_for_review(self):
         """Stale from a prior release, or the label was applied by hand in error."""
-        assert 3077 in plan_for([], [issue(3077, labels=["dev"])])["review"]
+        assert 3077 in plan_for([], [issue(3077, labels=["solved"])])["review"]
 
-    def test_dev_label_matching_is_case_insensitive(self):
+    def test_solved_label_matching_is_case_insensitive(self):
         prs = [{"number": 3128, "body": "Closes #3077"}]
-        assert 3077 in plan_for(prs, [issue(3077, labels=["DEV"])])["none"]
+        assert 3077 in plan_for(prs, [issue(3077, labels=["SOLVED"])])["none"]
 
 
 class TestCommandLine:


### PR DESCRIPTION
## The problem

The `dev` label meant **"merged into the `dev` branch, not yet on `main`"**. Nothing was wrong with the *removal* side — `docs/RELEASE.md` step 6 strips it in the write that closes the issue — but the **add** side never fired in practice.

The reason is structural: under that definition the only honest trigger is a merge, and no Claude session is around to observe a merge happening. `scripts/reconcile-dev-labels.py` had an `ADD` bucket all along, but nothing scheduled it — the only Routine that runs it is Dev2Main, which is manually fired at release time, and by then step 6 has just closed and stripped everything it would have tagged. The awaiting-release view was empty or stale nearly all the time, which is the exact state the label was invented to fix. Confirmed on the live repo: at the time of this PR, **zero** of the 22 open issues carried it, including four whose fixes had already merged to `dev` that day.

CLAUDE.md's rule "do not apply it by hand from a fix session" was correct *given the old meaning* — at PR-open time the merge hasn't happened, so the label would have been a lie — and it closed off the one moment a session could actually have applied it.

## The change

The label now means **"the development on this issue is done"** — the problem is solved, a fix PR carries it, and everything still owed is a git merge. That is a fact about people rather than about git, and it makes the label self-triggering: the fix session applies it when it opens the PR, in the same motion as its `Addressed in #M` comment.

Since the label no longer says anything about the `dev` branch, it is **renamed `dev` → `solved`**, along with `scripts/reconcile-dev-labels.py` → `scripts/reconcile-solved-labels.py` and its test file. Every remaining `dev` in the touched files refers to the branch.

The primary view flips to the negative one, which is what a human actually asks for:

```
is:issue is:open -label:solved    # what someone should pick up next
is:issue is:open label:solved     # solved; waiting only on merges
```

"Solved in an open PR" and "merged into `dev`" are different facts about git but the same fact about planning — neither has any thinking left in it, so neither should be offered to someone looking for work.

### The new removal case

Widening the front edge opens a hole the narrow meaning couldn't have: a fix PR **closed without merging** un-solves its issue, and the label has to come back off so the issue re-enters the human queue. Under the old meaning this was impossible, because the label only went on after a merge.

So the reconcile script now reads three PR lists instead of one:

| key | meaning | effect |
|---|---|---|
| `release_prs` | merged into `dev` this window | live claim → `ADD` |
| `open_prs` | open against `dev` | live claim → `ADD` |
| `abandoned_prs` | closed without merging | dead claim → `REMOVE` if labelled |

Claims resolve live-first, so a superseding "take two" PR beats the abandoned one it replaced, and an unlabelled issue with only a dead claim is left alone — it is already in the human queue, which is where it belongs. Reasons now distinguish `open PR #3160 claims …` from `merged PR #3128 claims …`.

Everything else about the resolution logic is untouched: closing keywords vs. `Refs`, `Partially addressed in #M` vs. `Addressed in #M`, the newest-comment rule, and the commit-SHA backstop all behave exactly as before.

## Doc and hook updates

- **`CLAUDE.md`** — the label's section is rewritten around the new meaning; the "do not apply by hand" rule is reversed into "apply it when you open the fix PR"; a third rule covers taking it back off when a fix falls through. The fix-PR-linking table gains a `solved` column so the keyword, the comment, and the label are decided together.
- **`docs/RELEASE.md`** — step 6b is reframed from "what puts the label on" to an **audit** (the fix session puts it on now), and its gathering recipe grows the two new PR lists.
- **`.claude/hooks/require-issue-labels.py`** — prose and the label constant. Its enforcement is unchanged and still correct: a `completed` close must state `labels` explicitly and must not keep the label.

## Backfill applied

The new definition was reconciled against the live repo and the five unambiguous `ADD`s applied — no `REMOVE`s, no `NEEDS REVIEW`:

| issue | claimed by |
|---|---|
| #3138 | open PR #3154 |
| #3139 | merged PR #3152 |
| #3140 | merged PR #3149 |
| #3144 | merged PR #3150 |
| #3145 | merged PR #3151 |

#3143 was deliberately *not* labelled: its comment reads "Prerequisite landed in #3153 — **not** a fix for this issue", which is not a resolution claim, and the script correctly left it in the human queue.

The old `dev` label now has no issues on it. It can't be deleted from a Claude session (the MCP server exposes no label-delete tool), so removing it from the repo's label list is a one-click manual cleanup.

## Testing

`./run-tests.sh` — full run, all gates green: 8691 passed, 6 skipped, 1 xfailed; pyright, pip-audit, npm audit and the Vitest suite all OK.

`tests/core/test_reconcile_solved_labels.py` grows 12 tests in two new classes — `TestOpenFixPrs` (an open PR resolves an issue; a comment pointing at an open PR resolves it; a non-closing keyword still doesn't) and `TestAbandonedFixPrs` (a labelled issue whose fix PR was abandoned loses the label; an unlabelled one is left alone; a superseding open or merged PR beats the dead claim).